### PR TITLE
enhance: migrate local storage I/O to rooted filesystem

### DIFF
--- a/docs/design-docs/design_docs/20260712-local-filesystem.md
+++ b/docs/design-docs/design_docs/20260712-local-filesystem.md
@@ -1,0 +1,525 @@
+# Rooted Local File System
+
+- **Created:** 2026-07-12
+- **Updated:** 2026-07-17
+- **Status:** Draft
+- **Component:** Local filesystem / Segcore / Index / Caching layer
+- **Related code:** `internal/core/src/local`,
+  `internal/core/src/storage`, `internal/core/src/index`,
+  `internal/core/src/segcore`
+
+## 1. Summary
+
+Milvus needs an explicit abstraction for files that live on the node running a
+component. These files include downloaded index artifacts, mmap backing files,
+and operation-scoped scratch data. They are different from persisted objects
+in S3-compatible storage even when both happen to be accessed through file-like
+APIs.
+
+This design introduces `milvus::local`:
+
+```text
+milvus::storage
+    persisted object/key storage and remote transfer
+
+milvus::local::FileSystem
+    a rooted capability for one local filesystem namespace
+
+milvus::local::io
+    RAII handles for opened files and mapped regions
+
+milvus::cachinglayer
+    cache loading, pinning, accounting, and eviction policy
+```
+
+`FileSystem` is a small, copyable value handle. `FileSystem::Open()` binds
+an absolute physical root once. All operations below that root use validated
+relative `local::Path` values. `Subtree()` derives a narrower capability
+without introducing another configured service or global registry.
+
+```cpp
+auto node_cache = local::FileSystem::Open(node_cache_root);
+auto local_chunk = node_cache.Subtree(local::Path("local_chunk"));
+auto growing_mmap = node_cache.Subtree(local::Path("growing_mmap"));
+```
+
+Directories that need writer-versus-cleanup coordination explicitly use
+`ManagedSubtree`. Ordinary filesystem operations remain immediate and do not
+hide cache or lifecycle policy.
+
+## 2. Motivation
+
+### 2.1 Local files are not object storage
+
+`ChunkManager` models objects addressed by keys. Its implementations cover
+remote object storage and persistent `storageType=local` compatibility.
+Node-local artifacts have different requirements:
+
+- directory creation and recursive removal;
+- validated paths below a configured root;
+- POSIX file descriptors and positioned I/O;
+- mmap lifetime ownership;
+- third-party libraries that require native paths;
+- coordination between active writers and cleanup.
+
+Putting these operations under `milvus::storage` blurs persistent storage,
+remote transfer, node-local cache, and scratch lifetimes.
+
+Persistent `storageType=local` remains under `milvus::storage`. The new
+namespace is for local filesystem mechanisms used by node-local artifacts.
+
+### 2.2 Absolute path strings spread authority
+
+Passing strings such as
+`/var/lib/milvus/data/cache/<node-id>/local_chunk/...` through business code
+duplicates root construction and lets every consumer address sibling
+directories. It also makes tests depend on process-global setup.
+
+A rooted handle centralizes the absolute root and gives leaf components only
+the subtree they need.
+
+### 2.3 One physical root contains several logical namespaces
+
+The node cache currently contains logical children such as:
+
+```text
+localStorage.path/cache/<node-id>/
+├── local_chunk/
+├── growing_mmap/
+├── bm25/
+├── file_resource/
+└── expr_cache/
+```
+
+These are subtrees, not five independent filesystem services. A configured
+mmap directory may still be opened as a separate root when it points at a
+different disk or mount.
+
+## 3. Goals and Non-goals
+
+### 3.1 Goals
+
+- represent local filesystem access as an explicit dependency;
+- bind absolute paths at composition boundaries;
+- use relative paths inside rooted namespaces;
+- reject absolute paths and `..` root escape;
+- support multiple roots in one process and in tests;
+- provide move-only RAII file and mmap handles;
+- preserve existing writer behavior and native-library compatibility;
+- make concurrent writer/cleanup coordination explicit;
+- preserve current on-disk paths and formats;
+- allow incremental migration from legacy local file access.
+
+### 3.2 Non-goals
+
+- replace `milvus::cachinglayer`;
+- introduce another cache namespace or eviction policy;
+- move S3 APIs into `milvus::local`;
+- remove persistent `storageType=local`;
+- redesign index layouts or remote object names;
+- migrate every direct filesystem call in one change;
+- introduce io_uring, a buffer pool, or a virtual filesystem plugin system.
+
+## 4. Namespace and Ownership Model
+
+```text
+internal/core/src/local/
+├── Path.h
+├── FileSystem.h
+├── FileSystem.cpp
+├── ManagedSubtree.h
+├── ManagedSubtree.cpp
+└── io/
+    ├── File.h
+    ├── File.cpp
+    ├── MappedRegion.h
+    └── MappedRegion.cpp
+```
+
+```cpp
+namespace milvus::local {
+class Path;
+class FileSystem;
+class ManagedSubtree;
+}
+
+namespace milvus::local::io {
+class RandomAccessFile;
+class WritableFile;
+class MappedRegion;
+}
+```
+
+The dependency direction is:
+
+```text
+storage transfer -----> local
+index / segcore ------> storage + local + cachinglayer
+cachinglayer policy --> local-backed values
+local ----------------X storage
+local ----------------X cachinglayer
+```
+
+`milvus::local` supplies mechanisms. It does not decide whether a file is a
+cache entry, scratch data, or persistent data.
+
+## 5. Relative Paths
+
+`local::Path` always represents a path relative to a `FileSystem` handle:
+
+```cpp
+class Path {
+ public:
+    explicit Path(std::string value);
+    std::string_view String() const noexcept;
+};
+```
+
+Construction rejects:
+
+- absolute paths;
+- embedded NUL bytes;
+- any normalized path containing `..`;
+- values that would escape the handle root.
+
+The absolute root appears only at `FileSystem::Open()`. Code below the
+composition boundary carries `Path` rather than absolute strings.
+
+## 6. FileSystem Value Handles
+
+```cpp
+class FileSystem final {
+ public:
+    static FileSystem Open(std::filesystem::path absolute_root);
+
+    FileSystem Subtree(const Path& path) const;
+    std::shared_ptr<ManagedSubtree> ManageSubtree(const Path& path) const;
+
+    bool Exists(const Path& path) const;
+    uint64_t FileSize(const Path& path) const;
+    std::vector<Path> List(const Path& directory, bool recursive) const;
+
+    void CreateDirectories(const Path& path) const;
+    void RemoveFile(const Path& path) const;
+    void RemoveAll(const Path& path) const;
+    void Rename(const Path& from, const Path& to) const;
+
+    io::RandomAccessFile OpenForRead(const Path& path) const;
+    io::WritableFile OpenForWrite(const Path& path,
+                                  const WriteOptions& options) const;
+    io::MappedRegion OpenMappedRegion(const Path& path,
+                                      const MapOptions& options) const;
+
+    std::filesystem::path ResolveNativePath(const Path& path) const;
+    Path PathFromNativePath(std::filesystem::path native_path) const;
+};
+```
+
+The handle contains immutable shared root state plus a subtree prefix. Copies
+are cheap and may be used concurrently. Sharing implementation state does not
+make the handle a process-wide service.
+
+There is no default filesystem, global registry, or `GetInstance()`.
+Consumers receive a handle through construction context.
+
+### 6.1 Subtree narrows authority
+
+```cpp
+auto node_cache = FileSystem::Open("/var/lib/milvus/data/cache/1001");
+auto local_chunk = node_cache.Subtree(Path("local_chunk"));
+
+local_chunk.OpenForRead(Path("index_files/10/index"));
+```
+
+The resolved native path is:
+
+```text
+/var/lib/milvus/data/cache/1001
+    + local_chunk
+    + index_files/10/index
+```
+
+The holder of `local_chunk` cannot address `expr_cache` through the
+relative API.
+
+### 6.2 Native path compatibility
+
+Knowhere, Tantivy, Arrow, and other third-party libraries sometimes require
+native paths. `ResolveNativePath()` is the explicit escape hatch. It accepts
+only a validated relative `Path` and produces a path below the scoped root.
+
+Milvus-owned I/O should prefer opened handles. Native paths should remain at
+third-party boundaries.
+
+## 7. Opened File I/O
+
+`RandomAccessFile` and `WritableFile` are move-only RAII wrappers. Their
+destructors close the native descriptor.
+
+```cpp
+class RandomAccessFile final {
+ public:
+    size_t ReadAt(uint64_t offset, std::span<std::byte> output) const;
+    uint64_t Size() const;
+};
+
+class WritableFile final {
+ public:
+    size_t Write(std::span<const std::byte> data);
+    size_t WriteAt(uint64_t offset, std::span<const std::byte> data);
+    uint64_t Size() const;
+    void Truncate(uint64_t size);
+    void Sync();
+};
+```
+
+A read-only handle does not expose writes. `ReadAt()` does not mutate shared
+file position and can be used concurrently while the handle remains alive.
+`WritableFile` does not serialize writes; callers own ordering and must not
+issue overlapping writes.
+
+Higher-level writer policy such as buffering, direct I/O alignment, priority,
+rate limiting, and completion remains above `WritableFile`.
+
+## 8. Mapped Regions
+
+`FileSystem::OpenMappedRegion()` returns a move-only
+`local::io::MappedRegion`. It stores both the page-aligned OS mapping and
+the caller-visible byte range. Destruction calls `munmap`.
+
+```cpp
+auto region = files.OpenMappedRegion(
+    Path("field.bin"),
+    MapOptions{.offset = offset, .length = length, .populate = true});
+auto bytes = region.Data();
+```
+
+Mapping is a filesystem operation rather than a method on
+`RandomAccessFile`. This keeps positional reads and OS mapping as separate
+capabilities. Higher-level chunk and segment layout remains outside
+`milvus::local::io`.
+
+Unlinking a mapped file is valid on supported POSIX systems: the mapping keeps
+the inode alive until `munmap`. Components that require path-level cleanup
+coordination use `ManagedSubtree`; they do not retain artificial reader
+leases solely for mmap lifetime.
+
+## 9. ManagedSubtree
+
+Ordinary deletion stays immediate:
+
+```cpp
+files.RemoveAll(path);
+```
+
+Only directories with a real writer-versus-cleanup race use
+`ManagedSubtree`.
+
+```cpp
+auto directory = files.ManageSubtree(Path("index_files/10"));
+
+{
+    auto lease = directory->AcquireWriter();
+    auto output = directory->Files().OpenForWrite(
+        Path("index"), WriteOptions{.create = true});
+    // Materialize the artifact.
+}
+
+directory->RemoveWhenIdle();
+```
+
+The state machine is:
+
+```text
+OPEN
+  |-- AcquireWriter -------------> OPEN, writers + 1
+  |-- RemoveWhenIdle -----------> CLOSING
+
+CLOSING
+  |-- AcquireWriter -------------> rejected
+  |-- final writer released -----> remove subtree -> REMOVED
+
+REMOVED
+  |-- AcquireWriter -------------> rejected
+  |-- RemoveWhenIdle ------------> no-op
+```
+
+`RemoveWhenIdle()` is destructor-safe and reports cleanup failures through
+the existing error/logging path. `RemoveAndWait()` waits and rethrows cleanup
+failure to callers that can handle it.
+
+## 10. Composition and Lifetimes
+
+Runtime code opens roots from configuration and derives scoped handles:
+
+```cpp
+auto node_cache = local::FileSystem::Open(
+    local_storage_path / "cache" / std::to_string(node_id));
+
+NodeLocalFiles files{
+    .local_chunk = node_cache.Subtree(Path("local_chunk")),
+    .growing_mmap = node_cache.Subtree(Path("growing_mmap")),
+    .bm25 = node_cache.Subtree(Path("bm25")),
+    .file_resource = node_cache.Subtree(Path("file_resource")),
+    .expr_cache = node_cache.Subtree(Path("expr_cache")),
+};
+```
+
+`NodeLocalFiles` is a construction value, not a global registry. A leaf
+object receives only the handle it needs.
+
+Across CGo, Go owns an opaque C++ `FileSystem` value and passes it explicitly
+to collections, segments, index tasks, or file-manager contexts. Leaf code
+does not fetch a global fallback.
+
+The intended lifetime order is:
+
+```text
+consumer stops using bytes
+    -> MappedRegion unmaps
+    -> file handles close
+    -> operation/cache owner requests subtree cleanup
+    -> directory is removed when active writers reach zero
+```
+
+Cache policy remains in `milvus::cachinglayer`. Scratch operations may use
+the same filesystem mechanisms without becoming cache entries.
+
+## 11. Error and Concurrency Semantics
+
+Local I/O must preserve distinct failures including:
+
+- path not found;
+- permission denied;
+- disk full or quota exhaustion;
+- read, write, truncate, sync, or mmap failure;
+- invalid internal relative path;
+- writer acquisition after cleanup begins;
+- cleanup failure.
+
+For valid internal load/build requests these are system failures unless the
+request content itself directly forces the error. Adding context must not
+erase an existing error category at the CGo boundary.
+
+Thread-safety contracts are explicit:
+
+- copied `FileSystem` handles are safe for concurrent use;
+- `RandomAccessFile::ReadAt()` supports concurrent positional reads;
+- `WritableFile` does not serialize overlapping writes;
+- `MappedRegion` and write leases are move-only;
+- `ManagedSubtree` serializes lifecycle transitions.
+
+## 12. Compatibility
+
+The migration preserves existing physical paths:
+
+```text
+localStorage.path/cache/<node-id>/local_chunk
+localStorage.path/cache/<node-id>/growing_mmap
+localStorage.path/cache/<node-id>/bm25
+localStorage.path/cache/<node-id>/file_resource
+localStorage.path/cache/<node-id>/expr_cache
+```
+
+Index contents, mmap layouts, remote object names, and persistent
+`storageType=local` behavior do not change. No required configuration is
+added.
+
+## 13. Migration
+
+1. Introduce `Path`, `FileSystem`, opened-file handles,
+   `MappedRegion`, and `ManagedSubtree` without changing production
+   callers.
+2. Move local writers, readers, and file managers onto rooted handles.
+3. Pass scoped handles through QueryNode/segcore construction.
+4. Pass scoped handles through DataNode/index construction.
+5. Remove legacy adapters and process-global local filesystem access after
+   every production consumer has an explicit handle.
+
+Removing `LocalChunkManagerSingleton` is the final migration step, not the
+identity of this design. `LocalChunkManager` remains for persistent
+`storageType=local` object-storage compatibility.
+
+## 14. Verification
+
+### 14.1 Path and filesystem tests
+
+- reject absolute paths and root escape;
+- open multiple roots in one process;
+- verify subtree composition and sibling isolation;
+- create, list, rename, and remove files and directories;
+- round-trip validated native paths;
+- prove cwd changes do not affect rooted operations.
+
+### 14.2 File and mmap tests
+
+- positional reads and writes;
+- create, truncate, sync, and file-size behavior;
+- descriptor closure on normal and exceptional paths;
+- aligned and unaligned mmap offsets;
+- mappings remain valid after source descriptor closure;
+- mmap failure categories.
+
+### 14.3 ManagedSubtree tests
+
+- multiple concurrent writers;
+- cleanup with active writers;
+- rejection of writers after closing begins;
+- removal on final writer release;
+- repeated removal requests;
+- synchronous cleanup error propagation;
+- independent managed subtrees under one root.
+
+### 14.4 Integration and repository audit
+
+- scalar/vector index build, upload, and load;
+- mmap and non-mmap segment load;
+- concurrent load, release, and cleanup;
+- QueryNode and DataNode shutdown;
+- persistent local storage beside node-local handles;
+- no production dependency on a global/default local filesystem.
+
+## 15. Rejected Alternatives
+
+### Keep node-local I/O under `milvus::storage`
+
+Rejected because object storage and node-local POSIX filesystem mechanisms
+have different ownership and lifetime semantics.
+
+### Replace the old singleton with a global `FileSystem`
+
+Rejected because a global getter or registry preserves hidden dependencies,
+test interference, and implicit shutdown order.
+
+### Create one service per logical directory
+
+Rejected because logical cache directories are subtrees below a small number
+of physical roots. `Subtree()` expresses the boundary more directly.
+
+### Put lifecycle tracking in every filesystem operation
+
+Rejected because ordinary removal would gain surprising deferred behavior.
+Only directories with an actual writer/cleanup race use `ManagedSubtree`.
+
+### Add another cache namespace
+
+Rejected because `milvus::cachinglayer` already owns cache policy. The local
+filesystem layer provides mechanisms and composes with it.
+
+### Require `RandomAccessFile::Map()`
+
+Rejected because positional reads and path-rooted OS mapping are distinct
+capabilities.
+
+## 16. Review Invariants
+
+1. `FileSystem` is a normal value handle with no global getter or registry.
+2. Business code uses validated relative paths below injected roots.
+3. `Subtree()` narrows authority without changing physical path layout.
+4. Ordinary filesystem operations do not hide lease or cache policy.
+5. `ManagedSubtree` is used only for real writer/cleanup coordination.
+6. Open files and mappings use move-only RAII ownership.
+7. Native paths are limited to compatibility boundaries.
+8. Cache policy remains in `milvus::cachinglayer`.
+9. Persistent `storageType=local` remains under `milvus::storage`.
+10. Existing paths, formats, and error categories remain compatible.

--- a/internal/core/src/CMakeLists.txt
+++ b/internal/core/src/CMakeLists.txt
@@ -99,6 +99,7 @@ add_subdirectory( pb )
 add_subdirectory( config )
 add_subdirectory( common )
 add_subdirectory( monitor )
+add_subdirectory( local )
 add_subdirectory( storage )
 add_subdirectory( index )
 add_subdirectory( query )
@@ -130,7 +131,8 @@ if (MILVUS_USE_PCH)
     # source files compiled with special target flags (-mavx512f, -march=armv8-a+sve)
     # which are incompatible with PCH compiled under default target features.
     foreach(_target
-        milvus_common milvus_config milvus_monitor milvus_storage milvus_index
+        milvus_common milvus_config milvus_monitor milvus_local milvus_storage
+        milvus_index
         milvus_query milvus_segcore milvus_indexbuilder milvus_clustering
         milvus_exec milvus_futures milvus_rescores
         milvus_plan)
