### PR TITLE
fix: [2.6] protect sealed segment when delegator view is ahead of current target

### DIFF
--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -444,9 +444,20 @@ func (c *SegmentChecker) filterOutSegmentInUse(ctx context.Context, replica *met
 		// if delegator has valid target version, and before it update to latest readable version, skip release it's sealed segment
 		for _, delegator := range delegatorList {
 			// Notice: if syncTargetVersion stuck, segment on delegator won't be released
-			readableVersionNotUpdate := delegator.View.TargetVersion != initialTargetVersion && delegator.View.TargetVersion < currentTargetVersion
-			if partition != nil && readableVersionNotUpdate {
-				// leader view version hasn't been updated, segment maybe still in use
+			// Protect the segment whenever the delegator's readable target version differs
+			// from the current target version, in EITHER direction:
+			//   - view < current: delegator lags, hasn't caught up to current yet (original case)
+			//   - view > current: the target was synced to this delegator but the current-target
+			//     promote was withheld because another delegator was not ready, so the readable
+			//     view runs ahead of current while next churns further ahead. The segment can
+			//     then be absent from both current and next yet still be in this delegator's
+			//     readable set; releasing it drops loadedRatio below 1.0 and makes the shard
+			//     unserviceable.
+			// Only release when view == current, where the delegator's readable set already
+			// matches current and the redundant segment is provably not in use.
+			readableVersionMismatch := delegator.View.TargetVersion != initialTargetVersion && delegator.View.TargetVersion != currentTargetVersion
+			if partition != nil && readableVersionMismatch {
+				// leader view version differs from current, segment maybe still in use
 				stillInUseByDelegator = true
 				break
 			}

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -1252,6 +1252,54 @@ func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentInUse() {
 	suite.Len(result, 0, "Should release all segments when partition is nil")
 }
 
+// TestFilterOutSegmentAheadOfCurrent covers the promote-race case where a delegator's
+// readable target version is AHEAD of the current target version (view > current).
+// In that state the redundant segment may still be part of the delegator's readable set,
+// so releasing it would drop loadedRatio below 1.0 and make the shard unserviceable.
+// The segment must be protected (filtered out of the release set) until the versions
+// reconcile, exactly like the view < current lagging case.
+func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentAheadOfCurrent() {
+	ctx := context.Background()
+	checker := suite.checker
+
+	collectionID := int64(1)
+	partitionID := int64(1)
+	segmentID := int64(1)
+	nodeID := int64(1)
+	channel := "test-insert-channel"
+
+	checker.meta.PutCollection(ctx, utils.CreateTestCollection(collectionID, 1))
+	checker.meta.PutPartition(ctx, utils.CreateTestPartition(collectionID, partitionID))
+	replica := utils.CreateTestReplica(1, collectionID, []int64{nodeID})
+
+	channels := []*datapb.VchannelInfo{
+		{CollectionID: collectionID, ChannelName: channel},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(
+		channels, []*datapb.SegmentInfo{}, nil).Maybe()
+	checker.targetMgr.UpdateCollectionCurrentTarget(ctx, collectionID)
+	currentTargetVersion := checker.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.CurrentTarget)
+
+	// delegator readable view is ahead of current (promote race)
+	leaderView := utils.CreateTestLeaderView(nodeID, collectionID, channel,
+		map[int64]int64{}, map[int64]*meta.Segment{})
+	leaderView.TargetVersion = currentTargetVersion + 1
+	checker.dist.ChannelDistManager.Update(nodeID, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channel},
+		Node:         nodeID,
+		View:         leaderView,
+	})
+
+	seg := utils.CreateTestSegment(collectionID, partitionID, segmentID, nodeID, 1, channel)
+	delegatorList := checker.dist.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica))
+	ch2DelegatorList := lo.GroupBy(delegatorList, func(d *meta.DmChannel) string {
+		return d.View.Channel
+	})
+
+	result := checker.filterOutSegmentInUse(ctx, replica, []*meta.Segment{seg}, ch2DelegatorList)
+	suite.Len(result, 0, "Segment must be protected when delegator view is ahead of current target")
+}
+
 func TestSegmentCheckerSuite(t *testing.T) {
 	suite.Run(t, new(SegmentCheckerTestSuite))
 }


### PR DESCRIPTION
## Summary

2.6 counterpart of #51261 (master). One-line guard change in `SegmentChecker.filterOutSegmentInUse`, plus a regression test.

On 2.6 this is a **live bug**, not hardening: 2.6 does not have the next-target pin from #50686, so the strict straddle `current < view < next` forms deterministically whenever one shard cannot keep up with segment loading.

### Root cause

A delegator serves reads from a snapshot pinned to a target version. A sealed segment is a release candidate only when it is absent from **both** current and next target; `filterOutSegmentInUse` then decides whether releasing it is safe. Today the in-use guard only protects the segment when the delegator's readable version **lags** current:

```go
readableVersionNotUpdate := view.TargetVersion != initialTargetVersion && view.TargetVersion < currentTargetVersion
```

The symmetric case is unprotected:

1. The target observer syncs the target to the delegators that **are** ready, but withholds the current-target promote because one delegator is not. The ready delegators' views move up; **current stays behind**.
2. Compaction churn (and next-target refresh on expiry) keeps moving **next** ahead of those views.
3. A segment can now be absent from both current and next while still being in a delegator's readable set at the intermediate version. The `<` guard does not fire → the segment is released → `loadedRatio` drops below `1.0` → the shard is unserviceable → the current target stays frozen, so the state **sustains itself** instead of clearing.

Clients see retriable `ChannelNotAvailable` (`code=106`) on cross-shard queries and non-PK-expression deletes.

### Fix

Protect the segment whenever the readable target version **differs** from current in either direction; release only at `view == current`, where the delegator's readable set provably matches current and the redundant segment is not in it. Redundant segments are still reclaimed in the steady state — no over-retention.

issue: #51260
pr: #51261

## Test Plan

- [x] `TestSegmentCheckerSuite/TestFilterOutSegmentAheadOfCurrent` — new regression test: **fails on the old `<` comparison**, passes with `!=` (verified both ways on this branch).
- [x] Existing `TestFilterOutSegmentInUse` cases (`view < current`, `view == current`, initial version, multi-delegator, nil partition) still pass; full `internal/querycoordv2/checkers/...` green.
- [x] **End-to-end on a real cluster, zero code injection** — full Milvus built from a 2.6-based branch, 4 shards, standalone, normal client traffic, with segment-load concurrency throttled to 1 (`queryNodeTaskParallelismFactor: 0.02`, a value seen in production). A/B on the **same binary / config / workload**, 700s each, switching only this comparison:

  | metric | guard `<` | guard `!=` |
  |---|---|---|
  | trigger present (`segment lacks`, delegator not ready) | 178 | **155 — still firing** |
  | strict straddle `current<view<next`, segment released | **3895** | **0** |
  | delegator unserviceable events | 1985 | **0** |
  | `code=106` | 1933 | **0 client-visible failures** |
  | delete failures (non-PK expression) | **26** | **0** |
  | redundant segments still reclaimed | yes | **yes — 26,440 releases, all at `view == current`** |

  The first row is the control: with the fix the trigger still fires just as often — only the harm disappears.

## Landing order

#51264 (the 2.6 backport of #50686 + #51307) lets an expired next target be refreshed while a not-serviceable delegator still holds an older view. With the guard still `<`, that is exactly the window this PR closes. **This PR should land before — or together with — #51264.**
