### PR TITLE
fix: fail fast on canceled context in wal state wait to deflake TestWALLifetime

### DIFF
--- a/internal/streamingnode/server/walmanager/wal_lifetime_test.go
+++ b/internal/streamingnode/server/walmanager/wal_lifetime_test.go
@@ -27,9 +27,17 @@ func TestWALLifetime(t *testing.T) {
 		resource.OptMixCoordClient(fMixcoord),
 	)
 
+	// Gate the term-11 open so the background task cannot converge while the
+	// canceled-context assertions below run: the waiters must actually wait
+	// (and observe the cancellation) instead of racing with the background
+	// convergence.
+	term11OpenGate := make(chan struct{})
 	opener := mock_wal.NewMockOpener(t)
 	opener.EXPECT().Open(mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, oo *wal.OpenOption) (wal.WAL, error) {
+			if oo.Channel.Term == 11 {
+				<-term11OpenGate
+			}
 			l := mock_wal.NewMockWAL(t)
 			l.EXPECT().Channel().Return(oo.Channel)
 			l.EXPECT().Close().Return()
@@ -100,6 +108,9 @@ func TestWALLifetime(t *testing.T) {
 
 	err = wlt.Remove(ctx, 11)
 	assert.ErrorIs(t, err, context.Canceled)
+
+	// Release the background convergence of term 11.
+	close(term11OpenGate)
 
 	err = wlt.Open(context.Background(), types.PChannelInfo{
 		Name: channel,

--- a/internal/streamingnode/server/walmanager/wal_state_pair.go
+++ b/internal/streamingnode/server/walmanager/wal_state_pair.go
@@ -24,6 +24,15 @@ type walStatePair struct {
 
 // WaitCurrentStateReachExpected waits until the current state is reach the expected state.
 func (w *walStatePair) WaitCurrentStateReachExpected(ctx context.Context, expected expectedWALState) error {
+	// Fail fast on an already-canceled context. Without this check the
+	// outcome would depend on whether the background task has already
+	// converged to the expected state (the fast path below never consults
+	// ctx), making the result of Open/Remove with a canceled context
+	// nondeterministic. The expected state is registered before this wait,
+	// so the background task still converges regardless.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	current := w.currentState.GetState()
 	for isStateBefore(current, expected) {
 		if err := w.currentState.WatchChanged(ctx, current); err != nil {


### PR DESCRIPTION
issue: #51183

`TestWALLifetime` is flaky (seen on unrelated PR #51180, the only failure among 14937 Go tests). Root cause is a nondeterministic contract, not test timing: `WaitCurrentStateReachExpected` only consults `ctx` when it actually has to wait — if the background task has already converged, the fast path returns without observing cancellation. Since the background intentionally executes even canceled expected states (see the deadlock note in `doLifetimeChanged`), `Open`/`Remove` with a pre-canceled context race between `context.Canceled` and `nil`.

## Changes

- **`wal_state_pair.go`**: check `ctx.Err()` at the entry of `WaitCurrentStateReachExpected`, making the canceled-context outcome deterministic (standard Go fail-fast convention). Behavior is otherwise unchanged: the expected state is registered before the wait, the background still converges, WAL lifecycle ownership stays with the background task, and the coord-side recovery (retry with new/higher term) is untouched — only the caller's wait terminates deterministically.
- **`wal_lifetime_test.go`**: gate the term-11 mock open so the canceled-context waiters provably have to wait, released right after the assertions — a regression pin that keeps the test deterministic even independently of the fail-fast check.

## Verification

- `go test -race -tags dynamic,test -run TestWALLifetime -count=50` → 50/50 pass
- full `walmanager` package, `-race -count=3` → pass
- `gofmt` / `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
