### PR TITLE
fix: [2.6] cap recovered growing manifest rows

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -22,6 +22,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <variant>
+#include <vector>
 
 #include "cachinglayer/CacheSlot.h"
 #include "common/Consts.h"
@@ -80,6 +81,75 @@ GetVectorArrayLength(const proto::schema::VectorField& vec_field,
                       element_type);
     }
     return 0;
+}
+
+int64_t
+GetLoadedFieldRows(
+    const std::vector<std::unordered_map<FieldId, std::vector<FieldDataPtr>>>&
+        column_group_results,
+    FieldId field_id) {
+    int64_t rows = 0;
+    bool found = false;
+    for (const auto& column_group_result : column_group_results) {
+        auto it = column_group_result.find(field_id);
+        if (it == column_group_result.end()) {
+            continue;
+        }
+        found = true;
+        for (const auto& field_data : it->second) {
+            rows += field_data->get_num_rows();
+        }
+    }
+    return found ? rows : -1;
+}
+
+void
+AssertLoadedFieldRows(
+    const std::vector<std::unordered_map<FieldId, std::vector<FieldDataPtr>>>&
+        column_group_results,
+    FieldId field_id,
+    int64_t expected_rows,
+    const char* field_name) {
+    if (expected_rows == 0) {
+        return;
+    }
+    auto rows = GetLoadedFieldRows(column_group_results, field_id);
+    AssertInfo(rows == expected_rows,
+               "growing segment StorageV3 manifest loads {} rows for {} "
+               "field {}, but SegmentLoadInfo expects {} rows",
+               rows,
+               field_name,
+               field_id.get(),
+               expected_rows);
+}
+
+void
+AssertAllLoadedFieldRows(
+    const std::vector<std::unordered_map<FieldId, std::vector<FieldDataPtr>>>&
+        column_group_results,
+    int64_t expected_rows) {
+    if (expected_rows == 0) {
+        return;
+    }
+
+    std::unordered_map<FieldId, int64_t> loaded_rows;
+    for (const auto& column_group_result : column_group_results) {
+        for (const auto& [field_id, field_data] : column_group_result) {
+            auto& rows = loaded_rows[field_id];
+            for (const auto& data : field_data) {
+                rows += data->get_num_rows();
+            }
+        }
+    }
+
+    for (const auto& [field_id, rows] : loaded_rows) {
+        AssertInfo(rows == expected_rows,
+                   "growing segment StorageV3 manifest loads {} rows for "
+                   "field {}, but SegmentLoadInfo expects {} rows",
+                   rows,
+                   field_id.get(),
+                   expected_rows);
+    }
 }
 
 void
@@ -1918,9 +1988,10 @@ SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path) {
         std::future<std::unordered_map<FieldId, std::vector<FieldDataPtr>>>>
         load_group_futures;
     for (int64_t i = 0; i < column_groups->size(); ++i) {
-        auto future = pool.Submit([this, column_groups, properties, i] {
-            return LoadColumnGroup(column_groups, properties, i);
-        });
+        auto future =
+            pool.Submit([this, column_groups, properties, i, num_rows] {
+                return LoadColumnGroup(column_groups, properties, i, num_rows);
+            });
         load_group_futures.emplace_back(std::move(future));
     }
 
@@ -1946,7 +2017,21 @@ SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path) {
         std::rethrow_exception(load_exceptions[0]);
     }
 
+    AssertInfo(primary_field_id.get() != INVALID_FIELD_ID, "Primary key is -1");
+    AssertLoadedFieldRows(
+        column_group_results, primary_field_id, num_rows, "primary");
+    AssertAllLoadedFieldRows(column_group_results, num_rows);
+    auto timestamp_rows =
+        GetLoadedFieldRows(column_group_results, TimestampFieldID);
+
     auto reserved_offset = PreInsert(num_rows);
