### PR TITLE
fix: [cp 3.0] refresh expired next target for unavailable delegator

### DIFF
--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -477,7 +477,8 @@ func (ob *TargetObserver) isNextTargetSyncStarted(ctx context.Context, collectio
 	return lo.ContainsBy(delegators, func(delegator *meta.DmChannel) bool {
 		return delegator != nil &&
 			delegator.View != nil &&
-			delegator.View.TargetVersion == nextVersion
+			delegator.View.TargetVersion == nextVersion &&
+			delegator.IsServiceable()
 	})
 }
 

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -754,6 +754,92 @@ func TestShouldUpdateNextTarget_DoesNotExpireAfterDelegatorSyncStarted(t *testin
 	assert.False(t, observer.shouldUpdateNextTarget(ctx, collectionID))
 }
 
+func TestShouldUpdateNextTarget_ExpiresWhenDelegatorSyncedButNotServiceable(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(Params.QueryCoordCfg.NextTargetSurviveTime.Key, "1")
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	nextVersion := int64(100)
+
+	nodeMgr := session.NewNodeManager()
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 1}))
+
+	targetMgr := meta.NewMockTargetManager(t)
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	observer := NewTargetObserver(
+		&meta.Meta{},
+		targetMgr,
+		distMgr,
+		meta.NewMockBroker(t),
+		session.NewMockCluster(t),
+		nodeMgr,
+	)
+
+	observer.nextTargetLastUpdate.Insert(collectionID, time.Now().Add(-time.Hour))
+	distMgr.ChannelDistManager.Update(1, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  "channel-1",
+		},
+		Node: 1,
+		View: &meta.LeaderView{
+			ID:            1,
+			CollectionID:  collectionID,
+			Channel:       "channel-1",
+			TargetVersion: nextVersion,
+			Status:        &querypb.LeaderViewStatus{Serviceable: false},
+		},
+	})
+	targetMgr.EXPECT().IsNextTargetExist(mock.Anything, collectionID).Return(true).Once()
+	targetMgr.EXPECT().GetCollectionTargetVersion(mock.Anything, collectionID, meta.NextTarget).Return(nextVersion).Once()
+
+	assert.True(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+}
+
+func TestShouldUpdateNextTarget_DoesNotExpireWhenServiceableDelegatorSynced(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(Params.QueryCoordCfg.NextTargetSurviveTime.Key, "1")
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	nextVersion := int64(100)
+
+	nodeMgr := session.NewNodeManager()
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 1}))
+
+	targetMgr := meta.NewMockTargetManager(t)
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	observer := NewTargetObserver(
+		&meta.Meta{},
+		targetMgr,
+		distMgr,
+		meta.NewMockBroker(t),
+		session.NewMockCluster(t),
+		nodeMgr,
+	)
+
+	observer.nextTargetLastUpdate.Insert(collectionID, time.Now().Add(-time.Hour))
+	distMgr.ChannelDistManager.Update(1, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  "channel-1",
+		},
+		Node: 1,
+		View: &meta.LeaderView{
+			ID:            1,
+			CollectionID:  collectionID,
+			Channel:       "channel-1",
+			TargetVersion: nextVersion,
+			Status:        &querypb.LeaderViewStatus{Serviceable: true},
+		},
+	})
+	targetMgr.EXPECT().IsNextTargetExist(mock.Anything, collectionID).Return(true).Once()
+	targetMgr.EXPECT().GetCollectionTargetVersion(mock.Anything, collectionID, meta.NextTarget).Return(nextVersion).Once()
+
+	assert.False(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+}
+
 func TestShouldUpdateCurrentTarget_SyncMetadataFailureDoesNotPinNextTarget(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().Save(Params.QueryCoordCfg.NextTargetSurviveTime.Key, "1")


### PR DESCRIPTION
issue: #48903
pr: #51307

- querycoord target observer: require a runtime-synced NextTarget view to be serviceable before it can pin an expired NextTarget refresh
- target observer tests: cover expired refresh when a delegator has the next target version but is not serviceable