### PR TITLE
enhance: extend external refresh job timeout to 24 hours

### DIFF
--- a/docs/design-docs/design_docs/20260105-external_table.md
+++ b/docs/design-docs/design_docs/20260105-external_table.md
@@ -1104,7 +1104,7 @@ func ReadFragmentsFromManifest(
 | `external.collection.worker.pool.size` | DataNode worker pool size | 4 |
 | `external.collection.job.retention.duration` | How long to keep completed/failed jobs | 24h |
 | `external.collection.job.max.concurrent` | Max concurrent refresh jobs | 2 |
-| `external.collection.job.timeout` | Timeout for a single refresh job | 1h |
+| `dataCoord.externalCollectionJobTimeout` | Overall refresh job timeout; also bounds external source exploration | 86,400 seconds (24 hours) |
 
 ---
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6647,7 +6647,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 		Key:          "dataCoord.externalCollectionJobTimeout",
 		Version:      "2.6.8",
 		Doc:          "The timeout in seconds for external collection refresh jobs. Jobs exceeding this duration will be marked as failed.",
-		DefaultValue: "3600",
+		DefaultValue: "86400",
 		PanicIfEmpty: false,
 	}
 	p.ExternalCollectionJobTimeout.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -981,6 +981,7 @@ func TestCachedParam(t *testing.T) {
 	assert.Equal(t, int32(16), params.DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
 	assert.Equal(t, int32(16), params.DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
 	assert.Equal(t, int64(1000000), params.DataNodeCfg.ExternalCollectionTargetRowsPerSegment.GetAsInt64())
+	assert.Equal(t, 24*time.Hour, params.DataCoordCfg.ExternalCollectionJobTimeout.GetAsDuration(time.Second))
 
 	assert.Equal(t, uint(100000), params.CommonCfg.BloomFilterSize.GetAsUint())
 	assert.Equal(t, uint(100000), params.CommonCfg.BloomFilterSize.GetAsUint())


### PR DESCRIPTION
issue: #45881

## What this PR does

- Increases the default external collection refresh job timeout from
  one hour to 24 hours.
- Documents that the same configuration also bounds external source
  exploration.
- Adds a regression assertion for the new default duration.

## Why

Large external collection refreshes may require more than one hour for
source exploration and task processing. The existing default can mark a
healthy long-running refresh as failed before it finishes.

Explicit `dataCoord.externalCollectionJobTimeout` configuration continues
to override the default.

## Validation

- `GOTOOLCHAIN=go1.26.4 make milvus`
- Full `pkg/v3/util/paramtable` test suite with coverage enabled
- `TestExternalCollectionRefreshChecker_TryTimeoutJob` with race and
  coverage enabled
- `GOTOOLCHAIN=go1.26.4 make lint-fix`
- `git diff --check`
