### PR TITLE
fix: harden search against inconsistent requery under concurrent DML/DQL

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1138,6 +1138,15 @@ common:
     mode:
       queryNode: sync # File resource mode for query node, options: [sync, close]. Default is sync.
       dataNode: sync # File resource mode for data node, options: [sync, ref, close]. Default is sync.
+  requery:
+    # the max number of retry attempts for search/hybrid_search when the requery result
+    # is inconsistent with the ANN search result (error code 2200), which can happen when the
+    # segment set observed by the two RPCs of a two-phase query drifts (e.g. due to a concurrent
+    # L0 compaction). This is independent of the generic RPC-level retry count.
+    inconsistentRequeryMaxAttempts: 15
+    # the max backoff sleep time in seconds between retries for the
+    # common.requery.inconsistentRequeryMaxAttempts retry budget above.
+    inconsistentRequeryMaxSleepTimeSeconds: 20
   groupBy:
     maxGroups: 100000 # Maximum number of groups allowed in GROUP BY aggregation, enforced both per segment and during cross-segment merge. Exceeding this limit fails the query.
 

--- a/examples/telemetry_e2e_test/go.mod
+++ b/examples/telemetry_e2e_test/go.mod
@@ -1,10 +1,11 @@
 module github.com/milvus-io/milvus/examples/telemetry_e2e_test
+
 go 1.26.5
 
 require (
 	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c
 	github.com/milvus-io/milvus/client/v2 v2.6.4-0.20251104142533-a2ce70d25256
-	google.golang.org/grpc v1.79.3
+	google.golang.org/grpc v1.80.0
 )
 
 replace (

--- a/examples/telemetry_e2e_test/go.sum
+++ b/examples/telemetry_e2e_test/go.sum
@@ -2,3 +2,4 @@ github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
 google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -776,6 +776,32 @@ VectorDiskAnnIndex<T>::Query(const DatasetPtr dataset,
         search_result.distances_.data(),
         distances,
         total_num * sizeof(*search_result.distances_.data()));
+
+    // knowhere's contract is that every slot is either a genuine row
+    // offset in [0, index_.Count()) or the INVALID_SEG_OFFSET sentinel; this
+    // is not otherwise validated above, so guard against out-of-range values
+    // (e.g. a future knowhere index type leaving a slot uninitialized)
+    // corrupting downstream bulk_subscript access. This cannot detect an
+    // in-range value that is itself a stale/uninitialized sentinel.
+    // Count() itself is not const (it overrides Index's non-const pure
+    // virtual), so query the underlying knowhere index directly here rather
+    // than through the virtual dispatch.
+    const auto row_count = index_.Count();
+    int64_t sanitized_count = 0;
+    for (auto& offset : search_result.seg_offsets_) {
+        if (offset != INVALID_SEG_OFFSET &&
+            (offset < 0 || offset >= row_count)) {
+            offset = INVALID_SEG_OFFSET;
+            sanitized_count++;
+        }
+    }
+    if (sanitized_count > 0) {
+        LOG_WARN(
+            "VectorDiskAnnIndex::Query: sanitized {} out-of-range offset(s) "
+            "from knowhere search result, row_count={}",
+            sanitized_count,
+            row_count);
+    }
 }
 
 template <typename T>

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -816,6 +816,32 @@ VectorMemIndex<T>::Query(const DatasetPtr dataset,
         search_result.distances_.data(),
         distances,
         total_num * sizeof(*search_result.distances_.data()));
+
+    // knowhere's contract is that every slot is either a genuine row
+    // offset in [0, index_.Count()) or the INVALID_SEG_OFFSET sentinel; this
+    // is not otherwise validated above, so guard against out-of-range values
+    // (e.g. a future knowhere index type leaving a slot uninitialized)
+    // corrupting downstream bulk_subscript access. This cannot detect an
+    // in-range value that is itself a stale/uninitialized sentinel.
+    // Count() itself is not const (it overrides Index's non-const pure
+    // virtual), so query the underlying knowhere index directly here rather
+    // than through the virtual dispatch.
+    const auto row_count = index_.Count();
+    int64_t sanitized_count = 0;
+    for (auto& offset : search_result.seg_offsets_) {
+        if (offset != INVALID_SEG_OFFSET &&
+            (offset < 0 || offset >= row_count)) {
+            offset = INVALID_SEG_OFFSET;
+            sanitized_count++;
+        }
+    }
+    if (sanitized_count > 0) {
+        LOG_WARN(
+            "VectorMemIndex::Query: sanitized {} out-of-range offset(s) "
+            "from knowhere search result, row_count={}",
+            sanitized_count,
+            row_count);
+    }
 }
 
 template <typename T>

