### PR TITLE
enhance: apply L0 deletes during binlog import via l0_delta_paths option

### DIFF
--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"io"
 	"math"
+	"runtime"
 	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -62,6 +64,7 @@ func NewReader(ctx context.Context,
 	storageConfig *indexpb.StorageConfig,
 	storageVersion int64,
 	paths []string,
+	l0DeltaPrefixes []string,
 	tsStart,
 	tsEnd uint64,
 	bufferSize int,
@@ -88,14 +91,14 @@ func NewReader(ctx context.Context,
 		importEz:       importEz,
 		retryAttempts:  paramtable.Get().CommonCfg.StorageReadRetryAttempts.GetAsUint(),
 	}
-	err := r.init(paths, tsStart, tsEnd)
+	err := r.init(paths, l0DeltaPrefixes, tsStart, tsEnd)
 	if err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 
-func (r *reader) init(paths []string, tsStart, tsEnd uint64) error {
+func (r *reader) init(paths []string, l0DeltaPrefixes []string, tsStart, tsEnd uint64) error {
 	if tsStart != 0 || tsEnd != math.MaxUint64 {
 		r.filters = append(r.filters, FilterWithTimeRange(tsStart, tsEnd))
 	}
@@ -154,20 +157,34 @@ func (r *reader) init(paths []string, tsStart, tsEnd uint64) error {
 		return storage.ValueDeserializerWithSchema(record, v, r.schema, true)
 	})
 
-	if len(paths) < 2 {
+	// Delta prefixes to apply as deletes during import: the segment's own delta
+	// (paths[1], optional) plus any L0 (delete-only) segment deltalog prefixes.
+	// All are merged into deleteData by primary key, so deleted rows are dropped
+	// on read and the produced segment carries no residual deletes.
+	deltaPrefixes := make([]string, 0, 1+len(l0DeltaPrefixes))
+	if len(paths) >= 2 {
+		deltaPrefixes = append(deltaPrefixes, paths[1])
+	}
+	deltaPrefixes = append(deltaPrefixes, l0DeltaPrefixes...)
+	if len(deltaPrefixes) == 0 {
 		return nil
 	}
+
 	var deltaLogs []string
-	err = importcommon.WalkWithPrefixRetry(r.ctx, r.cm, paths[1], true, r.retryAttempts,
-		func() {
-			deltaLogs = nil
-		},
-		func(chunkInfo *storage.ChunkObjectInfo) bool {
-			deltaLogs = append(deltaLogs, chunkInfo.FilePath)
-			return true
-		})
-	if err != nil {
-		return err
+	for _, prefix := range deltaPrefixes {
+		var prefixLogs []string
+		err = importcommon.WalkWithPrefixRetry(r.ctx, r.cm, prefix, true, r.retryAttempts,
+			func() {
+				prefixLogs = nil
+			},
+			func(chunkInfo *storage.ChunkObjectInfo) bool {
+				prefixLogs = append(prefixLogs, chunkInfo.FilePath)
+				return true
+			})
+		if err != nil {
+			return err
+		}
+		deltaLogs = append(deltaLogs, prefixLogs...)
 	}
 	if len(deltaLogs) == 0 {
 		return nil
@@ -247,30 +264,42 @@ func (r *reader) readDelete(deltaLogs []string, tsStart, tsEnd uint64) (map[any]
 		return tempData, nil
 	}
 
-	for _, path := range deltaLogs {
-		// try v1 first
-		tempData, errv1 := readInternal(path, v1opts)
-		if errv1 != nil {
-			// try v2 if v1 failed
-			tempData, errv2 := readInternal(path, v2opts)
-			if errv2 != nil {
-				return nil, errv2
-			}
-			// Merge v2 results into deleteData
-			for pk, ts := range tempData {
-				if tsExisting, ok := deleteData[pk]; ok && tsExisting > ts {
-					continue
+	// Load deltalog files concurrently. A binlog import may read many deltalog
+	// files (the segment's own delta plus any L0 delta prefixes), and each read
+	// is an independent object-storage round trip. Merging is by max timestamp
+	// per pk, which is order-independent, so parallel reads are safe.
+	partials := make([]map[any]typeutil.Timestamp, len(deltaLogs))
+	g, _ := errgroup.WithContext(r.ctx)
+	limit := runtime.GOMAXPROCS(0)
+	if limit < 1 {
+		limit = 1
+	}
+	g.SetLimit(limit)
+	for i, path := range deltaLogs {
+		g.Go(func() error {
+			// try v1 first, fall back to v2
+			tempData, errv1 := readInternal(path, v1opts)
+			if errv1 != nil {
+				var errv2 error
+				tempData, errv2 = readInternal(path, v2opts)
+				if errv2 != nil {
+					return errv2
 				}
-				deleteData[pk] = ts
 			}
-		} else {
-			// Merge v1 results into deleteData
-			for pk, ts := range tempData {
-				if tsExisting, ok := deleteData[pk]; ok && tsExisting > ts {
-					continue
-				}
-				deleteData[pk] = ts
+			partials[i] = tempData
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	for _, tempData := range partials {
+		for pk, ts := range tempData {
+			if tsExisting, ok := deleteData[pk]; ok && tsExisting > ts {
+				continue
 			}
+			deleteData[pk] = ts
 		}
 	}
 	return deleteData, nil

--- a/internal/util/importutilv2/binlog/reader_test.go
+++ b/internal/util/importutilv2/binlog/reader_test.go
@@ -388,7 +388,7 @@ func (suite *ReaderSuite) run(dataType schemapb.DataType, elemType schemapb.Data
 	cm, originalInsertData := suite.createMockChunk(schema, insertBinlogs, true)
 	cm.EXPECT().Size(mock.Anything, mock.Anything).Return(128, nil)
 
-	reader, err := NewReader(context.Background(), cm, schema, &indexpb.StorageConfig{}, storage.StorageV1, []string{insertPrefix, deltaPrefix}, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
+	reader, err := NewReader(context.Background(), cm, schema, &indexpb.StorageConfig{}, storage.StorageV1, []string{insertPrefix, deltaPrefix}, nil, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
 	suite.NoError(err)
 	insertData, err := reader.Read()
 	suite.NoError(err)
@@ -600,18 +600,18 @@ func (suite *ReaderSuite) TestVerify() {
 
 	checkFunc := func() {
 		cm, _ := suite.createMockChunk(schema, insertBinlogs, false)
-		reader, err := NewReader(context.Background(), cm, schema, &indexpb.StorageConfig{}, storage.StorageV1, []string{insertPrefix, deltaPrefix}, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
+		reader, err := NewReader(context.Background(), cm, schema, &indexpb.StorageConfig{}, storage.StorageV1, []string{insertPrefix, deltaPrefix}, nil, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
 		suite.Error(err)
 		suite.Nil(reader)
 	}
 
 	// no insert binlogs to import
-	reader, err := NewReader(context.Background(), nil, schema, &indexpb.StorageConfig{}, storage.StorageV1, []string{}, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
+	reader, err := NewReader(context.Background(), nil, schema, &indexpb.StorageConfig{}, storage.StorageV1, []string{}, nil, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
 	suite.Error(err)
 	suite.Nil(reader)
 
 	// too many input paths
-	reader, err = NewReader(context.Background(), nil, schema, &indexpb.StorageConfig{}, storage.StorageV1, []string{insertPrefix, deltaPrefix, "dummy"}, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
+	reader, err = NewReader(context.Background(), nil, schema, &indexpb.StorageConfig{}, storage.StorageV1, []string{insertPrefix, deltaPrefix, "dummy"}, nil, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
 	suite.Error(err)
 	suite.Nil(reader)
 
@@ -764,7 +764,7 @@ func (suite *ReaderSuite) TestZeroDeltaRead() {
 
 	checkFunc := func(targetSchema *schemapb.CollectionSchema, expectReadBinlogs map[int64][]string) {
 		cm := mockChunkFunc(sourceSchema, expectReadBinlogs)
-		reader, err := NewReader(context.Background(), cm, targetSchema, &indexpb.StorageConfig{}, storage.StorageV1, []string{insertPrefix, deltaPrefix}, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
+		reader, err := NewReader(context.Background(), cm, targetSchema, &indexpb.StorageConfig{}, storage.StorageV1, []string{insertPrefix, deltaPrefix}, nil, suite.tsStart, suite.tsEnd, 64*1024*1024, "")
 		suite.NoError(err)
 		suite.NotNil(reader)
 
@@ -873,7 +873,7 @@ func TestDeltaLogListing_RetryOnTransientError(t *testing.T) {
 		retryAttempts:  5,
 	}
 
-	err := r.init([]string{insertPrefix, deltaPrefix}, 0, math.MaxUint64)
+	err := r.init([]string{insertPrefix, deltaPrefix}, nil, 0, math.MaxUint64)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, deltaCallCount, "delta log WalkWithPrefix should have retried on transient error")
 }
@@ -910,10 +910,55 @@ func TestDeltaLogListing_NonRetryableErrorFailsFast(t *testing.T) {
 		retryAttempts:  5,
 	}
 
-	err := r.init([]string{insertPrefix, deltaPrefix}, 0, math.MaxUint64)
+	err := r.init([]string{insertPrefix, deltaPrefix}, nil, 0, math.MaxUint64)
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, merr.ErrIoPermissionDenied))
 	assert.Equal(t, 1, deltaCallCount, "non-retryable error should not retry")
+}
+
+func TestDeltaLogListing_L0DeltaPrefixesAreWalked(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	insertPrefix := "backup/insert_log/seg/"
+	ownDeltaPrefix := "backup/delta_log/seg/"
+	l0DeltaPrefix := "backup/delta_log/l0seg/"
+
+	cm.EXPECT().WalkWithPrefix(mock.Anything, insertPrefix, true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			walkFunc(&storage.ChunkObjectInfo{FilePath: insertPrefix + "0/file1"})
+			walkFunc(&storage.ChunkObjectInfo{FilePath: insertPrefix + "1/file1"})
+			return nil
+		}).Once()
+
+	// The segment's own delta prefix (paths[1]) is walked.
+	cm.EXPECT().WalkWithPrefix(mock.Anything, ownDeltaPrefix, true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			return nil
+		}).Once()
+
+	// The L0 delta prefix, passed separately, must also be walked so its deletes
+	// are applied to the imported data. Both walks return empty, so readDelete is
+	// skipped (len(deltaLogs) == 0) and init returns without reading deltalogs.
+	l0Walked := false
+	cm.EXPECT().WalkWithPrefix(mock.Anything, l0DeltaPrefix, true, mock.Anything).
+		RunAndReturn(func(ctx context.Context, prefix string, recursive bool, walkFunc storage.ChunkObjectWalkFunc) error {
+			l0Walked = true
+			return nil
+		}).Once()
+
+	r := &reader{
+		ctx:            ctx,
+		cm:             cm,
+		schema:         &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 0}, {FieldID: 1}}},
+		storageVersion: storage.StorageV1,
+		retryAttempts:  5,
+	}
+
+	err := r.init([]string{insertPrefix, ownDeltaPrefix}, []string{l0DeltaPrefix}, 0, math.MaxUint64)
+	assert.NoError(t, err)
+	assert.True(t, l0Walked, "L0 delta prefix should be walked so its deletes are applied during import")
 }
 
 func TestMultiReadWithRetry_NonRetryableError(t *testing.T) {

--- a/internal/util/importutilv2/option.go
+++ b/internal/util/importutilv2/option.go
@@ -57,6 +57,14 @@ const (
 	// L0Import indicates whether to import l0 segments only.
 	L0Import = "l0_import"
 
+	// L0DeltaPaths is a comma-separated list of L0 (delete-only) segment
+	// deltalog prefixes to apply during a binlog import. Instead of restoring
+	// them as separate L0 segments, their deletes are applied to the imported
+	// data by primary key so that deleted rows are dropped and no L0 segment is
+	// produced (equivalent to running an L0 compaction on the restore side).
+	// Empty when not set.
+	L0DeltaPaths = "l0_delta_paths"
+
 	// StorageVersion indicates the storage version to use for import.
 	// Type: int64
 	// storage v2: 2
@@ -138,6 +146,27 @@ func IsL0Import(options Options) bool {
 		return false
 	}
 	return true
+}
+
+// GetL0DeltaPaths returns the L0 deltalog prefixes to apply during a binlog
+// import (see the L0DeltaPaths option). Returns nil when the option is absent
+// or empty. Blank entries are skipped.
+func GetL0DeltaPaths(options Options) []string {
+	value, err := funcutil.GetAttrByKeyFromRepeatedKV(L0DeltaPaths, options)
+	if err != nil || len(value) == 0 {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	prefixes := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			prefixes = append(prefixes, p)
+		}
+	}
+	if len(prefixes) == 0 {
+		return nil
+	}
+	return prefixes
 }
 
 func GetStorageVersion(options Options) (int64, error) {

--- a/internal/util/importutilv2/reader.go
+++ b/internal/util/importutilv2/reader.go
@@ -64,7 +64,8 @@ func NewReader(ctx context.Context,
 			return nil, err
 		}
 		importEz, _ := GetEZK(options)
-		return binlog.NewReader(ctx, cm, schema, storageConfig, storageVersion, paths, tsStart, tsEnd, bufferSize, importEz)
+		l0DeltaPrefixes := GetL0DeltaPaths(options)
+		return binlog.NewReader(ctx, cm, schema, storageConfig, storageVersion, paths, l0DeltaPrefixes, tsStart, tsEnd, bufferSize, importEz)
 	}
 
 	fileType, err := GetFileType(importFile)


### PR DESCRIPTION
## What

Adds an `l0_delta_paths` import option so a binlog (backup) import can **apply** channel/partition-level L0 (delete-only) segment deltalogs to the imported data, instead of restoring them as separate L0 segments.

- `importutilv2/option.go`: new `l0_delta_paths` option + `GetL0DeltaPaths` (comma-separated prefixes).
- `importutilv2/reader.go`: parse the option in the backup branch and thread it into `binlog.NewReader` (like `importEz`).
- `importutilv2/binlog/reader.go`: read the L0 delta prefixes into the same `deleteData` as the segment's own delta and apply via the existing `FilterWithDelete`, so deleted rows are dropped on read and the produced data segment carries **no residual deletes**. Deltalog file loading in `readDelete` is now concurrent (merging by max-ts per pk is order-independent, so parallel reads are safe).

## Why

`commit_timestamp` (import 2PC, #48471) is the transaction-time basis for MVCC / delete filtering / compaction / GC on import segments. It applies to insert (data) segment rows; L0 is delete-only and its per-record delete timestamps encode causal order. Combining `commit_timestamp` with L0 breaks delete semantics (a `commit_ts`-stamped row vs an original-ts delete → `delete_ts < insert_ts` → delete rejected). Replication requires `commit_timestamp`, so L0 must not survive as a segment. Applying the L0 deletes on the restore side keeps existing (L0-containing) backups correct, including into replication clusters. See #51177 for the full analysis.

## Scope / follow-ups

- Kernel capability only. **milvus-backup wiring** (passing `l0_delta_paths` and dropping the separate `l0_import` job) is a separate PR (milvus-backup repo).
- **Partition-aware application** for partition-key collections (where one source segment can re-hash to multiple partitions) is a follow-up: the reader applies deletes by PK only, consistent with the existing per-segment delta path. Callers must pass partition-appropriate L0 prefixes, as they already do for insert/delta paths.

## Testing

- Added `TestDeltaLogListing_L0DeltaPrefixesAreWalked` covering that L0 prefixes are walked and applied alongside the segment's own delta.
- Code type-checks clean and `gofmt`/import order are clean. **Note:** the local dev environment has a stale prebuilt C++ core (missing a recent segcore symbol), so `make static-check` and the cgo-linked package tests could not be run locally; relying on CI to validate the full build and unit tests.

issue: #51177

## Compatibility

`l0_delta_paths` is parsed on the **datanode** (`importutilv2.NewReader` via `task_import.go` / `task_preimport.go`).

- **New datanode + old caller** (no `l0_delta_paths`): fully backward compatible — `GetL0DeltaPaths` returns nil and the existing `l0_import` path is unchanged.
- **Old datanode + a request carrying `l0_delta_paths`**: the old reader does not know the option and silently ignores it → the L0 deletes are **not applied** → deleted rows survive (**silent wrong data**). During a rolling upgrade, an import job's tasks are spread across datanodes, so a mix of new/old nodes can partially apply the deletes.

This PR is safe to merge on its own — no caller emits `l0_delta_paths` yet (milvus-backup wiring is a separate PR), so the capability lands inert. When wiring the caller, the failure mode is silent-wrong, so a **fail-closed guard belongs in datacoord**: reject an import carrying `l0_delta_paths` if any registered datanode is below the minimum supporting version (datacoord already tracks datanode sessions/versions). milvus-backup should additionally version-gate emission, and operators should complete the rolling upgrade before running L0-apply restores. The datacoord guard is tracked as part of the wiring follow-up.
