### PR TITLE
fix: treat unset IdField in zero-hit search results as empty in chain converter

### DIFF
--- a/internal/util/function/chain/converter.go
+++ b/internal/util/function/chain/converter.go
@@ -278,7 +278,11 @@ func FromSearchResultData(resultData *schemapb.SearchResultData, alloc memory.Al
 	}
 
 	// Import ID column ($id)
-	if ids := resultData.GetIds(); ids != nil {
+	// Zero-hit results may carry Ids as a non-nil shell whose IdField oneof is
+	// unset (e.g. querynode emptySearchResultData forwarded verbatim by the
+	// single-channel reduce fast path); it holds no IDs, so treat it exactly
+	// like Ids == nil.
+	if ids := resultData.GetIds(); ids.GetIdField() != nil {
 		if err := importIDs(builder, ids, offsets, alloc); err != nil {
 			return nil, err
 		}
@@ -287,6 +291,9 @@ func FromSearchResultData(resultData *schemapb.SearchResultData, alloc memory.Al
 		if err := importEmptyIDs(builder, offsets, alloc); err != nil {
 			return nil, err
 		}
+	} else if ids != nil {
+		// IdField unset but rows present: malformed input.
+		return nil, importIDs(builder, ids, offsets, alloc)
 	}
 
 	// Import Score column ($score)

--- a/internal/util/function/chain/converter_test.go
+++ b/internal/util/function/chain/converter_test.go
@@ -2461,6 +2461,76 @@ func (s *ConverterSuite) TestFromSearchResultData_UnsupportedIDType() {
 	s.Contains(err.Error(), "unsupported ID type")
 }
 
+// Zero-hit results reach the proxy as Ids=&schemapb.IDs{} with the IdField
+// oneof unset (e.g. querynode emptySearchResultData, single-channel reduce
+// passthrough). Such a shell carries no IDs and must take the same empty
+// path as Ids == nil instead of failing with "unsupported ID type" (#50969).
+func (s *ConverterSuite) TestFromSearchResultData_EmptyIDsZeroRows() {
+	for name, ids := range map[string]*schemapb.IDs{
+		"nil ids":             nil,
+		"shell without oneof": {}, // IDs with no IdField set
+	} {
+		for _, topks := range [][]int64{{0}, {0, 0}} {
+			resultData := &schemapb.SearchResultData{
+				NumQueries: int64(len(topks)),
+				TopK:       10,
+				Topks:      topks,
+				Scores:     []float32{},
+				Ids:        ids,
+				FieldsData: []*schemapb.FieldData{},
+			}
+
+			df, err := FromSearchResultData(resultData, s.pool, nil)
+			s.Require().NoError(err, name)
+			s.Equal(int64(0), df.NumRows(), name)
+			s.True(df.HasColumn(types.IDFieldName), name)
+			idType, ok := df.FieldType(types.IDFieldName)
+			s.True(ok, name)
+			// Int64 is the converter's schema-less empty-ID fallback, not necessarily the collection PK type.
+			s.Equal(schemapb.DataType_Int64, idType, name)
+			s.True(df.HasColumn(types.ScoreFieldName), name)
+			df.Release()
+		}
+	}
+}
+
+func (s *ConverterSuite) TestFromSearchResultData_EmptyIDsNoTopks() {
+	resultData := &schemapb.SearchResultData{
+		NumQueries: 0,
+		TopK:       10,
+		Topks:      []int64{},
+		Scores:     []float32{},
+		Ids:        &schemapb.IDs{},
+		FieldsData: []*schemapb.FieldData{},
+	}
+
+	df, err := FromSearchResultData(resultData, s.pool, nil)
+	s.Require().NoError(err)
+	defer df.Release()
+	s.Equal(int64(0), df.NumRows())
+	s.False(df.HasColumn(types.IDFieldName))
+	s.False(df.HasColumn(types.ScoreFieldName))
+}
+
+// Ids == nil with rows present is tolerated: the DataFrame is built without
+// an $id column (aggregation-style results carry no IDs). Pins the
+// pre-existing passthrough so it is not accidentally turned into an error.
+func (s *ConverterSuite) TestFromSearchResultData_NilIDsWithRows() {
+	resultData := &schemapb.SearchResultData{
+		NumQueries: 1,
+		TopK:       2,
+		Topks:      []int64{2},
+		Scores:     []float32{0.9, 0.8},
+	}
+
+	df, err := FromSearchResultData(resultData, s.pool, nil)
+	s.Require().NoError(err)
+	defer df.Release()
+	s.Equal(int64(2), df.NumRows())
+	s.False(df.HasColumn(types.IDFieldName))
+	s.True(df.HasColumn(types.ScoreFieldName))
+}
+
 // =============================================================================
 // exportFieldData unsupported type
 // =============================================================================


### PR DESCRIPTION
issue: #50969

### Problem

`hybrid_search` + `group_by` returning an empty result fails with `service internal error: unsupported ID type` (nightly `test_hybrid_search_group_by_empty_results`, master only). Despite the issue's original scope note, CI Loki shows the identical failure daily on the pulsar-based distributed deployment as well as both woodpecker deployments — the path is MQ-agnostic. Full RCA: https://github.com/milvus-io/milvus/issues/50969#issuecomment-4911084753

Zero-hit results reach the proxy carrying `Ids: &schemapb.IDs{}` — a non-nil shell whose `IdField` oneof is unset (`emptySearchResultData` in `querynodev2/tasks/search_task.go`, and the zero-hit fill in `querynodev2/segments/search_reduce.go`). With a single channel, `reduceAdvanceGroupBy` forwards that sub-result verbatim (skipping `setupIdListForSearchResult`), and the rerank operator's `chain.FromSearchResultData` only routed `Ids == nil` to the empty-`$id`-column path — the shell fell into `importIDs`' default branch and errored. With ≥2 channels the normal reduce path installs a typed empty `IdField`, which is why the bug only surfaces on single-shard collections. The same passthrough exists in `reduceSearchResultDataNoGroupBy`'s single-shard fast path, so plain search + function rerank with empty results could hit the same error.

### Fix (consumer-side)

In `FromSearchResultData`, an unset `IdField` carries no IDs and is now treated exactly like `Ids == nil`:

- shell / nil + zero rows → empty Int64 `$id` column (existing `importEmptyIDs` path)
- shell + rows present → still rejected as `unsupported ID type` (malformed input, unchanged semantics)
- nil + rows present → unchanged tolerated passthrough without `$id` column (aggregation-style results)

Fixing at the consumer covers all producers of the zero-hit shell (querynode empty result, delegator reduce, both proxy single-channel fast paths).

### Testing

- New regression test `TestFromSearchResultData_EmptyIDsZeroRows`: table-driven over `Ids == nil` and the unset-oneof shell (nq=1 and nq=2), asserting both produce the identical empty DataFrame; written first and observed failing with `unsupported ID type` before the fix.
- New `TestFromSearchResultData_NilIDsWithRows` pins the pre-existing nil-with-rows passthrough; existing `TestFromSearchResultData_UnsupportedIDType` (shell with rows → error) still passes.
- `./internal/util/function/chain/...` green, including `-race`; `go vet` and `gofmt` clean.
- After the fix the single-shard empty result flows into the rerank operator's existing `allEmpty` early-return, i.e. the same code path multi-shard empty results already exercise today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
