### PR TITLE
fix: preserve JSON flat contains three-valued validity

### DIFF
--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -763,10 +763,13 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
     auto pointer = milvus::index::JsonPointer(expr_->column_.nested_path_);
     bool lower_inclusive = expr_->lower_inclusive_;
     bool upper_inclusive = expr_->upper_inclusive_;
-    // Use GetValueWithCastNumber to handle mixed int64/float types safely.
-    // This allows int64 values to be cast to double when ValueType is double.
-    ValueType val1 = GetValueWithCastNumber<ValueType>(expr_->lower_val_);
-    ValueType val2 = GetValueWithCastNumber<ValueType>(expr_->upper_val_);
+    std::optional<ValueType> val1;
+    std::optional<ValueType> val2;
+    if constexpr (!std::is_same_v<GetType, int64_t> &&
+                  !std::is_same_v<GetType, double>) {
+        val1.emplace(GetValueWithCastNumber<ValueType>(expr_->lower_val_));
+        val2.emplace(GetValueWithCastNumber<ValueType>(expr_->upper_val_));
+    }
 
     if (cached_index_chunk_id_ != 0 && TryCacheGet()) {
         // Cache hit — skip Stats computation.
@@ -785,6 +788,8 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
 
         // process shredding data
+        const auto& lower_bound = expr_->lower_val_;
+        const auto& upper_bound = expr_->upper_val_;
         auto try_execute = [&](milvus::index::JSONType json_type,
                                auto GetType) {
             auto target_field = index->GetShreddingField(pointer, json_type);
@@ -794,29 +799,51 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
                 TargetBitmapView target_res_view(target_res);
                 TargetBitmap target_valid(active_count_, true);
                 TargetBitmapView target_valid_view(target_valid);
-                auto shredding_executor =
-                    [val1, val2, lower_inclusive, upper_inclusive](
-                        const ColType* src,
-                        const bool* valid,
-                        size_t size,
-                        TargetBitmapView res,
-                        TargetBitmapView valid_res) {
-                        for (size_t i = 0; i < size; ++i) {
-                            if (valid != nullptr && !valid[i]) {
-                                res[i] = valid_res[i] = false;
+                auto shredding_executor = [val1,
+                                           val2,
+                                           lower_inclusive,
+                                           upper_inclusive,
+                                           &lower_bound,
+                                           &upper_bound](
+                                              const ColType* src,
+                                              const bool* valid,
+                                              size_t size,
+                                              TargetBitmapView res,
+                                              TargetBitmapView valid_res) {
+                    for (size_t i = 0; i < size; ++i) {
+                        if (valid != nullptr && !valid[i]) {
+                            res[i] = valid_res[i] = false;
+                            continue;
+                        }
+                        if constexpr (std::is_same_v<ColType, int64_t> ||
+                                      std::is_same_v<ColType, double>) {
+                            auto lower_comparison =
+                                CompareJsonNumberToBound(src[i], lower_bound);
+                            auto upper_comparison =
+                                CompareJsonNumberToBound(src[i], upper_bound);
+                            if (!lower_comparison.has_value() ||
+                                !upper_comparison.has_value()) {
+                                res[i] = false;
                                 continue;
                             }
-                            if (lower_inclusive && upper_inclusive) {
-                                res[i] = src[i] >= val1 && src[i] <= val2;
-                            } else if (lower_inclusive && !upper_inclusive) {
-                                res[i] = src[i] >= val1 && src[i] < val2;
-                            } else if (!lower_inclusive && upper_inclusive) {
-                                res[i] = src[i] > val1 && src[i] <= val2;
-                            } else {
-                                res[i] = src[i] > val1 && src[i] < val2;
-                            }
+                            const auto lower_matches =
+                                lower_inclusive ? *lower_comparison >= 0
+                                                : *lower_comparison > 0;
+                            const auto upper_matches =
+                                upper_inclusive ? *upper_comparison <= 0
+                                                : *upper_comparison < 0;
+                            res[i] = lower_matches && upper_matches;
+                        } else if (lower_inclusive && upper_inclusive) {
+                            res[i] = src[i] >= *val1 && src[i] <= *val2;
+                        } else if (lower_inclusive && !upper_inclusive) {
+                            res[i] = src[i] >= *val1 && src[i] < *val2;
+                        } else if (!lower_inclusive && upper_inclusive) {
+                            res[i] = src[i] > *val1 && src[i] <= *val2;
+                        } else {
+                            res[i] = src[i] > *val1 && src[i] < *val2;
                         }
-                    };
+                    }
+                };
                 index->ExecutorForShreddingData<ColType>(op_ctx_,
                                                          target_field,
                                                          shredding_executor,
@@ -859,6 +886,8 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
                                 val2,
                                 lower_inclusive,
                                 upper_inclusive,
+                                &lower_bound,
+                                &upper_bound,
                                 &res_view,
                                 &valid_res_view](milvus::BsonView bson,
                                                  uint32_t row_id,
@@ -869,32 +898,34 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
             };
             if constexpr (std::is_same_v<GetType, int64_t> ||
                           std::is_same_v<GetType, double>) {
-                auto val = bson.ParseAsValueAtOffset<double>(value_offset);
-                if (!val.has_value()) {
+                auto lower_comparison =
+                    CompareBsonNumberToBound(bson, value_offset, lower_bound);
+                auto upper_comparison =
+                    CompareBsonNumberToBound(bson, value_offset, upper_bound);
+                if (!lower_comparison.has_value() ||
+                    !upper_comparison.has_value()) {
                     return;
                 }
-                if (lower_inclusive && upper_inclusive) {
-                    set_known(val.value() >= val1 && val.value() <= val2);
-                } else if (lower_inclusive && !upper_inclusive) {
-                    set_known(val.value() >= val1 && val.value() < val2);
-                } else if (!lower_inclusive && upper_inclusive) {
-                    set_known(val.value() > val1 && val.value() <= val2);
-                } else {
-                    set_known(val.value() > val1 && val.value() < val2);
-                }
+                const auto lower_matches = lower_inclusive
+                                               ? *lower_comparison >= 0
+                                               : *lower_comparison > 0;
+                const auto upper_matches = upper_inclusive
+                                               ? *upper_comparison <= 0
+                                               : *upper_comparison < 0;
+                set_known(lower_matches && upper_matches);
             } else {
                 auto val = bson.ParseAsValueAtOffset<GetType>(value_offset);
                 if (!val.has_value()) {
                     return;
                 }
                 if (lower_inclusive && upper_inclusive) {
-                    set_known(val.value() >= val1 && val.value() <= val2);
+                    set_known(val.value() >= *val1 && val.value() <= *val2);
                 } else if (lower_inclusive && !upper_inclusive) {
-                    set_known(val.value() >= val1 && val.value() < val2);
+                    set_known(val.value() >= *val1 && val.value() < *val2);
                 } else if (!lower_inclusive && upper_inclusive) {
-                    set_known(val.value() > val1 && val.value() <= val2);
+                    set_known(val.value() > *val1 && val.value() <= *val2);
                 } else {
-                    set_known(val.value() > val1 && val.value() < val2);
+                    set_known(val.value() > *val1 && val.value() < *val2);
                 }
             }
         };

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -29,6 +29,7 @@
 #include "common/bson_view.h"
 #include "common/type_c.h"
 #include "common/ScopedTimer.h"
+#include "exec/expression/JsonNumberComparison.h"
 #include "exec/expression/Utils.h"
 #include "fmt/core.h"
 #include "folly/FBVector.h"
@@ -124,12 +125,17 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
             if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
                 if (is_numeric) {
                     const auto has_unsafe_int_bound =
-                        !use_double && (!IsInt64SafeForJsonDoubleIndex(
-                                            expr_->lower_val_.int64_val()) ||
-                                        !IsInt64SafeForJsonDoubleIndex(
-                                            expr_->upper_val_.int64_val()));
+                        (lower_type ==
+                             proto::plan::GenericValue::ValCase::kInt64Val &&
+                         !IsInt64SafeForJsonDoubleIndex(
+                             expr_->lower_val_.int64_val())) ||
+                        (upper_type ==
+                             proto::plan::GenericValue::ValCase::kInt64Val &&
+                         !IsInt64SafeForJsonDoubleIndex(
+                             expr_->upper_val_.int64_val()));
                     if (has_unsafe_int_bound) {
-                        result = ExecRangeVisitorImplForJson<int64_t>(context);
+                        result =
+                            ExecRangeVisitorImplForJsonPreciseNumeric(context);
                     } else if (!use_double && PinnedJsonIndexIsFlat()) {
                         result = ExecRangeVisitorImplForIndex<int64_t>();
                     } else {
@@ -218,6 +224,102 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                       "unsupported data type: {}",
                       expr_->column_.data_type_);
     }
+}
+
+VectorPtr
+PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonPreciseNumeric(
+    EvalCtx& context) {
+    const auto& bitmap_input = context.get_bitmap_input();
+    auto* input = context.get_offset_input();
+    auto real_batch_size =
+        has_offset_input_ ? input->size() : GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
+
+    auto res_vec =
+        std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),
+                                       TargetBitmap(real_batch_size, true));
+    TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
+    TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
+    auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
+    auto lower_bound = expr_->lower_val_;
+    auto upper_bound = expr_->upper_val_;
+    const auto lower_inclusive = expr_->lower_inclusive_;
+    const auto upper_inclusive = expr_->upper_inclusive_;
+
+    size_t processed_cursor = 0;
+    auto execute_sub_batch =
+        [
+            pointer,
+            lower_bound,
+            upper_bound,
+            lower_inclusive,
+            upper_inclusive,
+            &bitmap_input,
+            &processed_cursor
+        ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::Json* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res) {
+        if (data == nullptr) {
+            processed_cursor += size;
+            return;
+        }
+        const bool has_bitmap_input = !bitmap_input.empty();
+        for (int i = 0; i < size; ++i) {
+            auto offset = i;
+            if constexpr (filter_type == FilterType::random) {
+                offset = offsets ? offsets[i] : i;
+            }
+            if (valid_data != nullptr && !valid_data[offset]) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
+                continue;
+            }
+
+            auto number = data[offset].at_numeric(pointer);
+            if (number.error()) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            auto lower_comparison =
+                CompareJsonNumberToBound(number.value(), lower_bound);
+            auto upper_comparison =
+                CompareJsonNumberToBound(number.value(), upper_bound);
+            if (!lower_comparison.has_value() ||
+                !upper_comparison.has_value()) {
+                res[i] = false;
+                continue;
+            }
+            const auto lower_matches = lower_inclusive ? *lower_comparison >= 0
+                                                       : *lower_comparison > 0;
+            const auto upper_matches = upper_inclusive ? *upper_comparison <= 0
+                                                       : *upper_comparison < 0;
+            res[i] = lower_matches && upper_matches;
+        }
+        processed_cursor += size;
+    };
+
+    int64_t processed_size;
+    if (has_offset_input_) {
+        processed_size = ProcessDataByOffsets<milvus::Json>(
+            execute_sub_batch, std::nullptr_t{}, input, res, valid_res);
+    } else {
+        processed_size = ProcessDataChunks<milvus::Json>(
+            execute_sub_batch, std::nullptr_t{}, res, valid_res);
+    }
+    AssertInfo(processed_size == real_batch_size,
+               "internal error: expr processed rows {} not equal "
+               "expect batch size {}",
+               processed_size,
+               real_batch_size);
+    return res_vec;
 }
 
 template <typename T>

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -123,31 +123,41 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
 
             if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
                 if (is_numeric) {
-                    // Convert both bounds to double for index path
-                    proto::plan::GenericValue double_lower_val;
-                    if (lower_type ==
-                        proto::plan::GenericValue::ValCase::kInt64Val) {
-                        double_lower_val.set_float_val(
-                            static_cast<double>(expr_->lower_val_.int64_val()));
+                    const auto has_unsafe_int_bound =
+                        !use_double && (!IsInt64SafeForJsonDoubleIndex(
+                                            expr_->lower_val_.int64_val()) ||
+                                        !IsInt64SafeForJsonDoubleIndex(
+                                            expr_->upper_val_.int64_val()));
+                    if (has_unsafe_int_bound) {
+                        result = ExecRangeVisitorImplForJson<int64_t>(context);
+                    } else if (!use_double && PinnedJsonIndexIsFlat()) {
+                        result = ExecRangeVisitorImplForIndex<int64_t>();
                     } else {
-                        double_lower_val.set_float_val(
-                            expr_->lower_val_.float_val());
-                    }
-                    proto::plan::GenericValue double_upper_val;
-                    if (upper_type ==
-                        proto::plan::GenericValue::ValCase::kInt64Val) {
-                        double_upper_val.set_float_val(
-                            static_cast<double>(expr_->upper_val_.int64_val()));
-                    } else {
-                        double_upper_val.set_float_val(
-                            expr_->upper_val_.float_val());
-                    }
+                        proto::plan::GenericValue double_lower_val;
+                        if (lower_type ==
+                            proto::plan::GenericValue::ValCase::kInt64Val) {
+                            double_lower_val.set_float_val(static_cast<double>(
+                                expr_->lower_val_.int64_val()));
+                        } else {
+                            double_lower_val.set_float_val(
+                                expr_->lower_val_.float_val());
+                        }
+                        proto::plan::GenericValue double_upper_val;
+                        if (upper_type ==
+                            proto::plan::GenericValue::ValCase::kInt64Val) {
+                            double_upper_val.set_float_val(static_cast<double>(
+                                expr_->upper_val_.int64_val()));
+                        } else {
+                            double_upper_val.set_float_val(
+                                expr_->upper_val_.float_val());
+                        }
 
-                    lower_arg_.SetValue<double>(double_lower_val);
-                    upper_arg_.SetValue<double>(double_upper_val);
-                    arg_inited_ = true;
+                        lower_arg_.SetValue<double>(double_lower_val);
+                        upper_arg_.SetValue<double>(double_upper_val);
+                        arg_inited_ = true;
 
-                    result = ExecRangeVisitorImplForIndex<double>();
+                        result = ExecRangeVisitorImplForIndex<double>();
+                    }
                 } else if (lower_type ==
                            proto::plan::GenericValue::ValCase::kStringVal) {
                     result = ExecRangeVisitorImplForJson<std::string>(context);

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -346,6 +346,9 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
     VectorPtr
     ExecRangeVisitorImplForJson(EvalCtx& context);
 
+    VectorPtr
+    ExecRangeVisitorImplForJsonPreciseNumeric(EvalCtx& context);
+
     template <typename ValueType>
     VectorPtr
     ExecRangeVisitorImplForJsonStats();

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -2247,6 +2247,20 @@ class SegmentExpr : public Expr {
         return true;
     }
 
+    bool
+    PinnedJsonIndexIsFlat() const {
+        return field_type_ == DataType::JSON && !pinned_index_.empty() &&
+               dynamic_cast<const index::JsonFlatIndex*>(
+                   pinned_index_[0].get()) != nullptr;
+    }
+
+    static bool
+    IsInt64SafeForJsonDoubleIndex(int64_t value) {
+        constexpr int64_t kFirstNonInjectiveInteger = int64_t{1} << 53;
+        return value > -kFirstNonInjectiveInteger &&
+               value < kFirstNonInjectiveInteger;
+    }
+
  public:
     bool
     CanUseNestedIndex() const override {

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1745,11 +1745,17 @@ class SegmentExpr : public Expr {
         return processed_size;
     }
 
+    enum class IndexValidityMode {
+        Default,
+        JsonExactPath,
+    };
+
     // ProcessIndexChunks: execute index query and batch results
     template <typename T, typename FUNC, typename... ValTypes>
     VectorPtr
     ProcessIndexChunks(FUNC func, const ValTypes&... values) {
-        return ProcessIndexChunksImpl<T>(func, false, values...);
+        return ProcessIndexChunksImpl<T>(
+            func, false, IndexValidityMode::Default, values...);
     }
 
     // ProcessIndexChunks with func_returns_row_level flag
@@ -1757,14 +1763,17 @@ class SegmentExpr : public Expr {
     //   (used when func already handles element-to-row conversion internally)
     template <typename T, typename FUNC, typename... ValTypes>
     VectorPtr
-    ProcessIndexChunksWithRowLevel(FUNC func, const ValTypes&... values) {
-        return ProcessIndexChunksImpl<T>(func, true, values...);
+    ProcessIndexChunksWithRowLevel(FUNC func,
+                                   IndexValidityMode validity_mode,
+                                   const ValTypes&... values) {
+        return ProcessIndexChunksImpl<T>(func, true, validity_mode, values...);
     }
 
     template <typename T, typename FUNC, typename... ValTypes>
     VectorPtr
     ProcessIndexChunksImpl(FUNC func,
                            bool func_returns_row_level,
+                           IndexValidityMode validity_mode,
                            const ValTypes&... values) {
         typedef std::
             conditional_t<std::is_same_v<T, std::string_view>, std::string, T>
@@ -1822,7 +1831,11 @@ class SegmentExpr : public Expr {
                     TargetBitmap res = func(index_ptr, values...);
 
                     TargetBitmap valid_res;
-                    if (cached_is_nested_index_ && func_returns_row_level) {
+                    if (validity_mode == IndexValidityMode::JsonExactPath &&
+                        executor != nullptr) {
+                        valid_res = executor->ExactPathExists();
+                    } else if (cached_is_nested_index_ &&
+                               func_returns_row_level) {
                         valid_res = TargetBitmap(active_count_, true);
                     } else {
                         valid_res = index_ptr->IsNotNull();

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -214,6 +214,317 @@ TYPED_TEST(JsonIndexTestFixture, TestJsonIndexUnaryExpr) {
     EXPECT_EQ(final.count(), N - expect_count);
 }
 
+TEST(JsonIndexTest, EmptyJsonInIsDeterministicForEveryRow) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto i64_fid = schema->AddDebugField("age64", DataType::INT64);
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+    schema->set_primary_field_id(i64_fid);
+
+    auto seg = CreateSealedSegment(schema);
+    auto file_manager_ctx = storage::FileManagerContext();
+    file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+        milvus::proto::schema::JSON);
+    file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+    file_manager_ctx.fieldDataMeta.field_schema.set_nullable(true);
+    file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
+
+    auto inv_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        index::CreateIndexInfo{
+            .index_type = index::INVERTED_INDEX_TYPE,
+            .json_cast_type = JsonCastType::FromString("BOOL"),
+            .json_path = "/a",
+        },
+        file_manager_ctx);
+    auto json_index = std::unique_ptr<index::JsonInvertedIndex<bool>>(
+        static_cast<index::JsonInvertedIndex<bool>*>(inv_index.release()));
+
+    const std::vector<std::string> json_strs = {R"({"a": true})",
+                                                R"({"a": "abc"})",
+                                                R"({"b": false})",
+                                                R"({"a": null})",
+                                                R"({})",
+                                                R"({"a": false})"};
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    std::vector<milvus::Json> jsons;
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    auto* valid_data = json_field->ValidData();
+    std::fill(valid_data,
+              valid_data + json_field->ValidDataSize(),
+              static_cast<uint8_t>(0));
+    valid_data[0] = 0b00011111;
+
+    json_index->BuildWithFieldData({json_field});
+    json_index->finish();
+    json_index->create_reader(milvus::index::SetBitsetSealed);
+
+    segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_id = json_fid.get();
+    load_index_info.field_type = DataType::JSON;
+    load_index_info.index_params = {{JSON_PATH, "/a"},
+                                    {JSON_CAST_TYPE, "BOOL"}};
+    load_index_info.cache_index =
+        CreateTestCacheIndex("empty_json_in", std::move(json_index));
+    seg->LoadIndex(load_index_info);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    seg->LoadFieldData(load_info);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{},
+        false);
+    auto check = [&](const expr::TypedExprPtr& filter_expr,
+                     bool expected_result) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        auto result = milvus::test::gen_filter_res(
+            plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_TRUE(valid_view[i]) << "row " << i;
+            EXPECT_EQ(result_view[i], expected_result) << "row " << i;
+        }
+    };
+
+    check(term_expr, false);
+    check(std::make_shared<expr::LogicalUnaryExpr>(
+              expr::LogicalUnaryExpr::OpType::LogicalNot, term_expr),
+          true);
+}
+
+TEST(JsonIndexTest, LargeInt64LiteralDoesNotAliasInDoublePathIndex) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto i64_fid = schema->AddDebugField("age64", DataType::INT64);
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    schema->set_primary_field_id(i64_fid);
+
+    auto seg = CreateSealedSegment(schema);
+    auto file_manager_ctx = storage::FileManagerContext();
+    file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+        milvus::proto::schema::JSON);
+    file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+    file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
+
+    auto inv_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        index::CreateIndexInfo{
+            .index_type = index::INVERTED_INDEX_TYPE,
+            .json_cast_type = JsonCastType::FromString("DOUBLE"),
+            .json_path = "/a",
+        },
+        file_manager_ctx);
+    auto json_index = std::unique_ptr<index::JsonInvertedIndex<double>>(
+        static_cast<index::JsonInvertedIndex<double>*>(inv_index.release()));
+
+    const std::vector<std::string> json_strs = {R"({"a": 9007199254740992})",
+                                                R"({"a": 9007199254740993})",
+                                                R"({"a": 9007199254740994})"};
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+    std::vector<milvus::Json> jsons;
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    json_index->BuildWithFieldData({json_field});
+    json_index->finish();
+    json_index->create_reader(milvus::index::SetBitsetSealed);
+
+    segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_id = json_fid.get();
+    load_index_info.field_type = DataType::JSON;
+    load_index_info.index_params = {{JSON_PATH, "/a"},
+                                    {JSON_CAST_TYPE, "DOUBLE"}};
+    load_index_info.cache_index =
+        CreateTestCacheIndex("large_int64", std::move(json_index));
+    seg->LoadIndex(load_index_info);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    seg->LoadFieldData(load_info);
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+    auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, equal_expr);
+    auto result = milvus::test::gen_filter_res(
+        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    TargetBitmapView result_view(result->GetRawData(), result->size());
+    TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+    for (size_t i = 0; i < result->size(); ++i) {
+        EXPECT_TRUE(valid_view[i]);
+    }
+    EXPECT_FALSE(result_view[0]);
+    EXPECT_TRUE(result_view[1]);
+    EXPECT_FALSE(result_view[2]);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{value},
+        false);
+    plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, term_expr);
+    result = milvus::test::gen_filter_res(
+        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_FALSE(result_view[0]);
+    EXPECT_TRUE(result_view[1]);
+    EXPECT_FALSE(result_view[2]);
+
+    auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  greater_expr);
+    result = milvus::test::gen_filter_res(
+        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_FALSE(result_view[0]);
+    EXPECT_FALSE(result_view[1]);
+    EXPECT_TRUE(result_view[2]);
+
+    auto between_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        value,
+        value,
+        true,
+        true);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  between_expr);
+    result = milvus::test::gen_filter_res(
+        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_FALSE(result_view[0]);
+    EXPECT_TRUE(result_view[1]);
+    EXPECT_FALSE(result_view[2]);
+}
+
+TEST(JsonRawScanTest, EmptyInAndLargeInt64KeepThreeValuedSemantics) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+    auto seg = CreateSealedSegment(schema);
+
+    const std::vector<std::string> json_strs = {R"({"a": 9007199254740992})",
+                                                R"({"a": 9007199254740993})",
+                                                R"({"a": 9007199254740994})",
+                                                R"({"a": "abc"})",
+                                                R"({})",
+                                                R"({"a": null})",
+                                                R"({"a": 9007199254740993})"};
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    std::vector<milvus::Json> jsons;
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    auto* valid_data = json_field->ValidData();
+    std::fill(valid_data,
+              valid_data + json_field->ValidDataSize(),
+              static_cast<uint8_t>(0));
+    valid_data[0] = 0b00111111;
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    seg->LoadFieldData(load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    };
+    auto check = [](const ColumnVectorPtr& result,
+                    const std::vector<bool>& expected_result,
+                    const std::vector<bool>& expected_valid) {
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_EQ(valid_view[i], expected_valid[i]) << "row " << i;
+            if (expected_valid[i]) {
+                EXPECT_EQ(result_view[i], expected_result[i]) << "row " << i;
+            }
+        }
+    };
+
+    auto empty_term = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{},
+        false);
+    check(evaluate(empty_term),
+          std::vector<bool>(json_strs.size(), false),
+          std::vector<bool>(json_strs.size(), true));
+    check(evaluate(std::make_shared<expr::LogicalUnaryExpr>(
+              expr::LogicalUnaryExpr::OpType::LogicalNot, empty_term)),
+          std::vector<bool>(json_strs.size(), true),
+          std::vector<bool>(json_strs.size(), true));
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+    const std::vector<bool> numeric_valid = {
+        true, true, true, false, false, false, false};
+    auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    check(evaluate(equal_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{value},
+        false);
+    check(evaluate(term_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+
+    auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    check(evaluate(greater_expr),
+          {false, false, true, false, false, false, false},
+          numeric_valid);
+
+    auto between_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        value,
+        value,
+        true,
+        true);
+    check(evaluate(between_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+}
+
 TEST(JsonIndexTest, TestJsonNotEqualExpr) {
     auto schema = std::make_shared<Schema>();
     schema->AddDebugField(

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -467,3 +467,86 @@ TEST(JsonStatsThreeValuedAuditTest,
           {false, true, false, false, false, false, false},
           numeric_valid);
 }
+
+TEST(JsonStatsThreeValuedAuditTest,
+     UnsafeInt64DoesNotAliasDoubleShreddingOrSharedData) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    auto segment = segcore::CreateSealedSegment(schema);
+
+    const std::vector<std::string> json_raw_data = {
+        R"({"typed": 9007199254740992.0, "shared": 9007199254740992.0, "typed_array": [9007199254740992.0], "shared_array": [9007199254740992.0]})",
+        R"({"typed": 9007199254740994.0, "shared": 1.5, "typed_array": [9007199254740994.0], "shared_array": [1.5]})",
+        R"({"typed": 1.0, "typed_array": [1.0]})",
+        R"({"typed": 2.0, "typed_array": [2.0]})"};
+
+    auto stats = BuildAndLoadJsonKeyStats(json_raw_data,
+                                          json_fid,
+                                          TestLocalPath,
+                                          1202,
+                                          2202,
+                                          3202,
+                                          json_fid.get(),
+                                          5202,
+                                          1);
+    auto* sealed =
+        dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    sealed->SetJsonStatsForTesting(json_fid, stats);
+
+    std::vector<milvus::Json> jsons;
+    jsons.reserve(json_raw_data.size());
+    for (const auto& json : json_raw_data) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+    json_field->add_json_data(jsons);
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, json_fid.get(), {json_field}, cm);
+    segment->LoadFieldData(load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), segment.get(), json_raw_data.size(), MAX_TIMESTAMP);
+    };
+    auto check_non_matches_are_known = [](const ColumnVectorPtr& result) {
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i : {0, 1}) {
+            EXPECT_TRUE(valid_view[i]) << "row " << i;
+            EXPECT_FALSE(result_view[i]) << "row " << i;
+        }
+    };
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+    for (const auto* path : {"typed", "shared"}) {
+        auto column = expr::ColumnInfo(json_fid, DataType::JSON, {path});
+        check_non_matches_are_known(
+            evaluate(std::make_shared<expr::UnaryRangeFilterExpr>(
+                column,
+                proto::plan::OpType::Equal,
+                value,
+                std::vector<proto::plan::GenericValue>())));
+        check_non_matches_are_known(
+            evaluate(std::make_shared<expr::TermFilterExpr>(
+                column, std::vector<proto::plan::GenericValue>{value}, false)));
+        check_non_matches_are_known(
+            evaluate(std::make_shared<expr::BinaryRangeFilterExpr>(
+                column, value, value, true, true)));
+    }
+
+    for (const auto* path : {"typed_array", "shared_array"}) {
+        check_non_matches_are_known(
+            evaluate(std::make_shared<expr::JsonContainsExpr>(
+                expr::ColumnInfo(json_fid, DataType::JSON, {path}),
+                proto::plan::JSONContainsExpr_JSONOp_Contains,
+                true,
+                std::vector<proto::plan::GenericValue>{value})));
+    }
+}

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -29,6 +29,8 @@
 #include "common/Tracer.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "exec/expression/BinaryRangeExpr.h"
