### PR TITLE
enhance: avoid DataNode import scheduler head-of-line blocking

### DIFF
--- a/internal/datanode/importv2/pool.go
+++ b/internal/datanode/importv2/pool.go
@@ -29,20 +29,118 @@ import (
 )
 
 var (
-	execPool         *conc.Pool[any]
+	execPool         *orderedExecPool
 	execPoolInitOnce sync.Once
 )
+
+// orderedExecPool preserves Submit start order before handing work to the inner pool.
+// Task completion remains independent, so later short work can finish first.
+type orderedExecPool struct {
+	inner *conc.Pool[any]
+
+	queue   conc.ConcurrentQueue[*orderedExecJob]
+	notify  chan struct{}
+	closeCh chan struct{}
+}
+
+type orderedExecJob struct {
+	action func() (any, error)
+	future chan *conc.Future[any]
+}
+
+func newOrderedExecPool(inner *conc.Pool[any]) *orderedExecPool {
+	pool := &orderedExecPool{
+		inner:   inner,
+		notify:  make(chan struct{}, 1),
+		closeCh: make(chan struct{}),
+	}
+	go pool.dispatch()
+	return pool
+}
+
+func (pool *orderedExecPool) Submit(fn func() (any, error)) *conc.Future[any] {
+	job := &orderedExecJob{
+		action: fn,
+		future: make(chan *conc.Future[any], 1),
+	}
+	pool.queue.Enqueue(job)
+	select {
+	case pool.notify <- struct{}{}:
+	default:
+	}
+
+	return conc.Go(func() (any, error) {
+		future := <-job.future
+		return future.Await()
+	})
+}
+
+func (pool *orderedExecPool) dispatch() {
+	for {
+		job, ok := pool.queue.Dequeue()
+		if !ok {
+			select {
+			case <-pool.notify:
+				continue
+			case <-pool.closeCh:
+				return
+			}
+		}
+
+		started := make(chan struct{})
+		future := pool.inner.Submit(func() (any, error) {
+			close(started)
+			return job.action()
+		})
+
+		select {
+		case <-started:
+			job.future <- future
+		case <-future.Inner():
+			job.future <- future
+		}
+		close(job.future)
+	}
+}
+
+func (pool *orderedExecPool) Cap() int {
+	return pool.inner.Cap()
+}
+
+func (pool *orderedExecPool) Running() int {
+	return pool.inner.Running()
+}
+
+func (pool *orderedExecPool) Free() int {
+	return pool.inner.Free()
+}
+
+func (pool *orderedExecPool) Waiting() int {
+	return pool.inner.Waiting() + pool.queue.Len()
+}
+
+func (pool *orderedExecPool) IsClosed() bool {
+	return pool.inner.IsClosed()
+}
+
+// Release and ReleaseTimeout is not implemented
+// since it is not used in the current implementation.
+
+func (pool *orderedExecPool) Resize(size int) error {
+	return pool.inner.Resize(size)
+}
 
 func initExecPool() {
 	pt := paramtable.Get()
 	cpuNum := hardware.GetCPUNum()
 	initPoolSize := cpuNum * pt.DataNodeCfg.ImportConcurrencyPerCPUCore.GetAsInt()
-	execPool = conc.NewPool[any](
+	innerPool := conc.NewPool[any](
 		initPoolSize,
 		conc.WithPreAlloc(false), // pre alloc must be false to resize pool dynamically, use warmup to alloc worker here
 		conc.WithDisablePurge(true),
 	)
-	conc.WarmupPool(execPool, runtime.LockOSThread)
+	conc.WarmupPool(innerPool, runtime.LockOSThread)
+	execPool = newOrderedExecPool(innerPool)
 
 	watchKey := pt.DataNodeCfg.ImportConcurrencyPerCPUCore.Key
 	pt.Watch(watchKey, config.NewHandler(watchKey, resizeExecPool))
@@ -64,7 +162,7 @@ func resizeExecPool(evt *config.Event) {
 	}
 }
 
-func GetExecPool() *conc.Pool[any] {
+func GetExecPool() *orderedExecPool {
 	execPoolInitOnce.Do(initExecPool)
 	return execPool
 }

--- a/internal/datanode/importv2/pool_test.go
+++ b/internal/datanode/importv2/pool_test.go
@@ -19,10 +19,13 @@ package importv2
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
+	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -63,4 +66,157 @@ func TestResizePools(t *testing.T) {
 		})
 		assert.Equal(t, expectedCap, GetExecPool().Cap())
 	})
