### PR TITLE
enhance: [poc_2.6.17] de-synchronize and rate-limit delete-triggered single compaction

### DIFF
--- a/internal/datacoord/compaction_admission.go
+++ b/internal/datacoord/compaction_admission.go
@@ -1,0 +1,286 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v2/log"
+)
+
+// Admission smoothing for single (delete/expiry-accumulation-triggered) compaction.
+//
+// Segments created in the same batch accumulate deltalogs at nearly the same
+// rate, so they cross the hard trigger thresholds nearly simultaneously and
+// produce a rewrite avalanche (see issue #51094). Two mechanisms de-synchronize
+// and bound this:
+//
+//  1. Per-segment threshold jitter: each segment gets a deterministic
+//     multiplier in [1, 1+J] applied to the accumulation thresholds, spreading
+//     a cohort's crossing times over J x (accumulation period).
+//  2. A token bucket at candidate admission: no matter how many delete-triggered
+//     segments become eligible in one trigger round (e.g. after a threshold
+//     config change), at most `rateLimitTokens` are admitted per
+//     `rateLimitInterval`. A segment whose delete pressure has reached
+//     `deferralHardCap` times a trigger threshold (on any delete axis) is always
+//     admitted so deferral stays bounded; that escape is itself jittered so a
+//     deferred cohort does not re-synchronize and avalanche through it at once.
+//
+// Only delete-accumulation candidates are routed through the admitter; both the
+// dirtiest-first ordering and the bounded-deferral escape use a normalized delete
+// pressure across all three delete axes (deltalog count, deleted-rows ratio,
+// delete-log size), so a segment triggered by any single axis is ordered and
+// bounded on that axis. Expiry accumulation, index rebuild and strict age-based
+// TTL are retention / correctness obligations that must not be paced behind a
+// delete backlog, so their callers bypass admission entirely and are only
+// de-synchronized by jitter (see compaction_trigger.go) — the token-bucket rate
+// ceiling applies to delete accumulation only.
+//
+// Both knobs are refreshable; jitter=0 and tokens=0 restore legacy behavior.
+
+// deferralHardCap bounds how far the admission limiter may defer a segment:
+// once its normalized delete pressure reaches deferralHardCap (4x a trigger
+// threshold on some delete axis, scaled by the segment's jitter multiplier) it
+// is admitted regardless of remaining tokens.
+const deferralHardCap = 4.0
+
+// consecutiveThrottledRoundsToWarn controls how many consecutive throttled
+// admission rounds are tolerated before emitting a warning; sustained
+// throttling means the bucket is sized below steady-state demand.
+const consecutiveThrottledRoundsToWarn = 30
+
+// reliefTokenFraction is the post-refill token level (as a fraction of the
+// budget) at which the bucket is considered genuinely recovered. A deferral-free
+// call only resets the sustained-throttle counter when the bucket has refilled
+// to at least this level, so a lightly loaded caller cannot mask a warning while
+// another caller is being throttled every round against a still-drained bucket.
+const reliefTokenFraction = 0.5
+
+// singleCompactionThresholdMultiplier returns the deterministic per-segment
+// jitter multiplier in [1, 1+J]. It is a pure function of the segment ID:
+// stable across restarts and nodes, re-drawn naturally when a compaction
+// produces a segment with a new ID.
+func singleCompactionThresholdMultiplier(segmentID int64) float64 {
+	jitter := Params.DataCoordCfg.SingleCompactionThresholdJitter.GetAsFloat()
+	if jitter <= 0 {
+		return 1.0
+	}
+	// splitmix64 finalizer as a cheap uniform hash.
+	x := uint64(segmentID)
+	x ^= x >> 30
+	x *= 0xbf58476d1ce4e5b9
+	x ^= x >> 27
+	x *= 0x94d049bb133111eb
+	x ^= x >> 31
+	hash01 := float64(x>>11) / float64(uint64(1)<<53)
+	return 1.0 + jitter*hash01
+}
+
+// segmentDeleteCompactionPressure returns a segment's normalized dirtiness across
+// all three delete trigger axes: the max of deltalog-count / maxnum,
+// deleted-rows-ratio / ratioThreshold, and delete-log-size / sizeThreshold. A
+// value of 1.0 means the segment just crossed a 1x trigger threshold on some
+// axis; deferralHardCap (4.0) means it has reached the bounded-deferral escape.
+// Using the normalized max means a segment triggered by any single axis (e.g.
+// large varchar-PK deletes concentrated in a few files, with a low row ratio) is
+// both ordered dirtiest-first and bounded on that axis, not only on the
+// file-count axis. Axes whose threshold is non-positive are skipped, so a
+// misconfigured (<= 0) threshold cannot spuriously drive pressure to the escape.
+func segmentDeleteCompactionPressure(segment *SegmentInfo) float64 {
+	var deltalogCount int
+	var deletedRows, deleteLogSize int64
+	for _, deltaLogs := range segment.GetDeltalogs() {
+		for _, l := range deltaLogs.GetBinlogs() {
+			deletedRows += l.GetEntriesNum()
+			deleteLogSize += l.GetMemorySize()
+		}
+		deltalogCount += len(deltaLogs.GetBinlogs())
+	}
+	pressure := 0.0
+	if maxNum := Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsFloat(); maxNum > 0 {
+		pressure = math.Max(pressure, float64(deltalogCount)/maxNum)
+	}
+	if rows := segment.GetNumOfRows(); rows > 0 {
+		if ratioThreshold := Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat(); ratioThreshold > 0 {
+			pressure = math.Max(pressure, (float64(deletedRows)/float64(rows))/ratioThreshold)
+		}
+	}
+	if sizeThreshold := float64(Params.DataCoordCfg.SingleCompactionDeltaLogMaxSize.GetAsInt64()); sizeThreshold > 0 {
+		pressure = math.Max(pressure, float64(deleteLogSize)/sizeThreshold)
+	}
+	return pressure
+}
+
+// singleCompactionAdmitter is a token bucket shared by every single-compaction
+// candidate producer (the legacy trigger and the single compaction policy), so
+// the whole DataCoord observes one admission budget. The shared budget is
+// intentional: the constraint being protected is the aggregate rewrite load
+// against a rate-limited object store, which does not care whether a rewrite
+// originated from the L1 trigger or the L2 policy. Cross-caller fairness within
+// a single round is first-come, but the bucket refills every round, so no caller
+// is starved across rounds.
+type singleCompactionAdmitter struct {
+	mu              sync.Mutex
+	tokens          float64
+	lastRefill      time.Time
+	throttledRounds int
+	nowFn           func() time.Time // injectable for tests
+}
+
+var (
+	globalSingleCompactionAdmitter     *singleCompactionAdmitter
+	globalSingleCompactionAdmitterOnce sync.Once
+)
+
+func getSingleCompactionAdmitter() *singleCompactionAdmitter {
+	globalSingleCompactionAdmitterOnce.Do(func() {
+		globalSingleCompactionAdmitter = &singleCompactionAdmitter{nowFn: time.Now}
+	})
+	return globalSingleCompactionAdmitter
+}
+
+// admit selects which eligible segments may be submitted this round.
+// Ordering: segments past the deferral hard cap are always admitted; the rest
+// are admitted dirtiest-first while tokens last. A non-positive token config
+// disables limiting entirely (legacy behavior). The returned gatedIDs are the
+// admitted segments that consumed a token (i.e. excluding the hard-cap bypass),
+// so the caller can refund tokens for plans it ends up dropping.
+func (a *singleCompactionAdmitter) admit(eligible []*SegmentInfo) (admitted []*SegmentInfo, gatedIDs map[int64]struct{}, deferred int) {
+	if len(eligible) == 0 {
+		return nil, nil, 0
+	}
+	budget := Params.DataCoordCfg.SingleCompactionRateLimitTokens.GetAsFloat()
+	if budget <= 0 {
+		return eligible, nil, 0
+	}
+	// A sub-one positive budget can never let tokens reach 1, which would defer
+	// every non-hard-cap candidate forever. Treat any positive budget as at
+	// least one admission per interval.
+	if budget < 1 {
+		budget = 1
+	}
+	interval := Params.DataCoordCfg.SingleCompactionRateLimitInterval.GetAsDuration(time.Second)
+	if interval <= 0 {
+		return eligible, nil, 0
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	now := a.nowFn()
+	if a.lastRefill.IsZero() {
+		a.tokens = budget
+	} else {
+		a.tokens += budget * now.Sub(a.lastRefill).Seconds() / interval.Seconds()
+		if a.tokens > budget {
+			a.tokens = budget
+		}
+	}
+	a.lastRefill = now
+	tokensAfterRefill := a.tokens
+
+	// Precompute each segment's normalized delete pressure once; it drives both
+	// the jittered hard-cap escape and the dirtiest-first ordering.
+	type pressured struct {
+		seg *SegmentInfo
+		p   float64
+	}
+	rest := make([]pressured, 0, len(eligible))
+	for _, segment := range eligible {
+		p := segmentDeleteCompactionPressure(segment)
+		// Jittered bounded-deferral escape: a segment whose pressure has reached
+		// deferralHardCap x its per-segment jitter multiplier on some delete axis
+		// is always admitted without consuming a token, so deferral stays bounded
+		// on every axis (count, ratio, size). Jittering the escape (like the 1x
+		// trigger) de-synchronizes a cohort that would otherwise all reach the 4x
+		// threshold at the same instant and avalanche through the bypass together;
+		// it also means a config decrease raises pressure only into a per-segment
+		// spread of escape thresholds rather than releasing the cohort at once.
+		if p >= deferralHardCap*singleCompactionThresholdMultiplier(segment.GetID()) {
+			admitted = append(admitted, segment)
+			continue
+		}
+		rest = append(rest, pressured{seg: segment, p: p})
+	}
+	sort.Slice(rest, func(i, j int) bool {
+		return rest[i].p > rest[j].p
+	})
+	for _, r := range rest {
+		if a.tokens < 1 {
+			deferred++
+			continue
+		}
+		a.tokens--
+		if gatedIDs == nil {
+			gatedIDs = make(map[int64]struct{})
+		}
+		gatedIDs[r.seg.GetID()] = struct{}{}
+		admitted = append(admitted, r.seg)
+	}
+
+	if deferred > 0 {
+		a.throttledRounds++
+		if a.throttledRounds >= consecutiveThrottledRoundsToWarn {
+			log.Ctx(context.TODO()).RatedWarn(60, "single compaction admission throttled for many consecutive rounds; "+
+				"the rate limit may be below steady-state demand and deltalog backlog is growing",
+				zap.Int("deferred", deferred),
+				zap.Int("consecutiveThrottledRounds", a.throttledRounds),
+				zap.Float64("rateLimitTokens", budget))
+		} else {
+			log.Ctx(context.TODO()).RatedInfo(10, "single compaction admission throttled",
+				zap.Int("admitted", len(admitted)),
+				zap.Int("deferred", deferred))
+		}
+	} else if tokensAfterRefill >= budget*reliefTokenFraction {
+		// Only a genuinely recovered bucket clears the sustained-throttle
+		// counter. If the bucket is still drained (another caller is exhausting
+		// it every round) a lightly loaded, deferral-free caller leaves the
+		// counter untouched instead of masking the warning.
+		a.throttledRounds = 0
+	}
+	return admitted, gatedIDs, deferred
+}
+
+// refund returns n unused tokens to the bucket, capped at the current budget.
+// The trigger consumes a token per admitted segment at selection time, but may
+// drop already-built plans when the compaction inspector fills mid-cycle; those
+// tokens are refunded so the effective admission rate is not silently collapsed
+// below the configured rate by backpressure.
+func (a *singleCompactionAdmitter) refund(n int) {
+	if n <= 0 {
+		return
+	}
+	budget := Params.DataCoordCfg.SingleCompactionRateLimitTokens.GetAsFloat()
+	if budget <= 0 {
+		return
+	}
+	if budget < 1 {
+		budget = 1
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.tokens += float64(n)
+	if a.tokens > budget {
+		a.tokens = budget
+	}
+}

--- a/internal/datacoord/compaction_admission_test.go
+++ b/internal/datacoord/compaction_admission_test.go
@@ -1,0 +1,323 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func makeAdmissionTestSegment(id int64, numRows int64, deletedRows int64, deltalogCount int) *SegmentInfo {
+	binlogs := make([]*datapb.Binlog, 0, deltalogCount)
+	perLog := int64(0)
+	if deltalogCount > 0 {
+		perLog = deletedRows / int64(deltalogCount)
+	}
+	for i := 0; i < deltalogCount; i++ {
+		binlogs = append(binlogs, &datapb.Binlog{EntriesNum: perLog, MemorySize: 1024})
+	}
+	return &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:        id,
+			NumOfRows: numRows,
+			Deltalogs: []*datapb.FieldBinlog{{Binlogs: binlogs}},
+		},
+	}
+}
+
+func TestSingleCompactionThresholdMultiplier(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+
+	t.Run("zero jitter restores legacy behavior", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key, "0")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key)
+		assert.Equal(t, 1.0, singleCompactionThresholdMultiplier(12345))
+	})
+
+	t.Run("deterministic and within range", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key, "0.25")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key)
+
+		seen := make(map[float64]int)
+		for _, id := range []int64{1, 2, 3, 1e12, 466295849486964560} {
+			m1 := singleCompactionThresholdMultiplier(id)
+			m2 := singleCompactionThresholdMultiplier(id)
+			assert.Equal(t, m1, m2, "multiplier must be deterministic for id %d", id)
+			assert.GreaterOrEqual(t, m1, 1.0)
+			assert.Less(t, m1, 1.25)
+			seen[m1]++
+		}
+		assert.Greater(t, len(seen), 1, "different ids should spread across the jitter band")
+	})
+}
+
+func TestSingleCompactionReasonAdmissionGated(t *testing.T) {
+	// Only delete accumulation is paced: it has both an ordering signal and a
+	// bounded-deferral hard cap measured from delete deltalogs. Expiry
+	// accumulation, strict age-TTL and index-rebuild bypass admission so they
+	// can never be starved behind a delete backlog.
+	assert.False(t, reasonNone.admissionGated())
+	assert.False(t, reasonExpiryStrict.admissionGated())
+	assert.False(t, reasonExpiryAccumulation.admissionGated())
+	assert.True(t, reasonTooManyDeletions.admissionGated())
+	assert.False(t, reasonRebuildIndex.admissionGated())
+}
+
+func TestSingleCompactionAdmitter(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	now := time.Now()
+	newAdmitter := func() *singleCompactionAdmitter {
+		return &singleCompactionAdmitter{nowFn: func() time.Time { return now }}
+	}
+	// Pin jitter off so the hard-cap escape threshold is exactly deferralHardCap
+	// (jitter itself is covered by TestSingleCompactionThresholdMultiplier).
+	pt.Save(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key, "0")
+	defer pt.Reset(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key)
+
+	t.Run("disabled bucket admits everything", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "0")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+
+		a := newAdmitter()
+		eligible := []*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 10),
+			makeAdmissionTestSegment(2, 1000, 100, 10),
+		}
+		admitted, gated, deferred := a.admit(eligible)
+		assert.Len(t, admitted, 2)
+		assert.Empty(t, gated)
+		assert.Zero(t, deferred)
+	})
+
+	t.Run("limits admissions and prefers the dirtiest segments", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "2")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+
+		a := newAdmitter()
+		eligible := []*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 10), // 10% deleted
+			makeAdmissionTestSegment(2, 1000, 500, 10), // 50% deleted -> dirtiest
+			makeAdmissionTestSegment(3, 1000, 300, 10), // 30% deleted
+		}
+		admitted, gated, deferred := a.admit(eligible)
+		assert.Len(t, admitted, 2)
+		assert.Len(t, gated, 2)
+		assert.Equal(t, 1, deferred)
+		assert.Equal(t, int64(2), admitted[0].GetID())
+		assert.Equal(t, int64(3), admitted[1].GetID())
+	})
+
+	t.Run("hard-cap segments bypass the bucket", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "1")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		pt.Save(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key, "200")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key)
+
+		a := newAdmitter()
+		overCap := makeAdmissionTestSegment(10, 1000, 10, 900) // >= 4x200 deltalogs
+		eligible := []*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 10),
+			makeAdmissionTestSegment(2, 1000, 500, 10),
+			overCap,
+		}
+		admitted, gated, deferred := a.admit(eligible)
+		assert.Len(t, admitted, 2) // hard-cap one + one token
+		assert.Len(t, gated, 1)    // only the token-consuming one is gated
+		assert.Equal(t, 1, deferred)
+		ids := []int64{admitted[0].GetID(), admitted[1].GetID()}
+		assert.Contains(t, ids, int64(10), "hard-cap segment must always be admitted")
+		assert.NotContains(t, gated, int64(10), "hard-cap bypass must not consume a token")
+	})
+
+	t.Run("tokens refill over time", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "1")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+
+		current := now
+		a := &singleCompactionAdmitter{nowFn: func() time.Time { return current }}
+		seg := func(id int64) []*SegmentInfo { return []*SegmentInfo{makeAdmissionTestSegment(id, 1000, 100, 10)} }
+
+		admitted, _, _ := a.admit(seg(1))
+		assert.Len(t, admitted, 1)
+		// bucket drained: an immediate retry is deferred
+		admitted, _, deferred := a.admit(seg(2))
+		assert.Len(t, admitted, 0)
+		assert.Equal(t, 1, deferred)
+		// after one full interval the bucket refills
+		current = current.Add(61 * time.Second)
+		admitted, _, deferred = a.admit(seg(3))
+		assert.Len(t, admitted, 1)
+		assert.Zero(t, deferred)
+	})
+
+	// Fix (review): a sub-one positive token budget must not soft-deadlock.
+	t.Run("sub-one positive budget still admits one per interval", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "0.5")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+
+		a := newAdmitter()
+		eligible := []*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 10),
+			makeAdmissionTestSegment(2, 1000, 200, 10),
+			makeAdmissionTestSegment(3, 1000, 300, 10),
+		}
+		admitted, _, deferred := a.admit(eligible)
+		assert.Len(t, admitted, 1, "a fractional budget is clamped to at least one admission")
+		assert.Equal(t, 2, deferred)
+	})
+
+	// Fix (review): a segment triggered only by delete-log size (few files, low
+	// row ratio, large delete bytes) must reach the bounded-deferral escape too,
+	// not just file-count-triggered segments.
+	t.Run("delete-size axis reaches the bounded-deferral escape", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "1")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+
+		sizeThreshold := pt.DataCoordCfg.SingleCompactionDeltaLogMaxSize.GetAsInt64()
+		// One file, ~zero row ratio, but delete bytes >> 4x the size threshold.
+		sizeSeg := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:        20,
+				NumOfRows: 1_000_000,
+				Deltalogs: []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{
+					{EntriesNum: 10, MemorySize: 5 * sizeThreshold},
+				}}},
+			},
+		}
+		// A ratio-dirtier but small segment competes for the single token.
+		ratioSeg := makeAdmissionTestSegment(21, 1000, 500, 5)
+
+		a := newAdmitter()
+		admitted, gated, _ := a.admit([]*SegmentInfo{ratioSeg, sizeSeg})
+		ids := []int64{}
+		for _, s := range admitted {
+			ids = append(ids, s.GetID())
+		}
+		// sizeSeg bypasses via the size axis (no token) even though its row ratio
+		// and file count would sort it last / never hit a count-only hard cap;
+		// ratioSeg takes the single token.
+		assert.Contains(t, ids, int64(20), "delete-size-triggered segment must reach the escape")
+		assert.NotContains(t, gated, int64(20), "escape must not consume a token")
+		assert.Contains(t, ids, int64(21))
+		assert.Contains(t, gated, int64(21))
+	})
+
+	// Fix (review): refund returns tokens for dropped plans so backpressure does
+	// not silently collapse the admission rate.
+	t.Run("refund returns unused tokens", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "2")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+
+		a := newAdmitter()
+		admitted, gated, _ := a.admit([]*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 10),
+			makeAdmissionTestSegment(2, 1000, 100, 10),
+		})
+		assert.Len(t, admitted, 2)
+		assert.Len(t, gated, 2)
+		// bucket drained now; refund one token
+		a.refund(1)
+		admitted, _, deferred := a.admit([]*SegmentInfo{makeAdmissionTestSegment(3, 1000, 100, 10)})
+		assert.Len(t, admitted, 1, "refunded token must be reusable")
+		assert.Zero(t, deferred)
+		// refund never exceeds the configured budget
+		a.refund(100)
+		admitted, _, _ = a.admit([]*SegmentInfo{
+			makeAdmissionTestSegment(4, 1000, 100, 10),
+			makeAdmissionTestSegment(5, 1000, 100, 10),
+			makeAdmissionTestSegment(6, 1000, 100, 10),
+		})
+		assert.LessOrEqual(t, len(admitted), 2, "refund must be capped at the budget")
+	})
+
+	// Fix (review): a non-positive deltalog-max config must not turn the count
+	// axis into a free bypass for every segment (which would silently disable
+	// pacing). A high deltalog count that would have tripped a count-based hard
+	// cap must still be routed through the bucket when maxnum <= 0.
+	t.Run("non-positive deltalog-max does not disable pacing", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "1")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		pt.Save(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key, "0")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key)
+
+		a := newAdmitter()
+		// 500 files each; with maxnum<=0 the count axis is skipped, so pressure
+		// stays well below the escape and the bucket still limits admissions.
+		admitted, _, deferred := a.admit([]*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 500),
+			makeAdmissionTestSegment(2, 1000, 100, 500),
+		})
+		assert.Len(t, admitted, 1)
+		assert.Equal(t, 1, deferred)
+	})
+
+	// Fix (review): a lightly loaded deferral-free caller must not reset the
+	// sustained-throttle counter while the shared bucket is still drained.
+	t.Run("throttle counter survives a deferral-free call on a drained bucket", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "1")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		pt.Save(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key, "200")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key)
+
+		current := now
+		a := &singleCompactionAdmitter{nowFn: func() time.Time { return current }}
+
+		// Round 1 throttles and drains the bucket.
+		_, _, deferred := a.admit([]*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 10),
+			makeAdmissionTestSegment(2, 1000, 100, 10),
+		})
+		assert.Equal(t, 1, deferred)
+		assert.Equal(t, 1, a.throttledRounds)
+
+		// Round 2: a hard-cap-only round defers nothing, but the bucket is still
+		// drained, so the throttle counter must be preserved (not masked).
+		_, _, deferred = a.admit([]*SegmentInfo{makeAdmissionTestSegment(3, 1000, 10, 900)})
+		assert.Zero(t, deferred)
+		assert.Equal(t, 1, a.throttledRounds, "drained bucket must not clear the throttle counter")
+
+		// Round 3: after a full refill the bucket has genuinely recovered, so a
+		// deferral-free call clears the counter.
+		current = current.Add(61 * time.Second)
+		_, _, deferred = a.admit([]*SegmentInfo{makeAdmissionTestSegment(4, 1000, 100, 10)})
+		assert.Zero(t, deferred)
+		assert.Zero(t, a.throttledRounds, "recovered bucket clears the throttle counter")
+	})
+}

