### PR TITLE
enhance: cache json flat validity bitmaps

### DIFF
--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -123,31 +123,41 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
 
             if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
                 if (is_numeric) {
-                    // Convert both bounds to double for index path
-                    proto::plan::GenericValue double_lower_val;
-                    if (lower_type ==
-                        proto::plan::GenericValue::ValCase::kInt64Val) {
-                        double_lower_val.set_float_val(
-                            static_cast<double>(expr_->lower_val_.int64_val()));
+                    const auto has_unsafe_int_bound =
+                        !use_double && (!IsInt64SafeForJsonDoubleIndex(
+                                            expr_->lower_val_.int64_val()) ||
+                                        !IsInt64SafeForJsonDoubleIndex(
+                                            expr_->upper_val_.int64_val()));
+                    if (has_unsafe_int_bound) {
+                        result = ExecRangeVisitorImplForJson<int64_t>(context);
+                    } else if (!use_double && PinnedJsonIndexIsFlat()) {
+                        result = ExecRangeVisitorImplForIndex<int64_t>();
                     } else {
-                        double_lower_val.set_float_val(
-                            expr_->lower_val_.float_val());
-                    }
-                    proto::plan::GenericValue double_upper_val;
-                    if (upper_type ==
-                        proto::plan::GenericValue::ValCase::kInt64Val) {
-                        double_upper_val.set_float_val(
-                            static_cast<double>(expr_->upper_val_.int64_val()));
-                    } else {
-                        double_upper_val.set_float_val(
-                            expr_->upper_val_.float_val());
-                    }
+                        proto::plan::GenericValue double_lower_val;
+                        if (lower_type ==
+                            proto::plan::GenericValue::ValCase::kInt64Val) {
+                            double_lower_val.set_float_val(static_cast<double>(
+                                expr_->lower_val_.int64_val()));
+                        } else {
+                            double_lower_val.set_float_val(
+                                expr_->lower_val_.float_val());
+                        }
+                        proto::plan::GenericValue double_upper_val;
+                        if (upper_type ==
+                            proto::plan::GenericValue::ValCase::kInt64Val) {
+                            double_upper_val.set_float_val(static_cast<double>(
+                                expr_->upper_val_.int64_val()));
+                        } else {
+                            double_upper_val.set_float_val(
+                                expr_->upper_val_.float_val());
+                        }
 
-                    lower_arg_.SetValue<double>(double_lower_val);
-                    upper_arg_.SetValue<double>(double_upper_val);
-                    arg_inited_ = true;
+                        lower_arg_.SetValue<double>(double_lower_val);
+                        upper_arg_.SetValue<double>(double_upper_val);
+                        arg_inited_ = true;
 
-                    result = ExecRangeVisitorImplForIndex<double>();
+                        result = ExecRangeVisitorImplForIndex<double>();
+                    }
                 } else if (lower_type ==
                            proto::plan::GenericValue::ValCase::kStringVal) {
                     result = ExecRangeVisitorImplForJson<std::string>(context);

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -2247,6 +2247,20 @@ class SegmentExpr : public Expr {
         return true;
     }
 
+    bool
+    PinnedJsonIndexIsFlat() const {
+        return field_type_ == DataType::JSON && !pinned_index_.empty() &&
+               dynamic_cast<const index::JsonFlatIndex*>(
+                   pinned_index_[0].get()) != nullptr;
+    }
+
+    static bool
+    IsInt64SafeForJsonDoubleIndex(int64_t value) {
+        constexpr int64_t kFirstNonInjectiveInteger = int64_t{1} << 53;
+        return value > -kFirstNonInjectiveInteger &&
+               value < kFirstNonInjectiveInteger;
+    }
+
  public:
     bool
     CanUseNestedIndex() const override {

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1745,11 +1745,17 @@ class SegmentExpr : public Expr {
         return processed_size;
     }
 
+    enum class IndexValidityMode {
+        Default,
+        JsonExactPath,
+    };
+
     // ProcessIndexChunks: execute index query and batch results
     template <typename T, typename FUNC, typename... ValTypes>
     VectorPtr
     ProcessIndexChunks(FUNC func, const ValTypes&... values) {
-        return ProcessIndexChunksImpl<T>(func, false, values...);
+        return ProcessIndexChunksImpl<T>(
+            func, false, IndexValidityMode::Default, values...);
     }
 
     // ProcessIndexChunks with func_returns_row_level flag
@@ -1757,14 +1763,17 @@ class SegmentExpr : public Expr {
     //   (used when func already handles element-to-row conversion internally)
     template <typename T, typename FUNC, typename... ValTypes>
     VectorPtr
-    ProcessIndexChunksWithRowLevel(FUNC func, const ValTypes&... values) {
-        return ProcessIndexChunksImpl<T>(func, true, values...);
+    ProcessIndexChunksWithRowLevel(FUNC func,
+                                   IndexValidityMode validity_mode,
+                                   const ValTypes&... values) {
+        return ProcessIndexChunksImpl<T>(func, true, validity_mode, values...);
     }
 
     template <typename T, typename FUNC, typename... ValTypes>
     VectorPtr
     ProcessIndexChunksImpl(FUNC func,
                            bool func_returns_row_level,
+                           IndexValidityMode validity_mode,
                            const ValTypes&... values) {
         typedef std::
             conditional_t<std::is_same_v<T, std::string_view>, std::string, T>
@@ -1822,7 +1831,11 @@ class SegmentExpr : public Expr {
                     TargetBitmap res = func(index_ptr, values...);
 
                     TargetBitmap valid_res;
-                    if (cached_is_nested_index_ && func_returns_row_level) {
+                    if (validity_mode == IndexValidityMode::JsonExactPath &&
+                        executor != nullptr) {
+                        valid_res = executor->ExactPathExists();
+                    } else if (cached_is_nested_index_ &&
+                               func_returns_row_level) {
                         valid_res = TargetBitmap(active_count_, true);
                     } else {
                         valid_res = index_ptr->IsNotNull();

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1790,12 +1790,14 @@ class SegmentExpr : public Expr {
             PinWrapper<const index::IndexBase*> json_pw;
             std::shared_ptr<index::JsonFlatIndexQueryExecutor<IndexInnerType>>
                 executor;
+            const auto json_pointer = field_type_ == DataType::JSON
+                                          ? milvus::Json::pointer(nested_path_)
+                                          : std::string();
             auto prepare_index = [&]() {
                 if (index_ptr != nullptr) {
                     return;
                 }
                 if (field_type_ == DataType::JSON) {
-                    auto pointer = milvus::Json::pointer(nested_path_);
                     json_pw = pinned_index_[0];
                     auto json_flat_index =
                         dynamic_cast<const index::JsonFlatIndex*>(
@@ -1806,7 +1808,7 @@ class SegmentExpr : public Expr {
                         executor =
                             json_flat_index
                                 ->template create_executor<IndexInnerType>(
-                                    pointer.substr(index_path.size()));
+                                    json_pointer.substr(index_path.size()));
                         index_ptr = executor.get();
                     } else {
                         auto json_index =
@@ -1831,9 +1833,45 @@ class SegmentExpr : public Expr {
                     TargetBitmap res = func(index_ptr, values...);
 
                     TargetBitmap valid_res;
-                    if (validity_mode == IndexValidityMode::JsonExactPath &&
-                        executor != nullptr) {
-                        valid_res = executor->ExactPathExists();
+                    std::optional<index::JsonValueType> json_value_type;
+                    if (executor != nullptr) {
+                        if (validity_mode == IndexValidityMode::JsonExactPath) {
+                            json_value_type = index::JsonValueType::Any;
+                        } else if constexpr (std::is_same_v<IndexInnerType,
+                                                            bool>) {
+                            json_value_type = index::JsonValueType::Bool;
+                        } else if constexpr (std::is_integral_v<
+                                                 IndexInnerType> ||
+                                             std::is_floating_point_v<
+                                                 IndexInnerType>) {
+                            json_value_type = index::JsonValueType::Numeric;
+                        } else if constexpr (std::is_same_v<IndexInnerType,
+                                                            std::string>) {
+                            json_value_type = index::JsonValueType::String;
+                        }
+                    }
+
+                    if (json_value_type.has_value()) {
+                        const auto family =
+                            static_cast<unsigned int>(json_value_type.value());
+                        const auto signature = fmt::format(
+                            "json-flat-validity:v1:field={}:path-length={}:"
+                            "path={}:family={}",
+                            field_id_.get(),
+                            json_pointer.size(),
+                            json_pointer,
+                            family);
+                        if (ExprResCacheManager::IsEnabled()) {
+                            auto validity = ExprCacheHelper::GetOrComputeBitmap(
+                                segment_, signature, active_count_, [&]() {
+                                    return executor->ExactPathExists(
+                                        json_value_type.value());
+                                });
+                            valid_res = std::move(*validity);
+                        } else {
+                            valid_res = executor->ExactPathExists(
+                                json_value_type.value());
+                        }
                     } else if (cached_is_nested_index_ &&
                                func_returns_row_level) {
                         valid_res = TargetBitmap(active_count_, true);

--- a/internal/core/src/exec/expression/ExprCacheHelper.h
+++ b/internal/core/src/exec/expression/ExprCacheHelper.h
@@ -139,6 +139,30 @@ class ExprCacheHelper {
 
         return {result, valid};
     }
+
+    // Cache one immutable bitmap artifact using the same backend, admission,
+    // staleness, and segment-invalidation rules as full expression results.
+    // The all-ones companion satisfies the existing two-bitmap cache value
+    // contract and is compressed efficiently by the memory backend.
+    template <typename ComputeFn>
+    static std::shared_ptr<TargetBitmap>
+    GetOrComputeBitmap(const segcore::SegmentInternalInterface* segment,
+                       const std::string& artifact_signature,
+                       int64_t active_count,
+                       ComputeFn&& compute,
+                       bool enable_cache_write = true) {
+        auto cached = GetOrCompute(
+            segment,
+            artifact_signature,
+            active_count,
+            [&]() -> ComputeResult {
+                auto result = compute();
+                TargetBitmap valid(result.size(), true);
+                return {std::move(result), std::move(valid)};
+            },
+            enable_cache_write);
+        return cached.result;
+    }
 };
 
 // ============================================================

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -214,6 +214,317 @@ TYPED_TEST(JsonIndexTestFixture, TestJsonIndexUnaryExpr) {
     EXPECT_EQ(final.count(), N - expect_count);
 }
 
+TEST(JsonIndexTest, EmptyJsonInIsDeterministicForEveryRow) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto i64_fid = schema->AddDebugField("age64", DataType::INT64);
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+    schema->set_primary_field_id(i64_fid);
+
+    auto seg = CreateSealedSegment(schema);
+    auto file_manager_ctx = storage::FileManagerContext();
+    file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+        milvus::proto::schema::JSON);
+    file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+    file_manager_ctx.fieldDataMeta.field_schema.set_nullable(true);
+    file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
+
+    auto inv_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        index::CreateIndexInfo{
+            .index_type = index::INVERTED_INDEX_TYPE,
+            .json_cast_type = JsonCastType::FromString("BOOL"),
+            .json_path = "/a",
+        },
+        file_manager_ctx);
+    auto json_index = std::unique_ptr<index::JsonInvertedIndex<bool>>(
+        static_cast<index::JsonInvertedIndex<bool>*>(inv_index.release()));
+
+    const std::vector<std::string> json_strs = {R"({"a": true})",
+                                                R"({"a": "abc"})",
+                                                R"({"b": false})",
+                                                R"({"a": null})",
+                                                R"({})",
+                                                R"({"a": false})"};
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    std::vector<milvus::Json> jsons;
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    auto* valid_data = json_field->ValidData();
+    std::fill(valid_data,
+              valid_data + json_field->ValidDataSize(),
+              static_cast<uint8_t>(0));
+    valid_data[0] = 0b00011111;
+
+    json_index->BuildWithFieldData({json_field});
+    json_index->finish();
+    json_index->create_reader(milvus::index::SetBitsetSealed);
+
+    segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_id = json_fid.get();
+    load_index_info.field_type = DataType::JSON;
+    load_index_info.index_params = {{JSON_PATH, "/a"},
+                                    {JSON_CAST_TYPE, "BOOL"}};
+    load_index_info.cache_index =
+        CreateTestCacheIndex("empty_json_in", std::move(json_index));
+    seg->LoadIndex(load_index_info);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    seg->LoadFieldData(load_info);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{},
+        false);
+    auto check = [&](const expr::TypedExprPtr& filter_expr,
+                     bool expected_result) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        auto result = milvus::test::gen_filter_res(
+            plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_TRUE(valid_view[i]) << "row " << i;
+            EXPECT_EQ(result_view[i], expected_result) << "row " << i;
+        }
+    };
+
+    check(term_expr, false);
+    check(std::make_shared<expr::LogicalUnaryExpr>(
+              expr::LogicalUnaryExpr::OpType::LogicalNot, term_expr),
+          true);
+}
+
+TEST(JsonIndexTest, LargeInt64LiteralDoesNotAliasInDoublePathIndex) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto i64_fid = schema->AddDebugField("age64", DataType::INT64);
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    schema->set_primary_field_id(i64_fid);
+
+    auto seg = CreateSealedSegment(schema);
+    auto file_manager_ctx = storage::FileManagerContext();
+    file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+        milvus::proto::schema::JSON);
+    file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+    file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
+
+    auto inv_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        index::CreateIndexInfo{
+            .index_type = index::INVERTED_INDEX_TYPE,
+            .json_cast_type = JsonCastType::FromString("DOUBLE"),
+            .json_path = "/a",
+        },
+        file_manager_ctx);
+    auto json_index = std::unique_ptr<index::JsonInvertedIndex<double>>(
+        static_cast<index::JsonInvertedIndex<double>*>(inv_index.release()));
+
+    const std::vector<std::string> json_strs = {R"({"a": 9007199254740992})",
+                                                R"({"a": 9007199254740993})",
+                                                R"({"a": 9007199254740994})"};
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+    std::vector<milvus::Json> jsons;
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    json_index->BuildWithFieldData({json_field});
+    json_index->finish();
+    json_index->create_reader(milvus::index::SetBitsetSealed);
+
+    segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_id = json_fid.get();
+    load_index_info.field_type = DataType::JSON;
+    load_index_info.index_params = {{JSON_PATH, "/a"},
+                                    {JSON_CAST_TYPE, "DOUBLE"}};
+    load_index_info.cache_index =
+        CreateTestCacheIndex("large_int64", std::move(json_index));
+    seg->LoadIndex(load_index_info);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    seg->LoadFieldData(load_info);
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+    auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, equal_expr);
+    auto result = milvus::test::gen_filter_res(
+        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    TargetBitmapView result_view(result->GetRawData(), result->size());
+    TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+    for (size_t i = 0; i < result->size(); ++i) {
+        EXPECT_TRUE(valid_view[i]);
+    }
+    EXPECT_FALSE(result_view[0]);
+    EXPECT_TRUE(result_view[1]);
+    EXPECT_FALSE(result_view[2]);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{value},
+        false);
+    plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, term_expr);
+    result = milvus::test::gen_filter_res(
+        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_FALSE(result_view[0]);
+    EXPECT_TRUE(result_view[1]);
+    EXPECT_FALSE(result_view[2]);
+
+    auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  greater_expr);
+    result = milvus::test::gen_filter_res(
+        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_FALSE(result_view[0]);
+    EXPECT_FALSE(result_view[1]);
+    EXPECT_TRUE(result_view[2]);
+
+    auto between_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        value,
+        value,
+        true,
+        true);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  between_expr);
+    result = milvus::test::gen_filter_res(
+        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_FALSE(result_view[0]);
+    EXPECT_TRUE(result_view[1]);
+    EXPECT_FALSE(result_view[2]);
+}
+
+TEST(JsonRawScanTest, EmptyInAndLargeInt64KeepThreeValuedSemantics) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+    auto seg = CreateSealedSegment(schema);
+
+    const std::vector<std::string> json_strs = {R"({"a": 9007199254740992})",
+                                                R"({"a": 9007199254740993})",
+                                                R"({"a": 9007199254740994})",
+                                                R"({"a": "abc"})",
+                                                R"({})",
+                                                R"({"a": null})",
+                                                R"({"a": 9007199254740993})"};
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    std::vector<milvus::Json> jsons;
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    auto* valid_data = json_field->ValidData();
+    std::fill(valid_data,
+              valid_data + json_field->ValidDataSize(),
+              static_cast<uint8_t>(0));
+    valid_data[0] = 0b00111111;
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    seg->LoadFieldData(load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    };
+    auto check = [](const ColumnVectorPtr& result,
+                    const std::vector<bool>& expected_result,
+                    const std::vector<bool>& expected_valid) {
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_EQ(valid_view[i], expected_valid[i]) << "row " << i;
+            if (expected_valid[i]) {
+                EXPECT_EQ(result_view[i], expected_result[i]) << "row " << i;
+            }
+        }
+    };
+
+    auto empty_term = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{},
+        false);
+    check(evaluate(empty_term),
+          std::vector<bool>(json_strs.size(), false),
+          std::vector<bool>(json_strs.size(), true));
+    check(evaluate(std::make_shared<expr::LogicalUnaryExpr>(
+              expr::LogicalUnaryExpr::OpType::LogicalNot, empty_term)),
+          std::vector<bool>(json_strs.size(), true),
+          std::vector<bool>(json_strs.size(), true));
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+    const std::vector<bool> numeric_valid = {
+        true, true, true, false, false, false, false};
+    auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    check(evaluate(equal_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{value},
+        false);
+    check(evaluate(term_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+
+    auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    check(evaluate(greater_expr),
+          {false, false, true, false, false, false, false},
+          numeric_valid);
+
+    auto between_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        value,
+        value,
+        true,
+        true);
+    check(evaluate(between_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+}
+
 TEST(JsonIndexTest, TestJsonNotEqualExpr) {
     auto schema = std::make_shared<Schema>();
     schema->AddDebugField(

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -29,6 +29,8 @@
 #include "common/Tracer.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "exec/expression/BinaryRangeExpr.h"
+#include "exec/expression/TermExpr.h"
 #include "exec/expression/UnaryExpr.h"
 #include "expr/ITypeExpr.h"
 #include "filemanager/InputStream.h"
@@ -52,6 +54,7 @@
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "test_utils/Constants.h"
+#include "test_utils/GenExprProto.h"
 #include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
@@ -351,4 +354,116 @@ TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathUnknownsAndMasksFieldNull) {
     EXPECT_TRUE(result[6]);
     EXPECT_FALSE(result[7]);
     EXPECT_EQ(result.count(), 2);
+}
+
+TEST(JsonStatsThreeValuedAuditTest,
+     EmptyInAndLargeInt64KeepThreeValuedSemantics) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+    auto segment = segcore::CreateSealedSegment(schema);
+
+    const std::vector<std::string> json_raw_data = {
+        R"({"a": 9007199254740992})",
+        R"({"a": 9007199254740993})",
+        R"({"a": 9007199254740994})",
+        R"({"a": "abc"})",
+        R"({})",
+        R"({"a": null})",
+        R"({"a": 9007199254740993})"};
+    const std::vector<uint8_t> valid_data{0b00111111};
+
+    auto stats = BuildAndLoadJsonKeyStats(json_raw_data,
+                                          json_fid,
+                                          TestLocalPath,
+                                          1201,
+                                          2201,
+                                          3201,
+                                          json_fid.get(),
+                                          5201,
+                                          1,
+                                          &valid_data);
+    auto* sealed =
+        dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    sealed->SetJsonStatsForTesting(json_fid, stats);
+
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    json_field->FillFieldData(MakeNullableJsonArray(json_raw_data, valid_data));
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, json_fid.get(), {json_field}, cm);
+    segment->LoadFieldData(load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), segment.get(), json_raw_data.size(), MAX_TIMESTAMP);
+    };
+    auto check = [](const ColumnVectorPtr& result,
+                    const std::vector<bool>& expected_result,
+                    const std::vector<bool>& expected_valid) {
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_EQ(valid_view[i], expected_valid[i]) << "row " << i;
+            if (expected_valid[i]) {
+                EXPECT_EQ(result_view[i], expected_result[i]) << "row " << i;
+            }
+        }
+    };
+
+    auto empty_term = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{},
+        false);
+    check(evaluate(empty_term),
+          std::vector<bool>(json_raw_data.size(), false),
+          std::vector<bool>(json_raw_data.size(), true));
+    check(evaluate(std::make_shared<expr::LogicalUnaryExpr>(
+              expr::LogicalUnaryExpr::OpType::LogicalNot, empty_term)),
+          std::vector<bool>(json_raw_data.size(), true),
+          std::vector<bool>(json_raw_data.size(), true));
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+    const std::vector<bool> numeric_valid = {
+        true, true, true, false, false, false, false};
+    auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    check(evaluate(equal_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{value},
+        false);
+    check(evaluate(term_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
+
+    auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    check(evaluate(greater_expr),
+          {false, false, true, false, false, false, false},
+          numeric_valid);
+
+    auto between_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        value,
+        value,
+        true,
+        true);
+    check(evaluate(between_expr),
+          {false, true, false, false, false, false, false},
+          numeric_valid);
 }

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -2460,8 +2460,11 @@ PhyJsonContainsFilterExpr::ExecArrayContainsForIndexSegmentImpl() {
     };
 
     // Use WithRowLevel version since func handles element-to-row conversion for nested index
-    auto res =
-        ProcessIndexChunksWithRowLevel<GetType>(execute_sub_batch, elems);
+    auto validity_mode = field_type_ == DataType::JSON
+                             ? IndexValidityMode::JsonExactPath
+                             : IndexValidityMode::Default;
+    auto res = ProcessIndexChunksWithRowLevel<GetType>(
+        execute_sub_batch, validity_mode, elems);
     AssertInfo(res->size() == real_batch_size,
                "internal error: expr processed rows {} not equal "
                "expect batch size {}",

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -261,12 +261,24 @@ PhyTermFilterExpr::ExecVisitorImplTemplateJson(EvalCtx& context) {
         return ExecTermJsonVariableInField<ValueType>(context);
     } else {
         if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
-            // we create double index for json int64 field for now
-            using GetType =
-                std::conditional_t<std::is_same_v<ValueType, int64_t>,
-                                   double,
-                                   ValueType>;
-            return ExecVisitorImplForIndex<GetType>();
+            if constexpr (std::is_same_v<ValueType, int64_t>) {
+                const auto has_unsafe_literal = std::any_of(
+                    expr_->vals_.begin(),
+                    expr_->vals_.end(),
+                    [this](const auto& val) {
+                        return val.has_int64_val() &&
+                               !IsInt64SafeForJsonDoubleIndex(val.int64_val());
+                    });
+                if (has_unsafe_literal) {
+                    return ExecTermJsonFieldInVariable<int64_t>(context);
+                }
+                if (PinnedJsonIndexIsFlat()) {
+                    return ExecVisitorImplForIndex<int64_t>();
+                }
+                return ExecVisitorImplForIndex<double>();
+            } else {
+                return ExecVisitorImplForIndex<ValueType>();
+            }
         } else {
             return ExecTermJsonFieldInVariable<ValueType>(context);
         }
@@ -951,6 +963,12 @@ PhyTermFilterExpr::ExecVisitorImplForIndex() {
     };
     auto args =
         std::dynamic_pointer_cast<FlatVectorElement<IndexInnerType>>(arg_set_);
+    if (field_type_ == DataType::JSON && args->values_.empty()) {
+        MoveCursor();
+        return std::make_shared<ColumnVector>(
+            TargetBitmap(real_batch_size, false),
+            TargetBitmap(real_batch_size, true));
+    }
     auto res = ProcessIndexChunks<T>(execute_sub_batch, args->values_);
     AssertInfo(res->size() == real_batch_size,
                "internal error: expr processed rows {} not equal "
@@ -984,6 +1002,12 @@ PhyTermFilterExpr::ExecVisitorImplForIndex<bool>() {
         return func(index_ptr, vals.size(), (bool*)vals.data());
     };
     auto args = std::dynamic_pointer_cast<FlatVectorElement<uint8_t>>(arg_set_);
+    if (field_type_ == DataType::JSON && args->values_.empty()) {
+        MoveCursor();
+        return std::make_shared<ColumnVector>(
+            TargetBitmap(real_batch_size, false),
+            TargetBitmap(real_batch_size, true));
+    }
     auto res = ProcessIndexChunks<bool>(execute_sub_batch, args->values_);
     return res;
 }

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -258,14 +258,19 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                         result = ExecRangeVisitorImplForIndex<bool>();
                         break;
                     case proto::plan::GenericValue::ValCase::kInt64Val:
-                        if (expr_->val_.has_int64_val()) {
+                        if (!IsInt64SafeForJsonDoubleIndex(
+                                expr_->val_.int64_val())) {
+                            result = ExecRangeVisitorImplJson<int64_t>(context);
+                        } else if (PinnedJsonIndexIsFlat()) {
+                            result = ExecRangeVisitorImplForIndex<int64_t>();
+                        } else {
                             proto::plan::GenericValue double_val;
                             double_val.set_float_val(
                                 static_cast<double>(expr_->val_.int64_val()));
                             value_arg_.SetValue<double>(double_val);
                             arg_inited_ = true;
+                            result = ExecRangeVisitorImplForIndex<double>();
                         }
-                        result = ExecRangeVisitorImplForIndex<double>();
                         break;
                     case proto::plan::GenericValue::ValCase::kFloatVal:
                         result = ExecRangeVisitorImplForIndex<double>();

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -28,6 +28,7 @@
 namespace milvus::index {
 
 class JsonFlatIndex;
+using JsonValueType = ::JsonExistValueType;
 // JsonFlatIndexQueryExecutor is used to execute queries on a specified json path, and can be constructed by JsonFlatIndex
 template <typename T>
 class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
@@ -53,16 +54,18 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::Exists",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        this->wrapper_->json_exist_query(json_path_, true, &bitset);
+        this->wrapper_->json_exist_query(
+            json_path_, true, JsonValueType::Any, &bitset);
         return bitset;
     }
 
     TargetBitmap
-    ExactPathExists() {
+    ExactPathExists(JsonValueType value_type = JsonValueType::Any) {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::ExactPathExists",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        this->wrapper_->json_exist_query(json_path_, false, &bitset);
+        this->wrapper_->json_exist_query(
+            json_path_, false, value_type, &bitset);
         return bitset;
     }
 
@@ -215,46 +218,6 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
     }
 
  private:
-    TargetBitmap
-    NumericComparableBitset() {
-        TargetBitmap bitset(this->Count());
-
-        TargetBitmap int_bitset(this->Count());
-        this->wrapper_->json_range_query(json_path_,
-                                         std::numeric_limits<int64_t>::lowest(),
-                                         std::numeric_limits<int64_t>::max(),
-                                         false,
-                                         false,
-                                         true,
-                                         true,
-                                         &int_bitset);
-        bitset |= int_bitset;
-
-        TargetBitmap double_bitset(this->Count());
-        this->wrapper_->json_range_query(json_path_,
-                                         std::numeric_limits<double>::lowest(),
-                                         std::numeric_limits<double>::max(),
-                                         false,
-                                         false,
-                                         true,
-                                         true,
-                                         &double_bitset);
-        bitset |= double_bitset;
-
-        TargetBitmap u64_bitset(this->Count());
-        this->wrapper_->json_range_query(json_path_,
-                                         std::numeric_limits<uint64_t>::min(),
-                                         std::numeric_limits<uint64_t>::max(),
-                                         false,
-                                         false,
-                                         true,
-                                         true,
-                                         &u64_bitset);
-        bitset |= u64_bitset;
-
-        return bitset;
-    }
-
     using U64Range = std::optional<std::pair<uint64_t, uint64_t>>;
     using I64Range = std::optional<std::pair<int64_t, int64_t>>;
 
@@ -745,20 +708,17 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
 
     TargetBitmap
     ComparableValueBitset() {
-        TargetBitmap bitset(this->Count());
         if constexpr (std::is_same_v<T, bool>) {
-            bool values[] = {false, true};
-            this->wrapper_->json_terms_query(json_path_, values, 2, &bitset);
+            return ExactPathExists(JsonValueType::Bool);
         } else if constexpr (std::is_integral_v<T>) {
-            bitset = NumericComparableBitset();
+            return ExactPathExists(JsonValueType::Numeric);
         } else if constexpr (std::is_floating_point_v<T>) {
-            bitset = NumericComparableBitset();
+            return ExactPathExists(JsonValueType::Numeric);
         } else if constexpr (std::is_same_v<T, std::string>) {
-            this->wrapper_->json_prefix_query(json_path_, "", &bitset);
+            return ExactPathExists(JsonValueType::String);
         } else {
-            this->wrapper_->json_exist_query(json_path_, true, &bitset);
+            return Exists();
         }
-        return bitset;
     }
 
     std::string json_path_;

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -53,7 +53,16 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::Exists",
                               tracer::GetRootSpan());
         TargetBitmap bitset(this->Count());
-        this->wrapper_->json_exist_query(json_path_, &bitset);
+        this->wrapper_->json_exist_query(json_path_, true, &bitset);
+        return bitset;
+    }
+
+    TargetBitmap
+    ExactPathExists() {
+        tracer::AutoSpan span("JsonFlatIndexQueryExecutor::ExactPathExists",
+                              tracer::GetRootSpan());
+        TargetBitmap bitset(this->Count());
+        this->wrapper_->json_exist_query(json_path_, false, &bitset);
         return bitset;
     }
 
@@ -747,7 +756,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         } else if constexpr (std::is_same_v<T, std::string>) {
             this->wrapper_->json_prefix_query(json_path_, "", &bitset);
         } else {
-            this->wrapper_->json_exist_query(json_path_, &bitset);
+            this->wrapper_->json_exist_query(json_path_, true, &bitset);
         }
         return bitset;
     }

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -67,6 +67,7 @@
 #include "storage/Util.h"
 #include "test_utils/Constants.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/GenExprProto.h"
 #include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 
