### PR TITLE
test: fix TextMatchIndex fuzzy test constructor

### DIFF
--- a/internal/core/src/index/TextMatchIndexTest.cpp
+++ b/internal/core/src/index/TextMatchIndexTest.cpp
@@ -348,7 +348,8 @@ TEST(TextMatch, FuzzyIndex) {
     auto index = std::make_unique<Index>(std::numeric_limits<int64_t>::max(),
                                          "unique_id",
                                          "milvus_tokenizer",
-                                         "{}");
+                                         "{}",
+                                         /*enable_background_merge=*/false);
     index->CreateReader(milvus::index::SetBitsetSealed);
     index->AddTextSealed("football, basketball, pingpang", true, 0);
     index->AddTextSealed("", false, 1);


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/51054