### PR TITLE
enhance: consume replayed inserts under their era schema on streaming node (#51117)

### DIFF
--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -218,6 +218,43 @@ ParseFlushSchema(const void* schema_blob, const int64_t schema_length) {
     return milvus::Schema::ParseFrom(collection_schema);
 }
 
+CStatus
+NewGrowingSegmentWithSchema(CCollection collection,
+                            int64_t segment_id,
+                            CSegmentInterface* newSegment,
+                            const uint8_t* schema_blob,
+                            const int64_t schema_length,
+                            const uint64_t schema_version,
+                            const uint8_t* load_info_blob,
+                            const int64_t load_info_length) {
+    SCOPE_CGO_CALL_METRIC();
+
+    try {
+        auto col = static_cast<milvus::segcore::Collection*>(collection);
+        // Build the segment columns from the explicit (era) schema instead of
+        // the collection's current schema; the segment upgrades to newer schema
+        // versions through the regular LazyCheckSchema/Reopen path afterwards.
+        auto schema =
+            ParseReopenSchema(schema_blob, schema_length, schema_version);
+        auto segment = milvus::segcore::CreateGrowingSegment(
+            schema,
+            col->get_index_meta(),
+            segment_id,
+            milvus::segcore::SegcoreConfig::default_config());
+        if (load_info_blob != nullptr && load_info_length > 0) {
+            milvus::proto::segcore::SegmentLoadInfo load_info;
+            auto suc =
+                load_info.ParseFromArray(load_info_blob, load_info_length);
+            AssertInfo(suc, "unmarshal load info failed");
+            segment->SetLoadInfo(std::move(load_info));
+        }
+        *newSegment = segment.release();
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
 CFuture*
 AsyncReopenSegment(CTraceContext c_trace,
                    CSegmentInterface c_segment,

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -59,6 +59,35 @@ NewSegmentWithLoadInfo(CCollection collection,
                        bool is_sorted_by_pk,
                        const uint8_t* load_info_blob,
                        const int64_t load_info_length);
+
+/**
+ * @brief Create a new growing segment with an explicit schema
+ * Unlike NewSegmentWithLoadInfo, the segment columns are built from the given
+ * schema blob instead of the collection's current schema. Used on WAL replay to
+ * rebuild a growing segment under the schema in effect when its data was
+ * written (its era schema), so replayed payloads always match the column set.
+ *
+ * @param collection: The collection that this segment belongs to (index meta source)
+ * @param segment_id: Unique identifier for this segment
+ * @param newSegment: Output parameter for the created segment interface
+ * @param schema_blob: Serialized CollectionSchema proto the columns are built from
+ * @param schema_length: Length of schema_blob in bytes
+ * @param schema_version: segcore schema version token for the created segment;
+ *        pass a token lower than the collection's current one (e.g. 0) so the
+ *        first query's LazyCheckSchema upgrades the segment schema in place
+ * @param load_info_blob: Serialized load information blob (optional, may be null)
+ * @param load_info_length: Length of load_info_blob in bytes
+ * @return CStatus indicating success or failure
+ */
+CStatus
+NewGrowingSegmentWithSchema(CCollection collection,
+                            int64_t segment_id,
+                            CSegmentInterface* newSegment,
+                            const uint8_t* schema_blob,
+                            const int64_t schema_length,
+                            const uint64_t schema_version,
+                            const uint8_t* load_info_blob,
+                            const int64_t load_info_length);
 /**
  * @brief Dispatch a segment manage load task.
  * This function make segment itself load index & field data according to load info previously set.

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -130,6 +130,12 @@ type InsertData struct {
 
 	StartPosition *msgpb.MsgPosition
 	PartitionID   int64
+	// Schema optionally carries the era schema the insert payload was written
+	// under (resolved from the wal recovery storage on replay). When set, a
+	// growing segment created for this data builds its columns from it instead
+	// of the collection's current schema, so the payload always matches the
+	// segment column set. Nil on the live path.
+	Schema *schemapb.CollectionSchema
 }
 
 type DeleteData struct {
@@ -178,6 +184,9 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 					DeltaPosition: insertData.StartPosition,
 					Level:         datapb.SegmentLevel_L1,
 				},
+				// nil on the live path; on replay carries the payload's era
+				// schema so the segment columns match the replayed data.
+				segments.WithCreationSchema(insertData.Schema),
 			)
 			if err != nil {
 				log.Error(context.TODO(), "failed to create new segment",

--- a/internal/querynodev2/pipeline/insert_node.go
+++ b/internal/querynodev2/pipeline/insert_node.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/registry"
 	"github.com/milvus-io/milvus/internal/util/function"
 	base "github.com/milvus-io/milvus/internal/util/pipeline"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -45,8 +46,27 @@ type insertNode struct {
 	functionStore *function.FunctionRunnerLocalStore
 }
 
-func (iNode *insertNode) addInsertData(insertDatas map[UniqueID]*delegator.InsertData, msg *InsertMsg, collection *Collection) {
-	insertRecord, err := storage.TransferInsertMsgToInsertRecord(collection.Schema(), msg)
+// verifyPayloadFields checks the payload columns against the message's own era
+// schema. Era-consistent producers (proxy validation plus WAL-append
+// materialization) never emit a column outside the schema the message was
+// written under, so a payload field missing from its era schema can only be a
+// corrupted payload and must not be silently dropped. When no era schema is
+// available (fallback to the current schema), this check is skipped by the
+// caller: an unknown field there is either a since-dropped field skipped by the
+// downstream filter, or left to segcore's own invariant check.
+func (iNode *insertNode) verifyPayloadFields(msg *InsertMsg, eraSchema *schemapb.CollectionSchema, eraFields typeutil.Set[int64]) error {
+	for _, fieldData := range msg.GetFieldsData() {
+		if !eraFields.Contain(fieldData.GetFieldId()) {
+			return merr.WrapErrServiceInternal(fmt.Sprintf(
+				"insert payload of segment %d carries field %d absent from its era schema (version %d), payload is corrupted",
+				msg.SegmentID, fieldData.GetFieldId(), eraSchema.GetVersion()))
+		}
+	}
+	return nil
+}
+
+func (iNode *insertNode) addInsertData(insertDatas map[UniqueID]*delegator.InsertData, msg *InsertMsg, schemaForMsg *schemapb.CollectionSchema, eraForCreation *schemapb.CollectionSchema) {
+	insertRecord, err := storage.TransferInsertMsgToInsertRecord(schemaForMsg, msg)
 	if err != nil {
 		err = merr.Wrap(err, "failed to get primary keys")
 		mlog.Error(context.TODO(), err.Error(), mlog.Int64("collectionID", iNode.collectionID), mlog.String("channel", iNode.channel))
@@ -61,6 +81,10 @@ func (iNode *insertNode) addInsertData(insertDatas map[UniqueID]*delegator.Inser
 				Timestamp:   msg.BeginTs(),
 				ChannelName: msg.GetShardName(),
 			},
+			// The first message decides the creation schema of a not-yet-known
+			// growing segment; the fence on schema change guarantees all its
+			// messages share one era.
+			Schema: eraForCreation,
 		}
 		insertDatas[msg.SegmentID] = iData
 	} else {
@@ -72,12 +96,12 @@ func (iNode *insertNode) addInsertData(insertDatas map[UniqueID]*delegator.Inser
 		iData.InsertRecord.NumRows += insertRecord.NumRows
 	}
 
-	if err := iNode.appendBM25Stats(iData, msg, collection.Schema()); err != nil {
+	if err := iNode.appendBM25Stats(iData, msg, schemaForMsg); err != nil {
 		mlog.Error(context.TODO(), "failed to append BM25 stats from insert message", mlog.String("channel", iNode.channel), mlog.Err(err))
 		panic(err)
 	}
 
-	pks, err := segments.GetPrimaryKeys(msg, collection.Schema())
+	pks, err := segments.GetPrimaryKeys(msg, schemaForMsg)
 	if err != nil {
 		mlog.Error(context.TODO(), "failed to get primary keys from insert message", mlog.Err(err))
 		panic(err)
@@ -114,21 +138,69 @@ func (iNode *insertNode) Operate(in Msg) Msg {
 			panic("insertNode with collection not exist")
 		}
 		schema := collection.Schema()
-		functionOutputFieldIDs, err := iNode.functionStore.OutputFieldIDs(schema)
-		if err != nil {
-			mlog.Error(context.TODO(), "failed to get embedding output fields", mlog.String("channel", iNode.channel), mlog.Err(err))
-			panic(err)
+
+		// The era-schema resolver exists only when this process serves the
+		// channel's WAL (streaming node). The era schema equals the current
+		// schema on the live path and differs only while replaying messages
+		// written before later schema changes.
+		resolver, resolverErr := registry.GetLocalSchemaResolver(iNode.channel)
+
+		// Field-id sets memoized per distinct schema snapshot in this batch.
+		fieldSets := make(map[*schemapb.CollectionSchema]typeutil.Set[int64])
+		getFieldSet := func(s *schemapb.CollectionSchema) typeutil.Set[int64] {
+			set, ok := fieldSets[s]
+			if !ok {
+				set = typeutil.NewSet[int64]()
+				for _, field := range typeutil.GetAllFieldSchemas(s) {
+					set.Insert(field.GetFieldID())
+				}
+				fieldSets[s] = set
+			}
+			return set
 		}
 
 		insertDatas := make(map[UniqueID]*delegator.InsertData)
 		for _, msg := range nodeMsg.insertMsgs {
+			// Interpret each message under the schema of its own era so that
+			// payload verification, function-output fill and segment creation
+			// all share one schema snapshot; fall back to the current schema
+			// when no local schema history is available.
+			schemaForMsg, isEra := schema, false
+			if resolverErr == nil {
+				eraSchema, err := resolver.GetSchema(context.TODO(), iNode.channel, msg.EndTs())
+				if err != nil || eraSchema == nil {
+					mlog.Warn(context.TODO(), "failed to resolve era schema for insert message, fall back to current schema",
+						mlog.String("channel", iNode.channel),
+						mlog.Uint64("timetick", msg.EndTs()),
+						mlog.Err(err))
+				} else {
+					schemaForMsg, isEra = eraSchema, true
+				}
+			}
+			if isEra {
+				if err := iNode.verifyPayloadFields(msg, schemaForMsg, getFieldSet(schemaForMsg)); err != nil {
+					mlog.Error(context.TODO(), "corrupted insert payload detected", mlog.String("channel", iNode.channel), mlog.Err(err))
+					panic(err)
+				}
+			}
+			functionOutputFieldIDs, err := iNode.functionStore.OutputFieldIDs(schemaForMsg)
+			if err != nil {
+				mlog.Error(context.TODO(), "failed to get embedding output fields", mlog.String("channel", iNode.channel), mlog.Err(err))
+				panic(err)
+			}
 			if len(functionOutputFieldIDs) > 0 && !function.HasAllFieldDataByID(msg.GetFieldsData(), functionOutputFieldIDs) {
-				if err := iNode.functionStore.FillEmbeddingData(iNode.collectionID, schema, msg.InsertRequest); err != nil {
+				if err := iNode.functionStore.FillEmbeddingData(iNode.collectionID, schemaForMsg, msg.InsertRequest); err != nil {
 					mlog.Error(context.TODO(), "failed to fill embedding data for insert message", mlog.String("channel", iNode.channel), mlog.Err(err))
 					panic(err)
 				}
 			}
-			iNode.addInsertData(insertDatas, msg, collection)
+			// Only a genuinely older era schema is carried to segment creation;
+			// the live path (era == current) keeps the existing creation flow.
+			eraForCreation := schemaForMsg
+			if !isEra || schemaForMsg.GetVersion() == schema.GetVersion() {
+				eraForCreation = nil
+			}
+			iNode.addInsertData(insertDatas, msg, schemaForMsg, eraForCreation)
 		}
 
 		iNode.delegator.ProcessInsert(insertDatas)

--- a/internal/querynodev2/pipeline/insert_node_payload_test.go
+++ b/internal/querynodev2/pipeline/insert_node_payload_test.go
@@ -1,0 +1,66 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func TestInsertNodeVerifyPayloadFields(t *testing.T) {
+	paramtable.Init()
+	iNode := &insertNode{channel: "by-dev-rootcoord-dml_0_100v0"}
+
+	eraSchema := &schemapb.CollectionSchema{
+		Version: 104,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100},
+			{FieldID: 101},
+			{FieldID: 158}, // dropped from the current schema since v104
+		},
+	}
+	eraFields := typeutil.NewSet[int64](100, 101, 158)
+
+	newMsg := func(fieldIDs ...int64) *InsertMsg {
+		fieldsData := make([]*schemapb.FieldData, 0, len(fieldIDs))
+		for _, id := range fieldIDs {
+			fieldsData = append(fieldsData, &schemapb.FieldData{FieldId: id})
+		}
+		return &InsertMsg{
+			BaseMsg: msgstream.BaseMsg{EndTimestamp: 1000},
+			InsertRequest: &msgpb.InsertRequest{
+				SegmentID:  1,
+				FieldsData: fieldsData,
+			},
+		}
+	}
+
+	// payload within its era schema, including a since-dropped field: valid.
+	assert.NoError(t, iNode.verifyPayloadFields(newMsg(100, 101, 158), eraSchema, eraFields))
+
+	// payload carries a field absent from its own era schema: corrupted.
+	err := iNode.verifyPayloadFields(newMsg(100, 159), eraSchema, eraFields)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "corrupted")
+}

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -395,12 +395,30 @@ type LocalSegment struct {
 	fieldJSONStatsMu   sync.RWMutex
 }
 
+// creationOption customizes segcore segment creation.
+type creationOption func(*creationOptions)
+
+type creationOptions struct {
+	schema *schemapb.CollectionSchema
+}
+
+// WithCreationSchema builds a growing segment's columns from the given (era)
+// schema instead of the collection's current schema. Used on WAL replay so the
+// replayed payloads always match the segment column set; the segment upgrades
+// to the collection's current schema through the regular LazyCheckSchema path.
+func WithCreationSchema(schema *schemapb.CollectionSchema) creationOption {
+	return func(o *creationOptions) {
+		o.schema = schema
+	}
+}
+
 func NewSegment(ctx context.Context,
 	collection *Collection,
 	manager SegmentManager,
 	segmentType SegmentType,
 	version int64,
 	loadInfo *querypb.SegmentLoadInfo,
+	opts ...creationOption,
 ) (Segment, error) {
 	/*
 		CStatus
@@ -408,6 +426,10 @@ func NewSegment(ctx context.Context,
 	*/
 	if loadInfo.GetLevel() == datapb.SegmentLevel_L0 {
 		return NewL0Segment(collection, segmentType, version, loadInfo)
+	}
+	creationOpts := &creationOptions{}
+	for _, opt := range opts {
+		opt(creationOpts)
 	}
 
 	base, err := newBaseSegment(collection, segmentType, version, loadInfo)
@@ -442,6 +464,7 @@ func NewSegment(ctx context.Context,
 			SegmentType: segmentType,
 			IsSorted:    loadInfo.GetIsSorted(),
 			LoadInfo:    loadInfo,
+			Schema:      creationOpts.schema,
 		})
 		return nil, err
 	}).Await(); err != nil {

--- a/internal/querynodev2/segments/segment_creation_schema_test.go
+++ b/internal/querynodev2/segments/segment_creation_schema_test.go
@@ -1,0 +1,133 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segments
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// TestNewGrowingSegmentWithCreationSchema simulates the WAL-replay scenario of
+// issue #51117: the collection schema has dropped a field, while the replayed
+// insert payload still carries its column. A growing segment created with the
+// payload's era schema accepts the payload; one created with the current schema
+// rejects it (segcore unknown-field invariant).
+func TestNewGrowingSegmentWithCreationSchema(t *testing.T) {
+	ctx := context.Background()
+	paramtable.Init()
+	initcore.InitRemoteChunkManager(paramtable.Get())
+	initcore.InitLocalChunkManager(t.Name())
+	initcore.InitMmapManager(paramtable.Get(), 1)
+	initcore.InitTieredStorage(paramtable.Get())
+
+	const (
+		collectionID   = int64(200)
+		partitionID    = int64(20)
+		droppedFieldID = int64(199)
+		msgLength      = 8
+	)
+
+	// Current schema: the era field has been dropped since.
+	currentSchema := mock_segcore.GenTestCollectionSchema("test-era-creation", schemapb.DataType_Int64, true)
+	// Era schema: current schema plus the since-dropped VarChar field.
+	eraSchema := proto.Clone(currentSchema).(*schemapb.CollectionSchema)
+	eraSchema.Fields = append(eraSchema.Fields, &schemapb.FieldSchema{
+		FieldID:  droppedFieldID,
+		Name:     "dropped_field",
+		DataType: schemapb.DataType_VarChar,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: "max_length", Value: "64"},
+		},
+	})
+
+	manager := NewManager()
+	err := manager.Collection.PutOrRef(collectionID, currentSchema,
+		mock_segcore.GenTestIndexMeta(collectionID, currentSchema),
+		&querypb.LoadMetaInfo{
+			LoadType:     querypb.LoadType_LoadCollection,
+			CollectionID: collectionID,
+			PartitionIDs: []int64{partitionID},
+		})
+	require.NoError(t, err)
+	collection := manager.Collection.Get(collectionID)
+	defer DeleteCollection(collection)
+
+	newLoadInfo := func(segmentID int64) *querypb.SegmentLoadInfo {
+		return &querypb.SegmentLoadInfo{
+			SegmentID:     segmentID,
+			CollectionID:  collectionID,
+			PartitionID:   partitionID,
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", collectionID),
+			Level:         datapb.SegmentLevel_L1,
+		}
+	}
+	newEraPayload := func(segmentID int64) ([]int64, []uint64, *segcorepb.InsertRecord) {
+		insertMsg, err := mock_segcore.GenInsertMsg(collection.GetCCollection(), partitionID, segmentID, msgLength)
+		require.NoError(t, err)
+		droppedData := make([]string, msgLength)
+		for i := range droppedData {
+			droppedData[i] = fmt.Sprintf("dropped-%d", i)
+		}
+		insertMsg.FieldsData = append(insertMsg.FieldsData, &schemapb.FieldData{
+			Type:      schemapb.DataType_VarChar,
+			FieldName: "dropped_field",
+			FieldId:   droppedFieldID,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{Data: droppedData},
+					},
+				},
+			},
+		})
+		insertRecord, err := storage.TransferInsertMsgToInsertRecord(eraSchema, insertMsg)
+		require.NoError(t, err)
+		return insertMsg.RowIDs, insertMsg.Timestamps, insertRecord
+	}
+
+	// A segment created with the era schema owns the dropped field's column and
+	// accepts the replayed payload.
+	eraSegment, err := NewSegment(ctx, collection, manager.Segment, SegmentTypeGrowing, 0,
+		newLoadInfo(1), WithCreationSchema(eraSchema))
+	require.NoError(t, err)
+	defer eraSegment.Release(ctx)
+	rowIDs, timestamps, insertRecord := newEraPayload(eraSegment.ID())
+	require.NoError(t, eraSegment.Insert(ctx, rowIDs, timestamps, insertRecord))
+
+	// A segment created with the current schema has no such column and must
+	// reject the same payload (segcore unknown-field invariant).
+	currentSegment, err := NewSegment(ctx, collection, manager.Segment, SegmentTypeGrowing, 0,
+		newLoadInfo(2))
+	require.NoError(t, err)
+	defer currentSegment.Release(ctx)
+	rowIDs, timestamps, insertRecord = newEraPayload(currentSegment.ID())
+	require.Error(t, currentSegment.Insert(ctx, rowIDs, timestamps, insertRecord))
+}

