### PR TITLE
enhance: reduce collection lifecycle contention

### DIFF
--- a/docs/agent_guides/streaming-system/wal/lock.md
+++ b/docs/agent_guides/streaming-system/wal/lock.md
@@ -7,6 +7,10 @@ The Lock interceptor enforces exclusive/shared access on VChannel or PChannel sc
 - **PChannel-level**: A global RWMutex. Exclusive lock blocks all appends on the entire PChannel; shared lock allows concurrent appends.
 - **VChannel-level**: A per-key RWMutex. Exclusive lock blocks appends on a specific VChannel; shared lock allows concurrent appends to the same VChannel.
 
+For collection-scoped broadcasts, exclusive locking applies to the data VChannel copies. The CChannel copy uses shared
+locking so DDL with non-conflicting ResourceKeys can append concurrently; conflicting DDL remains serialized by the
+Broadcaster's ResourceKey lock. PChannel-level messages sent through the CChannel still acquire the global exclusive lock.
+
 See [Message Semantic Docs](../message/message.md) for per-message lock requirements.
 
 ## Key Packages

--- a/internal/flushcommon/pipeline/data_sync_service.go
+++ b/internal/flushcommon/pipeline/data_sync_service.go
@@ -281,6 +281,12 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 	nodeList := []flowgraph.Node{}
 
 	dmStreamNode := newDmInputNode(config, input)
+	inputNodeOwnedByFlowgraph := false
+	defer func() {
+		if !inputNodeOwnedByFlowgraph {
+			dmStreamNode.Free()
+		}
+	}()
 	nodeList = append(nodeList, dmStreamNode)
 
 	// 1.ddNode
@@ -328,6 +334,7 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 		return nil, err
 	}
 
+	inputNodeOwnedByFlowgraph = true
 	return ds, nil
 }
 

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -553,9 +553,6 @@ func (mt *MetaTable) getDatabaseByNameInternal(ctx context.Context, dbName strin
 }
 
 func (mt *MetaTable) AddCollection(ctx context.Context, coll *model.Collection) error {
-	mt.ddLock.Lock()
-	defer mt.ddLock.Unlock()
-
 	// Note:
 	// 1, idempotency check was already done outside;
 	// 2, no need to check time travel logic, since ts should always be the latest;
@@ -563,16 +560,32 @@ func (mt *MetaTable) AddCollection(ctx context.Context, coll *model.Collection) 
 		return merr.WrapErrServiceInternalMsg("collection state should be created, collection name: %s, collection id: %d, state: %s", coll.Name, coll.CollectionID, coll.State)
 	}
 
+	mt.ddLock.RLock()
 	// check if there's a collection meta with the same collection id.
 	// merge the collection meta together.
-	if _, ok := mt.collID2Meta[coll.CollectionID]; ok {
+	_, collectionExists := mt.collID2Meta[coll.CollectionID]
+	mt.ddLock.RUnlock()
+	if collectionExists {
 		mlog.Info(ctx, "collection already created, skip add collection to meta table", mlog.Int64("collectionID", coll.CollectionID))
 		return nil
 	}
 
+	// The broadcaster resource-key lock serializes conflicting collection and
+	// database DDL. Do not hold the global metadata lock during catalog I/O so
+	// unrelated metadata readers and DDL can continue.
 	ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
 	if err := mt.catalog.CreateCollection(ctx1, coll, coll.CreateTime); err != nil {
 		return err
+	}
+
+	mt.ddLock.Lock()
+	defer mt.ddLock.Unlock()
+
+	// Recheck after catalog I/O for idempotent retries that may have completed
+	// while the global metadata lock was released.
+	if _, ok := mt.collID2Meta[coll.CollectionID]; ok {
+		mlog.Info(ctx, "collection already created after catalog write, skip add collection to meta table", mlog.Int64("collectionID", coll.CollectionID))
+		return nil
 	}
 
 	mt.collID2Meta[coll.CollectionID] = coll.Clone()

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -1223,6 +1223,154 @@ func TestMetaTable_GetCollectionByName(t *testing.T) {
 	})
 }
 