--- a/internal/datacoord/compaction_policy_single.go
+++ b/internal/datacoord/compaction_policy_single.go
@@ -234,6 +234,7 @@ func (policy *singleCompactionPolicy) triggerOneCollection(ctx context.Context, 
 			!segment.GetIsInvisible()
 	}))
 
+	var admissionCandidates []*SegmentInfo
 	for _, group := range partSegments {
 		if Params.DataCoordCfg.IndexBasedCompaction.GetAsBool() {
 			group.segments = FilterInIndexedSegments(ctx, policy.handler, policy.meta, false, group.segments...)
@@ -241,16 +242,31 @@ func (policy *singleCompactionPolicy) triggerOneCollection(ctx context.Context, 
 
 		for _, segment := range group.segments {
 			if hasTooManyDeletions(segment) {
-				segmentViews := GetViewsByInfo(segment)
-				view := &MixSegmentView{
-					label:         segmentViews[0].label,
-					segments:      segmentViews,
-					collectionTTL: collectionTTL,
-					triggerID:     newTriggerID,
-				}
-				views = append(views, view)
+				admissionCandidates = append(admissionCandidates, segment)
 			}
 		}
+	}
+	// Share the single-compaction admission budget with the legacy trigger so
+	// mass eligibility drains as a paced stream instead of an avalanche;
+	// deferred segments are stateless and re-evaluated next round.
+	admitted, gatedIDs, deferred := getSingleCompactionAdmitter().admit(admissionCandidates)
+	for _, segment := range admitted {
+		segmentViews := GetViewsByInfo(segment)
+		_, gated := gatedIDs[segment.GetID()]
+		view := &MixSegmentView{
+			label:          segmentViews[0].label,
+			segments:       segmentViews,
+			collectionTTL:  collectionTTL,
+			triggerID:      newTriggerID,
+			admissionGated: gated,
+		}
+		views = append(views, view)
+	}
+	if deferred > 0 {
+		log.RatedInfo(10, "deferred L2 single compaction candidates by admission limit",
+			zap.Int64("collectionID", collectionID),
+			zap.Int("admitted", len(admitted)),
+			zap.Int("deferred", deferred))
 	}
 
 	if len(views) > 0 {
@@ -268,6 +284,11 @@ type MixSegmentView struct {
 	segments      []*SegmentView
 	collectionTTL time.Duration
 	triggerID     int64
+	// admissionGated marks a view whose segment consumed a single-compaction
+	// admission token at selection time. If the view is later dropped before it
+	// is enqueued (alloc/handler error, inspector busy), the submitter refunds
+	// the token so the effective admission rate is not depressed by that leak.
+	admissionGated bool
 }
 
 func (v *MixSegmentView) GetGroupLabel() *CompactionGroupLabel {

--- a/internal/datacoord/compaction_policy_single_test.go
+++ b/internal/datacoord/compaction_policy_single_test.go
@@ -109,6 +109,11 @@ func buildTestSegment(id int64,
 }
 
 func (s *SingleCompactionPolicySuite) TestIsDeleteRowsTooManySegment() {
+	// This case asserts the exact legacy threshold boundary (201 vs 200), so
+	// disable the per-segment jitter which otherwise raises the effective bound.
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.SingleCompactionThresholdJitter.Key, "0")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.SingleCompactionThresholdJitter.Key)
+
 	segment0 := buildTestSegment(101, collID, datapb.SegmentLevel_L2, 0, 10000, 201, true, true)
 	s.Equal(true, hasTooManyDeletions(segment0))
 
@@ -123,6 +128,10 @@ func (s *SingleCompactionPolicySuite) TestL2SingleCompaction() {
 	ctx := context.Background()
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.IndexBasedCompaction.Key, "false")
 	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.IndexBasedCompaction.Key)
+	// One candidate sits exactly at the legacy deltalog boundary (201 vs 200);
+	// disable jitter so the expected view count is deterministic.
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.SingleCompactionThresholdJitter.Key, "0")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.SingleCompactionThresholdJitter.Key)
 
 	collID := int64(100)
 	coll := &collectionInfo{

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -379,9 +379,22 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 		}
 
 		expectedSize := getExpectedSegmentSize(t.meta, coll.ID, coll.Schema)
