### PR TITLE
fix: [2.6] parse group_by_fields in v2.6 search params

### DIFF
--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -495,10 +495,31 @@ func (g *groupByInfo) GetStrictCast() bool {
 func parseGroupByInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb.CollectionSchema) (*groupByInfo, error) {
 	ret := &groupByInfo{}
 
-	// 1. parse group_by_field
-	groupByFieldName, err := funcutil.GetAttrByKeyFromRepeatedKV(GroupByFieldKey, searchParamsPair)
-	if err != nil {
-		groupByFieldName = ""
+	// 1. parse group-by field name(s).
+	// `group_by_field` (singular, legacy SDK) wins over `group_by_fields` (plural, new SDK).
+	// When both are set the plural list is ignored to preserve old-client behavior.
+	var groupByFieldNames []string
+	if legacy, err := funcutil.GetAttrByKeyFromRepeatedKV(GroupByFieldKey, searchParamsPair); err == nil {
+		if trimmed := strings.TrimSpace(legacy); trimmed != "" {
+			groupByFieldNames = []string{trimmed}
+		}
+	}
+	if len(groupByFieldNames) == 0 {
+		if plural, err := funcutil.GetAttrByKeyFromRepeatedKV(GroupByFieldsKey, searchParamsPair); err == nil {
+			for _, f := range strings.Split(plural, ",") {
+				if trimmed := strings.TrimSpace(f); trimmed != "" {
+					groupByFieldNames = append(groupByFieldNames, trimmed)
+				}
+			}
+		}
+	}
+	if len(groupByFieldNames) > 1 {
+		return nil, merr.WrapErrParameterInvalidMsg("multi-field group_by_fields is not supported in v2.6")
+	}
+
+	groupByFieldName := ""
+	if len(groupByFieldNames) == 1 {
+		groupByFieldName = groupByFieldNames[0]
 	}
 	var groupByFieldId int64 = -1
 	if groupByFieldName != "" {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -59,6 +59,7 @@ const (
 	IteratorField        = "iterator"
 	CollectionID         = "collection_id"
 	GroupByFieldKey      = "group_by_field"
+	GroupByFieldsKey     = "group_by_fields"
 	GroupSizeKey         = "group_size"
 	StrictGroupSize      = "strict_group_size"
 	JSONPath             = "json_path"

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -4075,6 +4075,42 @@ func TestSearchTask_parseSearchInfo(t *testing.T) {
 	})
 }
 
+func TestSearchTask_tryGeneratePlanRejectsBinaryVectorPluralGroupByFields(t *testing.T) {
+	ctx := context.Background()
+	schema := &schemapb.CollectionSchema{
+		Name: "test_collection",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "vec", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "8"}}},
+			{FieldID: 102, Name: "g", DataType: schemapb.DataType_Int64},
+		},
+	}
+	task := &searchTask{
+		ctx: ctx,
+		SearchRequest: &internalpb.SearchRequest{
+			CollectionID: 1,
+		},
+		request: &milvuspb.SearchRequest{
+			CollectionName: "test_collection",
+		},
+		schema: newSchemaInfo(schema),
+	}
+	params := []*commonpb.KeyValuePair{
+		{Key: AnnsFieldKey, Value: "vec"},
+		{Key: TopKKey, Value: "4"},
+		{Key: common.MetricTypeKey, Value: metric.HAMMING},
+		{Key: ParamsKey, Value: `{}`},
+		{Key: GroupByFieldsKey, Value: "g"},
+		{Key: GroupSizeKey, Value: "1"},
+	}
+
+	plan, queryInfo, _, _, err := task.tryGeneratePlan(params, "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, plan)
+	assert.Nil(t, queryInfo)
+	assert.Contains(t, err.Error(), "not support search_group_by operation based on binary vector column")
+}
+
 func getSearchResultData(nq, topk int64) *schemapb.SearchResultData {
 	result := schemapb.SearchResultData{
 		NumQueries: nq,

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -82,6 +82,36 @@ func TestValidateCollectionName(t *testing.T) {
 	}
 }
 
+func TestParseGroupByInfoGroupByFieldsCompatibility(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "singular", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "plural", DataType: schemapb.DataType_Int64},
+			{FieldID: 103, Name: "another", DataType: schemapb.DataType_Int64},
+		},
+	}
+
+	t.Run("reject multi-field group_by_fields in v2.6", func(t *testing.T) {
+		info, err := parseGroupByInfo([]*commonpb.KeyValuePair{
+			{Key: GroupByFieldsKey, Value: "plural,another"},
+		}, schema)
+
+		assert.Nil(t, info)
+		assert.ErrorContains(t, err, "multi-field group_by_fields is not supported in v2.6")
+	})
+
+	t.Run("group_by_field wins over group_by_fields", func(t *testing.T) {
+		info, err := parseGroupByInfo([]*commonpb.KeyValuePair{
+			{Key: GroupByFieldKey, Value: "singular"},
+			{Key: GroupByFieldsKey, Value: "plural"},
+		}, schema)
+
+		assert.NoError(t, err)
+		assert.Equal(t, int64(101), info.groupByFieldId)
+	})
+}
+
 func TestValidateCollectionDescription(t *testing.T) {
 	maxLength := Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()
 	tests := []struct {


### PR DESCRIPTION
#### What

Backport v2.6 search parameter parsing so a single-field `group_by_fields` value is recognized as a compatibility alias for `group_by_field`. This prevents raw requests from bypassing existing group-by validation.

#### Why

In v2.6, `group_by_fields` is not supported, but a raw request using `group_by_fields="g"` was silently ignored. For BinaryVector ANN search, that bypassed the existing unsupported group-by validation and returned ordinary top-k results.

This change makes `group_by_fields="g"` enter the same validation path as `group_by_field="g"`, so BinaryVector group-by is rejected instead of ignored. Multi-field `group_by_fields` remains unsupported in v2.6.

Fixes #51136

Related master PR:
pr: #49071

#### Tests

- Added proxy regression test for BinaryVector + HAMMING + `group_by_fields`.
- `git diff --check`
