### PR TITLE
enhance: [cp 3.0] add FileResource APIs to Go SDK and REST v2

### DIFF
--- a/client/entity/file_resource.go
+++ b/client/entity/file_resource.go
@@ -1,0 +1,24 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entity
+
+// FileResource describes a remote file registered with Milvus.
+type FileResource struct {
+	ID   int64
+	Name string
+	Path string
+}

--- a/client/milvusclient/file_resource.go
+++ b/client/milvusclient/file_resource.go
@@ -23,8 +23,8 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-	"github.com/milvus-io/milvus/client/v2/entity"
-	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/client/v3/entity"
+	"github.com/milvus-io/milvus/client/v3/internal/merr"
 )
 
 // AddFileResource registers a remote file with Milvus.

--- a/client/milvusclient/file_resource.go
+++ b/client/milvusclient/file_resource.go
@@ -1,0 +1,80 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"context"
+
+	"github.com/samber/lo"
+	"google.golang.org/grpc"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/client/v2/entity"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// AddFileResource registers a remote file with Milvus.
+func (c *Client) AddFileResource(ctx context.Context, option AddFileResourceOption, callOptions ...grpc.CallOption) error {
+	if option == nil {
+		return merr.WrapErrParameterInvalid("AddFileResourceOption", "nil", "option cannot be nil")
+	}
+
+	req := option.Request()
+	return c.callService(func(service milvuspb.MilvusServiceClient) error {
+		resp, err := service.AddFileResource(ctx, req, callOptions...)
+		return merr.CheckRPCCall(resp, err)
+	})
+}
+
+// RemoveFileResource unregisters a remote file from Milvus.
+func (c *Client) RemoveFileResource(ctx context.Context, option RemoveFileResourceOption, callOptions ...grpc.CallOption) error {
+	if option == nil {
+		return merr.WrapErrParameterInvalid("RemoveFileResourceOption", "nil", "option cannot be nil")
+	}
+
+	req := option.Request()
+	return c.callService(func(service milvuspb.MilvusServiceClient) error {
+		resp, err := service.RemoveFileResource(ctx, req, callOptions...)
+		return merr.CheckRPCCall(resp, err)
+	})
+}
+
+// ListFileResources lists all remote files registered with Milvus.
+func (c *Client) ListFileResources(ctx context.Context, option ListFileResourcesOption, callOptions ...grpc.CallOption) ([]*entity.FileResource, error) {
+	if option == nil {
+		return nil, merr.WrapErrParameterInvalid("ListFileResourcesOption", "nil", "option cannot be nil")
+	}
+
+	req := option.Request()
+	var resources []*entity.FileResource
+	err := c.callService(func(service milvuspb.MilvusServiceClient) error {
+		resp, err := service.ListFileResources(ctx, req, callOptions...)
+		if err = merr.CheckRPCCall(resp, err); err != nil {
+			return err
+		}
+
+		resources = lo.Map(resp.GetResources(), func(resource *milvuspb.FileResourceInfo, _ int) *entity.FileResource {
+			return &entity.FileResource{
+				ID:   resource.GetId(),
+				Name: resource.GetName(),
+				Path: resource.GetPath(),
+			}
+		})
+		return nil
+	})
+	return resources, err
+}

--- a/client/milvusclient/file_resource_options.go
+++ b/client/milvusclient/file_resource_options.go
@@ -1,0 +1,88 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+)
+
+// AddFileResourceOption builds an AddFileResource request.
+type AddFileResourceOption interface {
+	Request() *milvuspb.AddFileResourceRequest
+}
+
+type addFileResourceOption struct {
+	name string
+	path string
+}
+
+// NewAddFileResourceOption creates an option for registering a remote file.
+func NewAddFileResourceOption(name, path string) *addFileResourceOption {
+	return &addFileResourceOption{name: name, path: path}
+}
+
+func (opt *addFileResourceOption) Request() *milvuspb.AddFileResourceRequest {
+	return &milvuspb.AddFileResourceRequest{
+		Base: &commonpb.MsgBase{},
+		Name: opt.name,
+		Path: opt.path,
+	}
+}
+
+// RemoveFileResourceOption builds a RemoveFileResource request.
+type RemoveFileResourceOption interface {
+	Request() *milvuspb.RemoveFileResourceRequest
+}
+
+type removeFileResourceOption struct {
+	name string
+}
+
+// NewRemoveFileResourceOption creates an option for unregistering a remote file.
+func NewRemoveFileResourceOption(name string) *removeFileResourceOption {
+	return &removeFileResourceOption{name: name}
+}
+
+func (opt *removeFileResourceOption) Request() *milvuspb.RemoveFileResourceRequest {
+	return &milvuspb.RemoveFileResourceRequest{
+		Base: &commonpb.MsgBase{},
+		Name: opt.name,
+	}
+}
+
+// ListFileResourcesOption builds a ListFileResources request.
+type ListFileResourcesOption interface {
+	Request() *milvuspb.ListFileResourcesRequest
+}
+
+type listFileResourcesOption struct{}
+
+// NewListFileResourcesOption creates an option for listing registered files.
+func NewListFileResourcesOption() *listFileResourcesOption {
+	return &listFileResourcesOption{}
+}
+
+func (opt *listFileResourcesOption) Request() *milvuspb.ListFileResourcesRequest {
+	return &milvuspb.ListFileResourcesRequest{Base: &commonpb.MsgBase{}}
+}
+
+var (
+	_ AddFileResourceOption    = (*addFileResourceOption)(nil)
+	_ RemoveFileResourceOption = (*removeFileResourceOption)(nil)
+	_ ListFileResourcesOption  = (*listFileResourcesOption)(nil)
+)

--- a/client/milvusclient/file_resource_test.go
+++ b/client/milvusclient/file_resource_test.go
@@ -1,0 +1,153 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+type FileResourceSuite struct {
+	MockSuiteBase
+}
+
+func (s *FileResourceSuite) TestOptions() {
+	addReq := NewAddFileResourceOption("synonyms", "analyzers/synonyms.txt").Request()
+	s.NotNil(addReq.GetBase())
+	s.Equal("synonyms", addReq.GetName())
+	s.Equal("analyzers/synonyms.txt", addReq.GetPath())
+
+	removeReq := NewRemoveFileResourceOption("synonyms").Request()
+	s.NotNil(removeReq.GetBase())
+	s.Equal("synonyms", removeReq.GetName())
+
+	listReq := NewListFileResourcesOption().Request()
+	s.NotNil(listReq.GetBase())
+}
+
+func (s *FileResourceSuite) TestAddFileResource() {
+	ctx := context.Background()
+
+	s.Run("success", func() {
+		s.mock.EXPECT().AddFileResource(mock.Anything, mock.Anything).RunAndReturn(
+			func(_ context.Context, req *milvuspb.AddFileResourceRequest) (*commonpb.Status, error) {
+				s.Equal("synonyms", req.GetName())
+				s.Equal("analyzers/synonyms.txt", req.GetPath())
+				return merr.Success(), nil
+			}).Once()
+
+		s.NoError(s.client.AddFileResource(ctx, NewAddFileResourceOption("synonyms", "analyzers/synonyms.txt")))
+	})
+
+	s.Run("rpc error", func() {
+		s.mock.EXPECT().AddFileResource(mock.Anything, mock.Anything).Return(nil, errors.New("mocked")).Once()
+		s.Error(s.client.AddFileResource(ctx, NewAddFileResourceOption("synonyms", "analyzers/synonyms.txt")))
+	})
+
+	s.Run("status error", func() {
+		s.mock.EXPECT().AddFileResource(mock.Anything, mock.Anything).Return(merr.Status(merr.ErrParameterInvalid), nil).Once()
+		s.Error(s.client.AddFileResource(ctx, NewAddFileResourceOption("synonyms", "analyzers/synonyms.txt")))
+	})
+
+	s.Run("nil option", func() {
+		err := s.client.AddFileResource(ctx, nil)
+		s.ErrorIs(err, merr.ErrParameterInvalid)
+	})
+}
+
+func (s *FileResourceSuite) TestRemoveFileResource() {
+	ctx := context.Background()
+
+	s.Run("success", func() {
+		s.mock.EXPECT().RemoveFileResource(mock.Anything, mock.Anything).RunAndReturn(
+			func(_ context.Context, req *milvuspb.RemoveFileResourceRequest) (*commonpb.Status, error) {
+				s.Equal("synonyms", req.GetName())
+				return merr.Success(), nil
+			}).Once()
+
+		s.NoError(s.client.RemoveFileResource(ctx, NewRemoveFileResourceOption("synonyms")))
+	})
+
+	s.Run("failure", func() {
+		s.mock.EXPECT().RemoveFileResource(mock.Anything, mock.Anything).Return(nil, errors.New("mocked")).Once()
+		s.Error(s.client.RemoveFileResource(ctx, NewRemoveFileResourceOption("synonyms")))
+	})
+
+	s.Run("status error", func() {
+		s.mock.EXPECT().RemoveFileResource(mock.Anything, mock.Anything).Return(merr.Status(merr.ErrParameterInvalid), nil).Once()
+		s.Error(s.client.RemoveFileResource(ctx, NewRemoveFileResourceOption("synonyms")))
+	})
+
+	s.Run("nil option", func() {
+		err := s.client.RemoveFileResource(ctx, nil)
+		s.ErrorIs(err, merr.ErrParameterInvalid)
+	})
+}
+
+func (s *FileResourceSuite) TestListFileResources() {
+	ctx := context.Background()
+
+	s.Run("success", func() {
+		s.mock.EXPECT().ListFileResources(mock.Anything, mock.Anything).Return(&milvuspb.ListFileResourcesResponse{
+			Status: merr.Success(),
+			Resources: []*milvuspb.FileResourceInfo{
+				{Id: 100, Name: "synonyms", Path: "analyzers/synonyms.txt"},
+			},
+		}, nil).Once()
+
+		resources, err := s.client.ListFileResources(ctx, NewListFileResourcesOption())
+		s.NoError(err)
+		s.Require().Len(resources, 1)
+		s.EqualValues(100, resources[0].ID)
+		s.Equal("synonyms", resources[0].Name)
+		s.Equal("analyzers/synonyms.txt", resources[0].Path)
+	})
+
+	s.Run("failure", func() {
+		s.mock.EXPECT().ListFileResources(mock.Anything, mock.Anything).Return(nil, errors.New("mocked")).Once()
+		resources, err := s.client.ListFileResources(ctx, NewListFileResourcesOption())
+		s.Error(err)
+		s.Nil(resources)
+	})
+
+	s.Run("status error", func() {
+		s.mock.EXPECT().ListFileResources(mock.Anything, mock.Anything).Return(&milvuspb.ListFileResourcesResponse{
+			Status: merr.Status(merr.ErrParameterInvalid),
+		}, nil).Once()
+		resources, err := s.client.ListFileResources(ctx, NewListFileResourcesOption())
+		s.Error(err)
+		s.Nil(resources)
+	})
+
+	s.Run("nil option", func() {
+		resources, err := s.client.ListFileResources(ctx, nil)
+		s.ErrorIs(err, merr.ErrParameterInvalid)
+		s.Nil(resources)
+	})
+}
+
+func TestFileResource(t *testing.T) {
+	suite.Run(t, new(FileResourceSuite))
+}

