### PR TITLE
fix: clear datacoord backoff entry for a non-Init task on the dispatch path

### DIFF
--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -308,6 +308,19 @@ func (s *globalTaskScheduler) schedule() {
 					// the very failure storms this backoff exists to relieve.
 					s.backoffs.Remove(task.GetTaskID())
 				}
+			} else {
+				// The task is no longer Init by the time it is dispatched.
+				// pendingTasks only holds Init or Retry tasks (Enqueue and check()
+				// route InProgress to runningTasks), and index/stats/analyze reset
+				// a queried Retry back to Init before re-queueing. Compaction
+				// instead keeps a worker-reported timeout in Retry: check() records
+				// a failure (creating a backoff entry) and re-queues the task, but
+				// this path only dispatches Init, so the task leaves the scheduler
+				// here without ever clearing that entry. The owning inspector cleans
+				// the task but never calls AbortAndRemoveTask, so drop the backoff
+				// now; otherwise it leaks until datacoord restarts, exactly under
+				// the timeout storms the backoff exists to relieve.
+				s.backoffs.Remove(task.GetTaskID())
 			}
 			return struct{}{}, nil
 		})

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -492,3 +492,43 @@ func TestGlobalScheduler_TerminalTaskClearsBackoff(t *testing.T) {
 	assert.Equal(t, 0, scheduler.runningTasks.Len())
 	assert.Equal(t, 0, len(scheduler.pendingTasks.TaskIDs()))
 }
+
+// TestGlobalScheduler_RetryPoppedTaskClearsBackoff guards against a backoff-entry
+// leak on the dispatch path when a task is already in a non-Init state as it is
+// picked up. Compaction hits this: a worker-reported timeout is kept in Retry by
+// QueryTaskOnWorker (unlike index/stats/analyze, which reset to Init), so check()
+// records a failure — creating a backoff entry — and re-queues the task. Because
+// schedule() only dispatches Init tasks, such a task leaves the scheduler without
+// entering runningTasks; its backoff entry must still be dropped, otherwise it
+// lives until datacoord restarts.
+func TestGlobalScheduler_RetryPoppedTaskClearsBackoff(t *testing.T) {
+	cluster := session.NewMockCluster(t)
+	cluster.EXPECT().QuerySlot().Return(map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 100},
+	}).Maybe()
+
+	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster).(*globalTaskScheduler)
+
+	task := NewMockTask(t)
+	task.EXPECT().GetTaskID().Return(11).Maybe()
+	task.EXPECT().GetTaskType().Return(taskcommon.Compaction).Maybe()
+	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return().Maybe()
+	task.EXPECT().GetTaskSlot().Return(1).Maybe()
+
+	// The task stays Retry the whole time — check() re-queued it after the worker
+	// reported a compaction timeout. CreateTaskOnWorker must never be called
+	// (schedule() only dispatches Init tasks), so no expectation is set for it.
+	task.EXPECT().GetTaskState().Return(taskcommon.Retry).Maybe()
+
+	// Seed the backoff entry check() would have created, with an already-elapsed
+	// delay so the task is eligible for dispatch this round rather than deferred.
+	scheduler.backoffs.Insert(11, &taskBackoff{failures: 2, notBefore: time.Now().Add(-time.Second)})
+	scheduler.pendingTasks.Push(task)
+
+	scheduler.schedule()
+
+	_, ok := scheduler.backoffs.Get(11)
+	assert.False(t, ok, "backoff entry for a non-Init popped task must be cleared")
+	assert.Equal(t, 0, scheduler.runningTasks.Len())
+	assert.Equal(t, 0, len(scheduler.pendingTasks.TaskIDs()))
+}


### PR DESCRIPTION
## What & why

`fix:` for #51300.

`globalTaskScheduler.schedule()` only dispatches `Init` tasks, but a task can be popped from `pendingTasks` already in `Retry`. Index / stats / analyze normalize a queried `Retry` back to `Init` before re-queueing, so they never reach this path — but **compaction** keeps a worker-reported timeout in `Retry` (`QueryTaskOnWorker`, mapped by `FromCompactionState(timeout)`), and `check()` records a failure — creating a `backoffs` entry — and re-queues the task still in `Retry`. `schedule()` then skips it without running the terminal-state cleanup added in #51092, so the backoff entry leaks until datacoord restarts. The owning compaction inspector cleans the task itself but never calls `AbortAndRemoveTask` (its only caller is `stats_inspector.go`).

## Fix

Drop the `backoffs` entry when a popped task is no longer `Init`, mirroring the existing terminal-state cleanup. `pendingTasks` only ever holds `Init`/`Retry` tasks (`Enqueue` and `check()` route `InProgress` to `runningTasks`), so this only touches tasks that are genuinely leaving the scheduler.

## Verification

- `TestGlobalScheduler_RetryPoppedTaskClearsBackoff` (added): **fails on master** (the leaked entry survives `schedule()`), **passes with the fix**.
- Existing `TestGlobalScheduler_TerminalTaskClearsBackoff` / `TestGlobalScheduler_RecordTaskFailureBackoff` still pass.
- Ran locally with `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/datacoord/task/`. (The package `init()` calls `paramtable.Init()`, which on macOS tries to `mkdir /var/lib/milvus/data`; I pointed `LOCALSTORAGE_PATH` at a writable directory to run the suite. This is a local-env note only — no product code depends on it.)

issue: #51300
