### PR TITLE
fix: avoid structured binding capture in OpenMP lambdas

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -7019,7 +7019,7 @@ ChunkedSegmentSealedImpl::FinalizeLoadDiffForReopen(
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
     for (const auto& [field_id, nested_paths] : diff.json_indexes_to_drop) {
         for (const auto& nested_path : nested_paths) {
-            committer.Commit([&, field_id, nested_path](
+            committer.Commit([&, field_id = field_id, nested_path](
                                  RuntimeResourceState& runtime,
                                  PublishedSegmentState& staged_state) {
                 for (auto& retired :
@@ -8169,7 +8169,7 @@ ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
                    field_id.get());
         auto future = pool.Submit([this,
                                    op_ctx,
-                                   field_id,
+                                   field_id = field_id,
                                    info = std::move(load_text_index_info),
                                    &segment_load_info,
                                    &committer]() mutable -> void {


### PR DESCRIPTION
## Summary

Avoid direct captures of structured bindings in `ChunkedSegmentSealedImpl.cpp`, which is compiled with OpenMP enabled.

- Use an init-capture for the field ID in `LoadBatchTextIndexes`.
- Use an init-capture for the field ID in `FinalizeLoadDiffForReopen` when dropping JSON indexes.
- Keep the inner text-index commit lambda as a normal value capture because it captures the ordinary init-capture from the outer lambda, not a structured binding.

issue: #51231

## Test Plan

- [x] `make`
- [x] `ninja -C cmake_build src/segcore/CMakeFiles/milvus_segcore.dir/ChunkedSegmentSealedImpl.cpp.o`
- [x] `git diff --check`