--- a/client/milvusclient/file_resource_test.go
+++ b/client/milvusclient/file_resource_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/client/v3/internal/merr"
 )
 
 type FileResourceSuite struct {

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -40,6 +40,7 @@ const (
 	CollectionFieldCategory       = "/collections/fields/"
 	CollectionStructFieldCategory = "/collections/struct_fields/"
 	ResourceGroupCategory         = "/resource_groups/"
+	FileResourceCategory          = "/file_resources/"
 	SegmentCategory               = "/segments/"
 	QuotaCenterCategory           = "/quotacenter/"
 	CommonCategory                = "/common/"
@@ -79,6 +80,7 @@ const (
 	AddFunctionFieldAction          = "add_function_field"
 	DropFunctionFieldAction         = "drop_function_field"
 	AddAction                       = `add`
+	RemoveAction                    = "remove"
 	DropPropertiesAction            = "drop_properties"
 	CompactAction                   = "compact"
 	CompactionStateAction           = "get_compaction_state"

--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2.go
@@ -1,0 +1,81 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func (h *HandlersV2) addFileResource(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*FileResourceReq)
+	req := &milvuspb.AddFileResourceRequest{
+		Name: httpReq.Name,
+		Path: httpReq.Path,
+	}
+	c.Set(ContextRequest, req)
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddFileResource", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.AddFileResource(reqCtx, req.(*milvuspb.AddFileResourceRequest))
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}
+
+func (h *HandlersV2) removeFileResource(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*FileResourceNameReq)
+	req := &milvuspb.RemoveFileResourceRequest{
+		Name: httpReq.Name,
+	}
+	c.Set(ContextRequest, req)
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/RemoveFileResource", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.RemoveFileResource(reqCtx, req.(*milvuspb.RemoveFileResourceRequest))
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}
+
+func (h *HandlersV2) listFileResources(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	req := &milvuspb.ListFileResourcesRequest{}
+	c.Set(ContextRequest, req)
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/ListFileResources", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.ListFileResources(reqCtx, req.(*milvuspb.ListFileResourcesRequest))
+	})
+	if err == nil {
+		resources := make([]gin.H, 0, len(resp.(*milvuspb.ListFileResourcesResponse).GetResources()))
+		for _, resource := range resp.(*milvuspb.ListFileResourcesResponse).GetResources() {
+			resources = append(resources, gin.H{
+				"id":   resource.GetId(),
+				"name": resource.GetName(),
+				"path": resource.GetPath(),
+			})
+		}
+		HTTPReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode: merr.Code(nil),
+			HTTPReturnData: resources,
+		})
+	}
+	return resp, err
+}

--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2.go
@@ -19,6 +19,7 @@ package httpserver
 import (
 	"context"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
@@ -64,10 +65,11 @@ func (h *HandlersV2) listFileResources(ctx context.Context, c *gin.Context, anyR
 		return h.proxy.ListFileResources(reqCtx, req.(*milvuspb.ListFileResourcesRequest))
 	})
 	if err == nil {
+		allowInt64, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
 		resources := make([]gin.H, 0, len(resp.(*milvuspb.ListFileResourcesResponse).GetResources()))
 		for _, resource := range resp.(*milvuspb.ListFileResourcesResponse).GetResources() {
 			resources = append(resources, gin.H{
-				"id":   resource.GetId(),
+				"id":   formatRESTInt64(resource.GetId(), allowInt64),
 				"name": resource.GetName(),
 				"path": resource.GetPath(),
 			})

--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
@@ -122,7 +122,7 @@ func TestFileResourceHandlerV2(t *testing.T) {
 		resources := response[HTTPReturnData].([]interface{})
 		require.Len(t, resources, 1)
 		resource := resources[0].(map[string]interface{})
-		assert.EqualValues(t, 100, resource["id"])
+		assert.Equal(t, "100", resource["id"])
 		assert.Equal(t, "synonyms", resource["name"])
 		assert.Equal(t, "files/synonyms.txt", resource["path"])
 	})
@@ -132,6 +132,61 @@ func TestFileResourceHandlerV2(t *testing.T) {
 		assert.EqualValues(t, 0, response[HTTPReturnCode])
 		assert.Empty(t, response[HTTPReturnData])
 	})
