### PR TITLE
fix: [Catalog] retry transient TiKV write transaction failures

### DIFF
--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -62,6 +62,40 @@ const (
 
 var Params *paramtable.ComponentParam = paramtable.Get()
 
+var (
+	// errPredicateNotMet marks deterministic predicate mismatches inside write transaction builds.
+	errPredicateNotMet = errors.New("predicate not met")
+	errBuildAbort      = errors.New("deterministic build error")
+)
+
+func wrapWriteBuildErr(reason string, err error) error {
+	wrapped := merr.WrapErrIoFailedReason(reason, err.Error())
+	if isLocalMutationValidationErr(err) {
+		return markBuildAbort(wrapped)
+	}
+	return wrapped
+}
+
+func markPredicateNotMet(err error) error {
+	return markBuildAbort(errors.Mark(err, errPredicateNotMet))
+}
+
+func markBuildAbort(err error) error {
+	return errors.Mark(err, errBuildAbort)
+}
+
+func isLocalMutationValidationErr(err error) bool {
+	var keyTooLarge *tikverr.ErrKeyTooLarge
+	if errors.As(err, &keyTooLarge) {
+		return true
+	}
+	var entryTooLarge *tikverr.ErrEntryTooLarge
+	if errors.As(err, &entryTooLarge) {
+		return true
+	}
+	return errors.Is(err, tikverr.ErrCannotSetNilValue)
+}
+
 // For reads by prefix we can customize the scan size to increase/decrease rpc calls.
 var SnapshotScanSize int
 
@@ -356,7 +390,7 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 			}
 			// Save the value within a transaction
 			if err = txn.Set([]byte(key), byteValue); err != nil {
-				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSave()", key, value), err.Error())
+				return wrapWriteBuildErr(fmt.Sprintf("Failed to set (%s:%s) for MultiSave()", key, value), err)
 			}
 		}
 		return nil
@@ -394,7 +428,7 @@ func (kv *txnTiKV) MultiRemove(ctx context.Context, keys []string) error {
 		for _, key := range keys {
 			key = kv.GetPath(key)
 			if err := txn.Delete([]byte(key)); err != nil {
-				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to delete %s for MultiRemove", key), err.Error())
+				return wrapWriteBuildErr(fmt.Sprintf("Failed to delete %s for MultiRemove", key), err)
 			}
 		}
 		return nil
@@ -446,17 +480,20 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 			key := kv.GetPath(pred.Key())
 			val, err := txn.Get(ctx, []byte(key))
 			if err != nil {
+				if errors.Is(err, tikverr.ErrNotExist) {
+					return markPredicateNotMet(merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()), err.Error()))
+				}
 				return merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()), err.Error())
 			}
 			if !pred.IsTrue(val.Value) {
-				return merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue()))
+				return markPredicateNotMet(merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue())))
 			}
 		}
 
 		for _, key := range removals {
 			key = kv.GetPath(key)
 			if err := txn.Delete([]byte(key)); err != nil {
-				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemove", key), err.Error())
+				return wrapWriteBuildErr(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemove", key), err)
 			}
 		}
 
@@ -468,7 +505,7 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 				return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemove", key, value))
 			}
 			if err = txn.Set([]byte(key), byteValue); err != nil {
-				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemove", key, value), err.Error())
+				return wrapWriteBuildErr(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemove", key, value), err)
 			}
 		}
 		return nil
@@ -494,37 +531,46 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 			key := kv.GetPath(pred.Key())
 			val, err := txn.Get(ctx, []byte(key))
 			if err != nil {
+				if errors.Is(err, tikverr.ErrNotExist) {
+					return markPredicateNotMet(merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()), err.Error()))
+				}
 				return merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()), err.Error())
 			}
 			if !pred.IsTrue(val.Value) {
-				return merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue()))
+				return markPredicateNotMet(merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue())))
 			}
 		}
 
 		// Remove keys with prefix
 		for _, prefix := range removals {
 			prefix = kv.GetPath(prefix)
-			// Get the start and end keys for the prefix range
-			startKey := []byte(prefix)
-			endKey := tikv.PrefixNextKey([]byte(prefix))
+			if err := func(prefix string) error {
+				// Get the start and end keys for the prefix range
+				startKey := []byte(prefix)
+				endKey := tikv.PrefixNextKey([]byte(prefix))
 
-			// Use Scan to iterate over keys in the prefix range
-			iter, err := txn.Iter(startKey, endKey)
-			if err != nil {
-				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create iterater for %s during MultiSaveAndRemoveWithPrefix()", prefix), err.Error())
-			}
-
-			// Iterate over keys and delete them
-			for iter.Valid() {
-				key := iter.Key()
-				if err = txn.Delete(key); err != nil {
-					return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveWithPrefix", string(key)), err.Error())
+				// Use Scan to iterate over keys in the prefix range
+				iter, err := txn.Iter(startKey, endKey)
+				if err != nil {
+					return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create iterater for %s during MultiSaveAndRemoveWithPrefix()", prefix), err.Error())
 				}
+				defer iter.Close()
 
-				// Move the iterator to the next key
-				if err = iter.Next(); err != nil {
-					return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to move Iterator after key %s for MultiSaveAndRemoveWithPrefix", string(key)), err.Error())
+				// Iterate over keys and delete them
+				for iter.Valid() {
+					key := iter.Key()
+					if err = txn.Delete(key); err != nil {
+						return wrapWriteBuildErr(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveWithPrefix", string(key)), err)
+					}
+
+					// Move the iterator to the next key
+					if err = iter.Next(); err != nil {
+						return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to move Iterator after key %s for MultiSaveAndRemoveWithPrefix", string(key)), err.Error())
+					}
 				}
+				return nil
+			}(prefix); err != nil {
+				return err
 			}
 		}
 
@@ -537,7 +583,7 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 				return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value))
 			}
 			if err = txn.Set([]byte(key), byteValue); err != nil {
-				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value), err.Error())
+				return wrapWriteBuildErr(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value), err)
 			}
 		}
 		return nil
