### PR TITLE
fix: [3.0] gate GIS filters out of the offset-input path

### DIFF
--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -675,5 +675,49 @@ OptimizeCompiledExprs(ExecContext* context, const std::vector<ExprPtr>& exprs) {
     milvus::monitor::internal_core_optimize_expr_latency.Observe(cost / 1000);
 }
 
+TargetBitmap
+EvalExprSetOverAllBatches(ExprSet& expr_set,
+                          EvalCtx& eval_ctx,
+                          int64_t total_rows,
+                          const char* what) {
+    std::vector<VectorPtr> results;
+    TargetBitmap bitset;
+    TargetBitmap valid_bitset;
+    while (static_cast<int64_t>(bitset.size()) < total_rows) {
+        expr_set.Eval(0, 1, true, eval_ctx, results);
+
+        AssertInfo(results.size() == 1 && results[0] != nullptr,
+                   "{}: filter expr returned null result",
+                   what);
+        auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
+        if (col_vec == nullptr) {
+            ThrowInfo(
+                UnexpectedError, "{}: result should be ColumnVector", what);
+        }
+        if (!col_vec->IsBitmap()) {
+            ThrowInfo(UnexpectedError, "{}: result should be bitmap", what);
+        }
+        auto col_vec_size = col_vec->size();
+        AssertInfo(col_vec_size > 0,
+                   "{}: filter expr returned empty batch after {} of {} rows",
+                   what,
+                   bitset.size(),
+                   total_rows);
+        TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
+        bitset.append(view);
+        TargetBitmapView valid_view(col_vec->GetValidRawData(), col_vec_size);
+        valid_bitset.append(valid_view);
+    }
+    AssertInfo(static_cast<int64_t>(bitset.size()) == total_rows,
+               "{}: filter bitset size {} must match total rows {}",
+               what,
+               bitset.size(),
+               total_rows);
+    // Fold UNKNOWN (NULL) into FALSE explicitly (data &= valid) instead of
+    // relying on the convention that UNKNOWN rows carry data=0.
+    bitset.inplace_and(valid_bitset, bitset.size());
+    return bitset;
+}
+
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -2774,5 +2774,17 @@ class ExprSet {
 expr::TypedExprPtr
 CreateTTLFieldFilterExpression(QueryContext* query_context);
 
+// Evaluate expr_set batch by batch until the accumulated result covers
+// total_rows, then fold UNKNOWN (NULL) into FALSE (data &= valid) so a
+// consumer that reads only the data bits is null-rejecting by construction.
+// Shared by the whole-range consumers of expressions that cannot take offset
+// input: PhyIterativeFilterNode's non-native branch and boost scoring's
+// non-native filter fallback. `what` names the caller in error messages.
+TargetBitmap
+EvalExprSetOverAllBatches(ExprSet& expr_set,
+                          EvalCtx& eval_ctx,
+                          int64_t total_rows,
+                          const char* what);
+
 }  //namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/ExprGISMiscTest.cpp
+++ b/internal/core/src/exec/expression/ExprGISMiscTest.cpp
@@ -41,6 +41,7 @@
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
 #include "exec/QueryContext.h"
+#include "exec/expression/Expr.h"
 #include "expr/ITypeExpr.h"
 #include "geos_c.h"
 #include "gtest/gtest.h"
@@ -881,4 +882,187 @@ TEST_P(ExprTest, TestFloatingPointModulo) {
         }
         ASSERT_EQ(final.count(), expected_count);
     }
+}
+
+// Regression for the GIS offset-input contract. PhyGISFunctionFilterExpr slices
+// only by its own batch cursor (GetNextBatchSize) and never reads the
+// offset-input list, but the SegmentExpr base defaults SupportOffsetInput() to
+// true. Left at the default, the native offset-input path (IterativeFilterNode
+// / rescore) would feed a sparse offset list into an Eval that ignores it and
+// return misaligned rows -- a silent wrong-results bug on any GIS predicate
+// reached through iterative filtering. The override must report false so the
+// consumer takes its non-native fallback. This pins the contract so a future
+// change cannot regress it.
+TEST(ExprTest, GISFilterDoesNotSupportOffsetInput) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto geo_fid = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+
+    const int64_t N = 256;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
+
+    // Compile a bare GIS leaf into its physical expr and inspect the contract.
+    milvus::expr::TypedExprPtr leaf =
+        std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+            milvus::expr::ColumnInfo(geo_fid, DataType::GEOMETRY),
+            proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+            "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))");
+    std::vector<milvus::expr::TypedExprPtr> filters{leaf};
+
+    auto query_context = std::make_shared<milvus::exec::QueryContext>(
+        DEAFULT_QUERY_ID, seg.get(), N, MAX_TIMESTAMP);
+    milvus::exec::ExecContext exec_context(query_context.get());
+    milvus::exec::ExprSet expr_set(filters, &exec_context);
+
+    ASSERT_EQ(expr_set.exprs().size(), 1u);
+    EXPECT_FALSE(expr_set.exprs()[0]->SupportOffsetInput());
+}
+
+namespace {
+
+// Build a growing segment where `age` equals the row index and the geometry
+// sits inside the query polygon only for rows [8192, 16384), then evaluate
+// `age >= 8192 AND st_within(geo, ...)`. The first expression batch [0, 8192)
+// leaves the AND with no active rows, so the conjunct skips the GIS
+// expression through MoveCursor(); a skipped batch that does not advance the
+// GIS cursor makes every later batch evaluate the wrong rows.
+void
+RunGrowingConjunctSkipTest(bool with_rtree_index) {
+    using namespace milvus;
+    using namespace milvus::segcore;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto age_fid = schema->AddDebugField("age", DataType::INT64);
+    auto geo_fid = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+
+    IndexMetaPtr index_meta = nullptr;
+    if (with_rtree_index) {
+        std::map<std::string, std::string> index_params = {
+            {"index_type", "RTREE"}};
+        std::map<std::string, std::string> type_params;
+        FieldIndexMeta geo_index_meta(
+            geo_fid, std::move(index_params), std::move(type_params));
+        std::map<FieldId, FieldIndexMeta> field_map = {
+            {geo_fid, geo_index_meta}};
+        index_meta =
+            std::make_shared<CollectionIndexMeta>(100000, std::move(field_map));
+    }
+
+    const int64_t N = 20000;  // three expression batches of 8192
+    const int64_t kBatch = 8192;
+    auto raw_data = DataGen(schema, N);
+
+    proto::schema::FieldData* age_field_data = nullptr;
+    proto::schema::FieldData* geo_field_data = nullptr;
+    for (auto& fd : *raw_data.raw_->mutable_fields_data()) {
+        if (fd.field_id() == age_fid.get()) {
+            age_field_data = &fd;
+        } else if (fd.field_id() == geo_fid.get()) {
+            geo_field_data = &fd;
+        }
+    }
+    ASSERT_NE(age_field_data, nullptr);
+    ASSERT_NE(geo_field_data, nullptr);
+
+    auto* age_col =
+        age_field_data->mutable_scalars()->mutable_long_data()->mutable_data();
+    for (int64_t i = 0; i < N; ++i) {
+        age_col->at(i) = i;
+    }
+
+    auto* geo_col = geo_field_data->mutable_scalars()->mutable_geometry_data();
+    geo_col->clear_data();
+    auto ctx = GEOS_init_r();
+    for (int64_t i = 0; i < N; ++i) {
+        const char* wkt = (i >= kBatch && i < 2 * kBatch)
+                              ? "POINT (0.5 0.5)"
+                              : "POINT (100.0 100.0)";
+        Geometry geom(ctx, wkt);
+        geo_col->add_data(geom.to_wkb_string());
+    }
+    GEOS_finish_r(ctx);
+
+    auto config = SegcoreConfig::default_config();
+    config.set_enable_interim_segment_index(with_rtree_index);
+    auto seg = CreateGrowingSegment(schema, index_meta, 1, config);
+    seg->PreInsert(N);
+    seg->Insert(0,
+                N,
+                raw_data.row_ids_.data(),
+                raw_data.timestamps_.data(),
+                raw_data.raw_);
+    ASSERT_EQ(seg->HasIndex(geo_fid), with_rtree_index);
+
+    {
+        // HasIndex() alone does not guarantee the ScalarIndex exec path —
+        // DetermineExecPath() silently falls back to RawData when the pin
+        // comes up empty (Expr.h). Assert the resolved path directly so the
+        // with_rtree_index variant fails loudly instead of silently
+        // degrading into a duplicate of the raw-data variant.
+        milvus::expr::TypedExprPtr gis_leaf =
+            std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+                milvus::expr::ColumnInfo(geo_fid, DataType::GEOMETRY),
+                proto::plan::GISFunctionFilterExpr_GISOp_Within,
+                "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+        std::vector<milvus::expr::TypedExprPtr> leaf_filters{gis_leaf};
+        auto leaf_query_context = std::make_shared<milvus::exec::QueryContext>(
+            DEAFULT_QUERY_ID, seg.get(), N, MAX_TIMESTAMP);
+        milvus::exec::ExecContext leaf_exec_context(leaf_query_context.get());
+        milvus::exec::ExprSet leaf_expr_set(leaf_filters, &leaf_exec_context);
+        ASSERT_EQ(leaf_expr_set.exprs().size(), 1u);
+        auto segment_expr =
+            std::dynamic_pointer_cast<milvus::exec::SegmentExpr>(
+                leaf_expr_set.exprs()[0]);
+        ASSERT_NE(segment_expr, nullptr);
+        ASSERT_EQ(segment_expr->UseIndexCursor(), with_rtree_index)
+            << "GIS expr resolved to the wrong exec path (with_rtree_index: "
+            << with_rtree_index << ")";
+    }
+
+    proto::plan::GenericValue val;
+    val.set_int64_val(kBatch);
+    auto age_expr = std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+        milvus::expr::ColumnInfo(age_fid, DataType::INT64),
+        proto::plan::OpType::GreaterEqual,
+        val);
+    auto gis_expr = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_fid, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Within,
+        "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+    auto filter = std::make_shared<milvus::expr::LogicalBinaryExpr>(
+        milvus::expr::LogicalBinaryExpr::OpType::And, age_expr, gis_expr);
+    auto plan = std::make_shared<milvus::plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, filter);
+
+    auto final =
+        milvus::query::ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
+    ASSERT_EQ(final.size(), N);
+    for (int64_t i = 0; i < N; ++i) {
+        bool expected = (i >= kBatch && i < 2 * kBatch);
+        ASSERT_EQ(final[i], expected)
+            << "cursor desync at row " << i
+            << " (with_rtree_index: " << with_rtree_index << ")";
+    }
+}
+
+}  // namespace
+
+// Raw-data path: growing segment without any geometry index.
+TEST(ExprTest, GISFilterGrowingConjunctSkipKeepsCursorInSync) {
+    RunGrowingConjunctSkipTest(false);
+}
+
+// Interim-index path: growing segment with an R-Tree interim index, where
+// EvalForIndexSegment advances the global index position together with the
+// data cursor and MoveCursor() must do the same on a skipped batch.
+TEST(ExprTest, GISFilterGrowingIndexConjunctSkipKeepsCursorInSync) {
+    RunGrowingConjunctSkipTest(true);
 }

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -13,6 +13,7 @@
 
 #include <fmt/core.h>
 #include <stdint.h>
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <string>
@@ -74,11 +75,39 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
         return fmt::format("{}", expr_->ToString());
     }
 
