### PR TITLE
test: [2.6] fix CDC force-promote cleanup before final diff

### DIFF
--- a/tests/python_client/cdc/testcases/test_force_promote.py
+++ b/tests/python_client/cdc/testcases/test_force_promote.py
@@ -159,6 +159,23 @@ class TestCDCForcePromote(TestCDCSyncBase):
                     logger.warning(f"[CLEANUP] failed to drop {resource_name} on {client_label}: {e}")
         self.resources_to_cleanup = []
 
+    def cleanup_downstream_only_collection(self, collection_name):
+        """Drop a collection created while downstream is force-promoted primary."""
+        client = self._downstream_client
+        if client is None:
+            return
+        try:
+            if client.has_collection(collection_name):
+                logger.info(f"[CLEANUP] Cleaning up downstream-only collection: {collection_name}")
+                client.drop_collection(collection_name)
+                logger.info(f"[SUCCESS] Downstream-only collection {collection_name} cleaned up successfully")
+        except Exception as e:
+            logger.warning(f"[FAILED] Failed to cleanup downstream-only collection {collection_name}: {e}")
+        finally:
+            self.resources_to_cleanup = [
+                resource for resource in self.resources_to_cleanup if resource != ("collection", collection_name)
+            ]
+
     # ------------------------------------------------------------------
     # Tests
     # ------------------------------------------------------------------
@@ -259,6 +276,7 @@ class TestCDCForcePromote(TestCDCSyncBase):
         finally:
             logger.info("[TEARDOWN] Waiting for source pods before topology restore...")
             kubectl_helper.wait_for_pods_ready(source_cluster_id, timeout=300)
+            self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
@@ -391,6 +409,7 @@ class TestCDCForcePromote(TestCDCSyncBase):
         finally:
             logger.info("[TEARDOWN] Waiting for target pods before topology restore...")
             kubectl_helper.wait_for_pods_ready(target_cluster_id, timeout=300)
+            self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
@@ -523,6 +542,7 @@ class TestCDCForcePromote(TestCDCSyncBase):
         finally:
             logger.info("[TEARDOWN] Waiting for source pods before topology restore...")
             kubectl_helper.wait_for_pods_ready(source_cluster_id, timeout=300)
+            self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
@@ -635,6 +655,7 @@ class TestCDCForcePromote(TestCDCSyncBase):
             res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
             assert res and res[0]["count(*)"] >= 100, f"downstream not writable after incomplete DDL: {res}"
         finally:
+            self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)
@@ -799,6 +820,7 @@ class TestCDCForcePromote(TestCDCSyncBase):
                 os.unlink(chaos_path)
             # Allow partition to clear before switchover
             time.sleep(10)
+            self.cleanup_downstream_only_collection(c_after)
             logger.info("[TEARDOWN] Restoring A→B topology...")
             try:
                 switchover_helper(source_cluster_id, target_cluster_id)

--- a/tests/python_client/cdc/testcases/test_force_promote_cleanup.py
+++ b/tests/python_client/cdc/testcases/test_force_promote_cleanup.py
@@ -1,0 +1,39 @@
+import importlib
+import importlib.util
+import sys
+import types
+
+if importlib.util.find_spec("yaml") is None:
+    yaml = types.ModuleType("yaml")
+    yaml.safe_dump = lambda *args, **kwargs: None
+    sys.modules.setdefault("yaml", yaml)
+
+_TestCDCForcePromote = importlib.import_module("cdc.testcases.test_force_promote").TestCDCForcePromote
+
+
+class FakeClient:
+    def __init__(self):
+        self.collections = {"downstream_only"}
+        self.dropped = []
+
+    def has_collection(self, collection_name):
+        return collection_name in self.collections
+
+    def drop_collection(self, collection_name):
+        self.dropped.append(collection_name)
+        self.collections.discard(collection_name)
+
+
+def test_cleanup_downstream_only_collection_before_topology_restore():
+    test = _TestCDCForcePromote()
+    test.resources_to_cleanup = [
+        ("collection", "normal_collection"),
+        ("collection", "downstream_only"),
+    ]
+    test._downstream_client = FakeClient()
+
+    test.cleanup_downstream_only_collection("downstream_only")
+
+    assert test._downstream_client.dropped == ["downstream_only"]
+    assert ("collection", "downstream_only") not in test.resources_to_cleanup
+    assert ("collection", "normal_collection") in test.resources_to_cleanup


### PR DESCRIPTION
## Summary

pr: #50326
issue: #50320

Backport the CDC force-promote cleanup fix from master to the 2.6 branch.

Force-promote tests create `*_after` collections while the downstream cluster is a standalone primary. The previous teardown restored the `upstream -> downstream` topology before cleanup, causing downstream to become secondary and reject the subsequent `drop_collection` requests.

## Changes

- Clean downstream-only collections before restoring the replication topology.
- Remove successfully handled downstream-only collections from the generic cleanup list.
- Add focused unit coverage for the cleanup helper.

## Validation

- [x] Targeted pytest: `1 passed`
- [x] Python syntax compilation
- [x] `ruff check`
- [x] `ruff format --check`
- [x] `git diff --check`
