### PR TITLE
fix: [cp2.6]correct the CDC replication lag metric

### DIFF
--- a/internal/cdc/replication/replicatemanager/channel_replicator.go
+++ b/internal/cdc/replication/replicatemanager/channel_replicator.go
@@ -77,6 +77,7 @@ func NewChannelReplicator(channel *meta.ReplicateChannel) Replicator {
 }
 
 func (r *channelReplicator) StartReplication() {
+	r.initLastReplicatedTimeTickMetric()
 	logger := log.With(zap.String("key", r.channel.Key), zap.Int64("modRevision", r.channel.ModRevision))
 	logger.Info("start replicate channel")
 	go func() {
@@ -110,6 +111,21 @@ func (r *channelReplicator) StartReplication() {
 	}()
 }
 
+// initLastReplicatedTimeTickMetric seeds the lag series synchronously, before
+// any network dependency, so that the series exists even while init() keeps
+// failing against an unreachable target — an absent series reads as zero lag
+// on the dashboard. The initialized (creation-time) checkpoint is a
+// conservative bound: real progress is at or after it, so the seed can only
+// overstate the lag. init() overwrites it with the target-confirmed
+// checkpoint once the target is reachable.
+func (r *channelReplicator) initLastReplicatedTimeTickMetric() {
+	checkpoint := r.channel.Value.GetInitializedCheckpoint()
+	if checkpoint == nil {
+		return
+	}
+	replicatestream.InitLastReplicatedTimeTick(r.channel.Value, checkpoint.GetTimeTick())
+}
+
 func (r *channelReplicator) init() error {
 	logger := log.With(zap.String("key", r.channel.Key), zap.Int64("modRevision", r.channel.ModRevision))
 	// init target client
@@ -139,6 +155,11 @@ func (r *channelReplicator) init() error {
 		})
 		r.msgScanner = scanner
 		r.msgChan = ch
+		// Seed the last replicated time tick from the resume checkpoint so that
+		// after a CDC pod restart the lag metric reports the real backlog
+		// immediately, instead of the series being absent (which reads as 0)
+		// until the first message is replicated.
+		replicatestream.InitLastReplicatedTimeTick(r.channel.Value, cp.TimeTick)
 		logger.Info("scanner initialized", zap.Any("checkpoint", cp))
 	}
 	// init replicate stream client
@@ -172,6 +193,10 @@ func (r *channelReplicator) startConsumeLoop() {
 				if util.IsReplicationRemovedByAlterReplicateConfigMessage(msg, r.channel.Value) {
 					logger.Info("replication removed, stop consume loop")
 					r.streamClient.BlockUntilFinish()
+					// The replication is genuinely removed, delete its lag
+					// series. Deleting after BlockUntilFinish ensures no
+					// in-flight confirm re-creates the series afterwards.
+					replicatestream.DeleteLastReplicatedTimeTick(r.channel.Value)
 					return
 				}
 			}

--- a/internal/cdc/replication/replicatemanager/channel_replicator_test.go
+++ b/internal/cdc/replication/replicatemanager/channel_replicator_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
 