+}
+
+func TestFileResourceHandlerV2FormatsInt64IDs(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	const resourceID int64 = 9007199254740993
+	testCases := []struct {
+		name        string
+		allowInt64  string
+		expectedRaw string
+	}{
+		{
+			name:        "default string",
+			expectedRaw: `"9007199254740993"`,
+		},
+		{
+			name:        "allow int64",
+			allowInt64:  "true",
+			expectedRaw: "9007199254740993",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockProxy := mocks.NewMockProxy(t)
+			mockProxy.EXPECT().ListFileResources(mock.Anything, mock.Anything).Return(&milvuspb.ListFileResourcesResponse{
+				Status: merr.Success(),
+				Resources: []*milvuspb.FileResourceInfo{
+					{Id: resourceID, Name: "synonyms", Path: "files/synonyms.txt"},
+				},
+			}, nil).Once()
+			server := initHTTPServerV2(mockProxy, false)
+
+			req := httptest.NewRequest(http.MethodPost, versionalV2(FileResourceCategory, ListAction), bytes.NewBufferString(`{}`))
+			if testCase.allowInt64 != "" {
+				req.Header.Set(HTTPHeaderAllowInt64, testCase.allowInt64)
+			}
+			recorder := httptest.NewRecorder()
+			server.ServeHTTP(recorder, req)
+			require.Equal(t, http.StatusOK, recorder.Code)
+
+			response := struct {
+				Code int32 `json:"code"`
+				Data []struct {
+					ID json.RawMessage `json:"id"`
+				} `json:"data"`
+			}{}
+			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+			assert.EqualValues(t, 0, response.Code)
+			require.Len(t, response.Data, 1)
+			assert.Equal(t, testCase.expectedRaw, string(response.Data[0].ID))
+		})
+	}
 }
 
 func TestFileResourceHandlerV2PropagatesErrors(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
@@ -146,7 +146,8 @@ func TestFileResourceHandlerV2FormatsInt64IDs(t *testing.T) {
 		expectedRaw string
 	}{
 		{
-			name:        "default string",
+			name:        "disallow int64",
+			allowInt64:  "false",
 			expectedRaw: `"9007199254740993"`,
 		},
 		{

--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
@@ -37,17 +37,25 @@ import (
 )
 
 type rejectingFileResourceLimiter struct {
-	t          *testing.T
-	checkCount int
+	t      *testing.T
+	checks []fileResourceLimiterCheck
+}
+
+type fileResourceLimiterCheck struct {
+	rateType internalpb.RateType
+	n        int
 }
 
 func (l *rejectingFileResourceLimiter) Check(dbID int64, collectionIDToPartIDs map[int64][]int64, rateType internalpb.RateType, n int) error {
 	l.t.Helper()
 	require.Equal(l.t, util.InvalidDBID, dbID)
 	require.Empty(l.t, collectionIDToPartIDs)
+	l.checks = append(l.checks, fileResourceLimiterCheck{rateType: rateType, n: n})
+	if n <= 0 {
+		return nil
+	}
 	require.Equal(l.t, internalpb.RateType_DDLCollection, rateType)
 	require.Equal(l.t, 1, n)
-	l.checkCount++
 	return merr.ErrServiceRateLimit
 }
 
@@ -220,20 +228,30 @@ func TestFileResourceHandlerV2ChecksQuota(t *testing.T) {
 	limiter := &rejectingFileResourceLimiter{t: t}
 	mockProxy := mocks.NewMockProxy(t)
 	mockProxy.EXPECT().GetRateLimiter().Return(limiter, nil).Times(3)
+	mockProxy.EXPECT().ListFileResources(mock.Anything, mock.Anything).Return(&milvuspb.ListFileResourcesResponse{
+		Status: merr.Success(),
+	}, nil).Once()
 	server := initHTTPServerV2(mockProxy, false)
 
-	testCases := []struct {
+	writeCases := []struct {
 		path string
 		body string
 	}{
 		{path: versionalV2(FileResourceCategory, AddAction), body: `{"name":"synonyms","path":"synonyms.txt"}`},
 		{path: versionalV2(FileResourceCategory, RemoveAction), body: `{"name":"synonyms"}`},
-		{path: versionalV2(FileResourceCategory, ListAction), body: `{}`},
 	}
-	for _, testCase := range testCases {
+	for _, testCase := range writeCases {
 		response := postFileResourceRequest(t, server, testCase.path, testCase.body)
 		assert.EqualValues(t, merr.Code(merr.ErrHTTPRateLimit), response[HTTPReturnCode])
 		assert.Contains(t, response[HTTPReturnMessage], merr.ErrServiceRateLimit.Error())
 	}
-	require.Equal(t, len(testCases), limiter.checkCount)
+
+	response := postFileResourceRequest(t, server, versionalV2(FileResourceCategory, ListAction), `{}`)
+	assert.EqualValues(t, 0, response[HTTPReturnCode])
+	assert.Empty(t, response[HTTPReturnData])
+
+	require.Len(t, limiter.checks, 3)
+	assert.Equal(t, fileResourceLimiterCheck{rateType: internalpb.RateType_DDLCollection, n: 1}, limiter.checks[0])
+	assert.Equal(t, fileResourceLimiterCheck{rateType: internalpb.RateType_DDLCollection, n: 1}, limiter.checks[1])
+	assert.Zero(t, limiter.checks[2].n)
 }

--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
@@ -18,6 +18,7 @@ package httpserver
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,9 +30,30 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+type rejectingFileResourceLimiter struct {
+	t          *testing.T
+	checkCount int
+}
+
+func (l *rejectingFileResourceLimiter) Check(dbID int64, collectionIDToPartIDs map[int64][]int64, rateType internalpb.RateType, n int) error {
+	l.t.Helper()
+	require.Equal(l.t, util.InvalidDBID, dbID)
+	require.Empty(l.t, collectionIDToPartIDs)
+	require.Equal(l.t, internalpb.RateType_DDLCollection, rateType)
+	require.Equal(l.t, 1, n)
+	l.checkCount++
+	return merr.ErrServiceRateLimit
+}
+
+func (l *rejectingFileResourceLimiter) Alloc(ctx context.Context, dbID int64, collectionIDToPartIDs map[int64][]int64, rateType internalpb.RateType, n int) error {
+	return l.Check(dbID, collectionIDToPartIDs, rateType, n)
+}
 
 func postFileResourceRequest(t *testing.T, server http.Handler, path, body string) map[string]interface{} {
 	t.Helper()
@@ -188,4 +210,30 @@ func TestFileResourceHandlerV2ReturnsEmptyList(t *testing.T) {
 	response := postFileResourceRequest(t, server, versionalV2(FileResourceCategory, ListAction), `{}`)
 	assert.EqualValues(t, 0, response[HTTPReturnCode])
 	assert.Empty(t, response[HTTPReturnData].([]interface{}))
+}
+
+func TestFileResourceHandlerV2ChecksQuota(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	limiter := &rejectingFileResourceLimiter{t: t}
+	mockProxy := mocks.NewMockProxy(t)
+	mockProxy.EXPECT().GetRateLimiter().Return(limiter, nil).Times(3)
+	server := initHTTPServerV2(mockProxy, false)
+
+	testCases := []struct {
+		path string
+		body string
+	}{
+		{path: versionalV2(FileResourceCategory, AddAction), body: `{"name":"synonyms","path":"synonyms.txt"}`},
+		{path: versionalV2(FileResourceCategory, RemoveAction), body: `{"name":"synonyms"}`},
+		{path: versionalV2(FileResourceCategory, ListAction), body: `{}`},
+	}
+	for _, testCase := range testCases {
+		response := postFileResourceRequest(t, server, testCase.path, testCase.body)
+		assert.EqualValues(t, merr.Code(merr.ErrHTTPRateLimit), response[HTTPReturnCode])
+		assert.Contains(t, response[HTTPReturnMessage], merr.ErrServiceRateLimit.Error())
+	}
+	require.Equal(t, len(testCases), limiter.checkCount)
 }

--- a/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/file_resource_handler_v2_test.go
@@ -1,0 +1,191 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func postFileResourceRequest(t *testing.T, server http.Handler, path, body string) map[string]interface{} {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(body))
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	response := make(map[string]interface{})
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	return response
+}
+
+func TestFileResourceHandlerV2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	mockProxy := mocks.NewMockProxy(t)
+	mockProxy.EXPECT().AddFileResource(mock.Anything, mock.MatchedBy(func(req *milvuspb.AddFileResourceRequest) bool {
+		return req.GetName() == "synonyms" && req.GetPath() == "files/synonyms.txt"
+	})).Return(merr.Success(), nil).Once()
+	mockProxy.EXPECT().RemoveFileResource(mock.Anything, mock.MatchedBy(func(req *milvuspb.RemoveFileResourceRequest) bool {
+		return req.GetName() == "synonyms"
+	})).Return(merr.Success(), nil).Once()
+	mockProxy.EXPECT().ListFileResources(mock.Anything, mock.Anything).Return(&milvuspb.ListFileResourcesResponse{
+		Status: merr.Success(),
+		Resources: []*milvuspb.FileResourceInfo{
+			{Id: 100, Name: "synonyms", Path: "files/synonyms.txt"},
+		},
+	}, nil).Once()
+	server := initHTTPServerV2(mockProxy, false)
+
+	t.Run("validation", func(t *testing.T) {
+		response := postFileResourceRequest(t, server, versionalV2(FileResourceCategory, AddAction), `{}`)
+		assert.EqualValues(t, merr.Code(merr.ErrMissingRequiredParameters), response[HTTPReturnCode])
+		assert.Contains(t, response[HTTPReturnMessage], "FileResourceReq.Name")
+		assert.Contains(t, response[HTTPReturnMessage], "FileResourceReq.Path")
+
+		response = postFileResourceRequest(t, server, versionalV2(FileResourceCategory, AddAction), `{"name":"synonyms"}`)
+		assert.EqualValues(t, merr.Code(merr.ErrMissingRequiredParameters), response[HTTPReturnCode])
+		assert.Contains(t, response[HTTPReturnMessage], "FileResourceReq.Path")
+
+		response = postFileResourceRequest(t, server, versionalV2(FileResourceCategory, RemoveAction), `{}`)
+		assert.EqualValues(t, merr.Code(merr.ErrMissingRequiredParameters), response[HTTPReturnCode])
+		assert.Contains(t, response[HTTPReturnMessage], "FileResourceNameReq.Name")
+	})
+
+	t.Run("add", func(t *testing.T) {
+		response := postFileResourceRequest(t, server, versionalV2(FileResourceCategory, AddAction), `{"name":"synonyms","path":"files/synonyms.txt"}`)
+		assert.EqualValues(t, 0, response[HTTPReturnCode])
+		assert.Empty(t, response[HTTPReturnData])
+	})
+
+	t.Run("list", func(t *testing.T) {
+		response := postFileResourceRequest(t, server, versionalV2(FileResourceCategory, ListAction), `{}`)
+		assert.EqualValues(t, 0, response[HTTPReturnCode])
+		resources := response[HTTPReturnData].([]interface{})
+		require.Len(t, resources, 1)
+		resource := resources[0].(map[string]interface{})
+		assert.EqualValues(t, 100, resource["id"])
+		assert.Equal(t, "synonyms", resource["name"])
+		assert.Equal(t, "files/synonyms.txt", resource["path"])
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		response := postFileResourceRequest(t, server, versionalV2(FileResourceCategory, RemoveAction), `{"name":"synonyms"}`)
+		assert.EqualValues(t, 0, response[HTTPReturnCode])
+		assert.Empty(t, response[HTTPReturnData])
+	})
+}
+
+func TestFileResourceHandlerV2PropagatesErrors(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	testCases := []struct {
+		name       string
+		path       string
+		body       string
+		setup      func(*mocks.MockProxy)
+		errCode    int32
+		errMessage string
+	}{
+		{
+			name: "add conflict",
+			path: versionalV2(FileResourceCategory, AddAction),
+			body: `{"name":"synonyms","path":"other.txt"}`,
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().AddFileResource(mock.Anything, mock.Anything).Return(merr.Status(merr.WrapErrParameterInvalidMsg("file resource synonyms already exists")), nil)
+			},
+			errCode:    merr.Code(merr.ErrParameterInvalid),
+			errMessage: "already exists",
+		},
+		{
+			name: "remove in use",
+			path: versionalV2(FileResourceCategory, RemoveAction),
+			body: `{"name":"synonyms"}`,
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().RemoveFileResource(mock.Anything, mock.Anything).Return(merr.Status(merr.WrapErrParameterInvalidMsg("file resource synonyms is still in use")), nil)
+			},
+			errCode:    merr.Code(merr.ErrParameterInvalid),
+			errMessage: "still in use",
+		},
+		{
+			name: "list failure",
+			path: versionalV2(FileResourceCategory, ListAction),
+			body: `{}`,
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().ListFileResources(mock.Anything, mock.Anything).Return(&milvuspb.ListFileResourcesResponse{
+					Status: merr.Status(merr.WrapErrParameterInvalidMsg("cannot list file resources")),
+				}, nil)
+			},
+			errCode:    merr.Code(merr.ErrParameterInvalid),
+			errMessage: "cannot list file resources",
+		},
+		{
+			name: "sync unavailable",
+			path: versionalV2(FileResourceCategory, AddAction),
+			body: `{"name":"synonyms","path":"synonyms.txt"}`,
+			setup: func(proxy *mocks.MockProxy) {
+				proxy.EXPECT().AddFileResource(mock.Anything, mock.Anything).Return(merr.Status(merr.WrapErrServiceUnavailableMsg("file resource sync failed")), nil)
+			},
+			errCode:    merr.Code(merr.ErrServiceUnavailable),
+			errMessage: "file resource sync failed",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockProxy := mocks.NewMockProxy(t)
+			testCase.setup(mockProxy)
+			server := initHTTPServerV2(mockProxy, false)
+
+			response := postFileResourceRequest(t, server, testCase.path, testCase.body)
+			assert.EqualValues(t, testCase.errCode, response[HTTPReturnCode])
+			assert.Contains(t, response[HTTPReturnMessage], testCase.errMessage)
+		})
+	}
+}
+
+func TestFileResourceHandlerV2ReturnsEmptyList(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	mockProxy := mocks.NewMockProxy(t)
+	mockProxy.EXPECT().ListFileResources(mock.Anything, mock.Anything).Return(&milvuspb.ListFileResourcesResponse{
+		Status: merr.Success(),
+	}, nil).Once()
+	server := initHTTPServerV2(mockProxy, false)
+
+	response := postFileResourceRequest(t, server, versionalV2(FileResourceCategory, ListAction), `{}`)
+	assert.EqualValues(t, 0, response[HTTPReturnCode])
+	assert.Empty(t, response[HTTPReturnData].([]interface{}))
+}

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -184,6 +184,10 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 	"/v2/vectordb/resource_groups/list":             "ListResourceGroups",
 	"/v2/vectordb/resource_groups/transfer_replica": "TransferMaster",
 
+	"/v2/vectordb/file_resources/add":    "AddFileResource",
+	"/v2/vectordb/file_resources/remove": "RemoveFileResource",
+	"/v2/vectordb/file_resources/list":   "ListFileResources",
+
 	"/v2/vectordb/segments/describe":    "GetSegmentsInfo",
 	"/v2/vectordb/quotacenter/describe": "GetQuotaMetrics",
 
