### PR TITLE
fix: fix ngram index UTF-8 literal length checks [2.6]

### DIFF
--- a/internal/core/src/index/NgramInvertedIndex.cpp
+++ b/internal/core/src/index/NgramInvertedIndex.cpp
@@ -58,6 +58,11 @@ const JsonCastType JSON_CAST_TYPE = JsonCastType::FromString("VARCHAR");
 const JsonCastFunction JSON_CAST_FUNCTION =
     JsonCastFunction::FromString("unknown");
 
+inline size_t
+Utf8LiteralLength(const std::string& literal) {
+    return Utf8CharCount(literal.data(), literal.size());
+}
+
 // for string/varchar type
 NgramInvertedIndex::NgramInvertedIndex(const storage::FileManagerContext& ctx,
                                        const NgramParams& params)
@@ -307,7 +312,8 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
                                  exec::SegmentExpr* segment) {
     tracer::AutoSpan span(
         "NgramInvertedIndex::ExecuteQuery", tracer::GetRootSpan(), true);
-    if (literal.length() < min_gram_) {
+    auto literal_char_count = Utf8LiteralLength(literal);
+    if (literal_char_count < min_gram_) {
         return std::nullopt;
     }
 
@@ -317,10 +323,10 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
         case proto::plan::OpType::InnerMatch: {
             span.GetSpan()->SetAttribute("op_type", "InnerMatch");
             span.GetSpan()->SetAttribute("query_literal_length",
-                                         static_cast<int>(literal.length()));
+                                         static_cast<int>(literal_char_count));
             span.GetSpan()->SetAttribute("min_gram", min_gram_);
             span.GetSpan()->SetAttribute("max_gram", max_gram_);
-            bool need_post_filter = literal.length() > max_gram_;
+            bool need_post_filter = literal_char_count > max_gram_;
 
             if (schema_.data_type() == proto::schema::DataType::JSON) {
                 auto predicate = [&literal, this](const milvus::Json& data) {
@@ -347,7 +353,7 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
         case proto::plan::OpType::PrefixMatch: {
             span.GetSpan()->SetAttribute("op_type", "PrefixMatch");
             span.GetSpan()->SetAttribute("query_literal_length",
-                                         static_cast<int>(literal.length()));
+                                         static_cast<int>(literal_char_count));
             span.GetSpan()->SetAttribute("min_gram", min_gram_);
             span.GetSpan()->SetAttribute("max_gram", max_gram_);
             if (schema_.data_type() == proto::schema::DataType::JSON) {
@@ -380,7 +386,7 @@ NgramInvertedIndex::ExecuteQuery(const std::string& literal,
         case proto::plan::OpType::PostfixMatch: {
             span.GetSpan()->SetAttribute("op_type", "PostfixMatch");
             span.GetSpan()->SetAttribute("query_literal_length",
-                                         static_cast<int>(literal.length()));
+                                         static_cast<int>(literal_char_count));
             span.GetSpan()->SetAttribute("min_gram", min_gram_);
             span.GetSpan()->SetAttribute("max_gram", max_gram_);
             if (schema_.data_type() == proto::schema::DataType::JSON) {
@@ -508,14 +514,14 @@ NgramInvertedIndex::MatchQuery(const std::string& literal,
                                exec::SegmentExpr* segment) {
     if (auto root_span = tracer::GetRootSpan()) {
         root_span->SetAttribute("match_query_literal_length",
-                                static_cast<int>(literal.length()));
+                                static_cast<int>(Utf8LiteralLength(literal)));
         root_span->SetAttribute("match_query_min_gram", min_gram_);
         root_span->SetAttribute("match_query_max_gram", max_gram_);
     }
     TargetBitmap bitset(static_cast<size_t>(Count()), true);
     auto literals = split_by_wildcard(literal);
     for (const auto& l : literals) {
-        if (l.length() < min_gram_) {
+        if (Utf8LiteralLength(l) < min_gram_) {
             return std::nullopt;
         }
         TargetBitmap tmp_bitset(static_cast<size_t>(Count()), false);

--- a/internal/core/src/index/NgramInvertedIndexTest.cpp
+++ b/internal/core/src/index/NgramInvertedIndexTest.cpp
@@ -95,6 +95,38 @@ struct LikePatternMatcher : public RegexMatcher {
         : RegexMatcher(translate_pattern_match_to_regex(pattern)) {
     }
 };
+
+std::unique_ptr<index::NgramInvertedIndex>
+CreateNgramIndexForExecuteQuery(uintptr_t min_gram = 2,
+                                uintptr_t max_gram = 4) {
+    int64_t collection_id = 1;
+    int64_t partition_id = 2;
+    int64_t segment_id = 3;
+    int64_t index_build_id = 4000;
+    int64_t index_version = 4000;
+
+    auto schema = std::make_shared<Schema>();
+    auto field_id = schema->AddDebugField("ngram", DataType::VARCHAR);
+
+    auto field_meta = milvus::segcore::gen_field_meta(collection_id,
+                                                      partition_id,
+                                                      segment_id,
+                                                      field_id.get(),
+                                                      DataType::VARCHAR,
+                                                      DataType::NONE,
+                                                      false);
+    auto index_meta = gen_index_meta(
+        segment_id, field_id.get(), index_build_id, index_version);
+
+    auto storage_config = gen_local_storage_config(TestLocalPath);
+    auto cm = CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
+    storage::FileManagerContext ctx(field_meta, index_meta, cm, fs);
+
+    auto ngram_params = index::NgramParams{
+        .loading_index = true, .min_gram = min_gram, .max_gram = max_gram};
+    return std::make_unique<index::NgramInvertedIndex>(ctx, ngram_params);
+}
 }  // namespace
 
 void
@@ -1514,6 +1546,24 @@ TEST(NgramPatternMatchConsistency, UTF8Patterns) {
 
         // Test with ngram index
         test_ngram_with_data(test_data, pattern, op_type, expected_results);
+    }
+}
+
+TEST(NgramPatternMatchConsistency, ExecuteQueryUsesUtf8CharacterCount) {
+    auto ngram_index = CreateNgramIndexForExecuteQuery(2, 4);
+
+    std::vector<std::pair<std::string, proto::plan::OpType>> short_literals = {
+        {"测", proto::plan::OpType::InnerMatch},
+        {"测", proto::plan::OpType::PrefixMatch},
+        {"测", proto::plan::OpType::PostfixMatch},
+        {"%测%", proto::plan::OpType::Match},
+    };
+
+    for (const auto& [literal, op_type] : short_literals) {
+        EXPECT_FALSE(ngram_index->ExecuteQuery(literal, op_type, nullptr)
+                         .has_value())
+            << "literal=\"" << literal
+            << "\", op_type=" << static_cast<int>(op_type);
     }
 }
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/42053
pr: https://github.com/milvus-io/milvus/pull/51238

This PR fixes ngram index eligibility checks for UTF-8 literals by using character count instead of byte length in the C++ gate and phase1 validation. It also adds regression coverage for short multibyte literals to ensure they correctly fall back instead of being sent to Tantivy ngram queries.