### PR TITLE
enhance: allow hyphens in collection names

### DIFF
--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -235,8 +235,8 @@ func validateCollectionNameOrAlias(entity, entityType string) error {
 
 	for i := 1; i < len(entity); i++ {
 		c := entity[i]
-		if c != '_' && !isAlpha(c) && !isNumber(c) {
-			return merr.WrapErrParameterInvalidMsg("%s collection %s can only contain numbers, letters and underscores", invalidMsg, entityType)
+		if c != '_' && c != '-' && !isAlpha(c) && !isNumber(c) {
+			return merr.WrapErrParameterInvalidMsg("%s collection %s can only contain numbers, letters, underscores and hyphens", invalidMsg, entityType)
 		}
 	}
 	return nil

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -94,6 +94,18 @@ func TestValidateCollectionName(t *testing.T) {
 	assert.Nil(t, validateCollectionName("_123abc"))
 	assert.Nil(t, validateCollectionName("abc123_"))
 
+	// Hyphens are allowed after the first character (issue #50676), so that
+	// externally-derived names (e.g. tenant/environment identifiers) can be
+	// used directly without a normalization layer.
+	assert.Nil(t, validateCollectionName("rag-prod"))
+	assert.Nil(t, validateCollectionName("tenant-a_docs"))
+	assert.Nil(t, validateCollectionName("customer-123_vectors"))
+	assert.Nil(t, validateCollectionName("a-b"))
+
+	// The same relaxation applies to aliases, which share the validator.
+	assert.Nil(t, validateCollectionNameOrAlias("rag-prod", "alias"))
+	assert.Nil(t, ValidateCollectionAlias("tenant-a_docs"))
+
 	longName := make([]byte, 256)
 	for i := 0; i < len(longName); i++ {
 		longName[i] = 'a'
@@ -108,6 +120,7 @@ func TestValidateCollectionName(t *testing.T) {
 		string(longName),
 		"中文",
 		"abc ",
+		"-abc", // hyphen is still not allowed as the first character
 	}
 
 	for _, name := range invalidNames {


### PR DESCRIPTION
## What

Allow the hyphen `-` in collection names (and aliases, which share the same
validator) after the first character. `validateCollectionNameOrAlias` in
`internal/proxy/util.go` previously accepted only letters, digits, and
underscores; it now also accepts `-` in positions 2..N. The first-character
rule is unchanged (must be an underscore or a letter), so a leading hyphen is
still rejected.

## Why

Many systems use hyphenated identifiers for environments, tenants, and datasets
(`rag-prod`, `tenant-a_docs`, `customer-123_vectors`). Today applications have to
add a normalization layer (usually `-` → `_`) before creating Milvus collections,
which adds friction when mapping collections back to upstream resources. This was
requested and accepted in issue #50676.

## Testing

- Extended `TestValidateCollectionName` (`internal/proxy/util_test.go`) with the
  new valid hyphenated names (`rag-prod`, `tenant-a_docs`, `customer-123_vectors`,
  `a-b`) and a still-invalid leading-hyphen case (`-abc`). The existing invalid
  cases (`$abc`, `abc$`, `中文`, whitespace, over-length) continue to fail, so only
  `-` was newly permitted.
- `internal/proxy` unit tests link the C++ core (`milvus_core`) plus `rocksdb`/
  `rdkafka` via cgo and cannot be built in my local environment, so I verified the
  patched validation loop's behavior with a standalone replica of the exact logic
  (7 valid + 9 invalid cases all correct). The package unit test
  (`TestValidateCollectionName`) is left for CI to compile and run.

## Compatibility

This is a strictly backward-compatible relaxation: every name valid before this
change is still valid, and no code path was found that rejects hyphenated names
downstream — collection-name validation is single-source in `internal/proxy/util.go`,
there is no C++ re-validation of collection names, and channel/etcd keys are built
from numeric collection IDs rather than by splitting names on `-`.

## Notes for reviewers

- The relaxed validator is shared by collection names and aliases, so aliases gain
  hyphen support too. This seems consistent (they share one namespace), but if you
  want aliases held to the stricter rule, I can split the validator.
- The sibling validators (database name, partition name, resource-group name,
  privilege-group name, field name) are intentionally left unchanged — this PR is
  scoped to collection names/aliases per the issue.

issue: #50676