@@ -345,6 +349,11 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(ResourceGroupCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &ResourceGroupReq{} }, wrapperTraceLog(h.describeResourceGroup))))
 	router.POST(ResourceGroupCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &EmptyReq{} }, wrapperTraceLog(h.listResourceGroups))))
 	router.POST(ResourceGroupCategory+TransferReplicaAction, timeoutMiddleware(wrapperPost(func() any { return &TransferReplicaReq{} }, wrapperTraceLog(h.transferReplica))))
+
+	// file resource
+	router.POST(FileResourceCategory+AddAction, timeoutMiddleware(wrapperPost(func() any { return &FileResourceReq{} }, wrapperTraceLog(h.addFileResource))))
+	router.POST(FileResourceCategory+RemoveAction, timeoutMiddleware(wrapperPost(func() any { return &FileResourceNameReq{} }, wrapperTraceLog(h.removeFileResource))))
+	router.POST(FileResourceCategory+ListAction, timeoutMiddleware(wrapperPost(func() any { return &EmptyReq{} }, wrapperTraceLog(h.listFileResources))))
 
 	// segment group
 	router.POST(SegmentCategory+DescribeAction, timeoutMiddleware(wrapperPost(func() any { return &GetSegmentsInfoReq{} }, wrapperTraceLog(h.getSegmentsInfo))))

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -36,6 +36,15 @@ type EmptyReq struct{}
 
 func (req *EmptyReq) GetDbName() string { return "" }
 
+type FileResourceReq struct {
+	Name string `json:"name" binding:"required"`
+	Path string `json:"path" binding:"required"`
+}
+
+type FileResourceNameReq struct {
+	Name string `json:"name" binding:"required"`
+}
+
 type DatabaseReq struct {
 	DbName string `json:"dbName"`
 }

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -377,6 +377,9 @@ func TestRateLimitInterceptor(t *testing.T) {
 		testGetFailedResponse(&milvuspb.ExportSnapshotRequest{}, internalpb.RateType_DDLCollection, merr.ErrServiceRateLimit, "exportSnapshot")
 		testGetFailedResponse(&milvuspb.FlushRequest{}, internalpb.RateType_DDLFlush, merr.ErrServiceRateLimit, "flush")
 		testGetFailedResponse(&milvuspb.ManualCompactionRequest{}, internalpb.RateType_DDLCompaction, merr.ErrServiceRateLimit, "compaction")
+		testGetFailedResponse(&milvuspb.AddFileResourceRequest{}, internalpb.RateType_DDLCollection, merr.ErrServiceRateLimit, "addFileResource")
+		testGetFailedResponse(&milvuspb.RemoveFileResourceRequest{}, internalpb.RateType_DDLCollection, merr.ErrServiceRateLimit, "removeFileResource")
+		testGetFailedResponse(&milvuspb.ListFileResourcesRequest{}, internalpb.RateType_DDLCollection, merr.ErrServiceRateLimit, "listFileResources")
 
 		// test illegal
 		rsp := GetFailedResponse(&milvuspb.SearchResults{}, merr.OldCodeToMerr(commonpb.ErrorCode_UnexpectedError))
@@ -671,6 +674,22 @@ func TestGetInfo(t *testing.T) {
 			assert.Equal(t, util.InvalidDBID, dbID)
 			assert.Equal(t, 0, len(collectionInfos))
 			assert.Equal(t, internalpb.RateType_DDLDB, rateType)
+			assert.Equal(t, 1, cost)
+		}
+	})
+
+	t.Run("get file resource request info", func(t *testing.T) {
+		requests := []proto.Message{
+			&milvuspb.AddFileResourceRequest{},
+			&milvuspb.RemoveFileResourceRequest{},
+			&milvuspb.ListFileResourcesRequest{},
+		}
+		for _, request := range requests {
+			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, request)
+			assert.NoError(t, err)
+			assert.Equal(t, util.InvalidDBID, dbID)
+			assert.Empty(t, collectionInfos)
+			assert.Equal(t, internalpb.RateType_DDLCollection, rateType)
 			assert.Equal(t, 1, cost)
 		}
 	})

