### PR TITLE
test: add struct array null semantics and lifecycle coverage

### DIFF
--- a/tests/python_client/milvus_client/test_drop_field_feature.py
+++ b/tests/python_client/milvus_client/test_drop_field_feature.py
@@ -1110,7 +1110,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             max_capacity=4,
         )
         index_params = client.prepare_index_params()
-        index_params.add_index("vec", index_type="FLAT", metric_type="L2")
+        index_params.add_index("vec", index_type="HNSW", metric_type="L2", params={"M": 8, "efConstruction": 64})
         index_params.add_index("events[embedding]", index_type="HNSW", metric_type="MAX_SIM_L2")
         index_params.add_index("events[name]", index_type="INVERTED")
         client.create_collection(

--- a/tests/python_client/milvus_client/test_drop_field_feature.py
+++ b/tests/python_client/milvus_client/test_drop_field_feature.py
@@ -1085,6 +1085,138 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
+    def test_drop_then_readd_same_struct_array_name_isolates_old_offsets(self):
+        """
+        target: verify a same-name Struct Array added after drop gets new field IDs and independent physical data
+        method: drop an indexed vector Struct, re-add the same parent/child name with a scalar-only schema through
+            an alias, then query old/new rows before and after nested index build and reload
+        expected: old Struct binlogs and indexes never surface through the new field; old rows are null and new offsets
+            belong only to newly inserted rows
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        alias = cf.gen_unique_str("struct_readd_alias")
+        schema = client.create_schema(enable_dynamic_field=False, auto_id=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("vec", DataType.FLOAT_VECTOR, dim=4)
+        old_struct_schema = client.create_struct_field_schema()
+        old_struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=4)
+        old_struct_schema.add_field("name", DataType.VARCHAR, max_length=64)
+        schema.add_field(
+            "events",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=old_struct_schema,
+            max_capacity=4,
+        )
+        index_params = client.prepare_index_params()
+        index_params.add_index("vec", index_type="FLAT", metric_type="L2")
+        index_params.add_index("events[embedding]", index_type="HNSW", metric_type="MAX_SIM_L2")
+        index_params.add_index("events[name]", index_type="INVERTED")
+        client.create_collection(
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level="Strong",
+        )
+        client.create_alias(collection_name, alias)
+
+        old_rows = [
+            {
+                "id": row_id,
+                "vec": [float(row_id), 0.0, 0.0, 0.0],
+                "events": [
+                    {
+                        "embedding": [float(row_id), 1.0, 0.0, 0.0],
+                        "name": f"old_{row_id}",
+                    }
+                ],
+            }
+            for row_id in range(3)
+        ]
+        client.insert(collection_name, old_rows)
+        client.flush(collection_name)
+        client.load_collection(collection_name)
+        before_drop = client.describe_collection(collection_name)
+        old_parent = next(field for field in before_drop["fields"] if field["name"] == "events")
+        old_parent_id = old_parent.get("field_id")
+
+        client.drop_collection_field(collection_name, "events")
+        for _ in range(30):
+            if not any(index_name.startswith("events[") for index_name in client.list_indexes(collection_name)):
+                break
+            time.sleep(1)
+        assert not any(index_name.startswith("events[") for index_name in client.list_indexes(collection_name))
+
+        new_struct_schema = client.create_struct_field_schema()
+        new_struct_schema.add_field("name", DataType.VARCHAR, max_length=128)
+        new_struct_schema.add_field("rank", DataType.INT64)
+        client.add_collection_struct_field(
+            alias,
+            "events",
+            new_struct_schema,
+            max_capacity=3,
+        )
+        after_add = client.describe_collection(alias)
+        new_parent = next(field for field in after_add["fields"] if field["name"] == "events")
+        new_parent_id = new_parent.get("field_id")
+        if old_parent_id is not None and new_parent_id is not None:
+            assert new_parent_id > old_parent_id
+
+        old_after_add = client.query(
+            alias,
+            filter="id in [0, 1, 2]",
+            output_fields=["id", "events"],
+        )
+        assert {row["id"] for row in old_after_add} == {0, 1, 2}
+        assert all(row["events"] is None for row in old_after_add)
+        assert client.query(alias, filter='array_contains(events[name], "old_1")', output_fields=["id"]) == []
+
+        new_rows = [
+            {"id": 100, "vec": [100.0, 0.0, 0.0, 0.0], "events": []},
+            {
+                "id": 101,
+                "vec": [101.0, 0.0, 0.0, 0.0],
+                "events": [{"name": "new_a", "rank": 10}, {"name": "new_b", "rank": 20}],
+            },
+        ]
+        client.insert(alias, new_rows)
+        client.flush(alias)
+        nested_indexes = client.prepare_index_params()
+        nested_indexes.add_index("events[name]", index_type="BITMAP")
+        nested_indexes.add_index("events[rank]", index_type="STL_SORT")
+        client.create_index(alias, nested_indexes)
+
+        def assert_new_schema_data():
+            old_rows_result = client.query(
+                alias,
+                filter="id in [0, 1, 2]",
+                output_fields=["id", "events"],
+            )
+            assert all(row["events"] is None for row in old_rows_result)
+            contains = client.query(
+                alias,
+                filter='array_contains(events[name], "new_b")',
+                output_fields=["id", "events"],
+            )
+            assert [row["id"] for row in contains] == [101]
+            assert contains[0]["events"] == new_rows[1]["events"]
+            element_rows = client.query(
+                alias,
+                filter="element_filter(events, $[rank] >= 10)",
+                output_fields=["id"],
+                limit=10,
+            )
+            assert sorted((row["id"], row["offset"]) for row in element_rows) == [(101, 0), (101, 1)]
+
+        assert_new_schema_data()
+        client.release_collection(alias)
+        client.load_collection(alias)
+        assert_new_schema_data()
+        client.drop_alias(alias)
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
     def test_drop_field_negative_constraint_matrix(self):
         """
         TC-L1-06: Drop Field negative constraint matrix.

--- a/tests/python_client/milvus_client/test_milvus_client_partial_update.py
+++ b/tests/python_client/milvus_client/test_milvus_client_partial_update.py
@@ -399,8 +399,10 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
         )
 
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index("vector", index_type="FLAT", metric_type="COSINE")
-        index_params.add_index("events[embedding]", index_type="FLAT", metric_type="COSINE")
+        index_params.add_index("vector", index_type="HNSW", metric_type="COSINE", params={"M": 8, "efConstruction": 64})
+        index_params.add_index(
+            "events[embedding]", index_type="HNSW", metric_type="COSINE", params={"M": 8, "efConstruction": 64}
+        )
         index_params.add_index("events[tag]", index_type="BITMAP")
         self.create_collection(
             client,
@@ -497,7 +499,7 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
                 collection_name,
                 data=[vector(0)],
                 anns_field="events[embedding]",
-                search_params={"metric_type": "COSINE"},
+                search_params={"metric_type": "COSINE", "params": {"ef": 64}},
                 filter="element_filter(events, $[score] >= 0)",
                 output_fields=["id"],
                 limit=3,
@@ -549,7 +551,7 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
             nullable=True,
         )
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index("vector", index_type="FLAT", metric_type="COSINE")
+        index_params.add_index("vector", index_type="HNSW", metric_type="COSINE", params={"M": 8, "efConstruction": 64})
         self.create_collection(
             client, collection_name, schema=schema, index_params=index_params, consistency_level="Strong"
         )

--- a/tests/python_client/milvus_client/test_milvus_client_partial_update.py
+++ b/tests/python_client/milvus_client/test_milvus_client_partial_update.py
@@ -8,6 +8,7 @@ from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
 from pymilvus import DataType, Function, FunctionType
 from pymilvus.client.embedding_list import EmbeddingList
+from pymilvus.client.field_ops import FieldOp
 from sklearn import preprocessing
 from utils.util_log import test_log as log
 from utils.util_pymilvus import *  # noqa: F403
@@ -368,6 +369,208 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
             assert search_results[0][0]["id"] == row_id
             assert search_results[0][0]["payload"] == f"payload_{row_id}"
             self._assert_struct_array_partial_update_events_equal(search_results[0][0]["events"], expected_events)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_partial_update_struct_array_state_transitions(self):
+        """
+        target: verify whole-Struct partial updates preserve null, empty, and element offset semantics
+        method: transition sealed rows through null, empty, and different non-empty lengths while omitting
+            ordinary fields, then compare nested-index query and element search before/after compact and reload
+        expected: the whole Struct is replaced, omitted ordinary fields are preserved, and stale elements disappear
+        """
+        client = self._client()
+        dim = 8
+        collection_name = cf.gen_unique_str(f"{prefix}_pu_struct_states")
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field("payload", DataType.VARCHAR, max_length=64)
+        struct_schema = self.create_struct_field_schema(client)[0]
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=dim)
+        struct_schema.add_field("score", DataType.INT64)
+        struct_schema.add_field("tag", DataType.VARCHAR, max_length=64)
+        schema.add_field(
+            "events",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=4,
+            nullable=True,
+        )
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index("vector", index_type="FLAT", metric_type="COSINE")
+        index_params.add_index("events[embedding]", index_type="FLAT", metric_type="COSINE")
+        index_params.add_index("events[tag]", index_type="BITMAP")
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level="Strong",
+        )
+
+        def vector(axis):
+            value = [0.0] * dim
+            value[axis % dim] = 1.0
+            return value
+
+        def events(row_id, count, state):
+            return [
+                {
+                    "embedding": vector(row_id + offset),
+                    "score": row_id * 100 + offset,
+                    "tag": f"{state}_{row_id}_{offset}",
+                }
+                for offset in range(count)
+            ]
+
+        expected = {
+            0: {"id": 0, "vector": vector(0), "payload": "payload_0", "events": None},
+            1: {"id": 1, "vector": vector(1), "payload": "payload_1", "events": []},
+            2: {"id": 2, "vector": vector(2), "payload": "payload_2", "events": events(2, 1, "initial")},
+            3: {"id": 3, "vector": vector(3), "payload": "payload_3", "events": events(3, 2, "initial")},
+        }
+        self.insert(client, collection_name, list(expected.values()))
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        first_transition = {
+            0: [],
+            1: events(1, 1, "first"),
+            2: None,
+            3: events(3, 3, "first"),
+        }
+        self.upsert(
+            client,
+            collection_name,
+            [{"id": row_id, "events": value} for row_id, value in first_transition.items()],
+            partial_update=True,
+        )
+        for row_id, value in first_transition.items():
+            expected[row_id]["events"] = value
+        self.flush(client, collection_name)
+
+        second_transition = {
+            0: events(0, 2, "final"),
+            1: None,
+            2: [],
+            3: events(3, 1, "final"),
+        }
+        self.upsert(
+            client,
+            collection_name,
+            [{"id": row_id, "events": value} for row_id, value in second_transition.items()],
+            partial_update=True,
+        )
+        for row_id, value in second_transition.items():
+            expected[row_id]["events"] = value
+        self.flush(client, collection_name)
+
+        def collect_observations():
+            rows = self.query(
+                client,
+                collection_name,
+                filter="id >= 0",
+                output_fields=["id", "vector", "payload", "events"],
+                limit=len(expected),
+            )[0]
+            rows_by_id = {row["id"]: row for row in rows}
+            assert set(rows_by_id) == set(expected)
+            for row_id, expected_row in expected.items():
+                assert rows_by_id[row_id]["payload"] == expected_row["payload"]
+                assert np.allclose(rows_by_id[row_id]["vector"], expected_row["vector"])
+                self._assert_struct_array_partial_update_events_equal(
+                    rows_by_id[row_id]["events"] or [], expected_row["events"] or []
+                )
+                assert (rows_by_id[row_id]["events"] is None) == (expected_row["events"] is None)
+
+            indexed_rows = self.query(
+                client,
+                collection_name,
+                filter='array_contains(events[tag], "final_0_1")',
+                output_fields=["id"],
+                limit=len(expected),
+            )[0]
+            element_hits = self.search(
+                client,
+                collection_name,
+                data=[vector(0)],
+                anns_field="events[embedding]",
+                search_params={"metric_type": "COSINE"},
+                filter="element_filter(events, $[score] >= 0)",
+                output_fields=["id"],
+                limit=3,
+            )[0][0]
+            return {
+                "projection": sorted(
+                    (row_id, rows_by_id[row_id]["payload"], rows_by_id[row_id]["events"]) for row_id in rows_by_id
+                ),
+                "indexed_ids": sorted(row["id"] for row in indexed_rows),
+                "element_keys": sorted((hit["id"], hit["offset"]) for hit in element_hits),
+            }
+
+        baseline = collect_observations()
+        assert baseline["indexed_ids"] == [0]
+        assert baseline["element_keys"] == [(0, 0), (0, 1), (3, 0)]
+
+        compact_id = self.compact(client, collection_name)[0]
+        assert compact_id > 0
+        assert self.wait_for_compaction_ready(client, compact_id, timeout=300)
+        self.release_collection(client, collection_name)
+        self.load_collection(client, collection_name)
+        assert collect_observations() == baseline
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize(
+        "field_name",
+        ["events", "events[tag]"],
+        ids=["struct-parent", "struct-subfield"],
+    )
+    def test_milvus_client_partial_update_struct_array_field_ops_rejected(self, field_name):
+        """
+        target: verify Array partial-update operators cannot mutate Struct parents or Struct sub-fields
+        method: apply ARRAY_APPEND to a whole Struct field and to one child field
+        expected: both requests are rejected and the original Struct remains unchanged
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_pu_struct_op")
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=4)
+        struct_schema = self.create_struct_field_schema(client)[0]
+        struct_schema.add_field("tag", DataType.VARCHAR, max_length=32)
+        schema.add_field(
+            "events",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=4,
+            nullable=True,
+        )
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index("vector", index_type="FLAT", metric_type="COSINE")
+        self.create_collection(
+            client, collection_name, schema=schema, index_params=index_params, consistency_level="Strong"
+        )
+        original = {"id": 0, "vector": [1.0, 0.0, 0.0, 0.0], "events": [{"tag": "original"}]}
+        self.insert(client, collection_name, [original])
+        self.load_collection(client, collection_name)
+
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: f'op ARRAY_APPEND is not supported for struct field "{field_name}"',
+        }
+        self.upsert(
+            client,
+            collection_name,
+            [{"id": 0, "events": [{"tag": "new"}]}],
+            field_ops={field_name: FieldOp.array_append()},
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+        rows = self.query(client, collection_name, filter="id == 0", output_fields=["events"])[0]
+        assert rows[0]["events"] == original["events"]
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_partial_update_all_field_types_one_by_one(self):

--- a/tests/python_client/milvus_client/test_milvus_client_regex_filter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_regex_filter.py
@@ -2456,6 +2456,57 @@ class TestRegexFilterStructArray(RegexFilterStructArraySharedBase):
         assert result == [1], f"indexed struct name =~ error.*timeout: expected [1], got {result}"
 
     @pytest.mark.tags(CaseLabel.L1)
+    def test_regex_struct_array_raw_index_reload_consistency(self):
+        """
+        target: regex results remain stable across raw, nested scalar-indexed, and reloaded states
+        expected: MATCH and element_filter PK/offset results are identical before indexing, after indexing, and reload
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        setup_struct_array_regex_collection(client, collection_name, create_scalar_index=False)
+
+        def collect_observations():
+            match_name = client.query(
+                collection_name,
+                filter='MATCH_ANY(events, $[name] =~ "error.*timeout")',
+                output_fields=["id"],
+            )
+            match_status = client.query(
+                collection_name,
+                filter='MATCH_ANY(events, $[status] !~ "ERROR")',
+                output_fields=["id"],
+            )
+            matching_elements = client.query(
+                collection_name,
+                filter='element_filter(events, $[name] =~ "login.*")',
+                output_fields=["id"],
+                limit=100,
+            )
+            return {
+                "match_name": sorted(row["id"] for row in match_name),
+                "match_status": sorted(row["id"] for row in match_status),
+                "elements": sorted((row["id"], row["offset"]) for row in matching_elements),
+            }
+
+        baseline = collect_observations()
+        assert baseline == {
+            "match_name": [1],
+            "match_status": [1, 2, 3],
+            "elements": [(1, 0), (1, 1)],
+        }
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(field_name="events[name]", index_type="INVERTED")
+        index_params.add_index(field_name="events[status]", index_type="INVERTED")
+        client.create_index(collection_name, index_params)
+        assert collect_observations() == baseline
+
+        client.release_collection(collection_name)
+        client.load_collection(collection_name)
+        assert collect_observations() == baseline
+        self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
     def test_regex_struct_array_hybrid_search(self):
         """
         target: hybrid_search supports regex filters on StructArray scalar paths

--- a/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
@@ -1617,9 +1617,9 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L2)
     def test_struct_array_element_search_with_primary_key_aggregation(self):
         """
