### PR TITLE
fix: skip non-materialized function output field on growing segment flush

### DIFF
--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1733,6 +1733,20 @@ class InsertRecordGrowing {
         return data_.find(field_id) != data_.end();
     }
 
+    // Field ids that have materialized columns. The exact set the flush
+    // layout must be trimmed to: non-materialized function outputs are
+    // absent here.
+    std::vector<int64_t>
+    get_data_field_ids() const {
+        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
+        std::vector<int64_t> ids;
+        ids.reserve(data_.size());
+        for (const auto& [field_id, _] : data_) {
+            ids.push_back(field_id.get());
+        }
+        return ids;
+    }
+
     bool
     is_valid_data_exist(FieldId field_id) const {
         std::shared_lock<std::shared_mutex> lck(field_map_mutex_);

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -1790,6 +1790,51 @@ BuildArrayForChunk(const FieldInfo& field_info,
 }  // anonymous namespace
 
 CStatus
+GetGrowingSegmentMaterializedFieldIDs(CSegmentInterface c_segment,
+                                      int64_t** field_ids,
+                                      int64_t* count) {
+    SCOPE_CGO_CALL_METRIC();
+
+    try {
+        if (!c_segment || !field_ids || !count) {
+            return milvus::FailureCStatus(
+                milvus::UnexpectedError,
+                "invalid arguments: segment, field_ids and count must not be "
+                "null");
+        }
+        *field_ids = nullptr;
+        *count = 0;
+        auto segment_interface =
+            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
+        auto growing_segment =
+            dynamic_cast<milvus::segcore::SegmentGrowingImpl*>(
+                segment_interface);
+        if (!growing_segment) {
+            return milvus::FailureCStatus(milvus::UnexpectedError,
+                                          "segment is not a growing segment");
+        }
+        auto ids = growing_segment->get_insert_record().get_data_field_ids();
+        if (!ids.empty()) {
+            auto* buf =
+                static_cast<int64_t*>(malloc(sizeof(int64_t) * ids.size()));
+            if (!buf) {
+                return milvus::FailureCStatus(
+                    milvus::UnexpectedError,
+                    "failed to allocate materialized field ids");
+            }
+            for (size_t i = 0; i < ids.size(); i++) {
+                buf[i] = ids[i];
+            }
+            *field_ids = buf;
+            *count = static_cast<int64_t>(ids.size());
+        }
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
 FlushGrowingSegmentData(CSegmentInterface c_segment,
                         int64_t start_offset,
                         int64_t end_offset,

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -1812,6 +1812,8 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         result->field_ids = nullptr;
         result->field_null_counts = nullptr;
         result->num_field_stats = 0;
+        result->flushed_field_ids = nullptr;
+        result->num_flushed_fields = 0;
         result->column_group_ids = nullptr;
         result->column_group_memory_sizes = nullptr;
         result->num_column_groups = 0;
@@ -1896,6 +1898,9 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         // to ensure deterministic column order matching the reader's expected order.
         std::vector<FieldInfo> field_infos;
         std::vector<std::shared_ptr<arrow::Field>> arrow_fields;
+        // Function-output columns skipped below; the column-group accounting
+        // loop must tolerate their absence as well.
+        std::unordered_set<int64_t> skipped_function_outputs;
 
         for (const auto& field_id : schema.get_field_ids()) {
             if (!allowed_field_ids.empty() &&
@@ -1913,6 +1918,29 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
             } else if (field_id == TimestampFieldID) {
                 vec_base = &insert_record.timestamps_;
             } else {
+                if (!insert_record.is_data_exist(field_id)) {
+                    // Segments born before the field was (re-)added never
+                    // materialize function-output columns (Reopen skips them
+                    // by design) — skip and let compaction backfill. Other
+                    // fields must exist once schema is synced to segment
+                    // level (#50704): error, not assert, to avoid
+                    // crash-looping the node.
+                    if (schema.is_function_output(field_id)) {
+                        LOG_INFO(
+                            "skip non-materialized function output field {} "
+                            "when flushing growing segment {}",
+                            field_id.get(),
+                            growing_segment->get_segment_id());
+                        skipped_function_outputs.insert(field_id.get());
+                        continue;
+                    }
+                    return milvus::FailureCStatus(
+                        milvus::UnexpectedError,
+                        fmt::format("non-function-output field {} has no "
+                                    "field data in growing segment {}",
+                                    field_id.get(),
+                                    growing_segment->get_segment_id()));
+                }
                 vec_base = insert_record.get_data_base(field_id);
                 if (!vec_base) {
                     LOG_ERROR("no data base for field {} of segment {}",
@@ -2001,6 +2029,20 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         if (field_infos.empty()) {
             return milvus::FailureCStatus(milvus::UnexpectedError,
                                           "no fields to flush");
+        }
+
+        // Publish the authoritative flushed-column set directly from
+        // field_infos; Go binlog meta must be derived from this.
+        result->flushed_field_ids =
+            static_cast<int64_t*>(malloc(sizeof(int64_t) * field_infos.size()));
+        if (!result->flushed_field_ids) {
+            return milvus::FailureCStatus(
+                milvus::UnexpectedError,
+                "failed to allocate flushed field ids");
+        }
+        result->num_flushed_fields = field_infos.size();
+        for (size_t i = 0; i < field_infos.size(); i++) {
+            result->flushed_field_ids[i] = field_infos[i].field_id.get();
         }
 
         auto arrow_schema = arrow::schema(arrow_fields);
@@ -2238,6 +2280,11 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                 for (size_t j = 0; j < field_count; j++) {
                     auto field_id =
                         config->column_group_field_ids[field_offset + j];
+                    if (skipped_function_outputs.count(field_id) > 0) {
+                        // Column intentionally not flushed; contributes no
+                        // size and must not fail the accounting.
+                        continue;
+                    }
                     auto size_it = field_uncompressed_sizes.find(field_id);
                     if (size_it == field_uncompressed_sizes.end()) {
                         return milvus::FailureCStatus(
@@ -2416,6 +2463,10 @@ FreeFlushResult(CFlushResult* result) {
     if (result && result->field_null_counts) {
         free(result->field_null_counts);
         result->field_null_counts = nullptr;
+    }
+    if (result && result->flushed_field_ids) {
+        free(result->flushed_field_ids);
+        result->flushed_field_ids = nullptr;
     }
     if (result && result->column_group_ids) {
         free(result->column_group_ids);

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -339,7 +339,11 @@ typedef struct CFlushResult {
     int64_t* field_ids;          // field ids for per-field flush summaries
     int64_t* field_null_counts;  // null count per field
     size_t num_field_stats;      // number of field summary entries
-    int64_t* column_group_ids;   // column group ids for binlog summaries
+    int64_t*
+        flushed_field_ids;  // exact set of columns actually written; skipped
+                            // non-materialized function outputs are absent
+    size_t num_flushed_fields;  // number of entries in flushed_field_ids
+    int64_t* column_group_ids;  // column group ids for binlog summaries
     int64_t*
         column_group_memory_sizes;  // uncompressed Arrow data size per column group
     size_t num_column_groups;       // number of column group summary entries

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -370,6 +370,16 @@ typedef struct CFlushResult {
  * @param result Output flush result (caller must free manifest_path)
  * @return CStatus indicating success or failure
  */
+/**
+ * @brief Get the field ids with materialized columns in a growing segment.
+ * The flush layout must be derived from this set. Caller frees *field_ids
+ * with free().
+ */
+CStatus
+GetGrowingSegmentMaterializedFieldIDs(CSegmentInterface c_segment,
+                                      int64_t** field_ids,
+                                      int64_t* count);
+
 CStatus
 FlushGrowingSegmentData(CSegmentInterface c_segment,
                         int64_t start_offset,

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -291,6 +291,15 @@ TEST_F(StorageTest, FlushGrowingSegmentSkipsNonMaterializedFunctionOutput) {
     config.retry_limit = 3;
     config.schema_blob = schema_blob.data();
     config.schema_length = static_cast<int64_t>(schema_blob.size());
+    // Column-group config still carrying the skipped function output: the
+    // accounting loop must tolerate its absence instead of failing the flush.
+    int64_t column_group_ids[] = {0};
+    int64_t column_group_field_ids[] = {0, 1, 100, 101};
+    size_t column_group_field_counts[] = {4};
+    config.column_group_ids = column_group_ids;
+    config.column_group_field_ids = column_group_field_ids;
+    config.column_group_field_counts = column_group_field_counts;
+    config.num_column_groups = 1;
 
     CFlushResult result{};
     auto status =
@@ -298,8 +307,12 @@ TEST_F(StorageTest, FlushGrowingSegmentSkipsNonMaterializedFunctionOutput) {
 
     ASSERT_EQ(status.error_code, Success) << status.error_msg;
     ASSERT_EQ(result.num_rows, N);
+    ASSERT_EQ(result.num_column_groups, 1u);
     for (size_t i = 0; i < result.num_field_stats; ++i) {
         EXPECT_NE(result.field_ids[i], 101);
+    }
+    for (size_t i = 0; i < result.num_flushed_fields; ++i) {
+        EXPECT_NE(result.flushed_field_ids[i], 101);
     }
 
     FreeFlushResult(&result);

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -219,6 +219,155 @@ TEST_F(StorageTest, TextFieldDataFromManifestResolvesLobRefs) {
     cleanup();
 }
 
+// A growing segment born while a function output field was absent from the
+// schema (add/drop-function churn) never materializes that column —
+// Reopen/FillAbsentFields skip function outputs by design. Flushing with a
+// newer schema that carries the field must skip the column instead of
+// hitting the insert_record assert (issue #51117).
+TEST_F(StorageTest, FlushGrowingSegmentSkipsNonMaterializedFunctionOutput) {
+    std::string test_dir =
+        "/tmp/flush_skip_fn_output_" +
+        std::to_string(
+            std::chrono::system_clock::now().time_since_epoch().count());
+    std::filesystem::create_directories(test_dir);
+    auto cleanup = [&]() {
+        if (std::filesystem::exists(test_dir)) {
+            std::filesystem::remove_all(test_dir);
+        }
+    };
+
+    milvus::proto::schema::CollectionSchema schema_proto;
+    schema_proto.set_name("flush_skip_fn_output");
+    // Real flush schemas always carry the RowID/Timestamp system fields;
+    // the flush validates the Timestamp column was exported.
+    auto* row_id_field = schema_proto.add_fields();
+    row_id_field->set_fieldid(0);
+    row_id_field->set_name("RowID");
+    row_id_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* ts_field = schema_proto.add_fields();
+    ts_field->set_fieldid(1);
+    ts_field->set_name("Timestamp");
+    ts_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+
+    auto segment_schema = Schema::ParseFrom(schema_proto);
+    auto segment = CreateGrowingSegment(segment_schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    constexpr int N = 3;
+    std::vector<int64_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {10, 11, 12};
+    std::vector<int64_t> pks = {100, 101, 102};
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(N);
+    insert_data->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(
+            pks.data(), nullptr, N, (*segment_schema)[FieldId(100)])
+            .release());
+
+    segment->PreInsert(N);
+    segment->Insert(0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    // Flush schema carries a function output field the segment never
+    // materialized.
+    auto flush_proto = schema_proto;
+    auto* fn_output = flush_proto.add_fields();
+    fn_output->set_fieldid(101);
+    fn_output->set_name("fn_sparse");
+    fn_output->set_data_type(
+        milvus::proto::schema::DataType::SparseFloatVector);
+    fn_output->set_is_function_output(true);
+    std::string schema_blob = flush_proto.SerializeAsString();
+
+    CFlushConfig config{};
+    std::string segment_path = test_dir + "/collection/partition/segment_fn";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.schema_blob = schema_blob.data();
+    config.schema_length = static_cast<int64_t>(schema_blob.size());
+
+    CFlushResult result{};
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(result.num_rows, N);
+    for (size_t i = 0; i < result.num_field_stats; ++i) {
+        EXPECT_NE(result.field_ids[i], 101);
+    }
+
+    FreeFlushResult(&result);
+    cleanup();
+}
+
+// A missing non-function-output column is an invariant violation (regular
+// fields are materialized by the ctor/Reopen): the flush must fail with a
+// clean error instead of the segcore assert.
+TEST_F(StorageTest, FlushGrowingSegmentMissingRegularFieldFails) {
+    milvus::proto::schema::CollectionSchema schema_proto;
+    schema_proto.set_name("flush_missing_regular_field");
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+
+    auto segment_schema = Schema::ParseFrom(schema_proto);
+    auto segment = CreateGrowingSegment(segment_schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    constexpr int N = 3;
+    std::vector<int64_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {10, 11, 12};
+    std::vector<int64_t> pks = {100, 101, 102};
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(N);
+    insert_data->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(
+            pks.data(), nullptr, N, (*segment_schema)[FieldId(100)])
+            .release());
+
+    segment->PreInsert(N);
+    segment->Insert(0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    auto flush_proto = schema_proto;
+    auto* extra = flush_proto.add_fields();
+    extra->set_fieldid(101);
+    extra->set_name("late_added");
+    extra->set_data_type(milvus::proto::schema::DataType::VarChar);
+    extra->set_nullable(true);
+    auto* param = extra->add_type_params();
+    param->set_key("max_length");
+    param->set_value("64");
+    std::string schema_blob = flush_proto.SerializeAsString();
+
+    CFlushConfig config{};
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.schema_blob = schema_blob.data();
+    config.schema_length = static_cast<int64_t>(schema_blob.size());
+
+    CFlushResult result{};
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+
+    ASSERT_NE(status.error_code, Success);
+    std::string msg = status.error_msg == nullptr ? "" : status.error_msg;
+    EXPECT_NE(msg.find("has no field data in growing segment"),
+              std::string::npos)
+        << msg;
+
+    FreeErrorStatus(status);
+    FreeFlushResult(&result);
+}
+
 TEST_F(StorageTest, GetLocalUsedSize) {
     int64_t size = 0;
     auto lcm = LocalChunkManagerSingleton::GetInstance().GetChunkManager();

--- a/internal/flushcommon/syncmgr/growing_source.go
+++ b/internal/flushcommon/syncmgr/growing_source.go
@@ -71,10 +71,16 @@ type GrowingFlushConfig struct {
 }
 
 type GrowingFlushResult struct {
-	ManifestPath           string
-	NumRows                int64
-	TimestampFrom          uint64
-	TimestampTo            uint64
+	ManifestPath  string
+	NumRows       int64
+	TimestampFrom uint64
+	TimestampTo   uint64
+	// FlushedFieldIDs is the authoritative set of columns the flush actually
+	// wrote. It may be a subset of the flush schema: non-materialized
+	// function-output columns are skipped (backfilled later by bump-schema
+	// compaction). All binlog meta must be derived from this set, never from
+	// the schema.
+	FlushedFieldIDs        []int64
 	ColumnGroupMemorySizes map[int64]int64
 	FieldNullCounts        map[int64]int64
 	BM25Stats              map[int64]*storage.BM25Stats
@@ -839,6 +845,24 @@ func buildGrowingSourceInsertBinlogs(columnGroups []storagecommon.ColumnGroup, r
 	logIDByGroup := make(map[int64]int64, len(columnGroups))
 	for i, columnGroup := range columnGroups {
 		logIDByGroup[columnGroup.GroupID] = logIDs[i]
+	}
+	// result.FlushedFieldIDs is the authoritative set of columns actually
+	// written; the flush skips non-materialized function-output columns, so
+	// the binlog meta must be trimmed to it. A group left empty is dropped.
+	if len(result.FlushedFieldIDs) > 0 {
+		flushedSet := typeutil.NewSet(result.FlushedFieldIDs...)
+		flushedGroups := make([]storagecommon.ColumnGroup, 0, len(columnGroups))
+		for _, columnGroup := range columnGroups {
+			flushedFields := lo.Filter(columnGroup.Fields, func(fieldID int64, _ int) bool {
+				return flushedSet.Contain(fieldID)
+			})
+			if len(flushedFields) == 0 {
+				continue
+			}
+			columnGroup.Fields = flushedFields
+			flushedGroups = append(flushedGroups, columnGroup)
+		}
+		columnGroups = flushedGroups
 	}
 	for _, columnGroup := range columnGroups {
 		if _, ok := result.ColumnGroupMemorySizes[columnGroup.GroupID]; !ok {

--- a/internal/flushcommon/syncmgr/growing_source.go
+++ b/internal/flushcommon/syncmgr/growing_source.go
@@ -88,6 +88,11 @@ type GrowingFlushResult struct {
 
 type GrowingFlushSource interface {
 	CurrentOffset() int64
+	// MaterializedFieldIDs returns the field ids with materialized columns in
+	// the source segment. The flush layout must be trimmed to this set;
+	// non-materialized function-output columns are absent from it. An empty
+	// result means the source cannot report and no trimming is applied.
+	MaterializedFieldIDs(ctx context.Context) ([]int64, error)
 	FlushGrowingData(ctx context.Context, startOffset, endOffset int64, config *GrowingFlushConfig) (*GrowingFlushResult, error)
 	Release()
 }
@@ -580,6 +585,13 @@ func (t *GrowingSourceSyncTask) Run(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	// Unification point: from here on the intended layout and the layout the
+	// flush actually writes are one. Every consumer below (writer config,
+	// binlog meta, metacache current split) sees the same trimmed groups.
+	columnGroups, err = t.trimColumnGroupsToMaterialized(ctx, columnGroups)
+	if err != nil {
+		return err
+	}
 	if t.committedManifestPath != "" {
 		t.manifestPath = t.committedManifestPath
 		t.bm25Stats = t.committedBM25Stats
@@ -676,6 +688,58 @@ func (t *GrowingSourceSyncTask) getColumnGroups(segment *metacache.SegmentInfo) 
 	return resolveColumnGroups(segment, t.schema, t.segmentID, func() map[int64]storagecommon.ColumnStats {
 		return map[int64]storagecommon.ColumnStats{}
 	}), nil
+}
+
+// trimColumnGroupsToMaterialized drops non-materialized function-output
+// fields from the flush layout: their columns are recomputable and are
+// backfilled by bump-schema compaction after flush. Non-function-output
+// fields are never dropped here — a missing one is source data and the C++
+// flush fails loudly on it. A group left empty is dropped entirely. When the
+// source cannot report materialized fields the layout is kept unchanged.
+func (t *GrowingSourceSyncTask) trimColumnGroupsToMaterialized(ctx context.Context, columnGroups []storagecommon.ColumnGroup) ([]storagecommon.ColumnGroup, error) {
+	if t.source == nil || t.schema == nil || len(columnGroups) == 0 {
+		return columnGroups, nil
+	}
+	functionOutputs := typeutil.NewSet[int64]()
+	for _, field := range typeutil.GetAllFieldSchemas(t.schema) {
+		if field.GetIsFunctionOutput() {
+			functionOutputs.Insert(field.GetFieldID())
+		}
+	}
+	if functionOutputs.Len() == 0 {
+		return columnGroups, nil
+	}
+	materialized, err := t.source.MaterializedFieldIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(materialized) == 0 {
+		return columnGroups, nil
+	}
+	materializedSet := typeutil.NewSet(materialized...)
+	skipped := make([]int64, 0)
+	trimmed := make([]storagecommon.ColumnGroup, 0, len(columnGroups))
+	for _, columnGroup := range columnGroups {
+		fields := make([]int64, 0, len(columnGroup.Fields))
+		for _, fieldID := range columnGroup.Fields {
+			if functionOutputs.Contain(fieldID) && !materializedSet.Contain(fieldID) {
+				skipped = append(skipped, fieldID)
+				continue
+			}
+			fields = append(fields, fieldID)
+		}
+		if len(fields) == 0 {
+			continue
+		}
+		columnGroup.Fields = fields
+		trimmed = append(trimmed, columnGroup)
+	}
+	if len(skipped) > 0 {
+		mlog.Info(ctx, "exclude non-materialized function output fields from growing flush layout",
+			mlog.Int64("segmentID", t.segmentID),
+			mlog.Int64s("fieldIDs", skipped))
+	}
+	return trimmed, nil
 }
 
 func (t *GrowingSourceSyncTask) schemaBasedPattern(columnGroups []storagecommon.ColumnGroup) (string, error) {

--- a/internal/flushcommon/syncmgr/growing_source_test.go
+++ b/internal/flushcommon/syncmgr/growing_source_test.go
@@ -50,6 +50,10 @@ type fakeCommitGrowingFlushSource struct {
 	commits []int64
 }
 
+func (s *fakeCommitGrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	return nil, nil
+}
+
 func (s *fakeCommitGrowingFlushSource) CurrentOffset() int64 {
 	return 10
 }
@@ -508,6 +512,10 @@ type fakeBM25GrowingFlushSource struct {
 	stats map[int64]*storage.BM25Stats
 }
 
+func (s *fakeBM25GrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	return nil, nil
+}
+
 func (s *fakeBM25GrowingFlushSource) CurrentOffset() int64 {
 	return 10
 }
@@ -580,4 +588,82 @@ func TestGrowingSourceSyncTaskMergesReturnedBM25Stats(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1, restored.NumRow())
 	require.EqualValues(t, 2, restored.NumToken())
+}
+
+type fakeMaterializedGrowingFlushSource struct {
+	materialized []int64
+}
+
+func (s *fakeMaterializedGrowingFlushSource) CurrentOffset() int64 { return 0 }
+
+func (s *fakeMaterializedGrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	return s.materialized, nil
+}
+
+func (s *fakeMaterializedGrowingFlushSource) FlushGrowingData(ctx context.Context, startOffset, endOffset int64, config *GrowingFlushConfig) (*GrowingFlushResult, error) {
+	return nil, nil
+}
+
+func (s *fakeMaterializedGrowingFlushSource) Release() {}
+
+func TestTrimColumnGroupsToMaterialized(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 102, Name: "fn_sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		},
+	}
+	groups := []storagecommon.ColumnGroup{
+		{GroupID: 0, Fields: []int64{0, 1, 100, 101, 102}},
+		{GroupID: 1, Fields: []int64{102}},
+	}
+
+	// A non-materialized function output is dropped; a group left empty vanishes.
+	task := NewGrowingSourceSyncTask().WithSchema(schema).
+		WithSource(&fakeMaterializedGrowingFlushSource{materialized: []int64{0, 1, 100, 101}})
+	trimmed, err := task.trimColumnGroupsToMaterialized(context.Background(), groups)
+	require.NoError(t, err)
+	require.Len(t, trimmed, 1)
+	require.Equal(t, []int64{0, 1, 100, 101}, trimmed[0].Fields)
+
+	// A materialized function output is kept.
+	task = NewGrowingSourceSyncTask().WithSchema(schema).
+		WithSource(&fakeMaterializedGrowingFlushSource{materialized: []int64{0, 1, 100, 101, 102}})
+	trimmed, err = task.trimColumnGroupsToMaterialized(context.Background(), groups)
+	require.NoError(t, err)
+	require.Len(t, trimmed, 2)
+
+	// Non-function-output fields are never dropped even when absent from the
+	// materialized set; the C++ flush guards them loudly instead.
+	task = NewGrowingSourceSyncTask().WithSchema(schema).
+		WithSource(&fakeMaterializedGrowingFlushSource{materialized: []int64{100}})
+	trimmed, err = task.trimColumnGroupsToMaterialized(context.Background(), groups)
+	require.NoError(t, err)
+	require.Len(t, trimmed, 1)
+	require.Equal(t, []int64{0, 1, 100, 101}, trimmed[0].Fields)
+
+	// Unknown materialized set keeps the layout unchanged.
+	task = NewGrowingSourceSyncTask().WithSchema(schema).
+		WithSource(&fakeMaterializedGrowingFlushSource{})
+	trimmed, err = task.trimColumnGroupsToMaterialized(context.Background(), groups)
+	require.NoError(t, err)
+	require.Len(t, trimmed, 2)
+}
+
+func TestBuildGrowingSourceInsertBinlogsTrimsToFlushedFields(t *testing.T) {
+	groups := []storagecommon.ColumnGroup{
+		{GroupID: 0, Fields: []int64{0, 1, 100, 102}},
+		{GroupID: 5, Fields: []int64{102}},
+	}
+	result := &GrowingFlushResult{
+		NumRows:                3,
+		FlushedFieldIDs:        []int64{0, 1, 100},
+		ColumnGroupMemorySizes: map[int64]int64{0: 10, 5: 0},
+		FieldNullCounts:        map[int64]int64{0: 0, 1: 0, 100: 0},
+	}
+	binlogs, err := buildGrowingSourceInsertBinlogs(groups, result, []int64{7, 8})
+	require.NoError(t, err)
+	require.Len(t, binlogs, 1)
+	require.Equal(t, []int64{0, 1, 100}, binlogs[0].GetChildFields())
 }

--- a/internal/flushcommon/writebuffer/l0_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer_test.go
@@ -56,6 +56,10 @@ func (s fakeGrowingFlushSource) CurrentOffset() int64 {
 	return 10
 }
 
+func (s fakeGrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	return nil, nil
+}
+
 func (s fakeGrowingFlushSource) FlushGrowingData(ctx context.Context, startOffset, endOffset int64, config *syncmgr.GrowingFlushConfig) (*syncmgr.GrowingFlushResult, error) {
 	if s.flushFunc != nil {
 		return s.flushFunc(ctx, startOffset, endOffset, config)

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -573,6 +573,7 @@ func (s *delegatorGrowingFlushSource) FlushGrowingData(ctx context.Context, star
 		NumRows:                result.NumRows,
 		TimestampFrom:          result.TimestampFrom,
 		TimestampTo:            result.TimestampTo,
+		FlushedFieldIDs:        result.FlushedFieldIDs,
 		ColumnGroupMemorySizes: result.ColumnGroupMemorySizes,
 		FieldNullCounts:        result.FieldNullCounts,
 		BM25Stats:              result.BM25Stats,

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -580,6 +580,20 @@ func (s *delegatorGrowingFlushSource) FlushGrowingData(ctx context.Context, star
 	}, nil
 }
 
+// materializedFieldIDsProvider is the capability a source segment must expose
+// for the flush layout to be trimmed to its materialized columns.
+type materializedFieldIDsProvider interface {
+	MaterializedFieldIDs(ctx context.Context) ([]int64, error)
+}
+
+func (s *delegatorGrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	provider, ok := s.segment.(materializedFieldIDsProvider)
+	if !ok {
+		return nil, merr.WrapErrServiceInternalMsg("growing flush source segment does not expose materialized field ids")
+	}
+	return provider.MaterializedFieldIDs(ctx)
+}
+
 func (s *delegatorGrowingFlushSource) Release() {
 	s.once.Do(func() {
 		if s.segment != nil {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1851,6 +1851,13 @@ func (s *LocalSegment) FlushData(ctx context.Context, startOffset, endOffset int
 			fieldNullCounts[fieldID] = int64(nullCounts[i])
 		}
 	}
+	flushedFieldIDs := make([]int64, 0, int(cResult.num_flushed_fields))
+	if cResult.num_flushed_fields > 0 {
+		ids := unsafe.Slice(cResult.flushed_field_ids, int(cResult.num_flushed_fields))
+		for i := 0; i < int(cResult.num_flushed_fields); i++ {
+			flushedFieldIDs = append(flushedFieldIDs, int64(ids[i]))
+		}
+	}
 	columnGroupMemorySizes := make(map[int64]int64, int(cResult.num_column_groups))
 	if cResult.num_column_groups > 0 {
 		columnGroupIDs := unsafe.Slice(cResult.column_group_ids, int(cResult.num_column_groups))
@@ -1879,6 +1886,7 @@ func (s *LocalSegment) FlushData(ctx context.Context, startOffset, endOffset int
 		NumRows:                int64(cResult.num_rows),
 		TimestampFrom:          uint64(cResult.timestamp_from),
 		TimestampTo:            uint64(cResult.timestamp_to),
+		FlushedFieldIDs:        flushedFieldIDs,
 		ColumnGroupMemorySizes: columnGroupMemorySizes,
 		FieldNullCounts:        fieldNullCounts,
 		BM25Stats:              bm25Stats,

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1642,6 +1642,39 @@ func (s *LocalSegment) GetFieldJSONIndexStats() map[int64]*querypb.JsonStatsInfo
 	return stats
 }
 
+// MaterializedFieldIDs returns the field ids with materialized columns in the
+// growing segment's insert record. Non-materialized function-output columns
+// are absent; the flush layout must be trimmed to this set.
+func (s *LocalSegment) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	if s.Type() != SegmentTypeGrowing {
+		return nil, merr.WrapErrServiceInternalMsg("unexpected segmentType for MaterializedFieldIDs, segmentType = %s", s.segmentType.String())
+	}
+	if !s.ptrLock.PinIf(state.IsNotReleased) {
+		return nil, merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
+	}
+	defer s.ptrLock.Unpin()
+
+	var cIDs *C.int64_t
+	var cCount C.int64_t
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		status = C.GetGrowingSegmentMaterializedFieldIDs(s.ptr, &cIDs, &cCount)
+		return nil, nil
+	}).Await()
+	if err := HandleCStatus(ctx, &status, "GetGrowingSegmentMaterializedFieldIDs"); err != nil {
+		return nil, err
+	}
+	if cIDs == nil || cCount == 0 {
+		return nil, nil
+	}
+	defer C.free(unsafe.Pointer(cIDs))
+	ids := make([]int64, 0, int(cCount))
+	for _, id := range unsafe.Slice(cIDs, int(cCount)) {
+		ids = append(ids, int64(id))
+	}
+	return ids, nil
+}
+
 // FlushData flushes data from the growing segment directly to storage via C++ milvus-storage.
 // This is a unified interface that combines data extraction from segcore and writing to storage.
 // The C++ side handles: extracting raw field data from ConcurrentVector, converting to Arrow,

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -203,9 +203,12 @@ type FlushResult struct {
 	// via packed.UnmarshalManifestPath when needed.
 	ManifestPath string
 	// Number of rows flushed
-	NumRows                int64
-	TimestampFrom          uint64
-	TimestampTo            uint64
+	NumRows       int64
+	TimestampFrom uint64
+	TimestampTo   uint64
+	// FlushedFieldIDs is the authoritative set of columns the flush actually
+	// wrote; non-materialized function-output columns are skipped and absent.
+	FlushedFieldIDs        []int64
 	ColumnGroupMemorySizes map[int64]int64
 	FieldNullCounts        map[int64]int64
 	BM25Stats              map[int64]*storage.BM25Stats


### PR DESCRIPTION
issue: #51117
companion pr: #50704

## Root cause

A growing segment created while a function output field was absent from the schema (the schema-evolution stress workload repeatedly `add_function_field` / `drop_function_field`, so segments are born inside drop windows) never materializes that column:

- the `InsertRecord` ctor only allocates columns for fields present at creation;
- `Reopen` / `FillAbsentFields` skip function outputs **by design** — their data must be recomputed from the input field, not zero-filled.

When such a segment is flushed with a newer schema that carries the re-added output field, `FlushGrowingSegmentData` hit
`Assert "data_.find(field_id) != data_.end()"` in `InsertRecord.h` and crash-looped the StreamingNode (exit 134), as reported in #51117.

## Fix

In `FlushGrowingSegmentData`, when a field in the flush schema has no materialized column:

- **function output field** → log and skip the column; the flushed segment lands without it, so `existingFields` at compaction correctly reports it missing and the bump-schema compaction backfills it via `RecordMaterializer` (the pre-existing contract). Zero-filling instead would poison `existingFields` and permanently suppress the backfill.
- **any other field** → return an error instead of asserting. Regular added fields are materialized by the ctor/`Reopen` once schema updates are synced down to segment level (companion PR #50704), so a missing one is a real invariant violation; a persistent condition behind an assert would deterministically crash-loop the whole node.

## Tests

- `StorageTest.FlushGrowingSegmentSkipsNonMaterializedFunctionOutput`: segment born without the function output field, flushed with a schema carrying it — must succeed and the flushed field stats must not contain the skipped field.
- `StorageTest.FlushGrowingSegmentMissingRegularFieldFails`: same shape with a regular late-added field — must fail with the clean guard error, not the segcore assert.

## Notes

- Depends on #50704 for the "non-function-output columns always exist" invariant; without it the error branch can also be reached by a never-queried segment whose lazy Reopen has not run, which fails the flush loudly instead of panicking inside segcore.
- Interaction with incremental growing-source flush layouts (existing manifest vs. new schema-based column groups) is exercised by CI; not verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)