--- a/internal/proxy/rate_limit_interceptor_test.go
+++ b/internal/proxy/rate_limit_interceptor_test.go
@@ -379,7 +379,6 @@ func TestRateLimitInterceptor(t *testing.T) {
 		testGetFailedResponse(&milvuspb.ManualCompactionRequest{}, internalpb.RateType_DDLCompaction, merr.ErrServiceRateLimit, "compaction")
 		testGetFailedResponse(&milvuspb.AddFileResourceRequest{}, internalpb.RateType_DDLCollection, merr.ErrServiceRateLimit, "addFileResource")
 		testGetFailedResponse(&milvuspb.RemoveFileResourceRequest{}, internalpb.RateType_DDLCollection, merr.ErrServiceRateLimit, "removeFileResource")
-		testGetFailedResponse(&milvuspb.ListFileResourcesRequest{}, internalpb.RateType_DDLCollection, merr.ErrServiceRateLimit, "listFileResources")
 
 		// test illegal
 		rsp := GetFailedResponse(&milvuspb.SearchResults{}, merr.OldCodeToMerr(commonpb.ErrorCode_UnexpectedError))
@@ -682,7 +681,6 @@ func TestGetInfo(t *testing.T) {
 		requests := []proto.Message{
 			&milvuspb.AddFileResourceRequest{},
 			&milvuspb.RemoveFileResourceRequest{},
-			&milvuspb.ListFileResourcesRequest{},
 		}
 		for _, request := range requests {
 			dbID, collectionInfos, rateType, cost, err := GetRequestInfo(ctx, request)
@@ -692,5 +690,11 @@ func TestGetInfo(t *testing.T) {
 			assert.Equal(t, internalpb.RateType_DDLCollection, rateType)
 			assert.Equal(t, 1, cost)
 		}
+
+		dbID, collectionInfos, _, cost, err := GetRequestInfo(ctx, &milvuspb.ListFileResourcesRequest{})
+		assert.NoError(t, err)
+		assert.Equal(t, util.InvalidDBID, dbID)
+		assert.Empty(t, collectionInfos)
+		assert.Zero(t, cost)
 	})
 }

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -3128,8 +3128,11 @@ func GetRequestInfo(ctx context.Context, req proto.Message) (int64, map[int64][]
 		return dbInfo.dbID, map[int64][]int64{
 			r.GetCollectionID(): {},
 		}, internalpb.RateType_DDLCompaction, 1, nil
-	case *milvuspb.AddFileResourceRequest, *milvuspb.RemoveFileResourceRequest,
-		*milvuspb.ListFileResourcesRequest:
+	case *milvuspb.ListFileResourcesRequest:
+		// ListFileResources is a cluster-scoped read-only request. Like the
+		// other cluster list APIs, it does not consume a limiter token.
+		return util.InvalidDBID, map[int64][]int64{}, 0, 0, nil
+	case *milvuspb.AddFileResourceRequest, *milvuspb.RemoveFileResourceRequest:
 		// File resources are cluster-scoped metadata used by collection
 		// analyzers. Charge the cluster collection-DDL limiter without
 		// attributing the request to an arbitrary database.
@@ -3177,10 +3180,6 @@ func GetFailedResponse(req any, err error) any {
 		*milvuspb.AlterDatabaseRequest,
 		*milvuspb.AddFileResourceRequest, *milvuspb.RemoveFileResourceRequest:
 		return merr.Status(err)
-	case *milvuspb.ListFileResourcesRequest:
-		return &milvuspb.ListFileResourcesResponse{
-			Status: merr.Status(err),
-		}
 	case *milvuspb.RestoreExternalSnapshotRequest:
 		return &milvuspb.RestoreExternalSnapshotResponse{
 			Status: merr.Status(err),

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -3128,6 +3128,12 @@ func GetRequestInfo(ctx context.Context, req proto.Message) (int64, map[int64][]
 		return dbInfo.dbID, map[int64][]int64{
 			r.GetCollectionID(): {},
 		}, internalpb.RateType_DDLCompaction, 1, nil
+	case *milvuspb.AddFileResourceRequest, *milvuspb.RemoveFileResourceRequest,
+		*milvuspb.ListFileResourcesRequest:
+		// File resources are cluster-scoped metadata used by collection
+		// analyzers. Charge the cluster collection-DDL limiter without
+		// attributing the request to an arbitrary database.
+		return util.InvalidDBID, map[int64][]int64{}, internalpb.RateType_DDLCollection, 1, nil
 	case *milvuspb.CreateDatabaseRequest:
 		mlog.Info(context.TODO(), "rate limiter CreateDatabaseRequest")
 		return util.InvalidDBID, map[int64][]int64{}, internalpb.RateType_DDLDB, 1, nil
@@ -3168,8 +3174,13 @@ func GetFailedResponse(req any, err error) any {
 		*milvuspb.LoadPartitionsRequest, *milvuspb.ReleasePartitionsRequest,
 		*milvuspb.CreateIndexRequest, *milvuspb.DropIndexRequest,
 		*milvuspb.CreateDatabaseRequest, *milvuspb.DropDatabaseRequest,
-		*milvuspb.AlterDatabaseRequest:
+		*milvuspb.AlterDatabaseRequest,
+		*milvuspb.AddFileResourceRequest, *milvuspb.RemoveFileResourceRequest:
 		return merr.Status(err)
+	case *milvuspb.ListFileResourcesRequest:
+		return &milvuspb.ListFileResourcesResponse{
+			Status: merr.Status(err),
+		}
 	case *milvuspb.RestoreExternalSnapshotRequest:
 		return &milvuspb.RestoreExternalSnapshotResponse{
 			Status: merr.Status(err),

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -3119,9 +3119,6 @@ func (c *Core) RemoveFileResource(ctx context.Context, req *milvuspb.RemoveFileR
 	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}
-	if req.GetName() == "" {
-		return merr.Status(merr.WrapErrParameterMissing("file resource name")), nil
-	}
 	err, exist := c.meta.RemoveFileResource(ctx, req.GetName())
 	if err != nil {
 		return merr.Status(err), nil

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -3070,6 +3070,9 @@ func (c *Core) AddFileResource(ctx context.Context, req *milvuspb.AddFileResourc
 	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}
+	if req.GetName() == "" {
+		return merr.Status(merr.WrapErrParameterMissing("file resource name")), nil
+	}
 
 	if exist, err := c.storage.Exist(ctx, req.GetPath()); err != nil {
 		return merr.Status(err), nil
@@ -3115,6 +3118,9 @@ func (c *Core) RemoveFileResource(ctx context.Context, req *milvuspb.RemoveFileR
 
 	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
 		return merr.Status(err), nil
+	}
+	if req.GetName() == "" {
+		return merr.Status(merr.WrapErrParameterMissing("file resource name")), nil
 	}
 	err, exist := c.meta.RemoveFileResource(ctx, req.GetName())
 	if err != nil {

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -2007,11 +2007,18 @@ func TestRootCoord_RemoveFileResource(t *testing.T) {
 		assert.Equal(t, commonpb.ErrorCode_NotReadyServe, resp.GetErrorCode())
 	})
 
-	t.Run("empty name", func(t *testing.T) {
-		c := newTestCore(withHealthyCode())
+	t.Run("remove legacy empty name", func(t *testing.T) {
+		meta := mockrootcoord.NewIMetaTable(t)
+		meta.EXPECT().RemoveFileResource(mock.Anything, "").Return(nil, true)
+
+		observer := NewMockFileResourceObserver(t)
+		observer.EXPECT().Sync().Return(nil)
+
+		c := newTestCore(withHealthyCode(), withMeta(meta))
+		c.SetFileResourceObserver(observer)
 		resp, err := c.RemoveFileResource(context.Background(), &milvuspb.RemoveFileResourceRequest{})
 		assert.NoError(t, err)
-		assert.ErrorIs(t, merr.Error(resp), merr.ErrParameterMissing)
+		assert.Equal(t, commonpb.ErrorCode_Success, resp.GetErrorCode())
 	})
 
 	t.Run("meta remove file resource error", func(t *testing.T) {

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -1892,6 +1892,15 @@ func TestRootCoord_AddFileResource(t *testing.T) {
 		assert.Equal(t, commonpb.ErrorCode_NotReadyServe, resp.GetErrorCode())
 	})
 
+	t.Run("empty name", func(t *testing.T) {
+		c := newTestCore(withHealthyCode())
+		resp, err := c.AddFileResource(context.Background(), &milvuspb.AddFileResourceRequest{
+			Path: "/path/to/file",
+		})
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp), merr.ErrParameterMissing)
+	})
+
 	t.Run("storage check error", func(t *testing.T) {
 		storageMock := mock_storage.NewMockChunkManager(t)
 		storageMock.EXPECT().Exist(mock.Anything, mock.Anything).Return(false, errors.New("storage error"))
@@ -1996,6 +2005,13 @@ func TestRootCoord_RemoveFileResource(t *testing.T) {
 		resp, err := c.RemoveFileResource(ctx, &milvuspb.RemoveFileResourceRequest{})
 		assert.NoError(t, err)
 		assert.Equal(t, commonpb.ErrorCode_NotReadyServe, resp.GetErrorCode())
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		c := newTestCore(withHealthyCode())
+		resp, err := c.RemoveFileResource(context.Background(), &milvuspb.RemoveFileResourceRequest{})
+		assert.NoError(t, err)
+		assert.ErrorIs(t, merr.Error(resp), merr.ErrParameterMissing)
 	})
 
 	t.Run("meta remove file resource error", func(t *testing.T) {

--- a/tests/go_client/testcases/advcases/file_resource_rbac_test.go
+++ b/tests/go_client/testcases/advcases/file_resource_rbac_test.go
@@ -1,0 +1,81 @@
+//go:build rbac
+
+package advcases
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+func TestFileResourceRBAC(t *testing.T) {
+	ctx := hp.CreateContext(t, 2*time.Minute)
+	rootClient := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{
+		Address:  hp.GetAddr(),
+		Username: hp.GetUser(),
+		Password: hp.GetPassword(),
+	})
+
+	userName := common.GenRandomString("file_resource_user", 6)
+	roleName := common.GenRandomString("file_resource_role", 6)
+	password := common.GenRandomString("pwd", 8)
+	require.NoError(t, rootClient.CreateUser(ctx, client.NewCreateUserOption(userName, password)))
+	require.NoError(t, rootClient.CreateRole(ctx, client.NewCreateRoleOption(roleName)))
+	require.NoError(t, rootClient.GrantRole(ctx, client.NewGrantRoleOption(userName, roleName)))
+
+	grantedPrivileges := make([]string, 0, 3)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		for _, privilege := range grantedPrivileges {
+			_ = rootClient.RevokePrivilegeV2(cleanupCtx,
+				client.NewRevokePrivilegeV2Option(roleName, privilege, AllObjectName).WithDbName(AllObjectName))
+		}
+		_ = rootClient.RevokeRole(cleanupCtx, client.NewRevokeRoleOption(userName, roleName))
+		_ = rootClient.DropUser(cleanupCtx, client.NewDropUserOption(userName))
+		_ = rootClient.DropRole(cleanupCtx, client.NewDropRoleOption(roleName))
+	})
+
+	userClient := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{
+		Address:  hp.GetAddr(),
+		Username: userName,
+		Password: password,
+	})
+	resourceName := common.GenRandomString("file_resource_rbac", 6)
+	missingPath := "file-resource-rbac/not-exist.txt"
+
+	// The three cluster privileges are independent. Without explicit grants,
+	// authorization must reject each operation before its business validation.
+	err := userClient.AddFileResource(ctx, client.NewAddFileResourceOption(resourceName, missingPath))
+	require.ErrorContains(t, err, "permission deny")
+	err = userClient.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(resourceName))
+	require.ErrorContains(t, err, "permission deny")
+	_, err = userClient.ListFileResources(ctx, client.NewListFileResourcesOption())
+	require.ErrorContains(t, err, "permission deny")
+
+	for _, privilege := range []string{"ListFileResources", "AddFileResource", "RemoveFileResource"} {
+		require.NoError(t, rootClient.GrantPrivilegeV2(ctx,
+			client.NewGrantPrivilegeV2Option(roleName, privilege, AllObjectName).WithDbName(AllObjectName)))
+		grantedPrivileges = append(grantedPrivileges, privilege)
+	}
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, listErr := userClient.ListFileResources(ctx, client.NewListFileResourcesOption())
+		require.NoError(collect, listErr)
+
+		// Reaching path validation proves AddFileResource authorization passed.
+		addErr := userClient.AddFileResource(ctx, client.NewAddFileResourceOption(resourceName, missingPath))
+		require.ErrorContains(collect, addErr, "path not exist")
+
+		// Removing a missing name is idempotent once RemoveFileResource is granted.
+		require.NoError(collect,
+			userClient.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(resourceName)))
+	}, 20*time.Second, time.Second)
+}

--- a/tests/go_client/testcases/advcases/file_resource_rbac_test.go
+++ b/tests/go_client/testcases/advcases/file_resource_rbac_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	client "github.com/milvus-io/milvus/client/v3/milvusclient"
 	"github.com/milvus-io/milvus/tests/go_client/common"
 	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
 )

--- a/tests/go_client/testcases/file_resource_test.go
+++ b/tests/go_client/testcases/file_resource_test.go
@@ -10,10 +10,9 @@ import (
 	miniogo "github.com/minio/minio-go/v7"
 	"github.com/stretchr/testify/require"
 
-	"github.com/milvus-io/milvus/client/v2/entity"
-	"github.com/milvus-io/milvus/client/v2/index"
-	client "github.com/milvus-io/milvus/client/v2/milvusclient"
-	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/client/v3/entity"
+	"github.com/milvus-io/milvus/client/v3/index"
+	client "github.com/milvus-io/milvus/client/v3/milvusclient"
 	"github.com/milvus-io/milvus/tests/go_client/base"
 	"github.com/milvus-io/milvus/tests/go_client/common"
 	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
@@ -140,12 +139,17 @@ func TestFileResourceCRUDAndValidation(t *testing.T) {
 func TestFileResourceEmptyNameRejected(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := createFileResourceMilvusClient(ctx, t)
+	assertMissingParameter := func(err error) {
+		require.Error(t, err)
+		require.Equal(t, int32(1101), client.ErrorCode(err))
+		require.ErrorContains(t, err, "missing parameter")
+	}
 
 	err := mc.AddFileResource(ctx, client.NewAddFileResourceOption("", "unused.txt"))
-	require.ErrorIs(t, err, merr.ErrParameterMissing)
+	assertMissingParameter(err)
 
 	err = mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(""))
-	require.ErrorIs(t, err, merr.ErrParameterMissing)
+	assertMissingParameter(err)
 }
 
 func TestFileResourceRemoteAnalyzerAndCollectionLifecycle(t *testing.T) {

--- a/tests/go_client/testcases/file_resource_test.go
+++ b/tests/go_client/testcases/file_resource_test.go
@@ -136,20 +136,18 @@ func TestFileResourceCRUDAndValidation(t *testing.T) {
 	require.NoError(t, mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(name)))
 }
 
-func TestFileResourceEmptyNameRejected(t *testing.T) {
+func TestFileResourceEmptyNameCompatibility(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := createFileResourceMilvusClient(ctx, t)
-	assertMissingParameter := func(err error) {
-		require.Error(t, err)
-		require.Equal(t, int32(1101), client.ErrorCode(err))
-		require.ErrorContains(t, err, "missing parameter")
-	}
 
 	err := mc.AddFileResource(ctx, client.NewAddFileResourceOption("", "unused.txt"))
-	assertMissingParameter(err)
+	require.Error(t, err)
+	require.Equal(t, int32(1101), client.ErrorCode(err))
+	require.ErrorContains(t, err, "missing parameter")
 
-	err = mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(""))
-	assertMissingParameter(err)
+	// Empty names were accepted by older releases. Keep removal available so
+	// an upgraded cluster can clean up a legacy empty-name resource.
+	require.NoError(t, mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption("")))
 }
 
 func TestFileResourceRemoteAnalyzerAndCollectionLifecycle(t *testing.T) {

--- a/tests/go_client/testcases/file_resource_test.go
+++ b/tests/go_client/testcases/file_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/milvus-io/milvus/client/v2/entity"
 	"github.com/milvus-io/milvus/client/v2/index"
 	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/tests/go_client/base"
 	"github.com/milvus-io/milvus/tests/go_client/common"
 	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
@@ -136,29 +137,15 @@ func TestFileResourceCRUDAndValidation(t *testing.T) {
 	require.NoError(t, mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(name)))
 }
 
-func TestFileResourceEmptyNameCompatibility(t *testing.T) {
+func TestFileResourceEmptyNameRejected(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := createFileResourceMilvusClient(ctx, t)
-	_, path := setupFileResourceObject(t, ctx, "synonyms.txt", "search, retrieval, query\n")
 
-	// FileResource names currently have no server-side length or character
-	// validation. Lock down the existing empty-name behavior for SDK parity.
-	require.NoError(t, mc.AddFileResource(ctx, client.NewAddFileResourceOption("", path)))
-	t.Cleanup(func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		_ = removeFileResourceEventually(cleanupCtx, mc, "")
-	})
+	err := mc.AddFileResource(ctx, client.NewAddFileResourceOption("", "unused.txt"))
+	require.ErrorIs(t, err, merr.ErrParameterMissing)
 
-	resources, err := mc.ListFileResources(ctx, client.NewListFileResourcesOption())
-	require.NoError(t, err)
-	for _, resource := range resources {
-		if resource.Name == "" {
-			require.Equal(t, path, resource.Path)
-			return
-		}
-	}
-	t.Fatal("empty-name resource must round-trip through ListFileResources")
+	err = mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(""))
+	require.ErrorIs(t, err, merr.ErrParameterMissing)
 }
 
 func TestFileResourceRemoteAnalyzerAndCollectionLifecycle(t *testing.T) {

--- a/tests/go_client/testcases/file_resource_test.go
+++ b/tests/go_client/testcases/file_resource_test.go
@@ -1,0 +1,251 @@
+package testcases
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	miniogo "github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v2/entity"
+	"github.com/milvus-io/milvus/client/v2/index"
+	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/base"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+func setupFileResourceObject(t *testing.T, ctx context.Context, fileName, content string) (minioConfig, string) {
+	t.Helper()
+
+	cfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(cfg)
+	require.NoError(t, err)
+
+	exists, err := minioClient.BucketExists(ctx, cfg.bucket)
+	require.NoError(t, err)
+	require.True(t, exists, "MinIO bucket %q must exist", cfg.bucket)
+
+	prefix := fmt.Sprintf("file-resource-e2e/%s", common.GenRandomString("go", 8))
+	path := fmt.Sprintf("%s/%s", prefix, fileName)
+	data := []byte(content)
+	_, err = minioClient.PutObject(ctx, cfg.bucket, path, bytes.NewReader(data), int64(len(data)), miniogo.PutObjectOptions{
+		ContentType: "text/plain; charset=utf-8",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		cleanupMinIOPrefix(cleanupCtx, minioClient, cfg.bucket, prefix+"/")
+	})
+	return cfg, path
+}
+
+func removeFileResourceEventually(ctx context.Context, mc *base.MilvusClient, name string) error {
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		err := mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(name))
+		if err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return err
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func remoteSynonymSchema(collectionName, resourceName string) *entity.Schema {
+	analyzerParams := map[string]any{
+		"tokenizer": "standard",
+		"filter": []any{
+			map[string]any{
+				"type":   "synonym",
+				"expand": true,
+				"synonyms_file": map[string]any{
+					"type":          "remote",
+					"resource_name": resourceName,
+					"file_name":     "synonyms.txt",
+				},
+			},
+		},
+	}
+
+	return entity.NewSchema().
+		WithName(collectionName).
+		WithAutoID(true).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).
+			WithIsPrimaryKey(true).WithIsAutoID(true)).
+		WithField(entity.NewField().WithName("text").WithDataType(entity.FieldTypeVarChar).
+			WithMaxLength(1024).WithEnableAnalyzer(true).WithAnalyzerParams(analyzerParams)).
+		WithField(entity.NewField().WithName("sparse_vector").WithDataType(entity.FieldTypeSparseVector)).
+		WithFunction(entity.NewFunction().WithName("bm25").WithType(entity.FunctionTypeBM25).
+			WithInputFields("text").WithOutputFields("sparse_vector"))
+}
+
+func createFileResourceMilvusClient(ctx context.Context, t *testing.T) *base.MilvusClient {
+	t.Helper()
+	return hp.CreateMilvusClient(ctx, t, &client.ClientConfig{
+		Address:  hp.GetAddr(),
+		Username: hp.GetUser(),
+		Password: hp.GetPassword(),
+	})
+}
+
+func TestFileResourceCRUDAndValidation(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := createFileResourceMilvusClient(ctx, t)
+	_, path := setupFileResourceObject(t, ctx, "synonyms.txt", "search, retrieval, query\n")
+	_, otherPath := setupFileResourceObject(t, ctx, "synonyms.txt", "milvus, vector-database\n")
+	name := common.GenRandomString("go_file_resource", 8)
+
+	require.NoError(t, mc.AddFileResource(ctx, client.NewAddFileResourceOption(name, path)))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = removeFileResourceEventually(cleanupCtx, mc, name)
+	})
+
+	resources, err := mc.ListFileResources(ctx, client.NewListFileResourcesOption())
+	require.NoError(t, err)
+	var found bool
+	for _, resource := range resources {
+		if resource.Name == name {
+			found = true
+			require.Positive(t, resource.ID)
+			require.Equal(t, path, resource.Path)
+		}
+	}
+	require.True(t, found, "registered resource %q must be returned by list", name)
+
+	// Identical add and repeated remove are idempotent.
+	require.NoError(t, mc.AddFileResource(ctx, client.NewAddFileResourceOption(name, path)))
+	err = mc.AddFileResource(ctx, client.NewAddFileResourceOption(name, otherPath))
+	require.ErrorContains(t, err, "already exists")
+
+	err = mc.AddFileResource(ctx, client.NewAddFileResourceOption(common.GenRandomString("missing", 8), path+".missing"))
+	require.ErrorContains(t, err, "path not exist")
+	err = mc.AddFileResource(ctx, client.NewAddFileResourceOption(common.GenRandomString("empty_path", 8), ""))
+	require.Error(t, err)
+
+	require.NoError(t, mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(name)))
+	require.NoError(t, mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(name)))
+}
+
+func TestFileResourceEmptyNameCompatibility(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := createFileResourceMilvusClient(ctx, t)
+	_, path := setupFileResourceObject(t, ctx, "synonyms.txt", "search, retrieval, query\n")
+
+	// FileResource names currently have no server-side length or character
+	// validation. Lock down the existing empty-name behavior for SDK parity.
+	require.NoError(t, mc.AddFileResource(ctx, client.NewAddFileResourceOption("", path)))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = removeFileResourceEventually(cleanupCtx, mc, "")
+	})
+
+	resources, err := mc.ListFileResources(ctx, client.NewListFileResourcesOption())
+	require.NoError(t, err)
+	for _, resource := range resources {
+		if resource.Name == "" {
+			require.Equal(t, path, resource.Path)
+			return
+		}
+	}
+	t.Fatal("empty-name resource must round-trip through ListFileResources")
+}
+
+func TestFileResourceRemoteAnalyzerAndCollectionLifecycle(t *testing.T) {
+	ctx := hp.CreateContext(t, 2*time.Minute)
+	mc := createFileResourceMilvusClient(ctx, t)
+	_, path := setupFileResourceObject(t, ctx, "synonyms.txt", "search, retrieval, query\n")
+	resourceName := common.GenRandomString("go_remote_analyzer", 8)
+	collectionName := common.GenRandomString("go_remote_analyzer", 8)
+
+	require.NoError(t, mc.AddFileResource(ctx, client.NewAddFileResourceOption(resourceName, path)))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = removeFileResourceEventually(cleanupCtx, mc, resourceName)
+	})
+
+	require.NoError(t, mc.CreateCollection(ctx, client.NewCreateCollectionOption(collectionName,
+		remoteSynonymSchema(collectionName, resourceName))))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collectionName))
+	})
+
+	indexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collectionName, "sparse_vector",
+		index.NewSparseInvertedIndex(entity.BM25, 0.1)))
+	require.NoError(t, err)
+	require.NoError(t, indexTask.Await(ctx))
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collectionName))
+	require.NoError(t, err)
+	require.NoError(t, loadTask.Await(ctx))
+
+	results, err := mc.RunAnalyzer(ctx, client.NewRunAnalyzerOption("search").WithField(collectionName, "text"))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	actualTokens := make([]string, 0, len(results[0].Tokens))
+	for _, token := range results[0].Tokens {
+		actualTokens = append(actualTokens, token.Text)
+	}
+	require.ElementsMatch(t, []string{"search", "retrieval", "query"}, actualTokens)
+
+	err = mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(resourceName))
+	require.ErrorContains(t, err, "is still in use")
+
+	require.NoError(t, mc.DropCollection(ctx, client.NewDropCollectionOption(collectionName)))
+	require.NoError(t, removeFileResourceEventually(ctx, mc, resourceName))
+}
+
+func TestFileResourceReferenceReleasedAcrossDatabaseLifecycle(t *testing.T) {
+	ctx := hp.CreateContext(t, 2*time.Minute)
+	mc := createFileResourceMilvusClient(ctx, t)
+	_, path := setupFileResourceObject(t, ctx, "synonyms.txt", "search, retrieval, query\n")
+	resourceName := common.GenRandomString("go_file_resource_db", 8)
+	databaseName := common.GenRandomString("go_file_resource_db", 8)
+	collectionName := common.GenRandomString("go_file_resource_db", 8)
+
+	require.NoError(t, mc.AddFileResource(ctx, client.NewAddFileResourceOption(resourceName, path)))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = removeFileResourceEventually(cleanupCtx, mc, resourceName)
+	})
+
+	require.NoError(t, mc.CreateDatabase(ctx, client.NewCreateDatabaseOption(databaseName)))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = mc.UseDatabase(cleanupCtx, client.NewUseDatabaseOption(common.DefaultDb))
+		_ = mc.DropDatabase(cleanupCtx, client.NewDropDatabaseOption(databaseName))
+	})
+	require.NoError(t, mc.UseDatabase(ctx, client.NewUseDatabaseOption(databaseName)))
+
+	require.NoError(t, mc.CreateCollection(ctx, client.NewCreateCollectionOption(collectionName,
+		remoteSynonymSchema(collectionName, resourceName))))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = mc.UseDatabase(cleanupCtx, client.NewUseDatabaseOption(databaseName))
+		_ = mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collectionName))
+		_ = mc.UseDatabase(cleanupCtx, client.NewUseDatabaseOption(common.DefaultDb))
+	})
+
+	err := mc.RemoveFileResource(ctx, client.NewRemoveFileResourceOption(resourceName))
+	require.ErrorContains(t, err, "is still in use")
+
+	require.NoError(t, mc.DropCollection(ctx, client.NewDropCollectionOption(collectionName)))
+	require.NoError(t, mc.UseDatabase(ctx, client.NewUseDatabaseOption(common.DefaultDb)))
+	require.NoError(t, mc.DropDatabase(ctx, client.NewDropDatabaseOption(databaseName)))
+	require.NoError(t, removeFileResourceEventually(ctx, mc, resourceName))
+}

