### PR TITLE
fix: recycle orphan StorageV3 files in datacoord GC

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -644,20 +644,33 @@ func (gc *garbageCollector) recycleUnusedBinLogWithChecker(ctx context.Context, 
 		segmentID, err := segmentIDFromPath(gc.option.cli.RootPath(), chunkInfo.FilePath)
 		if err != nil {
 			// Try V3 path format: insert_log/{coll}/{part}/{seg}/...
-			// V3 orphan files are managed by loon (milvus-storage), skip them.
-			if v3SegID, parseErr := parseV3SegmentID(gc.option.cli.RootPath(), chunkInfo.FilePath); parseErr == nil {
-				v3Seg := gc.meta.GetSegment(ctx, v3SegID)
-				if v3Seg == nil || v3Seg.GetStorageVersion() == storage.StorageV3 {
-					// V3 segment file or orphan V3 file — skip, managed by loon
+			v3SegID, parseErr := parseV3SegmentID(gc.option.cli.RootPath(), chunkInfo.FilePath)
+			if parseErr != nil {
+				unexpectedFailure.Inc()
+				logger.Warn(ctx, "garbageCollector recycleUnusedBinlogFiles parse segment id error",
+					mlog.String("filePath", chunkInfo.FilePath),
+					mlog.Err(err))
+				return true
+			}
+			if v3Seg := gc.meta.GetSegment(ctx, v3SegID); v3Seg != nil {
+				if v3Seg.GetStorageVersion() == storage.StorageV3 {
+					// registered V3 segment file — skip, live files are managed by
+					// loon and dropped V3 segments are recycled with the whole
+					// basePath by recycleDroppedSegments
 					valid++
 					return true
 				}
+				unexpectedFailure.Inc()
+				logger.Warn(ctx, "garbageCollector recycleUnusedBinlogFiles parse segment id error",
+					mlog.String("filePath", chunkInfo.FilePath),
+					mlog.Err(err))
+				return true
 			}
-			unexpectedFailure.Inc()
-			logger.Warn(ctx, "garbageCollector recycleUnusedBinlogFiles parse segment id error",
-				mlog.String("filePath", chunkInfo.FilePath),
-				mlog.Err(err))
-			return true
+			// Orphan V3 file: its segment was never registered in meta, e.g.
+			// output uploaded by a failed sort/mix compaction attempt (issue
+			// #50962). Nothing manages it, so recycle it like V1/V2 orphans:
+			// fall through to the shared checker/removal path below.
+			segmentID = v3SegID
 		}
 
 		segment := gc.meta.GetSegment(ctx, segmentID)

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -3085,6 +3085,97 @@ func TestGarbageCollector_recycleUnusedBinlogFiles_SnapshotReference(t *testing.
 	assert.Empty(t, removeCalledPaths, "binlog files of snapshot-referenced segments should not be removed")
 }
 
+// TestGarbageCollector_recycleUnusedBinlogFiles_V3Orphan tests that V3-layout files whose
+// segment was never registered in meta (e.g. output uploaded by a failed sort compaction
+// attempt, issue #50962) are recycled after missingTolerance, while files of registered
+// V3 segments are still skipped.
+func TestGarbageCollector_recycleUnusedBinlogFiles_V3Orphan(t *testing.T) {
+	ctx := context.Background()
+
+	cli := storage.NewLocalChunkManager(objectstorage.RootPath("/tmp/test"))
+
+	// Registered V3 segment, its files must be skipped by the orphan scan.
+	registered := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             1001,
+			CollectionID:   100,
+			PartitionID:    10,
+			State:          commonpb.SegmentState_Flushed,
+			InsertChannel:  "ch1",
+			StorageVersion: storage.StorageV3,
+		},
+	}
+
+	meta := &meta{
+		catalog:      &datacoord.Catalog{},
+		snapshotMeta: &snapshotMeta{},
+		indexMeta:    &indexMeta{},
+		segments: &SegmentsInfo{
+			segments: map[int64]*SegmentInfo{
+				1001: registered,
+			},
+		},
+		channelCPs: newChannelCps(),
+	}
+
+	gc := newGarbageCollector(meta, &ServerHandler{}, GcOption{
+		cli:              cli,
+		enabled:          true,
+		checkInterval:    time.Millisecond * 10,
+		scanInterval:     time.Hour * 7 * 24,
+		missingTolerance: time.Hour,
+		dropTolerance:    time.Hour * 24,
+	})
+
+	var (
+		removedMu    sync.Mutex
+		removedPaths []string
+	)
+	mockRemove := mockey.Mock((*storage.LocalChunkManager).Remove).To(func(cm *storage.LocalChunkManager, ctx context.Context, filePath string) error {
+		removedMu.Lock()
+		defer removedMu.Unlock()
+		removedPaths = append(removedPaths, filePath)
+		return nil
+	}).Build()
+	defer mockRemove.UnPatch()
+
+	expired := time.Now().Add(-2 * time.Hour)
+	insertPrefix := path.Join(cli.RootPath(), common.SegmentInsertLogPath)
+	files := []*storage.ChunkObjectInfo{
+		// deep V3 path of the registered segment: skipped
+		{FilePath: path.Join(insertPrefix, "100/10/1001/_stats/bloom_filter.100/2001"), ModifyTime: expired},
+		// deep V3 path of orphan segment 999 (not in meta), expired: removed
+		{FilePath: path.Join(insertPrefix, "100/10/999/_stats/bloom_filter.100/2002"), ModifyTime: expired},
+		// data file of the same orphan segment: removed
+		{FilePath: path.Join(insertPrefix, "100/10/999/_data/2003_uuid.parquet"), ModifyTime: expired},
+		// orphan V3 file still within missingTolerance: kept
+		{FilePath: path.Join(insertPrefix, "100/10/998/_stats/bloom_filter.100/2004"), ModifyTime: time.Now()},
+	}
+
+	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(func(cm *storage.LocalChunkManager, ctx context.Context, prefix string, recursive bool, fn storage.ChunkObjectWalkFunc) error {
+		if prefix != insertPrefix {
+			return nil
+		}
+		for _, file := range files {
+			if !fn(file) {
+				break
+			}
+		}
+		return nil
+	}).Build()
+	defer mockWalk.UnPatch()
+
+	mockIsSegBlocked := mockey.Mock((*snapshotMeta).IsSegmentGCBlocked).Return(false).Build()
+	defer mockIsSegBlocked.UnPatch()
+
+	gc.recycleUnusedBinlogFiles(ctx)
+
+	assert.ElementsMatch(t, []string{
+		path.Join(insertPrefix, "100/10/999/_stats/bloom_filter.100/2002"),
+		path.Join(insertPrefix, "100/10/999/_data/2003_uuid.parquet"),
+	}, removedPaths)
+}
+
 // TestGarbageCollector_recycleDroppedSegments_SnapshotMetaNil tests that GC handles nil snapshotMeta gracefully
 func TestGarbageCollector_recycleDroppedSegments_SnapshotMetaNil(t *testing.T) {
 	// Setup


### PR DESCRIPTION
issue: #50962

related: #50911 / #50999 (the meta-layer root cause of the `unexpected row count after sort compaction` mismatch itself, already fixed on master). This PR addresses the resource-leak side: insert logs uploaded by failed StorageV3 sort compaction attempts were never reclaimed by GC (a 500Gi MinIO PVC grew to ~997G in chaos testing).

## Root cause

Two aspects of the incident are **by design**, not defects: sort compaction streams its output to object storage before the final row-count validation can run, so a failed attempt necessarily leaves uploaded files behind with the target segment never registered in meta; and a failed compaction is re-triggered on the next cycle with a fresh planID/targetSegmentID. Orphan files from failed attempts are an anticipated byproduct, and the designed safety net for them is the datacoord GC orphan scan (`gc.scanInterval` + `gc.missingTolerance`).

**The bug is that this safety net is broken for StorageV3 paths.** In `recycleUnusedBinLogWithChecker`, V3-format paths that fail the V1 parser (deep paths such as `<seg>/_stats/bloom_filter.<field>/<id>`) hit the `parseV3SegmentID` branch, where files whose segment is **missing from meta** are permanently skipped as "managed by loon". But a never-registered target segment is referenced by no manifest, so loon cannot manage it — those files leak forever. (6-component `_data/*.parquet` paths happen to parse via the V1 branch and are still reclaimed.)

## Fix

`garbage_collector.go`: V3-path files whose segment does not exist in meta are now recycled with the same semantics as V1/V2 orphans (`missingTolerance` gate and snapshot protection preserved). Registered V3 segments keep the existing behavior: live files are managed by loon, and dropped segments are removed wholesale by `recycleDroppedSegments`.

We deliberately did **not** make the datanode delete the target output on failure: when the coordinator's query RPC transiently fails, the same plan (same targetSegmentID, same pre-allocated logIDs) can be re-dispatched to another node while a zombie attempt is still running; a prefix delete from the failed zombie could destroy data the successful attempt already registered. Deletion authority stays with datacoord GC, which checks meta and applies the tolerance window.

Note on retry amplification: a deterministically failing sort compaction still re-uploads one full output copy per trigger cycle (~60s), which can outpace the default GC scan cadence (168h). This PR restores reclaimability; deployments hitting a deterministic failure can lower `dataCoord.gc.scanInterval` to speed up reclamation. Throttling the re-trigger rate itself (e.g. failure backoff) is left as a possible follow-up.

## Tests

- New unit tests: GC recycles orphan deep V3 files while leaving registered-V3 and within-tolerance files untouched.
- Full `internal/datacoord` package regression (with etcd/minio/pulsar deps up): 0 failures; `go vet` / `gofmt` clean; no existing tests modified.
- End-to-end A/B reproduction on a local standalone (see PR comment below): on master, `_stats` files of orphan target segments survive every GC pass (counted as `valid`); with this PR, GC fully reclaims orphan dirs past `missingTolerance` while leaving the registered segment untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
