### PR TITLE
enhance: increase external segment target and timeout

### DIFF
--- a/docs/design-docs/design_docs/20260105-external_table.md
+++ b/docs/design-docs/design_docs/20260105-external_table.md
@@ -1038,21 +1038,29 @@ Final Segments: [S1, S3, S6, S7]
 
 ### 7.8 Fragment to Segment Organization
 
-The `balanceFragmentsToSegments` function organizes orphan fragments into balanced segments:
+The `balanceFragmentsToSegments` function organizes orphan fragments into
+balanced segments. External files are first split into stable fragments of at
+most 1,000,000 rows. Keeping this fragment boundary independent from the
+segment target preserves fragment identity across configuration-default
+changes.
 
 ```go
-func (t *UpdateExternalTask) balanceFragmentsToSegments(
+func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(
     ctx context.Context,
-    fragments []exttable.Fragment,
+    fragments []packed.Fragment,
 ) ([]*datapb.SegmentInfo, error) {
     // 1. Calculate total rows
-    // 2. Determine target rows per segment (default: 1M rows)
+    // 2. Determine target rows per segment (default: 5M rows)
     // 3. Sort fragments by row count descending
     // 4. Greedy bin-packing: assign each fragment to bin with lowest row count
     // 5. Create manifest for each segment
     // 6. Return SegmentInfo list
 }
 ```
+
+The configured row count is a grouping target rather than a strict upper
+bound. Fragment sizes and greedy bin packing can produce segments above or
+below the target.
 
 ---
 
@@ -1100,7 +1108,8 @@ func ReadFragmentsFromManifest(
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `external.collection.target.rows.per.segment` | Target rows per segment | 1,000,000 |
+| `dataNode.externalCollection.targetRowsPerSegment` | Target rows for newly created external segments | 5,000,000 |
+| `dataCoord.externalCollectionJobTimeout` | Overall refresh job timeout; also bounds external source exploration | 86,400 seconds (24 hours) |
 | `external.collection.worker.pool.size` | DataNode worker pool size | 4 |
 | `external.collection.job.retention.duration` | How long to keep completed/failed jobs | 24h |
 | `external.collection.job.max.concurrent` | Max concurrent refresh jobs | 2 |

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -256,8 +256,6 @@ func (t *RefreshExternalCollectionTask) fetchFragmentsFromExternalSource(ctx con
 		mlog.Int64("fileIndexBegin", t.req.GetFileIndexBegin()),
 		mlog.Int64("fileIndexEnd", t.req.GetFileIndexEnd()))
 
-	targetRowsPerSegment := paramtable.Get().DataNodeCfg.ExternalCollectionTargetRowsPerSegment.GetAsInt64()
-
 	return packed.FetchFragmentsFromExternalSourceWithRange(
 		ctx,
 		t.parsedSpec.Format,
@@ -270,7 +268,7 @@ func (t *RefreshExternalCollectionTask) fetchFragmentsFromExternalSource(ctx con
 		packed.ExternalFetchOptions{
 			CollectionID: t.req.GetCollectionID(),
 			ExternalSpec: t.req.GetExternalSpec(),
-			RowLimit:     targetRowsPerSegment,
+			RowLimit:     int64(packed.DefaultFragmentRowLimit),
 		},
 	)
 }

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -405,6 +405,58 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_Mult
 	}
 }
 
+func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_DefaultFiveMillionTarget() {
+	paramtable.Init()
+
+	ctx := context.Background()
+	req := &datapb.RefreshExternalCollectionTaskRequest{
+		CollectionID:           s.collectionID,
+		TaskID:                 s.taskID,
+		PreAllocatedSegmentIds: &datapb.IDRange{Begin: 100, End: 200},
+		StorageConfig:          &indexpb.StorageConfig{StorageType: "local"},
+		ExternalSource:         "s3://bucket/data/",
+		ExternalSpec:           `{"format":"parquet"}`,
+		Schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{{
+				FieldID:       100,
+				Name:          "text",
+				ExternalField: "text_col",
+			}},
+		},
+	}
+
+	task := NewRefreshExternalCollectionTask(ctx, req)
+	task.preallocatedIDRange = req.GetPreAllocatedSegmentIds()
+	task.nextAllocID = task.preallocatedIDRange.Begin
+	task.parsedSpec = &externalspec.ExternalSpec{Format: "parquet"}
+
+	manifestMock := mockey.Mock(packed.CreateSegmentManifestWithBasePathAndExtfs).
+		Return("manifest.json", nil).Build()
+	defer manifestMock.UnPatch()
+
+	sampleMock := mockey.Mock(packed.SampleExternalFieldSizes).
+		Return(map[string]int64{"text_col": 100}, nil).Build()
+	defer sampleMock.UnPatch()
+
+	fragments := make([]packed.Fragment, 20)
+	for i := range fragments {
+		fragments[i] = packed.Fragment{
+			FragmentID: int64(i),
+			FilePath:   fmt.Sprintf("f%d.parquet", i),
+			StartRow:   0,
+			EndRow:     int64(packed.DefaultFragmentRowLimit),
+			RowCount:   int64(packed.DefaultFragmentRowLimit),
+		}
+	}
+
+	segments, err := task.balanceFragmentsToSegments(ctx, fragments)
+	s.NoError(err)
+	s.Len(segments, 4)
+	for _, segment := range segments {
+		s.Equal(int64(5000000), segment.GetNumOfRows())
+	}
+}
+
 func (s *RefreshExternalCollectionTaskSuite) TestPreExecuteContextCanceled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -2785,6 +2837,57 @@ func (s *RefreshExternalCollectionTaskSuite) TestFetchFragmentsFromExternalSourc
 	frags, err := task.fetchFragmentsFromExternalSource(ctx)
 	s.NoError(err)
 	s.Len(frags, 1)
