### PR TITLE
fix: Keep segment-load thread pool IO-only to stop starving etcd keepalive

### DIFF
--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -409,12 +409,13 @@ TEST(LoadCellBatchAsync, PushesRawTablesForConsumerFinalize) {
     };
 
     auto channel = std::make_shared<CellReaderChannel>();
-    auto futures = LoadCellBatchAsync(nullptr,
-                                      std::move(specs),
-                                      MakeMockReaderFactory(),
-                                      channel,
-                                      32 * MB,
-                                      milvus::proto::common::LoadPriority::HIGH);
+    auto futures =
+        LoadCellBatchAsync(nullptr,
+                           std::move(specs),
+                           MakeMockReaderFactory(),
+                           channel,
+                           32 * MB,
+                           milvus::proto::common::LoadPriority::HIGH);
 
     int received = 0;
     std::shared_ptr<CellLoadResult> cell_data;

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -401,45 +401,36 @@ TEST(LoadCellBatchAsync, ReadParallelismScalesWithBatchBudget) {
     EXPECT_EQ(observed_reader_memory_limit.load(), 32 * MB);
 }
 
-TEST(LoadCellBatchAsync, FinalizeCellBeforePush) {
+TEST(LoadCellBatchAsync, PushesRawTablesForConsumerFinalize) {
     constexpr int64_t MB = 1 << 20;
     std::vector<CellSpec> specs = {
         {0, 0, 0, 1, 8 * MB},
         {1, 0, 1, 1, 8 * MB},
     };
 
-    std::atomic<int> finalized{0};
     auto channel = std::make_shared<CellReaderChannel>();
-    auto futures = LoadCellBatchAsync(
-        nullptr,
-        std::move(specs),
-        MakeMockReaderFactory(),
-        channel,
-        32 * MB,
-        milvus::proto::common::LoadPriority::HIGH,
-        [&finalized](const std::vector<std::shared_ptr<arrow::Table>>& tables,
-                     int64_t /*cid*/) {
-            EXPECT_EQ(tables.size(), 1);
-            finalized.fetch_add(1);
-            return std::make_unique<milvus::GroupChunk>();
-        });
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      std::move(specs),
+                                      MakeMockReaderFactory(),
+                                      channel,
+                                      32 * MB,
+                                      milvus::proto::common::LoadPriority::HIGH);
 
     int received = 0;
     std::shared_ptr<CellLoadResult> cell_data;
     while (channel->pop(cell_data)) {
         ASSERT_NE(cell_data, nullptr);
-        EXPECT_NE(cell_data->chunk, nullptr);
-        EXPECT_TRUE(cell_data->tables.empty());
-        EXPECT_EQ(cell_data->budget_bytes, 0);
+        // Batch tasks must push raw tables; finalization is the consumer's
+        // job so the shared load pool stays IO-only (#48060).
+        EXPECT_EQ(cell_data->tables.size(), 1);
+        EXPECT_GT(cell_data->budget_bytes, 0);
         ReleaseCellLoadResultBudget(cell_data);
         ++received;
     }
     for (auto& future : futures) {
         future.get();
     }
-
     EXPECT_EQ(received, 2);
-    EXPECT_EQ(finalized.load(), 2);
 }
 
 TEST(LoadCellBatchAsync, FileBoundarySplit) {

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -433,8 +433,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    BatchReaderFactory reader_factory,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
-                   milvus::proto::common::LoadPriority priority,
-                   CellFinalizeFunc finalize_cell) {
+                   milvus::proto::common::LoadPriority priority) {
     if (cell_specs.empty()) {
         channel->close();
         return {};
@@ -529,8 +528,6 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     auto remaining = std::make_shared<std::atomic<size_t>>(batches.size());
     auto shared_factory =
         std::make_shared<BatchReaderFactory>(std::move(reader_factory));
-    auto shared_finalizer =
-        std::make_shared<CellFinalizeFunc>(std::move(finalize_cell));
 
     std::vector<std::future<void>> futures;
     futures.reserve(batches.size());
@@ -548,7 +545,6 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                                           read_parallelism,
                                           channel,
                                           remaining,
-                                          shared_finalizer,
                                           op_ctx]() {
             auto task_guard = folly::makeGuard([&channel, &remaining]() {
                 if (remaining->fetch_sub(1) == 1) {
@@ -606,15 +602,6 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                         std::move(all_tables[table_offset + i]));
                 }
                 table_offset += cell.rg_count;
-                if (*shared_finalizer) {
-                    cell_result->chunk =
-                        (*shared_finalizer)(cell_result->tables, cell.cid);
-                    ReleaseCellLoadResultBudget(cell_result);
-                    transferred_budget_bytes += cell_budget_bytes;
-                    CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
-                    channel->push(std::move(cell_result));
-                    continue;
-                }
                 channel->push(std::move(cell_result));
                 transferred_budget_bytes += cell_budget_bytes;
             }
@@ -663,13 +650,15 @@ MakeChunkReaderFactory(
                           int64_t rg_offset,
                           int64_t total_rg_count,
                           int64_t /*reader_memory_limit*/,
-                          uint64_t /*read_parallelism*/)
+                          uint64_t read_parallelism)
                -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         std::vector<int64_t> rg_indices(total_rg_count);
         std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);
         ARROW_ASSIGN_OR_RAISE(
             auto batches,
-            chunk_reader->get_chunks(rg_indices, /*parallelism=*/1));
+            chunk_reader->get_chunks(
+                rg_indices,
+                std::max<size_t>(static_cast<size_t>(read_parallelism), 1)));
         std::vector<std::shared_ptr<arrow::Table>> tables;
         tables.reserve(batches.size());
         for (auto& batch : batches) {

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -158,13 +158,13 @@ struct CellSpec {
         0;  // transient overhead budget; 0 = memory_size
 };
 
-// Result of loading a single cell: cid + either the loaded Arrow tables or the
-// finalized group chunk when a cell finalizer is provided.
+// Result of loading a single cell: cid + the loaded Arrow tables. Consumers
+// build the final GroupChunk on their own thread so the shared load pool
+// stays IO/decode-only (see #48060).
 struct CellLoadResult {
     int64_t cid;
     size_t budget_bytes{0};
     std::vector<std::shared_ptr<arrow::Table>> tables;
-    std::unique_ptr<milvus::GroupChunk> chunk;
 };
 
 using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
@@ -185,15 +185,14 @@ using BatchReaderFactory =
         int64_t reader_memory_limit,
         uint64_t read_parallelism)>;
 
