### PR TITLE
fix: clean analyzer option update

### DIFF
--- a/internal/util/analyzer/canalyzer/c_analyzer_factory.go
+++ b/internal/util/analyzer/canalyzer/c_analyzer_factory.go
@@ -47,7 +47,7 @@ func InitOptions() error {
 		return nil
 	}
 
-	if err := UpdateParams(); err != nil {
+	if err := updateParams(); err != nil {
 		return err
 	}
 
@@ -77,10 +77,6 @@ func buildLinderaDownloadURLs(values map[string]string) map[string][]string {
 	return urls
 }
 
-func UpdateParams() error {
-	return updateParams()
-}
-
 func updateParams() error {
 	bytes, err := json.Marshal(BuildRuntimeOptions())
 	if err != nil {
@@ -91,10 +87,7 @@ func updateParams() error {
 	defer C.free(unsafe.Pointer(paramPtr))
 
 	status := C.set_tokenizer_option(paramPtr)
-	if err := HandleCStatus(&status, "failed to init segcore analyzer option"); err != nil {
-		return err
-	}
-	return nil
+	return HandleCStatus(&status, "failed to init segcore analyzer option")
 }
 
 func BuildExtraResourceInfo(storage string, resources []*internalpb.FileResourceInfo) (string, error) {

--- a/internal/util/analyzer/canalyzer/c_analyzer_test.go
+++ b/internal/util/analyzer/canalyzer/c_analyzer_test.go
@@ -182,7 +182,7 @@ func TestValidateAnalyzer(t *testing.T) {
 	{
 		resourcePath := pathutil.GetPath(pathutil.FileResourcePath, paramtable.GetNodeID())
 		defer os.RemoveAll(resourcePath)
-		require.NoError(t, UpdateParams())
+		require.NoError(t, updateParams())
 		resourceID := int64(100)
 
 		// mock remote resource file
@@ -208,7 +208,7 @@ func TestValidateAnalyzer(t *testing.T) {
 	{
 		resourcePath := pathutil.GetPath(pathutil.FileResourcePath, paramtable.GetNodeID())
 		defer os.RemoveAll(resourcePath)
-		require.NoError(t, UpdateParams())
+		require.NoError(t, updateParams())
 		resourceID := int64(100)
 
 		// mock remote resource file


### PR DESCRIPTION
issue: #50931

## Summary
Clean analyzer option update helpers on master to match the 2.6 follow-up.
Remove the exported UpdateParams wrapper and return C status handling directly during option initialization.