### PR TITLE
enhance: cache rootcoord collection counts

### DIFF
--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -90,17 +90,12 @@ func (t *createCollectionTask) validate(ctx context.Context) error {
 	}
 
 	// 2. check db-collection capacity
-	db2CollIDs := t.meta.ListAllAvailCollections(ctx)
-	if err := t.checkMaxCollectionsPerDB(ctx, db2CollIDs); err != nil {
+	dbCollectionCount, totalCollections, dbExists := t.meta.GetAvailableCollectionCount(ctx, t.header.DbId)
+	if err := t.checkMaxCollectionsPerDB(ctx, dbCollectionCount, dbExists); err != nil {
 		return err
 	}
 
 	// 3. check total collection number
-	totalCollections := 0
-	for _, collIDs := range db2CollIDs {
-		totalCollections += len(collIDs)
-	}
-
 	maxCollectionNum := Params.QuotaConfig.MaxCollectionNum.GetAsInt()
 	if totalCollections >= maxCollectionNum {
 		mlog.Warn(ctx, "unable to create collection because the number of collection has reached the limit", mlog.Int("max_collection_num", maxCollectionNum))
@@ -116,11 +111,10 @@ func (t *createCollectionTask) validate(ctx context.Context) error {
 }
 
 // checkMaxCollectionsPerDB DB properties take precedence over quota configurations for max collections.
-func (t *createCollectionTask) checkMaxCollectionsPerDB(ctx context.Context, db2CollIDs map[int64][]int64) error {
+func (t *createCollectionTask) checkMaxCollectionsPerDB(ctx context.Context, dbCollectionCount int, dbExists bool) error {
 	Params := paramtable.Get()
 
-	collIDs, ok := db2CollIDs[t.header.DbId]
-	if !ok {
+	if !dbExists {
 		mlog.Warn(ctx, "can not found DB ID", mlog.String("collection", t.Req.GetCollectionName()), mlog.String("dbName", t.Req.GetDbName()))
 		return merr.WrapErrDatabaseNotFound(t.Req.GetDbName(), "failed to create collection")
 	}
@@ -132,7 +126,7 @@ func (t *createCollectionTask) checkMaxCollectionsPerDB(ctx context.Context, db2
 	}
 
 	check := func(maxColNumPerDB int) error {
-		if len(collIDs) >= maxColNumPerDB {
+		if dbCollectionCount >= maxColNumPerDB {
 			mlog.Warn(ctx, "unable to create collection because the number of collection has reached the limit in DB", mlog.Int("maxCollectionNumPerDB", maxColNumPerDB))
 			return merr.WrapErrCollectionNumLimitExceeded(t.Req.GetDbName(), maxColNumPerDB)
 		}

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -92,9 +92,10 @@ func Test_createCollectionTask_validate(t *testing.T) {
 		defer paramtable.Get().Reset(Params.QuotaConfig.MaxCollectionNum.Key)
 
 		meta := mockrootcoord.NewIMetaTable(t)
-		meta.EXPECT().ListAllAvailCollections(
+		meta.EXPECT().GetAvailableCollectionCount(
 			mock.Anything,
-		).Return(map[int64][]int64{1: {1, 2}})
+			util.DefaultDBID,
+		).Return(2, 2, true)
 
 		meta.EXPECT().GetDatabaseByName(mock.Anything, mock.Anything, mock.Anything).
 			Return(&model.Database{Name: "db1"}, nil)
@@ -130,7 +131,7 @@ func Test_createCollectionTask_validate(t *testing.T) {
 		defer paramtable.Get().Reset(Params.QuotaConfig.MaxCollectionNumPerDB.Key)
 
 		meta := mockrootcoord.NewIMetaTable(t)
-		meta.EXPECT().ListAllAvailCollections(mock.Anything).Return(map[int64][]int64{util.DefaultDBID: {1, 2}})
+		meta.EXPECT().GetAvailableCollectionCount(mock.Anything, util.DefaultDBID).Return(2, 2, true)
 
 		// test reach limit
 		meta.EXPECT().GetDatabaseByName(mock.Anything, mock.Anything, mock.Anything).
@@ -188,7 +189,7 @@ func Test_createCollectionTask_validate(t *testing.T) {
 		defer paramtable.Get().Reset(Params.QuotaConfig.MaxCollectionNumPerDB.Key)
 
 		meta := mockrootcoord.NewIMetaTable(t)
-		meta.EXPECT().ListAllAvailCollections(mock.Anything).Return(map[int64][]int64{1: {1, 2}})
+		meta.EXPECT().GetAvailableCollectionCount(mock.Anything, util.DefaultDBID).Return(2, 2, true)
 		meta.EXPECT().GetDatabaseByName(mock.Anything, mock.Anything, mock.Anything).
 			Return(&model.Database{Name: "db1"}, nil)
 
@@ -223,7 +224,7 @@ func Test_createCollectionTask_validate(t *testing.T) {
 		defer paramtable.Get().Reset(Params.RootCoordCfg.MaxGeneralCapacity.Key)
 
 		meta := mockrootcoord.NewIMetaTable(t)
-		meta.EXPECT().ListAllAvailCollections(mock.Anything).Return(map[int64][]int64{1: {1, 2}})
+		meta.EXPECT().GetAvailableCollectionCount(mock.Anything, util.DefaultDBID).Return(2, 2, true)
 		meta.EXPECT().GetDatabaseByName(mock.Anything, mock.Anything, mock.Anything).
 			Return(&model.Database{Name: "db1"}, nil).Once()
 		meta.EXPECT().GetGeneralCount(mock.Anything).Return(1)
@@ -250,7 +251,7 @@ func Test_createCollectionTask_validate(t *testing.T) {
 		defer paramtable.Get().Reset(Params.QuotaConfig.MaxCollectionNumPerDB.Key)
 
 		meta := mockrootcoord.NewIMetaTable(t)
-		meta.EXPECT().ListAllAvailCollections(mock.Anything).Return(map[int64][]int64{1: {1, 2}})
+		meta.EXPECT().GetAvailableCollectionCount(mock.Anything, util.DefaultDBID).Return(2, 2, true)
 		meta.EXPECT().GetDatabaseByName(mock.Anything, mock.Anything, mock.Anything).
 			Return(&model.Database{
 				Name: "db1",
@@ -2037,11 +2038,10 @@ func Test_createCollectionTask_Prepare(t *testing.T) {
 		mock.Anything,
 		mock.Anything,
 	).Return(model.NewDefaultDatabase(nil), nil)
-	meta.On("ListAllAvailCollections",
+	meta.On("GetAvailableCollectionCount",
 		mock.Anything,
-	).Return(map[int64][]int64{
-		util.DefaultDBID: {1, 2},
-	}, nil)
+		util.DefaultDBID,
+	).Return(2, 2, true)
 	meta.EXPECT().GetGeneralCount(mock.Anything).Return(0)
 	meta.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errors.New("not found"))
 	meta.EXPECT().GetCollectionByName(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("not found"))
@@ -2132,9 +2132,7 @@ func TestCreateCollectionTask_Prepare_WithProperty(t *testing.T) {
 			Name: "foo",
 			ID:   1,
 		}, nil).Twice()
-		meta.EXPECT().ListAllAvailCollections(mock.Anything).Return(map[int64][]int64{
-			util.DefaultDBID: {1, 2},
-		}).Once()
+		meta.EXPECT().GetAvailableCollectionCount(mock.Anything, util.DefaultDBID).Return(2, 2, true).Once()
 		meta.EXPECT().GetGeneralCount(mock.Anything).Return(0).Once()
 		meta.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errors.New("not found"))
 		meta.EXPECT().GetCollectionByName(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("not found"))
@@ -2184,9 +2182,7 @@ func TestCreateCollectionTask_Prepare_WithProperty(t *testing.T) {
 			Name: "foo",
 			ID:   1,
 		}, nil).Twice()
-		meta.EXPECT().ListAllAvailCollections(mock.Anything).Return(map[int64][]int64{
-			util.DefaultDBID: {1, 2},
-		}).Once()
+		meta.EXPECT().GetAvailableCollectionCount(mock.Anything, util.DefaultDBID).Return(2, 2, true).Once()
 		meta.EXPECT().GetGeneralCount(mock.Anything).Return(0).Once()
 		defer cleanTestEnv()
 
@@ -2230,9 +2226,7 @@ func TestCreateCollectionTask_Prepare_WithProperty(t *testing.T) {
 			Name: "foo",
 			ID:   1,
 		}, nil).Twice()
-		meta.EXPECT().ListAllAvailCollections(mock.Anything).Return(map[int64][]int64{
-			util.DefaultDBID: {1, 2},
-		}).Once()
+		meta.EXPECT().GetAvailableCollectionCount(mock.Anything, util.DefaultDBID).Return(2, 2, true).Once()
 		meta.EXPECT().GetGeneralCount(mock.Anything).Return(0).Once()
 		meta.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errors.New("not found"))
 		meta.EXPECT().GetCollectionByName(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("not found"))
@@ -2295,11 +2289,10 @@ func Test_createCollectionTask_PartitionKey(t *testing.T) {
 		mock.Anything,
 		mock.Anything,
 	).Return(model.NewDefaultDatabase(nil), nil)
-	meta.On("ListAllAvailCollections",
+	meta.On("GetAvailableCollectionCount",
 		mock.Anything,
-	).Return(map[int64][]int64{
-		util.DefaultDBID: {1, 2},
-	}, nil)
+		util.DefaultDBID,
+	).Return(2, 2, true)
 	meta.EXPECT().GetGeneralCount(mock.Anything).Return(0)
 	meta.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errors.New("not found"))
 	meta.EXPECT().GetCollectionByName(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("not found"))

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -120,6 +120,7 @@ type IMetaTable interface {
 	TruncateCollection(ctx context.Context, result message.BroadcastResultTruncateCollectionMessageV2) error
 	CheckIfCollectionRenamable(ctx context.Context, dbName string, oldName string, newDBName string, newName string) error
 	GetGeneralCount(ctx context.Context) int
+	GetAvailableCollectionCount(ctx context.Context, dbID int64) (dbCount int, totalCount int, dbExists bool)
 
 	// TODO: it'll be a big cost if we handle the time travel logic, since we should always list all aliases in catalog.
 	IsAlias(ctx context.Context, db, name string) bool
@@ -177,7 +178,9 @@ type MetaTable struct {
 	fileResourceRefCnt    map[int64]int                           // file resource id -> reference count
 	fileResourceVersion   uint64
 
-	generalCnt int // sum of product of partition number and shard number
+	generalCnt                   int // sum of product of partition number and shard number
+	availableCollectionCount     int
+	availableCollectionCountByDB map[int64]int
 
 	// collections *collectionDb
 	names   *nameDb
@@ -308,6 +311,8 @@ func (mt *MetaTable) reload() error {
 			mt.aliases.insert(dbName, alias.Name, alias.CollectionID)
 		}
 	}
+
+	mt.rebuildAvailableCollectionCountLocked()
 
 	mlog.Info(mt.ctx, "rootcoord start to recover the channel stats for streaming coord balancer")
 	vchannels := make([]string, 0, len(mt.collID2Meta)*2)
@@ -443,6 +448,10 @@ func (mt *MetaTable) createDatabasePrivate(ctx context.Context, db *model.Databa
 	mt.names.createDbIfNotExist(dbName)
 	mt.aliases.createDbIfNotExist(dbName)
 	mt.dbName2Meta[dbName] = db
+	if mt.availableCollectionCountByDB == nil {
+		mt.availableCollectionCountByDB = make(map[int64]int)
+	}
+	mt.availableCollectionCountByDB[db.ID] = 0
 
 	mlog.Info(ctx, "create database", mlog.String("db", dbName), mlog.Uint64("ts", ts))
 	return nil
@@ -501,6 +510,7 @@ func (mt *MetaTable) DropDatabase(ctx context.Context, dbName string, ts typeuti
 	mt.names.dropDb(dbName)
 	mt.aliases.dropDb(dbName)
 	delete(mt.dbName2Meta, dbName)
+	delete(mt.availableCollectionCountByDB, db.ID)
 
 	metrics.RootCoordNumOfDatabases.Dec()
 	mlog.Info(ctx, "drop database", mlog.String("db", dbName), mlog.Uint64("ts", ts))
@@ -575,6 +585,7 @@ func (mt *MetaTable) AddCollection(ctx context.Context, coll *model.Collection) 
 
 	mt.collID2Meta[coll.CollectionID] = coll.Clone()
 	mt.names.insert(coll.DBName, coll.Name, coll.CollectionID)
+	mt.increaseAvailableCollectionCountLocked(coll.DBID)
 	// Build partition name index for the new collection
 	mt.partitionName2ID[coll.CollectionID] = make(map[string]int64)
 	for _, partition := range coll.Partitions {
@@ -633,7 +644,7 @@ func (mt *MetaTable) DropCollection(ctx context.Context, collectionID UniqueID, 
 		mlog.String("state", clone.State.String()),
 	)
 
-	db, err := mt.getDatabaseByIDInternal(ctx, coll.DBID, typeutil.MaxTimestamp)
+	db, err := mt.getDatabaseByIDInternal(ctx, normalizeCollectionDBID(coll.DBID), typeutil.MaxTimestamp)
 	if err != nil {
 		return merr.Wrapf(err, "dbID not found for collection:%d", collectionID)
 	}
@@ -641,6 +652,9 @@ func (mt *MetaTable) DropCollection(ctx context.Context, collectionID UniqueID, 
 	pn := coll.GetPartitionNum(true)
 
 	mt.generalCnt -= pn * int(coll.ShardsNum)
+	if coll.Available() {
+		mt.decreaseAvailableCollectionCountLocked(coll.DBID)
+	}
 	channel.StaticPChannelStatsManager.MustGet().RemoveVChannel(coll.VirtualChannelNames...)
 	metrics.RootCoordNumOfCollections.WithLabelValues(db.Name).Dec()
 	metrics.RootCoordNumOfPartitions.WithLabelValues().Sub(float64(pn))
@@ -926,6 +940,8 @@ func (mt *MetaTable) GetCollectionByIDWithMaxTs(ctx context.Context, collectionI
 	return mt.GetCollectionByID(ctx, "", collectionID, typeutil.MaxTimestamp, false)
 }
 
+// ListAllAvailCollections returns available collection IDs grouped by database.
+// Use GetAvailableCollectionCount for max-count checks that only need counts.
 func (mt *MetaTable) ListAllAvailCollections(ctx context.Context) map[int64][]int64 {
 	mt.ddLock.RLock()
 	defer mt.ddLock.RUnlock()
@@ -1093,6 +1109,9 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 
 	mt.names.remove(oldColl.DBName, oldColl.Name)
 	mt.names.insert(newColl.DBName, newColl.Name, newColl.CollectionID)
+	if dbChanged && oldColl.Available() && newColl.Available() {
+		mt.moveAvailableCollectionCountLocked(oldColl.DBID, newColl.DBID)
+	}
 	mt.collID2Meta[header.CollectionId] = newColl
 	mlog.Info(ctx, "alter collection finished",
 		mlog.String("oldDBName", oldColl.DBName),
@@ -1674,6 +1693,65 @@ func (mt *MetaTable) GetGeneralCount(ctx context.Context) int {
 	defer mt.ddLock.RUnlock()
 
 	return mt.generalCnt
+}
+
+func normalizeCollectionDBID(dbID int64) int64 {
+	if dbID == util.NonDBID {
+		return util.DefaultDBID
+	}
+	return dbID
+}
+
+func (mt *MetaTable) rebuildAvailableCollectionCountLocked() {
+	mt.availableCollectionCount = 0
+	mt.availableCollectionCountByDB = make(map[int64]int, len(mt.dbName2Meta))
+	for _, db := range mt.dbName2Meta {
+		mt.availableCollectionCountByDB[db.ID] = 0
+	}
+	for _, coll := range mt.collID2Meta {
+		if !coll.Available() {
+			continue
+		}
+		mt.increaseAvailableCollectionCountLocked(coll.DBID)
+	}
+}
+
+func (mt *MetaTable) increaseAvailableCollectionCountLocked(dbID int64) {
+	if mt.availableCollectionCountByDB == nil {
+		mt.availableCollectionCountByDB = make(map[int64]int)
+	}
+	dbID = normalizeCollectionDBID(dbID)
+	mt.availableCollectionCountByDB[dbID]++
+	mt.availableCollectionCount++
+}
+
+func (mt *MetaTable) decreaseAvailableCollectionCountLocked(dbID int64) {
+	dbID = normalizeCollectionDBID(dbID)
+	if mt.availableCollectionCountByDB[dbID] > 0 {
+		mt.availableCollectionCountByDB[dbID]--
+		if mt.availableCollectionCount > 0 {
+			mt.availableCollectionCount--
+		}
+	}
+}
+
+func (mt *MetaTable) moveAvailableCollectionCountLocked(fromDBID int64, toDBID int64) {
+	fromDBID = normalizeCollectionDBID(fromDBID)
+	toDBID = normalizeCollectionDBID(toDBID)
+	if fromDBID == toDBID {
+		return
+	}
+	mt.decreaseAvailableCollectionCountLocked(fromDBID)
+	mt.increaseAvailableCollectionCountLocked(toDBID)
+}
+
+func (mt *MetaTable) GetAvailableCollectionCount(ctx context.Context, dbID int64) (dbCount int, totalCount int, dbExists bool) {
+	mt.ddLock.RLock()
+	defer mt.ddLock.RUnlock()
+
+	dbID = normalizeCollectionDBID(dbID)
+	dbCount, dbExists = mt.availableCollectionCountByDB[dbID]
+	return dbCount, mt.availableCollectionCount, dbExists
 }
 
 func (mt *MetaTable) InitCredential(ctx context.Context) error {

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -621,6 +621,15 @@ func (mt *MetaTable) DropCollection(ctx context.Context, collectionID UniqueID, 
 		return nil
 	}
 
+	// Resolve the database before persisting the Dropping state. Once the
+	// collection becomes Dropping, callback retries take the idempotent return
+	// above, so no fallible lookup should remain before the in-memory counters
+	// and channel stats are updated.
+	db, err := mt.getDatabaseByIDInternal(ctx, normalizeCollectionDBID(coll.DBID), typeutil.MaxTimestamp)
+	if err != nil {
+		return merr.Wrapf(err, "dbID not found for collection:%d", collectionID)
+	}
+
 	clone := coll.Clone()
 	clone.State = pb.CollectionState_CollectionDropping
 	clone.UpdateTimestamp = ts
@@ -643,11 +652,6 @@ func (mt *MetaTable) DropCollection(ctx context.Context, collectionID UniqueID, 
 		mlog.Int64("collectionID", collectionID),
 		mlog.String("state", clone.State.String()),
 	)
-
-	db, err := mt.getDatabaseByIDInternal(ctx, normalizeCollectionDBID(coll.DBID), typeutil.MaxTimestamp)
-	if err != nil {
-		return merr.Wrapf(err, "dbID not found for collection:%d", collectionID)
-	}
 
 	pn := coll.GetPartitionNum(true)
 

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -2234,6 +2234,62 @@ func TestMetaTable_AvailableCollectionCountTransitions(t *testing.T) {
 	assert.Equal(t, 0, total)
 }
 
+func TestMetaTable_DropCollectionDBLookupFailureIsRetryable(t *testing.T) {
+	ctx := context.Background()
+	channel.ResetStaticPChannelStatsManager()
+	channel.RecoverPChannelStatsManager([]string{})
+	t.Cleanup(channel.ResetStaticPChannelStatsManager)
+
+	catalog := mocks.NewRootCoordCatalog(t)
+	catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).
+		Once()
+	catalog.On("DeleteGrantByCollectionName", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).
+		Once()
+
+	const dbID = int64(11)
+	meta := &MetaTable{
+		catalog: catalog,
+		collID2Meta: map[typeutil.UniqueID]*model.Collection{
+			100: {
+				CollectionID: 100,
+				DBID:         dbID,
+				DBName:       "db2",
+				Name:         "c1",
+				State:        pb.CollectionState_CollectionCreated,
+				ShardsNum:    1,
+				Partitions: []*model.Partition{
+					{PartitionID: 10, PartitionName: "_default", State: pb.PartitionState_PartitionCreated},
+				},
+			},
+		},
+		dbName2Meta:        map[string]*model.Database{},
+		fileResourceRefCnt: map[int64]int{},
+		generalCnt:         1,
+	}
+	meta.rebuildAvailableCollectionCountLocked()
+
+	err := meta.DropCollection(ctx, 100, 300)
+	require.ErrorIs(t, err, merr.ErrDatabaseNotFound)
+	assert.Equal(t, pb.CollectionState_CollectionCreated, meta.collID2Meta[100].State)
+	assert.Equal(t, 1, meta.generalCnt)
+	dbCount, total, ok := meta.GetAvailableCollectionCount(ctx, dbID)
+	require.True(t, ok)
+	assert.Equal(t, 1, dbCount)
+	assert.Equal(t, 1, total)
+	catalog.AssertNotCalled(t, "AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+
+	meta.dbName2Meta["db2"] = &model.Database{ID: dbID, Name: "db2"}
+	require.NoError(t, meta.DropCollection(ctx, 100, 300))
+	assert.Equal(t, pb.CollectionState_CollectionDropping, meta.collID2Meta[100].State)
+	assert.Equal(t, 0, meta.generalCnt)
+	dbCount, total, ok = meta.GetAvailableCollectionCount(ctx, dbID)
+	require.True(t, ok)
+	assert.Equal(t, 0, dbCount)
+	assert.Equal(t, 0, total)
+}
+
 func TestMetaTable_AddPartition(t *testing.T) {
 	t.Run("collection not available", func(t *testing.T) {
 		meta := &MetaTable{}

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -2087,6 +2088,150 @@ func TestMetaTable_ListAllAvailCollections(t *testing.T) {
 	db3, ok := ret[1111]
 	assert.True(t, ok)
 	assert.Equal(t, 0, len(db3))
+}
+
+func TestMetaTable_GetAvailableCollectionCount(t *testing.T) {
+	meta := &MetaTable{
+		dbName2Meta: map[string]*model.Database{
+			util.DefaultDBName: {ID: util.DefaultDBID},
+			"db2":              {ID: 11},
+			"db3":              {ID: 2},
+			"db4":              {ID: 1111},
+		},
+		collID2Meta: map[typeutil.UniqueID]*model.Collection{
+			111: {
+				CollectionID: 111,
+				DBID:         1111,
+				State:        pb.CollectionState_CollectionDropped,
+			},
+			2: {
+				CollectionID: 2,
+				DBID:         11,
+				State:        pb.CollectionState_CollectionCreated,
+			},
+			3: {
+				CollectionID: 3,
+				DBID:         11,
+				State:        pb.CollectionState_CollectionCreated,
+			},
+			4: {
+				CollectionID: 4,
+				DBID:         2,
+				State:        pb.CollectionState_CollectionCreated,
+			},
+			5: {
+				CollectionID: 5,
+				DBID:         util.NonDBID,
+				State:        pb.CollectionState_CollectionCreated,
+			},
+		},
+	}
+	meta.rebuildAvailableCollectionCountLocked()
+
+	dbCount, total, ok := meta.GetAvailableCollectionCount(context.TODO(), util.DefaultDBID)
+	assert.True(t, ok)
+	assert.Equal(t, 1, dbCount)
+	assert.Equal(t, 4, total)
+
+	dbCount, total, ok = meta.GetAvailableCollectionCount(context.TODO(), int64(11))
+	assert.True(t, ok)
+	assert.Equal(t, 2, dbCount)
+	assert.Equal(t, 4, total)
+
+	dbCount, total, ok = meta.GetAvailableCollectionCount(context.TODO(), int64(1111))
+	assert.True(t, ok)
+	assert.Equal(t, 0, dbCount)
+	assert.Equal(t, 4, total)
+
+	dbCount, total, ok = meta.GetAvailableCollectionCount(context.TODO(), int64(9999))
+	assert.False(t, ok)
+	assert.Equal(t, 0, dbCount)
+	assert.Equal(t, 4, total)
+}
+
+func TestMetaTable_AvailableCollectionCountTransitions(t *testing.T) {
+	ctx := context.Background()
+	channel.ResetStaticPChannelStatsManager()
+	channel.RecoverPChannelStatsManager([]string{})
+
+	catalog := mocks.NewRootCoordCatalog(t)
+	catalog.On("CreateCollection", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	catalog.On("AlterCollectionDB", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	catalog.On("DeleteGrantByCollectionName", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	catalog.On("MigrateGrantCollectionName", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	meta := &MetaTable{
+		catalog: catalog,
+		dbName2Meta: map[string]*model.Database{
+			util.DefaultDBName: {ID: util.DefaultDBID},
+			"db2":              {ID: 11},
+		},
+		collID2Meta:        map[typeutil.UniqueID]*model.Collection{},
+		partitionName2ID:   map[int64]map[string]int64{},
+		names:              newNameDb(),
+		aliases:            newNameDb(),
+		fileResourceRefCnt: map[int64]int{},
+	}
+	meta.names.createDbIfNotExist(util.DefaultDBName)
+	meta.names.createDbIfNotExist("db2")
+	meta.rebuildAvailableCollectionCountLocked()
+
+	err := meta.AddCollection(ctx, &model.Collection{
+		CollectionID: 100,
+		DBID:         util.DefaultDBID,
+		DBName:       util.DefaultDBName,
+		Name:         "c1",
+		State:        pb.CollectionState_CollectionCreated,
+		ShardsNum:    1,
+		Partitions: []*model.Partition{
+			{PartitionID: 10, PartitionName: "_default", State: pb.PartitionState_PartitionCreated},
+		},
+	})
+	require.NoError(t, err)
+	dbCount, total, ok := meta.GetAvailableCollectionCount(ctx, util.DefaultDBID)
+	require.True(t, ok)
+	assert.Equal(t, 1, dbCount)
+	assert.Equal(t, 1, total)
+
+	result := message.BroadcastResultAlterCollectionMessageV2{
+		Message: message.MustAsBroadcastAlterCollectionMessageV2(
+			message.NewAlterCollectionMessageBuilderV2().
+				WithHeader(&message.AlterCollectionMessageHeader{
+					CollectionId: 100,
+					UpdateMask:   &fieldmaskpb.FieldMask{Paths: []string{message.FieldMaskDB}},
+				}).
+				WithBody(&message.AlterCollectionMessageBody{
+					Updates: &message.AlterCollectionMessageUpdates{
+						DbId:   11,
+						DbName: "db2",
+					},
+				}).
+				WithBroadcast([]string{funcutil.GetControlChannel("by-dev-rootcoord-dml_1")}).
+				MustBuildBroadcast(),
+		),
+		Results: map[string]*message.AppendResult{
+			funcutil.GetControlChannel("by-dev-rootcoord-dml_1"): {TimeTick: 200},
+		},
+	}
+	err = meta.AlterCollection(ctx, result)
+	require.NoError(t, err)
+
+	dbCount, total, ok = meta.GetAvailableCollectionCount(ctx, util.DefaultDBID)
+	require.True(t, ok)
+	assert.Equal(t, 0, dbCount)
+	assert.Equal(t, 1, total)
+	dbCount, total, ok = meta.GetAvailableCollectionCount(ctx, int64(11))
+	require.True(t, ok)
+	assert.Equal(t, 1, dbCount)
+	assert.Equal(t, 1, total)
+
+	err = meta.DropCollection(ctx, 100, 300)
+	require.NoError(t, err)
+	dbCount, total, ok = meta.GetAvailableCollectionCount(ctx, int64(11))
+	require.True(t, ok)
+	assert.Equal(t, 0, dbCount)
+	assert.Equal(t, 0, total)
 }
 
 func TestMetaTable_AddPartition(t *testing.T) {

--- a/internal/rootcoord/mock_test.go
+++ b/internal/rootcoord/mock_test.go
@@ -100,6 +100,7 @@ type mockMetaTable struct {
 	ListPolicyFunc                   func(ctx context.Context, tenant string) ([]*milvuspb.GrantEntity, error)
 	ListUserRoleFunc                 func(ctx context.Context, tenant string) ([]string, error)
 	DescribeDatabaseFunc             func(ctx context.Context, dbName string) (*model.Database, error)
+	GetAvailableCollectionCountFunc  func(ctx context.Context, dbID int64) (int, int, bool)
 	CreatePrivilegeGroupFunc         func(ctx context.Context, groupName string) error
 	DropPrivilegeGroupFunc           func(ctx context.Context, groupName string) error
 	IsCustomPrivilegeGroupFunc       func(ctx context.Context, groupName string) (bool, error)
@@ -110,6 +111,10 @@ type mockMetaTable struct {
 
 func (m mockMetaTable) GetDatabaseByName(ctx context.Context, dbName string, ts Timestamp) (*model.Database, error) {
 	return m.DescribeDatabaseFunc(ctx, dbName)
+}
+
+func (m mockMetaTable) GetAvailableCollectionCount(ctx context.Context, dbID int64) (int, int, bool) {
+	return m.GetAvailableCollectionCountFunc(ctx, dbID)
 }
 
 func (m mockMetaTable) ListDatabases(ctx context.Context, ts typeutil.Timestamp) ([]*model.Database, error) {

--- a/internal/rootcoord/mocks/meta_table.go
+++ b/internal/rootcoord/mocks/meta_table.go
@@ -5,16 +5,12 @@ package mockrootcoord
 import (
 	context "context"
 
-	internalpb "github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
-	message "github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
-
-	messagespb "github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
-
 	milvuspb "github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-
-	mock "github.com/stretchr/testify/mock"
-
 	model "github.com/milvus-io/milvus/internal/metastore/model"
+	internalpb "github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	messagespb "github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	message "github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	mock "github.com/stretchr/testify/mock"
 
 	rootcoordpb "github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
 )
@@ -1936,6 +1932,70 @@ func (_c *IMetaTable_DropRole_Call) Return(_a0 error) *IMetaTable_DropRole_Call 
 }
 
 func (_c *IMetaTable_DropRole_Call) RunAndReturn(run func(context.Context, string, string) error) *IMetaTable_DropRole_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAvailableCollectionCount provides a mock function with given fields: ctx, dbID
+func (_m *IMetaTable) GetAvailableCollectionCount(ctx context.Context, dbID int64) (int, int, bool) {
+	ret := _m.Called(ctx, dbID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAvailableCollectionCount")
+	}
+
+	var r0 int
+	var r1 int
+	var r2 bool
+	if rf, ok := ret.Get(0).(func(context.Context, int64) (int, int, bool)); ok {
+		return rf(ctx, dbID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64) int); ok {
+		r0 = rf(ctx, dbID)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int64) int); ok {
+		r1 = rf(ctx, dbID)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, int64) bool); ok {
+		r2 = rf(ctx, dbID)
+	} else {
+		r2 = ret.Get(2).(bool)
+	}
+
+	return r0, r1, r2
+}
+
+// IMetaTable_GetAvailableCollectionCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAvailableCollectionCount'
+type IMetaTable_GetAvailableCollectionCount_Call struct {
+	*mock.Call
+}
+
+// GetAvailableCollectionCount is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dbID int64
+func (_e *IMetaTable_Expecter) GetAvailableCollectionCount(ctx interface{}, dbID interface{}) *IMetaTable_GetAvailableCollectionCount_Call {
+	return &IMetaTable_GetAvailableCollectionCount_Call{Call: _e.mock.On("GetAvailableCollectionCount", ctx, dbID)}
+}
+
+func (_c *IMetaTable_GetAvailableCollectionCount_Call) Run(run func(ctx context.Context, dbID int64)) *IMetaTable_GetAvailableCollectionCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64))
+	})
+	return _c
+}
+
+func (_c *IMetaTable_GetAvailableCollectionCount_Call) Return(dbCount int, totalCount int, dbExists bool) *IMetaTable_GetAvailableCollectionCount_Call {
+	_c.Call.Return(dbCount, totalCount, dbExists)
+	return _c
+}
+
+func (_c *IMetaTable_GetAvailableCollectionCount_Call) RunAndReturn(run func(context.Context, int64) (int, int, bool)) *IMetaTable_GetAvailableCollectionCount_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary
- Maintain cached available collection counts in RootCoord meta.
- Use cached per-DB and total counts for create collection quota checks.
- Add coverage for count rebuilds, DB moves, and drop transitions.

## Test Plan
- Not run per request.

issue: #52381