### PR TITLE
fix: Return early after parameter validation fails in RESTful v2 function DDL handlers

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -961,6 +961,7 @@ func (h *HandlersV2) addCollectionFunction(ctx context.Context, c *gin.Context, 
 			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 			HTTPReturnMessage: err.Error(),
 		})
+		return nil, err
 	}
 
 	req.FunctionSchema = fSchema
@@ -987,6 +988,7 @@ func (h *HandlersV2) alterCollectionFunction(ctx context.Context, c *gin.Context
 			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 			HTTPReturnMessage: err.Error(),
 		})
+		return nil, err
 	}
 
 	req.FunctionSchema = fSchema

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -4864,6 +4864,20 @@ func (s *CollectionFunctionSuite) TestAddCollectionFunctionNormal() {
 	})
 }
 
+func (s *CollectionFunctionSuite) TestAddCollectionFunctionInvalidType() {
+	// no expectation on s.mp: an invalid function type must be rejected
+	// before any AddCollectionFunction RPC is issued
+	addFunctionTestCases := []requestBodyTestCase{
+		{
+			path:        versionalV2(CollectionCategory, AddFunctionAction),
+			requestBody: []byte(`{"dbName": "db", "collectionName": "coll", "function": {"name": "test_function", "type": "InvalidType", "inputFieldNames": [], "OutputFieldNames": []}}`),
+			errCode:     1100,
+			errMsg:      "Unsupported function type: InvalidType: invalid parameter",
+		},
+	}
+	validateRequestBodyTestCases(s.T(), s.testEngine, addFunctionTestCases, false)
+}
+
 func (s *CollectionFunctionSuite) TestAlterCollectionFunctionNormal() {
 	s.Run("success", func() {
 		alterFunctionTestCases := []requestBodyTestCase{
@@ -4896,6 +4910,20 @@ func (s *CollectionFunctionSuite) TestAlterCollectionFunctionNormal() {
 		}
 		validateRequestBodyTestCases(s.T(), s.testEngine, alterFunctionTestCases, false)
 	})
+}
+
+func (s *CollectionFunctionSuite) TestAlterCollectionFunctionInvalidType() {
+	// no expectation on s.mp: an invalid function type must be rejected
+	// before any AlterCollectionFunction RPC is issued
+	alterFunctionTestCases := []requestBodyTestCase{
+		{
+			path:        versionalV2(CollectionCategory, AlterFunctionAction),
+			requestBody: []byte(`{"dbName": "db", "collectionName": "coll", "functionName": "test_function", "function": {"name": "test_function", "type": "InvalidType", "inputFieldNames": [], "OutputFieldNames": []}}`),
+			errCode:     1100,
+			errMsg:      "Unsupported function type: InvalidType: invalid parameter",
+		},
+	}
+	validateRequestBodyTestCases(s.T(), s.testEngine, alterFunctionTestCases, false)
 }
 
 func (s *CollectionFunctionSuite) TestDropCollectionFunctionNormal() {


### PR DESCRIPTION
issue: #51503

`addCollectionFunction` and `alterCollectionFunction` in the RESTful v2 handler call `HTTPAbortReturn` when `genFunctionSchema` rejects the request, but are missing the early `return`. gin's `Abort` only skips pending handlers in the middleware chain — it does not stop the currently executing handler (see [gin docs](https://pkg.go.dev/github.com/gin-gonic/gin#Context.Abort)) — so execution falls through:

- the DDL RPC is still issued with a nil `FunctionSchema` (rejected later by the task's `PreExecute` nil-check — a wasted dd-queue round trip, with the real validation error replaced by a misleading "function schema is nil" warning);
- a second JSON response is written onto the already-committed connection; under the REST timeout middleware this surfaces to the client as a 408 "request timeout" after the full timeout instead of the immediate validation error (observed in the regression test before the fix).

This PR adds the missing `return nil, err` after `HTTPAbortReturn` in both handlers, matching every sibling handler in the file, and adds regression tests asserting that an invalid function type is rejected immediately without issuing any RPC (strict mock: an unexpected `AddCollectionFunction`/`AlterCollectionFunction` call fails the test).

These two handlers are the only defective call sites — verified by sweeping all 101 `HTTPAbortReturn` call sites in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)