--- a/internal/streamingnode/client/handler/registry/schema_resolver.go
+++ b/internal/streamingnode/client/handler/registry/schema_resolver.go
@@ -1,0 +1,59 @@
+package registry
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// ErrNoSchemaResolver is returned when no schema resolver is registered for the
+// pchannel of the requested vchannel (no streaming node in this process, the WAL
+// of that pchannel is not served locally, or it is shutting down).
+var ErrNoSchemaResolver = errors.New("no schema resolver registered for channel")
+
+// schemaResolvers routes pchannel name -> the resolver registered by the local
+// wal flusher owning that pchannel's recovery storage. Unlike the process-wide
+// wal manager future, presence in this map is the single source of truth, so no
+// role gate is applied here: an empty map simply means no local resolver.
+var schemaResolvers = typeutil.NewConcurrentMap[string, LocalSchemaResolver]()
+
+// LocalSchemaResolver resolves the collection schema of a vchannel in effect at
+// the given timetick, backed by the wal recovery storage's persisted schema
+// history. The history is pruned past the flusher checkpoint (minus a tolerance),
+// so lookups within the replayable window always succeed; callers MUST fall back
+// to the current collection schema on any error.
+type LocalSchemaResolver interface {
+	GetSchema(ctx context.Context, vchannel string, timetick uint64) (*schemapb.CollectionSchema, error)
+}
+
+// RegisterLocalSchemaResolver registers the schema resolver of one pchannel.
+// It is called by the local wal flusher when its recovery storage is ready;
+// a re-registration after a pchannel term bump overwrites the previous one.
+func RegisterLocalSchemaResolver(pchannel string, resolver LocalSchemaResolver) {
+	schemaResolvers.Insert(pchannel, resolver)
+	mlog.Info(context.TODO(), "register local schema resolver done", mlog.String("pchannel", pchannel))
+}
+
+// UnregisterLocalSchemaResolver removes the schema resolver of one pchannel.
+// It is called by the local wal flusher on close, BEFORE closing the recovery
+// storage, so a resolver obtained from the registry never outlives its backing
+// storage.
+func UnregisterLocalSchemaResolver(pchannel string) {
+	schemaResolvers.Remove(pchannel)
+	mlog.Info(context.TODO(), "unregister local schema resolver done", mlog.String("pchannel", pchannel))
+}
+
+// GetLocalSchemaResolver returns the schema resolver serving the given vchannel,
+// or ErrNoSchemaResolver when the vchannel's pchannel is not served locally.
+func GetLocalSchemaResolver(vchannel string) (LocalSchemaResolver, error) {
+	resolver, ok := schemaResolvers.Get(funcutil.ToPhysicalChannel(vchannel))
+	if !ok {
+		return nil, ErrNoSchemaResolver
+	}
+	return resolver, nil
+}

