### PR TITLE
enhance: [2.6] backport supported StructArray capabilities

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
@@ -696,6 +697,7 @@ func (h *HandlersV2) getCollectionDetails(ctx context.Context, c *gin.Context, a
 		HTTPReturnDescription: coll.Schema.Description,
 		HTTPReturnFieldAutoID: autoID,
 		"fields":              printFieldsV2(coll.Schema.Fields),
+		"structFields":        printStructArrayFieldsV2(coll.Schema.StructArrayFields),
 		"functions":           printFunctionDetails(coll.Schema.Functions),
 		"aliases":             aliases,
 		"indexes":             indexDesc,
@@ -1033,9 +1035,46 @@ func (h *HandlersV2) flush(ctx context.Context, c *gin.Context, anyReq any, dbNa
 		return h.proxy.Flush(reqCtx, req.(*milvuspb.FlushRequest))
 	})
 	if err == nil {
+		err = h.waitForFlush(ctx, dbName, httpReq.CollectionName, resp.(*milvuspb.FlushResponse))
+		if err != nil {
+			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return resp, err
+		}
 		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
 	}
 	return resp, err
+}
+
+func (h *HandlersV2) waitForFlush(ctx context.Context, dbName string, collectionName string, flushResp *milvuspb.FlushResponse) error {
+	segmentIDs := flushResp.GetCollSegIDs()[collectionName].GetData()
+	flushTs, ok := flushResp.GetCollFlushTs()[collectionName]
+	if !ok {
+		return merr.WrapErrServiceInternal(fmt.Sprintf("failed to get flush timestamp for collection %s", collectionName))
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		stateResp, err := h.proxy.GetFlushState(ctx, &milvuspb.GetFlushStateRequest{
+			DbName:         dbName,
+			CollectionName: collectionName,
+			SegmentIDs:     segmentIDs,
+			FlushTs:        flushTs,
+		})
+		if err := merr.CheckRPCCall(stateResp, err); err != nil {
+			return err
+		}
+		if stateResp.GetFlushed() {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func (h *HandlersV2) alterCollectionFieldProperties(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
@@ -1485,6 +1524,19 @@ func generatePlaceholderGroup(ctx context.Context, body string, collSchema *sche
 				break
 			}
 		}
+		if vectorField == nil {
+			for _, sf := range collSchema.GetStructArrayFields() {
+				for _, sub := range sf.GetFields() {
+					if sub.GetName() == fieldName && typeutil.IsVectorType(sub.GetDataType()) {
+						vectorField = sub
+						break
+					}
+				}
+				if vectorField != nil {
+					break
+				}
+			}
+		}
 	}
 	if vectorField == nil {
 		return nil, merr.WrapErrFieldNotFound(fieldName, "cannot find a vector field")
@@ -1507,7 +1559,16 @@ func generatePlaceholderGroup(ctx context.Context, body string, collSchema *sche
 		}
 	}
 
-	phv, err := convertQueries2Placeholder(body, dataType, dim)
+	var phv *commonpb.PlaceholderValue
+	if vectorField.GetDataType() == schemapb.DataType_ArrayOfVector {
+		if isEmbeddingListData(body) {
+			phv, err = convertEmbListQueries2Placeholder(body, vectorField.GetElementType(), dim)
+		} else {
+			phv, err = convertQueries2Placeholder(body, vectorField.GetElementType(), dim)
+		}
+	} else {
+		phv, err = convertQueries2Placeholder(body, dataType, dim)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1934,6 +1995,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			Name:               httpReq.CollectionName,
 			AutoID:             httpReq.Schema.AutoId,
 			Fields:             []*schemapb.FieldSchema{},
+			StructArrayFields:  []*schemapb.StructArrayFieldSchema{},
 			Functions:          []*schemapb.FunctionSchema{},
 			EnableDynamicField: httpReq.Schema.EnableDynamicField,
 			Description:        httpReq.Description,
@@ -2018,6 +2080,34 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			}
 			collSchema.Fields = append(collSchema.Fields, &fieldSchema)
 			fieldNames[field.FieldName] = true
+		}
+		for i := range httpReq.Schema.StructFields {
+			structField := httpReq.Schema.StructFields[i]
+			if _, dup := fieldNames[structField.FieldName]; dup {
+				err := merr.WrapErrParameterInvalidMsg("duplicated field name: %s", structField.FieldName)
+				log.Ctx(ctx).Warn("high level restful api, create collection fail", zap.Error(err), zap.Any("request", anyReq))
+				HTTPAbortReturn(c, http.StatusOK, gin.H{
+					HTTPReturnCode:    merr.Code(err),
+					HTTPReturnMessage: err.Error(),
+				})
+				return nil, err
+			}
+			structProto, err := structField.GetProto(ctx)
+			if err != nil {
+				log.Ctx(ctx).Warn("high level restful api, convert struct array field fail",
+					zap.String("structField", structField.FieldName), zap.Error(err))
+				HTTPAbortReturn(c, http.StatusOK, gin.H{
+					HTTPReturnCode:    merr.Code(err),
+					HTTPReturnMessage: err.Error(),
+				})
+				return nil, err
+			}
+			collSchema.StructArrayFields = append(collSchema.StructArrayFields, structProto)
+			fieldNames[structField.FieldName] = true
+			for _, sub := range structProto.GetFields() {
+				qualified := typeutil.ConcatStructFieldName(structField.FieldName, sub.GetName())
+				fieldNames[qualified] = true
+			}
 		}
 		schema, err = proto.Marshal(&collSchema)
 	}

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -1075,7 +1075,21 @@ func TestFlush(t *testing.T) {
 
 	postTestCases := []requestBodyTestCase{}
 	mp := mocks.NewMockProxy(t)
-	mp.EXPECT().Flush(mock.Anything, mock.Anything).Return(&milvuspb.FlushResponse{}, nil).Once()
+	mp.EXPECT().Flush(mock.Anything, mock.Anything).Return(&milvuspb.FlushResponse{
+		Status: merr.Success(),
+		CollSegIDs: map[string]*schemapb.LongArray{
+			"test": {Data: []int64{1}},
+		},
+		CollFlushTs: map[string]uint64{
+			"test": 100,
+		},
+	}, nil).Once()
+	mp.EXPECT().GetFlushState(mock.Anything, mock.MatchedBy(func(req *milvuspb.GetFlushStateRequest) bool {
+		return req.GetCollectionName() == "test" && req.GetFlushTs() == 100 && assert.ObjectsAreEqual([]int64{1}, req.GetSegmentIDs())
+	})).Return(&milvuspb.GetFlushStateResponse{
+		Status:  merr.Success(),
+		Flushed: true,
+	}, nil).Once()
 	mp.EXPECT().Flush(mock.Anything, mock.Anything).Return(
 		&milvuspb.FlushResponse{
 			Status: &commonpb.Status{
@@ -1114,6 +1128,54 @@ func TestFlush(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWaitForFlush(t *testing.T) {
+	t.Run("missing flush timestamp", func(t *testing.T) {
+		h := &HandlersV2{proxy: mocks.NewMockProxy(t)}
+		err := h.waitForFlush(context.Background(), "", "test", &milvuspb.FlushResponse{
+			CollSegIDs: map[string]*schemapb.LongArray{
+				"test": {Data: []int64{1}},
+			},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get flush timestamp")
+	})
+
+	t.Run("get flush state rpc error", func(t *testing.T) {
+		mp := mocks.NewMockProxy(t)
+		mp.EXPECT().GetFlushState(mock.Anything, mock.Anything).Return(nil, errors.New("mock rpc")).Once()
+		h := &HandlersV2{proxy: mp}
+		err := h.waitForFlush(context.Background(), "", "test", &milvuspb.FlushResponse{
+			CollSegIDs: map[string]*schemapb.LongArray{
+				"test": {Data: []int64{1}},
+			},
+			CollFlushTs: map[string]uint64{
+				"test": 100,
+			},
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "mock rpc")
+	})
+
+	t.Run("context canceled before flush completes", func(t *testing.T) {
+		mp := mocks.NewMockProxy(t)
+		mp.EXPECT().GetFlushState(mock.Anything, mock.Anything).Return(&milvuspb.GetFlushStateResponse{
+			Status: merr.Success(),
+		}, nil).Once()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		h := &HandlersV2{proxy: mp}
+		err := h.waitForFlush(ctx, "", "test", &milvuspb.FlushResponse{
+			CollSegIDs: map[string]*schemapb.LongArray{
+				"test": {Data: []int64{1}},
+			},
+			CollFlushTs: map[string]uint64{
+				"test": 100,
+			},
+		})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
 }
 
 func TestDatabase(t *testing.T) {
@@ -1514,9 +1576,9 @@ func TestCreateCollection(t *testing.T) {
 
 	postTestCases := []requestBodyTestCase{}
 	mp := mocks.NewMockProxy(t)
-	mp.EXPECT().CreateCollection(mock.Anything, mock.Anything).Return(commonSuccessStatus, nil).Times(13)
-	mp.EXPECT().CreateIndex(mock.Anything, mock.Anything).Return(commonSuccessStatus, nil).Times(6)
-	mp.EXPECT().LoadCollection(mock.Anything, mock.Anything).Return(commonSuccessStatus, nil).Times(6)
+	mp.EXPECT().CreateCollection(mock.Anything, mock.Anything).Return(commonSuccessStatus, nil).Times(15)
+	mp.EXPECT().CreateIndex(mock.Anything, mock.Anything).Return(commonSuccessStatus, nil).Times(8)
+	mp.EXPECT().LoadCollection(mock.Anything, mock.Anything).Return(commonSuccessStatus, nil).Times(7)
 	mp.EXPECT().CreateIndex(mock.Anything, mock.Anything).Return(commonErrorStatus, nil).Twice()
 	mp.EXPECT().CreateCollection(mock.Anything, mock.Anything).Return(commonErrorStatus, nil).Twice()
 	testEngine := initHTTPServerV2(mp, false)
@@ -1655,11 +1717,53 @@ func TestCreateCollection(t *testing.T) {
 	postTestCases = append(postTestCases, requestBodyTestCase{
 		path: path,
 		requestBody: []byte(`{"collectionName": "` + DefaultCollectionName + `", "schema": {
-		        "fields": [
-		            {"fieldName": "book_id", "dataType": "Int64", "isPrimary": true, "isPartitionKey": true, "elementTypeParams": {}},
-		            {"fieldName": "book_intro", "dataType": "FloatVector", "elementTypeParams": {"dim": 2}}
-		        ]
-		    }, "params": {"partitionKeyIsolation": "true"}}`),
+			        "fields": [
+			            {"fieldName": "book_id", "dataType": "Int64", "isPrimary": true, "isPartitionKey": true, "elementTypeParams": {}},
+			            {"fieldName": "book_intro", "dataType": "FloatVector", "elementTypeParams": {"dim": 2}}
+			        ]
+			    }, "params": {"partitionKeyIsolation": "true"}}`),
+	})
+	// Struct sub-vector index via collection_create indexParams: the
+	// structName[subName] form is registered in fieldNames so users can
+	// create the sub-vector index alongside top-level indexes in one call.
+	postTestCases = append(postTestCases, requestBodyTestCase{
+		path: path,
+		requestBody: []byte(`{"collectionName": "` + DefaultCollectionName + `", "schema": {
+	        "fields": [
+	            {"fieldName": "book_id", "dataType": "Int64", "isPrimary": true, "elementTypeParams": {}},
+	            {"fieldName": "book_intro", "dataType": "FloatVector", "elementTypeParams": {"dim": 2}}
+	        ],
+	        "structFields": [{
+	            "fieldName": "my_struct",
+	            "fields": [
+	                {"fieldName": "sub_vec", "dataType": "ArrayOfVector", "elementDataType": "FloatVector", "elementTypeParams": {"dim": 2, "max_capacity": 4}}
+	            ]
+	        }]
+	    }, "indexParams": [
+	        {"fieldName": "book_intro", "indexName": "book_intro_vector", "metricType": "L2"},
+	        {"fieldName": "my_struct[sub_vec]", "indexName": "sub_vec_idx", "metricType": "L2"}
+	    ]}`),
+	})
+
+	// Struct sub-field qualified name that does not exist in schema is rejected.
+	postTestCases = append(postTestCases, requestBodyTestCase{
+		path: path,
+		requestBody: []byte(`{"collectionName": "` + DefaultCollectionName + `", "schema": {
+	        "fields": [
+	            {"fieldName": "book_id", "dataType": "Int64", "isPrimary": true, "elementTypeParams": {}},
+	            {"fieldName": "book_intro", "dataType": "FloatVector", "elementTypeParams": {"dim": 2}}
+	        ],
+	        "structFields": [{
+	            "fieldName": "my_struct",
+	            "fields": [
+	                {"fieldName": "sub_vec", "dataType": "ArrayOfVector", "elementDataType": "FloatVector", "elementTypeParams": {"dim": 2, "max_capacity": 4}}
+	            ]
+	        }]
+	    }, "indexParams": [
+	        {"fieldName": "my_struct[nonexistent]", "indexName": "bad", "metricType": "L2"}
+	    ]}`),
+		errMsg:  "missing required parameters, error: `my_struct[nonexistent]` hasn't defined in schema",
+		errCode: 1802,
 	})
 	postTestCases = append(postTestCases, requestBodyTestCase{
 		path:        path,
@@ -1839,6 +1943,36 @@ func TestCreateCollection(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, int32(0), returnBody.Code)
 	})
+}
+
+func TestCreateCollectionStructArrayDuplicateName(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	testEngine := initHTTPServerV2(mocks.NewMockProxy(t), false)
+	req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionCategory, CreateAction), bytes.NewReader([]byte(`{
+		"collectionName": "test",
+		"schema": {
+			"fields": [
+				{"fieldName": "book_id", "dataType": "Int64", "isPrimary": true, "elementTypeParams": {}}
+			],
+			"structFields": [{
+				"fieldName": "book_id",
+				"fields": [
+					{"fieldName": "sub_int", "dataType": "Array", "elementDataType": "Int32"}
+				]
+			}]
+		}
+	}`)))
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	err := json.Unmarshal(w.Body.Bytes(), returnBody)
+	assert.Nil(t, err)
+	assert.Equal(t, merr.Code(merr.ErrParameterInvalid), returnBody.Code)
+	assert.Contains(t, returnBody.Message, "duplicated field name: book_id")
 }
 
 func versionalV2(category string, action string) string {

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -649,7 +649,7 @@ func (field *FieldSchema) GetProto(ctx context.Context) (*schemapb.FieldSchema, 
 		log.Ctx(ctx).Warn("convert defaultValue fail", zap.Any("defaultValue", field.DefaultValue), zap.Error(err))
 		return nil, merr.WrapErrParameterInvalidMsg("convert defaultValue fail, err: %s", err.Error())
 	}
-	if dataType == schemapb.DataType_Array {
+	if dataType == schemapb.DataType_Array || dataType == schemapb.DataType_ArrayOfVector {
 		if _, ok := schemapb.DataType_value[field.ElementDataType]; !ok {
 			log.Ctx(ctx).Warn("element's data type is invalid(case sensitive).", zap.Any("elementDataType", field.ElementDataType), zap.Any("field", field))
 			return nil, merr.WrapErrParameterInvalidMsg("element data type %s is invalid(case sensitive)", field.ElementDataType)
@@ -664,6 +664,71 @@ func (field *FieldSchema) GetProto(ctx context.Context) (*schemapb.FieldSchema, 
 		fieldSchema.TypeParams = append(fieldSchema.TypeParams, &commonpb.KeyValuePair{Key: key, Value: value})
 	}
 	return fieldSchema, nil
+}
+
+// StructArrayFieldSchema describes a struct array field in RESTful v2 API.
+// Each struct array field contains multiple sub-fields; every sub-field must
+// be declared as either Array (scalar element) or ArrayOfVector (vector element).
+type StructArrayFieldSchema struct {
+	FieldName   string                 `json:"fieldName" binding:"required"`
+	Description string                 `json:"description"`
+	Fields      []FieldSchema          `json:"fields" binding:"required"`
+	TypeParams  map[string]interface{} `json:"typeParams"`
+}
+
+// GetProto converts the RESTful StructArrayFieldSchema to its proto counterpart.
+// Only Array / ArrayOfVector data types are allowed for sub-fields.
+func (sf *StructArrayFieldSchema) GetProto(ctx context.Context) (*schemapb.StructArrayFieldSchema, error) {
+	if len(sf.Fields) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("struct field %s must contain at least one sub-field", sf.FieldName)
+	}
+	proto := &schemapb.StructArrayFieldSchema{
+		Name:        sf.FieldName,
+		Description: sf.Description,
+		TypeParams:  []*commonpb.KeyValuePair{},
+	}
+	subNames := map[string]struct{}{}
+	for i := range sf.Fields {
+		sub := sf.Fields[i]
+		subProto, err := sub.GetProto(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if subProto.DataType != schemapb.DataType_Array && subProto.DataType != schemapb.DataType_ArrayOfVector {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"sub-field %s of struct %s must be Array or ArrayOfVector, got %s",
+				sub.FieldName, sf.FieldName, sub.DataType)
+		}
+		if subProto.IsPrimaryKey || subProto.IsPartitionKey || subProto.IsClusteringKey {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"sub-field %s of struct %s cannot be primary / partition / clustering key",
+				sub.FieldName, sf.FieldName)
+		}
+		if subProto.Nullable {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"sub-field %s of struct %s cannot be nullable",
+				sub.FieldName, sf.FieldName)
+		}
+		if subProto.DefaultValue != nil {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"sub-field %s of struct %s cannot set defaultValue",
+				sub.FieldName, sf.FieldName)
+		}
+		if _, dup := subNames[subProto.Name]; dup {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"duplicated sub-field name %s in struct %s", subProto.Name, sf.FieldName)
+		}
+		subNames[subProto.Name] = struct{}{}
+		proto.Fields = append(proto.Fields, subProto)
+	}
+	for key, param := range sf.TypeParams {
+		value, err := getElementTypeParams(param)
+		if err != nil {
+			return nil, err
+		}
+		proto.TypeParams = append(proto.TypeParams, &commonpb.KeyValuePair{Key: key, Value: value})
+	}
+	return proto, nil
 }
 
 type FunctionScore struct {
@@ -681,10 +746,11 @@ type FunctionSchema struct {
 }
 
 type CollectionSchema struct {
-	Fields             []FieldSchema    `json:"fields"`
-	Functions          []FunctionSchema `json:"functions"`
-	AutoId             bool             `json:"autoID"`
-	EnableDynamicField bool             `json:"enableDynamicField"`
+	Fields             []FieldSchema            `json:"fields"`
+	StructFields       []StructArrayFieldSchema `json:"structFields"`
+	Functions          []FunctionSchema         `json:"functions"`
+	AutoId             bool                     `json:"autoID"`
+	EnableDynamicField bool                     `json:"enableDynamicField"`
 }
 
 type CollectionReq struct {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -19,6 +19,7 @@ package httpserver
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"math"
 	"reflect"
@@ -310,11 +311,37 @@ func printFieldDetail(field *schemapb.FieldSchema, oldVersion bool) gin.H {
 		if field.TypeParams != nil {
 			fieldDetail[Params] = field.TypeParams
 		}
-		if field.DataType == schemapb.DataType_Array {
+		if field.DataType == schemapb.DataType_Array || field.DataType == schemapb.DataType_ArrayOfVector {
 			fieldDetail[HTTPReturnFieldElementType] = field.GetElementType().String()
 		}
 	}
 	return fieldDetail
+}
+
+func printStructArrayFieldsV2(structFields []*schemapb.StructArrayFieldSchema) []gin.H {
+	res := make([]gin.H, 0, len(structFields))
+	for _, sf := range structFields {
+		subs := make([]gin.H, 0, len(sf.GetFields()))
+		for _, sub := range sf.GetFields() {
+			detail := printFieldDetail(sub, false)
+			if short, err := typeutil.ExtractStructFieldName(sub.GetName()); err == nil && short != "" {
+				detail[HTTPReturnFieldName] = short
+			}
+			subs = append(subs, detail)
+		}
+		entry := gin.H{
+			HTTPReturnFieldName:   sf.GetName(),
+			HTTPReturnFieldID:     sf.GetFieldID(),
+			HTTPReturnDescription: sf.GetDescription(),
+			HTTPReturnFieldType:   schemapb.DataType_ArrayOfStruct.String(),
+			"fields":              subs,
+		}
+		if len(sf.GetTypeParams()) > 0 {
+			entry[Params] = sf.GetTypeParams()
+		}
+		res = append(res, entry)
+	}
+	return res
 }
 
 func printFunctionDetails(functions []*schemapb.FunctionSchema) []gin.H {
@@ -367,17 +394,31 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 		return reallyDataArray, validDataMap, merr.ErrMissingRequiredParameters
 	}
 
-	fieldNames := make([]string, 0, len(collSchema.Fields))
+	fieldNames := make([]string, 0, len(collSchema.Fields)+len(collSchema.StructArrayFields))
 	for _, field := range collSchema.Fields {
 		if field.IsDynamic {
 			continue
 		}
 		fieldNames = append(fieldNames, field.Name)
 	}
+	for _, structField := range collSchema.StructArrayFields {
+		fieldNames = append(fieldNames, structField.GetName())
+	}
 
 	for _, data := range dataResultArray {
 		reallyData := map[string]interface{}{}
 		if data.Type == gjson.JSON {
+			for _, structField := range collSchema.StructArrayFields {
+				rawValue := gjson.Get(data.Raw, structField.GetName())
+				if partialUpdate && !rawValue.Exists() {
+					continue
+				}
+				structRow, err := parseStructArrayRow(rawValue.Raw, structField)
+				if err != nil {
+					return reallyDataArray, validDataMap, err
+				}
+				reallyData[structField.GetName()] = structRow
+			}
 			for _, field := range collSchema.Fields {
 				if field.IsDynamic {
 					continue
@@ -721,6 +762,782 @@ func getDim(field *schemapb.FieldSchema) (int64, error) {
 	return int64(dim), nil
 }
 
+type structArrayRow map[string]interface{}
+
+func structFieldShortName(name string) string {
+	short, err := typeutil.ExtractStructFieldName(name)
+	if err != nil || short == "" {
+		return name
+	}
+	return short
+}
+
+func subShortName(sub *schemapb.FieldSchema) string {
+	return structFieldShortName(sub.GetName())
+}
+
+func parseStructArrayRow(rawJSON string, structSchema *schemapb.StructArrayFieldSchema) (structArrayRow, error) {
+	if rawJSON == "" {
+		return nil, merr.WrapErrParameterInvalidMsg("missing struct array field: %s", structSchema.GetName())
+	}
+	parsed := gjson.Parse(rawJSON)
+	if !parsed.IsArray() {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"struct array field %s expects a JSON array of objects", structSchema.GetName())
+	}
+	elems := parsed.Array()
+	collected := make(map[string][]gjson.Result, len(structSchema.GetFields()))
+	expected := make(map[string]struct{}, len(structSchema.GetFields()))
+	for _, sub := range structSchema.GetFields() {
+		key := subShortName(sub)
+		collected[key] = make([]gjson.Result, 0, len(elems))
+		expected[key] = struct{}{}
+	}
+	for idx, elem := range elems {
+		if elem.Type != gjson.JSON || !elem.IsObject() {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"struct array field %s element #%d must be a JSON object", structSchema.GetName(), idx)
+		}
+		seen := make(map[string]struct{}, len(structSchema.GetFields()))
+		elem.ForEach(func(key, value gjson.Result) bool {
+			name := key.String()
+			if _, ok := expected[name]; !ok {
+				return true
+			}
+			collected[name] = append(collected[name], value)
+			seen[name] = struct{}{}
+			return true
+		})
+		if len(seen) != len(expected) {
+			for name := range expected {
+				if _, ok := seen[name]; !ok {
+					return nil, merr.WrapErrParameterInvalidMsg(
+						"struct array field %s element #%d missing sub-field %s",
+						structSchema.GetName(), idx, name)
+				}
+			}
+		}
+	}
+
+	row := structArrayRow{}
+	for _, sub := range structSchema.GetFields() {
+		key := subShortName(sub)
+		vals := collected[key]
+		switch sub.GetDataType() {
+		case schemapb.DataType_Array:
+			scalar, err := buildStructSubArrayScalar(sub, vals)
+			if err != nil {
+				return nil, err
+			}
+			row[key] = scalar
+		case schemapb.DataType_ArrayOfVector:
+			vec, err := buildStructSubVectorField(sub, vals)
+			if err != nil {
+				return nil, err
+			}
+			row[key] = vec
+		default:
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"sub-field %s of struct %s has unsupported data type %s",
+				key, structSchema.GetName(), sub.GetDataType())
+		}
+	}
+	return row, nil
+}
+
+func buildStructSubArrayScalar(sub *schemapb.FieldSchema, vals []gjson.Result) (*schemapb.ScalarField, error) {
+	switch sub.GetElementType() {
+	case schemapb.DataType_Bool:
+		arr := make([]bool, 0, len(vals))
+		for _, v := range vals {
+			if v.Type != gjson.True && v.Type != gjson.False {
+				return nil, wrapStructSubParseError(sub, v, "expect bool")
+			}
+			arr = append(arr, v.Bool())
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+		arr := make([]int32, 0, len(vals))
+		for _, v := range vals {
+			if v.Type != gjson.Number {
+				return nil, wrapStructSubParseError(sub, v, "expect integer")
+			}
+			arr = append(arr, int32(v.Int()))
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_Int64:
+		arr := make([]int64, 0, len(vals))
+		for _, v := range vals {
+			if v.Type != gjson.Number {
+				return nil, wrapStructSubParseError(sub, v, "expect integer")
+			}
+			arr = append(arr, v.Int())
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_Float:
+		arr := make([]float32, 0, len(vals))
+		for _, v := range vals {
+			if v.Type != gjson.Number {
+				return nil, wrapStructSubParseError(sub, v, "expect float")
+			}
+			arr = append(arr, float32(v.Float()))
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_Double:
+		arr := make([]float64, 0, len(vals))
+		for _, v := range vals {
+			if v.Type != gjson.Number {
+				return nil, wrapStructSubParseError(sub, v, "expect double")
+			}
+			arr = append(arr, v.Float())
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: arr}},
+		}, nil
+	case schemapb.DataType_VarChar, schemapb.DataType_String:
+		arr := make([]string, 0, len(vals))
+		for _, v := range vals {
+			if v.Type != gjson.String {
+				return nil, wrapStructSubParseError(sub, v, "expect string")
+			}
+			arr = append(arr, v.String())
+		}
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: arr}},
+		}, nil
+	default:
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"sub-field %s has unsupported array element type %s",
+			sub.GetName(), sub.GetElementType())
+	}
+}
+
+func buildStructSubVectorField(sub *schemapb.FieldSchema, vals []gjson.Result) (*schemapb.VectorField, error) {
+	dim, err := getDim(sub)
+	if err != nil {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"sub-field %s: %s", sub.GetName(), err.Error())
+	}
+	switch sub.GetElementType() {
+	case schemapb.DataType_FloatVector:
+		packed := &schemapb.FloatArray{}
+		for _, v := range vals {
+			if !v.IsArray() {
+				return nil, wrapStructSubParseError(sub, v, "expect float vector array")
+			}
+			var row []float32
+			if err := json.Unmarshal([]byte(v.Raw), &row); err != nil {
+				return nil, wrapStructSubParseError(sub, v, err.Error())
+			}
+			if int64(len(row)) != dim {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"sub-field %s vector dim mismatch: expect %d, got %d",
+					sub.GetName(), dim, len(row))
+			}
+			packed.Data = append(packed.Data, row...)
+		}
+		return &schemapb.VectorField{
+			Dim:  dim,
+			Data: &schemapb.VectorField_FloatVector{FloatVector: packed},
+		}, nil
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		isFloat16 := sub.GetElementType() == schemapb.DataType_Float16Vector
+		bytesPerVec := dim * 2
+		buf := make([]byte, 0, int(bytesPerVec)*len(vals))
+		for _, v := range vals {
+			b, err := decodeByteVectorElement(v, dim, bytesPerVec, isFloat16)
+			if err != nil {
+				return nil, wrapStructSubParseError(sub, v, err.Error())
+			}
+			buf = append(buf, b...)
+		}
+		if isFloat16 {
+			return &schemapb.VectorField{
+				Dim:  dim,
+				Data: &schemapb.VectorField_Float16Vector{Float16Vector: buf},
+			}, nil
+		}
+		return &schemapb.VectorField{
+			Dim:  dim,
+			Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: buf},
+		}, nil
+	case schemapb.DataType_BinaryVector:
+		bytesPerVec := dim / 8
+		buf := make([]byte, 0, int(bytesPerVec)*len(vals))
+		for _, v := range vals {
+			if v.Type != gjson.String {
+				return nil, wrapStructSubParseError(sub, v, "binary vector must be base64-encoded string")
+			}
+			var row []byte
+			if err := json.Unmarshal([]byte(v.Raw), &row); err != nil {
+				return nil, wrapStructSubParseError(sub, v, err.Error())
+			}
+			if int64(len(row)) != bytesPerVec {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"sub-field %s binary vector byte-length mismatch: expect %d, got %d",
+					sub.GetName(), bytesPerVec, len(row))
+			}
+			buf = append(buf, row...)
+		}
+		return &schemapb.VectorField{
+			Dim:  dim,
+			Data: &schemapb.VectorField_BinaryVector{BinaryVector: buf},
+		}, nil
+	case schemapb.DataType_Int8Vector:
+		buf := make([]byte, 0, int(dim)*len(vals))
+		for _, v := range vals {
+			if !v.IsArray() {
+				return nil, wrapStructSubParseError(sub, v, "expect int8 vector array")
+			}
+			var row []int8
+			if err := json.Unmarshal([]byte(v.Raw), &row); err != nil {
+				return nil, wrapStructSubParseError(sub, v, err.Error())
+			}
+			if int64(len(row)) != dim {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"sub-field %s int8 vector dim mismatch: expect %d, got %d",
+					sub.GetName(), dim, len(row))
+			}
+			for _, x := range row {
+				buf = append(buf, byte(x))
+			}
+		}
+		return &schemapb.VectorField{
+			Dim:  dim,
+			Data: &schemapb.VectorField_Int8Vector{Int8Vector: buf},
+		}, nil
+	default:
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"sub-field %s has unsupported vector element type %s",
+			sub.GetName(), sub.GetElementType())
+	}
+}
+
+func decodeByteVectorElement(v gjson.Result, dim, bytesPerVec int64, isFloat16 bool) ([]byte, error) {
+	if v.IsArray() {
+		var row []float32
+		if err := json.Unmarshal([]byte(v.Raw), &row); err != nil {
+			return nil, err
+		}
+		if int64(len(row)) != dim {
+			return nil, merr.WrapErrParameterInvalidMsg("vector dim mismatch: expect %d, got %d", dim, len(row))
+		}
+		if isFloat16 {
+			return typeutil.Float32ArrayToFloat16Bytes(row), nil
+		}
+		return typeutil.Float32ArrayToBFloat16Bytes(row), nil
+	}
+	if v.Type != gjson.String {
+		return nil, merr.WrapErrParameterInvalidMsg("expect float vector array or base64 string")
+	}
+	var row []byte
+	if err := json.Unmarshal([]byte(v.Raw), &row); err != nil {
+		return nil, err
+	}
+	if int64(len(row)) != bytesPerVec {
+		return nil, merr.WrapErrParameterInvalidMsg("byte length mismatch: expect %d, got %d", bytesPerVec, len(row))
+	}
+	return row, nil
+}
+
+func wrapStructSubParseError(sub *schemapb.FieldSchema, v gjson.Result, msg string) error {
+	return merr.WrapErrParameterInvalidMsg(
+		"sub-field %s parse error: %s (value=%s)", sub.GetName(), msg, v.Raw)
+}
+
+func isEmbeddingListData(body string) bool {
+	raw := gjson.Get(body, HTTPRequestData)
+	if !raw.IsArray() {
+		return false
+	}
+	arr := raw.Array()
+	if len(arr) == 0 {
+		return false
+	}
+	first := arr[0]
+	if first.Type == gjson.String {
+		return false
+	}
+	if !first.IsArray() {
+		return false
+	}
+	inner := first.Array()
+	if len(inner) == 0 {
+		return false
+	}
+	firstInner := inner[0]
+	return firstInner.IsArray() || firstInner.Type == gjson.String
+}
+
+func convertEmbListQueries2Placeholder(body string, elemType schemapb.DataType, dim int64) (*commonpb.PlaceholderValue, error) {
+	raw := gjson.Get(body, HTTPRequestData)
+	if !raw.IsArray() {
+		return nil, merr.WrapErrParameterInvalidMsg("search data must be an array of embedding lists")
+	}
+	queries := raw.Array()
+	if len(queries) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("search data is empty")
+	}
+
+	placeholderType, err := embListPlaceholderType(elemType)
+	if err != nil {
+		return nil, err
+	}
+
+	values := make([][]byte, 0, len(queries))
+	for qIdx, q := range queries {
+		if !q.IsArray() {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"search data[%d] must be an array of vectors", qIdx)
+		}
+		vecs := q.Array()
+		if len(vecs) == 0 {
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"search data[%d] embedding list is empty", qIdx)
+		}
+		buf, err := encodeEmbListQuery(vecs, elemType, dim, qIdx)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, buf)
+	}
+	return &commonpb.PlaceholderValue{
+		Tag:    "$0",
+		Type:   placeholderType,
+		Values: values,
+	}, nil
+}
+
+func embListPlaceholderType(elemType schemapb.DataType) (commonpb.PlaceholderType, error) {
+	switch elemType {
+	case schemapb.DataType_FloatVector:
+		return commonpb.PlaceholderType_EmbListFloatVector, nil
+	case schemapb.DataType_Float16Vector:
+		return commonpb.PlaceholderType_EmbListFloat16Vector, nil
+	case schemapb.DataType_BFloat16Vector:
+		return commonpb.PlaceholderType_EmbListBFloat16Vector, nil
+	case schemapb.DataType_BinaryVector:
+		return commonpb.PlaceholderType_EmbListBinaryVector, nil
+	case schemapb.DataType_Int8Vector:
+		return commonpb.PlaceholderType_EmbListInt8Vector, nil
+	default:
+		return 0, merr.WrapErrParameterInvalidMsg(
+			"unsupported embedding list element type %s", elemType)
+	}
+}
+
+func encodeEmbListQuery(vecs []gjson.Result, elemType schemapb.DataType, dim int64, qIdx int) ([]byte, error) {
+	switch elemType {
+	case schemapb.DataType_FloatVector:
+		buf := make([]byte, 0, int(dim*4)*len(vecs))
+		for vIdx, v := range vecs {
+			if !v.IsArray() {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d] must be a float vector array", qIdx, vIdx)
+			}
+			var row []float32
+			if err := json.Unmarshal([]byte(v.Raw), &row); err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d] parse fail: %s", qIdx, vIdx, err.Error())
+			}
+			if int64(len(row)) != dim {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d] dim mismatch: expect %d got %d", qIdx, vIdx, dim, len(row))
+			}
+			buf = append(buf, typeutil.Float32ArrayToBytes(row)...)
+		}
+		return buf, nil
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		isFloat16 := elemType == schemapb.DataType_Float16Vector
+		bytesPerVec := dim * 2
+		buf := make([]byte, 0, int(bytesPerVec)*len(vecs))
+		for vIdx, v := range vecs {
+			b, err := decodeByteVectorElement(v, dim, bytesPerVec, isFloat16)
+			if err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d]: %s", qIdx, vIdx, err.Error())
+			}
+			buf = append(buf, b...)
+		}
+		return buf, nil
+	case schemapb.DataType_BinaryVector:
+		bytesPerVec := dim / 8
+		buf := make([]byte, 0, int(bytesPerVec)*len(vecs))
+		for vIdx, v := range vecs {
+			if v.Type != gjson.String {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d] binary vector must be base64-encoded string", qIdx, vIdx)
+			}
+			var row []byte
+			if err := json.Unmarshal([]byte(v.Raw), &row); err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d] parse fail: %s", qIdx, vIdx, err.Error())
+			}
+			if int64(len(row)) != bytesPerVec {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d] byte-length mismatch: expect %d got %d", qIdx, vIdx, bytesPerVec, len(row))
+			}
+			buf = append(buf, row...)
+		}
+		return buf, nil
+	case schemapb.DataType_Int8Vector:
+		buf := make([]byte, 0, int(dim)*len(vecs))
+		for vIdx, v := range vecs {
+			if !v.IsArray() {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d] must be an int8 vector array", qIdx, vIdx)
+			}
+			var row []int8
+			if err := json.Unmarshal([]byte(v.Raw), &row); err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d] parse fail: %s", qIdx, vIdx, err.Error())
+			}
+			if int64(len(row)) != dim {
+				return nil, merr.WrapErrParameterInvalidMsg(
+					"search data[%d][%d] dim mismatch: expect %d got %d", qIdx, vIdx, dim, len(row))
+			}
+			buf = append(buf, typeutil.Int8ArrayToBytes(row)...)
+		}
+		return buf, nil
+	default:
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"unsupported embedding list element type %s", elemType)
+	}
+}
+
+func buildStructArrayFieldData(structSchema *schemapb.StructArrayFieldSchema, perRow []structArrayRow) (*schemapb.FieldData, error) {
+	if len(perRow) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("struct array field %s has no rows", structSchema.GetName())
+	}
+	subs := structSchema.GetFields()
+	subFieldData := make([]*schemapb.FieldData, 0, len(subs))
+	for _, sub := range subs {
+		short := subShortName(sub)
+		switch sub.GetDataType() {
+		case schemapb.DataType_Array:
+			arrayArray := &schemapb.ArrayArray{
+				Data:        make([]*schemapb.ScalarField, 0, len(perRow)),
+				ElementType: sub.GetElementType(),
+			}
+			for rowIdx, row := range perRow {
+				val, ok := row[short]
+				if !ok {
+					return nil, merr.WrapErrParameterInvalidMsg("struct %s row %d missing sub-field %s",
+						structSchema.GetName(), rowIdx, short)
+				}
+				scalar, ok := val.(*schemapb.ScalarField)
+				if !ok {
+					return nil, merr.WrapErrParameterInvalidMsg("struct %s sub-field %s row %d: unexpected payload type %T",
+						structSchema.GetName(), short, rowIdx, val)
+				}
+				arrayArray.Data = append(arrayArray.Data, scalar)
+			}
+			subFieldData = append(subFieldData, &schemapb.FieldData{
+				Type:      schemapb.DataType_Array,
+				FieldName: short,
+				FieldId:   sub.GetFieldID(),
+				Field: &schemapb.FieldData_Scalars{
+					Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_ArrayData{ArrayData: arrayArray},
+					},
+				},
+			})
+		case schemapb.DataType_ArrayOfVector:
+			dim, err := getDim(sub)
+			if err != nil {
+				return nil, err
+			}
+			vecArray := &schemapb.VectorArray{
+				ElementType: sub.GetElementType(),
+				Dim:         dim,
+				Data:        make([]*schemapb.VectorField, 0, len(perRow)),
+			}
+			for rowIdx, row := range perRow {
+				val, ok := row[short]
+				if !ok {
+					return nil, merr.WrapErrParameterInvalidMsg("struct %s row %d missing sub-field %s",
+						structSchema.GetName(), rowIdx, short)
+				}
+				vf, ok := val.(*schemapb.VectorField)
+				if !ok {
+					return nil, merr.WrapErrParameterInvalidMsg("struct %s sub-field %s row %d: unexpected payload type %T",
+						structSchema.GetName(), short, rowIdx, val)
+				}
+				vecArray.Data = append(vecArray.Data, vf)
+			}
+			subFieldData = append(subFieldData, &schemapb.FieldData{
+				Type:      schemapb.DataType_ArrayOfVector,
+				FieldName: short,
+				FieldId:   sub.GetFieldID(),
+				Field: &schemapb.FieldData_Vectors{
+					Vectors: &schemapb.VectorField{
+						Dim: dim,
+						Data: &schemapb.VectorField_VectorArray{
+							VectorArray: vecArray,
+						},
+					},
+				},
+			})
+		default:
+			return nil, merr.WrapErrParameterInvalidMsg("unsupported struct sub-field data type: %s", sub.GetDataType())
+		}
+	}
+	return &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfStruct,
+		FieldName: structSchema.GetName(),
+		FieldId:   structSchema.GetFieldID(),
+		Field: &schemapb.FieldData_StructArrays{
+			StructArrays: &schemapb.StructArrayField{Fields: subFieldData},
+		},
+	}, nil
+}
+
+func extractStructArrayRow(fd *schemapb.FieldData, rowIdx int, schema *schemapb.CollectionSchema) ([]map[string]interface{}, error) {
+	subs := fd.GetStructArrays().GetFields()
+	if len(subs) == 0 {
+		return []map[string]interface{}{}, nil
+	}
+
+	subDims, err := structArraySubDims(fd.GetFieldName(), schema)
+	if err != nil {
+		return nil, err
+	}
+
+	elemCount, err := structSubElemCount(subs[0], rowIdx, subDims)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]interface{}, elemCount)
+	for i := 0; i < elemCount; i++ {
+		out[i] = make(map[string]interface{}, len(subs))
+	}
+	for _, sub := range subs {
+		short := structFieldShortName(sub.GetFieldName())
+		switch sub.GetType() {
+		case schemapb.DataType_Array:
+			rowData := sub.GetScalars().GetArrayData().GetData()
+			if rowIdx >= len(rowData) {
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s missing row %d", short, rowIdx)
+			}
+			values := scalarArrayToInterfaces(rowData[rowIdx])
+			if len(values) != elemCount {
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s element count mismatch: expect %d got %d",
+					short, elemCount, len(values))
+			}
+			for i, v := range values {
+				out[i][short] = v
+			}
+		case schemapb.DataType_ArrayOfVector:
+			va := sub.GetVectors().GetVectorArray()
+			if va == nil {
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s has no vector array", short)
+			}
+			if rowIdx >= len(va.GetData()) {
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s missing row %d", short, rowIdx)
+			}
+			dim, ok := subDims[short]
+			if !ok || dim <= 0 {
+				return nil, merr.WrapErrServiceInternalMsg("schema missing dim for struct sub-field %s", short)
+			}
+			values, err := vectorFieldToInterfaces(va.GetData()[rowIdx], va.GetElementType(), dim)
+			if err != nil {
+				return nil, err
+			}
+			if len(values) != elemCount {
+				return nil, merr.WrapErrServiceInternalMsg("struct sub-field %s vector element count mismatch: expect %d got %d",
+					short, elemCount, len(values))
+			}
+			for i, v := range values {
+				out[i][short] = v
+			}
+		default:
+			return nil, merr.WrapErrServiceInternalMsg("unsupported struct sub-field type %s", sub.GetType())
+		}
+	}
+	return out, nil
+}
+
+func structArraySubDims(fieldName string, schema *schemapb.CollectionSchema) (map[string]int64, error) {
+	subDims := make(map[string]int64)
+	for _, sf := range schema.GetStructArrayFields() {
+		if sf.GetName() != fieldName {
+			continue
+		}
+		for _, sub := range sf.GetFields() {
+			if sub.GetDataType() != schemapb.DataType_ArrayOfVector {
+				continue
+			}
+			dim, err := getDim(sub)
+			if err != nil {
+				return nil, merr.Wrapf(err, "schema sub-field %s has no dim", sub.GetName())
+			}
+			subDims[subShortName(sub)] = dim
+		}
+		break
+	}
+	return subDims, nil
+}
+
+func structSubElemCount(sub *schemapb.FieldData, rowIdx int, subDims map[string]int64) (int, error) {
+	switch sub.GetType() {
+	case schemapb.DataType_Array:
+		rowData := sub.GetScalars().GetArrayData().GetData()
+		if rowIdx >= len(rowData) {
+			return 0, merr.WrapErrServiceInternalMsg("struct sub-field %s row %d out of range", sub.GetFieldName(), rowIdx)
+		}
+		return len(scalarArrayToInterfaces(rowData[rowIdx])), nil
+	case schemapb.DataType_ArrayOfVector:
+		va := sub.GetVectors().GetVectorArray()
+		if va == nil || rowIdx >= len(va.GetData()) {
+			return 0, merr.WrapErrServiceInternalMsg("struct sub-field %s row %d out of range", sub.GetFieldName(), rowIdx)
+		}
+		short := structFieldShortName(sub.GetFieldName())
+		dim, ok := subDims[short]
+		if !ok || dim <= 0 {
+			return 0, merr.WrapErrServiceInternalMsg("schema missing dim for struct sub-field %s", short)
+		}
+		return vectorFieldElemCount(va.GetData()[rowIdx], va.GetElementType(), dim)
+	default:
+		return 0, merr.WrapErrServiceInternalMsg("unsupported struct sub-field type %s", sub.GetType())
+	}
+}
+
+func scalarArrayToInterfaces(sf *schemapb.ScalarField) []interface{} {
+	switch sf.GetData().(type) {
+	case *schemapb.ScalarField_BoolData:
+		src := sf.GetBoolData().GetData()
+		out := make([]interface{}, len(src))
+		for i, v := range src {
+			out[i] = v
+		}
+		return out
+	case *schemapb.ScalarField_IntData:
+		src := sf.GetIntData().GetData()
+		out := make([]interface{}, len(src))
+		for i, v := range src {
+			out[i] = v
+		}
+		return out
+	case *schemapb.ScalarField_LongData:
+		src := sf.GetLongData().GetData()
+		out := make([]interface{}, len(src))
+		for i, v := range src {
+			out[i] = v
+		}
+		return out
+	case *schemapb.ScalarField_FloatData:
+		src := sf.GetFloatData().GetData()
+		out := make([]interface{}, len(src))
+		for i, v := range src {
+			out[i] = v
+		}
+		return out
+	case *schemapb.ScalarField_DoubleData:
+		src := sf.GetDoubleData().GetData()
+		out := make([]interface{}, len(src))
+		for i, v := range src {
+			out[i] = v
+		}
+		return out
+	case *schemapb.ScalarField_StringData:
+		src := sf.GetStringData().GetData()
+		out := make([]interface{}, len(src))
+		for i, v := range src {
+			out[i] = v
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func vectorFieldElemCount(vf *schemapb.VectorField, elemType schemapb.DataType, dim int64) (int, error) {
+	if dim <= 0 {
+		return 0, merr.WrapErrServiceInternalMsg("invalid dim %d", dim)
+	}
+	switch elemType {
+	case schemapb.DataType_FloatVector:
+		return len(vf.GetFloatVector().GetData()) / int(dim), nil
+	case schemapb.DataType_Float16Vector:
+		return len(vf.GetFloat16Vector()) / int(dim*2), nil
+	case schemapb.DataType_BFloat16Vector:
+		return len(vf.GetBfloat16Vector()) / int(dim*2), nil
+	case schemapb.DataType_BinaryVector:
+		return len(vf.GetBinaryVector()) / int(dim/8), nil
+	case schemapb.DataType_Int8Vector:
+		return len(vf.GetInt8Vector()) / int(dim), nil
+	default:
+		return 0, merr.WrapErrServiceInternalMsg("unsupported vector element type %s", elemType)
+	}
+}
+
+func vectorFieldToInterfaces(vf *schemapb.VectorField, elemType schemapb.DataType, dim int64) ([]interface{}, error) {
+	if dim <= 0 {
+		return nil, merr.WrapErrServiceInternalMsg("invalid dim %d", dim)
+	}
+	switch elemType {
+	case schemapb.DataType_FloatVector:
+		buf := vf.GetFloatVector().GetData()
+		count := len(buf) / int(dim)
+		out := make([]interface{}, count)
+		for i := 0; i < count; i++ {
+			out[i] = buf[i*int(dim) : (i+1)*int(dim)]
+		}
+		return out, nil
+	case schemapb.DataType_Float16Vector:
+		buf := vf.GetFloat16Vector()
+		step := int(dim * 2)
+		count := len(buf) / step
+		out := make([]interface{}, count)
+		for i := 0; i < count; i++ {
+			out[i] = base64.StdEncoding.EncodeToString(buf[i*step : (i+1)*step])
+		}
+		return out, nil
+	case schemapb.DataType_BFloat16Vector:
+		buf := vf.GetBfloat16Vector()
+		step := int(dim * 2)
+		count := len(buf) / step
+		out := make([]interface{}, count)
+		for i := 0; i < count; i++ {
+			out[i] = base64.StdEncoding.EncodeToString(buf[i*step : (i+1)*step])
+		}
+		return out, nil
+	case schemapb.DataType_BinaryVector:
+		buf := vf.GetBinaryVector()
+		step := int(dim / 8)
+		count := len(buf) / step
+		out := make([]interface{}, count)
+		for i := 0; i < count; i++ {
+			out[i] = base64.StdEncoding.EncodeToString(buf[i*step : (i+1)*step])
+		}
+		return out, nil
+	case schemapb.DataType_Int8Vector:
+		buf := vf.GetInt8Vector()
+		step := int(dim)
+		count := len(buf) / step
+		out := make([]interface{}, count)
+		for i := 0; i < count; i++ {
+			seg := buf[i*step : (i+1)*step]
+			row := make([]int8, step)
+			for j, b := range seg {
+				row[j] = int8(b)
+			}
+			out[i] = row
+		}
+		return out, nil
+	default:
+		return nil, merr.WrapErrServiceInternalMsg("unsupported vector element type %s", elemType)
+	}
+}
+
 func convertFloatVectorToArray(vector [][]float32, dim int64) ([]float32, error) {
 	floatArray := make([]float32, 0)
 	for _, arr := range vector {
@@ -1025,6 +1842,9 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 
 			delete(set, field.Name)
 		}
+		for _, structField := range sch.GetStructArrayFields() {
+			delete(set, structField.GetName())
+		}
 		// if is not dynamic, but pass more field, will throw err in /internal/distributed/proxy/httpserver/utils.go@checkAndSetData
 		if isDynamic {
 			m := make(map[string]interface{})
@@ -1306,6 +2126,32 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 			IsDynamic: true,
 		})
 	}
+	for _, structField := range sch.GetStructArrayFields() {
+		perRow := make([]structArrayRow, 0, rowsLen)
+		for rowIdx, row := range rows {
+			val, ok := row[structField.GetName()]
+			if !ok {
+				if partialUpdate {
+					continue
+				}
+				return nil, merr.WrapErrParameterInvalidMsg("row %d does not has struct field %s", rowIdx, structField.GetName())
+			}
+			sr, ok := val.(structArrayRow)
+			if !ok {
+				return nil, merr.WrapErrParameterInvalidMsg("row %d struct field %s has unexpected payload type %T",
+					rowIdx, structField.GetName(), val)
+			}
+			perRow = append(perRow, sr)
+		}
+		if len(perRow) == 0 {
+			continue
+		}
+		structFieldData, err := buildStructArrayFieldData(structField, perRow)
+		if err != nil {
+			return nil, err
+		}
+		columns = append(columns, structFieldData)
+	}
 	return columns, nil
 }
 
@@ -1544,6 +2390,19 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 			return 0, merr.WrapErrParameterInvalidMsg("invalid int8 vector dimension %d for field %s", dim, fieldData.GetFieldName())
 		}
 		return int64(len(fieldData.GetVectors().GetInt8Vector())) / dim, nil
+	case schemapb.DataType_ArrayOfStruct:
+		subs := fieldData.GetStructArrays().GetFields()
+		if len(subs) == 0 {
+			return 0, nil
+		}
+		switch subs[0].GetType() {
+		case schemapb.DataType_Array:
+			return int64(len(subs[0].GetScalars().GetArrayData().GetData())), nil
+		case schemapb.DataType_ArrayOfVector:
+			return int64(len(subs[0].GetVectors().GetVectorArray().GetData())), nil
+		default:
+			return 0, merr.WrapErrServiceInternalMsg("unsupported struct sub-field type %s for field %s", subs[0].GetType(), fieldData.GetFieldName())
+		}
 	default:
 		return 0, merr.WrapErrParameterInvalidMsg("the type(%v) of field(%v) is not supported, use other sdk please", fieldData.GetType(), fieldData.GetFieldName())
 	}
@@ -1755,6 +2614,12 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 					} else {
 						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryWktData().Data[dataIdx]
 					}
+				case schemapb.DataType_ArrayOfStruct:
+					structRow, err := extractStructArrayRow(fieldDataList[j], int(dataIdx), collectionSchema)
+					if err != nil {
+						return nil, err
+					}
+					row[fieldDataList[j].GetFieldName()] = structRow
 				default:
 					row[fieldDataList[j].GetFieldName()] = ""
 				}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -3538,3 +3538,989 @@ func TestConvertIDsToSchemapbIDs(t *testing.T) {
 		assert.Contains(t, err.Error(), "unsupported primary key type")
 	})
 }
+
+func buildStructArrayTestSchema() *schemapb.CollectionSchema {
+	pk := &schemapb.FieldSchema{
+		FieldID:      100,
+		Name:         "id",
+		IsPrimaryKey: true,
+		DataType:     schemapb.DataType_Int64,
+	}
+	vec := &schemapb.FieldSchema{
+		FieldID:  101,
+		Name:     "vec",
+		DataType: schemapb.DataType_FloatVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: "4"},
+		},
+	}
+	subInt := &schemapb.FieldSchema{
+		FieldID:     103,
+		Name:        "sub_int",
+		DataType:    schemapb.DataType_Array,
+		ElementType: schemapb.DataType_Int32,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxCapacityKey, Value: "10"},
+		},
+	}
+	subVec := &schemapb.FieldSchema{
+		FieldID:     104,
+		Name:        "sub_vec",
+		DataType:    schemapb.DataType_ArrayOfVector,
+		ElementType: schemapb.DataType_FloatVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: "4"},
+			{Key: common.MaxCapacityKey, Value: "10"},
+		},
+	}
+	structField := &schemapb.StructArrayFieldSchema{
+		FieldID: 102,
+		Name:    "my_struct",
+		Fields:  []*schemapb.FieldSchema{subInt, subVec},
+	}
+	return &schemapb.CollectionSchema{
+		Name:              "c_test",
+		Fields:            []*schemapb.FieldSchema{pk, vec},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{structField},
+	}
+}
+
+func TestStructArrayFieldSchemaGetProto(t *testing.T) {
+	ctx := context.Background()
+	good := StructArrayFieldSchema{
+		FieldName:   "my_struct",
+		Description: "struct field",
+		Fields: []FieldSchema{
+			{
+				FieldName:       "sub_int",
+				DataType:        "Array",
+				ElementDataType: "Int32",
+				ElementTypeParams: map[string]interface{}{
+					"max_capacity": 10,
+				},
+			},
+			{
+				FieldName:       "sub_vec",
+				DataType:        "ArrayOfVector",
+				ElementDataType: "FloatVector",
+				ElementTypeParams: map[string]interface{}{
+					"dim":          4,
+					"max_capacity": 10,
+				},
+			},
+		},
+	}
+	proto, err := good.GetProto(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "my_struct", proto.GetName())
+	assert.Len(t, proto.GetFields(), 2)
+	assert.Equal(t, schemapb.DataType_Array, proto.GetFields()[0].GetDataType())
+	assert.Equal(t, schemapb.DataType_Int32, proto.GetFields()[0].GetElementType())
+	assert.Equal(t, schemapb.DataType_ArrayOfVector, proto.GetFields()[1].GetDataType())
+	assert.Equal(t, schemapb.DataType_FloatVector, proto.GetFields()[1].GetElementType())
+
+	_, err = (&StructArrayFieldSchema{
+		FieldName: "bad",
+		Fields: []FieldSchema{
+			{FieldName: "raw_int", DataType: "Int32"},
+		},
+	}).GetProto(ctx)
+	assert.Error(t, err)
+
+	_, err = (&StructArrayFieldSchema{
+		FieldName: "bad_pk",
+		Fields: []FieldSchema{
+			{
+				FieldName:       "sub_pk",
+				DataType:        "Array",
+				ElementDataType: "Int32",
+				IsPrimary:       true,
+			},
+		},
+	}).GetProto(ctx)
+	assert.Error(t, err)
+
+	_, err = (&StructArrayFieldSchema{FieldName: "empty"}).GetProto(ctx)
+	assert.Error(t, err)
+
+	_, err = (&StructArrayFieldSchema{
+		FieldName: "dup",
+		Fields: []FieldSchema{
+			{FieldName: "s", DataType: "Array", ElementDataType: "Int32"},
+			{FieldName: "s", DataType: "Array", ElementDataType: "Int32"},
+		},
+	}).GetProto(ctx)
+	assert.Error(t, err)
+
+	_, err = (&StructArrayFieldSchema{
+		FieldName: "bad_nullable",
+		Fields: []FieldSchema{
+			{
+				FieldName:       "sub_null",
+				DataType:        "Array",
+				ElementDataType: "Int32",
+				Nullable:        true,
+			},
+		},
+	}).GetProto(ctx)
+	assert.Error(t, err)
+
+	_, err = (&StructArrayFieldSchema{
+		FieldName: "bad_default",
+		Fields: []FieldSchema{
+			{
+				FieldName:       "sub_default",
+				DataType:        "Array",
+				ElementDataType: "Int32",
+				DefaultValue:    float64(1),
+			},
+		},
+	}).GetProto(ctx)
+	assert.Error(t, err)
+
+	_, err = (&StructArrayFieldSchema{
+		FieldName: "bad_part",
+		Fields: []FieldSchema{
+			{
+				FieldName:       "sub_part",
+				DataType:        "Array",
+				ElementDataType: "Int32",
+				IsPartitionKey:  true,
+			},
+		},
+	}).GetProto(ctx)
+	assert.Error(t, err)
+
+	_, err = (&StructArrayFieldSchema{
+		FieldName: "bad_cluster",
+		Fields: []FieldSchema{
+			{
+				FieldName:       "sub_cluster",
+				DataType:        "Array",
+				ElementDataType: "Int32",
+				IsClusteringKey: true,
+			},
+		},
+	}).GetProto(ctx)
+	assert.Error(t, err)
+}
+
+func TestParseStructArrayRowScalar(t *testing.T) {
+	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
+	raw := `[{"sub_int": 1, "sub_vec": [0.1, 0.2, 0.3, 0.4]},
+	         {"sub_int": 2, "sub_vec": [0.5, 0.6, 0.7, 0.8]}]`
+	row, err := parseStructArrayRow(raw, schema)
+	require.NoError(t, err)
+	require.Len(t, row, 2)
+
+	scalar, ok := row["sub_int"].(*schemapb.ScalarField)
+	require.True(t, ok)
+	assert.Equal(t, []int32{1, 2}, scalar.GetIntData().GetData())
+
+	vecField, ok := row["sub_vec"].(*schemapb.VectorField)
+	require.True(t, ok)
+	assert.Equal(t,
+		[]float32{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8},
+		vecField.GetFloatVector().GetData())
+}
+
+func TestParseStructArrayRowMissingField(t *testing.T) {
+	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
+	_, err := parseStructArrayRow(`[{"sub_int": 1}]`, schema)
+	assert.Error(t, err)
+}
+
+func TestParseStructArrayRowNotArray(t *testing.T) {
+	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
+	_, err := parseStructArrayRow(`{"sub_int": 1}`, schema)
+	assert.Error(t, err)
+}
+
+func TestBuildStructArrayFieldDataRoundTrip(t *testing.T) {
+	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
+	r1, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1, 0.2, 0.3, 0.4]},
+	                                 {"sub_int": 2, "sub_vec": [0.5, 0.6, 0.7, 0.8]}]`, schema)
+	require.NoError(t, err)
+	r2, err := parseStructArrayRow(`[{"sub_int": 3, "sub_vec": [0.9, 1.0, 1.1, 1.2]}]`, schema)
+	require.NoError(t, err)
+
+	fd, err := buildStructArrayFieldData(schema, []structArrayRow{r1, r2})
+	require.NoError(t, err)
+	require.Equal(t, schemapb.DataType_ArrayOfStruct, fd.GetType())
+	subs := fd.GetStructArrays().GetFields()
+	require.Len(t, subs, 2)
+
+	assert.Equal(t, schemapb.DataType_Array, subs[0].GetType())
+	assert.Len(t, subs[0].GetScalars().GetArrayData().GetData(), 2)
+	assert.Equal(t, schemapb.DataType_ArrayOfVector, subs[1].GetType())
+	assert.Len(t, subs[1].GetVectors().GetVectorArray().GetData(), 2)
+
+	extracted0, err := extractStructArrayRow(fd, 0, buildStructArrayTestSchema())
+	require.NoError(t, err)
+	require.Len(t, extracted0, 2)
+	assert.EqualValues(t, int32(1), extracted0[0]["sub_int"])
+	assert.EqualValues(t, []float32{0.1, 0.2, 0.3, 0.4}, extracted0[0]["sub_vec"])
+
+	extracted1, err := extractStructArrayRow(fd, 1, buildStructArrayTestSchema())
+	require.NoError(t, err)
+	require.Len(t, extracted1, 1)
+	assert.EqualValues(t, int32(3), extracted1[0]["sub_int"])
+}
+
+func TestAnyToColumnsStructArray(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	body := []byte(`{
+		"data": [
+			{
+				"id": 1,
+				"vec": [0.1, 0.2, 0.3, 0.4],
+				"my_struct": [
+					{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]},
+					{"sub_int": 20, "sub_vec": [2.1, 2.2, 2.3, 2.4]}
+				]
+			},
+			{
+				"id": 2,
+				"vec": [0.5, 0.6, 0.7, 0.8],
+				"my_struct": [
+					{"sub_int": 30, "sub_vec": [3.1, 3.2, 3.3, 3.4]}
+				]
+			}
+		]
+	}`)
+	rows, _, err := checkAndSetData(body, schema, false)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	fds, err := anyToColumns(rows, nil, schema, true, false)
+	require.NoError(t, err)
+
+	var structFD *schemapb.FieldData
+	for _, fd := range fds {
+		if fd.GetType() == schemapb.DataType_ArrayOfStruct {
+			structFD = fd
+			break
+		}
+	}
+	require.NotNil(t, structFD)
+	assert.Equal(t, "my_struct", structFD.GetFieldName())
+	subs := structFD.GetStructArrays().GetFields()
+	require.Len(t, subs, 2)
+
+	arrayData := subs[0].GetScalars().GetArrayData().GetData()
+	require.Len(t, arrayData, 2)
+	assert.Equal(t, []int32{10, 20}, arrayData[0].GetIntData().GetData())
+	assert.Equal(t, []int32{30}, arrayData[1].GetIntData().GetData())
+
+	vecData := subs[1].GetVectors().GetVectorArray().GetData()
+	require.Len(t, vecData, 2)
+	assert.Len(t, vecData[0].GetFloatVector().GetData(), 8)
+	assert.Len(t, vecData[1].GetFloatVector().GetData(), 4)
+}
+
+func TestBuildQueryRespStructArrayRoundTrip(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	body := []byte(`{
+		"data": [
+			{
+				"id": 1,
+				"vec": [0.1, 0.2, 0.3, 0.4],
+				"my_struct": [
+					{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]},
+					{"sub_int": 20, "sub_vec": [2.1, 2.2, 2.3, 2.4]}
+				]
+			}
+		]
+	}`)
+	rows, _, err := checkAndSetData(body, schema, false)
+	require.NoError(t, err)
+	fds, err := anyToColumns(rows, nil, schema, true, false)
+	require.NoError(t, err)
+
+	var structFD *schemapb.FieldData
+	for _, fd := range fds {
+		if fd.GetType() == schemapb.DataType_ArrayOfStruct {
+			structFD = fd
+			break
+		}
+	}
+	require.NotNil(t, structFD)
+
+	resp, err := buildQueryResp(0, []string{"my_struct"}, []*schemapb.FieldData{structFD}, nil, nil, true, schema)
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+
+	blob, err := json.Marshal(resp[0]["my_struct"])
+	require.NoError(t, err)
+	var decoded []map[string]interface{}
+	require.NoError(t, json.Unmarshal(blob, &decoded))
+	require.Len(t, decoded, 2)
+	assert.EqualValues(t, 10, decoded[0]["sub_int"])
+}
+
+func TestIsEmbeddingListData(t *testing.T) {
+	assert.False(t, isEmbeddingListData(`{"data": [[0.1, 0.2, 0.3, 0.4]]}`))
+	assert.False(t, isEmbeddingListData(`{"data": [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]]}`))
+	assert.False(t, isEmbeddingListData(`{"data": ["YmFzZTY0"]}`))
+	assert.False(t, isEmbeddingListData(`{"data": ["YmFzZTY0", "YmFzZTY1"]}`))
+
+	assert.True(t, isEmbeddingListData(`{"data": [[[0.1, 0.2, 0.3, 0.4]]]}`))
+	assert.True(t, isEmbeddingListData(`{"data": [[[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]], [[0.9, 1.0, 1.1, 1.2]]]}`))
+	assert.True(t, isEmbeddingListData(`{"data": [["YmFzZTY0", "YmFzZTY1"]]}`))
+
+	assert.False(t, isEmbeddingListData(`{"data": []}`))
+	assert.False(t, isEmbeddingListData(`{"data": "not-array"}`))
+	assert.False(t, isEmbeddingListData(`{"data": [[]]}`))
+}
+
+func TestPrintStructArrayFieldsV2(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	printed := printStructArrayFieldsV2(schema.GetStructArrayFields())
+	require.Len(t, printed, 1)
+	entry := printed[0]
+	assert.Equal(t, "my_struct", entry[HTTPReturnFieldName])
+	assert.Equal(t, schemapb.DataType_ArrayOfStruct.String(), entry[HTTPReturnFieldType])
+	subs, ok := entry["fields"].([]gin.H)
+	require.True(t, ok)
+	require.Len(t, subs, 2)
+	assert.Equal(t, "sub_int", subs[0][HTTPReturnFieldName])
+	assert.Equal(t, schemapb.DataType_Array.String(), subs[0][HTTPReturnFieldType])
+	assert.Equal(t, schemapb.DataType_Int32.String(), subs[0][HTTPReturnFieldElementType])
+	assert.Equal(t, "sub_vec", subs[1][HTTPReturnFieldName])
+	assert.Equal(t, schemapb.DataType_FloatVector.String(), subs[1][HTTPReturnFieldElementType])
+}
+
+func TestStructArrayScalarSubFieldTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		elementType schemapb.DataType
+		raw         string
+		assertFn    func(*testing.T, *schemapb.ScalarField)
+	}{
+		{
+			name:        "bool",
+			elementType: schemapb.DataType_Bool,
+			raw:         `[true,false]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []bool{true, false}, sf.GetBoolData().GetData())
+			},
+		},
+		{
+			name:        "int64",
+			elementType: schemapb.DataType_Int64,
+			raw:         `[10,20]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []int64{10, 20}, sf.GetLongData().GetData())
+			},
+		},
+		{
+			name:        "float",
+			elementType: schemapb.DataType_Float,
+			raw:         `[1.5,2.5]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []float32{1.5, 2.5}, sf.GetFloatData().GetData())
+			},
+		},
+		{
+			name:        "double",
+			elementType: schemapb.DataType_Double,
+			raw:         `[1.25,2.25]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []float64{1.25, 2.25}, sf.GetDoubleData().GetData())
+			},
+		},
+		{
+			name:        "string",
+			elementType: schemapb.DataType_VarChar,
+			raw:         `["red","blue"]`,
+			assertFn: func(t *testing.T, sf *schemapb.ScalarField) {
+				assert.Equal(t, []string{"red", "blue"}, sf.GetStringData().GetData())
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sub := &schemapb.FieldSchema{Name: test.name, ElementType: test.elementType}
+			got, err := buildStructSubArrayScalar(sub, gjson.Parse(test.raw).Array())
+			require.NoError(t, err)
+			test.assertFn(t, got)
+		})
+	}
+
+	_, err := buildStructSubArrayScalar(&schemapb.FieldSchema{Name: "bad", ElementType: schemapb.DataType_JSON}, gjson.Parse(`[{}]`).Array())
+	assert.Error(t, err)
+
+	_, err = buildStructSubArrayScalar(&schemapb.FieldSchema{Name: "bad_bool", ElementType: schemapb.DataType_Bool}, gjson.Parse(`[1]`).Array())
+	assert.Error(t, err)
+}
+
+func TestStructArrayVectorSubFieldTypes(t *testing.T) {
+	tests := []struct {
+		name        string
+		elementType schemapb.DataType
+		dim         string
+		raw         string
+		assertFn    func(*testing.T, *schemapb.VectorField)
+	}{
+		{
+			name:        "float16",
+			elementType: schemapb.DataType_Float16Vector,
+			dim:         "2",
+			raw:         `[[0.1,0.2],"AQIDBA=="]`,
+			assertFn: func(t *testing.T, vf *schemapb.VectorField) {
+				assert.Len(t, vf.GetFloat16Vector(), 8)
+			},
+		},
+		{
+			name:        "bfloat16",
+			elementType: schemapb.DataType_BFloat16Vector,
+			dim:         "2",
+			raw:         `[[0.1,0.2],[0.3,0.4]]`,
+			assertFn: func(t *testing.T, vf *schemapb.VectorField) {
+				assert.Len(t, vf.GetBfloat16Vector(), 8)
+			},
+		},
+		{
+			name:        "binary",
+			elementType: schemapb.DataType_BinaryVector,
+			dim:         "16",
+			raw:         `["AQI=","AwQ="]`,
+			assertFn: func(t *testing.T, vf *schemapb.VectorField) {
+				assert.Equal(t, []byte{1, 2, 3, 4}, vf.GetBinaryVector())
+			},
+		},
+		{
+			name:        "int8",
+			elementType: schemapb.DataType_Int8Vector,
+			dim:         "2",
+			raw:         `[[1,-2],[3,4]]`,
+			assertFn: func(t *testing.T, vf *schemapb.VectorField) {
+				assert.Equal(t, []byte{1, 254, 3, 4}, vf.GetInt8Vector())
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sub := &schemapb.FieldSchema{
+				Name:        test.name,
+				ElementType: test.elementType,
+				TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: test.dim}},
+			}
+			got, err := buildStructSubVectorField(sub, gjson.Parse(test.raw).Array())
+			require.NoError(t, err)
+			test.assertFn(t, got)
+		})
+	}
+
+	_, err := buildStructSubVectorField(&schemapb.FieldSchema{
+		Name:        "bad_dim",
+		ElementType: schemapb.DataType_FloatVector,
+		TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+	}, gjson.Parse(`[[0.1]]`).Array())
+	assert.Error(t, err)
+
+	_, err = buildStructSubVectorField(&schemapb.FieldSchema{
+		Name:        "bad_type",
+		ElementType: schemapb.DataType_JSON,
+		TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+	}, gjson.Parse(`[{}]`).Array())
+	assert.Error(t, err)
+}
+
+func TestEmbeddingListPlaceholderTypes(t *testing.T) {
+	tests := []struct {
+		name            string
+		elementType     schemapb.DataType
+		body            string
+		dim             int64
+		placeholderType commonpb.PlaceholderType
+		valueLen        int
+	}{
+		{
+			name:            "float",
+			elementType:     schemapb.DataType_FloatVector,
+			body:            `{"data": [[[0.1,0.2],[0.3,0.4]]]}`,
+			dim:             2,
+			placeholderType: commonpb.PlaceholderType_EmbListFloatVector,
+			valueLen:        16,
+		},
+		{
+			name:            "float16",
+			elementType:     schemapb.DataType_Float16Vector,
+			body:            `{"data": [[[0.1,0.2],[0.3,0.4]]]}`,
+			dim:             2,
+			placeholderType: commonpb.PlaceholderType_EmbListFloat16Vector,
+			valueLen:        8,
+		},
+		{
+			name:            "bfloat16",
+			elementType:     schemapb.DataType_BFloat16Vector,
+			body:            `{"data": [[[0.1,0.2],[0.3,0.4]]]}`,
+			dim:             2,
+			placeholderType: commonpb.PlaceholderType_EmbListBFloat16Vector,
+			valueLen:        8,
+		},
+		{
+			name:            "binary",
+			elementType:     schemapb.DataType_BinaryVector,
+			body:            `{"data": [["AQI=","AwQ="]]}`,
+			dim:             16,
+			placeholderType: commonpb.PlaceholderType_EmbListBinaryVector,
+			valueLen:        4,
+		},
+		{
+			name:            "int8",
+			elementType:     schemapb.DataType_Int8Vector,
+			body:            `{"data": [[[1,2],[3,4]]]}`,
+			dim:             2,
+			placeholderType: commonpb.PlaceholderType_EmbListInt8Vector,
+			valueLen:        4,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := convertEmbListQueries2Placeholder(test.body, test.elementType, test.dim)
+			require.NoError(t, err)
+			assert.Equal(t, test.placeholderType, got.GetType())
+			require.Len(t, got.GetValues(), 1)
+			assert.Len(t, got.GetValues()[0], test.valueLen)
+		})
+	}
+
+	for _, test := range []struct {
+		name        string
+		body        string
+		elementType schemapb.DataType
+		dim         int64
+	}{
+		{name: "data_not_array", body: `{"data":"bad"}`, elementType: schemapb.DataType_FloatVector, dim: 2},
+		{name: "empty_data", body: `{"data":[]}`, elementType: schemapb.DataType_FloatVector, dim: 2},
+		{name: "query_not_array", body: `{"data":[1]}`, elementType: schemapb.DataType_FloatVector, dim: 2},
+		{name: "empty_embedding_list", body: `{"data":[[]]}`, elementType: schemapb.DataType_FloatVector, dim: 2},
+		{name: "unsupported_element", body: `{"data":[[true]]}`, elementType: schemapb.DataType_Bool, dim: 2},
+		{name: "float_dim_mismatch", body: `{"data":[[[0.1]]]}`, elementType: schemapb.DataType_FloatVector, dim: 2},
+		{name: "binary_not_string", body: `{"data":[[[1,2]]]}`, elementType: schemapb.DataType_BinaryVector, dim: 16},
+		{name: "int8_not_array", body: `{"data":[["AQI="]]}`, elementType: schemapb.DataType_Int8Vector, dim: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := convertEmbListQueries2Placeholder(test.body, test.elementType, test.dim)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestGeneratePlaceholderGroupStructArrayField(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+
+	standard, err := generatePlaceholderGroup(context.Background(), `{"data": [[0.1,0.2,0.3,0.4]]}`, schema, "sub_vec")
+	require.NoError(t, err)
+	group := &commonpb.PlaceholderGroup{}
+	require.NoError(t, proto.Unmarshal(standard, group))
+	require.Len(t, group.GetPlaceholders(), 1)
+	assert.Equal(t, commonpb.PlaceholderType_FloatVector, group.GetPlaceholders()[0].GetType())
+
+	embList, err := generatePlaceholderGroup(context.Background(), `{"data": [[[0.1,0.2,0.3,0.4]]]}`, schema, "sub_vec")
+	require.NoError(t, err)
+	group.Reset()
+	require.NoError(t, proto.Unmarshal(embList, group))
+	require.Len(t, group.GetPlaceholders(), 1)
+	assert.Equal(t, commonpb.PlaceholderType_EmbListFloatVector, group.GetPlaceholders()[0].GetType())
+}
+
+func TestStructArrayFieldDataErrorPaths(t *testing.T) {
+	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
+
+	_, err := buildStructArrayFieldData(schema, nil)
+	assert.Error(t, err)
+
+	_, err = buildStructArrayFieldData(schema, []structArrayRow{{"sub_int": &schemapb.ScalarField{}}})
+	assert.Error(t, err)
+
+	_, err = buildStructArrayFieldData(schema, []structArrayRow{
+		{
+			"sub_int": int64(1),
+			"sub_vec": &schemapb.VectorField{},
+		},
+	})
+	assert.Error(t, err)
+
+	badTypeSchema := &schemapb.StructArrayFieldSchema{
+		Name:   "bad",
+		Fields: []*schemapb.FieldSchema{{Name: "sub", DataType: schemapb.DataType_Bool}},
+	}
+	_, err = buildStructArrayFieldData(badTypeSchema, []structArrayRow{{"sub": true}})
+	assert.Error(t, err)
+
+	noDimSchema := &schemapb.StructArrayFieldSchema{
+		Name: "bad_dim",
+		Fields: []*schemapb.FieldSchema{{
+			Name:     "sub_vec",
+			DataType: schemapb.DataType_ArrayOfVector,
+		}},
+	}
+	_, err = buildStructArrayFieldData(noDimSchema, []structArrayRow{{"sub_vec": &schemapb.VectorField{}}})
+	assert.Error(t, err)
+}
+
+func TestExtractStructArrayRowErrorPaths(t *testing.T) {
+	empty, err := extractStructArrayRow(&schemapb.FieldData{
+		Type: schemapb.DataType_ArrayOfStruct,
+		Field: &schemapb.FieldData_StructArrays{
+			StructArrays: &schemapb.StructArrayField{},
+		},
+	}, 0, buildStructArrayTestSchema())
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+
+	schema := buildStructArrayTestSchema()
+	row, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1, 0.2, 0.3, 0.4]}]`, schema.GetStructArrayFields()[0])
+	require.NoError(t, err)
+	fd, err := buildStructArrayFieldData(schema.GetStructArrayFields()[0], []structArrayRow{row})
+	require.NoError(t, err)
+
+	_, err = extractStructArrayRow(fd, 2, schema)
+	assert.Error(t, err)
+
+	mismatch := &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfStruct,
+		FieldName: "my_struct",
+		Field: &schemapb.FieldData_StructArrays{
+			StructArrays: &schemapb.StructArrayField{Fields: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Array,
+					FieldName: "sub_int",
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+							Data: []*schemapb.ScalarField{{
+								Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1, 2}}},
+							}},
+						}},
+					}},
+				},
+				{
+					Type:      schemapb.DataType_ArrayOfVector,
+					FieldName: "sub_vec",
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{
+							ElementType: schemapb.DataType_FloatVector,
+							Data: []*schemapb.VectorField{{
+								Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{0.1, 0.2, 0.3, 0.4}}},
+							}},
+						}},
+					}},
+				},
+			}},
+		},
+	}
+	_, err = extractStructArrayRow(mismatch, 0, schema)
+	assert.Error(t, err)
+
+	missingDimSchema := &schemapb.CollectionSchema{
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{{Name: "my_struct"}},
+	}
+	_, err = extractStructArrayRow(mismatch, 0, missingDimSchema)
+	assert.Error(t, err)
+
+	unsupported := &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfStruct,
+		FieldName: "my_struct",
+		Field: &schemapb.FieldData_StructArrays{
+			StructArrays: &schemapb.StructArrayField{Fields: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Array,
+					FieldName: "sub_int",
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+						Data: &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+							Data: []*schemapb.ScalarField{{
+								Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1}}},
+							}},
+						}},
+					}},
+				},
+				{Type: schemapb.DataType_Bool, FieldName: "bad"},
+			}},
+		},
+	}
+	_, err = extractStructArrayRow(unsupported, 0, schema)
+	assert.Error(t, err)
+}
+
+func TestStructArrayHelperValueConversions(t *testing.T) {
+	assert.Equal(t, "sub", structFieldShortName("my_struct[sub]"))
+	assert.Equal(t, "plain", structFieldShortName("plain"))
+
+	scalars := []*schemapb.ScalarField{
+		{Data: &schemapb.ScalarField_BoolData{BoolData: &schemapb.BoolArray{Data: []bool{true}}}},
+		{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{1}}}},
+		{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{2}}}},
+		{Data: &schemapb.ScalarField_FloatData{FloatData: &schemapb.FloatArray{Data: []float32{3.5}}}},
+		{Data: &schemapb.ScalarField_DoubleData{DoubleData: &schemapb.DoubleArray{Data: []float64{4.5}}}},
+		{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"five"}}}},
+	}
+	for _, scalar := range scalars {
+		assert.Len(t, scalarArrayToInterfaces(scalar), 1)
+	}
+	assert.Nil(t, scalarArrayToInterfaces(&schemapb.ScalarField{}))
+
+	vectorTests := []struct {
+		name        string
+		elementType schemapb.DataType
+		vector      *schemapb.VectorField
+		dim         int64
+		count       int
+	}{
+		{
+			name:        "float",
+			elementType: schemapb.DataType_FloatVector,
+			vector: &schemapb.VectorField{Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: []float32{0.1, 0.2, 0.3, 0.4}},
+			}},
+			dim:   2,
+			count: 2,
+		},
+		{
+			name:        "float16",
+			elementType: schemapb.DataType_Float16Vector,
+			vector:      &schemapb.VectorField{Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4}}},
+			dim:         2,
+			count:       1,
+		},
+		{
+			name:        "bfloat16",
+			elementType: schemapb.DataType_BFloat16Vector,
+			vector:      &schemapb.VectorField{Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{1, 2, 3, 4}}},
+			dim:         2,
+			count:       1,
+		},
+		{
+			name:        "binary",
+			elementType: schemapb.DataType_BinaryVector,
+			vector:      &schemapb.VectorField{Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2}}},
+			dim:         16,
+			count:       1,
+		},
+		{
+			name:        "int8",
+			elementType: schemapb.DataType_Int8Vector,
+			vector:      &schemapb.VectorField{Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 254}}},
+			dim:         2,
+			count:       1,
+		},
+	}
+	for _, test := range vectorTests {
+		t.Run(test.name, func(t *testing.T) {
+			count, err := vectorFieldElemCount(test.vector, test.elementType, test.dim)
+			require.NoError(t, err)
+			assert.Equal(t, test.count, count)
+			values, err := vectorFieldToInterfaces(test.vector, test.elementType, test.dim)
+			require.NoError(t, err)
+			assert.Len(t, values, test.count)
+		})
+	}
+
+	_, err := vectorFieldElemCount(&schemapb.VectorField{}, schemapb.DataType_FloatVector, 0)
+	assert.Error(t, err)
+	_, err = vectorFieldElemCount(&schemapb.VectorField{}, schemapb.DataType_JSON, 1)
+	assert.Error(t, err)
+	_, err = vectorFieldToInterfaces(&schemapb.VectorField{}, schemapb.DataType_FloatVector, 0)
+	assert.Error(t, err)
+	_, err = vectorFieldToInterfaces(&schemapb.VectorField{}, schemapb.DataType_JSON, 1)
+	assert.Error(t, err)
+}
+
+func TestStructArrayCheckAndSetPartialUpdate(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	body := []byte(`{"data": [{"id": 1, "vec": [0.1,0.2,0.3,0.4]}]}`)
+	rows, validData, err := checkAndSetData(body, schema, true)
+	require.NoError(t, err)
+	assert.NotContains(t, rows[0], "my_struct")
+	fds, err := anyToColumns(rows, validData, schema, false, true)
+	require.NoError(t, err)
+	for _, fd := range fds {
+		assert.NotEqual(t, schemapb.DataType_ArrayOfStruct, fd.GetType())
+	}
+
+	_, _, err = checkAndSetData(body, schema, false)
+	assert.Error(t, err)
+}
+
+func TestStructArrayFieldDataValueCount(t *testing.T) {
+	schema := buildStructArrayTestSchema().GetStructArrayFields()[0]
+	row, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1,0.2,0.3,0.4]}]`, schema)
+	require.NoError(t, err)
+	fd, err := buildStructArrayFieldData(schema, []structArrayRow{row})
+	require.NoError(t, err)
+	count, err := fieldDataValueCount(fd)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
+	subs := fd.GetStructArrays().GetFields()
+	fd.GetStructArrays().Fields = []*schemapb.FieldData{subs[1], subs[0]}
+	count, err = fieldDataValueCount(fd)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
+	fd.GetStructArrays().Fields = nil
+	count, err = fieldDataValueCount(fd)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+
+	fd.GetStructArrays().Fields = []*schemapb.FieldData{{Type: schemapb.DataType_Bool}}
+	_, err = fieldDataValueCount(fd)
+	assert.Error(t, err)
+}
+
+func TestStructArrayFieldSchemaGetProtoTypeParams(t *testing.T) {
+	proto, err := (&StructArrayFieldSchema{
+		FieldName:   "my_struct",
+		Description: "with params",
+		TypeParams: map[string]interface{}{
+			common.MaxCapacityKey: 8,
+		},
+		Fields: []FieldSchema{
+			{FieldName: "sub_int", DataType: "Array", ElementDataType: "Int32"},
+		},
+	}).GetProto(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "my_struct", proto.GetName())
+	assert.Equal(t, "with params", proto.GetDescription())
+	require.Len(t, proto.GetTypeParams(), 1)
+	assert.Equal(t, common.MaxCapacityKey, proto.GetTypeParams()[0].GetKey())
+	assert.Equal(t, "8", proto.GetTypeParams()[0].GetValue())
+
+	_, err = (&StructArrayFieldSchema{
+		FieldName: "bad_params",
+		TypeParams: map[string]interface{}{
+			"bad": func() {},
+		},
+		Fields: []FieldSchema{
+			{FieldName: "sub_int", DataType: "Array", ElementDataType: "Int32"},
+		},
+	}).GetProto(context.Background())
+	assert.Error(t, err)
+}
+
+func TestPrintStructArrayFieldsV2QualifiedSubFields(t *testing.T) {
+	printed := printStructArrayFieldsV2([]*schemapb.StructArrayFieldSchema{
+		{
+			FieldID:     10,
+			Name:        "my_struct",
+			Description: "qualified names",
+			TypeParams:  []*commonpb.KeyValuePair{{Key: common.MaxCapacityKey, Value: "16"}},
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:     11,
+					Name:        "my_struct[sub_int]",
+					DataType:    schemapb.DataType_Array,
+					ElementType: schemapb.DataType_Int32,
+				},
+				{
+					FieldID:     12,
+					Name:        "my_struct[sub_vec]",
+					DataType:    schemapb.DataType_ArrayOfVector,
+					ElementType: schemapb.DataType_FloatVector,
+					TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4"}},
+				},
+			},
+		},
+	})
+	require.Len(t, printed, 1)
+	entry := printed[0]
+	assert.Equal(t, "my_struct", entry[HTTPReturnFieldName])
+	params := entry[Params].([]*commonpb.KeyValuePair)
+	require.Len(t, params, 1)
+	assert.Equal(t, common.MaxCapacityKey, params[0].GetKey())
+	assert.Equal(t, "16", params[0].GetValue())
+
+	subs := entry["fields"].([]gin.H)
+	require.Len(t, subs, 2)
+	assert.Equal(t, "sub_int", subs[0][HTTPReturnFieldName])
+	assert.Equal(t, schemapb.DataType_Int32.String(), subs[0][HTTPReturnFieldElementType])
+	assert.Equal(t, "sub_vec", subs[1][HTTPReturnFieldName])
+	assert.Equal(t, schemapb.DataType_FloatVector.String(), subs[1][HTTPReturnFieldElementType])
+}
+
+func TestCheckAndSetDataStructArrayRows(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	body := []byte(`{"data": [
+		{
+			"id": 1,
+			"vec": [0.1, 0.2, 0.3, 0.4],
+			"my_struct": [
+				{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4], "ignored": true}
+			]
+		}
+	]}`)
+
+	rows, validData, err := checkAndSetData(body, schema, false)
+	require.NoError(t, err)
+	require.Empty(t, validData)
+	require.Len(t, rows, 1)
+	structRow, ok := rows[0]["my_struct"].(structArrayRow)
+	require.True(t, ok)
+	assert.Contains(t, structRow, "sub_int")
+	assert.Contains(t, structRow, "sub_vec")
+
+	_, _, err = checkAndSetData([]byte(`{"data": [{"id": 1, "vec": [0.1,0.2,0.3,0.4], "my_struct": [1]}]}`), schema, false)
+	assert.Error(t, err)
+}
+
+func TestParseStructArrayRowQualifiedSchemaNames(t *testing.T) {
+	schema := &schemapb.StructArrayFieldSchema{
+		Name: "my_struct",
+		Fields: []*schemapb.FieldSchema{
+			{
+				Name:        "my_struct[sub_int]",
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int32,
+			},
+			{
+				Name:        "my_struct[sub_vec]",
+				DataType:    schemapb.DataType_ArrayOfVector,
+				ElementType: schemapb.DataType_FloatVector,
+				TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+			},
+		},
+	}
+	row, err := parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1,0.2], "unknown": "ignored"}]`, schema)
+	require.NoError(t, err)
+	assert.Contains(t, row, "sub_int")
+	assert.Contains(t, row, "sub_vec")
+	assert.NotContains(t, row, "unknown")
+
+	unsupported := proto.Clone(schema).(*schemapb.StructArrayFieldSchema)
+	unsupported.Fields = append(unsupported.Fields, &schemapb.FieldSchema{Name: "bad", DataType: schemapb.DataType_Bool})
+	_, err = parseStructArrayRow(`[{"sub_int": 1, "sub_vec": [0.1,0.2], "bad": true}]`, unsupported)
+	assert.Error(t, err)
+}
+
+func TestByteVectorElementErrorPaths(t *testing.T) {
+	_, err := decodeByteVectorElement(gjson.Parse(`"bad-base64"`), 2, 4, true)
+	assert.Error(t, err)
+
+	_, err = decodeByteVectorElement(gjson.Parse(`"AQI="`), 2, 4, true)
+	assert.Error(t, err)
+
+	_, err = decodeByteVectorElement(gjson.Parse(`true`), 2, 4, true)
+	assert.Error(t, err)
+
+	_, err = decodeByteVectorElement(gjson.Parse(`[0.1]`), 2, 4, true)
+	assert.Error(t, err)
+}
+
+func TestEncodeEmbListQueryErrorPaths(t *testing.T) {
+	_, err := encodeEmbListQuery(gjson.Parse(`[[0.1]]`).Array(), schemapb.DataType_FloatVector, 2, 0)
+	assert.Error(t, err)
+
+	_, err = encodeEmbListQuery(gjson.Parse(`["AQI="]`).Array(), schemapb.DataType_BinaryVector, 32, 0)
+	assert.Error(t, err)
+
+	_, err = encodeEmbListQuery(gjson.Parse(`[[1, 2, 300]]`).Array(), schemapb.DataType_Int8Vector, 3, 0)
+	assert.Error(t, err)
+
+	_, err = encodeEmbListQuery(gjson.Parse(`[[true]]`).Array(), schemapb.DataType_Bool, 1, 0)
+	assert.Error(t, err)
+}

--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -73,6 +73,13 @@ class TestMilvusClientV2Base(Base):
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
                                        **kwargs).run()
         return res, check_result
+
+    @trace()
+    def create_struct_field_schema(self, client, check_task=None, check_items=None, **kwargs):
+        func_name = sys._getframe().f_code.co_name
+        res, check = api_request([client.create_struct_field_schema], **kwargs)
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
+        return res, check_result
     
     @trace()
     def add_field(self, schema, field_name, datatype, check_task=None, check_items=None, **kwargs):

--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -1,15 +1,16 @@
 import sys
 import time
-from typing import Optional
-from pymilvus import MilvusClient, DataType
+
+from pymilvus import DataType, MilvusClient
 
 sys.path.append("..")
-from check.func_check import ResponseChecker
-from utils.api_request import api_request
-from utils.wrapper import trace
-from utils.util_log import test_log as log
-from common import common_func as cf, common_type as ct
 from base.client_base import Base
+from check.func_check import ResponseChecker
+from common import common_func as cf
+from common import common_type as ct
+from utils.api_request import api_request
+from utils.util_log import test_log as log
+from utils.wrapper import trace
 
 TIMEOUT = 120
 INDEX_NAME = ""
@@ -80,7 +81,7 @@ class TestMilvusClientV2Base(Base):
         res, check = api_request([client.create_struct_field_schema], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
-    
+
     @trace()
     def add_field(self, schema, field_name, datatype, check_task=None, check_items=None, **kwargs):
 
@@ -98,7 +99,7 @@ class TestMilvusClientV2Base(Base):
         check_result = ResponseChecker(res, func_name, check_task, check_items, check,
                                        **kwargs).run()
         return res, check_result
-    
+
 
     @trace()
     def create_collection(self, client, collection_name, dimension=None, primary_field_name='id',
@@ -449,7 +450,7 @@ class TestMilvusClientV2Base(Base):
         return res, check_result
 
     @trace()
-    def create_database(self, client, db_name, properties: Optional[dict] = None, check_task=None, check_items=None, **kwargs):
+    def create_database(self, client, db_name, properties: dict | None = None, check_task=None, check_items=None, **kwargs):
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.create_database, db_name, properties], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task,

--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -17,7 +17,6 @@ INDEX_NAME = ""
 
 
 class TestMilvusClientV2Base(Base):
-
     # milvus_client = None
     active_trace = False
 
@@ -32,28 +31,52 @@ class TestMilvusClientV2Base(Base):
         self.async_milvus_client_wrap.init_async_client(**kwargs)
 
     def _client(self, active_trace=False, **kwargs):
-        """ return MilvusClient instance if connected successfully, otherwise return None"""
+        """return MilvusClient instance if connected successfully, otherwise return None"""
         if self.skip_connection:
             return None
         if cf.param_info.param_uri:
             uri = cf.param_info.param_uri
         else:
             uri = "http://" + cf.param_info.param_host + ":" + str(cf.param_info.param_port)
-        res, is_succ = self.init_milvus_client(uri=uri, token=cf.param_info.param_token, active_trace=active_trace, **kwargs)
+        res, is_succ = self.init_milvus_client(
+            uri=uri, token=cf.param_info.param_token, active_trace=active_trace, **kwargs
+        )
         if is_succ:
             # self.milvus_client = res
             log.info(f"server version: {res.get_server_version()}")
         return res
 
-    def init_milvus_client(self, uri, user="", password="", db_name="", token="", timeout=None,
-                           check_task=None, check_items=None, active_trace=False, **kwargs):
+    def init_milvus_client(
+        self,
+        uri,
+        user="",
+        password="",
+        db_name="",
+        token="",
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        active_trace=False,
+        **kwargs,
+    ):
         self.active_trace = active_trace
         func_name = sys._getframe().f_code.co_name
         res, is_succ = api_request([MilvusClient, uri, user, password, db_name, token, timeout], **kwargs)
         # self.milvus_client = res if is_succ else None
-        check_result = ResponseChecker(res, func_name, check_task, check_items, is_succ,
-                                       uri=uri, user=user, password=password, db_name=db_name, token=token,
-                                       timeout=timeout, **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            is_succ,
+            uri=uri,
+            user=user,
+            password=password,
+            db_name=db_name,
+            token=token,
+            timeout=timeout,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
@@ -64,15 +87,13 @@ class TestMilvusClientV2Base(Base):
         return res, check_result
 
     @trace()
-    def create_schema(self, client, timeout=None, check_task=None,
-                      check_items=None, **kwargs):
+    def create_schema(self, client, timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.create_schema], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -86,52 +107,83 @@ class TestMilvusClientV2Base(Base):
     def add_field(self, schema, field_name, datatype, check_task=None, check_items=None, **kwargs):
 
         # Set default parameters for specific field types
-        if datatype == DataType.VARCHAR and 'max_length' not in kwargs:
-            kwargs['max_length'] = ct.default_length
+        if datatype == DataType.VARCHAR and "max_length" not in kwargs:
+            kwargs["max_length"] = ct.default_length
         elif datatype == DataType.ARRAY:
-            if 'element_type' not in kwargs:
-                kwargs['element_type'] = DataType.INT64
-            if 'max_capacity' not in kwargs:
-                kwargs['max_capacity'] = ct.default_max_capacity
+            if "element_type" not in kwargs:
+                kwargs["element_type"] = DataType.INT64
+            if "max_capacity" not in kwargs:
+                kwargs["max_capacity"] = ct.default_max_capacity
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([schema.add_field, field_name, datatype], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
-
     @trace()
-    def create_collection(self, client, collection_name, dimension=None, primary_field_name='id',
-                          id_type='int', vector_field_name='vector', metric_type='COSINE',
-                          auto_id=False, schema=None, index_params=None, timeout=None, force_teardown=True,
-                          check_task=None, check_items=None, **kwargs):
+    def create_collection(
+        self,
+        client,
+        collection_name,
+        dimension=None,
+        primary_field_name="id",
+        id_type="int",
+        vector_field_name="vector",
+        metric_type="COSINE",
+        auto_id=False,
+        schema=None,
+        index_params=None,
+        timeout=None,
+        force_teardown=True,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         consistency_level = kwargs.get("consistency_level", "Strong")
         kwargs.update({"consistency_level": consistency_level})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.create_collection, collection_name, dimension, primary_field_name,
-                                  id_type, vector_field_name, metric_type, auto_id, timeout, schema,
-                                  index_params], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name, dimension=dimension,
-                                       **kwargs).run()
+        res, check = api_request(
+            [
+                client.create_collection,
+                collection_name,
+                dimension,
+                primary_field_name,
+                id_type,
+                vector_field_name,
+                metric_type,
+                auto_id,
+                timeout,
+                schema,
+                index_params,
+            ],
+            **kwargs,
+        )
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            dimension=dimension,
+            **kwargs,
+        ).run()
         if force_teardown:
             # if running with collection-shared-mode, please not teardown here, but do it in the specific test class
             self.tear_down_collection_names.append(collection_name)
         return res, check_result
 
-    def has_collection(self, client, collection_name, timeout=None, check_task=None,
-                       check_items=None, **kwargs):
+    def has_collection(self, client, collection_name, timeout=None, check_task=None, check_items=None, **kwargs):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.has_collection, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -141,8 +193,7 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.insert, collection_name, data], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -152,9 +203,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.upsert, collection_name, data], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name, data=data,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, data=data, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -164,58 +215,132 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.get_collection_stats, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
-    def search(self, client, collection_name, data=None, limit=10, filter=None, output_fields=None, search_params=None,
-               timeout=None, check_task=None, check_items=None, **kwargs):
+    def search(
+        self,
+        client,
+        collection_name,
+        data=None,
+        limit=10,
+        filter=None,
+        output_fields=None,
+        search_params=None,
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         # kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.search, collection_name, data, filter, limit,
-                                  output_fields, search_params], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name, data=data, limit=limit, filter=filter,
-                                       output_fields=output_fields, search_params=search_params,
-                                       **kwargs).run()
+        res, check = api_request(
+            [client.search, collection_name, data, filter, limit, output_fields, search_params], **kwargs
+        )
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            data=data,
+            limit=limit,
+            filter=filter,
+            output_fields=output_fields,
+            search_params=search_params,
+            **kwargs,
+        ).run()
         return res, check_result
 
-
     @trace()
-    def search_iterator(self, client, collection_name, data, batch_size, limit=-1, filter=None, output_fields=None,
-                        search_params=None, timeout=None, check_task=None, check_items=None, **kwargs):
+    def search_iterator(
+        self,
+        client,
+        collection_name,
+        data,
+        batch_size,
+        limit=-1,
+        filter=None,
+        output_fields=None,
+        search_params=None,
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.search_iterator, collection_name, data, batch_size, filter, limit,
-                                  output_fields, search_params], **kwargs)
-        if any(k in kwargs for k in ['use_rbac_mul_db', 'use_mul_db']):
-            self.using_database(client, kwargs.get('another_db'))
-        if kwargs.get('use_alias', False) is True:
+        res, check = api_request(
+            [client.search_iterator, collection_name, data, batch_size, filter, limit, output_fields, search_params],
+            **kwargs,
+        )
+        if any(k in kwargs for k in ["use_rbac_mul_db", "use_mul_db"]):
+            self.using_database(client, kwargs.get("another_db"))
+        if kwargs.get("use_alias", False) is True:
             alias = collection_name
-            self.alter_alias(client, kwargs.get('another_collection'), alias)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name, data=data, batch_size=batch_size, filter=filter,
-                                       limit=limit, output_fields=output_fields, search_params=search_params,
-                                       **kwargs).run()
+            self.alter_alias(client, kwargs.get("another_collection"), alias)
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            data=data,
+            batch_size=batch_size,
+            filter=filter,
+            limit=limit,
+            output_fields=output_fields,
+            search_params=search_params,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def hybrid_search(self, client, collection_name, reqs, ranker, limit=10,
-                      output_fields=None, timeout=None, partition_names=None,
-                      check_task=None, check_items=None, **kwargs):
+    def hybrid_search(
+        self,
+        client,
+        collection_name,
+        reqs,
+        ranker,
+        limit=10,
+        output_fields=None,
+        timeout=None,
+        partition_names=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         # kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.hybrid_search, collection_name, reqs, ranker, limit,
-                                  output_fields, timeout, partition_names], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name, reqs=reqs, ranker=ranker, limit=limit,
-                                       output_fields=output_fields, timeout=timeout, partition_names=partition_names, **kwargs).run()
+        res, check = api_request(
+            [client.hybrid_search, collection_name, reqs, ranker, limit, output_fields, timeout, partition_names],
+            **kwargs,
+        )
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            reqs=reqs,
+            ranker=ranker,
+            limit=limit,
+            output_fields=output_fields,
+            timeout=timeout,
+            partition_names=partition_names,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
@@ -225,9 +350,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.query, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -237,23 +362,39 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.query_iterator, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
-    def get(self, client, collection_name, ids, output_fields=None,
-            timeout=None, check_task=None, check_items=None, **kwargs):
+    def get(
+        self,
+        client,
+        collection_name,
+        ids,
+        output_fields=None,
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.get, collection_name, ids, output_fields], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name, ids=ids,
-                                       output_fields=output_fields,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            ids=ids,
+            output_fields=output_fields,
+            **kwargs,
+        ).run()
         return res, check_result
 
     # No client.num_entities method
@@ -270,15 +411,25 @@ class TestMilvusClientV2Base(Base):
     #     return res, check_result
 
     @trace()
-    def delete(self, client, collection_name, ids=None, timeout=None, filter=None, partition_name=None,
-               check_task=None, check_items=None, **kwargs):
+    def delete(
+        self,
+        client,
+        collection_name,
+        ids=None,
+        timeout=None,
+        filter=None,
+        partition_name=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.delete, collection_name, ids, timeout, filter, partition_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -288,9 +439,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.flush, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -300,9 +451,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.describe_collection, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -312,17 +463,16 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.list_collections], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
     def drop_collection(self, client, collection_name, check_task=None, check_items=None, **kwargs):
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.drop_collection, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         if check_result is True and collection_name in self.tear_down_collection_names:
             self.tear_down_collection_names.remove(collection_name)
         return res, check_result
@@ -331,20 +481,19 @@ class TestMilvusClientV2Base(Base):
     def list_indexes(self, client, collection_name, field_name=None, check_task=None, check_items=None, **kwargs):
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.list_indexes, collection_name, field_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
     def get_load_state(self, client, collection_name, check_task=None, check_items=None, **kwargs):
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.get_load_state, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
-
 
     @trace()
     def load_collection(self, client, collection_name, timeout=None, check_task=None, check_items=None, **kwargs):
@@ -353,9 +502,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.load_collection, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -365,9 +514,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.refresh_load, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -377,9 +526,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.release_collection, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -389,49 +538,65 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.truncate_collection, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
-    def list_persistent_segments(self, client, collection_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def list_persistent_segments(
+        self, client, collection_name, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.list_persistent_segments, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
-    def load_partitions(self, client, collection_name, partition_names, timeout=None, check_task=None, check_items=None, **kwargs):
+    def load_partitions(
+        self, client, collection_name, partition_names, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.load_partitions, collection_name, partition_names], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       partition_names=partition_names,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            partition_names=partition_names,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def release_partitions(self, client, collection_name, partition_names, timeout=None, check_task=None, check_items=None, **kwargs):
+    def release_partitions(
+        self, client, collection_name, partition_names, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.release_partitions, collection_name, partition_names], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       partition_names=partition_names,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            partition_names=partition_names,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
@@ -441,36 +606,42 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.rename_collection, old_name, new_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       old_name=old_name,
-                                       new_name=new_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, old_name=old_name, new_name=new_name, **kwargs
+        ).run()
         self.tear_down_collection_names.append(new_name)
         return res, check_result
 
     @trace()
-    def create_database(self, client, db_name, properties: dict | None = None, check_task=None, check_items=None, **kwargs):
+    def create_database(
+        self, client, db_name, properties: dict | None = None, check_task=None, check_items=None, **kwargs
+    ):
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.create_database, db_name, properties], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       db_name=db_name, properties=properties,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, db_name=db_name, properties=properties, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
-    def create_partition(self, client, collection_name, partition_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def create_partition(
+        self, client, collection_name, partition_name, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.create_partition, collection_name, partition_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       partition_name=partition_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            partition_name=partition_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
@@ -480,52 +651,72 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.list_partitions, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
-    def drop_partition(self, client, collection_name, partition_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def drop_partition(
+        self, client, collection_name, partition_name, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.drop_partition, collection_name, partition_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       partition_name=partition_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            partition_name=partition_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def has_partition(self, client, collection_name, partition_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def has_partition(
+        self, client, collection_name, partition_name, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.has_partition, collection_name, partition_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       partition_name=partition_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            partition_name=partition_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def get_partition_stats(self, client, collection_name, partition_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def get_partition_stats(
+        self, client, collection_name, partition_name, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.get_partition_stats, collection_name, partition_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       partition_name=partition_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            partition_name=partition_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
@@ -533,51 +724,70 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.prepare_index_params], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
-    def create_index(self, client, collection_name, index_params, timeout=None, check_task=None, check_items=None, **kwargs):
+    def create_index(
+        self, client, collection_name, index_params, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.create_index, collection_name, index_params], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       index_params=index_params,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            index_params=index_params,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def drop_index(self, client, collection_name, index_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def drop_index(
+        self, client, collection_name, index_name, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.drop_index, collection_name, index_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       index_name=index_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            index_name=index_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def describe_index(self, client, collection_name, index_name, timeout=None, check_task=None, check_items=None, **kwargs):
+    def describe_index(
+        self, client, collection_name, index_name, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.describe_index, collection_name, index_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       index_name=index_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            index_name=index_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     def wait_for_index_ready(self, client, collection_name, index_name, timeout=None, **kwargs):
@@ -607,11 +817,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.create_alias, collection_name, alias], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       alias=alias,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, alias=alias, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -621,10 +829,7 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.drop_alias, alias], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       alias=alias,
-                                       **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, alias=alias, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -634,11 +839,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.alter_alias, collection_name, alias], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       collection_name=collection_name,
-                                       alias=alias,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, alias=alias, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -648,10 +851,7 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.describe_alias, alias], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check,
-                                       alias=alias,
-                                       **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, alias=alias, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -661,9 +861,9 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.list_aliases, collection_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check, collection_name=collection_name,
-                                       **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, collection_name=collection_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -705,22 +905,42 @@ class TestMilvusClientV2Base(Base):
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.drop_user, user_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check, user_name=user_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, user_name=user_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
-    def update_password(self, client, user_name, old_password, new_password, reset_connection=False,
-                        timeout=None, check_task=None, check_items=None, **kwargs):
+    def update_password(
+        self,
+        client,
+        user_name,
+        old_password,
+        new_password,
+        reset_connection=False,
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.update_password, user_name, old_password, new_password,
-                                  reset_connection], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check, user_name=user_name, old_password=old_password,
-                                       new_password=new_password, reset_connection=reset_connection,
-                                       **kwargs).run()
+        res, check = api_request(
+            [client.update_password, user_name, old_password, new_password, reset_connection], **kwargs
+        )
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            user_name=user_name,
+            old_password=old_password,
+            new_password=new_password,
+            reset_connection=reset_connection,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
@@ -729,8 +949,7 @@ class TestMilvusClientV2Base(Base):
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.list_users], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check, **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -739,8 +958,9 @@ class TestMilvusClientV2Base(Base):
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.describe_user, user_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check, user_name=user_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, user_name=user_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -763,8 +983,9 @@ class TestMilvusClientV2Base(Base):
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.drop_role, role_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check, role_name=role_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, role_name=role_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -773,8 +994,9 @@ class TestMilvusClientV2Base(Base):
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.describe_role, role_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check, role_name=role_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, role_name=role_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -783,8 +1005,7 @@ class TestMilvusClientV2Base(Base):
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.list_roles], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task,
-                                       check_items, check, **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -793,8 +1014,9 @@ class TestMilvusClientV2Base(Base):
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.grant_role, user_name, role_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       user_name=user_name, role_name=role_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, user_name=user_name, role_name=role_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -803,56 +1025,107 @@ class TestMilvusClientV2Base(Base):
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.revoke_role, user_name, role_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       user_name=user_name, role_name=role_name, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, user_name=user_name, role_name=role_name, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
-    def grant_privilege(self, client, role_name, object_type, privilege, object_name, db_name="",
-                        timeout=None, check_task=None, check_items=None, **kwargs):
+    def grant_privilege(
+        self,
+        client,
+        role_name,
+        object_type,
+        privilege,
+        object_name,
+        db_name="",
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.grant_privilege, role_name, object_type, privilege,
-                                  object_name, db_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       role_name=role_name, object_type=object_type, privilege=privilege,
-                                       object_name=object_name, db_name=db_name, **kwargs).run()
+        res, check = api_request(
+            [client.grant_privilege, role_name, object_type, privilege, object_name, db_name], **kwargs
+        )
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            role_name=role_name,
+            object_type=object_type,
+            privilege=privilege,
+            object_name=object_name,
+            db_name=db_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def revoke_privilege(self, client, role_name, object_type, privilege, object_name, db_name="",
-                         timeout=None, check_task=None, check_items=None, **kwargs):
+    def revoke_privilege(
+        self,
+        client,
+        role_name,
+        object_type,
+        privilege,
+        object_name,
+        db_name="",
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.revoke_privilege, role_name, object_type, privilege,
-                                  object_name, db_name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       role_name=role_name, object_type=object_type, privilege=privilege,
-                                       object_name=object_name, db_name=db_name, **kwargs).run()
+        res, check = api_request(
+            [client.revoke_privilege, role_name, object_type, privilege, object_name, db_name], **kwargs
+        )
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            role_name=role_name,
+            object_type=object_type,
+            privilege=privilege,
+            object_name=object_name,
+            db_name=db_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def create_privilege_group(self, client, privilege_group: str, timeout=None, check_task=None, check_items=None, **kwargs):
+    def create_privilege_group(
+        self, client, privilege_group: str, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.create_privilege_group, privilege_group], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       privilege_group=privilege_group, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, privilege_group=privilege_group, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
-    def drop_privilege_group(self, client, privilege_group: str, timeout=None, check_task=None, check_items=None, **kwargs):
+    def drop_privilege_group(
+        self, client, privilege_group: str, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.drop_privilege_group, privilege_group], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       privilege_group=privilege_group, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, privilege_group=privilege_group, **kwargs
+        ).run()
         return res, check_result
 
     @trace()
@@ -866,119 +1139,191 @@ class TestMilvusClientV2Base(Base):
         return res, check_result
 
     @trace()
-    def add_privileges_to_group(self, client, privilege_group: str, privileges: list, timeout=None,
-                                check_task=None, check_items=None, **kwargs):
+    def add_privileges_to_group(
+        self, client, privilege_group: str, privileges: list, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.add_privileges_to_group, privilege_group, privileges], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       privilege_group=privilege_group, privileges=privileges, **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            privilege_group=privilege_group,
+            privileges=privileges,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def remove_privileges_from_group(self, client, privilege_group: str, privileges: list, timeout=None,
-                                     check_task=None, check_items=None, **kwargs):
+    def remove_privileges_from_group(
+        self, client, privilege_group: str, privileges: list, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.remove_privileges_from_group, privilege_group, privileges],
-                                 **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       privilege_group=privilege_group, privileges=privileges, **kwargs).run()
+        res, check = api_request([client.remove_privileges_from_group, privilege_group, privileges], **kwargs)
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            privilege_group=privilege_group,
+            privileges=privileges,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def grant_privilege_v2(self, client, role_name: str, privilege: str, collection_name: str, db_name=None, timeout=None,
-                           check_task=None, check_items=None, **kwargs):
+    def grant_privilege_v2(
+        self,
+        client,
+        role_name: str,
+        privilege: str,
+        collection_name: str,
+        db_name=None,
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.grant_privilege_v2, role_name, privilege, collection_name, db_name],
-                                 **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       role_name=role_name, privilege=privilege,
-                                       collection_name=collection_name, db_name=db_name, **kwargs).run()
+        res, check = api_request([client.grant_privilege_v2, role_name, privilege, collection_name, db_name], **kwargs)
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            role_name=role_name,
+            privilege=privilege,
+            collection_name=collection_name,
+            db_name=db_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def revoke_privilege_v2(self, client, role_name: str, privilege: str, collection_name: str, db_name=None,
-                            timeout=None, check_task=None, check_items=None, **kwargs):
+    def revoke_privilege_v2(
+        self,
+        client,
+        role_name: str,
+        privilege: str,
+        collection_name: str,
+        db_name=None,
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.revoke_privilege_v2, role_name, privilege, collection_name, db_name],
-                                 **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       role_name=role_name, privilege=privilege,
-                                       collection_name=collection_name, db_name=db_name, **kwargs).run()
+        res, check = api_request([client.revoke_privilege_v2, role_name, privilege, collection_name, db_name], **kwargs)
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            role_name=role_name,
+            privilege=privilege,
+            collection_name=collection_name,
+            db_name=db_name,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def alter_index_properties(self, client, collection_name, index_name, properties, timeout=None,
-                               check_task=None, check_items=None, **kwargs):
+    def alter_index_properties(
+        self, client, collection_name, index_name, properties, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.alter_index_properties, collection_name, index_name, properties],
-                                 **kwargs)
+        res, check = api_request([client.alter_index_properties, collection_name, index_name, properties], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
-    def drop_index_properties(self, client, collection_name, index_name, property_keys, timeout=None,
-                               check_task=None, check_items=None, **kwargs):
+    def drop_index_properties(
+        self,
+        client,
+        collection_name,
+        index_name,
+        property_keys,
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.drop_index_properties, collection_name, index_name, property_keys],
-                                 **kwargs)
+        res, check = api_request([client.drop_index_properties, collection_name, index_name, property_keys], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
-    def alter_collection_properties(self, client, collection_name, properties, timeout=None,
-                                    check_task=None, check_items=None, **kwargs):
+    def alter_collection_properties(
+        self, client, collection_name, properties, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.alter_collection_properties, collection_name, properties],
-                                 **kwargs)
+        res, check = api_request([client.alter_collection_properties, collection_name, properties], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
-    def drop_collection_properties(self, client, collection_name, property_keys, timeout=None,
-                                    check_task=None, check_items=None, **kwargs):
+    def drop_collection_properties(
+        self, client, collection_name, property_keys, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.drop_collection_properties, collection_name, property_keys, timeout],
-                                 **kwargs)
+        res, check = api_request([client.drop_collection_properties, collection_name, property_keys, timeout], **kwargs)
         check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
-    def alter_collection_field(self, client, collection_name, field_name, field_params, timeout=None,
-                               check_task=None, check_items=None, **kwargs):
+    def alter_collection_field(
+        self,
+        client,
+        collection_name,
+        field_name,
+        field_params,
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.alter_collection_field, collection_name, field_name, field_params, timeout],
-                                 **kwargs)
+        res, check = api_request(
+            [client.alter_collection_field, collection_name, field_name, field_params, timeout], **kwargs
+        )
         check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
-    def alter_database_properties(self, client, db_name, properties, timeout=None,
-                                  check_task=None, check_items=None, **kwargs):
+    def alter_database_properties(
+        self, client, db_name, properties, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
@@ -988,8 +1333,9 @@ class TestMilvusClientV2Base(Base):
         return res, check_result
 
     @trace()
-    def drop_database_properties(self, client, db_name, property_keys, timeout=None,
-                                 check_task=None, check_items=None, **kwargs):
+    def drop_database_properties(
+        self, client, db_name, property_keys, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
@@ -1034,18 +1380,29 @@ class TestMilvusClientV2Base(Base):
         kwargs.update({"timeout": timeout})
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.run_analyzer, text, analyzer_params], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check, text=text,
-                                       analyzer_params=analyzer_params, **kwargs).run()
+        check_result = ResponseChecker(
+            res, func_name, check_task, check_items, check, text=text, analyzer_params=analyzer_params, **kwargs
+        ).run()
         return res, check_result
 
-    def compact(self, client, collection_name, is_clustering=False, timeout=None, check_task=None, check_items=None, **kwargs):
+    def compact(
+        self, client, collection_name, is_clustering=False, timeout=None, check_task=None, check_items=None, **kwargs
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.compact, collection_name, is_clustering], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       collection_name=collection_name, is_clustering=is_clustering, **kwargs).run()
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            collection_name=collection_name,
+            is_clustering=is_clustering,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
@@ -1065,8 +1422,7 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.create_resource_group, name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       name=name, **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, name=name, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -1076,8 +1432,7 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.update_resource_groups, configs], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       configs=configs, **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, configs=configs, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -1087,8 +1442,7 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.drop_resource_group, name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       name=name, **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, name=name, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -1098,8 +1452,7 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.describe_resource_group, name], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       name=name, **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, name=name, **kwargs).run()
         return res, check_result
 
     @trace()
@@ -1109,31 +1462,60 @@ class TestMilvusClientV2Base(Base):
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.list_resource_groups], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result
 
     @trace()
-    def transfer_replica(self, client, source_group, target_group, collection_name, num_replicas,
-                         timeout=None, check_task=None, check_items=None, **kwargs):
+    def transfer_replica(
+        self,
+        client,
+        source_group,
+        target_group,
+        collection_name,
+        num_replicas,
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
-        res, check = api_request([client.transfer_replica, source_group, target_group, collection_name, num_replicas], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       source_group=source_group, target_group=target_group,
-                                       collection_name=collection_name, num_replicas=num_replicas,
-                                       **kwargs).run()
+        res, check = api_request(
+            [client.transfer_replica, source_group, target_group, collection_name, num_replicas], **kwargs
+        )
+        check_result = ResponseChecker(
+            res,
+            func_name,
+            check_task,
+            check_items,
+            check,
+            source_group=source_group,
+            target_group=target_group,
+            collection_name=collection_name,
+            num_replicas=num_replicas,
+            **kwargs,
+        ).run()
         return res, check_result
 
     @trace()
-    def add_collection_field(self, client, collection_name, field_name, data_type, desc="", timeout=None, check_task=None, check_items=None, **kwargs):
+    def add_collection_field(
+        self,
+        client,
+        collection_name,
+        field_name,
+        data_type,
+        desc="",
+        timeout=None,
+        check_task=None,
+        check_items=None,
+        **kwargs,
+    ):
         timeout = TIMEOUT if timeout is None else timeout
         kwargs.update({"timeout": timeout})
 
         func_name = sys._getframe().f_code.co_name
         res, check = api_request([client.add_collection_field, collection_name, field_name, data_type, desc], **kwargs)
-        check_result = ResponseChecker(res, func_name, check_task, check_items, check,
-                                       **kwargs).run()
+        check_result = ResponseChecker(res, func_name, check_task, check_items, check, **kwargs).run()
         return res, check_result

--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -1689,17 +1689,120 @@ class PartialUpdateChecker(Checker):
     def __init__(self, collection_name=None, shards_num=2, schema=None):
         if collection_name is None:
             collection_name = cf.gen_unique_str("PartialUpdateChecker_")
-        super().__init__(
-            collection_name=collection_name, shards_num=shards_num, schema=schema, enable_struct_array_field=False
-        )
+        super().__init__(collection_name=collection_name, shards_num=shards_num, schema=schema)
         self.data = cf.gen_row_data_by_schema(nb=constants.DELTA_PER_INS, schema=self.get_schema())
 
+    @staticmethod
+    def _schema_to_dict(schema):
+        if isinstance(schema, dict):
+            return schema
+        return cf.convert_orm_schema_to_dict_schema(schema)
+
+    @staticmethod
+    def _is_struct_array_field(field):
+        return field.get("type") == DataType.ARRAY and field.get("element_type") == DataType.STRUCT
+
+    @classmethod
+    def _struct_array_field_names(cls, schema):
+        schema = cls._schema_to_dict(schema)
+        names = []
+        for struct_field in schema.get("struct_fields", []) or []:
+            name = struct_field.get("name") if isinstance(struct_field, dict) else struct_field.name
+            if name:
+                names.append(name)
+        for field in schema.get("fields", []) or []:
+            name = field.get("name")
+            if name and name not in names and cls._is_struct_array_field(field):
+                names.append(name)
+        return names
+
+    @classmethod
+    def _partial_update_field_names(cls, schema, pk_field_name):
+        schema = cls._schema_to_dict(schema)
+        struct_array_field_names = set(cls._struct_array_field_names(schema))
+        function_output_field_names = set()
+        for func in schema.get("functions", []) or []:
+            function_output_field_names.update(func.get("output_field_names", []) or [])
+
+        field_names = []
+        for field in schema.get("fields", []) or []:
+            name = field.get("name")
+            if not name:
+                continue
+            if name == pk_field_name or name in struct_array_field_names or name in function_output_field_names:
+                continue
+            if field.get("auto_id", False) or cls._is_struct_array_field(field):
+                continue
+            field_names.append(name)
+        return field_names
+
+    def _gen_struct_array_partial_rows(self, schema, rows):
+        struct_array_field_names = self._struct_array_field_names(schema)
+        if not struct_array_field_names:
+            return None, []
+
+        struct_array_field_name = struct_array_field_names[0]
+        full_rows = cf.gen_row_data_by_schema(nb=rows, schema=schema)
+        partial_rows = [
+            {self.int64_field_name: row[self.int64_field_name], struct_array_field_name: row[struct_array_field_name]}
+            for row in full_rows
+            if struct_array_field_name in row
+        ]
+        return struct_array_field_name, partial_rows
+
+    @staticmethod
+    def _values_equal(actual, expected):
+        if isinstance(expected, float):
+            return isinstance(actual, (float, int)) and math.isclose(
+                float(actual), expected, rel_tol=1e-5, abs_tol=1e-5
+            )
+        if isinstance(expected, list):
+            if not isinstance(actual, list) or len(actual) != len(expected):
+                return False
+            return all(PartialUpdateChecker._values_equal(a, e) for a, e in zip(actual, expected))
+        if isinstance(expected, dict):
+            if not isinstance(actual, dict) or set(actual.keys()) != set(expected.keys()):
+                return False
+            return all(PartialUpdateChecker._values_equal(actual[key], expected[key]) for key in expected)
+        return actual == expected
+
+    def _verify_struct_array_partial_update(self, struct_array_field_name, expected_rows):
+        if not expected_rows:
+            return "no struct array rows to verify", False
+
+        expected_by_pk = {row[self.int64_field_name]: row[struct_array_field_name] for row in expected_rows}
+        pks = list(expected_by_pk)
+        res = self.milvus_client.query(
+            collection_name=self.c_name,
+            filter=f"{self.int64_field_name} in {pks}",
+            output_fields=[self.int64_field_name, struct_array_field_name],
+            limit=len(pks),
+            timeout=query_timeout,
+        )
+        actual_by_pk = {row[self.int64_field_name]: row.get(struct_array_field_name) for row in res}
+        if set(actual_by_pk) != set(expected_by_pk):
+            return f"struct array partial update query mismatch, expected pks {pks}, got {list(actual_by_pk)}", False
+
+        for pk, expected_value in expected_by_pk.items():
+            actual_value = actual_by_pk[pk]
+            if not self._values_equal(actual_value, expected_value):
+                return (
+                    f"struct array partial update mismatch for pk {pk}, expected {expected_value}, got {actual_value}"
+                ), False
+        return res, True
+
     @trace()
-    def partial_update_entities(self):
+    def partial_update_entities(self, verify_struct_array_field_name=None, expected_struct_array_rows=None):
         try:
             res = self.milvus_client.upsert(
                 collection_name=self.c_name, data=self.data, partial_update=True, timeout=timeout
             )
+            if verify_struct_array_field_name is not None:
+                verify_res, verify_result = self._verify_struct_array_partial_update(
+                    verify_struct_array_field_name, expected_struct_array_rows
+                )
+                if not verify_result:
+                    return verify_res, False
             return res, True
         except SchemaMismatchRetryableException:
             # Schema changed concurrently (AddVectorFieldChecker). Invalidate the SDK schema cache
@@ -1713,6 +1816,12 @@ class PartialUpdateChecker(Checker):
                 res = self.milvus_client.upsert(
                     collection_name=self.c_name, data=self.data, partial_update=True, timeout=timeout
                 )
+                if verify_struct_array_field_name is not None:
+                    verify_res, verify_result = self._verify_struct_array_partial_update(
+                        verify_struct_array_field_name, expected_struct_array_rows
+                    )
+                    if not verify_result:
+                        return verify_res, False
                 return res, True
             except Exception as e:
                 log.info(f"partial update failed (retry): {e}")
@@ -1727,20 +1836,32 @@ class PartialUpdateChecker(Checker):
         schema = self.get_schema()
         pk_field_name = self.int64_field_name
         rows = len(self.data)
+        verify_struct_array_field_name = None
+        expected_struct_array_rows = None
 
-        # if count is even, use partial update; if count is odd, use full insert
+        # Alternate full upsert, StructArray partial update, and ordinary field partial update.
         if count % 2 == 0:
             # Generate a fresh full batch (used for inserts and as a source of values)
             full_rows = cf.gen_row_data_by_schema(nb=rows, schema=schema)
             self.data = full_rows
+        elif count % 4 == 1 and self._struct_array_field_names(schema):
+            struct_array_field_name, partial_rows = self._gen_struct_array_partial_rows(schema, rows)
+            if not partial_rows:
+                return f"failed to generate partial update rows for struct array field {struct_array_field_name}", False
+            self.data = partial_rows
+            verify_struct_array_field_name = struct_array_field_name
+            expected_struct_array_rows = partial_rows[: min(10, len(partial_rows))]
         else:
-            num_fields = len(schema["fields"])
+            candidate_fields = self._partial_update_field_names(schema, pk_field_name)
+            if not candidate_fields:
+                self.data = cf.gen_row_data_by_schema(nb=rows, schema=schema)
+                res, result = self.partial_update_entities()
+                return res, result
             # Choose subset fields to update: always include PK + one non-PK field if available
-            num = count % num_fields
-            desired_fields = [pk_field_name, schema["fields"][num if num != 0 else 1]["name"]]
+            desired_fields = [pk_field_name, candidate_fields[count % len(candidate_fields)]]
             partial_rows = cf.gen_row_data_by_schema(nb=rows, schema=schema, desired_field_names=desired_fields)
             self.data = partial_rows
-        res, result = self.partial_update_entities()
+        res, result = self.partial_update_entities(verify_struct_array_field_name, expected_struct_array_rows)
         return res, result
 
     def keep_running(self):

--- a/tests/python_client/milvus_client/test_milvus_client_partial_update.py
+++ b/tests/python_client/milvus_client/test_milvus_client_partial_update.py
@@ -1,11 +1,15 @@
 # ruff: noqa: F403, F405
+import random
+
 import numpy as np
 import pytest
 from base.client_v2_base import TestMilvusClientV2Base
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
-from pymilvus import Function, FunctionType
+from pymilvus import DataType, Function, FunctionType
+from pymilvus.client.embedding_list import EmbeddingList
+from sklearn import preprocessing
 from utils.util_log import test_log as log
 from utils.util_pymilvus import *
 
@@ -209,6 +213,160 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
             assert len(result) == default_nb
 
         self.drop_collection(client, collection_name)
+
+    @staticmethod
+    def _make_struct_array_partial_update_vector(seed, dim):
+        return [float((seed + offset) % 97) / 97.0 for offset in range(dim)]
+
+    @classmethod
+    def _make_struct_array_partial_update_events(cls, row_id, state, dim):
+        offset = 100000 if state == "updated" else 0
+        return [
+            {
+                "embedding": cls._make_struct_array_partial_update_vector(row_id * 17 + elem_idx + offset, dim),
+                "score": row_id * 10 + elem_idx + offset,
+                "tag": f"{state}_{row_id}_{elem_idx}",
+            }
+            for elem_idx in range(2)
+        ]
+
+    @classmethod
+    def _make_struct_array_partial_update_rows(cls, start, count, dim):
+        return [
+            {
+                "id": row_id,
+                "vector": cls._make_struct_array_partial_update_vector(row_id, dim),
+                "payload": f"payload_{row_id}",
+                "events": cls._make_struct_array_partial_update_events(row_id, "initial", dim),
+            }
+            for row_id in range(start, start + count)
+        ]
+
+    @staticmethod
+    def _assert_struct_array_partial_update_events_equal(actual, expected):
+        assert len(actual) == len(expected)
+        for actual_event, expected_event in zip(actual, expected):
+            assert actual_event["score"] == expected_event["score"]
+            assert actual_event["tag"] == expected_event["tag"]
+            assert np.allclose(actual_event["embedding"], expected_event["embedding"])
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("embedding_index_type", ["HNSW", "DISKANN"])
+    def test_milvus_client_partial_update_struct_array_sealed_growing(self, embedding_index_type):
+        """
+        target: test partial update with a StructArray field
+        method:
+            1. create collection with a StructArray field that has scalar and vector sub-fields
+            2. create HNSW or DISKANN index for the StructArray embedding-list field
+            3. insert more than 3000 rows, flush the first part and keep the second part growing
+            4. partial update only the StructArray field for all rows
+            5. query and search sealed and growing sample rows
+        expected: StructArray values are updated, searchable, and omitted fields are preserved
+        """
+        client = self._client()
+        dim = default_dim
+        sealed_nb = default_nb
+        total_nb = default_nb_medium
+        growing_nb = total_nb - sealed_nb
+        collection_name = cf.gen_unique_str(f"{prefix}_pu_struct_{embedding_index_type.lower()}")
+        embedding_metric_type = "MAX_SIM_COSINE"
+        embedding_index_configs = {
+            "HNSW": {
+                "build_params": {"M": 16, "efConstruction": 96},
+                "search_params": {"ef": 64, "retrieval_ann_ratio": 3.0, "emb_list_rerank": True},
+            },
+            "DISKANN": {
+                "build_params": {},
+                "search_params": {"search_list": 30, "retrieval_ann_ratio": 3.0, "emb_list_rerank": True},
+            },
+        }
+        embedding_index_config = embedding_index_configs[embedding_index_type]
+
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field("payload", DataType.VARCHAR, max_length=128)
+
+        struct_schema = self.create_struct_field_schema(client)[0]
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=dim)
+        struct_schema.add_field("score", DataType.INT64)
+        struct_schema.add_field("tag", DataType.VARCHAR, max_length=128)
+        schema.add_field(
+            "events",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=4,
+        )
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name="vector", index_type="AUTOINDEX", metric_type="L2")
+        index_params.add_index(
+            field_name="events[embedding]",
+            index_type=embedding_index_type,
+            metric_type=embedding_metric_type,
+            params=embedding_index_config["build_params"],
+        )
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            consistency_level="Strong",
+            index_params=index_params,
+        )
+
+        self.insert(client, collection_name, self._make_struct_array_partial_update_rows(0, sealed_nb, dim))
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        self.insert(client, collection_name, self._make_struct_array_partial_update_rows(sealed_nb, growing_nb, dim))
+
+        partial_rows = [
+            {
+                "id": row_id,
+                "events": self._make_struct_array_partial_update_events(row_id, "updated", dim),
+            }
+            for row_id in range(total_nb)
+        ]
+        self.upsert(client, collection_name, partial_rows, partial_update=True)
+
+        sample_ids = [0, sealed_nb - 1, sealed_nb, total_nb - 1]
+        results = self.query(
+            client,
+            collection_name,
+            filter=f"id in {sample_ids}",
+            output_fields=["id", "payload", "events"],
+            limit=len(sample_ids),
+        )[0]
+        result_by_id = {row["id"]: row for row in results}
+        assert sorted(result_by_id) == sample_ids
+        for row_id in sample_ids:
+            assert result_by_id[row_id]["payload"] == f"payload_{row_id}"
+            self._assert_struct_array_partial_update_events_equal(
+                result_by_id[row_id]["events"],
+                self._make_struct_array_partial_update_events(row_id, "updated", dim),
+            )
+
+        for row_id in [sample_ids[0], sample_ids[-1]]:
+            expected_events = self._make_struct_array_partial_update_events(row_id, "updated", dim)
+            search_results = self.search(
+                client,
+                collection_name,
+                data=[EmbeddingList([event["embedding"] for event in expected_events])],
+                anns_field="events[embedding]",
+                search_params={
+                    "metric_type": embedding_metric_type,
+                    "params": embedding_index_config["search_params"],
+                },
+                filter=f"id == {row_id}",
+                output_fields=["id", "payload", "events"],
+                limit=1,
+            )[0]
+            assert len(search_results) == 1
+            assert len(search_results[0]) == 1
+            assert search_results[0][0]["id"] == row_id
+            assert search_results[0][0]["payload"] == f"payload_{row_id}"
+            self._assert_struct_array_partial_update_events_equal(search_results[0][0]["events"], expected_events)
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_partial_update_all_field_types_one_by_one(self):

--- a/tests/python_client/milvus_client/test_milvus_client_partial_update.py
+++ b/tests/python_client/milvus_client/test_milvus_client_partial_update.py
@@ -1595,15 +1595,21 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         collection_name = cf.gen_collection_name_by_testcase_name(module_index=1)
-        self.create_collection(client, collection_name, default_dim, schema=schema,
-                               consistency_level="Strong", index_params=index_params)
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
 
         # step 2: insert full rows, then partial upsert dynamic field `end_timestamp`
         nb = 100
         vectors = cf.gen_vectors(nb, default_dim)
-        rows = [{default_primary_key_field_name: i,
-                 default_vector_field_name: vectors[i],
-                 default_string_field_name: f"row_{i}"} for i in range(nb)]
+        rows = [
+            {
+                default_primary_key_field_name: i,
+                default_vector_field_name: vectors[i],
+                default_string_field_name: f"row_{i}",
+            }
+            for i in range(nb)
+        ]
         self.insert(client, collection_name, rows)
         self.flush(client, collection_name)
 
@@ -1612,14 +1618,16 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
         self.flush(client, collection_name)
 
         # verify dynamic field was written
-        res = self.query(client, collection_name, filter="id < 5",
-                         output_fields=[default_primary_key_field_name, "end_timestamp"])[0]
+        res = self.query(
+            client, collection_name, filter="id < 5", output_fields=[default_primary_key_field_name, "end_timestamp"]
+        )[0]
         for r in res:
             assert "end_timestamp" in r, f"end_timestamp should exist as dynamic field, got {r}"
 
         # step 3: add `end_timestamp` as a static column (schema evolution)
-        self.add_collection_field(client, collection_name, field_name="end_timestamp",
-                                  data_type=DataType.INT64, nullable=True)
+        self.add_collection_field(
+            client, collection_name, field_name="end_timestamp", data_type=DataType.INT64, nullable=True
+        )
         self.release_collection(client, collection_name)
         self.load_collection(client, collection_name)
 
@@ -1630,12 +1638,14 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
         self.flush(client, collection_name)
 
         # step 5: verify the static field has the new value
-        res = self.query(client, collection_name, filter="id < 5",
-                         output_fields=[default_primary_key_field_name, "end_timestamp"])[0]
+        res = self.query(
+            client, collection_name, filter="id < 5", output_fields=[default_primary_key_field_name, "end_timestamp"]
+        )[0]
         for r in res:
             pk = r[default_primary_key_field_name]
-            assert r["end_timestamp"] == new_ts + pk, \
+            assert r["end_timestamp"] == new_ts + pk, (
                 f"end_timestamp mismatch for pk={pk}: expected {new_ts + pk}, got {r['end_timestamp']}"
+            )
 
         self.drop_collection(client, collection_name)
 

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -65,14 +65,16 @@ EMB_LIST_INDEX_TYPES = list(EMB_LIST_INDEX_CONFIGS.keys())
 
 # Supported vector types per emb list index type (for MaxSim metrics)
 EMB_LIST_VECTOR_TYPES = {
-    "HNSW": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
-             DataType.INT8_VECTOR, DataType.BINARY_VECTOR],
-    "HNSW_SQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
-                DataType.INT8_VECTOR],
-    "HNSW_PQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
-                DataType.INT8_VECTOR],
-    "HNSW_PRQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
-                 DataType.INT8_VECTOR],
+    "HNSW": [
+        DataType.FLOAT_VECTOR,
+        DataType.FLOAT16_VECTOR,
+        DataType.BFLOAT16_VECTOR,
+        DataType.INT8_VECTOR,
+        DataType.BINARY_VECTOR,
+    ],
+    "HNSW_SQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR],
+    "HNSW_PQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR],
+    "HNSW_PRQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR],
     "IVF_FLAT": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
     "IVF_FLAT_CC": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
     "DISKANN": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
@@ -1557,9 +1559,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         # Create schema
         schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
         schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
-        schema.add_field(
-            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=dim
-        )
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=dim)
 
         # Create struct schema
         struct_schema = client.create_struct_field_schema()
@@ -2360,9 +2360,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         method: insert (flushed + growing) → index → load → search → upsert → delete → search → verify
         expected: all CRUD operations and search work correctly for each index type
         """
-        collection_name = cf.gen_unique_str(
-            f"{prefix}_search_{index_type.lower()}"
-        )
+        collection_name = cf.gen_unique_str(f"{prefix}_search_{index_type.lower()}")
         client = self._client()
 
         config = EMB_LIST_INDEX_CONFIGS[index_type]
@@ -2370,9 +2368,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         # Create collection with full schema
         schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
         schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
-        schema.add_field(
-            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM
-        )
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM)
 
         struct_schema = client.create_struct_field_schema()
         struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM)
@@ -2523,7 +2519,9 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         assert check
 
         results, check = self.query(
-            client, collection_name, filter="id < 10",
+            client,
+            collection_name,
+            filter="id < 10",
             output_fields=["id", "category", "clips"],
         )
         assert check
@@ -2541,9 +2539,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         res, check = self.flush(client, collection_name)
         assert check
 
-        results, check = self.query(
-            client, collection_name, filter="id >= 0", output_fields=["id"]
-        )
+        results, check = self.query(client, collection_name, filter="id >= 0", output_fields=["id"])
         assert check
         remaining_ids = {r["id"] for r in results}
         for del_id in delete_ids:
@@ -2571,8 +2567,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize(
         "vector_type",
-        [DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR,
-         DataType.BINARY_VECTOR],
+        [DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR, DataType.BINARY_VECTOR],
     )
     def test_search_emb_list_with_different_vector_types(self, vector_type):
         """
@@ -2593,9 +2588,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         # Create schema with specified vector type
         schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
         schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
-        schema.add_field(
-            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM
-        )
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM)
 
         struct_schema = client.create_struct_field_schema()
         struct_schema.add_field("clip_embedding1", vector_type, dim=EMB_LIST_DIM)
@@ -2707,9 +2700,7 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
                 [np.frombuffer(v, dtype=np.uint8) if isinstance(v, bytes) else v for v in search_vecs]
             )
         else:
-            embedding_list = EmbeddingList(
-                [np.array(v) if not isinstance(v, np.ndarray) else v for v in search_vecs]
-            )
+            embedding_list = EmbeddingList([np.array(v) if not isinstance(v, np.ndarray) else v for v in search_vecs])
 
         results, check = self.search(
             client,
@@ -2752,7 +2743,9 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         assert check
 
         results, check = self.query(
-            client, collection_name, filter="id < 10",
+            client,
+            collection_name,
+            filter="id < 10",
             output_fields=["id", "category", "clips"],
         )
         assert check
@@ -2765,18 +2758,14 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         delete_flushed_ids = [10, 11, 12, 13, 14]
         delete_growing_ids = list(range(nb_flushed, nb_flushed + 3))
         all_delete_ids = delete_flushed_ids + delete_growing_ids
-        res, check = self.delete(
-            client, collection_name, filter=f"id in {all_delete_ids}"
-        )
+        res, check = self.delete(client, collection_name, filter=f"id in {all_delete_ids}")
         assert check
 
         # Verify deletion
         res, check = self.flush(client, collection_name)
         assert check
 
-        results, check = self.query(
-            client, collection_name, filter="id >= 0", output_fields=["id"]
-        )
+        results, check = self.query(client, collection_name, filter="id >= 0", output_fields=["id"])
         assert check
         remaining_ids = {r["id"] for r in results}
         for del_id in all_delete_ids:
@@ -5435,9 +5424,7 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
                 struct_array.append(
                     {
                         "struct_int": item["struct_int"],
-                        "struct_vec": self.struct_vector_value_for_bulk_writer(
-                            vector_type, item["struct_int"], dim
-                        ),
+                        "struct_vec": self.struct_vector_value_for_bulk_writer(vector_type, item["struct_int"], dim),
                     }
                 )
             rows.append(

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F403, F405
+import csv
 import json
 import os
 import random
@@ -84,6 +85,25 @@ EMB_LIST_DIM = 32
 BINARY_METRIC = "MAX_SIM_HAMMING"
 FLOAT_METRIC = "MAX_SIM_COSINE"
 INT8_METRIC = "MAX_SIM_COSINE"
+STRUCT_ARRAY_IMPORT_VECTOR_TYPES = [
+    pytest.param(DataType.FLOAT_VECTOR, id="float_vector"),
+    pytest.param(DataType.FLOAT16_VECTOR, id="float16_vector"),
+    pytest.param(DataType.BFLOAT16_VECTOR, id="bfloat16_vector"),
+    pytest.param(DataType.INT8_VECTOR, id="int8_vector"),
+    pytest.param(DataType.BINARY_VECTOR, id="binary_vector"),
+]
+STRUCT_ARRAY_IMPORT_FILE_TYPES = [
+    pytest.param("JSON", id="json"),
+    pytest.param("JSONL", id="jsonl"),
+    pytest.param("CSV", id="csv"),
+    pytest.param("PARQUET", id="parquet"),
+]
+STRUCT_ARRAY_BULK_WRITER_FILE_TYPES = [
+    pytest.param(BulkFileType.JSON, id="bulk_writer_json"),
+    pytest.param(BulkFileType.JSONL, id="bulk_writer_jsonl"),
+    pytest.param(BulkFileType.CSV, id="bulk_writer_csv"),
+    pytest.param(BulkFileType.PARQUET, id="bulk_writer_parquet"),
+]
 
 
 class TestMilvusClientStructArrayBasic(TestMilvusClientV2Base):
@@ -4502,7 +4522,7 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
         self.minio_endpoint = f"{minio_host}:9000"
 
     def gen_file_with_local_bulk_writer(
-        self, schema, data: list[dict[str, Any]], file_type: str = "PARQUET"
+        self, schema, data: list[dict[str, Any]], file_type: str | BulkFileType = "PARQUET"
     ) -> tuple[list[list[str]], dict]:
         """
         Generate import files using LocalBulkWriter from insert-format data
@@ -4515,8 +4535,12 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
         Returns:
             Tuple of (LocalBulkWriter batch files, original data dict for verification)
         """
-        # Convert file_type string to BulkFileType enum
-        bulk_file_type = BulkFileType.PARQUET if file_type == "PARQUET" else BulkFileType.JSON
+        if isinstance(file_type, BulkFileType):
+            bulk_file_type = file_type
+            file_type_name = file_type.name
+        else:
+            bulk_file_type = BulkFileType[file_type]
+            file_type_name = file_type
 
         # Create LocalBulkWriter
         writer = LocalBulkWriter(
@@ -4526,7 +4550,7 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
             file_type=bulk_file_type,
         )
 
-        log.info(f"Creating {file_type} file using LocalBulkWriter with {len(data)} rows")
+        log.info(f"Creating {file_type_name} file using LocalBulkWriter with {len(data)} rows")
 
         # Append each row using the same format as insert
         for row in data:
@@ -5166,6 +5190,382 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
         log.info(f"Generated comprehensive JSON file with {num_rows} rows: {file_path}")
 
         return {"id": id_arr, "float_vector": float_vector_arr, "struct_array": struct_arr}
+
+    def gen_csv_file(self, num_rows: int, dim: int, file_path: str) -> dict:
+        """Generate CSV data with the StructArray column encoded as JSON."""
+        id_arr = []
+        float_vector_arr = []
+        struct_arr = []
+
+        with open(file_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["id", "float_vector", "struct_array"])
+            writer.writeheader()
+            for i in range(num_rows):
+                rng = random.Random(i)
+                id_arr.append(i)
+                float_vector = [rng.random() for _ in range(dim)]
+                float_vector_arr.append(float_vector)
+
+                struct_list = []
+                for j in range(rng.randint(1, 5)):
+                    struct_list.append(
+                        {
+                            "struct_varchar": f"varchar_{i}_{j}",
+                            "struct_int8": rng.randint(-128, 127),
+                            "struct_int16": rng.randint(-32768, 32767),
+                            "struct_int32": rng.randint(-2147483648, 2147483647),
+                            "struct_int64": rng.randint(-9223372036854775808, 9223372036854775807),
+                            "struct_float": rng.random() * 100,
+                            "struct_double": rng.random() * 1000,
+                            "struct_bool": rng.choice([True, False]),
+                            "struct_float_vec": [rng.random() for _ in range(dim)],
+                        }
+                    )
+                struct_arr.append(struct_list)
+                writer.writerow(
+                    {
+                        "id": i,
+                        "float_vector": json.dumps(float_vector),
+                        "struct_array": json.dumps(struct_list),
+                    }
+                )
+
+        log.info(f"Generated comprehensive CSV file with {num_rows} rows: {file_path}")
+        return {"id": id_arr, "float_vector": float_vector_arr, "struct_array": struct_arr}
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("dim", [128])
+    @pytest.mark.parametrize("entities", [200])
+    @pytest.mark.parametrize("array_capacity", [100])
+    def test_import_struct_array_with_csv(self, dim, entities, array_capacity):
+        """Test bulk import of a StructArray column from CSV."""
+        client = self._client()
+        c_name = cf.gen_unique_str("import_struct_array_csv")
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="float_vector", datatype=DataType.FLOAT_VECTOR, dim=dim)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("struct_varchar", DataType.VARCHAR, max_length=65535)
+        struct_schema.add_field("struct_int8", DataType.INT8)
+        struct_schema.add_field("struct_int16", DataType.INT16)
+        struct_schema.add_field("struct_int32", DataType.INT32)
+        struct_schema.add_field("struct_int64", DataType.INT64)
+        struct_schema.add_field("struct_float", DataType.FLOAT)
+        struct_schema.add_field("struct_double", DataType.DOUBLE)
+        struct_schema.add_field("struct_bool", DataType.BOOL)
+        struct_schema.add_field("struct_float_vec", DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field(
+            "struct_array",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=array_capacity,
+        )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="float_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params={"M": 16, "efConstruction": 200},
+        )
+        index_params.add_index(
+            field_name="struct_array[struct_float_vec]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params={"M": 16, "efConstruction": 200},
+        )
+        client.create_collection(collection_name=c_name, schema=schema, index_params=index_params)
+
+        local_file_path = os.path.join(self.LOCAL_FILES_PATH, f"test_{cf.gen_unique_str()}.csv")
+        original_data = self.gen_csv_file(entities, dim, local_file_path)
+        remote_files = self.upload_to_minio(local_file_path)
+        self.call_bulkinsert(c_name, remote_files)
+
+        client.refresh_load(collection_name=c_name)
+        stats = client.get_collection_stats(collection_name=c_name)
+        assert stats["row_count"] == entities
+        self.verify_data(client, c_name, original_data)
+
+    def create_vector_import_collection(
+        self, client, c_name: str, vector_type: DataType, dim: int, array_capacity: int
+    ):
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="float_vector", datatype=DataType.FLOAT_VECTOR, dim=dim)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("struct_int", DataType.INT64)
+        struct_schema.add_field("struct_vec", vector_type, dim=dim)
+        schema.add_field(
+            "struct_array",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=array_capacity,
+        )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="float_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params={"M": 16, "efConstruction": 200},
+        )
+        index_params.add_index(
+            field_name="struct_array[struct_vec]",
+            index_type="HNSW",
+            metric_type=self.struct_vector_metric(vector_type),
+            params={"M": 16, "efConstruction": 200},
+        )
+        client.create_collection(collection_name=c_name, schema=schema, index_params=index_params)
+        return schema
+
+    @staticmethod
+    def struct_vector_metric(vector_type: DataType) -> str:
+        return "MAX_SIM_HAMMING" if vector_type == DataType.BINARY_VECTOR else "MAX_SIM_COSINE"
+
+    @staticmethod
+    def struct_vector_arrow_type(vector_type: DataType):
+        if vector_type == DataType.FLOAT_VECTOR:
+            return pa.list_(pa.float32())
+        if vector_type in [DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.BINARY_VECTOR]:
+            return pa.list_(pa.uint8())
+        if vector_type == DataType.INT8_VECTOR:
+            return pa.list_(pa.int8())
+        raise ValueError(f"unsupported struct vector type: {vector_type}")
+
+    @staticmethod
+    def vector_type_name(vector_type: DataType) -> str:
+        return vector_type.name.lower()
+
+    @staticmethod
+    def float_values(seed: int, dim: int) -> list[float]:
+        return [float(((seed + i) % 97) + 1) / 97 for i in range(dim)]
+
+    @staticmethod
+    def binary_bytes(seed: int, dim: int) -> list[int]:
+        return [((seed + i) % 256) for i in range(dim // 8)]
+
+    @staticmethod
+    def binary_bits(seed: int, dim: int) -> list[int]:
+        return [((seed + i) % 2) for i in range(dim)]
+
+    @staticmethod
+    def int8_values(seed: int, dim: int) -> list[int]:
+        return [((seed + i) % 255) - 128 for i in range(dim)]
+
+    @classmethod
+    def struct_vector_value_for_import(cls, vector_type: DataType, seed: int, dim: int, file_type: str):
+        if vector_type == DataType.FLOAT_VECTOR:
+            return cls.float_values(seed, dim)
+        if vector_type == DataType.FLOAT16_VECTOR:
+            values = cls.float_values(seed, dim)
+            if file_type == "PARQUET":
+                return list(np.array(values, dtype=np.float16).tobytes())
+            return values
+        if vector_type == DataType.BFLOAT16_VECTOR:
+            values = cls.float_values(seed, dim)
+            if file_type == "PARQUET":
+                return list(np.array(values, dtype=cf.bfloat16).tobytes())
+            return values
+        if vector_type == DataType.INT8_VECTOR:
+            return cls.int8_values(seed, dim)
+        if vector_type == DataType.BINARY_VECTOR:
+            return cls.binary_bytes(seed, dim)
+        raise ValueError(f"unsupported struct vector type: {vector_type}")
+
+    @classmethod
+    def struct_vector_value_for_bulk_writer(cls, vector_type: DataType, seed: int, dim: int):
+        if vector_type == DataType.FLOAT_VECTOR:
+            return cls.float_values(seed, dim)
+        if vector_type == DataType.FLOAT16_VECTOR:
+            return np.array(cls.float_values(seed, dim), dtype=np.float16)
+        if vector_type == DataType.BFLOAT16_VECTOR:
+            return np.array(cls.float_values(seed, dim), dtype=cf.bfloat16)
+        if vector_type == DataType.INT8_VECTOR:
+            return np.array(cls.int8_values(seed, dim), dtype=np.int8)
+        if vector_type == DataType.BINARY_VECTOR:
+            return cls.binary_bits(seed, dim)
+        raise ValueError(f"unsupported struct vector type: {vector_type}")
+
+    @classmethod
+    def struct_search_vector(cls, vector_type: DataType, seed: int, dim: int):
+        if vector_type == DataType.FLOAT_VECTOR:
+            return EmbeddingList([np.array(cls.float_values(seed, dim), dtype=np.float32)])
+        if vector_type == DataType.FLOAT16_VECTOR:
+            return EmbeddingList([np.array(cls.float_values(seed, dim), dtype=np.float16)])
+        if vector_type == DataType.BFLOAT16_VECTOR:
+            return EmbeddingList([np.array(cls.float_values(seed, dim), dtype=cf.bfloat16)])
+        if vector_type == DataType.INT8_VECTOR:
+            return EmbeddingList([np.array(cls.int8_values(seed, dim), dtype=np.int8)])
+        if vector_type == DataType.BINARY_VECTOR:
+            return EmbeddingList([np.frombuffer(bytes(cls.binary_bytes(seed, dim)), dtype=np.uint8)])
+        raise ValueError(f"unsupported struct vector type: {vector_type}")
+
+    def gen_struct_vector_rows(self, entities: int, dim: int, vector_type: DataType, file_type: str) -> dict[str, Any]:
+        id_arr = []
+        float_vector_arr = []
+        struct_arr = []
+        for i in range(entities):
+            rng = random.Random(i)
+            struct_list = []
+            for j in range(rng.randint(1, 4)):
+                struct_list.append(
+                    {
+                        "struct_int": i * 10 + j,
+                        "struct_vec": self.struct_vector_value_for_import(vector_type, i * 10 + j, dim, file_type),
+                    }
+                )
+            id_arr.append(i)
+            float_vector_arr.append([rng.random() for _ in range(dim)])
+            struct_arr.append(struct_list)
+        return {"id": id_arr, "float_vector": float_vector_arr, "struct_array": struct_arr}
+
+    def gen_struct_vector_bulk_writer_rows(
+        self, entities: int, dim: int, vector_type: DataType
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        original_data = self.gen_struct_vector_rows(entities, dim, vector_type, "JSON")
+        rows = []
+        for i in range(entities):
+            struct_array = []
+            for item in original_data["struct_array"][i]:
+                struct_array.append(
+                    {
+                        "struct_int": item["struct_int"],
+                        "struct_vec": self.struct_vector_value_for_bulk_writer(
+                            vector_type, item["struct_int"], dim
+                        ),
+                    }
+                )
+            rows.append(
+                {
+                    "id": original_data["id"][i],
+                    "float_vector": original_data["float_vector"][i],
+                    "struct_array": struct_array,
+                }
+            )
+        return rows, original_data
+
+    def write_struct_vector_import_file(
+        self, data: dict[str, Any], vector_type: DataType, file_type: str, dim: int, file_path: str
+    ):
+        rows = [
+            {
+                "id": data["id"][i],
+                "float_vector": data["float_vector"][i],
+                "struct_array": data["struct_array"][i],
+            }
+            for i in range(len(data["id"]))
+        ]
+        if file_type == "JSON":
+            with open(file_path, "w") as f:
+                json.dump(rows, f, indent=2)
+            return
+        if file_type == "JSONL":
+            with open(file_path, "w") as f:
+                for row in rows:
+                    f.write(json.dumps(row))
+                    f.write("\n")
+            return
+        if file_type == "CSV":
+            with open(file_path, "w", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=["id", "float_vector", "struct_array"])
+                writer.writeheader()
+                for row in rows:
+                    writer.writerow(
+                        {
+                            "id": row["id"],
+                            "float_vector": json.dumps(row["float_vector"]),
+                            "struct_array": json.dumps(row["struct_array"]),
+                        }
+                    )
+            return
+
+        struct_type = pa.struct(
+            [
+                pa.field("struct_int", pa.int64()),
+                pa.field("struct_vec", self.struct_vector_arrow_type(vector_type)),
+            ]
+        )
+        table = pa.table(
+            {
+                "id": pa.array(data["id"], type=pa.int64()),
+                "float_vector": pa.array(data["float_vector"], type=pa.list_(pa.float32())),
+                "struct_array": pa.array(data["struct_array"], type=pa.list_(struct_type)),
+            }
+        )
+        pq.write_table(table, file_path, row_group_size=10000)
+
+    @staticmethod
+    def verify_struct_vector_import(client: MilvusClient, collection_name: str, entities: int):
+        client.refresh_load(collection_name=collection_name)
+        stats = client.get_collection_stats(collection_name=collection_name)
+        assert stats["row_count"] == entities
+        results = client.query(collection_name=collection_name, filter="id >= 0", output_fields=["id"], limit=entities)
+        assert len(results) == entities
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("dim", [32])
+    @pytest.mark.parametrize("entities", [20])
+    @pytest.mark.parametrize("array_capacity", [32])
+    @pytest.mark.parametrize("vector_type", STRUCT_ARRAY_IMPORT_VECTOR_TYPES)
+    @pytest.mark.parametrize("file_type", STRUCT_ARRAY_IMPORT_FILE_TYPES)
+    def test_import_struct_array_vector_subfield_all_file_types(
+        self, dim, entities, array_capacity, vector_type, file_type
+    ):
+        """Import every supported StructArray vector sub-field type from all row file formats."""
+        client = self._client()
+        c_name = cf.gen_unique_str(f"import_struct_{self.vector_type_name(vector_type)}_{file_type.lower()}")
+        self.create_vector_import_collection(client, c_name, vector_type, dim, array_capacity)
+
+        local_file_path = os.path.join(self.LOCAL_FILES_PATH, f"test_{cf.gen_unique_str()}.{file_type.lower()}")
+        original_data = self.gen_struct_vector_rows(entities, dim, vector_type, file_type)
+        self.write_struct_vector_import_file(original_data, vector_type, file_type, dim, local_file_path)
+        import_files = self.upload_to_minio(local_file_path)
+
+        self.call_bulkinsert(c_name, import_files)
+        self.verify_struct_vector_import(client, c_name, entities)
+
+        results = client.search(
+            collection_name=c_name,
+            data=[self.struct_search_vector(vector_type, 0, dim)],
+            anns_field="struct_array[struct_vec]",
+            search_params={"metric_type": self.struct_vector_metric(vector_type), "params": {"ef": 64}},
+            limit=1,
+            output_fields=["id"],
+        )
+        assert len(results[0]) == 1
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("dim", [32])
+    @pytest.mark.parametrize("entities", [20])
+    @pytest.mark.parametrize("array_capacity", [32])
+    @pytest.mark.parametrize("vector_type", STRUCT_ARRAY_IMPORT_VECTOR_TYPES)
+    @pytest.mark.parametrize("file_type", STRUCT_ARRAY_BULK_WRITER_FILE_TYPES)
+    def test_import_struct_array_vector_subfield_with_local_bulk_writer(
+        self, dim, entities, array_capacity, vector_type, file_type
+    ):
+        """Generate every supported StructArray vector type and row format with LocalBulkWriter."""
+        client = self._client()
+        c_name = cf.gen_unique_str(f"import_struct_bw_{self.vector_type_name(vector_type)}_{file_type.name.lower()}")
+        schema = self.create_vector_import_collection(client, c_name, vector_type, dim, array_capacity)
+        insert_data, _ = self.gen_struct_vector_bulk_writer_rows(entities, dim, vector_type)
+
+        batch_files, _ = self.gen_file_with_local_bulk_writer(
+            schema=schema,
+            data=insert_data,
+            file_type=file_type,
+        )
+        import_files = []
+        for file_list in batch_files:
+            for file_path in file_list:
+                import_files.extend(self.upload_to_minio(file_path))
+
+        self.call_bulkinsert(c_name, import_files)
+        self.verify_struct_vector_import(client, c_name, entities)
 
 
 class TestMilvusClientStructArrayMmap(TestMilvusClientV2Base):

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -33,6 +33,58 @@ default_capacity = 100
 METRICS = ["MAX_SIM", "MAX_SIM_IP", "MAX_SIM_COSINE", "MAX_SIM_L2"]
 INDEX_PARAMS = {"M": 16, "efConstruction": 200}
 
+# EmbList index type configs: {index_type: {build_params, search_params}}
+EMB_LIST_INDEX_CONFIGS = {
+    "HNSW_SQ": {
+        "build_params": {"M": 16, "efConstruction": 200, "sq_type": "SQ8"},
+        "search_params": {"ef": 64},
+    },
+    "HNSW_PQ": {
+        "build_params": {"M": 16, "efConstruction": 200},
+        "search_params": {"ef": 64},
+    },
+    "HNSW_PRQ": {
+        "build_params": {"M": 16, "efConstruction": 200},
+        "search_params": {"ef": 64},
+    },
+    "IVF_FLAT": {
+        "build_params": {"nlist": 128},
+        "search_params": {"nprobe": 10},
+    },
+    "IVF_FLAT_CC": {
+        "build_params": {"nlist": 128},
+        "search_params": {"nprobe": 10},
+    },
+    "DISKANN": {
+        "build_params": {},
+        "search_params": {"search_list": 30},
+    },
+}
+EMB_LIST_INDEX_TYPES = list(EMB_LIST_INDEX_CONFIGS.keys())
+
+# Supported vector types per emb list index type (for MaxSim metrics)
+EMB_LIST_VECTOR_TYPES = {
+    "HNSW": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
+             DataType.INT8_VECTOR, DataType.BINARY_VECTOR],
+    "HNSW_SQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
+                DataType.INT8_VECTOR],
+    "HNSW_PQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
+                DataType.INT8_VECTOR],
+    "HNSW_PRQ": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR,
+                 DataType.INT8_VECTOR],
+    "IVF_FLAT": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
+    "IVF_FLAT_CC": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
+    "DISKANN": [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR],
+}
+
+# Dim for emb list index tests (smaller for faster index building)
+EMB_LIST_DIM = 32
+
+# Metric type for binary vectors vs float vectors
+BINARY_METRIC = "MAX_SIM_HAMMING"
+FLOAT_METRIC = "MAX_SIM_COSINE"
+INT8_METRIC = "MAX_SIM_COSINE"
+
 
 class TestMilvusClientStructArrayBasic(TestMilvusClientV2Base):
     """Test case of struct array basic functionality"""
@@ -1471,6 +1523,99 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
             embedding_list.add(vector)
         return embedding_list
 
+    def create_collection_with_configurable_index(
+        self,
+        client: MilvusClient,
+        collection_name: str,
+        index_type: str = "HNSW",
+        metric_type: str = "MAX_SIM_COSINE",
+        build_params: dict = None,
+        dim: int = default_dim,
+        nb: int = default_nb,
+    ):
+        """Create collection with struct array, insert data and create configurable index"""
+        # Create schema
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=dim
+        )
+
+        # Create struct schema
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=dim)
+        struct_schema.add_field("scalar_field", DataType.INT64)
+        struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=100,
+        )
+
+        schema.add_field("scalar_field", datatype=DataType.INT64)
+        schema.add_field("category", datatype=DataType.VARCHAR, max_length=128)
+        schema.add_field("score", datatype=DataType.FLOAT)
+        # Create collection
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        # Insert data
+        data = []
+        for i in range(nb):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                struct_element = {
+                    "clip_embedding1": [random.random() for _ in range(dim)],
+                    "scalar_field": i * 10 + j,
+                    "category": f"cat_{i % 5}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(dim)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"cat_{i % 5}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            data.append(row)
+
+        res, check = self.insert(client, collection_name, data)
+        assert check
+
+        # Create indexes
+        if build_params is None:
+            build_params = INDEX_PARAMS
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index",
+            index_type=index_type,
+            metric_type=metric_type,
+            params=build_params,
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+        # Load collection
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        return data
+
     @pytest.mark.tags(CaseLabel.L0)
     def test_search_struct_array_vector_single(self):
         """
@@ -2186,6 +2331,452 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
                 assert recall >= 0.8, (
                     f"Recall should be >= 0.8 when retrieval_ann_ratio >= 3, but ratio {ratio} has recall {recall}"
                 )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("index_type", EMB_LIST_INDEX_TYPES)
+    def test_search_emb_list_with_different_index_types(self, index_type):
+        """
+        target: test search with full CRUD path for different emb list index types
+        method: insert (flushed + growing) → index → load → search → upsert → delete → search → verify
+        expected: all CRUD operations and search work correctly for each index type
+        """
+        collection_name = cf.gen_unique_str(
+            f"{prefix}_search_{index_type.lower()}"
+        )
+        client = self._client()
+
+        config = EMB_LIST_INDEX_CONFIGS[index_type]
+
+        # Create collection with full schema
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM
+        )
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM)
+        struct_schema.add_field("scalar_field", DataType.INT64)
+        struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=100,
+        )
+
+        schema.add_field("scalar_field", datatype=DataType.INT64)
+        schema.add_field("category", datatype=DataType.VARCHAR, max_length=128)
+        schema.add_field("score", datatype=DataType.FLOAT)
+
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        # Insert 3000 records and flush (sealed segments)
+        nb_flushed = 3000
+        flushed_data = []
+        for i in range(nb_flushed):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                struct_element = {
+                    "clip_embedding1": [random.random() for _ in range(EMB_LIST_DIM)],
+                    "scalar_field": i * 10 + j,
+                    "category": f"cat_{i % 5}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"cat_{i % 5}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            flushed_data.append(row)
+
+        res, check = self.insert(client, collection_name, flushed_data)
+        assert check
+        assert res["insert_count"] == nb_flushed
+
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        # Insert 500 more growing records
+        nb_growing = 500
+        growing_data = []
+        for i in range(nb_flushed, nb_flushed + nb_growing):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                struct_element = {
+                    "clip_embedding1": [random.random() for _ in range(EMB_LIST_DIM)],
+                    "scalar_field": i * 10 + j,
+                    "category": f"cat_{i % 5}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"cat_{i % 5}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            growing_data.append(row)
+
+        res, check = self.insert(client, collection_name, growing_data)
+        assert check
+        assert res["insert_count"] == nb_growing
+
+        # Create index with configurable type
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index",
+            index_type=index_type,
+            metric_type="MAX_SIM_COSINE",
+            params=config["build_params"],
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+        # Load collection
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        # Search with EmbeddingList and verify results
+        embedding_list = self.create_embedding_list(EMB_LIST_DIM, 3)
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={
+                "metric_type": "MAX_SIM_COSINE",
+                "params": config["search_params"],
+            },
+            limit=10,
+            output_fields=["id", "clips"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert 0 <= hit["id"] < nb_flushed + nb_growing
+
+        # Upsert 10 records from flushed segment
+        upsert_data = []
+        for i in range(10):
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
+                "clips": [
+                    {
+                        "clip_embedding1": [random.random() for _ in range(EMB_LIST_DIM)],
+                        "scalar_field": i + 10000,
+                        "category": f"upserted_{i}",
+                    }
+                ],
+                "scalar_field": i + 10000,
+                "category": f"upserted_{i}",
+                "score": random.uniform(10.0, 20.0),
+            }
+            upsert_data.append(row)
+
+        res, check = self.upsert(client, collection_name, upsert_data)
+        assert check
+
+        # Verify upsert via query
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id < 10",
+            output_fields=["id", "category", "clips"],
+        )
+        assert check
+        assert len(results) == 10
+        for result in results:
+            assert "upserted" in result["category"]
+            assert "upserted" in result["clips"][0]["category"]
+
+        # Delete 5 records from growing segment
+        delete_ids = list(range(nb_flushed, nb_flushed + 5))
+        res, check = self.delete(client, collection_name, filter=f"id in {delete_ids}")
+        assert check
+
+        # Verify deletion
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id >= 0", output_fields=["id"]
+        )
+        assert check
+        remaining_ids = {r["id"] for r in results}
+        for del_id in delete_ids:
+            assert del_id not in remaining_ids
+        assert len(results) == nb_flushed + nb_growing - 5
+
+        # Search again after CRUD operations
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={
+                "metric_type": "MAX_SIM_COSINE",
+                "params": config["search_params"],
+            },
+            limit=10,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert hit["id"] not in delete_ids
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize(
+        "vector_type",
+        [DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR,
+         DataType.BINARY_VECTOR],
+    )
+    def test_search_emb_list_with_different_vector_types(self, vector_type):
+        """
+        target: test search with full CRUD path for different vector data types in struct array
+        method: insert (flushed + growing) → HNSW index → load → search → upsert → delete → search → verify
+        expected: all CRUD operations and search work correctly for each vector type
+        """
+        # Select metric based on vector type
+        if vector_type == DataType.BINARY_VECTOR:
+            emb_list_metric = "MAX_SIM_HAMMING"
+        else:
+            emb_list_metric = "MAX_SIM_COSINE"
+
+        type_name = vector_type.name.lower()
+        collection_name = cf.gen_unique_str(f"{prefix}_search_vtype_{type_name}")
+        client = self._client()
+
+        # Create schema with specified vector type
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(
+            field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM
+        )
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("clip_embedding1", vector_type, dim=EMB_LIST_DIM)
+        struct_schema.add_field("scalar_field", DataType.INT64)
+        struct_schema.add_field("category", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=100,
+        )
+
+        schema.add_field("scalar_field", datatype=DataType.INT64)
+        schema.add_field("category", datatype=DataType.VARCHAR, max_length=128)
+        schema.add_field("score", datatype=DataType.FLOAT)
+
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        # Insert 3000 records and flush (sealed segments)
+        nb_flushed = 3000
+        flushed_data = []
+        for i in range(nb_flushed):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                vec = cf.gen_vectors(1, EMB_LIST_DIM, vector_type)[0]
+                struct_element = {
+                    "clip_embedding1": vec,
+                    "scalar_field": i * 10 + j,
+                    "category": f"flushed_{i}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"flushed_{i}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            flushed_data.append(row)
+
+        res, check = self.insert(client, collection_name, flushed_data)
+        assert check
+        assert res["insert_count"] == nb_flushed
+
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        # Insert 500 more growing records
+        nb_growing = 500
+        growing_data = []
+        for i in range(nb_flushed, nb_flushed + nb_growing):
+            array_length = random.randint(1, 5)
+            struct_array = []
+            for j in range(array_length):
+                vec = cf.gen_vectors(1, EMB_LIST_DIM, vector_type)[0]
+                struct_element = {
+                    "clip_embedding1": vec,
+                    "scalar_field": i * 10 + j,
+                    "category": f"growing_{i}",
+                }
+                struct_array.append(struct_element)
+
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
+                "clips": struct_array,
+                "scalar_field": i * 10 + j,
+                "category": f"growing_{i}",
+                "score": random.uniform(0.1, 10.0),
+            }
+            growing_data.append(row)
+
+        res, check = self.insert(client, collection_name, growing_data)
+        assert check
+        assert res["insert_count"] == nb_growing
+
+        # Create HNSW index with appropriate metric for vector type
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name="struct_vector_index",
+            index_type="HNSW",
+            metric_type=emb_list_metric,
+            params=INDEX_PARAMS,
+        )
+
+        res, check = self.create_index(client, collection_name, index_params)
+        assert check
+
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        # Search with EmbeddingList and verify results
+        search_vecs = cf.gen_vectors(3, EMB_LIST_DIM, vector_type)
+        if vector_type == DataType.BINARY_VECTOR:
+            embedding_list = EmbeddingList(
+                [np.frombuffer(v, dtype=np.uint8) if isinstance(v, bytes) else v for v in search_vecs]
+            )
+        else:
+            embedding_list = EmbeddingList(
+                [np.array(v) if not isinstance(v, np.ndarray) else v for v in search_vecs]
+            )
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={"metric_type": emb_list_metric},
+            limit=10,
+            output_fields=["id", "clips"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert 0 <= hit["id"] < nb_flushed + nb_growing
+
+        # Upsert 10 records from flushed segment
+        upsert_data = []
+        for i in range(10):
+            row = {
+                "id": i,
+                "normal_vector": [random.random() for _ in range(EMB_LIST_DIM)],
+                "clips": [
+                    {
+                        "clip_embedding1": cf.gen_vectors(1, EMB_LIST_DIM, vector_type)[0],
+                        "scalar_field": i + 10000,
+                        "category": f"upserted_{i}",
+                    }
+                ],
+                "scalar_field": i + 10000,
+                "category": f"upserted_{i}",
+                "score": random.uniform(10.0, 20.0),
+            }
+            upsert_data.append(row)
+
+        res, check = self.upsert(client, collection_name, upsert_data)
+        assert check
+
+        # Verify upsert via query
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id < 10",
+            output_fields=["id", "category", "clips"],
+        )
+        assert check
+        assert len(results) == 10
+        for result in results:
+            assert "upserted" in result["category"]
+            assert "upserted" in result["clips"][0]["category"]
+
+        # Delete 5 records from flushed segment and 3 from growing segment
+        delete_flushed_ids = [10, 11, 12, 13, 14]
+        delete_growing_ids = list(range(nb_flushed, nb_flushed + 3))
+        all_delete_ids = delete_flushed_ids + delete_growing_ids
+        res, check = self.delete(
+            client, collection_name, filter=f"id in {all_delete_ids}"
+        )
+        assert check
+
+        # Verify deletion
+        res, check = self.flush(client, collection_name)
+        assert check
+
+        results, check = self.query(
+            client, collection_name, filter="id >= 0", output_fields=["id"]
+        )
+        assert check
+        remaining_ids = {r["id"] for r in results}
+        for del_id in all_delete_ids:
+            assert del_id not in remaining_ids
+        assert len(results) == nb_flushed + nb_growing - len(all_delete_ids)
+
+        # Search again after CRUD operations
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[embedding_list],
+            anns_field="clips[clip_embedding1]",
+            search_params={"metric_type": emb_list_metric},
+            limit=10,
+            output_fields=["id"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert hit["id"] not in all_delete_ids
 
 
 class TestMilvusClientStructArrayHybridSearch(TestMilvusClientV2Base):

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -175,10 +175,7 @@ class StructArrayElementSearchBase(TestMilvusClientV2Base):
             ]
 
         def _struct_b(scores):
-            return [
-                {"embedding": self._cosine_vector(score), "tag": f"b_{idx}"}
-                for idx, score in enumerate(scores)
-            ]
+            return [{"embedding": self._cosine_vector(score), "tag": f"b_{idx}"} for idx, score in enumerate(scores)]
 
         score_rows = [
             (1, [0.99, 0.10, 0.10]),
@@ -231,8 +228,7 @@ class StructArrayElementSearchBase(TestMilvusClientV2Base):
                 "doc_int": i,
                 "normal_vector": _seed_vector(i + 999999),
                 "structA": [
-                    {"embedding": _seed_vector(i * 100 + k), "int_val": i * 10 + k}
-                    for k in range(rng.randint(3, 6))
+                    {"embedding": _seed_vector(i * 100 + k), "int_val": i * 10 + k} for k in range(rng.randint(3, 6))
                 ],
             }
 

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -788,7 +788,7 @@ class TestStructArrayElementHybridSearchNoFilter(StructArrayElementSearchBase):
             check_task=CheckTasks.err_res,
             check_items={
                 ct.err_code: 1100,
-                ct.err_msg: "range search is not supported for vector array (embedding-list) fields in hybrid search",
+                ct.err_msg: "range search is not supported for vector array fields",
             },
         )
 
@@ -829,6 +829,6 @@ class TestStructArrayElementHybridSearchNoFilter(StructArrayElementSearchBase):
             check_task=CheckTasks.err_res,
             check_items={
                 ct.err_code: 1100,
-                ct.err_msg: "group by search is not supported for vector array (embedding-list) fields in hybrid search",
+                ct.err_msg: "group by search is not supported for vector array fields",
             },
         )

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -5,8 +5,9 @@ import pytest
 from base.client_v2_base import TestMilvusClientV2Base
 from common import common_func as cf
 from common import common_type as ct
-from common.common_type import CaseLabel
+from common.common_type import CaseLabel, CheckTasks
 from pymilvus import AnnSearchRequest, DataType, RRFRanker, WeightedRanker
+from pymilvus.client.embedding_list import EmbeddingList
 
 prefix = "struct_elem"
 default_nb = ct.default_nb
@@ -125,6 +126,123 @@ class StructArrayElementSearchBase(TestMilvusClientV2Base):
         data = self._generate_data(nb=nb, dim=dim)
         self.insert(client, collection_name, data)
         self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+        return data
+
+    def _setup_multi_struct_collection(self, client, collection_name, metric_type="COSINE"):
+        """Create deterministic data for hybrid collapse and validation checks."""
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="doc_int", datatype=DataType.INT64)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim)
+
+        struct_a = client.create_struct_field_schema()
+        struct_a.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_a.add_field("embedding_alt", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_a.add_field("tag", DataType.VARCHAR, max_length=32)
+        schema.add_field(
+            "structA",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_a,
+            max_capacity=10,
+        )
+
+        struct_b = client.create_struct_field_schema()
+        struct_b.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_b.add_field("tag", DataType.VARCHAR, max_length=32)
+        schema.add_field(
+            "structB",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_b,
+            max_capacity=10,
+        )
+
+        index_params = client.prepare_index_params()
+        for field_name in ["normal_vector", "structA[embedding]", "structA[embedding_alt]", "structB[embedding]"]:
+            index_params.add_index(field_name=field_name, index_type="FLAT", metric_type=metric_type)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        def _struct_a(scores):
+            return [
+                {
+                    "embedding": self._cosine_vector(score),
+                    "embedding_alt": self._cosine_vector(score),
+                    "tag": f"a_{idx}",
+                }
+                for idx, score in enumerate(scores)
+            ]
+
+        def _struct_b(scores):
+            return [
+                {"embedding": self._cosine_vector(score), "tag": f"b_{idx}"}
+                for idx, score in enumerate(scores)
+            ]
+
+        score_rows = [
+            (1, [0.99, 0.10, 0.10]),
+            (2, [0.90, 0.89, 0.88]),
+            (3, [0.70, 0.69, 0.68]),
+        ]
+        data = [
+            {
+                "id": row_id,
+                "doc_int": row_id * 10,
+                "normal_vector": self._cosine_vector(0.20 + row_id * 0.01),
+                "structA": _struct_a(scores),
+                "structB": _struct_b(scores),
+            }
+            for row_id, scores in score_rows
+        ]
+        self.insert(client, collection_name, data)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+        return data
+
+    def _setup_embedding_list_collection(self, client, collection_name, sealed_nb=default_nb, growing_nb=200):
+        """Create an embedding-list StructArray collection for hybrid validation paths."""
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("doc_int", DataType.INT64)
+        schema.add_field("normal_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_schema.add_field("int_val", DataType.INT64)
+        schema.add_field(
+            "structA",
+            DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=default_capacity,
+        )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index("normal_vector", index_type="HNSW", metric_type="COSINE", params=INDEX_PARAMS)
+        index_params.add_index(
+            "structA[embedding]", index_type="HNSW", metric_type="MAX_SIM_COSINE", params=INDEX_PARAMS
+        )
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        def _gen_row(i):
+            rng = random.Random(i)
+            return {
+                "id": i,
+                "doc_int": i,
+                "normal_vector": _seed_vector(i + 999999),
+                "structA": [
+                    {"embedding": _seed_vector(i * 100 + k), "int_val": i * 10 + k}
+                    for k in range(rng.randint(3, 6))
+                ],
+            }
+
+        data = [_gen_row(i) for i in range(sealed_nb)]
+        for start in range(0, sealed_nb, 1000):
+            self.insert(client, collection_name, data[start : start + 1000])
+        self.flush(client, collection_name)
+        growing = [_gen_row(sealed_nb + i) for i in range(growing_nb)]
+        self.insert(client, collection_name, growing)
+        data.extend(growing)
         self.load_collection(client, collection_name)
         return data
 
@@ -505,3 +623,212 @@ class TestStructArrayElementHybridSearchNoFilter(StructArrayElementSearchBase):
             assert abs(hit["distance"] - expected_scores[hit["id"]]) < 1e-5, (
                 f"unexpected RRF score for id={hit['id']}: got {hit['distance']}, expected {expected_scores[hit['id']]}"
             )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_hybrid_element_scope_topk_sum_changes_collapse_order(self):
+        """Verify element_scope changes row-level collapse across different StructArray fields."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_scope_topk_sum")
+        self._setup_multi_struct_collection(client, collection_name)
+        query_vector = self._cosine_vector(1.0)
+
+        def _req(field_name, params=None):
+            search_params = {"metric_type": "COSINE"}
+            if params is not None:
+                search_params["params"] = params
+            return AnnSearchRequest(
+                **{
+                    "data": [query_vector],
+                    "anns_field": field_name,
+                    "param": search_params,
+                    "limit": 9,
+                }
+            )
+
+        default_results, check = self.hybrid_search(
+            client,
+            collection_name,
+            [_req("structA[embedding]"), _req("structB[embedding]")],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+        )
+        assert check
+        default_ids = [hit["id"] for hit in default_results[0]]
+        assert default_ids[0] == 1
+
+        element_scope = {"element_scope": {"collapse": {"strategy": "topk_sum", "topk": 3}}}
+        scoped_results, check = self.hybrid_search(
+            client,
+            collection_name,
+            [_req("structA[embedding]", element_scope), _req("structB[embedding]", element_scope)],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+        )
+        assert check
+        scoped_ids = [hit["id"] for hit in scoped_results[0]]
+        assert scoped_ids[0] == 2
+        assert scoped_ids != default_ids
+        assert len(scoped_ids) == len(set(scoped_ids))
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_same_struct_element_scope_not_supported(self):
+        """element_scope is invalid for a same-StructArray element-level hybrid search."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_scope_same_struct")
+        self._setup_multi_struct_collection(client, collection_name)
+        query_vector = self._cosine_vector(1.0)
+        req1 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding]",
+                "param": {
+                    "metric_type": "COSINE",
+                    "params": {"element_scope": {"collapse": {"strategy": "max"}}},
+                },
+                "limit": 9,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding_alt]",
+                "param": {"metric_type": "COSINE"},
+                "limit": 9,
+            }
+        )
+        self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items={
+                ct.err_code: 1100,
+                ct.err_msg: "element_scope is not allowed for same-struct element-level hybrid search",
+            },
+        )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_element_scope_sum_l2_not_supported(self):
+        """Sum-family element collapse is invalid for negatively related metrics."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_scope_l2")
+        self._setup_multi_struct_collection(client, collection_name, metric_type="L2")
+        query_vector = self._cosine_vector(1.0)
+        req1 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding]",
+                "param": {
+                    "metric_type": "L2",
+                    "params": {"element_scope": {"collapse": {"strategy": "topk_sum", "topk": 2}}},
+                },
+                "limit": 9,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structB[embedding]",
+                "param": {"metric_type": "L2"},
+                "limit": 9,
+            }
+        )
+        self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items={
+                ct.err_code: 1100,
+                ct.err_msg: "element_scope.collapse.strategy topk_sum is only supported",
+            },
+        )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_embedding_list_range_not_supported(self):
+        """Embedding-list-level hybrid search rejects range-search parameters."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_emblist_radius")
+        data = self._setup_embedding_list_collection(client, collection_name)
+
+        tensor = EmbeddingList()
+        tensor.add(_seed_vector(7))
+        tensor.add(_seed_vector(8))
+        req1 = AnnSearchRequest(
+            **{
+                "data": [tensor],
+                "anns_field": "structA[embedding]",
+                "param": {"metric_type": "MAX_SIM_COSINE", "params": {"radius": 0.1}},
+                "limit": 10,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [data[0]["normal_vector"]],
+                "anns_field": "normal_vector",
+                "param": {"metric_type": "COSINE"},
+                "limit": 10,
+            }
+        )
+        self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=10,
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items={
+                ct.err_code: 1100,
+                ct.err_msg: "range search is not supported for vector array (embedding-list) fields in hybrid search",
+            },
+        )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_embedding_list_group_by_not_supported(self):
+        """Embedding-list-level hybrid search rejects group-by."""
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_emblist_gb")
+        data = self._setup_embedding_list_collection(client, collection_name)
+
+        tensor = EmbeddingList()
+        tensor.add(_seed_vector(3))
+        tensor.add(_seed_vector(4))
+        req1 = AnnSearchRequest(
+            **{
+                "data": [tensor],
+                "anns_field": "structA[embedding]",
+                "param": {"metric_type": "MAX_SIM_COSINE"},
+                "limit": 10,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [data[0]["normal_vector"]],
+                "anns_field": "normal_vector",
+                "param": {"metric_type": "COSINE"},
+                "limit": 10,
+            }
+        )
+        self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=10,
+            output_fields=["id"],
+            group_by_field="id",
+            check_task=CheckTasks.err_res,
+            check_items={
+                ct.err_code: 1100,
+                ct.err_msg: "group by search is not supported for vector array (embedding-list) fields in hybrid search",
+            },
+        )

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -24,8 +24,8 @@ pytest-sugar==0.9.5
 pytest-random-order
 
 # pymilvus
-pymilvus==2.6.17rc2
-pymilvus[bulk_writer]==2.6.17rc2
+pymilvus==2.6.17rc11
+pymilvus[bulk_writer]==2.6.17rc11
 # for protobuf
 protobuf>=5.29.5
 

--- a/tests/restful_client_v2/testcases/test_collection_operations.py
+++ b/tests/restful_client_v2/testcases/test_collection_operations.py
@@ -1,8 +1,10 @@
 import datetime
 import logging
+import random
 import threading
 import time
 
+import numpy as np
 import pytest
 from api.milvus import CollectionClient
 from base.testbase import TestBase
@@ -1981,7 +1983,6 @@ class TestCollectionAddFieldNegative(TestBase):
 class TestCollectionMaintenance(TestBase):
     """Test collection maintenance operations"""
 
-    @pytest.mark.xfail(reason="issue: https://github.com/milvus-io/milvus/issues/39546")
     def test_collection_flush(self):
         """
         target: test collection flush
@@ -2073,3 +2074,530 @@ class TestCollectionMaintenance(TestBase):
         assert "state" in response["data"]
         assert "compactionID" in response["data"]
         # TODO need verification by pymilvus
+
+
+DEFAULT_STRUCT_ARRAY_DIM = 8
+DEFAULT_STRUCT_ARRAY_SUB_CAPACITY = 16
+
+
+def _rand_struct_array_vector(dim=DEFAULT_STRUCT_ARRAY_DIM):
+    return [random.random() for _ in range(dim)]
+
+
+def _build_struct_array_schema_payload(
+    name,
+    dim=DEFAULT_STRUCT_ARRAY_DIM,
+    max_capacity=DEFAULT_STRUCT_ARRAY_SUB_CAPACITY,
+    include_index_params=False,
+    metric_type="COSINE",
+    sub_metric_type="COSINE",
+    enable_dynamic_field=False,
+):
+    payload = {
+        "collectionName": name,
+        "schema": {
+            "autoId": False,
+            "enableDynamicField": enable_dynamic_field,
+            "fields": [
+                {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                {
+                    "fieldName": "vec",
+                    "dataType": "FloatVector",
+                    "elementTypeParams": {"dim": f"{dim}"},
+                },
+            ],
+            "structFields": [
+                {
+                    "fieldName": "my_struct",
+                    "fields": [
+                        {
+                            "fieldName": "sub_int",
+                            "dataType": "Array",
+                            "elementDataType": "Int32",
+                            "elementTypeParams": {"max_capacity": max_capacity},
+                        },
+                        {
+                            "fieldName": "sub_vec",
+                            "dataType": "ArrayOfVector",
+                            "elementDataType": "FloatVector",
+                            "elementTypeParams": {
+                                "dim": dim,
+                                "max_capacity": max_capacity,
+                            },
+                        },
+                    ],
+                }
+            ],
+        },
+    }
+    if include_index_params:
+        payload["indexParams"] = [
+            {"fieldName": "vec", "indexName": "vec_idx", "metricType": metric_type},
+            {
+                "fieldName": "my_struct[sub_vec]",
+                "indexName": "sub_vec_idx",
+                "metricType": sub_metric_type,
+            },
+        ]
+    return payload
+
+
+def _gen_struct_array_row(row_id, num_elems, dim=DEFAULT_STRUCT_ARRAY_DIM):
+    struct_elems = []
+    for j in range(num_elems):
+        struct_elems.append(
+            {
+                "sub_int": row_id * 100 + j,
+                "sub_vec": _rand_struct_array_vector(dim),
+            }
+        )
+    return {
+        "id": row_id,
+        "vec": _rand_struct_array_vector(dim),
+        "my_struct": struct_elems,
+    }
+
+
+@pytest.mark.L0
+class TestStructArrayCollection(TestBase):
+    def test_create_struct_array_collection(self):
+        name = gen_collection_name()
+        payload = _build_struct_array_schema_payload(name, include_index_params=True)
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0
+
+        rsp = self.collection_client.collection_describe(name)
+        assert rsp["code"] == 0
+        struct_fields = rsp["data"].get("structFields", [])
+        assert len(struct_fields) == 1, f"expected 1 struct field, got {struct_fields}"
+
+        struct_field = struct_fields[0]
+        assert struct_field["name"] == "my_struct"
+        assert struct_field["type"] == "ArrayOfStruct"
+
+        sub_fields = struct_field.get("fields", [])
+        sub_names = sorted(s["name"] for s in sub_fields)
+        assert sub_names == ["sub_int", "sub_vec"], sub_names
+
+        by_name = {s["name"]: s for s in sub_fields}
+        assert by_name["sub_int"]["type"] == "Array"
+        assert by_name["sub_int"]["elementType"] == "Int32"
+        assert by_name["sub_vec"]["elementType"] == "FloatVector"
+
+
+@pytest.mark.L1
+class TestStructArraySchemaValidation(TestBase):
+    def _create_with_bad_sub_field(self, name, bad_sub_field):
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {
+                        "fieldName": "vec",
+                        "dataType": "FloatVector",
+                        "elementTypeParams": {"dim": f"{DEFAULT_STRUCT_ARRAY_DIM}"},
+                    },
+                ],
+                "structFields": [
+                    {
+                        "fieldName": "bad_struct",
+                        "fields": [bad_sub_field],
+                    }
+                ],
+            },
+            "indexParams": [
+                {"fieldName": "vec", "indexName": "vec_idx", "metricType": "L2"},
+            ],
+        }
+        return self.collection_client.collection_create(payload)
+
+    def test_reject_nullable_sub_field(self):
+        name = gen_collection_name()
+        rsp = self._create_with_bad_sub_field(
+            name,
+            {
+                "fieldName": "sub",
+                "dataType": "Array",
+                "elementDataType": "Int32",
+                "elementTypeParams": {"max_capacity": DEFAULT_STRUCT_ARRAY_SUB_CAPACITY},
+                "nullable": True,
+            },
+        )
+        assert rsp["code"] != 0, rsp
+        assert "nullable" in rsp.get("message", "").lower()
+
+    def test_reject_default_value_sub_field(self):
+        name = gen_collection_name()
+        rsp = self._create_with_bad_sub_field(
+            name,
+            {
+                "fieldName": "sub",
+                "dataType": "Array",
+                "elementDataType": "Int32",
+                "elementTypeParams": {"max_capacity": DEFAULT_STRUCT_ARRAY_SUB_CAPACITY},
+                "defaultValue": 1,
+            },
+        )
+        assert rsp["code"] != 0, rsp
+        assert "default" in rsp.get("message", "").lower()
+
+    def test_reject_primary_key_sub_field(self):
+        name = gen_collection_name()
+        rsp = self._create_with_bad_sub_field(
+            name,
+            {
+                "fieldName": "sub",
+                "dataType": "Array",
+                "elementDataType": "Int64",
+                "elementTypeParams": {"max_capacity": DEFAULT_STRUCT_ARRAY_SUB_CAPACITY},
+                "isPrimary": True,
+            },
+        )
+        assert rsp["code"] != 0, rsp
+
+    def test_reject_partition_key_sub_field(self):
+        name = gen_collection_name()
+        rsp = self._create_with_bad_sub_field(
+            name,
+            {
+                "fieldName": "sub",
+                "dataType": "Array",
+                "elementDataType": "Int64",
+                "elementTypeParams": {"max_capacity": DEFAULT_STRUCT_ARRAY_SUB_CAPACITY},
+                "isPartitionKey": True,
+            },
+        )
+        assert rsp["code"] != 0, rsp
+
+    def test_reject_clustering_key_sub_field(self):
+        name = gen_collection_name()
+        rsp = self._create_with_bad_sub_field(
+            name,
+            {
+                "fieldName": "sub",
+                "dataType": "Array",
+                "elementDataType": "Int64",
+                "elementTypeParams": {"max_capacity": DEFAULT_STRUCT_ARRAY_SUB_CAPACITY},
+                "isClusteringKey": True,
+            },
+        )
+        assert rsp["code"] != 0, rsp
+
+    def test_reject_non_array_sub_field(self):
+        name = gen_collection_name()
+        rsp = self._create_with_bad_sub_field(
+            name,
+            {
+                "fieldName": "sub",
+                "dataType": "Int32",
+            },
+        )
+        assert rsp["code"] != 0, rsp
+
+    def test_reject_empty_sub_fields(self):
+        name = gen_collection_name()
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {
+                        "fieldName": "vec",
+                        "dataType": "FloatVector",
+                        "elementTypeParams": {"dim": f"{DEFAULT_STRUCT_ARRAY_DIM}"},
+                    },
+                ],
+                "structFields": [{"fieldName": "empty_struct", "fields": []}],
+            },
+            "indexParams": [
+                {"fieldName": "vec", "indexName": "vec_idx", "metricType": "L2"},
+            ],
+        }
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] != 0, rsp
+
+    def test_reject_duplicated_sub_field_name(self):
+        name = gen_collection_name()
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {
+                        "fieldName": "vec",
+                        "dataType": "FloatVector",
+                        "elementTypeParams": {"dim": f"{DEFAULT_STRUCT_ARRAY_DIM}"},
+                    },
+                ],
+                "structFields": [
+                    {
+                        "fieldName": "dup_struct",
+                        "fields": [
+                            {
+                                "fieldName": "s",
+                                "dataType": "Array",
+                                "elementDataType": "Int32",
+                                "elementTypeParams": {"max_capacity": DEFAULT_STRUCT_ARRAY_SUB_CAPACITY},
+                            },
+                            {
+                                "fieldName": "s",
+                                "dataType": "Array",
+                                "elementDataType": "Int32",
+                                "elementTypeParams": {"max_capacity": DEFAULT_STRUCT_ARRAY_SUB_CAPACITY},
+                            },
+                        ],
+                    }
+                ],
+            },
+            "indexParams": [
+                {"fieldName": "vec", "indexName": "vec_idx", "metricType": "L2"},
+            ],
+        }
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] != 0, rsp
+
+
+@pytest.mark.L0
+class TestStructArrayInsertQuery(TestBase):
+    def _create_and_load(self, name, dim=DEFAULT_STRUCT_ARRAY_DIM):
+        payload = _build_struct_array_schema_payload(name, dim=dim, include_index_params=True)
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+        self.collection_client.wait_load_completed(name, timeout=60)
+
+    def test_insert_and_query_struct_rows(self):
+        name = gen_collection_name()
+        self._create_and_load(name)
+
+        nb = 10
+        rows = [_gen_struct_array_row(i, num_elems=random.randint(1, 4)) for i in range(nb)]
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": rows})
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == nb
+
+        rsp = self.vector_client.vector_query(
+            {
+                "collectionName": name,
+                "filter": "id >= 0",
+                "outputFields": ["id", "my_struct"],
+                "limit": nb,
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        got = sorted(rsp["data"], key=lambda r: r["id"])
+        assert len(got) == nb
+
+        for orig, back in zip(rows, got):
+            assert back["id"] == orig["id"]
+            elems_back = back["my_struct"]
+            assert len(elems_back) == len(orig["my_struct"]), (
+                f"row {orig['id']} elem count mismatch: {len(elems_back)} vs {len(orig['my_struct'])}"
+            )
+            for eb, eo in zip(elems_back, orig["my_struct"]):
+                assert int(eb["sub_int"]) == eo["sub_int"]
+                np.testing.assert_allclose(eb["sub_vec"], eo["sub_vec"], rtol=1e-5, atol=1e-5)
+
+    def test_insert_reject_missing_sub_field(self):
+        name = gen_collection_name()
+        self._create_and_load(name)
+
+        bad_row = {
+            "id": 1,
+            "vec": _rand_struct_array_vector(),
+            "my_struct": [
+                {"sub_int": 1},
+            ],
+        }
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": [bad_row]})
+        assert rsp["code"] != 0, rsp
+        assert "sub_vec" in rsp.get("message", "") or "missing" in rsp.get("message", "").lower()
+
+    def test_insert_reject_struct_value_not_array(self):
+        name = gen_collection_name()
+        self._create_and_load(name)
+
+        bad_row = {
+            "id": 1,
+            "vec": _rand_struct_array_vector(),
+            "my_struct": {"sub_int": 1, "sub_vec": _rand_struct_array_vector()},
+        }
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": [bad_row]})
+        assert rsp["code"] != 0, rsp
+
+
+@pytest.mark.L0
+class TestStructSubVectorSearch(TestBase):
+    def _setup_collection_with_sub_index(self, name, dim=DEFAULT_STRUCT_ARRAY_DIM, nb=50, sub_metric="COSINE"):
+        payload = _build_struct_array_schema_payload(name, dim=dim, include_index_params=False)
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.index_client.index_create(
+            {
+                "collectionName": name,
+                "indexParams": [
+                    {"fieldName": "vec", "indexName": "vec_idx", "metricType": "COSINE"},
+                ],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.index_client.index_create(
+            {
+                "collectionName": name,
+                "indexParams": [
+                    {
+                        "fieldName": "my_struct[sub_vec]",
+                        "indexName": "sub_vec_idx",
+                        "metricType": sub_metric,
+                    },
+                ],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.collection_client.collection_load(collection_name=name)
+        assert rsp["code"] == 0, rsp
+        self.collection_client.wait_load_completed(name, timeout=60)
+
+        rows = [_gen_struct_array_row(i, num_elems=random.randint(2, 5), dim=dim) for i in range(nb)]
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": rows})
+        assert rsp["code"] == 0, rsp
+        self.collection_client.flush(name)
+        self.collection_client.wait_load_completed(name, timeout=60)
+        return rows
+
+    def test_element_level_sub_vector_search(self):
+        name = gen_collection_name()
+        nq = 2
+        self._setup_collection_with_sub_index(name)
+
+        search_payload = {
+            "collectionName": name,
+            "annsField": "my_struct[sub_vec]",
+            "data": [_rand_struct_array_vector() for _ in range(nq)],
+            "limit": 5,
+            "outputFields": ["id"],
+        }
+        rsp = self.vector_client.vector_search(search_payload)
+        assert rsp["code"] == 0, rsp
+        assert len(rsp["data"]) > 0, rsp
+
+    def test_embedding_list_sub_vector_search(self):
+        name = gen_collection_name()
+        nq = 2
+        per_query_vecs = 3
+        self._setup_collection_with_sub_index(name, sub_metric="MAX_SIM_COSINE")
+
+        search_payload = {
+            "collectionName": name,
+            "annsField": "my_struct[sub_vec]",
+            "data": [[_rand_struct_array_vector() for _ in range(per_query_vecs)] for _ in range(nq)],
+            "limit": 5,
+            "outputFields": ["id"],
+        }
+        rsp = self.vector_client.vector_search(search_payload)
+        assert rsp["code"] == 0, rsp
+        assert len(rsp["data"]) > 0, rsp
+
+    def test_sub_vector_search_dim_mismatch(self):
+        name = gen_collection_name()
+        self._setup_collection_with_sub_index(name)
+
+        search_payload = {
+            "collectionName": name,
+            "annsField": "my_struct[sub_vec]",
+            "data": [_rand_struct_array_vector(DEFAULT_STRUCT_ARRAY_DIM + 1)],
+            "limit": 5,
+        }
+        rsp = self.vector_client.vector_search(search_payload)
+        assert rsp["code"] != 0, rsp
+
+    def test_embedding_list_search_dim_mismatch(self):
+        name = gen_collection_name()
+        self._setup_collection_with_sub_index(name, sub_metric="MAX_SIM_COSINE")
+
+        search_payload = {
+            "collectionName": name,
+            "annsField": "my_struct[sub_vec]",
+            "data": [
+                [
+                    _rand_struct_array_vector(DEFAULT_STRUCT_ARRAY_DIM + 1),
+                    _rand_struct_array_vector(DEFAULT_STRUCT_ARRAY_DIM + 1),
+                ]
+            ],
+            "limit": 5,
+        }
+        rsp = self.vector_client.vector_search(search_payload)
+        assert rsp["code"] != 0, rsp
+
+
+@pytest.mark.L0
+class TestStructSubVectorSearchOneStep(TestBase):
+    def _create_load_insert(self, name, sub_metric, nb=50):
+        payload = _build_struct_array_schema_payload(
+            name,
+            include_index_params=True,
+            sub_metric_type=sub_metric,
+        )
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+        self.collection_client.wait_load_completed(name, timeout=60)
+
+        rows = [_gen_struct_array_row(i, num_elems=random.randint(2, 4)) for i in range(nb)]
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": rows})
+        assert rsp["code"] == 0, rsp
+        self.collection_client.flush(name)
+        self.collection_client.wait_load_completed(name, timeout=60)
+
+    def test_create_with_sub_vector_index_element_level(self):
+        name = gen_collection_name()
+        self._create_load_insert(name, sub_metric="COSINE")
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": name,
+                "annsField": "my_struct[sub_vec]",
+                "data": [_rand_struct_array_vector()],
+                "limit": 5,
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert len(rsp["data"]) > 0, rsp
+
+    def test_create_with_sub_vector_index_embedding_list(self):
+        name = gen_collection_name()
+        self._create_load_insert(name, sub_metric="MAX_SIM_COSINE")
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": name,
+                "annsField": "my_struct[sub_vec]",
+                "data": [
+                    [
+                        _rand_struct_array_vector(),
+                        _rand_struct_array_vector(),
+                        _rand_struct_array_vector(),
+                    ]
+                ],
+                "limit": 5,
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert len(rsp["data"]) > 0, rsp
+
+    def test_create_with_unknown_sub_field_rejected(self):
+        name = gen_collection_name()
+        payload = _build_struct_array_schema_payload(name, include_index_params=False)
+        payload["indexParams"] = [
+            {"fieldName": "vec", "indexName": "vec_idx", "metricType": "L2"},
+            {
+                "fieldName": "my_struct[no_such_sub]",
+                "indexName": "bad",
+                "metricType": "L2",
+            },
+        ]
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] != 0, rsp
+        assert "hasn't defined in schema" in rsp.get("message", ""), rsp


### PR DESCRIPTION
## What changed

- Backport RESTful v2 StructArray schema, insert/upsert, and search support from master.
- Backport Python client coverage for embedding-list index/vector matrices, partial update, import/BulkWriter, and supported hybrid-search behavior.
- Update the 2.6 Python test dependency to `pymilvus==2.6.17rc11` and align negative-case assertions with 2.6 server messages.
- Keep capabilities not supported by 2.6 out of scope, including Nullable StructArray fields and AddCollectionStructField.

## Why

The 2.6 server supports the selected StructArray capabilities, but RESTful v2 support and the corresponding regression coverage were missing from the 2.6 branch.

## User impact

RESTful v2 clients can use the supported StructArray schema/data/search paths on 2.6, with Python and Go SDK end-to-end coverage guarding the existing server behavior.

## Validation

- RESTful v2 E2E: 19 passed.
- Go SDK StructArray E2E: 13 passed.
- Python client StructArray E2E: 58 passed, including partial update, index/vector variants, hybrid negative cases, CSV/JSON/JSONL/Parquet import, and LocalBulkWriter.
- The tested Milvus image reported branch `struct_array_test_cp_2.6` and commit `ff710cd` for the server-code head; the final `994610bcae` commit contains test-only compatibility adjustments.

issue: #45496

pr: #49165

pr: #48616

pr: #50795

pr: #51166
