### PR TITLE
fix: pre-create volume directory with correct ownership in standalone_embed.sh

### DIFF
--- a/scripts/standalone_embed.sh
+++ b/scripts/standalone_embed.sh
@@ -39,7 +39,18 @@ EOF
         echo "user.yaml file does not exist. Please try to create it in the current directory."
         exit 1
     fi
-    
+
+    # Pre-create the data volume directory with the correct ownership.
+    # The milvus container runs as a non-root user. Without this,
+    # Docker daemon creates the bind-mount directory as root, causing
+    # "permission denied" when the milvus process tries to write data.
+    MILVUS_IMAGE="milvusdb/milvus:v3.0-beta"
+    id_output=$(sudo docker run --rm --entrypoint id ${MILVUS_IMAGE})
+    MILVUS_UID=$(echo "$id_output" | cut -d'=' -f2 | cut -d'(' -f1)
+    MILVUS_GID=$(echo "$id_output" | cut -d'=' -f3 | cut -d'(' -f1)
+    mkdir -p $(pwd)/volumes/milvus
+    sudo chown -R ${MILVUS_UID}:${MILVUS_GID} $(pwd)/volumes/milvus
+
     sudo docker run -d \
         --name milvus-standalone \
         --security-opt seccomp:unconfined \
@@ -59,7 +70,7 @@ EOF
         --health-start-period=90s \
         --health-timeout=20s \
         --health-retries=3 \
-        milvusdb/milvus:v3.0-beta \
+        ${MILVUS_IMAGE} \
         milvus run standalone  1> /dev/null
 }
 


### PR DESCRIPTION
## Summary

`standalone_embed.sh` bind-mounts `$(pwd)/volumes/milvus` to `/var/lib/milvus` but does not pre-create the directory. Docker daemon auto-creates it as `root:root`, while the container runs as `uid=999` (milvus user), causing `permission denied` on startup.

## Changes

- Query the milvus user UID/GID from the Docker image via `docker run --rm --entrypoint id`
- Pre-create `$(pwd)/volumes/milvus` and `chown` it to the correct UID:GID before starting the container
- Extract the image tag (`milvusdb/milvus:v3.0-beta`) into a `MILVUS_IMAGE` variable to avoid duplication

## Reproduction

```bash
curl -sfL https://raw.githubusercontent.com/milvus-io/milvus/master/scripts/standalone_embed.sh -o standalone_embed.sh
bash standalone_embed.sh start
```

**Before fix:**
```
[FATAL] ["failed to mkdir"] [localStoragePath=/var/lib/milvus/data/] [error="mkdir /var/lib/milvus/data/: permission denied"]
panic: failed to mkdir
```

**After fix:** Container starts successfully.

issue: #51221