@@ -32,8 +33,14 @@ import (
 	"github.com/milvus-io/milvus/internal/cdc/replication/replicatestream"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message/adaptor"
 	pulsar2 "github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/pulsar"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/syncutil"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 )
 
 func newMockPulsarMessageID() *commonpb.MessageID {
@@ -92,4 +99,85 @@ func TestChannelReplicator_StartReplicateChannel(t *testing.T) {
 	replicator.StartReplication()
 	time.Sleep(200 * time.Millisecond)
 	replicator.StopReplication()
+}
+
+// TestChannelReplicatorConsumeLoopDeletesLagSeriesOnRemoval verifies the
+// in-band removal path: when the consume loop replicates an
+// AlterReplicateConfig message that removes this replication, the lag series
+// is deleted.
+func TestChannelReplicatorConsumeLoopDeletesLagSeriesOnRemoval(t *testing.T) {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.ClusterPrefix.Key, "current-cluster")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.ClusterPrefix.Key)
+
+	source, target := "TestRemoval-source", "TestRemoval-target"
+	replicateInfo := &streamingpb.ReplicatePChannelMeta{
+		SourceChannelName: source,
+		TargetChannelName: target,
+		TargetCluster:     &commonpb.MilvusCluster{ClusterId: "removed-target-cluster"},
+	}
+
+	// An AlterReplicateConfig whose topology no longer contains the
+	// current->target edge, i.e. this replication is removed.
+	msg := message.NewAlterReplicateConfigMessageBuilderV2().
+		WithHeader(&message.AlterReplicateConfigMessageHeader{
+			ReplicateConfiguration: &commonpb.ReplicateConfiguration{
+				Clusters: []*commonpb.MilvusCluster{
+					{
+						ClusterId:       "current-cluster",
+						ConnectionParam: &commonpb.ConnectionParam{Uri: "localhost:19530"},
+						Pchannels:       []string{source},
+					},
+				},
+			},
+		}).
+		WithBody(&message.AlterReplicateConfigMessageBody{}).
+		WithAllVChannel().
+		MustBuildMutable().
+		WithLastConfirmedUseMessageID().
+		WithTimeTick(1).
+		IntoImmutableMessage(pulsar2.NewPulsarID(pulsar.EarliestMessageID()))
+
+	rs := replicatestream.NewMockReplicateStreamClient(t)
+	rs.EXPECT().Replicate(mock.Anything).Return(nil)
+	rs.EXPECT().BlockUntilFinish().Return()
+
+	replicator := &channelReplicator{
+		channel: &meta.ReplicateChannel{
+			Key:         "removal-key",
+			ModRevision: 1,
+			Value:       replicateInfo,
+		},
+		streamClient:  rs,
+		msgChan:       make(adaptor.ChanMessageHandler),
+		asyncNotifier: syncutil.NewAsyncTaskNotifier[struct{}](),
+	}
+	replicatestream.InitLastReplicatedTimeTick(replicateInfo, tsoutil.ComposeTSByTime(time.Now(), 0))
+
+	go func() { replicator.msgChan <- msg }()
+	replicator.startConsumeLoop()
+
+	assert.False(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}
+
+func TestChannelReplicatorInitMetricFromInitializedCheckpoint(t *testing.T) {
+	source, target := "TestInitMetric-source", "TestInitMetric-target"
+	checkpoint := tsoutil.ComposeTSByTime(time.Now().Add(-5*time.Minute), 0)
+	defer metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target)
+
+	replicator := NewChannelReplicator(&meta.ReplicateChannel{
+		Value: &streamingpb.ReplicatePChannelMeta{
+			SourceChannelName: source,
+			TargetChannelName: target,
+			InitializedCheckpoint: &commonpb.ReplicateCheckpoint{
+				TimeTick: checkpoint,
+			},
+		},
+	})
+	channelReplicator, ok := replicator.(*channelReplicator)
+	assert.True(t, ok)
+
+	channelReplicator.initLastReplicatedTimeTickMetric()
+
+	got := testutil.ToFloat64(metrics.CDCLastReplicatedTimeTick.WithLabelValues(source, target))
+	assert.InDelta(t, tsoutil.PhysicalTimeSeconds(checkpoint), got, 1)
 }