+#include "exec/expression/TermExpr.h"
 #include "exec/expression/UnaryExpr.h"
 #include "expr/ITypeExpr.h"
 #include "filemanager/InputStream.h"
@@ -52,6 +54,7 @@
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "test_utils/Constants.h"
+#include "test_utils/GenExprProto.h"
 #include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
@@ -351,4 +354,116 @@ TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathUnknownsAndMasksFieldNull) {
     EXPECT_TRUE(result[6]);
     EXPECT_FALSE(result[7]);
     EXPECT_EQ(result.count(), 2);
+}
+
+TEST(JsonStatsThreeValuedAuditTest,
+     EmptyInAndLargeInt64KeepThreeValuedSemantics) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+    auto segment = segcore::CreateSealedSegment(schema);
+
+    const std::vector<std::string> json_raw_data = {
+        R"({"a": 9007199254740992})",
+        R"({"a": 9007199254740993})",
+        R"({"a": 9007199254740994})",
+        R"({"a": "abc"})",
+        R"({})",
+        R"({"a": null})",
+        R"({"a": 9007199254740993})"};
+    const std::vector<uint8_t> valid_data{0b00111111};
+
+    auto stats = BuildAndLoadJsonKeyStats(json_raw_data,
+                                          json_fid,
+                                          TestLocalPath,
+                                          1201,
+                                          2201,
+                                          3201,
+                                          json_fid.get(),
+                                          5201,
+                                          1,
+                                          &valid_data);
+    auto* sealed =
+        dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    sealed->SetJsonStatsForTesting(json_fid, stats);
+
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    json_field->FillFieldData(MakeNullableJsonArray(json_raw_data, valid_data));
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, json_fid.get(), {json_field}, cm);
+    segment->LoadFieldData(load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), segment.get(), json_raw_data.size(), MAX_TIMESTAMP);
+    };
+    auto check = [](const ColumnVectorPtr& result,
+                    const std::vector<bool>& expected_result,
+                    const std::vector<bool>& expected_valid) {
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_EQ(valid_view[i], expected_valid[i]) << "row " << i;
+            if (expected_valid[i]) {
+                EXPECT_EQ(result_view[i], expected_result[i]) << "row " << i;
+            }
+        }
+    };
+
+    auto empty_term = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{},
+        false);
+    check(evaluate(empty_term),
+          std::vector<bool>(json_raw_data.size(), false),
+          std::vector<bool>(json_raw_data.size(), true));
+    check(evaluate(std::make_shared<expr::LogicalUnaryExpr>(
+              expr::LogicalUnaryExpr::OpType::LogicalNot, empty_term)),
+          std::vector<bool>(json_raw_data.size(), true),
+          std::vector<bool>(json_raw_data.size(), true));
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+    const std::vector<bool> numeric_valid = {
+        true, true, true, false, false, false, false};
+    auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    check(evaluate(equal_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{value},
+        false);
+    check(evaluate(term_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+
+    auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    check(evaluate(greater_expr),
+          {false, false, true, false, false, false, false},
+          numeric_valid);
+
+    auto between_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        value,
+        value,
+        true,
+        true);
+    check(evaluate(between_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
 }

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -168,9 +168,27 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
         }
         case DataType::JSON: {
             if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
-                result = EvalArrayContainsForIndexSegment(
-                    value_type_ == DataType::INT64 ? DataType::DOUBLE
-                                                   : value_type_);
+                const auto has_unsafe_int_literal =
+                    std::any_of(expr_->vals_.begin(),
+                                expr_->vals_.end(),
+                                [this](const auto& value) {
+                                    return value.has_int64_val() &&
+                                           !IsInt64SafeForJsonDoubleIndex(
+                                               value.int64_val());
+                                });
+                const auto all_int_literals = std::all_of(
+                    expr_->vals_.begin(),
+                    expr_->vals_.end(),
+                    [](const auto& value) { return value.has_int64_val(); });
+                if (all_int_literals && PinnedJsonIndexIsFlat()) {
+                    result = EvalArrayContainsForIndexSegment(DataType::INT64);
+                } else if (has_unsafe_int_literal) {
+                    result = EvalJsonContainsForDataSegment(context);
+                } else {
+                    result = EvalArrayContainsForIndexSegment(
+                        value_type_ == DataType::INT64 ? DataType::DOUBLE
+                                                       : value_type_);
+                }
             } else {
                 result = EvalJsonContainsForDataSegment(context);
             }

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -593,19 +593,6 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByStats() {
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
     if (!arg_inited_) {
         arg_set_ = std::make_shared<SetElement<GetType>>(expr_->vals_);
-        if constexpr (std::is_same_v<GetType, int64_t>) {
-            // for int64_t, we need to a double vector to store the values
-            auto int_arg_set =
-                std::dynamic_pointer_cast<SetElement<int64_t>>(arg_set_);
-            std::vector<double> double_vals;
-            double_vals.reserve(int_arg_set->GetElements().size());
-            for (const auto& val : int_arg_set->GetElements()) {
-                double_vals.emplace_back(static_cast<double>(val));
-            }
-            arg_set_double_ = std::make_shared<SetElement<double>>(double_vals);
-        } else if constexpr (std::is_same_v<GetType, double>) {
-            arg_set_double_ = arg_set_;
-        }
         arg_inited_ = true;
     }
 
@@ -644,7 +631,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByStats() {
                 TargetBitmap target_valid(active_count_, true);
                 TargetBitmapView target_valid_view(target_valid);
                 ShreddingArrayBsonContainsAnyExecutor<GetType> executor(
-                    arg_set_, arg_set_double_);
+                    arg_set_);
 
                 index->ExecutorForShreddingData<std::string_view>(
                     op_ctx_,
@@ -673,10 +660,9 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByStats() {
             for (const auto& element : val.value()) {
                 if constexpr (std::is_same_v<GetType, int64_t> ||
                               std::is_same_v<GetType, double>) {
-                    auto value = milvus::BsonView::GetValueFromBsonView<double>(
-                        element.get_value());
-                    if (value.has_value() &&
-                        this->arg_set_double_->In(value.value())) {
+                    auto value =
+                        GetBsonNumberExact<GetType>(element.get_value());
+                    if (value.has_value() && this->arg_set_->In(*value)) {
                         res_view[row_offset] = true;
                         return;
                     }
@@ -1339,26 +1325,17 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByStats() {
             if (shared_matcher.use_small()) {
                 uint64_t found = 0;
                 for (const auto& element : val.value()) {
-                    auto value =
-                        milvus::BsonView::GetValueFromBsonView<GetType>(
-                            element.get_value());
-                    if (!value.has_value()) {
-                        if constexpr (std::is_same_v<GetType, int64_t>) {
-                            auto double_value =
-                                milvus::BsonView::GetValueFromBsonView<double>(
-                                    element.get_value());
-                            if (double_value.has_value() &&
-                                double_value.value() ==
-                                    std::floor(double_value.value())) {
-                                if (shared_matcher.set_if_found(
-                                        static_cast<int64_t>(
-                                            double_value.value()),
-                                        found)) {
-                                    res_view[row_offset] = true;
-                                    return;
-                                }
-                            }
+                    auto value = [&]() -> std::optional<GetType> {
+                        if constexpr (std::is_same_v<GetType, int64_t> ||
+                                      std::is_same_v<GetType, double>) {
+                            return GetBsonNumberExact<GetType>(
+                                element.get_value());
+                        } else {
+                            return milvus::BsonView::GetValueFromBsonView<
+                                GetType>(element.get_value());
                         }
+                    }();
+                    if (!value.has_value()) {
                         continue;
                     }
                     if (shared_matcher.set_if_found(value.value(), found)) {
@@ -1372,27 +1349,17 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByStats() {
                     shared_found_large.begin(), shared_found_large.end(), 0);
                 size_t remaining = shared_matcher.target_count();
                 for (const auto& element : val.value()) {
-                    auto value =
-                        milvus::BsonView::GetValueFromBsonView<GetType>(
-                            element.get_value());
-                    if (!value.has_value()) {
-                        if constexpr (std::is_same_v<GetType, int64_t>) {
-                            auto double_value =
-                                milvus::BsonView::GetValueFromBsonView<double>(
-                                    element.get_value());
-                            if (double_value.has_value() &&
-                                double_value.value() ==
-                                    std::floor(double_value.value())) {
-                                if (shared_matcher.set_if_found(
-                                        static_cast<int64_t>(
-                                            double_value.value()),
-                                        shared_found_large,
-                                        remaining)) {
-                                    res_view[row_offset] = true;
-                                    return;
-                                }
-                            }
+                    auto value = [&]() -> std::optional<GetType> {
+                        if constexpr (std::is_same_v<GetType, int64_t> ||
+                                      std::is_same_v<GetType, double>) {
+                            return GetBsonNumberExact<GetType>(
+                                element.get_value());
+                        } else {
+                            return milvus::BsonView::GetValueFromBsonView<
+                                GetType>(element.get_value());
                         }
+                    }();
+                    if (!value.has_value()) {
                         continue;
                     }
                     if (shared_matcher.set_if_found(
@@ -1704,26 +1671,17 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByStats() {
                             break;
                         }
                         case proto::plan::GenericValue::kInt64Val: {
-                            // get double/int64 from bson
-                            auto val =
-                                milvus::BsonView::GetValueFromBsonView<double>(
-                                    sub_value.get_value());
-                            if (!val.has_value()) {
-                                continue;
-                            }
-                            if (val.value() == element.int64_val()) {
+                            auto comparison = CompareBsonNumberToBound(
+                                sub_value.get_value(), element);
+                            if (comparison.has_value() && *comparison == 0) {
                                 tmp_elements_index.erase(i);
                             }
                             break;
                         }
                         case proto::plan::GenericValue::kFloatVal: {
-                            auto val =
-                                milvus::BsonView::GetValueFromBsonView<double>(
-                                    sub_value.get_value());
-                            if (!val.has_value()) {
-                                continue;
-                            }
-                            if (val.value() == element.float_val()) {
+                            auto comparison = CompareBsonNumberToBound(
+                                sub_value.get_value(), element);
+                            if (comparison.has_value() && *comparison == 0) {
                                 tmp_elements_index.erase(i);
                             }
                             break;
@@ -2293,26 +2251,18 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByStats() {
                             break;
                         }
                         case proto::plan::GenericValue::kInt64Val: {
-                            auto val =
-                                milvus::BsonView::GetValueFromBsonView<double>(
-                                    sub_value.get_value());
-                            if (!val.has_value()) {
-                                continue;
-                            }
-                            if (val.value() == element.int64_val()) {
+                            auto comparison = CompareBsonNumberToBound(
+                                sub_value.get_value(), element);
+                            if (comparison.has_value() && *comparison == 0) {
                                 res_view[row_offset] = true;
                                 return;
                             }
                             break;
                         }
                         case proto::plan::GenericValue::kFloatVal: {
-                            auto val =
-                                milvus::BsonView::GetValueFromBsonView<double>(
-                                    sub_value.get_value());
-                            if (!val.has_value()) {
-                                continue;
-                            }
-                            if (val.value() == element.float_val()) {
+                            auto comparison = CompareBsonNumberToBound(
+                                sub_value.get_value(), element);
+                            if (comparison.has_value() && *comparison == 0) {
                                 res_view[row_offset] = true;
                                 return;
                             }

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -2460,8 +2460,11 @@ PhyJsonContainsFilterExpr::ExecArrayContainsForIndexSegmentImpl() {
     };
 
     // Use WithRowLevel version since func handles element-to-row conversion for nested index
-    auto res =
-        ProcessIndexChunksWithRowLevel<GetType>(execute_sub_batch, elems);
+    auto validity_mode = field_type_ == DataType::JSON
+                             ? IndexValidityMode::JsonExactPath
+                             : IndexValidityMode::Default;
+    auto res = ProcessIndexChunksWithRowLevel<GetType>(
+        execute_sub_batch, validity_mode, elems);
     AssertInfo(res->size() == real_batch_size,
                "internal error: expr processed rows {} not equal "
                "expect batch size {}",

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -23,6 +23,7 @@
 #include "common/Vector.h"
 #include "exec/expression/Expr.h"
 #include "exec/expression/Element.h"
+#include "exec/expression/JsonNumberComparison.h"
 #include "segcore/SegmentInterface.h"
 #include "common/bson_view.h"
 #include "exec/expression/Utils.h"
@@ -134,11 +135,9 @@ class ShreddingArrayBsonContainsAllArrayExecutor {
 template <typename GetType>
 class ShreddingArrayBsonContainsAnyExecutor {
  public:
-    ShreddingArrayBsonContainsAnyExecutor(
-        std::shared_ptr<MultiElement> arg_set,
-        std::shared_ptr<MultiElement> arg_set_double)
-        : arg_set_(std::move(arg_set)),
-          arg_set_double_(std::move(arg_set_double)) {
+    explicit ShreddingArrayBsonContainsAnyExecutor(
+        std::shared_ptr<MultiElement> arg_set)
+        : arg_set_(std::move(arg_set)) {
     }
 
     void
@@ -163,10 +162,9 @@ class ShreddingArrayBsonContainsAnyExecutor {
             for (const auto& element : array_view.value()) {
                 if constexpr (std::is_same_v<GetType, int64_t> ||
                               std::is_same_v<GetType, double>) {
-                    auto value = milvus::BsonView::GetValueFromBsonView<double>(
-                        element.get_value());
-                    if (value.has_value() &&
-                        arg_set_double_->In(value.value())) {
+                    auto value =
+                        GetBsonNumberExact<GetType>(element.get_value());
+                    if (value.has_value() && arg_set_->In(*value)) {
                         matched = true;
                         break;
                     }
@@ -186,7 +184,6 @@ class ShreddingArrayBsonContainsAnyExecutor {
 
  private:
     std::shared_ptr<MultiElement> arg_set_;
-    std::shared_ptr<MultiElement> arg_set_double_;
 };
 
 template <typename GetType>
@@ -217,8 +214,15 @@ class ShreddingArrayBsonContainsAllExecutor {
             }
             std::set<GetType> tmp_elements(elements_);
             for (const auto& element : array_view.value()) {
-                auto value = milvus::BsonView::GetValueFromBsonView<GetType>(
-                    element.get_value());
+                auto value = [&]() -> std::optional<GetType> {
+                    if constexpr (std::is_same_v<GetType, int64_t> ||
+                                  std::is_same_v<GetType, double>) {
+                        return GetBsonNumberExact<GetType>(element.get_value());
+                    } else {
+                        return milvus::BsonView::GetValueFromBsonView<GetType>(
+                            element.get_value());
+                    }
+                }();
                 if (!value.has_value()) {
                     continue;
                 }
@@ -281,25 +285,17 @@ class ShreddingArrayBsonContainsAllWithDiffTypeExecutor {
                             break;
                         }
                         case proto::plan::GenericValue::kInt64Val: {
-                            auto val =
-                                milvus::BsonView::GetValueFromBsonView<int64_t>(
-                                    sub_value.get_value());
-                            if (!val.has_value()) {
-                                continue;
-                            }
-                            if (val.value() == element.int64_val()) {
+                            auto comparison = CompareBsonNumberToBound(
+                                sub_value.get_value(), element);
+                            if (comparison.has_value() && *comparison == 0) {
                                 tmp_elements_index.erase(idx);
                             }
                             break;
                         }
                         case proto::plan::GenericValue::kFloatVal: {
-                            auto val =
-                                milvus::BsonView::GetValueFromBsonView<double>(
-                                    sub_value.get_value());
-                            if (!val.has_value()) {
-                                continue;
-                            }
-                            if (val.value() == element.float_val()) {
+                            auto comparison = CompareBsonNumberToBound(
+                                sub_value.get_value(), element);
+                            if (comparison.has_value() && *comparison == 0) {
                                 tmp_elements_index.erase(idx);
                             }
                             break;
@@ -390,21 +386,17 @@ class ShreddingArrayBsonContainsAnyWithDiffTypeExecutor {
                             break;
                         }
                         case proto::plan::GenericValue::kInt64Val: {
-                            auto val =
-                                milvus::BsonView::GetValueFromBsonView<int64_t>(
-                                    sub_value.get_value());
-                            if (val.has_value() &&
-                                val.value() == element.int64_val()) {
+                            auto comparison = CompareBsonNumberToBound(
+                                sub_value.get_value(), element);
+                            if (comparison.has_value() && *comparison == 0) {
                                 matched = true;
                             }
                             break;
                         }
                         case proto::plan::GenericValue::kFloatVal: {
-                            auto val =
-                                milvus::BsonView::GetValueFromBsonView<double>(
-                                    sub_value.get_value());
-                            if (val.has_value() &&
-                                val.value() == element.float_val()) {
+                            auto comparison = CompareBsonNumberToBound(
+                                sub_value.get_value(), element);
+                            if (comparison.has_value() && *comparison == 0) {
                                 matched = true;
                             }
                             break;
@@ -569,7 +561,6 @@ class PhyJsonContainsFilterExpr : public SegmentExpr {
     std::shared_ptr<const milvus::expr::JsonContainsExpr> expr_;
     bool arg_inited_{false};
     std::shared_ptr<MultiElement> arg_set_;
-    std::shared_ptr<MultiElement> arg_set_double_;
     std::shared_ptr<void>
         arg_cached_set_;  // For caching std::set<T> or std::vector<T>
     PinWrapper<index::BsonInvertedIndex*> bson_index_{nullptr};

--- a/internal/core/src/exec/expression/JsonNumberComparison.h
+++ b/internal/core/src/exec/expression/JsonNumberComparison.h
@@ -1,0 +1,151 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+
+#include <simdjson.h>
+
+#include "pb/plan.pb.h"
+
+namespace milvus::exec {
+
+inline int
+CompareInt64ToDouble(int64_t lhs, double rhs) {
+    constexpr double kInt64Lower = -0x1p63;
+    constexpr double kInt64Upper = 0x1p63;
+    if (rhs < kInt64Lower) {
+        return 1;
+    }
+    if (rhs >= kInt64Upper) {
+        return -1;
+    }
+
+    const auto rhs_integer = static_cast<int64_t>(rhs);
+    if (lhs < rhs_integer) {
+        return -1;
+    }
+    if (lhs > rhs_integer) {
+        return 1;
+    }
+
+    const auto rhs_integer_as_double = static_cast<double>(rhs_integer);
+    if (rhs > rhs_integer_as_double) {
+        return -1;
+    }
+    if (rhs < rhs_integer_as_double) {
+        return 1;
+    }
+    return 0;
+}
+
+inline int
+CompareUint64ToDouble(uint64_t lhs, double rhs) {
+    constexpr double kUint64Upper = 0x1p64;
+    if (rhs < 0) {
+        return 1;
+    }
+    if (rhs >= kUint64Upper) {
+        return -1;
+    }
+
+    const auto rhs_integer = static_cast<uint64_t>(rhs);
+    if (lhs < rhs_integer) {
+        return -1;
+    }
+    if (lhs > rhs_integer) {
+        return 1;
+    }
+
+    const auto rhs_integer_as_double = static_cast<double>(rhs_integer);
+    if (rhs > rhs_integer_as_double) {
+        return -1;
+    }
+    if (rhs < rhs_integer_as_double) {
+        return 1;
+    }
+    return 0;
+}
+
+inline std::optional<int>
+CompareJsonNumberToBound(const simdjson::ondemand::number& number,
+                         const proto::plan::GenericValue& bound) {
+    if (bound.has_int64_val()) {
+        const auto rhs = bound.int64_val();
+        if (number.is_int64()) {
+            const auto lhs = number.get_int64();
+            return lhs < rhs ? -1 : lhs > rhs ? 1 : 0;
+        }
+        if (number.is_uint64()) {
+            const auto lhs = number.get_uint64();
+            if (rhs < 0) {
+                return 1;
+            }
+            const auto unsigned_rhs = static_cast<uint64_t>(rhs);
+            return lhs < unsigned_rhs ? -1 : lhs > unsigned_rhs ? 1 : 0;
+        }
+        const auto lhs = number.get_double();
+        if (std::isnan(lhs)) {
+            return std::nullopt;
+        }
+        return -CompareInt64ToDouble(rhs, lhs);
+    }
+
+    if (bound.has_float_val()) {
+        const auto rhs = bound.float_val();
+        if (std::isnan(rhs)) {
+            return std::nullopt;
+        }
+        if (number.is_int64()) {
+            return CompareInt64ToDouble(number.get_int64(), rhs);
+        }
+        if (number.is_uint64()) {
+            return CompareUint64ToDouble(number.get_uint64(), rhs);
+        }
+        const auto lhs = number.get_double();
+        if (std::isnan(lhs)) {
+            return std::nullopt;
+        }
+        return lhs < rhs ? -1 : lhs > rhs ? 1 : 0;
+    }
+
+    return std::nullopt;
+}
+
+inline bool
+JsonNumberMatchesOp(int comparison, proto::plan::OpType op) {
+    switch (op) {
+        case proto::plan::OpType::Equal:
+            return comparison == 0;
+        case proto::plan::OpType::NotEqual:
+            return comparison != 0;
+        case proto::plan::OpType::GreaterThan:
+            return comparison > 0;
+        case proto::plan::OpType::GreaterEqual:
+            return comparison >= 0;
+        case proto::plan::OpType::LessThan:
+            return comparison < 0;
+        case proto::plan::OpType::LessEqual:
+            return comparison <= 0;
+        default:
+            return false;
+    }
+}
+
+}  // namespace milvus::exec

--- a/internal/core/src/exec/expression/JsonNumberComparison.h
+++ b/internal/core/src/exec/expression/JsonNumberComparison.h
@@ -19,9 +19,11 @@
 #include <cmath>
 #include <cstdint>
 #include <optional>
+#include <type_traits>
 
 #include <simdjson.h>
 
+#include "common/bson_view.h"
 #include "pb/plan.pb.h"
 
 namespace milvus::exec {
@@ -83,49 +85,189 @@ CompareUint64ToDouble(uint64_t lhs, double rhs) {
     return 0;
 }
 
+inline bool
+Int64RoundTripsThroughDouble(int64_t value) {
+    return CompareInt64ToDouble(value, static_cast<double>(value)) == 0;
+}
+
+inline std::optional<int64_t>
+DoubleToInt64Exact(double value) {
+    constexpr double kInt64Lower = -0x1p63;
+    constexpr double kInt64Upper = 0x1p63;
+    if (!std::isfinite(value) || value < kInt64Lower || value >= kInt64Upper) {
+        return std::nullopt;
+    }
+    const auto integer = static_cast<int64_t>(value);
+    return CompareInt64ToDouble(integer, value) == 0
+               ? std::optional<int64_t>(integer)
+               : std::nullopt;
+}
+
+template <typename Target, typename Source>
+std::optional<Target>
+ConvertJsonNumberExact(Source value) {
+    static_assert(
+        (std::is_same_v<Target, int64_t> || std::is_same_v<Target, double>)&&(
+            std::is_same_v<Source, int64_t> || std::is_same_v<Source, double>));
+    if constexpr (std::is_same_v<Target, Source>) {
+        return value;
+    } else if constexpr (std::is_same_v<Target, int64_t>) {
+        return DoubleToInt64Exact(value);
+    } else {
+        return Int64RoundTripsThroughDouble(value)
+                   ? std::optional<double>(static_cast<double>(value))
+                   : std::nullopt;
+    }
+}
+
+template <typename Target>
+std::optional<Target>
+GetBsonNumberExact(const milvus::bson::value_view& value) {
+    static_assert(std::is_same_v<Target, int64_t> ||
+                  std::is_same_v<Target, double>);
+    if (auto integer32 =
+            milvus::BsonView::GetValueFromBsonView<int32_t>(value)) {
+        return ConvertJsonNumberExact<Target>(static_cast<int64_t>(*integer32));
+    }
+    if (auto integer = milvus::BsonView::GetValueFromBsonView<int64_t>(value)) {
+        return ConvertJsonNumberExact<Target>(*integer);
+    }
+    if (auto floating = milvus::BsonView::GetValueFromBsonView<double>(value)) {
+        return ConvertJsonNumberExact<Target>(*floating);
+    }
+    return std::nullopt;
+}
+
+template <typename Target>
+std::optional<Target>
+ParseBsonNumberExact(milvus::BsonView& bson, size_t offset, bool& is_number) {
+    static_assert(std::is_same_v<Target, int64_t> ||
+                  std::is_same_v<Target, double>);
+    if (auto integer = bson.ParseAsValueAtOffset<int64_t>(offset)) {
+        is_number = true;
+        return ConvertJsonNumberExact<Target>(*integer);
+    }
+    if (auto floating = bson.ParseAsValueAtOffset<double>(offset)) {
+        is_number = true;
+        return ConvertJsonNumberExact<Target>(*floating);
+    }
+    is_number = false;
+    return std::nullopt;
+}
+
 inline std::optional<int>
-CompareJsonNumberToBound(const simdjson::ondemand::number& number,
+CompareJsonNumberToBound(int64_t number,
                          const proto::plan::GenericValue& bound) {
     if (bound.has_int64_val()) {
         const auto rhs = bound.int64_val();
-        if (number.is_int64()) {
-            const auto lhs = number.get_int64();
-            return lhs < rhs ? -1 : lhs > rhs ? 1 : 0;
+        return number < rhs ? -1 : number > rhs ? 1 : 0;
+    }
+    if (bound.has_float_val()) {
+        const auto rhs = bound.float_val();
+        return std::isnan(rhs)
+                   ? std::nullopt
+                   : std::optional<int>(CompareInt64ToDouble(number, rhs));
+    }
+    return std::nullopt;
+}
+
+inline std::optional<int>
+CompareJsonNumberToBound(double number,
+                         const proto::plan::GenericValue& bound) {
+    if (std::isnan(number)) {
+        return std::nullopt;
+    }
+    if (bound.has_int64_val()) {
+        return -CompareInt64ToDouble(bound.int64_val(), number);
+    }
+    if (bound.has_float_val()) {
+        const auto rhs = bound.float_val();
+        if (std::isnan(rhs)) {
+            return std::nullopt;
         }
-        if (number.is_uint64()) {
-            const auto lhs = number.get_uint64();
+        return number < rhs ? -1 : number > rhs ? 1 : 0;
+    }
+    return std::nullopt;
+}
+
+inline std::optional<int>
+CompareBsonNumberToBound(const milvus::bson::value_view& number,
+                         const proto::plan::GenericValue& bound) {
+    if (auto integer32 =
+            milvus::BsonView::GetValueFromBsonView<int32_t>(number)) {
+        return CompareJsonNumberToBound(static_cast<int64_t>(*integer32),
+                                        bound);
+    }
+    if (auto integer =
+            milvus::BsonView::GetValueFromBsonView<int64_t>(number)) {
+        return CompareJsonNumberToBound(*integer, bound);
+    }
+    if (auto floating =
+            milvus::BsonView::GetValueFromBsonView<double>(number)) {
+        return CompareJsonNumberToBound(*floating, bound);
+    }
+    return std::nullopt;
+}
+
+inline std::optional<int>
+CompareBsonNumberToBound(milvus::BsonView& bson,
+                         size_t offset,
+                         const proto::plan::GenericValue& bound) {
+    if (auto integer = bson.ParseAsValueAtOffset<int64_t>(offset)) {
+        return CompareJsonNumberToBound(*integer, bound);
+    }
+    if (auto floating = bson.ParseAsValueAtOffset<double>(offset)) {
+        return CompareJsonNumberToBound(*floating, bound);
+    }
+    return std::nullopt;
+}
+
+inline std::optional<int>
+CompareBsonArrayNumberToBound(const milvus::bson::array_view& array,
+                              size_t index,
+                              const proto::plan::GenericValue& bound) {
+    if (auto integer32 = milvus::BsonView::GetNthElementInArray<int32_t>(
+            array.data(), index)) {
+        return CompareJsonNumberToBound(static_cast<int64_t>(*integer32),
+                                        bound);
+    }
+    if (auto integer = milvus::BsonView::GetNthElementInArray<int64_t>(
+            array.data(), index)) {
+        return CompareJsonNumberToBound(*integer, bound);
+    }
+    if (auto floating = milvus::BsonView::GetNthElementInArray<double>(
+            array.data(), index)) {
+        return CompareJsonNumberToBound(*floating, bound);
+    }
+    return std::nullopt;
+}
+
+inline std::optional<int>
+CompareJsonNumberToBound(const simdjson::ondemand::number& number,
+                         const proto::plan::GenericValue& bound) {
+    if (number.is_int64()) {
+        return CompareJsonNumberToBound(number.get_int64(), bound);
+    }
+    if (number.is_uint64()) {
+        const auto lhs = number.get_uint64();
+        if (bound.has_int64_val()) {
+            const auto rhs = bound.int64_val();
             if (rhs < 0) {
                 return 1;
             }
             const auto unsigned_rhs = static_cast<uint64_t>(rhs);
             return lhs < unsigned_rhs ? -1 : lhs > unsigned_rhs ? 1 : 0;
         }
-        const auto lhs = number.get_double();
-        if (std::isnan(lhs)) {
-            return std::nullopt;
-        }
-        return -CompareInt64ToDouble(rhs, lhs);
-    }
-
-    if (bound.has_float_val()) {
-        const auto rhs = bound.float_val();
-        if (std::isnan(rhs)) {
-            return std::nullopt;
-        }
-        if (number.is_int64()) {
-            return CompareInt64ToDouble(number.get_int64(), rhs);
-        }
-        if (number.is_uint64()) {
+        if (bound.has_float_val()) {
+            const auto rhs = bound.float_val();
+            if (std::isnan(rhs)) {
+                return std::nullopt;
+            }
             return CompareUint64ToDouble(number.get_uint64(), rhs);
         }
-        const auto lhs = number.get_double();
-        if (std::isnan(lhs)) {
-            return std::nullopt;
-        }
-        return lhs < rhs ? -1 : lhs > rhs ? 1 : 0;
+        return std::nullopt;
     }
-
-    return std::nullopt;
+    return CompareJsonNumberToBound(number.get_double(), bound);
 }
 
 inline bool

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -261,12 +261,24 @@ PhyTermFilterExpr::ExecVisitorImplTemplateJson(EvalCtx& context) {
         return ExecTermJsonVariableInField<ValueType>(context);
     } else {
         if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
-            // we create double index for json int64 field for now
-            using GetType =
-                std::conditional_t<std::is_same_v<ValueType, int64_t>,
-                                   double,
-                                   ValueType>;
-            return ExecVisitorImplForIndex<GetType>();
+            if constexpr (std::is_same_v<ValueType, int64_t>) {
+                const auto has_unsafe_literal = std::any_of(
+                    expr_->vals_.begin(),
+                    expr_->vals_.end(),
+                    [this](const auto& val) {
+                        return val.has_int64_val() &&
+                               !IsInt64SafeForJsonDoubleIndex(val.int64_val());
+                    });
+                if (has_unsafe_literal) {
+                    return ExecTermJsonFieldInVariable<int64_t>(context);
+                }
+                if (PinnedJsonIndexIsFlat()) {
+                    return ExecVisitorImplForIndex<int64_t>();
+                }
+                return ExecVisitorImplForIndex<double>();
+            } else {
+                return ExecVisitorImplForIndex<ValueType>();
+            }
         } else {
             return ExecTermJsonFieldInVariable<ValueType>(context);
         }
@@ -951,6 +963,12 @@ PhyTermFilterExpr::ExecVisitorImplForIndex() {
     };
     auto args =
         std::dynamic_pointer_cast<FlatVectorElement<IndexInnerType>>(arg_set_);
+    if (field_type_ == DataType::JSON && args->values_.empty()) {
+        MoveCursor();
+        return std::make_shared<ColumnVector>(
+            TargetBitmap(real_batch_size, false),
+            TargetBitmap(real_batch_size, true));
+    }
     auto res = ProcessIndexChunks<T>(execute_sub_batch, args->values_);
     AssertInfo(res->size() == real_batch_size,
                "internal error: expr processed rows {} not equal "
@@ -984,6 +1002,12 @@ PhyTermFilterExpr::ExecVisitorImplForIndex<bool>() {
         return func(index_ptr, vals.size(), (bool*)vals.data());
     };
     auto args = std::dynamic_pointer_cast<FlatVectorElement<uint8_t>>(arg_set_);
+    if (field_type_ == DataType::JSON && args->values_.empty()) {
+        MoveCursor();
+        return std::make_shared<ColumnVector>(
+            TargetBitmap(real_batch_size, false),
+            TargetBitmap(real_batch_size, true));
+    }
     auto res = ProcessIndexChunks<bool>(execute_sub_batch, args->values_);
     return res;
 }

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -34,6 +34,7 @@
 #include "common/ScopedTimer.h"
 #include "exec/expression/Element.h"
 #include "exec/expression/EvalCtx.h"
+#include "exec/expression/JsonNumberComparison.h"
 #include "exec/expression/Utils.h"
 #include "folly/FBVector.h"
 #include "glog/logging.h"
@@ -619,18 +620,6 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
     auto pointer = milvus::index::JsonPointer(expr_->column_.nested_path_);
     if (!arg_inited_) {
         arg_set_ = std::make_shared<SetElement<ValueType>>(expr_->vals_);
-        if constexpr (std::is_same_v<GetType, int64_t>) {
-            // for int64_t, we need to a double vector to store the values
-            auto int_arg_set =
-                std::static_pointer_cast<SetElement<int64_t>>(arg_set_);
-            std::vector<double> double_vals;
-            for (const auto& val : int_arg_set->GetElements()) {
-                double_vals.emplace_back(static_cast<double>(val));
-            }
-            arg_set_double_ = std::make_shared<SetElement<double>>(double_vals);
-        } else if constexpr (std::is_same_v<GetType, double>) {
-            arg_set_double_ = arg_set_;
-        }
         arg_inited_ = true;
     }
 
@@ -659,10 +648,10 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
 
         // process shredding data
         auto try_execute = [&](milvus::index::JSONType json_type,
-                               auto GetType) {
+                               auto get_type) {
             auto target_field = index->GetShreddingField(pointer, json_type);
             if (!target_field.empty()) {
-                using ColType = decltype(GetType);
+                using ColType = decltype(get_type);
                 TargetBitmap target_res(active_count_, false);
                 TargetBitmapView target_res_view(target_res);
                 TargetBitmap target_valid(active_count_, true);
@@ -677,8 +666,12 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
                             res[i] = valid_res[i] = false;
                             continue;
                         }
-                        if constexpr (std::is_same_v<ColType, double>) {
-                            res[i] = this->arg_set_double_->In(src[i]);
+                        if constexpr (std::is_same_v<GetType, int64_t> ||
+                                      std::is_same_v<GetType, double>) {
+                            auto value =
+                                ConvertJsonNumberExact<GetType>(src[i]);
+                            res[i] =
+                                value.has_value() && this->arg_set_->In(*value);
                         } else {
                             res[i] = this->arg_set_->In(src[i]);
                         }
@@ -729,11 +722,13 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
                                    uint32_t value_offset) {
             if constexpr (std::is_same_v<GetType, int64_t> ||
                           std::is_same_v<GetType, double>) {
-                auto get_value =
-                    bson.ParseAsValueAtOffset<double>(value_offset);
+                bool is_number = false;
+                auto get_value = ParseBsonNumberExact<GetType>(
+                    bson, value_offset, is_number);
                 if (get_value.has_value()) {
-                    res_view[row_offset] =
-                        this->arg_set_double_->In(get_value.value());
+                    res_view[row_offset] = this->arg_set_->In(*get_value);
+                }
+                if (is_number) {
                     valid_res_view[row_offset] = true;
                 }
                 return;

--- a/internal/core/src/exec/expression/TermExpr.h
+++ b/internal/core/src/exec/expression/TermExpr.h
@@ -169,7 +169,6 @@ class PhyTermFilterExpr : public SegmentExpr {
     TargetBitmap cached_bits_;
     bool arg_inited_{false};
     std::shared_ptr<MultiElement> arg_set_;
-    std::shared_ptr<MultiElement> arg_set_double_;
     SingleElement arg_val_;
     PinWrapper<index::BsonInvertedIndex*> bson_index_{nullptr};
 

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -258,14 +258,19 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                         result = ExecRangeVisitorImplForIndex<bool>();
                         break;
                     case proto::plan::GenericValue::ValCase::kInt64Val:
-                        if (expr_->val_.has_int64_val()) {
+                        if (!IsInt64SafeForJsonDoubleIndex(
+                                expr_->val_.int64_val())) {
+                            result = ExecRangeVisitorImplJson<int64_t>(context);
+                        } else if (PinnedJsonIndexIsFlat()) {
+                            result = ExecRangeVisitorImplForIndex<int64_t>();
+                        } else {
                             proto::plan::GenericValue double_val;
                             double_val.set_float_val(
                                 static_cast<double>(expr_->val_.int64_val()));
                             value_arg_.SetValue<double>(double_val);
                             arg_inited_ = true;
+                            result = ExecRangeVisitorImplForIndex<double>();
                         }
-                        result = ExecRangeVisitorImplForIndex<double>();
                         break;
                     case proto::plan::GenericValue::ValCase::kFloatVal:
                         result = ExecRangeVisitorImplForIndex<double>();

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1214,6 +1214,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
         }
 
         // process shredding data
+        const auto& numeric_bound = expr_->val_;
         auto try_execute = [&](milvus::index::JSONType json_type,
                                auto GetType,
                                auto ValType) {
@@ -1221,18 +1222,50 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
             if (!target_field.empty()) {
                 using ColType = decltype(GetType);
                 using ValType = decltype(ValType);
+                constexpr bool kNumericColumn =
+                    std::is_same_v<ColType, int64_t> ||
+                    std::is_same_v<ColType, double>;
+                constexpr bool kNumericValue =
+                    std::is_same_v<ValType, int64_t> ||
+                    std::is_same_v<ValType, double>;
                 TargetBitmap target_res(active_count_, false);
                 TargetBitmapView target_res_view(target_res);
                 TargetBitmap target_valid(active_count_, true);
                 TargetBitmapView target_valid_view(target_valid);
-                ShreddingExecutor<ColType, ValType> executor(
-                    op_type, pointer, val);
-                index->ExecutorForShreddingData<ColType>(op_ctx_,
-                                                         target_field,
-                                                         executor,
-                                                         nullptr,
-                                                         target_res_view,
-                                                         target_valid_view);
+                if constexpr (kNumericColumn && kNumericValue) {
+                    auto executor = [op_type, &numeric_bound](
+                                        const ColType* src,
+                                        const bool* valid,
+                                        size_t size,
+                                        TargetBitmapView res,
+                                        TargetBitmapView valid_res) {
+                        for (size_t i = 0; i < size; ++i) {
+                            if (valid != nullptr && !valid[i]) {
+                                res[i] = valid_res[i] = false;
+                                continue;
+                            }
+                            auto comparison =
+                                CompareJsonNumberToBound(src[i], numeric_bound);
+                            res[i] = comparison.has_value() &&
+                                     JsonNumberMatchesOp(*comparison, op_type);
+                        }
+                    };
+                    index->ExecutorForShreddingData<ColType>(op_ctx_,
+                                                             target_field,
+                                                             executor,
+                                                             nullptr,
+                                                             target_res_view,
+                                                             target_valid_view);
+                } else {
+                    ShreddingExecutor<ColType, ValType> executor(
+                        op_type, pointer, val);
+                    index->ExecutorForShreddingData<ColType>(op_ctx_,
+                                                             target_field,
+                                                             executor,
+                                                             nullptr,
+                                                             target_res_view,
+                                                             target_valid_view);
+                }
                 res_view.inplace_or_with_count(target_res_view, active_count_);
                 valid_res_view.inplace_or_with_count(target_valid_view,
                                                      active_count_);
@@ -1318,6 +1351,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
         auto shared_executor = [op_type,
                                 val,
                                 array_index,
+                                &numeric_bound,
                                 &res_view,
                                 &valid_res_view,
                                 &context](milvus::BsonView bson,
@@ -1364,84 +1398,53 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                             : !CompareTwoJsonArray(array_value.value(), val));
                 }
             } else {
-                std::optional<GetType> get_value;
-                if (array_index != INVALID_ARRAY_INDEX) {
-                    auto array_value = bson.ParseAsArrayAtOffset(value_offset);
-                    if (!array_value.has_value()) {
+                if constexpr (std::is_same_v<GetType, int64_t> ||
+                              std::is_same_v<GetType, double>) {
+                    std::optional<int> comparison;
+                    if (array_index != INVALID_ARRAY_INDEX) {
+                        auto array_value =
+                            bson.ParseAsArrayAtOffset(value_offset);
+                        if (!array_value.has_value()) {
+                            set_unknown(row_id);
+                            return;
+                        }
+                        comparison = CompareBsonArrayNumberToBound(
+                            *array_value, array_index, numeric_bound);
+                    } else {
+                        comparison = CompareBsonNumberToBound(
+                            bson, value_offset, numeric_bound);
+                    }
+                    if (!comparison.has_value()) {
                         set_unknown(row_id);
                         return;
                     }
-                    get_value = milvus::BsonView::GetNthElementInArray<GetType>(
-                        array_value.value().data(), array_index);
-                    // If GetType is int and value is not found, try double
-                    if constexpr (std::is_same_v<GetType, int64_t>) {
-                        if (!get_value.has_value()) {
-                            auto get_value =
-                                milvus::BsonView::GetNthElementInArray<double>(
-                                    array_value.value().data(), array_index);
-                            if (get_value.has_value()) {
-                                set_known(row_id,
-                                          UnaryCompare(
-                                              get_value.value(), val, op_type));
-                            } else {
-                                set_unknown(row_id);
-                            }
-                            return;
-                        }
-                    } else if constexpr (std::is_same_v<GetType, double>) {
-                        if (!get_value.has_value()) {
-                            auto get_value =
-                                milvus::BsonView::GetNthElementInArray<int64_t>(
-                                    array_value.value().data(), array_index);
-                            if (get_value.has_value()) {
-                                set_known(row_id,
-                                          UnaryCompare(
-                                              get_value.value(), val, op_type));
-                            } else {
-                                set_unknown(row_id);
-                            }
-                            return;
-                        }
-                    }
-                } else {
-                    get_value =
-                        bson.ParseAsValueAtOffset<GetType>(value_offset);
-                    // If GetType is int and value is not found, try double
-                    if constexpr (std::is_same_v<GetType, int64_t>) {
-                        if (!get_value.has_value()) {
-                            auto get_value =
-                                bson.ParseAsValueAtOffset<double>(value_offset);
-                            if (get_value.has_value()) {
-                                set_known(row_id,
-                                          UnaryCompare(
-                                              get_value.value(), val, op_type));
-                            } else {
-                                set_unknown(row_id);
-                            }
-                            return;
-                        }
-                    } else if constexpr (std::is_same_v<GetType, double>) {
-                        if (!get_value.has_value()) {
-                            auto get_value = bson.ParseAsValueAtOffset<int64_t>(
-                                value_offset);
-                            if (get_value.has_value()) {
-                                set_known(row_id,
-                                          UnaryCompare(
-                                              get_value.value(), val, op_type));
-                            } else {
-                                set_unknown(row_id);
-                            }
-                            return;
-                        }
-                    }
-                }
-                if (!get_value.has_value()) {
-                    set_unknown(row_id);
+                    set_known(row_id,
+                              JsonNumberMatchesOp(*comparison, op_type));
                     return;
+                } else {
+                    std::optional<GetType> get_value;
+                    if (array_index != INVALID_ARRAY_INDEX) {
+                        auto array_value =
+                            bson.ParseAsArrayAtOffset(value_offset);
+                        if (!array_value.has_value()) {
+                            set_unknown(row_id);
+                            return;
+                        }
+                        get_value =
+                            milvus::BsonView::GetNthElementInArray<GetType>(
+                                array_value.value().data(), array_index);
+                    } else {
+                        get_value =
+                            bson.ParseAsValueAtOffset<GetType>(value_offset);
+                    }
+                    if (!get_value.has_value()) {
+                        set_unknown(row_id);
+                        return;
+                    }
+                    set_known(row_id,
+                              UnaryCompare(
+                                  get_value.value(), val, op_type, &context));
                 }
-                set_known(
-                    row_id,
-                    UnaryCompare(get_value.value(), val, op_type, &context));
             }
         };
 

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -46,6 +46,7 @@
 #include "common/type_c.h"
 #include "exec/expression/ExprCache.h"
 #include "exec/expression/ExprCacheHelper.h"
+#include "exec/expression/JsonNumberComparison.h"
 #include "fmt/core.h"
 #include "folly/FBVector.h"
 #include "glog/logging.h"
@@ -260,7 +261,8 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                     case proto::plan::GenericValue::ValCase::kInt64Val:
                         if (!IsInt64SafeForJsonDoubleIndex(
                                 expr_->val_.int64_val())) {
-                            result = ExecRangeVisitorImplJson<int64_t>(context);
+                            result =
+                                ExecRangeVisitorImplJsonPreciseNumeric(context);
                         } else if (PinnedJsonIndexIsFlat()) {
                             result = ExecRangeVisitorImplForIndex<int64_t>();
                         } else {
@@ -355,6 +357,82 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                       "unsupported data type: {}",
                       expr_->column_.data_type_);
     }
+}
+
+VectorPtr
+PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonPreciseNumeric(
+    EvalCtx& context) {
+    const auto& bitmap_input = context.get_bitmap_input();
+    auto* input = context.get_offset_input();
+    auto real_batch_size =
+        has_offset_input_ ? input->size() : GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
+
+    auto res_vec =
+        std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),
+                                       TargetBitmap(real_batch_size, true));
+    TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
+    TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
+    auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
+    auto bound = expr_->val_;
+    const auto op_type = expr_->op_type_;
+
+    size_t processed_cursor = 0;
+    auto execute_sub_batch =
+        [ pointer, bound, op_type, &bitmap_input, &
+          processed_cursor ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::Json* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res) {
+        if (data == nullptr) {
+            processed_cursor += size;
+            return;
+        }
+        const bool has_bitmap_input = !bitmap_input.empty();
+        for (int i = 0; i < size; ++i) {
+            auto offset = i;
+            if constexpr (filter_type == FilterType::random) {
+                offset = offsets ? offsets[i] : i;
+            }
+            if (valid_data != nullptr && !valid_data[offset]) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
+                continue;
+            }
+
+            auto number = data[offset].at_numeric(pointer);
+            if (number.error()) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            auto comparison = CompareJsonNumberToBound(number.value(), bound);
+            res[i] = comparison.has_value() &&
+                     JsonNumberMatchesOp(*comparison, op_type);
+        }
+        processed_cursor += size;
+    };
+
+    int64_t processed_size;
+    if (has_offset_input_) {
+        processed_size = ProcessDataByOffsets<milvus::Json>(
+            execute_sub_batch, std::nullptr_t{}, input, res, valid_res);
+    } else {
+        processed_size = ProcessDataChunks<milvus::Json>(
+            execute_sub_batch, std::nullptr_t{}, res, valid_res);
+    }
+    AssertInfo(processed_size == real_batch_size,
+               "internal error: expr processed rows {} not equal "
+               "expect batch size {}",
+               processed_size,
+               real_batch_size);
+    return res_vec;
 }
 
 template <typename ValueType>

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -1115,6 +1115,9 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
     VectorPtr
     ExecRangeVisitorImplJson(EvalCtx& context);
 
+    VectorPtr
+    ExecRangeVisitorImplJsonPreciseNumeric(EvalCtx& context);
+
     template <typename ExprValueType>
     VectorPtr
     ExecRangeVisitorImplJsonByStats();

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -28,6 +28,7 @@
 namespace milvus::index {
 
 class JsonFlatIndex;
+using JsonValueType = ::JsonExistValueType;
 // JsonFlatIndexQueryExecutor is used to execute queries on a specified json path, and can be constructed by JsonFlatIndex
 template <typename T>
 class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
@@ -53,16 +54,18 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::Exists",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        this->wrapper_->json_exist_query(json_path_, true, &bitset);
+        this->wrapper_->json_exist_query(
+            json_path_, true, JsonValueType::Any, &bitset);
         return bitset;
     }
 
     TargetBitmap
-    ExactPathExists() {
+    ExactPathExists(JsonValueType value_type = JsonValueType::Any) {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::ExactPathExists",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        this->wrapper_->json_exist_query(json_path_, false, &bitset);
+        this->wrapper_->json_exist_query(
+            json_path_, false, value_type, &bitset);
         return bitset;
     }
 
@@ -215,46 +218,6 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
     }
 
  private:
-    TargetBitmap
-    NumericComparableBitset() {
-        TargetBitmap bitset(this->Count());
-
-        TargetBitmap int_bitset(this->Count());
-        this->wrapper_->json_range_query(json_path_,
-                                         std::numeric_limits<int64_t>::lowest(),
-                                         std::numeric_limits<int64_t>::max(),
-                                         false,
-                                         false,
-                                         true,
-                                         true,
-                                         &int_bitset);
-        bitset |= int_bitset;
-
-        TargetBitmap double_bitset(this->Count());
-        this->wrapper_->json_range_query(json_path_,
-                                         std::numeric_limits<double>::lowest(),
-                                         std::numeric_limits<double>::max(),
-                                         false,
-                                         false,
-                                         true,
-                                         true,
-                                         &double_bitset);
-        bitset |= double_bitset;
-
-        TargetBitmap u64_bitset(this->Count());
-        this->wrapper_->json_range_query(json_path_,
-                                         std::numeric_limits<uint64_t>::min(),
-                                         std::numeric_limits<uint64_t>::max(),
-                                         false,
-                                         false,
-                                         true,
-                                         true,
-                                         &u64_bitset);
-        bitset |= u64_bitset;
-
-        return bitset;
-    }
-
     using U64Range = std::optional<std::pair<uint64_t, uint64_t>>;
     using I64Range = std::optional<std::pair<int64_t, int64_t>>;
 
@@ -745,20 +708,17 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
 
     TargetBitmap
     ComparableValueBitset() {
-        TargetBitmap bitset(this->Count());
         if constexpr (std::is_same_v<T, bool>) {
-            bool values[] = {false, true};
-            this->wrapper_->json_terms_query(json_path_, values, 2, &bitset);
+            return ExactPathExists(JsonValueType::Bool);
         } else if constexpr (std::is_integral_v<T>) {
-            bitset = NumericComparableBitset();
+            return ExactPathExists(JsonValueType::Numeric);
         } else if constexpr (std::is_floating_point_v<T>) {
-            bitset = NumericComparableBitset();
+            return ExactPathExists(JsonValueType::Numeric);
         } else if constexpr (std::is_same_v<T, std::string>) {
-            this->wrapper_->json_prefix_query(json_path_, "", &bitset);
+            return ExactPathExists(JsonValueType::String);
         } else {
-            this->wrapper_->json_exist_query(json_path_, true, &bitset);
+            return Exists();
         }
-        return bitset;
     }
 
     std::string json_path_;

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -53,7 +53,16 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::Exists",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        this->wrapper_->json_exist_query(json_path_, &bitset);
+        this->wrapper_->json_exist_query(json_path_, true, &bitset);
+        return bitset;
+    }
+
+    TargetBitmap
+    ExactPathExists() {
+        tracer::AutoSpan span("JsonFlatIndexQueryExecutor::ExactPathExists",
+                              tracer::GetRootSpan());
+        TargetBitmap bitset(this->Count());
+        this->wrapper_->json_exist_query(json_path_, false, &bitset);
         return bitset;
     }
 
@@ -747,7 +756,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         } else if constexpr (std::is_same_v<T, std::string>) {
             this->wrapper_->json_prefix_query(json_path_, "", &bitset);
         } else {
-            this->wrapper_->json_exist_query(json_path_, &bitset);
+            this->wrapper_->json_exist_query(json_path_, true, &bitset);
         }
         return bitset;
     }

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -231,7 +231,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
 
     void
     OrU64TermRanges(TargetBitmap& bitset, size_t n, const T* values) {
-        if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
+        if constexpr (std::is_floating_point_v<T>) {
             for (size_t i = 0; i < n; ++i) {
                 auto value = static_cast<double>(values[i]);
                 auto range = DoubleRangeForBounds(value, true, value, true);

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -67,6 +67,7 @@
 #include "storage/Util.h"
 #include "test_utils/Constants.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/GenExprProto.h"
 #include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 
@@ -276,6 +277,38 @@ TEST_F(JsonFlatIndexTest, TestExistsQuery) {
     ASSERT_TRUE(result[0]);   // Alice
     ASSERT_FALSE(result[1]);  // null
     ASSERT_FALSE(result[2]);  // not exist
+}
+
+TEST(JsonFlatIndexExactPathExistsTest, DistinguishesObjectSubpaths) {
+    auto json_index = BuildInMemoryJsonFlatIndex({
+        R"({"a": 1})",
+        R"({"a": [1, 2]})",
+        R"({"a": {"b": 1}})",
+        R"({"a": []})",
+        R"({"a": null})",
+        R"({})",
+    });
+
+    std::string json_path = "/a";
+    auto executor = json_index->create_executor<int64_t>(json_path);
+
+    auto recursive_exists = executor->Exists();
+    ASSERT_EQ(recursive_exists.size(), 6);
+    EXPECT_TRUE(recursive_exists[0]);
+    EXPECT_TRUE(recursive_exists[1]);
+    EXPECT_TRUE(recursive_exists[2]);
+    EXPECT_FALSE(recursive_exists[3]);
+    EXPECT_FALSE(recursive_exists[4]);
+    EXPECT_FALSE(recursive_exists[5]);
+
+    auto exact_exists = executor->ExactPathExists();
+    ASSERT_EQ(exact_exists.size(), 6);
+    EXPECT_TRUE(exact_exists[0]);
+    EXPECT_TRUE(exact_exists[1]);
+    EXPECT_FALSE(exact_exists[2]);
+    EXPECT_FALSE(exact_exists[3]);
+    EXPECT_FALSE(exact_exists[4]);
+    EXPECT_FALSE(exact_exists[5]);
 }
 
 TEST_F(JsonFlatIndexTest, TestComparableAndFieldValidityMasks) {
@@ -826,6 +859,155 @@ class JsonFlatIndexExprTest : public ::testing::Test {
     std::unique_ptr<index::JsonFlatIndex> json_index_;
     segcore::SegmentSealedUPtr segment_;
 };
+
+class JsonFlatIndexContainsExprTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        json_data_ = {
+            R"({"a": [1, 2]})",
+            R"({"a": [2]})",
+            R"({"a": 1})",
+            R"({"a": 2})",
+            R"({"a": {"b": 1}})",
+            R"({"a": []})",
+            R"({"a": null})",
+            R"({})",
+            R"({"a": ["x"]})",
+            R"({"a": [1]})",
+        };
+
+        auto schema = std::make_shared<Schema>();
+        schema->AddDebugField(
+            "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+        auto i64_fid = schema->AddDebugField("age64", DataType::INT64);
+        json_fid_ = schema->AddDebugField("json", DataType::JSON, true);
+        schema->set_primary_field_id(i64_fid);
+
+        segment_ = segcore::CreateSealedSegment(schema);
+        segcore::LoadIndexInfo load_index_info;
+
+        auto file_manager_ctx = storage::FileManagerContext();
+        file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+            milvus::proto::schema::JSON);
+        file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(
+            json_fid_.get());
+        file_manager_ctx.fieldDataMeta.field_schema.set_nullable(true);
+        file_manager_ctx.fieldDataMeta.field_id = json_fid_.get();
+
+        index::CreateIndexInfo json_index_info;
+        json_index_info.index_type = index::INVERTED_INDEX_TYPE;
+        json_index_info.json_cast_type = JsonCastType::FromString("JSON");
+        json_index_info.json_path = "";
+        auto index = index::IndexFactory::GetInstance().CreateJsonIndex(
+            json_index_info, file_manager_ctx);
+        auto json_index = std::unique_ptr<index::JsonFlatIndex>(
+            static_cast<index::JsonFlatIndex*>(index.release()));
+
+        json_field_ =
+            std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+        std::vector<milvus::Json> jsons;
+        for (auto& json_str : json_data_) {
+            jsons.emplace_back(simdjson::padded_string(json_str));
+        }
+        json_field_->add_json_data(jsons);
+        auto* valid_data = json_field_->ValidData();
+        std::fill(valid_data,
+                  valid_data + json_field_->ValidDataSize(),
+                  static_cast<uint8_t>(0));
+        valid_data[0] = 0xFF;
+        valid_data[1] = 0x01;
+
+        json_index->BuildWithFieldData({json_field_});
+        json_index->finish();
+        json_index->create_reader(milvus::index::SetBitsetSealed);
+
+        load_index_info.field_id = json_fid_.get();
+        load_index_info.field_type = DataType::JSON;
+        load_index_info.index_params = {{JSON_PATH, ""},
+                                        {JSON_CAST_TYPE, "JSON"}};
+        load_index_info.cache_index =
+            CreateTestCacheIndex("", std::move(json_index));
+        segment_->LoadIndex(load_index_info);
+
+        auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                      .GetRemoteChunkManager();
+        auto load_info = PrepareSingleFieldInsertBinlog(
+            1, 1, 1, json_fid_.get(), {json_field_}, cm);
+        segment_->LoadFieldData(load_info);
+    }
+
+    ColumnVectorPtr
+    Evaluate(proto::plan::JSONContainsExpr_JSONOp op,
+             std::vector<int64_t> values,
+             bool negate = false) {
+        std::vector<proto::plan::GenericValue> generic_values;
+        for (auto value : values) {
+            generic_values.emplace_back();
+            generic_values.back().set_int64_val(value);
+        }
+        auto contains_expr = std::make_shared<expr::JsonContainsExpr>(
+            expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+            op,
+            true,
+            generic_values);
+        expr::TypedExprPtr filter_expr = contains_expr;
+        if (negate) {
+            filter_expr = std::make_shared<expr::LogicalUnaryExpr>(
+                expr::LogicalUnaryExpr::OpType::LogicalNot, contains_expr);
+        }
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return gen_filter_res(
+            plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    }
+
+    void
+    CheckResult(const ColumnVectorPtr& result,
+                const std::vector<bool>& expected_result,
+                const std::vector<bool>& expected_valid) {
+        ASSERT_EQ(result->size(), expected_result.size());
+        ASSERT_EQ(result->size(), expected_valid.size());
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_EQ(valid_view[i], expected_valid[i]) << "row " << i;
+            if (expected_valid[i]) {
+                EXPECT_EQ(result_view[i], expected_result[i]) << "row " << i;
+            }
+        }
+    }
+
+    FieldId json_fid_;
+    std::vector<std::string> json_data_;
+    std::shared_ptr<FieldData<milvus::Json>> json_field_;
+    segcore::SegmentSealedUPtr segment_;
+};
+
+TEST_F(JsonFlatIndexContainsExprTest, UsesExactPathThreeValuedValidity) {
+    const std::vector<bool> expected_valid = {
+        true, true, true, true, false, false, false, false, true, false};
+
+    CheckResult(
+        Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains, {1}),
+        {true, false, true, false, false, false, false, false, false, false},
+        expected_valid);
+
+    CheckResult(
+        Evaluate(proto::plan::JSONContainsExpr_JSONOp_ContainsAny, {1, 3}),
+        {true, false, true, false, false, false, false, false, false, false},
+        expected_valid);
+
+    CheckResult(
+        Evaluate(proto::plan::JSONContainsExpr_JSONOp_ContainsAll, {1, 2}),
+        {true, false, false, false, false, false, false, false, false, false},
+        expected_valid);
+
+    CheckResult(
+        Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains, {1}, true),
+        {false, true, false, true, false, false, false, false, true, false},
+        expected_valid);
+}
 
 TEST_F(JsonFlatIndexExprTest, TestUnaryExpr) {
     proto::plan::GenericValue value;

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -631,7 +631,7 @@ TEST(JsonFlatIndexUint64Test, TestNumericQueriesIncludeMixedIntegerTerms) {
     EXPECT_TRUE(not_max_int64[1]);
     EXPECT_TRUE(not_max_int64[2]);
     EXPECT_TRUE(not_max_int64[3]);
-    EXPECT_FALSE(not_max_int64[4]);
+    EXPECT_TRUE(not_max_int64[4]);
     EXPECT_TRUE(not_max_int64[5]);
     EXPECT_FALSE(not_max_int64[6]);
     EXPECT_FALSE(not_max_int64[7]);
@@ -942,6 +942,10 @@ class JsonFlatIndexContainsExprTest : public ::testing::Test {
             R"({})",
             R"({"a": ["x"]})",
             R"({"a": [1]})",
+            R"({"a": [9007199254740992]})",
+            R"({"a": [9007199254740993]})",
+            R"({"a": [9007199254740994]})",
+            R"({"a": [9007199254740992.0]})",
         };
 
         auto schema = std::make_shared<Schema>();
@@ -983,7 +987,7 @@ class JsonFlatIndexContainsExprTest : public ::testing::Test {
                   valid_data + json_field_->ValidDataSize(),
                   static_cast<uint8_t>(0));
         valid_data[0] = 0xFF;
-        valid_data[1] = 0x01;
+        valid_data[1] = 0x3D;
 
         json_index->BuildWithFieldData({json_field_});
         json_index->finish();
@@ -1052,28 +1056,124 @@ class JsonFlatIndexContainsExprTest : public ::testing::Test {
 };
 
 TEST_F(JsonFlatIndexContainsExprTest, UsesExactPathThreeValuedValidity) {
-    const std::vector<bool> expected_valid = {
-        true, true, true, true, false, false, false, false, true, false};
+    const std::vector<bool> expected_valid = {true,
+                                              true,
+                                              true,
+                                              true,
+                                              false,
+                                              false,
+                                              false,
+                                              false,
+                                              true,
+                                              false,
+                                              true,
+                                              true,
+                                              true,
+                                              true};
 
-    CheckResult(
-        Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains, {1}),
-        {true, false, true, false, false, false, false, false, false, false},
-        expected_valid);
+    CheckResult(Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains, {1}),
+                {true,
+                 false,
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false},
+                expected_valid);
 
     CheckResult(
         Evaluate(proto::plan::JSONContainsExpr_JSONOp_ContainsAny, {1, 3}),
-        {true, false, true, false, false, false, false, false, false, false},
+        {true,
+         false,
+         true,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false},
         expected_valid);
 
     CheckResult(
         Evaluate(proto::plan::JSONContainsExpr_JSONOp_ContainsAll, {1, 2}),
-        {true, false, false, false, false, false, false, false, false, false},
+        {true,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false,
+         false},
         expected_valid);
 
     CheckResult(
         Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains, {1}, true),
-        {false, true, false, true, false, false, false, false, true, false},
+        {false,
+         true,
+         false,
+         true,
+         false,
+         false,
+         false,
+         false,
+         true,
+         false,
+         true,
+         true,
+         true,
+         true},
         expected_valid);
+}
+
+TEST_F(JsonFlatIndexContainsExprTest, PreservesLargeInt64LiteralPrecision) {
+    CheckResult(Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains,
+                         {9007199254740993LL}),
+                {false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 false,
+                 true,
+                 false,
+                 false},
+                {true,
+                 true,
+                 true,
+                 true,
+                 false,
+                 false,
+                 false,
+                 false,
+                 true,
+                 false,
+                 true,
+                 true,
+                 true,
+                 true});
 }
 
 TEST_F(JsonFlatIndexExprTest, TestUnaryExpr) {
@@ -1201,6 +1301,42 @@ TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
     EXPECT_TRUE(valid_view[17]);
     EXPECT_TRUE(valid_view[18]);
     EXPECT_FALSE(result_view[16]);
+    EXPECT_TRUE(result_view[17]);
+    EXPECT_FALSE(result_view[18]);
+
+    proto::plan::GenericValue upper_float;
+    upper_float.set_float_val(9007199254740994.0);
+    auto mixed_lower_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        value,
+        upper_float,
+        true,
+        true);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  mixed_lower_expr);
+    result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_FALSE(result_view[16]);
+    EXPECT_TRUE(result_view[17]);
+    EXPECT_TRUE(result_view[18]);
+
+    proto::plan::GenericValue lower_float;
+    lower_float.set_float_val(9007199254740992.0);
+    auto mixed_upper_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        lower_float,
+        value,
+        true,
+        true);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  mixed_upper_expr);
+    result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_TRUE(result_view[16]);
     EXPECT_TRUE(result_view[17]);
     EXPECT_FALSE(result_view[18]);
 }

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -790,6 +790,9 @@ class JsonFlatIndexExprTest : public ::testing::Test {
             R"({"a": 1, "b": 2})",
             R"({})",
             R"(null)",
+            R"({"a": 9007199254740992})",
+            R"({"a": 9007199254740993})",
+            R"({"a": 9007199254740994})",
         };
 
         auto json_index_path = "";
@@ -1039,8 +1042,11 @@ TEST_F(JsonFlatIndexExprTest, TestComparisonUnknowns) {
                                                        not_equal_expr);
     auto final = query::ExecuteQueryExpr(
         plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
-    EXPECT_EQ(final.count(), 1);
+    EXPECT_EQ(final.count(), 4);
     EXPECT_TRUE(final[2]);
+    EXPECT_TRUE(final[16]);
+    EXPECT_TRUE(final[17]);
+    EXPECT_TRUE(final[18]);
 
     auto greater_than_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
         expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
@@ -1058,6 +1064,108 @@ TEST_F(JsonFlatIndexExprTest, TestComparisonUnknowns) {
     EXPECT_TRUE(final[13]);
 }
 
+TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+
+    auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, equal_expr);
+    auto result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    TargetBitmapView result_view(result->GetRawData(), result->size());
+    TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+    EXPECT_TRUE(valid_view[16]);
+    EXPECT_TRUE(valid_view[17]);
+    EXPECT_TRUE(valid_view[18]);
+    EXPECT_FALSE(result_view[16]);
+    EXPECT_TRUE(result_view[17]);
+    EXPECT_FALSE(result_view[18]);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{value},
+        false);
+    plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, term_expr);
+    result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_TRUE(valid_view[16]);
+    EXPECT_TRUE(valid_view[17]);
+    EXPECT_TRUE(valid_view[18]);
+    EXPECT_FALSE(result_view[16]);
+    EXPECT_TRUE(result_view[17]);
+    EXPECT_FALSE(result_view[18]);
+
+    auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  greater_expr);
+    result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_TRUE(valid_view[16]);
+    EXPECT_TRUE(valid_view[17]);
+    EXPECT_TRUE(valid_view[18]);
+    EXPECT_FALSE(result_view[16]);
+    EXPECT_FALSE(result_view[17]);
+    EXPECT_TRUE(result_view[18]);
+
+    auto between_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        value,
+        value,
+        true,
+        true);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  between_expr);
+    result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_TRUE(valid_view[16]);
+    EXPECT_TRUE(valid_view[17]);
+    EXPECT_TRUE(valid_view[18]);
+    EXPECT_FALSE(result_view[16]);
+    EXPECT_TRUE(result_view[17]);
+    EXPECT_FALSE(result_view[18]);
+}
+
+TEST_F(JsonFlatIndexExprTest, EmptyJsonInIsDeterministicForEveryRow) {
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{},
+        false);
+    auto check = [&](const expr::TypedExprPtr& filter_expr,
+                     bool expected_result) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        auto result = gen_filter_res(
+            plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_TRUE(valid_view[i]) << "row " << i;
+            EXPECT_EQ(result_view[i], expected_result) << "row " << i;
+        }
+    };
+
+    check(term_expr, false);
+    check(std::make_shared<expr::LogicalUnaryExpr>(
+              expr::LogicalUnaryExpr::OpType::LogicalNot, term_expr),
+          true);
+}
+
 TEST_F(JsonFlatIndexExprTest, TestExistsExpr) {
     auto expr = std::make_shared<expr::ExistsExpr>(
         expr::ColumnInfo(json_fid_, DataType::JSON, {""}));
@@ -1065,7 +1173,7 @@ TEST_F(JsonFlatIndexExprTest, TestExistsExpr) {
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
     auto final = query::ExecuteQueryExpr(
         plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
-    EXPECT_EQ(final.count(), 12);
+    EXPECT_EQ(final.count(), 15);
     EXPECT_FALSE(final[5]);
     EXPECT_FALSE(final[7]);
     EXPECT_FALSE(final[14]);

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -311,6 +311,70 @@ TEST(JsonFlatIndexExactPathExistsTest, DistinguishesObjectSubpaths) {
     EXPECT_FALSE(exact_exists[5]);
 }
 
+TEST(JsonFlatIndexExactPathExistsTest, FiltersByComparableTypeFamily) {
+    auto json_index = BuildInMemoryJsonFlatIndex({
+        R"({"a": 1})",
+        R"({"a": 1.5})",
+        R"({"a": "one"})",
+        R"({"a": true})",
+        R"({"a": [2, 3]})",
+        R"({"a": ["two"]})",
+        R"({"a": [false]})",
+        R"({"a": {"b": 1}})",
+        R"({"a": null})",
+        R"({})",
+    });
+
+    std::string json_path = "/a";
+    auto executor = json_index->create_executor<int64_t>(json_path);
+
+    auto any = executor->ExactPathExists(index::JsonValueType::Any);
+    ASSERT_EQ(any.size(), 10);
+    EXPECT_EQ(any.count(), 7);
+    EXPECT_FALSE(any[7]);
+    EXPECT_FALSE(any[8]);
+    EXPECT_FALSE(any[9]);
+
+    auto numeric = executor->ExactPathExists(index::JsonValueType::Numeric);
+    ASSERT_EQ(numeric.size(), 10);
+    EXPECT_TRUE(numeric[0]);
+    EXPECT_TRUE(numeric[1]);
+    EXPECT_FALSE(numeric[2]);
+    EXPECT_FALSE(numeric[3]);
+    EXPECT_TRUE(numeric[4]);
+    EXPECT_FALSE(numeric[5]);
+    EXPECT_FALSE(numeric[6]);
+    EXPECT_FALSE(numeric[7]);
+    EXPECT_FALSE(numeric[8]);
+    EXPECT_FALSE(numeric[9]);
+
+    auto string = executor->ExactPathExists(index::JsonValueType::String);
+    ASSERT_EQ(string.size(), 10);
+    EXPECT_FALSE(string[0]);
+    EXPECT_FALSE(string[1]);
+    EXPECT_TRUE(string[2]);
+    EXPECT_FALSE(string[3]);
+    EXPECT_FALSE(string[4]);
+    EXPECT_TRUE(string[5]);
+    EXPECT_FALSE(string[6]);
+    EXPECT_FALSE(string[7]);
+    EXPECT_FALSE(string[8]);
+    EXPECT_FALSE(string[9]);
+
+    auto boolean = executor->ExactPathExists(index::JsonValueType::Bool);
+    ASSERT_EQ(boolean.size(), 10);
+    EXPECT_FALSE(boolean[0]);
+    EXPECT_FALSE(boolean[1]);
+    EXPECT_FALSE(boolean[2]);
+    EXPECT_TRUE(boolean[3]);
+    EXPECT_FALSE(boolean[4]);
+    EXPECT_FALSE(boolean[5]);
+    EXPECT_TRUE(boolean[6]);
+    EXPECT_FALSE(boolean[7]);
+    EXPECT_FALSE(boolean[8]);
+    EXPECT_FALSE(boolean[9]);
+}
+
 TEST_F(JsonFlatIndexTest, TestComparableAndFieldValidityMasks) {
     auto json_flat_index =
         dynamic_cast<index::JsonFlatIndex*>(json_index_.get());

--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
@@ -4044,6 +4044,7 @@ dependencies = [
  "serde_json",
  "tantivy 0.21.1",
  "tantivy 0.23.0",
+ "tantivy-columnar 0.3.0",
  "tar",
  "tempfile",
  "tokio",

--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
@@ -4044,7 +4044,6 @@ dependencies = [
  "serde_json",
  "tantivy 0.21.1",
  "tantivy 0.23.0",
- "tantivy-columnar 0.3.0",
  "tar",
  "tempfile",
  "tokio",

--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
@@ -25,6 +25,7 @@ overflow-checks = false
 [dependencies]
 tantivy = { git = "https://github.com/zilliztech/tantivy.git" }
 tantivy-5 = { package = "tantivy", git = "https://github.com/zilliztech/tantivy", tag = "0.21.1-fix4" }
+columnar = { package = "tantivy-columnar", git = "https://github.com/zilliztech/tantivy.git" }
 lindera = "0.42.4"
 fs2 = "0.4"
 lindera-dictionary = "0.42.4"

--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
@@ -25,7 +25,6 @@ overflow-checks = false
 [dependencies]
 tantivy = { git = "https://github.com/zilliztech/tantivy.git" }
 tantivy-5 = { package = "tantivy", git = "https://github.com/zilliztech/tantivy", tag = "0.21.1-fix4" }
-columnar = { package = "tantivy-columnar", git = "https://github.com/zilliztech/tantivy.git" }
 lindera = "0.42.4"
 fs2 = "0.4"
 lindera-dictionary = "0.42.4"

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -298,7 +298,10 @@ RustResult tantivy_json_terms_query_keyword(void *ptr,
                                             uintptr_t len,
                                             void *bitset);
 
-RustResult tantivy_json_exist_query(void *ptr, const char *json_path, void *bitset);
+RustResult tantivy_json_exist_query(void *ptr,
+                                    const char *json_path,
+                                    bool json_subpaths,
+                                    void *bitset);
 
 RustResult tantivy_json_range_query_i64(void *ptr,
                                         const char *json_path,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -6,6 +6,13 @@
 #include <ostream>
 #include <new>
 
+enum class JsonExistValueType : uint8_t {
+  Any,
+  Numeric,
+  String,
+  Bool,
+};
+
 enum class TantivyDataType : uint8_t {
   Text,
   Keyword,
@@ -301,6 +308,7 @@ RustResult tantivy_json_terms_query_keyword(void *ptr,
 RustResult tantivy_json_exist_query(void *ptr,
                                     const char *json_path,
                                     bool json_subpaths,
+                                    JsonExistValueType value_type,
                                     void *bitset);
 
 RustResult tantivy_json_range_query_i64(void *ptr,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/data_type.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/data_type.rs
@@ -10,3 +10,12 @@ pub enum TantivyDataType {
     Bool,
     JSON,
 }
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonExistValueType {
+    Any,
+    Numeric,
+    String,
+    Bool,
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
@@ -638,13 +638,18 @@ impl IndexReaderWrapper {
         self.search(&q, bitset)
     }
 
-    pub fn json_exist_query(&self, json_path: &str, bitset: *mut c_void) -> Result<()> {
+    pub fn json_exist_query(
+        &self,
+        json_path: &str,
+        json_subpaths: bool,
+        bitset: *mut c_void,
+    ) -> Result<()> {
         let full_json_path = if json_path == "" {
             self.field_name.clone()
         } else {
             format!("{}.{}", self.field_name, json_path)
         };
-        let q = ExistsQuery::new(full_json_path, true);
+        let q = ExistsQuery::new(full_json_path, json_subpaths);
         self.search(&q, bitset)
     }
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use libc::c_char;
 use tantivy::fastfield::FastValue;
-use tantivy::query::{
-    BooleanQuery, ExistsQuery, Query, RangeQuery, RegexQuery, TermQuery, TermSetQuery,
-};
+use tantivy::query::{BooleanQuery, Query, RangeQuery, RegexQuery, TermQuery, TermSetQuery};
 use tantivy::schema::{Field, IndexRecordOption};
 use tantivy::tokenizer::{NgramTokenizer, TokenStream, Tokenizer};
 use tantivy::{Directory, HasLen, Index, IndexReader, ReloadPolicy, Term};
@@ -19,7 +17,9 @@ use crate::milvus_id_collector::MilvusIdCollector;
 use crate::util::{c_ptr_to_str, make_bounds};
 use crate::vec_collector::VecCollector;
 
+use crate::data_type::JsonExistValueType;
 use crate::error::{Result, TantivyBindingError};
+use crate::json_exists_query::JsonExistsQuery;
 
 // Threshold for batch-in query. Less than this threshold, we use term_query one by one and use
 // TermSetQuery when larger than this threshold. This value is based on some experiments.
@@ -642,6 +642,7 @@ impl IndexReaderWrapper {
         &self,
         json_path: &str,
         json_subpaths: bool,
+        value_type: JsonExistValueType,
         bitset: *mut c_void,
     ) -> Result<()> {
         let full_json_path = if json_path == "" {
@@ -649,7 +650,7 @@ impl IndexReaderWrapper {
         } else {
             format!("{}.{}", self.field_name, json_path)
         };
-        let q = ExistsQuery::new(full_json_path, json_subpaths);
+        let q = JsonExistsQuery::new(full_json_path, json_subpaths, value_type);
         self.search(&q, bitset)
     }
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
@@ -3,6 +3,7 @@ use std::ffi::{c_char, c_void, CStr};
 use crate::{
     array::RustResult,
     convert_to_rust_slice, cstr_to_str,
+    data_type::JsonExistValueType,
     index_reader::IndexReaderWrapper,
     ptr_to_str,
     util::{create_binding, free_binding},
@@ -501,13 +502,14 @@ pub extern "C" fn tantivy_json_exist_query(
     ptr: *mut c_void,
     json_path: *const c_char,
     json_subpaths: bool,
+    value_type: JsonExistValueType,
     bitset: *mut c_void,
 ) -> RustResult {
     let real = ptr as *mut IndexReaderWrapper;
     let json_path = cstr_to_str!(json_path);
     unsafe {
         (*real)
-            .json_exist_query(json_path, json_subpaths, bitset)
+            .json_exist_query(json_path, json_subpaths, value_type, bitset)
             .into()
     }
 }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
@@ -500,11 +500,16 @@ pub extern "C" fn tantivy_json_terms_query_keyword(
 pub extern "C" fn tantivy_json_exist_query(
     ptr: *mut c_void,
     json_path: *const c_char,
+    json_subpaths: bool,
     bitset: *mut c_void,
 ) -> RustResult {
     let real = ptr as *mut IndexReaderWrapper;
     let json_path = cstr_to_str!(json_path);
-    unsafe { (*real).json_exist_query(json_path, bitset).into() }
+    unsafe {
+        (*real)
+            .json_exist_query(json_path, json_subpaths, bitset)
+            .into()
+    }
 }
 
 #[no_mangle]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/json_exists_query.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/json_exists_query.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use columnar::{ColumnIndex, ColumnType, DynamicColumn};
+use tantivy::columnar::{ColumnIndex, ColumnType, DynamicColumn};
 use tantivy::index::SegmentReader;
 use tantivy::query::{ConstScorer, EmptyScorer, EnableScoring, Explanation, Query, Scorer, Weight};
 use tantivy::schema::Type;

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/json_exists_query.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/json_exists_query.rs
@@ -1,0 +1,161 @@
+use core::fmt::Debug;
+
+use columnar::{ColumnIndex, ColumnType, DynamicColumn};
+use tantivy::index::SegmentReader;
+use tantivy::query::{ConstScorer, EmptyScorer, EnableScoring, Explanation, Query, Scorer, Weight};
+use tantivy::schema::Type;
+use tantivy::{DocId, DocSet, Score, TantivyError, TERMINATED};
+
+use crate::data_type::JsonExistValueType;
+
+#[derive(Clone, Debug)]
+pub struct JsonExistsQuery {
+    field_name: String,
+    json_subpaths: bool,
+    value_type: JsonExistValueType,
+}
+
+impl JsonExistsQuery {
+    pub fn new(field_name: String, json_subpaths: bool, value_type: JsonExistValueType) -> Self {
+        Self {
+            field_name,
+            json_subpaths,
+            value_type,
+        }
+    }
+}
+
+impl Query for JsonExistsQuery {
+    fn weight(&self, enable_scoring: EnableScoring) -> tantivy::Result<Box<dyn Weight>> {
+        let schema = enable_scoring.schema();
+        let Some((field, _path)) = schema.find_field(&self.field_name) else {
+            return Err(TantivyError::FieldNotFound(self.field_name.clone()));
+        };
+        let field_type = schema.get_field_entry(field).field_type();
+        if !field_type.is_fast() {
+            return Err(TantivyError::SchemaError(format!(
+                "Field {} is not a fast field.",
+                self.field_name
+            )));
+        }
+        Ok(Box::new(JsonExistsWeight {
+            field_name: self.field_name.clone(),
+            field_type: field_type.value_type(),
+            json_subpaths: self.json_subpaths,
+            value_type: self.value_type,
+        }))
+    }
+}
+
+struct JsonExistsWeight {
+    field_name: String,
+    field_type: Type,
+    json_subpaths: bool,
+    value_type: JsonExistValueType,
+}
+
+impl Weight for JsonExistsWeight {
+    fn scorer(&self, reader: &SegmentReader, boost: Score) -> tantivy::Result<Box<dyn Scorer>> {
+        let fast_field_reader = reader.fast_fields();
+        let mut column_handles = fast_field_reader.dynamic_column_handles(&self.field_name)?;
+        if self.field_type == Type::Json && self.json_subpaths {
+            let mut sub_columns =
+                fast_field_reader.dynamic_subpath_column_handles(&self.field_name)?;
+            column_handles.append(&mut sub_columns);
+        }
+
+        let dynamic_columns: tantivy::Result<Vec<DynamicColumn>> = column_handles
+            .into_iter()
+            .filter(|handle| self.value_type.matches(handle.column_type()))
+            .map(|handle| handle.open().map_err(Into::into))
+            .collect();
+        let non_empty_columns: Vec<DynamicColumn> = dynamic_columns?
+            .into_iter()
+            .filter(|column| !matches!(column.column_index(), ColumnIndex::Empty { .. }))
+            .collect();
+
+        if non_empty_columns.is_empty() {
+            Ok(Box::new(EmptyScorer))
+        } else {
+            let docset = JsonExistsDocSet::new(non_empty_columns, reader.max_doc());
+            Ok(Box::new(ConstScorer::new(docset, boost)))
+        }
+    }
+
+    fn explain(&self, reader: &SegmentReader, doc: DocId) -> tantivy::Result<Explanation> {
+        let mut scorer = self.scorer(reader, 1.0)?;
+        if scorer.seek(doc) != doc {
+            return Err(TantivyError::InvalidArgument(format!(
+                "Document #{doc} does not match"
+            )));
+        }
+        Ok(Explanation::new("JsonExistsQuery", 1.0))
+    }
+}
+
+impl JsonExistValueType {
+    fn matches(self, column_type: ColumnType) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Numeric => matches!(
+                column_type,
+                ColumnType::I64 | ColumnType::U64 | ColumnType::F64
+            ),
+            Self::String => column_type == ColumnType::Str,
+            Self::Bool => column_type == ColumnType::Bool,
+        }
+    }
+}
+
+struct JsonExistsDocSet {
+    columns: Vec<DynamicColumn>,
+    doc: DocId,
+    max_doc: DocId,
+}
+
+impl JsonExistsDocSet {
+    fn new(columns: Vec<DynamicColumn>, max_doc: DocId) -> Self {
+        let mut set = Self {
+            columns,
+            doc: 0,
+            max_doc,
+        };
+        set.find_next();
+        set
+    }
+
+    fn find_next(&mut self) -> DocId {
+        while self.doc < self.max_doc {
+            if self
+                .columns
+                .iter()
+                .any(|column| column.column_index().has_value(self.doc))
+            {
+                return self.doc;
+            }
+            self.doc += 1;
+        }
+        self.doc = TERMINATED;
+        TERMINATED
+    }
+}
+
+impl DocSet for JsonExistsDocSet {
+    fn advance(&mut self) -> DocId {
+        self.seek(self.doc + 1)
+    }
+
+    fn size_hint(&self) -> u32 {
+        0
+    }
+
+    fn doc(&self) -> DocId {
+        self.doc
+    }
+
+    #[inline(always)]
+    fn seek(&mut self, target: DocId) -> DocId {
+        self.doc = target;
+        self.find_next()
+    }
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/lib.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/lib.rs
@@ -22,6 +22,7 @@ mod index_writer_text;
 mod index_writer_text_c;
 mod index_writer_v5;
 mod index_writer_v7;
+mod json_exists_query;
 mod log;
 mod log_c;
 mod milvus_id_collector;

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -1395,9 +1395,10 @@ struct TantivyIndexWrapper {
     void
     json_exist_query(const std::string& json_path,
                      bool json_subpaths,
+                     JsonExistValueType value_type,
                      void* bitset) {
         auto array = tantivy_json_exist_query(
-            reader_, json_path.c_str(), json_subpaths, bitset);
+            reader_, json_path.c_str(), json_subpaths, value_type, bitset);
         auto res = RustResultWrapper(array);
         AssertInfo(res.result_->success,
                    "TantivyIndexWrapper.json_exist_query: {}",

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -1393,9 +1393,11 @@ struct TantivyIndexWrapper {
     }
 
     void
-    json_exist_query(const std::string& json_path, void* bitset) {
-        auto array =
-            tantivy_json_exist_query(reader_, json_path.c_str(), bitset);
+    json_exist_query(const std::string& json_path,
+                     bool json_subpaths,
+                     void* bitset) {
+        auto array = tantivy_json_exist_query(
+            reader_, json_path.c_str(), json_subpaths, bitset);
         auto res = RustResultWrapper(array);
         AssertInfo(res.result_->success,
                    "TantivyIndexWrapper.json_exist_query: {}",

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -1318,12 +1318,33 @@ struct TantivyIndexWrapper {
                     free_rust_result(res_u64);
                 }
 
-                // Also query as f64 since JSON doesn't distinguish int/float
-                std::vector<double> f64_values(n);
-                for (size_t i = 0; i < n; ++i)
-                    f64_values[i] = static_cast<double>(values[i]);
-                return tantivy_json_terms_query_f64(
-                    reader_, json_path.c_str(), f64_values.data(), n, bitset);
+                // Query f64 only when the integer round-trips exactly. JSON
+                // numeric equality is cross-type, but a lossy conversion here
+                // would alias adjacent integers above 2^53.
+                std::vector<double> f64_values;
+                f64_values.reserve(n);
+                for (size_t i = 0; i < n; ++i) {
+                    const auto value_as_double = static_cast<double>(values[i]);
+                    if constexpr (std::is_signed_v<T>) {
+                        if (can_cast_double_to_i64(value_as_double) &&
+                            static_cast<int64_t>(value_as_double) ==
+                                static_cast<int64_t>(values[i])) {
+                            f64_values.push_back(value_as_double);
+                        }
+                    } else if (can_cast_double_to_u64(value_as_double) &&
+                               static_cast<uint64_t>(value_as_double) ==
+                                   static_cast<uint64_t>(values[i])) {
+                        f64_values.push_back(value_as_double);
+                    }
+                }
+                double empty_f64_value = 0;
+                const auto* f64_data =
+                    f64_values.empty() ? &empty_f64_value : f64_values.data();
+                return tantivy_json_terms_query_f64(reader_,
+                                                    json_path.c_str(),
+                                                    f64_data,
+                                                    f64_values.size(),
+                                                    bitset);
             }
 
             if constexpr (std::is_floating_point_v<T>) {


### PR DESCRIPTION
## Summary

- add `json_subpaths` support to Tantivy `json_exist_query`
- expose exact-path existence through `ExistsQuery(..., false)`
- use a contains-specific `JsonExactPath` validity mode for actual JSON-flat executors
- keep contains hit lookup through `In()` while using exact-path non-null-leaf validity

## Semantics

- NULL, missing paths, JSON null, and object-only paths remain UNKNOWN
- `NOT UNKNOWN` remains UNKNOWN
- scalar values and non-empty arrays preserve current flattened contains behavior
- empty arrays remain the documented limitation

## Verification

- `JsonFlatIndex*`: 25/25 passed
- `*JsonContains*`: 597/597 passed
- `cargo fmt --check`
- clang-format dry-run on changed non-generated C++ files
- `git diff --check`

## Benchmark

For scalar-benchmark `json_array_operations/base/A01_contains_flat_array/json_flat` with 1M rows and 2 matches:

- first query: 24.945 ms
- average: 24.625 ms
- P50/P99: 24.525/24.607 ms
- current local master: approximately 1114/1119 ms P50/P99

issue: #51234
