### PR TITLE
enhance: [poc_2.6.17] add per-collection deltalog observability metrics

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -516,6 +516,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 	var total int64
 	storedBinlogSize := make(map[string]map[string]int64) // map[collectionID]map[segment_state]size
 	binlogFileCount := make(map[string]int64)             // map[collectionID]count
+	deltalogAggregates := make(map[string]*deltalogAggregate)
 	coll2DbName := make(map[string]string)
 
 	for _, segment := range segments {
@@ -541,6 +542,13 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 
 				storedBinlogSize[collIDStr][segment.GetState().String()] += segmentSize
 				binlogFileCount[collIDStr] += int64(getBinlogFileCount(segment.SegmentInfo))
+
+				agg, ok := deltalogAggregates[collIDStr]
+				if !ok {
+					agg = &deltalogAggregate{dbName: coll.DatabaseName}
+					deltalogAggregates[collIDStr] = agg
+				}
+				agg.observe(segment)
 			} else {
 				log.Ctx(context.TODO()).Warn("not found database name", zap.Int64("collectionID", segment.GetCollectionID()))
 			}
@@ -586,6 +594,8 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 			metrics.DataCoordL0DeleteEntriesNum.WithLabelValues(coll.DatabaseName, strconv.FormatInt(collectionID, 10)).Set(float64(entriesNum))
 		}
 	}
+
+	reportDeltalogMetrics(deltalogAggregates)
 
 	info.TotalBinlogSize = total
 	info.CollectionBinlogSize = collectionBinlogSize

