### PR TITLE
enhance: support query order-by in RESTful v2 API and Go SDK (#51170)

### DIFF
--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -113,6 +113,21 @@ func (s *SearchOptionSuite) TestWithNamespace() {
 	s.Equal(namespace, hybridReq.GetNamespace())
 }
 
+func (s *SearchOptionSuite) TestQueryOrderByFields() {
+	collName := "query_order_by"
+
+	queryReq, err := NewQueryOption(collName).
+		WithFilter("price > 50").
+		WithLimit(10).
+		WithOrderByFields("price:desc", "name:asc").
+		Request()
+	s.Require().NoError(err)
+
+	queryParams := entity.KvPairsMap(queryReq.GetQueryParams())
+	s.Equal("price:desc,name:asc", queryParams[spOrderByFields])
+	s.Equal("10", queryParams[spLimit])
+}
+
 func (s *SearchOptionSuite) TestPlaceHolder() {
 	type testCase struct {
 		tag         string

--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -47,6 +47,7 @@ const (
 	spGroupBy         = `group_by_field`
 	spGroupSize       = `group_size`
 	spStrictGroupSize = `strict_group_size`
+	spOrderByFields   = `order_by_fields`
 )
 
 type SearchOption interface {
@@ -700,6 +701,17 @@ func (opt *queryOption) WithLimit(limit int) *queryOption {
 		opt.queryParams = make(map[string]string)
 	}
 	opt.queryParams[spLimit] = strconv.Itoa(limit)
+	return opt
+}
+
+// WithOrderByFields sorts query results by the given scalar fields.
+// Each spec is "fieldName" or "fieldName:asc" / "fieldName:desc" (default asc).
+// The server requires an explicit limit when order-by fields are set.
+func (opt *queryOption) WithOrderByFields(fields ...string) *queryOption {
+	if opt.queryParams == nil {
+		opt.queryParams = make(map[string]string)
+	}
+	opt.queryParams[spOrderByFields] = strings.Join(fields, ",")
 	return opt
 }
 

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1244,6 +1244,9 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 	if httpReq.Limit > 0 && !matchCountRule(httpReq.OutputFields) {
 		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.LimitKey, Value: strconv.FormatInt(int64(httpReq.Limit), 10)})
 	}
+	if len(httpReq.OrderByFields) > 0 {
+		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.OrderByFieldsKey, Value: strings.Join(httpReq.OrderByFields, ",")})
+	}
 	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Query", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Query(reqCtx, req.(*milvuspb.QueryRequest))
 	})

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3725,6 +3725,42 @@ func TestDML(t *testing.T) {
 	validateTestCases(t, testEngine, queryTestCases, false)
 }
 
