### PR TITLE
enhance: [2.6] update knowhere version

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION v2.6.16 )
+set( KNOWHERE_VERSION v2.6.17 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
issue: #42937

/kind branch-feature

## Summary
- Update Knowhere dependency from `v2.6.16` to `v2.6.17`.
- Uses the Knowhere `v2.6.17` tag from the 2.6 branch: https://github.com/zilliztech/knowhere/tree/v2.6.17

## Changes included in v2.6.17 (since v2.6.16)
- fix: default ef in GPU_CAGRA CheckAndAdjust to prevent bad_optional_access (knowhere #1707)
- enhance: update cardinalv1 version for 2.6 (knowhere #1706)

> Note: this is a 2.6-branch-specific dependency bump; knowhere 2.6 is not tracked on milvus master (master follows knowhere v3.x), so there is no corresponding master PR.