### PR TITLE
enhance: [cp 3.0] trigger streaming balance on primary rg change

### DIFF
--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/discoverer"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/resolver"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
@@ -63,12 +64,14 @@ func RecoverBalancer(
 		reqCh:                  make(chan *request, 5),
 		backgroundTaskNotifier: syncutil.NewAsyncTaskNotifier[struct{}](),
 		freezeNodes:            typeutil.NewConcurrentSet[int64](),
+		primaryRGChangedCh:     make(chan struct{}, 1),
 	}
 	b.SetLogger(logger)
 	ready260Future, err := b.checkIfAllNodeGreaterThan260AndWatch(ctx)
 	if err != nil {
 		return nil, err
 	}
+	b.watchPrimaryResourceGroupChanges()
 	go b.execute(ready260Future)
 	return b, nil
 }
@@ -86,9 +89,23 @@ type balancerImpl struct {
 	reqCh                  chan *request                         // reqCh is the request channel, send the operation to background task.
 	backgroundTaskNotifier *syncutil.AsyncTaskNotifier[struct{}] // backgroundTaskNotifier is used to conmunicate with the background task.
 	freezeNodes            *typeutil.ConcurrentSet[int64]        // freezeNodes is the nodes that will be frozen, no more wal will be assigned to these nodes and wal will be removed from these nodes.
+	primaryRGChangedCh     chan struct{}                         // primaryRGChangedCh wakes the balance loop when streaming.primaryResourceGroup changes.
+	primaryRGChangeHandler config.EventHandler
 
 	fileResourceChecker FileResourceChecker
 	checkerMu           sync.RWMutex
+}
+
+func (b *balancerImpl) watchPrimaryResourceGroupChanges() {
+	key := paramtable.Get().StreamingCfg.PrimaryResourceGroup.Key
+	handler := config.NewHandler("streamingcoord.balancer.primary-rg", func(_ *config.Event) {
+		select {
+		case b.primaryRGChangedCh <- struct{}{}:
+		default:
+		}
+	})
+	b.primaryRGChangeHandler = handler
+	paramtable.Get().Watch(key, handler)
 }
 
 func (b *balancerImpl) SetFileResourceChecker(checker FileResourceChecker) {
@@ -305,6 +322,9 @@ func (b *balancerImpl) sendRequestAndWaitFinish(ctx context.Context, newReq *req
 
 // Close close the balancer.
 func (b *balancerImpl) Close() {
+	if b.primaryRGChangeHandler != nil {
+		paramtable.Get().Unwatch(paramtable.Get().StreamingCfg.PrimaryResourceGroup.Key, b.primaryRGChangeHandler)
+	}
 	b.lifetime.SetState(typeutil.LifetimeStateStopped)
 	b.provider.Close()
 	// cancel all watch opeartion by context.
@@ -377,6 +397,12 @@ func (b *balancerImpl) execute(ready260Future *syncutil.Future[error]) {
 		case <-channelChanged.WaitChan():
 			// balance triggered by channel changed.
 			channelChanged.Sync()
+		case <-b.primaryRGChangedCh:
+			b.Logger().Info(
+				b.backgroundTaskNotifier.Context(),
+				"balance triggered by primary resource group config change",
+				mlog.String("primaryResourceGroup", paramtable.Get().StreamingCfg.PrimaryResourceGroup.GetValue()),
+			)
 		case newChannels, ok := <-b.provider.NewIncomingChannels():
 			if !ok {
 				return

--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -557,6 +557,91 @@ func TestBalancer_WithRecoveryLag(t *testing.T) {
 	})
 }
 
+func TestBalancer_PrimaryResourceGroupChangeTriggersBalance(t *testing.T) {
+	paramtable.Init()
+	oldTriggerInterval := paramtable.Get().StreamingCfg.WALBalancerTriggerInterval.SwapTempValue("1h")
+	oldExpectedStreamingNodeNum := paramtable.Get().StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.SwapTempValue("0")
+	defer paramtable.Get().StreamingCfg.WALBalancerTriggerInterval.SwapTempValue(oldTriggerInterval)
+	defer paramtable.Get().StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.SwapTempValue(oldExpectedStreamingNodeNum)
+	assert.NoError(t, paramtable.Get().Save(paramtable.Get().StreamingCfg.PrimaryResourceGroup.Key, "rg-old"))
+	defer func() {
+		assert.NoError(t, paramtable.Get().Remove(paramtable.Get().StreamingCfg.PrimaryResourceGroup.Key))
+	}()
+
+	etcdClient, _ := kvfactory.GetEtcdAndPath()
+	channel.ResetStaticPChannelStatsManager()
+	channel.RecoverPChannelStatsManager([]string{})
+
+	rgHints := make(chan string, 8)
+	streamingNodeManager := mock_manager.NewMockManagerClient(t)
+	streamingNodeManager.EXPECT().WatchNodeChanged(mock.Anything).Return(make(chan struct{}), nil)
+	streamingNodeManager.EXPECT().Assign(mock.Anything, mock.Anything).Return(nil).Maybe()
+	streamingNodeManager.EXPECT().Remove(mock.Anything, mock.Anything).Return(nil).Maybe()
+	streamingNodeManager.EXPECT().CollectAllStatus(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, resourceGroupHint string) (map[int64]*types.StreamingNodeStatus, error) {
+		rgHints <- resourceGroupHint
+		return map[int64]*types.StreamingNodeStatus{
+			1: {
+				StreamingNodeInfo: types.StreamingNodeInfo{
+					ServerID: 1,
+					Address:  "localhost:1",
+				},
+			},
+		}, nil
+	}).Maybe()
+
+	catalog := mock_metastore.NewMockStreamingCoordCataLog(t)
+	s := sessionutil.NewMockSession(t)
+	s.EXPECT().GetRegisteredRevision().Return(int64(1))
+	resource.InitForTest(
+		resource.OptETCD(etcdClient),
+		resource.OptStreamingCatalog(catalog),
+		resource.OptStreamingManagerClient(streamingNodeManager),
+		resource.OptSession(s),
+	)
+	catalog.EXPECT().GetCChannel(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveCChannel(mock.Anything, mock.Anything).Return(nil)
+	catalog.EXPECT().GetVersion(mock.Anything).Return(&streamingpb.StreamingVersion{Version: channel.StreamingVersion260}, nil)
+	catalog.EXPECT().ListPChannel(mock.Anything).Unset()
+	catalog.EXPECT().ListPChannel(mock.Anything).Return([]*streamingpb.PChannelMeta{
+		{
+			Channel: &streamingpb.PChannelInfo{
+				Name:       "test-channel",
+				Term:       1,
+				AccessMode: streamingpb.PChannelAccessMode_PCHANNEL_ACCESS_READWRITE,
+			},
+			State: streamingpb.PChannelMetaState_PCHANNEL_META_STATE_ASSIGNED,
+			Node:  &streamingpb.StreamingNodeInfo{ServerId: 1},
+		},
+	}, nil)
+	catalog.EXPECT().SavePChannels(mock.Anything, mock.Anything).Return(nil).Maybe()
+	catalog.EXPECT().GetReplicateConfiguration(mock.Anything).Return(nil, nil)
+
+	ctx := context.Background()
+	b, err := balancer.RecoverBalancer(ctx, newStaticChannelProvider("test-channel"))
+	assert.NoError(t, err)
+	assert.NotNil(t, b)
+	defer b.Close()
+
+	assert.Eventually(t, func() bool {
+		select {
+		case hint := <-rgHints:
+			return hint == "rg-old"
+		default:
+			return false
+		}
+	}, 3*time.Second, 10*time.Millisecond)
+
+	assert.NoError(t, paramtable.Get().Save(paramtable.Get().StreamingCfg.PrimaryResourceGroup.Key, "rg-new"))
+	assert.Eventually(t, func() bool {
+		select {
+		case hint := <-rgHints:
+			return hint == "rg-new"
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestBalancer_DynamicChannelFromProvider(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().StreamingCfg.WALBalancerExpectedInitialStreamingNodeNum.SwapTempValue("0")


### PR DESCRIPTION
issue: #51123
pr: #51145

- streamingcoord balancer: wake the balance loop when `streaming.primaryResourceGroup` changes and keep convergence on the existing balance path
- streamingcoord tests: cover primary resource group runtime config changes without relying on the periodic balance timer