--- a/internal/streamingnode/client/handler/registry/schema_resolver_test.go
+++ b/internal/streamingnode/client/handler/registry/schema_resolver_test.go
@@ -1,0 +1,47 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+type fakeSchemaResolver struct {
+	schema *schemapb.CollectionSchema
+}
+
+func (r *fakeSchemaResolver) GetSchema(ctx context.Context, vchannel string, timetick uint64) (*schemapb.CollectionSchema, error) {
+	return r.schema, nil
+}
+
+func TestLocalSchemaResolverRegistry(t *testing.T) {
+	defer ResetRegisterLocalSchemaResolvers()
+
+	pchannel := "by-dev-rootcoord-dml_0"
+	vchannel := "by-dev-rootcoord-dml_0_123456v0"
+
+	// no resolver registered for the pchannel yet.
+	_, err := GetLocalSchemaResolver(vchannel)
+	assert.ErrorIs(t, err, ErrNoSchemaResolver)
+
+	resolver := &fakeSchemaResolver{schema: &schemapb.CollectionSchema{Name: "test", Version: 42}}
+	RegisterLocalSchemaResolver(pchannel, resolver)
+
+	got, err := GetLocalSchemaResolver(vchannel)
+	assert.NoError(t, err)
+	schema, err := got.GetSchema(context.Background(), vchannel, 100)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(42), schema.GetVersion())
+
+	// another pchannel is still unregistered.
+	_, err = GetLocalSchemaResolver("by-dev-rootcoord-dml_1_123456v0")
+	assert.ErrorIs(t, err, ErrNoSchemaResolver)
+
+	// unregister removes the resolver.
+	UnregisterLocalSchemaResolver(pchannel)
+	_, err = GetLocalSchemaResolver(vchannel)
+	assert.ErrorIs(t, err, ErrNoSchemaResolver)
+}

