### PR TITLE
fix: type the zero-hit chunk's $id array after the other chunks in MergeOp

### DIFF
--- a/internal/util/function/chain/operator_merge.go
+++ b/internal/util/function/chain/operator_merge.go
@@ -238,6 +238,10 @@ type scoreCollectFunc func(inputs []*DataFrame, chunkIdx int) (map[any]float32, 
 func (op *MergeOp) mergeWithScoreCollector(ctx *types.FuncContext, inputs []*DataFrame, collectFn scoreCollectFunc) (*DataFrame, error) {
 	numChunks := inputs[0].NumChunks()
 
+	// Resolved once for the whole merge: every chunk's $id array must share one
+	// arrow type, otherwise AddColumnFromChunks below cannot chunk them together.
+	idType := resolveIDType(inputs)
+
 	builder := NewDataFrameBuilder()
 	defer builder.Release()
 
@@ -264,7 +268,7 @@ func (op *MergeOp) mergeWithScoreCollector(ctx *types.FuncContext, inputs []*Dat
 		ids, scores, locs := sortAndExtractResults(idScores, idLocs, op.SortDescending())
 		newChunkSizes[chunkIdx] = int64(len(ids))
 
-		idArr, scoreArr, err := op.buildResultArrays(ctx, ids, scores)
+		idArr, scoreArr, err := op.buildResultArrays(ctx, ids, scores, idType)
 		if err != nil {
 			return nil, err
 		}
@@ -709,14 +713,41 @@ func compareIDs(a, b any) int {
 	}
 }
 
+// resolveIDType returns the arrow type of the merged $id column, taken from the
+// first input that actually carries IDs. Zero-row inputs cannot be trusted for
+// this: an empty result carries no ID type of its own and is materialized as an
+// empty Int64 column regardless of the collection's PK type (see importEmptyIDs
+// in converter.go). Falls back to Int64 when every input is empty, which is
+// self-consistent because then every chunk is empty as well.
+func resolveIDType(inputs []*DataFrame) arrow.DataType {
+	for _, df := range inputs {
+		if col := df.Column(types.IDFieldName); col != nil && col.Len() > 0 {
+			return col.DataType()
+		}
+	}
+	return arrow.PrimitiveTypes.Int64
+}
+
 // buildResultArrays builds ID and score arrays from results.
-func (op *MergeOp) buildResultArrays(ctx *types.FuncContext, ids []any, scores []float32) (arrow.Array, arrow.Array, error) {
+// idType types the ID array of a zero-hit chunk, which has no IDs to infer it from.
+func (op *MergeOp) buildResultArrays(ctx *types.FuncContext, ids []any, scores []float32, idType arrow.DataType) (arrow.Array, arrow.Array, error) {
 	if len(ids) == 0 {
-		// Empty result
-		idBuilder := array.NewInt64Builder(ctx.Pool())
+		// Empty result: type the empty array after the other chunks, otherwise
+		// arrow.NewChunked rejects the column (e.g. "mismatch data type int64 vs utf8").
 		scoreBuilder := array.NewFloat32Builder(ctx.Pool())
-		defer idBuilder.Release()
 		defer scoreBuilder.Release()
+
+		var idBuilder array.Builder
+		switch idType.ID() {
+		case arrow.STRING:
+			idBuilder = array.NewStringBuilder(ctx.Pool())
+		case arrow.INT64:
+			idBuilder = array.NewInt64Builder(ctx.Pool())
+		default:
+			return nil, nil, merr.WrapErrFunctionFailedMsg("merge_op: unsupported ID type %s", idType)
+		}
+		defer idBuilder.Release()
+
 		return idBuilder.NewArray(), scoreBuilder.NewArray(), nil
 	}
 

--- a/internal/util/function/chain/operator_merge_test.go
+++ b/internal/util/function/chain/operator_merge_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 )
 
@@ -1031,6 +1032,84 @@ func (s *MergeHelperTestSuite) TestMergeWithEmptyChunk() {
 	defer result.Release()
 
 	s.Equal(2, result.NumChunks())
+}
+
+// buildVarCharIDDataFrame builds a VarChar-PK DataFrame whose first query has
+// hits and whose second query returns nothing (topks = [len(ids), 0]).
+func (s *MergeHelperTestSuite) buildVarCharIDDataFrame(ids []string, scores []float32) *DataFrame {
+	builder := NewDataFrameBuilder()
+	builder.SetChunkSizes([]int64{int64(len(ids)), 0})
+
+	idB := array.NewStringBuilder(s.pool)
+	idB.AppendValues(ids, nil)
+	idArr := idB.NewArray()
+	idB.Release()
+
+	idB2 := array.NewStringBuilder(s.pool)
+	idArr2 := idB2.NewArray()
+	idB2.Release()
+
+	scoreB := array.NewFloat32Builder(s.pool)
+	scoreB.AppendValues(scores, nil)
+	scoreArr := scoreB.NewArray()
+	scoreB.Release()
+
+	scoreB2 := array.NewFloat32Builder(s.pool)
+	scoreArr2 := scoreB2.NewArray()
+	scoreB2.Release()
+
+	s.Require().NoError(builder.AddColumnFromChunks(types.IDFieldName, []arrow.Array{idArr, idArr2}))
+	s.Require().NoError(builder.AddColumnFromChunks(types.ScoreFieldName, []arrow.Array{scoreArr, scoreArr2}))
+	return builder.Build()
+}
+
+// A zero-hit chunk must adopt the ID type of the other chunks. Building it as
+// Int64 while the chunks with hits are utf8 makes arrow.NewChunked reject the
+// column ("mismatch data type int64 vs utf8"), which panics the proxy for any
+// VarChar-PK collection where one query of the batch returns nothing (#51372).
+func (s *MergeHelperTestSuite) TestMergeWithEmptyChunkVarCharIDs() {
+	df := s.buildVarCharIDDataFrame([]string{"a", "b"}, []float32{0.9, 0.8})
+	defer df.Release()
+
+	op := NewMergeOp(MergeStrategyRRF, WithNormalize(false))
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+
+	result, err := op.Execute(ctx, df)
+	s.Require().NoError(err)
+	defer result.Release()
+
+	s.Equal(2, result.NumChunks())
+	s.Equal(int64(2), result.NumRows())
+
+	idType, ok := result.FieldType(types.IDFieldName)
+	s.Require().True(ok)
+	s.Equal(schemapb.DataType_VarChar, idType)
+
+	idCol := result.Column(types.IDFieldName)
+	s.Require().NotNil(idCol)
+	s.Equal(arrow.STRING, idCol.DataType().ID())
+	s.Equal(2, idCol.Chunk(0).Len())
+	s.Equal(0, idCol.Chunk(1).Len())
+}
+
+// Same for multi-input merge (hybrid search): one leg is entirely empty, the
+// other carries VarChar IDs with a zero-hit query.
+func (s *MergeHelperTestSuite) TestMergeMultiInputEmptyLegVarCharIDs() {
+	dfEmpty := s.buildVarCharIDDataFrame(nil, nil)
+	defer dfEmpty.Release()
+	dfHits := s.buildVarCharIDDataFrame([]string{"a", "b"}, []float32{0.9, 0.8})
+	defer dfHits.Release()
+
+	op := NewMergeOp(MergeStrategyRRF, WithNormalize(false))
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+
+	result, err := op.ExecuteMulti(ctx, []*DataFrame{dfEmpty, dfHits})
+	s.Require().NoError(err)
+	defer result.Release()
+
+	s.Equal(2, result.NumChunks())
+	s.Equal(int64(2), result.NumRows())
+	s.Equal(arrow.STRING, result.Column(types.IDFieldName).DataType().ID())
 }
 
 // =============================================================================


### PR DESCRIPTION
issue: #51372

### Problem

`MergeOp.buildResultArrays` builds a zero-hit chunk's `$id` array with a hardcoded Int64 builder
(`operator_merge.go:713-721` before this change), while chunks that do have hits are typed from the
first actual ID (`buildInt64Results` / `buildStringResults`). All per-query chunks then go into
`AddColumnFromChunks`, which builds one `arrow.NewChunked` column out of them.

For a **VarChar-PK collection** where **one query of an nq >= 2 batch returns zero hits** while
another returns hits, those chunks mix `utf8` and `int64` and arrow panics:

```
panic: invalid: arrow/array: mismatch data type int64 vs utf8
```

`MergeOp` sits at chain index 0, so every request that goes through a function rerank chain — plain
search with a rerank function as well as hybrid search — can hit it. The proxy has no recovery
interceptor on its gRPC chains (`internal/distributed/proxy/service.go:295-307`, `416-424`) and no
`recover()` in `internal/proxy/`, so the panic takes the proxy process down.

The input side was never affected: `collectRRFScores` / `collectWeightedScores` read IDs row by row,
so an empty chunk is simply iterated zero times. Only the output side was broken.

### Fix

Resolve the `$id` arrow type once per merge, from the first input that actually carries IDs
(`resolveIDType`), and build the zero-hit chunk with that type.

Zero-row inputs are deliberately skipped when resolving: an empty result carries no ID type of its
own and is materialized as an empty Int64 column regardless of the collection's PK type
(`importEmptyIDs`, converter.go). When *every* input is empty, Int64 is kept — every chunk is then
empty as well, so the column is self-consistent and the rerank operator's `allEmpty` early-return
short-circuits before it anyway.

An unexpected arrow ID type now returns a `merr` error instead of silently producing an Int64 array.

### Testing

- `TestMergeWithEmptyChunkVarCharIDs` — single input, VarChar IDs, `topks=[2,0]`; asserts the merged
  `$id` column stays `utf8` with an empty second chunk. Written first and observed panicking with
  `mismatch data type int64 vs utf8` on unmodified master.
- `TestMergeMultiInputEmptyLegVarCharIDs` — hybrid-search shape: one leg entirely empty, the other
  with a zero-hit query.
- The existing `TestMergeWithEmptyChunk` (Int64) still passes, pinning the unchanged Int64 path.
- `./internal/util/function/...` green, including `-race`; `gofmt` clean.

### Note

Found while reviewing #51156 (fix for #50969). This panic is **not** introduced by that PR —
`operator_merge.go` is byte-identical between master and its head, and the repro above does not touch
the lines it changes. #51156 does widen the reachable surface, though: before it, a single-shard
zero-hit result failed earlier in the converter with `unsupported ID type` and never reached
`MergeOp`; after it, that input builds a DataFrame and walks into this panic.
