### PR TITLE
fix: avoid crashing flush pipeline on shutdown-window and drop-path failures

### DIFF
--- a/internal/flushcommon/pipeline/data_sync_service.go
+++ b/internal/flushcommon/pipeline/data_sync_service.go
@@ -322,7 +322,7 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 	if params.FlushSourceModeNotifier != nil {
 		writeBufferOptions = append(writeBufferOptions, writebuffer.WithFlushSourceModeNotifier(params.FlushSourceModeNotifier))
 	}
-	err = params.WriteBufferManager.Register(channelName, metacache, writeBufferOptions...)
+	err = params.WriteBufferManager.Register(ds.ctx, channelName, metacache, writeBufferOptions...)
 	if err != nil {
 		mlog.Warn(initCtx, "failed to register channel buffer", mlog.String("channel", channelName), mlog.Err(err))
 		return nil, err

--- a/internal/flushcommon/pipeline/data_sync_service_test.go
+++ b/internal/flushcommon/pipeline/data_sync_service_test.go
@@ -393,7 +393,7 @@ func (s *DataSyncServiceSuite) TestStartStop() {
 				return item, ok
 			})
 		}, nil)
-	s.wbManager.EXPECT().Register(insertChannelName, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	s.wbManager.EXPECT().Register(mock.Anything, insertChannelName, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	ufs := []*datapb.SegmentInfo{{
 		CollectionID:  collMeta.ID,

--- a/internal/flushcommon/pipeline/flow_graph_manager_test.go
+++ b/internal/flushcommon/pipeline/flow_graph_manager_test.go
@@ -62,7 +62,7 @@ func TestFlowGraphManager(t *testing.T) {
 	mockBroker.EXPECT().UpdateChannelCheckpoint(mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	wbm := writebuffer.NewMockBufferManager(t)
-	wbm.EXPECT().Register(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	wbm.EXPECT().Register(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	dispClient := msgdispatcher.NewMockClient(t)
 	dispClient.EXPECT().Register(mock.Anything, mock.Anything).Return(make(chan *msgstream.MsgPack), nil)
@@ -148,7 +148,7 @@ func newFlowGraphManager(t *testing.T) (string, FlowgraphManager) {
 	mockBroker.EXPECT().GetSegmentInfo(mock.Anything, mock.Anything).Return([]*datapb.SegmentInfo{}, nil).Maybe()
 
 	wbm := writebuffer.NewMockBufferManager(t)
-	wbm.EXPECT().Register(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	wbm.EXPECT().Register(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	dispClient := msgdispatcher.NewMockClient(t)
 	dispClient.EXPECT().Register(mock.Anything, mock.Anything).Return(make(chan *msgstream.MsgPack), nil)

--- a/internal/flushcommon/writebuffer/l0_write_buffer.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer.go
@@ -49,7 +49,12 @@ func NewL0WriteBuffer(channel string, metacache metacache.MetaCache, syncMgr syn
 
 func (wb *l0WriteBuffer) dispatchDeleteMsgsWithoutFilter(deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition) {
 	for _, msg := range deleteMsgs {
-		l0SegmentID := wb.getL0SegmentID(msg.GetPartitionID(), startPos)
+		l0SegmentID, err := wb.getL0SegmentID(msg.GetPartitionID(), startPos)
+		if err != nil {
+			// write buffer is closing; remaining deletes replay from the WAL on restart.
+			wb.logger.Warn(wb.ctx, "skip buffering delete, write buffer is closing", mlog.Err(err))
+			return
+		}
 		pks := storage.ParseIDs2PrimaryKeys(msg.GetPrimaryKeys())
 		pkTss := msg.GetTimestamps()
 		if len(pks) > 0 {
@@ -120,17 +125,26 @@ func (wb *l0WriteBuffer) bufferInsert(inData *InsertData, startPos, endPos *msgp
 	return nil
 }
 
-func (wb *l0WriteBuffer) getL0SegmentID(partitionID int64, startPos *msgpb.MsgPosition) int64 {
+func (wb *l0WriteBuffer) getL0SegmentID(partitionID int64, startPos *msgpb.MsgPosition) (int64, error) {
 	log := wb.logger
 	segmentID, ok := wb.l0Segments[partitionID]
 	if !ok {
-		err := retry.Do(context.Background(), func() error {
+		err := retry.Do(wb.ctx, func() error {
 			var err error
 			segmentID, err = wb.idAllocator.AllocOne()
 			return err
 		})
 		if err != nil {
-			log.Error(context.TODO(), "failed to allocate l0 segment ID", mlog.Err(err))
+			if merr.IsCanceledOrTimeout(err) {
+				// wb.ctx is canceled, i.e. the channel/node is stopping. The
+				// delete stays in the WAL and is replayed on restart; don't crash.
+				log.Warn(wb.ctx, "failed to allocate l0 segment ID, write buffer is closing", mlog.Err(err))
+				return 0, err
+			}
+			// The retry above is deliberately bounded: an unbounded retry here
+			// would block flowgraph draining and hang graceful shutdown when the
+			// coordinator happens to stop first (cluster stop ordering). Exhausted
+			// retries panic so the WAL replays the delete after restart.
 			panic(err)
 		}
 		wb.l0Segments[partitionID] = segmentID
@@ -144,11 +158,11 @@ func (wb *l0WriteBuffer) getL0SegmentID(partitionID int64, startPos *msgpb.MsgPo
 			State:         commonpb.SegmentState_Growing,
 			Level:         datapb.SegmentLevel_L0,
 		}, func(_ *datapb.SegmentInfo) pkoracle.PkStat { return pkoracle.NewBloomFilterSet() }, metacache.NoneBm25StatsFactory, metacache.SetStartPosRecorded(false))
-		log.Info(context.TODO(), "Add a new level zero segment",
+		log.Info(wb.ctx, "Add a new level zero segment",
 			mlog.FieldSegmentID(segmentID),
 			mlog.String("level", datapb.SegmentLevel_L0.String()),
 			mlog.Any("start position", startPos),
 		)
 	}
-	return segmentID
+	return segmentID, nil
 }

--- a/internal/flushcommon/writebuffer/l0_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/testutils"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
@@ -362,6 +363,44 @@ func (s *L0WriteBufferSuite) TestBufferData() {
 		s.NoError(err)
 		s.MetricsEqual(value, 5856)
 	})
+}
+
+// TestBufferDataAllocRetry is a regression test for issue #50261: a transient
+// ID-allocator failure (a rootcoord/datacoord RPC blip) must be retried instead
+// of crashing the whole flush pipeline host process via panic.
+func (s *L0WriteBufferSuite) TestBufferDataAllocRetry() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.EnableGrowingSourceFlush.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.EnableGrowingSourceFlush.Key)
+
+	wb, err := NewL0WriteBuffer(s.channelName, s.metacache, s.syncMgr, &writeBufferOption{
+		ctx:         context.Background(),
+		idAllocator: s.allocator,
+	})
+	s.Require().NoError(err)
+
+	// AllocOne fails transiently once, then succeeds: the buffer must retry and
+	// recover instead of panicking the whole process.
+	var calls atomic.Int32
+	allocated := int64(tsoutil.ComposeTSByTime(time.Now(), 0))
+	s.allocator.AllocOneF = func() (int64, error) {
+		if calls.Add(1) <= 1 {
+			return 0, merr.WrapErrServiceUnavailable("rootcoord temporarily unavailable")
+		}
+		return allocated, nil
+	}
+
+	pks, _ := s.composeInsertMsg(1000, 10, 128, schemapb.DataType_Int64)
+	delMsg := s.composeDeleteMsg(lo.Map(pks, func(id int64, _ int) storage.PrimaryKey { return storage.NewInt64PrimaryKey(id) }))
+
+	s.metacache.EXPECT().GetSegmentByID(mock.Anything).Return(nil, false).Maybe()
+	s.metacache.EXPECT().AddSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return().Maybe()
+
+	s.NotPanics(func() {
+		err = wb.BufferData([]*InsertData{}, []*msgstream.DeleteMsg{delMsg}, &msgpb.MsgPosition{Timestamp: 100}, &msgpb.MsgPosition{Timestamp: 200}, 100)
+	})
+	s.NoError(err)
+	s.GreaterOrEqual(calls.Load(), int32(2), "AllocOne should have been retried past the transient failure")
 }
 
 func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {

--- a/internal/flushcommon/writebuffer/manager.go
+++ b/internal/flushcommon/writebuffer/manager.go
@@ -24,8 +24,10 @@ import (
 //
 //go:generate mockery --name=BufferManager --structname=MockBufferManager --output=./  --filename=mock_manager.go --with-expecter --inpackage
 type BufferManager interface {
-	// Register adds a WriteBuffer with provided schema & options.
-	Register(channel string, metacache metacache.MetaCache, opts ...WriteBufferOption) error
+	// Register adds a WriteBuffer with provided schema & options. ctx bounds the
+	// buffer's background retries (e.g. L0 segment ID allocation); when ctx is
+	// canceled those retries stop instead of looping forever.
+	Register(ctx context.Context, channel string, metacache metacache.MetaCache, opts ...WriteBufferOption) error
 	// CreateNewGrowingSegment notifies writeBuffer to create a new growing segment.
 	CreateNewGrowingSegment(ctx context.Context, channel string, partition int64, segmentID int64, schemaVersion int32) error
 	// SealSegments notifies writeBuffer corresponding to provided channel to seal segments.
@@ -170,7 +172,8 @@ func (m *bufferManager) Stop() {
 }
 
 // Register a new WriteBuffer for channel.
-func (m *bufferManager) Register(channel string, metacache metacache.MetaCache, opts ...WriteBufferOption) error {
+func (m *bufferManager) Register(ctx context.Context, channel string, metacache metacache.MetaCache, opts ...WriteBufferOption) error {
+	opts = append(opts, WithContext(ctx))
 	buf, err := NewWriteBuffer(channel, metacache, m.syncMgr, opts...)
 	if err != nil {
 		return err

--- a/internal/flushcommon/writebuffer/manager_test.go
+++ b/internal/flushcommon/writebuffer/manager_test.go
@@ -74,10 +74,10 @@ func (s *ManagerSuite) SetupTest() {
 func (s *ManagerSuite) TestRegister() {
 	manager := s.manager
 
-	err := manager.Register(s.channelName, s.metacache, WithIDAllocator(s.allocator))
+	err := manager.Register(context.Background(), s.channelName, s.metacache, WithIDAllocator(s.allocator))
 	s.NoError(err)
 
-	err = manager.Register(s.channelName, s.metacache, WithIDAllocator(s.allocator))
+	err = manager.Register(context.Background(), s.channelName, s.metacache, WithIDAllocator(s.allocator))
 	s.Error(err)
 	s.ErrorIs(err, merr.ErrChannelReduplicate)
 }
@@ -225,7 +225,7 @@ func (s *ManagerSuite) TestRemoveChannel() {
 	})
 
 	s.Run("remove_channel", func() {
-		err := manager.Register(s.channelName, s.metacache, WithIDAllocator(s.allocator))
+		err := manager.Register(context.Background(), s.channelName, s.metacache, WithIDAllocator(s.allocator))
 		s.Require().NoError(err)
 
 		s.NotPanics(func() {

--- a/internal/flushcommon/writebuffer/mock_manager.go
+++ b/internal/flushcommon/writebuffer/mock_manager.go
@@ -448,14 +448,14 @@ func (_c *MockBufferManager_NotifyCheckpointUpdated_Call) RunAndReturn(run func(
 	return _c
 }
 
-// Register provides a mock function with given fields: channel, _a1, opts
-func (_m *MockBufferManager) Register(channel string, _a1 metacache.MetaCache, opts ...WriteBufferOption) error {
+// Register provides a mock function with given fields: ctx, channel, _a1, opts
+func (_m *MockBufferManager) Register(ctx context.Context, channel string, _a1 metacache.MetaCache, opts ...WriteBufferOption) error {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, channel, _a1)
+	_ca = append(_ca, ctx, channel, _a1)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
@@ -464,8 +464,8 @@ func (_m *MockBufferManager) Register(channel string, _a1 metacache.MetaCache, o
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, metacache.MetaCache, ...WriteBufferOption) error); ok {
-		r0 = rf(channel, _a1, opts...)
+	if rf, ok := ret.Get(0).(func(context.Context, string, metacache.MetaCache, ...WriteBufferOption) error); ok {
+		r0 = rf(ctx, channel, _a1, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -479,23 +479,24 @@ type MockBufferManager_Register_Call struct {
 }
 
 // Register is a helper method to define mock.On call
+//   - ctx context.Context
 //   - channel string
 //   - _a1 metacache.MetaCache
 //   - opts ...WriteBufferOption
-func (_e *MockBufferManager_Expecter) Register(channel interface{}, _a1 interface{}, opts ...interface{}) *MockBufferManager_Register_Call {
+func (_e *MockBufferManager_Expecter) Register(ctx interface{}, channel interface{}, _a1 interface{}, opts ...interface{}) *MockBufferManager_Register_Call {
 	return &MockBufferManager_Register_Call{Call: _e.mock.On("Register",
-		append([]interface{}{channel, _a1}, opts...)...)}
+		append([]interface{}{ctx, channel, _a1}, opts...)...)}
 }
 
-func (_c *MockBufferManager_Register_Call) Run(run func(channel string, _a1 metacache.MetaCache, opts ...WriteBufferOption)) *MockBufferManager_Register_Call {
+func (_c *MockBufferManager_Register_Call) Run(run func(ctx context.Context, channel string, _a1 metacache.MetaCache, opts ...WriteBufferOption)) *MockBufferManager_Register_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]WriteBufferOption, len(args)-2)
-		for i, a := range args[2:] {
+		variadicArgs := make([]WriteBufferOption, len(args)-3)
+		for i, a := range args[3:] {
 			if a != nil {
 				variadicArgs[i] = a.(WriteBufferOption)
 			}
 		}
-		run(args[0].(string), args[1].(metacache.MetaCache), variadicArgs...)
+		run(args[0].(context.Context), args[1].(string), args[2].(metacache.MetaCache), variadicArgs...)
 	})
 	return _c
 }
@@ -505,7 +506,7 @@ func (_c *MockBufferManager_Register_Call) Return(_a0 error) *MockBufferManager_
 	return _c
 }
 
-func (_c *MockBufferManager_Register_Call) RunAndReturn(run func(string, metacache.MetaCache, ...WriteBufferOption) error) *MockBufferManager_Register_Call {
+func (_c *MockBufferManager_Register_Call) RunAndReturn(run func(context.Context, string, metacache.MetaCache, ...WriteBufferOption) error) *MockBufferManager_Register_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/flushcommon/writebuffer/options.go
+++ b/internal/flushcommon/writebuffer/options.go
@@ -1,6 +1,7 @@
 package writebuffer
 
 import (
+	"context"
 	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
@@ -23,6 +24,7 @@ type FlushSourceModeNotifier func(segmentID int64, mode metacache.FlushSourceMod
 type GrowingSourceResolver func(segmentID int64, targetOffset int64, endPos *msgpb.MsgPosition) (syncmgr.GrowingFlushSource, syncmgr.GrowingSourceState)
 
 type writeBufferOption struct {
+	ctx          context.Context
 	idAllocator  allocator.Interface
 	syncPolicies []SyncPolicy
 
@@ -39,6 +41,7 @@ type writeBufferOption struct {
 
 func defaultWBOption(metacache metacache.MetaCache) *writeBufferOption {
 	return &writeBufferOption{
+		ctx: context.Background(),
 		syncPolicies: []SyncPolicy{
 			GetFullBufferPolicy(),
 			GetSyncStaleBufferPolicy(paramtable.Get().DataNodeCfg.SyncPeriod.GetAsDuration(time.Second)),
@@ -79,6 +82,15 @@ func WithSyncPolicy(policy SyncPolicy) WriteBufferOption {
 func WithErrorHandler(handler func(err error)) WriteBufferOption {
 	return func(opt *writeBufferOption) {
 		opt.errorHandler = handler
+	}
+}
+
+// WithContext sets the lifecycle context for the write buffer. Background
+// retries inside the buffer (e.g. L0 segment ID allocation) are bounded by this
+// context, so they stop when the channel/node is shutting down.
+func WithContext(ctx context.Context) WriteBufferOption {
+	return func(opt *writeBufferOption) {
+		opt.ctx = ctx
 	}
 }
 

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -246,6 +246,7 @@ func NewWriteBuffer(channel string, metacache metacache.MetaCache, syncMgr syncm
 
 // writeBufferBase is the common component for buffering data
 type writeBufferBase struct {
+	ctx          context.Context
 	collectionID int64
 	channelName  string
 
@@ -317,7 +318,12 @@ func newWriteBufferBase(channel string, metacache metacache.MetaCache, syncMgr s
 		growingSourceRetryInterval = defaultGrowingSourceRetryInterval
 	}
 
+	ctx := option.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	wb := &writeBufferBase{
+		ctx:                        ctx,
 		channelName:                channel,
 		collectionID:               metacache.Collection(),
 		estSizePerRecord:           estSize,
@@ -1009,7 +1015,11 @@ func (wb *writeBufferBase) submitSyncTasks(ctx context.Context, syncTasks []sync
 			if growingSourceTask, ok := syncTask.(*syncmgr.GrowingSourceSyncTask); ok {
 				growingSourceTask.ReleaseSource()
 			}
-			mlog.Fatal(ctx, "failed to sync data", mlog.Int64("segmentID", syncTask.SegmentID()), mlog.Err(err))
+			// SyncData only returns an error when the sync manager's worker pool
+			// is already closed, i.e. the node is shutting down. Don't crash the
+			// process: unsynced data stays in the WAL and is replayed on restart.
+			mlog.Warn(ctx, "failed to submit sync task, sync manager is closing", mlog.Int64("segmentID", syncTask.SegmentID()), mlog.Err(err))
+			continue
 		}
 		result = append(result, future)
 	}
@@ -1583,15 +1593,16 @@ func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
 	futures := wb.submitDropSyncTasks(ctx, syncTasks)
 	err := conc.AwaitAll(futures...)
 	if err != nil {
-		mlog.Error(ctx, "failed to sink write buffer data", mlog.Err(err))
-		// TODO change to remove channel in the future
-		panic(err)
+		// Best-effort final flush while dropping the channel: the collection is
+		// being removed, so a terminal flush failure must not crash the node.
+		mlog.Warn(ctx, "failed to sink write buffer data while dropping channel, continuing", mlog.Err(err))
 	}
+	// DropChannel is a datacoord RPC with bounded retry inside the meta writer.
+	// If it still fails, don't crash: the collection is being dropped and
+	// datacoord reconciles dropped-channel metadata on its own side.
 	err = wb.metaWriter.DropChannel(ctx, wb.channelName)
 	if err != nil {
-		mlog.Error(ctx, "failed to drop channel", mlog.Err(err))
-		// TODO change to remove channel in the future
-		panic(err)
+		mlog.Warn(ctx, "failed to drop channel meta, continuing", mlog.Err(err))
 	}
 }
 
@@ -1617,7 +1628,11 @@ func (wb *writeBufferBase) submitDropSyncTasks(ctx context.Context, syncTasks []
 			if growingSourceTask, ok := syncTask.(*syncmgr.GrowingSourceSyncTask); ok {
 				growingSourceTask.ReleaseSource()
 			}
-			mlog.Fatal(ctx, "failed to sync segment", mlog.Int64("segmentID", syncTask.SegmentID()), mlog.Err(err))
+			// SyncData only fails when the sync manager is already closed (node
+			// stopping). The channel is being dropped anyway, so log and skip
+			// instead of crashing the whole process.
+			mlog.Warn(ctx, "failed to submit sync task while dropping channel, sync manager is closing", mlog.Int64("segmentID", syncTask.SegmentID()), mlog.Err(err))
+			continue
 		}
 		futures = append(futures, f)
 	}


### PR DESCRIPTION
issue: #50261

## What this PR changes

- **Sync task submission failures during shutdown** (sync manager already closed) are logged and skipped instead of `log.Fatal`. Unsynced data is protected by the channel checkpoint (the checkpoint candidate added before submission is never removed on failure) and is replayed from the WAL on restart.
- **Drop-channel finalization no longer panics**: a failed final flush await or a failed `DropVirtualChannel` report is logged and the drop continues (resolves the two `// TODO change to remove channel` sites in `writeBufferBase.Close`). DataCoord reconciles dropped-channel metadata on its own side.
- **`BufferManager.Register` now takes a lifecycle `ctx`** that bounds the write buffer's background retries; the L0 segment-ID allocation exits gracefully (warn + skip, the delete is replayed from the WAL) when the channel is closing, instead of panicking.
- **Regression test**: a transient AllocID failure is retried and recovers without crashing the process.

## What is deliberately kept (bounded retry + panic-to-replay), and why

The following three sites keep their current bounded-retry-then-panic behavior instead of retrying indefinitely:

1. `SaveBinlogPaths` (broker meta writer, DataCoord RPC)
2. L0 segment-ID allocation exhausting its bounded retries (non-cancel errors)
3. `CommitImport` handling in the WAL flusher (`FlushChannel` / `HandleCommitVchannel`)

**Rationale**: these run inside the flowgraph / sync worker paths that graceful shutdown must drain (`fg.Close()` waits for in-flight work **before** the pipeline context is cancelled). Making them retry indefinitely would hang graceful shutdown whenever the dependency happens to stop first during a cluster stop — pod stop ordering is not guaranteed — leaving the node stuck until SIGKILL. Bounded retry + panic guarantees shutdown terminates under any stop order, and correctness is preserved by the existing recovery semantics: the channel checkpoint only advances after a successful sync, so the WAL replays everything after restart.

Deterministic failures (schema/data mismatch in `PrepareInsert`/embedding, segment buffer construction) also keep fail-fast panics per the error-handling policy: retrying cannot fix them and they need human attention.

## Shutdown-order safety

With this PR, no pod stop ordering can make the flush pipeline host hang worse than master: every remaining unbounded retry is bounded by a cancellable lifecycle context, and every bounded retry either continues gracefully (shutdown/drop paths) or panics-to-replay (data paths), both of which terminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
