### PR TITLE
enhance: skip schema work for non-insert batches

### DIFF
--- a/internal/flushcommon/pipeline/flow_graph_write_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_write_node.go
@@ -91,16 +91,18 @@ func (wNode *writeNode) Operate(in []Msg) []Msg {
 	}()
 
 	start, end := fgMsg.StartPositions[0], fgMsg.EndPositions[0]
-	currentSchema := wNode.metacache.GetSchema(fgMsg.TimeTick())
-	schemaVersion := currentSchema.GetVersion()
-	functionOutputFieldIDs, err := wNode.functionStore.OutputFieldIDs(currentSchema)
-	if err != nil {
-		mlog.Error(context.TODO(), "failed to get embedding output fields", mlog.Err(err))
-		panic(err)
-	}
+	// The schema version is only consumed while buffering insert data.
+	schemaVersion := int32(0)
 
 	insertData := make([]*writebuffer.InsertData, 0)
 	if len(fgMsg.InsertMessages) > 0 {
+		currentSchema := wNode.metacache.GetSchema(fgMsg.TimeTick())
+		schemaVersion = currentSchema.GetVersion()
+		functionOutputFieldIDs, err := wNode.functionStore.OutputFieldIDs(currentSchema)
+		if err != nil {
+			mlog.Error(context.TODO(), "failed to get embedding output fields", mlog.Err(err))
+			panic(err)
+		}
 		for _, msg := range fgMsg.InsertMessages {
 			if len(functionOutputFieldIDs) == 0 || function.HasAllFieldDataByID(msg.GetFieldsData(), functionOutputFieldIDs) {
 				continue
@@ -119,8 +121,7 @@ func (wNode *writeNode) Operate(in []Msg) []Msg {
 	}
 	fgMsg.InsertData = insertData
 
-	err = wNode.wbManager.BufferData(wNode.channelName, fgMsg.InsertData, fgMsg.DeleteMessages, start, end, schemaVersion)
-	if err != nil {
+	if err := wNode.wbManager.BufferData(wNode.channelName, fgMsg.InsertData, fgMsg.DeleteMessages, start, end, schemaVersion); err != nil {
 		mlog.Error(context.TODO(), "failed to buffer data", mlog.Err(err))
 		panic(err)
 	}

--- a/internal/flushcommon/pipeline/flow_graph_write_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_write_node.go
@@ -92,16 +92,18 @@ func (wNode *writeNode) Operate(in []Msg) []Msg {
 
 	start, end := fgMsg.StartPositions[0], fgMsg.EndPositions[0]
 	ctx := fgMsg.TraceCtx()
-	currentSchema := wNode.metacache.GetSchema(fgMsg.TimeTick())
-	schemaVersion := currentSchema.GetVersion()
-	functionOutputFieldIDs, err := wNode.functionStore.OutputFieldIDs(currentSchema)
-	if err != nil {
-		mlog.Error(ctx, "failed to get embedding output fields", mlog.Err(err))
-		panic(err)
-	}
+	// The schema version is only consumed while buffering insert data.
+	schemaVersion := int32(0)
 
 	insertData := make([]*writebuffer.InsertData, 0)
 	if len(fgMsg.InsertMessages) > 0 {
+		currentSchema := wNode.metacache.GetSchema(fgMsg.TimeTick())
+		schemaVersion = currentSchema.GetVersion()
+		functionOutputFieldIDs, err := wNode.functionStore.OutputFieldIDs(currentSchema)
+		if err != nil {
+			mlog.Error(ctx, "failed to get embedding output fields", mlog.Err(err))
+			panic(err)
+		}
 		for _, msg := range fgMsg.InsertMessages {
 			if len(functionOutputFieldIDs) == 0 || function.HasAllFieldDataByID(msg.GetFieldsData(), functionOutputFieldIDs) {
 				continue
@@ -120,8 +122,7 @@ func (wNode *writeNode) Operate(in []Msg) []Msg {
 	}
 	fgMsg.InsertData = insertData
 
-	err = wNode.wbManager.BufferData(wNode.channelName, fgMsg.InsertData, fgMsg.DeleteMessages, start, end, schemaVersion)
-	if err != nil {
+	if err := wNode.wbManager.BufferData(wNode.channelName, fgMsg.InsertData, fgMsg.DeleteMessages, start, end, schemaVersion); err != nil {
 		mlog.Error(ctx, "failed to buffer data", mlog.Err(err))
 		panic(err)
 	}

--- a/internal/flushcommon/pipeline/flow_graph_write_node_test.go
+++ b/internal/flushcommon/pipeline/flow_graph_write_node_test.go
@@ -1,0 +1,84 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+type noopStatsUpdater struct{}
+
+func (noopStatsUpdater) Update(string, typeutil.Timestamp, []*commonpb.SegmentStats) {}
+
+func (noopStatsUpdater) GetLatestTimestamp(string) typeutil.Timestamp { return 0 }
+
+func TestWriteNodeSkipsSchemaLookupForDeleteOnlyBatch(t *testing.T) {
+	const vchannel = "test-vchannel"
+
+	metaCache := metacache.NewMockMetaCache(t)
+	metaCache.EXPECT().
+		GetSchema(mock.Anything).
+		Return(&schemapb.CollectionSchema{Version: 42}).
+		Maybe()
+
+	bufferManager := writebuffer.NewMockBufferManager(t)
+	deleteMessages := []*msgstream.DeleteMsg{{}}
+	bufferManager.EXPECT().
+		BufferData(
+			vchannel,
+			mock.MatchedBy(func(data []*writebuffer.InsertData) bool { return len(data) == 0 }),
+			deleteMessages,
+			mock.Anything,
+			mock.Anything,
+			int32(0),
+		).
+		Return(nil).
+		Once()
+
+	functionStore := function.NewFunctionRunnerLocalStore()
+	defer functionStore.Close()
+
+	node := &writeNode{
+		channelName:   vchannel,
+		wbManager:     bufferManager,
+		updater:       noopStatsUpdater{},
+		metacache:     metaCache,
+		functionStore: functionStore,
+	}
+	msg := &FlowGraphMsg{
+		DeleteMessages: deleteMessages,
+		StartPositions: []*msgpb.MsgPosition{{ChannelName: "test-pchannel", Timestamp: 100}},
+		EndPositions:   []*msgpb.MsgPosition{{ChannelName: "test-pchannel", Timestamp: 200}},
+	}
+
+	output := node.Operate([]Msg{msg})
+
+	require.Len(t, output, 1)
+	metaCache.AssertNotCalled(t, "GetSchema", mock.Anything)
+}


### PR DESCRIPTION
issue: #51337

## Summary

- skip collection schema lookup and function output-field resolution for flowgraph batches without insert messages
- keep delete and time-tick processing unchanged, using schema version zero only where the write buffer does not consume it
- add regression coverage for the delete-only path

## Scope

This extracts the remaining safe flowgraph optimization from `83954d9ee7daef6ab5f1b0ed5f75e15aeaf6f5cd` into an independent PR. It does not depend on #51160 or #51255 and contains no newly added metrics or profiling instrumentation.

The WAL control-channel lock experiment, InputNode metric-handle cache, and RootCoord AddCollection lock release are intentionally excluded because their current forms have correctness or lifecycle risks.

## Test Plan

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/pipeline`
- `go test -race -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/pipeline -run "^TestWriteNodeSkipsSchemaLookupForDeleteOnlyBatch$"`