### PR TITLE
fix: propagate TSO window load errors instead of resetting to ZeroTime

### DIFF
--- a/internal/tso/tso.go
+++ b/internal/tso/tso.go
@@ -41,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -78,8 +79,14 @@ type timestampOracle struct {
 func (t *timestampOracle) loadTimestamp() (time.Time, error) {
 	strData, err := t.txnKV.Load(context.TODO(), t.key)
 	if err != nil {
-		// intend to return nil
-		return typeutil.ZeroTime, nil
+		if errors.Is(err, merr.ErrIoKeyNotFound) {
+			// Fresh deployment: no persisted window yet.
+			return typeutil.ZeroTime, nil
+		}
+		// Any other failure must surface: swallowing it into ZeroTime lets
+		// InitTimestamp fall back to time.Now() below an already-persisted
+		// window and regress TSO/ID monotonicity.
+		return typeutil.ZeroTime, errors.WithStack(err)
 	}
 
 	binData := []byte(strData)
@@ -102,9 +109,20 @@ func (t *timestampOracle) saveTimestamp(ts time.Time) error {
 	return nil
 }
 
+// initLoadRetryAttempts bounds retries of the persisted-window read during
+// initialization: a transient backend hiccup at boot (etcd leader change,
+// TiKV region move) must not fail the coordinator outright, while a
+// persistent failure still surfaces loudly instead of regressing the window
+// to time.Now().
+const initLoadRetryAttempts = 5
+
 func (t *timestampOracle) InitTimestamp() error {
-	last, err := t.loadTimestamp()
-	if err != nil {
+	var last time.Time
+	if err := retry.Do(context.TODO(), func() error {
+		var err error
+		last, err = t.loadTimestamp()
+		return err
+	}, retry.Attempts(initLoadRetryAttempts), retry.Sleep(50*time.Millisecond)); err != nil {
 		return err
 	}
 	next := time.Now()

--- a/internal/tso/tso_test.go
+++ b/internal/tso/tso_test.go
@@ -1,0 +1,107 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tso
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v3/kv"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// stubTxnKV lets tests control Load/Save outcomes independently. All other
+// TxnKV methods panic via the nil embedded interface, which is fine: the
+// oracle only uses Load and Save.
+type stubTxnKV struct {
+	kv.TxnKV
+	loadErr  error
+	loadData string
+	saveErr  error
+	// The first transientLoadFailures Load calls fail with transientLoadErr,
+	// then Load falls through to loadErr/loadData — modeling a backend
+	// hiccup (etcd leader change, TiKV region move) during startup.
+	transientLoadFailures int
+	transientLoadErr      error
+}
+
+func (s *stubTxnKV) Load(ctx context.Context, key string) (string, error) {
+	if s.transientLoadFailures > 0 {
+		s.transientLoadFailures--
+		return "", s.transientLoadErr
+	}
+	if s.loadErr != nil {
+		return "", s.loadErr
+	}
+	return s.loadData, nil
+}
+
+func (s *stubTxnKV) Save(ctx context.Context, key, value string) error {
+	return s.saveErr
+}
+
+// A transient read failure (anything but key-not-found) must fail
+// InitTimestamp instead of being swallowed into ZeroTime: swallowing lets a
+// restarting coord fall back to time.Now() below an already-persisted
+// window, regressing TSO/ID monotonicity.
+func TestInitTimestampFailsOnLoadError(t *testing.T) {
+	oracle := &timestampOracle{
+		key:          "tso-test",
+		txnKV:        &stubTxnKV{loadErr: errors.New("io broken")},
+		saveInterval: 3 * time.Second,
+	}
+
+	err := oracle.InitTimestamp()
+	require.Error(t, err, "a failed window read must not silently reset TSO to now()")
+}
+
+// A transient backend hiccup during startup (an etcd leader change, a TiKV
+// region move) must not fail coordinator initialization outright:
+// InitTimestamp retries the window read a bounded number of times before
+// surfacing the error.
+func TestInitTimestampRetriesTransientLoadError(t *testing.T) {
+	oracle := &timestampOracle{
+		key: "tso-test",
+		txnKV: &stubTxnKV{
+			transientLoadFailures: 2,
+			transientLoadErr:      errors.New("etcdserver: leader changed"),
+		},
+		saveInterval: 3 * time.Second,
+	}
+
+	require.NoError(t, oracle.InitTimestamp(),
+		"bounded retry must absorb a transient window-read failure at init")
+}
+
+// A missing key means a fresh deployment with no persisted window: that is
+// the one legitimate ZeroTime case and must keep working.
+func TestLoadTimestampTreatsKeyNotFoundAsFresh(t *testing.T) {
+	oracle := &timestampOracle{
+		key:          "tso-test",
+		txnKV:        &stubTxnKV{loadErr: merr.WrapErrIoKeyNotFound("tso-test")},
+		saveInterval: 3 * time.Second,
+	}
+
+	last, err := oracle.loadTimestamp()
+	require.NoError(t, err)
+	require.Equal(t, typeutil.ZeroTime, last)
+}


### PR DESCRIPTION
issue: #51469

### What this fixes

`timestampOracle.loadTimestamp` swallowed every kv `Load` error into `(ZeroTime, nil)`. On a transient read failure during coordinator restart, `InitTimestamp` then fell back to `time.Now()`: if the persisted window was ahead of wall clock, TSO/ID allocation regressed, breaking timestamp monotonicity and risking duplicate IDs. The failure is silent — a fresh deployment and a failed read are indistinguishable.

### Change

- `loadTimestamp`: only `merr.ErrIoKeyNotFound` (fresh deployment; constructed identically by both the etcd and TiKV metastore backends) still maps to ZeroTime. Any other error now surfaces.
- `InitTimestamp`: wraps the persisted-window read in a bounded retry (5 attempts, 50ms base) so a single backend blip at boot (etcd leader change, TiKV region move) does not fail the coordinator, while a persistent failure surfaces loudly instead of regressing the window.

Exposure is larger on the TiKV metastore backend, where region move / leader transfer are routine; on etcd the window is narrower but the same swallow exists.

### Verification

- Failing-first unit tests with a stubbed TxnKV in `internal/tso/tso_test.go`: fresh-deployment (key-not-found) path still returns ZeroTime and boots; a non-not-found load error surfaces from `loadTimestamp`; `InitTimestamp` recovers when the error is transient (fails once, then succeeds) and fails after bounded attempts when persistent.
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/tso/...` green on top of master `0fe1a5ba6f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)