### PR TITLE
fix: bitset read() range check capped multi-bit reads at 8 bits

### DIFF
--- a/internal/core/src/bitset/BitsetTest.cpp
+++ b/internal/core/src/bitset/BitsetTest.cpp
@@ -2901,6 +2901,58 @@ INSTANTIATE_TYPED_TEST_SUITE_P(FillTest, FillSuite, Ttypes0);
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
+// read() must accept widths up to 8 * sizeof(data_type) bits: the old range
+// check compared nbits against sizeof(data_type), silently capping reads at
+// 8 bits for a 64-bit word and rejecting every wider (legal) read.
+template <typename BitsetT>
+void
+TestReadImpl() {
+    constexpr size_t n = 150;
+    BitsetT bitset(n);
+    // pattern: every 3rd bit set
+    for (size_t i = 0; i < n; i += 3) {
+        bitset[i] = true;
+    }
+
+    for (const size_t offset : {0, 1, 7, 63, 64, 86}) {
+        for (const size_t nbits : {1, 8, 9, 33, 64}) {
+            if (offset + nbits > n) {
+                continue;
+            }
+            const auto value = bitset.read(offset, nbits);
+            for (size_t j = 0; j < nbits; ++j) {
+                const bool expected = ((offset + j) % 3 == 0);
+                ASSERT_EQ(((value >> j) & 1) != 0, expected)
+                    << "offset=" << offset << " nbits=" << nbits << " j=" << j;
+            }
+        }
+    }
+}
+
+TEST(ReadTest, BitWise) {
+    TestReadImpl<typename RefImplTraits<uint64_t, uint8_t>::bitset_type>();
+}
+
+TEST(ReadTest, ElementWise) {
+    TestReadImpl<typename ElementImplTraits<uint64_t, uint8_t>::bitset_type>();
+}
+
+TEST(ReadTest, Dynamic) {
+    TestReadImpl<typename VectorizedImplTraits<
+        uint64_t,
+        uint8_t,
+        milvus::bitset::detail::VectorizedDynamic>::bitset_type>();
+}
+
+TEST(ReadTest, VecRef) {
+    TestReadImpl<typename VectorizedImplTraits<
+        uint64_t,
+        uint8_t,
+        milvus::bitset::detail::VectorizedRef>::bitset_type>();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+
 int
 main(int argc, char* argv[]) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/internal/core/src/bitset/bitset.h
+++ b/internal/core/src/bitset/bitset.h
@@ -570,22 +570,16 @@ class BitsetBase {
 
     // Read multiple bits starting from a given bit index.
     inline data_type
-    read(const size_t starting_bit_idx, const size_t nbits) {
-        range_checker::le(nbits, sizeof(data_type));
+    read(const size_t starting_bit_idx, const size_t nbits) const {
+        range_checker::le(nbits, 8 * sizeof(data_type));
+        // Check the end bound without computing starting_bit_idx + nbits, which
+        // can wrap around size_t and slip past the check; both operands are
+        // unsigned so size() - starting_bit_idx is safe once the first holds.
+        range_checker::le(starting_bit_idx, this->size());
+        range_checker::le(nbits, this->size() - starting_bit_idx);
 
         return policy_type::op_read(
             this->data(), this->offset() + starting_bit_idx, nbits);
-    }
-
-    // Write multiple bits starting from a given bit index.
-    inline void
-    write(const size_t starting_bit_idx,
-          const data_type value,
-          const size_t nbits) {
-        range_checker::le(nbits, sizeof(data_type));
-
-        policy_type::op_write(
-            this->data(), this->offset() + starting_bit_idx, nbits, value);
     }
 
     // Compare two arrays element-wise

--- a/internal/core/src/bitset/detail/element_vectorized.h
+++ b/internal/core/src/bitset/detail/element_vectorized.h
@@ -227,6 +227,14 @@ struct VectorizedElementWiseBitsetPolicy {
     }
 
     //
+    static inline data_type
+    op_read(const data_type* const data,
+            const size_t start,
+            const size_t nbits) {
+        return ElementWiseBitsetPolicy<ElementT>::op_read(data, start, nbits);
+    }
+
+    //
     template <typename T, typename U, CompareOpType Op>
     static inline void
     op_compare_column(data_type* const __restrict data,


### PR DESCRIPTION
issue: #51379
Part of the stack tracked in #51385 (layer 1, no dependencies).

## What
`BitsetBase::read(idx, nbits)` validated `nbits <= sizeof(data_type)` instead of `8 * sizeof(data_type)`, capping legal reads at 8 bits on a 64-bit word and never checking the end bound. The vectorized element-wise policy also lacked the `op_read` forwarding, so `read()` was unusable on production bitset types. The sibling `write()` had the same broken check and zero callers repo-wide — deleted.

## Review guide
~60 lines. Check the new range checks and the op_read forwarding; `ReadTest` covers widths 1–64 across offsets for all four policies (bit-wise, element-wise, vectorized-ref, vectorized-dynamic).

Word-wise consumers land in the next stack layer.