### PR TITLE
fix: restore conjunct AND early-exit at null-rejecting consumers

### DIFF
--- a/internal/core/src/exec/expression/ConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/ConjunctExpr.cpp
@@ -48,48 +48,36 @@ PhyConjunctFilterExpr::ResolveType(const std::vector<DataType>& inputs) {
     return DataType::BOOL;
 }
 
-int64_t
-PhyConjunctFilterExpr::UpdateResult(ColumnVectorPtr& input_result,
-                                    EvalCtx& ctx,
-                                    ColumnVectorPtr& result) {
-    if (is_and_) {
-        common::ThreeValuedLogicOp::And(result, input_result);
-    } else {
-        common::ThreeValuedLogicOp::Or(result, input_result);
-    }
-
-    // Return rows that still need the following expressions.
-    // For AND: TRUE or NULL rows still need evaluation; only definite FALSE can
-    // stop. For OR: FALSE or NULL rows still need evaluation; only definite TRUE
-    // can stop.
-    const size_t size = result->size();
-    TargetBitmapView res_data(result->GetRawData(), size);
-    TargetBitmapView res_valid(result->GetValidRawData(), size);
-    if (is_and_) {
-        TargetBitmap active_rows(res_valid);
-        active_rows.inplace_sub(res_data, size);  // valid & ~data
-        active_rows.flip();                       // data | ~valid
-        return static_cast<int64_t>(active_rows.count());
-    } else {
-        TargetBitmap active_rows(res_data);
-        active_rows.inplace_and(res_valid, size);  // data & valid
-        active_rows.flip();                        // ~data | ~valid
-        return static_cast<int64_t>(active_rows.count());
-    }
-}
-
-bool
-PhyConjunctFilterExpr::CanSkipFollowingExprs(ColumnVectorPtr& vec) {
-    // For AND: can only skip if ALL rows are definitely FALSE (valid=1, data=0)
-    //   - If any row is TRUE, we need to continue to determine final result
-    //   - If any row is NULL, we need to continue because NULL AND FALSE = FALSE
-    //     but NULL AND TRUE = NULL, so the result depends on following exprs
+TargetBitmap
+PhyConjunctFilterExpr::BuildActiveBitmap(const ColumnVectorPtr& vec) {
+    // Rows that still need the following expressions.
     //
-    // For OR: can only skip if ALL rows are definitely TRUE (valid=1, data=1)
-    //   - If any row is FALSE, we need to continue to determine final result
-    //   - If any row is NULL, we need to continue because NULL OR TRUE = TRUE
-    //     but NULL OR FALSE = NULL, so the result depends on following exprs
-    return is_and_ ? vec->AllFalse() : vec->AllTrue();
+    // For AND: TRUE or NULL rows still need evaluation; only definite FALSE
+    //   can stop (NULL AND FALSE = FALSE, so a NULL row can still change).
+    //   With a null-rejecting consumer, NULL is already equivalent to FALSE
+    //   downstream, so NULL rows are dropped too and only TRUE rows stay
+    //   active — restoring the pre-3VL early exit for UNKNOWN-heavy batches.
+    // For OR: FALSE or NULL rows still need evaluation; only definite TRUE
+    //   can stop. A NULL row can still become TRUE (NULL OR TRUE = TRUE),
+    //   so null-rejection does not shrink the active set for OR.
+    const size_t size = vec->size();
+    TargetBitmapView data(vec->GetRawData(), size);
+    TargetBitmapView valid(vec->GetValidRawData(), size);
+    if (is_and_) {
+        if (null_rejecting_) {
+            TargetBitmap active_rows(data);
+            active_rows.inplace_and(valid, size);  // data & valid
+            return active_rows;
+        }
+        TargetBitmap active_rows(valid);
+        active_rows.inplace_sub(data, size);  // valid & ~data
+        active_rows.flip();                   // data | ~valid
+        return active_rows;
+    }
+    TargetBitmap active_rows(data);
+    active_rows.inplace_and(valid, size);  // data & valid
+    active_rows.flip();                    // ~data | ~valid
+    return active_rows;
 }
 
 void
@@ -113,18 +101,27 @@ PhyConjunctFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     }
 
     auto has_input_offset = context.get_offset_input() != nullptr;
