### PR TITLE
enhance: fold nested arithmetic chains in scalar filter expressions

### DIFF
--- a/internal/parser/planparserv2/nested_arith_test.go
+++ b/internal/parser/planparserv2/nested_arith_test.go
@@ -1,0 +1,228 @@
+package planparserv2
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+)
+
+// A folded chain must produce exactly the plan the equivalent single-operation
+// expression produces today. That is the whole safety argument for this feature:
+// the segcore executor is handed a BinaryArithOpEvalRangeExpr it already knows
+// how to run, not a new node shape.
+func TestExpr_NestedArith_FoldsToSingleOpPlan(t *testing.T) {
+	helper := newTestSchemaHelper(t)
+
+	tests := []struct {
+		nested     string
+		equivalent string
+	}{
+		// additive chains
+		{`((Int64Field + 2) + 3) == 5`, `Int64Field + 5 == 5`},
+		{`((Int64Field + 7) - 3) == 5`, `Int64Field + 4 == 5`},
+		{`((Int64Field - 2) + 6) == 5`, `Int64Field + 4 == 5`},
+		{`((Int64Field - 2) - 3) == 5`, `Int64Field + -5 == 5`},
+		// multiplicative chain
+		{`((Int64Field * 2) * 3) == 6`, `Int64Field * 6 == 6`},
+		// Bitwise chains. Note the parentheses on the right-hand expressions: in
+		// the grammar BitAnd/BitOr/BitXor bind *looser* than ==, so `x & 2 == 2`
+		// would parse as `x & (2 == 2)`.
+		{`((Int64Field & 6) & 3) == 2`, `(Int64Field & 2) == 2`},
+		{`((Int64Field | 4) | 1) == 5`, `(Int64Field | 5) == 5`},
+		{`((Int64Field ^ 4) ^ 1) == 5`, `(Int64Field ^ 5) == 5`},
+		// depth > 2 folds by recursion
+		{`(((Int64Field + 1) + 2) + 3) == 6`, `Int64Field + 6 == 6`},
+		{`((((Int64Field & 15) & 7) & 6) & 4) == 4`, `(Int64Field & 4) == 4`},
+		// narrower integer columns fold the same way
+		{`((Int8Field + 1) + 2) < 5`, `Int8Field + 3 < 5`},
+		{`((Int32Field * 2) * 5) > 6`, `Int32Field * 10 > 6`},
+		// the comparison operator is carried through untouched
+		{`((Int64Field + 2) + 3) != 5`, `Int64Field + 5 != 5`},
+		{`((Int64Field + 2) + 3) >= 5`, `Int64Field + 5 >= 5`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.nested, func(t *testing.T) {
+			got, err := ParseExpr(helper, tt.nested, nil)
+			require.NoError(t, err, tt.nested)
+			require.NotNil(t, got.GetBinaryArithOpEvalRangeExpr(), "expected a fused arith-range node")
+
+			want, err := ParseExpr(helper, tt.equivalent, nil)
+			require.NoError(t, err, tt.equivalent)
+
+			assert.True(t, proto.Equal(got, want),
+				"folded plan differs from the equivalent single-op plan\n nested: %s\n  got: %v\n want: %v",
+				tt.nested, got, want)
+		})
+	}
+}
+
+// The arithmetic operators are left-associative, so the way a user actually
+// writes a chain -- without redundant parentheses -- produces the same nested
+// tree and folds identically.
+func TestExpr_NestedArith_UnparenthesizedChain(t *testing.T) {
+	helper := newTestSchemaHelper(t)
+
+	tests := []struct {
+		expr    string
+		arithOp planpb.ArithOpType
+		operand int64
+	}{
+		{`Int64Field + 2 + 3 == 5`, planpb.ArithOpType_Add, 5},
+		{`Int64Field - 2 - 3 == 5`, planpb.ArithOpType_Add, -5},
+		{`Int64Field * 2 * 3 == 6`, planpb.ArithOpType_Mul, 6},
+		{`Int64Field + 1 + 2 + 3 == 6`, planpb.ArithOpType_Add, 6},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expr, func(t *testing.T) {
+			expr, err := ParseExpr(helper, tt.expr, nil)
+			require.NoError(t, err, tt.expr)
+			arith := expr.GetBinaryArithOpEvalRangeExpr()
+			require.NotNil(t, arith, tt.expr)
+			assert.Equal(t, tt.arithOp, arith.GetArithOp())
+			assert.EqualValues(t, tt.operand, arith.GetRightOperand().GetInt64Val())
+		})
+	}
+}
+
+// Everything the fold cannot prove equivalent must keep returning the
+// pre-existing error. A silent wrong answer here would be far worse than the
+// current "not supported".
+func TestExpr_NestedArith_UnsupportedChainsStillRejected(t *testing.T) {
+	helper := newTestSchemaHelper(t)
+
+	exprs := []string{
+		// Float arithmetic is not associative, so these must not fold.
+		`((FloatField + 0.1) + 0.2) == 0.3`,
+		`((DoubleField * 2.0) * 3.0) == 6.0`,
+		`((FloatField + 1) + 2) == 3`,
+		// JSON is dynamically typed: the runtime value may be a float.
+		`((JSONField["a"] + 1) + 2) == 5`,
+		`((A + 1) + 2) == 5`,
+		// Integer division truncates and Mod has no fold identity.
+		`((Int64Field / 2) / 3) == 1`,
+		`((Int64Field % 10) % 3) == 1`,
+		`((Int64Field + 2) / 3) == 1`,
+		`((Int64Field / 2) + 3) == 1`,
+		// Mixed operator families have no single-operation equivalent.
+		`((Int64Field + 2) * 3) == 9`,
+		`((Int64Field * 2) + 3) == 9`,
+		`((Int64Field & 6) | 1) == 3`,
+		`((Int64Field | 6) & 1) == 0`,
+		`((Int64Field ^ 6) & 1) == 0`,
+		// Reversed operands (constant on the left) remain unsupported.
+		`((2 - Int64Field) - 3) == 5`,
+		`(2 + (Int64Field + 1)) == 5`,
+		// Two fields is a different unsupported case entirely.
+		`((Int64Field + Int32Field) + 2) == 5`,
+	}
+
+	for _, expr := range exprs {
+		t.Run(expr, func(t *testing.T) {
+			plan, err := ParseExpr(helper, expr, nil)
+			assert.Error(t, err, expr)
+			assert.Nil(t, plan, expr)
+		})
+	}
+}
+
+// A template variable *inside the chain* carries no value at plan time, so the
+// chain cannot be folded and stays unsupported. A template variable on the
+// compared-against value is untouched by folding and keeps working.
+func TestExpr_NestedArith_Templates(t *testing.T) {
+	helper := newTestSchemaHelper(t)
+
+	t.Run("template inside the chain is not folded", func(t *testing.T) {
+		_, err := ParseExpr(helper, `((Int64Field + {v}) + 2) == 5`,
+			map[string]*schemapb.TemplateValue{"v": {Val: &schemapb.TemplateValue_Int64Val{Int64Val: 3}}})
+		assert.Error(t, err)
+	})
+
+	t.Run("template as the compared value still folds", func(t *testing.T) {
+		expr, err := ParseExpr(helper, `((Int64Field + 2) + 3) == {v}`,
+			map[string]*schemapb.TemplateValue{"v": {Val: &schemapb.TemplateValue_Int64Val{Int64Val: 5}}})
+		require.NoError(t, err)
+		arith := expr.GetBinaryArithOpEvalRangeExpr()
+		require.NotNil(t, arith)
+		assert.Equal(t, planpb.ArithOpType_Add, arith.GetArithOp())
+		assert.EqualValues(t, 5, arith.GetRightOperand().GetInt64Val())
+	})
+}
+
+// An integer array element is an integer column for folding purposes: the
+// executor evaluates it through the same int64 arithmetic path.
+func TestExpr_NestedArith_IntegerArrayElement(t *testing.T) {
+	helper := newTestSchemaHelper(t)
+
+	expr, err := ParseExpr(helper, `((ArrayField[0] + 2) + 3) == 5`, nil)
+	require.NoError(t, err)
+	arith := expr.GetBinaryArithOpEvalRangeExpr()
+	require.NotNil(t, arith)
+	assert.Equal(t, planpb.ArithOpType_Add, arith.GetArithOp())
+	assert.EqualValues(t, 5, arith.GetRightOperand().GetInt64Val())
+}
+
+// composeArithOps is the algebraic core; check the identities directly,
+// including the two's-complement boundaries where a naive implementation breaks.
+func TestComposeArithOps(t *testing.T) {
+	tests := []struct {
+		name    string
+		op1     planpb.ArithOpType
+		a       int64
+		op2     planpb.ArithOpType
+		b       int64
+		wantOp  planpb.ArithOpType
+		wantVal int64
+		wantOK  bool
+	}{
+		{"add-add", planpb.ArithOpType_Add, 2, planpb.ArithOpType_Add, 3, planpb.ArithOpType_Add, 5, true},
+		{"add-sub", planpb.ArithOpType_Add, 7, planpb.ArithOpType_Sub, 3, planpb.ArithOpType_Add, 4, true},
+		{"sub-add", planpb.ArithOpType_Sub, 2, planpb.ArithOpType_Add, 6, planpb.ArithOpType_Add, 4, true},
+		{"sub-sub", planpb.ArithOpType_Sub, 2, planpb.ArithOpType_Sub, 3, planpb.ArithOpType_Add, -5, true},
+		{"mul-mul", planpb.ArithOpType_Mul, 2, planpb.ArithOpType_Mul, 3, planpb.ArithOpType_Mul, 6, true},
+		{"and-and", planpb.ArithOpType_BitAnd, 6, planpb.ArithOpType_BitAnd, 3, planpb.ArithOpType_BitAnd, 2, true},
+		{"or-or", planpb.ArithOpType_BitOr, 4, planpb.ArithOpType_BitOr, 1, planpb.ArithOpType_BitOr, 5, true},
+		{"xor-xor", planpb.ArithOpType_BitXor, 4, planpb.ArithOpType_BitXor, 1, planpb.ArithOpType_BitXor, 5, true},
+
+		// Two's-complement boundaries. Reassociation is exact modulo 2^64, so the
+		// wrapped constant is the correct one; negating MinInt64 yields itself,
+		// which is precisely its additive inverse mod 2^64.
+		{"sub-minint64", planpb.ArithOpType_Sub, math.MinInt64, planpb.ArithOpType_Add, 0, planpb.ArithOpType_Add, math.MinInt64, true},
+		{"add-overflow-wraps", planpb.ArithOpType_Add, math.MaxInt64, planpb.ArithOpType_Add, 1, planpb.ArithOpType_Add, math.MinInt64, true},
+
+		// No identity exists for these pairs.
+		{"add-mul", planpb.ArithOpType_Add, 2, planpb.ArithOpType_Mul, 3, planpb.ArithOpType_Unknown, 0, false},
+		{"and-or", planpb.ArithOpType_BitAnd, 6, planpb.ArithOpType_BitOr, 1, planpb.ArithOpType_Unknown, 0, false},
+		{"div-div", planpb.ArithOpType_Div, 2, planpb.ArithOpType_Div, 3, planpb.ArithOpType_Unknown, 0, false},
+		{"mod-mod", planpb.ArithOpType_Mod, 10, planpb.ArithOpType_Mod, 3, planpb.ArithOpType_Unknown, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op, val, ok := composeArithOps(tt.op1, NewInt(tt.a), tt.op2, NewInt(tt.b))
+			assert.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				return
+			}
+			assert.Equal(t, tt.wantOp, op)
+			assert.Equal(t, tt.wantVal, val.GetInt64Val())
+		})
+	}
+}
+
+// A float constant anywhere in the chain must block the fold, even on an integer
+// column: the intermediate result is no longer an integer.
+func TestComposeArithOps_RejectsNonInteger(t *testing.T) {
+	_, _, ok := composeArithOps(planpb.ArithOpType_Add, NewFloat(1.5), planpb.ArithOpType_Add, NewInt(2))
+	assert.False(t, ok)
+
+	_, _, ok = composeArithOps(planpb.ArithOpType_Add, NewInt(1), planpb.ArithOpType_Add, NewFloat(2.5))
+	assert.False(t, ok)
+}

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -332,6 +332,159 @@ func combineArrayLengthExpr(op planpb.OpType, arithOp planpb.ArithOpType, column
 	}, nil
 }
 
