### PR TITLE
fix: Avoid structured binding capture in OpenMP build

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5371,7 +5371,7 @@ ChunkedSegmentSealedImpl::LoadBatchJsonKeyIndexes(
             continue;
         }
         committer.Commit(
-            [field_id, index = std::move(index)](
+            [field_id = field_id, index = std::move(index)](
                 RuntimeResourceState& runtime, PublishedSegmentState&) mutable {
                 runtime.json_stats[field_id] = std::move(index);
             });


### PR DESCRIPTION
## Summary

This PR avoids directly capturing a structured binding in `ChunkedSegmentSealedImpl::LoadBatchJsonKeyIndexes`.

Clang rejects direct structured-binding captures when compiling this code path with OpenMP enabled. The lambda now uses a generalized init-capture for `field_id`, preserving the existing value-capture behavior while avoiding the unsupported capture form.

issue: #51231

## Test Plan

- [x] `git diff --check`
- [x] `/tmp/milvus-clang-format-15-bin/clang-format-15 --dry-run --Werror --style=file internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp`
- [x] `make SKIP_3RDPARTY=1`
- [x] `PATH="/tmp/milvus-clang-format-15-bin:$PATH" make verifiers`