### PR TITLE
fix: keep delegator deleteMut free of bulk delete replay and batch-pin ts column in delete apply

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3906,8 +3906,49 @@ ChunkedSegmentSealedImpl::search_batch_pks(
     auto effective_commit_ts =
         snapshot->commit_ts != 0 ? std::optional<Timestamp>{snapshot->commit_ts}
                                  : std::nullopt;
+    // Resolve matched-row timestamps by lazily pinning the timestamp column
+    // ONE chunk at a time and reusing that pin for all offsets that fall in
+    // it, instead of the per-row ReadTimestamp() path (a fresh cachinglayer
+    // pin per matched row). Under the delete-replay amplification of issue
+    // #49435 (tens of millions of matched rows per LoadDeletedRecord call)
+    // the per-row pin dominated the whole call. A single group chunk stays
+    // pinned at a time (same peak residency as the per-row path, not the
+    // whole column group), and nothing is pinned for zero-hit calls (empty
+    // pks, bloom-filter false positives) because the pin is created on first
+    // use inside read_ts. Pins are refcounts on the snapshot's cells, so
+    // reopen's atomic publication is not blocked, and per-call snapshot
+    // consistency is identical to the per-row variant.
+    auto runtime_ts_data = runtime != nullptr ? runtime->timestamps : nullptr;
+    bool ts_from_array =
+        runtime_ts_data != nullptr && !runtime_ts_data->empty();
+    std::shared_ptr<ChunkedColumnInterface> ts_column;
+    cachinglayer::PinWrapper<Chunk*> ts_chunk_pin{nullptr};
+    const Timestamp* ts_chunk_data = nullptr;
+    int64_t ts_chunk_base = 0;
+    int64_t ts_chunk_limit = -1;  // pinned chunk covers offsets [base, limit)
     auto read_ts = [&](int64_t offset) -> Timestamp {
-        return ReadTimestamp(offset, runtime, effective_commit_ts);
+        if (effective_commit_ts) {
+            return *effective_commit_ts;
+        }
+        if (ts_from_array) {
+            return (*runtime_ts_data)[offset];
+        }
+        if (offset < ts_chunk_base || offset >= ts_chunk_limit) {
+            if (!ts_column) {
+                ts_column = get_column(runtime, TimestampFieldID);
+                AssertInfo(ts_column != nullptr, "timestamp data is not ready");
+            }
+            auto [cid, off_in_chunk] = ts_column->GetChunkIDByOffset(offset);
+            ts_chunk_pin = ts_column->GetChunk(nullptr, cid);
+            // Data() (not RawData()) skips a nullable field's leading null
+            // bitmap; the timestamp system field is non-nullable today so the
+            // two coincide, but Data() is the layout-correct accessor.
+            ts_chunk_data =
+                reinterpret_cast<const Timestamp*>(ts_chunk_pin.get()->Data());
+            ts_chunk_base = offset - static_cast<int64_t>(off_in_chunk);
+            ts_chunk_limit = ts_chunk_base + ts_column->chunk_row_nums(cid);
+        }
+        return ts_chunk_data[offset - ts_chunk_base];
     };
 
     // Virtual PK offset maps can resolve pk -> offset directly by bit-extract.

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -1032,7 +1032,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 	sd.deleteMut.RUnlock()
 	// RLock released — WAL pipeline (ProcessDelete) is now unblocked
 
-	// Create one forwarder per segment, shared across Phase 2 and Phase 3, flushed once at the end.
+	// Create one forwarder per segment, shared across Phase 2 and Phase 3.
 	forwarders := make([]*BufferForwarder, len(infos))
 	for i, info := range infos {
 		candidate := idCandidates[info.GetSegmentID()]
@@ -1065,50 +1065,135 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 		)
 	}
 
