### PR TITLE
fix: [2.6] gate GIS filters out of the offset-input path

### DIFF
--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -494,5 +494,48 @@ OptimizeCompiledExprs(ExecContext* context, const std::vector<ExprPtr>& exprs) {
     milvus::monitor::internal_core_optimize_expr_latency.Observe(cost / 1000);
 }
 
+TargetBitmap
+EvalExprSetOverAllBatches(ExprSet& expr_set,
+                          EvalCtx& eval_ctx,
+                          int64_t total_rows,
+                          const char* what) {
+    std::vector<VectorPtr> results;
+    TargetBitmap bitset;
+    TargetBitmap valid_bitset;
+    while (static_cast<int64_t>(bitset.size()) < total_rows) {
+        expr_set.Eval(0, 1, true, eval_ctx, results);
+
+        AssertInfo(results.size() == 1 && results[0] != nullptr,
+                   "{}: filter expr returned null result",
+                   what);
+        auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
+        if (col_vec == nullptr) {
+            ThrowInfo(ExprInvalid, "{}: result should be ColumnVector", what);
+        }
+        if (!col_vec->IsBitmap()) {
+            ThrowInfo(ExprInvalid, "{}: result should be bitmap", what);
+        }
+        auto col_vec_size = col_vec->size();
+        AssertInfo(col_vec_size > 0,
+                   "{}: filter expr returned empty batch after {} of {} rows",
+                   what,
+                   bitset.size(),
+                   total_rows);
+        TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
+        bitset.append(view);
+        TargetBitmapView valid_view(col_vec->GetValidRawData(), col_vec_size);
+        valid_bitset.append(valid_view);
+    }
+    AssertInfo(static_cast<int64_t>(bitset.size()) == total_rows,
+               "{}: filter bitset size {} must match total rows {}",
+               what,
+               bitset.size(),
+               total_rows);
+    // Fold UNKNOWN (NULL) into FALSE explicitly (data &= valid) instead of
+    // relying on the convention that UNKNOWN rows carry data=0.
+    bitset.inplace_and(valid_bitset, bitset.size());
+    return bitset;
+}
+
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1673,5 +1673,18 @@ class ExprSet {
     ExecContext* exec_ctx_;
 };
 
+// Evaluate expr_set batch by batch until the accumulated result covers
+// total_rows, then fold UNKNOWN (NULL) into FALSE (data &= valid) so a
+// consumer that reads only the data bits is null-rejecting by construction.
+// Shared by the whole-range consumers of expressions that cannot take offset
+// input: PhyIterativeFilterNode's non-native branch and PhyRescoresNode's
+// non-native boost filter fallback. `what` names the caller in error
+// messages.
+TargetBitmap
+EvalExprSetOverAllBatches(ExprSet& expr_set,
+                          EvalCtx& eval_ctx,
+                          int64_t total_rows,
+                          const char* what);
+
 }  //namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/ExprGISMiscTest.cpp
+++ b/internal/core/src/exec/expression/ExprGISMiscTest.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include "ExprTestBase.h"
+#include "exec/expression/Expr.h"
 
 EXPR_TEST_INSTANTIATE();
 
@@ -831,4 +832,161 @@ TEST_P(ExprTest, TestFloatingPointModulo) {
         }
         ASSERT_EQ(final.count(), expected_count);
     }