--- a/internal/streamingnode/client/handler/registry/test_utility.go
+++ b/internal/streamingnode/client/handler/registry/test_utility.go
@@ -3,9 +3,16 @@
 
 package registry
 
-import "github.com/milvus-io/milvus/pkg/v3/util/syncutil"
+import (
+	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
 
 func ResetRegisterLocalWALManager() {
 	registry = syncutil.NewFuture[WALManager]()
 	releaseManualFlushPreparerRegistry = syncutil.NewFuture[ReleaseManualFlushPreparer]()
+}
+
+func ResetRegisterLocalSchemaResolvers() {
+	schemaResolvers = typeutil.NewConcurrentMap[string, LocalSchemaResolver]()
 }

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/flushcommon/broker"
 	"github.com/milvus-io/milvus/internal/flushcommon/util"
+	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/registry"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/adaptor/rate"
@@ -53,8 +54,13 @@ func RecoverWALFlusher(param *RecoverWALFlusherParam) *WALFlusherImpl {
 		metrics:              newFlusherMetrics(param.ChannelInfo),
 		emptyTimeTickCounter: metrics.WALFlusherEmptyTimeTickFilteredTotal.WithLabelValues(paramtable.GetStringNodeID(), param.ChannelInfo.Name),
 		rateLimitComponent:   param.RateLimitComponent,
+		pchannel:             param.ChannelInfo.Name,
 		RecoveryStorage:      param.RecoveryStorage,
 	}
+	// The recovery storage is already recovered here; expose its persisted schema
+	// history to local consumers (e.g. the embedded querynode pipeline) so replayed
+	// messages can be interpreted under their own era schema.
+	registry.RegisterLocalSchemaResolver(flusher.pchannel, param.RecoveryStorage)
 	go flusher.Execute(param.RecoverySnapshot)
 	return flusher
 }