+// foldedArithChain is a nested arithmetic chain that has been reduced to a
+// single `column arithOp operand` triple.
+type foldedArithChain struct {
+	columnInfo *planpb.ColumnInfo
+	arithOp    planpb.ArithOpType
+	operand    *planpb.GenericValue
+}
+
+// isFoldableArithOp reports whether an arithmetic operation participates in one
+// of the algebraic identities used by composeArithOps.
+//
+// Div and Mod are deliberately excluded: integer division truncates, so
+// `(x / a) / b` cannot be folded into `x / (a*b)` in general, and Mod has no
+// such identity at all. ArrayLength takes no right operand.
+func isFoldableArithOp(op planpb.ArithOpType) bool {
+	switch op {
+	case planpb.ArithOpType_Add, planpb.ArithOpType_Sub, planpb.ArithOpType_Mul,
+		planpb.ArithOpType_BitAnd, planpb.ArithOpType_BitOr, planpb.ArithOpType_BitXor:
+		return true
+	default:
+		return false
+	}
+}
+
+// isIntegerArithColumn reports whether the column being operated on holds
+// integers.
+//
+// Folding is restricted to integer columns on purpose. Integer arithmetic is
+// two's-complement wrap-around arithmetic, under which +, - and * are exactly
+// associative (and &, | and ^ are associative by definition), so reassociating a
+// chain never changes a result -- not even when it overflows. Floating point
+// addition and multiplication are NOT associative, and a JSON column is
+// dynamically typed, so its runtime value may well be a float. Both are left to
+// the existing "not supported" path rather than silently rounding differently.
+func isIntegerArithColumn(columnInfo *planpb.ColumnInfo) bool {
+	dataType := columnInfo.GetDataType()
+	if typeutil.IsArrayType(dataType) &&
+		(len(columnInfo.GetNestedPath()) != 0 || columnInfo.GetIsElementLevel()) {
+		return typeutil.IsIntegerType(columnInfo.GetElementType())
+	}
+	return typeutil.IsIntegerType(dataType)
+}
+
+// composeArithOps folds two chained integer operations into the single operation
+// that is equivalent to applying both, i.e. it returns (op, c) such that
+// `(x op1 a) op2 b` == `x op c` for every integer x. It reports ok=false when the
+// pair has no such identity, in which case the caller must keep the chain
+// unsupported.
+func composeArithOps(op1 planpb.ArithOpType, a *planpb.GenericValue,
+	op2 planpb.ArithOpType, b *planpb.GenericValue,
+) (planpb.ArithOpType, *planpb.GenericValue, bool) {
+	if !IsInteger(a) || !IsInteger(b) {
+		return planpb.ArithOpType_Unknown, nil, false
+	}
+	// aVal is the inner operand, bVal the outer one; x below denotes the column.
+	aVal, bVal := a.GetInt64Val(), b.GetInt64Val()
+
+	switch op1 {
+	case planpb.ArithOpType_Add, planpb.ArithOpType_Sub:
+		// Normalize the inner operation to an addition: `x - a` == `x + (-a)`.
+		// Negating math.MinInt64 wraps to itself, which is exactly its additive
+		// inverse modulo 2^64, so this stays correct at the boundary.
+		inner := aVal
+		if op1 == planpb.ArithOpType_Sub {
+			inner = -aVal
+		}
+		switch op2 {
+		case planpb.ArithOpType_Add:
+			// (x + a) + b -> x + (a+b);  (x - a) + b -> x + (b-a)
+			return planpb.ArithOpType_Add, NewInt(inner + bVal), true
+		case planpb.ArithOpType_Sub:
+			// (x + a) - b -> x + (a-b);  (x - a) - b -> x + (-a-b)
+			return planpb.ArithOpType_Add, NewInt(inner - bVal), true
+		}
+	case planpb.ArithOpType_Mul:
+		if op2 == planpb.ArithOpType_Mul {
+			// (x * a) * b -> x * (a*b)
+			return planpb.ArithOpType_Mul, NewInt(aVal * bVal), true
+		}
+	case planpb.ArithOpType_BitAnd:
+		if op2 == planpb.ArithOpType_BitAnd {
+			// (x & a) & b -> x & (a&b)
+			return planpb.ArithOpType_BitAnd, NewInt(aVal & bVal), true
+		}
+	case planpb.ArithOpType_BitOr:
+		if op2 == planpb.ArithOpType_BitOr {
+			// (x | a) | b -> x | (a|b)
+			return planpb.ArithOpType_BitOr, NewInt(aVal | bVal), true
+		}
+	case planpb.ArithOpType_BitXor:
+		if op2 == planpb.ArithOpType_BitXor {
+			// (x ^ a) ^ b -> x ^ (a^b)
+			return planpb.ArithOpType_BitXor, NewInt(aVal ^ bVal), true
+		}
+	}
+	return planpb.ArithOpType_Unknown, nil, false
+}
+
+// foldArithChain reduces a nested arithmetic expression of the shape
+// `((column op1 a) op2 b) ...` -- with the column innermost and a constant on the
+// right of every operation -- down to a single `column arithOp operand` triple.
+// Chains of arbitrary depth fold, as long as every adjacent pair shares an
+// identity in composeArithOps.
+//
+// It reports ok=false for anything it cannot prove equivalent, which keeps the
+// caller on the pre-existing "not supported" error path.
+func foldArithChain(arithExpr *planpb.BinaryArithExpr) (*foldedArithChain, bool) {
+	op := arithExpr.GetOp()
+	if !isFoldableArithOp(op) {
+		return nil, false
+	}
+
+	// Every operation in the chain must have a plain integer constant on its
+	// right. A template variable ({v}) carries no value at plan time, so there is
+	// nothing to fold.
+	rightValueExpr := arithExpr.GetRight().GetValueExpr()
+	if rightValueExpr == nil || isTemplateExpr(rightValueExpr) || !IsInteger(rightValueExpr.GetValue()) {
+		return nil, false
+	}
+	rightValue := rightValueExpr.GetValue()
+
+	// Base case: `column op constant`, the innermost operation.
+	if columnExpr := arithExpr.GetLeft().GetColumnExpr(); columnExpr != nil {
+		if !isIntegerArithColumn(columnExpr.GetInfo()) {
+			return nil, false
+		}
+		return &foldedArithChain{
+			columnInfo: columnExpr.GetInfo(),
+			arithOp:    op,
+			operand:    rightValue,
+		}, true
+	}
+
+	// Recursive case: the left operand is itself an arithmetic chain.
+	innerArithExpr := arithExpr.GetLeft().GetBinaryArithExpr()
+	if innerArithExpr == nil {
+		return nil, false
+	}
+	inner, ok := foldArithChain(innerArithExpr)
+	if !ok {
+		return nil, false
+	}
+	arithOp, operand, ok := composeArithOps(inner.arithOp, inner.operand, op, rightValue)
+	if !ok {
+		return nil, false
+	}
+	return &foldedArithChain{
+		columnInfo: inner.columnInfo,
+		arithOp:    arithOp,
+		operand:    operand,
+	}, true
+}
+
 func handleBinaryArithExpr(op planpb.OpType, arithExpr *planpb.BinaryArithExpr, arithExprDataType schemapb.DataType, valueExpr *planpb.ValueExpr) (*planpb.Expr, error) {
 	leftExpr, leftValue := arithExpr.Left.GetColumnExpr(), arithExpr.Left.GetValueExpr()
 	rightExpr, rightValue := arithExpr.Right.GetColumnExpr(), arithExpr.Right.GetValueExpr()
@@ -371,6 +524,14 @@ func handleBinaryArithExpr(op planpb.OpType, arithExpr *planpb.BinaryArithExpr, 
 			return nil, merr.WrapErrQueryPlanMsg("module field is not yet supported")
 		}
 	} else {
+		// The left operand is itself an arithmetic expression, e.g.
+		// ((a + 1) + 2) == 5. Chains that are algebraically equivalent to a single
+		// `column op constant` operation fold into the existing
+		// BinaryArithOpEvalRangeExpr; everything else stays unsupported.
+		if folded, ok := foldArithChain(arithExpr); ok {
+			return combineBinaryArithExpr(op, folded.arithOp, arithExprDataType, folded.columnInfo,
+				&planpb.ValueExpr{Value: folded.operand}, valueExpr)
+		}
 		// (a + b) / 2 == 3
 		return nil, merr.WrapErrQueryPlanMsg("complicated arithmetic operations are not supported")
 	}