+}
+
+// Regression for the GIS offset-input contract. PhyGISFunctionFilterExpr slices
+// only by its own batch cursor (GetNextBatchSize) and never reads the
+// offset-input list, but the SegmentExpr base defaults SupportOffsetInput() to
+// true. Left at the default, the native offset-input path (IterativeFilterNode
+// / rescore) would feed a sparse offset list into an Eval that ignores it and
+// return misaligned rows -- a silent wrong-results bug on any GIS predicate
+// reached through iterative filtering. The override must report false so the
+// consumer takes its non-native fallback. This pins the contract so a future
+// change cannot regress it.
+TEST(ExprTest, GISFilterDoesNotSupportOffsetInput) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto geo_fid = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+
+    const int64_t N = 256;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
+
+    // Compile a bare GIS leaf into its physical expr and inspect the contract.
+    milvus::expr::TypedExprPtr leaf =
+        std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+            milvus::expr::ColumnInfo(geo_fid, DataType::GEOMETRY),
+            proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+            "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))");
+    std::vector<milvus::expr::TypedExprPtr> filters{leaf};
+
+    auto query_context = std::make_shared<milvus::exec::QueryContext>(
+        DEAFULT_QUERY_ID, seg.get(), N, MAX_TIMESTAMP);
+    milvus::exec::ExecContext exec_context(query_context.get());
+    milvus::exec::ExprSet expr_set(filters, &exec_context);
+
+    ASSERT_EQ(expr_set.exprs().size(), 1u);
+    EXPECT_FALSE(expr_set.exprs()[0]->SupportOffsetInput());
+}
+
+namespace {
+
+// Build a growing segment where `age` equals the row index and the geometry
+// sits inside the query polygon only for rows [8192, 16384), then evaluate
+// `age >= 8192 AND st_within(geo, ...)`. The first expression batch [0, 8192)
+// leaves the AND with no active rows, so the conjunct skips the GIS
+// expression through MoveCursor(); a skipped batch that does not advance the
+// GIS cursor makes every later batch evaluate the wrong rows.
+void
+RunGrowingConjunctSkipTest(bool with_rtree_index) {
+    using namespace milvus;
+    using namespace milvus::segcore;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto age_fid = schema->AddDebugField("age", DataType::INT64);
+    auto geo_fid = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+
+    IndexMetaPtr index_meta = nullptr;
+    if (with_rtree_index) {
+        std::map<std::string, std::string> index_params = {
+            {"index_type", "RTREE"}};
+        std::map<std::string, std::string> type_params;
+        FieldIndexMeta geo_index_meta(
+            geo_fid, std::move(index_params), std::move(type_params));
+        std::map<FieldId, FieldIndexMeta> field_map = {
+            {geo_fid, geo_index_meta}};
+        index_meta =
+            std::make_shared<CollectionIndexMeta>(100000, std::move(field_map));
+    }
+
+    const int64_t N = 20000;  // three expression batches of 8192
+    const int64_t kBatch = 8192;
+    auto raw_data = DataGen(schema, N);
+
+    proto::schema::FieldData* age_field_data = nullptr;
+    proto::schema::FieldData* geo_field_data = nullptr;
+    for (auto& fd : *raw_data.raw_->mutable_fields_data()) {
+        if (fd.field_id() == age_fid.get()) {
+            age_field_data = &fd;
+        } else if (fd.field_id() == geo_fid.get()) {
+            geo_field_data = &fd;
+        }
+    }
+    ASSERT_NE(age_field_data, nullptr);
+    ASSERT_NE(geo_field_data, nullptr);
+
+    auto* age_col =
+        age_field_data->mutable_scalars()->mutable_long_data()->mutable_data();
+    for (int64_t i = 0; i < N; ++i) {
+        age_col->at(i) = i;
+    }
+
+    auto* geo_col = geo_field_data->mutable_scalars()->mutable_geometry_data();
+    geo_col->clear_data();
+    auto ctx = GEOS_init_r();
+    for (int64_t i = 0; i < N; ++i) {
+        const char* wkt = (i >= kBatch && i < 2 * kBatch)
+                              ? "POINT (0.5 0.5)"
+                              : "POINT (100.0 100.0)";
+        Geometry geom(ctx, wkt);
+        geo_col->add_data(geom.to_wkb_string());
+    }
+    GEOS_finish_r(ctx);
+
+    auto config = SegcoreConfig::default_config();
+    config.set_enable_interim_segment_index(with_rtree_index);
+    auto seg = CreateGrowingSegment(schema, index_meta, 1, config);
+    seg->PreInsert(N);
+    seg->Insert(0,
+                N,
+                raw_data.row_ids_.data(),
+                raw_data.timestamps_.data(),
+                raw_data.raw_);
+    ASSERT_EQ(seg->HasIndex(geo_fid), with_rtree_index);
+
+    proto::plan::GenericValue val;
+    val.set_int64_val(kBatch);
+    auto age_expr = std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+        milvus::expr::ColumnInfo(age_fid, DataType::INT64),
+        proto::plan::OpType::GreaterEqual,
+        val);
+    auto gis_expr = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_fid, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Within,
+        "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+    auto filter = std::make_shared<milvus::expr::LogicalBinaryExpr>(
+        milvus::expr::LogicalBinaryExpr::OpType::And, age_expr, gis_expr);
+    auto plan = std::make_shared<milvus::plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, filter);
+
+    auto final =
+        milvus::query::ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
+    ASSERT_EQ(final.size(), N);
+    for (int64_t i = 0; i < N; ++i) {
+        bool expected = (i >= kBatch && i < 2 * kBatch);
+        ASSERT_EQ(final[i], expected)
+            << "cursor desync at row " << i
+            << " (with_rtree_index: " << with_rtree_index << ")";
+    }
+}
+
+}  // namespace
+
+// Raw-data path: growing segment without any geometry index.
+TEST(ExprTest, GISFilterGrowingConjunctSkipKeepsCursorInSync) {
+    RunGrowingConjunctSkipTest(false);
+}
+
+// Interim-index path: growing segment with an R-Tree interim index, where
+// EvalForIndexSegment advances the global index position together with the
+// data cursor and MoveCursor() must do the same on a skipped batch.
+TEST(ExprTest, GISFilterGrowingIndexConjunctSkipKeepsCursorInSync) {
+    RunGrowingConjunctSkipTest(true);
 }

