### PR TITLE
enhance: track JSON stats in runtime state

### DIFF
--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -229,7 +229,10 @@ TEST(JsonContainsByStatsTest, BasicContainsAnyOnArray) {
                                           field_id,
                                           build_id,
                                           version_id);
-    segment->LoadJsonStats(json_fid, stats);
+    auto* sealed =
+        dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    sealed->SetJsonStatsForTesting(json_fid, stats);
 
     // Load raw field data into sealed segment for execution
     std::vector<milvus::Json> jsons;
@@ -312,7 +315,10 @@ TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathUnknownsAndMasksFieldNull) {
                                           build_id,
                                           version_id,
                                           &valid_data);
-    segment->LoadJsonStats(json_fid, stats);
+    auto* sealed =
+        dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    sealed->SetJsonStatsForTesting(json_fid, stats);
 
     auto json_field =
         std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1596,15 +1596,6 @@ ChunkedSegmentSealedImpl::PublishRuntimeStateLocked(
             current->schema, current->load_info, runtime, current->commit_ts)));
 }
 
-void
-ChunkedSegmentSealedImpl::LoadJsonStats(
-    FieldId field_id, std::shared_ptr<index::JsonKeyStats> stats) {
-    std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
-    auto runtime = CloneMutableRuntimeResourceState();
-    runtime->json_stats[field_id] = std::move(stats);
-    PublishRuntimeStateLocked(ToConstRuntimeState(std::move(runtime)));
-}
-
 std::shared_ptr<index::JsonKeyStats>
 ChunkedSegmentSealedImpl::GetJsonStats(milvus::OpContext* op_ctx,
                                        FieldId field_id) const {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -899,6 +899,7 @@ ChunkedSegmentSealedImpl::CloneRuntimeResourceState(
     state->ngram_fields = current->ngram_fields;
     state->ngram_indexings = current->ngram_indexings;
     state->text_lob_paths = current->text_lob_paths;
+    state->json_stats = current->json_stats;
     state->reader = current->reader;
     state->timestamps = current->timestamps;
     state->timestamp_index = current->timestamp_index;
@@ -1149,6 +1150,7 @@ ChunkedSegmentSealedImpl::FreezeRuntimeResourceState(
     runtime->ngram_fields = current.ngram_fields;
     runtime->ngram_indexings = current.ngram_indexings;
     runtime->text_lob_paths = current.text_lob_paths;
+    runtime->json_stats = current.json_stats;
     runtime->reader = current.reader;
     runtime->timestamps = current.timestamps;
     runtime->timestamp_index = current.timestamp_index;
@@ -1592,6 +1594,29 @@ ChunkedSegmentSealedImpl::PublishRuntimeStateLocked(
         current,
         MakeStateDelta(
             current->schema, current->load_info, runtime, current->commit_ts)));
+}
+
+void
+ChunkedSegmentSealedImpl::LoadJsonStats(
+    FieldId field_id, std::shared_ptr<index::JsonKeyStats> stats) {
+    std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+    auto runtime = CloneMutableRuntimeResourceState();
+    runtime->json_stats[field_id] = std::move(stats);
+    PublishRuntimeStateLocked(ToConstRuntimeState(std::move(runtime)));
+}
+
+std::shared_ptr<index::JsonKeyStats>
+ChunkedSegmentSealedImpl::GetJsonStats(milvus::OpContext* op_ctx,
+                                       FieldId field_id) const {
+    auto runtime = CaptureRuntimeResourceState();
+    if (runtime == nullptr) {
+        return nullptr;
+    }
+    auto iter = runtime->json_stats.find(field_id);
+    if (iter == runtime->json_stats.end()) {
+        return nullptr;
+    }
+    return iter->second;
 }
 
 void
@@ -5231,15 +5256,16 @@ ChunkedSegmentSealedImpl::LoadTextIndex(
     build_guard.Commit(std::move(cache_slot));
 }
 
-void
-ChunkedSegmentSealedImpl::LoadJsonKeyIndex(
+std::shared_ptr<index::JsonKeyStats>
+ChunkedSegmentSealedImpl::BuildJsonKeyStatsIndex(
     milvus::OpContext* op_ctx,
-    std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo> info_proto) {
+    const std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>&
+        info_proto) {
     auto field_id = milvus::FieldId(info_proto->fieldid());
     CheckCancellation(op_ctx,
                       id_,
                       field_id.get(),
-                      "ChunkedSegmentSealedImpl::LoadJsonKeyIndex()");
+                      "ChunkedSegmentSealedImpl::BuildJsonKeyStatsIndex()");
 
     if (!JSON_KEY_STATS_ENABLED.load()) {
         LOG_WARN(
@@ -5249,7 +5275,7 @@ ChunkedSegmentSealedImpl::LoadJsonKeyIndex(
             info_proto->fieldid(),
             info_proto->buildid(),
             info_proto->version());
-        return;
+        return nullptr;
     }
 
     LOG_INFO(
@@ -5327,7 +5353,6 @@ ChunkedSegmentSealedImpl::LoadJsonKeyIndex(
         throw;
     }
 
-    LoadJsonStats(field_id, std::move(index));
     LOG_INFO(
         "load json key stats success, segment:{}, field:{}, build:{}, "
         "version:{}",
@@ -5335,6 +5360,7 @@ ChunkedSegmentSealedImpl::LoadJsonKeyIndex(
         info_proto->fieldid(),
         info_proto->buildid(),
         info_proto->version());
+    return index;
 }
 
 void
@@ -5343,23 +5369,22 @@ ChunkedSegmentSealedImpl::LoadBatchJsonKeyIndexes(
     const std::unordered_map<
         FieldId,
         std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>>& infos,
-    const SchemaPtr& schema_snapshot) {
+    const SchemaPtr& schema_snapshot,
+    StagedStateCommitter& committer) {
     for (const auto& [field_id, info_proto] : infos) {
         AssertInfo(field_exists_in_schema(schema_snapshot, field_id),
                    "field {} not found in schema when loading json stats",
                    field_id.get());
-        LoadJsonKeyIndex(op_ctx, info_proto);
+        auto index = BuildJsonKeyStatsIndex(op_ctx, info_proto);
+        if (index == nullptr) {
+            continue;
+        }
+        committer.Commit(
+            [field_id, index = std::move(index)](
+                RuntimeResourceState& runtime, PublishedSegmentState&) mutable {
+                runtime.json_stats[field_id] = std::move(index);
+            });
     }
-}
-
-void
-ChunkedSegmentSealedImpl::LoadBatchJsonKeyIndexes(
-    milvus::OpContext* op_ctx,
-    const std::unordered_map<
-        FieldId,
-        std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>>&
-        infos) {
-    LoadBatchJsonKeyIndexes(op_ctx, infos, CaptureSchemaSnapshot());
 }
 
 void
@@ -6793,11 +6818,11 @@ ChunkedSegmentSealedImpl::PrepareLoadDiffForReopen(
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
     if (!diff.json_stats_to_load.empty()) {
         LoadBatchJsonKeyIndexes(
-            op_ctx, diff.json_stats_to_load, schema_snapshot);
+            op_ctx, diff.json_stats_to_load, schema_snapshot, committer);
     }
     if (!diff.json_stats_to_replace.empty()) {
         LoadBatchJsonKeyIndexes(
-            op_ctx, diff.json_stats_to_replace, schema_snapshot);
+            op_ctx, diff.json_stats_to_replace, schema_snapshot, committer);
     }
 
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
@@ -6859,7 +6884,10 @@ ChunkedSegmentSealedImpl::FinalizeLoadDiffForReopen(
             LOG_INFO("drop json key stats, segment:{}, field:{}",
                      id_,
                      field_id.get());
-            RemoveJsonStats(field_id);
+            committer.Commit([field_id](RuntimeResourceState& runtime,
+                                        PublishedSegmentState&) {
+                runtime.json_stats.erase(field_id);
+            });
         }
     }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -255,10 +255,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                   std::shared_ptr<milvus::proto::indexcgo::LoadTextIndexInfo>
                       info_proto) override;
 
-    void
-    LoadJsonStats(FieldId field_id,
-                  std::shared_ptr<index::JsonKeyStats> stats) override;
-
     std::shared_ptr<index::JsonKeyStats>
     GetJsonStats(milvus::OpContext* op_ctx, FieldId field_id) const override;
 
@@ -2455,6 +2451,19 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         auto runtime = CloneRuntimeResourceState(current->runtime);
         runtime->text_lob_paths[field_id] = std::move(lob_base_path);
         next->runtime = ToConstRuntimeState(std::move(runtime));
+        PublishState(std::move(next));
+    }
+
+    void
+    SetJsonStatsForTesting(FieldId field_id,
+                           std::shared_ptr<index::JsonKeyStats> stats) {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+        auto current = CapturePublishedState();
+        auto next = ClonePublishedState(current);
+        auto runtime = CloneRuntimeResourceState(current->runtime);
+        runtime->json_stats[field_id] = std::move(stats);
+        next->runtime = ToConstRuntimeState(std::move(runtime));
+        NormalizePublishedState(*next);
         PublishState(std::move(next));
     }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -256,50 +256,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                       info_proto) override;
 
     void