--- a/internal/datacoord/metrics_deltalog.go
+++ b/internal/datacoord/metrics_deltalog.go
@@ -1,0 +1,182 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"math"
+	"sort"
+	"sync"
+
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+)
+
+// deltalogQuantiles are the summary quantiles published for the per-segment
+// deltalog distributions. The 1.0 quantile (max) tracks the dirtiest segment
+// against the single-compaction thresholds; the lower quantiles rising toward
+// a threshold reveal a same-batch cohort accumulating toward a synchronized
+// compaction wave, which the max alone cannot distinguish from a lone dirty
+// segment.
+var deltalogQuantiles = []struct {
+	label string
+	q     float64
+}{
+	{"0.5", 0.5},
+	{"0.9", 0.9},
+	{"0.99", 0.99},
+	{"1.0", 1.0},
+}
+
+// levelDist holds one segment level's mirrored deltalog distributions:
+// deltalog file count, accumulated deltalog size, and deleted-rows ratio.
+type levelDist struct {
+	fileCounts    []float64
+	sizes         []float64
+	deletedRatios []float64
+}
+
+// deltalogAggregate collects per-collection deltalog observability stats over
+// healthy FLUSHED non-L0 segments — the population hasTooManyDeletions is
+// approximately evaluated against (growing/sealed segments route deletes to L0
+// and would pad the distributions with zeros). It only gates on L0 + isFlushed
+// (the caller already guarantees healthy && !importing); the finer candidacy
+// predicates (isCompacting, IsSorted, IsInvisible, compaction-protected) are
+// not applied, so the distributions approximate rather than exactly equal the
+// candidate set. Distributions are kept per segment level (byLevel): the two
+// single-compaction paths that reach hasTooManyDeletions each cover one level
+// (auto-compaction filters to L2, manual to L1), so blending them into one
+// quantile would dilute p50/p90. Zero-row segments are excluded from the ratio
+// distribution (the trigger's own uncapped division would fire on them, but a
+// +Inf sample would poison the gauge). Deltalog files of L0 segments are
+// counted separately over all healthy L0 segments, matching
+// l0_delete_entries_num.
+type deltalogAggregate struct {
+	dbName      string
+	byLevel     map[datapb.SegmentLevel]*levelDist
+	l0FileCount int64
+}
+
+func (a *deltalogAggregate) observe(segment *SegmentInfo) {
+	// L0 uses only the deltalog file count (l0_delete_entries_num companion);
+	// skip the size/deleted-row accumulation the non-L0 path needs.
+	if segment.GetLevel() == datapb.SegmentLevel_L0 {
+		fileCount := 0
+		for _, deltaLogs := range segment.GetDeltalogs() {
+			fileCount += len(deltaLogs.GetBinlogs())
+		}
+		a.l0FileCount += int64(fileCount)
+		return
+	}
+	if !isFlushed(segment) {
+		return
+	}
+
+	fileCount := 0
+	size := int64(0)
+	deletedRows := int64(0)
+	for _, deltaLogs := range segment.GetDeltalogs() {
+		for _, l := range deltaLogs.GetBinlogs() {
+			deletedRows += l.GetEntriesNum()
+			size += l.GetMemorySize()
+		}
+		fileCount += len(deltaLogs.GetBinlogs())
+	}
+
+	if a.byLevel == nil {
+		a.byLevel = make(map[datapb.SegmentLevel]*levelDist)
+	}
+	d := a.byLevel[segment.GetLevel()]
+	if d == nil {
+		d = &levelDist{}
+		a.byLevel[segment.GetLevel()] = d
+	}
+	d.fileCounts = append(d.fileCounts, float64(fileCount))
+	d.sizes = append(d.sizes, float64(size))
+	if segment.GetNumOfRows() > 0 {
+		d.deletedRatios = append(d.deletedRatios, float64(deletedRows)/float64(segment.GetNumOfRows()))
+	}
+}
+
+// quantilesInPlace sorts values once and returns the exact nearest-rank
+// (rank = ceil(q*n)) value for each requested quantile; all-zeros for an empty
+// slice. Sorting once (vs once per quantile) shortens the read-lock hold in
+// reportDeltalogMetrics.
+func quantilesInPlace(values []float64, qs []float64) []float64 {
+	out := make([]float64, len(qs))
+	if len(values) == 0 {
+		return out
+	}
+	sort.Float64s(values)
+	for i, q := range qs {
+		idx := int(math.Ceil(q*float64(len(values)))) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(values) {
+			idx = len(values) - 1
+		}
+		out[i] = values[idx]
+	}
+	return out
+}
+
+var (
+	deltalogPublishMu sync.Mutex
+	// collections whose deltalog series are currently published; lets a
+	// refresh round prune collections that disappeared since the last one
+	publishedDeltalogCollections = make(map[string]struct{})
+)
+
+// reportDeltalogMetrics publishes the per-collection deltalog gauges, then
+// prunes series of collections absent from this round (dropped collections are
+// also eagerly cleaned in CleanupDataCoordWithCollectionID on DropCollection).
+// Publish-then-prune instead of Reset-then-Set so a concurrent scrape never
+// observes an empty window; the mutex serializes concurrent GetQuotaInfo
+// callers.
+func reportDeltalogMetrics(aggregates map[string]*deltalogAggregate) {
+	deltalogPublishMu.Lock()
+	defer deltalogPublishMu.Unlock()
+
+	qs := make([]float64, len(deltalogQuantiles))
+	for i, p := range deltalogQuantiles {
+		qs[i] = p.q
+	}
+
+	for collectionID, agg := range aggregates {
+		metrics.DataCoordL0DeltalogFileNum.WithLabelValues(agg.dbName, collectionID).Set(float64(agg.l0FileCount))
+		for level, d := range agg.byLevel {
+			levelStr := level.String()
+			fcQ := quantilesInPlace(d.fileCounts, qs)
+			szQ := quantilesInPlace(d.sizes, qs)
+			drQ := quantilesInPlace(d.deletedRatios, qs)
+			for i, p := range deltalogQuantiles {
+				metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues(agg.dbName, collectionID, levelStr, p.label).Set(fcQ[i])
+				metrics.DataCoordSegmentDeltalogSize.WithLabelValues(agg.dbName, collectionID, levelStr, p.label).Set(szQ[i])
+				metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues(agg.dbName, collectionID, levelStr, p.label).Set(drQ[i])
+			}
+		}
+	}
+	for collectionID := range publishedDeltalogCollections {
+		if _, ok := aggregates[collectionID]; !ok {
+			metrics.CleanupDataCoordDeltalogMetrics(collectionID)
+			delete(publishedDeltalogCollections, collectionID)
+		}
+	}
+	for collectionID := range aggregates {
+		publishedDeltalogCollections[collectionID] = struct{}{}
+	}
+}