--- a/internal/cdc/replication/replicatemanager/replicate_manager.go
+++ b/internal/cdc/replication/replicatemanager/replicate_manager.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/cdc/meta"
+	"github.com/milvus-io/milvus/internal/cdc/replication/replicatestream"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -76,21 +77,26 @@ func (r *replicateManager) CreateReplicator(channel *meta.ReplicateChannel) {
 func (r *replicateManager) RemoveReplicator(key string, modRevision int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.removeReplicatorInternal(key, modRevision)
+	channel, removed := r.removeReplicatorInternal(key, modRevision)
+	if removed && channel != nil {
+		replicatestream.DeleteLastReplicatedTimeTick(channel.Value)
+	}
 }
 
-func (r *replicateManager) removeReplicatorInternal(key string, modRevision int64) {
+func (r *replicateManager) removeReplicatorInternal(key string, modRevision int64) (*meta.ReplicateChannel, bool) {
 	logger := log.With(zap.String("key", key), zap.Int64("modRevision", modRevision))
 	repKey := buildReplicatorKey(key, modRevision)
 	replicator, ok := r.replicators[repKey]
 	if !ok {
 		logger.Info("replicator not found, skip remove")
-		return
+		return nil, false
 	}
+	channel := r.replicatorChannels[repKey]
 	replicator.StopReplication()
 	delete(r.replicators, repKey)
 	delete(r.replicatorChannels, repKey)
 	logger.Info("removed replicator for replicate pchannel")
+	return channel, true
 }
 
 func (r *replicateManager) RemoveOutdatedReplicators(aliveChannels []*meta.ReplicateChannel) {
@@ -104,6 +110,14 @@ func (r *replicateManager) RemoveOutdatedReplicators(aliveChannels []*meta.Repli
 	for repKey := range r.replicators {
 		if _, ok := alivesMap[repKey]; !ok {
 			channel := r.replicatorChannels[repKey]
+			if channel == nil {
+				continue
+			}
+			// No lag-series deletion here: a replicate pchannel key is only
+			// deleted after the replicator's in-band removal path
+			// (handleAlterReplicateConfigMessage) confirmed the removal and
+			// deleted the series; out-of-band key deletions are covered by
+			// the etcd DELETE event path (RemoveReplicator).
 			r.removeReplicatorInternal(channel.Key, channel.ModRevision)
 		}
 	}

--- a/internal/cdc/replication/replicatemanager/replicate_manager_test.go
+++ b/internal/cdc/replication/replicatemanager/replicate_manager_test.go
@@ -18,16 +18,45 @@ package replicatemanager
 
 import (
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus/internal/cdc/cluster"
 	"github.com/milvus-io/milvus/internal/cdc/meta"
+	"github.com/milvus-io/milvus/internal/cdc/replication/replicatestream"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
 )
+
+type testReplicator struct {
+	stopped bool
+}
+
+func (*testReplicator) StartReplication() {}
+
+func (r *testReplicator) StopReplication() {
+	r.stopped = true
+}
+
+func newTestReplicateChannel(key string, revision int64, source, target string) *meta.ReplicateChannel {
+	return &meta.ReplicateChannel{
+		Key:         key,
+		ModRevision: revision,
+		Value: &streamingpb.ReplicatePChannelMeta{
+			SourceChannelName: source,
+			TargetChannelName: target,
+			TargetCluster: &commonpb.MilvusCluster{
+				ClusterId: "test-target-cluster",
+			},
+		},
+	}
+}
 
 func TestReplicateManager_CreateReplicator(t *testing.T) {
 	paramtable.Get().Save(paramtable.Get().CommonCfg.ClusterPrefix.Key, "test-source")
@@ -90,4 +119,44 @@ func TestReplicateManager_CreateReplicator(t *testing.T) {
 	replicator1, exists := manager.replicators[buildReplicatorKey(key, 0)]
 	assert.True(t, exists)
 	assert.NotNil(t, replicator1)
+}
+
+func TestReplicateManagerRemoveReplicatorDeletesLagSeries(t *testing.T) {
+	source, target := "remove-source", "remove-target"
+	channel := newTestReplicateChannel("remove-key", 10, source, target)
+	manager := NewReplicateManager()
+	repKey := buildReplicatorKey(channel.Key, channel.ModRevision)
+	replicator := &testReplicator{}
+	manager.replicators[repKey] = replicator
+	manager.replicatorChannels[repKey] = channel
+	replicatestream.InitLastReplicatedTimeTick(
+		channel.Value,
+		tsoutil.ComposeTSByTime(time.Now(), 0),
+	)
+
+	manager.RemoveReplicator(channel.Key, channel.ModRevision)
+
+	assert.True(t, replicator.stopped)
+	assert.False(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}
+
+func TestRemoveOutdatedReplicatorsKeepsLiveLagSeries(t *testing.T) {
+	source, target := "replace-source", "replace-target"
+	oldChannel := newTestReplicateChannel("replace-key", 10, source, target)
+	newChannel := newTestReplicateChannel("replace-key", 11, source, target)
+	manager := NewReplicateManager()
+	oldKey := buildReplicatorKey(oldChannel.Key, oldChannel.ModRevision)
+	oldReplicator := &testReplicator{}
+	manager.replicators[oldKey] = oldReplicator
+	manager.replicatorChannels[oldKey] = oldChannel
+
+	newValue := tsoutil.ComposeTSByTime(time.Now(), 0)
+	replicatestream.InitLastReplicatedTimeTick(newChannel.Value, newValue)
+	defer metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target)
+
+	manager.RemoveOutdatedReplicators([]*meta.ReplicateChannel{newChannel})
+
+	assert.True(t, oldReplicator.stopped)
+	got := testutil.ToFloat64(metrics.CDCLastReplicatedTimeTick.WithLabelValues(source, target))
+	assert.InDelta(t, tsoutil.PhysicalTimeSeconds(newValue), got, 1)
 }

--- a/internal/cdc/replication/replicatestream/metrics.go
+++ b/internal/cdc/replication/replicatestream/metrics.go
@@ -54,11 +54,41 @@ func NewReplicateMetrics(replicateInfo *streamingpb.ReplicatePChannelMeta) Repli
 	}
 }
 
-func (m *replicateMetrics) UpdateLastReplicatedTimeTick(ts uint64) {
+func setLastReplicatedTimeTick(source, target string, ts uint64) {
 	metrics.CDCLastReplicatedTimeTick.WithLabelValues(
+		source,
+		target,
+	).Set(tsoutil.PhysicalTimeSeconds(ts))
+}
+
+func (m *replicateMetrics) UpdateLastReplicatedTimeTick(ts uint64) {
+	setLastReplicatedTimeTick(
 		m.replicateInfo.GetSourceChannelName(),
 		m.replicateInfo.GetTargetChannelName(),
-	).Set(tsoutil.PhysicalTimeSeconds(ts))
+		ts,
+	)
+}
+
+// InitLastReplicatedTimeTick initializes the last replicated time tick gauge
+// from a known checkpoint. Callers may seed it conservatively and later
+// overwrite it with the target-confirmed position.
+func InitLastReplicatedTimeTick(info *streamingpb.ReplicatePChannelMeta, ts uint64) {
+	if info == nil || ts == 0 {
+		return
+	}
+	setLastReplicatedTimeTick(info.GetSourceChannelName(), info.GetTargetChannelName(), ts)
+}
+
+// DeleteLastReplicatedTimeTick deletes the lag series for a replication task
+// that has been genuinely removed.
+func DeleteLastReplicatedTimeTick(info *streamingpb.ReplicatePChannelMeta) {
+	if info == nil {
+		return
+	}
+	metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(
+		info.GetSourceChannelName(),
+		info.GetTargetChannelName(),
+	)
 }
 
 func (m *replicateMetrics) StartReplicate(msg message.ImmutableMessage) {
@@ -134,6 +164,10 @@ func (m *replicateMetrics) OnConnect() {
 	).Inc()
 }
 
+// OnClose deletes the connection series of the target cluster.
+// CDCStreamRPCConnections is labeled by (target_cluster, status) only, so
+// this removes the series shared by every channel replicating to that
+// cluster, not just the ones owned by this stream instance.
 func (m *replicateMetrics) OnClose() {
 	metrics.CDCStreamRPCConnections.DeletePartialMatch(prometheus.Labels{
 		metrics.CDCLabelTargetCluster: m.replicateInfo.GetTargetCluster().GetClusterId(),

--- a/internal/cdc/replication/replicatestream/metrics_test.go
+++ b/internal/cdc/replication/replicatestream/metrics_test.go
@@ -1,0 +1,92 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replicatestream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
+)
+
+func newTestReplicateInfo(source, target string) *streamingpb.ReplicatePChannelMeta {
+	return &streamingpb.ReplicatePChannelMeta{
+		SourceChannelName: source,
+		TargetChannelName: target,
+		TargetCluster: &commonpb.MilvusCluster{
+			ClusterId: "test-cluster",
+		},
+	}
+}
+
+// TestInitLastReplicatedTimeTick verifies that seeding from the resume
+// checkpoint reports the real backlog (checkpoint physical time), so a
+// restarted CDC pod does not read as 0.
+func TestInitLastReplicatedTimeTick(t *testing.T) {
+	source, target := "TestInit-source", "TestInit-target"
+	defer metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target)
+
+	// A checkpoint 300s in the past -> the gauge reports that physical time,
+	// which against wall-clock now is a ~300s backlog, not 0.
+	checkpoint := tsoutil.ComposeTSByTime(time.Now().Add(-300*time.Second), 0)
+	InitLastReplicatedTimeTick(newTestReplicateInfo(source, target), checkpoint)
+
+	got := testutil.ToFloat64(metrics.CDCLastReplicatedTimeTick.WithLabelValues(source, target))
+	assert.InDelta(t, tsoutil.PhysicalTimeSeconds(checkpoint), got, 1)
+	assert.InDelta(t, 300, float64(time.Now().Unix())-got, 5)
+}
+
+func TestInitLastReplicatedTimeTickIgnoresZero(t *testing.T) {
+	source, target := "TestInitZero-source", "TestInitZero-target"
+
+	InitLastReplicatedTimeTick(newTestReplicateInfo(source, target), 0)
+
+	assert.False(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}
+
+func TestInitLastReplicatedTimeTickIgnoresNilInfo(t *testing.T) {
+	assert.NotPanics(t, func() {
+		InitLastReplicatedTimeTick(nil, tsoutil.ComposeTSByTime(time.Now(), 0))
+	})
+}
+
+func TestReplicateMetricsOnCloseKeepsLastReplicatedSeries(t *testing.T) {
+	source, target := "TestOnClose-source", "TestOnClose-target"
+
+	m := NewReplicateMetrics(newTestReplicateInfo(source, target))
+	m.UpdateLastReplicatedTimeTick(tsoutil.ComposeTSByTime(time.Now(), 0))
+
+	m.OnClose()
+
+	assert.True(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}
+
+func TestDeleteLastReplicatedTimeTickDeletesExactSeries(t *testing.T) {
+	source, target := "TestDelete-source", "TestDelete-target"
+	info := newTestReplicateInfo(source, target)
+	InitLastReplicatedTimeTick(info, tsoutil.ComposeTSByTime(time.Now(), 0))
+
+	DeleteLastReplicatedTimeTick(info)
+
+	assert.False(t, metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target))
+}


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #51049
issue: #50633
issue: #51048

## Summary

Cherry-picked from master PR #51049 (open - preemptive backport).

Backports the CDC lag metric lifecycle fix:
- Seed the lag gauge from InitializedCheckpoint before target access.
- Overwrite the seed with the target-confirmed checkpoint.
- Ignore nil and zero checkpoints.
- Delete the lag series only on genuine ReplicateManager removal.
- Preserve the live lag series during outdated revision cleanup.

## 2.6 adaptations

- Kept the 2.6 pkg/v2, go-api/v2, and log plus zap APIs.
- Omitted the master-only documentation change as requested for 2.6.

**Note**: Original PR #51049 is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] Code and test file counts and line counts match the master PR after excluding documentation
- [x] Per-file changed lines match after v3-to-v2 import normalization
- [x] No conflict markers
- [x] DCO sign-off
- [ ] make static-check (skipped by cherry-pick workflow)