### PR TITLE
fix: protect sealed segment when delegator view is ahead of current target

### DIFF
--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -467,9 +467,18 @@ func (c *SegmentChecker) filterOutSegmentInUse(ctx context.Context, replica *met
 		// if delegator has valid target version, and before it update to latest readable version, skip release it's sealed segment
 		for _, delegator := range delegatorList {
 			// Notice: if syncTargetVersion stuck, segment on delegator won't be released
-			readableVersionNotUpdate := delegator.View.TargetVersion != initialTargetVersion && delegator.View.TargetVersion < currentTargetVersion
-			if partition != nil && readableVersionNotUpdate {
-				// leader view version hasn't been updated, segment maybe still in use
+			// Protect the segment whenever the delegator's readable target version differs
+			// from the current target version, in EITHER direction:
+			//   - view < current: delegator lags, hasn't caught up to current yet (original case)
+			//   - view > current: delegator's readable view is AHEAD of current (promote race,
+			//     e.g. an out-of-band UpdateCollectionNextTarget on a load failure). The segment
+			//     may still be in the delegator's readable set; releasing it drops loadedRatio
+			//     below 1.0 and makes the shard unserviceable.
+			// Only release when view == current, where the delegator's readable set already
+			// matches current and the redundant segment is provably not in use.
+			readableVersionMismatch := delegator.View.TargetVersion != initialTargetVersion && delegator.View.TargetVersion != currentTargetVersion
+			if partition != nil && readableVersionMismatch {
+				// leader view version differs from current, segment maybe still in use
 				stillInUseByDelegator = true
 				break
 			}

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -470,10 +470,12 @@ func (c *SegmentChecker) filterOutSegmentInUse(ctx context.Context, replica *met
 			// Protect the segment whenever the delegator's readable target version differs
 			// from the current target version, in EITHER direction:
 			//   - view < current: delegator lags, hasn't caught up to current yet (original case)
-			//   - view > current: delegator's readable view is AHEAD of current (promote race,
-			//     e.g. an out-of-band UpdateCollectionNextTarget on a load failure). The segment
-			//     may still be in the delegator's readable set; releasing it drops loadedRatio
-			//     below 1.0 and makes the shard unserviceable.
+			//   - view > current: the target was synced to this delegator but the current-target
+			//     promote was withheld because another delegator was not ready, so the readable
+			//     view runs ahead of current while next churns further ahead. The segment can
+			//     then be absent from both current and next yet still be in this delegator's
+			//     readable set; releasing it drops loadedRatio below 1.0 and makes the shard
+			//     unserviceable.
 			// Only release when view == current, where the delegator's readable set already
 			// matches current and the redundant segment is provably not in use.
 			readableVersionMismatch := delegator.View.TargetVersion != initialTargetVersion && delegator.View.TargetVersion != currentTargetVersion

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -1253,6 +1253,54 @@ func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentInUse() {
 	suite.Len(result, 0, "Should release all segments when partition is nil")
 }
 
+// TestFilterOutSegmentAheadOfCurrent covers the promote-race case where a delegator's
+// readable target version is AHEAD of the current target version (view > current).
+// In that state the redundant segment may still be part of the delegator's readable set,
+// so releasing it would drop loadedRatio below 1.0 and make the shard unserviceable.
+// The segment must be protected (filtered out of the release set) until the versions
+// reconcile, exactly like the view < current lagging case.
+func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentAheadOfCurrent() {
+	ctx := context.Background()
+	checker := suite.checker
+
+	collectionID := int64(1)
+	partitionID := int64(1)
+	segmentID := int64(1)
+	nodeID := int64(1)
+	channel := "test-insert-channel"
+
+	checker.meta.PutCollection(ctx, utils.CreateTestCollection(collectionID, 1))
+	checker.meta.PutPartition(ctx, utils.CreateTestPartition(collectionID, partitionID))
+	replica := utils.CreateTestReplica(1, collectionID, []int64{nodeID})
+
+	channels := []*datapb.VchannelInfo{
+		{CollectionID: collectionID, ChannelName: channel},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(
+		channels, []*datapb.SegmentInfo{}, nil).Maybe()
+	checker.targetMgr.UpdateCollectionCurrentTarget(ctx, collectionID)
+	currentTargetVersion := checker.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.CurrentTarget)
+
+	// delegator readable view is ahead of current (promote race)
+	leaderView := utils.CreateTestLeaderView(nodeID, collectionID, channel,
+		map[int64]int64{}, map[int64]*meta.Segment{})
+	leaderView.TargetVersion = currentTargetVersion + 1
+	checker.dist.ChannelDistManager.Update(nodeID, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channel},
+		Node:         nodeID,
+		View:         leaderView,
+	})
+
+	seg := utils.CreateTestSegment(collectionID, partitionID, segmentID, nodeID, 1, channel)
+	delegatorList := checker.dist.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica))
+	ch2DelegatorList := lo.GroupBy(delegatorList, func(d *meta.DmChannel) string {
+		return d.View.Channel
+	})
+
+	result := checker.filterOutSegmentInUse(ctx, replica, []*meta.Segment{seg}, ch2DelegatorList)
+	suite.Len(result, 0, "Segment must be protected when delegator view is ahead of current target")
+}
+
 func (suite *SegmentCheckerTestSuite) TestReopenOnStaleDataVersion() {
 	ctx := context.Background()
 	checker := suite.checker


### PR DESCRIPTION
## Summary

Under compaction churn combined with throttled/lagging segment loading, `SegmentChecker.filterOutSegmentInUse` can release a sealed segment that a shard delegator is still serving. `loadedRatio` drops below `1.0`, the shard becomes unserviceable, and cross-shard queries and non-PK-expression deletes fail with a retriable `ChannelNotAvailable` (`code=106`) until the delegator advances its readable view.

### Root cause

A delegator serves reads from a snapshot pinned to a target version. The checker treats a sealed segment as *redundant* when it is absent from **both** the current and the next target, and `filterOutSegmentInUse` then decides whether releasing it is safe. The in-use guard only protected the segment when the delegator's readable version **lagged** the current target version:

```go
readableVersionNotUpdate := view.TargetVersion != initialTargetVersion && view.TargetVersion < currentTargetVersion
```

It misses the symmetric case where the readable view is **ahead of** current — the strict straddle `current < view < next`. That state is not an exotic race; on branches without the next-target pin (#50686) it forms deterministically whenever one shard cannot keep up with segment loading:

1. The target observer syncs the target to the delegators that *are* ready, but withholds the current-target promote because one delegator is not (`lo.Filter` + `lo.Every`). The ready delegators' views move up; **current stays behind**.
2. Compaction churn (and next-target refresh on expiry) keeps moving **next** ahead of those views.
3. A segment can now be absent from both current and next while still being in a delegator's readable set at the intermediate version. The `<` guard does not fire, the segment is released, `loadedRatio` drops below 1.0, and the shard goes unserviceable — which in turn keeps the current target frozen, so the state is self-sustaining rather than a transient blip.

### Fix

Protect the segment whenever the delegator's readable target version **differs** from the current target version in *either* direction, releasing only at `view == current`, where the delegator's readable set provably matches current and the redundant segment is not in it:

```go
readableVersionMismatch := view.TargetVersion != initialTargetVersion && view.TargetVersion != currentTargetVersion
```

This keeps the original lagging-delegator protection and adds symmetric protection for the ahead-of-current case. It does not block legitimate cleanup: at `view == current` (the steady state) redundant segments are still released as before, so there is no over-retention / memory regression.

issue: #51260

## Test Plan

- [x] `TestSegmentCheckerSuite/TestFilterOutSegmentAheadOfCurrent` — new regression test constructing `view > current`: **fails on the old `<` comparison** (segment wrongly released), **passes with `!=`**.
- [x] `TestSegmentCheckerSuite/TestFilterOutSegmentInUse` — existing cases (`view < current`, `view == current`, initial version, multi-delegator, nil partition) still pass.
- [x] Full `internal/querycoordv2/checkers/...` package green.
- [x] **End-to-end on a real cluster, zero code injection** — full Milvus built from a 2.6-based branch, 4 shards, normal client traffic, with segment-load concurrency throttled to 1 (`queryNodeTaskParallelismFactor: 0.02`, a value seen in production). A/B on the **same binary / config / workload**, 700s each, switching only this comparison:

  | metric | guard `<` | guard `!=` |
  |---|---|---|
  | trigger present (`segment lacks`, delegator not ready) | 178 | **155 — still firing** |
  | strict straddle `current<view<next`, segment released | **3895** | **0** |
  | delegator unserviceable events | 1985 | **0** |
  | `code=106` | 1933 | **0 client-visible failures** |
  | delete failures (non-PK expression) | **26** | **0** |
  | redundant segments still reclaimed | yes | **yes — 26,440 releases, all at `view == current`** |

  Details in the comment below.

## Landing order

The strict straddle is live on `2.6` / branches without #50686's next-target pin. On current `master` the pin keeps `view` equal to either `current` or `next`, so the straddle cannot form and this guard is hardening — **until #51307 lands**, which lets an expired next target be refreshed while a not-serviceable delegator still holds an older view. That reopens exactly this window, so **#51307 / #51264 should land after — or together with — this PR.**
