### PR TITLE
fix: roll back file resource refs on download failure

### DIFF
--- a/internal/util/fileresource/manager.go
+++ b/internal/util/fileresource/manager.go
@@ -281,6 +281,12 @@ func (m *RefManager) Download(ctx context.Context, downloader storage.ChunkManag
 		m.ref[key] += 1
 	}
 	m.Unlock()
+	downloaded := false
+	defer func() {
+		if !downloaded {
+			m.Release(resources...)
+		}
+	}()
 
 	for _, r := range resources {
 		resource := r
@@ -326,6 +332,7 @@ func (m *RefManager) Download(ctx context.Context, downloader storage.ChunkManag
 			return err
 		}
 	}
+	downloaded = true
 	return nil
 }
 

--- a/internal/util/fileresource/manager_test.go
+++ b/internal/util/fileresource/manager_test.go
@@ -309,6 +309,34 @@ func (suite *RefManagerSuite) TestNormal() {
 	suite.NoFileExists(filePath)
 }
 
+func (suite *RefManagerSuite) TestDownloadErrorRollsBackReferences() {
+	const rootPath = "/test/storage"
+	resources := []*internalpb.FileResourceInfo{
+		{Id: 1, Name: "test1", Path: "/storage/test1.file"},
+		{Id: 2, Name: "test2", Path: "/storage/test2.file"},
+	}
+
+	suite.mockStorage.EXPECT().RootPath().Return(rootPath)
+	suite.mockStorage.EXPECT().Reader(context.Background(), resources[0].GetPath()).Return(newMockReader("test content"), nil)
+	suite.mockStorage.EXPECT().Reader(context.Background(), resources[1].GetPath()).Return(nil, io.ErrUnexpectedEOF)
+
+	err := suite.manager.Download(context.Background(), suite.mockStorage, resources...)
+	suite.ErrorIs(err, io.ErrUnexpectedEOF)
+
+	firstKey := fmt.Sprintf("%s/%d", rootPath, resources[0].GetId())
+	secondKey := fmt.Sprintf("%s/%d", rootPath, resources[1].GetId())
+	suite.Equal(0, suite.manager.ref[firstKey])
+	suite.Equal(0, suite.manager.ref[secondKey])
+
+	firstFilePath := path.Join(suite.tempDir, firstKey, path.Base(resources[0].GetPath()))
+	suite.FileExists(firstFilePath)
+
+	suite.manager.CleanResource()
+	suite.NotContains(suite.manager.ref, firstKey)
+	suite.NotContains(suite.manager.ref, secondKey)
+	suite.NoFileExists(firstFilePath)
+}
+
 func (suite *RefManagerSuite) TestMode() {
 	mode := suite.manager.Mode()
 	suite.Equal(RefMode, mode)


### PR DESCRIPTION
issue: #51407

## What this PR does

- Roll back the full batch of file resource reference reservations when `RefManager.Download` fails.
- Keep successful download ownership unchanged so callers release references after use.
- Add a regression test covering a multi-resource batch that fails after a partial download.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/fileresource`
- `make static-check`