+func TestQueryOrderByFields(t *testing.T) {
+	paramtable.Init()
+	// disable rate limit
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Times(2)
+	orderByValues := []string{}
+	mp.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *milvuspb.QueryRequest) (*milvuspb.QueryResults, error) {
+		for _, pair := range req.GetQueryParams() {
+			if pair.GetKey() == proxy.OrderByFieldsKey {
+				orderByValues = append(orderByValues, pair.GetValue())
+			}
+		}
+		return &milvuspb.QueryResults{Status: commonSuccessStatus, OutputFields: []string{}, FieldsData: []*schemapb.FieldData{}}, nil
+	}).Times(2)
+	testEngine := initHTTPServerV2(mp, false)
+	validateTestCases(t, testEngine, []requestBodyTestCase{
+		{
+			path:        QueryAction,
+			requestBody: []byte(`{"collectionName": "book", "filter": "book_id > 0", "limit": 10, "orderByFields": ["word_count:desc", "book_id:asc"]}`),
+		},
+		{
+			// no orderByFields -> no order_by_fields query param forwarded
+			path:        QueryAction,
+			requestBody: []byte(`{"collectionName": "book", "filter": "book_id > 0", "limit": 10}`),
+		},
+	}, false)
+	assert.Equal(t, []string{"word_count:desc,book_id:asc"}, orderByValues)
+}
+
 func TestAllowInt64(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -349,13 +349,16 @@ type ExportSnapshotReq struct {
 func (req *ExportSnapshotReq) GetDbName() string { return req.DbName }
 
 type QueryReqV2 struct {
-	DbName           string                 `json:"dbName"`
-	CollectionName   string                 `json:"collectionName" binding:"required"`
-	PartitionNames   []string               `json:"partitionNames"`
-	OutputFields     []string               `json:"outputFields"`
-	Filter           string                 `json:"filter"`
-	Limit            int32                  `json:"limit"`
-	Offset           int32                  `json:"offset"`
+	DbName         string   `json:"dbName"`
+	CollectionName string   `json:"collectionName" binding:"required"`
+	PartitionNames []string `json:"partitionNames"`
+	OutputFields   []string `json:"outputFields"`
+	Filter         string   `json:"filter"`
+	Limit          int32    `json:"limit"`
+	Offset         int32    `json:"offset"`
+	// OrderByFields sorts query results by scalar fields; each item is
+	// "fieldName" or "fieldName:asc" / "fieldName:desc" (default asc).
+	OrderByFields    []string               `json:"orderByFields"`
 	ExprParams       map[string]interface{} `json:"exprParams"`
 	ConsistencyLevel string                 `json:"consistencyLevel"`
 }

--- a/tests/go_client/testcases/query_test.go
+++ b/tests/go_client/testcases/query_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/milvus-io/milvus/client/v2/column"
 	"github.com/milvus-io/milvus/client/v2/entity"
+	"github.com/milvus-io/milvus/client/v2/index"
 	client "github.com/milvus-io/milvus/client/v2/milvusclient"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/tests/go_client/common"
@@ -1289,4 +1290,79 @@ func TestRunAnalyzer(t *testing.T) {
 	for i, text := range []string{"doc"} {
 		require.Equal(t, text, tokens[0].Tokens[i].Text)
 	}
+}
+
+// test query with order by fields
+func TestQueryOrderBy(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	// The default query path already returns rows in pk-ascending order, so ordering
+	// by the pk cannot tell "order_by applied" from "order_by ignored". Use a scalar
+	// field holding a permutation of 0..nb-1 that is non-monotonic in the pk, so both
+	// asc and desc results differ from the default order.
+	collName := common.GenRandomString("query_order_by", 6)
+	scoreField := "score"
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithField(entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName(scoreField).WithDataType(entity.FieldTypeInt64)).
+		WithField(entity.NewField().WithName(common.DefaultFloatVecFieldName).WithDataType(entity.FieldTypeFloatVector).WithDim(common.DefaultDim))
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	nb := 200
+	pks := make([]int64, nb)
+	scores := make([]int64, nb)
+	for i := 0; i < nb; i++ {
+		pks[i] = int64(i)
+		scores[i] = int64((i*7 + 3) % nb) // gcd(7, nb)=1 -> permutation, non-monotonic in pk
+	}
+	vecColumn := hp.GenColumnData(nb, entity.FieldTypeFloatVector, *hp.TNewDataOption().TWithDim(common.DefaultDim))
+	_, err = mc.Insert(ctx, client.NewColumnBasedInsertOption(collName,
+		column.NewColumnInt64(common.DefaultInt64FieldName, pks),
+		column.NewColumnInt64(scoreField, scores),
+		vecColumn))
+	common.CheckErr(t, err, true)
+
+	flushTask, err := mc.Flush(ctx, client.NewFlushOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, flushTask.Await(ctx), true)
+	idxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, common.DefaultFloatVecFieldName, index.NewAutoIndex(entity.L2)))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, idxTask.Await(ctx), true)
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, loadTask.Await(ctx), true)
+
+	expr := fmt.Sprintf("%s >= 0", common.DefaultInt64FieldName)
+
+	// order by score asc (direction defaults to asc)
+	ascRes, err := mc.Query(ctx, client.NewQueryOption(collName).WithFilter(expr).WithLimit(nb).
+		WithOutputFields(scoreField).WithConsistencyLevel(entity.ClStrong).
+		WithOrderByFields(scoreField))
+	common.CheckErr(t, err, true)
+	ascScores := ascRes.GetColumn(scoreField).(*column.ColumnInt64).Data()
+	require.Len(t, ascScores, nb)
+	for i := 0; i < nb; i++ {
+		require.EqualValues(t, i, ascScores[i])
+	}
+
+	// order by score desc
+	descRes, err := mc.Query(ctx, client.NewQueryOption(collName).WithFilter(expr).WithLimit(nb).
+		WithOutputFields(scoreField).WithConsistencyLevel(entity.ClStrong).
+		WithOrderByFields(scoreField+":desc"))
+	common.CheckErr(t, err, true)
+	descScores := descRes.GetColumn(scoreField).(*column.ColumnInt64).Data()
+	require.Len(t, descScores, nb)
+	for i := 0; i < nb; i++ {
+		require.EqualValues(t, nb-1-i, descScores[i])
+	}
+
+	// order by without limit is rejected
+	_, err = mc.Query(ctx, client.NewQueryOption(collName).WithFilter(expr).
+		WithOrderByFields(scoreField+":desc"))
+	common.CheckErr(t, err, false, "ORDER BY requires explicit limit")
 }


### PR DESCRIPTION
issue: #51170

Expose the existing server-side query ORDER BY capability (query param key `order_by_fields`, already consumed by proxy `task_query.go`) through the two remaining client surfaces:

- **Go SDK**: `queryOption.WithOrderByFields(fields ...string)` — each spec is `"field"`, `"field:asc"` or `"field:desc"`, joined into the `order_by_fields` query param.
- **RESTful v2**: `QueryReqV2` gains `orderByFields` (`[]string`, same spec format), forwarded by the query handler as the `order_by_fields` query param.

Validation (sortable type, explicit-limit requirement, iterator exclusion) stays server-side in the proxy, consistent with how limit/offset/group-by are handled at these layers. Interface shape mirrors pymilvus (`order_by=["price:desc"]`).

Tests: Go SDK option unit test, RESTful v2 handler unit test (asserts the KV pair is forwarded, and absent when not requested), and a go_client e2e case (desc / asc-default / no-limit rejection).

Follow-up (out of scope here): search-side `order_by` first-class parity for RESTful v2 / Go SDK (currently reachable via raw search params only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)