### PR TITLE
test: cover create collection resource rollback boundary

### DIFF
--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -46,6 +46,21 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
+func TestCreateCollectionTaskReleaseFileResources(t *testing.T) {
+	meta := mockrootcoord.NewIMetaTable(t)
+	heldIDs := []int64{10, 20}
+	meta.EXPECT().DecFileResourceRefCnt(heldIDs).Once()
+
+	task := &createCollectionTask{
+		Core:                &Core{meta: meta},
+		heldFileResourceIds: heldIDs,
+	}
+
+	task.releaseFileResources()
+	require.Nil(t, task.heldFileResourceIds)
+	task.releaseFileResources()
+}
+
 func Test_createCollectionTask_validate(t *testing.T) {
 	paramtable.Init()
 	t.Run("empty request", func(t *testing.T) {

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -258,6 +258,43 @@ func TestBroadcastTaskNotCreatedOnStoppedBroadcaster(t *testing.T) {
 	nextGuards.Unlock()
 }
 
+func TestBroadcastTaskErrorAfterRegistrationIsUnmarked(t *testing.T) {
+	paramtable.Init()
+
+	locker := newResourceKeyLocker()
+	rk := message.NewExclusiveCollectionNameResourceKey("db", "collection")
+	guards := locker.Lock(rk)
+
+	taskRegistered := make(chan struct{})
+	scheduler := &broadcasterScheduler{
+		backgroundTaskNotifier: syncutil.NewAsyncTaskNotifier[struct{}](),
+		pendingChan:            make(chan *pendingBroadcastTask),
+	}
+	defer scheduler.backgroundTaskNotifier.Cancel()
+	go func() {
+		<-scheduler.pendingChan
+		close(taskRegistered)
+	}()
+
+	bm := &broadcastTaskManager{
+		lifetime:           typeutil.NewLifetime(),
+		mu:                 &sync.Mutex{},
+		tasks:              map[uint64]*broadcastTask{},
+		metrics:            newBroadcasterMetrics(),
+		broadcastScheduler: scheduler,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := bm.broadcast(ctx, createNewBroadcastMsg([]string{"v1"}, rk), 1, guards)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, IsBroadcastTaskNotCreated(err))
+	require.Contains(t, bm.tasks, uint64(1))
+	<-taskRegistered
+	bm.tasks[1].guards.Unlock()
+}
+
 func createNewBroadcastTask(broadcastID uint64, vchannels []string, rks ...message.ResourceKey) *streamingpb.BroadcastTask {
 	msg := createNewBroadcastMsg(vchannels).OverwriteBroadcastHeader(broadcastID, rks...)
 	pb := msg.IntoMessageProto()

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -248,6 +248,8 @@ func TestBroadcastTaskNotCreatedOnStoppedBroadcaster(t *testing.T) {
 
 	require.Error(t, err)
 	require.True(t, IsBroadcastTaskNotCreated(err))
+	require.True(t, IsBroadcastTaskNotCreated(errors.Wrap(err, "broadcast failed")))
+	require.False(t, IsBroadcastTaskNotCreated(context.Canceled))
 	require.True(t, streamingstatus.AsStreamingError(err).IsOnShutdown())
 	require.Empty(t, bm.tasks)
 


### PR DESCRIPTION
issue: #50961

## Summary

- verify reserved file-resource refs are released idempotently
- verify pre-registration broadcast failures are marked
- verify post-registration request cancellation stays unmarked so background tasks retain ownership