### PR TITLE
enhance: reduce delegator waitTSafe wakeups under high concurrency

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -149,10 +149,12 @@ type shardDelegator struct {
 	deleteMut    sync.RWMutex
 	deleteBuffer deletebuffer.DeleteBuffer[*deletebuffer.Item]
 
-	sf          conc.Singleflight[struct{}]
-	loader      segments.Loader
-	tsCond      *syncutil.ContextCond
-	latestTsafe *atomic.Uint64
+	sf     conc.Singleflight[struct{}]
+	loader segments.Loader
+	// tsafeNotifier tracks the delegator's latest tSafe and wakes only the
+	// waiters whose guarantee timestamp has been reached, avoiding the
+	// thundering-herd broadcast of a plain condition variable.
+	tsafeNotifier *syncutil.TargetNotifier
 	// queryHook
 	queryHook      optimizers.QueryHook
 	partitionStats map[UniqueID]*storage.PartitionStatsSnapshot
@@ -1067,7 +1069,7 @@ func (sd *shardDelegator) waitTSafe(ctx context.Context, ts uint64) (uint64, err
 	log := sd.getLogger(ctx)
 
 	// Fast path: tSafe already meets the guarantee timestamp.
-	latestTSafe := sd.latestTsafe.Load()
+	latestTSafe := sd.tsafeNotifier.Load()
 	if latestTSafe >= ts {
 		return latestTSafe, nil
 	}
@@ -1101,32 +1103,29 @@ func (sd *shardDelegator) waitTSafe(ctx context.Context, ts uint64) (uint64, err
 	// (e.g. forward delete retrying against a dead QueryNode).
 	stallTimeout := paramtable.Get().QueryNodeCfg.WaitTsafeStallTimeout.GetAsDurationByParse()
 
-	// Standard condition variable pattern: Lock → for !condition { Wait } → Unlock
-	sd.tsCond.L.Lock()
-	for sd.latestTsafe.Load() < ts && sd.Serviceable() {
-		stallCtx, stallCancel := context.WithTimeout(ctx, stallTimeout)
-		err := sd.tsCond.Wait(stallCtx)
-		stallCancel()
+	// Wait until tSafe reaches ts. UpdateTSafe only wakes waiters whose target
+	// is satisfied, so a sub-target advance does not wake us; WaitFor reports
+	// whether tSafe advanced at all during the wait, which is what drives stall
+	// detection (an advance that does not reach ts is progress, not a stall).
+	for sd.tsafeNotifier.Load() < ts && sd.Serviceable() {
+		progressed, err := sd.tsafeNotifier.WaitFor(ctx, ts, stallTimeout)
 		if err != nil {
-			// Wait returned without holding the lock.
-			if ctx.Err() != nil {
-				return 0, ctx.Err()
-			}
-			// No broadcast within stallTimeout — tSafe is stalled.
+			// Only ctx cancellation/expiry surfaces here.
+			return 0, err
+		}
+		if !progressed && sd.tsafeNotifier.Load() < ts && sd.Serviceable() {
+			// tSafe did not advance at all within stallTimeout — it is stalled.
 			log.Warn(ctx, "tsafe stall detected, fast-fail to allow proxy failover",
-				mlog.Uint64("currentTsafe", sd.latestTsafe.Load()),
+				mlog.Uint64("currentTsafe", sd.tsafeNotifier.Load()),
 				mlog.Uint64("targetTs", ts),
 				mlog.Duration("stallTimeout", stallTimeout),
 			)
 			return 0, WrapErrTsLagTooLarge(sd.vchannelName, gt.Sub(st), stallTimeout)
 		}
-		// Woken by broadcast with lock re-acquired, loop back to re-check condition.
+		// Woken by a satisfying advance or by Close's WakeAll — re-check the loop.
 	}
-	current := sd.latestTsafe.Load()
-	serviceable := sd.Serviceable()
-	sd.tsCond.L.Unlock()
-
-	if !serviceable {
+	current := sd.tsafeNotifier.Load()
+	if !sd.Serviceable() {
 		return 0, merr.WrapErrChannelNotAvailable(sd.vchannelName, "delegator closed during wait tsafe")
 	}
 	return current, nil
@@ -1165,17 +1164,16 @@ func (sd *shardDelegator) UpdateTSafe(tsafe uint64) {
 		mlog.Int64("collectionID", sd.collectionID),
 		mlog.String("vchannel", sd.vchannelName),
 		mlog.Time("tsafe", tsoutil.PhysicalTime(tsafe)),
-		mlog.Time("latestTSafe", tsoutil.PhysicalTime(sd.latestTsafe.Load())))
-	if tsafe <= sd.latestTsafe.Load() {
+		mlog.Time("latestTSafe", tsoutil.PhysicalTime(sd.tsafeNotifier.Load())))
+
+	// Advance atomically stores the new tSafe and wakes only the waiters whose
+	// target has been reached; it is a monotonic no-op when tsafe does not move
+	// the value forward, so stale updates return early. Doing the compare and
+	// the wakeup under the notifier's lock prevents lost wakeups (a waiter can
+	// no longer observe the old value and then park after the wake fired).
+	if !sd.tsafeNotifier.Advance(tsafe) {
 		return
 	}
-
-	// Store and broadcast under lock to prevent lost wakeups:
-	// without the lock, a waiter could observe the old tSafe, then enter
-	// Wait() after the broadcast has already fired, missing the notification.
-	sd.tsCond.LockAndBroadcast()
-	sd.latestTsafe.Store(tsafe)
-	sd.tsCond.L.Unlock()
 
 	// Check if caught up with streaming data (all fields are atomic, no lock needed)
 	if sd.catchingUpStreamingData.Load() {
@@ -1197,7 +1195,7 @@ func (sd *shardDelegator) UpdateTSafe(tsafe uint64) {
 }
 
 func (sd *shardDelegator) GetTSafe() uint64 {
-	return sd.latestTsafe.Load()
+	return sd.tsafeNotifier.Load()
 }
 
 // CatchingUpStreamingData returns true if delegator is still catching up with streaming data.
@@ -1342,9 +1340,8 @@ func (w *StatusWrapper) GetStatus() *commonpb.Status {
 func (sd *shardDelegator) Close() {
 	sd.lifetime.SetState(lifetime.Stopped)
 	sd.lifetime.Close()
-	// broadcast to all waitTsafe to quit
-	sd.tsCond.LockAndBroadcast()
-	sd.tsCond.L.Unlock()
+	// wake all waitTSafe waiters so they observe !Serviceable and quit
+	sd.tsafeNotifier.WakeAll()
 	sd.lifetime.Wait()
 
 	if sd.growingSourceProvider != nil {
@@ -1503,7 +1500,7 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		distribution:      NewDistribution(channel, queryView),
 		deleteBuffer: deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](startTs, sizePerBlock,
 			[]string{paramtable.GetStringNodeID(), channel}),
-		latestTsafe:                atomic.NewUint64(startTs),
+		tsafeNotifier:              syncutil.NewTargetNotifier(startTs),
 		loader:                     loader,
 		queryHook:                  queryHook,
 		chunkManager:               chunkManager,
@@ -1546,7 +1543,6 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		log.Info(ctx, "registered growing-source source support")
 	}
 
-	sd.tsCond = syncutil.NewContextCond(&sync.Mutex{})
 	paramtable.Get().Watch(paramtable.Get().QueryNodeCfg.DelegatorPostLoadConcurrencyFactor.Key, postLoadConfigHandler)
 	log.Info(ctx, "finish build new shardDelegator")
 	return sd, nil

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -2347,7 +2346,7 @@ func TestUpdateSchemaRejectsIncompatibleBM25FunctionChange(t *testing.T) {
 			functionFieldType: map[int64]schemapb.FunctionType{102: schemapb.FunctionType_BM25},
 		},
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
-		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		tsafeNotifier:              syncutil.NewTargetNotifier(0),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
 	sd.publishIDFOracle(oldOracle)
@@ -2381,7 +2380,7 @@ func TestUpdateSchemaSyncsAdditiveIDFOracleFunctions(t *testing.T) {
 			functionFieldType: map[int64]schemapb.FunctionType{},
 		},
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
-		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		tsafeNotifier:              syncutil.NewTargetNotifier(0),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
 	oldOracle := NewIDFOracle("test-channel", oldSchema.GetFunctions())
@@ -2419,7 +2418,7 @@ func TestUpdateSchemaDoesNotSyncIDFOracleWhenWorkerUpdateFails(t *testing.T) {
 			functionFieldType: map[int64]schemapb.FunctionType{},
 		},
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
-		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		tsafeNotifier:              syncutil.NewTargetNotifier(0),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
 	oldOracle := NewIDFOracle("test-channel", oldSchema.GetFunctions())
@@ -2453,7 +2452,7 @@ func TestUpdateSchemaInitializesIDFOracleWhenBM25Added(t *testing.T) {
 			functionFieldType: map[int64]schemapb.FunctionType{},
 		},
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
-		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		tsafeNotifier:              syncutil.NewTargetNotifier(0),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
 	defer sd.Close()
@@ -2496,7 +2495,7 @@ func TestUpdateSchemaRefreshesCollectionBaselineForSequentialBM25Validation(t *t
 		workerManager:              workerManager,
 		functionState:              functionState,
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
-		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		tsafeNotifier:              syncutil.NewTargetNotifier(0),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
 	defer sd.Close()
@@ -2532,7 +2531,7 @@ func TestUpdateSchemaSyncsFunctionRuntimeMetadata(t *testing.T) {
 			functionFieldType: map[int64]schemapb.FunctionType{999: schemapb.FunctionType_BM25},
 		},
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
-		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		tsafeNotifier:              syncutil.NewTargetNotifier(0),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
 	defer sd.Close()
@@ -2569,7 +2568,7 @@ func TestUpdateSchemaSkipsStaleSchemaBeforeSideEffects(t *testing.T) {
 		functionState:              currentFunctionState,
 		schemaBarrierTs:            100,
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
-		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		tsafeNotifier:              syncutil.NewTargetNotifier(0),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
 	defer sd.Close()
@@ -2844,9 +2843,8 @@ func TestDelegatorCatchingUpStreamingData(t *testing.T) {
 
 		sd := &shardDelegator{
 			vchannelName:               "test-channel",
-			latestTsafe:                atomic.NewUint64(0),
+			tsafeNotifier:              syncutil.NewTargetNotifier(0),
 			catchingUpStreamingData:    atomic.NewBool(true),
-			tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
 			latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 		}
 
@@ -2868,9 +2866,8 @@ func TestDelegatorCatchingUpStreamingData(t *testing.T) {
 
 		sd := &shardDelegator{
 			vchannelName:               "test-channel",
-			latestTsafe:                atomic.NewUint64(0),
+			tsafeNotifier:              syncutil.NewTargetNotifier(0),
 			catchingUpStreamingData:    atomic.NewBool(true),
-			tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
 			latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 		}
 
@@ -2892,9 +2889,8 @@ func TestDelegatorCatchingUpStreamingData(t *testing.T) {
 
 		sd := &shardDelegator{
 			vchannelName:               "test-channel",
-			latestTsafe:                atomic.NewUint64(0),
+			tsafeNotifier:              syncutil.NewTargetNotifier(0),
 			catchingUpStreamingData:    atomic.NewBool(true),
-			tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
 			latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 		}
 

--- a/pkg/util/syncutil/target_notifier.go
+++ b/pkg/util/syncutil/target_notifier.go
@@ -1,0 +1,147 @@
+package syncutil
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// TargetNotifier coordinates goroutines that wait for a monotonically
+// non-decreasing uint64 value (for example a QueryNode delegator tSafe) to
+// reach a per-waiter target.
+//
+// Unlike a broadcast condition variable (see ContextCond), advancing the value
+// wakes ONLY the waiters whose target has been reached. This avoids the
+// thundering-herd cost of waking every waiter on every small advance when most
+// of them still cannot make progress: under high-concurrency strong-consistency
+// workloads many requests wait on the same value with different targets, and a
+// broadcast forces every one of them to re-check and re-park on each tick.
+//
+// The zero value is not usable; construct one with NewTargetNotifier.
+type TargetNotifier struct {
+	mu          sync.Mutex
+	current     uint64
+	lastAdvance time.Time
+	waiters     map[*targetWaiter]struct{}
+}
+
+// targetWaiter is a single parked goroutine waiting for current to reach target.
+// ch is closed exactly once, by whichever of Advance/WakeAll releases it; the
+// releaser removes the waiter from the set under the lock, so a WaitFor that
+// instead leaves via ctx/timeout only ever deletes (never closes) the entry.
+type targetWaiter struct {
+	target uint64
+	ch     chan struct{}
+}
+
+// NewTargetNotifier creates a TargetNotifier seeded with an initial value.
+func NewTargetNotifier(initial uint64) *TargetNotifier {
+	return &TargetNotifier{
+		current:     initial,
+		lastAdvance: time.Now(),
+		waiters:     make(map[*targetWaiter]struct{}),
+	}
+}
+
+// Load returns the current value.
+func (n *TargetNotifier) Load() uint64 {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.current
+}
+
+// Advance sets the value to next and wakes every waiter whose target has been
+// reached. It is a monotonic no-op that returns false when next <= current, so
+// concurrent callers can never move the value backwards.
+func (n *TargetNotifier) Advance(next uint64) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if next <= n.current {
+		return false
+	}
+	n.current = next
+	n.lastAdvance = time.Now()
+	for w := range n.waiters {
+		if w.target <= next {
+			close(w.ch)
+			delete(n.waiters, w)
+		}
+	}
+	return true
+}
+
+// WakeAll wakes every waiter regardless of target, without changing the value.
+// Use it on shutdown, or when a higher-level serviceability condition flips, so
+// parked waiters unblock and re-evaluate their own exit condition.
+func (n *TargetNotifier) WakeAll() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for w := range n.waiters {
+		close(w.ch)
+		delete(n.waiters, w)
+	}
+}
+
+// WaiterCount returns the number of goroutines currently parked in WaitFor.
+// Intended for observability (for example a gauge of active tSafe waiters).
+func (n *TargetNotifier) WaiterCount() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.waiters)
+}
+
+// WaitFor blocks until one of: the value reaches target (targeted wake),
+// WakeAll is called, ctx is done, or waitTimeout elapses.
+//
+// It returns progressed=true when the value advanced at all while this call was
+// waiting (including reaching target), and progressed=false only when
+// waitTimeout elapsed with no advance observed. This lets the caller own its
+// stall policy (for example: fast-fail only after the value has been frozen for
+// an interval) without this primitive baking one in. err is non-nil only when
+// ctx is canceled or expires, in which case it carries context.Cause(ctx).
+//
+// The check-and-register is done under the same lock Advance takes, so a value
+// that reaches target concurrently with registration can never be missed
+// (no lost wakeup).
+func (n *TargetNotifier) WaitFor(ctx context.Context, target uint64, waitTimeout time.Duration) (progressed bool, err error) {
+	n.mu.Lock()
+	if n.current >= target {
+		n.mu.Unlock()
+		return true, nil
+	}
+	w := &targetWaiter{target: target, ch: make(chan struct{})}
+	n.waiters[w] = struct{}{}
+	startAdvance := n.lastAdvance
+	n.mu.Unlock()
+
+	timer := time.NewTimer(waitTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-w.ch:
+		// Released by Advance (target reached) or WakeAll; the releaser already
+		// removed w from the set under the lock.
+		return n.advancedSince(startAdvance), nil
+	case <-ctx.Done():
+		return n.finish(w, startAdvance), context.Cause(ctx)
+	case <-timer.C:
+		return n.finish(w, startAdvance), nil
+	}
+}
+
+// advancedSince reports whether the value advanced after the given timestamp.
+func (n *TargetNotifier) advancedSince(since time.Time) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.lastAdvance.After(since)
+}
+
+// finish deregisters w (if it is still registered) and reports whether the
+// value advanced since the given timestamp, under a single lock acquisition.
+// Deleting an already-released waiter is a safe no-op.
+func (n *TargetNotifier) finish(w *targetWaiter, since time.Time) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	delete(n.waiters, w)
+	return n.lastAdvance.After(since)
+}

--- a/pkg/util/syncutil/target_notifier_test.go
+++ b/pkg/util/syncutil/target_notifier_test.go
@@ -1,0 +1,319 @@
+package syncutil
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testWaitTimeout = 200 * time.Millisecond
+	testShortWait   = 30 * time.Millisecond
+)
+
+// waitForWaiterCount polls until WaiterCount reaches want or the deadline hits.
+func waitForWaiterCount(t *testing.T, n *TargetNotifier, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if n.WaiterCount() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	require.Equal(t, want, n.WaiterCount(), "WaiterCount did not converge")
+}
+
+func TestTargetNotifier_ImmediateWhenReached(t *testing.T) {
+	n := NewTargetNotifier(10)
+	assert.Equal(t, uint64(10), n.Load())
+
+	// A target at or below the current value returns immediately, progressed.
+	progressed, err := n.WaitFor(context.Background(), 10, testWaitTimeout)
+	require.NoError(t, err)
+	assert.True(t, progressed)
+
+	progressed, err = n.WaitFor(context.Background(), 5, testWaitTimeout)
+	require.NoError(t, err)
+	assert.True(t, progressed)
+	assert.Equal(t, 0, n.WaiterCount())
+}
+
+func TestTargetNotifier_WakesOnAdvanceToTarget(t *testing.T) {
+	n := NewTargetNotifier(0)
+
+	done := make(chan struct{})
+	var progressed bool
+	var werr error
+	go func() {
+		progressed, werr = n.WaitFor(context.Background(), 10, 2*time.Second)
+		close(done)
+	}()
+
+	waitForWaiterCount(t, n, 1)
+	assert.True(t, n.Advance(10))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter was not woken by Advance to target")
+	}
+	require.NoError(t, werr)
+	assert.True(t, progressed)
+	assert.Equal(t, 0, n.WaiterCount())
+}
+
+// TestTargetNotifier_TargetedWakeup is the core property: a small advance wakes
+// only the waiters it satisfies, leaving farther-target waiters parked.
+func TestTargetNotifier_TargetedWakeup(t *testing.T) {
+	n := NewTargetNotifier(0)
+
+	nearDone := make(chan struct{})
+	farDone := make(chan struct{})
+	go func() { n.WaitFor(context.Background(), 5, 5*time.Second); close(nearDone) }()
+	go func() { n.WaitFor(context.Background(), 100, 5*time.Second); close(farDone) }()
+
+	waitForWaiterCount(t, n, 2)
+
+	// Advance past the near target but well below the far target.
+	assert.True(t, n.Advance(5))
+
+	select {
+	case <-nearDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("near-target waiter should have woken on Advance(5)")
+	}
+
+	// The far waiter must still be parked — this is what saves the wakeups.
+	waitForWaiterCount(t, n, 1)
+	select {
+	case <-farDone:
+		t.Fatal("far-target waiter must NOT wake on an advance below its target")
+	case <-time.After(testShortWait):
+	}
+
+	// Advancing to the far target releases it.
+	assert.True(t, n.Advance(100))
+	select {
+	case <-farDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("far-target waiter should have woken on Advance(100)")
+	}
+	assert.Equal(t, 0, n.WaiterCount())
+}
+
+func TestTargetNotifier_MonotonicAdvance(t *testing.T) {
+	n := NewTargetNotifier(10)
+
+	assert.False(t, n.Advance(10), "advance to equal value is a no-op")
+	assert.False(t, n.Advance(5), "advance to a smaller value is a no-op")
+	assert.Equal(t, uint64(10), n.Load())
+
+	assert.True(t, n.Advance(11))
+	assert.Equal(t, uint64(11), n.Load())
+	assert.False(t, n.Advance(11))
+}
+
+func TestTargetNotifier_WakeAll(t *testing.T) {
+	n := NewTargetNotifier(0)
+
+	const nWaiters = 8
+	var wg sync.WaitGroup
+	progressedCount := int32(0)
+	for i := 0; i < nWaiters; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// High targets so only WakeAll can release them.
+			progressed, err := n.WaitFor(context.Background(), 1_000_000, 5*time.Second)
+			assert.NoError(t, err)
+			if progressed {
+				atomic.AddInt32(&progressedCount, 1)
+			}
+		}()
+	}
+
+	waitForWaiterCount(t, n, nWaiters)
+	n.WakeAll()
+
+	waitDone := make(chan struct{})
+	go func() { wg.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("WakeAll did not release all waiters")
+	}
+
+	assert.Equal(t, 0, n.WaiterCount())
+	// WakeAll did not advance the value, so no waiter reports progress.
+	assert.Equal(t, int32(0), atomic.LoadInt32(&progressedCount))
+	assert.Equal(t, uint64(0), n.Load())
+}
+
+func TestTargetNotifier_ContextCancel(t *testing.T) {
+	n := NewTargetNotifier(0)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := n.WaitFor(ctx, 10, 5*time.Second)
+		done <- err
+	}()
+
+	waitForWaiterCount(t, n, 1)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("context cancel did not unblock WaitFor")
+	}
+	// The waiter must deregister itself on cancel — no leak.
+	waitForWaiterCount(t, n, 0)
+}
+
+func TestTargetNotifier_ContextDeadline(t *testing.T) {
+	n := NewTargetNotifier(0)
+	ctx, cancel := context.WithTimeout(context.Background(), testShortWait)
+	defer cancel()
+
+	_, err := n.WaitFor(ctx, 10, 5*time.Second)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	waitForWaiterCount(t, n, 0)
+}
+
+// TestTargetNotifier_ProgressWithoutReachingTarget verifies the stall-vs-progress
+// distinction: a value that advances but does not reach the waiter's target must
+// (a) NOT wake the waiter early, and (b) be reported as progressed on timeout, so
+// callers do not mistake a slowly-advancing value for a stalled one.
+func TestTargetNotifier_ProgressWithoutReachingTarget(t *testing.T) {
+	n := NewTargetNotifier(0)
+
+	type result struct {
+		progressed bool
+		elapsed    time.Duration
+	}
+	res := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		p, err := n.WaitFor(context.Background(), 100, testWaitTimeout)
+		assert.NoError(t, err)
+		res <- result{p, time.Since(start)}
+	}()
+
+	waitForWaiterCount(t, n, 1)
+	// Advance below the target: the value moved, but the waiter cannot proceed.
+	time.Sleep(testShortWait)
+	assert.True(t, n.Advance(50))
+
+	r := <-res
+	// It must have parked for the full timeout (not woken by the sub-target advance).
+	assert.GreaterOrEqual(t, r.elapsed, testWaitTimeout,
+		"waiter woke before timeout despite target not being reached")
+	// And it must report progress, because the value did advance meanwhile.
+	assert.True(t, r.progressed, "advance below target must still count as progress")
+	assert.Equal(t, 0, n.WaiterCount())
+}
+
+// TestTargetNotifier_StallReported verifies that a full timeout with no advance
+// at all is reported as progressed=false (the caller's stall signal).
+func TestTargetNotifier_StallReported(t *testing.T) {
+	n := NewTargetNotifier(0)
+	progressed, err := n.WaitFor(context.Background(), 100, testShortWait)
+	require.NoError(t, err)
+	assert.False(t, progressed, "no advance within timeout must report no progress")
+	assert.Equal(t, 0, n.WaiterCount())
+}
+
+// TestTargetNotifier_NoLostWakeup hammers the register-vs-advance race: for each
+// round a waiter targets current+1 while another goroutine advances to exactly
+// that value. The waiter must always be released (never hang).
+func TestTargetNotifier_NoLostWakeup(t *testing.T) {
+	n := NewTargetNotifier(0)
+	for i := uint64(1); i <= 2000; i++ {
+		target := i
+		done := make(chan bool, 1)
+		go func() {
+			p, err := n.WaitFor(context.Background(), target, 2*time.Second)
+			assert.NoError(t, err)
+			done <- p
+		}()
+		// Race the advance against the registration.
+		go n.Advance(target)
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("lost wakeup: waiter for target %d never released", target)
+		}
+	}
+	waitForWaiterCount(t, n, 0)
+	assert.Equal(t, uint64(2000), n.Load())
+}
+
+// TestTargetNotifier_ConcurrentStress runs many waiters against a stream of small
+// advances plus periodic WakeAll, asserting no panic, no leak, and that every
+// waiter eventually returns. Meant to be run under -race.
+func TestTargetNotifier_ConcurrentStress(t *testing.T) {
+	n := NewTargetNotifier(0)
+	const (
+		nWaiters  = 64
+		maxTarget = 500
+	)
+	var wg sync.WaitGroup
+
+	stop := make(chan struct{})
+	// Advancer: many small steps.
+	go func() {
+		v := uint64(0)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			v++
+			n.Advance(v)
+			time.Sleep(time.Microsecond * 50)
+		}
+	}()
+	// Occasional WakeAll to exercise the shutdown-style path.
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-time.After(5 * time.Millisecond):
+				n.WakeAll()
+			}
+		}
+	}()
+
+	for i := 0; i < nWaiters; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(i)))
+			for j := 0; j < 50; j++ {
+				target := uint64(rng.Intn(maxTarget) + 1)
+				_, err := n.WaitFor(context.Background(), target, 20*time.Millisecond)
+				assert.NoError(t, err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(stop)
+	// Give the background goroutines a moment to observe stop.
+	time.Sleep(10 * time.Millisecond)
+	waitForWaiterCount(t, n, 0)
+}


### PR DESCRIPTION
## What this PR does

Reduces CPU overhead in the QueryNode `shardDelegator` tSafe wait path under high-concurrency strong-consistency workloads (issue #50101).

Today `UpdateTSafe` calls `ContextCond.LockAndBroadcast()`, waking **every** waiter on each tSafe advance regardless of its guarantee timestamp — a thundering herd where most woken requests re-check `latestTsafe < ts`, find it unmet, and re-park, spending CPU on scheduler wakeups and mutex contention instead of query execution.

## Approach (issue direction 1 — wake only satisfied waiters)

- New `pkg/util/syncutil.TargetNotifier`: a monotonically non-decreasing `uint64` value with waiters keyed by target; `Advance` wakes only the waiters whose target has been reached. The shared `ContextCond` (24 call sites) is left untouched.
- `waitTSafe` now waits via the notifier; `UpdateTSafe` advances-and-wakes atomically under the notifier lock; `Close` wakes all waiters so they observe `!Serviceable` and exit.

## Semantics preserved

- Same `waitTSafe` signature and `(uint64, error)` contract.
- **Stall detection preserved**: a sub-target advance is reported as *progress*, so a slowly-advancing tSafe never false-triggers the fast-fail/failover path; a genuinely frozen tSafe still fast-fails after `WaitTsafeStallTimeout`.
- `MaxTimestampLag`, downgrade-tsafe, and channel-not-available paths unchanged.
- `Advance` compares and wakes under one lock, also closing the previous compare-outside-the-lock in `UpdateTSafe`.

## Tests

`pkg/util/syncutil/target_notifier_test.go` covers targeted wakeup, monotonicity, `WakeAll`, context cancel/deadline, the stall-vs-progress distinction, and a `-race` lost-wakeup / waiter-leak stress test:

```
go -C pkg test -tags dynamic,test -gcflags="all=-N -l" -race ./util/syncutil/...   # ok
```

The delegator wiring preserves the existing `waitTSafe` contract; that package links the C++ core via cgo and is exercised by CI.

## Notes

- Observability (issue direction 3): `TargetNotifier.WaiterCount()` is exposed for a future active-waiter gauge; wiring the Prometheus metric is left as a focused follow-up so this PR stays scoped to the wakeup change.

issue: #50101