### PR TITLE
fix: build text index for newly added enable_match field on growing segment reopen (#50484)

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2365,8 +2365,15 @@ SegmentGrowingImpl::CreateTextIndex(FieldId field_id,
     CheckCancellation(
         op_ctx, id_, field_id.get(), "SegmentGrowingImpl::CreateTextIndex()");
 
+    auto index = BuildTextIndexForMeta(schema_->operator[](field_id));
     std::unique_lock lock(mutex_);
-    const auto& field_meta = schema_->operator[](field_id);
+    text_indexes_[field_id] = std::move(index);
+}
+
+// Builds a standalone index without publishing it into text_indexes_; the
+// meta is passed in because Reopen runs before the field is in schema_.
+std::unique_ptr<index::TextMatchIndex>
+SegmentGrowingImpl::BuildTextIndexForMeta(const FieldMeta& field_meta) {
     AssertInfo(IsStringDataType(field_meta.get_data_type()),
                "cannot create text index on non-string type");
     std::string unique_id = GetUniqueFieldId(field_meta.get_id().get());
@@ -2381,7 +2388,7 @@ SegmentGrowingImpl::CreateTextIndex(FieldId field_id,
     index->CreateReader(milvus::index::SetBitsetGrowing);
     index->RegisterAnalyzer("milvus_tokenizer",
                             field_meta.get_analyzer_params().c_str());
-    text_indexes_[field_id] = std::move(index);
+    return index;
 }
 
 void
@@ -2536,9 +2543,52 @@ SegmentGrowingImpl::Reopen(SchemaPtr sch) {
             fill_empty_field(field_meta);
         }
 
+        auto row_count = insert_record_.row_count();
+        // #50484: build text indexes for new enable_match fields BEFORE
+        // publishing schema_ -- readers skip Reopen once the new schema_ is
+        // visible. Backfill every pre-existing row (default value or nulls,
+        // same as fill_empty_field): doc offsets must stay dense and aligned
+        // with insert_record_ rows. Commit+Reload so the triggering query
+        // sees the backfill. Stage all fields locally and publish together
+        // only after every one succeeds: a present text_indexes_ entry is
+        // always complete, and a mid-build throw publishes nothing (schema_
+        // un-advanced, so the next query rebuilds from scratch).
+        std::vector<std::pair<FieldId, std::unique_ptr<index::TextMatchIndex>>>
+            staged_text_indexes;
+        for (const auto& field_meta : *absent_fields) {
+            if (sch->is_function_output(field_meta.get_id())) {
+                continue;
+            }
+            auto field_id = field_meta.get_id();
+            if (IsStringDataType(field_meta.get_data_type()) &&
+                field_meta.enable_match() &&
+                text_indexes_.find(field_id) == text_indexes_.end()) {
+                auto index = BuildTextIndexForMeta(field_meta);
+                if (row_count > 0) {
+                    const bool has_default =
+                        field_meta.default_value().has_value();
+                    std::vector<std::string> texts(
+                        row_count,
+                        has_default ? field_meta.default_value()->string_data()
+                                    : std::string());
+                    FixedVector<bool> texts_valid_data(row_count, has_default);
+                    index->AddTextsGrowing(
+                        row_count, texts.data(), texts_valid_data.data(), 0);
+                }
+                index->Commit();
+                index->Reload();
+                staged_text_indexes.emplace_back(field_id, std::move(index));
+            }
+        }
+        if (!staged_text_indexes.empty()) {
+            std::unique_lock lock(mutex_);
+            for (auto& [field_id, index] : staged_text_indexes) {
+                text_indexes_[field_id] = std::move(index);
+            }
+        }
+
         schema_ = sch;
 
-        auto row_count = insert_record_.row_count();
         for (const auto& field_meta : *absent_fields) {
             if (sch->is_function_output(field_meta.get_id())) {
                 continue;

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -776,6 +776,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
     void
     CreateTextIndexes();
 
+    std::unique_ptr<index::TextMatchIndex>
+    BuildTextIndexForMeta(const FieldMeta& field_meta);
+
     /**
      * @brief Initialize TEXT LOB spillover files for each TEXT field
      *

--- a/internal/core/unittest/test_schema_reopen.cpp
+++ b/internal/core/unittest/test_schema_reopen.cpp
@@ -119,3 +119,168 @@ TEST_F(SchemaReopenTest, LoadWithAbsentNullableVectorFieldShouldReadAllNull) {
         ASSERT_FALSE(col->valid_data(i)) << "row " << i << " should be null";
     }
 }
+
+// #50484: Reopen must build the text index for an enable_match field added
+// by schema evolution and index the pre-existing rows (nulls here);
+// otherwise text_match throws TextIndexNotFound.
+TEST_F(SchemaReopenTest, ReopenBuildsTextIndexForNewEnableMatchField) {
+    // V1 has no text field, so the constructor builds no text index.
+    auto segment = CreateGrowingSegment(schema_v1_, milvus::empty_index_meta);
+    auto* seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(seg_impl, nullptr);
+
+    int N = 20;
+    auto dataset = DataGen(schema_v1_, N, /*seed=*/7);
+    auto reserved = segment->PreInsert(N);
+    segment->Insert(reserved,
+                    N,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+    ASSERT_EQ(segment->get_row_count(), N);
+
+    // V2 shares V1's field ids and adds a nullable enable_match VARCHAR.
+    auto schema_v2 = std::make_shared<Schema>();
+    schema_v2->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    auto pk_fid = schema_v2->AddDebugField("pk", DataType::INT64);
+    std::map<std::string, std::string> analyzer_params;
+    auto text_fid = schema_v2->AddDebugVarcharField(FieldName("text_content"),
+                                                    DataType::VARCHAR,
+                                                    /*max_length=*/65535,
+                                                    /*nullable=*/true,
+                                                    /*enable_match=*/true,
+                                                    /*enable_analyzer=*/true,
+                                                    analyzer_params,
+                                                    std::nullopt);
+    schema_v2->set_primary_field_id(pk_fid);
+    schema_v2->set_schema_version(2);
+
+    milvus::OpContext op_ctx;
+    EXPECT_ANY_THROW(seg_impl->GetTextIndex(&op_ctx, text_fid));
+
+    seg_impl->Reopen(schema_v2);
+
+    ASSERT_NO_THROW(seg_impl->GetTextIndex(&op_ctx, text_fid));
+    auto pw = seg_impl->GetTextIndex(&op_ctx, text_fid);
+    auto* index = pw.get();
+    ASSERT_NE(index, nullptr);
+
+    // No explicit Commit/Reload: Reopen already made the backfill visible.
+    // No default value -> all rows null, nothing matches.
+    EXPECT_EQ(index->MatchQuery("anything", 1).count(), 0);
+    auto not_null = index->IsNotNull();
+    ASSERT_EQ(not_null.size(), static_cast<size_t>(N));
+    EXPECT_EQ(not_null.count(), 0);
+}
+
+// #50484: when the added enable_match field has a default value, Reopen's
+// backfill must index the default text for pre-existing rows, matching
+// sealed's create-from-raw results.
+TEST_F(SchemaReopenTest, ReopenTextIndexIndexesDefaultValueForOldRows) {
+    auto segment = CreateGrowingSegment(schema_v1_, milvus::empty_index_meta);
+    auto* seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(seg_impl, nullptr);
+
+    int N = 20;
+    auto dataset = DataGen(schema_v1_, N, /*seed=*/11);
+    auto reserved = segment->PreInsert(N);
+    segment->Insert(reserved,
+                    N,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+    ASSERT_EQ(segment->get_row_count(), N);
+
+    auto schema_v2 = std::make_shared<Schema>();
+    schema_v2->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    auto pk_fid = schema_v2->AddDebugField("pk", DataType::INT64);
+    std::map<std::string, std::string> analyzer_params;
+    DefaultValueType default_value;
+    default_value.set_string_data("sample default text");
+    auto text_fid =
+        schema_v2->AddDebugVarcharField(FieldName("text_content"),
+                                        DataType::VARCHAR,
+                                        /*max_length=*/65535,
+                                        /*nullable=*/true,
+                                        /*enable_match=*/true,
+                                        /*enable_analyzer=*/true,
+                                        analyzer_params,
+                                        std::make_optional(default_value));
+    schema_v2->set_primary_field_id(pk_fid);
+    schema_v2->set_schema_version(2);
+
+    seg_impl->Reopen(schema_v2);
+
+    milvus::OpContext op_ctx;
+    auto pw = seg_impl->GetTextIndex(&op_ctx, text_fid);
+    auto* index = pw.get();
+    ASSERT_NE(index, nullptr);
+
+    // No explicit Commit/Reload: every old row carries the default text.
+    EXPECT_EQ(index->MatchQuery("default", 1).count(), static_cast<size_t>(N));
+    EXPECT_EQ(index->MatchQuery("absent-token", 1).count(), 0);
+    auto not_null = index->IsNotNull();
+    ASSERT_EQ(not_null.size(), static_cast<size_t>(N));
+    EXPECT_EQ(not_null.count(), static_cast<size_t>(N));
+}
+
+// #50484: one Reopen may add several enable_match fields; the staged indexes
+// are published together, so every field must come out complete.
+TEST_F(SchemaReopenTest, ReopenBuildsTextIndexesForMultipleNewFields) {
+    auto segment = CreateGrowingSegment(schema_v1_, milvus::empty_index_meta);
+    auto* seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(seg_impl, nullptr);
+
+    int N = 20;
+    auto dataset = DataGen(schema_v1_, N, /*seed=*/13);
+    auto reserved = segment->PreInsert(N);
+    segment->Insert(reserved,
+                    N,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+    ASSERT_EQ(segment->get_row_count(), N);
+
+    auto schema_v2 = std::make_shared<Schema>();
+    schema_v2->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    auto pk_fid = schema_v2->AddDebugField("pk", DataType::INT64);
+    std::map<std::string, std::string> analyzer_params;
+    auto null_fid = schema_v2->AddDebugVarcharField(FieldName("text_null"),
+                                                    DataType::VARCHAR,
+                                                    /*max_length=*/65535,
+                                                    /*nullable=*/true,
+                                                    /*enable_match=*/true,
+                                                    /*enable_analyzer=*/true,
+                                                    analyzer_params,
+                                                    std::nullopt);
+    DefaultValueType default_value;
+    default_value.set_string_data("sample default text");
+    auto default_fid =
+        schema_v2->AddDebugVarcharField(FieldName("text_default"),
+                                        DataType::VARCHAR,
+                                        /*max_length=*/65535,
+                                        /*nullable=*/true,
+                                        /*enable_match=*/true,
+                                        /*enable_analyzer=*/true,
+                                        analyzer_params,
+                                        std::make_optional(default_value));
+    schema_v2->set_primary_field_id(pk_fid);
+    schema_v2->set_schema_version(2);
+
+    seg_impl->Reopen(schema_v2);
+
+    milvus::OpContext op_ctx;
+    auto null_pw = seg_impl->GetTextIndex(&op_ctx, null_fid);
+    ASSERT_NE(null_pw.get(), nullptr);
+    EXPECT_EQ(null_pw.get()->MatchQuery("anything", 1).count(), 0);
+    EXPECT_EQ(null_pw.get()->IsNotNull().count(), 0);
+
+    auto default_pw = seg_impl->GetTextIndex(&op_ctx, default_fid);
+    ASSERT_NE(default_pw.get(), nullptr);
+    EXPECT_EQ(default_pw.get()->MatchQuery("default", 1).count(),
+              static_cast<size_t>(N));
+    EXPECT_EQ(default_pw.get()->IsNotNull().count(), static_cast<size_t>(N));
+}


### PR DESCRIPTION
Backport of #51201 to the 3.0 branch.

After schema evolution adds an `enable_match` field (e.g. `drop_collection_field` + `add_collection_field` of a same-name text field), `text_match` could fail with `text index not found for field <id>` on a growing segment even though `describe_index` reported `Finished`. A growing segment built its per-segment text indexes only in the constructor; `SegmentGrowingImpl::Reopen(SchemaPtr)` backfilled column data but never built the text index for the newly added field. This fix builds and backfills the text index for newly added `IsStringDataType && enable_match` fields in `Reopen`, before publishing `schema_`, mirroring the sealed path. Function-output (BM25 sparse) fields remain skipped.

pr: #51201
issue: #50484
