### PR TITLE
test: fix flaky TestSnapshotRestoreWithMultiShardMultiPartition

### DIFF
--- a/tests/go_client/testcases/snapshot_test.go
+++ b/tests/go_client/testcases/snapshot_test.go
@@ -316,8 +316,8 @@ func TestSnapshotRestoreWithMultiSegment(t *testing.T) {
 // TestSnapshotRestoreWithMultiShardMultiPartition tests the complete snapshot restore workflow with data operations
 func TestSnapshotRestoreWithMultiShardMultiPartition(t *testing.T) {
 	// This resource-intensive case creates indexes across 3 shards and 10
-	// partitions. Keep it serial so package-level parallel tests do not starve
-	// the shared index and snapshot restore workers.
+	// partitions. Keep it serial so it is not starved by package-level parallel
+	// tests competing for the shared index and snapshot restore workers.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)

--- a/tests/go_client/testcases/snapshot_test.go
+++ b/tests/go_client/testcases/snapshot_test.go
@@ -315,7 +315,9 @@ func TestSnapshotRestoreWithMultiSegment(t *testing.T) {
 
 // TestSnapshotRestoreWithMultiShardMultiPartition tests the complete snapshot restore workflow with data operations
 func TestSnapshotRestoreWithMultiShardMultiPartition(t *testing.T) {
-	t.Parallel()
+	// This resource-intensive case creates indexes across 3 shards and 10
+	// partitions. Keep it serial so package-level parallel tests do not starve
+	// the shared index and snapshot restore workers.
 
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)


### PR DESCRIPTION
## What

Keep TestSnapshotRestoreWithMultiShardMultiPartition serial while the rest of the Go client package can continue to run in parallel. The test workload and its index/restore deadlines are unchanged.

## Root cause

This case creates 10 partitions across 3 shards, inserts two 30K-row phases, builds indexes, and restores a snapshot against the same Milvus instance used by other parallel Go client tests. Package-level t.Parallel allowed those tests to contend with this case for shared index and restore workers, making its fixed waits intermittently expire.

## Reproduction

- Target: TestSnapshotRestoreWithMultiShardMultiPartition
- Master: 4 failures in 88 real target executions under concurrent snapshot load
- Failure modes: 1 timeout waiting for indexes to be built (matching CI) and 3 timeout waiting for restore to complete
- Isolated baseline: 18/18 passed

## Verification

- Same total_runs after the fix: 88/88 target executions passed
- First 16 verification runs used the full snapshot-suite high-contention setup
- Remaining 72 runs used 8-way target plus parallel-peer paired execution
- All 10 snapshot tests passed in a normal single-process regression run (74.769s)

## Scope

This PR intentionally fixes the Jenkins-observed flaky target only. Synthetic extreme load also exposed timeout risk in sibling snapshot tests; broader grouping or serialization for those cases should be evaluated separately instead of expanding this targeted fix.

No data volume, shard count, partition count, or timeout was reduced to hide the failure.