@@ -596,17 +642,20 @@ func (kv *txnTiKV) WalkWithPrefix(ctx context.Context, prefix string, pagination
 // runWriteTxnWithRetry begins a transaction, applies build to it and commits,
 // retrying the whole cycle on transient failures (see writeTxnRetryAttempts).
 // All mutations in this file are idempotent, so re-committing after an
-// undetermined commit result is safe. Errors returned by build itself (bad
-// input, unmet predicate) are deterministic and are not retried; they are
-// returned to the caller unwrapped. The commit function is passed in so that
-// callers keep their existing metrics accounting (executeTxn vs raw commitTxn);
-// note the asymmetry under retry: Multi* methods commit via executeTxn, whose
-// MetaTxnLabel counters fire once per attempt, while Save/Remove aggregate
-// their MetaPut/MetaRemove counters once per logical call after all retries.
+// undetermined commit result is safe. Deterministic build failures (bad input,
+// unmet predicates, missing predicate targets, local TiKV mutation validation)
+// abort immediately; transient IO errors from build reads are retried like
+// begin/commit failures. Build errors are returned to the caller unwrapped. The
+// commit function is passed in so that callers keep their existing metrics
+// accounting (executeTxn vs raw commitTxn); note the asymmetry under retry:
+// Multi* methods commit via executeTxn, whose MetaTxnLabel counters fire once
+// per attempt, while Save/Remove aggregate their MetaPut/MetaRemove counters
+// once per logical call after all retries.
 func (kv *txnTiKV) runWriteTxnWithRetry(ctx context.Context, op string, build func(txn *transaction.KVTxn) error, commit func(ctx context.Context, txn *transaction.KVTxn) error) error {
 	var buildErr error
 	err := retry.Do(ctx, func() error {
 		var attemptErr error
+		buildErr = nil
 		txn, err := beginTxn(kv.txn)
 		if err != nil {
 			return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create txn for %s", op), err.Error())
@@ -616,7 +665,10 @@ func (kv *txnTiKV) runWriteTxnWithRetry(ctx context.Context, op string, build fu
 
 		if buildErr = build(txn); buildErr != nil {
 			attemptErr = buildErr
-			return retry.Unrecoverable(buildErr)
+			if errors.Is(buildErr, errBuildAbort) {
+				return retry.Unrecoverable(buildErr)
+			}
+			return buildErr
 		}
 		if err := commit(ctx, txn); err != nil {
 			attemptErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to commit for %s", op), err.Error())
@@ -693,7 +745,7 @@ func (kv *txnTiKV) putTiKVMeta(ctx context.Context, key, val string) error {
 
 	err = kv.runWriteTxnWithRetry(ctx1, "putTiKVMeta", func(txn *transaction.KVTxn) error {
 		if err := txn.Set([]byte(key), byteValue); err != nil {
-			return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set value for key %s in putTiKVMeta", key), err.Error())
+			return wrapWriteBuildErr(fmt.Sprintf("Failed to set value for key %s in putTiKVMeta", key), err)
 		}
 		return nil
 	}, commitTxn)
@@ -719,7 +771,7 @@ func (kv *txnTiKV) removeTiKVMeta(ctx context.Context, key string) error {
 
 	err := kv.runWriteTxnWithRetry(ctx1, "removeTiKVMeta", func(txn *transaction.KVTxn) error {
 		if err := txn.Delete([]byte(key)); err != nil {
-			return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to remove key %s in removeTiKVMeta", key), err.Error())
+			return wrapWriteBuildErr(fmt.Sprintf("Failed to remove key %s in removeTiKVMeta", key), err)
 		}
 		return nil
 	}, commitTxn)

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -67,6 +68,19 @@ var SnapshotScanSize int
 // defaultRequestTimeout is the default timeout for tikv request.
 const (
 	defaultRequestTimeout = 10 * time.Second
+)
+
+// Write transactions are rebuilt and retried on transient TiKV failures.
+// Region errors (e.g. epoch_not_match after a region split, or a briefly
+// unreachable store) escape txn.Commit() as plain errors once client-go's
+// internal backoff budget is exhausted, and a failed KVTxn cannot be reused,
+// so the retry must re-run the whole transaction on a fresh region cache.
+// Bounded by the per-call requestTimeout context; a persistently failing
+// call spends up to ~6s in backoff sleep before surfacing the error.
+// Declared as vars so tests injecting persistent failures can lower them.
+var (
+	writeTxnRetryAttempts = uint(5)
+	writeTxnRetrySleep    = 200 * time.Millisecond
 )
 
 var EmptyValueByte = []byte(EmptyValueString)
@@ -332,33 +346,22 @@ func (kv *txnTiKV) MultiSave(ctx context.Context, kvs map[string]string) error {
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSave() error", mlog.Any("kvs", kvs), mlog.Int("len", len(kvs)))
 
-	txn, err := beginTxn(kv.txn)
-	if err != nil {
-		loggingErr = merr.WrapErrIoFailedReason("Failed to create txn for MultiSave", err.Error())
-		return loggingErr
-	}
-
-	// Defer a rollback only if the transaction hasn't been committed
-	defer rollbackOnFailure(&loggingErr, txn)
-
-	for key, value := range kvs {
-		key = kv.GetPath(key)
-		// Check if value is empty or taking reserved EmptyValue
-		byteValue, err := convertEmptyStringToByte(value)
-		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSave()", key, value))
-			return loggingErr
+	loggingErr = kv.runWriteTxnWithRetry(ctx, "MultiSave()", func(txn *transaction.KVTxn) error {
+		for key, value := range kvs {
+			key = kv.GetPath(key)
+			// Check if value is empty or taking reserved EmptyValue
+			byteValue, err := convertEmptyStringToByte(value)
+			if err != nil {
+				return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSave()", key, value))
+			}
+			// Save the value within a transaction
+			if err = txn.Set([]byte(key), byteValue); err != nil {
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSave()", key, value), err.Error())
+			}
 		}
-		// Save the value within a transaction
-		err = txn.Set([]byte(key), byteValue)
-		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSave()", key, value), err.Error())
-			return loggingErr
-		}
-	}
-	err = kv.executeTxn(ctx, txn)
-	if err != nil {
-		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiSave()", err.Error())
+		return nil
+	}, kv.executeTxn)
+	if loggingErr != nil {
 		return loggingErr
 	}
 	CheckElapseAndWarn(start, "Slow txnTiKV MultiSave() operation", mlog.Any("kvs", kvs))
@@ -387,27 +390,16 @@ func (kv *txnTiKV) MultiRemove(ctx context.Context, keys []string) error {
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiRemove() error", mlog.Strings("keys", keys), mlog.Int("len", len(keys)))
 
-	txn, err := beginTxn(kv.txn)
-	if err != nil {
-		loggingErr = merr.WrapErrIoFailedReason("Failed to create txn for MultiRemove", err.Error())
-		return loggingErr
-	}
-
-	// Defer a rollback only if the transaction hasn't been committed
-	defer rollbackOnFailure(&loggingErr, txn)
-
-	for _, key := range keys {
-		key = kv.GetPath(key)
-		err = txn.Delete([]byte(key))
-		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to delete %s for MultiRemove", key), err.Error())
-			return loggingErr
+	loggingErr = kv.runWriteTxnWithRetry(ctx, "MultiRemove()", func(txn *transaction.KVTxn) error {
+		for _, key := range keys {
+			key = kv.GetPath(key)
+			if err := txn.Delete([]byte(key)); err != nil {
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to delete %s for MultiRemove", key), err.Error())
+			}
 		}
-	}
-
-	err = kv.executeTxn(ctx, txn)
-	if err != nil {
-		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiRemove()", err.Error())
+		return nil
+	}, kv.executeTxn)
+	if loggingErr != nil {
 		return loggingErr
 	}
 	CheckElapseAndWarn(start, "Slow txnTiKV MultiRemove() operation", mlog.Strings("keys", keys))
@@ -444,59 +436,44 @@ func (kv *txnTiKV) MultiSaveAndRemove(ctx context.Context, saves map[string]stri
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemove error", mlog.Any("saves", saves), mlog.Strings("removes", removals), mlog.Int("saveLength", len(saves)), mlog.Int("removeLength", len(removals)))
 
-	txn, err := beginTxn(kv.txn)
-	if err != nil {
-		loggingErr = merr.WrapErrIoFailedReason("Failed to create txn for MultiSaveAndRemove", err.Error())
-		return loggingErr
-	}
-
-	// Defer a rollback only if the transaction hasn't been committed
-	defer rollbackOnFailure(&loggingErr, txn)
-
-	for _, pred := range preds {
-		key := kv.GetPath(pred.Key())
-		val, err := txn.Get(ctx, []byte(key))
-		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()), err.Error())
-			return loggingErr
-		}
-		if !pred.IsTrue(val.Value) {
-			loggingErr = merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue()))
-			return loggingErr
-		}
-	}
-
 	// use complement to remove keys that are not in saves
 	saveKeys := typeutil.NewSet(lo.Keys(saves)...)
 	removeKeys := typeutil.NewSet(removals...)
 	removals = removeKeys.Complement(saveKeys).Collect()
 
-	for _, key := range removals {
-		key = kv.GetPath(key)
-		if err = txn.Delete([]byte(key)); err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemove", key), err.Error())
-			return loggingErr
+	loggingErr = kv.runWriteTxnWithRetry(ctx, "MultiSaveAndRemove", func(txn *transaction.KVTxn) error {
+		for _, pred := range preds {
+			key := kv.GetPath(pred.Key())
+			val, err := txn.Get(ctx, []byte(key))
+			if err != nil {
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()), err.Error())
+			}
+			if !pred.IsTrue(val.Value) {
+				return merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue()))
+			}
 		}
-	}
 
-	for key, value := range saves {
-		key = kv.GetPath(key)
-		// Check if value is empty or taking reserved EmptyValue
-		byteValue, err := convertEmptyStringToByte(value)
-		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemove", key, value))
-			return loggingErr
+		for _, key := range removals {
+			key = kv.GetPath(key)
+			if err := txn.Delete([]byte(key)); err != nil {
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemove", key), err.Error())
+			}
 		}
-		err = txn.Set([]byte(key), byteValue)
-		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemove", key, value), err.Error())
-			return loggingErr
-		}
-	}
 
-	err = kv.executeTxn(ctx, txn)
-	if err != nil {
-		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiSaveAndRemove", err.Error())
+		for key, value := range saves {
+			key = kv.GetPath(key)
+			// Check if value is empty or taking reserved EmptyValue
+			byteValue, err := convertEmptyStringToByte(value)
+			if err != nil {
+				return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemove", key, value))
+			}
+			if err = txn.Set([]byte(key), byteValue); err != nil {
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemove", key, value), err.Error())
+			}
+		}
+		return nil
+	}, kv.executeTxn)
+	if loggingErr != nil {
 		return loggingErr
 	}
 	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemove() operation", mlog.Any("saves", saves), mlog.Strings("removals", removals))
@@ -512,79 +489,60 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV MultiSaveAndRemoveWithPrefix() error", mlog.Any("saves", saves), mlog.Strings("removes", removals), mlog.Int("saveLength", len(saves)), mlog.Int("removeLength", len(removals)))
 
-	txn, err := beginTxn(kv.txn)
-	if err != nil {
-		loggingErr = merr.WrapErrIoFailedReason("Failed to create txn for MultiSaveAndRemoveWithPrefix", err.Error())
-		return loggingErr
-	}
-
-	// Defer a rollback only if the transaction hasn't been committed
-	defer rollbackOnFailure(&loggingErr, txn)
-
-	for _, pred := range preds {
-		key := kv.GetPath(pred.Key())
-		val, err := txn.Get(ctx, []byte(key))
-		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()), err.Error())
-			return loggingErr
-		}
-		if !pred.IsTrue(val.Value) {
-			loggingErr = merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue()))
-			return loggingErr
-		}
-	}
-
-	// Remove keys with prefix
-	for _, prefix := range removals {
-		prefix = kv.GetPath(prefix)
-		// Get the start and end keys for the prefix range
-		startKey := []byte(prefix)
-		endKey := tikv.PrefixNextKey([]byte(prefix))
-
-		// Use Scan to iterate over keys in the prefix range
-		iter, err := txn.Iter(startKey, endKey)
-		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create iterater for %s during MultiSaveAndRemoveWithPrefix()", prefix), err.Error())
-			return loggingErr
-		}
-
-		// Iterate over keys and delete them
-		for iter.Valid() {
-			key := iter.Key()
-			err = txn.Delete(key)
-			if loggingErr != nil {
-				loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveWithPrefix", string(key)), err.Error())
-				return loggingErr
-			}
-
-			// Move the iterator to the next key
-			err = iter.Next()
+	loggingErr = kv.runWriteTxnWithRetry(ctx, "MultiSaveAndRemoveWithPrefix", func(txn *transaction.KVTxn) error {
+		for _, pred := range preds {
+			key := kv.GetPath(pred.Key())
+			val, err := txn.Get(ctx, []byte(key))
 			if err != nil {
-				loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to move Iterator after key %s for MultiSaveAndRemoveWithPrefix", string(key)), err.Error())
-				return loggingErr
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("failed to read predicate target (%s:%v) for MultiSaveAndRemove", pred.Key(), pred.TargetValue()), err.Error())
+			}
+			if !pred.IsTrue(val.Value) {
+				return merr.WrapErrIoFailedReason("failed to meet predicate", fmt.Sprintf("key=%s, value=%v", pred.Key(), pred.TargetValue()))
 			}
 		}
-	}
 
-	// Save key-value pairs
-	for key, value := range saves {
-		key = kv.GetPath(key)
-		// Check if value is empty or taking reserved EmptyValue
-		byteValue, err := convertEmptyStringToByte(value)
-		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value))
-			return loggingErr
-		}
-		err = txn.Set([]byte(key), byteValue)
-		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value), err.Error())
-			return loggingErr
-		}
-	}
+		// Remove keys with prefix
+		for _, prefix := range removals {
+			prefix = kv.GetPath(prefix)
+			// Get the start and end keys for the prefix range
+			startKey := []byte(prefix)
+			endKey := tikv.PrefixNextKey([]byte(prefix))
 
-	err = kv.executeTxn(ctx, txn)
-	if err != nil {
-		loggingErr = merr.WrapErrIoFailedReason("Failed to commit for MultiSaveAndRemoveWithPrefix", err.Error())
+			// Use Scan to iterate over keys in the prefix range
+			iter, err := txn.Iter(startKey, endKey)
+			if err != nil {
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create iterater for %s during MultiSaveAndRemoveWithPrefix()", prefix), err.Error())
+			}
+
+			// Iterate over keys and delete them
+			for iter.Valid() {
+				key := iter.Key()
+				if err = txn.Delete(key); err != nil {
+					return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveWithPrefix", string(key)), err.Error())
+				}
+
+				// Move the iterator to the next key
+				if err = iter.Next(); err != nil {
+					return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to move Iterator after key %s for MultiSaveAndRemoveWithPrefix", string(key)), err.Error())
+				}
+			}
+		}
+
+		// Save key-value pairs
+		for key, value := range saves {
+			key = kv.GetPath(key)
+			// Check if value is empty or taking reserved EmptyValue
+			byteValue, err := convertEmptyStringToByte(value)
+			if err != nil {
+				return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value))
+			}
+			if err = txn.Set([]byte(key), byteValue); err != nil {
+				return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set (%s:%s) for MultiSaveAndRemoveWithPrefix()", key, value), err.Error())
+			}
+		}
+		return nil
+	}, kv.executeTxn)
+	if loggingErr != nil {
 		return loggingErr
 	}
 	CheckElapseAndWarn(start, "Slow txnTiKV MultiSaveAndRemoveWithPrefix() operation", mlog.Any("saves", saves), mlog.Strings("removals", removals))