--- a/internal/datacoord/metrics_deltalog_test.go
+++ b/internal/datacoord/metrics_deltalog_test.go
@@ -1,0 +1,117 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+)
+
+func makeDeltaMetricSegment(level datapb.SegmentLevel, state commonpb.SegmentState, numRows int64, deltalogCount int, rowsPerLog int64, sizePerLog int64) *SegmentInfo {
+	binlogs := make([]*datapb.Binlog, 0, deltalogCount)
+	for i := 0; i < deltalogCount; i++ {
+		binlogs = append(binlogs, &datapb.Binlog{EntriesNum: rowsPerLog, MemorySize: sizePerLog})
+	}
+	return &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			Level:     level,
+			State:     state,
+			NumOfRows: numRows,
+			Deltalogs: []*datapb.FieldBinlog{{Binlogs: binlogs}},
+		},
+	}
+}
+
+func TestDeltalogQuantile(t *testing.T) {
+	assert.Equal(t, []float64{0, 0}, quantilesInPlace(nil, []float64{0.5, 1.0}))
+
+	values := []float64{40, 10, 30, 20} // sorted: 10 20 30 40
+	got := quantilesInPlace(values, []float64{0.5, 0.99, 1.0})
+	assert.Equal(t, []float64{20, 40, 40}, got)
+
+	// nearest-rank: rank = ceil(0.9*9) = 9 -> the 9th value
+	nine := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	assert.Equal(t, []float64{9}, quantilesInPlace(nine, []float64{0.9}))
+
+	single := []float64{7}
+	assert.Equal(t, []float64{7, 7}, quantilesInPlace(single, []float64{0.5, 1.0}))
+}
+
+func TestDeltalogAggregateObserve(t *testing.T) {
+	agg := &deltalogAggregate{}
+
+	// L0 segments only feed the L0 file counter
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, commonpb.SegmentState_Flushed, 0, 7, 100, 1024))
+	assert.Equal(t, int64(7), agg.l0FileCount)
+	assert.Empty(t, agg.byLevel)
+
+	// non-flushed segments are outside the trigger's candidate population
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Growing, 1000, 3, 10, 512))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Sealed, 1000, 3, 10, 512))
+	assert.Empty(t, agg.byLevel)
+
+	// flushed non-L0 segments feed the distributions, kept per level
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Flushed, 1000, 30, 10, 2048)) // ratio 0.3
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 1000, 150, 1, 4096)) // ratio 0.15
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 0, 900, 1, 512))     // zero rows: ratio skipped
+
+	l1 := agg.byLevel[datapb.SegmentLevel_L1]
+	l2 := agg.byLevel[datapb.SegmentLevel_L2]
+	assert.Equal(t, []float64{30}, l1.fileCounts)
+	assert.Equal(t, []float64{30 * 2048}, l1.sizes)
+	assert.Len(t, l1.deletedRatios, 1)
+	assert.InDelta(t, 0.3, l1.deletedRatios[0], 1e-9)
+	assert.Equal(t, []float64{150, 900}, l2.fileCounts)
+	assert.Equal(t, []float64{150 * 4096, 900 * 512}, l2.sizes)
+	assert.Len(t, l2.deletedRatios, 1) // zero-row L2 segment excluded
+	assert.InDelta(t, 0.15, l2.deletedRatios[0], 1e-9)
+}
+
+func TestReportDeltalogMetrics(t *testing.T) {
+	agg := &deltalogAggregate{dbName: "db1"}
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, commonpb.SegmentState_Flushed, 0, 5, 100, 1024))
+	// L1 (manual-compaction candidates): a cohort at ~180 files
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Flushed, 1000, 180, 1, 1024))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Flushed, 1000, 181, 1, 1024))
+	// L2 (auto-compaction candidates): a cohort plus one lone dirty segment
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 1000, 182, 1, 1024))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 1000, 600, 1, 1024))
+
+	reportDeltalogMetrics(map[string]*deltalogAggregate{"100": agg})
+
+	assert.Equal(t, 5.0, testutil.ToFloat64(metrics.DataCoordL0DeltalogFileNum.WithLabelValues("db1", "100")))
+	// L1 and L2 stay separate quantiles (not blended): p50 = nearest-rank of each level's 2 samples
+	assert.Equal(t, 180.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "L1", "0.5")))
+	assert.Equal(t, 181.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "L1", "1.0")))
+	assert.Equal(t, 182.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "L2", "0.5")))
+	assert.Equal(t, 600.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "L2", "1.0")))
+	assert.Equal(t, float64(180*1024), testutil.ToFloat64(metrics.DataCoordSegmentDeltalogSize.WithLabelValues("db1", "100", "L1", "0.5")))
+	assert.InDelta(t, 0.180, testutil.ToFloat64(metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues("db1", "100", "L1", "0.5")), 1e-9)
+
+	// a refresh round without the collection prunes its series
+	reportDeltalogMetrics(map[string]*deltalogAggregate{})
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordSegmentDeltalogFileCount))
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordSegmentDeltalogSize))
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordSegmentDeletedRowsRatio))
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordL0DeltalogFileNum))
+}

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -30,6 +30,7 @@ const (
 	StatFileLabel            = "stat_file"
 	IndexFileLabel           = "index_file"
 	segmentFileTypeLabelName = "segment_file_type"
+	quantileLabelName        = "quantile"
 )
 
 var (
@@ -84,6 +85,76 @@ var (
 		}, []string{
 			databaseLabelName,
 			collectionIDLabelName,
+		})
+
+	DataCoordL0DeltalogFileNum = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.DataCoordRole,
+			Name:      "l0_deltalog_file_num",
+			Help:      "total deltalog file count of Level zero segments",
+		}, []string{
+			databaseLabelName,
+			collectionIDLabelName,
+		})
+
+	// DataCoordSegmentDeltalogFileCount publishes summary-style quantiles
+	// (0.5/0.9/0.99/1.0) of the per-segment deltalog file count over healthy
+	// FLUSHED non-L0 segments, split by segment_level, recomputed exactly on
+	// each metrics refresh round. The two single-compaction paths that call
+	// hasTooManyDeletions each cover one level (auto-compaction filters to L2,
+	// manual filters to L1), so the distributions are kept per level rather than
+	// blended. It approximates — not exactly equals — the candidate population:
+	// transient/stable candidacy predicates (isCompacting, IsSorted, IsInvisible,
+	// compaction-protected) are not applied here.
+	// Compare against dataCoord.compaction.single.deltalog.maxnum: the 1.0
+	// quantile shows how close the dirtiest segment is to triggering a
+	// delete-driven compaction, while p50/p90 rising toward the threshold
+	// reveals a same-batch cohort building up toward a synchronized
+	// compaction wave (a lone dirty segment leaves them unmoved).
+	DataCoordSegmentDeltalogFileCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.DataCoordRole,
+			Name:      "segment_deltalog_file_count",
+			Help: "quantiles (0.5/0.9/0.99/1.0) of deltalog file count over healthy flushed " +
+				"non-L0 segments, by segment_level; compare against dataCoord.compaction.single.deltalog.maxnum",
+		}, []string{
+			databaseLabelName,
+			collectionIDLabelName,
+			segmentLevelLabelName,
+			quantileLabelName,
+		})
+
+	DataCoordSegmentDeltalogSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.DataCoordRole,
+			Name:      "segment_deltalog_size",
+			Help: "quantiles (0.5/0.9/0.99/1.0) of accumulated deltalog size in bytes over " +
+				"healthy flushed non-L0 segments, by segment_level; compare against " +
+				"dataCoord.compaction.single.deltalog.maxsize (the varchar-PK trigger dimension)",
+		}, []string{
+			databaseLabelName,
+			collectionIDLabelName,
+			segmentLevelLabelName,
+			quantileLabelName,
+		})
+
+	DataCoordSegmentDeletedRowsRatio = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.DataCoordRole,
+			Name:      "segment_deleted_rows_ratio",
+			Help: "quantiles (0.5/0.9/0.99/1.0) of deleted-rows/total-rows ratio over healthy " +
+				"flushed non-L0 segments, by segment_level; compare against dataCoord.compaction.single.ratio.threshold. " +
+				"May exceed 1.0 (deltalog entries count repeated deletes of the same PK); " +
+				"zero-row segments are excluded",
+		}, []string{
+			databaseLabelName,
+			collectionIDLabelName,
+			segmentLevelLabelName,
+			quantileLabelName,
 		})
 
 	// DataCoordNumStoredRows all metrics will be cleaned up after removing matched collectionID and
