### PR TITLE
fix: drain thread pool futures before unwinding on error paths

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <boost/iterator/counting_iterator.hpp>
+#include <folly/ScopeGuard.h>
 #include "common/FastMem.h"
 #include <cxxabi.h>
 #include <algorithm>
@@ -1127,6 +1128,20 @@ SegmentGrowingImpl::load_column_group_data_internal(
             this->get_segment_id(),
             column_group_id.get());
 
+        // The load task captures this frame by reference and may be blocked
+        // pushing into the bounded channel. If the consumer loop below
+        // throws, unblock the task and wait for it before unwinding
+        // (see #46958).
+        auto drain_on_unwind = folly::makeGuard([&]() {
+            try {
+                std::shared_ptr<milvus::ArrowDataWrapper> discard;
+                while (column_group_info.arrow_reader_channel->pop(discard)) {
+                }
+            } catch (...) {
+            }
+            storage::DrainFuture(load_future);
+        });
+
         std::shared_ptr<milvus::ArrowDataWrapper> r;
 
         std::unordered_map<FieldId, std::vector<FieldDataPtr>> field_data_map;
@@ -1181,6 +1196,7 @@ SegmentGrowingImpl::load_column_group_data_internal(
         }
         // access underlying feature to get exception if any
         load_future.get();
