### PR TITLE
enhance: [3.0] pick least-loaded DataNode in globalScheduler instead of first-fit

### DIFF
--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -185,26 +185,66 @@ func (s *globalTaskScheduler) Stop() {
 	s.wg.Wait()
 }
 
-func (s *globalTaskScheduler) pickNode(workerSlots map[int64]*session.WorkerSlots, taskSlot int64) int64 {
-	var fallbackNodeID int64 = NullNodeID
-	var maxAvailable int64 = -1
+type nodeSlotEntry struct {
+	nodeID int64
+	slots  *session.WorkerSlots
+}
 
+// newNodeSlotHeap builds a max-heap of worker nodes ordered by their available
+// slots, so the most-available (least-loaded) node always sits at the top.
+func newNodeSlotHeap(workerSlots map[int64]*session.WorkerSlots) typeutil.Heap[*nodeSlotEntry] {
+	slots := make([]*nodeSlotEntry, 0, len(workerSlots))
 	for nodeID, ws := range workerSlots {
-		if ws.AvailableSlots >= taskSlot {
-			ws.AvailableSlots -= taskSlot
-			return nodeID
-		}
-		if ws.AvailableSlots > maxAvailable && ws.AvailableSlots > 0 {
-			maxAvailable = ws.AvailableSlots
-			fallbackNodeID = nodeID
-		}
+		slots = append(slots, &nodeSlotEntry{
+			nodeID: nodeID,
+			slots:  ws,
+		})
 	}
+	return typeutil.NewObjectArrayBasedMaximumHeap(slots, func(entry *nodeSlotEntry) int64 {
+		return entry.slots.AvailableSlots
+	})
+}
 
-	if fallbackNodeID != NullNodeID {
-		workerSlots[fallbackNodeID].AvailableSlots = 0
-		return fallbackNodeID
+// pickNode selects the least-loaded node (the one with the most available slots)
+// for a task requiring taskSlot slots, instead of the first node that happens to
+// fit. Always assigning to the most-available node spreads tasks evenly across
+// DataNodes (water-filling on available slots) rather than packing them onto
+// whichever node is iterated first.
+//
+// It returns NullNodeID when no node has any available slot for a positive-slot
+// task. Non-positive-slot tasks are scheduled on the most-available node without
+// consuming slots. When even the most-available node cannot fully satisfy
+// taskSlot, it falls back to that node on a best-effort basis and drains its
+// slots, preserving the previous behavior.
+//
+// The picked node's slots are updated in place; the caller reuses the same heap
+// across all tasks in a scheduling round so later picks observe the decremented
+// slots.
+func (s *globalTaskScheduler) pickNode(slotHeap typeutil.Heap[*nodeSlotEntry], taskSlot int64) int64 {
+	if slotHeap.Len() == 0 {
+		return NullNodeID
 	}
-	return NullNodeID
+	// Pop the most-available node, mutate its slots, then push it back. An element
+	// must not be mutated while it stays in the heap, or the heap order breaks.
+	entry := slotHeap.Pop()
+	if taskSlot <= 0 {
+		slotHeap.Push(entry)
+		return entry.nodeID
+	}
+	if entry.slots.AvailableSlots <= 0 {
+		// The most-available node has no slot, so neither does any other node.
+		slotHeap.Push(entry)
+		return NullNodeID
+	}
+	if entry.slots.AvailableSlots >= taskSlot {
+		entry.slots.AvailableSlots -= taskSlot
+	} else {
+		// No node can fully satisfy the request; assign to the most-available
+		// node on a best-effort basis and drain its slots.
+		entry.slots.AvailableSlots = 0
+	}
+	slotHeap.Push(entry)
+	return entry.nodeID
 }
 
 func (s *globalTaskScheduler) schedule() {
@@ -215,6 +255,9 @@ func (s *globalTaskScheduler) schedule() {
 	nodeSlots := s.cluster.QuerySlot()
 	mlog.Info(s.ctx, "scheduling pending tasks...", mlog.Int("num", pendingNum), mlog.Any("nodeSlots", nodeSlots))
 
+	// Build the node-slot max-heap once per round and reuse it across all picks,
+	// so each task is placed on the currently least-loaded node.
+	slotHeap := newNodeSlotHeap(nodeSlots)
 	futures := make([]*conc.Future[struct{}], 0)
 	var delayed []Task
 	for {
@@ -230,7 +273,7 @@ func (s *globalTaskScheduler) schedule() {
 			continue
 		}
 		taskSlot := task.GetTaskSlot()
-		nodeID := s.pickNode(nodeSlots, taskSlot)
+		nodeID := s.pickNode(slotHeap, taskSlot)
 		if nodeID == NullNodeID {
 			s.pendingTasks.Push(task)
 			break

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -89,48 +89,123 @@ func TestGlobalScheduler_AbortAndRemoveTask(t *testing.T) {
 func TestGlobalScheduler_pickNode(t *testing.T) {
 	scheduler := NewGlobalTaskScheduler(context.TODO(), nil).(*globalTaskScheduler)
 
-	nodeID := scheduler.pickNode(map[int64]*session.WorkerSlots{
-		1: {
-			NodeID:         1,
-			AvailableSlots: 30,
-		},
-		2: {
-			NodeID:         2,
-			AvailableSlots: 30,
-		},
-	}, 1)
-	assert.True(t, nodeID == int64(1) || nodeID == int64(2)) // random
+	// Tie: either node may be returned, but the most-available is always picked.
+	tie := newNodeSlotHeap(map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 30},
+		2: {NodeID: 2, AvailableSlots: 30},
+	})
+	nodeID := scheduler.pickNode(tie, 1)
+	assert.True(t, nodeID == int64(1) || nodeID == int64(2))
 
-	slotsNoEnough := map[int64]*session.WorkerSlots{
+	// Least-loaded selection: node 2 has more available slots, so it wins even
+	// though node 1 also fits and might be iterated first in the map.
+	leastLoaded := newNodeSlotHeap(map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 20},
+		2: {NodeID: 2, AvailableSlots: 80},
+	})
+	assert.Equal(t, int64(2), scheduler.pickNode(leastLoaded, 10))
+
+	// Route by the QuerySlot map key instead of relying on WorkerSlots.NodeID.
+	keyOnly := map[int64]*session.WorkerSlots{
+		10: {AvailableSlots: 20},
+		20: {AvailableSlots: 80},
+	}
+	assert.Equal(t, int64(20), scheduler.pickNode(newNodeSlotHeap(keyOnly), 10))
+	assert.Equal(t, int64(70), keyOnly[20].AvailableSlots)
+
+	// Fallback: no node can fully satisfy the request, pick the most-available
+	// node and drain its slots to 0.
+	noEnough := map[int64]*session.WorkerSlots{
 		1: {NodeID: 1, AvailableSlots: 20},
 		2: {NodeID: 2, AvailableSlots: 30},
 	}
-	nodeID = scheduler.pickNode(slotsNoEnough, 100)
-	assert.Equal(t, int64(2), nodeID) // fallback: pick node with max slots when none >= taskSlot
-	assert.Equal(t, int64(0), slotsNoEnough[2].AvailableSlots)
+	noEnoughHeap := newNodeSlotHeap(noEnough)
+	assert.Equal(t, int64(2), scheduler.pickNode(noEnoughHeap, 100))
+	assert.Equal(t, int64(0), noEnough[2].AvailableSlots)
 
-	slots := map[int64]*session.WorkerSlots{
+	// Single node: slots decrement across successive picks, then fall back.
+	single := map[int64]*session.WorkerSlots{
 		1: {NodeID: 1, AvailableSlots: 100},
 	}
-	assert.Equal(t, int64(1), scheduler.pickNode(slots, 10))
-	assert.Equal(t, int64(90), slots[1].AvailableSlots)
-	assert.Equal(t, int64(1), scheduler.pickNode(slots, 10))
-	assert.Equal(t, int64(80), slots[1].AvailableSlots)
-	nodeID = scheduler.pickNode(slots, 100) // 80 < 100, use fallback
-	assert.Equal(t, int64(1), nodeID)
-	assert.Equal(t, int64(0), slots[1].AvailableSlots)
+	singleHeap := newNodeSlotHeap(single)
+	assert.Equal(t, int64(1), scheduler.pickNode(singleHeap, 10))
+	assert.Equal(t, int64(90), single[1].AvailableSlots)
+	assert.Equal(t, int64(1), scheduler.pickNode(singleHeap, 10))
+	assert.Equal(t, int64(80), single[1].AvailableSlots)
+	assert.Equal(t, int64(1), scheduler.pickNode(singleHeap, 100)) // 80 < 100, fallback
+	assert.Equal(t, int64(0), single[1].AvailableSlots)
 
-	nodeID = scheduler.pickNode(map[int64]*session.WorkerSlots{
-		1: {
-			NodeID:         1,
-			AvailableSlots: 0,
-		},
-		2: {
-			NodeID:         2,
-			AvailableSlots: 0,
-		},
-	}, 1)
-	assert.Equal(t, int64(NullNodeID), nodeID) // no available slots
+	// No available slots at all.
+	empty := newNodeSlotHeap(map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 0},
+		2: {NodeID: 2, AvailableSlots: 0},
+	})
+	assert.Equal(t, int64(NullNodeID), scheduler.pickNode(empty, 1))
+
+	// Zero-slot cleanup work should still be dispatched even when every node is
+	// exhausted, and it should not consume any slots.
+	zeroSlot := map[int64]*session.WorkerSlots{
+		10: {AvailableSlots: 0},
+		20: {AvailableSlots: 0},
+	}
+	zeroSlotHeap := newNodeSlotHeap(zeroSlot)
+	nodeID = scheduler.pickNode(zeroSlotHeap, 0)
+	assert.True(t, nodeID == int64(10) || nodeID == int64(20))
+	assert.Equal(t, int64(0), zeroSlot[10].AvailableSlots)
+	assert.Equal(t, int64(0), zeroSlot[20].AvailableSlots)
+	assert.Equal(t, int64(NullNodeID), scheduler.pickNode(zeroSlotHeap, 1))
+
+	// Empty cluster.
+	assert.Equal(t, int64(NullNodeID), scheduler.pickNode(newNodeSlotHeap(nil), 1))
+}
+
+// TestGlobalScheduler_pickNode_Balancing verifies that successive picks spread
+// tasks evenly across nodes (water-filling) instead of packing one node first.
+func TestGlobalScheduler_pickNode_Balancing(t *testing.T) {
+	scheduler := NewGlobalTaskScheduler(context.TODO(), nil).(*globalTaskScheduler)
+
+	nodes := map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 100},
+		2: {NodeID: 2, AvailableSlots: 100},
+		3: {NodeID: 3, AvailableSlots: 100},
+	}
+	slotHeap := newNodeSlotHeap(nodes)
+
+	assigned := map[int64]int{}
+	// Each task needs 10 slots; 30 tasks should be spread 10 per node.
+	for i := 0; i < 30; i++ {
+		nodeID := scheduler.pickNode(slotHeap, 10)
+		assert.NotEqual(t, int64(NullNodeID), nodeID)
+		assigned[nodeID]++
+	}
+
+	for nodeID, ws := range nodes {
+		assert.Equal(t, 10, assigned[nodeID], "node %d should receive an even share", nodeID)
+		assert.Equal(t, int64(0), ws.AvailableSlots, "node %d should be fully drained", nodeID)
+	}
+
+	// All nodes are now empty: further picks return NullNodeID.
+	assert.Equal(t, int64(NullNodeID), scheduler.pickNode(slotHeap, 1))
+}
+
+func TestGlobalScheduler_pickNode_MixedTaskSizes(t *testing.T) {
+	scheduler := NewGlobalTaskScheduler(context.TODO(), nil).(*globalTaskScheduler)
+
+	nodes := map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 100},
+		2: {NodeID: 2, AvailableSlots: 80},
+		3: {NodeID: 3, AvailableSlots: 60},
+	}
+	slotHeap := newNodeSlotHeap(nodes)
+
+	assert.Equal(t, int64(1), scheduler.pickNode(slotHeap, 30))
+	assert.Equal(t, int64(2), scheduler.pickNode(slotHeap, 70))
+	assert.Equal(t, int64(1), scheduler.pickNode(slotHeap, 50))
+	assert.Equal(t, int64(3), scheduler.pickNode(slotHeap, 90))
+
+	assert.Equal(t, int64(20), nodes[1].AvailableSlots)
+	assert.Equal(t, int64(10), nodes[2].AvailableSlots)
+	assert.Equal(t, int64(0), nodes[3].AvailableSlots)
 }
 
 func TestGlobalScheduler_TestSchedule(t *testing.T) {
@@ -224,6 +299,34 @@ func TestGlobalScheduler_TestSchedule(t *testing.T) {
 			defer s.mu.RUnlock(1)
 			return stateCounter.Load() >= 2 && s.runningTasks.Len() == 0
 		}, 10*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("zero slot task dispatched when nodes exhausted", func(t *testing.T) {
+		cluster := session.NewMockCluster(t)
+		cluster.EXPECT().QuerySlot().Return(map[int64]*session.WorkerSlots{
+			10: {AvailableSlots: 0},
+			20: {AvailableSlots: 0},
+		}).Once()
+
+		scheduler := NewGlobalTaskScheduler(context.TODO(), cluster).(*globalTaskScheduler)
+		task := NewMockTask(t)
+		task.EXPECT().GetTaskID().Return(1).Maybe()
+		task.EXPECT().GetTaskType().Return(taskcommon.Compaction).Maybe()
+		task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return().Maybe()
+		task.EXPECT().GetTaskState().Return(taskcommon.Init).Maybe()
+		task.EXPECT().GetTaskSlot().Return(int64(0)).Once()
+
+		var dispatched atomic.Bool
+		task.EXPECT().CreateTaskOnWorker(mock.MatchedBy(func(nodeID int64) bool {
+			return nodeID == 10 || nodeID == 20
+		}), mock.Anything).Run(func(nodeID int64, cluster session.Cluster) {
+			dispatched.Store(true)
+		}).Once()
+
+		scheduler.Enqueue(task)
+		scheduler.schedule()
+
+		assert.True(t, dispatched.Load())
 	})
 
 	t.Run("normal case", func(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of #50912 to the 3.0 branch.

## What

The datacoord `globalTaskScheduler.pickNode` used **first-fit**: it returned the first node in map-iteration order whose available slots could satisfy the task. Because Go map iteration order is non-deterministic and the search stops at the first fit, scheduled tasks (import / compaction / index / stats) were not spread evenly across DataNodes — a cluster could land most tasks on one pod while others stayed idle.

This PR maintains a per-round **max-heap** of nodes keyed by available slots and always assigns each task to the **most-available (least-loaded)** node (water-filling on available slots). The heap is built once per `schedule()` round and reused across all picks, so later picks observe the decremented slots.

The previous fallback (drain the most-available node when no node can fully satisfy `taskSlot`) and the empty-cluster / no-slot behaviors are **preserved**.

## Why

Related discussion: https://github.com/milvus-io/milvus/discussions/50872 — bulk import on a multi-DataNode cluster spent ~90% of wall-clock on a single pod. One root cause is on the **scheduling layer**: first-fit selection did not balance tasks across nodes. This PR addresses that layer.

> Note: the import-specific regrouping in `RegroupImportFiles` (which can merge multiple files into a single task) is a separate, complementary issue and is **not** addressed here.

## Test

Clean cherry-pick (no conflicts); 3.0 already has `typeutil.NewObjectArrayBasedMaximumHeap`. On the 3.0 base:
- `go vet -tags dynamic,test ./internal/datacoord/task/` — clean.
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord/task/` — passes.
- `TestGlobalScheduler_pickNode`, `TestGlobalScheduler_pickNode_Balancing`, `TestGlobalScheduler_pickNode_MixedTaskSizes` all PASS.

pr: #50912
issue: #50914