-    LoadJsonKeyIndex(
-        milvus::OpContext* op_ctx,
-        std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>
-            info_proto);
-
-    void
-    LoadBatchJsonKeyIndexes(
-        milvus::OpContext* op_ctx,
-        const std::unordered_map<
-            FieldId,
-            std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>>&
-            infos,
-        const SchemaPtr& schema_snapshot);
-
-    void
-    LoadBatchJsonKeyIndexes(
-        milvus::OpContext* op_ctx,
-        const std::unordered_map<
-            FieldId,
-            std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>>&
-            infos);
-
-    void
-    RemoveJsonStats(FieldId field_id) override {
-        std::unique_lock lck(mutex_);
-        json_stats_.erase(field_id);
-    }
-
-    void
     LoadJsonStats(FieldId field_id,
-                  std::shared_ptr<index::JsonKeyStats> stats) override {
-        std::unique_lock lck(mutex_);
-        json_stats_[field_id] = stats;
-    }
+                  std::shared_ptr<index::JsonKeyStats> stats) override;
 
     std::shared_ptr<index::JsonKeyStats>
-    GetJsonStats(milvus::OpContext* op_ctx, FieldId field_id) const override {
-        std::shared_lock lck(mutex_);
-        auto iter = json_stats_.find(field_id);
-        if (iter == json_stats_.end()) {
-            return nullptr;
-        }
-        return iter->second;
-    }
+    GetJsonStats(milvus::OpContext* op_ctx, FieldId field_id) const override;
 
     PinWrapper<index::NgramInvertedIndex*>
     GetNgramIndex(milvus::OpContext* op_ctx, FieldId field_id) const override;
