### PR TITLE
feat: [Vortex1] add scalar local format data scan foundation

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -631,6 +631,7 @@ queryNode:
     multipleChunkedEnable: true # Deprecated. Enable multiple chunked search
     enableGeometryCache: false # Enable geometry cache for geometry data
     enableGISSplitFusion: true # Enable GIS filter coarse/refine split + same-column fusion optimization
+    scanCursorOwnsPin: false # Use cursor-owned rather than result-owned Cell pins for scalar Scan
     tieredStorage:
       warmup:
         # options: sync, async, disable.

--- a/docs/design-docs/design_docs/20260305-local_format.md
+++ b/docs/design-docs/design_docs/20260305-local_format.md
@@ -1,74 +1,113 @@
 # MEP: Local Format for Storage V3 Scalar Fields
 
+- **Feature DRI:** TBD
+- **Primary Approver:** TBD
+- **Independent Approver:** TBD
+- **Design Review:** TBD
 - **Created:** 2026-03-05
 - **Author(s):** @zhicheng
 - **Status:** Under Review
-- **Component:** QueryNode | DataNode | Storage
-- **Related Issues:** milvus-io/milvus#50304
-- **Released:** TBD
+- **Component:** RootCoord | DataNode | QueryNode | Storage
+- **Related Issue:** [milvus-io/milvus#50304](https://github.com/milvus-io/milvus/issues/50304)
+- **Target Release:** TBD
 
 ## Summary
 
-Add a field-level `local_format` type parameter for sealed segment scalar data
-loaded through Storage V3. The default value is `raw`, which keeps the existing
-Milvus on-node raw chunk layout. The first alternate value is `vortex`, which
-loads Vortex column group files through a cell-based local format path.
+`local_format` selects how a Storage V3 sealed scalar field is represented and
+accessed locally by QueryNode. It does not select the format written to object
+storage.
 
-The proposal keeps the public field schema model small:
+The initial choices are:
 
-- `local_format=raw`: existing behavior.
-- `local_format=vortex`: use Vortex local format when the Storage V3 manifest
-  also points to a Vortex physical column group for that field.
+- `raw` (default): materialize the existing Milvus Raw column representation.
+- `vortex`: retain a Vortex physical column group and read its Cells on demand.
 
-Vortex local format is a read-path feature for sealed scalar fields. It does not
-change growing segment execution, vector index execution, or the public query
-language. It changes how QueryNode loads and scans sealed scalar column data.
+The choice is recorded as field schema intent. At segment load time, QueryNode
+combines that intent with the physical format recorded in the Storage V3
+manifest and resolves one effective local backend for the complete physical
+column group. Raw and Vortex then expose the same column-level Scan and Take
+contract to sealed-segment consumers.
 
-## Motivation
+This document is primarily the design of local-format selection, loading,
+configuration, and behavior. The column Scan/Take API is included only where it
+defines the common boundary needed to hide Raw and Vortex storage details.
 
-Raw scalar chunks are simple and fast when fully resident, but they require
-Milvus to materialize the field data in its raw on-node layout. This is costly
-for large VARCHAR, JSON, ARRAY, and other scalar fields when a query only needs a
-subset of rows or only needs a predicate result.
+## Problem
 
-Vortex provides compressed, columnar files with row-group metadata and optional
-zone maps. Local format support lets Milvus keep Vortex data in its native file
-layout and materialize only the cells needed by scan or take operations.
+The existing Raw backend is simple and fast once resident, but loading it
+requires materializing scalar data into Milvus-owned chunks. Large VARCHAR,
+JSON, ARRAY, and other scalar fields can therefore consume memory and I/O even
+when a query reads only part of a segment.
 
-The design goals are:
+Storage V3 may persist the same logical fields in Vortex columnar files. Vortex
+has its own file layout, metadata, and decoding model, so exposing it as Raw
+chunks would discard its ability to prune and load data at its native Cell
+granularity. Milvus needs an explicit local-format choice and a common read
+boundary that does not expose either backend's physical representation.
 
-- Reduce sealed scalar field load memory for Storage V3 segments.
-- Keep the existing raw path as the default and avoid adding copies to it.
-- Let expression evaluation consume scalar data through a scan cursor instead
-  of repeatedly materializing chunks.
-- Pin Vortex data at a well-defined cell granularity in the Milvus cache layer.
-- Keep the common `FormatReader` interface stable; Vortex-specific operations
-  are exposed as Vortex extensions.
-- Support normal filter, offset-input filter, and retrieve/requery output paths
-  with clear and separate execution plans.
+## Goals and Non-goals
 
-The non-goals for the initial implementation are:
+Goals:
 
-- Vortex local format for vector fields.
-- Vortex local format for primary-key fields.
+- Keep Raw as the default and preserve its existing data-access behavior.
+- Allow eligible Storage V3 sealed scalar fields to use Vortex locally.
+- Resolve a physical column group to one unambiguous local backend.
+- Share Vortex footer, planner, cache, and Cell state among all columns in the
+  same physical column group.
+- Let QueryNode cache and evict Vortex data at Cell granularity.
+- Keep nullability, filtering, ordering, and ownership semantics identical from
+  the caller's perspective.
+- Make configuration, fallback, failure, rollout, and recovery behavior
+  explicit.
+
+Non-goals:
+
+- Changing the physical writer format through `local_format`.
+- Vortex local format for primary-key, vector, system, or growing-segment data.
 - Changing the query expression language.
-- Full predicate pushdown for every scalar expression.
-- Bitmap/selection pushdown for offset-input execution.
+- Supporting every scalar predicate as Vortex pushdown.
+- Replacing every legacy Chunk consumer in the first implementation phase.
+- Changing WAL, streaming, replication, or CDC behavior.
 
-## Public Interfaces
+## Terminology and Core Invariants
 
-### Field Type Parameter
+- **Schema intent** is the field's `local_format` type parameter.
+- **Physical format** is the column-group format recorded in the Storage V3
+  manifest. It is selected by the writer, not by `local_format`.
+- **Effective local backend** is the Raw or Vortex representation selected by
+  QueryNode when loading a sealed segment.
+- **Column group** is a physical group of fields stored in the same set of
+  files.
+- **Cell** is the Vortex cache/loading unit. For Raw it corresponds to the
+  existing chunk boundary used by the column planner.
 
-`local_format` is a field type parameter.
+The following invariants are mandatory:
 
-Valid values:
+1. Every physical column group has exactly one effective local backend in one
+   loaded segment generation.
+2. A mixed or ambiguous group never partially loads as Vortex.
+3. All Vortex fields in one physical group share one `VortexColumnGroup` and
+   therefore the same files, footer metadata, Cell geometry, and cache slots.
+4. A Cell pin protects every borrowed byte or view returned from that Cell for
+   the documented result lifetime; owned decoded output is independent of the
+   pin.
+5. Filtering may suppress data construction, but it never changes row
+   alignment or stored validity.
+6. Scan positions and Take offsets are absolute segment offsets. File- and
+   Cell-local coordinates remain backend-private.
+7. Corrupt or incompatible Vortex input fails segment loading or the operation;
+   it does not silently switch an already selected Vortex group to Raw.
+
+## User-visible Schema Setting
+
+`local_format` is stored in field type parameters.
 
 | Value | Meaning |
-|-------|---------|
-| `raw` | Default. Load sealed scalar data into the existing raw local format. |
-| `vortex` | Prefer Vortex local format for this field when the physical Storage V3 column group is Vortex. |
+|---|---|
+| absent or `raw` | Use the Raw local backend. `raw` is the initial server default. |
+| `vortex` | Request Vortex local access when the Storage V3 physical group is also Vortex and the complete group is eligible. |
 
-Example schema intent:
+Example:
 
 ```python
 schema.add_field(
@@ -79,468 +118,378 @@ schema.add_field(
 )
 ```
 
-SDKs may expose this as a direct field option, but the Milvus server stores and
-validates it as a field type parameter.
+Validation occurs during schema creation and alteration:
+
+- unknown values are rejected;
+- `vortex` is rejected for primary-key and vector fields;
+- omitted values parse as `raw`;
+- non-default values are preserved when the schema is serialized.
+
+SDKs may later expose a typed option, but the server contract remains the field
+type parameter.
 
-Validation rules:
+## End-to-end Local-format Resolution
 
-- Missing `local_format` uses the server default, which initially resolves to
-  `raw`.
-- `local_format=vortex` is accepted for non-primary-key, non-vector fields.
-- Primary-key fields reject `local_format=vortex`.
-- Vector fields reject `local_format=vortex`.
-- Unknown values are rejected. The supported values are `raw` and `vortex`.
+### 1. Write-time column-group planning
+
+The Storage V3 split policy partitions fields by the exact schema intent:
+absent/default, explicit `raw`, and explicit `vortex` remain separate. Later
+system, vector, text, size, and remanent split policies operate inside those
+partitions.
+
+Keeping absent and explicit `raw` separate allows a future default to change
+without reinterpreting fields that explicitly selected Raw. The split policy
+does not set the writer format; normal writer configuration determines the
+physical format stored in the manifest.
 
-### Storage V3 Relationship
+### 2. Manifest persistence
+
+The manifest remains the authority for physical files, their ordered segment
+row ranges, columns, sizes, and format. `local_format` remains schema metadata.
+It propagates through the existing collection schema and AlterCollection path;
+no new WAL record, streaming message type, acknowledgement, or CDC contract is
+introduced.
 
-`local_format` is only effective for Storage V3 sealed segments.
+Vortex files in one group must form an ordered, gap-free partition of
+`[0, segment_row_count)`. This is validated when the segment is loaded. Each
+file is opened independently and may use a different Arrow representation as
+long as the field can be normalized to the caller-selected target type.
 
-For write-time column group planning, fields with a default (empty), `raw`, or
-`vortex` local format are partitioned away from each other. The default value
-remains a separate partition so a future server-level default can be changed
-without mixing fields that explicitly requested `raw` or `vortex`.
+### 3. QueryNode load-time decision
 
-Local format does not select the physical writer format. New column groups use
-the writer's configured format, and existing column groups preserve the format
-recorded in the Storage V3 manifest.
+QueryNode resolves the backend for the complete physical group:
 
-For read-time loading, Vortex local format is used only when both conditions are
-true:
+| Physical group | Schema intent for all mapped fields | Effective backend |
+|---|---|---|
+| non-Vortex | any supported intent | Raw materialization |
+| Vortex | every mapped logical field requests `vortex` | Vortex |
+| Vortex | mixed, missing, unknown mapping, or any non-Vortex intent | current group default, which is Raw |
+| any group containing the primary key | any | Raw |
 
-- all fields in the physical column group have `local_format=vortex`;
-- the Storage V3 manifest says the physical column group file is Vortex.
+Multiple logical fields may map to one physical external column. That physical
+column is eligible only when every mapping requests Vortex. This prevents one
+field's preference from changing another field's representation.
 
-If either condition is false, the segment uses the existing raw loading path for
-that column group.
+The Vortex path additionally requires Storage V3, scalar non-system fields,
+non-empty file metadata, compatible schemas, aligned Cells across fields, and a
+row count matching the segment manifest.
 
-## Design Details
+### 4. Publication and replacement
 
-### High-Level Architecture
+Load constructs the complete backend off to the side and publishes it as one
+segment generation. A Vortex group creates one shared `VortexColumnGroup` and
+one field-level `VortexColumn` proxy per logical field. Reopen/add-field
+replacement publishes a new generation; existing operations continue using
+their captured generation and immutable planner/statistics state.
 
-The design extends `ChunkedColumnInterface` with column-oriented scan and
-positional access for sealed scalar fields. This is the main interface shift for
-local format: Vortex data is not naturally owned as Milvus raw chunks, so the
-new path moves callers from `ChunkedBase` chunk access to column-level
-operations.
+Creating or altering a schema uses the normal collection metadata lifecycle.
+Renaming a collection does not change field intent or persisted files. Dropping
+or unloading a collection destroys the loaded ColumnGroups and their ephemeral
+local cache files; durable object-storage cleanup remains the existing segment
+lifecycle's responsibility.
 
-`Scan` is one operation under `ChunkedColumnInterface`, used by expression
-evaluation. Positional take/output operations are also part of the same
-column-based abstraction and are used by retrieve and requery. The Vortex reader
-consumes a sparse local file view behind these column-level operations.
+## Raw Backend Behavior
 
-Milvus is in a transition state where two access families coexist:
+Raw remains the compatibility and default path:
 
-- `ChunkedBase` remains the raw chunk-oriented path for the existing raw local
-  format and existing chunk consumers.
-- `ChunkedColumnInterface` is the local-format-aware path used by Vortex and by
-  scan/take code that should not depend on physical chunk ownership.
+- the generic Storage V3 reader materializes the requested fields into the
+  existing Raw representation;
+- fixed-width access returns values directly from pinned chunks;
+- variable-width access returns views whose lifetime is protected by the
+  corresponding pin;
+- Raw Scan stops at a chunk boundary so it can return a zero-copy batch;
+- Raw Take resolves input offsets lazily and reuses the current chunk pin while
+  consecutive accesses remain in that chunk;
+- statistics that require loaded Raw payload remain an execution-time filter.
+  They may skip comparison/value construction, but are not used to avoid the
+  preceding load or pin.
 
-Filter scan path:
+Introducing the common column contract must not add full-range pinning,
+unnecessary value construction, or forced offset sorting to the Raw hot path.
 
-```text
-Expr
-  -> ChunkedColumnInterface::Scan(...)
-  -> VortexColumn
-  -> VortexPlanner
-  -> VortexColumnGroup cache slot pin
-  -> VortexFormatReader::read_with_plan / read_row_ids_with_plan
-  -> Vortex scan builder
-```
+## Vortex Backend Behavior
 
-Retrieve/requery output path:
+### Shared column-group state
 
-```text
-Retrieve output / bulk_subscript
-  -> ChunkedColumnInterface positional take
-  -> VortexColumn::Take...
-  -> VortexPlanner::PlanForOffsets
-  -> VortexColumnGroup cache slot pin
-  -> VortexFormatReader::read_with_plan(row indices)
-```
+`VortexColumnGroup` owns the state shared by all fields in one physical group.
+For every file it owns:
 
-The key ownership split is:
+- the validated absolute segment row range;
+- a sparse local filesystem view;
+- one footer reader;
+- immutable footer-backed planners for the projected fields;
+- one cache slot and Cell translator;
+- metadata memory accounting.
 
-- `milvus-storage` understands the Vortex file layout and maps row ranges,
-  offsets, and predicates to Vortex read plans.
-- Milvus QueryNode owns cache pinning, sparse-file lifecycle, expression cursor
-  consumption, and output conversion.
+Footer and optional zone-map bytes are loaded when the group is initialized,
+not once per field or query. Field-level `VortexColumn` objects reuse this group
+state and select only their projected logical column.
 
-### Column Group Splitting
+### Cells, planning, and pinning
 
-Column group splitting partitions fields by the default (empty), `raw`, or
-`vortex` `local_format` value before subsequent split policies finalize physical
-groups. This gives each physical group an unambiguous local-format intent while
-keeping physical writer-format selection independent.
+For Vortex V2 a Cell is one complete row group and its physical segments. For
+V1, which lacks stable row-group boundaries, a Cell is the complete flat
+physical unit. Cell row ranges are ordered, non-overlapping, and complete;
+fields in the same group must agree on them.
 
-The split policy behavior is:
-
-1. Partition pending fields by the exact `local_format` value, keeping default
-   (empty), `raw`, and `vortex` separate.
-2. Keep the partition boundary through later split policies.
-3. Leave the resulting column group's writer `Format` unset so normal writer
-   configuration or existing manifest metadata determines the physical format.
-
-System, vector, text, average-size, and remanent-short split policies still
-apply after the local-format partitioning. They split within the current local
-format partition instead of mixing formats.
-
-### Cell Semantics
-
-A cell is the cache and loading unit for Vortex local format. Cells are defined
-by the Vortex file layout and exposed through `VortexPlanner`.
-
-Vortex V1:
-
-- There is no stable row-group boundary.
-- A cell corresponds to a full flat physical unit.
-
-Vortex V2:
-
-- Row groups are available.
-- A cell corresponds to a complete row group and its physical segments.
-- Row-group boundaries must align for fields in the same physical column group.
-
-General cell invariants:
-
-- Cell ids are contiguous and start at zero within a file.
-- Cell row ranges are contiguous and cover the file.
-- Cells do not share physical segments.
-- All fields in the same physical column group share a `VortexColumnGroup`; pinning
-  a cell loads the underlying bytes once for all fields in that group.
-
-### Storage-Side Vortex Interfaces
-
-#### `VortexFooterReader`
-
-`VortexFooterReader` reads Vortex file metadata. It is not responsible for data
-scan, take, Milvus cache pinning, or cache lifetime.
-
-Responsibilities:
-
-- Open a Vortex file through a filesystem.
-- Materialize the footer into the sparse local file.
-- Optionally materialize V1/V2 zone-map segments.
-- Expose schema, row count, footer size, field layout, row-group ranges, and
-  physical byte ranges.
-- Prune row groups using zone maps when they are loaded.
-
-Lifecycle:
-
-- `Open(fs, load_zonemap)` succeeds at most once per reader instance.
-- `Open(false)` loads footer metadata only; pruning conservatively keeps all
-  candidate row groups.
-- `Open(true)` loads footer metadata, materializes zone-map bytes, and then
-  reopens the final Vortex file view so Vortex's internal initial-read cache
-  cannot retain sparse zero-filled zone-map bytes.
-
-#### `VortexPlanner`
-
-`VortexPlanner` converts logical Milvus access requests into two outputs:
-
-```cpp
-struct VortexPlan {
-    std::vector<uint64_t> cell_ids;
-    VortexReadPlan read_plan;
-};
-```
-
-- `cell_ids` are used by Milvus to pin Vortex cells through the cache layer.
-- `read_plan` is passed to `VortexFormatReader` for execution.
-
-Supported planning modes:
-
-- `PlanForRowRange(row_start, row_end, predicate)`
-- `PlanForOffsets(offsets)`
-
-For V2 row-group cells and supported predicates, the planner may use zone maps
-to prune cells. For V1 files or unsupported predicates, it returns all candidate
-cells conservatively.
-
-#### `VortexFormatReader`
-
-The common `FormatReader` interface remains compatible with existing callers.
-Vortex local format uses Vortex-specific extensions:
-
-- `read_with_plan(const VortexReadPlan&)`
-- `read_row_ids_with_plan(const VortexReadPlan&)`
-
-`read_with_plan` returns data as an Arrow stream. `read_row_ids_with_plan`
-returns file-local row ids satisfying the predicate in the plan. Predicate state
-is carried by `VortexReadPlan`, not by long-lived reader state. Existing
-`set_predicate` behavior remains for compatibility but is not the local format
-path.
-
-### Milvus-Side Components
-
-#### `FieldMeta`
-
-`FieldMeta` parses `type_params["local_format"]` and defaults to `raw`. It also
-serializes non-default local format back to the field schema.
-
-#### `ChunkedColumnInterface`
-
-`ChunkedColumnInterface` is the shared access contract for column-oriented scalar
-data. It lets callers express the operation they need without assuming the data
-is backed by raw Milvus chunks.
-
-The interface covers two operation groups:
-
-- scan operations for expression evaluation;
-- positional take/output operations for retrieve, requery, and bulk_subscript.
-
-`Scan` returns a cursor of `ScanBatch` values.
-
-Scan outputs:
-
-| Output | Payload |
-|--------|---------|
-| `ScanOutput::RowIds` | Sparse row ids that satisfy, or may satisfy, a pushed predicate. |
-| `ScanOutput::Data` | Dense values over a row range, plus validity when needed. |
-
-Data scan supports:
-
-- row range;
-- value kind (`FixedWidth`, `StringView`, `JsonView`, `ArrayView`);
-- validity;
-- validity-only projection.
-
-Row-id scan supports:
-
-- unary predicates;
-- binary range predicates;
-- sparse row-id batches.
-
-If a column implementation cannot support a scan mode, it falls back to the
-raw-compatible behavior through the existing chunked path.
-
-#### `VortexColumnGroup`
-
-`VortexColumnGroup` owns shared state for one physical Vortex column group.
-
-Each file state contains:
-
-- source filesystem and resolved source path;
-- sparse filesystem and sparse path;
-- `VortexFooterReader`;
-- group-level `VortexPlanner`;
-- cache slot and translator;
-- row count and memory accounting.
-
-All fields in the same physical group share the same `VortexColumnGroup`.
-
-#### `VortexColumn`
-
-`VortexColumn` is a field-level `ChunkedColumnInterface` implementation over a
-shared `VortexColumnGroup`.
-
-Responsibilities:
-
-- Resolve the Vortex field name. External fields use the external column name;
-  internal fields use the field id string.
-- Build a field-level projected Arrow schema.
-- Create field-level planner/reader state.
-- Implement `Scan`.
-- Implement positional take helpers for retrieve output.
-
-### Filter Scan
-
-#### Predicate Pushdown
-
-For supported unary and binary range expressions, expression execution requests
-`ScanOutput::RowIds`.
-
-Example:
-
-```text
-UnaryExpr / BinaryRangeExpr
-  -> ChunkedColumnInterface::Scan(ScanOutput::RowIds)
-  -> VortexColumn::Scan
-  -> VortexRowIdScanCursor
-  -> VortexPlanner::PlanForRowRange(predicate)
-  -> pin planned cells
-  -> VortexFormatReader::read_row_ids_with_plan
-  -> bitmap assembly in expression execution
-```
-
-The initial implementation supports a narrow set of predicate strings that can
-be represented safely for the Vortex reader. Unsupported expressions fall back
-to data scan. This keeps correctness independent of pushdown coverage.
-
-#### Data Scan
-
-Unsupported predicates, complex expressions, and expressions that need raw value
-inspection use `ScanOutput::Data`.
-
-Example:
-
-```text
-Expr data path
-  -> ChunkedColumnInterface::Scan(ScanOutput::Data)
-  -> VortexDataScanCursor
-  -> VortexPlanner::PlanForRowRange(no predicate)
-  -> pin planned cells
-  -> VortexFormatReader::read_with_plan
-  -> expression layer evaluates predicate
-```
-
-This is the current path for examples such as `LIKE`, `IN`, JSON path
-expressions, and array predicates when they cannot be represented as a Vortex
-predicate.
-
-### Offset Input Execution
-
-Offset-input execution is used when expression evaluation is restricted to a
-known set of segment offsets.
-
-The initial Vortex local format implementation handles dense sorted offsets by
-scanning one continuous range:
-
-```text
-ProcessDataByOffsets
-  -> ProcessSortedDataByOffsetsByScan
-  -> scan [min_offset, max_offset + 1)
-  -> expression layer checks the offset bitmap
-```
-
-Bitmap or selection pushdown into `ChunkedColumnInterface::Scan` is left as
-future work. The current strategy avoids many small reads while keeping
-semantics simple.
-
-### Retrieve and Requery
-
-Retrieve/requery output is not filter scan. It reads requested output fields at
-selected row offsets.
-
-```text
-FillTargetEntry / Retrieve output
-  -> bulk_subscript
-  -> ChunkedColumnInterface positional take
-  -> VortexColumn::BulkPrimitiveValueAt / BulkRawStringAt / BulkArrayAt
-  -> TakeOwn / TakeStringLikeViews
-  -> VortexPlanner::PlanForOffsets
-  -> pin planned cells
-  -> VortexFormatReader::read_with_plan(row indices)
-  -> restore requested output order
-```
-
-The planner disables predicate semantics for take because retrieve output is
-positional. Random requery over long strings can still touch many cells; this is
-tracked as a separate performance area from filter pushdown.
-
-### Nullable and Validity
-
-The `ChunkedColumnInterface` scan API uses `ValidityView` to present nullability
-uniformly.
-
-Rules:
-
-- Non-nullable fields may return all-valid validity.
-- Nullable dense data scans must return validity aligned with the dense row
-  range.
-- Row-id scans may return validity aligned with sparse row ids.
-- Validity-only projection is part of the scan model so callers that only need
-  nullability do not need to materialize full values.
-
-The raw path may adapt its existing `bool*` validity representation into this
-model. Vortex uses Arrow bitmap/null-buffer semantics.
-
-### Sparse Local File and Cache Loading
-
-Vortex local format uses a sparse local file as the file view consumed by the
-Vortex reader.
-
-Flow:
-
-```text
-VortexFooterReader
-  -> materialize footer and optional zone-map bytes into sparse file
-
-VortexPlanner
-  -> choose cell ids and read plan
-
-Milvus cache layer
-  -> pin cells
-  -> Vortex translator loads cell byte ranges into sparse file
-
-VortexFormatReader
-  -> reads the sparse file as a normal file
-```
-
-Properties:
-
-- Loaded byte ranges are written to the sparse file.
-- Missing ranges remain sparse holes and read as zero-filled bytes if an
-  over-wide read crosses them.
-- Footer bytes are always materialized before planning.
-- Zone-map bytes are materialized when pruning is enabled.
-- Cell lifecycle remains controlled by Milvus cache pin/unpin.
-
-### Warmup and Eviction
-
-Vortex local format reuses Milvus cache warmup policy. Warmed scalar fields can
-load their cells during segment load, reducing the first-query penalty. Manual
-eviction and warmup cancellation are implemented at the `VortexColumnGroup`
-level so all field proxies in the same physical group share the same state.
-
-## Compatibility, Deprecation, and Migration Plan
-
-- Backward compatible by default: fields without `local_format` use the server
-  default, which initially behaves as `raw`.
-- Existing non-Vortex segments continue to load through the raw path.
-- A schema can contain default (empty), raw, and Vortex local format fields;
-  column group splitting keeps the three intents physically separate.
-- During the transition, QueryNode keeps both access paths: raw fields continue
-  to use the `ChunkedBase` chunk-oriented path, while Vortex fields use the
-  `ChunkedColumnInterface` column-oriented path.
-- Vortex local format is only used for Storage V3 sealed segments.
-- Rolling upgrades must ensure QueryNodes understand Vortex local format before
-  new Vortex column groups are loaded. Older readers cannot load Vortex physical
-  column groups.
-
-## Test Plan
-
-System and integration validation:
-
-- Create collections with raw fields, Vortex local format fields, and mixed
-  fields; verify insert, flush, load, search, query, and retrieve.
-- Verify `local_format=vortex` is rejected for primary-key and vector fields.
-- Verify Storage V3 manifests with Vortex physical column groups load as
-  `VortexColumnGroup + VortexColumn`.
-- Verify non-Vortex physical files continue to load through the raw path.
-- Run scalar filter benchmark cases for primitive predicates, complex
-  expressions, offset-input execution, and retrieve/requery output.
-
-Unit and component validation:
-
-- `FieldMeta` parse/serialize of `local_format`.
-- Column group split policy keeps raw and Vortex fields separate.
-- `ChunkedColumnInterface` scan and positional take behavior.
-- Raw `ChunkedBase` path and Vortex `ChunkedColumnInterface` path coexist without
-  changing raw field behavior.
-- `VortexColumn` row-id scan, data scan, validity, and take paths.
-- `VortexFooterReader` footer and optional zone-map lifecycle.
-- `VortexPlanner` row range, offset, and predicate pruning plans.
-- `VortexFormatReader::read_with_plan` and `read_row_ids_with_plan`.
-
-Performance validation:
-
-- Compare Vortex and raw local format for cold and hot retrieve.
-- Compare Vortex and raw local format for primitive filter scan.
-- Track complex data scan cases such as JSON, ARRAY, and `LIKE`.
-- Track random retrieve/requery over long VARCHAR because it exercises take and
-  output conversion rather than filter scan.
-
-## Future Work
-
-- Push offset bitmaps or row selections into `ChunkedColumnInterface::Scan`.
-- Expand Vortex predicate construction for more scalar types and expression
-  forms.
-- Optimize long string, JSON, and ARRAY retrieve/take conversion paths.
-- Use validity-only scan in paths that only need nullability.
+Before data access, the footer-backed planner maps the requested segment range
+or offsets to Cells and may use loaded zone maps to identify data that a filter
+cannot match. QueryNode then pins only the Cells required by the operation,
+subject to nullability:
+
+- a non-nullable skipped Cell need not be pinned for data;
+- a nullable field still needs authoritative validity, so the Cell remains
+  readable even when its value payload is skipped.
+
+Skip state means “do not construct/evaluate this data,” not “remove these rows.”
+A skipped nullable row still returns its actual validity. Data is unspecified
+when either the row is null or data is skipped; validity distinguishes a true
+NULL from a valid skipped value.
+
+### Sparse local backing and lifecycle
+
+Vortex presents a sparse local file to the reader. Footer and zone-map ranges
+are materialized first; a Cell translator fills data ranges on cache load.
+Missing ranges remain sparse holes until their Cell is loaded.
+
+The production backing is memory or mmap, selected by the normal scalar mmap
+settings. Mmap files are local ephemeral cache artifacts:
+
+- created with owner-only permissions;
+- truncated for a new column-group generation;
+- removed when the group is destroyed;
+- rebuilt from remote Storage V3 files after QueryNode restart;
+- punched or zeroed when cache eviction releases a Cell range.
+
+They are not durable segment state and are not part of backup, replication, or
+CDC.
+
+### Predicate pushdown
+
+Vortex can return matching row ids for the currently supported unary and binary
+STRING/VARCHAR predicate forms. Unsupported predicates use data Scan and are
+evaluated by the normal expression implementation. Disabling pushdown changes
+only the execution strategy, never the result.
+
+## Supporting Column Access Contract
+
+Raw and Vortex are hidden behind column-level Scan and Take. This is a support
+contract for local format, not a new user-visible query API.
+
+### Scan
+
+`Scan(options)` creates one cursor for one expression leaf. Options fix the
+initial absolute segment position, target value type, output/predicate form,
+filter, prefetch choice, and pin policy. The execution window and whether a
+nullable data batch needs values or validity only are supplied later through
+cursor positioning and bounded `Next` calls.
+
+The cursor exposes:
+
+- `Position()`: next unread absolute segment offset;
+- `Seek(position)`: move forward without returning intervening rows;
+- `Next(max_length, read_mode)`: return one batch starting exactly at the
+  current position and advance by the batch's actual row count.
+
+`max_length` is an upper bound. Raw may stop at a chunk boundary and Vortex may
+stop at a reader boundary. The expression node owns the cursor across execution
+windows, seeks when its window start differs from `Position()`, and consumes
+successive batches until the window is complete. A batch never crosses a
+skipped range silently: it carries aligned `data_skipped` state and, for a
+nullable field, authoritative validity.
+
+Pin policy is selected once at `Scan` creation:
+
+- `ResultOwned` (default) transfers the Cell pin to each returned batch. The
+  batch remains valid until its owner is released; the cursor holds no pin.
+- `CursorOwned` keeps the current physical Cell or planned Cell-set pin in the
+  cursor, reuses an identical pin plan, and releases it before pinning a
+  different plan. The batch is borrowed only until the next `Next` or `Seek`.
+
+The caller never pins Cells directly. Optional prefetch submits the remaining
+planned Scan Cells for parallel cache loading and immediately releases those
+prefetch pins; normal batch reads still acquire their configured pin owner. It
+is enabled only on paths that intentionally preserve prior prefetch behavior,
+not implicitly for validity-only reads.
+
+### Take
+
+`Take(options)` accepts a finite list of absolute segment offsets and returns
+one `TakeResult` with exactly one position per input offset. Input order and
+duplicates are preserved. Filtered positions stay aligned and carry
+`data_skipped`; nullable positions also retain authoritative validity.
+
+`Get(i)` returns the value, validity, and skip state for one position.
+`IsValid(i)` reads validity without constructing data. `GetOwn()` materializes
+an ordered, contiguous result independent of backend pins.
+
+Raw keeps at most the currently accessed Cell pinned and copies only when owned
+output is requested. Vortex may sort, group, and deduplicate offsets internally
+to reduce decode work, then restores input order in its already-owned result.
+Neither backend exposes Cell ids, chunk ids, or file-local offsets to callers.
+
+## Configuration
+
+| Setting | Default | Scope / refresh | Effect |
+|---|---:|---|---|
+| field type parameter `local_format` | `raw` | schema metadata; applied when a sealed segment generation loads | Requests Raw or Vortex local representation. It does not select the writer format. |
+| field/collection property `mmap.enabled` | unset | schema property; applied at load | Overrides the global scalar mmap setting for the affected physical group. If any field in a group explicitly enables mmap, the group uses mmap. |
+| `queryNode.mmap.scalarField` | `false` | QueryNode configuration | Selects mmap rather than memory backing when no field/collection override exists. Disabling it does not disable Vortex; it selects memory backing. |
+| `queryNode.mmap.populate` | `true` | QueryNode startup configuration | Controls `MAP_POPULATE` for the Vortex sparse mmap backing. No effect when mmap backing is not selected. |
+| `queryNode.segcore.tieredStorage.warmup.scalarField` | `sync` | QueryNode/collection warmup policy | `sync`, `async`, or `disable` controls proactive Cell loading. `disable` keeps on-demand loading. |
+| `queryNode.segcore.enableVortexScanPushdown` | `true` | refreshable QueryNode setting | When false, Vortex filters use data Scan and normal expression evaluation. |
+| `queryNode.segcore.scanCursorOwnsPin` | `false` | non-refreshable QueryNode setting | When false use `ResultOwned`; when true use experimental `CursorOwned` Scan pin lifetime. |
+
+Configuration changes do not rewrite existing segment files. Schema or mmap
+changes take effect when the affected segment generation is loaded or replaced;
+the pushdown setting is read dynamically by execution.
+
+## Failure, Concurrency, and Recovery
+
+Vortex initialization validates file ordering and coverage, manifest row count,
+field projection, schema compatibility, Cell geometry, and cross-field Cell
+alignment. Invalid storage data is reported as a data-format failure. File
+creation, remote reads, cache loading, cancellation, and memory failures retain
+their underlying error category. No catch-all conversion should turn a
+transient system error into an input error.
+
+Once load-time resolution selects Vortex, a footer, planner, sparse-file, or
+reader failure fails the load or operation. Falling back to Raw at that point
+could hide corruption and create unpredictable memory behavior, so it is not
+allowed.
+
+The shared ColumnGroup, file table, planners, and statistics snapshots are
+immutable after publication. Cache slots provide the synchronization for Cell
+load/eviction. Cursors and Take results are operation-local and are not shared
+concurrently. Borrowed Raw views also require the operation context and their
+documented pin owner to remain alive.
+
+On restart, QueryNode re-reads the manifest and footer, reconstructs the
+ColumnGroup, and refills sparse Cell ranges on demand or according to warmup
+policy. No local Vortex cache file is recovered as authoritative state.
+
+## Observability and Troubleshooting
+
+Segment loading logs the segment id, physical column-group index, field count,
+and file count when Vortex is selected. Sparse-file cleanup and range-eviction
+failures are logged as warnings. Existing segment-load, tiered-cache, mmap, and
+query latency telemetry continues to apply.
+
+There are currently no dedicated local-format metrics or traces. Operators can
+diagnose selection by checking schema `local_format`, manifest physical format,
+the Vortex load log, mmap/warmup settings, and cache/load failures. Dedicated
+backend-selection, Cell-pruning, decoded-byte, and pin-lifetime metrics are a
+follow-up before treating the feature as independently observable at scale.
+
+## Compatibility, Rollout, and Rollback
+
+- Existing schemas default to Raw; non-Vortex physical groups remain on Raw.
+- `local_format=vortex` affects only Storage V3 sealed scalar groups that pass
+  the complete-group eligibility check.
+- A binary that understands the physical Vortex reader but not Vortex local
+  format may ignore the local preference and materialize the group through its
+  generic Raw reader path.
+- A binary without support for the manifest's physical Vortex format cannot
+  load that group. Rolling upgrade and rollback must therefore keep all serving
+  QueryNodes at a version that can read the physical files before such files are
+  introduced.
+- Disabling Vortex pushdown is a safe execution fallback. Changing a field back
+  to Raw requires publishing/reloading the affected segment generation; it does
+  not rewrite object-storage files.
+- Growing segments and vector indexes are unchanged.
+
+## Alternatives Considered
+
+### Treat Vortex as another Chunk implementation
+
+Rejected because Vortex has no stable Raw chunk object to expose. Synthesizing
+chunks would force decoding and ownership conversions before the caller knows
+which rows it needs.
+
+### Let each field own its own footer, planner, and cache
+
+Rejected because fields in one physical column group share files and physical
+Cells. Independent state would duplicate metadata, loads, and pins and could
+observe inconsistent eviction lifetimes.
+
+### Let `local_format` select the physical writer
+
+Rejected because schema intent and persisted encoding have different lifecycle
+and compatibility constraints. The manifest must remain authoritative for the
+physical format.
+
+### Fall back to Raw after a selected Vortex reader fails
+
+Rejected because it hides corruption or infrastructure failures and can turn a
+bounded on-demand load into unexpected full materialization.
+
+## Verification and Acceptance
+
+Correctness coverage must include:
+
+- schema create/alter validation and `FieldMeta` round-trip;
+- column-group splitting for absent, Raw, Vortex, primary-key, and mixed fields;
+- load-time decision-table cases for Raw and Vortex physical groups;
+- multiple ordered Vortex files, mixed per-file Arrow representations, empty
+  Cells, malformed ranges, row-count mismatch, and cross-field misalignment;
+- nullable and all-valid data, validity-only access, skipped valid rows, skipped
+  NULL rows, and NOT/candidate-mask expression behavior;
+- sequential/seeked Scan and ordered, shuffled, duplicate-offset Take;
+- retrieve, requery, offset-input expression, temporary text-index build, and
+  virtual-primary-key callers;
+- cancellation, remote read failure, corrupt footer/data, local sparse-file
+  failure, cache eviction, segment replacement, and restart reconstruction;
+- memory and mmap backings with sync, async, and disabled warmup.
+
+Performance acceptance compares the new Raw Scan/Take path with the previous
+Chunk path on the same segment and workload. Benchmarks cover fixed-width and
+view types, single and multiple Cells, hot and cold cache, sequential Scan,
+ordered and shuffled Take, first-window latency, total throughput, peak pinned
+bytes, and pin counts. A repeatable Raw regression requires optimization or an
+explicit design decision before rollout; reduced pin calls alone are not
+sufficient evidence. Vortex benchmarks separately measure pruning, bytes read,
+decode cost, and memory reduction.
+
+Required repository builds, focused unit tests, integration tests, DCO, and CI
+must pass before merge.
+
+## Implementation Phases and Follow-ups
+
+Phase 1 introduces local-format selection and the common Scan/Take operations on
+`ChunkedColumnInterface`, then migrates sealed expression and retrieve/requery
+main paths. Legacy Chunk access remains only for consumers not yet migrated.
+
+Phase 2 removes external Chunk access from sealed columns, leaves Chunk-specific
+APIs only behind concrete Raw/Growing implementations, and renames the common
+abstraction to `ColumnInterface`.
+
+Known follow-ups:
+
+Unless explicitly reassigned, the Feature DRI and Primary Approver own these
+follow-ups:
+
+- complete exact target validation for recursively represented ARRAY values
+  after the storage representation stabilizes;
+- avoid decoding Vortex Take positions that a filter has already skipped;
+- decide whether `CursorOwned` should become the default from representative
+  benchmarks; `ResultOwned` remains the current default;
+- integrate sparse Vortex writes with the unified Milvus file-I/O controller
+  when that interface is available;
+- optimize random long VARCHAR/JSON/ARRAY Take and owned conversion;
+- add dedicated local-format selection, pruning, decode, and pin metrics;
+- expand safe predicate pushdown beyond the initial VARCHAR operators.
+
+## Design Review Status
+
+The technical document records the intended final state, but it is not ready to
+merge under the Milvus Feature Design Review process until the Feature DRI,
+Primary Approver, Independent Approver, and review date are filled in; the
+required meeting (including Liu Li) is held; its conclusions are reflected
+here; and both named approvers explicitly approve the Design Doc PR.
 
 ## References
 
-- [Milvus PR: support vortex local format](https://github.com/milvus-io/milvus/pull/49908)
-- [Milvus issue: vortex local format](https://github.com/milvus-io/milvus/issues/50304)
+- [Milvus PR: scalar local-format data-scan foundation](https://github.com/milvus-io/milvus/pull/51504)
+- [Milvus issue: Vortex local format](https://github.com/milvus-io/milvus/issues/50304)
 - [milvus-storage](https://github.com/milvus-io/milvus-storage)
-- [Vortex project](https://github.com/vortex-data/vortex)
+- [Vortex](https://github.com/vortex-data/vortex)

--- a/docs/design-docs/design_docs/20260305-local_format.md
+++ b/docs/design-docs/design_docs/20260305-local_format.md
@@ -305,10 +305,19 @@ Data scan supports:
 - validity;
 - validity-only projection.
 
-Scan cursors are streaming. Implementations that materialize per-row views or
-wrappers must honor `ScanOptions::max_batch_rows` and create only the next
-bounded batch in `Next()`. Fixed-width zero-copy cursors may expose a larger
-natural source batch because doing so does not allocate one wrapper per row.
+`ValidityView` has one unambiguous no-mask state: `AllValid`. A non-empty mask
+uses either `BoolArray` or storage-native `Bitmap` with a non-null data pointer.
+The expression boundary normalizes either encoded mask to the legacy evaluator
+bool-array contract before evaluating values; evaluators therefore never
+interpret a bitmap-backed NULL row as valid.
+
+Scan cursors are streaming. For dense data scans, `Position()` is the next row
+not yet returned to the expression layer. `Next(max_rows)` returns a complete
+batch starting at that position, bounded by both `max_rows` and the current
+column chunk, then advances the cursor position. This keeps reader, file,
+buffer, and batch-slicing state inside the cursor. Materialized views are
+therefore bounded by the current execution request, while fixed-width batches
+remain zero-copy subviews.
 
 Row-id scan supports:
 
@@ -392,6 +401,16 @@ Expr data path
 This is the current path for examples such as `LIKE`, `IN`, JSON path
 expressions, and array predicates when they cannot be represented as a Vortex
 predicate.
+
+The expression layer keeps only its segment-global execution position. Normal
+evaluation consumes complete cursor batches and advances that position. If a
+conjunction short-circuits an execution batch, the expression advances its
+logical position and closes the active cursor. The next real read reopens a
+cursor at the new position on the same retained column generation. A future
+cursor seek operation can replace reopen without changing this ownership split.
+Legacy Chunk access follows the same position rule: chunk id and in-chunk offset
+are derived caches. A short-circuit invalidates that cache, and the next Chunk
+read reconstructs it from the segment-global execution position.
 
 ### Offset Input Execution
 

--- a/docs/design-docs/design_docs/20260305-local_format.md
+++ b/docs/design-docs/design_docs/20260305-local_format.md
@@ -130,10 +130,11 @@ consumes a sparse local file view behind these column-level operations.
 
 Milvus is in a transition state where two access families coexist:
 
-- `ChunkedBase` remains the raw chunk-oriented path for the existing raw local
-  format and existing chunk consumers.
-- `ChunkedColumnInterface` is the local-format-aware path used by Vortex and by
-  scan/take code that should not depend on physical chunk ownership.
+- `ChunkedBase` remains the physical raw-chunk interface for existing consumers
+  that explicitly need chunk ownership.
+- `ChunkedColumnInterface` is the local-format-aware path used by scan/take
+  code. Raw columns implement `Scan` as zero-copy views over their existing
+  chunks, while Vortex columns implement it with reader-backed cursors.
 
 Filter scan path:
 
@@ -305,11 +306,13 @@ Data scan supports:
 - validity;
 - validity-only projection.
 
-`ValidityView` has one unambiguous no-mask state: `AllValid`. A non-empty mask
-uses either `BoolArray` or storage-native `Bitmap` with a non-null data pointer.
-The expression boundary normalizes either encoded mask to the legacy evaluator
-bool-array contract before evaluating values; evaluators therefore never
-interpret a bitmap-backed NULL row as valid.
+`ScanBatch::validity` has one evaluator-facing representation: a batch-relative
+`const bool*`. A null pointer means every row in the batch is valid; otherwise
+the pointer contains one boolean per dense row or sparse row id. Each cursor
+normalizes storage-native validity before returning a batch. In particular,
+Vortex converts the current Arrow slice's validity bitmap into a
+`FixedVector<bool>`, and `ScanBatch::owner` keeps that mask and the values alive
+for the batch lifetime.
 
 Scan cursors are streaming. For dense data scans, `Position()` is the next row
 not yet returned to the expression layer. `Next(max_rows)` returns a complete
@@ -325,8 +328,10 @@ Row-id scan supports:
 - binary range predicates;
 - sparse row-id batches.
 
-If a column implementation cannot support a scan mode, it falls back to the
-raw-compatible behavior through the existing chunked path.
+Every sealed scalar column used by expression evaluation must provide the
+raw-compatible data scan. A missing sealed scan implementation is a column
+contract violation rather than a per-batch fallback. Growing and non-chunked
+segments continue to use their existing chunk access path.
 
 #### `VortexColumnGroup`
 
@@ -454,20 +459,22 @@ tracked as a separate performance area from filter pushdown.
 
 ### Nullable and Validity
 
-The `ChunkedColumnInterface` scan API uses `ValidityView` to present nullability
-uniformly.
+The `ChunkedColumnInterface` scan API presents nullability uniformly through
+`ScanBatch::validity`.
 
 Rules:
 
-- Non-nullable fields may return all-valid validity.
+- Non-nullable or all-valid batches return `nullptr`.
 - Nullable dense data scans must return validity aligned with the dense row
   range.
 - Row-id scans may return validity aligned with sparse row ids.
 - Validity-only projection is part of the scan model so callers that only need
   nullability do not need to materialize full values.
 
-The raw path may adapt its existing `bool*` validity representation into this
-model. Vortex uses Arrow bitmap/null-buffer semantics.
+Raw cursors expose their existing boolean validity directly. Vortex cursors
+convert Arrow bitmap/null-buffer semantics into a batch-local boolean mask
+before returning from `Next`; the expression layer never interprets a
+storage-native validity encoding.
 
 ### Sparse Local File and Cache Loading
 
@@ -514,9 +521,9 @@ level so all field proxies in the same physical group share the same state.
 - Existing non-Vortex segments continue to load through the raw path.
 - A schema can contain default (empty), raw, and Vortex local format fields;
   column group splitting keeps the three intents physically separate.
-- During the transition, QueryNode keeps both access paths: raw fields continue
-  to use the `ChunkedBase` chunk-oriented path, while Vortex fields use the
-  `ChunkedColumnInterface` column-oriented path.
+- During the transition, existing raw storage and non-scan chunk consumers are
+  unchanged. Sealed scalar expression evaluation uses the same
+  `ChunkedColumnInterface::Scan` contract for both raw and Vortex columns.
 - Vortex local format is only used for Storage V3 sealed segments.
 - Rolling upgrades must ensure QueryNodes understand Vortex local format before
   new Vortex column groups are loaded. Older readers cannot load Vortex physical

--- a/docs/design-docs/design_docs/20260305-local_format.md
+++ b/docs/design-docs/design_docs/20260305-local_format.md
@@ -314,13 +314,15 @@ Vortex converts the current Arrow slice's validity bitmap into a
 `FixedVector<bool>`, and `ScanBatch::owner` keeps that mask and the values alive
 for the batch lifetime.
 
-Scan cursors are streaming. For dense data scans, `Position()` is the next row
-not yet returned to the expression layer. `Next(max_rows)` returns a complete
-batch starting at that position, bounded by both `max_rows` and the current
-column chunk, then advances the cursor position. This keeps reader, file,
-buffer, and batch-slicing state inside the cursor. Materialized views are
-therefore bounded by the current execution request, while fixed-width batches
-remain zero-copy subviews.
+Scan creation first plans the cells required by the requested row range and
+projection, pins that complete cell set, and then constructs the cursor over
+the pinned input. Validity-only scans use the same flow but omit value parsing;
+non-nullable validity-only scans have an empty cell plan. `Next(max_rows)` never
+loads or pins cells. It only returns a complete batch starting at `Position()`,
+bounded by both `max_rows` and the current column chunk, and advances the cursor
+position. `ScanBatch::owner` shares the cursor's pinned input (plus any
+batch-local materialization) so returned pointers remain valid even if the
+cursor advances or is closed.
 
 Row-id scan supports:
 

--- a/docs/design-docs/design_docs/20260305-local_format.md
+++ b/docs/design-docs/design_docs/20260305-local_format.md
@@ -300,9 +300,15 @@ Scan outputs:
 Data scan supports:
 
 - row range;
-- value kind (`FixedWidth`, `StringView`, `JsonView`, `ArrayView`);
+- value kind (`FixedWidth`, `StringView`, `JsonView`, `ArrayView`,
+  `VectorArrayView`);
 - validity;
 - validity-only projection.
+
+Scan cursors are streaming. Implementations that materialize per-row views or
+wrappers must honor `ScanOptions::max_batch_rows` and create only the next
+bounded batch in `Next()`. Fixed-width zero-copy cursors may expose a larger
+natural source batch because doing so does not allocate one wrapper per row.
 
 Row-id scan supports:
 

--- a/internal/core/src/CMakeLists.txt
+++ b/internal/core/src/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 add_subdirectory( pb )
 add_subdirectory( config )
 add_subdirectory( common )
+add_subdirectory( mmap )
 add_subdirectory( monitor )
 add_subdirectory( storage )
 add_subdirectory( index )
@@ -131,7 +132,7 @@ if (MILVUS_USE_PCH)
     # which are incompatible with PCH compiled under default target features.
     foreach(_target
         milvus_common milvus_config milvus_monitor milvus_storage milvus_index
-        milvus_query milvus_segcore milvus_indexbuilder milvus_clustering
+        milvus_mmap milvus_query milvus_segcore milvus_indexbuilder milvus_clustering
         milvus_exec milvus_futures milvus_rescores
         milvus_plan)
         target_precompile_headers(${_target} PRIVATE ${MILVUS_PCH_HEADERS})
@@ -142,6 +143,7 @@ add_library(milvus_core SHARED
     $<TARGET_OBJECTS:milvus_pb>
     $<TARGET_OBJECTS:milvus_config>
     $<TARGET_OBJECTS:milvus_common>
+    $<TARGET_OBJECTS:milvus_mmap>
     $<TARGET_OBJECTS:milvus_monitor>
     $<TARGET_OBJECTS:milvus_storage>
     $<TARGET_OBJECTS:milvus_index>

--- a/internal/core/src/CMakeLists.txt
+++ b/internal/core/src/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 add_subdirectory( pb )
 add_subdirectory( config )
 add_subdirectory( common )
+add_subdirectory( mmap )
 add_subdirectory( monitor )
 add_subdirectory( storage )
 add_subdirectory( index )
@@ -146,7 +147,7 @@ if (MILVUS_USE_PCH)
     # which are incompatible with PCH compiled under default target features.
     foreach(_target
         milvus_common milvus_config milvus_monitor milvus_storage milvus_index
-        milvus_query milvus_segcore milvus_indexbuilder milvus_clustering
+        milvus_mmap milvus_query milvus_segcore milvus_indexbuilder milvus_clustering
         milvus_exec milvus_futures milvus_rescores
         milvus_plan)
         target_precompile_headers(${_target} PRIVATE ${MILVUS_PCH_HEADERS})
@@ -161,6 +162,7 @@ add_library(milvus_core SHARED
     $<TARGET_OBJECTS:milvus_pb>
     $<TARGET_OBJECTS:milvus_config>
     $<TARGET_OBJECTS:milvus_common>
+    $<TARGET_OBJECTS:milvus_mmap>
     $<TARGET_OBJECTS:milvus_monitor>
     $<TARGET_OBJECTS:milvus_storage>
     $<TARGET_OBJECTS:milvus_index>

--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -199,7 +199,7 @@ class Chunk {
 // for fixed size data, includes fixed size array
 class FixedWidthChunk : public Chunk {
  public:
-    FixedWidthChunk(int32_t row_nums,
+    FixedWidthChunk(int64_t row_nums,
                     int32_t dim,
                     char* data,
                     uint64_t size,

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -529,14 +529,11 @@ class SegmentExpr : public Expr {
                    static_cast<int>(data_access_mode_));
         AssertInfo(data_scan_column_ != nullptr,
                    "data scan column is not initialized");
-        auto options = ChunkedColumnInterface::ScanOptions::ForData(
-            position,
-            active_count_ - position,
-            data_scan_projection_,
-            data_scan_value_kind_);
-        data_scan_cursor_ = data_scan_column_->Scan(op_ctx_, options);
+        AssertInfo(data_prepared_scan_ != nullptr,
+                   "prepared data scan is not initialized");
+        data_scan_cursor_ = data_prepared_scan_->Seek(position);
         AssertInfo(data_scan_cursor_ != nullptr,
-                   "data scan backend cannot reopen field {} at row {}",
+                   "data scan backend cannot seek field {} to row {}",
                    field_id_.get(),
                    position);
         AssertInfo(data_scan_cursor_->Position() == position,
@@ -574,13 +571,19 @@ class SegmentExpr : public Expr {
             active_count_ - current_data_global_pos_,
             projection,
             value_kind);
-        data_scan_cursor_ = data_scan_column_->Scan(op_ctx_, options);
-        if (data_scan_cursor_ == nullptr) {
+        data_prepared_scan_ =
+            data_scan_column_->PrepareScan(op_ctx_, options);
+        if (data_prepared_scan_ == nullptr) {
             data_scan_skip_index_.reset();
             data_scan_column_.reset();
             data_access_mode_ = DataAccessMode::Chunk;
             return false;
         }
+        data_scan_cursor_ = data_prepared_scan_->Seek(current_data_global_pos_);
+        AssertInfo(data_scan_cursor_ != nullptr,
+                   "prepared data scan cannot seek field {} to row {}",
+                   field_id_.get(),
+                   current_data_global_pos_);
         data_access_mode_ = DataAccessMode::Scan;
         AssertInfo(data_scan_cursor_->Position() == current_data_global_pos_,
                    "data scan cursor opened at {}, expected {}",
@@ -3229,9 +3232,13 @@ class SegmentExpr : public Expr {
     DataAccessMode data_access_mode_{DataAccessMode::Uninitialized};
     // ScanCursor implementations retain a raw column pointer. Once Scan is
     // selected, keep the captured column generation for the expression's full
-    // lifetime so short-circuit reopen never observes a replacement column.
+    // lifetime so a short-circuit seek never observes a replacement column.
     std::shared_ptr<ChunkedColumnInterface> data_scan_column_{nullptr};
     std::shared_ptr<const SkipIndex> data_scan_skip_index_{nullptr};
+    // Owns the planned/pinned scan input independently from the active cursor.
+    // A conjunction short-circuit may discard the cursor and later seek while
+    // keeping this prepared scan alive, so seeking never pins cells again.
+    ChunkedColumnInterface::PreparedScanResult data_prepared_scan_{nullptr};
     std::unique_ptr<ChunkedColumnInterface::ScanCursor> data_scan_cursor_{
         nullptr};
     ChunkedColumnInterface::ScanProjection data_scan_projection_{

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -494,10 +494,13 @@ class SegmentExpr : public Expr {
 
     template <typename T>
     ChunkedColumnInterface::PreparedScanResult
-    PrepareDataScanWindow(int64_t start,
-                          int64_t length,
-                          ChunkedColumnInterface::ScanProjection projection =
-                              ChunkedColumnInterface::ScanProjection::Data) {
+    PrepareDataScanWindow(
+        int64_t start,
+        int64_t length,
+        ChunkedColumnInterface::ScanProjection projection =
+            ChunkedColumnInterface::ScanProjection::Data,
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func =
+            {}) {
         const auto value_kind = DataScanValueKind<T>();
         if (data_access_mode_ == DataAccessMode::Chunk) {
             return nullptr;
@@ -519,6 +522,20 @@ class SegmentExpr : public Expr {
 
         auto options = ChunkedColumnInterface::ScanOptions::ForData(
             start, length, projection, value_kind);
+        if (skip_func && data_scan_skip_index_ != nullptr) {
+            const auto source =
+                data_scan_skip_index_->GetMetricsSource(field_id_);
+            auto cell_skip = [skip_index = data_scan_skip_index_,
+                              skip_func = std::move(skip_func),
+                              field_id = field_id_](int64_t cell_id) {
+                return skip_func(*skip_index, field_id, cell_id);
+            };
+            if (source == SkipIndex::MetricsSource::PreloadedStatistics) {
+                options.metadata_skip_cell = std::move(cell_skip);
+            } else if (source == SkipIndex::MetricsSource::LoadedPayload) {
+                options.loaded_skip_cell = std::move(cell_skip);
+            }
+        }
         auto prepared = data_scan_column_->PrepareScan(op_ctx_, options);
         if (prepared == nullptr) {
             AssertInfo(data_access_mode_ != DataAccessMode::Scan,
@@ -1817,7 +1834,8 @@ class SegmentExpr : public Expr {
         auto prepared = PrepareDataScanWindow<T>(
             window_start,
             real_batch_size,
-            ChunkedColumnInterface::ScanProjection::Data);
+            ChunkedColumnInterface::ScanProjection::Data,
+            skip_func);
         if (prepared == nullptr) {
             return -1;
         }
@@ -1878,36 +1896,11 @@ class SegmentExpr : public Expr {
                        "invalid no-match scan range [{}, {})",
                        start,
                        end);
-            auto validity_cursor = prepared->Open(
-                ChunkedColumnInterface::ScanPlan::Full(start, end - start),
-                ChunkedColumnInterface::ScanProjection::NoData);
-            AssertInfo(validity_cursor != nullptr,
-                       "prepared scan cannot open validity range [{}, {})",
+            AssertInfo(!data_scan_column_->IsNullable(),
+                       "nullable data scan omitted validity range [{}, {})",
                        start,
                        end);
-            auto position = start;
-            ChunkedColumnInterface::ScanBatch validity_batch;
-            while (validity_cursor->Next(end - position, &validity_batch)) {
-                AssertInfo(validity_batch.row_id_start == position &&
-                               validity_batch.size > 0 &&
-                               position + validity_batch.size <= end,
-                           "invalid no-match validity batch [{}, {}) at {}",
-                           validity_batch.row_id_start,
-                           validity_batch.row_id_start + validity_batch.size,
-                           position);
-                const auto output_offset = position - window_start;
-                ApplyScanValidity(validity_batch,
-                                  0,
-                                  res + output_offset,
-                                  valid_res + output_offset,
-                                  validity_batch.size);
-                evaluate_batch(nullptr, nullptr, position, validity_batch.size);
-                position += validity_batch.size;
-            }
-            AssertInfo(position == end && validity_cursor->Position() == end,
-                       "no-match validity scan stopped at {}, expected {}",
-                       position,
-                       end);
+            evaluate_batch(nullptr, nullptr, start, end - start);
         };
 
         auto logical_position = window_start;
@@ -1936,29 +1929,7 @@ class SegmentExpr : public Expr {
             if (batch.row_id_start > logical_position) {
                 evaluate_no_match(logical_position, batch.row_id_start);
             }
-            AssertInfo(!batch.values.empty(),
-                       "evaluated data scan batch [{}, {}) has no values",
-                       batch.row_id_start,
-                       batch.row_id_start + batch.size);
-            bool legacy_skipped = false;
-            if (data_scan_column_->UseLegacyDataSkipIndex() && skip_func) {
-                AssertInfo(data_scan_skip_index_ != nullptr,
-                           "legacy data skip index is not initialized");
-                auto [chunk_id, _] =
-                    data_scan_column_->GetChunkIDByOffset(batch.row_id_start);
-                const auto chunk_end =
-                    data_scan_column_->GetNumRowsUntilChunk(chunk_id) +
-                    data_scan_column_->chunk_row_nums(chunk_id);
-                AssertInfo(batch.row_id_start + batch.size <= chunk_end,
-                           "legacy skip batch [{}, {}) crosses chunk {} end {}",
-                           batch.row_id_start,
-                           batch.row_id_start + batch.size,
-                           chunk_id,
-                           chunk_end);
-                legacy_skipped =
-                    skip_func(*data_scan_skip_index_, field_id_, chunk_id);
-            }
-            if (legacy_skipped) {
+            if (batch.values.empty()) {
                 const auto output_offset = batch.row_id_start - window_start;
                 ApplyScanValidity(batch,
                                   0,

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -586,9 +586,6 @@ class SegmentExpr : public Expr {
                    "data scan cursor opened at {}, expected {}",
                    data_scan_cursor_->Position(),
                    current_data_global_pos_);
-        if (projection != ChunkedColumnInterface::ScanProjection::NoData) {
-            PrefetchRawDataChunksForScanIfNeeded(data_scan_column_.get());
-        }
         return true;
     }
 
@@ -611,30 +608,6 @@ class SegmentExpr : public Expr {
                    data_scan_cursor_->Position(),
                    position);
         return true;
-    }
-
-    void
-    PrefetchRawDataChunksForScanIfNeeded(const ChunkedColumnInterface* column) {
-        if (column == nullptr || prefetched_ || !segment_->is_chunked()) {
-            return;
-        }
-        const auto num_chunks = column->num_chunks();
-        int64_t first_chunk = num_chunks;
-        if (current_data_global_pos_ < active_count_) {
-            first_chunk =
-                column->GetChunkIDByOffset(current_data_global_pos_).first;
-        }
-        AssertInfo(first_chunk >= 0 && first_chunk <= num_chunks,
-                   "scan prefetch chunk {} out of range {}",
-                   first_chunk,
-                   num_chunks);
-        std::vector<int64_t> chunk_ids;
-        chunk_ids.reserve(num_chunks - first_chunk);
-        for (int64_t i = first_chunk; i < num_chunks; i++) {
-            chunk_ids.push_back(i);
-        }
-        column->PrefetchChunks(op_ctx_, chunk_ids);
-        prefetched_ = true;
     }
 
     static void

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -62,6 +62,12 @@ enum class ExprExecPath {
     JsonStats,    // segment_->GetJsonStats
 };
 
+enum class DataAccessMode {
+    Uninitialized,
+    Chunk,
+    Scan,
+};
+
 inline std::vector<PinWrapper<const index::IndexBase*>>
 PinIndex(milvus::OpContext* op_ctx,
          const segcore::SegmentInternalInterface* segment,
@@ -394,96 +400,64 @@ class SegmentExpr : public Expr {
     }
 
     void
-    MoveCursorForDataMultipleChunk() {
-        int64_t processed_size = 0;
-        for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-            auto data_pos =
-                (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            // if segment is chunked, type won't be growing
-            int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
-
-            size = std::min(size, batch_size_ - processed_size);
-
-            processed_size += size;
-            current_data_chunk_ = i;
-            current_data_chunk_pos_ = data_pos + size;
-            if (processed_size >= batch_size_) {
-                break;
-            }
-        }
-        current_data_global_pos_ = current_data_global_pos_ + processed_size;
-    }
-
-    // Non-chunked segments are always Growing (Sealed is always chunked).
-    void
-    MoveCursorForDataSingleChunk() {
-        int64_t processed_size = 0;
-        for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-            auto data_pos =
-                (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            auto size = (i == (num_data_chunk_ - 1) &&
-                         active_count_ % size_per_chunk_ != 0)
-                            ? active_count_ % size_per_chunk_ - data_pos
-                            : size_per_chunk_ - data_pos;
-
-            size = std::min(size, batch_size_ - processed_size);
-
-            processed_size += size;
-            current_data_chunk_ = i;
-            current_data_chunk_pos_ = data_pos + size;
-            if (processed_size >= batch_size_) {
-                break;
-            }
-        }
-        current_data_global_pos_ = current_data_global_pos_ + processed_size;
-    }
-
-    void
-    MoveCursorForDataScan() {
-        AssertInfo(data_scan_column_ != nullptr,
-                   "data scan column is not initialized");
-        const auto target_size =
-            std::min(batch_size_, active_count_ - current_data_global_pos_);
-        int64_t processed_size = 0;
-        for (size_t i = current_data_chunk_;
-             i < static_cast<size_t>(data_scan_column_->num_chunks());
-             ++i) {
-            const auto data_pos =
-                (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            auto size = data_scan_column_->chunk_row_nums(i) - data_pos;
-            size = std::min(size, target_size - processed_size);
-
-            processed_size += size;
-            current_data_chunk_ = i;
-            current_data_chunk_pos_ = data_pos + size;
-            if (processed_size >= target_size) {
-                break;
-            }
-        }
-        current_data_global_pos_ += processed_size;
-    }
-
-    void
-    ResetDataScanCursor() {
-        data_scan_initialized_ = false;
+    CloseDataScanCursor() {
         data_scan_cursor_.reset();
-        data_scan_batch_ = ChunkedColumnInterface::ScanBatch{};
-        data_scan_batch_pos_ = 0;
-        data_scan_skip_index_.reset();
-        data_scan_column_.reset();
     }
 
     void
-    MoveCursorForData(bool preserve_data_scan_cursor = false) {
-        if (data_scan_column_ != nullptr) {
-            MoveCursorForDataScan();
-        } else if (segment_->is_chunked()) {
-            MoveCursorForDataMultipleChunk();
-        } else {
-            MoveCursorForDataSingleChunk();
+    InvalidateDataChunkCursor() {
+        data_chunk_cursor_global_pos_ = -1;
+    }
+
+    void
+    EnsureDataChunkCursorAt(int64_t position) {
+        AssertInfo(position >= 0 && position <= active_count_,
+                   "data chunk cursor position {} out of range {}",
+                   position,
+                   active_count_);
+        if (data_chunk_cursor_global_pos_ == position) {
+            return;
         }
-        if (!preserve_data_scan_cursor) {
-            ResetDataScanCursor();
+        if (position == active_count_) {
+            data_chunk_cursor_global_pos_ = position;
+            return;
+        }
+
+        if (segment_->is_chunked()) {
+            auto [chunk_id, chunk_offset] =
+                segment_->get_chunk_by_offset(field_id_, position);
+            current_data_chunk_ = chunk_id;
+            current_data_chunk_pos_ = chunk_offset;
+        } else {
+            current_data_chunk_ = position / size_per_chunk_;
+            current_data_chunk_pos_ = position % size_per_chunk_;
+        }
+        data_chunk_cursor_global_pos_ = position;
+    }
+
+    void
+    CommitDataChunkProgress(int64_t processed_rows) {
+        AssertInfo(
+            processed_rows >= 0 &&
+                current_data_global_pos_ + processed_rows <= active_count_,
+            "data chunk progress {} from {} exceeds row count {}",
+            processed_rows,
+            current_data_global_pos_,
+            active_count_);
+        current_data_global_pos_ += processed_rows;
+        data_chunk_cursor_global_pos_ = current_data_global_pos_;
+    }
+
+    void
+    MoveCursorForData() {
+        current_data_global_pos_ +=
+            std::min(batch_size_, active_count_ - current_data_global_pos_);
+        // MoveCursor() means this expression was short-circuited for the
+        // current execution batch. The global position is authoritative;
+        // backend-specific cursors are caches and are rebuilt on the next read.
+        InvalidateDataChunkCursor();
+        if (data_access_mode_ == DataAccessMode::Scan) {
+            CloseDataScanCursor();
         }
     }
 
@@ -499,7 +473,7 @@ class SegmentExpr : public Expr {
     }
 
     void
-    MoveCursorInternal(bool preserve_data_scan_cursor) {
+    MoveCursorInternal() {
         if (!has_offset_input_) {
             if (execute_all_at_once_) {
                 // One-shot execution, no cursor movement needed.
@@ -508,21 +482,21 @@ class SegmentExpr : public Expr {
             if (UseIndexCursor()) {
                 MoveCursorForIndex();
                 if (segment_->HasFieldData(field_id_)) {
-                    MoveCursorForData(preserve_data_scan_cursor);
+                    MoveCursorForData();
                 }
             } else if (exec_path_ == ExprExecPath::JsonStats) {
                 current_data_global_pos_ += std::min(
                     batch_size_, active_count_ - current_data_global_pos_);
             } else {
                 // RawData, PkIndex, and TextIndex use the data cursor.
-                MoveCursorForData(preserve_data_scan_cursor);
+                MoveCursorForData();
             }
         }
     }
 
     void
     MoveCursor() override {
-        MoveCursorInternal(false);
+        MoveCursorInternal();
     }
 
     template <typename T>
@@ -548,50 +522,94 @@ class SegmentExpr : public Expr {
         return segment_->GetDataScanResources(field_id_);
     }
 
+    void
+    OpenDataScanCursor(int64_t position) {
+        AssertInfo(data_access_mode_ == DataAccessMode::Scan,
+                   "cannot open data scan cursor in mode {}",
+                   static_cast<int>(data_access_mode_));
+        AssertInfo(data_scan_column_ != nullptr,
+                   "data scan column is not initialized");
+        auto options = ChunkedColumnInterface::ScanOptions::ForData(
+            position,
+            active_count_ - position,
+            data_scan_projection_,
+            data_scan_value_kind_);
+        data_scan_cursor_ = data_scan_column_->Scan(op_ctx_, options);
+        AssertInfo(data_scan_cursor_ != nullptr,
+                   "data scan backend cannot reopen field {} at row {}",
+                   field_id_.get(),
+                   position);
+        AssertInfo(data_scan_cursor_->Position() == position,
+                   "data scan cursor opened at {}, expected {}",
+                   data_scan_cursor_->Position(),
+                   position);
+    }
+
     template <typename T>
     bool
-    InitDataScanCursorIfNeeded(
-        ChunkedColumnInterface::ScanProjection projection =
-            ChunkedColumnInterface::ScanProjection::Data) {
-        if (data_scan_initialized_) {
-            return data_scan_cursor_ != nullptr;
+    EnsureDataScanBackend(ChunkedColumnInterface::ScanProjection projection =
+                              ChunkedColumnInterface::ScanProjection::Data) {
+        const auto value_kind = DataScanValueKind<T>();
+        if (data_access_mode_ == DataAccessMode::Chunk) {
+            return false;
         }
-        data_scan_initialized_ = true;
+        if (data_access_mode_ == DataAccessMode::Scan) {
+            AssertInfo(data_scan_projection_ == projection &&
+                           data_scan_value_kind_ == value_kind,
+                       "data scan contract changed after backend selection");
+            return true;
+        }
+
         std::tie(data_scan_column_, data_scan_skip_index_) =
             CaptureDataScanResources();
         if (data_scan_column_ == nullptr) {
+            data_access_mode_ = DataAccessMode::Chunk;
             return false;
         }
+
+        data_scan_projection_ = projection;
+        data_scan_value_kind_ = value_kind;
         auto options = ChunkedColumnInterface::ScanOptions::ForData(
             current_data_global_pos_,
             active_count_ - current_data_global_pos_,
             projection,
-            DataScanValueKind<T>(),
-            batch_size_);
+            value_kind);
         data_scan_cursor_ = data_scan_column_->Scan(op_ctx_, options);
         if (data_scan_cursor_ == nullptr) {
             data_scan_skip_index_.reset();
             data_scan_column_.reset();
+            data_access_mode_ = DataAccessMode::Chunk;
             return false;
         }
-        // Once this expression has bound a column scan, its stable cursor is
-        // the segment-global row position. Keep using that coordinate after a
-        // short-circuit reset: the saved chunk id/offset belong to the retained
-        // column generation and must not be interpreted through a concurrently
-        // published replacement before the next Scan() rebases them.
-        data_scan_mode_entered_ = true;
-        // Commit the chunk cursor only after Scan() succeeds. Capability
-        // probing must remain side-effect free for non-scan providers such as
-        // growing segments.
-        if (current_data_global_pos_ < active_count_) {
-            auto [chunk_id, chunk_offset] =
-                data_scan_column_->GetChunkIDByOffset(current_data_global_pos_);
-            current_data_chunk_ = chunk_id;
-            current_data_chunk_pos_ = chunk_offset;
-        }
+        data_access_mode_ = DataAccessMode::Scan;
+        AssertInfo(data_scan_cursor_->Position() == current_data_global_pos_,
+                   "data scan cursor opened at {}, expected {}",
+                   data_scan_cursor_->Position(),
+                   current_data_global_pos_);
         if (projection != ChunkedColumnInterface::ScanProjection::NoData) {
             PrefetchRawDataChunksForScanIfNeeded(data_scan_column_.get());
         }
+        return true;
+    }
+
+    template <typename T>
+    bool
+    EnsureDataScanCursorAt(int64_t position,
+                           ChunkedColumnInterface::ScanProjection projection =
+                               ChunkedColumnInterface::ScanProjection::Data) {
+        if (!EnsureDataScanBackend<T>(projection)) {
+            return false;
+        }
+        if (data_scan_cursor_ == nullptr) {
+            OpenDataScanCursor(position);
+        } else if (data_scan_cursor_->Position() < position) {
+            CloseDataScanCursor();
+            OpenDataScanCursor(position);
+        }
+        AssertInfo(data_scan_cursor_->Position() == position,
+                   "data scan cursor at {}, expected {}",
+                   data_scan_cursor_->Position(),
+                   position);
         return true;
     }
 
@@ -601,42 +619,22 @@ class SegmentExpr : public Expr {
             return;
         }
         const auto num_chunks = column->num_chunks();
-        AssertInfo(
-            current_data_chunk_ >= 0 && current_data_chunk_ <= num_chunks,
-            "scan prefetch chunk {} out of range {}",
-            current_data_chunk_,
-            num_chunks);
+        int64_t first_chunk = num_chunks;
+        if (current_data_global_pos_ < active_count_) {
+            first_chunk =
+                column->GetChunkIDByOffset(current_data_global_pos_).first;
+        }
+        AssertInfo(first_chunk >= 0 && first_chunk <= num_chunks,
+                   "scan prefetch chunk {} out of range {}",
+                   first_chunk,
+                   num_chunks);
         std::vector<int64_t> chunk_ids;
-        chunk_ids.reserve(num_chunks - current_data_chunk_);
-        for (int64_t i = current_data_chunk_; i < num_chunks; i++) {
+        chunk_ids.reserve(num_chunks - first_chunk);
+        for (int64_t i = first_chunk; i < num_chunks; i++) {
             chunk_ids.push_back(i);
         }
         column->PrefetchChunks(op_ctx_, chunk_ids);
         prefetched_ = true;
-    }
-
-    bool
-    EnsureDataScanBatch() {
-        while (data_scan_batch_pos_ >= data_scan_batch_.size) {
-            data_scan_batch_pos_ = 0;
-            if (!data_scan_cursor_->Next(&data_scan_batch_)) {
-                return false;
-            }
-            AssertInfo(data_scan_batch_.size > 0, "invalid data scan batch");
-        }
-        return true;
-    }
-
-    static const bool*
-    BoolValidityData(const ChunkedColumnInterface::ScanBatch& batch,
-                     int64_t batch_pos) {
-        if (batch.validity.encoding !=
-                ChunkedColumnInterface::ValidityEncoding::BoolArray ||
-            batch.validity.all_valid || batch.validity.data == nullptr) {
-            return nullptr;
-        }
-        return static_cast<const bool*>(batch.validity.data) +
-               batch.validity.offset + batch_pos;
     }
 
     static void
@@ -646,8 +644,7 @@ class SegmentExpr : public Expr {
                       TargetBitmapView valid_res,
                       int64_t size) {
         if (batch.validity.encoding ==
-                ChunkedColumnInterface::ValidityEncoding::AllValid ||
-            batch.validity.all_valid) {
+            ChunkedColumnInterface::ValidityEncoding::AllValid) {
             return;
         }
         for (int64_t i = 0; i < size; ++i) {
@@ -665,8 +662,7 @@ class SegmentExpr : public Expr {
                                TargetBitmapView valid_res,
                                int64_t size) {
         if (batch.validity.encoding ==
-                ChunkedColumnInterface::ValidityEncoding::AllValid ||
-            batch.validity.all_valid) {
+            ChunkedColumnInterface::ValidityEncoding::AllValid) {
             return;
         }
         for (int64_t i = 0; i < size; ++i) {
@@ -761,27 +757,11 @@ class SegmentExpr : public Expr {
     int64_t
     GetNextBatchSize() {
         EnsureExecPathDetermined();
-        if (exec_path_ == ExprExecPath::JsonStats || data_scan_mode_entered_) {
+        if (UseIndexCursor()) {
             return std::min(batch_size_,
-                            active_count_ - current_data_global_pos_);
+                            active_count_ - current_index_chunk_pos_);
         }
-        auto current_chunk =
-            UseIndexCursor() ? current_index_chunk_ : current_data_chunk_;
-        auto current_chunk_pos = UseIndexCursor() ? current_index_chunk_pos_
-                                                  : current_data_chunk_pos_;
-        auto current_rows = 0;
-        if (segment_->is_chunked()) {
-            current_rows =
-                UseIndexCursor() && segment_->type() == SegmentType::Sealed
-                    ? current_chunk_pos
-                    : segment_->num_rows_until_chunk(field_id_, current_chunk) +
-                          current_chunk_pos;
-        } else {
-            current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
-        }
-        return current_rows + batch_size_ >= active_count_
-                   ? active_count_ - current_rows
-                   : batch_size_;
+        return std::min(batch_size_, active_count_ - current_data_global_pos_);
     }
 
     int64_t
@@ -805,23 +785,8 @@ class SegmentExpr : public Expr {
                    "ArrayOffsets not found for field {}",
                    field_id_.get());
 
-        // Use index cursor or data cursor based on execution path
-        auto current_chunk =
-            UseIndexCursor() ? current_index_chunk_ : current_data_chunk_;
-        auto current_chunk_pos = UseIndexCursor() ? current_index_chunk_pos_
-                                                  : current_data_chunk_pos_;
-
-        int64_t current_rows = 0;
-        if (UseIndexCursor() && segment_->type() == SegmentType::Sealed) {
-            // For sealed segment with index, position is already global
-            current_rows = current_chunk_pos;
-        } else if (segment_->is_chunked()) {
-            current_rows =
-                segment_->num_rows_until_chunk(field_id_, current_chunk) +
-                current_chunk_pos;
-        } else {
-            current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
-        }
+        const auto current_rows = UseIndexCursor() ? current_index_chunk_pos_
+                                                   : current_data_global_pos_;
 
         auto batch_rows = std::min(batch_size_, active_count_ - current_rows);
 
@@ -1241,8 +1206,7 @@ class SegmentExpr : public Expr {
             scan_start,
             scan_length,
             ChunkedColumnInterface::ScanProjection::Data,
-            DataScanValueKind<T>(),
-            batch_size_);
+            DataScanValueKind<T>());
         auto cursor = column->Scan(op_ctx_, options);
         if (cursor == nullptr) {
             return -1;
@@ -1253,9 +1217,12 @@ class SegmentExpr : public Expr {
         batch_offsets.reserve(std::min<int64_t>(batch_size_, input->size()));
 
         ChunkedColumnInterface::ScanBatch batch;
-        while (processed_offsets < input->size() && cursor->Next(&batch)) {
+        FixedVector<bool> validity_scratch;
+        while (processed_offsets < input->size() &&
+               cursor->Next(batch_size_, &batch)) {
             AssertInfo(!batch.values.empty() && batch.size > 0,
                        "invalid offset data scan batch");
+            const auto* valid_data = batch.validity.bool_data(validity_scratch);
 
             int64_t batch_pos = 0;
             while (batch_pos < batch.size &&
@@ -1302,7 +1269,6 @@ class SegmentExpr : public Expr {
                 if (group_size > 0) {
                     if (!skipped) {
                         const auto* data = batch.values.data_as<T>();
-                        const auto* valid_data = BoolValidityData(batch, 0);
                         func.template operator()<FilterType::random>(
                             data,
                             valid_data,
@@ -1654,6 +1620,8 @@ class SegmentExpr : public Expr {
                    "ArrayOffsets not found for field {}",
                    field_id_.get());
 
+        const auto expected_rows = GetNextBatchSize();
+        EnsureDataChunkCursorAt(current_data_global_pos_);
         int64_t processed_rows = 0;
         int64_t processed_elems = 0;
 
@@ -1681,7 +1649,7 @@ class SegmentExpr : public Expr {
                                   : active_count_ % size_per_chunk_ - data_pos)
                            : size_per_chunk_ - data_pos;
             }
-            size = std::min(size, batch_size_ - processed_rows);
+            size = std::min(size, expected_rows - processed_rows);
             if (size <= 0) {
                 continue;
             }
@@ -1883,13 +1851,18 @@ class SegmentExpr : public Expr {
             }
 
             processed_rows += size;
-            if (processed_rows >= batch_size_) {
+            if (processed_rows >= expected_rows) {
                 current_data_chunk_ = i;
                 current_data_chunk_pos_ = data_pos + size;
                 break;
             }
         }
 
+        AssertInfo(processed_rows == expected_rows,
+                   "element data processed {} rows, expected {}",
+                   processed_rows,
+                   expected_rows);
+        CommitDataChunkProgress(processed_rows);
         return processed_elems;
     }
 
@@ -1904,6 +1877,8 @@ class SegmentExpr : public Expr {
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
+        const auto expected_rows = GetNextBatchSize();
+        EnsureDataChunkCursorAt(current_data_global_pos_);
         int64_t processed_size = 0;
 
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
@@ -1914,7 +1889,7 @@ class SegmentExpr : public Expr {
                             ? active_count_ % size_per_chunk_ - data_pos
                             : size_per_chunk_ - data_pos;
 
-            size = std::min(size, batch_size_ - processed_size);
+            size = std::min(size, expected_rows - processed_size);
             if (size == 0) {
                 continue;
             }
@@ -2004,13 +1979,18 @@ class SegmentExpr : public Expr {
             }
 
             processed_size += size;
-            if (processed_size >= batch_size_) {
+            if (processed_size >= expected_rows) {
                 current_data_chunk_ = i;
                 current_data_chunk_pos_ = data_pos + size;
                 break;
             }
         }
 
+        AssertInfo(processed_size == expected_rows,
+                   "chunk data processed {} rows, expected {}",
+                   processed_size,
+                   expected_rows);
+        CommitDataChunkProgress(processed_size);
         return processed_size;
     }
 
@@ -2025,7 +2005,7 @@ class SegmentExpr : public Expr {
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
-        if (!InitDataScanCursorIfNeeded<T>()) {
+        if (!EnsureDataScanBackend<T>()) {
             return -1;
         }
 
@@ -2034,31 +2014,39 @@ class SegmentExpr : public Expr {
         AssertInfo(data_scan_skip_index_ != nullptr,
                    "data scan skip index is not initialized");
 
+        FixedVector<bool> validity_scratch;
         while (processed_size < real_batch_size) {
-            if (!EnsureDataScanBatch()) {
+            const auto expected_row = current_data_global_pos_ + processed_size;
+            AssertInfo(EnsureDataScanCursorAt<T>(expected_row),
+                       "data scan backend changed while processing");
+            ChunkedColumnInterface::ScanBatch batch;
+            const auto remaining = real_batch_size - processed_size;
+            if (!data_scan_cursor_->Next(remaining, &batch)) {
                 break;
             }
-
-            const auto row =
-                data_scan_batch_.row_id_start + data_scan_batch_pos_;
-            const auto expected_row = current_data_global_pos_ + processed_size;
+            AssertInfo(batch.size > 0 && batch.size <= remaining,
+                       "invalid data scan batch size {}, remaining {}",
+                       batch.size,
+                       remaining);
+            const auto row = batch.row_id_start;
             AssertInfo(row == expected_row,
                        "data scan row mismatch, got {}, expected {}",
                        row,
                        expected_row);
 
-            auto size =
-                std::min<int64_t>(real_batch_size - processed_size,
-                                  data_scan_batch_.size - data_scan_batch_pos_);
+            const auto size = batch.size;
             auto [chunk_id, _] = data_scan_column_->GetChunkIDByOffset(row);
             const auto chunk_end =
                 data_scan_column_->GetNumRowsUntilChunk(chunk_id) +
                 data_scan_column_->chunk_row_nums(chunk_id);
-            size = std::min<int64_t>(size, chunk_end - row);
-            const auto* data =
-                data_scan_batch_.values.data_as<T>() + data_scan_batch_pos_;
-            const auto* valid_data =
-                BoolValidityData(data_scan_batch_, data_scan_batch_pos_);
+            AssertInfo(row + size <= chunk_end,
+                       "data scan batch [{}, {}) crosses chunk {} end {}",
+                       row,
+                       row + size,
+                       chunk_id,
+                       chunk_end);
+            const auto* data = batch.values.data_as<T>();
+            const auto* valid_data = batch.validity.bool_data(validity_scratch);
             const bool skipped =
                 skip_func &&
                 skip_func(*data_scan_skip_index_, field_id_, chunk_id);
@@ -2092,15 +2080,15 @@ class SegmentExpr : public Expr {
                          values...);
                 }
                 if (valid_data == nullptr) {
-                    ApplyScanValidity(data_scan_batch_,
-                                      data_scan_batch_pos_,
+                    ApplyScanValidity(batch,
+                                      0,
                                       res + processed_size,
                                       valid_res + processed_size,
                                       size);
                 }
             } else {
-                ApplyScanValidity(data_scan_batch_,
-                                  data_scan_batch_pos_,
+                ApplyScanValidity(batch,
+                                  0,
                                   res + processed_size,
                                   valid_res + processed_size,
                                   size);
@@ -2126,14 +2114,17 @@ class SegmentExpr : public Expr {
             }
 
             processed_size += size;
-            data_scan_batch_pos_ += size;
         }
 
         AssertInfo(processed_size == real_batch_size,
                    "data scan processed {} rows, expected {}",
                    processed_size,
                    real_batch_size);
-        MoveCursorInternal(true);
+        current_data_global_pos_ += processed_size;
+        AssertInfo(data_scan_cursor_->Position() == current_data_global_pos_,
+                   "data scan cursor at {}, execution at {}",
+                   data_scan_cursor_->Position(),
+                   current_data_global_pos_);
         return processed_size;
     }
 
@@ -2650,7 +2641,9 @@ class SegmentExpr : public Expr {
 
     TargetBitmap
     ProcessGrowingDataChunksForValid() {
-        TargetBitmap valid_result(GetNextBatchSize());
+        const auto expected_rows = GetNextBatchSize();
+        EnsureDataChunkCursorAt(current_data_global_pos_);
+        TargetBitmap valid_result(expected_rows);
         valid_result.set();
         int64_t processed_size = 0;
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
@@ -2663,7 +2656,7 @@ class SegmentExpr : public Expr {
                     : size_per_chunk_;
             auto size = size_in_chunk - data_pos;
 
-            size = std::min(size, batch_size_ - processed_size);
+            size = std::min(size, expected_rows - processed_size);
             if (size == 0) {
                 continue;
             }
@@ -2675,12 +2668,17 @@ class SegmentExpr : public Expr {
                                           valid_result + processed_size);
 
             processed_size += size;
-            if (processed_size >= batch_size_) {
+            if (processed_size >= expected_rows) {
                 current_data_chunk_ = i;
                 current_data_chunk_pos_ = data_pos + size;
                 break;
             }
         }
+        AssertInfo(processed_size == expected_rows,
+                   "growing validity processed {} rows, expected {}",
+                   processed_size,
+                   expected_rows);
+        CommitDataChunkProgress(processed_size);
         return valid_result;
     }
 
@@ -2690,7 +2688,7 @@ class SegmentExpr : public Expr {
         const auto batch_size = GetNextBatchSize();
         TargetBitmap valid_result(batch_size);
         valid_result.set();
-        if (!InitDataScanCursorIfNeeded<T>(
+        if (!EnsureDataScanBackend<T>(
                 ChunkedColumnInterface::ScanProjection::NoData)) {
             AssertInfo(!segment_->is_chunked(),
                        "sealed field {} does not provide a validity scan "
@@ -2700,25 +2698,39 @@ class SegmentExpr : public Expr {
         }
         int64_t processed_size = 0;
         while (processed_size < batch_size) {
-            if (!EnsureDataScanBatch()) {
+            const auto expected_row = current_data_global_pos_ + processed_size;
+            AssertInfo(EnsureDataScanCursorAt<T>(
+                           expected_row,
+                           ChunkedColumnInterface::ScanProjection::NoData),
+                       "validity scan backend changed while processing");
+            ChunkedColumnInterface::ScanBatch batch;
+            const auto remaining = batch_size - processed_size;
+            if (!data_scan_cursor_->Next(remaining, &batch)) {
                 break;
             }
-            const auto size =
-                std::min<int64_t>(batch_size - processed_size,
-                                  data_scan_batch_.size - data_scan_batch_pos_);
-            ApplyScanValidity(data_scan_batch_,
-                              data_scan_batch_pos_,
+            AssertInfo(batch.row_id_start == expected_row && batch.size > 0 &&
+                           batch.size <= remaining,
+                       "invalid validity scan batch [{}, {}) at expected {}",
+                       batch.row_id_start,
+                       batch.row_id_start + batch.size,
+                       expected_row);
+            const auto size = batch.size;
+            ApplyScanValidity(batch,
+                              0,
                               valid_result + processed_size,
                               valid_result + processed_size,
                               size);
             processed_size += size;
-            data_scan_batch_pos_ += size;
         }
         AssertInfo(processed_size == batch_size,
                    "validity scan processed {} rows, expected {}",
                    processed_size,
                    batch_size);
-        MoveCursorInternal(true);
+        current_data_global_pos_ += processed_size;
+        AssertInfo(data_scan_cursor_->Position() == current_data_global_pos_,
+                   "validity scan cursor at {}, execution at {}",
+                   data_scan_cursor_->Position(),
+                   current_data_global_pos_);
         return valid_result;
     }
 
@@ -3251,24 +3263,26 @@ class SegmentExpr : public Expr {
     int64_t current_data_chunk_{0};
     int64_t current_data_chunk_pos_{0};
     int64_t current_data_global_pos_{0};
+    // Chunk id/offset are a cache derived from current_data_global_pos_. A
+    // negative value means the cache must be rebuilt before the next chunk
+    // read, for example after a short-circuit skipped rows without touching
+    // the backend.
+    int64_t data_chunk_cursor_global_pos_{-1};
     int64_t current_index_chunk_{0};
     int64_t current_index_chunk_pos_{0};
     int64_t size_per_chunk_{0};
-    bool data_scan_initialized_{false};
-    // Remains true after ResetDataScanCursor(). It records that chunk-local
-    // coordinates may belong to an older published column generation, so batch
-    // sizing must stay on current_data_global_pos_ until the expression ends.
-    bool data_scan_mode_entered_{false};
-    // ScanCursor implementations retain a raw column pointer, so the
-    // expression must keep the published column generation alive for the
-    // cursor's full lifetime. This matters for callers without a segment read
-    // lease, such as boost-score evaluation concurrent with field replacement.
+    DataAccessMode data_access_mode_{DataAccessMode::Uninitialized};
+    // ScanCursor implementations retain a raw column pointer. Once Scan is
+    // selected, keep the captured column generation for the expression's full
+    // lifetime so short-circuit reopen never observes a replacement column.
     std::shared_ptr<ChunkedColumnInterface> data_scan_column_{nullptr};
     std::shared_ptr<const SkipIndex> data_scan_skip_index_{nullptr};
     std::unique_ptr<ChunkedColumnInterface::ScanCursor> data_scan_cursor_{
         nullptr};
-    ChunkedColumnInterface::ScanBatch data_scan_batch_;
-    int64_t data_scan_batch_pos_{0};
+    ChunkedColumnInterface::ScanProjection data_scan_projection_{
+        ChunkedColumnInterface::ScanProjection::Data};
+    ChunkedColumnInterface::ScanValueKind data_scan_value_kind_{
+        ChunkedColumnInterface::ScanValueKind::Default};
 
     // Unified cache for all index paths (ScalarIndex, PkIndex, TextIndex, JsonStats).
     // Populated once per segment, then sliced per batch via SliceCachedResult().

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -643,12 +643,11 @@ class SegmentExpr : public Expr {
                       TargetBitmapView res,
                       TargetBitmapView valid_res,
                       int64_t size) {
-        if (batch.validity.encoding ==
-            ChunkedColumnInterface::ValidityEncoding::AllValid) {
+        if (batch.validity == nullptr) {
             return;
         }
         for (int64_t i = 0; i < size; ++i) {
-            if (!batch.validity.IsValid(batch_pos + i)) {
+            if (!batch.validity[batch_pos + i]) {
                 res[i] = false;
                 valid_res[i] = false;
             }
@@ -661,12 +660,11 @@ class SegmentExpr : public Expr {
                                TargetBitmapView res,
                                TargetBitmapView valid_res,
                                int64_t size) {
-        if (batch.validity.encoding ==
-            ChunkedColumnInterface::ValidityEncoding::AllValid) {
+        if (batch.validity == nullptr) {
             return;
         }
         for (int64_t i = 0; i < size; ++i) {
-            if (!batch.validity.IsValid(offsets[i])) {
+            if (!batch.validity[offsets[i]]) {
                 res[i] = false;
                 valid_res[i] = false;
             }
@@ -1217,12 +1215,11 @@ class SegmentExpr : public Expr {
         batch_offsets.reserve(std::min<int64_t>(batch_size_, input->size()));
 
         ChunkedColumnInterface::ScanBatch batch;
-        FixedVector<bool> validity_scratch;
         while (processed_offsets < input->size() &&
                cursor->Next(batch_size_, &batch)) {
             AssertInfo(!batch.values.empty() && batch.size > 0,
                        "invalid offset data scan batch");
-            const auto* valid_data = batch.validity.bool_data(validity_scratch);
+            const auto* valid_data = batch.validity;
 
             int64_t batch_pos = 0;
             while (batch_pos < batch.size &&
@@ -1277,13 +1274,6 @@ class SegmentExpr : public Expr {
                             res + group_start,
                             valid_res + group_start,
                             values...);
-                        if (valid_data == nullptr) {
-                            ApplyScanValidityByOffsets(batch,
-                                                       batch_offsets.data(),
-                                                       res + group_start,
-                                                       valid_res + group_start,
-                                                       group_size);
-                        }
                     } else {
                         ApplyScanValidityByOffsets(batch,
                                                    batch_offsets.data(),
@@ -2014,7 +2004,6 @@ class SegmentExpr : public Expr {
         AssertInfo(data_scan_skip_index_ != nullptr,
                    "data scan skip index is not initialized");
 
-        FixedVector<bool> validity_scratch;
         while (processed_size < real_batch_size) {
             const auto expected_row = current_data_global_pos_ + processed_size;
             AssertInfo(EnsureDataScanCursorAt<T>(expected_row),
@@ -2046,7 +2035,7 @@ class SegmentExpr : public Expr {
                        chunk_id,
                        chunk_end);
             const auto* data = batch.values.data_as<T>();
-            const auto* valid_data = batch.validity.bool_data(validity_scratch);
+            const auto* valid_data = batch.validity;
             const bool skipped =
                 skip_func &&
                 skip_func(*data_scan_skip_index_, field_id_, chunk_id);
@@ -2078,13 +2067,6 @@ class SegmentExpr : public Expr {
                          res + processed_size,
                          valid_res + processed_size,
                          values...);
-                }
-                if (valid_data == nullptr) {
-                    ApplyScanValidity(batch,
-                                      0,
-                                      res + processed_size,
-                                      valid_res + processed_size,
-                                      size);
                 }
             } else {
                 ApplyScanValidity(batch,

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -24,7 +24,9 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <type_traits>
+#include <vector>
 
 #include "common/Array.h"
 #include "common/ArrayOffsets.h"
@@ -40,6 +42,7 @@
 #include "index/Index.h"
 #include "index/JsonFlatIndex.h"
 #include "log/Log.h"
+#include "mmap/ChunkedColumnInterface.h"
 #include "query/PlanProto.h"
 #include "segcore/SegmentSealed.h"
 #include "segcore/SegmentInterface.h"
@@ -250,6 +253,29 @@ class Expr : public std::enable_shared_from_this<Expr> {
     }
 
  protected:
+    static bool
+    IsSortedOffsetInput(const OffsetVector* input) {
+        for (size_t i = 1; i < input->size(); ++i) {
+            if ((*input)[i - 1] > (*input)[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool
+    IsDenseOffsetInputForScan(const OffsetVector* input) {
+        if (input == nullptr || input->empty()) {
+            return false;
+        }
+        if (!IsSortedOffsetInput(input)) {
+            return false;
+        }
+        const auto span = static_cast<int64_t>((*input)[input->size() - 1]) -
+                          static_cast<int64_t>((*input)[0]) + 1;
+        return span <= 4 * static_cast<int64_t>(input->size());
+    }
+
     DataType type_;
     std::vector<std::shared_ptr<Expr>> inputs_;
     std::string name_;
@@ -379,16 +405,15 @@ class SegmentExpr : public Expr {
             size = std::min(size, batch_size_ - processed_size);
 
             processed_size += size;
+            current_data_chunk_ = i;
+            current_data_chunk_pos_ = data_pos + size;
             if (processed_size >= batch_size_) {
-                current_data_chunk_ = i;
-                current_data_chunk_pos_ = data_pos + size;
-                current_data_global_pos_ =
-                    current_data_global_pos_ + processed_size;
                 break;
             }
-            // }
         }
+        current_data_global_pos_ = current_data_global_pos_ + processed_size;
     }
+
     // Non-chunked segments are always Growing (Sealed is always chunked).
     void
     MoveCursorForDataSingleChunk() {
@@ -404,22 +429,61 @@ class SegmentExpr : public Expr {
             size = std::min(size, batch_size_ - processed_size);
 
             processed_size += size;
+            current_data_chunk_ = i;
+            current_data_chunk_pos_ = data_pos + size;
             if (processed_size >= batch_size_) {
-                current_data_chunk_ = i;
-                current_data_chunk_pos_ = data_pos + size;
-                current_data_global_pos_ =
-                    current_data_global_pos_ + processed_size;
                 break;
             }
         }
+        current_data_global_pos_ = current_data_global_pos_ + processed_size;
     }
 
     void
-    MoveCursorForData() {
-        if (segment_->is_chunked()) {
+    MoveCursorForDataScan() {
+        AssertInfo(data_scan_column_ != nullptr,
+                   "data scan column is not initialized");
+        const auto target_size =
+            std::min(batch_size_, active_count_ - current_data_global_pos_);
+        int64_t processed_size = 0;
+        for (size_t i = current_data_chunk_;
+             i < static_cast<size_t>(data_scan_column_->num_chunks());
+             ++i) {
+            const auto data_pos =
+                (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
+            auto size = data_scan_column_->chunk_row_nums(i) - data_pos;
+            size = std::min(size, target_size - processed_size);
+
+            processed_size += size;
+            current_data_chunk_ = i;
+            current_data_chunk_pos_ = data_pos + size;
+            if (processed_size >= target_size) {
+                break;
+            }
+        }
+        current_data_global_pos_ += processed_size;
+    }
+
+    void
+    ResetDataScanCursor() {
+        data_scan_initialized_ = false;
+        data_scan_cursor_.reset();
+        data_scan_batch_ = ChunkedColumnInterface::ScanBatch{};
+        data_scan_batch_pos_ = 0;
+        data_scan_skip_index_.reset();
+        data_scan_column_.reset();
+    }
+
+    void
+    MoveCursorForData(bool preserve_data_scan_cursor = false) {
+        if (data_scan_column_ != nullptr) {
+            MoveCursorForDataScan();
+        } else if (segment_->is_chunked()) {
             MoveCursorForDataMultipleChunk();
         } else {
             MoveCursorForDataSingleChunk();
+        }
+        if (!preserve_data_scan_cursor) {
+            ResetDataScanCursor();
         }
     }
 
@@ -435,7 +499,7 @@ class SegmentExpr : public Expr {
     }
 
     void
-    MoveCursor() override {
+    MoveCursorInternal(bool preserve_data_scan_cursor) {
         if (!has_offset_input_) {
             if (execute_all_at_once_) {
                 // One-shot execution, no cursor movement needed.
@@ -444,14 +508,164 @@ class SegmentExpr : public Expr {
             if (UseIndexCursor()) {
                 MoveCursorForIndex();
                 if (segment_->HasFieldData(field_id_)) {
-                    MoveCursorForData();
+                    MoveCursorForData(preserve_data_scan_cursor);
                 }
             } else if (exec_path_ == ExprExecPath::JsonStats) {
                 current_data_global_pos_ += std::min(
                     batch_size_, active_count_ - current_data_global_pos_);
             } else {
                 // RawData, PkIndex, and TextIndex use the data cursor.
-                MoveCursorForData();
+                MoveCursorForData(preserve_data_scan_cursor);
+            }
+        }
+    }
+
+    void
+    MoveCursor() override {
+        MoveCursorInternal(false);
+    }
+
+    template <typename T>
+    static ChunkedColumnInterface::ScanValueKind
+    DataScanValueKind() {
+        if constexpr (std::is_same_v<T, std::string_view> ||
+                      std::is_same_v<T, std::string>) {
+            return ChunkedColumnInterface::ScanValueKind::StringView;
+        } else if constexpr (std::is_same_v<T, Json>) {
+            return ChunkedColumnInterface::ScanValueKind::JsonView;
+        } else if constexpr (std::is_same_v<T, ArrayView>) {
+            return ChunkedColumnInterface::ScanValueKind::ArrayView;
+        } else if constexpr (std::is_same_v<T, VectorArrayView>) {
+            return ChunkedColumnInterface::ScanValueKind::VectorArrayView;
+        } else {
+            return ChunkedColumnInterface::ScanValueKind::FixedWidth;
+        }
+    }
+
+    std::pair<std::shared_ptr<ChunkedColumnInterface>,
+              std::shared_ptr<const SkipIndex>>
+    CaptureDataScanResources() const {
+        return segment_->GetDataScanResources(field_id_);
+    }
+
+    template <typename T>
+    bool
+    InitDataScanCursorIfNeeded(
+        ChunkedColumnInterface::ScanProjection projection =
+            ChunkedColumnInterface::ScanProjection::Data) {
+        if (data_scan_initialized_) {
+            return data_scan_cursor_ != nullptr;
+        }
+        data_scan_initialized_ = true;
+        std::tie(data_scan_column_, data_scan_skip_index_) =
+            CaptureDataScanResources();
+        if (data_scan_column_ == nullptr) {
+            return false;
+        }
+        auto options = ChunkedColumnInterface::ScanOptions::ForData(
+            current_data_global_pos_,
+            active_count_ - current_data_global_pos_,
+            projection,
+            DataScanValueKind<T>());
+        data_scan_cursor_ = data_scan_column_->Scan(op_ctx_, options);
+        if (data_scan_cursor_ == nullptr) {
+            data_scan_skip_index_.reset();
+            data_scan_column_.reset();
+            return false;
+        }
+        // Commit the chunk cursor only after Scan() succeeds. Capability
+        // probing must remain side-effect free for non-scan providers such as
+        // growing segments.
+        if (current_data_global_pos_ < active_count_) {
+            auto [chunk_id, chunk_offset] =
+                data_scan_column_->GetChunkIDByOffset(current_data_global_pos_);
+            current_data_chunk_ = chunk_id;
+            current_data_chunk_pos_ = chunk_offset;
+        }
+        if (projection != ChunkedColumnInterface::ScanProjection::NoData) {
+            PrefetchRawDataChunksForScanIfNeeded(data_scan_column_.get());
+        }
+        return true;
+    }
+
+    void
+    PrefetchRawDataChunksForScanIfNeeded(const ChunkedColumnInterface* column) {
+        if (column == nullptr || prefetched_ || !segment_->is_chunked()) {
+            return;
+        }
+        const auto num_chunks = column->num_chunks();
+        AssertInfo(
+            current_data_chunk_ >= 0 && current_data_chunk_ <= num_chunks,
+            "scan prefetch chunk {} out of range {}",
+            current_data_chunk_,
+            num_chunks);
+        std::vector<int64_t> chunk_ids;
+        chunk_ids.reserve(num_chunks - current_data_chunk_);
+        for (int64_t i = current_data_chunk_; i < num_chunks; i++) {
+            chunk_ids.push_back(i);
+        }
+        column->PrefetchChunks(op_ctx_, chunk_ids);
+        prefetched_ = true;
+    }
+
+    bool
+    EnsureDataScanBatch() {
+        while (data_scan_batch_pos_ >= data_scan_batch_.size) {
+            data_scan_batch_pos_ = 0;
+            if (!data_scan_cursor_->Next(&data_scan_batch_)) {
+                return false;
+            }
+            AssertInfo(data_scan_batch_.size > 0, "invalid data scan batch");
+        }
+        return true;
+    }
+
+    static const bool*
+    BoolValidityData(const ChunkedColumnInterface::ScanBatch& batch,
+                     int64_t batch_pos) {
+        if (batch.validity.encoding !=
+                ChunkedColumnInterface::ValidityEncoding::BoolArray ||
+            batch.validity.all_valid || batch.validity.data == nullptr) {
+            return nullptr;
+        }
+        return static_cast<const bool*>(batch.validity.data) +
+               batch.validity.offset + batch_pos;
+    }
+
+    static void
+    ApplyScanValidity(const ChunkedColumnInterface::ScanBatch& batch,
+                      int64_t batch_pos,
+                      TargetBitmapView res,
+                      TargetBitmapView valid_res,
+                      int64_t size) {
+        if (batch.validity.encoding ==
+                ChunkedColumnInterface::ValidityEncoding::AllValid ||
+            batch.validity.all_valid) {
+            return;
+        }
+        for (int64_t i = 0; i < size; ++i) {
+            if (!batch.validity.IsValid(batch_pos + i)) {
+                res[i] = false;
+                valid_res[i] = false;
+            }
+        }
+    }
+
+    static void
+    ApplyScanValidityByOffsets(const ChunkedColumnInterface::ScanBatch& batch,
+                               const int32_t* offsets,
+                               TargetBitmapView res,
+                               TargetBitmapView valid_res,
+                               int64_t size) {
+        if (batch.validity.encoding ==
+                ChunkedColumnInterface::ValidityEncoding::AllValid ||
+            batch.validity.all_valid) {
+            return;
+        }
+        for (int64_t i = 0; i < size; ++i) {
+            if (!batch.validity.IsValid(offsets[i])) {
+                res[i] = false;
+                valid_res[i] = false;
             }
         }
     }
@@ -540,7 +754,8 @@ class SegmentExpr : public Expr {
     int64_t
     GetNextBatchSize() {
         EnsureExecPathDetermined();
-        if (exec_path_ == ExprExecPath::JsonStats) {
+        if (exec_path_ == ExprExecPath::JsonStats ||
+            data_scan_cursor_ != nullptr) {
             return std::min(batch_size_,
                             active_count_ - current_data_global_pos_);
         }
@@ -713,7 +928,7 @@ class SegmentExpr : public Expr {
     // does not move, but the callback may maintain a batch-local bitmap cursor.
     template <typename T, typename BatchEvaluator, typename... ValTypes>
     int64_t
-    ProcessDataByOffsets(
+    ProcessDataByOffsetsByChunkFallback(
         BatchEvaluator evaluate_batch,
         std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
         OffsetVector* input,
@@ -721,14 +936,6 @@ class SegmentExpr : public Expr {
         TargetBitmapView valid_res,
         const ValTypes&... values) {
         int64_t processed_size = 0;
-
-        // index reverse lookup (only for ScalarIndex path)
-        if constexpr (!std::is_same_v<T, VectorArrayView>) {
-            if (UseIndexCursor() && num_data_chunk_ == 0) {
-                return ProcessIndexLookupByOffsets<T>(
-                    evaluate_batch, input, res, valid_res, values...);
-            }
-        }
 
         auto skip_index = segment_->GetSkipIndex();
 
@@ -760,7 +967,7 @@ class SegmentExpr : public Expr {
                     // Chunk skipped by SkipIndex: apply valid mask, then still drive the
                     // callback on a null batch so cursor-tracking callbacks (which index
                     // bitmap_input by batch position via their processed_cursor) stay
-                    // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
+                    // aligned — mirrors the sequential data-scan skip branch.
                     ApplyValidData(valid_data.data(),
                                    res + processed_size,
                                    valid_res + processed_size,
@@ -848,7 +1055,7 @@ class SegmentExpr : public Expr {
                             // cursor-tracking callbacks (which index
                             // bitmap_input by batch position via their
                             // processed_cursor) stay aligned — mirrors the
-                            // ProcessDataChunksForMultipleChunk skip branch.
+                            // sequential data-scan skip branch.
                             if (!valid_data.empty() && !valid_data[j]) {
                                 res[processed_size] =
                                     valid_res[processed_size] = false;
@@ -910,7 +1117,7 @@ class SegmentExpr : public Expr {
                     // Chunk skipped by SkipIndex: apply valid mask, then still drive the
                     // callback on a null batch so cursor-tracking callbacks (which index
                     // bitmap_input by batch position via their processed_cursor) stay
-                    // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
+                    // aligned — mirrors the sequential data-scan skip branch.
                     ApplyValidData(valid_data,
                                    res + processed_size,
                                    valid_res + processed_size,
@@ -970,7 +1177,7 @@ class SegmentExpr : public Expr {
                     // Chunk skipped by SkipIndex: apply valid mask, then still drive the
                     // callback on a null batch so cursor-tracking callbacks (which index
                     // bitmap_input by batch position via their processed_cursor) stay
-                    // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
+                    // aligned — mirrors the sequential data-scan skip branch.
                     ApplyValidData(valid_data,
                                    res + processed_size,
                                    valid_res + processed_size,
@@ -986,8 +1193,196 @@ class SegmentExpr : public Expr {
                 }
                 processed_size++;
             }
+            return input->size();
         }
+    }
+
+    // accept sorted offsets array and process with one continuous Scan.
+    // TODO: push the offset selection into Scan when the interface supports it.
+    template <typename T, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessSortedDataByOffsetsByScan(
+        FUNC func,
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        OffsetVector* input,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const ValTypes&... values) {
+        auto [column, skip_index] = CaptureDataScanResources();
+        if (column == nullptr) {
+            return -1;
+        }
+        if (input->empty()) {
+            return 0;
+        }
+
+        const auto scan_start = static_cast<int64_t>((*input)[0]);
+        const auto scan_end =
+            static_cast<int64_t>((*input)[input->size() - 1]) + 1;
+        const auto scan_length = scan_end - scan_start;
+        AssertInfo(scan_length > 0,
+                   "invalid offset scan range [{}, {})",
+                   scan_start,
+                   scan_end);
+
+        TargetBitmap offset_bitmap(scan_length, false);
+        for (auto offset : *input) {
+            offset_bitmap[static_cast<size_t>(static_cast<int64_t>(offset) -
+                                              scan_start)] = true;
+        }
+
+        auto options = ChunkedColumnInterface::ScanOptions::ForData(
+            scan_start,
+            scan_length,
+            ChunkedColumnInterface::ScanProjection::Data,
+            DataScanValueKind<T>());
+        auto cursor = column->Scan(op_ctx_, options);
+        if (cursor == nullptr) {
+            return -1;
+        }
+
+        size_t processed_offsets = 0;
+        std::vector<int32_t> batch_offsets;
+        batch_offsets.reserve(std::min<int64_t>(batch_size_, input->size()));
+
+        ChunkedColumnInterface::ScanBatch batch;
+        while (processed_offsets < input->size() && cursor->Next(&batch)) {
+            AssertInfo(!batch.values.empty() && batch.size > 0,
+                       "invalid offset data scan batch");
+
+            int64_t batch_pos = 0;
+            while (batch_pos < batch.size &&
+                   processed_offsets < input->size()) {
+                const auto interval_start = batch.row_id_start + batch_pos;
+                const auto batch_end = batch.row_id_start + batch.size;
+                if (static_cast<int64_t>((*input)[processed_offsets]) >=
+                    batch_end) {
+                    break;
+                }
+
+                auto [chunk_id, _] = column->GetChunkIDByOffset(interval_start);
+                const auto chunk_end = column->GetNumRowsUntilChunk(chunk_id) +
+                                       column->chunk_row_nums(chunk_id);
+                const auto interval_end = std::min(batch_end, chunk_end);
+                if (static_cast<int64_t>((*input)[processed_offsets]) >=
+                    interval_end) {
+                    batch_pos += interval_end - interval_start;
+                    continue;
+                }
+
+                const bool skipped =
+                    skip_func && skip_func(*skip_index, field_id_, chunk_id);
+                const auto group_start = processed_offsets;
+                batch_offsets.clear();
+                for (int64_t row = interval_start;
+                     row < interval_end && processed_offsets < input->size();
+                     ++row) {
+                    const auto bitmap_pos = row - scan_start;
+                    if (!offset_bitmap[static_cast<size_t>(bitmap_pos)]) {
+                        continue;
+                    }
+                    while (processed_offsets < input->size() &&
+                           static_cast<int64_t>((*input)[processed_offsets]) ==
+                               row) {
+                        batch_offsets.push_back(
+                            static_cast<int32_t>(row - batch.row_id_start));
+                        ++processed_offsets;
+                    }
+                }
+
+                const auto group_size =
+                    static_cast<int64_t>(processed_offsets - group_start);
+                if (group_size > 0) {
+                    if (!skipped) {
+                        const auto* data = batch.values.data_as<T>();
+                        const auto* valid_data = BoolValidityData(batch, 0);
+                        func.template operator()<FilterType::random>(
+                            data,
+                            valid_data,
+                            batch_offsets.data(),
+                            static_cast<int>(group_size),
+                            res + group_start,
+                            valid_res + group_start,
+                            values...);
+                        if (valid_data == nullptr) {
+                            ApplyScanValidityByOffsets(batch,
+                                                       batch_offsets.data(),
+                                                       res + group_start,
+                                                       valid_res + group_start,
+                                                       group_size);
+                        }
+                    } else {
+                        ApplyScanValidityByOffsets(batch,
+                                                   batch_offsets.data(),
+                                                   res + group_start,
+                                                   valid_res + group_start,
+                                                   group_size);
+                        // Keep callback-local state (for example the
+                        // bitmap_input processed_cursor) aligned with every
+                        // logical candidate, even when SkipIndex already
+                        // decided the result for this chunk.
+                        func.template operator()<FilterType::random>(
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            static_cast<int>(group_size),
+                            res + group_start,
+                            valid_res + group_start,
+                            values...);
+                    }
+                }
+
+                batch_pos += interval_end - interval_start;
+            }
+        }
+
+        AssertInfo(processed_offsets == input->size(),
+                   "offset scan processed {} offsets, expected {}",
+                   processed_offsets,
+                   input->size());
         return input->size();
+    }
+
+    template <typename T, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessDataByOffsetsByScan(
+        FUNC func,
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        OffsetVector* input,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const ValTypes&... values) {
+        if (IsDenseOffsetInputForScan(input)) {
+            return ProcessSortedDataByOffsetsByScan<T>(
+                func, skip_func, input, res, valid_res, values...);
+        }
+        return -1;
+    }
+
+    template <typename T, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessDataByOffsets(
+        FUNC func,
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        OffsetVector* input,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const ValTypes&... values) {
+        // index reverse lookup (only for ScalarIndex path)
+        if constexpr (!std::is_same_v<T, VectorArrayView>) {
+            if (UseIndexCursor() && num_data_chunk_ == 0) {
+                return ProcessIndexLookupByOffsets<T>(
+                    func, input, res, valid_res, values...);
+            }
+        }
+
+        const auto processed_size = ProcessDataByOffsetsByScan<T>(
+            func, skip_func, input, res, valid_res, values...);
+        if (processed_size >= 0) {
+            return processed_size;
+        }
+        return ProcessDataByOffsetsByChunkFallback<T>(
+            func, skip_func, input, res, valid_res, values...);
     }
 
     // Process element-level data by element IDs
@@ -1491,7 +1886,6 @@ class SegmentExpr : public Expr {
         return processed_elems;
     }
 
-    // Template parameter to control whether segment offsets are needed (for GIS functions)
     template <typename T,
               bool NeedSegmentOffsets = false,
               typename FUNC,
@@ -1514,8 +1908,9 @@ class SegmentExpr : public Expr {
                             : size_per_chunk_ - data_pos;
 
             size = std::min(size, batch_size_ - processed_size);
-            if (size == 0)
-                continue;  //do not go empty-loop at the bound of the chunk
+            if (size == 0) {
+                continue;
+            }
 
             auto skip_index = segment_->GetSkipIndex();
             auto process_chunk = [&](const T* data, const bool* valid_data) {
@@ -1617,146 +2012,93 @@ class SegmentExpr : public Expr {
               typename FUNC,
               typename... ValTypes>
     int64_t
-    ProcessDataChunksForMultipleChunk(
+    ProcessDataChunksByScan(
         FUNC func,
         std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
-        int64_t processed_size = 0;
-
-        // prefetch chunks to reduce cache miss latency
-        if (!prefetched_) {
-            std::vector<int64_t> pf_chunk_ids;
-            pf_chunk_ids.reserve(num_data_chunk_ - current_data_chunk_);
-            for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-                pf_chunk_ids.push_back(i);
-            }
-            segment_->prefetch_chunks(op_ctx_, field_id_, pf_chunk_ids);
-            prefetched_ = true;
+        if (!InitDataScanCursorIfNeeded<T>()) {
+            return -1;
         }
 
-        for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-            auto data_pos =
-                i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
+        int64_t processed_size = 0;
+        const auto real_batch_size = GetNextBatchSize();
+        AssertInfo(data_scan_skip_index_ != nullptr,
+                   "data scan skip index is not initialized");
 
-            // if segment is chunked, type won't be growing
-            int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
-            size = std::min(size, batch_size_ - processed_size);
-
-            if (size == 0)
-                continue;  //do not go empty-loop at the bound of the chunk
-            std::vector<int32_t> segment_offsets_array(size);
-            auto start_offset =
-                segment_->num_rows_until_chunk(field_id_, i) + data_pos;
-            for (int64_t j = 0; j < size; ++j) {
-                int64_t offset = start_offset + j;
-                segment_offsets_array[j] = static_cast<int32_t>(offset);
+        while (processed_size < real_batch_size) {
+            if (!EnsureDataScanBatch()) {
+                break;
             }
-            auto skip_index = segment_->GetSkipIndex();
-            if (!skip_func || !skip_func(*skip_index, field_id_, i)) {
-                bool is_seal = false;
-                if constexpr (std::is_same_v<T, std::string_view> ||
-                              std::is_same_v<T, Json> ||
-                              std::is_same_v<T, ArrayView> ||
-                              std::is_same_v<T, VectorArrayView>) {
-                    if (segment_->type() == SegmentType::Sealed) {
-                        // first is the raw data, second is valid_data
-                        // use valid_data to see if raw data is null
-                        auto pw = segment_->get_batch_views<T>(
-                            op_ctx_, field_id_, i, data_pos, size);
-                        const auto& [data_vec, valid_data] = pw.get();
 
-                        if constexpr (NeedSegmentOffsets) {
-                            func(data_vec.data(),
-                                 valid_data.data(),
-                                 nullptr,
-                                 segment_offsets_array.data(),
-                                 size,
-                                 res + processed_size,
-                                 valid_res + processed_size,
-                                 values...);
-                        } else {
-                            func(data_vec.data(),
-                                 valid_data.data(),
-                                 nullptr,
-                                 size,
-                                 res + processed_size,
-                                 valid_res + processed_size,
-                                 values...);
-                        }
+            const auto row =
+                data_scan_batch_.row_id_start + data_scan_batch_pos_;
+            const auto expected_row = current_data_global_pos_ + processed_size;
+            AssertInfo(row == expected_row,
+                       "data scan row mismatch, got {}, expected {}",
+                       row,
+                       expected_row);
 
-                        is_seal = true;
-                    }
+            auto size =
+                std::min<int64_t>(real_batch_size - processed_size,
+                                  data_scan_batch_.size - data_scan_batch_pos_);
+            auto [chunk_id, _] = data_scan_column_->GetChunkIDByOffset(row);
+            const auto chunk_end =
+                data_scan_column_->GetNumRowsUntilChunk(chunk_id) +
+                data_scan_column_->chunk_row_nums(chunk_id);
+            size = std::min<int64_t>(size, chunk_end - row);
+            const auto* data =
+                data_scan_batch_.values.data_as<T>() + data_scan_batch_pos_;
+            const auto* valid_data =
+                BoolValidityData(data_scan_batch_, data_scan_batch_pos_);
+            const bool skipped =
+                skip_func &&
+                skip_func(*data_scan_skip_index_, field_id_, chunk_id);
+
+            auto make_segment_offsets = [&]() {
+                std::vector<int32_t> segment_offsets_array(size);
+                for (int64_t i = 0; i < size; ++i) {
+                    segment_offsets_array[i] = static_cast<int32_t>(row + i);
                 }
-                if constexpr (std::is_same_v<T, VectorArrayView>) {
-                    AssertInfo(is_seal,
-                               "VectorArrayView must be read through chunk "
-                               "views");
-                } else {
-                    if (!is_seal) {
-                        auto pw =
-                            segment_->chunk_data<T>(op_ctx_, field_id_, i);
-                        auto chunk = pw.get();
-                        const T* data = chunk.data() + data_pos;
-                        const bool* valid_data = chunk.valid_data();
-                        if (valid_data != nullptr) {
-                            valid_data += data_pos;
-                        }
+                return segment_offsets_array;
+            };
 
-                        if constexpr (NeedSegmentOffsets) {
-                            // For GIS functions: construct segment offsets array
-                            func(data,
-                                 valid_data,
-                                 nullptr,
-                                 segment_offsets_array.data(),
-                                 size,
-                                 res + processed_size,
-                                 valid_res + processed_size,
-                                 values...);
-                        } else {
-                            func(data,
-                                 valid_data,
-                                 nullptr,
-                                 size,
-                                 res + processed_size,
-                                 valid_res + processed_size,
-                                 values...);
-                        }
-                    }
+            if (!skipped) {
+                if constexpr (NeedSegmentOffsets) {
+                    auto segment_offsets_array = make_segment_offsets();
+                    func(data,
+                         valid_data,
+                         nullptr,
+                         segment_offsets_array.data(),
+                         size,
+                         res + processed_size,
+                         valid_res + processed_size,
+                         values...);
+                } else {
+                    func(data,
+                         valid_data,
+                         nullptr,
+                         size,
+                         res + processed_size,
+                         valid_res + processed_size,
+                         values...);
+                }
+                if (valid_data == nullptr) {
+                    ApplyScanValidity(data_scan_batch_,
+                                      data_scan_batch_pos_,
+                                      res + processed_size,
+                                      valid_res + processed_size,
+                                      size);
                 }
             } else {
-                // Chunk is skipped by SkipIndex.
-                // We still need to:
-                // 1. Apply valid_data to handle nullable fields
-                // 2. Call func with nullptr to update internal cursors
-                //    (e.g., processed_cursor for bitmap_input indexing)
-                const bool* valid_data;
-                if constexpr (std::is_same_v<T, std::string_view> ||
-                              std::is_same_v<T, Json> ||
-                              std::is_same_v<T, ArrayView> ||
-                              std::is_same_v<T, VectorArrayView>) {
-                    auto pw = segment_->get_batch_views<T>(
-                        op_ctx_, field_id_, i, data_pos, size);
-                    valid_data = pw.get().second.data();
-                    ApplyValidData(valid_data,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   size);
-                } else {
-                    auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, i);
-                    auto chunk = pw.get();
-                    valid_data = chunk.valid_data();
-                    if (valid_data != nullptr) {
-                        valid_data += data_pos;
-                    }
-                    ApplyValidData(valid_data,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   size);
-                }
-                // Call func with nullptr to update internal cursors
+                ApplyScanValidity(data_scan_batch_,
+                                  data_scan_batch_pos_,
+                                  res + processed_size,
+                                  valid_res + processed_size,
+                                  size);
                 if constexpr (NeedSegmentOffsets) {
+                    auto segment_offsets_array = make_segment_offsets();
                     func(nullptr,
                          nullptr,
                          nullptr,
@@ -1777,14 +2119,14 @@ class SegmentExpr : public Expr {
             }
 
             processed_size += size;
-
-            if (processed_size >= batch_size_) {
-                current_data_chunk_ = i;
-                current_data_chunk_pos_ = data_pos + size;
-                break;
-            }
+            data_scan_batch_pos_ += size;
         }
 
+        AssertInfo(processed_size == real_batch_size,
+                   "data scan processed {} rows, expected {}",
+                   processed_size,
+                   real_batch_size);
+        MoveCursorInternal(true);
         return processed_size;
     }
 
@@ -1799,13 +2141,17 @@ class SegmentExpr : public Expr {
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
-        if (segment_->is_chunked()) {
-            return ProcessDataChunksForMultipleChunk<T, NeedSegmentOffsets>(
+        const auto processed_size =
+            ProcessDataChunksByScan<T, NeedSegmentOffsets>(
                 func, skip_func, res, valid_res, values...);
-        } else {
-            return ProcessDataChunksForSingleChunk<T, NeedSegmentOffsets>(
-                func, skip_func, res, valid_res, values...);
+        if (processed_size >= 0) {
+            return processed_size;
         }
+        AssertInfo(!segment_->is_chunked(),
+                   "sealed field {} does not provide a data scan cursor",
+                   field_id_.get());
+        return ProcessDataChunksForSingleChunk<T, NeedSegmentOffsets>(
+            func, skip_func, res, valid_res, values...);
     }
 
     // Specialized method for ngram post-filter: processes data in a specific range
@@ -2295,32 +2641,25 @@ class SegmentExpr : public Expr {
         return valid_result;
     }
 
-    template <typename T>
     TargetBitmap
-    ProcessDataChunksForValid() {
+    ProcessGrowingDataChunksForValid() {
         TargetBitmap valid_result(GetNextBatchSize());
         valid_result.set();
         int64_t processed_size = 0;
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            int64_t size = 0;
-            if (segment_->is_chunked()) {
-                size = segment_->chunk_size(field_id_, i) - data_pos;
-            } else {
-                size = (i == (num_data_chunk_ - 1))
-                           ? (segment_->type() == SegmentType::Growing
-                                  ? (active_count_ % size_per_chunk_ == 0
-                                         ? size_per_chunk_ - data_pos
-                                         : active_count_ % size_per_chunk_ -
-                                               data_pos)
-                                  : active_count_ - data_pos)
-                           : size_per_chunk_ - data_pos;
-            }
+            const auto size_in_chunk =
+                i == (num_data_chunk_ - 1) &&
+                        active_count_ % size_per_chunk_ != 0
+                    ? active_count_ % size_per_chunk_
+                    : size_per_chunk_;
+            auto size = size_in_chunk - data_pos;
 
             size = std::min(size, batch_size_ - processed_size);
-            if (size == 0)
-                continue;  //do not go empty-loop at the bound of the chunk
+            if (size == 0) {
+                continue;
+            }
             segment_->ApplyFieldValidData(op_ctx_,
                                           field_id_,
                                           i,
@@ -2335,6 +2674,44 @@ class SegmentExpr : public Expr {
                 break;
             }
         }
+        return valid_result;
+    }
+
+    template <typename T>
+    TargetBitmap
+    ProcessDataChunksForValid() {
+        const auto batch_size = GetNextBatchSize();
+        TargetBitmap valid_result(batch_size);
+        valid_result.set();
+        if (!InitDataScanCursorIfNeeded<T>(
+                ChunkedColumnInterface::ScanProjection::NoData)) {
+            AssertInfo(!segment_->is_chunked(),
+                       "sealed field {} does not provide a validity scan "
+                       "cursor",
+                       field_id_.get());
+            return ProcessGrowingDataChunksForValid();
+        }
+        int64_t processed_size = 0;
+        while (processed_size < batch_size) {
+            if (!EnsureDataScanBatch()) {
+                break;
+            }
+            const auto size =
+                std::min<int64_t>(batch_size - processed_size,
+                                  data_scan_batch_.size - data_scan_batch_pos_);
+            ApplyScanValidity(data_scan_batch_,
+                              data_scan_batch_pos_,
+                              valid_result + processed_size,
+                              valid_result + processed_size,
+                              size);
+            processed_size += size;
+            data_scan_batch_pos_ += size;
+        }
+        AssertInfo(processed_size == batch_size,
+                   "validity scan processed {} rows, expected {}",
+                   processed_size,
+                   batch_size);
+        MoveCursorInternal(true);
         return valid_result;
     }
 
@@ -2870,6 +3247,17 @@ class SegmentExpr : public Expr {
     int64_t current_index_chunk_{0};
     int64_t current_index_chunk_pos_{0};
     int64_t size_per_chunk_{0};
+    bool data_scan_initialized_{false};
+    // ScanCursor implementations retain a raw column pointer, so the
+    // expression must keep the published column generation alive for the
+    // cursor's full lifetime. This matters for callers without a segment read
+    // lease, such as boost-score evaluation concurrent with field replacement.
+    std::shared_ptr<ChunkedColumnInterface> data_scan_column_{nullptr};
+    std::shared_ptr<const SkipIndex> data_scan_skip_index_{nullptr};
+    std::unique_ptr<ChunkedColumnInterface::ScanCursor> data_scan_cursor_{
+        nullptr};
+    ChunkedColumnInterface::ScanBatch data_scan_batch_;
+    int64_t data_scan_batch_pos_{0};
 
     // Unified cache for all index paths (ScalarIndex, PkIndex, TextIndex, JsonStats).
     // Populated once per segment, then sliced per batch via SliceCachedResult().

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -259,29 +259,6 @@ class Expr : public std::enable_shared_from_this<Expr> {
     }
 
  protected:
-    static bool
-    IsSortedOffsetInput(const OffsetVector* input) {
-        for (size_t i = 1; i < input->size(); ++i) {
-            if ((*input)[i - 1] > (*input)[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    static bool
-    IsDenseOffsetInputForScan(const OffsetVector* input) {
-        if (input == nullptr || input->empty()) {
-            return false;
-        }
-        if (!IsSortedOffsetInput(input)) {
-            return false;
-        }
-        const auto span = static_cast<int64_t>((*input)[input->size() - 1]) -
-                          static_cast<int64_t>((*input)[0]) + 1;
-        return span <= 4 * static_cast<int64_t>(input->size());
-    }
-
     DataType type_;
     std::vector<std::shared_ptr<Expr>> inputs_;
     std::string name_;
@@ -571,8 +548,7 @@ class SegmentExpr : public Expr {
             active_count_ - current_data_global_pos_,
             projection,
             value_kind);
-        data_prepared_scan_ =
-            data_scan_column_->PrepareScan(op_ctx_, options);
+        data_prepared_scan_ = data_scan_column_->PrepareScan(op_ctx_, options);
         if (data_prepared_scan_ == nullptr) {
             data_scan_skip_index_.reset();
             data_scan_column_.reset();
@@ -624,23 +600,6 @@ class SegmentExpr : public Expr {
         }
         for (int64_t i = 0; i < size; ++i) {
             if (!batch.validity[batch_pos + i]) {
-                res[i] = false;
-                valid_res[i] = false;
-            }
-        }
-    }
-
-    static void
-    ApplyScanValidityByOffsets(const ChunkedColumnInterface::ScanBatch& batch,
-                               const int32_t* offsets,
-                               TargetBitmapView res,
-                               TargetBitmapView valid_res,
-                               int64_t size) {
-        if (batch.validity == nullptr) {
-            return;
-        }
-        for (int64_t i = 0; i < size; ++i) {
-            if (!batch.validity[offsets[i]]) {
                 res[i] = false;
                 valid_res[i] = false;
             }
@@ -1142,11 +1101,26 @@ class SegmentExpr : public Expr {
         }
     }
 
-    // accept sorted offsets array and process with one continuous Scan.
-    // TODO: push the offset selection into Scan when the interface supports it.
+    static void
+    ApplyTakeValidity(const ChunkedColumnInterface::TakeBatch& batch,
+                      TargetBitmapView res,
+                      TargetBitmapView valid_res) {
+        if (batch.validity == nullptr) {
+            return;
+        }
+        for (int64_t i = 0; i < batch.size; ++i) {
+            const auto value_offset =
+                batch.selection == nullptr ? i : batch.selection[i];
+            if (!batch.validity[value_offset]) {
+                res[i] = false;
+                valid_res[i] = false;
+            }
+        }
+    }
+
     template <typename T, typename FUNC, typename... ValTypes>
     int64_t
-    ProcessSortedDataByOffsetsByScan(
+    ProcessDataByOffsetsByTake(
         FUNC func,
         std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
         OffsetVector* input,
@@ -1157,145 +1131,67 @@ class SegmentExpr : public Expr {
         if (column == nullptr) {
             return -1;
         }
-        if (input->empty()) {
-            return 0;
-        }
-
-        const auto scan_start = static_cast<int64_t>((*input)[0]);
-        const auto scan_end =
-            static_cast<int64_t>((*input)[input->size() - 1]) + 1;
-        const auto scan_length = scan_end - scan_start;
-        AssertInfo(scan_length > 0,
-                   "invalid offset scan range [{}, {})",
-                   scan_start,
-                   scan_end);
-
-        TargetBitmap offset_bitmap(scan_length, false);
-        for (auto offset : *input) {
-            offset_bitmap[static_cast<size_t>(static_cast<int64_t>(offset) -
-                                              scan_start)] = true;
-        }
-
-        auto options = ChunkedColumnInterface::ScanOptions::ForData(
-            scan_start,
-            scan_length,
-            ChunkedColumnInterface::ScanProjection::Data,
-            DataScanValueKind<T>());
-        auto cursor = column->Scan(op_ctx_, options);
+        auto cursor = column->Take(
+            op_ctx_,
+            ChunkedColumnInterface::TakeOptions{
+                ChunkedColumnInterface::OffsetView::From(
+                    input->data(), static_cast<int64_t>(input->size())),
+                DataScanValueKind<T>()});
         if (cursor == nullptr) {
             return -1;
         }
 
-        size_t processed_offsets = 0;
-        std::vector<int32_t> batch_offsets;
-        batch_offsets.reserve(std::min<int64_t>(batch_size_, input->size()));
-
-        ChunkedColumnInterface::ScanBatch batch;
-        while (processed_offsets < input->size() &&
-               cursor->Next(batch_size_, &batch)) {
+        int64_t processed_size = 0;
+        ChunkedColumnInterface::TakeBatch batch;
+        while (cursor->Next(batch_size_, &batch)) {
+            AssertInfo(batch.position == processed_size,
+                       "take batch position {}, expected {}",
+                       batch.position,
+                       processed_size);
             AssertInfo(!batch.values.empty() && batch.size > 0,
-                       "invalid offset data scan batch");
-            const auto* valid_data = batch.validity;
+                       "invalid take data batch");
+            AssertInfo(processed_size + batch.size <=
+                           static_cast<int64_t>(input->size()),
+                       "take returned {} rows after {}, input size {}",
+                       batch.size,
+                       processed_size,
+                       input->size());
 
-            int64_t batch_pos = 0;
-            while (batch_pos < batch.size &&
-                   processed_offsets < input->size()) {
-                const auto interval_start = batch.row_id_start + batch_pos;
-                const auto batch_end = batch.row_id_start + batch.size;
-                if (static_cast<int64_t>((*input)[processed_offsets]) >=
-                    batch_end) {
-                    break;
-                }
-
-                auto [chunk_id, _] = column->GetChunkIDByOffset(interval_start);
-                const auto chunk_end = column->GetNumRowsUntilChunk(chunk_id) +
-                                       column->chunk_row_nums(chunk_id);
-                const auto interval_end = std::min(batch_end, chunk_end);
-                if (static_cast<int64_t>((*input)[processed_offsets]) >=
-                    interval_end) {
-                    batch_pos += interval_end - interval_start;
-                    continue;
-                }
-
-                const bool skipped =
-                    skip_func && skip_func(*skip_index, field_id_, chunk_id);
-                const auto group_start = processed_offsets;
-                batch_offsets.clear();
-                for (int64_t row = interval_start;
-                     row < interval_end && processed_offsets < input->size();
-                     ++row) {
-                    const auto bitmap_pos = row - scan_start;
-                    if (!offset_bitmap[static_cast<size_t>(bitmap_pos)]) {
-                        continue;
-                    }
-                    while (processed_offsets < input->size() &&
-                           static_cast<int64_t>((*input)[processed_offsets]) ==
-                               row) {
-                        batch_offsets.push_back(
-                            static_cast<int32_t>(row - batch.row_id_start));
-                        ++processed_offsets;
-                    }
-                }
-
-                const auto group_size =
-                    static_cast<int64_t>(processed_offsets - group_start);
-                if (group_size > 0) {
-                    if (!skipped) {
-                        const auto* data = batch.values.data_as<T>();
-                        func.template operator()<FilterType::random>(
-                            data,
-                            valid_data,
-                            batch_offsets.data(),
-                            static_cast<int>(group_size),
-                            res + group_start,
-                            valid_res + group_start,
-                            values...);
-                    } else {
-                        ApplyScanValidityByOffsets(batch,
-                                                   batch_offsets.data(),
-                                                   res + group_start,
-                                                   valid_res + group_start,
-                                                   group_size);
-                        // Keep callback-local state (for example the
-                        // bitmap_input processed_cursor) aligned with every
-                        // logical candidate, even when SkipIndex already
-                        // decided the result for this chunk.
-                        func.template operator()<FilterType::random>(
-                            nullptr,
-                            nullptr,
-                            nullptr,
-                            static_cast<int>(group_size),
-                            res + group_start,
-                            valid_res + group_start,
-                            values...);
-                    }
-                }
-
-                batch_pos += interval_end - interval_start;
+            const bool skipped =
+                batch.source_chunk_id >= 0 && skip_func &&
+                skip_index != nullptr &&
+                skip_func(*skip_index, field_id_, batch.source_chunk_id);
+            if (!skipped) {
+                func.template operator()<FilterType::random>(
+                    batch.values.data_as<T>(),
+                    batch.validity,
+                    batch.selection,
+                    static_cast<int>(batch.size),
+                    res + processed_size,
+                    valid_res + processed_size,
+                    values...);
+            } else {
+                ApplyTakeValidity(
+                    batch, res + processed_size, valid_res + processed_size);
+                // Keep callback-local state aligned with every logical
+                // candidate even when SkipIndex decides this raw chunk.
+                func.template operator()<FilterType::random>(
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    static_cast<int>(batch.size),
+                    res + processed_size,
+                    valid_res + processed_size,
+                    values...);
             }
+            processed_size += batch.size;
         }
 
-        AssertInfo(processed_offsets == input->size(),
-                   "offset scan processed {} offsets, expected {}",
-                   processed_offsets,
+        AssertInfo(processed_size == static_cast<int64_t>(input->size()),
+                   "take processed {} offsets, expected {}",
+                   processed_size,
                    input->size());
-        return input->size();
-    }
-
-    template <typename T, typename FUNC, typename... ValTypes>
-    int64_t
-    ProcessDataByOffsetsByScan(
-        FUNC func,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
-        OffsetVector* input,
-        TargetBitmapView res,
-        TargetBitmapView valid_res,
-        const ValTypes&... values) {
-        if (IsDenseOffsetInputForScan(input)) {
-            return ProcessSortedDataByOffsetsByScan<T>(
-                func, skip_func, input, res, valid_res, values...);
-        }
-        return -1;
+        return processed_size;
     }
 
     template <typename T, typename FUNC, typename... ValTypes>
@@ -1315,7 +1211,7 @@ class SegmentExpr : public Expr {
             }
         }
 
-        const auto processed_size = ProcessDataByOffsetsByScan<T>(
+        const auto processed_size = ProcessDataByOffsetsByTake<T>(
             func, skip_func, input, res, valid_res, values...);
         if (processed_size >= 0) {
             return processed_size;

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -566,13 +566,20 @@ class SegmentExpr : public Expr {
             current_data_global_pos_,
             active_count_ - current_data_global_pos_,
             projection,
-            DataScanValueKind<T>());
+            DataScanValueKind<T>(),
+            batch_size_);
         data_scan_cursor_ = data_scan_column_->Scan(op_ctx_, options);
         if (data_scan_cursor_ == nullptr) {
             data_scan_skip_index_.reset();
             data_scan_column_.reset();
             return false;
         }
+        // Once this expression has bound a column scan, its stable cursor is
+        // the segment-global row position. Keep using that coordinate after a
+        // short-circuit reset: the saved chunk id/offset belong to the retained
+        // column generation and must not be interpreted through a concurrently
+        // published replacement before the next Scan() rebases them.
+        data_scan_mode_entered_ = true;
         // Commit the chunk cursor only after Scan() succeeds. Capability
         // probing must remain side-effect free for non-scan providers such as
         // growing segments.
@@ -754,8 +761,7 @@ class SegmentExpr : public Expr {
     int64_t
     GetNextBatchSize() {
         EnsureExecPathDetermined();
-        if (exec_path_ == ExprExecPath::JsonStats ||
-            data_scan_cursor_ != nullptr) {
+        if (exec_path_ == ExprExecPath::JsonStats || data_scan_mode_entered_) {
             return std::min(batch_size_,
                             active_count_ - current_data_global_pos_);
         }
@@ -1235,7 +1241,8 @@ class SegmentExpr : public Expr {
             scan_start,
             scan_length,
             ChunkedColumnInterface::ScanProjection::Data,
-            DataScanValueKind<T>());
+            DataScanValueKind<T>(),
+            batch_size_);
         auto cursor = column->Scan(op_ctx_, options);
         if (cursor == nullptr) {
             return -1;
@@ -3248,6 +3255,10 @@ class SegmentExpr : public Expr {
     int64_t current_index_chunk_pos_{0};
     int64_t size_per_chunk_{0};
     bool data_scan_initialized_{false};
+    // Remains true after ResetDataScanCursor(). It records that chunk-local
+    // coordinates may belong to an older published column generation, so batch
+    // sizing must stay on current_data_global_pos_ until the expression ends.
+    bool data_scan_mode_entered_{false};
     // ScanCursor implementations retain a raw column pointer, so the
     // expression must keep the published column generation alive for the
     // cursor's full lifetime. This matters for callers without a segment read

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -377,11 +377,6 @@ class SegmentExpr : public Expr {
     }
 
     void
-    CloseDataScanCursor() {
-        data_scan_cursor_.reset();
-    }
-
-    void
     InvalidateDataChunkCursor() {
         data_chunk_cursor_global_pos_ = -1;
     }
@@ -430,12 +425,10 @@ class SegmentExpr : public Expr {
         current_data_global_pos_ +=
             std::min(batch_size_, active_count_ - current_data_global_pos_);
         // MoveCursor() means this expression was short-circuited for the
-        // current execution batch. The global position is authoritative;
-        // backend-specific cursors are caches and are rebuilt on the next read.
+        // current execution batch. No scan resources were opened for the
+        // skipped operator window; the next evaluated window prepares its own
+        // plan/pins/cursor.
         InvalidateDataChunkCursor();
-        if (data_access_mode_ == DataAccessMode::Scan) {
-            CloseDataScanCursor();
-        }
     }
 
     void
@@ -499,94 +492,45 @@ class SegmentExpr : public Expr {
         return segment_->GetDataScanResources(field_id_);
     }
 
-    void
-    OpenDataScanCursor(int64_t position) {
-        AssertInfo(data_access_mode_ == DataAccessMode::Scan,
-                   "cannot open data scan cursor in mode {}",
-                   static_cast<int>(data_access_mode_));
-        AssertInfo(data_scan_column_ != nullptr,
-                   "data scan column is not initialized");
-        AssertInfo(data_prepared_scan_ != nullptr,
-                   "prepared data scan is not initialized");
-        data_scan_cursor_ = data_prepared_scan_->Seek(position);
-        AssertInfo(data_scan_cursor_ != nullptr,
-                   "data scan backend cannot seek field {} to row {}",
-                   field_id_.get(),
-                   position);
-        AssertInfo(data_scan_cursor_->Position() == position,
-                   "data scan cursor opened at {}, expected {}",
-                   data_scan_cursor_->Position(),
-                   position);
-    }
-
     template <typename T>
-    bool
-    EnsureDataScanBackend(ChunkedColumnInterface::ScanProjection projection =
+    ChunkedColumnInterface::PreparedScanResult
+    PrepareDataScanWindow(int64_t start,
+                          int64_t length,
+                          ChunkedColumnInterface::ScanProjection projection =
                               ChunkedColumnInterface::ScanProjection::Data) {
         const auto value_kind = DataScanValueKind<T>();
         if (data_access_mode_ == DataAccessMode::Chunk) {
-            return false;
+            return nullptr;
         }
         if (data_access_mode_ == DataAccessMode::Scan) {
             AssertInfo(data_scan_projection_ == projection &&
                            data_scan_value_kind_ == value_kind,
                        "data scan contract changed after backend selection");
-            return true;
+        } else {
+            std::tie(data_scan_column_, data_scan_skip_index_) =
+                CaptureDataScanResources();
+            if (data_scan_column_ == nullptr) {
+                data_access_mode_ = DataAccessMode::Chunk;
+                return nullptr;
+            }
+            data_scan_projection_ = projection;
+            data_scan_value_kind_ = value_kind;
         }
 
-        std::tie(data_scan_column_, data_scan_skip_index_) =
-            CaptureDataScanResources();
-        if (data_scan_column_ == nullptr) {
-            data_access_mode_ = DataAccessMode::Chunk;
-            return false;
-        }
-
-        data_scan_projection_ = projection;
-        data_scan_value_kind_ = value_kind;
         auto options = ChunkedColumnInterface::ScanOptions::ForData(
-            current_data_global_pos_,
-            active_count_ - current_data_global_pos_,
-            projection,
-            value_kind);
-        data_prepared_scan_ = data_scan_column_->PrepareScan(op_ctx_, options);
-        if (data_prepared_scan_ == nullptr) {
+            start, length, projection, value_kind);
+        auto prepared = data_scan_column_->PrepareScan(op_ctx_, options);
+        if (prepared == nullptr) {
+            AssertInfo(data_access_mode_ != DataAccessMode::Scan,
+                       "data scan backend stopped supporting field {}",
+                       field_id_.get());
             data_scan_skip_index_.reset();
             data_scan_column_.reset();
             data_access_mode_ = DataAccessMode::Chunk;
-            return false;
+            return nullptr;
         }
-        data_scan_cursor_ = data_prepared_scan_->Seek(current_data_global_pos_);
-        AssertInfo(data_scan_cursor_ != nullptr,
-                   "prepared data scan cannot seek field {} to row {}",
-                   field_id_.get(),
-                   current_data_global_pos_);
         data_access_mode_ = DataAccessMode::Scan;
-        AssertInfo(data_scan_cursor_->Position() == current_data_global_pos_,
-                   "data scan cursor opened at {}, expected {}",
-                   data_scan_cursor_->Position(),
-                   current_data_global_pos_);
-        return true;
-    }
-
-    template <typename T>
-    bool
-    EnsureDataScanCursorAt(int64_t position,
-                           ChunkedColumnInterface::ScanProjection projection =
-                               ChunkedColumnInterface::ScanProjection::Data) {
-        if (!EnsureDataScanBackend<T>(projection)) {
-            return false;
-        }
-        if (data_scan_cursor_ == nullptr) {
-            OpenDataScanCursor(position);
-        } else if (data_scan_cursor_->Position() < position) {
-            CloseDataScanCursor();
-            OpenDataScanCursor(position);
-        }
-        AssertInfo(data_scan_cursor_->Position() == position,
-                   "data scan cursor at {}, expected {}",
-                   data_scan_cursor_->Position(),
-                   position);
-        return true;
+        return prepared;
     }
 
     static void
@@ -1867,119 +1811,177 @@ class SegmentExpr : public Expr {
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
-        if (!EnsureDataScanBackend<T>()) {
+        const auto real_batch_size = GetNextBatchSize();
+        const auto window_start = current_data_global_pos_;
+        const auto window_end = window_start + real_batch_size;
+        auto prepared = PrepareDataScanWindow<T>(
+            window_start,
+            real_batch_size,
+            ChunkedColumnInterface::ScanProjection::Data);
+        if (prepared == nullptr) {
             return -1;
         }
+        const auto& plan = prepared->Plan();
+        AssertInfo(plan.requested_range.start == window_start &&
+                       plan.requested_range.end == window_end,
+                   "prepared scan plan [{}, {}) does not match window [{}, {})",
+                   plan.requested_range.start,
+                   plan.requested_range.end,
+                   window_start,
+                   window_end);
+        auto cursor =
+            prepared->Open(plan, ChunkedColumnInterface::ScanProjection::Data);
+        AssertInfo(cursor != nullptr,
+                   "prepared data scan cannot open field {} window [{}, {})",
+                   field_id_.get(),
+                   window_start,
+                   window_end);
 
-        int64_t processed_size = 0;
-        const auto real_batch_size = GetNextBatchSize();
-        AssertInfo(data_scan_skip_index_ != nullptr,
-                   "data scan skip index is not initialized");
-
-        while (processed_size < real_batch_size) {
-            const auto expected_row = current_data_global_pos_ + processed_size;
-            AssertInfo(EnsureDataScanCursorAt<T>(expected_row),
-                       "data scan backend changed while processing");
-            ChunkedColumnInterface::ScanBatch batch;
-            const auto remaining = real_batch_size - processed_size;
-            if (!data_scan_cursor_->Next(remaining, &batch)) {
-                break;
-            }
-            AssertInfo(batch.size > 0 && batch.size <= remaining,
-                       "invalid data scan batch size {}, remaining {}",
-                       batch.size,
-                       remaining);
-            const auto row = batch.row_id_start;
-            AssertInfo(row == expected_row,
-                       "data scan row mismatch, got {}, expected {}",
-                       row,
-                       expected_row);
-
-            const auto size = batch.size;
-            auto [chunk_id, _] = data_scan_column_->GetChunkIDByOffset(row);
-            const auto chunk_end =
-                data_scan_column_->GetNumRowsUntilChunk(chunk_id) +
-                data_scan_column_->chunk_row_nums(chunk_id);
-            AssertInfo(row + size <= chunk_end,
-                       "data scan batch [{}, {}) crosses chunk {} end {}",
-                       row,
-                       row + size,
-                       chunk_id,
-                       chunk_end);
-            const auto* data = batch.values.data_as<T>();
-            const auto* valid_data = batch.validity;
-            const bool skipped =
-                skip_func &&
-                skip_func(*data_scan_skip_index_, field_id_, chunk_id);
-
-            auto make_segment_offsets = [&]() {
+        const auto evaluate_batch = [&](const T* data,
+                                        const bool* valid_data,
+                                        int64_t row,
+                                        int64_t size) {
+            const auto output_offset = row - window_start;
+            AssertInfo(
+                output_offset >= 0 && output_offset + size <= real_batch_size,
+                "scan output range [{}, {}) outside window [{}, {})",
+                row,
+                row + size,
+                window_start,
+                window_end);
+            if constexpr (NeedSegmentOffsets) {
                 std::vector<int32_t> segment_offsets_array(size);
                 for (int64_t i = 0; i < size; ++i) {
                     segment_offsets_array[i] = static_cast<int32_t>(row + i);
                 }
-                return segment_offsets_array;
-            };
-
-            if (!skipped) {
-                if constexpr (NeedSegmentOffsets) {
-                    auto segment_offsets_array = make_segment_offsets();
-                    func(data,
-                         valid_data,
-                         nullptr,
-                         segment_offsets_array.data(),
-                         size,
-                         res + processed_size,
-                         valid_res + processed_size,
-                         values...);
-                } else {
-                    func(data,
-                         valid_data,
-                         nullptr,
-                         size,
-                         res + processed_size,
-                         valid_res + processed_size,
-                         values...);
-                }
+                func(data,
+                     valid_data,
+                     nullptr,
+                     segment_offsets_array.data(),
+                     size,
+                     res + output_offset,
+                     valid_res + output_offset,
+                     values...);
             } else {
+                func(data,
+                     valid_data,
+                     nullptr,
+                     size,
+                     res + output_offset,
+                     valid_res + output_offset,
+                     values...);
+            }
+        };
+
+        const auto evaluate_no_match = [&](int64_t start, int64_t end) {
+            AssertInfo(start < end,
+                       "invalid no-match scan range [{}, {})",
+                       start,
+                       end);
+            auto validity_cursor = prepared->Open(
+                ChunkedColumnInterface::ScanPlan::Full(start, end - start),
+                ChunkedColumnInterface::ScanProjection::NoData);
+            AssertInfo(validity_cursor != nullptr,
+                       "prepared scan cannot open validity range [{}, {})",
+                       start,
+                       end);
+            auto position = start;
+            ChunkedColumnInterface::ScanBatch validity_batch;
+            while (validity_cursor->Next(end - position, &validity_batch)) {
+                AssertInfo(validity_batch.row_id_start == position &&
+                               validity_batch.size > 0 &&
+                               position + validity_batch.size <= end,
+                           "invalid no-match validity batch [{}, {}) at {}",
+                           validity_batch.row_id_start,
+                           validity_batch.row_id_start + validity_batch.size,
+                           position);
+                const auto output_offset = position - window_start;
+                ApplyScanValidity(validity_batch,
+                                  0,
+                                  res + output_offset,
+                                  valid_res + output_offset,
+                                  validity_batch.size);
+                evaluate_batch(nullptr, nullptr, position, validity_batch.size);
+                position += validity_batch.size;
+            }
+            AssertInfo(position == end && validity_cursor->Position() == end,
+                       "no-match validity scan stopped at {}, expected {}",
+                       position,
+                       end);
+        };
+
+        auto logical_position = window_start;
+        while (logical_position < window_end) {
+            ChunkedColumnInterface::ScanBatch batch;
+            if (!cursor->Next(window_end - logical_position, &batch)) {
+                AssertInfo(
+                    cursor->Position() >= logical_position &&
+                        cursor->Position() <= window_end,
+                    "data scan cursor stopped at {}, logical position {}",
+                    cursor->Position(),
+                    logical_position);
+                if (cursor->Position() > logical_position) {
+                    evaluate_no_match(logical_position, cursor->Position());
+                    logical_position = cursor->Position();
+                }
+                break;
+            }
+            AssertInfo(batch.size > 0 &&
+                           batch.row_id_start >= logical_position &&
+                           batch.row_id_start + batch.size <= window_end,
+                       "invalid data scan batch [{}, {}) after {}",
+                       batch.row_id_start,
+                       batch.row_id_start + batch.size,
+                       logical_position);
+            if (batch.row_id_start > logical_position) {
+                evaluate_no_match(logical_position, batch.row_id_start);
+            }
+            AssertInfo(!batch.values.empty(),
+                       "evaluated data scan batch [{}, {}) has no values",
+                       batch.row_id_start,
+                       batch.row_id_start + batch.size);
+            bool legacy_skipped = false;
+            if (data_scan_column_->UseLegacyDataSkipIndex() && skip_func) {
+                AssertInfo(data_scan_skip_index_ != nullptr,
+                           "legacy data skip index is not initialized");
+                auto [chunk_id, _] =
+                    data_scan_column_->GetChunkIDByOffset(batch.row_id_start);
+                const auto chunk_end =
+                    data_scan_column_->GetNumRowsUntilChunk(chunk_id) +
+                    data_scan_column_->chunk_row_nums(chunk_id);
+                AssertInfo(batch.row_id_start + batch.size <= chunk_end,
+                           "legacy skip batch [{}, {}) crosses chunk {} end {}",
+                           batch.row_id_start,
+                           batch.row_id_start + batch.size,
+                           chunk_id,
+                           chunk_end);
+                legacy_skipped =
+                    skip_func(*data_scan_skip_index_, field_id_, chunk_id);
+            }
+            if (legacy_skipped) {
+                const auto output_offset = batch.row_id_start - window_start;
                 ApplyScanValidity(batch,
                                   0,
-                                  res + processed_size,
-                                  valid_res + processed_size,
-                                  size);
-                if constexpr (NeedSegmentOffsets) {
-                    auto segment_offsets_array = make_segment_offsets();
-                    func(nullptr,
-                         nullptr,
-                         nullptr,
-                         segment_offsets_array.data(),
-                         size,
-                         res + processed_size,
-                         valid_res + processed_size,
-                         values...);
-                } else {
-                    func(nullptr,
-                         nullptr,
-                         nullptr,
-                         size,
-                         res + processed_size,
-                         valid_res + processed_size,
-                         values...);
-                }
+                                  res + output_offset,
+                                  valid_res + output_offset,
+                                  batch.size);
+                evaluate_batch(
+                    nullptr, nullptr, batch.row_id_start, batch.size);
+            } else {
+                evaluate_batch(batch.values.data_as<T>(),
+                               batch.validity,
+                               batch.row_id_start,
+                               batch.size);
             }
-
-            processed_size += size;
+            logical_position = batch.row_id_start + batch.size;
         }
 
-        AssertInfo(processed_size == real_batch_size,
-                   "data scan processed {} rows, expected {}",
-                   processed_size,
-                   real_batch_size);
-        current_data_global_pos_ += processed_size;
-        AssertInfo(data_scan_cursor_->Position() == current_data_global_pos_,
-                   "data scan cursor at {}, execution at {}",
-                   data_scan_cursor_->Position(),
-                   current_data_global_pos_);
-        return processed_size;
+        AssertInfo(logical_position == window_end,
+                   "data scan processed through {}, expected {}",
+                   logical_position,
+                   window_end);
+        current_data_global_pos_ = window_end;
+        return real_batch_size;
     }
 
     template <typename T,
@@ -2542,24 +2544,33 @@ class SegmentExpr : public Expr {
         const auto batch_size = GetNextBatchSize();
         TargetBitmap valid_result(batch_size);
         valid_result.set();
-        if (!EnsureDataScanBackend<T>(
-                ChunkedColumnInterface::ScanProjection::NoData)) {
+        const auto window_start = current_data_global_pos_;
+        auto prepared = PrepareDataScanWindow<T>(
+            window_start,
+            batch_size,
+            ChunkedColumnInterface::ScanProjection::NoData);
+        if (prepared == nullptr) {
             AssertInfo(!segment_->is_chunked(),
                        "sealed field {} does not provide a validity scan "
                        "cursor",
                        field_id_.get());
             return ProcessGrowingDataChunksForValid();
         }
+        auto cursor = prepared->Open(
+            ChunkedColumnInterface::ScanPlan::Full(window_start, batch_size),
+            ChunkedColumnInterface::ScanProjection::NoData);
+        AssertInfo(
+            cursor != nullptr,
+            "prepared validity scan cannot open field {} window [{}, {})",
+            field_id_.get(),
+            window_start,
+            window_start + batch_size);
         int64_t processed_size = 0;
         while (processed_size < batch_size) {
-            const auto expected_row = current_data_global_pos_ + processed_size;
-            AssertInfo(EnsureDataScanCursorAt<T>(
-                           expected_row,
-                           ChunkedColumnInterface::ScanProjection::NoData),
-                       "validity scan backend changed while processing");
+            const auto expected_row = window_start + processed_size;
             ChunkedColumnInterface::ScanBatch batch;
             const auto remaining = batch_size - processed_size;
-            if (!data_scan_cursor_->Next(remaining, &batch)) {
+            if (!cursor->Next(remaining, &batch)) {
                 break;
             }
             AssertInfo(batch.row_id_start == expected_row && batch.size > 0 &&
@@ -2580,10 +2591,10 @@ class SegmentExpr : public Expr {
                    "validity scan processed {} rows, expected {}",
                    processed_size,
                    batch_size);
-        current_data_global_pos_ += processed_size;
-        AssertInfo(data_scan_cursor_->Position() == current_data_global_pos_,
+        current_data_global_pos_ = window_start + processed_size;
+        AssertInfo(cursor->Position() == current_data_global_pos_,
                    "validity scan cursor at {}, execution at {}",
-                   data_scan_cursor_->Position(),
+                   cursor->Position(),
                    current_data_global_pos_);
         return valid_result;
     }
@@ -3128,15 +3139,10 @@ class SegmentExpr : public Expr {
     DataAccessMode data_access_mode_{DataAccessMode::Uninitialized};
     // ScanCursor implementations retain a raw column pointer. Once Scan is
     // selected, keep the captured column generation for the expression's full
-    // lifetime so a short-circuit seek never observes a replacement column.
+    // lifetime, while each evaluated operator window owns its own prepared
+    // pins/cursor.
     std::shared_ptr<ChunkedColumnInterface> data_scan_column_{nullptr};
     std::shared_ptr<const SkipIndex> data_scan_skip_index_{nullptr};
-    // Owns the planned/pinned scan input independently from the active cursor.
-    // A conjunction short-circuit may discard the cursor and later seek while
-    // keeping this prepared scan alive, so seeking never pins cells again.
-    ChunkedColumnInterface::PreparedScanResult data_prepared_scan_{nullptr};
-    std::unique_ptr<ChunkedColumnInterface::ScanCursor> data_scan_cursor_{
-        nullptr};
     ChunkedColumnInterface::ScanProjection data_scan_projection_{
         ChunkedColumnInterface::ScanProjection::Data};
     ChunkedColumnInterface::ScanValueKind data_scan_value_kind_{

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -25,6 +25,7 @@
 #include <optional>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include "common/Array.h"
 #include "common/ArrayOffsets.h"
@@ -40,7 +41,10 @@
 #include "index/Index.h"
 #include "index/JsonFlatIndex.h"
 #include "log/Log.h"
+#include "mmap/ChunkedColumnInterface.h"
+#include "mmap/ChunkedColumnFilter.h"
 #include "query/PlanProto.h"
+#include "segcore/SegcoreConfig.h"
 #include "segcore/SegmentSealed.h"
 #include "segcore/SegmentInterface.h"
 #include "segcore/SegmentGrowingImpl.h"
@@ -57,6 +61,12 @@ enum class ExprExecPath {
     PkIndex,      // segment_->pk_range / search_ids
     TextIndex,    // segment_->GetTextIndex
     JsonStats,    // segment_->GetJsonStats
+};
+
+enum class DataAccessMode {
+    Uninitialized,
+    Chunk,
+    Scan,
 };
 
 inline std::vector<PinWrapper<const index::IndexBase*>>
@@ -101,6 +111,11 @@ ApplyValidMask(const bool* valid_data,
     if (valid_data == nullptr) {
         return;
     }
+    // When both destinations alias the same underlying bitmap (e.g. a
+    // validity-only scan passes one bitmap for result and validity), each NULL
+    // only needs a single write.
+    const bool valid_res_aliases_res =
+        res.data() == valid_res.data() && res.offset() == valid_res.offset();
     int i = 0;
     for (; i + 64 <= size; i += 64) {
         uint64_t m = 0;
@@ -110,12 +125,17 @@ ApplyValidMask(const bool* valid_data,
         for (uint64_t nulls = ~m; nulls != 0; nulls &= nulls - 1) {
             const int k = std::countr_zero(nulls);
             res[i + k] = false;
-            valid_res[i + k] = false;
+            if (!valid_res_aliases_res) {
+                valid_res[i + k] = false;
+            }
         }
     }
     for (; i < size; i++) {
         if (!valid_data[i]) {
-            res[i] = valid_res[i] = false;
+            res[i] = false;
+            if (!valid_res_aliases_res) {
+                valid_res[i] = false;
+            }
         }
     }
 }
@@ -128,6 +148,11 @@ ApplyValidMask(ValidityView validity,
     if (!validity) {
         return;
     }
+    // When both destinations alias the same underlying bitmap (e.g. a
+    // validity-only scan passes one bitmap for result and validity), each NULL
+    // only needs a single AND.
+    const bool valid_res_aliases_res =
+        res.data() == valid_res.data() && res.offset() == valid_res.offset();
 
     if (const auto* expanded = validity.expanded_data(); expanded != nullptr) {
         ApplyValidMask(expanded, res, valid_res, size);
@@ -161,9 +186,84 @@ ApplyValidMask(ValidityView validity,
         auto word = read_word(validity.bit_offset() + i, bit_count);
         TargetBitmapView validity_word(&word, bit_count);
         auto res_block = res.view(i);
-        auto valid_res_block = valid_res.view(i);
         res_block.inplace_and(validity_word, bit_count);
-        valid_res_block.inplace_and(validity_word, bit_count);
+        if (!valid_res_aliases_res) {
+            auto valid_res_block = valid_res.view(i);
+            valid_res_block.inplace_and(validity_word, bit_count);
+        }
+    }
+}
+
+inline void
+ApplyValidMaskForCandidates(ValidityView validity,
+                            TargetBitmapView res,
+                            TargetBitmapView valid_res,
+                            int64_t size,
+                            const TargetBitmap* candidate_mask,
+                            int64_t candidate_pos) {
+    if (!validity) {
+        return;
+    }
+    if (candidate_mask == nullptr || candidate_mask->empty()) {
+        ApplyValidMask(validity, res, valid_res, static_cast<int>(size));
+        return;
+    }
+    AssertInfo(
+        candidate_pos >= 0 && candidate_pos + size <=
+                                  static_cast<int64_t>(candidate_mask->size()),
+        "validity candidate range [{}, {}) exceeds mask size {}",
+        candidate_pos,
+        candidate_pos + size,
+        candidate_mask->size());
+
+    const bool valid_res_aliases_res =
+        res.data() == valid_res.data() && res.offset() == valid_res.offset();
+    const auto* expanded = validity.expanded_data();
+    const auto* packed = validity.packed_data();
+    AssertInfo(expanded != nullptr || packed != nullptr,
+               "Validity data is missing");
+    const auto read_validity_word = [&](int64_t offset, int bit_count) {
+        uint64_t word = 0;
+        if (expanded != nullptr) {
+            for (int i = 0; i < bit_count; ++i) {
+                word |= uint64_t(expanded[offset + i] != 0) << i;
+            }
+            return word;
+        }
+
+        const auto bit_offset = validity.bit_offset() + offset;
+        const auto byte_offset = bit_offset >> 3;
+        const auto shift = static_cast<int>(bit_offset & 0x07);
+        const auto bytes = (shift + bit_count + 7) >> 3;
+        const auto low_bytes = std::min(bytes, 8);
+        for (int i = 0; i < low_bytes; ++i) {
+            word |= uint64_t(packed[byte_offset + i]) << (i * 8);
+        }
+        word >>= shift;
+        if (bytes > 8) {
+            word |= uint64_t(packed[byte_offset + 8]) << (64 - shift);
+        }
+        if (bit_count < 64) {
+            word &= (uint64_t{1} << bit_count) - 1;
+        }
+        return word;
+    };
+
+    using CandidatePolicy = TargetBitmapView::policy_type;
+    static_assert(std::is_same_v<CandidatePolicy::data_type, uint64_t>);
+    for (int64_t i = 0; i < size; i += 64) {
+        const auto bit_count =
+            static_cast<int>(std::min<int64_t>(size - i, 64));
+        const auto candidate_word = CandidatePolicy::op_read(
+            candidate_mask->data(), candidate_pos + i, bit_count);
+        auto keep_word = ~candidate_word | read_validity_word(i, bit_count);
+        TargetBitmapView keep(&keep_word, bit_count);
+        auto res_block = res.view(i);
+        res_block.inplace_and(keep, bit_count);
+        if (!valid_res_aliases_res) {
+            auto valid_res_block = valid_res.view(i);
+            valid_res_block.inplace_and(keep, bit_count);
+        }
     }
 }
 
@@ -464,33 +564,78 @@ class SegmentExpr : public Expr {
     }
 
     void
-    MoveCursorForData() {
-        int64_t processed_size = 0;
-        for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-            auto data_pos =
-                (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            const auto active_remaining =
-                active_count_ - RowOffsetInSegment(i, data_pos);
-            if (active_remaining <= 0) {
-                break;
+    AdvanceDataChunkCursor(int64_t rows) {
+        AssertInfo(
+            rows >= 0 && current_data_global_pos_ + rows <= active_count_,
+            "data chunk advance {} from {} exceeds row count {}",
+            rows,
+            current_data_global_pos_,
+            active_count_);
+        int64_t advanced = 0;
+        for (size_t i = current_data_chunk_;
+             i < num_data_chunk_ && advanced < rows;
+             ++i) {
+            const auto data_pos =
+                i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
+            int64_t chunk_rows;
+            if (segment_->is_chunked()) {
+                chunk_rows = ChunkSize(field_id_, i);
+            } else {
+                chunk_rows = i == num_data_chunk_ - 1 &&
+                                     active_count_ % size_per_chunk_ != 0
+                                 ? active_count_ % size_per_chunk_
+                                 : size_per_chunk_;
             }
-            auto size = GetDataChunkRemainingRows(i, data_pos);
-
-            size = std::min(
-                {size, batch_size_ - processed_size, active_remaining});
+            const auto size = std::min(chunk_rows - data_pos, rows - advanced);
             if (size <= 0) {
                 continue;
             }
-
-            processed_size += size;
             current_data_chunk_ = i;
             current_data_chunk_pos_ = data_pos + size;
-            if (processed_size >= batch_size_) {
-                break;
-            }
+            advanced += size;
         }
-        current_data_global_pos_ =
-            RowOffsetInSegment(current_data_chunk_, current_data_chunk_pos_);
+        AssertInfo(advanced == rows,
+                   "data chunk cursor advanced {} rows, expected {}",
+                   advanced,
+                   rows);
+    }
+
+    void
+    AdvanceDataCursor(int64_t rows) {
+        // The segment offset is the common execution-window position. Before
+        // the access mode is selected, also advance the legacy Chunk cursor so
+        // fallback remains possible. Once Scan is selected its retained cursor
+        // uses only the segment offset; Chunk coordinates are no longer read or
+        // kept synchronized.
+        if (data_access_mode_ != DataAccessMode::Scan && num_data_chunk_ > 0) {
+            AdvanceDataChunkCursor(rows);
+        }
+        current_data_global_pos_ += rows;
+    }
+
+    // Legacy Chunk readers advance current_data_chunk_ and
+    // current_data_chunk_pos_ while consuming a batch. Keep the canonical
+    // segment offset synchronized without changing that existing read path.
+    void
+    CommitLegacyDataProgress(int64_t processed_rows) {
+        AssertInfo(
+            processed_rows >= 0 &&
+                current_data_global_pos_ + processed_rows <= active_count_,
+            "data chunk progress {} from {} exceeds row count {}",
+            processed_rows,
+            current_data_global_pos_,
+            active_count_);
+        current_data_global_pos_ += processed_rows;
+    }
+
+    void
+    MoveCursorForData() {
+        const auto rows =
+            std::min(batch_size_, active_count_ - current_data_global_pos_);
+        // A leaf short-circuited by its parent does not advance its scan
+        // cursor. The next evaluated call compares the cursor position with
+        // its window start and performs a forward Seek() when needed.
+        AdvanceDataCursor(rows);
     }
 
     void
@@ -508,7 +653,7 @@ class SegmentExpr : public Expr {
     }
 
     void
-    MoveCursor() override {
+    MoveCursorInternal() {
         if (!has_offset_input_) {
             if (execute_all_at_once_) {
                 // One-shot execution, no cursor movement needed.
@@ -527,6 +672,165 @@ class SegmentExpr : public Expr {
                 MoveCursorForData();
             }
         }
+    }
+
+    void
+    MoveCursor() override {
+        MoveCursorInternal();
+    }
+
+    template <typename T>
+    static ChunkedColumnInterface::TargetType
+    DataTargetType() {
+        return milvus::TargetTypeOf<T>();
+    }
+
+    std::pair<std::shared_ptr<ChunkedColumnInterface>,
+              std::shared_ptr<const SkipIndex>>
+    CaptureDataScanResources() const {
+        return snapshot_ ? snapshot_->GetDataScanResources(field_id_)
+                         : segment_->GetDataScanResources(field_id_);
+    }
+
+    void
+    EnsureDataTakeResources(
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func) {
+        if (data_take_resources_initialized_) {
+            return;
+        }
+        data_take_resources_initialized_ = true;
+        auto resources = CaptureDataScanResources();
+        data_take_column_ = std::move(resources.first);
+        if (data_take_column_ != nullptr) {
+            data_take_filter_ =
+                BindColumnFilter(skip_func, std::move(resources.second));
+        }
+    }
+
+    detail::ColumnFilter::PhysicalCellPredicate
+    BindCellSkipPredicate(
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        std::shared_ptr<const SkipIndex> skip_index) const {
+        if (!skip_func || skip_index == nullptr) {
+            return {};
+        }
+        const auto field_id = field_id_;
+        return [skip_func = std::move(skip_func),
+                skip_index = std::move(skip_index),
+                field_id](int64_t cell_id) {
+            return skip_func(*skip_index, field_id, static_cast<int>(cell_id));
+        };
+    }
+
+    detail::ColumnFilterPtr
+    BindColumnFilter(
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        std::shared_ptr<const SkipIndex> skip_index) const {
+        if (!skip_func || skip_index == nullptr) {
+            return {};
+        }
+        const auto source = skip_index->GetMetricsSource(field_id_);
+        if (source == SkipIndex::MetricsSource::None) {
+            return {};
+        }
+        const auto filter_source =
+            source == SkipIndex::MetricsSource::PreloadedStatistics
+                ? detail::ColumnFilter::MetricsSource::PreloadedStatistics
+                : detail::ColumnFilter::MetricsSource::LoadedPayload;
+        return std::make_shared<const detail::ColumnFilter>(
+            filter_source,
+            BindCellSkipPredicate(std::move(skip_func), std::move(skip_index)));
+    }
+
+    template <typename T>
+    ChunkedColumnInterface::ScanCursor*
+    EnsureDataScanCursor(
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func) {
+        const auto target_type = DataTargetType<T>();
+        return EnsureDataScanCursor(target_type, skip_func);
+    }
+
+    ChunkedColumnInterface::ScanCursor*
+    EnsureValidityScanCursor() {
+        return EnsureDataScanCursor(ChunkedColumnInterface::TargetType::None,
+                                    {});
+    }
+
+    ChunkedColumnInterface::ScanCursor*
+    EnsureDataScanCursor(
+        ChunkedColumnInterface::TargetType target_type,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func) {
+        if (data_access_mode_ == DataAccessMode::Chunk) {
+            return nullptr;
+        }
+        if (data_access_mode_ == DataAccessMode::Scan) {
+            AssertInfo(data_scan_target_type_ == target_type,
+                       "data scan contract changed after backend selection");
+            AssertInfo(data_scan_cursor_ != nullptr,
+                       "data scan mode has no cursor for field {}",
+                       field_id_.get());
+            return data_scan_cursor_.get();
+        } else {
+            auto resources = CaptureDataScanResources();
+            data_scan_column_ = std::move(resources.first);
+            if (data_scan_column_ == nullptr) {
+                data_access_mode_ = DataAccessMode::Chunk;
+                return nullptr;
+            }
+            data_scan_target_type_ = target_type;
+            data_scan_filter_ =
+                BindColumnFilter(skip_func, std::move(resources.second));
+        }
+
+        const auto cursor_prefetch =
+            target_type != ChunkedColumnInterface::TargetType::None &&
+            !prefetched_;
+
+        const auto pin_policy =
+            segcore::SegcoreConfig::default_config().get_scan_cursor_owns_pin()
+                ? ChunkedColumnInterface::ScanPinPolicy::CursorOwned
+                : ChunkedColumnInterface::ScanPinPolicy::ResultOwned;
+        auto options = ChunkedColumnInterface::ScanOptions::ForData(
+            current_data_global_pos_, target_type, pin_policy, cursor_prefetch);
+        options.filter = data_scan_filter_;
+        data_scan_cursor_ = data_scan_column_->Scan(op_ctx_, options);
+        if (data_scan_cursor_ == nullptr) {
+            AssertInfo(data_access_mode_ != DataAccessMode::Scan,
+                       "data scan backend stopped supporting field {}",
+                       field_id_.get());
+            data_scan_filter_.reset();
+            data_scan_column_.reset();
+            data_access_mode_ = DataAccessMode::Chunk;
+            return nullptr;
+        }
+        if (cursor_prefetch) {
+            prefetched_ = true;
+            raw_data_prefetch_deferred_ = false;
+        }
+        data_access_mode_ = DataAccessMode::Scan;
+        return data_scan_cursor_.get();
+    }
+
+    static void
+    ApplyScanValidity(const ChunkedColumnInterface::ScanBatch& batch,
+                      int64_t batch_pos,
+                      TargetBitmapView res,
+                      TargetBitmapView valid_res,
+                      int64_t size,
+                      const TargetBitmap* candidate_mask = nullptr,
+                      int64_t candidate_pos = 0) {
+        if (!batch.validity) {
+            return;
+        }
+        ApplyValidMaskForCandidates(batch.validity.Subview(batch_pos),
+                                    res,
+                                    valid_res,
+                                    size,
+                                    candidate_mask,
+                                    candidate_pos);
     }
 
     void
@@ -613,25 +917,10 @@ class SegmentExpr : public Expr {
     int64_t
     GetNextBatchSize() {
         EnsureExecPathDetermined();
-        if (exec_path_ == ExprExecPath::JsonStats) {
-            const auto remaining = active_count_ - current_data_global_pos_;
-            return remaining <= 0 ? 0 : std::min(batch_size_, remaining);
-        }
-        auto current_chunk =
-            UseIndexCursor() ? current_index_chunk_ : current_data_chunk_;
-        auto current_chunk_pos = UseIndexCursor() ? current_index_chunk_pos_
-                                                  : current_data_chunk_pos_;
-        auto current_rows = 0;
-        if (segment_->is_chunked()) {
-            current_rows =
-                UseIndexCursor() && segment_->type() == SegmentType::Sealed
-                    ? current_chunk_pos
-                    : NumRowsUntilChunk(field_id_, current_chunk) +
-                          current_chunk_pos;
-        } else {
-            current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
-        }
-        const auto remaining = active_count_ - current_rows;
+        const auto current_position = UseIndexCursor()
+                                          ? current_index_chunk_pos_
+                                          : current_data_global_pos_;
+        const auto remaining = active_count_ - current_position;
         return remaining <= 0 ? 0 : std::min(batch_size_, remaining);
     }
 
@@ -689,22 +978,8 @@ class SegmentExpr : public Expr {
                    "ArrayOffsets not found for field {}",
                    field_id_.get());
 
-        // Use index cursor or data cursor based on execution path
-        auto current_chunk =
-            UseIndexCursor() ? current_index_chunk_ : current_data_chunk_;
-        auto current_chunk_pos = UseIndexCursor() ? current_index_chunk_pos_
-                                                  : current_data_chunk_pos_;
-
-        int64_t current_rows = 0;
-        if (UseIndexCursor() && segment_->type() == SegmentType::Sealed) {
-            // For sealed segment with index, position is already global
-            current_rows = current_chunk_pos;
-        } else if (segment_->is_chunked()) {
-            current_rows =
-                NumRowsUntilChunk(field_id_, current_chunk) + current_chunk_pos;
-        } else {
-            current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
-        }
+        const auto current_rows = UseIndexCursor() ? current_index_chunk_pos_
+                                                   : current_data_global_pos_;
 
         const auto remaining = active_count_ - current_rows;
         auto batch_rows =
@@ -753,11 +1028,14 @@ class SegmentExpr : public Expr {
 
     // Candidate evaluator contract:
     // - every logical candidate position advances the evaluator exactly once;
-    // - data == nullptr means the reader already decided the candidate result
-    //   (for example candidate-mask/SkipIndex pruning or a NULL reverse
-    //   lookup), so the evaluator must only advance position-indexed state by
-    //   size and return;
-    // - result and validity for a null batch are owned by the reader.
+    // - an invalid value still carries a safe placeholder data pointer and
+    //   false validity, so each evaluator retains its existing NULL semantics;
+    // - an ordinary nullable Scan/Take row never uses data == nullptr; a null
+    //   pointer advances without evaluation when data was skipped, a candidate
+    //   is inactive, or an index reverse-lookup miss already applied its NULL
+    //   result;
+    // - inactive candidate-mask rows remain untouched, but still advance
+    //   position-indexed evaluator state.
     //
     // This contract keeps callback-local bitmap_input cursors aligned across
     // raw-data, element-level, and scalar-index-only candidate paths.
@@ -935,9 +1213,10 @@ class SegmentExpr : public Expr {
     // does not move, but the callback may maintain a batch-local bitmap cursor.
     template <typename T, typename BatchEvaluator, typename... ValTypes>
     int64_t
-    ProcessDataByOffsets(
+    ProcessDataByOffsetsByChunkFallback(
         BatchEvaluator evaluate_batch,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
         OffsetVector* input,
         TargetBitmapView res,
         TargetBitmapView valid_res,
@@ -958,12 +1237,36 @@ class SegmentExpr : public Expr {
     int64_t
     ProcessDataByOffsetsWithMask(
         BatchEvaluator evaluate_batch,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
         OffsetVector* input,
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const TargetBitmap& candidate_mask,
         const ValTypes&... values) {
+        if constexpr (!std::is_same_v<T, VectorArrayView> &&
+                      !std::is_same_v<T, ArrayValueView>) {
+            if (UseIndexCursor() && num_data_chunk_ == 0) {
+                return ProcessIndexLookupByOffsetsImpl<T>(evaluate_batch,
+                                                          input,
+                                                          res,
+                                                          valid_res,
+                                                          &candidate_mask,
+                                                          values...);
+            }
+        }
+
+        const auto processed_size =
+            ProcessDataByOffsetsByTake<T>(evaluate_batch,
+                                          skip_func,
+                                          input,
+                                          res,
+                                          valid_res,
+                                          &candidate_mask,
+                                          values...);
+        if (processed_size >= 0) {
+            return processed_size;
+        }
         return ProcessDataByOffsetsImpl<T>(evaluate_batch,
                                            skip_func,
                                            input,
@@ -977,13 +1280,28 @@ class SegmentExpr : public Expr {
     int64_t
     ProcessDataByOffsetsImpl(
         BatchEvaluator evaluate_batch,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
         OffsetVector* input,
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const TargetBitmap* candidate_mask,
         const ValTypes&... values) {
         int64_t processed_size = 0;
+        const bool has_candidate_mask =
+            candidate_mask != nullptr && !candidate_mask->empty();
+        AssertInfo(
+            !has_candidate_mask || candidate_mask->size() == input->size(),
+            "candidate mask size {} does not match offset input {}",
+            candidate_mask == nullptr ? 0 : candidate_mask->size(),
+            input->size());
+        auto apply_skipped_validity = [&](ValidityView validity,
+                                          int64_t logical_pos) {
+            if (!has_candidate_mask || (*candidate_mask)[logical_pos]) {
+                ApplyValidData(
+                    validity, res + logical_pos, valid_res + logical_pos, 1);
+            }
+        };
 
         // index reverse lookup (only for ScalarIndex path)
         if constexpr (!std::is_same_v<T, VectorArrayView> &&
@@ -997,7 +1315,6 @@ class SegmentExpr : public Expr {
                                                           values...);
             }
         }
-
         auto skip_index = segment_->GetSkipIndex();
 
         // Read arbitrary offsets from non-owning view columns. Input order is
@@ -1057,10 +1374,7 @@ class SegmentExpr : public Expr {
                             valid_res + processed_size,
                             values...);
                     } else {
-                        ApplyValidData(validity,
-                                       res + processed_size,
-                                       valid_res + processed_size,
-                                       1);
+                        apply_skipped_validity(validity, processed_size);
                         // Keep cursor-tracking callbacks aligned when the
                         // current chunk is pruned by SkipIndex.
                         evaluate_batch.template operator()<FilterType::random>(
@@ -1110,11 +1424,8 @@ class SegmentExpr : public Expr {
                     // Chunk skipped by SkipIndex: apply valid mask, then still drive the
                     // callback on a null batch so cursor-tracking callbacks (which index
                     // bitmap_input by batch position via their processed_cursor) stay
-                    // aligned — mirrors the ProcessDataChunksForChunkedSegment skip branch.
-                    ApplyValidData(valid_data,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   1);
+                    // aligned — mirrors the sequential data-scan skip branch.
+                    apply_skipped_validity(valid_data, processed_size);
                     evaluate_batch.template operator()<FilterType::random>(
                         nullptr,
                         ValidityView{},
@@ -1173,11 +1484,8 @@ class SegmentExpr : public Expr {
                     // Chunk skipped by SkipIndex: apply valid mask, then still drive the
                     // callback on a null batch so cursor-tracking callbacks (which index
                     // bitmap_input by batch position via their processed_cursor) stay
-                    // aligned — mirrors the ProcessDataChunksForChunkedSegment skip branch.
-                    ApplyValidData(validity,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   1);
+                    // aligned — mirrors the sequential data-scan skip branch.
+                    apply_skipped_validity(validity, processed_size);
                     evaluate_batch.template operator()<FilterType::random>(
                         nullptr,
                         ValidityView{},
@@ -1231,11 +1539,8 @@ class SegmentExpr : public Expr {
                     // Chunk skipped by SkipIndex: apply valid mask, then still drive the
                     // callback on a null batch so cursor-tracking callbacks (which index
                     // bitmap_input by batch position via their processed_cursor) stay
-                    // aligned — mirrors the ProcessDataChunksForChunkedSegment skip branch.
-                    ApplyValidData(validity,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   1);
+                    // aligned — mirrors the sequential data-scan skip branch.
+                    apply_skipped_validity(validity, processed_size);
                     evaluate_batch.template operator()<FilterType::random>(
                         nullptr,
                         ValidityView{},
@@ -1247,6 +1552,166 @@ class SegmentExpr : public Expr {
                 }
                 processed_size++;
             }
+            return input->size();
+        }
+    }
+
+    template <typename T, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessDataByOffsetsByTake(
+        FUNC func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
+        OffsetVector* input,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const TargetBitmap* candidate_mask,
+        const ValTypes&... values) {
+        // VECTOR_ARRAY has a target tag for typed access, but neither Raw nor
+        // Vortex implements Take for it. Fall back before building an O(N)
+        // Cell plan that the backend must reject.
+        if constexpr (!milvus::HasTargetType<T> ||
+                      std::is_same_v<T, VectorArrayView>) {
+            return -1;
+        } else {
+            return ProcessDataByOffsetsByTakeWithTarget<T>(func,
+                                                           skip_func,
+                                                           input,
+                                                           res,
+                                                           valid_res,
+                                                           candidate_mask,
+                                                           values...);
+        }
+    }
+
+    template <typename T, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessDataByOffsetsByTakeWithTarget(
+        FUNC func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
+        OffsetVector* input,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const TargetBitmap* candidate_mask,
+        const ValTypes&... values) {
+        static_assert(milvus::HasTargetType<T>);
+        if (input->empty()) {
+            return 0;
+        }
+        const bool has_candidate_mask =
+            candidate_mask != nullptr && !candidate_mask->empty();
+        AssertInfo(
+            !has_candidate_mask || candidate_mask->size() == input->size(),
+            "candidate mask size {} does not match Take input {}",
+            candidate_mask == nullptr ? 0 : candidate_mask->size(),
+            input->size());
+        EnsureDataTakeResources(skip_func);
+        if (data_take_column_ == nullptr) {
+            return -1;
+        }
+        const auto nullable = data_take_column_->IsNullable();
+        const auto input_view = ChunkedColumnInterface::OffsetView::From(
+            input->data(), static_cast<int64_t>(input->size()));
+        auto take = data_take_column_->Take(
+            op_ctx_,
+            ChunkedColumnInterface::TakeOptions{
+                input_view, DataTargetType<T>(), data_take_filter_});
+        if (take == nullptr) {
+            return -1;
+        }
+        AssertInfo(take->Size() == input_view.size,
+                   "take returned {} rows for input {}",
+                   take->Size(),
+                   input_view.size);
+        const auto take_is_owned = take->IsOwned();
+
+        if (take_is_owned && data_take_filter_ == nullptr) {
+            auto owned = take->GetOwn();
+            AssertInfo(owned.size == take->Size() && !owned.values.empty(),
+                       "invalid owned take result");
+            func.template operator()<FilterType::random>(
+                owned.values.template data_as<T>(),
+                owned.validity,
+                nullptr,
+                static_cast<int>(owned.size),
+                res,
+                valid_res,
+                values...);
+            return owned.size;
+        }
+
+        const auto items = take->template Access<T>();
+        AssertInfo(items.Size() == input_view.size,
+                   "typed take accessor returned {} rows for input {}",
+                   items.Size(),
+                   input_view.size);
+        const T invalid_value{};
+        for (int64_t logical_pos = 0;
+             logical_pos < static_cast<int64_t>(input->size());
+             ++logical_pos) {
+            if (has_candidate_mask && !(*candidate_mask)[logical_pos]) {
+                // Preserve the evaluator's candidate-position cursor without
+                // pinning or reading this already-excluded Take position.
+                func.template operator()<FilterType::random>(
+                    nullptr,
+                    ValidityView{},
+                    nullptr,
+                    1,
+                    res + logical_pos,
+                    valid_res + logical_pos,
+                    values...);
+                continue;
+            }
+            auto item = items[logical_pos];
+            const auto valid = item.is_valid;
+            if (item.data_skipped) {
+                const auto validity = nullable
+                                          ? ValidityView::FromExpanded(&valid)
+                                          : ValidityView{};
+                ApplyValidData(
+                    validity, res + logical_pos, valid_res + logical_pos, 1);
+                // Keep position-indexed evaluators aligned while leaving the
+                // predicate result false for this skipped logical position.
+                func.template operator()<FilterType::random>(
+                    nullptr,
+                    validity,
+                    nullptr,
+                    1,
+                    res + logical_pos,
+                    valid_res + logical_pos,
+                    values...);
+                continue;
+            }
+            if (!valid) {
+                const auto validity = ValidityView::FromExpanded(&valid);
+                // Match the regular Scan/Chunk path: the evaluator sees an
+                // ordinary invalid item and retains ownership of its NULL
+                // result semantics. The placeholder is never semantically
+                // read when the evaluator honors validity.
+                func.template operator()<FilterType::random>(
+                    &invalid_value,
+                    validity,
+                    nullptr,
+                    1,
+                    res + logical_pos,
+                    valid_res + logical_pos,
+                    values...);
+                continue;
+            }
+
+            AssertInfo(item.value.has_value(),
+                       "active Take row {} has no value",
+                       logical_pos);
+            const auto& value = *item.value;
+            func.template operator()<FilterType::random>(
+                &value,
+                nullable ? ValidityView::FromExpanded(&valid) : ValidityView{},
+                nullptr,
+                1,
+                res + logical_pos,
+                valid_res + logical_pos,
+                values...);
         }
         return input->size();
     }
@@ -1485,6 +1950,36 @@ class SegmentExpr : public Expr {
         return processed_elems;
     }
 
+    // Prefer the unified Take API for scalar candidates while retaining the
+    // legacy chunk reader for backends or representations it does not support.
+    template <typename T, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessDataByOffsets(
+        FUNC func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
+        OffsetVector* input,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const ValTypes&... values) {
+        // index reverse lookup (only for ScalarIndex path)
+        if constexpr (!std::is_same_v<T, VectorArrayView> &&
+                      !std::is_same_v<T, ArrayValueView>) {
+            if (UseIndexCursor() && num_data_chunk_ == 0) {
+                return ProcessIndexLookupByOffsets<T>(
+                    func, input, res, valid_res, values...);
+            }
+        }
+
+        const auto processed_size = ProcessDataByOffsetsByTake<T>(
+            func, skip_func, input, res, valid_res, nullptr, values...);
+        if (processed_size >= 0) {
+            return processed_size;
+        }
+        return ProcessDataByOffsetsByChunkFallback<T>(
+            func, skip_func, input, res, valid_res, values...);
+    }
+
     // Process element-level data by element IDs. Consecutive element IDs from
     // the same row are grouped into runs, and consecutive runs in the same
     // chunk share one row fetch.
@@ -1655,6 +2150,7 @@ class SegmentExpr : public Expr {
                    "ArrayOffsets not found for field {}",
                    field_id_.get());
 
+        const auto expected_rows = GetNextBatchSize();
         int64_t processed_rows = 0;
         int64_t processed_elems = 0;
         std::vector<ElementType> value_buffer;
@@ -1672,7 +2168,7 @@ class SegmentExpr : public Expr {
             }
             auto size = GetDataChunkRemainingRows(i, data_pos);
             size = std::min(
-                {size, batch_size_ - processed_rows, active_remaining});
+                {size, expected_rows - processed_rows, active_remaining});
             if (size <= 0) {
                 continue;
             }
@@ -1729,17 +2225,19 @@ class SegmentExpr : public Expr {
             processed_rows += size;
             current_data_chunk_ = i;
             current_data_chunk_pos_ = data_pos + size;
-            if (processed_rows >= batch_size_) {
+            if (processed_rows >= expected_rows) {
                 break;
             }
         }
 
-        current_data_global_pos_ =
-            RowOffsetInSegment(current_data_chunk_, current_data_chunk_pos_);
+        AssertInfo(processed_rows == expected_rows,
+                   "element data processed {} rows, expected {}",
+                   processed_rows,
+                   expected_rows);
+        CommitLegacyDataProgress(processed_rows);
         return processed_elems;
     }
 
-    // Template parameter to control whether segment offsets are needed (for GIS functions)
     template <typename T,
               bool NeedSegmentOffsets = false,
               typename FUNC,
@@ -1747,10 +2245,13 @@ class SegmentExpr : public Expr {
     int64_t
     ProcessDataChunksForSingleChunk(
         FUNC func,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
         TargetBitmapView res,
         TargetBitmapView valid_res,
+        const TargetBitmap* candidate_mask,
         const ValTypes&... values) {
+        const auto expected_rows = GetNextBatchSize();
         int64_t processed_size = 0;
 
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
@@ -1758,9 +2259,10 @@ class SegmentExpr : public Expr {
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
             auto size = GetDataChunkRemainingRows(i, data_pos);
 
-            size = std::min(size, batch_size_ - processed_size);
-            if (size == 0)
-                continue;  //do not go empty-loop at the bound of the chunk
+            size = std::min(size, expected_rows - processed_size);
+            if (size == 0) {
+                continue;
+            }
 
             auto skip_index = segment_->GetSkipIndex();
             auto process_chunk = [&](const T* data, ValidityView valid_data) {
@@ -1799,10 +2301,12 @@ class SegmentExpr : public Expr {
                 // 1. Apply valid_data to handle nullable fields
                 // 2. Call func with nullptr to update internal cursors
                 //    (e.g., processed_cursor for bitmap_input indexing)
-                ApplyValidData(valid_data,
-                               res + processed_size,
-                               valid_res + processed_size,
-                               size);
+                ApplyValidMaskForCandidates(valid_data,
+                                            res + processed_size,
+                                            valid_res + processed_size,
+                                            size,
+                                            candidate_mask,
+                                            processed_size);
                 if constexpr (NeedSegmentOffsets) {
                     std::vector<int32_t> segment_offsets_array(size);
                     for (int64_t j = 0; j < size; ++j) {
@@ -1844,13 +2348,18 @@ class SegmentExpr : public Expr {
             }
 
             processed_size += size;
-            if (processed_size >= batch_size_) {
+            if (processed_size >= expected_rows) {
                 current_data_chunk_ = i;
                 current_data_chunk_pos_ = data_pos + size;
                 break;
             }
         }
 
+        AssertInfo(processed_size == expected_rows,
+                   "chunk data processed {} rows, expected {}",
+                   processed_size,
+                   expected_rows);
+        CommitLegacyDataProgress(processed_size);
         return processed_size;
     }
 
@@ -1859,165 +2368,139 @@ class SegmentExpr : public Expr {
               typename FUNC,
               typename... ValTypes>
     int64_t
-    ProcessDataChunksForChunkedSegment(
+    ProcessDataChunksByScan(
         FUNC func,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
         TargetBitmapView res,
         TargetBitmapView valid_res,
+        const TargetBitmap* candidate_mask,
         const ValTypes&... values) {
-        AssertInfo(segment_->type() == SegmentType::Sealed,
-                   "chunked segment data processing requires a sealed segment");
-        int64_t processed_size = 0;
+        if constexpr (!milvus::HasTargetType<T>) {
+            return -1;
+        } else {
+            return ProcessDataChunksByScanWithTarget<T, NeedSegmentOffsets>(
+                func, skip_func, res, valid_res, candidate_mask, values...);
+        }
+    }
 
-        // prefetch chunks to reduce cache miss latency
-        if (!prefetched_) {
-            std::vector<int64_t> pf_chunk_ids;
-            pf_chunk_ids.reserve(num_data_chunk_ - current_data_chunk_);
-            for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-                pf_chunk_ids.push_back(i);
-            }
-            segment_->prefetch_chunks(op_ctx_, field_id_, pf_chunk_ids);
-            prefetched_ = true;
+    template <typename T,
+              bool NeedSegmentOffsets = false,
+              typename FUNC,
+              typename... ValTypes>
+    int64_t
+    ProcessDataChunksByScanWithTarget(
+        FUNC func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const TargetBitmap* candidate_mask,
+        const ValTypes&... values) {
+        static_assert(milvus::HasTargetType<T>);
+        const auto real_batch_size = GetNextBatchSize();
+        const auto window_start = current_data_global_pos_;
+        const auto window_end = window_start + real_batch_size;
+        if (real_batch_size == 0) {
+            return 0;
+        }
+        auto* cursor = EnsureDataScanCursor<T>(skip_func);
+        if (cursor == nullptr) {
+            return -1;
         }
 
-        for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-            auto data_pos =
-                i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
-
-            auto size = GetDataChunkRemainingRows(i, data_pos);
-            size = std::min(size, batch_size_ - processed_size);
-
-            if (size == 0)
-                continue;  //do not go empty-loop at the bound of the chunk
-            // Only GIS functions consume the segment offsets. Building the
-            // array unconditionally costs an allocation plus size int32 stores
-            // per batch for every other expression, and the result is never
-            // read. Default-constructing the empty vector is free; it stays in
-            // scope because the three call sites below are in different
-            // branches. Cf. ProcessDataChunksForSingleChunk, which already
-            // builds it inside the guard.
-            std::vector<int32_t> segment_offsets_array;
+        const auto evaluate_batch = [&](const T* data,
+                                        ValidityView valid_data,
+                                        int64_t row,
+                                        int64_t size) {
+            const auto output_offset = row - window_start;
+            AssertInfo(
+                output_offset >= 0 && output_offset + size <= real_batch_size,
+                "scan output range [{}, {}) outside window [{}, {})",
+                row,
+                row + size,
+                window_start,
+                window_end);
             if constexpr (NeedSegmentOffsets) {
-                segment_offsets_array.resize(size);
-                auto start_offset = NumRowsUntilChunk(field_id_, i) + data_pos;
-                for (int64_t j = 0; j < size; ++j) {
-                    int64_t offset = start_offset + j;
-                    segment_offsets_array[j] = static_cast<int32_t>(offset);
+                std::vector<int32_t> segment_offsets_array(size);
+                for (int64_t i = 0; i < size; ++i) {
+                    segment_offsets_array[i] = static_cast<int32_t>(row + i);
                 }
-            }
-            auto skip_index = segment_->GetSkipIndex();
-            if (!skip_func || !skip_func(*skip_index, field_id_, i)) {
-                if constexpr (std::is_same_v<T, std::string_view> ||
-                              std::is_same_v<T, Json> ||
-                              std::is_same_v<T, ArrayView> ||
-                              std::is_same_v<T, ArrayValueView> ||
-                              std::is_same_v<T, VectorArrayView>) {
-                    // Chunked segments expose non-owning types through view
-                    // APIs; chunk_data<T> is only valid for owning types.
-                    auto pw = segment_->get_batch_views<T>(
-                        op_ctx_, field_id_, i, data_pos, size);
-                    const auto& [data_vec, valid_data] = pw.get();
-
-                    if constexpr (NeedSegmentOffsets) {
-                        func(data_vec.data(),
-                             valid_data,
-                             nullptr,
-                             segment_offsets_array.data(),
-                             size,
-                             res + processed_size,
-                             valid_res + processed_size,
-                             values...);
-                    } else {
-                        func(data_vec.data(),
-                             valid_data,
-                             nullptr,
-                             size,
-                             res + processed_size,
-                             valid_res + processed_size,
-                             values...);
-                    }
-                } else {
-                    auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, i);
-                    auto chunk = pw.get();
-                    const T* data = chunk.data() + data_pos;
-                    const auto validity = chunk.validity().Subview(data_pos);
-
-                    if constexpr (NeedSegmentOffsets) {
-                        // For GIS functions: construct segment offsets array
-                        func(data,
-                             validity,
-                             nullptr,
-                             segment_offsets_array.data(),
-                             size,
-                             res + processed_size,
-                             valid_res + processed_size,
-                             values...);
-                    } else {
-                        func(data,
-                             validity,
-                             nullptr,
-                             size,
-                             res + processed_size,
-                             valid_res + processed_size,
-                             values...);
-                    }
-                }
+                func(data,
+                     valid_data,
+                     nullptr,
+                     segment_offsets_array.data(),
+                     size,
+                     res + output_offset,
+                     valid_res + output_offset,
+                     values...);
             } else {
-                // Chunk is skipped by SkipIndex.
-                // We still need to:
-                // 1. Apply valid_data to handle nullable fields
-                // 2. Call func with nullptr to update internal cursors
-                //    (e.g., processed_cursor for bitmap_input indexing)
-                if constexpr (std::is_same_v<T, std::string_view> ||
-                              std::is_same_v<T, Json> ||
-                              std::is_same_v<T, ArrayView> ||
-                              std::is_same_v<T, ArrayValueView> ||
-                              std::is_same_v<T, VectorArrayView>) {
-                    auto pw = segment_->get_batch_views<T>(
-                        op_ctx_, field_id_, i, data_pos, size);
-                    ApplyValidData(pw.get().second,
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   size);
-                } else {
-                    auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, i);
-                    auto chunk = pw.get();
-                    ApplyValidData(chunk.validity().Subview(data_pos),
-                                   res + processed_size,
-                                   valid_res + processed_size,
-                                   size);
-                }
-                // Call func with nullptr to update internal cursors
-                if constexpr (NeedSegmentOffsets) {
-                    func(nullptr,
-                         ValidityView{},
-                         nullptr,
-                         segment_offsets_array.data(),
-                         size,
-                         res + processed_size,
-                         valid_res + processed_size,
-                         values...);
-                } else {
-                    func(nullptr,
-                         ValidityView{},
-                         nullptr,
-                         size,
-                         res + processed_size,
-                         valid_res + processed_size,
-                         values...);
-                }
+                func(data,
+                     valid_data,
+                     nullptr,
+                     size,
+                     res + output_offset,
+                     valid_res + output_offset,
+                     values...);
             }
+        };
 
-            processed_size += size;
+        const auto advance_without_data = [&](int64_t row, int64_t size) {
+            AssertInfo(size > 0,
+                       "invalid data-free scan batch at row {} with size {}",
+                       row,
+                       size);
+            evaluate_batch(nullptr, ValidityView{}, row, size);
+        };
 
-            if (processed_size >= batch_size_) {
-                current_data_chunk_ = i;
-                current_data_chunk_pos_ = data_pos + size;
-                break;
+        auto offset = window_start;
+        if (cursor->Position() != offset) {
+            cursor->Seek(offset);
+        }
+        while (offset < window_end) {
+            const auto requested_size = window_end - offset;
+            ChunkedColumnInterface::ScanBatch batch;
+            const auto returned = cursor->Next(
+                requested_size,
+                ChunkedColumnInterface::ScanReadMode::DataAndValidity,
+                &batch);
+            AssertInfo(returned && batch.row_id_start == offset &&
+                           batch.size > 0 && batch.size <= requested_size,
+                       "invalid data scan batch [{}, {}) for request [{}, {})",
+                       batch.row_id_start,
+                       batch.row_id_start + batch.size,
+                       offset,
+                       window_end);
+
+            if (batch.data_skipped) {
+                AssertInfo(batch.values.empty(),
+                           "skipped scan batch [{}, {}) contains data",
+                           batch.row_id_start,
+                           batch.row_id_start + batch.size);
+                const auto output_offset = batch.row_id_start - window_start;
+                ApplyScanValidity(batch,
+                                  0,
+                                  res + output_offset,
+                                  valid_res + output_offset,
+                                  batch.size,
+                                  candidate_mask,
+                                  output_offset);
+                advance_without_data(batch.row_id_start, batch.size);
+            } else {
+                AssertInfo(!batch.values.empty(),
+                           "data scan batch [{}, {}) has no values",
+                           batch.row_id_start,
+                           batch.row_id_start + batch.size);
+                evaluate_batch(batch.values.data_as<T>(),
+                               batch.validity,
+                               batch.row_id_start,
+                               batch.size);
             }
+            offset += batch.size;
         }
 
-        return processed_size;
+        AdvanceDataCursor(real_batch_size);
+        return real_batch_size;
     }
 
     template <typename T,
@@ -2027,17 +2510,62 @@ class SegmentExpr : public Expr {
     int64_t
     ProcessDataChunks(
         FUNC func,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
-        if (segment_->is_chunked()) {
-            return ProcessDataChunksForChunkedSegment<T, NeedSegmentOffsets>(
-                func, skip_func, res, valid_res, values...);
-        } else {
-            return ProcessDataChunksForSingleChunk<T, NeedSegmentOffsets>(
-                func, skip_func, res, valid_res, values...);
+        return ProcessDataChunksImpl<T, NeedSegmentOffsets>(
+            func, skip_func, res, valid_res, nullptr, values...);
+    }
+
+    template <typename T,
+              bool NeedSegmentOffsets = false,
+              typename FUNC,
+              typename... ValTypes>
+    int64_t
+    ProcessDataChunksWithMask(
+        FUNC func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const TargetBitmap& candidate_mask,
+        const ValTypes&... values) {
+        AssertInfo(candidate_mask.empty() ||
+                       candidate_mask.size() ==
+                           static_cast<size_t>(GetNextBatchSize()),
+                   "candidate mask size {} does not match scan batch {}",
+                   candidate_mask.size(),
+                   GetNextBatchSize());
+        return ProcessDataChunksImpl<T, NeedSegmentOffsets>(
+            func, skip_func, res, valid_res, &candidate_mask, values...);
+    }
+
+    template <typename T,
+              bool NeedSegmentOffsets = false,
+              typename FUNC,
+              typename... ValTypes>
+    int64_t
+    ProcessDataChunksImpl(
+        FUNC func,
+        const std::function<bool(const milvus::SkipIndex&, FieldId, int)>&
+            skip_func,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const TargetBitmap* candidate_mask,
+        const ValTypes&... values) {
+        const auto processed_size =
+            ProcessDataChunksByScan<T, NeedSegmentOffsets>(
+                func, skip_func, res, valid_res, candidate_mask, values...);
+        if (processed_size >= 0) {
+            return processed_size;
         }
+        AssertInfo(!segment_->is_chunked(),
+                   "sealed field {} does not provide a data scan cursor",
+                   field_id_.get());
+        return ProcessDataChunksForSingleChunk<T, NeedSegmentOffsets>(
+            func, skip_func, res, valid_res, candidate_mask, values...);
     }
 
     // Specialized method for ngram post-filter: processes data in a specific range
@@ -2527,10 +3055,10 @@ class SegmentExpr : public Expr {
         return valid_result;
     }
 
-    template <typename T>
     TargetBitmap
-    ProcessDataChunksForValid() {
-        TargetBitmap valid_result(GetNextBatchSize());
+    ProcessGrowingDataChunksForValid() {
+        const auto expected_rows = GetNextBatchSize();
+        TargetBitmap valid_result(expected_rows);
         valid_result.set();
         int64_t processed_size = 0;
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
@@ -2538,9 +3066,10 @@ class SegmentExpr : public Expr {
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
             auto size = GetDataChunkRemainingRows(i, data_pos);
 
-            size = std::min(size, batch_size_ - processed_size);
-            if (size == 0)
-                continue;  //do not go empty-loop at the bound of the chunk
+            size = std::min(size, expected_rows - processed_size);
+            if (size == 0) {
+                continue;
+            }
             segment_->ApplyFieldValidData(op_ctx_,
                                           field_id_,
                                           i,
@@ -2549,12 +3078,71 @@ class SegmentExpr : public Expr {
                                           valid_result + processed_size);
 
             processed_size += size;
-            if (processed_size >= batch_size_) {
+            if (processed_size >= expected_rows) {
                 current_data_chunk_ = i;
                 current_data_chunk_pos_ = data_pos + size;
                 break;
             }
         }
+        AssertInfo(processed_size == expected_rows,
+                   "growing validity processed {} rows, expected {}",
+                   processed_size,
+                   expected_rows);
+        CommitLegacyDataProgress(processed_size);
+        return valid_result;
+    }
+
+    template <typename T>
+    TargetBitmap
+    ProcessDataChunksForValid() {
+        const auto batch_size = GetNextBatchSize();
+        TargetBitmap valid_result(batch_size);
+        valid_result.set();
+        const auto window_start = current_data_global_pos_;
+        auto* cursor = EnsureValidityScanCursor();
+        if (cursor == nullptr) {
+            AssertInfo(!segment_->is_chunked(),
+                       "sealed field {} does not provide a validity scan "
+                       "cursor",
+                       field_id_.get());
+            return ProcessGrowingDataChunksForValid();
+        }
+        if (!data_scan_column_->IsNullable()) {
+            AdvanceDataCursor(batch_size);
+            return valid_result;
+        }
+        int64_t processed_size = 0;
+        while (processed_size < batch_size) {
+            const auto expected_row = window_start + processed_size;
+            const auto remaining = batch_size - processed_size;
+            ChunkedColumnInterface::ScanBatch batch;
+            if (cursor->Position() != expected_row) {
+                cursor->Seek(expected_row);
+            }
+            const auto returned =
+                cursor->Next(remaining,
+                             ChunkedColumnInterface::ScanReadMode::ValidityOnly,
+                             &batch);
+            AssertInfo(returned && batch.row_id_start == expected_row &&
+                           batch.size > 0 && batch.size <= remaining &&
+                           batch.values.empty(),
+                       "invalid validity scan batch [{}, {}) at expected {}",
+                       batch.row_id_start,
+                       batch.row_id_start + batch.size,
+                       expected_row);
+            const auto size = batch.size;
+            ApplyScanValidity(batch,
+                              0,
+                              valid_result + processed_size,
+                              valid_result + processed_size,
+                              size);
+            processed_size += size;
+        }
+        AssertInfo(processed_size == batch_size,
+                   "validity scan processed {} rows, expected {}",
+                   processed_size,
+                   batch_size);
+        AdvanceDataCursor(processed_size);
         return valid_result;
     }
 
@@ -3168,14 +3756,32 @@ class SegmentExpr : public Expr {
     int64_t active_count_{0};
     int64_t num_data_chunk_{0};
     int64_t num_index_chunk_{0};
-    // State indicate position that expr computing at
-    // because expr maybe called for every batch.
+    // Transitional data position state. Scan and expression windows use the
+    // canonical segment-global offset. Growing and other legacy Chunk readers
+    // additionally maintain a chunk id plus chunk-local offset; a selected
+    // Scan path does not keep those unused coordinates synchronized. Once
+    // external Chunk access is removed, only current_data_global_pos_ remains.
     int64_t current_data_chunk_{0};
     int64_t current_data_chunk_pos_{0};
     int64_t current_data_global_pos_{0};
     int64_t current_index_chunk_{0};
     int64_t current_index_chunk_pos_{0};
     int64_t size_per_chunk_{0};
+    DataAccessMode data_access_mode_{DataAccessMode::Uninitialized};
+    // Keep the captured column generation and one forward-only cursor for the
+    // expression's full lifetime. ScanOptions fixes whether each batch or the
+    // cursor owns the physical Cell pin; callers never pin Cells separately.
+    std::shared_ptr<ChunkedColumnInterface> data_scan_column_{nullptr};
+    std::unique_ptr<ChunkedColumnInterface::ScanCursor> data_scan_cursor_;
+    detail::ColumnFilterPtr data_scan_filter_{nullptr};
+    ChunkedColumnInterface::TargetType data_scan_target_type_{
+        ChunkedColumnInterface::TargetType::None};
+    // Offset input is evaluated in multiple batches by the same expression.
+    // Capture one immutable Column generation and bind its filter once, just
+    // like the persistent sequential Scan cursor does.
+    bool data_take_resources_initialized_{false};
+    std::shared_ptr<ChunkedColumnInterface> data_take_column_{nullptr};
+    detail::ColumnFilterPtr data_take_filter_{nullptr};
 
     // Unified cache for all index paths (ScalarIndex, PkIndex, TextIndex, JsonStats).
     // Populated once per segment, then sliced per batch via SliceCachedResult().

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -1152,6 +1152,30 @@ TEST_P(JsonIndexExistsTest, TestExistsExpr) {
             ExecuteQueryExpr(plan, seg.get(), json_strs.size(), MAX_TIMESTAMP);
 
         EXPECT_TRUE(result == expect_res);
+
+        // Offset execution uses Raw Take even when the dense path can use the
+        // JSON index. NULL rows must retain the evaluator's EXISTS/NOT EXISTS
+        // semantics instead of inheriting field validity from the Take
+        // adapter. Keep the offsets unordered and duplicated to exercise the
+        // positional Take contract as well.
+        auto full_result = milvus::test::gen_filter_res(
+            plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+        exec::OffsetVector offsets = {8, 0, 15, 7, 8};
+        auto offset_result = milvus::test::gen_filter_res(
+            plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP, &offsets);
+        TargetBitmapView full_values(full_result->GetRawData(),
+                                     full_result->size());
+        TargetBitmapView full_validity(full_result->GetValidRawData(),
+                                       full_result->size());
+        TargetBitmapView offset_values(offset_result->GetRawData(),
+                                       offset_result->size());
+        TargetBitmapView offset_validity(offset_result->GetValidRawData(),
+                                         offset_result->size());
+        for (size_t i = 0; i < offsets.size(); ++i) {
+            const auto row = offsets[i];
+            EXPECT_EQ(offset_values[i], full_values[row]) << "row " << row;
+            EXPECT_EQ(offset_validity[i], full_validity[row]) << "row " << row;
+        }
     }
 }
 

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -802,6 +802,13 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                "expect batch size {}",
                batch_valid.size(),
                real_batch_size);
+    if (segment_->type() != SegmentType::Sealed) {
+        CommitLegacyDataProgress(processed_rows);
+        AssertInfo(current_data_global_pos_ == current_index_chunk_pos_,
+                   "growing GIS data cursor at {}, index cursor at {}",
+                   current_data_global_pos_,
+                   current_index_chunk_pos_);
+    }
     return std::make_shared<ColumnVector>(std::move(batch_result),
                                           std::move(batch_valid));
 }

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -570,6 +570,7 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
         processed_rows += size;
         current_index_chunk_pos_ += size;
     } else {
+        EnsureDataChunkCursorAt(current_data_global_pos_);
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
@@ -609,6 +610,13 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                "expect batch size {}",
                batch_valid.size(),
                real_batch_size);
+    if (segment_->type() != SegmentType::Sealed) {
+        CommitDataChunkProgress(processed_rows);
+        AssertInfo(current_data_global_pos_ == current_index_chunk_pos_,
+                   "growing GIS data cursor at {}, index cursor at {}",
+                   current_data_global_pos_,
+                   current_index_chunk_pos_);
+    }
     return std::make_shared<ColumnVector>(std::move(batch_result),
                                           std::move(batch_valid));
 }

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -182,22 +182,16 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
     // still advance this expression's cursors, otherwise it desynchronizes
     // from its sibling expressions and later batches evaluate the wrong rows.
     // The base MoveCursor() covers every case except the growing interim-index
-    // path: MoveCursorForIndex() asserts sealed-only, while
-    // EvalForIndexSegment() on a growing segment advances the global index
-    // position together with the data cursor -- mirror that here.
-    // Unlike the base implementation, MoveCursorForData() is called without a
-    // HasFieldData() guard: this exec path already walks data chunks
-    // unconditionally (EvalForIndexSegment), and with no field data
-    // num_data_chunk_ is 0, making the call a no-op -- the omission is
-    // intentional, not an oversight.
+    // path. EvalForIndexSegment() advances both the global index position and
+    // the legacy data chunk cursor, so a skipped batch must mirror both
+    // updates here.
     void
     MoveCursor() override {
         if (has_offset_input_ || execute_all_at_once_) {
             return;
         }
         if (UseIndexCursor() && segment_->type() != SegmentType::Sealed) {
-            current_index_chunk_pos_ +=
-                std::min(active_count_ - current_index_chunk_pos_, batch_size_);
+            MoveCursorForIndex();
             MoveCursorForData();
             return;
         }

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -139,22 +139,17 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
     // still advance this expression's cursors, otherwise it desynchronizes
     // from its sibling expressions and later batches evaluate the wrong rows.
     // The base MoveCursor() covers every case except the growing interim-index
-    // path: MoveCursorForIndex() asserts sealed-only, while
-    // EvalForIndexSegment() on a growing segment advances the global index
-    // position together with the data cursor -- mirror that here.
-    // Unlike the base implementation, MoveCursorForData() is called without a
-    // HasFieldData() guard: this exec path already walks data chunks
-    // unconditionally (EvalForIndexSegment), and with no field data
-    // num_data_chunk_ is 0, making the call a no-op -- the omission is
-    // intentional, not an oversight.
+    // path. EvalForIndexSegment() advances both the global index position and
+    // the authoritative data position, so a skipped batch must mirror both
+    // updates here. The following real read derives its chunk coordinates from
+    // that data position.
     void
     MoveCursor() override {
         if (has_offset_input_ || execute_all_at_once_) {
             return;
         }
         if (UseIndexCursor() && segment_->type() != SegmentType::Sealed) {
-            current_index_chunk_pos_ +=
-                std::min(active_count_ - current_index_chunk_pos_, batch_size_);
+            MoveCursorForIndex();
             MoveCursorForData();
             return;
         }

--- a/internal/core/src/exec/expression/MembershipFilterExpr.cpp
+++ b/internal/core/src/exec/expression/MembershipFilterExpr.cpp
@@ -154,8 +154,10 @@ PhyMembershipFilterExpr<LogicalExpr, ProbePolicy>::ExecVisitorImpl(
             const int size,
             TargetBitmapView res,
             TargetBitmapView valid_res) {
-        // data == nullptr means the chunk was skipped upstream; only the
-        // bitmap_input cursor needs to advance.
+        // A null data pointer means evaluation was suppressed because the
+        // payload was skipped, the candidate was inactive, or an index
+        // reverse-lookup miss already applied its invalid result. Ordinary
+        // nullable Scan/Take rows carry a placeholder plus real validity.
         if (data == nullptr) {
             processed_cursor += size;
             return;
@@ -189,8 +191,12 @@ PhyMembershipFilterExpr<LogicalExpr, ProbePolicy>::ExecVisitorImpl(
 
     int64_t processed_size;
     if (has_offset_input_) {
-        processed_size = ProcessDataByOffsets<T>(
-            execute_sub_batch, std::nullptr_t{}, input, res, valid_res);
+        processed_size = ProcessDataByOffsetsWithMask<T>(execute_sub_batch,
+                                                         std::nullptr_t{},
+                                                         input,
+                                                         res,
+                                                         valid_res,
+                                                         bitmap_input);
     } else {
         processed_size = ProcessDataChunks<T>(
             execute_sub_batch, std::nullptr_t{}, res, valid_res);
@@ -247,8 +253,8 @@ PhyMembershipFilterExpr<LogicalExpr, ProbePolicy>::ExecVisitorImplForIndex(
         TargetBitmapView valid_res) {
         // data == nullptr means the helper either pruned an inactive candidate
         // before reverse lookup (leaving false/valid untouched), or found an
-        // active NULL row (after writing false/invalid). In both cases the
-        // reader already owns the result.
+        // active missing value (after writing false/invalid). In both cases
+        // the reader already owns the result.
         if (data == nullptr) {
             return;
         }
@@ -346,8 +352,9 @@ PhyMembershipFilterExpr<LogicalExpr, ProbePolicy>::ExecVisitorImplJson(
             TargetBitmapView res,
             TargetBitmapView valid_res,
             const std::string& pointer) {
-        // data == nullptr means the chunk was skipped upstream; only the
-        // bitmap_input cursor needs to advance.
+        // A null data pointer means evaluation was suppressed because the
+        // payload was skipped or the candidate was inactive. Ordinary
+        // nullable Scan/Take rows carry a placeholder plus real validity.
         if (data == nullptr) {
             processed_cursor += size;
             return;
@@ -406,12 +413,14 @@ PhyMembershipFilterExpr<LogicalExpr, ProbePolicy>::ExecVisitorImplJson(
 
     int64_t processed_size;
     if (has_offset_input_) {
-        processed_size = ProcessDataByOffsets<milvus::Json>(execute_sub_batch,
-                                                            std::nullptr_t{},
-                                                            input,
-                                                            res,
-                                                            valid_res,
-                                                            pointer);
+        processed_size =
+            ProcessDataByOffsetsWithMask<milvus::Json>(execute_sub_batch,
+                                                       std::nullptr_t{},
+                                                       input,
+                                                       res,
+                                                       valid_res,
+                                                       bitmap_input,
+                                                       pointer);
     } else {
         processed_size = ProcessDataChunks<milvus::Json>(
             execute_sub_batch, std::nullptr_t{}, res, valid_res, pointer);

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -303,14 +303,18 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
         }
         const int64_t compare_us = compare_value;
         for (int i = 0; i < size; ++i) {
-            if (valid_data && !valid_data[i]) {
+            int32_t offset = i;
+            if constexpr (filter_type == FilterType::random) {
+                offset = offsets == nullptr ? i : offsets[i];
+            }
+            if (valid_data && !valid_data[offset]) {
                 // NULL never matches, under either polarity (three-valued
                 // logic); do not evaluate the storage placeholder value.
                 res[i] = valid_res[i] = false;
                 continue;
             }
             res[i] = EvaluateTimestamp(
-                data[i], arith_op, interval, compare_op, compare_us);
+                data[offset], arith_op, interval, compare_op, compare_us);
         }
     };
     int64_t processed_size;

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -303,14 +303,18 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
         }
         const int64_t compare_us = compare_value;
         for (int i = 0; i < size; ++i) {
-            if (valid_data != nullptr && !valid_data[i]) {
+            int32_t offset = i;
+            if constexpr (filter_type == FilterType::random) {
+                offset = offsets == nullptr ? i : offsets[i];
+            }
+            if (valid_data != nullptr && !valid_data[offset]) {
                 // NULL never matches, under either polarity (three-valued
                 // logic); do not evaluate the storage placeholder value.
                 res[i] = valid_res[i] = false;
                 continue;
             }
             res[i] = EvaluateTimestamp(
-                data[i], arith_op, interval, compare_op, compare_us);
+                data[offset], arith_op, interval, compare_op, compare_us);
         }
     };
     int64_t processed_size;

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -2012,8 +2012,13 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
             processed_size = ProcessElementLevelByOffsets<T>(
                 execute_sub_batch, skip_index_func, input, res, valid_res, val);
         } else {
-            processed_size = ProcessDataByOffsets<T>(
-                execute_sub_batch, skip_index_func, input, res, valid_res, val);
+            processed_size = ProcessDataByOffsetsWithMask<T>(execute_sub_batch,
+                                                             skip_index_func,
+                                                             input,
+                                                             res,
+                                                             valid_res,
+                                                             bitmap_input,
+                                                             val);
         }
     } else {
         if (expr_->column_.element_level_) {
@@ -2021,8 +2026,12 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
             processed_size = ProcessDataChunksForElementLevel<T>(
                 execute_sub_batch, skip_index_func, res, valid_res, val);
         } else {
-            processed_size = ProcessDataChunks<T>(
-                execute_sub_batch, skip_index_func, res, valid_res, val);
+            processed_size = ProcessDataChunksWithMask<T>(execute_sub_batch,
+                                                          skip_index_func,
+                                                          res,
+                                                          valid_res,
+                                                          bitmap_input,
+                                                          val);
         }
     }
     AssertInfo(processed_size == real_batch_size,

--- a/internal/core/src/index/SkipIndex.h
+++ b/internal/core/src/index/SkipIndex.h
@@ -185,11 +185,26 @@ class SkipIndex {
                            T>;
 
  public:
+    // Exactly one metrics source is registered for a field. LoadedPayload is
+    // a legacy Raw fallback, not an extra statistics layer on top of
+    // PreloadedStatistics.
+    enum class MetricsSource {
+        None,
+        // Built from file/footer statistics available at segment load, so the
+        // planner may consult it before pinning data Cells.
+        PreloadedStatistics,
+        // Used when legacy Raw data has no independently available
+        // statistics. Metrics are derived lazily from an already loaded Chunk
+        // and therefore can only skip post-pin predicate evaluation.
+        LoadedPayload,
+    };
+
     std::shared_ptr<SkipIndex>
     Clone() const {
         auto cloned = std::make_shared<SkipIndex>();
         std::shared_lock lck(mutex_);
         cloned->fieldChunkMetrics_ = fieldChunkMetrics_;
+        cloned->metricsSources_ = metricsSources_;
         return cloned;
     }
 
@@ -197,6 +212,14 @@ class SkipIndex {
     Erase(FieldId field_id) {
         std::unique_lock lck(mutex_);
         fieldChunkMetrics_.erase(field_id);
+        metricsSources_.erase(field_id);
+    }
+
+    MetricsSource
+    GetMetricsSource(FieldId field_id) const {
+        std::shared_lock lck(mutex_);
+        auto it = metricsSources_.find(field_id);
+        return it == metricsSources_.end() ? MetricsSource::None : it->second;
     }
 
     template <typename T>
@@ -469,6 +492,7 @@ class SkipIndex {
 
         std::unique_lock lck(mutex_);
         fieldChunkMetrics_[field_id] = std::move(cache_slot);
+        metricsSources_[field_id] = MetricsSource::LoadedPayload;
     }
 
     void
@@ -486,6 +510,7 @@ class SkipIndex {
 
         std::unique_lock lck(mutex_);
         fieldChunkMetrics_[field_id] = std::move(cache_slot);
+        metricsSources_[field_id] = MetricsSource::PreloadedStatistics;
     }
 
  private:
@@ -520,6 +545,7 @@ class SkipIndex {
         FieldId,
         std::shared_ptr<cachinglayer::CacheSlot<index::FieldChunkMetrics>>>
         fieldChunkMetrics_;
+    std::unordered_map<FieldId, MetricsSource> metricsSources_;
     mutable std::shared_mutex mutex_;
 };
 }  // namespace milvus

--- a/internal/core/src/index/SkipIndex.h
+++ b/internal/core/src/index/SkipIndex.h
@@ -185,11 +185,18 @@ class SkipIndex {
                            T>;
 
  public:
+    enum class MetricsSource {
+        None,
+        PreloadedStatistics,
+        LoadedPayload,
+    };
+
     std::shared_ptr<SkipIndex>
     Clone() const {
         auto cloned = std::make_shared<SkipIndex>();
         std::shared_lock lck(mutex_);
         cloned->fieldChunkMetrics_ = fieldChunkMetrics_;
+        cloned->metricsSources_ = metricsSources_;
         return cloned;
     }
 
@@ -197,6 +204,14 @@ class SkipIndex {
     Erase(FieldId field_id) {
         std::unique_lock lck(mutex_);
         fieldChunkMetrics_.erase(field_id);
+        metricsSources_.erase(field_id);
+    }
+
+    MetricsSource
+    GetMetricsSource(FieldId field_id) const {
+        std::shared_lock lck(mutex_);
+        auto it = metricsSources_.find(field_id);
+        return it == metricsSources_.end() ? MetricsSource::None : it->second;
     }
 
     template <typename T>
@@ -469,6 +484,7 @@ class SkipIndex {
 
         std::unique_lock lck(mutex_);
         fieldChunkMetrics_[field_id] = std::move(cache_slot);
+        metricsSources_[field_id] = MetricsSource::LoadedPayload;
     }
 
     void
@@ -486,6 +502,7 @@ class SkipIndex {
 
         std::unique_lock lck(mutex_);
         fieldChunkMetrics_[field_id] = std::move(cache_slot);
+        metricsSources_[field_id] = MetricsSource::PreloadedStatistics;
     }
 
  private:
@@ -520,6 +537,7 @@ class SkipIndex {
         FieldId,
         std::shared_ptr<cachinglayer::CacheSlot<index::FieldChunkMetrics>>>
         fieldChunkMetrics_;
+    std::unordered_map<FieldId, MetricsSource> metricsSources_;
     mutable std::shared_mutex mutex_;
 };
 }  // namespace milvus

--- a/internal/core/src/mmap/CMakeLists.txt
+++ b/internal/core/src/mmap/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (C) 2019-2020 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under the License
+
+
+add_source_at_current_directory_recursively()
+add_library(milvus_mmap OBJECT ${SOURCE_FILES})
+target_link_libraries(milvus_mmap PUBLIC milvus_conan_deps)

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -389,6 +389,16 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
         return PinWrapper<Chunk*>(std::move(ca), chunk);
     }
 
+    TakeCellPin
+    MakeTakeCellPin(milvus::OpContext* op_ctx) const override {
+        auto slot = slot_;
+        return [slot = std::move(slot), op_ctx](int64_t chunk_id) {
+            auto ca = SemiInlineGet(slot->PinCells(op_ctx, {chunk_id}));
+            auto* chunk = ca->get_cell_of(chunk_id);
+            return PinWrapper<Chunk*>(std::move(ca), chunk);
+        };
+    }
+
     std::vector<PinWrapper<Chunk*>>
     GetAllChunks(milvus::OpContext* op_ctx) const override {
         auto ca = SemiInlineGet(slot_->PinAllCells(op_ctx));
@@ -414,6 +424,11 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
     }
 
  protected:
+    std::optional<DataType>
+    GetDefaultScanDataType() const override {
+        return data_type_;
+    }
+
     bool nullable_{false};
     DataType data_type_{DataType::NONE};
     size_t num_rows_{0};

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -393,6 +393,11 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
     }
 
  protected:
+    std::optional<DataType>
+    GetDefaultScanDataType() const override {
+        return data_type_;
+    }
+
     bool nullable_{false};
     DataType data_type_{DataType::NONE};
     size_t num_rows_{0};

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -369,6 +369,21 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
     }
 
     std::vector<PinWrapper<Chunk*>>
+    PinChunks(milvus::OpContext* op_ctx,
+              const std::vector<int64_t>& chunk_ids) const override {
+        if (chunk_ids.empty()) {
+            return {};
+        }
+        auto ca = SemiInlineGet(slot_->PinCells(op_ctx, chunk_ids));
+        std::vector<PinWrapper<Chunk*>> chunks;
+        chunks.reserve(chunk_ids.size());
+        for (auto chunk_id : chunk_ids) {
+            chunks.emplace_back(ca, ca->get_cell_of(chunk_id));
+        }
+        return chunks;
+    }
+
+    std::vector<PinWrapper<Chunk*>>
     GetAllChunks(milvus::OpContext* op_ctx) const override {
         auto ca = SemiInlineGet(slot_->PinAllCells(op_ctx));
         std::vector<PinWrapper<Chunk*>> ret;

--- a/internal/core/src/mmap/ChunkedColumnFilter.h
+++ b/internal/core/src/mmap/ChunkedColumnFilter.h
@@ -1,0 +1,60 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+namespace milvus::detail {
+
+// Transitional binding between expression-specific SkipIndex predicates and
+// Column-internal physical planning. Column callers only pass this opaque
+// object through Scan/Take options; Cell ids never leave the backend read
+// implementation. A future expression-valued filter can replace the bound
+// callback without changing Scan/Take result contracts.
+class ColumnFilter final {
+ public:
+    enum class MetricsSource {
+        PreloadedStatistics,
+        LoadedPayload,
+    };
+
+    using PhysicalCellPredicate = std::function<bool(int64_t)>;
+
+    ColumnFilter(MetricsSource source, PhysicalCellPredicate predicate)
+        : source_(source), predicate_(std::move(predicate)) {
+    }
+
+    MetricsSource
+    Source() const {
+        return source_;
+    }
+
+    bool
+    CanSkipPhysicalCell(int64_t cell_id) const {
+        return predicate_ && predicate_(cell_id);
+    }
+
+ private:
+    MetricsSource source_;
+    PhysicalCellPredicate predicate_;
+};
+
+using ColumnFilterPtr = std::shared_ptr<const ColumnFilter>;
+
+}  // namespace milvus::detail

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -535,6 +535,21 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         return PinWrapper<Chunk*>(std::move(group_chunk), chunk.get());
     }
 
+    TakeCellPin
+    MakeTakeCellPin(milvus::OpContext* op_ctx) const override {
+        auto group = group_;
+        const auto field_id = field_id_;
+        return [group = std::move(group), field_id, op_ctx](int64_t chunk_id) {
+            auto group_chunk = group->GetGroupChunk(op_ctx, chunk_id);
+            auto* chunk = group_chunk.get()->GetChunkRaw(field_id);
+            AssertInfo(chunk != nullptr,
+                       "field {} is missing from group chunk {}",
+                       field_id.get(),
+                       chunk_id);
+            return PinWrapper<Chunk*>(std::move(group_chunk), chunk);
+        };
+    }
+
     std::vector<PinWrapper<Chunk*>>
     GetAllChunks(milvus::OpContext* op_ctx) const override {
         std::vector<PinWrapper<Chunk*>> ret;
@@ -861,6 +876,11 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
     }
 
  private:
+    std::optional<DataType>
+    GetDefaultScanDataType() const override {
+        return data_type_;
+    }
+
     // Resolve, for each requested offset, the chunk that owns it and invoke
     // fn(chunk, offset_in_chunk, i), preserving the original row order.
     //

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -769,6 +769,11 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
     }
 
  private:
+    std::optional<DataType>
+    GetDefaultScanDataType() const override {
+        return data_type_;
+    }
+
     // Resolve, for each requested offset, the chunk that owns it and invoke
     // fn(chunk, offset_in_chunk, i), preserving the original row order.
     //

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -479,6 +479,27 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
     }
 
     std::vector<PinWrapper<Chunk*>>
+    PinChunks(milvus::OpContext* op_ctx,
+              const std::vector<int64_t>& chunk_ids) const override {
+        if (chunk_ids.empty()) {
+            return {};
+        }
+        auto group_chunks = group_->GetGroupChunks(op_ctx, chunk_ids);
+        std::vector<PinWrapper<Chunk*>> chunks;
+        chunks.reserve(chunk_ids.size());
+        for (auto chunk_id : chunk_ids) {
+            auto group_chunk = group_chunks->get_cell_of(chunk_id);
+            auto chunk = group_chunk->GetChunkRaw(field_id_);
+            AssertInfo(chunk != nullptr,
+                       "field {} is missing from group chunk {}",
+                       field_id_.get(),
+                       chunk_id);
+            chunks.emplace_back(group_chunks, chunk);
+        }
+        return chunks;
+    }
+
+    std::vector<PinWrapper<Chunk*>>
     GetAllChunks(milvus::OpContext* op_ctx) const override {
         std::vector<PinWrapper<Chunk*>> ret;
         auto group_chunks = group_->GetAllGroupChunks(op_ctx);

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -15,19 +15,37 @@
 // limitations under the License.
 #pragma once
 
+#include <algorithm>
 #include <atomic>
+#include <functional>
+#include <memory>
 #include <mutex>
+#include <optional>
+#include <vector>
 
 #include "cachinglayer/CacheSlot.h"
 #include "common/Chunk.h"
+#include "common/EasyAssert.h"
 #include "common/OffsetMapping.h"
 #include "common/bson_view.h"
+#include "mmap/ChunkedColumnScanCommon.h"
 namespace milvus {
 
 using namespace milvus::cachinglayer;
 
 class ChunkedColumnInterface {
  public:
+    using ScanValueKind = milvus::ScanValueKind;
+    using ValueEncoding = milvus::ValueEncoding;
+    using ValidityEncoding = milvus::ValidityEncoding;
+    using ValueView = milvus::ValueView;
+    using ValidityView = milvus::ValidityView;
+    using ScanBatch = milvus::ScanBatch;
+    using ScanCursor = milvus::ScanCursor;
+    using ScanProjection = milvus::ScanProjection;
+    using ScanOptions = milvus::ScanOptions;
+    using ScanResult = milvus::ScanResult;
+
     virtual ~ChunkedColumnInterface() = default;
 
     // Check if this column is part of a multi-field column group.
@@ -178,6 +196,9 @@ class ChunkedColumnInterface {
             }
         }
     }
+
+    virtual ScanResult
+    Scan(milvus::OpContext* op_ctx, const ScanOptions& options) const;
 
     // Get number of rows before a specific chunk
     virtual int64_t
@@ -372,6 +393,11 @@ class ChunkedColumnInterface {
     }
 
  protected:
+    virtual std::optional<DataType>
+    GetDefaultScanDataType() const {
+        return std::nullopt;
+    }
+
     FixedVector<bool> valid_data_;
     std::vector<int64_t> valid_count_per_chunk_;
     std::vector<int64_t> num_valid_rows_until_chunk_;

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -16,21 +16,43 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
+#include <memory>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 #include "cachinglayer/CacheSlot.h"
 #include "common/ArrayValue.h"
 #include "common/Chunk.h"
+#include "common/EasyAssert.h"
 #include "common/OffsetMapping.h"
 #include "common/SealedOffsetMapping.h"
 #include "common/bson_view.h"
+#include "mmap/ChunkedColumnScanCommon.h"
 namespace milvus {
 
 using namespace milvus::cachinglayer;
 
 class ChunkedColumnInterface {
  public:
+    using TargetType = milvus::TargetType;
+    using ValueView = milvus::ValueView;
+    using ScanBatch = milvus::ScanBatch;
+    using ScanReadMode = milvus::ScanReadMode;
+    using ScanCursor = milvus::ScanCursor;
+    using ScanPinPolicy = milvus::ScanPinPolicy;
+    using ScanOptions = milvus::ScanOptions;
+    using ScanResult = milvus::ScanResult;
+    using OffsetView = milvus::OffsetView;
+    using OwnedTakeData = milvus::OwnedTakeData;
+    template <typename T>
+    using TakeItem = milvus::TakeItem<T>;
+    using TakeItemState = milvus::TakeItemState;
+    using TakeOptions = milvus::TakeOptions;
+    using TakeResult = milvus::TakeResult;
+    using TakeResultPtr = milvus::TakeResultPtr;
+
     virtual ~ChunkedColumnInterface() = default;
 
     // Check if this column is part of a multi-field column group.
@@ -181,6 +203,15 @@ class ChunkedColumnInterface {
                    chunk->RowNums());
         chunk->ApplyValidityMask(offset, size, valid_result);
     }
+
+    virtual ScanResult
+    Scan(milvus::OpContext* op_ctx, const ScanOptions& options) const;
+
+    // Convenience positional access. Backends consume segment offsets without
+    // exposing physical Cell/file locations. Results preserve input order and
+    // duplicates.
+    virtual TakeResultPtr
+    Take(milvus::OpContext* op_ctx, TakeOptions options) const;
 
     // Get number of rows before a specific chunk
     virtual int64_t
@@ -390,6 +421,37 @@ class ChunkedColumnInterface {
     }
 
  protected:
+    using TakeCellPin = std::function<PinWrapper<Chunk*>(int64_t)>;
+
+    // Return a generation-stable accessor used by the default Raw Take
+    // implementation to pin one Cell at a time after Take() returns. The
+    // accessor must own the cache resources it needs; it must not capture a
+    // bare column pointer. The caller keeps op_ctx alive until borrowed access
+    // and any GetOwn() materialization are complete.
+    virtual TakeCellPin
+    MakeTakeCellPin(milvus::OpContext* op_ctx) const {
+        return {};
+    }
+
+    // Return the immutable physical planner owned by this Column generation.
+    // Scan/Take implementations may use it, but callers must not observe Cell
+    // geometry through the Column API.
+    const ColumnPlanner&
+    Planner() const;
+
+    // Keep immutable generation geometry alive for lazy backend work that may
+    // outlive the concrete Column object (for example a Raw TakeResult).
+    std::shared_ptr<const ColumnPlanner>
+    PlannerHandle() const;
+
+    virtual std::unique_ptr<ColumnPlanner>
+    BuildPlanner() const;
+
+    virtual std::optional<DataType>
+    GetDefaultScanDataType() const {
+        return std::nullopt;
+    }
+
     FixedVector<bool> valid_data_;
     std::vector<int64_t> valid_count_per_chunk_;
     std::vector<int64_t> num_valid_rows_until_chunk_;
@@ -457,6 +519,10 @@ class ChunkedColumnInterface {
         }
         return std::make_pair(std::move(cids), std::move(offsets_in_chunk));
     }
+
+ private:
+    mutable std::once_flag planner_once_;
+    mutable std::shared_ptr<ColumnPlanner> planner_;
 };
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -40,9 +40,11 @@ class ChunkedColumnInterface {
     using ValueView = milvus::ValueView;
     using ScanBatch = milvus::ScanBatch;
     using ScanCursor = milvus::ScanCursor;
+    using PreparedScan = milvus::PreparedScan;
     using ScanProjection = milvus::ScanProjection;
     using ScanOptions = milvus::ScanOptions;
     using ScanResult = milvus::ScanResult;
+    using PreparedScanResult = milvus::PreparedScanResult;
 
     virtual ~ChunkedColumnInterface() = default;
 
@@ -211,6 +213,9 @@ class ChunkedColumnInterface {
 
     virtual ScanResult
     Scan(milvus::OpContext* op_ctx, const ScanOptions& options) const;
+
+    virtual PreparedScanResult
+    PrepareScan(milvus::OpContext* op_ctx, const ScanOptions& options) const;
 
     // Get number of rows before a specific chunk
     virtual int64_t

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -156,6 +156,20 @@ class ChunkedColumnInterface {
     virtual PinWrapper<Chunk*>
     GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const = 0;
 
+    // Pin all raw chunks required by one scan plan before constructing its
+    // cursor. Implementations backed by one cache slot should override this
+    // method so the requested cells are pinned by a single PinCells call.
+    virtual std::vector<PinWrapper<Chunk*>>
+    PinChunks(milvus::OpContext* op_ctx,
+              const std::vector<int64_t>& chunk_ids) const {
+        std::vector<PinWrapper<Chunk*>> chunks;
+        chunks.reserve(chunk_ids.size());
+        for (auto chunk_id : chunk_ids) {
+            chunks.emplace_back(GetChunk(op_ctx, chunk_id));
+        }
+        return chunks;
+    }
+
     virtual std::vector<PinWrapper<Chunk*>>
     GetAllChunks(milvus::OpContext* op_ctx) const = 0;
 

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -224,15 +224,6 @@ class ChunkedColumnInterface {
     virtual PreparedScanResult
     PrepareScan(milvus::OpContext* op_ctx, const ScanOptions& options) const;
 
-    // Existing Raw SkipIndex implementations may inspect pinned chunk payload
-    // and therefore run only after Scan has prepared the current window. Local
-    // formats with metadata/footer planners should override this to false and
-    // express pre-pin pruning through PreparedScan::Plan().
-    virtual bool
-    UseLegacyDataSkipIndex() const {
-        return true;
-    }
-
     // Positional access. The returned logical values must follow the input
     // offset order exactly and preserve duplicates. Backends are free to sort,
     // group, deduplicate, or materialize internally as long as those details

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -40,6 +40,8 @@ class ChunkedColumnInterface {
     using ValueView = milvus::ValueView;
     using ScanBatch = milvus::ScanBatch;
     using ScanCursor = milvus::ScanCursor;
+    using ScanRowRange = milvus::ScanRowRange;
+    using ScanPlan = milvus::ScanPlan;
     using PreparedScan = milvus::PreparedScan;
     using ScanProjection = milvus::ScanProjection;
     using ScanOptions = milvus::ScanOptions;
@@ -221,6 +223,15 @@ class ChunkedColumnInterface {
 
     virtual PreparedScanResult
     PrepareScan(milvus::OpContext* op_ctx, const ScanOptions& options) const;
+
+    // Existing Raw SkipIndex implementations may inspect pinned chunk payload
+    // and therefore run only after Scan has prepared the current window. Local
+    // formats with metadata/footer planners should override this to false and
+    // express pre-pin pruning through PreparedScan::Plan().
+    virtual bool
+    UseLegacyDataSkipIndex() const {
+        return true;
+    }
 
     // Positional access. The returned logical values must follow the input
     // offset order exactly and preserve duplicates. Backends are free to sort,

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -37,9 +37,7 @@ class ChunkedColumnInterface {
  public:
     using ScanValueKind = milvus::ScanValueKind;
     using ValueEncoding = milvus::ValueEncoding;
-    using ValidityEncoding = milvus::ValidityEncoding;
     using ValueView = milvus::ValueView;
-    using ValidityView = milvus::ValidityView;
     using ScanBatch = milvus::ScanBatch;
     using ScanCursor = milvus::ScanCursor;
     using ScanProjection = milvus::ScanProjection;

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -45,6 +45,11 @@ class ChunkedColumnInterface {
     using ScanOptions = milvus::ScanOptions;
     using ScanResult = milvus::ScanResult;
     using PreparedScanResult = milvus::PreparedScanResult;
+    using OffsetView = milvus::OffsetView;
+    using TakeBatch = milvus::TakeBatch;
+    using TakeCursor = milvus::TakeCursor;
+    using TakeOptions = milvus::TakeOptions;
+    using TakeResult = milvus::TakeResult;
 
     virtual ~ChunkedColumnInterface() = default;
 
@@ -216,6 +221,13 @@ class ChunkedColumnInterface {
 
     virtual PreparedScanResult
     PrepareScan(milvus::OpContext* op_ctx, const ScanOptions& options) const;
+
+    // Positional access. The returned logical values must follow the input
+    // offset order exactly and preserve duplicates. Backends are free to sort,
+    // group, deduplicate, or materialize internally as long as those details
+    // do not cross the TakeBatch boundary.
+    virtual TakeResult
+    Take(milvus::OpContext* op_ctx, const TakeOptions& options) const;
 
     // Get number of rows before a specific chunk
     virtual int64_t

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -43,6 +43,7 @@ constexpr int64_t kVectorArrayDim = 2;
 struct ColumnFixture {
     std::shared_ptr<ChunkedColumnInterface> column;
     std::shared_ptr<std::set<cachinglayer::cid_t>> fetched;
+    std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests;
     // Keeps chunk data buffers alive for the column's lifetime.
     std::shared_ptr<void> buffer_holder;
 };
@@ -244,6 +245,70 @@ class CountingGroupChunkTranslator : public TestGroupChunkTranslator {
     std::shared_ptr<std::set<cachinglayer::cid_t>> fetched_;
 };
 
+class ScanCountingChunkedColumn : public ChunkedColumn {
+ public:
+    ScanCountingChunkedColumn(
+        std::shared_ptr<CacheSlot<Chunk>> slot,
+        const FieldMeta& field_meta,
+        std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests)
+        : ChunkedColumn(std::move(slot), field_meta),
+          pin_requests_(std::move(pin_requests)) {
+    }
+
+    std::vector<PinWrapper<Chunk*>>
+    PinChunks(milvus::OpContext* op_ctx,
+              const std::vector<int64_t>& chunk_ids) const override {
+        pin_requests_->emplace_back(chunk_ids);
+        return ChunkedColumn::PinChunks(op_ctx, chunk_ids);
+    }
+
+ private:
+    std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests_;
+};
+
+class ScanCountingProxyChunkColumn : public ProxyChunkColumn {
+ public:
+    ScanCountingProxyChunkColumn(
+        std::shared_ptr<ChunkedColumnGroup> group,
+        FieldId field_id,
+        const FieldMeta& field_meta,
+        std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests)
+        : ProxyChunkColumn(std::move(group), field_id, field_meta),
+          pin_requests_(std::move(pin_requests)) {
+    }
+
+    std::vector<PinWrapper<Chunk*>>
+    PinChunks(milvus::OpContext* op_ctx,
+              const std::vector<int64_t>& chunk_ids) const override {
+        pin_requests_->emplace_back(chunk_ids);
+        return ProxyChunkColumn::PinChunks(op_ctx, chunk_ids);
+    }
+
+ private:
+    std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests_;
+};
+
+class ScanCountingStringColumn : public ChunkedVariableColumn<std::string> {
+ public:
+    ScanCountingStringColumn(
+        std::shared_ptr<cachinglayer::CacheSlot<Chunk>> slot,
+        const FieldMeta& field_meta,
+        std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests)
+        : ChunkedVariableColumn<std::string>(std::move(slot), field_meta),
+          pin_requests_(std::move(pin_requests)) {
+    }
+
+    std::vector<PinWrapper<Chunk*>>
+    PinChunks(milvus::OpContext* op_ctx,
+              const std::vector<int64_t>& chunk_ids) const override {
+        pin_requests_->emplace_back(chunk_ids);
+        return ChunkedVariableColumn<std::string>::PinChunks(op_ctx, chunk_ids);
+    }
+
+ private:
+    std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests_;
+};
+
 struct ChunkedColumnFactory {
     static ColumnFixture
     Create(const ColumnSpec& spec) {
@@ -271,9 +336,13 @@ struct ChunkedColumnFactory {
         auto fm = MakeTestFieldMeta(spec);
         auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
             std::move(translator), nullptr);
-        auto column = std::make_shared<ChunkedColumn>(std::move(slot), fm);
+        auto pin_requests =
+            std::make_shared<std::vector<std::vector<int64_t>>>();
+        auto column = std::make_shared<ScanCountingChunkedColumn>(
+            std::move(slot), fm, pin_requests);
         return {std::static_pointer_cast<ChunkedColumnInterface>(column),
                 std::move(fetched),
+                std::move(pin_requests),
                 std::static_pointer_cast<void>(buffers)};
     }
 };
@@ -313,10 +382,13 @@ struct ProxyChunkColumnFactory {
         auto group =
             std::make_shared<ChunkedColumnGroup>(std::move(translator));
         auto fm = MakeTestFieldMeta(spec);
-        auto column = std::make_shared<ProxyChunkColumn>(
-            group, FieldId(kTestFieldId), fm);
+        auto pin_requests =
+            std::make_shared<std::vector<std::vector<int64_t>>>();
+        auto column = std::make_shared<ScanCountingProxyChunkColumn>(
+            group, FieldId(kTestFieldId), fm, pin_requests);
         return {std::static_pointer_cast<ChunkedColumnInterface>(column),
                 std::move(fetched),
+                std::move(pin_requests),
                 std::static_pointer_cast<void>(buffers)};
     }
 };
@@ -633,7 +705,7 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
     EXPECT_FALSE(IsScanRowValid(batch, 1));
     EXPECT_EQ(cursor->Position(), 2);
     ASSERT_NE(batch.owner, nullptr);
-    EXPECT_EQ(batch.owner.use_count(), 1);
+    EXPECT_EQ(batch.owner.use_count(), 2);
 
     ASSERT_TRUE(cursor->Next(2, &batch));
     EXPECT_EQ(batch.row_id_start, 2);
@@ -641,7 +713,7 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
     EXPECT_TRUE(IsScanRowValid(batch, 0));
     EXPECT_TRUE(IsScanRowValid(batch, 1));
     ASSERT_NE(batch.owner, nullptr);
-    EXPECT_EQ(batch.owner.use_count(), 1);
+    EXPECT_EQ(batch.owner.use_count(), 2);
     EXPECT_EQ(cursor->Position(), kVectorArrayRows);
 }
 
@@ -676,6 +748,9 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
                             ChunkedColumnInterface::ScanValueKind::FixedWidth));
     ASSERT_NE(cursor, nullptr);
     EXPECT_EQ(cursor->Position(), 1);
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0, 1}));
+    EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
 
     ChunkedColumnInterface::ScanBatch batch;
     ASSERT_TRUE(cursor->Next(10, &batch));
@@ -698,6 +773,7 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_EQ(cursor->Position(), 5);
 
     EXPECT_FALSE(cursor->Next(10, &batch));
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
     EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
 }
 
@@ -712,6 +788,8 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     auto cursor = fx.column->Scan(
         nullptr, ChunkedColumnInterface::ScanOptions::ForNoData(0, 4));
     ASSERT_NE(cursor, nullptr);
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0}));
 
     ChunkedColumnInterface::ScanBatch batch;
     ASSERT_TRUE(cursor->Next(4, &batch));
@@ -723,6 +801,7 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_TRUE(IsScanRowValid(batch, 2));
     EXPECT_FALSE(IsScanRowValid(batch, 3));
     EXPECT_FALSE(cursor->Next(4, &batch));
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,
@@ -735,6 +814,8 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
         nullptr, ChunkedColumnInterface::ScanOptions::ForData(1, 4));
     ASSERT_NE(cursor, nullptr);
     EXPECT_EQ(cursor->Position(), 1);
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0}));
 
     ChunkedColumnInterface::ScanBatch batch;
     ASSERT_TRUE(cursor->Next(2, &batch));
@@ -752,6 +833,7 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_EQ(batch.size, 1);
     EXPECT_EQ(cursor->Position(), 5);
     EXPECT_FALSE(cursor->Next(2, &batch));
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,
@@ -764,6 +846,7 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
         nullptr, ChunkedColumnInterface::ScanOptions::ForNoData(0, 5));
     ASSERT_NE(cursor, nullptr);
     EXPECT_TRUE(fx.fetched->empty());
+    EXPECT_TRUE(fx.pin_requests->empty());
 
     ChunkedColumnInterface::ScanBatch batch;
     ASSERT_TRUE(cursor->Next(5, &batch));
@@ -777,6 +860,7 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_TRUE(batch.values.empty());
     EXPECT_EQ(batch.validity, nullptr);
     EXPECT_TRUE(fx.fetched->empty());
+    EXPECT_TRUE(fx.pin_requests->empty());
     EXPECT_FALSE(cursor->Next(5, &batch));
 }
 
@@ -839,13 +923,16 @@ TEST(ChunkedColumnInterfaceTest, VarcharPrimaryKeyUsesStringViewScanCursor) {
                          std::nullopt);
     auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
         std::move(translator), nullptr);
-    auto column =
-        MakeChunkedColumnBase(DataType::VARCHAR, std::move(slot), field_meta);
+    auto pin_requests = std::make_shared<std::vector<std::vector<int64_t>>>();
+    auto column = std::make_shared<ScanCountingStringColumn>(
+        std::move(slot), field_meta, pin_requests);
 
     auto cursor = column->Scan(nullptr,
                                ChunkedColumnInterface::ScanOptions::ForData(
                                    0, static_cast<int64_t>(values.size())));
     ASSERT_NE(cursor, nullptr);
+    ASSERT_EQ(pin_requests->size(), 1u);
+    EXPECT_EQ(pin_requests->front(), (std::vector<int64_t>{0}));
 
     ChunkedColumnInterface::ScanBatch batch;
     ASSERT_TRUE(cursor->Next(static_cast<int64_t>(values.size()), &batch));
@@ -885,8 +972,9 @@ TEST(ChunkedColumnInterfaceTest,
                          std::nullopt);
     auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
         std::move(translator), nullptr);
-    auto column =
-        MakeChunkedColumnBase(DataType::VARCHAR, std::move(slot), field_meta);
+    auto pin_requests = std::make_shared<std::vector<std::vector<int64_t>>>();
+    auto column = std::make_shared<ScanCountingStringColumn>(
+        std::move(slot), field_meta, pin_requests);
 
     constexpr int64_t kMaxBatchRows = 2;
     auto cursor =
@@ -897,6 +985,8 @@ TEST(ChunkedColumnInterfaceTest,
                          ChunkedColumnInterface::ScanProjection::Data,
                          ChunkedColumnInterface::ScanValueKind::StringView));
     ASSERT_NE(cursor, nullptr);
+    ASSERT_EQ(pin_requests->size(), 1u);
+    EXPECT_EQ(pin_requests->front(), (std::vector<int64_t>{0}));
 
     std::vector<std::string> scanned;
     std::vector<int64_t> batch_starts;
@@ -915,6 +1005,7 @@ TEST(ChunkedColumnInterfaceTest,
     EXPECT_EQ(batch_starts, (std::vector<int64_t>{0, 2, 4}));
     EXPECT_EQ(batch_sizes, (std::vector<int64_t>{2, 2, 1}));
     EXPECT_EQ(scanned, values);
+    EXPECT_EQ(pin_requests->size(), 1u);
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -837,6 +837,40 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,
+           PreparedScanSeeksWithoutRepinningChunks) {
+    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto prepared = fx.column->PrepareScan(
+        nullptr, ChunkedColumnInterface::ScanOptions::ForData(0, 5));
+    ASSERT_NE(prepared, nullptr);
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0, 1}));
+
+    auto first = prepared->Seek(0);
+    ASSERT_NE(first, nullptr);
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(first->Next(2, &batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 2);
+    first.reset();
+
+    auto resumed = prepared->Seek(2);
+    ASSERT_NE(resumed, nullptr);
+    ASSERT_TRUE(resumed->Next(2, &batch));
+    EXPECT_EQ(batch.row_id_start, 2);
+    EXPECT_EQ(batch.size, 1);
+    ASSERT_TRUE(resumed->Next(2, &batch));
+    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_FALSE(resumed->Next(2, &batch));
+
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
            NonNullableNoDataScanDoesNotFetchPayload) {
     ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
     spec.data_type = DataType::INT32;

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -615,12 +615,15 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
                         ChunkedColumnInterface::ScanOptions::ForNoData(
                             0,
                             kVectorArrayRows,
-                            ChunkedColumnInterface::ScanValueKind::FixedWidth));
+                            ChunkedColumnInterface::ScanValueKind::FixedWidth,
+                            /*max_batch_rows=*/2));
     ASSERT_NE(cursor, nullptr);
 
     ChunkedColumnInterface::ScanBatch batch;
     ASSERT_TRUE(cursor->Next(&batch));
     EXPECT_TRUE(batch.values.empty());
+    // Validity-only scans do not materialize per-row view wrappers, so the
+    // materialized-data cap must not split their natural chunk batch.
     EXPECT_EQ(batch.size, kVectorArrayRows);
     EXPECT_TRUE(batch.validity.IsValid(0));
     EXPECT_FALSE(batch.validity.IsValid(1));
@@ -812,6 +815,63 @@ TEST(ChunkedColumnInterfaceTest, VarcharPrimaryKeyUsesStringViewScanCursor) {
         EXPECT_EQ(scanned[i], values[i]);
     }
     EXPECT_FALSE(cursor->Next(&batch));
+}
+
+TEST(ChunkedColumnInterfaceTest,
+     MaterializedViewDataScanStreamsBoundedBatches) {
+    const std::vector<std::string> values{
+        "alpha", "beta", "gamma", "delta", "epsilon"};
+    auto buffer = BuildStringChunkBuffer(values);
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    chunks.push_back(
+        std::make_unique<StringChunk>(static_cast<int32_t>(values.size()),
+                                      buffer.data(),
+                                      buffer.size(),
+                                      /*nullable=*/false,
+                                      std::move(guard)));
+    auto translator = std::make_unique<TestChunkTranslator>(
+        std::vector<int64_t>{static_cast<int64_t>(values.size())},
+        "bounded_varchar_scan",
+        std::move(chunks));
+    FieldMeta field_meta(FieldName("varchar"),
+                         FieldId(kTestFieldId),
+                         DataType::VARCHAR,
+                         /*nullable=*/false,
+                         std::nullopt);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+        std::move(translator), nullptr);
+    auto column =
+        MakeChunkedColumnBase(DataType::VARCHAR, std::move(slot), field_meta);
+
+    constexpr int64_t kMaxBatchRows = 2;
+    auto cursor =
+        column->Scan(nullptr,
+                     ChunkedColumnInterface::ScanOptions::ForData(
+                         0,
+                         static_cast<int64_t>(values.size()),
+                         ChunkedColumnInterface::ScanProjection::Data,
+                         ChunkedColumnInterface::ScanValueKind::StringView,
+                         kMaxBatchRows));
+    ASSERT_NE(cursor, nullptr);
+
+    std::vector<std::string> scanned;
+    std::vector<int64_t> batch_starts;
+    std::vector<int64_t> batch_sizes;
+    ChunkedColumnInterface::ScanBatch batch;
+    while (cursor->Next(&batch)) {
+        batch_starts.emplace_back(batch.row_id_start);
+        batch_sizes.emplace_back(batch.size);
+        EXPECT_LE(batch.size, kMaxBatchRows);
+        const auto* batch_values = batch.values.data_as<std::string_view>();
+        for (int64_t i = 0; i < batch.size; ++i) {
+            scanned.emplace_back(batch_values[i]);
+        }
+    }
+
+    EXPECT_EQ(batch_starts, (std::vector<int64_t>{0, 2, 4}));
+    EXPECT_EQ(batch_sizes, (std::vector<int64_t>{2, 2, 1}));
+    EXPECT_EQ(scanned, values);
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -957,6 +957,23 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_FALSE(batch.values.empty());
     EXPECT_FALSE(cursor->Next(7, &batch));
     EXPECT_EQ(cursor->Position(), 7);
+
+    // Reopening a subrange keeps the planner skips selected before pinning.
+    // The caller does not need to repeat those ranges, and the cursor must not
+    // try to access the unpinned middle Cells.
+    cursor = prepared->Open(
+        ChunkedColumnInterface::ScanPlan::Full(1, 5),
+        ChunkedColumnInterface::ScanProjection::Data);
+    ASSERT_NE(cursor, nullptr);
+    ASSERT_TRUE(cursor->Next(5, &batch));
+    EXPECT_EQ(batch.row_id_start, 1);
+    EXPECT_EQ(batch.size, 1);
+    ASSERT_TRUE(cursor->Next(5, &batch));
+    EXPECT_EQ(batch.row_id_start, 5);
+    EXPECT_EQ(batch.size, 1);
+    EXPECT_FALSE(cursor->Next(5, &batch));
+    EXPECT_EQ(cursor->Position(), 6);
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -381,28 +381,12 @@ struct ProxyVectorArrayColumnFactory {
     }
 };
 
-}  // namespace
-
-TEST(ChunkedColumnScanCommonTest, BitmapValidityMaterializesEvaluatorMask) {
-    const std::array<uint8_t, 2> bitmap{0b10101101, 0b00000001};
-    ChunkedColumnInterface::ValidityView validity;
-    validity.encoding = ChunkedColumnInterface::ValidityEncoding::Bitmap;
-    validity.data = bitmap.data();
-    validity.offset = 2;
-    validity.size = 7;
-    validity.nullable = true;
-
-    FixedVector<bool> scratch;
-    const auto* mask = validity.bool_data(scratch);
-    ASSERT_NE(mask, nullptr);
-    ASSERT_EQ(scratch.size(), 7);
-    const std::array<bool, 7> expected{
-        true, true, false, true, false, true, true};
-    for (size_t i = 0; i < expected.size(); ++i) {
-        EXPECT_EQ(mask[i], expected[i]);
-        EXPECT_EQ(validity.IsValid(i), expected[i]);
-    }
+bool
+IsScanRowValid(const ChunkedColumnInterface::ScanBatch& batch, int64_t offset) {
+    return batch.validity == nullptr || batch.validity[offset];
 }
+
+}  // namespace
 
 template <typename Factory>
 class ChunkedColumnInterfaceTest : public ::testing::Test {};
@@ -621,10 +605,10 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
     EXPECT_EQ(views[0].length(), 1);
     EXPECT_EQ(views[2].length(), 0);
     EXPECT_EQ(views[3].length(), 2);
-    EXPECT_TRUE(batch.validity.IsValid(0));
-    EXPECT_FALSE(batch.validity.IsValid(1));
-    EXPECT_TRUE(batch.validity.IsValid(2));
-    EXPECT_TRUE(batch.validity.IsValid(3));
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+    EXPECT_FALSE(IsScanRowValid(batch, 1));
+    EXPECT_TRUE(IsScanRowValid(batch, 2));
+    EXPECT_TRUE(IsScanRowValid(batch, 3));
     EXPECT_EQ(cursor->Position(), 4);
     EXPECT_FALSE(cursor->Next(4, &batch));
 }
@@ -645,8 +629,8 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
     ASSERT_TRUE(cursor->Next(2, &batch));
     EXPECT_TRUE(batch.values.empty());
     EXPECT_EQ(batch.size, 2);
-    EXPECT_TRUE(batch.validity.IsValid(0));
-    EXPECT_FALSE(batch.validity.IsValid(1));
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+    EXPECT_FALSE(IsScanRowValid(batch, 1));
     EXPECT_EQ(cursor->Position(), 2);
     ASSERT_NE(batch.owner, nullptr);
     EXPECT_EQ(batch.owner.use_count(), 1);
@@ -654,8 +638,8 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
     ASSERT_TRUE(cursor->Next(2, &batch));
     EXPECT_EQ(batch.row_id_start, 2);
     EXPECT_EQ(batch.size, 2);
-    EXPECT_TRUE(batch.validity.IsValid(0));
-    EXPECT_TRUE(batch.validity.IsValid(1));
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+    EXPECT_TRUE(IsScanRowValid(batch, 1));
     ASSERT_NE(batch.owner, nullptr);
     EXPECT_EQ(batch.owner.use_count(), 1);
     EXPECT_EQ(cursor->Position(), kVectorArrayRows);
@@ -701,16 +685,16 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_EQ(batch.values.encoding,
               ChunkedColumnInterface::ValueEncoding::FixedWidth);
     EXPECT_EQ(batch.values.data_as<int32_t>()[1], 2);
-    EXPECT_FALSE(batch.validity.IsValid(0));
-    EXPECT_TRUE(batch.validity.IsValid(1));
+    EXPECT_FALSE(IsScanRowValid(batch, 0));
+    EXPECT_TRUE(IsScanRowValid(batch, 1));
     EXPECT_EQ(cursor->Position(), 3);
 
     ASSERT_TRUE(cursor->Next(10, &batch));
     EXPECT_EQ(batch.row_id_start, 3);
     EXPECT_EQ(batch.size, 2);
     EXPECT_EQ(batch.values.data_as<int32_t>()[1], 4);
-    EXPECT_FALSE(batch.validity.IsValid(0));
-    EXPECT_TRUE(batch.validity.IsValid(1));
+    EXPECT_FALSE(IsScanRowValid(batch, 0));
+    EXPECT_TRUE(IsScanRowValid(batch, 1));
     EXPECT_EQ(cursor->Position(), 5);
 
     EXPECT_FALSE(cursor->Next(10, &batch));
@@ -734,10 +718,10 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_EQ(batch.row_id_start, 0);
     EXPECT_EQ(batch.size, 4);
     EXPECT_TRUE(batch.values.empty());
-    EXPECT_TRUE(batch.validity.IsValid(0));
-    EXPECT_FALSE(batch.validity.IsValid(1));
-    EXPECT_TRUE(batch.validity.IsValid(2));
-    EXPECT_FALSE(batch.validity.IsValid(3));
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+    EXPECT_FALSE(IsScanRowValid(batch, 1));
+    EXPECT_TRUE(IsScanRowValid(batch, 2));
+    EXPECT_FALSE(IsScanRowValid(batch, 3));
     EXPECT_FALSE(cursor->Next(4, &batch));
 }
 
@@ -785,15 +769,13 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     ASSERT_TRUE(cursor->Next(5, &batch));
     EXPECT_EQ(batch.size, 3);
     EXPECT_TRUE(batch.values.empty());
-    EXPECT_EQ(batch.validity.encoding,
-              ChunkedColumnInterface::ValidityEncoding::AllValid);
+    EXPECT_EQ(batch.validity, nullptr);
     EXPECT_TRUE(fx.fetched->empty());
 
     ASSERT_TRUE(cursor->Next(5, &batch));
     EXPECT_EQ(batch.size, 2);
     EXPECT_TRUE(batch.values.empty());
-    EXPECT_EQ(batch.validity.encoding,
-              ChunkedColumnInterface::ValidityEncoding::AllValid);
+    EXPECT_EQ(batch.validity, nullptr);
     EXPECT_TRUE(fx.fetched->empty());
     EXPECT_FALSE(cursor->Next(5, &batch));
 }
@@ -810,10 +792,9 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
 
     ChunkedColumnInterface::ScanBatch batch;
     ASSERT_TRUE(cursor->Next(3, &batch));
-    EXPECT_EQ(batch.validity.encoding,
-              ChunkedColumnInterface::ValidityEncoding::AllValid);
+    EXPECT_EQ(batch.validity, nullptr);
     for (int64_t i = 0; i < batch.size; ++i) {
-        EXPECT_TRUE(batch.validity.IsValid(i));
+        EXPECT_TRUE(IsScanRowValid(batch, i));
     }
 }
 

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -458,6 +458,20 @@ IsScanRowValid(const ChunkedColumnInterface::ScanBatch& batch, int64_t offset) {
     return batch.validity == nullptr || batch.validity[offset];
 }
 
+int64_t
+TakeValueOffset(const ChunkedColumnInterface::TakeBatch& batch,
+                int64_t logical_offset) {
+    return batch.selection == nullptr ? logical_offset
+                                      : batch.selection[logical_offset];
+}
+
+bool
+IsTakeRowValid(const ChunkedColumnInterface::TakeBatch& batch,
+               int64_t logical_offset) {
+    return batch.validity == nullptr ||
+           batch.validity[TakeValueOffset(batch, logical_offset)];
+}
+
 }  // namespace
 
 template <typename Factory>
@@ -917,6 +931,71 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthTakePreservesOrderDuplicatesAndChunkRuns) {
+    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    const FixedVector<int32_t> offsets{2, 0, 0, 4, 3, 1};
+    auto cursor = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::ScanValueKind::FixedWidth});
+    ASSERT_NE(cursor, nullptr);
+
+    std::vector<int32_t> actual;
+    std::vector<int64_t> batch_positions;
+    std::vector<int64_t> batch_sizes;
+    std::vector<int64_t> source_chunks;
+    ChunkedColumnInterface::TakeBatch batch;
+    while (cursor->Next(4, &batch)) {
+        batch_positions.emplace_back(batch.position);
+        batch_sizes.emplace_back(batch.size);
+        source_chunks.emplace_back(batch.source_chunk_id);
+        ASSERT_NE(batch.owner, nullptr);
+        ASSERT_NE(batch.selection, nullptr);
+        const auto* values = batch.values.data_as<int32_t>();
+        for (int64_t i = 0; i < batch.size; ++i) {
+            actual.emplace_back(values[TakeValueOffset(batch, i)]);
+            EXPECT_TRUE(IsTakeRowValid(batch, i));
+        }
+    }
+
+    EXPECT_EQ(actual, (std::vector<int32_t>{2, 0, 0, 4, 3, 1}));
+    EXPECT_EQ(batch_positions, (std::vector<int64_t>{0, 3, 5}));
+    EXPECT_EQ(batch_sizes, (std::vector<int64_t>{3, 2, 1}));
+    EXPECT_EQ(source_chunks, (std::vector<int64_t>{0, 1, 0}));
+    EXPECT_EQ(cursor->Position(), static_cast<int64_t>(offsets.size()));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthTakeIndexesValidityThroughSelection) {
+    ColumnSpec spec{{4}, {{true, false, true, false}}, /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    spec.dense_nullable_payload = true;
+    auto fx = TypeParam::Create(spec);
+
+    const FixedVector<int32_t> offsets{3, 0, 1, 2};
+    auto cursor = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::ScanValueKind::FixedWidth});
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::TakeBatch batch;
+    ASSERT_TRUE(cursor->Next(4, &batch));
+    ASSERT_EQ(batch.size, 4);
+    EXPECT_FALSE(IsTakeRowValid(batch, 0));
+    EXPECT_TRUE(IsTakeRowValid(batch, 1));
+    EXPECT_FALSE(IsTakeRowValid(batch, 2));
+    EXPECT_TRUE(IsTakeRowValid(batch, 3));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
            FixedWidthDataScanRejectsMismatchedValueKind) {
     ColumnSpec spec{{3}, {}, /*nullable=*/false};
     spec.data_type = DataType::INT32;
@@ -980,6 +1059,54 @@ TEST(ChunkedColumnInterfaceTest, VarcharPrimaryKeyUsesStringViewScanCursor) {
         EXPECT_EQ(scanned[i], values[i]);
     }
     EXPECT_FALSE(cursor->Next(static_cast<int64_t>(values.size()), &batch));
+}
+
+TEST(ChunkedColumnInterfaceTest, VarcharTakeBuildsOnlyRequestedOrderedViews) {
+    const std::vector<std::string> values{"alpha", "beta", "gamma", "delta"};
+    auto buffer = BuildStringChunkBuffer(values);
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    chunks.push_back(
+        std::make_unique<StringChunk>(static_cast<int32_t>(values.size()),
+                                      buffer.data(),
+                                      buffer.size(),
+                                      /*nullable=*/false,
+                                      std::move(guard)));
+    auto translator = std::make_unique<TestChunkTranslator>(
+        std::vector<int64_t>{static_cast<int64_t>(values.size())},
+        "varchar_take",
+        std::move(chunks));
+    FieldMeta field_meta(FieldName("varchar"),
+                         FieldId(kTestFieldId),
+                         DataType::VARCHAR,
+                         /*nullable=*/false,
+                         std::nullopt);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+        std::move(translator), nullptr);
+    auto pin_requests = std::make_shared<std::vector<std::vector<int64_t>>>();
+    auto column = std::make_shared<ScanCountingStringColumn>(
+        std::move(slot), field_meta, pin_requests);
+
+    const FixedVector<int32_t> offsets{3, 1, 1, 0};
+    auto cursor = column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::ScanValueKind::StringView});
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::TakeBatch batch;
+    ASSERT_TRUE(cursor->Next(10, &batch));
+    EXPECT_EQ(batch.position, 0);
+    EXPECT_EQ(batch.size, 4);
+    EXPECT_EQ(batch.selection, nullptr);
+    const auto* taken = batch.values.data_as<std::string_view>();
+    EXPECT_EQ(taken[0], "delta");
+    EXPECT_EQ(taken[1], "beta");
+    EXPECT_EQ(taken[2], "beta");
+    EXPECT_EQ(taken[3], "alpha");
+    EXPECT_FALSE(cursor->Next(10, &batch));
 }
 
 TEST(ChunkedColumnInterfaceTest,

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -51,7 +51,30 @@ struct ColumnSpec {
     std::vector<int64_t> rows_per_chunk;
     std::vector<std::vector<bool>> valid_patterns;  // empty => all valid
     bool nullable{true};
+    DataType data_type{DataType::VECTOR_INT8};
+    // Primitive ChunkWriter keeps one payload slot per logical row. Some
+    // positional-access tests intentionally exercise the legacy compact
+    // fixture, while scan tests use the production dense layout.
+    bool dense_nullable_payload{false};
 };
+
+FieldMeta
+MakeTestFieldMeta(const ColumnSpec& spec) {
+    if (IsVectorDataType(spec.data_type)) {
+        return FieldMeta(FieldName("t"),
+                         FieldId(kTestFieldId),
+                         spec.data_type,
+                         kElementSize,
+                         std::nullopt,
+                         spec.nullable,
+                         std::nullopt);
+    }
+    return FieldMeta(FieldName("t"),
+                     FieldId(kTestFieldId),
+                     spec.data_type,
+                     spec.nullable,
+                     std::nullopt);
+}
 
 struct VectorArrayColumnFixture {
     std::shared_ptr<ChunkedColumnInterface> column;
@@ -62,7 +85,8 @@ std::vector<char>
 BuildChunkBuffer(int64_t row_num,
                  const std::vector<bool>* pattern,
                  bool nullable,
-                 int64_t start_logical_offset) {
+                 int64_t start_logical_offset,
+                 bool dense_nullable_payload = false) {
     const int32_t bitmap_bytes = nullable ? (row_num + 7) / 8 : 0;
     std::vector<char> buf(bitmap_bytes + row_num * kElementSize, 0);
     int64_t physical_offset = 0;
@@ -71,13 +95,17 @@ BuildChunkBuffer(int64_t row_num,
             const bool v = pattern ? (*pattern)[j] : true;
             if (v) {
                 buf[j >> 3] |= (1 << (j & 0x07));
-                const int32_t value = start_logical_offset + j;
+            }
+            const int32_t value = start_logical_offset + j;
+            const auto value_offset =
+                dense_nullable_payload ? j : physical_offset;
+            if (dense_nullable_payload || v) {
                 std::memcpy(
-                    buf.data() + bitmap_bytes + physical_offset * kElementSize,
+                    buf.data() + bitmap_bytes + value_offset * kElementSize,
                     &value,
                     sizeof(value));
-                ++physical_offset;
             }
+            physical_offset += v ? 1 : 0;
         }
     } else {
         for (int64_t j = 0; j < row_num; ++j) {
@@ -144,6 +172,27 @@ MakeVectorArrayChunk(char* data, size_t size) {
                                               /*nullable=*/true);
 }
 
+std::vector<char>
+BuildStringChunkBuffer(const std::vector<std::string>& values) {
+    const auto header_bytes = sizeof(uint32_t) * (values.size() + 1);
+    size_t payload_bytes = 0;
+    for (const auto& value : values) {
+        payload_bytes += value.size();
+    }
+
+    std::vector<char> buffer(header_bytes + payload_bytes, 0);
+    auto* offsets = reinterpret_cast<uint32_t*>(buffer.data());
+    uint32_t next_offset = static_cast<uint32_t>(header_bytes);
+    offsets[0] = next_offset;
+    for (size_t i = 0; i < values.size(); ++i) {
+        std::memcpy(
+            buffer.data() + next_offset, values[i].data(), values[i].size());
+        next_offset += static_cast<uint32_t>(values[i].size());
+        offsets[i + 1] = next_offset;
+    }
+    return buffer;
+}
+
 class CountingChunkTranslator : public TestChunkTranslator {
  public:
     CountingChunkTranslator(
@@ -208,7 +257,8 @@ struct ChunkedColumnFactory {
                 spec.rows_per_chunk[i],
                 spec.valid_patterns.empty() ? nullptr : &spec.valid_patterns[i],
                 spec.nullable,
-                start_logical_offset);
+                start_logical_offset,
+                spec.dense_nullable_payload);
             chunks.push_back(MakeFixedChunk(spec.rows_per_chunk[i],
                                             spec.nullable,
                                             (*buffers)[i].data(),
@@ -218,13 +268,7 @@ struct ChunkedColumnFactory {
         auto fetched = std::make_shared<std::set<cachinglayer::cid_t>>();
         auto translator = std::make_unique<CountingChunkTranslator>(
             spec.rows_per_chunk, "cc_iface", std::move(chunks), fetched);
-        FieldMeta fm(FieldName("t"),
-                     FieldId(kTestFieldId),
-                     DataType::VECTOR_INT8,
-                     kElementSize,
-                     std::nullopt,
-                     spec.nullable,
-                     std::nullopt);
+        auto fm = MakeTestFieldMeta(spec);
         auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
             std::move(translator), nullptr);
         auto column = std::make_shared<ChunkedColumn>(std::move(slot), fm);
@@ -247,7 +291,8 @@ struct ProxyChunkColumnFactory {
                 spec.rows_per_chunk[i],
                 spec.valid_patterns.empty() ? nullptr : &spec.valid_patterns[i],
                 spec.nullable,
-                start_logical_offset);
+                start_logical_offset,
+                spec.dense_nullable_payload);
             std::shared_ptr<Chunk> chunk =
                 MakeFixedChunk(spec.rows_per_chunk[i],
                                spec.nullable,
@@ -267,13 +312,7 @@ struct ProxyChunkColumnFactory {
             fetched);
         auto group =
             std::make_shared<ChunkedColumnGroup>(std::move(translator));
-        FieldMeta fm(FieldName("t"),
-                     FieldId(kTestFieldId),
-                     DataType::VECTOR_INT8,
-                     kElementSize,
-                     std::nullopt,
-                     spec.nullable,
-                     std::nullopt);
+        auto fm = MakeTestFieldMeta(spec);
         auto column = std::make_shared<ProxyChunkColumn>(
             group, FieldId(kTestFieldId), fm);
         return {std::static_pointer_cast<ChunkedColumnInterface>(column),
@@ -537,6 +576,242 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
         fx.column->BulkVectorArrayAt(
             nullptr, [](VectorFieldProto&&, size_t) {}, null_offset, 1),
         std::exception);
+}
+
+TYPED_TEST(VectorArrayColumnInterfaceTest,
+           DataScanReturnsLogicalVectorArrayViews) {
+    auto fx = TypeParam::Create();
+
+    auto cursor = fx.column->Scan(
+        nullptr, ChunkedColumnInterface::ScanOptions::ForData(0, 4));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 4);
+    EXPECT_EQ(batch.values.encoding,
+              ChunkedColumnInterface::ValueEncoding::VectorArrayView);
+    EXPECT_EQ(batch.values.kind,
+              ChunkedColumnInterface::ScanValueKind::VectorArrayView);
+
+    const auto* views = batch.values.data_as<VectorArrayView>();
+    EXPECT_EQ(views[0].length(), 1);
+    EXPECT_EQ(views[2].length(), 0);
+    EXPECT_EQ(views[3].length(), 2);
+    EXPECT_TRUE(batch.validity.IsValid(0));
+    EXPECT_FALSE(batch.validity.IsValid(1));
+    EXPECT_TRUE(batch.validity.IsValid(2));
+    EXPECT_TRUE(batch.validity.IsValid(3));
+    EXPECT_FALSE(cursor->Next(&batch));
+}
+
+TYPED_TEST(VectorArrayColumnInterfaceTest,
+           NoDataScanUsesColumnTypeInsteadOfRequestedValueKind) {
+    auto fx = TypeParam::Create();
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForNoData(
+                            0,
+                            kVectorArrayRows,
+                            ChunkedColumnInterface::ScanValueKind::FixedWidth));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_TRUE(batch.values.empty());
+    EXPECT_EQ(batch.size, kVectorArrayRows);
+    EXPECT_TRUE(batch.validity.IsValid(0));
+    EXPECT_FALSE(batch.validity.IsValid(1));
+    EXPECT_TRUE(batch.validity.IsValid(2));
+    EXPECT_TRUE(batch.validity.IsValid(3));
+}
+
+TYPED_TEST(VectorArrayColumnInterfaceTest, DataScanRejectsMismatchedValueKind) {
+    auto fx = TypeParam::Create();
+
+    EXPECT_THROW(
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0,
+                            kVectorArrayRows,
+                            ChunkedColumnInterface::ScanProjection::Data,
+                            ChunkedColumnInterface::ScanValueKind::FixedWidth)),
+        std::exception);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthDataScanReturnsNaturalChunkBatches) {
+    ColumnSpec spec{{3, 2},
+                    {{true, false, true}, {false, true}},
+                    /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    spec.dense_nullable_payload = true;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            1,
+                            4,
+                            ChunkedColumnInterface::ScanProjection::Data,
+                            ChunkedColumnInterface::ScanValueKind::FixedWidth));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_EQ(batch.row_id_start, 1);
+    EXPECT_EQ(batch.size, 2);
+    ASSERT_FALSE(batch.values.empty());
+    EXPECT_EQ(batch.values.encoding,
+              ChunkedColumnInterface::ValueEncoding::FixedWidth);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[1], 2);
+    EXPECT_FALSE(batch.validity.IsValid(0));
+    EXPECT_TRUE(batch.validity.IsValid(1));
+
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[1], 4);
+    EXPECT_FALSE(batch.validity.IsValid(0));
+    EXPECT_TRUE(batch.validity.IsValid(1));
+
+    EXPECT_FALSE(cursor->Next(&batch));
+    EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthNoDataScanReturnsOnlyValidity) {
+    ColumnSpec spec{{4},
+                    {{true, false, true, false}},
+                    /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor = fx.column->Scan(
+        nullptr, ChunkedColumnInterface::ScanOptions::ForNoData(0, 4));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 4);
+    EXPECT_TRUE(batch.values.empty());
+    EXPECT_TRUE(batch.validity.IsValid(0));
+    EXPECT_FALSE(batch.validity.IsValid(1));
+    EXPECT_TRUE(batch.validity.IsValid(2));
+    EXPECT_FALSE(batch.validity.IsValid(3));
+    EXPECT_FALSE(cursor->Next(&batch));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           NonNullableNoDataScanDoesNotFetchPayload) {
+    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor = fx.column->Scan(
+        nullptr, ChunkedColumnInterface::ScanOptions::ForNoData(0, 5));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_TRUE(fx.fetched->empty());
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_EQ(batch.size, 3);
+    EXPECT_TRUE(batch.values.empty());
+    EXPECT_TRUE(batch.validity.all_valid);
+    EXPECT_TRUE(fx.fetched->empty());
+
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_TRUE(batch.values.empty());
+    EXPECT_TRUE(batch.validity.all_valid);
+    EXPECT_TRUE(fx.fetched->empty());
+    EXPECT_FALSE(cursor->Next(&batch));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthDataScanReportsAllValidForNonNullableColumn) {
+    ColumnSpec spec{{3}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor = fx.column->Scan(
+        nullptr, ChunkedColumnInterface::ScanOptions::ForData(0, 3));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_EQ(batch.validity.encoding,
+              ChunkedColumnInterface::ValidityEncoding::AllValid);
+    EXPECT_TRUE(batch.validity.all_valid);
+    for (int64_t i = 0; i < batch.size; ++i) {
+        EXPECT_TRUE(batch.validity.IsValid(i));
+    }
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthDataScanRejectsMismatchedValueKind) {
+    ColumnSpec spec{{3}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    EXPECT_THROW(
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0,
+                            3,
+                            ChunkedColumnInterface::ScanProjection::Data,
+                            ChunkedColumnInterface::ScanValueKind::StringView)),
+        std::exception);
+}
+
+TEST(ChunkedColumnInterfaceTest, VarcharPrimaryKeyUsesStringViewScanCursor) {
+    // Primary-key metadata does not change the underlying column
+    // representation: a user-defined VARCHAR PK uses the regular string
+    // column and must therefore resolve to a StringView scan cursor.
+    const std::vector<std::string> values{"alpha", "beta", "gamma"};
+    auto buffer = BuildStringChunkBuffer(values);
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    chunks.push_back(
+        std::make_unique<StringChunk>(static_cast<int32_t>(values.size()),
+                                      buffer.data(),
+                                      buffer.size(),
+                                      /*nullable=*/false,
+                                      std::move(guard)));
+    auto translator = std::make_unique<TestChunkTranslator>(
+        std::vector<int64_t>{static_cast<int64_t>(values.size())},
+        "varchar_pk_scan",
+        std::move(chunks));
+    FieldMeta field_meta(FieldName("varchar_pk"),
+                         FieldId(kTestFieldId),
+                         DataType::VARCHAR,
+                         /*nullable=*/false,
+                         std::nullopt);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+        std::move(translator), nullptr);
+    auto column =
+        MakeChunkedColumnBase(DataType::VARCHAR, std::move(slot), field_meta);
+
+    auto cursor = column->Scan(nullptr,
+                               ChunkedColumnInterface::ScanOptions::ForData(
+                                   0, static_cast<int64_t>(values.size())));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_EQ(batch.values.encoding,
+              ChunkedColumnInterface::ValueEncoding::StringView);
+    EXPECT_EQ(batch.values.kind,
+              ChunkedColumnInterface::ScanValueKind::StringView);
+    const auto* scanned = batch.values.data_as<std::string_view>();
+    ASSERT_EQ(batch.size, static_cast<int64_t>(values.size()));
+    for (size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ(scanned[i], values[i]);
+    }
+    EXPECT_FALSE(cursor->Next(&batch));
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -879,8 +879,22 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_TRUE(IsScanRowValid(batch, 0));
 
     ASSERT_TRUE(cursor->Next(5, &batch));
+    EXPECT_EQ(batch.row_id_start, 1);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_TRUE(batch.values.empty());
+    EXPECT_FALSE(IsScanRowValid(batch, 0));
+    EXPECT_TRUE(IsScanRowValid(batch, 1));
+
+    ASSERT_TRUE(cursor->Next(5, &batch));
+    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_EQ(batch.size, 1);
+    EXPECT_TRUE(batch.values.empty());
+    EXPECT_FALSE(IsScanRowValid(batch, 0));
+
+    ASSERT_TRUE(cursor->Next(5, &batch));
     EXPECT_EQ(batch.row_id_start, 4);
     EXPECT_EQ(batch.size, 1);
+    EXPECT_FALSE(batch.values.empty());
     EXPECT_TRUE(IsScanRowValid(batch, 0));
     EXPECT_FALSE(cursor->Next(5, &batch));
     EXPECT_EQ(cursor->Position(), 5);
@@ -902,6 +916,85 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
 
     EXPECT_EQ(fx.pin_requests->size(), 1u);
     EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           CellSkipPlanningRunsBeforeAndAfterPinThenBuildsRanges) {
+    ColumnSpec spec{{2, 3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    std::vector<int64_t> metadata_calls;
+    std::vector<int64_t> loaded_calls;
+    auto options = ChunkedColumnInterface::ScanOptions::ForData(0, 7);
+    options.metadata_skip_cell = [&](int64_t cell_id) {
+        metadata_calls.emplace_back(cell_id);
+        EXPECT_TRUE(fx.pin_requests->empty());
+        return cell_id == 1;
+    };
+    options.loaded_skip_cell = [&](int64_t cell_id) {
+        loaded_calls.emplace_back(cell_id);
+        EXPECT_EQ(fx.pin_requests->size(), 1u);
+        EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0, 2}));
+        return cell_id == 2;
+    };
+
+    auto prepared = fx.column->PrepareScan(nullptr, options);
+    ASSERT_NE(prepared, nullptr);
+    EXPECT_EQ(metadata_calls, (std::vector<int64_t>{0, 1, 2}));
+    EXPECT_EQ(loaded_calls, (std::vector<int64_t>{0, 2}));
+    ASSERT_EQ(prepared->Plan().skip_ranges.size(), 1u);
+    EXPECT_EQ(prepared->Plan().skip_ranges[0].start, 2);
+    EXPECT_EQ(prepared->Plan().skip_ranges[0].end, 7);
+
+    auto cursor = prepared->Open(prepared->Plan(),
+                                 ChunkedColumnInterface::ScanProjection::Data);
+    ASSERT_NE(cursor, nullptr);
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(7, &batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_FALSE(batch.values.empty());
+    EXPECT_FALSE(cursor->Next(7, &batch));
+    EXPECT_EQ(cursor->Position(), 7);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           NullableSkippedCellsStayPinnedAndReturnValidityOnlyBatches) {
+    ColumnSpec spec{{2, 2},
+                    {{true, true}, {false, true}},
+                    /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    spec.dense_nullable_payload = true;
+    auto fx = TypeParam::Create(spec);
+
+    auto options = ChunkedColumnInterface::ScanOptions::ForData(0, 4);
+    options.metadata_skip_cell = [](int64_t cell_id) { return cell_id == 1; };
+    auto prepared = fx.column->PrepareScan(nullptr, options);
+    ASSERT_NE(prepared, nullptr);
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0, 1}));
+    ASSERT_EQ(prepared->Plan().skip_ranges.size(), 1u);
+    EXPECT_EQ(prepared->Plan().skip_ranges[0].start, 2);
+    EXPECT_EQ(prepared->Plan().skip_ranges[0].end, 4);
+
+    auto cursor = prepared->Open(prepared->Plan(),
+                                 ChunkedColumnInterface::ScanProjection::Data);
+    ASSERT_NE(cursor, nullptr);
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(4, &batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_FALSE(batch.values.empty());
+
+    ASSERT_TRUE(cursor->Next(4, &batch));
+    EXPECT_EQ(batch.row_id_start, 2);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_TRUE(batch.values.empty());
+    EXPECT_FALSE(IsScanRowValid(batch, 0));
+    EXPECT_TRUE(IsScanRowValid(batch, 1));
+    EXPECT_FALSE(cursor->Next(4, &batch));
+    EXPECT_EQ(cursor->Position(), 4);
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,
@@ -930,14 +1023,7 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
 TEST(ChunkedColumnInterfaceTest,
      VarcharPreparedScanStopsAtLeadingMiddleAndTrailingSkipRanges) {
     const std::vector<std::string> values{
-        "alpha",
-        "beta",
-        "gamma",
-        "delta",
-        "epsilon",
-        "zeta",
-        "eta",
-        "theta"};
+        "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"};
     auto buffer = BuildStringChunkBuffer(values);
     auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
     std::vector<std::unique_ptr<Chunk>> chunks;
@@ -958,8 +1044,7 @@ TEST(ChunkedColumnInterfaceTest,
                          std::nullopt);
     auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
         std::move(translator), nullptr);
-    auto pin_requests =
-        std::make_shared<std::vector<std::vector<int64_t>>>();
+    auto pin_requests = std::make_shared<std::vector<std::vector<int64_t>>>();
     auto column = std::make_shared<ScanCountingStringColumn>(
         std::move(slot), field_meta, pin_requests);
 

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -927,6 +927,82 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_EQ(fx.pin_requests->size(), 1u);
 }
 
+TEST(ChunkedColumnInterfaceTest,
+     VarcharPreparedScanStopsAtLeadingMiddleAndTrailingSkipRanges) {
+    const std::vector<std::string> values{
+        "alpha",
+        "beta",
+        "gamma",
+        "delta",
+        "epsilon",
+        "zeta",
+        "eta",
+        "theta"};
+    auto buffer = BuildStringChunkBuffer(values);
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    chunks.push_back(
+        std::make_unique<StringChunk>(static_cast<int32_t>(values.size()),
+                                      buffer.data(),
+                                      buffer.size(),
+                                      /*nullable=*/false,
+                                      std::move(guard)));
+    auto translator = std::make_unique<TestChunkTranslator>(
+        std::vector<int64_t>{static_cast<int64_t>(values.size())},
+        "varchar_skip_ranges",
+        std::move(chunks));
+    FieldMeta field_meta(FieldName("varchar"),
+                         FieldId(kTestFieldId),
+                         DataType::VARCHAR,
+                         /*nullable=*/false,
+                         std::nullopt);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+        std::move(translator), nullptr);
+    auto pin_requests =
+        std::make_shared<std::vector<std::vector<int64_t>>>();
+    auto column = std::make_shared<ScanCountingStringColumn>(
+        std::move(slot), field_meta, pin_requests);
+
+    auto prepared = column->PrepareScan(
+        nullptr,
+        ChunkedColumnInterface::ScanOptions::ForData(
+            0,
+            static_cast<int64_t>(values.size()),
+            ChunkedColumnInterface::ScanProjection::Data,
+            ChunkedColumnInterface::ScanValueKind::StringView));
+    ASSERT_NE(prepared, nullptr);
+    const auto row_count = static_cast<int64_t>(values.size());
+    auto plan = ChunkedColumnInterface::ScanPlan::Full(0, row_count);
+    plan.skip_ranges = {
+        ChunkedColumnInterface::ScanRowRange{0, 1},
+        ChunkedColumnInterface::ScanRowRange{3, 5},
+        ChunkedColumnInterface::ScanRowRange{7, 8},
+    };
+    auto cursor =
+        prepared->Open(plan, ChunkedColumnInterface::ScanProjection::Data);
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(row_count, &batch));
+    EXPECT_EQ(batch.row_id_start, 1);
+    EXPECT_EQ(batch.size, 2);
+    const auto* first = batch.values.data_as<std::string_view>();
+    EXPECT_EQ(first[0], "beta");
+    EXPECT_EQ(first[1], "gamma");
+
+    ASSERT_TRUE(cursor->Next(row_count, &batch));
+    EXPECT_EQ(batch.row_id_start, 5);
+    EXPECT_EQ(batch.size, 2);
+    const auto* second = batch.values.data_as<std::string_view>();
+    EXPECT_EQ(second[0], "zeta");
+    EXPECT_EQ(second[1], "eta");
+
+    EXPECT_FALSE(cursor->Next(row_count, &batch));
+    EXPECT_EQ(cursor->Position(), row_count);
+    ASSERT_EQ(pin_requests->size(), 1u);
+    EXPECT_EQ(pin_requests->front(), (std::vector<int64_t>{0}));
+}
+
 TYPED_TEST(ChunkedColumnInterfaceTest,
            NonNullableNoDataScanDoesNotFetchPayload) {
     ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -968,9 +968,6 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     ASSERT_TRUE(cursor->Next(5, &batch));
     EXPECT_EQ(batch.row_id_start, 1);
     EXPECT_EQ(batch.size, 1);
-    ASSERT_TRUE(cursor->Next(5, &batch));
-    EXPECT_EQ(batch.row_id_start, 5);
-    EXPECT_EQ(batch.size, 1);
     EXPECT_FALSE(cursor->Next(5, &batch));
     EXPECT_EQ(cursor->Position(), 6);
     EXPECT_EQ(fx.pin_requests->size(), 1u);

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -383,6 +383,27 @@ struct ProxyVectorArrayColumnFactory {
 
 }  // namespace
 
+TEST(ChunkedColumnScanCommonTest, BitmapValidityMaterializesEvaluatorMask) {
+    const std::array<uint8_t, 2> bitmap{0b10101101, 0b00000001};
+    ChunkedColumnInterface::ValidityView validity;
+    validity.encoding = ChunkedColumnInterface::ValidityEncoding::Bitmap;
+    validity.data = bitmap.data();
+    validity.offset = 2;
+    validity.size = 7;
+    validity.nullable = true;
+
+    FixedVector<bool> scratch;
+    const auto* mask = validity.bool_data(scratch);
+    ASSERT_NE(mask, nullptr);
+    ASSERT_EQ(scratch.size(), 7);
+    const std::array<bool, 7> expected{
+        true, true, false, true, false, true, true};
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(mask[i], expected[i]);
+        EXPECT_EQ(validity.IsValid(i), expected[i]);
+    }
+}
+
 template <typename Factory>
 class ChunkedColumnInterfaceTest : public ::testing::Test {};
 
@@ -585,9 +606,10 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
     auto cursor = fx.column->Scan(
         nullptr, ChunkedColumnInterface::ScanOptions::ForData(0, 4));
     ASSERT_NE(cursor, nullptr);
+    EXPECT_EQ(cursor->Position(), 0);
 
     ChunkedColumnInterface::ScanBatch batch;
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(4, &batch));
     EXPECT_EQ(batch.row_id_start, 0);
     EXPECT_EQ(batch.size, 4);
     EXPECT_EQ(batch.values.encoding,
@@ -603,7 +625,8 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
     EXPECT_FALSE(batch.validity.IsValid(1));
     EXPECT_TRUE(batch.validity.IsValid(2));
     EXPECT_TRUE(batch.validity.IsValid(3));
-    EXPECT_FALSE(cursor->Next(&batch));
+    EXPECT_EQ(cursor->Position(), 4);
+    EXPECT_FALSE(cursor->Next(4, &batch));
 }
 
 TYPED_TEST(VectorArrayColumnInterfaceTest,
@@ -615,20 +638,27 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
                         ChunkedColumnInterface::ScanOptions::ForNoData(
                             0,
                             kVectorArrayRows,
-                            ChunkedColumnInterface::ScanValueKind::FixedWidth,
-                            /*max_batch_rows=*/2));
+                            ChunkedColumnInterface::ScanValueKind::FixedWidth));
     ASSERT_NE(cursor, nullptr);
 
     ChunkedColumnInterface::ScanBatch batch;
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(2, &batch));
     EXPECT_TRUE(batch.values.empty());
-    // Validity-only scans do not materialize per-row view wrappers, so the
-    // materialized-data cap must not split their natural chunk batch.
-    EXPECT_EQ(batch.size, kVectorArrayRows);
+    EXPECT_EQ(batch.size, 2);
     EXPECT_TRUE(batch.validity.IsValid(0));
     EXPECT_FALSE(batch.validity.IsValid(1));
-    EXPECT_TRUE(batch.validity.IsValid(2));
-    EXPECT_TRUE(batch.validity.IsValid(3));
+    EXPECT_EQ(cursor->Position(), 2);
+    ASSERT_NE(batch.owner, nullptr);
+    EXPECT_EQ(batch.owner.use_count(), 1);
+
+    ASSERT_TRUE(cursor->Next(2, &batch));
+    EXPECT_EQ(batch.row_id_start, 2);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_TRUE(batch.validity.IsValid(0));
+    EXPECT_TRUE(batch.validity.IsValid(1));
+    ASSERT_NE(batch.owner, nullptr);
+    EXPECT_EQ(batch.owner.use_count(), 1);
+    EXPECT_EQ(cursor->Position(), kVectorArrayRows);
 }
 
 TYPED_TEST(VectorArrayColumnInterfaceTest, DataScanRejectsMismatchedValueKind) {
@@ -661,9 +691,10 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
                             ChunkedColumnInterface::ScanProjection::Data,
                             ChunkedColumnInterface::ScanValueKind::FixedWidth));
     ASSERT_NE(cursor, nullptr);
+    EXPECT_EQ(cursor->Position(), 1);
 
     ChunkedColumnInterface::ScanBatch batch;
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(10, &batch));
     EXPECT_EQ(batch.row_id_start, 1);
     EXPECT_EQ(batch.size, 2);
     ASSERT_FALSE(batch.values.empty());
@@ -672,15 +703,17 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_EQ(batch.values.data_as<int32_t>()[1], 2);
     EXPECT_FALSE(batch.validity.IsValid(0));
     EXPECT_TRUE(batch.validity.IsValid(1));
+    EXPECT_EQ(cursor->Position(), 3);
 
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(10, &batch));
     EXPECT_EQ(batch.row_id_start, 3);
     EXPECT_EQ(batch.size, 2);
     EXPECT_EQ(batch.values.data_as<int32_t>()[1], 4);
     EXPECT_FALSE(batch.validity.IsValid(0));
     EXPECT_TRUE(batch.validity.IsValid(1));
+    EXPECT_EQ(cursor->Position(), 5);
 
-    EXPECT_FALSE(cursor->Next(&batch));
+    EXPECT_FALSE(cursor->Next(10, &batch));
     EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
 }
 
@@ -697,7 +730,7 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     ASSERT_NE(cursor, nullptr);
 
     ChunkedColumnInterface::ScanBatch batch;
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(4, &batch));
     EXPECT_EQ(batch.row_id_start, 0);
     EXPECT_EQ(batch.size, 4);
     EXPECT_TRUE(batch.values.empty());
@@ -705,7 +738,36 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_FALSE(batch.validity.IsValid(1));
     EXPECT_TRUE(batch.validity.IsValid(2));
     EXPECT_FALSE(batch.validity.IsValid(3));
-    EXPECT_FALSE(cursor->Next(&batch));
+    EXPECT_FALSE(cursor->Next(4, &batch));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthDataScanHonorsCallerBatchLimit) {
+    ColumnSpec spec{{5}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor = fx.column->Scan(
+        nullptr, ChunkedColumnInterface::ScanOptions::ForData(1, 4));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_EQ(cursor->Position(), 1);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(2, &batch));
+    EXPECT_EQ(batch.row_id_start, 1);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_EQ(cursor->Position(), 3);
+
+    ASSERT_TRUE(cursor->Next(1, &batch));
+    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_EQ(batch.size, 1);
+    EXPECT_EQ(cursor->Position(), 4);
+
+    ASSERT_TRUE(cursor->Next(2, &batch));
+    EXPECT_EQ(batch.row_id_start, 4);
+    EXPECT_EQ(batch.size, 1);
+    EXPECT_EQ(cursor->Position(), 5);
+    EXPECT_FALSE(cursor->Next(2, &batch));
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,
@@ -720,18 +782,20 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     EXPECT_TRUE(fx.fetched->empty());
 
     ChunkedColumnInterface::ScanBatch batch;
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(5, &batch));
     EXPECT_EQ(batch.size, 3);
     EXPECT_TRUE(batch.values.empty());
-    EXPECT_TRUE(batch.validity.all_valid);
+    EXPECT_EQ(batch.validity.encoding,
+              ChunkedColumnInterface::ValidityEncoding::AllValid);
     EXPECT_TRUE(fx.fetched->empty());
 
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(5, &batch));
     EXPECT_EQ(batch.size, 2);
     EXPECT_TRUE(batch.values.empty());
-    EXPECT_TRUE(batch.validity.all_valid);
+    EXPECT_EQ(batch.validity.encoding,
+              ChunkedColumnInterface::ValidityEncoding::AllValid);
     EXPECT_TRUE(fx.fetched->empty());
-    EXPECT_FALSE(cursor->Next(&batch));
+    EXPECT_FALSE(cursor->Next(5, &batch));
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,
@@ -745,10 +809,9 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     ASSERT_NE(cursor, nullptr);
 
     ChunkedColumnInterface::ScanBatch batch;
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(3, &batch));
     EXPECT_EQ(batch.validity.encoding,
               ChunkedColumnInterface::ValidityEncoding::AllValid);
-    EXPECT_TRUE(batch.validity.all_valid);
     for (int64_t i = 0; i < batch.size; ++i) {
         EXPECT_TRUE(batch.validity.IsValid(i));
     }
@@ -804,7 +867,7 @@ TEST(ChunkedColumnInterfaceTest, VarcharPrimaryKeyUsesStringViewScanCursor) {
     ASSERT_NE(cursor, nullptr);
 
     ChunkedColumnInterface::ScanBatch batch;
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(static_cast<int64_t>(values.size()), &batch));
     EXPECT_EQ(batch.values.encoding,
               ChunkedColumnInterface::ValueEncoding::StringView);
     EXPECT_EQ(batch.values.kind,
@@ -814,7 +877,7 @@ TEST(ChunkedColumnInterfaceTest, VarcharPrimaryKeyUsesStringViewScanCursor) {
     for (size_t i = 0; i < values.size(); ++i) {
         EXPECT_EQ(scanned[i], values[i]);
     }
-    EXPECT_FALSE(cursor->Next(&batch));
+    EXPECT_FALSE(cursor->Next(static_cast<int64_t>(values.size()), &batch));
 }
 
 TEST(ChunkedColumnInterfaceTest,
@@ -851,15 +914,14 @@ TEST(ChunkedColumnInterfaceTest,
                          0,
                          static_cast<int64_t>(values.size()),
                          ChunkedColumnInterface::ScanProjection::Data,
-                         ChunkedColumnInterface::ScanValueKind::StringView,
-                         kMaxBatchRows));
+                         ChunkedColumnInterface::ScanValueKind::StringView));
     ASSERT_NE(cursor, nullptr);
 
     std::vector<std::string> scanned;
     std::vector<int64_t> batch_starts;
     std::vector<int64_t> batch_sizes;
     ChunkedColumnInterface::ScanBatch batch;
-    while (cursor->Next(&batch)) {
+    while (cursor->Next(kMaxBatchRows, &batch)) {
         batch_starts.emplace_back(batch.row_id_start);
         batch_sizes.emplace_back(batch.size);
         EXPECT_LE(batch.size, kMaxBatchRows);

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -851,9 +851,12 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,
-           PreparedScanSeeksWithoutRepinningChunks) {
-    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+           PreparedScanSkipsPlannedRangesAndReusesPinsForValidity) {
+    ColumnSpec spec{{3, 2},
+                    {{true, false, true}, {false, true}},
+                    /*nullable=*/true};
     spec.data_type = DataType::INT32;
+    spec.dense_nullable_payload = true;
     auto fx = TypeParam::Create(spec);
 
     auto prepared = fx.column->PrepareScan(
@@ -862,26 +865,66 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
     ASSERT_EQ(fx.pin_requests->size(), 1u);
     EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0, 1}));
 
-    auto first = prepared->Seek(0);
-    ASSERT_NE(first, nullptr);
+    auto plan = ChunkedColumnInterface::ScanPlan::Full(0, 5);
+    plan.skip_ranges = {
+        ChunkedColumnInterface::ScanRowRange{1, 4},
+    };
+    auto cursor =
+        prepared->Open(plan, ChunkedColumnInterface::ScanProjection::Data);
+    ASSERT_NE(cursor, nullptr);
     ChunkedColumnInterface::ScanBatch batch;
-    ASSERT_TRUE(first->Next(2, &batch));
+    ASSERT_TRUE(cursor->Next(5, &batch));
     EXPECT_EQ(batch.row_id_start, 0);
-    EXPECT_EQ(batch.size, 2);
-    first.reset();
-
-    auto resumed = prepared->Seek(2);
-    ASSERT_NE(resumed, nullptr);
-    ASSERT_TRUE(resumed->Next(2, &batch));
-    EXPECT_EQ(batch.row_id_start, 2);
     EXPECT_EQ(batch.size, 1);
-    ASSERT_TRUE(resumed->Next(2, &batch));
-    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+
+    ASSERT_TRUE(cursor->Next(5, &batch));
+    EXPECT_EQ(batch.row_id_start, 4);
+    EXPECT_EQ(batch.size, 1);
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+    EXPECT_FALSE(cursor->Next(5, &batch));
+    EXPECT_EQ(cursor->Position(), 5);
+
+    auto validity_cursor =
+        prepared->Open(ChunkedColumnInterface::ScanPlan::Full(1, 3),
+                       ChunkedColumnInterface::ScanProjection::NoData);
+    ASSERT_NE(validity_cursor, nullptr);
+    ASSERT_TRUE(validity_cursor->Next(5, &batch));
+    EXPECT_EQ(batch.row_id_start, 1);
     EXPECT_EQ(batch.size, 2);
-    EXPECT_FALSE(resumed->Next(2, &batch));
+    EXPECT_FALSE(IsScanRowValid(batch, 0));
+    EXPECT_TRUE(IsScanRowValid(batch, 1));
+    ASSERT_TRUE(validity_cursor->Next(5, &batch));
+    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_EQ(batch.size, 1);
+    EXPECT_FALSE(IsScanRowValid(batch, 0));
+    EXPECT_FALSE(validity_cursor->Next(5, &batch));
 
     EXPECT_EQ(fx.pin_requests->size(), 1u);
     EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           PreparedScanAllSkippedAdvancesWithoutReturningData) {
+    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto prepared = fx.column->PrepareScan(
+        nullptr, ChunkedColumnInterface::ScanOptions::ForData(0, 5));
+    ASSERT_NE(prepared, nullptr);
+    auto plan = ChunkedColumnInterface::ScanPlan::Full(0, 5);
+    plan.skip_ranges = {
+        ChunkedColumnInterface::ScanRowRange{0, 5},
+    };
+    auto cursor =
+        prepared->Open(plan, ChunkedColumnInterface::ScanProjection::Data);
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    EXPECT_FALSE(cursor->Next(5, &batch));
+    EXPECT_EQ(cursor->Position(), 5);
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <iterator>
 #include <memory>
+#include <numeric>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -29,6 +30,7 @@
 #include "common/Chunk.h"
 #include "common/GroupChunk.h"
 #include "mmap/ChunkedColumn.h"
+#include "mmap/ChunkedColumnFilter.h"
 #include "mmap/ChunkedColumnGroup.h"
 #include "test_utils/cachinglayer_test_utils.h"
 
@@ -44,15 +46,41 @@ constexpr int64_t kVectorArrayDim = 2;
 struct ColumnFixture {
     std::shared_ptr<ChunkedColumnInterface> column;
     std::shared_ptr<std::set<cachinglayer::cid_t>> fetched;
+    std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests;
     // Keeps chunk data buffers alive for the column's lifetime.
     std::shared_ptr<void> buffer_holder;
+    // Proxy columns delegate cache ownership to their shared group.
+    std::shared_ptr<ChunkedColumnGroup> group;
 };
 
 struct ColumnSpec {
     std::vector<int64_t> rows_per_chunk;
     std::vector<std::vector<bool>> valid_patterns;  // empty => all valid
     bool nullable{true};
+    DataType data_type{DataType::VECTOR_INT8};
+    // Primitive ChunkWriter keeps one payload slot per logical row. Some
+    // positional-access tests intentionally exercise the legacy compact
+    // fixture, while scan tests use the production dense layout.
+    bool dense_nullable_payload{false};
 };
+
+FieldMeta
+MakeTestFieldMeta(const ColumnSpec& spec) {
+    if (IsVectorDataType(spec.data_type)) {
+        return FieldMeta(FieldName("t"),
+                         FieldId(kTestFieldId),
+                         spec.data_type,
+                         kElementSize,
+                         std::nullopt,
+                         spec.nullable,
+                         std::nullopt);
+    }
+    return FieldMeta(FieldName("t"),
+                     FieldId(kTestFieldId),
+                     spec.data_type,
+                     spec.nullable,
+                     std::nullopt);
+}
 
 struct VectorArrayColumnFixture {
     std::shared_ptr<ChunkedColumnInterface> column;
@@ -63,7 +91,8 @@ std::vector<char>
 BuildChunkBuffer(int64_t row_num,
                  const std::vector<bool>* pattern,
                  bool nullable,
-                 int64_t start_logical_offset) {
+                 int64_t start_logical_offset,
+                 bool dense_nullable_payload = false) {
     const int32_t bitmap_bytes = nullable ? (row_num + 7) / 8 : 0;
     std::vector<char> buf(bitmap_bytes + row_num * kElementSize, 0);
     int64_t physical_offset = 0;
@@ -72,13 +101,17 @@ BuildChunkBuffer(int64_t row_num,
             const bool v = pattern ? (*pattern)[j] : true;
             if (v) {
                 buf[j >> 3] |= (1 << (j & 0x07));
-                const int32_t value = start_logical_offset + j;
+            }
+            const int32_t value = start_logical_offset + j;
+            const auto value_offset =
+                dense_nullable_payload ? j : physical_offset;
+            if (dense_nullable_payload || v) {
                 std::memcpy(
-                    buf.data() + bitmap_bytes + physical_offset * kElementSize,
+                    buf.data() + bitmap_bytes + value_offset * kElementSize,
                     &value,
                     sizeof(value));
-                ++physical_offset;
             }
+            physical_offset += v ? 1 : 0;
         }
     } else {
         for (int64_t j = 0; j < row_num; ++j) {
@@ -145,6 +178,47 @@ MakeVectorArrayChunk(char* data, size_t size) {
                                               /*nullable=*/true);
 }
 
+std::vector<char>
+BuildNullableEmptyArrayChunkBuffer() {
+    constexpr int64_t row_count = 2;
+    constexpr size_t bitmap_bytes = 1;
+    constexpr size_t header_entries = row_count * 2 + 1;
+    constexpr size_t header_bytes = header_entries * sizeof(uint32_t);
+    constexpr uint32_t payload_offset = bitmap_bytes + header_bytes;
+
+    // Keep one padding byte so an empty ArrayView has a stable, non-null data
+    // pointer. Row 0 is a valid empty INT64 array; row 1 is null.
+    std::vector<char> buffer(payload_offset + 1, 0);
+    buffer[0] = 0b00000001;
+    const std::array<uint32_t, header_entries> header{
+        payload_offset, 0, payload_offset, 0, payload_offset};
+    std::memcpy(buffer.data() + bitmap_bytes,
+                header.data(),
+                header.size() * sizeof(uint32_t));
+    return buffer;
+}
+
+std::vector<char>
+BuildStringChunkBuffer(const std::vector<std::string>& values) {
+    const auto header_bytes = sizeof(uint32_t) * (values.size() + 1);
+    size_t payload_bytes = 0;
+    for (const auto& value : values) {
+        payload_bytes += value.size();
+    }
+
+    std::vector<char> buffer(header_bytes + payload_bytes, 0);
+    auto* offsets = reinterpret_cast<uint32_t*>(buffer.data());
+    uint32_t next_offset = static_cast<uint32_t>(header_bytes);
+    offsets[0] = next_offset;
+    for (size_t i = 0; i < values.size(); ++i) {
+        std::memcpy(
+            buffer.data() + next_offset, values[i].data(), values[i].size());
+        next_offset += static_cast<uint32_t>(values[i].size());
+        offsets[i + 1] = next_offset;
+    }
+    return buffer;
+}
+
 class CountingChunkTranslator : public TestChunkTranslator {
  public:
     CountingChunkTranslator(
@@ -196,6 +270,136 @@ class CountingGroupChunkTranslator : public TestGroupChunkTranslator {
     std::shared_ptr<std::set<cachinglayer::cid_t>> fetched_;
 };
 
+class ScanCountingChunkedColumn : public ChunkedColumn {
+ public:
+    ScanCountingChunkedColumn(
+        std::shared_ptr<CacheSlot<Chunk>> slot,
+        const FieldMeta& field_meta,
+        std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests)
+        : ChunkedColumn(std::move(slot), field_meta),
+          pin_requests_(std::move(pin_requests)) {
+    }
+
+    PinWrapper<Chunk*>
+    GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        pin_requests_->emplace_back(std::vector<int64_t>{chunk_id});
+        return ChunkedColumn::GetChunk(op_ctx, chunk_id);
+    }
+
+    TakeCellPin
+    MakeTakeCellPin(milvus::OpContext* op_ctx) const override {
+        auto pin_cell = ChunkedColumn::MakeTakeCellPin(op_ctx);
+        auto pin_requests = pin_requests_;
+        return [pin_cell = std::move(pin_cell),
+                pin_requests = std::move(pin_requests)](int64_t chunk_id) {
+            pin_requests->emplace_back(std::vector<int64_t>{chunk_id});
+            return pin_cell(chunk_id);
+        };
+    }
+
+ private:
+    std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests_;
+};
+
+class ScanCountingProxyChunkColumn : public ProxyChunkColumn {
+ public:
+    ScanCountingProxyChunkColumn(
+        std::shared_ptr<ChunkedColumnGroup> group,
+        FieldId field_id,
+        const FieldMeta& field_meta,
+        std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests)
+        : ProxyChunkColumn(std::move(group), field_id, field_meta),
+          pin_requests_(std::move(pin_requests)) {
+    }
+
+    PinWrapper<Chunk*>
+    GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        pin_requests_->emplace_back(std::vector<int64_t>{chunk_id});
+        return ProxyChunkColumn::GetChunk(op_ctx, chunk_id);
+    }
+
+    TakeCellPin
+    MakeTakeCellPin(milvus::OpContext* op_ctx) const override {
+        auto pin_cell = ProxyChunkColumn::MakeTakeCellPin(op_ctx);
+        auto pin_requests = pin_requests_;
+        return [pin_cell = std::move(pin_cell),
+                pin_requests = std::move(pin_requests)](int64_t chunk_id) {
+            pin_requests->emplace_back(std::vector<int64_t>{chunk_id});
+            return pin_cell(chunk_id);
+        };
+    }
+
+ private:
+    std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests_;
+};
+
+class ScanCountingStringColumn : public ChunkedVariableColumn<std::string> {
+ public:
+    ScanCountingStringColumn(
+        std::shared_ptr<cachinglayer::CacheSlot<Chunk>> slot,
+        const FieldMeta& field_meta,
+        std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests)
+        : ChunkedVariableColumn<std::string>(std::move(slot), field_meta),
+          pin_requests_(std::move(pin_requests)) {
+    }
+
+    PinWrapper<Chunk*>
+    GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        pin_requests_->emplace_back(std::vector<int64_t>{chunk_id});
+        return ChunkedVariableColumn<std::string>::GetChunk(op_ctx, chunk_id);
+    }
+
+    TakeCellPin
+    MakeTakeCellPin(milvus::OpContext* op_ctx) const override {
+        auto pin_cell =
+            ChunkedVariableColumn<std::string>::MakeTakeCellPin(op_ctx);
+        auto pin_requests = pin_requests_;
+        return [pin_cell = std::move(pin_cell),
+                pin_requests = std::move(pin_requests)](int64_t chunk_id) {
+            pin_requests->emplace_back(std::vector<int64_t>{chunk_id});
+            return pin_cell(chunk_id);
+        };
+    }
+
+ private:
+    std::shared_ptr<std::vector<std::vector<int64_t>>> pin_requests_;
+};
+
+ColumnFixture
+CreateNullableEmptyArrayColumn() {
+    auto buffers = std::make_shared<std::vector<std::vector<char>>>(1);
+    (*buffers)[0] = BuildNullableEmptyArrayChunkBuffer();
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    chunks.emplace_back(std::make_unique<ArrayChunk>(2,
+                                                     (*buffers)[0].data(),
+                                                     (*buffers)[0].size(),
+                                                     DataType::INT64,
+                                                     /*nullable=*/true,
+                                                     guard));
+
+    auto fetched = std::make_shared<std::set<cachinglayer::cid_t>>();
+    auto translator =
+        std::make_unique<CountingChunkTranslator>(std::vector<int64_t>{2},
+                                                  "cc_empty_array_iface",
+                                                  std::move(chunks),
+                                                  fetched);
+    FieldMeta field_meta(FieldName("array"),
+                         FieldId(kTestFieldId),
+                         DataType::ARRAY,
+                         DataType::INT64,
+                         /*nullable=*/true,
+                         std::nullopt);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+        std::move(translator), nullptr);
+    auto column =
+        MakeChunkedColumnBase(DataType::ARRAY, std::move(slot), field_meta);
+    return {std::move(column),
+            std::move(fetched),
+            std::make_shared<std::vector<std::vector<int64_t>>>(),
+            std::static_pointer_cast<void>(buffers)};
+}
+
 struct ChunkedColumnFactory {
     static ColumnFixture
     Create(const ColumnSpec& spec) {
@@ -209,7 +413,8 @@ struct ChunkedColumnFactory {
                 spec.rows_per_chunk[i],
                 spec.valid_patterns.empty() ? nullptr : &spec.valid_patterns[i],
                 spec.nullable,
-                start_logical_offset);
+                start_logical_offset,
+                spec.dense_nullable_payload);
             chunks.push_back(MakeFixedChunk(spec.rows_per_chunk[i],
                                             spec.nullable,
                                             (*buffers)[i].data(),
@@ -219,18 +424,16 @@ struct ChunkedColumnFactory {
         auto fetched = std::make_shared<std::set<cachinglayer::cid_t>>();
         auto translator = std::make_unique<CountingChunkTranslator>(
             spec.rows_per_chunk, "cc_iface", std::move(chunks), fetched);
-        FieldMeta fm(FieldName("t"),
-                     FieldId(kTestFieldId),
-                     DataType::VECTOR_INT8,
-                     kElementSize,
-                     std::nullopt,
-                     spec.nullable,
-                     std::nullopt);
+        auto fm = MakeTestFieldMeta(spec);
         auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
             std::move(translator), nullptr);
-        auto column = std::make_shared<ChunkedColumn>(std::move(slot), fm);
+        auto pin_requests =
+            std::make_shared<std::vector<std::vector<int64_t>>>();
+        auto column = std::make_shared<ScanCountingChunkedColumn>(
+            std::move(slot), fm, pin_requests);
         return {std::static_pointer_cast<ChunkedColumnInterface>(column),
                 std::move(fetched),
+                std::move(pin_requests),
                 std::static_pointer_cast<void>(buffers)};
     }
 };
@@ -248,7 +451,8 @@ struct ProxyChunkColumnFactory {
                 spec.rows_per_chunk[i],
                 spec.valid_patterns.empty() ? nullptr : &spec.valid_patterns[i],
                 spec.nullable,
-                start_logical_offset);
+                start_logical_offset,
+                spec.dense_nullable_payload);
             std::shared_ptr<Chunk> chunk =
                 MakeFixedChunk(spec.rows_per_chunk[i],
                                spec.nullable,
@@ -268,18 +472,16 @@ struct ProxyChunkColumnFactory {
             fetched);
         auto group =
             std::make_shared<ChunkedColumnGroup>(std::move(translator));
-        FieldMeta fm(FieldName("t"),
-                     FieldId(kTestFieldId),
-                     DataType::VECTOR_INT8,
-                     kElementSize,
-                     std::nullopt,
-                     spec.nullable,
-                     std::nullopt);
-        auto column = std::make_shared<ProxyChunkColumn>(
-            group, FieldId(kTestFieldId), fm);
+        auto fm = MakeTestFieldMeta(spec);
+        auto pin_requests =
+            std::make_shared<std::vector<std::vector<int64_t>>>();
+        auto column = std::make_shared<ScanCountingProxyChunkColumn>(
+            group, FieldId(kTestFieldId), fm, pin_requests);
         return {std::static_pointer_cast<ChunkedColumnInterface>(column),
                 std::move(fetched),
-                std::static_pointer_cast<void>(buffers)};
+                std::move(pin_requests),
+                std::static_pointer_cast<void>(buffers),
+                std::move(group)};
     }
 };
 
@@ -342,6 +544,11 @@ struct ProxyVectorArrayColumnFactory {
                 std::static_pointer_cast<void>(buffers)};
     }
 };
+
+bool
+IsScanRowValid(const ChunkedColumnInterface::ScanBatch& batch, int64_t offset) {
+    return !batch.validity || batch.validity[offset];
+}
 
 }  // namespace
 
@@ -538,6 +745,1145 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
         fx.column->BulkVectorArrayAt(
             nullptr, [](VectorFieldProto&&, size_t) {}, null_offset, 1),
         std::exception);
+}
+
+TYPED_TEST(VectorArrayColumnInterfaceTest,
+           DataScanReturnsLogicalVectorArrayViews) {
+    auto fx = TypeParam::Create();
+
+    auto cursor = fx.column->Scan(
+        nullptr,
+        ChunkedColumnInterface::ScanOptions::ForData(
+            0, ChunkedColumnInterface::TargetType::VectorArrayView));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        4, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 4);
+    EXPECT_EQ(batch.values.target_type,
+              ChunkedColumnInterface::TargetType::VectorArrayView);
+
+    const auto* views = batch.values.data_as<VectorArrayView>();
+    EXPECT_EQ(views[0].length(), 1);
+    EXPECT_EQ(views[2].length(), 0);
+    EXPECT_EQ(views[3].length(), 2);
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+    EXPECT_FALSE(IsScanRowValid(batch, 1));
+    EXPECT_TRUE(IsScanRowValid(batch, 2));
+    EXPECT_TRUE(IsScanRowValid(batch, 3));
+}
+
+TYPED_TEST(VectorArrayColumnInterfaceTest,
+           ValidityOnlyScanUsesColumnTypeWithoutBuildingValues) {
+    auto fx = TypeParam::Create();
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0, ChunkedColumnInterface::TargetType::None));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::ValidityOnly, &batch));
+    EXPECT_TRUE(batch.values.empty());
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+    EXPECT_FALSE(IsScanRowValid(batch, 1));
+    ASSERT_NE(batch.owner, nullptr);
+
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::ValidityOnly, &batch));
+    EXPECT_EQ(batch.row_id_start, 2);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+    EXPECT_TRUE(IsScanRowValid(batch, 1));
+    ASSERT_NE(batch.owner, nullptr);
+}
+
+TYPED_TEST(VectorArrayColumnInterfaceTest,
+           DataScanRejectsMismatchedTargetType) {
+    auto fx = TypeParam::Create();
+
+    EXPECT_THROW(
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0, ChunkedColumnInterface::TargetType::Int32)),
+        std::exception);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthDataScanReturnsNaturalChunkBatches) {
+    ColumnSpec spec{{3, 2},
+                    {{true, false, true}, {false, true}},
+                    /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    spec.dense_nullable_payload = true;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            1, ChunkedColumnInterface::TargetType::Int32));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_TRUE(fx.pin_requests->empty());
+    EXPECT_TRUE(fx.fetched->empty());
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        4, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 1);
+    EXPECT_EQ(batch.size, 2);
+    ASSERT_FALSE(batch.values.empty());
+    EXPECT_EQ(batch.values.target_type,
+              ChunkedColumnInterface::TargetType::Int32);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[1], 2);
+    EXPECT_FALSE(IsScanRowValid(batch, 0));
+    EXPECT_TRUE(IsScanRowValid(batch, 1));
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[1], 4);
+    EXPECT_FALSE(IsScanRowValid(batch, 0));
+    EXPECT_TRUE(IsScanRowValid(batch, 1));
+
+    EXPECT_EQ(fx.pin_requests->size(), 2u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{0}));
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{1}));
+    EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, PrefetchOptionBatchWarmsRemainingCells) {
+    ColumnSpec spec{{3, 2},
+                    {{true, false, true}, {false, true}},
+                    /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    spec.dense_nullable_payload = true;
+    auto fx = TypeParam::Create(spec);
+
+    // Without prefetch, creation loads nothing.
+    auto plain =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0, ChunkedColumnInterface::TargetType::Int32));
+    ASSERT_NE(plain, nullptr);
+    EXPECT_TRUE(fx.fetched->empty());
+
+    // With prefetch, creation batch-warms every remaining cell.
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0,
+                            ChunkedColumnInterface::TargetType::Int32,
+                            ChunkedColumnInterface::ScanPinPolicy::ResultOwned,
+                            /*prefetch=*/true));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
+    // Warmup loads cells but does not retain pins; reads still pin per Cell.
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        5, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 3);
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0}));
+
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_EQ(fx.pin_requests->size(), 2u);
+    EXPECT_EQ(fx.pin_requests->back(), (std::vector<int64_t>{1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           PrefetchRetainsFilterDecisionsAndWarmsNullableSkippedCells) {
+    auto make_filter = [](const std::shared_ptr<std::vector<int>>& decisions) {
+        return std::make_shared<const detail::ColumnFilter>(
+            detail::ColumnFilter::MetricsSource::PreloadedStatistics,
+            [decisions](int64_t cell_id) {
+                ++(*decisions)[cell_id];
+                return cell_id == 0;
+            });
+    };
+
+    {
+        ColumnSpec spec{{2, 2}, {}, /*nullable=*/false};
+        spec.data_type = DataType::INT32;
+        auto fx = TypeParam::Create(spec);
+        auto decisions = std::make_shared<std::vector<int>>(2, 0);
+        auto options = ChunkedColumnInterface::ScanOptions::ForData(
+            0,
+            ChunkedColumnInterface::TargetType::Int32,
+            ChunkedColumnInterface::ScanPinPolicy::ResultOwned,
+            /*prefetch=*/true);
+        options.filter = make_filter(decisions);
+
+        auto cursor = fx.column->Scan(nullptr, options);
+        ASSERT_NE(cursor, nullptr);
+        EXPECT_EQ(*decisions, (std::vector<int>{1, 1}));
+        EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{1}));
+
+        ChunkedColumnInterface::ScanBatch batch;
+        ASSERT_TRUE(cursor->Next(
+            4, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+        EXPECT_TRUE(batch.data_skipped);
+        ASSERT_TRUE(cursor->Next(
+            2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+        EXPECT_FALSE(batch.data_skipped);
+        EXPECT_EQ(*decisions, (std::vector<int>{1, 1}));
+    }
+
+    {
+        ColumnSpec spec{{2, 2},
+                        {{false, true}, {true, true}},
+                        /*nullable=*/true};
+        spec.data_type = DataType::INT32;
+        spec.dense_nullable_payload = true;
+        auto fx = TypeParam::Create(spec);
+        auto decisions = std::make_shared<std::vector<int>>(2, 0);
+        auto options = ChunkedColumnInterface::ScanOptions::ForData(
+            0,
+            ChunkedColumnInterface::TargetType::Int32,
+            ChunkedColumnInterface::ScanPinPolicy::ResultOwned,
+            /*prefetch=*/true);
+        options.filter = make_filter(decisions);
+
+        auto cursor = fx.column->Scan(nullptr, options);
+        ASSERT_NE(cursor, nullptr);
+        EXPECT_EQ(*decisions, (std::vector<int>{1, 1}));
+        EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 1}));
+
+        ChunkedColumnInterface::ScanBatch batch;
+        ASSERT_TRUE(cursor->Next(
+            4, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+        EXPECT_TRUE(batch.data_skipped);
+        EXPECT_FALSE(IsScanRowValid(batch, 0));
+        EXPECT_TRUE(IsScanRowValid(batch, 1));
+        EXPECT_EQ(*decisions, (std::vector<int>{1, 1}));
+    }
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           ScanNextClampsLengthToRemainingSegmentRows) {
+    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            4, ChunkedColumnInterface::TargetType::Int32));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        1024, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 4);
+    EXPECT_EQ(batch.size, 1);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[0], 4);
+    EXPECT_EQ(cursor->Position(), 5);
+    EXPECT_FALSE(cursor->Next(
+        1024, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, PrefetchOptionSkipsZeroRowCells) {
+    ColumnSpec spec{{2, 0, 2},
+                    {{true, true}, {}, {true, true}},
+                    /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0,
+                            ChunkedColumnInterface::TargetType::Int32,
+                            ChunkedColumnInterface::ScanPinPolicy::ResultOwned,
+                            /*prefetch=*/true));
+    ASSERT_NE(cursor, nullptr);
+    // Only non-empty remaining cells are warmed; the zero-row cell is skipped.
+    EXPECT_EQ(*fx.fetched, (std::set<cachinglayer::cid_t>{0, 2}));
+    EXPECT_TRUE(fx.pin_requests->empty());
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthValidityOnlyScanReturnsOnlyValidity) {
+    ColumnSpec spec{{4},
+                    {{true, false, true, false}},
+                    /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0, ChunkedColumnInterface::TargetType::None));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        4, ChunkedColumnInterface::ScanReadMode::ValidityOnly, &batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 4);
+    EXPECT_TRUE(batch.values.empty());
+    EXPECT_TRUE(IsScanRowValid(batch, 0));
+    EXPECT_FALSE(IsScanRowValid(batch, 1));
+    EXPECT_TRUE(IsScanRowValid(batch, 2));
+    EXPECT_FALSE(IsScanRowValid(batch, 3));
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthDataScanPinIsOwnedByResultByDefault) {
+    ColumnSpec spec{{5}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            1, ChunkedColumnInterface::TargetType::Int32));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 1);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_NE(batch.owner, nullptr);
+
+    ASSERT_TRUE(cursor->Next(
+        1, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_EQ(batch.size, 1);
+
+    ASSERT_TRUE(cursor->Next(
+        1, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 4);
+    EXPECT_EQ(batch.size, 1);
+    EXPECT_EQ(fx.pin_requests->size(), 3u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{0}));
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{0}));
+    EXPECT_EQ((*fx.pin_requests)[2], (std::vector<int64_t>{0}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthDataScanPinCanBeOwnedByCursor) {
+    ColumnSpec spec{{5}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor = fx.column->Scan(
+        nullptr,
+        ChunkedColumnInterface::ScanOptions::ForData(
+            0,
+            ChunkedColumnInterface::TargetType::Int32,
+            ChunkedColumnInterface::ScanPinPolicy::CursorOwned));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.owner, nullptr);
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0}));
+
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
+
+    ASSERT_TRUE(cursor->Next(
+        1, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(fx.pin_requests->size(), 1u);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           CursorOwnedScanReleasesPreviousPinForSkippedCell) {
+    ColumnSpec spec{{2, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+    auto filter = std::make_shared<const detail::ColumnFilter>(
+        detail::ColumnFilter::MetricsSource::PreloadedStatistics,
+        [](int64_t cell_id) { return cell_id == 1; });
+    auto options = ChunkedColumnInterface::ScanOptions::ForData(
+        0,
+        ChunkedColumnInterface::TargetType::Int32,
+        ChunkedColumnInterface::ScanPinPolicy::CursorOwned);
+    options.filter = std::move(filter);
+    auto cursor = fx.column->Scan(nullptr, options);
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_FALSE(batch.data_skipped);
+    const int64_t first_cell_offset[] = {0};
+    ASSERT_TRUE(fx.column->CellsLoaded(first_cell_offset, 1));
+    const auto evict = [&] {
+        if (fx.group != nullptr) {
+            fx.group->ManualEvictCache();
+        } else {
+            fx.column->ManualEvictCache();
+        }
+    };
+    evict();
+    EXPECT_TRUE(fx.column->CellsLoaded(first_cell_offset, 1));
+
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_TRUE(batch.data_skipped);
+    evict();
+    EXPECT_FALSE(fx.column->CellsLoaded(first_cell_offset, 1));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           CursorOwnedScanReturnsBeforeCrossingCells) {
+    ColumnSpec spec{{3, 4}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor = fx.column->Scan(
+        nullptr,
+        ChunkedColumnInterface::ScanOptions::ForData(
+            0,
+            ChunkedColumnInterface::TargetType::Int32,
+            ChunkedColumnInterface::ScanPinPolicy::CursorOwned));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        4, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 3);
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0}));
+
+    ASSERT_TRUE(cursor->Next(
+        3, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 3);
+    EXPECT_EQ(batch.size, 3);
+    EXPECT_EQ(fx.pin_requests->size(), 2u);
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, ScanSkipsZeroRowCellsAtBoundaries) {
+    ColumnSpec spec{{0, 0, 2, 0, 0, 3, 0, 0}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0, ChunkedColumnInterface::TargetType::Int32));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        5, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 0);
+    EXPECT_EQ(batch.size, 2);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[0], 0);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[1], 1);
+
+    ASSERT_TRUE(cursor->Next(
+        3, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 2);
+    EXPECT_EQ(batch.size, 3);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[0], 2);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[2], 4);
+
+    ASSERT_EQ(fx.pin_requests->size(), 2u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{2}));
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{5}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           CursorOwnedScanSkipsZeroRowCellsWithoutRepinning) {
+    ColumnSpec spec{{0, 0, 2, 0, 0, 3, 0, 0}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor = fx.column->Scan(
+        nullptr,
+        ChunkedColumnInterface::ScanOptions::ForData(
+            0,
+            ChunkedColumnInterface::TargetType::Int32,
+            ChunkedColumnInterface::ScanPinPolicy::CursorOwned));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        1, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    ASSERT_TRUE(cursor->Next(
+        1, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    ASSERT_TRUE(cursor->Next(
+        3, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 2);
+    EXPECT_EQ(batch.size, 3);
+    EXPECT_EQ(batch.values.data_as<int32_t>()[2], 4);
+
+    ASSERT_EQ(fx.pin_requests->size(), 2u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{2}));
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{5}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, SeekSkipsWithoutPinningSkippedCells) {
+    ColumnSpec spec{{4, 4}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor = fx.column->Scan(
+        nullptr,
+        ChunkedColumnInterface::ScanOptions::ForData(
+            0,
+            ChunkedColumnInterface::TargetType::Int32,
+            ChunkedColumnInterface::ScanPinPolicy::CursorOwned));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ(fx.pin_requests->front(), (std::vector<int64_t>{0}));
+
+    cursor->Seek(5);
+    ASSERT_TRUE(cursor->Next(
+        1, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    ASSERT_EQ(fx.pin_requests->size(), 2u);
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, DataScanRejectsBackwardSeek) {
+    ColumnSpec spec{{4}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0, ChunkedColumnInterface::TargetType::Int32));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    cursor->Seek(1);
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_THROW(cursor->Seek(2), std::exception);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, NonNullableScanRejectsValidityOnlyMode) {
+    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0, ChunkedColumnInterface::TargetType::Int32));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_TRUE(fx.fetched->empty());
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    ChunkedColumnInterface::ScanBatch batch;
+    EXPECT_THROW(
+        cursor->Next(
+            3, ChunkedColumnInterface::ScanReadMode::ValidityOnly, &batch),
+        std::exception);
+    EXPECT_TRUE(fx.fetched->empty());
+    EXPECT_TRUE(fx.pin_requests->empty());
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthDataScanReportsAllValidForNonNullableColumn) {
+    ColumnSpec spec{{3}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    auto cursor =
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0, ChunkedColumnInterface::TargetType::Int32));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        3, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_FALSE(batch.validity);
+    for (int64_t i = 0; i < batch.size; ++i) {
+        EXPECT_TRUE(IsScanRowValid(batch, i));
+    }
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthTakePreservesOrderDuplicatesAcrossChunks) {
+    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    const FixedVector<int32_t> offsets{2, 0, 0, 4, 3, 1};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int32});
+    ASSERT_NE(take, nullptr);
+    ASSERT_EQ(take->Size(), static_cast<int64_t>(offsets.size()));
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    std::vector<int32_t> actual;
+    for (int64_t i = 0; i < take->Size(); ++i) {
+        const auto item = take->template Get<int32_t>(i);
+        ASSERT_TRUE(item.value.has_value());
+        actual.emplace_back(*item.value);
+        EXPECT_TRUE(item.is_valid);
+        EXPECT_FALSE(item.data_skipped);
+    }
+
+    EXPECT_EQ(actual, (std::vector<int32_t>{2, 0, 0, 4, 3, 1}));
+    ASSERT_EQ(fx.pin_requests->size(), 3u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{0}));
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{1}));
+    EXPECT_EQ((*fx.pin_requests)[2], (std::vector<int64_t>{0}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           TakeKeepsSkippedRowsAlignedWithoutPinningNonNullableData) {
+    ColumnSpec spec{{2, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+    auto filter = std::make_shared<const detail::ColumnFilter>(
+        detail::ColumnFilter::MetricsSource::PreloadedStatistics,
+        [](int64_t cell_id) { return cell_id == 0; });
+
+    const FixedVector<int32_t> offsets{0, 3, 1};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int32,
+            std::move(filter)});
+    ASSERT_NE(take, nullptr);
+
+    const auto skipped_first = take->template Get<int32_t>(0);
+    EXPECT_TRUE(skipped_first.is_valid);
+    EXPECT_TRUE(skipped_first.data_skipped);
+    EXPECT_FALSE(skipped_first.value.has_value());
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    const auto active = take->template Get<int32_t>(1);
+    ASSERT_TRUE(active.value.has_value());
+    EXPECT_EQ(*active.value, 3);
+    EXPECT_FALSE(active.data_skipped);
+
+    const auto skipped_last = take->template Get<int32_t>(2);
+    EXPECT_TRUE(skipped_last.data_skipped);
+    EXPECT_FALSE(skipped_last.value.has_value());
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{1}));
+
+    const auto owned = take->GetOwn();
+    ASSERT_TRUE(owned.data_skipped);
+    EXPECT_TRUE(owned.data_skipped[0]);
+    EXPECT_FALSE(owned.data_skipped[1]);
+    EXPECT_TRUE(owned.data_skipped[2]);
+    // Materializing the aligned result still must not pin the skipped Cell.
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           TakeSkippedNullableRowsStillReadRealValidity) {
+    ColumnSpec spec{{2, 2}, {{false, true}, {true, true}}, /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+    auto filter = std::make_shared<const detail::ColumnFilter>(
+        detail::ColumnFilter::MetricsSource::PreloadedStatistics,
+        [](int64_t cell_id) { return cell_id == 0; });
+
+    const FixedVector<int32_t> offsets{0, 1, 3};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int32,
+            std::move(filter)});
+    ASSERT_NE(take, nullptr);
+
+    const auto null_skipped = take->template Get<int32_t>(0);
+    EXPECT_FALSE(null_skipped.is_valid);
+    EXPECT_TRUE(null_skipped.data_skipped);
+    EXPECT_FALSE(null_skipped.value.has_value());
+
+    const auto valid_skipped = take->template Get<int32_t>(1);
+    EXPECT_TRUE(valid_skipped.is_valid);
+    EXPECT_TRUE(valid_skipped.data_skipped);
+    EXPECT_FALSE(valid_skipped.value.has_value());
+
+    const auto active = take->template Get<int32_t>(2);
+    ASSERT_TRUE(active.value.has_value());
+    EXPECT_EQ(*active.value, 3);
+    ASSERT_EQ(fx.pin_requests->size(), 2u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{0}));
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           ScanReturnsExplicitSkippedBatchWithoutExposingCellPlan) {
+    ColumnSpec spec{{2, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+    auto options = ChunkedColumnInterface::ScanOptions::ForData(
+        0, ChunkedColumnInterface::TargetType::Int32);
+    options.filter = std::make_shared<const detail::ColumnFilter>(
+        detail::ColumnFilter::MetricsSource::PreloadedStatistics,
+        [](int64_t cell_id) { return cell_id == 0; });
+    auto cursor = fx.column->Scan(nullptr, options);
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch skipped;
+    ASSERT_TRUE(cursor->Next(
+        4, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &skipped));
+    EXPECT_EQ(skipped.row_id_start, 0);
+    EXPECT_EQ(skipped.size, 2);
+    EXPECT_TRUE(skipped.data_skipped);
+    EXPECT_TRUE(skipped.values.empty());
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    ChunkedColumnInterface::ScanBatch active;
+    ASSERT_TRUE(cursor->Next(
+        2, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &active));
+    EXPECT_EQ(active.row_id_start, 2);
+    EXPECT_EQ(active.size, 2);
+    EXPECT_FALSE(active.data_skipped);
+    EXPECT_EQ(active.values.data_as<int32_t>()[0], 2);
+    ASSERT_EQ(fx.pin_requests->size(), 1u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           TakePreservesRequestedOrderWithoutEagerPin) {
+    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    const FixedVector<int32_t> offsets{4, 1, 3, 1};
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int32});
+    ASSERT_NE(take, nullptr);
+    ASSERT_EQ(take->Size(), static_cast<int64_t>(offsets.size()));
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    const auto items = take->template Access<int32_t>();
+    ASSERT_EQ(items.Size(), static_cast<int64_t>(offsets.size()));
+    std::vector<int32_t> actual;
+    for (int64_t i = 0; i < items.Size(); ++i) {
+        actual.emplace_back(*items[i].value);
+    }
+    EXPECT_EQ(actual, (std::vector<int32_t>{4, 1, 3, 1}));
+}
+
+TEST(ColumnPlannerTest, LocatesSegmentOffsets) {
+    ColumnPlanner planner(std::vector<int64_t>{0, 3, 5});
+    EXPECT_EQ(planner.NumCells(), 2);
+    EXPECT_EQ(planner.NumRows(), 5);
+    EXPECT_EQ(planner.CellBoundaries(), (std::vector<int64_t>{0, 3, 5}));
+
+    const auto last = planner.Locate(4);
+    EXPECT_EQ(last.cell_id, 1);
+    EXPECT_EQ(last.cell_offset, 1);
+    const auto first = planner.Locate(1);
+    EXPECT_EQ(first.cell_id, 0);
+    EXPECT_EQ(first.cell_offset, 1);
+    const auto boundary = planner.Locate(3);
+    EXPECT_EQ(boundary.cell_id, 1);
+    EXPECT_EQ(boundary.cell_offset, 0);
+}
+
+TEST(ColumnPlannerTest, BorrowsStableBoundariesAndOwnsTemporaryBoundaries) {
+    const std::vector<int64_t> stable_boundaries{0, 3, 5};
+    ColumnPlanner borrowed(stable_boundaries);
+    EXPECT_EQ(borrowed.CellBoundaries().data(), stable_boundaries.data());
+
+    ColumnPlanner owned(std::vector<int64_t>{0, 2, 5});
+    EXPECT_EQ(owned.CellBoundaries(), (std::vector<int64_t>{0, 2, 5}));
+    EXPECT_EQ(owned.NumRows(), 5);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthTakeReadsValidityByLogicalPosition) {
+    ColumnSpec spec{{4}, {{true, false, true, false}}, /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    spec.dense_nullable_payload = true;
+    auto fx = TypeParam::Create(spec);
+
+    const FixedVector<int32_t> offsets{3, 0, 1, 2};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int32});
+    ASSERT_NE(take, nullptr);
+    ASSERT_EQ(take->Size(), 4);
+    EXPECT_FALSE(take->IsValid(0));
+    EXPECT_TRUE(take->IsValid(1));
+    EXPECT_FALSE(take->IsValid(2));
+    EXPECT_TRUE(take->IsValid(3));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           RawTakeLazyPinAccessorKeepsColumnGenerationAlive) {
+    ColumnSpec spec{{2, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    const FixedVector<int32_t> offsets{3, 2, 0};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int32});
+    ASSERT_NE(take, nullptr);
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    fx.column.reset();
+    EXPECT_EQ(*take->template Get<int32_t>(0).value, 3);
+    EXPECT_EQ(*take->template Get<int32_t>(1).value, 2);
+    EXPECT_EQ(*take->template Get<int32_t>(2).value, 0);
+    ASSERT_EQ(fx.pin_requests->size(), 2u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{1}));
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{0}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, RawTakeDefersCellPlanning) {
+    ColumnSpec spec{{2, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+    auto filter_calls = std::make_shared<std::vector<int>>(2, 0);
+    auto filter = std::make_shared<const detail::ColumnFilter>(
+        detail::ColumnFilter::MetricsSource::PreloadedStatistics,
+        [filter_calls](int64_t cell_id) {
+            ++(*filter_calls)[cell_id];
+            return false;
+        });
+
+    const auto offsets = FixedVector<int32_t>{0, 3, 1};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int32,
+            std::move(filter)});
+    ASSERT_NE(take, nullptr);
+    EXPECT_EQ(*filter_calls, (std::vector<int>{0, 0}));
+    EXPECT_TRUE(fx.pin_requests->empty());
+
+    // Physical planning is performed only for positions that are consumed.
+    EXPECT_EQ(*take->template Get<int32_t>(1).value, 3);
+    EXPECT_EQ(*filter_calls, (std::vector<int>{0, 1}));
+    EXPECT_EQ(*take->template Get<int32_t>(1).value, 3);
+    EXPECT_EQ(*filter_calls, (std::vector<int>{0, 1}));
+    EXPECT_EQ(*take->template Get<int32_t>(0).value, 0);
+    EXPECT_EQ(*filter_calls, (std::vector<int>{1, 1}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           RawTakeGetOwnMaterializesOrderedIndependentData) {
+    ColumnSpec spec{{3, 2},
+                    {{true, false, true}, {false, true}},
+                    /*nullable=*/true};
+    spec.data_type = DataType::INT32;
+    spec.dense_nullable_payload = true;
+    auto fx = TypeParam::Create(spec);
+
+    const FixedVector<int32_t> offsets{4, 0, 3, 2};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int32});
+    ASSERT_NE(take, nullptr);
+    EXPECT_FALSE(take->IsOwned());
+    EXPECT_TRUE(fx.pin_requests->empty());
+    auto owned = take->GetOwn();
+    EXPECT_TRUE(take->IsOwned());
+    ASSERT_EQ(owned.size, 4);
+    ASSERT_NE(owned.owner, nullptr);
+    ASSERT_TRUE(owned.validity);
+    take.reset();
+
+    const auto* values = owned.values.template data_as<int32_t>();
+    EXPECT_EQ(values[0], 4);
+    EXPECT_EQ(values[1], 0);
+    EXPECT_EQ(values[2], 3);
+    EXPECT_EQ(values[3], 2);
+    EXPECT_TRUE(owned.validity[0]);
+    EXPECT_TRUE(owned.validity[1]);
+    EXPECT_FALSE(owned.validity[2]);
+    EXPECT_TRUE(owned.validity[3]);
+    ASSERT_EQ(fx.pin_requests->size(), 2u);
+    EXPECT_EQ((*fx.pin_requests)[0], (std::vector<int64_t>{1}));
+    EXPECT_EQ((*fx.pin_requests)[1], (std::vector<int64_t>{0}));
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           RawTakeGetOwnOmitsSkipMaskWhenFilterMatchesNoCell) {
+    ColumnSpec spec{{3, 2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+    auto filter = std::make_shared<const detail::ColumnFilter>(
+        detail::ColumnFilter::MetricsSource::PreloadedStatistics,
+        [](int64_t) { return false; });
+
+    const FixedVector<int32_t> offsets{4, 0, 3, 2};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int32,
+            std::move(filter)});
+    ASSERT_NE(take, nullptr);
+
+    const auto owned = take->GetOwn();
+    ASSERT_EQ(owned.size, static_cast<int64_t>(offsets.size()));
+    EXPECT_FALSE(owned.data_skipped);
+    const auto* values = owned.values.template data_as<int32_t>();
+    EXPECT_EQ(values[0], 4);
+    EXPECT_EQ(values[1], 0);
+    EXPECT_EQ(values[2], 3);
+    EXPECT_EQ(values[3], 2);
+}
+
+TEST(ChunkedColumnInterfaceTest,
+     RawTakeGetOwnPreservesValidEmptyArrayMetadata) {
+    auto fx = CreateNullableEmptyArrayColumn();
+    const FixedVector<int32_t> offsets{0, 1};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(offsets.data(), 2),
+            ChunkedColumnInterface::TargetType::ArrayView});
+    ASSERT_NE(take, nullptr);
+    ASSERT_TRUE(take->IsValid(0));
+    ASSERT_FALSE(take->IsValid(1));
+
+    auto owned = take->GetOwn();
+    ASSERT_EQ(owned.size, 2);
+    ASSERT_TRUE(owned.validity);
+    const auto* arrays = owned.values.data_as<ArrayView>();
+    EXPECT_EQ(arrays[0].length(), 0);
+    EXPECT_EQ(arrays[0].get_element_type(), DataType::INT64);
+    EXPECT_NE(arrays[0].data(), nullptr);
+    EXPECT_EQ(arrays[1].get_element_type(), DataType::NONE);
+    EXPECT_EQ(arrays[1].data(), nullptr);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, TakeGetRejectsMismatchedFixedType) {
+    ColumnSpec spec{{2}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    const FixedVector<int32_t> offsets{0};
+    auto take = fx.column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(offsets.data(), 1),
+            ChunkedColumnInterface::TargetType::Int32});
+    ASSERT_NE(take, nullptr);
+    EXPECT_THROW(take->template Get<int64_t>(0), std::exception);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           FixedWidthDataScanRejectsMismatchedTargetType) {
+    ColumnSpec spec{{3}, {}, /*nullable=*/false};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    EXPECT_THROW(
+        fx.column->Scan(nullptr,
+                        ChunkedColumnInterface::ScanOptions::ForData(
+                            0, ChunkedColumnInterface::TargetType::StringView)),
+        std::exception);
+}
+
+TEST(ChunkedColumnInterfaceTest, VarcharPrimaryKeyUsesStringViewScanCursor) {
+    // Primary-key metadata does not change the underlying column
+    // representation: a user-defined VARCHAR PK uses the regular string
+    // column and must therefore resolve to a StringView scan cursor.
+    const std::vector<std::string> values{"alpha", "beta", "gamma"};
+    auto buffer = BuildStringChunkBuffer(values);
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    chunks.push_back(
+        std::make_unique<StringChunk>(static_cast<int32_t>(values.size()),
+                                      buffer.data(),
+                                      buffer.size(),
+                                      /*nullable=*/false,
+                                      std::move(guard)));
+    auto translator = std::make_unique<TestChunkTranslator>(
+        std::vector<int64_t>{static_cast<int64_t>(values.size())},
+        "varchar_pk_scan",
+        std::move(chunks));
+    FieldMeta field_meta(FieldName("varchar_pk"),
+                         FieldId(kTestFieldId),
+                         DataType::VARCHAR,
+                         /*nullable=*/false,
+                         std::nullopt);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+        std::move(translator), nullptr);
+    auto pin_requests = std::make_shared<std::vector<std::vector<int64_t>>>();
+    auto column = std::make_shared<ScanCountingStringColumn>(
+        std::move(slot), field_meta, pin_requests);
+
+    auto cursor =
+        column->Scan(nullptr,
+                     ChunkedColumnInterface::ScanOptions::ForData(
+                         0, ChunkedColumnInterface::TargetType::StringView));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_TRUE(pin_requests->empty());
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(
+        cursor->Next(static_cast<int64_t>(values.size()),
+                     ChunkedColumnInterface::ScanReadMode::DataAndValidity,
+                     &batch));
+    EXPECT_EQ(batch.values.target_type,
+              ChunkedColumnInterface::TargetType::StringView);
+    const auto* scanned = batch.values.data_as<std::string_view>();
+    ASSERT_EQ(batch.size, static_cast<int64_t>(values.size()));
+    for (size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ(scanned[i], values[i]);
+    }
+    ASSERT_EQ(pin_requests->size(), 1u);
+    EXPECT_EQ(pin_requests->front(), (std::vector<int64_t>{0}));
+}
+
+TEST(ChunkedColumnInterfaceTest, VarcharTakeBuildsOnlyRequestedOrderedViews) {
+    const std::vector<std::string> values{"alpha", "beta", "gamma", "delta"};
+    auto buffer = BuildStringChunkBuffer(values);
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    chunks.push_back(
+        std::make_unique<StringChunk>(static_cast<int32_t>(values.size()),
+                                      buffer.data(),
+                                      buffer.size(),
+                                      /*nullable=*/false,
+                                      std::move(guard)));
+    auto translator = std::make_unique<TestChunkTranslator>(
+        std::vector<int64_t>{static_cast<int64_t>(values.size())},
+        "varchar_take",
+        std::move(chunks));
+    FieldMeta field_meta(FieldName("varchar"),
+                         FieldId(kTestFieldId),
+                         DataType::VARCHAR,
+                         /*nullable=*/false,
+                         std::nullopt);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+        std::move(translator), nullptr);
+    auto pin_requests = std::make_shared<std::vector<std::vector<int64_t>>>();
+    auto column = std::make_shared<ScanCountingStringColumn>(
+        std::move(slot), field_meta, pin_requests);
+
+    const FixedVector<int32_t> offsets{3, 1, 1, 0};
+    auto take = column->Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::StringView});
+    ASSERT_NE(take, nullptr);
+    ASSERT_EQ(take->Size(), 4);
+    EXPECT_TRUE(pin_requests->empty());
+    EXPECT_EQ(*take->Get<std::string_view>(0).value, "delta");
+    EXPECT_EQ(*take->Get<std::string_view>(1).value, "beta");
+    EXPECT_EQ(*take->Get<std::string_view>(2).value, "beta");
+    EXPECT_EQ(*take->Get<std::string_view>(3).value, "alpha");
+    ASSERT_EQ(pin_requests->size(), 1u);
+    EXPECT_EQ(pin_requests->front(), (std::vector<int64_t>{0}));
+}
+
+TEST(ChunkedColumnInterfaceTest, MaterializedViewDataScanUsesWindowBounds) {
+    const std::vector<std::string> values{
+        "alpha", "beta", "gamma", "delta", "epsilon"};
+    auto buffer = BuildStringChunkBuffer(values);
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    chunks.push_back(
+        std::make_unique<StringChunk>(static_cast<int32_t>(values.size()),
+                                      buffer.data(),
+                                      buffer.size(),
+                                      /*nullable=*/false,
+                                      std::move(guard)));
+    auto translator = std::make_unique<TestChunkTranslator>(
+        std::vector<int64_t>{static_cast<int64_t>(values.size())},
+        "bounded_varchar_scan",
+        std::move(chunks));
+    FieldMeta field_meta(FieldName("varchar"),
+                         FieldId(kTestFieldId),
+                         DataType::VARCHAR,
+                         /*nullable=*/false,
+                         std::nullopt);
+    auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+        std::move(translator), nullptr);
+    auto pin_requests = std::make_shared<std::vector<std::vector<int64_t>>>();
+    auto column = std::make_shared<ScanCountingStringColumn>(
+        std::move(slot), field_meta, pin_requests);
+
+    constexpr int64_t kMaxBatchRows = 2;
+    auto cursor =
+        column->Scan(nullptr,
+                     ChunkedColumnInterface::ScanOptions::ForData(
+                         0, ChunkedColumnInterface::TargetType::StringView));
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_TRUE(pin_requests->empty());
+
+    std::vector<std::string> scanned;
+    std::vector<int64_t> batch_starts;
+    std::vector<int64_t> batch_sizes;
+    for (int64_t start = 0; start < static_cast<int64_t>(values.size());
+         start += kMaxBatchRows) {
+        const auto length = std::min<int64_t>(
+            kMaxBatchRows, static_cast<int64_t>(values.size()) - start);
+        ChunkedColumnInterface::ScanBatch batch;
+        ASSERT_TRUE(
+            cursor->Next(length,
+                         ChunkedColumnInterface::ScanReadMode::DataAndValidity,
+                         &batch));
+        batch_starts.emplace_back(batch.row_id_start);
+        batch_sizes.emplace_back(batch.size);
+        EXPECT_LE(batch.size, kMaxBatchRows);
+        const auto* batch_values = batch.values.data_as<std::string_view>();
+        for (int64_t i = 0; i < batch.size; ++i) {
+            scanned.emplace_back(batch_values[i]);
+        }
+    }
+
+    EXPECT_EQ(batch_starts, (std::vector<int64_t>{0, 2, 4}));
+    EXPECT_EQ(batch_sizes, (std::vector<int64_t>{2, 2, 1}));
+    EXPECT_EQ(scanned, values);
+    EXPECT_EQ(pin_requests->size(), 3u);
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnPlanner.cpp
+++ b/internal/core/src/mmap/ChunkedColumnPlanner.cpp
@@ -1,0 +1,122 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mmap/ChunkedColumnInterface.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace milvus {
+
+ColumnPlanner::ColumnPlanner(const std::vector<int64_t>& num_rows_until_cell)
+    : num_rows_until_cell_(&num_rows_until_cell) {
+    ValidateBoundaries();
+}
+
+ColumnPlanner::ColumnPlanner(std::vector<int64_t>&& num_rows_until_cell)
+    : owned_num_rows_until_cell_(std::make_shared<const std::vector<int64_t>>(
+          std::move(num_rows_until_cell))),
+      num_rows_until_cell_(owned_num_rows_until_cell_.get()) {
+    ValidateBoundaries();
+}
+
+void
+ColumnPlanner::ValidateBoundaries() const {
+    AssertInfo(num_rows_until_cell_ != nullptr,
+               "column planner Cell boundaries are null");
+    const auto& boundaries = *num_rows_until_cell_;
+    AssertInfo(boundaries.size() >= 2,
+               "column planner requires at least one Cell boundary");
+    AssertInfo(boundaries.front() == 0,
+               "column planner first Cell boundary is {}, expected 0",
+               boundaries.front());
+    for (size_t i = 1; i < boundaries.size(); ++i) {
+        AssertInfo(boundaries[i] >= boundaries[i - 1],
+                   "column planner Cell boundaries are not monotonic at {}: "
+                   "{} < {}",
+                   i,
+                   boundaries[i],
+                   boundaries[i - 1]);
+    }
+}
+
+CellLocation
+ColumnPlanner::Locate(int64_t segment_offset) const {
+    AssertInfo(segment_offset >= 0 && segment_offset < NumRows(),
+               "segment offset {} out of planner rows {}",
+               segment_offset,
+               NumRows());
+    const auto& boundaries = *num_rows_until_cell_;
+    const auto it =
+        std::upper_bound(boundaries.begin(), boundaries.end(), segment_offset);
+    const auto cell_id =
+        static_cast<int64_t>(std::distance(boundaries.begin(), it)) - 1;
+    return CellLocation{cell_id, segment_offset - boundaries[cell_id]};
+}
+
+int64_t
+ColumnPlanner::CellStart(int64_t cell_id) const {
+    AssertInfo(cell_id >= 0 && cell_id <= NumCells(),
+               "planner Cell boundary {} out of range {}",
+               cell_id,
+               NumCells());
+    return (*num_rows_until_cell_)[cell_id];
+}
+
+int64_t
+ColumnPlanner::CellRows(int64_t cell_id) const {
+    return CellStart(cell_id + 1) - CellStart(cell_id);
+}
+
+int64_t
+ColumnPlanner::NumCells() const {
+    return static_cast<int64_t>(num_rows_until_cell_->size()) - 1;
+}
+
+int64_t
+ColumnPlanner::NumRows() const {
+    return num_rows_until_cell_->back();
+}
+
+const std::vector<int64_t>&
+ColumnPlanner::CellBoundaries() const {
+    return *num_rows_until_cell_;
+}
+
+const ColumnPlanner&
+ChunkedColumnInterface::Planner() const {
+    std::call_once(planner_once_, [this]() {
+        planner_ = BuildPlanner();
+        AssertInfo(planner_ != nullptr, "column planner is null");
+    });
+    return *planner_;
+}
+
+std::shared_ptr<const ColumnPlanner>
+ChunkedColumnInterface::PlannerHandle() const {
+    Planner();
+    return planner_;
+}
+
+std::unique_ptr<ColumnPlanner>
+ChunkedColumnInterface::BuildPlanner() const {
+    return std::make_unique<ColumnPlanner>(GetNumRowsUntilChunk());
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -41,12 +41,6 @@ enum class ValueEncoding {
     VectorArrayView,
 };
 
-enum class ValidityEncoding {
-    AllValid,
-    BoolArray,
-    Bitmap,
-};
-
 struct ValueView {
     ValueEncoding encoding = ValueEncoding::Empty;
     ScanValueKind kind = ScanValueKind::Default;
@@ -71,70 +65,15 @@ struct ValueView {
     }
 };
 
-struct ValidityView {
-    ValidityEncoding encoding = ValidityEncoding::AllValid;
-    const void* data = nullptr;
-    int64_t offset = 0;
-    int64_t size = 0;
-    bool nullable = false;
-
-    bool
-    IsValid(int64_t i) const {
-        AssertInfo(
-            i >= 0 && i < size, "validity offset {} out of range {}", i, size);
-        if (encoding == ValidityEncoding::AllValid) {
-            return true;
-        }
-        AssertInfo(data != nullptr,
-                   "validity data is null for encoding {}",
-                   static_cast<int>(encoding));
-        const auto pos = offset + i;
-        switch (encoding) {
-            case ValidityEncoding::BoolArray:
-                return static_cast<const bool*>(data)[pos];
-            case ValidityEncoding::Bitmap: {
-                const auto* bitmap = static_cast<const uint8_t*>(data);
-                return (bitmap[pos >> 3] >> (pos & 0x07)) & 1;
-            }
-            case ValidityEncoding::AllValid:
-                return true;
-        }
-        return true;
-    }
-
-    // Expression evaluators use a legacy bool-array contract where nullptr
-    // means every row is valid. Keep storage-native encodings at the Scan
-    // boundary and normalize them exactly once before invoking an evaluator.
-    const bool*
-    bool_data(FixedVector<bool>& scratch) const {
-        scratch.clear();
-        if (encoding == ValidityEncoding::AllValid || size == 0) {
-            return nullptr;
-        }
-        AssertInfo(data != nullptr,
-                   "validity data is null for encoding {}",
-                   static_cast<int>(encoding));
-        if (encoding == ValidityEncoding::BoolArray) {
-            return static_cast<const bool*>(data) + offset;
-        }
-        AssertInfo(encoding == ValidityEncoding::Bitmap,
-                   "cannot materialize validity encoding {} as bool data",
-                   static_cast<int>(encoding));
-
-        scratch.resize(size);
-        for (int64_t i = 0; i < size; ++i) {
-            scratch[i] = IsValid(i);
-        }
-        return scratch.data();
-    }
-};
-
 struct ScanBatch {
     // Every batch represents the dense row range
     // [row_id_start, row_id_start + size). Values are optional based on the
     // requested projection, while validity remains aligned with this range.
     ValueView values;
-    ValidityView validity;
+    // Evaluators consume validity as one bool per logical row. nullptr means
+    // every row in this batch is valid. Storage-native bitmap encodings must
+    // be normalized by the cursor before they cross this boundary.
+    const bool* validity = nullptr;
     std::shared_ptr<void> owner;
     int64_t row_id_start = 0;
     int64_t size = 0;

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -175,9 +176,10 @@ class ScanCursor {
 
     // Return the next evaluated batch from the underlying source. A batch is
     // always one continuous logical range, contains at most max_rows rows, and
-    // never crosses a skipped range or backend batch boundary. Position() may
-    // advance across skipped ranges before the next batch is returned, so
-    // adjacent batches are allowed to have a logical row gap.
+    // never crosses a skipped range or backend batch boundary. Non-nullable
+    // scans may advance Position() across a data-skip range without returning
+    // it. Nullable scans return that range as a validity-only batch so null
+    // rows preserve expression Unknown semantics without reopening a cursor.
     virtual bool
     Next(int64_t max_rows, ScanBatch* out) = 0;
 };
@@ -194,10 +196,9 @@ struct ScanPlan {
     }
 
     ScanRowRange requested_range;
-    // Sorted, non-overlapping segment-offset ranges that the data cursor must
-    // not return. Expressions still produce result/validity for these logical
-    // rows, using a validity-only cursor over the same PreparedScan when the
-    // source column is nullable.
+    // Sorted, non-overlapping segment-offset ranges whose data values must not
+    // be returned or evaluated. Non-nullable cursors skip these rows;
+    // nullable cursors return validity-only batches for them.
     std::vector<ScanRowRange> skip_ranges;
 };
 
@@ -218,10 +219,9 @@ class PreparedScan {
     virtual int64_t
     End() const = 0;
 
-    // Backend planner result for this prepared operator window. The plan is
-    // computed before data pinning from metadata that was loaded with the
-    // segment. Payload-dependent legacy Raw SkipIndex decisions are not part
-    // of this plan.
+    // Backend planner result for this prepared operator window. Backends keep
+    // metadata and post-load pruning in Cell-ID form, then convert the union
+    // to segment-offset ranges before exposing this cursor plan.
     virtual const ScanPlan&
     Plan() const = 0;
 
@@ -237,6 +237,8 @@ enum class ScanProjection {
 };
 
 struct ScanOptions {
+    using CellSkipPredicate = std::function<bool(int64_t)>;
+
     ScanOptions() = default;
 
     ScanOptions(int64_t start_offset,
@@ -269,6 +271,13 @@ struct ScanOptions {
     int64_t length = 0;
     ScanProjection projection = ScanProjection::Data;
     ScanValueKind value_kind = ScanValueKind::Default;
+    // The common Raw backend invokes metadata_skip_cell before pinning and
+    // loaded_skip_cell after the selected Cells have been pinned. Backends
+    // with native planners may keep their own scoped Cell identifiers instead.
+    // Cell identifiers remain backend-private until PreparedScan converts the
+    // final skipped set into segment-offset ScanPlan ranges.
+    CellSkipPredicate metadata_skip_cell;
+    CellSkipPredicate loaded_skip_cell;
 };
 
 using ScanResult = std::unique_ptr<ScanCursor>;

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -96,6 +96,24 @@ class ScanCursor {
     Next(int64_t max_rows, ScanBatch* out) = 0;
 };
 
+// PreparedScan owns the storage resources selected for one logical scan,
+// including cache pins. Cursors only own position and reader state, so callers
+// may discard a cursor after short-circuiting and seek to a new position
+// without planning or pinning the same cells again.
+class PreparedScan {
+ public:
+    virtual ~PreparedScan() = default;
+
+    virtual int64_t
+    Start() const = 0;
+
+    virtual int64_t
+    End() const = 0;
+
+    virtual std::unique_ptr<ScanCursor>
+    Seek(int64_t position) const = 0;
+};
+
 enum class ScanProjection {
     // Return ScanBatch::values.
     Data,
@@ -139,5 +157,6 @@ struct ScanOptions {
 };
 
 using ScanResult = std::unique_ptr<ScanCursor>;
+using PreparedScanResult = std::shared_ptr<PreparedScan>;
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -119,9 +119,10 @@ class ScanCursor {
  public:
     virtual ~ScanCursor() = default;
 
-    // Return the next natural batch from the underlying source. ScanOptions
-    // does not carry an upper-layer batch-size hint; callers should consume
-    // the returned batch directly or keep their own position inside it.
+    // Return the next batch from the underlying source. Materializing cursors
+    // must honor ScanOptions::max_batch_rows so one Next() call cannot allocate
+    // view wrappers for an arbitrarily large storage chunk. Zero-copy cursors
+    // may still expose a larger natural source batch.
     virtual bool
     Next(ScanBatch* out) = 0;
 };
@@ -134,38 +135,50 @@ enum class ScanProjection {
 };
 
 struct ScanOptions {
+    static constexpr int64_t kDefaultMaxBatchRows = 8192;
+
     ScanOptions() = default;
 
     ScanOptions(int64_t start_offset,
                 int64_t length,
                 ScanProjection projection = ScanProjection::Data,
-                ScanValueKind value_kind = ScanValueKind::Default)
+                ScanValueKind value_kind = ScanValueKind::Default,
+                int64_t max_batch_rows = kDefaultMaxBatchRows)
         : start_offset(start_offset),
           length(length),
           projection(projection),
-          value_kind(value_kind) {
+          value_kind(value_kind),
+          max_batch_rows(max_batch_rows) {
     }
 
     static ScanOptions
     ForData(int64_t start_offset,
             int64_t length,
             ScanProjection projection = ScanProjection::Data,
-            ScanValueKind value_kind = ScanValueKind::Default) {
-        return ScanOptions(start_offset, length, projection, value_kind);
+            ScanValueKind value_kind = ScanValueKind::Default,
+            int64_t max_batch_rows = kDefaultMaxBatchRows) {
+        return ScanOptions(
+            start_offset, length, projection, value_kind, max_batch_rows);
     }
 
     static ScanOptions
     ForNoData(int64_t start_offset,
               int64_t length,
-              ScanValueKind value_kind = ScanValueKind::Default) {
-        return ForData(
-            start_offset, length, ScanProjection::NoData, value_kind);
+              ScanValueKind value_kind = ScanValueKind::Default,
+              int64_t max_batch_rows = kDefaultMaxBatchRows) {
+        return ForData(start_offset,
+                       length,
+                       ScanProjection::NoData,
+                       value_kind,
+                       max_batch_rows);
     }
 
     int64_t start_offset = 0;
     int64_t length = 0;
     ScanProjection projection = ScanProjection::Data;
     ScanValueKind value_kind = ScanValueKind::Default;
+    // Upper bound for batches that allocate per-row materialized views.
+    int64_t max_batch_rows = kDefaultMaxBatchRows;
 };
 
 using ScanResult = std::unique_ptr<ScanCursor>;

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -77,18 +77,17 @@ struct ValidityView {
     int64_t offset = 0;
     int64_t size = 0;
     bool nullable = false;
-    bool all_valid = true;
 
     bool
     IsValid(int64_t i) const {
-        AssertInfo(i >= 0 && (size == 0 || i < size),
-                   "validity offset {} out of range {}",
-                   i,
-                   size);
-        if (encoding == ValidityEncoding::AllValid || all_valid ||
-            data == nullptr) {
+        AssertInfo(
+            i >= 0 && i < size, "validity offset {} out of range {}", i, size);
+        if (encoding == ValidityEncoding::AllValid) {
             return true;
         }
+        AssertInfo(data != nullptr,
+                   "validity data is null for encoding {}",
+                   static_cast<int>(encoding));
         const auto pos = offset + i;
         switch (encoding) {
             case ValidityEncoding::BoolArray:
@@ -101,6 +100,32 @@ struct ValidityView {
                 return true;
         }
         return true;
+    }
+
+    // Expression evaluators use a legacy bool-array contract where nullptr
+    // means every row is valid. Keep storage-native encodings at the Scan
+    // boundary and normalize them exactly once before invoking an evaluator.
+    const bool*
+    bool_data(FixedVector<bool>& scratch) const {
+        scratch.clear();
+        if (encoding == ValidityEncoding::AllValid || size == 0) {
+            return nullptr;
+        }
+        AssertInfo(data != nullptr,
+                   "validity data is null for encoding {}",
+                   static_cast<int>(encoding));
+        if (encoding == ValidityEncoding::BoolArray) {
+            return static_cast<const bool*>(data) + offset;
+        }
+        AssertInfo(encoding == ValidityEncoding::Bitmap,
+                   "cannot materialize validity encoding {} as bool data",
+                   static_cast<int>(encoding));
+
+        scratch.resize(size);
+        for (int64_t i = 0; i < size; ++i) {
+            scratch[i] = IsValid(i);
+        }
+        return scratch.data();
     }
 };
 
@@ -119,12 +144,17 @@ class ScanCursor {
  public:
     virtual ~ScanCursor() = default;
 
-    // Return the next batch from the underlying source. Materializing cursors
-    // must honor ScanOptions::max_batch_rows so one Next() call cannot allocate
-    // view wrappers for an arbitrarily large storage chunk. Zero-copy cursors
-    // may still expose a larger natural source batch.
+    // The next dense row that has not yet been returned to the caller.
+    virtual int64_t
+    Position() const = 0;
+
+    // Return the next dense batch from the underlying source. A successful
+    // call starts at Position(), returns at most max_rows without crossing a
+    // column chunk boundary, and advances Position() by the returned size.
+    // Callers consume the returned batch as a whole; physical reader and
+    // buffered-batch positions remain private to the cursor.
     virtual bool
-    Next(ScanBatch* out) = 0;
+    Next(int64_t max_rows, ScanBatch* out) = 0;
 };
 
 enum class ScanProjection {
@@ -135,50 +165,38 @@ enum class ScanProjection {
 };
 
 struct ScanOptions {
-    static constexpr int64_t kDefaultMaxBatchRows = 8192;
-
     ScanOptions() = default;
 
     ScanOptions(int64_t start_offset,
                 int64_t length,
                 ScanProjection projection = ScanProjection::Data,
-                ScanValueKind value_kind = ScanValueKind::Default,
-                int64_t max_batch_rows = kDefaultMaxBatchRows)
+                ScanValueKind value_kind = ScanValueKind::Default)
         : start_offset(start_offset),
           length(length),
           projection(projection),
-          value_kind(value_kind),
-          max_batch_rows(max_batch_rows) {
+          value_kind(value_kind) {
     }
 
     static ScanOptions
     ForData(int64_t start_offset,
             int64_t length,
             ScanProjection projection = ScanProjection::Data,
-            ScanValueKind value_kind = ScanValueKind::Default,
-            int64_t max_batch_rows = kDefaultMaxBatchRows) {
-        return ScanOptions(
-            start_offset, length, projection, value_kind, max_batch_rows);
+            ScanValueKind value_kind = ScanValueKind::Default) {
+        return ScanOptions(start_offset, length, projection, value_kind);
     }
 
     static ScanOptions
     ForNoData(int64_t start_offset,
               int64_t length,
-              ScanValueKind value_kind = ScanValueKind::Default,
-              int64_t max_batch_rows = kDefaultMaxBatchRows) {
-        return ForData(start_offset,
-                       length,
-                       ScanProjection::NoData,
-                       value_kind,
-                       max_batch_rows);
+              ScanValueKind value_kind = ScanValueKind::Default) {
+        return ForData(
+            start_offset, length, ScanProjection::NoData, value_kind);
     }
 
     int64_t start_offset = 0;
     int64_t length = 0;
     ScanProjection projection = ScanProjection::Data;
     ScanValueKind value_kind = ScanValueKind::Default;
-    // Upper bound for batches that allocate per-row materialized views.
-    int64_t max_batch_rows = kDefaultMaxBatchRows;
 };
 
 using ScanResult = std::unique_ptr<ScanCursor>;

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -1,0 +1,173 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "common/EasyAssert.h"
+#include "common/Types.h"
+
+namespace milvus {
+
+enum class ScanValueKind {
+    Default,
+    FixedWidth,
+    StringView,
+    JsonView,
+    ArrayView,
+    VectorArrayView,
+};
+
+enum class ValueEncoding {
+    Empty,
+    FixedWidth,
+    StringView,
+    JsonView,
+    ArrayView,
+    VectorArrayView,
+};
+
+enum class ValidityEncoding {
+    AllValid,
+    BoolArray,
+    Bitmap,
+};
+
+struct ValueView {
+    ValueEncoding encoding = ValueEncoding::Empty;
+    ScanValueKind kind = ScanValueKind::Default;
+    DataType physical_type = DataType::NONE;
+    DataType logical_type = DataType::NONE;
+    const void* data = nullptr;
+    int64_t offset = 0;
+    int64_t size = 0;
+    int32_t byte_width = 0;
+
+    bool
+    empty() const {
+        return encoding == ValueEncoding::Empty || data == nullptr;
+    }
+
+    template <typename T>
+    const T*
+    data_as() const {
+        AssertInfo(encoding != ValueEncoding::Empty && data != nullptr,
+                   "scan value view is empty");
+        return static_cast<const T*>(data) + offset;
+    }
+};
+
+struct ValidityView {
+    ValidityEncoding encoding = ValidityEncoding::AllValid;
+    const void* data = nullptr;
+    int64_t offset = 0;
+    int64_t size = 0;
+    bool nullable = false;
+    bool all_valid = true;
+
+    bool
+    IsValid(int64_t i) const {
+        AssertInfo(i >= 0 && (size == 0 || i < size),
+                   "validity offset {} out of range {}",
+                   i,
+                   size);
+        if (encoding == ValidityEncoding::AllValid || all_valid ||
+            data == nullptr) {
+            return true;
+        }
+        const auto pos = offset + i;
+        switch (encoding) {
+            case ValidityEncoding::BoolArray:
+                return static_cast<const bool*>(data)[pos];
+            case ValidityEncoding::Bitmap: {
+                const auto* bitmap = static_cast<const uint8_t*>(data);
+                return (bitmap[pos >> 3] >> (pos & 0x07)) & 1;
+            }
+            case ValidityEncoding::AllValid:
+                return true;
+        }
+        return true;
+    }
+};
+
+struct ScanBatch {
+    // Every batch represents the dense row range
+    // [row_id_start, row_id_start + size). Values are optional based on the
+    // requested projection, while validity remains aligned with this range.
+    ValueView values;
+    ValidityView validity;
+    std::shared_ptr<void> owner;
+    int64_t row_id_start = 0;
+    int64_t size = 0;
+};
+
+class ScanCursor {
+ public:
+    virtual ~ScanCursor() = default;
+
+    // Return the next natural batch from the underlying source. ScanOptions
+    // does not carry an upper-layer batch-size hint; callers should consume
+    // the returned batch directly or keep their own position inside it.
+    virtual bool
+    Next(ScanBatch* out) = 0;
+};
+
+enum class ScanProjection {
+    // Return ScanBatch::values.
+    Data,
+    // Omit ScanBatch::values while still returning validity.
+    NoData,
+};
+
+struct ScanOptions {
+    ScanOptions() = default;
+
+    ScanOptions(int64_t start_offset,
+                int64_t length,
+                ScanProjection projection = ScanProjection::Data,
+                ScanValueKind value_kind = ScanValueKind::Default)
+        : start_offset(start_offset),
+          length(length),
+          projection(projection),
+          value_kind(value_kind) {
+    }
+
+    static ScanOptions
+    ForData(int64_t start_offset,
+            int64_t length,
+            ScanProjection projection = ScanProjection::Data,
+            ScanValueKind value_kind = ScanValueKind::Default) {
+        return ScanOptions(start_offset, length, projection, value_kind);
+    }
+
+    static ScanOptions
+    ForNoData(int64_t start_offset,
+              int64_t length,
+              ScanValueKind value_kind = ScanValueKind::Default) {
+        return ForData(
+            start_offset, length, ScanProjection::NoData, value_kind);
+    }
+
+    int64_t start_offset = 0;
+    int64_t length = 0;
+    ScanProjection projection = ScanProjection::Data;
+    ScanValueKind value_kind = ScanValueKind::Default;
+};
+
+using ScanResult = std::unique_ptr<ScanCursor>;
+
+}  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -41,6 +41,46 @@ enum class ValueEncoding {
     VectorArrayView,
 };
 
+enum class OffsetElementType {
+    Int32,
+    Int64,
+};
+
+// A non-owning view over positional row offsets. Callers must keep the
+// underlying array alive for the lifetime of the TakeCursor. Supporting both
+// widths lets expression evaluation use its existing int32 offsets without a
+// widening copy while retrieve/requery can pass segment int64 offsets.
+struct OffsetView {
+    const void* data = nullptr;
+    int64_t size = 0;
+    OffsetElementType element_type = OffsetElementType::Int32;
+
+    static OffsetView
+    From(const int32_t* offsets, int64_t count) {
+        return OffsetView{offsets, count, OffsetElementType::Int32};
+    }
+
+    static OffsetView
+    From(const int64_t* offsets, int64_t count) {
+        return OffsetView{offsets, count, OffsetElementType::Int64};
+    }
+
+    int64_t
+    operator[](int64_t index) const {
+        AssertInfo(index >= 0 && index < size,
+                   "take offset index {} out of range {}",
+                   index,
+                   size);
+        AssertInfo(data != nullptr,
+                   "take offsets are null with non-empty size {}",
+                   size);
+        if (element_type == OffsetElementType::Int32) {
+            return static_cast<const int32_t*>(data)[index];
+        }
+        return static_cast<const int64_t*>(data)[index];
+    }
+};
+
 struct ValueView {
     ValueEncoding encoding = ValueEncoding::Empty;
     ScanValueKind kind = ScanValueKind::Default;
@@ -77,6 +117,50 @@ struct ScanBatch {
     std::shared_ptr<void> owner;
     int64_t row_id_start = 0;
     int64_t size = 0;
+};
+
+struct TakeBatch {
+    // Take preserves the caller's offset order. values is a backend-native
+    // addressable collection and selection maps each logical output item to
+    // one value in that collection. A null selection means identity indexing.
+    //
+    // Raw fixed-width batches expose a pinned Chunk span plus chunk-local
+    // selection offsets. Reader-backed formats may return already ordered,
+    // dense decoded values with a null selection.
+    ValueView values;
+    const int32_t* selection = nullptr;
+    // Validity uses the same indexing as values: selection[i] when selection
+    // is present, otherwise i. nullptr means every logical item is valid.
+    const bool* validity = nullptr;
+    std::shared_ptr<void> owner;
+    // Logical position in the input OffsetView of the first returned item.
+    int64_t position = 0;
+    int64_t size = 0;
+    // Raw batches identify their physical source chunk so expression skip
+    // statistics can remain chunk-aware. Reader-backed ordered results may
+    // combine sources and leave this as -1.
+    int64_t source_chunk_id = -1;
+};
+
+class TakeCursor {
+ public:
+    virtual ~TakeCursor() = default;
+
+    // Number of input offsets already returned.
+    virtual int64_t
+    Position() const = 0;
+
+    // Return the next ordered positional batch. Concatenating all successful
+    // batches must produce exactly the input offset order, including duplicate
+    // offsets. max_rows limits the logical items exposed to the caller; a
+    // backend may physically read/materialize more data once and slice it here.
+    virtual bool
+    Next(int64_t max_rows, TakeBatch* out) = 0;
+};
+
+struct TakeOptions {
+    OffsetView offsets;
+    ScanValueKind value_kind = ScanValueKind::Default;
 };
 
 class ScanCursor {
@@ -158,5 +242,6 @@ struct ScanOptions {
 
 using ScanResult = std::unique_ptr<ScanCursor>;
 using PreparedScanResult = std::shared_ptr<PreparedScan>;
+using TakeResult = std::unique_ptr<TakeCursor>;
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "common/EasyAssert.h"
 #include "common/Types.h"
@@ -167,23 +168,46 @@ class ScanCursor {
  public:
     virtual ~ScanCursor() = default;
 
-    // The next dense row that has not yet been returned to the caller.
+    // The next logical source row that has neither been returned nor skipped
+    // by the scan plan.
     virtual int64_t
     Position() const = 0;
 
-    // Return the next dense batch from the underlying source. A successful
-    // call starts at Position(), returns at most max_rows without crossing a
-    // column chunk boundary, and advances Position() by the returned size.
-    // Callers consume the returned batch as a whole; physical reader and
-    // buffered-batch positions remain private to the cursor.
+    // Return the next evaluated batch from the underlying source. A batch is
+    // always one continuous logical range, contains at most max_rows rows, and
+    // never crosses a skipped range or backend batch boundary. Position() may
+    // advance across skipped ranges before the next batch is returned, so
+    // adjacent batches are allowed to have a logical row gap.
     virtual bool
     Next(int64_t max_rows, ScanBatch* out) = 0;
 };
 
-// PreparedScan owns the storage resources selected for one logical scan,
-// including cache pins. Cursors only own position and reader state, so callers
-// may discard a cursor after short-circuiting and seek to a new position
-// without planning or pinning the same cells again.
+struct ScanRowRange {
+    int64_t start = 0;
+    int64_t end = 0;
+};
+
+struct ScanPlan {
+    static ScanPlan
+    Full(int64_t start, int64_t length) {
+        return ScanPlan{ScanRowRange{start, start + length}, {}};
+    }
+
+    ScanRowRange requested_range;
+    // Sorted, non-overlapping segment-offset ranges that the data cursor must
+    // not return. Expressions still produce result/validity for these logical
+    // rows, using a validity-only cursor over the same PreparedScan when the
+    // source column is nullable.
+    std::vector<ScanRowRange> skip_ranges;
+};
+
+enum class ScanProjection;
+
+// PreparedScan owns the storage resources selected for one operator/expression
+// window, including cache pins. Open() may create a data cursor that applies a
+// skip plan or a validity-only cursor over a subrange; both reuse the same
+// window-local resources. PreparedScan must not be retained across expression
+// windows.
 class PreparedScan {
  public:
     virtual ~PreparedScan() = default;
@@ -194,8 +218,15 @@ class PreparedScan {
     virtual int64_t
     End() const = 0;
 
+    // Backend planner result for this prepared operator window. The plan is
+    // computed before data pinning from metadata that was loaded with the
+    // segment. Payload-dependent legacy Raw SkipIndex decisions are not part
+    // of this plan.
+    virtual const ScanPlan&
+    Plan() const = 0;
+
     virtual std::unique_ptr<ScanCursor>
-    Seek(int64_t position) const = 0;
+    Open(const ScanPlan& plan, ScanProjection projection) const = 0;
 };
 
 enum class ScanProjection {

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -1,0 +1,547 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include "common/Array.h"
+#include "common/ArrayValue.h"
+#include "common/EasyAssert.h"
+#include "common/Json.h"
+#include "common/Types.h"
+#include "common/ValidityView.h"
+
+namespace milvus {
+
+namespace detail {
+class ColumnFilter;
+using ColumnFilterPtr = std::shared_ptr<const ColumnFilter>;
+}  // namespace detail
+
+// The exact value representation requested by a Scan/Take caller. A backend
+// validates this contract when the operation is opened and may normalize its
+// storage representation while producing results. Next()/Get() never
+// renegotiate the selected target.
+enum class TargetType {
+    None,
+    Bool,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    Float,
+    Double,
+    StringView,
+    Json,
+    ArrayView,
+    ArrayValueView,
+    VectorArrayView,
+};
+
+namespace detail {
+
+template <typename T>
+constexpr TargetType
+TargetTypeOfOrNone() {
+    using ValueType = std::remove_cv_t<std::remove_reference_t<T>>;
+    if constexpr (std::is_same_v<ValueType, bool>) {
+        return TargetType::Bool;
+    } else if constexpr (std::is_same_v<ValueType, int8_t>) {
+        return TargetType::Int8;
+    } else if constexpr (std::is_same_v<ValueType, int16_t>) {
+        return TargetType::Int16;
+    } else if constexpr (std::is_same_v<ValueType, int32_t>) {
+        return TargetType::Int32;
+    } else if constexpr (std::is_same_v<ValueType, int64_t>) {
+        return TargetType::Int64;
+    } else if constexpr (std::is_same_v<ValueType, float>) {
+        return TargetType::Float;
+    } else if constexpr (std::is_same_v<ValueType, double>) {
+        return TargetType::Double;
+    } else if constexpr (std::is_same_v<ValueType, std::string_view>) {
+        return TargetType::StringView;
+    } else if constexpr (std::is_same_v<ValueType, Json>) {
+        return TargetType::Json;
+    } else if constexpr (std::is_same_v<ValueType, ArrayView>) {
+        return TargetType::ArrayView;
+    } else if constexpr (std::is_same_v<ValueType, ArrayValueView>) {
+        return TargetType::ArrayValueView;
+    } else if constexpr (std::is_same_v<ValueType, VectorArrayView>) {
+        return TargetType::VectorArrayView;
+    } else {
+        return TargetType::None;
+    }
+}
+
+}  // namespace detail
+
+template <typename T>
+inline constexpr bool HasTargetType =
+    detail::TargetTypeOfOrNone<T>() != TargetType::None;
+
+template <typename T>
+constexpr TargetType
+TargetTypeOf() {
+    static_assert(HasTargetType<T>, "unsupported Scan/Take target type");
+    return detail::TargetTypeOfOrNone<T>();
+}
+
+inline bool
+IsFixedWidthTargetType(TargetType target_type) {
+    return target_type == TargetType::Bool || target_type == TargetType::Int8 ||
+           target_type == TargetType::Int16 ||
+           target_type == TargetType::Int32 ||
+           target_type == TargetType::Int64 ||
+           target_type == TargetType::Float ||
+           target_type == TargetType::Double;
+}
+
+inline bool
+CanReadAsTargetType(DataType data_type, TargetType target_type) {
+    switch (data_type) {
+        case DataType::BOOL:
+            return target_type == TargetType::Bool;
+        case DataType::INT8:
+            return target_type == TargetType::Int8;
+        case DataType::INT16:
+            return target_type == TargetType::Int16;
+        case DataType::INT32:
+            return target_type == TargetType::Int32;
+        case DataType::INT64:
+        case DataType::TIMESTAMPTZ:
+            return target_type == TargetType::Int64;
+        case DataType::FLOAT:
+            return target_type == TargetType::Float;
+        case DataType::DOUBLE:
+            return target_type == TargetType::Double;
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+        case DataType::GEOMETRY:
+            return target_type == TargetType::StringView;
+        case DataType::JSON:
+            return target_type == TargetType::Json;
+        case DataType::ARRAY:
+            return target_type == TargetType::ArrayView ||
+                   target_type == TargetType::ArrayValueView;
+        case DataType::VECTOR_ARRAY:
+            return target_type == TargetType::VectorArrayView;
+        default:
+            return false;
+    }
+}
+
+enum class OffsetElementType {
+    Int32,
+    Int64,
+};
+
+// A non-owning view over positional row offsets. The array must outlive the
+// returned TakeResult because Raw results resolve Cells lazily. Supporting both
+// widths lets expression evaluation use its existing int32 offsets without a
+// widening copy while retrieve/requery can pass segment int64 offsets.
+struct OffsetView {
+    const void* data = nullptr;
+    int64_t size = 0;
+    OffsetElementType element_type = OffsetElementType::Int32;
+
+    static OffsetView
+    From(const int32_t* offsets, int64_t count) {
+        return OffsetView{offsets, count, OffsetElementType::Int32};
+    }
+
+    static OffsetView
+    From(const int64_t* offsets, int64_t count) {
+        return OffsetView{offsets, count, OffsetElementType::Int64};
+    }
+
+    int64_t
+    operator[](int64_t index) const {
+        AssertInfo(index >= 0 && index < size,
+                   "take offset index {} out of range {}",
+                   index,
+                   size);
+        AssertInfo(data != nullptr,
+                   "take offsets are null with non-empty size {}",
+                   size);
+        return AtUnchecked(index);
+    }
+
+    int64_t
+    AtUnchecked(int64_t index) const {
+        return element_type == OffsetElementType::Int32
+                   ? static_cast<const int32_t*>(data)[index]
+                   : static_cast<const int64_t*>(data)[index];
+    }
+};
+
+struct CellLocation {
+    int64_t cell_id = -1;
+    int64_t cell_offset = 0;
+};
+
+// The single Cell-geometry authority for one Column generation. Column
+// backends use it for segment-offset-to-Cell conversion and Take planning;
+// physical Cell details never leave the Column read implementation.
+class ColumnPlanner {
+ public:
+    // Production Columns borrow their immutable generation metadata. The
+    // rvalue overload retains ownership for standalone planners and tests.
+    explicit ColumnPlanner(const std::vector<int64_t>& num_rows_until_cell);
+    explicit ColumnPlanner(std::vector<int64_t>&& num_rows_until_cell);
+    virtual ~ColumnPlanner() = default;
+
+    CellLocation
+    Locate(int64_t segment_offset) const;
+
+    int64_t
+    CellStart(int64_t cell_id) const;
+
+    int64_t
+    CellRows(int64_t cell_id) const;
+
+    int64_t
+    NumCells() const;
+
+    int64_t
+    NumRows() const;
+
+    const std::vector<int64_t>&
+    CellBoundaries() const;
+
+ private:
+    void
+    ValidateBoundaries() const;
+
+    std::shared_ptr<const std::vector<int64_t>> owned_num_rows_until_cell_;
+    const std::vector<int64_t>* num_rows_until_cell_{nullptr};
+};
+
+struct ValueView {
+    TargetType target_type = TargetType::None;
+    const void* data = nullptr;
+    int64_t offset = 0;
+    int32_t byte_width = 0;
+
+    bool
+    empty() const {
+        return target_type == TargetType::None || data == nullptr;
+    }
+
+    template <typename T>
+    const T*
+    data_as() const {
+        AssertInfo(target_type == TargetTypeOf<T>() && data != nullptr,
+                   "scan value view is empty");
+        AssertInfo(byte_width == sizeof(T),
+                   "scan value width {} does not match requested type width {}",
+                   byte_width,
+                   sizeof(T));
+        return static_cast<const T*>(data) + offset;
+    }
+};
+
+struct ScanBatch {
+    // Every batch represents the dense row range
+    // [row_id_start, row_id_start + size). Values are optional based on the
+    // requested projection, while validity remains aligned with this range.
+    ValueView values;
+    // Empty means every row in this batch is valid. The view may reference
+    // expanded bools or an LSB-first packed bitmap owned by `owner`.
+    ValidityView validity;
+    std::shared_ptr<void> owner;
+    int64_t row_id_start = 0;
+    int64_t size = 0;
+    // True only when the Column's filter proved that this batch's data is not
+    // needed. Validity remains the field's real validity. The cursor splits at
+    // filter boundaries, so this state applies to the complete dense batch.
+    bool data_skipped = false;
+};
+
+struct OwnedTakeData {
+    ValueView values;
+    ValidityView validity;
+    std::shared_ptr<void> owner;
+    int64_t size = 0;
+    // Empty means no positions were skipped. When present, this view is
+    // aligned with the requested offsets; values at true positions are
+    // unspecified and must not be evaluated.
+    ValidityView data_skipped;
+};
+
+template <typename T>
+struct TakeItem {
+    std::optional<T> value;
+    bool is_valid = true;
+    bool data_skipped = false;
+};
+
+struct TakeItemState {
+    bool is_valid = true;
+    bool data_skipped = false;
+};
+
+// Ordered positional access over one finite offset set. The input offsets must
+// outlive the result; callers do not manage backend Cell lifetimes.
+// Reader-backed results may already contain one dense owned value array. Raw
+// results pin only the Cell used by the current borrowed access; a borrowed
+// string/JSON/array view remains valid until the next access that switches
+// Cells, GetOwn(), or result destruction. Raw borrowed access and GetOwn() must
+// complete while the OpContext passed to Take() remains alive. TakeResult is
+// not thread-safe.
+class TakeResult {
+ public:
+    virtual ~TakeResult() = default;
+
+    // A non-owning type-checked view over this result for a bounded caller
+    // loop. It must not outlive the TakeResult. Access() validates the stable
+    // result contract once; operator[] deliberately does not repeat bounds or
+    // type checks for every item.
+    template <typename T>
+    class TypedAccessor {
+     public:
+        int64_t
+        Size() const {
+            return size_;
+        }
+
+        TakeItem<T>
+        operator[](int64_t index) const {
+            return result_->template GetUnchecked<T>(index);
+        }
+
+     private:
+        friend class TakeResult;
+
+        TypedAccessor(const TakeResult* result, int64_t size)
+            : result_(result), size_(size) {
+        }
+
+        const TakeResult* result_;
+        int64_t size_;
+    };
+
+    virtual int64_t
+    Size() const = 0;
+
+    virtual TargetType
+    GetTargetType() const = 0;
+
+    virtual DataType
+    GetDataType() const = 0;
+
+    // Validity-only access. It may pin the physical source because nullable
+    // validity is colocated with data, but it must not construct/decode data or
+    // evaluate the optional data filter.
+    bool
+    IsValid(int64_t index) const {
+        CheckIndex(index);
+        return PrepareItem(index, /*read_data=*/false).is_valid;
+    }
+
+    // True when GetOwn() can return the existing dense result without
+    // materializing Raw payload.
+    virtual bool
+    IsOwned() const = 0;
+
+    // Return an ordered dense value collection whose lifetime is independent
+    // of Raw Cell pins. Vortex results normally return their existing decoded
+    // owner; Raw results materialize and cache this representation lazily.
+    virtual OwnedTakeData
+    GetOwn() const = 0;
+
+    template <typename T>
+    TypedAccessor<T>
+    Access() const {
+        const auto size = Size();
+        AssertInfo(size >= 0, "take result has invalid size {}", size);
+        const auto target_type = GetTargetType();
+        AssertInfo(target_type == TargetTypeOf<T>(),
+                   "take result target {} does not match requested target {}",
+                   static_cast<int>(target_type),
+                   static_cast<int>(TargetTypeOf<T>()));
+        const auto data_type = GetDataType();
+        AssertInfo(CanReadAsTargetType(data_type, target_type),
+                   "take result type {} does not match requested target {}",
+                   data_type,
+                   static_cast<int>(target_type));
+        return TypedAccessor<T>(this, size);
+    }
+
+    template <typename T>
+    TakeItem<T>
+    Get(int64_t index) const {
+        auto accessor = Access<T>();
+        AssertInfo(index >= 0 && index < accessor.Size(),
+                   "take result index {} out of range {}",
+                   index,
+                   accessor.Size());
+        return accessor[index];
+    }
+
+ protected:
+    template <typename T>
+    TakeItem<T>
+    GetUnchecked(int64_t index) const {
+        auto state = PrepareItem(index, /*read_data=*/true);
+        TakeItem<T> item{std::nullopt, state.is_valid, state.data_skipped};
+        if (!state.is_valid || state.data_skipped) {
+            return item;
+        }
+        if constexpr (std::is_same_v<T, std::string_view>) {
+            item.value.emplace(StringViewAt(index));
+        } else if constexpr (std::is_same_v<T, Json>) {
+            item.value.emplace(JsonAt(index));
+        } else if constexpr (std::is_same_v<T, ArrayView>) {
+            item.value.emplace(ArrayAt(index));
+        } else if constexpr (std::is_same_v<T, ArrayValueView>) {
+            item.value.emplace(ArrayValueAt(index));
+        } else if constexpr (std::is_same_v<T, VectorArrayView>) {
+            item.value.emplace(VectorArrayAt(index));
+        } else {
+            item.value.emplace(*static_cast<const T*>(FixedValueAt(index)));
+        }
+        return item;
+    }
+
+    void
+    CheckIndex(int64_t index) const {
+        const auto size = Size();
+        AssertInfo(index >= 0 && index < size,
+                   "take result index {} out of range {}",
+                   index,
+                   size);
+    }
+
+    virtual TakeItemState
+    PrepareItem(int64_t index, bool read_data) const = 0;
+
+    virtual const void*
+    FixedValueAt(int64_t index) const = 0;
+
+    virtual std::string_view
+    StringViewAt(int64_t index) const = 0;
+
+    virtual Json
+    JsonAt(int64_t index) const = 0;
+
+    virtual ArrayView
+    ArrayAt(int64_t index) const = 0;
+
+    virtual ArrayValueView
+    ArrayValueAt(int64_t) const {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "take result does not contain recursive ARRAY values");
+    }
+
+    virtual VectorArrayView
+    VectorArrayAt(int64_t) const {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "take result does not contain VECTOR_ARRAY values");
+    }
+};
+
+struct TakeOptions {
+    OffsetView offsets;
+    TargetType target_type = TargetType::None;
+    // Backend-neutral filter binding. Physical Cell/file planning and skip
+    // decisions remain inside the Column implementation.
+    detail::ColumnFilterPtr filter;
+};
+
+enum class ScanReadMode {
+    // Return data and, for nullable columns, aligned validity.
+    DataAndValidity,
+    // For nullable data scans, return aligned validity without constructing
+    // or decoding data. Non-nullable columns must reject this mode.
+    ValidityOnly,
+};
+
+class ScanCursor {
+ public:
+    virtual ~ScanCursor() = default;
+
+    // The next unread absolute segment position. A cursor is initialized at
+    // ScanOptions::start_offset and advances by the source range consumed by
+    // Next().
+    virtual int64_t
+    Position() const = 0;
+
+    // Move the next unread position forward without reading the intervening
+    // rows. Seeking backward is not supported; reopen a cursor instead.
+    virtual void
+    Seek(int64_t position) = 0;
+
+    // Return at most one dense batch beginning exactly at Position(). The
+    // returned size may be smaller than length at a Cell, file, reader, or
+    // ownership boundary, but must never exceed length. A zero-length request
+    // returns false. Under CursorOwned, consume the borrowed batch before the
+    // next Next()/Seek(); under ResultOwned, its views remain valid while the
+    // returned batch owner remains alive.
+    virtual bool
+    Next(int64_t length, ScanReadMode read_mode, ScanBatch* out) = 0;
+};
+
+enum class ScanPinPolicy {
+    // The returned batch owns the physical Cell pin. Destroying or replacing
+    // the batch releases that pin independently of cursor movement.
+    ResultOwned,
+    // The cursor owns the physical Cell pin. A returned batch is borrowed and
+    // must be consumed before the next Next()/Seek() call.
+    CursorOwned,
+};
+
+struct ScanOptions {
+    ScanOptions() = default;
+
+    ScanOptions(int64_t start_offset,
+                TargetType target_type,
+                ScanPinPolicy pin_policy = ScanPinPolicy::ResultOwned,
+                bool prefetch = false)
+        : start_offset(start_offset),
+          target_type(target_type),
+          pin_policy(pin_policy),
+          prefetch(prefetch) {
+    }
+
+    static ScanOptions
+    ForData(int64_t start_offset,
+            TargetType target_type,
+            ScanPinPolicy pin_policy = ScanPinPolicy::ResultOwned,
+            bool prefetch = false) {
+        return ScanOptions(start_offset, target_type, pin_policy, prefetch);
+    }
+
+    int64_t start_offset = 0;
+    TargetType target_type = TargetType::None;
+    ScanPinPolicy pin_policy = ScanPinPolicy::ResultOwned;
+    // Batch-warm all remaining Cells at cursor creation without retaining
+    // their pins, matching the legacy multi-chunk inline prefetch. Reads still
+    // pin the current Cell one at a time, but cold loads are submitted
+    // together so tiered-storage I/O stays parallel.
+    bool prefetch = false;
+    detail::ColumnFilterPtr filter;
+};
+
+using ScanResult = std::unique_ptr<ScanCursor>;
+using TakeResultPtr = std::unique_ptr<TakeResult>;
+
+}  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -1,0 +1,560 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "mmap/ChunkedColumnFilter.h"
+#include "mmap/ChunkedColumnInterface.h"
+
+namespace milvus {
+namespace detail {
+
+class PinnedScanInput final {
+ public:
+    PinnedScanInput(int64_t chunk_id, PinWrapper<Chunk*>&& chunk)
+        : chunk_id_(chunk_id), chunk_(std::move(chunk)) {
+    }
+
+    Chunk*
+    GetChunk(int64_t chunk_id) const {
+        AssertInfo(chunk_id == chunk_id_,
+                   "scan chunk {} is not pinned, current chunk {}",
+                   chunk_id,
+                   chunk_id_);
+        return chunk_.get();
+    }
+
+ private:
+    int64_t chunk_id_;
+    PinWrapper<Chunk*> chunk_;
+};
+
+using StringViews = std::pair<std::vector<std::string_view>, ValidityView>;
+using ArrayViews = std::pair<std::vector<ArrayView>, ValidityView>;
+using ArrayValueViews = std::pair<std::vector<ArrayValueView>, ValidityView>;
+using VectorArrayViews = std::pair<std::vector<VectorArrayView>, ValidityView>;
+
+struct StringOwner {
+    StringOwner(std::shared_ptr<PinnedScanInput> input, StringViews&& views)
+        : input(std::move(input)), views(std::move(views)) {
+    }
+
+    std::shared_ptr<PinnedScanInput> input;
+    StringViews views;
+};
+
+struct JsonOwner {
+    JsonOwner(std::shared_ptr<PinnedScanInput> input, StringViews&& views)
+        : input(std::move(input)), views(std::move(views)) {
+        values.reserve(this->views.first.size());
+        for (const auto& value : this->views.first) {
+            values.emplace_back(value);
+        }
+    }
+
+    std::shared_ptr<PinnedScanInput> input;
+    StringViews views;
+    std::vector<Json> values;
+};
+
+struct ArrayOwner {
+    ArrayOwner(std::shared_ptr<PinnedScanInput> input, ArrayViews&& views)
+        : input(std::move(input)), views(std::move(views)) {
+    }
+
+    std::shared_ptr<PinnedScanInput> input;
+    ArrayViews views;
+};
+
+struct ArrayValueOwner {
+    ArrayValueOwner(std::shared_ptr<PinnedScanInput> input,
+                    ArrayValueViews&& views)
+        : input(std::move(input)), views(std::move(views)) {
+    }
+
+    std::shared_ptr<PinnedScanInput> input;
+    ArrayValueViews views;
+};
+
+struct VectorArrayOwner {
+    VectorArrayOwner(std::shared_ptr<PinnedScanInput> input,
+                     VectorArrayViews&& views)
+        : input(std::move(input)), views(std::move(views)) {
+    }
+
+    std::shared_ptr<PinnedScanInput> input;
+    VectorArrayViews views;
+};
+
+class RawScanCursor final : public ChunkedColumnInterface::ScanCursor {
+ public:
+    RawScanCursor(const ChunkedColumnInterface* column,
+                  const ColumnPlanner* planner,
+                  milvus::OpContext* op_ctx,
+                  int64_t start_offset,
+                  ChunkedColumnInterface::TargetType target_type,
+                  ChunkedColumnInterface::ScanPinPolicy pin_policy,
+                  bool prefetch,
+                  ColumnFilterPtr filter)
+        : column_(column),
+          planner_(planner),
+          op_ctx_(op_ctx),
+          target_type_(target_type),
+          pin_policy_(pin_policy),
+          filter_(std::move(filter)),
+          scan_pos_(start_offset) {
+        AssertInfo(column_ != nullptr, "raw scan column is null");
+        AssertInfo(planner_ != nullptr, "raw scan planner is null");
+        AssertInfo(start_offset >= 0 && start_offset <= planner_->NumRows(),
+                   "data scan start {} out of rows {}",
+                   start_offset,
+                   planner_->NumRows());
+        SetPhysicalPosition(start_offset);
+        if (prefetch) {
+            if (filter_ != nullptr &&
+                filter_->Source() ==
+                    ColumnFilter::MetricsSource::PreloadedStatistics) {
+                prefetched_skip_decisions_.assign(planner_->NumCells(), -1);
+            }
+            PrefetchRemainingCells();
+        }
+    }
+
+    int64_t
+    Position() const override {
+        return scan_pos_;
+    }
+
+    void
+    Seek(int64_t position) override {
+        AssertInfo(position >= scan_pos_,
+                   "raw scan cannot seek backward from {} to {}",
+                   scan_pos_,
+                   position);
+        AssertInfo(position <= planner_->NumRows(),
+                   "raw scan seek {} out of rows {}",
+                   position,
+                   planner_->NumRows());
+        if (position == scan_pos_) {
+            return;
+        }
+        SetPhysicalPosition(position);
+        if (cursor_input_ != nullptr && cursor_chunk_id_ != current_chunk_id_) {
+            ReleaseCursorInput();
+        }
+    }
+
+    bool
+    Next(int64_t length,
+         ChunkedColumnInterface::ScanReadMode read_mode,
+         ChunkedColumnInterface::ScanBatch* out) override {
+        AssertInfo(out != nullptr, "raw scan output batch is null");
+        ResetOutput(out);
+        AssertInfo(
+            length >= 0, "raw scan length {} must be non-negative", length);
+        if (length == 0 || scan_pos_ == planner_->NumRows()) {
+            ReleaseCursorInput();
+            return false;
+        }
+        length = std::min(length, planner_->NumRows() - scan_pos_);
+        AssertInfo(
+            read_mode != ChunkedColumnInterface::ScanReadMode::ValidityOnly ||
+                column_->IsNullable(),
+            "validity-only scan requested for non-nullable column");
+
+        const auto chunk_id = current_chunk_id_;
+        const auto chunk_rows = planner_->CellRows(chunk_id);
+        const auto size =
+            std::min<int64_t>(length, chunk_rows - current_chunk_offset_);
+        AssertInfo(size > 0,
+                   "raw scan made no progress in chunk {} at offset {}",
+                   chunk_id,
+                   current_chunk_offset_);
+
+        out->row_id_start = scan_pos_;
+        out->size = size;
+
+        if (read_mode == ChunkedColumnInterface::ScanReadMode::ValidityOnly) {
+            auto input = PinChunk(chunk_id);
+            auto* chunk = input->GetChunk(chunk_id);
+            FillValidityOnly(input, chunk, out);
+            Advance(size);
+            return true;
+        }
+
+        const auto preloaded_skip =
+            filter_ != nullptr &&
+            filter_->Source() ==
+                ColumnFilter::MetricsSource::PreloadedStatistics;
+        auto data_skipped = preloaded_skip && ShouldSkipCell(chunk_id);
+        if (data_skipped && !column_->IsNullable()) {
+            // Next() invalidates the previous batch. A CursorOwned pin from
+            // that batch must not survive merely because this Cell needs no
+            // data pin of its own.
+            ReleaseCursorInput();
+            out->data_skipped = true;
+            Advance(size);
+            return true;
+        }
+
+        auto input = PinChunk(chunk_id);
+        auto* chunk = input->GetChunk(chunk_id);
+        if (!data_skipped && filter_ != nullptr &&
+            filter_->Source() == ColumnFilter::MetricsSource::LoadedPayload) {
+            data_skipped = ShouldSkipCell(chunk_id);
+        }
+
+        if (data_skipped) {
+            out->data_skipped = true;
+            if (column_->IsNullable()) {
+                FillValidityOnly(input, chunk, out);
+            }
+            Advance(size);
+            return true;
+        }
+
+        if (IsFixedWidthTargetType(target_type_)) {
+            FillFixedWidth(input, chunk, out);
+        } else {
+            FillView(input, chunk, out);
+        }
+
+        Advance(size);
+        return true;
+    }
+
+ private:
+    static void
+    ResetOutput(ChunkedColumnInterface::ScanBatch* out) {
+        out->values = ChunkedColumnInterface::ValueView{};
+        out->validity = {};
+        out->owner.reset();
+        out->row_id_start = 0;
+        out->size = 0;
+        out->data_skipped = false;
+    }
+
+    void
+    SetPhysicalPosition(int64_t position) {
+        scan_pos_ = position;
+        if (position == planner_->NumRows()) {
+            current_chunk_id_ = planner_->NumCells();
+            current_chunk_offset_ = 0;
+            return;
+        }
+        const auto location = planner_->Locate(position);
+        current_chunk_id_ = location.cell_id;
+        current_chunk_offset_ = location.cell_offset;
+    }
+
+    std::shared_ptr<PinnedScanInput>
+    PinChunk(int64_t chunk_id) {
+        if (pin_policy_ == ChunkedColumnInterface::ScanPinPolicy::CursorOwned) {
+            if (cursor_input_ != nullptr) {
+                if (cursor_chunk_id_ == chunk_id) {
+                    return cursor_input_;
+                }
+                // Release the previous Cell before pinning the next one. This
+                // keeps CursorOwned at one physical Cell pin throughout Scan.
+                ReleaseCursorInput();
+            }
+            cursor_input_ = std::make_shared<PinnedScanInput>(
+                chunk_id, column_->GetChunk(op_ctx_, chunk_id));
+            cursor_chunk_id_ = chunk_id;
+            return cursor_input_;
+        }
+        return std::make_shared<PinnedScanInput>(
+            chunk_id, column_->GetChunk(op_ctx_, chunk_id));
+    }
+
+    std::shared_ptr<PinnedScanInput>
+    BatchPin(const std::shared_ptr<PinnedScanInput>& input) const {
+        return pin_policy_ == ChunkedColumnInterface::ScanPinPolicy::ResultOwned
+                   ? input
+                   : nullptr;
+    }
+
+    void
+    ReleaseCursorInput() {
+        cursor_input_.reset();
+        cursor_chunk_id_ = -1;
+    }
+
+    void
+    PrefetchRemainingCells() {
+        // Batch-warm every remaining Cell once, matching the legacy
+        // multi-chunk path that submitted all remaining chunk ids to
+        // prefetch_chunks() before evaluation. PrefetchChunks loads in
+        // parallel and drops the pins immediately, so per-batch reads still
+        // pin the current Cell but hit the warmed cache.
+        if (current_chunk_id_ >= planner_->NumCells()) {
+            return;
+        }
+        std::vector<int64_t> remaining;
+        remaining.reserve(planner_->NumCells() - current_chunk_id_);
+        for (int64_t cell_id = current_chunk_id_;
+             cell_id < planner_->NumCells();
+             ++cell_id) {
+            if (planner_->CellRows(cell_id) == 0) {
+                continue;
+            }
+            const auto data_skipped =
+                filter_ != nullptr &&
+                filter_->Source() ==
+                    ColumnFilter::MetricsSource::PreloadedStatistics &&
+                ShouldSkipCell(cell_id);
+            // A nullable skipped Cell is still needed for its real validity.
+            if (data_skipped && !column_->IsNullable()) {
+                continue;
+            }
+            remaining.push_back(cell_id);
+        }
+        if (remaining.empty()) {
+            return;
+        }
+        column_->PrefetchChunks(op_ctx_, remaining);
+    }
+
+    void
+    FillValidityOnly(const std::shared_ptr<PinnedScanInput>& input,
+                     Chunk* chunk,
+                     ChunkedColumnInterface::ScanBatch* out) const {
+        out->validity = chunk->Validity(current_chunk_offset_);
+        out->owner = BatchPin(input);
+    }
+
+    void
+    FillFixedWidth(const std::shared_ptr<PinnedScanInput>& input,
+                   Chunk* chunk,
+                   ChunkedColumnInterface::ScanBatch* out) const {
+        auto* fixed_chunk = dynamic_cast<FixedWidthChunk*>(chunk);
+        AssertInfo(fixed_chunk != nullptr,
+                   "scan chunk {} is not fixed-width",
+                   current_chunk_id_);
+        const auto span = fixed_chunk->Span();
+        AssertInfo(span.row_count() == planner_->CellRows(current_chunk_id_),
+                   "scan chunk {} row count mismatch, metadata {}, span {}",
+                   current_chunk_id_,
+                   planner_->CellRows(current_chunk_id_),
+                   span.row_count());
+        out->values.target_type = target_type_;
+        out->values.data = span.data();
+        out->values.offset = current_chunk_offset_;
+        out->values.byte_width = span.element_sizeof();
+        out->validity = span.validity().Subview(current_chunk_offset_);
+        out->owner = BatchPin(input);
+    }
+
+    void
+    FillView(const std::shared_ptr<PinnedScanInput>& input,
+             Chunk* chunk,
+             ChunkedColumnInterface::ScanBatch* out) const {
+        const auto range = std::make_pair(current_chunk_offset_, out->size);
+        switch (target_type_) {
+            case ChunkedColumnInterface::TargetType::StringView: {
+                auto* string_chunk = dynamic_cast<StringChunk*>(chunk);
+                AssertInfo(string_chunk != nullptr,
+                           "scan chunk {} is not string-like",
+                           current_chunk_id_);
+                auto owner = std::make_shared<StringOwner>(
+                    BatchPin(input), string_chunk->StringViews(range));
+                out->values.target_type = target_type_;
+                out->values.data = owner->views.first.data();
+                out->values.offset = 0;
+                out->values.byte_width = sizeof(std::string_view);
+                FillViewValidity(owner->views.second, out);
+                out->owner = std::move(owner);
+                return;
+            }
+            case ChunkedColumnInterface::TargetType::Json: {
+                auto* string_chunk = dynamic_cast<StringChunk*>(chunk);
+                AssertInfo(string_chunk != nullptr,
+                           "scan chunk {} is not JSON",
+                           current_chunk_id_);
+                auto owner = std::make_shared<JsonOwner>(
+                    BatchPin(input), string_chunk->StringViews(range));
+                out->values.target_type = target_type_;
+                out->values.data = owner->values.data();
+                out->values.offset = 0;
+                out->values.byte_width = sizeof(Json);
+                FillViewValidity(owner->views.second, out);
+                out->owner = std::move(owner);
+                return;
+            }
+            case ChunkedColumnInterface::TargetType::ArrayView: {
+                auto* array_chunk = dynamic_cast<ArrayChunk*>(chunk);
+                AssertInfo(array_chunk != nullptr,
+                           "scan chunk {} is not an array",
+                           current_chunk_id_);
+                auto owner = std::make_shared<ArrayOwner>(
+                    BatchPin(input), array_chunk->Views(range));
+                out->values.target_type = target_type_;
+                out->values.data = owner->views.first.data();
+                out->values.offset = 0;
+                out->values.byte_width = sizeof(ArrayView);
+                FillViewValidity(owner->views.second, out);
+                out->owner = std::move(owner);
+                return;
+            }
+            case ChunkedColumnInterface::TargetType::ArrayValueView: {
+                auto* array_chunk = dynamic_cast<ColumnarArrayChunk*>(chunk);
+                AssertInfo(array_chunk != nullptr,
+                           "scan chunk {} is not a recursive array",
+                           current_chunk_id_);
+                auto owner = std::make_shared<ArrayValueOwner>(
+                    BatchPin(input), array_chunk->Views<ArrayValueView>(range));
+                out->values.target_type = target_type_;
+                out->values.data = owner->views.first.data();
+                out->values.offset = 0;
+                out->values.byte_width = sizeof(ArrayValueView);
+                FillViewValidity(owner->views.second, out);
+                out->owner = std::move(owner);
+                return;
+            }
+            case ChunkedColumnInterface::TargetType::VectorArrayView: {
+                auto* array_chunk = dynamic_cast<VectorArrayChunk*>(chunk);
+                AssertInfo(array_chunk != nullptr,
+                           "scan chunk {} is not a vector array",
+                           current_chunk_id_);
+                auto owner = std::make_shared<VectorArrayOwner>(
+                    BatchPin(input), array_chunk->Views(range));
+                out->values.target_type = target_type_;
+                out->values.data = owner->views.first.data();
+                out->values.offset = 0;
+                out->values.byte_width = sizeof(VectorArrayView);
+                FillViewValidity(owner->views.second, out);
+                out->owner = std::move(owner);
+                return;
+            }
+            default:
+                ThrowInfo(ErrorCode::Unsupported,
+                          "unsupported raw scan target type {}",
+                          static_cast<int>(target_type_));
+        }
+    }
+
+    void
+    FillViewValidity(ValidityView validity,
+                     ChunkedColumnInterface::ScanBatch* out) const {
+        if (column_->IsNullable()) {
+            out->validity = validity;
+        }
+    }
+
+    void
+    Advance(int64_t size) {
+        scan_pos_ += size;
+        current_chunk_offset_ += size;
+        if (scan_pos_ == planner_->NumRows()) {
+            current_chunk_id_ = planner_->NumCells();
+            current_chunk_offset_ = 0;
+            return;
+        }
+
+        if (current_chunk_offset_ == planner_->CellRows(current_chunk_id_)) {
+            ++current_chunk_id_;
+            current_chunk_offset_ = 0;
+            while (current_chunk_id_ < planner_->NumCells() &&
+                   planner_->CellRows(current_chunk_id_) == 0) {
+                ++current_chunk_id_;
+            }
+        }
+    }
+
+    bool
+    ShouldSkipCell(int64_t cell_id) {
+        AssertInfo(
+            filter_ != nullptr, "raw scan has no filter for Cell {}", cell_id);
+        if (!prefetched_skip_decisions_.empty()) {
+            auto& decision = prefetched_skip_decisions_[cell_id];
+            if (decision < 0) {
+                decision = filter_->CanSkipPhysicalCell(cell_id) ? 1 : 0;
+            }
+            return decision != 0;
+        }
+        if (filter_cell_id_ != cell_id) {
+            filter_cell_id_ = cell_id;
+            filter_cell_skipped_ = filter_->CanSkipPhysicalCell(cell_id);
+        }
+        return filter_cell_skipped_;
+    }
+
+    const ChunkedColumnInterface* column_;
+    const ColumnPlanner* planner_{nullptr};
+    milvus::OpContext* op_ctx_;
+    ChunkedColumnInterface::TargetType target_type_;
+    ChunkedColumnInterface::ScanPinPolicy pin_policy_;
+    ColumnFilterPtr filter_;
+    int64_t scan_pos_{0};
+    int64_t current_chunk_id_{0};
+    int64_t current_chunk_offset_{0};
+    std::shared_ptr<PinnedScanInput> cursor_input_;
+    int64_t cursor_chunk_id_{-1};
+    int64_t filter_cell_id_{-1};
+    bool filter_cell_skipped_{false};
+    std::vector<int8_t> prefetched_skip_decisions_;
+};
+
+inline ChunkedColumnInterface::ScanResult
+OpenDataScan(const ChunkedColumnInterface* column,
+             const ColumnPlanner* planner,
+             milvus::OpContext* op_ctx,
+             int64_t start_offset,
+             DataType data_type,
+             ChunkedColumnInterface::TargetType target_type,
+             ChunkedColumnInterface::ScanPinPolicy pin_policy,
+             bool prefetch,
+             ColumnFilterPtr filter) {
+    AssertInfo(target_type == ChunkedColumnInterface::TargetType::None ||
+                   CanReadAsTargetType(data_type, target_type),
+               "data scan target {} does not match column type {}",
+               static_cast<int>(target_type),
+               data_type);
+    return std::make_unique<RawScanCursor>(column,
+                                           planner,
+                                           op_ctx,
+                                           start_offset,
+                                           target_type,
+                                           pin_policy,
+                                           prefetch,
+                                           std::move(filter));
+}
+
+}  // namespace detail
+
+ChunkedColumnInterface::ScanResult
+ChunkedColumnInterface::Scan(milvus::OpContext* op_ctx,
+                             const ScanOptions& options) const {
+    auto data_type = GetDefaultScanDataType();
+    if (!data_type.has_value()) {
+        return nullptr;
+    }
+    return detail::OpenDataScan(this,
+                                &Planner(),
+                                op_ctx,
+                                options.start_offset,
+                                *data_type,
+                                options.target_type,
+                                options.pin_policy,
+                                options.prefetch,
+                                options.filter);
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -169,14 +169,19 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
                        int64_t length,
                        DataType data_type,
                        ChunkedColumnInterface::ScanProjection projection,
-                       ChunkedColumnInterface::ScanValueKind value_kind)
+                       ChunkedColumnInterface::ScanValueKind value_kind,
+                       int64_t max_batch_rows)
         : column_(column),
           op_ctx_(op_ctx),
           data_type_(data_type),
           projection_(projection),
           value_kind_(value_kind),
+          max_batch_rows_(max_batch_rows),
           scan_pos_(start_offset),
           scan_end_(start_offset + length) {
+        AssertInfo(max_batch_rows_ > 0,
+                   "view data scan max batch rows must be positive, got {}",
+                   max_batch_rows_);
     }
 
     bool
@@ -189,8 +194,11 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
 
         auto [chunk_id, offset] = column_->GetChunkIDByOffset(scan_pos_);
         const auto chunk_rows = column_->chunk_row_nums(chunk_id);
-        const auto rows_to_return = std::min<int64_t>(
-            {chunk_rows - static_cast<int64_t>(offset), scan_end_ - scan_pos_});
+        auto rows_to_return = std::min<int64_t>(
+            chunk_rows - static_cast<int64_t>(offset), scan_end_ - scan_pos_);
+        if (projection_ != ChunkedColumnInterface::ScanProjection::NoData) {
+            rows_to_return = std::min(rows_to_return, max_batch_rows_);
+        }
         AssertInfo(rows_to_return > 0,
                    "invalid view data scan batch at offset {}",
                    scan_pos_);
@@ -417,6 +425,7 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     DataType data_type_;
     ChunkedColumnInterface::ScanProjection projection_;
     ChunkedColumnInterface::ScanValueKind value_kind_;
+    int64_t max_batch_rows_;
     int64_t scan_pos_;
     int64_t scan_end_;
 };
@@ -455,7 +464,8 @@ MakeDataScanCursor(const ChunkedColumnInterface* column,
                    int64_t length,
                    DataType data_type,
                    ChunkedColumnInterface::ScanProjection projection,
-                   ChunkedColumnInterface::ScanValueKind value_kind) {
+                   ChunkedColumnInterface::ScanValueKind value_kind,
+                   int64_t max_batch_rows) {
     std::optional<ChunkedColumnInterface::ScanValueKind> column_kind;
     if (ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
         column_kind = ChunkedColumnInterface::ScanValueKind::FixedWidth;
@@ -517,7 +527,8 @@ MakeDataScanCursor(const ChunkedColumnInterface* column,
                                                     length,
                                                     data_type,
                                                     projection,
-                                                    resolved_kind);
+                                                    resolved_kind,
+                                                    max_batch_rows);
     }
 
     return nullptr;
@@ -539,7 +550,8 @@ ChunkedColumnInterface::Scan(milvus::OpContext* op_ctx,
                                       options.length,
                                       *data_type,
                                       options.projection,
-                                      options.value_kind);
+                                      options.value_kind,
+                                      options.max_batch_rows);
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -1,0 +1,545 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "mmap/ChunkedColumnInterface.h"
+
+namespace milvus {
+
+namespace detail {
+
+class FixedWidthDataScanCursor final
+    : public ChunkedColumnInterface::ScanCursor {
+ public:
+    FixedWidthDataScanCursor(const ChunkedColumnInterface* column,
+                             milvus::OpContext* op_ctx,
+                             int64_t start_offset,
+                             int64_t length,
+                             DataType data_type,
+                             ChunkedColumnInterface::ScanProjection projection,
+                             ChunkedColumnInterface::ScanValueKind value_kind)
+        : column_(column),
+          op_ctx_(op_ctx),
+          data_type_(data_type),
+          projection_(projection),
+          value_kind_(value_kind),
+          scan_pos_(start_offset),
+          scan_end_(start_offset + length) {
+        if (start_offset < scan_end_) {
+            auto [chunk_id, offset] = column_->GetChunkIDByOffset(start_offset);
+            current_chunk_id_ = static_cast<int64_t>(chunk_id);
+            current_chunk_offset_ = static_cast<int64_t>(offset);
+        }
+    }
+
+    bool
+    Next(ChunkedColumnInterface::ScanBatch* out) override {
+        AssertInfo(out != nullptr, "data scan output batch is null");
+        out->values = ChunkedColumnInterface::ValueView{};
+        out->validity = ChunkedColumnInterface::ValidityView{};
+        out->owner.reset();
+        out->row_id_start = 0;
+        out->size = 0;
+        if (scan_pos_ >= scan_end_) {
+            return false;
+        }
+
+        while (scan_pos_ < scan_end_) {
+            const auto rows = column_->chunk_row_nums(current_chunk_id_);
+            if (current_chunk_offset_ >= rows) {
+                ++current_chunk_id_;
+                current_chunk_offset_ = 0;
+                cached_span_.reset();
+                continue;
+            }
+
+            const auto rows_left_in_chunk = rows - current_chunk_offset_;
+            const auto rows_left_in_scan = scan_end_ - scan_pos_;
+            const auto rows_to_return =
+                std::min<int64_t>(rows_left_in_chunk, rows_left_in_scan);
+
+            if (projection_ == ChunkedColumnInterface::ScanProjection::NoData &&
+                !column_->IsNullable()) {
+                out->validity.encoding =
+                    ChunkedColumnInterface::ValidityEncoding::AllValid;
+                out->validity.size = rows_to_return;
+                out->validity.nullable = false;
+                out->validity.all_valid = true;
+                out->row_id_start = scan_pos_;
+                out->size = rows_to_return;
+                scan_pos_ += rows_to_return;
+                current_chunk_offset_ += rows_to_return;
+                return true;
+            }
+
+            auto& span = GetCurrentSpan();
+            AssertInfo(span.get().row_count() == rows,
+                       "scan chunk {} row count mismatch, metadata {}, span {}",
+                       current_chunk_id_,
+                       rows,
+                       span.get().row_count());
+            std::shared_ptr<void> owner;
+            if (projection_ != ChunkedColumnInterface::ScanProjection::NoData) {
+                out->values.encoding =
+                    ChunkedColumnInterface::ValueEncoding::FixedWidth;
+                out->values.kind =
+                    value_kind_ ==
+                            ChunkedColumnInterface::ScanValueKind::Default
+                        ? ChunkedColumnInterface::ScanValueKind::FixedWidth
+                        : value_kind_;
+                out->values.physical_type = data_type_;
+                out->values.logical_type = data_type_;
+                out->values.size = rows_to_return;
+                out->values.byte_width = span.get().element_sizeof();
+                // Primitive ChunkWriter keeps one payload slot per logical
+                // row; validity masks null slots instead of compacting them.
+                out->values.data = span.get().data();
+                out->values.offset = current_chunk_offset_;
+                owner = std::make_shared<PinWrapper<SpanBase>>(span);
+            }
+            out->validity.size = rows_to_return;
+            out->validity.nullable = column_->IsNullable();
+            if (span.get().valid_data() != nullptr) {
+                out->validity.encoding =
+                    ChunkedColumnInterface::ValidityEncoding::BoolArray;
+                out->validity.data = span.get().valid_data();
+                out->validity.offset = current_chunk_offset_;
+                out->validity.all_valid = false;
+            }
+            if (owner == nullptr) {
+                owner = std::make_shared<PinWrapper<SpanBase>>(span);
+            }
+            out->owner = std::move(owner);
+            out->row_id_start = scan_pos_;
+            out->size = rows_to_return;
+
+            scan_pos_ += rows_to_return;
+            current_chunk_offset_ += rows_to_return;
+            return true;
+        }
+        return false;
+    }
+
+ private:
+    PinWrapper<SpanBase>&
+    GetCurrentSpan() {
+        if (!cached_span_.has_value() ||
+            cached_chunk_id_ != current_chunk_id_) {
+            cached_span_ = column_->Span(op_ctx_, current_chunk_id_);
+            cached_chunk_id_ = current_chunk_id_;
+        }
+        return cached_span_.value();
+    }
+
+    const ChunkedColumnInterface* column_;
+    milvus::OpContext* op_ctx_;
+    DataType data_type_;
+    ChunkedColumnInterface::ScanProjection projection_;
+    ChunkedColumnInterface::ScanValueKind value_kind_;
+    int64_t scan_pos_;
+    int64_t scan_end_;
+    int64_t current_chunk_id_{0};
+    int64_t current_chunk_offset_{0};
+    int64_t cached_chunk_id_{-1};
+    std::optional<PinWrapper<SpanBase>> cached_span_{std::nullopt};
+};
+
+class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
+ public:
+    ViewDataScanCursor(const ChunkedColumnInterface* column,
+                       milvus::OpContext* op_ctx,
+                       int64_t start_offset,
+                       int64_t length,
+                       DataType data_type,
+                       ChunkedColumnInterface::ScanProjection projection,
+                       ChunkedColumnInterface::ScanValueKind value_kind)
+        : column_(column),
+          op_ctx_(op_ctx),
+          data_type_(data_type),
+          projection_(projection),
+          value_kind_(value_kind),
+          scan_pos_(start_offset),
+          scan_end_(start_offset + length) {
+    }
+
+    bool
+    Next(ChunkedColumnInterface::ScanBatch* out) override {
+        AssertInfo(out != nullptr, "view data scan output batch is null");
+        ResetOutput(out);
+        if (scan_pos_ >= scan_end_) {
+            return false;
+        }
+
+        auto [chunk_id, offset] = column_->GetChunkIDByOffset(scan_pos_);
+        const auto chunk_rows = column_->chunk_row_nums(chunk_id);
+        const auto rows_to_return = std::min<int64_t>(
+            {chunk_rows - static_cast<int64_t>(offset), scan_end_ - scan_pos_});
+        AssertInfo(rows_to_return > 0,
+                   "invalid view data scan batch at offset {}",
+                   scan_pos_);
+
+        out->row_id_start = scan_pos_;
+        out->size = rows_to_return;
+        if (projection_ == ChunkedColumnInterface::ScanProjection::NoData) {
+            FillNoDataBatch(chunk_id, offset, out);
+            scan_pos_ += rows_to_return;
+            return true;
+        }
+
+        const auto range =
+            std::make_pair(static_cast<int64_t>(offset), rows_to_return);
+        switch (value_kind_) {
+            case ChunkedColumnInterface::ScanValueKind::StringView:
+                FillStringViewBatch(chunk_id, range, out);
+                break;
+            case ChunkedColumnInterface::ScanValueKind::JsonView:
+                FillJsonViewBatch(chunk_id, range, out);
+                break;
+            case ChunkedColumnInterface::ScanValueKind::ArrayView:
+                FillArrayViewBatch(chunk_id, range, out);
+                break;
+            case ChunkedColumnInterface::ScanValueKind::VectorArrayView:
+                FillVectorArrayViewBatch(chunk_id, range, out);
+                break;
+            default:
+                ThrowInfo(ErrorCode::Unsupported,
+                          "unsupported view data scan kind {}",
+                          static_cast<int>(value_kind_));
+        }
+
+        scan_pos_ += rows_to_return;
+        return true;
+    }
+
+ private:
+    using StringViews =
+        std::pair<std::vector<std::string_view>, FixedVector<bool>>;
+    using ArrayViews = std::pair<std::vector<ArrayView>, FixedVector<bool>>;
+    using VectorArrayViews =
+        std::pair<std::vector<VectorArrayView>, FixedVector<bool>>;
+
+    struct StringOwner {
+        explicit StringOwner(PinWrapper<StringViews>&& views)
+            : views(std::move(views)) {
+        }
+        PinWrapper<StringViews> views;
+    };
+
+    struct JsonOwner {
+        explicit JsonOwner(PinWrapper<StringViews>&& views)
+            : views(std::move(views)) {
+            auto& strings = this->views.get().first;
+            values.reserve(strings.size());
+            for (const auto& value : strings) {
+                values.emplace_back(Json(value));
+            }
+        }
+        PinWrapper<StringViews> views;
+        std::vector<Json> values;
+    };
+
+    struct ArrayOwner {
+        explicit ArrayOwner(PinWrapper<ArrayViews>&& views)
+            : views(std::move(views)) {
+        }
+        PinWrapper<ArrayViews> views;
+    };
+
+    struct VectorArrayOwner {
+        explicit VectorArrayOwner(PinWrapper<VectorArrayViews>&& views)
+            : views(std::move(views)) {
+        }
+        PinWrapper<VectorArrayViews> views;
+    };
+
+    struct ValidityOwner {
+        explicit ValidityOwner(PinWrapper<Chunk*>&& chunk)
+            : chunk(std::move(chunk)) {
+        }
+        PinWrapper<Chunk*> chunk;
+    };
+
+    static void
+    ResetOutput(ChunkedColumnInterface::ScanBatch* out) {
+        out->values = ChunkedColumnInterface::ValueView{};
+        out->validity = ChunkedColumnInterface::ValidityView{};
+        out->owner.reset();
+        out->row_id_start = 0;
+        out->size = 0;
+    }
+
+    void
+    FillValidity(const FixedVector<bool>& valid_data,
+                 ChunkedColumnInterface::ScanBatch* out) const {
+        out->validity.size = out->size;
+        out->validity.nullable = column_->IsNullable();
+        if (!column_->IsNullable() || valid_data.empty()) {
+            out->validity.encoding =
+                ChunkedColumnInterface::ValidityEncoding::AllValid;
+            out->validity.all_valid = true;
+            return;
+        }
+        out->validity.encoding =
+            ChunkedColumnInterface::ValidityEncoding::BoolArray;
+        out->validity.data = valid_data.data();
+        out->validity.offset = 0;
+        out->validity.all_valid = false;
+    }
+
+    void
+    FillNoDataBatch(int64_t chunk_id,
+                    int64_t offset,
+                    ChunkedColumnInterface::ScanBatch* out) const {
+        out->validity.size = out->size;
+        out->validity.nullable = column_->IsNullable();
+        if (!column_->IsNullable()) {
+            out->validity.encoding =
+                ChunkedColumnInterface::ValidityEncoding::AllValid;
+            out->validity.all_valid = true;
+            return;
+        }
+
+        auto owner = std::make_shared<ValidityOwner>(
+            column_->GetChunk(op_ctx_, chunk_id));
+        const auto& valid_data = owner->chunk.get()->Valid();
+        if (valid_data.empty()) {
+            out->validity.encoding =
+                ChunkedColumnInterface::ValidityEncoding::AllValid;
+            out->validity.all_valid = true;
+            return;
+        }
+
+        out->validity.encoding =
+            ChunkedColumnInterface::ValidityEncoding::BoolArray;
+        out->validity.data = valid_data.data();
+        out->validity.offset = offset;
+        out->validity.all_valid = false;
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillStringViewBatch(int64_t chunk_id,
+                        std::pair<int64_t, int64_t> range,
+                        ChunkedColumnInterface::ScanBatch* out) const {
+        auto owner = std::make_shared<StringOwner>(
+            column_->StringViews(op_ctx_, chunk_id, range));
+        auto& views = owner->views.get();
+        out->values.encoding =
+            ChunkedColumnInterface::ValueEncoding::StringView;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::StringView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = data_type_;
+        out->values.data = views.first.data();
+        out->values.offset = 0;
+        out->values.size = out->size;
+        out->values.byte_width = sizeof(std::string_view);
+        FillValidity(views.second, out);
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillJsonViewBatch(int64_t chunk_id,
+                      std::pair<int64_t, int64_t> range,
+                      ChunkedColumnInterface::ScanBatch* out) const {
+        auto owner = std::make_shared<JsonOwner>(
+            column_->StringViews(op_ctx_, chunk_id, range));
+        out->values.encoding = ChunkedColumnInterface::ValueEncoding::JsonView;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::JsonView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = DataType::JSON;
+        out->values.data = owner->values.data();
+        out->values.offset = 0;
+        out->values.size = out->size;
+        out->values.byte_width = sizeof(Json);
+        FillValidity(owner->views.get().second, out);
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillArrayViewBatch(int64_t chunk_id,
+                       std::pair<int64_t, int64_t> range,
+                       ChunkedColumnInterface::ScanBatch* out) const {
+        auto owner = std::make_shared<ArrayOwner>(
+            column_->ArrayViews(op_ctx_, chunk_id, range));
+        auto& views = owner->views.get();
+        out->values.encoding = ChunkedColumnInterface::ValueEncoding::ArrayView;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::ArrayView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = DataType::ARRAY;
+        out->values.data = views.first.data();
+        out->values.offset = 0;
+        out->values.size = out->size;
+        out->values.byte_width = sizeof(ArrayView);
+        FillValidity(views.second, out);
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillVectorArrayViewBatch(int64_t chunk_id,
+                             std::pair<int64_t, int64_t> range,
+                             ChunkedColumnInterface::ScanBatch* out) const {
+        auto owner = std::make_shared<VectorArrayOwner>(
+            column_->VectorArrayViews(op_ctx_, chunk_id, range));
+        auto& views = owner->views.get();
+        out->values.encoding =
+            ChunkedColumnInterface::ValueEncoding::VectorArrayView;
+        out->values.kind =
+            ChunkedColumnInterface::ScanValueKind::VectorArrayView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = DataType::VECTOR_ARRAY;
+        out->values.data = views.first.data();
+        out->values.offset = 0;
+        out->values.size = out->size;
+        out->values.byte_width = sizeof(VectorArrayView);
+        FillValidity(views.second, out);
+        out->owner = std::move(owner);
+    }
+
+    const ChunkedColumnInterface* column_;
+    milvus::OpContext* op_ctx_;
+    DataType data_type_;
+    ChunkedColumnInterface::ScanProjection projection_;
+    ChunkedColumnInterface::ScanValueKind value_kind_;
+    int64_t scan_pos_;
+    int64_t scan_end_;
+};
+
+inline std::unique_ptr<ChunkedColumnInterface::ScanCursor>
+MakeFixedWidthDataScanCursor(const ChunkedColumnInterface* column,
+                             milvus::OpContext* op_ctx,
+                             int64_t start_offset,
+                             int64_t length,
+                             DataType data_type,
+                             ChunkedColumnInterface::ScanProjection projection,
+                             ChunkedColumnInterface::ScanValueKind value_kind) {
+    AssertInfo(
+        start_offset >= 0 && length >= 0 &&
+            start_offset + length <= static_cast<int64_t>(column->NumRows()),
+        "data scan range [{}, {}) out of rows {}",
+        start_offset,
+        start_offset + length,
+        column->NumRows());
+    if (!ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
+        return nullptr;
+    }
+    return std::make_unique<FixedWidthDataScanCursor>(column,
+                                                      op_ctx,
+                                                      start_offset,
+                                                      length,
+                                                      data_type,
+                                                      projection,
+                                                      value_kind);
+}
+
+inline std::unique_ptr<ChunkedColumnInterface::ScanCursor>
+MakeDataScanCursor(const ChunkedColumnInterface* column,
+                   milvus::OpContext* op_ctx,
+                   int64_t start_offset,
+                   int64_t length,
+                   DataType data_type,
+                   ChunkedColumnInterface::ScanProjection projection,
+                   ChunkedColumnInterface::ScanValueKind value_kind) {
+    std::optional<ChunkedColumnInterface::ScanValueKind> column_kind;
+    if (ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
+        column_kind = ChunkedColumnInterface::ScanValueKind::FixedWidth;
+    } else if (data_type == DataType::JSON) {
+        column_kind = ChunkedColumnInterface::ScanValueKind::JsonView;
+    } else if (data_type == DataType::STRING ||
+               data_type == DataType::VARCHAR || data_type == DataType::TEXT ||
+               data_type == DataType::GEOMETRY) {
+        column_kind = ChunkedColumnInterface::ScanValueKind::StringView;
+    } else if (data_type == DataType::ARRAY) {
+        column_kind = ChunkedColumnInterface::ScanValueKind::ArrayView;
+    } else if (data_type == DataType::VECTOR_ARRAY) {
+        column_kind = ChunkedColumnInterface::ScanValueKind::VectorArrayView;
+    }
+    if (!column_kind.has_value()) {
+        return nullptr;
+    }
+
+    // Validity-only scans must not depend on the caller's value type. Choose
+    // the cursor from the column's physical type so, for example, a nullable
+    // VECTOR_ARRAY null predicate cannot accidentally request a fixed-width
+    // cursor through its expression template type.
+    const auto resolved_kind =
+        projection == ChunkedColumnInterface::ScanProjection::NoData ||
+                value_kind == ChunkedColumnInterface::ScanValueKind::Default
+            ? *column_kind
+            : value_kind;
+    AssertInfo(resolved_kind == *column_kind,
+               "data scan kind {} does not match column type {}, expected {}",
+               static_cast<int>(resolved_kind),
+               data_type,
+               static_cast<int>(*column_kind));
+
+    if (resolved_kind == ChunkedColumnInterface::ScanValueKind::FixedWidth) {
+        return MakeFixedWidthDataScanCursor(column,
+                                            op_ctx,
+                                            start_offset,
+                                            length,
+                                            data_type,
+                                            projection,
+                                            resolved_kind);
+    }
+
+    if (resolved_kind == ChunkedColumnInterface::ScanValueKind::StringView ||
+        resolved_kind == ChunkedColumnInterface::ScanValueKind::JsonView ||
+        resolved_kind == ChunkedColumnInterface::ScanValueKind::ArrayView ||
+        resolved_kind ==
+            ChunkedColumnInterface::ScanValueKind::VectorArrayView) {
+        AssertInfo(start_offset >= 0 && length >= 0 &&
+                       start_offset + length <=
+                           static_cast<int64_t>(column->NumRows()),
+                   "data scan range [{}, {}) out of rows {}",
+                   start_offset,
+                   start_offset + length,
+                   column->NumRows());
+        return std::make_unique<ViewDataScanCursor>(column,
+                                                    op_ctx,
+                                                    start_offset,
+                                                    length,
+                                                    data_type,
+                                                    projection,
+                                                    resolved_kind);
+    }
+
+    return nullptr;
+}
+
+}  // namespace detail
+
+ChunkedColumnInterface::ScanResult
+ChunkedColumnInterface::Scan(milvus::OpContext* op_ctx,
+                             const ScanOptions& options) const {
+    auto data_type = GetDefaultScanDataType();
+    if (!data_type.has_value()) {
+        return nullptr;
+    }
+
+    return detail::MakeDataScanCursor(this,
+                                      op_ctx,
+                                      options.start_offset,
+                                      options.length,
+                                      *data_type,
+                                      options.projection,
+                                      options.value_kind);
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -25,18 +25,71 @@ namespace milvus {
 
 namespace detail {
 
+class PinnedScanInput final {
+ public:
+    PinnedScanInput(int64_t first_chunk_id,
+                    std::vector<PinWrapper<Chunk*>>&& chunks)
+        : first_chunk_id_(first_chunk_id), chunks_(std::move(chunks)) {
+    }
+
+    Chunk*
+    GetChunk(int64_t chunk_id) const {
+        const auto index = chunk_id - first_chunk_id_;
+        AssertInfo(index >= 0 && index < static_cast<int64_t>(chunks_.size()),
+                   "scan chunk {} is outside pinned range [{}, {})",
+                   chunk_id,
+                   first_chunk_id_,
+                   first_chunk_id_ + chunks_.size());
+        return chunks_[index].get();
+    }
+
+ private:
+    int64_t first_chunk_id_;
+    std::vector<PinWrapper<Chunk*>> chunks_;
+};
+
+std::shared_ptr<PinnedScanInput>
+PinScanInput(const ChunkedColumnInterface* column,
+             milvus::OpContext* op_ctx,
+             int64_t start_offset,
+             int64_t length,
+             ChunkedColumnInterface::ScanProjection projection) {
+    if (length == 0 ||
+        (projection == ChunkedColumnInterface::ScanProjection::NoData &&
+         !column->IsNullable())) {
+        return nullptr;
+    }
+
+    const auto first_chunk_id =
+        static_cast<int64_t>(column->GetChunkIDByOffset(start_offset).first);
+    const auto last_chunk_id = static_cast<int64_t>(
+        column->GetChunkIDByOffset(start_offset + length - 1).first);
+    std::vector<int64_t> chunk_ids;
+    chunk_ids.reserve(last_chunk_id - first_chunk_id + 1);
+    for (auto chunk_id = first_chunk_id; chunk_id <= last_chunk_id;
+         ++chunk_id) {
+        chunk_ids.emplace_back(chunk_id);
+    }
+    auto chunks = column->PinChunks(op_ctx, chunk_ids);
+    AssertInfo(chunks.size() == chunk_ids.size(),
+               "scan pinned {} chunks for {} requested chunks",
+               chunks.size(),
+               chunk_ids.size());
+    return std::make_shared<PinnedScanInput>(first_chunk_id, std::move(chunks));
+}
+
 class FixedWidthDataScanCursor final
     : public ChunkedColumnInterface::ScanCursor {
  public:
     FixedWidthDataScanCursor(const ChunkedColumnInterface* column,
-                             milvus::OpContext* op_ctx,
+                             std::shared_ptr<PinnedScanInput> input,
                              int64_t start_offset,
                              int64_t length,
                              DataType data_type,
                              ChunkedColumnInterface::ScanProjection projection,
                              ChunkedColumnInterface::ScanValueKind value_kind)
         : column_(column),
-          op_ctx_(op_ctx),
+          input_(std::move(input)),
           data_type_(data_type),
           projection_(projection),
           value_kind_(value_kind),
@@ -91,12 +144,19 @@ class FixedWidthDataScanCursor final
                 return true;
             }
 
-            auto span = column_->Span(op_ctx_, current_chunk_id_);
-            AssertInfo(span.get().row_count() == rows,
+            AssertInfo(input_ != nullptr,
+                       "fixed-width data scan has no pinned input");
+            auto* chunk = input_->GetChunk(current_chunk_id_);
+            auto* fixed_chunk = dynamic_cast<FixedWidthChunk*>(chunk);
+            AssertInfo(fixed_chunk != nullptr,
+                       "scan chunk {} is not fixed-width",
+                       current_chunk_id_);
+            const auto span = fixed_chunk->Span();
+            AssertInfo(span.row_count() == rows,
                        "scan chunk {} row count mismatch, metadata {}, span {}",
                        current_chunk_id_,
                        rows,
-                       span.get().row_count());
+                       span.row_count());
             if (projection_ != ChunkedColumnInterface::ScanProjection::NoData) {
                 out->values.encoding =
                     ChunkedColumnInterface::ValueEncoding::FixedWidth;
@@ -108,17 +168,16 @@ class FixedWidthDataScanCursor final
                 out->values.physical_type = data_type_;
                 out->values.logical_type = data_type_;
                 out->values.size = rows_to_return;
-                out->values.byte_width = span.get().element_sizeof();
+                out->values.byte_width = span.element_sizeof();
                 // Primitive ChunkWriter keeps one payload slot per logical
                 // row; validity masks null slots instead of compacting them.
-                out->values.data = span.get().data();
+                out->values.data = span.data();
                 out->values.offset = current_chunk_offset_;
             }
-            if (span.get().valid_data() != nullptr) {
-                out->validity = span.get().valid_data() + current_chunk_offset_;
+            if (span.valid_data() != nullptr) {
+                out->validity = span.valid_data() + current_chunk_offset_;
             }
-            out->owner =
-                std::make_shared<PinWrapper<SpanBase>>(std::move(span));
+            out->owner = input_;
             out->row_id_start = scan_pos_;
             out->size = rows_to_return;
 
@@ -131,7 +190,7 @@ class FixedWidthDataScanCursor final
 
  private:
     const ChunkedColumnInterface* column_;
-    milvus::OpContext* op_ctx_;
+    std::shared_ptr<PinnedScanInput> input_;
     DataType data_type_;
     ChunkedColumnInterface::ScanProjection projection_;
     ChunkedColumnInterface::ScanValueKind value_kind_;
@@ -144,14 +203,14 @@ class FixedWidthDataScanCursor final
 class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
  public:
     ViewDataScanCursor(const ChunkedColumnInterface* column,
-                       milvus::OpContext* op_ctx,
+                       std::shared_ptr<PinnedScanInput> input,
                        int64_t start_offset,
                        int64_t length,
                        DataType data_type,
                        ChunkedColumnInterface::ScanProjection projection,
                        ChunkedColumnInterface::ScanValueKind value_kind)
         : column_(column),
-          op_ctx_(op_ctx),
+          input_(std::move(input)),
           data_type_(data_type),
           projection_(projection),
           value_kind_(value_kind),
@@ -225,44 +284,42 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
         std::pair<std::vector<VectorArrayView>, FixedVector<bool>>;
 
     struct StringOwner {
-        explicit StringOwner(PinWrapper<StringViews>&& views)
-            : views(std::move(views)) {
+        StringOwner(std::shared_ptr<PinnedScanInput> input, StringViews&& views)
+            : input(std::move(input)), views(std::move(views)) {
         }
-        PinWrapper<StringViews> views;
+        std::shared_ptr<PinnedScanInput> input;
+        StringViews views;
     };
 
     struct JsonOwner {
-        explicit JsonOwner(PinWrapper<StringViews>&& views)
-            : views(std::move(views)) {
-            auto& strings = this->views.get().first;
+        JsonOwner(std::shared_ptr<PinnedScanInput> input, StringViews&& views)
+            : input(std::move(input)), views(std::move(views)) {
+            auto& strings = this->views.first;
             values.reserve(strings.size());
             for (const auto& value : strings) {
                 values.emplace_back(Json(value));
             }
         }
-        PinWrapper<StringViews> views;
+        std::shared_ptr<PinnedScanInput> input;
+        StringViews views;
         std::vector<Json> values;
     };
 
     struct ArrayOwner {
-        explicit ArrayOwner(PinWrapper<ArrayViews>&& views)
-            : views(std::move(views)) {
+        ArrayOwner(std::shared_ptr<PinnedScanInput> input, ArrayViews&& views)
+            : input(std::move(input)), views(std::move(views)) {
         }
-        PinWrapper<ArrayViews> views;
+        std::shared_ptr<PinnedScanInput> input;
+        ArrayViews views;
     };
 
     struct VectorArrayOwner {
-        explicit VectorArrayOwner(PinWrapper<VectorArrayViews>&& views)
-            : views(std::move(views)) {
+        VectorArrayOwner(std::shared_ptr<PinnedScanInput> input,
+                         VectorArrayViews&& views)
+            : input(std::move(input)), views(std::move(views)) {
         }
-        PinWrapper<VectorArrayViews> views;
-    };
-
-    struct ValidityOwner {
-        explicit ValidityOwner(PinWrapper<Chunk*>&& chunk)
-            : chunk(std::move(chunk)) {
-        }
-        PinWrapper<Chunk*> chunk;
+        std::shared_ptr<PinnedScanInput> input;
+        VectorArrayViews views;
     };
 
     static void
@@ -291,24 +348,27 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
             return;
         }
 
-        auto owner = std::make_shared<ValidityOwner>(
-            column_->GetChunk(op_ctx_, chunk_id));
-        const auto& valid_data = owner->chunk.get()->Valid();
+        AssertInfo(input_ != nullptr, "nullable view scan has no pinned input");
+        const auto& valid_data = input_->GetChunk(chunk_id)->Valid();
         if (valid_data.empty()) {
             return;
         }
 
         out->validity = valid_data.data() + offset;
-        out->owner = std::move(owner);
+        out->owner = input_;
     }
 
     void
     FillStringViewBatch(int64_t chunk_id,
                         std::pair<int64_t, int64_t> range,
                         ChunkedColumnInterface::ScanBatch* out) const {
-        auto owner = std::make_shared<StringOwner>(
-            column_->StringViews(op_ctx_, chunk_id, range));
-        auto& views = owner->views.get();
+        AssertInfo(input_ != nullptr, "view scan has no pinned input");
+        auto* chunk = dynamic_cast<StringChunk*>(input_->GetChunk(chunk_id));
+        AssertInfo(
+            chunk != nullptr, "scan chunk {} is not string-like", chunk_id);
+        auto owner =
+            std::make_shared<StringOwner>(input_, chunk->StringViews(range));
+        auto& views = owner->views;
         out->values.encoding =
             ChunkedColumnInterface::ValueEncoding::StringView;
         out->values.kind = ChunkedColumnInterface::ScanValueKind::StringView;
@@ -326,8 +386,11 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     FillJsonViewBatch(int64_t chunk_id,
                       std::pair<int64_t, int64_t> range,
                       ChunkedColumnInterface::ScanBatch* out) const {
-        auto owner = std::make_shared<JsonOwner>(
-            column_->StringViews(op_ctx_, chunk_id, range));
+        AssertInfo(input_ != nullptr, "view scan has no pinned input");
+        auto* chunk = dynamic_cast<StringChunk*>(input_->GetChunk(chunk_id));
+        AssertInfo(chunk != nullptr, "scan chunk {} is not JSON", chunk_id);
+        auto owner =
+            std::make_shared<JsonOwner>(input_, chunk->StringViews(range));
         out->values.encoding = ChunkedColumnInterface::ValueEncoding::JsonView;
         out->values.kind = ChunkedColumnInterface::ScanValueKind::JsonView;
         out->values.physical_type = data_type_;
@@ -336,7 +399,7 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
         out->values.offset = 0;
         out->values.size = out->size;
         out->values.byte_width = sizeof(Json);
-        FillValidity(owner->views.get().second, out);
+        FillValidity(owner->views.second, out);
         out->owner = std::move(owner);
     }
 
@@ -344,9 +407,11 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     FillArrayViewBatch(int64_t chunk_id,
                        std::pair<int64_t, int64_t> range,
                        ChunkedColumnInterface::ScanBatch* out) const {
-        auto owner = std::make_shared<ArrayOwner>(
-            column_->ArrayViews(op_ctx_, chunk_id, range));
-        auto& views = owner->views.get();
+        AssertInfo(input_ != nullptr, "view scan has no pinned input");
+        auto* chunk = dynamic_cast<ArrayChunk*>(input_->GetChunk(chunk_id));
+        AssertInfo(chunk != nullptr, "scan chunk {} is not an array", chunk_id);
+        auto owner = std::make_shared<ArrayOwner>(input_, chunk->Views(range));
+        auto& views = owner->views;
         out->values.encoding = ChunkedColumnInterface::ValueEncoding::ArrayView;
         out->values.kind = ChunkedColumnInterface::ScanValueKind::ArrayView;
         out->values.physical_type = data_type_;
@@ -363,9 +428,14 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     FillVectorArrayViewBatch(int64_t chunk_id,
                              std::pair<int64_t, int64_t> range,
                              ChunkedColumnInterface::ScanBatch* out) const {
-        auto owner = std::make_shared<VectorArrayOwner>(
-            column_->VectorArrayViews(op_ctx_, chunk_id, range));
-        auto& views = owner->views.get();
+        AssertInfo(input_ != nullptr, "view scan has no pinned input");
+        auto* chunk =
+            dynamic_cast<VectorArrayChunk*>(input_->GetChunk(chunk_id));
+        AssertInfo(
+            chunk != nullptr, "scan chunk {} is not a vector array", chunk_id);
+        auto owner =
+            std::make_shared<VectorArrayOwner>(input_, chunk->Views(range));
+        auto& views = owner->views;
         out->values.encoding =
             ChunkedColumnInterface::ValueEncoding::VectorArrayView;
         out->values.kind =
@@ -381,7 +451,7 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     }
 
     const ChunkedColumnInterface* column_;
-    milvus::OpContext* op_ctx_;
+    std::shared_ptr<PinnedScanInput> input_;
     DataType data_type_;
     ChunkedColumnInterface::ScanProjection projection_;
     ChunkedColumnInterface::ScanValueKind value_kind_;
@@ -407,8 +477,9 @@ MakeFixedWidthDataScanCursor(const ChunkedColumnInterface* column,
     if (!ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
         return nullptr;
     }
+    auto input = PinScanInput(column, op_ctx, start_offset, length, projection);
     return std::make_unique<FixedWidthDataScanCursor>(column,
-                                                      op_ctx,
+                                                      std::move(input),
                                                       start_offset,
                                                       length,
                                                       data_type,
@@ -479,8 +550,10 @@ MakeDataScanCursor(const ChunkedColumnInterface* column,
                    start_offset,
                    start_offset + length,
                    column->NumRows());
+        auto input =
+            PinScanInput(column, op_ctx, start_offset, length, projection);
         return std::make_unique<ViewDataScanCursor>(column,
-                                                    op_ctx,
+                                                    std::move(input),
                                                     start_offset,
                                                     length,
                                                     data_type,

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -191,6 +191,12 @@ class FixedWidthDataScanCursor final
         }
 
         while (scan_pos_ < scan_end_) {
+            const auto rows = column_->chunk_row_nums(current_chunk_id_);
+            if (current_chunk_offset_ >= rows) {
+                ++current_chunk_id_;
+                current_chunk_offset_ = 0;
+                continue;
+            }
             if (projection_ == ChunkedColumnInterface::ScanProjection::Data &&
                 IsInSkippedRange()) {
                 if (column_->IsNullable()) {
@@ -201,13 +207,6 @@ class FixedWidthDataScanCursor final
             if (scan_pos_ >= scan_end_) {
                 return false;
             }
-            const auto rows = column_->chunk_row_nums(current_chunk_id_);
-            if (current_chunk_offset_ >= rows) {
-                ++current_chunk_id_;
-                current_chunk_offset_ = 0;
-                continue;
-            }
-
             const auto rows_left_in_chunk = rows - current_chunk_offset_;
             const auto rows_left_in_scan = scan_end_ - scan_pos_;
             const auto rows_before_skip =

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -25,6 +25,33 @@ namespace milvus {
 
 namespace detail {
 
+void
+ValidateScanPlan(const ChunkedColumnInterface::ScanPlan& plan,
+                 int64_t prepared_start,
+                 int64_t prepared_end) {
+    const auto& requested = plan.requested_range;
+    AssertInfo(requested.start >= prepared_start &&
+                   requested.start <= requested.end &&
+                   requested.end <= prepared_end,
+               "scan plan range [{}, {}) outside prepared range [{}, {})",
+               requested.start,
+               requested.end,
+               prepared_start,
+               prepared_end);
+    auto previous_end = requested.start;
+    for (const auto& range : plan.skip_ranges) {
+        AssertInfo(range.start >= previous_end && range.start < range.end &&
+                       range.end <= requested.end,
+                   "invalid scan skip range [{}, {}) after {} in [{}, {})",
+                   range.start,
+                   range.end,
+                   previous_end,
+                   requested.start,
+                   requested.end);
+        previous_end = range.end;
+    }
+}
+
 class PinnedScanInput final {
  public:
     PinnedScanInput(int64_t first_chunk_id,
@@ -81,24 +108,25 @@ PinScanInput(const ChunkedColumnInterface* column,
 class FixedWidthDataScanCursor final
     : public ChunkedColumnInterface::ScanCursor {
  public:
-    FixedWidthDataScanCursor(const ChunkedColumnInterface* column,
-                             std::shared_ptr<PinnedScanInput> input,
-                             int64_t start_offset,
-                             int64_t length,
-                             DataType data_type,
-                             ChunkedColumnInterface::ScanProjection projection,
-                             ChunkedColumnInterface::ScanValueKind value_kind)
+    FixedWidthDataScanCursor(
+        const ChunkedColumnInterface* column,
+        std::shared_ptr<PinnedScanInput> input,
+        int64_t start_offset,
+        int64_t length,
+        DataType data_type,
+        ChunkedColumnInterface::ScanProjection projection,
+        ChunkedColumnInterface::ScanValueKind value_kind,
+        std::vector<ChunkedColumnInterface::ScanRowRange> skip_ranges)
         : column_(column),
           input_(std::move(input)),
           data_type_(data_type),
           projection_(projection),
           value_kind_(value_kind),
           scan_pos_(start_offset),
-          scan_end_(start_offset + length) {
+          scan_end_(start_offset + length),
+          skip_ranges_(std::move(skip_ranges)) {
         if (start_offset < scan_end_) {
-            auto [chunk_id, offset] = column_->GetChunkIDByOffset(start_offset);
-            current_chunk_id_ = static_cast<int64_t>(chunk_id);
-            current_chunk_offset_ = static_cast<int64_t>(offset);
+            SetChunkPosition(start_offset);
         }
     }
 
@@ -123,6 +151,10 @@ class FixedWidthDataScanCursor final
         }
 
         while (scan_pos_ < scan_end_) {
+            AdvancePastSkippedRanges();
+            if (scan_pos_ >= scan_end_) {
+                return false;
+            }
             const auto rows = column_->chunk_row_nums(current_chunk_id_);
             if (current_chunk_offset_ >= rows) {
                 ++current_chunk_id_;
@@ -132,8 +164,17 @@ class FixedWidthDataScanCursor final
 
             const auto rows_left_in_chunk = rows - current_chunk_offset_;
             const auto rows_left_in_scan = scan_end_ - scan_pos_;
-            const auto rows_to_return = std::min<int64_t>(
-                {rows_left_in_chunk, rows_left_in_scan, max_rows});
+            const auto rows_before_skip =
+                skip_index_ < skip_ranges_.size()
+                    ? skip_ranges_[skip_index_].start - scan_pos_
+                    : rows_left_in_scan;
+            const auto rows_to_return = std::min<int64_t>({rows_left_in_chunk,
+                                                           rows_left_in_scan,
+                                                           rows_before_skip,
+                                                           max_rows});
+            AssertInfo(rows_to_return > 0,
+                       "invalid fixed-width scan batch at row {}",
+                       scan_pos_);
 
             if (projection_ == ChunkedColumnInterface::ScanProjection::NoData &&
                 !column_->IsNullable()) {
@@ -189,6 +230,34 @@ class FixedWidthDataScanCursor final
     }
 
  private:
+    void
+    SetChunkPosition(int64_t position) {
+        auto [chunk_id, offset] = column_->GetChunkIDByOffset(position);
+        current_chunk_id_ = static_cast<int64_t>(chunk_id);
+        current_chunk_offset_ = static_cast<int64_t>(offset);
+    }
+
+    void
+    AdvancePastSkippedRanges() {
+        bool advanced = false;
+        while (skip_index_ < skip_ranges_.size()) {
+            const auto& range = skip_ranges_[skip_index_];
+            if (range.end <= scan_pos_) {
+                ++skip_index_;
+                continue;
+            }
+            if (range.start > scan_pos_) {
+                break;
+            }
+            scan_pos_ = range.end;
+            ++skip_index_;
+            advanced = true;
+        }
+        if (advanced && scan_pos_ < scan_end_) {
+            SetChunkPosition(scan_pos_);
+        }
+    }
+
     const ChunkedColumnInterface* column_;
     std::shared_ptr<PinnedScanInput> input_;
     DataType data_type_;
@@ -196,26 +265,31 @@ class FixedWidthDataScanCursor final
     ChunkedColumnInterface::ScanValueKind value_kind_;
     int64_t scan_pos_;
     int64_t scan_end_;
+    std::vector<ChunkedColumnInterface::ScanRowRange> skip_ranges_;
+    size_t skip_index_{0};
     int64_t current_chunk_id_{0};
     int64_t current_chunk_offset_{0};
 };
 
 class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
  public:
-    ViewDataScanCursor(const ChunkedColumnInterface* column,
-                       std::shared_ptr<PinnedScanInput> input,
-                       int64_t start_offset,
-                       int64_t length,
-                       DataType data_type,
-                       ChunkedColumnInterface::ScanProjection projection,
-                       ChunkedColumnInterface::ScanValueKind value_kind)
+    ViewDataScanCursor(
+        const ChunkedColumnInterface* column,
+        std::shared_ptr<PinnedScanInput> input,
+        int64_t start_offset,
+        int64_t length,
+        DataType data_type,
+        ChunkedColumnInterface::ScanProjection projection,
+        ChunkedColumnInterface::ScanValueKind value_kind,
+        std::vector<ChunkedColumnInterface::ScanRowRange> skip_ranges)
         : column_(column),
           input_(std::move(input)),
           data_type_(data_type),
           projection_(projection),
           value_kind_(value_kind),
           scan_pos_(start_offset),
-          scan_end_(start_offset + length) {
+          scan_end_(start_offset + length),
+          skip_ranges_(std::move(skip_ranges)) {
     }
 
     int64_t
@@ -234,10 +308,19 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
             return false;
         }
 
+        AdvancePastSkippedRanges();
+        if (scan_pos_ >= scan_end_) {
+            return false;
+        }
+
         auto [chunk_id, offset] = column_->GetChunkIDByOffset(scan_pos_);
         const auto chunk_rows = column_->chunk_row_nums(chunk_id);
         auto rows_to_return = std::min<int64_t>(
             chunk_rows - static_cast<int64_t>(offset), scan_end_ - scan_pos_);
+        if (skip_index_ < skip_ranges_.size()) {
+            rows_to_return = std::min(
+                rows_to_return, skip_ranges_[skip_index_].start - scan_pos_);
+        }
         rows_to_return = std::min(rows_to_return, max_rows);
         AssertInfo(rows_to_return > 0,
                    "invalid view data scan batch at offset {}",
@@ -329,6 +412,22 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
         out->owner.reset();
         out->row_id_start = 0;
         out->size = 0;
+    }
+
+    void
+    AdvancePastSkippedRanges() {
+        while (skip_index_ < skip_ranges_.size()) {
+            const auto& range = skip_ranges_[skip_index_];
+            if (range.end <= scan_pos_) {
+                ++skip_index_;
+                continue;
+            }
+            if (range.start > scan_pos_) {
+                break;
+            }
+            scan_pos_ = range.end;
+            ++skip_index_;
+        }
     }
 
     void
@@ -457,6 +556,8 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     ChunkedColumnInterface::ScanValueKind value_kind_;
     int64_t scan_pos_;
     int64_t scan_end_;
+    std::vector<ChunkedColumnInterface::ScanRowRange> skip_ranges_;
+    size_t skip_index_{0};
 };
 
 class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
@@ -472,6 +573,7 @@ class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
           input_(std::move(input)),
           start_(start_offset),
           end_(start_offset + length),
+          plan_(ChunkedColumnInterface::ScanPlan::Full(start_offset, length)),
           data_type_(data_type),
           projection_(projection),
           value_kind_(value_kind) {
@@ -487,31 +589,39 @@ class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
         return end_;
     }
 
+    const ChunkedColumnInterface::ScanPlan&
+    Plan() const override {
+        return plan_;
+    }
+
     std::unique_ptr<ChunkedColumnInterface::ScanCursor>
-    Seek(int64_t position) const override {
-        AssertInfo(position >= start_ && position <= end_,
-                   "data scan cursor position {} outside prepared range [{}, {})",
-                   position,
-                   start_,
-                   end_);
-        const auto length = end_ - position;
-        if (value_kind_ ==
-            ChunkedColumnInterface::ScanValueKind::FixedWidth) {
+    Open(const ChunkedColumnInterface::ScanPlan& plan,
+         ChunkedColumnInterface::ScanProjection projection) const override {
+        ValidateScanPlan(plan, start_, end_);
+        AssertInfo(
+            projection_ == ChunkedColumnInterface::ScanProjection::Data ||
+                projection == ChunkedColumnInterface::ScanProjection::NoData,
+            "validity-only prepared scan cannot open a data cursor");
+        const auto start = plan.requested_range.start;
+        const auto length = plan.requested_range.end - start;
+        if (value_kind_ == ChunkedColumnInterface::ScanValueKind::FixedWidth) {
             return std::make_unique<FixedWidthDataScanCursor>(column_,
                                                               input_,
-                                                              position,
+                                                              start,
                                                               length,
                                                               data_type_,
-                                                              projection_,
-                                                              value_kind_);
+                                                              projection,
+                                                              value_kind_,
+                                                              plan.skip_ranges);
         }
         return std::make_unique<ViewDataScanCursor>(column_,
                                                     input_,
-                                                    position,
+                                                    start,
                                                     length,
                                                     data_type_,
-                                                    projection_,
-                                                    value_kind_);
+                                                    projection,
+                                                    value_kind_,
+                                                    plan.skip_ranges);
     }
 
  private:
@@ -519,6 +629,7 @@ class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
     std::shared_ptr<PinnedScanInput> input_;
     int64_t start_;
     int64_t end_;
+    ChunkedColumnInterface::ScanPlan plan_;
     DataType data_type_;
     ChunkedColumnInterface::ScanProjection projection_;
     ChunkedColumnInterface::ScanValueKind value_kind_;
@@ -612,7 +723,9 @@ ChunkedColumnInterface::ScanResult
 ChunkedColumnInterface::Scan(milvus::OpContext* op_ctx,
                              const ScanOptions& options) const {
     auto prepared = PrepareScan(op_ctx, options);
-    return prepared == nullptr ? nullptr : prepared->Seek(options.start_offset);
+    return prepared == nullptr
+               ? nullptr
+               : prepared->Open(prepared->Plan(), options.projection);
 }
 
 ChunkedColumnInterface::PreparedScanResult

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -54,55 +54,95 @@ ValidateScanPlan(const ChunkedColumnInterface::ScanPlan& plan,
 
 class PinnedScanInput final {
  public:
-    PinnedScanInput(int64_t first_chunk_id,
+    PinnedScanInput(std::vector<int64_t> chunk_ids,
                     std::vector<PinWrapper<Chunk*>>&& chunks)
-        : first_chunk_id_(first_chunk_id), chunks_(std::move(chunks)) {
+        : chunk_ids_(std::move(chunk_ids)), chunks_(std::move(chunks)) {
+        AssertInfo(chunk_ids_.size() == chunks_.size(),
+                   "scan input has {} chunk ids for {} pins",
+                   chunk_ids_.size(),
+                   chunks_.size());
     }
 
     Chunk*
     GetChunk(int64_t chunk_id) const {
-        const auto index = chunk_id - first_chunk_id_;
-        AssertInfo(index >= 0 && index < static_cast<int64_t>(chunks_.size()),
-                   "scan chunk {} is outside pinned range [{}, {})",
-                   chunk_id,
-                   first_chunk_id_,
-                   first_chunk_id_ + chunks_.size());
-        return chunks_[index].get();
+        const auto it =
+            std::lower_bound(chunk_ids_.begin(), chunk_ids_.end(), chunk_id);
+        AssertInfo(it != chunk_ids_.end() && *it == chunk_id,
+                   "scan chunk {} is not pinned",
+                   chunk_id);
+        return chunks_[std::distance(chunk_ids_.begin(), it)].get();
     }
 
  private:
-    int64_t first_chunk_id_;
+    std::vector<int64_t> chunk_ids_;
     std::vector<PinWrapper<Chunk*>> chunks_;
 };
 
 std::shared_ptr<PinnedScanInput>
 PinScanInput(const ChunkedColumnInterface* column,
              milvus::OpContext* op_ctx,
-             int64_t start_offset,
-             int64_t length,
+             const std::vector<int64_t>& chunk_ids,
              ChunkedColumnInterface::ScanProjection projection) {
-    if (length == 0 ||
+    if (chunk_ids.empty() ||
         (projection == ChunkedColumnInterface::ScanProjection::NoData &&
          !column->IsNullable())) {
         return nullptr;
-    }
-
-    const auto first_chunk_id =
-        static_cast<int64_t>(column->GetChunkIDByOffset(start_offset).first);
-    const auto last_chunk_id = static_cast<int64_t>(
-        column->GetChunkIDByOffset(start_offset + length - 1).first);
-    std::vector<int64_t> chunk_ids;
-    chunk_ids.reserve(last_chunk_id - first_chunk_id + 1);
-    for (auto chunk_id = first_chunk_id; chunk_id <= last_chunk_id;
-         ++chunk_id) {
-        chunk_ids.emplace_back(chunk_id);
     }
     auto chunks = column->PinChunks(op_ctx, chunk_ids);
     AssertInfo(chunks.size() == chunk_ids.size(),
                "scan pinned {} chunks for {} requested chunks",
                chunks.size(),
                chunk_ids.size());
-    return std::make_shared<PinnedScanInput>(first_chunk_id, std::move(chunks));
+    return std::make_shared<PinnedScanInput>(chunk_ids, std::move(chunks));
+}
+
+std::vector<int64_t>
+GetScanChunkIds(const ChunkedColumnInterface* column,
+                int64_t start_offset,
+                int64_t length) {
+    std::vector<int64_t> chunk_ids;
+    if (length == 0) {
+        return chunk_ids;
+    }
+    const auto first_chunk_id =
+        static_cast<int64_t>(column->GetChunkIDByOffset(start_offset).first);
+    const auto last_chunk_id = static_cast<int64_t>(
+        column->GetChunkIDByOffset(start_offset + length - 1).first);
+    chunk_ids.reserve(last_chunk_id - first_chunk_id + 1);
+    for (auto chunk_id = first_chunk_id; chunk_id <= last_chunk_id;
+         ++chunk_id) {
+        chunk_ids.emplace_back(chunk_id);
+    }
+    return chunk_ids;
+}
+
+std::vector<ChunkedColumnInterface::ScanRowRange>
+SkippedCellsToRanges(const ChunkedColumnInterface* column,
+                     int64_t start_offset,
+                     int64_t length,
+                     std::vector<int64_t> skipped_cell_ids) {
+    std::sort(skipped_cell_ids.begin(), skipped_cell_ids.end());
+    skipped_cell_ids.erase(
+        std::unique(skipped_cell_ids.begin(), skipped_cell_ids.end()),
+        skipped_cell_ids.end());
+    std::vector<ChunkedColumnInterface::ScanRowRange> ranges;
+    const auto scan_end = start_offset + length;
+    for (const auto cell_id : skipped_cell_ids) {
+        const auto cell_start = column->GetNumRowsUntilChunk(cell_id);
+        const auto cell_end = cell_start + column->chunk_row_nums(cell_id);
+        const auto range_start = std::max(start_offset, cell_start);
+        const auto range_end = std::min(scan_end, cell_end);
+        if (range_start >= range_end) {
+            continue;
+        }
+        if (!ranges.empty() && ranges.back().end == range_start) {
+            ranges.back().end = range_end;
+        } else {
+            ranges.emplace_back(
+                ChunkedColumnInterface::ScanRowRange{range_start, range_end});
+        }
+    }
+    return ranges;
 }
 
 class FixedWidthDataScanCursor final
@@ -151,7 +191,13 @@ class FixedWidthDataScanCursor final
         }
 
         while (scan_pos_ < scan_end_) {
-            AdvancePastSkippedRanges();
+            if (projection_ == ChunkedColumnInterface::ScanProjection::Data &&
+                IsInSkippedRange()) {
+                if (column_->IsNullable()) {
+                    return FillSkippedValidityBatch(max_rows, out);
+                }
+                AdvancePastSkippedRanges();
+            }
             if (scan_pos_ >= scan_end_) {
                 return false;
             }
@@ -165,7 +211,8 @@ class FixedWidthDataScanCursor final
             const auto rows_left_in_chunk = rows - current_chunk_offset_;
             const auto rows_left_in_scan = scan_end_ - scan_pos_;
             const auto rows_before_skip =
-                skip_index_ < skip_ranges_.size()
+                projection_ == ChunkedColumnInterface::ScanProjection::Data &&
+                        skip_index_ < skip_ranges_.size()
                     ? skip_ranges_[skip_index_].start - scan_pos_
                     : rows_left_in_scan;
             const auto rows_to_return = std::min<int64_t>({rows_left_in_chunk,
@@ -230,6 +277,49 @@ class FixedWidthDataScanCursor final
     }
 
  private:
+    bool
+    IsInSkippedRange() {
+        while (skip_index_ < skip_ranges_.size() &&
+               skip_ranges_[skip_index_].end <= scan_pos_) {
+            ++skip_index_;
+        }
+        return skip_index_ < skip_ranges_.size() &&
+               skip_ranges_[skip_index_].start <= scan_pos_;
+    }
+
+    bool
+    FillSkippedValidityBatch(int64_t max_rows,
+                             ChunkedColumnInterface::ScanBatch* out) {
+        AssertInfo(input_ != nullptr,
+                   "nullable skipped scan has no pinned input");
+        const auto& skipped = skip_ranges_[skip_index_];
+        const auto rows = column_->chunk_row_nums(current_chunk_id_);
+        const auto rows_to_return =
+            std::min<int64_t>({max_rows,
+                               skipped.end - scan_pos_,
+                               rows - current_chunk_offset_,
+                               scan_end_ - scan_pos_});
+        AssertInfo(rows_to_return > 0,
+                   "invalid skipped validity batch at row {}",
+                   scan_pos_);
+        auto* chunk = input_->GetChunk(current_chunk_id_);
+        auto* fixed_chunk = dynamic_cast<FixedWidthChunk*>(chunk);
+        AssertInfo(fixed_chunk != nullptr,
+                   "scan chunk {} is not fixed-width",
+                   current_chunk_id_);
+        const auto span = fixed_chunk->Span();
+        AssertInfo(span.valid_data() != nullptr,
+                   "nullable scan chunk {} has no validity",
+                   current_chunk_id_);
+        out->validity = span.valid_data() + current_chunk_offset_;
+        out->owner = input_;
+        out->row_id_start = scan_pos_;
+        out->size = rows_to_return;
+        scan_pos_ += rows_to_return;
+        current_chunk_offset_ += rows_to_return;
+        return true;
+    }
+
     void
     SetChunkPosition(int64_t position) {
         auto [chunk_id, offset] = column_->GetChunkIDByOffset(position);
@@ -308,7 +398,13 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
             return false;
         }
 
-        AdvancePastSkippedRanges();
+        if (projection_ == ChunkedColumnInterface::ScanProjection::Data &&
+            IsInSkippedRange()) {
+            if (column_->IsNullable()) {
+                return FillSkippedValidityBatch(max_rows, out);
+            }
+            AdvancePastSkippedRanges();
+        }
         if (scan_pos_ >= scan_end_) {
             return false;
         }
@@ -317,7 +413,8 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
         const auto chunk_rows = column_->chunk_row_nums(chunk_id);
         auto rows_to_return = std::min<int64_t>(
             chunk_rows - static_cast<int64_t>(offset), scan_end_ - scan_pos_);
-        if (skip_index_ < skip_ranges_.size()) {
+        if (projection_ == ChunkedColumnInterface::ScanProjection::Data &&
+            skip_index_ < skip_ranges_.size()) {
             rows_to_return = std::min(
                 rows_to_return, skip_ranges_[skip_index_].start - scan_pos_);
         }
@@ -412,6 +509,44 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
         out->owner.reset();
         out->row_id_start = 0;
         out->size = 0;
+    }
+
+    bool
+    IsInSkippedRange() {
+        while (skip_index_ < skip_ranges_.size() &&
+               skip_ranges_[skip_index_].end <= scan_pos_) {
+            ++skip_index_;
+        }
+        return skip_index_ < skip_ranges_.size() &&
+               skip_ranges_[skip_index_].start <= scan_pos_;
+    }
+
+    bool
+    FillSkippedValidityBatch(int64_t max_rows,
+                             ChunkedColumnInterface::ScanBatch* out) {
+        AssertInfo(input_ != nullptr,
+                   "nullable skipped view scan has no pinned input");
+        const auto& skipped = skip_ranges_[skip_index_];
+        auto [chunk_id, offset] = column_->GetChunkIDByOffset(scan_pos_);
+        const auto chunk_rows = column_->chunk_row_nums(chunk_id);
+        const auto rows_to_return =
+            std::min<int64_t>({max_rows,
+                               skipped.end - scan_pos_,
+                               chunk_rows - static_cast<int64_t>(offset),
+                               scan_end_ - scan_pos_});
+        AssertInfo(rows_to_return > 0,
+                   "invalid skipped view validity batch at row {}",
+                   scan_pos_);
+        const auto& valid_data = input_->GetChunk(chunk_id)->Valid();
+        AssertInfo(!valid_data.empty(),
+                   "nullable scan chunk {} has no validity",
+                   chunk_id);
+        out->validity = valid_data.data() + offset;
+        out->owner = input_;
+        out->row_id_start = scan_pos_;
+        out->size = rows_to_return;
+        scan_pos_ += rows_to_return;
+        return true;
     }
 
     void
@@ -568,7 +703,8 @@ class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
                      int64_t length,
                      DataType data_type,
                      ChunkedColumnInterface::ScanProjection projection,
-                     ChunkedColumnInterface::ScanValueKind value_kind)
+                     ChunkedColumnInterface::ScanValueKind value_kind,
+                     std::vector<int64_t> skipped_cell_ids)
         : column_(column),
           input_(std::move(input)),
           start_(start_offset),
@@ -577,6 +713,8 @@ class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
           data_type_(data_type),
           projection_(projection),
           value_kind_(value_kind) {
+        plan_.skip_ranges = SkippedCellsToRanges(
+            column_, start_offset, length, std::move(skipped_cell_ids));
     }
 
     int64_t
@@ -642,7 +780,11 @@ PrepareDataScan(const ChunkedColumnInterface* column,
                 int64_t length,
                 DataType data_type,
                 ChunkedColumnInterface::ScanProjection projection,
-                ChunkedColumnInterface::ScanValueKind value_kind) {
+                ChunkedColumnInterface::ScanValueKind value_kind,
+                const ChunkedColumnInterface::ScanOptions::CellSkipPredicate&
+                    metadata_skip_cell,
+                const ChunkedColumnInterface::ScanOptions::CellSkipPredicate&
+                    loaded_skip_cell) {
     AssertInfo(
         start_offset >= 0 && length >= 0 &&
             start_offset + length <= static_cast<int64_t>(column->NumRows()),
@@ -683,19 +825,41 @@ PrepareDataScan(const ChunkedColumnInterface* column,
                data_type,
                static_cast<int>(*column_kind));
 
+    const auto scan_chunk_ids = GetScanChunkIds(column, start_offset, length);
+    std::vector<int64_t> skipped_cell_ids;
+    std::vector<int64_t> loaded_cell_ids;
+    skipped_cell_ids.reserve(scan_chunk_ids.size());
+    loaded_cell_ids.reserve(scan_chunk_ids.size());
+    for (const auto cell_id : scan_chunk_ids) {
+        if (metadata_skip_cell && metadata_skip_cell(cell_id)) {
+            skipped_cell_ids.emplace_back(cell_id);
+        } else {
+            loaded_cell_ids.emplace_back(cell_id);
+        }
+    }
+    const auto& pinned_cell_ids =
+        column->IsNullable() ? scan_chunk_ids : loaded_cell_ids;
+    auto input = PinScanInput(column, op_ctx, pinned_cell_ids, projection);
+    if (loaded_skip_cell) {
+        for (const auto cell_id : loaded_cell_ids) {
+            if (loaded_skip_cell(cell_id)) {
+                skipped_cell_ids.emplace_back(cell_id);
+            }
+        }
+    }
+
     if (resolved_kind == ChunkedColumnInterface::ScanValueKind::FixedWidth) {
         if (!ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
             return nullptr;
         }
-        auto input =
-            PinScanInput(column, op_ctx, start_offset, length, projection);
         return std::make_shared<PreparedDataScan>(column,
                                                   std::move(input),
                                                   start_offset,
                                                   length,
                                                   data_type,
                                                   projection,
-                                                  resolved_kind);
+                                                  resolved_kind,
+                                                  std::move(skipped_cell_ids));
     }
 
     if (resolved_kind == ChunkedColumnInterface::ScanValueKind::StringView ||
@@ -703,15 +867,14 @@ PrepareDataScan(const ChunkedColumnInterface* column,
         resolved_kind == ChunkedColumnInterface::ScanValueKind::ArrayView ||
         resolved_kind ==
             ChunkedColumnInterface::ScanValueKind::VectorArrayView) {
-        auto input =
-            PinScanInput(column, op_ctx, start_offset, length, projection);
         return std::make_shared<PreparedDataScan>(column,
                                                   std::move(input),
                                                   start_offset,
                                                   length,
                                                   data_type,
                                                   projection,
-                                                  resolved_kind);
+                                                  resolved_kind,
+                                                  std::move(skipped_cell_ids));
     }
 
     return nullptr;
@@ -742,7 +905,9 @@ ChunkedColumnInterface::PrepareScan(milvus::OpContext* op_ctx,
                                    options.length,
                                    *data_type,
                                    options.projection,
-                                   options.value_kind);
+                                   options.value_kind,
+                                   options.metadata_skip_cell,
+                                   options.loaded_skip_cell);
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -459,14 +459,79 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     int64_t scan_end_;
 };
 
-inline std::unique_ptr<ChunkedColumnInterface::ScanCursor>
-MakeFixedWidthDataScanCursor(const ChunkedColumnInterface* column,
-                             milvus::OpContext* op_ctx,
-                             int64_t start_offset,
-                             int64_t length,
-                             DataType data_type,
-                             ChunkedColumnInterface::ScanProjection projection,
-                             ChunkedColumnInterface::ScanValueKind value_kind) {
+class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
+ public:
+    PreparedDataScan(const ChunkedColumnInterface* column,
+                     std::shared_ptr<PinnedScanInput> input,
+                     int64_t start_offset,
+                     int64_t length,
+                     DataType data_type,
+                     ChunkedColumnInterface::ScanProjection projection,
+                     ChunkedColumnInterface::ScanValueKind value_kind)
+        : column_(column),
+          input_(std::move(input)),
+          start_(start_offset),
+          end_(start_offset + length),
+          data_type_(data_type),
+          projection_(projection),
+          value_kind_(value_kind) {
+    }
+
+    int64_t
+    Start() const override {
+        return start_;
+    }
+
+    int64_t
+    End() const override {
+        return end_;
+    }
+
+    std::unique_ptr<ChunkedColumnInterface::ScanCursor>
+    Seek(int64_t position) const override {
+        AssertInfo(position >= start_ && position <= end_,
+                   "data scan cursor position {} outside prepared range [{}, {})",
+                   position,
+                   start_,
+                   end_);
+        const auto length = end_ - position;
+        if (value_kind_ ==
+            ChunkedColumnInterface::ScanValueKind::FixedWidth) {
+            return std::make_unique<FixedWidthDataScanCursor>(column_,
+                                                              input_,
+                                                              position,
+                                                              length,
+                                                              data_type_,
+                                                              projection_,
+                                                              value_kind_);
+        }
+        return std::make_unique<ViewDataScanCursor>(column_,
+                                                    input_,
+                                                    position,
+                                                    length,
+                                                    data_type_,
+                                                    projection_,
+                                                    value_kind_);
+    }
+
+ private:
+    const ChunkedColumnInterface* column_;
+    std::shared_ptr<PinnedScanInput> input_;
+    int64_t start_;
+    int64_t end_;
+    DataType data_type_;
+    ChunkedColumnInterface::ScanProjection projection_;
+    ChunkedColumnInterface::ScanValueKind value_kind_;
+};
+
+inline ChunkedColumnInterface::PreparedScanResult
+PrepareDataScan(const ChunkedColumnInterface* column,
+                milvus::OpContext* op_ctx,
+                int64_t start_offset,
+                int64_t length,
+                DataType data_type,
+                ChunkedColumnInterface::ScanProjection projection,
+                ChunkedColumnInterface::ScanValueKind value_kind) {
     AssertInfo(
         start_offset >= 0 && length >= 0 &&
             start_offset + length <= static_cast<int64_t>(column->NumRows()),
@@ -474,27 +539,6 @@ MakeFixedWidthDataScanCursor(const ChunkedColumnInterface* column,
         start_offset,
         start_offset + length,
         column->NumRows());
-    if (!ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
-        return nullptr;
-    }
-    auto input = PinScanInput(column, op_ctx, start_offset, length, projection);
-    return std::make_unique<FixedWidthDataScanCursor>(column,
-                                                      std::move(input),
-                                                      start_offset,
-                                                      length,
-                                                      data_type,
-                                                      projection,
-                                                      value_kind);
-}
-
-inline std::unique_ptr<ChunkedColumnInterface::ScanCursor>
-MakeDataScanCursor(const ChunkedColumnInterface* column,
-                   milvus::OpContext* op_ctx,
-                   int64_t start_offset,
-                   int64_t length,
-                   DataType data_type,
-                   ChunkedColumnInterface::ScanProjection projection,
-                   ChunkedColumnInterface::ScanValueKind value_kind) {
     std::optional<ChunkedColumnInterface::ScanValueKind> column_kind;
     if (ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
         column_kind = ChunkedColumnInterface::ScanValueKind::FixedWidth;
@@ -529,13 +573,18 @@ MakeDataScanCursor(const ChunkedColumnInterface* column,
                static_cast<int>(*column_kind));
 
     if (resolved_kind == ChunkedColumnInterface::ScanValueKind::FixedWidth) {
-        return MakeFixedWidthDataScanCursor(column,
-                                            op_ctx,
-                                            start_offset,
-                                            length,
-                                            data_type,
-                                            projection,
-                                            resolved_kind);
+        if (!ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
+            return nullptr;
+        }
+        auto input =
+            PinScanInput(column, op_ctx, start_offset, length, projection);
+        return std::make_shared<PreparedDataScan>(column,
+                                                  std::move(input),
+                                                  start_offset,
+                                                  length,
+                                                  data_type,
+                                                  projection,
+                                                  resolved_kind);
     }
 
     if (resolved_kind == ChunkedColumnInterface::ScanValueKind::StringView ||
@@ -543,22 +592,15 @@ MakeDataScanCursor(const ChunkedColumnInterface* column,
         resolved_kind == ChunkedColumnInterface::ScanValueKind::ArrayView ||
         resolved_kind ==
             ChunkedColumnInterface::ScanValueKind::VectorArrayView) {
-        AssertInfo(start_offset >= 0 && length >= 0 &&
-                       start_offset + length <=
-                           static_cast<int64_t>(column->NumRows()),
-                   "data scan range [{}, {}) out of rows {}",
-                   start_offset,
-                   start_offset + length,
-                   column->NumRows());
         auto input =
             PinScanInput(column, op_ctx, start_offset, length, projection);
-        return std::make_unique<ViewDataScanCursor>(column,
-                                                    std::move(input),
-                                                    start_offset,
-                                                    length,
-                                                    data_type,
-                                                    projection,
-                                                    resolved_kind);
+        return std::make_shared<PreparedDataScan>(column,
+                                                  std::move(input),
+                                                  start_offset,
+                                                  length,
+                                                  data_type,
+                                                  projection,
+                                                  resolved_kind);
     }
 
     return nullptr;
@@ -569,18 +611,25 @@ MakeDataScanCursor(const ChunkedColumnInterface* column,
 ChunkedColumnInterface::ScanResult
 ChunkedColumnInterface::Scan(milvus::OpContext* op_ctx,
                              const ScanOptions& options) const {
+    auto prepared = PrepareScan(op_ctx, options);
+    return prepared == nullptr ? nullptr : prepared->Seek(options.start_offset);
+}
+
+ChunkedColumnInterface::PreparedScanResult
+ChunkedColumnInterface::PrepareScan(milvus::OpContext* op_ctx,
+                                    const ScanOptions& options) const {
     auto data_type = GetDefaultScanDataType();
     if (!data_type.has_value()) {
         return nullptr;
     }
 
-    return detail::MakeDataScanCursor(this,
-                                      op_ctx,
-                                      options.start_offset,
-                                      options.length,
-                                      *data_type,
-                                      options.projection,
-                                      options.value_kind);
+    return detail::PrepareDataScan(this,
+                                   op_ctx,
+                                   options.start_offset,
+                                   options.length,
+                                   *data_type,
+                                   options.projection,
+                                   options.value_kind);
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -61,7 +61,7 @@ class FixedWidthDataScanCursor final
                    "data scan max rows must be positive, got {}",
                    max_rows);
         out->values = ChunkedColumnInterface::ValueView{};
-        out->validity = ChunkedColumnInterface::ValidityView{};
+        out->validity = nullptr;
         out->owner.reset();
         out->row_id_start = 0;
         out->size = 0;
@@ -74,7 +74,6 @@ class FixedWidthDataScanCursor final
             if (current_chunk_offset_ >= rows) {
                 ++current_chunk_id_;
                 current_chunk_offset_ = 0;
-                cached_span_.reset();
                 continue;
             }
 
@@ -85,10 +84,6 @@ class FixedWidthDataScanCursor final
 
             if (projection_ == ChunkedColumnInterface::ScanProjection::NoData &&
                 !column_->IsNullable()) {
-                out->validity.encoding =
-                    ChunkedColumnInterface::ValidityEncoding::AllValid;
-                out->validity.size = rows_to_return;
-                out->validity.nullable = false;
                 out->row_id_start = scan_pos_;
                 out->size = rows_to_return;
                 scan_pos_ += rows_to_return;
@@ -96,13 +91,12 @@ class FixedWidthDataScanCursor final
                 return true;
             }
 
-            auto& span = GetCurrentSpan();
+            auto span = column_->Span(op_ctx_, current_chunk_id_);
             AssertInfo(span.get().row_count() == rows,
                        "scan chunk {} row count mismatch, metadata {}, span {}",
                        current_chunk_id_,
                        rows,
                        span.get().row_count());
-            std::shared_ptr<void> owner;
             if (projection_ != ChunkedColumnInterface::ScanProjection::NoData) {
                 out->values.encoding =
                     ChunkedColumnInterface::ValueEncoding::FixedWidth;
@@ -119,20 +113,12 @@ class FixedWidthDataScanCursor final
                 // row; validity masks null slots instead of compacting them.
                 out->values.data = span.get().data();
                 out->values.offset = current_chunk_offset_;
-                owner = std::make_shared<PinWrapper<SpanBase>>(span);
             }
-            out->validity.size = rows_to_return;
-            out->validity.nullable = column_->IsNullable();
             if (span.get().valid_data() != nullptr) {
-                out->validity.encoding =
-                    ChunkedColumnInterface::ValidityEncoding::BoolArray;
-                out->validity.data = span.get().valid_data();
-                out->validity.offset = current_chunk_offset_;
+                out->validity = span.get().valid_data() + current_chunk_offset_;
             }
-            if (owner == nullptr) {
-                owner = std::make_shared<PinWrapper<SpanBase>>(span);
-            }
-            out->owner = std::move(owner);
+            out->owner =
+                std::make_shared<PinWrapper<SpanBase>>(std::move(span));
             out->row_id_start = scan_pos_;
             out->size = rows_to_return;
 
@@ -144,16 +130,6 @@ class FixedWidthDataScanCursor final
     }
 
  private:
-    PinWrapper<SpanBase>&
-    GetCurrentSpan() {
-        if (!cached_span_.has_value() ||
-            cached_chunk_id_ != current_chunk_id_) {
-            cached_span_ = column_->Span(op_ctx_, current_chunk_id_);
-            cached_chunk_id_ = current_chunk_id_;
-        }
-        return cached_span_.value();
-    }
-
     const ChunkedColumnInterface* column_;
     milvus::OpContext* op_ctx_;
     DataType data_type_;
@@ -163,8 +139,6 @@ class FixedWidthDataScanCursor final
     int64_t scan_end_;
     int64_t current_chunk_id_{0};
     int64_t current_chunk_offset_{0};
-    int64_t cached_chunk_id_{-1};
-    std::optional<PinWrapper<SpanBase>> cached_span_{std::nullopt};
 };
 
 class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
@@ -294,7 +268,7 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     static void
     ResetOutput(ChunkedColumnInterface::ScanBatch* out) {
         out->values = ChunkedColumnInterface::ValueView{};
-        out->validity = ChunkedColumnInterface::ValidityView{};
+        out->validity = nullptr;
         out->owner.reset();
         out->row_id_start = 0;
         out->size = 0;
@@ -303,28 +277,17 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     void
     FillValidity(const FixedVector<bool>& valid_data,
                  ChunkedColumnInterface::ScanBatch* out) const {
-        out->validity.size = out->size;
-        out->validity.nullable = column_->IsNullable();
         if (!column_->IsNullable() || valid_data.empty()) {
-            out->validity.encoding =
-                ChunkedColumnInterface::ValidityEncoding::AllValid;
             return;
         }
-        out->validity.encoding =
-            ChunkedColumnInterface::ValidityEncoding::BoolArray;
-        out->validity.data = valid_data.data();
-        out->validity.offset = 0;
+        out->validity = valid_data.data();
     }
 
     void
     FillNoDataBatch(int64_t chunk_id,
                     int64_t offset,
                     ChunkedColumnInterface::ScanBatch* out) const {
-        out->validity.size = out->size;
-        out->validity.nullable = column_->IsNullable();
         if (!column_->IsNullable()) {
-            out->validity.encoding =
-                ChunkedColumnInterface::ValidityEncoding::AllValid;
             return;
         }
 
@@ -332,15 +295,10 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
             column_->GetChunk(op_ctx_, chunk_id));
         const auto& valid_data = owner->chunk.get()->Valid();
         if (valid_data.empty()) {
-            out->validity.encoding =
-                ChunkedColumnInterface::ValidityEncoding::AllValid;
             return;
         }
 
-        out->validity.encoding =
-            ChunkedColumnInterface::ValidityEncoding::BoolArray;
-        out->validity.data = valid_data.data();
-        out->validity.offset = offset;
+        out->validity = valid_data.data() + offset;
         out->owner = std::move(owner);
     }
 

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -739,8 +740,41 @@ class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
             projection_ == ChunkedColumnInterface::ScanProjection::Data ||
                 projection == ChunkedColumnInterface::ScanProjection::NoData,
             "validity-only prepared scan cannot open a data cursor");
-        const auto start = plan.requested_range.start;
-        const auto length = plan.requested_range.end - start;
+        auto effective_plan = plan;
+        if (projection == ChunkedColumnInterface::ScanProjection::Data) {
+            // Planner-pruned Cells may not be present in input_. Reopening a
+            // cursor for a subrange must retain those skips automatically;
+            // callers should only describe the logical range (and any
+            // additional skips), not repeat backend pin-selection state.
+            for (const auto& prepared_skip : plan_.skip_ranges) {
+                const auto start = std::max(prepared_skip.start,
+                                            plan.requested_range.start);
+                const auto end =
+                    std::min(prepared_skip.end, plan.requested_range.end);
+                if (start < end) {
+                    effective_plan.skip_ranges.emplace_back(
+                        ChunkedColumnInterface::ScanRowRange{start, end});
+                }
+            }
+            std::sort(effective_plan.skip_ranges.begin(),
+                      effective_plan.skip_ranges.end(),
+                      [](const auto& left, const auto& right) {
+                          return std::tie(left.start, left.end) <
+                                 std::tie(right.start, right.end);
+                      });
+            std::vector<ChunkedColumnInterface::ScanRowRange> merged;
+            for (const auto& skip : effective_plan.skip_ranges) {
+                if (!merged.empty() && skip.start <= merged.back().end) {
+                    merged.back().end = std::max(merged.back().end, skip.end);
+                } else {
+                    merged.emplace_back(skip);
+                }
+            }
+            effective_plan.skip_ranges = std::move(merged);
+            ValidateScanPlan(effective_plan, start_, end_);
+        }
+        const auto start = effective_plan.requested_range.start;
+        const auto length = effective_plan.requested_range.end - start;
         if (value_kind_ == ChunkedColumnInterface::ScanValueKind::FixedWidth) {
             return std::make_unique<FixedWidthDataScanCursor>(column_,
                                                               input_,
@@ -749,7 +783,8 @@ class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
                                                               data_type_,
                                                               projection,
                                                               value_kind_,
-                                                              plan.skip_ranges);
+                                                              effective_plan
+                                                                  .skip_ranges);
         }
         return std::make_unique<ViewDataScanCursor>(column_,
                                                     input_,
@@ -758,7 +793,7 @@ class PreparedDataScan final : public ChunkedColumnInterface::PreparedScan {
                                                     data_type_,
                                                     projection,
                                                     value_kind_,
-                                                    plan.skip_ranges);
+                                                    effective_plan.skip_ranges);
     }
 
  private:

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -49,9 +49,17 @@ class FixedWidthDataScanCursor final
         }
     }
 
+    int64_t
+    Position() const override {
+        return scan_pos_;
+    }
+
     bool
-    Next(ChunkedColumnInterface::ScanBatch* out) override {
+    Next(int64_t max_rows, ChunkedColumnInterface::ScanBatch* out) override {
         AssertInfo(out != nullptr, "data scan output batch is null");
+        AssertInfo(max_rows > 0,
+                   "data scan max rows must be positive, got {}",
+                   max_rows);
         out->values = ChunkedColumnInterface::ValueView{};
         out->validity = ChunkedColumnInterface::ValidityView{};
         out->owner.reset();
@@ -72,8 +80,8 @@ class FixedWidthDataScanCursor final
 
             const auto rows_left_in_chunk = rows - current_chunk_offset_;
             const auto rows_left_in_scan = scan_end_ - scan_pos_;
-            const auto rows_to_return =
-                std::min<int64_t>(rows_left_in_chunk, rows_left_in_scan);
+            const auto rows_to_return = std::min<int64_t>(
+                {rows_left_in_chunk, rows_left_in_scan, max_rows});
 
             if (projection_ == ChunkedColumnInterface::ScanProjection::NoData &&
                 !column_->IsNullable()) {
@@ -81,7 +89,6 @@ class FixedWidthDataScanCursor final
                     ChunkedColumnInterface::ValidityEncoding::AllValid;
                 out->validity.size = rows_to_return;
                 out->validity.nullable = false;
-                out->validity.all_valid = true;
                 out->row_id_start = scan_pos_;
                 out->size = rows_to_return;
                 scan_pos_ += rows_to_return;
@@ -121,7 +128,6 @@ class FixedWidthDataScanCursor final
                     ChunkedColumnInterface::ValidityEncoding::BoolArray;
                 out->validity.data = span.get().valid_data();
                 out->validity.offset = current_chunk_offset_;
-                out->validity.all_valid = false;
             }
             if (owner == nullptr) {
                 owner = std::make_shared<PinWrapper<SpanBase>>(span);
@@ -169,24 +175,27 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
                        int64_t length,
                        DataType data_type,
                        ChunkedColumnInterface::ScanProjection projection,
-                       ChunkedColumnInterface::ScanValueKind value_kind,
-                       int64_t max_batch_rows)
+                       ChunkedColumnInterface::ScanValueKind value_kind)
         : column_(column),
           op_ctx_(op_ctx),
           data_type_(data_type),
           projection_(projection),
           value_kind_(value_kind),
-          max_batch_rows_(max_batch_rows),
           scan_pos_(start_offset),
           scan_end_(start_offset + length) {
-        AssertInfo(max_batch_rows_ > 0,
-                   "view data scan max batch rows must be positive, got {}",
-                   max_batch_rows_);
+    }
+
+    int64_t
+    Position() const override {
+        return scan_pos_;
     }
 
     bool
-    Next(ChunkedColumnInterface::ScanBatch* out) override {
+    Next(int64_t max_rows, ChunkedColumnInterface::ScanBatch* out) override {
         AssertInfo(out != nullptr, "view data scan output batch is null");
+        AssertInfo(max_rows > 0,
+                   "view data scan max rows must be positive, got {}",
+                   max_rows);
         ResetOutput(out);
         if (scan_pos_ >= scan_end_) {
             return false;
@@ -196,9 +205,7 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
         const auto chunk_rows = column_->chunk_row_nums(chunk_id);
         auto rows_to_return = std::min<int64_t>(
             chunk_rows - static_cast<int64_t>(offset), scan_end_ - scan_pos_);
-        if (projection_ != ChunkedColumnInterface::ScanProjection::NoData) {
-            rows_to_return = std::min(rows_to_return, max_batch_rows_);
-        }
+        rows_to_return = std::min(rows_to_return, max_rows);
         AssertInfo(rows_to_return > 0,
                    "invalid view data scan batch at offset {}",
                    scan_pos_);
@@ -301,14 +308,12 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
         if (!column_->IsNullable() || valid_data.empty()) {
             out->validity.encoding =
                 ChunkedColumnInterface::ValidityEncoding::AllValid;
-            out->validity.all_valid = true;
             return;
         }
         out->validity.encoding =
             ChunkedColumnInterface::ValidityEncoding::BoolArray;
         out->validity.data = valid_data.data();
         out->validity.offset = 0;
-        out->validity.all_valid = false;
     }
 
     void
@@ -320,7 +325,6 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
         if (!column_->IsNullable()) {
             out->validity.encoding =
                 ChunkedColumnInterface::ValidityEncoding::AllValid;
-            out->validity.all_valid = true;
             return;
         }
 
@@ -330,7 +334,6 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
         if (valid_data.empty()) {
             out->validity.encoding =
                 ChunkedColumnInterface::ValidityEncoding::AllValid;
-            out->validity.all_valid = true;
             return;
         }
 
@@ -338,7 +341,6 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
             ChunkedColumnInterface::ValidityEncoding::BoolArray;
         out->validity.data = valid_data.data();
         out->validity.offset = offset;
-        out->validity.all_valid = false;
         out->owner = std::move(owner);
     }
 
@@ -425,7 +427,6 @@ class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
     DataType data_type_;
     ChunkedColumnInterface::ScanProjection projection_;
     ChunkedColumnInterface::ScanValueKind value_kind_;
-    int64_t max_batch_rows_;
     int64_t scan_pos_;
     int64_t scan_end_;
 };
@@ -464,8 +465,7 @@ MakeDataScanCursor(const ChunkedColumnInterface* column,
                    int64_t length,
                    DataType data_type,
                    ChunkedColumnInterface::ScanProjection projection,
-                   ChunkedColumnInterface::ScanValueKind value_kind,
-                   int64_t max_batch_rows) {
+                   ChunkedColumnInterface::ScanValueKind value_kind) {
     std::optional<ChunkedColumnInterface::ScanValueKind> column_kind;
     if (ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
         column_kind = ChunkedColumnInterface::ScanValueKind::FixedWidth;
@@ -527,8 +527,7 @@ MakeDataScanCursor(const ChunkedColumnInterface* column,
                                                     length,
                                                     data_type,
                                                     projection,
-                                                    resolved_kind,
-                                                    max_batch_rows);
+                                                    resolved_kind);
     }
 
     return nullptr;
@@ -550,8 +549,7 @@ ChunkedColumnInterface::Scan(milvus::OpContext* op_ctx,
                                       options.length,
                                       *data_type,
                                       options.projection,
-                                      options.value_kind,
-                                      options.max_batch_rows);
+                                      options.value_kind);
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnTakeCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnTakeCursors.cpp
@@ -1,0 +1,302 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License
+// at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+#include "mmap/ChunkedColumnInterface.h"
+
+namespace milvus {
+namespace detail {
+
+using StringViews = std::pair<std::vector<std::string_view>, FixedVector<bool>>;
+using ArrayViews = std::pair<std::vector<ArrayView>, FixedVector<bool>>;
+
+struct FixedTakeOwner {
+    FixedTakeOwner(PinWrapper<SpanBase>&& input,
+                   FixedVector<int32_t>&& selection)
+        : input(std::move(input)), selection(std::move(selection)) {
+    }
+
+    PinWrapper<SpanBase> input;
+    FixedVector<int32_t> selection;
+};
+
+struct StringTakeOwner {
+    explicit StringTakeOwner(PinWrapper<StringViews>&& input)
+        : input(std::move(input)) {
+    }
+
+    PinWrapper<StringViews> input;
+};
+
+struct JsonTakeOwner {
+    explicit JsonTakeOwner(PinWrapper<StringViews>&& input)
+        : input(std::move(input)) {
+        const auto& strings = this->input.get().first;
+        values.reserve(strings.size());
+        for (const auto& value : strings) {
+            values.emplace_back(value);
+        }
+    }
+
+    PinWrapper<StringViews> input;
+    std::vector<Json> values;
+};
+
+struct ArrayTakeOwner {
+    explicit ArrayTakeOwner(PinWrapper<ArrayViews>&& input)
+        : input(std::move(input)) {
+    }
+
+    PinWrapper<ArrayViews> input;
+};
+
+void
+ResetTakeBatch(ChunkedColumnInterface::TakeBatch* out) {
+    out->values = ChunkedColumnInterface::ValueView{};
+    out->selection = nullptr;
+    out->validity = nullptr;
+    out->owner.reset();
+    out->position = 0;
+    out->size = 0;
+    out->source_chunk_id = -1;
+}
+
+std::optional<ChunkedColumnInterface::ScanValueKind>
+ResolveTakeValueKind(DataType data_type,
+                     ChunkedColumnInterface::ScanValueKind requested) {
+    ChunkedColumnInterface::ScanValueKind physical;
+    if (ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
+        physical = ChunkedColumnInterface::ScanValueKind::FixedWidth;
+    } else if (data_type == DataType::JSON) {
+        physical = ChunkedColumnInterface::ScanValueKind::JsonView;
+    } else if (data_type == DataType::STRING ||
+               data_type == DataType::VARCHAR || data_type == DataType::TEXT ||
+               data_type == DataType::GEOMETRY) {
+        physical = ChunkedColumnInterface::ScanValueKind::StringView;
+    } else if (data_type == DataType::ARRAY) {
+        physical = ChunkedColumnInterface::ScanValueKind::ArrayView;
+    } else {
+        return std::nullopt;
+    }
+
+    const auto resolved =
+        requested == ChunkedColumnInterface::ScanValueKind::Default ? physical
+                                                                    : requested;
+    AssertInfo(resolved == physical,
+               "take value kind {} does not match column type {}, expected {}",
+               static_cast<int>(resolved),
+               data_type,
+               static_cast<int>(physical));
+    return resolved;
+}
+
+class RawTakeCursor final : public ChunkedColumnInterface::TakeCursor {
+ public:
+    RawTakeCursor(const ChunkedColumnInterface* column,
+                  milvus::OpContext* op_ctx,
+                  ChunkedColumnInterface::OffsetView offsets,
+                  DataType data_type,
+                  ChunkedColumnInterface::ScanValueKind value_kind)
+        : column_(column),
+          op_ctx_(op_ctx),
+          offsets_(offsets),
+          data_type_(data_type),
+          value_kind_(value_kind) {
+    }
+
+    int64_t
+    Position() const override {
+        return position_;
+    }
+
+    bool
+    Next(int64_t max_rows, ChunkedColumnInterface::TakeBatch* out) override {
+        AssertInfo(out != nullptr, "take output batch is null");
+        AssertInfo(
+            max_rows > 0, "take max rows must be positive, got {}", max_rows);
+        ResetTakeBatch(out);
+        if (position_ >= offsets_.size) {
+            return false;
+        }
+
+        const auto batch_position = position_;
+        const auto first_offset = offsets_[position_];
+        auto [chunk_id, chunk_offset] =
+            column_->GetChunkIDByOffset(first_offset);
+        FixedVector<int32_t> local_offsets;
+        local_offsets.reserve(
+            std::min<int64_t>(max_rows, offsets_.size - position_));
+        local_offsets.emplace_back(static_cast<int32_t>(chunk_offset));
+        ++position_;
+        while (position_ < offsets_.size &&
+               static_cast<int64_t>(local_offsets.size()) < max_rows) {
+            auto [next_chunk_id, next_chunk_offset] =
+                column_->GetChunkIDByOffset(offsets_[position_]);
+            if (next_chunk_id != chunk_id) {
+                break;
+            }
+            local_offsets.emplace_back(static_cast<int32_t>(next_chunk_offset));
+            ++position_;
+        }
+
+        out->position = batch_position;
+        out->size = static_cast<int64_t>(local_offsets.size());
+        out->source_chunk_id = static_cast<int64_t>(chunk_id);
+        switch (value_kind_) {
+            case ChunkedColumnInterface::ScanValueKind::FixedWidth:
+                FillFixedWidth(chunk_id, std::move(local_offsets), out);
+                break;
+            case ChunkedColumnInterface::ScanValueKind::StringView:
+                FillStringViews(chunk_id, local_offsets, out);
+                break;
+            case ChunkedColumnInterface::ScanValueKind::JsonView:
+                FillJsonViews(chunk_id, local_offsets, out);
+                break;
+            case ChunkedColumnInterface::ScanValueKind::ArrayView:
+                FillArrayViews(chunk_id, local_offsets, out);
+                break;
+            default:
+                ThrowInfo(ErrorCode::Unsupported,
+                          "unsupported raw take value kind {}",
+                          static_cast<int>(value_kind_));
+        }
+        return true;
+    }
+
+ private:
+    void
+    FillFixedWidth(int64_t chunk_id,
+                   FixedVector<int32_t>&& local_offsets,
+                   ChunkedColumnInterface::TakeBatch* out) const {
+        auto owner = std::make_shared<FixedTakeOwner>(
+            column_->Span(op_ctx_, chunk_id), std::move(local_offsets));
+        const auto& span = owner->input.get();
+        out->values.encoding =
+            ChunkedColumnInterface::ValueEncoding::FixedWidth;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::FixedWidth;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = data_type_;
+        out->values.data = span.data();
+        out->values.offset = 0;
+        out->values.size = span.row_count();
+        out->values.byte_width = span.element_sizeof();
+        out->selection = owner->selection.data();
+        out->validity = span.valid_data();
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillStringViews(int64_t chunk_id,
+                    const FixedVector<int32_t>& local_offsets,
+                    ChunkedColumnInterface::TakeBatch* out) const {
+        auto owner = std::make_shared<StringTakeOwner>(
+            column_->StringViewsByOffsets(op_ctx_, chunk_id, local_offsets));
+        const auto& [views, validity] = owner->input.get();
+        out->values.encoding =
+            ChunkedColumnInterface::ValueEncoding::StringView;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::StringView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = data_type_;
+        out->values.data = views.data();
+        out->values.offset = 0;
+        out->values.size = views.size();
+        out->values.byte_width = sizeof(std::string_view);
+        if (column_->IsNullable() && !validity.empty()) {
+            out->validity = validity.data();
+        }
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillJsonViews(int64_t chunk_id,
+                  const FixedVector<int32_t>& local_offsets,
+                  ChunkedColumnInterface::TakeBatch* out) const {
+        auto owner = std::make_shared<JsonTakeOwner>(
+            column_->StringViewsByOffsets(op_ctx_, chunk_id, local_offsets));
+        const auto& validity = owner->input.get().second;
+        out->values.encoding = ChunkedColumnInterface::ValueEncoding::JsonView;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::JsonView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = DataType::JSON;
+        out->values.data = owner->values.data();
+        out->values.offset = 0;
+        out->values.size = owner->values.size();
+        out->values.byte_width = sizeof(Json);
+        if (column_->IsNullable() && !validity.empty()) {
+            out->validity = validity.data();
+        }
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillArrayViews(int64_t chunk_id,
+                   const FixedVector<int32_t>& local_offsets,
+                   ChunkedColumnInterface::TakeBatch* out) const {
+        auto owner = std::make_shared<ArrayTakeOwner>(
+            column_->ArrayViewsByOffsets(op_ctx_, chunk_id, local_offsets));
+        const auto& [views, validity] = owner->input.get();
+        out->values.encoding = ChunkedColumnInterface::ValueEncoding::ArrayView;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::ArrayView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = DataType::ARRAY;
+        out->values.data = views.data();
+        out->values.offset = 0;
+        out->values.size = views.size();
+        out->values.byte_width = sizeof(ArrayView);
+        if (column_->IsNullable() && !validity.empty()) {
+            out->validity = validity.data();
+        }
+        out->owner = std::move(owner);
+    }
+
+    const ChunkedColumnInterface* column_;
+    milvus::OpContext* op_ctx_;
+    ChunkedColumnInterface::OffsetView offsets_;
+    DataType data_type_;
+    ChunkedColumnInterface::ScanValueKind value_kind_;
+    int64_t position_{0};
+};
+
+}  // namespace detail
+
+ChunkedColumnInterface::TakeResult
+ChunkedColumnInterface::Take(milvus::OpContext* op_ctx,
+                             const TakeOptions& options) const {
+    AssertInfo(options.offsets.size >= 0,
+               "take offset count must be non-negative, got {}",
+               options.offsets.size);
+    if (options.offsets.size > 0) {
+        AssertInfo(options.offsets.data != nullptr,
+                   "take offsets are null with count {}",
+                   options.offsets.size);
+    }
+    auto data_type = GetDefaultScanDataType();
+    if (!data_type.has_value()) {
+        return nullptr;
+    }
+    auto value_kind =
+        detail::ResolveTakeValueKind(*data_type, options.value_kind);
+    if (!value_kind.has_value()) {
+        return nullptr;
+    }
+    return std::make_unique<detail::RawTakeCursor>(
+        this, op_ctx, options.offsets, *data_type, *value_kind);
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnTakeCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnTakeCursors.cpp
@@ -1,0 +1,556 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "mmap/ChunkedColumnFilter.h"
+#include "mmap/ChunkedColumnInterface.h"
+
+namespace milvus {
+namespace detail {
+
+using RawTakeCellPin = std::function<PinWrapper<Chunk*>(int64_t)>;
+
+struct OwnedTakeStorage {
+    std::vector<int8_t> int8_values;
+    std::vector<int16_t> int16_values;
+    std::vector<int32_t> int32_values;
+    std::vector<int64_t> int64_values;
+    std::vector<float> float_values;
+    std::vector<double> double_values;
+    FixedVector<bool> bool_values;
+
+    std::vector<std::string> strings;
+    std::vector<std::string_view> string_views;
+    std::vector<Json> json_values;
+    std::vector<Array> arrays;
+    std::vector<ArrayView> array_views;
+    std::vector<ArrayValue> array_values;
+    std::vector<ArrayValueView> array_value_views;
+    FixedVector<bool> validity;
+    FixedVector<bool> data_skipped;
+};
+
+struct RawTakeLocation {
+    int64_t source_cell_id = -1;
+    size_t cell_offset = 0;
+};
+
+std::optional<ChunkedColumnInterface::TargetType>
+ValidateTakeTargetType(DataType data_type,
+                       ChunkedColumnInterface::TargetType requested) {
+    AssertInfo(requested != ChunkedColumnInterface::TargetType::None,
+               "take target type must be specified");
+    AssertInfo(CanReadAsTargetType(data_type, requested),
+               "take target {} does not match column type {}",
+               static_cast<int>(requested),
+               data_type);
+    if (requested == ChunkedColumnInterface::TargetType::VectorArrayView) {
+        return std::nullopt;
+    }
+    return requested;
+}
+
+class RawTakeResult final : public ChunkedColumnInterface::TakeResult {
+ public:
+    RawTakeResult(RawTakeCellPin pin_cell,
+                  std::shared_ptr<const ColumnPlanner> planner,
+                  OffsetView offsets,
+                  ColumnFilterPtr filter,
+                  DataType data_type,
+                  ChunkedColumnInterface::TargetType target_type,
+                  bool nullable)
+        : pin_cell_(std::move(pin_cell)),
+          planner_(std::move(planner)),
+          data_type_(data_type),
+          target_type_(target_type),
+          nullable_(nullable),
+          offsets_(offsets),
+          filter_(std::move(filter)) {
+        AssertInfo(static_cast<bool>(pin_cell_),
+                   "raw take cell accessor is null");
+        AssertInfo(planner_ != nullptr, "raw take planner is null");
+        for (int64_t i = 0; i < offsets_.size; ++i) {
+            const auto offset = offsets_.AtUnchecked(i);
+            AssertInfo(offset >= 0 && offset < planner_->NumRows(),
+                       "take offset {} is outside column rows {}",
+                       offset,
+                       planner_->NumRows());
+        }
+    }
+
+    int64_t
+    Size() const override {
+        return offsets_.size;
+    }
+
+    ChunkedColumnInterface::TargetType
+    GetTargetType() const override {
+        return target_type_;
+    }
+
+    DataType
+    GetDataType() const override {
+        return data_type_;
+    }
+
+ protected:
+    ChunkedColumnInterface::TakeItemState
+    PrepareItem(int64_t index, bool read_data) const override {
+        if (owned_ != nullptr) {
+            return {!owned_data_.validity || owned_data_.validity[index],
+                    read_data && owned_data_.data_skipped &&
+                        owned_data_.data_skipped[index]};
+        }
+        if (!nullable_ && !read_data) {
+            return {true, false};
+        }
+        const auto& location = ResolveLocation(index);
+        const auto preloaded_skip =
+            read_data && filter_ != nullptr &&
+            filter_->Source() ==
+                ColumnFilter::MetricsSource::PreloadedStatistics &&
+            ShouldSkipFilteredCell(location.source_cell_id);
+        if (!nullable_ && preloaded_skip) {
+            return {true, true};
+        }
+        auto* chunk = PinCell(location.source_cell_id);
+        const auto valid = !nullable_ || chunk->isValid(location.cell_offset);
+        if (!read_data || filter_ == nullptr) {
+            return {valid, false};
+        }
+        if (preloaded_skip) {
+            return {valid, true};
+        }
+        if (filter_->Source() != ColumnFilter::MetricsSource::LoadedPayload) {
+            return {valid, false};
+        }
+        return {valid, ShouldSkipFilteredCell(location.source_cell_id)};
+    }
+
+ public:
+    bool
+    IsOwned() const override {
+        return owned_ != nullptr;
+    }
+
+    ChunkedColumnInterface::OwnedTakeData
+    GetOwn() const override {
+        if (owned_ != nullptr) {
+            return owned_data_;
+        }
+
+        auto owner = std::make_shared<OwnedTakeStorage>();
+        if (nullable_) {
+            owner->validity.resize(Size());
+        }
+        ChunkedColumnInterface::ValueView values;
+        values.offset = 0;
+
+        auto visit_values = [this, &owner](auto&& fn) {
+            VisitGrouped([&](int64_t index) {
+                const auto state = PrepareItem(index, /*read_data=*/true);
+                if (nullable_) {
+                    owner->validity[index] = state.is_valid;
+                }
+                if (state.data_skipped) {
+                    // Filtering is decided and cached at Cell granularity.
+                    // Expand it to the logical offset order only when an
+                    // owned result actually contains a skipped position.
+                    if (owner->data_skipped.empty()) {
+                        owner->data_skipped.resize(Size());
+                    }
+                    owner->data_skipped[index] = true;
+                    return;
+                }
+                const auto [chunk, chunk_offset] = ResolveBorrowed(index);
+                fn(index, chunk, chunk_offset, state.is_valid);
+            });
+        };
+
+        auto fill_primitive = [this, &visit_values]<typename T>(
+                                  std::vector<T>& output) {
+            output.resize(Size());
+            visit_values(
+                [&](int64_t index, Chunk* chunk, size_t chunk_offset, bool) {
+                    output[index] = *static_cast<const T*>(
+                        static_cast<const void*>(chunk->ValueAt(chunk_offset)));
+                });
+        };
+
+        switch (data_type_) {
+            case DataType::INT8:
+                fill_primitive(owner->int8_values);
+                values.data = owner->int8_values.data();
+                values.byte_width = sizeof(int8_t);
+                break;
+            case DataType::INT16:
+                fill_primitive(owner->int16_values);
+                values.data = owner->int16_values.data();
+                values.byte_width = sizeof(int16_t);
+                break;
+            case DataType::INT32:
+                fill_primitive(owner->int32_values);
+                values.data = owner->int32_values.data();
+                values.byte_width = sizeof(int32_t);
+                break;
+            case DataType::INT64:
+            case DataType::TIMESTAMPTZ:
+                fill_primitive(owner->int64_values);
+                values.data = owner->int64_values.data();
+                values.byte_width = sizeof(int64_t);
+                break;
+            case DataType::FLOAT:
+                fill_primitive(owner->float_values);
+                values.data = owner->float_values.data();
+                values.byte_width = sizeof(float);
+                break;
+            case DataType::DOUBLE:
+                fill_primitive(owner->double_values);
+                values.data = owner->double_values.data();
+                values.byte_width = sizeof(double);
+                break;
+            case DataType::BOOL:
+                owner->bool_values.resize(Size());
+                visit_values([&](int64_t index,
+                                 Chunk* chunk,
+                                 size_t chunk_offset,
+                                 bool) {
+                    owner->bool_values[index] = *static_cast<const bool*>(
+                        static_cast<const void*>(chunk->ValueAt(chunk_offset)));
+                });
+                values.data = owner->bool_values.data();
+                values.byte_width = sizeof(bool);
+                break;
+            case DataType::STRING:
+            case DataType::VARCHAR:
+            case DataType::TEXT:
+            case DataType::GEOMETRY:
+                owner->strings.resize(Size());
+                visit_values([&](int64_t index,
+                                 Chunk* chunk,
+                                 size_t chunk_offset,
+                                 bool valid) {
+                    if (valid) {
+                        owner->strings[index] =
+                            static_cast<StringChunk*>(chunk)->operator[](
+                                chunk_offset);
+                    }
+                });
+                owner->string_views.resize(Size());
+                for (int64_t i = 0; i < Size(); ++i) {
+                    owner->string_views[i] = owner->strings[i];
+                }
+                values.data = owner->string_views.data();
+                values.byte_width = sizeof(std::string_view);
+                break;
+            case DataType::JSON:
+                owner->json_values.resize(Size());
+                visit_values([&](int64_t index,
+                                 Chunk* chunk,
+                                 size_t chunk_offset,
+                                 bool valid) {
+                    if (!valid) {
+                        return;
+                    }
+                    const auto view =
+                        static_cast<StringChunk*>(chunk)->operator[](
+                            chunk_offset);
+                    owner->json_values[index] =
+                        Json(simdjson::padded_string(view.data(), view.size()));
+                });
+                values.data = owner->json_values.data();
+                values.byte_width = sizeof(Json);
+                break;
+            case DataType::ARRAY:
+                if (target_type_ == TargetType::ArrayValueView) {
+                    owner->array_values.resize(Size());
+                    owner->array_value_views.resize(Size());
+                    visit_values([&](int64_t index,
+                                     Chunk* chunk,
+                                     size_t chunk_offset,
+                                     bool valid) {
+                        if (!valid) {
+                            return;
+                        }
+                        auto* array_chunk =
+                            dynamic_cast<ColumnarArrayChunk*>(chunk);
+                        AssertInfo(array_chunk != nullptr,
+                                   "raw take Cell is not a recursive array");
+                        auto view =
+                            array_chunk->View<ArrayValueView>(chunk_offset);
+                        owner->array_values[index] =
+                            ArrayValue(view.output_data(), view.type());
+                        owner->array_value_views[index] =
+                            owner->array_values[index].View();
+                    });
+                    values.data = owner->array_value_views.data();
+                    values.byte_width = sizeof(ArrayValueView);
+                } else {
+                    owner->arrays.resize(Size());
+                    owner->array_views.resize(Size());
+                    visit_values([&](int64_t index,
+                                     Chunk* chunk,
+                                     size_t chunk_offset,
+                                     bool valid) {
+                        if (!valid) {
+                            return;
+                        }
+                        auto* array_chunk = dynamic_cast<ArrayChunk*>(chunk);
+                        AssertInfo(array_chunk != nullptr,
+                                   "raw take Cell is not a flat array");
+                        array_chunk->View(chunk_offset)
+                            .output_data(owner->arrays[index]);
+                        auto& array = owner->arrays[index];
+                        owner->array_views[index] =
+                            ArrayView(const_cast<char*>(array.data()),
+                                      array.length(),
+                                      array.byte_size(),
+                                      array.get_element_type(),
+                                      array.get_offsets_data());
+                    });
+                    values.data = owner->array_views.data();
+                    values.byte_width = sizeof(ArrayView);
+                }
+                break;
+            default:
+                ThrowInfo(ErrorCode::Unsupported,
+                          "unsupported raw owned take type {}",
+                          data_type_);
+        }
+
+        values.target_type = target_type_;
+
+        owned_ = owner;
+        owned_data_ = ChunkedColumnInterface::OwnedTakeData{
+            values,
+            owner->validity.empty()
+                ? ValidityView{}
+                : ValidityView::FromExpanded(owner->validity.data()),
+            owner,
+            Size(),
+            owner->data_skipped.empty()
+                ? ValidityView{}
+                : ValidityView::FromExpanded(owner->data_skipped.data())};
+        ResetBorrowedPin();
+        return owned_data_;
+    }
+
+ protected:
+    const void*
+    FixedValueAt(int64_t index) const override {
+        if (owned_ != nullptr) {
+            return static_cast<const char*>(owned_data_.values.data) +
+                   (owned_data_.values.offset + index) *
+                       owned_data_.values.byte_width;
+        }
+        const auto [chunk, offset] = ResolveBorrowed(index);
+        return chunk->ValueAt(offset);
+    }
+
+    std::string_view
+    StringViewAt(int64_t index) const override {
+        if (owned_ != nullptr) {
+            return owned_data_.values.data_as<std::string_view>()[index];
+        }
+        const auto [chunk, offset] = ResolveBorrowed(index);
+        return static_cast<StringChunk*>(chunk)->operator[](offset);
+    }
+
+    Json
+    JsonAt(int64_t index) const override {
+        if (owned_ != nullptr) {
+            return owned_data_.values.data_as<Json>()[index];
+        }
+        return Json(StringViewAt(index));
+    }
+
+    ArrayView
+    ArrayAt(int64_t index) const override {
+        if (owned_ != nullptr) {
+            return owned_data_.values.data_as<ArrayView>()[index];
+        }
+        const auto [chunk, offset] = ResolveBorrowed(index);
+        auto* array_chunk = dynamic_cast<ArrayChunk*>(chunk);
+        AssertInfo(array_chunk != nullptr, "raw take Cell is not a flat array");
+        return array_chunk->View(offset);
+    }
+
+    ArrayValueView
+    ArrayValueAt(int64_t index) const override {
+        if (owned_ != nullptr) {
+            return owned_data_.values.data_as<ArrayValueView>()[index];
+        }
+        const auto [chunk, offset] = ResolveBorrowed(index);
+        auto* array_chunk = dynamic_cast<ColumnarArrayChunk*>(chunk);
+        AssertInfo(array_chunk != nullptr,
+                   "raw take Cell is not a recursive array");
+        return array_chunk->View<ArrayValueView>(offset);
+    }
+
+ private:
+    struct CellGroup {
+        int64_t cell_id;
+        std::vector<int64_t> positions;
+    };
+
+    Chunk*
+    PinCell(int64_t cell_id) const {
+        if (current_pin_.has_value() && current_cell_id_ == cell_id) {
+            return current_chunk_;
+        }
+        ResetBorrowedPin();
+        auto next = pin_cell_(cell_id);
+        auto* chunk = next.get();
+        AssertInfo(chunk != nullptr, "raw take pinned null cell {}", cell_id);
+        current_pin_.emplace(std::move(next));
+        current_cell_id_ = cell_id;
+        current_chunk_ = chunk;
+        return chunk;
+    }
+
+    std::pair<Chunk*, size_t>
+    ResolveBorrowed(int64_t index) const {
+        const auto& location = ResolveLocation(index);
+        return {PinCell(location.source_cell_id), location.cell_offset};
+    }
+
+    const RawTakeLocation&
+    ResolveLocation(int64_t index) const {
+        if (cached_location_index_ == index) {
+            return cached_location_;
+        }
+        const auto location = planner_->Locate(offsets_.AtUnchecked(index));
+        cached_location_ = RawTakeLocation{
+            location.cell_id, static_cast<size_t>(location.cell_offset)};
+        cached_location_index_ = index;
+        return cached_location_;
+    }
+
+    bool
+    ShouldSkipFilteredCell(int64_t cell_id) const {
+        AssertInfo(filter_ != nullptr, "raw take filter is null");
+        if (filter_->Source() == ColumnFilter::MetricsSource::LoadedPayload) {
+            AssertInfo(current_cell_id_ == cell_id && current_chunk_ != nullptr,
+                       "loaded-payload filter Cell {} is not pinned",
+                       cell_id);
+        }
+        if (current_filter_cell_id_ == cell_id &&
+            current_filter_skip_.has_value()) {
+            return *current_filter_skip_;
+        }
+        auto [it, inserted] = filter_skip_by_cell_.try_emplace(cell_id, false);
+        if (inserted) {
+            it->second = filter_->CanSkipPhysicalCell(cell_id);
+        }
+        current_filter_cell_id_ = cell_id;
+        current_filter_skip_ = it->second;
+        return *current_filter_skip_;
+    }
+
+    template <typename Fn>
+    void
+    VisitGrouped(Fn&& fn) const {
+        std::vector<CellGroup> cell_groups;
+        std::unordered_map<int64_t, size_t> cell_to_group;
+        const auto max_groups =
+            static_cast<size_t>(std::min(Size(), planner_->NumCells()));
+        cell_groups.reserve(max_groups);
+        cell_to_group.reserve(max_groups);
+        for (int64_t position = 0; position < Size(); ++position) {
+            const auto cell_id = ResolveLocation(position).source_cell_id;
+            auto [it, inserted] =
+                cell_to_group.emplace(cell_id, cell_groups.size());
+            if (inserted) {
+                cell_groups.emplace_back(CellGroup{cell_id, {}});
+            }
+            cell_groups[it->second].positions.emplace_back(position);
+        }
+
+        for (const auto& group : cell_groups) {
+            for (const auto position : group.positions) {
+                fn(position);
+            }
+        }
+    }
+
+    void
+    ResetBorrowedPin() const {
+        current_pin_.reset();
+        current_cell_id_ = -1;
+        current_chunk_ = nullptr;
+    }
+
+    RawTakeCellPin pin_cell_;
+    std::shared_ptr<const ColumnPlanner> planner_;
+    DataType data_type_;
+    ChunkedColumnInterface::TargetType target_type_;
+    bool nullable_;
+    OffsetView offsets_;
+    ColumnFilterPtr filter_;
+    mutable std::unordered_map<int64_t, bool> filter_skip_by_cell_;
+    mutable int64_t current_filter_cell_id_{-1};
+    mutable std::optional<bool> current_filter_skip_;
+    mutable int64_t cached_location_index_{-1};
+    mutable RawTakeLocation cached_location_;
+    mutable std::optional<PinWrapper<Chunk*>> current_pin_;
+    mutable int64_t current_cell_id_{-1};
+    mutable Chunk* current_chunk_{nullptr};
+    mutable std::shared_ptr<OwnedTakeStorage> owned_;
+    mutable ChunkedColumnInterface::OwnedTakeData owned_data_;
+};
+
+}  // namespace detail
+
+ChunkedColumnInterface::TakeResultPtr
+ChunkedColumnInterface::Take(milvus::OpContext* op_ctx,
+                             TakeOptions options) const {
+    AssertInfo(options.offsets.size >= 0,
+               "take offset count must be non-negative, got {}",
+               options.offsets.size);
+    AssertInfo(options.offsets.size == 0 || options.offsets.data != nullptr,
+               "take offsets are null with count {}",
+               options.offsets.size);
+    auto data_type = GetDefaultScanDataType();
+    if (!data_type.has_value()) {
+        return nullptr;
+    }
+    auto target_type =
+        detail::ValidateTakeTargetType(*data_type, options.target_type);
+    if (!target_type.has_value()) {
+        return nullptr;
+    }
+    auto pin_cell = MakeTakeCellPin(op_ctx);
+    if (!pin_cell) {
+        return nullptr;
+    }
+    auto planner = PlannerHandle();
+    return std::make_unique<detail::RawTakeResult>(std::move(pin_cell),
+                                                   std::move(planner),
+                                                   options.offsets,
+                                                   std::move(options.filter),
+                                                   *data_type,
+                                                   *target_type,
+                                                   IsNullable());
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.cpp
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.cpp
@@ -1,0 +1,304 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mmap/VirtualPKChunkedColumn.h"
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "mmap/ChunkedColumnFilter.h"
+
+namespace milvus {
+namespace {
+
+inline int64_t
+ComputeVirtualPKValue(int64_t shifted_segment_id, int64_t offset) {
+    return shifted_segment_id | (offset & 0xFFFFFFFF);
+}
+
+void
+ValidateVirtualPKScanTargetType(TargetType requested) {
+    AssertInfo(requested == TargetType::None || requested == TargetType::Int64,
+               "virtual PK scan target {} is neither None nor Int64",
+               static_cast<int>(requested));
+}
+
+void
+ValidateVirtualPKTakeTargetType(TargetType requested) {
+    AssertInfo(requested == TargetType::Int64,
+               "virtual PK target {} is not Int64",
+               static_cast<int>(requested));
+}
+
+struct VirtualPKValues {
+    std::vector<int64_t> values;
+    FixedVector<bool> data_skipped;
+};
+
+ValueView
+MakeVirtualPKValueView(const VirtualPKValues& owner) {
+    ValueView values;
+    values.target_type = TargetType::Int64;
+    values.data = owner.values.empty() ? nullptr : owner.values.data();
+    values.offset = 0;
+    values.byte_width = sizeof(int64_t);
+    return values;
+}
+
+class VirtualPKScanCursor final : public ScanCursor {
+ public:
+    VirtualPKScanCursor(int64_t shifted_segment_id,
+                        int64_t num_rows,
+                        int64_t start_offset,
+                        TargetType target_type,
+                        std::function<bool()> should_skip_data)
+        : shifted_segment_id_(shifted_segment_id),
+          num_rows_(num_rows),
+          target_type_(target_type),
+          should_skip_data_(std::move(should_skip_data)),
+          scan_pos_(start_offset) {
+        AssertInfo(start_offset >= 0 && start_offset <= num_rows_,
+                   "virtual PK scan start {} out of rows {}",
+                   start_offset,
+                   num_rows_);
+    }
+
+    int64_t
+    Position() const override {
+        return scan_pos_;
+    }
+
+    void
+    Seek(int64_t position) override {
+        AssertInfo(position >= scan_pos_,
+                   "virtual PK scan cannot seek backward from {} to {}",
+                   scan_pos_,
+                   position);
+        AssertInfo(position <= num_rows_,
+                   "virtual PK scan seek {} out of rows {}",
+                   position,
+                   num_rows_);
+        scan_pos_ = position;
+    }
+
+    bool
+    Next(int64_t length, ScanReadMode read_mode, ScanBatch* out) override {
+        AssertInfo(out != nullptr, "virtual PK scan output batch is null");
+        *out = ScanBatch{};
+        AssertInfo(length >= 0,
+                   "virtual PK scan length {} must be non-negative",
+                   length);
+        if (length == 0 || scan_pos_ == num_rows_) {
+            return false;
+        }
+        length = std::min(length, num_rows_ - scan_pos_);
+        AssertInfo(read_mode != ScanReadMode::ValidityOnly,
+                   "validity-only scan requested for non-nullable virtual PK "
+                   "column");
+        AssertInfo(target_type_ == TargetType::Int64,
+                   "virtual PK data scan target {} is not Int64",
+                   static_cast<int>(target_type_));
+
+        out->row_id_start = scan_pos_;
+        out->size = length;
+        AssertInfo(read_mode == ScanReadMode::DataAndValidity,
+                   "unsupported virtual PK scan mode {}",
+                   static_cast<int>(read_mode));
+        if (!filter_evaluated_) {
+            filter_evaluated_ = true;
+            data_skipped_ = should_skip_data_ && should_skip_data_();
+        }
+        if (data_skipped_) {
+            out->data_skipped = true;
+            scan_pos_ += length;
+            return true;
+        }
+        auto owner = std::make_shared<VirtualPKValues>();
+        owner->values.reserve(length);
+        for (int64_t i = 0; i < length; ++i) {
+            owner->values.emplace_back(
+                ComputeVirtualPKValue(shifted_segment_id_, scan_pos_ + i));
+        }
+        out->values = MakeVirtualPKValueView(*owner);
+        out->owner = std::move(owner);
+        scan_pos_ += length;
+        return true;
+    }
+
+ private:
+    int64_t shifted_segment_id_;
+    int64_t num_rows_;
+    TargetType target_type_;
+    std::function<bool()> should_skip_data_;
+    bool filter_evaluated_{false};
+    bool data_skipped_{false};
+    int64_t scan_pos_;
+};
+
+class VirtualPKTakeResult final : public TakeResult {
+ public:
+    VirtualPKTakeResult(std::shared_ptr<VirtualPKValues> owner, int64_t size)
+        : owner_(std::move(owner)), size_(size) {
+        AssertInfo(owner_ != nullptr, "virtual PK take owner is null");
+        AssertInfo(
+            size_ >= 0, "virtual PK take size {} must be non-negative", size_);
+        AssertInfo(
+            owner_->data_skipped.empty()
+                ? static_cast<int64_t>(owner_->values.size()) == size_
+                : (static_cast<int64_t>(owner_->data_skipped.size()) == size_ &&
+                   owner_->values.empty()),
+            "virtual PK take storage does not match logical size {}",
+            size_);
+    }
+
+    int64_t
+    Size() const override {
+        return size_;
+    }
+
+    TargetType
+    GetTargetType() const override {
+        return TargetType::Int64;
+    }
+
+    DataType
+    GetDataType() const override {
+        return DataType::INT64;
+    }
+
+ protected:
+    TakeItemState
+    PrepareItem(int64_t index, bool read_data) const override {
+        return {true,
+                read_data && !owner_->data_skipped.empty() &&
+                    owner_->data_skipped[index]};
+    }
+
+ public:
+    bool
+    IsOwned() const override {
+        return true;
+    }
+
+    OwnedTakeData
+    GetOwn() const override {
+        const auto data_skipped =
+            owner_->data_skipped.empty()
+                ? ValidityView{}
+                : ValidityView::FromExpanded(owner_->data_skipped.data());
+        return OwnedTakeData{
+            MakeVirtualPKValueView(*owner_), {}, owner_, Size(), data_skipped};
+    }
+
+ protected:
+    const void*
+    FixedValueAt(int64_t index) const override {
+        return owner_->values.data() + index;
+    }
+
+    std::string_view
+    StringViewAt(int64_t) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "virtual PK Take does not contain string values");
+    }
+
+    Json
+    JsonAt(int64_t) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "virtual PK Take does not contain JSON values");
+    }
+
+    ArrayView
+    ArrayAt(int64_t) const override {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "virtual PK Take does not contain array values");
+    }
+
+ private:
+    std::shared_ptr<VirtualPKValues> owner_;
+    int64_t size_;
+};
+
+}  // namespace
+
+ChunkedColumnInterface::ScanResult
+VirtualPKChunkedColumn::Scan(milvus::OpContext*,
+                             const ScanOptions& options) const {
+    ValidateVirtualPKScanTargetType(options.target_type);
+    return std::make_unique<VirtualPKScanCursor>(
+        shifted_segment_id_,
+        num_rows_,
+        options.start_offset,
+        options.target_type,
+        options.filter == nullptr
+            ? std::function<bool()>{}
+            : std::function<bool()>{[this, filter = options.filter]() {
+                  return ShouldSkipData(filter);
+              }});
+}
+
+ChunkedColumnInterface::TakeResultPtr
+VirtualPKChunkedColumn::Take(milvus::OpContext*, TakeOptions options) const {
+    ValidateVirtualPKTakeTargetType(options.target_type);
+    const auto offsets = options.offsets;
+    AssertInfo(offsets.size >= 0,
+               "virtual PK Take offset count must be non-negative, got {}",
+               offsets.size);
+    AssertInfo(offsets.size == 0 || offsets.data != nullptr,
+               "virtual PK Take offsets are null with count {}",
+               offsets.size);
+
+    auto owner = std::make_shared<VirtualPKValues>();
+    const auto data_skipped =
+        offsets.size > 0 && ShouldSkipData(options.filter);
+    if (data_skipped) {
+        owner->data_skipped.resize(offsets.size, true);
+    } else {
+        owner->values.reserve(offsets.size);
+    }
+    for (int64_t i = 0; i < offsets.size; ++i) {
+        const auto offset = offsets[i];
+        AssertInfo(offset >= 0 && offset < num_rows_,
+                   "virtual PK Take offset {} is out of rows {}",
+                   offset,
+                   num_rows_);
+        if (!data_skipped) {
+            owner->values.emplace_back(ComputeVirtualPK(offset));
+        }
+    }
+    return std::make_unique<VirtualPKTakeResult>(std::move(owner),
+                                                 offsets.size);
+}
+
+bool
+VirtualPKChunkedColumn::ShouldSkipData(
+    const detail::ColumnFilterPtr& filter) const {
+    if (filter == nullptr) {
+        return false;
+    }
+    if (filter->Source() ==
+        detail::ColumnFilter::MetricsSource::LoadedPayload) {
+        // Match the legacy Chunk path: payload-backed statistics are consulted
+        // only after the generated data has been materialized.
+        EnsureMaterialized();
+    }
+    return filter->CanSkipPhysicalCell(0);
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.h
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.h
@@ -46,7 +46,8 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
     DataOfChunk(milvus::OpContext* op_ctx, int chunk_id) const override {
         EnsureMaterialized();
         return PinWrapper<const char*>(
-            reinterpret_cast<const char*>(materialized_pks_.data()));
+            materialized_,
+            reinterpret_cast<const char*>(materialized_->pks.data()));
     }
 
     bool
@@ -100,7 +101,8 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
     Span(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
         EnsureMaterialized();
         return PinWrapper<SpanBase>(
-            SpanBase(materialized_pks_.data(), num_rows_, sizeof(int64_t)));
+            materialized_,
+            SpanBase(materialized_->pks.data(), num_rows_, sizeof(int64_t)));
     }
 
     void
@@ -214,14 +216,22 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
 
     PinWrapper<Chunk*>
     GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
-        ThrowInfo(ErrorCode::Unsupported,
-                  "GetChunk not supported for VirtualPKChunkedColumn");
+        AssertInfo(chunk_id == 0, "VirtualPKChunkedColumn has only 1 chunk");
+        EnsureMaterialized();
+        return PinWrapper<Chunk*>(materialized_, materialized_->chunk.get());
     }
+
+    ScanResult
+    Scan(milvus::OpContext* op_ctx, const ScanOptions& options) const override;
+
+    TakeResultPtr
+    Take(milvus::OpContext* op_ctx, TakeOptions options) const override;
 
     std::vector<PinWrapper<Chunk*>>
     GetAllChunks(milvus::OpContext* op_ctx) const override {
-        ThrowInfo(ErrorCode::Unsupported,
-                  "GetAllChunks not supported for VirtualPKChunkedColumn");
+        std::vector<PinWrapper<Chunk*>> chunks;
+        chunks.emplace_back(GetChunk(op_ctx, 0));
+        return chunks;
     }
 
     int64_t
@@ -293,7 +303,24 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
         return truncated_segment_id_;
     }
 
+ protected:
+    std::optional<DataType>
+    GetDefaultScanDataType() const override {
+        // The system-injected __virtual_pk__ field is always INT64. External
+        // collections with a user-defined VARCHAR primary key load that field
+        // through the regular string column implementation instead.
+        return DataType::INT64;
+    }
+
  private:
+    bool
+    ShouldSkipData(const detail::ColumnFilterPtr& filter) const;
+
+    struct MaterializedData {
+        std::vector<int64_t> pks;
+        std::shared_ptr<FixedWidthChunk> chunk;
+    };
+
     // Compute virtual PK from an offset using the pre-shifted segment ID.
     // Centralizes the inlined formula so all call sites stay consistent.
     inline int64_t
@@ -304,10 +331,20 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
     void
     EnsureMaterialized() const {
         std::call_once(materialize_once_, [this]() {
-            materialized_pks_.resize(num_rows_);
+            auto materialized = std::make_shared<MaterializedData>();
+            materialized->pks.resize(num_rows_);
             for (int64_t i = 0; i < num_rows_; i++) {
-                materialized_pks_[i] = ComputeVirtualPK(i);
+                materialized->pks[i] = ComputeVirtualPK(i);
             }
+            materialized->chunk = std::make_shared<FixedWidthChunk>(
+                static_cast<int32_t>(num_rows_),
+                1,
+                reinterpret_cast<char*>(materialized->pks.data()),
+                materialized->pks.size() * sizeof(int64_t),
+                sizeof(int64_t),
+                /*nullable=*/false,
+                nullptr);
+            materialized_ = std::move(materialized);
         });
     }
 
@@ -317,7 +354,7 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
     int64_t num_rows_;
     std::vector<int64_t> num_rows_until_chunk_;
     mutable std::once_flag materialize_once_;
-    mutable std::vector<int64_t> materialized_pks_;
+    mutable std::shared_ptr<MaterializedData> materialized_;
 };
 
 }  // namespace milvus

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.h
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.h
@@ -274,6 +274,15 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
         return truncated_segment_id_;
     }
 
+ protected:
+    std::optional<DataType>
+    GetDefaultScanDataType() const override {
+        // The system-injected __virtual_pk__ field is always INT64. External
+        // collections with a user-defined VARCHAR primary key load that field
+        // through the regular string column implementation instead.
+        return DataType::INT64;
+    }
+
  private:
     // Compute virtual PK from an offset using the pre-shifted segment ID.
     // Centralizes the inlined formula so all call sites stay consistent.

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.h
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.h
@@ -195,14 +195,30 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
 
     PinWrapper<Chunk*>
     GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
-        ThrowInfo(ErrorCode::Unsupported,
-                  "GetChunk not supported for VirtualPKChunkedColumn");
+        AssertInfo(chunk_id == 0, "VirtualPKChunkedColumn has only 1 chunk");
+        EnsureMaterialized();
+        return PinWrapper<Chunk*>(materialized_chunk_,
+                                  materialized_chunk_.get());
+    }
+
+    std::vector<PinWrapper<Chunk*>>
+    PinChunks(milvus::OpContext* op_ctx,
+              const std::vector<int64_t>& chunk_ids) const override {
+        if (chunk_ids.empty()) {
+            return {};
+        }
+        AssertInfo(chunk_ids.size() == 1 && chunk_ids.front() == 0,
+                   "VirtualPKChunkedColumn has only 1 chunk");
+        std::vector<PinWrapper<Chunk*>> chunks;
+        chunks.emplace_back(GetChunk(op_ctx, 0));
+        return chunks;
     }
 
     std::vector<PinWrapper<Chunk*>>
     GetAllChunks(milvus::OpContext* op_ctx) const override {
-        ThrowInfo(ErrorCode::Unsupported,
-                  "GetAllChunks not supported for VirtualPKChunkedColumn");
+        std::vector<PinWrapper<Chunk*>> chunks;
+        chunks.emplace_back(GetChunk(op_ctx, 0));
+        return chunks;
     }
 
     int64_t
@@ -298,6 +314,14 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
             for (int64_t i = 0; i < num_rows_; i++) {
                 materialized_pks_[i] = ComputeVirtualPK(i);
             }
+            materialized_chunk_ = std::make_shared<FixedWidthChunk>(
+                num_rows_,
+                1,
+                reinterpret_cast<char*>(materialized_pks_.data()),
+                materialized_pks_.size() * sizeof(int64_t),
+                sizeof(int64_t),
+                /*nullable=*/false,
+                nullptr);
         });
     }
 
@@ -308,6 +332,7 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
     std::vector<int64_t> num_rows_until_chunk_;
     mutable std::once_flag materialize_once_;
     mutable std::vector<int64_t> materialized_pks_;
+    mutable std::shared_ptr<FixedWidthChunk> materialized_chunk_;
 };
 
 }  // namespace milvus

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3582,6 +3582,16 @@ ChunkedSegmentSealedImpl::GetSkipIndexSnapshot() const {
     return runtime->skip_index;
 }
 
+std::pair<std::shared_ptr<ChunkedColumnInterface>,
+          std::shared_ptr<const SkipIndex>>
+ChunkedSegmentSealedImpl::GetDataScanResources(FieldId field_id) const {
+    auto runtime = CaptureRuntimeResourceState();
+    if (runtime == nullptr) {
+        return {nullptr, nullptr};
+    }
+    return {get_column(runtime, field_id), runtime->skip_index};
+}
+
 int64_t
 ChunkedSegmentSealedImpl::get_deleted_count() const {
     std::shared_lock lck(mutex_);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1193,6 +1193,15 @@ class ChunkedSegmentSealedImpl::SealedReadSnapshot
         return state_->runtime->row_count;
     }
 
+    std::pair<std::shared_ptr<ChunkedColumnInterface>,
+              std::shared_ptr<const SkipIndex>>
+    GetDataScanResources(FieldId field_id) const override {
+        auto it = state_->runtime->fields.find(field_id);
+        auto column =
+            it == state_->runtime->fields.end() ? nullptr : it->second;
+        return {std::move(column), state_->runtime->skip_index};
+    }
+
  private:
     bool
     FieldDataReady(FieldId field_id) const {
@@ -3780,6 +3789,16 @@ ChunkedSegmentSealedImpl::GetSkipIndexSnapshot() const {
         return std::make_shared<const SkipIndex>();
     }
     return runtime->skip_index;
+}
+
+std::pair<std::shared_ptr<ChunkedColumnInterface>,
+          std::shared_ptr<const SkipIndex>>
+ChunkedSegmentSealedImpl::GetDataScanResources(FieldId field_id) const {
+    auto runtime = CaptureRuntimeResourceState();
+    if (runtime == nullptr) {
+        return {nullptr, nullptr};
+    }
+    return {get_column(runtime, field_id), runtime->skip_index};
 }
 
 int64_t
@@ -7204,6 +7223,10 @@ ChunkedSegmentSealedImpl::load_field_data_common(
             const std::shared_ptr<ChunkedColumnInterface>& old_column,
             const PublishedSegmentState& state_snapshot) {
             prepare_array_offsets(target_runtime);
+
+            if (is_replace && target_runtime.skip_index != nullptr) {
+                target_runtime.skip_index->Erase(field_id);
+            }
 
             if (IsVariableDataType(data_type)) {
                 if (enable_mmap) {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -609,6 +609,15 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                  int64_t count,
                                  TargetBitmapView valid_result) const override;
 
+    std::shared_ptr<ChunkedColumnInterface>
+    GetChunkedColumn(FieldId field_id) const override {
+        return get_column(field_id);
+    }
+
+    std::pair<std::shared_ptr<ChunkedColumnInterface>,
+              std::shared_ptr<const SkipIndex>>
+    GetDataScanResources(FieldId field_id) const override;
+
  protected:
     // blob and row_count
     PinWrapper<SpanBase>

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -621,6 +621,15 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                  int64_t count,
                                  TargetBitmapView valid_result) const override;
 
+    std::shared_ptr<ChunkedColumnInterface>
+    GetChunkedColumn(FieldId field_id) const override {
+        return get_column(field_id);
+    }
+
+    std::pair<std::shared_ptr<ChunkedColumnInterface>,
+              std::shared_ptr<const SkipIndex>>
+    GetDataScanResources(FieldId field_id) const override;
+
  protected:
     // blob and row_count
     PinWrapper<SpanBase>
@@ -2461,6 +2470,33 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<const PublishedSegmentState>& current,
         StateDelta& final_delta,
         Verifier&& verifier) {
+        TestStageLoadFieldDataThenPublish(field_id,
+                                          column,
+                                          num_rows,
+                                          data_type,
+                                          schema_snapshot,
+                                          std::move(runtime),
+                                          staged_state,
+                                          current,
+                                          final_delta,
+                                          /*is_proxy_column=*/false,
+                                          std::forward<Verifier>(verifier));
+    }
+
+    template <typename Verifier>
+    void
+    TestStageLoadFieldDataThenPublish(
+        FieldId field_id,
+        const std::shared_ptr<ChunkedColumnInterface>& column,
+        size_t num_rows,
+        DataType data_type,
+        const SchemaPtr& schema_snapshot,
+        std::shared_ptr<RuntimeResourceState> runtime,
+        PublishedSegmentState* staged_state,
+        const std::shared_ptr<const PublishedSegmentState>& current,
+        StateDelta& final_delta,
+        bool is_proxy_column,
+        Verifier&& verifier) {
         std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
         StagedStateCommitter committer(*this, runtime.get(), staged_state);
         load_field_data_common(field_id,
@@ -2468,7 +2504,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                num_rows,
                                data_type,
                                /*enable_mmap=*/false,
-                               /*is_proxy_column=*/false,
+                               is_proxy_column,
                                *current->load_info,
                                schema_snapshot,
                                runtime.get(),

--- a/internal/core/src/segcore/SegcoreConfig.h
+++ b/internal/core/src/segcore/SegcoreConfig.h
@@ -290,6 +290,16 @@ class SegcoreConfig {
         return enable_gis_split_fusion_;
     }
 
+    void
+    set_scan_cursor_owns_pin(bool value) {
+        scan_cursor_owns_pin_ = value;
+    }
+
+    bool
+    get_scan_cursor_owns_pin() const {
+        return scan_cursor_owns_pin_;
+    }
+
  private:
     inline static const std::unordered_set<std::string>
         valid_dense_vector_index_type = {
@@ -316,6 +326,7 @@ class SegcoreConfig {
     inline static bool refine_with_quant_flag_ = false;
     inline static bool enable_geometry_cache_ = false;
     inline static bool enable_gis_split_fusion_ = false;
+    inline static bool scan_cursor_owns_pin_ = false;
     inline static bool prefer_field_data_when_index_has_raw_data_ = false;
     inline static bool reject_remote_vector_output_ = false;
     inline static std::atomic<int64_t> take_for_output_result_count_limit_{

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -388,6 +388,17 @@ class SegmentInternalInterface : public SegmentInterface {
                                  int64_t count,
                                  TargetBitmapView valid_result) const = 0;
 
+    virtual std::shared_ptr<ChunkedColumnInterface>
+    GetChunkedColumn(FieldId field_id) const {
+        return nullptr;
+    }
+
+    virtual std::pair<std::shared_ptr<ChunkedColumnInterface>,
+                      std::shared_ptr<const SkipIndex>>
+    GetDataScanResources(FieldId field_id) const {
+        return {GetChunkedColumn(field_id), GetSkipIndex()};
+    }
+
     template <typename T>
     PinWrapper<Span<T>>
     chunk_data(milvus::OpContext* op_ctx,

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -117,6 +117,10 @@ class SegmentReadSnapshot {
 
     virtual int64_t
     get_row_count() const = 0;
+
+    virtual std::pair<std::shared_ptr<ChunkedColumnInterface>,
+                      std::shared_ptr<const SkipIndex>>
+    GetDataScanResources(FieldId field_id) const = 0;
 };
 
 // common interface of SegmentSealed and SegmentGrowing used by C API
@@ -450,6 +454,17 @@ class SegmentInternalInterface : public SegmentInterface {
                                  const int64_t* offsets,
                                  int64_t count,
                                  TargetBitmapView valid_result) const = 0;
+
+    virtual std::shared_ptr<ChunkedColumnInterface>
+    GetChunkedColumn(FieldId field_id) const {
+        return nullptr;
+    }
+
+    virtual std::pair<std::shared_ptr<ChunkedColumnInterface>,
+                      std::shared_ptr<const SkipIndex>>
+    GetDataScanResources(FieldId field_id) const {
+        return {GetChunkedColumn(field_id), GetSkipIndex()};
+    }
 
     template <typename T>
     PinWrapper<Span<T>>

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -104,6 +104,13 @@ SegcoreSetEnableGISSplitFusion(const bool value) {
 }
 
 extern "C" void
+SegcoreSetScanCursorOwnsPin(const bool value) {
+    milvus::segcore::SegcoreConfig& config =
+        milvus::segcore::SegcoreConfig::default_config();
+    config.set_scan_cursor_owns_pin(value);
+}
+
+extern "C" void
 SegcoreSetVisibilityFilterEnabled(const bool value) {
     // Deprecated compatibility shim: row visibility filtering is always
     // enforced and this value is ignored. The symbol survives so callers

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -45,6 +45,9 @@ void
 SegcoreSetEnableGISSplitFusion(const bool);
 
 void
+SegcoreSetScanCursorOwnsPin(const bool);
+
+void
 SegcoreSetNlist(const int64_t);
 
 // FM-index count-first guard threshold (queryNode.fmindexCostRatio).

--- a/internal/core/unittest/test_bloom_filter_expr.cpp
+++ b/internal/core/unittest/test_bloom_filter_expr.cpp
@@ -1467,6 +1467,58 @@ TEST_F(BloomFilterExprEvalTest,
 }
 
 TEST_F(BloomFilterExprEvalTest,
+       UnaryRangeBitmapInputLeavesExcludedNullCandidatesUntouched) {
+    std::vector<size_t> null_rows;
+    std::vector<size_t> valid_rows;
+    for (size_t i = 0; i < N; ++i) {
+        (i64_valid_[i] ? valid_rows : null_rows).push_back(i);
+    }
+    ASSERT_GE(null_rows.size(), 2u);
+    ASSERT_GE(valid_rows.size(), 2u);
+
+    OffsetVector offsets{
+        static_cast<int32_t>(null_rows[0]),
+        static_cast<int32_t>(valid_rows[0]),
+        static_cast<int32_t>(null_rows[1]),
+        static_cast<int32_t>(valid_rows[1]),
+    };
+    TargetBitmap candidate_mask(offsets.size(), false);
+    candidate_mask.set(1);
+    candidate_mask.set(2);
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(i64_col_[valid_rows[0]]);
+    expr::TypedExprPtr logical = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(i64_fid_, DataType::INT64, {}, true),
+        proto::plan::OpType::Equal,
+        value);
+
+    auto growing = BuildGrowing();
+    auto sealed = BuildSealed();
+    for (const SegmentInternalInterface* segment :
+         {static_cast<const SegmentInternalInterface*>(growing.get()),
+          static_cast<const SegmentInternalInterface*>(sealed.get())}) {
+        auto result =
+            EvalPhysical(segment, logical, candidate_mask.clone(), &offsets);
+        ASSERT_NE(result, nullptr);
+        BitsetTypeView bits(result->GetRawData(), result->size());
+        BitsetTypeView valid(result->GetValidRawData(), result->size());
+        ASSERT_EQ(result->size(), offsets.size());
+
+        EXPECT_FALSE(bits[0]);
+        EXPECT_TRUE(valid[0])
+            << "an excluded NULL candidate must remain untouched";
+        EXPECT_TRUE(bits[1]);
+        EXPECT_TRUE(valid[1]);
+        EXPECT_FALSE(bits[2]);
+        EXPECT_FALSE(valid[2]) << "an active NULL candidate is invalid";
+        EXPECT_FALSE(bits[3]);
+        EXPECT_TRUE(valid[3])
+            << "an excluded valid candidate must remain untouched";
+    }
+}
+
+TEST_F(BloomFilterExprEvalTest,
        JsonBitmapInputLeavesExcludedNullCandidatesUntouched) {
     std::vector<std::string> rows(N, R"({"uid": 5})");
     FixedVector<bool> validity(N, true);

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -43,6 +43,32 @@ using namespace milvus::segcore;
 
 namespace {
 
+class InspectableSegmentExpr : public SegmentExpr {
+ public:
+    using SegmentExpr::IsDenseOffsetInputForScan;
+    using SegmentExpr::SegmentExpr;
+
+    bool
+    DataScanInitialized() const {
+        return data_scan_initialized_;
+    }
+
+    const ChunkedColumnInterface::ScanCursor*
+    DataScanCursor() const {
+        return data_scan_cursor_.get();
+    }
+
+    int64_t
+    DataScanBatchPosition() const {
+        return data_scan_batch_pos_;
+    }
+
+    int64_t
+    CurrentDataChunkPosition() const {
+        return current_data_chunk_pos_;
+    }
+};
+
 std::unique_ptr<SegmentSealed>
 CreateTwoChunkSealed(const SchemaPtr& schema,
                      const GeneratedData& first,
@@ -138,7 +164,8 @@ template <typename T>
 void
 VerifySkipCursorContract(SegmentExpr& segment_expr,
                          OffsetVector* input,
-                         int skipped_chunk_id) {
+                         int skipped_chunk_id,
+                         bool use_sorted_scan = false) {
     TargetBitmap bitmap_input(input->size(), false);
     for (size_t i = input->size() / 2; i < input->size(); ++i) {
         bitmap_input[i] = true;
@@ -174,11 +201,18 @@ VerifySkipCursorContract(SegmentExpr& segment_expr,
     TargetBitmap res(input->size(), false);
     TargetBitmap valid(input->size(), true);
     const auto processed =
-        segment_expr.ProcessDataByOffsets<T>(evaluate_batch,
-                                             skip_chunk,
-                                             input,
-                                             TargetBitmapView(res),
-                                             TargetBitmapView(valid));
+        use_sorted_scan
+            ? segment_expr.ProcessSortedDataByOffsetsByScan<T>(
+                  evaluate_batch,
+                  skip_chunk,
+                  input,
+                  TargetBitmapView(res),
+                  TargetBitmapView(valid))
+            : segment_expr.ProcessDataByOffsets<T>(evaluate_batch,
+                                                   skip_chunk,
+                                                   input,
+                                                   TargetBitmapView(res),
+                                                   TargetBitmapView(valid));
 
     EXPECT_EQ(processed, int64_t(input->size()));
     EXPECT_EQ(processed_cursor, int64_t(input->size()));
@@ -602,10 +636,10 @@ TEST_F(OffsetsEvalCorrectnessTest,
     }
 }
 
-// Sealed raw data is chunked by binlog. Cover the fixed-width branch with
-// candidates from a skipped first binlog followed by a probed second binlog.
+// Pin the dense sorted scan path directly: candidates from the skipped first
+// binlog must still advance the callback cursor before the second binlog.
 TEST_F(OffsetsEvalCorrectnessTest,
-       SealedScalarSkipBranchKeepsBitmapCursorAligned) {
+       SealedDenseOffsetScanSkipKeepsBitmapCursorAligned) {
     auto query_context = std::make_shared<QueryContext>(
         DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
     auto seg_expr = MakeDirectSegmentExpr(
@@ -615,7 +649,135 @@ TEST_F(OffsetsEvalCorrectnessTest,
         offsets.emplace_back(offset);
     }
 
-    VerifySkipCursorContract<int64_t>(*seg_expr, &offsets, 0);
+    VerifySkipCursorContract<int64_t>(
+        *seg_expr, &offsets, 0, /*use_sorted_scan=*/true);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanPreservesPartiallyConsumedBatch) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "scan cursor probe",
+                                    query_context->get_op_context(),
+                                    sealed_.get(),
+                                    i64_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/4,
+                                    query_context->get_consistency_level());
+    auto evaluate_batch =
+        []<FilterType filter_type = FilterType::sequential>(const int64_t*,
+                                                            const bool*,
+                                                            const int32_t*,
+                                                            int,
+                                                            TargetBitmapView,
+                                                            TargetBitmapView){};
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+    TargetBitmap first_res(4, false);
+    TargetBitmap first_valid(4, true);
+    EXPECT_EQ(
+        seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                            no_skip,
+                                            TargetBitmapView(first_res),
+                                            TargetBitmapView(first_valid)),
+        4);
+    ASSERT_TRUE(seg_expr.DataScanInitialized());
+    const auto* cursor = seg_expr.DataScanCursor();
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_EQ(seg_expr.DataScanBatchPosition(), 4);
+
+    TargetBitmap second_res(4, false);
+    TargetBitmap second_valid(4, true);
+    EXPECT_EQ(
+        seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                            no_skip,
+                                            TargetBitmapView(second_res),
+                                            TargetBitmapView(second_valid)),
+        4);
+    EXPECT_EQ(seg_expr.DataScanCursor(), cursor);
+    EXPECT_EQ(seg_expr.DataScanBatchPosition(), 8);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanKeepsColumnAliveAcrossFieldDrop) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    std::weak_ptr<ChunkedColumnInterface> weak_column;
+
+    {
+        auto column = sealed_->GetChunkedColumn(i64_fid_);
+        ASSERT_NE(column, nullptr);
+        weak_column = column;
+        column.reset();
+
+        InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                        "scan column lifetime probe",
+                                        query_context->get_op_context(),
+                                        sealed_.get(),
+                                        i64_fid_,
+                                        std::vector<std::string>{},
+                                        DataType::INT64,
+                                        N,
+                                        /*batch_size=*/4,
+                                        query_context->get_consistency_level());
+        int64_t rows_seen = 0;
+        auto evaluate_batch =
+            [&rows_seen]<FilterType filter_type = FilterType::sequential>(
+                const int64_t* data,
+                const bool*,
+                const int32_t*,
+                int size,
+                TargetBitmapView,
+                TargetBitmapView) {
+            ASSERT_NE(data, nullptr);
+            rows_seen += size;
+        };
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+        TargetBitmap first_res(4, false);
+        TargetBitmap first_valid(4, true);
+        EXPECT_EQ(
+            seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                no_skip,
+                                                TargetBitmapView(first_res),
+                                                TargetBitmapView(first_valid)),
+            4);
+
+        sealed_->DropFieldData(i64_fid_);
+        ASSERT_FALSE(sealed_->HasFieldData(i64_fid_));
+        ASSERT_FALSE(weak_column.expired())
+            << "the active scan cursor must retain its source column";
+
+        TargetBitmap second_res(4, false);
+        TargetBitmap second_valid(4, true);
+        EXPECT_EQ(
+            seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                no_skip,
+                                                TargetBitmapView(second_res),
+                                                TargetBitmapView(second_valid)),
+            4);
+        EXPECT_EQ(rows_seen, 8);
+    }
+
+    EXPECT_TRUE(weak_column.expired());
+}
+
+TEST(OffsetScanDensityTest, RejectsBatchSizedSparseRange) {
+    OffsetVector sparse_offsets;
+    sparse_offsets.emplace_back(0);
+    sparse_offsets.emplace_back(8191);
+    EXPECT_FALSE(
+        InspectableSegmentExpr::IsDenseOffsetInputForScan(&sparse_offsets));
+
+    OffsetVector dense_offsets;
+    for (int32_t offset = 0; offset < 8; ++offset) {
+        dense_offsets.emplace_back(offset);
+    }
+    EXPECT_TRUE(
+        InspectableSegmentExpr::IsDenseOffsetInputForScan(&dense_offsets));
 }
 
 // Exercise the production expression stack used by iterative filtering:
@@ -760,6 +922,57 @@ TEST_F(OffsetsEvalCorrectnessTest,
     }
 
     VerifySkipCursorContract<VectorArrayView>(*seg_expr, &offsets, 0);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialVectorArrayScanKeepsCursorAlignedAcrossSkippedBatch) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "vector array scan cursor probe",
+                                    query_context->get_op_context(),
+                                    sealed_.get(),
+                                    vector_array_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::VECTOR_ARRAY,
+                                    N,
+                                    /*batch_size=*/4,
+                                    query_context->get_consistency_level());
+    auto evaluate_batch = []<FilterType filter_type = FilterType::sequential>(
+        const VectorArrayView*,
+        const bool*,
+        const int32_t*,
+        int,
+        TargetBitmapView,
+        TargetBitmapView){};
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+    auto process_batch = [&]() {
+        TargetBitmap res(4, false);
+        TargetBitmap valid(4, true);
+        EXPECT_EQ(seg_expr.ProcessDataChunks<VectorArrayView>(
+                      evaluate_batch,
+                      no_skip,
+                      TargetBitmapView(res),
+                      TargetBitmapView(valid)),
+                  4);
+    };
+
+    process_batch();
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 4);
+
+    ASSERT_NE(seg_expr.DataScanCursor(), nullptr);
+
+    // Simulate a conjunction short-circuit: skip the second expression batch
+    // and reset the active scan without evaluating it.
+    seg_expr.MoveCursor();
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 8);
+    EXPECT_EQ(seg_expr.DataScanCursor(), nullptr);
+
+    // Recreate the VECTOR_ARRAY scan at the post-skip global position.
+    process_batch();
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 12);
+    EXPECT_NE(seg_expr.DataScanCursor(), nullptr);
 }
 
 TEST_F(OffsetsEvalCorrectnessTest,

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -50,7 +50,7 @@ class InspectableSegmentExpr : public SegmentExpr {
 
     bool
     DataScanInitialized() const {
-        return data_scan_initialized_;
+        return data_access_mode_ != DataAccessMode::Uninitialized;
     }
 
     const ChunkedColumnInterface::ScanCursor*
@@ -59,13 +59,18 @@ class InspectableSegmentExpr : public SegmentExpr {
     }
 
     int64_t
-    DataScanBatchPosition() const {
-        return data_scan_batch_pos_;
+    CurrentDataChunkPosition() const {
+        return current_data_chunk_pos_;
     }
 
     int64_t
-    CurrentDataChunkPosition() const {
-        return current_data_chunk_pos_;
+    CurrentExecutionPosition() const {
+        return current_data_global_pos_;
+    }
+
+    int64_t
+    NextBatchSize() {
+        return GetNextBatchSize();
     }
 };
 
@@ -653,8 +658,7 @@ TEST_F(OffsetsEvalCorrectnessTest,
         *seg_expr, &offsets, 0, /*use_sorted_scan=*/true);
 }
 
-TEST_F(OffsetsEvalCorrectnessTest,
-       SequentialScanPreservesPartiallyConsumedBatch) {
+TEST_F(OffsetsEvalCorrectnessTest, SequentialScanCursorOwnsItsLogicalPosition) {
     auto query_context = std::make_shared<QueryContext>(
         DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
     InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
@@ -687,7 +691,9 @@ TEST_F(OffsetsEvalCorrectnessTest,
     ASSERT_TRUE(seg_expr.DataScanInitialized());
     const auto* cursor = seg_expr.DataScanCursor();
     ASSERT_NE(cursor, nullptr);
-    EXPECT_EQ(seg_expr.DataScanBatchPosition(), 4);
+    EXPECT_EQ(cursor->Position(), 4);
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 4);
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
 
     TargetBitmap second_res(4, false);
     TargetBitmap second_valid(4, true);
@@ -698,7 +704,171 @@ TEST_F(OffsetsEvalCorrectnessTest,
                                             TargetBitmapView(second_valid)),
         4);
     EXPECT_EQ(seg_expr.DataScanCursor(), cursor);
-    EXPECT_EQ(seg_expr.DataScanBatchPosition(), 8);
+    EXPECT_EQ(cursor->Position(), 8);
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanExecutionBatchCrossesColumnChunks) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "cross-chunk scan cursor probe",
+                                    query_context->get_op_context(),
+                                    sealed_.get(),
+                                    i64_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/20,
+                                    query_context->get_consistency_level());
+    std::vector<int64_t> callback_sizes;
+    auto evaluate_batch =
+        [&callback_sizes]<FilterType filter_type = FilterType::sequential>(
+            const int64_t* data,
+            const bool*,
+            const int32_t*,
+            int size,
+            TargetBitmapView,
+            TargetBitmapView) {
+        ASSERT_NE(data, nullptr);
+        callback_sizes.push_back(size);
+    };
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+    TargetBitmap res(20, false);
+    TargetBitmap valid(20, true);
+    EXPECT_EQ(seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                  no_skip,
+                                                  TargetBitmapView(res),
+                                                  TargetBitmapView(valid)),
+              20);
+    EXPECT_EQ(callback_sizes, (std::vector<int64_t>{16, 4}));
+    ASSERT_NE(seg_expr.DataScanCursor(), nullptr);
+    EXPECT_EQ(seg_expr.DataScanCursor()->Position(), 20);
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 20);
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanUsesGlobalPositionBeforeBackendSelection) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "pre-bind scan position probe",
+                                    query_context->get_op_context(),
+                                    sealed_.get(),
+                                    i64_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/20,
+                                    query_context->get_consistency_level());
+
+    // Skip the first execution batch before Scan has selected or retained a
+    // column generation. The old generation has chunk sizes [16, 16], so its
+    // cached chunk coordinate for row 20 would be (1, 4).
+    ASSERT_FALSE(seg_expr.DataScanInitialized());
+    seg_expr.MoveCursor();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 20);
+    ASSERT_FALSE(seg_expr.DataScanInitialized());
+
+    // Publish the same logical rows with different chunk geometry. Reusing the
+    // old (1, 4) coordinate against [24, 8] would incorrectly report row 28 as
+    // the execution position. Batch sizing and the first Scan must instead use
+    // the segment-global row 20.
+    std::vector<FieldDataPtr> chunks;
+    int64_t next_value = 1000;
+    for (const int64_t rows : {24, 8}) {
+        auto field_data =
+            std::make_shared<FieldData<int64_t>>(DataType::INT64, false);
+        std::vector<int64_t> values(rows);
+        std::iota(values.begin(), values.end(), next_value);
+        next_value += rows;
+        field_data->FillFieldData(values.data(), rows);
+        chunks.push_back(std::move(field_data));
+    }
+    auto cm = storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(kCollectionID,
+                                                    kPartitionID,
+                                                    kSegmentID,
+                                                    i64_fid_.get(),
+                                                    std::move(chunks),
+                                                    cm);
+    sealed_->DropFieldData(i64_fid_);
+    const auto status = LoadFieldData(sealed_.get(), &load_info);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(sealed_->chunk_size(i64_fid_, 0), 24);
+    ASSERT_EQ(sealed_->chunk_size(i64_fid_, 1), 8);
+
+    ASSERT_EQ(seg_expr.NextBatchSize(), 12);
+    std::vector<int64_t> values_seen;
+    auto evaluate_batch =
+        [&values_seen]<FilterType filter_type = FilterType::sequential>(
+            const int64_t* data,
+            const bool*,
+            const int32_t*,
+            int size,
+            TargetBitmapView,
+            TargetBitmapView) {
+        ASSERT_NE(data, nullptr);
+        values_seen.insert(values_seen.end(), data, data + size);
+    };
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+    TargetBitmap res(12, false);
+    TargetBitmap valid(12, true);
+    EXPECT_EQ(seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                  no_skip,
+                                                  TargetBitmapView(res),
+                                                  TargetBitmapView(valid)),
+              12);
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), N);
+    std::vector<int64_t> expected(12);
+    std::iota(expected.begin(), expected.end(), 1020);
+    EXPECT_EQ(values_seen, expected);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       GrowingChunkCacheRebasesFromGlobalPositionAfterShortCircuit) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, growing_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "growing chunk position probe",
+                                    query_context->get_op_context(),
+                                    growing_.get(),
+                                    i64_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/4,
+                                    query_context->get_consistency_level());
+    auto evaluate_batch =
+        []<FilterType filter_type = FilterType::sequential>(const int64_t*,
+                                                            const bool*,
+                                                            const int32_t*,
+                                                            int,
+                                                            TargetBitmapView,
+                                                            TargetBitmapView){};
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+    auto process_batch = [&]() {
+        TargetBitmap res(4, false);
+        TargetBitmap valid(4, true);
+        EXPECT_EQ(seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                      no_skip,
+                                                      TargetBitmapView(res),
+                                                      TargetBitmapView(valid)),
+                  4);
+    };
+
+    process_batch();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 4);
+    seg_expr.MoveCursor();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
+    process_batch();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 12);
 }
 
 TEST_F(OffsetsEvalCorrectnessTest,
@@ -750,6 +920,13 @@ TEST_F(OffsetsEvalCorrectnessTest,
         ASSERT_FALSE(sealed_->HasFieldData(i64_fid_));
         ASSERT_FALSE(weak_column.expired())
             << "the active scan cursor must retain its source column";
+
+        // Skip one execution batch after the live segment drops the field.
+        // Reopening must use the retained column generation instead of asking
+        // the segment for its now-missing field again.
+        seg_expr.MoveCursor();
+        EXPECT_EQ(seg_expr.DataScanCursor(), nullptr);
+        EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
 
         TargetBitmap second_res(4, false);
         TargetBitmap second_valid(4, true);
@@ -959,19 +1136,29 @@ TEST_F(OffsetsEvalCorrectnessTest,
     };
 
     process_batch();
-    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 4);
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 4);
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
 
     ASSERT_NE(seg_expr.DataScanCursor(), nullptr);
 
     // Simulate a conjunction short-circuit: skip the second expression batch
     // and reset the active scan without evaluating it.
     seg_expr.MoveCursor();
-    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 8);
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
+    EXPECT_EQ(seg_expr.DataScanCursor(), nullptr);
+
+    // A second consecutive short-circuit must advance only the execution
+    // position. There is no cursor generation or chunk geometry to reuse.
+    seg_expr.MoveCursor();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 12);
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
     EXPECT_EQ(seg_expr.DataScanCursor(), nullptr);
 
     // Recreate the VECTOR_ARRAY scan at the post-skip global position.
     process_batch();
-    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 12);
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 16);
+    EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
     EXPECT_NE(seg_expr.DataScanCursor(), nullptr);
 }
 

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -45,7 +45,6 @@ namespace {
 
 class InspectableSegmentExpr : public SegmentExpr {
  public:
-    using SegmentExpr::IsDenseOffsetInputForScan;
     using SegmentExpr::SegmentExpr;
 
     bool
@@ -174,8 +173,7 @@ template <typename T>
 void
 VerifySkipCursorContract(SegmentExpr& segment_expr,
                          OffsetVector* input,
-                         int skipped_chunk_id,
-                         bool use_sorted_scan = false) {
+                         int skipped_chunk_id) {
     TargetBitmap bitmap_input(input->size(), false);
     for (size_t i = input->size() / 2; i < input->size(); ++i) {
         bitmap_input[i] = true;
@@ -211,18 +209,11 @@ VerifySkipCursorContract(SegmentExpr& segment_expr,
     TargetBitmap res(input->size(), false);
     TargetBitmap valid(input->size(), true);
     const auto processed =
-        use_sorted_scan
-            ? segment_expr.ProcessSortedDataByOffsetsByScan<T>(
-                  evaluate_batch,
-                  skip_chunk,
-                  input,
-                  TargetBitmapView(res),
-                  TargetBitmapView(valid))
-            : segment_expr.ProcessDataByOffsets<T>(evaluate_batch,
-                                                   skip_chunk,
-                                                   input,
-                                                   TargetBitmapView(res),
-                                                   TargetBitmapView(valid));
+        segment_expr.ProcessDataByOffsets<T>(evaluate_batch,
+                                             skip_chunk,
+                                             input,
+                                             TargetBitmapView(res),
+                                             TargetBitmapView(valid));
 
     EXPECT_EQ(processed, int64_t(input->size()));
     EXPECT_EQ(processed_cursor, int64_t(input->size()));
@@ -646,10 +637,8 @@ TEST_F(OffsetsEvalCorrectnessTest,
     }
 }
 
-// Pin the dense sorted scan path directly: candidates from the skipped first
-// binlog must still advance the callback cursor before the second binlog.
 TEST_F(OffsetsEvalCorrectnessTest,
-       SealedDenseOffsetScanSkipKeepsBitmapCursorAligned) {
+       SealedOffsetTakeSkipKeepsBitmapCursorAligned) {
     auto query_context = std::make_shared<QueryContext>(
         DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
     auto seg_expr = MakeDirectSegmentExpr(
@@ -659,8 +648,7 @@ TEST_F(OffsetsEvalCorrectnessTest,
         offsets.emplace_back(offset);
     }
 
-    VerifySkipCursorContract<int64_t>(
-        *seg_expr, &offsets, 0, /*use_sorted_scan=*/true);
+    VerifySkipCursorContract<int64_t>(*seg_expr, &offsets, 0);
 }
 
 TEST_F(OffsetsEvalCorrectnessTest, SequentialScanCursorOwnsItsLogicalPosition) {
@@ -947,21 +935,6 @@ TEST_F(OffsetsEvalCorrectnessTest,
     }
 
     EXPECT_TRUE(weak_column.expired());
-}
-
-TEST(OffsetScanDensityTest, RejectsBatchSizedSparseRange) {
-    OffsetVector sparse_offsets;
-    sparse_offsets.emplace_back(0);
-    sparse_offsets.emplace_back(8191);
-    EXPECT_FALSE(
-        InspectableSegmentExpr::IsDenseOffsetInputForScan(&sparse_offsets));
-
-    OffsetVector dense_offsets;
-    for (int32_t offset = 0; offset < 8; ++offset) {
-        dense_offsets.emplace_back(offset);
-    }
-    EXPECT_TRUE(
-        InspectableSegmentExpr::IsDenseOffsetInputForScan(&dense_offsets));
 }
 
 // Exercise the production expression stack used by iterative filtering:

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -58,6 +58,11 @@ class InspectableSegmentExpr : public SegmentExpr {
         return data_scan_cursor_.get();
     }
 
+    bool
+    HasPreparedDataScan() const {
+        return data_prepared_scan_ != nullptr;
+    }
+
     int64_t
     CurrentDataChunkPosition() const {
         return current_data_chunk_pos_;
@@ -915,6 +920,7 @@ TEST_F(OffsetsEvalCorrectnessTest,
                                                 TargetBitmapView(first_res),
                                                 TargetBitmapView(first_valid)),
             4);
+        EXPECT_TRUE(seg_expr.HasPreparedDataScan());
 
         sealed_->DropFieldData(i64_fid_);
         ASSERT_FALSE(sealed_->HasFieldData(i64_fid_));
@@ -926,6 +932,7 @@ TEST_F(OffsetsEvalCorrectnessTest,
         // the segment for its now-missing field again.
         seg_expr.MoveCursor();
         EXPECT_EQ(seg_expr.DataScanCursor(), nullptr);
+        EXPECT_TRUE(seg_expr.HasPreparedDataScan());
         EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
 
         TargetBitmap second_res(4, false);

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -52,14 +52,9 @@ class InspectableSegmentExpr : public SegmentExpr {
         return data_access_mode_ != DataAccessMode::Uninitialized;
     }
 
-    const ChunkedColumnInterface::ScanCursor*
-    DataScanCursor() const {
-        return data_scan_cursor_.get();
-    }
-
     bool
-    HasPreparedDataScan() const {
-        return data_prepared_scan_ != nullptr;
+    HasRetainedDataScanColumn() const {
+        return data_scan_column_ != nullptr;
     }
 
     int64_t
@@ -651,7 +646,8 @@ TEST_F(OffsetsEvalCorrectnessTest,
     VerifySkipCursorContract<int64_t>(*seg_expr, &offsets, 0);
 }
 
-TEST_F(OffsetsEvalCorrectnessTest, SequentialScanCursorOwnsItsLogicalPosition) {
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanAdvancesByWindowWithoutRetainingCursor) {
     auto query_context = std::make_shared<QueryContext>(
         DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
     InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
@@ -682,9 +678,7 @@ TEST_F(OffsetsEvalCorrectnessTest, SequentialScanCursorOwnsItsLogicalPosition) {
                                             TargetBitmapView(first_valid)),
         4);
     ASSERT_TRUE(seg_expr.DataScanInitialized());
-    const auto* cursor = seg_expr.DataScanCursor();
-    ASSERT_NE(cursor, nullptr);
-    EXPECT_EQ(cursor->Position(), 4);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
     EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 4);
     EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
 
@@ -696,8 +690,7 @@ TEST_F(OffsetsEvalCorrectnessTest, SequentialScanCursorOwnsItsLogicalPosition) {
                                             TargetBitmapView(second_res),
                                             TargetBitmapView(second_valid)),
         4);
-    EXPECT_EQ(seg_expr.DataScanCursor(), cursor);
-    EXPECT_EQ(cursor->Position(), 8);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
     EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
     EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
 }
@@ -738,8 +731,7 @@ TEST_F(OffsetsEvalCorrectnessTest,
                                                   TargetBitmapView(valid)),
               20);
     EXPECT_EQ(callback_sizes, (std::vector<int64_t>{16, 4}));
-    ASSERT_NE(seg_expr.DataScanCursor(), nullptr);
-    EXPECT_EQ(seg_expr.DataScanCursor()->Position(), 20);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
     EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 20);
     EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
 }
@@ -908,19 +900,18 @@ TEST_F(OffsetsEvalCorrectnessTest,
                                                 TargetBitmapView(first_res),
                                                 TargetBitmapView(first_valid)),
             4);
-        EXPECT_TRUE(seg_expr.HasPreparedDataScan());
+        EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
 
         sealed_->DropFieldData(i64_fid_);
         ASSERT_FALSE(sealed_->HasFieldData(i64_fid_));
         ASSERT_FALSE(weak_column.expired())
-            << "the active scan cursor must retain its source column";
+            << "the expression must retain its selected source column";
 
         // Skip one execution batch after the live segment drops the field.
-        // Reopening must use the retained column generation instead of asking
-        // the segment for its now-missing field again.
+        // The next window must prepare from the retained column generation
+        // instead of asking the segment for its now-missing field again.
         seg_expr.MoveCursor();
-        EXPECT_EQ(seg_expr.DataScanCursor(), nullptr);
-        EXPECT_TRUE(seg_expr.HasPreparedDataScan());
+        EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
         EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
 
         TargetBitmap second_res(4, false);
@@ -1118,28 +1109,27 @@ TEST_F(OffsetsEvalCorrectnessTest,
     process_batch();
     EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 4);
     EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
-
-    ASSERT_NE(seg_expr.DataScanCursor(), nullptr);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
 
     // Simulate a conjunction short-circuit: skip the second expression batch
-    // and reset the active scan without evaluating it.
+    // without preparing scan resources for that window.
     seg_expr.MoveCursor();
     EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
     EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
-    EXPECT_EQ(seg_expr.DataScanCursor(), nullptr);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
 
     // A second consecutive short-circuit must advance only the execution
-    // position. There is no cursor generation or chunk geometry to reuse.
+    // position. There is no cursor or prepared scan state to reuse.
     seg_expr.MoveCursor();
     EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 12);
     EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
-    EXPECT_EQ(seg_expr.DataScanCursor(), nullptr);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
 
     // Recreate the VECTOR_ARRAY scan at the post-skip global position.
     process_batch();
     EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 16);
     EXPECT_EQ(seg_expr.CurrentDataChunkPosition(), 0);
-    EXPECT_NE(seg_expr.DataScanCursor(), nullptr);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
 }
 
 TEST_F(OffsetsEvalCorrectnessTest,

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -43,6 +43,50 @@ using namespace milvus::segcore;
 
 namespace {
 
+class InspectableSegmentExpr : public SegmentExpr {
+ public:
+    using SegmentExpr::SegmentExpr;
+
+    bool
+    DataScanInitialized() const {
+        return data_access_mode_ != DataAccessMode::Uninitialized;
+    }
+
+    bool
+    HasRetainedDataScanColumn() const {
+        return data_scan_column_ != nullptr;
+    }
+
+    int64_t
+    CurrentExecutionPosition() const {
+        return current_data_global_pos_;
+    }
+
+    int64_t
+    NextBatchSize() {
+        return GetNextBatchSize();
+    }
+};
+
+class NoOpPrefetchSegmentExpr final : public InspectableSegmentExpr {
+ public:
+    using InspectableSegmentExpr::InspectableSegmentExpr;
+
+    int
+    PrefetchCalls() const {
+        return prefetch_calls_;
+    }
+
+ protected:
+    void
+    PrefetchRawData() override {
+        ++prefetch_calls_;
+    }
+
+ private:
+    int prefetch_calls_{0};
+};
+
 std::unique_ptr<SegmentSealed>
 CreateTwoChunkSealed(const SchemaPtr& schema,
                      const GeneratedData& first,
@@ -109,6 +153,27 @@ SetInt64FieldData(GeneratedData& dataset,
             field_data->mutable_scalars()->mutable_long_data()->mutable_data();
         data->Clear();
         data->Add(values.data(), values.data() + values.size());
+        return;
+    }
+    ThrowInfo(FieldIDInvalid, "field id {} not found", field_id.get());
+}
+
+void
+SetScalarFieldValidity(GeneratedData& dataset,
+                       FieldId field_id,
+                       const std::vector<bool>& validity) {
+    AssertInfo(dataset.raw_->num_rows() == validity.size(),
+               "validity size must match row count");
+    for (int i = 0; i < dataset.raw_->fields_data_size(); ++i) {
+        auto* field_data = dataset.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != field_id.get()) {
+            continue;
+        }
+        auto* valid_data = field_data->mutable_scalars()->mutable_valid_data();
+        valid_data->Clear();
+        for (const auto valid : validity) {
+            valid_data->Add(valid);
+        }
         return;
     }
     ThrowInfo(FieldIDInvalid, "field id {} not found", field_id.get());
@@ -537,6 +602,72 @@ TEST_F(OffsetsEvalCorrectnessTest, SkipBranchKeepsBitmapCursorAligned) {
     }
 }
 
+TEST_F(OffsetsEvalCorrectnessTest,
+       GrowingSkippedOffsetValidityHonorsCandidateMask) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto nullable_fid =
+        schema->AddDebugField("nullable_value", DataType::INT64, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto dataset = DataGen(schema, N, 47, 0, 1, 1);
+    std::vector<bool> validity(N, true);
+    validity[0] = false;
+    validity[1] = false;
+    SetScalarFieldValidity(dataset, nullable_fid, validity);
+
+    SegcoreConfig config = SegcoreConfig::default_config();
+    config.set_chunk_rows(kChunkRows);
+    auto segment = CreateGrowingSegment(schema, empty_index_meta, 1, config);
+    segment->PreInsert(N);
+    segment->Insert(0,
+                    N,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, segment.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        segment.get(), nullable_fid, DataType::INT64, *query_context);
+    OffsetVector offsets{0, 1, 8};
+    TargetBitmap candidate_mask(offsets.size(), false);
+    candidate_mask.set(1);
+    candidate_mask.set(2);
+
+    auto skip_chunk0 = [](const milvus::SkipIndex&,
+                          FieldId,
+                          int chunk_id) -> bool { return chunk_id == 0; };
+    int64_t processed_cursor = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t*,
+        ValidityView,
+        const int32_t*,
+        int size,
+        TargetBitmapView,
+        TargetBitmapView) {
+        processed_cursor += size;
+    };
+
+    TargetBitmap result(offsets.size(), false);
+    TargetBitmap valid(offsets.size(), true);
+    EXPECT_EQ(seg_expr->ProcessDataByOffsetsWithMask<int64_t>(
+                  evaluate_batch,
+                  skip_chunk0,
+                  &offsets,
+                  TargetBitmapView(result),
+                  TargetBitmapView(valid),
+                  candidate_mask),
+              static_cast<int64_t>(offsets.size()));
+    EXPECT_EQ(processed_cursor, static_cast<int64_t>(offsets.size()));
+    EXPECT_TRUE(valid[0])
+        << "an excluded NULL in a skipped Cell must remain untouched";
+    EXPECT_FALSE(valid[1]) << "an active NULL in a skipped Cell is invalid";
+    EXPECT_TRUE(valid[2]);
+}
+
 // Element-level filters use a separate offsets helper. It must invoke the
 // evaluator for skipped candidates too, or its bitmap cursor shifts exactly as
 // it did in the scalar offset path.
@@ -602,20 +733,546 @@ TEST_F(OffsetsEvalCorrectnessTest,
     }
 }
 
-// Sealed raw data is chunked by binlog. Cover the fixed-width branch with
-// candidates from a skipped first binlog followed by a probed second binlog.
 TEST_F(OffsetsEvalCorrectnessTest,
-       SealedScalarSkipBranchKeepsBitmapCursorAligned) {
+       SealedOffsetTakeAppliesLoadedPayloadSkipAfterPin) {
+    ASSERT_EQ(sealed_->GetSkipIndex()->GetMetricsSource(i64_fid_),
+              SkipIndex::MetricsSource::LoadedPayload);
     auto query_context = std::make_shared<QueryContext>(
         DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
     auto seg_expr = MakeDirectSegmentExpr(
         sealed_.get(), i64_fid_, DataType::INT64, *query_context);
-    OffsetVector offsets;
-    for (auto offset : std::vector<int32_t>{0, 1, 2, 3, 16, 17, 18, 19}) {
-        offsets.emplace_back(offset);
+    OffsetVector offsets{0, 16, 1, 17};
+
+    int skip_checks = 0;
+    auto reject_every_cell = [&](const milvus::SkipIndex&, FieldId, int) {
+        ++skip_checks;
+        return true;
+    };
+
+    int64_t null_rows = 0;
+    int64_t data_rows = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        ValidityView,
+        const int32_t*,
+        int size,
+        TargetBitmapView,
+        TargetBitmapView) {
+        if (data == nullptr) {
+            null_rows += size;
+        } else {
+            data_rows += size;
+        }
+    };
+
+    TargetBitmap result(offsets.size(), false);
+    TargetBitmap valid(offsets.size(), true);
+    EXPECT_EQ(seg_expr->ProcessDataByOffsets<int64_t>(evaluate_batch,
+                                                      reject_every_cell,
+                                                      &offsets,
+                                                      TargetBitmapView(result),
+                                                      TargetBitmapView(valid)),
+              static_cast<int64_t>(offsets.size()));
+    EXPECT_EQ(skip_checks, 2);
+    EXPECT_EQ(null_rows, static_cast<int64_t>(offsets.size()));
+    EXPECT_EQ(data_rows, 0);
+    EXPECT_EQ(result.count(), 0);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SealedNullableOffsetTakePreservesValidityWhenDataIsSkipped) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto nullable_fid =
+        schema->AddDebugField("nullable_value", DataType::INT64, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto first = DataGen(schema, N / 2, 45, 0, 1, 1);
+    auto second = DataGen(schema, N / 2, 46, 0, 1, 1);
+    std::vector<bool> first_valid(N / 2, true);
+    std::vector<bool> second_valid(N / 2, true);
+    first_valid[1] = false;
+    second_valid[0] = false;
+    SetScalarFieldValidity(first, nullable_fid, first_valid);
+    SetScalarFieldValidity(second, nullable_fid, second_valid);
+
+    auto segment = CreateTwoChunkSealed(schema, first, second);
+    ASSERT_EQ(segment->GetSkipIndex()->GetMetricsSource(nullable_fid),
+              SkipIndex::MetricsSource::LoadedPayload);
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, segment.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        segment.get(), nullable_fid, DataType::INT64, *query_context);
+    OffsetVector offsets{0, 16, 1, 17};
+
+    int skip_checks = 0;
+    auto reject_every_cell = [&](const milvus::SkipIndex&, FieldId, int) {
+        ++skip_checks;
+        return true;
+    };
+    int64_t null_rows = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        ValidityView,
+        const int32_t*,
+        int size,
+        TargetBitmapView,
+        TargetBitmapView) {
+        EXPECT_EQ(data, nullptr);
+        null_rows += size;
+    };
+
+    TargetBitmap result(offsets.size(), false);
+    TargetBitmap valid(offsets.size(), true);
+    EXPECT_EQ(seg_expr->ProcessDataByOffsets<int64_t>(evaluate_batch,
+                                                      reject_every_cell,
+                                                      &offsets,
+                                                      TargetBitmapView(result),
+                                                      TargetBitmapView(valid)),
+              static_cast<int64_t>(offsets.size()));
+    EXPECT_EQ(skip_checks, 2);
+    EXPECT_EQ(null_rows, static_cast<int64_t>(offsets.size()));
+    EXPECT_EQ(result.count(), 0);
+    EXPECT_TRUE(valid[0]);
+    EXPECT_FALSE(valid[1]);
+    EXPECT_FALSE(valid[2]);
+    EXPECT_TRUE(valid[3]);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest, SequentialScanAdvancesGlobalPosition) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "scan cursor probe",
+                                    query_context->get_op_context(),
+                                    sealed_.get(),
+                                    i64_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/4,
+                                    query_context->get_consistency_level());
+    auto evaluate_batch =
+        []<FilterType filter_type = FilterType::sequential>(const int64_t*,
+                                                            ValidityView,
+                                                            const int32_t*,
+                                                            int,
+                                                            TargetBitmapView,
+                                                            TargetBitmapView){};
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+    TargetBitmap first_res(4, false);
+    TargetBitmap first_valid(4, true);
+    EXPECT_EQ(
+        seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                            no_skip,
+                                            TargetBitmapView(first_res),
+                                            TargetBitmapView(first_valid)),
+        4);
+    ASSERT_TRUE(seg_expr.DataScanInitialized());
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 4);
+
+    TargetBitmap second_res(4, false);
+    TargetBitmap second_valid(4, true);
+    EXPECT_EQ(
+        seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                            no_skip,
+                                            TargetBitmapView(second_res),
+                                            TargetBitmapView(second_valid)),
+        4);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest, DirectScanDelegatesPrefetchToColumn) {
+    auto column = sealed_->GetChunkedColumn(i64_fid_);
+    ASSERT_NE(column, nullptr);
+    column->ManualEvictCache();
+    const int64_t first_cell[] = {0};
+    const int64_t second_cell[] = {N / 2};
+    ASSERT_FALSE(column->CellsLoaded(first_cell, std::size(first_cell)));
+    ASSERT_FALSE(column->CellsLoaded(second_cell, std::size(second_cell)));
+
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    NoOpPrefetchSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                     "direct scan prefetch probe",
+                                     query_context->get_op_context(),
+                                     sealed_.get(),
+                                     i64_fid_,
+                                     std::vector<std::string>{},
+                                     DataType::INT64,
+                                     N,
+                                     /*batch_size=*/4,
+                                     query_context->get_consistency_level());
+    auto evaluate_batch =
+        []<FilterType filter_type = FilterType::sequential>(const int64_t*,
+                                                            ValidityView,
+                                                            const int32_t*,
+                                                            int,
+                                                            TargetBitmapView,
+                                                            TargetBitmapView){};
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+    TargetBitmap res(4, false);
+    TargetBitmap valid(4, true);
+    EXPECT_EQ(seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                  no_skip,
+                                                  TargetBitmapView(res),
+                                                  TargetBitmapView(valid)),
+              4);
+
+    // Scan owns physical Cell access, including warmup. The expression-level
+    // legacy prefetch hook must not be involved once Scan is selected.
+    EXPECT_EQ(seg_expr.PrefetchCalls(), 0);
+    EXPECT_TRUE(column->CellsLoaded(first_cell, std::size(first_cell)));
+    EXPECT_TRUE(column->CellsLoaded(second_cell, std::size(second_cell)));
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanExecutionBatchCrossesColumnChunks) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "cross-chunk scan cursor probe",
+                                    query_context->get_op_context(),
+                                    sealed_.get(),
+                                    i64_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/20,
+                                    query_context->get_consistency_level());
+    std::vector<int64_t> callback_sizes;
+    auto evaluate_batch =
+        [&callback_sizes]<FilterType filter_type = FilterType::sequential>(
+            const int64_t* data,
+            ValidityView,
+            const int32_t*,
+            int size,
+            TargetBitmapView,
+            TargetBitmapView) {
+        ASSERT_NE(data, nullptr);
+        callback_sizes.push_back(size);
+    };
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+    TargetBitmap res(20, false);
+    TargetBitmap valid(20, true);
+    EXPECT_EQ(seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                  no_skip,
+                                                  TargetBitmapView(res),
+                                                  TargetBitmapView(valid)),
+              20);
+    EXPECT_EQ(callback_sizes, (std::vector<int64_t>{16, 4}));
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 20);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanAppliesLoadedPayloadSkipAfterReadingTheCell) {
+    ASSERT_EQ(sealed_->GetSkipIndex()->GetMetricsSource(i64_fid_),
+              SkipIndex::MetricsSource::LoadedPayload);
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "loaded skip scan probe",
+                                    query_context->get_op_context(),
+                                    sealed_.get(),
+                                    i64_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/20,
+                                    query_context->get_consistency_level());
+
+    std::vector<std::pair<bool, int64_t>> callbacks;
+    auto evaluate_batch =
+        [&callbacks]<FilterType filter_type = FilterType::sequential>(
+            const int64_t* data,
+            ValidityView,
+            const int32_t*,
+            int size,
+            TargetBitmapView,
+            TargetBitmapView) {
+        callbacks.emplace_back(data == nullptr, size);
+    };
+    auto skip_first_cell = [](const milvus::SkipIndex&, FieldId, int chunk_id) {
+        return chunk_id == 0;
+    };
+
+    TargetBitmap res(20, false);
+    TargetBitmap valid(20, true);
+    EXPECT_EQ(seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                  skip_first_cell,
+                                                  TargetBitmapView(res),
+                                                  TargetBitmapView(valid)),
+              20);
+    EXPECT_EQ(callbacks,
+              (std::vector<std::pair<bool, int64_t>>{{true, 16}, {false, 4}}));
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 20);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanSkippedValidityHonorsCandidateMask) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto nullable_fid =
+        schema->AddDebugField("nullable_value", DataType::INT64, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto first = DataGen(schema, N / 2, 61, 0, 1, 1);
+    auto second = DataGen(schema, N / 2, 62, 0, 1, 1);
+    std::vector<bool> first_valid(N / 2, true);
+    first_valid[0] = false;
+    first_valid[1] = false;
+    SetScalarFieldValidity(first, nullable_fid, first_valid);
+    auto segment = CreateTwoChunkSealed(schema, first, second);
+    ASSERT_EQ(segment->GetSkipIndex()->GetMetricsSource(nullable_fid),
+              SkipIndex::MetricsSource::LoadedPayload);
+
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, segment.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "candidate-aware skipped validity",
+                                    query_context->get_op_context(),
+                                    segment.get(),
+                                    nullable_fid,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/20,
+                                    query_context->get_consistency_level());
+    auto skip_first_cell = [](const SkipIndex&, FieldId, int chunk_id) {
+        return chunk_id == 0;
+    };
+    TargetBitmap candidate_mask(20, false);
+    candidate_mask.set(1);
+    int64_t processed_cursor = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        ValidityView,
+        const int32_t*,
+        int size,
+        TargetBitmapView,
+        TargetBitmapView) {
+        if (processed_cursor < N / 2) {
+            EXPECT_EQ(data, nullptr);
+        }
+        processed_cursor += size;
+    };
+
+    TargetBitmap result(20, false);
+    TargetBitmap valid(20, true);
+    EXPECT_EQ(
+        seg_expr.ProcessDataChunksWithMask<int64_t>(evaluate_batch,
+                                                    skip_first_cell,
+                                                    TargetBitmapView(result),
+                                                    TargetBitmapView(valid),
+                                                    candidate_mask),
+        20);
+    EXPECT_EQ(processed_cursor, 20);
+    EXPECT_TRUE(valid[0])
+        << "an upstream-excluded NULL in a skipped Cell stays untouched";
+    EXPECT_FALSE(valid[1])
+        << "an active NULL in a skipped Cell remains authoritative";
+    EXPECT_TRUE(valid[2]);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanUsesGlobalPositionBeforeBackendSelection) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "pre-bind scan position probe",
+                                    query_context->get_op_context(),
+                                    sealed_.get(),
+                                    i64_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/20,
+                                    query_context->get_consistency_level());
+
+    // Skip the first execution batch before Scan has selected or retained a
+    // column generation. The old generation has chunk sizes [16, 16], so its
+    // cached chunk coordinate for row 20 would be (1, 4).
+    ASSERT_FALSE(seg_expr.DataScanInitialized());
+    seg_expr.MoveCursor();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 20);
+    ASSERT_FALSE(seg_expr.DataScanInitialized());
+
+    // Publish the same logical rows with different chunk geometry. Reusing the
+    // old (1, 4) coordinate against [24, 8] would incorrectly report row 28 as
+    // the execution position. Batch sizing and the first Scan must instead use
+    // the segment-global row 20.
+    std::vector<FieldDataPtr> chunks;
+    int64_t next_value = 1000;
+    for (const int64_t rows : {24, 8}) {
+        auto field_data =
+            std::make_shared<FieldData<int64_t>>(DataType::INT64, false);
+        std::vector<int64_t> values(rows);
+        std::iota(values.begin(), values.end(), next_value);
+        next_value += rows;
+        field_data->FillFieldData(values.data(), rows);
+        chunks.push_back(std::move(field_data));
+    }
+    auto cm = storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(kCollectionID,
+                                                    kPartitionID,
+                                                    kSegmentID,
+                                                    i64_fid_.get(),
+                                                    std::move(chunks),
+                                                    cm);
+    sealed_->DropFieldData(i64_fid_);
+    const auto status = LoadFieldData(sealed_.get(), &load_info);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(sealed_->chunk_size(i64_fid_, 0), 24);
+    ASSERT_EQ(sealed_->chunk_size(i64_fid_, 1), 8);
+
+    ASSERT_EQ(seg_expr.NextBatchSize(), 12);
+    std::vector<int64_t> values_seen;
+    auto evaluate_batch =
+        [&values_seen]<FilterType filter_type = FilterType::sequential>(
+            const int64_t* data,
+            ValidityView,
+            const int32_t*,
+            int size,
+            TargetBitmapView,
+            TargetBitmapView) {
+        ASSERT_NE(data, nullptr);
+        values_seen.insert(values_seen.end(), data, data + size);
+    };
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+    TargetBitmap res(12, false);
+    TargetBitmap valid(12, true);
+    EXPECT_EQ(seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                  no_skip,
+                                                  TargetBitmapView(res),
+                                                  TargetBitmapView(valid)),
+              12);
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), N);
+    std::vector<int64_t> expected(12);
+    std::iota(expected.begin(), expected.end(), 1020);
+    EXPECT_EQ(values_seen, expected);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       GrowingChunkCacheRebasesFromGlobalPositionAfterShortCircuit) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, growing_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "growing chunk position probe",
+                                    query_context->get_op_context(),
+                                    growing_.get(),
+                                    i64_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::INT64,
+                                    N,
+                                    /*batch_size=*/4,
+                                    query_context->get_consistency_level());
+    auto evaluate_batch =
+        []<FilterType filter_type = FilterType::sequential>(const int64_t*,
+                                                            ValidityView,
+                                                            const int32_t*,
+                                                            int,
+                                                            TargetBitmapView,
+                                                            TargetBitmapView){};
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+    auto process_batch = [&]() {
+        TargetBitmap res(4, false);
+        TargetBitmap valid(4, true);
+        EXPECT_EQ(seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                      no_skip,
+                                                      TargetBitmapView(res),
+                                                      TargetBitmapView(valid)),
+                  4);
+    };
+
+    process_batch();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 4);
+    seg_expr.MoveCursor();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
+    process_batch();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 12);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialScanKeepsColumnAliveAcrossFieldDrop) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    std::weak_ptr<ChunkedColumnInterface> weak_column;
+
+    {
+        auto column = sealed_->GetChunkedColumn(i64_fid_);
+        ASSERT_NE(column, nullptr);
+        weak_column = column;
+        column.reset();
+
+        InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                        "scan column lifetime probe",
+                                        query_context->get_op_context(),
+                                        sealed_.get(),
+                                        i64_fid_,
+                                        std::vector<std::string>{},
+                                        DataType::INT64,
+                                        N,
+                                        /*batch_size=*/4,
+                                        query_context->get_consistency_level());
+        int64_t rows_seen = 0;
+        auto evaluate_batch =
+            [&rows_seen]<FilterType filter_type = FilterType::sequential>(
+                const int64_t* data,
+                ValidityView,
+                const int32_t*,
+                int size,
+                TargetBitmapView,
+                TargetBitmapView) {
+            ASSERT_NE(data, nullptr);
+            rows_seen += size;
+        };
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+        TargetBitmap first_res(4, false);
+        TargetBitmap first_valid(4, true);
+        EXPECT_EQ(
+            seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                no_skip,
+                                                TargetBitmapView(first_res),
+                                                TargetBitmapView(first_valid)),
+            4);
+        EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
+
+        sealed_->DropFieldData(i64_fid_);
+        ASSERT_FALSE(sealed_->HasFieldData(i64_fid_));
+        ASSERT_FALSE(weak_column.expired())
+            << "the expression must retain its selected source column";
+
+        // Skip one execution batch after the live segment drops the field.
+        // The next window must prepare from the retained column generation
+        // instead of asking the segment for its now-missing field again.
+        seg_expr.MoveCursor();
+        EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
+        EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
+
+        TargetBitmap second_res(4, false);
+        TargetBitmap second_valid(4, true);
+        EXPECT_EQ(
+            seg_expr.ProcessDataChunks<int64_t>(evaluate_batch,
+                                                no_skip,
+                                                TargetBitmapView(second_res),
+                                                TargetBitmapView(second_valid)),
+            4);
+        EXPECT_EQ(rows_seen, 8);
     }
 
-    VerifySkipCursorContract<int64_t>(*seg_expr, &offsets, 0);
+    EXPECT_TRUE(weak_column.expired());
 }
 
 // Exercise the production expression stack used by iterative filtering:
@@ -726,20 +1383,51 @@ TEST(OffsetsEvalProductionRegressionTest,
     }
 }
 
-// VARCHAR/JSON/ARRAY use get_views_by_offsets rather than chunk_data. Pin the
-// view branch separately because its validity storage and ownership differ.
 TEST_F(OffsetsEvalCorrectnessTest,
-       SealedViewSkipBranchKeepsBitmapCursorAligned) {
+       SealedViewTakeAppliesLoadedPayloadSkipWithoutBuildingViews) {
+    ASSERT_EQ(sealed_->GetSkipIndex()->GetMetricsSource(varchar_fid_),
+              SkipIndex::MetricsSource::LoadedPayload);
     auto query_context = std::make_shared<QueryContext>(
         DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
     auto seg_expr = MakeDirectSegmentExpr(
         sealed_.get(), varchar_fid_, DataType::VARCHAR, *query_context);
-    OffsetVector offsets;
-    for (auto offset : std::vector<int32_t>{0, 1, 2, 3, 16, 17, 18, 19}) {
-        offsets.emplace_back(offset);
-    }
+    OffsetVector offsets{0, 16, 1, 17};
 
-    VerifySkipCursorContract<std::string_view>(*seg_expr, &offsets, 0);
+    int skip_checks = 0;
+    auto reject_every_cell = [&](const milvus::SkipIndex&, FieldId, int) {
+        ++skip_checks;
+        return true;
+    };
+
+    int64_t null_rows = 0;
+    int64_t data_rows = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const std::string_view* data,
+        ValidityView,
+        const int32_t*,
+        int size,
+        TargetBitmapView,
+        TargetBitmapView) {
+        if (data == nullptr) {
+            null_rows += size;
+        } else {
+            data_rows += size;
+        }
+    };
+
+    TargetBitmap result(offsets.size(), false);
+    TargetBitmap valid(offsets.size(), true);
+    EXPECT_EQ(seg_expr->ProcessDataByOffsets<std::string_view>(
+                  evaluate_batch,
+                  reject_every_cell,
+                  &offsets,
+                  TargetBitmapView(result),
+                  TargetBitmapView(valid)),
+              static_cast<int64_t>(offsets.size()));
+    EXPECT_EQ(skip_checks, 2);
+    EXPECT_EQ(null_rows, static_cast<int64_t>(offsets.size()));
+    EXPECT_EQ(data_rows, 0);
+    EXPECT_EQ(result.count(), 0);
 }
 
 // VECTOR_ARRAY has its own chunk_view branch. There is no production
@@ -760,6 +1448,62 @@ TEST_F(OffsetsEvalCorrectnessTest,
     }
 
     VerifySkipCursorContract<VectorArrayView>(*seg_expr, &offsets, 0);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SequentialVectorArrayScanKeepsCursorAlignedAcrossSkippedBatch) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    InspectableSegmentExpr seg_expr(std::vector<ExprPtr>{},
+                                    "vector array scan cursor probe",
+                                    query_context->get_op_context(),
+                                    sealed_.get(),
+                                    vector_array_fid_,
+                                    std::vector<std::string>{},
+                                    DataType::VECTOR_ARRAY,
+                                    N,
+                                    /*batch_size=*/4,
+                                    query_context->get_consistency_level());
+    auto evaluate_batch = []<FilterType filter_type = FilterType::sequential>(
+        const VectorArrayView*,
+        ValidityView,
+        const int32_t*,
+        int,
+        TargetBitmapView,
+        TargetBitmapView){};
+    std::function<bool(const milvus::SkipIndex&, FieldId, int)> no_skip;
+
+    auto process_batch = [&]() {
+        TargetBitmap res(4, false);
+        TargetBitmap valid(4, true);
+        EXPECT_EQ(seg_expr.ProcessDataChunks<VectorArrayView>(
+                      evaluate_batch,
+                      no_skip,
+                      TargetBitmapView(res),
+                      TargetBitmapView(valid)),
+                  4);
+    };
+
+    process_batch();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 4);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
+
+    // Simulate a conjunction short-circuit: skip the second expression batch
+    // without preparing scan resources for that window.
+    seg_expr.MoveCursor();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 8);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
+
+    // A second consecutive short-circuit advances the execution window
+    // without asking the retained cursor to read or pin data.
+    seg_expr.MoveCursor();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 12);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
+
+    // Resume the VECTOR_ARRAY scan at the post-skip global position.
+    process_batch();
+    EXPECT_EQ(seg_expr.CurrentExecutionPosition(), 16);
+    EXPECT_TRUE(seg_expr.HasRetainedDataScanColumn());
 }
 
 TEST_F(OffsetsEvalCorrectnessTest,
@@ -1187,4 +1931,130 @@ TEST(OffsetsEvalIndexOnlyCorrectnessTest,
     EXPECT_FALSE(valid[1]);
     EXPECT_TRUE(valid[2]);
     EXPECT_TRUE(valid[3]);
+}
+
+// A validity-only scan passes the same TargetBitmapView as both destinations.
+// Applying the alias optimization must preserve the same mask as distinct
+// result and validity destinations.
+TEST(ScanValidityMaskTest, AliasedDestinationMatchesDistinctMask) {
+    const bool valid_data[] = {
+        true, false, true, false, true, true, false, true, false, false, true};
+    const int size = static_cast<int>(std::size(valid_data));
+
+    // Distinct result/validity destinations: every NULL clears both bitmaps.
+    TargetBitmap distinct_res(size, true);
+    TargetBitmap distinct_valid(size, true);
+    ApplyValidMask(ValidityView::FromExpanded(valid_data),
+                   TargetBitmapView(distinct_res),
+                   TargetBitmapView(distinct_valid),
+                   size);
+    for (int i = 0; i < size; ++i) {
+        EXPECT_EQ(bool(distinct_res[i]), valid_data[i]);
+        EXPECT_EQ(bool(distinct_valid[i]), valid_data[i]);
+    }
+
+    // Aliased destination (the ProcessDataChunksForValid shape): the same
+    // bitmap is passed for result and validity, and NULLs are cleared once.
+    TargetBitmap aliased(size, true);
+    ApplyValidMask(ValidityView::FromExpanded(valid_data),
+                   TargetBitmapView(aliased),
+                   TargetBitmapView(aliased),
+                   size);
+    for (int i = 0; i < size; ++i) {
+        EXPECT_EQ(bool(aliased[i]), valid_data[i]);
+    }
+}
+
+// Cover the packed-validity overload used by Raw and Vortex scans.
+TEST(ScanValidityMaskTest, AliasedPackedDestinationMatchesDistinctMask) {
+    std::vector<uint8_t> packed((11 + 7) / 8, 0xff);
+    // Rows 1, 3, 8, 9 are NULL.
+    for (int i : {1, 3, 8, 9}) {
+        packed[i >> 3] &= static_cast<uint8_t>(~(uint8_t{1} << (i & 0x07)));
+    }
+    auto validity = ValidityView::FromPacked(packed.data());
+
+    TargetBitmap distinct_res(11, true);
+    TargetBitmap distinct_valid(11, true);
+    ApplyValidMask(validity,
+                   TargetBitmapView(distinct_res),
+                   TargetBitmapView(distinct_valid),
+                   11);
+    for (int i : {1, 3, 8, 9}) {
+        EXPECT_FALSE(distinct_res[i]);
+        EXPECT_FALSE(distinct_valid[i]);
+    }
+    for (int i : {0, 2, 4, 5, 6, 7, 10}) {
+        EXPECT_TRUE(distinct_res[i]);
+        EXPECT_TRUE(distinct_valid[i]);
+    }
+
+    TargetBitmap aliased(11, true);
+    ApplyValidMask(
+        validity, TargetBitmapView(aliased), TargetBitmapView(aliased), 11);
+    for (int i : {1, 3, 8, 9}) {
+        EXPECT_FALSE(aliased[i]);
+    }
+    for (int i : {0, 2, 4, 5, 6, 7, 10}) {
+        EXPECT_TRUE(aliased[i]);
+    }
+}
+
+TEST(ScanValidityMaskTest, CandidateMaskUsesBatchRelativeWordRanges) {
+    constexpr int64_t size = 137;
+    constexpr int64_t validity_pos = 3;
+    constexpr int64_t candidate_pos = 5;
+    constexpr int64_t destination_pos = 7;
+    constexpr int64_t validity_size = validity_pos + size + 2;
+
+    auto expanded = std::make_unique<bool[]>(validity_size);
+    std::vector<uint8_t> packed((validity_size + 7) / 8, 0);
+    TargetBitmap candidates(candidate_pos + size + 2, false);
+    for (int64_t i = 0; i < validity_size; ++i) {
+        expanded[i] = i % 5 != 1;
+        if (expanded[i]) {
+            packed[i >> 3] |= uint8_t{1} << (i & 0x07);
+        }
+    }
+    for (int64_t i = 0; i < size; ++i) {
+        if (i % 3 != 0) {
+            candidates.set(candidate_pos + i);
+        }
+    }
+
+    const auto verify = [&](ValidityView validity) {
+        TargetBitmap result(destination_pos + size + 2, true);
+        TargetBitmap valid(destination_pos + size + 2, true);
+        ApplyValidMaskForCandidates(validity.Subview(validity_pos),
+                                    result.view(destination_pos, size),
+                                    valid.view(destination_pos, size),
+                                    size,
+                                    &candidates,
+                                    candidate_pos);
+        for (int64_t i = 0; i < size; ++i) {
+            const bool expected =
+                !candidates[candidate_pos + i] || expanded[validity_pos + i];
+            EXPECT_EQ(bool(result[destination_pos + i]), expected) << i;
+            EXPECT_EQ(bool(valid[destination_pos + i]), expected) << i;
+        }
+        EXPECT_TRUE(result[destination_pos - 1]);
+        EXPECT_TRUE(result[destination_pos + size]);
+
+        TargetBitmap aliased(destination_pos + size + 2, true);
+        auto destination = aliased.view(destination_pos, size);
+        ApplyValidMaskForCandidates(validity.Subview(validity_pos),
+                                    destination,
+                                    destination,
+                                    size,
+                                    &candidates,
+                                    candidate_pos);
+        for (int64_t i = 0; i < size; ++i) {
+            const bool expected =
+                !candidates[candidate_pos + i] || expanded[validity_pos + i];
+            EXPECT_EQ(bool(aliased[destination_pos + i]), expected) << i;
+        }
+    };
+
+    verify(ValidityView::FromExpanded(expanded.get()));
+    verify(ValidityView::FromPacked(packed.data()));
 }

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -5503,6 +5503,65 @@ TEST(SealedSegmentCowState, ReplacePkStateIsInvisibleUntilFinalPublish) {
     EXPECT_EQ(current->runtime->pk_index_slot, old_pk_index_slot);
 }
 
+TEST(SealedSegmentCowState, ReplaceProxyColumnClearsStaleSkipMetrics) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto payload = schema->AddDebugField("payload", DataType::INT64);
+    schema->set_primary_field_id(pk);
+
+    auto old_dataset = DataGen(schema, 4);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, old_dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    ASSERT_EQ(sealed->GetSkipIndexSnapshot()->GetMetricsSource(payload),
+              SkipIndex::MetricsSource::LoadedPayload);
+
+    auto replacement_dataset = DataGen(schema, 4, /*seed=*/271828);
+    auto replacement_segment =
+        CreateSealedWithFieldDataLoaded(schema, replacement_dataset);
+    auto* replacement_sealed =
+        dynamic_cast<ChunkedSegmentSealedImpl*>(replacement_segment.get());
+    ASSERT_NE(replacement_sealed, nullptr);
+    auto replacement_state =
+        replacement_sealed->TestGetPublishedStateSnapshot();
+    auto replacement_column = replacement_state->runtime->fields.at(payload);
+
+    auto current = sealed->TestGetPublishedStateSnapshot();
+    auto runtime = sealed->TestCloneMutableRuntimeResourceState();
+    ChunkedSegmentSealedImpl::StateDelta initial_delta;
+    initial_delta.schema = current->schema;
+    initial_delta.load_info = current->load_info;
+    initial_delta.runtime = sealed->TestFreezeRuntimeResourceState(runtime);
+    initial_delta.commit_ts = current->commit_ts;
+    auto staged = sealed->TestBuildNextPublishedState(current, initial_delta);
+
+    ChunkedSegmentSealedImpl::StateDelta final_delta;
+    final_delta.schema = current->schema;
+    final_delta.load_info = current->load_info;
+    final_delta.commit_ts = current->commit_ts;
+
+    sealed->TestStageLoadFieldDataThenPublish(
+        payload,
+        replacement_column,
+        replacement_dataset.raw_->num_rows(),
+        DataType::INT64,
+        schema,
+        runtime,
+        staged.get(),
+        current,
+        final_delta,
+        /*is_proxy_column=*/true,
+        [&] {
+            EXPECT_EQ(runtime->skip_index->GetMetricsSource(payload),
+                      SkipIndex::MetricsSource::None);
+            EXPECT_EQ(sealed->GetSkipIndexSnapshot()->GetMetricsSource(payload),
+                      SkipIndex::MetricsSource::LoadedPayload);
+        });
+
+    EXPECT_EQ(sealed->GetSkipIndexSnapshot()->GetMetricsSource(payload),
+              SkipIndex::MetricsSource::None);
+}
+
 TEST(SealedSegmentCowState, ClearPublishedStateDropsRuntimeSnapshot) {
     auto schema = std::make_shared<Schema>();
     auto pk = schema->AddDebugField("pk", DataType::INT64);

--- a/internal/core/unittest/test_timestamptz_arith_compare.cpp
+++ b/internal/core/unittest/test_timestamptz_arith_compare.cpp
@@ -80,6 +80,26 @@ MakeTstzPlusOneMonthCompare(FieldId tstz_fid,
 constexpr int64_t kFarFutureUs = 4102444800LL * 1000000;  // 2100-01-01
 constexpr int64_t kFarPastUs = -2208988800LL * 1000000;   // 1900-01-01
 
+void
+SetTimestamptzValues(GeneratedData& dataset,
+                     FieldId field_id,
+                     const std::vector<int64_t>& values) {
+    ASSERT_EQ(dataset.raw_->num_rows(), values.size());
+    for (int i = 0; i < dataset.raw_->fields_data_size(); ++i) {
+        auto* field_data = dataset.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != field_id.get()) {
+            continue;
+        }
+        auto* data = field_data->mutable_scalars()
+                         ->mutable_timestamptz_data()
+                         ->mutable_data();
+        data->Clear();
+        data->Add(values.data(), values.data() + values.size());
+        return;
+    }
+    FAIL() << "timestamptz field " << field_id.get() << " not found";
+}
+
 }  // namespace
 
 class TimestamptzArithCompareCorrectnessTest : public ::testing::Test {
@@ -303,4 +323,60 @@ TEST_F(TimestamptzArithCompareCorrectnessTest,
 
 TEST_F(TimestamptzArithCompareCorrectnessTest, SealedOffsetInputNullSemantics) {
     AssertOffsetInputNullSemantics(sealed_.get());
+}
+
+TEST(TimestamptzArithCompareOffsetScanTest,
+     DenseSortedAndDuplicateOffsetsGatherSourceRows) {
+    constexpr int64_t kRowCount = 32;
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto timestamp_fid =
+        schema->AddDebugField("ts", DataType::TIMESTAMPTZ, false);
+    schema->set_primary_field_id(pk_fid);
+
+    auto dataset = DataGen(schema, kRowCount, 84);
+    std::vector<int64_t> timestamps(kRowCount);
+    for (int64_t i = 0; i < kRowCount; ++i) {
+        timestamps[i] = i * 1000000;
+    }
+    SetTimestamptzValues(dataset, timestamp_fid, timestamps);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+
+    proto::plan::Interval interval;
+    proto::plan::GenericValue compare_value;
+    compare_value.set_int64_val(11500000);
+    auto typed_expr =
+        std::make_shared<milvus::expr::TimestamptzArithCompareExpr>(
+            expr::ColumnInfo(timestamp_fid, DataType::TIMESTAMPTZ),
+            proto::plan::ArithOpType::Add,
+            interval,
+            proto::plan::OpType::LessThan,
+            compare_value);
+    auto filter_node = std::make_shared<milvus::plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, typed_expr);
+
+    OffsetVector offsets{10, 12, 12};
+    auto col_vec = milvus::test::gen_filter_res(
+        filter_node.get(), segment.get(), kRowCount, MAX_TIMESTAMP, &offsets);
+    {
+        BitsetTypeView res(col_vec->GetRawData(), col_vec->size());
+        ASSERT_EQ(res.size(), offsets.size());
+        EXPECT_TRUE(res[0]);
+        EXPECT_FALSE(res[1]);
+        EXPECT_FALSE(res[2]);
+    }
+
+    OffsetVector duplicate_offsets{10, 10, 10};
+    col_vec = milvus::test::gen_filter_res(filter_node.get(),
+                                           segment.get(),
+                                           kRowCount,
+                                           MAX_TIMESTAMP,
+                                           &duplicate_offsets);
+    BitsetTypeView duplicate_res(col_vec->GetRawData(), col_vec->size());
+    ASSERT_EQ(duplicate_res.size(), duplicate_offsets.size());
+    EXPECT_TRUE(duplicate_res[0]);
+    EXPECT_TRUE(duplicate_res[1]);
+    EXPECT_TRUE(duplicate_res[2]);
 }

--- a/internal/core/unittest/test_virtual_pk.cpp
+++ b/internal/core/unittest/test_virtual_pk.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include "common/VirtualPK.h"
+#include "mmap/ChunkedColumnFilter.h"
 #include "mmap/VirtualPKChunkedColumn.h"
 
 using namespace milvus;
@@ -128,6 +129,39 @@ class VirtualPKChunkedColumnTest : public ::testing::Test {
     }
 };
 
+class TrackingVirtualPKChunkedColumn : public VirtualPKChunkedColumn {
+ public:
+    using VirtualPKChunkedColumn::Take;
+
+    TrackingVirtualPKChunkedColumn(int64_t segment_id, int64_t num_rows)
+        : VirtualPKChunkedColumn(segment_id, num_rows) {
+    }
+
+    PinWrapper<Chunk*>
+    GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
+        ++get_chunk_calls;
+        return VirtualPKChunkedColumn::GetChunk(op_ctx, chunk_id);
+    }
+
+    TakeCellPin
+    MakeTakeCellPin(milvus::OpContext*) const override {
+        ++make_take_pin_calls;
+        return {};
+    }
+
+ protected:
+    std::unique_ptr<ColumnPlanner>
+    BuildPlanner() const override {
+        ++build_planner_calls;
+        return ChunkedColumnInterface::BuildPlanner();
+    }
+
+ public:
+    mutable int get_chunk_calls{0};
+    mutable int make_take_pin_calls{0};
+    mutable int build_planner_calls{0};
+};
+
 TEST_F(VirtualPKChunkedColumnTest, BasicProperties) {
     int64_t segment_id = 12345;
     int64_t num_rows = 1000;
@@ -173,6 +207,185 @@ TEST_F(VirtualPKChunkedColumnTest, BulkPrimitiveValueAt) {
         int64_t expected = GetVirtualPK(segment_id, offsets[i]);
         ASSERT_EQ(results[i], expected);
     }
+}
+
+TEST_F(VirtualPKChunkedColumnTest,
+       Int64VirtualPrimaryKeyUsesFixedWidthScanCursor) {
+    constexpr int64_t segment_id = 200;
+    constexpr int64_t num_rows = 5;
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    auto cursor =
+        column.Scan(nullptr,
+                    ChunkedColumnInterface::ScanOptions::ForData(
+                        1, ChunkedColumnInterface::TargetType::Int64));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(
+        cursor->Next(num_rows + 10,
+                     ChunkedColumnInterface::ScanReadMode::DataAndValidity,
+                     &batch));
+    EXPECT_EQ(batch.row_id_start, 1);
+    EXPECT_EQ(batch.size, num_rows - 1);
+    EXPECT_EQ(batch.values.target_type,
+              ChunkedColumnInterface::TargetType::Int64);
+    const auto* values = batch.values.data_as<int64_t>();
+    for (int64_t i = 0; i < batch.size; ++i) {
+        EXPECT_EQ(values[i], GetVirtualPK(segment_id, i + 1));
+    }
+    EXPECT_FALSE(cursor->Next(
+        1024, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+}
+
+TEST_F(VirtualPKChunkedColumnTest,
+       ScanAndTakeGenerateRequestedRowsWithoutChunkAccess) {
+    constexpr int64_t segment_id = 200;
+    constexpr int64_t num_rows = 20;
+    TrackingVirtualPKChunkedColumn column(segment_id, num_rows);
+
+    const int64_t* no_offsets = nullptr;
+    auto empty_take =
+        column.Take(nullptr,
+                    ChunkedColumnInterface::TakeOptions{
+                        ChunkedColumnInterface::OffsetView::From(no_offsets, 0),
+                        ChunkedColumnInterface::TargetType::Int64});
+    ASSERT_NE(empty_take, nullptr);
+    EXPECT_EQ(empty_take->Size(), 0);
+    EXPECT_TRUE(empty_take->IsOwned());
+    auto empty_owned = empty_take->GetOwn();
+    EXPECT_EQ(empty_owned.size, 0);
+    EXPECT_NE(empty_owned.owner, nullptr);
+
+    const std::vector<int64_t> offsets{7, 1, 7, 19};
+    auto take = column.Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int64});
+    ASSERT_NE(take, nullptr);
+    ASSERT_EQ(take->Size(), static_cast<int64_t>(offsets.size()));
+    EXPECT_TRUE(take->IsOwned());
+    for (int64_t i = 0; i < take->Size(); ++i) {
+        EXPECT_TRUE(take->IsValid(i));
+        const auto item = take->Get<int64_t>(i);
+        ASSERT_TRUE(item.value.has_value());
+        EXPECT_EQ(*item.value, GetVirtualPK(segment_id, offsets[i]));
+    }
+    auto owned = take->GetOwn();
+    ASSERT_EQ(owned.size, static_cast<int64_t>(offsets.size()));
+    const auto* owned_values = owned.values.data_as<int64_t>();
+    for (int64_t i = 0; i < owned.size; ++i) {
+        EXPECT_EQ(owned_values[i], GetVirtualPK(segment_id, offsets[i]));
+    }
+
+    auto cursor =
+        column.Scan(nullptr,
+                    ChunkedColumnInterface::ScanOptions::ForData(
+                        3, ChunkedColumnInterface::TargetType::Int64));
+    ASSERT_NE(cursor, nullptr);
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        5, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    ASSERT_EQ(batch.row_id_start, 3);
+    ASSERT_EQ(batch.size, 5);
+    ASSERT_FALSE(batch.validity);
+    const auto* values = batch.values.data_as<int64_t>();
+    for (int64_t i = 0; i < batch.size; ++i) {
+        EXPECT_EQ(values[i], GetVirtualPK(segment_id, 3 + i));
+    }
+
+    EXPECT_THROW(
+        cursor->Next(
+            2, ChunkedColumnInterface::ScanReadMode::ValidityOnly, &batch),
+        std::exception);
+
+    EXPECT_EQ(column.get_chunk_calls, 0);
+    EXPECT_EQ(column.make_take_pin_calls, 0);
+    EXPECT_EQ(column.build_planner_calls, 0);
+}
+
+TEST_F(VirtualPKChunkedColumnTest,
+       ScanAndTakeApplyFilterWithoutExposingPhysicalCells) {
+    constexpr int64_t segment_id = 200;
+    constexpr int64_t num_rows = 20;
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+    std::vector<int64_t> visited_cells;
+    auto filter = std::make_shared<const detail::ColumnFilter>(
+        detail::ColumnFilter::MetricsSource::PreloadedStatistics,
+        [&](int64_t cell_id) {
+            visited_cells.emplace_back(cell_id);
+            return true;
+        });
+
+    auto scan_options = ChunkedColumnInterface::ScanOptions::ForData(
+        2, ChunkedColumnInterface::TargetType::Int64);
+    scan_options.filter = filter;
+    auto cursor = column.Scan(nullptr, scan_options);
+    ASSERT_NE(cursor, nullptr);
+    EXPECT_TRUE(visited_cells.empty());
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(
+        3, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch));
+    EXPECT_EQ(batch.row_id_start, 2);
+    EXPECT_EQ(batch.size, 3);
+    EXPECT_TRUE(batch.data_skipped);
+    EXPECT_TRUE(batch.values.empty());
+
+    const int64_t* no_offsets = nullptr;
+    auto empty_take =
+        column.Take(nullptr,
+                    ChunkedColumnInterface::TakeOptions{
+                        ChunkedColumnInterface::OffsetView::From(no_offsets, 0),
+                        ChunkedColumnInterface::TargetType::Int64,
+                        filter});
+    ASSERT_NE(empty_take, nullptr);
+    EXPECT_EQ(empty_take->Size(), 0);
+    EXPECT_EQ(visited_cells, (std::vector<int64_t>{0}));
+
+    const std::vector<int64_t> offsets{7, 1, 7};
+    auto take = column.Take(
+        nullptr,
+        ChunkedColumnInterface::TakeOptions{
+            ChunkedColumnInterface::OffsetView::From(
+                offsets.data(), static_cast<int64_t>(offsets.size())),
+            ChunkedColumnInterface::TargetType::Int64,
+            filter});
+    ASSERT_NE(take, nullptr);
+    ASSERT_EQ(take->Size(), static_cast<int64_t>(offsets.size()));
+    for (int64_t i = 0; i < take->Size(); ++i) {
+        EXPECT_TRUE(take->IsValid(i));
+        const auto item = take->Get<int64_t>(i);
+        EXPECT_TRUE(item.data_skipped);
+        EXPECT_FALSE(item.value.has_value());
+    }
+    const auto owned = take->GetOwn();
+    EXPECT_TRUE(owned.values.empty());
+    ASSERT_TRUE(owned.data_skipped);
+    for (int64_t i = 0; i < owned.size; ++i) {
+        EXPECT_TRUE(owned.data_skipped[i]);
+    }
+    EXPECT_EQ(visited_cells, (std::vector<int64_t>{0, 0}));
+}
+
+TEST_F(VirtualPKChunkedColumnTest,
+       NoneTargetCanOpenUniformValidityCursorButCannotReadData) {
+    VirtualPKChunkedColumn column(/*segment_id=*/200, /*num_rows=*/5);
+    auto cursor = column.Scan(nullptr,
+                              ChunkedColumnInterface::ScanOptions::ForData(
+                                  0, ChunkedColumnInterface::TargetType::None));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    EXPECT_THROW(
+        cursor->Next(
+            1, ChunkedColumnInterface::ScanReadMode::DataAndValidity, &batch),
+        std::exception);
+    EXPECT_THROW(
+        cursor->Next(
+            1, ChunkedColumnInterface::ScanReadMode::ValidityOnly, &batch),
+        std::exception);
 }
 
 TEST_F(VirtualPKChunkedColumnTest, BulkValueAt) {
@@ -307,15 +520,38 @@ TEST_F(VirtualPKChunkedColumnTest, SupportedOperations) {
 
     VirtualPKChunkedColumn column(segment_id, num_rows);
 
-    // DataOfChunk and Span are supported via EnsureMaterialized
+    // Chunk-backed access remains available for legacy Chunk consumers.
     EXPECT_NO_THROW(column.DataOfChunk(nullptr, 0));
     EXPECT_NO_THROW(column.Span(nullptr, 0));
+    EXPECT_NO_THROW(column.GetChunk(nullptr, 0));
+    EXPECT_NO_THROW(column.GetAllChunks(nullptr));
 
     // Verify DataOfChunk returns valid data
     auto data = column.DataOfChunk(nullptr, 0);
     auto pks = reinterpret_cast<const int64_t*>(data.get());
     ASSERT_NE(pks, nullptr);
     ASSERT_EQ(pks[0], GetVirtualPK(GetTruncatedSegmentID(segment_id), 0));
+
+    auto chunks = column.GetAllChunks(nullptr);
+    ASSERT_EQ(chunks.size(), 1);
+    ASSERT_EQ(chunks[0].get()->RowNums(), num_rows);
+}
+
+TEST_F(VirtualPKChunkedColumnTest, MaterializedChunkKeepsVirtualPkBufferAlive) {
+    constexpr int64_t segment_id = 100;
+    constexpr int64_t num_rows = 50;
+    auto pinned_chunk = [=]() {
+        auto column =
+            std::make_shared<VirtualPKChunkedColumn>(segment_id, num_rows);
+        return column->GetChunk(nullptr, 0);
+    }();
+
+    ASSERT_NE(pinned_chunk.get(), nullptr);
+    for (int64_t i = 0; i < num_rows; ++i) {
+        EXPECT_EQ(
+            *reinterpret_cast<const int64_t*>(pinned_chunk.get()->ValueAt(i)),
+            GetVirtualPK(segment_id, i));
+    }
 }
 
 TEST_F(VirtualPKChunkedColumnTest, UnsupportedOperations) {
@@ -324,9 +560,6 @@ TEST_F(VirtualPKChunkedColumnTest, UnsupportedOperations) {
 
     VirtualPKChunkedColumn column(segment_id, num_rows);
 
-    // These operations should throw
-    EXPECT_THROW(column.GetChunk(nullptr, 0), std::exception);
-    EXPECT_THROW(column.GetAllChunks(nullptr), std::exception);
     EXPECT_THROW(column.StringViews(nullptr, 0, std::nullopt), std::exception);
     EXPECT_THROW(column.ArrayViews(nullptr, 0, std::nullopt), std::exception);
 }

--- a/internal/core/unittest/test_virtual_pk.cpp
+++ b/internal/core/unittest/test_virtual_pk.cpp
@@ -334,15 +334,22 @@ TEST_F(VirtualPKChunkedColumnTest, SupportedOperations) {
 
     VirtualPKChunkedColumn column(segment_id, num_rows);
 
-    // DataOfChunk and Span are supported via EnsureMaterialized
+    // Chunk-backed access is supported via EnsureMaterialized so the common
+    // scan path can pin its input before constructing the cursor.
     EXPECT_NO_THROW(column.DataOfChunk(nullptr, 0));
     EXPECT_NO_THROW(column.Span(nullptr, 0));
+    EXPECT_NO_THROW(column.GetChunk(nullptr, 0));
+    EXPECT_NO_THROW(column.GetAllChunks(nullptr));
 
     // Verify DataOfChunk returns valid data
     auto data = column.DataOfChunk(nullptr, 0);
     auto pks = reinterpret_cast<const int64_t*>(data.get());
     ASSERT_NE(pks, nullptr);
     ASSERT_EQ(pks[0], GetVirtualPK(GetTruncatedSegmentID(segment_id), 0));
+
+    auto chunks = column.GetAllChunks(nullptr);
+    ASSERT_EQ(chunks.size(), 1);
+    ASSERT_EQ(chunks[0].get()->RowNums(), num_rows);
 }
 
 TEST_F(VirtualPKChunkedColumnTest, UnsupportedOperations) {
@@ -351,9 +358,6 @@ TEST_F(VirtualPKChunkedColumnTest, UnsupportedOperations) {
 
     VirtualPKChunkedColumn column(segment_id, num_rows);
 
-    // These operations should throw
-    EXPECT_THROW(column.GetChunk(nullptr, 0), std::exception);
-    EXPECT_THROW(column.GetAllChunks(nullptr), std::exception);
     EXPECT_THROW(column.StringViews(nullptr, 0, std::nullopt), std::exception);
     EXPECT_THROW(column.ArrayViews(nullptr, 0, std::nullopt), std::exception);
 }

--- a/internal/core/unittest/test_virtual_pk.cpp
+++ b/internal/core/unittest/test_virtual_pk.cpp
@@ -184,9 +184,10 @@ TEST_F(VirtualPKChunkedColumnTest,
     auto cursor = column.Scan(
         nullptr, ChunkedColumnInterface::ScanOptions::ForData(1, num_rows - 1));
     ASSERT_NE(cursor, nullptr);
+    EXPECT_EQ(cursor->Position(), 1);
 
     ChunkedColumnInterface::ScanBatch batch;
-    ASSERT_TRUE(cursor->Next(&batch));
+    ASSERT_TRUE(cursor->Next(num_rows - 1, &batch));
     EXPECT_EQ(batch.row_id_start, 1);
     EXPECT_EQ(batch.size, num_rows - 1);
     EXPECT_EQ(batch.values.encoding,
@@ -197,7 +198,8 @@ TEST_F(VirtualPKChunkedColumnTest,
     for (int64_t i = 0; i < batch.size; ++i) {
         EXPECT_EQ(values[i], GetVirtualPK(segment_id, i + 1));
     }
-    EXPECT_FALSE(cursor->Next(&batch));
+    EXPECT_EQ(cursor->Position(), num_rows);
+    EXPECT_FALSE(cursor->Next(num_rows - 1, &batch));
 }
 
 TEST_F(VirtualPKChunkedColumnTest, BulkValueAt) {

--- a/internal/core/unittest/test_virtual_pk.cpp
+++ b/internal/core/unittest/test_virtual_pk.cpp
@@ -175,6 +175,31 @@ TEST_F(VirtualPKChunkedColumnTest, BulkPrimitiveValueAt) {
     }
 }
 
+TEST_F(VirtualPKChunkedColumnTest,
+       Int64VirtualPrimaryKeyUsesFixedWidthScanCursor) {
+    constexpr int64_t segment_id = 200;
+    constexpr int64_t num_rows = 5;
+    VirtualPKChunkedColumn column(segment_id, num_rows);
+
+    auto cursor = column.Scan(
+        nullptr, ChunkedColumnInterface::ScanOptions::ForData(1, num_rows - 1));
+    ASSERT_NE(cursor, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    ASSERT_TRUE(cursor->Next(&batch));
+    EXPECT_EQ(batch.row_id_start, 1);
+    EXPECT_EQ(batch.size, num_rows - 1);
+    EXPECT_EQ(batch.values.encoding,
+              ChunkedColumnInterface::ValueEncoding::FixedWidth);
+    EXPECT_EQ(batch.values.kind,
+              ChunkedColumnInterface::ScanValueKind::FixedWidth);
+    const auto* values = batch.values.data_as<int64_t>();
+    for (int64_t i = 0; i < batch.size; ++i) {
+        EXPECT_EQ(values[i], GetVirtualPK(segment_id, i + 1));
+    }
+    EXPECT_FALSE(cursor->Next(&batch));
+}
+
 TEST_F(VirtualPKChunkedColumnTest, BulkValueAt) {
     int64_t segment_id = 300;
     int64_t num_rows = 50;

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -899,6 +899,12 @@ func InitGISSplitFusion(params *paramtable.ComponentParam) error {
 	return nil
 }
 
+func InitScanPinPolicy(params *paramtable.ComponentParam) error {
+	cursorOwnsPin := C.bool(params.QueryNodeCfg.ScanCursorOwnsPin.GetAsBool())
+	C.SegcoreSetScanCursorOwnsPin(cursorOwnsPin)
+	return nil
+}
+
 func CleanRemoteChunkManager() {
 	C.CleanRemoteChunkManagerSingleton()
 }

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -246,6 +246,11 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 		return err
 	}
 
+	err = InitScanPinPolicy(paramtable.Get())
+	if err != nil {
+		return err
+	}
+
 	InitTraceConfig(paramtable.Get())
 	C.InitExecExpressionFunctionFactory()
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4216,6 +4216,7 @@ type queryNodeConfig struct {
 	MultipleChunkedEnable              ParamItem `refreshable:"false"` // Deprecated
 	EnableGeometryCache                ParamItem `refreshable:"false"`
 	EnableGISSplitFusion               ParamItem `refreshable:"false"`
+	ScanCursorOwnsPin                  ParamItem `refreshable:"false"`
 
 	TieredWarmupScalarField         ParamItem `refreshable:"true"`
 	TieredWarmupScalarIndex         ParamItem `refreshable:"true"`
@@ -5001,6 +5002,15 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Export:       true,
 	}
 	p.EnableGISSplitFusion.Init(base.mgr)
+
+	p.ScanCursorOwnsPin = ParamItem{
+		Key:          "queryNode.segcore.scanCursorOwnsPin",
+		Version:      "2.6.6",
+		DefaultValue: "false",
+		Doc:          "Use cursor-owned rather than result-owned Cell pins for scalar Scan",
+		Export:       true,
+	}
+	p.ScanCursorOwnsPin.Init(base.mgr)
 
 	p.InterimIndexNProbe = ParamItem{
 		Key:     "queryNode.segcore.interimIndex.nprobe",


### PR DESCRIPTION
relate: #50304

design doc: docs/design-docs/design_docs/20260305-local_format.md

## Summary
Introduce the scalar local-format metadata contract and column-oriented DataScan foundation described in the [local format design document](https://github.com/milvus-io/milvus/blob/buqian/aoiasd/aoiasd-vortex-data-scan/docs/design-docs/design_docs/20260305-local_format.md). This includes write-time grouping, field validation, raw-compatible scan interfaces, and focused coverage for the new contract.