@@ -406,6 +477,10 @@ func RegisterDataCoord(registry *prometheus.Registry) {
 	registry.MustRegister(ImportTaskLatency)
 	registry.MustRegister(DataCoordSizeStoredL0Segment)
 	registry.MustRegister(DataCoordL0DeleteEntriesNum)
+	registry.MustRegister(DataCoordL0DeltalogFileNum)
+	registry.MustRegister(DataCoordSegmentDeltalogFileCount)
+	registry.MustRegister(DataCoordSegmentDeltalogSize)
+	registry.MustRegister(DataCoordSegmentDeletedRowsRatio)
 	registry.MustRegister(FlushedSegmentFileNum)
 	registry.MustRegister(IndexRequestCounter)
 	registry.MustRegister(IndexTaskNum)
@@ -445,5 +520,24 @@ func CleanupDataCoordWithCollectionID(collectionID int64) {
 	})
 	DataCoordL0DeleteEntriesNum.DeletePartialMatch(prometheus.Labels{
 		collectionIDLabelName: fmt.Sprint(collectionID),
+	})
+	CleanupDataCoordDeltalogMetrics(fmt.Sprint(collectionID))
+}
+
+// CleanupDataCoordDeltalogMetrics removes one collection's deltalog
+// observability series; called on DropCollection and when a metrics refresh
+// round no longer observes the collection.
+func CleanupDataCoordDeltalogMetrics(collectionID string) {
+	DataCoordSegmentDeltalogFileCount.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: collectionID,
+	})
+	DataCoordSegmentDeltalogSize.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: collectionID,
+	})
+	DataCoordSegmentDeletedRowsRatio.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: collectionID,
+	})
+	DataCoordL0DeltalogFileNum.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: collectionID,
 	})
 }