### PR DESCRIPTION
## Summary

Expressions that need **two** arithmetic operations before the comparison, e.g. `((a + 1) + 2) == 5`, are rejected at plan time with `complicated arithmetic operations are not supported`. `handleBinaryArithExpr` only understands a single `column OP constant` operand, and `BinaryArithOpEvalRangeExpr` carries exactly one `(arith_op, right_operand)` pair.

This folds a chain of constant-operand arithmetic into the single equivalent operation **in the planner**, so it emits the *existing* `BinaryArithOpEvalRangeExpr`. No proto change, no segcore change: the plan produced for `((a + 1) + 2) == 5` is identical to the one already produced for `a + 3 == 5`.

Folded pairs (integer columns only, arbitrary depth by recursion):

| chain | folded |
|---|---|
| `(x + a) + b` / `(x + a) - b` | `x + (a±b)` |
| `(x - a) + b` / `(x - a) - b` | `x + (b-a)` / `x + (-a-b)` |
| `(x * a) * b` | `x * (a*b)` |
| `(x & a) & b`, `(x \| a) \| b`, `(x ^ a) ^ b` | `x & (a&b)`, `x \| (a\|b)`, `x ^ (a^b)` |

Because the arithmetic operators are left-associative, the form users actually write folds too: `a + 2 + 3 == 5` builds the same tree as `((a + 2) + 3) == 5`.

