### PR TITLE
enhance: pin third-party actions (zymap/bot, maximize-build-space) to full commit SHAs

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794 # master
         if: ${{ ! startsWith(runner.name, 'self') }} # skip this step if it is self-hosted runner
         with:
           root-reserve-mb: 20480
@@ -75,7 +75,7 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794 # master
         if: ${{ ! startsWith(runner.name, 'self') }} # skip this step if it is self-hosted runner
         with:
           root-reserve-mb: 20480
@@ -107,7 +107,7 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794 # master
         if: ${{ ! startsWith(runner.name, 'self') }} # skip this step if it is self-hosted runner
         with:
           root-reserve-mb: 20480

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup mold
         uses: rui314/setup-mold@v1
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794 # master
         if: ${{ ! startsWith(runner.name, 'self') }} # skip this step if it is self-hosted runner
         with:
           root-reserve-mb: 20480
@@ -120,7 +120,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794 # master
         if: ${{ ! startsWith(runner.name, 'self') }} # skip this step if it is self-hosted runner
         with:
           root-reserve-mb: 20480
@@ -172,7 +172,7 @@ jobs:
     timeout-minutes: 150
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794 # master
         if: ${{ ! startsWith(runner.name, 'self') }} # skip this step if it is self-hosted runner
         with:
           root-reserve-mb: 20480
@@ -224,7 +224,7 @@ jobs:
     timeout-minutes: 150
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794 # master
         if: ${{ ! startsWith(runner.name, 'self') }} # skip this step if it is self-hosted runner
         with:
           root-reserve-mb: 20480

--- a/.github/workflows/publish-builder.yaml
+++ b/.github/workflows/publish-builder.yaml
@@ -41,7 +41,7 @@ jobs:
       IMAGE_ARCH: ${{ matrix.arch }}
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794 # master
         if: ${{ ! startsWith(runner.name, 'self') }} # skip this step if it is self-hosted runner
         with:
           root-reserve-mb: 10240

--- a/.github/workflows/publish-gpu-builder.yaml
+++ b/.github/workflows/publish-gpu-builder.yaml
@@ -40,7 +40,7 @@ jobs:
       OS: ubuntu22.04
     steps:
       - name: Maximize build space
-        uses: easimon/maximize-build-space@master
+        uses: easimon/maximize-build-space@c28619d8999a147d5e09c1199f84ff6af6ad5794 # master
         with:
           root-reserve-mb: 10240
           overprovision-lvm: 'true'

--- a/.github/workflows/rerun-failure-checks.yaml
+++ b/.github/workflows/rerun-failure-checks.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Rerun Failure Checks
         if: "github.event_name == 'issue_comment' && steps.is_organization_member.outputs.is-member == 'true'"
-        uses: zymap/bot@master
+        uses: zymap/bot@0245bde808cc2355fb0686d31fc99aa9330e7b5d # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # replace here to your token
         with:


### PR DESCRIPTION
### What

Pin the third-party actions currently referenced by the mutable `@master` tag to their current
`master` commit SHA (the tag is kept in a trailing comment for readability):

| Action | Pinned to | Files |
|---|---|---|
| `zymap/bot` | `0245bde…` | `rerun-failure-checks.yaml` |
| `easimon/maximize-build-space` | `c28619d…` | `code-checker.yaml`, `main.yaml`, `publish-builder.yaml`, `publish-gpu-builder.yaml` |

### Why

`@master` is a moving reference — whatever that branch points to at run time is what runs in the job.
The most pressing one is [`rerun-failure-checks.yaml`](https://github.com/milvus-io/milvus/blob/4dbaba0042d3952fa75bbb5d2fb9606c6b67f44d/.github/workflows/rerun-failure-checks.yaml#L38-L40), which hands `zymap/bot@master` the workflow token:

```yaml
- uses: zymap/bot@master
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

`zymap/bot` is a small personal repo whose `master` has not been updated in years. If that ref were
moved (account compromise or an unintended change), the new code would run with milvus's token — the
class of issue behind the 2025 `tj-actions/changed-files` incident. `easimon/maximize-build-space` is
better-maintained but is the same mutable-ref pattern, so I pinned it too for consistency.

### Scope / safety

- Behaviour is unchanged — each SHA is the current tip of that action's `master`.
- Only clearly third-party actions are touched; `actions/*`, `docker/*`, and `apache/skywalking-eyes`
  are left as-is (happy to pin those too if you'd like). Renovate/Dependabot can still bump a SHA pin.
- DCO signed-off.

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the token exposure, and the pinned SHAs myself.</sub>
