### PR TITLE
fix: reject function rerank when using search iterator

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -916,6 +916,14 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 		return merr.WrapErrParameterInvalidMsg("order_by and function rerank cannot be used together: they specify conflicting sort criteria")
 	}
 
+	// search iterator and function rerank cannot be used together: the iterator
+	// derives its next-page bound from the returned scores, and rerank rewrites
+	// them, so continuation would resume from a bound in the wrong score space
+	// and repeat pages
+	if isIterator && (t.rerankMeta != nil || len(querynodeFunctionChains) > 0) {
+		return merr.WrapErrParameterInvalidMsg("function rerank is not permitted when using a search iterator")
+	}
+
 	analyzer, err := funcutil.GetAttrByKeyFromRepeatedKV(AnalyzerKey, t.request.GetSearchParams())
 	if err == nil {
 		t.AnalyzerName = analyzer

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -5643,6 +5643,65 @@ func TestSearchTask_FunctionChainRerankMeta(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "order_by and function rerank cannot be used together")
 	})
+
+	t.Run("ordinary search rejects search iterator with l0 function chain", func(t *testing.T) {
+		request, _ := newL0FunctionChainRequest()
+		request.SearchParams = append(request.SearchParams, &commonpb.KeyValuePair{Key: IteratorField, Value: "True"})
+		task := newTask(request)
+
+		err := task.initSearchRequest(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "function rerank is not permitted when using a search iterator")
+	})
+
+	t.Run("ordinary search rejects search iterator v2 with l0 function chain", func(t *testing.T) {
+		request, _ := newL0FunctionChainRequest()
+		request.SearchParams = append(request.SearchParams,
+			&commonpb.KeyValuePair{Key: IteratorField, Value: "True"},
+			&commonpb.KeyValuePair{Key: SearchIterV2Key, Value: "True"},
+			&commonpb.KeyValuePair{Key: SearchIterBatchSizeKey, Value: "10"},
+		)
+		task := newTask(request)
+
+		err := task.initSearchRequest(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "function rerank is not permitted when using a search iterator")
+	})
+
+	t.Run("ordinary search rejects search iterator with l2 function chain", func(t *testing.T) {
+		request := newFunctionChainRequest()
+		request.SearchParams = append(request.SearchParams, &commonpb.KeyValuePair{Key: IteratorField, Value: "True"})
+		task := newTask(request)
+
+		err := task.initSearchRequest(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "function rerank is not permitted when using a search iterator")
+	})
+
+	t.Run("ordinary search rejects search iterator with function score", func(t *testing.T) {
+		request := newRequest()
+		request.FunctionScore = &schemapb.FunctionScore{
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:             "decay",
+					Type:             schemapb.FunctionType_Rerank,
+					InputFieldNames:  []string{"ts"},
+					OutputFieldNames: []string{},
+					Params: []*commonpb.KeyValuePair{
+						{Key: "reranker", Value: "decay"},
+						{Key: "origin", Value: "100"},
+						{Key: "scale", Value: "10"},
+					},
+				},
+			},
+		}
+		request.SearchParams = append(request.SearchParams, &commonpb.KeyValuePair{Key: IteratorField, Value: "True"})
+		task := newTask(request)
+
+		err := task.initSearchRequest(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "function rerank is not permitted when using a search iterator")
+	})
 }
 
 func TestSearchTask_AddHighlightTask(t *testing.T) {


### PR DESCRIPTION
issue: #51306

### Problem

`search_iterator` with an L0 FunctionChain silently returns the first page repeatedly (#51306).

### Root cause

Search iterator v2 continuation derives its next-page bound from the last score of the previous page (`getLastBound` in `internal/proxy/task_search.go` reads `result.Results.Scores`). With an L0 rerank those scores are the rerank outputs, not ANN distances. The contaminated `last_bound` is sent back on the next request, where segcore's `CachedSearchIterator::IsValid` applies it as `dist > last_bound` in the sign-normalized ANN distance space. An XGBoost raw score is far outside the metric's range (e.g. ~20 vs COSINE's [-1, 1]), so the continuation filter excludes nothing and the same top batch is returned again — exactly the duplicate page in the report.

The same contamination applies to L2 function chains and `function_score` rerank, and to iterator v1, whose client-side continuation is likewise derived from the returned distances.

### Fix

Properly supporting rerank under iteration needs the raw ANN distance carried alongside the rewritten score through reduce — a feature-level change for #51192. Until then, reject the combination explicitly at the proxy (the issue's stated expected behavior), matching the existing iterator guards for group_by, offset, and order_by: a search combining an iterator with `function_chains` or `function_score` now fails with `ParameterInvalid` instead of silently returning duplicate pages.

The released PyMilvus `search_iterator` API does not accept a ranker, so the `function_score` half of the guard only affects raw-request combinations whose pagination was already silently broken.

### Test

Added parse-level unit tests in `TestSearchTask_FunctionChainRerankMeta` covering rejection of iterator (v1 and v2 param shapes) with an L0 chain, an L2 chain, and `function_score`, plus verified existing iterator tests carry no rerank so no expectations change.