@@ -68,6 +74,7 @@ type WALFlusherImpl struct {
 	lastDispatchTimeTick uint64 // The last time tick that the message is dispatched.
 	emptyTimeTickCounter prometheus.Counter
 	rateLimitComponent   *rate.WALRateLimitComponent
+	pchannel             string
 	recovery.RecoveryStorage
 }
 
@@ -144,6 +151,10 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 func (impl *WALFlusherImpl) Close() {
 	impl.notifier.Cancel()
 	impl.notifier.BlockUntilFinish()
+
+	// Unregister BEFORE closing the recovery storage so a resolver obtained from
+	// the registry never outlives its backing storage.
+	registry.UnregisterLocalSchemaResolver(impl.pchannel)
 
 	impl.logger.Info(context.TODO(), "wal flusher start to close the recovery storage...")
 	impl.RecoveryStorage.Close()

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/cgo"
@@ -51,6 +52,12 @@ type CreateCSegmentRequest struct {
 	SegmentType SegmentType
 	IsSorted    bool
 	LoadInfo    *querypb.SegmentLoadInfo
+	// Schema optionally builds a GROWING segment's columns from this (era)
+	// schema instead of the collection's current schema; used on WAL replay so
+	// replayed payloads always match the segment column set. The segment is
+	// created with segcore schema version 0 so the first query's
+	// LazyCheckSchema upgrades it to the collection's current schema in place.
+	Schema *schemapb.CollectionSchema
 }
 
 func (req *CreateCSegmentRequest) getCSegmentType() C.SegmentType {
@@ -70,7 +77,29 @@ func (req *CreateCSegmentRequest) getCSegmentType() C.SegmentType {
 func CreateCSegment(req *CreateCSegmentRequest) (CSegment, error) {
 	var ptr C.CSegmentInterface
 	var status C.CStatus
-	if req.LoadInfo != nil {
+	if req.Schema != nil {
+		if req.SegmentType != SegmentTypeGrowing {
+			return nil, merr.WrapErrServiceInternal("explicit schema is only supported for growing segment creation")
+		}
+		schemaBlob, err := proto.Marshal(req.Schema)
+		if err != nil {
+			return nil, err
+		}
+		var loadInfoBlob []byte
+		if req.LoadInfo != nil {
+			segLoadInfo := ConvertToSegcoreSegmentLoadInfo(req.LoadInfo)
+			if loadInfoBlob, err = proto.Marshal(segLoadInfo); err != nil {
+				return nil, err
+			}
+		}
+		var loadInfoPtr *C.uint8_t
+		if len(loadInfoBlob) > 0 {
+			loadInfoPtr = (*C.uint8_t)(unsafe.Pointer(&loadInfoBlob[0]))
+		}
+		status = C.NewGrowingSegmentWithSchema(req.Collection.rawPointer(), C.int64_t(req.SegmentID), &ptr,
+			(*C.uint8_t)(unsafe.Pointer(&schemaBlob[0])), C.int64_t(len(schemaBlob)), C.uint64_t(0),
+			loadInfoPtr, C.int64_t(len(loadInfoBlob)))
+	} else if req.LoadInfo != nil {
 		segLoadInfo := ConvertToSegcoreSegmentLoadInfo(req.LoadInfo)
 		loadInfoBlob, err := proto.Marshal(segLoadInfo)
 		if err != nil {


### PR DESCRIPTION
## What

Interpret every replayed insert message on the StreamingNode consume path under the schema of its own era (the schema in effect at the message's timetick), restoring deterministic WAL replay for growing segments:

1. **Schema history exposure**: the wal flusher registers its `RecoveryStorage` (whose persisted schema history covers the replayable window) as a per-pchannel schema resolver via the existing local registry pattern (`streamingnode/client/handler/registry`); unregistered before the storage closes.
2. **Era-consistent insert path**: the querynode `insertNode` resolves the era schema per message and uses that single snapshot for payload verification, function-output fill, and insert-record conversion. A payload field absent from its own era schema can only be a corrupted payload and is rejected instead of silently dropped. When no local resolver is available (no streaming node in this process, pruned history), the current-schema behavior applies unchanged.
3. **Era segment creation**: a growing segment created for replayed data builds its segcore columns from the era schema through a new `NewGrowingSegmentWithSchema` cgo entry (created at segcore schema version 0, so the first query's `LazyCheckSchema` upgrades it to the current schema in place). The live path (era == current) keeps the existing creation flow.

## Why

Root cause chain of #51117 (fully log-verified there): after a field is dropped, WAL replay redelivers a pre-drop insert whose payload still carries the dropped field's column; the growing segment is rebuilt from the coord's current schema (coord meta lives at the WAL head; the schema-version gate correctly refuses rollback), so `SegmentGrowingImpl::Insert` hits the unknown-field assert → StreamingNode panics → the checkpoint never passes the message → CrashLoopBackOff.

PR #51137 stops the crash by skipping payload columns absent from the current schema. This enhancement makes replay era-deterministic instead: create/fill/verify/convert all share the message-era schema snapshot, so replayed payloads always match the segment column set, no data column needs dropping at insert time (the flush schema discards dead columns later), and the segcore unknown-field assert stays a strong invariant. It also distinguishes a legitimately dropped field from a genuinely corrupted payload, which the current-schema skip-filter cannot.

## Key invariant

create / fill / filter must use ONE schema snapshot per message; mixing eras (e.g. era-created segment + current-schema fill) reintroduces the crash. Hence the per-message resolution rather than a per-batch one — one pack can straddle schema changes.

## Tests

- `registry`: resolver register/unregister/route UT (pure Go, passed locally).
- `pipeline`: `verifyPayloadFields` corruption-vs-valid UT.
- `segments`: cgo end-to-end repro of the #51117 scenario — an era-created growing segment accepts a payload carrying a since-dropped field, while a current-schema segment rejects the same payload.

## Notes

- Logically depends on #51137 (the current-schema skip-filter remains the fallback whenever the era schema is unavailable); no textual conflict — different files.
- `LoadGrowing` (watch-time load of unflushed segments) keeps current-schema creation; its loaded data is pull-model and unaffected.
- The per-message `RecoveryStorage.GetSchema` lookup is an RLock plus a short reverse scan, comparable to the flush-side writeNode's existing per-timetick schema lookups.

issue: #51117