### PR TITLE
fix: [cp 3.0] wait for delegator serviceability in load config compliance

### DIFF
--- a/internal/coordinator/restful_replica.go
+++ b/internal/coordinator/restful_replica.go
@@ -118,16 +118,6 @@ func (s *mixCoordImpl) HandleReplicaLoadConfigCompliance(w http.ResponseWriter, 
 			}
 		}
 
-		for _, replica := range internalReplicas {
-			if !replica.IsQueryVisible() {
-				reason := fmt.Sprintf("collection %d: replica %d (rg=%s) is not query visible",
-					collectionID, replica.GetID(), replica.GetResourceGroup())
-				logger.Info(ctx, "collection has query-invisible replica", mlog.String("reason", reason))
-				s.writeComplianceResponse(w, LoadConfigComplianceStateNotReady, reason)
-				return
-			}
-		}
-
 		// Now that replica count and RG distribution match, verify every replica actually
 		// has a serviceable shard leader for every channel. This live dist check avoids
 		// the stale CollectionObserver-persisted LoadPercentage that can falsely report
@@ -137,6 +127,16 @@ func (s *mixCoordImpl) HandleReplicaLoadConfigCompliance(w http.ResponseWriter, 
 			logger.Info(ctx, "collection not serviceable", mlog.String("reason", reason))
 			s.writeComplianceResponse(w, LoadConfigComplianceStateNotReady, reason)
 			return
+		}
+
+		for _, replica := range internalReplicas {
+			if !replica.IsQueryVisible() {
+				reason := fmt.Sprintf("collection %d: replica %d (rg=%s) is not query visible",
+					collectionID, replica.GetID(), replica.GetResourceGroup())
+				logger.Info(ctx, "collection has query-invisible replica", mlog.String("reason", reason))
+				s.writeComplianceResponse(w, LoadConfigComplianceStateNotReady, reason)
+				return
+			}
 		}
 
 		// Check that physical resources have been released from querynodes no longer

--- a/internal/coordinator/restful_replica_test.go
+++ b/internal/coordinator/restful_replica_test.go
@@ -236,6 +236,9 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		mocker3 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
 		defer mocker3.UnPatch()
 
+		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mockerSvc.UnPatch()
+
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
 		w := httptest.NewRecorder()
 
@@ -471,6 +474,53 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		assert.Contains(t, resp.Reason, "catching up")
 	})
 
+	t.Run("delegator not serviceable reason takes precedence over query-invisible", func(t *testing.T) {
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "1")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1")
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer registerTestBalancer(t, nil)()
+
+		replica := meta.NewReplica(&querypb.Replica{
+			ID:            1,
+			CollectionID:  100,
+			ResourceGroup: "rg1",
+		}, typeutil.NewUniqueSet())
+		mutableReplica := replica.CopyForWrite()
+		mutableReplica.SetQueryInvisible(true)
+		replicas := []*meta.Replica{mutableReplica.IntoReplica()}
+
+		coord := &mixCoordImpl{
+			queryCoordServer: &querycoordv2.Server{},
+		}
+
+		mocker1 := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
+			Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			CollectionIDs:       []int64{100},
+			InMemoryPercentages: []int64{100},
+		}, nil).Build()
+		defer mocker1.UnPatch()
+
+		mocker2 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
+		defer mocker2.UnPatch()
+
+		mocker3 := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).
+			Return(fmt.Errorf("replica 1 (rg=rg1) channel c1 not serviceable: delegator reported not serviceable")).Build()
+		defer mocker3.UnPatch()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
+		w := httptest.NewRecorder()
+
+		coord.HandleReplicaLoadConfigCompliance(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp LoadConfigComplianceResponse
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, LoadConfigComplianceStateNotReady, resp.State)
+		assert.Contains(t, resp.Reason, "delegator reported not serviceable")
+		assert.NotContains(t, resp.Reason, "not query visible")
+	})
+
 	t.Run("query-invisible replica returns NotReady", func(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "1")
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "rg1")
@@ -500,6 +550,9 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 
 		mocker2 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
 		defer mocker2.UnPatch()
