### PR TITLE
fix: [2.6] handle empty element vector search

### DIFF
--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -120,8 +120,8 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
     if (element_count == 0) {
         return;
     }
-    if (!IsVectorDataType(data_type_)) {
-        null_count_ = array->null_count();
+    if (!(nullable_ && IsVectorDataType(data_type_))) {
+        null_count_ += array->null_count();
     }
     switch (data_type_) {
         case DataType::BOOL: {
@@ -366,7 +366,9 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
                        "Element type not set for VECTOR_ARRAY");
 
             auto values_array = list_array->values();
-            std::vector<VectorArray> values(element_count);
+            std::vector<VectorArray> values;
+            values.reserve(nullable_ ? element_count - list_array->null_count()
+                                     : element_count);
 
             switch (element_type) {
                 case DataType::VECTOR_FLOAT:
@@ -387,13 +389,19 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
                         milvus::vector_bytes_per_element(element_type, dim);
 
                     for (size_t index = 0; index < element_count; ++index) {
+                        if (nullable_ && list_array->IsNull(index)) {
+                            continue;
+                        }
                         int64_t start_offset = list_array->value_offset(index);
                         int64_t end_offset =
                             list_array->value_offset(index + 1);
                         int64_t num_vectors = end_offset - start_offset;
 
                         auto data_size = num_vectors * bytes_per_vec;
-                        auto data_ptr = std::make_unique<uint8_t[]>(data_size);
+                        auto data_ptr =
+                            data_size > 0
+                                ? std::make_unique<uint8_t[]>(data_size)
+                                : nullptr;
 
                         for (int64_t i = 0; i < num_vectors; i++) {
                             const uint8_t* binary_data =
@@ -402,7 +410,7 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
                             std::memcpy(dest, binary_data, bytes_per_vec);
                         }
 
-                        values[index] = VectorArray(
+                        values.emplace_back(
                             static_cast<const void*>(data_ptr.get()),
                             num_vectors,
                             dim,
@@ -414,6 +422,12 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
                     ThrowInfo(DataTypeInvalid,
                               "Unsupported element type {} in VectorArray",
                               GetDataTypeName(element_type));
+            }
+            if (nullable_) {
+                return FillFieldData(values.data(),
+                                     list_array->null_bitmap_data(),
+                                     element_count,
+                                     list_array->offset());
             }
             return FillFieldData(values.data(), element_count);
         }

--- a/internal/core/src/common/FieldData.h
+++ b/internal/core/src/common/FieldData.h
@@ -98,8 +98,10 @@ class FieldData<VectorArray> : public FieldDataVectorArrayImpl {
  public:
     explicit FieldData(int64_t dim,
                        DataType element_type,
+                       bool nullable = false,
                        int64_t buffered_num_rows = 0)
-        : FieldDataVectorArrayImpl(DataType::VECTOR_ARRAY, buffered_num_rows),
+        : FieldDataVectorArrayImpl(
+              DataType::VECTOR_ARRAY, nullable, buffered_num_rows),
           dim_(dim),
           element_type_(element_type) {
         AssertInfo(element_type != DataType::NONE,
@@ -123,9 +125,7 @@ class FieldData<VectorArray> : public FieldDataVectorArrayImpl {
 
     const VectorArray*
     value_at(ssize_t offset) const {
-        AssertInfo(offset < get_num_rows(),
-                   "field data subscript out of range");
-        AssertInfo(offset < length(),
+        AssertInfo(offset < get_valid_rows(),
                    "subscript position don't has valid value");
         return &data_[offset];
     }
@@ -445,5 +445,13 @@ using FieldDataChannelPtr = std::shared_ptr<FieldDataChannel>;
 
 FieldDataPtr
 InitScalarFieldData(const DataType& type, bool nullable, int64_t cap_rows);
+
+FieldDataPtr
+InitScalarFieldDataWithLength(const DataType& type, int64_t length);
+
+void
+ResizeScalarFieldData(const DataType& type,
+                      int64_t new_size,
+                      FieldDataPtr& field_data);
 
 }  // namespace milvus

--- a/internal/core/src/common/FieldDataInterface.h
+++ b/internal/core/src/common/FieldDataInterface.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <iostream>
 #include <memory>
@@ -841,17 +842,65 @@ class FieldDataArrayImpl : public FieldDataImpl<Array, true> {
 
 // is_type_entire_row set be true as each element in data_ is a VectorArray
 class FieldDataVectorArrayImpl : public FieldDataImpl<VectorArray, true> {
+    using Base = FieldDataImpl<VectorArray, true>;
+
  public:
     explicit FieldDataVectorArrayImpl(DataType data_type,
+                                      bool nullable,
                                       int64_t total_num_rows = 0)
-        : FieldDataImpl<VectorArray, true>(
-              1, data_type, false, total_num_rows) {
+        : Base(1, data_type, nullable, total_num_rows) {
+    }
+
+    using Base::FillFieldData;
+
+    void
+    FillFieldData(const void* field_data,
+                  const uint8_t* valid_data,
+                  ssize_t total_element_count,
+                  ssize_t offset) override {
+        AssertInfo(this->nullable_, "requires nullable to be true");
+        if (total_element_count == 0) {
+            return;
+        }
+
+        int64_t valid_count = 0;
+        if (valid_data == nullptr) {
+            valid_count = total_element_count;
+        } else {
+            for (ssize_t i = 0; i < total_element_count; ++i) {
+                auto bit_pos = offset + i;
+                valid_count +=
+                    (valid_data[bit_pos >> 3] >> (bit_pos & 0x07)) & 1;
+            }
+        }
+
+        std::lock_guard lck(this->tell_mutex_);
+        resize_nullable_field_data(this->length_ + total_element_count,
+                                   this->valid_count_ + valid_count);
+        if (valid_data != nullptr) {
+            bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_copy(
+                valid_data,
+                offset,
+                this->valid_data_.data(),
+                this->length_,
+                total_element_count);
+        }
+        if (valid_count > 0) {
+            std::copy_n(static_cast<const VectorArray*>(field_data),
+                        valid_count,
+                        this->data_.data() + this->valid_count_);
+            this->valid_count_ += valid_count;
+        }
+        this->null_count_ += total_element_count - valid_count;
+        this->length_ += total_element_count;
     }
 
     int64_t
     DataSize() const override {
+        std::shared_lock lck(this->tell_mutex_);
+        auto count = this->nullable_ ? this->valid_count_ : this->length_;
         int64_t data_size = 0;
-        for (size_t offset = 0; offset < length(); ++offset) {
+        for (size_t offset = 0; offset < count; ++offset) {
             data_size += data_[offset].byte_size();
         }
         return data_size;
@@ -859,11 +908,46 @@ class FieldDataVectorArrayImpl : public FieldDataImpl<VectorArray, true> {
 
     int64_t
     DataSize(ssize_t offset) const override {
+        auto count = this->nullable_ ? this->get_valid_rows() : length();
+        AssertInfo(offset < get_num_rows(),
+                   "field data subscript out of range");
+        AssertInfo(offset < count, "subscript position don't has valid value");
+        return data_[offset].byte_size();
+    }
+
+    int64_t
+    get_valid_rows() const override {
+        std::shared_lock lck(this->tell_mutex_);
+        if (this->nullable_) {
+            return this->valid_count_;
+        }
+        return this->length_;
+    }
+
+    bool
+    is_valid(ssize_t offset) const override {
+        std::shared_lock lck(this->tell_mutex_);
         AssertInfo(offset < get_num_rows(),
                    "field data subscript out of range");
         AssertInfo(offset < length(),
                    "subscript position don't has valid value");
-        return data_[offset].byte_size();
+        if (!this->nullable_) {
+            return true;
+        }
+        return (this->valid_data_[offset >> 3] >> (offset & 0x07)) & 1;
+    }
+
+ private:
+    void
+    resize_nullable_field_data(int64_t num_rows, int64_t valid_count) {
+        std::lock_guard lck(this->num_rows_mutex_);
+        if (num_rows > this->num_rows_) {
+            this->num_rows_ = num_rows;
+            this->valid_data_.resize((num_rows + 7) / 8, 0xFF);
+        }
+        if (valid_count > this->valid_count_) {
+            this->data_.resize(valid_count);
+        }
     }
 };
 

--- a/internal/core/src/common/FieldMeta.cpp
+++ b/internal/core/src/common/FieldMeta.cpp
@@ -164,8 +164,13 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
         AssertInfo(type_map.count("dim"), "dim not found");
         dim = boost::lexical_cast<int64_t>(type_map.at("dim"));
 
-        return FieldMeta{
-            name, field_id, data_type, element_type, dim, std::nullopt};
+        return FieldMeta{name,
+                         field_id,
+                         data_type,
+                         element_type,
+                         dim,
+                         std::nullopt,
+                         nullable};
     }
 
     if (IsVectorDataType(data_type)) {

--- a/internal/core/src/common/FieldMeta.h
+++ b/internal/core/src/common/FieldMeta.h
@@ -135,11 +135,12 @@ class FieldMeta {
               DataType type,
               DataType element_type,
               int64_t dim,
-              std::optional<knowhere::MetricType> metric_type)
+              std::optional<knowhere::MetricType> metric_type,
+              bool nullable = false)
         : name_(std::move(name)),
           id_(id),
           type_(type),
-          nullable_(false),
+          nullable_(nullable),
           element_type_(element_type),
           vector_info_(VectorInfo{dim, std::move(metric_type)}) {
         Assert(type_ == DataType::VECTOR_ARRAY);

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -140,7 +140,8 @@ class Schema {
     AddDebugVectorArrayField(const std::string& name,
                              DataType element_type,
                              int64_t dim,
-                             std::optional<knowhere::MetricType> metric_type) {
+                             std::optional<knowhere::MetricType> metric_type,
+                             bool nullable = false) {
         auto field_id = FieldId(debug_id);
         debug_id++;
         auto field_meta = FieldMeta(FieldName(name),
@@ -148,7 +149,8 @@ class Schema {
                                     DataType::VECTOR_ARRAY,
                                     element_type,
                                     dim,
-                                    metric_type);
+                                    metric_type,
+                                    nullable);
         this->AddField(std::move(field_meta));
         return field_id;
     }

--- a/internal/core/src/common/VectorArray.h
+++ b/internal/core/src/common/VectorArray.h
@@ -37,15 +37,17 @@ class VectorArray : public milvus::VectorTrait {
                 int64_t dim,
                 DataType element_type)
         : dim_(dim), length_(num_vectors), element_type_(element_type) {
-        assert(data != nullptr);
-        assert(num_vectors > 0);
+        assert(data != nullptr || num_vectors == 0);
+        assert(num_vectors >= 0);
         assert(dim > 0);
 
         size_ =
             num_vectors * milvus::vector_bytes_per_element(element_type, dim);
 
-        data_ = std::make_unique<char[]>(size_);
-        std::memcpy(data_.get(), data, size_);
+        if (size_ > 0) {
+            data_ = std::make_unique<char[]>(size_);
+            std::memcpy(data_.get(), data, size_);
+        }
     }
 
     // One row of VectorFieldProto
@@ -224,25 +226,43 @@ class VectorArray : public milvus::VectorTrait {
         vector_field.set_dim(dim_);
         switch (element_type_) {
             case DataType::VECTOR_FLOAT: {
-                auto data = reinterpret_cast<const float*>(data_.get());
-                vector_field.mutable_float_vector()->mutable_data()->Add(
-                    data, data + length_ * dim_);
+                auto* obj = vector_field.mutable_float_vector();
+                if (length_ > 0) {
+                    auto data = reinterpret_cast<const float*>(data_.get());
+                    obj->mutable_data()->Add(data, data + length_ * dim_);
+                }
                 break;
             }
             case DataType::VECTOR_BINARY: {
-                vector_field.set_binary_vector(data_.get(), size_);
+                if (size_ > 0) {
+                    vector_field.set_binary_vector(data_.get(), size_);
+                } else {
+                    vector_field.mutable_binary_vector();
+                }
                 break;
             }
             case DataType::VECTOR_FLOAT16: {
-                vector_field.set_float16_vector(data_.get(), size_);
+                if (size_ > 0) {
+                    vector_field.set_float16_vector(data_.get(), size_);
+                } else {
+                    vector_field.mutable_float16_vector();
+                }
                 break;
             }
             case DataType::VECTOR_BFLOAT16: {
-                vector_field.set_bfloat16_vector(data_.get(), size_);
+                if (size_ > 0) {
+                    vector_field.set_bfloat16_vector(data_.get(), size_);
+                } else {
+                    vector_field.mutable_bfloat16_vector();
+                }
                 break;
             }
             case DataType::VECTOR_INT8: {
-                vector_field.set_int8_vector(data_.get(), size_);
+                if (size_ > 0) {
+                    vector_field.set_int8_vector(data_.get(), size_);
+                } else {
+                    vector_field.mutable_int8_vector();
+                }
                 break;
             }
             default: {
@@ -317,8 +337,11 @@ class VectorArray : public milvus::VectorTrait {
     VectorArray(
         char* data, int len, int dim, size_t size, DataType element_type)
         : size_(size), length_(len), dim_(dim), element_type_(element_type) {
-        data_ = std::make_unique<char[]>(size);
-        std::copy(data, data + size, data_.get());
+        if (size > 0) {
+            assert(data != nullptr);
+            data_ = std::make_unique<char[]>(size);
+            std::copy(data, data + size, data_.get());
+        }
     }
 
     int64_t dim_ = 0;

--- a/internal/core/src/exec/operator/Utils.h
+++ b/internal/core/src/exec/operator/Utils.h
@@ -90,7 +90,7 @@ PrepareVectorIteratorsFromIndex(const SearchInfo& search_info,
                         "inside, terminate {} operation",
                         operator_type));
             }
-            search_result.total_nq_ = dataset->GetRows();
+            search_result.total_nq_ = nq;
             search_result.unity_topK_ = search_info.topk_;
         } catch (const std::runtime_error& e) {
             std::string operator_type = "";

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -101,6 +101,11 @@ PhyVectorSearchNode::GetOutput() {
                 array_offsets->RowBitsetToElementBitset(view, valid_view, 0);
             data_cnt = element_bitset.size();
             query_context_->set_active_element_count(data_cnt);
+            if (element_bitset.empty()) {
+                query_context_->set_search_result(
+                    empty_search_result(num_queries, true));
+                return input_;
+            }
 
             std::vector<VectorPtr> col_res;
             col_res.push_back(std::make_shared<ColumnVector>(

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -40,12 +40,140 @@ namespace milvus::index {
 
 namespace {
 
+constexpr const char* EMPTY_EMB_LIST_OFFSET_KEY = "empty_emb_list_offsets";
+
 struct DiskValidData {
     bool found = false;
     size_t total_count = 0;
     size_t valid_count = 0;
     std::vector<uint8_t> bitmap;
 };
+
+struct EmptyEmbListState {
+    int64_t dim = 0;
+    std::vector<size_t> offsets;
+};
+
+class DiskEmptyVectorIterator : public knowhere::IndexNode::iterator {
+ public:
+    std::pair<int64_t, float>
+    Next() override {
+        throw std::runtime_error("empty vector iterator has no next result");
+    }
+
+    bool
+    HasNext() override {
+        return false;
+    }
+};
+
+template <typename LocalChunkManagerPtr>
+std::optional<std::vector<size_t>>
+ReadDiskEmbListOffsets(const LocalChunkManagerPtr& local_chunk_manager,
+                       const std::string& offsets_path) {
+    if (!local_chunk_manager->Exist(offsets_path)) {
+        return std::nullopt;
+    }
+
+    auto file_size = local_chunk_manager->Size(offsets_path);
+    AssertInfo(file_size >= sizeof(size_t),
+               "embedding list offsets file is too small");
+    size_t num_offsets = 0;
+    local_chunk_manager->Read(offsets_path, 0, &num_offsets, sizeof(size_t));
+    AssertInfo(num_offsets > 0, "embedding list offsets count is invalid");
+    AssertInfo(file_size >= sizeof(size_t) + num_offsets * sizeof(size_t),
+               "embedding list offsets file payload is too small");
+
+    std::vector<size_t> offsets(num_offsets);
+    local_chunk_manager->Read(offsets_path,
+                              sizeof(size_t),
+                              offsets.data(),
+                              num_offsets * sizeof(size_t));
+    AssertInfo(offsets.front() == 0, "embedding list offsets must start at 0");
+    return offsets;
+}
+
+template <typename LocalChunkManagerPtr>
+void
+WriteDiskEmptyEmbListOffsets(const LocalChunkManagerPtr& local_chunk_manager,
+                             const std::string& empty_offsets_path,
+                             int64_t dim,
+                             const std::vector<size_t>& offsets) {
+    AssertInfo(dim > 0, "empty emb_list dim is invalid");
+    AssertInfo(!offsets.empty() && offsets.front() == 0,
+               "empty emb_list offsets are invalid");
+    AssertInfo(offsets.back() == 0,
+               "empty emb_list offsets must have no flattened vectors");
+
+    if (!local_chunk_manager->Exist(empty_offsets_path)) {
+        local_chunk_manager->CreateFile(empty_offsets_path);
+    }
+
+    auto count = ToValidDataCount(offsets.size());
+    int64_t write_pos = 0;
+    local_chunk_manager->Write(
+        empty_offsets_path, write_pos, &dim, sizeof(int64_t));
+    write_pos += sizeof(int64_t);
+    local_chunk_manager->Write(
+        empty_offsets_path, write_pos, &count, sizeof(uint64_t));
+    write_pos += sizeof(uint64_t);
+    local_chunk_manager->Write(empty_offsets_path,
+                               write_pos,
+                               const_cast<size_t*>(offsets.data()),
+                               offsets.size() * sizeof(size_t));
+}
+
+template <typename LocalChunkManagerPtr>
+std::optional<EmptyEmbListState>
+ReadDiskEmptyEmbListOffsets(const LocalChunkManagerPtr& local_chunk_manager,
+                            const std::string& empty_offsets_path) {
+    if (!local_chunk_manager->Exist(empty_offsets_path)) {
+        return std::nullopt;
+    }
+
+    auto file_size = local_chunk_manager->Size(empty_offsets_path);
+    AssertInfo(file_size >= sizeof(int64_t) + sizeof(uint64_t),
+               "empty emb_list offsets file is too small");
+
+    int64_t read_pos = 0;
+    int64_t dim = 0;
+    local_chunk_manager->Read(
+        empty_offsets_path, read_pos, &dim, sizeof(int64_t));
+    read_pos += sizeof(int64_t);
+
+    uint64_t wire_count = 0;
+    local_chunk_manager->Read(
+        empty_offsets_path, read_pos, &wire_count, sizeof(uint64_t));
+    read_pos += sizeof(uint64_t);
+
+    auto count = FromValidDataCount(wire_count);
+    AssertInfo(count > 0, "empty emb_list offsets count is invalid");
+    AssertInfo(file_size >= read_pos + count * sizeof(size_t),
+               "empty emb_list offsets payload is too small");
+
+    std::vector<size_t> offsets(count);
+    local_chunk_manager->Read(
+        empty_offsets_path, read_pos, offsets.data(), count * sizeof(size_t));
+    AssertInfo(offsets.front() == 0, "empty emb_list offsets must start at 0");
+    AssertInfo(offsets.back() == 0,
+               "empty emb_list offsets must have no flattened vectors");
+    return EmptyEmbListState{dim, std::move(offsets)};
+}
+
+size_t
+GetEmbListNumOffsets(const DatasetPtr& dataset,
+                     const size_t* offsets,
+                     size_t total_vectors) {
+    auto num_queries = dataset->Get<int64_t>(knowhere::meta::NQ);
+    AssertInfo(num_queries > 0, "embedding list build query count is missing");
+    AssertInfo(offsets[num_queries] == total_vectors,
+               "embedding list build offsets are inconsistent with "
+               "flattened rows: nq={}, terminal_offset={}, rows={}",
+               num_queries,
+               offsets[num_queries],
+               total_vectors);
+    return static_cast<size_t>(num_queries) + 1;
+}
 
 template <typename LocalChunkManagerPtr>
 DiskValidData
@@ -187,7 +315,10 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
     bool all_null_nullable = disk_valid_data.found &&
                              disk_valid_data.total_count > 0 &&
                              disk_valid_data.valid_count == 0;
-    if (!all_null_nullable) {
+    auto empty_emb_list_state = ReadDiskEmptyEmbListOffsets(
+        local_chunk_manager,
+        local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY);
+    if (!all_null_nullable && !empty_emb_list_state.has_value()) {
         // start engine load index span
         auto span_load_engine =
             milvus::tracer::StartSpan("SegCoreEngineLoadDiskIndex", &ctx);
@@ -206,6 +337,10 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
             SetDim(dim.value());
         }
     }
+    if (empty_emb_list_state.has_value()) {
+        SetDim(empty_emb_list_state->dim);
+        empty_emb_list_offsets_ = std::move(empty_emb_list_state->offsets);
+    }
 
     if (disk_valid_data.found) {
         BuildValidDataFromBitmap(
@@ -218,7 +353,7 @@ IndexStatsPtr
 VectorDiskAnnIndex<T>::Upload(const Config& config) {
     BinarySet ret;
     const auto& offset_mapping = GetOffsetMapping();
-    if (!IsAllNullNullable(offset_mapping)) {
+    if (!IsAllNullNullable(offset_mapping) && !IsEmptyEmbListIndex()) {
         auto stat = index_.Serialize(ret);
         if (stat != knowhere::Status::success) {
             ThrowInfo(ErrorCode::UnexpectedError,
@@ -288,10 +423,35 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
 
     // For VECTOR_ARRAY, verify offsets file exists and pass its path to build_config
     if (is_embedding_list) {
-        if (!local_chunk_manager->Exist(offsets_path)) {
+        auto offsets =
+            ReadDiskEmbListOffsets(local_chunk_manager, offsets_path);
+        if (!offsets.has_value()) {
             ThrowInfo(ErrorCode::UnexpectedError,
                       fmt::format("Embedding list offsets file not found: {}",
                                   offsets_path));
+        }
+        if (offsets->back() == 0) {
+            auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
+            AssertInfo(dim.has_value() && dim.value() > 0,
+                       "dim is missing when build empty emb_list disk index");
+            SetDim(dim.value());
+
+            auto empty_offsets_path =
+                local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY;
+            WriteDiskEmptyEmbListOffsets(local_chunk_manager,
+                                         empty_offsets_path,
+                                         GetDim(),
+                                         offsets.value());
+            file_manager_->AddFile(empty_offsets_path);
+            if (local_chunk_manager->Exist(valid_data_path)) {
+                file_manager_->AddFile(valid_data_path);
+            }
+            local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
+                local_chunk_manager, segment_id, field_id));
+            empty_emb_list_offsets_ = std::move(offsets.value());
+            LOG_INFO("build all-empty emb_list disk index done, build_id: {}",
+                     config.value("build_id", "unknown"));
+            return;
         }
         build_config[EMB_LIST_OFFSETS_PATH] = offsets_path;
     }
@@ -377,6 +537,30 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         return;
     }
 
+    if (is_embedding_list && milvus::GetDatasetRows(dataset) == 0) {
+        auto offsets =
+            dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        if (offsets == nullptr) {
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "Embedding list offsets is empty when build index");
+        }
+        auto num_offsets = GetEmbListNumOffsets(dataset, offsets, 0);
+        auto empty_offsets =
+            std::vector<size_t>(offsets, offsets + num_offsets);
+        auto empty_offsets_path =
+            local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY;
+        WriteDiskEmptyEmbListOffsets(local_chunk_manager,
+                                     empty_offsets_path,
+                                     dataset->GetDim(),
+                                     empty_offsets);
+        file_manager_->AddFile(empty_offsets_path);
+        SetDim(dataset->GetDim());
+        empty_emb_list_offsets_ = std::move(empty_offsets);
+        local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
+            local_chunk_manager, segment_id, field_id));
+        return;
+    }
+
     if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
         auto num_threads = GetValueFromConfig<std::string>(
             build_config, DISK_ANN_BUILD_THREAD_NUM);
@@ -419,16 +603,10 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
             "offset";
         local_chunk_manager->CreateFile(offsets_path);
 
-        // GetDatasetRows returns total flattened vector count for vector arrays,
-        // not the number of emb_lists. Count actual offsets by scanning the array
-        // until we reach the terminal element (== total_vectors).
         size_t total_vectors =
             static_cast<size_t>(milvus::GetDatasetRows(dataset));
-        size_t num_offsets = 0;
-        while (offsets[num_offsets] < total_vectors) {
-            num_offsets++;
-        }
-        num_offsets++;  // include the terminal element (== total_vectors)
+        auto num_offsets =
+            GetEmbListNumOffsets(dataset, offsets, total_vectors);
 
         // Write offsets to file
         // Format: [num_offsets (size_t)][offsets_data (size_t array)]
@@ -479,6 +657,31 @@ VectorDiskAnnIndex<T>::Query(const DatasetPtr dataset,
     auto topk = search_info.topk_;
 
     knowhere::Json search_config = PrepareSearchParams(search_info);
+
+    if (IsAllNullNullable(*offset_mapping_) || IsEmptyEmbListIndex()) {
+        auto offsets =
+            dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        auto num_queries = dataset->GetRows();
+        if (offsets != nullptr) {
+            num_queries = dataset->Get<int64_t>(knowhere::meta::NQ);
+            AssertInfo(num_queries > 0,
+                       "embedding list query count is missing");
+            auto total_vectors = static_cast<size_t>(dataset->GetRows());
+            AssertInfo(
+                offsets[num_queries] == total_vectors,
+                "embedding list query offsets are inconsistent with flattened "
+                "rows: nq={}, terminal_offset={}, rows={}",
+                num_queries,
+                offsets[num_queries],
+                total_vectors);
+        }
+        auto total_num = num_queries * topk;
+        search_result.seg_offsets_.assign(total_num, INVALID_SEG_OFFSET);
+        search_result.distances_.assign(total_num, 0.0F);
+        search_result.total_nq_ = num_queries;
+        search_result.unity_topK_ = topk;
+        return;
+    }
 
     if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
         // set search list size
@@ -550,12 +753,43 @@ knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
 VectorDiskAnnIndex<T>::VectorIterators(const DatasetPtr dataset,
                                        const knowhere::Json& conf,
                                        const BitsetView& bitset) const {
+    auto make_empty_iterators = [](int64_t num_queries) {
+        std::vector<knowhere::IndexNode::IteratorPtr> iterators;
+        iterators.reserve(num_queries);
+        for (int64_t i = 0; i < num_queries; ++i) {
+            iterators.emplace_back(std::make_shared<DiskEmptyVectorIterator>());
+        }
+        return iterators;
+    };
+
+    if (IsAllNullNullable(*offset_mapping_) || IsEmptyEmbListIndex()) {
+        auto offsets =
+            dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        auto num_queries = dataset->GetRows();
+        if (offsets != nullptr) {
+            num_queries = dataset->Get<int64_t>(knowhere::meta::NQ);
+            AssertInfo(num_queries > 0,
+                       "embedding list query count is missing");
+            auto total_vectors = static_cast<size_t>(dataset->GetRows());
+            AssertInfo(
+                offsets[num_queries] == total_vectors,
+                "embedding list query offsets are inconsistent with flattened "
+                "rows: nq={}, terminal_offset={}, rows={}",
+                num_queries,
+                offsets[num_queries],
+                total_vectors);
+        }
+        return make_empty_iterators(num_queries);
+    }
     return this->index_.AnnIterator(dataset, conf, bitset, false);
 }
 
 template <typename T>
 const bool
 VectorDiskAnnIndex<T>::HasRawData() const {
+    if (IsAllNullNullable(*offset_mapping_) || IsEmptyEmbListIndex()) {
+        return true;
+    }
     return index_.HasRawData(GetMetricType());
 }
 

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -52,6 +52,12 @@ class VectorDiskAnnIndex : public VectorIndex {
 
     int64_t
     Count() override {
+        if (HasValidData() && GetValidCount() == 0) {
+            return 0;
+        }
+        if (IsEmptyEmbListIndex()) {
+            return 0;
+        }
         return index_.Count();
     }
 
@@ -96,6 +102,11 @@ class VectorDiskAnnIndex : public VectorIndex {
                     const BitsetView& bitset) const override;
 
  private:
+    bool
+    IsEmptyEmbListIndex() const {
+        return elem_type_ != DataType::NONE && !empty_emb_list_offsets_.empty();
+    }
+
     knowhere::Json
     update_load_json(const Config& config);
 
@@ -105,6 +116,7 @@ class VectorDiskAnnIndex : public VectorIndex {
     uint32_t search_beamwidth_ = 8;
     // used for embedding list only
     DataType elem_type_;
+    std::vector<size_t> empty_emb_list_offsets_;
 };
 
 template <typename T>

--- a/internal/core/src/index/VectorIndexValidDataUtils.h
+++ b/internal/core/src/index/VectorIndexValidDataUtils.h
@@ -85,8 +85,7 @@ ContainsOnlyValidData(const BinarySet& binary_set) {
 
 inline bool
 IsAllNullNullable(const OffsetMapping& offset_mapping) {
-    return offset_mapping.IsEnabled() && offset_mapping.GetTotalCount() > 0 &&
-           offset_mapping.GetValidCount() == 0;
+    return offset_mapping.IsEnabled() && offset_mapping.GetValidCount() == 0;
 }
 
 inline size_t

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -38,6 +38,11 @@
 #include "index/VectorIndexValidDataUtils.h"
 #include "common/EasyAssert.h"
 #include "config/ConfigKnowhere.h"
+#include "knowhere/binaryset.h"
+#include "knowhere/comp/index_param.h"
+#include "knowhere/comp/time_recorder.h"
+#include "knowhere/dataset.h"
+#include "knowhere/emb_list_utils.h"
 #include "knowhere/index/index_factory.h"
 #include "knowhere/comp/time_recorder.h"
 #include "common/BitsetView.h"
@@ -57,6 +62,89 @@
 #include "storage/FileWriter.h"
 
 namespace milvus::index {
+
+namespace {
+
+constexpr const char* EMPTY_EMB_LIST_OFFSET_KEY = "empty_emb_list_offsets";
+
+struct EmptyEmbListState {
+    int64_t dim;
+    std::vector<size_t> offsets;
+};
+
+class EmptyVectorIterator : public knowhere::IndexNode::iterator {
+ public:
+    std::pair<int64_t, float>
+    Next() override {
+        throw std::runtime_error("empty vector iterator has no next result");
+    }
+
+    bool
+    HasNext() override {
+        return false;
+    }
+};
+
+EmptyEmbListState
+LoadEmptyEmbListOffsetsFromPayload(const uint8_t* data, size_t size) {
+    AssertInfo(data != nullptr, "empty emb_list offset data is null");
+    AssertInfo(size >= sizeof(int64_t) + sizeof(uint64_t),
+               "empty emb_list offset file is invalid");
+    const auto* ptr = data;
+    int64_t dim = 0;
+    std::memcpy(&dim, ptr, sizeof(int64_t));
+    ptr += sizeof(int64_t);
+
+    uint64_t wire_count = 0;
+    std::memcpy(&wire_count, ptr, sizeof(uint64_t));
+    ptr += sizeof(uint64_t);
+
+    auto count = FromValidDataCount(wire_count);
+    AssertInfo(count > 0, "empty emb_list offset count is invalid");
+    auto expected_size =
+        sizeof(int64_t) + sizeof(uint64_t) + count * sizeof(size_t);
+    AssertInfo(size >= expected_size,
+               "empty emb_list offset file is too small");
+
+    std::vector<size_t> offsets(count);
+    std::memcpy(offsets.data(), ptr, count * sizeof(size_t));
+    AssertInfo(offsets.front() == 0, "empty emb_list offset must start at 0");
+    AssertInfo(offsets.back() == 0,
+               "empty emb_list offset must have no flattened vectors");
+    return EmptyEmbListState{dim, std::move(offsets)};
+}
+
+void
+AppendEmptyEmbListOffsetsToBinarySet(int64_t dim,
+                                     const std::vector<size_t>& offsets,
+                                     BinarySet& binary_set) {
+    if (offsets.empty()) {
+        return;
+    }
+
+    auto count = ToValidDataCount(offsets.size());
+    auto bytes =
+        sizeof(int64_t) + sizeof(uint64_t) + offsets.size() * sizeof(size_t);
+    std::shared_ptr<uint8_t[]> data(new uint8_t[bytes]);
+    auto* ptr = data.get();
+    std::memcpy(ptr, &dim, sizeof(int64_t));
+    ptr += sizeof(int64_t);
+    std::memcpy(ptr, &count, sizeof(uint64_t));
+    ptr += sizeof(uint64_t);
+    std::memcpy(ptr, offsets.data(), offsets.size() * sizeof(size_t));
+    binary_set.Append(EMPTY_EMB_LIST_OFFSET_KEY, data, bytes);
+}
+
+std::optional<EmptyEmbListState>
+LoadEmptyEmbListOffsetsFromBinarySet(const BinarySet& binary_set) {
+    auto data = binary_set.GetByName(EMPTY_EMB_LIST_OFFSET_KEY);
+    if (data == nullptr) {
+        return std::nullopt;
+    }
+    return LoadEmptyEmbListOffsetsFromPayload(data->data.get(), data->size);
+}
+
+}  // namespace
 
 template <typename T>
 VectorMemIndex<T>::VectorMemIndex(
@@ -128,6 +216,54 @@ knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
 VectorMemIndex<T>::VectorIterators(const milvus::DatasetPtr dataset,
                                    const knowhere::Json& conf,
                                    const milvus::BitsetView& bitset) const {
+    auto make_empty_iterators = [](int64_t num_queries) {
+        std::vector<knowhere::IndexNode::IteratorPtr> iterators;
+        iterators.reserve(num_queries);
+        for (int64_t i = 0; i < num_queries; ++i) {
+            iterators.emplace_back(std::make_shared<EmptyVectorIterator>());
+        }
+        return iterators;
+    };
+
+    if (IsAllNullNullable(*offset_mapping_)) {
+        auto offsets =
+            dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        auto num_queries = dataset->GetRows();
+        if (offsets != nullptr) {
+            num_queries = dataset->Get<int64_t>(knowhere::meta::NQ);
+            AssertInfo(num_queries > 0,
+                       "embedding list query count is missing");
+            auto total_vectors = static_cast<size_t>(dataset->GetRows());
+            AssertInfo(
+                offsets[num_queries] == total_vectors,
+                "embedding list query offsets are inconsistent with flattened "
+                "rows: nq={}, terminal_offset={}, rows={}",
+                num_queries,
+                offsets[num_queries],
+                total_vectors);
+        }
+        return make_empty_iterators(num_queries);
+    }
+
+    if (IsEmptyEmbListIndex()) {
+        auto offsets =
+            dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        auto num_queries = dataset->GetRows();
+        if (offsets != nullptr) {
+            num_queries = dataset->Get<int64_t>(knowhere::meta::NQ);
+            AssertInfo(num_queries > 0,
+                       "embedding list query count is missing");
+            auto total_vectors = static_cast<size_t>(dataset->GetRows());
+            AssertInfo(
+                offsets[num_queries] == total_vectors,
+                "embedding list query offsets are inconsistent with flattened "
+                "rows: nq={}, terminal_offset={}, rows={}",
+                num_queries,
+                offsets[num_queries],
+                total_vectors);
+        }
+        return make_empty_iterators(num_queries);
+    }
     return this->index_.AnnIterator(dataset, conf, bitset, false);
 }
 
@@ -148,7 +284,10 @@ VectorMemIndex<T>::Serialize(const Config& config) {
     knowhere::BinarySet ret;
     const auto& offset_mapping = GetOffsetMapping();
     bool all_null_nullable = IsAllNullNullable(offset_mapping);
-    if (!all_null_nullable) {
+    if (IsEmptyEmbListIndex()) {
+        AppendEmptyEmbListOffsetsToBinarySet(
+            GetDim(), empty_emb_list_offsets_, ret);
+    } else if (!all_null_nullable) {
         auto stat = index_.Serialize(ret);
         if (stat != knowhere::Status::success)
             ThrowInfo(ErrorCode::UnexpectedError,
@@ -166,7 +305,12 @@ template <typename T>
 void
 VectorMemIndex<T>::LoadWithoutAssemble(const BinarySet& binary_set,
                                        const Config& config) {
-    if (ContainsOnlyValidData(binary_set)) {
+    auto empty_emb_list_state =
+        LoadEmptyEmbListOffsetsFromBinarySet(binary_set);
+    if (empty_emb_list_state.has_value()) {
+        SetDim(empty_emb_list_state->dim);
+        empty_emb_list_offsets_ = std::move(empty_emb_list_state->offsets);
+    } else if (ContainsOnlyValidData(binary_set)) {
         if (config.contains(DIM_KEY)) {
             SetDim(GetDimFromConfig(config));
         }
@@ -422,7 +566,7 @@ VectorMemIndex<T>::Build(const Config& config) {
                 data.reset();
             }
         } else {
-            offsets.reserve(total_num_rows + 1);
+            offsets.reserve((nullable ? total_valid_rows : total_num_rows) + 1);
             offsets.push_back(lim_offset);
             auto bytes_per_vec = vector_bytes_per_element(elem_type_, dim);
             for (auto data : field_datas) {
@@ -432,26 +576,45 @@ VectorMemIndex<T>::Build(const Config& config) {
                            "failed to cast field data to vector array");
 
                 auto rows = vec_array_data->get_num_rows();
+                auto data_offset_before = offset;
+                int64_t physical_row = 0;
                 for (auto i = 0; i < rows; ++i) {
-                    auto size = vec_array_data->DataSize(i);
+                    if (vec_array_data->IsNullable() &&
+                        !vec_array_data->is_valid(i)) {
+                        continue;
+                    }
+                    auto size = vec_array_data->DataSize(physical_row);
                     assert(size % bytes_per_vec == 0);
                     assert(bytes_per_vec != 0);
 
-                    auto vec_array = vec_array_data->value_at(i);
+                    auto vec_array = vec_array_data->value_at(physical_row);
 
-                    std::memcpy(buf.get() + offset, vec_array->data(), size);
+                    if (size > 0) {
+                        std::memcpy(
+                            buf.get() + offset, vec_array->data(), size);
+                    }
                     offset += size;
 
                     lim_offset += size / bytes_per_vec;
                     offsets.push_back(lim_offset);
+                    physical_row++;
                 }
 
-                assert(data->Size() == offset);
+                AssertInfo(data->DataSize() == offset - data_offset_before,
+                           "inconsistent vector array data size");
 
                 data.reset();
             }
 
             total_valid_rows = lim_offset;
+            if (lim_offset == 0) {
+                SetDim(dim);
+                empty_emb_list_offsets_ = std::move(offsets);
+                if (nullable) {
+                    BuildValidData(valid_data.get(), total_num_rows);
+                }
+                return;
+            }
         }
 
         field_datas.clear();
@@ -541,6 +704,30 @@ VectorMemIndex<T>::Query(const DatasetPtr dataset,
     auto num_vectors = dataset->GetRows();
     knowhere::Json search_conf = PrepareSearchParams(search_info);
     auto topk = search_info.topk_;
+    if (IsAllNullNullable(*offset_mapping_) || IsEmptyEmbListIndex()) {
+        auto offsets =
+            dataset->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+        auto num_queries = dataset->GetRows();
+        if (offsets != nullptr) {
+            num_queries = dataset->Get<int64_t>(knowhere::meta::NQ);
+            AssertInfo(num_queries > 0,
+                       "embedding list query count is missing");
+            auto total_vectors = static_cast<size_t>(dataset->GetRows());
+            AssertInfo(
+                offsets[num_queries] == total_vectors,
+                "embedding list query offsets are inconsistent with flattened "
+                "rows: nq={}, terminal_offset={}, rows={}",
+                num_queries,
+                offsets[num_queries],
+                total_vectors);
+        }
+        auto total_num = num_queries * topk;
+        search_result.seg_offsets_.assign(total_num, INVALID_SEG_OFFSET);
+        search_result.distances_.assign(total_num, 0.0F);
+        search_result.total_nq_ = num_queries;
+        search_result.unity_topK_ = topk;
+        return;
+    }
     // TODO :: check dim of search data
     auto final = [&] {
         auto index_type = GetIndexType();
@@ -602,6 +789,9 @@ VectorMemIndex<T>::Query(const DatasetPtr dataset,
 template <typename T>
 const bool
 VectorMemIndex<T>::HasRawData() const {
+    if (IsAllNullNullable(*offset_mapping_) || IsEmptyEmbListIndex()) {
+        return true;
+    }
     return index_.HasRawData(GetMetricType());
 }
 
@@ -719,6 +909,7 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
     std::chrono::duration<double> write_disk_duration_sum;
     std::unique_ptr<storage::DataCodec> valid_data_count_codec;
     std::unique_ptr<storage::DataCodec> valid_data_codec;
+    std::unique_ptr<storage::DataCodec> empty_emb_list_offsets_codec;
     std::map<std::string, IndexDataCodec> deferred_index_data_codecs;
     bool wrote_index_data = false;
     auto DeferIndexData = [&](const std::string& prefix,
@@ -744,6 +935,8 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
         } else if (prefix == VALID_DATA_COUNT_KEY) {
             DeferIndexData(prefix, index_data);
         } else if (prefix == VALID_DATA_KEY) {
+            DeferIndexData(prefix, index_data);
+        } else if (prefix == EMPTY_EMB_LIST_OFFSET_KEY) {
             DeferIndexData(prefix, index_data);
         } else {
             file_writer.Write(index_data->PayloadData(),
@@ -825,6 +1018,8 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
     }
     valid_data_count_codec = AssembleDeferredIndexData(VALID_DATA_COUNT_KEY);
     valid_data_codec = AssembleDeferredIndexData(VALID_DATA_KEY);
+    empty_emb_list_offsets_codec =
+        AssembleDeferredIndexData(EMPTY_EMB_LIST_OFFSET_KEY);
     milvus::monitor::internal_storage_download_duration.Observe(
         std::chrono::duration_cast<std::chrono::milliseconds>(load_duration_sum)
             .count());
@@ -856,6 +1051,13 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
                       KnowhereStatusString(stat));
         }
         this->SetDim(index_.Dim());
+    } else if (empty_emb_list_offsets_codec) {
+        LOG_INFO("load empty emb_list vector index metadata only...");
+        auto empty_emb_list_state = LoadEmptyEmbListOffsetsFromPayload(
+            empty_emb_list_offsets_codec->PayloadData(),
+            static_cast<size_t>(empty_emb_list_offsets_codec->PayloadSize()));
+        this->SetDim(empty_emb_list_state.dim);
+        empty_emb_list_offsets_ = std::move(empty_emb_list_state.offsets);
     } else {
         LOG_INFO("load all-null nullable vector index valid data only...");
         AssertInfo(valid_data_count_codec && valid_data_codec,

--- a/internal/core/src/index/VectorMemIndex.h
+++ b/internal/core/src/index/VectorMemIndex.h
@@ -72,6 +72,12 @@ class VectorMemIndex : public VectorIndex {
 
     int64_t
     Count() override {
+        if (HasValidData() && GetValidCount() == 0) {
+            return 0;
+        }
+        if (IsEmptyEmbListIndex()) {
+            return 0;
+        }
         return index_.Count();
     }
 
@@ -107,6 +113,11 @@ class VectorMemIndex : public VectorIndex {
     void
     LoadFromFile(const Config& config);
 
+    bool
+    IsEmptyEmbListIndex() const {
+        return elem_type_ != DataType::NONE && !empty_emb_list_offsets_.empty();
+    }
+
  protected:
     Config config_;
     knowhere::Index<knowhere::IndexNode> index_;
@@ -116,6 +127,7 @@ class VectorMemIndex : public VectorIndex {
 
     CreateIndexInfo create_index_info_;
     bool use_knowhere_build_pool_;
+    std::vector<size_t> empty_emb_list_offsets_;
 };
 
 template <typename T>

--- a/internal/core/src/query/CachedSearchIterator.cpp
+++ b/internal/core/src/query/CachedSearchIterator.cpp
@@ -26,7 +26,21 @@ CachedSearchIterator::CachedSearchIterator(
         ThrowInfo(ErrorCode::UnexpectedError,
                   "Query dataset is nullptr, cannot initialize iterator");
     }
-    nq_ = query_ds->GetRows();
+    auto offsets =
+        query_ds->Get<const size_t*>(knowhere::meta::EMB_LIST_OFFSET);
+    if (offsets != nullptr) {
+        nq_ = query_ds->Get<int64_t>(knowhere::meta::NQ);
+        AssertInfo(nq_ > 0, "embedding list query count is missing");
+        auto total_vectors = static_cast<size_t>(query_ds->GetRows());
+        AssertInfo(offsets[nq_] == total_vectors,
+                   "embedding list query offsets are inconsistent with "
+                   "flattened rows: nq={}, terminal_offset={}, rows={}",
+                   nq_,
+                   offsets[nq_],
+                   total_vectors);
+    } else {
+        nq_ = query_ds->GetRows();
+    }
     Init(search_info);
 
     auto search_json = index.PrepareSearchParams(search_info);

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -106,6 +106,7 @@ PrepareBFDataSet(const dataset::SearchDataset& query_ds,
         // ditto
         query_dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                            query_ds.query_offsets);
+        query_dataset->Set(knowhere::meta::NQ, query_ds.num_queries);
 
         query_dataset->SetRows(query_ds.query_offsets[query_ds.num_queries]);
     }

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -155,11 +155,14 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         // step 3: brute force search where small indexing is unavailable
         auto vec_ptr = record.get_data_base(vecfield_id);
         const auto& offset_mapping = vec_ptr->get_offset_mapping();
+        const bool is_element_level_search =
+            data_type == DataType::VECTOR_ARRAY &&
+            info.array_offsets_ != nullptr;
         const auto has_offset_mapping = offset_mapping.IsEnabled();
 
         TargetBitmap transformed_bitset;
         BitsetView search_bitset = bitset;
-        if (has_offset_mapping && !bitset.empty()) {
+        if (has_offset_mapping && !is_element_level_search && !bitset.empty()) {
             auto status =
                 offset_mapping.TransformBitset(bitset, transformed_bitset);
             if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
@@ -188,8 +191,18 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 search_result.PinBitset(std::move(transformed_bitset));
         }
 
+        // Element-level search (embedding-search-embedding): knowhere sees
+        // a scalar vector type and the per-chunk size must be measured in
+        // elements. Compute this before the iterator_v2 branch so both
+        // paths share the substitution. Emb-list (multi-search-multi)
+        // iterator is rejected by the proxy; the assert below is
+        // defense-in-depth.
+        const auto iter_data_type =
+            is_element_level_search ? element_type : data_type;
+        const bool use_vector_iterator = milvus::exec::UseVectorIterator(info);
+
         if (info.iterator_v2_info_.has_value()) {
-            AssertInfo(data_type != DataType::VECTOR_ARRAY,
+            AssertInfo(iter_data_type != DataType::VECTOR_ARRAY,
                        "vector array(embedding list) is not supported for "
                        "vector iterator");
 
@@ -199,7 +212,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                                              info,
                                              index_info,
                                              search_bitset,
-                                             data_type);
+                                             iter_data_type);
             cached_iter.NextBatch(info, search_result);
             FinalizeVectorSearchOffsets(
                 search_result, offset_mapping, info.array_offsets_.get());
@@ -210,9 +223,8 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         auto max_chunk = upper_div(active_count, vec_size_per_chunk);
         bool element_level_search = data_type == DataType::VECTOR_ARRAY &&
                                     info.array_offsets_ != nullptr;
-        AssertInfo(
-            !element_level_search || !milvus::exec::UseVectorIterator(info),
-            "element-level search is not supported for vector iterator");
+        AssertInfo(!element_level_search || !use_vector_iterator,
+                   "element-level search is not supported for vector iterator");
 
         int64_t cumulative_element_offset = 0;
 
@@ -285,7 +297,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
 
             auto search_data_type =
                 element_level_search ? element_type : data_type;
-            if (milvus::exec::UseVectorIterator(info)) {
+            if (use_vector_iterator) {
                 AssertInfo(search_data_type != DataType::VECTOR_ARRAY,
                            "vector array(embedding list) is not supported for "
                            "vector iterator");
@@ -314,7 +326,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 final_qr.merge(sub_qr);
             }
         }
-        if (milvus::exec::UseVectorIterator(info)) {
+        if (use_vector_iterator) {
             std::vector<int64_t> chunk_rows(max_chunk, 0);
             for (int i = 1; i < max_chunk; ++i) {
                 chunk_rows[i] = i * vec_size_per_chunk;

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -67,6 +67,7 @@ SearchOnSealedIndex(const Schema& schema,
         auto num_vectors = query_offsets[num_queries];
         dataset = knowhere::GenDataSet(num_vectors, dim, query_data);
         dataset->Set(knowhere::meta::EMB_LIST_OFFSET, query_offsets);
+        dataset->Set(knowhere::meta::NQ, num_queries);
     }
 
     dataset->SetIsSparse(is_sparse);
@@ -76,10 +77,11 @@ SearchOnSealedIndex(const Schema& schema,
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
 
     const auto& offset_mapping = vec_index->GetOffsetMapping();
+    const bool is_element_level_search = search_info.array_offsets_ != nullptr;
     TargetBitmap transformed_bitset;
     BitsetView search_bitset = bitset;
     const auto has_offset_mapping = offset_mapping.IsEnabled();
-    if (has_offset_mapping) {
+    if (has_offset_mapping && !is_element_level_search) {
         if (offset_mapping.GetValidCount() == 0) {
             FillEmptySearchResult(search_result, num_queries, topK);
             return;
@@ -176,27 +178,44 @@ SearchOnSealedColumn(const Schema& schema,
 
     // Check for nullable vector field with all null values - must be done before creating iterators
     const auto& offset_mapping = column->GetOffsetMapping();
+    // Element-level VECTOR_ARRAY search has already expanded the row bitset
+    // to element IDs. OffsetMapping is row-level, so only use it for row-level
+    // vector searches.
+    bool is_element_level_search =
+        field.get_data_type() == DataType::VECTOR_ARRAY &&
+        search_info.array_offsets_ != nullptr;
     TargetBitmap transformed_bitset;
     BitsetView search_bitview = bitview;
     const auto has_offset_mapping = offset_mapping.IsEnabled();
     if (has_offset_mapping) {
-        if (offset_mapping.GetValidCount() == 0) {
-            // All vectors are null, return empty result
-            FillEmptySearchResult(result, num_queries, search_info.topk_);
-            return;
-        }
-        if (!bitview.empty()) {
-            auto status =
-                offset_mapping.TransformBitset(bitview, transformed_bitset);
-            if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
+        if (!is_element_level_search) {
+            if (offset_mapping.GetValidCount() == 0) {
+                // All vectors are null, return empty result
                 FillEmptySearchResult(result, num_queries, search_info.topk_);
                 return;
             }
-            search_bitview =
-                status == OffsetMapping::BitsetTransformStatus::NoFilter
-                    ? BitsetView{}
-                    : result.PinBitset(std::move(transformed_bitset));
+            if (!bitview.empty()) {
+                auto status =
+                    offset_mapping.TransformBitset(bitview, transformed_bitset);
+                if (status ==
+                    OffsetMapping::BitsetTransformStatus::AllFiltered) {
+                    FillEmptySearchResult(
+                        result, num_queries, search_info.topk_);
+                    return;
+                }
+                search_bitview =
+                    status == OffsetMapping::BitsetTransformStatus::NoFilter
+                        ? BitsetView{}
+                        : result.PinBitset(std::move(transformed_bitset));
+            }
         }
+    }
+
+    // For element-level search (embedding-search-embedding), the underlying
+    // knowhere search is keyed by the scalar element type rather than
+    // VECTOR_ARRAY, and per-chunk sizes must be counted in elements.
+    if (is_element_level_search) {
+        data_type = element_type;
     }
 
     if (search_info.iterator_v2_info_.has_value()) {
@@ -225,11 +244,6 @@ SearchOnSealedColumn(const Schema& schema,
                              search_info.metric_type_,
                              search_info.round_decimal_);
 
-    bool is_element_level_search = data_type == DataType::VECTOR_ARRAY &&
-                                   search_info.array_offsets_ != nullptr;
-    if (is_element_level_search) {
-        data_type = element_type;
-    }
     AssertInfo(!is_element_level_search ||
                    !milvus::exec::UseVectorIterator(search_info),
                "element-level search is not supported for vector iterator");

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -171,10 +171,10 @@ ChunkedSegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
         info.field_id,
         id_);
 
-    const bool keep_nullable_vector_field_data =
-        field_meta.is_nullable() &&
-        IsVectorDataType(field_meta.get_data_type());
-    if (request.has_raw_data && !keep_nullable_vector_field_data &&
+    const bool keep_vector_field_data =
+        field_meta.is_nullable() ||
+        field_meta.get_data_type() == DataType::VECTOR_ARRAY;
+    if (request.has_raw_data && !keep_vector_field_data &&
         get_bit(field_data_ready_bitset_, field_id)) {
         drop_field_data_locked(field_id);
     }
@@ -1017,6 +1017,8 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
                                      int64_t count) const {
     auto& field_meta = schema_->operator[](field_id);
     AssertInfo(field_meta.is_vector(), "vector field is not vector type");
+    AssertInfo(field_meta.get_data_type() != DataType::VECTOR_ARRAY,
+               "VECTOR_ARRAY raw data must be read from field data");
 
     if (!get_bit(index_ready_bitset_, field_id) &&
         !get_bit(binlog_index_bitset_, field_id)) {
@@ -1085,6 +1087,16 @@ void
 ChunkedSegmentSealedImpl::drop_field_data_locked(const FieldId field_id) {
     // NOTE: mutex_ must be already held by caller
     if (get_bit(field_data_ready_bitset_, field_id)) {
+        if (schema_->operator[](field_id).get_data_type() ==
+            DataType::VECTOR_ARRAY) {
+            LOG_INFO(
+                "Skip dropping VECTOR_ARRAY field data for field {} in "
+                "segment {} because 2.6 indexes cannot reconstruct embedding "
+                "list rows",
+                field_id.get(),
+                id_);
+            return;
+        }
         // Check if the field is in a multi-field column group.
         // If so, skip dropping because it shares storage with other fields.
         auto column = get_column(field_id);
@@ -2433,6 +2445,9 @@ ChunkedSegmentSealedImpl::HasRawData(int64_t field_id) const {
     std::shared_lock lck(mutex_);
     auto fieldID = FieldId(field_id);
     const auto& field_meta = schema_->operator[](fieldID);
+    if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
+        return get_bit(field_data_ready_bitset_, fieldID);
+    }
     if (IsVectorDataType(field_meta.get_data_type())) {
         if (get_bit(index_ready_bitset_, fieldID)) {
             AssertInfo(vector_indexings_.is_ready(fieldID),

--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -50,9 +50,42 @@ VectorBase::set_data_raw(ssize_t element_offset,
         } else if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
             auto& vector_array = data->vectors().vector_array().data();
             std::vector<VectorArray> data_raw{};
-            data_raw.reserve(vector_array.size());
-            for (auto& e : vector_array) {
-                data_raw.emplace_back(VectorArray(e));
+            if (field_meta.is_nullable() &&
+                data->valid_data_size() == element_count) {
+                ssize_t valid_count = 0;
+                for (ssize_t i = 0; i < element_count; ++i) {
+                    if (data->valid_data(i)) {
+                        ++valid_count;
+                    }
+                }
+                data_raw.reserve(valid_count);
+                if (vector_array.size() == element_count) {
+                    for (ssize_t i = 0; i < element_count; ++i) {
+                        if (data->valid_data(i)) {
+                            data_raw.emplace_back(VectorArray(vector_array[i]));
+                        }
+                    }
+                } else {
+                    AssertInfo(
+                        vector_array.size() == valid_count,
+                        "compact nullable VECTOR_ARRAY data size {} must "
+                        "match valid count {}",
+                        vector_array.size(),
+                        valid_count);
+                    for (auto& e : vector_array) {
+                        data_raw.emplace_back(VectorArray(e));
+                    }
+                }
+            } else {
+                AssertInfo(vector_array.size() == element_count,
+                           "VECTOR_ARRAY data size {} must match element "
+                           "count {} when not using compact nullable format",
+                           vector_array.size(),
+                           element_count);
+                data_raw.reserve(vector_array.size());
+                for (auto& e : vector_array) {
+                    data_raw.emplace_back(VectorArray(e));
+                }
             }
             return set_data_raw(element_offset, data_raw.data(), element_count);
         } else {

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -59,6 +59,29 @@ using namespace milvus::cachinglayer;
 
 namespace {
 
+int32_t
+GetVectorArrayLength(const proto::schema::VectorField& vec_field,
+                     DataType element_type,
+                     int64_t dim) {
+    switch (element_type) {
+        case DataType::VECTOR_FLOAT:
+            return vec_field.float_vector().data_size() / dim;
+        case DataType::VECTOR_FLOAT16:
+            return vec_field.float16_vector().size() / (dim * 2);
+        case DataType::VECTOR_BFLOAT16:
+            return vec_field.bfloat16_vector().size() / (dim * 2);
+        case DataType::VECTOR_BINARY:
+            return vec_field.binary_vector().size() / (dim / 8);
+        case DataType::VECTOR_INT8:
+            return vec_field.int8_vector().size() / dim;
+        default:
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "Unexpected VECTOR_ARRAY element type: {}",
+                      element_type);
+    }
+    return 0;
+}
+
 void
 ExtractArrayLengthsFromFieldData(const std::vector<FieldDataPtr>& field_data,
                                  const FieldMeta& field_meta,
@@ -69,9 +92,14 @@ ExtractArrayLengthsFromFieldData(const std::vector<FieldDataPtr>& field_data,
         auto num_rows = data->get_num_rows();
         if (data_type == DataType::VECTOR_ARRAY) {
             auto* raw_data = static_cast<const VectorArray*>(data->Data());
+            int64_t physical_row = 0;
             for (int64_t i = 0; i < num_rows; ++i) {
-                array_lengths[offset + i] =
-                    data->is_valid(i) ? raw_data[i].length() : 0;
+                if (data->IsNullable() && !data->is_valid(i)) {
+                    array_lengths[offset + i] = 0;
+                    continue;
+                }
+                auto source_index = data->IsNullable() ? physical_row++ : i;
+                array_lengths[offset + i] = raw_data[source_index].length();
             }
         } else {
             auto* raw_data = static_cast<const ArrayView*>(data->Data());
@@ -94,34 +122,54 @@ ExtractArrayLengths(const proto::schema::FieldData& field_data,
         const auto& vector_array = field_data.vectors().vector_array();
         int64_t dim = field_meta.get_dim();
         auto element_type = field_meta.get_element_type();
+        bool compact_nullable = false;
+        if (field_meta.is_nullable()) {
+            int64_t valid_count = 0;
+            if (field_data.valid_data_size() == num_rows) {
+                for (int64_t i = 0; i < num_rows; ++i) {
+                    if (field_data.valid_data(i)) {
+                        ++valid_count;
+                    }
+                }
+            }
+            auto dense_aligned = vector_array.data_size() == num_rows;
+            compact_nullable = field_data.valid_data_size() == num_rows &&
+                               vector_array.data_size() == valid_count;
+            AssertInfo(
+                dense_aligned || compact_nullable,
+                "nullable VECTOR_ARRAY supports only dense-aligned data "
+                "(data_size == num_rows) or compact data "
+                "(valid_data_size == num_rows and data_size == valid_count), "
+                "got data_size {}, valid_data_size {}, num_rows {}, "
+                "valid_count {}",
+                vector_array.data_size(),
+                field_data.valid_data_size(),
+                num_rows,
+                valid_count);
+            compact_nullable = compact_nullable && !dense_aligned;
+        } else {
+            AssertInfo(vector_array.data_size() == num_rows,
+                       "non-nullable VECTOR_ARRAY data_size {} must match "
+                       "num_rows {}",
+                       vector_array.data_size(),
+                       num_rows);
+        }
+        int64_t physical_row = 0;
+        auto has_valid_data = field_data.valid_data_size() == num_rows;
 
         for (int i = 0; i < num_rows; ++i) {
-            const auto& vec_field = vector_array.data(i);
-            int32_t array_len = 0;
-
-            switch (element_type) {
-                case DataType::VECTOR_FLOAT:
-                    array_len = vec_field.float_vector().data_size() / dim;
-                    break;
-                case DataType::VECTOR_FLOAT16:
-                    array_len = vec_field.float16_vector().size() / (dim * 2);
-                    break;
-                case DataType::VECTOR_BFLOAT16:
-                    array_len = vec_field.bfloat16_vector().size() / (dim * 2);
-                    break;
-                case DataType::VECTOR_BINARY:
-                    array_len = vec_field.binary_vector().size() / (dim / 8);
-                    break;
-                case DataType::VECTOR_INT8:
-                    array_len = vec_field.int8_vector().size() / dim;
-                    break;
-                default:
-                    ThrowInfo(ErrorCode::UnexpectedError,
-                              "Unexpected VECTOR_ARRAY element type: {}",
-                              element_type);
+            if (field_meta.is_nullable() && has_valid_data &&
+                !field_data.valid_data(i)) {
+                array_lengths[i] = 0;
+                continue;
             }
 
-            array_lengths[i] = array_len;
+            auto source_index = compact_nullable ? physical_row++ : i;
+            AssertInfo(source_index < vector_array.data_size(),
+                       "VECTOR_ARRAY row {} is missing from field data",
+                       source_index);
+            array_lengths[i] = GetVectorArrayLength(
+                vector_array.data(source_index), element_type, dim);
         }
     } else {
         const auto& array_data = field_data.scalars().array_data();

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -36,6 +36,36 @@
 
 namespace milvus::segcore {
 
+namespace {
+
+void
+InitEmptyVectorArrayRow(proto::schema::VectorField* row,
+                        DataType element_type) {
+    switch (element_type) {
+        case DataType::VECTOR_FLOAT:
+            row->mutable_float_vector();
+            break;
+        case DataType::VECTOR_BINARY:
+            row->mutable_binary_vector();
+            break;
+        case DataType::VECTOR_FLOAT16:
+            row->mutable_float16_vector();
+            break;
+        case DataType::VECTOR_BFLOAT16:
+            row->mutable_bfloat16_vector();
+            break;
+        case DataType::VECTOR_INT8:
+            row->mutable_int8_vector();
+            break;
+        default:
+            ThrowInfo(DataTypeInvalid,
+                      "unsupported ArrayOfVector element type {}",
+                      element_type);
+    }
+}
+
+}  // namespace
+
 void
 // Takes a non-const DataArray& because VARCHAR strings are moved (not copied)
 // into the PkType variant vector. Callers must ensure the DataArray is
@@ -470,7 +500,8 @@ CreateEmptyVectorDataArray(int64_t count,
                            const void* valid_data,
                            const FieldMeta& field_meta) {
     int64_t data_count = count;
-    if (field_meta.is_nullable()) {
+    if (field_meta.is_nullable() &&
+        field_meta.get_data_type() != DataType::VECTOR_ARRAY) {
         data_count = valid_data != nullptr ? valid_count : 0;
     }
     auto data_array = CreateEmptyVectorDataArray(data_count, field_meta);
@@ -717,6 +748,24 @@ CreateVectorDataArrayFrom(const void* data_raw,
                           int64_t count,
                           int64_t valid_count,
                           const FieldMeta& field_meta) {
+    if (field_meta.get_data_type() == DataType::VECTOR_ARRAY &&
+        field_meta.is_nullable() && valid_data != nullptr) {
+        auto data_array = CreateEmptyVectorDataArray(
+            count, valid_count, valid_data, field_meta);
+        auto dst = data_array->mutable_vectors()
+                       ->mutable_vector_array()
+                       ->mutable_data();
+        auto src = reinterpret_cast<const VectorFieldProto*>(data_raw);
+        auto valid_data_bool = reinterpret_cast<const bool*>(valid_data);
+        int64_t src_offset = 0;
+        for (int64_t i = 0; i < count; ++i) {
+            if (valid_data_bool[i]) {
+                dst->at(i) = src[src_offset++];
+            }
+        }
+        return data_array;
+    }
+
     auto data_array =
         CreateVectorDataArrayFrom(data_raw, valid_count, field_meta);
     if (field_meta.is_nullable() && valid_data != nullptr) {
@@ -739,7 +788,14 @@ CreateDataArrayFrom(const void* data_raw,
             data_raw, valid_data, count, field_meta);
     }
 
-    return CreateVectorDataArrayFrom(data_raw, count, field_meta);
+    auto data_array = CreateVectorDataArrayFrom(data_raw, count, field_meta);
+    if (field_meta.get_data_type() == DataType::VECTOR_ARRAY &&
+        field_meta.is_nullable() && valid_data != nullptr) {
+        auto obj = data_array->mutable_valid_data();
+        auto valid_data_bool = reinterpret_cast<const bool*>(valid_data);
+        obj->Add(valid_data_bool, valid_data_bool + count);
+    }
+    return data_array;
 }
 
 // TODO remove merge dataArray, instead fill target entity when get data slice
@@ -777,11 +833,25 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             }
 
             if (!is_valid) {
+                if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
+                    auto vector_array = data_array->mutable_vectors();
+                    auto dim = field_meta.get_dim();
+                    vector_array->set_dim(dim);
+                    auto obj = vector_array->mutable_vector_array();
+                    obj->set_dim(dim);
+                    obj->set_element_type(
+                        proto::schema::DataType(field_meta.get_element_type()));
+                    auto* row = obj->mutable_data()->Add();
+                    row->set_dim(dim);
+                    InitEmptyVectorArrayRow(row, field_meta.get_element_type());
+                }
                 continue;
             }
 
             int64_t physical_offset =
-                merge_base.getValidDataOffset(field_meta.get_id());
+                field_meta.get_data_type() == DataType::VECTOR_ARRAY
+                    ? src_offset
+                    : merge_base.getValidDataOffset(field_meta.get_id());
 
             auto vector_array = data_array->mutable_vectors();
             auto dim = 0;
@@ -831,6 +901,7 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             } else if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
                 auto& data = src_field_data->vectors().vector_array();
                 auto obj = vector_array->mutable_vector_array();
+                obj->set_dim(dim);
                 obj->set_element_type(
                     proto::schema::DataType(field_meta.get_element_type()));
                 *(obj->mutable_data()->Add()) = data.data(physical_offset);

--- a/internal/core/src/segcore/UtilsTest.cpp
+++ b/internal/core/src/segcore/UtilsTest.cpp
@@ -232,6 +232,70 @@ TEST(Util_Segcore, TransformBitsetKeepsEmptyViewAsNoFilter) {
     EXPECT_TRUE(physical_bitset.empty());
 }
 
+TEST(Util_Segcore, MergeDataArrayWithNullableVectorArrayUsesLogicalOffsets) {
+    using namespace milvus;
+    using namespace milvus::segcore;
+
+    auto schema = std::make_shared<Schema>();
+    constexpr int64_t dim = 4;
+    auto vec = schema->AddDebugVectorArrayField("embeddings",
+                                                DataType::VECTOR_FLOAT,
+                                                dim,
+                                                knowhere::metric::MAX_SIM,
+                                                true);
+    auto& field_meta = (*schema)[vec];
+
+    bool valid_flags[] = {false, true, true};
+    auto data_array = CreateEmptyVectorDataArray(3, 2, valid_flags, field_meta);
+    auto* rows =
+        data_array->mutable_vectors()->mutable_vector_array()->mutable_data();
+
+    auto make_row = [dim](std::initializer_list<float> values) {
+        VectorFieldProto row;
+        row.set_dim(dim);
+        row.mutable_float_vector()->mutable_data()->Add(values.begin(),
+                                                        values.end());
+        return row;
+    };
+    rows->Mutable(1)->CopyFrom(make_row({1.0F, 2.0F, 3.0F, 4.0F}));
+    rows->Mutable(2)->CopyFrom(
+        make_row({5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F}));
+
+    std::map<FieldId, std::unique_ptr<milvus::DataArray>> output_fields_data;
+    output_fields_data[vec] = std::move(data_array);
+
+    std::vector<MergeBase> merge_bases;
+    merge_bases.emplace_back(&output_fields_data, 0);
+    merge_bases.emplace_back(&output_fields_data, 1);
+    merge_bases.back().setValidDataOffset(vec, 0);
+    merge_bases.emplace_back(&output_fields_data, 2);
+    merge_bases.back().setValidDataOffset(vec, 1);
+
+    auto merged_result = MergeDataArray(merge_bases, field_meta);
+
+    ASSERT_EQ(merged_result->valid_data_size(), 3);
+    EXPECT_FALSE(merged_result->valid_data(0));
+    EXPECT_TRUE(merged_result->valid_data(1));
+    EXPECT_TRUE(merged_result->valid_data(2));
+
+    const auto& result_rows = merged_result->vectors().vector_array().data();
+    ASSERT_EQ(result_rows.size(), 3);
+    EXPECT_TRUE(result_rows.Get(0).has_float_vector());
+    EXPECT_EQ(result_rows.Get(0).float_vector().data_size(), 0);
+
+    ASSERT_EQ(result_rows.Get(1).float_vector().data_size(), dim);
+    for (int64_t i = 0; i < dim; ++i) {
+        EXPECT_FLOAT_EQ(result_rows.Get(1).float_vector().data(i),
+                        static_cast<float>(i + 1));
+    }
+
+    ASSERT_EQ(result_rows.Get(2).float_vector().data_size(), dim * 2);
+    for (int64_t i = 0; i < dim * 2; ++i) {
+        EXPECT_FLOAT_EQ(result_rows.Get(2).float_vector().data(i),
+                        static_cast<float>(i + 5));
+    }
+}
+
 // Tests for CheckCancellation utility function
 TEST(UtilSegcore, CheckCancellationNullContext) {
     using namespace milvus::segcore;

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -616,7 +616,8 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
 
                 for (auto field_id : plan_->target_entries_) {
                     auto& field_meta = plan_->schema_->operator[](field_id);
-                    if (field_meta.is_vector() && field_meta.is_nullable()) {
+                    if (field_meta.is_vector() && field_meta.is_nullable() &&
+                        field_meta.get_data_type() != DataType::VECTOR_ARRAY) {
                         auto it =
                             search_result->output_fields_data_.find(field_id);
                         if (it != search_result->output_fields_data_.end()) {

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -565,27 +565,34 @@ DiskFileManagerImpl::cache_raw_data_to_disk_internal(const Config& config) {
     // Write offsets file for VECTOR_ARRAY
     if (is_vector_array) {
         AssertInfo(
-            offsets.size() >= 2 && offsets.front() == 0,
+            !offsets.empty() && offsets.front() == 0,
             "invalid emb_list offsets: size {}, front {}",
             offsets.size(),
             offsets.empty() ? -1 : static_cast<int64_t>(offsets.front()));
-        // Get offsets path from config if provided, otherwise use default
-        auto offsets_path = index::GetValueFromConfig<std::string>(
-                                config, index::EMB_LIST_OFFSETS_PATH)
-                                .value();
-        local_chunk_manager->CreateFile(offsets_path);
+        if (offsets.size() == 1) {
+            AssertInfo(nullable || total_num_rows == 0,
+                       "non-nullable emb_list offsets must include rows");
+            AssertInfo(num_rows == 0,
+                       "empty emb_list offsets cannot reference raw vectors");
+        } else {
+            // Get offsets path from config if provided, otherwise use default
+            auto offsets_path = index::GetValueFromConfig<std::string>(
+                                    config, index::EMB_LIST_OFFSETS_PATH)
+                                    .value();
+            local_chunk_manager->CreateFile(offsets_path);
 
-        size_t num_offsets = offsets.size();
-        int64_t offsets_write_pos = 0;
+            size_t num_offsets = offsets.size();
+            int64_t offsets_write_pos = 0;
 
-        local_chunk_manager->Write(
-            offsets_path, offsets_write_pos, &num_offsets, sizeof(size_t));
-        offsets_write_pos += sizeof(size_t);
+            local_chunk_manager->Write(
+                offsets_path, offsets_write_pos, &num_offsets, sizeof(size_t));
+            offsets_write_pos += sizeof(size_t);
 
-        local_chunk_manager->Write(offsets_path,
-                                   offsets_write_pos,
-                                   offsets.data(),
-                                   offsets.size() * sizeof(size_t));
+            local_chunk_manager->Write(offsets_path,
+                                       offsets_write_pos,
+                                       offsets.data(),
+                                       offsets.size() * sizeof(size_t));
+        }
     }
 
     if (nullable && valid_data_path.has_value() && total_num_rows > 0) {
@@ -657,7 +664,7 @@ DiskFileManagerImpl::cache_raw_data_to_disk_common(
 
         // Calculate total data size needed
         int64_t total_size = 0;
-        for (auto i = 0; i < rows; ++i) {
+        for (auto i = 0; i < vec_array_data->get_valid_rows(); ++i) {
             total_size += vec_array_data->DataSize(i);
         }
 
@@ -665,9 +672,14 @@ DiskFileManagerImpl::cache_raw_data_to_disk_common(
         auto buf = std::unique_ptr<uint8_t[]>(new uint8_t[total_size]);
         int64_t buf_offset = 0;
 
+        int64_t physical_row = 0;
         for (auto i = 0; i < rows; ++i) {
-            auto vec_array = vec_array_data->value_at(i);
-            auto size = vec_array_data->DataSize(i);
+            if (vec_array_data->IsNullable() && !vec_array_data->is_valid(i)) {
+                continue;
+            }
+
+            auto vec_array = vec_array_data->value_at(physical_row);
+            auto size = vec_array_data->DataSize(physical_row);
 
             // Collect offsets information if needed (cumulative offsets)
             if (offsets != nullptr) {
@@ -676,8 +688,11 @@ DiskFileManagerImpl::cache_raw_data_to_disk_common(
                 offsets->push_back(last_offset + vec_array->length());
             }
 
-            std::memcpy(buf.get() + buf_offset, vec_array->data(), size);
+            if (size > 0) {
+                std::memcpy(buf.get() + buf_offset, vec_array->data(), size);
+            }
             buf_offset += size;
+            physical_row++;
         }
 
         // Write flattened data to disk
@@ -837,28 +852,35 @@ DiskFileManagerImpl::cache_raw_data_to_disk_storage_v2(const Config& config) {
     // Write offsets file for VECTOR_ARRAY
     if (is_vector_array) {
         AssertInfo(
-            offsets.size() >= 2 && offsets.front() == 0,
+            !offsets.empty() && offsets.front() == 0,
             "invalid emb_list offsets: size {}, front {}",
             offsets.size(),
             offsets.empty() ? -1 : static_cast<int64_t>(offsets.front()));
-        // Get offsets path from config if provided, otherwise use default
-        auto offsets_path = index::GetValueFromConfig<std::string>(
-                                config, index::EMB_LIST_OFFSETS_PATH)
-                                .value();
+        if (offsets.size() == 1) {
+            AssertInfo(nullable || total_num_rows == 0,
+                       "non-nullable emb_list offsets must include rows");
+            AssertInfo(num_rows == 0,
+                       "empty emb_list offsets cannot reference raw vectors");
+        } else {
+            // Get offsets path from config if provided, otherwise use default
+            auto offsets_path = index::GetValueFromConfig<std::string>(
+                                    config, index::EMB_LIST_OFFSETS_PATH)
+                                    .value();
 
-        local_chunk_manager->CreateFile(offsets_path);
+            local_chunk_manager->CreateFile(offsets_path);
 
-        size_t num_offsets = offsets.size();
-        int64_t offsets_write_pos = 0;
+            size_t num_offsets = offsets.size();
+            int64_t offsets_write_pos = 0;
 
-        local_chunk_manager->Write(
-            offsets_path, offsets_write_pos, &num_offsets, sizeof(size_t));
-        offsets_write_pos += sizeof(size_t);
+            local_chunk_manager->Write(
+                offsets_path, offsets_write_pos, &num_offsets, sizeof(size_t));
+            offsets_write_pos += sizeof(size_t);
 
-        local_chunk_manager->Write(offsets_path,
-                                   offsets_write_pos,
-                                   offsets.data(),
-                                   offsets.size() * sizeof(size_t));
+            local_chunk_manager->Write(offsets_path,
+                                       offsets_write_pos,
+                                       offsets.data(),
+                                       offsets.size() * sizeof(size_t));
+        }
     }
 
     if (nullable && valid_data_path.has_value() && total_num_rows > 0) {

--- a/internal/core/src/storage/Event.cpp
+++ b/internal/core/src/storage/Event.cpp
@@ -265,8 +265,11 @@ BaseEventData::Serialize() {
             AssertInfo(vector_array_field != nullptr,
                        "Failed to cast to FieldData<VectorArray>");
             auto element_type = vector_array_field->get_element_type();
-            payload_writer = std::make_unique<PayloadWriter>(
-                data_type, field_data->get_dim(), element_type);
+            payload_writer =
+                std::make_unique<PayloadWriter>(data_type,
+                                                field_data->get_dim(),
+                                                element_type,
+                                                field_data->IsNullable());
         } else if (IsVectorDataType(data_type) &&
                    !IsSparseFloatVectorDataType(data_type)) {
             payload_writer = std::make_unique<PayloadWriter>(

--- a/internal/core/src/storage/PayloadWriter.cpp
+++ b/internal/core/src/storage/PayloadWriter.cpp
@@ -41,16 +41,18 @@ PayloadWriter::PayloadWriter(const DataType column_type, int dim, bool nullable)
 // create payload writer for VectorArray with element_type
 PayloadWriter::PayloadWriter(const DataType column_type,
                              int dim,
-                             DataType element_type)
-    // VECTOR_ARRAY is not nullable
-    : column_type_(column_type), nullable_(false), element_type_(element_type) {
+                             DataType element_type,
+                             bool nullable)
+    : column_type_(column_type),
+      nullable_(nullable),
+      element_type_(element_type) {
     AssertInfo(column_type == DataType::VECTOR_ARRAY,
                "This constructor is only for VECTOR_ARRAY");
     AssertInfo(element_type != DataType::NONE,
                "element_type must be specified for VECTOR_ARRAY");
     dimension_ = dim;
-    builder_ = CreateArrowBuilder(column_type, element_type, dim);
-    schema_ = CreateArrowSchema(column_type, dim, element_type);
+    builder_ = CreateArrowBuilder(column_type, element_type, dim, nullable_);
+    schema_ = CreateArrowSchema(column_type, dim, element_type, nullable_);
 }
 
 void

--- a/internal/core/src/storage/PayloadWriter.h
+++ b/internal/core/src/storage/PayloadWriter.h
@@ -30,7 +30,8 @@ class PayloadWriter {
     // Constructor for VectorArray with element_type
     explicit PayloadWriter(const DataType column_type,
                            int dim,
-                           DataType element_type);
+                           DataType element_type,
+                           bool nullable = false);
     ~PayloadWriter() = default;
 
     void

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -323,25 +323,11 @@ AddPayloadToArrowBuilder(std::shared_ptr<arrow::ArrayBuilder> builder,
                        "builder must be ListBuilder for VECTOR_ARRAY");
 
             auto vector_arrays = reinterpret_cast<VectorArray*>(raw_data);
+            auto valid_data = payload.valid_data;
+            AssertInfo((nullable && valid_data) || !nullable,
+                       "valid_data is required for nullable VectorArray");
 
             if (length > 0) {
-                auto element_type = vector_arrays[0].get_element_type();
-
-                // Validate element type
-                switch (element_type) {
-                    case DataType::VECTOR_FLOAT:
-                    case DataType::VECTOR_BINARY:
-                    case DataType::VECTOR_FLOAT16:
-                    case DataType::VECTOR_BFLOAT16:
-                    case DataType::VECTOR_INT8:
-                        break;
-                    default:
-                        ThrowInfo(DataTypeInvalid,
-                                  "Unsupported element type in VectorArray: {}",
-                                  element_type);
-                }
-
-                // All supported vector types use FixedSizeBinaryBuilder
                 auto value_builder =
                     static_cast<arrow::FixedSizeBinaryBuilder*>(
                         list_builder->value_builder());
@@ -349,23 +335,60 @@ AddPayloadToArrowBuilder(std::shared_ptr<arrow::ArrayBuilder> builder,
                            "value_builder must be FixedSizeBinaryBuilder for "
                            "VectorArray");
 
-                for (int i = 0; i < length; ++i) {
+                DataType element_type = DataType::NONE;
+                auto append_vector_array = [&](const VectorArray& array) {
+                    if (element_type == DataType::NONE) {
+                        element_type = array.get_element_type();
+                        switch (element_type) {
+                            case DataType::VECTOR_FLOAT:
+                            case DataType::VECTOR_BINARY:
+                            case DataType::VECTOR_FLOAT16:
+                            case DataType::VECTOR_BFLOAT16:
+                            case DataType::VECTOR_INT8:
+                                break;
+                            default:
+                                ThrowInfo(
+                                    DataTypeInvalid,
+                                    "Unsupported element type in VectorArray: "
+                                    "{}",
+                                    element_type);
+                        }
+                    } else {
+                        AssertInfo(array.get_element_type() == element_type,
+                                   "Inconsistent element types in "
+                                   "VectorArray");
+                    }
                     auto status = list_builder->Append();
                     AssertInfo(status.ok(),
                                "Failed to append list: {}",
                                status.ToString());
 
-                    const auto& array = vector_arrays[i];
-                    AssertInfo(array.get_element_type() == element_type,
-                               "Inconsistent element types in VectorArray");
-
                     int num_vectors = array.length();
-                    auto ast = value_builder->AppendValues(
-                        reinterpret_cast<const uint8_t*>(array.data()),
-                        num_vectors);
-                    AssertInfo(ast.ok(),
-                               "Failed to batch append vectors: {}",
-                               ast.ToString());
+                    if (num_vectors > 0) {
+                        auto ast = value_builder->AppendValues(
+                            reinterpret_cast<const uint8_t*>(array.data()),
+                            num_vectors);
+                        AssertInfo(ast.ok(),
+                                   "Failed to batch append vectors: {}",
+                                   ast.ToString());
+                    }
+                };
+
+                int valid_index = 0;
+                for (int i = 0; i < length; ++i) {
+                    if (nullable) {
+                        auto bit = (valid_data[i >> 3] >> (i & 0x07)) & 1;
+                        if (!bit) {
+                            auto status = list_builder->AppendNull();
+                            AssertInfo(status.ok(),
+                                       "Failed to append null list: {}",
+                                       status.ToString());
+                            continue;
+                        }
+                        append_vector_array(vector_arrays[valid_index++]);
+                    } else {
+                        append_vector_array(vector_arrays[i]);
+                    }
                 }
             }
             break;
@@ -758,7 +781,10 @@ CreateArrowSchema(DataType data_type, int dim, bool nullable) {
 }
 
 std::shared_ptr<arrow::Schema>
-CreateArrowSchema(DataType data_type, int dim, DataType element_type) {
+CreateArrowSchema(DataType data_type,
+                  int dim,
+                  DataType element_type,
+                  bool nullable) {
     AssertInfo(data_type == DataType::VECTOR_ARRAY,
                "This overload is only for VECTOR_ARRAY type");
     AssertInfo(dim > 0, "invalid dim value");
@@ -768,8 +794,8 @@ CreateArrowSchema(DataType data_type, int dim, DataType element_type) {
         {ELEMENT_TYPE_KEY_FOR_ARROW, DIM_KEY},
         {std::to_string(static_cast<int>(element_type)), std::to_string(dim)});
 
-    // VECTOR_ARRAY is not nullable
-    auto field = arrow::field("val", value_type, false)->WithMetadata(metadata);
+    auto field =
+        arrow::field("val", value_type, nullable)->WithMetadata(metadata);
     return arrow::schema({field});
 }
 
@@ -1245,7 +1271,7 @@ CreateFieldData(const DataType& type,
                 dim, type, nullable, total_num_rows);
         case DataType::VECTOR_ARRAY:
             return std::make_shared<FieldData<VectorArray>>(
-                dim, element_type, total_num_rows);
+                dim, element_type, nullable, total_num_rows);
         default:
             ThrowInfo(DataTypeInvalid,
                       "CreateFieldData not support data type " +

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -84,7 +84,10 @@ std::shared_ptr<arrow::Schema>
 CreateArrowSchema(DataType data_type, int dim, bool nullable);
 
 std::shared_ptr<arrow::Schema>
-CreateArrowSchema(DataType data_type, int dim, DataType element_type);
+CreateArrowSchema(DataType data_type,
+                  int dim,
+                  DataType element_type,
+                  bool nullable = false);
 
 int
 GetDimensionFromFileMetaData(const parquet::ColumnDescriptor* schema,

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -1046,11 +1046,11 @@ TEST(Indexing, DiskAnnEmbListBuildWithDataset) {
     IndexType index_type = knowhere::IndexEnum::INDEX_DISKANN;
     MetricType metric_type = knowhere::metric::MAX_SIM_L2;
 
-    // Variable-length emb_lists: lengths cycle through 1,2,3,4,5
+    // Variable-length emb_lists with trailing empty lists.
     std::vector<size_t> offsets;
     offsets.push_back(0);
     for (int64_t i = 0; i < num_emb_lists; ++i) {
-        size_t len = (i % 5) + 1;  // 1..5 vectors per emb_list
+        size_t len = i >= num_emb_lists - 2 ? 0 : (i % 5) + 1;
         offsets.push_back(offsets.back() + len);
     }
     int64_t total_vectors = static_cast<int64_t>(offsets.back());
@@ -1068,6 +1068,7 @@ TEST(Indexing, DiskAnnEmbListBuildWithDataset) {
         knowhere::GenDataSet(total_vectors, DIM, xb_data.data());
     xb_dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                     const_cast<const size_t*>(offsets.data()));
+    xb_dataset->Set(knowhere::meta::NQ, num_emb_lists);
 
     // Setup file manager context
     int64_t collection_id = 1;
@@ -1142,6 +1143,7 @@ TEST(Indexing, DiskAnnEmbListBuildWithDataset) {
     std::vector<size_t> query_offsets = {0, 3, 5};
     xq_dataset->Set(knowhere::meta::EMB_LIST_OFFSET,
                     const_cast<const size_t*>(query_offsets.data()));
+    xq_dataset->Set(knowhere::meta::NQ, int64_t{2});
 
     milvus::SearchInfo search_info;
     search_info.topk_ = K;

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -1035,6 +1035,22 @@ func TestAddFieldTask(t *testing.T) {
 		err = task.PreExecute(ctx)
 		assert.NoError(t, err)
 
+		fSchema = &schemapb.FieldSchema{
+			Name:        "array_struct",
+			DataType:    schemapb.DataType_Array,
+			ElementType: schemapb.DataType_Struct,
+			Nullable:    true,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxCapacityKey, Value: "4"},
+			},
+		}
+		bytes, err = proto.Marshal(fSchema)
+		assert.NoError(t, err)
+		task.Schema = bytes
+		err = task.PreExecute(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "element type Struct is not supported")
+
 		// not support system field
 		fSchema = &schemapb.FieldSchema{
 			Name: common.TimeStampFieldName,

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -636,6 +636,9 @@ func ValidateField(field *schemapb.FieldSchema, schema *schemapb.CollectionSchem
 	// valid max capacity for array per row parameters
 	// if max_capacity not specified, return error
 	if field.DataType == schemapb.DataType_Array {
+		if err := validateElementType(field.GetElementType()); err != nil {
+			return err
+		}
 		if err = validateMaxCapacityPerRow(schema.Name, field); err != nil {
 			return err
 		}


### PR DESCRIPTION
pr: #50035
issue: #50010
issue: #50009
issue: #50049
issue: #50063
issue: #50068
issue: #50071
issue: #50072

This is the 2.6 backport for PR #50035.

Summary:
- Backport empty element vector-search handling to 2.6.
- Preserve valid-data handling through vector field data, indexes, search, storage, and segment loading paths.
- Include the 2.6 regression coverage carried by the backport branch.

Verification from branch author:
- Clean worktree check.
- Conflict marker check.
- `diff/show --check` style checks.

Verification before PR creation:
- `git diff --check origin/2.6...buqian/slock-cindy-2.6-cp-50035`.