-		plans := t.generatePlans(group.segments, signal, ct, expectedSize)
+		plans, gatedIDs := t.generatePlans(group.segments, signal, ct, expectedSize)
+		// A token was consumed per admission-gated segment at selection time. If
+		// a plan is dropped below (inspector full, alloc error, enqueue error)
+		// its segments are not rewritten this round, so refund those tokens; the
+		// segments are stateless and re-evaluated next round. Without this the
+		// effective admission rate silently collapses below the configured rate
+		// under sustained backpressure.
+		enqueuedGated := 0
+		refundUnusedTokens := func() {
+			if remaining := len(gatedIDs) - enqueuedGated; remaining > 0 {
+				getSingleCompactionAdmitter().refund(remaining)
+			}
+		}
 		for _, plan := range plans {
 			if !signal.isForce && t.inspector.isFull() {
+				refundUnusedTokens()
 				log.Warn("skip to generate compaction plan due to handler full")
 				return merr.WrapErrServiceQuotaExceeded("compaction handler full")
 			}
@@ -390,6 +403,7 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 			n := 11 * paramtable.Get().DataCoordCfg.CompactionPreAllocateIDExpansionFactor.GetAsInt64()
 			startID, endID, err := t.allocator.AllocN(n)
 			if err != nil {
+				refundUnusedTokens()
 				log.Warn("fail to allocate id", zap.Error(err))
 				return err
 			}
@@ -423,6 +437,11 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 					zap.Error(err))
 				continue
 			}