@@ -380,6 +341,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
             std::unordered_map<std::string, index::CacheIndexBasePtr>>
             ngram_indexings;
         std::unordered_map<FieldId, std::string> text_lob_paths;
+        std::unordered_map<FieldId, std::shared_ptr<index::JsonKeyStats>>
+            json_stats;
         std::shared_ptr<milvus_storage::api::Reader> reader;
         std::shared_ptr<TimestampData> timestamps;
         std::shared_ptr<const TimestampIndex> timestamp_index;
@@ -1558,6 +1521,22 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     PublishState(std::shared_ptr<PublishedSegmentState> state);
+
+    std::shared_ptr<index::JsonKeyStats>
+    BuildJsonKeyStatsIndex(
+        milvus::OpContext* op_ctx,
+        const std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>&
+            info_proto);
+
+    void
+    LoadBatchJsonKeyIndexes(
+        milvus::OpContext* op_ctx,
+        const std::unordered_map<
+            FieldId,
+            std::shared_ptr<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>>&
+            infos,
+        const SchemaPtr& schema_snapshot,
+        StagedStateCommitter& committer);
 
     template <typename Mutator>
     void

--- a/internal/core/src/segcore/SegmentSealed.h
+++ b/internal/core/src/segcore/SegmentSealed.h
@@ -182,9 +182,6 @@ class SegmentSealed : public SegmentInternalInterface {
     LoadJsonStats(FieldId field_id,
                   std::shared_ptr<index::JsonKeyStats> stats) = 0;
 
-    virtual void
-    RemoveJsonStats(FieldId field_id) = 0;
-
     SegmentType
     type() const override {
         return SegmentType::Sealed;

--- a/internal/core/src/segcore/SegmentSealed.h
+++ b/internal/core/src/segcore/SegmentSealed.h
@@ -178,9 +178,6 @@ class SegmentSealed : public SegmentInternalInterface {
     GetNgramIndexForJson(milvus::OpContext* op_ctx,
                          FieldId field_id,
                          const std::string& nested_path) const override = 0;
-    virtual void
-    LoadJsonStats(FieldId field_id,
-                  std::shared_ptr<index::JsonKeyStats> stats) = 0;
 
     SegmentType
     type() const override {

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -38,7 +38,6 @@
 #include "common/OpContext.h"
 #include "common/QueryInfo.h"
 #include "common/QueryResult.h"
-#include "common/ScopedTimer.h"
 #include "common/Tracer.h"
 #include "common/Types.h"
 #include "common/Utils.h"
@@ -54,14 +53,11 @@
 #include "futures/Future.h"
 #include "glog/logging.h"
 #include "index/Meta.h"
-#include "index/json_stats/JsonKeyStats.h"
 #include "log/Log.h"
 #include "milvus-storage/filesystem/fs.h"
-#include "monitor/Monitor.h"
 #include "monitor/scope_metric.h"
 #include "nlohmann/json.hpp"
 #include "opentelemetry/trace/span.h"
-#include "pb/index_cgo_msg.pb.h"
 #include "pb/schema.pb.h"
 #include "pb/segcore.pb.h"
 #include "prometheus/histogram.h"
@@ -77,7 +73,6 @@
 #include "segcore/SegmentSealed.h"
 #include "segcore/Types.h"
 #include "storage/FileManager.h"
-#include "storage/RemoteChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/loon_ffi/property_singleton.h"
@@ -743,113 +738,6 @@ UpdateSealedSegmentIndex(CSegmentInterface c_segment,
         auto load_index_info =
             static_cast<milvus::segcore::LoadIndexInfo*>(c_load_index_info);
         segment->LoadIndex(*load_index_info);
-        return milvus::SuccessCStatus();
-    } catch (std::exception& e) {
-        return milvus::FailureCStatus(&e);
-    }
-}
-
-CStatus
-LoadJsonKeyIndex(CTraceContext c_trace,
-                 CSegmentInterface c_segment,
-                 const uint8_t* serialized_load_json_key_index_info,
-                 const uint64_t len,
-                 CLoadCancellationSource source) {
-    SCOPE_CGO_CALL_METRIC();
-
-    try {
-        auto ctx = milvus::tracer::TraceContext{
-            c_trace.traceID, c_trace.spanID, c_trace.traceFlags};
-        auto segment_interface =
-            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
-        auto segment =
-            dynamic_cast<milvus::segcore::SegmentSealed*>(segment_interface);
-        AssertInfo(segment != nullptr, "segment conversion failed");
-
-        // Check for cancellation before starting
-        if (source) {
-            auto cancellation_source =
-                static_cast<folly::CancellationSource*>(source);
-            if (cancellation_source->getToken().isCancellationRequested()) {
-                throw milvus::SegcoreError(
-                    milvus::ErrorCode::FollyCancel,
-                    fmt::format("Load cancelled for segment {} json stats",
-                                segment->get_segment_id()));
-            }
-        }
-
-        auto info_proto =
-            std::make_unique<milvus::proto::indexcgo::LoadJsonKeyIndexInfo>();
-        info_proto->ParseFromArray(serialized_load_json_key_index_info, len);
-        if (!milvus::JSON_KEY_STATS_ENABLED.load()) {
-            LOG_WARN(
-                "skip load json stats because json key stats is disabled, "
-                "segment:{}, field:{}, build:{}, version:{}",
-                segment->get_segment_id(),
-                info_proto->fieldid(),
-                info_proto->buildid(),
-                info_proto->version());
-            return milvus::SuccessCStatus();
-        }
-
-        milvus::storage::FieldDataMeta field_meta{info_proto->collectionid(),
-                                                  info_proto->partitionid(),
-                                                  segment->get_segment_id(),
-                                                  info_proto->fieldid(),
-                                                  info_proto->schema()};
-        milvus::storage::IndexMeta index_meta{segment->get_segment_id(),
-                                              info_proto->fieldid(),
-                                              info_proto->buildid(),
-                                              info_proto->version()};
-        auto remote_chunk_manager =
-            milvus::storage::RemoteChunkManagerSingleton::GetInstance()
-                .GetRemoteChunkManager();
-        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
-        AssertInfo(fs != nullptr, "arrow file system is null");
-
-        milvus::Config config;
-        std::vector<std::string> files;
-        files.reserve(info_proto->files_size());
-        for (const auto& f : info_proto->files()) {
-            files.push_back(f);
-        }
-        config[milvus::index::INDEX_FILES] = files;
-        config[milvus::LOAD_PRIORITY] = info_proto->load_priority();
-        config[milvus::index::ENABLE_MMAP] = info_proto->enable_mmap();
-        if (info_proto->enable_mmap()) {
-            config[milvus::index::MMAP_FILE_PATH] = info_proto->mmap_dir_path();
-        }
-        if (info_proto->warmup_policy() != "") {
-            config[milvus::index::WARMUP] = info_proto->warmup_policy();
-        }
-        config[milvus::index::INDEX_SIZE] = info_proto->stats_size();
-        if (!info_proto->base_path().empty()) {
-            config[STATS_BASE_PATH_KEY] = info_proto->base_path();
-        }
-
-        milvus::storage::FileManagerContext file_ctx(
-            field_meta, index_meta, remote_chunk_manager, fs);
-
-        auto index =
-            std::make_shared<milvus::index::JsonKeyStats>(file_ctx, true);
-        {
-            milvus::ScopedTimer timer(
-                "json_stats_load",
-                [](double us) {
-                    milvus::monitor::internal_json_stats_latency_load.Observe(
-                        us / 1000.0);
-                },
-                milvus::ScopedTimer::LogLevel::Info);
-            index->Load(ctx, config);
-        }
-
-        segment->LoadJsonStats(milvus::FieldId(info_proto->fieldid()),
-                               std::move(index));
-
-        LOG_INFO("load json stats success for field:{} of segment:{}",
-                 info_proto->fieldid(),
-                 segment->get_segment_id());
-
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -249,13 +249,6 @@ UpdateSealedSegmentIndex(CSegmentInterface c_segment,
                          CLoadIndexInfo c_load_index_info);
 
 CStatus
-LoadJsonKeyIndex(CTraceContext c_trace,
-                 CSegmentInterface c_segment,
-                 const uint8_t* serialied_load_json_key_index_info,
-                 const uint64_t len,
-                 CLoadCancellationSource source);
-
-CStatus
 UpdateFieldRawDataSize(CSegmentInterface c_segment,
                        int64_t field_id,
                        int64_t num_rows,

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -4356,6 +4356,39 @@ TEST(SealedSegmentCowState, ClearPublishedStateDropsRuntimeSnapshot) {
     EXPECT_FALSE(GetFieldBit(after->field_data_ready_bitset, payload));
 }
 
+TEST(SealedSegmentCowState, JsonStatsLivesInRuntimeSnapshot) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto json = schema->AddDebugField("payload", DataType::JSON);
+    schema->set_primary_field_id(pk);
+
+    auto segment = CreateSealedSegment(schema);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    sealed->LoadJsonStats(json, nullptr);
+
+    auto after_load = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(after_load, nullptr);
+    ASSERT_NE(after_load->runtime, nullptr);
+    ASSERT_EQ(after_load->runtime->json_stats.count(json), 1);
+
+    auto runtime = sealed->TestCloneMutableRuntimeResourceState();
+    ASSERT_EQ(runtime->json_stats.count(json), 1);
+    runtime->json_stats.erase(json);
+
+    ChunkedSegmentSealedImpl::StateDelta delta;
+    delta.schema = after_load->schema;
+    delta.load_info = after_load->load_info;
+    delta.runtime = sealed->TestFreezeRuntimeResourceState(std::move(runtime));
+    delta.commit_ts = after_load->commit_ts;
+
+    auto next = sealed->TestBuildNextPublishedState(after_load, delta);
+    ASSERT_NE(next, nullptr);
+    ASSERT_NE(next->runtime, nullptr);
+    EXPECT_EQ(next->runtime->json_stats.count(json), 0);
+}
+
 TEST(SealedSegmentCowState, ExternalSyntheticFieldsUseStagedLoadInfoRows) {
     auto schema = std::make_shared<Schema>();
     auto pk = schema->AddDebugField("pk", DataType::INT64);

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -4366,21 +4366,33 @@ TEST(SealedSegmentCowState, JsonStatsLivesInRuntimeSnapshot) {
     auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
     ASSERT_NE(sealed, nullptr);
 
-    sealed->LoadJsonStats(json, nullptr);
+    auto current = sealed->TestGetPublishedStateSnapshot();
+    auto load_runtime = sealed->TestCloneMutableRuntimeResourceState();
+    load_runtime->json_stats[json] = nullptr;
 
-    auto after_load = sealed->TestGetPublishedStateSnapshot();
+    ChunkedSegmentSealedImpl::StateDelta load_delta;
+    load_delta.schema = current->schema;
+    load_delta.load_info = current->load_info;
+    load_delta.runtime =
+        sealed->TestFreezeRuntimeResourceState(std::move(load_runtime));
+    load_delta.commit_ts = current->commit_ts;
+
+    auto after_load = sealed->TestBuildNextPublishedState(current, load_delta);
     ASSERT_NE(after_load, nullptr);
     ASSERT_NE(after_load->runtime, nullptr);
     ASSERT_EQ(after_load->runtime->json_stats.count(json), 1);
 
-    auto runtime = sealed->TestCloneMutableRuntimeResourceState();
-    ASSERT_EQ(runtime->json_stats.count(json), 1);
-    runtime->json_stats.erase(json);
+    auto drop_runtime =
+        std::make_shared<ChunkedSegmentSealedImpl::RuntimeResourceState>(
+            *after_load->runtime);
+    ASSERT_EQ(drop_runtime->json_stats.count(json), 1);
+    drop_runtime->json_stats.erase(json);
 
     ChunkedSegmentSealedImpl::StateDelta delta;
     delta.schema = after_load->schema;
     delta.load_info = after_load->load_info;
-    delta.runtime = sealed->TestFreezeRuntimeResourceState(std::move(runtime));
+    delta.runtime =
+        sealed->TestFreezeRuntimeResourceState(std::move(drop_runtime));
     delta.commit_ts = after_load->commit_ts;
 
     auto next = sealed->TestBuildNextPublishedState(after_load, delta);

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -55,7 +55,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/cgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
 	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
@@ -1273,85 +1272,6 @@ func (s *LocalSegment) innerLoadIndex(ctx context.Context,
 		mlog.Warn(ctx, "load index failed", mlog.Err(err))
 	}
 	return err
-}
-
-func (s *LocalSegment) LoadJSONKeyIndex(ctx context.Context, jsonKeyStats *datapb.JsonKeyStats, schemaHelper *typeutil.SchemaHelper, basePath string) error {
-	if !s.ptrLock.PinIf(state.IsNotReleased) {
-		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
-	}
-	defer s.ptrLock.Unpin()
-
-	if !paramtable.Get().CommonCfg.EnabledJSONKeyStats.GetAsBool() {
-		mlog.Warn(ctx, "load json key index failed, json key stats is not enabled")
-		return nil
-	}
-
-	// for compatibility, we only support load data format version equal to the current data format version
-	// if the data format version is less than the current version, wait for trigger a stats task again
-	if jsonKeyStats.GetJsonKeyStatsDataFormat() != common.JSONStatsDataFormatVersion {
-		mlog.Warn(ctx, "load json key index failed dataformat invalid", mlog.Int64("dataformat", jsonKeyStats.GetJsonKeyStatsDataFormat()), mlog.Int64("field id", jsonKeyStats.GetFieldID()), mlog.Any("json key logs", jsonKeyStats))
-		return nil
-	}
-	mlog.Info(ctx, "load json key index", mlog.Int64("field id", jsonKeyStats.GetFieldID()), mlog.Any("json key logs", jsonKeyStats))
-	s.fieldJSONStatsMu.RLock()
-	_, loaded := s.fieldJSONStats[jsonKeyStats.GetFieldID()]
-	s.fieldJSONStatsMu.RUnlock()
-	if loaded {
-		mlog.Warn(ctx, "JsonKeyIndexStats already loaded", mlog.Int64("field id", jsonKeyStats.GetFieldID()), mlog.Any("json key logs", jsonKeyStats))
-		return nil
-	}
-
-	f, err := schemaHelper.GetFieldFromID(jsonKeyStats.GetFieldID())
-	if err != nil {
-		return err
-	}
-
-	// JSON key stats should based on scala field's warmup policy
-	warmupPolicy := getScalarDataWarmupPolicy(f)
-
-	cgoProto := &indexcgopb.LoadJsonKeyIndexInfo{
-		FieldID:      jsonKeyStats.GetFieldID(),
-		Version:      jsonKeyStats.GetVersion(),
-		BuildID:      jsonKeyStats.GetBuildID(),
-		Files:        jsonKeyStats.GetFiles(),
-		Schema:       f,
-		CollectionID: s.Collection(),
-		PartitionID:  s.Partition(),
-		LoadPriority: s.loadInfo.Load().GetPriority(),
-		EnableMmap:   paramtable.Get().QueryNodeCfg.MmapJSONStats.GetAsBool(),
-		MmapDirPath:  paramtable.Get().QueryNodeCfg.MmapDirPath.GetValue(),
-		StatsSize:    jsonKeyStats.GetLogSize(),
-		WarmupPolicy: warmupPolicy,
-		BasePath:     basePath,
-	}
-
-	marshaled, err := proto.Marshal(cgoProto)
-	if err != nil {
-		return err
-	}
-
-	guard := segcore.NewCancellationGuard(ctx)
-	defer guard.Close()
-
-	var status C.CStatus
-	_, _ = GetLoadPool().Submit(func() (any, error) {
-		traceCtx := ParseCTraceContext(ctx)
-		status = C.LoadJsonKeyIndex(traceCtx.ctx, s.ptr, (*C.uint8_t)(unsafe.Pointer(&marshaled[0])), (C.uint64_t)(len(marshaled)), (C.CLoadCancellationSource)(guard.Source()))
-		return nil, nil
-	}).Await()
-
-	if err := HandleCStatus(ctx, &status, "Load JsonKeyStats failed"); err != nil {
-		return err
-	}
-	s.fieldJSONStatsMu.Lock()
-	s.fieldJSONStats[jsonKeyStats.GetFieldID()] = &querypb.JsonStatsInfo{
-		FieldID:           jsonKeyStats.GetFieldID(),
-		DataFormatVersion: jsonKeyStats.GetJsonKeyStatsDataFormat(),
-		BuildID:           jsonKeyStats.GetBuildID(),
-		VersionID:         jsonKeyStats.GetVersion(),
-	}
-	s.fieldJSONStatsMu.Unlock()
-	return nil
 }
 
 func (s *LocalSegment) UpdateIndexInfo(ctx context.Context, indexInfo *querypb.FieldIndexInfo, info *LoadIndexInfo) error {


### PR DESCRIPTION
Related to #51068

Keep sealed JSON stats in RuntimeResourceState so published runtime snapshots carry them through clone and freeze transitions.

Load and replace JSON stats through the staged reopen committer, and drop them by mutating the staged runtime state. This removes the old direct LoadJsonKeyIndex CGO path and the unused RemoveJsonStats interface.