+}
+
+func TestOrderedExecPoolSubmitOrder(t *testing.T) {
+	const (
+		poolSize = 3
+		taskNum  = 12
+	)
+
+	inner := conc.NewPool[any](poolSize, conc.WithDisablePurge(true))
+	pool := newOrderedExecPool(inner)
+	defer closeOrderedExecPoolForTest(pool)
+
+	started := make(chan int, taskNum)
+	releases := make([]chan struct{}, taskNum)
+	futures := make([]*conc.Future[any], 0, taskNum)
+
+	for i := 0; i < taskNum; i++ {
+		taskID := i
+		releases[taskID] = make(chan struct{})
+		future := pool.Submit(func() (any, error) {
+			started <- taskID
+			<-releases[taskID]
+			return taskID, nil
+		})
+		futures = append(futures, future)
+	}
+
+	startedTasks := make([]int, 0, poolSize)
+	for i := 0; i < poolSize; i++ {
+		startedTasks = append(startedTasks, requireStarted(t, started))
+	}
+	assert.ElementsMatch(t, []int{0, 1, 2}, startedTasks)
+	requireNoBufferedStart(t, started)
+
+	close(releases[poolSize-1])
+	value, err := awaitFuture(t, futures[poolSize-1])
+	require.NoError(t, err)
+	assert.Equal(t, poolSize-1, value)
+	assert.False(t, futures[0].Done())
+	assert.False(t, futures[1].Done())
+	require.Equal(t, poolSize, requireStarted(t, started))
+
+	for i := 0; i < taskNum-poolSize-1; i++ {
+		taskID := i
+		if i >= poolSize-1 {
+			taskID++
+		}
+		close(releases[taskID])
+		value, err := awaitFuture(t, futures[taskID])
+		require.NoError(t, err)
+		assert.Equal(t, taskID, value)
+
+		require.Equal(t, i+poolSize+1, requireStarted(t, started))
+	}
+
+	for i := taskNum - poolSize; i < taskNum; i++ {
+		close(releases[i])
+		value, err := awaitFuture(t, futures[i])
+		require.NoError(t, err)
+		assert.Equal(t, i, value)
+	}
+}
+
+func TestOrderedExecPoolHOLBlocking(t *testing.T) {
+	const taskNum = 6
+
+	inner := conc.NewPool[any](1, conc.WithDisablePurge(true))
+	pool := newOrderedExecPool(inner)
+	defer closeOrderedExecPoolForTest(pool)
+
+	releaseOccupy := make(chan struct{})
+	occupy := inner.Submit(func() (any, error) {
+		<-releaseOccupy
+		return nil, nil
+	})
+
+	started := make(chan int, taskNum)
+	releases := make([]chan struct{}, taskNum)
+	futures := make([]*conc.Future[any], 0, taskNum)
+
+	for i := 0; i < taskNum; i++ {
+		taskID := i
+		releases[taskID] = make(chan struct{})
+		future := pool.Submit(func() (any, error) {
+			started <- taskID
+			<-releases[taskID]
+			return taskID, nil
+		})
+		futures = append(futures, future)
+	}
+
+	waitQueueLen(t, &pool.queue, taskNum-1)
+	requireNoBufferedStart(t, started)
+
+	close(releaseOccupy)
+	_, err := awaitFuture(t, occupy)
+	require.NoError(t, err)
+
+	for i := 0; i < taskNum; i++ {
+		require.Equal(t, i, requireStarted(t, started))
+		requireNoBufferedStart(t, started)
+		close(releases[i])
+		value, err := awaitFuture(t, futures[i])
+		require.NoError(t, err)
+		assert.Equal(t, i, value)
+	}
+}
+
+func closeOrderedExecPoolForTest(pool *orderedExecPool) {
+	close(pool.closeCh)
+	pool.inner.Release()
+}
+
+func requireStarted(t *testing.T, started <-chan int) int {
+	t.Helper()
+
+	select {
+	case taskID := <-started:
+		return taskID
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for task start")
+		return 0
+	}
+}
+
+func requireNoBufferedStart(t *testing.T, started <-chan int) {
+	t.Helper()
+
+	select {
+	case taskID := <-started:
+		require.FailNowf(t, "unexpected task start", "task %d started unexpectedly", taskID)
+	default:
+	}
+}
+
+func waitQueueLen[T any](t *testing.T, queue *conc.ConcurrentQueue[T], expected int) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return queue.Len() == expected
+	}, time.Second, 10*time.Millisecond)
+}
+
+func awaitFuture(t *testing.T, future *conc.Future[any]) (any, error) {
+	t.Helper()
+
+	select {
+	case <-future.Inner():
+		return future.Await()
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for future")
+		return nil, nil
+	}
 }