--- a/internal/core/unittest/test_indexing.cpp
+++ b/internal/core/unittest/test_indexing.cpp
@@ -597,6 +597,16 @@ TEST_P(IndexTest, BuildAndQuery) {
     EXPECT_EQ(result.unity_topK_, K);
     EXPECT_EQ(result.distances_.size(), NQ * K);
     EXPECT_EQ(result.seg_offsets_.size(), NQ * K);
+    // regression guard for the out-of-range sanitization in
+    // VectorMemIndex<T>::Query / VectorDiskAnnIndex<T>::Query: every offset
+    // knowhere returns must either be a valid row in [0, NB) or the
+    // INVALID_SEG_OFFSET sentinel.
+    EXPECT_TRUE(std::all_of(result.seg_offsets_.begin(),
+                            result.seg_offsets_.end(),
+                            [this](int64_t offset) {
+                                return offset == INVALID_SEG_OFFSET ||
+                                       (offset >= 0 && offset < NB);
+                            }));
     if (metric_type == knowhere::metric::L2) {
         // for L2 metric each vector is closest to itself
         for (int i = 0; i < NQ; i++) {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -2946,7 +2946,14 @@ func (node *Proxy) Search(ctx context.Context, request *milvuspb.SearchRequest) 
 			return false, merr.Error(rspGT.GetStatus())
 		}
 		return false, nil
-	})
+	}, retry.Attempts(func() uint {
+		a := Params.CommonCfg.InconsistentRequeryMaxAttempts.GetAsUint()
+		if a == 0 {
+			return 1
+		}
+		return a
+	}()),
+		retry.MaxSleepTime(Params.CommonCfg.InconsistentRequeryMaxSleepTimeSeconds.GetAsDuration(time.Second)))
 	if err2 != nil {
 		rsp.Status = merr.Status(err2)
 	} else if err != nil {
@@ -3196,7 +3203,14 @@ func (node *Proxy) HybridSearch(ctx context.Context, request *milvuspb.HybridSea
 			return true, merr.Error(rsp.GetStatus())
 		}
 		return false, nil
-	})
+	}, retry.Attempts(func() uint {
+		a := Params.CommonCfg.InconsistentRequeryMaxAttempts.GetAsUint()
+		if a == 0 {
+			return 1
+		}
+		return a
+	}()),
+		retry.MaxSleepTime(Params.CommonCfg.InconsistentRequeryMaxSleepTimeSeconds.GetAsDuration(time.Second)))
 	if err2 != nil {
 		rsp.Status = merr.Status(err2)
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/prometheus/client_golang/prometheus"
@@ -2035,6 +2036,53 @@ func TestProxy(t *testing.T) {
 			assert.NotEqual(t, commonpb.ErrorCode_Success, resp.Status.ErrorCode)
 			Params.Reset(Params.ProxyCfg.MustUsePartitionKey.Key)
 		}
+	})
+
+	t.Run("search retries on inconsistent requery then succeeds", func(t *testing.T) {
+		Params.Save(Params.CommonCfg.InconsistentRequeryMaxAttempts.Key, "3")
+		Params.Save(Params.CommonCfg.InconsistentRequeryMaxSleepTimeSeconds.Key, "0")
+		defer Params.Reset(Params.CommonCfg.InconsistentRequeryMaxAttempts.Key)
+		defer Params.Reset(Params.CommonCfg.InconsistentRequeryMaxSleepTimeSeconds.Key)
+
+		var callCount int
+		mockey.Mock((*Proxy).search).To(func(ctx context.Context, request *milvuspb.SearchRequest, optimizedSearch bool, isRecallEvaluation bool) (*milvuspb.SearchResults, bool, bool, bool, error) {
+			callCount++
+			if callCount < 3 {
+				return &milvuspb.SearchResults{
+					Status: merr.Status(merr.WrapErrInconsistentRequery("missing id")),
+				}, false, false, false, nil
+			}
+			return &milvuspb.SearchResults{Status: merr.Success()}, false, false, false, nil
+		}).Build()
+		defer mockey.UnPatchAll()
+
+		req := constructTestSearchRequest(dbName, collectionName, floatVecField, expr, nq, nprobe, topk, roundDecimal, dim)
+		resp, err := proxy.Search(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, commonpb.ErrorCode_Success, resp.Status.ErrorCode)
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("search exhausts retry budget on persistent inconsistent requery", func(t *testing.T) {
+		Params.Save(Params.CommonCfg.InconsistentRequeryMaxAttempts.Key, "2")
+		Params.Save(Params.CommonCfg.InconsistentRequeryMaxSleepTimeSeconds.Key, "0")
+		defer Params.Reset(Params.CommonCfg.InconsistentRequeryMaxAttempts.Key)
+		defer Params.Reset(Params.CommonCfg.InconsistentRequeryMaxSleepTimeSeconds.Key)
+
+		var callCount int
+		mockey.Mock((*Proxy).search).To(func(ctx context.Context, request *milvuspb.SearchRequest, optimizedSearch bool, isRecallEvaluation bool) (*milvuspb.SearchResults, bool, bool, bool, error) {
+			callCount++
+			return &milvuspb.SearchResults{
+				Status: merr.Status(merr.WrapErrInconsistentRequery("missing id")),
+			}, false, false, false, nil
+		}).Build()
+		defer mockey.UnPatchAll()
+
+		req := constructTestSearchRequest(dbName, collectionName, floatVecField, expr, nq, nprobe, topk, roundDecimal, dim)
+		resp, err := proxy.Search(ctx, req)
+		assert.NoError(t, err)
+		assert.True(t, errors.Is(merr.Error(resp.GetStatus()), merr.ErrInconsistentRequery))
+		assert.Equal(t, 2, callCount)
 	})
 
 	t.Run("advanced search", func(t *testing.T) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -360,6 +360,9 @@ type commonConfig struct {
 	QNFileResourceMode        ParamItem `refreshable:"true"`
 	DNFileResourceMode        ParamItem `refreshable:"true"`
 
+	InconsistentRequeryMaxAttempts         ParamItem `refreshable:"true"`
+	InconsistentRequeryMaxSleepTimeSeconds ParamItem `refreshable:"true"`
+
 	// group by
 	GroupByMaxGroups ParamItem `refreshable:"false"`
 }
@@ -1487,6 +1490,28 @@ If enabled, IPv6 ULA/global addresses will be prioritized ahead of IPv4.`,
 		Export:       false,
 	}
 	p.SearchRequeryPolicy.Init(base.mgr)
+
+	p.InconsistentRequeryMaxAttempts = ParamItem{
+		Key:          "common.requery.inconsistentRequeryMaxAttempts",
+		Version:      "3.0.0",
+		DefaultValue: "15",
+		Doc: `the max number of retry attempts for search/hybrid_search when the requery result
+is inconsistent with the ANN search result (error code 2200), which can happen when the
+segment set observed by the two RPCs of a two-phase query drifts (e.g. due to a concurrent
+L0 compaction). This is independent of the generic RPC-level retry count.`,
+		Export: true,
+	}
+	p.InconsistentRequeryMaxAttempts.Init(base.mgr)
+
+	p.InconsistentRequeryMaxSleepTimeSeconds = ParamItem{
+		Key:          "common.requery.inconsistentRequeryMaxSleepTimeSeconds",
+		Version:      "3.0.0",
+		DefaultValue: "20",
+		Doc: `the max backoff sleep time in seconds between retries for the
+common.requery.inconsistentRequeryMaxAttempts retry budget above.`,
+		Export: true,
+	}
+	p.InconsistentRequeryMaxSleepTimeSeconds.Init(base.mgr)
 
 	p.QNFileResourceMode = ParamItem{
 		Key:          "common.fileResource.mode.queryNode",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -188,6 +188,18 @@ func TestComponentParam(t *testing.T) {
 		params.Save("common.storage.zstd.concurrency", "2")
 		assert.Equal(t, 2, params.CommonCfg.StorageZstdConcurrency.GetAsInt())
 
+		assert.Equal(t, uint(15), params.CommonCfg.InconsistentRequeryMaxAttempts.GetAsUint())
+		params.Save("common.requery.inconsistentRequeryMaxAttempts", "30")
+		assert.Equal(t, uint(30), params.CommonCfg.InconsistentRequeryMaxAttempts.GetAsUint())
+		params.Reset("common.requery.inconsistentRequeryMaxAttempts")
+		assert.Equal(t, uint(15), params.CommonCfg.InconsistentRequeryMaxAttempts.GetAsUint())
+
+		assert.Equal(t, 20*time.Second, params.CommonCfg.InconsistentRequeryMaxSleepTimeSeconds.GetAsDuration(time.Second))
+		params.Save("common.requery.inconsistentRequeryMaxSleepTimeSeconds", "45")
+		assert.Equal(t, 45*time.Second, params.CommonCfg.InconsistentRequeryMaxSleepTimeSeconds.GetAsDuration(time.Second))
+		params.Reset("common.requery.inconsistentRequeryMaxSleepTimeSeconds")
+		assert.Equal(t, 20*time.Second, params.CommonCfg.InconsistentRequeryMaxSleepTimeSeconds.GetAsDuration(time.Second))
+
 		assert.Equal(t, 0, params.CommonCfg.ClusterID.GetAsInt())
 		params.Save("common.clusterID", "32")
 		assert.Panics(t, func() {


### PR DESCRIPTION
VectorMemIndex/VectorDiskAnnIndex::Query now clamp any knowhere offset outside [0, Count()) to INVALID_SEG_OFFSET before it reaches downstream bulk_subscript, guarding against a future index type leaving a slot uninitialized (this cannot distinguish a genuine low offset from a stale/uninitialized one — that ambiguity can only be resolved at the searcher's construction site, as knowhere's own HNSW v2 fix did).

Proxy.Search/Proxy.HybridSearch now use a dedicated, larger retry budget for ErrInconsistentRequery via two new paramtable options (common.requery.inconsistentRequeryMaxAttempts / inconsistentRequeryMaxSleepTimeSeconds), shrinking the exposure window around delegator segment-topology swaps during L0 compaction. This reduces but does not eliminate the race described in the issue; the architectural fix (anchoring requery to the search-observed target version) is left as a follow-up design item.

issue: #38126