### PR TITLE
fix: keep group-by values consistent with grouping decision after requery

### DIFF
--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tidwall/gjson"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -2981,6 +2982,65 @@ func mergeIDsFunc(ctx context.Context, span trace.Span, inputs ...any) ([]any, e
 	return []any{uniqueIDs}, nil
 }
 
+// restoreGroupByFieldData overwrites group-by columns in FieldsData with the
+// search-time group-by values carried on the result data (GroupByFieldValues,
+// or the legacy singular GroupByFieldValue). The group-by decision (which rows
+// survive group_size) is made on the rows returned by search, but output fields
+// are re-fetched by PK only via requery/organize; when duplicate PKs exist, the
+// re-fetched row can be a different physical row with a different group-by
+// value, surfacing duplicated group values in the final response even with
+// group_size=1. Restoring the search-time values keeps the response consistent
+// with the grouping decision. Results without group-by are left untouched.
+func restoreGroupByFieldData(data *schemapb.SearchResultData) {
+	if data == nil {
+		return
+	}
+	groupByValues := data.GetGroupByFieldValues()
+	if len(groupByValues) == 0 && data.GetGroupByFieldValue() != nil {
+		groupByValues = []*schemapb.FieldData{data.GetGroupByFieldValue()}
+	}
+	for _, gbv := range groupByValues {
+		if gbv == nil {
+			continue
+		}
+		for i, fd := range data.GetFieldsData() {
+			// A type mismatch means the group-by key is an extraction (e.g. a
+			// JSON path or dynamic key) rather than the whole column; keep the
+			// re-fetched column in that case.
+			if fd == nil || fd.GetType() != gbv.GetType() {
+				continue
+			}
+			if (gbv.GetFieldId() != 0 && fd.GetFieldId() == gbv.GetFieldId()) ||
+				(gbv.GetFieldId() == 0 && gbv.GetFieldName() != "" && fd.GetFieldName() == gbv.GetFieldName()) {
+				data.FieldsData[i] = proto.Clone(gbv).(*schemapb.FieldData)
+				break
+			}
+		}
+	}
+}
+
+// attachOrganizedFieldsFunc is the shared "result" node body of rerank-based
+// pipelines: attach the organized output fields to the rank result, then
+// restore group-by columns so they reflect the values the grouping was
+// computed on (see restoreGroupByFieldData).
+func attachOrganizedFieldsFunc(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+	result := inputs[0].(*milvuspb.SearchResults)
+	fields := inputs[1].([][]*schemapb.FieldData)
+	result.Results.FieldsData = fields[0]
+	restoreGroupByFieldData(result.GetResults())
+	return []any{result}, nil
+}
+
+// pickOrganizedFieldsFunc is attachOrganizedFieldsFunc for pipelines whose
+// carrying result is the reduced result list instead of a rank result.
+func pickOrganizedFieldsFunc(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+	result := inputs[0].([]*milvuspb.SearchResults)[0]
+	fields := inputs[1].([][]*schemapb.FieldData)
+	result.Results.FieldsData = fields[0]
+	restoreGroupByFieldData(result.GetResults())
+	return []any{result}, nil
+}
+
 type pipeline struct {
 	name         string
 	nodes        []*Node
@@ -3147,12 +3207,7 @@ var searchWithRequeryPipe = &pipelineDef{
 			inputs:  []string{"reduced", "organized_fields"},
 			outputs: []string{"result"},
 			params: map[string]any{
-				lambdaParamKey: func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
-					result := inputs[0].([]*milvuspb.SearchResults)[0]
-					fields := inputs[1].([][]*schemapb.FieldData)
-					result.Results.FieldsData = fields[0]
-					return []any{result}, nil
-				},
+				lambdaParamKey: pickOrganizedFieldsFunc,
 			},
 			opName: lambdaOp,
 		},
@@ -3199,12 +3254,7 @@ var searchWithRerankPipe = &pipelineDef{
 			inputs:  []string{"rank_result", "organized_fields"},
 			outputs: []string{"result"},
 			params: map[string]any{
-				lambdaParamKey: func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
-					result := inputs[0].(*milvuspb.SearchResults)
-					fields := inputs[1].([][]*schemapb.FieldData)
-					result.Results.FieldsData = fields[0]
-					return []any{result}, nil
-				},
+				lambdaParamKey: attachOrganizedFieldsFunc,
 			},
 			opName: lambdaOp,
 		},
