### PR TITLE
enhance: [cp 3.0] record and expose DataNode task cost_time / cost_cpu_num via QueryTask

### DIFF
--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -262,20 +262,22 @@ func (sched *TaskScheduler) processTask(t Task) {
 			if indexTask != nil {
 				endMs := taskcost.NowMs()
 				costTimeMs := taskcost.CalcCostTimeMs(startMs, endMs)
-				indexTask.manager.StoreIndexTaskExecutionEnd(indexTask.req.GetClusterID(), indexTask.req.GetBuildID(), endMs, costTimeMs)
+				// End bookkeeping and final state must land in one critical
+				// section, so a concurrent QueryTask never sees a final cost
+				// paired with an in-progress state.
+				indexTask.SetStateWithCost(getStateFromError(err), err.Error(), endMs, costTimeMs)
 				mlog.Warn(t.Ctx(), "process task failed", mlog.Err(err), mlog.Int64("costTimeMs", costTimeMs), mlog.Int64("costCPUNum", costCPUNum))
 			} else {
+				t.SetState(getStateFromError(err), err.Error())
 				mlog.Warn(t.Ctx(), "process task failed", mlog.Err(err))
 			}
-			t.SetState(getStateFromError(err), err.Error())
 			return
 		}
 	}
 	if indexTask != nil {
 		endMs := taskcost.NowMs()
 		costTimeMs := taskcost.CalcCostTimeMs(startMs, endMs)
-		indexTask.manager.StoreIndexTaskExecutionEnd(indexTask.req.GetClusterID(), indexTask.req.GetBuildID(), endMs, costTimeMs)
-		t.SetState(indexpb.JobState_JobStateFinished, "")
+		indexTask.SetStateWithCost(indexpb.JobState_JobStateFinished, "", endMs, costTimeMs)
 		mlog.Debug(t.Ctx(), "process task completed", mlog.String("task", t.Name()), mlog.Int64("costTimeMs", costTimeMs), mlog.Int64("costCPUNum", costCPUNum))
 	} else {
 		t.SetState(indexpb.JobState_JobStateFinished, "")

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
 
+	"github.com/milvus-io/milvus/internal/datanode/taskcost"
 	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
@@ -242,19 +243,47 @@ func (sched *TaskScheduler) processTask(t Task) {
 	}()
 	sched.TaskQueue.AddActiveTask(t)
 	defer sched.TaskQueue.PopActiveTask(t.Name())
-	mlog.Debug(t.Ctx(), "process task", mlog.String("task", t.Name()))
+	var (
+		indexTask  *indexBuildTask
+		costCPUNum int64
+		startMs    int64
+	)
+	if ibt, ok := t.(*indexBuildTask); ok {
+		indexTask = ibt
+		costCPUNum = taskcost.EstimateIndexBuildCPUNum(indexTask.IsVectorIndex())
+		startMs = taskcost.NowMs()
+		indexTask.manager.StoreIndexTaskExecutionStart(indexTask.req.GetClusterID(), indexTask.req.GetBuildID(), startMs, costCPUNum)
+	}
+
+	mlog.Debug(t.Ctx(), "process task", mlog.String("task", t.Name()), mlog.Int64("costCPUNum", costCPUNum))
 	pipelines := []func(context.Context) error{t.PreExecute, t.Execute, t.PostExecute}
 	for _, fn := range pipelines {
 		if err := wrap(fn); err != nil {
-			mlog.Warn(t.Ctx(), "process task failed", mlog.Err(err))
+			if indexTask != nil {
+				endMs := taskcost.NowMs()
+				costTimeMs := taskcost.CalcCostTimeMs(startMs, endMs)
+				indexTask.manager.StoreIndexTaskExecutionEnd(indexTask.req.GetClusterID(), indexTask.req.GetBuildID(), endMs, costTimeMs)
+				mlog.Warn(t.Ctx(), "process task failed", mlog.Err(err), mlog.Int64("costTimeMs", costTimeMs), mlog.Int64("costCPUNum", costCPUNum))
+			} else {
+				mlog.Warn(t.Ctx(), "process task failed", mlog.Err(err))
+			}
 			t.SetState(getStateFromError(err), err.Error())
 			return
 		}
 	}
-	t.SetState(indexpb.JobState_JobStateFinished, "")
+	if indexTask != nil {
+		endMs := taskcost.NowMs()
+		costTimeMs := taskcost.CalcCostTimeMs(startMs, endMs)
+		indexTask.manager.StoreIndexTaskExecutionEnd(indexTask.req.GetClusterID(), indexTask.req.GetBuildID(), endMs, costTimeMs)
+		t.SetState(indexpb.JobState_JobStateFinished, "")
+		mlog.Debug(t.Ctx(), "process task completed", mlog.String("task", t.Name()), mlog.Int64("costTimeMs", costTimeMs), mlog.Int64("costCPUNum", costCPUNum))
+	} else {
+		t.SetState(indexpb.JobState_JobStateFinished, "")
+		mlog.Debug(t.Ctx(), "process task completed", mlog.String("task", t.Name()))
+	}
 
 	// Publish filesystem metrics after index task completion
-	if indexTask, ok := t.(*indexBuildTask); ok {
+	if indexTask != nil {
 		if indexTask.req != nil && indexTask.req.GetStorageConfig() != nil {
 			storagev2.PublishFilesystemMetricsWithConfig(indexTask.req.GetStorageConfig())
 		}

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"runtime/debug"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
@@ -246,26 +247,30 @@ func (sched *TaskScheduler) processTask(t Task) {
 	var (
 		indexTask  *indexBuildTask
 		costCPUNum int64
-		startMs    int64
+		execStart  time.Time
 	)
 	if ibt, ok := t.(*indexBuildTask); ok {
 		indexTask = ibt
 		costCPUNum = taskcost.EstimateIndexBuildCPUNum(indexTask.IsVectorIndex())
-		startMs = taskcost.NowMs()
-		indexTask.manager.StoreIndexTaskExecutionStart(indexTask.req.GetClusterID(), indexTask.req.GetBuildID(), startMs, costCPUNum)
+		// execStart carries a monotonic clock reading; CostTimeMs derived from
+		// it is immune to wall-clock steps. ExecStartMs/ExecEndMs stay wall-clock
+		// timestamps for external exposure.
+		execStart = time.Now()
+		indexTask.manager.StoreIndexTaskExecutionStart(indexTask.req.GetClusterID(), indexTask.req.GetBuildID(), taskcost.NowMs(), costCPUNum)
+		mlog.Debug(t.Ctx(), "process task", mlog.String("task", t.Name()), mlog.Int64("costCPUNum", costCPUNum))
+	} else {
+		mlog.Debug(t.Ctx(), "process task", mlog.String("task", t.Name()))
 	}
 
-	mlog.Debug(t.Ctx(), "process task", mlog.String("task", t.Name()), mlog.Int64("costCPUNum", costCPUNum))
 	pipelines := []func(context.Context) error{t.PreExecute, t.Execute, t.PostExecute}
 	for _, fn := range pipelines {
 		if err := wrap(fn); err != nil {
 			if indexTask != nil {
-				endMs := taskcost.NowMs()
-				costTimeMs := taskcost.CalcCostTimeMs(startMs, endMs)
+				costTimeMs := taskcost.ElapsedMs(execStart)
 				// End bookkeeping and final state must land in one critical
 				// section, so a concurrent QueryTask never sees a final cost
 				// paired with an in-progress state.
-				indexTask.SetStateWithCost(getStateFromError(err), err.Error(), endMs, costTimeMs)
+				indexTask.SetStateWithCost(getStateFromError(err), err.Error(), taskcost.NowMs(), costTimeMs)
 				mlog.Warn(t.Ctx(), "process task failed", mlog.Err(err), mlog.Int64("costTimeMs", costTimeMs), mlog.Int64("costCPUNum", costCPUNum))
 			} else {
 				t.SetState(getStateFromError(err), err.Error())
@@ -275,9 +280,8 @@ func (sched *TaskScheduler) processTask(t Task) {
 		}
 	}
 	if indexTask != nil {
-		endMs := taskcost.NowMs()
-		costTimeMs := taskcost.CalcCostTimeMs(startMs, endMs)
-		indexTask.SetStateWithCost(indexpb.JobState_JobStateFinished, "", endMs, costTimeMs)
+		costTimeMs := taskcost.ElapsedMs(execStart)
+		indexTask.SetStateWithCost(indexpb.JobState_JobStateFinished, "", taskcost.NowMs(), costTimeMs)
 		mlog.Debug(t.Ctx(), "process task completed", mlog.String("task", t.Name()), mlog.Int64("costTimeMs", costTimeMs), mlog.Int64("costCPUNum", costCPUNum))
 	} else {
 		t.SetState(indexpb.JobState_JobStateFinished, "")

--- a/internal/datanode/index/scheduler_test.go
+++ b/internal/datanode/index/scheduler_test.go
@@ -23,10 +23,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -229,4 +234,73 @@ func TestIndexTaskScheduler(t *testing.T) {
 	for _, task := range tasks {
 		assert.Equal(t, task.GetState(), indexpb.JobState_JobStateFinished)
 	}
+}
+
+func newSchedulerIndexBuildTask(t *testing.T, manager *TaskManager, buildID int64) *indexBuildTask {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	req := &workerpb.CreateJobRequest{
+		ClusterID: "test-cluster",
+		BuildID:   buildID,
+		IndexParams: []*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "STL_SORT"},
+		},
+		Field: &schemapb.FieldSchema{
+			FieldID:  100,
+			DataType: schemapb.DataType_Int64,
+		},
+	}
+	manager.LoadOrStoreIndexTask(req.GetClusterID(), req.GetBuildID(), &IndexTaskInfo{
+		State: commonpb.IndexState_InProgress,
+	})
+	return NewIndexBuildTask(ctx, cancel, req, nil, manager, nil)
+}
+
+func TestIndexTaskSchedulerRecordsIndexTaskCost(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("success records execution cost", func(t *testing.T) {
+		manager := NewTaskManager(context.Background())
+		task := newSchedulerIndexBuildTask(t, manager, 1001)
+
+		preMock := mockey.Mock((*indexBuildTask).PreExecute).Return(nil).Build()
+		defer preMock.UnPatch()
+		executeMock := mockey.Mock((*indexBuildTask).Execute).Return(nil).Build()
+		defer executeMock.UnPatch()
+		postMock := mockey.Mock((*indexBuildTask).PostExecute).Return(nil).Build()
+		defer postMock.UnPatch()
+
+		scheduler := NewTaskScheduler(context.Background())
+		scheduler.processTask(task)
+
+		info := manager.GetIndexTaskInfo("test-cluster", 1001)
+		assert.NotNil(t, info)
+		assert.Equal(t, commonpb.IndexState_Finished, info.State)
+		assert.Greater(t, info.ExecStartMs, int64(0))
+		assert.GreaterOrEqual(t, info.ExecEndMs, info.ExecStartMs)
+		assert.GreaterOrEqual(t, info.CostTimeMs, int64(0))
+		assert.Equal(t, int64(1), info.CostCPUNum)
+	})
+
+	t.Run("pre execute failure still records execution end", func(t *testing.T) {
+		manager := NewTaskManager(context.Background())
+		task := newSchedulerIndexBuildTask(t, manager, 1002)
+		expectedErr := errors.New("pre execute failed")
+
+		preMock := mockey.Mock((*indexBuildTask).PreExecute).Return(expectedErr).Build()
+		defer preMock.UnPatch()
+
+		scheduler := NewTaskScheduler(context.Background())
+		scheduler.processTask(task)
+
+		info := manager.GetIndexTaskInfo("test-cluster", 1002)
+		assert.NotNil(t, info)
+		assert.Equal(t, commonpb.IndexState_Retry, info.State)
+		assert.Equal(t, expectedErr.Error(), info.FailReason)
+		assert.Greater(t, info.ExecStartMs, int64(0))
+		assert.GreaterOrEqual(t, info.ExecEndMs, info.ExecStartMs)
+		assert.GreaterOrEqual(t, info.CostTimeMs, int64(0))
+		assert.Equal(t, int64(1), info.CostCPUNum)
+	})
 }

--- a/internal/datanode/index/scheduler_test.go
+++ b/internal/datanode/index/scheduler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -302,5 +303,30 @@ func TestIndexTaskSchedulerRecordsIndexTaskCost(t *testing.T) {
 		assert.GreaterOrEqual(t, info.ExecEndMs, info.ExecStartMs)
 		assert.GreaterOrEqual(t, info.CostTimeMs, int64(0))
 		assert.Equal(t, int64(1), info.CostCPUNum)
+	})
+
+	t.Run("vector index records build pool cpu num", func(t *testing.T) {
+		manager := NewTaskManager(context.Background())
+		task := newSchedulerIndexBuildTask(t, manager, 1003)
+
+		vecMock := mockey.Mock((*indexBuildTask).IsVectorIndex).Return(true).Build()
+		defer vecMock.UnPatch()
+		preMock := mockey.Mock((*indexBuildTask).PreExecute).Return(nil).Build()
+		defer preMock.UnPatch()
+		executeMock := mockey.Mock((*indexBuildTask).Execute).Return(nil).Build()
+		defer executeMock.UnPatch()
+		postMock := mockey.Mock((*indexBuildTask).PostExecute).Return(nil).Build()
+		defer postMock.UnPatch()
+
+		scheduler := NewTaskScheduler(context.Background())
+		scheduler.processTask(task)
+
+		info := manager.GetIndexTaskInfo("test-cluster", 1003)
+		assert.NotNil(t, info)
+		assert.Equal(t, commonpb.IndexState_Finished, info.State)
+		assert.Greater(t, info.ExecStartMs, int64(0))
+		assert.GreaterOrEqual(t, info.ExecEndMs, info.ExecStartMs)
+		assert.GreaterOrEqual(t, info.CostTimeMs, int64(0))
+		assert.Equal(t, int64(hardware.GetCPUNum()), info.CostCPUNum)
 	})
 }

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -118,6 +118,19 @@ func (it *indexBuildTask) Name() string {
 
 func (it *indexBuildTask) SetState(state indexpb.JobState, failReason string) {
 	it.manager.StoreIndexTaskState(it.req.GetClusterID(), it.req.GetBuildID(), commonpb.IndexState(state), failReason)
+	it.observeStateMetrics(state)
+}
+
+// SetStateWithCost stores the final state/failReason together with the
+// execution-end cost bookkeeping in one TaskManager critical section, so a
+// concurrent QueryTask can never observe a final cost paired with a stale
+// in-progress state.
+func (it *indexBuildTask) SetStateWithCost(state indexpb.JobState, failReason string, endMs, costTimeMs int64) {
+	it.manager.StoreIndexTaskExecutionEndWithState(it.req.GetClusterID(), it.req.GetBuildID(), endMs, costTimeMs, commonpb.IndexState(state), failReason)
+	it.observeStateMetrics(state)
+}
+
+func (it *indexBuildTask) observeStateMetrics(state indexpb.JobState) {
 	if state == indexpb.JobState_JobStateFinished {
 		metrics.DataNodeBuildIndexLatency.WithLabelValues(paramtable.GetStringNodeID()).Observe(it.tr.ElapseSpan().Seconds())
 		metrics.DataNodeIndexTaskLatencyInQueue.WithLabelValues(paramtable.GetStringNodeID()).Observe(float64(it.queueDur.Milliseconds()))

--- a/internal/datanode/index/task_manager.go
+++ b/internal/datanode/index/task_manager.go
@@ -150,13 +150,22 @@ func (m *TaskManager) StoreIndexTaskExecutionStart(clusterID string, buildID typ
 	}
 }
 
-func (m *TaskManager) StoreIndexTaskExecutionEnd(clusterID string, buildID typeutil.UniqueID, endMs int64, costTimeMs int64) {
+// StoreIndexTaskExecutionEndWithState records the execution-end cost bookkeeping
+// together with the final task state/failReason in a single critical section, so
+// a concurrent reader can never observe a final cost paired with a stale state
+// (or vice versa).
+func (m *TaskManager) StoreIndexTaskExecutionEndWithState(clusterID string, buildID typeutil.UniqueID, endMs int64, costTimeMs int64, state commonpb.IndexState, failReason string) {
 	key := Key{ClusterID: clusterID, TaskID: buildID}
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 	if task, ok := m.indexTasks[key]; ok {
+		mlog.Debug(m.ctx, "store task execution end with state", mlog.String("clusterID", clusterID), mlog.FieldBuildID(buildID),
+			mlog.String("state", state.String()), mlog.String("fail reason", failReason),
+			mlog.Int64("costTimeMs", costTimeMs))
 		task.ExecEndMs = endMs
 		task.CostTimeMs = costTimeMs
+		task.State = state
+		task.FailReason = failReason
 	}
 }
 

--- a/internal/datanode/index/task_manager.go
+++ b/internal/datanode/index/task_manager.go
@@ -44,6 +44,10 @@ type IndexTaskInfo struct {
 	CurrentIndexVersion       int32
 	CurrentScalarIndexVersion int32
 	IndexStorePathVersion     indexpb.IndexStorePathVersion
+	ExecStartMs               int64
+	ExecEndMs                 int64
+	CostTimeMs                int64
+	CostCPUNum                int64
 
 	// task statistics
 	statistic *indexpb.JobInfo
@@ -60,6 +64,10 @@ func (i *IndexTaskInfo) Clone() *IndexTaskInfo {
 		CurrentIndexVersion:       i.CurrentIndexVersion,
 		CurrentScalarIndexVersion: i.CurrentScalarIndexVersion,
 		IndexStorePathVersion:     i.IndexStorePathVersion,
+		ExecStartMs:               i.ExecStartMs,
+		ExecEndMs:                 i.ExecEndMs,
+		CostTimeMs:                i.CostTimeMs,
+		CostCPUNum:                i.CostCPUNum,
 		statistic:                 typeutil.Clone(i.statistic),
 	}
 }
@@ -130,12 +138,44 @@ func (m *TaskManager) StoreIndexTaskState(ClusterID string, buildID typeutil.Uni
 	}
 }
 
+func (m *TaskManager) StoreIndexTaskExecutionStart(clusterID string, buildID typeutil.UniqueID, startMs int64, costCPUNum int64) {
+	key := Key{ClusterID: clusterID, TaskID: buildID}
+	m.stateLock.Lock()
+	defer m.stateLock.Unlock()
+	if task, ok := m.indexTasks[key]; ok {
+		task.ExecStartMs = startMs
+		task.CostCPUNum = costCPUNum
+		task.ExecEndMs = 0
+		task.CostTimeMs = 0
+	}
+}
+
+func (m *TaskManager) StoreIndexTaskExecutionEnd(clusterID string, buildID typeutil.UniqueID, endMs int64, costTimeMs int64) {
+	key := Key{ClusterID: clusterID, TaskID: buildID}
+	m.stateLock.Lock()
+	defer m.stateLock.Unlock()
+	if task, ok := m.indexTasks[key]; ok {
+		task.ExecEndMs = endMs
+		task.CostTimeMs = costTimeMs
+	}
+}
+
 func (m *TaskManager) ForeachIndexTaskInfo(fn func(ClusterID string, buildID typeutil.UniqueID, info *IndexTaskInfo)) {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
 	for key, info := range m.indexTasks {
 		fn(key.ClusterID, key.TaskID, info)
 	}
+}
+
+func (m *TaskManager) GetIndexTaskInfo(clusterID string, buildID typeutil.UniqueID) *IndexTaskInfo {
+	m.stateLock.Lock()
+	defer m.stateLock.Unlock()
+
+	if info, ok := m.indexTasks[Key{ClusterID: clusterID, TaskID: buildID}]; ok {
+		return info.Clone()
+	}
+	return nil
 }
 
 func (m *TaskManager) StoreIndexFilesAndStatistic(

--- a/internal/datanode/index/task_manager_test.go
+++ b/internal/datanode/index/task_manager_test.go
@@ -162,7 +162,7 @@ func (s *statsTaskInfoSuite) Test_IndexTaskCostMethods() {
 	s.manager.LoadOrStoreIndexTask(s.cluster, buildID, &IndexTaskInfo{State: commonpb.IndexState_InProgress})
 
 	s.manager.StoreIndexTaskExecutionStart(s.cluster, buildID, 111, 4)
-	s.manager.StoreIndexTaskExecutionEnd(s.cluster, buildID, 222, 111)
+	s.manager.StoreIndexTaskExecutionEndWithState(s.cluster, buildID, 222, 111, commonpb.IndexState_Failed, "mock failure")
 
 	info := s.manager.GetIndexTaskInfo(s.cluster, buildID)
 	s.Require().NotNil(info)
@@ -170,6 +170,9 @@ func (s *statsTaskInfoSuite) Test_IndexTaskCostMethods() {
 	s.Equal(int64(222), info.ExecEndMs)
 	s.Equal(int64(111), info.CostTimeMs)
 	s.Equal(int64(4), info.CostCPUNum)
+	// state/failReason land together with the cost in one critical section
+	s.Equal(commonpb.IndexState_Failed, info.State)
+	s.Equal("mock failure", info.FailReason)
 
 	info.CostCPUNum = 999
 	reloaded := s.manager.GetIndexTaskInfo(s.cluster, buildID)

--- a/internal/datanode/index/task_manager_test.go
+++ b/internal/datanode/index/task_manager_test.go
@@ -156,3 +156,29 @@ func (s *statsTaskInfoSuite) TestIndexTaskInfoReturnsIndexStorePathVersion() {
 	cloned := info.Clone()
 	s.Equal(indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_COLLECTION_ROOTED, cloned.IndexStorePathVersion)
 }
+
+func (s *statsTaskInfoSuite) Test_IndexTaskCostMethods() {
+	buildID := int64(200)
+	s.manager.LoadOrStoreIndexTask(s.cluster, buildID, &IndexTaskInfo{State: commonpb.IndexState_InProgress})
+
+	s.manager.StoreIndexTaskExecutionStart(s.cluster, buildID, 111, 4)
+	s.manager.StoreIndexTaskExecutionEnd(s.cluster, buildID, 222, 111)
+
+	info := s.manager.GetIndexTaskInfo(s.cluster, buildID)
+	s.Require().NotNil(info)
+	s.Equal(int64(111), info.ExecStartMs)
+	s.Equal(int64(222), info.ExecEndMs)
+	s.Equal(int64(111), info.CostTimeMs)
+	s.Equal(int64(4), info.CostCPUNum)
+
+	info.CostCPUNum = 999
+	reloaded := s.manager.GetIndexTaskInfo(s.cluster, buildID)
+	s.Equal(int64(4), reloaded.CostCPUNum)
+
+	s.manager.StoreIndexTaskExecutionStart(s.cluster, buildID, 333, 8)
+	reloaded = s.manager.GetIndexTaskInfo(s.cluster, buildID)
+	s.Equal(int64(333), reloaded.ExecStartMs)
+	s.Equal(int64(8), reloaded.CostCPUNum)
+	s.Equal(int64(0), reloaded.ExecEndMs)
+	s.Equal(int64(0), reloaded.CostTimeMs)
+}

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -814,22 +814,31 @@ func (node *DataNode) QueryTask(ctx context.Context, request *workerpb.QueryTask
 		}
 		return wrapQueryTaskResult(resp, resProperties)
 	case taskcommon.Index:
-		resp, err := node.queryIndexTask(ctx, &workerpb.QueryJobsRequest{ClusterID: clusterID, TaskIDs: []int64{taskID}})
-		if err != nil {
-			return nil, err
-		}
+		// State/reason and cost must come from one snapshot cloned under one
+		// lock, so a concurrently completing task can never yield a final cost
+		// paired with an in-progress state (or vice versa).
 		resProperties := taskcommon.NewProperties(nil)
-		results := resp.GetIndexJobResults().GetResults()
-		if len(results) > 0 {
-			resProperties.AppendTaskState(taskcommon.State(results[0].GetState()))
-			resProperties.AppendReason(results[0].GetFailReason())
-		}
-		if taskInfo := node.taskManager.GetIndexTaskInfo(clusterID, taskID); taskInfo != nil {
-			resProperties.AppendCostTime(taskInfo.CostTimeMs)
-			resProperties.AppendCostCPUNum(taskInfo.CostCPUNum)
-		} else {
+		info := node.taskManager.GetIndexTaskInfo(clusterID, taskID)
+		if info == nil {
 			resProperties.AppendCostTime(0)
 			resProperties.AppendCostCPUNum(0)
+			resp := &workerpb.QueryJobsV2Response{
+				Status: merr.Status(merr.WrapErrServiceInternalMsg("tasks '%v' not found", []int64{taskID})),
+			}
+			return wrapQueryTaskResult(resp, resProperties)
+		}
+		resProperties.AppendTaskState(taskcommon.State(info.State))
+		resProperties.AppendReason(info.FailReason)
+		resProperties.AppendCostTime(info.CostTimeMs)
+		resProperties.AppendCostCPUNum(info.CostCPUNum)
+		resp := &workerpb.QueryJobsV2Response{
+			Status:    merr.Success(),
+			ClusterID: clusterID,
+			Result: &workerpb.QueryJobsV2Response_IndexJobResults{
+				IndexJobResults: &workerpb.IndexJobResults{
+					Results: []*workerpb.IndexTaskInfo{info.ToIndexTaskInfo(taskID)},
+				},
+			},
 		}
 		return wrapQueryTaskResult(resp, resProperties)
 	case taskcommon.Stats:

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -824,6 +824,13 @@ func (node *DataNode) QueryTask(ctx context.Context, request *workerpb.QueryTask
 			resProperties.AppendTaskState(taskcommon.State(results[0].GetState()))
 			resProperties.AppendReason(results[0].GetFailReason())
 		}
+		if taskInfo := node.taskManager.GetIndexTaskInfo(clusterID, taskID); taskInfo != nil {
+			resProperties.AppendCostTime(taskInfo.CostTimeMs)
+			resProperties.AppendCostCPUNum(taskInfo.CostCPUNum)
+		} else {
+			resProperties.AppendCostTime(0)
+			resProperties.AppendCostCPUNum(0)
+		}
 		return wrapQueryTaskResult(resp, resProperties)
 	case taskcommon.Stats:
 		resp, err := node.queryStatsTask(ctx, &workerpb.QueryJobsRequest{ClusterID: clusterID, TaskIDs: []int64{taskID}})

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datanode/compactor"
 	"github.com/milvus-io/milvus/internal/datanode/external"
+	"github.com/milvus-io/milvus/internal/datanode/index"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -676,6 +677,25 @@ func (s *DataNodeServicesSuite) TestQueryTask() {
 		resp, err := s.node.QueryTask(s.ctx, req)
 		s.Error(merr.CheckRPCCall(resp, err))
 		s.True(strings.Contains(resp.GetStatus().GetReason(), "not found"))
+	})
+
+	s.Run("query index task with cost", func() {
+		s.node.taskManager.LoadOrStoreIndexTask("cluster-0", 101, &index.IndexTaskInfo{State: commonpb.IndexState_Finished})
+		s.node.taskManager.StoreIndexTaskExecutionStart("cluster-0", 101, 100, 3)
+		s.node.taskManager.StoreIndexTaskExecutionEnd("cluster-0", 101, 180, 80)
+
+		req := &workerpb.QueryTaskRequest{
+			Properties: map[string]string{
+				taskcommon.ClusterIDKey: "cluster-0",
+				taskcommon.TypeKey:      taskcommon.Index,
+				taskcommon.TaskIDKey:    "101",
+			},
+		}
+		resp, err := s.node.QueryTask(s.ctx, req)
+		s.NoError(merr.CheckRPCCall(resp, err))
+		props := taskcommon.NewProperties(resp.GetProperties())
+		s.Equal(int64(80), props.GetCostTime())
+		s.Equal(int64(3), props.GetCostCPUNum())
 	})
 
 	s.Run("invalid task type", func() {

--- a/internal/datanode/services_test.go
+++ b/internal/datanode/services_test.go
@@ -680,9 +680,9 @@ func (s *DataNodeServicesSuite) TestQueryTask() {
 	})
 
 	s.Run("query index task with cost", func() {
-		s.node.taskManager.LoadOrStoreIndexTask("cluster-0", 101, &index.IndexTaskInfo{State: commonpb.IndexState_Finished})
+		s.node.taskManager.LoadOrStoreIndexTask("cluster-0", 101, &index.IndexTaskInfo{State: commonpb.IndexState_InProgress})
 		s.node.taskManager.StoreIndexTaskExecutionStart("cluster-0", 101, 100, 3)
-		s.node.taskManager.StoreIndexTaskExecutionEnd("cluster-0", 101, 180, 80)
+		s.node.taskManager.StoreIndexTaskExecutionEndWithState("cluster-0", 101, 180, 80, commonpb.IndexState_Finished, "")
 
 		req := &workerpb.QueryTaskRequest{
 			Properties: map[string]string{
@@ -694,6 +694,10 @@ func (s *DataNodeServicesSuite) TestQueryTask() {
 		resp, err := s.node.QueryTask(s.ctx, req)
 		s.NoError(merr.CheckRPCCall(resp, err))
 		props := taskcommon.NewProperties(resp.GetProperties())
+		// state and cost come from the same snapshot
+		state, err := props.GetTaskState()
+		s.NoError(err)
+		s.Equal(taskcommon.State(commonpb.IndexState_Finished), state)
 		s.Equal(int64(80), props.GetCostTime())
 		s.Equal(int64(3), props.GetCostCPUNum())
 	})

--- a/internal/datanode/taskcost/cost.go
+++ b/internal/datanode/taskcost/cost.go
@@ -1,0 +1,52 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskcost
+
+import (
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
+)
+
+func NowMs() int64 {
+	return time.Now().UnixMilli()
+}
+
+func CalcCostTimeMs(startMs, endMs int64) int64 {
+	if startMs <= 0 || endMs <= 0 || endMs < startMs {
+		return 0
+	}
+	return endMs - startMs
+}
+
+// EstimateIndexBuildCPUNum returns the approximate number of CPU threads an
+// index build task consumes during execution.
+//
+// Vector indexes go through knowhere's build thread pool (sized to NumCPU
+// in cluster mode, see internal/datanode/index/init_segcore.go:74), so they
+// report hardware.GetCPUNum(). All current scalar indexes build
+// single-threaded: the tantivy wrapper hardcodes 1 thread
+// (internal/core/thirdparty/tantivy/tantivy-wrapper.h:23 — covers INVERTED /
+// NGRAM / TEXT_MATCH / JSON_INVERTED), and the rest (BITMAP / STL_SORT /
+// STRING_SORT / MARISA / HYBRID / RTREE) are plain loops with no thread
+// pool / OpenMP / std::async. They therefore report 1.
+func EstimateIndexBuildCPUNum(isVectorIndex bool) int64 {
+	if isVectorIndex {
+		return int64(hardware.GetCPUNum())
+	}
+	return 1
+}

--- a/internal/datanode/taskcost/cost.go
+++ b/internal/datanode/taskcost/cost.go
@@ -22,15 +22,18 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 )
 
+// NowMs returns the current wall-clock time in milliseconds. Use it only for
+// externally exposed timestamps (ExecStartMs / ExecEndMs); never subtract two
+// NowMs readings to derive a duration — use ElapsedMs instead.
 func NowMs() int64 {
 	return time.Now().UnixMilli()
 }
 
-func CalcCostTimeMs(startMs, endMs int64) int64 {
-	if startMs <= 0 || endMs <= 0 || endMs < startMs {
-		return 0
-	}
-	return endMs - startMs
+// ElapsedMs returns the duration since start in milliseconds. It relies on the
+// monotonic clock reading embedded in start (time.Since), so the result is
+// immune to wall-clock steps such as NTP corrections and is never negative.
+func ElapsedMs(start time.Time) int64 {
+	return time.Since(start).Milliseconds()
 }
 
 // EstimateIndexBuildCPUNum returns the approximate number of CPU threads an

--- a/internal/datanode/taskcost/cost.go
+++ b/internal/datanode/taskcost/cost.go
@@ -36,6 +36,11 @@ func CalcCostTimeMs(startMs, endMs int64) int64 {
 // EstimateIndexBuildCPUNum returns the approximate number of CPU threads an
 // index build task consumes during execution.
 //
+// The value is task-level statistics for observability only and is never used
+// for coordinator-side scheduling, so approximation error is acceptable (e.g.
+// standalone sizes the build pool to NumCPU * buildIndexThreadPoolRatio, and
+// concurrent builds share one pool).
+//
 // Vector indexes go through knowhere's build thread pool (sized to NumCPU
 // in cluster mode, see internal/datanode/index/init_segcore.go:74), so they
 // report hardware.GetCPUNum(). All current scalar indexes build

--- a/internal/datanode/taskcost/cost_test.go
+++ b/internal/datanode/taskcost/cost_test.go
@@ -1,0 +1,49 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskcost
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
+)
+
+func TestNowMs(t *testing.T) {
+	before := time.Now().UnixMilli()
+	got := NowMs()
+	after := time.Now().UnixMilli()
+	assert.GreaterOrEqual(t, got, before)
+	assert.LessOrEqual(t, got, after)
+}
+
+func TestCalcCostTimeMs(t *testing.T) {
+	assert.Equal(t, int64(50), CalcCostTimeMs(100, 150))
+	assert.Equal(t, int64(0), CalcCostTimeMs(100, 100))
+	assert.Equal(t, int64(0), CalcCostTimeMs(0, 150), "zero start returns 0")
+	assert.Equal(t, int64(0), CalcCostTimeMs(100, 0), "zero end returns 0")
+	assert.Equal(t, int64(0), CalcCostTimeMs(200, 100), "end before start returns 0")
+}
+
+func TestEstimateIndexBuildCPUNum(t *testing.T) {
+	assert.Equal(t, int64(hardware.GetCPUNum()), EstimateIndexBuildCPUNum(true),
+		"vector index saturates knowhere build pool")
+	assert.Equal(t, int64(1), EstimateIndexBuildCPUNum(false),
+		"all scalar indexes currently build single-threaded")
+}

--- a/internal/datanode/taskcost/cost_test.go
+++ b/internal/datanode/taskcost/cost_test.go
@@ -33,12 +33,12 @@ func TestNowMs(t *testing.T) {
 	assert.LessOrEqual(t, got, after)
 }
 
-func TestCalcCostTimeMs(t *testing.T) {
-	assert.Equal(t, int64(50), CalcCostTimeMs(100, 150))
-	assert.Equal(t, int64(0), CalcCostTimeMs(100, 100))
-	assert.Equal(t, int64(0), CalcCostTimeMs(0, 150), "zero start returns 0")
-	assert.Equal(t, int64(0), CalcCostTimeMs(100, 0), "zero end returns 0")
-	assert.Equal(t, int64(0), CalcCostTimeMs(200, 100), "end before start returns 0")
+func TestElapsedMs(t *testing.T) {
+	start := time.Now()
+	time.Sleep(10 * time.Millisecond)
+	got := ElapsedMs(start)
+	// Sleep guarantees at least 10ms elapsed on the monotonic clock.
+	assert.GreaterOrEqual(t, got, int64(10))
 }
 
 func TestEstimateIndexBuildCPUNum(t *testing.T) {

--- a/pkg/taskcommon/properties.go
+++ b/pkg/taskcommon/properties.go
@@ -37,8 +37,10 @@ const (
 	CollectionIDKey = "collection_id"
 
 	// result
-	StateKey  = "task_state"
-	ReasonKey = "task_reason"
+	StateKey      = "task_state"
+	ReasonKey     = "task_reason"
+	CostTimeKey   = "cost_time"
+	CostCPUNumKey = "cost_cpu_num"
 )
 
 type Properties map[string]string
@@ -100,6 +102,14 @@ func (p Properties) AppendReason(reason string) {
 
 func (p Properties) AppendTaskState(state State) {
 	p[StateKey] = state.String()
+}
+
+func (p Properties) AppendCostTime(costTime int64) {
+	p[CostTimeKey] = fmt.Sprintf("%d", costTime)
+}
+
+func (p Properties) AppendCostCPUNum(costCPUNum int64) {
+	p[CostCPUNumKey] = fmt.Sprintf("%d", costCPUNum)
 }
 
 func (p Properties) GetTaskType() (Type, error) {
@@ -205,4 +215,26 @@ func (p Properties) GetCollectionID() (int64, error) {
 		return 0, err
 	}
 	return collectionID, nil
+}
+
+func (p Properties) GetCostTime() int64 {
+	if _, ok := p[CostTimeKey]; !ok {
+		return 0
+	}
+	costTime, err := strconv.ParseInt(p[CostTimeKey], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return costTime
+}
+
+func (p Properties) GetCostCPUNum() int64 {
+	if _, ok := p[CostCPUNumKey]; !ok {
+		return 0
+	}
+	costCPUNum, err := strconv.ParseInt(p[CostCPUNumKey], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return costCPUNum
 }

--- a/pkg/taskcommon/properties_test.go
+++ b/pkg/taskcommon/properties_test.go
@@ -100,3 +100,29 @@ func TestProperties_CollectionID(t *testing.T) {
 		assert.Equal(t, int64(-1), collectionID)
 	})
 }
+
+func TestProperties_CostFields(t *testing.T) {
+	t.Run("append and get", func(t *testing.T) {
+		props := NewProperties(nil)
+		props.AppendCostTime(123)
+		props.AppendCostCPUNum(4)
+
+		assert.Equal(t, int64(123), props.GetCostTime())
+		assert.Equal(t, int64(4), props.GetCostCPUNum())
+	})
+
+	t.Run("missing keys", func(t *testing.T) {
+		props := NewProperties(nil)
+		assert.Equal(t, int64(0), props.GetCostTime())
+		assert.Equal(t, int64(0), props.GetCostCPUNum())
+	})
+
+	t.Run("invalid values", func(t *testing.T) {
+		props := NewProperties(map[string]string{
+			CostTimeKey:   "abc",
+			CostCPUNumKey: "xyz",
+		})
+		assert.Equal(t, int64(0), props.GetCostTime())
+		assert.Equal(t, int64(0), props.GetCostCPUNum())
+	})
+}


### PR DESCRIPTION
issue: #49156
pr: #51443

## Summary

Cherry-pick of #51443 to 3.0 (clean pick, cumulative diff byte-identical to the master PR):

- Record `cost_time` / `cost_cpu_num` on DataNode index build tasks and surface them through `QueryTask` response `Properties`.
- Reserve the unified `cost_time` / `cost_cpu_num` keys under `pkg/taskcommon` so future PRs can wire up the other `CreateTask`-dispatched task types.
- Introduce small `internal/datanode/taskcost` helper (`NowMs`, `CalcCostTimeMs`, `EstimateIndexBuildCPUNum`) for index build task cost accounting.
- Final state/failReason and execution-end cost are written in a single `TaskManager` critical section, and `QueryTask` reads them from a single snapshot, so state and cost in one response are always consistent.

## Notes

Producer-side only; DataCoord / proxy / metrics exporter do not consume these properties yet. `cost_cpu_num` is a coarse, statistics-only estimate for observability and is not used for coordinator-side scheduling.

Includes both master commits: the feature (`8a4ab16f1f`) and the adversarial-review fixes (`055842e1c9`).