+
+		mocker3 := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mocker3.UnPatch()
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
 		w := httptest.NewRecorder()

--- a/internal/querycoordv2/load_config_visibility.go
+++ b/internal/querycoordv2/load_config_visibility.go
@@ -33,17 +33,20 @@ func (s *Server) tryPromoteReadyLoadConfigReplicas(ctx context.Context) {
 	if len(replicas) == 0 {
 		return
 	}
-	replicaIDs := make([]typeutil.UniqueID, 0, len(replicas))
+	// Promote load-config replicas all-or-nothing. Partially exposing ready
+	// replicas can let the query path enter a resource group while the load path
+	// is still moving the remaining replicas, causing the two paths to compete
+	// for resources during the switch.
 	for _, replica := range replicas {
 		if err := s.checkReplicaServiceable(ctx, replica); err != nil {
-			continue
+			return
 		}
-		replicaIDs = append(replicaIDs, replica.GetID())
-	}
-	if len(replicaIDs) == 0 {
-		return
 	}
 
+	replicaIDs := make([]typeutil.UniqueID, 0, len(replicas))
+	for _, replica := range replicas {
+		replicaIDs = append(replicaIDs, replica.GetID())
+	}
 	collections := s.meta.SetReplicasQueryVisible(ctx, replicaIDs...)
 	if len(collections) == 0 {
 		return

--- a/internal/querycoordv2/load_config_visibility.go
+++ b/internal/querycoordv2/load_config_visibility.go
@@ -33,16 +33,17 @@ func (s *Server) tryPromoteReadyLoadConfigReplicas(ctx context.Context) {
 	if len(replicas) == 0 {
 		return
 	}
-	for _, replica := range replicas {
-		if err := s.checkReplicaServiceable(ctx, replica); err != nil {
-			return
-		}
-	}
-
 	replicaIDs := make([]typeutil.UniqueID, 0, len(replicas))
 	for _, replica := range replicas {
+		if err := s.checkReplicaServiceable(ctx, replica); err != nil {
+			continue
+		}
 		replicaIDs = append(replicaIDs, replica.GetID())
 	}
+	if len(replicaIDs) == 0 {
+		return
+	}
+
 	collections := s.meta.SetReplicasQueryVisible(ctx, replicaIDs...)
 	if len(collections) == 0 {
 		return

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -922,11 +922,11 @@ func (s *Server) checkReplicaServiceable(ctx context.Context, replica *meta.Repl
 				replica.GetID(), replica.GetResourceGroup(), channelName)
 		}
 		if err := utils.CheckDelegatorDataReady(s.nodeMgr, s.targetMgr, leader.View, meta.CurrentTarget); err != nil {
-			return merr.Wrapf(err, "replica %d (rg=%s) channel %s not serviceable", replica.GetID(), replica.GetResourceGroup(), channelName)
+			return merr.Wrapf(err, "replica %d (rg=%s) not serviceable", replica.GetID(), replica.GetResourceGroup())
 		}
-		if leader.View.Status != nil && !leader.View.Status.GetServiceable() {
+		if !leader.IsServiceable() {
 			err := merr.WrapErrChannelNotAvailable(channelName, "delegator reported not serviceable")
-			return merr.Wrapf(err, "replica %d (rg=%s) channel %s not serviceable", replica.GetID(), replica.GetResourceGroup(), channelName)
+			return merr.Wrapf(err, "replica %d (rg=%s) not serviceable", replica.GetID(), replica.GetResourceGroup())
 		}
 	}
 	return nil

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -924,6 +924,10 @@ func (s *Server) checkReplicaServiceable(ctx context.Context, replica *meta.Repl
 		if err := utils.CheckDelegatorDataReady(s.nodeMgr, s.targetMgr, leader.View, meta.CurrentTarget); err != nil {
 			return merr.Wrapf(err, "replica %d (rg=%s) channel %s not serviceable", replica.GetID(), replica.GetResourceGroup(), channelName)
 		}
+		if leader.View.Status != nil && !leader.View.Status.GetServiceable() {
+			err := merr.WrapErrChannelNotAvailable(channelName, "delegator reported not serviceable")
+			return merr.Wrapf(err, "replica %d (rg=%s) channel %s not serviceable", replica.GetID(), replica.GetResourceGroup(), channelName)
+		}
 	}
 	return nil
 }

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -70,6 +70,76 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+type noopQueryCoordCatalog struct{}
+
+func (noopQueryCoordCatalog) SaveCollection(ctx context.Context, collection *querypb.CollectionLoadInfo, partitions ...*querypb.PartitionLoadInfo) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) SavePartition(ctx context.Context, info ...*querypb.PartitionLoadInfo) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) SaveReplica(ctx context.Context, replicas ...*querypb.Replica) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) GetCollections(ctx context.Context) ([]*querypb.CollectionLoadInfo, error) {
+	return nil, nil
+}
+
+func (noopQueryCoordCatalog) GetPartitions(ctx context.Context, collectionIDs []int64) (map[int64][]*querypb.PartitionLoadInfo, error) {
+	return nil, nil
+}
+
+func (noopQueryCoordCatalog) GetReplicas(ctx context.Context) ([]*querypb.Replica, error) {
+	return nil, nil
+}
+
+func (noopQueryCoordCatalog) ReleaseCollection(ctx context.Context, collection int64) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) ReleasePartition(ctx context.Context, collection int64, partitions ...int64) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) ReleaseReplicas(ctx context.Context, collectionID int64) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) ReleaseReplica(ctx context.Context, collection int64, replicas ...int64) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) SaveResourceGroup(ctx context.Context, rgs ...*querypb.ResourceGroup) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) RemoveResourceGroup(ctx context.Context, rgName string) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) GetResourceGroups(ctx context.Context) ([]*querypb.ResourceGroup, error) {
+	return nil, nil
+}
+
+func (noopQueryCoordCatalog) SaveCollectionTargets(ctx context.Context, target ...*querypb.CollectionTarget) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) RemoveCollectionTarget(ctx context.Context, collectionID int64) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) RemoveCollectionTargets(ctx context.Context) error {
+	return nil
+}
+
+func (noopQueryCoordCatalog) GetCollectionTargets(ctx context.Context) (map[int64]*querypb.CollectionTarget, error) {
+	return nil, nil
+}
+
 type ServerSuite struct {
 	suite.Suite
 
@@ -1285,6 +1355,32 @@ func TestCheckAllReplicasServiceable(t *testing.T) {
 		assert.ErrorContains(t, err, "reported not serviceable")
 	})
 
