### PR TITLE
feat: support analyzer char filter

### DIFF
--- a/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
+++ b/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
@@ -1,0 +1,121 @@
+# Analyzer Char Filters
+
+## Summary
+
+Custom analyzers can run character filters over the complete input before
+tokenization. A character filter is a `String -> String` transformation: it
+modifies the tokenizer's input string, and its output becomes the tokenizer's
+next input directly. It does not consume or emit tokens. A wrapper tokenizer
+owns the configured character filters and the user-selected Tantivy analyzer,
+then corrects token offsets back to the original input.
+
+The first supported character filter is `mapping`. It is a pre-tokenization
+string rewriter backed by `source => target` rules. It scans the current input
+from left to right, selects the longest matching source at each position,
+appends its target, and advances past the source. If no rule matches, it copies
+the next Unicode scalar unchanged. A target may replace, expand, contract, or
+delete source text.
+
+Replacement output is not scanned again by the same mapping character filter.
+A later character filter processes the complete output of the previous filter.
+Offset corrections preserve the relationship between rewritten text and the
+original tokenizer input.
+
+Mapping rules trim syntax whitespace on both sides of `=>`, matching
+Elasticsearch. Whitespace that is part of a source or target must use an escape
+such as `\u0020`. The parser supports `\\`, `\n`, `\t`, `\r`, `\b`, `\f`, and
+`\uXXXX`; valid UTF-16 surrogate-pair escapes are combined into one Unicode
+scalar before processing UTF-8 text. When a rule contains multiple unescaped
+`=>` sequences, the last one is the separator. Duplicate sources are rejected
+after trimming and unescaping.
+
+## Configuration
+
+`char_filter` is an ordered array on a custom analyzer:
+
+```json
+{
+  "char_filter": [
+    {
+      "type": "mapping",
+      "mappings": ["& => and"]
+    }
+  ],
+  "char_filter_offset_mode": "source_span",
+  "tokenizer": "standard",
+  "filter": ["lowercase"]
+}
+```
+
+Character filters run in array order before the tokenizer. Token filters run
+after the tokenizer as before. Built-in analyzer templates do not accept
+character-filter options.
+
+`char_filter_offset_mode` is optional:
+
+- `source_span` is the default. Every token that overlaps replacement output is
+  attributed to the complete source span of that replacement.
+- `boundary` maps each replacement character boundary to a source character
+  boundary. Expansions may therefore produce zero-length token offsets.
+
+Both modes return UTF-8 byte offsets, matching Tantivy and Rust strings. Given
+valid tokenizer offsets, boundary mode advances by Unicode scalar values through
+`char_indices()`, so a returned offset never divides a UTF-8 encoded scalar
+value. It is similar to
+Lucene boundary correction but is not numerically compatible with
+Elasticsearch, whose offsets use UTF-16 code units.
+
+## Architecture
+
+`CharFilterTokenizer` wraps the selected analyzer because Tantivy has no
+pre-tokenization character-filter role. For each input it:
+
+1. Builds a `FilteredText` from the original UTF-8 input.
+2. Applies each character filter and composes its offset corrections.
+3. Creates the inner token stream over the filtered text.
+4. Lazily corrects each emitted token's start and end offsets.
+
+The wrapper retains the filtered text for the lifetime of the inner stream. It
+does not buffer emitted tokens.
+
+## Offset Correction
+
+Offset metadata is sparse and monotonic.
+
+Source-span mode stores one tuple per replacement. For tuple `(a, b, c, d)`,
+`a` is the filtered span start, `b` is its filtered byte length, `c` is the
+source-minus-filtered length delta, and `d` is the cumulative delta before the
+span. A token start inside the span maps to its source start; a token end inside
+the span maps to its source end.
+
+Boundary mode stores only filtered-to-source boundary corrections. Replacement
+boundaries are generated from UTF-8 character boundaries rather than individual
+bytes.
+
+Correcting a token performs one binary search for its start. Because token spans
+are normally short and correction points are ordered, the end correction scans
+forward from that position. The cost is `O(log C + K)` for `C` correction
+records and `K` records crossed by the token.
+
+When filters are chained, existing corrections are composed into the next
+filtered text. Source-span records are merged with a forward cursor. Boundary
+replacement construction performs one initial binary search and then advances
+through source corrections monotonically.
+
+## Compatibility And Limits
+
+- Existing analyzers without `char_filter` are unchanged.
+- `source_span` avoids ambiguous or zero-length provenance for expanded text.
+- `boundary` is available when consumers require character-boundary behavior.
+- UTF-16 offsets are not supported. Adding them would require a coordinate
+  contract across tokenizers, Rust/Cgo bindings, Go, and API consumers rather
+  than a local character-filter change.
+- A gRPC tokenizer used with character filters must return ordered UTF-8 byte
+  offsets for the filtered input. Contract validation is future work.
+
+## Verification
+
+Rust unit and integration tests cover mapping, expansion, contraction, deletion,
+UTF-8 input and replacement text, chained character filters, both offset modes,
+configuration validation, and lazy token streaming. Cgo analyzer tests cover the
+default source-span behavior through the Go boundary.

--- a/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
+++ b/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
@@ -25,9 +25,10 @@ Mapping rules trim syntax whitespace on both sides of `=>`, matching
 Elasticsearch. Whitespace that is part of a source or target must use an escape
 such as `\u0020`. The parser supports `\\`, `\n`, `\t`, `\r`, `\b`, `\f`, and
 `\uXXXX`; valid UTF-16 surrogate-pair escapes are combined into one Unicode
-scalar before processing UTF-8 text. When a rule contains multiple unescaped
-`=>` sequences, the last one is the separator. Duplicate sources are rejected
-after trimming and unescaping.
+scalar before processing UTF-8 text. When a rule contains multiple raw `=>`
+sequences, the last one is the separator. A literal arrow inside either side
+must be escaped as `\=\>`, so it contains no raw separator. Duplicate sources
+are rejected after trimming and unescaping.
 
 ## Configuration
 
@@ -110,8 +111,9 @@ through source corrections monotonically.
 - UTF-16 offsets are not supported. Adding them would require a coordinate
   contract across tokenizers, Rust/Cgo bindings, Go, and API consumers rather
   than a local character-filter change.
-- A gRPC tokenizer used with character filters must return ordered UTF-8 byte
-  offsets for the filtered input. Contract validation is future work.
+- Every tokenizer, including the gRPC tokenizer, owns the contract of returning
+  ordered UTF-8 byte offsets for its input. The character-filter wrapper trusts
+  those offsets and does not validate or repair tokenizer output.
 
 ## Verification
 

--- a/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
+++ b/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
@@ -168,6 +168,16 @@ No new metrics or logs are added. Invalid configurations use the existing
 analyzer-validation response, and `RunAnalyzer` with detailed tokens exposes
 the corrected offsets for troubleshooting.
 
+## Open Decisions
+
+- Decide whether mappings containing U+0000 are rejected or the Rust/C string
+  boundary is made length-aware. The current C-string transport cannot carry a
+  NUL safely.
+- Define a transformed-output and correction-record limit, including the error
+  returned when chained mappings exceed it.
+
+Both decisions block Design Review approval.
+
 ## Alternatives
 
 - Applying normalization in a token filter was rejected because tokenization

--- a/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
+++ b/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
@@ -47,10 +47,11 @@ Mapping rules trim syntax whitespace on both sides of `=>`, matching
 Elasticsearch. Whitespace that is part of a source or target must use an escape
 such as `\u0020`. The parser supports `\\`, `\n`, `\t`, `\r`, `\b`, `\f`, and
 `\uXXXX`; valid UTF-16 surrogate-pair escapes are combined into one Unicode
-scalar before processing UTF-8 text. When a rule contains multiple raw `=>`
-sequences, the last one is the separator. A literal arrow inside either side
-must be escaped as `\=\>`, so it contains no raw separator. Duplicate sources
-are rejected after trimming and unescaping.
+scalar before processing UTF-8 text. U+0000 is rejected because the existing
+Rust/C analyzer boundary uses NUL-terminated strings. When a rule contains
+multiple raw `=>` sequences, the last one is the separator. A literal arrow
+inside either side must be escaped as `\=\>`, so it contains no raw separator.
+Duplicate sources are rejected after trimming and unescaping.
 
 ## Public Interface And Validation
 
@@ -160,6 +161,9 @@ through source corrections monotonically.
 - Every tokenizer, including the gRPC tokenizer, owns the contract of returning
   ordered UTF-8 byte offsets for its input. The character-filter wrapper trusts
   those offsets and does not validate or repair tokenizer output.
+- Mapping sources and targets cannot contain U+0000. Supporting NUL would
+  require length-aware input, token, and error representations across the
+  Rust/C/Go boundary.
 - Mapping output size grows with replacement expansion. Inline mappings add no
   file access or other external I/O; existing input and configuration transport
   limits are unchanged. This version assumes inline mappings and normal
@@ -168,14 +172,6 @@ through source corrections monotonically.
 No new metrics or logs are added. Invalid configurations use the existing
 analyzer-validation response, and `RunAnalyzer` with detailed tokens exposes
 the corrected offsets for troubleshooting.
-
-## Open Decisions
-
-- Decide whether mappings containing U+0000 are rejected or the Rust/C string
-  boundary is made length-aware. The current C-string transport cannot carry a
-  NUL safely.
-
-This decision blocks Design Review approval.
 
 ## Alternatives
 

--- a/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
+++ b/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
@@ -162,7 +162,8 @@ through source corrections monotonically.
   those offsets and does not validate or repair tokenizer output.
 - Mapping output size grows with replacement expansion. Inline mappings add no
   file access or other external I/O; existing input and configuration transport
-  limits are unchanged.
+  limits are unchanged. This version assumes inline mappings and normal
+  transformed inputs remain small and adds no transformed-output limit.
 
 No new metrics or logs are added. Invalid configurations use the existing
 analyzer-validation response, and `RunAnalyzer` with detailed tokens exposes
@@ -173,10 +174,8 @@ the corrected offsets for troubleshooting.
 - Decide whether mappings containing U+0000 are rejected or the Rust/C string
   boundary is made length-aware. The current C-string transport cannot carry a
   NUL safely.
-- Define a transformed-output and correction-record limit, including the error
-  returned when chained mappings exceed it.
 
-Both decisions block Design Review approval.
+This decision blocks Design Review approval.
 
 ## Alternatives
 

--- a/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
+++ b/docs/design-docs/design_docs/20260824-analyzer-char-filter.md
@@ -1,5 +1,27 @@
 # Analyzer Char Filters
 
+- **Feature DRI:** TBD
+- **Primary Approver:** @zhengbuqian
+- **Independent Approver:** TBD
+- **Design Review:** TBD
+
+## Motivation And Scope
+
+Milvus custom analyzers currently follow Tantivy's tokenizer-then-token-filter
+pipeline. They cannot normalize the complete input before tokenization, and a
+token filter cannot provide equivalent behavior after token boundaries have
+already been chosen.
+
+This design adds an ordered pre-tokenization character-filter stage while
+preserving offsets into the original input. Its intended final state is the
+scope delivered by this change: custom analyzers support inline character
+filters, the first implementation is `mapping`, and analyzers without character
+filters retain their current behavior.
+
+File-backed mappings, additional character-filter types, character filters on
+built-in analyzer templates, and UTF-16 offsets are out of scope. This change
+does not add a new public RPC or protobuf field.
+
 ## Summary
 
 Custom analyzers can run character filters over the complete input before
@@ -30,7 +52,7 @@ sequences, the last one is the separator. A literal arrow inside either side
 must be escaped as `\=\>`, so it contains no raw separator. Duplicate sources
 are rejected after trimming and unescaping.
 
-## Configuration
+## Public Interface And Validation
 
 `char_filter` is an ordered array on a custom analyzer:
 
@@ -51,6 +73,17 @@ are rejected after trimming and unescaping.
 Character filters run in array order before the tokenizer. Token filters run
 after the tokenizer as before. Built-in analyzer templates do not accept
 character-filter options.
+
+The configuration remains part of the existing analyzer JSON used by field
+`analyzer_params`, analyzer validation, and `RunAnalyzer`. Collection creation
+and schema changes use the existing validation path, which constructs the
+analyzer on a query node. Invalid character-filter configuration is returned as
+the existing invalid-parameter error; no new error code is introduced.
+
+Validation rejects a non-array `char_filter`, non-object entries, missing or
+unsupported `type`, missing or non-array `mappings`, non-string mapping entries,
+empty or duplicate sources, malformed escapes, and unsupported offset modes.
+`char_filter_offset_mode` requires `char_filter` to be present.
 
 `char_filter_offset_mode` is optional:
 
@@ -79,6 +112,13 @@ pre-tokenization character-filter role. For each input it:
 The wrapper retains the filtered text for the lifetime of the inner stream. It
 does not buffer emitted tokens.
 
+Analyzer JSON continues to be stored with the field schema and consumed through
+the existing analyzer construction paths for indexing, BM25 execution, and
+`RunAnalyzer`. Character filters add no independent identifiers, metadata,
+persistence, cache, WAL record, recovery procedure, lock, retry, or background
+task. Each analyzer instance owns immutable filter configuration, and each token
+stream owns the transformed text and offset corrections for one input.
+
 ## Offset Correction
 
 Offset metadata is sparse and monotonic.
@@ -103,9 +143,15 @@ filtered text. Source-span records are merged with a forward cursor. Boundary
 replacement construction performs one initial binary search and then advances
 through source corrections monotonically.
 
-## Compatibility And Limits
+## Compatibility, Rollout, And Limits
 
 - Existing analyzers without `char_filter` are unchanged.
+- Old binaries reject the new configuration. Operators must upgrade all nodes
+  that validate or execute analyzers before creating fields that use it.
+- There is no feature flag or data migration. Before data is analyzed, rollback
+  consists of removing the new options. After derived text or BM25 data has
+  been produced, changing the analyzer alone would make index-time and
+  query-time analysis inconsistent; affected derived data must be rebuilt.
 - `source_span` avoids ambiguous or zero-length provenance for expanded text.
 - `boundary` is available when consumers require character-boundary behavior.
 - UTF-16 offsets are not supported. Adding them would require a coordinate
@@ -114,6 +160,22 @@ through source corrections monotonically.
 - Every tokenizer, including the gRPC tokenizer, owns the contract of returning
   ordered UTF-8 byte offsets for its input. The character-filter wrapper trusts
   those offsets and does not validate or repair tokenizer output.
+- Mapping output size grows with replacement expansion. Inline mappings add no
+  file access or other external I/O; existing input and configuration transport
+  limits are unchanged.
+
+No new metrics or logs are added. Invalid configurations use the existing
+analyzer-validation response, and `RunAnalyzer` with detailed tokens exposes
+the corrected offsets for troubleshooting.
+
+## Alternatives
+
+- Applying normalization in a token filter was rejected because tokenization
+  has already fixed token boundaries and cannot represent whole-input rewrites.
+- Preprocessing outside the analyzer was rejected because indexing and query
+  paths could diverge and original-input offset correction would be lost.
+- Buffering all emitted tokens and storing one correction per output byte were
+  rejected in favor of lazy token streaming and sparse corrections.
 
 ## Verification
 
@@ -121,3 +183,6 @@ Rust unit and integration tests cover mapping, expansion, contraction, deletion,
 UTF-8 input and replacement text, chained character filters, both offset modes,
 configuration validation, and lazy token streaming. Cgo analyzer tests cover the
 default source-span behavior through the Go boundary.
+
+No design-review meeting conclusion has been recorded yet. The Feature DRI,
+Independent Approver, and review date remain required before design approval.

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/analyzer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/analyzer.rs
@@ -1,10 +1,14 @@
-use log::warn;
 use serde_json as json;
 use std::collections::HashMap;
 use tantivy::tokenizer::*;
 
 use super::options::{get_global_file_resource_helper, FileResourcePathHelper};
-use super::{build_in_analyzer::*, filter::*, tokenizers::get_builder_with_tokenizer};
+use super::{
+    build_in_analyzer::*,
+    char_filter::build_char_filters,
+    filter::*,
+    tokenizers::{get_builder_with_tokenizer, CharFilterTokenizer},
+};
 use crate::analyzer::filter::{create_filter, get_stop_words_list, get_string_list};
 use crate::error::Result;
 use crate::error::TantivyBindingError;