--- a/tests/python_client/milvus_client/test_milvus_client_file_resource.py
+++ b/tests/python_client/milvus_client/test_milvus_client_file_resource.py
@@ -303,11 +303,18 @@ class TestMilvusClientFileResourceAdd(FileResourceTestBase):
         """
         target: add with empty name
         method: add_file_resource(name="", ...)
-        expected: server may accept empty name (no validation); cleanup after
+        expected: reject the request because name is required
         """
         client = self._client()
         # 1. add file resource with empty name
-        self.add_file_resource(client, "", JIEBA_DICT_PATH)
+        error = {ct.err_code: 1101, ct.err_msg: "missing parameter"}
+        self.add_file_resource(
+            client,
+            "",
+            JIEBA_DICT_PATH,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_add_file_resource_empty_path(self, file_resource_env):

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1096,6 +1096,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             schema=schema,
             index_params=index_params,
             consistency_level="Strong",
+            properties={"collection.autocompaction.enabled": "false"},
         )
 
         def profile(row_id, length, tag_prefix="keep"):

--- a/tests/restful_client_v2/api/milvus.py
+++ b/tests/restful_client_v2/api/milvus.py
@@ -766,6 +766,16 @@ class RoleClient(Requests):
         res = response.json()
         return res
 
+    def role_grant_v2(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/roles/grant_privilege_v2"
+        response = self.post(url, headers=self.update_headers(), data=payload)
+        return response.json()
+
+    def role_revoke_v2(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/roles/revoke_privilege_v2"
+        response = self.post(url, headers=self.update_headers(), data=payload)
+        return response.json()
+
 
 class IndexClient(Requests):
     def __init__(self, endpoint, token):
@@ -1036,6 +1046,25 @@ class DatabaseClient(Requests):
         payload = {"dbName": db_name, "propertyKeys": property_keys}
         response = self.post(url, headers=self.update_headers(), data=payload)
         return response.json()
+
+
+class FileResourceClient(Requests):
+    def __init__(self, endpoint, token):
+        super().__init__(url=endpoint, api_key=token)
+        self.endpoint = endpoint
+        self.api_key = token
+
+    def file_resource_add(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/file_resources/add"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def file_resource_remove(self, payload):
+        url = f"{self.endpoint}/v2/vectordb/file_resources/remove"
+        return self.post(url, headers=self.update_headers(), data=payload).json()
+
+    def file_resource_list(self):
+        url = f"{self.endpoint}/v2/vectordb/file_resources/list"
+        return self.post(url, headers=self.update_headers(), data={}).json()
 
 
 class StorageClient:

--- a/tests/restful_client_v2/base/testbase.py
+++ b/tests/restful_client_v2/base/testbase.py
@@ -8,6 +8,7 @@ from api.milvus import (
     AliasClient,
     CollectionClient,
     DatabaseClient,
+    FileResourceClient,
     ImportJobClient,
     IndexClient,
     PartitionClient,
@@ -47,6 +48,7 @@ class Base:
     storage_client = None
     milvus_client = None
     database_client = None
+    file_resource_client = None
 
 
 class TestBase(Base):
@@ -106,6 +108,7 @@ class TestBase(Base):
         self.import_job_client = ImportJobClient(self.endpoint, self.api_key)
         self.storage_client = StorageClient(f"{minio_host}:9000", "minioadmin", "minioadmin", bucket_name, root_path)
         self.database_client = DatabaseClient(self.endpoint, self.api_key)
+        self.file_resource_client = FileResourceClient(self.endpoint, self.api_key)
 
         if token is None:
             self.vector_client.api_key = None

--- a/tests/restful_client_v2/testcases/test_file_resource_operations.py
+++ b/tests/restful_client_v2/testcases/test_file_resource_operations.py
@@ -165,7 +165,7 @@ class TestFileResourceOperations(TestBase):
         matches = [resource for resource in rsp["data"] if resource["name"] == resource_name]
         assert len(matches) == 1, rsp
         assert matches[0]["path"] == path
-        assert isinstance(matches[0]["id"], int)
+        assert isinstance(matches[0]["id"], str)
 
         rsp = self._add_file_resource(resource_name, path)
         assert rsp["code"] == 0, rsp

--- a/tests/restful_client_v2/testcases/test_file_resource_operations.py
+++ b/tests/restful_client_v2/testcases/test_file_resource_operations.py
@@ -1,0 +1,352 @@
+import io
+import time
+
+import pytest
+from api.milvus import FileResourceClient
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name, gen_unique_str
+
+
+class TestFileResourceOperations(TestBase):
+    """End-to-end FileResource coverage using only REST v2 Milvus APIs."""
+
+    def setup_method(self):
+        self._file_resources_to_cleanup = []
+        self._minio_objects_to_cleanup = []
+
+    def teardown_method(self):
+        try:
+            super().teardown_method()
+        finally:
+            self.file_resource_client.api_key = self.api_key
+            self._cleanup_file_resources()
+            self._cleanup_minio_objects()
+
+    def _upload_file(self, content, file_name="synonyms.txt"):
+        resource_name = gen_unique_str("rest_file_resource")
+        path = f"file-resource-rest/{resource_name}/{file_name}"
+        self.storage_client.client.put_object(
+            self.storage_client.bucket_name,
+            path,
+            io.BytesIO(content),
+            len(content),
+            content_type="text/plain; charset=utf-8",
+        )
+        self._minio_objects_to_cleanup.append(path)
+        return resource_name, path
+
+    def _add_file_resource(self, resource_name, path):
+        rsp = self.file_resource_client.file_resource_add({"name": resource_name, "path": path})
+        if rsp["code"] == 0 and resource_name not in self._file_resources_to_cleanup:
+            self._file_resources_to_cleanup.append(resource_name)
+        return rsp
+
+    def _upload_and_register_synonyms(self):
+        resource_name, path = self._upload_file(b"search, retrieval, query\n")
+        rsp = self._add_file_resource(resource_name, path)
+        assert rsp["code"] == 0, rsp
+        return resource_name
+
+    def _remove_file_resource(self, resource_name):
+        rsp = self.file_resource_client.file_resource_remove({"name": resource_name})
+        if rsp["code"] == 0 and resource_name in self._file_resources_to_cleanup:
+            self._file_resources_to_cleanup.remove(resource_name)
+        return rsp
+
+    def _remove_file_resource_eventually(self, resource_name, timeout=30):
+        deadline = time.time() + timeout
+        last_rsp = None
+        while time.time() < deadline:
+            last_rsp = self._remove_file_resource(resource_name)
+            if last_rsp["code"] == 0:
+                return last_rsp
+            if "is still in use" not in last_rsp.get("message", ""):
+                raise AssertionError(last_rsp)
+            time.sleep(0.5)
+        raise AssertionError(f"file resource {resource_name!r} was not released: {last_rsp}")
+
+    def _cleanup_file_resources(self):
+        for resource_name in list(self._file_resources_to_cleanup):
+            try:
+                self._remove_file_resource_eventually(resource_name)
+            except Exception:
+                pass
+
+    def _cleanup_minio_objects(self):
+        for path in self._minio_objects_to_cleanup:
+            try:
+                self.storage_client.client.remove_object(self.storage_client.bucket_name, path)
+            except Exception:
+                pass
+
+    @staticmethod
+    def _wait_for_code(call, expected_code, timeout=20):
+        deadline = time.time() + timeout
+        last_rsp = None
+        while time.time() < deadline:
+            last_rsp = call()
+            if last_rsp.get("code") == expected_code:
+                return last_rsp
+            time.sleep(1)
+        raise AssertionError(f"expected code {expected_code}, last response: {last_rsp}")
+
+    @staticmethod
+    def _remote_analyzer_collection_payload(collection_name, resource_name, db_name=None):
+        payload = {
+            "collectionName": collection_name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {
+                        "fieldName": "id",
+                        "dataType": "Int64",
+                        "isPrimary": True,
+                        "elementTypeParams": {},
+                    },
+                    {
+                        "fieldName": "text",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {
+                            "max_length": "1024",
+                            "enable_analyzer": True,
+                            "analyzer_params": {
+                                "tokenizer": "standard",
+                                "filter": [
+                                    {
+                                        "type": "synonym",
+                                        "expand": True,
+                                        "synonyms_file": {
+                                            "type": "remote",
+                                            "resource_name": resource_name,
+                                            "file_name": "synonyms.txt",
+                                        },
+                                    }
+                                ],
+                            },
+                        },
+                    },
+                    {"fieldName": "sparse_vector", "dataType": "SparseFloatVector"},
+                ],
+                "functions": [
+                    {
+                        "name": "bm25",
+                        "type": "BM25",
+                        "inputFieldNames": ["text"],
+                        "outputFieldNames": ["sparse_vector"],
+                        "params": {},
+                    }
+                ],
+            },
+            "indexParams": [
+                {
+                    "fieldName": "sparse_vector",
+                    "indexName": "sparse_vector",
+                    "metricType": "BM25",
+                    "params": {"index_type": "SPARSE_INVERTED_INDEX"},
+                }
+            ],
+        }
+        if db_name is not None:
+            payload["dbName"] = db_name
+        return payload
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_file_resource_crud_idempotency_and_conflict(self):
+        resource_name, path = self._upload_file(b"search, retrieval, query\n")
+        _, other_path = self._upload_file(b"database, db\n")
+
+        rsp = self._add_file_resource(resource_name, path)
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.file_resource_client.file_resource_list()
+        assert rsp["code"] == 0, rsp
+        matches = [resource for resource in rsp["data"] if resource["name"] == resource_name]
+        assert len(matches) == 1, rsp
+        assert matches[0]["path"] == path
+        assert isinstance(matches[0]["id"], int)
+
+        rsp = self._add_file_resource(resource_name, path)
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.file_resource_client.file_resource_add({"name": resource_name, "path": other_path})
+        assert rsp["code"] == 1100, rsp
+        assert "already exists" in rsp["message"], rsp
+
+        rsp = self._remove_file_resource(resource_name)
+        assert rsp["code"] == 0, rsp
+        rsp = self._remove_file_resource(resource_name)
+        assert rsp["code"] == 0, rsp
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_file_resource_input_validation_and_missing_path(self):
+        rsp = self.file_resource_client.file_resource_add({"name": "", "path": "path.txt"})
+        assert rsp["code"] == 1802, rsp
+
+        rsp = self.file_resource_client.file_resource_add({"name": gen_unique_str("resource"), "path": ""})
+        assert rsp["code"] == 1802, rsp
+
+        rsp = self.file_resource_client.file_resource_remove({"name": ""})
+        assert rsp["code"] == 1802, rsp
+
+        rsp = self.file_resource_client.file_resource_add(
+            {"name": gen_unique_str("resource"), "path": f"missing/{gen_unique_str('object')}.txt"}
+        )
+        assert rsp["code"] == 1100, rsp
+        assert "path not exist" in rsp["message"], rsp
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_remote_synonym_search_and_reference_lifecycle(self):
+        resource_name = self._upload_and_register_synonyms()
+        collection_name = gen_collection_name("rest_remote_analyzer")
+        payload = self._remote_analyzer_collection_payload(collection_name, resource_name)
+
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+        self.wait_collection_load_completed(collection_name)
+
+        rsp = self.vector_client.vector_insert(
+            {
+                "collectionName": collection_name,
+                "data": [
+                    {"id": 1, "text": "search engine"},
+                    {"id": 2, "text": "distributed database"},
+                ],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": collection_name,
+                "data": ["retrieval"],
+                "annsField": "sparse_vector",
+                "outputFields": ["id", "text"],
+                "limit": 10,
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert any(hit["id"] == 1 and "search engine" in hit["text"] for hit in rsp["data"]), rsp
+
+        rsp = self._remove_file_resource(resource_name)
+        assert rsp["code"] == 1100, rsp
+        assert "is still in use" in rsp["message"], rsp
+
+        rsp = self.collection_client.collection_drop({"collectionName": collection_name})
+        assert rsp["code"] == 0, rsp
+        self._remove_file_resource_eventually(resource_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_file_resource_released_after_collection_and_database_drop(self):
+        resource_name = self._upload_and_register_synonyms()
+        db_name = gen_unique_str("rest_file_resource_db")
+        collection_name = gen_collection_name("rest_remote_analyzer_db")
+
+        rsp = self.database_client.database_create({"dbName": db_name})
+        assert rsp["code"] == 0, rsp
+        payload = self._remote_analyzer_collection_payload(collection_name, resource_name, db_name=db_name)
+        rsp = self.collection_client.collection_create(payload, db_name=db_name)
+        assert rsp["code"] == 0, rsp
+
+        rsp = self._remove_file_resource(resource_name)
+        assert rsp["code"] == 1100, rsp
+        assert "is still in use" in rsp["message"], rsp
+
+        rsp = self.collection_client.collection_drop({"dbName": db_name, "collectionName": collection_name})
+        assert rsp["code"] == 0, rsp
+        rsp = self.database_client.database_drop({"dbName": db_name})
+        assert rsp["code"] == 0, rsp
+        self._remove_file_resource_eventually(resource_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_missing_remote_resource_returns_stable_error(self):
+        collection_name = gen_collection_name("rest_missing_remote_analyzer")
+        payload = self._remote_analyzer_collection_payload(collection_name, gen_unique_str("missing_resource"))
+
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 1100, rsp
+        assert "not found in local resource list" in rsp["message"], rsp
+
+    @pytest.mark.tags(CaseLabel.RBAC)
+    def test_file_resource_management_requires_authentication(self):
+        unauthenticated_client = FileResourceClient(self.endpoint, self.invalid_api_key)
+        resource_name = gen_unique_str("unauthenticated_resource")
+
+        rsp = unauthenticated_client.file_resource_add({"name": resource_name, "path": "missing.txt"})
+        assert rsp["code"] == 1800, rsp
+        rsp = unauthenticated_client.file_resource_list()
+        assert rsp["code"] == 1800, rsp
+        rsp = unauthenticated_client.file_resource_remove({"name": resource_name})
+        assert rsp["code"] == 1800, rsp
+
+    @pytest.mark.tags(CaseLabel.RBAC)
+    def test_file_resource_management_privileges(self):
+        resource_name, path = self._upload_file(b"search, retrieval, query\n")
+        user_name = gen_unique_str("rest_file_resource_user")
+        role_name = gen_unique_str("rest_file_resource_role")
+        password = "FileResource123!"
+        privileges = ["ListFileResources", "AddFileResource", "RemoveFileResource"]
+        user_created = False
+        role_created = False
+        role_bound = False
+        granted = []
+        try:
+            rsp = self.user_client.user_create({"userName": user_name, "password": password})
+            assert rsp["code"] == 0, rsp
+            user_created = True
+            rsp = self.role_client.role_create({"roleName": role_name})
+            assert rsp["code"] == 0, rsp
+            role_created = True
+            rsp = self.user_client.user_grant({"userName": user_name, "roleName": role_name})
+            assert rsp["code"] == 0, rsp
+            role_bound = True
+
+            limited_client = FileResourceClient(self.endpoint, f"{user_name}:{password}")
+
+            def add_as_limited_user():
+                add_rsp = limited_client.file_resource_add({"name": resource_name, "path": path})
+                if add_rsp.get("code") == 0 and resource_name not in self._file_resources_to_cleanup:
+                    self._file_resources_to_cleanup.append(resource_name)
+                return add_rsp
+
+            rsp = self._wait_for_code(add_as_limited_user, 65535)
+            assert "PrivilegeAddFileResource: permission deny" in rsp["message"], rsp
+            rsp = self._wait_for_code(limited_client.file_resource_list, 65535)
+            assert "PrivilegeListFileResources: permission deny" in rsp["message"], rsp
+            rsp = self._wait_for_code(lambda: limited_client.file_resource_remove({"name": resource_name}), 65535)
+            assert "PrivilegeRemoveFileResource: permission deny" in rsp["message"], rsp
+
+            for privilege in privileges:
+                payload = {
+                    "roleName": role_name,
+                    "dbName": "*",
+                    "collectionName": "*",
+                    "privilege": privilege,
+                }
+                rsp = self.role_client.role_grant_v2(payload)
+                assert rsp["code"] == 0, rsp
+                granted.append(privilege)
+
+            self._wait_for_code(limited_client.file_resource_list, 0)
+            rsp = self._wait_for_code(add_as_limited_user, 0)
+            assert rsp["code"] == 0, rsp
+            rsp = self._wait_for_code(lambda: limited_client.file_resource_remove({"name": resource_name}), 0)
+            assert rsp["code"] == 0, rsp
+            self._file_resources_to_cleanup.remove(resource_name)
+        finally:
+            for privilege in granted:
+                self.role_client.role_revoke_v2(
+                    {
+                        "roleName": role_name,
+                        "dbName": "*",
+                        "collectionName": "*",
+                        "privilege": privilege,
+                    }
+                )
+            if role_bound:
+                self.user_client.user_revoke({"userName": user_name, "roleName": role_name})
+            if user_created:
+                self.user_client.user_drop({"userName": user_name})
+            if role_created:
+                self.role_client.role_drop({"roleName": role_name})

--- a/tests/restful_client_v2/testcases/test_file_resource_operations.py
+++ b/tests/restful_client_v2/testcases/test_file_resource_operations.py
@@ -165,7 +165,7 @@ class TestFileResourceOperations(TestBase):
         matches = [resource for resource in rsp["data"] if resource["name"] == resource_name]
         assert len(matches) == 1, rsp
         assert matches[0]["path"] == path
-        assert isinstance(matches[0]["id"], str)
+        assert isinstance(matches[0]["id"], int)
 
         rsp = self._add_file_resource(resource_name, path)
         assert rsp["code"] == 0, rsp


### PR DESCRIPTION
issue: #51241
pr: #51339
pr: #51703

## Summary

Cherry-pick of master PR #51339 to the `3.0` branch.

- Add `AddFileResource`, `ListFileResources`, and `RemoveFileResource` to the Go SDK.
- Add REST v2 FileResource endpoints under `/v2/vectordb/file_resources`.
- Keep add/remove under the cluster-level collection DDL limiter while leaving the read-only list operation zero-cost.
- Reject empty FileResource names at the server boundary for consistent SDK and REST behavior.
- Include the Go SDK, REST handler, E2E, and RBAC coverage from the master PR.

## Branch notes

This is a clean cherry-pick of all three commits from #51339. No 3.0-specific conflict resolution or code changes were required. `git range-diff` and stable patch IDs match all three source commits.

## Validation

- 3.0 remote Go UT: `client/milvusclient` (`TestFileResource`)
- 3.0 remote Go UT: `internal/distributed/proxy/httpserver` (`TestFileResourceHandlerV2`)
- 3.0 remote Go UT: `internal/proxy` (`TestRateLimitInterceptor|TestGetInfo`)
- 3.0 remote Go UT: `internal/rootcoord` (`TestRootCoord_(Add|Remove)FileResource`)
- `go test -tags dynamic,test -gcflags='all=-N -l' -count=1 ./util/merr/...` from `pkg/`
- Ruff check and format check for the changed REST client files
- `git diff --check upstream/3.0...HEAD`
- Master PR CI: build/UT, default E2E, Go SDK, and Go SDK ARM checks passed
