### PR TITLE
test: Add REST query order by coverage

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_query_order.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query_order.py
@@ -22,10 +22,26 @@ CUSTOM_PARTITION_NAME = "odd_partition"
 PRICE_MIN = 10.0
 RATING_MIN = 0.0
 CATEGORIES = [
-    "electronics", "tools", "books", "sports", "movies",
-    "games", "furniture", "health", "toys", "jewelry",
-    "cosmetics", "clothing", "garden", "food", "travel",
-    "pet_supplies", "beauty", "appliances", "automotive", "music"
+    "electronics",
+    "tools",
+    "books",
+    "sports",
+    "movies",
+    "games",
+    "furniture",
+    "health",
+    "toys",
+    "jewelry",
+    "cosmetics",
+    "clothing",
+    "garden",
+    "food",
+    "travel",
+    "pet_supplies",
+    "beauty",
+    "appliances",
+    "automotive",
+    "music",
 ]
 
 
@@ -82,7 +98,6 @@ def gen_query_order_data(nb, start_id=0):
     return rows
 
 
-
 # =====================================================================
 # Valid test cases — shared Collection A
 # =====================================================================
@@ -102,12 +117,14 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         schema = build_query_order_schema(client)
 
         index_params = client.prepare_index_params()
-        index_params.add_index(field_name="embeddings", index_type="HNSW",
-                               metric_type="COSINE", M=16, efConstruction=200)
+        index_params.add_index(
+            field_name="embeddings", index_type="HNSW", metric_type="COSINE", M=16, efConstruction=200
+        )
         index_params.add_index(field_name="int32_field", index_type="INVERTED")
 
-        client.create_collection(collection_name=collection_name, schema=schema,
-                                 index_params=index_params, consistency_level="Strong")
+        client.create_collection(
+            collection_name=collection_name, schema=schema, index_params=index_params, consistency_level="Strong"
+        )
         client.create_partition(collection_name, CUSTOM_PARTITION_NAME)
 
         # 3 batches → 3 sealed segments, even ids → _default, odd ids → custom partition
@@ -119,8 +136,7 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             if default_data:
                 client.insert(collection_name=collection_name, data=default_data)
             if odd_data:
-                client.insert(collection_name=collection_name, data=odd_data,
-                              partition_name=CUSTOM_PARTITION_NAME)
+                client.insert(collection_name=collection_name, data=odd_data, partition_name=CUSTOM_PARTITION_NAME)
             client.flush(collection_name=collection_name)
 
         # 1 growing segment (no flush), same partition split
@@ -131,15 +147,14 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         if even_growing:
             client.insert(collection_name=collection_name, data=even_growing)
         if odd_growing:
-            client.insert(collection_name=collection_name, data=odd_growing,
-                          partition_name=CUSTOM_PARTITION_NAME)
+            client.insert(collection_name=collection_name, data=odd_growing, partition_name=CUSTOM_PARTITION_NAME)
 
         # Wait until all 3200 rows are visible
         expected = 3 * default_batch + default_growing
         for _ in range(30):
-            count = client.query(collection_name, filter="id >= 0",
-                                 output_fields=["count(*)"],
-                                 consistency_level="Strong")
+            count = client.query(
+                collection_name, filter="id >= 0", output_fields=["count(*)"], consistency_level="Strong"
+            )
             if count[0]["count(*)"] >= expected:
                 break
             time.sleep(1)
@@ -152,6 +167,7 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
                     self.drop_collection(client, VALID_COLLECTION_NAME)
             except Exception:
                 pass
+
         request.addfinalizer(teardown)
 
     # ==================== 5.1 L0: Basic Functionality ====================
@@ -160,72 +176,80 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
     def test_query_order_by_single_field_asc(self):
         """OB-001: Single field ascending"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=20,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=20,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+            assert prices[i] <= prices[i + 1], f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_order_by_single_field_desc(self):
         """OB-002: Single field descending"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=20,