+	t.Run("nil leader status returns error even when data ready", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+		s.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 10, Address: "localhost:10", Hostname: "localhost"}))
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetDmChannelsByCollection(mock.Anything, collectionID, meta.CurrentTarget).Return(map[string]*meta.DmChannel{
+			channelName: {VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName}},
+		})
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetSealedSegmentsByChannel(mock.Anything, collectionID, channelName, meta.CurrentTarget).Return(map[int64]*datapb.SegmentInfo{
+			42: {ID: 42, CollectionID: collectionID},
+		})
+
+		s.dist.ChannelDistManager.Update(10, &meta.DmChannel{
+			VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName},
+			Node:         10,
+			Version:      1,
+			View: &meta.LeaderView{
+				ID: 10, CollectionID: collectionID, Channel: channelName,
+				Segments: map[int64]*querypb.SegmentDist{42: {NodeID: 10}},
+			},
+		})
+
+		err := s.CheckAllReplicasServiceable(context.Background(), collectionID)
+		assert.ErrorContains(t, err, "reported not serviceable")
+	})
+
 	t.Run("all serviceable returns nil", func(t *testing.T) {
 		s := newServer()
 		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
@@ -1309,4 +1405,41 @@ func TestCheckAllReplicasServiceable(t *testing.T) {
 		err := s.CheckAllReplicasServiceable(context.Background(), collectionID)
 		assert.NoError(t, err)
 	})
+}
+
+func TestTryPromoteReadyLoadConfigReplicasPromotesReadyReplicasIndependently(t *testing.T) {
+	ctx := context.Background()
+	nodeMgr := session.NewNodeManager()
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	id := int64(0)
+	idAllocator := func() (int64, error) {
+		id++
+		return id, nil
+	}
+	metaMgr := meta.NewMeta(idAllocator, noopQueryCoordCatalog{}, nodeMgr)
+	replicasA, err := metaMgr.Spawn(ctx, 100, map[string]int{"rg-a": 1}, nil, commonpb.LoadPriority_HIGH, meta.WithQueryInvisible())
+	assert.NoError(t, err)
+	replicasB, err := metaMgr.Spawn(ctx, 200, map[string]int{"rg-b": 1}, nil, commonpb.LoadPriority_HIGH, meta.WithQueryInvisible())
+	assert.NoError(t, err)
+	assert.False(t, replicasA[0].IsQueryVisible())
+	assert.False(t, replicasB[0].IsQueryVisible())
+
+	s := &Server{
+		meta:      metaMgr,
+		dist:      distMgr,
+		nodeMgr:   nodeMgr,
+		targetMgr: meta.NewMockTargetManager(t),
+	}
+	mocker := mockey.Mock((*Server).checkReplicaServiceable).To(func(s *Server, ctx context.Context, replica *meta.Replica) error {
+		if replica.GetID() == replicasA[0].GetID() {
+			return fmt.Errorf("replica %d is not ready", replica.GetID())
+		}
+		return nil
+	}).Build()
+	defer mocker.UnPatch()
+
+	s.tryPromoteReadyLoadConfigReplicas(ctx)
+
+	assert.False(t, metaMgr.Get(ctx, replicasA[0].GetID()).IsQueryVisible())
+	assert.True(t, metaMgr.Get(ctx, replicasB[0].GetID()).IsQueryVisible())
 }

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -1258,6 +1258,33 @@ func TestCheckAllReplicasServiceable(t *testing.T) {
 		assert.ErrorContains(t, err, "not serviceable")
 	})
 
