### PR TITLE
fix: skip raw vector fielddata on storage-v3 load when index has raw data

### DIFF
--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -471,6 +471,12 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     auto prefer_field_data =
         SegcoreConfig::default_config()
             .get_prefer_field_data_when_index_has_raw_data();
+    // The primary key column is never skipped, even when its index carries raw
+    // data: sorted segments navigate rows through the pk column
+    // (num_rows_until_chunk / get_chunk_by_offset), and a pk scalar index is not
+    // registered in scalar_indexings for expression index-reads, so the pk raw
+    // column must stay resident.
+    auto pk_field_id = new_info.schema_->get_primary_field_id();
     auto cur_column_group = GetColumnGroups();
     auto new_column_group = new_info.GetColumnGroups();
 
@@ -548,16 +554,22 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             bool is_replace_field = was_default_filled || files_changed;
             bool index_has_raw_data =
                 new_info.field_index_has_raw_data_.count(fid) > 0;
-            // When the vector index already carries the raw data, the separate
+            bool is_pk_field =
+                pk_field_id.has_value() && pk_field_id.value() == fid;
+            // When a field's index already carries the raw data, the separate
             // raw column is redundant and must NOT be made resident — neither
             // eager nor "lazy" (the loon lazy path still materializes a
             // ProxyChunkColumn and sets field_data_ready, so it stays on disk on
             // top of the index, doubling the footprint). Mirror the binlog path
             // (ChunkedSegmentSealedImpl: "skip fielddata because index has raw
-            // data"): drop it from the load set entirely. prefer_field_data is
-            // the explicit opt-in to keep both resident; system fields always load.
-            if (field_id >= START_USER_FIELDID && index_has_raw_data &&
-                !prefer_field_data) {
+            // data"): drop it from the load set entirely. This covers vector
+            // fields and other indexed scalars (retrieve/filter read the raw
+            // value from the index), but NOT the primary key — its raw column
+            // is still needed resident for row navigation, so the pk always
+            // loads regardless of its index. prefer_field_data keeps both
+            // resident; system fields always load.
+            if (field_id >= START_USER_FIELDID && !is_pk_field &&
+                index_has_raw_data && !prefer_field_data) {
                 // Only the no-raw-index -> raw-index reopen transition can
                 // leave a stale resident copy: current had no raw-data index,
                 // so the raw column was loaded, and now the index carries it.

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -548,6 +548,28 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             bool is_replace_field = was_default_filled || files_changed;
             bool index_has_raw_data =
                 new_info.field_index_has_raw_data_.count(fid) > 0;
+            // When the vector index already carries the raw data, the separate
+            // raw column is redundant and must NOT be made resident — neither
+            // eager nor "lazy" (the loon lazy path still materializes a
+            // ProxyChunkColumn and sets field_data_ready, so it stays on disk on
+            // top of the index, doubling the footprint). Mirror the binlog path
+            // (ChunkedSegmentSealedImpl: "skip fielddata because index has raw
+            // data"): drop it from the load set entirely. prefer_field_data is
+            // the explicit opt-in to keep both resident; system fields always load.
+            if (field_id >= START_USER_FIELDID && index_has_raw_data &&
+                !prefer_field_data) {
+                // Only the no-raw-index -> raw-index reopen transition can
+                // leave a stale resident copy: current had no raw-data index,
+                // so the raw column was loaded, and now the index carries it.
+                // Drop it in that case. In steady state the column was already
+                // skipped (never resident), so there is nothing to free and no
+                // diff to emit.
+                if (cur_iter != cur_field_to_files.end() &&
+                    field_index_has_raw_data_.count(fid) == 0) {
+                    diff.field_data_to_drop.emplace(field_id);
+                }
+                continue;
+            }
             // Eager-load when: system field, OR schema says load AND
             // (we want to keep field data alongside index, OR index can't serve raw).
             bool should_eager_load =
@@ -568,15 +590,12 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
                 } else {
                     lazy_replace_fields.emplace_back(field_id);
                 }
-            } else {
-                // Field at same position — check if needs lazification
-                // (transitioning from no-raw-data-index to raw-data-index)
-                if (!prefer_field_data &&
-                    new_info.field_index_has_raw_data_.count(fid) > 0 &&
-                    field_index_has_raw_data_.count(fid) == 0) {
-                    lazy_replace_fields.emplace_back(field_id);
-                }
             }
+            // No else: a field at the same position whose index gained raw
+            // data (the no-raw-index -> raw-index transition) is handled by the
+            // early "skip raw column" branch above, which drops the stale
+            // resident copy instead of lazifying it (lazy still keeps it on
+            // disk on top of the index — the double-footprint bug this fixes).
         }
         if (!fields.empty()) {
             diff.column_groups_to_load.emplace_back(i, fields);


### PR DESCRIPTION
issue: #51299

## Problem

On the 100M / 128-dim DiskANN benchmark (`test_concurrent_locust_100m_diskann_ddl_dql_filter_cluster`, 1 replica, 100Gi querynode ephemeral-storage), `load_collection` fails on storage-v3 with:

```
segment request resource failed[resourceType=Disk]
```

Root cause: **storage-v3 (loon/vortex) segments load the raw vector column resident *on top of* the vector index, even when the index already carries the raw data.**

The v2 binlog load path skips the raw fielddata when the index has raw data (`ChunkedSegmentSealedImpl`: *"skip fielddata because index has raw data"*). The v3 manifest path in `SegmentLoadInfo::ComputeDiffColumnGroups` instead marked the column **lazy**, but `LoadColumnGroup(eager_load=false)` still materialized a `ProxyChunkColumn` and set `field_data_ready` — so the raw column stayed resident on disk anyway, ~doubling the per-segment footprint.

Evidence (from the failed run's logs + a segcore reproduction):

| | per-node disk | `num_chunk_data(vec)` | `"index has raw data"` skip |
|---|---|---|---|
| **2.6 (v2)** | ~71 GiB predicted (passes) | 0 | logged 99×/node |
| **3.0 (v3)** | ~101 GiB predicted (over 100Gi → fail) | 1 | logged 0×/node |

The extra ~47 GiB ≈ the raw vectors (100M × 128 × 4B).

## Fix

In `SegmentLoadInfo::ComputeDiffColumnGroups`, when a **user field's index carries raw data** and `prefer_field_data_when_index_has_raw_data == false`, drop the raw column from the load set entirely (and free any stale resident copy on the no-raw-index → raw-index reopen transition) instead of lazy-loading it. This mirrors the v2 binlog path. `prefer_field_data` remains the explicit opt-in to keep both resident.

## Test

Adds `internal/core/unittest/test_v2v3_raw_residency.cpp`: builds a V2 (binlog) and a V3 (loon manifest) float-vector segment with a **real IVF_FLAT index**, loads each through the **production load path** (`SegmentLoadInfo → SetLoadInfo → Load`, not a force-load helper), and asserts:
- `num_chunk_data(vec) == 0` and `HasFieldData(vec) == false` (raw column skipped) — for both v2 and v3;
- **correctness gate**: `get_vector` still returns the correct vectors (reconstructed from the index) after the raw column is skipped.

Before the fix this test reproduces the bug (v3 = 1 chunk resident); after the fix v3 should match v2 (0).

## Status

> ⚠️ Draft — the remote unittest build/run to confirm the retrieve-correctness gate + the segcore regression sweep was still in progress when this was pushed. Relying on CI to confirm; will flip to ready once green.
