### PR TITLE
fix: [cp3.0] stop flusher setup when collection observation fails

### DIFF
--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -38,13 +38,15 @@ type flusherComponents struct {
 }
 
 // WhenCreateCollection handles the create collection message.
-func (impl *flusherComponents) WhenCreateCollection(createCollectionMsg message.ImmutableCreateCollectionMessageV1) {
+func (impl *flusherComponents) WhenCreateCollection(ctx context.Context, createCollectionMsg message.ImmutableCreateCollectionMessageV1) error {
 	// because we need to get the schema from the recovery storage, we need to observe the message at recovery storage first.
-	impl.rs.ObserveMessage(context.Background(), createCollectionMsg)
+	if err := impl.rs.ObserveMessage(ctx, createCollectionMsg); err != nil {
+		return err
+	}
 	if _, ok := impl.dataServices[createCollectionMsg.VChannel()]; ok {
 		impl.logger.Info(context.TODO(), "the data sync service of current vchannel is built, skip it", mlog.FieldVChannel(createCollectionMsg.VChannel()))
 		// May repeated consumed, so we ignore the message.
-		return
+		return nil
 	}
 	if createCollectionMsg.TimeTick() <= impl.recoveryCheckPointTimeTick {
 		// It should already be recovered from the recovery storage.
@@ -54,7 +56,7 @@ func (impl *flusherComponents) WhenCreateCollection(createCollectionMsg message.
 			mlog.FieldVChannel(createCollectionMsg.VChannel()),
 			mlog.Uint64("timeTick", createCollectionMsg.TimeTick()),
 			mlog.Uint64("recoveryCheckPointTimeTick", impl.recoveryCheckPointTimeTick))
-		return
+		return nil
 	}
 
 	msgChan := make(chan *msgstream.MsgPack, 10)
@@ -101,6 +103,7 @@ func (impl *flusherComponents) WhenCreateCollection(createCollectionMsg message.
 		nil,
 	)
 	impl.addNewDataSyncService(createCollectionMsg, msgChan, ds)
+	return nil
 }
 
 // WhenDropCollection handles the drop collection message.

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -288,7 +288,9 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 			impl.logger.DPanic(context.TODO(), "the message type is not CreateCollectionMessage", mlog.Err(err))
 			return nil
 		}
-		impl.flusherComponents.WhenCreateCollection(createCollectionMsg)
+		if err := impl.flusherComponents.WhenCreateCollection(impl.notifier.Context(), createCollectionMsg); err != nil {
+			return err
+		}
 	case message.MessageTypeDropCollection:
 		// defer to remove the data sync service from the components.
 		// TODO: Current drop collection message will be handled by the underlying data sync service.

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
@@ -147,6 +147,20 @@ func TestWALFlusher_DispatchDefersAckSyncUpDropCollectionObserve(t *testing.T) {
 	require.ErrorContains(t, flusher.dispatch(msg), "observe failed")
 }
 
+func TestWALFlusher_DispatchStopsCreateCollectionOnObserveError(t *testing.T) {
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+	flusher := newTestWALFlusher(rs)
+
+	msg := message.CreateTestCreateCollectionMessage(t, 2, 100, rmq.NewRmqID(100)).
+		IntoImmutableMessage(rmq.NewRmqID(101))
+	rs.EXPECT().ObserveMessage(mock.Anything, mock.Anything).Return(context.Canceled).Twice()
+
+	err := flusher.dispatch(msg)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, flusher.flusherComponents.dataServices)
+	rs.AssertNotCalled(t, "GetSchema", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestWALFlusher_DispatchObservesAckSyncUpTruncateCollectionBeforeHandling(t *testing.T) {
 	rs := mock_recovery.NewMockRecoveryStorage(t)
 	rs.EXPECT().ObserveMessage(mock.Anything, mock.Anything).Return(errors.New("observe failed")).Once()


### PR DESCRIPTION
Cherry-pick from master
pr: #51458

issue: #51436

Stop CreateCollection processing when recovery storage observation fails, so the flusher does not construct a data sync service with unavailable collection metadata.

## Test Plan

- `gofumpt -l internal/streamingnode/server/flusher/flusherimpl/flusher_components.go internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go`
- `git diff --check`
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/streamingnode/server/flusher/flusherimpl -run TestWALFlusher_DispatchStopsCreateCollectionOnObserveError` (blocked: local pkg-config cannot find `milvus_core` and `milvus-storage`)
