### PR TITLE
enhance: simplify tsoutil timestamp composition (#51120)

### DIFF
--- a/internal/compaction/entity_filter_test.go
+++ b/internal/compaction/entity_filter_test.go
@@ -69,7 +69,7 @@ func (s *EntityFilterSuite) TestEntityFilterByTTL() {
 		s.Run(test.description, func() {
 			filter := newEntityFilter(nil, test.collTTL, test.nowTime, 0)
 
-			entityTs := tsoutil.ComposeTSByTime(test.entityTime, 0)
+			entityTs := tsoutil.ComposeTSByTime(test.entityTime)
 			got := filter.Filtered("mockpk", entityTs, -1)
 			s.Equal(test.expect, got)
 
@@ -93,7 +93,7 @@ func (s *EntityFilterSuite) TestEntityFilterByTTLWithCommitTs() {
 
 	// Entity timestamp is 6 hours before commit (typical import lag).
 	entityTime := nowTime.Add(-6 * time.Hour)
-	entityTs := tsoutil.ComposeTSByTime(entityTime, 0)
+	entityTs := tsoutil.ComposeTSByTime(entityTime)
 
 	// Collection TTL is 1 hour — entity timestamp alone would appear expired.
 	ttlOneHour := int64(1 * time.Hour)
@@ -107,7 +107,7 @@ func (s *EntityFilterSuite) TestEntityFilterByTTLWithCommitTs() {
 	s.Run("with commitTs recent enough: row is protected", func() {
 		// commitTs is 30 minutes ago — within TTL.
 		recentCommitTime := nowTime.Add(-30 * time.Minute)
-		commitTs := tsoutil.ComposeTSByTime(recentCommitTime, 0)
+		commitTs := tsoutil.ComposeTSByTime(recentCommitTime)
 		filter := newEntityFilter(nil, ttlOneHour, nowTime, commitTs)
 		got := filter.Filtered("pk1", entityTs, -1)
 		s.False(got, "row should not expire when commitTs is within TTL window")
@@ -116,7 +116,7 @@ func (s *EntityFilterSuite) TestEntityFilterByTTLWithCommitTs() {
 	s.Run("with commitTs also expired: row expires", func() {
 		// commitTs is 2 hours ago — beyond TTL.
 		expiredCommitTime := nowTime.Add(-2 * time.Hour)
-		commitTs := tsoutil.ComposeTSByTime(expiredCommitTime, 0)
+		commitTs := tsoutil.ComposeTSByTime(expiredCommitTime)
 		filter := newEntityFilter(nil, ttlOneHour, nowTime, commitTs)
 		got := filter.Filtered("pk1", entityTs, -1)
 		s.True(got, "row should expire when both row_ts and commitTs are beyond TTL")
@@ -127,9 +127,9 @@ func (s *EntityFilterSuite) TestEntityFilterByTTLWithCommitTs() {
 		// user intent and should be honored regardless of commitTs.
 		expiredTimeMicros := nowTime.Add(-1 * time.Hour).UnixMicro()
 		recentCommitTime := nowTime.Add(-30 * time.Minute)
-		commitTs := tsoutil.ComposeTSByTime(recentCommitTime, 0)
+		commitTs := tsoutil.ComposeTSByTime(recentCommitTime)
 		filter := newEntityFilter(nil, ttlOneHour, nowTime, commitTs)
-		got := filter.Filtered("pk1", tsoutil.ComposeTSByTime(recentCommitTime, 0), expiredTimeMicros)
+		got := filter.Filtered("pk1", tsoutil.ComposeTSByTime(recentCommitTime), expiredTimeMicros)
 		s.True(got, "ttl_field expiration should apply even when commitTs is set")
 	})
 
@@ -137,7 +137,7 @@ func (s *EntityFilterSuite) TestEntityFilterByTTLWithCommitTs() {
 		expiredTimeMicros := nowTime.Add(-1 * time.Hour).UnixMicro()
 		filter := newEntityFilter(nil, ttlOneHour, nowTime, 0)
 		// Use a recent entity ts so TTL by timestamp alone would NOT expire it.
-		recentTs := tsoutil.ComposeTSByTime(nowTime.Add(-30*time.Minute), 0)
+		recentTs := tsoutil.ComposeTSByTime(nowTime.Add(-30 * time.Minute))
 		got := filter.Filtered("pk1", recentTs, expiredTimeMicros)
 		s.True(got, "ttl_field should expire the row when commitTs is 0")
 	})

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -379,7 +379,7 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 			return nil
 		}
 
-		ct, err := getCompactTime(tsoutil.ComposeTSByTime(time.Now(), 0), coll)
+		ct, err := getCompactTime(tsoutil.ComposeTSByTime(time.Now()), coll)
 		if err != nil {
 			log.Warn(context.TODO(), "get compact time failed, skip to handle compaction")
 			return err

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -1322,7 +1322,7 @@ func Test_compactionTrigger_PrioritizedCandi(t *testing.T) {
 		(tt.fields.inspector).(*spyCompactionInspector).meta = tt.fields.meta
 		t.Run(tt.name, func(t *testing.T) {
 			tt.fields.meta.channelCPs.checkpoints["ch1"] = &msgpb.MsgPosition{
-				Timestamp: tsoutil.ComposeTSByTime(time.Now(), 0),
+				Timestamp: tsoutil.ComposeTSByTime(time.Now()),
 				MsgID:     []byte{1, 2, 3, 4},
 			}
 			tr := &compactionTrigger{
@@ -1465,7 +1465,7 @@ func Test_compactionTrigger_SmallCandi(t *testing.T) {
 		(tt.fields.inspector).(*spyCompactionInspector).meta = tt.fields.meta
 		t.Run(tt.name, func(t *testing.T) {
 			tt.fields.meta.channelCPs.checkpoints["ch1"] = &msgpb.MsgPosition{
-				Timestamp: tsoutil.ComposeTSByTime(time.Now(), 0),
+				Timestamp: tsoutil.ComposeTSByTime(time.Now()),
 				MsgID:     []byte{1, 2, 3, 4},
 			}
 			tr := &compactionTrigger{
@@ -1649,7 +1649,7 @@ func Test_compactionTrigger_noplan_random_size(t *testing.T) {
 		(tt.fields.inspector).(*spyCompactionInspector).meta = tt.fields.meta
 		t.Run(tt.name, func(t *testing.T) {
 			tt.fields.meta.channelCPs.checkpoints["ch1"] = &msgpb.MsgPosition{
-				Timestamp: tsoutil.ComposeTSByTime(time.Now(), 0),
+				Timestamp: tsoutil.ComposeTSByTime(time.Now()),
 				MsgID:     []byte{1, 2, 3, 4},
 			}
 			tr := &compactionTrigger{
@@ -1932,8 +1932,8 @@ func Test_compactionTrigger_shouldDoSingleCompaction(t *testing.T) {
 		// expireTime is 5000 which is > row timestamps but < commit_timestamp.
 		// Without the fix, rows appear expired. With the fix, commit_timestamp is used as effective ts.
 		now := time.Now()
-		commitTs := tsoutil.ComposeTSByTime(now.Add(24*time.Hour), 0) // future: definitely not expired
-		expireTime := uint64(5000)                                    // > old row ts (1000) but < commitTs
+		commitTs := tsoutil.ComposeTSByTime(now.Add(24 * time.Hour)) // future: definitely not expired
+		expireTime := uint64(5000)                                   // > old row ts (1000) but < commitTs
 
 		var importBinlogs []*datapb.FieldBinlog
 		for i := 0; i < 100; i++ {
@@ -2028,7 +2028,7 @@ func Test_compactionTrigger_ShouldStrictCompactExpiry(t *testing.T) {
 	trigger := &compactionTrigger{}
 
 	now := time.Now()
-	expireTS := tsoutil.ComposeTSByTime(now, 0)
+	expireTS := tsoutil.ComposeTSByTime(now)
 	compact := &compactTime{
 		expireTime: expireTS,
 	}
@@ -2045,13 +2045,13 @@ func Test_compactionTrigger_ShouldStrictCompactExpiry(t *testing.T) {
 	t.Run("no tolerance, fromTs before expire time => should compact", func(t *testing.T) {
 		Params.Save(Params.DataCoordCfg.CompactionExpiryTolerance.Key, "0")
 		defer Params.Save(Params.DataCoordCfg.CompactionExpiryTolerance.Key, "-1") // reset
-		fromTs := tsoutil.ComposeTSByTime(now.Add(-time.Hour), 0)
+		fromTs := tsoutil.ComposeTSByTime(now.Add(-time.Hour))
 		shouldCompact := trigger.ShouldCompactExpiry(fromTs, compact, segment)
 		assert.True(t, shouldCompact)
 	})
 
 	t.Run("negative tolerance, disable force expiry compaction => should not compact", func(t *testing.T) {
-		fromTs := tsoutil.ComposeTSByTime(now.Add(-time.Hour), 0)
+		fromTs := tsoutil.ComposeTSByTime(now.Add(-time.Hour))
 		shouldCompact := trigger.ShouldCompactExpiry(fromTs, compact, segment)
 		assert.False(t, shouldCompact)
 	})
@@ -2060,7 +2060,7 @@ func Test_compactionTrigger_ShouldStrictCompactExpiry(t *testing.T) {
 		Params.Save(Params.DataCoordCfg.CompactionExpiryTolerance.Key, "2")
 		defer Params.Save(Params.DataCoordCfg.CompactionExpiryTolerance.Key, "-1") // reset
 
-		fromTs := tsoutil.ComposeTSByTime(now.Add(-time.Hour), 0) // within 2h tolerance
+		fromTs := tsoutil.ComposeTSByTime(now.Add(-time.Hour)) // within 2h tolerance
 		shouldCompact := trigger.ShouldCompactExpiry(fromTs, compact, segment)
 		assert.False(t, shouldCompact)
 	})
@@ -2068,7 +2068,7 @@ func Test_compactionTrigger_ShouldStrictCompactExpiry(t *testing.T) {
 	t.Run("with tolerance, fromTs before expireTime - tolerance => should compact", func(t *testing.T) {
 		Params.Save(Params.DataCoordCfg.CompactionExpiryTolerance.Key, "2")
 		defer Params.Save(Params.DataCoordCfg.CompactionExpiryTolerance.Key, "-1") // reset
-		fromTs := tsoutil.ComposeTSByTime(now.Add(-3*time.Hour), 0)                // earlier than expireTime - 30m
+		fromTs := tsoutil.ComposeTSByTime(now.Add(-3 * time.Hour))                 // earlier than expireTime - 30m
 		shouldCompact := trigger.ShouldCompactExpiry(fromTs, compact, segment)
 		assert.True(t, shouldCompact)
 	})
@@ -2173,7 +2173,7 @@ func Test_compactionTrigger_getCompactTime(t *testing.T) {
 			common.CollectionTTLConfigKey: "10",
 		},
 	}
-	now := tsoutil.GetCurrentTime()
+	now := tsoutil.ComposeTSByTime(time.Now())
 	ct, err := getCompactTime(now, coll)
 	assert.NoError(t, err)
 	assert.NotNil(t, ct)
@@ -2455,7 +2455,7 @@ func (s *CompactionTriggerSuite) SetupTest() {
 	}
 	s.meta.UpdateChannelCheckpoint(context.TODO(), s.channel, &msgpb.MsgPosition{
 		ChannelName: s.channel,
-		Timestamp:   tsoutil.ComposeTSByTime(time.Now(), 0),
+		Timestamp:   tsoutil.ComposeTSByTime(time.Now()),
 		MsgID:       []byte{1, 2, 3, 4},
 	})
 	s.allocator = allocator.NewMockAllocator(s.T())
@@ -3329,12 +3329,12 @@ func Test_compactionTrigger_ShouldCompactExpiryWithTTLField(t *testing.T) {
 		},
 	}
 
-	startTime := tsoutil.ComposeTSByTime(ts.Add(time.Minute), 0)
+	startTime := tsoutil.ComposeTSByTime(ts.Add(time.Minute))
 	ct := &compactTime{startTime: startTime, collectionTTL: 0}
 	shouldCompact := trigger.ShouldCompactExpiryWithTTLField(ct, segment)
 	assert.True(t, shouldCompact)
 
-	startTime = tsoutil.ComposeTSByTime(ts.Add(-1*time.Hour), 0)
+	startTime = tsoutil.ComposeTSByTime(ts.Add(-1 * time.Hour))
 	ct = &compactTime{startTime: startTime, collectionTTL: 0}
 	shouldCompact = trigger.ShouldCompactExpiryWithTTLField(ct, segment)
 	assert.False(t, shouldCompact)
@@ -3342,13 +3342,13 @@ func Test_compactionTrigger_ShouldCompactExpiryWithTTLField(t *testing.T) {
 	origin := Params.DataCoordCfg.SingleCompactionRatioThreshold.GetValue()
 	defer Params.Save(Params.DataCoordCfg.SingleCompactionRatioThreshold.Key, origin)
 	Params.Save(Params.DataCoordCfg.SingleCompactionRatioThreshold.Key, "0.1")
-	startTime = tsoutil.ComposeTSByTime(ts.Add(time.Minute), 0)
+	startTime = tsoutil.ComposeTSByTime(ts.Add(time.Minute))
 	ct = &compactTime{startTime: startTime, collectionTTL: 0}
 	shouldCompact = trigger.ShouldCompactExpiryWithTTLField(ct, segment)
 	assert.True(t, shouldCompact)
 
 	Params.Save(Params.DataCoordCfg.SingleCompactionRatioThreshold.Key, "5")
-	startTime = tsoutil.ComposeTSByTime(ts.Add(time.Minute), 0)
+	startTime = tsoutil.ComposeTSByTime(ts.Add(time.Minute))
 	ct = &compactTime{startTime: startTime, collectionTTL: 0}
 	shouldCompact = trigger.ShouldCompactExpiryWithTTLField(ct, segment)
 	assert.False(t, shouldCompact)
@@ -3366,7 +3366,7 @@ func Test_compactionTrigger_ShouldCompactExpiryWithTTLField(t *testing.T) {
 		},
 	}
 
-	startTime = tsoutil.ComposeTSByTime(ts.Add(time.Minute), 0)
+	startTime = tsoutil.ComposeTSByTime(ts.Add(time.Minute))
 	ct = &compactTime{startTime: startTime, collectionTTL: 0}
 	shouldCompact = trigger.ShouldCompactExpiryWithTTLField(ct, segment2)
 	assert.False(t, shouldCompact)
@@ -3382,7 +3382,7 @@ func Test_compactionTrigger_ShouldCompactExpiryWithTTLField_CommitTimestamp(t *t
 		SegmentInfo: &datapb.SegmentInfo{
 			ID:              1,
 			CollectionID:    2,
-			CommitTimestamp: tsoutil.ComposeTSByTime(ts, 0), // import segment
+			CommitTimestamp: tsoutil.ComposeTSByTime(ts),
 			ExpirQuantiles: []int64{
 				oldTs.UnixMicro(),
 				oldTs.Add(time.Minute).UnixMicro(),
@@ -3395,7 +3395,7 @@ func Test_compactionTrigger_ShouldCompactExpiryWithTTLField_CommitTimestamp(t *t
 
 	// expirQuantiles are based on original row timestamps; ShouldCompactExpiryWithTTLField
 	// does not adjust for commit_timestamp, so stale quantiles still trigger compaction.
-	startTime := tsoutil.ComposeTSByTime(ts.Add(time.Minute), 0)
+	startTime := tsoutil.ComposeTSByTime(ts.Add(time.Minute))
 	ct := &compactTime{startTime: startTime, collectionTTL: 0}
 	shouldCompact := trigger.ShouldCompactExpiryWithTTLField(ct, segment)
 	assert.True(t, shouldCompact, "stale expirQuantiles should still trigger TTL compaction")

--- a/internal/datacoord/copy_segment_checker_test.go
+++ b/internal/datacoord/copy_segment_checker_test.go
@@ -401,7 +401,7 @@ func (s *CopySegmentCheckerSuite) TestTryTimeoutJob() {
 	s.catalog.EXPECT().SaveCopySegmentJob(mock.Anything, mock.Anything).Return(nil).Times(2)
 
 	// Create a job with timeout in the past
-	timeoutTs := tsoutil.ComposeTSByTime(time.Now().Add(-1*time.Hour), 0)
+	timeoutTs := tsoutil.ComposeTSByTime(time.Now().Add(-1 * time.Hour))
 	job := &copySegmentJob{
 		CopySegmentJob: &datapb.CopySegmentJob{
 			JobId:        s.jobID,
@@ -431,7 +431,7 @@ func (s *CopySegmentCheckerSuite) TestCheckGC_RemoveCompletedJob() {
 	s.catalog.EXPECT().DropCopySegmentJob(mock.Anything, mock.Anything).Return(nil)
 
 	// Create a completed job with cleanup time in the past
-	cleanupTs := tsoutil.ComposeTSByTime(time.Now().Add(-1*time.Hour), 0)
+	cleanupTs := tsoutil.ComposeTSByTime(time.Now().Add(-1 * time.Hour))
 	job := &copySegmentJob{
 		CopySegmentJob: &datapb.CopySegmentJob{
 			JobId:        s.jobID,

--- a/internal/datacoord/copy_segment_job.go
+++ b/internal/datacoord/copy_segment_job.go
@@ -69,7 +69,7 @@ func UpdateCopyJobState(state datapb.CopySegmentJobState) UpdateCopySegmentJobAc
 			// Set cleanup ts based on copy segment task retention
 			dur := Params.DataCoordCfg.CopySegmentTaskRetention.GetAsDuration(time.Second)
 			cleanupTime := time.Now().Add(dur)
-			cleanupTs := tsoutil.ComposeTSByTime(cleanupTime, 0)
+			cleanupTs := tsoutil.ComposeTSByTime(cleanupTime)
 			job.(*copySegmentJob).CleanupTs = cleanupTs
 			mlog.Info(context.TODO(), "set copy segment job cleanup ts",
 				mlog.FieldJobID(job.GetJobId()),

--- a/internal/datacoord/handler_test.go
+++ b/internal/datacoord/handler_test.go
@@ -1357,13 +1357,13 @@ func TestShouldDropChannel(t *testing.T) {
 	myRoot := &myRootCoord{}
 	myRoot.EXPECT().AllocTimestamp(mock.Anything, mock.Anything).Return(&rootcoordpb.AllocTimestampResponse{
 		Status:    merr.Success(),
-		Timestamp: tsoutil.ComposeTSByTime(time.Now(), 0),
+		Timestamp: tsoutil.ComposeTSByTime(time.Now()),
 		Count:     1,
 	}, nil)
 
 	myRoot.EXPECT().AllocID(mock.Anything, mock.Anything).Return(&rootcoordpb.AllocIDResponse{
 		Status: merr.Success(),
-		ID:     int64(tsoutil.ComposeTSByTime(time.Now(), 0)),
+		ID:     int64(tsoutil.ComposeTSByTime(time.Now())),
 		Count:  1,
 	}, nil)
 

--- a/internal/datacoord/import_checker_test.go
+++ b/internal/datacoord/import_checker_test.go
@@ -99,7 +99,7 @@ func (s *ImportCheckerSuite) SetupTest() {
 			Vchannels:    []string{"ch0"},
 			State:        internalpb.ImportJobState_Pending,
 			TimeoutTs:    1000,
-			CleanupTs:    tsoutil.GetCurrentTime(),
+			CleanupTs:    tsoutil.ComposeTSByTime(time.Now()),
 			Schema: &schemapb.CollectionSchema{
 				Fields: []*schemapb.FieldSchema{
 					{
@@ -613,8 +613,8 @@ func TestImportCheckerCompaction(t *testing.T) {
 			ReadyVchannels: []string{"ch0"},
 			Vchannels:      []string{"ch0", "ch1"},
 			State:          internalpb.ImportJobState_Pending,
-			TimeoutTs:      tsoutil.ComposeTSByTime(time.Now().Add(time.Hour), 0),
-			CleanupTs:      tsoutil.ComposeTSByTime(time.Now().Add(time.Hour), 0),
+			TimeoutTs:      tsoutil.ComposeTSByTime(time.Now().Add(time.Hour)),
+			CleanupTs:      tsoutil.ComposeTSByTime(time.Now().Add(time.Hour)),
 			Schema: &schemapb.CollectionSchema{
 				Fields: []*schemapb.FieldSchema{
 					{
@@ -661,8 +661,8 @@ func TestImportCheckerCompaction(t *testing.T) {
 			ReadyVchannels: []string{"ch1"},
 			Vchannels:      []string{"ch0", "ch1"},
 			State:          internalpb.ImportJobState_Pending,
-			TimeoutTs:      tsoutil.ComposeTSByTime(time.Now().Add(time.Hour), 0),
-			CleanupTs:      tsoutil.ComposeTSByTime(time.Now().Add(time.Hour), 0),
+			TimeoutTs:      tsoutil.ComposeTSByTime(time.Now().Add(time.Hour)),
+			CleanupTs:      tsoutil.ComposeTSByTime(time.Now().Add(time.Hour)),
 			Schema: &schemapb.CollectionSchema{
 				Fields: []*schemapb.FieldSchema{
 					{

--- a/internal/datacoord/import_job.go
+++ b/internal/datacoord/import_job.go
@@ -74,7 +74,7 @@ func UpdateJobState(state internalpb.ImportJobState) UpdateJobAction {
 			// set cleanup ts
 			dur := Params.DataCoordCfg.ImportTaskRetention.GetAsDuration(time.Second)
 			cleanupTime := time.Now().Add(dur)
-			cleanupTs := tsoutil.ComposeTSByTime(cleanupTime, 0)
+			cleanupTs := tsoutil.ComposeTSByTime(cleanupTime)
 			job.(*importJob).CleanupTs = cleanupTs
 			mlog.Info(context.TODO(), "set import job cleanup ts", mlog.FieldJobID(job.GetJobID()),
 				mlog.Time("cleanupTime", cleanupTime), mlog.Uint64("cleanupTs", cleanupTs))

--- a/internal/datacoord/index_service_test.go
+++ b/internal/datacoord/index_service_test.go
@@ -79,7 +79,7 @@ func initStreamingSystem(t *testing.T) {
 		for _, vchannel := range msg.BroadcastHeader().VChannels {
 			results[vchannel] = &message.AppendResult{
 				MessageID:              rmq.NewRmqID(1),
-				TimeTick:               tsoutil.ComposeTSByTime(time.Now(), 0),
+				TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
 				LastConfirmedMessageID: rmq.NewRmqID(1),
 			}
 		}

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -2347,7 +2347,7 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 			Statslogs:           seg.GetField2StatslogPaths(),
 			CreatedByCompaction: true,
 			CompactionFrom:      compactFromSegIDs,
-			LastExpireTime:      tsoutil.ComposeTSByTime(time.Unix(t.GetStartTime(), 0), 0),
+			LastExpireTime:      tsoutil.ComposeTSByTime(time.Unix(t.GetStartTime(), 0)),
 			Level:               datapb.SegmentLevel_L2,
 			StartPosition:       startPos,
 			DmlPosition:         dmlPos,
@@ -2453,7 +2453,7 @@ func (m *meta) completeMixCompactionMutation(
 
 				CreatedByCompaction: true,
 				CompactionFrom:      compactFromSegIDs,
-				LastExpireTime:      tsoutil.ComposeTSByTime(time.Unix(t.GetStartTime(), 0), 0),
+				LastExpireTime:      tsoutil.ComposeTSByTime(time.Unix(t.GetStartTime(), 0)),
 				Level:               datapb.SegmentLevel_L1,
 				StorageVersion:      compactToSegment.GetStorageVersion(),
 				StartPosition:       startPos,

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -2602,7 +2602,7 @@ func Test_CheckHealth(t *testing.T) {
 			channelCPs: &channelCPs{
 				checkpoints: map[string]*msgpb.MsgPosition{
 					"cluster-id-rootcoord-dm_3_449684528748778322v0": {
-						Timestamp: tsoutil.ComposeTSByTime(time.Now().Add(-1000*time.Hour), 0),
+						Timestamp: tsoutil.ComposeTSByTime(time.Now().Add(-1000 * time.Hour)),
 						MsgID:     []byte{1, 2, 3, 4},
 					},
 				},
@@ -2624,15 +2624,15 @@ func Test_CheckHealth(t *testing.T) {
 			channelCPs: &channelCPs{
 				checkpoints: map[string]*msgpb.MsgPosition{
 					"cluster-id-rootcoord-dm_3_449684528748778322v0": {
-						Timestamp: tsoutil.ComposeTSByTime(time.Now(), 0),
+						Timestamp: tsoutil.ComposeTSByTime(time.Now()),
 						MsgID:     []byte{1, 2, 3, 4},
 					},
 					"cluster-id-rootcoord-dm_3_449684528748778323v0": {
-						Timestamp: tsoutil.ComposeTSByTime(time.Now(), 0),
+						Timestamp: tsoutil.ComposeTSByTime(time.Now()),
 						MsgID:     []byte{1, 2, 3, 4},
 					},
 					"invalid-vchannel-name": {
-						Timestamp: tsoutil.ComposeTSByTime(time.Now(), 0),
+						Timestamp: tsoutil.ComposeTSByTime(time.Now()),
 						MsgID:     []byte{1, 2, 3, 4},
 					},
 				},

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -1983,7 +1983,7 @@ func TestServer_FlushAll(t *testing.T) {
 			for _, vchannel := range msg.BroadcastHeader().VChannels {
 				results[vchannel] = &message.AppendResult{
 					MessageID:              rmq.NewRmqID(1),
-					TimeTick:               tsoutil.ComposeTSByTime(time.Now(), 0),
+					TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
 					LastConfirmedMessageID: rmq.NewRmqID(1),
 				}
 			}
@@ -3822,7 +3822,7 @@ func TestServer_CommitBackfillResult(t *testing.T) {
 					AppendResults: map[string]*types2.AppendResult{
 						"by-dev-rootcoord-dml_0": {
 							MessageID:              rmq.NewRmqID(1),
-							TimeTick:               tsoutil.ComposeTSByTime(time.Now(), 0),
+							TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
 							LastConfirmedMessageID: rmq.NewRmqID(1),
 						},
 					},
@@ -3963,7 +3963,7 @@ func TestServer_CommitBackfillResult(t *testing.T) {
 			AppendResults: map[string]*types2.AppendResult{
 				"by-dev-rootcoord-dml_0": {
 					MessageID:              rmq.NewRmqID(1),
-					TimeTick:               tsoutil.ComposeTSByTime(time.Now(), 0),
+					TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
 					LastConfirmedMessageID: rmq.NewRmqID(1),
 				},
 			},
@@ -4032,7 +4032,7 @@ func TestServer_CommitBackfillResult(t *testing.T) {
 					AppendResults: map[string]*types2.AppendResult{
 						"by-dev-rootcoord-dml_0": {
 							MessageID:              rmq.NewRmqID(1),
-							TimeTick:               tsoutil.ComposeTSByTime(time.Now(), 0),
+							TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
 							LastConfirmedMessageID: rmq.NewRmqID(1),
 						},
 					},
@@ -4292,7 +4292,7 @@ func TestServer_CommitBackfillResult(t *testing.T) {
 					AppendResults: map[string]*types2.AppendResult{
 						"by-dev-rootcoord-dml_0": {
 							MessageID:              rmq.NewRmqID(1),
-							TimeTick:               tsoutil.ComposeTSByTime(time.Now(), 0),
+							TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
 							LastConfirmedMessageID: rmq.NewRmqID(1),
 						},
 					},
@@ -4459,7 +4459,7 @@ func TestServer_BatchUpdateManifest(t *testing.T) {
 			AppendResults: map[string]*types2.AppendResult{
 				"by-dev-rootcoord-dml_0": {
 					MessageID:              rmq.NewRmqID(1),
-					TimeTick:               tsoutil.ComposeTSByTime(time.Now(), 0),
+					TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
 					LastConfirmedMessageID: rmq.NewRmqID(1),
 				},
 			},

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -424,7 +424,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) initSegBufferForSchemaBumpWithFie
 	for i := 0; i < 3; i++ {
 		value := map[int64]interface{}{
 			common.RowIDField:     segID + int64(i),
-			common.TimeStampField: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			common.TimeStampField: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 			100:                   segID + int64(i),
 			101:                   "test string " + string(rune('0'+i)),
 		}
@@ -433,7 +433,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) initSegBufferForSchemaBumpWithFie
 		}
 		v := storage.Value{
 			PK:        storage.NewInt64PrimaryKey(segID + int64(i)),
-			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 			Value:     value,
 		}
 		err = multiSegWriter.WriteValue(&v)
@@ -626,8 +626,8 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRebuildsTextStats(
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestSelectFullRewriteRecordDropsDeletedAndExpiredRows() {
 	currentTime := getMilvusBirthday().Add(time.Hour)
-	insertTs := tsoutil.ComposeTSByTime(currentTime, 0)
-	oldTs := tsoutil.ComposeTSByTime(currentTime.Add(-2*time.Minute), 0)
+	insertTs := tsoutil.ComposeTSByTime(currentTime)
+	oldTs := tsoutil.ComposeTSByTime(currentTime.Add(-2 * time.Minute))
 	expiredByTTLField := currentTime.Add(-time.Minute).UnixMicro()
 	keptTTLField := currentTime.Add(time.Hour).UnixMicro()
 	pkField := &schemapb.FieldSchema{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true}
@@ -645,7 +645,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestSelectFullRewriteRecordDropsD
 		},
 		len: 5,
 	}
-	deleteTs := tsoutil.ComposeTSByTime(currentTime.Add(time.Second), 0)
+	deleteTs := tsoutil.ComposeTSByTime(currentTime.Add(time.Second))
 	entityFilter := compaction.NewEntityFilter(map[any]typeutil.Timestamp{int64(2): deleteTs}, int64(time.Minute), currentTime, 0)
 
 	selection, ttlValues, err := selectFullRewriteRecord(record, pkField, entityFilter, 102, true, nil)

--- a/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
@@ -89,7 +89,7 @@ func (s *ClusteringCompactionTaskStorageV2Suite) TestScalarCompactionNormal_V2To
 	dblobs, err := getInt64DeltaBlobs(
 		1,
 		[]int64{100},
-		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second), 0)},
+		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second))},
 	)
 	s.Require().NoError(err)
 	s.mockBinlogIO.EXPECT().Download(mock.Anything, []string{deltalogs.GetBinlogs()[0].GetLogPath()}).
@@ -205,7 +205,7 @@ func (s *ClusteringCompactionTaskStorageV2Suite) initStorageV2Segments(rows int,
 	}).Return().Maybe()
 
 	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", CollectionID)
-	deleteData := storage.NewDeleteData([]storage.PrimaryKey{storage.NewInt64PrimaryKey(100)}, []uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second), 0)})
+	deleteData := storage.NewDeleteData([]storage.PrimaryKey{storage.NewInt64PrimaryKey(100)}, []uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second))})
 	pack := new(syncmgr.SyncPack).WithCollectionID(CollectionID).WithPartitionID(PartitionID).WithSegmentID(segmentID).WithChannelName(channelName).WithInsertData(genInsertData(rows, segmentID, genCollectionSchema())).WithDeleteData(deleteData)
 	sch := genCollectionSchema()
 	fields := typeutil.GetAllFieldSchemas(sch)

--- a/internal/datanode/compactor/clustering_compactor_storage_v3_test.go
+++ b/internal/datanode/compactor/clustering_compactor_storage_v3_test.go
@@ -208,7 +208,7 @@ func (s *ClusteringCompactionTaskStorageV3Suite) initStorageV3Segments(rows int,
 	channelName := fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", CollectionID)
 	deleteData := storage.NewDeleteData(
 		[]storage.PrimaryKey{storage.NewInt64PrimaryKey(100)},
-		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second), 0)},
+		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second))},
 	)
 	pack := new(syncmgr.SyncPack).
 		WithCollectionID(CollectionID).
@@ -517,7 +517,7 @@ func genTextLOBCompactionSchema() *schemapb.CollectionSchema {
 
 func genTextLOBInsertData(rows int, seed int64, schema *schemapb.CollectionSchema) []*storage.InsertData {
 	buf, _ := storage.NewInsertData(schema)
-	ts := int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0))
+	ts := int64(tsoutil.ComposeTSByTime(getMilvusBirthday()))
 	for i := 0; i < rows; i++ {
 		pk := seed*100 + int64(i)
 		_ = buf.Append(map[int64]interface{}{

--- a/internal/datanode/compactor/clustering_compactor_test.go
+++ b/internal/datanode/compactor/clustering_compactor_test.go
@@ -190,7 +190,7 @@ func (s *ClusteringCompactionTaskSuite) preparScalarCompactionNormalTask() {
 	dblobs, err := getInt64DeltaBlobs(
 		1,
 		[]int64{100},
-		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second), 0)},
+		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second))},
 	)
 	s.Require().NoError(err)
 	s.mockBinlogIO.EXPECT().Download(mock.Anything, []string{"1"}).
@@ -203,7 +203,7 @@ func (s *ClusteringCompactionTaskSuite) preparScalarCompactionNormalTask() {
 	for i := 0; i < 10240; i++ {
 		v := storage.Value{
 			PK:        storage.NewInt64PrimaryKey(int64(i)),
-			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 			Value:     genRow(int64(i)),
 		}
 		err = segWriter.Write(&v)
@@ -299,7 +299,7 @@ func (s *ClusteringCompactionTaskSuite) prepareScalarCompactionNormalByMemoryLim
 	for i := 0; i < 10240; i++ {
 		v := storage.Value{
 			PK:        storage.NewInt64PrimaryKey(int64(i)),
-			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 			Value:     genRow(int64(i)),
 		}
 		err = segWriter.Write(&v)
@@ -403,7 +403,7 @@ func (s *ClusteringCompactionTaskSuite) prepareCompactionWithBM25OutputTask(rowN
 	for i := 0; i < rowNum; i++ {
 		v := storage.Value{
 			PK:        storage.NewInt64PrimaryKey(int64(i)),
-			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 			Value:     genRowWithBM25(int64(i)),
 		}
 		err = segWriter.Write(&v)
@@ -533,7 +533,7 @@ func (s *ClusteringCompactionTaskSuite) TestScalarAnalyzeSegmentFiltersDroppedOr
 }
 
 func genRow(magic int64) map[int64]interface{} {
-	ts := tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)
+	ts := tsoutil.ComposeTSByTime(getMilvusBirthday())
 	return map[int64]interface{}{
 		common.RowIDField:     magic,
 		common.TimeStampField: int64(ts),
@@ -648,7 +648,7 @@ func genCollectionSchemaWithBM25() *schemapb.CollectionSchema {
 }
 
 func genRowWithBM25(magic int64) map[int64]interface{} {
-	ts := tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)
+	ts := tsoutil.ComposeTSByTime(getMilvusBirthday())
 	return map[int64]interface{}{
 		common.RowIDField:     magic,
 		common.TimeStampField: int64(ts),

--- a/internal/datanode/compactor/mix_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/mix_compactor_storage_v2_test.go
@@ -112,7 +112,7 @@ func (s *MixCompactionTaskStorageV2Suite) TestCompactDupPK_MixToV2Format() {
 	dblobs, err := getInt64DeltaBlobs(
 		1,
 		[]int64{100},
-		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second), 0)},
+		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second))},
 	)
 	s.Require().NoError(err)
 
@@ -324,7 +324,7 @@ func (s *MixCompactionTaskStorageV2Suite) initStorageV2Segments(rows int, seed i
 }
 
 func getRowWithoutNil(magic int64) map[int64]interface{} {
-	ts := tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)
+	ts := tsoutil.ComposeTSByTime(getMilvusBirthday())
 	return map[int64]interface{}{
 		common.RowIDField:      magic,
 		common.TimeStampField:  int64(ts), // should be int64 here

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -155,7 +155,7 @@ func TestMixCompactionMaterializesMissingFieldWithDeleteFilter(t *testing.T) {
 	s.Require().NoError(err)
 	removeFieldBinlogForTest(kvs, fBinlogs, StringField)
 
-	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10*time.Second), 0)
+	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10 * time.Second))
 	blob, err := getInt64DeltaBlobs(segmentID, []int64{segmentID}, []uint64{deleteTs})
 	s.Require().NoError(err)
 	deltaPath := "deltalog/missing-field-delete"
@@ -304,7 +304,7 @@ func (s *MixCompactionTaskStorageV1Suite) prepareCompactDupPKSegments() {
 	dblobs, err := getInt64DeltaBlobs(
 		1,
 		[]int64{100},
-		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second), 0)},
+		[]uint64{tsoutil.ComposeTSByTime(getMilvusBirthday().Add(time.Second))},
 	)
 	s.Require().NoError(err)
 
@@ -463,7 +463,7 @@ func (s *MixCompactionTaskStorageV1Suite) prepareCompactSortedSegment() {
 	alloc := allocator.NewLocalAllocator(100, math.MaxInt64)
 	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil)
 	s.task.plan.SegmentBinlogs = make([]*datapb.CompactionSegmentBinlogs, 0)
-	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10*time.Second), 0)
+	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10 * time.Second))
 	for _, segID := range segments {
 		s.initMultiRowsSegBuffer(segID, 100, 3)
 		kvs, fBinlogs, err := serializeWrite(context.TODO(), alloc, s.segWriter)
@@ -522,7 +522,7 @@ func (s *MixCompactionTaskStorageV1Suite) prepareCompactSortedSegmentLackBinlog(
 	alloc := allocator.NewLocalAllocator(100, math.MaxInt64)
 	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil)
 	s.task.plan.SegmentBinlogs = make([]*datapb.CompactionSegmentBinlogs, 0)
-	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10*time.Second), 0)
+	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10 * time.Second))
 	addedFieldSet := typeutil.NewSet[int64]()
 	for _, f := range s.meta.GetSchema().GetFields() {
 		if !f.Nullable {
@@ -644,7 +644,7 @@ func (s *MixCompactionTaskStorageV1Suite) TestSplitMergeEntityExpired() {
 
 func (s *MixCompactionTaskStorageV1Suite) TestMergeNoExpirationLackBinlog() {
 	s.initSegBuffer(1, 4)
-	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10*time.Second), 0)
+	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10 * time.Second))
 	tests := []struct {
 		description string
 		deletions   map[int64]uint64
@@ -731,7 +731,7 @@ func (s *MixCompactionTaskStorageV1Suite) TestMergeNoExpirationLackBinlog() {
 
 func (s *MixCompactionTaskStorageV1Suite) TestMergeNoExpiration() {
 	s.initSegBuffer(1, 4)
-	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10*time.Second), 0)
+	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday().Add(10 * time.Second))
 	tests := []struct {
 		description string
 		deletions   map[int64]uint64
@@ -993,7 +993,7 @@ func (s *MixCompactionTaskStorageV1Suite) TestCompactFail() {
 
 func getRow(magic int64, ts int64) map[int64]interface{} {
 	if ts == 0 {
-		ts = int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0))
+		ts = int64(tsoutil.ComposeTSByTime(getMilvusBirthday()))
 	}
 	return map[int64]interface{}{
 		common.RowIDField:      magic,
@@ -1037,7 +1037,7 @@ func (s *MixCompactionTaskStorageV1Suite) initMultiRowsSegBuffer(magic, numRows,
 	for i := int64(0); i < numRows; i++ {
 		v := storage.Value{
 			PK:        storage.NewInt64PrimaryKey(magic + i*step),
-			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 			Value:     getRow(magic+i*step, 0),
 		}
 		err = segWriter.Write(&v)
@@ -1055,7 +1055,7 @@ func (s *MixCompactionTaskStorageV1Suite) initSegBufferWithBM25(magic int64) {
 
 	v := storage.Value{
 		PK:        storage.NewInt64PrimaryKey(magic),
-		Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+		Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 		Value:     genRowWithBM25(magic),
 	}
 	err = segWriter.Write(&v)
@@ -1072,8 +1072,8 @@ func (s *MixCompactionTaskStorageV1Suite) initSegBuffer(size int, seed int64) {
 	for i := 0; i < size; i++ {
 		v := storage.Value{
 			PK:        storage.NewInt64PrimaryKey(seed),
-			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
-			Value:     getRow(seed, int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0))),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
+			Value:     getRow(seed, int64(tsoutil.ComposeTSByTime(getMilvusBirthday()))),
 		}
 		err = segWriter.Write(&v)
 		s.Require().NoError(err)

--- a/internal/datanode/compactor/multi_segment_writer_test.go
+++ b/internal/datanode/compactor/multi_segment_writer_test.go
@@ -223,7 +223,7 @@ func (s *MultiSegmentWriterSuite) genSimpleSchema() *schemapb.CollectionSchema {
 
 // genTestValue generates a test storage.Value for the given ID
 func (s *MultiSegmentWriterSuite) genTestValue(id int64) *storage.Value {
-	ts := tsoutil.ComposeTSByTime(time.Now(), 0)
+	ts := tsoutil.ComposeTSByTime(time.Now())
 	return &storage.Value{
 		PK:        storage.NewInt64PrimaryKey(id),
 		Timestamp: int64(ts),

--- a/internal/datanode/compactor/namespace_compactor_test.go
+++ b/internal/datanode/compactor/namespace_compactor_test.go
@@ -91,7 +91,7 @@ func (s *NamespaceCompactorTestSuite) setupSortedSegments() {
 		for j := 0; j < rows; j++ {
 			v := map[int64]interface{}{
 				common.RowIDField:     int64(j),
-				common.TimeStampField: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+				common.TimeStampField: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 				100:                   int64(j),
 				101:                   int64(j),
 			}

--- a/internal/datanode/compactor/segment_writer_test.go
+++ b/internal/datanode/compactor/segment_writer_test.go
@@ -51,7 +51,7 @@ func (s *SegmentWriteSuite) TestWriteFailed() {
 
 		v := storage.Value{
 			PK:        storage.NewInt64PrimaryKey(int64(0)),
-			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 			Value:     genRowWithBM25(int64(0)),
 		}
 		err = writer.Write(&v)
@@ -66,7 +66,7 @@ func (s *SegmentWriteSuite) TestWriteFailed() {
 
 		v := storage.Value{
 			PK:        storage.NewInt64PrimaryKey(int64(0)),
-			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 			Value:     genRowWithBM25(int64(0)),
 		}
 		err = writer.Write(&v)

--- a/internal/datanode/compactor/sort_compaction_test.go
+++ b/internal/datanode/compactor/sort_compaction_test.go
@@ -207,7 +207,7 @@ func (s *SortCompactionTaskSuite) prepareSortCompactionTask() {
 	})).Return(lo.Values(kvs), nil).Once()
 
 	// Create delta log for deletion
-	deleteTs := tsoutil.ComposeTSByTime(getMilvusBirthday(), 5)
+	deleteTs := tsoutil.ComposeTSByTimeWithLogical(getMilvusBirthday(), 5)
 	blob, err := getInt64DeltaBlobs(segmentID, []int64{segmentID}, []uint64{deleteTs})
 	s.Require().NoError(err)
 	deltaPath := "deltalog/1001"
@@ -448,8 +448,8 @@ func (s *SortCompactionTaskSuite) initSegBuffer(size int, seed int64) {
 	for i := 0; i < size; i++ {
 		v := storage.Value{
 			PK:        storage.NewInt64PrimaryKey(seed),
-			Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), int64(i))),
-			Value:     getRow(seed, int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), int64(i)))),
+			Timestamp: int64(tsoutil.ComposeTSByTimeWithLogical(getMilvusBirthday(), int64(i))),
+			Value:     getRow(seed, int64(tsoutil.ComposeTSByTimeWithLogical(getMilvusBirthday(), int64(i)))),
 		}
 		err := s.segWriter.Write(&v)
 		s.Require().NoError(err)
@@ -462,7 +462,7 @@ func (s *SortCompactionTaskSuite) initSegBufferWithBM25(seed int64) {
 
 	v := storage.Value{
 		PK:        storage.NewInt64PrimaryKey(seed),
-		Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+		Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 		Value:     genRowWithBM25(seed),
 	}
 	err := s.segWriter.Write(&v)

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -80,7 +80,7 @@ func (s *TaskStatsSuite) GenSegmentWriterWithBM25(magic int64) {
 
 	v := storage.Value{
 		PK:        storage.NewInt64PrimaryKey(magic),
-		Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+		Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 		Value:     genRowWithBM25(magic),
 	}
 	err = segWriter.Write(&v)
@@ -288,7 +288,7 @@ func genCollectionSchemaWithBM25() *schemapb.CollectionSchema {
 }
 
 func genRowWithBM25(magic int64) map[int64]interface{} {
-	ts := tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)
+	ts := tsoutil.ComposeTSByTime(getMilvusBirthday())
 	return map[int64]interface{}{
 		common.RowIDField:     magic,
 		common.TimeStampField: int64(ts),

--- a/internal/flushcommon/broker/datacoord_test.go
+++ b/internal/flushcommon/broker/datacoord_test.go
@@ -173,7 +173,7 @@ func (s *dataCoordSuite) TestUpdateChannelCheckpoint() {
 	checkpoint := &msgpb.MsgPosition{
 		ChannelName: channelName,
 		MsgID:       []byte{1, 2, 3},
-		Timestamp:   tsoutil.ComposeTSByTime(time.Now(), 0),
+		Timestamp:   tsoutil.ComposeTSByTime(time.Now()),
 	}
 
 	s.Run("normal_case", func() {

--- a/internal/flushcommon/pipeline/data_sync_service_test.go
+++ b/internal/flushcommon/pipeline/data_sync_service_test.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -447,7 +448,7 @@ func (s *DataSyncServiceSuite) TestStartStop() {
 		TimestampMax: math.MaxUint64 - 1,
 	}
 
-	msgTs := tsoutil.GetCurrentTime()
+	msgTs := tsoutil.ComposeTSByTime(time.Now())
 	dataFactory := NewDataFactory()
 	insertMessages := dataFactory.GetMsgStreamTsInsertMsgs(2, insertChannelName, msgTs)
 
@@ -470,15 +471,15 @@ func (s *DataSyncServiceSuite) TestStartStop() {
 
 	timeTickMsg := &msgstream.TimeTickMsg{
 		BaseMsg: msgstream.BaseMsg{
-			BeginTimestamp: tsoutil.GetCurrentTime(),
-			EndTimestamp:   tsoutil.GetCurrentTime(),
+			BeginTimestamp: tsoutil.ComposeTSByTime(time.Now()),
+			EndTimestamp:   tsoutil.ComposeTSByTime(time.Now()),
 			HashValues:     []uint32{0},
 		},
 		TimeTickMsg: &msgpb.TimeTickMsg{
 			Base: &commonpb.MsgBase{
 				MsgType:   commonpb.MsgType_TimeTick,
 				MsgID:     typeutil.UniqueID(0),
-				Timestamp: tsoutil.GetCurrentTime(),
+				Timestamp: tsoutil.ComposeTSByTime(time.Now()),
 				SourceID:  0,
 			},
 		},

--- a/internal/flushcommon/syncmgr/storage_serializer_test.go
+++ b/internal/flushcommon/syncmgr/storage_serializer_test.go
@@ -130,7 +130,7 @@ func (s *StorageV1SerializerSuite) getDeleteBuffer() *storage.DeleteData {
 	buf := &storage.DeleteData{}
 	for i := 0; i < 10; i++ {
 		pk := storage.NewInt64PrimaryKey(int64(i + 1))
-		ts := tsoutil.ComposeTSByTime(time.Now(), 0)
+		ts := tsoutil.ComposeTSByTime(time.Now())
 		buf.Append(pk, ts)
 	}
 	return buf

--- a/internal/flushcommon/syncmgr/task_test.go
+++ b/internal/flushcommon/syncmgr/task_test.go
@@ -146,7 +146,7 @@ func (s *SyncTaskSuite) getDeleteBuffer() *storage.DeleteData {
 	buf := &storage.DeleteData{}
 	for i := 0; i < 10; i++ {
 		pk := storage.NewInt64PrimaryKey(int64(i + 1))
-		ts := tsoutil.ComposeTSByTime(time.Now(), 0)
+		ts := tsoutil.ComposeTSByTime(time.Now())
 		buf.Append(pk, ts)
 	}
 	return buf

--- a/internal/flushcommon/writebuffer/delta_buffer_test.go
+++ b/internal/flushcommon/writebuffer/delta_buffer_test.go
@@ -22,7 +22,7 @@ func (s *DeltaBufferSuite) TestBuffer() {
 	s.Run("int64_pk", func() {
 		deltaBuffer := NewDeltaBuffer()
 
-		tss := lo.RepeatBy(100, func(idx int) uint64 { return tsoutil.ComposeTSByTime(time.Now(), int64(idx)) })
+		tss := lo.RepeatBy(100, func(idx int) uint64 { return tsoutil.ComposeTSByTimeWithLogical(time.Now(), int64(idx)) })
 		pks := lo.Map(tss, func(ts uint64, _ int) storage.PrimaryKey { return storage.NewInt64PrimaryKey(int64(ts)) })
 
 		memSize := deltaBuffer.Buffer(pks, tss, &msgpb.MsgPosition{Timestamp: 100}, &msgpb.MsgPosition{Timestamp: 200})
@@ -33,7 +33,7 @@ func (s *DeltaBufferSuite) TestBuffer() {
 	s.Run("string_pk", func() {
 		deltaBuffer := NewDeltaBuffer()
 
-		tss := lo.RepeatBy(100, func(idx int) uint64 { return tsoutil.ComposeTSByTime(time.Now(), int64(idx)) })
+		tss := lo.RepeatBy(100, func(idx int) uint64 { return tsoutil.ComposeTSByTimeWithLogical(time.Now(), int64(idx)) })
 		pks := lo.Map(tss, func(ts uint64, idx int) storage.PrimaryKey {
 			return storage.NewVarCharPrimaryKey(fmt.Sprintf("%03d", idx))
 		})
@@ -52,7 +52,7 @@ func (s *DeltaBufferSuite) TestYield() {
 
 	deltaBuffer = NewDeltaBuffer()
 
-	tss := lo.RepeatBy(100, func(idx int) uint64 { return tsoutil.ComposeTSByTime(time.Now(), int64(idx)) })
+	tss := lo.RepeatBy(100, func(idx int) uint64 { return tsoutil.ComposeTSByTimeWithLogical(time.Now(), int64(idx)) })
 	pks := lo.Map(tss, func(ts uint64, _ int) storage.PrimaryKey { return storage.NewInt64PrimaryKey(int64(ts)) })
 
 	deltaBuffer.Buffer(pks, tss, &msgpb.MsgPosition{Timestamp: 100}, &msgpb.MsgPosition{Timestamp: 200})

--- a/internal/flushcommon/writebuffer/insert_buffer_test.go
+++ b/internal/flushcommon/writebuffer/insert_buffer_test.go
@@ -49,7 +49,7 @@ func (s *InsertBufferSuite) SetupSuite() {
 }
 
 func (s *InsertBufferSuite) composeInsertMsg(rowCount int, dim int) ([]int64, *msgstream.InsertMsg) {
-	tss := lo.RepeatBy(rowCount, func(idx int) int64 { return int64(tsoutil.ComposeTSByTime(time.Now(), int64(idx))) })
+	tss := lo.RepeatBy(rowCount, func(idx int) int64 { return int64(tsoutil.ComposeTSByTimeWithLogical(time.Now(), int64(idx))) })
 	vectors := lo.RepeatBy(rowCount, func(_ int) []float32 {
 		return lo.RepeatBy(dim, func(_ int) float32 { return rand.Float32() })
 	})

--- a/internal/flushcommon/writebuffer/l0_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer_test.go
@@ -176,7 +176,7 @@ func (s *L0WriteBufferSuite) SetupSuite() {
 }
 
 func (s *L0WriteBufferSuite) composeInsertMsg(segmentID int64, rowCount int, dim int, pkType schemapb.DataType) ([]int64, *msgstream.InsertMsg) {
-	tss := lo.RepeatBy(rowCount, func(idx int) int64 { return int64(tsoutil.ComposeTSByTime(time.Now(), int64(idx))) })
+	tss := lo.RepeatBy(rowCount, func(idx int) int64 { return int64(tsoutil.ComposeTSByTimeWithLogical(time.Now(), int64(idx))) })
 	vectors := lo.RepeatBy(rowCount, func(_ int) []float32 {
 		return lo.RepeatBy(dim, func(_ int) float32 { return rand.Float32() })
 	})
@@ -296,7 +296,7 @@ func (s *L0WriteBufferSuite) composeDeleteMsg(pks []storage.PrimaryKey) *msgstre
 	delMsg := &msgstream.DeleteMsg{
 		DeleteRequest: &msgpb.DeleteRequest{
 			PrimaryKeys: storage.ParsePrimaryKeys2IDs(pks),
-			Timestamps:  lo.RepeatBy(len(pks), func(idx int) uint64 { return tsoutil.ComposeTSByTime(time.Now(), int64(idx)+1) }),
+			Timestamps:  lo.RepeatBy(len(pks), func(idx int) uint64 { return tsoutil.ComposeTSByTimeWithLogical(time.Now(), int64(idx)+1) }),
 		},
 	}
 	return delMsg
@@ -308,7 +308,7 @@ func (s *L0WriteBufferSuite) SetupTest() {
 	s.metacache.EXPECT().GetSchema(mock.Anything).Return(s.collSchema).Maybe()
 	s.metacache.EXPECT().Collection().Return(s.collID).Maybe()
 	s.allocator = allocator.NewMockGIDAllocator()
-	s.allocator.AllocOneF = func() (int64, error) { return int64(tsoutil.ComposeTSByTime(time.Now(), 0)), nil }
+	s.allocator.AllocOneF = func() (int64, error) { return int64(tsoutil.ComposeTSByTime(time.Now())), nil }
 }
 
 func (s *L0WriteBufferSuite) newTextMetaCache(schema *schemapb.CollectionSchema) *metacache.MockMetaCache {

--- a/internal/flushcommon/writebuffer/manager_test.go
+++ b/internal/flushcommon/writebuffer/manager_test.go
@@ -190,7 +190,7 @@ func (s *ManagerSuite) TestGetCheckpoint() {
 		wb := NewMockWriteBuffer(s.T())
 
 		manager.buffers.Insert(s.channelName, wb)
-		pos := &msgpb.MsgPosition{ChannelName: s.channelName, Timestamp: tsoutil.ComposeTSByTime(time.Now(), 0)}
+		pos := &msgpb.MsgPosition{ChannelName: s.channelName, Timestamp: tsoutil.ComposeTSByTime(time.Now())}
 		wb.EXPECT().GetCheckpoint().Return(pos)
 		wb.EXPECT().GetFlushTimestamp().Return(nonFlushTS)
 		result, needUpdate, err := manager.GetCheckpoint(s.channelName)
@@ -203,7 +203,7 @@ func (s *ManagerSuite) TestGetCheckpoint() {
 		wb := NewMockWriteBuffer(s.T())
 
 		manager.buffers.Insert(s.channelName, wb)
-		cpTimestamp := tsoutil.ComposeTSByTime(time.Now(), 0)
+		cpTimestamp := tsoutil.ComposeTSByTime(time.Now())
 
 		pos := &msgpb.MsgPosition{ChannelName: s.channelName, Timestamp: cpTimestamp}
 		wb.EXPECT().GetCheckpoint().Return(pos)

--- a/internal/flushcommon/writebuffer/sync_policy_test.go
+++ b/internal/flushcommon/writebuffer/sync_policy_test.go
@@ -55,21 +55,21 @@ func (s *SyncPolicySuite) TestSyncStalePolicy() {
 	buffer, err := newSegmentBuffer(100, s.collSchema)
 	s.Require().NoError(err)
 
-	ids := policy.SelectSegments([]*segmentBuffer{buffer}, tsoutil.ComposeTSByTime(time.Now(), 0))
+	ids := policy.SelectSegments([]*segmentBuffer{buffer}, tsoutil.ComposeTSByTime(time.Now()))
 	s.Equal(0, len(ids), "empty buffer shall not be synced")
 
 	buffer.insertBuffer.startPos = &msgpb.MsgPosition{
-		Timestamp: tsoutil.ComposeTSByTime(time.Now().Add(-time.Minute*3), 0),
+		Timestamp: tsoutil.ComposeTSByTime(time.Now().Add(-time.Minute * 3)),
 	}
 
-	ids = policy.SelectSegments([]*segmentBuffer{buffer}, tsoutil.ComposeTSByTime(time.Now(), 0))
+	ids = policy.SelectSegments([]*segmentBuffer{buffer}, tsoutil.ComposeTSByTime(time.Now()))
 	s.ElementsMatch([]int64{100}, ids)
 
 	buffer.insertBuffer.startPos = &msgpb.MsgPosition{
-		Timestamp: tsoutil.ComposeTSByTime(time.Now().Add(-time.Minute), 0),
+		Timestamp: tsoutil.ComposeTSByTime(time.Now().Add(-time.Minute)),
 	}
 
-	ids = policy.SelectSegments([]*segmentBuffer{buffer}, tsoutil.ComposeTSByTime(time.Now(), 0))
+	ids = policy.SelectSegments([]*segmentBuffer{buffer}, tsoutil.ComposeTSByTime(time.Now()))
 	s.Equal(0, len(ids), "")
 }
 
@@ -78,7 +78,7 @@ func (s *SyncPolicySuite) TestSyncDroppedPolicy() {
 	policy := GetDroppedSegmentPolicy(metacache)
 	ids := []int64{1, 2, 3}
 	metacache.EXPECT().GetSegmentIDsBy(mock.Anything).Return(ids)
-	result := policy.SelectSegments([]*segmentBuffer{}, tsoutil.ComposeTSByTime(time.Now(), 0))
+	result := policy.SelectSegments([]*segmentBuffer{}, tsoutil.ComposeTSByTime(time.Now()))
 	s.ElementsMatch(ids, result)
 }
 
@@ -89,7 +89,7 @@ func (s *SyncPolicySuite) TestSealedSegmentsPolicy() {
 	metacache.EXPECT().GetSegmentIDsBy(mock.Anything).Return(ids)
 	metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything, mock.Anything).Return()
 
-	result := policy.SelectSegments([]*segmentBuffer{}, tsoutil.ComposeTSByTime(time.Now(), 0))
+	result := policy.SelectSegments([]*segmentBuffer{}, tsoutil.ComposeTSByTime(time.Now()))
 	s.ElementsMatch(ids, result)
 }
 

--- a/internal/flushcommon/writebuffer/write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/write_buffer_test.go
@@ -733,9 +733,9 @@ func (s *WriteBufferSuite) TestGrowingSourceProgressSelectedByPolicy() {
 	}()
 
 	now := time.Now()
-	recentTs := tsoutil.ComposeTSByTime(now.Add(500*time.Millisecond), 0)
-	staleTs := tsoutil.ComposeTSByTime(now.Add(2*time.Second), 0)
-	startTs := tsoutil.ComposeTSByTime(now, 0)
+	recentTs := tsoutil.ComposeTSByTime(now.Add(500 * time.Millisecond))
+	staleTs := tsoutil.ComposeTSByTime(now.Add(2 * time.Second))
+	startTs := tsoutil.ComposeTSByTime(now)
 
 	s.Run("pending_flush", func() {
 		selected := s.wb.growingSourceProgressSelectedByPolicy(recentTs, 1001, &growingSourceProgress{

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -899,7 +899,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	if collectionInfo.collectionTTL != 0 {
 		physicalTime := tsoutil.PhysicalTime(t.GetBase().GetTimestamp())
 		expireTime := physicalTime.Add(-time.Duration(collectionInfo.collectionTTL))
-		t.CollectionTtlTimestamps = tsoutil.ComposeTSByTime(expireTime, 0)
+		t.CollectionTtlTimestamps = tsoutil.ComposeTSByTime(expireTime)
 		// preventing overflow, abort
 		if t.CollectionTtlTimestamps > t.GetBase().GetTimestamp() {
 			return merr.WrapErrServiceInternalMsg("ttl timestamp overflow, base timestamp: %d, ttl duration %v", t.GetBase().GetTimestamp(), collectionInfo.collectionTTL)
@@ -907,7 +907,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	}
 	deadline, ok := t.TraceCtx().Deadline()
 	if ok {
-		t.TimeoutTimestamp = tsoutil.ComposeTSByTime(deadline, 0)
+		t.TimeoutTimestamp = tsoutil.ComposeTSByTime(deadline)
 	}
 
 	t.DbID = 0 // TODO

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -322,7 +322,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	t.IsIterator = t.isIterator
 
 	if deadline, ok := t.TraceCtx().Deadline(); ok {
-		t.TimeoutTimestamp = tsoutil.ComposeTSByTime(deadline, 0)
+		t.TimeoutTimestamp = tsoutil.ComposeTSByTime(deadline)
 	}
 
 	// Set username of this search request for feature like task scheduling.
@@ -333,7 +333,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	if collectionInfo.collectionTTL != 0 {
 		physicalTime := tsoutil.PhysicalTime(t.GetBase().GetTimestamp())
 		expireTime := physicalTime.Add(-time.Duration(collectionInfo.collectionTTL))
-		t.CollectionTtlTimestamps = tsoutil.ComposeTSByTime(expireTime, 0)
+		t.CollectionTtlTimestamps = tsoutil.ComposeTSByTime(expireTime)
 		// preventing overflow, abort
 		if t.CollectionTtlTimestamps > t.GetBase().GetTimestamp() {
 			return merr.WrapErrServiceInternalMsg("ttl timestamp overflow, base timestamp: %d, ttl duration %v", t.GetBase().GetTimestamp(), collectionInfo.collectionTTL)

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -148,7 +148,7 @@ func TestSearchTask_PostExecute(t *testing.T) {
 			tr:       timerecord.NewTimeRecorder("test-search"),
 		}
 		require.NoError(t, task.OnEnqueue())
-		task.SetTs(tsoutil.ComposeTSByTime(time.Now(), 0))
+		task.SetTs(tsoutil.ComposeTSByTime(time.Now()))
 		return task
 	}
 	t.Run("Test empty result", func(t *testing.T) {
@@ -852,7 +852,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 			tr:       timerecord.NewTimeRecorder("test-search"),
 		}
 		require.NoError(t, task.OnEnqueue())
-		task.SetTs(tsoutil.ComposeTSByTime(time.Now(), 0))
+		task.SetTs(tsoutil.ComposeTSByTime(time.Now()))
 		return task
 	}
 
@@ -869,7 +869,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 			tr:       timerecord.NewTimeRecorder("test-search"),
 		}
 		require.NoError(t, task.OnEnqueue())
-		task.SetTs(tsoutil.ComposeTSByTime(time.Now(), 0))
+		task.SetTs(tsoutil.ComposeTSByTime(time.Now()))
 		return task
 	}
 
@@ -903,7 +903,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 			tr:       timerecord.NewTimeRecorder("test-search"),
 		}
 		require.NoError(t, task.OnEnqueue())
-		task.SetTs(tsoutil.ComposeTSByTime(time.Now(), 0))
+		task.SetTs(tsoutil.ComposeTSByTime(time.Now()))
 		return task
 	}
 
@@ -1044,7 +1044,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 		_, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		require.Equal(t, typeutil.ZeroTimestamp, st.TimeoutTimestamp)
-		enqueueTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+		enqueueTs := tsoutil.ComposeTSByTime(time.Now())
 		st.SetTs(enqueueTs)
 		assert.NoError(t, st.PreExecute(ctx))
 		assert.True(t, st.isIterator)
@@ -1073,7 +1073,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 		_, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		require.Equal(t, typeutil.ZeroTimestamp, st.TimeoutTimestamp)
-		enqueueTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+		enqueueTs := tsoutil.ComposeTSByTime(time.Now())
 		st.SetTs(enqueueTs)
 		assert.Error(t, st.PreExecute(ctx))
 	})
@@ -1104,7 +1104,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 		_, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		require.Equal(t, typeutil.ZeroTimestamp, st.TimeoutTimestamp)
-		enqueueTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+		enqueueTs := tsoutil.ComposeTSByTime(time.Now())
 		st.SetTs(enqueueTs)
 		assert.NoError(t, st.PreExecute(ctx))
 		assert.NotNil(t, st.rerankMeta)
@@ -1133,7 +1133,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 		_, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		require.Equal(t, typeutil.ZeroTimestamp, st.TimeoutTimestamp)
-		enqueueTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+		enqueueTs := tsoutil.ComposeTSByTime(time.Now())
 		st.SetTs(enqueueTs)
 		assert.NoError(t, st.PreExecute(ctx))
 		assert.NotNil(t, st.rerankMeta)
@@ -1155,7 +1155,7 @@ func TestSearchTask_PreExecute(t *testing.T) {
 		_, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		require.Equal(t, typeutil.ZeroTimestamp, st.TimeoutTimestamp)
-		enqueueTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+		enqueueTs := tsoutil.ComposeTSByTime(time.Now())
 		st.SetTs(enqueueTs)
 		assert.NoError(t, st.PreExecute(ctx))
 	})

--- a/internal/proxy/task_statistic.go
+++ b/internal/proxy/task_statistic.go
@@ -127,7 +127,7 @@ func (g *getStatisticsTask) PreExecute(ctx context.Context) error {
 
 	deadline, ok := g.TraceCtx().Deadline()
 	if ok {
-		g.TimeoutTimestamp = tsoutil.ComposeTSByTime(deadline, 0)
+		g.TimeoutTimestamp = tsoutil.ComposeTSByTime(deadline)
 	}
 
 	// check if collection/partitions are loaded into query node

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2318,8 +2318,8 @@ func Test_UpsertTaskCheckPrimaryFieldData(t *testing.T) {
 func Test_ParseGuaranteeTs(t *testing.T) {
 	strongTs := typeutil.Timestamp(0)
 	boundedTs := typeutil.Timestamp(2)
-	tsNow := tsoutil.GetCurrentTime()
-	tsMax := tsoutil.GetCurrentTime()
+	tsNow := tsoutil.ComposeTSByTime(time.Now())
+	tsMax := tsoutil.ComposeTSByTime(time.Now())
 
 	assert.Equal(t, tsMax, parseGuaranteeTs(strongTs, tsMax))
 	ratio := Params.CommonCfg.GracefulTime.GetAsDuration(time.Millisecond)
@@ -2336,8 +2336,8 @@ func Test_ParseGuaranteeTsFromConsistency(t *testing.T) {
 
 	tsDefault := typeutil.Timestamp(0)
 	tsEventually := typeutil.Timestamp(1)
-	tsNow := tsoutil.GetCurrentTime()
-	tsMax := tsoutil.GetCurrentTime()
+	tsNow := tsoutil.ComposeTSByTime(time.Now())
+	tsMax := tsoutil.ComposeTSByTime(time.Now())
 
 	assert.Equal(t, tsMax, parseGuaranteeTsFromConsistency(tsDefault, tsMax, strong))
 	ratio := Params.CommonCfg.GracefulTime.GetAsDuration(time.Millisecond)

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -137,7 +137,7 @@ func initStreamingSystem() {
 		for _, vchannel := range msg.BroadcastHeader().VChannels {
 			results[vchannel] = &message.AppendResult{
 				MessageID:              walimplstest.NewTestMessageID(1),
-				TimeTick:               tsoutil.ComposeTSByTime(time.Now(), 0),
+				TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
 				LastConfirmedMessageID: walimplstest.NewTestMessageID(1),
 			}
 		}

--- a/internal/querycoordv2/utils/types_test.go
+++ b/internal/querycoordv2/utils/types_test.go
@@ -32,10 +32,10 @@ func Test_packLoadSegmentRequest(t *testing.T) {
 	mockVChannel := "fake-by-dev-rootcoord-dml-1-test-packLoadSegmentRequest-v0"
 	mockPChannel := "fake-by-dev-rootcoord-dml-1"
 
-	t0 := tsoutil.ComposeTSByTime(time.Now().Add(-20*time.Minute), 0)
-	t1 := tsoutil.ComposeTSByTime(time.Now().Add(-8*time.Minute), 0)
-	t2 := tsoutil.ComposeTSByTime(time.Now().Add(-5*time.Minute), 0)
-	t3 := tsoutil.ComposeTSByTime(time.Now().Add(-1*time.Minute), 0)
+	t0 := tsoutil.ComposeTSByTime(time.Now().Add(-20 * time.Minute))
+	t1 := tsoutil.ComposeTSByTime(time.Now().Add(-8 * time.Minute))
+	t2 := tsoutil.ComposeTSByTime(time.Now().Add(-5 * time.Minute))
+	t3 := tsoutil.ComposeTSByTime(time.Now().Add(-1 * time.Minute))
 
 	segmentInfo := &datapb.SegmentInfo{
 		ID:            0,
@@ -88,7 +88,7 @@ func TestPackSegmentLoadInfo_ManifestPath(t *testing.T) {
 	mockPChannel := "fake-by-dev-rootcoord-dml-1"
 	checkpoint := &msgpb.MsgPosition{
 		ChannelName: mockPChannel,
-		Timestamp:   tsoutil.ComposeTSByTime(time.Now().Add(-1*time.Minute), 0),
+		Timestamp:   tsoutil.ComposeTSByTime(time.Now().Add(-1 * time.Minute)),
 	}
 
 	t.Run("manifest set clears legacy stats fields", func(t *testing.T) {

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1139,7 +1139,7 @@ func (sd *shardDelegator) GetLatestRequiredMVCCTimeTick() uint64 {
 		// If the empty timetick is filtered, the load operation will be blocked.
 		// We want the delegator to catch up the streaming data, and load done as soon as possible,
 		// so we always return the current time as the latest required mvcc timestamp.
-		return tsoutil.GetCurrentTime()
+		return tsoutil.ComposeTSByTime(time.Now())
 	}
 	return sd.latestRequiredMVCCTimeTick.Load()
 }

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -187,7 +187,7 @@ func (s *DelegatorDataSuite) genNormalCollection() {
 	}, &querypb.LoadMetaInfo{
 		LoadType:        querypb.LoadType_LoadCollection,
 		PartitionIDs:    []int64{1001, 1002},
-		SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now(), 0),
+		SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now()),
 	})
 }
 
@@ -221,7 +221,7 @@ func (s *DelegatorDataSuite) genTextCollection() {
 	}, nil, &querypb.LoadMetaInfo{
 		LoadType:        querypb.LoadType_LoadCollection,
 		PartitionIDs:    []int64{1001},
-		SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now(), 0),
+		SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now()),
 	})
 }
 
@@ -258,7 +258,7 @@ func (s *DelegatorDataSuite) genCollectionWithFunction() {
 			InputFieldIds:  []int64{102},
 			OutputFieldIds: []int64{101},
 		}},
-	}, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now(), 0)})
+	}, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now())})
 
 	delegator, err := NewShardDelegator(context.Background(), s.collectionID, s.replicaID, s.vchannelName, s.version, s.workerManager, s.manager, s.loader, 10000, nil, s.chunkManager, NewChannelQueryView(nil, nil, nil, initialTargetVersion), nil)
 	s.NoError(err)

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -172,7 +172,7 @@ func (s *DelegatorSuite) SetupTest() {
 		},
 	}, &querypb.LoadMetaInfo{
 		PartitionIDs:    s.partitionIDs,
-		SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now(), 0),
+		SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now()),
 	})
 
 	s.mq = &msgstream.MockMsgStream{}
@@ -220,7 +220,7 @@ func (s *DelegatorSuite) TestCreateDelegatorWithFunction() {
 				InputFieldIds:  []int64{102},
 				OutputFieldIds: []int64{101, 103}, // invalid output field
 			}},
-		}, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		}, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now())})
 
 		_, err := NewShardDelegator(context.Background(), s.collectionID, s.replicaID, s.vchannelName, s.version, s.workerManager, manager, s.loader, 10000, nil, s.chunkManager, NewChannelQueryView(nil, nil, nil, initialTargetVersion), nil)
 		s.Error(err)
@@ -259,7 +259,7 @@ func (s *DelegatorSuite) TestCreateDelegatorWithFunction() {
 				InputFieldIds:  []int64{102},
 				OutputFieldIds: []int64{101},
 			}},
-		}, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		}, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now())})
 
 		delegator, err := NewShardDelegator(context.Background(), s.collectionID, s.replicaID, s.vchannelName, s.version, s.workerManager, manager, s.loader, 10000, nil, s.chunkManager, NewChannelQueryView(nil, nil, nil, initialTargetVersion), nil)
 		s.NoError(err)
@@ -2854,7 +2854,7 @@ func TestDelegatorCatchingUpStreamingData(t *testing.T) {
 		assert.True(t, sd.CatchingUpStreamingData())
 
 		// Update tsafe with a recent timestamp (lag < 5s)
-		recentTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+		recentTs := tsoutil.ComposeTSByTime(time.Now())
 		sd.UpdateTSafe(recentTs)
 
 		// Should now be caught up
@@ -2878,7 +2878,7 @@ func TestDelegatorCatchingUpStreamingData(t *testing.T) {
 		assert.True(t, sd.CatchingUpStreamingData())
 
 		// Update tsafe with an old timestamp (lag > 5s)
-		oldTs := tsoutil.ComposeTSByTime(time.Now().Add(-10*time.Second), 0)
+		oldTs := tsoutil.ComposeTSByTime(time.Now().Add(-10 * time.Second))
 		sd.UpdateTSafe(oldTs)
 
 		// Should still be catching up
@@ -2902,7 +2902,7 @@ func TestDelegatorCatchingUpStreamingData(t *testing.T) {
 		assert.True(t, sd.CatchingUpStreamingData())
 
 		// Update tsafe with a recent timestamp
-		recentTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+		recentTs := tsoutil.ComposeTSByTime(time.Now())
 		sd.UpdateTSafe(recentTs)
 
 		// Should still be catching up (threshold disabled)
@@ -2955,7 +2955,7 @@ func (s *DelegatorSuite) TestDelegatorSearchWithMinHashFunction() {
 
 	s.Run("alloc function failed", func() {
 		manager := segments.NewManager()
-		manager.Collection.PutOrRef(s.collectionID, schema1, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		manager.Collection.PutOrRef(s.collectionID, schema1, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now())})
 
 		delegator, err := NewShardDelegator(context.Background(), s.collectionID, s.replicaID, s.vchannelName, s.version, s.workerManager, manager, s.loader, 10000, nil, s.chunkManager, NewChannelQueryView(nil, nil, nil, initialTargetVersion), nil)
 		s.Require().NoError(err)
@@ -2985,7 +2985,7 @@ func (s *DelegatorSuite) TestDelegatorSearchWithMinHashFunction() {
 	s.Run("init function ", func() {
 		minHashFunctionSchema.OutputFieldIds = []int64{101}
 		manager := segments.NewManager()
-		manager.Collection.PutOrRef(s.collectionID, schema1, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		manager.Collection.PutOrRef(s.collectionID, schema1, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now())})
 
 		delegator, err := NewShardDelegator(context.Background(), s.collectionID, s.replicaID, s.vchannelName, s.version, s.workerManager, manager, s.loader, 10000, nil, s.chunkManager, NewChannelQueryView(nil, nil, nil, initialTargetVersion), nil)
 		s.NoError(err)

--- a/internal/querynodev2/metrics_info_test.go
+++ b/internal/querynodev2/metrics_info_test.go
@@ -147,8 +147,8 @@ func TestStreamingQuotaMetrics(t *testing.T) {
 				ChannelInfo: types.PChannelInfo{
 					Name: "ch1",
 				},
-				MVCCTimeTick:     tsoutil.ComposeTSByTime(now, 0),
-				RecoveryTimeTick: tsoutil.ComposeTSByTime(now.Add(-time.Second), 0),
+				MVCCTimeTick:     tsoutil.ComposeTSByTime(now),
+				RecoveryTimeTick: tsoutil.ComposeTSByTime(now.Add(-time.Second)),
 			},
 			{Name: "ch2"}: types.ROWALMetrics{},
 		},
@@ -160,7 +160,7 @@ func TestStreamingQuotaMetrics(t *testing.T) {
 	m := getStreamingQuotaMetrics()
 	assert.Len(t, m.WALs, 1)
 	assert.Equal(t, "ch1", m.WALs[0].Channel.Name)
-	assert.Equal(t, tsoutil.ComposeTSByTime(now.Add(-time.Second), 0), m.WALs[0].RecoveryTimeTick)
+	assert.Equal(t, tsoutil.ComposeTSByTime(now.Add(-time.Second)), m.WALs[0].RecoveryTimeTick)
 
 	local.EXPECT().GetMetricsIfLocal(mock.Anything).Unset()
 	local.EXPECT().GetMetricsIfLocal(mock.Anything).Return(nil, errors.New("test"))

--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -1669,7 +1669,7 @@ func (q *QuotaCenter) toRatesRequest() *proxypb.SetRatesRequest {
 		Children: dbLimiters,
 	}
 
-	timestamp := tsoutil.ComposeTSByTime(time.Now(), 0)
+	timestamp := tsoutil.ComposeTSByTime(time.Now())
 	return &proxypb.SetRatesRequest{
 		Base: commonpbutil.NewMsgBase(
 			commonpbutil.WithMsgID(int64(timestamp)),

--- a/internal/rootcoord/quota_center_test.go
+++ b/internal/rootcoord/quota_center_test.go
@@ -444,7 +444,7 @@ func TestQuotaCenter(t *testing.T) {
 
 		for _, c := range ttCases {
 			paramtable.Get().Save(Params.QuotaConfig.MaxTimeTickDelay.Key, fmt.Sprintf("%f", c.maxTtDelay.Seconds()))
-			fgTs := tsoutil.ComposeTSByTime(c.fgTt, 0)
+			fgTs := tsoutil.ComposeTSByTime(c.fgTt)
 			quotaCenter.queryNodeMetrics = map[UniqueID]*metricsinfo.QueryNodeQuotaMetrics{
 				1: {
 					Fgm: metricsinfo.FlowGraphMetric{
@@ -454,7 +454,7 @@ func TestQuotaCenter(t *testing.T) {
 					},
 				},
 			}
-			curTs := tsoutil.ComposeTSByTime(c.curTt, 0)
+			curTs := tsoutil.ComposeTSByTime(c.curTt)
 			factors := quotaCenter.getTimeTickDelayFactor(curTs)
 			for _, factor := range factors {
 				assert.True(t, math.Abs(factor-c.expectedFactor) < 0.01)
@@ -501,8 +501,8 @@ func TestQuotaCenter(t *testing.T) {
 		alloc := newMockTsoAllocator()
 		quotaCenter.tsoAllocator = alloc
 		for _, c := range ttCases {
-			minTS := tsoutil.ComposeTSByTime(time.Now(), 0)
-			hackCurTs := tsoutil.ComposeTSByTime(time.Now().Add(c.delay), 0)
+			minTS := tsoutil.ComposeTSByTime(time.Now())
+			hackCurTs := tsoutil.ComposeTSByTime(time.Now().Add(c.delay))
 			alloc.GenerateTSOF = func(count uint32) (typeutil.Timestamp, error) {
 				return hackCurTs, nil
 			}
@@ -1327,7 +1327,7 @@ func (s *QuotaCenterSuite) TestNodeOffline() {
 	err := quotaCenter.collectMetrics()
 	s.Require().NoError(err)
 
-	quotaCenter.getTimeTickDelayFactor(tsoutil.ComposeTSByTime(time.Now(), 0))
+	quotaCenter.getTimeTickDelayFactor(tsoutil.ComposeTSByTime(time.Now()))
 
 	s.CollectCntEqual(metrics.RootCoordTtDelay, 4)
 
@@ -1368,7 +1368,7 @@ func (s *QuotaCenterSuite) TestNodeOffline() {
 	err = quotaCenter.collectMetrics()
 	s.Require().NoError(err)
 
-	quotaCenter.getTimeTickDelayFactor(tsoutil.ComposeTSByTime(time.Now(), 0))
+	quotaCenter.getTimeTickDelayFactor(tsoutil.ComposeTSByTime(time.Now()))
 	s.CollectCntEqual(metrics.RootCoordTtDelay, 2)
 }
 

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -128,7 +128,7 @@ func initStreamingSystemAndCore(t *testing.T) *Core {
 		for _, vchannel := range msg.BroadcastHeader().VChannels {
 			results[vchannel] = &message.AppendResult{
 				MessageID:              rmq.NewRmqID(1),
-				TimeTick:               tsoutil.ComposeTSByTime(time.Now(), 0),
+				TimeTick:               tsoutil.ComposeTSByTime(time.Now()),
 				LastConfirmedMessageID: rmq.NewRmqID(1),
 			}
 		}
@@ -813,7 +813,7 @@ func TestRootCoord_AllocTimestamp(t *testing.T) {
 		alloc := newMockTsoAllocator()
 		count := uint32(10)
 		current := time.Now()
-		ts := tsoutil.ComposeTSByTime(current.Add(time.Second), 1)
+		ts := tsoutil.ComposeTSByTimeWithLogical(current.Add(time.Second), 1)
 		alloc.GenerateTSOF = func(count uint32) (uint64, error) {
 			// end ts
 			return ts, nil
@@ -826,7 +826,7 @@ func TestRootCoord_AllocTimestamp(t *testing.T) {
 			withTsoAllocator(alloc))
 		resp, err := c.AllocTimestamp(ctx, &rootcoordpb.AllocTimestampRequest{
 			Count:          count,
-			BlockTimestamp: tsoutil.ComposeTSByTime(current.Add(time.Second), 0),
+			BlockTimestamp: tsoutil.ComposeTSByTime(current.Add(time.Second)),
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
@@ -1532,8 +1532,8 @@ func TestRootCoord_CheckHealth(t *testing.T) {
 	// 	}, nil
 	// }
 
-	// querynodeTT := tsoutil.ComposeTSByTime(time.Now().Add(-1*time.Minute), 0)
-	// datanodeTT := tsoutil.ComposeTSByTime(time.Now().Add(-2*time.Minute), 0)
+	// querynodeTT := tsoutil.ComposeTSByTime(time.Now().Add(-1 * time.Minute))
+	// datanodeTT := tsoutil.ComposeTSByTime(time.Now().Add(-2 * time.Minute))
 
 	// dcClient := mocks.NewMixCoord(t)
 	// dcClient.EXPECT().GetMetrics(mock.Anything, mock.Anything).Return(getDataCoordMetricsFunc(datanodeTT))

--- a/internal/rootcoord/show_collection_task_test.go
+++ b/internal/rootcoord/show_collection_task_test.go
@@ -19,6 +19,7 @@ package rootcoord
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
@@ -124,7 +125,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 				DBID:         1,
 				CollectionID: 100,
 				Name:         "foo",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 			},
 		}, nil).Once()
 
@@ -151,7 +152,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 				DBID:         1,
 				CollectionID: 100,
 				Name:         "foo",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 			},
 		}, nil).Once()
 
@@ -178,7 +179,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 				DBID:         1,
 				CollectionID: 100,
 				Name:         "foo",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 			},
 		}, nil).Once()
 
@@ -295,7 +296,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 				DBID:         1,
 				CollectionID: 100,
 				Name:         "foo",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 			},
 		}, nil).Once()
 		meta.EXPECT().ListPrivilegeGroups(mock.Anything).Return(nil, nil).Once()
@@ -378,7 +379,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 				DBID:         1,
 				CollectionID: 100,
 				Name:         "foo",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 			},
 		}, nil).Once()
 		meta.EXPECT().ListPrivilegeGroups(mock.Anything).Return(nil, nil).Once()
@@ -430,7 +431,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 				DBID:         1,
 				CollectionID: 100,
 				Name:         "foo",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 			},
 		}, nil).Once()
 		meta.EXPECT().ListPrivilegeGroups(mock.Anything).Return(nil, nil).Once()
@@ -477,7 +478,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 				DBID:         1,
 				CollectionID: 100,
 				Name:         "foo",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 			},
 		}, nil).Once()
 		meta.EXPECT().ListPrivilegeGroups(mock.Anything).Return(nil, nil).Once()
@@ -530,13 +531,13 @@ func TestShowCollectionsAuth(t *testing.T) {
 				DBID:         1,
 				CollectionID: 100,
 				Name:         "foo",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 			},
 			{
 				DBID:         1,
 				CollectionID: 200,
 				Name:         "a",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 			},
 		}, nil).Once()
 		meta.EXPECT().ListPrivilegeGroups(mock.Anything).Return(nil, nil).Once()
@@ -593,7 +594,7 @@ func TestShowCollectionsAuth(t *testing.T) {
 				DBID:         1,
 				CollectionID: 100,
 				Name:         "test_collection",
-				CreateTime:   tsoutil.GetCurrentTime(),
+				CreateTime:   tsoutil.ComposeTSByTime(time.Now()),
 				ShardsNum:    2,
 			},
 		}, nil).Once()

--- a/internal/storage/rw_test.go
+++ b/internal/storage/rw_test.go
@@ -234,7 +234,7 @@ func (s *PackedBinlogRecordSuite) TestGenerateBM25Stats() {
 
 	v := &Value{
 		PK:        NewVarCharPrimaryKey("0"),
-		Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)),
+		Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
 		Value:     genRowWithBM25(0),
 	}
 	rec, err := ValueSerializer([]*Value{v}, s.schema)
@@ -460,7 +460,7 @@ func (s *PackedBinlogRecordSuite) TestV3StatsWrittenUnderBasePath() {
 }
 
 func genRowWithBM25(magic int64) map[int64]interface{} {
-	ts := tsoutil.ComposeTSByTime(getMilvusBirthday(), 0)
+	ts := tsoutil.ComposeTSByTime(getMilvusBirthday())
 	return map[int64]interface{}{
 		common.RowIDField:     magic,
 		common.TimeStampField: int64(ts),

--- a/internal/streamingcoord/server/balancer/balancer_test.go
+++ b/internal/streamingcoord/server/balancer/balancer_test.go
@@ -435,8 +435,8 @@ func TestBalancer_WithRecoveryLag(t *testing.T) {
 	streamingNodeManager.EXPECT().Remove(mock.Anything, mock.Anything).Return(nil)
 	streamingNodeManager.EXPECT().CollectAllStatus(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, resourceGroupHint string) (map[int64]*types.StreamingNodeStatus, error) {
 		now := time.Now()
-		mvccTimeTick := tsoutil.ComposeTSByTime(now, 0)
-		recoveryTimeTick := tsoutil.ComposeTSByTime(now.Add(-time.Second*10), 0)
+		mvccTimeTick := tsoutil.ComposeTSByTime(now)
+		recoveryTimeTick := tsoutil.ComposeTSByTime(now.Add(-time.Second * 10))
 		if !lag.Load() {
 			recoveryTimeTick = mvccTimeTick
 		}

--- a/internal/streamingnode/client/handler/consumer/consumer_test.go
+++ b/internal/streamingnode/client/handler/consumer/consumer_test.go
@@ -177,7 +177,7 @@ func newMockedConsumerImpl(t *testing.T, ctx context.Context, h message.Handler)
 }
 
 func newConsumeResponse(id message.MessageID, msg message.MutableMessage) *streamingpb.ConsumeResponse {
-	msg.WithTimeTick(tsoutil.GetCurrentTime())
+	msg.WithTimeTick(tsoutil.ComposeTSByTime(time.Now()))
 	msg.WithLastConfirmed(walimplstest.NewTestMessageID(0))
 	immutableMsg := msg.IntoImmutableMessage(id)
 	return &streamingpb.ConsumeResponse{

--- a/internal/streamingnode/server/wal/interceptors/txn/session_test.go
+++ b/internal/streamingnode/server/wal/interceptors/txn/session_test.go
@@ -166,9 +166,9 @@ func TestManager(t *testing.T) {
 func TestManagerRecoverAndFailAll(t *testing.T) {
 	resource.InitForTest(t)
 	now := time.Now()
-	beginMsg1 := newImmutableBeginTxnMessageWithVChannel("v1", 1, tsoutil.ComposeTSByTime(now, 0), 10*time.Millisecond)
-	beginMsg2 := newImmutableBeginTxnMessageWithVChannel("v2", 2, tsoutil.ComposeTSByTime(now, 1), 10*time.Millisecond)
-	beginMsg3 := newImmutableBeginTxnMessageWithVChannel("v1", 3, tsoutil.ComposeTSByTime(now, 2), 10*time.Millisecond)
+	beginMsg1 := newImmutableBeginTxnMessageWithVChannel("v1", 1, tsoutil.ComposeTSByTime(now), 10*time.Millisecond)
+	beginMsg2 := newImmutableBeginTxnMessageWithVChannel("v2", 2, tsoutil.ComposeTSByTimeWithLogical(now, 1), 10*time.Millisecond)
+	beginMsg3 := newImmutableBeginTxnMessageWithVChannel("v1", 3, tsoutil.ComposeTSByTimeWithLogical(now, 2), 10*time.Millisecond)
 	builders := map[message.TxnID]*message.ImmutableTxnMessageBuilder{
 		message.TxnID(1): message.NewImmutableTxnMessageBuilder(beginMsg1),
 		message.TxnID(2): message.NewImmutableTxnMessageBuilder(beginMsg2),
@@ -180,7 +180,7 @@ func TestManagerRecoverAndFailAll(t *testing.T) {
 		WithHeader(&message.InsertMessageHeader{}).
 		WithBody(&msgpb.InsertRequest{}).
 		MustBuildMutable().
-		WithTimeTick(tsoutil.ComposeTSByTime(now, 3)).
+		WithTimeTick(tsoutil.ComposeTSByTimeWithLogical(now, 3)).
 		WithLastConfirmedUseMessageID().
 		WithTxnContext(message.TxnContext{
 			TxnID:     message.TxnID(1),
@@ -306,8 +306,8 @@ func TestRollbackAllInFlightTransactions(t *testing.T) {
 	t.Run("RollbackWithRecoveredSessions", func(t *testing.T) {
 		// Create a manager with recovered sessions
 		now := time.Now()
-		beginMsg1 := newImmutableBeginTxnMessageWithVChannel("v1", 1, tsoutil.ComposeTSByTime(now, 0), 10*time.Minute)
-		beginMsg2 := newImmutableBeginTxnMessageWithVChannel("v2", 2, tsoutil.ComposeTSByTime(now, 1), 10*time.Minute)
+		beginMsg1 := newImmutableBeginTxnMessageWithVChannel("v1", 1, tsoutil.ComposeTSByTime(now), 10*time.Minute)
+		beginMsg2 := newImmutableBeginTxnMessageWithVChannel("v2", 2, tsoutil.ComposeTSByTimeWithLogical(now, 1), 10*time.Minute)
 
 		builders := map[message.TxnID]*message.ImmutableTxnMessageBuilder{
 			message.TxnID(1): message.NewImmutableTxnMessageBuilder(beginMsg1),

--- a/internal/streamingnode/server/wal/utility/txn_buffer_test.go
+++ b/internal/streamingnode/server/wal/utility/txn_buffer_test.go
@@ -21,7 +21,7 @@ var idAllocator = typeutil.NewIDAllocator()
 func TestTxnBuffer(t *testing.T) {
 	b := NewTxnBuffer(mlog.With(), metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics())
 
-	baseTso := tsoutil.GetCurrentTime()
+	baseTso := tsoutil.ComposeTSByTime(time.Now())
 
 	msgs := b.HandleImmutableMessages([]message.ImmutableMessage{
 		newInsertMessage(t, nil, baseTso),
@@ -175,7 +175,7 @@ func newAlterReplicateConfigMessage(t *testing.T, forcePromote bool, ignore bool
 func TestRollbackAllUncommittedTxn(t *testing.T) {
 	b := NewTxnBuffer(mlog.With(), metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics())
 
-	baseTso := tsoutil.GetCurrentTime()
+	baseTso := tsoutil.ComposeTSByTime(time.Now())
 
 	// Create uncommitted transactions
 	txnCtx1 := &message.TxnContext{
@@ -226,7 +226,7 @@ func TestRollbackAllUncommittedTxn_Empty(t *testing.T) {
 func TestForcePromoteRollsBackUncommittedTxn(t *testing.T) {
 	b := NewTxnBuffer(mlog.With(), metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics())
 
-	baseTso := tsoutil.GetCurrentTime()
+	baseTso := tsoutil.ComposeTSByTime(time.Now())
 
 	// Create uncommitted transaction
 	txnCtx := &message.TxnContext{
@@ -262,7 +262,7 @@ func TestForcePromoteRollsBackUncommittedTxn(t *testing.T) {
 func TestForcePromoteIgnored_DoesNotRollback(t *testing.T) {
 	b := NewTxnBuffer(mlog.With(), metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics())
 
-	baseTso := tsoutil.GetCurrentTime()
+	baseTso := tsoutil.ComposeTSByTime(time.Now())
 
 	// Create uncommitted transaction
 	txnCtx := &message.TxnContext{
@@ -298,7 +298,7 @@ func TestForcePromoteIgnored_DoesNotRollback(t *testing.T) {
 func TestNonForcePromoteAlterReplicateConfig_DoesNotRollback(t *testing.T) {
 	b := NewTxnBuffer(mlog.With(), metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics())
 
-	baseTso := tsoutil.GetCurrentTime()
+	baseTso := tsoutil.ComposeTSByTime(time.Now())
 
 	// Create uncommitted transaction
 	txnCtx := &message.TxnContext{

--- a/internal/util/idalloc/test_mock_root_coord_client.go
+++ b/internal/util/idalloc/test_mock_root_coord_client.go
@@ -41,7 +41,7 @@ func NewMockRootCoordClient(t *testing.T) *mocks.MockMixCoordClient {
 			}
 			return &rootcoordpb.AllocTimestampResponse{
 				Status:    merr.Success(),
-				Timestamp: tsoutil.ComposeTSByTime(now, 0),
+				Timestamp: tsoutil.ComposeTSByTime(now),
 				Count:     atr.Count,
 			}, nil
 		},

--- a/internal/util/importutilv2/option.go
+++ b/internal/util/importutilv2/option.go
@@ -84,7 +84,7 @@ func GetTimeoutTs(options Options) (uint64, error) {
 		if err != nil {
 			return 0, merr.Wrap(err, "parse timeout failed")
 		}
-		curTs := tsoutil.GetCurrentTime()
+		curTs := tsoutil.ComposeTSByTime(time.Now())
 		timeoutTs = tsoutil.AddPhysicalDurationOnTs(curTs, dur)
 	}
 	return timeoutTs, nil

--- a/internal/util/importutilv2/option_test.go
+++ b/internal/util/importutilv2/option_test.go
@@ -61,14 +61,14 @@ func TestOption_ParseTimeRange(t *testing.T) {
 	assert.Equal(t, uint64(0), s)
 	assert.Equal(t, uint64(math.MaxUint64), e)
 
-	startTs := tsoutil.GetCurrentTime()
+	startTs := tsoutil.ComposeTSByTime(time.Now())
 	options := []*commonpb.KeyValuePair{{Key: StartTs, Value: fmt.Sprintf("%d", startTs)}}
 	s, e, err = ParseTimeRange(options)
 	assert.NoError(t, err)
 	assert.Equal(t, startTs, s)
 	assert.Equal(t, uint64(math.MaxUint64), e)
 
-	endTs := tsoutil.GetCurrentTime()
+	endTs := tsoutil.ComposeTSByTime(time.Now())
 	options = []*commonpb.KeyValuePair{{Key: EndTs, Value: fmt.Sprintf("%d", endTs)}}
 	s, e, err = ParseTimeRange(options)
 	assert.NoError(t, err)

--- a/pkg/mq/mqimpl/rocksmq/server/rocksmq_impl.go
+++ b/pkg/mq/mqimpl/rocksmq/server/rocksmq_impl.go
@@ -388,7 +388,7 @@ func (rmq *rocksmq) allocMsgID(topicName string, delta int) (UniqueID, UniqueID,
 
 		if msgID == DefaultMessageID {
 			// initialize a new message id if not found the latest msg in the topic
-			msgID = UniqueID(tsoutil.ComposeTSByTime(time.Now(), 0))
+			msgID = UniqueID(tsoutil.ComposeTSByTime(time.Now()))
 			mlog.Warn(rmq.ctx, "init new message id", mlog.String("topicName", topicName), mlog.Err(err))
 		}
 		mlog.Info(rmq.ctx, "init the latest message id done", mlog.String("topicName", topicName), mlog.Int64("msgID", msgID))

--- a/pkg/streaming/util/types/wal_metrics_test.go
+++ b/pkg/streaming/util/types/wal_metrics_test.go
@@ -15,10 +15,10 @@ func TestWALMetrics(t *testing.T) {
 		ChannelInfo: PChannelInfo{
 			Name: "ch1",
 		},
-		MVCCTimeTick:     tsoutil.ComposeTSByTime(now, 0),
-		RecoveryTimeTick: tsoutil.ComposeTSByTime(now.Add(-time.Second), 0),
+		MVCCTimeTick:     tsoutil.ComposeTSByTime(now),
+		RecoveryTimeTick: tsoutil.ComposeTSByTime(now.Add(-time.Second)),
 	}
 	assert.Equal(t, time.Second, rw.RecoveryLag())
-	rw.MVCCTimeTick = tsoutil.ComposeTSByTime(now.Add(-2*time.Second), 0)
+	rw.MVCCTimeTick = tsoutil.ComposeTSByTime(now.Add(-2 * time.Second))
 	assert.Zero(t, rw.RecoveryLag())
 }

--- a/pkg/util/tsoutil/tso.go
+++ b/pkg/util/tsoutil/tso.go
@@ -27,19 +27,22 @@ const (
 	logicalBitsMask = (1 << logicalBits) - 1
 )
 
-// ComposeTS returns a timestamp composed of physical part and logical part
+// ComposeTS returns a timestamp composed of physical part and logical part.
+// The logical part is a low-level hybrid logical clock detail. Only the TSO
+// allocator or equivalent timestamp sources should set it non-zero.
 func ComposeTS(physical, logical int64) uint64 {
 	return uint64((physical << logicalBits) + logical)
 }
 
-// ComposeTSByTime returns a timestamp composed of physical time.Time and logical time
-func ComposeTSByTime(physical time.Time, logical int64) uint64 {
-	return ComposeTS(physical.UnixNano()/int64(time.Millisecond), logical)
+// ComposeTSByTime returns a timestamp composed of physical time.Time and logical zero.
+func ComposeTSByTime(physical time.Time) typeutil.Timestamp {
+	return ComposeTS(physical.UnixMilli(), 0)
 }
 
-// GetCurrentTime returns the current timestamp
-func GetCurrentTime() typeutil.Timestamp {
-	return ComposeTSByTime(time.Now(), 0)
+// ComposeTSByTimeWithLogical returns a timestamp composed of physical time.Time and logical time.
+// Use this only when a caller intentionally needs to compose a non-zero logical part.
+func ComposeTSByTimeWithLogical(physical time.Time, logical int64) typeutil.Timestamp {
+	return ComposeTS(physical.UnixMilli(), logical)
 }
 
 // ParseTS parses the ts to (physical,logical).

--- a/pkg/util/tsoutil/tso_test.go
+++ b/pkg/util/tsoutil/tso_test.go
@@ -38,35 +38,43 @@ func TestParseHybridTs(t *testing.T) {
 
 func Test_Tso(t *testing.T) {
 	t.Run("test ComposeTSByTime", func(t *testing.T) {
-		physical := time.Now()
+		physical := time.Unix(1700000000, 123456789)
+		timestamp := ComposeTSByTime(physical)
+		pRes, lRes := ParseHybridTs(timestamp)
+		assert.Equal(t, physical.UnixMilli(), pRes)
+		assert.Equal(t, int64(0), lRes)
+	})
+
+	t.Run("test ComposeTSByTimeWithLogical", func(t *testing.T) {
+		physical := time.Unix(1700000000, 123456789)
 		logical := int64(1000)
-		timestamp := ComposeTSByTime(physical, logical)
-		pRes, lRes := ParseTS(timestamp)
-		assert.Equal(t, physical.Unix(), pRes.Unix())
-		assert.Equal(t, uint64(logical), lRes)
+		timestamp := ComposeTSByTimeWithLogical(physical, logical)
+		pRes, lRes := ParseHybridTs(timestamp)
+		assert.Equal(t, physical.UnixMilli(), pRes)
+		assert.Equal(t, logical, lRes)
 	})
 }
 
 func TestCalculateDuration(t *testing.T) {
 	now := time.Now()
-	ts1 := ComposeTSByTime(now, 0)
+	ts1 := ComposeTSByTime(now)
 	durationInMilliSecs := int64(20 * 1000)
-	ts2 := ComposeTSByTime(now.Add(time.Duration(durationInMilliSecs)*time.Millisecond), 0)
+	ts2 := ComposeTSByTime(now.Add(time.Duration(durationInMilliSecs) * time.Millisecond))
 	diff := CalculateDuration(ts2, ts1)
 	assert.Equal(t, durationInMilliSecs, diff)
 }
 
 func TestAddPhysicalDurationOnTs(t *testing.T) {
 	now := time.Now()
-	ts1 := ComposeTSByTime(now, 0)
+	ts1 := ComposeTSByTime(now)
 	duration := time.Millisecond * (20 * 1000)
 	ts2 := AddPhysicalDurationOnTs(ts1, duration)
-	ts3 := ComposeTSByTime(now.Add(duration), 0)
+	ts3 := ComposeTSByTime(now.Add(duration))
 	// diff := CalculateDuration(ts2, ts1)
 	assert.Equal(t, ts3, ts2)
 
 	ts2 = AddPhysicalDurationOnTs(ts1, -duration)
-	ts3 = ComposeTSByTime(now.Add(-duration), 0)
+	ts3 = ComposeTSByTime(now.Add(-duration))
 	// diff := CalculateDuration(ts2, ts1)
 	assert.Equal(t, ts3, ts2)
 }
@@ -76,7 +84,7 @@ func TestIsValidUnixMilli(t *testing.T) {
 	assert.True(t, IsValidPhysicalTs(physicalTs))
 	assert.False(t, IsValidHybridTs(physicalTs))
 
-	hybridTs := GetCurrentTime()
+	hybridTs := ComposeTSByTime(time.Now())
 	assert.False(t, IsValidPhysicalTs(hybridTs))
 	assert.True(t, IsValidHybridTs(hybridTs))
 }

--- a/tests/integration/commit_timestamp/commit_timestamp_test.go
+++ b/tests/integration/commit_timestamp/commit_timestamp_test.go
@@ -239,11 +239,11 @@ func (s *CommitTimestampSuite) TestMVCC_Visibility() {
 
 	collName, collectionID := s.createCollectionAndInsert(ctx, rowNum)
 
-	tBefore := tsoutil.ComposeTSByTime(time.Now(), 0)
+	tBefore := tsoutil.ComposeTSByTime(time.Now())
 
 	// Set commit_ts to a future time to test MVCC
-	tCommit := tsoutil.ComposeTSByTime(time.Now().Add(10*time.Second), 0)
-	tAfterCommit := tsoutil.ComposeTSByTime(time.Now().Add(20*time.Second), 0)
+	tCommit := tsoutil.ComposeTSByTime(time.Now().Add(10 * time.Second))
+	tAfterCommit := tsoutil.ComposeTSByTime(time.Now().Add(20 * time.Second))
 	s.setCommitTimestamp(collectionID, tCommit)
 
 	s.buildIndexAndLoad(ctx, collName)
@@ -278,7 +278,7 @@ func (s *CommitTimestampSuite) TestMVCC_StrongConsistency_CommitTsInPast() {
 	collName, collectionID := s.createCollectionAndInsert(ctx, rowNum)
 
 	// Set commit_ts to now (in the past by the time query runs)
-	commitTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+	commitTs := tsoutil.ComposeTSByTime(time.Now())
 	s.setCommitTimestamp(collectionID, commitTs)
 
 	s.buildIndexAndLoad(ctx, collName)
@@ -299,8 +299,8 @@ func (s *CommitTimestampSuite) TestSearch_WithGuaranteeTs() {
 
 	collName, collectionID := s.createCollectionAndInsert(ctx, rowNum)
 
-	tBefore := tsoutil.ComposeTSByTime(time.Now(), 0)
-	tCommit := tsoutil.ComposeTSByTime(time.Now().Add(10*time.Second), 0)
+	tBefore := tsoutil.ComposeTSByTime(time.Now())
+	tCommit := tsoutil.ComposeTSByTime(time.Now().Add(10 * time.Second))
 	s.setCommitTimestamp(collectionID, tCommit)
 
 	s.buildIndexAndLoad(ctx, collName)
@@ -328,7 +328,7 @@ func (s *CommitTimestampSuite) TestDelete_AfterCommitTs() {
 	collName, collectionID := s.createCollectionAndInsert(ctx, rowNum)
 
 	// commit_ts in the past so delete_ts > commit_ts
-	commitTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+	commitTs := tsoutil.ComposeTSByTime(time.Now())
 	s.setCommitTimestamp(collectionID, commitTs)
 
 	s.buildIndexAndLoad(ctx, collName)
@@ -356,7 +356,7 @@ func (s *CommitTimestampSuite) TestDelete_BeforeCommitTs() {
 	collName, collectionID := s.createCollectionAndInsert(ctx, rowNum)
 
 	// commit_ts in the future so delete_ts < commit_ts
-	commitTs := tsoutil.ComposeTSByTime(time.Now().Add(10*time.Second), 0)
+	commitTs := tsoutil.ComposeTSByTime(time.Now().Add(10 * time.Second))
 	s.setCommitTimestamp(collectionID, commitTs)
 
 	s.buildIndexAndLoad(ctx, collName)
@@ -382,7 +382,7 @@ func (s *CommitTimestampSuite) TestUpsert_AfterCommitTs() {
 	collName, collectionID := s.createCollectionAndInsert(ctx, rowNum)
 
 	// commit_ts in the past so upsert_ts > commit_ts
-	commitTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+	commitTs := tsoutil.ComposeTSByTime(time.Now())
 	s.setCommitTimestamp(collectionID, commitTs)
 
 	s.buildIndexAndLoad(ctx, collName)
@@ -428,7 +428,7 @@ func (s *CommitTimestampSuite) TestUpsert_BeforeCommitTs() {
 	collName, collectionID := s.createCollectionAndInsert(ctx, rowNum)
 
 	// commit_ts in the future so upsert_ts < commit_ts
-	commitTs := tsoutil.ComposeTSByTime(time.Now().Add(10*time.Second), 0)
+	commitTs := tsoutil.ComposeTSByTime(time.Now().Add(10 * time.Second))
 	s.setCommitTimestamp(collectionID, commitTs)
 
 	s.buildIndexAndLoad(ctx, collName)
@@ -504,7 +504,7 @@ func (s *CommitTimestampSuite) TestCompaction_NormalizesCommitTs() {
 	s.Require().NoError(err)
 	collectionID := showResp.GetCollectionIds()[0]
 
-	commitTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+	commitTs := tsoutil.ComposeTSByTime(time.Now())
 	modifiedSegIDs := s.setCommitTimestamp(collectionID, commitTs)
 	s.Require().GreaterOrEqual(len(modifiedSegIDs), 2,
 		"should have at least 2 segments to compact")
@@ -581,7 +581,7 @@ func (s *CommitTimestampSuite) TestGC_ImportSegmentNotPrematurelyDropped() {
 	collName, collectionID := s.createCollectionAndInsert(ctx, rowNum)
 
 	// Set commit_ts to now
-	commitTs := tsoutil.ComposeTSByTime(time.Now(), 0)
+	commitTs := tsoutil.ComposeTSByTime(time.Now())
 	s.setCommitTimestamp(collectionID, commitTs)
 
 	s.buildIndexAndLoad(ctx, collName)


### PR DESCRIPTION
Make ComposeTSByTime the logical-zero time-based timestamp API, add
ComposeTSByTimeWithLogical for explicit logical composition in tests,
and remove the duplicate GetCurrentTime wrapper.

pr: #51120
See also: #51119

Signed-off-by: yangxuan <xuan.yang@zilliz.com>