### PR TITLE
enhance: use raw scan for inverted LIKE match

### DIFF
--- a/internal/core/src/common/RegexQueryTest.cpp
+++ b/internal/core/src/common/RegexQueryTest.cpp
@@ -468,8 +468,9 @@ TEST_F(SealedSegmentRegexQueryTest, InnerMatchOnInvertedIndexStringField) {
     ASSERT_TRUE(final[4]);
 }
 
-TEST_F(SealedSegmentRegexQueryTest, RegexQueryOnInvertedIndexStringField) {
-    std::string operand = "a%";
+TEST_F(SealedSegmentRegexQueryTest,
+       MatchQueryFallsBackToRawDataWithInvertedIndex) {
+    std::string operand = "a%b%";
     const auto& str_meta = schema->operator[](FieldName("str"));
     auto column_info = test::GenColumnInfo(str_meta.get_id().get(),
                                            proto::schema::DataType::VarChar,
@@ -491,8 +492,8 @@ TEST_F(SealedSegmentRegexQueryTest, RegexQueryOnInvertedIndexStringField) {
     BitsetType final;
     final = ExecuteQueryExpr(parsed, segpromote, N, MAX_TIMESTAMP);
     ASSERT_FALSE(final[0]);
-    ASSERT_TRUE(final[1]);
-    ASSERT_TRUE(final[2]);
+    ASSERT_FALSE(final[1]);
+    ASSERT_FALSE(final[2]);
     ASSERT_TRUE(final[3]);
     ASSERT_TRUE(final[4]);
 }

--- a/internal/core/src/index/InvertedIndexTantivy.h
+++ b/internal/core/src/index/InvertedIndexTantivy.h
@@ -289,13 +289,14 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
 
     bool
     ShouldUseOp(proto::plan::OpType op) const override {
-        // Suffix/contains LIKE and regex can be executed correctly over indexed
-        // terms, but for short varchar values they are often slower than raw
-        // scan. Keep only prefix/LIKE Match on the inverted-index path.
+        // Generic LIKE, suffix/contains LIKE, and regex can be executed
+        // correctly over indexed terms, but for short varchar values they are
+        // often slower than raw scan. Keep only prefix matching on the
+        // inverted-index path.
         switch (op) {
-            case proto::plan::OpType::Match:
             case proto::plan::OpType::PrefixMatch:
                 return SupportPatternMatch() || HasRawData();
+            case proto::plan::OpType::Match:
             case proto::plan::OpType::RegexMatch:
             case proto::plan::OpType::PostfixMatch:
             case proto::plan::OpType::InnerMatch:

--- a/internal/core/src/index/InvertedIndexTest.cpp
+++ b/internal/core/src/index/InvertedIndexTest.cpp
@@ -83,7 +83,7 @@ TEST(InvertedIndex, PatternMatchPlannerPolicy) {
     EXPECT_TRUE(index.ShouldUseOp(proto::plan::OpType::PrefixMatch));
     EXPECT_FALSE(index.ShouldUseOp(proto::plan::OpType::RegexMatch));
     EXPECT_TRUE(index.ShouldUseOp(proto::plan::OpType::Equal));
-    EXPECT_TRUE(index.ShouldUseOp(proto::plan::OpType::Match));
+    EXPECT_FALSE(index.ShouldUseOp(proto::plan::OpType::Match));
     EXPECT_FALSE(index.ShouldUseOp(proto::plan::OpType::InnerMatch));
     EXPECT_FALSE(index.ShouldUseOp(proto::plan::OpType::PostfixMatch));
 


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/49922

## Summary
Route generic LIKE Match operations to raw-data scan when a varchar inverted index is present, while keeping PrefixMatch on the inverted-index path. Update planner policy and sealed-segment coverage for a complex LIKE pattern.