-        target: clarify StructArray element-vector search support when grouped by primary key.
-        method: search structA[embedding] and request aggregation by the primary key field.
-        expected: request succeeds because element-level StructArray search only supports primary-key grouping.
+        target: verify StructArray element results are aggregated exactly by primary key.
+        method: search six elements from three primary keys and request PK buckets with counts and two top hits.
+        expected: all three PK buckets contain exactly their two elements without cross-row mixing or loss.
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -1646,16 +1646,24 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
             params={"M": 8, "efConstruction": 64},
         )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
-        vectors = cf.gen_vectors(self.nb * 2, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)
+        vectors = [
+            [1.0, 0.0] + [0.0] * (dim - 2),
+            [0.9, 0.1] + [0.0] * (dim - 2),
+            [0.0, 1.0] + [0.0] * (dim - 2),
+            [0.1, 0.9] + [0.0] * (dim - 2),
+            [-1.0, 0.0] + [0.0] * (dim - 2),
+            [-0.9, -0.1] + [0.0] * (dim - 2),
+        ]
+        primary_keys = [10, 20, 30]
         rows = [
             {
-                "id": i,
+                "id": primary_key,
                 "structA": [
                     {"embedding": vectors[i * 2], "label": f"label_{i}_0"},
                     {"embedding": vectors[i * 2 + 1], "label": f"label_{i}_1"},
                 ],
             }
-            for i in range(self.nb)
+            for i, primary_key in enumerate(primary_keys)
         ]
         self.insert(client, collection_name, data=rows)
         self.flush(client, collection_name)
@@ -1664,25 +1672,30 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
         res, _ = self.search(
             client,
             collection_name,
-            data=[vectors[0]],
+            data=[[0.7, 0.7] + [0.0] * (dim - 2)],
             anns_field="structA[embedding]",
-            search_params={"metric_type": "COSINE", "params": {"ef": 32}},
-            limit=10,
-            output_fields=["id"],
+            search_params={"metric_type": "COSINE", "params": {"ef": 64}},
+            limit=len(vectors),
+            output_fields=["id", "structA[label]"],
             search_aggregation=SearchAggregation(
                 fields=["id"],
                 size=3,
                 metrics={"doc_count": {"count": "*"}},
-                top_hits=TopHits(size=1),
+                top_hits=TopHits(size=2, sort=[{"_score": "desc"}]),
             ),
         )
 
         assert len(res.agg_buckets) == 1
-        assert 1 <= len(res.agg_buckets[0]) <= 3
+        assert len(res.agg_buckets[0]) == len(primary_keys)
+        buckets_by_id = {bucket.key[0]["value"]: bucket for bucket in res.agg_buckets[0]}
+        assert set(buckets_by_id) == set(primary_keys)
         for bucket in res.agg_buckets[0]:
             assert [entry["field_name"] for entry in bucket.key] == ["id"]
-            assert bucket.metrics["doc_count"] == bucket.count
-            assert len(bucket.hits) == 1
+            primary_key = bucket.key[0]["value"]
+            assert bucket.metrics["doc_count"] == bucket.count == 2
+            assert len(bucket.hits) == 2
+            assert all(hit.pk == primary_key for hit in bucket.hits)
+            assert bucket.hits[0].score >= bucket.hits[1].score
 
 
 @pytest.mark.xdist_group("TestSearchAggregationTextAndBM25")

--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -2245,7 +2245,6 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientSnapshotBase):
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51414", strict=True)
     def test_snapshot_restores_struct_array_semantics_and_indexes(self):
         """
         target: verify snapshot restores Struct Array schema, nullability, nested indexes, and both search modes

--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -2245,6 +2245,7 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientSnapshotBase):
         self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51414", strict=True)
     def test_snapshot_restores_struct_array_semantics_and_indexes(self):
         """
         target: verify snapshot restores Struct Array schema, nullability, nested indexes, and both search modes

--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -2249,8 +2249,8 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientSnapshotBase):
         """
         target: verify snapshot restores Struct Array schema, nullability, nested indexes, and both search modes
         method: snapshot nullable Struct rows with empty and variable-length values plus separate embedding-list and
-            element-vector sub-fields, restore to a new collection, and compare exact observations
-        expected: restored projection, predicates, element offsets, embedding-list PK, and index metadata equal source
+            element-vector sub-fields, restore to a new collection, and compare exact semantic observations
+        expected: restored projection, predicates, complete valid ANN candidate sets, and index metadata equal source
         """
         client = self._client()
         collection_name = cf.gen_unique_str(f"{prefix}_struct_source")
@@ -2274,14 +2274,19 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientSnapshotBase):
             nullable=True,
         )
         index_params = client.prepare_index_params()
-        index_params.add_index("vector", index_type="FLAT", metric_type="COSINE")
+        index_params.add_index("vector", index_type="HNSW", metric_type="COSINE", params={"M": 8, "efConstruction": 64})
         index_params.add_index(
             "events[embedding]",
             index_type="HNSW",
             metric_type="MAX_SIM_COSINE",
             params={"M": 8, "efConstruction": 64},
         )
-        index_params.add_index("events[element_embedding]", index_type="FLAT", metric_type="COSINE")
+        index_params.add_index(
+            "events[element_embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params={"M": 8, "efConstruction": 64},
+        )
         index_params.add_index("events[tag]", index_type="BITMAP")
         self.create_collection(
             client,
@@ -2337,7 +2342,7 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientSnapshotBase):
                 target_collection,
                 data=[vector(0)],
                 anns_field="events[element_embedding]",
-                search_params={"metric_type": "COSINE"},
+                search_params={"metric_type": "COSINE", "params": {"ef": 64}},
                 output_fields=["id"],
                 limit=3,
             )[0][0]
@@ -2350,14 +2355,14 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientSnapshotBase):
                 anns_field="events[embedding]",
                 search_params={"metric_type": "MAX_SIM_COSINE", "params": {"ef": 32}},
                 output_fields=["id"],
-                limit=1,
+                limit=2,
             )[0][0]
             return {
                 "projection": sorted((row["id"], row["events"]) for row in projected),
                 "contains_ids": sorted(row["id"] for row in contains),
                 "match_ids": sorted(row["id"] for row in matched),
                 "element_keys": sorted((hit["id"], hit["offset"]) for hit in element_hits),
-                "embedding_ids": [hit["id"] for hit in embedding_hits],
+                "embedding_ids": sorted(hit["id"] for hit in embedding_hits),
                 "indexes": sorted(client.list_indexes(target_collection)),
             }
 
@@ -2365,7 +2370,7 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientSnapshotBase):
         assert source_observations["contains_ids"] == [2]
         assert source_observations["match_ids"] == [2]
         assert source_observations["element_keys"] == [(2, 0), (2, 1), (3, 0)]
-        assert source_observations["embedding_ids"] == [2]
+        assert source_observations["embedding_ids"] == [2, 3]
 
         self.create_snapshot(client, snapshot_name, collection_name)
         job_id = self.restore_snapshot(
@@ -2376,10 +2381,14 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientSnapshotBase):
         )[0]
         wait_for_restore_complete(self, client, job_id)
         self.load_collection(client, restored_collection_name)
-        assert collect_observations(restored_collection_name) == source_observations
-
-        self.drop_snapshot(client, snapshot_name, collection_name)
-        self.drop_collection(client, restored_collection_name)
+        try:
+            restored_observations = collect_observations(restored_collection_name)
+            for key in ("projection", "contains_ids", "match_ids", "element_keys", "indexes"):
+                assert restored_observations[key] == source_observations[key]
+            assert restored_observations["embedding_ids"] == [2, 3]
+        finally:
+            self.drop_snapshot(client, snapshot_name, collection_name)
+            self.drop_collection(client, restored_collection_name)
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_snapshot_with_bfloat16_vector(self):

--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -9,6 +9,7 @@ from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
 from ml_dtypes import bfloat16
 from pymilvus import DataType
+from pymilvus.client.embedding_list import EmbeddingList
 from utils.util_log import test_log as log
 
 prefix = "snapshot"
@@ -2240,6 +2241,143 @@ class TestMilvusClientSnapshotAllDataTypes(TestMilvusClientSnapshotBase):
         assert has_struct_data, "Should have rows with array_struct data"
 
         # Cleanup