--- a/internal/datanode/importv2/scheduler.go
+++ b/internal/datanode/importv2/scheduler.go
@@ -38,6 +38,7 @@ type Scheduler interface {
 type scheduler struct {
 	manager TaskManager
 
+	futures   map[int64][]*conc.Future[any]
 	closeOnce sync.Once
 	closeChan chan struct{}
 }
@@ -45,6 +46,7 @@ type scheduler struct {
 func NewScheduler(manager TaskManager) Scheduler {
 	return &scheduler{
 		manager:   manager,
+		futures:   make(map[int64][]*conc.Future[any]),
 		closeChan: make(chan struct{}),
 	}
 }
@@ -73,6 +75,8 @@ func (s *scheduler) Start() {
 }
 
 func (s *scheduler) scheduleTasks() {
+	s.tryFreeFutures()
+
 	tasks := s.manager.GetBy(WithStates(datapb.ImportTaskStateV2_Pending))
 	sort.Slice(tasks, func(i, j int) bool {
 		return tasks[i].GetTaskID() < tasks[j].GetTaskID()
@@ -87,22 +91,15 @@ func (s *scheduler) scheduleTasks() {
 	})
 	mlog.Info(context.TODO(), "processing tasks...", mlog.Int64s("taskIDs", taskIDs))
 
-	futures := make(map[int64][]*conc.Future[any])
 	for _, task := range tasks {
-		fs := task.Execute()
-		futures[task.GetTaskID()] = fs
-	}
-
-	for taskID, fs := range futures {
-		err := conc.AwaitAll(fs...)
-		if err != nil {
+		taskID := task.GetTaskID()
+		if _, ok := s.futures[taskID]; ok {
 			continue
 		}
-		s.manager.Update(taskID, UpdateState(datapb.ImportTaskStateV2_Completed))
-		mlog.Info(context.TODO(), "preimport/import done", mlog.FieldTaskID(taskID))
+		s.futures[taskID] = task.Execute()
 	}
 
-	mlog.Info(context.TODO(), "all tasks completed", mlog.Int64s("taskIDs", taskIDs))
+	s.tryFreeFutures()
 }
 
 // Slots returns the used slots for import
@@ -120,15 +117,32 @@ func (s *scheduler) Close() {
 	})
 }
 
-func tryFreeFutures(futures map[int64][]*conc.Future[any]) {
-	for k, fs := range futures {
-		fs = lo.Filter(fs, func(f *conc.Future[any], _ int) bool {
-			if f.Done() {
-				_, err := f.Await()
-				return err != nil
-			}
-			return true
-		})
-		futures[k] = fs
+func (s *scheduler) tryFreeFutures() {
+	for taskID, fs := range s.futures {
+		task := s.manager.Get(taskID)
+		if task == nil {
+			delete(s.futures, taskID)
+			continue
+		}
+		if task.GetState() == datapb.ImportTaskStateV2_Failed {
+			delete(s.futures, taskID)
+			mlog.Warn(context.TODO(), "preimport/import failed", WrapLogFields(task)...)
+			continue
+		}
+
+		if lo.SomeBy(fs, func(f *conc.Future[any]) bool {
+			return !f.Done()
+		}) {
+			continue
+		}
+
+		err := conc.AwaitAll(fs...)
+		delete(s.futures, taskID)
+		if err != nil {
+			mlog.Warn(context.TODO(), "preimport/import failed", WrapLogFields(task, mlog.Err(err))...)
+			continue
+		}
+		s.manager.Update(taskID, UpdateState(datapb.ImportTaskStateV2_Completed))
+		mlog.Info(context.TODO(), "preimport/import done", mlog.FieldTaskID(taskID))
 	}
 }

--- a/internal/datanode/importv2/scheduler_test.go
+++ b/internal/datanode/importv2/scheduler_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -65,6 +66,78 @@ type mockReader struct {
 
 func (mr *mockReader) Size() (int64, error) {
 	return mr.size, nil
+}
+
+type schedulerTestTask struct {
+	taskID int64
+	state  *atomic.Int32
+
+	execute func() []*conc.Future[any]
+}
+
+func newSchedulerTestTask(taskID int64, execute func() []*conc.Future[any]) *schedulerTestTask {
+	task := &schedulerTestTask{
+		taskID:  taskID,
+		state:   atomic.NewInt32(int32(datapb.ImportTaskStateV2_Pending)),
+		execute: execute,
+	}
+	return task
+}
+
+func (t *schedulerTestTask) Execute() []*conc.Future[any] {
+	t.state.Store(int32(datapb.ImportTaskStateV2_InProgress))
+	return t.execute()
+}
+
+func (t *schedulerTestTask) GetJobID() int64 {
+	return 1
+}
+
+func (t *schedulerTestTask) GetTaskID() int64 {
+	return t.taskID
+}
+
+func (t *schedulerTestTask) GetCollectionID() int64 {
+	return 1
+}
+
+func (t *schedulerTestTask) GetPartitionIDs() []int64 {
+	return nil
+}
+
+func (t *schedulerTestTask) GetVchannels() []string {
+	return nil
+}
+
+func (t *schedulerTestTask) GetType() TaskType {
+	return TaskType(-1)
+}
+
+func (t *schedulerTestTask) GetState() datapb.ImportTaskStateV2 {
+	return datapb.ImportTaskStateV2(t.state.Load())
+}
+
+func (t *schedulerTestTask) GetReason() string {
+	return ""
+}
+
+func (t *schedulerTestTask) GetSchema() *schemapb.CollectionSchema {
+	return nil
+}
+
+func (t *schedulerTestTask) GetSlots() int64 {
+	return 1
+}
+
+func (t *schedulerTestTask) GetBufferSize() int64 {
+	return 0
+}
+
+func (t *schedulerTestTask) Cancel() {
+}
+
+func (t *schedulerTestTask) Clone() Task {
+	return t
 }
 
 type SchedulerSuite struct {
@@ -141,6 +214,94 @@ func (s *SchedulerSuite) TestScheduler_Slots() {
 
 	slots := s.scheduler.Slots()
 	s.Equal(int64(10), slots)
+}
+
+func (s *SchedulerSuite) TestScheduler_DoesNotBlockShortTaskBehindLongFuture() {
+	longDone := make(chan struct{})
+	longStarted := make(chan struct{})
+	shortStarted := make(chan struct{})
+	var longFuture *conc.Future[any]
+
+	longTask := newSchedulerTestTask(1, func() []*conc.Future[any] {
+		close(longStarted)
+		longFuture = conc.Go(func() (any, error) {
+			<-longDone
+			return nil, nil
+		})
+		return []*conc.Future[any]{longFuture}
+	})
+	shortTask := newSchedulerTestTask(2, func() []*conc.Future[any] {
+		close(shortStarted)
+		return []*conc.Future[any]{
+			conc.Go(func() (any, error) {
+				return nil, nil
+			}),
+		}
+	})
+	s.manager.Add(longTask)
+	s.manager.Add(shortTask)
+
+	s.scheduler.scheduleTasks()
+	requireClosed(s.T(), longStarted)
+	requireClosed(s.T(), shortStarted)
+	s.Require().NotNil(longFuture)
+	s.False(longFuture.Done())
+
+	select {
+	case <-longDone:
+		s.Fail("long task completed before short task started")
+	default:
+	}
+	close(longDone)
+}
+
+func (s *SchedulerSuite) TestScheduler_FreesCompletedTaskInSameSchedule() {
+	doneFuture := conc.Go(func() (any, error) {
+		return nil, nil
+	})
+	_, err := doneFuture.Await()
+	s.NoError(err)
+
+	task := newSchedulerTestTask(1, func() []*conc.Future[any] {
+		return []*conc.Future[any]{
+			doneFuture,
+		}
+	})
+	s.manager.Add(task)
+
+	s.scheduler.scheduleTasks()
+
+	s.Empty(s.scheduler.futures)
+}
+
+func (s *SchedulerSuite) TestScheduler_FreesFailedTaskWithUnfinishedFutures() {
+	task := newSchedulerTestTask(1, func() []*conc.Future[any] {
+		return nil
+	})
+	task.state.Store(int32(datapb.ImportTaskStateV2_Failed))
+	s.manager.Add(task)
+
+	block := make(chan struct{})
+	defer close(block)
+	future := conc.Go(func() (any, error) {
+		<-block
+		return nil, nil
+	})
+	s.scheduler.futures[task.GetTaskID()] = []*conc.Future[any]{future}
+
+	s.scheduler.tryFreeFutures()
+
+	s.Empty(s.scheduler.futures)
+}
+
+func requireClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	default:
+		t.Fatal("channel is not closed")
+	}
 }
 
 func (s *SchedulerSuite) TestScheduler_Start_Preimport() {

--- a/pkg/util/conc/concurrent_queue.go
+++ b/pkg/util/conc/concurrent_queue.go
@@ -1,0 +1,55 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conc
+
+import "sync"
+
+type ConcurrentQueue[T any] struct {
+	mu    sync.Mutex
+	items []T
+}
+
+func (q *ConcurrentQueue[T]) Enqueue(item T) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.items = append(q.items, item)
+}
+
+func (q *ConcurrentQueue[T]) Dequeue() (T, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.items) == 0 {
+		var zero T
+		return zero, false
+	}
+
+	item := q.items[0]
+	var zero T
+	q.items[0] = zero
+	q.items = q.items[1:]
+
+	return item, true
+}
+
+func (q *ConcurrentQueue[T]) Len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	return len(q.items)
+}

--- a/pkg/util/conc/concurrent_queue_test.go
+++ b/pkg/util/conc/concurrent_queue_test.go
@@ -1,0 +1,72 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conc
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrentQueue(t *testing.T) {
+	var queue ConcurrentQueue[int]
+
+	_, ok := queue.Dequeue()
+	require.False(t, ok)
+
+	queue.Enqueue(1)
+	queue.Enqueue(2)
+	assert.Equal(t, 2, queue.Len())
+
+	item, ok := queue.Dequeue()
+	require.True(t, ok)
+	assert.Equal(t, 1, item)
+
+	item, ok = queue.Dequeue()
+	require.True(t, ok)
+	assert.Equal(t, 2, item)
+	assert.Equal(t, 0, queue.Len())
+}
+
+func TestConcurrentQueueConcurrentEnqueue(t *testing.T) {
+	var queue ConcurrentQueue[int]
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < 100; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			queue.Enqueue(i)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 100, queue.Len())
+	seen := make(map[int]struct{}, 100)
+	for {
+		item, ok := queue.Dequeue()
+		if !ok {
+			break
+		}
+		seen[item] = struct{}{}
+	}
+
+	assert.Len(t, seen, 100)
+}

--- a/pkg/util/conc/future.go
+++ b/pkg/util/conc/future.go
@@ -16,8 +16,6 @@
 
 package conc
 
-import "go.uber.org/atomic"
-
 type future interface {
 	wait()
 	OK() bool
@@ -31,13 +29,11 @@ type Future[T any] struct {
 	ch    chan struct{}
 	value T
 	err   error
-	done  *atomic.Bool
 }
 
 func newFuture[T any]() *Future[T] {
 	return &Future[T]{
-		ch:   make(chan struct{}),
-		done: atomic.NewBool(false),
+		ch: make(chan struct{}),
 	}
 }
 
@@ -61,7 +57,12 @@ func (future *Future[T]) Value() T {
 
 // Done indicates if the fn has finished.
 func (future *Future[T]) Done() bool {
-	return future.done.Load()
+	select {
+	case <-future.ch:
+		return true
+	default:
+		return false
+	}
 }
 
 // False if error occurred,
@@ -95,7 +96,6 @@ func Go[T any](fn func() (T, error)) *Future[T] {
 	go func() {
 		future.value, future.err = fn()
 		close(future.ch)
-		future.done.Store(true)
 	}()
 	return future
 }

--- a/pkg/util/conc/future_test.go
+++ b/pkg/util/conc/future_test.go
@@ -47,6 +47,21 @@ func (s *FutureSuite) TestFuture() {
 	s.Equal(10, resultFuture.Value())
 }
 
+func (s *FutureSuite) TestDone() {
+	release := make(chan struct{})
+	future := Go(func() (int, error) {
+		<-release
+		return 1, nil
+	})
+
+	s.False(future.Done())
+	close(release)
+	value, err := future.Await()
+	s.NoError(err)
+	s.Equal(1, value)
+	s.True(future.Done())
+}
+
 func (s *FutureSuite) TestBlockOnAll() {
 	cnt := atomic.NewInt32(0)
 	futures := make([]*Future[struct{}], 10)

--- a/pkg/util/conc/pool_test.go
+++ b/pkg/util/conc/pool_test.go
@@ -44,6 +44,7 @@ func TestPool(t *testing.T) {
 	for i, future := range futures {
 		res, err := future.Await()
 		assert.NoError(t, err)
+		assert.True(t, future.Done())
 		assert.Equal(t, err, future.Err())
 		assert.True(t, future.OK())
 		assert.Equal(t, res, future.Value())
@@ -86,4 +87,18 @@ func TestPoolWithPanic(t *testing.T) {
 	// make sure error returned when conceal panic
 	_, err := future.Await()
 	assert.Error(t, err)
+	assert.True(t, future.Done())
+}
+
+func TestPoolSubmitDoneWhenSubmitFails(t *testing.T) {
+	pool := NewPool[any](1)
+	pool.Release()
+
+	future := pool.Submit(func() (any, error) {
+		return nil, nil
+	})
+
+	_, err := future.Await()
+	assert.Error(t, err)
+	assert.True(t, future.Done())
 }


### PR DESCRIPTION
issue: #51161

## What this PR does

Fixes DataNode import scheduler head-of-line blocking.

Before this change, the scheduler picked all pending import tasks, called `Execute()` for the batch, and then waited for all returned file-level futures before returning to the scheduler loop. One slow import task could therefore keep the scheduler from seeing later pending tasks, even when those later tasks were small and execution slots were still available.

This PR changes two parts of the flow:

### 1. Non-blocking scheduler future tracking

The scheduler now keeps in-flight futures by task ID. On each tick it:

- collects futures that have finished;
- marks tasks completed when all their futures are done;
- schedules pending tasks without calling `AwaitAll` in the scheduler loop.

Task completion remains asynchronous, so a long-running task no longer blocks the next scheduling tick.

### 2. Ordered import execution-pool admission

`task.Execute()` submits file-level work to the import execution pool. The underlying ants pool can block `Submit()` when saturated, but it does not guarantee FIFO wake-up for blocked submitters. That can let later tasks overtake earlier tasks under heavy queueing.

This PR wraps the import execution pool with an ordered dispatcher: file work is admitted to the inner pool in submit order, while actual task completion remains independent. This preserves lower task ID execution order without forcing tasks to finish in order.

## Benchmarks

Added a deterministic virtual-time scheduler benchmark. It isolates scheduler behavior from storage reads, network latency, and import data processing. A virtual tick represents modeled task execution time and is not a wall-clock duration.

The benchmark compares the previous blocking-batch policy with the new non-blocking policy under two workloads.

### Head-of-line workload

Configuration:

- 64 execution slots;
- one head task containing 16 long-running jobs, each taking 1,000 virtual ticks;
- 1,024 one-tick tasks arriving in the next scheduling round;
- 48 slots remain available while the head task is running.

| Metric | Blocking batch | Non-blocking |
|---|---:|---:|
| Small tasks completed before the head task | 0 / 1,024 | 1,024 / 1,024 |
| Small-task p50 latency | 1,007 ticks | 11 ticks |
| Small-task p95 latency | 1,015 ticks | 21 ticks |
| Small-task p99 latency | 1,015 ticks | 22 ticks |
| Total makespan | 1,016 ticks | 1,000 ticks |
| Throughput | 1,009 tasks/Ktick | 1,025 tasks/Ktick |

Under this modeled workload, the non-blocking policy reduces small-task p50 latency by 91.55x and allows every small task to finish before the head task. The available execution slots are used immediately instead of remaining idle behind the blocking batch.

### Normal-distribution workload

The non-regression workload contains 4,096 tasks on 64 slots. All tasks arrive in the same scheduling batch, and task durations are generated from a normal distribution `N(20, 5)` using a fixed random seed for reproducibility.

| Metric | Blocking batch | Non-blocking |
|---|---:|---:|
| Task p50 latency | 652 ticks | 652 ticks |
| Task p95 latency | 1,225 ticks | 1,225 ticks |
| Task p99 latency | 1,276 ticks | 1,276 ticks |
| Total makespan | 1,297 ticks | 1,297 ticks |
| Throughput | 3,158 tasks/Ktick | 3,158 tasks/Ktick |

The normal workload produces identical latency, makespan, and throughput results for both policies, showing no modeled scheduling-efficiency regression when all work belongs to a regular batch.