### PR TITLE
fix: fill cached DescribeCollection db fields when queried by id

### DIFF
--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -106,6 +106,7 @@ type Cache interface {
 type collectionInfo struct {
 	collID                typeutil.UniqueID
 	dbName                string
+	dbID                  typeutil.UniqueID
 	schema                *schemaInfo
 	createdTimestamp      uint64
 	createdUtcTimestamp   uint64
@@ -502,6 +503,7 @@ func (m *MetaCache) update(ctx context.Context, database, collectionName string,
 		return &collectionInfo{
 			collID:                collection.CollectionID,
 			dbName:                collection.GetDbName(),
+			dbID:                  collection.GetDbId(),
 			schema:                schemaInfo,
 			createdTimestamp:      collection.CreatedTimestamp,
 			createdUtcTimestamp:   collection.CreatedUtcTimestamp,
@@ -534,6 +536,7 @@ func (m *MetaCache) update(ctx context.Context, database, collectionName string,
 	m.collInfo[database][collectionName] = &collectionInfo{
 		collID:                collection.CollectionID,
 		dbName:                collection.GetDbName(),
+		dbID:                  collection.GetDbId(),
 		schema:                schemaInfo,
 		createdTimestamp:      collection.CreatedTimestamp,
 		createdUtcTimestamp:   collection.CreatedUtcTimestamp,

--- a/internal/proxy/service_provider.go
+++ b/internal/proxy/service_provider.go
@@ -197,6 +197,9 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 		resp.Status = wrapErrorStatus(err)
 		return resp, nil
 	}
+	if resp.CollectionName == "" {
+		resp.CollectionName = c.schema.Name
+	}
 
 	// skip dynamic fields, see describeCollectionTask.Execute
 	resp.Schema = &schemapb.CollectionSchema{

--- a/internal/proxy/service_provider.go
+++ b/internal/proxy/service_provider.go
@@ -229,6 +229,11 @@ func (node *CachedProxyServiceProvider) DescribeCollection(ctx context.Context,
 		return nil, err
 	}
 
+	// Prefer the collection's actual db from cache instead of echoing request.DbName,
+	// which is empty when the collection is queried by id only (e.g. the HTTP management
+	// API). Keeps the response consistent with the non-cached describeCollectionTask path.
+	resp.DbName = c.dbName
+	resp.DbId = c.dbID
 	resp.CollectionID = c.collID
 	resp.UpdateTimestamp = c.updateTimestamp
 	resp.UpdateTimestampStr = fmt.Sprintf("%d", c.updateTimestamp)

--- a/internal/proxy/service_provider_test.go
+++ b/internal/proxy/service_provider_test.go
@@ -78,6 +78,52 @@ func TestCachedProxyServiceProvider_DescribeCollection_IgnoresLegacyDoPhysicalBa
 	assert.False(t, resp.GetSchema().GetDoPhysicalBackfill())
 }
 
+func TestCachedProxyServiceProvider_DescribeCollection_FillsDbFromCacheWhenQueriedByID(t *testing.T) {
+	ctx := context.Background()
+
+	origCache := globalMetaCache
+	defer func() { globalMetaCache = origCache }()
+
+	dbName := "db1"
+	dbID := int64(3)
+	collectionName := "coll1"
+	collectionID := int64(449574)
+	schema := &schemapb.CollectionSchema{
+		Name: collectionName,
+		Fields: []*schemapb.FieldSchema{{
+			FieldID:      common.StartOfUserFieldID,
+			Name:         "id",
+			IsPrimaryKey: true,
+			DataType:     schemapb.DataType_Int64,
+		}},
+	}
+
+	// Query by collection id only: no collection name, no db name (e.g. the HTTP
+	// management API). The provider must resolve the real db from the meta cache
+	// rather than echo the empty request.DbName / leave DbId at 0.
+	mockCache := &MockCache{}
+	mockCache.EXPECT().GetCollectionName(mock.Anything, "", collectionID).Return(collectionName, nil)
+	mockCache.EXPECT().GetCollectionID(mock.Anything, "", collectionName).Return(collectionID, nil)
+	mockCache.EXPECT().GetCollectionInfo(mock.Anything, "", collectionName, collectionID).Return(&collectionInfo{
+		collID:    collectionID,
+		dbName:    dbName,
+		dbID:      dbID,
+		schema:    newSchemaInfo(schema),
+		shardsNum: common.DefaultShardsNum,
+	}, nil)
+	globalMetaCache = mockCache
+
+	provider := &CachedProxyServiceProvider{Proxy: &Proxy{}}
+	resp, err := provider.DescribeCollection(ctx, &milvuspb.DescribeCollectionRequest{
+		CollectionID: collectionID,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
+	assert.Equal(t, collectionID, resp.GetCollectionID())
+	assert.Equal(t, dbName, resp.GetDbName())
+	assert.Equal(t, dbID, resp.GetDbId())
+}
+
 func TestCachedProxyServiceProvider_DescribeCollection_FilterNamespaceField(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/proxy/service_provider_test.go
+++ b/internal/proxy/service_provider_test.go
@@ -119,6 +119,7 @@ func TestCachedProxyServiceProvider_DescribeCollection_FillsDbFromCacheWhenQueri
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, commonpb.ErrorCode_Success, resp.GetStatus().GetErrorCode())
+	assert.Equal(t, collectionName, resp.GetCollectionName())
 	assert.Equal(t, collectionID, resp.GetCollectionID())
 	assert.Equal(t, dbName, resp.GetDbName())
 	assert.Equal(t, dbID, resp.GetDbId())

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1780,6 +1780,9 @@ func (t *describeCollectionTask) Execute(ctx context.Context) error {
 		}
 		return nil
 	}
+	if t.result.CollectionName == "" {
+		t.result.CollectionName = result.GetCollectionName()
+	}
 
 	t.result.Schema.Name = result.Schema.Name
 	t.result.Schema.Description = result.Schema.Description

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -2537,6 +2537,47 @@ func TestDescribeCollectionTask_FilterNamespaceField(t *testing.T) {
 	assert.Equal(t, collectionName, task.result.GetCollectionName())
 }
 
+func TestDescribeCollectionTask_FillsNameFromResultWhenQueriedByID(t *testing.T) {
+	ctx := context.Background()
+	mix := NewMixCoordMock()
+
+	const (
+		collectionName = "collection_from_result"
+		collectionID   = int64(449574)
+		dbName         = "db_from_result"
+		dbID           = int64(3)
+	)
+	mix.SetDescribeCollectionFunc(func(context.Context, *milvuspb.DescribeCollectionRequest) (*milvuspb.DescribeCollectionResponse, error) {
+		return &milvuspb.DescribeCollectionResponse{
+			Status:         merr.Success(),
+			CollectionName: collectionName,
+			CollectionID:   collectionID,
+			DbName:         dbName,
+			DbId:           dbID,
+			Schema: &schemapb.CollectionSchema{
+				Name: collectionName,
+			},
+		}, nil
+	})
+
+	task := &describeCollectionTask{
+		Condition: NewTaskCondition(ctx),
+		DescribeCollectionRequest: &milvuspb.DescribeCollectionRequest{
+			Base:         &commonpb.MsgBase{MsgType: commonpb.MsgType_DescribeCollection},
+			CollectionID: collectionID,
+		},
+		ctx:      ctx,
+		mixCoord: mix,
+	}
+
+	assert.NoError(t, task.PreExecute(ctx))
+	assert.NoError(t, task.Execute(ctx))
+	assert.Equal(t, collectionName, task.result.GetCollectionName())
+	assert.Equal(t, collectionID, task.result.GetCollectionID())
+	assert.Equal(t, dbName, task.result.GetDbName())
+	assert.Equal(t, dbID, task.result.GetDbId())
+}
+
 // Security regression: DescribeCollection must redact credentials embedded in
 // ExternalSpec.extfs (access_key_id / access_key_value / ssl_ca_cert) before
 // returning to the client. Any caller with Describe privilege would otherwise


### PR DESCRIPTION
pr: #51313

## What

Backport #51313 to `3.0` and include its follow-up for the remote path.

- Populate cached `DescribeCollectionResponse.db_name` and `db_id` from the resolved collection cache entry.
- For ID-only requests, fill the top-level `collection_name` from the resolved collection on both cached and remote paths.
- Preserve alias/name request echoing by only filling `collection_name` when the request omitted it.

## Why

An ID-only `DescribeCollection` request could return an empty `db_name`, `db_id = 0`, and an empty top-level `collection_name` when the cached provider was enabled. The provider switch must not alter the observable response.

## Validation

- `git diff --check`
- Attempted targeted test with `go test -tags test ./internal/proxy -run 'TestCachedProxyServiceProvider_DescribeCollection_FillsDbFromCacheWhenQueriedByID|TestDescribeCollectionTask_FillsNameFromResultWhenQueriedByID' -count=1 -v`.
- Local execution is blocked before tests run because the macOS runtime cannot load `libmilvus_core.dylib`; CI builds the core and should execute these tests.