@@ -3267,12 +3317,7 @@ var searchWithRerankRequeryPipe = &pipelineDef{
 			inputs:  []string{"rank_result", "organized_fields"},
 			outputs: []string{"result"},
 			params: map[string]any{
-				lambdaParamKey: func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
-					result := inputs[0].(*milvuspb.SearchResults)
-					fields := inputs[1].([][]*schemapb.FieldData)
-					result.Results.FieldsData = fields[0]
-					return []any{result}, nil
-				},
+				lambdaParamKey: attachOrganizedFieldsFunc,
 			},
 			opName: lambdaOp,
 		},
@@ -3422,12 +3467,7 @@ var hybridSearchWithRequeryAndRerankByFieldDataPipe = &pipelineDef{
 			inputs:  []string{"rank_result", "organized_fields"},
 			outputs: []string{"result"},
 			params: map[string]any{
-				lambdaParamKey: func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
-					result := inputs[0].(*milvuspb.SearchResults)
-					fields := inputs[1].([][]*schemapb.FieldData)
-					result.Results.FieldsData = fields[0]
-					return []any{result}, nil
-				},
+				lambdaParamKey: attachOrganizedFieldsFunc,
 			},
 			opName: lambdaOp,
 		},
@@ -3491,12 +3531,7 @@ var hybridSearchWithRequeryPipe = &pipelineDef{
 			inputs:  []string{"rank_result", "organized_fields"},
 			outputs: []string{"result"},
 			params: map[string]any{
-				lambdaParamKey: func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
-					result := inputs[0].(*milvuspb.SearchResults)
-					fields := inputs[1].([][]*schemapb.FieldData)
-					result.Results.FieldsData = fields[0]
-					return []any{result}, nil
-				},
+				lambdaParamKey: attachOrganizedFieldsFunc,
 			},
 			opName: lambdaOp,
 		},
@@ -3555,12 +3590,7 @@ var searchWithOrderByPipe = &pipelineDef{
 			inputs:  []string{"reduced", "organized_fields"},
 			outputs: []string{"result"},
 			params: map[string]any{
-				lambdaParamKey: func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
-					result := inputs[0].([]*milvuspb.SearchResults)[0]
-					fields := inputs[1].([][]*schemapb.FieldData)
-					result.Results.FieldsData = fields[0]
-					return []any{result}, nil
-				},
+				lambdaParamKey: pickOrganizedFieldsFunc,
 			},
 			opName: lambdaOp,
 		},

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -2698,6 +2698,159 @@ func (s *SearchPipelineSuite) TestHybridSearchWithRequeryPipe() {
 	s.Equal(int64(2*2*10), results.GetResults().AllSearchCount)
 }
 