+	t.Run("leader reported non-serviceable returns error even when data ready", func(t *testing.T) {
+		s := newServer()
+		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+		defer mocker.UnPatch()
+		s.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 10, Address: "localhost:10", Hostname: "localhost"}))
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetDmChannelsByCollection(mock.Anything, collectionID, meta.CurrentTarget).Return(map[string]*meta.DmChannel{
+			channelName: {VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName}},
+		})
+		s.targetMgr.(*meta.MockTargetManager).EXPECT().GetSealedSegmentsByChannel(mock.Anything, collectionID, channelName, meta.CurrentTarget).Return(map[int64]*datapb.SegmentInfo{
+			42: {ID: 42, CollectionID: collectionID},
+		})
+
+		s.dist.ChannelDistManager.Update(10, &meta.DmChannel{
+			VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName},
+			Node:         10,
+			Version:      1,
+			View: &meta.LeaderView{
+				ID: 10, CollectionID: collectionID, Channel: channelName,
+				Status:   &querypb.LeaderViewStatus{Serviceable: false},
+				Segments: map[int64]*querypb.SegmentDist{42: {NodeID: 10}},
+			},
+		})
+
+		err := s.CheckAllReplicasServiceable(context.Background(), collectionID)
+		assert.ErrorContains(t, err, "reported not serviceable")
+	})
+
 	t.Run("all serviceable returns nil", func(t *testing.T) {
 		s := newServer()
 		mocker := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -70,76 +70,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-type noopQueryCoordCatalog struct{}
-
-func (noopQueryCoordCatalog) SaveCollection(ctx context.Context, collection *querypb.CollectionLoadInfo, partitions ...*querypb.PartitionLoadInfo) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) SavePartition(ctx context.Context, info ...*querypb.PartitionLoadInfo) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) SaveReplica(ctx context.Context, replicas ...*querypb.Replica) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) GetCollections(ctx context.Context) ([]*querypb.CollectionLoadInfo, error) {
-	return nil, nil
-}
-
-func (noopQueryCoordCatalog) GetPartitions(ctx context.Context, collectionIDs []int64) (map[int64][]*querypb.PartitionLoadInfo, error) {
-	return nil, nil
-}
-
-func (noopQueryCoordCatalog) GetReplicas(ctx context.Context) ([]*querypb.Replica, error) {
-	return nil, nil
-}
-
-func (noopQueryCoordCatalog) ReleaseCollection(ctx context.Context, collection int64) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) ReleasePartition(ctx context.Context, collection int64, partitions ...int64) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) ReleaseReplicas(ctx context.Context, collectionID int64) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) ReleaseReplica(ctx context.Context, collection int64, replicas ...int64) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) SaveResourceGroup(ctx context.Context, rgs ...*querypb.ResourceGroup) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) RemoveResourceGroup(ctx context.Context, rgName string) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) GetResourceGroups(ctx context.Context) ([]*querypb.ResourceGroup, error) {
-	return nil, nil
-}
-
-func (noopQueryCoordCatalog) SaveCollectionTargets(ctx context.Context, target ...*querypb.CollectionTarget) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) RemoveCollectionTarget(ctx context.Context, collectionID int64) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) RemoveCollectionTargets(ctx context.Context) error {
-	return nil
-}
-
-func (noopQueryCoordCatalog) GetCollectionTargets(ctx context.Context) (map[int64]*querypb.CollectionTarget, error) {
-	return nil, nil
-}
-
 type ServerSuite struct {
 	suite.Suite
 
@@ -1405,41 +1335,4 @@ func TestCheckAllReplicasServiceable(t *testing.T) {
 		err := s.CheckAllReplicasServiceable(context.Background(), collectionID)
 		assert.NoError(t, err)
 	})
