### PR TITLE
fix: skip non-materialized function output field on growing segment flush (#51117)

### DIFF
--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1733,6 +1733,25 @@ class InsertRecordGrowing {
         return data_.find(field_id) != data_.end();
     }
 
+    // Field ids that have materialized columns. The exact set the flush
+    // layout must be trimmed to: non-materialized function outputs are
+    // absent here.
+    std::vector<int64_t>
+    get_data_field_ids() const {
+        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
+        std::vector<int64_t> ids;
+        ids.reserve(data_.size());
+        for (const auto& [field_id, entry] : data_) {
+            // An allocated-but-empty column (e.g. a function output the
+            // replayed older-era inserts never filled) is not materialized.
+            if (!entry || entry->empty()) {
+                continue;
+            }
+            ids.push_back(field_id.get());
+        }
+        return ids;
+    }
+
     bool
     is_valid_data_exist(FieldId field_id) const {
         std::shared_lock<std::shared_mutex> lck(field_map_mutex_);

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -1854,6 +1854,51 @@ BuildArrayForChunk(const FieldInfo& field_info,
 }  // anonymous namespace
 
 CStatus
+GetGrowingSegmentMaterializedFieldIDs(CSegmentInterface c_segment,
+                                      int64_t** field_ids,
+                                      int64_t* count) {
+    SCOPE_CGO_CALL_METRIC();
+
+    try {
+        if (!c_segment || !field_ids || !count) {
+            return milvus::FailureCStatus(
+                milvus::UnexpectedError,
+                "invalid arguments: segment, field_ids and count must not be "
+                "null");
+        }
+        *field_ids = nullptr;
+        *count = 0;
+        auto segment_interface =
+            reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
+        auto growing_segment =
+            dynamic_cast<milvus::segcore::SegmentGrowingImpl*>(
+                segment_interface);
+        if (!growing_segment) {
+            return milvus::FailureCStatus(milvus::UnexpectedError,
+                                          "segment is not a growing segment");
+        }
+        auto ids = growing_segment->get_insert_record().get_data_field_ids();
+        if (!ids.empty()) {
+            auto* buf =
+                static_cast<int64_t*>(malloc(sizeof(int64_t) * ids.size()));
+            if (!buf) {
+                return milvus::FailureCStatus(
+                    milvus::UnexpectedError,
+                    "failed to allocate materialized field ids");
+            }
+            for (size_t i = 0; i < ids.size(); i++) {
+                buf[i] = ids[i];
+            }
+            *field_ids = buf;
+            *count = static_cast<int64_t>(ids.size());
+        }
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
 FlushGrowingSegmentData(CSegmentInterface c_segment,
                         int64_t start_offset,
                         int64_t end_offset,
@@ -1876,6 +1921,8 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         result->field_ids = nullptr;
         result->field_null_counts = nullptr;
         result->num_field_stats = 0;
+        result->flushed_field_ids = nullptr;
+        result->num_flushed_fields = 0;
         result->column_group_ids = nullptr;
         result->column_group_memory_sizes = nullptr;
         result->num_column_groups = 0;
@@ -1960,6 +2007,10 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         // to ensure deterministic column order matching the reader's expected order.
         std::vector<FieldInfo> field_infos;
         std::vector<std::shared_ptr<arrow::Field>> arrow_fields;
+        // Columns legally skipped below (dropped fields, non-materialized
+        // function outputs); the column-group accounting loop must tolerate
+        // their absence as well.
+        std::unordered_set<int64_t> skipped_columns;
 
         for (const auto& field_id : schema.get_field_ids()) {
             if (!allowed_field_ids.empty() &&
@@ -1977,6 +2028,46 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
             } else if (field_id == TimestampFieldID) {
                 vec_base = &insert_record.timestamps_;
             } else {
+                // HasFieldData, not is_data_exist: a column the ctor
+                // allocated but replayed older-era inserts never filled is
+                // not materialized either.
+                if (!growing_segment->HasFieldData(field_id)) {
+                    // Legally absent: the field is gone from the segment's
+                    // own schema (dropped; the flush schema is a staler
+                    // snapshot), or it is a function output the segment
+                    // never materializes (backfilled by bump-schema
+                    // compaction). The Go layer normally trims such columns
+                    // from the layout already — this is the defense for
+                    // stale layouts.
+                    if (!growing_segment->get_schema().has_field(field_id)) {
+                        LOG_INFO(
+                            "skip dropped field {} when flushing growing "
+                            "segment {}",
+                            field_id.get(),
+                            growing_segment->get_segment_id());
+                        skipped_columns.insert(field_id.get());
+                        continue;
+                    }
+                    if (schema.is_function_output(field_id)) {
+                        LOG_INFO(
+                            "skip non-materialized function output field {} "
+                            "when flushing growing segment {}",
+                            field_id.get(),
+                            growing_segment->get_segment_id());
+                        skipped_columns.insert(field_id.get());
+                        continue;
+                    }
+                    // A regular field of the segment's own schema is
+                    // materialized by the ctor/Reopen by construction;
+                    // reaching here is real data loss.
+                    return milvus::FailureCStatus(
+                        milvus::UnexpectedError,
+                        fmt::format("field {} has no field data in growing "
+                                    "segment {} but is present in the "
+                                    "segment schema",
+                                    field_id.get(),
+                                    growing_segment->get_segment_id()));
+                }
                 vec_base = insert_record.get_data_base(field_id);
                 if (!vec_base) {
                     LOG_ERROR("no data base for field {} of segment {}",
@@ -2065,6 +2156,20 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         if (field_infos.empty()) {
             return milvus::FailureCStatus(milvus::UnexpectedError,
                                           "no fields to flush");
+        }
+
+        // Publish the authoritative flushed-column set directly from
+        // field_infos; Go binlog meta must be derived from this.
+        result->flushed_field_ids =
+            static_cast<int64_t*>(malloc(sizeof(int64_t) * field_infos.size()));
+        if (!result->flushed_field_ids) {
+            return milvus::FailureCStatus(
+                milvus::UnexpectedError,
+                "failed to allocate flushed field ids");
+        }
+        result->num_flushed_fields = field_infos.size();
+        for (size_t i = 0; i < field_infos.size(); i++) {
+            result->flushed_field_ids[i] = field_infos[i].field_id.get();
         }
 
         auto arrow_schema = arrow::schema(arrow_fields);
@@ -2302,6 +2407,11 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                 for (size_t j = 0; j < field_count; j++) {
                     auto field_id =
                         config->column_group_field_ids[field_offset + j];
+                    if (skipped_columns.count(field_id) > 0) {
+                        // Column intentionally not flushed; contributes no
+                        // size and must not fail the accounting.
+                        continue;
+                    }
                     auto size_it = field_uncompressed_sizes.find(field_id);
                     if (size_it == field_uncompressed_sizes.end()) {
                         return milvus::FailureCStatus(
@@ -2480,6 +2590,10 @@ FreeFlushResult(CFlushResult* result) {
     if (result && result->field_null_counts) {
         free(result->field_null_counts);
         result->field_null_counts = nullptr;
+    }
+    if (result && result->flushed_field_ids) {
+        free(result->flushed_field_ids);
+        result->flushed_field_ids = nullptr;
     }
     if (result && result->column_group_ids) {
         free(result->column_group_ids);

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -339,7 +339,11 @@ typedef struct CFlushResult {
     int64_t* field_ids;          // field ids for per-field flush summaries
     int64_t* field_null_counts;  // null count per field
     size_t num_field_stats;      // number of field summary entries
-    int64_t* column_group_ids;   // column group ids for binlog summaries
+    int64_t*
+        flushed_field_ids;  // exact set of columns actually written; skipped
+                            // non-materialized function outputs are absent
+    size_t num_flushed_fields;  // number of entries in flushed_field_ids
+    int64_t* column_group_ids;  // column group ids for binlog summaries
     int64_t*
         column_group_memory_sizes;  // uncompressed Arrow data size per column group
     size_t num_column_groups;       // number of column group summary entries
@@ -366,6 +370,16 @@ typedef struct CFlushResult {
  * @param result Output flush result (caller must free manifest_path)
  * @return CStatus indicating success or failure
  */
+/**
+ * @brief Get the field ids with materialized columns in a growing segment.
+ * The flush layout must be derived from this set. Caller frees *field_ids
+ * with free().
+ */
+CStatus
+GetGrowingSegmentMaterializedFieldIDs(CSegmentInterface c_segment,
+                                      int64_t** field_ids,
+                                      int64_t* count);
+
 CStatus
 FlushGrowingSegmentData(CSegmentInterface c_segment,
                         int64_t start_offset,

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -219,6 +219,275 @@ TEST_F(StorageTest, TextFieldDataFromManifestResolvesLobRefs) {
     cleanup();
 }
 
+// A growing segment born while a function output field was absent from the
+// schema (add/drop-function churn) never materializes that column —
+// Reopen/FillAbsentFields skip function outputs by design. Flushing with a
+// newer schema that carries the field must skip the column instead of
+// hitting the insert_record assert (issue #51117).
+TEST_F(StorageTest, FlushGrowingSegmentSkipsNonMaterializedFunctionOutput) {
+    std::string test_dir =
+        "/tmp/flush_skip_fn_output_" +
+        std::to_string(
+            std::chrono::system_clock::now().time_since_epoch().count());
+    std::filesystem::create_directories(test_dir);
+    auto cleanup = [&]() {
+        if (std::filesystem::exists(test_dir)) {
+            std::filesystem::remove_all(test_dir);
+        }
+    };
+
+    milvus::proto::schema::CollectionSchema schema_proto;
+    schema_proto.set_name("flush_skip_fn_output");
+    // Real flush schemas always carry the RowID/Timestamp system fields;
+    // the flush validates the Timestamp column was exported.
+    auto* row_id_field = schema_proto.add_fields();
+    row_id_field->set_fieldid(0);
+    row_id_field->set_name("RowID");
+    row_id_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* ts_field = schema_proto.add_fields();
+    ts_field->set_fieldid(1);
+    ts_field->set_name("Timestamp");
+    ts_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+
+    auto segment_schema = Schema::ParseFrom(schema_proto);
+    auto segment = CreateGrowingSegment(segment_schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    constexpr int N = 3;
+    std::vector<int64_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {10, 11, 12};
+    std::vector<int64_t> pks = {100, 101, 102};
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(N);
+    insert_data->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(
+            pks.data(), nullptr, N, (*segment_schema)[FieldId(100)])
+            .release());
+
+    segment->PreInsert(N);
+    segment->Insert(0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    // Flush schema carries a function output field the segment never
+    // materialized.
+    auto flush_proto = schema_proto;
+    auto* fn_output = flush_proto.add_fields();
+    fn_output->set_fieldid(101);
+    fn_output->set_name("fn_sparse");
+    fn_output->set_data_type(
+        milvus::proto::schema::DataType::SparseFloatVector);
+    fn_output->set_is_function_output(true);
+    std::string schema_blob = flush_proto.SerializeAsString();
+
+    CFlushConfig config{};
+    std::string segment_path = test_dir + "/collection/partition/segment_fn";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.schema_blob = schema_blob.data();
+    config.schema_length = static_cast<int64_t>(schema_blob.size());
+    // Column-group config still carrying the skipped function output: the
+    // accounting loop must tolerate its absence instead of failing the flush.
+    int64_t column_group_ids[] = {0};
+    int64_t column_group_field_ids[] = {0, 1, 100, 101};
+    size_t column_group_field_counts[] = {4};
+    config.column_group_ids = column_group_ids;
+    config.column_group_field_ids = column_group_field_ids;
+    config.column_group_field_counts = column_group_field_counts;
+    config.num_column_groups = 1;
+
+    CFlushResult result{};
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(result.num_rows, N);
+    ASSERT_EQ(result.num_column_groups, 1u);
+    for (size_t i = 0; i < result.num_field_stats; ++i) {
+        EXPECT_NE(result.field_ids[i], 101);
+    }
+    for (size_t i = 0; i < result.num_flushed_fields; ++i) {
+        EXPECT_NE(result.flushed_field_ids[i], 101);
+    }
+
+    FreeFlushResult(&result);
+    cleanup();
+}
+
+// A regular field carried by a staler flush schema but absent from the
+// segment's own schema was dropped before the segment was created: the
+// flush must skip it instead of erroring or asserting.
+TEST_F(StorageTest, FlushGrowingSegmentSkipsFieldAbsentFromSegmentSchema) {
+    std::string test_dir =
+        "/tmp/flush_skip_dropped_field_" +
+        std::to_string(
+            std::chrono::system_clock::now().time_since_epoch().count());
+    std::filesystem::create_directories(test_dir);
+    auto cleanup = [&]() {
+        if (std::filesystem::exists(test_dir)) {
+            std::filesystem::remove_all(test_dir);
+        }
+    };
+
+    milvus::proto::schema::CollectionSchema schema_proto;
+    schema_proto.set_name("flush_skip_dropped_field");
+    auto* row_id_field = schema_proto.add_fields();
+    row_id_field->set_fieldid(0);
+    row_id_field->set_name("RowID");
+    row_id_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* ts_field = schema_proto.add_fields();
+    ts_field->set_fieldid(1);
+    ts_field->set_name("Timestamp");
+    ts_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+
+    auto segment_schema = Schema::ParseFrom(schema_proto);
+    auto segment = CreateGrowingSegment(segment_schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    constexpr int N = 3;
+    std::vector<int64_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {10, 11, 12};
+    std::vector<int64_t> pks = {100, 101, 102};
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(N);
+    insert_data->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(
+            pks.data(), nullptr, N, (*segment_schema)[FieldId(100)])
+            .release());
+
+    segment->PreInsert(N);
+    segment->Insert(0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    // Staler flush schema still carries an ordinary field the segment's own
+    // schema never had (dropped before the segment was created).
+    auto flush_proto = schema_proto;
+    auto* extra = flush_proto.add_fields();
+    extra->set_fieldid(101);
+    extra->set_name("dropped_field");
+    extra->set_data_type(milvus::proto::schema::DataType::VarChar);
+    extra->set_nullable(true);
+    auto* param = extra->add_type_params();
+    param->set_key("max_length");
+    param->set_value("64");
+    std::string schema_blob = flush_proto.SerializeAsString();
+
+    CFlushConfig config{};
+    std::string segment_path = test_dir + "/collection/partition/segment_dp";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.schema_blob = schema_blob.data();
+    config.schema_length = static_cast<int64_t>(schema_blob.size());
+
+    CFlushResult result{};
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(result.num_rows, N);
+    for (size_t i = 0; i < result.num_flushed_fields; ++i) {
+        EXPECT_NE(result.flushed_field_ids[i], 101);
+    }
+
+    FreeFlushResult(&result);
+    cleanup();
+}
+
+// A function-output column the ctor allocated but no insert ever filled
+// (older-era replayed inserts omit it) is not materialized: the flush must
+// skip it instead of tripping the empty-chunk assert.
+TEST_F(StorageTest, FlushGrowingSegmentSkipsEmptyFunctionOutputColumn) {
+    std::string test_dir =
+        "/tmp/flush_skip_empty_fn_output_" +
+        std::to_string(
+            std::chrono::system_clock::now().time_since_epoch().count());
+    std::filesystem::create_directories(test_dir);
+    auto cleanup = [&]() {
+        if (std::filesystem::exists(test_dir)) {
+            std::filesystem::remove_all(test_dir);
+        }
+    };
+
+    milvus::proto::schema::CollectionSchema schema_proto;
+    schema_proto.set_name("flush_skip_empty_fn_output");
+    auto* row_id_field = schema_proto.add_fields();
+    row_id_field->set_fieldid(0);
+    row_id_field->set_name("RowID");
+    row_id_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* ts_field = schema_proto.add_fields();
+    ts_field->set_fieldid(1);
+    ts_field->set_name("Timestamp");
+    ts_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+    // Function output present in the segment's own schema: the ctor
+    // allocates its column, but replayed inserts never fill it.
+    auto* fn_output = schema_proto.add_fields();
+    fn_output->set_fieldid(101);
+    fn_output->set_name("fn_sparse");
+    fn_output->set_data_type(
+        milvus::proto::schema::DataType::SparseFloatVector);
+    fn_output->set_is_function_output(true);
+
+    auto segment_schema = Schema::ParseFrom(schema_proto);
+    auto segment = CreateGrowingSegment(segment_schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    constexpr int N = 3;
+    std::vector<int64_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {10, 11, 12};
+    std::vector<int64_t> pks = {100, 101, 102};
+
+    // Insert carries no data for the function output; the consume path
+    // exempts function outputs, leaving field 101 allocated but empty.
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(N);
+    insert_data->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(
+            pks.data(), nullptr, N, (*segment_schema)[FieldId(100)])
+            .release());
+
+    segment->PreInsert(N);
+    segment->Insert(0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    std::string schema_blob = schema_proto.SerializeAsString();
+
+    CFlushConfig config{};
+    std::string segment_path = test_dir + "/collection/partition/segment_ef";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.schema_blob = schema_blob.data();
+    config.schema_length = static_cast<int64_t>(schema_blob.size());
+
+    CFlushResult result{};
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(result.num_rows, N);
+    for (size_t i = 0; i < result.num_flushed_fields; ++i) {
+        EXPECT_NE(result.flushed_field_ids[i], 101);
+    }
+
+    FreeFlushResult(&result);
+    cleanup();
+}
+
 TEST_F(StorageTest, GetLocalUsedSize) {
     int64_t size = 0;
     auto lcm = LocalChunkManagerSingleton::GetInstance().GetChunkManager();

--- a/internal/flushcommon/syncmgr/growing_source.go
+++ b/internal/flushcommon/syncmgr/growing_source.go
@@ -71,10 +71,16 @@ type GrowingFlushConfig struct {
 }
 
 type GrowingFlushResult struct {
-	ManifestPath           string
-	NumRows                int64
-	TimestampFrom          uint64
-	TimestampTo            uint64
+	ManifestPath  string
+	NumRows       int64
+	TimestampFrom uint64
+	TimestampTo   uint64
+	// FlushedFieldIDs is the authoritative set of columns the flush actually
+	// wrote. It may be a subset of the flush schema: non-materialized
+	// function-output columns are skipped (backfilled later by bump-schema
+	// compaction). All binlog meta must be derived from this set, never from
+	// the schema.
+	FlushedFieldIDs        []int64
 	ColumnGroupMemorySizes map[int64]int64
 	FieldNullCounts        map[int64]int64
 	BM25Stats              map[int64]*storage.BM25Stats
@@ -82,6 +88,13 @@ type GrowingFlushResult struct {
 
 type GrowingFlushSource interface {
 	CurrentOffset() int64
+	// MaterializedFieldIDs returns the field ids with materialized columns in
+	// the source segment. The flush layout must be trimmed to this set; a
+	// non-materialized column is legally absent (a dropped field or a
+	// function output backfilled by bump-schema compaction). A live segment
+	// always has materialized columns, so an empty set is an error, not a
+	// no-op.
+	MaterializedFieldIDs(ctx context.Context) ([]int64, error)
 	FlushGrowingData(ctx context.Context, startOffset, endOffset int64, config *GrowingFlushConfig) (*GrowingFlushResult, error)
 	Release()
 }
@@ -574,6 +587,13 @@ func (t *GrowingSourceSyncTask) Run(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	// Unification point: from here on the intended layout and the layout the
+	// flush actually writes are one. Every consumer below (writer config,
+	// binlog meta, metacache current split) sees the same trimmed groups.
+	columnGroups, err = t.trimColumnGroupsToMaterialized(ctx, columnGroups)
+	if err != nil {
+		return err
+	}
 	if t.committedManifestPath != "" {
 		t.manifestPath = t.committedManifestPath
 		t.bm25Stats = t.committedBM25Stats
@@ -670,6 +690,91 @@ func (t *GrowingSourceSyncTask) getColumnGroups(segment *metacache.SegmentInfo) 
 	return resolveColumnGroups(segment, t.schema, t.segmentID, func() map[int64]storagecommon.ColumnStats {
 		return map[int64]storagecommon.ColumnStats{}
 	}), nil
+}
+
+// filterColumnGroupFields keeps only the fields keep() accepts, trimming the
+// parallel Columns array in lockstep so downstream consumers that map over
+// Columns (e.g. SchemaBasedPattern) never see a dropped field. Groups left
+// empty are removed. The skipped field ids are returned for logging.
+func filterColumnGroupFields(columnGroups []storagecommon.ColumnGroup, keep func(fieldID int64) bool) ([]storagecommon.ColumnGroup, []int64) {
+	skipped := make([]int64, 0)
+	trimmed := make([]storagecommon.ColumnGroup, 0, len(columnGroups))
+	for _, columnGroup := range columnGroups {
+		fields := make([]int64, 0, len(columnGroup.Fields))
+		columns := make([]int, 0, len(columnGroup.Columns))
+		for i, fieldID := range columnGroup.Fields {
+			if !keep(fieldID) {
+				skipped = append(skipped, fieldID)
+				continue
+			}
+			fields = append(fields, fieldID)
+			if i < len(columnGroup.Columns) {
+				columns = append(columns, columnGroup.Columns[i])
+			}
+		}
+		if len(fields) == 0 {
+			continue
+		}
+		columnGroup.Fields = fields
+		columnGroup.Columns = columns
+		trimmed = append(trimmed, columnGroup)
+	}
+	return trimmed, skipped
+}
+
+// trimColumnGroupsToMaterialized trims the flush layout to the columns the
+// source segment has actually materialized (plus system fields, which live
+// outside the insert record). A non-materialized column is legally absent —
+// a dropped field or a function output backfilled later by bump-schema
+// compaction; real schema/data inconsistency is segcore's concern and the
+// flush verifies it internally. A group left empty is dropped entirely. On a
+// committed-flush ack retry the source is gone; the committed binlogs are
+// the persisted truth and the layout is trimmed to them instead.
+func (t *GrowingSourceSyncTask) trimColumnGroupsToMaterialized(ctx context.Context, columnGroups []storagecommon.ColumnGroup) ([]storagecommon.ColumnGroup, error) {
+	if t.schema == nil || len(columnGroups) == 0 {
+		return columnGroups, nil
+	}
+	if t.source == nil {
+		if len(t.committedInsertBinlogs) == 0 {
+			return columnGroups, nil
+		}
+		// The committed binlogs are keyed by column group id; the flushed
+		// field ids live in ChildFields.
+		committed := typeutil.NewSet[int64]()
+		for _, fieldBinlog := range t.committedInsertBinlogs {
+			committed.Insert(fieldBinlog.GetChildFields()...)
+		}
+		trimmed, skipped := filterColumnGroupFields(columnGroups, func(fieldID int64) bool {
+			return committed.Contain(fieldID)
+		})
+		if len(skipped) > 0 {
+			mlog.Info(ctx, "trim growing flush layout to committed binlogs on ack retry",
+				mlog.Int64("segmentID", t.segmentID),
+				mlog.Int64s("fieldIDs", skipped))
+		}
+		return trimmed, nil
+	}
+	materialized, err := t.source.MaterializedFieldIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// A live growing segment materializes its creation-schema columns in the
+	// InsertRecord ctor, so an empty set has no legal meaning — refuse it
+	// instead of writing a layout that may disagree with the data.
+	if len(materialized) == 0 {
+		return nil, merr.WrapErrServiceInternalMsg(
+			"growing flush source reported empty materialized field ids for segment %d", t.segmentID)
+	}
+	materializedSet := typeutil.NewSet(materialized...)
+	trimmed, skipped := filterColumnGroupFields(columnGroups, func(fieldID int64) bool {
+		return materializedSet.Contain(fieldID) || common.IsSystemField(fieldID)
+	})
+	if len(skipped) > 0 {
+		mlog.Info(ctx, "exclude non-materialized columns from growing flush layout",
+			mlog.Int64("segmentID", t.segmentID),
+			mlog.Int64s("fieldIDs", skipped))
+	}
+	return trimmed, nil
 }
 
 func (t *GrowingSourceSyncTask) schemaBasedPattern(columnGroups []storagecommon.ColumnGroup) (string, error) {
@@ -839,6 +944,16 @@ func buildGrowingSourceInsertBinlogs(columnGroups []storagecommon.ColumnGroup, r
 	logIDByGroup := make(map[int64]int64, len(columnGroups))
 	for i, columnGroup := range columnGroups {
 		logIDByGroup[columnGroup.GroupID] = logIDs[i]
+	}
+	// result.FlushedFieldIDs is the authoritative set of columns actually
+	// written; the flush skips legally-absent columns (dropped fields,
+	// non-materialized function outputs), so the binlog meta must be trimmed
+	// to it. A group left empty is dropped.
+	if len(result.FlushedFieldIDs) > 0 {
+		flushedSet := typeutil.NewSet(result.FlushedFieldIDs...)
+		columnGroups, _ = filterColumnGroupFields(columnGroups, func(fieldID int64) bool {
+			return flushedSet.Contain(fieldID)
+		})
 	}
 	for _, columnGroup := range columnGroups {
 		if _, ok := result.ColumnGroupMemorySizes[columnGroup.GroupID]; !ok {

--- a/internal/flushcommon/syncmgr/growing_source_test.go
+++ b/internal/flushcommon/syncmgr/growing_source_test.go
@@ -50,6 +50,10 @@ type fakeCommitGrowingFlushSource struct {
 	commits []int64
 }
 
+func (s *fakeCommitGrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	return []int64{0, 1, 100, 101, 102}, nil
+}
+
 func (s *fakeCommitGrowingFlushSource) CurrentOffset() int64 {
 	return 10
 }
@@ -508,6 +512,10 @@ type fakeBM25GrowingFlushSource struct {
 	stats map[int64]*storage.BM25Stats
 }
 
+func (s *fakeBM25GrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	return []int64{0, 1, 100, 101, 102}, nil
+}
+
 func (s *fakeBM25GrowingFlushSource) CurrentOffset() int64 {
 	return 10
 }
@@ -580,4 +588,99 @@ func TestGrowingSourceSyncTaskMergesReturnedBM25Stats(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1, restored.NumRow())
 	require.EqualValues(t, 2, restored.NumToken())
+}
+
+type fakeMaterializedGrowingFlushSource struct {
+	materialized []int64
+}
+
+func (s *fakeMaterializedGrowingFlushSource) CurrentOffset() int64 { return 0 }
+
+func (s *fakeMaterializedGrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	return s.materialized, nil
+}
+
+func (s *fakeMaterializedGrowingFlushSource) FlushGrowingData(ctx context.Context, startOffset, endOffset int64, config *GrowingFlushConfig) (*GrowingFlushResult, error) {
+	return nil, nil
+}
+
+func (s *fakeMaterializedGrowingFlushSource) Release() {}
+
+func TestTrimColumnGroupsToMaterialized(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 102, Name: "fn_sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		},
+	}
+	groups := []storagecommon.ColumnGroup{
+		{GroupID: 0, Fields: []int64{0, 1, 100, 101, 102}, Columns: []int{0, 1, 2, 3, 4}},
+		{GroupID: 1, Fields: []int64{102}, Columns: []int{4}},
+	}
+
+	// A non-materialized column (function output here) is dropped; a group
+	// left empty vanishes; the parallel Columns array is trimmed in lockstep
+	// so the writer pattern never names the dropped column.
+	task := NewGrowingSourceSyncTask().WithSchema(schema).
+		WithSource(&fakeMaterializedGrowingFlushSource{materialized: []int64{0, 1, 100, 101}})
+	trimmed, err := task.trimColumnGroupsToMaterialized(context.Background(), groups)
+	require.NoError(t, err)
+	require.Len(t, trimmed, 1)
+	require.Equal(t, []int64{0, 1, 100, 101}, trimmed[0].Fields)
+	require.Equal(t, []int{0, 1, 2, 3}, trimmed[0].Columns)
+
+	// A materialized function output is kept.
+	task = NewGrowingSourceSyncTask().WithSchema(schema).
+		WithSource(&fakeMaterializedGrowingFlushSource{materialized: []int64{0, 1, 100, 101, 102}})
+	trimmed, err = task.trimColumnGroupsToMaterialized(context.Background(), groups)
+	require.NoError(t, err)
+	require.Len(t, trimmed, 2)
+
+	// A non-materialized dropped ordinary field is trimmed the same way;
+	// system fields stay even though they live outside the insert record.
+	task = NewGrowingSourceSyncTask().WithSchema(schema).
+		WithSource(&fakeMaterializedGrowingFlushSource{materialized: []int64{100}})
+	trimmed, err = task.trimColumnGroupsToMaterialized(context.Background(), groups)
+	require.NoError(t, err)
+	require.Len(t, trimmed, 1)
+	require.Equal(t, []int64{0, 1, 100}, trimmed[0].Fields)
+	require.Equal(t, []int{0, 1, 2}, trimmed[0].Columns)
+
+	// An empty materialized report has no legal meaning: error out instead
+	// of writing a layout that may disagree with the data.
+	task = NewGrowingSourceSyncTask().WithSchema(schema).
+		WithSource(&fakeMaterializedGrowingFlushSource{})
+	_, err = task.trimColumnGroupsToMaterialized(context.Background(), groups)
+	require.Error(t, err)
+
+	// On a committed-flush ack retry the source is gone: the layout is
+	// trimmed to the committed binlogs, the persisted truth. The binlog map
+	// is keyed by column group id; flushed fields live in ChildFields.
+	task = NewGrowingSourceSyncTask().WithSchema(schema).
+		WithCommittedFlush("manifest", nil, map[int64]*datapb.FieldBinlog{
+			0: {ChildFields: []int64{0, 1, 100, 101}},
+		})
+	trimmed, err = task.trimColumnGroupsToMaterialized(context.Background(), groups)
+	require.NoError(t, err)
+	require.Len(t, trimmed, 1)
+	require.Equal(t, []int64{0, 1, 100, 101}, trimmed[0].Fields)
+	require.Equal(t, []int{0, 1, 2, 3}, trimmed[0].Columns)
+}
+
+func TestBuildGrowingSourceInsertBinlogsTrimsToFlushedFields(t *testing.T) {
+	groups := []storagecommon.ColumnGroup{
+		{GroupID: 0, Fields: []int64{0, 1, 100, 102}},
+		{GroupID: 5, Fields: []int64{102}},
+	}
+	result := &GrowingFlushResult{
+		NumRows:                3,
+		FlushedFieldIDs:        []int64{0, 1, 100},
+		ColumnGroupMemorySizes: map[int64]int64{0: 10, 5: 0},
+		FieldNullCounts:        map[int64]int64{0: 0, 1: 0, 100: 0},
+	}
+	binlogs, err := buildGrowingSourceInsertBinlogs(groups, result, []int64{7, 8})
+	require.NoError(t, err)
+	require.Len(t, binlogs, 1)
+	require.Equal(t, []int64{0, 1, 100}, binlogs[0].GetChildFields())
 }

--- a/internal/flushcommon/writebuffer/l0_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer_test.go
@@ -56,6 +56,10 @@ func (s fakeGrowingFlushSource) CurrentOffset() int64 {
 	return 10
 }
 
+func (s fakeGrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	return []int64{0, 1, 100, 101, 102}, nil
+}
+
 func (s fakeGrowingFlushSource) FlushGrowingData(ctx context.Context, startOffset, endOffset int64, config *syncmgr.GrowingFlushConfig) (*syncmgr.GrowingFlushResult, error) {
 	if s.flushFunc != nil {
 		return s.flushFunc(ctx, startOffset, endOffset, config)

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -573,10 +573,25 @@ func (s *delegatorGrowingFlushSource) FlushGrowingData(ctx context.Context, star
 		NumRows:                result.NumRows,
 		TimestampFrom:          result.TimestampFrom,
 		TimestampTo:            result.TimestampTo,
+		FlushedFieldIDs:        result.FlushedFieldIDs,
 		ColumnGroupMemorySizes: result.ColumnGroupMemorySizes,
 		FieldNullCounts:        result.FieldNullCounts,
 		BM25Stats:              result.BM25Stats,
 	}, nil
+}
+
+// materializedFieldIDsProvider is the capability a source segment must expose
+// for the flush layout to be trimmed to its materialized columns.
+type materializedFieldIDsProvider interface {
+	MaterializedFieldIDs(ctx context.Context) ([]int64, error)
+}
+
+func (s *delegatorGrowingFlushSource) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	provider, ok := s.segment.(materializedFieldIDsProvider)
+	if !ok {
+		return nil, merr.WrapErrServiceInternalMsg("growing flush source segment does not expose materialized field ids")
+	}
+	return provider.MaterializedFieldIDs(ctx)
 }
 
 func (s *delegatorGrowingFlushSource) Release() {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1642,6 +1642,40 @@ func (s *LocalSegment) GetFieldJSONIndexStats() map[int64]*querypb.JsonStatsInfo
 	return stats
 }
 
+// MaterializedFieldIDs returns the field ids with materialized columns in the
+// growing segment's insert record. The flush layout must be trimmed to this
+// set; a non-materialized column is legally absent (a dropped field or a
+// function output backfilled by bump-schema compaction).
+func (s *LocalSegment) MaterializedFieldIDs(ctx context.Context) ([]int64, error) {
+	if s.Type() != SegmentTypeGrowing {
+		return nil, merr.WrapErrServiceInternalMsg("unexpected segmentType for MaterializedFieldIDs, segmentType = %s", s.segmentType.String())
+	}
+	if !s.ptrLock.PinIf(state.IsNotReleased) {
+		return nil, merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
+	}
+	defer s.ptrLock.Unpin()
+
+	var cIDs *C.int64_t
+	var cCount C.int64_t
+	var status C.CStatus
+	GetDynamicPool().Submit(func() (any, error) {
+		status = C.GetGrowingSegmentMaterializedFieldIDs(s.ptr, &cIDs, &cCount)
+		return nil, nil
+	}).Await()
+	if err := HandleCStatus(ctx, &status, "GetGrowingSegmentMaterializedFieldIDs"); err != nil {
+		return nil, err
+	}
+	if cIDs == nil || cCount == 0 {
+		return nil, nil
+	}
+	defer C.free(unsafe.Pointer(cIDs))
+	ids := make([]int64, 0, int(cCount))
+	for _, id := range unsafe.Slice(cIDs, int(cCount)) {
+		ids = append(ids, int64(id))
+	}
+	return ids, nil
+}
+
 // FlushData flushes data from the growing segment directly to storage via C++ milvus-storage.
 // This is a unified interface that combines data extraction from segcore and writing to storage.
 // The C++ side handles: extracting raw field data from ConcurrentVector, converting to Arrow,
@@ -1851,6 +1885,13 @@ func (s *LocalSegment) FlushData(ctx context.Context, startOffset, endOffset int
 			fieldNullCounts[fieldID] = int64(nullCounts[i])
 		}
 	}
+	flushedFieldIDs := make([]int64, 0, int(cResult.num_flushed_fields))
+	if cResult.num_flushed_fields > 0 {
+		ids := unsafe.Slice(cResult.flushed_field_ids, int(cResult.num_flushed_fields))
+		for i := 0; i < int(cResult.num_flushed_fields); i++ {
+			flushedFieldIDs = append(flushedFieldIDs, int64(ids[i]))
+		}
+	}
 	columnGroupMemorySizes := make(map[int64]int64, int(cResult.num_column_groups))
 	if cResult.num_column_groups > 0 {
 		columnGroupIDs := unsafe.Slice(cResult.column_group_ids, int(cResult.num_column_groups))
@@ -1879,6 +1920,7 @@ func (s *LocalSegment) FlushData(ctx context.Context, startOffset, endOffset int
 		NumRows:                int64(cResult.num_rows),
 		TimestampFrom:          uint64(cResult.timestamp_from),
 		TimestampTo:            uint64(cResult.timestamp_to),
+		FlushedFieldIDs:        flushedFieldIDs,
 		ColumnGroupMemorySizes: columnGroupMemorySizes,
 		FieldNullCounts:        fieldNullCounts,
 		BM25Stats:              bm25Stats,

--- a/internal/querynodev2/segments/segment_interface.go
+++ b/internal/querynodev2/segments/segment_interface.go
@@ -203,9 +203,12 @@ type FlushResult struct {
 	// via packed.UnmarshalManifestPath when needed.
 	ManifestPath string
 	// Number of rows flushed
-	NumRows                int64
-	TimestampFrom          uint64
-	TimestampTo            uint64
+	NumRows       int64
+	TimestampFrom uint64
+	TimestampTo   uint64
+	// FlushedFieldIDs is the authoritative set of columns the flush actually
+	// wrote; non-materialized function-output columns are skipped and absent.
+	FlushedFieldIDs        []int64
 	ColumnGroupMemorySizes map[int64]int64
 	FieldNullCounts        map[int64]int64
 	BM25Stats              map[int64]*storage.BM25Stats


### PR DESCRIPTION
Cherry-pick of #51266 to 3.0.

issue: #51117
pr: #51266

Skips legally-absent columns (dropped fields, non-materialized function outputs) on growing-segment flush instead of asserting, and trims the flush layout to the segment's materialized columns at the source so the writer pattern, binlog meta and metacache current split always describe the written data. Fixes the StreamingNode crash-loop hit by the schema-evolution L3 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)