@@ -633,6 +591,43 @@ func (kv *txnTiKV) WalkWithPrefix(ctx context.Context, prefix string, pagination
 	}
 	CheckElapseAndWarn(start, "Slow txnTiKV WalkWithPagination() operation", mlog.String("prefix", prefix))
 	return nil
+}
+
+// runWriteTxnWithRetry begins a transaction, applies build to it and commits,
+// retrying the whole cycle on transient failures (see writeTxnRetryAttempts).
+// All mutations in this file are idempotent, so re-committing after an
+// undetermined commit result is safe. Errors returned by build itself (bad
+// input, unmet predicate) are deterministic and are not retried; they are
+// returned to the caller unwrapped. The commit function is passed in so that
+// callers keep their existing metrics accounting (executeTxn vs raw commitTxn);
+// note the asymmetry under retry: Multi* methods commit via executeTxn, whose
+// MetaTxnLabel counters fire once per attempt, while Save/Remove aggregate
+// their MetaPut/MetaRemove counters once per logical call after all retries.
+func (kv *txnTiKV) runWriteTxnWithRetry(ctx context.Context, op string, build func(txn *transaction.KVTxn) error, commit func(ctx context.Context, txn *transaction.KVTxn) error) error {
+	var buildErr error
+	err := retry.Do(ctx, func() error {
+		var attemptErr error
+		txn, err := beginTxn(kv.txn)
+		if err != nil {
+			return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create txn for %s", op), err.Error())
+		}
+		// Defer a rollback only if the transaction hasn't been committed
+		defer rollbackOnFailure(&attemptErr, txn)
+
+		if buildErr = build(txn); buildErr != nil {
+			attemptErr = buildErr
+			return retry.Unrecoverable(buildErr)
+		}
+		if err := commit(ctx, txn); err != nil {
+			attemptErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to commit for %s", op), err.Error())
+			return attemptErr
+		}
+		return nil
+	}, retry.Attempts(writeTxnRetryAttempts), retry.Sleep(writeTxnRetrySleep))
+	if buildErr != nil {
+		return buildErr
+	}
+	return err
 }
 
 func (kv *txnTiKV) executeTxn(ctx context.Context, txn *transaction.KVTxn) error {
@@ -690,23 +685,18 @@ func (kv *txnTiKV) putTiKVMeta(ctx context.Context, key, val string) error {
 
 	start := timerecord.NewTimeRecorder("putTiKVMeta")
 
-	txn, err := beginTxn(kv.txn)
-	if err != nil {
-		return merr.WrapErrIoFailedReason("Failed to build transaction for putTiKVMeta", err.Error())
-	}
-	// Defer a rollback only if the transaction hasn't been committed
-	defer rollbackOnFailure(&err, txn)
-
 	// Check if the value being written needs to be empty placeholder
 	byteValue, err := convertEmptyStringToByte(val)
 	if err != nil {
 		return merr.Wrap(err, fmt.Sprintf("Failed to cast to byte (%s:%s) for putTiKVMeta", key, val))
 	}
-	err = txn.Set([]byte(key), byteValue)
-	if err != nil {
-		return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set value for key %s in putTiKVMeta", key), err.Error())
-	}
-	err = commitTxn(ctx1, txn)
+
+	err = kv.runWriteTxnWithRetry(ctx1, "putTiKVMeta", func(txn *transaction.KVTxn) error {
+		if err := txn.Set([]byte(key), byteValue); err != nil {
+			return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to set value for key %s in putTiKVMeta", key), err.Error())
+		}
+		return nil
+	}, commitTxn)
 
 	elapsed := start.ElapseSpan()
 	metrics.MetaOpCounter.WithLabelValues(metrics.MetaPutLabel, metrics.TotalLabel).Inc()
@@ -727,18 +717,12 @@ func (kv *txnTiKV) removeTiKVMeta(ctx context.Context, key string) error {
 
 	start := timerecord.NewTimeRecorder("removeTiKVMeta")
 
-	txn, err := beginTxn(kv.txn)
-	if err != nil {
-		return merr.WrapErrIoFailedReason("Failed to build transaction for removeTiKVMeta", err.Error())
-	}
-	// Defer a rollback only if the transaction hasn't been committed
-	defer rollbackOnFailure(&err, txn)
-
-	err = txn.Delete([]byte(key))
-	if err != nil {
-		return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to remove key %s in removeTiKVMeta", key), err.Error())
-	}
-	err = commitTxn(ctx1, txn)
+	err := kv.runWriteTxnWithRetry(ctx1, "removeTiKVMeta", func(txn *transaction.KVTxn) error {
+		if err := txn.Delete([]byte(key)); err != nil {
+			return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to remove key %s in removeTiKVMeta", key), err.Error())
+		}
+		return nil
+	}, commitTxn)
 
 	elapsed := start.ElapseSpan()
 	metrics.MetaOpCounter.WithLabelValues(metrics.MetaRemoveLabel, metrics.TotalLabel).Inc()

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -109,8 +109,11 @@ const (
 // unreachable store) escape txn.Commit() as plain errors once client-go's
 // internal backoff budget is exhausted, and a failed KVTxn cannot be reused,
 // so the retry must re-run the whole transaction on a fresh region cache.
-// Bounded by the per-call requestTimeout context; a persistently failing
-// call spends up to ~6s in backoff sleep before surfacing the error.
+// Commit is bounded by the per-call requestTimeout context. The begin-phase
+// startTS fetch is not; client-go may spend up to its TSO backoff budget
+// (~15s) before returning. retry.Do checks the deadline between attempts, so
+// a persistently failing call can spend approximately one overlong begin
+// attempt past requestTimeout but will not start another retry afterward.
 // Declared as vars so tests injecting persistent failures can lower them.
 var (
 	writeTxnRetryAttempts = uint(5)
@@ -641,21 +644,24 @@ func (kv *txnTiKV) WalkWithPrefix(ctx context.Context, prefix string, pagination
 
 // runWriteTxnWithRetry begins a transaction, applies build to it and commits,
 // retrying the whole cycle on transient failures (see writeTxnRetryAttempts).
-// All mutations in this file are idempotent, so re-committing after an
-// undetermined commit result is safe. Deterministic build failures (bad input,
-// unmet predicates, missing predicate targets, local TiKV mutation validation)
-// abort immediately; transient IO errors from build reads are retried like
-// begin/commit failures. Build errors are returned to the caller unwrapped. The
-// commit function is passed in so that callers keep their existing metrics
-// accounting (executeTxn vs raw commitTxn); note the asymmetry under retry:
+// Undetermined commit results and caller cancellation abort immediately with
+// the original error preserved; only classified-transient commit failures are
+// replayed. Deterministic build failures (bad input, unmet predicates, missing
+// predicate targets, local TiKV mutation validation) abort immediately;
+// transient IO errors from build reads are retried like begin/commit failures.
+// Build errors are returned to the caller unwrapped. The commit function is
+// passed in so that callers keep their existing metrics accounting (executeTxn
+// vs raw commitTxn); note the asymmetry under retry:
 // Multi* methods commit via executeTxn, whose MetaTxnLabel counters fire once
 // per attempt, while Save/Remove aggregate their MetaPut/MetaRemove counters
 // once per logical call after all retries.
 func (kv *txnTiKV) runWriteTxnWithRetry(ctx context.Context, op string, build func(txn *transaction.KVTxn) error, commit func(ctx context.Context, txn *transaction.KVTxn) error) error {
 	var buildErr error
+	var commitAbortErr error
 	err := retry.Do(ctx, func() error {
 		var attemptErr error
 		buildErr = nil
+		commitAbortErr = nil
 		txn, err := beginTxn(kv.txn)
 		if err != nil {
 			return merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create txn for %s", op), err.Error())
@@ -671,6 +677,19 @@ func (kv *txnTiKV) runWriteTxnWithRetry(ctx context.Context, op string, build fu
 			return buildErr
 		}
 		if err := commit(ctx, txn); err != nil {
+			if tikverr.IsErrorUndetermined(err) {
+				commitAbortErr = err
+			} else if ctxErr := ctx.Err(); ctxErr != nil {
+				// client-go backoffers can return the last real error instead
+				// of ctx.Err() when the caller context dies mid-commit.
+				commitAbortErr = ctxErr
+			} else if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) {
+				commitAbortErr = err
+			}
+			if commitAbortErr != nil {
+				attemptErr = commitAbortErr
+				return retry.Unrecoverable(commitAbortErr)
+			}
 			attemptErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to commit for %s", op), err.Error())
 			return attemptErr
 		}
@@ -678,6 +697,9 @@ func (kv *txnTiKV) runWriteTxnWithRetry(ctx context.Context, op string, build fu
 	}, retry.Attempts(writeTxnRetryAttempts), retry.Sleep(writeTxnRetrySleep))
 	if buildErr != nil {
 		return buildErr
+	}
+	if commitAbortErr != nil {
+		return commitAbortErr
 	}
 	return err
 }

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/txnkv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 	"golang.org/x/exp/maps"
@@ -746,7 +747,127 @@ func TestWriteTxnRetry(t *testing.T) {
 
 		err := kv.MultiSave(ctx, map[string]string{"retry_key_4": "v4"})
 		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+		assert.True(t, retry.IsRecoverable(err))
 		assert.Equal(t, int(writeTxnRetryAttempts), commits)
+	})
+
+	t.Run("undetermined commit aborts on first attempt", func(t *testing.T) {
+		commits := 0
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return fmt.Errorf("commit failed: %w", tikverr.ErrResultUndetermined)
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.MultiSave(ctx, map[string]string{"undetermined_commit_key": "v"})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, tikverr.ErrResultUndetermined)
+		assert.True(t, retry.IsRecoverable(err))
+		assert.Equal(t, 1, commits)
+	})
+
+	t.Run("undetermined commit wins over transient shape", func(t *testing.T) {
+		commits := 0
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return fmt.Errorf("%w after %w", tikverr.ErrResultUndetermined, tikverr.ErrRegionUnavailable)
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.MultiSave(ctx, map[string]string{"undetermined_region_key": "v"})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, tikverr.ErrResultUndetermined)
+		assert.True(t, retry.IsRecoverable(err))
+		assert.Equal(t, 1, commits)
+	})
+
+	t.Run("undetermined commit wins over caller cancellation", func(t *testing.T) {
+		callerCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		commits := 0
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			cancel()
+			return fmt.Errorf("commit failed: %w", tikverr.ErrResultUndetermined)
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.MultiSave(callerCtx, map[string]string{"undetermined_cancel_key": "v"})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, tikverr.ErrResultUndetermined)
+		assert.True(t, retry.IsRecoverable(err))
+		assert.Equal(t, 1, commits)
+	})
+
+	t.Run("canceled commit aborts and surfaces", func(t *testing.T) {
+		commits := 0
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return context.Canceled
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.MultiSave(ctx, map[string]string{"canceled_commit_key": "v"})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.True(t, retry.IsRecoverable(err))
+		assert.Equal(t, 1, commits)
+	})
+
+	t.Run("mid commit caller cancel aborts with context error", func(t *testing.T) {
+		callerCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		commits := 0
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			cancel()
+			return tikverr.ErrRegionUnavailable
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.MultiSave(callerCtx, map[string]string{"mid_cancel_key": "v"})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.True(t, retry.IsRecoverable(err))
+		assert.Equal(t, 1, commits)
+	})
+
+	t.Run("deadline stops commit retries", func(t *testing.T) {
+		origSleep := writeTxnRetrySleep
+		writeTxnRetrySleep = 200 * time.Millisecond
+		defer func() {
+			writeTxnRetrySleep = origSleep
+		}()
+
+		deadlineCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		defer cancel()
+
+		commits := 0
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return tikverr.ErrRegionUnavailable
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.MultiSave(deadlineCtx, map[string]string{"deadline_commit_key": "v"})
+		assert.Error(t, err)
+		assert.Less(t, commits, int(writeTxnRetryAttempts))
+		assert.GreaterOrEqual(t, commits, 1)
 	})
 
 	t.Run("transient build failure recovers", func(t *testing.T) {

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 )
 
 func TestTiKVLoad(te *testing.T) {
@@ -296,6 +297,11 @@ func TestTiKVLoad(te *testing.T) {
 	})
 
 	te.Run("kv failed to start txn", func(t *testing.T) {
+		origSleep := writeTxnRetrySleep
+		writeTxnRetrySleep = time.Millisecond
+		defer func() {
+			writeTxnRetrySleep = origSleep
+		}()
 		rootPath := "/tikv/test/root/start_exn"
 		kv := NewTiKV(txnClient, rootPath)
 		defer kv.Close()
@@ -321,6 +327,11 @@ func TestTiKVLoad(te *testing.T) {
 	})
 
 	te.Run("kv failed to commit txn", func(t *testing.T) {
+		origSleep := writeTxnRetrySleep
+		writeTxnRetrySleep = time.Millisecond
+		defer func() {
+			writeTxnRetrySleep = origSleep
+		}()
 		rootPath := "/tikv/test/root/commit_txn"
 		kv := NewTiKV(txnClient, rootPath)
 		defer kv.Close()
@@ -639,4 +650,118 @@ func TestTxnWithPredicates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWriteTxnRetry(t *testing.T) {
+	rootPath := "/tikv/test/root/write_txn_retry"
+	kv := NewTiKV(txnClient, rootPath)
+	err := kv.RemoveWithPrefix(context.TODO(), "")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix(context.TODO(), "")
+
+	ctx := context.TODO()
+
+	t.Run("transient commit failure recovers for MultiSave", func(t *testing.T) {
+		fails := 2
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			if fails > 0 {
+				fails--
+				// Simulate a region error escaping client-go after its internal
+				// backoff budget is exhausted (e.g. a region split under load).
+				return errors.New("epoch_not_match:<>")
+			}
+			return tiTxnCommit(ctx, txn)
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.MultiSave(ctx, map[string]string{"retry_key_1": "v1"})
+		assert.NoError(t, err)
+		assert.Zero(t, fails)
+
+		val, err := kv.Load(ctx, "retry_key_1")
+		assert.NoError(t, err)
+		assert.Equal(t, "v1", val)
+	})
+
+	t.Run("transient commit failure recovers for Save", func(t *testing.T) {
+		fails := 1
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			if fails > 0 {
+				fails--
+				return errors.New("epoch_not_match:<>")
+			}
+			return tiTxnCommit(ctx, txn)
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.Save(ctx, "retry_key_2", "v2")
+		assert.NoError(t, err)
+		assert.Zero(t, fails)
+
+		val, err := kv.Load(ctx, "retry_key_2")
+		assert.NoError(t, err)
+		assert.Equal(t, "v2", val)
+	})
+
+	t.Run("transient begin failure recovers", func(t *testing.T) {
+		fails := 1
+		beginTxn = func(txn *txnkv.Client) (*transaction.KVTxn, error) {
+			if fails > 0 {
+				fails--
+				return nil, errors.New("pd timeout")
+			}
+			return tiTxnBegin(txn)
+		}
+		defer func() {
+			beginTxn = tiTxnBegin
+		}()
+
+		err := kv.MultiSave(ctx, map[string]string{"retry_key_3": "v3"})
+		assert.NoError(t, err)
+		assert.Zero(t, fails)
+	})
+
+	t.Run("persistent commit failure still surfaces", func(t *testing.T) {
+		origSleep := writeTxnRetrySleep
+		writeTxnRetrySleep = time.Millisecond
+		defer func() {
+			writeTxnRetrySleep = origSleep
+		}()
+		commits := 0
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return errors.New("epoch_not_match:<>")
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.MultiSave(ctx, map[string]string{"retry_key_4": "v4"})
+		assert.Error(t, err)
+		assert.Equal(t, int(writeTxnRetryAttempts), commits)
+	})
+
+	t.Run("build failure is not retried and not wrapped", func(t *testing.T) {
+		commits := 0
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return tiTxnCommit(ctx, txn)
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		// Reserved empty-value placeholder is rejected while building mutations.
+		err := kv.MultiSave(ctx, map[string]string{"bad_key": EmptyValueString})
+		assert.Error(t, err)
+		assert.Zero(t, commits)
+		// The retry.Unrecoverable marker must not leak to callers.
+		assert.True(t, retry.IsRecoverable(err))
+	})
 }

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 )
 
@@ -747,7 +749,197 @@ func TestWriteTxnRetry(t *testing.T) {
 		assert.Equal(t, int(writeTxnRetryAttempts), commits)
 	})
 
-	t.Run("build failure is not retried and not wrapped", func(t *testing.T) {
+	t.Run("transient build failure recovers", func(t *testing.T) {
+		builds := 0
+		begins := 0
+		commits := 0
+		beginTxn = func(txn *txnkv.Client) (*transaction.KVTxn, error) {
+			begins++
+			return tiTxnBegin(txn)
+		}
+		defer func() {
+			beginTxn = tiTxnBegin
+		}()
+
+		err := kv.runWriteTxnWithRetry(ctx, "test transient build", func(txn *transaction.KVTxn) error {
+			builds++
+			if builds == 1 {
+				return merr.WrapErrIoFailedReason("transient build read", "epoch_not_match")
+			}
+			return nil
+		}, func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return tiTxnCommit(ctx, txn)
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2, builds)
+		assert.Equal(t, 2, begins)
+		assert.Equal(t, 1, commits)
+	})
+
+	t.Run("persistent build failure still surfaces", func(t *testing.T) {
+		origSleep := writeTxnRetrySleep
+		writeTxnRetrySleep = time.Millisecond
+		defer func() {
+			writeTxnRetrySleep = origSleep
+		}()
+
+		builds := 0
+		commits := 0
+		err := kv.runWriteTxnWithRetry(ctx, "test persistent build", func(txn *transaction.KVTxn) error {
+			builds++
+			return merr.WrapErrIoFailedReason("transient build read", "epoch_not_match")
+		}, func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return tiTxnCommit(ctx, txn)
+		})
+
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+		assert.True(t, retry.IsRecoverable(err))
+		assert.Equal(t, int(writeTxnRetryAttempts), builds)
+		assert.Zero(t, commits)
+	})
+
+	t.Run("local mutation validation build failure is not retried", func(t *testing.T) {
+		origSleep := writeTxnRetrySleep
+		writeTxnRetrySleep = time.Millisecond
+		defer func() {
+			writeTxnRetrySleep = origSleep
+		}()
+
+		begins := 0
+		commits := 0
+		beginTxn = func(txn *txnkv.Client) (*transaction.KVTxn, error) {
+			begins++
+			return tiTxnBegin(txn)
+		}
+		defer func() {
+			beginTxn = tiTxnBegin
+		}()
+		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return tiTxnCommit(ctx, txn)
+		}
+		defer func() {
+			commitTxn = tiTxnCommit
+		}()
+
+		err := kv.MultiSave(ctx, map[string]string{strings.Repeat("k", 1<<16): "v"})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+		assert.Contains(t, err.Error(), "key size too large")
+		assert.True(t, retry.IsRecoverable(err))
+		assert.Equal(t, 1, begins)
+		assert.Zero(t, commits)
+	})
+
+	t.Run("later begin failure is not hidden by previous build failure", func(t *testing.T) {
+		origSleep := writeTxnRetrySleep
+		writeTxnRetrySleep = time.Millisecond
+		defer func() {
+			writeTxnRetrySleep = origSleep
+		}()
+
+		begins := 0
+		builds := 0
+		commits := 0
+		beginTxn = func(txn *txnkv.Client) (*transaction.KVTxn, error) {
+			begins++
+			if begins > 1 {
+				return nil, errors.New("pd timeout")
+			}
+			return tiTxnBegin(txn)
+		}
+		defer func() {
+			beginTxn = tiTxnBegin
+		}()
+
+		err := kv.runWriteTxnWithRetry(ctx, "test build then begin", func(txn *transaction.KVTxn) error {
+			builds++
+			return merr.WrapErrIoFailedReason("transient build read", "epoch_not_match")
+		}, func(ctx context.Context, txn *transaction.KVTxn) error {
+			commits++
+			return tiTxnCommit(ctx, txn)
+		})
+
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrIoFailed)
+		assert.Contains(t, err.Error(), "Failed to create txn for test build then begin")
+		assert.Equal(t, int(writeTxnRetryAttempts), begins)
+		assert.Equal(t, 1, builds)
+		assert.Zero(t, commits)
+	})
+
+	t.Run("predicate failure is not retried and not wrapped", func(t *testing.T) {
+		err := kv.MultiSave(ctx, map[string]string{"predicate_key": "1"})
+		require.NoError(t, err)
+
+		for _, test := range []struct {
+			name string
+			run  func() error
+		}{
+			{
+				name: "MultiSaveAndRemoveWrongValue",
+				run: func() error {
+					return kv.MultiSaveAndRemove(ctx, map[string]string{"predicate_save": "v"}, nil, predicates.ValueEqual("predicate_key", "2"))
+				},
+			},
+			{
+				name: "MultiSaveAndRemoveWithPrefixWrongValue",
+				run: func() error {
+					return kv.MultiSaveAndRemoveWithPrefix(ctx, map[string]string{"predicate_prefix_save": "v"}, nil, predicates.ValueEqual("predicate_key", "2"))
+				},
+			},
+			{
+				name: "MultiSaveAndRemoveMissingKey",
+				run: func() error {
+					return kv.MultiSaveAndRemove(ctx, map[string]string{"predicate_missing_save": "v"}, nil, predicates.ValueEqual("predicate_missing_key", "1"))
+				},
+			},
+			{
+				name: "MultiSaveAndRemoveWithPrefixMissingKey",
+				run: func() error {
+					return kv.MultiSaveAndRemoveWithPrefix(ctx, map[string]string{"predicate_missing_prefix_save": "v"}, nil, predicates.ValueEqual("predicate_missing_key", "1"))
+				},
+			},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				origSleep := writeTxnRetrySleep
+				writeTxnRetrySleep = time.Millisecond
+				defer func() {
+					writeTxnRetrySleep = origSleep
+				}()
+
+				begins := 0
+				beginTxn = func(txn *txnkv.Client) (*transaction.KVTxn, error) {
+					begins++
+					return tiTxnBegin(txn)
+				}
+				defer func() {
+					beginTxn = tiTxnBegin
+				}()
+
+				err := test.run()
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, merr.ErrIoFailed)
+				assert.True(t, retry.IsRecoverable(err))
+				assert.Equal(t, 1, begins)
+			})
+		}
+	})
+
+	t.Run("reserved value build failure is not retried and not wrapped", func(t *testing.T) {
+		begins := 0
+		beginTxn = func(txn *txnkv.Client) (*transaction.KVTxn, error) {
+			begins++
+			return tiTxnBegin(txn)
+		}
+		defer func() {
+			beginTxn = tiTxnBegin
+		}()
+
 		commits := 0
 		commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
 			commits++
@@ -760,6 +952,8 @@ func TestWriteTxnRetry(t *testing.T) {
 		// Reserved empty-value placeholder is rejected while building mutations.
 		err := kv.MultiSave(ctx, map[string]string{"bad_key": EmptyValueString})
 		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Equal(t, 1, begins)
 		assert.Zero(t, commits)
 		// The retry.Unrecoverable marker must not leak to callers.
 		assert.True(t, retry.IsRecoverable(err))

--- a/pkg/kv/reliable_write_meta_kv.go
+++ b/pkg/kv/reliable_write_meta_kv.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	tikverr "github.com/tikv/client-go/v2/error"
 
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -88,6 +89,9 @@ func (kv *ReliableWriteMetaKv) retryWithBackoff(ctx context.Context, fn func(ctx
 		err := fn(ctx)
 		if err == nil {
 			return nil
+		}
+		if tikverr.IsErrorUndetermined(err) {
+			return err
 		}
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/pkg/kv/reliable_write_meta_kv_test.go
+++ b/pkg/kv/reliable_write_meta_kv_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	tikverr "github.com/tikv/client-go/v2/error"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
@@ -124,4 +125,21 @@ func TestReliableWriteMetaKv(t *testing.T) {
 
 	_, err := rkv.CompareVersionAndSwap(ctx, "test", 0, "test")
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestReliableWriteMetaKvDoesNotRetryUndeterminedWriteResult(t *testing.T) {
+	metaKV := mock_kv.NewMockMetaKv(t)
+	calls := atomic.NewInt32(0)
+	metaKV.EXPECT().Save(mock.Anything, "k", "v").RunAndReturn(
+		func(ctx context.Context, key, value string) error {
+			if calls.Inc() == 1 {
+				return errors.Wrap(tikverr.ErrResultUndetermined, "commit failed")
+			}
+			return nil
+		}).Maybe()
+
+	rkv := NewReliableWriteMetaKv(metaKV)
+	err := rkv.Save(context.Background(), "k", "v")
+	assert.ErrorIs(t, err, tikverr.ErrResultUndetermined)
+	assert.Equal(t, int32(1), calls.Load())
 }


### PR DESCRIPTION
- Rebuild TiKV write transactions on retriable begin, build-stage IO, and classified-transient commit failures while aborting deterministic build failures and unsafe commit outcomes.
- Preserve original errors for TiKV undetermined commit results and caller cancellation before string-wrapping; keep private `retry.Unrecoverable` markers inside the retry helper so they never leak to callers.
- Stop `ReliableWriteMetaKv` from replaying undetermined TiKV write results, correct the TiKV begin/requestTimeout comment, and add regression tests for commit aborts, retry exhaustion, deadline stopping, and outer reliable-write behavior.

related: #51425