@@ -143,6 +145,7 @@ add_library(milvus_core SHARED
     $<TARGET_OBJECTS:milvus_config>
     $<TARGET_OBJECTS:milvus_common>
     $<TARGET_OBJECTS:milvus_monitor>
+    $<TARGET_OBJECTS:milvus_local>
     $<TARGET_OBJECTS:milvus_storage>
     $<TARGET_OBJECTS:milvus_index>
     $<TARGET_OBJECTS:milvus_query>

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -19,9 +19,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <filesystem>
 #include <list>
 #include <map>
 #include <optional>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -51,8 +53,6 @@
 #include "storage/DataCodec.h"
 #include "storage/FileManager.h"
 #include "storage/IndexEntryWriter.h"
-#include "storage/LocalChunkManager.h"
-#include "storage/LocalChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
@@ -75,7 +75,9 @@ InvertedIndexTantivy<T>::InitForBuildIndex() {
     auto field =
         std::to_string(disk_file_manager_->GetFieldDataMeta().field_id);
     path_ = disk_file_manager_->GetLocalTempIndexObjectPrefix();
-    boost::filesystem::create_directories(path_);
+    auto path = disk_file_manager_->GetLocalFiles().PathFromNativePath(path_);
+    auto lease = disk_file_manager_->AcquireLocalDirWriteLease(path_);
+    disk_file_manager_->GetLocalFiles().CreateDirectories(path);
     d_type_ = get_tantivy_data_type(schema_);
     if (tantivy_index_exist(path_.c_str())) {
         ThrowInfo(IndexBuildError,
@@ -117,15 +119,21 @@ template <typename T>
 InvertedIndexTantivy<T>::~InvertedIndexTantivy() {
     if (wrapper_) {
         wrapper_->free();
+        wrapper_.reset();
     }
     if (path_.empty()) {
         return;
     }
-    auto local_chunk_manager =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    auto prefix = path_;
-    LOG_INFO("inverted index remove path:{}", path_);
-    local_chunk_manager->RemoveDir(prefix);
+    if (disk_file_manager_) {
+        try {
+            (void)disk_file_manager_->GetLocalFiles().PathFromNativePath(path_);
+            return;  // Rooted paths are owned by the disk file manager.
+        } catch (const SegcoreError&) {
+            // BuildWithRawDataForUT uses an independent temporary path.
+        }
+    }
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
 }
 
 template <typename T>
@@ -925,7 +933,9 @@ InvertedIndexTantivy<T>::LoadEntries(storage::IndexEntryReader& reader,
     bool has_null = reader.GetMeta<bool>("has_null");
 
     path_ = disk_file_manager_->GetLocalIndexObjectPrefix();
-    boost::filesystem::create_directories(path_);
+    auto path = disk_file_manager_->GetLocalFiles().PathFromNativePath(path_);
+    auto lease = disk_file_manager_->AcquireLocalDirWriteLease(path_);
+    disk_file_manager_->GetLocalFiles().CreateDirectories(path);
 
     std::vector<std::pair<std::string, std::string>> pairs;
     for (const auto& fn : file_names) {

--- a/internal/core/src/index/NgramInvertedIndex.cpp
+++ b/internal/core/src/index/NgramInvertedIndex.cpp
@@ -93,7 +93,10 @@ NgramInvertedIndex::NgramInvertedIndex(const storage::FileManagerContext& ctx,
         path_ = disk_file_manager_->GetLocalNgramIndexPrefix();
     } else {
         path_ = disk_file_manager_->GetLocalTempNgramIndexPrefix();
-        boost::filesystem::create_directories(path_);
+        auto lease = disk_file_manager_->AcquireLocalDirWriteLease(path_);
+        auto path =
+            disk_file_manager_->GetLocalFiles().PathFromNativePath(path_);
+        disk_file_manager_->GetLocalFiles().CreateDirectories(path);
         d_type_ = TantivyDataType::Keyword;
         std::string field_name =
             std::to_string(disk_file_manager_->GetFieldDataMeta().field_id);

--- a/internal/core/src/index/RTreeIndex.cpp
+++ b/internal/core/src/index/RTreeIndex.cpp
@@ -43,8 +43,6 @@
 #include "pb/common.pb.h"
 #include "pb/schema.pb.h"
 #include "storage/DataCodec.h"
-#include "storage/LocalChunkManager.h"
-#include "storage/LocalChunkManagerSingleton.h"
 #include "storage/ThreadPools.h"
 #include "storage/FileWriter.h"
 #include "storage/IndexEntryReader.h"
@@ -54,12 +52,6 @@
 namespace milvus::index {
 
 static constexpr size_t kMetaJsonSuffixLen = sizeof(".meta.json") - 1;
-
-static std::string
-GetRTreeTempPrefix() {
-    auto& lcm = milvus::storage::LocalChunkManagerSingleton::GetInstance();
-    return lcm.GetChunkManager()->GetRootPath() + "/rtree-index/";
-}
 
 // helper to check suffix
 static inline bool
@@ -76,9 +68,12 @@ RTreeIndex<T>::InitForBuildIndex(bool is_growing) {
     if (is_growing) {
         path_ = "";
     } else {
-        auto prefix = disk_file_manager_->GetIndexIdentifier();
-        path_ = GetRTreeTempPrefix() + prefix;
-        boost::filesystem::create_directories(path_);
+        path_ =
+            disk_file_manager_->GetLocalTempIndexObjectPrefix() + "rtree-index";
+        auto lease = disk_file_manager_->AcquireLocalDirWriteLease(path_);
+        auto path =
+            disk_file_manager_->GetLocalFiles().PathFromNativePath(path_);
+        disk_file_manager_->GetLocalFiles().CreateDirectories(path);
         index_file_path = path_ + "/index_file";  // base path (no ext)
         if (boost::filesystem::exists(index_file_path + ".bgi")) {
             ThrowInfo(IndexBuildError,
@@ -107,16 +102,6 @@ template <typename T>
 RTreeIndex<T>::~RTreeIndex() {
     // Free wrapper explicitly to ensure files not being used
     wrapper_.reset();
-
-    // Remove temporary directory if it exists
-    if (!path_.empty()) {
-        auto local_cm = storage::LocalChunkManagerSingleton::GetInstance()
-                            .GetChunkManager();
-        if (local_cm) {
-            LOG_INFO("rtree index remove path:{}", path_);
-            local_cm->RemoveDir(path_);
-        }
-    }
 }
 
 static std::string
@@ -143,7 +128,7 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
 
     // 1. Extract and load null_offset file(s) if present
     {
-        auto find_file = [&](const std::string& target) -> auto{
+        auto find_file = [&](const std::string& target) -> auto {
             return std::find_if(
                 files.begin(), files.end(), [&](const std::string& filename) {
                     return GetFileName(filename) == target;
@@ -696,7 +681,9 @@ RTreeIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
     bool has_null = reader.GetMeta<bool>("has_null");
 
     path_ = disk_file_manager_->GetLocalIndexObjectPrefix();
-    boost::filesystem::create_directories(path_);
+    auto lease = disk_file_manager_->AcquireLocalDirWriteLease(path_);
+    auto path = disk_file_manager_->GetLocalFiles().PathFromNativePath(path_);
+    disk_file_manager_->GetLocalFiles().CreateDirectories(path);
 
     std::vector<std::pair<std::string, std::string>> pairs;
     for (const auto& fn : file_names) {

--- a/internal/core/src/index/ScalarIndexSort.cpp
+++ b/internal/core/src/index/ScalarIndexSort.cpp
@@ -318,6 +318,11 @@ ScalarIndexSort<T>::SetupMmapFromData(
                          ? disk_file_manager_->GetLocalIndexObjectPrefix() +
                                STLSORT_INDEX_FILE_NAME
                          : MMAP_PATH_FOR_TEST;
+    auto lease =
+        disk_file_manager_ != nullptr
+            ? std::optional(disk_file_manager_->AcquireLocalDirWriteLease(
+                  disk_file_manager_->GetLocalIndexObjectPrefix()))
+            : std::nullopt;
     std::filesystem::create_directories(
         std::filesystem::path(mmap_filepath_).parent_path());
 
@@ -731,6 +736,11 @@ ScalarIndexSort<T>::LoadEntries(storage::IndexEntryReader& reader,
                              ? disk_file_manager_->GetLocalIndexObjectPrefix() +
                                    STLSORT_INDEX_FILE_NAME
                              : MMAP_PATH_FOR_TEST;
+        auto lease =
+            disk_file_manager_ != nullptr
+                ? std::optional(disk_file_manager_->AcquireLocalDirWriteLease(
+                      disk_file_manager_->GetLocalIndexObjectPrefix()))
+                : std::nullopt;
         std::filesystem::create_directories(
             std::filesystem::path(mmap_filepath_).parent_path());
 
@@ -824,6 +834,11 @@ ScalarIndexSort<T>::LoadEntries(storage::IndexEntryReader& reader,
                  ? disk_file_manager_->GetLocalIndexObjectPrefix()
                  : MMAP_PATH_FOR_TEST) +
             "stlsort-meta";
+        auto meta_lease =
+            disk_file_manager_ != nullptr
+                ? std::optional(disk_file_manager_->AcquireLocalDirWriteLease(
+                      disk_file_manager_->GetLocalIndexObjectPrefix()))
+                : std::nullopt;
         std::filesystem::create_directories(
             std::filesystem::path(mmap_meta_filepath_).parent_path());
 

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -53,10 +53,9 @@
 #include "marisa/base.h"
 #include "marisa/key.h"
 #include "marisa/keyset.h"
+#include "local/LegacyLocalChunkFiles.h"
 #include "nlohmann/json.hpp"
 #include "pb/common.pb.h"
-#include "storage/FileWriter.h"
-#include "storage/LocalChunkManager.h"
 #include "storage/IndexEntryReader.h"
 #include "storage/IndexEntryWriter.h"
 #include "storage/MemFileManagerImpl.h"
@@ -71,11 +70,20 @@ constexpr uint32_t MARISA_CSR_FORMAT_VERSION = 1;
 constexpr const char* MARISA_CSR_FORMAT_VERSION_META =
     "marisa_csr_format_version";
 
+local::FileSystem
+ResolveLocalFiles(const storage::FileManagerContext& context) {
+    if (context.local_files.has_value()) {
+        return *context.local_files;
+    }
+    return local::LegacyLocalChunkFiles();
+}
+
 }  // namespace
 
 StringIndexMarisa::StringIndexMarisa(
     const storage::FileManagerContext& file_manager_context)
-    : StringIndex(MARISA_TRIE) {
+    : StringIndex(MARISA_TRIE),
+      local_files_(ResolveLocalFiles(file_manager_context)) {
     if (file_manager_context.Valid()) {
         this->file_manager_ =
             std::make_shared<storage::MemFileManagerImpl>(file_manager_context);
@@ -289,25 +297,24 @@ StringIndexMarisa::LoadWithoutAssemble(const BinarySet& set,
                                        const Config& config) {
     auto uuid = boost::uuids::random_generator()();
     auto uuid_string = boost::uuids::to_string(uuid);
-    // TODO: change the mmap path of marisa index
-    auto file_name = std::string("/tmp/") + uuid_string;
+    auto trie_path = local::Path("tmp/marisa/" + uuid_string);
+    local_files_.CreateDirectories(local::Path("tmp/marisa"));
+    auto file_name = local_files_.ResolveNativePath(trie_path).string();
+    auto trie_file_raii = std::make_unique<MmapFileRAII>(file_name);
 
     auto index = set.GetByName(MARISA_TRIE_INDEX);
     auto len = index->size;
-    auto load_priority =
-        GetValueFromConfig<milvus::proto::common::LoadPriority>(
-            config, milvus::LOAD_PRIORITY)
-            .value_or(milvus::proto::common::LoadPriority::HIGH);
-
     {
-        auto file_writer = storage::FileWriter(
-            file_name, storage::io::GetPriorityFromLoadPriority(load_priority));
-        file_writer.Write(index->data.get(), len);
-        file_writer.Finish();
+        auto file_writer = local_files_.OpenForWrite(
+            trie_path, local::WriteOptions{.create = true, .truncate = true});
+        auto bytes = std::span(
+            reinterpret_cast<const std::byte*>(index->data.get()), len);
+        AssertInfo(file_writer.Write(bytes) == len,
+                   "short write of marisa trie");
+        file_writer.Sync();
     }
 
     if (config.contains(MMAP_FILE_PATH)) {
-        auto trie_file_raii = std::make_unique<MmapFileRAII>(file_name);
         trie_.mmap(file_name.c_str());
         mmap_file_raii_ = std::move(trie_file_raii);
     } else {
@@ -317,7 +324,7 @@ StringIndexMarisa::LoadWithoutAssemble(const BinarySet& set,
     }
 
     if (!config.contains(MMAP_FILE_PATH)) {
-        unlink(file_name.c_str());
+        local_files_.RemoveFile(trie_path);
     }
 
     auto str_ids = set.GetByName(MARISA_STR_IDS);
@@ -825,24 +832,17 @@ StringIndexMarisa::in_lexicographic_order() {
 void
 StringIndexMarisa::WriteEntries(storage::IndexEntryWriter* writer) {
     // Write trie data via temp file (marisa trie writes to file descriptor)
-    auto local_cm =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    std::string tmp_dir =
-        local_cm ? local_cm->GetRootPath() : std::string("/tmp");
-    std::error_code ec;
-    std::filesystem::create_directories(tmp_dir, ec);
-    AssertInfo(!ec,
-               "failed to create string index temp directory: {}, error: {}",
-               tmp_dir,
-               ec.message());
+    const auto tmp_dir = local::Path("tmp/marisa");
+    local_files_.CreateDirectories(tmp_dir);
     auto uuid = boost::uuids::random_generator()();
     auto uuid_string = boost::uuids::to_string(uuid);
-    auto file = tmp_dir + "/" + uuid_string;
+    auto file_path = local::Path("tmp/marisa/" + uuid_string);
+    auto file = local_files_.ResolveNativePath(file_path);
 
     auto fd = open(file.c_str(),
                    O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC,
                    S_IRUSR | S_IWUSR | S_IXUSR);
-    AssertInfo(fd != -1, "open file failed: {}", file);
+    AssertInfo(fd != -1, "open file failed: {}", file.string());
     auto close_fd = folly::makeGuard([fd]() { close(fd); });
 
     // Immediately unlink the file so it will be deleted when fd is closed,
@@ -873,38 +873,29 @@ StringIndexMarisa::WriteEntries(storage::IndexEntryWriter* writer) {
 void
 StringIndexMarisa::LoadEntries(storage::IndexEntryReader& reader,
                                const Config& config) {
-    auto local_cm =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    std::string tmp_dir =
-        local_cm ? local_cm->GetRootPath() : std::string("/tmp");
-    std::error_code ec;
-    std::filesystem::create_directories(tmp_dir, ec);
-    AssertInfo(!ec,
-               "failed to create string index temp directory: {}, error: {}",
-               tmp_dir,
-               ec.message());
+    const auto tmp_dir = local::Path("tmp/marisa");
+    local_files_.CreateDirectories(tmp_dir);
     auto uuid = boost::uuids::random_generator()();
     auto uuid_string = boost::uuids::to_string(uuid);
-    auto file_name = tmp_dir + "/" + uuid_string;
+    auto trie_path = local::Path("tmp/marisa/" + uuid_string);
+    auto file_name = local_files_.ResolveNativePath(trie_path).string();
+    auto trie_file_raii = std::make_unique<MmapFileRAII>(file_name);
 
-    auto load_priority =
-        GetValueFromConfig<milvus::proto::common::LoadPriority>(
-            config, milvus::LOAD_PRIORITY)
-            .value_or(milvus::proto::common::LoadPriority::HIGH);
-
-    // Stream trie entry directly to temp file (no full-size temp buffer)
+    // Stream trie entry directly to a rooted temp file.
     {
-        auto file_writer = storage::FileWriter(
-            file_name, storage::io::GetPriorityFromLoadPriority(load_priority));
-        reader.ReadEntryStream(MARISA_TRIE_INDEX,
-                               [&](const uint8_t* data, size_t len) {
-                                   file_writer.Write(data, len);
-                               });
-        file_writer.Finish();
+        auto file_writer = local_files_.OpenForWrite(
+            trie_path, local::WriteOptions{.create = true, .truncate = true});
+        reader.ReadEntryStream(
+            MARISA_TRIE_INDEX, [&](const uint8_t* data, size_t len) {
+                auto bytes =
+                    std::span(reinterpret_cast<const std::byte*>(data), len);
+                AssertInfo(file_writer.Write(bytes) == len,
+                           "short write of marisa trie");
+            });
+        file_writer.Sync();
     }
 
     if (config.contains(MMAP_FILE_PATH)) {
-        auto trie_file_raii = std::make_unique<MmapFileRAII>(file_name);
         trie_.mmap(file_name.c_str());
         mmap_file_raii_ = std::move(trie_file_raii);
     } else {
@@ -914,7 +905,7 @@ StringIndexMarisa::LoadEntries(storage::IndexEntryReader& reader,
     }
 
     if (!config.contains(MMAP_FILE_PATH)) {
-        unlink(file_name.c_str());
+        local_files_.RemoveFile(trie_path);
     }
 
     // Stream str_ids entry
@@ -923,24 +914,28 @@ StringIndexMarisa::LoadEntries(storage::IndexEntryReader& reader,
         MARISA_STR_IDS, str_ids_bytes, sizeof(int64_t));
     if (config.contains(MMAP_FILE_PATH)) {
         // mmap path: stream to disk file, then mmap
-        auto str_ids_path = file_name + ".str_ids";
+        auto str_ids_local_path =
+            local::Path(std::string(trie_path.String()) + ".str_ids");
+        auto str_ids_path =
+            local_files_.ResolveNativePath(str_ids_local_path).string();
+        auto str_ids_file_raii = std::make_unique<MmapFileRAII>(str_ids_path);
         {
-            auto fw = storage::FileWriter(
-                str_ids_path,
-                storage::io::GetPriorityFromLoadPriority(load_priority));
+            auto fw = local_files_.OpenForWrite(
+                str_ids_local_path,
+                local::WriteOptions{.create = true, .truncate = true});
             size_t written = 0;
-            reader.ReadEntryStream(MARISA_STR_IDS,
-                                   [&](const uint8_t* d, size_t len) {
-                                       fw.Write(d, len);
-                                       written += len;
-                                   });
+            reader.ReadEntryStream(
+                MARISA_STR_IDS, [&](const uint8_t* d, size_t len) {
+                    auto bytes =
+                        std::span(reinterpret_cast<const std::byte*>(d), len);
+                    written += fw.Write(bytes);
+                });
             AssertInfo(written == str_ids_bytes,
                        "str_ids stream read size mismatch: got {}, expected {}",
                        written,
                        str_ids_bytes);
-            fw.Finish();
+            fw.Sync();
         }
-        auto str_ids_file_raii = std::make_unique<MmapFileRAII>(str_ids_path);
         auto str_ids_file = File::Open(str_ids_path, O_RDONLY);
         auto* mapped = mmap(NULL,
                             str_ids_bytes,
@@ -1037,31 +1032,36 @@ StringIndexMarisa::LoadEntries(storage::IndexEntryReader& reader,
 
         if (config.contains(MMAP_FILE_PATH)) {
             // mmap path: stream csr_index + csr_offsets to disk, then mmap
-            auto csr_path = file_name + ".csr";
+            auto csr_local_path =
+                local::Path(std::string(trie_path.String()) + ".csr");
+            auto csr_path =
+                local_files_.ResolveNativePath(csr_local_path).string();
+            auto csr_file_raii = std::make_unique<MmapFileRAII>(csr_path);
 
             {
-                auto fw = storage::FileWriter(
-                    csr_path,
-                    storage::io::GetPriorityFromLoadPriority(load_priority));
+                auto fw = local_files_.OpenForWrite(
+                    csr_local_path,
+                    local::WriteOptions{.create = true, .truncate = true});
                 size_t written = 0;
-                reader.ReadEntryStream(MARISA_CSR_INDEX,
-                                       [&](const uint8_t* d, size_t len) {
-                                           fw.Write(d, len);
-                                           written += len;
-                                       });
-                reader.ReadEntryStream(MARISA_CSR_OFFSETS,
-                                       [&](const uint8_t* d, size_t len) {
-                                           fw.Write(d, len);
-                                           written += len;
-                                       });
+                reader.ReadEntryStream(
+                    MARISA_CSR_INDEX, [&](const uint8_t* d, size_t len) {
+                        auto bytes = std::span(
+                            reinterpret_cast<const std::byte*>(d), len);
+                        written += fw.Write(bytes);
+                    });
+                reader.ReadEntryStream(
+                    MARISA_CSR_OFFSETS, [&](const uint8_t* d, size_t len) {
+                        auto bytes = std::span(
+                            reinterpret_cast<const std::byte*>(d), len);
+                        written += fw.Write(bytes);
+                    });
                 AssertInfo(written == idx_bytes + off_bytes,
                            "CSR stream read size mismatch: got {}, expected {}",
                            written,
                            idx_bytes + off_bytes);
-                fw.Finish();
+                fw.Sync();
             }
 
-            auto csr_file_raii = std::make_unique<MmapFileRAII>(csr_path);
             csr_mmap_size_ = idx_bytes + off_bytes;
             auto csr_file = File::Open(csr_path, O_RDONLY);
             auto* mapped = mmap(NULL,

--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -22,6 +22,8 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <optional>
+#include "local/FileSystem.h"
 #include "storage/MemFileManagerImpl.h"
 
 namespace milvus::index {
@@ -158,6 +160,7 @@ class StringIndexMarisa : public StringIndex {
                 const Config& config) override;
 
  private:
+    local::FileSystem local_files_;
     Config config_;
     marisa::Trie trie_;
 

--- a/internal/core/src/index/StringIndexTest.cpp
+++ b/internal/core/src/index/StringIndexTest.cpp
@@ -37,7 +37,7 @@
 #include "pb/common.pb.h"
 #include "pb/schema.pb.h"
 #include "storage/ChunkManager.h"
-#include "storage/LocalChunkManagerSingleton.h"
+#include "local/FileSystem.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "test_utils/AssertUtils.h"
@@ -61,7 +61,12 @@ CreateStringTestFileManagerContext(const std::string& root_path) {
     storage::FieldDataMeta field_meta{1, 2, 3, 101};
     field_meta.field_schema.set_data_type(proto::schema::DataType::VarChar);
     storage::IndexMeta index_meta{3, 101, 1000, 10000};
-    storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager, fs);
+    storage::FileManagerContext ctx(
+        field_meta,
+        index_meta,
+        chunk_manager,
+        fs,
+        local::FileSystem::Open(std::filesystem::absolute(root_path)));
     return ctx;
 }
 
@@ -443,11 +448,8 @@ TEST_F(StringIndexMarisaTest, UnifiedCodecRecreatesMissingLocalChunkDir) {
 
     index->Build(nb, strings.data());
 
-    auto local_cm =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    ASSERT_NE(local_cm, nullptr);
-    auto local_root = local_cm->GetRootPath();
-    ASSERT_FALSE(local_root.empty());
+    auto local_root = std::filesystem::absolute(
+        TestRemotePath + "string_marisa_missing_local_chunk/");
 
     std::error_code ec;
     std::filesystem::remove_all(local_root, ec);

--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -90,7 +90,9 @@ TextMatchIndex::TextMatchIndex(const storage::FileManagerContext& ctx,
 
     path_ = disk_file_manager_->GetLocalTempTextIndexPrefix();
 
-    boost::filesystem::create_directories(path_);
+    auto lease = disk_file_manager_->AcquireLocalDirWriteLease(path_);
+    auto path = disk_file_manager_->GetLocalFiles().PathFromNativePath(path_);
+    disk_file_manager_->GetLocalFiles().CreateDirectories(path);
     d_type_ = TantivyDataType::Text;
     std::string field_name =
         std::to_string(disk_file_manager_->GetFieldDataMeta().field_id);

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -24,6 +24,7 @@
 #include <exception>
 #include <iosfwd>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 
@@ -52,8 +53,7 @@
 #include "opentelemetry/trace/span.h"
 #include "opentelemetry/trace/tracer.h"
 #include "pb/common.pb.h"
-#include "storage/LocalChunkManager.h"
-#include "storage/LocalChunkManagerSingleton.h"
+#include "local/FileSystem.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
@@ -94,36 +94,37 @@ class DiskEmptyVectorIterator : public knowhere::IndexNode::iterator {
     }
 };
 
-template <typename LocalChunkManagerPtr>
 std::optional<std::vector<size_t>>
-ReadDiskEmbListOffsets(const LocalChunkManagerPtr& local_chunk_manager,
-                       const std::string& offsets_path) {
-    if (!local_chunk_manager->Exist(offsets_path)) {
+ReadDiskEmbListOffsets(const local::FileSystem& files,
+                       const local::Path& offsets_path) {
+    if (!files.Exists(offsets_path)) {
         return std::nullopt;
     }
 
-    auto file_size = local_chunk_manager->Size(offsets_path);
+    auto file = files.OpenForRead(offsets_path);
+    auto file_size = file.Size();
     AssertInfo(file_size >= sizeof(size_t),
                "embedding list offsets file is too small");
     size_t num_offsets = 0;
-    local_chunk_manager->Read(offsets_path, 0, &num_offsets, sizeof(size_t));
+    auto count_bytes = std::as_writable_bytes(std::span(&num_offsets, 1));
+    AssertInfo(file.ReadAt(0, count_bytes) == count_bytes.size(),
+               "short read of embedding list offsets count");
     AssertInfo(num_offsets > 0, "embedding list offsets count is invalid");
     AssertInfo(file_size >= sizeof(size_t) + num_offsets * sizeof(size_t),
                "embedding list offsets file payload is too small");
 
     std::vector<size_t> offsets(num_offsets);
-    local_chunk_manager->Read(offsets_path,
-                              sizeof(size_t),
-                              offsets.data(),
-                              num_offsets * sizeof(size_t));
+    auto offsets_bytes = std::as_writable_bytes(std::span(offsets));
+    AssertInfo(
+        file.ReadAt(sizeof(size_t), offsets_bytes) == offsets_bytes.size(),
+        "short read of embedding list offsets payload");
     AssertInfo(offsets.front() == 0, "embedding list offsets must start at 0");
     return offsets;
 }
 
-template <typename LocalChunkManagerPtr>
 void
-WriteDiskEmptyEmbListOffsets(const LocalChunkManagerPtr& local_chunk_manager,
-                             const std::string& empty_offsets_path,
+WriteDiskEmptyEmbListOffsets(const local::FileSystem& files,
+                             const local::Path& empty_offsets_path,
                              int64_t dim,
                              const std::vector<size_t>& offsets) {
     AssertInfo(dim > 0, "empty emb_list dim is invalid");
@@ -132,45 +133,45 @@ WriteDiskEmptyEmbListOffsets(const LocalChunkManagerPtr& local_chunk_manager,
     AssertInfo(offsets.back() == 0,
                "empty emb_list offsets must have no flattened vectors");
 
-    if (!local_chunk_manager->Exist(empty_offsets_path)) {
-        local_chunk_manager->CreateFile(empty_offsets_path);
-    }
-
+    auto file = files.OpenForWrite(
+        empty_offsets_path,
+        local::WriteOptions{.create = true, .truncate = true});
     auto count = ToValidDataCount(offsets.size());
-    int64_t write_pos = 0;
-    local_chunk_manager->Write(
-        empty_offsets_path, write_pos, &dim, sizeof(int64_t));
-    write_pos += sizeof(int64_t);
-    local_chunk_manager->Write(
-        empty_offsets_path, write_pos, &count, sizeof(uint64_t));
-    write_pos += sizeof(uint64_t);
-    local_chunk_manager->Write(empty_offsets_path,
-                               write_pos,
-                               const_cast<size_t*>(offsets.data()),
-                               offsets.size() * sizeof(size_t));
+    auto dim_bytes = std::as_bytes(std::span(&dim, 1));
+    auto count_bytes = std::as_bytes(std::span(&count, 1));
+    auto offsets_bytes = std::as_bytes(std::span(offsets));
+    AssertInfo(file.WriteAt(0, dim_bytes) == dim_bytes.size(),
+               "short write of empty embedding list dimension");
+    AssertInfo(file.WriteAt(sizeof(int64_t), count_bytes) == count_bytes.size(),
+               "short write of empty embedding list offsets count");
+    AssertInfo(file.WriteAt(sizeof(int64_t) + sizeof(uint64_t),
+                            offsets_bytes) == offsets_bytes.size(),
+               "short write of empty embedding list offsets payload");
 }
 
-template <typename LocalChunkManagerPtr>
 std::optional<EmptyEmbListState>
-ReadDiskEmptyEmbListOffsets(const LocalChunkManagerPtr& local_chunk_manager,
-                            const std::string& empty_offsets_path) {
-    if (!local_chunk_manager->Exist(empty_offsets_path)) {
+ReadDiskEmptyEmbListOffsets(const local::FileSystem& files,
+                            const local::Path& empty_offsets_path) {
+    if (!files.Exists(empty_offsets_path)) {
         return std::nullopt;
     }
 
-    auto file_size = local_chunk_manager->Size(empty_offsets_path);
+    auto file = files.OpenForRead(empty_offsets_path);
+    auto file_size = file.Size();
     AssertInfo(file_size >= sizeof(int64_t) + sizeof(uint64_t),
                "empty emb_list offsets file is too small");
 
-    int64_t read_pos = 0;
+    uint64_t read_pos = 0;
     int64_t dim = 0;
-    local_chunk_manager->Read(
-        empty_offsets_path, read_pos, &dim, sizeof(int64_t));
+    auto dim_bytes = std::as_writable_bytes(std::span(&dim, 1));
+    AssertInfo(file.ReadAt(read_pos, dim_bytes) == dim_bytes.size(),
+               "short read of empty embedding list dimension");
     read_pos += sizeof(int64_t);
 
     uint64_t wire_count = 0;
-    local_chunk_manager->Read(
-        empty_offsets_path, read_pos, &wire_count, sizeof(uint64_t));
+    auto count_bytes = std::as_writable_bytes(std::span(&wire_count, 1));
+    AssertInfo(file.ReadAt(read_pos, count_bytes) == count_bytes.size(),
+               "short read of empty embedding list offsets count");
     read_pos += sizeof(uint64_t);
 
     auto count = FromValidDataCount(wire_count);
@@ -179,8 +180,9 @@ ReadDiskEmptyEmbListOffsets(const LocalChunkManagerPtr& local_chunk_manager,
                "empty emb_list offsets payload is too small");
 
     std::vector<size_t> offsets(count);
-    local_chunk_manager->Read(
-        empty_offsets_path, read_pos, offsets.data(), count * sizeof(size_t));
+    auto offsets_bytes = std::as_writable_bytes(std::span(offsets));
+    AssertInfo(file.ReadAt(read_pos, offsets_bytes) == offsets_bytes.size(),
+               "short read of empty embedding list offsets payload");
     AssertInfo(offsets.front() == 0, "empty emb_list offsets must start at 0");
     AssertInfo(offsets.back() == 0,
                "empty emb_list offsets must have no flattened vectors");
@@ -202,55 +204,56 @@ GetEmbListNumOffsets(const DatasetPtr& dataset,
     return static_cast<size_t>(num_queries) + 1;
 }
 
-template <typename LocalChunkManagerPtr>
 DiskValidData
-ReadDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
-                  const std::string& valid_data_path) {
+ReadDiskValidData(const local::FileSystem& files,
+                  const local::Path& valid_data_path) {
     DiskValidData valid_data;
-    if (!local_chunk_manager->Exist(valid_data_path)) {
+    if (!files.Exists(valid_data_path)) {
         return valid_data;
     }
 
     valid_data.found = true;
-    auto file_size = local_chunk_manager->Size(valid_data_path);
+    auto file = files.OpenForRead(valid_data_path);
+    auto file_size = file.Size();
     AssertInfo(file_size >= sizeof(uint64_t),
                "nullable vector disk valid_data file is too small");
     uint64_t wire_count = 0;
-    local_chunk_manager->Read(
-        valid_data_path, 0, &wire_count, sizeof(uint64_t));
+    auto count_bytes = std::as_writable_bytes(std::span(&wire_count, 1));
+    AssertInfo(file.ReadAt(0, count_bytes) == count_bytes.size(),
+               "short read of nullable vector count");
     valid_data.total_count = FromValidDataCount(wire_count);
     valid_data.bitmap.resize(GetValidDataBitmapSize(valid_data.total_count));
     AssertInfo(file_size >= sizeof(uint64_t) + valid_data.bitmap.size(),
                "nullable vector disk valid_data bitmap file is too small");
     if (!valid_data.bitmap.empty()) {
-        local_chunk_manager->Read(valid_data_path,
-                                  sizeof(uint64_t),
-                                  valid_data.bitmap.data(),
-                                  valid_data.bitmap.size());
+        auto bitmap_bytes =
+            std::as_writable_bytes(std::span(valid_data.bitmap));
+        AssertInfo(
+            file.ReadAt(sizeof(uint64_t), bitmap_bytes) == bitmap_bytes.size(),
+            "short read of nullable vector bitmap");
     }
     valid_data.valid_count =
         CountValidDataBitmap(valid_data.total_count, valid_data.bitmap.data());
     return valid_data;
 }
 
-template <typename LocalChunkManagerPtr>
 void
-WriteDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
-                   const std::string& valid_data_path,
+WriteDiskValidData(const local::FileSystem& files,
+                   const local::Path& valid_data_path,
                    const OffsetMapping& offset_mapping) {
     auto total_count = static_cast<size_t>(offset_mapping.GetTotalCount());
     auto wire_count = ToValidDataCount(total_count);
     auto packed_data = PackValidDataBitmap(offset_mapping);
-    if (!local_chunk_manager->Exist(valid_data_path)) {
-        local_chunk_manager->CreateFile(valid_data_path);
-    }
-    local_chunk_manager->Write(
-        valid_data_path, 0, &wire_count, sizeof(uint64_t));
+    auto file = files.OpenForWrite(
+        valid_data_path, local::WriteOptions{.create = true, .truncate = true});
+    auto count_bytes = std::as_bytes(std::span(&wire_count, 1));
+    AssertInfo(file.WriteAt(0, count_bytes) == count_bytes.size(),
+               "short write of nullable vector count");
     if (!packed_data.empty()) {
-        local_chunk_manager->Write(valid_data_path,
-                                   sizeof(uint64_t),
-                                   packed_data.data(),
-                                   packed_data.size());
+        auto bitmap_bytes = std::as_bytes(std::span(packed_data));
+        AssertInfo(
+            file.WriteAt(sizeof(uint64_t), bitmap_bytes) == bitmap_bytes.size(),
+            "short write of nullable vector bitmap");
     }
 }
 
@@ -268,18 +271,21 @@ VectorDiskAnnIndex<T>::VectorDiskAnnIndex(
     file_manager_ =
         std::make_shared<storage::DiskFileManagerImpl>(file_manager_context);
     AssertInfo(file_manager_ != nullptr, "create file manager failed!");
-    auto local_chunk_manager =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    const auto& local_files = file_manager_->GetLocalFiles();
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
+    auto local_index_path =
+        local_files.PathFromNativePath(local_index_path_prefix);
+    auto index_lease =
+        file_manager_->AcquireLocalDirWriteLease(local_index_path_prefix);
 
     // As we have guarded dup-load in QueryNode,
     // this assertion failed only if the Milvus rebooted in the same pod,
     // need to remove these files then re-load the segment
-    if (local_chunk_manager->Exist(local_index_path_prefix)) {
-        local_chunk_manager->RemoveDir(local_index_path_prefix);
+    if (local_files.Exists(local_index_path)) {
+        local_files.RemoveAll(local_index_path);
     }
     CheckCompatible(version);
-    local_chunk_manager->CreateDir(local_index_path_prefix);
+    local_files.CreateDirectories(local_index_path);
     auto diskann_index_pack =
         knowhere::Pack(std::shared_ptr<milvus::FileManager>(file_manager_));
     auto get_index_obj = knowhere::IndexFactory::Instance().Create<T>(
@@ -332,19 +338,19 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
         read_file_span->End();
     }
 
-    auto local_chunk_manager =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    const auto& local_files = file_manager_->GetLocalFiles();
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
 
     auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-    auto disk_valid_data =
-        ReadDiskValidData(local_chunk_manager, valid_data_path);
+    auto disk_valid_data = ReadDiskValidData(
+        local_files, local_files.PathFromNativePath(valid_data_path));
     bool all_null_nullable = disk_valid_data.found &&
                              disk_valid_data.total_count > 0 &&
                              disk_valid_data.valid_count == 0;
     auto empty_emb_list_state = ReadDiskEmptyEmbListOffsets(
-        local_chunk_manager,
-        local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY);
+        local_files,
+        local_files.PathFromNativePath(local_index_path_prefix + "/" +
+                                       EMPTY_EMB_LIST_OFFSET_KEY));
     if (!all_null_nullable && !empty_emb_list_state.has_value()) {
         // start engine load index span
         auto span_load_engine =
@@ -401,8 +407,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     LOG_INFO("start build disk index, build_id: {}",
              config.value("build_id", "unknown"));
 
-    auto local_chunk_manager =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    const auto& local_files = file_manager_->GetLocalFiles();
     knowhere::Json build_config;
     build_config.update(config);
 
@@ -431,8 +436,8 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
         file_manager_->CacheRawDataToDisk<T>(config_with_emb_list);
     build_config[DISK_ANN_RAW_DATA_PATH] = local_data_path;
 
-    auto disk_valid_data =
-        ReadDiskValidData(local_chunk_manager, valid_data_path);
+    auto disk_valid_data = ReadDiskValidData(
+        local_files, local_files.PathFromNativePath(valid_data_path));
     if (disk_valid_data.found) {
         BuildValidDataFromBitmap(
             this, disk_valid_data.total_count, disk_valid_data.bitmap.data());
@@ -451,8 +456,8 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
 
     // For VECTOR_ARRAY, verify offsets file exists and pass its path to build_config
     if (is_embedding_list) {
-        auto offsets =
-            ReadDiskEmbListOffsets(local_chunk_manager, offsets_path);
+        auto offsets = ReadDiskEmbListOffsets(
+            local_files, local_files.PathFromNativePath(offsets_path));
         if (!offsets.has_value()) {
             ThrowInfo(ErrorCode::UnexpectedError,
                       fmt::format("Embedding list offsets file not found: {}",
@@ -466,12 +471,14 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
 
             auto empty_offsets_path =
                 local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY;
-            WriteDiskEmptyEmbListOffsets(local_chunk_manager,
-                                         empty_offsets_path,
-                                         GetDim(),
-                                         offsets.value());
+            WriteDiskEmptyEmbListOffsets(
+                local_files,
+                local_files.PathFromNativePath(empty_offsets_path),
+                GetDim(),
+                offsets.value());
             file_manager_->AddFile(empty_offsets_path);
-            if (local_chunk_manager->Exist(valid_data_path)) {
+            if (local_files.Exists(
+                    local_files.PathFromNativePath(valid_data_path))) {
                 file_manager_->AddFile(valid_data_path);
             }
             file_manager_->RemoveRawDataFiles();
@@ -516,7 +523,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
                   KnowhereStatusString(stat));
 
     // Add valid_data file to index if it was created (nullable vector field)
-    if (local_chunk_manager->Exist(valid_data_path)) {
+    if (local_files.Exists(local_files.PathFromNativePath(valid_data_path))) {
         file_manager_->AddFile(valid_data_path);
     }
 
@@ -530,8 +537,7 @@ template <typename T>
 void
 VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
                                         const Config& config) {
-    auto local_chunk_manager =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    const auto& local_files = file_manager_->GetLocalFiles();
     knowhere::Json build_config;
     build_config.update(config);
 
@@ -554,8 +560,9 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     if (HasValidData() && GetValidCount() == 0 &&
         offset_mapping.GetTotalCount() > 0) {
         auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-        WriteDiskValidData(
-            local_chunk_manager, valid_data_path, offset_mapping);
+        WriteDiskValidData(local_files,
+                           local_files.PathFromNativePath(valid_data_path),
+                           offset_mapping);
         file_manager_->AddFile(valid_data_path);
         auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
         if (dim.has_value()) {
@@ -577,10 +584,11 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
             std::vector<size_t>(offsets, offsets + num_offsets);
         auto empty_offsets_path =
             local_index_path_prefix + "/" + EMPTY_EMB_LIST_OFFSET_KEY;
-        WriteDiskEmptyEmbListOffsets(local_chunk_manager,
-                                     empty_offsets_path,
-                                     dataset->GetDim(),
-                                     empty_offsets);
+        WriteDiskEmptyEmbListOffsets(
+            local_files,
+            local_files.PathFromNativePath(empty_offsets_path),
+            dataset->GetDim(),
+            empty_offsets);
         file_manager_->AddFile(empty_offsets_path);
         SetDim(dataset->GetDim());
         empty_emb_list_offsets_ = std::move(empty_offsets);
@@ -597,22 +605,28 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         build_config[DISK_ANN_THREADS_NUM] =
             std::atoi(num_threads.value().c_str());
     }
-    if (!local_chunk_manager->Exist(local_data_path)) {
-        local_chunk_manager->CreateFile(local_data_path);
-    }
-
-    int64_t offset = 0;
+    auto local_data_file = local_files.OpenForWrite(
+        local_files.PathFromNativePath(local_data_path),
+        local::WriteOptions{.create = true, .truncate = true});
+    uint64_t offset = 0;
     auto num = uint32_t(milvus::GetDatasetRows(dataset));
-    local_chunk_manager->Write(local_data_path, offset, &num, sizeof(num));
+    auto num_bytes = std::as_bytes(std::span(&num, 1));
+    AssertInfo(local_data_file.WriteAt(offset, num_bytes) == num_bytes.size(),
+               "short write of disk index row count");
     offset += sizeof(num);
 
     auto dim = uint32_t(milvus::GetDatasetDim(dataset));
-    local_chunk_manager->Write(local_data_path, offset, &dim, sizeof(dim));
+    auto dim_bytes = std::as_bytes(std::span(&dim, 1));
+    AssertInfo(local_data_file.WriteAt(offset, dim_bytes) == dim_bytes.size(),
+               "short write of disk index dimension");
     offset += sizeof(dim);
 
     size_t data_size = static_cast<size_t>(num) * milvus::GetVecRowSize<T>(dim);
-    auto raw_data = const_cast<void*>(milvus::GetDatasetTensor(dataset));
-    local_chunk_manager->Write(local_data_path, offset, raw_data, data_size);
+    auto raw_data =
+        static_cast<const std::byte*>(milvus::GetDatasetTensor(dataset));
+    auto data_bytes = std::span(raw_data, data_size);
+    AssertInfo(local_data_file.WriteAt(offset, data_bytes) == data_bytes.size(),
+               "short write of disk index vector data");
 
     // For VECTOR_ARRAY, write offsets to a separate file and pass the path to knowhere
     if (elem_type_ != DataType::NONE) {
@@ -625,7 +639,9 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
 
         // Write offsets to disk file (use same path convention as Build method)
         std::string offsets_path = local_raw_data_prefix + "offset";
-        local_chunk_manager->CreateFile(offsets_path);
+        auto offsets_file = local_files.OpenForWrite(
+            local_files.PathFromNativePath(offsets_path),
+            local::WriteOptions{.create = true, .truncate = true});
 
         size_t total_vectors =
             static_cast<size_t>(milvus::GetDatasetRows(dataset));
@@ -634,16 +650,17 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
 
         // Write offsets to file
         // Format: [num_offsets (size_t)][offsets_data (size_t array)]
-        int64_t write_pos = 0;
-        local_chunk_manager->Write(
-            offsets_path, write_pos, &num_offsets, sizeof(size_t));
+        uint64_t write_pos = 0;
+        auto count_bytes = std::as_bytes(std::span(&num_offsets, 1));
+        AssertInfo(
+            offsets_file.WriteAt(write_pos, count_bytes) == count_bytes.size(),
+            "short write of embedding list offsets count");
         write_pos += sizeof(size_t);
 
-        local_chunk_manager->Write(
-            offsets_path,
-            write_pos,
-            const_cast<void*>(static_cast<const void*>(offsets)),
-            num_offsets * sizeof(size_t));
+        auto offsets_bytes = std::as_bytes(std::span(offsets, num_offsets));
+        AssertInfo(offsets_file.WriteAt(write_pos, offsets_bytes) ==
+                       offsets_bytes.size(),
+                   "short write of embedding list offsets payload");
 
         build_config[EMB_LIST_OFFSETS_PATH] = offsets_path;
     }
@@ -656,8 +673,9 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
 
     if (HasValidData()) {
         auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-        WriteDiskValidData(
-            local_chunk_manager, valid_data_path, offset_mapping);
+        WriteDiskValidData(local_files,
+                           local_files.PathFromNativePath(valid_data_path),
+                           offset_mapping);
         file_manager_->AddFile(valid_data_path);
     }
 

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <initializer_list>
 #include <iosfwd>
+#include <span>
 #include <unordered_set>
 #include <variant>
 #include "segcore/default_fs.h"
@@ -44,6 +45,7 @@
 #include "index/json_stats/JsonKeyStats.h"
 #include "index/json_stats/bson_builder.h"
 #include "index/json_stats/parquet_writer.h"
+#include "local/FileSystem.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/metadata.h"
@@ -63,8 +65,6 @@
 #include "segcore/Utils.h"
 #include "storage/DiskFileManagerImpl.h"
 #include "storage/FileManager.h"
-#include "storage/LocalChunkManager.h"
-#include "storage/LocalChunkManagerSingleton.h"
 #include "storage/MemFileManagerImpl.h"
 #include "storage/MmapManager.h"
 #include "storage/Util.h"
@@ -223,17 +223,23 @@ JsonKeyStats::JsonKeyStats(const storage::FileManagerContext& ctx,
         LOG_INFO("init local shared bson index with path: {} for segment {}",
                  shared_key_index_path,
                  segment_id_);
-        boost::filesystem::create_directories(shared_key_index_path);
+        auto shared_key_path =
+            disk_file_manager_->GetLocalFiles().PathFromNativePath(
+                shared_key_index_path);
+        disk_file_manager_->GetLocalFiles().CreateDirectories(shared_key_path);
         bson_inverted_index_ = std::make_shared<BsonInvertedIndex>(
             shared_key_index_path, field_id_, ctx, tantivy_index_version);
     }
+
+    auto lease = disk_file_manager_->AcquireLocalDirWriteLease(path_);
+    auto local_path =
+        disk_file_manager_->GetLocalFiles().PathFromNativePath(path_);
+    disk_file_manager_->GetLocalFiles().CreateDirectories(local_path);
 }
 
 JsonKeyStats::~JsonKeyStats() {
     bson_inverted_index_.reset();
     bson_index_cache_slot_.reset();
-    boost::filesystem::remove_all(path_);
-    LOG_INFO("remove json key stats with path: {}", path_);
 }
 
 void
@@ -767,11 +773,13 @@ JsonKeyStats::WriteMetaFile() {
     auto meta_content = json_stats_meta_.Serialize();
     auto meta_file_path = GetMetaFilePath();
 
-    auto local_chunk_manager =
-        milvus::storage::LocalChunkManagerSingleton::GetInstance()
-            .GetChunkManager();
-    local_chunk_manager->Write(
-        meta_file_path, meta_content.data(), meta_content.size());
+    const auto& local_files = disk_file_manager_->GetLocalFiles();
+    auto meta_file = local_files.OpenForWrite(
+        local_files.PathFromNativePath(meta_file_path),
+        local::WriteOptions{.create = true, .truncate = true});
+    auto meta_bytes = std::as_bytes(std::span(meta_content));
+    AssertInfo(meta_file.Write(meta_bytes) == meta_bytes.size(),
+               "short write of json stats meta file");
 
     meta_file_size_ = meta_content.size();
     LOG_INFO("write meta file: {} with size {} for segment {} for field {}",
@@ -788,14 +796,15 @@ JsonKeyStats::LoadMetaFile(const std::string& local_meta_file_path) {
              segment_id_,
              field_id_);
 
-    auto local_chunk_manager =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-
-    auto file_size = local_chunk_manager->Size(local_meta_file_path);
+    const auto& local_files = disk_file_manager_->GetLocalFiles();
+    auto file = local_files.OpenForRead(
+        local_files.PathFromNativePath(local_meta_file_path));
+    auto file_size = file.Size();
     std::string meta_content;
     meta_content.resize(file_size);
-    local_chunk_manager->Read(
-        local_meta_file_path, meta_content.data(), file_size);
+    auto meta_bytes = std::as_writable_bytes(std::span(meta_content));
+    AssertInfo(file.ReadAt(0, meta_bytes) == meta_bytes.size(),
+               "short read of json stats meta file");
 
     key_field_map_ = JsonStatsMeta::DeserializeToKeyFieldMap(meta_content);
 
@@ -1334,10 +1343,7 @@ JsonKeyStats::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     auto enable_mmap =
         GetValueFromConfig<bool>(config, ENABLE_MMAP).value_or(false);
     if (enable_mmap) {
-        mmap_filepath_ =
-            milvus::storage::LocalChunkManagerSingleton::GetInstance()
-                .GetChunkManager()
-                ->GetRootPath();
+        mmap_filepath_ = path_;
         LOG_INFO("load json stats for segment {} with mmap local file path: {}",
                  segment_id_,
                  mmap_filepath_);

--- a/internal/core/src/index/json_stats/bson_inverted.cpp
+++ b/internal/core/src/index/json_stats/bson_inverted.cpp
@@ -28,8 +28,6 @@
 #include "index/json_stats/bson_inverted.h"
 #include "log/Log.h"
 #include "storage/DiskFileManagerImpl.h"
-#include "storage/LocalChunkManager.h"
-#include "storage/LocalChunkManagerSingleton.h"
 #include "storage/Types.h"
 
 namespace milvus::index {
@@ -44,6 +42,10 @@ BsonInvertedIndex::BsonInvertedIndex(const std::string& path,
     disk_file_manager_ =
         std::make_shared<milvus::storage::DiskFileManagerImpl>(ctx);
     path_ = path;
+    auto lease = disk_file_manager_->AcquireLocalDirWriteLease(path_);
+    auto local_path =
+        disk_file_manager_->GetLocalFiles().PathFromNativePath(path_);
+    disk_file_manager_->GetLocalFiles().CreateDirectories(local_path);
     LOG_INFO("bson inverted index build path:{}", path_);
 }
 
@@ -59,13 +61,8 @@ BsonInvertedIndex::BsonInvertedIndex(
 BsonInvertedIndex::~BsonInvertedIndex() {
     if (wrapper_) {
         wrapper_->free();
+        wrapper_.reset();
     }
-    auto local_chunk_manager =
-        milvus::storage::LocalChunkManagerSingleton::GetInstance()
-            .GetChunkManager();
-    auto prefix = path_;
-    LOG_INFO("bson inverted index remove path:{}", path_);
-    local_chunk_manager->RemoveDir(prefix);
 }
 
 void

--- a/internal/core/src/local/CMakeLists.txt
+++ b/internal/core/src/local/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Licensed to the LF AI & Data foundation under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(LOCAL_SOURCE_FILES
+    FileSystem.cpp
+    ManagedSubtree.cpp
+    io/File.cpp
+    io/MappedRegion.cpp
+)
+
+add_library(milvus_local OBJECT ${LOCAL_SOURCE_FILES})
+target_link_libraries(milvus_local PUBLIC milvus_conan_deps)

--- a/internal/core/src/local/CMakeLists.txt
+++ b/internal/core/src/local/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 set(LOCAL_SOURCE_FILES
     FileSystem.cpp
+    LegacyLocalChunkFiles.cpp
     ManagedSubtree.cpp
     io/File.cpp
     io/MappedRegion.cpp

--- a/internal/core/src/local/FileSystem.cpp
+++ b/internal/core/src/local/FileSystem.cpp
@@ -1,0 +1,551 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "local/FileSystem.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <limits>
+#include <utility>
+
+#include "common/EasyAssert.h"
+#include "local/ManagedSubtree.h"
+
+#ifndef MAP_POPULATE
+#define MAP_POPULATE 0
+#endif
+
+namespace milvus::local {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[noreturn]] void
+ThrowFileSystemError(ErrorCode code,
+                     const std::string& operation,
+                     const fs::path& path,
+                     const std::error_code& error) {
+    ThrowInfo(code,
+              "{} local path {} failed, error: {}",
+              operation,
+              path.string(),
+              error.message());
+}
+
+bool
+IsWithin(const fs::path& root, const fs::path& candidate) {
+    auto root_it = root.begin();
+    auto candidate_it = candidate.begin();
+    for (; root_it != root.end(); ++root_it, ++candidate_it) {
+        if (candidate_it == candidate.end() || *root_it != *candidate_it) {
+            return false;
+        }
+    }
+    return true;
+}
+
+fs::path
+Canonicalize(const fs::path& path, ErrorCode code) {
+    std::error_code error;
+    auto result = fs::weakly_canonical(path, error);
+    if (error) {
+        ThrowFileSystemError(code, "canonicalize", path, error);
+    }
+    return result;
+}
+
+class UniqueFd final {
+ public:
+    explicit UniqueFd(int fd) noexcept : fd_(fd) {
+    }
+
+    UniqueFd(const UniqueFd&) = delete;
+    UniqueFd&
+    operator=(const UniqueFd&) = delete;
+
+    UniqueFd(UniqueFd&& other) noexcept : fd_(std::exchange(other.fd_, -1)) {
+    }
+
+    ~UniqueFd() {
+        if (fd_ != -1) {
+            close(fd_);
+        }
+    }
+
+    int
+    Get() const noexcept {
+        return fd_;
+    }
+
+    int
+    Release() noexcept {
+        return std::exchange(fd_, -1);
+    }
+
+ private:
+    int fd_;
+};
+
+UniqueFd
+OpenFile(const fs::path& path, int flags, ErrorCode code) {
+    auto fd = open(path.c_str(), flags, S_IRUSR | S_IWUSR);
+    if (fd == -1) {
+        ThrowInfo(code,
+                  "failed to open local file {}, error: {}",
+                  path.string(),
+                  strerror(errno));
+    }
+    return UniqueFd(fd);
+}
+
+}  // namespace
+
+struct FileSystem::RootState {
+    explicit RootState(fs::path root) : root(std::move(root)) {
+    }
+
+    const fs::path root;
+};
+
+Path::Path(std::string value) {
+    if (value.empty() || value.find('\0') != std::string::npos) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "local path must be non-empty and contain no NUL bytes");
+    }
+
+    fs::path parsed(value);
+    if (parsed.is_absolute() || parsed.has_root_name() ||
+        parsed.has_root_directory()) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "local path must be relative, got: {}",
+                  value);
+    }
+    for (const auto& component : parsed) {
+        if (component == "..") {
+            ThrowInfo(ErrorCode::InvalidParameter,
+                      "local path must not contain parent traversal, got: {}",
+                      value);
+        }
+    }
+
+    auto normalized = parsed.lexically_normal();
+    if (normalized.empty() || normalized == ".") {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "local path resolves to an empty path: {}",
+                  value);
+    }
+    value_ = normalized.generic_string();
+    while (!value_.empty() && value_.back() == '/') {
+        value_.pop_back();
+    }
+}
+
+FileSystem::FileSystem(std::shared_ptr<const RootState> root, fs::path prefix)
+    : root_(std::move(root)), prefix_(std::move(prefix)) {
+}
+
+FileSystem
+FileSystem::Open(fs::path absolute_root) {
+    if (absolute_root.empty() || !absolute_root.is_absolute()) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "local filesystem root must be an absolute path, got: {}",
+                  absolute_root.string());
+    }
+
+    absolute_root = absolute_root.lexically_normal();
+    std::error_code error;
+    fs::create_directories(absolute_root, error);
+    if (error) {
+        ThrowFileSystemError(ErrorCode::FileCreateFailed,
+                             "create root directory",
+                             absolute_root,
+                             error);
+    }
+    if (!fs::is_directory(absolute_root, error) || error) {
+        if (error) {
+            ThrowFileSystemError(ErrorCode::FileReadFailed,
+                                 "inspect root directory",
+                                 absolute_root,
+                                 error);
+        }
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "local filesystem root is not a directory: {}",
+                  absolute_root.string());
+    }
+
+    auto canonical_root =
+        Canonicalize(absolute_root, ErrorCode::FileOpenFailed);
+    return FileSystem(std::make_shared<RootState>(std::move(canonical_root)),
+                      {});
+}
+
+FileSystem
+FileSystem::Subtree(const Path& path) const {
+    auto prefix = (prefix_ / std::string(path.String())).lexically_normal();
+    return FileSystem(root_, std::move(prefix));
+}
+
+std::shared_ptr<ManagedSubtree>
+FileSystem::ManageSubtree(const Path& path) const {
+    return std::shared_ptr<ManagedSubtree>(new ManagedSubtree(*this, path));
+}
+
+fs::path
+FileSystem::ScopedRoot() const {
+    return (root_->root / prefix_).lexically_normal();
+}
+
+fs::path
+FileSystem::CheckedNativePath(const Path& path) const {
+    auto scoped_root = ScopedRoot();
+    auto canonical_scope = Canonicalize(scoped_root, ErrorCode::FileOpenFailed);
+    if (!IsWithin(root_->root, canonical_scope)) {
+        ThrowInfo(ErrorCode::FileOpenFailed,
+                  "local filesystem subtree {} escapes root {}",
+                  scoped_root.string(),
+                  root_->root.string());
+    }
+
+    auto candidate =
+        (scoped_root / std::string(path.String())).lexically_normal();
+    auto canonical_candidate =
+        Canonicalize(candidate, ErrorCode::FileOpenFailed);
+    if (!IsWithin(canonical_scope, canonical_candidate)) {
+        ThrowInfo(ErrorCode::FileOpenFailed,
+                  "local path {} escapes filesystem subtree {}",
+                  candidate.string(),
+                  scoped_root.string());
+    }
+    return candidate;
+}
+
+fs::path
+FileSystem::ResolveNativePath(const Path& path) const {
+    return CheckedNativePath(path);
+}
+
+Path
+FileSystem::PathFromNativePath(fs::path native_path) const {
+    if (native_path.empty() || !native_path.is_absolute()) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "native local path must be absolute, got: {}",
+                  native_path.string());
+    }
+
+    native_path = native_path.lexically_normal();
+    auto scoped_root = ScopedRoot().lexically_normal();
+    auto relative = native_path.lexically_relative(scoped_root);
+    if (relative.empty() || relative == "." || relative.is_absolute()) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "native local path must name an entry below root {}, got: {}",
+                  scoped_root.string(),
+                  native_path.string());
+    }
+    for (const auto& component : relative) {
+        if (component == "..") {
+            ThrowInfo(ErrorCode::InvalidParameter,
+                      "native local path escapes root {}, got: {}",
+                      scoped_root.string(),
+                      native_path.string());
+        }
+    }
+    return Path(relative.generic_string());
+}
+
+bool
+FileSystem::Exists(const Path& path) const {
+    auto native_path = CheckedNativePath(path);
+    std::error_code error;
+    auto exists = fs::exists(native_path, error);
+    if (error) {
+        ThrowFileSystemError(
+            ErrorCode::FileReadFailed, "check", native_path, error);
+    }
+    return exists;
+}
+
+uint64_t
+FileSystem::FileSize(const Path& path) const {
+    auto native_path = CheckedNativePath(path);
+    std::error_code error;
+    auto size = fs::file_size(native_path, error);
+    if (error) {
+        if (error == std::errc::no_such_file_or_directory) {
+            ThrowInfo(ErrorCode::PathNotExist,
+                      "local path does not exist: {}",
+                      native_path.string());
+        }
+        ThrowFileSystemError(
+            ErrorCode::FileReadFailed, "get size of", native_path, error);
+    }
+    return size;
+}
+
+std::vector<Path>
+FileSystem::List(const Path& directory, bool recursive) const {
+    auto native_directory = CheckedNativePath(directory);
+    std::error_code error;
+    if (!fs::is_directory(native_directory, error)) {
+        if (error) {
+            ThrowFileSystemError(ErrorCode::FileReadFailed,
+                                 "inspect directory",
+                                 native_directory,
+                                 error);
+        }
+        ThrowInfo(ErrorCode::PathNotExist,
+                  "local directory does not exist: {}",
+                  native_directory.string());
+    }
+
+    std::vector<Path> files;
+    auto add_file = [&](const fs::directory_entry& entry) {
+        std::error_code status_error;
+        if (!entry.is_regular_file(status_error)) {
+            if (status_error) {
+                ThrowFileSystemError(ErrorCode::FileReadFailed,
+                                     "inspect directory entry",
+                                     entry.path(),
+                                     status_error);
+            }
+            return;
+        }
+        auto relative = fs::relative(entry.path(), ScopedRoot(), status_error);
+        if (status_error) {
+            ThrowFileSystemError(ErrorCode::FileReadFailed,
+                                 "resolve relative path for",
+                                 entry.path(),
+                                 status_error);
+        }
+        files.emplace_back(relative.generic_string());
+    };
+
+    if (recursive) {
+        fs::recursive_directory_iterator iterator(native_directory, error);
+        if (error) {
+            ThrowFileSystemError(ErrorCode::FileReadFailed,
+                                 "list directory",
+                                 native_directory,
+                                 error);
+        }
+        for (const auto& entry : iterator) {
+            add_file(entry);
+        }
+    } else {
+        fs::directory_iterator iterator(native_directory, error);
+        if (error) {
+            ThrowFileSystemError(ErrorCode::FileReadFailed,
+                                 "list directory",
+                                 native_directory,
+                                 error);
+        }
+        for (const auto& entry : iterator) {
+            add_file(entry);
+        }
+    }
+
+    std::sort(
+        files.begin(), files.end(), [](const auto& left, const auto& right) {
+            return left.String() < right.String();
+        });
+    return files;
+}
+
+void
+FileSystem::CreateDirectories(const Path& path) const {
+    auto native_path = CheckedNativePath(path);
+    std::error_code error;
+    fs::create_directories(native_path, error);
+    if (error) {
+        ThrowFileSystemError(ErrorCode::FileCreateFailed,
+                             "create directories",
+                             native_path,
+                             error);
+    }
+}
+
+void
+FileSystem::RemoveFile(const Path& path) const {
+    auto native_path = CheckedNativePath(path);
+    std::error_code error;
+    fs::remove(native_path, error);
+    if (error) {
+        ThrowFileSystemError(
+            ErrorCode::FileWriteFailed, "remove file", native_path, error);
+    }
+}
+
+void
+FileSystem::RemoveAll(const Path& path) const {
+    auto native_path = CheckedNativePath(path);
+    std::error_code error;
+    fs::remove_all(native_path, error);
+    if (error) {
+        ThrowFileSystemError(
+            ErrorCode::FileWriteFailed, "remove subtree", native_path, error);
+    }
+}
+
+void
+FileSystem::Rename(const Path& from, const Path& to) const {
+    auto native_from = CheckedNativePath(from);
+    auto native_to = CheckedNativePath(to);
+    std::error_code error;
+    fs::rename(native_from, native_to, error);
+    if (error) {
+        ThrowInfo(ErrorCode::FileWriteFailed,
+                  "rename local path {} to {} failed, error: {}",
+                  native_from.string(),
+                  native_to.string(),
+                  error.message());
+    }
+}
+
+io::RandomAccessFile
+FileSystem::OpenForRead(const Path& path) const {
+    auto native_path = CheckedNativePath(path);
+    auto fd = OpenFile(native_path, O_RDONLY, ErrorCode::FileOpenFailed);
+    return io::RandomAccessFile(fd.Release(), std::move(native_path));
+}
+
+io::WritableFile
+FileSystem::OpenForWrite(const Path& path, const WriteOptions& options) const {
+    auto native_path = CheckedNativePath(path);
+    if (options.create_parent) {
+        std::error_code error;
+        fs::create_directories(native_path.parent_path(), error);
+        if (error) {
+            ThrowFileSystemError(ErrorCode::FileCreateFailed,
+                                 "create parent directory",
+                                 native_path.parent_path(),
+                                 error);
+        }
+    }
+
+    auto flags = O_RDWR;
+    if (options.create) {
+        flags |= O_CREAT;
+    }
+    if (options.truncate) {
+        flags |= O_TRUNC;
+    }
+#if !defined(__APPLE__) && defined(O_DIRECT)
+    if (options.direct_io) {
+        flags |= O_DIRECT;
+    }
+#endif
+
+    auto fd = OpenFile(native_path,
+                       flags,
+                       options.create ? ErrorCode::FileCreateFailed
+                                      : ErrorCode::FileOpenFailed);
+#ifdef __APPLE__
+    if (options.direct_io && fcntl(fd.Get(), F_NOCACHE, 1) == -1) {
+        auto direct_io_error = errno;
+        ThrowInfo(ErrorCode::FileOpenFailed,
+                  "failed to enable direct IO for local file {}, error: {}",
+                  native_path.string(),
+                  strerror(direct_io_error));
+    }
+#endif
+    return io::WritableFile(
+        fd.Release(), std::move(native_path), options.direct_io);
+}
+
+io::MappedRegion
+FileSystem::OpenMappedRegion(const Path& path,
+                             const MapOptions& options) const {
+    auto native_path = CheckedNativePath(path);
+    auto fd = OpenFile(native_path, O_RDONLY, ErrorCode::FileOpenFailed);
+
+    struct stat status {};
+    if (fstat(fd.Get(), &status) != 0) {
+        auto stat_error = errno;
+        ThrowInfo(ErrorCode::FileReadFailed,
+                  "failed to inspect local file {} for mmap, error: {}",
+                  native_path.string(),
+                  strerror(stat_error));
+    }
+    auto file_size = static_cast<uint64_t>(status.st_size);
+    if (options.offset > file_size) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "mmap offset {} exceeds local file {} size {}",
+                  options.offset,
+                  native_path.string(),
+                  file_size);
+    }
+
+    auto visible_size = options.length == 0
+                            ? file_size - options.offset
+                            : static_cast<uint64_t>(options.length);
+    if (visible_size > file_size - options.offset) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "mmap range [{}, {}) exceeds local file {} size {}",
+                  options.offset,
+                  options.offset + visible_size,
+                  native_path.string(),
+                  file_size);
+    }
+    if (visible_size == 0) {
+        return {};
+    }
+
+    auto page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) {
+        auto page_error = errno;
+        ThrowInfo(ErrorCode::MmapError,
+                  "failed to determine mmap page size, error: {}",
+                  strerror(page_error));
+    }
+    auto page_size_u64 = static_cast<uint64_t>(page_size);
+    auto aligned_offset = options.offset - (options.offset % page_size_u64);
+    auto displacement = options.offset - aligned_offset;
+    if (visible_size > std::numeric_limits<size_t>::max() - displacement) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "mmap range for local file {} exceeds platform limit",
+                  native_path.string());
+    }
+    auto mapping_size = static_cast<size_t>(visible_size + displacement);
+
+    auto flags = MAP_SHARED;
+    if (options.populate) {
+        flags |= MAP_POPULATE;
+    }
+    auto mapping = mmap(nullptr,
+                        mapping_size,
+                        PROT_READ,
+                        flags,
+                        fd.Get(),
+                        static_cast<off_t>(aligned_offset));
+    auto mmap_error = errno;
+    if (mapping == MAP_FAILED) {
+        ThrowInfo(ErrorCode::MmapError,
+                  "mmap local file {} failed, error: {}",
+                  native_path.string(),
+                  strerror(mmap_error));
+    }
+
+    auto* data = static_cast<const std::byte*>(mapping) + displacement;
+    return io::MappedRegion(
+        mapping, mapping_size, data, static_cast<size_t>(visible_size));
+}
+
+}  // namespace milvus::local

--- a/internal/core/src/local/FileSystem.h
+++ b/internal/core/src/local/FileSystem.h
@@ -1,0 +1,111 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+#include "local/Path.h"
+#include "local/io/File.h"
+#include "local/io/MappedRegion.h"
+
+namespace milvus::local {
+
+class ManagedSubtree;
+
+struct WriteOptions {
+    bool create{false};
+    bool truncate{false};
+    bool create_parent{false};
+    bool direct_io{false};
+};
+
+struct MapOptions {
+    uint64_t offset{0};
+    size_t length{0};
+    bool populate{false};
+};
+
+class FileSystem final {
+ public:
+    // FileSystem is a copyable capability for one immutable rooted subtree.
+    // Copies may be used concurrently.
+    static FileSystem
+    Open(std::filesystem::path absolute_root);
+
+    FileSystem
+    Subtree(const Path& path) const;
+
+    std::shared_ptr<ManagedSubtree>
+    ManageSubtree(const Path& path) const;
+
+    bool
+    Exists(const Path& path) const;
+
+    uint64_t
+    FileSize(const Path& path) const;
+
+    std::vector<Path>
+    List(const Path& directory, bool recursive) const;
+
+    void
+    CreateDirectories(const Path& path) const;
+
+    void
+    RemoveFile(const Path& path) const;
+
+    void
+    RemoveAll(const Path& path) const;
+
+    void
+    Rename(const Path& from, const Path& to) const;
+
+    io::RandomAccessFile
+    OpenForRead(const Path& path) const;
+
+    io::WritableFile
+    OpenForWrite(const Path& path, const WriteOptions& options) const;
+
+    io::MappedRegion
+    OpenMappedRegion(const Path& path, const MapOptions& options) const;
+
+    std::filesystem::path
+    ResolveNativePath(const Path& path) const;
+
+    Path
+    PathFromNativePath(std::filesystem::path native_path) const;
+
+ private:
+    struct RootState;
+
+    FileSystem(std::shared_ptr<const RootState> root,
+               std::filesystem::path prefix);
+
+    std::filesystem::path
+    ScopedRoot() const;
+
+    std::filesystem::path
+    CheckedNativePath(const Path& path) const;
+
+    std::shared_ptr<const RootState> root_;
+    std::filesystem::path prefix_;
+};
+
+}  // namespace milvus::local

--- a/internal/core/src/local/FileSystemTest.cpp
+++ b/internal/core/src/local/FileSystemTest.cpp
@@ -1,0 +1,295 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <span>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "common/EasyAssert.h"
+#include "local/FileSystem.h"
+
+namespace milvus::local {
+namespace {
+
+namespace fs = std::filesystem;
+
+static_assert(std::is_copy_constructible_v<FileSystem>);
+static_assert(std::is_copy_assignable_v<FileSystem>);
+static_assert(!std::is_copy_constructible_v<io::RandomAccessFile>);
+static_assert(!std::is_copy_constructible_v<io::WritableFile>);
+static_assert(!std::is_copy_constructible_v<io::MappedRegion>);
+
+class CurrentPathGuard {
+ public:
+    CurrentPathGuard() : original_(fs::current_path()) {
+    }
+
+    CurrentPathGuard(const CurrentPathGuard&) = delete;
+    CurrentPathGuard&
+    operator=(const CurrentPathGuard&) = delete;
+
+    ~CurrentPathGuard() {
+        std::error_code error;
+        fs::current_path(original_, error);
+    }
+
+ private:
+    fs::path original_;
+};
+
+class LocalFileSystemTest : public testing::Test {
+ protected:
+    void
+    SetUp() override {
+        root_ = fs::temp_directory_path() / "milvus_rooted_local_filesystem" /
+                testing::UnitTest::GetInstance()->current_test_info()->name();
+        fs::remove_all(root_);
+        files_.emplace(FileSystem::Open(root_));
+    }
+
+    void
+    TearDown() override {
+        files_.reset();
+        fs::remove_all(root_);
+    }
+
+    fs::path root_;
+    std::optional<FileSystem> files_;
+};
+
+TEST(PathTest, ValidatesAndNormalizesRelativePaths) {
+    EXPECT_EQ(Path("index/./field//data").String(), "index/field/data");
+
+    EXPECT_THROW(Path(""), SegcoreError);
+    EXPECT_THROW(Path("."), SegcoreError);
+    EXPECT_THROW(Path("/tmp/outside"), SegcoreError);
+    EXPECT_THROW(Path("../outside"), SegcoreError);
+    EXPECT_THROW(Path("index/../../outside"), SegcoreError);
+    EXPECT_THROW(Path(std::string("index\0outside", 13)), SegcoreError);
+    EXPECT_THROW(FileSystem::Open("relative/root"), SegcoreError);
+}
+
+TEST_F(LocalFileSystemTest, CopiesAndSubtreesKeepIndependentRoots) {
+    auto other_root = root_.parent_path() / (root_.filename().string() + "_2");
+    fs::remove_all(other_root);
+    auto other = FileSystem::Open(other_root);
+
+    auto local_chunk = files_->Subtree(Path("local_chunk"));
+    auto copied = local_chunk;
+    auto sibling = files_->Subtree(Path("expr_cache"));
+
+    copied.CreateDirectories(Path("indexes"));
+    sibling.CreateDirectories(Path("entries"));
+    other.CreateDirectories(Path("indexes"));
+
+    EXPECT_TRUE(fs::is_directory(root_ / "local_chunk/indexes"));
+    EXPECT_TRUE(fs::is_directory(root_ / "expr_cache/entries"));
+    EXPECT_TRUE(fs::is_directory(other_root / "indexes"));
+    EXPECT_THROW(local_chunk.ResolveNativePath(Path("../expr_cache")),
+                 SegcoreError);
+
+    fs::remove_all(other_root);
+}
+
+TEST_F(LocalFileSystemTest, OperationsDoNotDependOnCurrentWorkingDirectory) {
+    CurrentPathGuard guard;
+    auto subtree = files_->Subtree(Path("local_chunk"));
+
+    fs::current_path(fs::temp_directory_path());
+    subtree.CreateDirectories(Path("indexes"));
+
+    EXPECT_TRUE(fs::is_directory(root_ / "local_chunk/indexes"));
+    EXPECT_EQ(subtree.ResolveNativePath(Path("indexes/data")),
+              (fs::weakly_canonical(root_) / "local_chunk/indexes/data")
+                  .lexically_normal());
+}
+
+TEST_F(LocalFileSystemTest, RejectsSymlinkEscapes) {
+    auto outside =
+        root_.parent_path() / (root_.filename().string() + "_outside");
+    fs::remove_all(outside);
+    fs::create_directories(outside);
+    {
+        auto outside_files = FileSystem::Open(fs::weakly_canonical(outside));
+        auto output = outside_files.OpenForWrite(
+            Path("data"), WriteOptions{.create = true, .truncate = true});
+        constexpr std::array<std::byte, 1> data = {std::byte{42}};
+        output.Write(data);
+    }
+    fs::create_directory_symlink(outside, root_ / "escape");
+
+    EXPECT_THROW(files_->Exists(Path("escape/data")), SegcoreError);
+    EXPECT_THROW(files_->Subtree(Path("escape")).Exists(Path("data")),
+                 SegcoreError);
+
+    fs::remove_all(outside);
+}
+
+TEST_F(LocalFileSystemTest, OpensCapabilitySpecificFileHandles) {
+    constexpr std::array<std::byte, 8> expected = {
+        std::byte{1},
+        std::byte{2},
+        std::byte{3},
+        std::byte{4},
+        std::byte{5},
+        std::byte{6},
+        std::byte{7},
+        std::byte{8},
+    };
+    auto path = Path("index/field/data");
+
+    {
+        auto output = files_->OpenForWrite(
+            path,
+            WriteOptions{
+                .create = true, .truncate = true, .create_parent = true});
+        EXPECT_EQ(output.Write(std::span(expected).first<3>()), 3);
+        EXPECT_EQ(output.WriteAt(3, std::span(expected).subspan<3>()), 5);
+        output.Sync();
+        EXPECT_EQ(output.Size(), expected.size());
+        output.Truncate(6);
+        EXPECT_EQ(output.Size(), 6);
+        output.Truncate(expected.size());
+        EXPECT_EQ(output.WriteAt(6, std::span(expected).last<2>()), 2);
+    }
+
+    auto input = files_->OpenForRead(path);
+    std::array<std::byte, 8> actual{};
+    EXPECT_EQ(input.ReadAt(0, actual), actual.size());
+    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(input.Size(), expected.size());
+    EXPECT_EQ(input.ReadAt(expected.size(), actual), 0);
+}
+
+TEST_F(LocalFileSystemTest, ManagesDirectoriesFilesAndRenameWithinRoot) {
+    constexpr std::array<std::byte, 1> data = {std::byte{42}};
+    auto original = Path("nested/a/data");
+    auto renamed = Path("nested/b/data");
+
+    auto output = files_->OpenForWrite(
+        original,
+        WriteOptions{.create = true, .truncate = true, .create_parent = true});
+    output.Write(data);
+
+    EXPECT_TRUE(files_->Exists(original));
+    EXPECT_EQ(files_->FileSize(original), data.size());
+    files_->CreateDirectories(Path("nested/b"));
+    files_->Rename(original, renamed);
+    EXPECT_FALSE(files_->Exists(original));
+    EXPECT_TRUE(files_->Exists(renamed));
+
+    auto listed = files_->List(Path("nested"), true);
+    ASSERT_EQ(listed.size(), 1);
+    EXPECT_EQ(listed.front().String(), "nested/b/data");
+
+    files_->RemoveFile(renamed);
+    files_->RemoveAll(Path("nested"));
+    EXPECT_FALSE(files_->Exists(Path("nested")));
+}
+
+TEST_F(LocalFileSystemTest, MapsUnalignedRangesAndOwnsTheMapping) {
+    constexpr std::array<std::byte, 12> data = {
+        std::byte{0},
+        std::byte{1},
+        std::byte{2},
+        std::byte{3},
+        std::byte{4},
+        std::byte{5},
+        std::byte{6},
+        std::byte{7},
+        std::byte{8},
+        std::byte{9},
+        std::byte{10},
+        std::byte{11},
+    };
+    auto path = Path("mmap/data");
+    {
+        auto output = files_->OpenForWrite(
+            path,
+            WriteOptions{
+                .create = true, .truncate = true, .create_parent = true});
+        output.Write(data);
+    }
+
+    auto region = files_->OpenMappedRegion(
+        path, MapOptions{.offset = 3, .length = 7, .populate = false});
+    ASSERT_EQ(region.Data().size(), 7);
+    EXPECT_TRUE(std::equal(
+        region.Data().begin(), region.Data().end(), data.begin() + 3));
+
+    auto moved = std::move(region);
+    EXPECT_TRUE(region.Data().empty());
+    ASSERT_EQ(moved.Data().size(), 7);
+    EXPECT_EQ(moved.Data().front(), std::byte{3});
+    EXPECT_EQ(moved.Data().back(), std::byte{9});
+
+    auto populated = files_->OpenMappedRegion(
+        path, MapOptions{.offset = 1, .length = 2, .populate = true});
+    EXPECT_EQ(populated.Data()[0], std::byte{1});
+    EXPECT_EQ(populated.Data()[1], std::byte{2});
+
+    auto tail = files_->OpenMappedRegion(path, MapOptions{.offset = 10});
+    ASSERT_EQ(tail.Data().size(), 2);
+    EXPECT_EQ(tail.Data()[0], std::byte{10});
+    EXPECT_EQ(tail.Data()[1], std::byte{11});
+}
+
+TEST_F(LocalFileSystemTest, PreservesFileAndMappingErrorCategories) {
+    try {
+        static_cast<void>(files_->OpenForRead(Path("missing")));
+        FAIL() << "expected opening a missing file to fail";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::FileOpenFailed);
+    }
+
+    auto path = Path("mmap/empty");
+    auto output = files_->OpenForWrite(
+        path,
+        WriteOptions{.create = true, .truncate = true, .create_parent = true});
+    output.Truncate(4);
+
+    try {
+        static_cast<void>(files_->OpenMappedRegion(
+            path, MapOptions{.offset = 3, .length = 2}));
+        FAIL() << "expected an out-of-range mapping to fail";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::InvalidParameter);
+    }
+}
+
+TEST_F(LocalFileSystemTest, ConvertsNativePathsOnlyWithinRoot) {
+    EXPECT_EQ(Path("nested/").String(), "nested");
+    auto native = files_->ResolveNativePath(Path("nested/file"));
+    EXPECT_EQ(files_->PathFromNativePath(native).String(), "nested/file");
+
+    EXPECT_THROW(static_cast<void>(files_->PathFromNativePath(
+                     root_.parent_path() / "outside")),
+                 SegcoreError);
+    EXPECT_THROW(static_cast<void>(files_->PathFromNativePath("relative")),
+                 SegcoreError);
+}
+
+}  // namespace
+}  // namespace milvus::local

--- a/internal/core/src/local/LegacyLocalChunkFiles.cpp
+++ b/internal/core/src/local/LegacyLocalChunkFiles.cpp
@@ -1,0 +1,39 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "local/LegacyLocalChunkFiles.h"
+
+#include <filesystem>
+
+#include "common/EasyAssert.h"
+#include "storage/LocalChunkManagerSingleton.h"
+
+namespace milvus::local {
+
+FileSystem
+LegacyLocalChunkFiles() {
+    auto chunk_manager =
+        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    if (chunk_manager == nullptr) {
+        ThrowInfo(ErrorCode::FileOpenFailed,
+                  "legacy local chunk manager is not initialized");
+    }
+
+    auto root = std::filesystem::absolute(chunk_manager->GetRootPath());
+    return FileSystem::Open(root.lexically_normal());
+}
+
+}  // namespace milvus::local

--- a/internal/core/src/local/LegacyLocalChunkFiles.h
+++ b/internal/core/src/local/LegacyLocalChunkFiles.h
@@ -1,0 +1,28 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "local/FileSystem.h"
+
+namespace milvus::local {
+
+// Compatibility adapter for callers that do not inject a local filesystem.
+// New code should pass FileSystem explicitly instead.
+FileSystem
+LegacyLocalChunkFiles();
+
+}  // namespace milvus::local

--- a/internal/core/src/local/ManagedSubtree.cpp
+++ b/internal/core/src/local/ManagedSubtree.cpp
@@ -1,0 +1,176 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "local/ManagedSubtree.h"
+
+#include <exception>
+#include <utility>
+
+#include "common/EasyAssert.h"
+
+namespace milvus::local {
+
+ManagedSubtree::WriteLease::WriteLease(
+    std::shared_ptr<ManagedSubtree> directory)
+    : directory_(std::move(directory)) {
+}
+
+ManagedSubtree::WriteLease&
+ManagedSubtree::WriteLease::operator=(WriteLease&& other) noexcept {
+    if (this != &other) {
+        Release();
+        directory_ = std::move(other.directory_);
+    }
+    return *this;
+}
+
+ManagedSubtree::WriteLease::~WriteLease() {
+    Release();
+}
+
+void
+ManagedSubtree::WriteLease::Release() noexcept {
+    auto directory = std::exchange(directory_, nullptr);
+    if (directory != nullptr) {
+        directory->ReleaseWriter();
+    }
+}
+
+ManagedSubtree::ManagedSubtree(FileSystem parent, Path path)
+    : parent_(std::move(parent)),
+      path_(std::move(path)),
+      subtree_(parent_.Subtree(path_)) {
+}
+
+ManagedSubtree::WriteLease
+ManagedSubtree::AcquireWriter() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (state_ != State::Open) {
+        ThrowInfo(ErrorCode::FileWriteFailed,
+                  "cannot acquire a writer after local subtree cleanup begins");
+    }
+    ++writers_;
+    return WriteLease(shared_from_this());
+}
+
+bool
+ManagedSubtree::BeginRemovalLocked() noexcept {
+    if (state_ != State::Closing || writers_ != 0 || removal_in_progress_) {
+        return false;
+    }
+    removal_in_progress_ = true;
+    return true;
+}
+
+bool
+ManagedSubtree::RequestRemoval() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (state_ == State::Removed) {
+        return false;
+    }
+    state_ = State::Closing;
+    return BeginRemovalLocked();
+}
+
+void
+ManagedSubtree::RemoveWhenIdle() noexcept {
+    try {
+        if (RequestRemoval()) {
+            PerformRemoval();
+        }
+    } catch (...) {
+        // RequestRemoval only mutates in-memory state. Keep this method
+        // noexcept even if a future implementation changes that detail.
+    }
+}
+
+void
+ManagedSubtree::RemoveAndWait() {
+    if (RequestRemoval()) {
+        PerformRemoval();
+    }
+
+    std::optional<ErrorCode> cleanup_error_code;
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this]() { return state_ == State::Removed; });
+        cleanup_error_code = cleanup_error_code_;
+    }
+    if (cleanup_error_code.has_value()) {
+        ThrowInfo(*cleanup_error_code,
+                  "failed to remove managed local subtree");
+    }
+}
+
+void
+ManagedSubtree::ReleaseWriter() noexcept {
+    bool remove = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (writers_ == 0) {
+            return;
+        }
+        --writers_;
+        remove = BeginRemovalLocked();
+    }
+    if (remove) {
+        PerformRemoval();
+    }
+}
+
+void
+ManagedSubtree::PerformRemoval() noexcept {
+    try {
+        parent_.RemoveAll(path_);
+    } catch (const SegcoreError& error) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            cleanup_error_code_ = error.get_error_code();
+            removal_in_progress_ = false;
+            state_ = State::Removed;
+        }
+        cv_.notify_all();
+        return;
+    } catch (const std::exception&) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            cleanup_error_code_ = ErrorCode::UnexpectedError;
+            removal_in_progress_ = false;
+            state_ = State::Removed;
+        }
+        cv_.notify_all();
+        return;
+    } catch (...) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            cleanup_error_code_ = ErrorCode::UnexpectedError;
+            removal_in_progress_ = false;
+            state_ = State::Removed;
+        }
+        cv_.notify_all();
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cleanup_error_code_.reset();
+        removal_in_progress_ = false;
+        state_ = State::Removed;
+    }
+    cv_.notify_all();
+}
+
+}  // namespace milvus::local

--- a/internal/core/src/local/ManagedSubtree.h
+++ b/internal/core/src/local/ManagedSubtree.h
@@ -1,0 +1,118 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <optional>
+
+#include "common/EasyAssert.h"
+#include "local/FileSystem.h"
+
+namespace milvus::local {
+
+class ManagedSubtree final
+    : public std::enable_shared_from_this<ManagedSubtree> {
+ public:
+    class WriteLease final {
+     public:
+        WriteLease() = default;
+
+        WriteLease(const WriteLease&) = delete;
+        WriteLease&
+        operator=(const WriteLease&) = delete;
+
+        WriteLease(WriteLease&& other) noexcept = default;
+        WriteLease&
+        operator=(WriteLease&& other) noexcept;
+
+        ~WriteLease();
+
+        explicit
+        operator bool() const noexcept {
+            return directory_ != nullptr;
+        }
+
+     private:
+        friend class ManagedSubtree;
+
+        explicit WriteLease(std::shared_ptr<ManagedSubtree> directory);
+
+        void
+        Release() noexcept;
+
+        std::shared_ptr<ManagedSubtree> directory_;
+    };
+
+    ManagedSubtree(const ManagedSubtree&) = delete;
+    ManagedSubtree&
+    operator=(const ManagedSubtree&) = delete;
+
+    WriteLease
+    AcquireWriter();
+
+    // Reject new writers and remove after the final active writer exits.
+    void
+    RemoveWhenIdle() noexcept;
+
+    // Request removal, wait for it to finish, and rethrow cleanup failures.
+    void
+    RemoveAndWait();
+
+    const FileSystem&
+    Files() const noexcept {
+        return subtree_;
+    }
+
+ private:
+    friend class FileSystem;
+
+    enum class State {
+        Open,
+        Closing,
+        Removed,
+    };
+
+    ManagedSubtree(FileSystem parent, Path path);
+
+    bool
+    RequestRemoval();
+
+    bool
+    BeginRemovalLocked() noexcept;
+
+    void
+    ReleaseWriter() noexcept;
+
+    void
+    PerformRemoval() noexcept;
+
+    FileSystem parent_;
+    Path path_;
+    FileSystem subtree_;
+
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    State state_{State::Open};
+    size_t writers_{0};
+    bool removal_in_progress_{false};
+    std::optional<ErrorCode> cleanup_error_code_;
+};
+
+}  // namespace milvus::local

--- a/internal/core/src/local/ManagedSubtreeTest.cpp
+++ b/internal/core/src/local/ManagedSubtreeTest.cpp
@@ -1,0 +1,139 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <future>
+#include <optional>
+#include <string>
+
+#include "common/EasyAssert.h"
+#include "local/FileSystem.h"
+#include "local/ManagedSubtree.h"
+
+namespace milvus::local {
+namespace {
+
+namespace fs = std::filesystem;
+
+class ManagedSubtreeTest : public testing::Test {
+ protected:
+    void
+    SetUp() override {
+        root_ = fs::temp_directory_path() / "milvus_managed_subtree" /
+                testing::UnitTest::GetInstance()->current_test_info()->name();
+        fs::remove_all(root_);
+        files_.emplace(FileSystem::Open(root_));
+    }
+
+    void
+    TearDown() override {
+        files_.reset();
+        fs::remove_all(root_);
+        fs::remove_all(OutsidePath());
+    }
+
+    fs::path
+    OutsidePath() const {
+        return root_.parent_path() / (root_.filename().string() + "_outside");
+    }
+
+    fs::path root_;
+    std::optional<FileSystem> files_;
+};
+
+TEST_F(ManagedSubtreeTest, DefersRemovalUntilTheFinalWriterExits) {
+    auto directory = files_->ManageSubtree(Path("artifact"));
+    directory->Files().CreateDirectories(Path("work"));
+    auto first = directory->AcquireWriter();
+    std::optional<ManagedSubtree::WriteLease> second(
+        directory->AcquireWriter());
+
+    directory->RemoveWhenIdle();
+    EXPECT_TRUE(fs::exists(root_ / "artifact"));
+
+    try {
+        static_cast<void>(directory->AcquireWriter());
+        FAIL() << "expected a closing subtree to reject new writers";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::FileWriteFailed);
+    }
+
+    first = std::move(*second);
+    second.reset();
+    EXPECT_TRUE(fs::exists(root_ / "artifact"));
+
+    first = {};
+    EXPECT_FALSE(fs::exists(root_ / "artifact"));
+
+    directory->RemoveWhenIdle();
+    directory->RemoveAndWait();
+}
+
+TEST_F(ManagedSubtreeTest, RemoveAndWaitBlocksForActiveWriters) {
+    auto directory = files_->ManageSubtree(Path("artifact"));
+    directory->Files().CreateDirectories(Path("work"));
+    std::optional<ManagedSubtree::WriteLease> writer(
+        directory->AcquireWriter());
+
+    auto removal = std::async(std::launch::async,
+                              [directory]() { directory->RemoveAndWait(); });
+    EXPECT_EQ(removal.wait_for(std::chrono::milliseconds(50)),
+              std::future_status::timeout);
+
+    writer.reset();
+    EXPECT_NO_THROW(removal.get());
+    EXPECT_FALSE(fs::exists(root_ / "artifact"));
+}
+
+TEST_F(ManagedSubtreeTest, IndependentSubtreesDoNotShareLifecycleState) {
+    auto first = files_->ManageSubtree(Path("first"));
+    auto second = files_->ManageSubtree(Path("second"));
+    first->Files().CreateDirectories(Path("work"));
+    second->Files().CreateDirectories(Path("work"));
+    auto second_writer = second->AcquireWriter();
+
+    first->RemoveAndWait();
+
+    EXPECT_FALSE(fs::exists(root_ / "first"));
+    EXPECT_TRUE(fs::exists(root_ / "second"));
+    EXPECT_NO_THROW(second->AcquireWriter());
+}
+
+TEST_F(ManagedSubtreeTest, RemoveAndWaitPropagatesCleanupFailure) {
+    auto directory = files_->ManageSubtree(Path("artifact"));
+    directory->Files().CreateDirectories(Path("work"));
+
+    auto outside = OutsidePath();
+    fs::create_directories(outside);
+    fs::remove_all(root_ / "artifact");
+    fs::create_directory_symlink(outside, root_ / "artifact");
+
+    try {
+        directory->RemoveAndWait();
+        FAIL() << "expected subtree cleanup to report the symlink escape";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::FileOpenFailed);
+    }
+
+    EXPECT_TRUE(fs::exists(outside));
+    EXPECT_THROW(directory->AcquireWriter(), SegcoreError);
+}
+
+}  // namespace
+}  // namespace milvus::local

--- a/internal/core/src/local/Path.h
+++ b/internal/core/src/local/Path.h
@@ -1,0 +1,37 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace milvus::local {
+
+class Path {
+ public:
+    explicit Path(std::string value);
+
+    std::string_view
+    String() const noexcept {
+        return value_;
+    }
+
+ private:
+    std::string value_;
+};
+
+}  // namespace milvus::local

--- a/internal/core/src/local/io/File.cpp
+++ b/internal/core/src/local/io/File.cpp
@@ -1,0 +1,247 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "local/io/File.h"
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <limits>
+#include <utility>
+
+#include "common/EasyAssert.h"
+
+namespace milvus::local::io {
+namespace {
+
+off_t
+CheckedOffset(uint64_t offset, const std::filesystem::path& path) {
+    if (offset > static_cast<uint64_t>(std::numeric_limits<off_t>::max())) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "local file offset {} exceeds the platform limit for {}",
+                  offset,
+                  path.string());
+    }
+    return static_cast<off_t>(offset);
+}
+
+off_t
+CheckedOffset(uint64_t offset,
+              size_t delta,
+              const std::filesystem::path& path) {
+    if (delta > std::numeric_limits<uint64_t>::max() - offset) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "local file offset {} plus length {} overflows for {}",
+                  offset,
+                  delta,
+                  path.string());
+    }
+    return CheckedOffset(offset + delta, path);
+}
+
+uint64_t
+FileSize(int fd, const std::filesystem::path& path) {
+    struct stat status {};
+    if (fstat(fd, &status) != 0) {
+        ThrowInfo(ErrorCode::FileReadFailed,
+                  "failed to inspect local file {}, error: {}",
+                  path.string(),
+                  strerror(errno));
+    }
+    return static_cast<uint64_t>(status.st_size);
+}
+
+}  // namespace
+
+RandomAccessFile::RandomAccessFile(int fd,
+                                   std::filesystem::path debug_path) noexcept
+    : fd_(fd), debug_path_(std::move(debug_path)) {
+}
+
+RandomAccessFile::RandomAccessFile(RandomAccessFile&& other) noexcept
+    : fd_(std::exchange(other.fd_, -1)),
+      debug_path_(std::move(other.debug_path_)) {
+}
+
+RandomAccessFile&
+RandomAccessFile::operator=(RandomAccessFile&& other) noexcept {
+    if (this != &other) {
+        Close();
+        fd_ = std::exchange(other.fd_, -1);
+        debug_path_ = std::move(other.debug_path_);
+    }
+    return *this;
+}
+
+RandomAccessFile::~RandomAccessFile() {
+    Close();
+}
+
+void
+RandomAccessFile::Close() noexcept {
+    if (fd_ != -1) {
+        close(fd_);
+        fd_ = -1;
+    }
+}
+
+size_t
+RandomAccessFile::ReadAt(uint64_t offset, std::span<std::byte> output) const {
+    size_t total = 0;
+    while (total < output.size()) {
+        auto current_offset = CheckedOffset(offset, total, debug_path_);
+        auto read_size = pread(
+            fd_, output.data() + total, output.size() - total, current_offset);
+        if (read_size < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            ThrowInfo(ErrorCode::FileReadFailed,
+                      "failed to read local file {} at offset {}, error: {}",
+                      debug_path_.string(),
+                      static_cast<uint64_t>(current_offset),
+                      strerror(errno));
+        }
+        if (read_size == 0) {
+            break;
+        }
+        total += static_cast<size_t>(read_size);
+    }
+    return total;
+}
+
+uint64_t
+RandomAccessFile::Size() const {
+    return FileSize(fd_, debug_path_);
+}
+
+WritableFile::WritableFile(int fd,
+                           std::filesystem::path debug_path,
+                           bool direct_io) noexcept
+    : fd_(fd), debug_path_(std::move(debug_path)), direct_io_(direct_io) {
+}
+
+WritableFile::WritableFile(WritableFile&& other) noexcept
+    : fd_(std::exchange(other.fd_, -1)),
+      debug_path_(std::move(other.debug_path_)),
+      direct_io_(std::exchange(other.direct_io_, false)) {
+}
+
+WritableFile&
+WritableFile::operator=(WritableFile&& other) noexcept {
+    if (this != &other) {
+        Close();
+        fd_ = std::exchange(other.fd_, -1);
+        debug_path_ = std::move(other.debug_path_);
+        direct_io_ = std::exchange(other.direct_io_, false);
+    }
+    return *this;
+}
+
+WritableFile::~WritableFile() {
+    Close();
+}
+
+void
+WritableFile::Close() noexcept {
+    if (fd_ != -1) {
+        close(fd_);
+        fd_ = -1;
+    }
+}
+
+size_t
+WritableFile::Write(std::span<const std::byte> data) {
+    size_t total = 0;
+    while (total < data.size()) {
+        auto written = write(fd_, data.data() + total, data.size() - total);
+        if (written < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            ThrowInfo(ErrorCode::FileWriteFailed,
+                      "failed to write local file {}, error: {}",
+                      debug_path_.string(),
+                      strerror(errno));
+        }
+        if (written == 0) {
+            ThrowInfo(ErrorCode::FileWriteFailed,
+                      "write to local file {} made no progress",
+                      debug_path_.string());
+        }
+        total += static_cast<size_t>(written);
+    }
+    return total;
+}
+
+size_t
+WritableFile::WriteAt(uint64_t offset, std::span<const std::byte> data) {
+    size_t total = 0;
+    while (total < data.size()) {
+        auto current_offset = CheckedOffset(offset, total, debug_path_);
+        auto written = pwrite(
+            fd_, data.data() + total, data.size() - total, current_offset);
+        if (written < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            ThrowInfo(ErrorCode::FileWriteFailed,
+                      "failed to write local file {} at offset {}, error: {}",
+                      debug_path_.string(),
+                      static_cast<uint64_t>(current_offset),
+                      strerror(errno));
+        }
+        if (written == 0) {
+            ThrowInfo(ErrorCode::FileWriteFailed,
+                      "write to local file {} at offset {} made no progress",
+                      debug_path_.string(),
+                      static_cast<uint64_t>(current_offset));
+        }
+        total += static_cast<size_t>(written);
+    }
+    return total;
+}
+
+uint64_t
+WritableFile::Size() const {
+    return FileSize(fd_, debug_path_);
+}
+
+void
+WritableFile::Truncate(uint64_t size) {
+    auto checked_size = CheckedOffset(size, debug_path_);
+    if (ftruncate(fd_, checked_size) != 0) {
+        ThrowInfo(ErrorCode::FileWriteFailed,
+                  "failed to truncate local file {} to {}, error: {}",
+                  debug_path_.string(),
+                  size,
+                  strerror(errno));
+    }
+}
+
+void
+WritableFile::Sync() {
+    if (fsync(fd_) != 0) {
+        ThrowInfo(ErrorCode::FileWriteFailed,
+                  "failed to sync local file {}, error: {}",
+                  debug_path_.string(),
+                  strerror(errno));
+    }
+}
+
+}  // namespace milvus::local::io

--- a/internal/core/src/local/io/File.h
+++ b/internal/core/src/local/io/File.h
@@ -1,0 +1,117 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <span>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+
+namespace milvus::local {
+class FileSystem;
+}
+
+namespace milvus::local::io {
+
+// ReadAt does not mutate a shared file position and may be called concurrently
+// while the handle remains alive.
+class RandomAccessFile final {
+ public:
+    RandomAccessFile(const RandomAccessFile&) = delete;
+    RandomAccessFile&
+    operator=(const RandomAccessFile&) = delete;
+
+    RandomAccessFile(RandomAccessFile&& other) noexcept;
+    RandomAccessFile&
+    operator=(RandomAccessFile&& other) noexcept;
+
+    ~RandomAccessFile();
+
+    size_t
+    ReadAt(uint64_t offset, std::span<std::byte> output) const;
+
+    uint64_t
+    Size() const;
+
+ private:
+    friend class local::FileSystem;
+
+    RandomAccessFile(int fd, std::filesystem::path debug_path) noexcept;
+
+    void
+    Close() noexcept;
+
+    int fd_{-1};
+    std::filesystem::path debug_path_;
+};
+
+// WritableFile does not serialize writes. Callers own ordering and must not
+// issue overlapping concurrent writes.
+class WritableFile final {
+ public:
+    WritableFile(const WritableFile&) = delete;
+    WritableFile&
+    operator=(const WritableFile&) = delete;
+
+    WritableFile(WritableFile&& other) noexcept;
+    WritableFile&
+    operator=(WritableFile&& other) noexcept;
+
+    ~WritableFile();
+
+    size_t
+    Write(std::span<const std::byte> data);
+
+    size_t
+    WriteAt(uint64_t offset, std::span<const std::byte> data);
+
+    uint64_t
+    Size() const;
+
+    void
+    Truncate(uint64_t size);
+
+    void
+    Sync();
+
+    const std::filesystem::path&
+    DebugPath() const noexcept {
+        return debug_path_;
+    }
+
+    bool
+    DirectIOEnabled() const noexcept {
+        return direct_io_;
+    }
+
+ private:
+    friend class local::FileSystem;
+
+    WritableFile(int fd,
+                 std::filesystem::path debug_path,
+                 bool direct_io) noexcept;
+
+    void
+    Close() noexcept;
+
+    int fd_{-1};
+    std::filesystem::path debug_path_;
+    bool direct_io_{false};
+};
+
+}  // namespace milvus::local::io

--- a/internal/core/src/local/io/MappedRegion.cpp
+++ b/internal/core/src/local/io/MappedRegion.cpp
@@ -1,0 +1,65 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "local/io/MappedRegion.h"
+
+#include <sys/mman.h>
+#include <utility>
+
+namespace milvus::local::io {
+
+MappedRegion::MappedRegion(void* mapping,
+                           size_t mapping_size,
+                           const std::byte* data,
+                           size_t size) noexcept
+    : mapping_(mapping), mapping_size_(mapping_size), data_(data), size_(size) {
+}
+
+MappedRegion::MappedRegion(MappedRegion&& other) noexcept
+    : mapping_(std::exchange(other.mapping_, nullptr)),
+      mapping_size_(std::exchange(other.mapping_size_, 0)),
+      data_(std::exchange(other.data_, nullptr)),
+      size_(std::exchange(other.size_, 0)) {
+}
+
+MappedRegion&
+MappedRegion::operator=(MappedRegion&& other) noexcept {
+    if (this != &other) {
+        Reset();
+        mapping_ = std::exchange(other.mapping_, nullptr);
+        mapping_size_ = std::exchange(other.mapping_size_, 0);
+        data_ = std::exchange(other.data_, nullptr);
+        size_ = std::exchange(other.size_, 0);
+    }
+    return *this;
+}
+
+MappedRegion::~MappedRegion() {
+    Reset();
+}
+
+void
+MappedRegion::Reset() noexcept {
+    if (mapping_ != nullptr) {
+        munmap(mapping_, mapping_size_);
+    }
+    mapping_ = nullptr;
+    mapping_size_ = 0;
+    data_ = nullptr;
+    size_ = 0;
+}
+
+}  // namespace milvus::local::io

--- a/internal/core/src/local/io/MappedRegion.h
+++ b/internal/core/src/local/io/MappedRegion.h
@@ -1,0 +1,65 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <span>
+
+#include <cstddef>
+
+namespace milvus::local {
+class FileSystem;
+}
+
+namespace milvus::local::io {
+
+class MappedRegion final {
+ public:
+    MappedRegion() = default;
+
+    MappedRegion(const MappedRegion&) = delete;
+    MappedRegion&
+    operator=(const MappedRegion&) = delete;
+
+    MappedRegion(MappedRegion&& other) noexcept;
+    MappedRegion&
+    operator=(MappedRegion&& other) noexcept;
+
+    ~MappedRegion();
+
+    std::span<const std::byte>
+    Data() const noexcept {
+        return {data_, size_};
+    }
+
+ private:
+    friend class local::FileSystem;
+
+    MappedRegion(void* mapping,
+                 size_t mapping_size,
+                 const std::byte* data,
+                 size_t size) noexcept;
+
+    void
+    Reset() noexcept;
+
+    void* mapping_{nullptr};
+    size_t mapping_size_{0};
+    const std::byte* data_{nullptr};
+    size_t size_{0};
+};
+
+}  // namespace milvus::local::io

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -27,6 +27,7 @@
 #include <iosfwd>
 #include <memory>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <tuple>
 #include <unordered_map>
@@ -52,6 +53,7 @@
 #include "index/Meta.h"
 #include "index/Utils.h"
 #include "knowhere/sparse_utils.h"
+#include "local/LegacyLocalChunkFiles.h"
 #include "log/Log.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "nlohmann/json.hpp"
@@ -61,8 +63,6 @@
 #include "storage/DiskFileManagerImpl.h"
 #include "storage/FileManager.h"
 #include "storage/FileWriter.h"
-#include "storage/LocalChunkManager.h"
-#include "storage/LocalChunkManagerSingleton.h"
 #include "storage/RemoteOutputStream.h"
 #include "storage/ThreadPool.h"
 #include "storage/ThreadPools.h"
@@ -73,72 +73,36 @@ namespace milvus::storage {
 
 namespace {
 std::atomic<uint64_t> g_file_path_generation{0};
-}
 
-struct DiskFileManagerImpl::LocalDirState {
-    explicit LocalDirState(std::string dir) : dir(std::move(dir)) {
+local::FileSystem
+ResolveLocalFiles(const FileManagerContext& context) {
+    if (context.local_files.has_value()) {
+        return *context.local_files;
     }
-
-    std::string dir;
-    std::mutex mutex;
-    bool closed = false;
-    bool delete_on_zero = false;
-    uint64_t active_writers = 0;
-};
-
-DiskFileManagerImpl::LocalDirWriteLease::LocalDirWriteLease(
-    std::shared_ptr<LocalDirState> state)
-    : state_(std::move(state)) {
-}
-
-DiskFileManagerImpl::LocalDirWriteLease&
-DiskFileManagerImpl::LocalDirWriteLease::operator=(
-    LocalDirWriteLease&& other) noexcept {
-    if (this != &other) {
-        Release();
-        state_ = std::move(other.state_);
-    }
-    return *this;
-}
-
-DiskFileManagerImpl::LocalDirWriteLease::~LocalDirWriteLease() {
-    Release();
+    return local::LegacyLocalChunkFiles();
 }
 
 void
-DiskFileManagerImpl::LocalDirWriteLease::Release() noexcept {
-    auto state = std::exchange(state_, nullptr);
-    if (state == nullptr) {
-        return;
-    }
-
-    bool remove_dir = false;
-    std::string dir;
-    {
-        std::lock_guard<std::mutex> lock(state->mutex);
-        if (state->active_writers == 0) {
-            LOG_WARN(
-                "local dir write lease released with no active writers, "
-                "dir: {}",
-                state->dir);
-            return;
-        }
-        --state->active_writers;
-        if (state->active_writers == 0 && state->delete_on_zero) {
-            remove_dir = true;
-            dir = state->dir;
-        }
-    }
-
-    if (remove_dir) {
-        DiskFileManagerImpl::RemoveLocalDirBestEffort(dir);
-    }
+WriteBytesAt(local::io::WritableFile& file,
+             uint64_t offset,
+             const void* data,
+             size_t size) {
+    auto bytes = std::span<const std::byte>(
+        reinterpret_cast<const std::byte*>(data), size);
+    auto bytes_written = file.WriteAt(offset, bytes);
+    AssertInfo(bytes_written == size,
+               "short write to local file {}, expected {}, got {}",
+               file.DebugPath().string(),
+               size,
+               bytes_written);
 }
+}  // namespace
 
 DiskFileManagerImpl::DiskFileManagerImpl(
     const FileManagerContext& fileManagerContext)
     : FileManagerImpl(fileManagerContext.fieldDataMeta,
-                      fileManagerContext.indexMeta),
+                      fileManagerContext.indexMeta,
+                      ResolveLocalFiles(fileManagerContext)),
       file_path_generation_(
           g_file_path_generation.fetch_add(1, std::memory_order_relaxed)) {
     rcm_ = fileManagerContext.chunkManagerPtr;
@@ -151,9 +115,12 @@ DiskFileManagerImpl::DiskFileManagerImpl(
 
 DiskFileManagerImpl::~DiskFileManagerImpl() {
     RemoveIndexFiles();
+    CloseAndRemoveLocalDir(LocalIndexObjectPath(true));
     RemoveTextLogFiles();
     RemoveJsonStatsFiles();
+    CloseAndRemoveLocalDir(LocalJsonStatsPath(true));
     RemoveNgramIndexFiles();
+    CloseAndRemoveLocalDir(LocalNgramIndexPath(true));
     RemoveRawDataFiles();
 }
 
@@ -214,92 +181,120 @@ DiskFileManagerImpl::GetLocalJsonStatsMetaPrefix() {
 }
 
 std::string
-DiskFileManagerImpl::AppendLocalPathGeneration(
-    const std::string& prefix) const {
+DiskFileManagerImpl::ResolveLocalPrefix(const local::Path& path) const {
     namespace fs = std::filesystem;
-    auto base = prefix;
-    auto is_path_separator = [](char c) { return c == '/' || c == '\\'; };
-    while (!base.empty() && is_path_separator(base.back())) {
-        base.pop_back();
-    }
-
-    auto path = fs::path(base);
-    auto leaf = path.filename().string();
-    auto result =
-        leaf.empty()
-            ? (fs::path(prefix) / std::to_string(file_path_generation_))
-                  .string()
-            : (path.parent_path() /
-               fmt::format("{}_{}", leaf, file_path_generation_))
-                  .string();
+    auto result = local_files_->ResolveNativePath(path).string();
     if (!result.empty() && result.back() != fs::path::preferred_separator) {
         result += fs::path::preferred_separator;
     }
     return result;
 }
 
-void
-DiskFileManagerImpl::RemoveLocalDirBestEffort(const std::string& dir) noexcept {
-    try {
-        auto local_chunk_manager =
-            LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-        if (local_chunk_manager != nullptr) {
-            local_chunk_manager->RemoveDir(dir);
-        }
-    } catch (const std::exception& e) {
-        LOG_WARN("failed to remove local dir {}, error: {}", dir, e.what());
-    } catch (...) {
-        LOG_WARN("failed to remove local dir {}, unknown error", dir);
-    }
+local::Path
+DiskFileManagerImpl::LocalIndexObjectPath(bool temporary) const {
+    auto prefix = temporary ? std::filesystem::path("tmp") / INDEX_ROOT_PATH
+                            : std::filesystem::path(INDEX_ROOT_PATH);
+    return local::Path((prefix / fmt::format("{}_{}_{}_{}_{}",
+                                             index_meta_.build_id,
+                                             index_meta_.index_version,
+                                             index_meta_.segment_id,
+                                             index_meta_.field_id,
+                                             file_path_generation_))
+                           .generic_string());
 }
 
-std::shared_ptr<DiskFileManagerImpl::LocalDirState>
-DiskFileManagerImpl::GetOrCreateLocalDirState(const std::string& dir) {
-    std::lock_guard<std::mutex> lock(local_dir_states_mutex_);
-    auto it = local_dir_states_.find(dir);
-    if (it != local_dir_states_.end()) {
+local::Path
+DiskFileManagerImpl::LocalTextIndexPath(bool temporary) const {
+    if (temporary) {
+        return LocalIndexObjectPath(true);
+    }
+    return local::Path((std::filesystem::path(TEXT_LOG_ROOT_PATH) /
+                        fmt::format("{}_{}_{}_{}_{}",
+                                    index_meta_.build_id,
+                                    index_meta_.index_version,
+                                    field_meta_.segment_id,
+                                    field_meta_.field_id,
+                                    file_path_generation_))
+                           .generic_string());
+}
+
+local::Path
+DiskFileManagerImpl::LocalJsonStatsPath(bool temporary) const {
+    auto prefix = temporary
+                      ? std::filesystem::path("tmp") / JSON_STATS_ROOT_PATH
+                      : std::filesystem::path(JSON_STATS_ROOT_PATH);
+    return local::Path((prefix / fmt::format("{}_{}_{}_{}_{}",
+                                             index_meta_.build_id,
+                                             index_meta_.index_version,
+                                             field_meta_.segment_id,
+                                             field_meta_.field_id,
+                                             file_path_generation_))
+                           .generic_string());
+}
+
+local::Path
+DiskFileManagerImpl::LocalNgramIndexPath(bool temporary) const {
+    auto prefix = temporary ? std::filesystem::path("tmp") / NGRAM_LOG_ROOT_PATH
+                            : std::filesystem::path(NGRAM_LOG_ROOT_PATH);
+    return local::Path((prefix / fmt::format("{}_{}_{}_{}_{}",
+                                             index_meta_.build_id,
+                                             index_meta_.index_version,
+                                             field_meta_.segment_id,
+                                             field_meta_.field_id,
+                                             file_path_generation_))
+                           .generic_string());
+}
+
+local::Path
+DiskFileManagerImpl::LocalRawDataPath() const {
+    return local::Path((std::filesystem::path(RAWDATA_ROOT_PATH) /
+                        fmt::format("{}_{}_{}",
+                                    field_meta_.segment_id,
+                                    field_meta_.field_id,
+                                    file_path_generation_))
+                           .generic_string());
+}
+
+std::shared_ptr<local::ManagedSubtree>
+DiskFileManagerImpl::GetOrCreateManagedSubtree(const local::Path& path) {
+    auto key = std::string(path.String());
+    std::lock_guard<std::mutex> lock(managed_subtrees_mutex_);
+    auto it = managed_subtrees_.find(key);
+    if (it != managed_subtrees_.end()) {
         return it->second;
     }
 
-    auto state = std::make_shared<LocalDirState>(dir);
-    local_dir_states_.emplace(dir, state);
-    return state;
+    auto subtree = local_files_->ManageSubtree(path);
+    managed_subtrees_.emplace(std::move(key), subtree);
+    return subtree;
+}
+
+local::Path
+DiskFileManagerImpl::LocalPathForResolvedPrefix(const std::string& dir) const {
+    return local_files_->PathFromNativePath(dir);
 }
 
 DiskFileManagerImpl::LocalDirWriteLease
 DiskFileManagerImpl::AcquireLocalDirWriteLease(const std::string& dir) {
-    auto state = GetOrCreateLocalDirState(dir);
-    std::lock_guard<std::mutex> lock(state->mutex);
-    if (state->closed) {
-        ThrowInfo(FileWriteFailed,
-                  fmt::format("local dir {} is closed for cleanup", dir));
-    }
-    ++state->active_writers;
-    return LocalDirWriteLease(std::move(state));
+    return AcquireLocalDirWriteLease(LocalPathForResolvedPrefix(dir));
+}
+
+DiskFileManagerImpl::LocalDirWriteLease
+DiskFileManagerImpl::AcquireLocalDirWriteLease(const local::Path& path) {
+    return GetOrCreateManagedSubtree(path)->AcquireWriter();
 }
 
 void
-DiskFileManagerImpl::CloseAndRemoveLocalDir(const std::string& dir) noexcept {
+DiskFileManagerImpl::CloseAndRemoveLocalDir(const local::Path& path) noexcept {
     try {
-        auto state = GetOrCreateLocalDirState(dir);
-        bool remove_dir = false;
-        {
-            std::lock_guard<std::mutex> lock(state->mutex);
-            state->closed = true;
-            if (state->active_writers == 0) {
-                remove_dir = true;
-            } else {
-                state->delete_on_zero = true;
-            }
-        }
-
-        if (remove_dir) {
-            RemoveLocalDirBestEffort(dir);
-        }
-    } catch (const std::exception& e) {
-        LOG_WARN("failed to close local dir {}, error: {}", dir, e.what());
+        GetOrCreateManagedSubtree(path)->RemoveWhenIdle();
+    } catch (const std::exception& error) {
+        LOG_WARN("failed to close local subtree {}, error: {}",
+                 path.String(),
+                 error.what());
     } catch (...) {
-        LOG_WARN("failed to close local dir {}, unknown error", dir);
+        LOG_WARN("failed to close local subtree {}, unknown error",
+                 path.String());
     }
 }
 
@@ -308,10 +303,9 @@ DiskFileManagerImpl::AddFileInternal(
     const std::string& file,
     const std::function<std::string(const std::string&, int)>&
         get_remote_path) noexcept {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     FILEMANAGER_TRY
-    if (!local_chunk_manager->Exist(file)) {
+    auto local_path = local_files_->PathFromNativePath(file);
+    if (!local_files_->Exists(local_path)) {
         LOG_ERROR("local file {} not exists", file);
         return false;
     }
@@ -320,7 +314,7 @@ DiskFileManagerImpl::AddFileInternal(
     local_paths_.emplace_back(file);
 
     auto fileName = GetFileName(file);
-    auto fileSize = local_chunk_manager->Size(file);
+    auto fileSize = local_files_->FileSize(local_path);
     added_total_file_size_ += fileSize;
 
     std::vector<std::string> batch_remote_files;
@@ -385,23 +379,27 @@ DiskFileManagerImpl::AddJsonSharedIndexLog(const std::string& file) noexcept {
 
 bool
 DiskFileManagerImpl::AddJsonStatsMetaLog(const std::string& file) noexcept {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     FILEMANAGER_TRY
-    if (!local_chunk_manager->Exist(file)) {
+    auto local_path = local_files_->PathFromNativePath(file);
+    if (!local_files_->Exists(local_path)) {
         LOG_ERROR("local meta file {} not exists", file);
         return false;
     }
 
     local_paths_.emplace_back(file);
     auto fileName = GetFileName(file);
-    auto fileSize = local_chunk_manager->Size(file);
+    auto local_file = local_files_->OpenForRead(local_path);
+    auto fileSize = local_file.Size();
     added_total_file_size_ += fileSize;
 
     // Meta file is small, upload directly without slicing
     auto remote_path = GetRemoteJsonStatsMetaPath(fileName);
     auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[fileSize]);
-    local_chunk_manager->Read(file, buf.get(), fileSize);
+    auto bytes =
+        std::span<std::byte>(reinterpret_cast<std::byte*>(buf.get()), fileSize);
+    AssertInfo(local_file.ReadAt(0, bytes) == fileSize,
+               "failed to read complete local meta file {}",
+               file);
     rcm_->Write(remote_path, buf.get(), fileSize);
 
     remote_paths_to_size_[remote_path] = fileSize;
@@ -429,8 +427,9 @@ DiskFileManagerImpl::AddBatchIndexFiles(
     const std::vector<int64_t>& local_file_offsets,
     const std::vector<std::string>& remote_files,
     const std::vector<int64_t>& remote_file_sizes) {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto local_path = local_files_->PathFromNativePath(local_file_name);
+    auto local_file = std::make_shared<local::io::RandomAccessFile>(
+        local_files_->OpenForRead(local_path));
     auto& pool = ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
 
     std::vector<std::future<std::shared_ptr<uint8_t[]>>> futures;
@@ -442,15 +441,19 @@ DiskFileManagerImpl::AddBatchIndexFiles(
 
     for (int64_t i = 0; i < remote_files.size(); ++i) {
         futures.push_back(pool.Submit(
-            [local_chunk_manager](
-                const std::string& file,
-                const int64_t offset,
-                const int64_t data_size) -> std::shared_ptr<uint8_t[]> {
+            [local_file](const int64_t offset, const int64_t data_size)
+                -> std::shared_ptr<uint8_t[]> {
                 auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[data_size]);
-                local_chunk_manager->Read(file, offset, buf.get(), data_size);
+                auto bytes = std::span<std::byte>(
+                    reinterpret_cast<std::byte*>(buf.get()), data_size);
+                auto bytes_read = local_file->ReadAt(offset, bytes);
+                AssertInfo(
+                    bytes_read == data_size,
+                    "short read from local index file, expected {}, got {}",
+                    data_size,
+                    bytes_read);
                 return buf;
             },
-            local_file_name,
             local_file_offsets[i],
             remote_file_sizes[i]));
     }
@@ -483,9 +486,6 @@ DiskFileManagerImpl::CacheIndexToDiskInternal(
     const std::vector<std::string>& remote_files,
     const std::string& local_index_prefix,
     milvus::proto::common::LoadPriority priority) {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-
     std::map<std::string, std::vector<int>> index_slices;
     for (auto& file_path : remote_files) {
         auto pos = file_path.find_last_of('_');
@@ -514,7 +514,8 @@ DiskFileManagerImpl::CacheIndexToDiskInternal(
         auto prefix = slices.first;
         auto local_index_file_name =
             local_index_prefix + prefix.substr(prefix.find_last_of('/') + 1);
-        local_chunk_manager->CreateFile(local_index_file_name);
+        auto local_path =
+            local_files_->PathFromNativePath(local_index_file_name);
 
         // Get the remote files
         std::vector<std::string> batch_remote_files;
@@ -524,8 +525,12 @@ DiskFileManagerImpl::CacheIndexToDiskInternal(
             uint64_t(DEFAULT_FIELD_MAX_MEMORY_LIMIT / FILE_SLICE_SIZE.load());
 
         {
+            auto local_file = local_files_->OpenForWrite(
+                local_path,
+                local::WriteOptions{
+                    .create = true, .truncate = true, .create_parent = true});
             auto file_writer = storage::FileWriter(
-                local_index_file_name,
+                std::move(local_file),
                 storage::io::GetPriorityFromLoadPriority(priority));
             auto appendIndexFiles = [&]() {
                 auto index_chunks_futures =
@@ -566,7 +571,7 @@ DiskFileManagerImpl::CacheIndexToDisk(
     const std::vector<std::string>& remote_files,
     milvus::proto::common::LoadPriority priority) {
     auto local_prefix = GetLocalIndexObjectPrefix();
-    auto lease = AcquireLocalDirWriteLease(local_prefix);
+    auto lease = AcquireLocalDirWriteLease(LocalIndexObjectPath(false));
     CacheIndexToDiskInternal(remote_files, local_prefix, priority);
 }
 
@@ -575,7 +580,7 @@ DiskFileManagerImpl::CacheTextLogToDisk(
     const std::vector<std::string>& remote_files,
     milvus::proto::common::LoadPriority priority) {
     auto local_prefix = GetLocalTextIndexPrefix();
-    auto lease = AcquireLocalDirWriteLease(local_prefix);
+    auto lease = AcquireLocalDirWriteLease(LocalTextIndexPath(false));
     CacheIndexToDiskInternal(remote_files, local_prefix, priority);
 }
 
@@ -584,7 +589,7 @@ DiskFileManagerImpl::CacheNgramIndexToDisk(
     const std::vector<std::string>& remote_files,
     milvus::proto::common::LoadPriority priority) {
     auto local_prefix = GetLocalNgramIndexPrefix();
-    auto lease = AcquireLocalDirWriteLease(local_prefix);
+    auto lease = AcquireLocalDirWriteLease(LocalNgramIndexPath(false));
     CacheIndexToDiskInternal(remote_files, local_prefix, priority);
 }
 
@@ -593,7 +598,7 @@ DiskFileManagerImpl::CacheJsonStatsSharedIndexToDisk(
     const std::vector<std::string>& remote_files,
     milvus::proto::common::LoadPriority priority) {
     auto local_prefix = GetLocalJsonStatsSharedIndexPrefix();
-    auto lease = AcquireLocalDirWriteLease(GetLocalJsonStatsPrefix());
+    auto lease = AcquireLocalDirWriteLease(LocalJsonStatsPath(false));
     CacheIndexToDiskInternal(remote_files, local_prefix, priority);
 }
 
@@ -601,25 +606,27 @@ std::string
 DiskFileManagerImpl::CacheJsonStatsMetaToDisk(
     const std::string& remote_file,
     milvus::proto::common::LoadPriority priority) {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     auto local_prefix = GetLocalJsonStatsMetaPrefix();
-    auto lease = AcquireLocalDirWriteLease(GetLocalJsonStatsPrefix());
+    auto lease = AcquireLocalDirWriteLease(LocalJsonStatsPath(false));
 
     auto file_name = remote_file.substr(remote_file.find_last_of('/') + 1);
     auto local_file =
         (std::filesystem::path(local_prefix) / file_name).string();
 
-    auto parent_path = std::filesystem::path(local_file).parent_path();
-    if (!local_chunk_manager->Exist(parent_path.string())) {
-        local_chunk_manager->CreateDir(parent_path.string());
-    }
-
     // remote_file is an absolute remote path (basePath already prepended by caller)
     auto file_size = rcm_->Size(remote_file);
     auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[file_size]);
     rcm_->Read(remote_file, buf.get(), file_size);
-    local_chunk_manager->Write(local_file, buf.get(), file_size);
+    auto local_path = local_files_->PathFromNativePath(local_file);
+    auto output = local_files_->OpenForWrite(
+        local_path,
+        local::WriteOptions{
+            .create = true, .truncate = true, .create_parent = true});
+    auto bytes = std::span<const std::byte>(
+        reinterpret_cast<const std::byte*>(buf.get()), file_size);
+    AssertInfo(output.Write(bytes) == file_size,
+               "failed to write complete json stats meta file {}",
+               local_file);
 
     LOG_INFO("Cached json stats meta file from {} to {}, size: {}",
              remote_file,
@@ -632,14 +639,13 @@ DiskFileManagerImpl::CacheJsonStatsMetaToDisk(
 template <typename DataType>
 std::string
 DiskFileManagerImpl::CacheRawDataToDisk(const Config& config) {
-    auto raw_data_lease =
-        AcquireLocalDirWriteLease(GetLocalRawDataObjectPrefix());
+    auto raw_data_lease = AcquireLocalDirWriteLease(LocalRawDataPath());
     std::optional<LocalDirWriteLease> valid_data_lease;
     if (index::GetValueFromConfig<std::string>(config,
                                                index::VALID_DATA_PATH_KEY)
             .has_value()) {
         valid_data_lease.emplace(
-            AcquireLocalDirWriteLease(GetLocalIndexObjectPrefix()));
+            AcquireLocalDirWriteLease(LocalIndexObjectPath(false)));
     }
 
     auto storage_version =
@@ -661,10 +667,8 @@ DiskFileManagerImpl::cache_raw_data_to_disk_internal(const Config& config) {
     auto remote_files = insert_files.value();
     SortByPath(remote_files);
 
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     std::string local_data_path;
-    bool file_created = false;
+    std::optional<local::io::WritableFile> local_file;
 
     // Check if we're dealing with embedding list (VECTOR_ARRAY)
     auto is_embedding_list =
@@ -718,9 +722,8 @@ DiskFileManagerImpl::cache_raw_data_to_disk_internal(const Config& config) {
 
                 cache_raw_data_to_disk_common<DataType>(
                     field_data,
-                    local_chunk_manager,
+                    local_file,
                     local_data_path,
-                    file_created,
                     dim,
                     write_offset,
                     is_vector_array ? &offsets : nullptr);
@@ -750,11 +753,9 @@ DiskFileManagerImpl::cache_raw_data_to_disk_internal(const Config& config) {
 
     // write num_rows and dim value to file header
     write_offset = 0;
-    local_chunk_manager->Write(
-        local_data_path, write_offset, &num_rows, sizeof(num_rows));
+    WriteBytesAt(*local_file, write_offset, &num_rows, sizeof(num_rows));
     write_offset += sizeof(num_rows);
-    local_chunk_manager->Write(
-        local_data_path, write_offset, &dim, sizeof(dim));
+    WriteBytesAt(*local_file, write_offset, &dim, sizeof(dim));
 
     // Write offsets file for VECTOR_ARRAY
     if (is_vector_array) {
@@ -773,27 +774,28 @@ DiskFileManagerImpl::cache_raw_data_to_disk_internal(const Config& config) {
             auto offsets_path = index::GetValueFromConfig<std::string>(
                                     config, index::EMB_LIST_OFFSETS_PATH)
                                     .value();
-            local_chunk_manager->CreateFile(offsets_path);
+            auto offsets_file = local_files_->OpenForWrite(
+                local_files_->PathFromNativePath(offsets_path),
+                local::WriteOptions{
+                    .create = true, .truncate = true, .create_parent = true});
 
             size_t num_offsets = offsets.size();
             int64_t offsets_write_pos = 0;
 
-            local_chunk_manager->Write(
-                offsets_path, offsets_write_pos, &num_offsets, sizeof(size_t));
+            WriteBytesAt(
+                offsets_file, offsets_write_pos, &num_offsets, sizeof(size_t));
             offsets_write_pos += sizeof(size_t);
 
-            local_chunk_manager->Write(offsets_path,
-                                       offsets_write_pos,
-                                       offsets.data(),
-                                       offsets.size() * sizeof(size_t));
+            WriteBytesAt(offsets_file,
+                         offsets_write_pos,
+                         offsets.data(),
+                         offsets.size() * sizeof(size_t));
         }
     }
 
     if (nullable && valid_data_path.has_value() && total_num_rows > 0) {
-        write_valid_data_file(local_chunk_manager,
-                              valid_data_path.value(),
-                              valid_bitmap,
-                              total_num_rows);
+        write_valid_data_file(
+            valid_data_path.value(), valid_bitmap, total_num_rows);
     }
 
     return local_data_path;
@@ -803,23 +805,27 @@ template <typename DataType>
 void
 DiskFileManagerImpl::cache_raw_data_to_disk_common(
     const FieldDataPtr& field_data,
-    const std::shared_ptr<LocalChunkManager>& local_chunk_manager,
+    std::optional<local::io::WritableFile>& local_file,
     std::string& local_data_path,
-    bool& file_created,
     uint32_t& dim,
     int64_t& write_offset,
     std::vector<size_t>* offsets) {
     auto data_type = field_data->get_data_type();
-    if (!file_created) {
+    if (!local_file.has_value()) {
         auto init_file_info = [&](milvus::DataType dt) {
-            local_data_path = GetLocalRawDataObjectPrefix() + "raw_data";
+            auto relative_path =
+                std::string(LocalRawDataPath().String()) + "/raw_data";
             if (dt == milvus::DataType::VECTOR_SPARSE_U32_F32) {
-                local_data_path += ".sparse_u32_f32";
+                relative_path += ".sparse_u32_f32";
             }
-            local_chunk_manager->CreateFile(local_data_path);
+            auto path = local::Path(std::move(relative_path));
+            local_data_path = local_files_->ResolveNativePath(path).string();
+            local_file.emplace(local_files_->OpenForWrite(
+                path,
+                local::WriteOptions{
+                    .create = true, .truncate = true, .create_parent = true}));
         };
         init_file_info(data_type);
-        file_created = true;
     }
     if (data_type == milvus::DataType::VECTOR_SPARSE_U32_F32) {
         dim =
@@ -833,13 +839,9 @@ DiskFileManagerImpl::cache_raw_data_to_disk_common(
             auto row = sparse_rows[i];
             auto row_byte_size = row.data_byte_size();
             uint32_t nnz = row.size();
-            local_chunk_manager->Write(local_data_path,
-                                       write_offset,
-                                       const_cast<uint32_t*>(&nnz),
-                                       sizeof(nnz));
+            WriteBytesAt(*local_file, write_offset, &nnz, sizeof(nnz));
             write_offset += sizeof(nnz);
-            local_chunk_manager->Write(
-                local_data_path, write_offset, row.data(), row_byte_size);
+            WriteBytesAt(*local_file, write_offset, row.data(), row_byte_size);
             write_offset += row_byte_size;
         }
     } else if (data_type == milvus::DataType::VECTOR_ARRAY) {
@@ -887,38 +889,33 @@ DiskFileManagerImpl::cache_raw_data_to_disk_common(
         }
 
         // Write flattened data to disk
-        local_chunk_manager->Write(
-            local_data_path, write_offset, buf.get(), total_size);
+        WriteBytesAt(*local_file, write_offset, buf.get(), total_size);
         write_offset += total_size;
     } else {
         dim = field_data->get_dim();
         auto data_size =
             field_data->get_valid_rows() * milvus::GetVecRowSize<DataType>(dim);
-        local_chunk_manager->Write(local_data_path,
-                                   write_offset,
-                                   const_cast<void*>(field_data->Data()),
-                                   data_size);
+        WriteBytesAt(*local_file, write_offset, field_data->Data(), data_size);
         write_offset += data_size;
     }
 }
 
 void
-DiskFileManagerImpl::write_valid_data_file(
-    const std::shared_ptr<LocalChunkManager>& local_chunk_manager,
-    const std::string& valid_data_path,
-    std::vector<uint8_t>& valid_bitmap,
-    uint64_t total_num_rows) {
-    local_chunk_manager->CreateFile(valid_data_path);
+DiskFileManagerImpl::write_valid_data_file(const std::string& valid_data_path,
+                                           std::vector<uint8_t>& valid_bitmap,
+                                           uint64_t total_num_rows) {
+    auto valid_file = local_files_->OpenForWrite(
+        local_files_->PathFromNativePath(valid_data_path),
+        local::WriteOptions{
+            .create = true, .truncate = true, .create_parent = true});
     int64_t valid_write_pos = 0;
 
-    local_chunk_manager->Write(
-        valid_data_path, valid_write_pos, &total_num_rows, sizeof(uint64_t));
+    WriteBytesAt(
+        valid_file, valid_write_pos, &total_num_rows, sizeof(uint64_t));
     valid_write_pos += sizeof(uint64_t);
 
-    local_chunk_manager->Write(valid_data_path,
-                               valid_write_pos,
-                               valid_bitmap.data(),
-                               valid_bitmap.size());
+    WriteBytesAt(
+        valid_file, valid_write_pos, valid_bitmap.data(), valid_bitmap.size());
 }
 
 template <typename T>
@@ -941,10 +938,8 @@ DiskFileManagerImpl::cache_raw_data_to_disk_storage_v2(const Config& config) {
         SortByPath(remote_files);
     }
 
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     std::string local_data_path;
-    bool file_created = false;
+    std::optional<local::io::WritableFile> local_file;
 
     // Check if we're dealing with embedding list (VECTOR_ARRAY)
     auto is_embedding_list =
@@ -1020,9 +1015,8 @@ DiskFileManagerImpl::cache_raw_data_to_disk_storage_v2(const Config& config) {
         }
 
         cache_raw_data_to_disk_common<T>(field_data,
-                                         local_chunk_manager,
+                                         local_file,
                                          local_data_path,
-                                         file_created,
                                          var_dim,
                                          write_offset,
                                          is_vector_array ? &offsets : nullptr);
@@ -1036,11 +1030,9 @@ DiskFileManagerImpl::cache_raw_data_to_disk_storage_v2(const Config& config) {
 
     // write num_rows and dim value to file header
     write_offset = 0;
-    local_chunk_manager->Write(
-        local_data_path, write_offset, &num_rows, sizeof(num_rows));
+    WriteBytesAt(*local_file, write_offset, &num_rows, sizeof(num_rows));
     write_offset += sizeof(num_rows);
-    local_chunk_manager->Write(
-        local_data_path, write_offset, &var_dim, sizeof(var_dim));
+    WriteBytesAt(*local_file, write_offset, &var_dim, sizeof(var_dim));
 
     // Write offsets file for VECTOR_ARRAY
     if (is_vector_array) {
@@ -1060,27 +1052,28 @@ DiskFileManagerImpl::cache_raw_data_to_disk_storage_v2(const Config& config) {
                                     config, index::EMB_LIST_OFFSETS_PATH)
                                     .value();
 
-            local_chunk_manager->CreateFile(offsets_path);
+            auto offsets_file = local_files_->OpenForWrite(
+                local_files_->PathFromNativePath(offsets_path),
+                local::WriteOptions{
+                    .create = true, .truncate = true, .create_parent = true});
 
             size_t num_offsets = offsets.size();
             int64_t offsets_write_pos = 0;
 
-            local_chunk_manager->Write(
-                offsets_path, offsets_write_pos, &num_offsets, sizeof(size_t));
+            WriteBytesAt(
+                offsets_file, offsets_write_pos, &num_offsets, sizeof(size_t));
             offsets_write_pos += sizeof(size_t);
 
-            local_chunk_manager->Write(offsets_path,
-                                       offsets_write_pos,
-                                       offsets.data(),
-                                       offsets.size() * sizeof(size_t));
+            WriteBytesAt(offsets_file,
+                         offsets_write_pos,
+                         offsets.data(),
+                         offsets.size() * sizeof(size_t));
         }
     }
 
     if (nullable && valid_data_path.has_value() && total_num_rows > 0) {
-        write_valid_data_file(local_chunk_manager,
-                              valid_data_path.value(),
-                              valid_bitmap,
-                              total_num_rows);
+        write_valid_data_file(
+            valid_data_path.value(), valid_bitmap, total_num_rows);
     }
 
     return local_data_path;
@@ -1088,42 +1081,40 @@ DiskFileManagerImpl::cache_raw_data_to_disk_storage_v2(const Config& config) {
 
 void
 DiskFileManagerImpl::RemoveIndexFiles() {
-    CloseAndRemoveLocalDir(GetLocalIndexObjectPrefix());
+    CloseAndRemoveLocalDir(LocalIndexObjectPath(false));
 }
 
 void
 DiskFileManagerImpl::RemoveTextLogFiles() {
-    CloseAndRemoveLocalDir(GetLocalTextIndexPrefix());
+    CloseAndRemoveLocalDir(LocalTextIndexPath(false));
 }
 
 void
 DiskFileManagerImpl::RemoveJsonStatsSharedIndexFiles() {
-    CloseAndRemoveLocalDir(GetLocalJsonStatsPrefix());
+    CloseAndRemoveLocalDir(LocalJsonStatsPath(false));
 }
 
 void
 DiskFileManagerImpl::RemoveJsonStatsFiles() {
-    CloseAndRemoveLocalDir(GetLocalJsonStatsPrefix());
+    CloseAndRemoveLocalDir(LocalJsonStatsPath(false));
 }
 
 void
 DiskFileManagerImpl::RemoveNgramIndexFiles() {
-    CloseAndRemoveLocalDir(GetLocalNgramIndexPrefix());
+    CloseAndRemoveLocalDir(LocalNgramIndexPath(false));
 }
 
 void
 DiskFileManagerImpl::RemoveRawDataFiles() {
-    CloseAndRemoveLocalDir(GetLocalRawDataObjectPrefix());
+    CloseAndRemoveLocalDir(LocalRawDataPath());
 }
 
 template <DataType T>
 bool
-WriteOptFieldIvfDataImpl(
-    const int64_t field_id,
-    const std::shared_ptr<LocalChunkManager>& local_chunk_manager,
-    const std::string& local_data_path,
-    const std::vector<FieldDataPtr>& field_datas,
-    uint64_t& write_offset) {
+WriteOptFieldIvfDataImpl(const int64_t field_id,
+                         local::io::WritableFile& local_file,
+                         const std::vector<FieldDataPtr>& field_datas,
+                         uint64_t& write_offset) {
     using FieldDataT = DataTypeNativeOrVoid<T>;
     using OffsetT = uint32_t;
     std::unordered_map<FieldDataT, std::vector<OffsetT>> mp;
@@ -1143,48 +1134,35 @@ WriteOptFieldIvfDataImpl(
     }
 
     LOG_INFO("Get opt fields with {} categories", mp.size());
-    local_chunk_manager->Write(local_data_path,
-                               write_offset,
-                               const_cast<int64_t*>(&field_id),
-                               sizeof(field_id));
+    WriteBytesAt(local_file, write_offset, &field_id, sizeof(field_id));
     write_offset += sizeof(field_id);
     const uint32_t num_of_unique_field_data = mp.size();
-    local_chunk_manager->Write(local_data_path,
-                               write_offset,
-                               const_cast<uint32_t*>(&num_of_unique_field_data),
-                               sizeof(num_of_unique_field_data));
+    WriteBytesAt(local_file,
+                 write_offset,
+                 &num_of_unique_field_data,
+                 sizeof(num_of_unique_field_data));
     write_offset += sizeof(num_of_unique_field_data);
     for (const auto& [val, offsets] : mp) {
         const uint32_t offsets_cnt = offsets.size();
-        local_chunk_manager->Write(local_data_path,
-                                   write_offset,
-                                   const_cast<uint32_t*>(&offsets_cnt),
-                                   sizeof(offsets_cnt));
+        WriteBytesAt(
+            local_file, write_offset, &offsets_cnt, sizeof(offsets_cnt));
         write_offset += sizeof(offsets_cnt);
         const size_t data_size = offsets_cnt * sizeof(OffsetT);
-        local_chunk_manager->Write(local_data_path,
-                                   write_offset,
-                                   const_cast<OffsetT*>(offsets.data()),
-                                   data_size);
+        WriteBytesAt(local_file, write_offset, offsets.data(), data_size);
         write_offset += data_size;
     }
     return true;
 }
 
-#define GENERATE_OPT_FIELD_IVF_IMPL(DT)               \
-    WriteOptFieldIvfDataImpl<DT>(field_id,            \
-                                 local_chunk_manager, \
-                                 local_data_path,     \
-                                 field_datas,         \
-                                 write_offset)
+#define GENERATE_OPT_FIELD_IVF_IMPL(DT) \
+    WriteOptFieldIvfDataImpl<DT>(       \
+        field_id, local_file, field_datas, write_offset)
 bool
-WriteOptFieldIvfData(
-    const DataType& dt,
-    const int64_t field_id,
-    const std::shared_ptr<LocalChunkManager>& local_chunk_manager,
-    const std::string& local_data_path,
-    const std::vector<FieldDataPtr>& field_datas,
-    uint64_t& write_offset) {
+WriteOptFieldIvfData(const DataType& dt,
+                     const int64_t field_id,
+                     local::io::WritableFile& local_file,
+                     const std::vector<FieldDataPtr>& field_datas,
+                     uint64_t& write_offset) {
     switch (dt) {
         case DataType::BOOL:
             return GENERATE_OPT_FIELD_IVF_IMPL(DataType::BOOL);
@@ -1215,21 +1193,14 @@ WriteOptFieldIvfData(
 #undef GENERATE_OPT_FIELD_IVF_IMPL
 
 void
-WriteOptFieldsIvfMeta(
-    const std::shared_ptr<LocalChunkManager>& local_chunk_manager,
-    const std::string& local_data_path,
-    const uint32_t num_of_fields,
-    uint64_t& write_offset) {
+WriteOptFieldsIvfMeta(local::io::WritableFile& local_file,
+                      const uint32_t num_of_fields,
+                      uint64_t& write_offset) {
     const uint8_t kVersion = 0;
-    local_chunk_manager->Write(local_data_path,
-                               write_offset,
-                               const_cast<uint8_t*>(&kVersion),
-                               sizeof(kVersion));
+    WriteBytesAt(local_file, write_offset, &kVersion, sizeof(kVersion));
     write_offset += sizeof(kVersion);
-    local_chunk_manager->Write(local_data_path,
-                               write_offset,
-                               const_cast<uint32_t*>(&num_of_fields),
-                               sizeof(num_of_fields));
+    WriteBytesAt(
+        local_file, write_offset, &num_of_fields, sizeof(num_of_fields));
     write_offset += sizeof(num_of_fields);
 }
 
@@ -1240,7 +1211,7 @@ DiskFileManagerImpl::CacheOptFieldToDisk(const Config& config) {
     if (!opt_fields.has_value() || opt_fields->empty()) {
         return "";
     }
-    auto lease = AcquireLocalDirWriteLease(GetLocalRawDataObjectPrefix());
+    auto lease = AcquireLocalDirWriteLease(LocalRawDataPath());
 
     auto storage_version =
         index::GetValueFromConfig<int64_t>(config, STORAGE_VERSION_KEY)
@@ -1261,14 +1232,14 @@ DiskFileManagerImpl::CacheOptFieldToDisk(const Config& config) {
             "vector index build with multiple fields is not supported yet");
     }
 
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     auto local_data_path =
         GetLocalRawDataObjectPrefix() + std::string(VEC_OPT_FIELDS);
-    local_chunk_manager->CreateFile(local_data_path);
+    auto local_file = local_files_->OpenForWrite(
+        local_files_->PathFromNativePath(local_data_path),
+        local::WriteOptions{
+            .create = true, .truncate = true, .create_parent = true});
     uint64_t write_offset = 0;
-    WriteOptFieldsIvfMeta(
-        local_chunk_manager, local_data_path, num_of_fields, write_offset);
+    WriteOptFieldsIvfMeta(local_file, num_of_fields, write_offset);
 
     std::unordered_set<int64_t> actual_field_ids;
     for (auto& [field_id, tup] : fields_map) {
@@ -1284,22 +1255,16 @@ DiskFileManagerImpl::CacheOptFieldToDisk(const Config& config) {
         std::vector<FieldDataPtr> field_datas =
             FetchFieldData(rcm_.get(), field_paths);
 
-        if (WriteOptFieldIvfData(field_type,
-                                 field_id,
-                                 local_chunk_manager,
-                                 local_data_path,
-                                 field_datas,
-                                 write_offset)) {
+        if (WriteOptFieldIvfData(
+                field_type, field_id, local_file, field_datas, write_offset)) {
             actual_field_ids.insert(field_id);
         }
     }
 
     if (actual_field_ids.size() != num_of_fields) {
         write_offset = 0;
-        WriteOptFieldsIvfMeta(local_chunk_manager,
-                              local_data_path,
-                              actual_field_ids.size(),
-                              write_offset);
+        WriteOptFieldsIvfMeta(
+            local_file, actual_field_ids.size(), write_offset);
         if (actual_field_ids.empty()) {
             return "";
         }
@@ -1337,14 +1302,14 @@ DiskFileManagerImpl::cache_opt_field_to_disk_v2(const Config& config) {
             "vector index build with multiple fields is not supported yet");
     }
 
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     auto local_data_path =
         GetLocalRawDataObjectPrefix() + std::string(VEC_OPT_FIELDS);
-    local_chunk_manager->CreateFile(local_data_path);
+    auto local_file = local_files_->OpenForWrite(
+        local_files_->PathFromNativePath(local_data_path),
+        local::WriteOptions{
+            .create = true, .truncate = true, .create_parent = true});
     uint64_t write_offset = 0;
-    WriteOptFieldsIvfMeta(
-        local_chunk_manager, local_data_path, num_of_fields, write_offset);
+    WriteOptFieldsIvfMeta(local_file, num_of_fields, write_offset);
 
     std::unordered_set<int64_t> actual_field_ids;
     for (auto& [field_id, tup] : fields_map) {
@@ -1358,22 +1323,16 @@ DiskFileManagerImpl::cache_opt_field_to_disk_v2(const Config& config) {
                                                       1,
                                                       fs_);
 
-        if (WriteOptFieldIvfData(field_type,
-                                 field_id,
-                                 local_chunk_manager,
-                                 local_data_path,
-                                 field_datas,
-                                 write_offset)) {
+        if (WriteOptFieldIvfData(
+                field_type, field_id, local_file, field_datas, write_offset)) {
             actual_field_ids.insert(field_id);
         }
     }
 
     if (actual_field_ids.size() != num_of_fields) {
         write_offset = 0;
-        WriteOptFieldsIvfMeta(local_chunk_manager,
-                              local_data_path,
-                              actual_field_ids.size(),
-                              write_offset);
+        WriteOptFieldsIvfMeta(
+            local_file, actual_field_ids.size(), write_offset);
         if (actual_field_ids.empty()) {
             return "";
         }
@@ -1408,14 +1367,14 @@ DiskFileManagerImpl::cache_opt_field_to_disk_v3(const Config& config) {
                "[StorageV3] loon ffi properties is null when build index "
                "with manifest");
 
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     auto local_data_path =
         GetLocalRawDataObjectPrefix() + std::string(VEC_OPT_FIELDS);
-    local_chunk_manager->CreateFile(local_data_path);
+    auto local_file = local_files_->OpenForWrite(
+        local_files_->PathFromNativePath(local_data_path),
+        local::WriteOptions{
+            .create = true, .truncate = true, .create_parent = true});
     uint64_t write_offset = 0;
-    WriteOptFieldsIvfMeta(
-        local_chunk_manager, local_data_path, num_of_fields, write_offset);
+    WriteOptFieldsIvfMeta(local_file, num_of_fields, write_offset);
 
     std::unordered_set<int64_t> actual_field_ids;
     for (auto& [field_id, tup] : fields_map) {
@@ -1440,22 +1399,16 @@ DiskFileManagerImpl::cache_opt_field_to_disk_v3(const Config& config) {
                                       element_type,
                                       GetStorageColumnMapping(field_id));
 
-        if (WriteOptFieldIvfData(field_type,
-                                 field_id,
-                                 local_chunk_manager,
-                                 local_data_path,
-                                 field_datas,
-                                 write_offset)) {
+        if (WriteOptFieldIvfData(
+                field_type, field_id, local_file, field_datas, write_offset)) {
             actual_field_ids.insert(field_id);
         }
     }
 
     if (actual_field_ids.size() != num_of_fields) {
         write_offset = 0;
-        WriteOptFieldsIvfMeta(local_chunk_manager,
-                              local_data_path,
-                              actual_field_ids.size(),
-                              write_offset);
+        WriteOptFieldsIvfMeta(
+            local_file, actual_field_ids.size(), write_offset);
         if (actual_field_ids.empty()) {
             return "";
         }
@@ -1481,83 +1434,35 @@ DiskFileManagerImpl::GetIndexIdentifier() {
 // path to store pre-built index contents downloaded from remote storage
 std::string
 DiskFileManagerImpl::GetLocalIndexObjectPrefix() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return AppendLocalPathGeneration(
-        GenIndexPathPrefix(local_chunk_manager,
-                           index_meta_.build_id,
-                           index_meta_.index_version,
-                           index_meta_.segment_id,
-                           index_meta_.field_id,
-                           false));
+    return ResolveLocalPrefix(LocalIndexObjectPath(false));
 }
 
 // temporary path used during index building
 std::string
 DiskFileManagerImpl::GetLocalTempIndexObjectPrefix() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return AppendLocalPathGeneration(
-        GenIndexPathPrefix(local_chunk_manager,
-                           index_meta_.build_id,
-                           index_meta_.index_version,
-                           index_meta_.segment_id,
-                           index_meta_.field_id,
-                           true));
+    return ResolveLocalPrefix(LocalIndexObjectPath(true));
 }
 
 // path to store pre-built index contents downloaded from remote storage
 std::string
 DiskFileManagerImpl::GetLocalTextIndexPrefix() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return AppendLocalPathGeneration(
-        GenTextIndexPathPrefix(local_chunk_manager,
-                               index_meta_.build_id,
-                               index_meta_.index_version,
-                               field_meta_.segment_id,
-                               field_meta_.field_id,
-                               false));
+    return ResolveLocalPrefix(LocalTextIndexPath(false));
 }
 
 // temporary path used during index building
 std::string
 DiskFileManagerImpl::GetLocalTempTextIndexPrefix() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return AppendLocalPathGeneration(
-        GenIndexPathPrefix(local_chunk_manager,
-                           index_meta_.build_id,
-                           index_meta_.index_version,
-                           field_meta_.segment_id,
-                           field_meta_.field_id,
-                           true));
+    return ResolveLocalPrefix(LocalTextIndexPath(true));
 }
 
 std::string
 DiskFileManagerImpl::GetLocalJsonStatsPrefix() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return AppendLocalPathGeneration(
-        GenJsonStatsPathPrefix(local_chunk_manager,
-                               index_meta_.build_id,
-                               index_meta_.index_version,
-                               field_meta_.segment_id,
-                               field_meta_.field_id,
-                               false));
+    return ResolveLocalPrefix(LocalJsonStatsPath(false));
 }
 
 std::string
 DiskFileManagerImpl::GetLocalTempJsonStatsPrefix() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return AppendLocalPathGeneration(
-        GenJsonStatsPathPrefix(local_chunk_manager,
-                               index_meta_.build_id,
-                               index_meta_.index_version,
-                               field_meta_.segment_id,
-                               field_meta_.field_id,
-                               true));
+    return ResolveLocalPrefix(LocalJsonStatsPath(true));
 }
 
 std::string
@@ -1592,28 +1497,12 @@ DiskFileManagerImpl::GetLocalJsonStatsShreddingPath(
 
 std::string
 DiskFileManagerImpl::GetLocalNgramIndexPrefix() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return AppendLocalPathGeneration(
-        GenNgramIndexPrefix(local_chunk_manager,
-                            index_meta_.build_id,
-                            index_meta_.index_version,
-                            field_meta_.segment_id,
-                            field_meta_.field_id,
-                            false));
+    return ResolveLocalPrefix(LocalNgramIndexPath(false));
 }
 
 std::string
 DiskFileManagerImpl::GetLocalTempNgramIndexPrefix() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return AppendLocalPathGeneration(
-        GenNgramIndexPrefix(local_chunk_manager,
-                            index_meta_.build_id,
-                            index_meta_.index_version,
-                            field_meta_.segment_id,
-                            field_meta_.field_id,
-                            true));
+    return ResolveLocalPrefix(LocalNgramIndexPath(true));
 }
 
 std::string
@@ -1632,10 +1521,7 @@ DiskFileManagerImpl::GetRemoteJsonStatsLogPrefix() {
 
 std::string
 DiskFileManagerImpl::GetLocalRawDataObjectPrefix() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return AppendLocalPathGeneration(GenFieldRawDataPathPrefix(
-        local_chunk_manager, field_meta_.segment_id, field_meta_.field_id));
+    return ResolveLocalPrefix(LocalRawDataPath());
 }
 
 bool
@@ -1646,16 +1532,12 @@ DiskFileManagerImpl::RemoveFile(const std::string& file) noexcept {
 
 std::optional<bool>
 DiskFileManagerImpl::IsExisted(const std::string& file) noexcept {
-    bool isExist = false;
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     try {
-        isExist = local_chunk_manager->Exist(file);
+        return local_files_->Exists(local_files_->PathFromNativePath(file));
     } catch (std::exception& e) {
         // LOG_DEBUG("Exception:{}", e).what();
         return std::nullopt;
     }
-    return isExist;
 }
 
 template std::string

--- a/internal/core/src/storage/DiskFileManagerImpl.h
+++ b/internal/core/src/storage/DiskFileManagerImpl.h
@@ -25,9 +25,10 @@
 #include <unordered_map>
 #include <vector>
 
+#include "local/ManagedSubtree.h"
+#include "local/Path.h"
 #include "storage/IndexData.h"
 #include "storage/FileManager.h"
-#include "storage/LocalChunkManager.h"
 #include "common/Consts.h"
 #include "storage/Types.h"
 #include "storage/ThreadPools.h"
@@ -35,35 +36,8 @@
 namespace milvus::storage {
 
 class DiskFileManagerImpl : public FileManagerImpl {
- private:
-    struct LocalDirState;
-
  public:
-    class LocalDirWriteLease {
-     public:
-        LocalDirWriteLease() = default;
-        LocalDirWriteLease(LocalDirWriteLease&& other) noexcept = default;
-        LocalDirWriteLease&
-        operator=(LocalDirWriteLease&& other) noexcept;
-        LocalDirWriteLease(const LocalDirWriteLease&) = delete;
-        LocalDirWriteLease&
-        operator=(const LocalDirWriteLease&) = delete;
-        ~LocalDirWriteLease();
-
-        explicit operator bool() const {
-            return state_ != nullptr;
-        }
-
-     private:
-        friend class DiskFileManagerImpl;
-
-        explicit LocalDirWriteLease(std::shared_ptr<LocalDirState> state);
-
-        void
-        Release() noexcept;
-
-        std::shared_ptr<LocalDirState> state_;
-    };
+    using LocalDirWriteLease = local::ManagedSubtree::WriteLease;
 
     explicit DiskFileManagerImpl(const FileManagerContext& fileManagerContext);
 
@@ -260,16 +234,34 @@ class DiskFileManagerImpl : public FileManagerImpl {
     GetRemoteTextLogPath(const std::string& file_name, int64_t slice_num) const;
 
     std::string
-    AppendLocalPathGeneration(const std::string& prefix) const;
+    ResolveLocalPrefix(const local::Path& path) const;
 
-    static void
-    RemoveLocalDirBestEffort(const std::string& dir) noexcept;
+    local::Path
+    LocalIndexObjectPath(bool temporary) const;
+
+    local::Path
+    LocalTextIndexPath(bool temporary) const;
+
+    local::Path
+    LocalJsonStatsPath(bool temporary) const;
+
+    local::Path
+    LocalNgramIndexPath(bool temporary) const;
+
+    local::Path
+    LocalRawDataPath() const;
 
     void
-    CloseAndRemoveLocalDir(const std::string& dir) noexcept;
+    CloseAndRemoveLocalDir(const local::Path& path) noexcept;
 
-    std::shared_ptr<LocalDirState>
-    GetOrCreateLocalDirState(const std::string& dir);
+    LocalDirWriteLease
+    AcquireLocalDirWriteLease(const local::Path& path);
+
+    local::Path
+    LocalPathForResolvedPrefix(const std::string& dir) const;
+
+    std::shared_ptr<local::ManagedSubtree>
+    GetOrCreateManagedSubtree(const local::Path& path);
 
     bool
     AddFileInternal(const std::string& file_name,
@@ -300,9 +292,8 @@ class DiskFileManagerImpl : public FileManagerImpl {
     void
     cache_raw_data_to_disk_common(
         const FieldDataPtr& field_data,
-        const std::shared_ptr<LocalChunkManager>& local_chunk_manager,
+        std::optional<local::io::WritableFile>& local_file,
         std::string& local_data_path,
-        bool& file_created,
         uint32_t& dim,
         int64_t& write_offset,
         std::vector<size_t>* offsets = nullptr);
@@ -313,11 +304,9 @@ class DiskFileManagerImpl : public FileManagerImpl {
     }
 
     void
-    write_valid_data_file(
-        const std::shared_ptr<LocalChunkManager>& local_chunk_manager,
-        const std::string& valid_data_path,
-        std::vector<uint8_t>& valid_bitmap,
-        uint64_t total_num_rows);
+    write_valid_data_file(const std::string& valid_data_path,
+                          std::vector<uint8_t>& valid_bitmap,
+                          uint64_t total_num_rows);
 
  private:
     // local file path (abs path)
@@ -326,9 +315,9 @@ class DiskFileManagerImpl : public FileManagerImpl {
     // remote file path
     std::map<std::string, int64_t> remote_paths_to_size_;
 
-    mutable std::mutex local_dir_states_mutex_;
-    std::unordered_map<std::string, std::shared_ptr<LocalDirState>>
-        local_dir_states_;
+    mutable std::mutex managed_subtrees_mutex_;
+    std::unordered_map<std::string, std::shared_ptr<local::ManagedSubtree>>
+        managed_subtrees_;
 
     size_t added_total_file_size_ = 0;
 

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -57,6 +57,7 @@
 #include "knowhere/binaryset.h"
 #include "knowhere/operands.h"
 #include "knowhere/sparse_utils.h"
+#include "local/FileSystem.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "pb/common.pb.h"
 #include "pb/index_coord.pb.h"
@@ -1251,6 +1252,63 @@ TEST_F(DiskAnnFileManagerTest, LocalPathGenerationIsPerFileManager) {
     EXPECT_EQ(fm1->GetRemoteTextLogPrefix(), fm2->GetRemoteTextLogPrefix());
 }
 
+TEST_F(DiskAnnFileManagerTest, LocalPathsUseInjectedIndependentRoots) {
+    auto temp_root = std::filesystem::temp_directory_path() /
+                     "milvus_disk_file_manager_roots";
+    auto first_root = temp_root / "first";
+    auto second_root = temp_root / "second";
+    auto cleanup =
+        folly::makeGuard([&]() { std::filesystem::remove_all(temp_root); });
+
+    auto make_file_manager = [&](const std::filesystem::path& root) {
+        IndexMeta index_meta = {3,
+                                100,
+                                1000,
+                                1,
+                                "opt_fields",
+                                "field_name",
+                                DataType::VECTOR_FLOAT,
+                                1};
+        return std::make_shared<DiskFileManagerImpl>(
+            storage::FileManagerContext(kOptVecFieldDataMeta,
+                                        index_meta,
+                                        cm_,
+                                        fs_,
+                                        local::FileSystem::Open(root)));
+    };
+
+    auto first = make_file_manager(first_root);
+    auto second = make_file_manager(second_root);
+    auto canonical_first_root = std::filesystem::weakly_canonical(first_root);
+    auto canonical_second_root = std::filesystem::weakly_canonical(second_root);
+
+    const std::vector<std::pair<std::string, std::string>> first_paths = {
+        {first->GetLocalIndexObjectPrefix(), "index_files"},
+        {first->GetLocalTempIndexObjectPrefix(), "tmp/index_files"},
+        {first->GetLocalTextIndexPrefix(), "text_log"},
+        {first->GetLocalTempTextIndexPrefix(), "tmp/index_files"},
+        {first->GetLocalJsonStatsPrefix(), "json_stats"},
+        {first->GetLocalTempJsonStatsPrefix(), "tmp/json_stats"},
+        {first->GetLocalNgramIndexPrefix(), "ngram_log"},
+        {first->GetLocalTempNgramIndexPrefix(), "tmp/ngram_log"},
+        {first->GetLocalRawDataObjectPrefix(), "raw_datas"}};
+
+    for (const auto& [path, expected_parent] : first_paths) {
+        auto relative = std::filesystem::relative(
+            StripTrailingPathSeparators(path), canonical_first_root);
+        EXPECT_EQ(relative.parent_path(), expected_parent);
+    }
+
+    EXPECT_TRUE(StartsWith(first->GetLocalIndexObjectPrefix(),
+                           canonical_first_root.string()));
+    EXPECT_TRUE(StartsWith(second->GetLocalIndexObjectPrefix(),
+                           canonical_second_root.string()));
+    EXPECT_FALSE(StartsWith(first->GetLocalIndexObjectPrefix(),
+                            canonical_second_root.string()));
+    EXPECT_FALSE(StartsWith(second->GetLocalIndexObjectPrefix(),
+                            canonical_first_root.string()));
+}
+
 TEST_F(DiskAnnFileManagerTest, LocalPathGenerationUsesLeafFolderName) {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
@@ -1323,14 +1381,22 @@ TEST_F(DiskAnnFileManagerTest,
         const std::vector<std::pair<std::string, std::string>> fm1_files = {
             {fm1->GetLocalIndexObjectPrefix() + "index_data",
              fm2->GetLocalIndexObjectPrefix() + "index_data"},
+            {fm1->GetLocalTempIndexObjectPrefix() + "temp_index_data",
+             fm2->GetLocalTempIndexObjectPrefix() + "temp_index_data"},
             {fm1->GetLocalTextIndexPrefix() + "text_log_data",
              fm2->GetLocalTextIndexPrefix() + "text_log_data"},
+            {fm1->GetLocalTempTextIndexPrefix() + "temp_text_log_data",
+             fm2->GetLocalTempTextIndexPrefix() + "temp_text_log_data"},
             {fm1->GetLocalJsonStatsSharedIndexPrefix() + "shared_index_data",
              fm2->GetLocalJsonStatsSharedIndexPrefix() + "shared_index_data"},
             {fm1->GetLocalJsonStatsPrefix() + "meta.json",
              fm2->GetLocalJsonStatsPrefix() + "meta.json"},
+            {fm1->GetLocalTempJsonStatsPrefix() + "temp_meta.json",
+             fm2->GetLocalTempJsonStatsPrefix() + "temp_meta.json"},
             {fm1->GetLocalNgramIndexPrefix() + "ngram_index_data",
              fm2->GetLocalNgramIndexPrefix() + "ngram_index_data"},
+            {fm1->GetLocalTempNgramIndexPrefix() + "temp_ngram_index_data",
+             fm2->GetLocalTempNgramIndexPrefix() + "temp_ngram_index_data"},
             {fm1->GetLocalRawDataObjectPrefix() + "raw_data",
              fm2->GetLocalRawDataObjectPrefix() + "raw_data"},
         };
@@ -1373,6 +1439,25 @@ TEST_F(DiskAnnFileManagerTest, DirectoryLeaseDefersCleanupUntilRelease) {
         EXPECT_TRUE(local_chunk_manager->Exist(local_index_file));
     }
 
+    EXPECT_FALSE(local_chunk_manager->Exist(local_index_file));
+}
+
+TEST_F(DiskAnnFileManagerTest,
+       FileManagerDestructionDefersCleanupUntilLeaseRelease) {
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto file_manager = CreateFileManager(cm_, fs_);
+    auto local_index_prefix = file_manager->GetLocalIndexObjectPrefix();
+    auto local_index_file = local_index_prefix + "index_data";
+    auto lease = file_manager->AcquireLocalDirWriteLease(local_index_prefix);
+
+    local_chunk_manager->CreateFile(local_index_file);
+    ASSERT_TRUE(local_chunk_manager->Exist(local_index_file));
+
+    file_manager.reset();
+    EXPECT_TRUE(local_chunk_manager->Exist(local_index_file));
+
+    lease = {};
     EXPECT_FALSE(local_chunk_manager->Exist(local_index_file));
 }
 

--- a/internal/core/src/storage/FileManager.h
+++ b/internal/core/src/storage/FileManager.h
@@ -29,12 +29,12 @@
 #include "common/type_c.h"
 #include "index/Meta.h"
 #include "filemanager/FileManager.h"
+#include "local/FileSystem.h"
+#include "local/LegacyLocalChunkFiles.h"
 #include "log/Log.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/properties.h"
 #include "storage/ChunkManager.h"
-#include "storage/LocalChunkManager.h"
-#include "storage/LocalChunkManagerSingleton.h"
 #include "storage/IndexEntryDirectStreamWriter.h"
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 #include "storage/IndexEntryWriter.h"
@@ -74,6 +74,18 @@ struct FileManagerContext {
           indexMeta(indexMeta),
           chunkManagerPtr(chunkManagerPtr),
           fs(std::move(fs)) {
+    }
+
+    FileManagerContext(const FieldDataMeta& fieldDataMeta,
+                       const IndexMeta& indexMeta,
+                       const ChunkManagerPtr& chunkManagerPtr,
+                       milvus_storage::ArrowFileSystemPtr fs,
+                       local::FileSystem local_files)
+        : fieldDataMeta(fieldDataMeta),
+          indexMeta(indexMeta),
+          chunkManagerPtr(chunkManagerPtr),
+          fs(std::move(fs)),
+          local_files(std::move(local_files)) {
     }
 
     bool
@@ -120,6 +132,7 @@ struct FileManagerContext {
     IndexMeta indexMeta;
     ChunkManagerPtr chunkManagerPtr;
     milvus_storage::ArrowFileSystemPtr fs;
+    std::optional<local::FileSystem> local_files;
     bool for_loading_index{false};
     std::shared_ptr<CPluginContext> plugin_context;
     std::shared_ptr<milvus_storage::api::Properties> loon_ffi_properties;
@@ -141,9 +154,13 @@ struct FileManagerContext {
 
 class FileManagerImpl : public milvus::FileManager {
  public:
-    explicit FileManagerImpl(const FieldDataMeta& field_mata,
-                             IndexMeta index_meta)
-        : field_meta_(field_mata), index_meta_(std::move(index_meta)) {
+    explicit FileManagerImpl(
+        const FieldDataMeta& field_mata,
+        IndexMeta index_meta,
+        std::optional<local::FileSystem> local_files = std::nullopt)
+        : field_meta_(field_mata),
+          index_meta_(std::move(index_meta)),
+          local_files_(std::move(local_files)) {
     }
 
  public:
@@ -274,7 +291,7 @@ class FileManagerImpl : public milvus::FileManager {
                     cipher_plugin,
                     plugin_context_->ez_id,
                     plugin_context_->collection_id,
-                    GetLocalTempDir());
+                    GetLocalFiles());
             }
         }
         return std::make_unique<IndexEntryDirectStreamWriter>(
@@ -348,14 +365,12 @@ class FileManagerImpl : public milvus::FileManager {
         return boost::filesystem::path(filepath).filename().string();
     }
 
-    std::string
-    GetLocalTempDir() const {
-        auto local_cm =
-            LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-        if (local_cm) {
-            return local_cm->GetRootPath();
+    const local::FileSystem&
+    GetLocalFiles() {
+        if (!local_files_.has_value()) {
+            local_files_.emplace(local::LegacyLocalChunkFiles());
         }
-        return "";
+        return *local_files_;
     }
 
     std::optional<StorageColumnMapping>
@@ -373,6 +388,7 @@ class FileManagerImpl : public milvus::FileManager {
 
     // index meta
     IndexMeta index_meta_;
+    std::optional<local::FileSystem> local_files_;
     ChunkManagerPtr rcm_;
     milvus_storage::ArrowFileSystemPtr fs_;
     std::shared_ptr<milvus_storage::api::Properties> loon_ffi_properties_;

--- a/internal/core/src/storage/FileWriter.cpp
+++ b/internal/core/src/storage/FileWriter.cpp
@@ -62,9 +62,9 @@ PWriteAll(int fd, const void* data, size_t nbyte, size_t file_offset) {
     return true;
 }
 
+template <typename Write>
 void
-PositionedWriteWithRateLimit(int fd,
-                             const std::string& filename,
+PositionedWriteWithRateLimit(Write&& write,
                              io::WriteRateLimiter& rate_limiter,
                              io::Priority priority,
                              size_t alignment_bytes,
@@ -92,12 +92,7 @@ PositionedWriteWithRateLimit(int fd,
                 continue;
             }
         }
-        if (!PWriteAll(fd, data, allowed_bytes, file_offset)) {
-            ThrowInfo(ErrorCode::FileWriteFailed,
-                      "Failed to write to file: {}, error: {}",
-                      filename,
-                      strerror(errno));
-        }
+        write(data, allowed_bytes, file_offset);
         file_offset += allowed_bytes;
         bytes_to_write -= allowed_bytes;
         data = static_cast<const char*>(data) + allowed_bytes;
@@ -115,28 +110,7 @@ FileWriter::FileWriter(std::string filename, io::Priority priority)
     : filename_(std::move(filename)),
       priority_(priority),
       rate_limiter_(io::WriteRateLimiter::GetInstance()) {
-    // high priority always use buffered mode, otherwise use the global mode
-    auto mode =
-        priority_ == io::Priority::HIGH ? WriteMode::BUFFERED : GetMode();
-
-    use_direct_io_ = mode == WriteMode::DIRECT;
-    use_writer_pool_ = FileWriteWorkerPool::GetInstance().HasPool();
-
-    // allocate an internal aligned buffer for both modes to batch writes
-    size_t buf_size = GetBufferSize();
-    AssertInfo(
-        buf_size != 0 && (buf_size % ALIGNMENT_BYTES) == 0,
-        "Buffer size must be greater than 0 and aligned to the alignment "
-        "size, buf_size: {}, alignment size: {}",
-        buf_size,
-        ALIGNMENT_BYTES);
-    capacity_ = buf_size;
-    aligned_buf_ = aligned_alloc(ALIGNMENT_BYTES, capacity_);
-    if (aligned_buf_ == nullptr) {
-        ThrowInfo(ErrorCode::MemAllocateFailed,
-                  "Failed to allocate aligned buffer of size {}",
-                  capacity_);
-    }
+    Initialize();
 
     auto open_flags = O_CREAT | O_RDWR | O_TRUNC;
     if (use_direct_io_) {
@@ -168,6 +142,47 @@ FileWriter::FileWriter(std::string filename, io::Priority priority)
 #endif
 }
 
+FileWriter::FileWriter(local::io::WritableFile file, io::Priority priority)
+    : filename_(file.DebugPath().string()),
+      file_(std::move(file)),
+      priority_(priority),
+      rate_limiter_(io::WriteRateLimiter::GetInstance()) {
+    Initialize();
+}
+
+void
+FileWriter::Initialize() {
+    // high priority always use buffered mode, otherwise use the global mode
+    auto mode =
+        priority_ == io::Priority::HIGH ? WriteMode::BUFFERED : GetMode();
+
+    use_direct_io_ = mode == WriteMode::DIRECT;
+    use_writer_pool_ = FileWriteWorkerPool::GetInstance().HasPool();
+
+    if (file_.has_value() && file_->DirectIOEnabled() != use_direct_io_) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "WritableFile direct IO mode does not match FileWriter "
+                  "policy for {}",
+                  filename_);
+    }
+
+    // allocate an internal aligned buffer for both modes to batch writes
+    size_t buf_size = GetBufferSize();
+    AssertInfo(
+        buf_size != 0 && (buf_size % ALIGNMENT_BYTES) == 0,
+        "Buffer size must be greater than 0 and aligned to the alignment "
+        "size, buf_size: {}, alignment size: {}",
+        buf_size,
+        ALIGNMENT_BYTES);
+    capacity_ = buf_size;
+    aligned_buf_ = aligned_alloc(ALIGNMENT_BYTES, capacity_);
+    if (aligned_buf_ == nullptr) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "Failed to allocate aligned buffer of size {}",
+                  capacity_);
+    }
+}
+
 FileWriter::~FileWriter() {
     Cleanup();
 }
@@ -178,6 +193,7 @@ FileWriter::Cleanup() noexcept {
         close(fd_);
         fd_ = -1;
     }
+    file_.reset();
     if (aligned_buf_ != nullptr) {
         free(aligned_buf_);
         aligned_buf_ = nullptr;
@@ -188,6 +204,16 @@ bool
 FileWriter::PositionedWrite(const void* data,
                             size_t nbyte,
                             size_t file_offset) {
+    if (file_.has_value()) {
+        try {
+            file_->WriteAt(
+                file_offset,
+                std::span(static_cast<const std::byte*>(data), nbyte));
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
     return PWriteAll(fd_, data, nbyte, file_offset);
 }
 
@@ -197,14 +223,31 @@ FileWriter::PositionedWriteWithCheck(const void* data,
                                      size_t file_offset) {
     size_t alignment_bytes = use_direct_io_ ? ALIGNMENT_BYTES : 1;
     try {
-        PositionedWriteWithRateLimit(fd_,
-                                     filename_,
-                                     rate_limiter_,
-                                     priority_,
-                                     alignment_bytes,
-                                     data,
-                                     nbyte,
-                                     file_offset);
+        PositionedWriteWithRateLimit(
+            [this](const void* write_data,
+                   size_t write_size,
+                   size_t write_offset) {
+                if (file_.has_value()) {
+                    file_->WriteAt(
+                        write_offset,
+                        std::span(static_cast<const std::byte*>(write_data),
+                                  write_size));
+                    return;
+                }
+                if (!PWriteAll(fd_, write_data, write_size, write_offset)) {
+                    ThrowInfo(ErrorCode::FileWriteFailed,
+                              "Failed to write to file: {}, "
+                              "error: {}",
+                              filename_,
+                              strerror(errno));
+                }
+            },
+            rate_limiter_,
+            priority_,
+            alignment_bytes,
+            data,
+            nbyte,
+            file_offset);
     } catch (...) {
         Cleanup();
         throw;
@@ -320,7 +363,9 @@ FileWriter::FlushWithDirectIO() {
     PositionedWriteWithCheck(aligned_buf_, nearest_aligned_offset, file_size_);
     file_size_ += offset_;
     // truncate the file to the actual size since the file written by the aligned buffer may be larger than the actual size
-    if (ftruncate(fd_, file_size_) != 0) {
+    if (file_.has_value()) {
+        file_->Truncate(file_size_);
+    } else if (ftruncate(fd_, file_size_) != 0) {
         Cleanup();
         ThrowInfo(ErrorCode::FileWriteFailed,
                   "Failed to truncate file: {}, error: {}",
@@ -425,6 +470,25 @@ PositionedFileWriter::PositionedFileWriter(std::string filename,
 #endif
 }
 
+PositionedFileWriter::PositionedFileWriter(local::io::WritableFile file,
+                                           size_t file_size,
+                                           io::Priority priority)
+    : filename_(file.DebugPath().string()),
+      file_(std::move(file)),
+      file_size_(file_size),
+      mode_(priority == io::Priority::HIGH ? FileWriter::WriteMode::BUFFERED
+                                           : FileWriter::GetMode()),
+      use_direct_io_(mode_ == FileWriter::WriteMode::DIRECT),
+      priority_(priority),
+      rate_limiter_(io::WriteRateLimiter::GetInstance()) {
+    if (file_->DirectIOEnabled() != use_direct_io_) {
+        ThrowInfo(ErrorCode::InvalidParameter,
+                  "WritableFile direct IO mode does not match "
+                  "PositionedFileWriter policy for {}",
+                  filename_);
+    }
+}
+
 PositionedFileWriter::~PositionedFileWriter() {
     Cleanup();
 }
@@ -435,6 +499,24 @@ PositionedFileWriter::Cleanup() noexcept {
         close(fd_);
         fd_ = -1;
     }
+    file_.reset();
+}
+
+void
+PositionedFileWriter::WriteAllAt(size_t file_offset,
+                                 const void* data,
+                                 size_t size) {
+    if (file_.has_value()) {
+        file_->WriteAt(file_offset,
+                       std::span(static_cast<const std::byte*>(data), size));
+        return;
+    }
+    if (!PWriteAll(fd_, data, size, file_offset)) {
+        ThrowInfo(ErrorCode::FileWriteFailed,
+                  "Failed to write to file: {}, error: {}",
+                  filename_,
+                  strerror(errno));
+    }
 }
 
 void
@@ -442,7 +524,15 @@ PositionedFileWriter::WriteBufferedAt(size_t file_offset,
                                       const void* data,
                                       size_t size) {
     PositionedWriteWithRateLimit(
-        fd_, filename_, rate_limiter_, priority_, 1, data, size, file_offset);
+        [this](const void* write_data, size_t write_size, size_t write_offset) {
+            WriteAllAt(write_offset, write_data, write_size);
+        },
+        rate_limiter_,
+        priority_,
+        1,
+        data,
+        size,
+        file_offset);
 }
 
 void
@@ -469,14 +559,18 @@ PositionedFileWriter::WriteDirectAlignedAt(size_t file_offset,
     bool aligned_data =
         (reinterpret_cast<uintptr_t>(data) & FileWriter::ALIGNMENT_MASK) == 0;
     if (aligned_data && write_size == size) {
-        PositionedWriteWithRateLimit(fd_,
-                                     filename_,
-                                     rate_limiter_,
-                                     priority_,
-                                     FileWriter::ALIGNMENT_BYTES,
-                                     data,
-                                     size,
-                                     file_offset);
+        PositionedWriteWithRateLimit(
+            [this](const void* write_data,
+                   size_t write_size,
+                   size_t write_offset) {
+                WriteAllAt(write_offset, write_data, write_size);
+            },
+            rate_limiter_,
+            priority_,
+            FileWriter::ALIGNMENT_BYTES,
+            data,
+            size,
+            file_offset);
         return;
     }
 
@@ -493,14 +587,16 @@ PositionedFileWriter::WriteDirectAlignedAt(size_t file_offset,
         memset(
             static_cast<char*>(aligned_data_ptr) + size, 0, write_size - size);
     }
-    PositionedWriteWithRateLimit(fd_,
-                                 filename_,
-                                 rate_limiter_,
-                                 priority_,
-                                 FileWriter::ALIGNMENT_BYTES,
-                                 aligned_data_ptr,
-                                 write_size,
-                                 file_offset);
+    PositionedWriteWithRateLimit(
+        [this](const void* write_data, size_t write_size, size_t write_offset) {
+            WriteAllAt(write_offset, write_data, write_size);
+        },
+        rate_limiter_,
+        priority_,
+        FileWriter::ALIGNMENT_BYTES,
+        aligned_data_ptr,
+        write_size,
+        file_offset);
 }
 
 void
@@ -508,7 +604,8 @@ PositionedFileWriter::WriteAt(size_t file_offset,
                               const void* data,
                               size_t size) {
     AssertInfo(!finished_, "Cannot write after Finish() has been called");
-    AssertInfo(fd_ != -1, "File is not open: {}", filename_);
+    AssertInfo(
+        fd_ != -1 || file_.has_value(), "File is not open: {}", filename_);
     if (size == 0) {
         return;
     }
@@ -533,7 +630,9 @@ PositionedFileWriter::Finish() {
     AssertInfo(!finished_, "Finish() has already been called");
     finished_ = true;
 
-    if (fd_ != -1 && ftruncate(fd_, file_size_) != 0) {
+    if (file_.has_value()) {
+        file_->Truncate(file_size_);
+    } else if (fd_ != -1 && ftruncate(fd_, file_size_) != 0) {
         Cleanup();
         ThrowInfo(ErrorCode::FileWriteFailed,
                   "Failed to truncate file: {}, error: {}",

--- a/internal/core/src/storage/FileWriter.h
+++ b/internal/core/src/storage/FileWriter.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <type_traits>
@@ -33,6 +34,7 @@
 
 #include "common/EasyAssert.h"
 #include "glog/logging.h"
+#include "local/io/File.h"
 #include "log/Log.h"
 #include "pb/common.pb.h"
 
@@ -230,6 +232,9 @@ class FileWriter {
     explicit FileWriter(std::string filename,
                         io::Priority priority = io::Priority::MIDDLE);
 
+    explicit FileWriter(local::io::WritableFile file,
+                        io::Priority priority = io::Priority::MIDDLE);
+
     ~FileWriter();
 
     void
@@ -272,8 +277,12 @@ class FileWriter {
     void
     Cleanup() noexcept;
 
+    void
+    Initialize();
+
     int fd_{-1};
     std::string filename_{""};
+    std::optional<local::io::WritableFile> file_;
     size_t file_size_{0};
 
     bool use_writer_pool_{false};
@@ -300,6 +309,10 @@ class PositionedFileWriter {
                                   size_t file_size,
                                   io::Priority priority = io::Priority::MIDDLE);
 
+    explicit PositionedFileWriter(local::io::WritableFile file,
+                                  size_t file_size,
+                                  io::Priority priority = io::Priority::MIDDLE);
+
     ~PositionedFileWriter();
 
     PositionedFileWriter(const PositionedFileWriter&) = delete;
@@ -322,8 +335,12 @@ class PositionedFileWriter {
     void
     Cleanup() noexcept;
 
+    void
+    WriteAllAt(size_t file_offset, const void* data, size_t size);
+
     int fd_{-1};
     std::string filename_{""};
+    std::optional<local::io::WritableFile> file_;
     size_t file_size_{0};
     FileWriter::WriteMode mode_{FileWriter::WriteMode::BUFFERED};
     bool use_direct_io_{false};

--- a/internal/core/src/storage/FileWriterTest.cpp
+++ b/internal/core/src/storage/FileWriterTest.cpp
@@ -19,15 +19,13 @@
 #include <fstream>
 #include <iterator>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include "common/EasyAssert.h"
-#include "gtest/gtest.h"
+#include "local/FileSystem.h"
 #include "storage/FileWriter.h"
-#include "test_utils/Constants.h"
 
 using namespace milvus;
 using namespace milvus::storage;
@@ -36,7 +34,9 @@ class FileWriterTest : public testing::Test {
  protected:
     void
     SetUp() override {
-        test_dir_ = std::filesystem::path(TestLocalPath) / "file_writer_test";
+        test_dir_ =
+            std::filesystem::temp_directory_path() / "milvus_file_writer_test" /
+            testing::UnitTest::GetInstance()->current_test_info()->name();
         std::filesystem::create_directories(test_dir_);
     }
 
@@ -55,6 +55,29 @@ class FileWriterTest : public testing::Test {
 
     std::filesystem::path test_dir_;
     const size_t kBufferSize = 4096;  // 4KB buffer size
+
+    milvus::local::io::WritableFile
+    OpenWritable(const std::string& filename,
+                 io::Priority priority = io::Priority::MIDDLE) {
+        auto files = milvus::local::FileSystem::Open(test_dir_);
+        auto direct_io = priority != io::Priority::HIGH &&
+                         FileWriter::GetMode() == FileWriter::WriteMode::DIRECT;
+        return files.OpenForWrite(
+            milvus::local::Path(filename),
+            milvus::local::WriteOptions{
+                .create = true, .truncate = true, .direct_io = direct_io});
+    }
+
+    template <typename Operation>
+    void
+    ExpectSegcoreError(Operation operation, ErrorCode expected_code) {
+        try {
+            operation();
+            FAIL() << "expected SegcoreError";
+        } catch (const SegcoreError& error) {
+            EXPECT_EQ(error.get_error_code(), expected_code);
+        }
+    }
 };
 
 // Test basic file writing functionality with buffered IO
@@ -353,7 +376,8 @@ TEST_F(FileWriterTest, InvalidFilePathWithDirectIO) {
     FileWriter::SetBufferSize(kBufferSize);
 
     std::string invalid_path = "/invalid/path/file.txt";
-    EXPECT_THROW(FileWriter writer(invalid_path), std::runtime_error);
+    ExpectSegcoreError([&]() { FileWriter writer(invalid_path); },
+                       ErrorCode::FileCreateFailed);
 }
 
 // Test writing to a file that already exists
@@ -444,8 +468,8 @@ TEST_F(FileWriterTest, PositionedWriterDirectIORejectsUnalignedOffset) {
     std::vector<char> data(kBufferSize);
 
     PositionedFileWriter writer(filename, data.size());
-    EXPECT_THROW(writer.WriteAt(1, data.data(), data.size()),
-                 std::runtime_error);
+    ExpectSegcoreError([&]() { writer.WriteAt(1, data.data(), data.size()); },
+                       ErrorCode::UnexpectedError);
 }
 
 TEST_F(FileWriterTest, PositionedWriterDirectIORejectsMiddleUnalignedWrite) {
@@ -457,8 +481,8 @@ TEST_F(FileWriterTest, PositionedWriterDirectIORejectsMiddleUnalignedWrite) {
     std::vector<char> data(kBufferSize * 2 + 17);
 
     PositionedFileWriter writer(filename, data.size());
-    EXPECT_THROW(writer.WriteAt(kBufferSize, data.data(), 17),
-                 std::runtime_error);
+    ExpectSegcoreError([&]() { writer.WriteAt(kBufferSize, data.data(), 17); },
+                       ErrorCode::UnexpectedError);
 }
 
 TEST_F(FileWriterTest, PositionedWriterKeepsFileOpenAfterWriteAtError) {
@@ -472,8 +496,9 @@ TEST_F(FileWriterTest, PositionedWriterKeepsFileOpenAfterWriteAtError) {
 
     {
         PositionedFileWriter writer(filename, data.size());
-        EXPECT_THROW(writer.WriteAt(kBufferSize, data.data(), 17),
-                     std::runtime_error);
+        ExpectSegcoreError(
+            [&]() { writer.WriteAt(kBufferSize, data.data(), 17); },
+            ErrorCode::UnexpectedError);
         writer.WriteAt(0, data.data(), kBufferSize);
         writer.WriteAt(kBufferSize, data.data() + kBufferSize, kBufferSize);
         writer.Finish();
@@ -515,6 +540,107 @@ TEST_F(FileWriterTest, PositionedWriterDirectIOSupportsConcurrentWrites) {
     std::vector<char> read_data((std::istreambuf_iterator<char>(file)),
                                 std::istreambuf_iterator<char>());
     EXPECT_EQ(read_data, data);
+}
+
+TEST_F(FileWriterTest, WritableFileConstructorMatchesLegacyOutput) {
+    FileWriter::SetBufferSize(kBufferSize);
+    std::vector<char> data(kBufferSize * 2 + 17);
+    std::generate(data.begin(), data.end(), std::rand);
+
+    for (auto mode :
+         {FileWriter::WriteMode::BUFFERED, FileWriter::WriteMode::DIRECT}) {
+        FileWriter::SetMode(mode);
+        auto suffix =
+            mode == FileWriter::WriteMode::BUFFERED ? "buffered" : "direct";
+        auto legacy_name = std::string("legacy_") + suffix;
+        auto handle_name = std::string("handle_") + suffix;
+
+        FileWriter legacy((test_dir_ / legacy_name).string());
+        legacy.Write(data.data(), data.size());
+        EXPECT_EQ(legacy.Finish(), data.size());
+
+        FileWriter handle(OpenWritable(handle_name));
+        handle.Write(data.data(), data.size());
+        EXPECT_EQ(handle.Finish(), data.size());
+
+        std::ifstream legacy_file(test_dir_ / legacy_name, std::ios::binary);
+        std::ifstream handle_file(test_dir_ / handle_name, std::ios::binary);
+        std::vector<char> legacy_data(
+            (std::istreambuf_iterator<char>(legacy_file)),
+            std::istreambuf_iterator<char>());
+        std::vector<char> handle_data(
+            (std::istreambuf_iterator<char>(handle_file)),
+            std::istreambuf_iterator<char>());
+        EXPECT_EQ(handle_data, legacy_data);
+        EXPECT_EQ(handle_data, data);
+    }
+}
+
+TEST_F(FileWriterTest, PositionedWritableFileWritesOutOfOrder) {
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    std::vector<char> data(kBufferSize * 2 + 17);
+    std::generate(data.begin(), data.end(), std::rand);
+
+    PositionedFileWriter writer(OpenWritable("positioned_handle"), data.size());
+    writer.WriteAt(kBufferSize, data.data() + kBufferSize, kBufferSize);
+    writer.WriteAt(kBufferSize * 2, data.data() + kBufferSize * 2, 17);
+    writer.WriteAt(0, data.data(), kBufferSize);
+    EXPECT_EQ(writer.Finish(), data.size());
+
+    std::ifstream file(test_dir_ / "positioned_handle", std::ios::binary);
+    std::vector<char> actual((std::istreambuf_iterator<char>(file)),
+                             std::istreambuf_iterator<char>());
+    EXPECT_EQ(actual, data);
+}
+
+TEST_F(FileWriterTest, PositionedWritableFileSupportsConcurrentDirectWrites) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+    std::vector<char> data(kBufferSize * 8);
+    std::generate(data.begin(), data.end(), std::rand);
+
+    PositionedFileWriter writer(OpenWritable("positioned_handle_direct"),
+                                data.size());
+    std::vector<std::thread> threads;
+    for (size_t i = 0; i < 8; ++i) {
+        threads.emplace_back([&, i]() {
+            writer.WriteAt(
+                i * kBufferSize, data.data() + i * kBufferSize, kBufferSize);
+        });
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    EXPECT_EQ(writer.Finish(), data.size());
+
+    std::ifstream file(test_dir_ / "positioned_handle_direct",
+                       std::ios::binary);
+    std::vector<char> actual((std::istreambuf_iterator<char>(file)),
+                             std::istreambuf_iterator<char>());
+    EXPECT_EQ(actual, data);
+}
+
+TEST_F(FileWriterTest, WritableFileConstructorsRejectMismatchedDirectIOMode) {
+    FileWriter::SetMode(FileWriter::WriteMode::DIRECT);
+    FileWriter::SetBufferSize(kBufferSize);
+    auto files = milvus::local::FileSystem::Open(test_dir_);
+
+    auto open_buffered = [&](const std::string& filename) {
+        return files.OpenForWrite(
+            milvus::local::Path(filename),
+            milvus::local::WriteOptions{
+                .create = true, .truncate = true, .direct_io = false});
+    };
+
+    ExpectSegcoreError(
+        [&]() { FileWriter writer(open_buffered("sequential")); },
+        ErrorCode::InvalidParameter);
+    ExpectSegcoreError(
+        [&]() {
+            PositionedFileWriter writer(open_buffered("positioned"),
+                                        kBufferSize);
+        },
+        ErrorCode::InvalidParameter);
 }
 
 // Test rate limiter basic behavior: alignment and refill period
@@ -1060,14 +1186,14 @@ TEST_F(FileWriterTest, ErrorHandlingInAsyncOperations) {
     std::string invalid_path = "/invalid/path/async_test.txt";
 
     // This should throw an exception even in async context
-    EXPECT_THROW(
-        {
+    ExpectSegcoreError(
+        [&]() {
             FileWriter writer(invalid_path);
             std::string test_data = "Test data";
             writer.Write(test_data.data(), test_data.size());
             writer.Finish();
         },
-        std::runtime_error);
+        ErrorCode::FileCreateFailed);
 }
 
 // Test concurrent access to FileWriterConfig

--- a/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
+++ b/internal/core/src/storage/IndexEntryEncryptedLocalWriter.cpp
@@ -16,7 +16,6 @@
 
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 
-#include <fcntl.h>
 #include <folly/ScopeGuard.h>
 #include <unistd.h>
 #include <cerrno>
@@ -40,6 +39,22 @@
 
 namespace milvus::storage {
 
+namespace {
+
+local::FileSystem
+OpenLegacyTempFiles(const std::string& temp_dir) {
+    auto root = temp_dir.empty() ? std::filesystem::path("/tmp")
+                                 : std::filesystem::path(temp_dir);
+    return local::FileSystem::Open(std::filesystem::absolute(root));
+}
+
+std::span<const std::byte>
+AsBytes(const void* data, size_t size) {
+    return {reinterpret_cast<const std::byte*>(data), size};
+}
+
+}  // namespace
+
 IndexEntryEncryptedLocalWriter::IndexEntryEncryptedLocalWriter(
     const std::string& remote_path,
     milvus_storage::ArrowFileSystemPtr fs,
@@ -48,13 +63,31 @@ IndexEntryEncryptedLocalWriter::IndexEntryEncryptedLocalWriter(
     int64_t collection_id,
     const std::string& temp_dir,
     size_t slice_size)
+    : IndexEntryEncryptedLocalWriter(remote_path,
+                                     std::move(fs),
+                                     std::move(cipher_plugin),
+                                     ez_id,
+                                     collection_id,
+                                     OpenLegacyTempFiles(temp_dir),
+                                     slice_size) {
+}
+
+IndexEntryEncryptedLocalWriter::IndexEntryEncryptedLocalWriter(
+    const std::string& remote_path,
+    milvus_storage::ArrowFileSystemPtr fs,
+    std::shared_ptr<plugin::ICipherPlugin> cipher_plugin,
+    int64_t ez_id,
+    int64_t collection_id,
+    local::FileSystem local_files,
+    size_t slice_size)
     : remote_path_(remote_path),
       fs_(std::move(fs)),
       cipher_plugin_(std::move(cipher_plugin)),
       ez_id_(ez_id),
       collection_id_(collection_id),
       slice_size_(slice_size),
-      pool_(ThreadPools::GetThreadPool(ThreadPoolPriority::MIDDLE)) {
+      pool_(ThreadPools::GetThreadPool(ThreadPoolPriority::MIDDLE)),
+      local_files_(std::move(local_files)) {
     AssertInfo(IsStreamSliceSizeAligned(slice_size_),
                "Encrypted entry slice_size must be {}-byte aligned, got {}",
                kStreamSliceAlignment,
@@ -65,31 +98,37 @@ IndexEntryEncryptedLocalWriter::IndexEntryEncryptedLocalWriter(
     edek_ = std::move(edek);
 
     auto uuid = boost::uuids::random_generator()();
-    std::string dir = temp_dir.empty() ? "/tmp" : temp_dir;
-    local_path_ = dir + "/milvus_enc_" + boost::uuids::to_string(uuid);
-
-    local_fd_ = ::open(local_path_.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
-    AssertInfo(
-        local_fd_ != -1, "Failed to create temp file: {}", strerror(errno));
+    local_path_.emplace("milvus_enc_" + boost::uuids::to_string(uuid));
+    local_file_.emplace(local_files_.OpenForWrite(
+        *local_path_, local::WriteOptions{.create = true, .truncate = true}));
 
     try {
         auto written =
-            ::write(local_fd_, MILVUS_V3_MAGIC, MILVUS_V3_MAGIC_SIZE);
-        AssertInfo(written == static_cast<ssize_t>(MILVUS_V3_MAGIC_SIZE),
+            local_file_->Write(AsBytes(MILVUS_V3_MAGIC, MILVUS_V3_MAGIC_SIZE));
+        AssertInfo(written == MILVUS_V3_MAGIC_SIZE,
                    "Failed to write magic number");
     } catch (...) {
-        ::close(local_fd_);
-        local_fd_ = -1;
-        ::unlink(local_path_.c_str());
+        local_file_.reset();
+        RemoveLocalFile();
         throw;
     }
 }
 
 IndexEntryEncryptedLocalWriter::~IndexEntryEncryptedLocalWriter() {
-    if (local_fd_ != -1) {
-        ::close(local_fd_);
-        ::unlink(local_path_.c_str());
+    local_file_.reset();
+    RemoveLocalFile();
+}
+
+void
+IndexEntryEncryptedLocalWriter::RemoveLocalFile() noexcept {
+    if (!local_path_.has_value()) {
+        return;
     }
+    try {
+        local_files_.RemoveFile(*local_path_);
+    } catch (...) {
+    }
+    local_path_.reset();
 }
 
 void
@@ -155,8 +194,8 @@ IndexEntryEncryptedLocalWriter::WriteEntry(const std::string& name,
             auto encrypted = pending.front().get();
             pending.pop_front();
             auto written =
-                ::write(local_fd_, encrypted.data(), encrypted.size());
-            AssertInfo(written == static_cast<ssize_t>(encrypted.size()),
+                local_file_->Write(AsBytes(encrypted.data(), encrypted.size()));
+            AssertInfo(written == encrypted.size(),
                        "Failed to write encrypted slice");
             slices.push_back(
                 {current_offset_, static_cast<uint64_t>(encrypted.size())});
@@ -202,8 +241,8 @@ IndexEntryEncryptedLocalWriter::EncryptAndWriteSlices(const std::string& name,
             auto encrypted = pending.front().get();
             pending.pop_front();
             auto written =
-                ::write(local_fd_, encrypted.data(), encrypted.size());
-            AssertInfo(written == static_cast<ssize_t>(encrypted.size()),
+                local_file_->Write(AsBytes(encrypted.data(), encrypted.size()));
+            AssertInfo(written == encrypted.size(),
                        "Failed to write encrypted slice");
             slices.push_back(
                 {current_offset_, static_cast<uint64_t>(encrypted.size())});
@@ -250,9 +289,8 @@ IndexEntryEncryptedLocalWriter::Finish() {
     dir_json["__ez_id__"] = std::to_string(ez_id_);
 
     auto dir_str = dir_json.dump();
-    auto written = ::write(local_fd_, dir_str.data(), dir_str.size());
-    AssertInfo(written == static_cast<ssize_t>(dir_str.size()),
-               "Failed to write directory table");
+    auto written = local_file_->Write(AsBytes(dir_str.data(), dir_str.size()));
+    AssertInfo(written == dir_str.size(), "Failed to write directory table");
 
     // Write 32-byte Footer
     uint8_t footer[MILVUS_V3_FOOTER_SIZE] = {};
@@ -264,18 +302,15 @@ IndexEntryEncryptedLocalWriter::Finish() {
     milvus::fastmem::FastMemcpy(footer + 24, &meta_size_u32, sizeof(uint32_t));
     milvus::fastmem::FastMemcpy(footer + 28, &dir_size_u32, sizeof(uint32_t));
 
-    written = ::write(local_fd_, footer, MILVUS_V3_FOOTER_SIZE);
-    AssertInfo(written == static_cast<ssize_t>(MILVUS_V3_FOOTER_SIZE),
-               "Failed to write footer");
+    written = local_file_->Write(AsBytes(footer, MILVUS_V3_FOOTER_SIZE));
+    AssertInfo(written == MILVUS_V3_FOOTER_SIZE, "Failed to write footer");
 
-    ::close(local_fd_);
-    local_fd_ = -1;
+    local_file_.reset();
 
     total_bytes_written_ = MILVUS_V3_MAGIC_SIZE + current_offset_ +
                            dir_str.size() + MILVUS_V3_FOOTER_SIZE;
 
-    auto cleanup_local_file =
-        folly::makeGuard([this]() { ::unlink(local_path_.c_str()); });
+    auto cleanup_local_file = folly::makeGuard([this]() { RemoveLocalFile(); });
     UploadLocalFile();
 
     finished_ = true;
@@ -290,28 +325,21 @@ IndexEntryEncryptedLocalWriter::UploadLocalFile() {
     auto remote_stream =
         std::make_shared<RemoteOutputStream>(std::move(result.ValueOrDie()));
 
-    int read_fd = ::open(local_path_.c_str(), O_RDONLY);
-    AssertInfo(
-        read_fd != -1, "Failed to open local file for upload: {}", local_path_);
-    auto close_read_fd = folly::makeGuard([read_fd]() { ::close(read_fd); });
+    auto local_file = local_files_.OpenForRead(*local_path_);
 
     constexpr size_t kBufSize = 16 * 1024 * 1024;
-    std::vector<char> buf(kBufSize);
-    while (true) {
-        ssize_t n = ::read(read_fd, buf.data(), kBufSize);
-        if (n > 0) {
-            remote_stream->Write(buf.data(), n);
-        } else if (n == 0) {
-            break;  // EOF
-        } else {
-            if (errno == EINTR) {
-                continue;
-            }
-            ThrowInfo(ErrorCode::UnexpectedError,
-                      fmt::format("Failed to read local file {}: {}",
-                                  local_path_,
-                                  strerror(errno)));
-        }
+    std::vector<std::byte> buf(kBufSize);
+    uint64_t offset = 0;
+    auto size = local_file.Size();
+    while (offset < size) {
+        auto bytes_to_read = std::min<uint64_t>(buf.size(), size - offset);
+        auto bytes_read = local_file.ReadAt(
+            offset, std::span<std::byte>(buf.data(), bytes_to_read));
+        AssertInfo(bytes_read == bytes_to_read,
+                   "short read from encrypted staging file at offset {}",
+                   offset);
+        remote_stream->Write(buf.data(), bytes_read);
+        offset += bytes_read;
     }
     remote_stream->Close();
 }

--- a/internal/core/src/storage/IndexEntryEncryptedLocalWriter.h
+++ b/internal/core/src/storage/IndexEntryEncryptedLocalWriter.h
@@ -21,9 +21,11 @@
 #include <deque>
 #include <future>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "local/FileSystem.h"
 #include "storage/IndexEntryWriter.h"
 #include "storage/plugin/PluginInterface.h"
 #include "storage/ThreadPools.h"
@@ -40,6 +42,15 @@ class IndexEntryEncryptedLocalWriter : public IndexEntryWriter {
         int64_t ez_id,
         int64_t collection_id,
         const std::string& temp_dir = "",
+        size_t slice_size = 16 * 1024 * 1024);
+
+    IndexEntryEncryptedLocalWriter(
+        const std::string& remote_path,
+        milvus_storage::ArrowFileSystemPtr fs,
+        std::shared_ptr<plugin::ICipherPlugin> cipher_plugin,
+        int64_t ez_id,
+        int64_t collection_id,
+        local::FileSystem local_files,
         size_t slice_size = 16 * 1024 * 1024);
     ~IndexEntryEncryptedLocalWriter();
 
@@ -63,6 +74,9 @@ class IndexEntryEncryptedLocalWriter : public IndexEntryWriter {
     void
     UploadLocalFile();
 
+    void
+    RemoveLocalFile() noexcept;
+
     std::string remote_path_;
     milvus_storage::ArrowFileSystemPtr fs_;
     std::shared_ptr<plugin::ICipherPlugin> cipher_plugin_;
@@ -72,8 +86,9 @@ class IndexEntryEncryptedLocalWriter : public IndexEntryWriter {
     size_t slice_size_;
 
     ThreadPool& pool_;
-    std::string local_path_;
-    int local_fd_ = -1;
+    local::FileSystem local_files_;
+    std::optional<local::Path> local_path_;
+    std::optional<local::io::WritableFile> local_file_;
     size_t current_offset_ = 0;
     size_t total_bytes_written_ = 0;
     bool finished_ = false;

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -123,6 +123,22 @@ EncryptedStreamBudgetBytes(size_t cipher_len, size_t plain_len) {
 
 constexpr size_t kEntryDownloadRangeSize = 16 * 1024 * 1024;
 
+size_t
+CheckedEntryStreamSliceSize() {
+    auto slice_size = DefaultEntryStreamSliceSize();
+    AssertInfo(slice_size >= kMinStreamSliceSize,
+               "ReadEntriesStreamToFiles slice_size must be at least {} bytes, "
+               "got {}",
+               kMinStreamSliceSize,
+               slice_size);
+    AssertInfo(IsStreamSliceSizeAligned(slice_size),
+               "ReadEntriesStreamToFiles slice_size must be {}-byte aligned, "
+               "got {}",
+               kStreamSliceAlignment,
+               slice_size);
+    return slice_size;
+}
+
 void
 DrainFutures(std::vector<std::future<void>>& futures,
              std::exception_ptr& first_error) {
@@ -867,17 +883,7 @@ IndexEntryReader::PrepareEntryStreamDownload(const std::string& name,
                                              const EntryMeta& meta,
                                              io::Priority write_priority) {
     CheckCancelled("IndexEntryReader::PrepareEntryStreamDownload");
-    auto slice_size = DefaultEntryStreamSliceSize();
-    AssertInfo(slice_size >= kMinStreamSliceSize,
-               "ReadEntriesStreamToFiles slice_size must be at least {} bytes, "
-               "got {}",
-               kMinStreamSliceSize,
-               slice_size);
-    AssertInfo(IsStreamSliceSizeAligned(slice_size),
-               "ReadEntriesStreamToFiles slice_size must be {}-byte aligned, "
-               "got {}",
-               kStreamSliceAlignment,
-               slice_size);
+    auto slice_size = CheckedEntryStreamSliceSize();
 
     EntryStreamDownloadState state;
     state.name = name;
@@ -892,6 +898,31 @@ IndexEntryReader::PrepareEntryStreamDownload(const std::string& name,
             PlainStreamSliceCount(meta.plain.size, slice_size));
         state.writer = std::make_unique<PositionedFileWriter>(
             local_path, meta.plain.size, write_priority);
+    }
+    return state;
+}
+
+IndexEntryReader::EntryStreamDownloadState
+IndexEntryReader::PrepareEntryStreamDownload(const std::string& name,
+                                             local::io::WritableFile output,
+                                             const EntryMeta& meta,
+                                             io::Priority write_priority) {
+    CheckCancelled("IndexEntryReader::PrepareEntryStreamDownload");
+    auto slice_size = CheckedEntryStreamSliceSize();
+
+    EntryStreamDownloadState state;
+    state.name = name;
+    if (meta.encrypted) {
+        state.expected_crc = meta.enc.crc32;
+        state.range_crcs.resize(meta.enc.slices.size());
+        state.writer = std::make_unique<PositionedFileWriter>(
+            std::move(output), meta.enc.original_size, write_priority);
+    } else {
+        state.expected_crc = meta.plain.crc32;
+        state.range_crcs.resize(
+            PlainStreamSliceCount(meta.plain.size, slice_size));
+        state.writer = std::make_unique<PositionedFileWriter>(
+            std::move(output), meta.plain.size, write_priority);
     }
     return state;
 }
@@ -1133,32 +1164,27 @@ IndexEntryReader::ReadEntryStreamToFile(const std::string& name,
 }
 
 void
-IndexEntryReader::ReadEntriesStreamToFiles(
-    const std::vector<std::pair<std::string, std::string>>& name_path_pairs,
-    io::Priority write_priority) {
-    CheckCancelled("IndexEntryReader::ReadEntriesStreamToFiles");
-    if (name_path_pairs.empty()) {
-        return;
-    }
+IndexEntryReader::ReadEntryStreamToFile(const std::string& name,
+                                        local::io::WritableFile output,
+                                        io::Priority write_priority) {
+    CheckCancelled("IndexEntryReader::ReadEntryStreamToFile");
+    AssertInfo(HasEntry(name), "Entry not found: {}", name);
+    auto writer = FileWriter(std::move(output), write_priority);
+    ReadEntryStream(name, [&writer](const uint8_t* data, size_t len) {
+        writer.Write(data, len);
+    });
+    writer.Finish();
+}
 
-    std::vector<EntryStreamDownloadState> states;
-    states.reserve(name_path_pairs.size());
+void
+IndexEntryReader::CompleteEntryStreamDownloads(
+    std::vector<EntryStreamDownloadState>& states, size_t total_task_count) {
     std::vector<std::future<void>> all_futures;
-
     try {
-        size_t total_task_count = 0;
-        for (const auto& [name, path] : name_path_pairs) {
-            auto it = entry_index_.find(name);
-            AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
-            states.push_back(PrepareEntryStreamDownload(
-                name, path, it->second, write_priority));
-            total_task_count += StreamDownloadTaskCount(it->second);
-        }
-
         all_futures.reserve(total_task_count);
-        for (size_t i = 0; i < name_path_pairs.size(); i++) {
-            const auto& meta = entry_index_.at(name_path_pairs[i].first);
-            SubmitEntryStreamDownloadTasks(meta, states[i], all_futures);
+        for (auto& state : states) {
+            SubmitEntryStreamDownloadTasks(
+                entry_index_.at(state.name), state, all_futures);
         }
 
         std::exception_ptr first_error = nullptr;
@@ -1178,6 +1204,50 @@ IndexEntryReader::ReadEntriesStreamToFiles(
         }
         std::rethrow_exception(first_error);
     }
+}
+
+void
+IndexEntryReader::ReadEntriesStreamToFiles(
+    const std::vector<std::pair<std::string, std::string>>& name_path_pairs,
+    io::Priority write_priority) {
+    CheckCancelled("IndexEntryReader::ReadEntriesStreamToFiles");
+    if (name_path_pairs.empty()) {
+        return;
+    }
+
+    std::vector<EntryStreamDownloadState> states;
+    states.reserve(name_path_pairs.size());
+    size_t total_task_count = 0;
+    for (const auto& [name, path] : name_path_pairs) {
+        auto it = entry_index_.find(name);
+        AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
+        states.push_back(
+            PrepareEntryStreamDownload(name, path, it->second, write_priority));
+        total_task_count += StreamDownloadTaskCount(it->second);
+    }
+    CompleteEntryStreamDownloads(states, total_task_count);
+}
+
+void
+IndexEntryReader::ReadEntriesStreamToFiles(
+    std::vector<std::pair<std::string, local::io::WritableFile>> named_outputs,
+    io::Priority write_priority) {
+    CheckCancelled("IndexEntryReader::ReadEntriesStreamToFiles");
+    if (named_outputs.empty()) {
+        return;
+    }
+
+    std::vector<EntryStreamDownloadState> states;
+    states.reserve(named_outputs.size());
+    size_t total_task_count = 0;
+    for (auto& [name, output] : named_outputs) {
+        auto it = entry_index_.find(name);
+        AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
+        states.push_back(PrepareEntryStreamDownload(
+            name, std::move(output), it->second, write_priority));
+        total_task_count += StreamDownloadTaskCount(it->second);
+    }
+    CompleteEntryStreamDownloads(states, total_task_count);
 }
 
 size_t

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "folly/CancellationToken.h"
@@ -72,8 +73,19 @@ class IndexEntryReader {
                           io::Priority write_priority = io::Priority::MIDDLE);
 
     void
+    ReadEntryStreamToFile(const std::string& name,
+                          local::io::WritableFile output,
+                          io::Priority write_priority = io::Priority::MIDDLE);
+
+    void
     ReadEntriesStreamToFiles(
         const std::vector<std::pair<std::string, std::string>>& name_path_pairs,
+        io::Priority write_priority = io::Priority::MIDDLE);
+
+    void
+    ReadEntriesStreamToFiles(
+        std::vector<std::pair<std::string, local::io::WritableFile>>
+            named_outputs,
         io::Priority write_priority = io::Priority::MIDDLE);
 
     /// Stream entry data via transient memory budget.
@@ -226,6 +238,16 @@ class IndexEntryReader {
                                const std::string& local_path,
                                const EntryMeta& meta,
                                io::Priority write_priority);
+
+    EntryStreamDownloadState
+    PrepareEntryStreamDownload(const std::string& name,
+                               local::io::WritableFile output,
+                               const EntryMeta& meta,
+                               io::Priority write_priority);
+
+    void
+    CompleteEntryStreamDownloads(std::vector<EntryStreamDownloadState>& states,
+                                 size_t total_task_count);
 
     void
     SubmitEntryStreamDownloadTasks(const EntryMeta& meta,

--- a/internal/core/src/storage/IndexEntryReaderLocalTest.cpp
+++ b/internal/core/src/storage/IndexEntryReaderLocalTest.cpp
@@ -1,0 +1,250 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "filemanager/InputStream.h"
+#include "filemanager/OutputStream.h"
+#include "local/FileSystem.h"
+#include "storage/IndexEntryDirectStreamWriter.h"
+#include "storage/IndexEntryReader.h"
+
+namespace milvus::storage {
+namespace {
+
+class VectorOutputStream final : public milvus::OutputStream {
+ public:
+    size_t
+    Tell() const override {
+        return data_.size();
+    }
+
+    size_t
+    Write(const void* data, size_t size) override {
+        auto* bytes = static_cast<const uint8_t*>(data);
+        data_.insert(data_.end(), bytes, bytes + size);
+        return size;
+    }
+
+    size_t
+    Write(int fd, size_t size) override {
+        std::vector<uint8_t> buffer(std::min<size_t>(size, 64 * 1024));
+        size_t total = 0;
+        while (total < size) {
+            auto count = ::read(
+                fd, buffer.data(), std::min(buffer.size(), size - total));
+            AssertInfo(count > 0, "failed to read source file");
+            Write(buffer.data(), count);
+            total += count;
+        }
+        return total;
+    }
+
+    void
+    Close() override {
+    }
+
+    std::vector<uint8_t>
+    TakeData() {
+        return std::move(data_);
+    }
+
+ private:
+    std::vector<uint8_t> data_;
+};
+
+class VectorInputStream final : public milvus::InputStream {
+ public:
+    explicit VectorInputStream(std::vector<uint8_t> data)
+        : data_(std::move(data)) {
+    }
+
+    size_t
+    Size() const override {
+        return data_.size();
+    }
+
+    bool
+    Seek(int64_t offset) override {
+        if (offset < 0 || static_cast<size_t>(offset) > data_.size()) {
+            return false;
+        }
+        position_ = offset;
+        return true;
+    }
+
+    size_t
+    Tell() const override {
+        return position_;
+    }
+
+    bool
+    Eof() const override {
+        return position_ == data_.size();
+    }
+
+    size_t
+    Read(void* output, size_t size) override {
+        auto count = ReadAt(output, position_, size);
+        position_ += count;
+        return count;
+    }
+
+    size_t
+    ReadAt(void* output, size_t offset, size_t size) override {
+        if (offset >= data_.size()) {
+            return 0;
+        }
+        auto count = std::min(size, data_.size() - offset);
+        std::memcpy(output, data_.data() + offset, count);
+        return count;
+    }
+
+    size_t
+    Read(int fd, size_t size) override {
+        std::vector<uint8_t> buffer(std::min<size_t>(size, 64 * 1024));
+        size_t total = 0;
+        while (total < size) {
+            auto count =
+                Read(buffer.data(), std::min(buffer.size(), size - total));
+            if (count == 0) {
+                break;
+            }
+            auto written = ::write(fd, buffer.data(), count);
+            AssertInfo(written == static_cast<ssize_t>(count),
+                       "failed to write destination file");
+            total += count;
+        }
+        return total;
+    }
+
+ private:
+    std::vector<uint8_t> data_;
+    size_t position_{0};
+};
+
+std::vector<uint8_t>
+Pattern(size_t size, uint8_t seed) {
+    std::vector<uint8_t> data(size);
+    for (size_t i = 0; i < size; ++i) {
+        data[i] = static_cast<uint8_t>(seed + i);
+    }
+    return data;
+}
+
+std::unique_ptr<IndexEntryReader>
+MakeReader(
+    const std::vector<std::pair<std::string, std::vector<uint8_t>>>& entries) {
+    auto output = std::make_shared<VectorOutputStream>();
+    IndexEntryDirectStreamWriter writer(output);
+    for (const auto& [name, data] : entries) {
+        writer.WriteEntry(name, data.data(), data.size());
+    }
+    writer.Finish();
+
+    auto input = std::make_shared<VectorInputStream>(output->TakeData());
+    auto size = input->Size();
+    return IndexEntryReader::Open(std::move(input), size);
+}
+
+class IndexEntryReaderLocalTest : public testing::Test {
+ protected:
+    void
+    SetUp() override {
+        root_ = std::filesystem::temp_directory_path() /
+                "milvus_index_entry_reader_local" /
+                testing::UnitTest::GetInstance()->current_test_info()->name();
+        files_ = local::FileSystem::Open(root_);
+    }
+
+    void
+    TearDown() override {
+        std::filesystem::remove_all(root_);
+    }
+
+    local::io::WritableFile
+    OpenOutput(const std::string& path) {
+        return files_->OpenForWrite(
+            local::Path(path),
+            local::WriteOptions{.create = true, .truncate = true});
+    }
+
+    std::vector<uint8_t>
+    ReadOutput(const std::string& path) {
+        auto input = files_->OpenForRead(local::Path(path));
+        std::vector<uint8_t> data(input.Size());
+        input.ReadAt(0, std::as_writable_bytes(std::span(data)));
+        return data;
+    }
+
+    std::filesystem::path root_;
+    std::optional<local::FileSystem> files_;
+};
+
+TEST_F(IndexEntryReaderLocalTest, StreamsEntryToWritableFile) {
+    auto data = Pattern(3 * 1024 * 1024 + 19, 7);
+    auto reader = MakeReader({{"data", data}});
+
+    reader->ReadEntryStreamToFile(
+        "data", OpenOutput("single.bin"), io::Priority::HIGH);
+
+    EXPECT_EQ(ReadOutput("single.bin"), data);
+}
+
+TEST_F(IndexEntryReaderLocalTest, StreamsEntriesToWritableFiles) {
+    auto first = Pattern(1024 * 1024 + 7, 11);
+    auto second = Pattern(2 * 1024 * 1024 + 13, 29);
+    auto reader = MakeReader({{"first", first}, {"second", second}});
+
+    std::vector<std::pair<std::string, local::io::WritableFile>> outputs;
+    outputs.emplace_back("first", OpenOutput("first.bin"));
+    outputs.emplace_back("second", OpenOutput("second.bin"));
+    reader->ReadEntriesStreamToFiles(std::move(outputs), io::Priority::HIGH);
+
+    EXPECT_EQ(ReadOutput("first.bin"), first);
+    EXPECT_EQ(ReadOutput("second.bin"), second);
+}
+
+TEST_F(IndexEntryReaderLocalTest, PathAdapterKeepsBatchBehavior) {
+    auto first = Pattern(1024 * 1024 + 5, 17);
+    auto second = Pattern(1024 * 1024 + 9, 31);
+    auto reader = MakeReader({{"first", first}, {"second", second}});
+
+    std::vector<std::pair<std::string, std::string>> outputs = {
+        {"first", (root_ / "first.path.bin").string()},
+        {"second", (root_ / "second.path.bin").string()}};
+    reader->ReadEntriesStreamToFiles(outputs, io::Priority::HIGH);
+
+    EXPECT_EQ(ReadOutput("first.path.bin"), first);
+    EXPECT_EQ(ReadOutput("second.path.bin"), second);
+}
+
+}  // namespace
+}  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <filesystem>
 #include <future>
 #include <limits>
 #include <memory>
@@ -37,6 +38,7 @@
 #include "test_utils/Constants.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "storage/IndexEntryDirectStreamWriter.h"
+#include "local/FileSystem.h"
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 #include "storage/IndexEntryReader.h"
 #include "storage/EntryStreamUtils.h"
@@ -968,6 +970,34 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedSmallEntryRoundtrip) {
     auto info = fs_->GetFileInfo(file_path);
     ASSERT_TRUE(info.ok());
     EXPECT_GT(info.ValueOrDie().size(), entry_size);  // ciphertext > plaintext
+}
+
+TEST_F(IndexEntryEncryptedV3Test, EncryptedStagingUsesInjectedRootAndCleansUp) {
+    const auto staging_root =
+        std::filesystem::temp_directory_path() / "milvus_encrypted_staging" /
+        testing::UnitTest::GetInstance()->current_test_info()->name();
+    std::filesystem::remove_all(staging_root);
+    auto cleanup =
+        folly::makeGuard([&]() { std::filesystem::remove_all(staging_root); });
+    auto local_files = milvus::local::FileSystem::Open(staging_root);
+
+    {
+        IndexEntryEncryptedLocalWriter writer(
+            kV3FilePath + "_enc_injected_staging",
+            fs_,
+            mock_cipher_,
+            /*ez_id=*/1,
+            /*collection_id=*/100,
+            local_files,
+            kStreamSliceAlignment);
+        EXPECT_FALSE(std::filesystem::is_empty(staging_root));
+
+        auto data = GeneratePattern(1024);
+        writer.WriteEntry("entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    EXPECT_TRUE(std::filesystem::is_empty(staging_root));
 }
 
 TEST_F(IndexEntryEncryptedV3Test, EncryptedWriterRejectsUnalignedSliceSize) {


### PR DESCRIPTION
## What this PR does

Migrates local storage and index file I/O onto rooted `milvus::local::FileSystem` handles.

## Scope

- adapt `FileWriter` and `IndexEntryReader` to opened local file handles
- move directory write/cleanup leases into `ManagedSubtree`
- migrate `DiskFileManagerImpl` and encrypted local writers
- migrate scalar, text, JSON, Tantivy, RTree, Marisa, and disk-vector index paths
- retain a narrow legacy adapter until runtime filesystem injection is complete

## Stack

- depends on #51509
- PR 2 of 4
- review this commit independently: `enhance: migrate local storage I/O to rooted filesystem`

issue: #51507

## Test plan

- [x] `git diff --check`
- [x] clang-format check
- [x] key storage/index implementation objects compile
- [x] affected C++ test objects compile
- [ ] full `milvus_storage` build is blocked by the current master dependency missing `milvus-storage/ffi_internal/ffi_error_code.h`
- [ ] running `all_tests` is blocked on this macOS environment by an existing Azure SDK/libc++ ABI link failure