+        drain_on_unwind.dismiss();
 
         for (auto& [field_id, field_data] : field_data_map) {
             load_field_data_common(field_id,

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -442,7 +442,8 @@ DiskFileManagerImpl::AddBatchIndexFiles(
 
     for (int64_t i = 0; i < remote_files.size(); ++i) {
         futures.push_back(pool.Submit(
-            [&](const std::string& file,
+            [local_chunk_manager](
+                const std::string& file,
                 const int64_t offset,
                 const int64_t data_size) -> std::shared_ptr<uint8_t[]> {
                 auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[data_size]);
@@ -454,13 +455,14 @@ DiskFileManagerImpl::AddBatchIndexFiles(
             remote_file_sizes[i]));
     }
 
-    // hold index data util upload index file done
-    std::vector<std::shared_ptr<uint8_t[]>> index_datas;
+    // hold index data util upload index file done.
+    // WaitAllFutures drains every task before rethrowing, so a failed read
+    // cannot unwind this frame while remaining tasks are still running.
+    auto index_datas = WaitAllFutures(std::move(futures));
     std::vector<const uint8_t*> data_slices;
-    for (auto& future : futures) {
-        auto res = future.get();
-        index_datas.emplace_back(res);
-        data_slices.emplace_back(res.get());
+    data_slices.reserve(index_datas.size());
+    for (auto& index_data : index_datas) {
+        data_slices.emplace_back(index_data.get());
     }
 
     std::map<std::string, int64_t> res;

--- a/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
+++ b/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
@@ -17,12 +17,15 @@
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 
 #include <fcntl.h>
+#include <folly/ScopeGuard.h>
 #include <unistd.h>
 #include <cerrno>
 #include <cstring>
 #include <algorithm>
 #include <utility>
 #include <vector>
+
+#include "storage/Util.h"
 
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -128,6 +131,11 @@ IndexEntryEncryptedLocalWriter::WriteEntry(const std::string& name,
     size_t remaining = size;
     uint32_t crc = 0;
 
+    // Encryption tasks capture `this`; on error the caller destroys the
+    // writer, so finish them before unwinding (see #46958).
+    auto drain_on_unwind =
+        folly::makeGuard([&pending]() { DrainFutures(pending); });
+
     while (remaining > 0 || !pending.empty()) {
         // Fill the sliding window: read one slice from fd and submit encryption
         while (pending.size() < W && remaining > 0) {
@@ -170,6 +178,11 @@ IndexEntryEncryptedLocalWriter::EncryptAndWriteSlices(const std::string& name,
     size_t remaining = size;
     size_t read_offset = 0;
     uint32_t crc = 0;
+
+    // Encryption tasks capture `this`; on error the caller destroys the
+    // writer, so finish them before unwinding (see #46958).
+    auto drain_on_unwind =
+        folly::makeGuard([&pending]() { DrainFutures(pending); });
 
     while (remaining > 0 || !pending.empty()) {
         while (pending.size() < W && remaining > 0) {

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1508,23 +1508,40 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
                                     milvus::proto::common::LoadPriority::HIGH);
         });
         // read field data from channel
-        std::shared_ptr<milvus::ArrowDataWrapper> r;
-        while (field_data_info.arrow_reader_channel->pop(r)) {
-            size_t num_rows = 0;
-            std::vector<std::shared_ptr<arrow::ChunkedArray>> chunked_arrays;
-            for (const auto& table_info : r->arrow_tables) {
-                num_rows += table_info.table->num_rows();
-                chunked_arrays.push_back(table_info.table->column(col_offset));
+        try {
+            std::shared_ptr<milvus::ArrowDataWrapper> r;
+            while (field_data_info.arrow_reader_channel->pop(r)) {
+                size_t num_rows = 0;
+                std::vector<std::shared_ptr<arrow::ChunkedArray>>
+                    chunked_arrays;
+                for (const auto& table_info : r->arrow_tables) {
+                    num_rows += table_info.table->num_rows();
+                    chunked_arrays.push_back(
+                        table_info.table->column(col_offset));
+                }
+                auto field_data =
+                    storage::CreateFieldData(data_type,
+                                             element_type,
+                                             field_schema->nullable(),
+                                             dim,
+                                             num_rows);
+                for (const auto& chunked_array : chunked_arrays) {
+                    field_data->FillFieldData(chunked_array);
+                }
+                field_data_list.push_back(field_data);
             }
-            auto field_data = storage::CreateFieldData(data_type,
-                                                       element_type,
-                                                       field_schema->nullable(),
-                                                       dim,
-                                                       num_rows);
-            for (const auto& chunked_array : chunked_arrays) {
-                field_data->FillFieldData(chunked_array);
+        } catch (...) {
+            // The load task captures this frame by reference and may be
+            // blocked pushing into the bounded channel. Unblock it, then
+            // wait for it to finish before unwinding (see #46958).
+            try {
+                std::shared_ptr<milvus::ArrowDataWrapper> discard;
+                while (field_data_info.arrow_reader_channel->pop(discard)) {
+                }
+            } catch (...) {
             }
-            field_data_list.push_back(field_data);
+            DrainFuture(load_future);
+            throw;
         }
         // access underlying feature to get exception if any
         load_future.get();

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -283,6 +283,37 @@ ProcessFuturesInOrder(std::vector<std::future<T>>& futures,
     }
 }
 
+// Best-effort drain for cleanup paths (catch blocks / scope guards): wait for
+// every still-valid future and swallow its exception, so that background
+// tasks referencing the caller's stack state finish before the caller
+// unwinds (see #46958). Unlike WaitAllFutures, this never throws — use it
+// when another exception is already propagating.
+template <typename FutureContainer>
+void
+DrainFutures(FutureContainer& futures) noexcept {
+    for (auto& future : futures) {
+        if (!future.valid()) {
+            continue;
+        }
+        try {
+            future.get();
+        } catch (...) {
+        }
+    }
+}
+
+template <typename T>
+void
+DrainFuture(std::future<T>& future) noexcept {
+    if (!future.valid()) {
+        return;
+    }
+    try {
+        future.get();
+    } catch (...) {
+    }
+}
+
 std::vector<FieldDataPtr>
 GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
                            int64_t field_id,


### PR DESCRIPTION
issue: #51179

`ThreadPool::Submit` returns `std::packaged_task` futures, which do not block on destruction. Sites that submit tasks capturing stack state by reference and wait with a bare `future.get()` loop let the first exception unwind the frame while remaining tasks are still queued/running — turning a recoverable I/O error into use-after-scope / use-after-free. Same defect class as the `IndexEntryReader` fix (#46958 / 2.6's #50937); an audit found four remaining sites.

## Changes

- **`storage/Util.h`**: add noexcept `DrainFutures` / `DrainFuture` cleanup helpers (wait for every still-valid future, swallow its exception), complementing the existing `WaitAllFutures`. For use in catch blocks / scope guards where another exception is already propagating.
- **`DiskFileManagerImpl::AddBatchIndexFiles`**: capture `local_chunk_manager` by value instead of `[&]`; collect slice buffers via the existing `WaitAllFutures`, which drains all tasks before rethrowing the first error.
- **`GetFieldDatasFromStorageV2`** (`storage/Util.cpp`): wrap the channel-consumption loop; on exception, drain the channel first (the producer may be blocked pushing into the bounded channel), then wait for the load task, then rethrow — the pattern `GroupChunkTranslator` already uses.
- **`SegmentGrowingImpl::load_column_group_data_internal`**: same treatment via a `folly::makeGuard` drain guard (dismissed on the success path).
- **`IndexEntryEncryptedLocalWriter::WriteEntry` / `EncryptAndWriteSlices`**: drain the sliding window of pending encryption tasks (which capture `this`) with a scope guard before unwinding, so no task outlives the writer.

## Semantics

The primary exception always propagates to the caller unchanged (bare `throw;` / `WaitAllFutures` rethrows the first task error after all tasks complete). Only secondary background-task errors during cleanup are swallowed — C++ permits a single in-flight exception, and letting another escape from unwind-time cleanup would `std::terminate`.

## Verification

- All five touched files compile cleanly (clang 19 `-fsyntax-only` with the project's exact compile flags), including a collision check against the file-local `DrainFutures(futures, first_error)` in `IndexEntryReader.cpp`.
- Changed lines pass clang-format 19 with the repo `.clang-format` (zero diffs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