+func TestMetaTable_AddCollectionDoesNotBlockReadersDuringCatalogCreate(t *testing.T) {
+	channel.ResetStaticPChannelStatsManager()
+	channel.RecoverPChannelStatsManager([]string{})
+	t.Cleanup(channel.ResetStaticPChannelStatsManager)
+
+	catalog := mocks.NewRootCoordCatalog(t)
+	enteredCatalog := make(chan struct{})
+	unblockCatalog := make(chan struct{})
+	catalog.EXPECT().
+		CreateCollection(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(context.Context, *model.Collection, uint64) error {
+			close(enteredCatalog)
+			<-unblockCatalog
+			return nil
+		}).
+		Once()
+
+	existingColl := &model.Collection{
+		CollectionID: 100,
+		DBID:         util.DefaultDBID,
+		DBName:       util.DefaultDBName,
+		Name:         "existing",
+		State:        pb.CollectionState_CollectionCreated,
+		Partitions: []*model.Partition{
+			{PartitionID: 10, PartitionName: Params.CommonCfg.DefaultPartitionName.GetValue(), State: pb.PartitionState_PartitionCreated},
+		},
+	}
+	meta := &MetaTable{
+		catalog: catalog,
+		dbName2Meta: map[string]*model.Database{
+			util.DefaultDBName: model.NewDefaultDatabase(nil),
+		},
+		collID2Meta: map[typeutil.UniqueID]*model.Collection{
+			existingColl.CollectionID: existingColl,
+		},
+		partitionName2ID:   map[int64]map[string]int64{},
+		names:              newNameDb(),
+		aliases:            newNameDb(),
+		fileResourceRefCnt: map[int64]int{},
+	}
+	meta.names.insert(util.DefaultDBName, existingColl.Name, existingColl.CollectionID)
+
+	addErr := make(chan error, 1)
+	go func() {
+		addErr <- meta.AddCollection(context.Background(), &model.Collection{
+			CollectionID: 101,
+			DBID:         util.DefaultDBID,
+			DBName:       util.DefaultDBName,
+			Name:         "creating",
+			State:        pb.CollectionState_CollectionCreated,
+			ShardsNum:    1,
+			Partitions: []*model.Partition{
+				{PartitionID: 11, PartitionName: Params.CommonCfg.DefaultPartitionName.GetValue(), State: pb.PartitionState_PartitionCreated},
+			},
+		})
+	}()
+
+	select {
+	case <-enteredCatalog:
+	case <-time.After(time.Second):
+		require.FailNow(t, "AddCollection did not enter catalog CreateCollection")
+	}
+
+	type readResponse struct {
+		collection *model.Collection
+		err        error
+	}
+	readResult := make(chan readResponse, 1)
+	go func() {
+		coll, err := meta.GetCollectionByName(context.Background(), util.DefaultDBName, existingColl.Name, typeutil.MaxTimestamp, false)
+		readResult <- readResponse{collection: coll, err: err}
+	}()
+
+	select {
+	case result := <-readResult:
+		require.NoError(t, result.err)
+		require.Equal(t, existingColl.CollectionID, result.collection.CollectionID)
+	case <-time.After(time.Second):
+		close(unblockCatalog)
+		require.NoError(t, <-addErr)
+		require.FailNow(t, "GetCollectionByName blocked while catalog CreateCollection was in progress")
+	}
+
+	close(unblockCatalog)
+	require.NoError(t, <-addErr)
+}
+
+func TestMetaTable_AddCollectionRechecksAfterCatalogCreate(t *testing.T) {
+	channel.ResetStaticPChannelStatsManager()
+	channel.RecoverPChannelStatsManager([]string{})
+	t.Cleanup(channel.ResetStaticPChannelStatsManager)
+
+	catalog := mocks.NewRootCoordCatalog(t)
+	enteredCatalog := make(chan struct{})
+	unblockCatalog := make(chan struct{})
+	catalog.EXPECT().
+		CreateCollection(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(context.Context, *model.Collection, uint64) error {
+			close(enteredCatalog)
+			<-unblockCatalog
+			return nil
+		}).
+		Once()
+
+	coll := &model.Collection{
+		CollectionID: 101,
+		DBID:         util.DefaultDBID,
+		DBName:       util.DefaultDBName,
+		Name:         "creating",
+		State:        pb.CollectionState_CollectionCreated,
+		ShardsNum:    1,
+		Partitions: []*model.Partition{
+			{PartitionID: 11, PartitionName: Params.CommonCfg.DefaultPartitionName.GetValue(), State: pb.PartitionState_PartitionCreated},
+		},
+	}
+	meta := &MetaTable{
+		catalog:              catalog,
+		collID2Meta:          map[typeutil.UniqueID]*model.Collection{},
+		partitionName2ID:     map[int64]map[string]int64{},
+		names:                newNameDb(),
+		aliases:              newNameDb(),
+		fileResourceRefCnt:   map[int64]int{},
+		fileResourceRefHolds: map[int64]map[int64]int{},
+		generalCnt:           7,
+	}
+
+	addErr := make(chan error, 1)
+	go func() {
+		addErr <- meta.AddCollection(context.Background(), coll)
+	}()
+
+	select {
+	case <-enteredCatalog:
+	case <-time.After(time.Second):
+		require.FailNow(t, "AddCollection did not enter catalog CreateCollection")
+	}
+
+	meta.ddLock.Lock()
+	meta.collID2Meta[coll.CollectionID] = coll.Clone()
+	meta.names.insert(coll.DBName, coll.Name, coll.CollectionID)
+	meta.ddLock.Unlock()
+	close(unblockCatalog)
+
+	require.NoError(t, <-addErr)
+	require.Equal(t, 7, meta.generalCnt)
+	require.NotContains(t, meta.partitionName2ID, coll.CollectionID)
+}
+
 /*
 func TestMetaTable_AlterCollection(t *testing.T) {
 	t.Run("alter metastore fail", func(t *testing.T) {

--- a/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
 )
 
@@ -37,7 +38,7 @@ func (r *lockAppendInterceptor) acquireLockGuard(_ context.Context, msg message.
 				r.txnManager.FailTxnAtVChannel("")
 				r.glock.Unlock()
 			}
-		} else {
+		} else if !funcutil.IsControlChannel(vchannel) {
 			r.vchannelLocker.Lock(vchannel)
 			return func() {
 				// For exclusive messages, we need to fail all transactions at the vchannel.
@@ -52,6 +53,11 @@ func (r *lockAppendInterceptor) acquireLockGuard(_ context.Context, msg message.
 				r.vchannelLocker.Unlock(vchannel)
 			}
 		}
+		// Collection-scoped DDL is exclusive on its data VChannels. Its
+		// control-channel copy uses the shared path below so DDL with
+		// non-conflicting resource keys can append concurrently. Conflicting
+		// DDL is serialized by the broadcaster resource-key lock. PChannel-level
+		// messages already acquire the global write lock above.
 	}
 	r.glock.RLock()
 	r.vchannelLocker.RLock(vchannel)

--- a/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
 )
 
@@ -29,6 +30,30 @@ func newTestInterceptor() *lockAppendInterceptor {
 }
 
 func TestAcquireLockGuard(t *testing.T) {
+	t.Run("PChannelLevelOnControlChannel", func(t *testing.T) {
+		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
+		defer mocker.UnPatch()
+
+		interceptor := newTestInterceptor()
+		controlChannel := funcutil.GetControlChannel(testPChannelName)
+		broadcast := message.NewFlushAllMessageBuilderV2().
+			WithHeader(&message.FlushAllMessageHeader{}).
+			WithBody(&message.FlushAllMessageBody{}).
+			WithClusterLevelBroadcast(message.ClusterChannels{
+				Channels:       []string{testPChannelName},
+				ControlChannel: controlChannel,
+			}).
+			MustBuildBroadcast()
+		broadcast.WithBroadcastID(1)
+		msg := broadcast.SplitIntoMutableMessage()[0]
+
+		guard := interceptor.acquireLockGuard(context.Background(), msg)
+		assert.False(t, interceptor.glock.TryRLock(), "pchannel-level message should hold the global write lock")
+		guard()
+		assert.True(t, interceptor.glock.TryRLock())
+		interceptor.glock.RUnlock()
+	})
+
 	// Test: Exclusive message with pchannel name as vchannel should acquire global write lock (existing behavior).
 	t.Run("ExclusiveWithPChannelName", func(t *testing.T) {
 		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
@@ -69,6 +94,30 @@ func TestAcquireLockGuard(t *testing.T) {
 		// Other vchannels should not be blocked.
 		assert.True(t, interceptor.vchannelLocker.TryLock("other-vchannel"), "other vchannels should not be blocked")
 		interceptor.vchannelLocker.Unlock("other-vchannel")
+		guard()
+	})
+
+	t.Run("ExclusiveOnControlChannel", func(t *testing.T) {
+		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
+		defer mocker.UnPatch()
+
+		interceptor := newTestInterceptor()
+		controlChannel := funcutil.GetControlChannel(testPChannelName)
+		msg := message.NewCreateCollectionMessageBuilderV1().
+			WithVChannel(controlChannel).
+			WithHeader(&messagespb.CreateCollectionMessageHeader{CollectionId: 1}).
+			WithBody(&msgpb.CreateCollectionRequest{}).
+			MustBuildMutable()
+
+		guard := interceptor.acquireLockGuard(context.Background(), msg)
+		// A control-channel copy of collection DDL uses shared locks so another
+		// non-conflicting DDL can append concurrently.
+		assert.False(t, interceptor.glock.TryLock(), "global read lock should be held")
+		assert.True(t, interceptor.glock.TryRLock(), "another global read lock should succeed")
+		interceptor.glock.RUnlock()
+		assert.False(t, interceptor.vchannelLocker.TryLock(controlChannel), "control channel read lock should be held")
+		assert.True(t, interceptor.vchannelLocker.TryRLock(controlChannel), "another control channel read lock should succeed")
+		interceptor.vchannelLocker.RUnlock(controlChannel)
 		guard()
 	})
 

--- a/internal/util/flowgraph/input_node.go
+++ b/internal/util/flowgraph/input_node.go
@@ -19,8 +19,10 @@ package flowgraph
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
@@ -39,18 +41,83 @@ const (
 	CloseImmediately bool = false
 )
 
+type inputNodeMetricsKey struct {
+	nodeID       string
+	dataType     string
+	collectionID string
+}
+
+type inputNodeMetricsHandle struct {
+	consumeMsgCount    prometheus.Counter
+	consumeTimeTickLag prometheus.Gauge
+	references         int
+}
+
+var inputNodeMetricsCache = struct {
+	sync.Mutex
+	handles map[inputNodeMetricsKey]*inputNodeMetricsHandle
+}{
+	handles: make(map[inputNodeMetricsKey]*inputNodeMetricsHandle),
+}
+
+func acquireInputNodeMetrics(key inputNodeMetricsKey) *inputNodeMetricsHandle {
+	inputNodeMetricsCache.Lock()
+	defer inputNodeMetricsCache.Unlock()
+
+	handle, ok := inputNodeMetricsCache.handles[key]
+	if !ok {
+		handle = &inputNodeMetricsHandle{
+			consumeMsgCount: metrics.DataNodeConsumeMsgCount.WithLabelValues(
+				key.nodeID,
+				key.dataType,
+				key.collectionID,
+			),
+			consumeTimeTickLag: metrics.DataNodeConsumeTimeTickLag.WithLabelValues(
+				key.nodeID,
+				key.dataType,
+				key.collectionID,
+			),
+		}
+		inputNodeMetricsCache.handles[key] = handle
+	}
+	handle.references++
+	return handle
+}
+
+func releaseInputNodeMetrics(key inputNodeMetricsKey) {
+	inputNodeMetricsCache.Lock()
+	defer inputNodeMetricsCache.Unlock()
+
+	handle, ok := inputNodeMetricsCache.handles[key]
+	if !ok {
+		return
+	}
+	handle.references--
+	if handle.references > 0 {
+		return
+	}
+
+	metrics.DataNodeConsumeMsgCount.DeleteLabelValues(key.nodeID, key.dataType, key.collectionID)
+	metrics.DataNodeConsumeTimeTickLag.DeleteLabelValues(key.nodeID, key.dataType, key.collectionID)
+	delete(inputNodeMetricsCache.handles, key)
+}
+
 // InputNode is the entry point of flowgragh
 type InputNode struct {
 	BaseNode
-	input           <-chan *msgstream.MsgPack
-	lastMsg         *msgstream.MsgPack
-	name            string
-	role            string
-	nodeID          int64
-	nodeIDStr       string
-	collectionID    int64
-	collectionIDStr string
-	dataType        string
+	input              <-chan *msgstream.MsgPack
+	lastMsg            *msgstream.MsgPack
+	name               string
+	role               string
+	nodeID             int64
+	nodeIDStr          string
+	collectionID       int64
+	collectionIDStr    string
+	dataType           string
+	consumeMsgCount    prometheus.Counter
+	consumeTimeTickLag prometheus.Gauge
+	metricsKey         inputNodeMetricsKey
+	metricsReleaseOnce sync.Once
 
 	closeGracefully *atomic.Bool
 
@@ -79,6 +146,15 @@ func (inNode *InputNode) SetCloseMethod(gracefully bool) {
 		mlog.String("node", inNode.Name()),
 		mlog.Int64("collection", inNode.collectionID),
 		mlog.Bool("gracefully", gracefully))
+}
+
+func (inNode *InputNode) Free() {
+	if inNode.role != typeutil.DataNodeRole {
+		return
+	}
+	inNode.metricsReleaseOnce.Do(func() {
+		releaseInputNodeMetrics(inNode.metricsKey)
+	})
 }
 
 // Operate consume a message pack from msgstream and return
@@ -117,13 +193,8 @@ func (inNode *InputNode) Operate(in []Msg) []Msg {
 	inNode.lastMsg = msgPack
 	sub := tsoutil.SubByNow(msgPack.EndTs)
 	if inNode.role == typeutil.DataNodeRole {
-		metrics.DataNodeConsumeMsgCount.
-			WithLabelValues(inNode.nodeIDStr, inNode.dataType, inNode.collectionIDStr).
-			Inc()
-
-		metrics.DataNodeConsumeTimeTickLag.
-			WithLabelValues(inNode.nodeIDStr, inNode.dataType, inNode.collectionIDStr).
-			Set(float64(sub))
+		inNode.consumeMsgCount.Inc()
+		inNode.consumeTimeTickLag.Set(float64(sub))
 	}
 
 	var spans []trace.Span
@@ -187,18 +258,31 @@ func NewInputNode(input <-chan *msgstream.MsgPack, nodeName string, maxQueueLeng
 	baseNode.SetMaxQueueLength(maxQueueLength)
 	baseNode.SetMaxParallelism(maxParallelism)
 
-	return &InputNode{
+	nodeIDStr := fmt.Sprint(nodeID)
+	collectionIDStr := fmt.Sprint(collectionID)
+	node := &InputNode{
 		BaseNode:            baseNode,
 		input:               input,
 		name:                nodeName,
 		role:                role,
 		nodeID:              nodeID,
-		nodeIDStr:           fmt.Sprint(nodeID),
+		nodeIDStr:           nodeIDStr,
 		collectionID:        collectionID,
-		collectionIDStr:     fmt.Sprint(collectionID),
+		collectionIDStr:     collectionIDStr,
 		dataType:            dataType,
 		closeGracefully:     atomic.NewBool(CloseImmediately),
 		skipCount:           0,
 		lastNotTimetickTime: time.Now(),
 	}
+	if role == typeutil.DataNodeRole {
+		node.metricsKey = inputNodeMetricsKey{
+			nodeID:       nodeIDStr,
+			dataType:     dataType,
+			collectionID: collectionIDStr,
+		}
+		handle := acquireInputNodeMetrics(node.metricsKey)
+		node.consumeMsgCount = handle.consumeMsgCount
+		node.consumeTimeTickLag = handle.consumeTimeTickLag
+	}
+	return node
 }

--- a/internal/util/flowgraph/input_node_test.go
+++ b/internal/util/flowgraph/input_node_test.go
@@ -23,9 +23,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/mq/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
@@ -75,6 +77,38 @@ func Test_NewInputNode(t *testing.T) {
 	assert.Equal(t, node.maxParallelism, maxParallelism)
 }
 
+func TestInputNodeMetricsHandlesSurvivePartialCleanup(t *testing.T) {
+	metrics.DataNodeConsumeMsgCount.Reset()
+	metrics.DataNodeConsumeTimeTickLag.Reset()
+
+	const (
+		nodeID       = int64(10101)
+		collectionID = int64(20202)
+	)
+	node1 := NewInputNode(nil, "input-node-1", 0, 1, typeutil.DataNodeRole, nodeID, collectionID, metrics.AllLabel)
+	node2 := NewInputNode(nil, "input-node-2", 0, 1, typeutil.DataNodeRole, nodeID, collectionID, metrics.AllLabel)
+
+	node1.consumeMsgCount.Inc()
+	node1.consumeTimeTickLag.Set(100)
+	node1.Free()
+	node1.Free()
+
+	// Closing one channel still runs collection cleanup. The surviving InputNode
+	// must keep updating the exported AllLabel metrics with its cached handles.
+	metrics.CleanupDataNodeCollectionMetrics(nodeID, collectionID, "unused-channel")
+	node2.consumeMsgCount.Inc()
+	node2.consumeTimeTickLag.Set(200)
+
+	assert.Equal(t, float64(2), testutil.ToFloat64(node2.consumeMsgCount))
+	assert.Equal(t, float64(200), testutil.ToFloat64(node2.consumeTimeTickLag))
+	assert.Equal(t, 1, testutil.CollectAndCount(metrics.DataNodeConsumeMsgCount))
+	assert.Equal(t, 1, testutil.CollectAndCount(metrics.DataNodeConsumeTimeTickLag))
+
+	node2.Free()
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataNodeConsumeMsgCount))
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataNodeConsumeTimeTickLag))
+}
+
 func Test_InputNodeSkipMode(t *testing.T) {
 	t.Setenv("ROCKSMQ_PATH", "/tmp/MilvusTest/FlowGraph/Test_InputNodeSkipMode")
 	factory := dependency.NewDefaultFactory(true)
@@ -93,7 +127,7 @@ func Test_InputNodeSkipMode(t *testing.T) {
 	nodeName := "input_node"
 	dispatcher := msgstream.NewSimpleMsgDispatcher(msgStream, func(pm msgstream.ConsumeMsg) bool { return true })
 	inputNode := NewInputNode(dispatcher.Chan(), nodeName, 100, 100, typeutil.DataNodeRole, 0, 0, "")
-	defer inputNode.Close()
+	defer inputNode.Free()
 
 	outputCount := 0
 	go func() {

--- a/pkg/metrics/datanode_metrics.go
+++ b/pkg/metrics/datanode_metrics.go
@@ -475,15 +475,9 @@ func registerDataNodeOnce(registry *prometheus.Registry) {
 }
 
 func CleanupDataNodeCollectionMetrics(nodeID int64, collectionID int64, channel string) {
-	DataNodeConsumeTimeTickLag.
-		Delete(
-			prometheus.Labels{
-				nodeIDLabelName:       fmt.Sprint(nodeID),
-				msgTypeLabelName:      AllLabel,
-				collectionIDLabelName: fmt.Sprint(collectionID),
-			})
-
-	for _, label := range []string{AllLabel, DeleteLabel, InsertLabel} {
+	// The InputNode owns the collection-level AllLabel metrics. They are
+	// deleted when the last InputNode using the cached handles is closed.
+	for _, label := range []string{DeleteLabel, InsertLabel} {
 		DataNodeConsumeMsgCount.
 			Delete(
 				prometheus.Labels{

--- a/pkg/streaming/util/message/message_type.go
+++ b/pkg/streaming/util/message/message_type.go
@@ -148,6 +148,8 @@ func (t MessageType) Valid() bool {
 // IsExclusiveRequired checks if the MessageType is exclusive append required.
 // An exclusive required message type is that the message's timetick should keep same order with message id.
 // And when the message is appending, other messages with the same vchannel cannot append concurrently.
+// Collection-scoped broadcast messages apply this requirement to their data VChannel copies. Their control-channel
+// copies are ordered by broadcaster resource keys so non-conflicting DDL can append concurrently.
 func (t MessageType) IsExclusiveRequired() bool {
 	return messageTypePropertiesMap[t].ExclusiveRequired
 }


### PR DESCRIPTION
issue: #51333
related: #51255

## Summary

- cache and reference-count the existing DataNode InputNode metric handles, keeping collection-level series exported until the last channel is released
- allow collection-scoped CChannel DDL copies with non-conflicting ResourceKeys to append concurrently, while preserving exclusive data VChannel locks and PChannel-level global barriers
- avoid holding the RootCoord ddLock during AddCollection catalog I/O and recheck under the write lock before publishing in-memory metadata

## Scope

- no new metrics, histograms, or profiling instrumentation
- only optimizes and fixes the lifecycle of existing metrics
- keeps the three changes as separate commits in this single PR

## Verification

- go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/flowgraph ./internal/flushcommon/pipeline
- go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/streamingnode/server/wal/interceptors/lock
- go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/rootcoord/...
- cd pkg && go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./metrics ./streaming/util/message
- targeted race tests for the InputNode metric lifecycle, CChannel lock behavior, and AddCollection lock release