+}
+
+func (s *RefreshExternalCollectionTaskSuite) TestFetchFragmentsFromExternalSource_UsesStableFragmentRowLimit() {
+	paramtable.Init()
+	key := paramtable.Get().DataNodeCfg.ExternalCollectionTargetRowsPerSegment.Key
+	paramtable.Get().Save(key, "10000000")
+	defer paramtable.Get().Reset(key)
+
+	ctx := context.Background()
+	req := &datapb.RefreshExternalCollectionTaskRequest{
+		CollectionID:        s.collectionID,
+		TaskID:              s.taskID,
+		ExternalSource:      "s3:///bucket/path",
+		ExternalSpec:        `{"format":"parquet"}`,
+		ExploreManifestPath: "/manifests/explore.json",
+		FileIndexBegin:      0,
+		FileIndexEnd:        1,
+		StorageConfig: &indexpb.StorageConfig{
+			StorageType: "local",
+			BucketName:  "/tmp",
+		},
+	}
+	task := NewRefreshExternalCollectionTask(ctx, req)
+	task.parsedSpec = &externalspec.ExternalSpec{Format: "parquet"}
+	task.columns = []string{"col1"}
+
+	mockFetch := mockey.Mock(packed.FetchFragmentsFromExternalSourceWithRange).
+		To(func(
+			ctx context.Context,
+			format string,
+			columns []string,
+			externalSource string,
+			storageConfig *indexpb.StorageConfig,
+			fileIndexBegin, fileIndexEnd int64,
+			exploreManifestPath string,
+			opts packed.ExternalFetchOptions,
+		) ([]packed.Fragment, error) {
+			s.Equal(int64(packed.DefaultFragmentRowLimit), opts.RowLimit)
+			return []packed.Fragment{{
+				FragmentID: 0,
+				FilePath:   "f1.parquet",
+				StartRow:   0,
+				EndRow:     1000,
+				RowCount:   1000,
+			}}, nil
+		}).Build()
+	defer mockFetch.UnPatch()
+
+	fragments, err := task.fetchFragmentsFromExternalSource(ctx)
+	s.NoError(err)
+	s.Len(fragments, 1)
 }
 
 func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_CreateManifestError() {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6647,7 +6647,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 		Key:          "dataCoord.externalCollectionJobTimeout",
 		Version:      "2.6.8",
 		Doc:          "The timeout in seconds for external collection refresh jobs. Jobs exceeding this duration will be marked as failed.",
-		DefaultValue: "3600",
+		DefaultValue: "86400",
 		PanicIfEmpty: false,
 	}
 	p.ExternalCollectionJobTimeout.Init(base.mgr)
@@ -7522,7 +7522,7 @@ if this parameter <= 0, will set it as 10`,
 	p.ExternalCollectionTargetRowsPerSegment = ParamItem{
 		Key:          "dataNode.externalCollection.targetRowsPerSegment",
 		Version:      "3.0.0",
-		DefaultValue: "1000000",
+		DefaultValue: "5000000",
 		Doc:          "Target number of rows per segment for external collections",
 		Export:       false,
 	}

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -980,7 +980,8 @@ func TestCachedParam(t *testing.T) {
 
 	assert.Equal(t, int32(16), params.DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
 	assert.Equal(t, int32(16), params.DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
-	assert.Equal(t, int64(1000000), params.DataNodeCfg.ExternalCollectionTargetRowsPerSegment.GetAsInt64())
+	assert.Equal(t, int64(5000000), params.DataNodeCfg.ExternalCollectionTargetRowsPerSegment.GetAsInt64())
+	assert.Equal(t, 24*time.Hour, params.DataCoordCfg.ExternalCollectionJobTimeout.GetAsDuration(time.Second))
 
 	assert.Equal(t, uint(100000), params.CommonCfg.BloomFilterSize.GetAsUint())
 	assert.Equal(t, uint(100000), params.CommonCfg.BloomFilterSize.GetAsUint())


### PR DESCRIPTION
issue: #45881

## What changed

- Keep external fragments capped at one million rows so fragment
  identities remain stable across configuration changes.
- Increase
  `dataNode.externalCollection.targetRowsPerSegment` from 1,000,000
  to 5,000,000.
- Increase `dataCoord.externalCollectionJobTimeout` from one hour to
  24 hours. The same timeout also bounds external source exploration.
- Add regression coverage and update the external table design.

## Why

The previous segment target created too many small external segments.
Using the segment target as the fragment split limit also meant that
raising the default would change fragment identities and rebuild
unchanged source data.

Large external refreshes may also exceed the previous one-hour job
timeout while exploring or processing large sources.

## Compatibility

Existing unchanged segments are not forcibly reorganized. Newly
created or rebuilt segments use the five-million-row target.

The timeout key and its seconds-based configuration format remain
unchanged. The upstream pre-allocation default remains 500,000 IDs.

## Validation

- `make milvus`
- Targeted RED/GREEN tests for the five-million-row default
- Full `pkg/v3/util/paramtable` tests with race and coverage
- Full `internal/datanode/external` tests with race and coverage
- `TestExternalCollectionRefreshChecker_TryTimeoutJob`
- `make lint-fix`
- `git diff --check`
- No proto changes
- No new mockery usage