### PR DESCRIPTION
Cherry-pick of #51097 onto `poc_2.6.17` (squashed; upstream commits 691db63 + 0a54c39 + 36a917d, both adversarial-review rounds folded in).

### What

Per-collection summary-quantile gauges over healthy **flushed non-L0** segments, split by `segment_level`, computed in the existing `GetQuotaInfo` refresh loop (no new iteration):

| Metric | Labels | Compare against |
|---|---|---|
| `segment_deltalog_file_count` | `segment_level`, `quantile`=0.5/0.9/0.99/1.0 | `single.deltalog.maxnum` (200) |
| `segment_deltalog_size` | `segment_level`, `quantile` | `single.deltalog.maxsize` |
| `segment_deleted_rows_ratio` | `segment_level`, `quantile` | `single.ratio.threshold` (0.2) |
| `l0_deltalog_file_num` | — | total L0 deltalog files |

Surfaces the delete-driven single-compaction **cohort signal** behind #51094 (p50 marching toward the threshold *is* the avalanche warning) before the rewrite avalanche starts. Observability companion of #51096.

### Backport adaptation

- `pkg/v3` → `pkg/v2` and `go-api/v3` → `go-api/v2` import paths.
- `meta.go`: kept the `poc_2.6.17`-only "not found database name" else-branch alongside the new `aggregate.observe()` call.

### Test

- Build passes; `TestDeltalogQuantile`, `TestDeltalogAggregateObserve`, `TestReportDeltalogMetrics` all pass locally on `poc_2.6.17` (aa866d0c22).

issue: #51094
pr: #51097