**Why this is safe.** segcore evaluates integer arithmetic in `int64_t` — `ArithHighPrecisionType` (`internal/core/src/bitset/common.h:130`) promotes *every* integral column, so folding computes the constant in the same domain the executor uses. Reassociating `+`, `-` and `*` is exact modulo 2^64, so folding cannot change a result even when it overflows; `&`, `|`, `^` are associative by definition.

**Scope / non-goals.** Everything the fold cannot *prove* equivalent keeps the pre-existing error rather than risking a silent wrong answer:

- **float / double / JSON columns** — floating point addition is not associative, and JSON is dynamically typed (the runtime value may be a float). `ArithHighPrecisionType` keeps `T` for non-integral types, which is exactly why they are excluded.
- **`Div` / `Mod`** — truncating integer division has no such identity.
- **mixed operator families** (`(x + a) * b`) — no single-operation equivalent.
- **template variables inside the chain**, and **reversed operands** (`2 - x`, already unsupported today).

Note the shift-then-mask case from the issue (`(flags >> k) & m`) is **not** reachable on master — `<<`/`>>` land in #51051 — and it is a *mixed* family, so it is not covered here. The general recursive/two-op evaluator the issue describes is still the right long-term fix for those shapes; this change removes the same-family subset from the unsupported list without touching segcore.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2/...` — passes (package + `rewriter` subpackage), so no regression in existing planner behavior.
- New `internal/parser/planparserv2/nested_arith_test.go`:
  - Every folded chain is asserted **`proto.Equal` to the plan of the equivalent single-op expression** — this is the core claim: segcore is handed a node it already executes, not a new shape.
  - Every non-foldable shape above has a test asserting the original error is still returned.
  - `composeArithOps` is unit-tested directly on the two's-complement boundaries (`MinInt64` negation, `MaxInt64 + 1` wrap) and on pairs with no identity.
  - Integer array elements and a templated compare-value are covered.
- The fold is only reachable from the branch that previously always returned an error, so no expression that worked before takes a changed code path.
- `gofmt` and `go vet` are clean. `golangci-lint` was not run locally (not installed); leaving that to CI.
- Not verified locally: the C++ core does not build on my machine (cgo/segcore toolchain), so I did not run the C++ UTs. This change emits no new plan-node shape, so I do not expect segcore impact — but I have not executed it end-to-end against a running Milvus, and I'm not claiming otherwise.

issue: #51269