-	// === Phase 3: Catch-up new entries + flush + add distribution under RLock (fast — milliseconds) ===
-	sd.deleteMut.RLock()
-	defer sd.deleteMut.RUnlock()
-
-	for i, info := range infos {
-		candidate := idCandidates[info.GetSegmentID()]
-
-		// Use timestamp-based catch-up: fetch records added after the snapshot's max timestamp.
-		// This is robust against delete buffer eviction (Put → evict discards old tail during Phase 2).
-		// Index-based approach (allRecords[snapshotLen:]) would panic or miss data if eviction occurs.
-		// Item.Ts comes from WAL TSO, monotonically increasing and unique per ProcessDelete call,
-		// so ListAfter(snapshotMaxTs + 1) precisely captures only new records.
-		catchUpTs := segmentEffectiveTs(info)
-		if snapshots[i].snapshotMaxTs > 0 {
-			catchUpTs = snapshots[i].snapshotMaxTs + 1
-		}
-		newRecords := sd.deleteBuffer.ListAfter(catchUpTs)
-		if len(newRecords) > 0 {
-			start := time.Now()
-			tsHit, bfHit, err := sd.processDeleteRecords(candidate, newRecords, forwarders[i])
-			if err != nil {
-				return err
-			}
-			log.Info(ctx, "forward delete to worker (phase 3: catch-up)...",
-				mlog.String("channel", info.InsertChannel),
-				mlog.FieldSegmentID(info.GetSegmentID()),
-				mlog.Int64("tsHitDeleteRowNum", tsHit),
-				mlog.Int64("bfHitDeleteRowNum", bfHit),
-				mlog.Int64("bfCost", time.Since(start).Milliseconds()),
-			)
-		}
-
-		// Flush once per segment after both phases are done
+	// === Phase 2.5: Flush the bulk snapshot payload WITHOUT the lock ===
+	// This is where the expensive worker.Delete → LoadDeltaData apply happens
+	// (potentially tens of seconds for huge replays, see issue #49435).
+	// Holding deleteMut across it would starve ProcessDelete — the single
+	// writer that also advances tsafe — and freeze the whole channel.
+	for i := range infos {
 		if err := forwarders[i].Flush(); err != nil {
 			return err
 		}
 	}
 
-	// Atomically add to distribution while still holding RLock.
-	// This guarantees no ProcessDelete can run between catch-up and distribution update,
-	// so there is no gap between "deletes applied" and "segment visible".
-	if err := sd.addDistributionIfSchemaBarrierOK(schemaBarrierTs, entries...); err != nil {
-		return err
+	// Per-segment catch-up cursors. Timestamp-based catch-up is robust against
+	// delete buffer eviction (Put → evict discards old tail while we run
+	// lock-free). Item.Ts comes from WAL TSO, monotonically increasing, so
+	// ListAfter(lastTs + 1) precisely captures only newer records.
+	catchUpTs := make([]uint64, len(infos))
+	for i, info := range infos {
+		catchUpTs[i] = segmentEffectiveTs(info)
+		if snapshots[i].snapshotMaxTs > 0 {
+			catchUpTs[i] = snapshots[i].snapshotMaxTs + 1
+		}
 	}
+
+	// === Phase 3: catch-up the live delete stream, then publish. ===
+	// Normal catch-up forwards (worker.Delete, a cross-node RPC) are done WITHOUT
+	// the lock: deleteMut excludes ProcessDelete, the single writer that advances
+	// tsafe, so awaiting an RPC under it would refreeze the channel exactly when
+	// the worker is saturated by a load storm (issue #49435). The only exception
+	// is the bounded final barrier below, used after several lock-free attempts
+	// fail to find a quiet point.
+	//
+	// Each lock-free round forwards only the deletes that arrived during the
+	// previous round, so the remainder usually shrinks quickly. If arrivals keep
+	// the buffer non-empty past maxLockFreeCatchUpRounds, do one final catch-up
+	// while holding RLock and publish before unlocking. That bounded barrier is
+	// the termination escape hatch: ProcessDelete cannot interleave, so after
+	// this tail is applied, "all buffered deletes applied" and "segment visible"
+	// become atomic. New deletes after unlock see the segment in distribution
+	// and use the normal streaming forward path. The expensive bulk snapshot
+	// replay remains lock-free; only the small live tail falls back to the
+	// locked barrier.
+	const maxLockFreeCatchUpRounds = 5
+	pending := make([][]*deletebuffer.Item, len(infos))
+	for round := 0; ; round++ {
+		sd.deleteMut.RLock()
+		remaining := 0
+		for i := range infos {
+			pending[i] = sd.deleteBuffer.ListAfter(catchUpTs[i])
+			remaining += len(pending[i])
+		}
+
+		// Drained: publish while still holding RLock. No Flush is called here:
+		// the normal catch-up path keeps worker.Delete RPCs outside deleteMut,
+		// otherwise a saturated worker can starve ProcessDelete and freeze tsafe.
+		if remaining == 0 {
+			// Atomically add to distribution while still holding RLock, so no
+			// ProcessDelete can run between "deletes applied" and "segment
+			// visible".
+			if err := sd.addDistributionIfSchemaBarrierOK(schemaBarrierTs, entries...); err != nil {
+				sd.deleteMut.RUnlock()
+				return err
+			}
+			sd.deleteMut.RUnlock()
+			break
+		}
+
+		if round >= maxLockFreeCatchUpRounds {
+			log.Info(ctx, "loadStreamDelete catch-up exceeded expected rounds; applying final locked barrier",
+				mlog.Int("round", round),
+				mlog.Int("remainingDeleteRecords", remaining))
+			for i, info := range infos {
+				if len(pending[i]) == 0 {
+					continue
+				}
+				candidate := idCandidates[info.GetSegmentID()]
+				start := time.Now()
+				tsHit, bfHit, err := sd.processDeleteRecords(candidate, pending[i], forwarders[i])
+				if err != nil {
+					sd.deleteMut.RUnlock()
+					return err
+				}
+				if err := forwarders[i].Flush(); err != nil {
+					sd.deleteMut.RUnlock()
+					return err
+				}
+				log.Info(ctx, "forward delete to worker (phase 3: final locked catch-up)...",
+					mlog.String("channel", info.InsertChannel),
+					mlog.FieldSegmentID(info.GetSegmentID()),
+					mlog.Int("round", round),
+					mlog.Int64("tsHitDeleteRowNum", tsHit),
+					mlog.Int64("bfHitDeleteRowNum", bfHit),
+					mlog.Int64("bfCost", time.Since(start).Milliseconds()),
+				)
+			}
+			if err := sd.addDistributionIfSchemaBarrierOK(schemaBarrierTs, entries...); err != nil {
+				sd.deleteMut.RUnlock()
+				return err
+			}
+			sd.deleteMut.RUnlock()
+			break
+		}
+		sd.deleteMut.RUnlock()
+
+		// Forward this round's arrivals OUTSIDE the lock.
+		for i, info := range infos {
+			if len(pending[i]) == 0 {
+				continue
+			}
+			candidate := idCandidates[info.GetSegmentID()]
+			start := time.Now()
+			tsHit, bfHit, err := sd.processDeleteRecords(candidate, pending[i], forwarders[i])
+			if err != nil {
+				return err
+			}
+			if err := forwarders[i].Flush(); err != nil {
+				return err
+			}
+			catchUpTs[i] = pending[i][len(pending[i])-1].Ts + 1
+			log.Info(ctx, "forward delete to worker (phase 3: lock-free catch-up)...",
+				mlog.String("channel", info.InsertChannel),
+				mlog.FieldSegmentID(info.GetSegmentID()),
+				mlog.Int("round", round),
+				mlog.Int64("tsHitDeleteRowNum", tsHit),
+				mlog.Int64("bfHitDeleteRowNum", bfHit),
+				mlog.Int64("bfCost", time.Since(start).Milliseconds()),
+			)
+		}
+	}
+
 	log.Info(ctx, "load stream delete done")
 	return nil
 }

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -2316,6 +2316,378 @@ func (s *DelegatorDataSuite) TestLoadSegmentsDoesNotBlockProcessDelete() {
 	s.False(processDeleteBlocked.Load(), "ProcessDelete was blocked for too long during LoadSegments — tsafe would freeze")
 }
 
+// TestLoadStreamDeletePhase3FlushStarvesProcessDelete is a minimal reproduction of issue
+// #49435 ("channel tsafe stalled" under concurrent Strong query + upsert).
+//
+// Root cause: loadStreamDelete Phase 3 holds deleteMut.RLock while doing the network
+// Flush() (worker.Delete). When that forward is slow — as happens under a post-compaction
+// load storm where the single worker is saturated — the live ProcessDelete, which needs
+// deleteMut.Lock (write) and is the ONLY thing that advances tsafe (deleteNode.Operate
+// calls ProcessDelete then UpdateTSafe on the same single-threaded flowgraph), is starved.
+// A frozen tsafe is exactly what makes Strong-consistency queries fail with
+// "channel tsafe stalled".
+//
+// This test makes the Phase-3 worker.Delete block (RLock held) and asserts ProcessDelete is
+// NOT starved. It FAILS on current code (Flush under RLock) and PASSES once the network Flush
+// is moved out of the RLock.
+func (s *DelegatorDataSuite) TestLoadStreamDeletePhase3FlushStarvesProcessDelete() {
+	defer func() {
+		s.workerManager.ExpectedCalls = nil
+		s.loader.ExpectedCalls = nil
+	}()
+
+	// BF matches only {10,20,30}, so Phase 3 forwards just a few rows — well under the 4MB
+	// ForwardBatchSize, guaranteeing worker.Delete is called ONLY in Phase 3's Flush (under
+	// RLock), never via a lock-free Phase 2 auto-sync.
+	s.loader.EXPECT().LoadBloomFilterSet(mock.Anything, s.collectionID, mock.Anything).
+		Call.Return(func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) []*pkoracle.BloomFilterSet {
+		return lo.Map(infos, func(info *querypb.SegmentLoadInfo, _ int) *pkoracle.BloomFilterSet {
+			bfs := pkoracle.NewBloomFilterSet(info.GetSegmentID(), info.GetPartitionID(), commonpb.SegmentState_Sealed)
+			bf := bloomfilter.NewBloomFilterWithType(
+				paramtable.Get().CommonCfg.BloomFilterSize.GetAsUint(),
+				paramtable.Get().CommonCfg.MaxBloomFalsePositive.GetAsFloat(),
+				paramtable.Get().CommonCfg.BloomFilterType.GetValue())
+			pks := &storage.PkStatistics{PkFilter: bf}
+			pks.UpdatePKRange(&storage.Int64FieldData{Data: []int64{10, 20, 30}})
+			bfs.AddHistoricalStats(pks)
+			return bfs
+		})
+	}, func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) error {
+		return nil
+	})
+
+	worker1 := &cluster.MockWorker{}
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
+
+	// Block the Phase-3 Flush's worker.Delete, simulating a worker saturated by the load storm.
+	// Signal once we are inside it — at that point Phase 3 is holding deleteMut.RLock.
+	deleteEntered := make(chan struct{})
+	releaseDelete := make(chan struct{})
+	var once sync.Once
+	worker1.EXPECT().Delete(mock.Anything, mock.AnythingOfType("*querypb.DeleteRequest")).
+		RunAndReturn(func(ctx context.Context, req *querypb.DeleteRequest) error {
+			once.Do(func() { close(deleteEntered) })
+			<-releaseDelete
+			return nil
+		})
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+
+	// Pre-populate the delete buffer so loadStreamDelete has historical deletes to replay.
+	for i := 0; i < 100; i++ {
+		s.delegator.ProcessDelete([]*DeleteData{{
+			PartitionID: 500,
+			PrimaryKeys: []storage.PrimaryKey{storage.NewInt64PrimaryKey(int64(i))},
+			Timestamps:  []uint64{uint64(10 + i)},
+			RowCount:    1,
+		}}, uint64(10+i))
+	}
+
+	// Start the segment load; its Phase-3 Flush blocks in worker.Delete while holding RLock.
+	go func() {
+		_ = s.delegator.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+			Base:         commonpbutil.NewMsgBase(),
+			DstNodeID:    1,
+			CollectionID: s.collectionID,
+			Infos: []*querypb.SegmentLoadInfo{{
+				SegmentID:     300,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 5},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 5},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			}},
+		})
+	}()
+
+	// Wait until Phase 3 is inside the blocked worker.Delete, i.e. holding deleteMut.RLock.
+	select {
+	case <-deleteEntered:
+	case <-time.After(5 * time.Second):
+		close(releaseDelete)
+		s.FailNow("loadStreamDelete never reached Phase-3 worker.Delete")
+	}
+
+	// A live delete now arrives on the flowgraph. ProcessDelete needs deleteMut.Lock (write);
+	// tsafe advancement depends on it completing. It must NOT be starved by the Phase-3 RLock.
+	processDone := make(chan struct{})
+	go func() {
+		s.delegator.ProcessDelete([]*DeleteData{{
+			PartitionID: 500,
+			PrimaryKeys: []storage.PrimaryKey{storage.NewInt64PrimaryKey(999)},
+			Timestamps:  []uint64{200},
+			RowCount:    1,
+		}}, 200)
+		close(processDone)
+	}()
+
+	starved := false
+	select {
+	case <-processDone:
+	case <-time.After(time.Second):
+		starved = true // still blocked while Phase 3 holds RLock during the slow Flush
+	}
+
+	close(releaseDelete) // let the load finish
+	<-processDone        // ProcessDelete returns once the RLock is released
+
+	s.False(starved, "ProcessDelete (and thus tsafe) was starved by loadStreamDelete Phase-3 RLock-during-Flush — issue #49435")
+}
+
+// TestLoadStreamDeleteCatchUpFlushDoesNotStarveProcessDelete covers the catch-up
+// path specifically (issue #49435 adversarial review): a delete that arrives
+// AFTER the Phase-1 snapshot is forwarded during catch-up. The catch-up
+// worker.Delete must run without deleteMut.RLock held, so a saturated worker
+// there must not starve the live ProcessDelete either. This FAILS if the final
+// catch-up forward is done under the lock, and PASSES once catch-up forwards
+// lock-free.
+func (s *DelegatorDataSuite) TestLoadStreamDeleteCatchUpFlushDoesNotStarveProcessDelete() {
+	defer func() {
+		s.workerManager.ExpectedCalls = nil
+		s.loader.ExpectedCalls = nil
+	}()
+
+	// BF matches {10,20,30}: small batches, so worker.Delete is reached only via
+	// explicit Flush, never a lock-free auto-sync over ForwardBatchSize.
+	s.loader.EXPECT().LoadBloomFilterSet(mock.Anything, s.collectionID, mock.Anything).
+		Call.Return(func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) []*pkoracle.BloomFilterSet {
+		return lo.Map(infos, func(info *querypb.SegmentLoadInfo, _ int) *pkoracle.BloomFilterSet {
+			bfs := pkoracle.NewBloomFilterSet(info.GetSegmentID(), info.GetPartitionID(), commonpb.SegmentState_Sealed)
+			bf := bloomfilter.NewBloomFilterWithType(
+				paramtable.Get().CommonCfg.BloomFilterSize.GetAsUint(),
+				paramtable.Get().CommonCfg.MaxBloomFalsePositive.GetAsFloat(),
+				paramtable.Get().CommonCfg.BloomFilterType.GetValue())
+			pks := &storage.PkStatistics{PkFilter: bf}
+			pks.UpdatePKRange(&storage.Int64FieldData{Data: []int64{10, 20, 30}})
+			bfs.AddHistoricalStats(pks)
+			return bfs
+		})
+	}, func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) error {
+		return nil
+	})
+
+	worker1 := &cluster.MockWorker{}
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+
+	// worker.Delete: the FIRST call is the bulk-snapshot flush (lock-free). Inside
+	// it, inject a NEW delete (pk 20, later ts) so the catch-up round has a record
+	// to forward. Every SUBSEQUENT call (the catch-up flush) blocks, simulating a
+	// worker still saturated by the load storm; signal once we're inside it.
+	deleteEntered := make(chan struct{})
+	releaseDelete := make(chan struct{})
+	var callNo atomic.Int32
+	var enterOnce sync.Once
+	worker1.EXPECT().Delete(mock.Anything, mock.AnythingOfType("*querypb.DeleteRequest")).
+		RunAndReturn(func(ctx context.Context, req *querypb.DeleteRequest) error {
+			if callNo.Add(1) == 1 {
+				// Bulk flush done lock-free; a live delete arrives now and lands
+				// after the Phase-1 snapshot, so it must be caught up.
+				s.delegator.ProcessDelete([]*DeleteData{{
+					PartitionID: 500,
+					PrimaryKeys: []storage.PrimaryKey{storage.NewInt64PrimaryKey(20)},
+					Timestamps:  []uint64{200},
+					RowCount:    1,
+				}}, 200)
+				return nil
+			}
+			enterOnce.Do(func() { close(deleteEntered) })
+			<-releaseDelete
+			return nil
+		})
+
+	// Pre-populate the delete buffer (the Phase-1 snapshot).
+	for i := 0; i < 100; i++ {
+		s.delegator.ProcessDelete([]*DeleteData{{
+			PartitionID: 500,
+			PrimaryKeys: []storage.PrimaryKey{storage.NewInt64PrimaryKey(int64(i))},
+			Timestamps:  []uint64{uint64(10 + i)},
+			RowCount:    1,
+		}}, uint64(10+i))
+	}
+
+	go func() {
+		_ = s.delegator.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+			Base:         commonpbutil.NewMsgBase(),
+			DstNodeID:    1,
+			CollectionID: s.collectionID,
+			Infos: []*querypb.SegmentLoadInfo{{
+				SegmentID:     301,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 5},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 5},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			}},
+		})
+	}()
+
+	// Wait until the catch-up flush is inside the blocked worker.Delete.
+	select {
+	case <-deleteEntered:
+	case <-time.After(5 * time.Second):
+		close(releaseDelete)
+		s.FailNow("loadStreamDelete never reached the catch-up worker.Delete")
+	}
+
+	// A live delete arrives; ProcessDelete needs deleteMut.Lock and must not be
+	// starved by the (now lock-free) catch-up flush.
+	processDone := make(chan struct{})
+	go func() {
+		s.delegator.ProcessDelete([]*DeleteData{{
+			PartitionID: 500,
+			PrimaryKeys: []storage.PrimaryKey{storage.NewInt64PrimaryKey(999)},
+			Timestamps:  []uint64{300},
+			RowCount:    1,
+		}}, 300)
+		close(processDone)
+	}()
+
+	starved := false
+	select {
+	case <-processDone:
+	case <-time.After(time.Second):
+		starved = true
+	}
+
+	close(releaseDelete)
+	<-processDone
+
+	s.False(starved, "ProcessDelete was starved by the catch-up worker.Delete holding deleteMut.RLock — issue #49435")
+}
+
+// TestLoadStreamDeleteCatchUpPastCapTerminatesWithFinalBarrier covers the
+// adversarial cap path: catch-up keeps seeing new delete records past the
+// lock-free rounds. loadStreamDelete must eventually stop waiting for a
+// globally quiet delete stream by applying one final locked tail and publishing
+// the segment before releasing deleteMut.
+func (s *DelegatorDataSuite) TestLoadStreamDeleteCatchUpPastCapTerminatesWithFinalBarrier() {
+	defer func() {
+		s.workerManager.ExpectedCalls = nil
+		s.loader.ExpectedCalls = nil
+	}()
+
+	s.loader.EXPECT().LoadBloomFilterSet(mock.Anything, s.collectionID, mock.Anything).
+		Call.Return(func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) []*pkoracle.BloomFilterSet {
+		return lo.Map(infos, func(info *querypb.SegmentLoadInfo, _ int) *pkoracle.BloomFilterSet {
+			bfs := pkoracle.NewBloomFilterSet(info.GetSegmentID(), info.GetPartitionID(), commonpb.SegmentState_Sealed)
+			bf := bloomfilter.NewBloomFilterWithType(
+				paramtable.Get().CommonCfg.BloomFilterSize.GetAsUint(),
+				paramtable.Get().CommonCfg.MaxBloomFalsePositive.GetAsFloat(),
+				paramtable.Get().CommonCfg.BloomFilterType.GetValue())
+			pks := &storage.PkStatistics{PkFilter: bf}
+			pks.UpdatePKRange(&storage.Int64FieldData{Data: []int64{10, 20, 30}})
+			bfs.AddHistoricalStats(pks)
+			return bfs
+		})
+	}, func(ctx context.Context, collectionID int64, infos ...*querypb.SegmentLoadInfo) error {
+		return nil
+	})
+
+	worker1 := &cluster.MockWorker{}
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+
+	finalBarrierEntered := make(chan struct{})
+	releaseFinalBarrier := make(chan struct{})
+	var releaseFinalOnce sync.Once
+	defer releaseFinalOnce.Do(func() { close(releaseFinalBarrier) })
+	var callNo atomic.Int32
+	var finalOnce sync.Once
+	worker1.EXPECT().Delete(mock.Anything, mock.AnythingOfType("*querypb.DeleteRequest")).
+		RunAndReturn(func(ctx context.Context, req *querypb.DeleteRequest) error {
+			call := callNo.Add(1)
+			if call <= 6 {
+				// Keep one matching delete arriving after every lock-free
+				// catch-up flush. Call 1 is the bulk snapshot flush; calls
+				// 2-6 are catch-up rounds 0-4, so the next round reaches the
+				// maxLockFreeCatchUpRounds cap with remaining > 0.
+				ts := uint64(199 + call)
+				s.delegator.ProcessDelete([]*DeleteData{{
+					PartitionID: 500,
+					PrimaryKeys: []storage.PrimaryKey{
+						storage.NewInt64PrimaryKey(20),
+					},
+					Timestamps: []uint64{ts},
+					RowCount:   1,
+				}}, ts)
+				return nil
+			}
+			finalOnce.Do(func() { close(finalBarrierEntered) })
+			<-releaseFinalBarrier
+			return nil
+		})
+
+	for i := 0; i < 100; i++ {
+		s.delegator.ProcessDelete([]*DeleteData{{
+			PartitionID: 500,
+			PrimaryKeys: []storage.PrimaryKey{
+				storage.NewInt64PrimaryKey(int64(i)),
+			},
+			Timestamps: []uint64{uint64(10 + i)},
+			RowCount:   1,
+		}}, uint64(10+i))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	loadDone := make(chan error, 1)
+	go func() {
+		loadDone <- s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+			Base:         commonpbutil.NewMsgBase(),
+			DstNodeID:    1,
+			CollectionID: s.collectionID,
+			Infos: []*querypb.SegmentLoadInfo{{
+				SegmentID:     302,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 5},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 5},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			}},
+		})
+	}()
+
+	select {
+	case <-finalBarrierEntered:
+	case <-time.After(5 * time.Second):
+		releaseFinalOnce.Do(func() { close(releaseFinalBarrier) })
+		s.FailNow("loadStreamDelete never reached the final locked catch-up barrier")
+	}
+
+	// A live delete attempts to arrive while the final barrier holds RLock. It is
+	// allowed to wait briefly here; the point of the barrier is that loadStreamDelete
+	// now terminates instead of chasing new arrivals forever.
+	processDone := make(chan struct{})
+	go func() {
+		s.delegator.ProcessDelete([]*DeleteData{{
+			PartitionID: 500,
+			PrimaryKeys: []storage.PrimaryKey{
+				storage.NewInt64PrimaryKey(999),
+			},
+			Timestamps: []uint64{300},
+			RowCount:   1,
+		}}, 300)
+		close(processDone)
+	}()
+
+	releaseFinalOnce.Do(func() { close(releaseFinalBarrier) })
+
+	select {
+	case err := <-loadDone:
+		s.NoError(err)
+	case <-time.After(2 * time.Second):
+		s.FailNow("loadStreamDelete did not terminate after the final locked catch-up barrier")
+	}
+
+	select {
+	case <-processDone:
+	case <-time.After(2 * time.Second):
+		s.FailNow("ProcessDelete did not resume after the final locked catch-up barrier")
+	}
+
+	s.GreaterOrEqual(callNo.Load(), int32(7), "loadStreamDelete should reach the post-cap final barrier")
+}
+
 func (s *DelegatorDataSuite) TestDelegatorData_ExcludeSegments() {
 	s.delegator.AddExcludedSegments(map[int64]uint64{
 		1: 3,


### PR DESCRIPTION
issue: #49435

On streaming standalone, concurrent Strong `count(*)` + upsert intermittently fails with `code=505 channel tsafe stalled`.

### Root cause (measured with per-step instrumentation on the reproducing benchmark)

1. `loadStreamDelete` held the delegator's `deleteMut.RLock` across the whole post-load delete replay (forward → `LoadDeltaData` → segcore apply). Under replay amplification — a freshly compacted segment replays the entire buffered delete history, and batches of ~100K delete pks matched 50–100M rows (multiple delete versions per pk × multiple physical row versions) — a single apply took 20–50s, starving `ProcessDelete`, the single writer that also advances tsafe. The channel froze and every Strong query on it failed; on standalone (single replica) the retries land on the same delegator, so the failure is user-visible.
2. Inside the apply, `search_batch_pks` resolved every matched row's insert timestamp through `ReadTimestamp()` — a per-row cachinglayer pin — measured at ~60% of the call.

### Fixes

1. **Delegator (chase-then-lock)**: the bulk snapshot flush and iterative catch-up rounds now run lock-free; only the final trickle catch-up + `addDistribution` remain under `deleteMut.RLock`. The original atomicity invariant (no delete can fall between "deletes applied" and "segment visible") is unchanged — the locked section is structurally identical to before — while its payload drops from the whole replay to typically zero-to-a-few-hundred rows. Includes a regression test that blocks `worker.Delete` during load and asserts `ProcessDelete` is not starved (fails on the old code with a 50s+ stall).
2. **Segcore**: batch-pin the timestamp column once per `search_batch_pks` call from the same published snapshot and read raw pointers in the loop. Pins are refcounts on the snapshot's cells, so segment-reopen's atomic publication is not blocked; per-call snapshot consistency is identical to the per-row variant.

### Verification

2 rounds × 4 concurrent instances of the reproducing benchmark (sift-2M, partition-key collection, Strong `count(*)` + upsert, 8C/16Gi standalone) — all 8 runs passed:

| metric | before (4 runs) | after (8 runs) |
|---|---|---|
| `channel tsafe stalled` | ≥1000 lines per pod | **0** |
| client-visible errors | present | **0** (incl. `count(*)==2,000,000` checks) |
| `LoadDeletedRecord` avg | ~10.9s (peaks 28–54s) | 1.5–2.1s |
| writer `ProcessDelete` avg (incl. lock wait) | spikes 1000–3900ms | 10–12ms |

Notably the fixed runs still contained ~87 applies exceeding 10s (the replay-window amplification is a separate follow-up: a delete-coverage watermark recorded at compaction time), yet **zero** tsafe stalls — the lock fix decouples apply latency from query availability structurally, not merely by being faster.

Argo: [round 1](https://argo-workflows.zilliz.cc/archived-workflows/qa/30407f17-7081-4e95-ad5f-0b976492f1ab), [round 2](https://argo-workflows.zilliz.cc/workflows/qa/fouramf-concurrent-008?tab=workflow&nodeId=fouramf-concurrent-008-1424237708&nodePanelView=containers&sidePanel=logs:fouramf-concurrent-008-1424237708:)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