-    if (!has_input_offset && !like_batch_initialized_ && is_and_ &&
-        like_indices_.size() > 1) {
+    if (!like_batch_initialized_ && is_and_ && like_indices_.size() > 1) {
         like_batch_initialized_ = true;
-        // Collect LIKE expressions that can use ngram index at runtime
+        // Collect LIKE expressions that can use ngram index at runtime.
+        // The batch-ngram path evaluates whole batches, so it cannot be
+        // used with an offset input; ngram_exprs then stays empty and the
+        // else branch below erases the input_order_ slot reserved at
+        // compile time. Deciding here — once, in every mode — keeps the
+        // invariant that each input_order_ entry has a backing expression
+        // in inputs_ before anything indexes inputs_ with it. (An
+        // instance's offset mode is fixed for its lifetime, so no later
+        // call could have used the batch path anyway.)
         std::vector<std::shared_ptr<PhyUnaryRangeFilterExpr>> ngram_exprs;
-        for (size_t idx : like_indices_) {
-            auto unary_expr =
-                std::dynamic_pointer_cast<PhyUnaryRangeFilterExpr>(
-                    inputs_[idx]);
-            if (unary_expr && unary_expr->CanUseNgramIndex()) {
-                ngram_exprs.push_back(unary_expr);
-                batch_ngram_indices_.insert(idx);
+        if (!has_input_offset) {
+            for (size_t idx : like_indices_) {
+                auto unary_expr =
+                    std::dynamic_pointer_cast<PhyUnaryRangeFilterExpr>(
+                        inputs_[idx]);
+                if (unary_expr && unary_expr->CanUseNgramIndex()) {
+                    ngram_exprs.push_back(unary_expr);
+                    batch_ngram_indices_.insert(idx);
+                }
             }
         }
 
@@ -152,6 +149,17 @@ PhyConjunctFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
         }
     }
 
+    // Position of the last entry that will actually be evaluated: trailing
+    // batch-ngram entries are skipped in the loop and must not force a
+    // useless active-bitmap build after the real last input.
+    size_t last_eval_pos = input_order_.size();
+    for (size_t i = input_order_.size(); i-- > 0;) {
+        if (batch_ngram_indices_.count(input_order_[i]) == 0) {
+            last_eval_pos = i;
+            break;
+        }
+    }
+
     bool has_result = false;
     for (size_t i = 0; i < input_order_.size(); ++i) {
         size_t idx = input_order_[i];
@@ -164,28 +172,39 @@ PhyConjunctFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
         VectorPtr input_result;
         inputs_[idx]->Eval(context, input_result);
 
+        ColumnVectorPtr all_flat_result;
         if (!has_result) {
             result = input_result;
             has_result = true;
-            auto all_flat_result = GetColumnVector(result);
-            if (CanSkipFollowingExprs(all_flat_result)) {
-                SkipFollowingExprs(i + 1);
-                ClearBitmapInput(context);
-                return;
+            all_flat_result = GetColumnVector(result);
+        } else {
+            auto input_flat_result = GetColumnVector(input_result);
+            all_flat_result = GetColumnVector(result);
+            if (is_and_) {
+                common::ThreeValuedLogicOp::And(all_flat_result,
+                                                input_flat_result);
+            } else {
+                common::ThreeValuedLogicOp::Or(all_flat_result,
+                                               input_flat_result);
             }
-            SetNextExprBitmapInput(all_flat_result, context);
-            continue;
         }
-        auto input_flat_result = GetColumnVector(input_result);
-        auto all_flat_result = GetColumnVector(result);
-        auto active_rows =
-            UpdateResult(input_flat_result, context, all_flat_result);
-        if (active_rows == 0) {
+
+        // The last evaluated expression needs neither a skip decision nor a
+        // bitmap input for a successor.
+        if (i == last_eval_pos) {
+            break;
+        }
+
+        // Build the active-row bitmap once per input: it decides the
+        // batch-level early exit, and the same bitmap becomes the row-level
+        // input of the next expression.
+        auto active_rows = BuildActiveBitmap(all_flat_result);
+        if (active_rows.none()) {
             SkipFollowingExprs(i + 1);
             ClearBitmapInput(context);
             return;
         }
-        SetNextExprBitmapInput(all_flat_result, context);
+        context.set_bitmap_input(std::move(active_rows));
     }
     ClearBitmapInput(context);
 }

--- a/internal/core/src/exec/expression/ConjunctExpr.h
+++ b/internal/core/src/exec/expression/ConjunctExpr.h
@@ -157,42 +157,26 @@ class PhyConjunctFilterExpr : public Expr {
         return inputs_.size() - 1;
     }
 
-    // Set the bitmap input for the next expression in the conjunction.
-    // The bitmap indicates which rows still need to be evaluated.
-    //
-    // For AND: A row needs evaluation if it's currently TRUE or NULL
-    //   - TRUE rows: need to check if they remain TRUE after AND
-    //   - NULL rows: need to check if result becomes FALSE (NULL AND FALSE = FALSE)
-    //   - FALSE rows: already determined, no need to evaluate
-    //   => bitmap = data | ~valid (TRUE or NULL)
-    //
-    // For OR: A row needs evaluation if it's currently FALSE or NULL
-    //   - FALSE rows: need to check if they become TRUE after OR
-    //   - NULL rows: need to check if result becomes TRUE (NULL OR TRUE = TRUE)
-    //   - TRUE rows: already determined, no need to evaluate
-    //   => bitmap = ~data | ~valid (FALSE or NULL)
+    // This conjunction feeds a null-rejecting consumer: one that treats an
+    // UNKNOWN (NULL) output row exactly like FALSE. Under AND, an UNKNOWN
+    // row can never become TRUE (UNKNOWN AND x is UNKNOWN or FALSE), so a
+    // null-rejecting AND may stop evaluating it early; the row then stays
+    // UNKNOWN instead of possibly collapsing to FALSE, which is
+    // indistinguishable downstream. The property crosses AND/OR — their
+    // combination cannot turn an operand's UNKNOWN into TRUE when the root
+    // folds UNKNOWN into FALSE — so it propagates to the inputs; any other
+    // node keeps the no-op default and stops the propagation.
     void
-    SetNextExprBitmapInput(const ColumnVectorPtr& vec, EvalCtx& context) {
-        const size_t size = vec->size();
-        TargetBitmapView data(vec->GetRawData(), size);
-        TargetBitmapView valid(vec->GetValidRawData(), size);
-
-        if (is_and_) {
-            // bitmap = data | ~valid
-            // Using De Morgan's law: data | ~valid = ~(~data & valid) = ~(valid & ~data)
-            // Use inplace_sub which computes: this = this & ~other
-            TargetBitmap next_input_bitmap(valid);      // copy valid
-            next_input_bitmap.inplace_sub(data, size);  // valid & ~data
-            next_input_bitmap.flip();  // ~(valid & ~data) = data | ~valid
-            context.set_bitmap_input(std::move(next_input_bitmap));
-        } else {
-            // bitmap = ~data | ~valid
-            // Using De Morgan's law: ~data | ~valid = ~(data & valid)
-            TargetBitmap next_input_bitmap(data);        // copy data
-            next_input_bitmap.inplace_and(valid, size);  // data & valid
-            next_input_bitmap.flip();  // ~(data & valid) = ~data | ~valid
-            context.set_bitmap_input(std::move(next_input_bitmap));
+    MarkNullRejecting() override {
+        null_rejecting_ = true;
+        for (auto& input : inputs_) {
+            input->MarkNullRejecting();
         }
+    }
+
+    bool
+    IsNullRejecting() const {
+        return null_rejecting_;
     }
 
     void
@@ -221,21 +205,22 @@ class PhyConjunctFilterExpr : public Expr {
     }
 
  private:
-    int64_t
-    UpdateResult(ColumnVectorPtr& input_result,
-                 EvalCtx& ctx,
-                 ColumnVectorPtr& result);
+    // Build the bitmap of rows that still need the following expressions:
+    // its count drives the batch-level early exit and the bitmap itself
+    // becomes the row-level input of the next expression.
+    TargetBitmap
+    BuildActiveBitmap(const ColumnVectorPtr& vec);
 
     static DataType
     ResolveType(const std::vector<DataType>& inputs);
-
-    bool
-    CanSkipFollowingExprs(ColumnVectorPtr& vec);
 
     void
     SkipFollowingExprs(int start);
     // true if conjunction (and), false if disjunction (or).
     bool is_and_;
+    // true if the consumer of this expression's output treats UNKNOWN like
+    // FALSE (see MarkNullRejecting).
+    bool null_rejecting_{false};
     std::vector<size_t> input_order_;
     // Indices of LIKE expressions for potential batch ngram optimization (AND only)
     std::vector<size_t> like_indices_;

--- a/internal/core/src/exec/expression/ConjunctExprTest.cpp
+++ b/internal/core/src/exec/expression/ConjunctExprTest.cpp
@@ -68,13 +68,49 @@ class FixedBitmapExpr : public Expr {
     TargetBitmap valid_;
 };
 
+// Each row given as {data, valid}.
 std::shared_ptr<FixedBitmapExpr>
-FixedBool(const bool data, const bool valid) {
-    TargetBitmap data_bitmap(1, data);
-    TargetBitmap valid_bitmap(1, valid);
+FixedRows(std::initializer_list<std::pair<bool, bool>> rows) {
+    TargetBitmap data_bitmap(rows.size(), false);
+    TargetBitmap valid_bitmap(rows.size(), false);
+    size_t i = 0;
+    for (const auto& [data, valid] : rows) {
+        data_bitmap[i] = data;
+        valid_bitmap[i] = valid;
+        ++i;
+    }
     return std::make_shared<FixedBitmapExpr>(std::move(data_bitmap),
                                              std::move(valid_bitmap));
 }
+
+std::shared_ptr<FixedBitmapExpr>
+FixedBool(const bool data, const bool valid) {
+    return FixedRows({{data, valid}});
+}
+
+// A boolean node that is not a conjunction (stand-in for NOT in the
+// null-rejection propagation tests).
+class PassThroughExpr : public Expr {
+ public:
+    explicit PassThroughExpr(ExprPtr input)
+        : Expr(DataType::BOOL, {std::move(input)}, "PassThroughExpr", nullptr) {
+    }
+
+    void
+    Eval(EvalCtx& context, VectorPtr& result) override {
+        inputs_[0]->Eval(context, result);
+    }
+
+    std::string
+    ToString() const override {
+        return "PassThroughExpr";
+    }
+
+    std::optional<milvus::expr::ColumnInfo>
+    GetColumnInfo() const override {
+        return std::nullopt;
+    }
+};
 
 }  // namespace
 
@@ -107,6 +143,197 @@ TEST(ConjunctExprTest, AndKeepsUnknownRowsActiveForFollowingFalse) {
     EXPECT_EQ(true_expr->eval_count_, 1);
     EXPECT_EQ(false_expr->eval_count_, 1);
     EXPECT_EQ(false_expr->move_count_, 0);
+}
+
+TEST(ConjunctExprTest, NullRejectingAndSkipsFollowingForAllUnknown) {
+    auto unknown = FixedBool(false, false);
+    auto heavy = FixedBool(true, true);
+
+    std::vector<ExprPtr> inputs{unknown, heavy};
+    auto conjunct = std::make_shared<PhyConjunctFilterExpr>(
+        std::move(inputs), true, nullptr);
+    conjunct->MarkNullRejecting();
+
+    QueryContext query_context("conjunct_test", nullptr, 1, 0);
+    ExecContext exec_context(&query_context);
+    EvalCtx eval_context(&exec_context);
+
+    VectorPtr result;
+    conjunct->Eval(eval_context, result);
+
+    auto output = std::dynamic_pointer_cast<ColumnVector>(result);
+    ASSERT_NE(output, nullptr);
+    TargetBitmapView data(output->GetRawData(), output->size());
+    TargetBitmapView valid(output->GetValidRawData(), output->size());
+    ASSERT_EQ(output->size(), 1);
+    // The row stays UNKNOWN, which the null-rejecting consumer treats as
+    // FALSE.
+    EXPECT_FALSE(data[0]);
+    EXPECT_FALSE(valid[0]);
+
+    // The UNKNOWN row can never become TRUE under AND, so the following
+    // expression must be skipped, not evaluated.
+    EXPECT_EQ(unknown->eval_count_, 1);
+    EXPECT_EQ(heavy->eval_count_, 0);
+    EXPECT_EQ(heavy->move_count_, 1);
+}
+
+TEST(ConjunctExprTest, NullRejectingAndStillEvaluatesForTrueRows) {
+    auto first = FixedRows({{false, false}, {true, true}});
+    auto second = FixedRows({{true, true}, {false, true}});
+
+    std::vector<ExprPtr> inputs{first, second};
+    auto conjunct = std::make_shared<PhyConjunctFilterExpr>(
+        std::move(inputs), true, nullptr);
+    conjunct->MarkNullRejecting();
+
+    QueryContext query_context("conjunct_test", nullptr, 2, 0);
+    ExecContext exec_context(&query_context);
+    EvalCtx eval_context(&exec_context);
+
+    VectorPtr result;
+    conjunct->Eval(eval_context, result);
+
+    // Row 1 is TRUE after the first expression, so the second must run.
+    EXPECT_EQ(second->eval_count_, 1);
+    EXPECT_EQ(second->move_count_, 0);
+
+    auto output = std::dynamic_pointer_cast<ColumnVector>(result);
+    ASSERT_NE(output, nullptr);
+    TargetBitmapView data(output->GetRawData(), output->size());
+    TargetBitmapView valid(output->GetValidRawData(), output->size());
+    ASSERT_EQ(output->size(), 2);
+    // Row 1: TRUE AND FALSE = FALSE.
+    EXPECT_FALSE(data[1]);
+    EXPECT_TRUE(valid[1]);
+    // Row 0 is excluded either way (UNKNOWN or FALSE).
+    EXPECT_FALSE(data[0] && valid[0]);
+}
+
+TEST(ConjunctExprTest, NullRejectingMatchesDefaultIncludedSet) {
+    // The included set (definite TRUE rows) must be identical with and
+    // without null-rejection; only excluded rows may differ between
+    // UNKNOWN and FALSE.
+    auto build_and_eval = [](bool null_rejecting) {
+        auto first = FixedRows({{false, false}, {true, true}, {false, true}});
+        auto second = FixedRows({{false, true}, {true, true}, {true, true}});
+        std::vector<ExprPtr> inputs{first, second};
+        auto conjunct = std::make_shared<PhyConjunctFilterExpr>(
+            std::move(inputs), true, nullptr);
+        if (null_rejecting) {
+            conjunct->MarkNullRejecting();
+        }
+        QueryContext query_context("conjunct_test", nullptr, 3, 0);
+        ExecContext exec_context(&query_context);
+        EvalCtx eval_context(&exec_context);
+        VectorPtr result;
+        conjunct->Eval(eval_context, result);
+        auto output = std::dynamic_pointer_cast<ColumnVector>(result);
+        TargetBitmapView data(output->GetRawData(), output->size());
+        TargetBitmapView valid(output->GetValidRawData(), output->size());
+        std::vector<bool> included;
+        for (size_t i = 0; i < output->size(); ++i) {
+            included.push_back(data[i] && valid[i]);
+        }
+        return included;
+    };
+
+    EXPECT_EQ(build_and_eval(true), build_and_eval(false));
+}
+
+TEST(ConjunctExprTest, NullRejectingOrKeepsUnknownRowsActive) {
+    // Under OR an UNKNOWN row can still become TRUE (UNKNOWN OR TRUE =
+    // TRUE), so null-rejection must not skip the following expression.
+    auto unknown = FixedBool(false, false);
+    auto true_expr = FixedBool(true, true);
+
+    std::vector<ExprPtr> inputs{unknown, true_expr};
+    auto disjunct = std::make_shared<PhyConjunctFilterExpr>(
+        std::move(inputs), false, nullptr);
+    disjunct->MarkNullRejecting();
+
+    QueryContext query_context("conjunct_test", nullptr, 1, 0);
+    ExecContext exec_context(&query_context);
+    EvalCtx eval_context(&exec_context);
+
+    VectorPtr result;
+    disjunct->Eval(eval_context, result);
+
+    EXPECT_EQ(true_expr->eval_count_, 1);
+
+    auto output = std::dynamic_pointer_cast<ColumnVector>(result);
+    ASSERT_NE(output, nullptr);
+    TargetBitmapView data(output->GetRawData(), output->size());
+    TargetBitmapView valid(output->GetValidRawData(), output->size());
+    // UNKNOWN OR TRUE = TRUE: the row must be included.
+    EXPECT_TRUE(data[0]);
+    EXPECT_TRUE(valid[0]);
+}
+
+TEST(ConjunctExprTest, OffsetInputErasesUnmaterializedReservedLikeSlot) {
+    // ReorderConjunctExpr reserves index inputs_.size() for a runtime
+    // PhyLikeConjunctExpr and records the LIKE positions via SetLikeIndices.
+    // The batch-ngram path cannot be used with an offset input, so the init
+    // block must erase the reserved slot on that path too — otherwise both
+    // the Eval loop and the early-exit path (SkipFollowingExprs) would
+    // index inputs_ past its end.
+    auto first = FixedBool(false, true);  // definite FALSE -> early exit
+    auto second = FixedBool(true, true);
+
+    std::vector<ExprPtr> inputs{first, second};
+    auto conjunct = std::make_shared<PhyConjunctFilterExpr>(
+        std::move(inputs), true, nullptr);
+    conjunct->SetLikeIndices({0, 1});
+    conjunct->Reorder({0, 1, 2});
+
+    QueryContext query_context("conjunct_test", nullptr, 1, 0);
+    ExecContext exec_context(&query_context);
+    EvalCtx eval_context(&exec_context);
+    OffsetVector offsets;
+    offsets.push_back(0);
+    eval_context.set_offset_input(&offsets);
+
+    VectorPtr result;
+    conjunct->Eval(eval_context, result);
+
+    auto output = std::dynamic_pointer_cast<ColumnVector>(result);
+    ASSERT_NE(output, nullptr);
+    TargetBitmapView data(output->GetRawData(), output->size());
+    TargetBitmapView valid(output->GetValidRawData(), output->size());
+    ASSERT_EQ(output->size(), 1);
+    EXPECT_FALSE(data[0]);
+    EXPECT_TRUE(valid[0]);
+    // The definite-FALSE first input early-exits: the second expression is
+    // skipped via MoveCursor and the erased reserved slot is never touched.
+    EXPECT_EQ(first->eval_count_, 1);
+    EXPECT_EQ(second->eval_count_, 0);
+    EXPECT_EQ(second->move_count_, 1);
+}
+
+TEST(ConjunctExprTest, MarkNullRejectingStopsAtNonConjunctNodes) {
+    std::vector<ExprPtr> inner_inputs{FixedBool(true, true),
+                                      FixedBool(true, true)};
+    auto inner_and = std::make_shared<PhyConjunctFilterExpr>(
+        std::move(inner_inputs), true, nullptr);
+
+    std::vector<ExprPtr> hidden_inputs{FixedBool(true, true),
+                                       FixedBool(true, true)};
+    auto hidden_and = std::make_shared<PhyConjunctFilterExpr>(
+        std::move(hidden_inputs), true, nullptr);
+    auto wrapper = std::make_shared<PassThroughExpr>(hidden_and);
+
+    std::vector<ExprPtr> outer_inputs{inner_and, wrapper};
+    auto outer_or = std::make_shared<PhyConjunctFilterExpr>(
+        std::move(outer_inputs), false, nullptr);
+
+    outer_or->MarkNullRejecting();
+
+    // Propagates through nested AND/OR ...
+    EXPECT_TRUE(outer_or->IsNullRejecting());
+    EXPECT_TRUE(inner_and->IsNullRejecting());
+    // ... but stops at any non-conjunct node (e.g. NOT), where FALSE and
+    // UNKNOWN produce different results.
+    EXPECT_FALSE(hidden_and->IsNullRejecting());
 }
 
 }  // namespace milvus::exec

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -190,6 +190,17 @@ class Expr : public std::enable_shared_from_this<Expr> {
         return false;
     }
 
+    // Called when this expression's output feeds a null-rejecting consumer:
+    // one that treats an UNKNOWN (NULL) row exactly like FALSE, such as the
+    // top-level filter, which folds UNKNOWN into the excluded set. Nodes
+    // whose operands keep that property (AND/OR) override this to accept the
+    // mark and propagate it to their inputs; everywhere else (in particular
+    // NOT, where FALSE and UNKNOWN produce different results) the default
+    // no-op stops the propagation.
+    virtual void
+    MarkNullRejecting() {
+    }
+
     virtual bool
     CanUseNestedIndex() const {
         return false;
@@ -2564,10 +2575,20 @@ CompileExpression(const expr::TypedExprPtr& expr,
 
 class ExprSet {
  public:
+    // null_rejecting: the consumer of these expressions' output treats
+    // UNKNOWN rows exactly like FALSE (e.g. a filter that folds UNKNOWN into
+    // the excluded set); lets conjunctions drop UNKNOWN rows from their
+    // active sets early. See Expr::MarkNullRejecting.
     explicit ExprSet(const std::vector<expr::TypedExprPtr>& logical_exprs,
-                     ExecContext* exec_ctx)
+                     ExecContext* exec_ctx,
+                     bool null_rejecting = false)
         : exec_ctx_(exec_ctx) {
         exprs_ = CompileExpressions(logical_exprs, exec_ctx);
+        if (null_rejecting) {
+            for (auto& compiled_expr : exprs_) {
+                compiled_expr->MarkNullRejecting();
+            }
+        }
     }
 
     virtual ~ExprSet() = default;

--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -88,7 +88,12 @@ PhyFilterBitsNode::PhyFilterBitsNode(
     query_context_ = exec_context->get_query_context();
     std::vector<expr::TypedExprPtr> filters;
     filters.emplace_back(filter->filter());
-    exprs_ = std::make_unique<ExprSet>(filters, exec_context);
+    // This operator folds UNKNOWN predicate rows into the excluded set
+    // (ConvertPredicateToFilteredBitset), i.e. it is a null-rejecting
+    // consumer: let conjunctions in the predicate tree drop UNKNOWN rows
+    // from their active sets early.
+    exprs_ = std::make_unique<ExprSet>(
+        filters, exec_context, /*null_rejecting=*/true);
     need_process_rows_ = query_context_->get_active_count();
     num_processed_rows_ = 0;
 

--- a/internal/core/src/exec/operator/IterativeFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeFilterNode.cpp
@@ -64,7 +64,11 @@ PhyIterativeFilterNode::PhyIterativeFilterNode(
     query_context_ = exec_context->get_query_context();
     std::vector<expr::TypedExprPtr> filters;
     filters.emplace_back(filter->filter());
-    exprs_ = std::make_unique<ExprSet>(filters, exec_context);
+    // This operator reads only the data bits of the predicate output, so
+    // UNKNOWN rows are excluded exactly like FALSE — a null-rejecting
+    // consumer.
+    exprs_ = std::make_unique<ExprSet>(
+        filters, exec_context, /*null_rejecting=*/true);
     const auto& exprs = exprs_->exprs();
     for (const auto& expr : exprs) {
         is_native_supported_ =
@@ -186,6 +190,11 @@ PhyIterativeFilterNode::GetOutput() {
         }
         Assert(bitset.size() == need_process_rows_);
         Assert(valid_bitset.size() == need_process_rows_);
+        // Rows are included below on the data bit alone, so fold UNKNOWN
+        // into FALSE explicitly (data &= valid) instead of relying on the
+        // convention that UNKNOWN rows carry data=0. This is what makes
+        // this operator a null-rejecting consumer by construction.
+        bitset.inplace_and(valid_bitset, need_process_rows_);
     }
     if (search_result.vector_iterators_.has_value()) {
         AssertInfo(search_result.vector_iterators_.value().size() ==
@@ -294,6 +303,11 @@ PhyIterativeFilterNode::GetOutput() {
                     auto col_vec_size = col_vec->size();
                     TargetBitmapView bitsetview(col_vec->GetRawData(),
                                                 col_vec_size);
+                    // Fold UNKNOWN into FALSE explicitly (data &= valid):
+                    // rows are included below on the data bit alone.
+                    TargetBitmapView validview(col_vec->GetValidRawData(),
+                                               col_vec_size);
+                    bitsetview.inplace_and(validview, col_vec_size);
 
                     if (element_level) {
                         Assert(bitsetview.size() == doc_offsets.size());


### PR DESCRIPTION
issue: #51181

The 3VL null-semantics rework correctly made conjunctions keep UNKNOWN rows active (under `NOT`, `UNKNOWN AND FALSE = FALSE` must stay reachable), but this disabled the AND early-exit everywhere — including at the top-level filter, which folds UNKNOWN into the excluded set exactly like FALSE. For filters like `json["a"] == 1 and heavy_expr and ...` over data where most rows lack the key, every following conjunct ran over rows whose outcome was already decided.

## Changes

**Null-rejecting propagation (compile-time, zero hot-path cost)**
- New virtual `Expr::MarkNullRejecting()`: no-op default stops the propagation at any non-conjunct node (in particular `NOT`, where FALSE ≠ UNKNOWN); `PhyConjunctFilterExpr` overrides it to set `null_rejecting_` and recurse into its inputs. The property legally crosses nested AND/OR: their combination cannot turn an operand's UNKNOWN into TRUE when the root folds UNKNOWN into FALSE.
- `ExprSet` gains a `null_rejecting` ctor flag; `PhyFilterBitsNode` (folds UNKNOWN in `ConvertPredicateToFilteredBitset`) and `PhyIterativeFilterNode` (includes rows on data bits) pass true. Element-level filter operators keep the default and merely miss the optimization for now.
- A null-rejecting AND uses `data & valid` as its active set: the zero-TRUE batch early exit is restored, and UNKNOWN rows are dropped from the next expression's row-level bitmap input. OR is untouched (`UNKNOWN OR TRUE = TRUE` can still flip a row in). Included row set is provably unchanged — pinned by `NullRejectingMatchesDefaultIncludedSet`; the existing NOT-context test keeps guarding strict 3VL behavior in unmarked conjuncts.

**Single active-bitmap build per input per batch**
- Previously the identical `data | ~valid` bitmap was built twice per non-first input (once in `UpdateResult` only to be counted and discarded, once in `SetNextExprBitmapInput`), plus once more for the final input where `ClearBitmapInput` immediately discarded it. Now `BuildActiveBitmap` runs once: `none()` (early-terminating, no full popcount) decides the batch-level exit and the same bitmap is `std::move`d into the eval context. The build is skipped for the last actually-evaluated position (`last_eval_pos`), so trailing batch-ngram entries don't force a useless build.

**Pre-existing OOB crash fixed at its root**
- `ReorderConjunctExpr` reserves `input_order_` slot `inputs_.size()` for a runtime `PhyLikeConjunctExpr`, but the block that materializes or erases it was gated on `!has_input_offset`. On `PhyIterativeFilterNode`'s native offset path (reachable: LIKE supports offset input) the reserved slot never got a backing expression, and both the Eval loop and `SkipFollowingExprs` indexed `inputs_[inputs_.size()]` — reproduced as a SIGSEGV under gtest with the production-reachable state. The init block now decides materialize-vs-erase in every mode (the batch-ngram path cannot be used with an offset input anyway, and an instance's offset mode is fixed for its lifetime), restoring the invariant "every `input_order_` entry has a backing expression" at its single owner rather than guarding each consumer.

**IterativeFilterNode: null-rejecting by construction**
- Both consumption paths now fold `data &= valid` explicitly instead of relying on the unenforced convention that UNKNOWN rows carry `data=0` (the fallback path collected `valid_bitset` but used it only in asserts).

Note: `ColumnVector::AllTrue/AllFalse` lose their last production caller here but are kept as general-purpose public API with existing tests.

## Verification

- Unit tests (Linux, `make build-cpp-with-unittest`): `ConjunctExprTest` 7/7 (6 new: null-rejecting early exit / TRUE rows still evaluated / included-set equivalence marked-vs-unmarked / OR unaffected / propagation stops at non-conjunct nodes / offset-input reserved-slot erasure incl. the previously-crashing early-exit path), `*Conjunct*` 9/9, `*Iterative*` 4/4, `TaskTest*` + `FilterOnlySearchTest*` 37/37, `LikeConjunctExpr` pass.
- Two rounds of multi-agent adversarial review; all confirmed findings addressed.
- clang-format (19) clean on all changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
