### PR TITLE
fix: avoid crashing coordinators on transient etcd failures

### DIFF
--- a/internal/cdc/replication/replicatestream/replicate_stream_client_impl.go
+++ b/internal/cdc/replication/replicatestream/replicate_stream_client_impl.go
@@ -18,7 +18,6 @@ package replicatestream
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -37,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 )
 
 var ErrReplicationRemoved = errors.New("replication removed")
@@ -344,17 +344,22 @@ func (r *replicateStreamClient) handleAlterReplicateConfigMessage(msg message.Im
 		// Cannot find the target channel, it means that the `current->target` topology edge is removed,
 		// so we need to remove the replicate pchannel and stop replicate.
 		etcdCli := resource.Resource().ETCD()
-		ok, err := meta.RemoveReplicatePChannelWithRevision(r.ctx, etcdCli, r.channel.Key, r.channel.ModRevision)
+		// Retry transient etcd failures instead of crashing the process; r.ctx is
+		// canceled when the client is closed or when the pchannel is deleted, so
+		// the retry never outlives this replication.
+		var ok bool
+		err := retry.Do(r.ctx, func() error {
+			var err error
+			ok, err = meta.RemoveReplicatePChannelWithRevision(r.ctx, etcdCli, r.channel.Key, r.channel.ModRevision)
+			return err
+		}, retry.AttemptAlways())
 		if err != nil {
-			logger.Warn(r.ctx, "failed to remove replicate pchannel", mlog.Err(err))
 			// When performing delete operation on etcd, the context may be canceled by the delete event
 			// in cdc controller and then return `context.Canceled` error.
 			// Since the delete event is generated after the delete operation is committed in etcd,
 			// the delete is guaranteed to have succeeded on the server side.
 			// So we can ignore the context canceled error here.
-			if !errors.Is(err, context.Canceled) {
-				panic(fmt.Sprintf("failed to remove replicate pchannel: %v", err))
-			}
+			logger.Warn(r.ctx, "failed to remove replicate pchannel", mlog.Err(err))
 		}
 		if ok {
 			logger.Info(r.ctx, "handle AlterReplicateConfigMessage done, replicate pchannel removed")

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -1082,7 +1082,11 @@ func (rm *ResourceManager) unassignNode(ctx context.Context, node int64) (string
 		rg := mrg.ToResourceGroup()
 
 		if err := rm.catalog.SaveResourceGroup(ctx, rg.GetMeta()); err != nil {
-			mlog.Fatal(context.TODO(), "unassign node from resource group",
+			// A transient meta-store failure must not crash the whole querycoord.
+			// The resource observer recovers resource groups periodically, so the
+			// unassignment is re-applied on a later check once the meta store is
+			// back; callers already log the returned error.
+			mlog.Warn(ctx, "failed to save resource group when unassigning node",
 				mlog.String("rgName", rg.GetName()),
 				mlog.Int64("node", node),
 				mlog.Err(err),

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -708,14 +708,22 @@ func (c *Core) restore(ctx context.Context) error {
 }
 
 func (c *Core) startInternal() error {
-	if err := c.proxyWatcher.WatchProxy(c.ctx); err != nil {
-		mlog.Fatal(context.TODO(), "rootcoord failed to watch proxy", mlog.Err(err))
-		// you can not just stuck here,
-		panic(err)
+	// WatchProxy and restore read from the meta store; retry transient etcd
+	// failures at startup for a bounded budget (~1 min) instead of crashing,
+	// and fail the startup normally when the failure persists. WatchProxy is
+	// safe to retry: it only returns an error before its watch goroutines start.
+	if err := retry.Do(c.ctx, func() error {
+		return c.proxyWatcher.WatchProxy(c.ctx)
+	}, retry.Attempts(20)); err != nil {
+		mlog.Error(c.ctx, "rootcoord failed to watch proxy", mlog.Err(err))
+		return err
 	}
 
-	if err := c.restore(c.ctx); err != nil {
-		panic(err)
+	if err := retry.Do(c.ctx, func() error {
+		return c.restore(c.ctx)
+	}, retry.Attempts(20)); err != nil {
+		mlog.Error(c.ctx, "rootcoord failed to restore", mlog.Err(err))
+		return err
 	}
 
 	if Params.QuotaConfig.QuotaAndLimitsEnabled.GetAsBool() {

--- a/internal/streamingcoord/server/broadcaster/broadcast_task.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_task.go
@@ -529,15 +529,16 @@ func (b *broadcastTask) saveTaskIfDirty(ctx context.Context, logger *mlog.Logger
 	if !b.dirty {
 		return nil
 	}
-	b.dirty = false
 	logger = logger.With(mlog.String("state", b.task.State.String()), mlog.Int("ackedVChannelCount", ackedCount(b.task)))
 	if err := resource.Resource().StreamingCatalog().SaveBroadcastTask(ctx, b.header().BroadcastID, b.task); err != nil {
+		// Keep the task dirty so a later ack/recovery attempt persists it again:
+		// the in-memory task already holds the acked state, and on restart the
+		// recovery path re-derives it. A transient meta-store failure must not
+		// crash the whole streamingcoord.
 		logger.Warn(ctx, "save broadcast task failed", mlog.Err(err))
-		if ctx.Err() == nil {
-			panic("critical error: the save broadcast task is failed before the context is done")
-		}
 		return err
 	}
+	b.dirty = false
 	b.ObserveStateChanged(b.task.State)
 	logger.Info(ctx, "save broadcast task done")
 	return nil

--- a/internal/util/dependency/kv/kv_client_handler.go
+++ b/internal/util/dependency/kv/kv_client_handler.go
@@ -1,6 +1,7 @@
 package kvfactory
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 )
 
 var clientCreator = &etcdClientCreator{}
@@ -48,8 +50,14 @@ func getEtcdAndPath() (*clientv3.Client, string) {
 	defer clientCreator.mu.Unlock()
 	// If client/path doesn’t exist, create a new one
 	if clientCreator.client == nil {
-		var err error
-		clientCreator.client, err = createEtcdClient()
+		// Retry transient etcd unavailability for a bounded budget (~1 min) so a
+		// brief outage doesn't crash the process; a persistent failure (e.g. bad
+		// endpoints/TLS config) still fails fast for human attention.
+		err := retry.Do(context.Background(), func() error {
+			var err error
+			clientCreator.client, err = createEtcdClient()
+			return err
+		}, retry.Attempts(20))
 		if err != nil {
 			panic(fmt.Errorf("failed to create etcd client: %w", err))
 		}


### PR DESCRIPTION
issue: #51175

## What this PR changes

A transient etcd / meta-store failure (rolling restart, leader election, brief network blip) must not crash a coordinator. This PR replaces the panic / `mlog.Fatal` on five such paths with error propagation and retries **bounded by lifecycle contexts or bounded budgets**:

| Site | Before | After |
|---|---|---|
| `querycoordv2` `ResourceManager.unassignNode` | `mlog.Fatal` → `os.Exit(1)` killed the whole QueryCoord when `SaveResourceGroup` failed during node-down handling (the `return err` after it was dead code) | log + return the error; callers already log it, and the ResourceObserver's periodic `checkAndRecoverResourceGroup` re-applies the unassignment once the meta store is back |
| CDC `replicateStreamClient.handleAlterReplicateConfigMessage` | panicked on any non-`context.Canceled` error of the etcd txn — a transient outage returns `DeadlineExceeded`/`Unavailable`, hitting the panic | retry bounded by the client's lifecycle ctx (cancelled on close / pchannel delete), keeping the existing tolerance for the delete-event cancellation |
| `streamingcoord` `broadcastTask.saveTaskIfDirty` | panicked when persisting failed while ctx was alive; `b.dirty` was cleared **before** the save, so a failed save silently lost the need to persist | clear the dirty flag **only after a successful save** and return the error: the in-memory task keeps the acked state, the next ack / recovery attempt persists it again, and restart recovery re-derives it |
| `kvfactory.getEtcdAndPath` (lazy etcd client) | panicked on the first creation failure | bounded retry budget (~1 min); persistent failures (bad endpoints / TLS config) still fail fast for human attention |
| `rootcoord` `startInternal` (`WatchProxy` / `restore`) | `mlog.Fatal` + panic on a single failure → crash-loop on a startup-time etcd blip | bounded retry budget (~1 min), then fail the startup normally (`Core.Start` propagates the error). `WatchProxy` is safe to retry: it only returns an error before its watch goroutines start |

## Design principles

- **No unbounded, un-cancellable retries**: every added retry is bounded by a lifecycle context or a bounded attempt budget, so graceful shutdown can never hang on them regardless of pod stop ordering.
- **Session liveness stays the backstop**: a sustained etcd outage (longer than the session TTL) still exits the process with code 80 by design; this PR only removes crashes for outages *shorter* than the TTL, which the retries absorb.
- **Config errors still fail fast**: bounded budgets mean persistent misconfiguration surfaces as a startup/creation failure instead of being retried forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