+			for _, sid := range inputSegmentIDs {
+				if _, ok := gatedIDs[sid]; ok {
+					enqueuedGated++
+				}
+			}
 
 			log.Info("time cost of generating compaction",
 				zap.Int64("planID", task.GetPlanID()),
@@ -430,14 +449,19 @@ func (t *compactionTrigger) handleSignal(signal *compactionSignal) error {
 				zap.Int64("target size", task.GetMaxSize()),
 				zap.Int64s("inputSegments", inputSegmentIDs))
 		}
+		// Refund tokens for any gated segment whose plan failed to enqueue.
+		refundUnusedTokens()
 	}
 	return nil
 }
 
-func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compactionSignal, compactTime *compactTime, expectedSize int64) []*typeutil.Pair[int64, []int64] {
+// generatePlans returns the compaction plans for a candidate group together
+// with the set of segment IDs that consumed an admission token, so handleSignal
+// can refund tokens for any plan it drops under inspector backpressure.
+func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compactionSignal, compactTime *compactTime, expectedSize int64) ([]*typeutil.Pair[int64, []int64], map[int64]struct{}) {
 	if len(segments) == 0 {
 		log.Warn("the number of candidate segments is 0, skip to generate compaction plan")
-		return []*typeutil.Pair[int64, []int64]{}
+		return []*typeutil.Pair[int64, []int64]{}, nil
 	}
 
 	// find segments need internal compaction
@@ -445,18 +469,47 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 	var prioritizedCandidates []*SegmentInfo
 	var smallCandidates []*SegmentInfo
 	var nonPlannedSegments []*SegmentInfo
+	// admissionCandidates hold avalanche-shaped delete-accumulation segments that
+	// are paced by the token bucket. Expiry accumulation, strict age-TTL and
+	// index-rebuild segments bypass pacing (they are correctness / retention
+	// obligations and must not be starved behind a delete backlog).
+	var admissionCandidates []*SegmentInfo
 
 	// TODO, currently we lack of the measurement of data distribution, there should be another compaction help on redistributing segment based on scalar/vector field distribution
 	for _, segment := range segments {
 		segment := segment.ShadowClone()
 		// TODO should we trigger compaction periodically even if the segment has no obvious reason to be compacted?
-		if signal.isForce || t.ShouldDoSingleCompaction(segment, compactTime) {
+		if signal.isForce {
+			// manual/force compaction expresses explicit operator intent and
+			// bypasses admission limiting.
 			prioritizedCandidates = append(prioritizedCandidates, segment)
-		} else if t.isSmallSegment(segment, expectedSize) {
-			smallCandidates = append(smallCandidates, segment)
-		} else {
-			nonPlannedSegments = append(nonPlannedSegments, segment)
+			continue
 		}
+		switch reason := t.singleCompactionReasonFor(segment, compactTime); {
+		case reason == reasonNone:
+			if t.isSmallSegment(segment, expectedSize) {
+				smallCandidates = append(smallCandidates, segment)
+			} else {
+				nonPlannedSegments = append(nonPlannedSegments, segment)
+			}
+		case reason.admissionGated():
+			admissionCandidates = append(admissionCandidates, segment)
+		default:
+			prioritizedCandidates = append(prioritizedCandidates, segment)
+		}
+	}
+
+	// Rate-limit single-compaction admissions so that mass eligibility (a
+	// same-batch cohort crossing thresholds together, a threshold config change)
+	// becomes a paced stream instead of an avalanche. Deferred segments carry no
+	// state and are re-evaluated next round.
+	admitted, gatedIDs, deferred := getSingleCompactionAdmitter().admit(admissionCandidates)
+	prioritizedCandidates = append(prioritizedCandidates, admitted...)
+	if deferred > 0 {
+		log.RatedInfo(10, "deferred single compaction candidates by admission limit",
+			zap.Int64("collectionID", signal.collectionID),
+			zap.Int("admitted", len(admitted)),
+			zap.Int("deferred", deferred))
 	}
 
 	buckets := [][]*SegmentInfo{}
@@ -535,7 +588,7 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 			zap.String("channel", signal.channel),
 			zap.Int("smallRemainingCount", len(smallRemaining)))
 	}