+    // The GIS filter slices by its own batch cursor (GetNextBatchSize) and never
+    // reads the offset-input list, so it cannot serve the offset-input
+    // (iterative-filter / rescore) path. Report false so IterativeFilterNode
+    // takes its non-native fallback instead of feeding offsets into Eval.
+    bool
+    SupportOffsetInput() override {
+        return false;
+    }
+
+    // A skipped batch (conjunct short-circuit via SkipFollowingExprs) must
+    // still advance this expression's cursors, otherwise it desynchronizes
+    // from its sibling expressions and later batches evaluate the wrong rows.
+    // The base MoveCursor() covers every case except the growing interim-index
+    // path: MoveCursorForIndex() asserts sealed-only, while
+    // EvalForIndexSegment() on a growing segment advances the global index
+    // position together with the data cursor -- mirror that here.
+    // Unlike the base implementation, MoveCursorForData() is called without a
+    // HasFieldData() guard: this exec path already walks data chunks
+    // unconditionally (EvalForIndexSegment), and with no field data
+    // num_data_chunk_ is 0, making the call a no-op -- the omission is
+    // intentional, not an oversight.
     void
     MoveCursor() override {
-        if (segment_->type() == SegmentType::Sealed) {
-            SegmentExpr::MoveCursor();
+        if (has_offset_input_ || execute_all_at_once_) {
+            return;
         }
+        if (UseIndexCursor() && segment_->type() != SegmentType::Sealed) {
+            current_index_chunk_pos_ +=
+                std::min(active_count_ - current_index_chunk_pos_, batch_size_);
+            MoveCursorForData();
+            return;
+        }
+        SegmentExpr::MoveCursor();
     }
 
  private:

--- a/internal/core/src/exec/operator/IterativeFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeFilterNode.cpp
@@ -113,38 +113,12 @@ PhyIterativeFilterNode::GetOutput() {
     // get bitset of whole segment first
     if (!is_native_supported_) {
         EvalCtx eval_ctx(operator_context_->get_exec_context());
-
-        TargetBitmap valid_bitset;
-        while (num_processed_rows_ < need_process_rows_) {
-            exprs_->Eval(0, 1, true, eval_ctx, results_);
-
-            AssertInfo(
-                results_.size() == 1 && results_[0] != nullptr,
-                "PhyIterativeFilterNode result size should be size one and not "
-                "be nullptr");
-
-            if (auto col_vec =
-                    std::dynamic_pointer_cast<ColumnVector>(results_[0])) {
-                if (col_vec->IsBitmap()) {
-                    auto col_vec_size = col_vec->size();
-                    TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
-                    bitset.append(view);
-                    TargetBitmapView valid_view(col_vec->GetValidRawData(),
-                                                col_vec_size);
-                    valid_bitset.append(valid_view);
-                    num_processed_rows_ += col_vec_size;
-                } else {
-                    ThrowInfo(UnexpectedError,
-                              "PhyIterativeFilterNode result should be bitmap");
-                }
-            } else {
-                ThrowInfo(
-                    UnexpectedError,
-                    "PhyIterativeFilterNode result should be ColumnVector");
-            }
-        }
-        Assert(bitset.size() == need_process_rows_);
-        Assert(valid_bitset.size() == need_process_rows_);
+        // Rows are included below on the data bit alone; the helper folds
+        // UNKNOWN into FALSE (data &= valid), which is what makes this
+        // operator a null-rejecting consumer by construction.
+        bitset = EvalExprSetOverAllBatches(
+            *exprs_, eval_ctx, need_process_rows_, "PhyIterativeFilterNode");
+        num_processed_rows_ = need_process_rows_;
     }
     if (search_result.vector_iterators_.has_value()) {
         AssertInfo(search_result.vector_iterators_.value().size() ==
@@ -226,12 +200,22 @@ PhyIterativeFilterNode::GetOutput() {
                         auto [doc_id, elem_idx] =
                             array_offsets->ElementIDToRowID(element_id);
                         element_to_doc_mapping.push_back({doc_id, elem_idx});
-                        unique_doc_ids.insert(doc_id);
                     }
 
-                    doc_offsets.reserve(unique_doc_ids.size());
-                    for (auto doc_id : unique_doc_ids) {
-                        doc_offsets.emplace_back(static_cast<int32_t>(doc_id));
+                    // The deduplicated doc offsets feed only the native
+                    // offset-input Eval below; the non-native fallback
+                    // indexes the segment-wide bitset by doc id directly
+                    // and never reads eval_offsets.
+                    if (is_native_supported_) {
+                        for (const auto& [doc_id, elem_idx] :
+                             element_to_doc_mapping) {
+                            unique_doc_ids.insert(doc_id);
+                        }
+                        doc_offsets.reserve(unique_doc_ids.size());
+                        for (auto doc_id : unique_doc_ids) {
+                            doc_offsets.emplace_back(
+                                static_cast<int32_t>(doc_id));
+                        }
                     }
                     eval_offsets = &doc_offsets;
                 } else {
@@ -294,8 +278,30 @@ PhyIterativeFilterNode::GetOutput() {
                             }
                         }
                     }
+                } else if (element_level) {
+                    // element_level_ is a property of the placeholder, not of
+                    // the filter expression, so an element-level search whose
+                    // filter cannot consume offset input (text match, GIS)
+                    // legitimately reaches this fallback. The segment-wide
+                    // bitset is indexed by doc offset and already holds the
+                    // verdict for every doc, so no doc_eval_cache is needed --
+                    // map each element back to its doc and test that bit.
+                    for (size_t i = 0; i < offsets.size(); ++i) {
+                        auto [doc_id, elem_idx] = element_to_doc_mapping[i];
+                        if (bitset[doc_id] > 0) {
+                            topk_binsert(search_result,
+                                         nq_index * unity_topk,
+                                         topk,
+                                         large_is_better,
+                                         distances[i],
+                                         doc_id,
+                                         elem_idx);
+                            if (topk == unity_topk) {
+                                break;
+                            }
+                        }
+                    }
                 } else {
-                    Assert(!element_level);
                     for (auto i = 0; i < offsets.size(); ++i) {
                         if (bitset[offsets[i]] > 0) {
                             topk_binsert(search_result,

--- a/internal/core/src/rescores/BoostScoreRunner.cpp
+++ b/internal/core/src/rescores/BoostScoreRunner.cpp
@@ -39,7 +39,71 @@ CopyScoresToBuffers(const std::vector<std::optional<float>>& scores,
     }
 }
 
+std::unique_ptr<exec::ExprSet>
+BuildFilterExprSet(const expr::TypedExprPtr& filter,
+                   exec::ExecContext* exec_context) {
+    std::vector<expr::TypedExprPtr> filters;
+    filters.emplace_back(filter);
+    // Boost scoring reads only the data bits of the filter output — an
+    // UNKNOWN (NULL) row never receives a boost, exactly like FALSE. 3.0's
+    // ExprSet has no null-rejecting flag (master-only optimization hint);
+    // the explicit valid-bitmap folds on both scoring branches provide the
+    // same guarantee.
+    return std::make_unique<exec::ExprSet>(filters, exec_context);
+}
+
+bool
+AllSupportOffsetInput(const exec::ExprSet& expr_set) {
+    for (const auto& expr : expr_set.exprs()) {
+        if (!expr->SupportOffsetInput()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Without offset-input support each Eval only advances the expression by one
+// internal batch (DEFAULT_EXEC_EVAL_EXPR_BATCH_SIZE rows), while the scorer
+// offsets may reference any row of the segment. The shared helper
+// accumulates every batch so the bitset covers all active rows and folds
+// UNKNOWN (NULL) into FALSE so null rows never receive a boost, matching
+// PhyIterativeFilterNode's handling.
+TargetBitmap
+EvalFilterOverAllBatches(exec::ExecContext* exec_context,
+                         exec::ExprSet& expr_set) {
+    exec::EvalCtx eval_ctx(exec_context);
+    auto active_count = exec_context->get_query_context()->get_active_count();
+    return exec::EvalExprSetOverAllBatches(
+        expr_set, eval_ctx, active_count, "ComputeScorerScores");
+}
+
 }  // namespace
+
+std::optional<TargetBitmap>
+ComputeNonNativeFilterBitset(exec::ExecContext* exec_context,
+                             const std::shared_ptr<Scorer>& scorer,
+                             std::unique_ptr<exec::ExprSet>* out_expr_set) {
+    auto filter = scorer->filter();
+    if (!filter) {
+        return std::nullopt;
+    }
+    auto expr_set = BuildFilterExprSet(filter, exec_context);
+    if (AllSupportOffsetInput(*expr_set)) {
+        // Native filter: no whole-segment bitset, but hand the compiled
+        // expressions back so per-chunk scoring does not rebuild them.
+        if (out_expr_set != nullptr) {
+            *out_expr_set = std::move(expr_set);
+        }
+        return std::nullopt;
+    }
+    auto bitset = EvalFilterOverAllBatches(exec_context, *expr_set);
+    // The non-native path is fully answered by the bitset; the expressions
+    // have been advanced to the end of the segment and must not be reused.
+    if (out_expr_set != nullptr) {
+        out_expr_set->reset();
+    }
+    return bitset;
+}
 
 void
 ComputeScorerScores(exec::ExecContext* exec_context,
@@ -47,7 +111,9 @@ ComputeScorerScores(exec::ExecContext* exec_context,
                     const segcore::SegmentInternalInterface* segment,
                     const std::shared_ptr<Scorer>& scorer,
                     FixedVector<int32_t>& offsets,
-                    std::vector<std::optional<float>>& output_scores) {
+                    std::vector<std::optional<float>>& output_scores,
+                    const TargetBitmap* filter_bitset,
+                    exec::ExprSet* prepared_expr_set) {
     AssertInfo(output_scores.size() == offsets.size(),
                "scorer score output size {} must match offsets size {}",
                output_scores.size(),
@@ -61,20 +127,25 @@ ComputeScorerScores(exec::ExecContext* exec_context,
         return;
     }
 
-    std::vector<expr::TypedExprPtr> filters;
-    filters.emplace_back(filter);
-    auto expr_set = std::make_unique<exec::ExprSet>(filters, exec_context);
-    std::vector<VectorPtr> results;
-    exec::EvalCtx eval_ctx(exec_context);
-
-    const auto& exprs = expr_set->exprs();
-    bool is_native_supported = true;
-    for (const auto& expr : exprs) {
-        is_native_supported =
-            (is_native_supported && (expr->SupportOffsetInput()));
+    if (filter_bitset != nullptr) {
+        scorer->batch_score(op_context,
+                            segment,
+                            function_mode,
+                            offsets,
+                            *filter_bitset,
+                            output_scores);
+        return;
     }
 
-    if (is_native_supported) {
+    std::unique_ptr<exec::ExprSet> owned_expr_set;
+    if (prepared_expr_set == nullptr) {
+        owned_expr_set = BuildFilterExprSet(filter, exec_context);
+        prepared_expr_set = owned_expr_set.get();
+    }
+    auto& expr_set = prepared_expr_set;
+    if (AllSupportOffsetInput(*expr_set)) {
+        std::vector<VectorPtr> results;
+        exec::EvalCtx eval_ctx(exec_context);
         eval_ctx.set_offset_input(&offsets);
         expr_set->Eval(0, 1, true, eval_ctx, results);
 
@@ -90,6 +161,12 @@ ComputeScorerScores(exec::ExecContext* exec_context,
                    filter->ToString());
         auto col_vec_size = col_vec->size();
         TargetBitmapView bitsetview(col_vec->GetRawData(), col_vec_size);
+        // Fold UNKNOWN (NULL) into FALSE (data &= valid) so a null row
+        // never receives a boost, keeping NULL policy identical on the
+        // native and non-native branches (PhyIterativeFilterNode folds on
+        // both of its branches too).
+        TargetBitmapView validview(col_vec->GetValidRawData(), col_vec_size);
+        bitsetview.inplace_and(validview, col_vec_size);
         scorer->batch_score(op_context,
                             segment,
                             function_mode,
@@ -97,21 +174,7 @@ ComputeScorerScores(exec::ExecContext* exec_context,
                             bitsetview,
                             output_scores);
     } else {
-        expr_set->Eval(0, 1, true, eval_ctx, results);
-
-        AssertInfo(!results.empty() && results[0] != nullptr,
-                   "ComputeScorerScores: filter expr returned null result, "
-                   "filter: {}",
-                   filter->ToString());
-        auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
-        AssertInfo(col_vec != nullptr,
-                   "ComputeScorerScores: failed to cast result to "
-                   "ColumnVector, filter: {}",
-                   filter->ToString());
-        TargetBitmap bitset;
-        auto col_vec_size = col_vec->size();
-        TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
-        bitset.append(view);
+        auto bitset = EvalFilterOverAllBatches(exec_context, *expr_set);
         scorer->batch_score(
             op_context, segment, function_mode, offsets, bitset, output_scores);
     }
@@ -124,10 +187,18 @@ ComputeScorerScores(exec::ExecContext* exec_context,
                     const std::shared_ptr<Scorer>& scorer,
                     FixedVector<int32_t>& offsets,
                     float* output_scores,
-                    bool* output_has_score) {
+                    bool* output_has_score,
+                    const TargetBitmap* filter_bitset,
+                    exec::ExprSet* prepared_expr_set) {
     std::vector<std::optional<float>> scores(offsets.size());
-    ComputeScorerScores(
-        exec_context, op_context, segment, scorer, offsets, scores);
+    ComputeScorerScores(exec_context,
+                        op_context,
+                        segment,
+                        scorer,
+                        offsets,
+                        scores,
+                        filter_bitset,
+                        prepared_expr_set);
     CopyScoresToBuffers(scores, output_scores, output_has_score);
 }
 

--- a/internal/core/src/rescores/BoostScoreRunner.h
+++ b/internal/core/src/rescores/BoostScoreRunner.h
@@ -28,17 +28,48 @@
 
 namespace milvus::exec {
 class ExecContext;
-}
+class ExprSet;
+}  // namespace milvus::exec
 
 namespace milvus::rescores {
 
+// Evaluate the scorer's filter over the whole segment when the filter cannot
+// consume offset input (text match, GIS, ...). Returns std::nullopt when the
+// scorer has no filter or when every filter expression supports offset input
+// natively -- ComputeScorerScores then evaluates the filter against the
+// offsets it receives. UNKNOWN (NULL) rows are folded to FALSE.
+//
+// Callers that score multiple offset chunks against one scorer must compute
+// this once and pass it to every ComputeScorerScores call; evaluating inside
+// the per-chunk call would re-scan the whole segment once per chunk.
+//
+// out_expr_set: optional sink for the compiled filter expressions. Deciding
+// native-vs-non-native requires compiling the filter, which also pins scalar
+// indexes; handing the result back lets the caller pass it to every
+// ComputeScorerScores call instead of each of them compiling its own. Reuse is
+// safe because SetHasOffsetInput() is reset from the arguments on every Eval
+// and MoveCursor() is a no-op while offset input is set, so each Eval is
+// self-contained on the offsets it receives.
+std::optional<TargetBitmap>
+ComputeNonNativeFilterBitset(
+    exec::ExecContext* exec_context,
+    const std::shared_ptr<Scorer>& scorer,
+    std::unique_ptr<exec::ExprSet>* out_expr_set = nullptr);
+
+// filter_bitset: whole-segment filter result from
+// ComputeNonNativeFilterBitset(); pass nullptr to let this call evaluate the
+// filter itself (single-shot callers).
+// prepared_expr_set: compiled filter from ComputeNonNativeFilterBitset()'s
+// out_expr_set; pass nullptr to compile the filter here.
 void
 ComputeScorerScores(exec::ExecContext* exec_context,
                     OpContext* op_context,
                     const segcore::SegmentInternalInterface* segment,
                     const std::shared_ptr<Scorer>& scorer,
                     FixedVector<int32_t>& offsets,
-                    std::vector<std::optional<float>>& output_scores);
+                    std::vector<std::optional<float>>& output_scores,
+                    const TargetBitmap* filter_bitset = nullptr,
+                    exec::ExprSet* prepared_expr_set = nullptr);
 
 void
 ComputeScorerScores(exec::ExecContext* exec_context,
@@ -47,7 +78,9 @@ ComputeScorerScores(exec::ExecContext* exec_context,
                     const std::shared_ptr<Scorer>& scorer,
                     FixedVector<int32_t>& offsets,
                     float* output_scores,
-                    bool* output_has_score);
+                    bool* output_has_score,
+                    const TargetBitmap* filter_bitset = nullptr,
+                    exec::ExprSet* prepared_expr_set = nullptr);
 
 void
 ComputeFunctionScores(exec::ExecContext* exec_context,

--- a/internal/core/src/rescores/Scorer.cpp
+++ b/internal/core/src/rescores/Scorer.cpp
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -23,11 +25,47 @@
 #include "Utils.h"
 #include "bitset/bitset.h"
 #include "common/Types.h"
+#include "log/Log.h"
 #include "pb/schema.pb.h"
 #include "rescores/Murmur3.h"
 #include "segcore/SegmentInterface.h"
 
 namespace milvus::rescores {
+
+namespace {
+
+// The out-of-bounds skip below fires once per batch_score call, i.e. once
+// per offset chunk, and its usual cause (text index lagging the vector
+// index) is expected and transient -- so during sustained lag an unthrottled
+// warning would repeat once per chunk x segment x query. Allow at most one
+// warning per interval process-wide, but never lose counts: calls whose
+// warning is suppressed fold their count into the next emitted one, so a
+// sustained systemic desync shows up as a large accumulated total rather
+// than one stray line.
+//
+// Returns the total count to report (this call's plus everything suppressed
+// since the last emitted warning), or 0 if this call's warning is
+// suppressed.
+int64_t
+AccumulateOutOfBoundsForLog(int64_t out_of_bounds) {
+    constexpr int64_t kLogIntervalUs = 10'000'000;  // 10s
+    static std::atomic<int64_t> last_log_us{0};
+    static std::atomic<int64_t> suppressed_count{0};
+    auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                      std::chrono::steady_clock::now().time_since_epoch())
+                      .count();
+    auto last = last_log_us.load(std::memory_order_relaxed);
+    if (now_us - last >= kLogIntervalUs &&
+        last_log_us.compare_exchange_strong(
+            last, now_us, std::memory_order_relaxed)) {
+        return out_of_bounds +
+               suppressed_count.exchange(0, std::memory_order_relaxed);
+    }
+    suppressed_count.fetch_add(out_of_bounds, std::memory_order_relaxed);
+    return 0;
+}
+
+}  // namespace
 
 void
 WeightScorer::batch_score(milvus::OpContext* op_ctx,
@@ -52,6 +90,7 @@ WeightScorer::batch_score(milvus::OpContext* op_ctx,
                           const TargetBitmap& bitmap,
                           std::vector<std::optional<float>>& boost_scores) {
     auto bitmap_size = bitmap.size();
+    size_t out_of_bounds = 0;
     for (auto i = 0; i < offsets.size(); i++) {
         auto offset = offsets[i];
         // Bounds check: offset must be within bitmap size.
@@ -61,8 +100,26 @@ WeightScorer::batch_score(milvus::OpContext* op_ctx,
             if (bitmap[offset] > 0) {
                 set_score(boost_scores[i], mode);
             }
+        } else {
+            // Out of bounds: treat as "no match" (don't apply boost), but
+            // count it -- a silent skip here once masked a short filter
+            // bitset, so make any bitmap/offset desync observable.
+            ++out_of_bounds;
         }
-        // If offset is out of bounds, treat as "no match" (don't apply boost)
+    }
+    if (out_of_bounds > 0) {
+        auto total = AccumulateOutOfBoundsForLog(out_of_bounds);
+        if (total > 0) {
+            LOG_WARN(
+                "WeightScorer::batch_score skipped {} offsets outside the "
+                "filter bitmap since the last report ({} of {} in this call, "
+                "bitmap size {}, segment {})",
+                total,
+                out_of_bounds,
+                offsets.size(),
+                bitmap_size,
+                segment != nullptr ? segment->get_segment_id() : -1);
+        }
     }
 };
 
@@ -128,10 +185,37 @@ RandomScorer::batch_score(milvus::OpContext* op_ctx,
     target_offsets.reserve(offsets.size());
     idx.reserve(offsets.size());
 
+    auto bitmap_size = bitmap.size();
+    size_t out_of_bounds = 0;
     for (auto i = 0; i < offsets.size(); i++) {
-        if (bitmap[offsets[i]] > 0) {
-            target_offsets.push_back(static_cast<int64_t>(offsets[i]));
-            idx.push_back(i);
+        auto offset = offsets[i];
+        // Bounds check: offset must be within bitmap size.
+        // Race condition: text index may lag behind vector index,
+        // causing offsets to reference rows not yet in text index.
+        if (offset >= 0 && static_cast<size_t>(offset) < bitmap_size) {
+            if (bitmap[offset] > 0) {
+                target_offsets.push_back(static_cast<int64_t>(offset));
+                idx.push_back(i);
+            }
+        } else {
+            // Out of bounds: treat as "no match" (don't apply boost), but
+            // count it -- a silent skip here once masked a short filter
+            // bitset, so make any bitmap/offset desync observable.
+            ++out_of_bounds;
+        }
+    }
+    if (out_of_bounds > 0) {
+        auto total = AccumulateOutOfBoundsForLog(out_of_bounds);
+        if (total > 0) {
+            LOG_WARN(
+                "RandomScorer::batch_score skipped {} offsets outside the "
+                "filter bitmap since the last report ({} of {} in this call, "
+                "bitmap size {}, segment {})",
+                total,
+                out_of_bounds,
+                offsets.size(),
+                bitmap_size,
+                segment != nullptr ? segment->get_segment_id() : -1);
         }
     }
 

--- a/internal/core/src/segcore/boost_score.cpp
+++ b/internal/core/src/segcore/boost_score.cpp
@@ -19,6 +19,7 @@
 #include <arrow/array/array_primitive.h>
 #include <arrow/c/bridge.h>
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <vector>
@@ -29,6 +30,7 @@
 #include "common/OpContext.h"
 #include "common/Types.h"
 #include "exec/QueryContext.h"
+#include "exec/expression/Expr.h"
 #include "futures/Executor.h"
 #include "futures/Future.h"
 #include "pb/plan.pb.h"
@@ -139,6 +141,39 @@ ComputeScorerScoresOnPreparedChunks(
     float* const* output_score_chunks,
     bool* const* output_has_score_chunks,
     const folly::CancellationToken& cancel_token = folly::CancellationToken()) {
+    // Observe a pre-cancelled request before doing anything at all --
+    // including the all-empty fast path below, which the per-chunk loop's
+    // cancellation check used to cover before the fast path existed.
+    milvus::futures::throwIfCancelled(cancel_token);
+
+    // Nothing to score: skip the whole setup. Bailing out here matters for a
+    // non-native filter (text match, GIS) -- otherwise it would scan the whole
+    // segment to build a bitset no chunk ever consumes.
+    auto has_offsets = std::any_of(
+        scorer_offset_chunks.begin(),
+        scorer_offset_chunks.end(),
+        [](const auto& scorer_offsets) { return !scorer_offsets.empty(); });
+    if (!has_offsets) {
+        return;
+    }
+
+    // Preflight before the potentially expensive whole-segment filter
+    // evaluation below (ComputeNonNativeFilterBitset): catch a null
+    // per-chunk output pointer before doing any work rather than midway
+    // through the chunk loop.
+    for (auto chunk_idx = 0; chunk_idx < scorer_offset_chunks.size();
+         ++chunk_idx) {
+        if (scorer_offset_chunks[chunk_idx].empty()) {
+            continue;
+        }
+        AssertInfo(output_score_chunks[chunk_idx] != nullptr,
+                   "output score chunk {} is null",
+                   chunk_idx);
+        AssertInfo(output_has_score_chunks[chunk_idx] != nullptr,
+                   "output has score chunk {} is null",
+                   chunk_idx);
+    }
+
     auto active_count = segment->get_active_count(timestamp);
     auto query_context = std::make_shared<milvus::exec::QueryContext>(
         DEAFULT_QUERY_ID,
@@ -159,6 +194,16 @@ ComputeScorerScoresOnPreparedChunks(
     query_context->set_op_context(&op_context);
     auto exec_context = milvus::exec::ExecContext(query_context.get());
 
+    // A filter that cannot consume offset input (text match, GIS) is
+    // evaluated over the whole segment; do that once here instead of once
+    // per offset chunk inside ComputeScorerScores.
+    // The compiled filter is reused across chunks too: deciding native vs
+    // non-native already builds it, and a native filter would otherwise be
+    // recompiled (and its scalar indexes re-pinned) once per chunk.
+    std::unique_ptr<milvus::exec::ExprSet> filter_expr_set;
+    auto filter_bitset = milvus::rescores::ComputeNonNativeFilterBitset(
+        &exec_context, scorer, &filter_expr_set);
+
     for (auto chunk_idx = 0; chunk_idx < scorer_offset_chunks.size();
          ++chunk_idx) {
         milvus::futures::throwIfCancelled(cancel_token);
@@ -166,13 +211,7 @@ ComputeScorerScoresOnPreparedChunks(
         if (scorer_offsets.empty()) {
             continue;
         }
-        AssertInfo(output_score_chunks[chunk_idx] != nullptr,
-                   "output score chunk {} is null",
-                   chunk_idx);
-        AssertInfo(output_has_score_chunks[chunk_idx] != nullptr,
-                   "output has score chunk {} is null",
-                   chunk_idx);
-
+        // Output pointers were validated by the preflight above.
         milvus::rescores::ComputeScorerScores(
             &exec_context,
             &op_context,
@@ -180,7 +219,9 @@ ComputeScorerScoresOnPreparedChunks(
             scorer,
             scorer_offsets,
             output_score_chunks[chunk_idx],
-            output_has_score_chunks[chunk_idx]);
+            output_has_score_chunks[chunk_idx],
+            filter_bitset.has_value() ? &filter_bitset.value() : nullptr,
+            filter_expr_set.get());
     }
 }
 

--- a/internal/core/unittest/test_boost_score_c.cpp
+++ b/internal/core/unittest/test_boost_score_c.cpp
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 
 #include <chrono>
+#include <map>
 #include <memory>
 #include <string>
 #include <thread>
@@ -31,6 +32,7 @@
 #include "segcore/SegmentSealed.h"
 #include "segcore/boost_score_c.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/GenExprProto.h"
 #include "test_utils/storage_test_utils.h"
 
 namespace {
@@ -443,6 +445,276 @@ TEST_F(BoostScoreCTest, RejectInvalidOffsetChunks) {
     FreeStatus(&status);
 
     ReleaseArrow(&null_offset_array, &null_offset_schema);
+}
+
+// Text match cannot consume offset input, so the C wrapper evaluates the
+// filter once over the whole segment and reuses the bitset for every offset
+// chunk. Every chunk -- including offsets beyond the first expression batch
+// (8192 rows) -- must be scored against the full-segment filter result.
+TEST_F(BoostScoreCTest, NonNativeFilterScoresAllChunks) {
+    const int64_t N = 10000;  // more than one expression batch (8192)
+    auto schema = std::make_shared<milvus::Schema>();
+    std::map<std::string, std::string> match_params;
+    {
+        milvus::FieldMeta f(milvus::FieldName("pk"),
+                            milvus::FieldId(100),
+                            milvus::DataType::INT64,
+                            false,
+                            std::nullopt);
+        schema->AddField(std::move(f));
+        schema->set_primary_field_id(milvus::FieldId(100));
+    }
+    {
+        milvus::FieldMeta f(milvus::FieldName("str"),
+                            milvus::FieldId(101),
+                            milvus::DataType::VARCHAR,
+                            65536,
+                            false,
+                            true,
+                            true,
+                            match_params,
+                            std::nullopt);
+        schema->AddField(std::move(f));
+    }
+    {
+        milvus::FieldMeta f(milvus::FieldName("fvec"),
+                            milvus::FieldId(102),
+                            milvus::DataType::VECTOR_FLOAT,
+                            16,
+                            knowhere::metric::L2,
+                            false,
+                            std::nullopt);
+        schema->AddField(std::move(f));
+    }
+
+    auto raw_data = milvus::segcore::DataGen(schema, N);
+    auto* str_col = raw_data.raw_->mutable_fields_data()
+                        ->at(1)
+                        .mutable_scalars()
+                        ->mutable_string_data()
+                        ->mutable_data();
+    for (int64_t i = 0; i < N; i++) {
+        str_col->at(i) = (i % 2 == 0) ? "football match" : "swimming pool";
+    }
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+    segment->CreateTextIndex(milvus::FieldId(101));
+
+    milvus::proto::plan::PlanNode plan_node;
+    auto anns = plan_node.mutable_vector_anns();
+    anns->set_vector_type(milvus::proto::plan::VectorType::FloatVector);
+    anns->set_field_id(102);
+    anns->set_placeholder_tag("$0");
+    auto query_info = anns->mutable_query_info();
+    query_info->set_topk(10);
+    query_info->set_metric_type(knowhere::metric::L2);
+    query_info->set_search_params(R"({"nprobe": 10})");
+    auto plan = milvus::query::CreateSearchPlanFromPlanNode(schema, plan_node);
+
+    auto scorer = MakeWeightScorer(2.0F);
+    auto column_info = milvus::test::GenColumnInfo(
+        101, milvus::proto::schema::DataType::VarChar, false, false);
+    std::string query = "football";
+    auto unary_range_expr = milvus::test::GenUnaryRangeExpr(
+        milvus::proto::plan::OpType::TextMatch, query);
+    unary_range_expr->set_allocated_column_info(column_info);
+    auto slop = milvus::test::GenGenericValue(static_cast<int64_t>(0));
+    unary_range_expr->add_extra_values()->CopyFrom(*slop);
+    delete slop;
+    scorer.mutable_filter()->set_allocated_unary_range_expr(unary_range_expr);
+    std::string scorer_blob;
+    ASSERT_TRUE(scorer.SerializeToString(&scorer_blob));
+
+    // Two offset chunks, both mixing matching and non-matching rows; the
+    // second one reaches past the first expression batch.
+    std::vector<std::vector<int64_t>> chunk_offsets = {
+        {0, 1},
+        {9000, 9001, N - 2},
+    };
+    const int64_t num_chunks = static_cast<int64_t>(chunk_offsets.size());
+    std::vector<ArrowArray> offset_arrays(num_chunks);
+    std::vector<ArrowSchema> offset_schemas(num_chunks);
+    std::vector<std::vector<float>> scores(num_chunks);
+    std::vector<std::unique_ptr<bool[]>> has_scores(num_chunks);
+    std::vector<float*> score_ptrs(num_chunks);
+    std::vector<bool*> has_score_ptrs(num_chunks);
+    for (int64_t i = 0; i < num_chunks; ++i) {
+        ExportOffsets(MakeOffsets(chunk_offsets[i]),
+                      &offset_arrays[i],
+                      &offset_schemas[i]);
+        scores[i].resize(chunk_offsets[i].size(), -1.0F);
+        has_scores[i] = std::make_unique<bool[]>(chunk_offsets[i].size());
+        score_ptrs[i] = scores[i].data();
+        has_score_ptrs[i] = has_scores[i].get();
+    }
+
+    auto status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment.get()),
+        static_cast<CSearchPlan>(plan.get()),
+        scorer_blob.data(),
+        scorer_blob.size(),
+        offset_arrays.data(),
+        offset_schemas.data(),
+        num_chunks,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_ptrs.data(),
+        has_score_ptrs.data());
+    ASSERT_EQ(status.error_code, milvus::Success) << status.error_msg;
+    FreeStatus(&status);
+
+    // Chunk 0: row 0 matches, row 1 does not.
+    EXPECT_TRUE(has_scores[0][0]);
+    EXPECT_FLOAT_EQ(scores[0][0], 2.0F);
+    EXPECT_FALSE(has_scores[0][1]);
+
+    // Chunk 1: offsets beyond the first expression batch keep their boost.
+    EXPECT_TRUE(has_scores[1][0]);
+    EXPECT_FLOAT_EQ(scores[1][0], 2.0F);
+    EXPECT_FALSE(has_scores[1][1]);
+    EXPECT_TRUE(has_scores[1][2]);
+    EXPECT_FLOAT_EQ(scores[1][2], 2.0F);
+
+    for (int64_t i = 0; i < num_chunks; ++i) {
+        ReleaseArrow(&offset_arrays[i], &offset_schemas[i]);
+    }
+}
+
+// The Go caller exports every offset chunk, empty ones included, and only
+// short-circuits when the chunk count itself is zero. So a request with
+// nothing to score still reaches the C wrapper as N empty chunks. Hoisting
+// the non-native filter out of the per-chunk loop must not make that request
+// scan the whole segment: for GIS that would be millions of wasted GEOS
+// calls, and a filter that cannot be evaluated at all (here: text match with
+// no text index) would fail a request that needed no scoring.
+TEST_F(BoostScoreCTest, AllEmptyChunksSkipNonNativeFilter) {
+    const int64_t N = 100;
+    auto schema = std::make_shared<milvus::Schema>();
+    std::map<std::string, std::string> match_params;
+    {
+        milvus::FieldMeta f(milvus::FieldName("pk"),
+                            milvus::FieldId(100),
+                            milvus::DataType::INT64,
+                            false,
+                            std::nullopt);
+        schema->AddField(std::move(f));
+        schema->set_primary_field_id(milvus::FieldId(100));
+    }
+    {
+        milvus::FieldMeta f(milvus::FieldName("str"),
+                            milvus::FieldId(101),
+                            milvus::DataType::VARCHAR,
+                            65536,
+                            false,
+                            true,
+                            true,
+                            match_params,
+                            std::nullopt);
+        schema->AddField(std::move(f));
+    }
+    {
+        milvus::FieldMeta f(milvus::FieldName("fvec"),
+                            milvus::FieldId(102),
+                            milvus::DataType::VECTOR_FLOAT,
+                            16,
+                            knowhere::metric::L2,
+                            false,
+                            std::nullopt);
+        schema->AddField(std::move(f));
+    }
+
+    auto raw_data = milvus::segcore::DataGen(schema, N);
+    // Deliberately no CreateTextIndex: evaluating the filter would throw.
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    milvus::proto::plan::PlanNode plan_node;
+    auto anns = plan_node.mutable_vector_anns();
+    anns->set_vector_type(milvus::proto::plan::VectorType::FloatVector);
+    anns->set_field_id(102);
+    anns->set_placeholder_tag("$0");
+    auto query_info = anns->mutable_query_info();
+    query_info->set_topk(10);
+    query_info->set_metric_type(knowhere::metric::L2);
+    query_info->set_search_params(R"({"nprobe": 10})");
+    auto plan = milvus::query::CreateSearchPlanFromPlanNode(schema, plan_node);
+
+    auto scorer = MakeWeightScorer(2.0F);
+    auto column_info = milvus::test::GenColumnInfo(
+        101, milvus::proto::schema::DataType::VarChar, false, false);
+    std::string query = "football";
+    auto unary_range_expr = milvus::test::GenUnaryRangeExpr(
+        milvus::proto::plan::OpType::TextMatch, query);
+    unary_range_expr->set_allocated_column_info(column_info);
+    auto slop = milvus::test::GenGenericValue(static_cast<int64_t>(0));
+    unary_range_expr->add_extra_values()->CopyFrom(*slop);
+    delete slop;
+    scorer.mutable_filter()->set_allocated_unary_range_expr(unary_range_expr);
+    std::string scorer_blob;
+    ASSERT_TRUE(scorer.SerializeToString(&scorer_blob));
+
+    // Two chunks, both empty -- exactly what the Go path hands over when no
+    // row of this segment needs a boost score.
+    const int64_t num_chunks = 2;
+    std::vector<ArrowArray> offset_arrays(num_chunks);
+    std::vector<ArrowSchema> offset_schemas(num_chunks);
+    for (int64_t i = 0; i < num_chunks; ++i) {
+        ExportOffsets(MakeOffsets({}), &offset_arrays[i], &offset_schemas[i]);
+    }
+    // Empty chunks get no output buffer from the Go caller either.
+    std::vector<float*> score_ptrs(num_chunks, nullptr);
+    std::vector<bool*> has_score_ptrs(num_chunks, nullptr);
+
+    auto status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment.get()),
+        static_cast<CSearchPlan>(plan.get()),
+        scorer_blob.data(),
+        scorer_blob.size(),
+        offset_arrays.data(),
+        offset_schemas.data(),
+        num_chunks,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_ptrs.data(),
+        has_score_ptrs.data());
+    EXPECT_EQ(status.error_code, milvus::Success) << status.error_msg;
+    FreeStatus(&status);
+
+    for (int64_t i = 0; i < num_chunks; ++i) {
+        ReleaseArrow(&offset_arrays[i], &offset_schemas[i]);
+    }
+
+    // Control: the same setup with one non-empty chunk does evaluate the
+    // filter, so the assertion above is about the skip and not about the
+    // filter being harmless here.
+    ArrowArray offset_array{};
+    ArrowSchema offset_schema{};
+    ExportOffsets(MakeOffsets({0}), &offset_array, &offset_schema);
+    std::vector<float> scores(1, -1.0F);
+    auto has_scores = std::make_unique<bool[]>(1);
+    float* score_chunks[] = {scores.data()};
+    bool* has_score_chunks[] = {has_scores.get()};
+
+    status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment.get()),
+        static_cast<CSearchPlan>(plan.get()),
+        scorer_blob.data(),
+        scorer_blob.size(),
+        &offset_array,
+        &offset_schema,
+        1,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_chunks,
+        has_score_chunks);
+    EXPECT_NE(status.error_code, milvus::Success);
+    FreeStatus(&status);
+
+    ReleaseArrow(&offset_array, &offset_schema);
 }
 
 }  // namespace

--- a/internal/core/unittest/test_element_filter.cpp
+++ b/internal/core/unittest/test_element_filter.cpp
@@ -4513,3 +4513,114 @@ TEST(ElementVectorSearch, SealedBruteForce_IteratorV2_MultiBatch) {
         << "multi-batch iterator should accumulate strictly more results "
         << "than a single batch";
 }
+
+// A filter that cannot consume offset input (text match, GIS) makes
+// PhyIterativeFilterNode fall back to evaluating the whole segment.
+// SearchResult::element_level_ is a property of the placeholder -- an
+// emb-list / struct-array vector field -- not of the filter expression, so
+// "element-level placeholder + non-native filter" is a legal plan that lands
+// in that fallback. It must return element-level results instead of tripping
+// an assertion.
+TEST(ElementFilterSealed, NonNativeFilterOnElementLevelSearch) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    const int dim = 16;
+    const size_t N = 200;
+    const int array_len = 3;
+
+    auto schema = std::make_shared<Schema>();
+    auto vec_fid = schema->AddDebugVectorArrayField("structA[array_vec]",
+                                                    DataType::VECTOR_FLOAT,
+                                                    dim,
+                                                    knowhere::metric::L2);
+    auto int64_fid = schema->AddDebugField("id", DataType::INT64);
+    schema->set_primary_field_id(int64_fid);
+
+    // A doc-level VARCHAR with text match enabled: text_match() does not
+    // support offset input, which is what forces the non-native fallback.
+    std::map<std::string, std::string> match_params;
+    const FieldId text_fid(102);
+    {
+        FieldMeta f(FieldName("doc_text"),
+                    text_fid,
+                    DataType::VARCHAR,
+                    65536,
+                    false,
+                    true,
+                    true,
+                    match_params,
+                    std::nullopt);
+        schema->AddField(std::move(f));
+    }
+
+    auto raw_data = DataGen(schema, N, 42, 0, 1, array_len);
+    for (int i = 0; i < raw_data.raw_->fields_data_size(); i++) {
+        auto* field_data = raw_data.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != text_fid.get()) {
+            continue;
+        }
+        auto* str_col = field_data->mutable_scalars()
+                            ->mutable_string_data()
+                            ->mutable_data();
+        for (size_t row = 0; row < N; row++) {
+            str_col->at(row) = (row % 2 == 0) ? "football match" : "swimming";
+        }
+        break;
+    }
+
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+    segment->CreateTextIndex(text_fid);
+
+    const int topK = 5;
+    ScopedSchemaHandle handle(*schema);
+
+    auto run = [&](const std::string& search_params) {
+        auto plan_bytes = handle.ParseSearch("text_match(doc_text, 'football')",
+                                             "structA[array_vec]",
+                                             topK,
+                                             knowhere::metric::L2,
+                                             search_params,
+                                             3);
+        auto plan = CreateSearchPlanByExpr(
+            schema, plan_bytes.data(), plan_bytes.size());
+        // CreatePlaceholderGroupForType is a member of the parameterized
+        // fixtures above; this is a plain TEST, and the vector field is
+        // VECTOR_FLOAT, so build the element-level group directly.
+        auto ph_group_raw = CreatePlaceholderGroup<milvus::FloatVector>(
+            1, dim, 1024, /*element_level=*/true);
+        auto ph_group =
+            ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+        return segment->Search(plan.get(), ph_group.get(), 1L << 63);
+    };
+
+    // Before the fix this threw SegcoreError from Assert(!element_level) in
+    // PhyIterativeFilterNode's non-native branch.
+    auto iterative = run(R"({"ef": 50, "hints": "iterative_filter"})");
+    ASSERT_NE(iterative, nullptr);
+    ASSERT_TRUE(iterative->element_level_);
+    ASSERT_FALSE(iterative->seg_offsets_.empty());
+    ASSERT_EQ(iterative->element_indices_.size(),
+              iterative->seg_offsets_.size());
+
+    // Every returned doc must actually satisfy the filter, and the element
+    // index must stay inside the array.
+    auto ids = raw_data.get_col<int64_t>(int64_fid);
+    for (size_t i = 0; i < iterative->seg_offsets_.size(); i++) {
+        auto doc = iterative->seg_offsets_[i];
+        if (doc == INVALID_SEG_OFFSET) {
+            continue;
+        }
+        EXPECT_EQ(doc % 2, 0) << "doc " << doc << " does not match 'football'";
+        EXPECT_GE(iterative->element_indices_[i], 0);
+        EXPECT_LT(iterative->element_indices_[i], array_len);
+    }
+
+    // The iterative-filter plan must agree with the ordinary plan.
+    auto ordinary = run(R"({"ef": 50})");
+    ASSERT_NE(ordinary, nullptr);
+    ASSERT_TRUE(ordinary->element_level_);
+    EXPECT_EQ(iterative->seg_offsets_, ordinary->seg_offsets_);
+    EXPECT_EQ(iterative->element_indices_, ordinary->element_indices_);
+}

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -33,6 +33,7 @@
 #include "segcore/SegcoreConfig.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/GenExprProto.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 
@@ -349,6 +350,11 @@ VerifyNullableElementFullScanLogicalCount(
 
 class OffsetsEvalCorrectnessTest : public ::testing::Test {
  protected:
+    // SegcoreConfig members are process-global (inline static), so the
+    // "copy + set_chunk_rows" below actually mutates every later test in
+    // the process; restore the defaults when this fixture goes away.
+    ScopedSegcoreConfigRestore config_restore_;
+
     void
     SetUp() override {
         schema_ = std::make_shared<Schema>();
@@ -854,6 +860,9 @@ TEST(OffsetsEvalNullableElementTest,
     schema->set_primary_field_id(pk_fid);
 
     auto dataset = DataGen(schema, kRowCount, 600, 0, 1, kArrayLength);
+    // SegcoreConfig members are process-global (inline static): the copy
+    // below does not isolate set_chunk_rows, so restore on scope exit.
+    ScopedSegcoreConfigRestore config_restore;
     SegcoreConfig config = SegcoreConfig::default_config();
     config.set_chunk_rows(kChunkRows);
     auto segment = CreateGrowingSegment(schema, empty_index_meta, 1, config);
@@ -883,6 +892,9 @@ TEST(OffsetsEvalNullableElementTest,
     schema->set_primary_field_id(pk_fid);
 
     auto dataset = DataGen(schema, kRowCount, 650, 0, 1, kArrayLength);
+    // SegcoreConfig members are process-global (inline static): the copy
+    // below does not isolate set_chunk_rows, so restore on scope exit.
+    ScopedSegcoreConfigRestore config_restore;
     SegcoreConfig config = SegcoreConfig::default_config();
     config.set_chunk_rows(kChunkRows);
     auto segment = CreateGrowingSegment(schema, empty_index_meta, 1, config);

--- a/internal/core/unittest/test_scorer.cpp
+++ b/internal/core/unittest/test_scorer.cpp
@@ -18,13 +18,27 @@
 #include <utility>
 #include <vector>
 
+#include "common/Geometry.h"
+#include "common/Schema.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/Expr.h"
+#include "expr/ITypeExpr.h"
 #include "filemanager/InputStream.h"
+#include "geos_c.h"
 #include "gtest/gtest.h"
+#include "index/ScalarIndexSort.h"
+#include "knowhere/comp/index_param.h"
 #include "pb/plan.pb.h"
+#include "query/PlanProto.h"
 #include "rescores/BoostScoreRunner.h"
 #include "rescores/Scorer.h"
+#include "segcore/Types.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/GenExprProto.h"
+#include "test_utils/cachinglayer_test_utils.h"
+#include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
 using namespace milvus::rescores;
@@ -239,4 +253,614 @@ TEST(BoostScoreRunnerTest, ComputeFunctionScoresRejectsMismatchedOutputSize) {
                                        offsets,
                                        scores),
                  milvus::SegcoreError);
+}
+
+// Test: TargetBitmap batch_score with out-of-bounds offsets (should NOT crash).
+// Unlike WeightScorer, RandomScorer had no bounds check on bitmap[offset].
+TEST(RandomScorerTest, BatchScoreTargetBitmapOutOfBoundsOffsets) {
+    // The segment is only consulted for get_segment_id() on the
+    // no-seed-field path of random_score.
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+    auto raw_data = segcore::DataGen(schema, 8);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    expr::TypedExprPtr filter = nullptr;
+    ProtoParams params;
+    auto* seed = params.Add();
+    seed->set_key("seed");
+    seed->set_value("42");
+    RandomScorer scorer(filter, 1.0F, params);
+
+    TargetBitmap bitmap(50);
+    bitmap.set(10);
+    bitmap.set(40);
+
+    // Offsets where some are OUT OF BOUNDS (>= 50), e.g. when the filter
+    // bitmap does not cover the whole segment.
+    FixedVector<int32_t> offsets = {10, 40, 60, 100, 200};
+    std::vector<std::optional<float>> boost_scores(offsets.size(),
+                                                   std::nullopt);
+
+    ASSERT_NO_THROW(scorer.batch_score(nullptr,
+                                       segment.get(),
+                                       proto::plan::FunctionModeSum,
+                                       offsets,
+                                       bitmap,
+                                       boost_scores));
+
+    // In-bounds matched offsets should be scored.
+    EXPECT_TRUE(boost_scores[0].has_value());
+    EXPECT_TRUE(boost_scores[1].has_value());
+
+    // Out-of-bounds offsets should NOT have scores (safely skipped).
+    EXPECT_FALSE(boost_scores[2].has_value());
+    EXPECT_FALSE(boost_scores[3].has_value());
+    EXPECT_FALSE(boost_scores[4].has_value());
+}
+
+namespace {
+
+SchemaPtr
+GenTextMatchSchema() {
+    auto schema = std::make_shared<Schema>();
+    std::map<std::string, std::string> match_params;
+    {
+        FieldMeta f(FieldName("pk"),
+                    FieldId(100),
+                    DataType::INT64,
+                    false,
+                    std::nullopt);
+        schema->AddField(std::move(f));
+        schema->set_primary_field_id(FieldId(100));
+    }
+    {
+        FieldMeta f(FieldName("str"),
+                    FieldId(101),
+                    DataType::VARCHAR,
+                    65536,
+                    false,
+                    true,
+                    true,
+                    match_params,
+                    std::nullopt);
+        schema->AddField(std::move(f));
+    }
+    {
+        FieldMeta f(FieldName("fvec"),
+                    FieldId(102),
+                    DataType::VECTOR_FLOAT,
+                    16,
+                    knowhere::metric::L2,
+                    false,
+                    std::nullopt);
+        schema->AddField(std::move(f));
+    }
+    return schema;
+}
+
+expr::TypedExprPtr
+GenTextMatchTypedExpr(const SchemaPtr& schema, const std::string& query) {
+    const auto& str_meta = schema->operator[](FieldName("str"));
+    auto column_info = test::GenColumnInfo(str_meta.get_id().get(),
+                                           proto::schema::DataType::VarChar,
+                                           false,
+                                           false);
+    auto unary_range_expr =
+        test::GenUnaryRangeExpr(proto::plan::OpType::TextMatch, query);
+    unary_range_expr->set_allocated_column_info(column_info);
+    auto slop = test::GenGenericValue(static_cast<int64_t>(0));
+    unary_range_expr->add_extra_values()->CopyFrom(*slop);
+    delete slop;
+    auto expr = test::GenExpr();
+    expr->set_allocated_unary_range_expr(unary_range_expr);
+    auto parser = query::ProtoParser(schema);
+    return parser.ParseExprs(*expr);
+}
+
+}  // namespace
+
+// Test: a filter whose expression does not support offset input (text match,
+// GIS) is evaluated batch by batch over the whole segment. The resulting
+// bitset must cover every active row, not just the first expression batch,
+// otherwise offsets beyond DEFAULT_EXEC_EVAL_EXPR_BATCH_SIZE silently lose
+// their boost.
+TEST(BoostScoreRunnerTest, ComputeScorerScoresNonNativeFilterCoversAllBatches) {
+    const int64_t N = 10000;  // more than one expression batch (8192)
+    auto schema = GenTextMatchSchema();
+    auto raw_data = segcore::DataGen(schema, N);
+    auto* str_col = raw_data.raw_->mutable_fields_data()
+                        ->at(1)
+                        .mutable_scalars()
+                        ->mutable_string_data()
+                        ->mutable_data();
+    for (int64_t i = 0; i < N; i++) {
+        str_col->at(i) = (i % 2 == 0) ? "football match" : "swimming pool";
+    }
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+    segment->CreateTextIndex(FieldId(101));
+
+    auto filter = GenTextMatchTypedExpr(schema, "football");
+    auto scorer = std::make_shared<WeightScorer>(filter, 2.0F);
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "test_scorer_multi_batch", segment.get(), N, MAX_TIMESTAMP);
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    auto exec_context = exec::ExecContext(query_context.get());
+
+    FixedVector<int32_t> offsets = {
+        0, 1, 9000, 9001, static_cast<int32_t>(N - 2)};
+    std::vector<std::optional<float>> scores(offsets.size(), std::nullopt);
+    ComputeScorerScores(
+        &exec_context, &op_context, segment.get(), scorer, offsets, scores);
+
+    // First batch behaves as before.
+    ASSERT_TRUE(scores[0].has_value());  // 0: "football match"
+    EXPECT_FLOAT_EQ(scores[0].value(), 2.0F);
+    EXPECT_FALSE(scores[1].has_value());  // 1: "swimming pool"
+
+    // Offsets beyond the first expression batch must still be scored.
+    ASSERT_TRUE(scores[2].has_value());  // 9000: "football match"
+    EXPECT_FLOAT_EQ(scores[2].value(), 2.0F);
+    EXPECT_FALSE(scores[3].has_value());  // 9001: "swimming pool"
+    ASSERT_TRUE(scores[4].has_value());   // 9998: "football match"
+    EXPECT_FLOAT_EQ(scores[4].value(), 2.0F);
+}
+
+// Same regression through a GIS filter. GIS gained SupportOffsetInput() ==
+// false in the offset-input contract fix, which routes it into the same
+// non-native fallback as text match; a boosted offset past the first
+// expression batch must still be scored.
+TEST(BoostScoreRunnerTest, ComputeScorerScoresGISFilterCoversAllBatches) {
+    const int64_t N = 10000;  // more than one expression batch (8192)
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto geo_fid = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->AddDebugField(
+        "fvec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+
+    auto raw_data = segcore::DataGen(schema, N);
+    proto::schema::FieldData* geo_field_data = nullptr;
+    for (auto& fd : *raw_data.raw_->mutable_fields_data()) {
+        if (fd.field_id() == geo_fid.get()) {
+            geo_field_data = &fd;
+            break;
+        }
+    }
+    ASSERT_NE(geo_field_data, nullptr);
+    // Even rows sit inside the query polygon, odd rows far outside.
+    auto* geo_col = geo_field_data->mutable_scalars()->mutable_geometry_data();
+    geo_col->clear_data();
+    auto ctx = GEOS_init_r();
+    for (int64_t i = 0; i < N; i++) {
+        const char* wkt =
+            (i % 2 == 0) ? "POINT (0.5 0.5)" : "POINT (100.0 100.0)";
+        Geometry geom(ctx, wkt);
+        geo_col->add_data(geom.to_wkb_string());
+    }
+    GEOS_finish_r(ctx);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    auto filter = std::make_shared<expr::GISFunctionFilterExpr>(
+        expr::ColumnInfo(geo_fid, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Within,
+        "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))");
+    auto scorer = std::make_shared<WeightScorer>(filter, 3.0F);
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "test_scorer_gis_multi_batch", segment.get(), N, MAX_TIMESTAMP);
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    auto exec_context = exec::ExecContext(query_context.get());
+
+    FixedVector<int32_t> offsets = {
+        0, 1, 9000, 9001, static_cast<int32_t>(N - 2)};
+    std::vector<std::optional<float>> scores(offsets.size(), std::nullopt);
+    ComputeScorerScores(
+        &exec_context, &op_context, segment.get(), scorer, offsets, scores);
+
+    // First batch behaves as before.
+    ASSERT_TRUE(scores[0].has_value());  // 0: inside the polygon
+    EXPECT_FLOAT_EQ(scores[0].value(), 3.0F);
+    EXPECT_FALSE(scores[1].has_value());  // 1: outside the polygon
+
+    // Offsets beyond the first expression batch must still be scored.
+    ASSERT_TRUE(scores[2].has_value());  // 9000: inside the polygon
+    EXPECT_FLOAT_EQ(scores[2].value(), 3.0F);
+    EXPECT_FALSE(scores[3].has_value());  // 9001: outside the polygon
+    ASSERT_TRUE(scores[4].has_value());   // 9998: inside the polygon
+    EXPECT_FLOAT_EQ(scores[4].value(), 3.0F);
+}
+
+// NULL policy must be identical on the native and non-native branches of
+// ComputeScorerScores: an UNKNOWN (NULL) filter verdict never grants a
+// boost. The non-native branch folds the valid bitmap explicitly; this
+// pins the same contract for a native (offset-input) filter evaluated on
+// a nullable field.
+TEST(BoostScoreRunnerTest, NativeFilterGivesNullRowsNoBoost) {
+    const int64_t N = 1000;
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto age_fid =
+        schema->AddDebugField("age", DataType::INT64, /*nullable=*/true);
+    schema->AddDebugField(
+        "fvec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+
+    auto raw_data = segcore::DataGen(schema, N);
+    proto::schema::FieldData* age_field_data = nullptr;
+    for (auto& fd : *raw_data.raw_->mutable_fields_data()) {
+        if (fd.field_id() == age_fid.get()) {
+            age_field_data = &fd;
+            break;
+        }
+    }
+    ASSERT_NE(age_field_data, nullptr);
+    // Every row satisfies the filter on its data bits; odd rows are NULL.
+    auto* age_col =
+        age_field_data->mutable_scalars()->mutable_long_data()->mutable_data();
+    auto* valid_col = age_field_data->mutable_valid_data();
+    ASSERT_EQ(valid_col->size(), N);
+    for (int64_t i = 0; i < N; i++) {
+        age_col->at(i) = i;
+        valid_col->at(i) = (i % 2 == 0);
+    }
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    proto::plan::GenericValue val;
+    val.set_int64_val(0);
+    auto filter = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(age_fid, DataType::INT64, {}, /*nullable=*/true),
+        proto::plan::OpType::GreaterEqual,
+        val);
+    auto scorer = std::make_shared<WeightScorer>(filter, 2.0F);
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "test_scorer_native_null_fold", segment.get(), N, MAX_TIMESTAMP);
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    auto exec_context = exec::ExecContext(query_context.get());
+
+    // Guard: this filter must resolve to the native branch, otherwise the
+    // assertions below silently degrade into another non-native case.
+    EXPECT_FALSE(
+        ComputeNonNativeFilterBitset(&exec_context, scorer).has_value());
+
+    FixedVector<int32_t> offsets = {0, 1, 2, 3, 500, 501};
+    std::vector<std::optional<float>> scores(offsets.size(), std::nullopt);
+    ComputeScorerScores(
+        &exec_context, &op_context, segment.get(), scorer, offsets, scores);
+
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        if (offsets[i] % 2 == 0) {
+            ASSERT_TRUE(scores[i].has_value())
+                << "valid row " << offsets[i] << " must be boosted";
+            EXPECT_FLOAT_EQ(scores[i].value(), 2.0F);
+        } else {
+            EXPECT_FALSE(scores[i].has_value())
+                << "null row " << offsets[i] << " must not be boosted";
+        }
+    }
+}
+
+// The per-chunk scoring loop in boost_score.cpp must not re-evaluate a
+// non-native filter once per offset chunk; ComputeNonNativeFilterBitset is
+// its hoisting hook. Pin the contract: no filter and native filters yield
+// std::nullopt (nothing to hoist), non-native filters yield the
+// whole-segment bitset.
+TEST(BoostScoreRunnerTest, ComputeNonNativeFilterBitsetNulloptWithoutFilter) {
+    auto scorer = std::make_shared<WeightScorer>(nullptr, 2.0F);
+    EXPECT_FALSE(ComputeNonNativeFilterBitset(nullptr, scorer).has_value());
+}
+
+TEST(BoostScoreRunnerTest, ComputeNonNativeFilterBitsetNulloptForNativeFilter) {
+    const int64_t N = 100;
+    auto schema = GenTextMatchSchema();
+    auto raw_data = segcore::DataGen(schema, N);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    // An int64 unary range expression consumes offset input natively, so
+    // there is no whole-segment bitset to hoist.
+    proto::plan::GenericValue val;
+    val.set_int64_val(0);
+    auto filter = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(FieldId(100), DataType::INT64),
+        proto::plan::OpType::GreaterEqual,
+        val);
+    auto scorer = std::make_shared<WeightScorer>(filter, 2.0F);
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "test_native_filter_bitset", segment.get(), N, MAX_TIMESTAMP);
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    auto exec_context = exec::ExecContext(query_context.get());
+
+    EXPECT_FALSE(
+        ComputeNonNativeFilterBitset(&exec_context, scorer).has_value());
+}
+
+// A non-native filter evaluated once via ComputeNonNativeFilterBitset must
+// cover the whole segment, and passing that bitset into per-chunk
+// ComputeScorerScores calls must score every chunk as if the filter had been
+// evaluated inside the call.
+TEST(BoostScoreRunnerTest, PrecomputedFilterBitsetScoresChunksConsistently) {
+    const int64_t N = 10000;  // more than one expression batch (8192)
+    auto schema = GenTextMatchSchema();
+    auto raw_data = segcore::DataGen(schema, N);
+    auto* str_col = raw_data.raw_->mutable_fields_data()
+                        ->at(1)
+                        .mutable_scalars()
+                        ->mutable_string_data()
+                        ->mutable_data();
+    for (int64_t i = 0; i < N; i++) {
+        str_col->at(i) = (i % 2 == 0) ? "football match" : "swimming pool";
+    }
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+    segment->CreateTextIndex(FieldId(101));
+
+    auto filter = GenTextMatchTypedExpr(schema, "football");
+    auto scorer = std::make_shared<WeightScorer>(filter, 2.0F);
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "test_precomputed_filter_bitset", segment.get(), N, MAX_TIMESTAMP);
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    auto exec_context = exec::ExecContext(query_context.get());
+
+    auto filter_bitset = ComputeNonNativeFilterBitset(&exec_context, scorer);
+    ASSERT_TRUE(filter_bitset.has_value());
+    ASSERT_EQ(filter_bitset->size(), N);
+    EXPECT_TRUE((*filter_bitset)[0]);
+    EXPECT_FALSE((*filter_bitset)[1]);
+    EXPECT_TRUE((*filter_bitset)[9000]);
+    EXPECT_FALSE((*filter_bitset)[9001]);
+
+    // Chunk 1 through the optional<float> overload.
+    FixedVector<int32_t> chunk1 = {0, 1};
+    std::vector<std::optional<float>> scores1(chunk1.size(), std::nullopt);
+    ComputeScorerScores(&exec_context,
+                        &op_context,
+                        segment.get(),
+                        scorer,
+                        chunk1,
+                        scores1,
+                        &filter_bitset.value());
+    ASSERT_TRUE(scores1[0].has_value());
+    EXPECT_FLOAT_EQ(scores1[0].value(), 2.0F);
+    EXPECT_FALSE(scores1[1].has_value());
+
+    // Chunk 2 through the raw-buffer overload, with offsets beyond the
+    // first expression batch.
+    FixedVector<int32_t> chunk2 = {9000, 9001, static_cast<int32_t>(N - 2)};
+    std::vector<float> scores2(chunk2.size(), -1.0F);
+    auto has_scores2 = std::make_unique<bool[]>(chunk2.size());
+    ComputeScorerScores(&exec_context,
+                        &op_context,
+                        segment.get(),
+                        scorer,
+                        chunk2,
+                        scores2.data(),
+                        has_scores2.get(),
+                        &filter_bitset.value());
+    EXPECT_TRUE(has_scores2[0]);
+    EXPECT_FLOAT_EQ(scores2[0], 2.0F);
+    EXPECT_FALSE(has_scores2[1]);
+    EXPECT_TRUE(has_scores2[2]);
+    EXPECT_FLOAT_EQ(scores2[2], 2.0F);
+}
+
+// Deciding native-vs-non-native already compiles the filter (and pins its
+// scalar indexes). A native filter yields no hoisted bitset, but the compiled
+// expressions must come back through out_expr_set so per-chunk scoring reuses
+// them instead of recompiling once per chunk. Reusing one ExprSet across
+// chunks must produce exactly what a freshly compiled one produces.
+TEST(BoostScoreRunnerTest, NativeFilterHandsBackReusableExprSet) {
+    const int64_t N = 10000;  // more than one expression batch (8192)
+    auto schema = GenTextMatchSchema();
+    auto raw_data = segcore::DataGen(schema, N);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    // An int64 unary range expression consumes offset input natively.
+    proto::plan::GenericValue val;
+    val.set_int64_val(0);
+    auto filter = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(FieldId(100), DataType::INT64),
+        proto::plan::OpType::GreaterEqual,
+        val);
+    auto scorer = std::make_shared<WeightScorer>(filter, 2.0F);
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "test_native_expr_set_reuse", segment.get(), N, MAX_TIMESTAMP);
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    auto exec_context = exec::ExecContext(query_context.get());
+
+    std::unique_ptr<exec::ExprSet> expr_set;
+    auto filter_bitset =
+        ComputeNonNativeFilterBitset(&exec_context, scorer, &expr_set);
+    EXPECT_FALSE(filter_bitset.has_value());
+    ASSERT_NE(expr_set, nullptr);
+
+    // Two chunks, the second past the first expression batch, scored against
+    // the single reused ExprSet.
+    FixedVector<int32_t> chunk1 = {0, 1, 2};
+    FixedVector<int32_t> chunk2 = {9000, 9001, static_cast<int32_t>(N - 1)};
+    std::vector<std::optional<float>> reused1(chunk1.size(), std::nullopt);
+    std::vector<std::optional<float>> reused2(chunk2.size(), std::nullopt);
+    ComputeScorerScores(&exec_context,
+                        &op_context,
+                        segment.get(),
+                        scorer,
+                        chunk1,
+                        reused1,
+                        nullptr,
+                        expr_set.get());
+    ComputeScorerScores(&exec_context,
+                        &op_context,
+                        segment.get(),
+                        scorer,
+                        chunk2,
+                        reused2,
+                        nullptr,
+                        expr_set.get());
+
+    // The same chunks, each compiling its own ExprSet (the old behaviour).
+    std::vector<std::optional<float>> fresh1(chunk1.size(), std::nullopt);
+    std::vector<std::optional<float>> fresh2(chunk2.size(), std::nullopt);
+    ComputeScorerScores(
+        &exec_context, &op_context, segment.get(), scorer, chunk1, fresh1);
+    ComputeScorerScores(
+        &exec_context, &op_context, segment.get(), scorer, chunk2, fresh2);
+
+    EXPECT_EQ(reused1, fresh1);
+    EXPECT_EQ(reused2, fresh2);
+}
+
+// Cross-chunk ExprSet reuse must also hold on the ScalarIndex exec path --
+// the only path with a stateful index cursor that could in principle desync
+// across chunks. It cannot: the index branch is gated on !has_offset_input_
+// and MoveCursor() is a no-op while offset input is set, so offset-input
+// evaluation never touches the cursor. The sibling test above filters the
+// primary key, which resolves to PkIndex and skips that machinery entirely;
+// this variant loads a real STL_SORT index on a non-pk field and pins the
+// resolved path via UseIndexCursor() so the invariant is actually exercised.
+TEST(BoostScoreRunnerTest, NativeFilterExprSetReuseOnScalarIndexPath) {
+    const int64_t N = 10000;  // more than one expression batch (8192)
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto age_fid = schema->AddDebugField("age", DataType::INT64);
+    schema->AddDebugField(
+        "fvec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+
+    auto raw_data = segcore::DataGen(schema, N);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    // DataGen fills the non-pk int64 column with the row index, so
+    // `age >= 5000` matches exactly the rows past the midpoint.
+    auto age_col = raw_data.get_col<int64_t>(age_fid);
+    auto age_index = milvus::index::CreateScalarIndexSort<int64_t>();
+    age_index->Build(N, age_col.data());
+    segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_id = age_fid.get();
+    load_index_info.field_type = DataType::INT64;
+    load_index_info.index_params = GenIndexParams(age_index.get());
+    load_index_info.cache_index =
+        CreateTestCacheIndex("test_age_index", std::move(age_index));
+    segment->LoadIndex(load_index_info);
+
+    proto::plan::GenericValue val;
+    val.set_int64_val(5000);
+    auto filter = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(age_fid, DataType::INT64),
+        proto::plan::OpType::GreaterEqual,
+        val);
+    auto scorer = std::make_shared<WeightScorer>(filter, 2.0F);
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "test_native_expr_set_reuse_scalar_index",
+        segment.get(),
+        N,
+        MAX_TIMESTAMP);
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    auto exec_context = exec::ExecContext(query_context.get());
+
+    std::unique_ptr<exec::ExprSet> expr_set;
+    auto filter_bitset =
+        ComputeNonNativeFilterBitset(&exec_context, scorer, &expr_set);
+    EXPECT_FALSE(filter_bitset.has_value());
+    ASSERT_NE(expr_set, nullptr);
+
+    // Pin the exec path this variant exists for: with the index loaded the
+    // compiled expression must resolve to ScalarIndex, not RawData/PkIndex,
+    // or the reuse-under-index-cursor invariant goes untested.
+    ASSERT_EQ(expr_set->exprs().size(), 1u);
+    auto segment_expr =
+        std::dynamic_pointer_cast<exec::SegmentExpr>(expr_set->exprs()[0]);
+    ASSERT_NE(segment_expr, nullptr);
+    ASSERT_TRUE(segment_expr->UseIndexCursor())
+        << "filter did not resolve to the ScalarIndex path; the reuse "
+           "invariant is not being exercised";
+
+    // Two chunks straddling the expression batch boundary, scored against
+    // the single reused ExprSet.
+    FixedVector<int32_t> chunk1 = {0, 4999, 5000};
+    FixedVector<int32_t> chunk2 = {9000, 9001, static_cast<int32_t>(N - 1)};
+    std::vector<std::optional<float>> reused1(chunk1.size(), std::nullopt);
+    std::vector<std::optional<float>> reused2(chunk2.size(), std::nullopt);
+    ComputeScorerScores(&exec_context,
+                        &op_context,
+                        segment.get(),
+                        scorer,
+                        chunk1,
+                        reused1,
+                        nullptr,
+                        expr_set.get());
+    ComputeScorerScores(&exec_context,
+                        &op_context,
+                        segment.get(),
+                        scorer,
+                        chunk2,
+                        reused2,
+                        nullptr,
+                        expr_set.get());
+
+    // Semantic expectations, not just reuse==fresh: rows below 5000 get no
+    // boost, rows at or above it do.
+    EXPECT_FALSE(reused1[0].has_value());  // 0
+    EXPECT_FALSE(reused1[1].has_value());  // 4999
+    ASSERT_TRUE(reused1[2].has_value());   // 5000
+    EXPECT_FLOAT_EQ(reused1[2].value(), 2.0F);
+    for (size_t i = 0; i < reused2.size(); ++i) {
+        ASSERT_TRUE(reused2[i].has_value()) << "offset idx " << i;
+        EXPECT_FLOAT_EQ(reused2[i].value(), 2.0F);
+    }
+
+    // The same chunks, each compiling its own ExprSet, must agree.
+    std::vector<std::optional<float>> fresh1(chunk1.size(), std::nullopt);
+    std::vector<std::optional<float>> fresh2(chunk2.size(), std::nullopt);
+    ComputeScorerScores(
+        &exec_context, &op_context, segment.get(), scorer, chunk1, fresh1);
+    ComputeScorerScores(
+        &exec_context, &op_context, segment.get(), scorer, chunk2, fresh2);
+    EXPECT_EQ(reused1, fresh1);
+    EXPECT_EQ(reused2, fresh2);
+}
+
+// The non-native branch advances its ExprSet to the end of the segment while
+// building the bitset, so a spent ExprSet must never be handed back for reuse.
+TEST(BoostScoreRunnerTest, NonNativeFilterDoesNotHandBackSpentExprSet) {
+    const int64_t N = 100;
+    auto schema = GenTextMatchSchema();
+    auto raw_data = segcore::DataGen(schema, N);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+    segment->CreateTextIndex(FieldId(101));
+
+    auto filter = GenTextMatchTypedExpr(schema, "football");
+    auto scorer = std::make_shared<WeightScorer>(filter, 2.0F);
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "test_non_native_expr_set", segment.get(), N, MAX_TIMESTAMP);
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    auto exec_context = exec::ExecContext(query_context.get());
+
+    std::unique_ptr<exec::ExprSet> expr_set;
+    auto filter_bitset =
+        ComputeNonNativeFilterBitset(&exec_context, scorer, &expr_set);
+    ASSERT_TRUE(filter_bitset.has_value());
+    EXPECT_EQ(expr_set, nullptr);
+}
+
+// Passing no sink must keep the original two-argument behaviour intact.
+TEST(BoostScoreRunnerTest, ExprSetSinkIsOptional) {
+    auto scorer = std::make_shared<WeightScorer>(nullptr, 2.0F);
+    EXPECT_FALSE(
+        ComputeNonNativeFilterBitset(nullptr, scorer, nullptr).has_value());
 }


### PR DESCRIPTION
issue: #51485, #51501
pr: #51486

Backport of #51486 to 3.0. The 3.0 `rescores` module matches master's
architecture, so all five commits cherry-pick cleanly with identical content:

1. **Gate GIS filters out of the offset-input path** — `SupportOffsetInput()`
   override so the iterative-filter / rescore consumer takes its non-native
   fallback instead of receiving a misaligned bitmap (silent wrong results).
2. **Cover all expression batches in the boost non-native fallback** — the
   fallback called `ExprSet::Eval` once (one 8192-row batch) while topk
   offsets can reference any row; offsets past the first batch lost their
   boost (`WeightScorer`) or read out of bounds (`RandomScorer`).
3. **Bounds check in `RandomScorer::batch_score`** — mirror `WeightScorer`'s
   guard; out-of-range offsets are treated as no-match.
4. **Evaluate the non-native boost filter once per segment, not per offset
   chunk** — hoist the whole-segment bitset into
   `ComputeNonNativeFilterBitset`, computed once per (scorer, segment) before
   the chunk loop; `O(active_count)` regardless of `num_chunks`.
5. **Advance GIS filter cursors on growing segments during conjunct skip** —
   `MoveCursor()` was a no-op on growing segments, desynchronizing the GIS
   cursor after `SkipFollowingExprs`; growing segments now route through
   `MoveCursorForData()`, and the growing interim-index path also advances
   the global index position.

## Test

Same suite as master #51486:
`ExprTest.GISFilterDoesNotSupportOffsetInput`,
`BoostScoreRunnerTest.ComputeScorerScoresNonNativeFilterCoversAllBatches` /
`…GISFilterCoversAllBatches`,
`RandomScorerTest.BatchScoreTargetBitmapOutOfBoundsOffsets`,
`BoostScoreCTest.NonNativeFilterScoresAllChunks` + three
`ComputeNonNativeFilterBitset` contract tests,
`ExprTest.GISFilterGrowingConjunctSkipKeepsCursorInSync` (+`Index` variant).
