### PR TITLE
enhance: [3.0] allow updating inactive field analyzer params

### DIFF
--- a/internal/metastore/model/collection.go
+++ b/internal/metastore/model/collection.go
@@ -217,6 +217,7 @@ func (c *Collection) ApplyUpdates(header *message.AlterCollectionMessageHeader, 
 			c.Functions = UnmarshalFunctionModels(updates.Schema.Functions)
 			c.StructArrayFields = UnmarshalStructArrayFieldModels(updates.Schema.StructArrayFields)
 			c.SchemaVersion = updates.Schema.Version
+			c.FileResourceIds = updates.Schema.GetFileResourceIds()
 			c.ExternalSource = updates.Schema.ExternalSource
 			c.ExternalSpec = updates.Schema.ExternalSpec
 		case message.FieldMaskCollectionExternalSpec:

--- a/internal/mocks/streamingcoord/server/mock_broadcaster/mock_Broadcaster.go
+++ b/internal/mocks/streamingcoord/server/mock_broadcaster/mock_Broadcaster.go
@@ -6,9 +6,7 @@ import (
 	context "context"
 
 	broadcaster "github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
-
 	message "github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -104,12 +102,12 @@ func (_c *MockBroadcaster_Close_Call) RunAndReturn(run func()) *MockBroadcaster_
 	return _c
 }
 
-// GetPendingCreateCollectionResources provides a mock function with no fields
-func (_m *MockBroadcaster) GetPendingCreateCollectionResources() map[int64][]int64 {
+// GetPendingSchemaFileResources provides a mock function with no fields
+func (_m *MockBroadcaster) GetPendingSchemaFileResources() map[int64][]int64 {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetPendingCreateCollectionResources")
+		panic("no return value specified for GetPendingSchemaFileResources")
 	}
 
 	var r0 map[int64][]int64
@@ -124,29 +122,29 @@ func (_m *MockBroadcaster) GetPendingCreateCollectionResources() map[int64][]int
 	return r0
 }
 
-// MockBroadcaster_GetPendingCreateCollectionResources_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPendingCreateCollectionResources'
-type MockBroadcaster_GetPendingCreateCollectionResources_Call struct {
+// MockBroadcaster_GetPendingSchemaFileResources_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPendingSchemaFileResources'
+type MockBroadcaster_GetPendingSchemaFileResources_Call struct {
 	*mock.Call
 }
 
-// GetPendingCreateCollectionResources is a helper method to define mock.On call
-func (_e *MockBroadcaster_Expecter) GetPendingCreateCollectionResources() *MockBroadcaster_GetPendingCreateCollectionResources_Call {
-	return &MockBroadcaster_GetPendingCreateCollectionResources_Call{Call: _e.mock.On("GetPendingCreateCollectionResources")}
+// GetPendingSchemaFileResources is a helper method to define mock.On call
+func (_e *MockBroadcaster_Expecter) GetPendingSchemaFileResources() *MockBroadcaster_GetPendingSchemaFileResources_Call {
+	return &MockBroadcaster_GetPendingSchemaFileResources_Call{Call: _e.mock.On("GetPendingSchemaFileResources")}
 }
 
-func (_c *MockBroadcaster_GetPendingCreateCollectionResources_Call) Run(run func()) *MockBroadcaster_GetPendingCreateCollectionResources_Call {
+func (_c *MockBroadcaster_GetPendingSchemaFileResources_Call) Run(run func()) *MockBroadcaster_GetPendingSchemaFileResources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockBroadcaster_GetPendingCreateCollectionResources_Call) Return(_a0 map[int64][]int64) *MockBroadcaster_GetPendingCreateCollectionResources_Call {
+func (_c *MockBroadcaster_GetPendingSchemaFileResources_Call) Return(_a0 map[int64][]int64) *MockBroadcaster_GetPendingSchemaFileResources_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockBroadcaster_GetPendingCreateCollectionResources_Call) RunAndReturn(run func() map[int64][]int64) *MockBroadcaster_GetPendingCreateCollectionResources_Call {
+func (_c *MockBroadcaster_GetPendingSchemaFileResources_Call) RunAndReturn(run func() map[int64][]int64) *MockBroadcaster_GetPendingSchemaFileResources_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -2491,6 +2491,8 @@ var allowedAlterProps = []string{
 	common.MmapEnabledKey,
 	common.MaxCapacityKey,
 	common.FieldDescriptionKey,
+	common.EnableAnalyzerKey,
+	common.AnalyzerParamKey,
 	common.WarmupKey,
 	common.WarmupScalarFieldKey,
 	common.WarmupScalarIndexKey,
@@ -2500,6 +2502,8 @@ var allowedAlterProps = []string{
 
 var allowedDropProps = []string{
 	common.MmapEnabledKey,
+	common.EnableAnalyzerKey,
+	common.AnalyzerParamKey,
 	common.WarmupKey,
 	common.WarmupScalarFieldKey,
 	common.WarmupScalarIndexKey,
@@ -2553,6 +2557,38 @@ func updatePropertiesKeys(oldProps []*commonpb.KeyValuePair) []*commonpb.KeyValu
 	return propKV
 }
 
+func isAnalyzerFieldParam(key string) bool {
+	return key == common.EnableAnalyzerKey || key == common.AnalyzerParamKey
+}
+
+func getAlterCollectionFieldTarget(schema *schemapb.CollectionSchema, fieldName string) *schemapb.FieldSchema {
+	for _, field := range schema.GetFields() {
+		if field.GetName() == fieldName {
+			return field
+		}
+	}
+	return nil
+}
+
+func validateAlterAnalyzerFieldParam(collSchema *schemapb.CollectionSchema, fieldName string) error {
+	field := getAlterCollectionFieldTarget(collSchema, fieldName)
+	if field == nil {
+		return merr.WrapErrParameterInvalidMsg("field not found: %s", fieldName)
+	}
+
+	if !typeutil.IsStringType(field.GetDataType()) {
+		return merr.WrapErrParameterInvalidMsg("can not alter analyzer params for non-string field %s", fieldName)
+	}
+
+	if typeutil.CreateFieldSchemaHelper(field).EnableMatch() || typeutil.IsBm25FunctionInputField(collSchema, field) {
+		return merr.WrapErrParameterInvalidMsg(
+			"can not alter analyzer params for field %s after text match is enabled or BM25 function depends on it",
+			fieldName,
+		)
+	}
+	return nil
+}
+
 func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
@@ -2578,6 +2614,16 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 		}
 		// Check the value type based on the key
 		switch prop.Key {
+		case common.EnableAnalyzerKey, common.AnalyzerParamKey:
+			if err := validateAlterAnalyzerFieldParam(collSchema.CollectionSchema, t.FieldName); err != nil {
+				return err
+			}
+			if prop.Key == common.EnableAnalyzerKey {
+				if _, err := strconv.ParseBool(prop.Value); err != nil {
+					return merr.WrapErrParameterInvalidMsg("%s should be a boolean, but got %s", prop.Key, prop.Value)
+				}
+			}
+
 		case common.MmapEnabledKey:
 			loaded, err := isCollectionLoadedFn()
 			if err != nil {
@@ -2651,6 +2697,11 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 		updatedKey := updateKey(key)
 		if !IsKeyAllowDrop(updatedKey) {
 			return merr.WrapErrParameterInvalidMsg("%s is not allowed to drop in collection field param", key)
+		}
+		if isAnalyzerFieldParam(updatedKey) {
+			if err := validateAlterAnalyzerFieldParam(collSchema.CollectionSchema, t.FieldName); err != nil {
+				return err
+			}
 		}
 
 		if updatedKey == common.MmapEnabledKey || common.IsFieldWarmupKey(updatedKey) {

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -6312,6 +6312,43 @@ func TestAlterCollectionField(t *testing.T) {
 				ElementType: schemapb.DataType_Int64,
 				TypeParams:  []*commonpb.KeyValuePair{{Key: "max_capacity", Value: "100"}},
 			},
+			{
+				FieldID:  102,
+				Name:     "text_match_field",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "100"},
+					{Key: "enable_match", Value: "true"},
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+			{
+				FieldID:  103,
+				Name:     "bm25_input_field",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "100"},
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+			{
+				FieldID:          104,
+				Name:             "bm25_output_field",
+				DataType:         schemapb.DataType_SparseFloatVector,
+				IsFunctionOutput: true,
+			},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name:             "bm25_func",
+				Type:             schemapb.FunctionType_BM25,
+				InputFieldIds:    []int64{103},
+				InputFieldNames:  []string{"bm25_input_field"},
+				OutputFieldIds:   []int64{104},
+				OutputFieldNames: []string{"bm25_output_field"},
+			},
 		},
 	}
 	schemaBytes, err := proto.Marshal(schema)
@@ -6376,6 +6413,60 @@ func TestAlterCollectionField(t *testing.T) {
 				{Key: common.MmapEnabledKey, Value: "true"},
 			},
 			expectError: false,
+		},
+		{
+			name:      "update analyzer params on inactive string field",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+			},
+			expectError: false,
+		},
+		{
+			name:      "update analyzer params without enable analyzer",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+			},
+			expectError: false,
+		},
+		{
+			name:      "reject analyzer params on non-string field",
+			fieldName: "array_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "invalid enable analyzer value",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "not_bool"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "reject analyzer params on text match field",
+			fieldName: "text_match_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"whitespace"}`},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "reject analyzer params on bm25 input field",
+			fieldName: "bm25_input_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"whitespace"}`},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
 		},
 		{
 			name:      "invalid property key",
@@ -6460,6 +6551,33 @@ func TestAlterCollectionField(t *testing.T) {
 			fieldName:   "string_field",
 			deleteKeys:  []string{MmapEnabledKey},
 			expectError: false,
+		},
+		{
+			name:        "delete analyzer params on inactive string field",
+			fieldName:   "string_field",
+			deleteKeys:  []string{common.EnableAnalyzerKey, common.AnalyzerParamKey},
+			expectError: false,
+		},
+		{
+			name:        "reject delete analyzer params on non-string field",
+			fieldName:   "array_field",
+			deleteKeys:  []string{common.EnableAnalyzerKey, common.AnalyzerParamKey},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:        "reject delete analyzer params on text match field",
+			fieldName:   "text_match_field",
+			deleteKeys:  []string{common.AnalyzerParamKey},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:        "reject delete analyzer params on bm25 input field",
+			fieldName:   "bm25_input_field",
+			deleteKeys:  []string{common.AnalyzerParamKey},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
 		},
 		{
 			name:        "delete max_length is not allowed",

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -808,6 +808,21 @@ func TestValidateFieldType(t *testing.T) {
 	}
 }
 
+func TestValidateFieldAllowsAnalyzerParamsWithoutEnableAnalyzer(t *testing.T) {
+	field := &schemapb.FieldSchema{
+		Name:     "text_field",
+		DataType: schemapb.DataType_VarChar,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "100"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+		},
+	}
+	schema := &schemapb.CollectionSchema{Name: "test_collection"}
+
+	err := ValidateField(field, schema)
+	require.NoError(t, err)
+}
+
 func TestValidateMultipleVectorFields(t *testing.T) {
 	// case1, no vector field
 	schema1 := &schemapb.CollectionSchema{}

--- a/internal/rootcoord/alter_collection_analyzer_resources.go
+++ b/internal/rootcoord/alter_collection_analyzer_resources.go
@@ -1,0 +1,45 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+import (
+	"context"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/metastore/model"
+	streamingbroadcaster "github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
+)
+
+func (c *Core) prepareAlterCollectionAnalyzerFileResources(ctx context.Context, coll *model.Collection, schema *schemapb.CollectionSchema) ([]int64, error) {
+	fileResourceIds, err := c.validateSchemaAnalyzerFileResources(ctx, schema)
+	if err != nil {
+		return nil, err
+	}
+	schema.FileResourceIds = fileResourceIds
+
+	addedFileResourceIds, _ := diffFileResourceIDs(coll.FileResourceIds, schema.FileResourceIds)
+	if err := reserveAlterCollectionFileResourceRefs(c.meta, coll.CollectionID, addedFileResourceIds); err != nil {
+		return nil, err
+	}
+	return addedFileResourceIds, nil
+}
+
+func rollbackAlterCollectionAnalyzerFileResourceReservation(ctx context.Context, meta IMetaTable, collectionID int64, ids []int64, broadcastErr error) {
+	if streamingbroadcaster.IsBroadcastTaskNotCreated(broadcastErr) {
+		rollbackAlterCollectionFileResourceRefs(ctx, meta, collectionID, ids)
+	}
+}

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -230,54 +230,63 @@ func (t *createCollectionTask) validateSchema(ctx context.Context, schema *schem
 		return err
 	}
 
-	// check analyzer was vaild
-	analyzerInfos := make([]*querypb.AnalyzerInfo, 0)
-	for _, field := range schema.GetFields() {
-		err := validateAnalyzer(schema, field, &analyzerInfos)
-		if err != nil {
+	fileResourceIds, err := t.validateSchemaAnalyzerFileResources(ctx, schema)
+	if err != nil {
+		return err
+	}
+	schema.FileResourceIds = fileResourceIds
+
+	if len(schema.FileResourceIds) > 0 {
+		// Bind file resources to collection lifecycle: refCnt++ now, refCnt-- on
+		// drop. Under ddLock, atomic with RemoveFileResource. See #48612.
+		if err := reserveFileResourceRefs(t.meta, schema.FileResourceIds); err != nil {
 			return err
 		}
+		t.heldFileResourceIds = schema.FileResourceIds
+	}
+
+	return validateFieldDataType(schema.GetFields())
+}
+
+func (c *Core) validateSchemaAnalyzerFileResources(ctx context.Context, schema *schemapb.CollectionSchema) ([]int64, error) {
+	analyzerInfos, err := collectAnalyzerInfos(schema)
+	if err != nil {
+		return nil, err
+	}
+	return c.validateAnalyzerInfos(ctx, analyzerInfos)
+}
+
+func (c *Core) validateAnalyzerInfos(ctx context.Context, analyzerInfos []*querypb.AnalyzerInfo) ([]int64, error) {
+	if len(analyzerInfos) == 0 {
+		return nil, nil
 	}
 
 	// validate analyzer params at any streaming node
 	// and set file resource ids to schema
-	if len(analyzerInfos) > 0 {
-		err := retry.Do(ctx, func() error {
-			if t.fileResourceObserver == nil {
-				return nil
-			}
-			if err := t.fileResourceObserver.CheckAllQnReady(); err != nil {
-				return err
-			}
+	err := retry.Do(ctx, func() error {
+		if c.fileResourceObserver == nil {
 			return nil
-		}, retry.Attempts(10), retry.Sleep(3*time.Second))
-		if err != nil {
+		}
+		if err := c.fileResourceObserver.CheckAllQnReady(); err != nil {
 			return err
 		}
-
-		resp, err := t.mixCoord.ValidateAnalyzer(t.ctx, &querypb.ValidateAnalyzerRequest{
-			AnalyzerInfos: analyzerInfos,
-		})
-		if err != nil {
-			return err
-		}
-
-		if err := merr.Error(resp.GetStatus()); err != nil {
-			return err
-		}
-		schema.FileResourceIds = resp.GetResourceIds()
-
-		// Bind file resources to collection lifecycle: refCnt++ now, refCnt-- on
-		// drop. Under ddLock, atomic with RemoveFileResource. See #48612.
-		if len(schema.FileResourceIds) > 0 {
-			if err := t.meta.IncFileResourceRefCnt(schema.FileResourceIds); err != nil {
-				return err
-			}
-			t.heldFileResourceIds = schema.FileResourceIds
-		}
+		return nil
+	}, retry.Attempts(10), retry.Sleep(3*time.Second))
+	if err != nil {
+		return nil, err
 	}
 
-	return validateFieldDataType(schema.GetFields())
+	resp, err := c.mixCoord.ValidateAnalyzer(ctx, &querypb.ValidateAnalyzerRequest{
+		AnalyzerInfos: analyzerInfos,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := merr.Error(resp.GetStatus()); err != nil {
+		return nil, err
+	}
+	return resp.GetResourceIds(), nil
 }
 
 func (t *createCollectionTask) assignFieldAndFunctionID(schema *schemapb.CollectionSchema) error {
@@ -922,14 +931,26 @@ func validateMultiAnalyzerParams(params string, coll *schemapb.CollectionSchema,
 	return nil
 }
 
+func collectAnalyzerInfos(collSchema *schemapb.CollectionSchema) ([]*querypb.AnalyzerInfo, error) {
+	analyzerInfos := make([]*querypb.AnalyzerInfo, 0)
+	for _, field := range collSchema.GetFields() {
+		if err := validateAnalyzer(collSchema, field, &analyzerInfos); err != nil {
+			return nil, err
+		}
+	}
+	return analyzerInfos, nil
+}
+
+// validateAnalyzer validates active match/BM25 fields and fields with
+// enable_analyzer=true. Analyzer params are ignored while analyzer is disabled.
 func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo) error {
 	h := typeutil.CreateFieldSchemaHelper(fieldSchema)
-	if !h.EnableMatch() && !typeutil.IsBm25FunctionInputField(collSchema, fieldSchema) {
-		return nil
-	}
-
-	if !h.EnableAnalyzer() {
+	active := h.EnableMatch() || typeutil.IsBm25FunctionInputField(collSchema, fieldSchema)
+	if active && !h.EnableAnalyzer() {
 		return merr.WrapErrParameterInvalidMsg("field %s which has enable_match or is input of BM25 function must also enable_analyzer", fieldSchema.Name)
+	}
+	if !h.EnableAnalyzer() {
+		return nil
 	}
 
 	if params, ok := h.GetMultiAnalyzerParams(); ok {

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -1541,7 +1541,6 @@ func Test_createCollectionTask_prepareSchema(t *testing.T) {
 					TypeParams: []*commonpb.KeyValuePair{
 						{Key: common.MaxLengthKey, Value: "100"},
 						{Key: "enable_analyzer", Value: "true"},
-						{Key: "enable_match", Value: "true"},
 						{Key: "analyzer_params", Value: `{"type": "standard"}`},
 					},
 				},
@@ -1598,7 +1597,6 @@ func Test_createCollectionTask_prepareSchema(t *testing.T) {
 					TypeParams: []*commonpb.KeyValuePair{
 						{Key: common.MaxLengthKey, Value: "100"},
 						{Key: "enable_analyzer", Value: "true"},
-						{Key: "enable_match", Value: "true"},
 						{Key: "analyzer_params", Value: `{"type": "standard"}`},
 					},
 				},
@@ -2786,6 +2784,19 @@ func Test_validateAnalyzer(t *testing.T) {
 		assert.Len(t, infos, 0)
 	})
 
+	t.Run("field with analyzer params but analyzer disabled", func(t *testing.T) {
+		fieldSchema := createTestFieldSchema("text_field", schemapb.DataType_VarChar, []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "100"},
+			{Key: common.AnalyzerParamKey, Value: `{"type": "standard"}`},
+		})
+		collSchema := createTestCollectionSchemaWithBM25([]*schemapb.FieldSchema{fieldSchema}, "invalid_field")
+		infos := make([]*querypb.AnalyzerInfo, 0)
+
+		err := validateAnalyzer(collSchema, fieldSchema, &infos)
+		assert.NoError(t, err)
+		assert.Empty(t, infos)
+	})
+
 	t.Run("field with enable_match but no enable_analyzer", func(t *testing.T) {
 		fieldSchema := createTestFieldSchema("text_field", schemapb.DataType_VarChar, []*commonpb.KeyValuePair{
 			{Key: common.MaxLengthKey, Value: "100"},
@@ -2902,8 +2913,7 @@ func Test_validateAnalyzer(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("field with analyzer_params only", func(t *testing.T) {
-		// Create a field with analyzer_params only
+	t.Run("field with enable_analyzer and analyzer_params", func(t *testing.T) {
 		fieldSchema := createTestFieldSchema("text_field", schemapb.DataType_VarChar, []*commonpb.KeyValuePair{
 			{Key: common.MaxLengthKey, Value: "100"},
 			{Key: "enable_analyzer", Value: "true"},
@@ -2934,6 +2944,20 @@ func Test_validateAnalyzer(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, infos, 0) // No analyzer_params, uses default analyzer
 	})
+}
+
+func TestCheckFieldSchemaAllowsAnalyzerParamsWithoutEnableAnalyzer(t *testing.T) {
+	err := checkFieldSchema([]*schemapb.FieldSchema{
+		{
+			Name:     "text_field",
+			DataType: schemapb.DataType_VarChar,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxLengthKey, Value: "100"},
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+			},
+		},
+	})
+	require.NoError(t, err)
 }
 
 func Test_appendConsistecyLevel(t *testing.T) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
@@ -91,6 +91,10 @@ func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *mil
 	if err != nil {
 		return err
 	}
+	addedFileResourceIds, err := c.prepareAlterCollectionAnalyzerFileResources(ctx, coll, schema)
+	if err != nil {
+		return err
+	}
 
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
@@ -114,6 +118,7 @@ func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *mil
 		WithBroadcast(channels).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
+		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)
 		return err
 	}
 	return nil

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field_test.go
@@ -20,11 +20,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -104,6 +110,64 @@ func TestDDLCallbacksAlterCollectionAddField(t *testing.T) {
 	assertFieldProperties(t, ctx, core, dbName, collectionName, "field1", "key1", "value1")
 	assertFieldExists(t, ctx, core, dbName, collectionName, "field3", 102)
 	assertSchemaVersion(t, ctx, core, dbName, collectionName, 2)
+}
+
+func TestDDLCallbacksAlterCollectionAddFieldAnalyzerFileResourceRefs(t *testing.T) {
+	core := initStreamingSystemAndCore(t)
+
+	ctx := context.Background()
+	dbName := "testDB" + funcutil.RandomString(10)
+	collectionName := "testCollection" + funcutil.RandomString(10)
+	fieldName := "text_with_dict"
+
+	createCollectionForTest(t, ctx, core, dbName, collectionName)
+
+	meta := core.meta.(*MetaTable)
+	resourceID := int64(10001)
+	meta.fileResourceName2Meta = map[string]*internalpb.FileResourceInfo{
+		"dict": {Id: resourceID, Name: "dict", Path: "dict.txt"},
+	}
+	meta.fileResourceID2Meta = map[int64]*internalpb.FileResourceInfo{
+		resourceID: {Id: resourceID, Name: "dict", Path: "dict.txt"},
+	}
+	meta.fileResourceRefCnt = map[int64]int{}
+
+	mixCoord := core.mixCoord.(*mocks.MixCoord)
+	mixCoord.EXPECT().ValidateAnalyzer(mock.Anything, mock.MatchedBy(func(req *querypb.ValidateAnalyzerRequest) bool {
+		infos := req.GetAnalyzerInfos()
+		return len(infos) == 1 &&
+			infos[0].GetField() == fieldName &&
+			infos[0].GetParams() == `{"tokenizer":"standard"}`
+	})).Return(&querypb.ValidateAnalyzerResponse{
+		Status:      merr.Success(),
+		ResourceIds: []int64{resourceID},
+	}, nil).Once()
+
+	fieldSchema := &schemapb.FieldSchema{
+		Name:     fieldName,
+		DataType: schemapb.DataType_VarChar,
+		Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "128"},
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+		},
+	}
+	schemaBytes, err := proto.Marshal(fieldSchema)
+	require.NoError(t, err)
+
+	resp, err := core.AddCollectionField(ctx, &milvuspb.AddCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         schemaBytes,
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+
+	coll, err := core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []int64{resourceID}, coll.FileResourceIds)
+	require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+	assertFieldExists(t, ctx, core, dbName, collectionName, fieldName, 101)
 }
 
 func TestDDLCallbacksAlterCollectionAddTextField(t *testing.T) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field.go
@@ -2,24 +2,80 @@ package rootcoord
 
 import (
 	"context"
+	"strconv"
 
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
+func hasAnalyzerFieldParamMutation(req *milvuspb.AlterCollectionFieldRequest) bool {
+	for _, prop := range req.GetProperties() {
+		if prop.GetKey() == common.EnableAnalyzerKey || prop.GetKey() == common.AnalyzerParamKey {
+			return true
+		}
+	}
+	for _, key := range req.GetDeleteKeys() {
+		if key == common.EnableAnalyzerKey || key == common.AnalyzerParamKey {
+			return true
+		}
+	}
+	return false
+}
+
+func validateAlterCollectionFieldAnalyzerParams(req *milvuspb.AlterCollectionFieldRequest) error {
+	for _, prop := range req.GetProperties() {
+		if prop.GetKey() != common.EnableAnalyzerKey {
+			continue
+		}
+		if _, err := strconv.ParseBool(prop.GetValue()); err != nil {
+			return merr.WrapErrParameterInvalidMsg("%s should be a boolean, but got %s", prop.GetKey(), prop.GetValue())
+		}
+	}
+	return nil
+}
+
+func getAlterCollectionField(schema *schemapb.CollectionSchema, fieldName string) *schemapb.FieldSchema {
+	for _, field := range schema.GetFields() {
+		if field.GetName() == fieldName {
+			return field
+		}
+	}
+	return nil
+}
+
+func validateAlterCollectionFieldAnalyzerMutation(schema *schemapb.CollectionSchema, fieldName string) error {
+	field := getAlterCollectionField(schema, fieldName)
+	if field == nil {
+		return merr.WrapErrParameterInvalidMsg("field not found: %s", fieldName)
+	}
+	if !typeutil.IsStringType(field.GetDataType()) {
+		return merr.WrapErrParameterInvalidMsg("can not alter analyzer params for non-string field %s", fieldName)
+	}
+	fieldHelper := typeutil.CreateFieldSchemaHelper(field)
+	if fieldHelper.EnableMatch() || typeutil.IsBm25FunctionInputField(schema, field) {
+		return merr.WrapErrParameterInvalidMsg(
+			"can not alter analyzer params for field %s after text match is enabled or BM25 function depends on it",
+			fieldName,
+		)
+	}
+	return nil
+}
+
 func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Context, req *milvuspb.AlterCollectionFieldRequest) error {
-	broadcaster, err := c.startBroadcastWithAliasOrCollectionLock(ctx, req.GetDbName(), req.GetCollectionName())
+	broadcastAPI, err := c.startBroadcastWithAliasOrCollectionLock(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		return err
 	}
-	defer broadcaster.Close()
+	defer broadcastAPI.Close()
 
 	coll, err := c.meta.GetCollectionByName(ctx, req.GetDbName(), req.GetCollectionName(), typeutil.MaxTimestamp, false)
 	if err != nil {
@@ -71,6 +127,16 @@ func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Con
 		return err
 	}
 
+	analyzerFieldParamMutated := hasAnalyzerFieldParamMutation(req)
+	if analyzerFieldParamMutated {
+		if err := validateAlterCollectionFieldAnalyzerParams(req); err != nil {
+			return err
+		}
+		if err := validateAlterCollectionFieldAnalyzerMutation(schema, req.GetFieldName()); err != nil {
+			return err
+		}
+	}
+
 	header := &messagespb.AlterCollectionMessageHeader{
 		DbId:         coll.DBID,
 		CollectionId: coll.CollectionID,
@@ -88,12 +154,20 @@ func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Con
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
 	channels = append(channels, coll.VirtualChannelNames...)
+	var addedFileResourceIds []int64
+	if analyzerFieldParamMutated {
+		addedFileResourceIds, err = c.prepareAlterCollectionAnalyzerFileResources(ctx, coll, schema)
+		if err != nil {
+			return err
+		}
+	}
 	msg := message.NewAlterCollectionMessageBuilderV2().
 		WithHeader(header).
 		WithBody(body).
 		WithBroadcast(channels).
 		MustBuildBroadcast()
-	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
+	if _, err := broadcastAPI.Broadcast(ctx, msg); err != nil {
+		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)
 		return err
 	}
 	return nil

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field_test.go
@@ -20,10 +20,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -123,6 +130,196 @@ func TestDDLCallbacksAlterCollectionField(t *testing.T) {
 	assertFieldProperties(t, ctx, core, dbName, collectionName, fieldName, "key1", "value1")
 	assertFieldPropertiesNotFound(t, ctx, core, dbName, collectionName, fieldName, "key2")
 	assertSchemaVersion(t, ctx, core, dbName, collectionName, 3)
+}
+
+func TestDDLCallbacksAlterCollectionFieldAnalyzerValidation(t *testing.T) {
+	core := initStreamingSystemAndCore(t)
+
+	ctx := context.Background()
+	dbName := "testDB" + funcutil.RandomString(10)
+	collectionName := "testCollection" + funcutil.RandomString(10)
+	fieldName := "text"
+	intFieldName := "count"
+
+	resp, err := core.CreateDatabase(ctx, &milvuspb.CreateDatabaseRequest{
+		DbName: dbName,
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	testSchema := &schemapb.CollectionSchema{
+		Name: collectionName,
+		Fields: []*schemapb.FieldSchema{
+			{
+				Name:       fieldName,
+				DataType:   schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "128"}},
+			},
+			{
+				Name:     intFieldName,
+				DataType: schemapb.DataType_Int64,
+			},
+		},
+	}
+	schemaBytes, err := proto.Marshal(testSchema)
+	require.NoError(t, err)
+	resp, err = core.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         schemaBytes,
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+
+	meta := core.meta.(*MetaTable)
+	resourceID := int64(10001)
+	meta.fileResourceName2Meta = map[string]*internalpb.FileResourceInfo{
+		"dict": {Id: resourceID, Name: "dict", Path: "dict.txt"},
+	}
+	meta.fileResourceID2Meta = map[int64]*internalpb.FileResourceInfo{
+		resourceID: {Id: resourceID, Name: "dict", Path: "dict.txt"},
+	}
+	meta.fileResourceRefCnt = map[int64]int{}
+
+	mixCoord := core.mixCoord.(*mocks.MixCoord)
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+		},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	assertFieldProperties(t, ctx, core, dbName, collectionName, fieldName, common.AnalyzerParamKey, `{"tokenizer":"standard"}`)
+	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+
+	mixCoord.EXPECT().ValidateAnalyzer(mock.Anything, mock.MatchedBy(func(req *querypb.ValidateAnalyzerRequest) bool {
+		infos := req.GetAnalyzerInfos()
+		return len(infos) == 1 &&
+			infos[0].GetField() == fieldName &&
+			infos[0].GetParams() == `{"tokenizer":"standard"}`
+	})).Return(&querypb.ValidateAnalyzerResponse{
+		Status:      merr.Success(),
+		ResourceIds: []int64{resourceID},
+	}, nil).Once()
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+		},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	coll, err := core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []int64{resourceID}, coll.FileResourceIds)
+	require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+	assertFieldProperties(t, ctx, core, dbName, collectionName, fieldName, common.AnalyzerParamKey, `{"tokenizer":"standard"}`)
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		DeleteKeys:     []string{common.EnableAnalyzerKey},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	coll, err = core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
+	require.NoError(t, err)
+	require.Empty(t, coll.FileResourceIds)
+	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+	assertFieldProperties(t, ctx, core, dbName, collectionName, fieldName, common.AnalyzerParamKey, `{"tokenizer":"standard"}`)
+	assertFieldPropertiesNotFound(t, ctx, core, dbName, collectionName, fieldName, common.EnableAnalyzerKey)
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "not-bool"},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp, err))
+	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      intFieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp, err))
+	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"bad"}`},
+		},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	assertFieldProperties(t, ctx, core, dbName, collectionName, fieldName, common.AnalyzerParamKey, `{"tokenizer":"bad"}`)
+	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+
+	mixCoord.EXPECT().ValidateAnalyzer(mock.Anything, mock.MatchedBy(func(req *querypb.ValidateAnalyzerRequest) bool {
+		infos := req.GetAnalyzerInfos()
+		return len(infos) == 1 &&
+			infos[0].GetField() == fieldName &&
+			infos[0].GetParams() == `{"tokenizer":"bad"}`
+	})).Return(&querypb.ValidateAnalyzerResponse{
+		Status: merr.Status(merr.WrapErrParameterInvalidMsg("bad analyzer")),
+	}, nil).Once()
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp, err))
+	assertFieldProperties(t, ctx, core, dbName, collectionName, fieldName, common.AnalyzerParamKey, `{"tokenizer":"bad"}`)
+	assertFieldPropertiesNotFound(t, ctx, core, dbName, collectionName, fieldName, common.EnableAnalyzerKey)
+	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+
+	mixCoord.EXPECT().ValidateAnalyzer(mock.Anything, mock.MatchedBy(func(req *querypb.ValidateAnalyzerRequest) bool {
+		infos := req.GetAnalyzerInfos()
+		return len(infos) == 1 &&
+			infos[0].GetField() == fieldName &&
+			infos[0].GetParams() == `{"tokenizer":"standard"}`
+	})).Return(&querypb.ValidateAnalyzerResponse{
+		Status:      merr.Success(),
+		ResourceIds: []int64{resourceID},
+	}, nil).Once()
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+		},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		DeleteKeys:     []string{common.AnalyzerParamKey},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	coll, err = core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
+	require.NoError(t, err)
+	require.Empty(t, coll.FileResourceIds)
+	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+	assertFieldPropertiesNotFound(t, ctx, core, dbName, collectionName, fieldName, common.AnalyzerParamKey)
 }
 
 func assertFieldPropertiesNotFound(t *testing.T, ctx context.Context, core *Core, dbName string, collectionName string, fieldName string, key string) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -151,6 +151,10 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 	if err != nil {
 		return err
 	}
+	addedFileResourceIds, err := c.prepareAlterCollectionAnalyzerFileResources(ctx, coll, schema)
+	if err != nil {
+		return err
+	}
 
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
@@ -174,6 +178,7 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 		WithBroadcast(channels).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
+		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)
 		return err
 	}
 	return nil
@@ -389,6 +394,10 @@ func (c *Core) broadcastAlterCollectionSchemaDrop(ctx context.Context, broadcast
 	if err != nil {
 		return err
 	}
+	addedFileResourceIds, err := c.prepareAlterCollectionAnalyzerFileResources(ctx, coll, schema)
+	if err != nil {
+		return err
+	}
 
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
@@ -412,6 +421,7 @@ func (c *Core) broadcastAlterCollectionSchemaDrop(ctx context.Context, broadcast
 		WithBroadcast(channels).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
+		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)
 		return err
 	}
 	return nil

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -43,7 +43,9 @@ import (
 	"github.com/milvus-io/milvus/internal/util/schemautil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -727,6 +729,72 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 		},
 	})
 	require.Error(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+}
+
+func TestDDLCallbacksAlterCollectionSchemaAnalyzerFileResourceRefs(t *testing.T) {
+	core := initStreamingSystemAndCore(t)
+
+	ctx := context.Background()
+	dbName := "testDB" + funcutil.RandomString(10)
+	collectionName := "testCollection" + funcutil.RandomString(10)
+	fieldName := "schema_text_with_dict"
+
+	createCollectionForTest(t, ctx, core, dbName, collectionName)
+
+	meta := core.meta.(*MetaTable)
+	resourceID := int64(10002)
+	meta.fileResourceName2Meta = map[string]*internalpb.FileResourceInfo{
+		"schema_dict": {Id: resourceID, Name: "schema_dict", Path: "schema_dict.txt"},
+	}
+	meta.fileResourceID2Meta = map[int64]*internalpb.FileResourceInfo{
+		resourceID: {Id: resourceID, Name: "schema_dict", Path: "schema_dict.txt"},
+	}
+	meta.fileResourceRefCnt = map[int64]int{}
+
+	mixCoord := core.mixCoord.(*imocks.MixCoord)
+	mixCoord.EXPECT().ValidateAnalyzer(mock.Anything, mock.MatchedBy(func(req *querypb.ValidateAnalyzerRequest) bool {
+		infos := req.GetAnalyzerInfos()
+		return len(infos) == 1 &&
+			infos[0].GetField() == fieldName &&
+			infos[0].GetParams() == `{"tokenizer":"standard"}`
+	})).Return(&querypb.ValidateAnalyzerResponse{
+		Status:      merr.Success(),
+		ResourceIds: []int64{resourceID},
+	}, nil).Once()
+
+	resp, err := core.AlterCollectionSchema(ctx, buildAlterSchemaAddFieldSchemaReq(dbName, collectionName, &schemapb.FieldSchema{
+		Name:     fieldName,
+		DataType: schemapb.DataType_VarChar,
+		Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "128"},
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+		},
+	}, false))
+	require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	coll, err := core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []int64{resourceID}, coll.FileResourceIds)
+	require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+
+	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_DropRequest{
+				DropRequest: &milvuspb.AlterCollectionSchemaRequest_DropRequest{
+					Identifier: &milvuspb.AlterCollectionSchemaRequest_DropRequest_FieldName{FieldName: fieldName},
+				},
+			},
+		},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	coll, err = core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
+	require.NoError(t, err)
+	require.Empty(t, coll.FileResourceIds)
+	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+	assertFieldNotExists(t, ctx, core, dbName, collectionName, fieldName)
 }
 
 func TestDDLCallbacksAlterCollectionSchemaValidatesFunctionOnlyFinalSchema(t *testing.T) {

--- a/internal/rootcoord/ddl_callbacks_collection_function.go
+++ b/internal/rootcoord/ddl_callbacks_collection_function.go
@@ -42,10 +42,10 @@ func rejectExternalCollectionFunctionMutation(schema *schemapb.CollectionSchema)
 	return nil
 }
 
-func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.BroadcastAPI, coll *model.Collection, dbName string, collectionName string) error {
+func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.BroadcastAPI, oldColl *model.Collection, newColl *model.Collection, dbName string, collectionName string) error {
 	// build new collection schema.
-	schema := coll.ToCollectionSchemaPB()
-	schema.Version = coll.SchemaVersion + 1
+	schema := newColl.ToCollectionSchemaPB()
+	schema.Version = newColl.SchemaVersion + 1
 	if err := typeutil.ValidateExternalCollectionResolvedSchema(schema); err != nil {
 		return err
 	}
@@ -56,8 +56,8 @@ func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.B
 	}
 
 	header := &messagespb.AlterCollectionMessageHeader{
-		DbId:         coll.DBID,
-		CollectionId: coll.CollectionID,
+		DbId:         newColl.DBID,
+		CollectionId: newColl.CollectionID,
 		UpdateMask: &fieldmaskpb.FieldMask{
 			Paths: []string{message.FieldMaskCollectionSchema},
 		},
@@ -69,15 +69,21 @@ func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.B
 		},
 	}
 
-	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
+	addedFileResourceIds, err := c.prepareAlterCollectionAnalyzerFileResources(ctx, oldColl, schema)
+	if err != nil {
+		return err
+	}
+
+	channels := make([]string, 0, len(newColl.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
-	channels = append(channels, coll.VirtualChannelNames...)
+	channels = append(channels, newColl.VirtualChannelNames...)
 	msg := message.NewAlterCollectionMessageBuilderV2().
 		WithHeader(header).
 		WithBody(body).
 		WithBroadcast(channels).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
+		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, newColl.CollectionID, addedFileResourceIds, err)
 		return err
 	}
 	return nil
@@ -168,7 +174,7 @@ func (c *Core) broadcastAlterCollectionForAlterFunction(ctx context.Context, req
 		return err
 	}
 
-	return callAlterCollection(ctx, c, broadcaster, newColl, req.GetDbName(), req.GetCollectionName())
+	return callAlterCollection(ctx, c, broadcaster, oldColl, newColl, req.GetDbName(), req.GetCollectionName())
 }
 
 func (c *Core) broadcastAlterCollectionForDropFunction(ctx context.Context, req *milvuspb.DropCollectionFunctionRequest) error {
@@ -218,7 +224,7 @@ func (c *Core) broadcastAlterCollectionForDropFunction(ctx context.Context, req 
 		}
 		field.IsFunctionOutput = false
 	}
-	return callAlterCollection(ctx, c, broadcaster, newColl, req.GetDbName(), req.GetCollectionName())
+	return callAlterCollection(ctx, c, broadcaster, oldColl, newColl, req.GetDbName(), req.GetCollectionName())
 }
 
 func (c *Core) broadcastAlterCollectionForAddFunction(ctx context.Context, req *milvuspb.AddCollectionFunctionRequest) error {
@@ -278,5 +284,5 @@ func (c *Core) broadcastAlterCollectionForAddFunction(ctx context.Context, req *
 	}
 	newFunc := model.UnmarshalFunctionModel(fSchema)
 	newColl.Functions = append(newColl.Functions, newFunc)
-	return callAlterCollection(ctx, c, broadcaster, newColl, req.GetDbName(), req.GetCollectionName())
+	return callAlterCollection(ctx, c, broadcaster, oldColl, newColl, req.GetDbName(), req.GetCollectionName())
 }

--- a/internal/rootcoord/ddl_callbacks_collection_function_test.go
+++ b/internal/rootcoord/ddl_callbacks_collection_function_test.go
@@ -151,7 +151,7 @@ func (suite *DDLCallbacksCollectionFunctionTestSuite) TestCallAlterCollection_Su
 		return msg != nil
 	})).Return(&types.BroadcastAppendResult{}, nil)
 
-	err := callAlterCollection(ctx, core, suite.mockBroadcaster, coll, dbName, collectionName)
+	err := callAlterCollection(ctx, core, suite.mockBroadcaster, coll, coll, dbName, collectionName)
 	suite.NoError(err)
 }
 
@@ -169,7 +169,7 @@ func (suite *DDLCallbacksCollectionFunctionTestSuite) TestCallAlterCollection_Ge
 	// Mock meta calls to return error
 	mockMeta.EXPECT().GetCollectionByName(mock.Anything, dbName, collectionName, typeutil.MaxTimestamp, mock.Anything).Return(nil, errors.New("cache expire error"))
 
-	err := callAlterCollection(ctx, core, suite.mockBroadcaster, coll, dbName, collectionName)
+	err := callAlterCollection(ctx, core, suite.mockBroadcaster, coll, coll, dbName, collectionName)
 	suite.Error(err)
 	suite.Contains(err.Error(), "cache expire error")
 }
@@ -192,7 +192,7 @@ func (suite *DDLCallbacksCollectionFunctionTestSuite) TestCallAlterCollection_Br
 	// Mock broadcaster to return error
 	suite.mockBroadcaster.EXPECT().Broadcast(mock.Anything, mock.Anything).Return(nil, errors.New("broadcast error"))
 
-	err := callAlterCollection(ctx, core, suite.mockBroadcaster, coll, dbName, collectionName)
+	err := callAlterCollection(ctx, core, suite.mockBroadcaster, coll, coll, dbName, collectionName)
 	suite.Error(err)
 	suite.Contains(err.Error(), "broadcast error")
 }

--- a/internal/rootcoord/ddl_callbacks_create_collection.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/metastore/model"
+	streamingbroadcaster "github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
@@ -94,9 +95,11 @@ func (c *Core) broadcastCreateCollectionV1(ctx context.Context, req *milvuspb.Cr
 		WithBroadcast(broadcastChannel).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
-		// Do NOT release file resources here: the broadcast task is already in the
-		// scheduler and will retry until success. refCnt will be decremented when
-		// the collection is eventually dropped.
+		// Once the broadcast task is created, it will retry until success and owns
+		// the reserved refs. If the task was not created, release the reservation.
+		if streamingbroadcaster.IsBroadcastTaskNotCreated(err) {
+			createCollectionTask.releaseFileResources()
+		}
 		return err
 	}
 	return nil

--- a/internal/rootcoord/ddl_callbacks_create_collection_test.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection_test.go
@@ -1,0 +1,77 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/distributed/streaming"
+	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
+	"github.com/milvus-io/milvus/internal/mocks/streamingcoord/server/mock_broadcaster"
+	mockrootcoord "github.com/milvus-io/milvus/internal/rootcoord/mocks"
+	streamingbroadcaster "github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
+)
+
+func TestBroadcastCreateCollectionV1RollbackFileResourcesWhenTaskNotCreated(t *testing.T) {
+	mockey.PatchConvey("rollback create collection file resources when broadcast task is not created", t, func() {
+		const (
+			dbName         = "default"
+			collectionName = "test_collection"
+		)
+		heldFileResourceIDs := []int64{1001}
+		schemaBytes, err := proto.Marshal(&schemapb.CollectionSchema{Name: collectionName})
+		require.NoError(t, err)
+
+		meta := mockrootcoord.NewIMetaTable(t)
+		meta.EXPECT().DecFileResourceRefCnt(heldFileResourceIDs).Once()
+		core := newTestCore(withMeta(meta))
+
+		broadcastAPI := mock_broadcaster.NewMockBroadcastAPI(t)
+		broadcastAPI.EXPECT().Broadcast(mock.Anything, mock.Anything).
+			Return(nil, streamingbroadcaster.ErrBroadcastTaskNotCreated).Once()
+		broadcastAPI.EXPECT().Close().Return().Once()
+
+		mockey.Mock((*Core).startBroadcastWithCollectionLock).Return(broadcastAPI, nil).Build()
+		mockey.Mock((*createCollectionTask).Prepare).To(func(task *createCollectionTask, ctx context.Context) error {
+			task.Req.ShardsNum = 1
+			task.body.VirtualChannelNames = []string{"by-dev-rootcoord-dml_0_100v0"}
+			task.heldFileResourceIds = heldFileResourceIDs
+			return nil
+		}).Build()
+
+		wal := mock_streaming.NewMockWALAccesser(t)
+		wal.EXPECT().ControlChannel().Return("by-dev-rootcoord-dml_0").Once()
+		streaming.SetWALForTest(wal)
+		defer streaming.SetWALForTest(nil)
+
+		err = core.broadcastCreateCollectionV1(context.Background(), &milvuspb.CreateCollectionRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			ShardsNum:      1,
+			Schema:         schemaBytes,
+		})
+		require.ErrorIs(t, err, streamingbroadcaster.ErrBroadcastTaskNotCreated)
+	})
+}

--- a/internal/rootcoord/file_resource_ref.go
+++ b/internal/rootcoord/file_resource_ref.go
@@ -1,0 +1,185 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+import (
+	"context"
+
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func diffFileResourceIDs(oldIDs []int64, newIDs []int64) ([]int64, []int64) {
+	oldSet := make(map[int64]struct{}, len(oldIDs))
+	for _, id := range oldIDs {
+		oldSet[id] = struct{}{}
+	}
+	newSet := make(map[int64]struct{}, len(newIDs))
+	for _, id := range newIDs {
+		newSet[id] = struct{}{}
+	}
+
+	added := make([]int64, 0)
+	addedSet := make(map[int64]struct{}, len(newIDs))
+	for _, id := range newIDs {
+		if _, ok := oldSet[id]; ok {
+			continue
+		}
+		if _, ok := addedSet[id]; !ok {
+			added = append(added, id)
+			addedSet[id] = struct{}{}
+		}
+	}
+	removed := make([]int64, 0)
+	removedSet := make(map[int64]struct{}, len(oldIDs))
+	for _, id := range oldIDs {
+		if _, ok := newSet[id]; ok {
+			continue
+		}
+		if _, ok := removedSet[id]; !ok {
+			removed = append(removed, id)
+			removedSet[id] = struct{}{}
+		}
+	}
+	return added, removed
+}
+
+func (mt *MetaTable) validateAddedFileResourceRefsLocked(collectionID int64, addedIDs []int64) error {
+	for _, id := range addedIDs {
+		if _, ok := mt.fileResourceID2Meta[id]; !ok {
+			return merr.WrapErrServiceInternalMsg("collection %d references missing file resource %d", collectionID, id)
+		}
+	}
+	return nil
+}
+
+type alterCollectionFileResourceRefReserver interface {
+	reserveAlterCollectionFileResourceRefs(collectionID int64, ids []int64) error
+}
+
+type alterCollectionFileResourceRefRollbacker interface {
+	rollbackAlterCollectionFileResourceRefs(ctx context.Context, collectionID int64, ids []int64)
+}
+
+func reserveFileResourceRefs(meta IMetaTable, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return meta.IncFileResourceRefCnt(ids)
+}
+
+func reserveAlterCollectionFileResourceRefs(meta IMetaTable, collectionID int64, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if reserver, ok := meta.(alterCollectionFileResourceRefReserver); ok {
+		return reserver.reserveAlterCollectionFileResourceRefs(collectionID, ids)
+	}
+	return reserveFileResourceRefs(meta, ids)
+}
+
+func rollbackAlterCollectionFileResourceRefs(ctx context.Context, meta IMetaTable, collectionID int64, ids []int64) {
+	if len(ids) == 0 {
+		return
+	}
+	if rollbacker, ok := meta.(alterCollectionFileResourceRefRollbacker); ok {
+		rollbacker.rollbackAlterCollectionFileResourceRefs(ctx, collectionID, ids)
+		return
+	}
+	meta.DecFileResourceRefCnt(ids)
+}
+
+func (mt *MetaTable) reserveAlterCollectionFileResourceRefs(collectionID int64, ids []int64) error {
+	mt.ddLock.Lock()
+	defer mt.ddLock.Unlock()
+	if err := mt.incFileResourceRefCntLocked(ids); err != nil {
+		return err
+	}
+	mt.recordFileResourceRefHoldLocked(collectionID, ids)
+	return nil
+}
+
+func (mt *MetaTable) rollbackAlterCollectionFileResourceRefs(ctx context.Context, collectionID int64, ids []int64) {
+	mt.ddLock.Lock()
+	defer mt.ddLock.Unlock()
+	for _, id := range ids {
+		if !mt.consumeFileResourceRefHoldLocked(collectionID, id) {
+			mlog.Warn(ctx, "AlterCollection: rollback file resource reservation without hold",
+				mlog.Int64("collectionID", collectionID), mlog.Int64("fileResourceID", id))
+			continue
+		}
+		if mt.fileResourceRefCnt[id] > 0 {
+			mt.fileResourceRefCnt[id]--
+		} else {
+			mlog.Warn(ctx, "AlterCollection: rollback file resource refCnt underflow",
+				mlog.Int64("collectionID", collectionID), mlog.Int64("fileResourceID", id))
+		}
+	}
+}
+
+func (mt *MetaTable) recordFileResourceRefHoldLocked(collectionID int64, ids []int64) {
+	if len(ids) == 0 {
+		return
+	}
+	if mt.fileResourceRefHolds == nil {
+		mt.fileResourceRefHolds = make(map[int64]map[int64]int)
+	}
+	holds := mt.fileResourceRefHolds[collectionID]
+	if holds == nil {
+		holds = make(map[int64]int, len(ids))
+		mt.fileResourceRefHolds[collectionID] = holds
+	}
+	for _, id := range ids {
+		holds[id]++
+	}
+}
+
+func (mt *MetaTable) consumeFileResourceRefHoldLocked(collectionID int64, resourceID int64) bool {
+	holds := mt.fileResourceRefHolds[collectionID]
+	if holds == nil || holds[resourceID] == 0 {
+		return false
+	}
+	holds[resourceID]--
+	if holds[resourceID] == 0 {
+		delete(holds, resourceID)
+	}
+	if len(holds) == 0 {
+		delete(mt.fileResourceRefHolds, collectionID)
+	}
+	return true
+}
+
+func (mt *MetaTable) applyAlterCollectionFileResourceRefCntLocked(ctx context.Context, collectionID int64, addedIDs, removedIDs []int64) {
+	for _, id := range addedIDs {
+		if mt.consumeFileResourceRefHoldLocked(collectionID, id) {
+			// A request-path reservation already incremented the effective refCnt.
+			// Keep the count unchanged; updating collID2Meta below turns it into a
+			// committed collection reference. WAL replay/replicated tasks have no
+			// reservation for this collection, so they fall through and increment here.
+			continue
+		}
+		mt.fileResourceRefCnt[id]++
+	}
+	for _, id := range removedIDs {
+		if mt.fileResourceRefCnt[id] > 0 {
+			mt.fileResourceRefCnt[id]--
+		} else {
+			mlog.Warn(ctx, "AlterCollection: file resource refCnt underflow",
+				mlog.Int64("collectionID", collectionID), mlog.Int64("fileResourceID", id))
+		}
+	}
+}

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -175,6 +175,7 @@ type MetaTable struct {
 	fileResourceName2Meta map[string]*internalpb.FileResourceInfo // file resource name -> file resource meta
 	fileResourceID2Meta   map[int64]*internalpb.FileResourceInfo  // file resource id -> file resource meta
 	fileResourceRefCnt    map[int64]int                           // file resource id -> reference count
+	fileResourceRefHolds  map[int64]map[int64]int                 // collection id -> file resource id -> pending alter reservation count
 	fileResourceVersion   uint64
 
 	generalCnt int // sum of product of partition number and shard number
@@ -209,6 +210,7 @@ func (mt *MetaTable) reload() error {
 	mt.collID2Meta = make(map[UniqueID]*model.Collection)
 	mt.partitionName2ID = make(map[int64]map[string]int64)
 	mt.fileResourceRefCnt = make(map[int64]int)
+	mt.fileResourceRefHolds = make(map[int64]map[int64]int)
 	mt.names = newNameDb()
 	mt.aliases = newNameDb()
 
@@ -1071,6 +1073,14 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 		}
 	}
 	newColl.UpdateTimestamp = result.GetMaxTimeTick()
+	var addedFileResourceIds []int64
+	var removedFileResourceIds []int64
+	if fieldModify {
+		addedFileResourceIds, removedFileResourceIds = diffFileResourceIDs(oldColl.FileResourceIds, newColl.FileResourceIds)
+		if err := mt.validateAddedFileResourceRefsLocked(newColl.CollectionID, addedFileResourceIds); err != nil {
+			return err
+		}
+	}
 
 	ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
 	if !dbChanged {
@@ -1089,6 +1099,10 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 				mlog.String("oldDBName", oldColl.DBName), mlog.String("oldName", oldColl.Name),
 				mlog.String("newDBName", newColl.DBName), mlog.String("newName", newColl.Name), mlog.Err(err))
 		}
+	}
+
+	if fieldModify {
+		mt.applyAlterCollectionFileResourceRefCntLocked(ctx, oldColl.CollectionID, addedFileResourceIds, removedFileResourceIds)
 	}
 
 	mt.names.remove(oldColl.DBName, oldColl.Name)
@@ -2467,12 +2481,17 @@ func (mt *MetaTable) ListFileResource(ctx context.Context) ([]*internalpb.FileRe
 	return lo.Values(mt.fileResourceID2Meta), mt.fileResourceVersion
 }
 
-// IncFileResourceRefCnt increments refCnt for file resources, binding them to a
-// collection being created. Under ddLock, atomic with RemoveFileResource.
+// IncFileResourceRefCnt increments refCnt for file resources, reserving them for
+// a pending collection schema change. Under ddLock, atomic with
+// RemoveFileResource.
 // Returns error if any resource ID does not exist.
 func (mt *MetaTable) IncFileResourceRefCnt(ids []int64) error {
 	mt.ddLock.Lock()
 	defer mt.ddLock.Unlock()
+	return mt.incFileResourceRefCntLocked(ids)
+}
+
+func (mt *MetaTable) incFileResourceRefCntLocked(ids []int64) error {
 	for _, id := range ids {
 		if _, ok := mt.fileResourceID2Meta[id]; !ok {
 			return merr.WrapErrParameterInvalidMsg("file resource %d not found", id)
@@ -2499,18 +2518,29 @@ func (mt *MetaTable) DecFileResourceRefCnt(ids []int64) {
 }
 
 // RecoverFileResourceRefCnt re-increments refCnt for file resources referenced by
-// pending CreateCollection broadcast tasks whose collections have not yet been
-// persisted. Called during startup before rootcoord becomes Healthy.
+// pending schema broadcast tasks. CreateCollection tasks may not have persisted
+// their collections yet; AlterCollection tasks may reference resources that are
+// not in the persisted collection schema yet. Called during startup before
+// rootcoord becomes Healthy.
 func (mt *MetaTable) RecoverFileResourceRefCnt(pendingCollections map[int64][]int64) {
 	mt.ddLock.Lock()
 	defer mt.ddLock.Unlock()
 	for collID, resourceIds := range pendingCollections {
-		if _, exists := mt.collID2Meta[collID]; exists {
-			continue // collection already persisted, reload already counted it
+		existingResourceIDs := map[int64]struct{}{}
+		if coll, exists := mt.collID2Meta[collID]; exists {
+			for _, id := range coll.FileResourceIds {
+				existingResourceIDs[id] = struct{}{}
+			}
 		}
 		for _, id := range resourceIds {
+			if _, exists := existingResourceIDs[id]; exists {
+				continue
+			}
 			if _, ok := mt.fileResourceID2Meta[id]; ok {
 				mt.fileResourceRefCnt[id]++
+				if _, collectionExists := mt.collID2Meta[collID]; collectionExists {
+					mt.recordFileResourceRefHoldLocked(collID, []int64{id})
+				}
 			} else {
 				mlog.Warn(context.TODO(), "RecoverFileResourceRefCnt: pending task references missing file resource",
 					mlog.Int64("collectionID", collID), mlog.Int64("resourceID", id))

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -41,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	pb "github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
@@ -1696,6 +1698,146 @@ func TestMetaTable_DropCollection_GrantCleanup(t *testing.T) {
 		ctx := context.Background()
 		err := meta.DropCollection(ctx, 100, 9999)
 		assert.NoError(t, err)
+	})
+}
+
+func buildAlterCollectionSchemaResult(collectionID int64, schema *schemapb.CollectionSchema, timetick uint64) message.BroadcastResultAlterCollectionMessageV2 {
+	controlChannel := funcutil.GetControlChannel("test")
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId: collectionID,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{message.FieldMaskCollectionSchema},
+			},
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				Schema: schema,
+			},
+		}).
+		WithBroadcast([]string{controlChannel}).
+		MustBuildBroadcast()
+	return message.BroadcastResultAlterCollectionMessageV2{
+		Message: message.MustAsBroadcastAlterCollectionMessageV2(raw),
+		Results: map[string]*message.AppendResult{
+			controlChannel: {TimeTick: timetick},
+		},
+	}
+}
+
+func TestMetaTableAlterCollectionFileResourceRefCnt(t *testing.T) {
+	const (
+		collectionID = int64(100)
+		resourceID   = int64(10)
+		oldResource  = int64(20)
+	)
+
+	newMeta := func(oldIDs []int64, refCnt map[int64]int) (*MetaTable, *mocks.RootCoordCatalog) {
+		catalog := mocks.NewRootCoordCatalog(t)
+		meta := &MetaTable{
+			catalog: catalog,
+			names:   newNameDb(),
+			aliases: newNameDb(),
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				collectionID: {
+					CollectionID:    collectionID,
+					Name:            "collection",
+					DBName:          "db",
+					DBID:            1,
+					State:           pb.CollectionState_CollectionCreated,
+					FileResourceIds: oldIDs,
+				},
+			},
+			fileResourceID2Meta: map[int64]*internalpb.FileResourceInfo{
+				resourceID:  {Id: resourceID, Name: "dict", Path: "dict.txt"},
+				oldResource: {Id: oldResource, Name: "old_dict", Path: "old_dict.txt"},
+			},
+			fileResourceRefCnt: refCnt,
+			fileResourceRefHolds: map[int64]map[int64]int{
+				999: {resourceID: 1},
+			},
+		}
+		meta.names.insert("db", "collection", collectionID)
+		return meta, catalog
+	}
+
+	buildSchema := func(ids ...int64) *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name:            "collection",
+			Version:         2,
+			FileResourceIds: ids,
+		}
+	}
+
+	t.Run("consume request path reservation", func(t *testing.T) {
+		meta, catalog := newMeta(nil, map[int64]int{})
+		require.NoError(t, reserveAlterCollectionFileResourceRefs(meta, collectionID, []int64{resourceID}))
+		catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, true).Return(nil).Once()
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.NoError(t, err)
+		require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+		require.ElementsMatch(t, []int64{resourceID}, meta.collID2Meta[collectionID].FileResourceIds)
+	})
+
+	t.Run("rollback request path reservation", func(t *testing.T) {
+		meta, _ := newMeta(nil, map[int64]int{})
+		require.NoError(t, reserveAlterCollectionFileResourceRefs(meta, collectionID, []int64{resourceID}))
+
+		rollbackAlterCollectionFileResourceRefs(context.Background(), meta, collectionID, []int64{resourceID})
+
+		require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+		require.NotContains(t, meta.fileResourceRefHolds, collectionID)
+	})
+
+	t.Run("replay or replicated task adds refCnt without reservation", func(t *testing.T) {
+		meta, catalog := newMeta(nil, map[int64]int{resourceID: 1})
+		catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, true).Return(nil).Once()
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.NoError(t, err)
+		require.Equal(t, 2, meta.fileResourceRefCnt[resourceID])
+		require.ElementsMatch(t, []int64{resourceID}, meta.collID2Meta[collectionID].FileResourceIds)
+		require.Equal(t, 1, meta.fileResourceRefHolds[999][resourceID])
+	})
+
+	t.Run("recovery hold prevents double increment for pending alter", func(t *testing.T) {
+		meta, catalog := newMeta(nil, map[int64]int{})
+		meta.RecoverFileResourceRefCnt(map[int64][]int64{collectionID: {resourceID}})
+		catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, true).Return(nil).Once()
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.NoError(t, err)
+		require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+		require.NotContains(t, meta.fileResourceRefHolds, collectionID)
+		require.ElementsMatch(t, []int64{resourceID}, meta.collID2Meta[collectionID].FileResourceIds)
+	})
+
+	t.Run("replace resource decrements removed and consumes added reservation", func(t *testing.T) {
+		meta, catalog := newMeta([]int64{oldResource}, map[int64]int{oldResource: 1})
+		require.NoError(t, reserveAlterCollectionFileResourceRefs(meta, collectionID, []int64{resourceID}))
+		catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, true).Return(nil).Once()
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.NoError(t, err)
+		require.Equal(t, 0, meta.fileResourceRefCnt[oldResource])
+		require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+		require.ElementsMatch(t, []int64{resourceID}, meta.collID2Meta[collectionID].FileResourceIds)
+	})
+
+	t.Run("missing added resource fails before catalog update", func(t *testing.T) {
+		meta, catalog := newMeta(nil, map[int64]int{})
+		delete(meta.fileResourceID2Meta, resourceID)
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.Error(t, err)
+		catalog.AssertNotCalled(t, "AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		require.Empty(t, meta.collID2Meta[collectionID].FileResourceIds)
 	})
 }
 

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -557,10 +557,10 @@ func (c *Core) Init() error {
 
 	c.initOnce.Do(func() {
 		initError = c.initInternal()
-		// Recover file resource refCnt for pending CreateCollection broadcast tasks
+		// Recover file resource refCnt for pending schema broadcast tasks
 		// before registering DDL callbacks, so ack callbacks won't race with recovery.
 		// See #48612.
-		pending := broadcast.GetPendingCreateCollectionResources()
+		pending := broadcast.GetPendingSchemaFileResources()
 		if len(pending) > 0 {
 			c.meta.RecoverFileResourceRefCnt(pending)
 			mlog.Info(context.TODO(), "recovered file resource refCnt from pending broadcast tasks", mlog.Int("count", len(pending)))

--- a/internal/streamingcoord/server/broadcaster/broadcast/singleton.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast/singleton.go
@@ -61,13 +61,13 @@ func StartBroadcastWithSecondaryClusterResourceKey(ctx context.Context) (broadca
 	return broadcaster.WithSecondaryClusterResourceKey(ctx)
 }
 
-// GetPendingCreateCollectionResources returns pending CreateCollection file resource
-// IDs from the broadcaster. Must be called after Register.
-func GetPendingCreateCollectionResources() map[int64][]int64 {
+// GetPendingSchemaFileResources returns pending schema file resource IDs
+// from the broadcaster. Must be called after Register.
+func GetPendingSchemaFileResources() map[int64][]int64 {
 	if !singleton.Ready() {
 		return nil
 	}
-	return singleton.Get().GetPendingCreateCollectionResources()
+	return singleton.Get().GetPendingSchemaFileResources()
 }
 
 // Release releases the broadcaster.

--- a/internal/streamingcoord/server/broadcaster/broadcast_manager.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_manager.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
@@ -212,7 +214,7 @@ func (bm *broadcastTaskManager) appendSharedClusterRK(resourceKeys ...message.Re
 func (bm *broadcastTaskManager) broadcast(ctx context.Context, msg message.BroadcastMutableMessage, broadcastID uint64, guards *lockGuards) (*types.BroadcastAppendResult, error) {
 	if !bm.lifetime.Add(typeutil.LifetimeStateWorking) {
 		guards.Unlock()
-		return nil, status.NewOnShutdownError("broadcaster is closing")
+		return nil, errors.Mark(status.NewOnShutdownError("broadcaster is closing"), ErrBroadcastTaskNotCreated)
 	}
 	defer bm.lifetime.Done()
 
@@ -364,10 +366,10 @@ func (bm *broadcastTaskManager) getIncompleteBroadcastTasks() []*broadcastTask {
 	return result
 }
 
-// GetPendingCreateCollectionResources returns collection ID → file resource IDs
-// for all non-tombstone CreateCollection broadcast tasks. Used during recovery to
-// rebuild file resource refCnt for collections whose AddCollection hasn't run yet.
-func (bm *broadcastTaskManager) GetPendingCreateCollectionResources() map[int64][]int64 {
+// GetPendingSchemaFileResources returns collection ID -> file resource IDs
+// for all non-tombstone schema broadcast tasks. Used during recovery to rebuild
+// file resource refCnt for resources referenced by pending schema changes.
+func (bm *broadcastTaskManager) GetPendingSchemaFileResources() map[int64][]int64 {
 	bm.mu.Lock()
 	defer bm.mu.Unlock()
 
@@ -376,18 +378,43 @@ func (bm *broadcastTaskManager) GetPendingCreateCollectionResources() map[int64]
 		if task.State() == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
 			continue
 		}
-		if task.msg.MessageType() != message.MessageTypeCreateCollection {
+		switch task.msg.MessageTypeWithVersion() {
+		case message.MessageTypeCreateCollectionV1:
+			createMsg, err := message.AsMutableCreateCollectionMessageV1(task.msg)
+			if err != nil {
+				continue
+			}
+			body := createMsg.MustBody()
+			ids := body.CollectionSchema.GetFileResourceIds()
+			appendPendingFileResourceIDs(result, createMsg.Header().CollectionId, ids)
+		case message.MessageTypeAlterCollectionV2:
+			alterMsg, err := message.AsMutableAlterCollectionMessageV2(task.msg)
+			if err != nil {
+				continue
+			}
+			schema := alterMsg.MustBody().GetUpdates().GetSchema()
+			ids := schema.GetFileResourceIds()
+			appendPendingFileResourceIDs(result, alterMsg.Header().CollectionId, ids)
+		default:
 			continue
-		}
-		createMsg, err := message.AsMutableCreateCollectionMessageV1(task.msg)
-		if err != nil {
-			continue
-		}
-		body := createMsg.MustBody()
-		ids := body.CollectionSchema.GetFileResourceIds()
-		if len(ids) > 0 {
-			result[createMsg.Header().CollectionId] = ids
 		}
 	}
 	return result
+}
+
+func appendPendingFileResourceIDs(result map[int64][]int64, collectionID int64, ids []int64) {
+	if len(ids) == 0 {
+		return
+	}
+	seen := make(map[int64]struct{}, len(result[collectionID])+len(ids))
+	for _, id := range result[collectionID] {
+		seen[id] = struct{}{}
+	}
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		result[collectionID] = append(result[collectionID], id)
+		seen[id] = struct{}{}
+	}
 }

--- a/internal/streamingcoord/server/broadcaster/broadcaster.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster.go
@@ -12,7 +12,14 @@ import (
 var (
 	ErrNotPrimary   = errors.New("cluster is not primary, cannot do any DDL/DCL")
 	ErrNotSecondary = errors.New("cluster is not secondary, cannot perform force promote")
+
+	// ErrBroadcastTaskNotCreated marks a Broadcast error returned before the task is registered in the manager.
+	ErrBroadcastTaskNotCreated = errors.New("broadcast task not created")
 )
+
+func IsBroadcastTaskNotCreated(err error) bool {
+	return errors.Is(err, ErrBroadcastTaskNotCreated)
+}
 
 type Broadcaster interface {
 	// WithResourceKeys sets the resource keys of the broadcast operation.
@@ -32,10 +39,10 @@ type Broadcaster interface {
 	// Ack acknowledges the message at the specified vchannel.
 	Ack(ctx context.Context, msg message.ImmutableMessage) error
 
-	// GetPendingCreateCollectionResources returns collection ID → file resource IDs
-	// for all pending CreateCollection broadcast tasks that haven't completed
-	// their ack callback yet. Used during recovery to rebuild file resource refCnt.
-	GetPendingCreateCollectionResources() map[int64][]int64
+	// GetPendingSchemaFileResources returns collection ID -> file resource IDs
+	// for all pending schema broadcast tasks that haven't completed their ack
+	// callback yet. Used during recovery to rebuild file resource refCnt.
+	GetPendingSchemaFileResources() map[int64][]int64
 
 	// Close closes the broadcaster.
 	Close()

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
 	"github.com/milvus-io/milvus/internal/mocks/mock_metastore"
@@ -26,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
 	internaltypes "github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/idalloc"
+	streamingstatus "github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/mocks/streaming/util/mock_message"
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
@@ -231,6 +233,29 @@ func createNewBroadcastMsg(vchannels []string, rks ...message.ResourceKey) messa
 	return msg.OverwriteBroadcastHeader(0, rks...)
 }
 
+func TestBroadcastTaskNotCreatedOnStoppedBroadcaster(t *testing.T) {
+	locker := newResourceKeyLocker()
+	rk := message.NewExclusiveCollectionNameResourceKey("db", "collection")
+	guards := locker.Lock(rk)
+	bm := &broadcastTaskManager{
+		lifetime: typeutil.NewLifetime(),
+		mu:       &sync.Mutex{},
+		tasks:    map[uint64]*broadcastTask{},
+	}
+	bm.lifetime.SetState(typeutil.LifetimeStateStopped)
+
+	_, err := bm.broadcast(context.Background(), createNewBroadcastMsg([]string{"v1"}, rk), 1, guards)
+
+	require.Error(t, err)
+	require.True(t, IsBroadcastTaskNotCreated(err))
+	require.True(t, streamingstatus.AsStreamingError(err).IsOnShutdown())
+	require.Empty(t, bm.tasks)
+
+	nextGuards, lockErr := locker.FastLock(rk)
+	require.NoError(t, lockErr)
+	nextGuards.Unlock()
+}
+
 func createNewBroadcastTask(broadcastID uint64, vchannels []string, rks ...message.ResourceKey) *streamingpb.BroadcastTask {
 	msg := createNewBroadcastMsg(vchannels).OverwriteBroadcastHeader(broadcastID, rks...)
 	pb := msg.IntoMessageProto()
@@ -409,6 +434,62 @@ func TestGetIncompleteBroadcastTasks(t *testing.T) {
 	assert.Contains(t, resultIDs, uint64(2), "REPLICATED task with pending messages should be returned")
 	assert.NotContains(t, resultIDs, uint64(3), "PENDING task with all vchannels acked should not be returned")
 	assert.NotContains(t, resultIDs, uint64(4), "TOMBSTONE task should not be returned")
+}
+
+func TestGetPendingSchemaFileResources(t *testing.T) {
+	paramtable.Init()
+
+	metrics := newBroadcasterMetrics()
+	ackScheduler := newAckCallbackScheduler(mlog.With())
+
+	createCollectionMsg := func(collectionID int64, fileResourceIDs []int64) message.BroadcastMutableMessage {
+		return message.NewCreateCollectionMessageBuilderV1().
+			WithHeader(&message.CreateCollectionMessageHeader{
+				CollectionId: collectionID,
+			}).
+			WithBody(&msgpb.CreateCollectionRequest{
+				CollectionSchema: &schemapb.CollectionSchema{
+					FileResourceIds: fileResourceIDs,
+				},
+			}).
+			WithBroadcast([]string{"v1"}).
+			MustBuildBroadcast()
+	}
+	alterCollectionMsg := func(collectionID int64, fileResourceIDs []int64) message.BroadcastMutableMessage {
+		return message.NewAlterCollectionMessageBuilderV2().
+			WithHeader(&message.AlterCollectionMessageHeader{
+				CollectionId: collectionID,
+			}).
+			WithBody(&message.AlterCollectionMessageBody{
+				Updates: &message.AlterCollectionMessageUpdates{
+					Schema: &schemapb.CollectionSchema{
+						FileResourceIds: fileResourceIDs,
+					},
+				},
+			}).
+			WithBroadcast([]string{"v1"}).
+			MustBuildBroadcast()
+	}
+	newTask := func(broadcastID uint64, msg message.BroadcastMutableMessage, state streamingpb.BroadcastTaskState) *broadcastTask {
+		proto := createNewWaitAckBroadcastTaskFromMessage(msg.WithBroadcastID(broadcastID), state, []byte{0x00})
+		return newBroadcastTaskFromProto(proto, metrics, ackScheduler)
+	}
+
+	bm := &broadcastTaskManager{
+		mu: &sync.Mutex{},
+		tasks: map[uint64]*broadcastTask{
+			1: newTask(1, createCollectionMsg(100, []int64{10, 20}), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING),
+			2: newTask(2, alterCollectionMsg(100, []int64{20, 30}), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING),
+			3: newTask(3, alterCollectionMsg(200, nil), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING),
+			4: newTask(4, alterCollectionMsg(300, []int64{40}), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE),
+			5: newTask(5, createNewBroadcastMsg([]string{"v1"}), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING),
+		},
+	}
+
+	result := bm.GetPendingSchemaFileResources()
+
+	require.Len(t, result, 1)
+	assert.ElementsMatch(t, []int64{10, 20, 30}, result[100])
 }
 
 func TestWithSecondaryClusterResourceKey(t *testing.T) {

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -4074,9 +4074,25 @@ func IsBM25FunctionOutputField(field *schemapb.FieldSchema, collSchema *schemapb
 }
 
 func IsBm25FunctionInputField(coll *schemapb.CollectionSchema, field *schemapb.FieldSchema) bool {
+	if coll == nil || field == nil {
+		return false
+	}
 	for _, fn := range coll.GetFunctions() {
-		if fn.GetType() == schemapb.FunctionType_BM25 && field.GetName() == fn.GetInputFieldNames()[0] {
-			return true
+		if fn.GetType() != schemapb.FunctionType_BM25 {
+			continue
+		}
+		if field.GetFieldID() != 0 && len(fn.GetInputFieldIds()) > 0 {
+			for _, id := range fn.GetInputFieldIds() {
+				if field.GetFieldID() == id {
+					return true
+				}
+			}
+			continue
+		}
+		for _, name := range fn.GetInputFieldNames() {
+			if field.GetName() == name {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -4956,7 +4956,28 @@ func TestIsBM25FunctionOutputField(t *testing.T) {
 func TestIsBm25FunctionInputField(t *testing.T) {
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
-			{Name: "input_field", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "enable_analyzer", Value: "true"}}},
+			{FieldID: 100, Name: "input_field", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "enable_analyzer", Value: "true"}}},
+			{FieldID: 101, Name: "output_field", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name:             "bm25_func",
+				Type:             schemapb.FunctionType_BM25,
+				InputFieldIds:    []int64{100},
+				InputFieldNames:  []string{"input_field"},
+				OutputFieldIds:   []int64{101},
+				OutputFieldNames: []string{"output_field"},
+			},
+		},
+	}
+	assert.True(t, IsBm25FunctionInputField(schema, schema.Fields[0]))
+	assert.False(t, IsBm25FunctionInputField(schema, schema.Fields[1]))
+
+	// CreateCollection validation runs before field IDs are assigned, so the
+	// helper must fall back to input field names when IDs are unavailable.
+	schemaWithoutIds := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "input_field", DataType: schemapb.DataType_VarChar},
 			{Name: "output_field", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
 		},
 		Functions: []*schemapb.FunctionSchema{
@@ -4968,28 +4989,32 @@ func TestIsBm25FunctionInputField(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, IsBm25FunctionInputField(schema, schema.Fields[0]))
-	assert.False(t, IsBm25FunctionInputField(schema, schema.Fields[1]))
+	assert.True(t, IsBm25FunctionInputField(schemaWithoutIds, schemaWithoutIds.Fields[0]))
+	assert.False(t, IsBm25FunctionInputField(schemaWithoutIds, schemaWithoutIds.Fields[1]))
 
 	// Test with multiple functions, only one is BM25
 	multipleSchema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
-			{Name: "input_field1", DataType: schemapb.DataType_VarChar},
-			{Name: "input_field2", DataType: schemapb.DataType_VarChar},
-			{Name: "output_field1", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
-			{Name: "output_field2", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true},
+			{FieldID: 100, Name: "input_field1", DataType: schemapb.DataType_VarChar},
+			{FieldID: 101, Name: "input_field2", DataType: schemapb.DataType_VarChar},
+			{FieldID: 102, Name: "output_field1", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+			{FieldID: 103, Name: "output_field2", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true},
 		},
 		Functions: []*schemapb.FunctionSchema{
 			{
 				Name:             "bm25_func",
 				Type:             schemapb.FunctionType_BM25,
+				InputFieldIds:    []int64{100},
 				InputFieldNames:  []string{"input_field1"},
+				OutputFieldIds:   []int64{102},
 				OutputFieldNames: []string{"output_field1"},
 			},
 			{
 				Name:             "other_func",
 				Type:             schemapb.FunctionType_Unknown,
+				InputFieldIds:    []int64{101},
 				InputFieldNames:  []string{"input_field2"},
+				OutputFieldIds:   []int64{103},
 				OutputFieldNames: []string{"output_field2"},
 			},
 		},


### PR DESCRIPTION
issue: #50961
pr: https://github.com/milvus-io/milvus/pull/50492

## Summary
Backport the complete implementation from #50492 to 3.0.

- allow `AlterCollectionField` to set or delete analyzer configuration on inactive string fields
- keep analyzer params immutable after text match is enabled or a BM25 function depends on the field
- revalidate analyzer configuration and reserve newly referenced file resources before schema broadcasts
- reconcile file resource refCnt for request, WAL replay, replicated, and startup recovery paths
- rollback reservations only when the broadcast task was not registered