-using CellFinalizeFunc = std::function<std::unique_ptr<milvus::GroupChunk>(
-    const std::vector<std::shared_ptr<arrow::Table>>& tables, int64_t cid)>;
-
 /**
  * Load cells in batches using a pluggable reader factory. Cells are sorted by
  * (file_idx, local_rg_offset) and grouped into IO-merged batches.
- * Each completed cell is pushed to the channel immediately. When finalize_cell
- * is provided, the batch task converts Arrow tables into the final GroupChunk
- * before pushing and releases the transient Arrow budget immediately.
+ * Each completed cell is pushed to the channel immediately as raw Arrow
+ * tables; the consumer finalizes cells on its own thread. Batch tasks must
+ * stay IO/decode-only: running CPU-heavy finalization on the shared load
+ * pool can occupy the container CPU quota and starve the Go runtime's etcd
+ * keepalive (#48060).
  *
  * @param op_ctx operation context for cancellation
  * @param cell_specs cell specifications (sorted internally)
@@ -211,8 +210,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
                    milvus::proto::common::LoadPriority priority =
-                       milvus::proto::common::LoadPriority::HIGH,
-                   CellFinalizeFunc finalize_cell = nullptr);
+                       milvus::proto::common::LoadPriority::HIGH);
 
 void
 ReleaseCellLoadResultBudget(

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -356,20 +356,15 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
     auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);
-    auto finalize_cell =
-        [this](const std::vector<std::shared_ptr<arrow::Table>>& tables,
-               int64_t cid) {
-            return load_group_chunk(
-                tables, static_cast<milvus::cachinglayer::cid_t>(cid));
-        };
+    // No finalize_cell: keep the shared load thread pool IO/decode-only and
+    // build chunks on the caller thread in the pop loop. See #48060.
     auto load_futures = milvus::segcore::LoadCellBatchAsync(
         ctx,
         std::move(cell_specs),
         std::move(factory),
         channel,
         FieldDataLoadBatchSplitTargetBytes(),
-        load_priority_,
-        std::move(finalize_cell));
+        load_priority_);
 
     LOG_INFO(
         "[StorageV2] translator {} submits {} batch tasks for column group {}",
@@ -377,7 +372,7 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
         load_futures.size(),
         column_group_info_.field_id);
 
-    // Pop loop — batch tasks finalize cells before pushing.
+    // Pop loop — finalize each cell on this thread as it arrives.
     std::unordered_map<cachinglayer::cid_t, std::unique_ptr<milvus::GroupChunk>>
         completed_cells;
     completed_cells.reserve(cids.size());
@@ -388,12 +383,15 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
             try {
                 CheckCancellation(
                     ctx, segment_id_, "GroupChunkTranslator::get_cells()");
-                AssertInfo(cell_data->chunk != nullptr,
-                           "[StorageV2] translator {} cell {} is not "
-                           "finalized by batch task",
+                AssertInfo(!cell_data->tables.empty(),
+                           "[StorageV2] translator {} cell {} has no loaded "
+                           "tables",
                            key_,
                            cell_data->cid);
-                completed_cells[cell_data->cid] = std::move(cell_data->chunk);
+                auto cell_cid =
+                    static_cast<milvus::cachinglayer::cid_t>(cell_data->cid);
+                completed_cells[cell_cid] =
+                    load_group_chunk(cell_data->tables, cell_cid);
                 milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
             } catch (...) {
                 milvus::segcore::ReleaseCellLoadResultBudget(cell_data);

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -309,18 +309,19 @@ ManifestGroupTranslator::get_cells(
         static_cast<size_t>(pool.GetMaxThreadNum() *
                             milvus::segcore::kChannelCapacityMultiplier));
 
+    // No finalize_cell: batch tasks on the shared load thread pool only
+    // perform IO/decode and push raw Arrow tables. The CPU-heavy chunk
+    // building (NormalizeArrowForChunkWriter + create_group_chunk) runs on
+    // this (caller) thread in the pop loop below, so the shared load pool
+    // never turns into a fleet of CPU-bound threads that can starve the Go
+    // runtime (etcd keepalive) under container CPU quotas. See #48060.
     auto load_futures = milvus::segcore::LoadCellBatchAsync(
         ctx,
         std::move(cell_specs),
         std::move(factory),
         channel,
         FieldDataLoadBatchSplitTargetBytes(),
-        load_priority_,
-        [this](const std::vector<std::shared_ptr<arrow::Table>>& tables,
-               int64_t cid) {
-            return load_group_chunk(
-                tables, static_cast<milvus::cachinglayer::cid_t>(cid));
-        });
+        load_priority_);
 
     LOG_INFO(
         "[StorageV2] translator {} submits {} batch tasks for manifest "
@@ -329,7 +330,7 @@ ManifestGroupTranslator::get_cells(
         load_futures.size(),
         column_group_index_);
 
-    // Pop loop — batch tasks finalize cells before pushing.
+    // Pop loop — finalize each cell on this thread as it arrives.
     std::unordered_map<milvus::cachinglayer::cid_t,
                        std::unique_ptr<milvus::GroupChunk>>
         completed_cells;
@@ -341,12 +342,15 @@ ManifestGroupTranslator::get_cells(
             try {
                 CheckCancellation(
                     ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
-                AssertInfo(cell_data->chunk != nullptr,
-                           "[StorageV2] translator {} cell {} is not "
-                           "finalized by batch task",
+                AssertInfo(!cell_data->tables.empty(),
+                           "[StorageV2] translator {} cell {} has no loaded "
+                           "tables",
                            key_,
                            cell_data->cid);
-                completed_cells[cell_data->cid] = std::move(cell_data->chunk);
+                auto cell_cid =
+                    static_cast<milvus::cachinglayer::cid_t>(cell_data->cid);
+                completed_cells[cell_cid] =
+                    load_group_chunk(cell_data->tables, cell_cid);
                 milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
             } catch (...) {
                 milvus::segcore::ReleaseCellLoadResultBudget(cell_data);

--- a/internal/core/src/storage/ThreadPool.cpp
+++ b/internal/core/src/storage/ThreadPool.cpp
@@ -19,6 +19,7 @@
 #include <chrono>
 
 #include "log/Log.h"
+#include "milvus-storage/thread_pool.h"
 #include "storage/SafeQueue.h"
 
 namespace milvus {
@@ -58,6 +59,16 @@ SetLowPriorityThreadCoreCoefficient(const float coefficient) {
 void
 InitCpuNum(const int num) {
     CPU_NUM = num;
+    // Size the milvus-storage shared reader pool by the same CPU budget.
+    // Without this singleton, every parallel ChunkReader::get_chunks() call
+    // spins up its own ephemeral IOThreadPoolExecutor, so the number of
+    // decode threads is unbounded across concurrent segment loads. One
+    // shared pool keeps load-time decode parallelism <= the CPU budget so
+    // it cannot monopolize a container CPU quota. See #48060.
+    milvus_storage::ThreadPoolHolder::WithSingleton(
+        static_cast<size_t>(std::max(num, 1)));
+    LOG_INFO("init milvus-storage shared reader pool, threads: {}",
+             std::max(num, 1));
 }
 
 void


### PR DESCRIPTION
issue: #48060

## Problem

After #47904 refactored `ManifestGroupTranslator::get_cells()` to streaming (per-batch) loading, QueryNode enters CrashLoopBackOff when loading many sealed segments with large VARCHAR columns under a container CPU limit: the etcd session lease expires mid-load and the node self-terminates (see #48060 for the full report and bisect).

Root cause, confirmed by reading the code and by a local quantitative reproduction:

1. **Batch tasks do CPU-heavy work on the shared load pool.** Each `LoadCellBatchAsync` task runs on the HIGH-priority segcore pool (capped at 16 threads) and performs not only the read but also the chunk finalization (`NormalizeArrowForChunkWriter` + `create_group_chunk`) — pure CPU work for large VARCHAR data.
2. **Reads inside a batch are serial.** `MakeChunkReaderFactory` hardcodes `get_chunks(rg_indices, /*parallelism=*/1)`, ignoring the `read_parallelism` that `BatchReadParallelism()` computes, so each cgo call pins its OS thread for a long time and the whole load stretches out.
3. **No shared reader pool.** Nothing initializes `milvus_storage::ThreadPoolHolder`, so any parallel `get_chunks()` call would spin up an ephemeral `IOThreadPoolExecutor` per call, and `Reader::parallelism_` silently degrades to 1.

Under a k8s CPU limit the sustained fleet of CPU-bound pool threads (measured locally: ~28 CPU-hot threads against an 8-CPU quota) exhausts the CFS quota early in every period, freezing the whole cgroup — including the Go runtime and its etcd keepalive goroutine — for most of every 100ms period, for the entire duration of the load storm. In the reproduction, 100% of CFS periods were throttled during load and in-process gRPC dials started failing with `context deadline exceeded`; in the incident environment this escalates to etcd keepalive `DeadlineExceeded` → lease expiry → self-kill → coordinator re-dispatch → crash loop.

## Fix

1. `LoadCellBatchAsync` batch tasks now always push raw Arrow tables; consumers (translator `get_cells`, already parked on the channel) finalize cells on their own thread. The `CellFinalizeFunc` path is removed entirely so CPU-heavy work cannot silently migrate back onto the shared load pool. The streaming memory bound of #47904 is unchanged: the transient budget is still acquired by producers and released by the consumer after finalization.
2. `MakeChunkReaderFactory` passes the computed `read_parallelism` to `ChunkReader::get_chunks()` instead of hardcoding 1. This restores the intra-batch parallel reads that existed before the streaming refactor (this is **not** a revert of #47904 — the streaming structure and its memory bound are fully kept; only the read parallelism that the refactor incidentally dropped is brought back), shortening the time each cgo call pins its OS thread.
3. `InitCpuNum` initializes the milvus-storage `ThreadPoolHolder` singleton sized by the CPU budget (GOMAXPROCS-aware), so parallel readers share one bounded pool instead of creating an ephemeral pool per call.

## Local verification

Environment: standalone (master) with MinIO, 60 sealed segments (~17.6 GB raw), schema mirroring the failing benchmark (3-dim vector + VARCHAR 256/32768/65535 all filled, INVERTED on all three, IVF_FLAT, sync warmup), run under `systemd-run` scopes with `CPUQuota=800%` to mirror the incident pod's 8-CPU limit (GOMAXPROCS=8, HIGH pool=16 — same as the incident). Cold load, clean boot, identical data/config for both binaries:

| metric (8-CPU quota) | master | this PR |
|---|---|---|
| `load_collection` wall time | 42.9 s | **30.1 s (1.43×)** |
| cgroup throttled time during load | 168 CPU-s | **105 CPU-s (−38%)** |
| in-process gRPC dial timeouts during load window | 11 | **0** |
| QueryNode RSS peak (streaming memory bound kept) | 31.0 GB | 30.9 GB |

Correctness after load with the fix: `count(*)` exact (180,000), boundary-row VARCHAR lengths exact, vector search returns the mathematically expected pks (query vector maps to `pk ≡ 211 (mod 1001)`; top-5 hits were 211/1212/2213/3214/4215 at distance 0).

Note on reproducing the lease expiry itself: with a localhost etcd (sub-ms RTT) the clientv3 keepalive survives even at 4-CPU quota with an added 20 ms RTT proxy, so the local run demonstrates the starvation mechanism (100% throttled CFS periods + control-plane RPC timeouts) rather than the final lease death. It would be great if QA could re-run `test_inverted_locust_varchar_dml_dql_streaming_cluster` (the reproducer from #48060) against this PR's image for the authoritative check. /cc @wangting0128

## Tests

- Updated `MemoryPlannerTest`: batch tasks must push raw tables (the consumer-finalize contract); all 12 `LoadCellBatchAsync`/planner tests pass.
- `ManifestGroupTranslatorTest` + `GroupChunkTranslatorTest` (16 tests) pass unchanged — `get_cells()` external behavior is identical.
- Full C++ `all_tests` and `go test ./internal/util/segcore/... ./internal/querynodev2/segments/...` pass locally (only pre-existing failures, none introduced).

## Follow-ups (out of scope)

- Async-CGO (futures) for `LoadFieldData` as suggested in the issue: parked cgo threads do not consume CPU quota, so it is not required to fix the crash loop, but it would be a nice structural improvement.
- Related: #47430.