@@ -276,6 +277,38 @@ TEST_F(JsonFlatIndexTest, TestExistsQuery) {
     ASSERT_TRUE(result[0]);   // Alice
     ASSERT_FALSE(result[1]);  // null
     ASSERT_FALSE(result[2]);  // not exist
+}
+
+TEST(JsonFlatIndexExactPathExistsTest, DistinguishesObjectSubpaths) {
+    auto json_index = BuildInMemoryJsonFlatIndex({
+        R"({"a": 1})",
+        R"({"a": [1, 2]})",
+        R"({"a": {"b": 1}})",
+        R"({"a": []})",
+        R"({"a": null})",
+        R"({})",
+    });
+
+    std::string json_path = "/a";
+    auto executor = json_index->create_executor<int64_t>(json_path);
+
+    auto recursive_exists = executor->Exists();
+    ASSERT_EQ(recursive_exists.size(), 6);
+    EXPECT_TRUE(recursive_exists[0]);
+    EXPECT_TRUE(recursive_exists[1]);
+    EXPECT_TRUE(recursive_exists[2]);
+    EXPECT_FALSE(recursive_exists[3]);
+    EXPECT_FALSE(recursive_exists[4]);
+    EXPECT_FALSE(recursive_exists[5]);
+
+    auto exact_exists = executor->ExactPathExists();
+    ASSERT_EQ(exact_exists.size(), 6);
+    EXPECT_TRUE(exact_exists[0]);
+    EXPECT_TRUE(exact_exists[1]);
+    EXPECT_FALSE(exact_exists[2]);
+    EXPECT_FALSE(exact_exists[3]);
+    EXPECT_FALSE(exact_exists[4]);
+    EXPECT_FALSE(exact_exists[5]);
 }
 
 TEST_F(JsonFlatIndexTest, TestComparableAndFieldValidityMasks) {
@@ -826,6 +859,155 @@ class JsonFlatIndexExprTest : public ::testing::Test {
     std::unique_ptr<index::JsonFlatIndex> json_index_;
     segcore::SegmentSealedUPtr segment_;
 };
+
+class JsonFlatIndexContainsExprTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        json_data_ = {
+            R"({"a": [1, 2]})",
+            R"({"a": [2]})",
+            R"({"a": 1})",
+            R"({"a": 2})",
+            R"({"a": {"b": 1}})",
+            R"({"a": []})",
+            R"({"a": null})",
+            R"({})",
+            R"({"a": ["x"]})",
+            R"({"a": [1]})",
+        };
+
+        auto schema = std::make_shared<Schema>();
+        schema->AddDebugField(
+            "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+        auto i64_fid = schema->AddDebugField("age64", DataType::INT64);
+        json_fid_ = schema->AddDebugField("json", DataType::JSON, true);
+        schema->set_primary_field_id(i64_fid);
+
+        segment_ = segcore::CreateSealedSegment(schema);
+        segcore::LoadIndexInfo load_index_info;
+
+        auto file_manager_ctx = storage::FileManagerContext();
+        file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+            milvus::proto::schema::JSON);
+        file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(
+            json_fid_.get());
+        file_manager_ctx.fieldDataMeta.field_schema.set_nullable(true);
+        file_manager_ctx.fieldDataMeta.field_id = json_fid_.get();
+
+        index::CreateIndexInfo json_index_info;
+        json_index_info.index_type = index::INVERTED_INDEX_TYPE;
+        json_index_info.json_cast_type = JsonCastType::FromString("JSON");
+        json_index_info.json_path = "";
+        auto index = index::IndexFactory::GetInstance().CreateJsonIndex(
+            json_index_info, file_manager_ctx);
+        auto json_index = std::unique_ptr<index::JsonFlatIndex>(
+            static_cast<index::JsonFlatIndex*>(index.release()));
+
+        json_field_ =
+            std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+        std::vector<milvus::Json> jsons;
+        for (auto& json_str : json_data_) {
+            jsons.emplace_back(simdjson::padded_string(json_str));
+        }
+        json_field_->add_json_data(jsons);
+        auto* valid_data = json_field_->ValidData();
+        std::fill(valid_data,
+                  valid_data + json_field_->ValidDataSize(),
+                  static_cast<uint8_t>(0));
+        valid_data[0] = 0xFF;
+        valid_data[1] = 0x01;
+
+        json_index->BuildWithFieldData({json_field_});
+        json_index->finish();
+        json_index->create_reader(milvus::index::SetBitsetSealed);
+
+        load_index_info.field_id = json_fid_.get();
+        load_index_info.field_type = DataType::JSON;
+        load_index_info.index_params = {{JSON_PATH, ""},
+                                        {JSON_CAST_TYPE, "JSON"}};
+        load_index_info.cache_index =
+            CreateTestCacheIndex("", std::move(json_index));
+        segment_->LoadIndex(load_index_info);
+
+        auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                      .GetRemoteChunkManager();
+        auto load_info = PrepareSingleFieldInsertBinlog(
+            1, 1, 1, json_fid_.get(), {json_field_}, cm);
+        segment_->LoadFieldData(load_info);
+    }
+
+    ColumnVectorPtr
+    Evaluate(proto::plan::JSONContainsExpr_JSONOp op,
+             std::vector<int64_t> values,
+             bool negate = false) {
+        std::vector<proto::plan::GenericValue> generic_values;
+        for (auto value : values) {
+            generic_values.emplace_back();
+            generic_values.back().set_int64_val(value);
+        }
+        auto contains_expr = std::make_shared<expr::JsonContainsExpr>(
+            expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+            op,
+            true,
+            generic_values);
+        expr::TypedExprPtr filter_expr = contains_expr;
+        if (negate) {
+            filter_expr = std::make_shared<expr::LogicalUnaryExpr>(
+                expr::LogicalUnaryExpr::OpType::LogicalNot, contains_expr);
+        }
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return gen_filter_res(
+            plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    }
+
+    void
+    CheckResult(const ColumnVectorPtr& result,
+                const std::vector<bool>& expected_result,
+                const std::vector<bool>& expected_valid) {
+        ASSERT_EQ(result->size(), expected_result.size());
+        ASSERT_EQ(result->size(), expected_valid.size());
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_EQ(valid_view[i], expected_valid[i]) << "row " << i;
+            if (expected_valid[i]) {
+                EXPECT_EQ(result_view[i], expected_result[i]) << "row " << i;
+            }
+        }
+    }
+
+    FieldId json_fid_;
+    std::vector<std::string> json_data_;
+    std::shared_ptr<FieldData<milvus::Json>> json_field_;
+    segcore::SegmentSealedUPtr segment_;
+};
+
+TEST_F(JsonFlatIndexContainsExprTest, UsesExactPathThreeValuedValidity) {
+    const std::vector<bool> expected_valid = {
+        true, true, true, true, false, false, false, false, true, false};
+
+    CheckResult(
+        Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains, {1}),
+        {true, false, true, false, false, false, false, false, false, false},
+        expected_valid);
+
+    CheckResult(
+        Evaluate(proto::plan::JSONContainsExpr_JSONOp_ContainsAny, {1, 3}),
+        {true, false, true, false, false, false, false, false, false, false},
+        expected_valid);
+
+    CheckResult(
+        Evaluate(proto::plan::JSONContainsExpr_JSONOp_ContainsAll, {1, 2}),
+        {true, false, false, false, false, false, false, false, false, false},
+        expected_valid);
+
+    CheckResult(
+        Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains, {1}, true),
+        {false, true, false, true, false, false, false, false, true, false},
+        expected_valid);
+}
 
 TEST_F(JsonFlatIndexExprTest, TestUnaryExpr) {
     proto::plan::GenericValue value;

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -35,6 +35,7 @@
 #include "common/Tracer.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "exec/expression/ExprCache.h"
 #include "expr/ITypeExpr.h"
 #include "filemanager/InputStream.h"
 #include "gtest/gtest.h"
@@ -837,6 +838,10 @@ class JsonFlatIndexExprTest : public ::testing::Test {
  protected:
     void
     SetUp() override {
+        auto& cache = exec::ExprResCacheManager::Instance();
+        cache.Clear();
+        exec::ExprResCacheManager::SetEnabled(false);
+
         json_data_ = {
             R"({"a": 1.0})",
             R"({"a": "abc"})",
@@ -919,6 +924,9 @@ class JsonFlatIndexExprTest : public ::testing::Test {
 
     void
     TearDown() override {
+        auto& cache = exec::ExprResCacheManager::Instance();
+        cache.Clear();
+        exec::ExprResCacheManager::SetEnabled(false);
     }
 
     FieldId json_fid_;
@@ -931,6 +939,10 @@ class JsonFlatIndexContainsExprTest : public ::testing::Test {
  protected:
     void
     SetUp() override {
+        auto& cache = exec::ExprResCacheManager::Instance();
+        cache.Clear();
+        exec::ExprResCacheManager::SetEnabled(false);
+
         json_data_ = {
             R"({"a": [1, 2]})",
             R"({"a": [2]})",
@@ -1002,6 +1014,13 @@ class JsonFlatIndexContainsExprTest : public ::testing::Test {
         auto load_info = PrepareSingleFieldInsertBinlog(
             1, 1, 1, json_fid_.get(), {json_field_}, cm);
         segment_->LoadFieldData(load_info);
+    }
+
+    void
+    TearDown() override {
+        auto& cache = exec::ExprResCacheManager::Instance();
+        cache.Clear();
+        exec::ExprResCacheManager::SetEnabled(false);
     }
 
     ColumnVectorPtr
@@ -1076,6 +1095,28 @@ TEST_F(JsonFlatIndexContainsExprTest, UsesExactPathThreeValuedValidity) {
         expected_valid);
 }
 
+TEST_F(JsonFlatIndexContainsExprTest,
+       ReusesExactPathValidityAcrossLiteralsAndOperators) {
+    auto& cache = exec::ExprResCacheManager::Instance();
+    exec::CacheConfig config;
+    config.mode = exec::CacheMode::Memory;
+    config.mem_max_bytes = 1 << 20;
+    config.compression_enabled = true;
+    config.admission_threshold = 1;
+    config.mem_min_eval_duration_us = 0;
+    ASSERT_TRUE(cache.SetConfig(config));
+    exec::ExprResCacheManager::SetEnabled(true);
+
+    Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains, {1});
+    EXPECT_EQ(cache.GetEntryCount(), 2);
+
+    Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains, {2});
+    EXPECT_EQ(cache.GetEntryCount(), 3);
+
+    Evaluate(proto::plan::JSONContainsExpr_JSONOp_ContainsAny, {1, 3});
+    EXPECT_EQ(cache.GetEntryCount(), 4);
+}
+
 TEST_F(JsonFlatIndexExprTest, TestUnaryExpr) {
     proto::plan::GenericValue value;
     value.set_int64_val(1);
@@ -1126,6 +1167,77 @@ TEST_F(JsonFlatIndexExprTest, TestComparisonUnknowns) {
     EXPECT_EQ(final.count(), 2);
     EXPECT_TRUE(final[0]);
     EXPECT_TRUE(final[13]);
+}
+
+TEST_F(JsonFlatIndexExprTest, ReusesValidityAcrossLiteralsAndOperators) {
+    auto& cache = exec::ExprResCacheManager::Instance();
+    exec::CacheConfig config;
+    config.mode = exec::CacheMode::Memory;
+    config.mem_max_bytes = 1 << 20;
+    config.compression_enabled = true;
+    config.admission_threshold = 1;
+    config.mem_min_eval_duration_us = 0;
+    ASSERT_TRUE(cache.SetConfig(config));
+    exec::ExprResCacheManager::SetEnabled(true);
+
+    auto evaluate = [&](std::vector<std::string> nested_path,
+                        proto::plan::OpType op,
+                        proto::plan::GenericValue value) {
+        auto unary_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(json_fid_, DataType::JSON, std::move(nested_path)),
+            op,
+            value,
+            std::vector<proto::plan::GenericValue>());
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           unary_expr);
+        return query::ExecuteQueryExpr(
+            plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    };
+    auto int_value = [](int64_t literal) {
+        proto::plan::GenericValue value;
+        value.set_int64_val(literal);
+        return value;
+    };
+
+    EXPECT_EQ(evaluate({"a"}, proto::plan::OpType::Equal, int_value(1)).count(),
+              2);
+    EXPECT_EQ(cache.GetEntryCount(), 2);
+
+    exec::ExprResCacheManager::Key artifact_key{
+        segment_->get_segment_id(),
+        fmt::format("json-flat-validity:v1:field={}:path-length=2:"
+                    "path=/a:family={}",
+                    json_fid_.get(),
+                    static_cast<unsigned int>(index::JsonValueType::Numeric))};
+    exec::ExprResCacheManager::Value artifact;
+    artifact.active_count = json_data_.size();
+    ASSERT_TRUE(cache.Get(artifact_key, artifact));
+    EXPECT_EQ(artifact.result->count(), 6);
+    EXPECT_EQ(artifact.valid_result->count(), json_data_.size());
+    artifact.active_count = json_data_.size() + 1;
+    EXPECT_FALSE(cache.Get(artifact_key, artifact));
+
+    EXPECT_EQ(evaluate({"a"}, proto::plan::OpType::Equal, int_value(3)).count(),
+              1);
+    EXPECT_EQ(cache.GetEntryCount(), 3);
+
+    EXPECT_EQ(
+        evaluate({"a"}, proto::plan::OpType::GreaterThan, int_value(1)).count(),
+        4);
+    EXPECT_EQ(cache.GetEntryCount(), 4);
+
+    proto::plan::GenericValue string_value;
+    string_value.set_string_val("abc");
+    EXPECT_EQ(evaluate({"a"}, proto::plan::OpType::Equal, string_value).count(),
+              1);
+    EXPECT_EQ(cache.GetEntryCount(), 6);
+
+    EXPECT_EQ(evaluate({"b"}, proto::plan::OpType::Equal, int_value(2)).count(),
+              1);
+    EXPECT_EQ(cache.GetEntryCount(), 8);
+
+    EXPECT_EQ(cache.EraseSegment(segment_->get_segment_id()), 8);
+    EXPECT_EQ(cache.GetEntryCount(), 0);
 }
 
 TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -790,6 +790,9 @@ class JsonFlatIndexExprTest : public ::testing::Test {
             R"({"a": 1, "b": 2})",
             R"({})",
             R"(null)",
+            R"({"a": 9007199254740992})",
+            R"({"a": 9007199254740993})",
+            R"({"a": 9007199254740994})",
         };
 
         auto json_index_path = "";
@@ -1039,8 +1042,11 @@ TEST_F(JsonFlatIndexExprTest, TestComparisonUnknowns) {
                                                        not_equal_expr);
     auto final = query::ExecuteQueryExpr(
         plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
-    EXPECT_EQ(final.count(), 1);
+    EXPECT_EQ(final.count(), 4);
     EXPECT_TRUE(final[2]);
+    EXPECT_TRUE(final[16]);
+    EXPECT_TRUE(final[17]);
+    EXPECT_TRUE(final[18]);
 
     auto greater_than_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
         expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
@@ -1058,6 +1064,108 @@ TEST_F(JsonFlatIndexExprTest, TestComparisonUnknowns) {
     EXPECT_TRUE(final[13]);
 }
 
+TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+
+    auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, equal_expr);
+    auto result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    TargetBitmapView result_view(result->GetRawData(), result->size());
+    TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+    EXPECT_TRUE(valid_view[16]);
+    EXPECT_TRUE(valid_view[17]);
+    EXPECT_TRUE(valid_view[18]);
+    EXPECT_FALSE(result_view[16]);
+    EXPECT_TRUE(result_view[17]);
+    EXPECT_FALSE(result_view[18]);
+
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{value},
+        false);
+    plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, term_expr);
+    result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_TRUE(valid_view[16]);
+    EXPECT_TRUE(valid_view[17]);
+    EXPECT_TRUE(valid_view[18]);
+    EXPECT_FALSE(result_view[16]);
+    EXPECT_TRUE(result_view[17]);
+    EXPECT_FALSE(result_view[18]);
+
+    auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  greater_expr);
+    result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_TRUE(valid_view[16]);
+    EXPECT_TRUE(valid_view[17]);
+    EXPECT_TRUE(valid_view[18]);
+    EXPECT_FALSE(result_view[16]);
+    EXPECT_FALSE(result_view[17]);
+    EXPECT_TRUE(result_view[18]);
+
+    auto between_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        value,
+        value,
+        true,
+        true);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  between_expr);
+    result = gen_filter_res(
+        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result_view = TargetBitmapView(result->GetRawData(), result->size());
+    valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
+    EXPECT_TRUE(valid_view[16]);
+    EXPECT_TRUE(valid_view[17]);
+    EXPECT_TRUE(valid_view[18]);
+    EXPECT_FALSE(result_view[16]);
+    EXPECT_TRUE(result_view[17]);
+    EXPECT_FALSE(result_view[18]);
+}
+
+TEST_F(JsonFlatIndexExprTest, EmptyJsonInIsDeterministicForEveryRow) {
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{},
+        false);
+    auto check = [&](const expr::TypedExprPtr& filter_expr,
+                     bool expected_result) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        auto result = gen_filter_res(
+            plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+        TargetBitmapView result_view(result->GetRawData(), result->size());
+        TargetBitmapView valid_view(result->GetValidRawData(), result->size());
+        for (size_t i = 0; i < result->size(); ++i) {
+            EXPECT_TRUE(valid_view[i]) << "row " << i;
+            EXPECT_EQ(result_view[i], expected_result) << "row " << i;
+        }
+    };
+
+    check(term_expr, false);
+    check(std::make_shared<expr::LogicalUnaryExpr>(
+              expr::LogicalUnaryExpr::OpType::LogicalNot, term_expr),
+          true);
+}
+
 TEST_F(JsonFlatIndexExprTest, TestExistsExpr) {
     auto expr = std::make_shared<expr::ExistsExpr>(
         expr::ColumnInfo(json_fid_, DataType::JSON, {""}));
@@ -1065,7 +1173,7 @@ TEST_F(JsonFlatIndexExprTest, TestExistsExpr) {
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
     auto final = query::ExecuteQueryExpr(
         plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
-    EXPECT_EQ(final.count(), 12);
+    EXPECT_EQ(final.count(), 15);
     EXPECT_FALSE(final[5]);
     EXPECT_FALSE(final[7]);
     EXPECT_FALSE(final[14]);

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -311,6 +311,70 @@ TEST(JsonFlatIndexExactPathExistsTest, DistinguishesObjectSubpaths) {
     EXPECT_FALSE(exact_exists[5]);
 }
 
+TEST(JsonFlatIndexExactPathExistsTest, FiltersByComparableTypeFamily) {
+    auto json_index = BuildInMemoryJsonFlatIndex({
+        R"({"a": 1})",
+        R"({"a": 1.5})",
+        R"({"a": "one"})",
+        R"({"a": true})",
+        R"({"a": [2, 3]})",
+        R"({"a": ["two"]})",
+        R"({"a": [false]})",
+        R"({"a": {"b": 1}})",
+        R"({"a": null})",
+        R"({})",
+    });
+
+    std::string json_path = "/a";
+    auto executor = json_index->create_executor<int64_t>(json_path);
+
+    auto any = executor->ExactPathExists(index::JsonValueType::Any);
+    ASSERT_EQ(any.size(), 10);
+    EXPECT_EQ(any.count(), 7);
+    EXPECT_FALSE(any[7]);
+    EXPECT_FALSE(any[8]);
+    EXPECT_FALSE(any[9]);
+
+    auto numeric = executor->ExactPathExists(index::JsonValueType::Numeric);
+    ASSERT_EQ(numeric.size(), 10);
+    EXPECT_TRUE(numeric[0]);
+    EXPECT_TRUE(numeric[1]);
+    EXPECT_FALSE(numeric[2]);
+    EXPECT_FALSE(numeric[3]);
+    EXPECT_TRUE(numeric[4]);
+    EXPECT_FALSE(numeric[5]);
+    EXPECT_FALSE(numeric[6]);
+    EXPECT_FALSE(numeric[7]);
+    EXPECT_FALSE(numeric[8]);
+    EXPECT_FALSE(numeric[9]);
+
+    auto string = executor->ExactPathExists(index::JsonValueType::String);
+    ASSERT_EQ(string.size(), 10);
+    EXPECT_FALSE(string[0]);
+    EXPECT_FALSE(string[1]);
+    EXPECT_TRUE(string[2]);
+    EXPECT_FALSE(string[3]);
+    EXPECT_FALSE(string[4]);
+    EXPECT_TRUE(string[5]);
+    EXPECT_FALSE(string[6]);
+    EXPECT_FALSE(string[7]);
+    EXPECT_FALSE(string[8]);
+    EXPECT_FALSE(string[9]);
+
+    auto boolean = executor->ExactPathExists(index::JsonValueType::Bool);
+    ASSERT_EQ(boolean.size(), 10);
+    EXPECT_FALSE(boolean[0]);
+    EXPECT_FALSE(boolean[1]);
+    EXPECT_FALSE(boolean[2]);
+    EXPECT_TRUE(boolean[3]);
+    EXPECT_FALSE(boolean[4]);
+    EXPECT_FALSE(boolean[5]);
+    EXPECT_TRUE(boolean[6]);
+    EXPECT_FALSE(boolean[7]);
+    EXPECT_FALSE(boolean[8]);
+    EXPECT_FALSE(boolean[9]);
+}
+
 TEST_F(JsonFlatIndexTest, TestComparableAndFieldValidityMasks) {
     auto json_flat_index =
         dynamic_cast<index::JsonFlatIndex*>(json_index_.get());

--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.lock
@@ -4044,6 +4044,7 @@ dependencies = [
  "serde_json",
  "tantivy 0.21.1",
  "tantivy 0.23.0",
+ "tantivy-columnar 0.3.0",
  "tar",
  "tempfile",
  "tokio",

--- a/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/Cargo.toml
@@ -25,6 +25,7 @@ overflow-checks = false
 [dependencies]
 tantivy = { git = "https://github.com/zilliztech/tantivy.git" }
 tantivy-5 = { package = "tantivy", git = "https://github.com/zilliztech/tantivy", tag = "0.21.1-fix4" }
+columnar = { package = "tantivy-columnar", git = "https://github.com/zilliztech/tantivy.git" }
 lindera = "0.42.4"
 fs2 = "0.4"
 lindera-dictionary = "0.42.4"

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -298,7 +298,10 @@ RustResult tantivy_json_terms_query_keyword(void *ptr,
                                             uintptr_t len,
                                             void *bitset);
 
-RustResult tantivy_json_exist_query(void *ptr, const char *json_path, void *bitset);
+RustResult tantivy_json_exist_query(void *ptr,
+                                    const char *json_path,
+                                    bool json_subpaths,
+                                    void *bitset);
 
 RustResult tantivy_json_range_query_i64(void *ptr,
                                         const char *json_path,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -6,6 +6,13 @@
 #include <ostream>
 #include <new>
 
+enum class JsonExistValueType : uint8_t {
+  Any,
+  Numeric,
+  String,
+  Bool,
+};
+
 enum class TantivyDataType : uint8_t {
   Text,
   Keyword,
@@ -301,6 +308,7 @@ RustResult tantivy_json_terms_query_keyword(void *ptr,
 RustResult tantivy_json_exist_query(void *ptr,
                                     const char *json_path,
                                     bool json_subpaths,
+                                    JsonExistValueType value_type,
                                     void *bitset);
 
 RustResult tantivy_json_range_query_i64(void *ptr,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/data_type.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/data_type.rs
@@ -10,3 +10,12 @@ pub enum TantivyDataType {
     Bool,
     JSON,
 }
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonExistValueType {
+    Any,
+    Numeric,
+    String,
+    Bool,
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
@@ -638,13 +638,18 @@ impl IndexReaderWrapper {
         self.search(&q, bitset)
     }
 
-    pub fn json_exist_query(&self, json_path: &str, bitset: *mut c_void) -> Result<()> {
+    pub fn json_exist_query(
+        &self,
+        json_path: &str,
+        json_subpaths: bool,
+        bitset: *mut c_void,
+    ) -> Result<()> {
         let full_json_path = if json_path == "" {
             self.field_name.clone()
         } else {
             format!("{}.{}", self.field_name, json_path)
         };
-        let q = ExistsQuery::new(full_json_path, true);
+        let q = ExistsQuery::new(full_json_path, json_subpaths);
         self.search(&q, bitset)
     }
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use libc::c_char;
 use tantivy::fastfield::FastValue;
-use tantivy::query::{
-    BooleanQuery, ExistsQuery, Query, RangeQuery, RegexQuery, TermQuery, TermSetQuery,
-};
+use tantivy::query::{BooleanQuery, Query, RangeQuery, RegexQuery, TermQuery, TermSetQuery};
 use tantivy::schema::{Field, IndexRecordOption};
 use tantivy::tokenizer::{NgramTokenizer, TokenStream, Tokenizer};
 use tantivy::{Directory, HasLen, Index, IndexReader, ReloadPolicy, Term};
@@ -19,7 +17,9 @@ use crate::milvus_id_collector::MilvusIdCollector;
 use crate::util::{c_ptr_to_str, make_bounds};
 use crate::vec_collector::VecCollector;
 
+use crate::data_type::JsonExistValueType;
 use crate::error::{Result, TantivyBindingError};
+use crate::json_exists_query::JsonExistsQuery;
 
 // Threshold for batch-in query. Less than this threshold, we use term_query one by one and use
 // TermSetQuery when larger than this threshold. This value is based on some experiments.
@@ -642,6 +642,7 @@ impl IndexReaderWrapper {
         &self,
         json_path: &str,
         json_subpaths: bool,
+        value_type: JsonExistValueType,
         bitset: *mut c_void,
     ) -> Result<()> {
         let full_json_path = if json_path == "" {
@@ -649,7 +650,7 @@ impl IndexReaderWrapper {
         } else {
             format!("{}.{}", self.field_name, json_path)
         };
-        let q = ExistsQuery::new(full_json_path, json_subpaths);
+        let q = JsonExistsQuery::new(full_json_path, json_subpaths, value_type);
         self.search(&q, bitset)
     }
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
@@ -3,6 +3,7 @@ use std::ffi::{c_char, c_void, CStr};
 use crate::{
     array::RustResult,
     convert_to_rust_slice, cstr_to_str,
+    data_type::JsonExistValueType,
     index_reader::IndexReaderWrapper,
     ptr_to_str,
     util::{create_binding, free_binding},
@@ -501,13 +502,14 @@ pub extern "C" fn tantivy_json_exist_query(
     ptr: *mut c_void,
     json_path: *const c_char,
     json_subpaths: bool,
+    value_type: JsonExistValueType,
     bitset: *mut c_void,
 ) -> RustResult {
     let real = ptr as *mut IndexReaderWrapper;
     let json_path = cstr_to_str!(json_path);
     unsafe {
         (*real)
-            .json_exist_query(json_path, json_subpaths, bitset)
+            .json_exist_query(json_path, json_subpaths, value_type, bitset)
             .into()
     }
 }

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
@@ -500,11 +500,16 @@ pub extern "C" fn tantivy_json_terms_query_keyword(
 pub extern "C" fn tantivy_json_exist_query(
     ptr: *mut c_void,
     json_path: *const c_char,
+    json_subpaths: bool,
     bitset: *mut c_void,
 ) -> RustResult {
     let real = ptr as *mut IndexReaderWrapper;
     let json_path = cstr_to_str!(json_path);
-    unsafe { (*real).json_exist_query(json_path, bitset).into() }
+    unsafe {
+        (*real)
+            .json_exist_query(json_path, json_subpaths, bitset)
+            .into()
+    }
 }
 
 #[no_mangle]

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/json_exists_query.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/json_exists_query.rs
@@ -1,0 +1,161 @@
+use core::fmt::Debug;
+
+use columnar::{ColumnIndex, ColumnType, DynamicColumn};
+use tantivy::index::SegmentReader;
+use tantivy::query::{ConstScorer, EmptyScorer, EnableScoring, Explanation, Query, Scorer, Weight};
+use tantivy::schema::Type;
+use tantivy::{DocId, DocSet, Score, TantivyError, TERMINATED};
+
+use crate::data_type::JsonExistValueType;
+
+#[derive(Clone, Debug)]
+pub struct JsonExistsQuery {
+    field_name: String,
+    json_subpaths: bool,
+    value_type: JsonExistValueType,
+}
+
+impl JsonExistsQuery {
+    pub fn new(field_name: String, json_subpaths: bool, value_type: JsonExistValueType) -> Self {
+        Self {
+            field_name,
+            json_subpaths,
+            value_type,
+        }
+    }
+}
+
+impl Query for JsonExistsQuery {
+    fn weight(&self, enable_scoring: EnableScoring) -> tantivy::Result<Box<dyn Weight>> {
+        let schema = enable_scoring.schema();
+        let Some((field, _path)) = schema.find_field(&self.field_name) else {
+            return Err(TantivyError::FieldNotFound(self.field_name.clone()));
+        };
+        let field_type = schema.get_field_entry(field).field_type();
+        if !field_type.is_fast() {
+            return Err(TantivyError::SchemaError(format!(
+                "Field {} is not a fast field.",
+                self.field_name
+            )));
+        }
+        Ok(Box::new(JsonExistsWeight {
+            field_name: self.field_name.clone(),
+            field_type: field_type.value_type(),
+            json_subpaths: self.json_subpaths,
+            value_type: self.value_type,
+        }))
+    }
+}
+
+struct JsonExistsWeight {
+    field_name: String,
+    field_type: Type,
+    json_subpaths: bool,
+    value_type: JsonExistValueType,
+}
+
+impl Weight for JsonExistsWeight {
+    fn scorer(&self, reader: &SegmentReader, boost: Score) -> tantivy::Result<Box<dyn Scorer>> {
+        let fast_field_reader = reader.fast_fields();
+        let mut column_handles = fast_field_reader.dynamic_column_handles(&self.field_name)?;
+        if self.field_type == Type::Json && self.json_subpaths {
+            let mut sub_columns =
+                fast_field_reader.dynamic_subpath_column_handles(&self.field_name)?;
+            column_handles.append(&mut sub_columns);
+        }
+
+        let dynamic_columns: tantivy::Result<Vec<DynamicColumn>> = column_handles
+            .into_iter()
+            .filter(|handle| self.value_type.matches(handle.column_type()))
+            .map(|handle| handle.open().map_err(Into::into))
+            .collect();
+        let non_empty_columns: Vec<DynamicColumn> = dynamic_columns?
+            .into_iter()
+            .filter(|column| !matches!(column.column_index(), ColumnIndex::Empty { .. }))
+            .collect();
+
+        if non_empty_columns.is_empty() {
+            Ok(Box::new(EmptyScorer))
+        } else {
+            let docset = JsonExistsDocSet::new(non_empty_columns, reader.max_doc());
+            Ok(Box::new(ConstScorer::new(docset, boost)))
+        }
+    }
+
+    fn explain(&self, reader: &SegmentReader, doc: DocId) -> tantivy::Result<Explanation> {
+        let mut scorer = self.scorer(reader, 1.0)?;
+        if scorer.seek(doc) != doc {
+            return Err(TantivyError::InvalidArgument(format!(
+                "Document #{doc} does not match"
+            )));
+        }
+        Ok(Explanation::new("JsonExistsQuery", 1.0))
+    }
+}
+
+impl JsonExistValueType {
+    fn matches(self, column_type: ColumnType) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Numeric => matches!(
+                column_type,
+                ColumnType::I64 | ColumnType::U64 | ColumnType::F64
+            ),
+            Self::String => column_type == ColumnType::Str,
+            Self::Bool => column_type == ColumnType::Bool,
+        }
+    }
+}
+
+struct JsonExistsDocSet {
+    columns: Vec<DynamicColumn>,
+    doc: DocId,
+    max_doc: DocId,
+}
+
+impl JsonExistsDocSet {
+    fn new(columns: Vec<DynamicColumn>, max_doc: DocId) -> Self {
+        let mut set = Self {
+            columns,
+            doc: 0,
+            max_doc,
+        };
+        set.find_next();
+        set
+    }
+
+    fn find_next(&mut self) -> DocId {
+        while self.doc < self.max_doc {
+            if self
+                .columns
+                .iter()
+                .any(|column| column.column_index().has_value(self.doc))
+            {
+                return self.doc;
+            }
+            self.doc += 1;
+        }
+        self.doc = TERMINATED;
+        TERMINATED
+    }
+}
+
+impl DocSet for JsonExistsDocSet {
+    fn advance(&mut self) -> DocId {
+        self.seek(self.doc + 1)
+    }
+
+    fn size_hint(&self) -> u32 {
+        0
+    }
+
+    fn doc(&self) -> DocId {
+        self.doc
+    }
+
+    #[inline(always)]
+    fn seek(&mut self, target: DocId) -> DocId {
+        self.doc = target;
+        self.find_next()
+    }
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/lib.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/lib.rs
@@ -22,6 +22,7 @@ mod index_writer_text;
 mod index_writer_text_c;
 mod index_writer_v5;
 mod index_writer_v7;
+mod json_exists_query;
 mod log;
 mod log_c;
 mod milvus_id_collector;

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -1395,9 +1395,10 @@ struct TantivyIndexWrapper {
     void
     json_exist_query(const std::string& json_path,
                      bool json_subpaths,
+                     JsonExistValueType value_type,
                      void* bitset) {
         auto array = tantivy_json_exist_query(
-            reader_, json_path.c_str(), json_subpaths, bitset);
+            reader_, json_path.c_str(), json_subpaths, value_type, bitset);
         auto res = RustResultWrapper(array);
         AssertInfo(res.result_->success,
                    "TantivyIndexWrapper.json_exist_query: {}",

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -1393,9 +1393,11 @@ struct TantivyIndexWrapper {
     }
 
     void
-    json_exist_query(const std::string& json_path, void* bitset) {
-        auto array =
-            tantivy_json_exist_query(reader_, json_path.c_str(), bitset);
+    json_exist_query(const std::string& json_path,
+                     bool json_subpaths,
+                     void* bitset) {
+        auto array = tantivy_json_exist_query(
+            reader_, json_path.c_str(), json_subpaths, bitset);
         auto res = RustResultWrapper(array);
         AssertInfo(res.result_->success,
                    "TantivyIndexWrapper.json_exist_query: {}",


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/pull/51234

This PR layers the JSON flat validity bitmap cache changes on top of buqian/jay/fix-json-flat-contains-3vl.

It includes the commit:
- 8ca9e2a1ac perf: cache json flat validity bitmaps