### PR TITLE
fix: avoid nil worker dereference in delegator ReleaseSegments

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -1180,12 +1180,12 @@ func (sd *shardDelegator) ReleaseSegments(ctx context.Context, req *querypb.Rele
 		if err != nil {
 			log.Warn(ctx, "delegator failed to find worker", mlog.Err(err))
 			releaseErr = err
-		}
-		req.Base.TargetID = targetNodeID
-		err = worker.ReleaseSegments(ctx, req)
-		if err != nil {
-			log.Warn(ctx, "worker failed to release segments", mlog.Err(err))
-			releaseErr = err
+		} else {
+			req.Base.TargetID = targetNodeID
+			if err = worker.ReleaseSegments(ctx, req); err != nil {
+				log.Warn(ctx, "worker failed to release segments", mlog.Err(err))
+				releaseErr = err
+			}
 		}
 	}
 	if len(growing) > 0 {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1733,6 +1733,31 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 	s.NoError(err)
 }
 
+func (s *DelegatorDataSuite) TestReleaseSegmentsWorkerNotAvailable() {
+	ctx := context.Background()
+	// the target worker is offline/unhealthy, GetWorker returns no worker
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).
+		Return(nil, merr.WrapErrNodeNotAvailable(1))
+
+	err := s.delegator.ReleaseSegments(ctx, &querypb.ReleaseSegmentsRequest{
+		Base:       commonpbutil.NewMsgBase(),
+		NodeID:     1,
+		SegmentIDs: []int64{1000},
+		Scope:      querypb.DataScope_All,
+	}, false)
+	s.Error(err)
+	// pin the contract: GetWorker's error code must reach the caller unmasked
+	s.ErrorIs(err, merr.ErrNodeNotAvailable)
+
+	// growingSegmentLock must be released even when the remote release fails,
+	// otherwise the channel's insert pipeline blocks forever
+	locked := s.delegator.growingSegmentLock.TryLock()
+	s.True(locked, "growingSegmentLock should be released after failed release")
+	if locked {
+		s.delegator.growingSegmentLock.Unlock()
+	}
+}
+
 func (s *DelegatorDataSuite) TestReleaseGrowingSourceAfterPreparedHandoff() {
 	ctx := context.Background()
 	s.workerManager = &cluster.MockManager{}


### PR DESCRIPTION
issue: #51472

## Summary

When the target worker is offline or unhealthy, `workerManager.GetWorker` returns `(nil, err)`. `shardDelegator.ReleaseSegments` recorded the error into `releaseErr` but still fell through and invoked `worker.ReleaseSegments(ctx, req)` on the nil `cluster.Worker` interface, panicking the QueryNode. When the release scope included growing segments (`DataScope_All` / `DataScope_Streaming`), the panic unwound past the `growingSegmentLock.Unlock()`, leaking the mutex and permanently blocking the channel's insert pipeline (`ProcessInsert` blocks forever).

This is reachable from the normal `needTransfer` release path (`QueryNode.ReleaseSegments` → `shardDelegator.ReleaseSegments(ctx, req, false)`) whenever QueryCoord releases segments on a node that has just gone offline — routine during rebalancing / node-failure recovery.

## Fix

Guard the worker call in an `else` branch so a failed `GetWorker` returns the error to QueryCoord for retry, matching how `LoadSegments` handles the same failure. The single `growingSegmentLock` unlock path and the existing `releaseErr` semantics (distribution already removed, segments already excluded, release retried by QueryCoord) are preserved.

## Test

- New regression test `TestReleaseSegmentsWorkerNotAvailable`: mocks `GetWorker` returning `(nil, err)`, asserts `ReleaseSegments` returns the error without panicking and that `growingSegmentLock` is released afterward. The test reproduces the nil-pointer panic at `delegator_data.go:1185` before the fix.
- Full `./internal/querynodev2/delegator/...` package tests pass.
- `make static-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)