### PR TITLE
test: [skip e2e] remove fixed search order xfail

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search_order.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_order.py
@@ -805,10 +805,6 @@ class TestMilvusClientSearchOrderIndependent(TestMilvusClientV2Base):
     """
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.xfail(
-        reason="Milvus issue #49879: search with order_by_fields applies offset before scalar ordering",
-        strict=True,
-    )
     def test_milvus_client_search_order_by_with_offset(self):
         """
         target: verify search pagination with order_by_fields applies offset after scalar ordering


### PR DESCRIPTION
issue: #49879

The search order_by_fields offset behavior was fixed by #50143.
Remove the strict xfail marker so the regression test is expected to pass.