-}
-
-func TestTryPromoteReadyLoadConfigReplicasPromotesReadyReplicasIndependently(t *testing.T) {
-	ctx := context.Background()
-	nodeMgr := session.NewNodeManager()
-	distMgr := meta.NewDistributionManager(nodeMgr)
-	id := int64(0)
-	idAllocator := func() (int64, error) {
-		id++
-		return id, nil
-	}
-	metaMgr := meta.NewMeta(idAllocator, noopQueryCoordCatalog{}, nodeMgr)
-	replicasA, err := metaMgr.Spawn(ctx, 100, map[string]int{"rg-a": 1}, nil, commonpb.LoadPriority_HIGH, meta.WithQueryInvisible())
-	assert.NoError(t, err)
-	replicasB, err := metaMgr.Spawn(ctx, 200, map[string]int{"rg-b": 1}, nil, commonpb.LoadPriority_HIGH, meta.WithQueryInvisible())
-	assert.NoError(t, err)
-	assert.False(t, replicasA[0].IsQueryVisible())
-	assert.False(t, replicasB[0].IsQueryVisible())
-
-	s := &Server{
-		meta:      metaMgr,
-		dist:      distMgr,
-		nodeMgr:   nodeMgr,
-		targetMgr: meta.NewMockTargetManager(t),
-	}
-	mocker := mockey.Mock((*Server).checkReplicaServiceable).To(func(s *Server, ctx context.Context, replica *meta.Replica) error {
-		if replica.GetID() == replicasA[0].GetID() {
-			return fmt.Errorf("replica %d is not ready", replica.GetID())
-		}
-		return nil
-	}).Build()
-	defer mocker.UnPatch()
-
-	s.tryPromoteReadyLoadConfigReplicas(ctx)
-
-	assert.False(t, metaMgr.Get(ctx, replicasA[0].GetID()).IsQueryVisible())
-	assert.True(t, metaMgr.Get(ctx, replicasB[0].GetID()).IsQueryVisible())
 }


### PR DESCRIPTION
issue: #51289
pr: #51295

- QueryCoord serviceability: treat delegator-reported non-serviceable leader views as not ready after data readiness checks pass
- load config compliance: report live replica serviceability failures before query-visible fallback reasons