+        self.drop_snapshot(client, snapshot_name, collection_name)
+        self.drop_collection(client, restored_collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_snapshot_restores_struct_array_semantics_and_indexes(self):
+        """
+        target: verify snapshot restores Struct Array schema, nullability, nested indexes, and both search modes
+        method: snapshot nullable Struct rows with empty and variable-length values plus separate embedding-list and
+            element-vector sub-fields, restore to a new collection, and compare exact observations
+        expected: restored projection, predicates, element offsets, embedding-list PK, and index metadata equal source
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_struct_source")
+        restored_collection_name = cf.gen_unique_str(f"{prefix}_struct_restored")
+        snapshot_name = cf.gen_unique_str(f"{prefix}_struct")
+        dim = 8
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=dim)
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=dim)
+        struct_schema.add_field("element_embedding", DataType.FLOAT_VECTOR, dim=dim)
+        struct_schema.add_field("tag", DataType.VARCHAR, max_length=32)
+        schema.add_field(
+            "events",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=4,
+            nullable=True,
+        )
+        index_params = client.prepare_index_params()
+        index_params.add_index("vector", index_type="FLAT", metric_type="COSINE")
+        index_params.add_index(
+            "events[embedding]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params={"M": 8, "efConstruction": 64},
+        )
+        index_params.add_index("events[element_embedding]", index_type="FLAT", metric_type="COSINE")
+        index_params.add_index("events[tag]", index_type="BITMAP")
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level="Strong",
+        )
+
+        def vector(axis):
+            value = [0.0] * dim
+            value[axis % dim] = 1.0
+            return value
+
+        def event(axis, tag):
+            value = vector(axis)
+            return {"embedding": value, "element_embedding": value, "tag": tag}
+
+        rows = [
+            {"id": 0, "vector": vector(0), "events": None},
+            {"id": 1, "vector": vector(1), "events": []},
+            {"id": 2, "vector": vector(2), "events": [event(0, "target"), event(2, "other")]},
+            {"id": 3, "vector": vector(3), "events": [event(1, "control")]},
+        ]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        def collect_observations(target_collection):
+            projected = self.query(
+                client,
+                target_collection,
+                filter="id >= 0",
+                output_fields=["id", "events"],
+                limit=len(rows),
+            )[0]
+            contains = self.query(
+                client,
+                target_collection,
+                filter='array_contains(events[tag], "target")',
+                output_fields=["id"],
+                limit=len(rows),
+            )[0]
+            matched = self.query(
+                client,
+                target_collection,
+                filter='MATCH_ANY(events, $[tag] == "target")',
+                output_fields=["id"],
+                limit=len(rows),
+            )[0]
+            element_hits = self.search(
+                client,
+                target_collection,
+                data=[vector(0)],
+                anns_field="events[element_embedding]",
+                search_params={"metric_type": "COSINE"},
+                output_fields=["id"],
+                limit=3,
+            )[0][0]
+            tensor = EmbeddingList()
+            tensor.add(vector(0))
+            embedding_hits = self.search(
+                client,
+                target_collection,
+                data=[tensor],
+                anns_field="events[embedding]",
+                search_params={"metric_type": "MAX_SIM_COSINE", "params": {"ef": 32}},
+                output_fields=["id"],
+                limit=1,
+            )[0][0]
+            return {
+                "projection": sorted((row["id"], row["events"]) for row in projected),
+                "contains_ids": sorted(row["id"] for row in contains),
+                "match_ids": sorted(row["id"] for row in matched),
+                "element_keys": sorted((hit["id"], hit["offset"]) for hit in element_hits),
+                "embedding_ids": [hit["id"] for hit in embedding_hits],
+                "indexes": sorted(client.list_indexes(target_collection)),
+            }
+
+        source_observations = collect_observations(collection_name)
+        assert source_observations["contains_ids"] == [2]
+        assert source_observations["match_ids"] == [2]
+        assert source_observations["element_keys"] == [(2, 0), (2, 1), (3, 0)]
+        assert source_observations["embedding_ids"] == [2]
+
+        self.create_snapshot(client, snapshot_name, collection_name)
+        job_id = self.restore_snapshot(
+            client,
+            snapshot_name,
+            collection_name,
+            restored_collection_name,
+        )[0]
+        wait_for_restore_complete(self, client, job_id)
+        self.load_collection(client, restored_collection_name)
+        assert collect_observations(restored_collection_name) == source_observations
+
         self.drop_snapshot(client, snapshot_name, collection_name)
         self.drop_collection(client, restored_collection_name)
 

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -4047,6 +4047,227 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
         assert len(scoped_ids) == len(set(scoped_ids)), f"row-level hybrid should not duplicate ids: {scoped_ids}"
 
     @pytest.mark.tags(CaseLabel.L1)
+    def test_hybrid_element_scope_all_collapse_strategies_exact(self):
+        """
+        target: verify all Struct element collapse strategies with exact row order and RRF score
+        method: use identical deterministic vectors in two parent Struct fields, run nq=2 hybrid search for
+            max, sum, avg, topk_sum, and topk_avg, including topk larger than the row element count
+        expected: each strategy produces its calculated row order, exact RRF scores, and no element offset leakage
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_scope_all")
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+
+        for struct_name in ("structA", "structB"):
+            struct_schema = client.create_struct_field_schema()
+            struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+            schema.add_field(
+                struct_name,
+                datatype=DataType.ARRAY,
+                element_type=DataType.STRUCT,
+                struct_schema=struct_schema,
+                max_capacity=4,
+            )
+
+        index_params = client.prepare_index_params()
+        for field_name in ("structA[embedding]", "structB[embedding]"):
+            index_params.add_index(field_name=field_name, index_type="FLAT", metric_type="COSINE")
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        scores_by_id = {
+            1: [0.99, 0.10, 0.10, 0.10],
+            2: [0.80, 0.80, 0.80, 0.80],
+            3: [0.90, 0.90],
+            4: [0.95],
+        }
+        rows = []
+        for row_id, scores in scores_by_id.items():
+            values = [{"embedding": self._cosine_vector(score)} for score in scores]
+            rows.append({"id": row_id, "structA": values, "structB": values})
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        expected_orders = {
+            "max": [1, 4, 3, 2],
+            "sum": [2, 3, 1, 4],
+            "avg": [4, 3, 2, 1],
+            "topk_sum": [3, 2, 1, 4],
+            "topk_avg": [4, 3, 2, 1],
+            "topk_sum_all": [2, 3, 1, 4],
+            "topk_avg_all": [4, 3, 2, 1],
+        }
+        cases = [
+            ("max", {"strategy": "max"}),
+            ("sum", {"strategy": "sum"}),
+            ("avg", {"strategy": "avg"}),
+            ("topk_sum", {"strategy": "topk_sum", "topk": 2}),
+            ("topk_avg", {"strategy": "topk_avg", "topk": 2}),
+            ("topk_sum_all", {"strategy": "topk_sum", "topk": 10}),
+            ("topk_avg_all", {"strategy": "topk_avg", "topk": 10}),
+        ]
+        query_vector = self._cosine_vector(1.0)
+        rrf_k = 60
+
+        for case_name, collapse in cases:
+            requests = [
+                AnnSearchRequest(
+                    **{
+                        "data": [query_vector, query_vector],
+                        "anns_field": field_name,
+                        "param": {
+                            "metric_type": "COSINE",
+                            "params": {"element_scope": {"collapse": collapse}},
+                        },
+                        "limit": sum(len(values) for values in scores_by_id.values()),
+                    }
+                )
+                for field_name in ("structA[embedding]", "structB[embedding]")
+            ]
+            results, check = self.hybrid_search(
+                client,
+                collection_name,
+                requests,
+                ranker=RRFRanker(rrf_k),
+                limit=len(scores_by_id),
+                output_fields=["id"],
+            )
+            assert check
+            assert len(results) == 2
+            for hits in results:
+                assert [hit["id"] for hit in hits] == expected_orders[case_name]
+                assert all("offset" not in hit for hit in hits)
+                for rank, hit in enumerate(hits):
+                    assert hit["distance"] == pytest.approx(2 / (rrf_k + rank + 1), abs=1e-6)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_element_scope_validation_matrix(self):
+        """
+        target: verify element collapse strategy and topk validation
+        method: submit missing, zero, extraneous, and unsupported collapse parameters
+        expected: every invalid configuration is rejected with its source-defined parameter error
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_scope_validation")
+        self._setup_multi_struct_collection(client, collection_name)
+        query_vector = self._cosine_vector(1.0)
+        invalid_cases = [
+            ({"strategy": "topk_sum"}, "element_scope.collapse.topk is required for strategy topk_sum"),
+            ({"strategy": "topk_avg", "topk": 0}, "element_scope.collapse.topk must be positive"),
+            ({"strategy": "max", "topk": 1}, "element_scope.collapse.topk is only valid for topk strategies"),
+            ({"strategy": "median"}, "unsupported element_scope.collapse.strategy: median"),
+        ]
+
+        for collapse, expected_message in invalid_cases:
+            req1 = AnnSearchRequest(
+                **{
+                    "data": [query_vector],
+                    "anns_field": "structA[embedding]",
+                    "param": {
+                        "metric_type": "COSINE",
+                        "params": {"element_scope": {"collapse": collapse}},
+                    },
+                    "limit": 9,
+                }
+            )
+            req2 = AnnSearchRequest(
+                **{
+                    "data": [query_vector],
+                    "anns_field": "structB[embedding]",
+                    "param": {"metric_type": "COSINE"},
+                    "limit": 9,
+                }
+            )
+            self.hybrid_search(
+                client,
+                collection_name,
+                [req1, req2],
+                ranker=RRFRanker(),
+                limit=3,
+                check_task=CheckTasks.err_res,
+                check_items={ct.err_code: 1100, ct.err_msg: expected_message},
+            )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize(
+        "ranker",
+        [RRFRanker(60), WeightedRanker(0.5, 0.5)],
+        ids=["rrf", "weighted"],
+    )
+    def test_hybrid_same_struct_string_pk_element_identity_exact(self, ranker):
+        """
+        target: verify same-Struct hybrid preserves string primary key and element offset identity
+        method: rerank two identical vector sub-fields with RRF and WeightedRanker
+        expected: both rankers return the exact ordered (string PK, offset) sequence without row collapse
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_string_pk")
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.VARCHAR, max_length=32, is_primary=True)
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_schema.add_field("embedding_alt", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(
+            "structA",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=4,
+        )
+        index_params = client.prepare_index_params()
+        for field_name in ("structA[embedding]", "structA[embedding_alt]"):
+            index_params.add_index(field_name=field_name, index_type="FLAT", metric_type="COSINE")
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        score_rows = {"doc/a": [0.99, 0.10], "doc:b": [0.90, 0.80]}
+        rows = []
+        for row_id, scores in score_rows.items():
+            rows.append(
+                {
+                    "id": row_id,
+                    "structA": [
+                        {
+                            "embedding": self._cosine_vector(score),
+                            "embedding_alt": self._cosine_vector(score),
+                        }
+                        for score in scores
+                    ],
+                }
+            )
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        query_vector = self._cosine_vector(1.0)
+        requests = [
+            AnnSearchRequest(
+                **{
+                    "data": [query_vector],
+                    "anns_field": field_name,
+                    "param": {"metric_type": "COSINE"},
+                    "limit": 4,
+                }
+            )
+            for field_name in ("structA[embedding]", "structA[embedding_alt]")
+        ]
+        results, check = self.hybrid_search(
+            client,
+            collection_name,
+            requests,
+            ranker=ranker,
+            limit=4,
+            output_fields=["id"],
+        )
+        assert check
+        assert [(hit["id"], hit["offset"]) for hit in results[0]] == [
+            ("doc/a", 0),
+            ("doc:b", 0),
+            ("doc:b", 1),
+            ("doc/a", 1),
+        ]
+
+    @pytest.mark.tags(CaseLabel.L1)
     def test_hybrid_element_level_range_same_struct_supported(self):
         """
         target: same-struct element-level hybrid supports range search

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -733,6 +733,7 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
         assert top_hit["offset"] == target_elem, f"expected element offset={target_elem}, got {top_hit['offset']}"
 
     @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51416", strict=True)
     def test_element_filter_template_matches_inline_query_and_search(self):
         """
         target: verify filter templates bind Struct child values for element-level query and search

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -732,6 +732,72 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
         assert "offset" in top_hit, "element offset not exposed on hit"
         assert top_hit["offset"] == target_elem, f"expected element offset={target_elem}, got {top_hit['offset']}"
 
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_element_filter_template_matches_inline_query_and_search(self):
+        """
+        target: verify filter templates bind Struct child values for element-level query and search
+        method: compare a string template against its inline element_filter form for query and vector search
+        expected: template and inline forms return identical PK/offset results
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_ef_template")
+        data = self._create_collection_and_insert(client, collection_name, nb=20, metric_type="COSINE")
+        target_row = 5
+        target_elem = 2
+        tag = data[target_row]["structA"][target_elem]["str_val"]
+        query_vector = data[target_row]["structA"][target_elem]["embedding"]
+        inline = f'element_filter(structA, $[str_val] == "{tag}")'
+        template = "element_filter(structA, $[str_val] == {tag})"
+        failures = []
+
+        inline_query = client.query(
+            collection_name,
+            filter=inline,
+            output_fields=["id"],
+            limit=100,
+        )
+        try:
+            template_query = client.query(
+                collection_name,
+                filter=template,
+                filter_params={"tag": tag},
+                output_fields=["id"],
+                limit=100,
+            )
+            assert [(row["id"], row["offset"]) for row in template_query] == [
+                (row["id"], row["offset"]) for row in inline_query
+            ]
+        except Exception as exc:
+            failures.append(f"query failed: {exc}")
+
+        inline_search = client.search(
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE"},
+            filter=inline,
+            limit=10,
+            output_fields=["id"],
+        )[0]
+        try:
+            template_search = client.search(
+                collection_name,
+                data=[query_vector],
+                anns_field="structA[embedding]",
+                search_params={"metric_type": "COSINE"},
+                filter=template,
+                filter_params={"tag": tag},
+                limit=10,
+                output_fields=["id"],
+            )[0]
+            assert [(hit["id"], hit["offset"]) for hit in template_search] == [
+                (hit["id"], hit["offset"]) for hit in inline_search
+            ]
+        except Exception as exc:
+            failures.append(f"search failed: {exc}")
+
+        assert not failures, "\n".join(failures)
+
     # ---- L1 tests ----
 
     @pytest.mark.tags(CaseLabel.L1)

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -3854,7 +3854,12 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
 
         index_params = client.prepare_index_params()
         for field_name in ["normal_vector", "structA[embedding]", "structA[embedding_alt]", "structB[embedding]"]:
-            index_params.add_index(field_name=field_name, index_type="FLAT", metric_type=metric_type)
+            index_params.add_index(
+                field_name=field_name,
+                index_type="HNSW",
+                metric_type=metric_type,
+                params={"M": 8, "efConstruction": 64},
+            )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         def _struct_a(scores):
@@ -4073,9 +4078,9 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
         query_vector = self._cosine_vector(1.0)
 
         def _req(field_name, params=None):
-            search_params = {"metric_type": "COSINE"}
+            search_params = {"metric_type": "COSINE", "params": {"ef": 64}}
             if params is not None:
-                search_params["params"] = params
+                search_params["params"].update(params)
             return AnnSearchRequest(
                 **{
                     "data": [query_vector],
@@ -4138,7 +4143,12 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
 
         index_params = client.prepare_index_params()
         for field_name in ("structA[embedding]", "structB[embedding]"):
-            index_params.add_index(field_name=field_name, index_type="FLAT", metric_type="COSINE")
+            index_params.add_index(
+                field_name=field_name,
+                index_type="HNSW",
+                metric_type="COSINE",
+                params={"M": 8, "efConstruction": 64},
+            )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         scores_by_id = {
@@ -4184,7 +4194,7 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
                         "anns_field": field_name,
                         "param": {
                             "metric_type": "COSINE",
-                            "params": {"element_scope": {"collapse": collapse}},
+                            "params": {"ef": 64, "element_scope": {"collapse": collapse}},
                         },
                         "limit": sum(len(values) for values in scores_by_id.values()),
                     }
@@ -4232,7 +4242,7 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
                     "anns_field": "structA[embedding]",
                     "param": {
                         "metric_type": "COSINE",
-                        "params": {"element_scope": {"collapse": collapse}},
+                        "params": {"ef": 64, "element_scope": {"collapse": collapse}},
                     },
                     "limit": 9,
                 }
@@ -4241,7 +4251,7 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
                 **{
                     "data": [query_vector],
                     "anns_field": "structB[embedding]",
-                    "param": {"metric_type": "COSINE"},
+                    "param": {"metric_type": "COSINE", "params": {"ef": 64}},
                     "limit": 9,
                 }
             )
@@ -4283,7 +4293,12 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
         )
         index_params = client.prepare_index_params()
         for field_name in ("structA[embedding]", "structA[embedding_alt]"):
-            index_params.add_index(field_name=field_name, index_type="FLAT", metric_type="COSINE")
+            index_params.add_index(
+                field_name=field_name,
+                index_type="HNSW",
+                metric_type="COSINE",
+                params={"M": 8, "efConstruction": 64},
+            )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         score_rows = {"doc/a": [0.99, 0.10], "doc:b": [0.90, 0.80]}
@@ -4311,7 +4326,7 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
                 **{
                     "data": [query_vector],
                     "anns_field": field_name,
-                    "param": {"metric_type": "COSINE"},
+                    "param": {"metric_type": "COSINE", "params": {"ef": 64}},
                     "limit": 4,
                 }
             )
@@ -4344,7 +4359,7 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(f"{prefix}_hyb_range_same_struct")
         self._setup_multi_struct_collection(client, collection_name)
         query_vector = self._cosine_vector(1.0)
-        range_params = {"radius": 0.85}
+        range_params = {"ef": 64, "radius": 0.85}
 
         req1 = AnnSearchRequest(
             **{

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -733,7 +733,6 @@ class TestMilvusClientStructArrayElementFilterSearch(TestMilvusClientV2Base):
         assert top_hit["offset"] == target_elem, f"expected element offset={target_elem}, got {top_hit['offset']}"
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51416", strict=True)
     def test_element_filter_template_matches_inline_query_and_search(self):
         """
         target: verify filter templates bind Struct child values for element-level query and search

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -18,7 +18,7 @@ from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
 from minio import Minio
 from minio.error import S3Error
-from pymilvus import DataType
+from pymilvus import AnnSearchRequest, DataType, WeightedRanker
 from pymilvus.bulk_writer import (
     bulk_import,
     get_import_progress,
@@ -1176,6 +1176,267 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         self.release_collection(client, collection_name)
         self.load_collection(client, collection_name)
         assert collect_observations() == baseline
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize(
+        "template, params, inline, include_offset, check_hybrid",
+        [
+            pytest.param(
+                f"MATCH_LEAST({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= {{min_score}}, threshold=1)",
+                {"min_score": 10},
+                f"MATCH_LEAST({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 10, threshold=1)",
+                False,
+                True,
+                id="match_int",
+            ),
+            pytest.param(
+                f"array_contains_any({STRUCT_TAG_FIELD}, {{tags}})",
+                {"tags": ["blue"]},
+                f'array_contains_any({STRUCT_TAG_FIELD}, ["blue"])',
+                False,
+                False,
+                id="contains_any_list",
+            ),
+            pytest.param(
+                f"array_contains_all({STRUCT_TAG_FIELD}, {{tags}})",
+                {"tags": []},
+                f"array_contains_all({STRUCT_TAG_FIELD}, [])",
+                False,
+                False,
+                id="contains_all_empty_list",
+            ),
+        ],
+    )
+    def test_struct_array_filter_template_matches_inline_expression(
+        self,
+        template,
+        params,
+        inline,
+        include_offset,
+        check_hybrid,
+    ):
+        """
+        target: verify filter templates compose with Struct element syntax and nested scalar indexes
+        method: compare inline and parameterized MATCH and contains expressions through query,
+            normal-vector search, and hybrid search, including scalar, string, list, and empty-list parameters
+        expected: template and inline forms return identical PK/offset results; incompatible parameter types fail
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_filter_template")
+        schema = gen_struct_array_schema(self, client, include_vector_subfield=False)
+        index_params = gen_index_params(self, client)
+        index_params.add_index(VECTOR_FIELD, index_type="FLAT", metric_type="L2")
+        index_params.add_index(STRUCT_INT_FIELD, index_type="STL_SORT")
+        index_params.add_index(STRUCT_TAG_FIELD, index_type="BITMAP")
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level="Strong",
+        )
+        rows = [
+            gen_row_by_schema(schema, 0, "null", profile=None),
+            gen_row_by_schema(schema, 1, "empty", profile=[]),
+            gen_row_by_schema(
+                schema,
+                2,
+                "red",
+                profile=[{INT_SUBFIELD: 5, TAG_SUBFIELD: "red"}],
+            ),
+            gen_row_by_schema(
+                schema,
+                3,
+                "mixed",
+                profile=[
+                    {INT_SUBFIELD: 10, TAG_SUBFIELD: "blue"},
+                    {INT_SUBFIELD: 20, TAG_SUBFIELD: "red"},
+                ],
+            ),
+        ]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        failures = []
+        inline_query = client.query(
+            collection_name,
+            filter=inline,
+            output_fields=[PK_FIELD],
+            limit=len(rows) * STRUCT_MAX_CAPACITY,
+        )
+        try:
+            template_query = client.query(
+                collection_name,
+                filter=template,
+                filter_params=params,
+                output_fields=[PK_FIELD],
+                limit=len(rows) * STRUCT_MAX_CAPACITY,
+            )
+            key = (lambda row: (row[PK_FIELD], row["offset"])) if include_offset else (lambda row: row[PK_FIELD])
+            assert sorted(map(key, template_query)) == sorted(map(key, inline_query))
+        except Exception as exc:
+            failures.append(f"query failed: {exc}")
+
+        inline_search = client.search(
+            collection_name,
+            data=[rows[-1][VECTOR_FIELD]],
+            anns_field=VECTOR_FIELD,
+            search_params=NORMAL_VECTOR_SEARCH_PARAMS,
+            filter=inline,
+            output_fields=[PK_FIELD],
+            limit=len(rows),
+        )[0]
+        try:
+            template_search = client.search(
+                collection_name,
+                data=[rows[-1][VECTOR_FIELD]],
+                anns_field=VECTOR_FIELD,
+                search_params=NORMAL_VECTOR_SEARCH_PARAMS,
+                filter=template,
+                filter_params=params,
+                output_fields=[PK_FIELD],
+                limit=len(rows),
+            )[0]
+            assert [hit[PK_FIELD] for hit in template_search] == [hit[PK_FIELD] for hit in inline_search]
+        except Exception as exc:
+            failures.append(f"search failed: {exc}")
+
+        if check_hybrid:
+            template_request = AnnSearchRequest(
+                data=[rows[-1][VECTOR_FIELD]],
+                anns_field=VECTOR_FIELD,
+                param=NORMAL_VECTOR_SEARCH_PARAMS,
+                limit=len(rows),
+                expr=template,
+                expr_params=params,
+            )
+            inline_request = AnnSearchRequest(
+                data=[rows[-1][VECTOR_FIELD]],
+                anns_field=VECTOR_FIELD,
+                param=NORMAL_VECTOR_SEARCH_PARAMS,
+                limit=len(rows),
+                expr=inline,
+            )
+            inline_hybrid = client.hybrid_search(
+                collection_name,
+                [inline_request],
+                ranker=WeightedRanker(1.0),
+                limit=len(rows),
+                output_fields=[PK_FIELD],
+            )[0]
+            try:
+                template_hybrid = client.hybrid_search(
+                    collection_name,
+                    [template_request],
+                    ranker=WeightedRanker(1.0),
+                    limit=len(rows),
+                    output_fields=[PK_FIELD],
+                )[0]
+                assert [hit[PK_FIELD] for hit in template_hybrid] == [hit[PK_FIELD] for hit in inline_hybrid]
+            except Exception as exc:
+                failures.append(f"hybrid search failed: {exc}")
+
+            with pytest.raises(Exception):
+                client.query(
+                    collection_name,
+                    filter=f"MATCH_ANY({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= {{min_score}})",
+                    filter_params={"min_score": "not-an-integer"},
+                    output_fields=[PK_FIELD],
+                )
+
+        assert not failures, "\n".join(failures)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_struct_array_dynamic_field_name_isolation(self):
+        """
+        target: verify dynamic JSON keys remain isolated from same-name Struct child fields
+        method: insert top-level dynamic keys named like a Struct child, query both namespaces, build a nested index,
+            and submit a Struct element containing an unknown child key
+        expected: dynamic projection/filter and Struct projection/filter do not overwrite each other; unknown child fails
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_dynamic_isolation")
+        schema = gen_struct_array_schema(
+            self,
+            client,
+            include_vector_subfield=False,
+            enable_dynamic_field=True,
+        )
+        index_params = gen_index_params(self, client)
+        index_params.add_index(VECTOR_FIELD, index_type="FLAT", metric_type="L2")
+        index_params.add_index(STRUCT_TAG_FIELD, index_type="BITMAP")
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level="Strong",
+        )
+        rows = [
+            {
+                PK_FIELD: 0,
+                VECTOR_FIELD: gen_vector(0),
+                TAG_FIELD: "row_0",
+                TAG_SUBFIELD: "dynamic_top",
+                "shadow": "dynamic_shadow",
+                STRUCT_FIELD: [{INT_SUBFIELD: 10, TAG_SUBFIELD: "struct_value"}],
+            },
+            {
+                PK_FIELD: 1,
+                VECTOR_FIELD: gen_vector(1),
+                TAG_FIELD: "row_1",
+                TAG_SUBFIELD: "dynamic_other",
+                "shadow": "other_shadow",
+                STRUCT_FIELD: [],
+            },
+        ]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        projected = self.query(
+            client,
+            collection_name,
+            filter=f'{TAG_SUBFIELD} == "dynamic_top"',
+            output_fields=[PK_FIELD, TAG_SUBFIELD, "shadow", STRUCT_FIELD],
+        )[0]
+        assert len(projected) == 1
+        assert projected[0][PK_FIELD] == 0
+        assert projected[0][TAG_SUBFIELD] == "dynamic_top"
+        assert projected[0]["shadow"] == "dynamic_shadow"
+        assert projected[0][STRUCT_FIELD][0][TAG_SUBFIELD] == "struct_value"
+
+        struct_rows = self.query(
+            client,
+            collection_name,
+            filter=f'array_contains({STRUCT_TAG_FIELD}, "struct_value")',
+            output_fields=[PK_FIELD, STRUCT_FIELD],
+        )[0]
+        assert [row[PK_FIELD] for row in struct_rows] == [0]
+        assert struct_rows[0][STRUCT_FIELD][0][TAG_SUBFIELD] == "struct_value"
+
+        with pytest.raises(Exception) as exc_info:
+            client.insert(
+                collection_name,
+                [
+                    {
+                        PK_FIELD: 2,
+                        VECTOR_FIELD: gen_vector(2),
+                        TAG_FIELD: "row_2",
+                        STRUCT_FIELD: [
+                            {
+                                INT_SUBFIELD: 20,
+                                TAG_SUBFIELD: "known",
+                                "unknown_child": "must_not_become_dynamic",
+                            }
+                        ],
+                    }
+                ],
+            )
+        assert "unexpected fields" in str(exc_info.value)
+        count = self.query(client, collection_name, filter="", output_fields=["count(*)"])[0]
+        assert count[0]["count(*)"] == len(rows)
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_add_struct_array_field_schema_nullable_propagation(self):

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1000,6 +1000,183 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
 
     min_index_sealed_rows = 3000
 
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_struct_array_compaction_preserves_null_empty_offsets_and_indexes(self):
+        """
+        target: verify Struct Array data and element identities survive segment compaction
+        method: create multiple sealed segments containing null, empty, and variable-length Struct Arrays,
+            apply delete and upsert deltas, then compare projection, predicates, element search, and
+            embedding-list search before compaction, after compaction, and after release/load
+        expected: every phase returns identical Struct values, PK sets, and element offsets
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_compact_offsets")
+        element_vector_subfield = "p_vec_element"
+        struct_element_vector_field = f"{STRUCT_FIELD}[{element_vector_subfield}]"
+        schema = gen_schema(self, client, auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name=PK_FIELD, datatype=PK_TYPE, is_primary=True)
+        schema.add_field(field_name=VECTOR_FIELD, datatype=VECTOR_TYPE, dim=VECTOR_DIM)
+        schema.add_field(field_name=TAG_FIELD, datatype=TAG_TYPE, max_length=TAG_MAX_LENGTH)
+        profile_schema = gen_struct_schema(self, client)
+        profile_schema.add_field(INT_SUBFIELD, INT_SUBFIELD_TYPE)
+        profile_schema.add_field(TAG_SUBFIELD, TAG_SUBFIELD_TYPE, max_length=TAG_MAX_LENGTH)
+        profile_schema.add_field(VECTOR_SUBFIELD, VECTOR_SUBFIELD_TYPE, dim=VECTOR_SUBFIELD_DIM)
+        profile_schema.add_field(element_vector_subfield, VECTOR_SUBFIELD_TYPE, dim=VECTOR_SUBFIELD_DIM)
+        schema.add_field(
+            STRUCT_FIELD,
+            datatype=STRUCT_TYPE,
+            element_type=STRUCT_ELEMENT_TYPE,
+            struct_schema=profile_schema,
+            max_capacity=STRUCT_MAX_CAPACITY,
+            nullable=True,
+        )
+
+        index_params = gen_index_params(self, client)
+        index_params.add_index(
+            field_name=VECTOR_FIELD,
+            index_type="FLAT",
+            metric_type=NORMAL_VECTOR_METRIC_TYPE,
+        )
+        index_params.add_index(
+            field_name=STRUCT_VECTOR_FIELD,
+            index_type=STRUCT_VECTOR_HNSW_INDEX_TYPE,
+            metric_type=STRUCT_VECTOR_HNSW_METRIC_TYPE,
+            params=HNSW_INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name=struct_element_vector_field,
+            index_type="FLAT",
+            metric_type="COSINE",
+        )
+        index_params.add_index(field_name=STRUCT_INT_FIELD, index_type="STL_SORT")
+        index_params.add_index(field_name=STRUCT_TAG_FIELD, index_type="BITMAP")
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level="Strong",
+        )
+
+        def profile(row_id, length, tag_prefix="keep"):
+            result = []
+            for offset in range(length):
+                vector = gen_unit_vector(row_id + offset)
+                result.append(
+                    {
+                        INT_SUBFIELD: row_id * 10 + offset,
+                        TAG_SUBFIELD: f"{tag_prefix}_{row_id}_{offset}",
+                        VECTOR_SUBFIELD: vector,
+                        element_vector_subfield: vector,
+                    }
+                )
+            return result
+
+        source_by_id = {
+            0: gen_row_by_schema(schema, 0, "null", profile=None),
+            1: gen_row_by_schema(schema, 1, "empty", profile=[]),
+            2: gen_row_by_schema(schema, 2, "two", profile=profile(2, 2)),
+            3: gen_row_by_schema(schema, 3, "one", profile=profile(3, 1)),
+            4: gen_row_by_schema(schema, 4, "initial", profile=profile(4, 2, "old")),
+            5: gen_row_by_schema(schema, 5, "deleted", profile=profile(5, 3)),
+            10: gen_row_by_schema(schema, 10, "three", profile=profile(10, 3)),
+            11: gen_row_by_schema(schema, 11, "null_second", profile=None),
+            12: gen_row_by_schema(schema, 12, "empty_second", profile=[]),
+            20: gen_row_by_schema(schema, 20, "one_third", profile=profile(20, 1)),
+            21: gen_row_by_schema(schema, 21, "four_third", profile=profile(21, 4)),
+        }
+        for batch_ids in ([0, 1, 2, 3, 4, 5], [10, 11, 12], [20, 21]):
+            result, _ = self.insert(client, collection_name, [source_by_id[row_id] for row_id in batch_ids])
+            assert result["insert_count"] == len(batch_ids)
+            self.flush(client, collection_name)
+
+        self.delete(client, collection_name, ids=[5])
+        del source_by_id[5]
+        replacement = gen_row_by_schema(schema, 4, "replaced", profile=profile(4, 3))
+        self.upsert(client, collection_name, [replacement])
+        source_by_id[4] = replacement
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        def collect_observations():
+            rows, _ = self.query(
+                client,
+                collection_name,
+                filter=ALL_ROWS_FILTER,
+                output_fields=[PK_FIELD, TAG_FIELD, STRUCT_FIELD],
+                limit=len(source_by_id),
+            )
+            rows_by_id = {row[PK_FIELD]: row for row in rows}
+            assert set(rows_by_id) == set(source_by_id)
+            for row_id, expected in source_by_id.items():
+                assert rows_by_id[row_id][TAG_FIELD] == expected[TAG_FIELD]
+                assert_profile_equal(rows_by_id[row_id][STRUCT_FIELD], expected[STRUCT_FIELD])
+
+            match_rows, _ = self.query(
+                client,
+                collection_name,
+                filter=f"MATCH_ANY({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 0)",
+                output_fields=[PK_FIELD],
+                limit=len(source_by_id),
+            )
+            contains_rows, _ = self.query(
+                client,
+                collection_name,
+                filter=f'array_contains({STRUCT_TAG_FIELD}, "keep_4_1")',
+                output_fields=[PK_FIELD],
+                limit=len(source_by_id),
+            )
+            element_results, _ = self.search(
+                client,
+                collection_name,
+                data=[gen_unit_vector(0)],
+                anns_field=struct_element_vector_field,
+                search_params={"metric_type": "COSINE"},
+                filter=f"element_filter({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 0)",
+                output_fields=[PK_FIELD],
+                limit=sum(len(row[STRUCT_FIELD] or []) for row in source_by_id.values()),
+            )
+            query_tensor = EmbeddingList()
+            query_tensor.add(gen_unit_vector(0))
+            embedding_results, _ = self.search(
+                client,
+                collection_name,
+                data=[query_tensor],
+                anns_field=STRUCT_VECTOR_FIELD,
+                search_params={"metric_type": STRUCT_VECTOR_HNSW_METRIC_TYPE, "params": {"ef": 128}},
+                output_fields=[PK_FIELD],
+                limit=sum(1 for row in source_by_id.values() if row[STRUCT_FIELD]),
+            )
+            embedding_ids = sorted(hit[PK_FIELD] for hit in embedding_results[0])
+            assert set(embedding_ids).issubset({row_id for row_id, row in source_by_id.items() if row[STRUCT_FIELD]}), (
+                f"embedding-list search returned a null or empty Struct row: {embedding_ids}"
+            )
+            return {
+                "projection": sorted(
+                    (row_id, rows_by_id[row_id][TAG_FIELD], rows_by_id[row_id][STRUCT_FIELD]) for row_id in rows_by_id
+                ),
+                "match_ids": sorted(row[PK_FIELD] for row in match_rows),
+                "contains_ids": sorted(row[PK_FIELD] for row in contains_rows),
+                "element_keys": sorted((hit[PK_FIELD], hit["offset"]) for hit in element_results[0]),
+                "embedding_ids": embedding_ids,
+            }
+
+        baseline = collect_observations()
+        assert baseline["match_ids"] == sorted(row_id for row_id, row in source_by_id.items() if row[STRUCT_FIELD])
+        assert baseline["contains_ids"] == [4]
+        assert baseline["element_keys"] == sorted(
+            (row_id, offset) for row_id, row in source_by_id.items() for offset in range(len(row[STRUCT_FIELD] or []))
+        )
+
+        compact_id, _ = self.compact(client, collection_name)
+        assert compact_id > 0
+        assert self.wait_for_compaction_ready(client, compact_id, timeout=300)
+        assert collect_observations() == baseline
+
+        self.release_collection(client, collection_name)
+        self.load_collection(client, collection_name)
+        assert collect_observations() == baseline
+
     @pytest.mark.tags(CaseLabel.L0)
     def test_add_struct_array_field_schema_nullable_propagation(self):
         """

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1039,7 +1039,6 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
     min_index_sealed_rows = 3000
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51414", strict=True)
     def test_struct_array_compaction_preserves_null_empty_offsets_and_indexes(self):
         """
         target: verify Struct Array data and element identities survive segment compaction
@@ -1268,7 +1267,6 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
                 f"MATCH_LEAST({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 10, threshold=1)",
                 False,
                 True,
-                marks=pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51416", strict=True),
                 id="match_int",
             ),
             pytest.param(
@@ -2407,7 +2405,6 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             assert_expression_rows_match_source(actual_rows, source_by_id)
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51381", strict=True)
     def test_create_scalar_struct_array_field_nullable_match_family_null_semantics(self):
         """
         target: test MATCH family null/empty semantics for a nullable scalar Struct Array
@@ -2525,7 +2522,6 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
                 assert_scalar_profile_equal(entity[STRUCT_FIELD], expected[STRUCT_FIELD])
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51381", strict=True)
     def test_nullable_struct_array_index_preserves_null_validity(self):
         """
         target: test nullable struct-array predicates before and after indexing every scalar struct subfield
@@ -7188,7 +7184,6 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51381", strict=True)
     def test_add_scalar_struct_array_field_match_null_vs_empty_after_reload(self):
         """
         target: test MATCH three-valued semantics for schema-evolution backfill rows
@@ -12304,7 +12299,6 @@ class TestMilvusClientStructArrayNullableImport(TestMilvusClientV2Base):
         [
             pytest.param(
                 "embedding_list",
-                marks=pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51414", strict=True),
                 id="embedding_list",
             ),
             pytest.param("element", id="element"),

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1072,8 +1072,9 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         index_params = gen_index_params(self, client)
         index_params.add_index(
             field_name=VECTOR_FIELD,
-            index_type="FLAT",
+            index_type="HNSW",
             metric_type=NORMAL_VECTOR_METRIC_TYPE,
+            params=HNSW_INDEX_PARAMS,
         )
         index_params.add_index(
             field_name=STRUCT_VECTOR_FIELD,
@@ -1083,8 +1084,9 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         )
         index_params.add_index(
             field_name=struct_element_vector_field,
-            index_type="FLAT",
+            index_type="HNSW",
             metric_type="COSINE",
+            params=HNSW_INDEX_PARAMS,
         )
         index_params.add_index(field_name=STRUCT_INT_FIELD, index_type="STL_SORT")
         index_params.add_index(field_name=STRUCT_TAG_FIELD, index_type="BITMAP")
@@ -1099,7 +1101,9 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         def profile(row_id, length, tag_prefix="keep"):
             result = []
             for offset in range(length):
-                vector = gen_unit_vector(row_id + offset)
+                rng = np.random.RandomState(row_id * STRUCT_MAX_CAPACITY + offset)
+                vector = rng.uniform(-1.0, 1.0, VECTOR_SUBFIELD_DIM).astype(np.float32)
+                vector = (vector / np.linalg.norm(vector)).tolist()
                 result.append(
                     {
                         INT_SUBFIELD: row_id * 10 + offset,
@@ -1136,6 +1140,45 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         self.flush(client, collection_name)
         self.load_collection(client, collection_name)
 
+        non_empty_rows = [row for row in source_by_id.values() if row[STRUCT_FIELD]]
+        valid_element_keys = {
+            (row[PK_FIELD], offset) for row in non_empty_rows for offset in range(len(row[STRUCT_FIELD]))
+        }
+        element_query = np.asarray(non_empty_rows[0][STRUCT_FIELD][0][element_vector_subfield])
+        element_limit = min(10, len(valid_element_keys))
+        exact_element_keys = [
+            (row_id, offset)
+            for row_id, offset, _ in sorted(
+                (
+                    (
+                        row[PK_FIELD],
+                        offset,
+                        float(np.dot(element_query, np.asarray(element[element_vector_subfield]))),
+                    )
+                    for row in non_empty_rows
+                    for offset, element in enumerate(row[STRUCT_FIELD])
+                ),
+                key=lambda item: item[2],
+                reverse=True,
+            )[:element_limit]
+        ]
+        embedding_query_vectors = [np.asarray(element[VECTOR_SUBFIELD]) for element in non_empty_rows[0][STRUCT_FIELD]]
+        embedding_limit = min(5, len(non_empty_rows))
+        exact_embedding_ids = [
+            row[PK_FIELD]
+            for row in sorted(
+                non_empty_rows,
+                key=lambda row: sum(
+                    max(
+                        float(np.dot(query_vector, np.asarray(element[VECTOR_SUBFIELD])))
+                        for element in row[STRUCT_FIELD]
+                    )
+                    for query_vector in embedding_query_vectors
+                ),
+                reverse=True,
+            )[:embedding_limit]
+        ]
+
         def collect_observations():
             rows, _ = self.query(
                 client,
@@ -1167,15 +1210,16 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             element_results, _ = self.search(
                 client,
                 collection_name,
-                data=[gen_unit_vector(0)],
+                data=[element_query.tolist()],
                 anns_field=struct_element_vector_field,
-                search_params={"metric_type": "COSINE"},
+                search_params={"metric_type": "COSINE", "params": {"ef": 128}},
                 filter=f"element_filter({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 0)",
                 output_fields=[PK_FIELD],
-                limit=sum(len(row[STRUCT_FIELD] or []) for row in source_by_id.values()),
+                limit=element_limit,
             )
             query_tensor = EmbeddingList()
-            query_tensor.add(gen_unit_vector(0))
+            for query_vector in embedding_query_vectors:
+                query_tensor.add(query_vector.tolist())
             embedding_results, _ = self.search(
                 client,
                 collection_name,
@@ -1183,29 +1227,27 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
                 anns_field=STRUCT_VECTOR_FIELD,
                 search_params={"metric_type": STRUCT_VECTOR_HNSW_METRIC_TYPE, "params": {"ef": 128}},
                 output_fields=[PK_FIELD],
-                limit=sum(1 for row in source_by_id.values() if row[STRUCT_FIELD]),
+                limit=embedding_limit,
             )
-            embedding_ids = sorted(hit[PK_FIELD] for hit in embedding_results[0])
-            assert set(embedding_ids).issubset({row_id for row_id, row in source_by_id.items() if row[STRUCT_FIELD]}), (
+            element_keys = [(hit[PK_FIELD], hit["offset"]) for hit in element_results[0]]
+            assert set(element_keys).issubset(valid_element_keys)
+            assert_ann_recall(element_keys, exact_element_keys)
+            embedding_ids = [hit[PK_FIELD] for hit in embedding_results[0]]
+            assert set(embedding_ids).issubset({row[PK_FIELD] for row in non_empty_rows}), (
                 f"embedding-list search returned a null or empty Struct row: {embedding_ids}"
             )
+            assert_ann_recall(embedding_ids, exact_embedding_ids)
             return {
                 "projection": sorted(
                     (row_id, rows_by_id[row_id][TAG_FIELD], rows_by_id[row_id][STRUCT_FIELD]) for row_id in rows_by_id
                 ),
                 "match_ids": sorted(row[PK_FIELD] for row in match_rows),
                 "contains_ids": sorted(row[PK_FIELD] for row in contains_rows),
-                "element_keys": sorted((hit[PK_FIELD], hit["offset"]) for hit in element_results[0]),
-                "embedding_ids": embedding_ids,
             }
 
         baseline = collect_observations()
         assert baseline["match_ids"] == sorted(row_id for row_id, row in source_by_id.items() if row[STRUCT_FIELD])
         assert baseline["contains_ids"] == [4]
-        assert baseline["element_keys"] == sorted(
-            (row_id, offset) for row_id, row in source_by_id.items() for offset in range(len(row[STRUCT_FIELD] or []))
-        )
-
         compact_id, _ = self.compact(client, collection_name)
         assert compact_id > 0
         assert self.wait_for_compaction_ready(client, compact_id, timeout=300)
@@ -1263,7 +1305,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         collection_name = cf.gen_unique_str(f"{prefix}_filter_template")
         schema = gen_struct_array_schema(self, client, include_vector_subfield=False)
         index_params = gen_index_params(self, client)
-        index_params.add_index(VECTOR_FIELD, index_type="FLAT", metric_type="L2")
+        index_params.add_index(VECTOR_FIELD, index_type="HNSW", metric_type="L2", params=INDEX_PARAMS)
         index_params.add_index(STRUCT_INT_FIELD, index_type="STL_SORT")
         index_params.add_index(STRUCT_TAG_FIELD, index_type="BITMAP")
         self.create_collection(
@@ -1402,7 +1444,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             enable_dynamic_field=True,
         )
         index_params = gen_index_params(self, client)
-        index_params.add_index(VECTOR_FIELD, index_type="FLAT", metric_type="L2")
+        index_params.add_index(VECTOR_FIELD, index_type="HNSW", metric_type="L2", params=INDEX_PARAMS)
         index_params.add_index(STRUCT_TAG_FIELD, index_type="BITMAP")
         self.create_collection(
             client,
@@ -12285,7 +12327,10 @@ class TestMilvusClientStructArrayNullableImport(TestMilvusClientV2Base):
 
         index_params = gen_index_params(self, client)
         index_params.add_index(
-            field_name=VECTOR_FIELD, index_type=NORMAL_VECTOR_INDEX_TYPE, metric_type=NORMAL_VECTOR_METRIC_TYPE
+            field_name=VECTOR_FIELD,
+            index_type="HNSW",
+            metric_type=NORMAL_VECTOR_METRIC_TYPE,
+            params=INDEX_PARAMS,
         )
         if search_mode == "embedding_list":
             index_params.add_index(

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -2000,6 +2000,92 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
                 assert_scalar_profile_equal(entity[STRUCT_FIELD], expected[STRUCT_FIELD])
 
     @pytest.mark.tags(CaseLabel.L0)
+    def test_nullable_struct_array_index_preserves_null_validity(self):
+        """
+        target: test nullable struct-array predicates before and after indexing every scalar struct subfield
+        method: query NOT array_contains, empty array_contains_all, and MATCH_ANY on controlled null, empty,
+            and non-empty rows; then release, create nested BITMAP indexes, reload, and repeat query/search
+        expected: NULL and omitted rows stay excluded under NOT and empty contains-all, raw/indexed results match,
+            and MATCH remains executable after the index-only reload path
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_nullable_struct_bitmap_validity")
+        client = self._client()
+        fixture = gen_expression_fixture(self, client, collection_name)
+        source_by_id = fixture["source_by_id"]
+        controlled_ids = sorted(fixture["controlled_ids"])
+        scoped_prefix = f"{PK_FIELD} in {controlled_ids} && "
+
+        real_array_ids = {row_id for row_id in controlled_ids if source_by_id[row_id][STRUCT_FIELD] is not None}
+        not_contains_ids = {
+            row_id
+            for row_id in real_array_ids
+            if all(element[TAG_SUBFIELD] != "match_9100" for element in source_by_id[row_id][STRUCT_FIELD])
+        }
+        match_any_ids = {
+            row_id
+            for row_id in real_array_ids
+            if any(element[TAG_SUBFIELD] == "match_9100" for element in source_by_id[row_id][STRUCT_FIELD])
+        }
+
+        expressions = {
+            "not_contains": f'not array_contains({STRUCT_TAG_FIELD}, "match_9100")',
+            "empty_contains_all": f"array_contains_all({STRUCT_TAG_FIELD}, [])",
+            "match_any": f'MATCH_ANY({STRUCT_FIELD}, $[{TAG_SUBFIELD}] == "match_9100")',
+        }
+
+        def collect_evidence():
+            evidence = {}
+            for name, expression in expressions.items():
+                rows, _ = self.query(
+                    client,
+                    collection_name,
+                    filter=scoped_prefix + expression,
+                    output_fields=[PK_FIELD],
+                    limit=len(controlled_ids),
+                )
+                evidence[f"query_{name}"] = {row[PK_FIELD] for row in rows}
+
+            search_results, _ = self.search(
+                client,
+                collection_name,
+                data=[gen_vector(7004)],
+                anns_field=VECTOR_FIELD,
+                search_params=NORMAL_VECTOR_SEARCH_PARAMS,
+                filter=scoped_prefix + expressions["empty_contains_all"],
+                output_fields=[PK_FIELD],
+                limit=len(controlled_ids),
+            )
+            evidence["search_empty_contains_all"] = {hit[PK_FIELD] for hit in search_results[0]}
+            return evidence
+
+        raw_evidence = collect_evidence()
+
+        res, _ = self.flush(client, collection_name)
+        res, _ = self.release_collection(client, collection_name)
+        nested_index_params = gen_index_params(self, client)
+        nested_index_params.add_index(field_name=STRUCT_INT_FIELD, index_type="BITMAP")
+        nested_index_params.add_index(field_name=STRUCT_TAG_FIELD, index_type="BITMAP")
+        res, _ = self.create_index(client, collection_name, nested_index_params)
+        assert self.wait_for_index_ready(client, collection_name, STRUCT_INT_FIELD, timeout=300)
+        assert self.wait_for_index_ready(client, collection_name, STRUCT_TAG_FIELD, timeout=300)
+        res, _ = self.load_collection(client, collection_name)
+
+        indexed_evidence = collect_evidence()
+        expected_evidence = {
+            "query_not_contains": not_contains_ids,
+            "query_empty_contains_all": real_array_ids,
+            "query_match_any": match_any_ids,
+            "search_empty_contains_all": real_array_ids,
+        }
+        assert {
+            "raw": raw_evidence,
+            "indexed": indexed_evidence,
+        } == {
+            "raw": expected_evidence,
+            "indexed": expected_evidence,
+        }
+
+    @pytest.mark.tags(CaseLabel.L0)
     def test_create_scalar_struct_array_field_nullable_parent_null_expression(self):
         """
         target: test direct null expressions on a nullable scalar Struct Array parent
@@ -4448,11 +4534,11 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
     @pytest.mark.tags(CaseLabel.L1)
     def test_add_scalar_struct_array_field_concurrent_dml_query_search(self):
         """
-        target: test insert/delete/upsert traffic while dynamically adding a nullable scalar struct array field
-        method: load a collection with indexed sealed rows and growing rows, run AddCollectionStructField concurrently
-            with old-schema insert, delete, and upsert requests, then insert post-add struct rows
-        expected: concurrent DML requests succeed without partial schema visibility, deleted rows are absent, and old
-            schema rows expose the added struct field as null while post-add rows preserve their struct values
+        target: test read/write traffic while dynamically adding a nullable scalar struct array field
+        method: load indexed sealed and growing rows, run AddCollectionStructField concurrently with query/search,
+            insert, delete, and upsert requests, then query MATCH on the newly added field and insert post-add rows
+        expected: concurrent reads and DML complete without crash or partial map state, MATCH excludes backfilled NULL
+            rows, deleted rows are absent, and old/new rows expose the expected struct values
         """
         collection_name = cf.gen_unique_str(f"{prefix}_add_scalar_struct_concurrent_dml")
         client = self._client()
@@ -4528,7 +4614,9 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         ]
         delete_ids = [old_sealed_rows[1][PK_FIELD], old_growing_rows[1][PK_FIELD]]
 
-        start_barrier = threading.Barrier(4)
+        start_barrier = threading.Barrier(5)
+        reader_ready = threading.Event()
+        schema_added = threading.Event()
 
         def run_dml_with_schema_retry(action, count_key):
             last_error = None
@@ -4548,6 +4636,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             profile_schema.add_field(INT_SUBFIELD, INT_SUBFIELD_TYPE)
             profile_schema.add_field(TAG_SUBFIELD, TAG_SUBFIELD_TYPE, max_length=TAG_MAX_LENGTH)
             start_barrier.wait()
+            assert reader_ready.wait(timeout=30)
             result, task_check = self.add_collection_struct_field(
                 task_client,
                 collection_name,
@@ -4556,7 +4645,83 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
                 max_capacity=STRUCT_MAX_CAPACITY,
             )
             assert task_check
+            schema_added.set()
             return "add", result
+
+        def query_search_task():
+            task_client = self._client()
+            start_barrier.wait()
+
+            rows, task_check = self.query(
+                task_client,
+                collection_name,
+                filter=ALL_ROWS_FILTER,
+                output_fields=[PK_FIELD],
+                limit=8,
+            )
+            assert task_check
+            assert rows
+            reader_ready.set()
+
+            for _ in range(20):
+                rows, task_check = self.query(
+                    task_client,
+                    collection_name,
+                    filter=ALL_ROWS_FILTER,
+                    output_fields=[PK_FIELD],
+                    limit=8,
+                )
+                assert task_check
+                assert rows
+                search_results, task_check = self.search(
+                    task_client,
+                    collection_name,
+                    data=[gen_vector(0)],
+                    anns_field=VECTOR_FIELD,
+                    search_params=NORMAL_VECTOR_SEARCH_PARAMS,
+                    filter=ALL_ROWS_FILTER,
+                    output_fields=[PK_FIELD],
+                    limit=1,
+                )
+                assert task_check
+                assert search_results[0]
+
+            assert schema_added.wait(timeout=30)
+            match_expression = f"MATCH_ANY({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 0)"
+            last_error = None
+            for _ in range(30):
+                rows, query_check = self.query(
+                    task_client,
+                    collection_name,
+                    filter=match_expression,
+                    output_fields=[PK_FIELD],
+                    limit=8,
+                    check_task=CheckTasks.check_nothing,
+                )
+                if not query_check:
+                    last_error = rows
+                    time.sleep(0.2)
+                    continue
+                assert rows == []
+
+                search_results, search_check = self.search(
+                    task_client,
+                    collection_name,
+                    data=[gen_vector(0)],
+                    anns_field=VECTOR_FIELD,
+                    search_params=NORMAL_VECTOR_SEARCH_PARAMS,
+                    filter=match_expression,
+                    output_fields=[PK_FIELD],
+                    limit=1,
+                    check_task=CheckTasks.check_nothing,
+                )
+                if not search_check:
+                    last_error = search_results
+                    time.sleep(0.2)
+                    continue
+                assert search_results == [[]]
+                return "read", 1
+            raise AssertionError(f"MATCH query/search did not recover after schema propagation: {last_error}")
 
         def insert_task():
             task_client = self._client()
@@ -4599,9 +4764,10 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             return "delete", result["delete_count"]
 
         task_results = {}
-        with ThreadPoolExecutor(max_workers=4) as executor:
+        with ThreadPoolExecutor(max_workers=5) as executor:
             futures = [
                 executor.submit(add_struct_field_task),
+                executor.submit(query_search_task),
                 executor.submit(insert_task),
                 executor.submit(upsert_task),
                 executor.submit(delete_task),
@@ -4613,6 +4779,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         assert task_results["insert"] == len(concurrent_insert_rows)
         assert task_results["upsert"] == len(concurrent_upsert_rows)
         assert task_results["delete"] == len(delete_ids)
+        assert task_results["read"] == 1
 
         post_add_rows = [
             {
@@ -6493,6 +6660,128 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             check_task=CheckTasks.err_res,
             check_items=error,
         )
+
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_add_scalar_struct_array_field_match_null_vs_empty_after_reload(self):
+        """
+        target: test MATCH three-valued semantics for schema-evolution backfill rows
+        method: add a nullable struct array field after sealed and growing rows exist, insert explicit null,
+            omitted, empty, matching, and non-matching rows, then query before and after release/load
+        expected: backfilled/null/omitted rows are UNKNOWN and excluded, while real empty arrays retain
+            vacuous MATCH_ALL, MATCH_EXACT(0), and NOT MATCH_ANY behavior across reload
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_add_struct_match_null_empty")
+        client = self._client()
+
+        schema = gen_schema(self, client, auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name=PK_FIELD, datatype=PK_TYPE, is_primary=True)
+        schema.add_field(field_name=VECTOR_FIELD, datatype=VECTOR_TYPE, dim=VECTOR_DIM)
+        schema.add_field(field_name=TAG_FIELD, datatype=TAG_TYPE, max_length=TAG_MAX_LENGTH)
+        res, _ = self.create_collection(client, collection_name, schema=schema)
+
+        old_sealed_row = {
+            PK_FIELD: 0,
+            VECTOR_FIELD: gen_vector(0),
+            TAG_FIELD: "old_sealed_backfill_null",
+        }
+        res, _ = self.insert(client, collection_name, [old_sealed_row])
+        assert res["insert_count"] == 1
+        res, _ = self.flush(client, collection_name)
+
+        index_params = gen_index_params(self, client)
+        index_params.add_index(
+            field_name=VECTOR_FIELD,
+            index_type=NORMAL_VECTOR_INDEX_TYPE,
+            metric_type=NORMAL_VECTOR_METRIC_TYPE,
+        )
+        res, _ = self.create_index(client, collection_name, index_params)
+        res, _ = self.load_collection(client, collection_name)
+
+        old_growing_row = {
+            PK_FIELD: 1,
+            VECTOR_FIELD: gen_vector(1),
+            TAG_FIELD: "old_growing_backfill_null",
+        }
+        res, _ = self.insert(client, collection_name, [old_growing_row])
+        assert res["insert_count"] == 1
+
+        profile_schema = gen_struct_schema(self, client)
+        profile_schema.add_field(INT_SUBFIELD, INT_SUBFIELD_TYPE)
+        profile_schema.add_field(TAG_SUBFIELD, TAG_SUBFIELD_TYPE, max_length=TAG_MAX_LENGTH)
+        res, _ = self.add_collection_struct_field(
+            client,
+            collection_name,
+            STRUCT_FIELD,
+            profile_schema,
+            max_capacity=STRUCT_MAX_CAPACITY,
+        )
+
+        post_add_rows = [
+            {
+                PK_FIELD: 2,
+                VECTOR_FIELD: gen_vector(2),
+                TAG_FIELD: "explicit_null",
+                STRUCT_FIELD: None,
+            },
+            {PK_FIELD: 3, VECTOR_FIELD: gen_vector(3), TAG_FIELD: "omitted"},
+            {
+                PK_FIELD: 4,
+                VECTOR_FIELD: gen_vector(4),
+                TAG_FIELD: "empty",
+                STRUCT_FIELD: [],
+            },
+            {
+                PK_FIELD: 5,
+                VECTOR_FIELD: gen_vector(5),
+                TAG_FIELD: "positive",
+                STRUCT_FIELD: [{INT_SUBFIELD: 10, TAG_SUBFIELD: "positive"}],
+            },
+            {
+                PK_FIELD: 6,
+                VECTOR_FIELD: gen_vector(6),
+                TAG_FIELD: "negative",
+                STRUCT_FIELD: [{INT_SUBFIELD: -1, TAG_SUBFIELD: "negative"}],
+            },
+        ]
+        res, _ = self.insert(client, collection_name, post_add_rows)
+        assert res["insert_count"] == len(post_add_rows)
+
+        controlled_ids = list(range(7))
+        scoped_prefix = f"{PK_FIELD} in {controlled_ids} && "
+        expected_ids_by_expression = {
+            f"MATCH_ALL({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 0)": {4, 5},
+            f"MATCH_EXACT({STRUCT_FIELD}, $[{INT_SUBFIELD}] > 1000, threshold=0)": {4, 5, 6},
+            f"not MATCH_ANY({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 0)": {4, 6},
+        }
+
+        def query_ids_by_expression():
+            actual = {}
+            for expression in expected_ids_by_expression:
+                rows, _ = self.query(
+                    client,
+                    collection_name,
+                    filter=scoped_prefix + expression,
+                    output_fields=[PK_FIELD],
+                    limit=len(controlled_ids),
+                )
+                actual[expression] = {row[PK_FIELD] for row in rows}
+            return actual
+
+        live_evidence = query_ids_by_expression()
+
+        res, _ = self.flush(client, collection_name)
+        assert self.wait_for_index_ready(client, collection_name, VECTOR_FIELD, timeout=300)
+        res, _ = self.release_collection(client, collection_name)
+        res, _ = self.load_collection(client, collection_name)
+
+        reloaded_evidence = query_ids_by_expression()
+        assert {
+            "live": live_evidence,
+            "reloaded": reloaded_evidence,
+        } == {
+            "live": expected_ids_by_expression,
+            "reloaded": expected_ids_by_expression,
+        }
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_add_scalar_struct_array_field_match_family_query_search(self):

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -364,6 +364,32 @@ def write_scalar_struct_rows_parquet(
     pq.write_table(table, local_file_path, row_group_size=row_group_size)
 
 
+def write_struct_vector_rows_parquet(
+    rows: list[dict[str, Any]],
+    local_file_path: str,
+    *,
+    row_group_size: int,
+):
+    profile_type = pa.list_(
+        pa.struct(
+            [
+                pa.field(INT_SUBFIELD, pa.int64()),
+                pa.field(TAG_SUBFIELD, pa.string()),
+                pa.field(VECTOR_SUBFIELD, pa.list_(pa.float32())),
+            ]
+        )
+    )
+    table = pa.table(
+        {
+            PK_FIELD: pa.array([row[PK_FIELD] for row in rows], type=pa.int64()),
+            VECTOR_FIELD: pa.array([row[VECTOR_FIELD] for row in rows], type=pa.list_(pa.float32())),
+            TAG_FIELD: pa.array([row[TAG_FIELD] for row in rows], type=pa.string()),
+            STRUCT_FIELD: pa.array([row[STRUCT_FIELD] for row in rows], type=profile_type),
+        }
+    )
+    pq.write_table(table, local_file_path, row_group_size=row_group_size)
+
+
 def gen_index_filler_rows(
     start_id: int,
     count: int,
@@ -695,6 +721,18 @@ def assert_profile_vector_subfield_equal(
         expected,
         expected_keys=(VECTOR_SUBFIELD,),
         exact_keys=True,
+    )
+
+
+def assert_ann_recall(actual_keys, expected_keys, minimum_recall=0.8):
+    """Assert ANN Top-K recall against exact ground truth without requiring a specific hit."""
+    expected_set = set(expected_keys)
+    actual_set = set(actual_keys)
+    assert expected_set
+    recall = len(actual_set.intersection(expected_set)) / len(expected_set)
+    assert recall >= minimum_recall, (
+        f"ANN recall {recall:.2f} is below {minimum_recall:.2f}; "
+        f"missing={sorted(expected_set - actual_set)}, extra={sorted(actual_set - expected_set)}"
     )
 
 
@@ -1574,7 +1612,10 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
 
         index_params = gen_index_params(self, client)
         index_params.add_index(
-            field_name=VECTOR_FIELD, index_type=NORMAL_VECTOR_INDEX_TYPE, metric_type=NORMAL_VECTOR_METRIC_TYPE
+            field_name=VECTOR_FIELD,
+            index_type="HNSW",
+            metric_type=NORMAL_VECTOR_METRIC_TYPE,
+            params=INDEX_PARAMS,
         )
         res, _ = self.create_index(client, collection_name, index_params)
 
@@ -12209,18 +12250,20 @@ class TestMilvusClientStructArrayNullableImport(TestMilvusClientV2Base):
             assert entity[STRUCT_FIELD] is None
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_import_nullable_struct_array_with_vector_json(self):
+    @pytest.mark.parametrize("file_format", SCALAR_IMPORT_FORMATS, ids=SCALAR_IMPORT_FORMATS)
+    @pytest.mark.parametrize("search_mode", ["embedding_list", "element"], ids=["embedding_list", "element"])
+    def test_import_nullable_struct_array_with_vector(self, file_format, search_mode):
         """
-        target: test JSON bulk import for a nullable Struct Array field with scalar and vector sub-fields
+        target: test JSON and Parquet import for a nullable Struct Array field with scalar and vector sub-fields
         method: create a collection with nullable Struct Array, import rows with null, empty, and non-empty profile
-            values, build indexes on normal vector and struct vector sub-field, then query and normal-vector search the
-            imported data
+            values, build an embedding-list or element-level index on the Struct vector child, then query and search
+            the imported data
         expected: imported row count matches source data, indexes are ready, and query/search output preserves nullable
-            struct semantics including vector sub-field values
+            Struct semantics, vector values, and element offsets in both row file formats
         """
         client = self._client()
-        collection_name = cf.gen_unique_str(f"{prefix}_import_nullable_struct_vector_json")
-        entities = 3000
+        collection_name = cf.gen_unique_str(f"{prefix}_import_nullable_struct_vector_{file_format}_{search_mode}")
+        entities = 60
 
         schema = gen_schema(self, client, auto_id=False, enable_dynamic_field=False)
         schema.add_field(field_name=PK_FIELD, datatype=PK_TYPE, is_primary=True)
@@ -12244,12 +12287,20 @@ class TestMilvusClientStructArrayNullableImport(TestMilvusClientV2Base):
         index_params.add_index(
             field_name=VECTOR_FIELD, index_type=NORMAL_VECTOR_INDEX_TYPE, metric_type=NORMAL_VECTOR_METRIC_TYPE
         )
-        index_params.add_index(
-            field_name=STRUCT_VECTOR_FIELD,
-            index_type=STRUCT_VECTOR_INDEX_TYPE,
-            metric_type=STRUCT_VECTOR_METRIC_TYPE,
-            params=INDEX_PARAMS,
-        )
+        if search_mode == "embedding_list":
+            index_params.add_index(
+                field_name=STRUCT_VECTOR_FIELD,
+                index_type=STRUCT_VECTOR_INDEX_TYPE,
+                metric_type=STRUCT_VECTOR_METRIC_TYPE,
+                params=INDEX_PARAMS,
+            )
+        else:
+            index_params.add_index(
+                field_name=STRUCT_VECTOR_FIELD,
+                index_type="HNSW",
+                metric_type="COSINE",
+                params=INDEX_PARAMS,
+            )
         self.create_collection(client, collection_name, schema=schema, index_params=index_params)
 
         rows = []
@@ -12261,6 +12312,10 @@ class TestMilvusClientStructArrayNullableImport(TestMilvusClientV2Base):
                 profile = []
             else:
                 profile = gen_profile(row_id)
+                for offset, element in enumerate(profile):
+                    rng = np.random.RandomState(row_id * STRUCT_MAX_CAPACITY + offset)
+                    vector = rng.uniform(-1.0, 1.0, VECTOR_SUBFIELD_DIM).astype(np.float32)
+                    element[VECTOR_SUBFIELD] = (vector / np.linalg.norm(vector)).tolist()
             row = {
                 PK_FIELD: row_id,
                 VECTOR_FIELD: gen_vector(row_id),
@@ -12270,7 +12325,12 @@ class TestMilvusClientStructArrayNullableImport(TestMilvusClientV2Base):
             rows.append(row)
             source_by_id[row_id] = row
 
-        remote_files = self.upload_import_rows(collection_name, rows, "json", row_group_size=entities)
+        if file_format == "parquet":
+            local_file_path = os.path.join(self.LOCAL_FILES_PATH, f"{collection_name}.parquet")
+            write_struct_vector_rows_parquet(rows, local_file_path, row_group_size=entities)
+            remote_files = self.upload_to_minio(local_file_path)
+        else:
+            remote_files = self.upload_import_rows(collection_name, rows, file_format, row_group_size=entities)
         self.call_bulkinsert(collection_name, remote_files)
 
         assert self.wait_for_index_ready(client, collection_name, VECTOR_FIELD, timeout=300)
@@ -12294,20 +12354,90 @@ class TestMilvusClientStructArrayNullableImport(TestMilvusClientV2Base):
             assert_profile_equal(row[STRUCT_FIELD], expected[STRUCT_FIELD])
 
         search_row = source_by_id[entities - 1]
-        search_results, _ = self.search(
+        ann_limit = 10
+        normal_search_results, _ = self.search(
             client,
             collection_name,
             data=[search_row[VECTOR_FIELD]],
             anns_field=VECTOR_FIELD,
-            search_params=NORMAL_VECTOR_SEARCH_PARAMS,
+            search_params={"metric_type": NORMAL_VECTOR_METRIC_TYPE, "params": {"ef": 128}},
             output_fields=[PK_FIELD, TAG_FIELD, STRUCT_FIELD],
-            limit=entities,
+            limit=ann_limit,
         )
-        hits = search_results[0]
-        assert {hit[PK_FIELD] for hit in hits} == set(source_by_id)
-        assert hits[0][PK_FIELD] == search_row[PK_FIELD]
-        for hit in hits:
+        normal_hits = normal_search_results[0]
+        exact_normal_ids = [
+            row[PK_FIELD]
+            for row in sorted(
+                rows,
+                key=lambda row: np.sum((np.asarray(search_row[VECTOR_FIELD]) - np.asarray(row[VECTOR_FIELD])) ** 2),
+            )[:ann_limit]
+        ]
+        assert_ann_recall([hit[PK_FIELD] for hit in normal_hits], exact_normal_ids)
+        for hit in normal_hits:
             expected = source_by_id[hit[PK_FIELD]]
             entity = search_entity(hit)
             assert entity[TAG_FIELD] == expected[TAG_FIELD]
             assert_profile_equal(entity[STRUCT_FIELD], expected[STRUCT_FIELD])
+
+        non_empty_rows = [row for row in rows if row[STRUCT_FIELD]]
+        target_row = non_empty_rows[-1]
+        if search_mode == "embedding_list":
+            query_tensor = EmbeddingList()
+            for element in target_row[STRUCT_FIELD]:
+                query_tensor.add(element[VECTOR_SUBFIELD])
+            struct_results, _ = self.search(
+                client,
+                collection_name,
+                data=[query_tensor],
+                anns_field=STRUCT_VECTOR_FIELD,
+                search_params={"metric_type": STRUCT_VECTOR_METRIC_TYPE, "params": {"ef": 128}},
+                output_fields=[PK_FIELD],
+                limit=ann_limit,
+            )
+            query_vectors = [np.asarray(element[VECTOR_SUBFIELD]) for element in target_row[STRUCT_FIELD]]
+            exact_embedding_ids = [
+                row[PK_FIELD]
+                for row in sorted(
+                    non_empty_rows,
+                    key=lambda row: sum(
+                        max(
+                            float(np.dot(query_vector, np.asarray(element[VECTOR_SUBFIELD])))
+                            for element in row[STRUCT_FIELD]
+                        )
+                        for query_vector in query_vectors
+                    ),
+                    reverse=True,
+                )[:ann_limit]
+            ]
+            actual_ids = [hit[PK_FIELD] for hit in struct_results[0]]
+            assert set(actual_ids).issubset({row[PK_FIELD] for row in non_empty_rows})
+            assert_ann_recall(actual_ids, exact_embedding_ids)
+        else:
+            query_vector = np.asarray(target_row[STRUCT_FIELD][0][VECTOR_SUBFIELD])
+            struct_results, _ = self.search(
+                client,
+                collection_name,
+                data=[query_vector.tolist()],
+                anns_field=STRUCT_VECTOR_FIELD,
+                search_params={"metric_type": "COSINE", "params": {"ef": 128}},
+                output_fields=[PK_FIELD],
+                limit=ann_limit,
+            )
+            exact_elements = sorted(
+                (
+                    (
+                        row[PK_FIELD],
+                        offset,
+                        float(np.dot(query_vector, np.asarray(element[VECTOR_SUBFIELD]))),
+                    )
+                    for row in non_empty_rows
+                    for offset, element in enumerate(row[STRUCT_FIELD])
+                ),
+                key=lambda item: item[2],
+                reverse=True,
+            )[:ann_limit]
+            expected_keys = [(row_id, offset) for row_id, offset, _ in exact_elements]
+            actual_keys = [(hit[PK_FIELD], hit["offset"]) for hit in struct_results[0]]
+            valid_keys = {(row[PK_FIELD], offset) for row in non_empty_rows for offset in range(len(row[STRUCT_FIELD]))}
+            assert set(actual_keys).issubset(valid_keys)
+            assert_ann_recall(actual_keys, expected_keys)

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1039,6 +1039,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
     min_index_sealed_rows = 3000
 
     @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51414", strict=True)
     def test_struct_array_compaction_preserves_null_empty_offsets_and_indexes(self):
         """
         target: verify Struct Array data and element identities survive segment compaction
@@ -1267,6 +1268,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
                 f"MATCH_LEAST({STRUCT_FIELD}, $[{INT_SUBFIELD}] >= 10, threshold=1)",
                 False,
                 True,
+                marks=pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51416", strict=True),
                 id="match_int",
             ),
             pytest.param(
@@ -1283,6 +1285,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
                 f"array_contains_all({STRUCT_TAG_FIELD}, [])",
                 False,
                 False,
+                marks=pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51416", strict=True),
                 id="contains_all_empty_list",
             ),
         ],
@@ -2521,6 +2524,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
                 assert_scalar_profile_equal(entity[STRUCT_FIELD], expected[STRUCT_FIELD])
 
     @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51381", strict=True)
     def test_nullable_struct_array_index_preserves_null_validity(self):
         """
         target: test nullable struct-array predicates before and after indexing every scalar struct subfield
@@ -7183,6 +7187,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51381", strict=True)
     def test_add_scalar_struct_array_field_match_null_vs_empty_after_reload(self):
         """
         target: test MATCH three-valued semantics for schema-evolution backfill rows
@@ -12293,7 +12298,17 @@ class TestMilvusClientStructArrayNullableImport(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("file_format", SCALAR_IMPORT_FORMATS, ids=SCALAR_IMPORT_FORMATS)
-    @pytest.mark.parametrize("search_mode", ["embedding_list", "element"], ids=["embedding_list", "element"])
+    @pytest.mark.parametrize(
+        "search_mode",
+        [
+            pytest.param(
+                "embedding_list",
+                marks=pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51414", strict=True),
+                id="embedding_list",
+            ),
+            pytest.param("element", id="element"),
+        ],
+    )
     def test_import_nullable_struct_array_with_vector(self, file_format, search_mode):
         """
         target: test JSON and Parquet import for a nullable Struct Array field with scalar and vector sub-fields

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -2407,6 +2407,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             assert_expression_rows_match_source(actual_rows, source_by_id)
 
     @pytest.mark.tags(CaseLabel.L0)
+    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51381", strict=True)
     def test_create_scalar_struct_array_field_nullable_match_family_null_semantics(self):
         """
         target: test MATCH family null/empty semantics for a nullable scalar Struct Array


### PR DESCRIPTION
issue: #51381

related: #51414
related: #51416

### What this PR does

- Adds Python client E2E coverage for nullable Struct Array NULL-versus-empty semantics.
- Covers compaction, snapshot restoration, partial updates, drop and re-add isolation, imports, regex indexes, aggregation, and dynamic fields.
- Adds exact ANN oracles for Struct Array element and embedding-list searches without assuming self-hit behavior.
- Covers hybrid search collapse strategies and element identity preservation.
- Marks known regressions with strict xfail markers linked to their corresponding issues while keeping unaffected parameters active.

### Why

Struct Array rows can represent NULL, empty arrays, and non-empty arrays. These states affect predicates, nested indexes, element offsets, and vector search candidates differently. The added coverage protects these semantics across write, reload, compaction, import, and snapshot lifecycle paths.

### Validation

- `ruff check` passed for all changed Python files.
- `ruff format --check` passed for all changed Python files.
- Python compilation passed for all changed Python files.
- Pytest collection passed.
- The nine known regression nodes executed as expected: `9 xfailed`.
- The three unaffected parameterized cases passed.
- Targeted E2E validation used Milvus master build `09c44f2dbb`.
