### PR TITLE
fix: [Catalog] harden TiKV KV scans and write metrics

### DIFF
--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -227,6 +227,12 @@ func (kv *txnTiKV) HasPrefix(ctx context.Context, prefix string) (bool, error) {
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV HasPrefix() error", mlog.String("prefix", prefix))
 
+	// The snapshot iterator below does not accept a context, so honor
+	// caller cancellation explicitly before starting the scan.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return false, ctxErr
+	}
+
 	ss := getSnapshot(kv.txn, SnapshotScanSize)
 
 	// Retrieve bounding keys for prefix
@@ -273,8 +279,9 @@ func (kv *txnTiKV) Load(ctx context.Context, key string) (string, error) {
 func batchConvertFromString(prefix string, keys []string) [][]byte {
 	output := make([][]byte, len(keys))
 	for i := 0; i < len(keys); i++ {
-		keys[i] = util.GetPath(prefix, keys[i])
-		output[i] = []byte(keys[i])
+		// Never write the prefixed path back into the caller's slice:
+		// callers may legally reuse it across calls (e.g. on retry).
+		output[i] = []byte(util.GetPath(prefix, keys[i]))
 	}
 	return output
 }
@@ -303,9 +310,10 @@ func (kv *txnTiKV) MultiLoad(ctx context.Context, keys []string) ([]string, erro
 	missingValues := []string{}
 	validValues := []string{}
 
-	// Loop through keys and build valid/invalid slices
-	for _, k := range keys {
-		v, ok := keyMap[k]
+	// Loop through keys and build valid/invalid slices, looking up by the
+	// prefixed path while reporting the caller's original key.
+	for i, k := range keys {
+		v, ok := keyMap[string(byteKeys[i])]
 		if !ok {
 			missingValues = append(missingValues, k)
 		}
@@ -329,6 +337,12 @@ func (kv *txnTiKV) LoadWithPrefix(ctx context.Context, prefix string) ([]string,
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV LoadWithPrefix() error", mlog.String("prefix", prefix))
 
+	// The snapshot iterator below does not accept a context, so honor
+	// caller cancellation explicitly before starting the scan.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, nil, ctxErr
+	}
+
 	ss := getSnapshot(kv.txn, SnapshotScanSize)
 
 	// Retrieve key-value pairs with the specified prefix
@@ -344,8 +358,13 @@ func (kv *txnTiKV) LoadWithPrefix(ctx context.Context, prefix string) ([]string,
 	var keys []string
 	var values []string
 
-	// Iterate over the key-value pairs
+	// Iterate over the key-value pairs. The iterator does not accept a
+	// context, so poll caller cancellation each step: a caller that has
+	// given up must not leave an unkillable scan running.
 	for iter.Valid() {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, nil, ctxErr
+		}
 		val := iter.Value()
 		// Check if empty value placeholder
 		strVal := convertEmptyByteToString(val)
@@ -559,8 +578,14 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 				}
 				defer iter.Close()
 
-				// Iterate over keys and delete them
+				// Iterate over keys and delete them. The transaction
+				// iterator does not accept a context either, so poll
+				// caller cancellation each step; the bare context error
+				// surfaces to the caller through the build-error path.
 				for iter.Valid() {
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return ctxErr
+					}
 					key := iter.Key()
 					if err = txn.Delete(key); err != nil {
 						return wrapWriteBuildErr(fmt.Sprintf("Failed to delete %s for MultiSaveAndRemoveWithPrefix", string(key)), err)
@@ -606,6 +631,12 @@ func (kv *txnTiKV) WalkWithPrefix(ctx context.Context, prefix string, pagination
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV WalkWithPagination error", mlog.String("prefix", prefix))
 
+	// The snapshot iterator below does not accept a context, so honor
+	// caller cancellation explicitly before starting the scan.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+
 	// Since only reading, use Snapshot for less overhead
 	ss := getSnapshot(kv.txn, paginationSize)
 
@@ -619,8 +650,13 @@ func (kv *txnTiKV) WalkWithPrefix(ctx context.Context, prefix string, pagination
 	}
 	defer iter.Close()
 
-	// Iterate over the key-value pairs
+	// Iterate over the key-value pairs. The iterator does not accept a
+	// context, so poll caller cancellation each step: a caller that has
+	// given up must not leave an unkillable scan running.
 	for iter.Valid() {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		// Grab value for empty check
 		byteVal := iter.Value()
 		// Check if empty val and replace with placeholder
@@ -707,9 +743,9 @@ func (kv *txnTiKV) runWriteTxnWithRetry(ctx context.Context, op string, build fu
 func (kv *txnTiKV) executeTxn(ctx context.Context, txn *transaction.KVTxn) error {
 	start := timerecord.NewTimeRecorder("executeTxn")
 
-	elapsed := start.ElapseSpan()
 	metrics.MetaOpCounter.WithLabelValues(metrics.MetaTxnLabel, metrics.TotalLabel).Inc()
 	err := commitTxn(ctx, txn)
+	elapsed := start.ElapseSpan()
 	if err == nil {
 		metrics.MetaRequestLatency.WithLabelValues(metrics.MetaTxnLabel).Observe(float64(elapsed.Milliseconds()))
 		metrics.MetaOpCounter.WithLabelValues(metrics.MetaTxnLabel, metrics.SuccessLabel).Inc()

--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -571,6 +571,12 @@ func (kv *txnTiKV) MultiSaveAndRemoveWithPrefix(ctx context.Context, saves map[s
 				startKey := []byte(prefix)
 				endKey := tikv.PrefixNextKey([]byte(prefix))
 
+				// The transaction iterator does not accept a context, and
+				// Begin is not ctx-bound, so the deadline may already be dead.
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+
 				// Use Scan to iterate over keys in the prefix range
 				iter, err := txn.Iter(startKey, endKey)
 				if err != nil {

--- a/internal/kv/tikv/txn_tikv_hardening_test.go
+++ b/internal/kv/tikv/txn_tikv_hardening_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/txnkv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -181,4 +182,36 @@ func TestMultiSaveAndRemoveWithPrefixHonorsCanceledContext(t *testing.T) {
 	keys, _, err := kv.LoadWithPrefix(context.TODO(), "scan")
 	require.NoError(t, err)
 	require.Len(t, keys, 3, "a canceled prefix delete must not remove keys")
+}
+
+func TestMultiSaveAndRemoveWithPrefixStopsPrefixScanWhenContextCanceledDuringBegin(t *testing.T) {
+	rootPath := "/tikv/test/root/prefix_delete_cancel_during_begin"
+	kv := NewTiKV(txnClient, rootPath)
+	err := kv.RemoveWithPrefix(context.TODO(), "")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix(context.TODO(), "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	origBegin := beginTxn
+	beginTxn = func(txn *txnkv.Client) (*transaction.KVTxn, error) {
+		cancel()
+		return origBegin(txn)
+	}
+	defer func() { beginTxn = origBegin }()
+
+	commitCalled := false
+	origCommit := commitTxn
+	commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+		commitCalled = true
+		return origCommit(ctx, txn)
+	}
+	defer func() { commitTxn = origCommit }()
+
+	err = kv.MultiSaveAndRemoveWithPrefix(ctx, map[string]string{"save_after_cancel": "v"}, []string{"missing_prefix"})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, commitCalled, "cancellation during begin must stop the prefix-removal scan before commit")
 }

--- a/internal/kv/tikv/txn_tikv_hardening_test.go
+++ b/internal/kv/tikv/txn_tikv_hardening_test.go
@@ -1,0 +1,184 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/txnkv/transaction"
+
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+)
+
+func txnLatencySum(t *testing.T) float64 {
+	h, ok := metrics.MetaRequestLatency.WithLabelValues(metrics.MetaTxnLabel).(prometheus.Histogram)
+	require.True(t, ok)
+	m := &dto.Metric{}
+	require.NoError(t, h.Write(m))
+	return m.GetHistogram().GetSampleSum()
+}
+
+// MultiLoad must not mutate the caller's keys slice: callers may legally
+// reuse the same slice across calls (e.g. on retry), and an in-place
+// rootPath-prefix rewrite makes every subsequent call double-prefixed.
+func TestMultiLoadDoesNotMutateCallerKeys(t *testing.T) {
+	rootPath := "/tikv/test/root/multiload_no_mutation"
+	kv := NewTiKV(txnClient, rootPath)
+	err := kv.RemoveWithPrefix(context.TODO(), "")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix(context.TODO(), "")
+
+	err = kv.MultiSave(context.TODO(), map[string]string{"key_a": "1", "key_b": "2"})
+	require.NoError(t, err)
+
+	keys := []string{"key_a", "key_b"}
+
+	vals, err := kv.MultiLoad(context.TODO(), keys)
+	require.NoError(t, err)
+	require.Equal(t, []string{"1", "2"}, vals)
+
+	// The caller's slice must be untouched after the call.
+	require.Equal(t, []string{"key_a", "key_b"}, keys)
+
+	// Reusing the same slice must yield the same result, not a
+	// double-prefixed miss.
+	vals, err = kv.MultiLoad(context.TODO(), keys)
+	require.NoError(t, err)
+	require.Equal(t, []string{"1", "2"}, vals)
+
+	// A missing key must be reported under the caller's original name,
+	// not the rootPath-prefixed lookup path.
+	mixed := []string{"key_a", "key_missing"}
+	_, err = kv.MultiLoad(context.TODO(), mixed)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "key_missing")
+	require.NotContains(t, err.Error(), rootPath)
+	require.Equal(t, []string{"key_a", "key_missing"}, mixed)
+}
+
+// The txn latency histogram must measure the commit itself: a commit taking
+// N ms must observe at least N ms, not a near-zero pre-commit elapsed.
+func TestExecuteTxnLatencyMeasuresCommit(t *testing.T) {
+	rootPath := "/tikv/test/root/txn_latency"
+	kv := NewTiKV(txnClient, rootPath)
+	defer kv.Close()
+	defer kv.RemoveWithPrefix(context.TODO(), "")
+
+	origCommit := commitTxn
+	commitTxn = func(ctx context.Context, txn *transaction.KVTxn) error {
+		time.Sleep(60 * time.Millisecond)
+		return origCommit(ctx, txn)
+	}
+	defer func() { commitTxn = origCommit }()
+
+	before := txnLatencySum(t)
+	err := kv.MultiSave(context.TODO(), map[string]string{"lat_key": "v"})
+	require.NoError(t, err)
+	after := txnLatencySum(t)
+
+	require.GreaterOrEqual(t, after-before, 55.0,
+		"txn latency histogram must include commit duration")
+}
+
+// Prefix reads must honor caller cancellation: a caller that has already
+// given up (timeout, disconnect, shutdown) must not leave an unkillable
+// scan running against TiKV. The snapshot iterator does not accept a
+// context (its internal backoffer uses context.Background()), so the kv
+// layer has to check the caller context itself.
+func TestPrefixReadsHonorCanceledContext(t *testing.T) {
+	rootPath := "/tikv/test/root/prefix_cancel"
+	kv := NewTiKV(txnClient, rootPath)
+	err := kv.RemoveWithPrefix(context.TODO(), "")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix(context.TODO(), "")
+
+	err = kv.MultiSave(context.TODO(), map[string]string{
+		"scan/a": "1", "scan/b": "2", "scan/c": "3",
+	})
+	require.NoError(t, err)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	t.Run("LoadWithPrefix", func(t *testing.T) {
+		_, _, err := kv.LoadWithPrefix(canceled, "scan")
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("HasPrefix", func(t *testing.T) {
+		_, err := kv.HasPrefix(canceled, "scan")
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("WalkWithPrefix", func(t *testing.T) {
+		err := kv.WalkWithPrefix(canceled, "scan", 1, func(k, v []byte) error { return nil })
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	// An empty prefix must not bypass the cancellation check: the scan loop
+	// never runs, so the entry check has to catch it.
+	t.Run("LoadWithPrefix_empty_prefix", func(t *testing.T) {
+		_, _, err := kv.LoadWithPrefix(canceled, "no_such_prefix")
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("WalkWithPrefix_empty_prefix", func(t *testing.T) {
+		err := kv.WalkWithPrefix(canceled, "no_such_prefix", 1, func(k, v []byte) error { return nil })
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// Regression guard for the write-path prefix scan: a canceled caller must
+// get context.Canceled back and must not lose keys. The pre-canceled case
+// is already caught by retry.Do's entry check before the scan starts; the
+// in-loop poll added alongside mirrors the read-path scans as best-effort
+// early abort for cancellation arriving mid-scan (not deterministically
+// testable from the public API).
+func TestMultiSaveAndRemoveWithPrefixHonorsCanceledContext(t *testing.T) {
+	rootPath := "/tikv/test/root/prefix_delete_cancel"
+	kv := NewTiKV(txnClient, rootPath)
+	err := kv.RemoveWithPrefix(context.TODO(), "")
+	require.NoError(t, err)
+
+	defer kv.Close()
+	defer kv.RemoveWithPrefix(context.TODO(), "")
+
+	err = kv.MultiSave(context.TODO(), map[string]string{
+		"scan/a": "1", "scan/b": "2", "scan/c": "3",
+	})
+	require.NoError(t, err)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = kv.MultiSaveAndRemoveWithPrefix(canceled, nil, []string{"scan"})
+	require.ErrorIs(t, err, context.Canceled)
+
+	// The scan must have been aborted before any delete took effect.
+	keys, _, err := kv.LoadWithPrefix(context.TODO(), "scan")
+	require.NoError(t, err)
+	require.Len(t, keys, 3, "a canceled prefix delete must not remove keys")
+}


### PR DESCRIPTION
- Honor caller cancellation before and during TiKV prefix scans. Read-path scans check `ctx.Err()` before opening snapshot iterators and while iterating; write-path prefix deletes now also check immediately before the contextless `txn.Iter`, including deadlines that expire during non-ctx-bound `beginTxn`.
- Avoid mutating `MultiLoad` callers' key slices by building prefixed byte keys separately, while still reporting missing keys under the callers' original names.
- Measure TiKV transaction latency after commit completes so `MetaTxnLabel` captures the commit path instead of the pre-commit elapsed time.
- Add hardening tests for `MultiLoad` slice reuse, canceled prefix scans/deletes, begin-time cancellation before prefix-delete scans, and transaction latency metrics.

related: #51513