@@ -74,6 +78,7 @@ impl<'a> AnalyzerBuilder<'a> {
         for (key, value) in self.params {
             match key.as_str() {
                 "tokenizer" => {}
+                "char_filter" => {}
                 "filter" => {
                     // build with filter if filter param exist
                     builder = self.build_filter(builder, value)?;
@@ -121,6 +126,11 @@ impl<'a> AnalyzerBuilder<'a> {
         // build base build-in analyzer
         match self.params.get("type") {
             Some(type_) => {
+                if self.params.contains_key("char_filter") {
+                    return Err(TantivyBindingError::InvalidArgument(
+                        "char_filter cannot be used with build-in analyzer type".to_string(),
+                    ));
+                }
                 if !type_.is_string() {
                     return Err(TantivyBindingError::InternalError(format!(
                         "analyzer type should be string"
@@ -151,6 +161,15 @@ impl<'a> AnalyzerBuilder<'a> {
             &mut self.helper,
             create_analyzer_by_json,
         )?;
+
+        if let Some(char_filter_params) = self.params.get("char_filter") {
+            let char_filters = build_char_filters(char_filter_params)?;
+            if !char_filters.is_empty() {
+                builder =
+                    TextAnalyzer::builder(CharFilterTokenizer::new(char_filters, builder.build()))
+                        .dynamic();
+            }
+        }
 
         // build and check other options
         builder = self.build_option(builder)?;
@@ -209,6 +228,7 @@ pub fn validate_analyzer(params: &str, extra_info: &str) -> Result<Vec<i64>> {
 #[cfg(test)]
 mod tests {
     use crate::analyzer::analyzer::create_analyzer;
+    use tantivy::tokenizer::TokenStream;
 
     #[test]
     fn test_standard_analyzer() {
@@ -219,6 +239,81 @@ mod tests {
 
         let tokenizer = create_analyzer(&params.to_string(), "");
         assert!(tokenizer.is_ok(), "error: {}", tokenizer.err().unwrap());
+    }
+
+    #[test]
+    fn test_analyzer_with_empty_char_filter() {
+        let params = r#"{
+            "char_filter": [],
+            "tokenizer": "standard",
+            "filter": ["lowercase"]
+        }"#;
+
+        let analyzer = create_analyzer(params, "");
+        assert!(analyzer.is_ok(), "error: {}", analyzer.err().unwrap());
+
+        let mut analyzer = analyzer.unwrap();
+        let mut stream = analyzer.token_stream("MILVUS");
+        assert!(stream.advance());
+
+        let token = stream.token();
+        assert_eq!(token.text, "milvus");
+        assert_eq!(token.offset_from, 0);
+        assert_eq!(token.offset_to, 6);
+        assert!(!stream.advance());
+    }
+
+    #[test]
+    fn test_analyzer_with_mapping_char_filter() {
+        let params = r#"{
+            "char_filter": [
+                {
+                    "type": "mapping",
+                    "mappings": ["&=>and"]
+                }
+            ],
+            "tokenizer": "standard",
+            "filter": ["lowercase"]
+        }"#;
+
+        let analyzer = create_analyzer(params, "");
+        assert!(analyzer.is_ok(), "error: {}", analyzer.err().unwrap());
+
+        let mut analyzer = analyzer.unwrap();
+        let mut stream = analyzer.token_stream("A&B");
+        assert!(stream.advance());
+
+        let token = stream.token();
+        assert_eq!(token.text, "aandb");
+        assert_eq!(token.offset_from, 0);
+        assert_eq!(token.offset_to, 3);
+        assert!(!stream.advance());
+    }
+
+    #[test]
+    fn test_analyzer_rejects_unsupported_char_filter() {
+        let params = r#"{
+            "char_filter": [
+                {
+                    "type": "unsupported"
+                }
+            ],
+            "tokenizer": "standard"
+        }"#;
+
+        let analyzer = create_analyzer(params, "");
+        assert!(analyzer.is_err());
+    }
+
+    #[test]
+    fn test_char_filter_rejects_build_in_analyzer() {
+        let params = r#"{
+            "type": "standard",
+            "char_filter": []
+        }"#;
+
+        let analyzer = create_analyzer(params, "");
+        assert!(analyzer.is_err());
     }
 
     #[test]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/analyzer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/analyzer.rs
@@ -5,7 +5,7 @@ use tantivy::tokenizer::*;
 use super::options::{get_global_file_resource_helper, FileResourcePathHelper};
 use super::{
     build_in_analyzer::*,
-    char_filter::build_char_filters,
+    char_filter::{build_char_filters, OffsetMappingMode},
     filter::*,
     tokenizers::{get_builder_with_tokenizer, CharFilterTokenizer},
 };
@@ -79,6 +79,7 @@ impl<'a> AnalyzerBuilder<'a> {
             match key.as_str() {
                 "tokenizer" => {}
                 "char_filter" => {}
+                "char_filter_offset_mode" => {}
                 "filter" => {
                     // build with filter if filter param exist
                     builder = self.build_filter(builder, value)?;
@@ -126,9 +127,12 @@ impl<'a> AnalyzerBuilder<'a> {
         // build base build-in analyzer
         match self.params.get("type") {
             Some(type_) => {
-                if self.params.contains_key("char_filter") {
+                if self.params.contains_key("char_filter")
+                    || self.params.contains_key("char_filter_offset_mode")
+                {
                     return Err(TantivyBindingError::InvalidArgument(
-                        "char_filter cannot be used with build-in analyzer type".to_string(),
+                        "char_filter options cannot be used with build-in analyzer type"
+                            .to_string(),
                     ));
                 }
                 if !type_.is_string() {
@@ -162,12 +166,23 @@ impl<'a> AnalyzerBuilder<'a> {
             create_analyzer_by_json,
         )?;
 
+        if self.params.contains_key("char_filter_offset_mode")
+            && !self.params.contains_key("char_filter")
+        {
+            return Err(TantivyBindingError::InvalidArgument(
+                "char_filter_offset_mode requires char_filter".to_string(),
+            ));
+        }
+        let offset_mode = OffsetMappingMode::from_json(self.params.get("char_filter_offset_mode"))?;
         if let Some(char_filter_params) = self.params.get("char_filter") {
             let char_filters = build_char_filters(char_filter_params)?;
             if !char_filters.is_empty() {
-                builder =
-                    TextAnalyzer::builder(CharFilterTokenizer::new(char_filters, builder.build()))
-                        .dynamic();
+                builder = TextAnalyzer::builder(CharFilterTokenizer::new(
+                    char_filters,
+                    builder.build(),
+                    offset_mode,
+                ))
+                .dynamic();
             }
         }
 
@@ -303,6 +318,17 @@ mod tests {
 
         let analyzer = create_analyzer(params, "");
         assert!(analyzer.is_err());
+    }
+
+    #[test]
+    fn test_analyzer_rejects_unsupported_char_filter_offset_mode() {
+        let params = r#"{
+            "char_filter": [],
+            "char_filter_offset_mode": "unsupported",
+            "tokenizer": "standard"
+        }"#;
+
+        assert!(create_analyzer(params, "").is_err());
     }
 
     #[test]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
@@ -1,0 +1,217 @@
+pub(crate) trait CharFilter: Send + Sync {
+    fn apply(&self, input: FilteredText) -> FilteredText;
+    fn box_clone(&self) -> BoxCharFilter;
+}
+
+pub(crate) type BoxCharFilter = Box<dyn CharFilter>;
+
+impl Clone for BoxCharFilter {
+    fn clone(&self) -> Self {
+        self.box_clone()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FilteredText {
+    pub(crate) text: String,
+    offset_map: Vec<usize>,
+}
+
+impl FilteredText {
+    pub(crate) fn new(text: &str) -> Self {
+        FilteredText {
+            text: text.to_string(),
+            offset_map: (0..=text.len()).collect(),
+        }
+    }
+
+    pub(crate) fn correct_offset(&self, offset: usize) -> usize {
+        self.offset_map
+            .get(offset)
+            .copied()
+            .unwrap_or_else(|| *self.offset_map.last().unwrap_or(&0))
+    }
+
+    /// Replacements must be sorted, non-overlapping, and aligned to UTF-8 byte
+    /// boundaries in the current filtered text.
+    pub(crate) fn replace_ranges(&self, replacements: Vec<(usize, usize, String)>) -> Self {
+        debug_assert!(
+            Self::valid_replacements(&self.text, &replacements),
+            "char filter replacements must be sorted, non-overlapping, and valid UTF-8 ranges"
+        );
+
+        if replacements.is_empty() {
+            return self.clone();
+        }
+
+        let mut text = String::with_capacity(self.text.len());
+        let mut offset_map = Vec::with_capacity(self.text.len() + 1);
+        offset_map.push(self.correct_offset(0));
+
+        let mut cursor = 0;
+        for (start, end, replacement) in replacements {
+            if start < cursor {
+                continue;
+            }
+            self.push_original_segment(cursor, start, &mut text, &mut offset_map);
+            self.push_replacement(start, end, &replacement, &mut text, &mut offset_map);
+            cursor = end;
+        }
+        self.push_original_segment(cursor, self.text.len(), &mut text, &mut offset_map);
+
+        FilteredText { text, offset_map }
+    }
+
+    fn valid_replacements(text: &str, replacements: &[(usize, usize, String)]) -> bool {
+        let mut cursor = 0;
+        for (start, end, _) in replacements {
+            if *start < cursor || *start > *end || *end > text.len() {
+                return false;
+            }
+            if !text.is_char_boundary(*start) || !text.is_char_boundary(*end) {
+                return false;
+            }
+            cursor = *end;
+        }
+        true
+    }
+
+    fn push_original_segment(
+        &self,
+        start: usize,
+        end: usize,
+        output: &mut String,
+        output_offsets: &mut Vec<usize>,
+    ) {
+        if let Some(last) = output_offsets.last_mut() {
+            *last = self.correct_offset(start);
+        }
+        output.push_str(&self.text[start..end]);
+        for offset in (start + 1)..=end {
+            output_offsets.push(self.correct_offset(offset));
+        }
+    }
+
+    fn push_replacement(
+        &self,
+        start: usize,
+        end: usize,
+        replacement: &str,
+        output: &mut String,
+        output_offsets: &mut Vec<usize>,
+    ) {
+        if let Some(last) = output_offsets.last_mut() {
+            *last = self.correct_offset(start);
+        }
+
+        if replacement.is_empty() {
+            if let Some(last) = output_offsets.last_mut() {
+                *last = self.correct_offset(end);
+            }
+            return;
+        }
+
+        output.push_str(replacement);
+
+        let source_boundaries = self.char_boundaries(start, end);
+        let replacement_boundaries = char_boundaries(replacement);
+        let source_char_count = source_boundaries.len().saturating_sub(1);
+        let replacement_char_count = replacement_boundaries.len().saturating_sub(1);
+
+        let mut previous_boundary = 0;
+        for (boundary_index, boundary) in replacement_boundaries.iter().enumerate().skip(1) {
+            let source_boundary_index = if boundary_index == replacement_char_count {
+                source_char_count
+            } else if replacement_char_count == 0 {
+                0
+            } else {
+                source_char_count * boundary_index / replacement_char_count
+            };
+            let corrected = self.correct_offset(source_boundaries[source_boundary_index]);
+
+            for _ in (previous_boundary + 1)..=*boundary {
+                output_offsets.push(corrected);
+            }
+            previous_boundary = *boundary;
+        }
+    }
+
+    fn char_boundaries(&self, start: usize, end: usize) -> Vec<usize> {
+        let mut boundaries = Vec::new();
+        boundaries.push(start);
+        for (offset, _) in self.text[start..end].char_indices().skip(1) {
+            boundaries.push(start + offset);
+        }
+        boundaries.push(end);
+        boundaries
+    }
+}
+
+fn char_boundaries(text: &str) -> Vec<usize> {
+    let mut boundaries = Vec::new();
+    boundaries.push(0);
+    for (offset, _) in text.char_indices().skip(1) {
+        boundaries.push(offset);
+    }
+    boundaries.push(text.len());
+    boundaries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FilteredText;
+
+    #[test]
+    fn test_replace_ranges_with_longer_replacement() {
+        let text = FilteredText::new("a-b");
+        let filtered = text.replace_ranges(vec![(1, 2, " and ".to_string())]);
+
+        assert_eq!(filtered.text, "a and b");
+        assert_eq!(filtered.correct_offset(0), 0);
+        assert_eq!(filtered.correct_offset(1), 1);
+        assert_eq!(filtered.correct_offset(6), 2);
+        assert_eq!(filtered.correct_offset(7), 3);
+    }
+
+    #[test]
+    fn test_replace_ranges_with_empty_replacement() {
+        let text = FilteredText::new("a--b");
+        let filtered = text.replace_ranges(vec![(1, 3, "".to_string())]);
+
+        assert_eq!(filtered.text, "ab");
+        assert_eq!(filtered.correct_offset(0), 0);
+        assert_eq!(filtered.correct_offset(1), 3);
+        assert_eq!(filtered.correct_offset(2), 4);
+    }
+
+    #[test]
+    fn test_replace_ranges_with_utf8_text() {
+        let text = FilteredText::new("中-文");
+        let filtered = text.replace_ranges(vec![(3, 4, "".to_string())]);
+
+        assert_eq!(filtered.text, "中文");
+        assert_eq!(filtered.correct_offset(0), 0);
+        assert_eq!(filtered.correct_offset(3), 4);
+        assert_eq!(filtered.correct_offset(6), 7);
+    }
+
+    #[test]
+    fn test_valid_replacements_rejects_invalid_ranges() {
+        assert!(FilteredText::valid_replacements(
+            "a-b",
+            &[(1, 2, " ".to_string())]
+        ));
+        assert!(!FilteredText::valid_replacements(
+            "abc",
+            &[(2, 3, "".to_string()), (1, 2, "".to_string())]
+        ));
+        assert!(!FilteredText::valid_replacements(
+            "abc",
+            &[(2, 1, "".to_string())]
+        ));
+        assert!(!FilteredText::valid_replacements(
+            "中文",
+            &[(1, 3, "".to_string())]
+        ));
+    }
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
@@ -14,52 +14,70 @@ impl Clone for BoxCharFilter {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct FilteredText {
     pub(crate) text: String,
-    offset_map: Vec<usize>,
+    corrections: Vec<OffsetCorrection>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct OffsetCorrection {
+    filtered_offset: usize,
+    original_offset: usize,
+}
+
+impl Default for FilteredText {
+    fn default() -> Self {
+        FilteredText::new("")
+    }
 }
 
 impl FilteredText {
     pub(crate) fn new(text: &str) -> Self {
         FilteredText {
             text: text.to_string(),
-            offset_map: (0..=text.len()).collect(),
+            corrections: Vec::new(),
         }
     }
 
     pub(crate) fn correct_offset(&self, offset: usize) -> usize {
-        self.offset_map
-            .get(offset)
-            .copied()
-            .unwrap_or_else(|| *self.offset_map.last().unwrap_or(&0))
+        let offset = offset.min(self.text.len());
+        match self
+            .corrections
+            .binary_search_by_key(&offset, |correction| correction.filtered_offset)
+        {
+            Ok(index) => self.corrections[index].original_offset,
+            Err(0) => offset,
+            Err(index) => {
+                let correction = &self.corrections[index - 1];
+                correction.original_offset + (offset - correction.filtered_offset)
+            }
+        }
     }
 
     /// Replacements must be sorted, non-overlapping, and aligned to UTF-8 byte
     /// boundaries in the current filtered text.
-    pub(crate) fn replace_ranges(&self, replacements: Vec<(usize, usize, String)>) -> Self {
+    pub(crate) fn replace_ranges(self, replacements: Vec<(usize, usize, String)>) -> Self {
         debug_assert!(
             Self::valid_replacements(&self.text, &replacements),
             "char filter replacements must be sorted, non-overlapping, and valid UTF-8 ranges"
         );
 
         if replacements.is_empty() {
-            return self.clone();
+            return self;
         }
 
-        let mut text = String::with_capacity(self.text.len());
-        let mut offset_map = Vec::with_capacity(self.text.len() + 1);
-        offset_map.push(self.correct_offset(0));
+        let mut output = FilteredText {
+            text: String::with_capacity(self.text.len()),
+            corrections: Vec::with_capacity(replacements.len() * 2),
+        };
 
         let mut cursor = 0;
         for (start, end, replacement) in replacements {
-            if start < cursor {
-                continue;
-            }
-            self.push_original_segment(cursor, start, &mut text, &mut offset_map);
-            self.push_replacement(start, end, &replacement, &mut text, &mut offset_map);
+            self.push_original_segment(cursor, start, &mut output);
+            self.push_replacement(start, end, &replacement, &mut output);
             cursor = end;
         }
-        self.push_original_segment(cursor, self.text.len(), &mut text, &mut offset_map);
+        self.push_original_segment(cursor, self.text.len(), &mut output);
 
-        FilteredText { text, offset_map }
+        output
     }
 
     fn valid_replacements(text: &str, replacements: &[(usize, usize, String)]) -> bool {
@@ -76,19 +94,18 @@ impl FilteredText {
         true
     }
 
-    fn push_original_segment(
-        &self,
-        start: usize,
-        end: usize,
-        output: &mut String,
-        output_offsets: &mut Vec<usize>,
-    ) {
-        if let Some(last) = output_offsets.last_mut() {
-            *last = self.correct_offset(start);
-        }
-        output.push_str(&self.text[start..end]);
-        for offset in (start + 1)..=end {
-            output_offsets.push(self.correct_offset(offset));
+    fn push_original_segment(&self, start: usize, end: usize, output: &mut FilteredText) {
+        let output_start = output.text.len();
+        output.push_correction(output_start, self.correct_offset(start));
+        output.text.push_str(&self.text[start..end]);
+
+        for correction in self.corrections.iter().filter(|correction| {
+            correction.filtered_offset > start && correction.filtered_offset <= end
+        }) {
+            output.push_correction(
+                output_start + correction.filtered_offset - start,
+                correction.original_offset,
+            );
         }
     }
 
@@ -97,43 +114,58 @@ impl FilteredText {
         start: usize,
         end: usize,
         replacement: &str,
-        output: &mut String,
-        output_offsets: &mut Vec<usize>,
+        output: &mut FilteredText,
     ) {
-        if let Some(last) = output_offsets.last_mut() {
-            *last = self.correct_offset(start);
-        }
+        let output_start = output.text.len();
 
         if replacement.is_empty() {
-            if let Some(last) = output_offsets.last_mut() {
-                *last = self.correct_offset(end);
-            }
+            output.push_correction(output_start, self.correct_offset(end));
             return;
         }
 
-        output.push_str(replacement);
+        output.push_correction(output_start, self.correct_offset(start));
+        output.text.push_str(replacement);
 
         let source_boundaries = self.char_boundaries(start, end);
         let replacement_boundaries = char_boundaries(replacement);
         let source_char_count = source_boundaries.len().saturating_sub(1);
         let replacement_char_count = replacement_boundaries.len().saturating_sub(1);
 
-        let mut previous_boundary = 0;
         for (boundary_index, boundary) in replacement_boundaries.iter().enumerate().skip(1) {
             let source_boundary_index = if boundary_index == replacement_char_count {
                 source_char_count
-            } else if replacement_char_count == 0 {
+            } else if source_char_count == 0 {
                 0
+            } else if replacement_char_count > source_char_count
+                && boundary_index >= source_char_count
+            {
+                source_char_count - 1
             } else {
-                source_char_count * boundary_index / replacement_char_count
+                boundary_index.min(source_char_count)
             };
             let corrected = self.correct_offset(source_boundaries[source_boundary_index]);
-
-            for _ in (previous_boundary + 1)..=*boundary {
-                output_offsets.push(corrected);
-            }
-            previous_boundary = *boundary;
+            output.push_correction(output_start + boundary, corrected);
         }
+    }
+
+    fn push_correction(&mut self, filtered_offset: usize, original_offset: usize) {
+        if let Some(last) = self.corrections.last() {
+            if last.filtered_offset == filtered_offset {
+                self.corrections.pop();
+            }
+        }
+
+        let expected_original_offset = self.corrections.last().map_or(filtered_offset, |last| {
+            last.original_offset + (filtered_offset - last.filtered_offset)
+        });
+        if original_offset == expected_original_offset {
+            return;
+        }
+
+        self.corrections.push(OffsetCorrection {
+            filtered_offset,
+            original_offset,
+        });
     }
 
     fn char_boundaries(&self, start: usize, end: usize) -> Vec<usize> {
@@ -174,6 +206,27 @@ mod tests {
     }
 
     #[test]
+    fn test_expansion_preserves_common_character_boundaries() {
+        let text = FilteredText::new("ab");
+        let filtered = text.replace_ranges(vec![(0, 2, "x y".to_string())]);
+
+        assert_eq!(filtered.text, "x y");
+        assert_eq!(filtered.correct_offset(0), 0);
+        assert_eq!(filtered.correct_offset(1), 1);
+        assert_eq!(filtered.correct_offset(2), 1);
+        assert_eq!(filtered.correct_offset(3), 2);
+    }
+
+    #[test]
+    fn test_equal_length_replacement_needs_no_offset_corrections() {
+        let text = FilteredText::new("ab");
+        let filtered = text.replace_ranges(vec![(0, 2, "xy".to_string())]);
+
+        assert_eq!(filtered.text, "xy");
+        assert!(filtered.corrections.is_empty());
+    }
+
+    #[test]
     fn test_replace_ranges_with_empty_replacement() {
         let text = FilteredText::new("a--b");
         let filtered = text.replace_ranges(vec![(1, 3, "".to_string())]);
@@ -193,6 +246,19 @@ mod tests {
         assert_eq!(filtered.correct_offset(0), 0);
         assert_eq!(filtered.correct_offset(3), 4);
         assert_eq!(filtered.correct_offset(6), 7);
+    }
+
+    #[test]
+    fn test_offset_corrections_compose_across_filters() {
+        let text = FilteredText::new("a-b");
+        let first = text.replace_ranges(vec![(1, 2, " and ".to_string())]);
+        let second = first.replace_ranges(vec![(1, 6, "_".to_string())]);
+
+        assert_eq!(second.text, "a_b");
+        assert_eq!(second.correct_offset(0), 0);
+        assert_eq!(second.correct_offset(1), 1);
+        assert_eq!(second.correct_offset(2), 2);
+        assert_eq!(second.correct_offset(3), 3);
     }
 
     #[test]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
@@ -14,11 +14,84 @@ impl Clone for BoxCharFilter {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct FilteredText {
     pub(crate) text: String,
-    corrections: Vec<OffsetCorrection>,
+    corrections: OffsetCorrections,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum OffsetMappingMode {
+    #[default]
+    SourceSpan,
+    Boundary,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct OffsetCorrection {
+enum OffsetCorrections {
+    SourceSpan(Vec<SpanOffsetCorrection>),
+    Boundary(Vec<BoundaryOffsetCorrection>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SpanOffsetCorrection {
+    // Tuple (a, b, c, d) maps [a, a + b) to
+    // [a + d, a + b + c + d).
+    filtered_start: usize,
+    filtered_len: usize,
+    length_delta: isize,
+    start_delta: isize,
+}
+
+impl SpanOffsetCorrection {
+    fn new(
+        filtered_start: usize,
+        filtered_len: usize,
+        original_start: usize,
+        original_end: usize,
+    ) -> Self {
+        debug_assert!(original_start <= original_end);
+        SpanOffsetCorrection {
+            filtered_start,
+            filtered_len,
+            length_delta: signed_delta(original_end - original_start, filtered_len),
+            start_delta: signed_delta(original_start, filtered_start),
+        }
+    }
+
+    fn filtered_end(&self) -> usize {
+        self.filtered_start + self.filtered_len
+    }
+
+    fn original_start(&self) -> usize {
+        add_delta(self.filtered_start, self.start_delta)
+    }
+
+    fn original_end(&self) -> usize {
+        add_delta(self.filtered_end(), self.start_delta + self.length_delta)
+    }
+
+    fn post_delta(&self) -> isize {
+        self.start_delta + self.length_delta
+    }
+
+    fn correct_start(&self, offset: usize) -> usize {
+        if offset < self.filtered_end() {
+            self.original_start()
+        } else {
+            add_delta(offset, self.post_delta())
+        }
+    }
+
+    fn correct_end(&self, offset: usize) -> usize {
+        debug_assert!(self.filtered_start < offset);
+        if offset <= self.filtered_end() {
+            self.original_end()
+        } else {
+            add_delta(offset, self.post_delta())
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct BoundaryOffsetCorrection {
     filtered_offset: usize,
     original_offset: usize,
 }
@@ -31,25 +104,102 @@ impl Default for FilteredText {
 
 impl FilteredText {
     pub(crate) fn new(text: &str) -> Self {
+        Self::with_offset_mode(text, OffsetMappingMode::default())
+    }
+
+    pub(crate) fn with_offset_mode(text: &str, mode: OffsetMappingMode) -> Self {
         FilteredText {
             text: text.to_string(),
-            corrections: Vec::new(),
+            corrections: match mode {
+                OffsetMappingMode::SourceSpan => OffsetCorrections::SourceSpan(Vec::new()),
+                OffsetMappingMode::Boundary => OffsetCorrections::Boundary(Vec::new()),
+            },
         }
     }
 
-    pub(crate) fn correct_offset(&self, offset: usize) -> usize {
-        let offset = offset.min(self.text.len());
-        match self
-            .corrections
-            .binary_search_by_key(&offset, |correction| correction.filtered_offset)
-        {
-            Ok(index) => self.corrections[index].original_offset,
-            Err(0) => offset,
-            Err(index) => {
-                let correction = &self.corrections[index - 1];
-                correction.original_offset + (offset - correction.filtered_offset)
+    pub(crate) fn correct_offsets(&self, offset_from: usize, offset_to: usize) -> (usize, usize) {
+        let offset_from = offset_from.min(self.text.len());
+        let offset_to = offset_to.min(self.text.len());
+        debug_assert!(offset_from <= offset_to);
+
+        match &self.corrections {
+            OffsetCorrections::SourceSpan(corrections) => {
+                Self::correct_source_span_offsets(corrections, offset_from, offset_to)
+            }
+            OffsetCorrections::Boundary(corrections) => {
+                Self::correct_boundary_offsets(corrections, offset_from, offset_to)
             }
         }
+    }
+
+    fn correct_source_span_offsets(
+        corrections: &[SpanOffsetCorrection],
+        offset_from: usize,
+        offset_to: usize,
+    ) -> (usize, usize) {
+        let correction_at_or_before = |offset| {
+            corrections
+                .partition_point(|correction| correction.filtered_start <= offset)
+                .checked_sub(1)
+        };
+
+        if offset_from >= offset_to {
+            let offset = correction_at_or_before(offset_from).map_or(offset_from, |index| {
+                corrections[index].correct_start(offset_from)
+            });
+            return (offset, offset);
+        }
+
+        let start_index = correction_at_or_before(offset_from);
+        let corrected_from = start_index.map_or(offset_from, |index| {
+            corrections[index].correct_start(offset_from)
+        });
+
+        // Token spans are normally short. Reuse the start lookup and walk only
+        // the correction records crossed by this token.
+        let mut end_index = start_index;
+        let mut next_index = start_index.map_or(0, |index| index + 1);
+        while next_index < corrections.len() && corrections[next_index].filtered_start < offset_to {
+            end_index = Some(next_index);
+            next_index += 1;
+        }
+        let corrected_to =
+            end_index.map_or(offset_to, |index| corrections[index].correct_end(offset_to));
+
+        (corrected_from, corrected_to)
+    }
+
+    fn correct_boundary_offsets(
+        corrections: &[BoundaryOffsetCorrection],
+        offset_from: usize,
+        offset_to: usize,
+    ) -> (usize, usize) {
+        let start_index = corrections
+            .partition_point(|correction| correction.filtered_offset <= offset_from)
+            .checked_sub(1);
+        let corrected_from = Self::correct_boundary_offset(corrections, start_index, offset_from);
+
+        // Token spans are normally short, so reuse the start lookup for the end.
+        let mut end_index = start_index;
+        let mut next_index = start_index.map_or(0, |index| index + 1);
+        while next_index < corrections.len() && corrections[next_index].filtered_offset <= offset_to
+        {
+            end_index = Some(next_index);
+            next_index += 1;
+        }
+        let corrected_to = Self::correct_boundary_offset(corrections, end_index, offset_to);
+        (corrected_from, corrected_to)
+    }
+
+    fn correct_boundary_offset(
+        corrections: &[BoundaryOffsetCorrection],
+        correction_index: Option<usize>,
+        offset: usize,
+    ) -> usize {
+        correction_index.map_or(offset, |index| {
+            let correction = &corrections[index];
+            correction.original_offset + (offset - correction.filtered_offset)
+        })
     }
 
     /// Replacements must be sorted, non-overlapping, and aligned to UTF-8 byte
@@ -64,20 +214,36 @@ impl FilteredText {
             return self;
         }
 
+        let correction_capacity = self.correction_count() + replacements.len();
         let mut output = FilteredText {
             text: String::with_capacity(self.text.len()),
-            corrections: Vec::with_capacity(replacements.len() * 2),
+            corrections: match &self.corrections {
+                OffsetCorrections::SourceSpan(_) => {
+                    OffsetCorrections::SourceSpan(Vec::with_capacity(correction_capacity))
+                }
+                OffsetCorrections::Boundary(_) => {
+                    OffsetCorrections::Boundary(Vec::with_capacity(correction_capacity * 2))
+                }
+            },
         };
 
         let mut cursor = 0;
+        let mut correction_index = 0;
         for (start, end, replacement) in replacements {
-            self.push_original_segment(cursor, start, &mut output);
+            self.push_original_segment(cursor, start, &mut correction_index, &mut output);
             self.push_replacement(start, end, &replacement, &mut output);
             cursor = end;
         }
-        self.push_original_segment(cursor, self.text.len(), &mut output);
+        self.push_original_segment(cursor, self.text.len(), &mut correction_index, &mut output);
 
         output
+    }
+
+    fn correction_count(&self) -> usize {
+        match &self.corrections {
+            OffsetCorrections::SourceSpan(corrections) => corrections.len(),
+            OffsetCorrections::Boundary(corrections) => corrections.len(),
+        }
     }
 
     fn valid_replacements(text: &str, replacements: &[(usize, usize, String)]) -> bool {
@@ -94,18 +260,94 @@ impl FilteredText {
         true
     }
 
-    fn push_original_segment(&self, start: usize, end: usize, output: &mut FilteredText) {
+    fn push_original_segment(
+        &self,
+        start: usize,
+        end: usize,
+        correction_index: &mut usize,
+        output: &mut FilteredText,
+    ) {
         let output_start = output.text.len();
-        output.push_correction(output_start, self.correct_offset(start));
         output.text.push_str(&self.text[start..end]);
 
-        for correction in self.corrections.iter().filter(|correction| {
-            correction.filtered_offset > start && correction.filtered_offset <= end
-        }) {
-            output.push_correction(
-                output_start + correction.filtered_offset - start,
-                correction.original_offset,
-            );
+        match (&self.corrections, &mut output.corrections) {
+            (
+                OffsetCorrections::SourceSpan(corrections),
+                OffsetCorrections::SourceSpan(output_corrections),
+            ) => {
+                if start >= end {
+                    return;
+                }
+
+                while *correction_index < corrections.len() {
+                    let correction = &corrections[*correction_index];
+                    let correction_end = correction.filtered_end();
+
+                    if correction.filtered_len == 0 {
+                        if correction.filtered_start < start {
+                            *correction_index += 1;
+                            continue;
+                        }
+                        if correction.filtered_start >= end {
+                            break;
+                        }
+
+                        Self::push_span_correction(
+                            output_corrections,
+                            output_start + correction.filtered_start - start,
+                            0,
+                            correction.original_start(),
+                            correction.original_end(),
+                        );
+                        *correction_index += 1;
+                        continue;
+                    }
+
+                    if correction_end <= start {
+                        *correction_index += 1;
+                        continue;
+                    }
+                    if correction.filtered_start >= end {
+                        break;
+                    }
+
+                    let copied_start = correction.filtered_start.max(start);
+                    let copied_end = correction_end.min(end);
+                    Self::push_span_correction(
+                        output_corrections,
+                        output_start + copied_start - start,
+                        copied_end - copied_start,
+                        correction.original_start(),
+                        correction.original_end(),
+                    );
+
+                    if correction_end <= end {
+                        *correction_index += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            (
+                OffsetCorrections::Boundary(corrections),
+                OffsetCorrections::Boundary(output_corrections),
+            ) => {
+                let original_start = Self::correct_boundary_offset_at(corrections, start);
+                Self::push_boundary_correction(output_corrections, output_start, original_start);
+
+                let first =
+                    corrections.partition_point(|correction| correction.filtered_offset <= start);
+                let last =
+                    corrections.partition_point(|correction| correction.filtered_offset <= end);
+                for correction in &corrections[first..last] {
+                    Self::push_boundary_correction(
+                        output_corrections,
+                        output_start + correction.filtered_offset - start,
+                        correction.original_offset,
+                    );
+                }
+            }
+            _ => unreachable!("offset mapping mode must remain unchanged"),
         }
     }
 
@@ -118,54 +360,128 @@ impl FilteredText {
     ) {
         let output_start = output.text.len();
 
-        if replacement.is_empty() {
-            output.push_correction(output_start, self.correct_offset(end));
-            return;
-        }
+        match (&self.corrections, &mut output.corrections) {
+            (
+                OffsetCorrections::SourceSpan(_),
+                OffsetCorrections::SourceSpan(output_corrections),
+            ) => {
+                let (original_start, original_end) = self.correct_offsets(start, end);
+                output.text.push_str(replacement);
+                Self::push_span_correction(
+                    output_corrections,
+                    output_start,
+                    replacement.len(),
+                    original_start,
+                    original_end,
+                );
+            }
+            (
+                OffsetCorrections::Boundary(corrections),
+                OffsetCorrections::Boundary(output_corrections),
+            ) => {
+                if replacement.is_empty() {
+                    let corrected = Self::correct_boundary_offset_at(corrections, end);
+                    Self::push_boundary_correction(output_corrections, output_start, corrected);
+                    return;
+                }
 
-        output.push_correction(output_start, self.correct_offset(start));
-        output.text.push_str(replacement);
+                let source_boundaries = self.char_boundaries(start, end);
+                let replacement_boundaries = char_boundaries(replacement);
+                let source_char_count = source_boundaries.len().saturating_sub(1);
+                let replacement_char_count = replacement_boundaries.len().saturating_sub(1);
+                let mut source_correction_index = corrections
+                    .partition_point(|correction| {
+                        correction.filtered_offset <= source_boundaries[0]
+                    })
+                    .checked_sub(1);
+                let mut next_correction_index =
+                    source_correction_index.map_or(0, |index| index + 1);
 
-        let source_boundaries = self.char_boundaries(start, end);
-        let replacement_boundaries = char_boundaries(replacement);
-        let source_char_count = source_boundaries.len().saturating_sub(1);
-        let replacement_char_count = replacement_boundaries.len().saturating_sub(1);
-
-        for (boundary_index, boundary) in replacement_boundaries.iter().enumerate().skip(1) {
-            let source_boundary_index = if boundary_index == replacement_char_count {
-                source_char_count
-            } else if source_char_count == 0 {
-                0
-            } else if replacement_char_count > source_char_count
-                && boundary_index >= source_char_count
-            {
-                source_char_count - 1
-            } else {
-                boundary_index.min(source_char_count)
-            };
-            let corrected = self.correct_offset(source_boundaries[source_boundary_index]);
-            output.push_correction(output_start + boundary, corrected);
+                output.text.push_str(replacement);
+                for (boundary_index, boundary) in replacement_boundaries.iter().enumerate() {
+                    let source_boundary_index = if boundary_index == replacement_char_count {
+                        source_char_count
+                    } else if source_char_count == 0 {
+                        0
+                    } else if replacement_char_count > source_char_count
+                        && boundary_index >= source_char_count
+                    {
+                        source_char_count - 1
+                    } else {
+                        boundary_index.min(source_char_count)
+                    };
+                    let source_boundary = source_boundaries[source_boundary_index];
+                    while next_correction_index < corrections.len()
+                        && corrections[next_correction_index].filtered_offset <= source_boundary
+                    {
+                        source_correction_index = Some(next_correction_index);
+                        next_correction_index += 1;
+                    }
+                    let corrected = Self::correct_boundary_offset(
+                        corrections,
+                        source_correction_index,
+                        source_boundary,
+                    );
+                    Self::push_boundary_correction(
+                        output_corrections,
+                        output_start + boundary,
+                        corrected,
+                    );
+                }
+            }
+            _ => unreachable!("offset mapping mode must remain unchanged"),
         }
     }
 
-    fn push_correction(&mut self, filtered_offset: usize, original_offset: usize) {
-        if let Some(last) = self.corrections.last() {
-            if last.filtered_offset == filtered_offset {
-                self.corrections.pop();
-            }
+    fn push_span_correction(
+        corrections: &mut Vec<SpanOffsetCorrection>,
+        filtered_start: usize,
+        filtered_len: usize,
+        original_start: usize,
+        original_end: usize,
+    ) {
+        debug_assert!(corrections.last().map_or(true, |correction| {
+            correction.filtered_start <= filtered_start
+        }));
+        corrections.push(SpanOffsetCorrection::new(
+            filtered_start,
+            filtered_len,
+            original_start,
+            original_end,
+        ));
+    }
+
+    fn correct_boundary_offset_at(
+        corrections: &[BoundaryOffsetCorrection],
+        offset: usize,
+    ) -> usize {
+        let index = corrections
+            .partition_point(|correction| correction.filtered_offset <= offset)
+            .checked_sub(1);
+        Self::correct_boundary_offset(corrections, index, offset)
+    }
+
+    fn push_boundary_correction(
+        corrections: &mut Vec<BoundaryOffsetCorrection>,
+        filtered_offset: usize,
+        original_offset: usize,
+    ) {
+        if corrections
+            .last()
+            .is_some_and(|last| last.filtered_offset == filtered_offset)
+        {
+            corrections.pop();
         }
 
-        let expected_original_offset = self.corrections.last().map_or(filtered_offset, |last| {
+        let expected_original_offset = corrections.last().map_or(filtered_offset, |last| {
             last.original_offset + (filtered_offset - last.filtered_offset)
         });
-        if original_offset == expected_original_offset {
-            return;
+        if original_offset != expected_original_offset {
+            corrections.push(BoundaryOffsetCorrection {
+                filtered_offset,
+                original_offset,
+            });
         }
-
-        self.corrections.push(OffsetCorrection {
-            filtered_offset,
-            original_offset,
-        });
     }
 
     fn char_boundaries(&self, start: usize, end: usize) -> Vec<usize> {
@@ -189,9 +505,29 @@ fn char_boundaries(text: &str) -> Vec<usize> {
     boundaries
 }
 
+fn signed_delta(value: usize, base: usize) -> isize {
+    if value >= base {
+        isize::try_from(value - base).expect("offset delta must fit in isize")
+    } else {
+        -isize::try_from(base - value).expect("offset delta must fit in isize")
+    }
+}
+
+fn add_delta(offset: usize, delta: isize) -> usize {
+    if delta >= 0 {
+        offset
+            .checked_add(delta as usize)
+            .expect("corrected offset must fit in usize")
+    } else {
+        offset
+            .checked_sub((-delta) as usize)
+            .expect("corrected offset must not be negative")
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::FilteredText;
+    use super::{FilteredText, OffsetMappingMode};
 
     #[test]
     fn test_replace_ranges_with_longer_replacement() {
@@ -199,31 +535,85 @@ mod tests {
         let filtered = text.replace_ranges(vec![(1, 2, " and ".to_string())]);
 
         assert_eq!(filtered.text, "a and b");
-        assert_eq!(filtered.correct_offset(0), 0);
-        assert_eq!(filtered.correct_offset(1), 1);
-        assert_eq!(filtered.correct_offset(6), 2);
-        assert_eq!(filtered.correct_offset(7), 3);
+        assert_eq!(filtered.correct_offsets(0, 1), (0, 1));
+        assert_eq!(filtered.correct_offsets(2, 5), (1, 2));
+        assert_eq!(filtered.correct_offsets(6, 7), (2, 3));
     }
 
     #[test]
-    fn test_expansion_preserves_common_character_boundaries() {
+    fn test_expansion_maps_each_token_to_the_full_source_span() {
         let text = FilteredText::new("ab");
         let filtered = text.replace_ranges(vec![(0, 2, "x y".to_string())]);
 
         assert_eq!(filtered.text, "x y");
-        assert_eq!(filtered.correct_offset(0), 0);
-        assert_eq!(filtered.correct_offset(1), 1);
-        assert_eq!(filtered.correct_offset(2), 1);
-        assert_eq!(filtered.correct_offset(3), 2);
+        assert_eq!(filtered.correct_offsets(0, 1), (0, 2));
+        assert_eq!(filtered.correct_offsets(2, 3), (0, 2));
+        assert_eq!(filtered.correct_offsets(0, 3), (0, 2));
     }
 
     #[test]
-    fn test_equal_length_replacement_needs_no_offset_corrections() {
+    fn test_equal_length_replacement_preserves_source_provenance() {
         let text = FilteredText::new("ab");
         let filtered = text.replace_ranges(vec![(0, 2, "xy".to_string())]);
 
         assert_eq!(filtered.text, "xy");
-        assert!(filtered.corrections.is_empty());
+        assert_eq!(filtered.correct_offsets(0, 1), (0, 2));
+        assert_eq!(filtered.correct_offsets(1, 2), (0, 2));
+        assert_eq!(filtered.correction_count(), 1);
+    }
+
+    #[test]
+    fn test_boundary_mode_preserves_common_character_boundaries() {
+        let text = FilteredText::with_offset_mode("ab", OffsetMappingMode::Boundary);
+        let filtered = text.replace_ranges(vec![(0, 2, "x y".to_string())]);
+
+        assert_eq!(filtered.text, "x y");
+        assert_eq!(filtered.correct_offsets(0, 1), (0, 1));
+        assert_eq!(filtered.correct_offsets(2, 3), (1, 2));
+        assert_eq!(filtered.correct_offsets(0, 3), (0, 2));
+    }
+
+    #[test]
+    fn test_boundary_mode_uses_utf8_character_boundaries() {
+        let text = FilteredText::with_offset_mode("中", OffsetMappingMode::Boundary);
+        let filtered = text.replace_ranges(vec![(0, 3, "x y".to_string())]);
+
+        assert_eq!(filtered.text, "x y");
+        assert_eq!(filtered.correct_offsets(0, 1), (0, 0));
+        assert_eq!(filtered.correct_offsets(2, 3), (0, 3));
+        assert_eq!(filtered.correct_offsets(0, 3), (0, 3));
+    }
+
+    #[test]
+    fn test_boundary_mode_handles_multibyte_replacement() {
+        let text = FilteredText::with_offset_mode("a", OffsetMappingMode::Boundary);
+        let filtered = text.replace_ranges(vec![(0, 1, "中英".to_string())]);
+
+        assert_eq!(filtered.text, "中英");
+        assert_eq!(filtered.correct_offsets(0, 3), (0, 0));
+        assert_eq!(filtered.correct_offsets(3, 6), (0, 1));
+    }
+
+    #[test]
+    fn test_boundary_mode_handles_multibyte_contraction() {
+        let text = FilteredText::with_offset_mode("中英", OffsetMappingMode::Boundary);
+        let filtered = text.replace_ranges(vec![(0, 6, "xy".to_string())]);
+
+        assert_eq!(filtered.text, "xy");
+        assert_eq!(filtered.correct_offsets(0, 1), (0, 3));
+        assert_eq!(filtered.correct_offsets(1, 2), (3, 6));
+    }
+
+    #[test]
+    fn test_boundary_mode_composes_across_filters() {
+        let text = FilteredText::with_offset_mode("中", OffsetMappingMode::Boundary);
+        let first = text.replace_ranges(vec![(0, 3, "x y".to_string())]);
+        let second = first.replace_ranges(vec![(0, 1, "p q".to_string())]);
+
+        assert_eq!(second.text, "p q y");
+        assert_eq!(second.correct_offsets(0, 1), (0, 0));
+        assert_eq!(second.correct_offsets(2, 3), (0, 0));
+        assert_eq!(second.correct_offsets(4, 5), (0, 3));
     }
 
     #[test]
@@ -232,9 +622,9 @@ mod tests {
         let filtered = text.replace_ranges(vec![(1, 3, "".to_string())]);
 
         assert_eq!(filtered.text, "ab");
-        assert_eq!(filtered.correct_offset(0), 0);
-        assert_eq!(filtered.correct_offset(1), 3);
-        assert_eq!(filtered.correct_offset(2), 4);
+        assert_eq!(filtered.correct_offsets(0, 1), (0, 1));
+        assert_eq!(filtered.correct_offsets(1, 2), (3, 4));
+        assert_eq!(filtered.correct_offsets(0, 2), (0, 4));
     }
 
     #[test]
@@ -243,9 +633,9 @@ mod tests {
         let filtered = text.replace_ranges(vec![(3, 4, "".to_string())]);
 
         assert_eq!(filtered.text, "中文");
-        assert_eq!(filtered.correct_offset(0), 0);
-        assert_eq!(filtered.correct_offset(3), 4);
-        assert_eq!(filtered.correct_offset(6), 7);
+        assert_eq!(filtered.correct_offsets(0, 3), (0, 3));
+        assert_eq!(filtered.correct_offsets(3, 6), (4, 7));
+        assert_eq!(filtered.correct_offsets(0, 6), (0, 7));
     }
 
     #[test]
@@ -255,10 +645,48 @@ mod tests {
         let second = first.replace_ranges(vec![(1, 6, "_".to_string())]);
 
         assert_eq!(second.text, "a_b");
-        assert_eq!(second.correct_offset(0), 0);
-        assert_eq!(second.correct_offset(1), 1);
-        assert_eq!(second.correct_offset(2), 2);
-        assert_eq!(second.correct_offset(3), 3);
+        assert_eq!(second.correct_offsets(0, 1), (0, 1));
+        assert_eq!(second.correct_offsets(1, 2), (1, 2));
+        assert_eq!(second.correct_offsets(2, 3), (2, 3));
+    }
+
+    #[test]
+    fn test_offset_corrections_compose_for_partial_replacement_copies() {
+        let text = FilteredText::new("ab");
+        let first = text.replace_ranges(vec![(0, 1, "x y".to_string())]);
+        let second = first.replace_ranges(vec![(0, 1, "p q".to_string())]);
+
+        assert_eq!(second.text, "p q yb");
+        assert_eq!(second.correct_offsets(0, 1), (0, 1));
+        assert_eq!(second.correct_offsets(2, 3), (0, 1));
+        assert_eq!(second.correct_offsets(4, 5), (0, 1));
+        assert_eq!(second.correct_offsets(5, 6), (1, 2));
+    }
+
+    #[test]
+    fn test_end_correction_scans_replacements_crossed_by_token() {
+        let text = FilteredText::new("ab");
+        let filtered =
+            text.replace_ranges(vec![(0, 1, "x y".to_string()), (1, 2, "u v".to_string())]);
+
+        assert_eq!(filtered.text, "x yu v");
+        assert_eq!(filtered.correct_offsets(0, 1), (0, 1));
+        assert_eq!(filtered.correct_offsets(2, 3), (0, 1));
+        assert_eq!(filtered.correct_offsets(3, 4), (1, 2));
+        assert_eq!(filtered.correct_offsets(5, 6), (1, 2));
+        assert_eq!(filtered.correct_offsets(0, 4), (0, 2));
+    }
+
+    #[test]
+    fn test_adjacent_deletion_and_replacement_share_filtered_start() {
+        let text = FilteredText::new("abc");
+        let filtered = text.replace_ranges(vec![(1, 2, "".to_string()), (2, 3, "x y".to_string())]);
+
+        assert_eq!(filtered.text, "ax y");
+        assert_eq!(filtered.correct_offsets(0, 1), (0, 1));
+        assert_eq!(filtered.correct_offsets(1, 2), (2, 3));
+        assert_eq!(filtered.correct_offsets(3, 4), (2, 3));
+        assert_eq!(filtered.correct_offsets(0, 4), (0, 3));
     }
 
     #[test]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
@@ -118,8 +118,6 @@ impl FilteredText {
     }
 
     pub(crate) fn correct_offsets(&self, offset_from: usize, offset_to: usize) -> (usize, usize) {
-        let offset_from = offset_from.min(self.text.len());
-        let offset_to = offset_to.min(self.text.len());
         debug_assert!(offset_from <= offset_to);
 
         match &self.corrections {
@@ -204,7 +202,10 @@ impl FilteredText {
 
     /// Replacements must be sorted, non-overlapping, and aligned to UTF-8 byte
     /// boundaries in the current filtered text.
-    pub(crate) fn replace_ranges(self, replacements: Vec<(usize, usize, String)>) -> Self {
+    pub(crate) fn replace_ranges<S: AsRef<str>>(
+        self,
+        replacements: Vec<(usize, usize, S)>,
+    ) -> Self {
         debug_assert!(
             Self::valid_replacements(&self.text, &replacements),
             "char filter replacements must be sorted, non-overlapping, and valid UTF-8 ranges"
@@ -231,7 +232,7 @@ impl FilteredText {
         let mut correction_index = 0;
         for (start, end, replacement) in replacements {
             self.push_original_segment(cursor, start, &mut correction_index, &mut output);
-            self.push_replacement(start, end, &replacement, &mut output);
+            self.push_replacement(start, end, replacement.as_ref(), &mut output);
             cursor = end;
         }
         self.push_original_segment(cursor, self.text.len(), &mut correction_index, &mut output);
@@ -246,7 +247,7 @@ impl FilteredText {
         }
     }
 
-    fn valid_replacements(text: &str, replacements: &[(usize, usize, String)]) -> bool {
+    fn valid_replacements<S>(text: &str, replacements: &[(usize, usize, S)]) -> bool {
         let mut cursor = 0;
         for (start, end, _) in replacements {
             if *start < cursor || *start > *end || *end > text.len() {

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
@@ -497,12 +497,21 @@ impl FilteredText {
         debug_assert!(corrections.last().map_or(true, |correction| {
             correction.filtered_start <= filtered_start
         }));
-        corrections.push(SpanOffsetCorrection::new(
+        let correction = SpanOffsetCorrection::new(
             filtered_start,
             filtered_len,
             original_start,
             original_end,
-        ));
+        );
+        if filtered_len == 0 {
+            if let Some(last) = corrections.last_mut().filter(|last| {
+                last.filtered_start == filtered_start && last.filtered_len == 0
+            }) {
+                *last = correction;
+                return;
+            }
+        }
+        corrections.push(correction);
     }
 
     fn correct_boundary_offset_at(

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
@@ -215,18 +215,7 @@ impl FilteredText {
             return self;
         }
 
-        let correction_capacity = self.correction_count() + replacements.len();
-        let mut output = FilteredText {
-            text: String::with_capacity(self.text.len()),
-            corrections: match &self.corrections {
-                OffsetCorrections::SourceSpan(_) => {
-                    OffsetCorrections::SourceSpan(Vec::with_capacity(correction_capacity))
-                }
-                OffsetCorrections::Boundary(_) => {
-                    OffsetCorrections::Boundary(Vec::with_capacity(correction_capacity * 2))
-                }
-            },
-        };
+        let mut output = self.empty_output(self.correction_count() + replacements.len());
 
         let mut cursor = 0;
         let mut correction_index = 0;
@@ -238,6 +227,61 @@ impl FilteredText {
         self.push_original_segment(cursor, self.text.len(), &mut correction_index, &mut output);
 
         output
+    }
+
+    pub(crate) fn replace_matches<'a, F>(self, mut match_at: F) -> Self
+    where
+        F: FnMut(&str) -> Option<(usize, &'a str)>,
+    {
+        let mut output = None;
+        let mut cursor = 0;
+        let mut copied_until = 0;
+        let mut correction_index = 0;
+
+        while cursor < self.text.len() {
+            if let Some((matched_len, replacement)) = match_at(&self.text[cursor..]) {
+                debug_assert!(matched_len > 0);
+                debug_assert!(self.text.is_char_boundary(cursor + matched_len));
+                let output = output
+                    .get_or_insert_with(|| self.empty_output(self.correction_count() + 1));
+                self.push_original_segment(
+                    copied_until,
+                    cursor,
+                    &mut correction_index,
+                    output,
+                );
+                self.push_replacement(cursor, cursor + matched_len, replacement, output);
+                cursor += matched_len;
+                copied_until = cursor;
+            } else {
+                cursor += self.text[cursor..].chars().next().unwrap().len_utf8();
+            }
+        }
+
+        let Some(mut output) = output else {
+            return self;
+        };
+        self.push_original_segment(
+            copied_until,
+            self.text.len(),
+            &mut correction_index,
+            &mut output,
+        );
+        output
+    }
+
+    fn empty_output(&self, correction_capacity: usize) -> Self {
+        FilteredText {
+            text: String::with_capacity(self.text.len()),
+            corrections: match &self.corrections {
+                OffsetCorrections::SourceSpan(_) => {
+                    OffsetCorrections::SourceSpan(Vec::with_capacity(correction_capacity))
+                }
+                OffsetCorrections::Boundary(_) => {
+                    OffsetCorrections::Boundary(Vec::with_capacity(correction_capacity * 2))
+                }
+            },
+        }
     }
 
     fn correction_count(&self) -> usize {

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
@@ -386,21 +386,27 @@ impl FilteredText {
                     return;
                 }
 
-                let source_boundaries = self.char_boundaries(start, end);
-                let replacement_boundaries = char_boundaries(replacement);
-                let source_char_count = source_boundaries.len().saturating_sub(1);
-                let replacement_char_count = replacement_boundaries.len().saturating_sub(1);
+                let source_char_count = self.text[start..end].chars().count();
+                let replacement_char_count = replacement.chars().count();
+                let mut source_boundaries = self.text[start..end]
+                    .char_indices()
+                    .map(|(offset, _)| start + offset)
+                    .chain(std::iter::once(end));
+                let mut source_boundary_index = 0;
+                let mut source_boundary = source_boundaries.next().unwrap();
                 let mut source_correction_index = corrections
-                    .partition_point(|correction| {
-                        correction.filtered_offset <= source_boundaries[0]
-                    })
+                    .partition_point(|correction| correction.filtered_offset <= source_boundary)
                     .checked_sub(1);
                 let mut next_correction_index =
                     source_correction_index.map_or(0, |index| index + 1);
 
                 output.text.push_str(replacement);
-                for (boundary_index, boundary) in replacement_boundaries.iter().enumerate() {
-                    let source_boundary_index = if boundary_index == replacement_char_count {
+                let replacement_boundaries = replacement
+                    .char_indices()
+                    .map(|(offset, _)| offset)
+                    .chain(std::iter::once(replacement.len()));
+                for (boundary_index, boundary) in replacement_boundaries.enumerate() {
+                    let wanted_source_boundary = if boundary_index == replacement_char_count {
                         source_char_count
                     } else if source_char_count == 0 {
                         0
@@ -411,7 +417,10 @@ impl FilteredText {
                     } else {
                         boundary_index.min(source_char_count)
                     };
-                    let source_boundary = source_boundaries[source_boundary_index];
+                    while source_boundary_index < wanted_source_boundary {
+                        source_boundary = source_boundaries.next().unwrap();
+                        source_boundary_index += 1;
+                    }
                     while next_correction_index < corrections.len()
                         && corrections[next_correction_index].filtered_offset <= source_boundary
                     {
@@ -484,26 +493,6 @@ impl FilteredText {
             });
         }
     }
-
-    fn char_boundaries(&self, start: usize, end: usize) -> Vec<usize> {
-        let mut boundaries = Vec::new();
-        boundaries.push(start);
-        for (offset, _) in self.text[start..end].char_indices().skip(1) {
-            boundaries.push(start + offset);
-        }
-        boundaries.push(end);
-        boundaries
-    }
-}
-
-fn char_boundaries(text: &str) -> Vec<usize> {
-    let mut boundaries = Vec::new();
-    boundaries.push(0);
-    for (offset, _) in text.char_indices().skip(1) {
-        boundaries.push(offset);
-    }
-    boundaries.push(text.len());
-    boundaries
 }
 
 fn signed_delta(value: usize, base: usize) -> isize {

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
@@ -412,13 +412,22 @@ impl FilteredText {
             ) => {
                 let (original_start, original_end) = self.correct_offsets(start, end);
                 output.text.push_str(replacement);
-                Self::push_span_correction(
-                    output_corrections,
-                    output_start,
-                    replacement.len(),
-                    original_start,
-                    original_end,
-                );
+                let source = &self.text[start..end];
+                let preserves_single_char_offsets = !source.is_empty()
+                    && source.chars().nth(1).is_none()
+                    && !replacement.is_empty()
+                    && replacement.chars().nth(1).is_none()
+                    && original_start == output_start
+                    && original_end == output.text.len();
+                if !preserves_single_char_offsets {
+                    Self::push_span_correction(
+                        output_corrections,
+                        output_start,
+                        replacement.len(),
+                        original_start,
+                        original_end,
+                    );
+                }
             }
             (
                 OffsetCorrections::Boundary(corrections),

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/char_filter.rs
@@ -242,14 +242,9 @@ impl FilteredText {
             if let Some((matched_len, replacement)) = match_at(&self.text[cursor..]) {
                 debug_assert!(matched_len > 0);
                 debug_assert!(self.text.is_char_boundary(cursor + matched_len));
-                let output = output
-                    .get_or_insert_with(|| self.empty_output(self.correction_count() + 1));
-                self.push_original_segment(
-                    copied_until,
-                    cursor,
-                    &mut correction_index,
-                    output,
-                );
+                let output =
+                    output.get_or_insert_with(|| self.empty_output(self.correction_count() + 1));
+                self.push_original_segment(copied_until, cursor, &mut correction_index, output);
                 self.push_replacement(cursor, cursor + matched_len, replacement, output);
                 cursor += matched_len;
                 copied_until = cursor;
@@ -506,16 +501,13 @@ impl FilteredText {
         debug_assert!(corrections.last().map_or(true, |correction| {
             correction.filtered_start <= filtered_start
         }));
-        let correction = SpanOffsetCorrection::new(
-            filtered_start,
-            filtered_len,
-            original_start,
-            original_end,
-        );
+        let correction =
+            SpanOffsetCorrection::new(filtered_start, filtered_len, original_start, original_end);
         if filtered_len == 0 {
-            if let Some(last) = corrections.last_mut().filter(|last| {
-                last.filtered_start == filtered_start && last.filtered_len == 0
-            }) {
+            if let Some(last) = corrections
+                .last_mut()
+                .filter(|last| last.filtered_start == filtered_start && last.filtered_len == 0)
+            {
                 *last = correction;
                 return;
             }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde_json as json;
 
 use super::char_filter::{BoxCharFilter, CharFilter, FilteredText};
@@ -5,7 +7,7 @@ use crate::error::{Result, TantivyBindingError};
 
 #[derive(Clone)]
 pub(crate) struct MappingCharFilter {
-    mappings: Vec<(String, String)>,
+    mappings: HashMap<char, Vec<(String, String)>>,
 }
 
 impl MappingCharFilter {
@@ -34,8 +36,19 @@ impl MappingCharFilter {
             parsed.push(parse_mapping(mapping)?);
         }
 
-        parsed.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
-        Ok(MappingCharFilter { mappings: parsed })
+        let mut mappings: HashMap<char, Vec<(String, String)>> = HashMap::new();
+        for (source, target) in parsed {
+            let first_char = source.chars().next().unwrap();
+            mappings
+                .entry(first_char)
+                .or_default()
+                .push((source, target));
+        }
+        for rules in mappings.values_mut() {
+            rules.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        }
+
+        Ok(MappingCharFilter { mappings })
     }
 }
 
@@ -45,9 +58,12 @@ impl CharFilter for MappingCharFilter {
         let mut cursor = 0;
 
         while cursor < input.text.len() {
+            let next = input.text[cursor..].chars().next().unwrap();
             if let Some((source, target)) = self
                 .mappings
-                .iter()
+                .get(&next)
+                .into_iter()
+                .flatten()
                 .find(|(source, _)| input.text[cursor..].starts_with(source))
             {
                 replacements.push((cursor, cursor + source.len(), target.clone()));
@@ -55,7 +71,6 @@ impl CharFilter for MappingCharFilter {
                 continue;
             }
 
-            let next = input.text[cursor..].chars().next().unwrap();
             cursor += next.len_utf8();
         }
 
@@ -68,7 +83,7 @@ impl CharFilter for MappingCharFilter {
 }
 
 fn parse_mapping(mapping: &str) -> Result<(String, String)> {
-    let separator = mapping.find("=>").ok_or_else(|| {
+    let separator = find_unescaped_separator(mapping).ok_or_else(|| {
         TantivyBindingError::InvalidArgument(format!(
             "invalid mapping char_filter mapping: {}",
             mapping
@@ -83,13 +98,57 @@ fn parse_mapping(mapping: &str) -> Result<(String, String)> {
         target = target.trim_start();
     }
 
+    let source = unescape_mapping_side(source)?;
+    let target = unescape_mapping_side(target)?;
     if source.is_empty() {
         return Err(TantivyBindingError::InvalidArgument(
             "mapping char_filter source must not be empty".to_string(),
         ));
     }
 
-    Ok((source.to_string(), target.to_string()))
+    Ok((source, target))
+}
+
+fn find_unescaped_separator(mapping: &str) -> Option<usize> {
+    let mut escaped = false;
+    for (offset, ch) in mapping.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if mapping[offset..].starts_with("=>") {
+            return Some(offset);
+        }
+    }
+    None
+}
+
+fn unescape_mapping_side(input: &str) -> Result<String> {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            output.push(ch);
+            continue;
+        }
+
+        let escaped = chars.next().ok_or_else(|| {
+            TantivyBindingError::InvalidArgument(
+                "mapping char_filter escape sequence must not end with backslash".to_string(),
+            )
+        })?;
+        match escaped {
+            'n' => output.push('\n'),
+            'r' => output.push('\r'),
+            't' => output.push('\t'),
+            other => output.push(other),
+        }
+    }
+    Ok(output)
 }
 
 fn has_separator_padding(source: &str, target: &str) -> bool {
@@ -177,5 +236,29 @@ mod tests {
         let output = filter.apply(FilteredText::new("a-b c"));
 
         assert_eq!(output.text, "a b_c");
+    }
+
+    #[test]
+    fn test_mapping_char_filter_supports_escaped_whitespace_and_separator() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["\\t=>\\ ", "\\=\\>=>arrow"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+        let filter = MappingCharFilter::from_json(&params).unwrap();
+        let output = filter.apply(FilteredText::new("\t=>"));
+
+        assert_eq!(output.text, " arrow");
+    }
+
+    #[test]
+    fn test_mapping_char_filter_rejects_trailing_escape() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["a=>b\\"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+
+        assert!(MappingCharFilter::from_json(&params).is_err());
     }
 }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
@@ -1,0 +1,181 @@
+use serde_json as json;
+
+use super::char_filter::{BoxCharFilter, CharFilter, FilteredText};
+use crate::error::{Result, TantivyBindingError};
+
+#[derive(Clone)]
+pub(crate) struct MappingCharFilter {
+    mappings: Vec<(String, String)>,
+}
+
+impl MappingCharFilter {
+    pub(crate) fn from_json(params: &json::Map<String, json::Value>) -> Result<Self> {
+        let mappings = params
+            .get("mappings")
+            .ok_or_else(|| {
+                TantivyBindingError::InvalidArgument(
+                    "mapping char_filter must set mappings".to_string(),
+                )
+            })?
+            .as_array()
+            .ok_or_else(|| {
+                TantivyBindingError::InvalidArgument(
+                    "mapping char_filter mappings must be array".to_string(),
+                )
+            })?;
+
+        let mut parsed = Vec::with_capacity(mappings.len());
+        for mapping in mappings {
+            let mapping = mapping.as_str().ok_or_else(|| {
+                TantivyBindingError::InvalidArgument(
+                    "mapping char_filter mapping item must be string".to_string(),
+                )
+            })?;
+            parsed.push(parse_mapping(mapping)?);
+        }
+
+        parsed.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        Ok(MappingCharFilter { mappings: parsed })
+    }
+}
+
+impl CharFilter for MappingCharFilter {
+    fn apply(&self, input: FilteredText) -> FilteredText {
+        let mut replacements = Vec::new();
+        let mut cursor = 0;
+
+        while cursor < input.text.len() {
+            if let Some((source, target)) = self
+                .mappings
+                .iter()
+                .find(|(source, _)| input.text[cursor..].starts_with(source))
+            {
+                replacements.push((cursor, cursor + source.len(), target.clone()));
+                cursor += source.len();
+                continue;
+            }
+
+            let next = input.text[cursor..].chars().next().unwrap();
+            cursor += next.len_utf8();
+        }
+
+        input.replace_ranges(replacements)
+    }
+
+    fn box_clone(&self) -> BoxCharFilter {
+        Box::new(self.clone())
+    }
+}
+
+fn parse_mapping(mapping: &str) -> Result<(String, String)> {
+    let separator = mapping.find("=>").ok_or_else(|| {
+        TantivyBindingError::InvalidArgument(format!(
+            "invalid mapping char_filter mapping: {}",
+            mapping
+        ))
+    })?;
+
+    let mut source = &mapping[..separator];
+    let mut target = &mapping[(separator + 2)..];
+    // Preserve one-sided whitespace so rules can map to or from a space.
+    if has_separator_padding(source, target) {
+        source = source.trim_end();
+        target = target.trim_start();
+    }
+
+    if source.is_empty() {
+        return Err(TantivyBindingError::InvalidArgument(
+            "mapping char_filter source must not be empty".to_string(),
+        ));
+    }
+
+    Ok((source.to_string(), target.to_string()))
+}
+
+fn has_separator_padding(source: &str, target: &str) -> bool {
+    matches!(source.chars().next_back(), Some(ch) if ch.is_whitespace())
+        && matches!(target.chars().next(), Some(ch) if ch.is_whitespace())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json as json;
+
+    use super::MappingCharFilter;
+    use crate::analyzer::char_filter::{CharFilter, FilteredText};
+
+    #[test]
+    fn test_mapping_char_filter() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["&=>and", "--=>-"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+        let filter = MappingCharFilter::from_json(&params).unwrap();
+        let output = filter.apply(FilteredText::new("a&b--c"));
+
+        assert_eq!(output.text, "aandb-c");
+        assert_eq!(output.correct_offset(0), 0);
+        assert_eq!(output.correct_offset(1), 1);
+        assert_eq!(output.correct_offset(4), 2);
+        assert_eq!(output.correct_offset(6), 5);
+        assert_eq!(output.correct_offset(7), 6);
+    }
+
+    #[test]
+    fn test_mapping_char_filter_uses_longest_match() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["a=>x", "aa=>y"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+        let filter = MappingCharFilter::from_json(&params).unwrap();
+        let output = filter.apply(FilteredText::new("aa"));
+
+        assert_eq!(output.text, "y");
+        assert_eq!(output.correct_offset(0), 0);
+        assert_eq!(output.correct_offset(1), 2);
+    }
+
+    #[test]
+    fn test_mapping_char_filter_accepts_es_style_separator_padding() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["& => and", ":) => _happy_"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+        let filter = MappingCharFilter::from_json(&params).unwrap();
+        let output = filter.apply(FilteredText::new("a&b :)"));
+
+        assert_eq!(output.text, "aandb _happy_");
+    }
+
+    #[test]
+    fn test_mapping_char_filter_can_delete() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["-=>"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+        let filter = MappingCharFilter::from_json(&params).unwrap();
+        let output = filter.apply(FilteredText::new("中-文"));
+
+        assert_eq!(output.text, "中文");
+        assert_eq!(output.correct_offset(0), 0);
+        assert_eq!(output.correct_offset(3), 4);
+        assert_eq!(output.correct_offset(6), 7);
+    }
+
+    #[test]
+    fn test_mapping_char_filter_preserves_whitespace() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["-=> ", " =>_"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+        let filter = MappingCharFilter::from_json(&params).unwrap();
+        let output = filter.apply(FilteredText::new("a-b c"));
+
+        assert_eq!(output.text, "a b_c");
+    }
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
@@ -83,7 +83,7 @@ impl CharFilter for MappingCharFilter {
                 .flatten()
                 .find(|(source, _)| input.text[cursor..].starts_with(source))
             {
-                replacements.push((cursor, cursor + source.len(), target.clone()));
+                replacements.push((cursor, cursor + source.len(), target.as_str()));
                 cursor += source.len();
                 continue;
             }
@@ -100,7 +100,7 @@ impl CharFilter for MappingCharFilter {
 }
 
 fn parse_mapping(mapping: &str) -> Result<(String, String)> {
-    let separator = find_last_unescaped_separator(mapping).ok_or_else(|| {
+    let separator = mapping.rfind("=>").ok_or_else(|| {
         TantivyBindingError::InvalidArgument(format!(
             "invalid mapping char_filter mapping: {}",
             mapping
@@ -119,25 +119,6 @@ fn parse_mapping(mapping: &str) -> Result<(String, String)> {
     }
 
     Ok((source, target))
-}
-
-fn find_last_unescaped_separator(mapping: &str) -> Option<usize> {
-    let mut escaped = false;
-    let mut separator = None;
-    for (offset, ch) in mapping.char_indices() {
-        if escaped {
-            escaped = false;
-            continue;
-        }
-        if ch == '\\' {
-            escaped = true;
-            continue;
-        }
-        if mapping[offset..].starts_with("=>") {
-            separator = Some(offset);
-        }
-    }
-    separator
 }
 
 fn unescape_mapping_side(input: &str) -> Result<String> {
@@ -305,7 +286,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mapping_char_filter_uses_last_unescaped_separator() {
+    fn test_mapping_char_filter_uses_last_raw_separator() {
         let params = r#"{
             "type": "mapping",
             "mappings": ["a=>b=>c"]
@@ -315,6 +296,17 @@ mod tests {
         let output = filter.apply(FilteredText::new("a=>b"));
 
         assert_eq!(output.text, "c");
+    }
+
+    #[test]
+    fn test_mapping_char_filter_rejects_backslash_before_raw_separator() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["a=>b\\=>c"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+
+        assert!(MappingCharFilter::from_json(&params).is_err());
     }
 
     #[test]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
@@ -1,10 +1,16 @@
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 use serde_json as json;
 
 use super::char_filter::{BoxCharFilter, CharFilter, FilteredText};
 use crate::error::{Result, TantivyBindingError};
 
+/// Rewrites tokenizer input with greedy longest-match `source => target` rules.
+///
+/// The filter scans its input once from left to right. Replacement output is
+/// not processed again by this filter, but can be processed by a later char
+/// filter in the analyzer chain. `FilteredText` composes the replacements with
+/// existing offset corrections.
 #[derive(Clone)]
 pub(crate) struct MappingCharFilter {
     mappings: HashMap<char, Vec<(String, String)>>,
@@ -26,14 +32,25 @@ impl MappingCharFilter {
                 )
             })?;
 
-        let mut parsed = Vec::with_capacity(mappings.len());
+        let mut parsed = HashMap::with_capacity(mappings.len());
         for mapping in mappings {
             let mapping = mapping.as_str().ok_or_else(|| {
                 TantivyBindingError::InvalidArgument(
                     "mapping char_filter mapping item must be string".to_string(),
                 )
             })?;
-            parsed.push(parse_mapping(mapping)?);
+            let (source, target) = parse_mapping(mapping)?;
+            match parsed.entry(source) {
+                Entry::Vacant(entry) => {
+                    entry.insert(target);
+                }
+                Entry::Occupied(entry) => {
+                    return Err(TantivyBindingError::InvalidArgument(format!(
+                        "mapping char_filter source must be unique: {:?}",
+                        entry.key()
+                    )));
+                }
+            }
         }
 
         let mut mappings: HashMap<char, Vec<(String, String)>> = HashMap::new();
@@ -83,20 +100,15 @@ impl CharFilter for MappingCharFilter {
 }
 
 fn parse_mapping(mapping: &str) -> Result<(String, String)> {
-    let separator = find_unescaped_separator(mapping).ok_or_else(|| {
+    let separator = find_last_unescaped_separator(mapping).ok_or_else(|| {
         TantivyBindingError::InvalidArgument(format!(
             "invalid mapping char_filter mapping: {}",
             mapping
         ))
     })?;
 
-    let mut source = &mapping[..separator];
-    let mut target = &mapping[(separator + 2)..];
-    // Preserve one-sided whitespace so rules can map to or from a space.
-    if has_separator_padding(source, target) {
-        source = source.trim_end();
-        target = target.trim_start();
-    }
+    let source = trim_mapping_side(&mapping[..separator]);
+    let target = trim_mapping_side(&mapping[(separator + 2)..]);
 
     let source = unescape_mapping_side(source)?;
     let target = unescape_mapping_side(target)?;
@@ -109,8 +121,9 @@ fn parse_mapping(mapping: &str) -> Result<(String, String)> {
     Ok((source, target))
 }
 
-fn find_unescaped_separator(mapping: &str) -> Option<usize> {
+fn find_last_unescaped_separator(mapping: &str) -> Option<usize> {
     let mut escaped = false;
+    let mut separator = None;
     for (offset, ch) in mapping.char_indices() {
         if escaped {
             escaped = false;
@@ -121,10 +134,10 @@ fn find_unescaped_separator(mapping: &str) -> Option<usize> {
             continue;
         }
         if mapping[offset..].starts_with("=>") {
-            return Some(offset);
+            separator = Some(offset);
         }
     }
-    None
+    separator
 }
 
 fn unescape_mapping_side(input: &str) -> Result<String> {
@@ -142,18 +155,60 @@ fn unescape_mapping_side(input: &str) -> Result<String> {
             )
         })?;
         match escaped {
+            '\\' => output.push('\\'),
             'n' => output.push('\n'),
             'r' => output.push('\r'),
             't' => output.push('\t'),
+            'b' => output.push('\u{0008}'),
+            'f' => output.push('\u{000c}'),
+            'u' => output.push(parse_unicode_escape(&mut chars)?),
             other => output.push(other),
         }
     }
     Ok(output)
 }
 
-fn has_separator_padding(source: &str, target: &str) -> bool {
-    matches!(source.chars().next_back(), Some(ch) if ch.is_whitespace())
-        && matches!(target.chars().next(), Some(ch) if ch.is_whitespace())
+// Elasticsearch trims characters up to U+0020 before parsing escapes.
+fn trim_mapping_side(input: &str) -> &str {
+    input.trim_matches(|ch| ch <= '\u{0020}')
+}
+
+fn parse_unicode_escape(chars: &mut std::str::Chars<'_>) -> Result<char> {
+    let first = parse_unicode_code_unit(chars)?;
+    let code_point = if (0xd800..=0xdbff).contains(&first) {
+        if chars.next() != Some('\\') || chars.next() != Some('u') {
+            return Err(invalid_unicode_escape());
+        }
+        let second = parse_unicode_code_unit(chars)?;
+        if !(0xdc00..=0xdfff).contains(&second) {
+            return Err(invalid_unicode_escape());
+        }
+        0x10000 + (((first as u32 - 0xd800) << 10) | (second as u32 - 0xdc00))
+    } else if (0xdc00..=0xdfff).contains(&first) {
+        return Err(invalid_unicode_escape());
+    } else {
+        first as u32
+    };
+
+    char::from_u32(code_point).ok_or_else(invalid_unicode_escape)
+}
+
+fn parse_unicode_code_unit(chars: &mut std::str::Chars<'_>) -> Result<u16> {
+    let mut value = 0u16;
+    for _ in 0..4 {
+        let digit = chars
+            .next()
+            .and_then(|ch| ch.to_digit(16))
+            .ok_or_else(invalid_unicode_escape)?;
+        value = (value << 4) | digit as u16;
+    }
+    Ok(value)
+}
+
+fn invalid_unicode_escape() -> TantivyBindingError {
+    TantivyBindingError::InvalidArgument(
+        "mapping char_filter contains an invalid unicode escape".to_string(),
+    )
 }
 
 #[cfg(test)]
@@ -174,11 +229,10 @@ mod tests {
         let output = filter.apply(FilteredText::new("a&b--c"));
 
         assert_eq!(output.text, "aandb-c");
-        assert_eq!(output.correct_offset(0), 0);
-        assert_eq!(output.correct_offset(1), 1);
-        assert_eq!(output.correct_offset(4), 2);
-        assert_eq!(output.correct_offset(6), 5);
-        assert_eq!(output.correct_offset(7), 6);
+        assert_eq!(output.correct_offsets(1, 4), (1, 2));
+        assert_eq!(output.correct_offsets(4, 5), (2, 3));
+        assert_eq!(output.correct_offsets(5, 6), (3, 5));
+        assert_eq!(output.correct_offsets(0, 7), (0, 6));
     }
 
     #[test]
@@ -192,8 +246,7 @@ mod tests {
         let output = filter.apply(FilteredText::new("aa"));
 
         assert_eq!(output.text, "y");
-        assert_eq!(output.correct_offset(0), 0);
-        assert_eq!(output.correct_offset(1), 2);
+        assert_eq!(output.correct_offsets(0, 1), (0, 2));
     }
 
     #[test]
@@ -220,16 +273,16 @@ mod tests {
         let output = filter.apply(FilteredText::new("中-文"));
 
         assert_eq!(output.text, "中文");
-        assert_eq!(output.correct_offset(0), 0);
-        assert_eq!(output.correct_offset(3), 4);
-        assert_eq!(output.correct_offset(6), 7);
+        assert_eq!(output.correct_offsets(0, 3), (0, 3));
+        assert_eq!(output.correct_offsets(3, 6), (4, 7));
+        assert_eq!(output.correct_offsets(0, 6), (0, 7));
     }
 
     #[test]
-    fn test_mapping_char_filter_preserves_whitespace() {
+    fn test_mapping_char_filter_uses_unicode_escape_for_whitespace() {
         let params = r#"{
             "type": "mapping",
-            "mappings": ["-=> ", " =>_"]
+            "mappings": ["-=>\\u0020", "\\u0020=>_"]
         }"#;
         let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
         let filter = MappingCharFilter::from_json(&params).unwrap();
@@ -242,13 +295,75 @@ mod tests {
     fn test_mapping_char_filter_supports_escaped_whitespace_and_separator() {
         let params = r#"{
             "type": "mapping",
-            "mappings": ["\\t=>\\ ", "\\=\\>=>arrow"]
+            "mappings": ["\\t=>\\u0020", "\\=\\>=>arrow"]
         }"#;
         let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
         let filter = MappingCharFilter::from_json(&params).unwrap();
         let output = filter.apply(FilteredText::new("\t=>"));
 
         assert_eq!(output.text, " arrow");
+    }
+
+    #[test]
+    fn test_mapping_char_filter_uses_last_unescaped_separator() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["a=>b=>c"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+        let filter = MappingCharFilter::from_json(&params).unwrap();
+        let output = filter.apply(FilteredText::new("a=>b"));
+
+        assert_eq!(output.text, "c");
+    }
+
+    #[test]
+    fn test_mapping_char_filter_rejects_duplicate_source() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["a=>x", "\\u0061=>y"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+
+        assert!(MappingCharFilter::from_json(&params).is_err());
+    }
+
+    #[test]
+    fn test_mapping_char_filter_trims_each_mapping_side() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["a => b", "-=> "]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+        let filter = MappingCharFilter::from_json(&params).unwrap();
+        let output = filter.apply(FilteredText::new("a-"));
+
+        assert_eq!(output.text, "b");
+    }
+
+    #[test]
+    fn test_mapping_char_filter_supports_unicode_surrogate_pairs() {
+        let params = r#"{
+            "type": "mapping",
+            "mappings": ["\\u4e2d=>zhong", "\\ud83d\\ude00=>smile"]
+        }"#;
+        let params = json::from_str::<json::Map<String, json::Value>>(params).unwrap();
+        let filter = MappingCharFilter::from_json(&params).unwrap();
+        let output = filter.apply(FilteredText::new("中😀"));
+
+        assert_eq!(output.text, "zhongsmile");
+    }
+
+    #[test]
+    fn test_mapping_char_filter_rejects_invalid_unicode_escape() {
+        for mapping in ["\\u123=>x", "\\ud83d=>x", "\\ud83d\\u0041=>x"] {
+            let params = json::json!({
+                "type": "mapping",
+                "mappings": [mapping]
+            });
+
+            assert!(MappingCharFilter::from_json(params.as_object().unwrap()).is_err());
+        }
     }
 
     #[test]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
@@ -196,7 +196,7 @@ fn invalid_unicode_escape() -> TantivyBindingError {
 mod tests {
     use serde_json as json;
 
-    use super::MappingCharFilter;
+    use super::{unescape_mapping_side, MappingCharFilter};
     use crate::analyzer::char_filter::{CharFilter, FilteredText};
 
     #[test]
@@ -283,6 +283,16 @@ mod tests {
         let output = filter.apply(FilteredText::new("\t=>"));
 
         assert_eq!(output.text, " arrow");
+    }
+
+    #[test]
+    fn test_mapping_char_filter_supports_es_escape_rules() {
+        let escaped = r#"\\\n\r\t\b\f\u0041\"\q\=\>"#;
+
+        assert_eq!(
+            unescape_mapping_side(escaped).unwrap(),
+            "\\\n\r\t\u{0008}\u{000c}A\"q=>"
+        );
     }
 
     #[test]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
@@ -1,4 +1,5 @@
 use std::collections::{hash_map::Entry, HashMap};
+use std::sync::Arc;
 
 use serde_json as json;
 
@@ -13,7 +14,7 @@ use crate::error::{Result, TantivyBindingError};
 /// existing offset corrections.
 #[derive(Clone)]
 pub(crate) struct MappingCharFilter {
-    mappings: HashMap<char, Vec<(String, String)>>,
+    mappings: Arc<HashMap<char, Vec<(String, String)>>>,
 }
 
 impl MappingCharFilter {
@@ -65,7 +66,9 @@ impl MappingCharFilter {
             rules.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
         }
 
-        Ok(MappingCharFilter { mappings })
+        Ok(MappingCharFilter {
+            mappings: Arc::new(mappings),
+        })
     }
 }
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
@@ -74,27 +74,16 @@ impl MappingCharFilter {
 
 impl CharFilter for MappingCharFilter {
     fn apply(&self, input: FilteredText) -> FilteredText {
-        let mut replacements = Vec::new();
-        let mut cursor = 0;
-
-        while cursor < input.text.len() {
-            let next = input.text[cursor..].chars().next().unwrap();
-            if let Some((source, target)) = self
+        input.replace_matches(|text| {
+            let next = text.chars().next().unwrap();
+            self
                 .mappings
                 .get(&next)
                 .into_iter()
                 .flatten()
-                .find(|(source, _)| input.text[cursor..].starts_with(source))
-            {
-                replacements.push((cursor, cursor + source.len(), target.as_str()));
-                cursor += source.len();
-                continue;
-            }
-
-            cursor += next.len_utf8();
-        }
-
-        input.replace_ranges(replacements)
+                .find(|(source, _)| text.starts_with(source))
+                .map(|(source, target)| (source.len(), target.as_str()))
+        })
     }
 
     fn box_clone(&self) -> BoxCharFilter {

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
@@ -76,8 +76,7 @@ impl CharFilter for MappingCharFilter {
     fn apply(&self, input: FilteredText) -> FilteredText {
         input.replace_matches(|text| {
             let next = text.chars().next().unwrap();
-            self
-                .mappings
+            self.mappings
                 .get(&next)
                 .into_iter()
                 .flatten()

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mapping_char_filter.rs
@@ -103,6 +103,10 @@ impl CharFilter for MappingCharFilter {
 }
 
 fn parse_mapping(mapping: &str) -> Result<(String, String)> {
+    if mapping.contains('\0') {
+        return Err(nul_not_supported());
+    }
+
     let separator = mapping.rfind("=>").ok_or_else(|| {
         TantivyBindingError::InvalidArgument(format!(
             "invalid mapping char_filter mapping: {}",
@@ -115,6 +119,9 @@ fn parse_mapping(mapping: &str) -> Result<(String, String)> {
 
     let source = unescape_mapping_side(source)?;
     let target = unescape_mapping_side(target)?;
+    if source.contains('\0') || target.contains('\0') {
+        return Err(nul_not_supported());
+    }
     if source.is_empty() {
         return Err(TantivyBindingError::InvalidArgument(
             "mapping char_filter source must not be empty".to_string(),
@@ -122,6 +129,10 @@ fn parse_mapping(mapping: &str) -> Result<(String, String)> {
     }
 
     Ok((source, target))
+}
+
+fn nul_not_supported() -> TantivyBindingError {
+    TantivyBindingError::InvalidArgument("mapping char_filter does not support U+0000".to_string())
 }
 
 fn unescape_mapping_side(input: &str) -> Result<String> {

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mod.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mod.rs
@@ -1,0 +1,45 @@
+mod char_filter;
+mod mapping_char_filter;
+
+use serde_json as json;
+
+#[cfg(test)]
+pub(crate) use self::char_filter::CharFilter;
+pub(crate) use self::char_filter::{BoxCharFilter, FilteredText};
+use self::mapping_char_filter::MappingCharFilter;
+use crate::error::{Result, TantivyBindingError};
+
+pub(crate) fn build_char_filters(params: &json::Value) -> Result<Vec<BoxCharFilter>> {
+    let filters = params.as_array().ok_or_else(|| {
+        TantivyBindingError::InvalidArgument("char_filter params should be array".to_string())
+    })?;
+
+    let mut result = Vec::with_capacity(filters.len());
+    for filter in filters {
+        let filter = filter.as_object().ok_or_else(|| {
+            TantivyBindingError::InvalidArgument("char_filter item should be object".to_string())
+        })?;
+        result.push(create_char_filter(filter)?);
+    }
+    Ok(result)
+}
+
+fn create_char_filter(params: &json::Map<String, json::Value>) -> Result<BoxCharFilter> {
+    let type_ = params
+        .get("type")
+        .ok_or_else(|| {
+            TantivyBindingError::InvalidArgument("char_filter type must be set".to_string())
+        })?
+        .as_str()
+        .ok_or_else(|| {
+            TantivyBindingError::InvalidArgument("char_filter type should be string".to_string())
+        })?;
+
+    match type_ {
+        "mapping" => MappingCharFilter::from_json(params).map(|filter| Box::new(filter) as _),
+        other => Err(TantivyBindingError::InvalidArgument(format!(
+            "unsupported char_filter type: {}",
+            other
+        ))),
+    }
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mod.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/char_filter/mod.rs
@@ -5,9 +5,31 @@ use serde_json as json;
 
 #[cfg(test)]
 pub(crate) use self::char_filter::CharFilter;
-pub(crate) use self::char_filter::{BoxCharFilter, FilteredText};
+pub(crate) use self::char_filter::{BoxCharFilter, FilteredText, OffsetMappingMode};
 use self::mapping_char_filter::MappingCharFilter;
 use crate::error::{Result, TantivyBindingError};
+
+impl OffsetMappingMode {
+    pub(crate) fn from_json(value: Option<&json::Value>) -> Result<Self> {
+        let Some(value) = value else {
+            return Ok(Self::default());
+        };
+        let mode = value.as_str().ok_or_else(|| {
+            TantivyBindingError::InvalidArgument(
+                "char_filter_offset_mode should be string".to_string(),
+            )
+        })?;
+
+        match mode {
+            "source_span" => Ok(Self::SourceSpan),
+            "boundary" => Ok(Self::Boundary),
+            other => Err(TantivyBindingError::InvalidArgument(format!(
+                "unsupported char_filter_offset_mode: {}",
+                other
+            ))),
+        }
+    }
+}
 
 pub(crate) fn build_char_filters(params: &json::Value) -> Result<Vec<BoxCharFilter>> {
     let filters = params.as_array().ok_or_else(|| {

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/mod.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/mod.rs
@@ -1,5 +1,6 @@
 mod analyzer;
 mod build_in_analyzer;
+pub(crate) mod char_filter;
 mod dict;
 mod filter;
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_filter_tokenizer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_filter_tokenizer.rs
@@ -1,0 +1,107 @@
+use tantivy::tokenizer::{TextAnalyzer, Token, TokenStream, Tokenizer};
+
+use crate::analyzer::char_filter::{BoxCharFilter, FilteredText};
+
+#[derive(Clone)]
+pub struct CharFilterTokenizer {
+    char_filters: Vec<BoxCharFilter>,
+    inner: TextAnalyzer,
+}
+
+impl CharFilterTokenizer {
+    pub(crate) fn new(char_filters: Vec<BoxCharFilter>, inner: TextAnalyzer) -> Self {
+        CharFilterTokenizer {
+            char_filters,
+            inner,
+        }
+    }
+
+    fn apply_char_filters(&self, text: &str) -> FilteredText {
+        self.char_filters
+            .iter()
+            .fold(FilteredText::new(text), |input, filter| filter.apply(input))
+    }
+
+    fn tokenize(&mut self, text: &str) -> Vec<Token> {
+        let filtered = self.apply_char_filters(text);
+        let mut stream = self.inner.token_stream(&filtered.text);
+        let mut tokens = Vec::new();
+
+        while stream.advance() {
+            let mut token = stream.token().clone();
+            token.offset_from = filtered.correct_offset(token.offset_from);
+            token.offset_to = filtered.correct_offset(token.offset_to);
+            tokens.push(token);
+        }
+
+        tokens
+    }
+}
+
+impl Tokenizer for CharFilterTokenizer {
+    type TokenStream<'a> = CharFilterTokenStream;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+        CharFilterTokenStream {
+            tokens: self.tokenize(text),
+            index: 0,
+        }
+    }
+}
+
+pub struct CharFilterTokenStream {
+    tokens: Vec<Token>,
+    index: usize,
+}
+
+impl TokenStream for CharFilterTokenStream {
+    fn advance(&mut self) -> bool {
+        if self.index < self.tokens.len() {
+            self.index += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn token(&self) -> &Token {
+        &self.tokens[self.index - 1]
+    }
+
+    fn token_mut(&mut self) -> &mut Token {
+        &mut self.tokens[self.index - 1]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json as json;
+    use tantivy::tokenizer::{TextAnalyzer, TokenStream, Tokenizer};
+
+    use super::CharFilterTokenizer;
+    use crate::analyzer::char_filter::{build_char_filters, BoxCharFilter};
+
+    #[test]
+    fn test_char_filter_tokenizer_corrects_offsets() {
+        let params = json::json!([
+            {
+                "type": "mapping",
+                "mappings": ["&=>and"]
+            }
+        ]);
+        let filters: Vec<BoxCharFilter> = build_char_filters(&params).unwrap();
+        let mut tokenizer = CharFilterTokenizer::new(
+            filters,
+            TextAnalyzer::builder(tantivy::tokenizer::SimpleTokenizer::default())
+                .dynamic()
+                .build(),
+        );
+        let mut stream = tokenizer.token_stream("a&b");
+
+        assert!(stream.advance());
+        let token = stream.token();
+        assert_eq!(token.text, "aandb");
+        assert_eq!(token.offset_from, 0);
+        assert_eq!(token.offset_to, 3);
+    }
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_filter_tokenizer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_filter_tokenizer.rs
@@ -1,11 +1,21 @@
-use tantivy::tokenizer::{TextAnalyzer, Token, TokenStream, Tokenizer};
+use tantivy::tokenizer::{BoxTokenStream, TextAnalyzer, Token, TokenStream, Tokenizer};
 
 use crate::analyzer::char_filter::{BoxCharFilter, FilteredText};
 
-#[derive(Clone)]
 pub struct CharFilterTokenizer {
     char_filters: Vec<BoxCharFilter>,
     inner: TextAnalyzer,
+    filtered: FilteredText,
+}
+
+impl Clone for CharFilterTokenizer {
+    fn clone(&self) -> Self {
+        CharFilterTokenizer {
+            char_filters: self.char_filters.clone(),
+            inner: self.inner.clone(),
+            filtered: FilteredText::default(),
+        }
+    }
 }
 
 impl CharFilterTokenizer {
@@ -13,6 +23,7 @@ impl CharFilterTokenizer {
         CharFilterTokenizer {
             char_filters,
             inner,
+            filtered: FilteredText::default(),
         }
     }
 
@@ -21,65 +32,107 @@ impl CharFilterTokenizer {
             .iter()
             .fold(FilteredText::new(text), |input, filter| filter.apply(input))
     }
-
-    fn tokenize(&mut self, text: &str) -> Vec<Token> {
-        let filtered = self.apply_char_filters(text);
-        let mut stream = self.inner.token_stream(&filtered.text);
-        let mut tokens = Vec::new();
-
-        while stream.advance() {
-            let mut token = stream.token().clone();
-            token.offset_from = filtered.correct_offset(token.offset_from);
-            token.offset_to = filtered.correct_offset(token.offset_to);
-            tokens.push(token);
-        }
-
-        tokens
-    }
 }
 
 impl Tokenizer for CharFilterTokenizer {
-    type TokenStream<'a> = CharFilterTokenStream;
+    type TokenStream<'a> = CharFilterTokenStream<'a>;
 
     fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
-        CharFilterTokenStream {
-            tokens: self.tokenize(text),
-            index: 0,
-        }
+        let filtered = self.apply_char_filters(text);
+        self.filtered = filtered;
+
+        let filtered = &self.filtered;
+        let tail = self.inner.token_stream(&filtered.text);
+        CharFilterTokenStream { tail, filtered }
     }
 }
 
-pub struct CharFilterTokenStream {
-    tokens: Vec<Token>,
-    index: usize,
+pub struct CharFilterTokenStream<'a> {
+    tail: BoxTokenStream<'a>,
+    filtered: &'a FilteredText,
 }
 
-impl TokenStream for CharFilterTokenStream {
+impl TokenStream for CharFilterTokenStream<'_> {
     fn advance(&mut self) -> bool {
-        if self.index < self.tokens.len() {
-            self.index += 1;
-            true
-        } else {
-            false
+        if !self.tail.advance() {
+            return false;
         }
+
+        let token = self.tail.token_mut();
+        token.offset_from = self.filtered.correct_offset(token.offset_from);
+        token.offset_to = self.filtered.correct_offset(token.offset_to);
+        true
     }
 
     fn token(&self) -> &Token {
-        &self.tokens[self.index - 1]
+        self.tail.token()
     }
 
     fn token_mut(&mut self) -> &mut Token {
-        &mut self.tokens[self.index - 1]
+        self.tail.token_mut()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
     use serde_json as json;
-    use tantivy::tokenizer::{TextAnalyzer, TokenStream, Tokenizer};
+    use tantivy::tokenizer::{TextAnalyzer, Token, TokenStream, Tokenizer};
 
     use super::CharFilterTokenizer;
     use crate::analyzer::char_filter::{build_char_filters, BoxCharFilter};
+
+    #[derive(Clone)]
+    struct CountingTokenizer {
+        advance_count: Arc<AtomicUsize>,
+    }
+
+    struct CountingTokenStream<'a> {
+        text: &'a str,
+        advance_count: Arc<AtomicUsize>,
+        emitted: bool,
+        token: Token,
+    }
+
+    impl Tokenizer for CountingTokenizer {
+        type TokenStream<'a> = CountingTokenStream<'a>;
+
+        fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+            CountingTokenStream {
+                text,
+                advance_count: self.advance_count.clone(),
+                emitted: false,
+                token: Token::default(),
+            }
+        }
+    }
+
+    impl TokenStream for CountingTokenStream<'_> {
+        fn advance(&mut self) -> bool {
+            if self.emitted {
+                return false;
+            }
+            self.emitted = true;
+            self.advance_count.fetch_add(1, Ordering::SeqCst);
+            self.token.offset_from = 0;
+            self.token.offset_to = self.text.len();
+            self.token.position = 0;
+            self.token.text = self.text.to_string();
+            true
+        }
+
+        fn token(&self) -> &Token {
+            &self.token
+        }
+
+        fn token_mut(&mut self) -> &mut Token {
+            &mut self.token
+        }
+    }
 
     #[test]
     fn test_char_filter_tokenizer_corrects_offsets() {
@@ -103,5 +156,28 @@ mod tests {
         assert_eq!(token.text, "aandb");
         assert_eq!(token.offset_from, 0);
         assert_eq!(token.offset_to, 3);
+    }
+
+    #[test]
+    fn test_char_filter_tokenizer_keeps_inner_stream_lazy() {
+        let params = json::json!([
+            {
+                "type": "mapping",
+                "mappings": ["&=>and"]
+            }
+        ]);
+        let filters: Vec<BoxCharFilter> = build_char_filters(&params).unwrap();
+        let advance_count = Arc::new(AtomicUsize::new(0));
+        let inner = CountingTokenizer {
+            advance_count: advance_count.clone(),
+        };
+        let mut tokenizer =
+            CharFilterTokenizer::new(filters, TextAnalyzer::builder(inner).dynamic().build());
+
+        let mut stream = tokenizer.token_stream("a&b");
+        assert_eq!(advance_count.load(Ordering::SeqCst), 0);
+        assert!(stream.advance());
+        assert_eq!(advance_count.load(Ordering::SeqCst), 1);
+        assert_eq!(stream.token().text, "aandb");
     }
 }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_filter_tokenizer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_filter_tokenizer.rs
@@ -1,10 +1,11 @@
 use tantivy::tokenizer::{BoxTokenStream, TextAnalyzer, Token, TokenStream, Tokenizer};
 
-use crate::analyzer::char_filter::{BoxCharFilter, FilteredText};
+use crate::analyzer::char_filter::{BoxCharFilter, FilteredText, OffsetMappingMode};
 
 pub struct CharFilterTokenizer {
     char_filters: Vec<BoxCharFilter>,
     inner: TextAnalyzer,
+    offset_mode: OffsetMappingMode,
     filtered: FilteredText,
 }
 
@@ -13,24 +14,31 @@ impl Clone for CharFilterTokenizer {
         CharFilterTokenizer {
             char_filters: self.char_filters.clone(),
             inner: self.inner.clone(),
-            filtered: FilteredText::default(),
+            offset_mode: self.offset_mode,
+            filtered: FilteredText::with_offset_mode("", self.offset_mode),
         }
     }
 }
 
 impl CharFilterTokenizer {
-    pub(crate) fn new(char_filters: Vec<BoxCharFilter>, inner: TextAnalyzer) -> Self {
+    pub(crate) fn new(
+        char_filters: Vec<BoxCharFilter>,
+        inner: TextAnalyzer,
+        offset_mode: OffsetMappingMode,
+    ) -> Self {
         CharFilterTokenizer {
             char_filters,
             inner,
-            filtered: FilteredText::default(),
+            offset_mode,
+            filtered: FilteredText::with_offset_mode("", offset_mode),
         }
     }
 
     fn apply_char_filters(&self, text: &str) -> FilteredText {
-        self.char_filters
-            .iter()
-            .fold(FilteredText::new(text), |input, filter| filter.apply(input))
+        self.char_filters.iter().fold(
+            FilteredText::with_offset_mode(text, self.offset_mode),
+            |input, filter| filter.apply(input),
+        )
     }
 }
 
@@ -59,8 +67,9 @@ impl TokenStream for CharFilterTokenStream<'_> {
         }
 
         let token = self.tail.token_mut();
-        token.offset_from = self.filtered.correct_offset(token.offset_from);
-        token.offset_to = self.filtered.correct_offset(token.offset_to);
+        (token.offset_from, token.offset_to) = self
+            .filtered
+            .correct_offsets(token.offset_from, token.offset_to);
         true
     }
 
@@ -84,7 +93,7 @@ mod tests {
     use tantivy::tokenizer::{TextAnalyzer, Token, TokenStream, Tokenizer};
 
     use super::CharFilterTokenizer;
-    use crate::analyzer::char_filter::{build_char_filters, BoxCharFilter};
+    use crate::analyzer::char_filter::{build_char_filters, BoxCharFilter, OffsetMappingMode};
 
     #[derive(Clone)]
     struct CountingTokenizer {
@@ -148,6 +157,7 @@ mod tests {
             TextAnalyzer::builder(tantivy::tokenizer::SimpleTokenizer::default())
                 .dynamic()
                 .build(),
+            OffsetMappingMode::SourceSpan,
         );
         let mut stream = tokenizer.token_stream("a&b");
 
@@ -171,8 +181,11 @@ mod tests {
         let inner = CountingTokenizer {
             advance_count: advance_count.clone(),
         };
-        let mut tokenizer =
-            CharFilterTokenizer::new(filters, TextAnalyzer::builder(inner).dynamic().build());
+        let mut tokenizer = CharFilterTokenizer::new(
+            filters,
+            TextAnalyzer::builder(inner).dynamic().build(),
+            OffsetMappingMode::SourceSpan,
+        );
 
         let mut stream = tokenizer.token_stream("a&b");
         assert_eq!(advance_count.load(Ordering::SeqCst), 0);

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_filter_tokenizer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/char_filter_tokenizer.rs
@@ -46,8 +46,8 @@ impl Tokenizer for CharFilterTokenizer {
     type TokenStream<'a> = CharFilterTokenStream<'a>;
 
     fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
-        let filtered = self.apply_char_filters(text);
-        self.filtered = filtered;
+        self.filtered = FilteredText::with_offset_mode("", self.offset_mode);
+        self.filtered = self.apply_char_filters(text);
 
         let filtered = &self.filtered;
         let tail = self.inner.token_stream(&filtered.text);

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/mod.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/mod.rs
@@ -1,3 +1,4 @@
+mod char_filter_tokenizer;
 mod char_group_tokenizer;
 mod grpc_tokenizer;
 mod icu_tokneizer;
@@ -8,6 +9,7 @@ mod ngram_tokenizer_with_chars;
 mod thai_tokenizer;
 mod tokenizer;
 
+pub use self::char_filter_tokenizer::CharFilterTokenizer;
 pub use self::char_group_tokenizer::CharGroupTokenizer;
 pub use self::grpc_tokenizer::GrpcTokenizer;
 pub use self::icu_tokneizer::IcuTokenizer;

--- a/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
@@ -81,3 +81,115 @@ fn test_mapping_char_filter_accepts_es_style_separator_padding() {
 
     assert!(!stream.advance());
 }
+
+#[test]
+fn test_mapping_char_filter_preserves_source_spans_when_expanding() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["ab=>x y"]
+            }
+        ],
+        "tokenizer": "standard"
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("ab");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "x");
+    assert_eq!(token.offset_from, 0);
+    assert_eq!(token.offset_to, 1);
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "y");
+    assert_eq!(token.offset_from, 1);
+    assert_eq!(token.offset_to, 2);
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_supports_escaped_whitespace() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["\\t=>\\ "]
+            }
+        ],
+        "tokenizer": {
+            "type": "char_group",
+            "delimiters": [" "]
+        }
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("foo\tbar");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "foo");
+    assert_eq!(token.offset_from, 0);
+    assert_eq!(token.offset_to, 3);
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "bar");
+    assert_eq!(token.offset_from, 4);
+    assert_eq!(token.offset_to, 7);
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_chain_composes_offsets() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["-=> and "]
+            },
+            {
+                "type": "mapping",
+                "mappings": [" and =>x"]
+            }
+        ],
+        "tokenizer": "standard",
+        "filter": ["lowercase"]
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("A-B");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "axb");
+    assert_eq!(token.offset_from, 0);
+    assert_eq!(token.offset_to, 3);
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_deletion_preserves_utf8_offsets() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["-=>"]
+            }
+        ],
+        "tokenizer": "standard"
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("中-文");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "中文");
+    assert_eq!(token.offset_from, 0);
+    assert_eq!(token.offset_to, 7);
+    assert!(!stream.advance());
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
@@ -1,0 +1,83 @@
+use tantivy::tokenizer::TokenStream;
+use tantivy_binding::analyzer::create_analyzer;
+
+#[test]
+fn test_mapping_char_filter_pipeline() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["-=> "]
+            }
+        ],
+        "tokenizer": "standard",
+        "filter": ["lowercase"]
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("FOO-BAR");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "foo");
+    assert_eq!(token.offset_from, 0);
+    assert_eq!(token.offset_to, 3);
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "bar");
+    assert_eq!(token.offset_from, 4);
+    assert_eq!(token.offset_to, 7);
+
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_expansion_offsets() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["&=>and"]
+            }
+        ],
+        "tokenizer": "standard",
+        "filter": ["lowercase"]
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("A&B");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "aandb");
+    assert_eq!(token.offset_from, 0);
+    assert_eq!(token.offset_to, 3);
+
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_accepts_es_style_separator_padding() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["& => and"]
+            }
+        ],
+        "tokenizer": "standard",
+        "filter": ["lowercase"]
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("A&B");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "aandb");
+    assert_eq!(token.offset_from, 0);
+    assert_eq!(token.offset_to, 3);
+
+    assert!(!stream.advance());
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
@@ -7,7 +7,7 @@ fn test_mapping_char_filter_pipeline() {
         "char_filter": [
             {
                 "type": "mapping",
-                "mappings": ["-=> "]
+                "mappings": ["-=>\\u0020"]
             }
         ],
         "tokenizer": "standard",
@@ -83,6 +83,102 @@ fn test_mapping_char_filter_accepts_es_style_separator_padding() {
 }
 
 #[test]
+fn test_mapping_char_filter_trims_each_mapping_side() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["a => b", "-=> "]
+            }
+        ],
+        "tokenizer": "standard"
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("a-");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "b");
+    assert_eq!((token.offset_from, token.offset_to), (0, 1));
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_supports_unicode_surrogate_pair_escape() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["\\ud83d\\ude00=>smile"]
+            }
+        ],
+        "tokenizer": "standard"
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("😀");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "smile");
+    assert_eq!((token.offset_from, token.offset_to), (0, 4));
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_rejects_invalid_unicode_escape() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["\\ud83d=>smile"]
+            }
+        ],
+        "tokenizer": "standard"
+    }"#;
+
+    assert!(create_analyzer(params, "").is_err());
+}
+
+#[test]
+fn test_mapping_char_filter_uses_last_unescaped_separator() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["a=>b=>c"]
+            }
+        ],
+        "tokenizer": "standard"
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("a=>b");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "c");
+    assert_eq!((token.offset_from, token.offset_to), (0, 4));
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_rejects_duplicate_source() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["a=>x", "\\u0061=>y"]
+            }
+        ],
+        "tokenizer": "standard"
+    }"#;
+
+    assert!(create_analyzer(params, "").is_err());
+}
+
+#[test]
 fn test_mapping_char_filter_preserves_source_spans_when_expanding() {
     let params = r#"{
         "char_filter": [
@@ -101,13 +197,96 @@ fn test_mapping_char_filter_preserves_source_spans_when_expanding() {
     let token = stream.token();
     assert_eq!(token.text, "x");
     assert_eq!(token.offset_from, 0);
-    assert_eq!(token.offset_to, 1);
+    assert_eq!(token.offset_to, 2);
 
     assert!(stream.advance());
     let token = stream.token();
     assert_eq!(token.text, "y");
-    assert_eq!(token.offset_from, 1);
+    assert_eq!(token.offset_from, 0);
     assert_eq!(token.offset_to, 2);
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_single_character_expansion_uses_full_source_span() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["a=>x y"]
+            }
+        ],
+        "tokenizer": "standard"
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("a");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "x");
+    assert_eq!((token.offset_from, token.offset_to), (0, 1));
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "y");
+    assert_eq!((token.offset_from, token.offset_to), (0, 1));
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_boundary_mode_preserves_character_boundaries() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["ab=>x y"]
+            }
+        ],
+        "char_filter_offset_mode": "boundary",
+        "tokenizer": "standard"
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("ab");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "x");
+    assert_eq!((token.offset_from, token.offset_to), (0, 1));
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "y");
+    assert_eq!((token.offset_from, token.offset_to), (1, 2));
+    assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_boundary_mode_returns_utf8_byte_offsets() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["中=>x y"]
+            }
+        ],
+        "char_filter_offset_mode": "boundary",
+        "tokenizer": "standard"
+    }"#;
+
+    let mut analyzer = create_analyzer(params, "").unwrap();
+    let mut stream = analyzer.token_stream("中");
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "x");
+    assert_eq!((token.offset_from, token.offset_to), (0, 0));
+
+    assert!(stream.advance());
+    let token = stream.token();
+    assert_eq!(token.text, "y");
+    assert_eq!((token.offset_from, token.offset_to), (0, 3));
     assert!(!stream.advance());
 }
 
@@ -117,7 +296,7 @@ fn test_mapping_char_filter_supports_escaped_whitespace() {
         "char_filter": [
             {
                 "type": "mapping",
-                "mappings": ["\\t=>\\ "]
+                "mappings": ["\\t=>\\u0020"]
             }
         ],
         "tokenizer": {
@@ -149,11 +328,11 @@ fn test_mapping_char_filter_chain_composes_offsets() {
         "char_filter": [
             {
                 "type": "mapping",
-                "mappings": ["-=> and "]
+                "mappings": ["-=>\\u0020and\\u0020"]
             },
             {
                 "type": "mapping",
-                "mappings": [" and =>x"]
+                "mappings": ["\\u0020and\\u0020=>x"]
             }
         ],
         "tokenizer": "standard",

--- a/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
@@ -142,7 +142,7 @@ fn test_mapping_char_filter_rejects_invalid_unicode_escape() {
 }
 
 #[test]
-fn test_mapping_char_filter_uses_last_unescaped_separator() {
+fn test_mapping_char_filter_uses_last_raw_separator() {
     let params = r#"{
         "char_filter": [
             {
@@ -161,6 +161,21 @@ fn test_mapping_char_filter_uses_last_unescaped_separator() {
     assert_eq!(token.text, "c");
     assert_eq!((token.offset_from, token.offset_to), (0, 4));
     assert!(!stream.advance());
+}
+
+#[test]
+fn test_mapping_char_filter_rejects_backslash_before_raw_separator() {
+    let params = r#"{
+        "char_filter": [
+            {
+                "type": "mapping",
+                "mappings": ["a=>b\\=>c"]
+            }
+        ],
+        "tokenizer": "standard"
+    }"#;
+
+    assert!(create_analyzer(params, "").is_err());
 }
 
 #[test]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/tests/char_filter.rs
@@ -142,6 +142,32 @@ fn test_mapping_char_filter_rejects_invalid_unicode_escape() {
 }
 
 #[test]
+fn test_mapping_char_filter_rejects_nul() {
+    let configs = [
+        r#"{
+            "char_filter": [{"type": "mapping", "mappings": ["a=>\u0000"]}],
+            "tokenizer": "standard"
+        }"#,
+        r#"{
+            "char_filter": [{"type": "mapping", "mappings": ["a=>\\u0000"]}],
+            "tokenizer": "standard"
+        }"#,
+    ];
+
+    for params in configs {
+        let error = create_analyzer(params, "")
+            .err()
+            .expect("NUL mapping should be rejected")
+            .to_string();
+        assert_eq!(
+            error,
+            "InvalidArgument: mapping char_filter does not support U+0000"
+        );
+        assert!(!error.contains('\0'));
+    }
+}
+
+#[test]
 fn test_mapping_char_filter_uses_last_raw_separator() {
     let params = r#"{
         "char_filter": [

--- a/internal/util/analyzer/canalyzer/c_analyzer_test.go
+++ b/internal/util/analyzer/canalyzer/c_analyzer_test.go
@@ -83,6 +83,24 @@ func TestAnalyzer(t *testing.T) {
 		assert.Equal(t, len(tokens), 3)
 	}
 
+	// use char_filter before tokenizer.
+	{
+		m := `{"char_filter": [{"type": "mapping", "mappings": ["& => and"]}], "tokenizer": "standard", "filter": ["lowercase"]}`
+		analyzer, err := NewAnalyzer(m, "")
+		require.NoError(t, err)
+		defer analyzer.Destroy()
+
+		tokenStream := analyzer.NewTokenStream("A&B")
+		defer tokenStream.Destroy()
+
+		require.True(t, tokenStream.Advance())
+		token := tokenStream.DetailedToken()
+		assert.Equal(t, "aandb", token.GetToken())
+		assert.Equal(t, int64(0), token.GetStartOffset())
+		assert.Equal(t, int64(3), token.GetEndOffset())
+		assert.False(t, tokenStream.Advance())
+	}
+
 	// jieba tokenizer.
 	{
 		m := "{\"tokenizer\": \"jieba\"}"
@@ -174,6 +192,28 @@ func TestValidateAnalyzer(t *testing.T) {
 	// invalid tokenizer
 	{
 		m := "{\"tokenizer\": \"invalid\"}"
+		_, err := ValidateAnalyzer(m, "")
+		assert.Error(t, err)
+	}
+
+	// valid char_filter
+	{
+		m := `{"char_filter": [{"type": "mapping", "mappings": ["& => and"]}], "tokenizer": "standard"}`
+		ids, err := ValidateAnalyzer(m, "")
+		assert.NoError(t, err)
+		assert.Equal(t, len(ids), 0)
+	}
+
+	// unsupported char_filter type
+	{
+		m := `{"char_filter": [{"type": "unsupported"}], "tokenizer": "standard"}`
+		_, err := ValidateAnalyzer(m, "")
+		assert.Error(t, err)
+	}
+
+	// char_filter is not supported with build-in analyzer type in the first version.
+	{
+		m := `{"type": "standard", "char_filter": []}`
 		_, err := ValidateAnalyzer(m, "")
 		assert.Error(t, err)
 	}

--- a/internal/util/analyzer/canalyzer/c_analyzer_test.go
+++ b/internal/util/analyzer/canalyzer/c_analyzer_test.go
@@ -101,6 +101,30 @@ func TestAnalyzer(t *testing.T) {
 		assert.False(t, tokenStream.Advance())
 	}
 
+	// preserve source spans when a mapping expands into multiple tokens.
+	{
+		m := `{"char_filter": [{"type": "mapping", "mappings": ["ab=>x y"]}], "tokenizer": "standard"}`
+		analyzer, err := NewAnalyzer(m, "")
+		require.NoError(t, err)
+		defer analyzer.Destroy()
+
+		tokenStream := analyzer.NewTokenStream("ab")
+		defer tokenStream.Destroy()
+
+		require.True(t, tokenStream.Advance())
+		token := tokenStream.DetailedToken()
+		assert.Equal(t, "x", token.GetToken())
+		assert.Equal(t, int64(0), token.GetStartOffset())
+		assert.Equal(t, int64(1), token.GetEndOffset())
+
+		require.True(t, tokenStream.Advance())
+		token = tokenStream.DetailedToken()
+		assert.Equal(t, "y", token.GetToken())
+		assert.Equal(t, int64(1), token.GetStartOffset())
+		assert.Equal(t, int64(2), token.GetEndOffset())
+		assert.False(t, tokenStream.Advance())
+	}
+
 	// jieba tokenizer.
 	{
 		m := "{\"tokenizer\": \"jieba\"}"

--- a/internal/util/analyzer/canalyzer/c_analyzer_test.go
+++ b/internal/util/analyzer/canalyzer/c_analyzer_test.go
@@ -115,6 +115,30 @@ func TestAnalyzer(t *testing.T) {
 		token := tokenStream.DetailedToken()
 		assert.Equal(t, "x", token.GetToken())
 		assert.Equal(t, int64(0), token.GetStartOffset())
+		assert.Equal(t, int64(2), token.GetEndOffset())
+
+		require.True(t, tokenStream.Advance())
+		token = tokenStream.DetailedToken()
+		assert.Equal(t, "y", token.GetToken())
+		assert.Equal(t, int64(0), token.GetStartOffset())
+		assert.Equal(t, int64(2), token.GetEndOffset())
+		assert.False(t, tokenStream.Advance())
+	}
+
+	// preserve character boundaries when boundary offset mode is requested.
+	{
+		m := `{"char_filter": [{"type": "mapping", "mappings": ["ab=>x y"]}], "char_filter_offset_mode": "boundary", "tokenizer": "standard"}`
+		analyzer, err := NewAnalyzer(m, "")
+		require.NoError(t, err)
+		defer analyzer.Destroy()
+
+		tokenStream := analyzer.NewTokenStream("ab")
+		defer tokenStream.Destroy()
+
+		require.True(t, tokenStream.Advance())
+		token := tokenStream.DetailedToken()
+		assert.Equal(t, "x", token.GetToken())
+		assert.Equal(t, int64(0), token.GetStartOffset())
 		assert.Equal(t, int64(1), token.GetEndOffset())
 
 		require.True(t, tokenStream.Advance())


### PR DESCRIPTION
relate: #51126

design: [Analyzer Char Filters](https://github.com/aoiasd/milvus/blob/char_filter/docs/design-docs/design_docs/20260824-analyzer-char-filter.md)

## Summary
Add analyzer-level `char_filter` support before tokenizer by wrapping configured tokenizers with a char-filter tokenizer. Implement the mapping char filter with original-text offset correction and add Rust/Go analyzer coverage for the new pipeline.