-                         order_by_fields=[{"field": "price", "order": "desc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=20,
+            order_by_fields=[{"field": "price", "order": "desc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] >= prices[i + 1], \
-                f"price not descending at index {i}: {prices[i]} < {prices[i + 1]}"
+            assert prices[i] >= prices[i + 1], f"price not descending at index {i}: {prices[i]} < {prices[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("direction", ["ascending", "descending"])
     def test_query_order_by_direction_variants(self, direction):
         """OB-003: Direction variants — ascending/descending"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=20,
-                         order_by_fields=[{"field": "price", "order": direction}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=20,
+            order_by_fields=[{"field": "price", "order": direction}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         prices = [r["price"] for r in res]
         is_asc = direction == "ascending"
         for i in range(len(prices) - 1):
             if is_asc:
-                assert prices[i] <= prices[i + 1], \
-                    f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+                assert prices[i] <= prices[i + 1], f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
             else:
-                assert prices[i] >= prices[i + 1], \
-                    f"price not descending at index {i}: {prices[i]} < {prices[i + 1]}"
+                assert prices[i] >= prices[i + 1], f"price not descending at index {i}: {prices[i]} < {prices[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_order_by_multi_fields(self):
         """OB-004: Multi-field sort — primary int32 asc, secondary rating desc"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "int32_field", "rating"],
-                         limit=50,
-                         order_by_fields=[
-                             {"field": "int32_field", "order": "asc"},
-                             {"field": "rating", "order": "desc"},
-                         ],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "int32_field", "rating"],
+            limit=50,
+            order_by_fields=[
+                {"field": "int32_field", "order": "asc"},
+                {"field": "rating", "order": "desc"},
+            ],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 50
         secondary_sort_tested = False
@@ -234,51 +258,53 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             v2 = res[i + 1]["int32_field"]
             assert v1 <= v2, f"int32_field not ascending at index {i}: {v1} > {v2}"
             if v1 == v2:
-                assert res[i]["rating"] >= res[i + 1]["rating"], \
-                    f"rating not descending within same int32 at index {i}"
+                assert res[i]["rating"] >= res[i + 1]["rating"], f"rating not descending within same int32 at index {i}"
                 secondary_sort_tested = True
-        assert secondary_sort_tested, \
-            "No duplicate int32_field values found — secondary sort not tested"
+        assert secondary_sort_tested, "No duplicate int32_field values found — secondary sort not tested"
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_order_by_with_filter(self):
         """OB-005: ORDER BY combined with filter"""
         client = self._client()
         filter_expr = "price >= 20.0 && price <= 40.0"
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter=filter_expr,
-                         output_fields=["id", "price"],
-                         limit=200,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter=filter_expr,
+            output_fields=["id", "price"],
+            limit=200,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 200
         prices = [r["price"] for r in res]
         for p in prices:
             assert 20.0 <= p <= 40.0, f"price {p} not in filter range [20.0, 40.0]"
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+            assert prices[i] <= prices[i + 1], f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("limit", [1, 5, 50, 100, 500])
     def test_query_order_by_different_limit(self, limit):
         """OB-006: ORDER BY with different limit values"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=limit,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=limit,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == limit
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
             assert prices[i] <= prices[i + 1]
         # First result should be the global minimum price
-        assert prices[0] == PRICE_MIN, \
-            f"Expected min price {PRICE_MIN}, got {prices[0]}"
+        assert prices[0] == PRICE_MIN, f"Expected min price {PRICE_MIN}, got {prices[0]}"
 
     # ==================== 5.2 L1: Parameter Format Variants ====================
     # OB-007 (Dict list format) is covered by OB-001
@@ -287,63 +313,72 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
     def test_query_order_by_string_list_format(self):
         """OB-008: String list format — order_by_fields=["price:asc"]"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=20,
-                         order_by_fields=["price:asc"],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=20,
+            order_by_fields=["price:asc"],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+            assert prices[i] <= prices[i + 1], f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_raw_string_format(self):
         """OB-009: Raw string via order_by kwarg"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price", "rating"],
-                         limit=20,
-                         order_by="price:asc,rating:desc",
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price", "rating"],
+            limit=20,
+            order_by="price:asc,rating:desc",
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         for i in range(len(res) - 1):
-            assert res[i]["price"] <= res[i + 1]["price"], \
-                f"price not ascending at index {i}"
+            assert res[i]["price"] <= res[i + 1]["price"], f"price not ascending at index {i}"
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_dict_without_order_key(self):
         """OB-010: Dict without 'order' key — should default to ascending"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=20,
-                         order_by_fields=[{"field": "price"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=20,
+            order_by_fields=[{"field": "price"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+            assert prices[i] <= prices[i + 1], f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("direction", ["ASC", "Desc", "DESCENDING", "Ascending"])
     def test_query_order_by_direction_case_variants(self, direction):
         """OB-011: Direction case variants — verify whether accepted or rejected"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=20,
-                         order_by_fields=[{"field": "price", "order": direction}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=20,
+            order_by_fields=[{"field": "price", "order": direction}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         prices = [r["price"] for r in res]
@@ -357,52 +392,63 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
     # ==================== 5.3 L1: Data Type Coverage ====================
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("field_name,order", [
-        ("int8_field", "asc"),
-        ("int8_field", "desc"),
-        ("int16_field", "asc"),
-        ("int16_field", "desc"),
-        ("int32_field", "asc"),
-        ("int32_field", "desc"),
-        ("id", "asc"),
-        ("id", "desc"),
-        ("float_field", "asc"),
-        ("float_field", "desc"),
-        ("price", "asc"),
-        ("price", "desc"),
-        ("category", "asc"),
-        ("category", "desc"),
-    ])
+    @pytest.mark.parametrize(
+        "field_name,order",
+        [
+            ("int8_field", "asc"),
+            ("int8_field", "desc"),
+            ("int16_field", "asc"),
+            ("int16_field", "desc"),
+            ("int32_field", "asc"),
+            ("int32_field", "desc"),
+            ("id", "asc"),
+            ("id", "desc"),
+            ("float_field", "asc"),
+            ("float_field", "desc"),
+            ("price", "asc"),
+            ("price", "desc"),
+            ("category", "asc"),
+            ("category", "desc"),
+        ],
+    )
     def test_query_order_by_scalar_types(self, field_name, order):
         """OB-012~018: Sort by various scalar data types"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", field_name],
-                         limit=50,
-                         order_by_fields=[{"field": field_name, "order": order}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", field_name],
+            limit=50,
+            order_by_fields=[{"field": field_name, "order": order}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 50
         values = [r[field_name] for r in res]
         for i in range(len(values) - 1):
             if order == "asc":
-                assert values[i] <= values[i + 1], \
+                assert values[i] <= values[i + 1], (
                     f"{field_name} not ascending at index {i}: {values[i]} > {values[i + 1]}"
+                )
             else:
-                assert values[i] >= values[i + 1], \
+                assert values[i] >= values[i + 1], (
                     f"{field_name} not descending at index {i}: {values[i]} < {values[i + 1]}"
+                )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_bool_field(self):
         """OB-019: Bool field — not in user guide supported types, verify behavior"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "bool_field"],
-                         limit=100,
-                         order_by_fields=[{"field": "bool_field", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "bool_field"],
+            limit=100,
+            order_by_fields=[{"field": "bool_field", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 100
         values = [r["bool_field"] for r in res]
@@ -423,25 +469,34 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         order_by = [{"field": "price", "order": "asc"}]
 
         # --- OB-020: Page 1 and Page 2 consistency ---
-        page1 = self.query(client, VALID_COLLECTION_NAME,
-                           filter="",
-                           output_fields=["id", "price"],
-                           limit=10, offset=0,
-                           order_by_fields=order_by,
-                           consistency_level="Strong")[0]
-        page2 = self.query(client, VALID_COLLECTION_NAME,
-                           filter="",
-                           output_fields=["id", "price"],
-                           limit=10, offset=10,
-                           order_by_fields=order_by,
-                           consistency_level="Strong")[0]
+        page1 = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=10,
+            offset=0,
+            order_by_fields=order_by,
+            consistency_level="Strong",
+        )[0]
+        page2 = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=10,
+            offset=10,
+            order_by_fields=order_by,
+            consistency_level="Strong",
+        )[0]
         assert len(page1) == 10
         assert len(page2) == 10
         ids1 = {r["id"] for r in page1}
         ids2 = {r["id"] for r in page2}
         assert ids1.isdisjoint(ids2), f"Overlap between pages: {ids1 & ids2}"
-        assert page1[-1]["price"] <= page2[0]["price"], \
+        assert page1[-1]["price"] <= page2[0]["price"], (
             f"Pages not contiguous: page1 last {page1[-1]['price']} > page2 first {page2[0]['price']}"
+        )
 
         # --- OB-021: Multi-page full traversal ---
         page_size = 100
@@ -449,12 +504,16 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         all_prices = []
         offset = 0
         while True:
-            page = self.query(client, VALID_COLLECTION_NAME,
-                              filter="",
-                              output_fields=["id", "price"],
-                              limit=page_size, offset=offset,
-                              order_by_fields=order_by,
-                              consistency_level="Strong")[0]
+            page = self.query(
+                client,
+                VALID_COLLECTION_NAME,
+                filter="",
+                output_fields=["id", "price"],
+                limit=page_size,
+                offset=offset,
+                order_by_fields=order_by,
+                consistency_level="Strong",
+            )[0]
             if len(page) == 0:
                 break
             page_ids = {r["id"] for r in page}
@@ -464,30 +523,37 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             offset += page_size
             if offset > default_nb + 1000:
                 break
-        assert len(all_ids) == default_nb, \
-            f"Expected {default_nb} total rows, got {len(all_ids)}"
+        assert len(all_ids) == default_nb, f"Expected {default_nb} total rows, got {len(all_ids)}"
         for i in range(len(all_prices) - 1):
-            assert all_prices[i] <= all_prices[i + 1], \
+            assert all_prices[i] <= all_prices[i + 1], (
                 f"Global sort broken at index {i}: {all_prices[i]} > {all_prices[i + 1]}"
+            )
 
         # --- OB-022: Offset exceeds total rows (but within topK cap 16384) ---
         # Data has 3200 rows, offset=4000 is beyond data but offset+limit=4010 < 16384
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=10, offset=4000,
-                         order_by_fields=order_by,
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=10,
+            offset=4000,
+            order_by_fields=order_by,
+            consistency_level="Strong",
+        )[0]
         assert len(res) == 0
 
         # --- OB-023: Limit exceeds total rows (but within topK cap 16384) ---
         # Data has 3200 rows, limit=16000 > total but < 16384
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=16000,
-                         order_by_fields=order_by,
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=16000,
+            order_by_fields=order_by,
+            consistency_level="Strong",
+        )[0]
         assert len(res) == default_nb
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
@@ -501,12 +567,15 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         """OB-024: Nullable INT32 ASC — non-NULL ascending first, NULLs at end (NULLS LAST)"""
         client = self._client()
         # Use filter to limit scope: id < 200 → 160 non-NULL + 40 NULL
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="id < 200",
-                         output_fields=["id", "nullable_score"],
-                         limit=200,
-                         order_by_fields=[{"field": "nullable_score", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="id < 200",
+            output_fields=["id", "nullable_score"],
+            limit=200,
+            order_by_fields=[{"field": "nullable_score", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 200
         values = [r["nullable_score"] for r in res]
@@ -519,8 +588,9 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         assert len(nulls) > 0, "Expected some NULL values"
         # Non-NULL values should be ascending
         for i in range(len(non_nulls) - 1):
-            assert non_nulls[i] <= non_nulls[i + 1], \
+            assert non_nulls[i] <= non_nulls[i + 1], (
                 f"nullable_score not ascending at index {i}: {non_nulls[i]} > {non_nulls[i + 1]}"
+            )
         # All values after first NULL should also be NULL
         for v in nulls:
             assert v is None, f"Expected NULL after first NULL, got {v}"
@@ -530,12 +600,15 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         """OB-025: Nullable INT32 DESC — NULLs at beginning (NULLS FIRST), then non-NULL descending"""
         client = self._client()
         # Use filter to limit scope: id < 200 → 160 non-NULL + 40 NULL
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="id < 200",
-                         output_fields=["id", "nullable_score"],
-                         limit=200,
-                         order_by_fields=[{"field": "nullable_score", "order": "desc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="id < 200",
+            output_fields=["id", "nullable_score"],
+            limit=200,
+            order_by_fields=[{"field": "nullable_score", "order": "desc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 200
         values = [r["nullable_score"] for r in res]
@@ -551,19 +624,23 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             assert v is None, f"Expected NULL at beginning, got {v}"
         # Non-NULL values should be descending
         for i in range(len(non_nulls) - 1):
-            assert non_nulls[i] >= non_nulls[i + 1], \
+            assert non_nulls[i] >= non_nulls[i + 1], (
                 f"nullable_score not descending at index {i}: {non_nulls[i]} < {non_nulls[i + 1]}"
+            )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_nullable_varchar_asc(self):
         """OB-026: Nullable VarChar ASC — non-NULL lexicographic ascending, NULLs at end"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="id < 200",
-                         output_fields=["id", "nullable_varchar"],
-                         limit=200,
-                         order_by_fields=[{"field": "nullable_varchar", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="id < 200",
+            output_fields=["id", "nullable_varchar"],
+            limit=200,
+            order_by_fields=[{"field": "nullable_varchar", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 200
         values = [r["nullable_varchar"] for r in res]
@@ -573,8 +650,9 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         assert len(non_nulls) > 0, "Expected some non-NULL values"
         assert len(nulls) > 0, "Expected some NULL values"
         for i in range(len(non_nulls) - 1):
-            assert non_nulls[i] <= non_nulls[i + 1], \
+            assert non_nulls[i] <= non_nulls[i + 1], (
                 f"nullable_varchar not ascending at index {i}: {non_nulls[i]} > {non_nulls[i + 1]}"
+            )
         for v in nulls:
             assert v is None, f"Expected NULL after first NULL, got {v}"
 
@@ -582,12 +660,15 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
     def test_query_order_by_nullable_varchar_desc(self):
         """OB-027: Nullable VarChar DESC — NULLs first, then non-NULL descending"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="id < 200",
-                         output_fields=["id", "nullable_varchar"],
-                         limit=200,
-                         order_by_fields=[{"field": "nullable_varchar", "order": "desc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="id < 200",
+            output_fields=["id", "nullable_varchar"],
+            limit=200,
+            order_by_fields=[{"field": "nullable_varchar", "order": "desc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 200
         values = [r["nullable_varchar"] for r in res]
@@ -599,42 +680,47 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         for v in nulls:
             assert v is None, f"Expected NULL at beginning, got {v}"
         for i in range(len(non_nulls) - 1):
-            assert non_nulls[i] >= non_nulls[i + 1], \
+            assert non_nulls[i] >= non_nulls[i + 1], (
                 f"nullable_varchar not descending at index {i}: {non_nulls[i]} < {non_nulls[i + 1]}"
+            )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_all_null_values(self):
         """OB-028: Filter to only NULL rows and inspect the returned subset order."""
         client = self._client()
         # idx % 5 == 0 rows have NULL nullable_score
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="nullable_score is null",
-                         output_fields=["id", "nullable_score"],
-                         limit=200,
-                         order_by_fields=[{"field": "nullable_score", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="nullable_score is null",
+            output_fields=["id", "nullable_score"],
+            limit=200,
+            order_by_fields=[{"field": "nullable_score", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) > 0, "Expected some NULL rows"
         for r in res:
-            assert r["nullable_score"] is None, \
-                f"Expected NULL nullable_score, got {r['nullable_score']}"
+            assert r["nullable_score"] is None, f"Expected NULL nullable_score, got {r['nullable_score']}"
         # Check monotonic IDs within the returned subset only. The API does not
         # guarantee which rows are selected when all explicit sort keys tie.
         ids = [r["id"] for r in res]
         for i in range(len(ids) - 1):
-            assert ids[i] < ids[i + 1], \
-                f"id not ascending among NULL rows at index {i}: {ids[i]} >= {ids[i + 1]}"
+            assert ids[i] < ids[i + 1], f"id not ascending among NULL rows at index {i}: {ids[i]} >= {ids[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_nulls_first_override(self):
         """OB-029: Explicit nulls_first override — ASC with nulls_first puts NULLs at beginning"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="id < 200",
-                         output_fields=["id", "nullable_score"],
-                         limit=200,
-                         order_by_fields=["nullable_score:asc:nulls_first"],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="id < 200",
+            output_fields=["id", "nullable_score"],
+            limit=200,
+            order_by_fields=["nullable_score:asc:nulls_first"],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 200
         values = [r["nullable_score"] for r in res]
@@ -647,19 +733,23 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         for v in nulls:
             assert v is None
         for i in range(len(non_nulls) - 1):
-            assert non_nulls[i] <= non_nulls[i + 1], \
+            assert non_nulls[i] <= non_nulls[i + 1], (
                 f"nullable_score not ascending at index {i}: {non_nulls[i]} > {non_nulls[i + 1]}"
+            )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_nulls_last_override(self):
         """OB-030: Explicit nulls_last override — DESC with nulls_last puts NULLs at end"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="id < 200",
-                         output_fields=["id", "nullable_score"],
-                         limit=200,
-                         order_by_fields=["nullable_score:desc:nulls_last"],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="id < 200",
+            output_fields=["id", "nullable_score"],
+            limit=200,
+            order_by_fields=["nullable_score:desc:nulls_last"],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 200
         values = [r["nullable_score"] for r in res]
@@ -673,19 +763,22 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         null_rows = res[first_null:]
         for i in range(len(non_null_rows) - 1):
             a, b = non_null_rows[i], non_null_rows[i + 1]
-            assert a["nullable_score"] >= b["nullable_score"], \
+            assert a["nullable_score"] >= b["nullable_score"], (
                 f"nullable_score not descending at index {i}: {a['nullable_score']} < {b['nullable_score']}"
+            )
             # Check the order of surviving equal-key rows, not the exact tied subset.
             if a["nullable_score"] == b["nullable_score"]:
-                assert a["id"] < b["id"], \
+                assert a["id"] < b["id"], (
                     f"id not ascending among returned equal-key rows at index {i}: {a['id']} >= {b['id']}"
+                )
         for v in nulls:
             assert v is None, f"Expected NULL at end, got {v}"
         # This checks only the order of returned NULL rows, not exact row selection.
         null_ids = [r["id"] for r in null_rows]
         for i in range(len(null_ids) - 1):
-            assert null_ids[i] < null_ids[i + 1], \
+            assert null_ids[i] < null_ids[i + 1], (
                 f"id not ascending among NULL rows at index {i}: {null_ids[i]} >= {null_ids[i + 1]}"
+            )
 
     # ==================== 5.6 L1: Output Fields Relationship ====================
 
@@ -693,12 +786,15 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
     def test_query_order_by_sort_field_not_in_output(self):
         """OB-031: Sort field NOT in output_fields — sorted by price but price not in output"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "category"],
-                         limit=20,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "category"],
+            limit=20,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         # price should NOT appear in output
@@ -706,57 +802,64 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             assert "price" not in r, f"price should not be in output, got keys: {list(r.keys())}"
         # Verify sort correctness via second query
         ids = [r["id"] for r in res]
-        verify = self.query(client, VALID_COLLECTION_NAME,
-                            filter=f"id in {ids}",
-                            output_fields=["id", "price"],
-                            consistency_level="Strong")[0]
+        verify = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter=f"id in {ids}",
+            output_fields=["id", "price"],
+            consistency_level="Strong",
+        )[0]
         price_map = {r["id"]: r["price"] for r in verify}
         prices_in_order = [price_map[rid] for rid in ids]
         for i in range(len(prices_in_order) - 1):
-            assert prices_in_order[i] <= prices_in_order[i + 1], \
+            assert prices_in_order[i] <= prices_in_order[i + 1], (
                 f"Sort by price not correct at index {i}: {prices_in_order[i]} > {prices_in_order[i + 1]}"
+            )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_sort_field_in_output(self):
         """OB-032: Sort field IN output_fields — results sorted and price visible in output"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price", "category"],
-                         limit=20,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price", "category"],
+            limit=20,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         for r in res:
             assert "price" in r, f"price should be in output, got keys: {list(r.keys())}"
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+            assert prices[i] <= prices[i + 1], f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_output_fields_complete(self):
         """OB-061: All specified output_fields are present in every result row"""
         client = self._client()
         output_fields = ["id", "price", "rating", "category", "int32_field"]
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=output_fields,
-                         limit=20,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=output_fields,
+            limit=20,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 20
         for r in res:
             for field in output_fields:
-                assert field in r, \
-                    f"Field '{field}' missing in result row, got keys: {list(r.keys())}"
+                assert field in r, f"Field '{field}' missing in result row, got keys: {list(r.keys())}"
         # Verify sorting is also correct
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+            assert prices[i] <= prices[i + 1], f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
 
     # ==================== 5.7 L1: No Filter / Empty Results ====================
 
@@ -764,17 +867,19 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
     def test_query_order_by_empty_filter_full_scan(self):
         """OB-033: Empty filter (full scan) — top-10 from entire collection"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=10,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=10,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 10
         prices = [r["price"] for r in res]
-        assert prices[0] == PRICE_MIN, \
-            f"Expected min price {PRICE_MIN}, got {prices[0]}"
+        assert prices[0] == PRICE_MIN, f"Expected min price {PRICE_MIN}, got {prices[0]}"
         for i in range(len(prices) - 1):
             assert prices[i] <= prices[i + 1]
 
@@ -782,12 +887,15 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
     def test_query_order_by_filter_matches_nothing(self):
         """OB-034: Filter matches nothing — returns empty list, no error"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="int32_field > 999999",
-                         output_fields=["id", "int32_field"],
-                         limit=10,
-                         order_by_fields=[{"field": "int32_field", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="int32_field > 999999",
+            output_fields=["id", "int32_field"],
+            limit=10,
+            order_by_fields=[{"field": "int32_field", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 0, f"Expected empty result, got {len(res)} rows"
 
@@ -798,23 +906,24 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         """OB-035: ORDER BY within partition — sorted results from specified partition only"""
         client = self._client()
         # odd_partition contains only odd ids (id % 2 == 1), total 1600 rows
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=50,
-                         partition_names=[CUSTOM_PARTITION_NAME],
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=50,
+            partition_names=[CUSTOM_PARTITION_NAME],
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 50
         # All ids should be odd (from the custom partition)
         for r in res:
-            assert r["id"] % 2 == 1, \
-                f"Expected odd id from {CUSTOM_PARTITION_NAME}, got {r['id']}"
+            assert r["id"] % 2 == 1, f"Expected odd id from {CUSTOM_PARTITION_NAME}, got {r['id']}"
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
+            assert prices[i] <= prices[i + 1], f"price not ascending at index {i}: {prices[i]} > {prices[i + 1]}"
 
     # ==================== 5.9 L2: Segment & Index Coverage ====================
 
@@ -824,72 +933,79 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         Each segment has price range 10.0~59.0 (overlapping), verifies cross-segment merge sort."""
         client = self._client()
         # id < 3000 spans 3 sealed segments (0~999, 1000~1999, 2000~2999)
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="id < 3000",
-                         output_fields=["id", "price"],
-                         limit=3000,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="id < 3000",
+            output_fields=["id", "price"],
+            limit=3000,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 3000
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"Cross-segment sort broken at index {i}: {prices[i]} > {prices[i + 1]}"
+            assert prices[i] <= prices[i + 1], f"Cross-segment sort broken at index {i}: {prices[i]} > {prices[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_sealed_and_growing_mixed(self):
         """OB-037: Sealed + growing mixed — growing data (id >= 3000) merged into global sort"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=default_nb,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=default_nb,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == default_nb
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"Sealed+growing sort broken at index {i}: {prices[i]} > {prices[i + 1]}"
+            assert prices[i] <= prices[i + 1], f"Sealed+growing sort broken at index {i}: {prices[i]} > {prices[i + 1]}"
         # Verify growing segment data (id >= 3000) is included
         ids = {r["id"] for r in res}
         growing_ids = set(range(3 * default_batch, 3 * default_batch + default_growing))
-        assert growing_ids.issubset(ids), \
-            f"Growing segment data missing: {growing_ids - ids}"
+        assert growing_ids.issubset(ids), f"Growing segment data missing: {growing_ids - ids}"
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_indexed_vs_non_indexed(self):
         """OB-038: Indexed field (int32_field with INVERTED) vs non-indexed (price) — both correct"""
         client = self._client()
         # int32_field has INVERTED index
-        res_indexed = self.query(client, VALID_COLLECTION_NAME,
-                                 filter="",
-                                 output_fields=["id", "int32_field"],
-                                 limit=100,
-                                 order_by_fields=[{"field": "int32_field", "order": "asc"}],
-                                 consistency_level="Strong")[0]
+        res_indexed = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "int32_field"],
+            limit=100,
+            order_by_fields=[{"field": "int32_field", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
         # price has no index
-        res_no_index = self.query(client, VALID_COLLECTION_NAME,
-                                  filter="",
-                                  output_fields=["id", "price"],
-                                  limit=100,
-                                  order_by_fields=[{"field": "price", "order": "asc"}],
-                                  consistency_level="Strong")[0]
+        res_no_index = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=100,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res_indexed) == 100
         assert len(res_no_index) == 100
 
         int32_vals = [r["int32_field"] for r in res_indexed]
         for i in range(len(int32_vals) - 1):
-            assert int32_vals[i] <= int32_vals[i + 1], \
-                f"Indexed int32_field not ascending at index {i}"
+            assert int32_vals[i] <= int32_vals[i + 1], f"Indexed int32_field not ascending at index {i}"
 
         prices = [r["price"] for r in res_no_index]
         for i in range(len(prices) - 1):
-            assert prices[i] <= prices[i + 1], \
-                f"Non-indexed price not ascending at index {i}"
+            assert prices[i] <= prices[i + 1], f"Non-indexed price not ascending at index {i}"
 
     # ==================== 5.10 L2: PK Deduplication ====================
 
@@ -902,10 +1018,12 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         try:
             schema = build_query_order_schema(client)
             index_params = client.prepare_index_params()
-            index_params.add_index(field_name="embeddings", index_type="HNSW",
-                                   metric_type="COSINE", M=16, efConstruction=200)
-            client.create_collection(collection_name=collection_name, schema=schema,
-                                     index_params=index_params, consistency_level="Strong")
+            index_params.add_index(
+                field_name="embeddings", index_type="HNSW", metric_type="COSINE", M=16, efConstruction=200
+            )
+            client.create_collection(
+                collection_name=collection_name, schema=schema, index_params=index_params, consistency_level="Strong"
+            )
 
             # Insert 100 rows
             data = gen_query_order_data(100, start_id=0)
@@ -919,25 +1037,25 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             client.upsert(collection_name=collection_name, data=upsert_data)
             client.flush(collection_name=collection_name)
 
-            res = self.query(client, collection_name,
-                             filter="",
-                             output_fields=["id", "price"],
-                             limit=100,
-                             order_by_fields=[{"field": "price", "order": "desc"}],
-                             consistency_level="Strong")[0]
+            res = self.query(
+                client,
+                collection_name,
+                filter="",
+                output_fields=["id", "price"],
+                limit=100,
+                order_by_fields=[{"field": "price", "order": "desc"}],
+                consistency_level="Strong",
+            )[0]
 
             assert len(res) == 100
             prices = [r["price"] for r in res]
             for i in range(len(prices) - 1):
-                assert prices[i] >= prices[i + 1], \
-                    f"price not descending at index {i}"
+                assert prices[i] >= prices[i + 1], f"price not descending at index {i}"
             # Upserted rows (id 0~9) should be at the top with highest prices
             top_ids = {r["id"] for r in res[:10]}
-            assert top_ids == set(range(10)), \
-                f"Upserted rows not at top: expected {{0..9}}, got {top_ids}"
+            assert top_ids == set(range(10)), f"Upserted rows not at top: expected {{0..9}}, got {top_ids}"
             for r in res[:10]:
-                assert r["price"] == 999.0 + r["id"], \
-                    f"Upserted row {r['id']} has wrong price: {r['price']}"
+                assert r["price"] == 999.0 + r["id"], f"Upserted row {r['id']} has wrong price: {r['price']}"
         finally:
             if client.has_collection(collection_name):
                 client.drop_collection(collection_name)
@@ -952,17 +1070,22 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         try:
             schema = build_query_order_schema(client)
             index_params = client.prepare_index_params()
-            index_params.add_index(field_name="embeddings", index_type="HNSW",
-                                   metric_type="COSINE", M=16, efConstruction=200)
-            client.create_collection(collection_name=collection_name, schema=schema,
-                                     index_params=index_params, consistency_level="Strong")
+            index_params.add_index(
+                field_name="embeddings", index_type="HNSW", metric_type="COSINE", M=16, efConstruction=200
+            )
+            client.create_collection(
+                collection_name=collection_name, schema=schema, index_params=index_params, consistency_level="Strong"
+            )
 
-            res = self.query(client, collection_name,
-                             filter="",
-                             output_fields=["id", "price"],
-                             limit=10,
-                             order_by_fields=[{"field": "price", "order": "asc"}],
-                             consistency_level="Strong")[0]
+            res = self.query(
+                client,
+                collection_name,
+                filter="",
+                output_fields=["id", "price"],
+                limit=10,
+                order_by_fields=[{"field": "price", "order": "asc"}],
+                consistency_level="Strong",
+            )[0]
 
             assert len(res) == 0, f"Expected empty result on empty collection, got {len(res)} rows"
         finally:
@@ -975,81 +1098,100 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
     def test_query_order_by_vector_field(self):
         """OB-040: Unsupported type: FloatVector — error code 1100"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "order_by field 'embeddings' has type FloatVector which is not sortable"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id"],
-                   limit=10,
-                   order_by_fields=[{"field": "embeddings", "order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: "order_by field 'embeddings' has type FloatVector which is not sortable",
+        }
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id"],
+            limit=10,
+            order_by_fields=[{"field": "embeddings", "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_json_field(self):
         """OB-041: Unsupported type: JSON (no path) — error code 1100"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "order_by field 'json_field' has type JSON which is not sortable"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id"],
-                   limit=10,
-                   order_by_fields=[{"field": "json_field", "order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "order_by field 'json_field' has type JSON which is not sortable"}
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id"],
+            limit=10,
+            order_by_fields=[{"field": "json_field", "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_nonexistent_field(self):
         """OB-042: Non-existent field — error code 1100"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "order_by field 'no_such_field' does not exist in collection schema"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id"],
-                   limit=10,
-                   order_by_fields=[{"field": "no_such_field", "order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "order_by field 'no_such_field' does not exist in collection schema"}
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id"],
+            limit=10,
+            order_by_fields=[{"field": "no_such_field", "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_invalid_direction(self):
         """OB-043: Invalid direction — error code 1100"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "invalid order direction 'up' for field 'price', must be 'asc' or 'desc'"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id"],
-                   limit=10,
-                   order_by_fields=[{"field": "price", "order": "up"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: "invalid order direction 'up' for field 'price', must be 'asc' or 'desc'",
+        }
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id"],
+            limit=10,
+            order_by_fields=[{"field": "price", "order": "up"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_missing_limit(self):
         """OB-044: Missing limit — ORDER BY requires explicit limit"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "ORDER BY requires explicit limit"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id"],
-                   order_by_fields=[{"field": "price", "order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "ORDER BY requires explicit limit"}
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id"],
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_empty_list(self):
         """OB-045: Empty order_by list — should behave like normal query, no error"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=10,
-                         order_by_fields=[],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=10,
+            order_by_fields=[],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 10
 
@@ -1057,43 +1199,49 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
     def test_query_order_by_empty_field_name(self):
         """OB-046: Empty field name — error"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "order_by field '' does not exist in collection schema"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id"],
-                   limit=10,
-                   order_by_fields=[{"field": "", "order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "order_by field '' does not exist in collection schema"}
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id"],
+            limit=10,
+            order_by_fields=[{"field": "", "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_missing_field_key(self):
         """OB-062: Malformed dict missing 'field' key — error"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "order_by field '' does not exist in collection schema"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id"],
-                   limit=10,
-                   order_by_fields=[{"order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "order_by field '' does not exist in collection schema"}
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id"],
+            limit=10,
+            order_by_fields=[{"order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_array_field(self):
         """OB-047: Unsupported type: Array — error code 1100"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "order_by field 'array_field' has type Array which is not sortable"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id"],
-                   limit=10,
-                   order_by_fields=[{"field": "array_field", "order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "order_by field 'array_field' has type Array which is not sortable"}
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id"],
+            limit=10,
+            order_by_fields=[{"field": "array_field", "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     # ==================== 5.12 L2: Edge Cases ====================
 
@@ -1102,12 +1250,15 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         """OB-048: All values identical — inspect the returned subset order."""
         client = self._client()
         # int32_field = idx % 500, so int32_field==0 matches idx=0,500,1000,...
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="int32_field == 0",
-                         output_fields=["id", "int32_field"],
-                         limit=20,
-                         order_by_fields=[{"field": "int32_field", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="int32_field == 0",
+            output_fields=["id", "int32_field"],
+            limit=20,
+            order_by_fields=[{"field": "int32_field", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) > 0
         for r in res:
@@ -1116,23 +1267,27 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         # the exact PK-ordered prefix of all matching rows.
         ids = [r["id"] for r in res]
         for i in range(len(ids) - 1):
-            assert ids[i] < ids[i + 1], \
+            assert ids[i] < ids[i + 1], (
                 f"id not ascending among returned equal-key rows at index {i}: {ids[i]} >= {ids[i + 1]}"
+            )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_three_sort_fields(self):
         """OB-049: 3 sort fields — correct cascading sort"""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "int32_field", "price", "rating"],
-                         limit=100,
-                         order_by_fields=[
-                             {"field": "int32_field", "order": "asc"},
-                             {"field": "price", "order": "asc"},
-                             {"field": "rating", "order": "desc"},
-                         ],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "int32_field", "price", "rating"],
+            limit=100,
+            order_by_fields=[
+                {"field": "int32_field", "order": "asc"},
+                {"field": "price", "order": "asc"},
+                {"field": "rating", "order": "desc"},
+            ],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) == 100
         second_level_tested = False
@@ -1141,22 +1296,17 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             a, b = res[i], res[i + 1]
             if a["int32_field"] < b["int32_field"]:
                 continue
-            assert a["int32_field"] == b["int32_field"], \
-                f"int32_field not ascending at index {i}"
+            assert a["int32_field"] == b["int32_field"], f"int32_field not ascending at index {i}"
             # Same int32_field, check price
             second_level_tested = True
             if a["price"] < b["price"]:
                 continue
-            assert a["price"] == b["price"], \
-                f"price not ascending at index {i} within same int32"
+            assert a["price"] == b["price"], f"price not ascending at index {i} within same int32"
             # Same int32_field + price, check rating
             third_level_tested = True
-            assert a["rating"] >= b["rating"], \
-                f"rating not descending at index {i} within same int32+price"
-        assert second_level_tested, \
-            "No duplicate int32_field values found — second level sort not tested"
-        assert third_level_tested, \
-            "No duplicate int32_field+price values found — third level sort not tested"
+            assert a["rating"] >= b["rating"], f"rating not descending at index {i} within same int32+price"
+        assert second_level_tested, "No duplicate int32_field values found — second level sort not tested"
+        assert third_level_tested, "No duplicate int32_field+price values found — third level sort not tested"
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_single_row(self):
@@ -1171,23 +1321,27 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=default_dim)
 
             index_params = client.prepare_index_params()
-            index_params.add_index(field_name="embeddings", index_type="HNSW",
-                                   metric_type="COSINE", M=16, efConstruction=200)
+            index_params.add_index(
+                field_name="embeddings", index_type="HNSW", metric_type="COSINE", M=16, efConstruction=200
+            )
 
-            client.create_collection(collection_name=collection_name, schema=schema,
-                                     index_params=index_params, consistency_level="Strong")
+            client.create_collection(
+                collection_name=collection_name, schema=schema, index_params=index_params, consistency_level="Strong"
+            )
 
-            data = [{"id": 0, "price": 42.0,
-                     "embeddings": list(cf.gen_vectors(1, default_dim)[0])}]
+            data = [{"id": 0, "price": 42.0, "embeddings": list(cf.gen_vectors(1, default_dim)[0])}]
             client.insert(collection_name=collection_name, data=data)
             client.flush(collection_name=collection_name)
 
-            res = self.query(client, collection_name,
-                             filter="",
-                             output_fields=["id", "price"],
-                             limit=10,
-                             order_by_fields=[{"field": "price", "order": "asc"}],
-                             consistency_level="Strong")[0]
+            res = self.query(
+                client,
+                collection_name,
+                filter="",
+                output_fields=["id", "price"],
+                limit=10,
+                order_by_fields=[{"field": "price", "order": "asc"}],
+                consistency_level="Strong",
+            )[0]
 
             assert len(res) == 1
             assert res[0]["id"] == 0
@@ -1204,106 +1358,120 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
 
         first_ids = None
         for attempt in range(10):
-            res = self.query(client, VALID_COLLECTION_NAME,
-                             filter="",
-                             output_fields=["id", "price"],
-                             limit=50,
-                             order_by_fields=order_by,
-                             consistency_level="Strong")[0]
+            res = self.query(
+                client,
+                VALID_COLLECTION_NAME,
+                filter="",
+                output_fields=["id", "price"],
+                limit=50,
+                order_by_fields=order_by,
+                consistency_level="Strong",
+            )[0]
             ids = [r["id"] for r in res]
             if first_ids is None:
                 first_ids = ids
             else:
-                assert ids == first_ids, \
-                    f"Result changed on attempt {attempt + 1}"
+                assert ids == first_ids, f"Result changed on attempt {attempt + 1}"
 
     # ==================== 5.13 L2: Feature Interaction ====================
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("agg_field", [
-        "count(*)",
-        "sum(price)",
-        "avg(price)",
-        "min(price)",
-        "max(price)",
-    ])
+    @pytest.mark.parametrize(
+        "agg_field",
+        [
+            "count(*)",
+            "sum(price)",
+            "avg(price)",
+            "min(price)",
+            "max(price)",
+        ],
+    )
     def test_query_order_by_with_aggregation(self, agg_field):
         """OB-052: ORDER BY + aggregation — error: ORDER BY can only reference GROUP BY columns"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "ORDER BY can only reference GROUP BY columns"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="id < 200",
-                   output_fields=[agg_field],
-                   limit=10,
-                   order_by_fields=[{"field": "price", "order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "ORDER BY can only reference GROUP BY columns"}
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="id < 200",
+            output_fields=[agg_field],
+            limit=10,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_dynamic_field(self):
         """OB-053: ORDER BY + dynamic field — not supported for query"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "order_by field 'dyn_age' does not exist in collection schema"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id", "dyn_age"],
-                   limit=10,
-                   order_by_fields=[{"field": "dyn_age", "order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "order_by field 'dyn_age' does not exist in collection schema"}
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "dyn_age"],
+            limit=10,
+            order_by_fields=[{"field": "dyn_age", "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_json_path(self):
         """OB-054: ORDER BY + JSON path — not supported for query"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "does not exist in collection schema"}
-        self.query(client, VALID_COLLECTION_NAME,
-                   filter="",
-                   output_fields=["id", "json_field"],
-                   limit=10,
-                   order_by_fields=[{"field": 'json_field["val"]', "order": "asc"}],
-                   check_task=CheckTasks.err_res,
-                   check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "does not exist in collection schema"}
+        self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "json_field"],
+            limit=10,
+            order_by_fields=[{"field": 'json_field["val"]', "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_with_complex_filter(self):
         """OB-055: ORDER BY + complex filter (IN/LIKE) — filtered + sorted correctly"""
         client = self._client()
         filter_expr = 'price in [10.0, 20.0, 30.0] && category like "elec%"'
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter=filter_expr,
-                         output_fields=["id", "price", "category"],
-                         limit=100,
-                         order_by_fields=[{"field": "price", "order": "desc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter=filter_expr,
+            output_fields=["id", "price", "category"],
+            limit=100,
+            order_by_fields=[{"field": "price", "order": "desc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) > 0
         for r in res:
-            assert r["price"] in [10.0, 20.0, 30.0], \
-                f"price {r['price']} not in filter list"
-            assert r["category"].startswith("elec"), \
-                f"category '{r['category']}' does not match LIKE 'elec%'"
+            assert r["price"] in [10.0, 20.0, 30.0], f"price {r['price']} not in filter list"
+            assert r["category"].startswith("elec"), f"category '{r['category']}' does not match LIKE 'elec%'"
         prices = [r["price"] for r in res]
         for i in range(len(prices) - 1):
-            assert prices[i] >= prices[i + 1], \
-                f"price not descending at index {i}: {prices[i]} < {prices[i + 1]}"
+            assert prices[i] >= prices[i + 1], f"price not descending at index {i}: {prices[i]} < {prices[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_with_iterator(self):
         """OB-056: ORDER BY + query iterator — not supported"""
         client = self._client()
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "ORDER BY with iterator is not supported"}
-        self.query_iterator(client, VALID_COLLECTION_NAME,
-                            filter="",
-                            output_fields=["id", "price"],
-                            batch_size=10, limit=50,
-                            order_by_fields=[{"field": "price", "order": "asc"}],
-                            check_task=CheckTasks.err_res,
-                            check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "ORDER BY with iterator is not supported"}
+        self.query_iterator(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            batch_size=10,
+            limit=50,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_group_by_positive(self):
@@ -1311,27 +1479,29 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         OB-052 tests ORDER BY on non-GROUP BY column (expects error).
         This tests the positive case: ORDER BY references the GROUP BY column."""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["category", "count(*)"],
-                         limit=20,
-                         group_by_fields=["category"],
-                         order_by_fields=[{"field": "category", "order": "desc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["category", "count(*)"],
+            limit=20,
+            group_by_fields=["category"],
+            order_by_fields=[{"field": "category", "order": "desc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) > 0
         # Each category should appear exactly once (aggregation GROUP BY)
         categories = [r["category"] for r in res]
-        assert len(categories) == len(set(categories)), \
-            f"Duplicate categories in GROUP BY result: {categories}"
+        assert len(categories) == len(set(categories)), f"Duplicate categories in GROUP BY result: {categories}"
         # Categories should be sorted descending (not default order)
         for i in range(len(categories) - 1):
-            assert categories[i] >= categories[i + 1], \
+            assert categories[i] >= categories[i + 1], (
                 f"category not descending at index {i}: '{categories[i]}' < '{categories[i + 1]}'"
+            )
         # Each row should have a count
         for r in res:
-            assert r["count(*)"] > 0, \
-                f"count(*) should be > 0 for category '{r['category']}'"
+            assert r["count(*)"] > 0, f"count(*) should be > 0 for category '{r['category']}'"
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_offset_last_row(self):
@@ -1339,36 +1509,42 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         client = self._client()
         # Total rows = default_nb = 3200, offset = 3199, limit = 10
         # Should return only 1 row (the last one)
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="",
-                         output_fields=["id", "price"],
-                         limit=10, offset=default_nb - 1,
-                         order_by_fields=[{"field": "price", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="",
+            output_fields=["id", "price"],
+            limit=10,
+            offset=default_nb - 1,
+            order_by_fields=[{"field": "price", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
-        assert len(res) == 1, \
-            f"Expected 1 row at offset={default_nb - 1}, got {len(res)}"
+        assert len(res) == 1, f"Expected 1 row at offset={default_nb - 1}, got {len(res)}"
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_float_field_with_duplicates(self):
         """OB-059: ORDER BY float field with many duplicate values.
         float_field = round((idx % 1000) * 0.1, 1), so 3200 rows produce many duplicates."""
         client = self._client()
-        res = self.query(client, VALID_COLLECTION_NAME,
-                         filter="float_field == 0.5",
-                         output_fields=["id", "float_field"],
-                         limit=100,
-                         order_by_fields=[{"field": "float_field", "order": "asc"}],
-                         consistency_level="Strong")[0]
+        res = self.query(
+            client,
+            VALID_COLLECTION_NAME,
+            filter="float_field == 0.5",
+            output_fields=["id", "float_field"],
+            limit=100,
+            order_by_fields=[{"field": "float_field", "order": "asc"}],
+            consistency_level="Strong",
+        )[0]
 
         assert len(res) > 1, "Need multiple rows with the same float value to exercise equal-key ordering"
         # All float values should be identical
         for r in res:
-            assert r["float_field"] == 0.5, \
-                f"Expected float_field=0.5, got {r['float_field']}"
+            assert r["float_field"] == 0.5, f"Expected float_field=0.5, got {r['float_field']}"
         # Check monotonic IDs within the returned subset. Equal-key candidate
         # selection is not guaranteed without an explicit final sort field.
         ids = [r["id"] for r in res]
         for i in range(len(ids) - 1):
-            assert ids[i] < ids[i + 1], \
+            assert ids[i] < ids[i + 1], (
                 f"id not ascending among returned equal-key rows at index {i}: {ids[i]} >= {ids[i + 1]}"
+            )

--- a/tests/python_client/milvus_client/test_milvus_client_query_order.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query_order.py
@@ -1,14 +1,14 @@
 import time
 
 import pytest
-
 from base.client_v2_base import TestMilvusClientV2Base
-from utils.util_log import test_log as log
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
-from utils.util_pymilvus import *
 from pymilvus import DataType
+from utils.util_log import test_log as log
+from utils.util_pymilvus import *  # noqa: F403
+
 default_nb = 3200
 default_dim = 8
 default_batch = 1000
@@ -418,7 +418,7 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_pagination(self):
-        """OB-020~023: Pagination with ORDER BY (single field, PK as implicit tie-breaker)."""
+        """OB-020~023: Pagination with a single ORDER BY field."""
         client = self._client()
         order_by = [{"field": "price", "order": "asc"}]
 
@@ -604,7 +604,7 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_query_order_by_all_null_values(self):
-        """OB-028: Filter to only NULL rows, sort — all NULL, PK as implicit tie-breaker"""
+        """OB-028: Filter to only NULL rows and inspect the returned subset order."""
         client = self._client()
         # idx % 5 == 0 rows have NULL nullable_score
         res = self.query(client, VALID_COLLECTION_NAME,
@@ -618,7 +618,8 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         for r in res:
             assert r["nullable_score"] is None, \
                 f"Expected NULL nullable_score, got {r['nullable_score']}"
-        # All values are NULL, PK (id) should serve as implicit tie-breaker (ascending)
+        # Check monotonic IDs within the returned subset only. The API does not
+        # guarantee which rows are selected when all explicit sort keys tie.
         ids = [r["id"] for r in res]
         for i in range(len(ids) - 1):
             assert ids[i] < ids[i + 1], \
@@ -674,13 +675,13 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
             a, b = non_null_rows[i], non_null_rows[i + 1]
             assert a["nullable_score"] >= b["nullable_score"], \
                 f"nullable_score not descending at index {i}: {a['nullable_score']} < {b['nullable_score']}"
-            # PK as tie-breaker when values are equal
+            # Check the order of surviving equal-key rows, not the exact tied subset.
             if a["nullable_score"] == b["nullable_score"]:
                 assert a["id"] < b["id"], \
-                    f"id not ascending as tie-breaker at index {i}: {a['id']} >= {b['id']}"
+                    f"id not ascending among returned equal-key rows at index {i}: {a['id']} >= {b['id']}"
         for v in nulls:
             assert v is None, f"Expected NULL at end, got {v}"
-        # Among NULL rows, PK (id) should be ascending as tie-breaker
+        # This checks only the order of returned NULL rows, not exact row selection.
         null_ids = [r["id"] for r in null_rows]
         for i in range(len(null_ids) - 1):
             assert null_ids[i] < null_ids[i + 1], \
@@ -1098,7 +1099,7 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_all_values_identical(self):
-        """OB-048: All values identical — int32_field==0 rows, PK as tie-breaker"""
+        """OB-048: All values identical — inspect the returned subset order."""
         client = self._client()
         # int32_field = idx % 500, so int32_field==0 matches idx=0,500,1000,...
         res = self.query(client, VALID_COLLECTION_NAME,
@@ -1111,11 +1112,12 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
         assert len(res) > 0
         for r in res:
             assert r["int32_field"] == 0
-        # All values identical, PK (id) should be ascending as tie-breaker
+        # Check monotonic IDs in the returned subset without asserting that it is
+        # the exact PK-ordered prefix of all matching rows.
         ids = [r["id"] for r in res]
         for i in range(len(ids) - 1):
             assert ids[i] < ids[i + 1], \
-                f"id not ascending as tie-breaker at index {i}: {ids[i]} >= {ids[i + 1]}"
+                f"id not ascending among returned equal-key rows at index {i}: {ids[i]} >= {ids[i + 1]}"
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_three_sort_fields(self):
@@ -1349,7 +1351,7 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_query_order_by_float_field_with_duplicates(self):
-        """OB-059: ORDER BY float field with many duplicate values — verify stable sort with PK tie-breaking.
+        """OB-059: ORDER BY float field with many duplicate values.
         float_field = round((idx % 1000) * 0.1, 1), so 3200 rows produce many duplicates."""
         client = self._client()
         res = self.query(client, VALID_COLLECTION_NAME,
@@ -1359,13 +1361,14 @@ class TestMilvusClientQueryOrderValid(TestMilvusClientV2Base):
                          order_by_fields=[{"field": "float_field", "order": "asc"}],
                          consistency_level="Strong")[0]
 
-        assert len(res) > 1, "Need multiple rows with same float value to test tie-breaking"
+        assert len(res) > 1, "Need multiple rows with the same float value to exercise equal-key ordering"
         # All float values should be identical
         for r in res:
             assert r["float_field"] == 0.5, \
                 f"Expected float_field=0.5, got {r['float_field']}"
-        # PK (id) should be ascending as tie-breaker
+        # Check monotonic IDs within the returned subset. Equal-key candidate
+        # selection is not guaranteed without an explicit final sort field.
         ids = [r["id"] for r in res]
         for i in range(len(ids) - 1):
             assert ids[i] < ids[i + 1], \
-                f"id not ascending as tie-breaker at index {i}: {ids[i]} >= {ids[i + 1]}"
+                f"id not ascending among returned equal-key rows at index {i}: {ids[i]} >= {ids[i + 1]}"

--- a/tests/restful_client_v2/testcases/test_query_order_by.py
+++ b/tests/restful_client_v2/testcases/test_query_order_by.py
@@ -1,0 +1,467 @@
+import pytest
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+DIM = 4
+NB = 200
+
+
+def _vec(seed):
+    return [float(seed), 0.0, 0.0, 0.0]
+
+
+def _rows(nb=NB):
+    rows = []
+    for i in range(nb):
+        rows.append(
+            {
+                "id": i,
+                "price": float(10 + (i % 10)),
+                "score": (i * 17 + 11) % nb,
+                "rating": float((i * 13) % 100) / 10,
+                "category": f"category_{i % 5}",
+                "nullable_score": None if i % 5 == 0 else i % 50,
+                "json_field": {"value": i},
+                "array_field": [i % 10, (i + 1) % 10],
+                "vec": _vec(i),
+            }
+        )
+    return rows
+
+
+def _parse_order_by_field(order_by_field):
+    parts = order_by_field.split(":")
+    field_name = parts[0]
+    direction = parts[1].lower() if len(parts) > 1 and parts[1] else "asc"
+    descending = direction in ("desc", "descending")
+    nulls_first = descending
+    if len(parts) > 2:
+        nulls_first = parts[2].lower() == "nulls_first"
+    return field_name, descending, nulls_first
+
+
+def _expected_rows(order_by_fields, limit, row_filter=None, offset=0):
+    rows = [row for row in _rows() if row_filter is None or row_filter(row)]
+    order_specs = [_parse_order_by_field(field) for field in order_by_fields]
+
+    def order_key(row):
+        key = []
+        for field_name, descending, nulls_first in order_specs:
+            value = row[field_name]
+            if value is None:
+                key.append((0 if nulls_first else 1, 0))
+            else:
+                key.append((1 if nulls_first else 0, -value if descending else value))
+        key.append(row["id"])
+        return tuple(key)
+
+    rows = sorted(rows, key=order_key)
+    return rows[offset : offset + limit]
+
+
+class TestQueryOrderBy(TestBase):
+    def setup_class(self):
+        self.collection_name = self.__class__.__name__ + gen_collection_name()
+
+    @pytest.fixture(scope="class", autouse=True)
+    def prepare_shared_query_order_collection(self, request, init_class_config):
+        collection_client, vector_client = self._class_scope_clients()
+
+        def teardown():
+            collection_client.collection_drop({"collectionName": self.collection_name})
+
+        request.addfinalizer(teardown)
+        self._create_query_order_collection(self.collection_name, collection_client, vector_client)
+
+    def _create_query_order_collection(self, name, collection_client, vector_client):
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {"fieldName": "price", "dataType": "Double"},
+                    {"fieldName": "score", "dataType": "Int64"},
+                    {"fieldName": "rating", "dataType": "Double"},
+                    {"fieldName": "category", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
+                    {"fieldName": "nullable_score", "dataType": "Int32", "nullable": True},
+                    {"fieldName": "json_field", "dataType": "JSON"},
+                    {
+                        "fieldName": "array_field",
+                        "dataType": "Array",
+                        "elementDataType": "Int64",
+                        "elementTypeParams": {"max_capacity": "8"},
+                    },
+                    {"fieldName": "vec", "dataType": "FloatVector", "elementTypeParams": {"dim": str(DIM)}},
+                ],
+            },
+            "indexParams": [{"fieldName": "vec", "indexName": "vec_index", "metricType": "L2"}],
+        }
+        rsp = collection_client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+        collection_client.wait_load_completed(name, timeout=60)
+
+        rows = _rows()
+        rsp = vector_client.vector_insert({"collectionName": name, "data": rows})
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == len(rows)
+        rsp = collection_client.flush(name)
+        assert rsp["code"] == 0, rsp
+
+    def _shared_collection(self):
+        return self.collection_name
+
+    def _query(self, payload, timeout=1):
+        rsp = self.vector_client.vector_query(payload, timeout=timeout)
+        assert rsp["code"] == 0, rsp
+        return rsp.get("data", [])
+
+    @staticmethod
+    def _assert_ordered(rows, field_name, descending=False):
+        values = [row[field_name] for row in rows]
+        for i in range(len(values) - 1):
+            if descending:
+                assert values[i] >= values[i + 1], f"{field_name} not descending at index {i}: {values}"
+            else:
+                assert values[i] <= values[i + 1], f"{field_name} not ascending at index {i}: {values}"
+
+    @staticmethod
+    def _assert_expected_ids(rows, expected_rows):
+        assert [row["id"] for row in rows] == [row["id"] for row in expected_rows]
+
+    @staticmethod
+    def _assert_expected_values(rows, expected_rows, fields):
+        actual = [tuple(row[field] for field in fields) for row in rows]
+        expected = [tuple(row[field] for field in fields) for row in expected_rows]
+        assert actual == expected
+
+    @staticmethod
+    def _assert_pk_tie_breaker(rows, fields):
+        for current, following in zip(rows, rows[1:]):
+            if all(current[field] == following[field] for field in fields):
+                assert current["id"] < following["id"], rows
+
+    @staticmethod
+    def _assert_nulls_at_end(values):
+        first_null = next((i for i, value in enumerate(values) if value is None), len(values))
+        non_nulls = values[:first_null]
+        nulls = values[first_null:]
+        assert non_nulls, "Expected non-null values before nulls"
+        assert nulls, "Expected null values at the end"
+        assert all(value is None for value in nulls)
+        return non_nulls
+
+    @staticmethod
+    def _assert_nulls_at_beginning(values):
+        first_non_null = next((i for i, value in enumerate(values) if value is not None), len(values))
+        nulls = values[:first_non_null]
+        non_nulls = values[first_non_null:]
+        assert nulls, "Expected null values at the beginning"
+        assert non_nulls, "Expected non-null values after nulls"
+        assert all(value is None for value in nulls)
+        return non_nulls
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_order_by_single_field_asc(self):
+        """
+        target: verify REST query supports orderByFields with default ascending order
+        method: query rows ordered by score without an explicit direction
+        expected: returned rows are globally sorted by score ascending
+        """
+        rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "limit": 20,
+                "outputFields": ["id", "score"],
+                "orderByFields": ["score"],
+            }
+        )
+        assert len(rows) == 20
+        self._assert_ordered(rows, "score")
+        expected = _expected_rows(["score"], limit=20)
+        assert [row["score"] for row in rows] == [row["score"] for row in expected]
+        self._assert_expected_ids(rows, expected)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_order_by_single_field_desc(self):
+        """
+        target: verify REST query supports descending orderByFields
+        method: query rows ordered by score:desc
+        expected: returned rows are globally sorted by score descending
+        """
+        rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "limit": 20,
+                "outputFields": ["id", "score"],
+                "orderByFields": ["score:desc"],
+            }
+        )
+        assert len(rows) == 20
+        self._assert_ordered(rows, "score", descending=True)
+        expected = _expected_rows(["score:desc"], limit=20)
+        assert [row["score"] for row in rows] == [row["score"] for row in expected]
+        self._assert_expected_ids(rows, expected)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_order_by_multi_fields(self):
+        """
+        target: verify REST query supports multi-field orderByFields
+        method: sort by price ascending and rating descending
+        expected: primary and secondary sort orders are both respected
+        """
+        rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "limit": 80,
+                "outputFields": ["id", "price", "rating"],
+                "orderByFields": ["price:asc", "rating:desc"],
+            }
+        )
+        assert len(rows) == 80
+        secondary_sort_tested = False
+        for i in range(len(rows) - 1):
+            current = rows[i]
+            following = rows[i + 1]
+            assert current["price"] <= following["price"], rows
+            if current["price"] == following["price"]:
+                assert current["rating"] >= following["rating"], rows
+                secondary_sort_tested = True
+        assert secondary_sort_tested, "No duplicate price values found; secondary sort was not verified"
+        expected = _expected_rows(["price:asc", "rating:desc"], limit=80)
+        self._assert_expected_values(rows, expected, ["price", "rating"])
+        self._assert_expected_ids(rows, expected)
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_order_by_with_filter(self):
+        """
+        target: verify REST query applies filter before orderByFields
+        method: filter a price range and sort by price ascending
+        expected: all rows match the filter and are sorted by price
+        """
+        rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "price >= 12 && price <= 16",
+                "limit": 50,
+                "outputFields": ["id", "price"],
+                "orderByFields": ["price:asc"],
+            }
+        )
+        assert len(rows) == 50
+        assert all(12 <= row["price"] <= 16 for row in rows)
+        self._assert_ordered(rows, "price")
+        expected = _expected_rows(
+            ["price:asc"],
+            limit=50,
+            row_filter=lambda row: 12 <= row["price"] <= 16,
+        )
+        self._assert_expected_values(rows, expected, ["price"])
+        self._assert_pk_tie_breaker(rows, ["price"])
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_query_order_by_default_limit(self):
+        """
+        target: verify REST query applies the default limit when orderByFields omits limit
+        method: send orderByFields and omit limit
+        expected: request succeeds with 100 ordered rows
+        """
+        rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "outputFields": ["id", "score"],
+                "orderByFields": ["score:desc"],
+            }
+        )
+        assert len(rows) == 100
+        self._assert_ordered(rows, "score", descending=True)
+        expected = _expected_rows(["score:desc"], limit=100)
+        self._assert_expected_ids(rows, expected)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_order_by_with_offset(self):
+        """
+        target: verify REST query applies offset after ordering
+        method: compare the second ordered page with a larger ordered baseline
+        expected: offset page equals the matching slice of the baseline result
+        """
+        base_payload = {
+            "collectionName": self._shared_collection(),
+            "filter": "id >= 0",
+            "limit": 20,
+            "outputFields": ["id", "price"],
+            "orderByFields": ["price:asc"],
+        }
+        baseline = self._query(base_payload)
+        page_payload = {**base_payload, "limit": 10, "offset": 10}
+        page = self._query(page_payload)
+        repeated_page = self._query(page_payload)
+
+        assert len(baseline) == 20
+        assert len({row["price"] for row in baseline}) == 1
+        assert [row["id"] for row in page] == [row["id"] for row in baseline[10:20]]
+        assert [row["id"] for row in repeated_page] == [row["id"] for row in page]
+        expected = _expected_rows(["price:asc"], limit=10, offset=10)
+        self._assert_expected_ids(page, expected)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_order_by_nullable_default_order(self):
+        """
+        target: verify REST query default null ordering for orderByFields
+        method: sort nullable_score ascending and descending
+        expected: asc puts nulls last; desc puts nulls first
+        """
+        asc_rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "limit": NB,
+                "outputFields": ["id", "nullable_score"],
+                "orderByFields": ["nullable_score:asc"],
+            }
+        )
+        assert len(asc_rows) == NB
+        asc_non_nulls = self._assert_nulls_at_end([row["nullable_score"] for row in asc_rows])
+        for i in range(len(asc_non_nulls) - 1):
+            assert asc_non_nulls[i] <= asc_non_nulls[i + 1]
+
+        desc_rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "limit": NB,
+                "outputFields": ["id", "nullable_score"],
+                "orderByFields": ["nullable_score:desc"],
+            }
+        )
+        assert len(desc_rows) == NB
+        desc_non_nulls = self._assert_nulls_at_beginning([row["nullable_score"] for row in desc_rows])
+        for i in range(len(desc_non_nulls) - 1):
+            assert desc_non_nulls[i] >= desc_non_nulls[i + 1]
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_order_by_nulls_override(self):
+        """
+        target: verify REST query supports explicit null ordering in orderByFields
+        method: use asc:nulls_first and desc:nulls_last
+        expected: explicit null placement overrides the default null ordering
+        """
+        nulls_first_rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "limit": NB,
+                "outputFields": ["id", "nullable_score"],
+                "orderByFields": ["nullable_score:asc:nulls_first"],
+            }
+        )
+        assert len(nulls_first_rows) == NB
+        non_nulls = self._assert_nulls_at_beginning([row["nullable_score"] for row in nulls_first_rows])
+        for i in range(len(non_nulls) - 1):
+            assert non_nulls[i] <= non_nulls[i + 1]
+
+        nulls_last_rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "limit": NB,
+                "outputFields": ["id", "nullable_score"],
+                "orderByFields": ["nullable_score:desc:nulls_last"],
+            }
+        )
+        assert len(nulls_last_rows) == NB
+        non_nulls = self._assert_nulls_at_end([row["nullable_score"] for row in nulls_last_rows])
+        for i in range(len(non_nulls) - 1):
+            assert non_nulls[i] >= non_nulls[i + 1]
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_order_by_sort_field_not_in_output(self):
+        """
+        target: verify REST query can order by a field omitted from outputFields
+        method: sort by price while outputting only id and category
+        expected: price is absent from output and the returned ids are still price-sorted
+        """
+        rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "limit": 20,
+                "outputFields": ["id", "category"],
+                "orderByFields": ["price:asc"],
+            }
+        )
+        assert len(rows) == 20
+        assert all("price" not in row for row in rows)
+        expected = _expected_rows(["price:asc"], limit=20)
+        expected_prices = [row["price"] for row in expected]
+
+        ids = [row["id"] for row in rows]
+        verify_rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": f"id in {ids}",
+                "limit": len(ids),
+                "outputFields": ["id", "price"],
+                "orderByFields": ["price:asc"],
+            }
+        )
+        price_by_id = {row["id"]: row["price"] for row in verify_rows}
+        prices_in_output_order = [price_by_id[row_id] for row_id in ids]
+        assert prices_in_output_order == expected_prices
+        for i in range(len(prices_in_output_order) - 1):
+            assert prices_in_output_order[i] <= prices_in_output_order[i + 1]
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_query_order_by_empty_result(self):
+        """
+        target: verify REST query returns empty result when filter matches no rows
+        method: query with impossible filter and orderByFields
+        expected: request succeeds and data is empty
+        """
+        rows = self._query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "score > 999999",
+                "limit": 10,
+                "outputFields": ["id", "score"],
+                "orderByFields": ["score:asc"],
+            },
+            timeout=0,
+        )
+        assert rows == []
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize(
+        "order_by,message",
+        [
+            ("vec:asc", "not sortable"),
+            ("json_field:asc", "not sortable"),
+            ("array_field:asc", "not sortable"),
+            ("unknown_field:asc", "does not exist"),
+            ("score:invalid", "invalid order direction"),
+            (":asc", "does not exist"),
+        ],
+    )
+    def test_query_order_by_invalid_params(self, order_by, message):
+        """
+        target: verify REST query rejects invalid orderByFields
+        method: send unsupported field types, unknown field, invalid direction, and empty field
+        expected: each request fails with a validation error
+        """
+        rsp = self.vector_client.vector_query(
+            {
+                "collectionName": self._shared_collection(),
+                "filter": "id >= 0",
+                "limit": 10,
+                "outputFields": ["id"],
+                "orderByFields": [order_by],
+            }
+        )
+        assert rsp["code"] == 1100, rsp
+        assert message in rsp["message"], rsp

--- a/tests/restful_client_v2/testcases/test_query_order_by.py
+++ b/tests/restful_client_v2/testcases/test_query_order_by.py
@@ -42,6 +42,11 @@ def _parse_order_by_field(order_by_field):
 
 
 def _expected_rows(order_by_fields, limit, row_filter=None, offset=0):
+    """Build a deterministic reference order for local assertions.
+
+    The final ID key stabilizes this test helper only. Query ORDER BY does not
+    guarantee an implicit PK tie-breaker when all explicit sort fields match.
+    """
     rows = [row for row in _rows() if row_filter is None or row_filter(row)]
     order_specs = [_parse_order_by_field(field) for field in order_by_fields]
 
@@ -138,7 +143,8 @@ class TestQueryOrderBy(TestBase):
         assert actual == expected
 
     @staticmethod
-    def _assert_pk_tie_breaker(rows, fields):
+    def _assert_returned_ties_pk_monotonic(rows, fields):
+        """Check the current returned subset without asserting exact tie selection."""
         for current, following in zip(rows, rows[1:]):
             if all(current[field] == following[field] for field in fields):
                 assert current["id"] < following["id"], rows
@@ -262,7 +268,7 @@ class TestQueryOrderBy(TestBase):
             row_filter=lambda row: 12 <= row["price"] <= 16,
         )
         self._assert_expected_values(rows, expected, ["price"])
-        self._assert_pk_tie_breaker(rows, ["price"])
+        self._assert_returned_ties_pk_monotonic(rows, ["price"])
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_query_order_by_default_limit(self):


### PR DESCRIPTION
## What this PR does

- Adds REST v2 query coverage for orderByFields across ascending, descending, multi-field, filtering, pagination, nullable fields, and invalid parameters.
- Uses class-scoped REST clients and shared collection setup consistent with the existing REST v2 test pattern.
- Verifies that omitting limit applies the REST default of 100 rows.
- Covers duplicate-key pagination behavior and exact validation error code 1100.

## Test

Against schema-evolution-v3-latest through port-forward:

    cd tests/restful_client_v2
    ../python_client/.venv/bin/python -m pytest testcases/test_query_order_by.py -v --tb=short -p no:rerunfailures --endpoint http://127.0.0.1:19530 --token root:Milvus

Result: 16 passed, 16 warnings in 40.87s.