### PR TITLE
fix: [3.0] thread op_ctx_ into baseline GIS no-cache bulk_subscript

### DIFF
--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -550,9 +550,8 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                     }
                 }
             } else {
-                milvus::OpContext op_ctx;
                 auto data_array = segment_->bulk_subscript(
-                    &op_ctx, field_id_, hit_offsets.data(), hit_offsets.size());
+                    op_ctx_, field_id_, hit_offsets.data(), hit_offsets.size());
 
                 auto geometry_array =
                     static_cast<const milvus::proto::schema::GeometryArray*>(


### PR DESCRIPTION
Pick the baseline half of master PR #50675 review fix (commit 053dfaaa08) to 3.0.

## What

The GIS filter's no-cache `bulk_subscript` in `PhyGISFunctionFilterExpr` created a bare local `OpContext` instead of threading the operator's `op_ctx_` member, so tracing / tiered-storage accounting was lost for that read. Pass `SegmentExpr::op_ctx_` instead, matching every other data-fetch path in this expr (`chunk_data` / `PinIndex` / offset reads).

The split-fusion half of the master fix does not apply here — `GISConjunctExpr.cpp` does not exist on 3.0.

pr: #50675

🤖 Generated with [Claude Code](https://claude.com/claude-code)