-	return tasks
+	return tasks, gatedIDs
 }
 
 // getCandidates converts signal criterion into corresponding compaction candidate groups
@@ -638,34 +691,42 @@ func hasTooManyDeletions(segment *SegmentInfo) bool {
 		deltaLogCount += len(deltaLogs.GetBinlogs())
 	}
 
+	// Deterministic per-segment jitter de-synchronizes same-batch segments,
+	// whose accumulation rates are nearly identical, so they do not cross the
+	// hard thresholds simultaneously (see compaction_admission.go).
+	mult := singleCompactionThresholdMultiplier(segment.ID)
+
 	// Too many deltalog files, accumulates IO count.
-	if deltaLogCount > Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsInt() {
+	if float64(deltaLogCount) > Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsFloat()*mult {
 		log.Ctx(context.TODO()).Info("delta logs file count exceeds threshold",
 			zap.Int64("segmentID", segment.ID),
 			zap.Int("delta log count", deltaLogCount),
 			zap.Int("file number threshold", Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsInt()),
+			zap.Float64("jitterMultiplier", mult),
 		)
 		return true
 	}
 
 	// The proportion of deleted rows is too large, int64 PK tends to accumulates deleted row counts.
-	if float64(totalDeletedRows)/float64(segment.GetNumOfRows()) >= Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat() {
+	if float64(totalDeletedRows)/float64(segment.GetNumOfRows()) >= Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat()*mult {
 		log.Ctx(context.TODO()).Info("deleted entities rows proportion exceeds threshold",
 			zap.Int64("segmentID", segment.ID),
 			zap.Int64("number of rows", segment.GetNumOfRows()),
 			zap.Int("deleted rows", totalDeletedRows),
 			zap.Float64("proportion threshold", Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat()),
+			zap.Float64("jitterMultiplier", mult),
 		)
 		return true
 	}
 
 	// Delete size is too large, varchar PK tends to accumulates deltalog size.
-	if totalDeleteLogSize > Params.DataCoordCfg.SingleCompactionDeltaLogMaxSize.GetAsInt64() {
+	if float64(totalDeleteLogSize) > float64(Params.DataCoordCfg.SingleCompactionDeltaLogMaxSize.GetAsInt64())*mult {
 		log.Ctx(context.TODO()).Info("total delete entries size exceeds threshold",
 			zap.Int64("segmentID", segment.ID),
 			zap.Int64("numRows", segment.GetNumOfRows()),
 			zap.Int64("delete entries size", totalDeleteLogSize),
 			zap.Int64("size threshold", Params.DataCoordCfg.SingleCompactionDeltaLogMaxSize.GetAsInt64()),
+			zap.Float64("jitterMultiplier", mult),
 		)
 		return true
 	}
@@ -695,7 +756,46 @@ func (t *compactionTrigger) ShouldCompactExpiry(fromTs uint64, compactTime *comp
 	return false
 }
 
-func (t *compactionTrigger) ShouldDoSingleCompaction(segment *SegmentInfo, compactTime *compactTime) bool {
+// singleCompactionReason identifies why a segment qualifies for single
+// compaction. It lets the caller decide whether the reason is avalanche-shaped
+// (delete accumulation — paced by the admission limiter) or a correctness /
+// retention obligation (strict age-based TTL, expiry accumulation, index
+// rebuild) that must bypass pacing so it cannot be starved behind a delete
+// backlog.
+type singleCompactionReason int
+
+const (
+	reasonNone               singleCompactionReason = iota
+	reasonExpiryStrict                              // strict age-based TTL: bypass admission
+	reasonExpiryAccumulation                        // proportion/size of expired entities: bypass admission
+	reasonTooManyDeletions                          // deltalog count/size/deleted-rows ratio: paced
+	reasonRebuildIndex                              // index engine version upgrade: bypass admission
+)
+
+// admissionGated reports whether a candidate with this reason should be paced by
+// the single-compaction admission limiter. Only delete accumulation is gated:
+// its dirtiness (deleted-rows ratio) and bounded-deferral escape hatch (deltalog
+// count vs the hard cap) are both measured from delete deltalogs. Expiry
+// accumulation lives in insert binlogs, so it has neither an ordering signal nor
+// a hard-cap fallback here; pacing it would let a delete backlog starve
+// retention reclamation without bound. It therefore bypasses admission (its
+// bounded per-segment jitter still de-synchronizes a cohort), together with
+// strict age-TTL and index rebuild.
+func (r singleCompactionReason) admissionGated() bool {
+	return r == reasonTooManyDeletions
+}
+
+// singleCompactionReasonFor classifies a segment. Reasons are evaluated in
+// priority order and the first match wins; because delete accumulation is the
+// only gated reason, first-match interacts with gating as follows:
+//   - A delete-heavy segment that is also index-old is checked for deletions
+//     before rebuild, so it is paced (its rewrite rebuilds the index anyway).
+//   - A delete-heavy segment that also trips strict age-TTL or expiry
+//     accumulation matches those first (they precede deletions) and therefore
+//     bypasses pacing — retention must not be starved behind a delete backlog.
+//   - A segment whose only reason is expiry / age-TTL / index rebuild bypasses
+//     pacing.
+func (t *compactionTrigger) singleCompactionReasonFor(segment *SegmentInfo, compactTime *compactTime) singleCompactionReason {
 	// no longer restricted binlog numbers because this is now related to field numbers
 	log := log.Ctx(context.TODO())
 
@@ -719,27 +819,36 @@ func (t *compactionTrigger) ShouldDoSingleCompaction(segment *SegmentInfo, compa
 		}
 	}
 	if t.ShouldCompactExpiry(earliestFromTs, compactTime, segment) {
-		return true
+		return reasonExpiryStrict
 	}
 
-	if float64(totalExpiredRows)/float64(segment.GetNumOfRows()) >= Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat() ||
-		totalExpiredSize > Params.DataCoordCfg.SingleCompactionExpiredLogMaxSize.GetAsInt64() {
+	// Accumulation-type expiry thresholds share the per-segment jitter; the pure
+	// age-based TTL check above is deliberately not jittered (delaying retention
+	// cleanup is a semantic change).
+	expiryMult := singleCompactionThresholdMultiplier(segment.ID)
+	if float64(totalExpiredRows)/float64(segment.GetNumOfRows()) >= Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat()*expiryMult ||
+		float64(totalExpiredSize) > float64(Params.DataCoordCfg.SingleCompactionExpiredLogMaxSize.GetAsInt64())*expiryMult {
 		log.Info("total expired entities is too much, trigger compaction", zap.Int64("segmentID", segment.ID),
 			zap.Int("expiredRows", totalExpiredRows), zap.Int64("expiredLogSize", totalExpiredSize),
-			zap.Bool("createdByCompaction", segment.CreatedByCompaction), zap.Int64s("compactionFrom", segment.CompactionFrom))
-		return true
+			zap.Bool("createdByCompaction", segment.CreatedByCompaction), zap.Int64s("compactionFrom", segment.CompactionFrom),
+			zap.Float64("jitterMultiplier", expiryMult))
+		return reasonExpiryAccumulation
 	}
 
 	// check if deltalog count, size, and deleted rowcount ratio exceeds threshold
 	if hasTooManyDeletions(segment) {
-		return true
+		return reasonTooManyDeletions
 	}
 
 	if t.ShouldRebuildSegmentIndex(segment) {
-		return true
+		return reasonRebuildIndex
 	}
 
-	return false
+	return reasonNone
+}
+
+func (t *compactionTrigger) ShouldDoSingleCompaction(segment *SegmentInfo, compactTime *compactTime) bool {
+	return t.singleCompactionReasonFor(segment, compactTime) != reasonNone
 }
 
 func (t *compactionTrigger) ShouldRebuildSegmentIndex(segment *SegmentInfo) bool {

--- a/internal/datacoord/compaction_trigger_test.go
+++ b/internal/datacoord/compaction_trigger_test.go
@@ -2778,7 +2778,7 @@ func Test_compactionTrigger_generatePlans(t *testing.T) {
 				testingOnly:   true,
 			}
 
-			if got := tr.generatePlans(tt.args.segments, tt.args.signal, tt.args.compactTime, tt.args.expectedSize); !reflect.DeepEqual(got, tt.want) {
+			if got, _ := tr.generatePlans(tt.args.segments, tt.args.signal, tt.args.compactTime, tt.args.expectedSize); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("compactionTrigger.generatePlans() = %+v, want %+v", got, tt.want)
 			}
 		})
@@ -3074,7 +3074,7 @@ func Test_compactionTrigger_generatePlansByTime(t *testing.T) {
 				testingOnly:   true,
 			}
 
-			got := tr.generatePlans(tt.args.segments, tt.args.signal, tt.args.compactTime, tt.args.expectedSize)
+			got, _ := tr.generatePlans(tt.args.segments, tt.args.signal, tt.args.compactTime, tt.args.expectedSize)
 			for i, pair := range got {
 				t.Logf("got[%d]: totalRows=%d, segmentIDs=%v", i, pair.A, pair.B)
 			}

--- a/internal/datacoord/compaction_trigger_v2.go
+++ b/internal/datacoord/compaction_trigger_v2.go
@@ -470,6 +470,18 @@ func (m *CompactionTriggerManager) SubmitClusteringViewToScheduler(ctx context.C
 func (m *CompactionTriggerManager) SubmitSingleViewToScheduler(ctx context.Context, view CompactionView, triggerType CompactionTriggerType) {
 	// single view is definitely one-one mapping
 	log := log.Ctx(ctx).With(zap.String("trigger type", triggerType.String()), zap.String("view", view.String()))
+	// A view whose segment consumed a single-compaction admission token refunds
+	// it if the view is dropped before it is enqueued (alloc/handler error,
+	// inspector busy), so transient failures do not permanently depress the
+	// configured admission rate.
+	submitted := false
+	if mv, ok := view.(*MixSegmentView); ok && mv.admissionGated {
+		defer func() {
+			if !submitted {
+				getSingleCompactionAdmitter().refund(1)
+			}
+		}()
+	}
 	// TODO[GOOSE], 11 = 1 planID + 10 segmentID, this is a hack need to be removed.
 	// Any plan that output segment number greater than 10 will be marked as invalid plan for now.
 	n := 11 * paramtable.Get().DataCoordCfg.CompactionPreAllocateIDExpansionFactor.GetAsInt64()
@@ -520,6 +532,7 @@ func (m *CompactionTriggerManager) SubmitSingleViewToScheduler(ctx context.Conte
 			zap.Error(err))
 		return
 	}
+	submitted = true
 	log.Info("Finish to submit a single compaction task",
 		zap.Int64("triggerID", task.GetTriggerID()),
 		zap.Int64("planID", task.GetPlanID()),

--- a/internal/datacoord/compaction_trigger_v2_test.go
+++ b/internal/datacoord/compaction_trigger_v2_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -22,6 +23,56 @@ import (
 
 func TestCompactionTriggerManagerSuite(t *testing.T) {
 	suite.Run(t, new(CompactionTriggerManagerSuite))
+}
+
+// TestSubmitSingleViewRefundsGatedTokenOnDrop covers the L2 backpressure refund
+// wiring end-to-end: a single view whose segment consumed an admission token is
+// dropped before enqueue (here via an AllocN failure), and the shared bucket
+// must recover the token. A non-gated view leaves the bucket untouched.
+func (s *CompactionTriggerManagerSuite) TestSubmitSingleViewRefundsGatedTokenOnDrop() {
+	newView := func(gated bool) *MixSegmentView {
+		seg := &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            777,
+			CollectionID:  s.testLabel.CollectionID,
+			PartitionID:   s.testLabel.PartitionID,
+			InsertChannel: s.testLabel.Channel,
+			NumOfRows:     1000,
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L2,
+		}}
+		return &MixSegmentView{
+			label:          s.testLabel,
+			segments:       GetViewsByInfo(seg),
+			triggerID:      1,
+			admissionGated: gated,
+		}
+	}
+	// AllocN failure drops the view before it is enqueued.
+	s.mockAlloc.EXPECT().AllocN(mock.Anything).Return(int64(0), int64(0), errors.New("mock alloc fail"))
+
+	a := getSingleCompactionAdmitter()
+
+	s.Run("gated view refunds its token", func() {
+		a.mu.Lock()
+		a.tokens = 5
+		a.mu.Unlock()
+		s.triggerManager.SubmitSingleViewToScheduler(context.Background(), newView(true), TriggerTypeSingle)
+		a.mu.Lock()
+		got := a.tokens
+		a.mu.Unlock()
+		s.InDelta(6.0, got, 0.01, "a dropped gated view must refund its token")
+	})
+
+	s.Run("non-gated view does not refund", func() {
+		a.mu.Lock()
+		a.tokens = 5
+		a.mu.Unlock()
+		s.triggerManager.SubmitSingleViewToScheduler(context.Background(), newView(false), TriggerTypeSingle)
+		a.mu.Lock()
+		got := a.tokens
+		a.mu.Unlock()
+		s.InDelta(5.0, got, 0.01, "a dropped non-gated view must not touch the bucket")
+	})
 }
 
 type CompactionTriggerManagerSuite struct {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4911,6 +4911,9 @@ type dataCoordConfig struct {
 	SingleCompactionDeltaLogMaxSize   ParamItem `refreshable:"true"`
 	SingleCompactionExpiredLogMaxSize ParamItem `refreshable:"true"`
 	SingleCompactionDeltalogMaxNum    ParamItem `refreshable:"true"`
+	SingleCompactionThresholdJitter   ParamItem `refreshable:"true"`
+	SingleCompactionRateLimitTokens   ParamItem `refreshable:"true"`
+	SingleCompactionRateLimitInterval ParamItem `refreshable:"true"`
 
 	StorageVersionCompactionEnabled           ParamItem `refreshable:"true"`
 	StorageVersionCompactionRateLimitTokens   ParamItem `refreshable:"true"`
@@ -5430,6 +5433,42 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.SingleCompactionDeltalogMaxNum.Init(base.mgr)
+
+	p.SingleCompactionThresholdJitter = ParamItem{
+		Key:          "dataCoord.compaction.single.thresholdJitter",
+		Version:      "2.6.17",
+		DefaultValue: "0.25",
+		Doc: "Deterministic per-segment jitter applied to the single-compaction accumulation thresholds " +
+			"(deltalog count/size, deleted-rows ratio, expired-entities ratio/size). Each segment's effective " +
+			"threshold becomes configured x [1, 1+jitter], de-synchronizing same-batch segments so they do not " +
+			"trigger rewrites simultaneously. 0 disables (legacy behavior).",
+		Export: false,
+	}
+	p.SingleCompactionThresholdJitter.Init(base.mgr)
+
+	p.SingleCompactionRateLimitTokens = ParamItem{
+		Key:          "dataCoord.compaction.single.rateLimitTokens",
+		Version:      "2.6.17",
+		DefaultValue: "256",
+		Doc: "Max delete-accumulation single-compaction candidates admitted per rateLimitInterval (token bucket). " +
+			"Shock protection against mass eligibility (e.g. a threshold config change); size it well above " +
+			"steady-state demand — an undersized bucket defers rewrites and lets deltalog backlog grow. A segment " +
+			"whose normalized delete pressure (max over deltalog count, deleted-rows ratio and delete-log size, each " +
+			"vs its threshold) reaches 4x on any axis — scaled by the segment's jitter multiplier — bypasses the " +
+			"limit so deferral stays bounded. Expiry-accumulation, strict age-TTL and index-rebuild compaction are " +
+			"never gated (de-synchronized by jitter only). 0 disables (legacy behavior).",
+		Export: false,
+	}
+	p.SingleCompactionRateLimitTokens.Init(base.mgr)
+
+	p.SingleCompactionRateLimitInterval = ParamItem{
+		Key:          "dataCoord.compaction.single.rateLimitInterval",
+		Version:      "2.6.17",
+		DefaultValue: "60",
+		Doc:          "Refill interval of the single-compaction admission token bucket, in seconds.",
+		Export:       false,
+	}
+	p.SingleCompactionRateLimitInterval.Init(base.mgr)
 
 	p.StorageVersionCompactionEnabled = ParamItem{
 		Key:          "dataCoord.compaction.storageVersion.enabled",


### PR DESCRIPTION
issue: #51094 (ported from #51096, targeting the poc_2.6.17 production branch where the incident occurred)

### What

Segments created in the same batch (bulk import, DR initial sync, restore) accumulate deltalogs at nearly the same rate, so they cross the single-compaction hard thresholds almost simultaneously. The result is a synchronized rewrite avalanche: in a production incident, ~1,400 segments became eligible within ~36 hours and the cluster rewrote multiple TB against a rate-limited object store, degrading queries for days.

Two independent, individually-disableable, refreshable mechanisms:

1. **Deterministic per-segment threshold jitter** (`dataCoord.compaction.single.thresholdJitter`, default 0.25). Each segment gets a stable multiplier in `[1, 1+J]` (splitmix64 hash of segment ID — no persisted state, consistent across restarts/nodes) applied to every accumulation dimension (deltalog count/size, deleted-rows ratio, expired-entities ratio/size). Applies to **all** single-compaction trigger axes and spreads a cohort's crossing times.
2. **Token-bucket admission at plan generation** (`dataCoord.compaction.single.rateLimitTokens` / `rateLimitInterval`, default 256 per 60s) for **delete-accumulation candidates only**, dirtiest-first, with a jittered bounded-deferral escape.

### Scope of each mechanism (precise guarantees)

- The **token-bucket rate ceiling applies to delete accumulation only.** Its dirtiest-first ordering and its bounded-deferral escape both use a *normalized delete pressure* = `max` over the three delete axes (deltalog count, deleted-rows ratio, delete-log size) of `actual / threshold`, so a segment triggered by any single axis (e.g. large varchar-PK deletes concentrated in a few files) is ordered and bounded on that axis — not only on file count.
- **Expiry accumulation, strict age-based TTL, and index rebuild bypass admission** (they are retention / correctness obligations that must not be paced behind a delete backlog). They are **de-synchronized by jitter only**, not rate-capped. A TTL cliff is therefore smeared by jitter, not converted into a token-bucket-paced stream.
- The bounded-deferral **escape is itself jittered** (`pressure >= 4x` scaled by the segment's jitter multiplier) and does not consume a token, so a deferred count-triggered cohort does not re-synchronize at the `4x` threshold and avalanche through the bypass together. The same jitter means a threshold config *decrease* raises pressure into a per-segment spread of escape points rather than releasing the cohort in one round.
- An axis whose threshold is non-positive is skipped, so a misconfigured (`<= 0`) threshold disables that axis rather than turning the escape into a free bypass.
- `thresholdJitter=0` plus `rateLimitTokens=0` restore exact legacy behavior; force/manual compaction bypasses admission.

### Adversarial-review fixes folded in (three rounds on #51096)

- **Starvation of non-delete reasons** — only delete accumulation is admission-gated; expiry accumulation, strict age-TTL and index rebuild bypass pacing.
- **Bounded deferral on every delete axis** (not just file count) via the normalized-pressure escape; dirtiest-first ordering likewise covers all axes.
- **Jittered escape** so a deferred count-triggered cohort cannot re-synchronize and avalanche through the bypass.
- **Sub-one token budget soft-deadlock** — a positive `rateLimitTokens` below 1 clamps to 1.
- **Non-positive threshold** no longer disables pacing (per-axis skip).
- **Throttle-warning masking** — the sustained-throttle counter is cleared only when the bucket has genuinely refilled.
- **Tokens vs backpressure** — both the L1 trigger and the L2 policy refund tokens for admission-gated segments whose plans are dropped before enqueue.

The single shared bucket is intentional: it bounds *aggregate* rewrite load against the object store (which is source-agnostic), and refills every round; per-caller buckets would multiply the aggregate ceiling by the caller count and defeat the protection. Sustained one-sided saturation is surfaced by the throttle warning.

### Test plan

- New `compaction_admission_test.go`: multiplier determinism / range / zero-jitter disable; disabled-bucket passthrough, dirtiest-first limiting, jittered escape bypass, token refill with injected clock; plus dedicated cases for each review fix (sub-one budget, delete-size-axis reaches the escape, non-positive threshold still paces, refund, throttle-counter survival on a drained bucket, reason classification).
- Existing `Test_compactionTrigger_*`, `TestSingleCompactionPolicySuite`, `TestCompactionTriggerManager` pass; two cases asserting the exact legacy `201 vs 200` deltalog boundary pin `thresholdJitter=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)