### PR TITLE
enhance: carry TEXT LOB refs through schema-bump full-rewrite compaction (#51125)

### DIFF
--- a/internal/compaction/lob_compaction.go
+++ b/internal/compaction/lob_compaction.go
@@ -44,6 +44,9 @@ const (
 // forced strategies:
 //   - clustering compaction: always REWRITE_ALL (data is repartitioned)
 //   - sort compaction: always REUSE_ALL (row order changes but same data)
+//   - schema-bump compaction: always REUSE_ALL (1->1, only materializes a new
+//     non-LOB output column + bumps schema version; existing TEXT LOB data is
+//     unchanged, so its refs are carried as-is — never REWRITE_ALL)
 //   - mix compaction with multiple outputs (N->M, M>1): always REWRITE_ALL
 //     (LOB refs cannot be duplicated across output manifests without inflating ValidRows)
 //   - L0 delete compaction: always SKIP (only applies delete logs, segment LOB refs unchanged)
@@ -55,6 +58,9 @@ func GetForcedStrategy(compactionType datapb.CompactionType, sourceSegmentCount,
 
 	case datapb.CompactionType_SortCompaction,
 		datapb.CompactionType_PartitionKeySortCompaction:
+		return LOBStrategyReuseAll, true
+
+	case datapb.CompactionType_BumpSchemaVersionCompaction:
 		return LOBStrategyReuseAll, true
 
 	case datapb.CompactionType_MixCompaction:

--- a/internal/compaction/lob_compaction_test.go
+++ b/internal/compaction/lob_compaction_test.go
@@ -77,6 +77,14 @@ func TestGetForcedStrategy_AllTypes(t *testing.T) {
 			sourceCount: 1, targetCount: 1,
 			wantStrategy: 0, wantForced: false,
 		},
+		{
+			// schema-bump is 1->1 and never changes existing TEXT LOB data, so it
+			// must force REUSE_ALL (never fall through to hole-ratio REWRITE_ALL).
+			name:        "schema bump compaction",
+			compType:    datapb.CompactionType_BumpSchemaVersionCompaction,
+			sourceCount: 1, targetCount: 1,
+			wantStrategy: LOBStrategyReuseAll, wantForced: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -56,6 +56,11 @@ type bumpSchemaVersionCompactionTask struct {
 	logIDAlloc       allocator.Interface
 	chunkManager     storage.ChunkManager
 	currentTime      time.Time
+	// lobContext holds LOB (TEXT) compaction strategy decisions for the full-rewrite
+	// path. A schema bump is 1->1 and never changes existing TEXT LOB data, so it
+	// always uses REUSE_ALL: the existing LOB files are unchanged and only their
+	// references are merged into the output manifest (mirrors sort compaction).
+	lobContext *compaction.LOBCompactionContext
 }
 
 func (t *bumpSchemaVersionCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
@@ -449,8 +454,29 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 	}
 	defer materializer.Close()
 
+	// Prepare LOB (TEXT) handling: a schema bump keeps existing TEXT LOB data
+	// unchanged, so REUSE_ALL — the writer preserves the encoded LOB reference
+	// bytes (WithTextRefsAsBinary) and the source LOB files are merged into the
+	// output manifest afterwards (applyLOBCompaction). Mirrors sort compaction.
+	if err := t.initLOBCompactionContext(t.ctx); err != nil {
+		return nil, err
+	}
+
 	alloc := allocator.NewLocalAllocator(t.plan.GetPreAllocatedLogIDs().GetBegin(), t.plan.GetPreAllocatedLogIDs().GetEnd())
-	// TODO(#50021): Support full TEXT LOB rewrite for schema-bump compaction.
+	writerOpts := []storage.RwOption{
+		storage.WithUploader(func(ctx context.Context, kvs map[string][]byte) error {
+			return t.chunkManager.MultiWrite(ctx, kvs)
+		}),
+		storage.WithVersion(segment.GetStorageVersion()),
+		storage.WithStorageConfig(t.compactionParams.StorageConfig),
+		storage.WithCollectionID(collectionID),
+		storage.WithUseLoonFFI(t.compactionParams.UseLoonFFI),
+	}
+	if t.lobContext != nil && t.lobContext.HasReuseAllFields() {
+		// Existing TEXT columns arrive from the reader as encoded binary LOB refs;
+		// tell the writer to write them via the physical binary schema unchanged.
+		writerOpts = append(writerOpts, storage.WithTextRefsAsBinary())
+	}
 	writer, err := storage.NewBinlogRecordWriter(t.ctx,
 		collectionID,
 		segment.GetPartitionID(),
@@ -459,13 +485,7 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		alloc,
 		t.compactionParams.BinLogMaxSize,
 		t.plan.GetTotalRows(),
-		storage.WithUploader(func(ctx context.Context, kvs map[string][]byte) error {
-			return t.chunkManager.MultiWrite(ctx, kvs)
-		}),
-		storage.WithVersion(segment.GetStorageVersion()),
-		storage.WithStorageConfig(t.compactionParams.StorageConfig),
-		storage.WithCollectionID(collectionID),
-		storage.WithUseLoonFFI(t.compactionParams.UseLoonFFI),
+		writerOpts...,
 	)
 	if err != nil {
 		return nil, err
@@ -529,6 +549,18 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		return nil, err
 	}
 	writerClosed = true
+
+	// Update per-LOB-file valid_rows for REUSE_ALL fields: rows dropped by
+	// delete/TTL during the rewrite reduce the number of live LOB references.
+	if t.lobContext != nil && t.lobContext.HasReuseAllFields() {
+		inputRows := t.plan.GetTotalRows()
+		deletedRows := inputRows - totalRows
+		if deletedRows < 0 {
+			deletedRows = 0
+		}
+		t.lobContext.SetSegmentRowStats(segment.GetSegmentID(), inputRows, deletedRows)
+	}
+
 	insertLogs, statsLog, bm25StatsLogs, manifestPath, expirQuantiles := writer.GetLogs()
 	if totalRows > 0 && manifestPath == "" {
 		return nil, merr.WrapErrServiceInternal("schema bump full rewrite produced empty manifest")
@@ -565,6 +597,18 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		IsSorted:            segment.GetIsSorted(),
 		IsSortedByNamespace: segment.GetIsSortedByNamespace(),
 	}
+
+	// Merge the source segment's TEXT LOB file references into the output manifest
+	// (REUSE_ALL) BEFORE building the text-match index. createTextIndex reads the TEXT
+	// column through this manifest, so the carried LOB files must already be referenced
+	// -- otherwise the match index for an out-of-line (>=64KB) TEXT field is built against
+	// a manifest that does not yet list those LOB files, silently missing that data.
+	// Mirrors sort/mix (applyLOBCompaction before createTextIndex); AddStatsToManifest
+	// below then chains its text stats onto the LOB-merged manifest.
+	if err := t.applyLOBCompaction(t.ctx, resultSegment); err != nil {
+		return nil, err
+	}
+
 	if totalRows > 0 {
 		// Text stats are built explicitly, matching sort compaction.
 		textStatsLogs, err := createTextIndex(t.ctx, t.chunkManager, t.plan, t.compactionParams, segment.GetStorageVersion(), collectionID, segment.GetPartitionID(), newSegmentID, t.plan.GetPlanID(), resultSegment)
@@ -597,6 +641,67 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		Segments: []*datapb.CompactionSegment{resultSegment},
 		Type:     t.plan.GetType(),
 	}, nil
+}
+
+// initLOBCompactionContext prepares REUSE_ALL LOB handling for the (single) input
+// segment's TEXT columns. A schema bump is 1->1 and never changes existing TEXT LOB
+// data, so all TEXT fields are forced REUSE_ALL (GetForcedStrategy): the source LOB
+// files stay in place and only their references are merged into the output manifest.
+// No-op when the schema has no TEXT fields. Mirrors sort compaction.
+func (t *bumpSchemaVersionCompactionTask) initLOBCompactionContext(ctx context.Context) error {
+	textFieldIDs := compaction.GetTEXTFieldIDsFromSchema(t.plan.GetSchema())
+	if len(textFieldIDs) == 0 {
+		return nil
+	}
+
+	// preCompact already guarantees a StorageV3 segment with a non-empty manifest,
+	// and this only runs from runFullSchemaRewrite (after preCompact), so no manifest guard.
+	segment := t.plan.GetSegmentBinlogs()[0]
+	sourceManifests := map[int64]string{segment.GetSegmentID(): segment.GetManifest()}
+	lobFilesBySegment, err := compaction.CollectLobFilesFromManifests(sourceManifests, t.compactionParams.StorageConfig)
+	if err != nil {
+		return err
+	}
+
+	t.lobContext = compaction.NewLOBCompactionContext()
+	for segID, files := range lobFilesBySegment {
+		t.lobContext.AddSegmentLobFiles(segID, files)
+	}
+	// schema-bump is always 1 source -> 1 output; forced REUSE_ALL.
+	t.lobContext.SetCompactionType(datapb.CompactionType_BumpSchemaVersionCompaction, 1, 1)
+	t.lobContext.ComputeStrategies(textFieldIDs, t.compactionParams.LOBHoleRatioThreshold)
+	mlog.Info(ctx, "schema bump: initialized LOB compaction context (REUSE_ALL)",
+		mlog.Int64("planID", t.GetPlanID()),
+		mlog.FieldSegmentID(segment.GetSegmentID()),
+		mlog.Int64s("textFieldIDs", textFieldIDs),
+	)
+	return nil
+}
+
+// applyLOBCompaction merges the source segment's TEXT LOB file references into the
+// output segment's manifest (REUSE_ALL): LOB files are unchanged, only their
+// references (and valid_rows) are copied over. Mirrors sort compaction.
+func (t *bumpSchemaVersionCompactionTask) applyLOBCompaction(ctx context.Context, outputSegment *datapb.CompactionSegment) error {
+	if t.lobContext == nil || !t.lobContext.HasReuseAllFields() {
+		return nil
+	}
+	if outputSegment.GetManifest() == "" {
+		return nil
+	}
+
+	outputManifests := map[int64]string{outputSegment.GetSegmentID(): outputSegment.GetManifest()}
+	updatedManifests, err := compaction.ApplyLobCompactionToManifests(t.lobContext, outputManifests, t.compactionParams.StorageConfig)
+	if err != nil {
+		return err
+	}
+	if newManifest, ok := updatedManifests[outputSegment.GetSegmentID()]; ok {
+		outputSegment.Manifest = newManifest
+	}
+	mlog.Info(ctx, "schema bump: merged TEXT LOB references into output manifest",
+		mlog.Int64("planID", t.GetPlanID()),
+		mlog.FieldSegmentID(outputSegment.GetSegmentID()),
+	)
+	return nil
 }
 
 func appendBM25StatsFromArrowArray(stats *storage.BM25Stats, arr arrow.Array) (int, error) {

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -474,6 +474,130 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionSu
 	}
 }
 
+// buildTextLOBTask builds a minimal schema-bump task whose schema optionally has a
+// DataType_Text field (the LOB-carrying input of a BM25 function). Only plan +
+// compactionParams are needed to exercise the LOB wiring (the cgo manifest helpers
+// are mocked in the tests below), so no chunk manager is required.
+func (s *BumpSchemaVersionCompactionTaskSuite) buildTextLOBTask(withTextField bool) *bumpSchemaVersionCompactionTask {
+	fields := []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+		{FieldID: common.TimeStampField, Name: "Timestamp", DataType: schemapb.DataType_Int64},
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}
+	schema := &schemapb.CollectionSchema{Name: "text_lob_bump", Fields: fields}
+	if withTextField {
+		schema.Fields = append(schema.Fields,
+			&schemapb.FieldSchema{FieldID: 101, Name: "text", DataType: schemapb.DataType_Text},
+			&schemapb.FieldSchema{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		)
+		schema.Functions = []*schemapb.FunctionSchema{{
+			Name: "bm25", Id: 100, Type: schemapb.FunctionType_BM25,
+			InputFieldNames: []string{"text"}, InputFieldIds: []int64{101},
+			OutputFieldNames: []string{"sparse"}, OutputFieldIds: []int64{102},
+		}}
+	}
+	plan := &datapb.CompactionPlan{
+		PlanID:    999,
+		Type:      datapb.CompactionType_BumpSchemaVersionCompaction,
+		Schema:    schema,
+		TotalRows: 3,
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{
+			CollectionID: 1, PartitionID: 1, SegmentID: 100,
+			StorageVersion: storage.StorageV3, Manifest: "manifest",
+		}},
+	}
+	params := compaction.GenParams()
+	params.StorageVersion = storage.StorageV3
+	return &bumpSchemaVersionCompactionTask{
+		ctx:              context.Background(),
+		plan:             plan,
+		compactionParams: params,
+	}
+}
+
+// TestInitLOBCompactionContextTextFieldReuseAll: a schema-bump on a segment with a
+// TEXT field forces REUSE_ALL for that field (never REWRITE_ALL), so its existing
+// LOB data is carried by reference.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestInitLOBCompactionContextTextFieldReuseAll() {
+	task := s.buildTextLOBTask(true)
+	collectPatch := mockey.Mock(compaction.CollectLobFilesFromManifests).Return(
+		map[int64][]packed.LobFileInfo{100: {{FieldID: 101, TotalRows: 3, ValidRows: 3}}}, nil,
+	).Build()
+	defer collectPatch.UnPatch()
+
+	err := task.initLOBCompactionContext(context.Background())
+	s.NoError(err)
+	s.Require().NotNil(task.lobContext)
+	s.True(task.lobContext.HasReuseAllFields(), "TEXT field must be forced REUSE_ALL for schema bump")
+	s.True(task.lobContext.IsReuseAll(101))
+}
+
+// TestInitLOBCompactionContextInlineTextReuseAll: even with NO LOB files (inline
+// TEXT < threshold), the forced strategy still produces a REUSE_ALL decision, so
+// the writer is told WithTextRefsAsBinary (HasReuseAllFields true) and the inline
+// bytes are preserved.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestInitLOBCompactionContextInlineTextReuseAll() {
+	task := s.buildTextLOBTask(true)
+	collectPatch := mockey.Mock(compaction.CollectLobFilesFromManifests).Return(
+		map[int64][]packed.LobFileInfo{}, nil, // no LOB files -> inline TEXT
+	).Build()
+	defer collectPatch.UnPatch()
+
+	err := task.initLOBCompactionContext(context.Background())
+	s.NoError(err)
+	s.Require().NotNil(task.lobContext)
+	s.True(task.lobContext.HasReuseAllFields(), "inline TEXT must still force REUSE_ALL so WithTextRefsAsBinary is applied")
+}
+
+// TestInitLOBCompactionContextNoTextFieldNoop: schemas without a TEXT field skip
+// the LOB path entirely (lobContext stays nil).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestInitLOBCompactionContextNoTextFieldNoop() {
+	task := s.buildTextLOBTask(false)
+	err := task.initLOBCompactionContext(context.Background())
+	s.NoError(err)
+	s.Nil(task.lobContext, "no TEXT field -> lobContext stays nil (no-op)")
+}
+
+// TestApplyLOBCompactionMergesRefsIntoManifest: the output manifest is updated with
+// the merged LOB references (REUSE_ALL).
+func (s *BumpSchemaVersionCompactionTaskSuite) TestApplyLOBCompactionMergesRefsIntoManifest() {
+	task := s.buildTextLOBTask(true)
+	collectPatch := mockey.Mock(compaction.CollectLobFilesFromManifests).Return(
+		map[int64][]packed.LobFileInfo{100: {{FieldID: 101, TotalRows: 3, ValidRows: 3}}}, nil,
+	).Build()
+	defer collectPatch.UnPatch()
+	s.Require().NoError(task.initLOBCompactionContext(context.Background()))
+	s.Require().True(task.lobContext.HasReuseAllFields())
+
+	// Capture the chained manifest value inside the closure at call time rather than
+	// storing the argument map and reading it back after applyLOBCompaction returns:
+	// holding the map reference and indexing it later trips the runtime "concurrent
+	// map read and map write" detector under -race.
+	var gotChainedManifest string
+	applyPatch := mockey.Mock(compaction.ApplyLobCompactionToManifests).To(
+		func(_ *compaction.LOBCompactionContext, outputManifests map[int64]string, _ *indexpb.StorageConfig) (map[int64]string, error) {
+			gotChainedManifest = outputManifests[200]
+			return map[int64]string{200: "merged-manifest"}, nil
+		}).Build()
+	defer applyPatch.UnPatch()
+
+	out := &datapb.CompactionSegment{SegmentID: 200, Manifest: "orig-manifest"}
+	err := task.applyLOBCompaction(context.Background(), out)
+	s.NoError(err)
+	s.Equal("merged-manifest", out.GetManifest(), "output manifest must be updated with merged LOB refs")
+	s.Equal("orig-manifest", gotChainedManifest, "merge must chain on the segment's current manifest")
+}
+
+// TestApplyLOBCompactionNilContextNoop: no LOB context (e.g. no TEXT fields) -> the
+// output manifest is left unchanged.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestApplyLOBCompactionNilContextNoop() {
+	task := s.buildTextLOBTask(true) // no init -> lobContext nil
+	out := &datapb.CompactionSegment{SegmentID: 200, Manifest: "orig-manifest"}
+	err := task.applyLOBCompaction(context.Background(), out)
+	s.NoError(err)
+	s.Equal("orig-manifest", out.GetManifest())
+}
+
 func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteDropsExpirQuantilesWhenTTLFieldRemoved() {
 	s.prepareBumpSchemaVersionCompactionWithDroppedField()
 	s.task.plan.GetSegmentBinlogs()[0].IsSorted = true
@@ -622,6 +746,102 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRebuildsTextStats(
 	s.Contains(segment.GetTextStatsLogs(), int64(101))
 	s.EqualValues(42, segment.GetTextStatsLogs()[101].GetLogSize())
 	s.Contains(segment.GetManifest(), "with-text-stats")
+}
+
+// TestFullRewriteFillsMissingNullableTextAsBinary is the real-cgo regression for the
+// datanode crash-loop reported on PR #51125: adding a nullable TEXT field and then
+// dropping any field routes to runFullSchemaRewrite, where the new TEXT column is
+// absent from the source segment. The packed writer types TEXT columns as binary
+// (WithTextRefsAsBinary), so the materializer must backfill the missing TEXT column
+// as a binary null array; a utf8 fill makes array.NewRecord panic and crash-loops the
+// datanode. Unlike the mocked-writer tests, this drives the actual packed writer so
+// the fill type is exercised end to end.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteFillsMissingNullableTextAsBinary() {
+	const newTextFieldID = int64(104)
+	// Target schema gains a nullable TEXT field absent from the source segment.
+	// enable_match is intentionally omitted so createTextIndex skips it and the test
+	// exercises only the record-write path where the panic occurred.
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  newTextFieldID,
+		Name:     "note",
+		DataType: schemapb.DataType_Text,
+		Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "65535"},
+		},
+	})
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+
+	// Source segment carries a dropped field (103) -> droppedFieldIDs>0 -> full rewrite.
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.Equal(datapb.CompactionTaskState_completed, result.GetState())
+	s.Require().Len(result.GetSegments(), 1)
+
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+
+	// The backfilled TEXT column must be materialized into the rewritten segment (as a
+	// binary null column), either as a top-level field or a column-group child.
+	found := false
+	for _, fb := range segment.GetInsertLogs() {
+		if fb.GetFieldID() == newTextFieldID {
+			found = true
+			break
+		}
+		for _, cf := range fb.GetChildFields() {
+			if cf == newTextFieldID {
+				found = true
+				break
+			}
+		}
+		if found {
+			break
+		}
+	}
+	s.True(found, "missing nullable TEXT field must be backfilled into the rewritten segment")
+}
+
+// TestFullRewriteMergesLOBRefsBeforeBuildingTextIndex guards the ordering fixed for
+// liliu-z's review. createTextIndex reads the TEXT column through the output segment's
+// manifest, so applyLOBCompaction -- which merges the carried source LOB file references
+// into that manifest -- must run BEFORE createTextIndex. Otherwise the text-match index
+// for an out-of-line (>=64KB) TEXT field is built against a manifest that does not yet
+// list the LOB files, silently missing that data. Mirrors sort/mix. We stamp the manifest
+// on LOB apply and assert createTextIndex observes the stamped (LOB-merged) manifest; the
+// old order (createTextIndex first) fails this assertion.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteMergesLOBRefsBeforeBuildingTextIndex() {
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	const lobStamp = "-lob-merged"
+	applyPatch := mockey.Mock((*bumpSchemaVersionCompactionTask).applyLOBCompaction).
+		To(func(_ *bumpSchemaVersionCompactionTask, _ context.Context, seg *datapb.CompactionSegment) error {
+			seg.Manifest = seg.GetManifest() + lobStamp
+			return nil
+		}).Build()
+	defer applyPatch.UnPatch()
+
+	var manifestAtTextIndex string
+	textIndexPatch := mockey.Mock(createTextIndex).
+		To(func(_ context.Context, _ storage.ChunkManager, _ *datapb.CompactionPlan, _ compaction.Params,
+			_ int64, _ int64, _ int64, _ int64, _ int64, seg *datapb.CompactionSegment,
+		) (map[int64]*datapb.TextIndexStats, error) {
+			manifestAtTextIndex = seg.GetManifest()
+			return map[int64]*datapb.TextIndexStats{}, nil
+		}).Build()
+	defer textIndexPatch.UnPatch()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.Contains(manifestAtTextIndex, lobStamp,
+		"applyLOBCompaction must run before createTextIndex so the text-match index is built "+
+			"against a manifest that already references the carried LOB files")
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestSelectFullRewriteRecordDropsDeletedAndExpiredRows() {

--- a/internal/proxy/function_task.go
+++ b/internal/proxy/function_task.go
@@ -100,12 +100,18 @@ func (t *addCollectionFunctionTask) PreExecute(ctx context.Context) error {
 	if t.FunctionSchema.Type == schemapb.FunctionType_BM25 {
 		return merr.WrapErrParameterInvalidMsg("currently does not support adding BM25 function")
 	}
+	if err := validateAddFunctionRequiresStorageV3(); err != nil {
+		return err
+	}
 	coll, err := getCollectionInfo(ctx, t.GetDbName(), t.GetCollectionName())
 	if err != nil {
 		mlog.Error(t.ctx, "AddCollectionTask, get collection info failed",
 			mlog.String("dbName", t.GetDbName()),
 			mlog.String("collectionName", t.GetCollectionName()),
 			mlog.Err(err))
+		return err
+	}
+	if err := validateAddFunctionInputNotText(coll.schema.CollectionSchema, t.FunctionSchema); err != nil {
 		return err
 	}
 	newColl := proto.Clone(coll.schema.CollectionSchema).(*schemapb.CollectionSchema)

--- a/internal/proxy/function_task_test.go
+++ b/internal/proxy/function_task_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/util/function/validator"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type FunctionTaskSuite struct {
@@ -38,6 +39,60 @@ type FunctionTaskSuite struct {
 
 func TestFunctionTask(t *testing.T) {
 	suite.Run(t, new(FunctionTaskSuite))
+}
+
+// TestAddFunctionRequiresStorageV3Gate guards the add_function_field V3 gate (issue #51167):
+// adding a function must be rejected unless StorageV3 (useLoonFFI), the schema-bump compaction
+// (bumpSchemaVersion.enabled), and the storage-version upgrade compaction (storageVersion.enabled)
+// are all on, so the new function output is actually backfilled into pre-existing segments.
+func (f *FunctionTaskSuite) TestAddFunctionRequiresStorageV3Gate() {
+	useLoon := paramtable.Get().CommonCfg.UseLoonFFI.Key
+	bumpEnabled := paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key
+	svEnabled := paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key
+	defer paramtable.Get().Reset(useLoon)
+	defer paramtable.Get().Reset(bumpEnabled)
+	defer paramtable.Get().Reset(svEnabled)
+
+	// useLoonFFI off -> reject
+	paramtable.Get().Save(useLoon, "false")
+	f.ErrorContains(validateAddFunctionRequiresStorageV3(), "StorageV3")
+
+	// useLoonFFI on but bumpSchemaVersion.enabled off -> reject
+	paramtable.Get().Save(useLoon, "true")
+	paramtable.Get().Save(bumpEnabled, "false")
+	f.ErrorContains(validateAddFunctionRequiresStorageV3(), "bumpSchemaVersion.enabled")
+
+	// bumpSchemaVersion on but storageVersion.enabled off -> reject
+	paramtable.Get().Save(bumpEnabled, "true")
+	paramtable.Get().Save(svEnabled, "false")
+	f.ErrorContains(validateAddFunctionRequiresStorageV3(), "storageVersion.enabled")
+
+	// all on -> pass
+	paramtable.Get().Save(svEnabled, "true")
+	f.NoError(validateAddFunctionRequiresStorageV3())
+}
+
+// TestValidateAddFunctionInputNotText guards the reject of a BM25/MinHash function whose
+// input is a TEXT field (issue #51167): its output cannot be backfilled into existing
+// segments (stringInputsFromRecord hard-fails on the binary LOB column), so add-function
+// must fail fast. VarChar input stays allowed; non-materialized function types are ignored.
+func (f *FunctionTaskSuite) TestValidateAddFunctionInputNotText() {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "varchar_in", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "text_in", DataType: schemapb.DataType_Text},
+	}}
+	fn := func(t schemapb.FunctionType, input string) *schemapb.FunctionSchema {
+		return &schemapb.FunctionSchema{Name: "fn", Type: t, InputFieldNames: []string{input}}
+	}
+
+	// TEXT input rejected for BM25 and MinHash
+	f.ErrorContains(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "text_in")), "TEXT input field")
+	f.ErrorContains(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "text_in")), "TEXT input field")
+	// VarChar input allowed
+	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "varchar_in")))
+	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "varchar_in")))
+	// non-materialized function type (e.g. TextEmbedding) is out of scope -> allowed even with TEXT input
+	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_TextEmbedding, "text_in")))
 }
 
 func (f *FunctionTaskSuite) TestFunctionOnType() {
@@ -87,6 +142,13 @@ func (f *FunctionTaskSuite) TestFunctionOnType() {
 
 func (f *FunctionTaskSuite) TestAddCollectionFunctionTaskPreExecute() {
 	ctx := context.Background()
+	// Adding a function requires StorageV3 + schema-bump/storage-version compaction enabled
+	// (see validateAddFunctionRequiresStorageV3). storageVersion.enabled defaults true;
+	// bumpSchemaVersion.enabled defaults false, so it must be set explicitly.
+	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key)
 	{
 		mixc := mocks.NewMockMixCoordClient(f.T())
 		req := &milvuspb.AddCollectionFunctionRequest{

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -214,6 +214,64 @@ func validateTextStorageV3Enabled(schema *schemapb.CollectionSchema) error {
 	return nil
 }
 
+// validateAddFunctionRequiresStorageV3 rejects adding a function to an existing collection
+// unless the compaction infrastructure that backfills its output field into pre-existing
+// sealed segments is enabled. The new function-output field is materialized only by
+// compaction (bump_schema_version compaction requires a StorageV3 segment):
+//   - common.storage.useLoonFFI: StorageV3 mode (bump works only on V3 segments; TEXT needs V3).
+//   - dataCoord.compaction.bumpSchemaVersion.enabled: the bumpSchemaVersionPolicy that directly
+//     backfills pre-existing V3 segments; it defaults to false, and there is no direct trigger
+//     on the add-function DDL, so without it an already-V3 old segment never receives the output.
+//   - dataCoord.compaction.storageVersion.enabled: the storageVersionUpgradePolicy that first
+//     mix-upgrades a pre-existing V2 segment to V3 so it can be bumped.
+//
+// Without all three, the DDL would succeed while old rows silently never get the function output.
+// New writes always compute the function output at flush, so create_collection with a function is
+// unaffected; this guard applies only to add-function on an existing collection. See issue #51167.
+func validateAddFunctionRequiresStorageV3() error {
+	if !Params.CommonCfg.UseLoonFFI.GetAsBool() {
+		return merr.WrapErrParameterInvalidMsg("adding a function field requires StorageV3; enable common.storage.useLoonFFI")
+	}
+	if !Params.DataCoordCfg.BumpSchemaVersionCompactionEnabled.GetAsBool() {
+		return merr.WrapErrParameterInvalidMsg("adding a function field requires schema-bump compaction to backfill existing segments; enable dataCoord.compaction.bumpSchemaVersion.enabled")
+	}
+	if !Params.DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool() {
+		return merr.WrapErrParameterInvalidMsg("adding a function field requires the storage-version upgrade compaction; enable dataCoord.compaction.storageVersion.enabled")
+	}
+	return nil
+}
+
+// validateAddFunctionInputNotText rejects adding a BM25/MinHash function whose input is a
+// TEXT field. TEXT columns are stored as binary LOB references, so when the async backfill
+// compaction materializes the function output for pre-existing segments it reads the input
+// back as *array.Binary and hard-fails in stringInputsFromRecord ("cannot materialize bm25
+// from text binary values without lob decoding"); the add-function DDL would return success
+// while the backfill silently fails and old rows never get the output. Reject it up front
+// (fail-fast). VarChar inputs stay allowed, and create_collection with such a function is
+// unaffected -- its output is computed at flush from the raw text. Distinct from the
+// storage-version gate (validateAddFunctionRequiresStorageV3): this is a request-content
+// input-type constraint, not an environment/config check. See issue #51167.
+func validateAddFunctionInputNotText(schema *schemapb.CollectionSchema, function *schemapb.FunctionSchema) error {
+	switch function.GetType() {
+	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
+	default:
+		// Only BM25/MinHash are materialized from string input during backfill.
+		return nil
+	}
+	fieldByName := make(map[string]*schemapb.FieldSchema, len(schema.GetFields()))
+	for _, f := range schema.GetFields() {
+		fieldByName[f.GetName()] = f
+	}
+	for _, name := range function.GetInputFieldNames() {
+		if f, ok := fieldByName[name]; ok && f.GetDataType() == schemapb.DataType_Text {
+			return merr.WrapErrParameterInvalidMsg(
+				"adding a %s function with a TEXT input field (%s) is not supported: its output cannot be backfilled into existing segments; use a VARCHAR input field",
+				function.GetType().String(), name)
+		}
+	}
+	return nil
+}
+
 type createCollectionTask struct {
 	baseTask
 	Condition
@@ -1118,6 +1176,9 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 		}
 	}
 	if plan.HasFunction() {
+		if err := validateAddFunctionRequiresStorageV3(); err != nil {
+			return err
+		}
 		if err := schemautil.ValidateAlterSchemaAddFunctionPlan(plan); err != nil {
 			return err
 		}
@@ -1155,6 +1216,9 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 		mergedSchema.Fields = append(mergedSchema.Fields, proto.Clone(plan.Field).(*schemapb.FieldSchema))
 	}
 	mergedSchema.Functions = append(mergedSchema.Functions, plan.Function)
+	if err := validateAddFunctionInputNotText(mergedSchema, plan.Function); err != nil {
+		return err
+	}
 	if err := validator.ValidateFunction(mergedSchema, plan.Function.GetName(), false); err != nil {
 		return err
 	}

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -7602,6 +7602,13 @@ func TestValidateAddFieldRequest(t *testing.T) {
 }
 
 func TestAlterCollectionSchemaTask(t *testing.T) {
+	// Add-function cases require StorageV3 + schema-bump/storage-version compaction enabled
+	// (validateAddFunctionRequiresStorageV3). storageVersion.enabled defaults true;
+	// bumpSchemaVersion.enabled defaults false, so it must be set explicitly.
+	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key)
 	rc := NewMixCoordMock()
 	ctx := context.Background()
 	prefix := "TestAlterCollectionSchemaTask"


### PR DESCRIPTION
Cherry-pick of #51125 to the 3.0 branch.

issue: #50021, #51167
pr: #51125