### PR TITLE
fix: three-valued NULL semantics and races in struct-array element match

### DIFF
--- a/internal/core/src/bitset/BitsetTest.cpp
+++ b/internal/core/src/bitset/BitsetTest.cpp
@@ -2901,6 +2901,58 @@ INSTANTIATE_TYPED_TEST_SUITE_P(FillTest, FillSuite, Ttypes0);
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
+// read() must accept widths up to 8 * sizeof(data_type) bits: the old range
+// check compared nbits against sizeof(data_type), silently capping reads at
+// 8 bits for a 64-bit word and rejecting every wider (legal) read.
+template <typename BitsetT>
+void
+TestReadImpl() {
+    constexpr size_t n = 150;
+    BitsetT bitset(n);
+    // pattern: every 3rd bit set
+    for (size_t i = 0; i < n; i += 3) {
+        bitset[i] = true;
+    }
+
+    for (const size_t offset : {0, 1, 7, 63, 64, 86}) {
+        for (const size_t nbits : {1, 8, 9, 33, 64}) {
+            if (offset + nbits > n) {
+                continue;
+            }
+            const auto value = bitset.read(offset, nbits);
+            for (size_t j = 0; j < nbits; ++j) {
+                const bool expected = ((offset + j) % 3 == 0);
+                ASSERT_EQ(((value >> j) & 1) != 0, expected)
+                    << "offset=" << offset << " nbits=" << nbits << " j=" << j;
+            }
+        }
+    }
+}
+
+TEST(ReadTest, BitWise) {
+    TestReadImpl<typename RefImplTraits<uint64_t, uint8_t>::bitset_type>();
+}
+
+TEST(ReadTest, ElementWise) {
+    TestReadImpl<typename ElementImplTraits<uint64_t, uint8_t>::bitset_type>();
+}
+
+TEST(ReadTest, Dynamic) {
+    TestReadImpl<typename VectorizedImplTraits<
+        uint64_t,
+        uint8_t,
+        milvus::bitset::detail::VectorizedDynamic>::bitset_type>();
+}
+
+TEST(ReadTest, VecRef) {
+    TestReadImpl<typename VectorizedImplTraits<
+        uint64_t,
+        uint8_t,
+        milvus::bitset::detail::VectorizedRef>::bitset_type>();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+
 int
 main(int argc, char* argv[]) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/internal/core/src/bitset/bitset.h
+++ b/internal/core/src/bitset/bitset.h
@@ -570,22 +570,12 @@ class BitsetBase {
 
     // Read multiple bits starting from a given bit index.
     inline data_type
-    read(const size_t starting_bit_idx, const size_t nbits) {
-        range_checker::le(nbits, sizeof(data_type));
+    read(const size_t starting_bit_idx, const size_t nbits) const {
+        range_checker::le(nbits, 8 * sizeof(data_type));
+        range_checker::le(starting_bit_idx + nbits, this->size());
 
         return policy_type::op_read(
             this->data(), this->offset() + starting_bit_idx, nbits);
-    }
-
-    // Write multiple bits starting from a given bit index.
-    inline void
-    write(const size_t starting_bit_idx,
-          const data_type value,
-          const size_t nbits) {
-        range_checker::le(nbits, sizeof(data_type));
-
-        policy_type::op_write(
-            this->data(), this->offset() + starting_bit_idx, nbits, value);
     }
 
     // Compare two arrays element-wise

--- a/internal/core/src/bitset/detail/element_vectorized.h
+++ b/internal/core/src/bitset/detail/element_vectorized.h
@@ -227,6 +227,14 @@ struct VectorizedElementWiseBitsetPolicy {
     }
 
     //
+    static inline data_type
+    op_read(const data_type* const data,
+            const size_t start,
+            const size_t nbits) {
+        return ElementWiseBitsetPolicy<ElementT>::op_read(data, start, nbits);
+    }
+
+    //
     template <typename T, typename U, CompareOpType Op>
     static inline void
     op_compare_column(data_type* const __restrict data,

--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -331,6 +331,11 @@ ArrayOffsetsSealed::BuildFromSegment(const void* segment,
     auto data_type = field_meta.get_data_type();
 
     std::vector<int32_t> row_to_element_start(row_count + 1);
+    // Retain per-row NULL info so row-level consumers (e.g. array_contains via a
+    // nested index) can exclude NULL rows -- a NULL row has zero elements and is
+    // otherwise indistinguishable from an empty array at element level.
+    TargetBitmap row_valid(row_count, true);
+    bool nullable_seen = false;
 
     auto temp_op_ctx = std::make_unique<OpContext>();
     auto op_ctx_ptr = temp_op_ctx.get();
@@ -349,6 +354,9 @@ ArrayOffsetsSealed::BuildFromSegment(const void* segment,
                 int32_t array_len = 0;
                 if (valid_flags.empty() || valid_flags[i]) {
                     array_len = vector_array_views[i].length();
+                } else {
+                    nullable_seen = true;
+                    row_valid[current_row_id] = false;
                 }
 
                 row_to_element_start[current_row_id] = total_elements;
@@ -366,6 +374,9 @@ ArrayOffsetsSealed::BuildFromSegment(const void* segment,
                 int32_t array_len = 0;
                 if (valid_flags.empty() || valid_flags[i]) {
                     array_len = array_views[i].length();
+                } else {
+                    nullable_seen = true;
+                    row_valid[current_row_id] = false;
                 }
 
                 row_to_element_start[current_row_id] = total_elements;
@@ -393,6 +404,11 @@ ArrayOffsetsSealed::BuildFromSegment(const void* segment,
     auto result =
         std::make_shared<ArrayOffsetsSealed>(std::move(row_to_element_start));
     result->resource_size_ = 4 * (row_count + 1);
+    if (nullable_seen) {
+        result->has_row_valid_ = true;
+        result->row_valid_ = std::move(row_valid);
+        result->resource_size_ += (row_count + 7) / 8;
+    }
     cachinglayer::Manager::GetInstance().ChargeLoadedResource(
         cachinglayer::ResourceUsage{result->resource_size_, 0});
     return result;
@@ -413,6 +429,9 @@ ArrayOffsetsSealed::BuildFromColumn(const ChunkedColumnInterface& column,
     auto data_type = field_meta.get_data_type();
 
     std::vector<int32_t> row_to_element_start(row_count + 1);
+    // See BuildFromSegment: retain per-row NULL info for row-level consumers.
+    TargetBitmap row_valid(row_count, true);
+    bool nullable_seen = false;
 
     auto temp_op_ctx = std::make_unique<OpContext>();
     auto op_ctx_ptr = temp_op_ctx.get();
@@ -431,6 +450,9 @@ ArrayOffsetsSealed::BuildFromColumn(const ChunkedColumnInterface& column,
                 int32_t array_len = 0;
                 if (valid_flags.empty() || valid_flags[i]) {
                     array_len = vector_array_views[i].length();
+                } else {
+                    nullable_seen = true;
+                    row_valid[current_row_id] = false;
                 }
 
                 row_to_element_start[current_row_id] = total_elements;
@@ -448,6 +470,9 @@ ArrayOffsetsSealed::BuildFromColumn(const ChunkedColumnInterface& column,
                 int32_t array_len = 0;
                 if (valid_flags.empty() || valid_flags[i]) {
                     array_len = array_views[i].length();
+                } else {
+                    nullable_seen = true;
+                    row_valid[current_row_id] = false;
                 }
 
                 row_to_element_start[current_row_id] = total_elements;
@@ -475,6 +500,11 @@ ArrayOffsetsSealed::BuildFromColumn(const ChunkedColumnInterface& column,
     auto result =
         std::make_shared<ArrayOffsetsSealed>(std::move(row_to_element_start));
     result->resource_size_ = 4 * (row_count + 1);
+    if (nullable_seen) {
+        result->has_row_valid_ = true;
+        result->row_valid_ = std::move(row_valid);
+        result->resource_size_ += (row_count + 7) / 8;
+    }
     cachinglayer::Manager::GetInstance().ChargeLoadedResource(
         cachinglayer::ResourceUsage{result->resource_size_, 0});
     return result;
@@ -731,38 +761,75 @@ ArrayOffsetsGrowing::Insert(int64_t row_id_start,
     for (int64_t i = 0; i < count; ++i) {
         int32_t row_id = row_id_start + i;
         int32_t array_len = array_lengths[i];
+        // Negative length marks a NULL row: zero elements + row-invalid.
+        bool valid = array_len >= 0;
+        if (!valid) {
+            array_len = 0;
+        }
 
         if (row_id == committed_row_count_) {
-            // Get current total element count (from sentinel or compute)
-            int32_t current_total = row_to_element_start_.empty()
-                                        ? 0
-                                        : row_to_element_start_.back();
-
-            // Record the start position for this row
-            if (row_to_element_start_.size() >
-                static_cast<size_t>(committed_row_count_)) {
-                // Sentinel exists, overwrite it with row start
-                row_to_element_start_[committed_row_count_] = current_total;
-            } else {
-                row_to_element_start_.push_back(current_total);
-            }
-
-            // Update sentinel (new total after this row)
-            int32_t new_total = current_total + array_len;
-            if (row_to_element_start_.size() >
-                static_cast<size_t>(committed_row_count_ + 1)) {
-                row_to_element_start_[committed_row_count_ + 1] = new_total;
-            } else {
-                row_to_element_start_.push_back(new_total);
-            }
-
-            committed_row_count_++;
+            CommitRow(array_len, valid);
         } else {
-            pending_rows_[row_id] = {row_id, array_len};
+            pending_rows_[row_id] = {row_id, array_len, valid};
         }
     }
 
     DrainPendingRows();
+}
+
+void
+ArrayOffsetsGrowing::InsertNulls(int64_t row_id_start, int64_t count) {
+    std::unique_lock lock(mutex_);
+
+    for (int64_t i = 0; i < count; ++i) {
+        int64_t row_id = row_id_start + i;
+        if (row_id == committed_row_count_) {
+            CommitRow(/*array_len=*/0, /*valid=*/false);
+        } else {
+            pending_rows_[row_id] = {row_id, 0, false};
+        }
+    }
+
+    DrainPendingRows();
+}
+
+// Commit one row at committed_row_count_. Caller must hold the unique lock.
+void
+ArrayOffsetsGrowing::CommitRow(int32_t array_len, bool valid) {
+    // Get current total element count (from sentinel or compute)
+    int32_t current_total =
+        row_to_element_start_.empty() ? 0 : row_to_element_start_.back();
+
+    // Record the start position for this row
+    if (row_to_element_start_.size() >
+        static_cast<size_t>(committed_row_count_)) {
+        // Sentinel exists, overwrite it with row start
+        row_to_element_start_[committed_row_count_] = current_total;
+    } else {
+        row_to_element_start_.push_back(current_total);
+    }
+
+    // Update sentinel (new total after this row)
+    int32_t new_total = current_total + array_len;
+    if (row_to_element_start_.size() >
+        static_cast<size_t>(committed_row_count_ + 1)) {
+        row_to_element_start_[committed_row_count_ + 1] = new_total;
+    } else {
+        row_to_element_start_.push_back(new_total);
+    }
+
+    // Row validity is materialized lazily on the first NULL row (all prior
+    // committed rows were valid); from then on it stays lockstep with
+    // committed_row_count_.
+    if (!valid && !has_row_valid_) {
+        row_valid_.assign(static_cast<size_t>(committed_row_count_), 1);
+        has_row_valid_ = true;
+    }
+    if (has_row_valid_) {
+        row_valid_.push_back(valid ? 1 : 0);
+    }
+
+    committed_row_count_++;
 }
 
 void
@@ -774,33 +841,28 @@ ArrayOffsetsGrowing::DrainPendingRows() {
         }
 
         const auto& pending = it->second;
-
-        // Get current total element count
-        int32_t current_total =
-            (committed_row_count_ > 0)
-                ? row_to_element_start_[committed_row_count_]
-                : 0;
-
-        // If sentinel exists at current position, overwrite it; otherwise push_back
-        if (row_to_element_start_.size() >
-            static_cast<size_t>(committed_row_count_)) {
-            row_to_element_start_[committed_row_count_] = current_total;
-        } else {
-            row_to_element_start_.push_back(current_total);
-        }
-
-        // Update sentinel for next row
-        int32_t new_total = current_total + pending.array_len;
-        if (row_to_element_start_.size() >
-            static_cast<size_t>(committed_row_count_ + 1)) {
-            row_to_element_start_[committed_row_count_ + 1] = new_total;
-        } else {
-            row_to_element_start_.push_back(new_total);
-        }
-
-        committed_row_count_++;
-
+        CommitRow(pending.array_len, pending.valid);
         pending_rows_.erase(it);
+    }
+}
+
+void
+ArrayOffsetsGrowing::AndRowValidBitmap(TargetBitmapView result,
+                                       int64_t row_start,
+                                       int64_t row_count) const {
+    std::shared_lock lock(mutex_);
+    if (!has_row_valid_) {
+        return;
+    }
+    auto rows = static_cast<int64_t>(row_valid_.size());
+    for (int64_t i = 0; i < row_count; ++i) {
+        auto row = row_start + i;
+        if (row >= rows) {
+            break;
+        }
+        if (row_valid_[row] == 0) {
+            result[i] = false;
+        }
     }
 }
 

--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -17,7 +17,9 @@
 #include "ArrayOffsets.h"
 
 #include <assert.h>
+#include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <type_traits>
 
 #include "bitset/bitset.h"
@@ -34,6 +36,82 @@
 #include "segcore/SegmentInterface.h"
 
 namespace milvus {
+
+namespace {
+
+// Word-wise ANY-semantics reduction shared by the sealed and growing
+// implementations of ElementBitsetToRowBitsetAny.
+//
+// `starts` is the row -> element-start table, indexable over
+// [row_start, row_start + row_count]. Bit j of `elem_bitset` corresponds to
+// global element id (elem_offset + j).
+//
+// Linear merge of the element bitmap (consumed one 64-bit word at a time)
+// with the sorted row-start table: zero words are skipped with a single
+// compare, a set bit advances the monotone row cursor (amortized
+// O(row_count) over the whole call, no binary search), and once a row is
+// marked the scan jumps directly to the row's end, skipping its remaining
+// words. Complexity is O(total_elements / 64 + row_count + hit_rows)
+// instead of the per-bit O(total_elements).
+void
+ElementBitsetAnyReduce(const int32_t* starts,
+                       const TargetBitmapView& elem_bitset,
+                       int64_t elem_offset,
+                       int64_t row_start,
+                       int64_t row_count,
+                       TargetBitmapView row_result) {
+    using word_t = TargetBitmapView::policy_type::data_type;
+    constexpr int64_t kWordBits = static_cast<int64_t>(8 * sizeof(word_t));
+
+    if (row_count == 0) {
+        return;
+    }
+    const int64_t first_bit = starts[row_start] - elem_offset;
+    const int64_t last_bit = starts[row_start + row_count] - elem_offset;
+    AssertInfo(
+        first_bit >= 0 && last_bit <= static_cast<int64_t>(elem_bitset.size()),
+        "element bitset does not cover rows [{}, {}): bits [{}, {}), "
+        "bitset size {}",
+        row_start,
+        row_start + row_count,
+        first_bit,
+        last_bit,
+        elem_bitset.size());
+
+    int64_t pos = first_bit;
+    int64_t row = row_start;
+    while (pos < last_bit) {
+        const int64_t n = std::min(kWordBits, last_bit - pos);
+        word_t word =
+            elem_bitset.read(static_cast<size_t>(pos), static_cast<size_t>(n));
+        if (word == 0) {
+            pos += n;
+            continue;
+        }
+        int64_t next_pos = pos + n;
+        do {
+            const int64_t bit = pos + __builtin_ctzll(word);
+            const int32_t elem_id = static_cast<int32_t>(bit + elem_offset);
+            // Monotone row cursor; empty rows are skipped by the same loop.
+            while (starts[row + 1] <= elem_id) {
+                ++row;
+            }
+            row_result[row - row_start] = true;
+            // Skip the rest of this row's elements.
+            const int64_t row_end = starts[row + 1] - elem_offset;
+            if (row_end >= pos + n) {
+                next_pos = row_end;
+                break;
+            }
+            // row_end falls inside the current word: clear bits below it.
+            // (0 < row_end - pos < kWordBits, so the shift is well-defined.)
+            word &= ~word_t(0) << (row_end - pos);
+        } while (word != 0);
+        pos = next_pos;
+    }
+}
+
+}  // namespace
 
 std::pair<int32_t, int32_t>
 ArrayOffsetsSealed::ElementIDToRowID(int32_t elem_id) const {
@@ -60,6 +138,40 @@ ArrayOffsetsSealed::ElementIDRangeOfRow(int32_t row_id) const {
         return {total, total};
     }
     return {row_to_element_start_[row_id], row_to_element_start_[row_id + 1]};
+}
+
+void
+ArrayOffsetsSealed::CopyRowElementRanges(
+    const int32_t* row_ids,
+    int64_t count,
+    std::pair<int32_t, int32_t>* out) const {
+    const auto row_count = static_cast<int32_t>(GetRowCount());
+    const int32_t* starts = row_to_element_start_.data();
+    for (int64_t i = 0; i < count; ++i) {
+        const int32_t row_id = row_ids[i];
+        assert(row_id >= 0 && row_id <= row_count);
+        if (row_id == row_count) {
+            out[i] = {starts[row_count], starts[row_count]};
+        } else {
+            out[i] = {starts[row_id], starts[row_id + 1]};
+        }
+    }
+}
+
+void
+ArrayOffsetsSealed::CopyRowElementStarts(int64_t row_start,
+                                         int64_t row_count,
+                                         int32_t* out) const {
+    AssertInfo(row_start >= 0 && row_count >= 0 &&
+                   row_start + row_count <= GetRowCount(),
+               "row range out of bounds: row_start={}, row_count={}, "
+               "total_rows={}",
+               row_start,
+               row_count,
+               GetRowCount());
+    std::memcpy(out,
+                row_to_element_start_.data() + row_start,
+                sizeof(int32_t) * (row_count + 1));
 }
 
 std::pair<TargetBitmap, TargetBitmap>
@@ -177,6 +289,28 @@ ArrayOffsetsSealed::ForEachRowElementRange(
     }
 
     return result;
+}
+
+void
+ArrayOffsetsSealed::ElementBitsetToRowBitsetAny(
+    const TargetBitmapView& elem_bitset,
+    int64_t elem_offset,
+    int64_t row_start,
+    TargetBitmapView row_result) const {
+    const int64_t row_count = row_result.size();
+    AssertInfo(row_start >= 0 && row_start + row_count <= GetRowCount(),
+               "row range out of bounds: row_start={}, row_count={}, "
+               "total_rows={}",
+               row_start,
+               row_count,
+               GetRowCount());
+
+    ElementBitsetAnyReduce(row_to_element_start_.data(),
+                           elem_bitset,
+                           elem_offset,
+                           row_start,
+                           row_count,
+                           row_result);
 }
 
 std::shared_ptr<ArrayOffsetsSealed>
@@ -375,6 +509,64 @@ ArrayOffsetsGrowing::ElementIDRangeOfRow(int32_t row_id) const {
     return {row_to_element_start_[row_id], row_to_element_start_[row_id + 1]};
 }
 
+void
+ArrayOffsetsGrowing::CopyRowElementRanges(
+    const int32_t* row_ids,
+    int64_t count,
+    std::pair<int32_t, int32_t>* out) const {
+    // ONE shared lock for the whole batch (the per-row method locks per
+    // call, which contends with Insert's unique lock on hot scan paths).
+    std::shared_lock lock(mutex_);
+    const int32_t* starts = row_to_element_start_.data();
+    for (int64_t i = 0; i < count; ++i) {
+        const int32_t row_id = row_ids[i];
+        // Out-of-range insurance: with zero committed rows the vector is
+        // empty, and a not-yet-committed row has no range yet.
+        if (row_id < 0 || row_id > committed_row_count_ ||
+            row_to_element_start_.empty()) {
+            out[i] = {0, 0};
+            continue;
+        }
+        if (row_id == committed_row_count_) {
+            auto total = starts[committed_row_count_];
+            out[i] = {total, total};
+        } else {
+            out[i] = {starts[row_id], starts[row_id + 1]};
+        }
+    }
+}
+
+void
+ArrayOffsetsGrowing::CopyRowElementStarts(int64_t row_start,
+                                          int64_t row_count,
+                                          int32_t* out) const {
+    AssertInfo(row_start >= 0 && row_count >= 0,
+               "invalid row range: row_start={}, row_count={}",
+               row_start,
+               row_count);
+    std::shared_lock lock(mutex_);
+    if (row_to_element_start_.empty()) {
+        // No committed rows yet: every requested row clamps to total == 0.
+        std::fill(out, out + row_count + 1, 0);
+        return;
+    }
+    const int32_t* starts = row_to_element_start_.data();
+    const int64_t committed = committed_row_count_;
+    if (row_start + row_count <= committed) {
+        // Fast path: fully committed range, straight copy under the lock.
+        std::memcpy(
+            out, starts + row_start, sizeof(int32_t) * (row_count + 1));
+        return;
+    }
+    // Rows at or beyond the committed count clamp to the committed total
+    // ({total, total}-style safety: not-yet-committed rows read as empty).
+    const int32_t total = starts[committed];
+    for (int64_t i = 0; i <= row_count; ++i) {
+        const int64_t row = row_start + i;
+        out[i] = row <= committed ? starts[row] : total;
+    }
+}
+
 std::pair<TargetBitmap, TargetBitmap>
 ArrayOffsetsGrowing::RowBitsetToElementBitset(
     const TargetBitmapView& row_bitset,
@@ -501,13 +693,41 @@ ArrayOffsetsGrowing::ForEachRowElementRange(
 }
 
 void
+ArrayOffsetsGrowing::ElementBitsetToRowBitsetAny(
+    const TargetBitmapView& elem_bitset,
+    int64_t elem_offset,
+    int64_t row_start,
+    TargetBitmapView row_result) const {
+    std::shared_lock lock(mutex_);
+
+    const int64_t row_count = row_result.size();
+    AssertInfo(row_start >= 0 && row_start + row_count <= committed_row_count_,
+               "row range out of bounds: row_start={}, row_count={}, "
+               "committed_rows={}",
+               row_start,
+               row_count,
+               committed_row_count_);
+
+    ElementBitsetAnyReduce(row_to_element_start_.data(),
+                           elem_bitset,
+                           elem_offset,
+                           row_start,
+                           row_count,
+                           row_result);
+}
+
+void
 ArrayOffsetsGrowing::Insert(int64_t row_id_start,
                             const int32_t* array_lengths,
                             int64_t count) {
     std::unique_lock lock(mutex_);
 
-    row_to_element_start_.reserve(row_id_start + count + 1);
-
+    // NOTE: no reserve() here on purpose. An exact-size reserve per insert
+    // batch (row_id_start + count + 1) defeats the vector's geometric growth:
+    // every batch whose target exceeded the previous exact capacity forced a
+    // full reallocation + memcpy of the whole table while holding the writer
+    // lock, turning N batched inserts into O(N^2) copied bytes. push_back's
+    // amortized doubling is the right behavior.
     for (int64_t i = 0; i < count; ++i) {
         int32_t row_id = row_id_start + i;
         int32_t array_len = array_lengths[i];

--- a/internal/core/src/common/ArrayOffsets.h
+++ b/internal/core/src/common/ArrayOffsets.h
@@ -55,6 +55,29 @@ class IArrayOffsets {
     virtual std::pair<int32_t, int32_t>
     ElementIDRangeOfRow(int32_t row_id) const = 0;
 
+    // Batched form of ElementIDRangeOfRow: out[i] = element range of
+    // row_ids[i]. Semantics per entry match the per-row method, but the
+    // growing implementation takes ONE shared lock (and the caller pays one
+    // virtual call) for the whole batch instead of one per row. A row id
+    // outside [0, committed rows] yields {0, 0} on growing (out-of-range
+    // insurance: a not-yet-committed row has no range yet).
+    virtual void
+    CopyRowElementRanges(const int32_t* row_ids,
+                         int64_t count,
+                         std::pair<int32_t, int32_t>* out) const = 0;
+
+    // Contiguous form for the common sequential-batch case: copy
+    // starts[row_start .. row_start + row_count] into out (row_count + 1
+    // entries), so [out[i], out[i+1]) is row (row_start + i)'s element
+    // range. Sealed is a straight memcpy; growing takes one shared lock and
+    // clamps rows beyond the committed count to the last committed total
+    // (equivalent to the per-row method's {total, total} for row ==
+    // committed_row_count_, extended to any not-yet-committed row).
+    virtual void
+    CopyRowElementStarts(int64_t row_start,
+                         int64_t row_count,
+                         int32_t* out) const = 0;
+
     // Convert row-level bitsets to element-level bitsets
     // row_start: starting row index (0-based)
     // row_bitset.size(): number of rows to process
@@ -87,6 +110,21 @@ class IArrayOffsets {
     ForEachRowElementRange(const ElementRangePredicate& predicate,
                            int64_t row_start,
                            int64_t row_count) const = 0;
+
+    // Word-wise ANY-semantics reduction of an element-level bitmap to row
+    // level. Bit j of elem_bitset corresponds to global element id
+    // (elem_offset + j). For each i in [0, row_result.size()), sets
+    // row_result[i] = true iff any element bit of row (row_start + i) is set.
+    // Bits in row_result are only ever set, never cleared. elem_bitset must
+    // cover the element ranges of all addressed rows.
+    // This is the hot path used to fold element-level match bits back to
+    // rows (MATCH_ANY over an all-valid element bitmap); it skips zero words
+    // instead of testing element bits one by one.
+    virtual void
+    ElementBitsetToRowBitsetAny(const TargetBitmapView& elem_bitset,
+                                int64_t elem_offset,
+                                int64_t row_start,
+                                TargetBitmapView row_result) const = 0;
 };
 
 class ArrayOffsetsSealed : public IArrayOffsets {
@@ -138,6 +176,16 @@ class ArrayOffsetsSealed : public IArrayOffsets {
     std::pair<int32_t, int32_t>
     ElementIDRangeOfRow(int32_t row_id) const override;
 
+    void
+    CopyRowElementRanges(const int32_t* row_ids,
+                         int64_t count,
+                         std::pair<int32_t, int32_t>* out) const override;
+
+    void
+    CopyRowElementStarts(int64_t row_start,
+                         int64_t row_count,
+                         int32_t* out) const override;
+
     std::pair<TargetBitmap, TargetBitmap>
     RowBitsetToElementBitset(const TargetBitmapView& row_bitset,
                              const TargetBitmapView& valid_row_bitset,
@@ -155,6 +203,12 @@ class ArrayOffsetsSealed : public IArrayOffsets {
     ForEachRowElementRange(const ElementRangePredicate& predicate,
                            int64_t row_start,
                            int64_t row_count) const override;
+
+    void
+    ElementBitsetToRowBitsetAny(const TargetBitmapView& elem_bitset,
+                                int64_t elem_offset,
+                                int64_t row_start,
+                                TargetBitmapView row_result) const override;
 
     static std::shared_ptr<ArrayOffsetsSealed>
     BuildFromSegment(const void* segment, const FieldMeta& field_meta);
@@ -194,6 +248,16 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
     std::pair<int32_t, int32_t>
     ElementIDRangeOfRow(int32_t row_id) const override;
 
+    void
+    CopyRowElementRanges(const int32_t* row_ids,
+                         int64_t count,
+                         std::pair<int32_t, int32_t>* out) const override;
+
+    void
+    CopyRowElementStarts(int64_t row_start,
+                         int64_t row_count,
+                         int32_t* out) const override;
+
     std::pair<TargetBitmap, TargetBitmap>
     RowBitsetToElementBitset(const TargetBitmapView& row_bitset,
                              const TargetBitmapView& valid_row_bitset,
@@ -211,6 +275,12 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
     ForEachRowElementRange(const ElementRangePredicate& predicate,
                            int64_t row_start,
                            int64_t row_count) const override;
+
+    void
+    ElementBitsetToRowBitsetAny(const TargetBitmapView& elem_bitset,
+                                int64_t elem_offset,
+                                int64_t row_start,
+                                TargetBitmapView row_result) const override;
 
  private:
     struct PendingRow {

--- a/internal/core/src/common/ArrayOffsets.h
+++ b/internal/core/src/common/ArrayOffsets.h
@@ -98,6 +98,22 @@ class IArrayOffsets {
     RowOffsetsToElementOffsets(
         const FixedVector<int32_t>& row_offsets) const = 0;
 
+    // Apply per-row NULL info retained from the raw field: clear result[i]
+    // for every row (row_start + i) whose ARRAY value is NULL. No-op when no
+    // validity was recorded (non-nullable source: every row is valid).
+    //
+    // A nested array index only exposes element-level validity, and a NULL row
+    // has zero elements -- indistinguishable at element level from an empty
+    // array. Row-level consumers (e.g. array_contains over a nullable array via
+    // a nested index) use this to exclude NULL rows exactly as the brute-force
+    // path does. Thread-safe on growing segments (locks internally); exposed
+    // as an apply-operation rather than a raw bitmap pointer because the
+    // growing implementation's bitmap grows concurrently with inserts.
+    virtual void
+    AndRowValidBitmap(TargetBitmapView result,
+                      int64_t row_start,
+                      int64_t row_count) const = 0;
+
     // Iterate over rows and apply predicate with element range
     // predicate: function(element_start, element_end) -> bool
     //   element_start: first element ID of the row (inclusive)
@@ -155,6 +171,23 @@ class ArrayOffsetsSealed : public IArrayOffsets {
         return result;
     }
 
+    // Build zero element ranges for rows whose ARRAY value is NULL. Offsets
+    // alone cannot distinguish NULL from a valid empty array, so retain an
+    // explicit all-false row-valid bitmap for row-level consumers of nested
+    // indexes. Used when schema evolution backfills a nullable ARRAY field
+    // without a default value.
+    static std::shared_ptr<ArrayOffsetsSealed>
+    BuildAllNulls(int64_t row_count) {
+        auto result = std::make_shared<ArrayOffsetsSealed>(
+            std::vector<int32_t>(row_count + 1, 0));
+        result->has_row_valid_ = true;
+        result->row_valid_ = TargetBitmap(row_count, false);
+        result->resource_size_ = 4 * (row_count + 1) + (row_count + 7) / 8;
+        cachinglayer::Manager::GetInstance().ChargeLoadedResource(
+            cachinglayer::ResourceUsage{result->resource_size_, 0});
+        return result;
+    }
+
     ~ArrayOffsetsSealed() {
         cachinglayer::Manager::GetInstance().RefundLoadedResource(
             {resource_size_, 0});
@@ -199,6 +232,25 @@ class ArrayOffsetsSealed : public IArrayOffsets {
     RowOffsetsToElementOffsets(
         const FixedVector<int32_t>& row_offsets) const override;
 
+    void
+    AndRowValidBitmap(TargetBitmapView result,
+                      int64_t row_start,
+                      int64_t row_count) const override {
+        if (!has_row_valid_) {
+            return;
+        }
+        auto rows = static_cast<int64_t>(row_valid_.size());
+        for (int64_t i = 0; i < row_count; ++i) {
+            auto row = row_start + i;
+            if (row >= rows) {
+                break;
+            }
+            if (!row_valid_[row]) {
+                result[i] = false;
+            }
+        }
+    }
+
     TargetBitmap
     ForEachRowElementRange(const ElementRangePredicate& predicate,
                            int64_t row_start,
@@ -220,6 +272,11 @@ class ArrayOffsetsSealed : public IArrayOffsets {
 
  private:
     const std::vector<int32_t> row_to_element_start_;
+    // Per-row NULL bitmap (bit==true => non-null). Populated by the static
+    // builders when the source field is nullable; empty & has_row_valid_==false
+    // for non-nullable fields (all rows valid).
+    TargetBitmap row_valid_;
+    bool has_row_valid_{false};
     int64_t resource_size_{0};
 };
 
@@ -227,8 +284,20 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
  public:
     ArrayOffsetsGrowing() = default;
 
+    // array_lengths[i] < 0 marks a NULL row: recorded as zero elements AND
+    // row-invalid (see AndRowValidBitmap); >= 0 is a real (possibly empty)
+    // array. The insert extractors emit -1 for NULL rows so offsets-level
+    // consumers can distinguish NULL from [] exactly like sealed segments.
     void
     Insert(int64_t row_id_start, const int32_t* array_lengths, int64_t count);
+
+    // Backfill for schema evolution: `count` rows starting at row_id_start
+    // whose ARRAY value is NULL (zero elements, row-invalid). Mirrors
+    // ArrayOffsetsSealed::BuildAllNulls so growing and sealed segments agree
+    // that historical rows of a backfilled nullable ARRAY field are NULL,
+    // not empty arrays.
+    void
+    InsertNulls(int64_t row_id_start, int64_t count);
 
     int64_t
     GetRowCount() const override {
@@ -271,6 +340,11 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
     RowOffsetsToElementOffsets(
         const FixedVector<int32_t>& row_offsets) const override;
 
+    void
+    AndRowValidBitmap(TargetBitmapView result,
+                      int64_t row_start,
+                      int64_t row_count) const override;
+
     TargetBitmap
     ForEachRowElementRange(const ElementRangePredicate& predicate,
                            int64_t row_start,
@@ -286,13 +360,25 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
     struct PendingRow {
         int64_t row_id;
         int32_t array_len;
+        bool valid;
     };
+
+    void
+    CommitRow(int32_t array_len, bool valid);
 
     void
     DrainPendingRows();
 
  private:
     std::vector<int32_t> row_to_element_start_;
+
+    // Per-committed-row validity (1 = non-null), lockstep with
+    // committed_row_count_. Lazily materialized on the first NULL row so the
+    // common all-valid case stays overhead-free; has_row_valid_ (not
+    // row_valid_.empty(), which is ambiguous when the first committed row is
+    // itself NULL) tells whether it was materialized.
+    std::vector<uint8_t> row_valid_;
+    bool has_row_valid_{false};
 
     // Number of rows committed (contiguous from 0)
     int32_t committed_row_count_ = 0;

--- a/internal/core/src/common/ArrayOffsetsTest.cpp
+++ b/internal/core/src/common/ArrayOffsetsTest.cpp
@@ -156,6 +156,104 @@ TEST_F(ArrayOffsetsTest, SealedEmptyArrays) {
     }
 }
 
+TEST_F(ArrayOffsetsTest, SealedAllNullArrays) {
+    constexpr int64_t row_count = 4;
+    auto offsets = ArrayOffsetsSealed::BuildAllNulls(row_count);
+
+    ASSERT_NE(offsets, nullptr);
+    EXPECT_EQ(offsets->GetRowCount(), row_count);
+    EXPECT_EQ(offsets->GetTotalElementCount(), 0);
+    for (int64_t row = 0; row <= row_count; ++row) {
+        auto [start, end] = offsets->ElementIDRangeOfRow(row);
+        EXPECT_EQ(start, 0);
+        EXPECT_EQ(end, 0);
+    }
+
+    milvus::TargetBitmap probe(row_count, true);
+    offsets->AndRowValidBitmap(probe.view(), 0, row_count);
+    EXPECT_TRUE(probe.none());
+}
+
+TEST_F(ArrayOffsetsTest, GrowingRowValidity) {
+    ArrayOffsetsGrowing offsets;
+
+    // -1 marks a NULL row: zero elements + row-invalid; 0 is a real empty
+    // array and stays valid.
+    std::vector<int32_t> lens = {2, -1, 0, 3};
+    offsets.Insert(0, lens.data(), 4);
+
+    EXPECT_EQ(offsets.GetRowCount(), 4);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 5);
+    // NULL row and empty row both have zero-length element ranges...
+    auto [null_start, null_end] = offsets.ElementIDRangeOfRow(1);
+    EXPECT_EQ(null_start, null_end);
+    auto [empty_start, empty_end] = offsets.ElementIDRangeOfRow(2);
+    EXPECT_EQ(empty_start, empty_end);
+
+    // ...but only the NULL row is reported invalid.
+    milvus::TargetBitmap probe(4, true);
+    offsets.AndRowValidBitmap(probe.view(), 0, 4);
+    EXPECT_TRUE(probe[0]);
+    EXPECT_FALSE(probe[1]);
+    EXPECT_TRUE(probe[2]);
+    EXPECT_TRUE(probe[3]);
+
+    // Out-of-order insert keeps validity lockstep: row 5 arrives (pending),
+    // then row 4 (NULL) commits both.
+    std::vector<int32_t> lens5 = {1};
+    offsets.Insert(5, lens5.data(), 1);
+    std::vector<int32_t> lens4 = {-1};
+    offsets.Insert(4, lens4.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 6);
+    milvus::TargetBitmap probe2(6, true);
+    offsets.AndRowValidBitmap(probe2.view(), 0, 6);
+    EXPECT_FALSE(probe2[4]);
+    EXPECT_TRUE(probe2[5]);
+
+    // row_start slicing.
+    milvus::TargetBitmap probe3(2, true);
+    offsets.AndRowValidBitmap(probe3.view(), 4, 2);
+    EXPECT_FALSE(probe3[0]);
+    EXPECT_TRUE(probe3[1]);
+}
+
+TEST_F(ArrayOffsetsTest, GrowingInsertNullsBackfill) {
+    ArrayOffsetsGrowing offsets;
+
+    // Schema-evolution backfill: historical rows are NULL, not empty arrays
+    // (mirrors ArrayOffsetsSealed::BuildAllNulls).
+    offsets.InsertNulls(0, 3);
+    EXPECT_EQ(offsets.GetRowCount(), 3);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 0);
+
+    milvus::TargetBitmap probe(3, true);
+    offsets.AndRowValidBitmap(probe.view(), 0, 3);
+    EXPECT_TRUE(probe.none());
+
+    // Rows inserted after the evolution behave normally.
+    std::vector<int32_t> lens = {2};
+    offsets.Insert(3, lens.data(), 1);
+    milvus::TargetBitmap probe2(4, true);
+    offsets.AndRowValidBitmap(probe2.view(), 0, 4);
+    EXPECT_FALSE(probe2[0]);
+    EXPECT_FALSE(probe2[1]);
+    EXPECT_FALSE(probe2[2]);
+    EXPECT_TRUE(probe2[3]);
+}
+
+TEST_F(ArrayOffsetsTest, GrowingAllValidIsNoop) {
+    ArrayOffsetsGrowing offsets;
+
+    std::vector<int32_t> lens = {1, 0, 2};
+    offsets.Insert(0, lens.data(), 3);
+
+    // No NULL row was ever inserted: validity is not materialized and the
+    // apply is a no-op.
+    milvus::TargetBitmap probe(3, true);
+    offsets.AndRowValidBitmap(probe.view(), 0, 3);
+    EXPECT_TRUE(probe.all());
+}
+
 TEST_F(ArrayOffsetsTest, GrowingBasicInsert) {
     ArrayOffsetsGrowing offsets;
 

--- a/internal/core/src/common/ArrayOffsetsTest.cpp
+++ b/internal/core/src/common/ArrayOffsetsTest.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include <cstdint>
+#include <random>
 #include <string>
 #include <thread>
 #include <utility>
@@ -692,4 +693,325 @@ TEST_F(ArrayOffsetsTest, GrowingRowBitsetToElementBitsetWithRowStart) {
     EXPECT_FALSE(elem_bitset[3]);
     EXPECT_TRUE(elem_bitset[4]);
     EXPECT_TRUE(elem_bitset[5]);
+}
+
+// ============ ElementBitsetToRowBitsetAny (word-wise ANY reduction) ============
+
+namespace {
+
+// Per-bit reference implementation of ANY-semantics element->row reduction.
+TargetBitmap
+ReferenceAnyReduce(const IArrayOffsets& offsets,
+                   const TargetBitmap& elem_bitset,
+                   int64_t elem_offset,
+                   int64_t row_start,
+                   int64_t row_count) {
+    TargetBitmap expected(row_count);
+    for (int64_t i = 0; i < row_count; ++i) {
+        auto [start, end] = offsets.ElementIDRangeOfRow(row_start + i);
+        for (int64_t e = start; e < end; ++e) {
+            if (elem_bitset[e - elem_offset]) {
+                expected[i] = true;
+                break;
+            }
+        }
+    }
+    return expected;
+}
+
+void
+CheckAnyReduce(const IArrayOffsets& offsets,
+               const TargetBitmap& elem_bitset,
+               int64_t elem_offset,
+               int64_t row_start,
+               int64_t row_count) {
+    TargetBitmap actual(row_count);
+    offsets.ElementBitsetToRowBitsetAny(
+        elem_bitset.view(), elem_offset, row_start, actual.view());
+    TargetBitmap expected = ReferenceAnyReduce(
+        offsets, elem_bitset, elem_offset, row_start, row_count);
+    ASSERT_EQ(actual.size(), expected.size());
+    for (int64_t i = 0; i < row_count; ++i) {
+        ASSERT_EQ(actual[i], expected[i])
+            << "row " << i << " (row_start=" << row_start
+            << ", elem_offset=" << elem_offset << ")";
+    }
+}
+
+}  // namespace
+
+TEST_F(ArrayOffsetsTest, SealedElementBitsetToRowBitsetAnyBasic) {
+    // row 0: elems [0,2), row 1: elems [2,5), row 2: empty, row 3: elems [5,6)
+    ArrayOffsetsSealed offsets({0, 2, 5, 5, 6});
+
+    TargetBitmap elem_bitset(6);
+    elem_bitset[3] = true;  // row 1
+    elem_bitset[5] = true;  // row 3
+
+    TargetBitmap row_bitset(4);
+    offsets.ElementBitsetToRowBitsetAny(
+        elem_bitset.view(), 0, 0, row_bitset.view());
+    EXPECT_FALSE(row_bitset[0]);
+    EXPECT_TRUE(row_bitset[1]);
+    EXPECT_FALSE(row_bitset[2]);  // empty row never matches
+    EXPECT_TRUE(row_bitset[3]);
+
+    // Never clears pre-set bits.
+    TargetBitmap preset(4);
+    preset[0] = true;
+    offsets.ElementBitsetToRowBitsetAny(
+        elem_bitset.view(), 0, 0, preset.view());
+    EXPECT_TRUE(preset[0]);
+    EXPECT_TRUE(preset[1]);
+    EXPECT_FALSE(preset[2]);
+    EXPECT_TRUE(preset[3]);
+}
+
+TEST_F(ArrayOffsetsTest, SealedElementBitsetToRowBitsetAnyEdgeCases) {
+    ArrayOffsetsSealed offsets({0, 2, 5, 5, 6});
+
+    // All-zero element bitmap -> no rows.
+    {
+        TargetBitmap elem_bitset(6);
+        TargetBitmap row_bitset(4);
+        offsets.ElementBitsetToRowBitsetAny(
+            elem_bitset.view(), 0, 0, row_bitset.view());
+        EXPECT_EQ(row_bitset.count(), 0);
+    }
+    // All-one element bitmap -> all non-empty rows.
+    {
+        TargetBitmap elem_bitset(6, true);
+        TargetBitmap row_bitset(4);
+        offsets.ElementBitsetToRowBitsetAny(
+            elem_bitset.view(), 0, 0, row_bitset.view());
+        EXPECT_TRUE(row_bitset[0]);
+        EXPECT_TRUE(row_bitset[1]);
+        EXPECT_FALSE(row_bitset[2]);
+        EXPECT_TRUE(row_bitset[3]);
+    }
+    // Empty row range.
+    {
+        TargetBitmap elem_bitset(6, true);
+        TargetBitmap row_bitset(0);
+        offsets.ElementBitsetToRowBitsetAny(
+            elem_bitset.view(), 0, 0, row_bitset.view());
+    }
+    // Sub-range of rows with a batch-local bitmap (elem_offset != 0):
+    // rows [1, 4) cover elements [2, 6).
+    {
+        TargetBitmap elem_bitset(4);
+        elem_bitset[0] = true;  // global elem 2 -> row 1
+        elem_bitset[3] = true;  // global elem 5 -> row 3
+        TargetBitmap row_bitset(3);
+        offsets.ElementBitsetToRowBitsetAny(elem_bitset.view(),
+                                            /*elem_offset=*/2,
+                                            /*row_start=*/1,
+                                            row_bitset.view());
+        EXPECT_TRUE(row_bitset[0]);
+        EXPECT_FALSE(row_bitset[1]);
+        EXPECT_TRUE(row_bitset[2]);
+    }
+    // Global bitmap but only a sub-range of rows: hits outside the row range
+    // must be ignored.
+    {
+        TargetBitmap elem_bitset(6);
+        elem_bitset[0] = true;  // row 0, outside range
+        elem_bitset[3] = true;  // row 1, inside
+        TargetBitmap row_bitset(2);
+        offsets.ElementBitsetToRowBitsetAny(
+            elem_bitset.view(), 0, /*row_start=*/1, row_bitset.view());
+        EXPECT_TRUE(row_bitset[0]);   // row 1
+        EXPECT_FALSE(row_bitset[1]);  // row 2 (empty)
+    }
+}
+
+TEST_F(ArrayOffsetsTest, ElementBitsetToRowBitsetAnyRandomized) {
+    std::mt19937 rng(12345);
+    for (int iter = 0; iter < 20; ++iter) {
+        // Random layout: mixes empty rows, short and long (multi-word) rows.
+        int64_t num_rows = 1 + rng() % 300;
+        std::vector<int32_t> starts(num_rows + 1, 0);
+        std::vector<int32_t> lengths(num_rows);
+        for (int64_t i = 0; i < num_rows; ++i) {
+            int pick = rng() % 4;
+            lengths[i] = pick == 0 ? 0 : (pick == 1 ? rng() % 3 : rng() % 200);
+            starts[i + 1] = starts[i] + lengths[i];
+        }
+        int64_t total = starts[num_rows];
+
+        ArrayOffsetsSealed sealed(starts);
+        ArrayOffsetsGrowing growing;
+        growing.Insert(0, lengths.data(), num_rows);
+
+        for (double density : {0.0, 0.005, 0.1, 0.9, 1.0}) {
+            TargetBitmap elem_bitset(total);
+            for (int64_t e = 0; e < total; ++e) {
+                if (rng() % 1000 < density * 1000) {
+                    elem_bitset[e] = true;
+                }
+            }
+            CheckAnyReduce(sealed, elem_bitset, 0, 0, num_rows);
+            CheckAnyReduce(growing, elem_bitset, 0, 0, num_rows);
+
+            // Random row sub-range with a batch-local element bitmap.
+            int64_t row_start = rng() % num_rows;
+            int64_t row_count = rng() % (num_rows - row_start + 1);
+            int64_t elem_lo = starts[row_start];
+            int64_t elem_hi = starts[row_start + row_count];
+            TargetBitmap local(elem_hi - elem_lo);
+            for (int64_t e = elem_lo; e < elem_hi; ++e) {
+                if (elem_bitset[e]) {
+                    local[e - elem_lo] = true;
+                }
+            }
+            CheckAnyReduce(sealed, local, elem_lo, row_start, row_count);
+            CheckAnyReduce(growing, local, elem_lo, row_start, row_count);
+        }
+    }
+}
+
+// ==== CopyRowElementStarts / CopyRowElementRanges (batched row lookups) ====
+
+TEST_F(ArrayOffsetsTest, SealedCopyRowElementStarts) {
+    // row 0: [0,2), row 1: [2,5), row 2: empty, row 3: [5,6)
+    ArrayOffsetsSealed offsets({0, 2, 5, 5, 6});
+
+    // Full range: row_count + 1 entries.
+    {
+        std::vector<int32_t> out(5, -1);
+        offsets.CopyRowElementStarts(0, 4, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 2, 5, 5, 6}));
+    }
+    // Sub-range starting mid-way (covers the empty row 2).
+    {
+        std::vector<int32_t> out(3, -1);
+        offsets.CopyRowElementStarts(1, 2, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{2, 5, 5}));
+    }
+    // row_count == 0: single entry, the start of row_start (here the total,
+    // since row_start == row count).
+    {
+        int32_t out = -1;
+        offsets.CopyRowElementStarts(4, 0, &out);
+        EXPECT_EQ(out, 6);
+    }
+    // Consistency with the per-row method.
+    {
+        std::vector<int32_t> out(5, -1);
+        offsets.CopyRowElementStarts(0, 4, out.data());
+        for (int32_t row = 0; row < 4; ++row) {
+            auto [start, end] = offsets.ElementIDRangeOfRow(row);
+            EXPECT_EQ(out[row], start);
+            EXPECT_EQ(out[row + 1], end);
+        }
+    }
+}
+
+TEST_F(ArrayOffsetsTest, GrowingCopyRowElementStartsClamp) {
+    ArrayOffsetsGrowing offsets;
+
+    // No committed rows yet: every entry clamps to 0.
+    {
+        std::vector<int32_t> out(4, -1);
+        offsets.CopyRowElementStarts(0, 3, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 0, 0, 0}));
+    }
+
+    std::vector<int32_t> lens = {2, 3, 0, 1};
+    offsets.Insert(0, lens.data(), 4);
+
+    // Fully committed range (fast copy path), includes the empty row 2.
+    {
+        std::vector<int32_t> out(5, -1);
+        offsets.CopyRowElementStarts(0, 4, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 2, 5, 5, 6}));
+    }
+    // Row 6 arrives out of order and stays PENDING (row 4/5 missing): rows
+    // at or beyond the committed count clamp to the committed total, so
+    // pending rows read as empty instead of exposing garbage.
+    std::vector<int32_t> lens6 = {7};
+    offsets.Insert(6, lens6.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 4);
+    {
+        std::vector<int32_t> out(8, -1);
+        offsets.CopyRowElementStarts(0, 7, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 2, 5, 5, 6, 6, 6, 6}));
+    }
+    // Range entirely beyond the committed rows.
+    {
+        std::vector<int32_t> out(3, -1);
+        offsets.CopyRowElementStarts(5, 2, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{6, 6, 6}));
+    }
+    // Committing the gap drains the pending row and un-clamps it.
+    std::vector<int32_t> lens45 = {1, 0};
+    offsets.Insert(4, lens45.data(), 2);
+    EXPECT_EQ(offsets.GetRowCount(), 7);
+    {
+        std::vector<int32_t> out(8, -1);
+        offsets.CopyRowElementStarts(0, 7, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 2, 5, 5, 6, 7, 7, 14}));
+    }
+}
+
+TEST_F(ArrayOffsetsTest, SealedCopyRowElementRanges) {
+    // row 0: [0,2), row 1: [2,5), row 2: empty, row 3: [5,6)
+    ArrayOffsetsSealed offsets({0, 2, 5, 5, 6});
+
+    // Arbitrary order + duplicates + the end sentinel row (== row_count).
+    std::vector<int32_t> rows = {3, 0, 2, 0, 4};
+    std::vector<std::pair<int32_t, int32_t>> out(rows.size());
+    offsets.CopyRowElementRanges(
+        rows.data(), static_cast<int64_t>(rows.size()), out.data());
+    EXPECT_EQ(out[0], (std::pair<int32_t, int32_t>{5, 6}));
+    EXPECT_EQ(out[1], (std::pair<int32_t, int32_t>{0, 2}));
+    EXPECT_EQ(out[2], (std::pair<int32_t, int32_t>{5, 5}));  // empty row
+    EXPECT_EQ(out[3], (std::pair<int32_t, int32_t>{0, 2}));
+    EXPECT_EQ(out[4], (std::pair<int32_t, int32_t>{6, 6}));  // == row_count
+    // Consistency with the per-row method.
+    for (size_t i = 0; i < rows.size(); ++i) {
+        EXPECT_EQ(out[i], offsets.ElementIDRangeOfRow(rows[i]));
+    }
+}
+
+TEST_F(ArrayOffsetsTest, GrowingCopyRowElementRanges) {
+    ArrayOffsetsGrowing offsets;
+
+    // No committed rows: {0, 0} out-of-range insurance.
+    {
+        std::vector<int32_t> rows = {0};
+        std::pair<int32_t, int32_t> out{-1, -1};
+        offsets.CopyRowElementRanges(rows.data(), 1, &out);
+        EXPECT_EQ(out, (std::pair<int32_t, int32_t>{0, 0}));
+    }
+
+    std::vector<int32_t> lens = {2, 0, 3};
+    offsets.Insert(0, lens.data(), 3);
+
+    std::vector<int32_t> rows = {2, 1, 0, 3};
+    std::vector<std::pair<int32_t, int32_t>> out(rows.size());
+    offsets.CopyRowElementRanges(
+        rows.data(), static_cast<int64_t>(rows.size()), out.data());
+    EXPECT_EQ(out[0], (std::pair<int32_t, int32_t>{2, 5}));
+    EXPECT_EQ(out[1], (std::pair<int32_t, int32_t>{2, 2}));  // empty row
+    EXPECT_EQ(out[2], (std::pair<int32_t, int32_t>{0, 2}));
+    // committed_row_count_ itself reads as {total, total}.
+    EXPECT_EQ(out[3], (std::pair<int32_t, int32_t>{5, 5}));
+    for (size_t i = 0; i < rows.size(); ++i) {
+        EXPECT_EQ(out[i], offsets.ElementIDRangeOfRow(rows[i]));
+    }
+
+    // Row 5 arrives out of order and stays pending: it is beyond the
+    // committed count and reads as {0, 0} (out-of-range insurance) rather
+    // than exposing a half-written range.
+    std::vector<int32_t> lens5 = {4};
+    offsets.Insert(5, lens5.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 3);
+    {
+        std::vector<int32_t> pending_rows = {5, 4};
+        std::vector<std::pair<int32_t, int32_t>> pending_out(2);
+        offsets.CopyRowElementRanges(pending_rows.data(), 2, pending_out.data());
+        EXPECT_EQ(pending_out[0], (std::pair<int32_t, int32_t>{0, 0}));
+        EXPECT_EQ(pending_out[1], (std::pair<int32_t, int32_t>{0, 0}));
+    }
 }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1941,7 +1941,24 @@ class SegmentExpr : public Expr {
                         }
                     } else if (cached_is_nested_index_ &&
                                func_returns_row_level) {
+                        // The func already reduced element-level matches to a
+                        // row-level bitset, but a nested index only exposes
+                        // element-level validity (index_ptr->IsNotNull()): a
+                        // NULL row has zero elements and cannot be recovered
+                        // from it. Recover per-row NULL info from the raw field
+                        // (retained by ArrayOffsets at build time) and AND it in
+                        // so NULL rows are excluded exactly as the brute-force
+                        // path does -- otherwise `not array_contains(nullable,
+                        // x)` wrongly includes NULL rows.
                         valid_res = TargetBitmap(active_count_, true);
+                        if (field_type_ == DataType::ARRAY) {
+                            auto array_offsets =
+                                segment_->GetArrayOffsets(field_id_);
+                            if (array_offsets != nullptr) {
+                                array_offsets->AndRowValidBitmap(
+                                    valid_res.view(), 0, active_count_);
+                            }
+                        }
                     } else {
                         valid_res = index_ptr->IsNotNull();
                     }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -971,82 +971,124 @@ class SegmentExpr : public Expr {
                           field_id_.get());
             }
 
-            // Batch process consecutive elements belonging to the same chunk
+            // The element ids arriving here come from
+            // RowOffsetsToElementOffsets, which emits each row's element ids
+            // CONSECUTIVELY ASCENDING. Exploit that: resolve (row, elem_idx)
+            // ONCE per run of consecutive ids inside one row, instead of one
+            // binary search + one chunk lookup + one ArrayView fetch per
+            // element. The run assumption is guarded per element (any id
+            // that is not the expected consecutive one simply starts a fresh
+            // run), so correctness never depends on the input being sorted.
             size_t processed_size = 0;
             size_t i = 0;
 
-            // Reuse these vectors to avoid repeated heap allocations
+            // Reuse these vectors to avoid repeated heap allocations.
+            // One entry per RUN (not per element): the run's row chunk
+            // offset, the run's first element index within the row, and the
+            // run length in elements.
             FixedVector<int32_t> offsets;
-            FixedVector<int32_t> elem_indices;
+            FixedVector<int32_t> first_elem_indices;
+            FixedVector<int32_t> run_lengths;
+
+            struct RunInfo {
+                int32_t row_id;
+                int32_t first_elem_idx;
+                int32_t length;
+            };
+            // Resolve the run starting at input position pos: one row
+            // resolution covers every consecutive element id of that row.
+            auto resolve_run = [&](size_t pos) -> RunInfo {
+                int32_t element_id = (*element_ids)[pos];
+                auto [row_id, elem_idx] =
+                    array_offsets->ElementIDToRowID(element_id);
+                const int32_t row_last =
+                    array_offsets->ElementIDRangeOfRow(row_id).second;
+                int64_t max_run =
+                    std::min<int64_t>(row_last - element_id,
+                                      element_ids->size() - pos);
+                int64_t run_len = 1;
+                while (run_len < max_run &&
+                       (*element_ids)[pos + run_len] == element_id + run_len) {
+                    ++run_len;
+                }
+                return {row_id, elem_idx, static_cast<int32_t>(run_len)};
+            };
 
             while (i < element_ids->size()) {
                 // Start of a new chunk batch
-                int64_t element_id = (*element_ids)[i];
-                auto [doc_id, elem_idx] =
-                    array_offsets->ElementIDToRowID(element_id);
+                auto run = resolve_run(i);
                 auto [chunk_id, chunk_offset] =
-                    segment_->get_chunk_by_offset(field_id_, doc_id);
+                    segment_->get_chunk_by_offset(field_id_, run.row_id);
 
-                // Collect consecutive elements belonging to the same chunk
+                // Collect consecutive runs belonging to the same chunk
                 offsets.clear();
-                elem_indices.clear();
+                first_elem_indices.clear();
+                run_lengths.clear();
                 offsets.push_back(chunk_offset);
-                elem_indices.push_back(elem_idx);
+                first_elem_indices.push_back(run.first_elem_idx);
+                run_lengths.push_back(run.length);
 
                 size_t batch_start = i;
-                i++;
+                i += run.length;
 
-                // Look ahead for more elements in the same chunk
+                // Look ahead for more runs in the same chunk
                 while (i < element_ids->size()) {
-                    int64_t next_element_id = (*element_ids)[i];
-                    auto [next_doc_id, next_elem_idx] =
-                        array_offsets->ElementIDToRowID(next_element_id);
+                    auto next_run = resolve_run(i);
                     auto [next_chunk_id, next_chunk_offset] =
-                        segment_->get_chunk_by_offset(field_id_, next_doc_id);
+                        segment_->get_chunk_by_offset(field_id_,
+                                                      next_run.row_id);
 
                     if (next_chunk_id != chunk_id) {
                         break;  // Different chunk, process current batch
                     }
 
                     offsets.push_back(next_chunk_offset);
-                    elem_indices.push_back(next_elem_idx);
-                    i++;
+                    first_elem_indices.push_back(next_run.first_elem_idx);
+                    run_lengths.push_back(next_run.length);
+                    i += next_run.length;
                 }
 
-                // Batch fetch all ArrayViews for this chunk
+                // Batch fetch ONE ArrayView per run (per row) in this chunk
                 auto pw = segment_->get_views_by_offsets<ArrayView>(
                     op_ctx_, field_id_, chunk_id, offsets);
 
                 auto [array_vec, valid_data] = pw.get();
 
-                // Process each element in this batch
+                const bool chunk_active =
+                    !skip_func || !skip_func(skip_index, field_id_, chunk_id);
+
+                // Process each run's elements in this batch
+                size_t result_idx = batch_start;
                 for (size_t j = 0; j < offsets.size(); j++) {
-                    size_t result_idx = batch_start + j;
+                    for (int32_t t = 0; t < run_lengths[j];
+                         ++t, ++result_idx) {
+                        if (chunk_active) {
+                            // Extract element from ArrayView
+                            auto value =
+                                array_vec[j].template get_data<ElementType>(
+                                    first_elem_indices[j] + t);
+                            bool is_valid =
+                                !valid_data.data() || valid_data[j];
 
-                    if (!skip_func ||
-                        !skip_func(skip_index, field_id_, chunk_id)) {
-                        // Extract element from ArrayView
-                        auto value =
-                            array_vec[j].template get_data<ElementType>(
-                                elem_indices[j]);
-                        bool is_valid = !valid_data.data() || valid_data[j];
-
-                        func.template operator()<FilterType::random>(
-                            &value,
-                            &is_valid,
-                            nullptr,
-                            1,
-                            res + result_idx,
-                            valid_res + result_idx,
-                            values...);
-                    } else {
-                        // Chunk is skipped - handle exactly like ProcessDataByOffsets
-                        if (valid_data.size() > j && !valid_data[j]) {
-                            res[result_idx] = valid_res[result_idx] = false;
+                            func.template operator()<FilterType::random>(
+                                &value,
+                                &is_valid,
+                                nullptr,
+                                1,
+                                res + result_idx,
+                                valid_res + result_idx,
+                                values...);
+                        } else {
+                            // Chunk is skipped - handle exactly like
+                            // ProcessDataByOffsets
+                            if (valid_data.size() > j && !valid_data[j]) {
+                                res[result_idx] = valid_res[result_idx] =
+                                    false;
+                            }
                         }
-                    }
 
-                    processed_size++;
+                        processed_size++;
+                    }
                 }
             }
             return processed_size;
@@ -1060,12 +1102,29 @@ class SegmentExpr : public Expr {
 
             auto& skip_index = segment_->GetSkipIndex();
             size_t processed_size = 0;
+            size_t i = 0;
 
-            for (size_t i = 0; i < element_ids->size(); i++) {
-                int64_t element_id = (*element_ids)[i];
+            // Same run exploitation as the sealed branch: element ids from
+            // RowOffsetsToElementOffsets list each row's elements
+            // consecutively ascending, so resolve the row (two virtual
+            // calls, i.e. two shared locks on the growing offsets) and pin
+            // the Array chunk ONCE per run instead of once per element. The
+            // consecutive-id guard below keeps this correct for arbitrary
+            // input orders.
+            while (i < element_ids->size()) {
+                int32_t element_id = (*element_ids)[i];
 
                 auto [doc_id, elem_idx] =
                     array_offsets->ElementIDToRowID(element_id);
+                const int32_t row_last =
+                    array_offsets->ElementIDRangeOfRow(doc_id).second;
+                int64_t max_run = std::min<int64_t>(
+                    row_last - element_id, element_ids->size() - i);
+                int64_t run_len = 1;
+                while (run_len < max_run &&
+                       (*element_ids)[i + run_len] == element_id + run_len) {
+                    ++run_len;
+                }
 
                 // Calculate chunk_id and chunk_offset for this doc
                 auto chunk_id = doc_id / size_per_chunk_;
@@ -1081,27 +1140,35 @@ class SegmentExpr : public Expr {
                     valid_data += chunk_offset;
                 }
 
-                if (!skip_func || !skip_func(skip_index, field_id_, chunk_id)) {
-                    // Extract element from Array
-                    auto value = array_ptr->get_data<ElementType>(elem_idx);
-                    bool is_valid = !valid_data || valid_data[0];
+                const bool chunk_active =
+                    !skip_func || !skip_func(skip_index, field_id_, chunk_id);
 
-                    func.template operator()<FilterType::random>(
-                        &value,
-                        &is_valid,
-                        nullptr,
-                        1,
-                        res + processed_size,
-                        valid_res + processed_size,
-                        values...);
-                } else {
-                    // Chunk is skipped
-                    if (valid_data && !valid_data[0]) {
-                        res[processed_size] = valid_res[processed_size] = false;
+                for (int64_t t = 0; t < run_len; ++t) {
+                    if (chunk_active) {
+                        // Extract element from Array
+                        auto value =
+                            array_ptr->get_data<ElementType>(elem_idx + t);
+                        bool is_valid = !valid_data || valid_data[0];
+
+                        func.template operator()<FilterType::random>(
+                            &value,
+                            &is_valid,
+                            nullptr,
+                            1,
+                            res + processed_size,
+                            valid_res + processed_size,
+                            values...);
+                    } else {
+                        // Chunk is skipped
+                        if (valid_data && !valid_data[0]) {
+                            res[processed_size] = valid_res[processed_size] =
+                                false;
+                        }
                     }
-                }
 
-                processed_size++;
+                    processed_size++;
+                }
+                i += run_len;
             }
 
             return processed_size;

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1079,12 +1079,22 @@ class SegmentExpr : public Expr {
                                 valid_res + result_idx,
                                 values...);
                         } else {
-                            // Chunk is skipped - handle exactly like
-                            // ProcessDataByOffsets
+                            // Chunk skipped by SkipIndex: mark null rows
+                            // invalid, then drive the callback on a null batch
+                            // so cursor-tracking callbacks keep processed_cursor
+                            // aligned (mirrors the ProcessDataByOffsets skip
+                            // branches).
                             if (valid_data.size() > j && !valid_data[j]) {
-                                res[result_idx] = valid_res[result_idx] =
-                                    false;
+                                res[result_idx] = valid_res[result_idx] = false;
                             }
+                            func.template operator()<FilterType::random>(
+                                nullptr,
+                                nullptr,
+                                nullptr,
+                                1,
+                                res + result_idx,
+                                valid_res + result_idx,
+                                values...);
                         }
 
                         processed_size++;
@@ -1159,11 +1169,22 @@ class SegmentExpr : public Expr {
                             valid_res + processed_size,
                             values...);
                     } else {
-                        // Chunk is skipped
+                        // Chunk skipped by SkipIndex: mark null rows invalid,
+                        // then drive the callback on a null batch so cursor-
+                        // tracking callbacks keep processed_cursor aligned
+                        // (mirrors the ProcessDataByOffsets skip branches).
                         if (valid_data && !valid_data[0]) {
                             res[processed_size] = valid_res[processed_size] =
                                 false;
                         }
+                        func.template operator()<FilterType::random>(
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            1,
+                            res + processed_size,
+                            valid_res + processed_size,
+                            values...);
                     }
 
                     processed_size++;

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -136,6 +136,11 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));
     if (expr_->vals_.empty()) {
+        if (expr_->column_.data_type_ == DataType::ARRAY &&
+            expr_->op_ == proto::plan::JSONContainsExpr_JSONOp_ContainsAll) {
+            result = ExecEmptyArrayContainsAll(context);
+            return;
+        }
         auto real_batch_size = has_offset_input_
                                    ? context.get_offset_input()->size()
                                    : GetNextBatchSize();
@@ -1048,6 +1053,76 @@ PhyJsonContainsFilterExpr::ExecArrayContainsAll(EvalCtx& context) {
     } else {
         processed_size = ProcessDataChunks<milvus::ArrayView>(
             execute_sub_batch, std::nullptr_t{}, res, valid_res, *elements);
+    }
+    AssertInfo(processed_size == real_batch_size,
+               "internal error: expr processed rows {} not equal "
+               "expect batch size {}",
+               processed_size,
+               real_batch_size);
+    return res_vec;
+}
+
+VectorPtr
+PhyJsonContainsFilterExpr::ExecEmptyArrayContainsAll(EvalCtx& context) {
+    auto* input = context.get_offset_input();
+    const auto& bitmap_input = context.get_bitmap_input();
+    AssertInfo(expr_->column_.nested_path_.size() == 0,
+               "[ExecEmptyArrayContainsAll]nested path must be null");
+    auto real_batch_size =
+        has_offset_input_ ? input->size() : GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
+
+    auto res_vec =
+        std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),
+                                       TargetBitmap(real_batch_size, true));
+    TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
+    TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
+
+    int processed_cursor = 0;
+    auto execute_sub_batch =
+        [&processed_cursor, &
+         bitmap_input ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::ArrayView* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res) {
+        // If data is nullptr, this chunk was skipped by SkipIndex.
+        // We only need to update processed_cursor for bitmap_input indexing.
+        if (data == nullptr) {
+            processed_cursor += size;
+            return;
+        }
+        bool has_bitmap_input = !bitmap_input.empty();
+        for (int i = 0; i < size; ++i) {
+            auto offset = i;
+            if constexpr (filter_type == FilterType::random) {
+                offset = (offsets) ? offsets[i] : i;
+            }
+            if (valid_data != nullptr && !valid_data[offset]) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
+                continue;
+            }
+            // A real array — even an empty one — vacuously contains all
+            // zero requested elements.
+            res[i] = true;
+        }
+        processed_cursor += size;
+    };
+
+    int64_t processed_size;
+    if (has_offset_input_) {
+        processed_size = ProcessDataByOffsets<milvus::ArrayView>(
+            execute_sub_batch, std::nullptr_t{}, input, res, valid_res);
+    } else {
+        processed_size = ProcessDataChunks<milvus::ArrayView>(
+            execute_sub_batch, std::nullptr_t{}, res, valid_res);
     }
     AssertInfo(processed_size == real_batch_size,
                "internal error: expr processed rows {} not equal "

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -495,6 +495,14 @@ class PhyJsonContainsFilterExpr : public SegmentExpr {
             exec_path_ = ExprExecPath::JsonStats;
             return;
         }
+        if (expr_->column_.data_type_ == DataType::ARRAY &&
+            expr_->vals_.empty() &&
+            expr_->op_ == proto::plan::JSONContainsExpr_JSONOp_ContainsAll) {
+            // Empty-set ARRAY ContainsAll needs row validity to distinguish
+            // NULL from [], which the scalar-index result cannot provide.
+            exec_path_ = ExprExecPath::RawData;
+            return;
+        }
         SegmentExpr::DetermineExecPath();
     }
 
@@ -525,6 +533,11 @@ class PhyJsonContainsFilterExpr : public SegmentExpr {
     template <typename ExprValueType>
     VectorPtr
     ExecArrayContainsAll(EvalCtx& context);
+
+    // Empty-set ARRAY ContainsAll is TRUE for every real array (including [])
+    // and UNKNOWN for NULL rows.
+    VectorPtr
+    ExecEmptyArrayContainsAll(EvalCtx& context);
 
     VectorPtr
     ExecJsonContainsArray(EvalCtx& context);

--- a/internal/core/src/exec/expression/MatchExpr.cpp
+++ b/internal/core/src/exec/expression/MatchExpr.cpp
@@ -36,6 +36,12 @@ using MatchType = milvus::expr::MatchType;
 
 // Core matching logic for a single row's elements
 // Returns true if the row matches the condition
+//
+// Word-wise implementation: the row's element bits are consumed in 64-bit
+// chunks (bitmap word width) instead of bit by bit. Invalid elements are
+// masked out with the valid bitmap, which preserves the per-bit semantics:
+// only valid elements are counted, and MatchAll requires every *valid*
+// element to match (vacuously true when the row has no valid elements).
 template <MatchType match_type, bool all_valid>
 bool
 MatchSingleRow(int64_t bitset_start,
@@ -43,68 +49,62 @@ MatchSingleRow(int64_t bitset_start,
                const TargetBitmapView& match_bitset,
                const TargetBitmapView& valid_bitset,
                int64_t threshold) {
+    using word_t = TargetBitmapView::policy_type::data_type;
+    constexpr int64_t kWordBits = static_cast<int64_t>(8 * sizeof(word_t));
+
     int64_t hit_count = 0;
-    int64_t element_count = row_elem_count;
 
-    if constexpr (all_valid) {
-        for (int64_t j = 0; j < row_elem_count; ++j) {
-            bool matched = match_bitset[bitset_start + j];
-            if (matched) {
-                ++hit_count;
-            }
-
-            // Early exit conditions
-            if constexpr (match_type == MatchType::MatchAny) {
-                if (hit_count > 0)
-                    return true;
-            } else if constexpr (match_type == MatchType::MatchAll) {
-                if (!matched)
+    for (int64_t done = 0; done < row_elem_count; done += kWordBits) {
+        const size_t n =
+            static_cast<size_t>(std::min(kWordBits, row_elem_count - done));
+        const size_t pos = static_cast<size_t>(bitset_start + done);
+        word_t m = match_bitset.read(pos, n);
+        if constexpr (all_valid) {
+            if constexpr (match_type == MatchType::MatchAll) {
+                const word_t full = (n == static_cast<size_t>(kWordBits))
+                                        ? ~word_t(0)
+                                        : ((word_t(1) << n) - 1);
+                if (m != full) {
                     return false;
-            } else if constexpr (match_type == MatchType::MatchLeast) {
-                if (hit_count >= threshold)
-                    return true;
-            } else if constexpr (match_type == MatchType::MatchMost ||
-                                 match_type == MatchType::MatchExact) {
-                if (hit_count > threshold)
-                    return false;
-            }
-        }
-    } else {
-        element_count = 0;
-        for (int64_t j = 0; j < row_elem_count; ++j) {
-            if (!valid_bitset[bitset_start + j]) {
+                }
                 continue;
             }
-            ++element_count;
-            bool matched = match_bitset[bitset_start + j];
-            if (matched) {
-                ++hit_count;
+        } else {
+            const word_t v = valid_bitset.read(pos, n);
+            m &= v;
+            if constexpr (match_type == MatchType::MatchAll) {
+                // Some valid element unmatched?
+                if (m != v) {
+                    return false;
+                }
+                continue;
             }
-
-            // Early exit conditions
-            if constexpr (match_type == MatchType::MatchAny) {
-                if (hit_count > 0)
-                    return true;
-            } else if constexpr (match_type == MatchType::MatchAll) {
-                if (!matched)
-                    return false;
-            } else if constexpr (match_type == MatchType::MatchLeast) {
-                if (hit_count >= threshold)
-                    return true;
-            } else if constexpr (match_type == MatchType::MatchMost ||
-                                 match_type == MatchType::MatchExact) {
-                if (hit_count > threshold)
-                    return false;
+        }
+        if constexpr (match_type == MatchType::MatchAny) {
+            if (m != 0) {
+                return true;
+            }
+        } else if constexpr (match_type == MatchType::MatchLeast) {
+            hit_count += __builtin_popcountll(m);
+            if (hit_count >= threshold) {
+                return true;
+            }
+        } else if constexpr (match_type == MatchType::MatchMost ||
+                             match_type == MatchType::MatchExact) {
+            hit_count += __builtin_popcountll(m);
+            if (hit_count > threshold) {
+                return false;
             }
         }
     }
 
     // Final match decision
     if constexpr (match_type == MatchType::MatchAny) {
-        return hit_count > 0;
+        return false;
     } else if constexpr (match_type == MatchType::MatchAll) {
-        // Empty array returns true (vacuous truth)
-        return hit_count == element_count;
+        // Every (valid) element matched; empty array returns true
+        // (vacuous truth).
+        return true;
     } else if constexpr (match_type == MatchType::MatchLeast) {
         return hit_count >= threshold;
     } else if constexpr (match_type == MatchType::MatchMost) {
@@ -147,11 +147,26 @@ ProcessContiguousRows(int64_t row_count,
                       const TargetBitmapView& valid_bitset,
                       TargetBitmapView& result_bitset,
                       int64_t threshold) {
+    if constexpr (match_type == MatchType::MatchAny && all_valid) {
+        // Fast path: ANY-semantics reduction over contiguous rows. The match
+        // bitmap covers exactly the element ranges of
+        // [row_start, row_start + row_count) shifted by elem_start; jump
+        // between set bits word-wise instead of walking rows element by
+        // element.
+        array_offsets->ElementBitsetToRowBitsetAny(
+            match_bitset, elem_start, row_start, result_bitset);
+        return;
+    }
+    // ONE batched virtual call for the whole batch instead of one
+    // ElementIDRangeOfRow per row (on growing segments the per-row call is a
+    // shared_lock acquire/release each, contending with Insert's unique
+    // lock).
+    FixedVector<int32_t> row_elem_starts(row_count + 1);
+    array_offsets->CopyRowElementStarts(
+        row_start, row_count, row_elem_starts.data());
     for (int64_t i = 0; i < row_count; ++i) {
-        auto [first_elem, last_elem] =
-            array_offsets->ElementIDRangeOfRow(row_start + i);
-        int64_t bitset_start = first_elem - elem_start;
-        int64_t row_elem_count = last_elem - first_elem;
+        int64_t bitset_start = row_elem_starts[i] - elem_start;
+        int64_t row_elem_count = row_elem_starts[i + 1] - row_elem_starts[i];
 
         bool matched = MatchSingleRow<match_type, all_valid>(bitset_start,
                                                              row_elem_count,
@@ -173,11 +188,16 @@ ProcessOffsetRows(const OffsetVector* row_offsets,
                   const TargetBitmapView& valid_bitset,
                   TargetBitmapView& result_bitset,
                   int64_t threshold) {
+    // ONE batched virtual call for all requested rows instead of one
+    // ElementIDRangeOfRow per row (single shared_lock on growing).
+    const auto row_count = static_cast<int64_t>(row_offsets->size());
+    FixedVector<std::pair<int32_t, int32_t>> ranges(row_count);
+    array_offsets->CopyRowElementRanges(
+        row_offsets->data(), row_count, ranges.data());
+
     int64_t elem_cursor = 0;
-    for (size_t i = 0; i < row_offsets->size(); ++i) {
-        auto [first_elem, last_elem] =
-            array_offsets->ElementIDRangeOfRow((*row_offsets)[i]);
-        int64_t row_elem_count = last_elem - first_elem;
+    for (int64_t i = 0; i < row_count; ++i) {
+        int64_t row_elem_count = ranges[i].second - ranges[i].first;
 
         if (MatchSingleRow<match_type, all_valid>(elem_cursor,
                                                   row_elem_count,

--- a/internal/core/src/exec/expression/MatchExpr.cpp
+++ b/internal/core/src/exec/expression/MatchExpr.cpp
@@ -308,6 +308,7 @@ PhyMatchFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
         if (MatchEmptyElements(match_type, threshold)) {
             bitset_view.set();
         }
+        MaskNullRows(col_vec.get(), field_meta.get_id(), input, batch_rows);
         if (!has_offset_input_) {
             current_pos_ += batch_rows;
         }
@@ -406,8 +407,35 @@ PhyMatchFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
         dispatch.template operator()<false>();
     }
 
+    MaskNullRows(col_vec.get(), field_meta.get_id(), input, batch_rows);
     if (!has_offset_input_) {
         current_pos_ += batch_rows;
+    }
+}
+
+void
+PhyMatchFilterExpr::MaskNullRows(ColumnVector* col_vec,
+                                 FieldId field_id,
+                                 const OffsetVector* input,
+                                 int64_t batch_rows) {
+    // Build the physical row-offset list for this batch (offset-input vs
+    // sequential scan), then ask the segment to clear the valid bits of NULL
+    // field rows. ApplyFieldValidDataByOffsets only CLEARS invalid rows and is
+    // a no-op for a non-nullable field, so this is safe for all field kinds and
+    // for both sealed and growing segments.
+    std::vector<int64_t> row_offsets(batch_rows);
+    for (int64_t i = 0; i < batch_rows; ++i) {
+        row_offsets[i] = has_offset_input_ ? static_cast<int64_t>((*input)[i])
+                                           : (current_pos_ + i);
+    }
+    TargetBitmapView bitset_view(col_vec->GetRawData(), col_vec->size());
+    TargetBitmapView valid_view(col_vec->GetValidRawData(), col_vec->size());
+    segment_->ApplyFieldValidDataByOffsets(
+        op_ctx_, field_id, row_offsets.data(), batch_rows, valid_view);
+    for (int64_t i = 0; i < batch_rows; ++i) {
+        if (!valid_view[i]) {
+            bitset_view[i] = false;
+        }
     }
 }
 

--- a/internal/core/src/exec/expression/MatchExpr.h
+++ b/internal/core/src/exec/expression/MatchExpr.h
@@ -84,6 +84,16 @@ class PhyMatchFilterExpr : public Expr {
     }
 
  private:
+    // Three-valued MATCH: mask rows whose ARRAY field value is NULL. For each row
+    // in the batch, clears both the valid bit and the match bit when the field is
+    // NULL. Works for both sealed and growing segments (reads field validity via
+    // segment_->ApplyFieldValidDataByOffsets). No-op for a non-nullable field.
+    void
+    MaskNullRows(ColumnVector* col_vec,
+                 FieldId field_id,
+                 const OffsetVector* input,
+                 int64_t batch_rows);
+
     std::shared_ptr<const milvus::expr::MatchExpr> expr_;
     const segcore::SegmentInternalInterface* segment_;
     int64_t active_count_;

--- a/internal/core/src/exec/expression/MatchExprTest.cpp
+++ b/internal/core/src/exec/expression/MatchExprTest.cpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <random>
 #include <set>
@@ -485,6 +486,273 @@ TEST(MatchExprZeroElementBatch, MatchAnyTreatsEmptyRowsAsNoMatch) {
     ASSERT_NE(result, nullptr);
     ASSERT_EQ(result->offset_size(), 1);
     EXPECT_EQ(result->offset(0), 2);
+}
+
+namespace {
+
+// Shared helpers for the nullable-struct three-valued-logic tests below.
+
+// Build the insert payload for a schema {id, struct_array[sub_int](nullable)}:
+// row0=[1,2], row1=NULL, row2=[], row3=[9001], row4=NULL. A NULL row and an
+// empty [] row both have zero elements; only three-valued handling
+// (PhyMatchFilterExpr::MaskNullRows) can tell them apart.
+std::unique_ptr<InsertRecordProto>
+BuildNullableStructInsertData(const std::shared_ptr<Schema>& schema,
+                              FieldId int64_fid,
+                              FieldId sub_int_fid,
+                              int64_t N) {
+    auto insert_data = std::make_unique<InsertRecordProto>();
+
+    std::vector<int64_t> ids(N);
+    std::iota(ids.begin(), ids.end(), 0);
+    auto id_array = CreateDataArrayFrom(
+        ids.data(), nullptr, N, schema->operator[](int64_fid));
+    insert_data->mutable_fields_data()->AddAllocated(id_array.release());
+
+    // Dense layout: NULL rows occupy an empty ScalarField slot.
+    std::vector<milvus::proto::schema::ScalarField> sub_int_data(N);
+    sub_int_data[0].mutable_int_data()->add_data(1);
+    sub_int_data[0].mutable_int_data()->add_data(2);
+    sub_int_data[3].mutable_int_data()->add_data(9001);
+    FixedVector<bool> valid = {true, false, true, true, false};
+    auto sub_int_array = CreateDataArrayFrom(
+        sub_int_data.data(), valid.data(), N, schema->operator[](sub_int_fid));
+    insert_data->mutable_fields_data()->AddAllocated(sub_int_array.release());
+    insert_data->set_num_rows(N);
+    return insert_data;
+}
+
+std::set<int64_t>
+RetrieveOffsets(SegmentInternalInterface* segment,
+                const std::shared_ptr<Schema>& schema,
+                const std::string& expr) {
+    ScopedSchemaHandle schema_handle(*schema);
+    auto plan_str = schema_handle.Parse(expr);
+    auto plan =
+        CreateRetrievePlanByExpr(schema, plan_str.data(), plan_str.size());
+    EXPECT_NE(plan, nullptr);
+    auto result = segment->Retrieve(
+        nullptr, plan.get(), 1L << 63, DEFAULT_MAX_OUTPUT_SIZE, false);
+    EXPECT_NE(result, nullptr);
+    std::set<int64_t> offsets;
+    for (const auto& offset : result->offset()) {
+        offsets.insert(offset);
+    }
+    return offsets;
+}
+
+// Three-valued MATCH over a NULLABLE struct array: a NULL row yields UNKNOWN
+// and must be excluded from every MATCH_* result -- including under `not`
+// (NOT UNKNOWN is still UNKNOWN) -- while a real empty [] row is a valid
+// zero-element array evaluated vacuously (ALL/EXACT(0) keep it, ANY drops
+// it). At offsets level a NULL row is indistinguishable from []: without
+// PhyMatchFilterExpr::MaskNullRows, MATCH_ALL vacuously matches NULL rows and
+// `not MATCH_ANY` turns their definite-FALSE into TRUE.
+void
+CheckNullableStructMatchThreeValued(SegmentInternalInterface* segment,
+                                    const std::shared_ptr<Schema>& schema) {
+    // Only row3 has a hit; NULL rows have no elements to begin with.
+    EXPECT_EQ(RetrieveOffsets(
+                  segment, schema, "match_any(struct_array, $[sub_int] >= 9000)"),
+              (std::set<int64_t>{3}));
+
+    // Every element of every REAL row satisfies >= 0 ([] vacuously). The NULL
+    // rows (1, 4) have zero elements too: without MaskNullRows they would be
+    // wrongly included as vacuous matches.
+    EXPECT_EQ(RetrieveOffsets(
+                  segment, schema, "match_all(struct_array, $[sub_int] >= 0)"),
+              (std::set<int64_t>{0, 2, 3}));
+
+    // NOT of MATCH_ANY: real zero-hit rows only. Without MaskNullRows the
+    // NULL rows read as definite FALSE and negation wrongly includes them.
+    EXPECT_EQ(
+        RetrieveOffsets(
+            segment, schema, "not match_any(struct_array, $[sub_int] >= 9000)"),
+        (std::set<int64_t>{0, 2}));
+
+    // EXACT(0): zero-hit REAL rows (incl. the empty array), never NULL rows.
+    EXPECT_EQ(RetrieveOffsets(segment,
+                              schema,
+                              "match_exact(struct_array, $[sub_int] == 12345, "
+                              "threshold=0)"),
+              (std::set<int64_t>{0, 2, 3}));
+}
+
+}  // namespace
+
+TEST(MatchExprNullableStruct, SealedNullRowsExcludedIncludingUnderNot) {
+    struct BatchSizeGuard {
+        int64_t saved;
+        ~BatchSizeGuard() {
+            EXEC_EVAL_EXPR_BATCH_SIZE.store(saved);
+        }
+    } guard{EXEC_EVAL_EXPR_BATCH_SIZE.load()};
+    // Batch size 2 makes the last batch contain ONLY the trailing NULL row
+    // (zero elements), exercising the all-empty-batch path of
+    // PhyMatchFilterExpr::Eval (MatchEmptyElements + MaskNullRows) in
+    // addition to the normal batched path.
+    EXEC_EVAL_EXPR_BATCH_SIZE.store(2);
+
+    auto schema = std::make_shared<Schema>();
+    auto int64_fid = schema->AddDebugField("id", DataType::INT64);
+    schema->set_primary_field_id(int64_fid);
+    auto sub_int_fid = schema->AddDebugArrayField(
+        "struct_array[sub_int]", DataType::INT32, /*nullable=*/true);
+
+    constexpr int64_t N = 5;
+    auto insert_data =
+        BuildNullableStructInsertData(schema, int64_fid, sub_int_fid, N);
+
+    GeneratedData generated_data;
+    generated_data.schema_ = schema;
+    generated_data.raw_ = insert_data.release();
+    for (int64_t i = 0; i < N; ++i) {
+        generated_data.row_ids_.push_back(i);
+        generated_data.timestamps_.push_back(i);
+    }
+
+    auto segment = CreateSealedWithFieldDataLoaded(schema, generated_data);
+    CheckNullableStructMatchThreeValued(segment.get(), schema);
+}
+
+TEST(MatchExprNullableStruct, GrowingNullRowsExcludedIncludingUnderNot) {
+    struct BatchSizeGuard {
+        int64_t saved;
+        ~BatchSizeGuard() {
+            EXEC_EVAL_EXPR_BATCH_SIZE.store(saved);
+        }
+    } guard{EXEC_EVAL_EXPR_BATCH_SIZE.load()};
+    EXEC_EVAL_EXPR_BATCH_SIZE.store(2);
+
+    auto schema = std::make_shared<Schema>();
+    auto int64_fid = schema->AddDebugField("id", DataType::INT64);
+    schema->set_primary_field_id(int64_fid);
+    auto sub_int_fid = schema->AddDebugArrayField(
+        "struct_array[sub_int]", DataType::INT32, /*nullable=*/true);
+
+    constexpr int64_t N = 5;
+    auto insert_data =
+        BuildNullableStructInsertData(schema, int64_fid, sub_int_fid, N);
+
+    std::vector<idx_t> row_ids(N);
+    std::vector<Timestamp> timestamps(N);
+    for (int64_t i = 0; i < N; ++i) {
+        row_ids[i] = i;
+        timestamps[i] = i;
+    }
+
+    // The realtime Insert path records the NULL rows through
+    // ExtractArrayLengths' -1 sentinel (zero elements, row-invalid).
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    segment->PreInsert(N);
+    segment->Insert(
+        0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    CheckNullableStructMatchThreeValued(segment.get(), schema);
+
+    // The growing offsets table must also report the NULL rows invalid for
+    // row-level consumers (AndRowValidBitmap), not merely zero-length.
+    auto offsets = segment->GetArrayOffsets(sub_int_fid);
+    ASSERT_NE(offsets, nullptr);
+    milvus::TargetBitmap probe(N, true);
+    offsets->AndRowValidBitmap(probe.view(), 0, N);
+    EXPECT_TRUE(probe[0]);
+    EXPECT_FALSE(probe[1]);
+    EXPECT_TRUE(probe[2]);
+    EXPECT_TRUE(probe[3]);
+    EXPECT_FALSE(probe[4]);
+}
+
+// Schema evolution backfill: rows that existed before a nullable struct-array
+// field was added are NULL, not empty arrays. The growing Reopen path must
+// register the field's offsets via InsertNulls so AndRowValidBitmap reports
+// every backfilled row invalid (mirroring ArrayOffsetsSealed::BuildAllNulls).
+TEST(StructArrayNullBackfill, GrowingReopenRecordsBackfilledRowsAsNull) {
+    auto schema_v1 = std::make_shared<Schema>();
+    auto pk_fid = schema_v1->AddDebugField("id", DataType::INT64);
+    schema_v1->set_primary_field_id(pk_fid);
+    schema_v1->set_schema_version(1);
+
+    constexpr int64_t N = 3;
+    auto segment = CreateGrowingSegment(schema_v1, empty_index_meta);
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    std::vector<int64_t> ids(N);
+    std::iota(ids.begin(), ids.end(), 0);
+    auto id_array = CreateDataArrayFrom(
+        ids.data(), nullptr, N, schema_v1->operator[](pk_fid));
+    insert_data->mutable_fields_data()->AddAllocated(id_array.release());
+    insert_data->set_num_rows(N);
+
+    std::vector<idx_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {0, 1, 2};
+    segment->PreInsert(N);
+    segment->Insert(
+        0, N, row_ids.data(), timestamps.data(), insert_data.get());
+    ASSERT_EQ(segment->get_row_count(), N);
+
+    // V2 copies V1 (identical ids for shared fields) and adds a nullable
+    // struct-array sub-field, as AddCollectionField would.
+    auto schema_v2 = std::make_shared<Schema>(*schema_v1);
+    auto sub_fid = schema_v2->AddDebugArrayField(
+        "struct_array[sub_int]", DataType::INT32, /*nullable=*/true);
+    schema_v2->set_schema_version(2);
+
+    segment->LazyCheckSchema(schema_v2, nullptr);
+
+    auto offsets = segment->GetArrayOffsets(sub_fid);
+    ASSERT_NE(offsets, nullptr);
+    EXPECT_EQ(offsets->GetRowCount(), N);
+    EXPECT_EQ(offsets->GetTotalElementCount(), 0);
+
+    // All backfilled rows must be NULL (row-invalid), not empty arrays.
+    milvus::TargetBitmap probe(N, true);
+    offsets->AndRowValidBitmap(probe.view(), 0, N);
+    EXPECT_TRUE(probe.none());
+}
+
+// Sealed counterpart: the sealed Reopen path must register
+// ArrayOffsetsSealed::BuildAllNulls (all-false row validity), not
+// BuildAllZeros (which would read the backfilled NULLs as empty arrays).
+TEST(StructArrayNullBackfill, SealedReopenRecordsBackfilledRowsAsNull) {
+    auto schema_v1 = std::make_shared<Schema>();
+    auto pk_fid = schema_v1->AddDebugField("id", DataType::INT64);
+    schema_v1->set_primary_field_id(pk_fid);
+    schema_v1->set_schema_version(1);
+
+    constexpr int64_t N = 3;
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    std::vector<int64_t> ids(N);
+    std::iota(ids.begin(), ids.end(), 0);
+    auto id_array = CreateDataArrayFrom(
+        ids.data(), nullptr, N, schema_v1->operator[](pk_fid));
+    insert_data->mutable_fields_data()->AddAllocated(id_array.release());
+    insert_data->set_num_rows(N);
+
+    GeneratedData generated_data;
+    generated_data.schema_ = schema_v1;
+    generated_data.raw_ = insert_data.release();
+    for (int64_t i = 0; i < N; ++i) {
+        generated_data.row_ids_.push_back(i);
+        generated_data.timestamps_.push_back(i);
+    }
+    auto segment = CreateSealedWithFieldDataLoaded(schema_v1, generated_data);
+
+    auto schema_v2 = std::make_shared<Schema>(*schema_v1);
+    auto sub_fid = schema_v2->AddDebugArrayField(
+        "struct_array[sub_int]", DataType::INT32, /*nullable=*/true);
+    schema_v2->set_schema_version(2);
+
+    segment->LazyCheckSchema(schema_v2, nullptr);
+
+    auto offsets = segment->GetArrayOffsets(sub_fid);
+    ASSERT_NE(offsets, nullptr);
+    EXPECT_EQ(offsets->GetRowCount(), N);
+    EXPECT_EQ(offsets->GetTotalElementCount(), 0);
+
+    milvus::TargetBitmap probe(N, true);
+    offsets->AndRowValidBitmap(probe.view(), 0, N);
+    EXPECT_TRUE(probe.none());
 }
 
 class SealedMatchExprTest : public ::testing::Test {

--- a/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
@@ -182,6 +182,18 @@ PhyIterativeElementFilterNode::CollectResults(
     search_result.distances_.resize(nq * topk, 0.0f);
     search_result.element_indices_.resize(nq * topk, -1);
 
+    // Resolve element_id -> (doc_id, elem_idx) once per run of ids that
+    // land in the same row: iterator output is distance-ordered, but ids
+    // from one row still arrive in clusters. Cache the last resolved
+    // row's element range [first, last) and answer in-range ids without
+    // the virtual binary-search lookup; any other id falls back to the
+    // per-element lookup, so correctness never depends on the output
+    // order. A resolved row's range is immutable, so the cache stays
+    // valid across iterators.
+    int32_t cached_doc_id = 0;
+    int32_t cached_first_elem = 0;
+    int32_t cached_last_elem = 0;  // empty range: first lookup always misses
+
     for (int64_t q = 0; q < nq; ++q) {
         auto& iterator = iterators[q];
         int64_t count = 0;
@@ -194,8 +206,23 @@ PhyIterativeElementFilterNode::CollectResults(
             }
 
             auto [element_id, distance] = result.value();
-            auto [doc_id, elem_idx] =
-                array_offsets->ElementIDToRowID(element_id);
+            int32_t doc_id;
+            int32_t elem_idx;
+            if (element_id >= cached_first_elem &&
+                element_id < cached_last_elem) {
+                doc_id = cached_doc_id;
+                elem_idx = static_cast<int32_t>(element_id) -
+                           cached_first_elem;
+            } else {
+                const auto row = array_offsets->ElementIDToRowID(element_id);
+                doc_id = row.first;
+                elem_idx = row.second;
+                cached_doc_id = doc_id;
+                cached_first_elem =
+                    static_cast<int32_t>(element_id) - elem_idx;
+                cached_last_elem =
+                    array_offsets->ElementIDRangeOfRow(doc_id).second;
+            }
 
             // Find insert position using binary search
             size_t pos =

--- a/internal/core/src/exec/operator/IterativeFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeFilterNode.cpp
@@ -228,6 +228,16 @@ PhyIterativeFilterNode::GetOutput() {
         std::vector<std::pair<int32_t, int32_t>> element_to_doc_mapping;
         std::unordered_map<int64_t, bool> doc_eval_cache;
         std::unordered_set<int64_t> unique_doc_ids;
+        // Cached element range of the last resolved row: element ids from
+        // one row arrive in clusters even though iterator output is
+        // distance-ordered, so ids inside the cached range resolve without
+        // the virtual binary-search lookup and anything else falls back to
+        // the per-element lookup (correctness never depends on ordering).
+        // A resolved row's range is immutable, so the cache stays valid
+        // across batches and nqs.
+        int32_t cached_doc_id = 0;
+        int32_t cached_first_elem = 0;
+        int32_t cached_last_elem = 0;  // empty: first lookup always misses
 
         for (auto& iterator : search_result.vector_iterators_.value()) {
             EvalCtx eval_ctx(operator_context_->get_exec_context());
@@ -273,8 +283,23 @@ PhyIterativeFilterNode::GetOutput() {
                     element_to_doc_mapping.reserve(offsets.size());
 
                     for (auto element_id : offsets) {
-                        auto [doc_id, elem_idx] =
-                            array_offsets->ElementIDToRowID(element_id);
+                        int32_t doc_id;
+                        int32_t elem_idx;
+                        if (element_id >= cached_first_elem &&
+                            element_id < cached_last_elem) {
+                            doc_id = cached_doc_id;
+                            elem_idx = element_id - cached_first_elem;
+                        } else {
+                            const auto row =
+                                array_offsets->ElementIDToRowID(element_id);
+                            doc_id = row.first;
+                            elem_idx = row.second;
+                            cached_doc_id = doc_id;
+                            cached_first_elem = element_id - elem_idx;
+                            cached_last_elem =
+                                array_offsets->ElementIDRangeOfRow(doc_id)
+                                    .second;
+                        }
                         element_to_doc_mapping.push_back({doc_id, elem_idx});
                         unique_doc_ids.insert(doc_id);
                     }

--- a/internal/core/src/index/BitmapIndex.h
+++ b/internal/core/src/index/BitmapIndex.h
@@ -188,8 +188,13 @@ class BitmapIndex : public ScalarIndex<T> {
 
     const bool
     HasRawData() const override {
-        if (schema_.data_type() == proto::schema::DataType::Array &&
-            !is_nested_index_) {
+        // Array bitmap indexes -- nested or not -- cannot reconstruct the
+        // per-row array structure (row boundaries, null/empty rows) that
+        // IArrayOffsets / MATCH_* / element_filter / array_length need, so they
+        // must not let the segment loader skip the raw array data. (Previously a
+        // nested array bitmap reported true, allowing an index-only load that
+        // left MATCH_* with no offsets and aborted at query time.)
+        if (schema_.data_type() == proto::schema::DataType::Array) {
             return false;
         }
         return true;

--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -578,7 +578,10 @@ TEST(BitmapIndexArrayNestedTest, BuildAndLoadElementLevelBitmap) {
     auto index = std::make_unique<index::BitmapIndex<int32_t>>(ctx, true);
     index->BuildWithFieldData(std::vector<FieldDataPtr>{field_data});
     ASSERT_TRUE(index->IsNestedIndex());
-    ASSERT_TRUE(index->HasRawData());
+    // Array bitmap indexes (nested or not) report HasRawData()==false so the
+    // segment loader keeps the raw array data that IArrayOffsets/MATCH_* need;
+    // an index-only load would otherwise leave MATCH_* with no offsets.
+    ASSERT_FALSE(index->HasRawData());
     ASSERT_EQ(index->Count(), 4);
 
     auto binary_set = index->Serialize({});

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -7313,7 +7313,10 @@ ChunkedSegmentSealedImpl::EnsureArrayOffsetsForStructField(
 
     auto it = runtime.struct_to_array_offsets.find(*struct_name);
     if (it == runtime.struct_to_array_offsets.end()) {
-        auto array_offsets = ArrayOffsetsSealed::BuildAllZeros(row_count);
+        // Backfilled rows of a schema-evolved struct array are NULL, not empty
+        // arrays: retain an explicit all-false row-valid bitmap so row-level
+        // consumers do not mistake historical NULLs for [].
+        auto array_offsets = ArrayOffsetsSealed::BuildAllNulls(row_count);
         it =
             runtime.struct_to_array_offsets.emplace(*struct_name, array_offsets)
                 .first;

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -497,20 +497,63 @@ class OffsetOrderedMap : public OffsetMap {
         auto more_hit_than_limit = cnt > limit;
         limit = std::min(limit, cnt);
 
-        // Traverse map_ in PK order
+        // Traverse map_ in PK order; for each PK visit offsets from back to
+        // front to obtain the latest offset, and only use the first (newest)
+        // offset that has matching elements (same as find_first_n_by_index)
+        // to avoid returning stale versions.
+        // Element ranges are resolved in windows: gather the next
+        // kRangeBatchSize candidate doc offsets in traversal order and
+        // resolve them with ONE CopyRowElementRanges call (one shared lock
+        // for the whole window on growing) instead of one locking virtual
+        // call per doc. Ranges prefetched for docs the traversal ends up
+        // skipping (older offsets of an already-hit PK, or docs past the
+        // limit) are simply unused — the lookups are pure.
+        constexpr int64_t kRangeBatchSize = 64;
+        int64_t batch_docs[kRangeBatchSize];
+        int32_t batch_rows[kRangeBatchSize];
+        std::pair<int32_t, int32_t> batch_ranges[kRangeBatchSize];
+        const typename OrderedMap::value_type* batch_pks[kRangeBatchSize];
+
         std::vector<int32_t> matching_indices;
-        auto it = map_.begin();
-        for (; hit_num < limit && it != map_.end(); ++it) {
-            // For each PK, traverse from back to front to obtain the latest offset.
-            // Same as find_first_n_by_index: only use the first (newest) offset
-            // that has matching elements, then break to avoid returning stale versions.
-            for (int i = it->second.size() - 1; i >= 0 && hit_num < limit;
-                 --i) {
-                auto doc_offset = it->second[i];
+        // Gather cursor over the flattened (pk, offset) traversal.
+        auto gather_it = map_.begin();
+        int64_t gather_idx =
+            gather_it == map_.end()
+                ? -1
+                : static_cast<int64_t>(gather_it->second.size()) - 1;
+        // PK entry whose remaining (older) offsets must be skipped — the
+        // batched equivalent of the per-doc inner-loop `break`.
+        const typename OrderedMap::value_type* skip_pk = nullptr;
+        while (hit_num < limit && gather_it != map_.end()) {
+            // Gather the next window of candidate docs.
+            int64_t n = 0;
+            while (n < kRangeBatchSize && gather_it != map_.end()) {
+                if (gather_idx < 0) {
+                    ++gather_it;
+                    if (gather_it == map_.end()) {
+                        break;
+                    }
+                    gather_idx =
+                        static_cast<int64_t>(gather_it->second.size()) - 1;
+                    continue;
+                }
+                batch_docs[n] = gather_it->second[gather_idx];
+                batch_rows[n] = static_cast<int32_t>(batch_docs[n]);
+                batch_pks[n] = &*gather_it;
+                ++n;
+                --gather_idx;
+            }
+            array_offsets->CopyRowElementRanges(batch_rows, n, batch_ranges);
+
+            for (int64_t k = 0; k < n && hit_num < limit; ++k) {
+                const auto* pk_entry = batch_pks[k];
+                if (pk_entry == skip_pk) {
+                    continue;
+                }
+                auto doc_offset = batch_docs[k];
 
                 // Get element range for this doc
-                auto [first_elem, last_elem] =
-                    array_offsets->ElementIDRangeOfRow(doc_offset);
+                auto [first_elem, last_elem] = batch_ranges[k];
 
                 // Collect all matching element indices for this doc
                 matching_indices.clear();
@@ -521,7 +564,7 @@ class OffsetOrderedMap : public OffsetMap {
                         continue;
                     }
                     if (is_skipped_by_cursor(
-                            it->first, elem_id - first_elem, cursor)) {
+                            pk_entry->first, elem_id - first_elem, cursor)) {
                         continue;
                     }
                     if (!element_bitset[elem_id]) {  // 0 means pass filter
@@ -536,12 +579,11 @@ class OffsetOrderedMap : public OffsetMap {
                     doc_offsets.push_back(doc_offset);
                     element_indices.push_back(std::move(matching_indices));
                     // PK hit, no need to continue traversing older offsets with the same PK.
-                    break;
-                }
-                if (is_cursor_pk(it->first, cursor)) {
+                    skip_pk = pk_entry;
+                } else if (is_cursor_pk(pk_entry->first, cursor)) {
                     // The cursor applies to the newest visible row for this PK.
                     // Do not fall through to older offsets of the same PK.
-                    break;
+                    skip_pk = pk_entry;
                 }
             }
         }
@@ -776,39 +818,56 @@ class OffsetOrderedArray : public OffsetMap {
         auto more_hit_than_limit = cnt > limit;
         limit = std::min(limit, cnt);
 
-        // Traverse array_ in PK order (already sorted)
+        // Traverse array_ in PK order (already sorted). Element ranges are
+        // resolved in windows of kRangeBatchSize docs with one
+        // CopyRowElementRanges call each instead of one virtual call per
+        // doc; ranges prefetched past an early limit-exit are unused (the
+        // lookups are pure).
+        constexpr int64_t kRangeBatchSize = 64;
+        int32_t batch_rows[kRangeBatchSize];
+        std::pair<int32_t, int32_t> batch_ranges[kRangeBatchSize];
+
         std::vector<int32_t> matching_indices;
-        auto it = array_.begin();
-        for (; hit_num < limit && it != array_.end(); ++it) {
-            auto doc_offset = it->second;
-
-            // Get element range for this doc
-            auto [first_elem, last_elem] =
-                array_offsets->ElementIDRangeOfRow(doc_offset);
-
-            // Collect all matching element indices for this doc
-            matching_indices.clear();
-            for (int64_t elem_id = first_elem;
-                 elem_id < last_elem && hit_num < limit;
-                 ++elem_id) {
-                if (elem_id >= element_size) {
-                    continue;
-                }
-                if (is_skipped_by_cursor(
-                        it->first, elem_id - first_elem, cursor)) {
-                    continue;
-                }
-                if (!element_bitset[elem_id]) {  // 0 means pass filter
-                    matching_indices.push_back(
-                        static_cast<int32_t>(elem_id - first_elem));
-                    hit_num++;
-                }
+        const int64_t total = static_cast<int64_t>(array_.size());
+        for (int64_t base = 0; base < total && hit_num < limit;
+             base += kRangeBatchSize) {
+            const int64_t n = std::min(kRangeBatchSize, total - base);
+            for (int64_t k = 0; k < n; ++k) {
+                batch_rows[k] = array_[base + k].second;
             }
+            array_offsets->CopyRowElementRanges(batch_rows, n, batch_ranges);
 
-            // Only add doc if it has matching elements
-            if (!matching_indices.empty()) {
-                doc_offsets.push_back(doc_offset);
-                element_indices.push_back(std::move(matching_indices));
+            for (int64_t k = 0; k < n && hit_num < limit; ++k) {
+                const auto& entry = array_[base + k];
+                auto doc_offset = entry.second;
+
+                // Get element range for this doc
+                auto [first_elem, last_elem] = batch_ranges[k];
+
+                // Collect all matching element indices for this doc
+                matching_indices.clear();
+                for (int64_t elem_id = first_elem;
+                     elem_id < last_elem && hit_num < limit;
+                     ++elem_id) {
+                    if (elem_id >= element_size) {
+                        continue;
+                    }
+                    if (is_skipped_by_cursor(
+                            entry.first, elem_id - first_elem, cursor)) {
+                        continue;
+                    }
+                    if (!element_bitset[elem_id]) {  // 0 means pass filter
+                        matching_indices.push_back(
+                            static_cast<int32_t>(elem_id - first_elem));
+                        hit_num++;
+                    }
+                }
+
+                // Only add doc if it has matching elements
+                if (!matching_indices.empty()) {
+                    doc_offsets.push_back(doc_offset);
+                    element_indices.push_back(std::move(matching_indices));
+                }
             }
         }
 
@@ -992,21 +1051,35 @@ class VirtualPKOffsetMap : public OffsetMap {
         std::vector<std::vector<int32_t>> element_indices;
         int64_t hit_num = 0;
 
-        for (int64_t doc = 0; doc < num_rows_ && hit_num < limit; doc++) {
-            auto [first_elem, last_elem] =
-                array_offsets->ElementIDRangeOfRow(doc);
-            std::vector<int32_t> matching;
-            for (int64_t e = first_elem; e < last_elem && hit_num < limit;
-                 e++) {
-                if (e < element_size && !element_bitset[e] &&
-                    !is_skipped_by_cursor(doc, e - first_elem, cursor)) {
-                    matching.push_back(static_cast<int32_t>(e - first_elem));
-                    hit_num++;
+        // Docs are scanned sequentially, so resolve element ranges with one
+        // contiguous CopyRowElementStarts call per window of kRowBatchSize
+        // rows ([starts[i], starts[i+1]) is row (base + i)'s range) instead
+        // of one virtual call per row.
+        constexpr int64_t kRowBatchSize = 64;
+        int32_t batch_starts[kRowBatchSize + 1];
+
+        for (int64_t base = 0; base < num_rows_ && hit_num < limit;
+             base += kRowBatchSize) {
+            const int64_t n = std::min(kRowBatchSize, num_rows_ - base);
+            array_offsets->CopyRowElementStarts(base, n, batch_starts);
+            for (int64_t i = 0; i < n && hit_num < limit; i++) {
+                const int64_t doc = base + i;
+                const int32_t first_elem = batch_starts[i];
+                const int32_t last_elem = batch_starts[i + 1];
+                std::vector<int32_t> matching;
+                for (int64_t e = first_elem; e < last_elem && hit_num < limit;
+                     e++) {
+                    if (e < element_size && !element_bitset[e] &&
+                        !is_skipped_by_cursor(doc, e - first_elem, cursor)) {
+                        matching.push_back(
+                            static_cast<int32_t>(e - first_elem));
+                        hit_num++;
+                    }
                 }
-            }
-            if (!matching.empty()) {
-                doc_offsets.push_back(doc);
-                element_indices.push_back(std::move(matching));
+                if (!matching.empty()) {
+                    doc_offsets.push_back(doc);
+                    element_indices.push_back(std::move(matching));
+                }
             }
         }
         return {std::move(doc_offsets),

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -203,16 +203,29 @@ ExtractArrayLengthsFromFieldData(const std::vector<FieldDataPtr>& field_data,
             int64_t physical_row = 0;
             for (int64_t i = 0; i < num_rows; ++i) {
                 if (data->IsNullable() && !data->is_valid(i)) {
-                    array_lengths[offset + i] = 0;
+                    // -1: NULL row (zero elements, row-invalid) -- see
+                    // ArrayOffsetsGrowing::Insert.
+                    array_lengths[offset + i] = -1;
                     continue;
                 }
                 auto source_index = data->IsNullable() ? physical_row++ : i;
                 array_lengths[offset + i] = raw_data[source_index].length();
             }
         } else {
-            // For regular array types (INT32, FLOAT, etc.)
+            // For regular (scalar) array types (INT32, FLOAT, etc.), nullable
+            // FieldData is stored DENSELY: a NULL row occupies a length-0 Array
+            // slot at its logical position (FieldDataArrayImpl does not pack
+            // valid rows). This differs from the VECTOR_ARRAY branch above,
+            // where FieldDataVectorArrayImpl packs only valid rows and so must
+            // be read by physical index. Read each scalar-array row by its
+            // logical index i; a NULL row is reported as -1 so the offsets
+            // record it as NULL rather than a valid empty array.
             auto* raw_data = static_cast<const ArrayView*>(data->Data());
             for (int64_t i = 0; i < num_rows; ++i) {
+                if (data->IsNullable() && !data->is_valid(i)) {
+                    array_lengths[offset + i] = -1;
+                    continue;
+                }
                 array_lengths[offset + i] = raw_data[i].length();
             }
         }
@@ -268,7 +281,8 @@ ExtractArrayLengths(const proto::schema::FieldData& field_data,
         for (int i = 0; i < num_rows; ++i) {
             if (field_meta.is_nullable() && has_valid_data &&
                 !field_data.valid_data(i)) {
-                array_lengths[i] = 0;
+                // -1: NULL row (zero elements, row-invalid).
+                array_lengths[i] = -1;
                 continue;
             }
 
@@ -319,12 +333,14 @@ ExtractArrayLengths(const proto::schema::FieldData& field_data,
         }
     }
 
-    // Handle nullable fields
+    // Handle nullable fields: -1 marks a NULL row (zero elements,
+    // row-invalid) -- see ArrayOffsetsGrowing::Insert. NULL is NOT an empty
+    // array: MATCH_ALL treats [] as a vacuous match but a NULL row as UNKNOWN.
     if (field_meta.is_nullable() && field_data.valid_data_size() > 0) {
         const auto& valid_data = field_data.valid_data();
         for (int i = 0; i < num_rows; ++i) {
             if (!valid_data[i]) {
-                array_lengths[i] = 0;  // null → empty array
+                array_lengths[i] = -1;
             }
         }
     }
@@ -344,6 +360,8 @@ SchemaHasTextField(const Schema& schema) {
 
 void
 SegmentGrowingImpl::InitializeArrayOffsets() {
+    std::unique_lock lock(array_offsets_map_mutex_);
+
     // Group fields by struct_name
     std::unordered_map<std::string, std::vector<FieldId>> struct_fields;
 
@@ -762,8 +780,20 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
                 field_meta);
         }
 
-        // update ArrayOffsetsGrowing for struct fields
-        if (struct_representative_fields_.count(field_id) > 0) {
+        // update ArrayOffsetsGrowing for struct fields. Copy the shared_ptr
+        // out under the shared lock, then insert without holding it (the
+        // offsets object has its own internal mutex).
+        std::shared_ptr<ArrayOffsetsGrowing> array_offsets;
+        {
+            std::shared_lock lock(array_offsets_map_mutex_);
+            if (struct_representative_fields_.count(field_id) > 0) {
+                auto offsets_it = array_offsets_map_.find(field_id);
+                if (offsets_it != array_offsets_map_.end()) {
+                    array_offsets = offsets_it->second;
+                }
+            }
+        }
+        if (array_offsets != nullptr) {
             const auto& field_data =
                 insert_record_proto->fields_data(data_offset);
 
@@ -771,11 +801,8 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
             ExtractArrayLengths(
                 field_data, field_meta, num_rows, array_lengths.data());
 
-            auto offsets_it = array_offsets_map_.find(field_id);
-            if (offsets_it != array_offsets_map_.end()) {
-                offsets_it->second->Insert(
-                    reserved_offset, array_lengths.data(), num_rows);
-            }
+            array_offsets->Insert(
+                reserved_offset, array_lengths.data(), num_rows);
         }
 
         // index text.
@@ -1019,17 +1046,25 @@ SegmentGrowingImpl::load_field_data_common(
         }
     }
 
-    // update ArrayOffsetsGrowing for struct fields
-    if (struct_representative_fields_.count(field_id) > 0) {
+    // update ArrayOffsetsGrowing for struct fields. Copy the shared_ptr out
+    // under the shared lock, then insert without holding it (the offsets
+    // object has its own internal mutex).
+    std::shared_ptr<ArrayOffsetsGrowing> array_offsets;
+    {
+        std::shared_lock lock(array_offsets_map_mutex_);
+        if (struct_representative_fields_.count(field_id) > 0) {
+            auto offsets_it = array_offsets_map_.find(field_id);
+            if (offsets_it != array_offsets_map_.end()) {
+                array_offsets = offsets_it->second;
+            }
+        }
+    }
+    if (array_offsets != nullptr) {
         std::vector<int32_t> array_lengths(num_rows);
         ExtractArrayLengthsFromFieldData(
             field_data, field_meta, array_lengths.data());
 
-        auto offsets_it = array_offsets_map_.find(field_id);
-        if (offsets_it != array_offsets_map_.end()) {
-            offsets_it->second->Insert(
-                reserved_offset, array_lengths.data(), num_rows);
-        }
+        array_offsets->Insert(reserved_offset, array_lengths.data(), num_rows);
 
         LOG_INFO("Updated ArrayOffsetsGrowing for field {} with {} rows",
                  field_id.get(),
@@ -3009,6 +3044,10 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
 void
 SegmentGrowingImpl::EnsureArrayOffsetsForStructField(
     const FieldMeta& field_meta, int64_t row_count) {
+    // Reopen (schema evolution) runs concurrently with insert/query readers
+    // of array_offsets_map_ / struct_representative_fields_.
+    std::unique_lock lock(array_offsets_map_mutex_);
+
     auto struct_name = GetStructNameForArrayField(field_meta);
     if (!struct_name.has_value()) {
         return;
@@ -3032,8 +3071,11 @@ SegmentGrowingImpl::EnsureArrayOffsetsForStructField(
     if (!array_offsets) {
         array_offsets = std::make_shared<ArrayOffsetsGrowing>();
         if (row_count > 0) {
-            std::vector<int32_t> empty_lengths(row_count, 0);
-            array_offsets->Insert(0, empty_lengths.data(), row_count);
+            // Backfilled rows of a schema-evolved struct array are NULL, not
+            // empty arrays (mirrors ArrayOffsetsSealed::BuildAllNulls on the
+            // sealed side): the field did not exist when those rows were
+            // written, and an added field must be nullable.
+            array_offsets->InsertNulls(0, row_count);
         }
         struct_representative_fields_.insert(field_meta.get_id());
     }

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -641,6 +641,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     std::shared_ptr<const IArrayOffsets>
     GetArrayOffsets(FieldId field_id) const override {
+        std::shared_lock lock(array_offsets_map_mutex_);
         auto it = array_offsets_map_.find(field_id);
         if (it != array_offsets_map_.end()) {
             return it->second;
@@ -869,6 +870,13 @@ class SegmentGrowingImpl : public SegmentGrowing {
     // Representative field_id for each struct (used to extract array lengths during Insert)
     // One field_id per struct, since all fields in the same struct have identical array lengths
     std::unordered_set<FieldId> struct_representative_fields_;
+
+    // Guards array_offsets_map_ AND struct_representative_fields_: the Reopen
+    // (schema evolution) path mutates both concurrently with insert-path and
+    // query-path readers. Hold it only for map/set access -- copy the
+    // shared_ptr out and release before calling into the offsets object,
+    // which has its own internal mutex.
+    mutable std::shared_mutex array_offsets_map_mutex_;
 
     // Tracked resource usage for refund-then-charge pattern
     // This stores the last estimated resource usage that was charged to the cache manager

--- a/internal/core/unittest/test_element_filter.cpp
+++ b/internal/core/unittest/test_element_filter.cpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <random>
 #include <set>
@@ -36,7 +37,9 @@
 #include "gtest/gtest.h"
 #include "index/Index.h"
 #include "index/Meta.h"
+#include "index/BitmapIndex.h"
 #include "index/ScalarIndexSort.h"
+#include "index/StringIndexSort.h"
 #include "index/VectorIndex.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/operands.h"
@@ -684,6 +687,118 @@ TEST(ElementFilter, GrowingSegmentArrayOffsets) {
             ASSERT_EQ(mapped_idx, elem_idx)
                 << "Element " << elem_id << " should have index " << elem_idx;
         }
+    }
+}
+
+// Regression: a growing segment recovering a NULLABLE VECTOR_ARRAY field from
+// binlog must build a correct element-offset table even when NULL rows precede
+// valid ones. VECTOR_ARRAY FieldData is stored COMPACTLY
+// (FieldDataVectorArrayImpl packs only valid rows), so
+// ExtractArrayLengthsFromFieldData reads valid rows by physical index -- the
+// OPPOSITE convention from a scalar ARRAY (stored densely, read by logical
+// index). This guards the VECTOR_ARRAY (compact) branch of the growing
+// binlog-recovery extractor.
+TEST(ElementFilter, GrowingNullableVectorArrayBinlogRecovery) {
+    constexpr int64_t dim = 4;
+    constexpr int64_t N = 5;
+    // row0=NULL, row1=2 vecs, row2=NULL, row3=3 vecs, row4=1 vec. The leading
+    // and interior NULLs are what break a (wrong) logical-index read of the
+    // compact buffer.
+    const std::vector<int> vec_counts = {0, 2, 0, 3, 1};
+    const std::vector<bool> valid = {false, true, false, true, true};
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("id", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+    // Bracket name -> the field is a struct representative and so gets an
+    // ArrayOffsets table built during load.
+    auto vec_fid = schema->AddDebugVectorArrayField("structA[array_vec]",
+                                                    DataType::VECTOR_FLOAT,
+                                                    dim,
+                                                    knowhere::metric::MAX_SIM,
+                                                    /*nullable=*/true);
+
+    // Build the COMPACT nullable VECTOR_ARRAY FieldData: only valid rows are
+    // stored (packed), while the valid bitmap is sized by the logical row count
+    // N. This mirrors how the storage/arrow layer materializes a nullable
+    // vector array, so the growing load path sees the real compact buffer.
+    std::vector<milvus::VectorArray> compact;
+    std::vector<uint8_t> valid_bitmap((N + 7) / 8, 0);
+    for (int64_t i = 0; i < N; ++i) {
+        if (!valid[i]) {
+            continue;
+        }
+        valid_bitmap[i >> 3] |= (1 << (i & 0x07));
+        VectorFieldProto vf;
+        vf.set_dim(dim);
+        for (int v = 0; v < vec_counts[i]; ++v) {
+            for (int d = 0; d < dim; ++d) {
+                vf.mutable_float_vector()->add_data(
+                    static_cast<float>(i * 100 + v * 10 + d));
+            }
+        }
+        compact.emplace_back(vf);
+    }
+    auto vec_fd = storage::CreateFieldData(
+        DataType::VECTOR_ARRAY, DataType::VECTOR_FLOAT, /*nullable=*/true, dim);
+    vec_fd->FillFieldData(compact.data(), valid_bitmap.data(), N, 0);
+
+    // Assemble ONE LoadFieldDataInfo carrying RowID + Timestamp + pk (from
+    // PrepareInsertBinlog) plus the nullable vector-array field, then load it
+    // through the growing binlog recovery path in a single batch -- exactly what
+    // SegmentGrowingImpl::Load does in production (load_field_data_internal
+    // asserts the system + pk fields are present together).
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto proto = std::make_unique<InsertRecordProto>();
+    std::vector<int64_t> ids(N);
+    std::iota(ids.begin(), ids.end(), 0);
+    auto id_arr =
+        CreateDataArrayFrom(ids.data(), nullptr, N, schema->operator[](pk_fid));
+    proto->mutable_fields_data()->AddAllocated(id_arr.release());
+    proto->set_num_rows(N);
+    GeneratedData gen;
+    gen.schema_ = schema;
+    gen.raw_ = proto.release();
+    for (int64_t i = 0; i < N; ++i) {
+        gen.row_ids_.push_back(i);
+        gen.timestamps_.push_back(i);
+    }
+    auto load_info =
+        PrepareInsertBinlog(kCollectionID, kPartitionID, kSegmentID, gen, cm);
+    auto vec_info = PrepareSingleFieldInsertBinlog(
+        kCollectionID, kPartitionID, kSegmentID, vec_fid.get(), {vec_fd}, cm);
+    for (auto& [fid, info] : vec_info.field_infos) {
+        load_info.field_infos.emplace(fid, info);
+    }
+
+    auto loaded = CreateGrowingSegment(schema, empty_index_meta);
+    auto status = LoadFieldData(loaded.get(), &load_info);
+    ASSERT_EQ(status.error_code, milvus::Success);
+
+    auto growing = dynamic_cast<SegmentGrowingImpl*>(loaded.get());
+    ASSERT_NE(growing, nullptr);
+
+    // The element-offset table must reflect the per-row vector counts: NULL rows
+    // contribute 0, valid rows their actual count. A logical-index read of the
+    // compact buffer would shift these once a NULL precedes a valid row.
+    auto offsets = growing->GetArrayOffsets(vec_fid);
+    ASSERT_NE(offsets, nullptr);
+    ASSERT_EQ(offsets->GetRowCount(), N);
+    ASSERT_EQ(offsets->GetTotalElementCount(), 0 + 2 + 0 + 3 + 1);
+    for (int64_t i = 0; i < N; ++i) {
+        auto [start, end] = offsets->ElementIDRangeOfRow(i);
+        EXPECT_EQ(end - start, vec_counts[i])
+            << "row " << i << " element count mismatch";
+    }
+
+    // NULL rows (recorded via the -1 length sentinel) must be reported
+    // row-invalid; real rows stay valid.
+    milvus::TargetBitmap probe(N, true);
+    offsets->AndRowValidBitmap(probe.view(), 0, N);
+    for (int64_t i = 0; i < N; ++i) {
+        EXPECT_EQ(bool(probe[i]), bool(valid[i]))
+            << "row " << i << " validity mismatch";
     }
 }
 
@@ -4512,4 +4627,51 @@ TEST(ElementVectorSearch, SealedBruteForce_IteratorV2_MultiBatch) {
     ASSERT_GE(seen.size(), static_cast<size_t>(kElemTopK))
         << "multi-batch iterator should accumulate strictly more results "
         << "than a single batch";
+}
+
+// A nested (array-element) scalar index must report HasRawData()==false so the
+// segment loader keeps the raw array data. A nested index stores only flattened
+// element values -- no row boundaries, no null/empty rows -- so it cannot
+// reconstruct the per-row array structure that IArrayOffsets needs. If such an
+// index reported HasRawData()==true, the loader could load the index alone and
+// skip the raw data, leaving MATCH_*/element_filter with no offsets to abort on
+// ("Array offsets not available"). Non-nested scalar indexes are unaffected.
+TEST(NestedArrayIndexRawData, NestedIndexesReportNoRawData) {
+    // STL_SORT (ScalarIndexSort): nested -> false, non-nested -> true.
+    auto stl_nested = std::make_unique<index::ScalarIndexSort<int32_t>>(
+        storage::FileManagerContext(), /*is_nested_index=*/true);
+    EXPECT_FALSE(stl_nested->HasRawData());
+
+    auto stl_plain = std::make_unique<index::ScalarIndexSort<int32_t>>(
+        storage::FileManagerContext(), /*is_nested_index=*/false);
+    EXPECT_TRUE(stl_plain->HasRawData());
+
+    // BITMAP: any Array bitmap index (nested or not) -> false; non-array -> true.
+    {
+        storage::FileManagerContext ctx;
+        ctx.fieldDataMeta.field_schema.set_data_type(
+            proto::schema::DataType::Array);
+        auto bitmap_nested = std::make_unique<index::BitmapIndex<int32_t>>(
+            ctx, /*is_nested_index=*/true);
+        EXPECT_FALSE(bitmap_nested->HasRawData());
+        auto bitmap_array = std::make_unique<index::BitmapIndex<int32_t>>(
+            ctx, /*is_nested_index=*/false);
+        EXPECT_FALSE(bitmap_array->HasRawData());
+    }
+    {
+        storage::FileManagerContext ctx;
+        ctx.fieldDataMeta.field_schema.set_data_type(
+            proto::schema::DataType::Int32);
+        auto bitmap_scalar = std::make_unique<index::BitmapIndex<int32_t>>(ctx);
+        EXPECT_TRUE(bitmap_scalar->HasRawData());
+    }
+
+    // STL_SORT for VarChar (StringIndexSort): nested -> false, non-nested -> true.
+    auto str_nested = std::make_unique<index::StringIndexSort>(
+        storage::FileManagerContext(), /*is_nested_index=*/true);
+    EXPECT_FALSE(str_nested->HasRawData());
+
+    auto str_plain = std::make_unique<index::StringIndexSort>(
+        storage::FileManagerContext(), /*is_nested_index=*/false);
+    EXPECT_TRUE(str_plain->HasRawData());
 }

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_match.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_match.py
@@ -1,0 +1,281 @@
+"""
+E2E tests for quantified element filtering (MATCH_* family) on struct array
+fields, complementing test_milvus_client_struct_array_element_query.py:
+
+- all five MATCH_* operators on an int sub-field of a small, fully-known dataset
+  with nullable rows and empty struct arrays (three-valued NULL semantics)
+- string predicates on a varchar sub-field: == and like-prefix
+- compound predicates across two sub-fields inside one element
+- element_filter(sa, p) row-set equivalence with MATCH_ANY(sa, p)
+- `not MATCH_*` with nullable rows (NULL row stays excluded under negation)
+"""
+
+import pytest
+from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common.common_type import CaseLabel
+from pymilvus import DataType
+
+prefix = "struct_array_match"
+
+PK_FIELD = "id"
+VECTOR_FIELD = "normal_vector"
+VECTOR_DIM = 32
+STRUCT_FIELD = "profile"
+INT_SUBFIELD = "p_int"
+STR_SUBFIELD = "p_tag"
+STRUCT_MAX_CAPACITY = 8
+STR_MAX_LENGTH = 64
+
+FLAT_INDEX = {"index_type": "FLAT", "metric_type": "L2"}
+
+
+def _elem(p_int, p_tag):
+    return {INT_SUBFIELD: p_int, STR_SUBFIELD: p_tag}
+
+
+# Known dataset. Row index == primary key (non-autoID Int64 pk with explicit values).
+#   pk 0 -> [(1, "x"), (2, "y")]
+#   pk 1 -> [(2, "x"), (2, "x"), (5, "pre_a")]
+#   pk 2 -> [(0, "pre_b")]
+#   pk 3 -> []            (real empty struct array: vacuous TRUE for ALL/MOST/EXACT(0))
+#   pk 4 -> None          (NULL struct array: EXCLUDED by every MATCH_*, also under `not`)
+#   pk 5 -> [(9, "z")]
+KNOWN_PROFILES = [
+    [_elem(1, "x"), _elem(2, "y")],
+    [_elem(2, "x"), _elem(2, "x"), _elem(5, "pre_a")],
+    [_elem(0, "pre_b")],
+    [],
+    None,
+    [_elem(9, "z")],
+]
+ALL_PKS = list(range(len(KNOWN_PROFILES)))
+
+
+def match_pks(match_type, pred, threshold=None, negated=False, profiles=KNOWN_PROFILES):
+    """Python oracle for MATCH_* over a struct array, honoring three-valued NULL:
+    a NULL struct array row is excluded whether or not the expression is negated;
+    an empty [] row is a real zero-element array and is evaluated normally."""
+    pks = []
+    for pk, profile in enumerate(profiles):
+        if profile is None:
+            continue
+        cnt = sum(1 for e in profile if pred(e))
+        total = len(profile)
+        if match_type == "ANY":
+            matched = cnt >= 1
+        elif match_type == "ALL":
+            matched = cnt == total
+        elif match_type == "LEAST":
+            matched = cnt >= threshold
+        elif match_type == "MOST":
+            matched = cnt <= threshold
+        elif match_type == "EXACT":
+            matched = cnt == threshold
+        else:
+            raise ValueError(match_type)
+        if matched != negated:
+            pks.append(pk)
+    return pks
+
+
+class TestMilvusClientStructArrayMatch(TestMilvusClientV2Base):
+    """Quantified MATCH_* / element_filter on a struct array field with an int
+    and a varchar sub-field, over nullable rows and empty struct arrays."""
+
+    def _build_collection(self, client):
+        collection_name = cf.gen_unique_str(prefix)
+
+        schema, _ = self.create_schema(client, auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name=PK_FIELD, datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name=VECTOR_FIELD, datatype=DataType.FLOAT_VECTOR, dim=VECTOR_DIM)
+
+        struct_schema, _ = self.create_struct_field_schema(client)
+        struct_schema.add_field(INT_SUBFIELD, DataType.INT64)
+        struct_schema.add_field(STR_SUBFIELD, DataType.VARCHAR, max_length=STR_MAX_LENGTH)
+        schema.add_field(
+            STRUCT_FIELD,
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=STRUCT_MAX_CAPACITY,
+            nullable=True,
+        )
+
+        self.create_collection(client, collection_name, schema=schema)
+
+        vectors = cf.gen_vectors(len(KNOWN_PROFILES), VECTOR_DIM)
+        rows = [
+            {
+                PK_FIELD: pk,
+                VECTOR_FIELD: list(vectors[pk]),
+                STRUCT_FIELD: KNOWN_PROFILES[pk],
+            }
+            for pk in ALL_PKS
+        ]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        index_params, _ = self.prepare_index_params(client)
+        index_params.add_index(field_name=VECTOR_FIELD, **FLAT_INDEX)
+        self.create_index(client, collection_name, index_params)
+        self.load_collection(client, collection_name)
+        return collection_name
+
+    def _query_pks(self, client, collection_name, expr, **kwargs):
+        res, _ = self.query(client, collection_name, filter=expr, output_fields=[PK_FIELD], **kwargs)
+        return sorted(row[PK_FIELD] for row in res)
+
+    def _check_match(self, client, collection_name, expr, expected_pks, **kwargs):
+        actual = self._query_pks(client, collection_name, expr, **kwargs)
+        assert actual == expected_pks, f"{expr}: expected {expected_pks}, got {actual}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_struct_array_match_int_operators(self):
+        """
+        target: test all five MATCH_* operators on $[p_int] with nullable and empty rows
+        method: insert the known dataset, run each operator, compare with the python oracle
+        expected: returned pks equal the oracle sets; the NULL row (pk 4) never appears
+        """
+        client = self._client()
+        collection_name = self._build_collection(client)
+
+        # MATCH_ANY(profile, $[p_int] > 1) -> pk 0 (2), pk 1 (2,2,5), pk 5 (9)
+        expected = match_pks("ANY", lambda e: e[INT_SUBFIELD] > 1)
+        assert expected == [0, 1, 5]
+        self._check_match(client, collection_name, f"MATCH_ANY({STRUCT_FIELD}, $[{INT_SUBFIELD}] > 1)", expected)
+
+        # MATCH_ALL(profile, $[p_int] >= 1) -> pk 0, pk 1, pk 3 ([] vacuous), pk 5
+        expected = match_pks("ALL", lambda e: e[INT_SUBFIELD] >= 1)
+        assert expected == [0, 1, 3, 5]
+        self._check_match(client, collection_name, f"MATCH_ALL({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 1)", expected)
+
+        # MATCH_LEAST(profile, $[p_int] == 2, threshold=2) -> pk 1 (two 2s)
+        expected = match_pks("LEAST", lambda e: e[INT_SUBFIELD] == 2, threshold=2)
+        assert expected == [1]
+        self._check_match(
+            client, collection_name, f"MATCH_LEAST({STRUCT_FIELD}, $[{INT_SUBFIELD}] == 2, threshold=2)", expected
+        )
+
+        # MATCH_MOST(profile, $[p_int] > 1, threshold=1) -> counts 1,3,0,0,-,1 -> pk 0,2,3,5
+        expected = match_pks("MOST", lambda e: e[INT_SUBFIELD] > 1, threshold=1)
+        assert expected == [0, 2, 3, 5]
+        self._check_match(
+            client, collection_name, f"MATCH_MOST({STRUCT_FIELD}, $[{INT_SUBFIELD}] > 1, threshold=1)", expected
+        )
+
+        # MATCH_EXACT(profile, $[p_int] == 2, threshold=2) -> pk 1
+        expected = match_pks("EXACT", lambda e: e[INT_SUBFIELD] == 2, threshold=2)
+        assert expected == [1]
+        self._check_match(
+            client, collection_name, f"MATCH_EXACT({STRUCT_FIELD}, $[{INT_SUBFIELD}] == 2, threshold=2)", expected
+        )
+
+        # MATCH_EXACT threshold=0: zero-match rows including the empty array (pk 3),
+        # but never the NULL row (pk 4)
+        expected = match_pks("EXACT", lambda e: e[INT_SUBFIELD] == 2, threshold=0)
+        assert expected == [2, 3, 5]
+        self._check_match(
+            client, collection_name, f"MATCH_EXACT({STRUCT_FIELD}, $[{INT_SUBFIELD}] == 2, threshold=0)", expected
+        )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_struct_array_match_varchar_predicates(self):
+        """
+        target: test string element predicates on $[p_tag]: equality and like-prefix
+        method: query MATCH_ANY with $[p_tag] == "x" and $[p_tag] like "pre%"
+        expected: returned pks equal the oracle sets
+        """
+        client = self._client()
+        collection_name = self._build_collection(client)
+
+        # MATCH_ANY(profile, $[p_tag] == "x") -> pk 0, pk 1
+        expected = match_pks("ANY", lambda e: e[STR_SUBFIELD] == "x")
+        assert expected == [0, 1]
+        self._check_match(client, collection_name, f'MATCH_ANY({STRUCT_FIELD}, $[{STR_SUBFIELD}] == "x")', expected)
+
+        # MATCH_ANY(profile, $[p_tag] like "pre%") -> pk 1 ("pre_a"), pk 2 ("pre_b")
+        expected = match_pks("ANY", lambda e: e[STR_SUBFIELD].startswith("pre"))
+        assert expected == [1, 2]
+        self._check_match(
+            client, collection_name, f'MATCH_ANY({STRUCT_FIELD}, $[{STR_SUBFIELD}] like "pre%")', expected
+        )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_struct_array_match_compound_subfields(self):
+        """
+        target: test a compound element predicate across two sub-fields
+        method: query MATCH_ANY(profile, $[p_int] > 1 && $[p_tag] == "x"); both conditions
+                must hold on the SAME element
+        expected: only pk 1 matches (element (2, "x")); pk 0 has 1/"x" and 2/"y" split
+                  across two elements and must not match
+        """
+        client = self._client()
+        collection_name = self._build_collection(client)
+
+        expected = match_pks("ANY", lambda e: e[INT_SUBFIELD] > 1 and e[STR_SUBFIELD] == "x")
+        assert expected == [1]
+        self._check_match(
+            client,
+            collection_name,
+            f'MATCH_ANY({STRUCT_FIELD}, $[{INT_SUBFIELD}] > 1 && $[{STR_SUBFIELD}] == "x")',
+            expected,
+        )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_struct_array_element_filter_matches_match_any(self):
+        """
+        target: verify element_filter(sa, p) selects exactly the MATCH_ANY(sa, p) row set
+        method: run both forms for an int and a string predicate; element_filter returns
+                one row per matching element, so dedup its pks before comparing
+        expected: distinct element_filter pks == MATCH_ANY pks; element row count equals
+                  the oracle's total match count
+        """
+        client = self._client()
+        collection_name = self._build_collection(client)
+
+        cases = [
+            (f"$[{INT_SUBFIELD}] > 1", lambda e: e[INT_SUBFIELD] > 1),
+            (f'$[{STR_SUBFIELD}] == "x"', lambda e: e[STR_SUBFIELD] == "x"),
+        ]
+        for condition, pred in cases:
+            match_any_pks = self._query_pks(client, collection_name, f"MATCH_ANY({STRUCT_FIELD}, {condition})")
+            res, _ = self.query(
+                client,
+                collection_name,
+                filter=f"element_filter({STRUCT_FIELD}, {condition})",
+                output_fields=[PK_FIELD],
+            )
+            distinct_pks = sorted({row[PK_FIELD] for row in res})
+            assert distinct_pks == match_any_pks, (
+                f"element_filter({condition}) pks {distinct_pks} != MATCH_ANY pks {match_any_pks}"
+            )
+            expected_element_rows = sum(
+                sum(1 for e in profile if pred(e)) for profile in KNOWN_PROFILES if profile is not None
+            )
+            assert len(res) == expected_element_rows, (
+                f"element_filter({condition}): expected {expected_element_rows} element rows, got {len(res)}"
+            )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_struct_array_match_not_with_nullable(self):
+        """
+        target: test `not MATCH_*` three-valued semantics with nullable struct rows
+        method: negate MATCH_ANY and MATCH_ALL; the NULL row must stay excluded and the
+                empty-array row must follow vacuous evaluation
+        expected: returned pks equal the oracle sets computed with negated=True
+        """
+        client = self._client()
+        collection_name = self._build_collection(client)
+
+        # not MATCH_ANY(profile, $[p_int] > 1): real rows with zero matches -> pk 2, pk 3.
+        # pk 4 (NULL) is UNKNOWN and excluded even under negation.
+        expected = match_pks("ANY", lambda e: e[INT_SUBFIELD] > 1, negated=True)
+        assert expected == [2, 3]
+        self._check_match(client, collection_name, f"not MATCH_ANY({STRUCT_FIELD}, $[{INT_SUBFIELD}] > 1)", expected)
+
+        # not MATCH_ALL(profile, $[p_int] >= 1): pk 2 only ([] is vacuously ALL-true,
+        # so pk 3 is NOT returned; pk 4 stays excluded)
+        expected = match_pks("ALL", lambda e: e[INT_SUBFIELD] >= 1, negated=True)
+        assert expected == [2]
+        self._check_match(client, collection_name, f"not MATCH_ALL({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 1)", expected)

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -965,7 +965,14 @@ def gt_struct_array_expression_rows(
         threshold = int(raw_threshold) if raw_threshold is not None else None
         results = []
         for row in scoped_rows:
-            struct_array = row.get(STRUCT_FIELD) or []
+            struct_array = row.get(STRUCT_FIELD)
+            # Three-valued MATCH semantics: a row whose struct-array field is NULL
+            # (explicit null or omitted) yields UNKNOWN and is excluded for every
+            # MATCH operator -- it is NOT treated as an empty array. A real empty
+            # array [] is a valid zero-element input and is still evaluated
+            # vacuously below (MATCH_ALL/MOST/EXACT(0) keep it, ANY/LEAST drop it).
+            if struct_array is None:
+                continue
             match_count = sum(1 for element in struct_array if _eval_struct_element_condition(element, condition))
             total_count = len(struct_array)
             matched = (


### PR DESCRIPTION
issue: #51381
> **Stacked on #51380's PR** (#51385 layer 3). Review the last commit.

## What — ⚠️ user-visible behavior fixes to shipped struct arrays
Under pg-aligned 3VL a NULL array row and a real empty array [] are different inputs: MATCH_ALL over [] is a vacuous match, over NULL it is UNKNOWN (excluded, incl. under NOT). Master conflates them:
1. Array offsets now record per-row validity (sealed builders capture it from nullable columns; `BuildAllNulls` replaces all-zeros for schema-evolution backfill; growing records NULL rows via a −1 length sentinel and `InsertNulls`), exposed through the thread-safe `AndRowValidBitmap`.
2. `MATCH_*` masks NULL rows to UNKNOWN (`MaskNullRows`) — `not MATCH_ANY(...)` no longer includes NULL rows.
3. The row-level nested-struct-index fold ANDs the offsets' row validity in — `not array_contains(nullable_sub, x)` no longer includes NULL rows.
4. `json_contains_all(array_field, [])` keeps IS-NOT-NULL semantics (was blanket TRUE incl. NULL rows; pg: NULL @> '{}' is NULL).
5. `array_offsets_map_`/`struct_representative_fields_` gained a shared_mutex (schema-evolution Reopen raced query/insert readers — UB).
6. `BitmapIndex::HasRawData` reports false for every ARRAY index (row-level ones claiming raw data allowed index-only loads that leave MATCH without offsets).

## Review guide
- The behavior table above IS the review: for each line, check the new test that pins it (`MatchExprNullableStruct.*`, `StructArrayNullBackfill.*`, ArrayOffsets validity tests, the empty-ContainsAll tests, pytest nullable suite).
- Check the −1 sentinel convention at both extractors and its single consumer.
- 760/760 at this layer.

## Release note
`NOT` of MATCH/array_contains over nullable struct arrays and `json_contains_all(field, [])` no longer return NULL rows; backfilled (schema-evolution) rows no longer vacuously match MATCH_ALL.