### PR TITLE
enhance: move sealed vector index state into runtime resource

### DIFF
--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -51,7 +51,7 @@ namespace milvus::query {
 
 void
 SearchOnSealedIndex(const Schema& schema,
-                    const segcore::SealedIndexingRecord& record,
+                    const segcore::SealedIndexingEntry& entry,
                     const SearchInfo& search_info,
                     const void* query_data,
                     const size_t* query_offsets,
@@ -68,13 +68,10 @@ SearchOnSealedIndex(const Schema& schema,
     // TODO(SPARSE): see todo in PlanImpl.h::PlaceHolder.
     auto dim = is_sparse ? 0 : field.get_dim();
 
-    AssertInfo(record.is_ready(field_id), "[SearchOnSealed]Record isn't ready");
-    // Keep the field_indexing smart pointer, until all reference by raw dropped.
-    auto field_indexing = record.get_field_indexing(field_id);
-    AssertInfo(field_indexing->metric_type_ == search_info.metric_type_,
+    AssertInfo(entry.metric_type_ == search_info.metric_type_,
                "Metric type of field index isn't the same with search info,"
                "field index: {}, search info: {}",
-               field_indexing->metric_type_,
+               entry.metric_type_,
                search_info.metric_type_);
 
     knowhere::DataSetPtr dataset;
@@ -91,8 +88,7 @@ SearchOnSealedIndex(const Schema& schema,
     }
 
     dataset->SetIsSparse(is_sparse);
-    auto accessor =
-        SemiInlineGet(field_indexing->indexing_->PinCells(op_context, {0}));
+    auto accessor = SemiInlineGet(entry.indexing_->PinCells(op_context, {0}));
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
 

--- a/internal/core/src/query/SearchOnSealed.h
+++ b/internal/core/src/query/SearchOnSealed.h
@@ -29,7 +29,7 @@ namespace milvus::query {
 
 void
 SearchOnSealedIndex(const Schema& schema,
-                    const segcore::SealedIndexingRecord& record,
+                    const segcore::SealedIndexingEntry& entry,
                     const SearchInfo& search_info,
                     const void* query_data,
                     const size_t* query_offsets,

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -118,6 +118,15 @@ AssertVectorIteratorUsableAfterSearchReturns(SearchResult& search_result,
     ASSERT_GT(result_count, 0);
 }
 
+segcore::SealedIndexingEntry
+MakeSealedIndexingEntry(const MetricType& metric_type,
+                        index::CacheIndexBasePtr indexing) {
+    segcore::SealedIndexingEntry entry;
+    entry.metric_type_ = metric_type;
+    entry.indexing_ = std::move(indexing);
+    return entry;
+}
+
 const DataArray&
 FindFieldData(const segcore::GeneratedData& dataset, FieldId field_id) {
     for (const auto& field_data : dataset.raw_->fields_data()) {
@@ -233,9 +242,7 @@ TEST(SearchOnSealedIndexBitsetLifetime,
     ASSERT_NE(vector_index, nullptr);
     ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
 
-    segcore::SealedIndexingRecord indexing_record;
-    indexing_record.append_field_indexing(
-        vector_field,
+    auto indexing_entry = MakeSealedIndexingEntry(
         knowhere::metric::COSINE,
         CreateTestCacheIndex("nullable-vector-bitset-lifetime",
                              std::move(index_base)));
@@ -249,7 +256,7 @@ TEST(SearchOnSealedIndexBitsetLifetime,
 
     SearchResult search_result;
     SearchOnSealedIndex(*schema,
-                        indexing_record,
+                        indexing_entry,
                         search_info,
                         query.data(),
                         nullptr,
@@ -279,9 +286,7 @@ TEST(SearchOnSealedIndexCancellation, PinVectorIndexUsesCallerOpContext) {
         BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
 
     milvus::OpContext* observed_ctx = nullptr;
-    segcore::SealedIndexingRecord indexing_record;
-    indexing_record.append_field_indexing(
-        vector_field,
+    auto indexing_entry = MakeSealedIndexingEntry(
         knowhere::metric::COSINE,
         CreateTestCacheIndex("cancellable-search-on-sealed-index",
                              std::move(index_base),
@@ -300,7 +305,7 @@ TEST(SearchOnSealedIndexCancellation, PinVectorIndexUsesCallerOpContext) {
     milvus::OpContext op_context(source.getToken());
     SearchResult search_result;
     SearchOnSealedIndex(*schema,
-                        indexing_record,
+                        indexing_entry,
                         search_info,
                         vectors.data(),
                         nullptr,
@@ -334,9 +339,7 @@ TEST(SearchOnSealedIndexNullableNoFilter,
     ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
     ASSERT_EQ(vector_index->GetOffsetMapping().GetValidCount(), valid_count);
 
-    segcore::SealedIndexingRecord indexing_record;
-    indexing_record.append_field_indexing(
-        vector_field,
+    auto indexing_entry = MakeSealedIndexingEntry(
         knowhere::metric::COSINE,
         CreateTestCacheIndex("nullable-vector-empty-bitset",
                              std::move(index_base)));
@@ -352,7 +355,7 @@ TEST(SearchOnSealedIndexNullableNoFilter,
 
     SearchResult search_result;
     SearchOnSealedIndex(*schema,
-                        indexing_record,
+                        indexing_entry,
                         search_info,
                         vectors.data(),
                         nullptr,
@@ -386,9 +389,7 @@ TEST(SearchOnSealedIndexNullableIteratorNoFilter,
 
     auto index_base =
         BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
-    segcore::SealedIndexingRecord indexing_record;
-    indexing_record.append_field_indexing(
-        vector_field,
+    auto indexing_entry = MakeSealedIndexingEntry(
         knowhere::metric::COSINE,
         CreateTestCacheIndex("nullable-vector-empty-bitset-iterator",
                              std::move(index_base)));
@@ -406,7 +407,7 @@ TEST(SearchOnSealedIndexNullableIteratorNoFilter,
 
     SearchResult search_result;
     SearchOnSealedIndex(*schema,
-                        indexing_record,
+                        indexing_entry,
                         search_info,
                         vectors.data(),
                         nullptr,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -991,27 +991,25 @@ ChunkedSegmentSealedImpl::GetVectorIndexing(
     return it != runtime->vector_indexings.end() ? it->second : nullptr;
 }
 
-void
-ChunkedSegmentSealedImpl::DropVectorIndexing(RuntimeResourceState& runtime,
-                                             FieldId field_id) {
+SealedIndexingEntryPtr
+ChunkedSegmentSealedImpl::EraseVectorIndexing(RuntimeResourceState& runtime,
+                                              FieldId field_id) {
     auto it = runtime.vector_indexings.find(field_id);
-    if (it != runtime.vector_indexings.end()) {
-        if (it->second != nullptr && it->second->indexing_ != nullptr) {
-            it->second->indexing_->CancelWarmup();
-        }
-        runtime.vector_indexings.erase(it);
+    if (it == runtime.vector_indexings.end()) {
+        return nullptr;
     }
+    auto entry = std::move(it->second);
+    runtime.vector_indexings.erase(it);
+    return entry;
 }
 
 void
-ChunkedSegmentSealedImpl::ClearVectorIndexings(RuntimeResourceState& runtime) {
-    for (auto& [_, entry] : runtime.vector_indexings) {
-        if (entry != nullptr && entry->indexing_ != nullptr) {
-            entry->indexing_->CancelWarmup();
-        }
+ChunkedSegmentSealedImpl::DropVectorIndexing(RuntimeResourceState& runtime,
+                                             FieldId field_id) {
+    auto entry = EraseVectorIndexing(runtime, field_id);
+    if (entry != nullptr && entry->indexing_ != nullptr) {
+        entry->indexing_->CancelWarmup();
     }
-    runtime.vector_indexings.clear();
-    runtime.vec_binlog_config.clear();
 }
 
 std::shared_ptr<ChunkedSegmentSealedImpl::PublishedSegmentState>
@@ -1799,198 +1797,7 @@ ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
 }
 
 void
-ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
-                                           milvus::OpContext* op_ctx) {
-    std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
-    auto snapshot = CapturePublishedState();
-    auto runtime = CloneMutableRuntimeResourceState();
-    LoadColumnGroups(manifest_path,
-                     *snapshot->load_info,
-                     snapshot->schema,
-                     op_ctx,
-                     runtime.get());
-    PublishRuntimeStateLocked(ToConstRuntimeState(std::move(runtime)));
-}
-
-void
 ChunkedSegmentSealedImpl::LoadColumnGroups(
-    const std::string& manifest_path,
-    const SegmentLoadInfo& segment_load_info,
-    const SchemaPtr& schema_snapshot,
-    milvus::OpContext* op_ctx,
-    RuntimeResourceState* runtime) {
-    AssertInfo(runtime != nullptr,
-               "runtime must not be null when loading manifest column groups "
-               "for segment {}",
-               id_);
-    auto load_cg_start = std::chrono::high_resolution_clock::now();
-    CheckCancellation(
-        op_ctx, id_, "ChunkedSegmentSealedImpl::LoadColumnGroups()");
-    auto properties = std::make_shared<milvus_storage::api::Properties>(
-        *milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
-             .GetProperties());
-    auto column_groups = segment_load_info.GetColumnGroups();
-
-    // External collections: inject extfs.{collectionID}.* derived from
-    // external_source and external_spec only. InjectExternalSpecProperties zero-
-    // initializes every extfs field so nothing is inherited from the
-    // cluster's internal fs.* baseline — credentials and endpoint come
-    // exclusively from spec.extfs (see refactor: [ExternalTable] isolate
-    // extfs namespace from fs.* baseline). milvus_storage routes each file
-    // URI to the matching extfs alias by (bucket, address); file URIs in
-    // the Iceberg manifest live under external_source, so the alias always
-    // matches.
-    if (schema_snapshot->is_external_collection()) {
-        InjectExternalSpecProperties(*properties,
-                                     segment_load_info.GetCollectionID(),
-                                     schema_snapshot->get_external_source(),
-                                     schema_snapshot->get_external_spec());
-    }
-
-    // Schemaless reader for external collections: pass nullptr schema and
-    // let the Reader derive types from file metadata (Parquet footer).
-    // FillFieldData handles Parquet-native → Milvus type conversion.
-    //
-    // This overload is reached only via
-    // ApplyLoadDiff when load_external_manifest is set, which in turn is
-    // gated on is_external_collection() — see SegmentLoadInfo.cpp where the
-    // flag is assigned. The non-external path uses LoadColumnGroups(
-    // column_groups, ...) and never enters here.
-    auto needed_columns = schema_snapshot->GetExternalColumnNames();
-    // reader_mutex_ guards reader_ against concurrent use in ExecuteTake.
-    // Reopen reaches this function with mutex_ already released (see Reopen
-    // for the rationale), so without this lock a concurrent ExecuteTake can
-    // observe a mid-assigned shared_ptr or drop the old Reader's refcount
-    // while another thread is still calling take() on it. Initial load is
-    // uncontended (segment not yet ready), so the extra lock is free.
-    runtime->reader = std::shared_ptr<milvus_storage::api::Reader>(
-        milvus_storage::api::Reader::create(column_groups,
-                                            /*arrow_schema=*/nullptr,
-                                            needed_columns,
-                                            *properties)
-            .release());
-
-    auto reader_create_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::high_resolution_clock::now() - load_cg_start)
-            .count();
-    LOG_INFO(
-        "[LoadColumnGroups] segment {} reader created in {}ms, {} column "
-        "groups",
-        id_,
-        reader_create_ms,
-        column_groups->size());
-
-    // Pre-resolve field IDs for each column group, then reuse the
-    // standard LoadColumnGroup overload.
-    std::vector<std::pair<int, std::vector<FieldId>>> cg_field_ids;
-    cg_field_ids.reserve(column_groups->size());
-    for (size_t i = 0; i < column_groups->size(); ++i) {
-        auto cg = column_groups->at(i);
-        std::vector<FieldId> field_ids;
-        field_ids.reserve(cg->columns.size());
-        for (auto& column : cg->columns) {
-            field_ids.emplace_back(
-                schema_snapshot->ResolveColumnFieldId(column));
-        }
-        cg_field_ids.emplace_back(static_cast<int>(i), std::move(field_ids));
-    }
-
-    // Split each column group's fields into eager (warmup=sync/async) and
-    // lazy (warmup=disable) subsets, so that each subset creates its own
-    // ChunkReader with column projection.  This avoids downloading all
-    // columns from S3 when only a subset needs eager warming.
-    struct FieldGroupTask {
-        int cg_index;
-        std::vector<FieldId> field_ids;
-        bool eager_load;
-    };
-    std::vector<FieldGroupTask> tasks;
-
-    for (const auto& pair : cg_field_ids) {
-        auto cg_index = pair.first;
-        const auto& all_fields = pair.second;
-
-        std::vector<FieldId> eager_fields;
-        std::vector<FieldId> lazy_fields;
-
-        for (const auto& field_id : all_fields) {
-            const auto& field_meta = (*schema_snapshot)[field_id];
-            bool field_is_vector = IsVectorDataType(field_meta.get_data_type());
-            const auto pk_field_id = schema_snapshot->get_primary_field_id();
-            if (pk_field_id.has_value() &&
-                pk_field_id.value().get() == field_id.get() &&
-                schema_snapshot->IsExternalDataField(field_id)) {
-                eager_fields.push_back(field_id);
-                continue;
-            }
-            auto [has_warmup, warmup_str] = schema_snapshot->WarmupPolicy(
-                field_id, field_is_vector, /*is_index=*/false);
-            // Resolve effective warmup using global config as fallback
-            auto resolved = getCacheWarmupPolicy(has_warmup ? warmup_str : "",
-                                                 field_is_vector,
-                                                 /*is_index=*/false,
-                                                 /*in_load_list=*/true);
-            if (resolved != CacheWarmupPolicy::CacheWarmupPolicy_Disable) {
-                eager_fields.push_back(field_id);
-            } else {
-                lazy_fields.push_back(field_id);
-            }
-        }
-
-        if (!eager_fields.empty()) {
-            tasks.push_back({cg_index, std::move(eager_fields), true});
-        }
-        // Lazy fields are emitted one-per-field so that each creates its
-        // own single-column projected ChunkReader. Accessing one lazy
-        // field (e.g. caption) will not co-load sibling lazy fields
-        // (e.g. vector), avoiding unnecessary S3 downloads.
-        for (const auto& fid : lazy_fields) {
-            tasks.push_back({cg_index, {fid}, false});
-        }
-        LOG_INFO(
-            "[LoadColumnGroups] segment {} cg {} fields={} eager_fields={} "
-            "lazy_fields={}",
-            get_segment_id(),
-            cg_index,
-            FormatFieldIds(all_fields),
-            FormatFieldIds(eager_fields),
-            FormatFieldIds(lazy_fields));
-    }
-
-    LOG_INFO(
-        "[LoadColumnGroups] segment {} external table: {} tasks from {} column "
-        "groups",
-        get_segment_id(),
-        tasks.size(),
-        cg_field_ids.size());
-
-    for (const auto& task : tasks) {
-        CheckCancellation(op_ctx,
-                          id_,
-                          task.cg_index,
-                          "ChunkedSegmentSealedImpl::LoadColumnGroup()");
-        LoadColumnGroup(column_groups,
-                        properties,
-                        task.cg_index,
-                        task.field_ids,
-                        segment_load_info,
-                        schema_snapshot,
-                        task.eager_load,
-                        op_ctx,
-                        /*is_replace=*/false,
-                        runtime);
-    }
-
-    if (schema_snapshot->is_external_collection()) {
-        SynthesizeExternalSystemFields(
-            segment_load_info, schema_snapshot, runtime);
-    }
-}
-
-void
-ChunkedSegmentSealedImpl::LoadColumnGroups(
-    const std::string& manifest_path,
     const SegmentLoadInfo& segment_load_info,
     const SchemaPtr& schema_snapshot,
     milvus::OpContext* op_ctx,
@@ -6776,11 +6583,7 @@ ChunkedSegmentSealedImpl::PrepareLoadDiffForReopen(
 
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
     if (diff.load_external_manifest) {
-        LoadColumnGroups(segment_load_info.GetManifestPath(),
-                         segment_load_info,
-                         schema_snapshot,
-                         op_ctx,
-                         committer);
+        LoadColumnGroups(segment_load_info, schema_snapshot, op_ctx, committer);
     } else {
         bool has_cg_changes = !diff.column_groups_to_load.empty() ||
                               !diff.column_groups_to_replace.empty() ||
@@ -7594,109 +7397,6 @@ ChunkedSegmentSealedImpl::InitTextLobPaths(const std::string& manifest_path,
                      lob_path);
         }
     });
-}
-
-void
-ChunkedSegmentSealedImpl::LoadColumnGroups(
-    const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
-    const std::shared_ptr<milvus_storage::api::Properties>& properties,
-    std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
-    bool eager_load,
-    milvus::OpContext* op_ctx,
-    bool is_replace) {
-    auto snapshot = CapturePublishedState();
-    if (snapshot->schema->is_external_collection()) {
-        auto runtime = CloneMutableRuntimeResourceState();
-        LoadColumnGroups(column_groups,
-                         properties,
-                         cg_field_ids,
-                         *snapshot->load_info,
-                         snapshot->schema,
-                         eager_load,
-                         op_ctx,
-                         is_replace,
-                         runtime.get());
-        PublishRuntimeStateLocked(ToConstRuntimeState(std::move(runtime)));
-        return;
-    }
-    LoadColumnGroups(column_groups,
-                     properties,
-                     cg_field_ids,
-                     *snapshot->load_info,
-                     snapshot->schema,
-                     eager_load,
-                     op_ctx,
-                     is_replace,
-                     nullptr);
-}
-
-void
-ChunkedSegmentSealedImpl::LoadColumnGroups(
-    const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
-    const std::shared_ptr<milvus_storage::api::Properties>& properties,
-    std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
-    const SegmentLoadInfo& segment_load_info,
-    const SchemaPtr& schema_snapshot,
-    bool eager_load,
-    milvus::OpContext* op_ctx,
-    bool is_replace,
-    RuntimeResourceState* runtime) {
-    if (runtime != nullptr) {
-        for (const auto& pair : cg_field_ids) {
-            auto cg_index = pair.first;
-            const auto& field_ids = pair.second;
-            CheckCancellation(op_ctx,
-                              id_,
-                              cg_index,
-                              "ChunkedSegmentSealedImpl::LoadColumnGroup()");
-            LoadColumnGroup(column_groups,
-                            properties,
-                            cg_index,
-                            field_ids,
-                            segment_load_info,
-                            schema_snapshot,
-                            eager_load,
-                            op_ctx,
-                            is_replace,
-                            runtime);
-        }
-        return;
-    }
-
-    auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::MIDDLE);
-    std::vector<std::future<void>> load_group_futures;
-    for (const auto& pair : cg_field_ids) {
-        auto cg_index = pair.first;
-        const auto& field_ids = pair.second;
-        auto future = pool.Submit([this,
-                                   column_groups,
-                                   properties,
-                                   cg_index,
-                                   field_ids,
-                                   &segment_load_info,
-                                   schema_snapshot,
-                                   eager_load,
-                                   op_ctx,
-                                   is_replace]() {
-            CheckCancellation(op_ctx,
-                              id_,
-                              cg_index,
-                              "ChunkedSegmentSealedImpl::LoadColumnGroup()");
-            LoadColumnGroup(column_groups,
-                            properties,
-                            cg_index,
-                            field_ids,
-                            segment_load_info,
-                            schema_snapshot,
-                            eager_load,
-                            op_ctx,
-                            is_replace,
-                            nullptr);
-        });
-        load_group_futures.emplace_back(std::move(future));
-    }
-
-    storage::WaitAllFutures(load_group_futures);
 }
 
 void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -684,17 +684,19 @@ ChunkedSegmentSealedImpl::LoadVecIndex(LoadIndexInfo& info,
             *staged_state, field_id, request.has_raw_data);
         NormalizePublishedState(*staged_state);
     } else {
-        std::unique_lock lck(mutex_);
+        auto next_runtime = CloneMutableRuntimeResourceState();
         if (drop_existing) {
-            vector_indexings_.drop_field_indexing(field_id);
+            DropVectorIndexing(*next_runtime, field_id);
+            next_runtime->vec_binlog_config.erase(field_id);
         }
-        vector_indexings_.append_field_indexing(
-            field_id, metric_type, std::move(info.cache_index));
-        lck.unlock();
+        next_runtime->vector_indexings[field_id] =
+            BuildVectorIndexEntry(metric_type, std::move(info.cache_index));
         LOG_INFO("Has load vec index done, fieldID:{}. segmentID:{}, ",
                  info.field_id,
                  id_);
-        PublishIndexReadyLocked(field_id, request.has_raw_data);
+        PublishIndexReadyLocked(field_id,
+                                request.has_raw_data,
+                                ToConstRuntimeState(std::move(next_runtime)));
     }
 }
 
@@ -896,6 +898,8 @@ ChunkedSegmentSealedImpl::CloneRuntimeResourceState(
     state->struct_to_array_offsets = current->struct_to_array_offsets;
     state->array_offsets_map = current->array_offsets_map;
     state->scalar_indexings = current->scalar_indexings;
+    state->vector_indexings = current->vector_indexings;
+    state->vec_binlog_config = current->vec_binlog_config;
     state->ngram_fields = current->ngram_fields;
     state->ngram_indexings = current->ngram_indexings;
     state->text_lob_paths = current->text_lob_paths;
@@ -958,6 +962,56 @@ std::shared_ptr<const TimestampData>
 ChunkedSegmentSealedImpl::CaptureTimestampSnapshot() const {
     auto runtime = CaptureRuntimeResourceState();
     return runtime != nullptr ? runtime->timestamps : nullptr;
+}
+
+SealedIndexingEntryPtr
+ChunkedSegmentSealedImpl::BuildVectorIndexEntry(
+    const MetricType& metric_type, index::CacheIndexBasePtr indexing) {
+    auto entry = std::make_shared<SealedIndexingEntry>();
+    entry->metric_type_ = metric_type;
+    entry->indexing_ = std::move(indexing);
+    return entry;
+}
+
+bool
+ChunkedSegmentSealedImpl::RuntimeVectorIndexReady(
+    const RuntimeResourceState* runtime, FieldId field_id) {
+    return runtime != nullptr && runtime->vector_indexings.find(field_id) !=
+                                     runtime->vector_indexings.end();
+}
+
+SealedIndexingEntryPtr
+ChunkedSegmentSealedImpl::GetVectorIndexing(
+    const std::shared_ptr<const RuntimeResourceState>& runtime,
+    FieldId field_id) {
+    if (runtime == nullptr) {
+        return nullptr;
+    }
+    auto it = runtime->vector_indexings.find(field_id);
+    return it != runtime->vector_indexings.end() ? it->second : nullptr;
+}
+
+void
+ChunkedSegmentSealedImpl::DropVectorIndexing(RuntimeResourceState& runtime,
+                                             FieldId field_id) {
+    auto it = runtime.vector_indexings.find(field_id);
+    if (it != runtime.vector_indexings.end()) {
+        if (it->second != nullptr && it->second->indexing_ != nullptr) {
+            it->second->indexing_->CancelWarmup();
+        }
+        runtime.vector_indexings.erase(it);
+    }
+}
+
+void
+ChunkedSegmentSealedImpl::ClearVectorIndexings(RuntimeResourceState& runtime) {
+    for (auto& [_, entry] : runtime.vector_indexings) {
+        if (entry != nullptr && entry->indexing_ != nullptr) {
+            entry->indexing_->CancelWarmup();
+        }
+    }
+    runtime.vector_indexings.clear();
+    runtime.vec_binlog_config.clear();
 }
 
 std::shared_ptr<ChunkedSegmentSealedImpl::PublishedSegmentState>
@@ -1147,6 +1201,8 @@ ChunkedSegmentSealedImpl::FreezeRuntimeResourceState(
     runtime->struct_to_array_offsets = current.struct_to_array_offsets;
     runtime->array_offsets_map = current.array_offsets_map;
     runtime->scalar_indexings = current.scalar_indexings;
+    runtime->vector_indexings = current.vector_indexings;
+    runtime->vec_binlog_config = current.vec_binlog_config;
     runtime->ngram_fields = current.ngram_fields;
     runtime->ngram_indexings = current.ngram_indexings;
     runtime->text_lob_paths = current.text_lob_paths;
@@ -1514,19 +1570,23 @@ ChunkedSegmentSealedImpl::PublishIndexReadyLocked(
     MutatePublishedStateLocked([&](PublishedSegmentState& state) {
         if (runtime != nullptr) {
             state.runtime = runtime;
-        } else {
-            clear_bit_if_present(state.published_binlog_index_ready_bitset,
-                                 field_id);
-            set_bit(state.published_index_ready_bitset, field_id, true);
         }
+        clear_bit_if_present(state.published_binlog_index_ready_bitset,
+                             field_id);
+        set_bit(state.published_index_ready_bitset, field_id, true);
         SetPublishedIndexRawDataInState(state, field_id, has_raw_data);
     });
 }
 
 void
-ChunkedSegmentSealedImpl::PublishBinlogIndexReadyLocked(FieldId field_id,
-                                                        bool has_raw_data) {
+ChunkedSegmentSealedImpl::PublishBinlogIndexReadyLocked(
+    FieldId field_id,
+    bool has_raw_data,
+    const std::shared_ptr<const RuntimeResourceState>& runtime) {
     MutatePublishedStateLocked([&](PublishedSegmentState& state) {
+        if (runtime != nullptr) {
+            state.runtime = runtime;
+        }
         clear_bit_if_present(state.published_index_ready_bitset, field_id);
         set_bit(state.published_binlog_index_ready_bitset, field_id, true);
         SetPublishedIndexRawDataInState(state, field_id, has_raw_data);
@@ -3316,23 +3376,24 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
     auto snapshot = CapturePublishedState();
     AssertInfo(snapshot->system_field_ready, "System field is not ready");
     auto field_id = search_info.field_id_;
+    auto runtime = snapshot->runtime;
     auto& field_meta = snapshot->schema->operator[](field_id);
 
     AssertInfo(field_meta.is_vector(),
                "The meta type of vector field is not vector type");
 
     if (get_bit(snapshot->binlog_index_bitset, field_id)) {
-        AssertInfo(
-            vec_binlog_config_.find(field_id) != vec_binlog_config_.end(),
-            "The binlog params is not generate.");
-        auto binlog_search_info =
-            vec_binlog_config_.at(field_id)->GetSearchConf(search_info);
+        auto config_it = runtime->vec_binlog_config.find(field_id);
+        AssertInfo(config_it != runtime->vec_binlog_config.end(),
+                   "The binlog params is not generate.");
+        auto binlog_search_info = config_it->second->GetSearchConf(search_info);
 
-        AssertInfo(vector_indexings_.is_ready(field_id),
+        auto vector_entry = GetVectorIndexing(runtime, field_id);
+        AssertInfo(vector_entry != nullptr,
                    "vector indexes isn't ready for field " +
                        std::to_string(field_id.get()));
         query::SearchOnSealedIndex(*snapshot->schema,
-                                   vector_indexings_,
+                                   *vector_entry,
                                    binlog_search_info,
                                    query_data,
                                    query_offsets,
@@ -3344,14 +3405,15 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
             "finish_searching_vector_temperate_binlog_index");
     } else if (get_bit(snapshot->index_ready_bitset, field_id)) {
         if (search_info.global_refine_enable_ &&
-            IsIndexRefineEnabledLocked(op_context, field_id)) {
+            IsIndexRefineEnabledLocked(op_context, field_id, runtime)) {
             search_info.topk_ = GetEffectiveSearchTopk(search_info);
         }
-        AssertInfo(vector_indexings_.is_ready(field_id),
+        auto vector_entry = GetVectorIndexing(runtime, field_id);
+        AssertInfo(vector_entry != nullptr,
                    "vector indexes isn't ready for field " +
                        std::to_string(field_id.get()));
         query::SearchOnSealedIndex(*snapshot->schema,
-                                   vector_indexings_,
+                                   *vector_entry,
                                    search_info,
                                    query_data,
                                    query_offsets,
@@ -3396,17 +3458,13 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
 ChunkedSegmentSealedImpl::ValidResult
 ChunkedSegmentSealedImpl::FilterVectorValidOffsetsFromIndex(
     milvus::OpContext* op_ctx,
-    FieldId field_id,
+    const SealedIndexingEntry& entry,
     const int64_t* seg_offsets,
     int64_t count) const {
     ValidResult result;
     result.valid_count = count;
 
-    AssertInfo(vector_indexings_.is_ready(field_id),
-               "vector index is not ready");
-    auto field_indexing = vector_indexings_.get_field_indexing(field_id);
-    auto cache_index = field_indexing->indexing_;
-    auto ca = SemiInlineGet(cache_index->PinCells(op_ctx, {0}));
+    auto ca = SemiInlineGet(entry.indexing_->PinCells(op_ctx, {0}));
     auto vec_index = dynamic_cast<index::VectorIndex*>(ca->get_cell_of(0));
     AssertInfo(vec_index != nullptr, "invalid vector indexing");
     AssertInfo(vec_index->HasValidData(),
@@ -3458,11 +3516,9 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
         return fill_with_empty(field_id, count);
     }
 
-    AssertInfo(vector_indexings_.is_ready(field_id),
-               "vector index is not ready");
-    auto field_indexing = vector_indexings_.get_field_indexing(field_id);
-    auto cache_index = field_indexing->indexing_;
-    auto ca = SemiInlineGet(cache_index->PinCells(op_ctx, {0}));
+    auto vector_entry = GetVectorIndexing(snapshot->runtime, field_id);
+    AssertInfo(vector_entry != nullptr, "vector index is not ready");
+    auto ca = SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
     auto vec_index = dynamic_cast<index::VectorIndex*>(ca->get_cell_of(0));
     AssertInfo(vec_index, "invalid vector indexing");
 
@@ -3487,8 +3543,8 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
                           "nullable vector index has raw data but no valid "
                           "data, and field data is unavailable");
             }
-            filter_result =
-                FilterVectorValidOffsetsFromIndex(op_ctx, field_id, ids, count);
+            filter_result = FilterVectorValidOffsetsFromIndex(
+                op_ctx, *vector_entry, ids, count);
             ids_ds = GenIdsDataset(filter_result.valid_count,
                                    filter_result.valid_offsets.data());
             valid_count = filter_result.valid_count;
@@ -3528,11 +3584,9 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
         return fill_with_empty(field_id, count);
     }
 
-    AssertInfo(vector_indexings_.is_ready(field_id),
-               "vector index is not ready");
-    auto field_indexing = vector_indexings_.get_field_indexing(field_id);
-    auto cache_index = field_indexing->indexing_;
-    auto ca = SemiInlineGet(cache_index->PinCells(op_ctx, {0}));
+    auto vector_entry = GetVectorIndexing(snapshot->runtime, field_id);
+    AssertInfo(vector_entry != nullptr, "vector index is not ready");
+    auto ca = SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
     auto vec_index = dynamic_cast<index::VectorIndex*>(ca->get_cell_of(0));
     AssertInfo(vec_index, "invalid vector indexing");
     auto has_raw_data = vec_index->HasRawData();
@@ -3563,7 +3617,7 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
                       "data, and field data is unavailable");
         }
         filter_result = FilterVectorValidOffsetsFromIndex(
-            op_ctx, field_id, seg_offsets, count);
+            op_ctx, *vector_entry, seg_offsets, count);
         valid_count = filter_result.valid_count;
         valid_data = filter_result.valid_data.get();
         valid_offsets = filter_result.valid_offsets.data();
@@ -3685,15 +3739,21 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id,
         LOG_INFO(
             "Skip dropping pk field {} in segment {}", field_id.get(), id_);
         if (runtime == nullptr && has_binlog_index) {
-            MarkBinlogIndexReadyLocked(field_id, false);
-            if (!get_bit(snapshot->index_ready_bitset, field_id)) {
-                ClearIndexHasRawDataLocked(field_id);
-            }
-        }
-
-        std::unique_lock<std::shared_mutex> lck(mutex_);
-        if (runtime == nullptr && has_binlog_index) {
-            vector_indexings_.drop_field_indexing(field_id);
+            auto next_runtime = CloneMutableRuntimeResourceState();
+            DropVectorIndexing(*next_runtime, field_id);
+            next_runtime->vec_binlog_config.erase(field_id);
+            auto published_runtime =
+                ToConstRuntimeState(std::move(next_runtime));
+            MutatePublishedStateLocked([&](PublishedSegmentState& state) {
+                state.runtime = published_runtime;
+                clear_bit_if_present(state.published_binlog_index_ready_bitset,
+                                     field_id);
+                clear_bit_if_present(state.binlog_index_bitset, field_id);
+                if (!get_bit_if_present(state.index_ready_bitset, field_id)) {
+                    ClearPublishedIndexRawDataInState(state, field_id);
+                    ClearIndexRawDataInState(state, field_id);
+                }
+            });
         }
         return;
     }
@@ -3709,15 +3769,12 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id,
         auto next_runtime = CloneMutableRuntimeResourceState();
         next_runtime->fields.erase(field_id);
         next_runtime->array_offsets_map.erase(field_id);
+        if (has_binlog_index) {
+            DropVectorIndexing(*next_runtime, field_id);
+            next_runtime->vec_binlog_config.erase(field_id);
+        }
         PublishFieldDroppedLocked(field_id,
                                   ToConstRuntimeState(std::move(next_runtime)));
-    }
-
-    if (runtime == nullptr) {
-        std::unique_lock<std::shared_mutex> lck(mutex_);
-        if (has_binlog_index) {
-            vector_indexings_.drop_field_indexing(field_id);
-        }
     }
 }
 
@@ -3747,13 +3804,10 @@ ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id,
         auto next_runtime = CloneMutableRuntimeResourceState();
         cancel_and_erase_scalar_index(next_runtime->scalar_indexings, field_id);
         next_runtime->ngram_fields.erase(field_id);
+        DropVectorIndexing(*next_runtime, field_id);
+        next_runtime->vec_binlog_config.erase(field_id);
         PublishIndexDroppedLocked(field_id,
                                   ToConstRuntimeState(std::move(next_runtime)));
-    }
-
-    if (runtime == nullptr) {
-        std::unique_lock lck(mutex_);
-        vector_indexings_.drop_field_indexing(field_id);
     }
 }
 
@@ -4835,6 +4889,14 @@ ChunkedSegmentSealedImpl::bulk_subscript_text_impl(
 void
 ChunkedSegmentSealedImpl::ClearData() {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+    auto runtime_snapshot = CaptureRuntimeResourceState();
+    if (runtime_snapshot != nullptr) {
+        for (const auto& [_, entry] : runtime_snapshot->vector_indexings) {
+            if (entry != nullptr && entry->indexing_ != nullptr) {
+                entry->indexing_->CancelWarmup();
+            }
+        }
+    }
     {
         std::unique_lock lck(mutex_);
         num_rows_ = std::nullopt;
@@ -4842,8 +4904,6 @@ ChunkedSegmentSealedImpl::ClearData() {
         scalar_indexings_.withWLock([&](auto& scalar_indexings) {
             cancel_and_clear_scalar_indexings(scalar_indexings);
         });
-        vector_indexings_.clear();
-        vec_binlog_config_.clear();
         ngram_indexings_.withWLock([&](auto& ngram_indexings) {
             cancel_and_clear_ngram_indexings(ngram_indexings);
         });
@@ -5982,10 +6042,10 @@ ChunkedSegmentSealedImpl::HasRawData(int64_t field_id) const {
 
     if (IsVectorDataType(field_meta.get_data_type())) {
         if (get_bit(snapshot->index_ready_bitset, fieldID)) {
-            AssertInfo(vector_indexings_.is_ready(fieldID),
+            AssertInfo(GetVectorIndexing(snapshot->runtime, fieldID) != nullptr,
                        "vector index is not ready");
         } else if (get_bit(snapshot->binlog_index_bitset, fieldID)) {
-            AssertInfo(vector_indexings_.is_ready(fieldID),
+            AssertInfo(GetVectorIndexing(snapshot->runtime, fieldID) != nullptr,
                        "interim index is not ready");
         }
     }
@@ -6008,12 +6068,13 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
     bool is_cosine,
     float* distances) const {
     std::shared_lock vector_state_lck(mutex_);
-    if (!vector_indexings_.is_ready(field_id)) {
+    auto runtime = CaptureRuntimeResourceState();
+    auto vector_entry = GetVectorIndexing(runtime, field_id);
+    if (vector_entry == nullptr) {
         return false;
     }
-    auto field_indexing = vector_indexings_.get_field_indexing(field_id);
     auto accessor =
-        SemiInlineGet(field_indexing->indexing_->PinCells(op_ctx, {0}));
+        SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
     if (vec_index == nullptr) {
@@ -6046,14 +6107,16 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
 }
 
 bool
-ChunkedSegmentSealedImpl::IsIndexRefineEnabledLocked(milvus::OpContext* op_ctx,
-                                                     FieldId field_id) const {
-    if (!vector_indexings_.is_ready(field_id)) {
+ChunkedSegmentSealedImpl::IsIndexRefineEnabledLocked(
+    milvus::OpContext* op_ctx,
+    FieldId field_id,
+    const std::shared_ptr<const RuntimeResourceState>& runtime) const {
+    auto vector_entry = GetVectorIndexing(runtime, field_id);
+    if (vector_entry == nullptr) {
         return false;
     }
-    auto field_indexing = vector_indexings_.get_field_indexing(field_id);
     auto accessor =
-        SemiInlineGet(field_indexing->indexing_->PinCells(op_ctx, {0}));
+        SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
     return vec_index != nullptr && vec_index->IsIndexRefineEnabled();
@@ -6063,7 +6126,8 @@ bool
 ChunkedSegmentSealedImpl::IsIndexRefineEnabled(milvus::OpContext* op_ctx,
                                                FieldId field_id) const {
     std::shared_lock vector_state_lck(mutex_);
-    return IsIndexRefineEnabledLocked(op_ctx, field_id);
+    return IsIndexRefineEnabledLocked(
+        op_ctx, field_id, CaptureRuntimeResourceState());
 }
 
 DataType
@@ -6321,8 +6385,11 @@ ChunkedSegmentSealedImpl::generate_interim_index(
             if (committer->IsVectorIndexReady(field_id)) {
                 return false;
             }
-        } else if (vector_indexings_.is_ready(field_id)) {
-            return false;
+        } else {
+            auto snapshot = CapturePublishedState();
+            if (RuntimeVectorIndexReady(snapshot->runtime.get(), field_id)) {
+                return false;
+            }
         }
         return true;
     };
@@ -6423,14 +6490,17 @@ ChunkedSegmentSealedImpl::generate_interim_index(
                             staged_state, field_id, has_raw_data);
                     });
             } else {
-                std::unique_lock lck(mutex_);
-                vector_indexings_.append_field_indexing(
+                auto next_runtime = CloneMutableRuntimeResourceState();
+                next_runtime->vector_indexings[field_id] =
+                    BuildVectorIndexEntry(index_metric,
+                                          std::move(interim_index_cache_slot));
+                next_runtime->vec_binlog_config[field_id] =
+                    std::shared_ptr<const VecIndexConfig>(
+                        std::move(field_binlog_config));
+                PublishBinlogIndexReadyLocked(
                     field_id,
-                    index_metric,
-                    std::move(interim_index_cache_slot));
-                vec_binlog_config_[field_id] = std::move(field_binlog_config);
-                lck.unlock();
-                PublishBinlogIndexReadyLocked(field_id, has_raw_data);
+                    has_raw_data,
+                    ToConstRuntimeState(std::move(next_runtime)));
             }
 
             LOG_INFO(
@@ -9430,12 +9500,10 @@ void
 ChunkedSegmentSealedImpl::prefetch_vector(milvus::OpContext* op_ctx,
                                           FieldId field_id) const {
     std::shared_lock vector_state_lck(mutex_);
-    auto is_ready = this->vector_indexings_.is_ready(field_id);
-    if (is_ready) {
-        auto field_indexing =
-            this->vector_indexings_.get_field_indexing(field_id);
-        auto cache_index = field_indexing->indexing_;
-        SemiInlineGet(cache_index->PinCells(op_ctx, {0}));
+    auto runtime = CaptureRuntimeResourceState();
+    auto vector_entry = GetVectorIndexing(runtime, field_id);
+    if (vector_entry != nullptr) {
+        SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
     } else {
         this->prefetch_chunks_locked(op_ctx, field_id);
     }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1398,11 +1398,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<const RuntimeResourceState>& runtime,
         FieldId field_id);
 
-    static void
-    DropVectorIndexing(RuntimeResourceState& runtime, FieldId field_id);
+    static SealedIndexingEntryPtr
+    EraseVectorIndexing(RuntimeResourceState& runtime, FieldId field_id);
 
     static void
-    ClearVectorIndexings(RuntimeResourceState& runtime);
+    DropVectorIndexing(RuntimeResourceState& runtime, FieldId field_id);
 
     std::shared_ptr<PublishedSegmentState>
     BuildNextPublishedState(
@@ -1456,7 +1456,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                        index::CacheIndexBasePtr indexing,
                                        bool drop_existing) {
             if (drop_existing) {
-                DropVectorIndexing(*runtime_, field_id);
+                RetireVectorIndexingLocked(field_id);
                 runtime_->vec_binlog_config.erase(field_id);
             }
             runtime_->vector_indexings[field_id] =
@@ -1465,7 +1465,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
         void
         StageVectorIndexDropLocked(FieldId field_id) {
-            DropVectorIndexing(*runtime_, field_id);
+            RetireVectorIndexingLocked(field_id);
             runtime_->vec_binlog_config.erase(field_id);
         }
 
@@ -1484,15 +1484,33 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         void
         Publish(const std::shared_ptr<const PublishedSegmentState>& current,
                 const StateDelta& delta) {
-            std::lock_guard<std::mutex> lock(mutex_);
-            segment_.PublishState(
-                segment_.BuildNextPublishedState(current, delta));
+            std::vector<SealedIndexingEntryPtr> retired_indexings;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                segment_.PublishState(
+                    segment_.BuildNextPublishedState(current, delta));
+                retired_indexings.swap(retired_vector_indexings_);
+            }
+            for (auto& entry : retired_indexings) {
+                if (entry != nullptr && entry->indexing_ != nullptr) {
+                    entry->indexing_->CancelWarmup();
+                }
+            }
         }
 
      private:
+        void
+        RetireVectorIndexingLocked(FieldId field_id) {
+            auto entry = EraseVectorIndexing(*runtime_, field_id);
+            if (entry != nullptr) {
+                retired_vector_indexings_.push_back(std::move(entry));
+            }
+        }
+
         ChunkedSegmentSealedImpl& segment_;
         RuntimeResourceState* runtime_;
         PublishedSegmentState* staged_state_;
+        std::vector<SealedIndexingEntryPtr> retired_vector_indexings_;
         std::mutex mutex_;
     };
 
@@ -1868,49 +1886,16 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const SegmentLoadInfo& segment_load_info,
         const SchemaPtr& schema_snapshot,
         bool eager_load,
-        milvus::OpContext* op_ctx = nullptr,
-        bool is_replace = false,
-        RuntimeResourceState* runtime = nullptr);
-
-    void
-    LoadColumnGroups(
-        const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
-        const std::shared_ptr<milvus_storage::api::Properties>& properties,
-        std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
-        const SegmentLoadInfo& segment_load_info,
-        const SchemaPtr& schema_snapshot,
-        bool eager_load,
         milvus::OpContext* op_ctx,
         bool is_replace,
         StagedStateCommitter& committer);
 
+    // Load external collection column groups from staged segment load info.
     void
-    LoadColumnGroups(
-        const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
-        const std::shared_ptr<milvus_storage::api::Properties>& properties,
-        std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
-        bool eager_load,
-        milvus::OpContext* op_ctx = nullptr,
-        bool is_replace = false);
-
-    void
-    LoadColumnGroups(const std::string& manifest_path,
-                     const SegmentLoadInfo& segment_load_info,
-                     const SchemaPtr& schema_snapshot,
-                     milvus::OpContext* op_ctx = nullptr,
-                     RuntimeResourceState* runtime = nullptr);
-
-    // Load column groups from a manifest file path (for external collections)
-    void
-    LoadColumnGroups(const std::string& manifest_path,
-                     const SegmentLoadInfo& segment_load_info,
+    LoadColumnGroups(const SegmentLoadInfo& segment_load_info,
                      const SchemaPtr& schema_snapshot,
                      milvus::OpContext* op_ctx,
                      StagedStateCommitter& committer);
-
-    void
-    LoadColumnGroups(const std::string& manifest_path,
-                     milvus::OpContext* op_ctx = nullptr);
 
     void
     LoadColumnGroup(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -334,6 +334,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         std::unordered_map<FieldId, std::shared_ptr<ArrayOffsetsSealed>>
             array_offsets_map;
         std::unordered_map<FieldId, index::CacheIndexBasePtr> scalar_indexings;
+        std::unordered_map<FieldId, SealedIndexingEntryPtr> vector_indexings;
+        std::unordered_map<FieldId, std::shared_ptr<const VecIndexConfig>>
+            vec_binlog_config;
         std::unordered_set<FieldId> ngram_fields;
         std::unordered_map<
             FieldId,
@@ -1251,7 +1254,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     ValidResult
     FilterVectorValidOffsetsFromIndex(milvus::OpContext* op_ctx,
-                                      FieldId field_id,
+                                      const SealedIndexingEntry& entry,
                                       const int64_t* seg_offsets,
                                       int64_t count) const;
 
@@ -1336,8 +1339,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         StagedStateCommitter* committer = nullptr);
 
     bool
-    IsIndexRefineEnabledLocked(milvus::OpContext* op_ctx,
-                               FieldId field_id) const;
+    IsIndexRefineEnabledLocked(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        const std::shared_ptr<const RuntimeResourceState>& runtime) const;
 
     void
     prefetch_chunks_locked(milvus::OpContext* op_ctx, FieldId field_id) const;
@@ -1379,6 +1384,25 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     std::shared_ptr<const TimestampData>
     CaptureTimestampSnapshot() const;
+
+    static SealedIndexingEntryPtr
+    BuildVectorIndexEntry(const MetricType& metric_type,
+                          index::CacheIndexBasePtr indexing);
+
+    static bool
+    RuntimeVectorIndexReady(const RuntimeResourceState* runtime,
+                            FieldId field_id);
+
+    static SealedIndexingEntryPtr
+    GetVectorIndexing(
+        const std::shared_ptr<const RuntimeResourceState>& runtime,
+        FieldId field_id);
+
+    static void
+    DropVectorIndexing(RuntimeResourceState& runtime, FieldId field_id);
+
+    static void
+    ClearVectorIndexings(RuntimeResourceState& runtime);
 
     std::shared_ptr<PublishedSegmentState>
     BuildNextPublishedState(
@@ -1431,26 +1455,18 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                        const MetricType& metric_type,
                                        index::CacheIndexBasePtr indexing,
                                        bool drop_existing) {
-            vector_index_mutations_.push_back(VectorIndexMutation{
-                field_id,
-                metric_type,
-                std::move(indexing),
-                nullptr,
-                drop_existing,
-                false,
-            });
+            if (drop_existing) {
+                DropVectorIndexing(*runtime_, field_id);
+                runtime_->vec_binlog_config.erase(field_id);
+            }
+            runtime_->vector_indexings[field_id] =
+                BuildVectorIndexEntry(metric_type, std::move(indexing));
         }
 
         void
         StageVectorIndexDropLocked(FieldId field_id) {
-            vector_index_mutations_.push_back(VectorIndexMutation{
-                field_id,
-                MetricType{},
-                nullptr,
-                nullptr,
-                true,
-                false,
-            });
+            DropVectorIndexing(*runtime_, field_id);
+            runtime_->vec_binlog_config.erase(field_id);
         }
 
         void
@@ -1459,56 +1475,24 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
             const MetricType& metric_type,
             index::CacheIndexBasePtr indexing,
             std::unique_ptr<VecIndexConfig> binlog_config) {
-            vector_index_mutations_.push_back(VectorIndexMutation{
-                field_id,
-                metric_type,
-                std::move(indexing),
-                std::move(binlog_config),
-                false,
-                true,
-            });
+            runtime_->vector_indexings[field_id] =
+                BuildVectorIndexEntry(metric_type, std::move(indexing));
+            runtime_->vec_binlog_config[field_id] =
+                std::shared_ptr<const VecIndexConfig>(std::move(binlog_config));
         }
 
         void
         Publish(const std::shared_ptr<const PublishedSegmentState>& current,
                 const StateDelta& delta) {
             std::lock_guard<std::mutex> lock(mutex_);
-            std::unique_lock<std::shared_mutex> segment_lock(segment_.mutex_);
-            for (auto& mutation : vector_index_mutations_) {
-                if (mutation.drop_existing) {
-                    segment_.vector_indexings_.drop_field_indexing(
-                        mutation.field_id);
-                }
-                if (mutation.indexing != nullptr) {
-                    segment_.vector_indexings_.append_field_indexing(
-                        mutation.field_id,
-                        mutation.metric_type,
-                        std::move(mutation.indexing));
-                }
-                if (mutation.update_binlog_config) {
-                    segment_.vec_binlog_config_[mutation.field_id] =
-                        std::move(mutation.binlog_config);
-                }
-            }
-            vector_index_mutations_.clear();
             segment_.PublishState(
                 segment_.BuildNextPublishedState(current, delta));
         }
 
      private:
-        struct VectorIndexMutation {
-            FieldId field_id;
-            MetricType metric_type;
-            index::CacheIndexBasePtr indexing;
-            std::unique_ptr<VecIndexConfig> binlog_config;
-            bool drop_existing;
-            bool update_binlog_config;
-        };
-
         ChunkedSegmentSealedImpl& segment_;
         RuntimeResourceState* runtime_;
         PublishedSegmentState* staged_state_;
-        std::vector<VectorIndexMutation> vector_index_mutations_;
         std::mutex mutex_;
     };
 
@@ -1696,7 +1680,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<const RuntimeResourceState>& runtime = nullptr);
 
     void
-    PublishBinlogIndexReadyLocked(FieldId field_id, bool has_raw_data);
+    PublishBinlogIndexReadyLocked(
+        FieldId field_id,
+        bool has_raw_data,
+        const std::shared_ptr<const RuntimeResourceState>& runtime = nullptr);
 
     void
     PublishVectorIndexFactsLocked(FieldId field_id,
@@ -2168,8 +2155,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // scalar field index
     folly::Synchronized<std::unordered_map<FieldId, index::CacheIndexBasePtr>>
         scalar_indexings_;
-    // vector field index
-    SealedIndexingRecord vector_indexings_;
 
     // inserted fields data and row_ids, timestamps
     InsertRecord<true> insert_record_;
@@ -2214,8 +2199,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // only useful in binlog
     IndexMetaPtr col_index_meta_;
     SegcoreConfig segcore_config_;
-    std::unordered_map<FieldId, std::unique_ptr<VecIndexConfig>>
-        vec_binlog_config_;
 
     SegmentStats stats_{};
 
@@ -2406,8 +2389,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     bool
     TestVectorIndexReady(FieldId field_id) const {
-        std::shared_lock lck(mutex_);
-        return vector_indexings_.is_ready(field_id);
+        auto runtime = CaptureRuntimeResourceState();
+        return GetVectorIndexing(runtime, field_id) != nullptr;
     }
 
     void

--- a/internal/core/src/segcore/IndexConfigGenerator.cpp
+++ b/internal/core/src/segcore/IndexConfigGenerator.cpp
@@ -104,17 +104,17 @@ VecIndexConfig::GetBuildThreshold() const noexcept {
 }
 
 knowhere::IndexType
-VecIndexConfig::GetIndexType() noexcept {
+VecIndexConfig::GetIndexType() const noexcept {
     return index_type_;
 }
 
 knowhere::MetricType
-VecIndexConfig::GetMetricType() noexcept {
+VecIndexConfig::GetMetricType() const noexcept {
     return metric_type_;
 }
 
 knowhere::Json
-VecIndexConfig::GetBuildBaseParams(DataType data_type) {
+VecIndexConfig::GetBuildBaseParams(DataType data_type) const {
     if (data_type == DataType::VECTOR_BFLOAT16 &&
         build_params_[knowhere::indexparam::REFINE_TYPE] ==
             knowhere::RefineType::FLOAT16_QUANT) {
@@ -135,7 +135,7 @@ VecIndexConfig::GetBuildBaseParams(DataType data_type) {
 }
 
 SearchInfo
-VecIndexConfig::GetSearchConf(const SearchInfo& searchInfo) {
+VecIndexConfig::GetSearchConf(const SearchInfo& searchInfo) const {
     SearchInfo searchParam(searchInfo);
     searchParam.metric_type_ = metric_type_;
     searchParam.search_params_ = search_params_;

--- a/internal/core/src/segcore/IndexConfigGenerator.h
+++ b/internal/core/src/segcore/IndexConfigGenerator.h
@@ -49,16 +49,16 @@ class VecIndexConfig {
     GetBuildThreshold() const noexcept;
 
     knowhere::IndexType
-    GetIndexType() noexcept;
+    GetIndexType() const noexcept;
 
     knowhere::MetricType
-    GetMetricType() noexcept;
+    GetMetricType() const noexcept;
 
     knowhere::Json
-    GetBuildBaseParams(DataType data_type);
+    GetBuildBaseParams(DataType data_type) const;
 
     SearchInfo
-    GetSearchConf(const SearchInfo& searchInfo);
+    GetSearchConf(const SearchInfo& searchInfo) const;
 
  private:
     const SegcoreConfig& config_;

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -18,14 +18,17 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <exception>
+#include <future>
 #include <iostream>
 #include <limits>
 #include <map>
 #include <memory>
 #include <string>
 #include <string_view>
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -99,6 +102,100 @@ GetFieldBit(const BitsetType& bitset, FieldId field_id) {
     auto pos = field_id.get() - START_USER_FIELDID;
     AssertInfo(pos >= 0, "invalid field id");
     return bitset[pos];
+}
+
+class CancellationObservingIndexTranslator
+    : public cachinglayer::Translator<index::IndexBase> {
+ public:
+    CancellationObservingIndexTranslator(
+        std::string key,
+        std::unique_ptr<index::IndexBase> index,
+        folly::CancellationToken* observed_token,
+        std::promise<void>* warmup_started)
+        : key_(std::move(key)),
+          index_(std::move(index)),
+          observed_token_(observed_token),
+          warmup_started_(warmup_started),
+          meta_(cachinglayer::StorageType::MEMORY,
+                cachinglayer::CellIdMappingMode::IDENTICAL,
+                cachinglayer::CellDataType::OTHER,
+                CacheWarmupPolicy::CacheWarmupPolicy_Async,
+                false) {
+    }
+
+    size_t
+    num_cells() const override {
+        return 1;
+    }
+
+    cachinglayer::cid_t
+    cell_id_of(cachinglayer::uid_t uid) const override {
+        return uid;
+    }
+
+    std::pair<cachinglayer::ResourceUsage, cachinglayer::ResourceUsage>
+    estimated_byte_size_of_cell(cachinglayer::cid_t) const override {
+        return {{0, 0}, {0, 0}};
+    }
+
+    int64_t
+    cells_storage_bytes(
+        const std::vector<cachinglayer::cid_t>&) const override {
+        return 0;
+    }
+
+    const std::string&
+    key() const override {
+        return key_;
+    }
+
+    cachinglayer::Meta*
+    meta() override {
+        return &meta_;
+    }
+
+    std::vector<
+        std::pair<cachinglayer::cid_t, std::unique_ptr<index::IndexBase>>>
+    get_cells(milvus::OpContext* ctx,
+              const std::vector<cachinglayer::cid_t>& cids) override {
+        AssertInfo(ctx != nullptr, "warmup context must not be null");
+        *observed_token_ = ctx->cancellation_token;
+        warmup_started_->set_value();
+        std::vector<
+            std::pair<cachinglayer::cid_t, std::unique_ptr<index::IndexBase>>>
+            result;
+        result.reserve(cids.size());
+        for (auto cid : cids) {
+            AssertInfo(cid == 0, "test index translator has one cell");
+            result.emplace_back(cid, std::move(index_));
+        }
+        return result;
+    }
+
+ private:
+    std::string key_;
+    std::unique_ptr<index::IndexBase> index_;
+    folly::CancellationToken* observed_token_;
+    std::promise<void>* warmup_started_;
+    cachinglayer::Meta meta_;
+};
+
+index::CacheIndexBasePtr
+CreateCancellationObservingCacheIndex(std::string key,
+                                      std::unique_ptr<index::IndexBase> index,
+                                      folly::CancellationToken* observed_token,
+                                      std::promise<void>* warmup_started,
+                                      cachinglayer::internal::DList* dlist) {
+    auto translator = std::make_unique<CancellationObservingIndexTranslator>(
+        std::move(key), std::move(index), observed_token, warmup_started);
+    return std::make_shared<cachinglayer::CacheSlot<index::IndexBase>>(
+        std::move(translator),
+        dlist,
+        false,
+        false,
+        true,
+        std::chrono::seconds(5),
+        std::chrono::seconds(5));
 }
 
 }  // namespace
@@ -4250,6 +4347,130 @@ TEST(SealedSegmentCowState, StagedVectorIndexSkipsInterimIndexGeneration) {
     EXPECT_FALSE(GetFieldBit(final_state->binlog_index_bitset, vec));
     EXPECT_TRUE(final_state->index_has_raw_data.at(vec));
     EXPECT_TRUE(sealed->TestVectorIndexReady(vec));
+}
+
+TEST(SealedSegmentCowState,
+     StagedVectorIndexRetiresPublishedWarmupOnlyAfterPublish) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto vec = schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 4, knowhere::metric::L2);
+    schema->set_primary_field_id(pk);
+
+    auto warmup_limit = cachinglayer::ResourceUsage{1024 * 1024, 0};
+    auto warmup_dlist = std::make_shared<cachinglayer::internal::DList>(
+        false,
+        warmup_limit,
+        warmup_limit,
+        warmup_limit,
+        cachinglayer::EvictionConfig{});
+    auto segment = CreateSealedSegment(schema);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    auto create_index = [] {
+        milvus::index::CreateIndexInfo create_index_info;
+        create_index_info.field_type = DataType::VECTOR_FLOAT;
+        create_index_info.metric_type = knowhere::metric::L2;
+        create_index_info.index_type = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT;
+        create_index_info.index_engine_version =
+            knowhere::Version::GetCurrentVersion().VersionNumber();
+        return milvus::index::IndexFactory::GetInstance().CreateIndex(
+            create_index_info, milvus::storage::FileManagerContext());
+    };
+
+    folly::CancellationToken published_warmup_token;
+    std::promise<void> warmup_started;
+    auto warmup_started_future = warmup_started.get_future();
+    auto published_index_impl = create_index();
+    auto published_index_params = GenIndexParams(published_index_impl.get());
+    auto published_cache_index =
+        CreateCancellationObservingCacheIndex("published-vector",
+                                              std::move(published_index_impl),
+                                              &published_warmup_token,
+                                              &warmup_started,
+                                              warmup_dlist.get());
+    auto warmup_pool = std::make_shared<folly::CPUThreadPoolExecutor>(1);
+    published_cache_index->Warmup(nullptr, warmup_pool);
+    ASSERT_EQ(warmup_started_future.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    ASSERT_FALSE(published_warmup_token.isCancellationRequested());
+
+    LoadIndexInfo published_index;
+    published_index.field_id = vec.get();
+    published_index.index_params = std::move(published_index_params);
+    published_index.index_params["metric_type"] = knowhere::metric::L2;
+    published_index.cache_index = published_cache_index;
+    published_index.load_resource_request =
+        LoadResourceRequest{0, 0, 0, 0, true};
+    sealed->LoadIndex(published_index);
+
+    auto stage_replacement = [&](bool fail_before_publish) {
+        auto current = sealed->TestGetPublishedStateSnapshot();
+        auto runtime = sealed->TestCloneMutableRuntimeResourceState();
+        auto staged = sealed->TestBuildNextPublishedState(
+            current,
+            {current->schema,
+             current->load_info,
+             sealed->TestFreezeRuntimeResourceState(runtime),
+             current->commit_ts});
+
+        auto replacement_impl = create_index();
+        LoadIndexInfo replacement;
+        replacement.field_id = vec.get();
+        replacement.index_params = GenIndexParams(replacement_impl.get());
+        replacement.index_params["metric_type"] = knowhere::metric::L2;
+        replacement.cache_index = CreateTestCacheIndex(
+            fail_before_publish ? "rolled-back-vector" : "replacement-vector",
+            std::move(replacement_impl));
+        replacement.load_resource_request =
+            LoadResourceRequest{0, 0, 0, 0, true};
+
+        ChunkedSegmentSealedImpl::StateDelta final_delta;
+        final_delta.schema = current->schema;
+        final_delta.load_info = current->load_info;
+        final_delta.commit_ts = current->commit_ts;
+
+        auto stage_and_publish = [&] {
+            sealed->TestStageLoadIndexThenPublish(
+                replacement,
+                true,
+                current->schema,
+                runtime,
+                staged.get(),
+                current,
+                final_delta,
+                [&] {
+                    auto published = sealed->TestGetPublishedStateSnapshot();
+                    ASSERT_EQ(
+                        published->runtime->vector_indexings.at(vec)->indexing_,
+                        published_cache_index);
+                    EXPECT_FALSE(
+                        published_warmup_token.isCancellationRequested());
+                    if (fail_before_publish) {
+                        throw std::runtime_error("abort staged publish");
+                    }
+                });
+        };
+
+        if (fail_before_publish) {
+            EXPECT_THROW(stage_and_publish(), std::runtime_error);
+        } else {
+            EXPECT_NO_THROW(stage_and_publish());
+        }
+    };
+
+    stage_replacement(true);
+    EXPECT_FALSE(published_warmup_token.isCancellationRequested());
+    auto after_rollback = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_EQ(after_rollback->runtime->vector_indexings.at(vec)->indexing_,
+              published_cache_index);
+
+    stage_replacement(false);
+    EXPECT_TRUE(published_warmup_token.isCancellationRequested());
+    auto after_publish = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(after_publish->runtime->vector_indexings.at(vec)->indexing_,
+              published_cache_index);
 }
 
 TEST(SealedSegmentCowState, ReplaceScalarIndexStagesRuntimeUntilFinalPublish) {


### PR DESCRIPTION
Related to #51068

Migrate sealed segment vector index runtime state from live members into RuntimeResourceState, including vector index entries and binlog vector index configs. Update vector search, vector retrieval, raw-data checks, refine, prefetch, load/drop/clear, and staged reopen paths to read and publish through runtime snapshots.

Also update SearchOnSealedIndex to consume a pinned vector index entry directly, and make vector index config accessors const-compatible for snapshot usage.