### PR TITLE
test: enable FileResource regression cases for closed issues

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_file_resource.py
+++ b/tests/python_client/milvus_client/test_milvus_client_file_resource.py
@@ -1710,12 +1710,6 @@ class TestMilvusClientFileResourceContent(FileResourceTestBase):
         self.add_file_resource(client, res_name, remote)
         self.remove_file_resource(client, res_name)
 
-    @pytest.mark.xfail(
-        reason="https://github.com/milvus-io/milvus/issues/49684: "
-        "UTF-8 BOM is not stripped from first line of stop-words file, "
-        "so the first stop word (`\\ufeff的`) fails to match `的` and leaks through.",
-        strict=False,
-    )
     @pytest.mark.tags(CaseLabel.L2)
     def test_file_with_bom_and_crlf(self, file_resource_env):
         """
@@ -1829,7 +1823,6 @@ class TestMilvusClientFileResourceLifecycleAdvanced(FileResourceTestBase):
 
             assert self.wait_until(_ok, timeout=30, interval=1), f"{name} still in-use after collection drop"
 
-    @pytest.mark.skip(reason="https://github.com/milvus-io/milvus/issues/49279")
     @pytest.mark.tags(CaseLabel.L2)
     def test_drop_collection_then_remove_remote_resources_no_panic(self, file_resource_env):
         """


### PR DESCRIPTION
## What changed

- Remove the stale `xfail` marker from `test_file_with_bom_and_crlf`, which covers the UTF-8 BOM regression tracked by [#49684](https://github.com/milvus-io/milvus/issues/49684) and fixed by [#49691](https://github.com/milvus-io/milvus/pull/49691).
- Remove the stale `skip` marker from `test_drop_collection_then_remove_remote_resources_no_panic`, which covers the FileResource lifecycle panic tracked by [#49279](https://github.com/milvus-io/milvus/issues/49279) and fixed by [#49412](https://github.com/milvus-io/milvus/pull/49412).

Both issues are closed. This change makes the existing cases active CI regressions; it does not change their fixtures, test bodies, assertions, or server behavior.

## User impact

CI will now detect regressions where stop-word files with a UTF-8 BOM are parsed incorrectly, or where dropping a collection and removing its remote analyzer resources can panic the server.

## Validation

The existing cases were previously run against the latest `upstream/master` commit `03762320e8537f855c18c28133834bf292b45361` using image `harbor.milvus.io/manta/milvus:master-20260710-0376232`. The `-p no:skipping` option only bypassed pytest's skip/xfail marker handling; no case code, fixture, or assertion was changed:

```bash
python -W ignore -m pytest -v -p no:skipping \
  milvus_client/test_milvus_client_file_resource.py::TestMilvusClientFileResourceContent::test_file_with_bom_and_crlf \
  milvus_client/test_milvus_client_file_resource.py::TestMilvusClientFileResourceLifecycleAdvanced::test_drop_collection_then_remove_remote_resources_no_panic \
  --host <temporary-milvus-host> --port 19530 --token 'root:Milvus' \
  --minio_host <temporary-minio-host> --minio_bucket fr-closed-issues-master \
  --tb=short
```

Result: `2 passed in 2.16s`.

The #49279 case was then repeated ten times with the same marker bypass:

```bash
python -W ignore -m pytest -q -p no:skipping \
  milvus_client/test_milvus_client_file_resource.py::TestMilvusClientFileResourceLifecycleAdvanced::test_drop_collection_then_remove_remote_resources_no_panic \
  --count=10 \
  --host <temporary-milvus-host> --port 19530 --token 'root:Milvus' \
  --minio_host <temporary-minio-host> --minio_bucket fr-closed-issues-master \
  --tb=short
```

Result: `10 passed in 14.59s`. Milvus remained healthy, pod restart count was zero, and logs contained no panic, `tokenizer.h:31`, fatal error, or segmentation fault. The temporary validation instance has been cleaned up.

The two node IDs also collect successfully after removing the markers:

```bash
python -W ignore -m pytest --collect-only -q \
  milvus_client/test_milvus_client_file_resource.py::TestMilvusClientFileResourceContent::test_file_with_bom_and_crlf \
  milvus_client/test_milvus_client_file_resource.py::TestMilvusClientFileResourceLifecycleAdvanced::test_drop_collection_then_remove_remote_resources_no_panic
```

Result: `2 tests collected in 0.09s`.