+
+    if (timestamp_rows == -1 && num_rows > 0) {
+        std::vector<Timestamp> timestamps(num_rows, 0);
+        insert_record_.timestamps_.set_data_raw(
+            reserved_offset, timestamps.data(), num_rows);
+        stats_.mem_size += num_rows * sizeof(Timestamp);
+    }
 
     for (auto& column_group_result : column_group_results) {
         for (auto& [field_id, field_data] : column_group_result) {
@@ -1972,7 +2057,8 @@ std::unordered_map<FieldId, std::vector<FieldDataPtr>>
 SegmentGrowingImpl::LoadColumnGroup(
     const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
-    int64_t index) {
+    int64_t index,
+    int64_t row_limit) {
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
     auto column_group = column_groups->get_column_group(index);
@@ -1989,14 +2075,38 @@ SegmentGrowingImpl::LoadColumnGroup(
     auto parallel_degree =
         static_cast<uint64_t>(DEFAULT_FIELD_MAX_MEMORY_LIMIT / FILE_SLICE_SIZE);
 
-    std::vector<int64_t> all_row_groups(chunk_reader->total_number_of_chunks());
+    AssertInfo(row_limit >= 0,
+               "load column group row limit should be non-negative, got {}",
+               row_limit);
+    auto chunk_rows_result = chunk_reader->get_chunk_rows();
+    AssertInfo(chunk_rows_result.ok(),
+               "get chunk rows failed, segment {}, column group index {}, "
+               "error: {}",
+               get_segment_id(),
+               index,
+               chunk_rows_result.status().ToString());
 
-    std::iota(all_row_groups.begin(), all_row_groups.end(), 0);
+    auto chunk_rows = std::move(chunk_rows_result).ValueOrDie();
+    std::vector<int64_t> row_groups_to_load;
+    row_groups_to_load.reserve(chunk_rows.size());
+    auto rows_to_read = int64_t{0};
+    for (auto chunk_index = size_t{0};
+         chunk_index < chunk_rows.size() && rows_to_read < row_limit;
+         ++chunk_index) {
+        row_groups_to_load.push_back(static_cast<int64_t>(chunk_index));
+        rows_to_read += static_cast<int64_t>(chunk_rows[chunk_index]);
+    }
+    AssertInfo(rows_to_read >= row_limit,
+               "column group {} has fewer rows than checkpoint row count, "
+               "loaded rows {}, expected rows {}",
+               index,
+               rows_to_read,
+               row_limit);
 
     // create parallel degree split strategy
     auto strategy =
         std::make_unique<ParallelDegreeSplitStrategy>(parallel_degree);
-    auto split_result = strategy->split(all_row_groups);
+    auto split_result = strategy->split(row_groups_to_load);
 
     auto& thread_pool =
         ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
@@ -2016,11 +2126,18 @@ SegmentGrowingImpl::LoadColumnGroup(
     }
 
     std::unordered_map<FieldId, std::vector<FieldDataPtr>> field_data_map;
-    for (auto& future : part_futures) {
-        auto part_result = future.get();
+    // Growing recovery may reuse a manifest that already contains rows past the
+    // segment checkpoint. Only load rows covered by SegmentLoadInfo so WAL
+    // replay can append the remaining rows at the expected offsets.
+    int64_t loaded_rows = 0;
+    storage::ProcessFuturesInOrder(part_futures, [&](auto part_result) {
         for (auto& record_batch : part_result) {
-            // result->emplace_back(std::move(record_batch));
+            if (loaded_rows >= row_limit) {
+                break;
+            }
             auto batch_num_rows = record_batch->num_rows();
+            auto rows_to_load =
+                std::min<int64_t>(batch_num_rows, row_limit - loaded_rows);
             for (auto i = 0; i < column_group->columns.size(); ++i) {
                 auto column = column_group->columns[i];
                 auto field_id = FieldId(std::stoll(column));
@@ -2036,13 +2153,17 @@ SegmentGrowingImpl::LoadColumnGroup(
                             !IsSparseFloatVectorDataType(data_type)
                         ? field.get_dim()
                         : 1,
-                    batch_num_rows);
+                    rows_to_load);
                 auto array = record_batch->column(i);
+                if (rows_to_load < batch_num_rows) {
+                    array = array->Slice(0, rows_to_load);
+                }
                 field_data->FillFieldData(array);
                 field_data_map[FieldId(field_id)].push_back(field_data);
             }
+            loaded_rows += rows_to_load;
         }
-    }
+    });
 
     LOG_INFO("Finished loading segment {} column group {}", id_, index);
     return field_data_map;

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -681,7 +681,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     LoadColumnGroup(
         const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
-        int64_t index);
+        int64_t index,
+        int64_t row_limit);
 
  private:
     storage::MmapChunkDescriptorPtr mmap_descriptor_ = nullptr;

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -10,7 +10,18 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <gtest/gtest.h>
-
+#include <nlohmann/json.hpp>
+#include <stddef.h>
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -26,12 +37,43 @@
 #include "expr/ITypeExpr.h"
 #include "plan/PlanNode.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/ManifestTestUtil.h"
 #include "test_utils/storage_test_utils.h"
 #include "test_utils/GenExprProto.h"
 
 using namespace milvus::segcore;
 using namespace milvus;
 namespace pb = milvus::proto;
+
+namespace {
+
+void
+AddStorageV3SystemFields(const SchemaPtr& schema) {
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+}
+
+bool
+ManifestHasField(const milvus::test::V3SegmentTestData& test_data,
+                 FieldId field_id) {
+    auto field_column = std::to_string(field_id.get());
+    auto column_groups = test_data.GetColumnGroups();
+    for (size_t i = 0; i < column_groups->size(); ++i) {
+        const auto& columns = column_groups->get_column_group(i)->columns;
+        if (std::find(columns.begin(), columns.end(), field_column) !=
+            columns.end()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
 
 TEST(Growing, DeleteCount) {
     auto schema = std::make_shared<Schema>();
@@ -103,6 +145,113 @@ TEST(Growing, RealCount) {
     status = segment->Delete(c, del_ids3.get(), del_tss3.data());
     ASSERT_TRUE(status.ok());
     ASSERT_EQ(0, segment->get_real_count());
+}
+
+TEST(Growing, LoadStorageV3ManifestCapsRowsAtCheckpoint) {
+    auto schema = std::make_shared<Schema>();
+    AddStorageV3SystemFields(schema);
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    constexpr int64_t dim = 4;
+    auto vec = schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2);
+
+    std::map<std::string, std::string> analyzer_params;
+    auto text = schema->AddDebugVarcharField(FieldName("text"),
+                                             DataType::VARCHAR,
+                                             65535,
+                                             false,
+                                             true,
+                                             true,
+                                             analyzer_params,
+                                             std::nullopt);
+    schema->set_primary_field_id(pk);
+
+    auto base_path = (std::filesystem::path(TestLocalPath) /
+                      "growing_recovery_checkpoint_row_cap")
+                         .string();
+    std::filesystem::remove_all(base_path);
+    milvus::test::V3SegmentTestData test_data(
+        schema, 2, 3, dim, TestLocalPath, base_path);
+    ASSERT_EQ(test_data.NumColumnGroups(), 2);
+    ASSERT_TRUE(ManifestHasField(test_data, RowFieldID));
+    ASSERT_TRUE(ManifestHasField(test_data, TimestampFieldID));
+
+    constexpr int64_t checkpoint_rows = 4;
+    milvus::proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_collectionid(1);
+    load_info.set_partitionid(2);
+    load_info.set_segmentid(3);
+    load_info.set_storageversion(STORAGE_V2);
+    load_info.set_num_of_rows(checkpoint_rows);
+    load_info.set_manifest_path(test_data.ManifestPathJson());
+    load_info.set_insert_channel("by-dev-rootcoord-dml_0_1v0");
+
+    auto segment =
+        CreateGrowingSegment(schema, empty_index_meta, load_info.segmentid());
+    segment->SetLoadInfo(load_info);
+    milvus::tracer::TraceContext trace_ctx;
+    segment->Load(trace_ctx, nullptr);
+    ASSERT_EQ(segment->get_row_count(), checkpoint_rows);
+    EXPECT_EQ(segment->get_real_count(), checkpoint_rows);
+
+    std::vector<int64_t> row_ids = {checkpoint_rows};
+    std::vector<Timestamp> timestamps = {100};
+    std::vector<int64_t> pks = {100000};
+    std::vector<std::string> texts = {"text after recovery checkpoint"};
+    std::vector<float> vectors(dim, 1.0F);
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(1);
+    insert_data->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(pks.data(), nullptr, 1, (*schema)[pk]).release());
+    insert_data->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(texts.data(), nullptr, 1, (*schema)[text])
+            .release());
+    insert_data->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(vectors.data(), nullptr, 1, (*schema)[vec])
+            .release());
+
+    auto offset = segment->PreInsert(1);
+    ASSERT_EQ(offset, checkpoint_rows);
+    ASSERT_NO_THROW(segment->Insert(
+        offset, 1, row_ids.data(), timestamps.data(), insert_data.get()));
+    EXPECT_EQ(segment->get_row_count(), checkpoint_rows + 1);
+
+    std::filesystem::remove_all(base_path);
+}
+
+TEST(Growing, LoadStorageV3ManifestRejectsShortRequiredRows) {
+    auto schema = std::make_shared<Schema>();
+    AddStorageV3SystemFields(schema);
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk);
+
+    auto base_path = (std::filesystem::path(TestLocalPath) /
+                      "growing_recovery_short_required_rows")
+                         .string();
+    std::filesystem::remove_all(base_path);
+    milvus::test::V3SegmentTestData test_data(
+        schema, 1, 2, 1, TestLocalPath, base_path);
+    ASSERT_TRUE(ManifestHasField(test_data, RowFieldID));
+    ASSERT_TRUE(ManifestHasField(test_data, TimestampFieldID));
+
+    milvus::proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_collectionid(1);
+    load_info.set_partitionid(2);
+    load_info.set_segmentid(4);
+    load_info.set_storageversion(STORAGE_V2);
+    load_info.set_num_of_rows(test_data.TotalRows() + 1);
+    load_info.set_manifest_path(test_data.ManifestPathJson());
+    load_info.set_insert_channel("by-dev-rootcoord-dml_0_1v0");
+
+    auto segment =
+        CreateGrowingSegment(schema, empty_index_meta, load_info.segmentid());
+    segment->SetLoadInfo(load_info);
+    milvus::tracer::TraceContext trace_ctx;
+    ASSERT_ANY_THROW(segment->Load(trace_ctx, nullptr));
+    EXPECT_EQ(segment->get_row_count(), 0);
+
+    std::filesystem::remove_all(base_path);
 }
 
 class GrowingTest

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -237,6 +237,33 @@ WaitAllFutures(std::vector<std::future<T>> futures) {
     return results;
 }
 
+// Process futures in order, invoking processor on each result as soon as it's
+// ready. This reduces peak memory compared to WaitAllFutures because each
+// result can be consumed before later futures resolve.
+// On exception, continue waiting for all remaining futures to avoid use-after-free
+// on resources captured by background threads.
+template <typename T, typename Processor>
+void
+ProcessFuturesInOrder(std::vector<std::future<T>>& futures,
+                      Processor&& processor) {
+    std::exception_ptr first_exception = nullptr;
+    for (auto& future : futures) {
+        try {
+            auto result = future.get();
+            if (!first_exception) {
+                processor(std::move(result));
+            }
+        } catch (...) {
+            if (!first_exception) {
+                first_exception = std::current_exception();
+            }
+        }
+    }
+    if (first_exception) {
+        std::rethrow_exception(first_exception);
+    }
+}
+
 std::vector<FieldDataPtr>
 GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
                            int64_t field_id,

--- a/internal/core/unittest/test_utils/ManifestTestUtil.h
+++ b/internal/core/unittest/test_utils/ManifestTestUtil.h
@@ -1,0 +1,285 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "arrow/record_batch.h"
+#include "common/FieldMeta.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "milvus-storage/column_groups.h"
+#include "milvus-storage/common/config.h"
+#include "milvus-storage/properties.h"
+#include "milvus-storage/reader.h"
+#include "milvus-storage/transaction/transaction.h"
+#include "milvus-storage/writer.h"
+#include "DataGen.h"
+
+namespace milvus::test {
+
+// Generate a schema_based column group pattern from a Schema.
+// Mirrors Go's SelectedDataTypePolicy + RemanentShortPolicy:
+//   - Each vector field -> its own group
+//   - All scalar fields -> one group
+// Pattern format: groups separated by ",", columns within a group by "|".
+inline std::string
+GenerateColumnGroupPattern(const SchemaPtr& schema) {
+    std::vector<std::string> scalar_ids;
+    std::vector<std::string> vector_groups;
+
+    for (const auto& field_id : schema->get_field_ids()) {
+        const auto& meta = (*schema)[field_id];
+        auto id_str = std::to_string(field_id.get());
+        if (IsVectorDataType(meta.get_data_type())) {
+            vector_groups.push_back(id_str);
+        } else {
+            scalar_ids.push_back(id_str);
+        }
+    }
+
+    std::string pattern;
+    if (!scalar_ids.empty()) {
+        for (size_t i = 0; i < scalar_ids.size(); ++i) {
+            if (i > 0) {
+                pattern += "|";
+            }
+            pattern += scalar_ids[i];
+        }
+    }
+    for (const auto& vg : vector_groups) {
+        if (!pattern.empty()) {
+            pattern += ",";
+        }
+        pattern += vg;
+    }
+    return pattern;
+}
+
+inline std::shared_ptr<arrow::Schema>
+ConvertToStorageV3ArrowSchema(const SchemaPtr& schema) {
+    auto arrow_schema = schema->ConvertToArrowSchema();
+    arrow::FieldVector fields;
+    const auto& field_ids = schema->get_field_ids();
+    fields.reserve(field_ids.size());
+    for (size_t i = 0; i < field_ids.size(); ++i) {
+        fields.push_back(arrow_schema->field(i)->WithName(
+            std::to_string(field_ids[i].get())));
+    }
+    return arrow::schema(std::move(fields));
+}
+
+// Generates V3 segment data using real milvus-storage APIs.
+// Writes actual Parquet files + manifest to base_path.
+class V3SegmentTestData {
+ public:
+    V3SegmentTestData(const SchemaPtr& schema,
+                      int64_t n_batch,
+                      int64_t per_batch,
+                      int64_t dim,
+                      const std::string& root_path,
+                      const std::string& base_path)
+        : schema_(schema), base_path_(base_path), root_path_(root_path) {
+        std::filesystem::create_directories(std::filesystem::path(root_path) /
+                                            std::filesystem::path(base_path));
+
+        // Convert schema to Arrow schemas
+        auto arrow_schema = schema_->ConvertToArrowSchema();
+        loon_schema_ = ConvertToStorageV3ArrowSchema(schema_);
+
+        // Generate data batches and remap to Loon schema
+        std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+        batches.reserve(n_batch);
+        for (int64_t i = 0; i < n_batch; ++i) {
+            auto dataset = milvus::segcore::DataGen(schema_, per_batch, 42 + i);
+            auto batch = milvus::segcore::ConvertToArrowRecordBatch(
+                dataset, dim, arrow_schema);
+            // Remap to Loon schema (field IDs as column names).
+            // Both schemas iterate field_ids_ in the same order, so
+            // columns align directly.
+            auto loon_batch = arrow::RecordBatch::Make(
+                loon_schema_, batch->num_rows(), batch->columns());
+            batches.push_back(std::move(loon_batch));
+        }
+        total_rows_ = n_batch * per_batch;
+
+        // Set up Writer properties with schema_based column group policy
+        auto pattern = GenerateColumnGroupPattern(schema_);
+        milvus_storage::api::Properties props;
+        milvus_storage::api::SetValue(props, PROPERTY_FS_STORAGE_TYPE, "local");
+        milvus_storage::api::SetValue(
+            props, PROPERTY_FS_ROOT_PATH, root_path.c_str());
+        milvus_storage::api::SetValue(props,
+                                      PROPERTY_WRITER_POLICY,
+                                      LOON_COLUMN_GROUP_POLICY_SCHEMA_BASED);
+        milvus_storage::api::SetValue(
+            props, PROPERTY_WRITER_SCHEMA_BASE_PATTERNS, pattern.c_str());
+
+        auto policy_result =
+            milvus_storage::api::ColumnGroupPolicy::create_column_group_policy(
+                props, loon_schema_);
+        AssertInfo(policy_result.ok(),
+                   "Failed to create column group policy: {}",
+                   policy_result.status().ToString());
+        auto policy = std::move(policy_result).ValueOrDie();
+
+        // Write data using Writer API
+        auto writer = milvus_storage::api::Writer::create(
+            base_path_, loon_schema_, std::move(policy), props);
+        for (auto& batch : batches) {
+            auto status = writer->write(batch);
+            AssertInfo(
+                status.ok(), "Failed to write batch: {}", status.ToString());
+        }
+        auto close_result = writer->close();
+        AssertInfo(close_result.ok(),
+                   "Failed to close writer: {}",
+                   close_result.status().ToString());
+        auto column_groups = std::move(close_result).ValueOrDie();
+
+        // Commit manifest via the 2.6 transaction API.
+        using namespace milvus_storage::api::transaction;
+        auto txn =
+            std::make_shared<TransactionImpl<Manifest>>(props, base_path_);
+        auto begin_status = txn->begin();
+        AssertInfo(begin_status.ok(),
+                   "Failed to begin transaction: {}",
+                   begin_status.ToString());
+        auto commit_result = txn->commit(column_groups,
+                                         UpdateType::APPENDFILES,
+                                         TransResolveStrategy::RESOLVE_FAIL);
+        AssertInfo(commit_result.ok(),
+                   "Failed to commit transaction: {}",
+                   commit_result.status().ToString());
+        auto commit = std::move(commit_result).ValueOrDie();
+        AssertInfo(commit.success,
+                   "Failed to commit transaction: {}",
+                   commit.failed_message);
+        committed_version_ = commit.committed_version;
+
+        // Read back from manifest to get the committed column groups
+        auto read_txn =
+            std::make_shared<TransactionImpl<Manifest>>(props, base_path_);
+        begin_status = read_txn->begin(committed_version_);
+        AssertInfo(begin_status.ok(),
+                   "Failed to begin read transaction: {}",
+                   begin_status.ToString());
+        auto manifest_result = read_txn->get_current_manifest();
+        AssertInfo(manifest_result.ok(),
+                   "Failed to get manifest: {}",
+                   manifest_result.status().ToString());
+        column_groups_ = std::move(manifest_result).ValueOrDie();
+    }
+
+    ~V3SegmentTestData() {
+        // if (std::filesystem::exists(base_path_)) {
+        //     std::filesystem::remove_all(base_path_);
+        // }
+    }
+
+    // Non-copyable, non-movable
+    V3SegmentTestData(const V3SegmentTestData&) = delete;
+    V3SegmentTestData&
+    operator=(const V3SegmentTestData&) = delete;
+    V3SegmentTestData(V3SegmentTestData&&) = delete;
+    V3SegmentTestData&
+    operator=(V3SegmentTestData&&) = delete;
+
+    std::unique_ptr<milvus_storage::api::ChunkReader>
+    CreateChunkReader(int64_t cg_index) const {
+        milvus_storage::api::Properties reader_props;
+        milvus_storage::api::SetValue(
+            reader_props, PROPERTY_FS_STORAGE_TYPE, "local");
+        milvus_storage::api::SetValue(
+            reader_props, PROPERTY_FS_ROOT_PATH, root_path_.c_str());
+        auto reader = milvus_storage::api::Reader::create(
+            column_groups_, loon_schema_, nullptr, reader_props);
+        auto result = reader->get_chunk_reader(cg_index);
+        AssertInfo(result.ok(),
+                   "Failed to create chunk reader for cg_index {}: {}",
+                   cg_index,
+                   result.status().ToString());
+        return std::move(result).ValueOrDie();
+    }
+
+    std::unordered_map<FieldId, FieldMeta>
+    GetFieldMetas(int64_t cg_index) const {
+        std::unordered_map<FieldId, FieldMeta> result;
+        const auto& cg = column_groups_->get_column_group(cg_index);
+        for (const auto& col_name : cg->columns) {
+            auto fid = FieldId(std::stoll(col_name));
+            result.emplace(fid, (*schema_)[fid]);
+        }
+        return result;
+    }
+
+    std::unordered_map<FieldId, FieldMeta>
+    GetAllFieldMetas() const {
+        return schema_->get_fields();
+    }
+
+    std::shared_ptr<arrow::Schema>
+    GetLoonSchema() const {
+        return loon_schema_;
+    }
+
+    std::shared_ptr<milvus_storage::api::ColumnGroups>
+    GetColumnGroups() const {
+        return column_groups_;
+    }
+
+    int64_t
+    TotalRows() const {
+        return total_rows_;
+    }
+
+    int64_t
+    NumColumnGroups() const {
+        return static_cast<int64_t>(column_groups_->size());
+    }
+
+    const std::string&
+    BasePath() const {
+        return base_path_;
+    }
+
+    int64_t
+    Version() const {
+        return committed_version_;
+    }
+
+    std::string
+    ManifestPathJson() const {
+        return "{\"base_path\":\"" + base_path_ +
+               "\",\"ver\":" + std::to_string(committed_version_) + "}";
+    }
+
+ private:
+    SchemaPtr schema_;
+    std::shared_ptr<arrow::Schema> loon_schema_;
+    std::shared_ptr<milvus_storage::api::ColumnGroups> column_groups_;
+    std::string base_path_;
+    std::string root_path_;
+    int64_t total_rows_ = 0;
+    int64_t committed_version_ = 0;
+};
+
+}  // namespace milvus::test


### PR DESCRIPTION
pr: #50952
issue: #50910
issue: #50945

This is the 2.6 backport for PR #50952.

Summary:
- Cap recovered growing StorageV3 manifest rows at the segment checkpoint row count before raw fields, PKs, and text indexes are populated.
- Prevent recovered text-match indexes from advancing beyond the checkpoint row count before WAL replay resumes.
- Add 2.6 regression coverage for loading a StorageV3 manifest capped at checkpoint rows and inserting the next row at the checkpoint offset.

Verification from branch author:
- Clean worktree check.
- Conflict marker check.
- `diff/show --check` style checks.

Verification before PR creation:
- `git diff --check origin/2.6...buqian/slock-cindy-2.6-cp-50952`.