--- a/internal/core/src/exec/expression/ExprGISMiscTest.cpp
+++ b/internal/core/src/exec/expression/ExprGISMiscTest.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include "ExprTestBase.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "exec/expression/Expr.h"
 
 EXPR_TEST_INSTANTIATE();
@@ -940,6 +941,10 @@ RunGrowingConjunctSkipTest(bool with_rtree_index) {
     }
     GEOS_finish_r(ctx);
 
+    // SegcoreConfig members are process-global (inline static): the copy
+    // below does not isolate the interim-index toggle, so restore on scope
+    // exit instead of leaking it into every later growing-segment test.
+    ScopedSegcoreConfigRestore config_restore;
     auto config = SegcoreConfig::default_config();
     config.set_enable_interim_segment_index(with_rtree_index);
     auto seg = CreateGrowingSegment(schema, index_meta, 1, config);

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -12,6 +12,8 @@
 #pragma once
 
 #include <fmt/core.h>
+
+#include <algorithm>
 #include <memory>
 
 #include "common/FieldDataInterface.h"
@@ -61,11 +63,40 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
         return fmt::format("{}", expr_->ToString());
     }
 
+    // The GIS filter slices by its own batch cursor (GetNextBatchSize) and never
+    // reads the offset-input list, so it cannot serve the offset-input
+    // (iterative-filter / rescore) path. Report false so IterativeFilterNode
+    // takes its non-native fallback instead of feeding offsets into Eval.
+    bool
+    SupportOffsetInput() override {
+        return false;
+    }
+
+    // A skipped batch (conjunct short-circuit via SkipFollowingExprs) must
+    // still advance this expression's cursors, otherwise it desynchronizes
+    // from its sibling expressions and later batches evaluate the wrong rows.
+    // The base MoveCursor() covers every case except the growing
+    // interim-index path: MoveCursorForIndex() asserts sealed-only, while
+    // EvalForIndexSegment() on a growing segment advances the global index
+    // position together with the data cursor -- mirror that here.
+    // Unlike the base implementation, MoveCursorForData() is called without a
+    // HasFieldData() guard: this exec path already walks data chunks
+    // unconditionally (EvalForIndexSegment), and with no field data
+    // num_data_chunk_ is 0, making the call a no-op -- the omission is
+    // intentional, not an oversight.
     void
