### PR TITLE
auto: use build-ut-cov for master ci gate

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -65,13 +65,9 @@ misc:
         - or: *WHEN_GO_UNIT_TEST_SUCCESS
         - or: *WHEN_CODE_CHECK_UBUNTU_SUCCESS
   - when_master_build_ut_cov_gate_success: &WHEN_MASTER_BUILD_UT_COV_GATE_SUCCESS
-      or:
-        - status-success=ci-v2/build-ut-cov
-        - *WHEN_MASTER_LEGACY_BUILD_UT_COV_SUCCESS
+      status-success=ci-v2/build-ut-cov
   - when_master_go_unit_build_ut_cov_gate_success: &WHEN_MASTER_GO_UNIT_BUILD_UT_COV_GATE_SUCCESS
-      or:
-        - status-success=ci-v2/build-ut-cov
-        - *WHEN_MASTER_GO_UNIT_LEGACY_BUILD_UT_COV_SUCCESS
+      status-success=ci-v2/build-ut-cov
   - when_master_legacy_build_ut_cov_failure: &WHEN_MASTER_LEGACY_BUILD_UT_COV_FAILURE
       or:
         - and:
@@ -145,12 +141,10 @@ misc:
       and:
         - -status-success=ci-v2/build-ut-cov
         - status-failure=ci-v2/build-ut-cov
-        - *WHEN_MASTER_LEGACY_BUILD_UT_COV_FAILURE
   - when_master_go_unit_build_ut_cov_gate_failure: &WHEN_MASTER_GO_UNIT_BUILD_UT_COV_GATE_FAILURE
       and:
         - -status-success=ci-v2/build-ut-cov
         - status-failure=ci-v2/build-ut-cov
-        - *WHEN_MASTER_GO_UNIT_LEGACY_BUILD_UT_COV_FAILURE
 
   # Branch configurations
   - branch: &BRANCHES
@@ -429,8 +423,7 @@ pull_request_rules:
       - label!=manual-pass
       - *source_code_files
       - or:
-        # build-ut-cov replaces the legacy build/ut/code-check group on master:
-        # remove ci-passed only when both systems indicate failure.
+        # build-ut-cov replaces the legacy build/ut/code-check group on master.
         - and:
             - *only_go_unittest_files
             - *WHEN_MASTER_GO_UNIT_BUILD_UT_COV_GATE_FAILURE


### PR DESCRIPTION
## What\n- Make master Mergify build-ut-cov gate success depend only on ci-v2/build-ut-cov.\n- Make master Mergify build-ut-cov gate failure remove ci-passed when ci-v2/build-ut-cov fails, without requiring legacy split CI failures.\n\n## Why\nWhen legacy split CI jobs are downlined on master, those checks can be missing instead of failed. The previous remove rule required both build-ut-cov failure and legacy failure, so ci-passed could remain after build-ut-cov failed.\n\n## Validation\n- python3 -c "import yaml; yaml.safe_load(open('/Users/zilliz/workspace/milvus/zhikunyao_milvus_ci/.github/mergify.yml')); print('yaml ok')"\n- git diff --check