+func makeInt64FieldData(name string, id int64, values []int64) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: name,
+		FieldId:   id,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: values}},
+			},
+		},
+	}
+}
+
+func (s *SearchPipelineSuite) TestRestoreGroupByFieldData() {
+	s.Run("nil data", func() {
+		s.NotPanics(func() { restoreGroupByFieldData(nil) })
+	})
+
+	s.Run("no group-by values is a no-op", func() {
+		data := &schemapb.SearchResultData{FieldsData: []*schemapb.FieldData{makeInt64FieldData("f", 101, []int64{1, 2})}}
+		restoreGroupByFieldData(data)
+		s.Equal([]int64{1, 2}, data.FieldsData[0].GetScalars().GetLongData().GetData())
+	})
+
+	s.Run("restores column matched by field id", func() {
+		data := &schemapb.SearchResultData{
+			FieldsData:         []*schemapb.FieldData{makeInt64FieldData("f", 101, []int64{66, 66, 66})},
+			GroupByFieldValues: []*schemapb.FieldData{makeInt64FieldData("f", 101, []int64{66001, 66002, 66003})},
+		}
+		restoreGroupByFieldData(data)
+		s.Equal([]int64{66001, 66002, 66003}, data.FieldsData[0].GetScalars().GetLongData().GetData())
+	})
+
+	s.Run("restores column from legacy singular channel", func() {
+		data := &schemapb.SearchResultData{
+			FieldsData:        []*schemapb.FieldData{makeInt64FieldData("f", 101, []int64{66, 66})},
+			GroupByFieldValue: makeInt64FieldData("f", 101, []int64{1, 2}),
+		}
+		restoreGroupByFieldData(data)
+		s.Equal([]int64{1, 2}, data.FieldsData[0].GetScalars().GetLongData().GetData())
+	})
+
+	s.Run("matches by name when field id is unset", func() {
+		data := &schemapb.SearchResultData{
+			FieldsData:         []*schemapb.FieldData{makeInt64FieldData("f", 101, []int64{66, 66})},
+			GroupByFieldValues: []*schemapb.FieldData{makeInt64FieldData("f", 0, []int64{7, 8})},
+		}
+		restoreGroupByFieldData(data)
+		s.Equal([]int64{7, 8}, data.FieldsData[0].GetScalars().GetLongData().GetData())
+	})
+
+	s.Run("keeps column when types differ (json path group key)", func() {
+		jsonField := &schemapb.FieldData{
+			Type:      schemapb.DataType_JSON,
+			FieldName: "meta",
+			FieldId:   102,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{"k":1}`)}}},
+				},
+			},
+		}
+		data := &schemapb.SearchResultData{
+			FieldsData:         []*schemapb.FieldData{jsonField},
+			GroupByFieldValues: []*schemapb.FieldData{makeInt64FieldData("meta", 102, []int64{1})},
+		}
+		restoreGroupByFieldData(data)
+		s.Equal([][]byte{[]byte(`{"k":1}`)}, data.FieldsData[0].GetScalars().GetJsonData().GetData())
+	})
+
+	s.Run("other columns stay intact", func() {
+		data := &schemapb.SearchResultData{
+			FieldsData: []*schemapb.FieldData{
+				makeInt64FieldData("other", 105, []int64{9, 9}),
+				makeInt64FieldData("f", 101, []int64{66, 66}),
+			},
+			GroupByFieldValues: []*schemapb.FieldData{makeInt64FieldData("f", 101, []int64{1, 2})},
+		}
+		restoreGroupByFieldData(data)
+		s.Equal([]int64{9, 9}, data.FieldsData[0].GetScalars().GetLongData().GetData())
+		s.Equal([]int64{1, 2}, data.FieldsData[1].GetScalars().GetLongData().GetData())
+	})
+}
+
+// Regression for the duplicate-PK group-by mismatch: the group-by decision is
+// made on the rows returned by search, but requery re-fetches output fields by
+// PK only. When the same PK has multiple physical rows with different group-by
+// values, the requeried row can differ from the searched row and the response
+// would show duplicated group values despite group_size=1. The final result
+// must carry the search-time group-by values.
+func (s *SearchPipelineSuite) TestHybridSearchWithRequeryPipeKeepsGroupByFieldValues() {
+	task := getHybridSearchTask("test_collection", [][]string{{"1"}, {"2"}}, []string{"intField"})
+
+	originalReduceFactory := opFactory[hybridSearchReduceOp]
+	originalRerankFactory := opFactory[rerankOp]
+	defer func() {
+		opFactory[hybridSearchReduceOp] = originalReduceFactory
+		opFactory[rerankOp] = originalRerankFactory
+	}()
+
+	opFactory[hybridSearchReduceOp] = func(_ *searchTask, _ map[string]any) (operator, error) {
+		return searchPipelineTestOperator(func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+			reduced := []*milvuspb.SearchResults{{
+				Status:  merr.Success(),
+				Results: &schemapb.SearchResultData{},
+			}}
+			return []any{reduced, []string{"IP"}}, nil
+		}), nil
+	}
+
+	// The rerank/group-by stage selected three rows whose search-time group-by
+	// values are distinct.
+	opFactory[rerankOp] = func(_ *searchTask, _ map[string]any) (operator, error) {
+		return searchPipelineTestOperator(func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
+			return []any{&milvuspb.SearchResults{
+				Status: merr.Success(),
+				Results: &schemapb.SearchResultData{
+					NumQueries: 1,
+					TopK:       3,
+					Topks:      []int64{3},
+					Ids: &schemapb.IDs{
+						IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{6, 7, 8}}},
+					},
+					Scores:             []float32{0.9, 0.8, 0.7},
+					GroupByFieldValues: []*schemapb.FieldData{makeInt64FieldData("intField", 101, []int64{66001, 66002, 66003})},
+				},
+			}}, nil
+		}), nil
+	}
+
+	// Requery returns newer duplicate-PK rows whose group-by values collapsed
+	// to a single value.
+	mocker := mockey.Mock((*requeryOperator).requery).Return(&milvuspb.QueryResults{
+		FieldsData: []*schemapb.FieldData{
+			makeInt64FieldData("int64", 100, []int64{6, 7, 8}),
+			makeInt64FieldData("intField", 101, []int64{66, 66, 66}),
+		},
+	}, segcore.StorageCost{}, nil).Build()
+	defer mocker.UnPatch()
+
+	pipeline, err := newPipeline(hybridSearchWithRequeryPipe, task)
+	s.Require().NoError(err)
+	s.Require().NoError(pipeline.AddNodes(task, endNode))
+
+	results, _, err := pipeline.Run(context.Background(), s.span, nil, segcore.StorageCost{})
+	s.Require().NoError(err)
+
+	s.Equal([]int64{6, 7, 8}, results.GetResults().GetIds().GetIntId().GetData())
+	s.Require().Len(results.GetResults().GetFieldsData(), 1)
+	s.Equal("intField", results.GetResults().GetFieldsData()[0].GetFieldName())
+	s.Equal([]int64{66001, 66002, 66003}, results.GetResults().GetFieldsData()[0].GetScalars().GetLongData().GetData())
+}
+
 func getHybridSearchTask(collName string, data [][]string, outputFields []string) *searchTask {
 	subReqs := []*milvuspb.SubSearchRequest{}
 	for _, item := range data {


### PR DESCRIPTION
issue: #50603

### Problem

`HybridSearch` with `group_by_field`, `group_size=1`, `strict_group_size=True` can return duplicated group values in the final response. The group-by decision is made on the rows returned by search (the rank result carries their group-by values), but `pick_ids -> requery` then re-fetches output fields **by primary key only**. When the same PK has multiple visible physical rows whose group-by values differ (duplicate PKs inserted rather than upserted), search/group-by picks the best-distance row while requery returns the latest-timestamp row — so the displayed group value can differ from the value the grouping was decided on, and distinct groups collapse into duplicates in the output.

### Change

- Add `restoreGroupByFieldData`, which overwrites group-by columns in the final `FieldsData` with the search-time group-by values already carried on the result (`GroupByFieldValues`, or the legacy singular `GroupByFieldValue`). Columns are matched by field id (name as fallback); a type mismatch means the group key is an extraction (JSON path / dynamic key) rather than a whole column, and the re-fetched column is kept in that case.
- Apply it in the result/pick node of every pipeline that overwrites `FieldsData` with re-fetched fields: `hybridSearchWithRequeryPipe`, `hybridSearchWithRequeryAndRerankByFieldDataPipe`, `searchWithRerankRequeryPipe`, `searchWithRerankPipe`, `searchWithRequeryPipe`, `searchWithOrderByPipe`. Those six node bodies were byte-identical lambdas; they are deduplicated into two named functions (`attachOrganizedFieldsFunc` / `pickOrganizedFieldsFunc`), so the fix lives in one place.
- Results without group-by carry no group-by values, so the restore is a no-op on all non-group-by paths.

### What this does not change

Non-group-by output fields still come from the requeried row, exactly as before. Pinning requery to the exact physical row that was searched (instead of PK-only fetch) would be a much larger change across proxy/querynode and is out of scope; with this fix the response is always consistent with the grouping decision, which is what `group_size` / `strict_group_size` semantics promise.

### Tests

- Unit tests for `restoreGroupByFieldData` (match by field id, name fallback, legacy singular channel, JSON-path/type-mismatch guard, untouched sibling columns, no-op without group-by).
- Pipeline-level regression `TestHybridSearchWithRequeryPipeKeepsGroupByFieldValues` reproducing the duplicate-PK scenario from the issue end-to-end through `pick_ids -> requery -> organize -> result -> filter_field`: rerank selects rows with group values `66001/66002/66003`, requery returns the same PKs collapsed to `66`, and the final response must show `66001/66002/66003`.
