### PR TITLE
fix: base64-encode encryption key in NewManifestRecordReader

### DIFF
--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -382,7 +382,7 @@ func NewManifestRecordReader(ctx context.Context, manifestPath string, schema *s
 					pluginContext = &indexcgopb.StoragePluginContext{
 						EncryptionZoneId: ez.EzID,
 						CollectionId:     ez.CollectionID,
-						EncryptionKey:    string(unsafe),
+						EncryptionKey:    base64.StdEncoding.EncodeToString(unsafe),
 					}
 				}
 			}

--- a/internal/storage/serde_events_test.go
+++ b/internal/storage/serde_events_test.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"math/rand"
@@ -728,7 +729,9 @@ func TestNewManifestRecordReaderBranches(t *testing.T) {
 	require.NotNil(t, capturedPluginContext)
 	require.Equal(t, int64(7), capturedPluginContext.GetEncryptionZoneId())
 	require.Equal(t, int64(2), capturedPluginContext.GetCollectionId())
-	require.Equal(t, "unsafe-key", capturedPluginContext.GetEncryptionKey())
+	// the plugin context contract carries the key base64-encoded, matching
+	// NewBinlogRecordReader/NewBinlogRecordWriter and hookutil.GetCPluginContext
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("unsafe-key")), capturedPluginContext.GetEncryptionKey())
 }
 
 func TestBinlogSerializeWriter(t *testing.T) {


### PR DESCRIPTION
issue: #51475

## Summary

`StoragePluginContext.EncryptionKey` is a base64-carrying field: every producer encodes the raw key with `base64.StdEncoding.EncodeToString` — `NewBinlogRecordReader` (`rw.go:320`), `NewBinlogRecordWriter` (`rw.go:438`), `pack_writer_v2.go:136`, and `hookutil.GetCPluginContext` (`cipher.go:384`). The one exception was `NewManifestRecordReader` (`rw.go:385`), which passed the raw key bytes as a string.

For an encryption-enabled collection stored in StorageV3 manifest (loon) format, reads going through `NewManifestRecordReader` — compaction (`compactor_common.go:301`) and the external function executor (`function_executor.go:225`) — therefore handed the cipher plugin differently-encoded key material than the writer used.

## Fix

One line: encode the key with base64, matching the four sibling construction sites. Also fixes `TestNewManifestRecordReaderBranches`, which had asserted the raw key (codifying the bug), to assert the base64-encoded key.

## Test

- `TestNewManifestRecordReaderBranches` now asserts the base64 contract and passes.
- Full `./internal/storage/` package passes locally, excluding the six Azure/GCP-endpoint tests (`TestAzureObjectStorage`, `TestReadFile`, `TestAzureChunkManager`, `TestGcpNativeObjectStorage`, `TestGcpNativeReadFile`, `TestInitRemoteChunkManager`) which require the cloud emulators available only in CI; none of them touch the changed code path.
- `make static-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)