### PR TITLE
test: run heavy snapshot / external-table go-sdk cases serially

### DIFF
--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -449,7 +449,10 @@ func indexAndLoadCollectionWithScalarAndVector(ctx context.Context, t *testing.T
 // --- E2E Tests ---
 
 func TestExternalCollectionSnapshotRestoreAndAccess(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -553,7 +556,10 @@ func TestExternalCollectionSnapshotRestoreAndAccess(t *testing.T) {
 //  4. Wait for refresh to complete
 //  5. Verify the generated segment count and total row count
 func TestRefreshExternalCollectionAndVerifySegments(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -837,7 +843,10 @@ func TestExternalCollectionParquetCompressionCodecs(t *testing.T) {
 //  7. Query with filter and output fields
 //  8. Search with vector
 func TestExternalCollectionLoadAndQuery(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1082,7 +1091,10 @@ indexAndLoad:
 }
 
 func TestExternalCollectionNullableFloatVectorTakeOutput(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1330,7 +1342,10 @@ func TestExternalCollectionSparseVectorCurrentlyRejected(t *testing.T) {
 //  2. Remove data1, add data2 (ids 2000-2299) → 800 rows
 //  3. Verify: data0 intact, data1 gone, data2 present
 func TestExternalCollectionIncrementalRefresh(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*600) // 10 min for two refresh+load cycles
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1491,7 +1506,10 @@ func TestExternalCollectionIncrementalRefresh(t *testing.T) {
 // adding an external field to an already refreshed external collection patches
 // existing same-fragment segments and returns correct values for the new field.
 func TestRefreshExternalCollectionAfterAddColumnReturnsCorrectData(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*600)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1637,7 +1655,10 @@ func assertExternalScoreRows(t *testing.T, result client.ResultSet, expected map
 // TestExternalCollectionMultipleDataTypes tests external collections with various data types:
 // Bool, Int8, Int16, Int32, Int64, Float, Double, VarChar, FloatVector
 func TestExternalCollectionMultipleDataTypes(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -2077,7 +2098,10 @@ func mapToEnvSlice(m map[string]string) []string {
 //  6. Query with filter
 //  7. Search with vector
 func TestExternalCollectionLanceFormat(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*600) // 10 min for lance operations
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -2371,7 +2395,10 @@ func buildVortexMultiTypeExternalSchema(collName, externalSource, externalSpec s
 //  6. Query with filter
 //  7. Search with vector
 func TestExternalCollectionVortexFormat(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*600)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -2598,7 +2625,10 @@ func TestExternalCollectionVortexFormat(t *testing.T) {
 // Vortex 0.56.0 cannot write Arrow FixedSizeBinary, so binary/half/int8 vector
 // fields remain covered by the parquet and lance multi-type tests.
 func TestExternalCollectionMultipleDataTypesVortex(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -2642,7 +2672,10 @@ func TestExternalCollectionMultipleDataTypesVortex(t *testing.T) {
 // format. Exercises the same multi-type schema and shared
 // refresh/index/load/query/search verification across the lance bridge.
 func TestExternalCollectionMultipleDataTypesLance(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -2687,7 +2720,10 @@ func TestExternalCollectionMultipleDataTypesLance(t *testing.T) {
 // types regardless of the output schema.  Vortex and Lance require schema-level
 // changes to support float32 list vectors (tracked separately).
 func TestExternalCollectionFloat32ListVector(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*600)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)

--- a/tests/go_client/testcases/snapshot_test.go
+++ b/tests/go_client/testcases/snapshot_test.go
@@ -126,7 +126,10 @@ func waitForAllIndexesBuilt(ctx context.Context, mc *base.MilvusClient, collName
 
 // TestCreateSnapshot tests creating a snapshot for a collection
 func TestCreateSnapshot(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -176,7 +179,10 @@ func TestCreateSnapshot(t *testing.T) {
 
 // TestSnapshotRestoreWithMultiSegment tests the complete snapshot restore workflow with data operations
 func TestSnapshotRestoreWithMultiSegment(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -315,7 +321,10 @@ func TestSnapshotRestoreWithMultiSegment(t *testing.T) {
 
 // TestSnapshotRestoreWithMultiShardMultiPartition tests the complete snapshot restore workflow with data operations
 func TestSnapshotRestoreWithMultiShardMultiPartition(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -465,7 +474,10 @@ func TestSnapshotRestoreWithMultiShardMultiPartition(t *testing.T) {
 
 // TestSnapshotRestoreWithMultiFields tests snapshot restore with all supported field types
 func TestSnapshotRestoreWithMultiFields(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -672,7 +684,10 @@ func TestSnapshotRestoreWithMultiFields(t *testing.T) {
 // TestSnapshotRestoreEmptyCollection tests snapshot and restore of an empty collection
 // Verifies that schema and indexes are preserved correctly without any data
 func TestSnapshotRestoreEmptyCollection(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -940,7 +955,10 @@ func TestSnapshotRestoreEmptyCollection(t *testing.T) {
 // This test verifies that JSON stats (both legacy json_key_index_log and new json_stats formats)
 // are correctly preserved and restored during snapshot operations
 func TestSnapshotRestoreWithJSONStats(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1153,7 +1171,10 @@ func TestSnapshotRestoreWithJSONStats(t *testing.T) {
 // TestSnapshotRestoreAfterDropPartitionAndCollection tests snapshot restore functionality
 // after dropping partitions and the entire collection
 func TestSnapshotRestoreAfterDropPartitionAndCollection(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1345,7 +1366,10 @@ func TestSnapshotRestoreAfterDropPartitionAndCollection(t *testing.T) {
 // Verifies that ListSnapshots with db-level filtering returns only snapshots
 // belonging to collections in the specified database.
 func TestSnapshotCrossDatabase(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1419,7 +1443,10 @@ func TestSnapshotCrossDatabase(t *testing.T) {
 // 3. Drop collection B, restore A1 again to collection C
 // 4. Verify both A and C can load and query/search
 func TestSnapshotRestoreDropAndRestoreAgain(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -1576,7 +1603,10 @@ func TestSnapshotRestoreDropAndRestoreAgain(t *testing.T) {
 // This covers the bug where CopySegmentResult.index_infos used fieldID as map key,
 // causing only the last index per field to survive (overwriting earlier ones).
 func TestSnapshotRestoreWithMultipleJSONPathIndexes(t *testing.T) {
-	t.Parallel()
+	// Heavy case (large data volume + minute-scale index/refresh/restore
+	// waits): intentionally NOT run in parallel. Under t.Parallel() it competes
+	// with the rest of the suite for the shared standalone cluster and flakes on
+	// those timeouts; keep it serial so it gets the resources it needs.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)


### PR DESCRIPTION
## What

Drop `t.Parallel()` from the heavy go_client cases in `snapshot_test.go` (10 cases) and `external_table_refresh_test.go` (12 cases), and mark each with a comment explaining why it must stay serial.

## Why

`t.Parallel()` was blanket-added to every go_client testcase in #49138. That is fine for the light cases, but the snapshot/restore and external-table refresh cases are heavy: they insert tens of thousands of vectors and then wait minutes for index build / snapshot / restore. Running them alongside the large parallel test swarm starves the shared standalone cluster, and they flake on their own index-build / restore timeouts, e.g.:

- `TestSnapshotRestoreWithMultiSegment` — timeout waiting for indexes to be built
- `TestSnapshotRestoreWithMultiFields` — timeout waiting for restore to complete

Go runs the non-parallel tests first (sequentially, each with the cluster to itself), then the parallel suite. Keeping these heavy cases serial gives them the resources they need while leaving the light parallel tests untouched. The trade is a little extra wall-clock for stability.

## Changes

- `tests/go_client/testcases/snapshot_test.go` — remove `t.Parallel()` from 10 heavy cases; add marker comment.
- `tests/go_client/testcases/external_table_refresh_test.go` — remove `t.Parallel()` from 12 heavy cases; add marker comment.

No test logic changed; `gofmt` clean, `go vet ./testcases/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