-    MoveCursor() {
-        if (segment_->type() == SegmentType::Sealed) {
-            SegmentExpr::MoveCursor();
+    MoveCursor() override {
+        if (has_offset_input_) {
+            return;
         }
+        if (SegmentExpr::CanUseIndex() &&
+            segment_->type() != SegmentType::Sealed) {
+            current_index_chunk_pos_ +=
+                std::min(active_count_ - current_index_chunk_pos_, batch_size_);
+            MoveCursorForData();
+            return;
+        }
+        SegmentExpr::MoveCursor();
     }
 
  private:

--- a/internal/core/src/exec/operator/IterativeFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeFilterNode.cpp
@@ -140,38 +140,12 @@ PhyIterativeFilterNode::GetOutput() {
     // get bitset of whole segment first
     if (!is_native_supported_) {
         EvalCtx eval_ctx(operator_context_->get_exec_context(), exprs_.get());
-
-        TargetBitmap valid_bitset;
-        while (num_processed_rows_ < need_process_rows_) {
-            exprs_->Eval(0, 1, true, eval_ctx, results_);
-
-            AssertInfo(
-                results_.size() == 1 && results_[0] != nullptr,
-                "PhyIterativeFilterNode result size should be size one and not "
-                "be nullptr");
-
-            if (auto col_vec =
-                    std::dynamic_pointer_cast<ColumnVector>(results_[0])) {
-                if (col_vec->IsBitmap()) {
-                    auto col_vec_size = col_vec->size();
-                    TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
-                    bitset.append(view);
-                    TargetBitmapView valid_view(col_vec->GetValidRawData(),
-                                                col_vec_size);
-                    valid_bitset.append(valid_view);
-                    num_processed_rows_ += col_vec_size;
-                } else {
-                    ThrowInfo(ExprInvalid,
-                              "PhyIterativeFilterNode result should be bitmap");
-                }
-            } else {
-                ThrowInfo(
-                    ExprInvalid,
-                    "PhyIterativeFilterNode result should be ColumnVector");
-            }
-        }
-        Assert(bitset.size() == need_process_rows_);
-        Assert(valid_bitset.size() == need_process_rows_);
+        // Rows are included below on the data bit alone; the helper folds
+        // UNKNOWN into FALSE (data &= valid), which is what makes this
+        // operator a null-rejecting consumer by construction.
+        bitset = EvalExprSetOverAllBatches(
+            *exprs_, eval_ctx, need_process_rows_, "PhyIterativeFilterNode");
+        num_processed_rows_ = need_process_rows_;
     }
     if (search_result.vector_iterators_.has_value()) {
         AssertInfo(search_result.vector_iterators_.value().size() ==

--- a/internal/core/src/exec/operator/RescoresNode.cpp
+++ b/internal/core/src/exec/operator/RescoresNode.cpp
@@ -142,6 +142,13 @@ PhyRescoresNode::GetOutput() {
                 filter->ToString());
             auto col_vec_size = col_vec->size();
             TargetBitmapView bitsetview(col_vec->GetRawData(), col_vec_size);
+            // Fold UNKNOWN (NULL) into FALSE (data &= valid) so a null row
+            // never receives a boost, keeping NULL policy identical on the
+            // native and non-native branches (PhyIterativeFilterNode folds
+            // on both of its branches too).
+            TargetBitmapView validview(col_vec->GetValidRawData(),
+                                       col_vec_size);
+            bitsetview.inplace_and(validview, col_vec_size);
             scorer->batch_score(op_context,
                                 segment,
                                 function_mode,
@@ -150,23 +157,9 @@ PhyRescoresNode::GetOutput() {
                                 boost_scores);
         } else {
             // query all segment if expr not native
-            expr_set->Eval(0, 1, true, eval_ctx, results);
-
             // filter result for offsets[i] was bitset[offset[i]]
-            AssertInfo(!results.empty() && results[0] != nullptr,
-                       "PhyRescoresNode: filter expr returned null result, "
-                       "filter: {}",
-                       filter->ToString());
-            auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
-            AssertInfo(
-                col_vec != nullptr,
-                "PhyRescoresNode: failed to cast result to ColumnVector, "
-                "filter: {}",
-                filter->ToString());
-            TargetBitmap bitset;
-            auto col_vec_size = col_vec->size();
-            TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
-            bitset.append(view);
+            TargetBitmap bitset = EvalNonNativeBoostFilterAllBatches(
+                exec_context, expr_set.get(), eval_ctx, filter);
             scorer->batch_score(op_context,
                                 segment,
                                 function_mode,
@@ -217,5 +210,18 @@ PhyRescoresNode::GetOutput() {
     tracer::AddEvent(fmt::format("rescored_count: {}", offsets.size()));
     return input_;
 };
+
+TargetBitmap
+EvalNonNativeBoostFilterAllBatches(ExecContext* exec_context,
+                                   ExprSet* expr_set,
+                                   EvalCtx& eval_ctx,
+                                   const expr::TypedExprPtr& filter) {
+    auto active_count = exec_context->get_query_context()->get_active_count();
+    // The shared helper accumulates every expression batch so the bitset
+    // covers all active rows and folds UNKNOWN (NULL) into FALSE so null
+    // rows never receive a boost, matching PhyIterativeFilterNode.
+    return EvalExprSetOverAllBatches(
+        *expr_set, eval_ctx, active_count, "PhyRescoresNode");
+}
 
 }  // namespace milvus::exec

--- a/internal/core/src/exec/operator/RescoresNode.h
+++ b/internal/core/src/exec/operator/RescoresNode.h
@@ -75,4 +75,17 @@ class PhyRescoresNode : public Operator {
     const proto::plan::ScoreOption* option_;
     bool is_finished_{false};
 };
+
+// Evaluate a boost filter whose expression cannot consume offset input
+// (text match, GIS) over the whole segment. Each ExprSet::Eval call only
+// advances the expression by one internal batch
+// (DEFAULT_EXEC_EVAL_EXPR_BATCH_SIZE rows), while the topk offsets being
+// scored may reference any row of the segment -- accumulate every batch so
+// the returned bitset covers all active rows. UNKNOWN (NULL) rows are folded
+// to FALSE so they never receive a boost.
+TargetBitmap
+EvalNonNativeBoostFilterAllBatches(ExecContext* exec_context,
+                                   ExprSet* expr_set,
+                                   EvalCtx& eval_ctx,
+                                   const expr::TypedExprPtr& filter);
 }  // namespace milvus::exec

--- a/internal/core/src/exec/operator/RescoresNodeTest.cpp
+++ b/internal/core/src/exec/operator/RescoresNodeTest.cpp
@@ -10,9 +10,19 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <gtest/gtest.h>
+#include "common/Geometry.h"
+#include "common/OpContext.h"
 #include "common/Schema.h"
 #include "common/Types.h"
+#include "common/protobuf_utils.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/Expr.h"
+#include "exec/operator/RescoresNode.h"
+#include "expr/ITypeExpr.h"
+#include "geos_c.h"
+#include "pb/plan.pb.h"
 #include "query/Plan.h"
+#include "rescores/Scorer.h"
 
 #include "segcore/reduce_c.h"
 #include "test_utils/cachinglayer_test_utils.h"
@@ -177,5 +187,159 @@ TEST(Rescorer, Normal) {
                        search_result->distances_[i],
                        search_result_same_seed->distances_[i]);
         }
+    }
+}
+// Test: TargetBitmap batch_score with out-of-bounds offsets (should NOT
+// crash). Both WeightScorer and RandomScorer indexed bitmap[offsets[i]]
+// without a bounds check, reading past the end of the bitset whenever the
+// filter bitmap does not cover the whole segment.
+TEST(WeightScorerTest, BatchScoreTargetBitmapOutOfBoundsOffsets) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+    auto raw_data = DataGen(schema, 8);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    expr::TypedExprPtr filter = nullptr;
+    rescores::WeightScorer scorer(filter, 2.0F);
+
+    TargetBitmap bitmap(50);
+    bitmap.set(10);
+    bitmap.set(40);
+
+    // Offsets where some are OUT OF BOUNDS (>= 50), e.g. when the filter
+    // bitmap does not cover the whole segment.
+    FixedVector<int32_t> offsets = {10, 40, 60, 100, 200};
+    std::vector<std::optional<float>> boost_scores(offsets.size(),
+                                                   std::nullopt);
+
+    ASSERT_NO_THROW(scorer.batch_score(nullptr,
+                                       segment.get(),
+                                       proto::plan::FunctionModeSum,
+                                       offsets,
+                                       bitmap,
+                                       boost_scores));
+
+    // In-bounds matched offsets should be scored.
+    EXPECT_TRUE(boost_scores[0].has_value());
+    EXPECT_TRUE(boost_scores[1].has_value());
+
+    // Out-of-bounds offsets should NOT have scores (safely skipped).
+    EXPECT_FALSE(boost_scores[2].has_value());
+    EXPECT_FALSE(boost_scores[3].has_value());
+    EXPECT_FALSE(boost_scores[4].has_value());
+}
+
+TEST(RandomScorerTest, BatchScoreTargetBitmapOutOfBoundsOffsets) {
+    // The segment is only consulted for get_segment_id() on the
+    // no-seed-field path of random_score.
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+    auto raw_data = DataGen(schema, 8);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    expr::TypedExprPtr filter = nullptr;
+    ProtoParams params;
+    auto* seed = params.Add();
+    seed->set_key("seed");
+    seed->set_value("42");
+    rescores::RandomScorer scorer(filter, 1.0F, params);
+
+    TargetBitmap bitmap(50);
+    bitmap.set(10);
+    bitmap.set(40);
+
+    FixedVector<int32_t> offsets = {10, 40, 60, 100, 200};
+    std::vector<std::optional<float>> boost_scores(offsets.size(),
+                                                   std::nullopt);
+
+    ASSERT_NO_THROW(scorer.batch_score(nullptr,
+                                       segment.get(),
+                                       proto::plan::FunctionModeSum,
+                                       offsets,
+                                       bitmap,
+                                       boost_scores));
+
+    // In-bounds matched offsets should be scored.
+    EXPECT_TRUE(boost_scores[0].has_value());
+    EXPECT_TRUE(boost_scores[1].has_value());
+
+    // Out-of-bounds offsets should NOT have scores (safely skipped).
+    EXPECT_FALSE(boost_scores[2].has_value());
+    EXPECT_FALSE(boost_scores[3].has_value());
+    EXPECT_FALSE(boost_scores[4].has_value());
+}
+
+// Test: a boost filter whose expression does not support offset input (GIS,
+// text match) is evaluated batch by batch over the whole segment. The
+// resulting bitset must cover every active row, not just the first
+// expression batch (DEFAULT_EXEC_EVAL_EXPR_BATCH_SIZE = 8192 rows),
+// otherwise offsets beyond the first batch silently lose their boost (or
+// read out of bounds).
+TEST(RescoresNode, NonNativeBoostFilterBitsetCoversAllBatches) {
+    const int64_t N = 10000;  // more than one expression batch (8192)
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto geo_fid = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->AddDebugField(
+        "fvec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+
+    auto raw_data = DataGen(schema, N);
+    proto::schema::FieldData* geo_field_data = nullptr;
+    for (auto& fd : *raw_data.raw_->mutable_fields_data()) {
+        if (fd.field_id() == geo_fid.get()) {
+            geo_field_data = &fd;
+            break;
+        }
+    }
+    ASSERT_NE(geo_field_data, nullptr);
+    // Even rows sit inside the query polygon, odd rows far outside.
+    auto* geo_col = geo_field_data->mutable_scalars()->mutable_geometry_data();
+    geo_col->clear_data();
+    auto ctx = GEOS_init_r();
+    for (int64_t i = 0; i < N; i++) {
+        const char* wkt =
+            (i % 2 == 0) ? "POINT (0.5 0.5)" : "POINT (100.0 100.0)";
+        Geometry geom(ctx, wkt);
+        geo_col->add_data(geom.to_wkb_string());
+    }
+    GEOS_finish_r(ctx);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    expr::TypedExprPtr filter = std::make_shared<expr::GISFunctionFilterExpr>(
+        expr::ColumnInfo(geo_fid, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Within,
+        "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "test_rescore_gis_multi_batch", segment.get(), N, MAX_TIMESTAMP);
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    auto exec_context = exec::ExecContext(query_context.get());
+
+    std::vector<expr::TypedExprPtr> filters;
+    filters.emplace_back(filter);
+    auto expr_set = std::make_unique<exec::ExprSet>(filters, &exec_context);
+    exec::EvalCtx eval_ctx(&exec_context, expr_set.get());
+
+    // GIS must take the non-native fallback.
+    ASSERT_FALSE(expr_set->exprs()[0]->SupportOffsetInput());
+
+    auto bitset = exec::EvalNonNativeBoostFilterAllBatches(
+        &exec_context, expr_set.get(), eval_ctx, filter);
+
+    // The bitset must cover every active row, not just the first batch.
+    ASSERT_EQ(bitset.size(), N);
+    for (int64_t offset :
+         {int64_t(0), int64_t(1), int64_t(9000), int64_t(9001), N - 2, N - 1}) {
+        bool expected = (offset % 2 == 0);
+        ASSERT_EQ(bitset[offset], expected)
+            << "wrong filter bit at offset " << offset;
     }
 }

--- a/internal/core/src/rescores/Scorer.cpp
+++ b/internal/core/src/rescores/Scorer.cpp
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <optional>
 #include <random>
@@ -23,8 +25,43 @@
 #include "Utils.h"
 #include "log/Log.h"
 #include "rescores/Murmur3.h"
+#include "segcore/SegmentInterface.h"
 
 namespace milvus::rescores {
+
+namespace {
+
+// The out-of-bounds skip below fires once per batch_score call, and its
+// usual cause (text index lagging the vector index) is expected and
+// transient -- so during sustained lag an unthrottled warning would repeat
+// once per segment x query. Allow at most one warning per interval
+// process-wide, but never lose counts: calls whose warning is suppressed
+// fold their count into the next emitted one, so a sustained systemic
+// desync shows up as a large accumulated total rather than one stray line.
+//
+// Returns the total count to report (this call's plus everything suppressed
+// since the last emitted warning), or 0 if this call's warning is
+// suppressed.
+int64_t
+AccumulateOutOfBoundsForLog(int64_t out_of_bounds) {
+    constexpr int64_t kLogIntervalUs = 10'000'000;  // 10s
+    static std::atomic<int64_t> last_log_us{0};
+    static std::atomic<int64_t> suppressed_count{0};
+    auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                      std::chrono::steady_clock::now().time_since_epoch())
+                      .count();
+    auto last = last_log_us.load(std::memory_order_relaxed);
+    if (now_us - last >= kLogIntervalUs &&
+        last_log_us.compare_exchange_strong(
+            last, now_us, std::memory_order_relaxed)) {
+        return out_of_bounds +
+               suppressed_count.exchange(0, std::memory_order_relaxed);
+    }
+    suppressed_count.fetch_add(out_of_bounds, std::memory_order_relaxed);
+    return 0;
+}
+
+}  // namespace
 
 void
 WeightScorer::batch_score(milvus::OpContext* op_ctx,
@@ -48,9 +85,36 @@ WeightScorer::batch_score(milvus::OpContext* op_ctx,
                           const FixedVector<int32_t>& offsets,
                           const TargetBitmap& bitmap,
                           std::vector<std::optional<float>>& boost_scores) {
+    auto bitmap_size = bitmap.size();
+    size_t out_of_bounds = 0;
     for (auto i = 0; i < offsets.size(); i++) {
-        if (bitmap[offsets[i]] > 0) {
-            set_score(boost_scores[i], mode);
+        auto offset = offsets[i];
+        // Bounds check: offset must be within bitmap size.
+        // Race condition: text index may lag behind vector index,
+        // causing offsets to reference rows not yet in text index.
+        if (offset >= 0 && static_cast<size_t>(offset) < bitmap_size) {
+            if (bitmap[offset] > 0) {
+                set_score(boost_scores[i], mode);
+            }
+        } else {
+            // Out of bounds: treat as "no match" (don't apply boost), but
+            // count it -- a silent skip here once masked a short filter
+            // bitset, so make any bitmap/offset desync observable.
+            ++out_of_bounds;
+        }
+    }
+    if (out_of_bounds > 0) {
+        auto total = AccumulateOutOfBoundsForLog(out_of_bounds);
+        if (total > 0) {
+            LOG_WARN(
+                "WeightScorer::batch_score skipped {} offsets outside the "
+                "filter bitmap since the last report ({} of {} in this call, "
+                "bitmap size {}, segment {})",
+                total,
+                out_of_bounds,
+                offsets.size(),
+                bitmap_size,
+                segment != nullptr ? segment->get_segment_id() : -1);
         }
     }
 };
@@ -117,10 +181,37 @@ RandomScorer::batch_score(milvus::OpContext* op_ctx,
     target_offsets.reserve(offsets.size());
     idx.reserve(offsets.size());
 
+    auto bitmap_size = bitmap.size();
+    size_t out_of_bounds = 0;
     for (auto i = 0; i < offsets.size(); i++) {
-        if (bitmap[offsets[i]] > 0) {
-            target_offsets.push_back(static_cast<int64_t>(offsets[i]));
-            idx.push_back(i);
+        auto offset = offsets[i];
+        // Bounds check: offset must be within bitmap size.
+        // Race condition: text index may lag behind vector index,
+        // causing offsets to reference rows not yet in text index.
+        if (offset >= 0 && static_cast<size_t>(offset) < bitmap_size) {
+            if (bitmap[offset] > 0) {
+                target_offsets.push_back(static_cast<int64_t>(offset));
+                idx.push_back(i);
+            }
+        } else {
+            // Out of bounds: treat as "no match" (don't apply boost), but
+            // count it -- a silent skip here once masked a short filter
+            // bitset, so make any bitmap/offset desync observable.
+            ++out_of_bounds;
+        }
+    }
+    if (out_of_bounds > 0) {
+        auto total = AccumulateOutOfBoundsForLog(out_of_bounds);
+        if (total > 0) {
+            LOG_WARN(
+                "RandomScorer::batch_score skipped {} offsets outside the "
+                "filter bitmap since the last report ({} of {} in this call, "
+                "bitmap size {}, segment {})",
+                total,
+                out_of_bounds,
+                offsets.size(),
+                bitmap_size,
+                segment != nullptr ? segment->get_segment_id() : -1);
         }
     }
 


### PR DESCRIPTION
issue: #51485, #51501
pr: #51486

Backport of #51486, adapted to the 2.6 architecture. Three commits:

**1. Gate GIS filters out of the offset-input path.**
`PhyGISFunctionFilterExpr` slices only by its own batch cursor and never reads
the offset-input list, but inherited `SegmentExpr::SupportOffsetInput()`'s
default of `true` — so a GIS predicate on the native offset-input path
(iterative filter / rescore) returns rows misaligned to the requested offsets
(silent wrong results). Override it to `false` so the consumer takes its
correct non-native fallback. Carries the same standalone regression test
(`ExprTest.GISFilterDoesNotSupportOffsetInput`, red/green verified on master).

**2. Cover all expression batches in the boost rescore non-native fallback
(+ scorer bounds checks).**
2.6 has no `BoostScoreRunner` / chunked `boost_score` C-API — the fallback
lives inline in `PhyRescoresNode::GetOutput`, and it called `ExprSet::Eval`
exactly once. Each `Eval` only advances one internal batch (8192 rows), while
the topk offsets can reference any row of the segment: offsets past the first
batch silently lost their boost (`WeightScorer`) or read out of bounds
(`RandomScorer`). The loop is extracted into
`EvalNonNativeBoostFilterAllBatches` (unit-testable), accumulating batches
until the bitset covers all active rows and folding NULL rows to no-boost.
On 2.6 **both** `WeightScorer` and `RandomScorer` `TargetBitmap` overloads
lacked the bounds check (master's `WeightScorer` already had it) — both are
guarded now.

**3. Advance GIS filter cursors on growing segments during conjunct skip.**
`MoveCursor()` was a no-op on growing segments, so a conjunct short-circuit
(`SkipFollowingExprs`) desynchronized the GIS cursor from its siblings and
later batches ANDed the wrong rows. 2.6 adaptation: gate on
`SegmentExpr::CanUseIndex()` (2.6 has no `UseIndexCursor` helper); growing
interim R-Tree segments advance the global index position plus the data
cursor, mirroring `EvalForIndexSegment`.

The per-offset-chunk re-scan fix from master (#51486 commit 4) does not apply:
2.6 has no chunked `boost_score` C-API, the rescore fallback is single-shot.

## Test

- `ExprTest.GISFilterDoesNotSupportOffsetInput` — contract pin.
- `RescoresNode.NonNativeBoostFilterBitsetCoversAllBatches` — GIS filter over
  N=10000 rows (> one expression batch), asserts filter bits past row 8192.
- `WeightScorerTest` / `RandomScorerTest`
  `BatchScoreTargetBitmapOutOfBoundsOffsets` — out-of-range offsets are
  skipped, no OOB access.
- `ExprTest.GISFilterGrowingConjunctSkipKeepsCursorInSync` (+`Index` variant) —
  20000-row growing segment, `age >= 8192 AND st_within(...)` whose first
  batch matches nothing; asserts no cursor desync on the raw-data and interim
  R-Tree index paths.
