### PR TITLE
enhance: migrate sealed segment misc state to runtime snapshots

### DIFF
--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -2672,18 +2672,19 @@ PhyBinaryArithOpEvalRangeExpr::PrefetchRawData() {
         std::conditional_t<std::is_integral_v<T> && !std::is_same_v<bool, T>,
                            int64_t,
                            T>;
-    auto& skip_index = segment_->GetSkipIndex();
+    auto skip_index = segment_->GetSkipIndex();
     auto value = GetValueWithCastNumber<H>(expr_->value_);
     auto right_value = GetValueWithCastNumber<H>(expr_->right_operand_);
 
     std::vector<int64_t> chunks_may_hit;
     for (size_t i = 0; i < num_data_chunk_; ++i) {
-        auto skip = skip_index.CanSkipBinaryArithRange<T>(field_id_,
-                                                          i,
-                                                          expr_->op_type_,
-                                                          expr_->arith_op_type_,
-                                                          value,
-                                                          right_value);
+        auto skip =
+            skip_index->CanSkipBinaryArithRange<T>(field_id_,
+                                                   i,
+                                                   expr_->op_type_,
+                                                   expr_->arith_op_type_,
+                                                   value,
+                                                   right_value);
         if (!skip) {
             chunks_may_hit.push_back(i);
         }

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -1220,16 +1220,16 @@ PhyBinaryRangeFilterExpr::PrefetchRawData() {
                            U>;
     H lower_val = GetValueWithCastNumber<H>(expr_->lower_val_);
     H upper_val = GetValueWithCastNumber<H>(expr_->upper_val_);
-    auto& skip_index = segment_->GetSkipIndex();
+    auto skip_index = segment_->GetSkipIndex();
 
     std::vector<int64_t> chunks_may_hit;
     for (size_t i = 0; i < num_data_chunk_; ++i) {
-        auto skip = skip_index.CanSkipBinaryRange(field_id_,
-                                                  i,
-                                                  lower_val,
-                                                  upper_val,
-                                                  expr_->lower_inclusive_,
-                                                  expr_->upper_inclusive_);
+        auto skip = skip_index->CanSkipBinaryRange(field_id_,
+                                                   i,
+                                                   lower_val,
+                                                   upper_val,
+                                                   expr_->lower_inclusive_,
+                                                   expr_->upper_inclusive_);
         if (!skip) {
             chunks_may_hit.push_back(i);
         }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -607,11 +607,11 @@ class SegmentExpr : public Expr {
         if (need_size == 0)
             return 0;  //do not go empty-loop at the bound of the chunk
 
-        auto& skip_index = segment_->GetSkipIndex();
+        auto skip_index = segment_->GetSkipIndex();
         auto pw = segment_->get_batch_views<T>(
             op_ctx_, field_id_, 0, current_data_chunk_pos_, need_size);
         auto views_info = pw.get();
-        if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
+        if (!skip_func || !skip_func(*skip_index, field_id_, 0)) {
             // first is the raw data, second is valid_data
             // use valid_data to see if raw data is null
             if constexpr (NeedSegmentOffsets) {
@@ -662,11 +662,11 @@ class SegmentExpr : public Expr {
         // For non_chunked sealed segment, only single chunk
         Assert(num_data_chunk_ == 1);
 
-        auto& skip_index = segment_->GetSkipIndex();
+        auto skip_index = segment_->GetSkipIndex();
         auto pw =
             segment_->get_views_by_offsets<T>(op_ctx_, field_id_, 0, *input);
         auto [data_vec, valid_data] = pw.get();
-        if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
+        if (!skip_func || !skip_func(*skip_index, field_id_, 0)) {
             func(data_vec.data(),
                  valid_data.data(),
                  nullptr,
@@ -719,7 +719,7 @@ class SegmentExpr : public Expr {
         TargetBitmapView valid_res,
         const ValTypes&... values) {
         AssertInfo(num_index_chunk_ == 1, "scalar index chunk num must be 1");
-        auto& skip_index = segment_->GetSkipIndex();
+        auto skip_index = segment_->GetSkipIndex();
 
         using IndexInnerType = std::
             conditional_t<std::is_same_v<T, std::string_view>, std::string, T>;
@@ -730,7 +730,7 @@ class SegmentExpr : public Expr {
         const bool all_valid = cached_index_all_valid_;
         auto batch_size = input->size();
 
-        if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
+        if (!skip_func || !skip_func(*skip_index, field_id_, 0)) {
             for (auto i = 0; i < batch_size; ++i) {
                 auto offset = (*input)[i];
                 auto raw = index_ptr->Reverse_Lookup(offset);
@@ -786,7 +786,7 @@ class SegmentExpr : public Expr {
             }
         }
 
-        auto& skip_index = segment_->GetSkipIndex();
+        auto skip_index = segment_->GetSkipIndex();
 
         if constexpr (std::is_same_v<T, VectorArrayView>) {
             for (size_t i = 0; i < input->size(); ++i) {
@@ -802,7 +802,8 @@ class SegmentExpr : public Expr {
                     chunk_id,
                     std::make_pair(chunk_offset, int64_t{1}));
                 const auto& [data_vec, valid_data] = pw.get();
-                if (!skip_func || !skip_func(skip_index, field_id_, chunk_id)) {
+                if (!skip_func ||
+                    !skip_func(*skip_index, field_id_, chunk_id)) {
                     func.template operator()<FilterType::random>(
                         data_vec.data(),
                         valid_data.data(),
@@ -838,7 +839,7 @@ class SegmentExpr : public Expr {
                             {int32_t(chunk_offset)});
                         auto [data_vec, valid_data] = pw.get();
                         if (!skip_func ||
-                            !skip_func(skip_index, field_id_, chunk_id)) {
+                            !skip_func(*skip_index, field_id_, chunk_id)) {
                             func.template operator()<FilterType::random>(
                                 data_vec.data(),
                                 valid_data.data(),
@@ -870,7 +871,7 @@ class SegmentExpr : public Expr {
                         valid_data += chunk_offset;
                     }
                     if (!skip_func ||
-                        !skip_func(skip_index, field_id_, chunk_id)) {
+                        !skip_func(*skip_index, field_id_, chunk_id)) {
                         func.template operator()<FilterType::random>(
                             data,
                             valid_data,
@@ -899,7 +900,7 @@ class SegmentExpr : public Expr {
                 auto chunk = pw.get();
                 const T* data = chunk.data();
                 const bool* valid_data = chunk.valid_data();
-                if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
+                if (!skip_func || !skip_func(*skip_index, field_id_, 0)) {
                     func.template operator()<FilterType::random>(data,
                                                                  valid_data,
                                                                  input->data(),
@@ -925,7 +926,8 @@ class SegmentExpr : public Expr {
                 if (valid_data != nullptr) {
                     valid_data += chunk_offset;
                 }
-                if (!skip_func || !skip_func(skip_index, field_id_, chunk_id)) {
+                if (!skip_func ||
+                    !skip_func(*skip_index, field_id_, chunk_id)) {
                     func.template operator()<FilterType::random>(
                         data,
                         valid_data,
@@ -958,7 +960,7 @@ class SegmentExpr : public Expr {
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
-        auto& skip_index = segment_->GetSkipIndex();
+        auto skip_index = segment_->GetSkipIndex();
         if (segment_->type() == SegmentType::Sealed) {
             AssertInfo(
                 segment_->is_chunked(),
@@ -1024,7 +1026,7 @@ class SegmentExpr : public Expr {
                     size_t result_idx = batch_start + j;
 
                     if (!skip_func ||
-                        !skip_func(skip_index, field_id_, chunk_id)) {
+                        !skip_func(*skip_index, field_id_, chunk_id)) {
                         // Extract element from ArrayView
                         auto value =
                             array_vec[j].template get_data<ElementType>(
@@ -1058,7 +1060,7 @@ class SegmentExpr : public Expr {
                           field_id_.get());
             }
 
-            auto& skip_index = segment_->GetSkipIndex();
+            auto skip_index = segment_->GetSkipIndex();
             size_t processed_size = 0;
 
             for (size_t i = 0; i < element_ids->size(); i++) {
@@ -1081,7 +1083,8 @@ class SegmentExpr : public Expr {
                     valid_data += chunk_offset;
                 }
 
-                if (!skip_func || !skip_func(skip_index, field_id_, chunk_id)) {
+                if (!skip_func ||
+                    !skip_func(*skip_index, field_id_, chunk_id)) {
                     // Extract element from Array
                     auto value = array_ptr->get_data<ElementType>(elem_idx);
                     bool is_valid = !valid_data || valid_data[0];
@@ -1156,8 +1159,8 @@ class SegmentExpr : public Expr {
                 continue;
             }
 
-            auto& skip_index = segment_->GetSkipIndex();
-            if ((!skip_func || !skip_func(skip_index, field_id_, i))) {
+            auto skip_index = segment_->GetSkipIndex();
+            if ((!skip_func || !skip_func(*skip_index, field_id_, i))) {
                 if (segment_->type() == SegmentType::Sealed) {
                     auto pw = segment_->get_batch_views<ArrayView>(
                         op_ctx_, field_id_, i, data_pos, size);
@@ -1401,9 +1404,10 @@ class SegmentExpr : public Expr {
             if (size == 0)
                 continue;  //do not go empty-loop at the bound of the chunk
 
-            auto& skip_index = segment_->GetSkipIndex();
+            auto skip_index = segment_->GetSkipIndex();
             auto process_chunk = [&](const T* data, const bool* valid_data) {
-                auto skipped = skip_func && skip_func(skip_index, field_id_, i);
+                auto skipped =
+                    skip_func && skip_func(*skip_index, field_id_, i);
                 if (!skipped) {
                     if constexpr (NeedSegmentOffsets) {
                         // For GIS functions: construct segment offsets array
@@ -1536,8 +1540,8 @@ class SegmentExpr : public Expr {
                 int64_t offset = start_offset + j;
                 segment_offsets_array[j] = static_cast<int32_t>(offset);
             }
-            auto& skip_index = segment_->GetSkipIndex();
-            if (!skip_func || !skip_func(skip_index, field_id_, i)) {
+            auto skip_index = segment_->GetSkipIndex();
+            if (!skip_func || !skip_func(*skip_index, field_id_, i)) {
                 bool is_seal = false;
                 if constexpr (std::is_same_v<T, std::string_view> ||
                               std::is_same_v<T, Json> ||

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -175,7 +175,7 @@ PhyTermFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
 template <typename T>
 bool
 PhyTermFilterExpr::CanSkipSegment() {
-    const auto& skip_index = segment_->GetSkipIndex();
+    auto skip_index = segment_->GetSkipIndex();
     T min, max;
     for (auto i = 0; i < expr_->vals_.size(); i++) {
         auto val = GetValueFromProto<T>(expr_->vals_[i]);
@@ -185,7 +185,7 @@ PhyTermFilterExpr::CanSkipSegment() {
     auto can_skip = [&]() -> bool {
         bool res = false;
         for (int i = 0; i < num_data_chunk_; ++i) {
-            if (!skip_index.CanSkipBinaryRange<T>(
+            if (!skip_index->CanSkipBinaryRange<T>(
                     op_ctx_, field_id_, i, min, max, true, true)) {
                 return false;
             } else {
@@ -1308,7 +1308,7 @@ PhyTermFilterExpr::PrefetchRawData() {
 template <typename T>
 void
 PhyTermFilterExpr::PrefetchRawData() {
-    auto& skip_index = segment_->GetSkipIndex();
+    auto skip_index = segment_->GetSkipIndex();
 
     std::vector<T> elements;
     elements.reserve(expr_->vals_.size());
@@ -1319,7 +1319,7 @@ PhyTermFilterExpr::PrefetchRawData() {
 
     std::vector<int64_t> chunks_may_hit;
     for (size_t i = 0; i < num_data_chunk_; ++i) {
-        auto skip = skip_index.CanSkipInQuery(field_id_, i, elements);
+        auto skip = skip_index->CanSkipInQuery(field_id_, i, elements);
         if (!skip) {
             chunks_may_hit.push_back(i);
         }

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -2359,12 +2359,12 @@ PhyUnaryRangeFilterExpr::PrefetchRawData() {
     using U =
         std::conditional_t<std::is_same_v<T, std::string_view>, std::string, T>;
     auto op_type = expr_->op_type_;
-    auto& skip_index = segment_->GetSkipIndex();
+    auto skip_index = segment_->GetSkipIndex();
     U val = GetValueFromProto<U>(expr_->val_);
 
     std::vector<int64_t> chunks_may_hit;
     for (size_t i = 0; i < num_data_chunk_; i++) {
-        if (skip_index.CanSkipUnaryRange<U>(field_id_, i, op_type, val)) {
+        if (skip_index->CanSkipUnaryRange<U>(field_id_, i, op_type, val)) {
             continue;
         }
         chunks_may_hit.push_back(i);

--- a/internal/core/src/index/SkipIndex.h
+++ b/internal/core/src/index/SkipIndex.h
@@ -185,6 +185,20 @@ class SkipIndex {
                            T>;
 
  public:
+    std::shared_ptr<SkipIndex>
+    Clone() const {
+        auto cloned = std::make_shared<SkipIndex>();
+        std::shared_lock lck(mutex_);
+        cloned->fieldChunkMetrics_ = fieldChunkMetrics_;
+        return cloned;
+    }
+
+    void
+    Erase(FieldId field_id) {
+        std::unique_lock lck(mutex_);
+        fieldChunkMetrics_.erase(field_id);
+    }
+
     template <typename T>
     std::enable_if_t<SkipIndex::IsAllowedType<T>::value, bool>
     CanSkipUnaryRange(milvus::OpContext* op_ctx,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -242,60 +242,11 @@ cancel_and_erase_scalar_index(
     }
 }
 
-static inline void
-cancel_and_clear_scalar_indexings(
-    std::unordered_map<FieldId, index::CacheIndexBasePtr>& scalar_indexings) {
-    for (auto& [_, index] : scalar_indexings) {
-        cancel_warmup(index);
-    }
-    scalar_indexings.clear();
-}
-
-static inline void
-cancel_and_erase_ngram_index(
-    std::unordered_map<
-        FieldId,
-        std::unordered_map<std::string, index::CacheIndexBasePtr>>&
-        ngram_indexings,
-    FieldId field_id,
-    const std::string& nested_path) {
-    auto field_it = ngram_indexings.find(field_id);
-    if (field_it == ngram_indexings.end()) {
-        return;
-    }
-
-    auto& path_indexings = field_it->second;
-    if (auto path_it = path_indexings.find(nested_path);
-        path_it != path_indexings.end()) {
-        cancel_warmup(path_it->second);
-        path_indexings.erase(path_it);
-    }
-
-    if (path_indexings.empty()) {
-        ngram_indexings.erase(field_it);
-    }
-}
-
-static inline void
-cancel_and_clear_ngram_indexings(
-    std::unordered_map<
-        FieldId,
-        std::unordered_map<std::string, index::CacheIndexBasePtr>>&
-        ngram_indexings) {
-    for (auto& [_, path_indexings] : ngram_indexings) {
-        for (auto& [__, index] : path_indexings) {
-            cancel_warmup(index);
-        }
-    }
-    ngram_indexings.clear();
-}
-
 PinWrapper<const storagev2translator::TimestampIndexCell*>
 ChunkedSegmentSealedImpl::PinTimestampIndex(
     const std::shared_ptr<const RuntimeResourceState>& runtime,
     milvus::OpContext* op_ctx) const {
-    auto slot = runtime != nullptr ? runtime->timestamp_index_slot
-                                   : *timestamp_index_slot_.rlock();
+    auto slot = runtime != nullptr ? runtime->timestamp_index_slot : nullptr;
     if (!slot) {
         return PinWrapper<const storagev2translator::TimestampIndexCell*>(
             nullptr);
@@ -719,7 +670,7 @@ ChunkedSegmentSealedImpl::LoadVecIndex(LoadIndexInfo& info,
             *staged_state, field_id, request.has_raw_data);
         NormalizePublishedState(*staged_state);
     } else {
-        auto next_runtime = CloneMutableRuntimeResourceState();
+        auto next_runtime = CloneRuntimeResourceState(snapshot->runtime);
         if (drop_existing) {
             DropVectorIndexing(*next_runtime, field_id);
             next_runtime->vec_binlog_config.erase(field_id);
@@ -793,7 +744,7 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
     std::unique_lock lck(mutex_);
     if (is_replace) {
         if (target_runtime == nullptr) {
-            owned_runtime = CloneMutableRuntimeResourceState();
+            owned_runtime = CloneRuntimeResourceState(snapshot->runtime);
             target_runtime = owned_runtime.get();
         }
         cancel_and_erase_scalar_index(target_runtime->scalar_indexings,
@@ -811,7 +762,7 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
     if (field_meta.get_data_type() == DataType::JSON) {
         auto path = info.index_params.at(JSON_PATH);
         if (target_runtime == nullptr) {
-            owned_runtime = CloneMutableRuntimeResourceState();
+            owned_runtime = CloneRuntimeResourceState(snapshot->runtime);
             target_runtime = owned_runtime.get();
         }
         for (auto& retired :
@@ -867,7 +818,7 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
     }
 
     if (target_runtime == nullptr) {
-        owned_runtime = CloneMutableRuntimeResourceState();
+        owned_runtime = CloneRuntimeResourceState(snapshot->runtime);
         target_runtime = owned_runtime.get();
     }
     auto cache_index = info.cache_index;
@@ -892,7 +843,7 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
                 info.index_size,
                 info.index_params,
                 info.enable_mmap,
-                num_rows_.value_or(0));
+                target_runtime->row_count);
     }
 
     request.has_raw_data =
@@ -952,13 +903,16 @@ ChunkedSegmentSealedImpl::CaptureRuntimeResourceState() const {
 
 std::shared_ptr<const ChunkedSegmentSealedImpl::RuntimeResourceState>
 ChunkedSegmentSealedImpl::BuildRuntimeResourceState() {
-    return std::make_shared<const RuntimeResourceState>();
+    auto runtime = std::make_shared<RuntimeResourceState>();
+    runtime->skip_index = std::make_shared<SkipIndex>();
+    return ToConstRuntimeState(std::move(runtime));
 }
 
 std::shared_ptr<ChunkedSegmentSealedImpl::RuntimeResourceState>
 ChunkedSegmentSealedImpl::CloneRuntimeResourceState(
     const std::shared_ptr<const RuntimeResourceState>& current) {
     auto state = std::make_shared<RuntimeResourceState>();
+    state->skip_index = std::make_shared<SkipIndex>();
     if (!current) {
         return state;
     }
@@ -980,6 +934,11 @@ ChunkedSegmentSealedImpl::CloneRuntimeResourceState(
     state->timestamp_index_slot = current->timestamp_index_slot;
     state->pk_index_slot = current->pk_index_slot;
     state->virtual_pk2offset = current->virtual_pk2offset;
+    state->skip_index =
+        current->skip_index ? current->skip_index->Clone() : state->skip_index;
+    state->mmap_field_ids = current->mmap_field_ids;
+    state->variable_fields_avg_size = current->variable_fields_avg_size;
+    state->row_count = current->row_count;
     return state;
 }
 
@@ -1376,6 +1335,11 @@ ChunkedSegmentSealedImpl::FreezeRuntimeResourceState(
     runtime->timestamp_index_slot = current.timestamp_index_slot;
     runtime->pk_index_slot = current.pk_index_slot;
     runtime->virtual_pk2offset = current.virtual_pk2offset;
+    runtime->skip_index = current.skip_index ? current.skip_index->Clone()
+                                             : std::make_shared<SkipIndex>();
+    runtime->mmap_field_ids = current.mmap_field_ids;
+    runtime->variable_fields_avg_size = current.variable_fields_avg_size;
+    runtime->row_count = current.row_count;
     return ToConstRuntimeState(std::move(runtime));
 }
 
@@ -2214,7 +2178,7 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
         runtime->timestamp_index_slot.reset();
         {
             std::unique_lock lck(mutex_);
-            update_row_count(0);
+            update_row_count(*runtime, 0);
         }
         return;
     }
@@ -2263,7 +2227,7 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
     // Row count
     {
         std::unique_lock lck(mutex_);
-        update_row_count(num_rows);
+        update_row_count(*runtime, num_rows);
     }
 }
 
@@ -2790,9 +2754,14 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
 
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
+    auto visible_runtime_owner =
+        runtime == nullptr ? CaptureRuntimeResourceState() : nullptr;
+    auto visible_runtime =
+        runtime != nullptr ? runtime : visible_runtime_owner.get();
     AssertInfo(
-        !num_rows_.has_value() || num_rows_ == num_rows,
-        "num_rows_ is set but not equal to num_rows of LoadFieldDataInfo");
+        visible_runtime == nullptr || visible_runtime->row_count == 0 ||
+            visible_runtime->row_count == num_rows,
+        "published row count is not equal to num_rows of LoadFieldDataInfo");
 
     for (auto& [id, info] : load_info.field_infos) {
         AssertInfo(info.row_count > 0, "The row count of field data is 0");
@@ -2902,9 +2871,10 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
 
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
+    auto* staged_runtime = committer.runtime();
     AssertInfo(
-        !num_rows_.has_value() || num_rows_ == num_rows,
-        "num_rows_ is set but not equal to num_rows of LoadFieldDataInfo");
+        staged_runtime->row_count == 0 || staged_runtime->row_count == num_rows,
+        "staged row count is not equal to num_rows of LoadFieldDataInfo");
 
     for (auto& [id, info] : load_info.field_infos) {
         AssertInfo(info.row_count > 0, "The row count of field data is 0");
@@ -2975,6 +2945,8 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                     runtime.timestamps = std::move(timestamp_data);
                     runtime.timestamp_index = std::move(timestamp_index);
                     runtime.timestamp_index_slot.reset();
+                    std::unique_lock lck(mutex_);
+                    update_row_count(runtime, num_rows);
                     stats_.mem_size += sizeof(Timestamp) * num_rows;
                 });
             } else {
@@ -2983,8 +2955,11 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                 std::shared_ptr<milvus::ArrowDataWrapper> r;
                 while (field_data_info.arrow_reader_channel->pop(r)) {
                 }
-                std::unique_lock lck(mutex_);
-                update_row_count(num_rows);
+                committer.Commit([this, num_rows](RuntimeResourceState& runtime,
+                                                  PublishedSegmentState&) {
+                    std::unique_lock lck(mutex_);
+                    update_row_count(runtime, num_rows);
+                });
             }
             LOG_INFO("segment {} loads system field {} mmap false done",
                      this->get_segment_id(),
@@ -3048,6 +3023,12 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
     SCOPE_CGO_CALL_METRIC();
 
     auto num_rows = data.row_count;
+    std::shared_ptr<RuntimeResourceState> owned_runtime;
+    auto* target_runtime = runtime;
+    if (target_runtime == nullptr) {
+        owned_runtime = CloneMutableRuntimeResourceState();
+        target_runtime = owned_runtime.get();
+    }
     AssertInfo(SystemProperty::Instance().IsSystem(field_id),
                "system field is not system field");
     auto system_field_type =
@@ -3073,10 +3054,7 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
             std::fill(timestamps.begin(), timestamps.end(), commit_ts_);
         }
         init_storage_v1_timestamp_index(
-            std::move(timestamps), num_rows, runtime);
-        if (publish_ready) {
-            PublishSystemFieldStateLocked();
-        }
+            std::move(timestamps), num_rows, target_runtime);
     } else {
         AssertInfo(system_field_type == SystemFieldType::RowId,
                    "System field type of id column is not RowId");
@@ -3088,7 +3066,11 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
     }
     {
         std::unique_lock lck(mutex_);
-        update_row_count(num_rows);
+        update_row_count(*target_runtime, num_rows);
+    }
+    if (owned_runtime != nullptr && publish_ready) {
+        PublishRuntimeStateLocked(
+            ToConstRuntimeState(std::move(owned_runtime)));
     }
 }
 
@@ -3153,7 +3135,8 @@ ChunkedSegmentSealedImpl::chunk_size(FieldId field_id, int64_t chunk_id) const {
         return 0;
     }
     auto column = get_column(snapshot->runtime, field_id);
-    return column ? column->chunk_row_nums(chunk_id) : num_rows_.value();
+    return column ? column->chunk_row_nums(chunk_id)
+                  : snapshot->runtime->row_count;
 }
 
 std::pair<int64_t, int64_t>
@@ -3180,8 +3163,9 @@ ChunkedSegmentSealedImpl::num_rows_until_chunk(FieldId field_id,
 
 bool
 ChunkedSegmentSealedImpl::is_mmap_field(FieldId field_id) const {
-    std::shared_lock lck(mutex_);
-    return mmap_field_ids_.find(field_id) != mmap_field_ids_.end();
+    auto runtime = CaptureRuntimeResourceState();
+    return runtime != nullptr && runtime->mmap_field_ids.find(field_id) !=
+                                     runtime->mmap_field_ids.end();
 }
 
 void
@@ -3420,8 +3404,65 @@ ChunkedSegmentSealedImpl::GetNgramIndexForJson(
 
 int64_t
 ChunkedSegmentSealedImpl::get_row_count() const {
-    std::shared_lock lck(mutex_);
-    return num_rows_.value_or(0);
+    auto runtime = CaptureRuntimeResourceState();
+    return runtime != nullptr ? runtime->row_count : 0;
+}
+
+int64_t
+ChunkedSegmentSealedImpl::get_field_avg_size(FieldId field_id) const {
+    AssertInfo(field_id.get() >= 0,
+               "invalid field id, should be greater than or equal to 0");
+    if (SystemProperty::Instance().IsSystem(field_id)) {
+        if (field_id == TimestampFieldID || field_id == RowFieldID) {
+            return sizeof(int64_t);
+        }
+        ThrowInfo(FieldIDInvalid, "unsupported system field id");
+    }
+    auto snapshot = CapturePublishedState();
+    auto& field_meta = snapshot->schema->operator[](field_id);
+    if (!IsVariableDataType(field_meta.get_data_type())) {
+        return field_meta.get_sizeof();
+    }
+    auto runtime = snapshot->runtime;
+    if (runtime == nullptr) {
+        return 0;
+    }
+    auto it = runtime->variable_fields_avg_size.find(field_id);
+    return it != runtime->variable_fields_avg_size.end() ? it->second.second
+                                                         : 0;
+}
+
+void
+ChunkedSegmentSealedImpl::set_field_avg_size(FieldId field_id,
+                                             int64_t num_rows,
+                                             int64_t field_size) {
+    AssertInfo(field_id.get() >= 0,
+               "invalid field id, should be greater than or equal to 0");
+    AssertInfo(num_rows > 0,
+               "The num rows of field data should be greater than 0");
+    std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+    auto current = CapturePublishedState();
+    auto& field_meta = current->schema->operator[](field_id);
+    if (!IsVariableDataType(field_meta.get_data_type())) {
+        return;
+    }
+    auto runtime = CloneRuntimeResourceState(current->runtime);
+    auto& field_info = runtime->variable_fields_avg_size[field_id];
+    auto size = field_info.first * field_info.second + field_size;
+    field_info.first += num_rows;
+    field_info.second = size / field_info.first;
+    auto next = ClonePublishedState(current);
+    next->runtime = ToConstRuntimeState(std::move(runtime));
+    PublishState(std::move(next));
+}
+
+std::shared_ptr<const SkipIndex>
+ChunkedSegmentSealedImpl::GetSkipIndexSnapshot() const {
+    auto runtime = CaptureRuntimeResourceState();
+    if (runtime == nullptr || runtime->skip_index == nullptr) {
+        return std::make_shared<const SkipIndex>();
+    }
+    return runtime->skip_index;
 }
 
 int64_t
@@ -3505,8 +3546,8 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
         AssertInfo(
             get_bit(snapshot->field_data_ready_bitset, field_id),
             "Field Data is not loaded: " + std::to_string(field_id.get()));
-        AssertInfo(num_rows_.has_value(), "Can't get row count value");
-        auto row_count = num_rows_.value();
+        auto row_count = runtime != nullptr ? runtime->row_count : 0;
+        AssertInfo(row_count > 0, "Can't get row count value");
         auto vec_data = get_column(snapshot->runtime, field_id);
         AssertInfo(
             vec_data != nullptr, "vector field {} not loaded", field_id.get());
@@ -3793,19 +3834,25 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
 void
 ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id) {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
-    auto snapshot = CapturePublishedState();
-    DropFieldData(field_id, snapshot->schema);
+    auto current = CapturePublishedState();
+    DropFieldData(field_id, current->schema, nullptr, current);
 }
 
 void
-ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id,
-                                        const SchemaPtr& schema_snapshot,
-                                        RuntimeResourceState* runtime) {
+ChunkedSegmentSealedImpl::DropFieldData(
+    const FieldId field_id,
+    const SchemaPtr& schema_snapshot,
+    RuntimeResourceState* runtime,
+    const std::shared_ptr<const PublishedSegmentState>& current_snapshot) {
     AssertInfo(!SystemProperty::Instance().IsSystem(field_id),
                "Dropping system field is not supported, field id: {}",
                field_id.get());
-    auto snapshot = CapturePublishedState();
+    auto snapshot = current_snapshot;
+    if (snapshot == nullptr && runtime == nullptr) {
+        snapshot = CapturePublishedState();
+    }
     bool has_binlog_index =
+        snapshot != nullptr &&
         has_bit_position(snapshot->binlog_index_bitset, field_id) &&
         get_bit(snapshot->binlog_index_bitset, field_id);
     auto schema_has_field = field_exists_in_schema(schema_snapshot, field_id);
@@ -3818,7 +3865,7 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id,
         LOG_INFO(
             "Skip dropping pk field {} in segment {}", field_id.get(), id_);
         if (runtime == nullptr && has_binlog_index) {
-            auto next_runtime = CloneMutableRuntimeResourceState();
+            auto next_runtime = CloneRuntimeResourceState(snapshot->runtime);
             DropVectorIndexing(*next_runtime, field_id);
             next_runtime->vec_binlog_config.erase(field_id);
             auto published_runtime =
@@ -3837,17 +3884,35 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id,
         return;
     }
 
-    auto old_column = get_column(field_id);
+    std::shared_ptr<ChunkedColumnInterface> old_column;
+    if (runtime != nullptr) {
+        auto it = runtime->fields.find(field_id);
+        if (it != runtime->fields.end()) {
+            old_column = it->second;
+        }
+    } else {
+        old_column = get_column(snapshot->runtime, field_id);
+    }
     if (old_column) {
         old_column->CancelWarmup();
     }
     if (runtime != nullptr) {
         runtime->fields.erase(field_id);
         runtime->array_offsets_map.erase(field_id);
+        runtime->mmap_field_ids.erase(field_id);
+        runtime->variable_fields_avg_size.erase(field_id);
+        if (runtime->skip_index != nullptr) {
+            runtime->skip_index->Erase(field_id);
+        }
     } else {
-        auto next_runtime = CloneMutableRuntimeResourceState();
+        auto next_runtime = CloneRuntimeResourceState(snapshot->runtime);
         next_runtime->fields.erase(field_id);
         next_runtime->array_offsets_map.erase(field_id);
+        next_runtime->mmap_field_ids.erase(field_id);
+        next_runtime->variable_fields_avg_size.erase(field_id);
+        if (next_runtime->skip_index != nullptr) {
+            next_runtime->skip_index->Erase(field_id);
+        }
         if (has_binlog_index) {
             DropVectorIndexing(*next_runtime, field_id);
             next_runtime->vec_binlog_config.erase(field_id);
@@ -4315,7 +4380,7 @@ ChunkedSegmentSealedImpl::find_first_n(int64_t limit,
         return pk_cell->pk2offset().find_first_n(limit, bitset);
     }
     if (limit == Unlimited || limit == NoLimit) {
-        limit = num_rows_.value();
+        limit = runtime != nullptr ? runtime->row_count : 0;
     }
 
     int64_t hit_num = 0;  // avoid counting the number everytime.
@@ -4446,9 +4511,6 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
     int64_t segment_id,
     bool is_sorted_by_pk)
     : segcore_config_(segcore_config),
-      ngram_fields_(std::unordered_set<FieldId>(schema->size())),
-      scalar_indexings_(std::unordered_map<FieldId, index::CacheIndexBasePtr>(
-          schema->size())),
       mmap_descriptor_(storage::MmapManager::GetInstance()
                            .GetMmapChunkManager()
                            ->Register()),
@@ -4626,7 +4688,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
             auto* dst = static_cast<Timestamp*>(output);
             // Import/CDC segments: every row carries commit_ts_, including
             // v2/v3 column-group segments where the raw timestamp column is
-            // emplaced into fields_ but never overwritten. Short-circuit
+            // published in runtime but never overwritten. Short-circuit
             // before consulting the column.
             auto runtime = snapshot->runtime;
             auto effective_commit_ts =
@@ -4659,7 +4721,8 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                          bool small_int_raw_type) const {
     auto snapshot = CapturePublishedState();
     auto& field_meta = snapshot->schema->operator[](field_id);
-    // DO NOT directly access the column by map like: `fields_.at(field_id)->Data()`,
+    // Keep a shared column owner from the captured runtime instead of reading
+    // through a mutable live map.
     // we have to clone the shared pointer, to make sure it won't get released
     // if segment released
     auto column = get_column(snapshot->runtime, field_id);
@@ -4994,6 +5057,9 @@ ChunkedSegmentSealedImpl::ClearData() {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
     auto runtime_snapshot = CaptureRuntimeResourceState();
     if (runtime_snapshot != nullptr) {
+        for (const auto& [_, indexing] : runtime_snapshot->scalar_indexings) {
+            cancel_warmup(indexing);
+        }
         for (const auto& [_, entry] : runtime_snapshot->vector_indexings) {
             if (entry != nullptr && entry->indexing_ != nullptr) {
                 entry->indexing_->CancelWarmup();
@@ -5011,17 +5077,6 @@ ChunkedSegmentSealedImpl::ClearData() {
     }
     {
         std::unique_lock lck(mutex_);
-        num_rows_ = std::nullopt;
-        ngram_fields_.wlock()->clear();
-        scalar_indexings_.withWLock([&](auto& scalar_indexings) {
-            cancel_and_clear_scalar_indexings(scalar_indexings);
-        });
-        ngram_indexings_.withWLock([&](auto& ngram_indexings) {
-            cancel_and_clear_ngram_indexings(ngram_indexings);
-        });
-        timestamp_index_slot_.wlock()->reset();
-        fields_.wlock()->clear();
-        variable_fields_avg_size_.clear();
         stats_.mem_size = 0;
     }
     ClearPublishedStateLocked();
@@ -5599,10 +5654,10 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
                                        const FieldMeta& field_meta,
                                        const int64_t* seg_offsets,
                                        int64_t count) const {
-    // DO NOT directly access the column by map like: `fields_.at(field_id)->Data()`,
-    // we have to clone the shared pointer,
-    // to make sure it won't get released if segment released
-    auto column = get_column(field_id);
+    // Keep a shared column owner from the captured runtime so the column stays
+    // alive even if a newer runtime is published.
+    auto snapshot = CapturePublishedState();
+    auto column = get_column(snapshot->runtime, field_id);
     AssertInfo(column != nullptr,
                "field {} must exist when getting raw data",
                field_id.get());
@@ -5648,7 +5703,6 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
 
         case DataType::TEXT: {
             // TEXT type is only supported in StorageV3 with LOB files.
-            auto snapshot = CapturePublishedState();
             auto runtime = snapshot->runtime != nullptr
                                ? snapshot->runtime
                                : BuildRuntimeResourceState();
@@ -6364,17 +6418,20 @@ void
 ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
                                                Timestamp timestamp,
                                                Timestamp collection_ttl) const {
-    auto schema_snapshot = CaptureSchemaSnapshot();
+    auto snapshot = CapturePublishedState();
+    auto schema_snapshot = snapshot->schema;
     // External collections have no timestamps; all data is always visible
     if (schema_snapshot->is_external_collection()) {
         return;
     }
-    auto runtime = CaptureRuntimeResourceState();
+    auto runtime = snapshot->runtime;
     AssertInfo(runtime != nullptr && runtime->timestamp_index != nullptr,
                "timestamp index is not ready");
     auto& ts_index_data = *runtime->timestamp_index;
-    auto effective_commit_ts = EffectiveCommitTs();
-    auto total_size = static_cast<int64_t>(get_row_count());
+    auto effective_commit_ts =
+        snapshot->commit_ts != 0 ? std::optional<Timestamp>{snapshot->commit_ts}
+                                 : std::nullopt;
+    auto total_size = runtime->row_count;
 
     auto do_scan = [&](int64_t beg, int64_t end, auto pred) {
         for (int64_t i = beg; i < end; ++i) {
@@ -6400,10 +6457,6 @@ ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
         }
     }
 
-    AssertInfo(total_size == get_row_count(),
-               fmt::format("Timestamp size not equal to row count: {}, {}",
-                           total_size,
-                           get_row_count()));
     auto range = ts_index_data.get_active_range(timestamp);
 
     // range == (size_, size_): all data is useful, no filtering needed.
@@ -6521,7 +6574,8 @@ ChunkedSegmentSealedImpl::generate_interim_index(
     if (col_index_meta_ == nullptr || !col_index_meta_->HasField(field_id)) {
         return false;
     }
-    auto schema_snapshot = CaptureSchemaSnapshot();
+    auto snapshot = CapturePublishedState();
+    auto schema_snapshot = snapshot->schema;
     auto& field_meta = schema_snapshot->operator[](field_id);
     auto& field_index_meta = col_index_meta_->GetFieldIndexMeta(field_id);
     auto& index_params = field_index_meta.GetIndexParams();
@@ -6558,7 +6612,6 @@ ChunkedSegmentSealedImpl::generate_interim_index(
                 return false;
             }
         } else {
-            auto snapshot = CapturePublishedState();
             if (RuntimeVectorIndexReady(snapshot->runtime.get(), field_id)) {
                 return false;
             }
@@ -6728,22 +6781,14 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     milvus::OpContext* op_ctx,
     bool is_replace,
     StagedStateCommitter* committer) {
-    auto snapshot = CapturePublishedState();
-
-    if (!enable_mmap) {
-        if (IsVariableDataType(data_type)) {
-            SegmentInternalInterface::set_field_avg_size(
-                field_id, num_rows, column->DataByteSize());
+    std::shared_ptr<const PublishedSegmentState> snapshot;
+    auto capture_snapshot =
+        [&]() -> const std::shared_ptr<const PublishedSegmentState>& {
+        if (snapshot == nullptr) {
+            snapshot = CapturePublishedState();
         }
-    }
-    if (!IsVariableDataType(data_type) || IsStringDataType(data_type)) {
-        if (statistics) {
-            LoadSkipIndexFromStatistics(
-                field_id, data_type, statistics.value());
-        } else if (!is_proxy_column) {
-            LoadSkipIndex(field_id, data_type, column);
-        }
-    }
+        return snapshot;
+    };
 
     std::shared_ptr<CacheSlot<storagev2translator::PkIndexCell>> pk_index_slot;
     const bool is_primary_field =
@@ -6789,6 +6834,32 @@ ChunkedSegmentSealedImpl::load_field_data_common(
             const PublishedSegmentState& state_snapshot) {
             prepare_array_offsets(target_runtime);
 
+            if (IsVariableDataType(data_type)) {
+                if (enable_mmap) {
+                    target_runtime.variable_fields_avg_size.erase(field_id);
+                } else {
+                    auto& field_info =
+                        target_runtime.variable_fields_avg_size[field_id];
+                    auto total_size = field_info.first * field_info.second +
+                                      column->DataByteSize();
+                    field_info.first += num_rows;
+                    field_info.second = total_size / field_info.first;
+                }
+            }
+
+            if (!IsVariableDataType(data_type) || IsStringDataType(data_type)) {
+                if (target_runtime.skip_index == nullptr) {
+                    target_runtime.skip_index = std::make_shared<SkipIndex>();
+                }
+                if (statistics) {
+                    target_runtime.skip_index->LoadSkipFromStatistics(
+                        id_, field_id, data_type, statistics.value());
+                } else if (!is_proxy_column) {
+                    target_runtime.skip_index->LoadSkip(
+                        id_, field_id, data_type, column);
+                }
+            }
+
             if (is_primary_field) {
                 target_runtime.pk_index_slot = pk_index_slot;
                 target_runtime.virtual_pk2offset.reset();
@@ -6820,7 +6891,9 @@ ChunkedSegmentSealedImpl::load_field_data_common(
             }
 
             if (enable_mmap) {
-                mmap_field_ids_.insert(field_id);
+                target_runtime.mmap_field_ids.insert(field_id);
+            } else {
+                target_runtime.mmap_field_ids.erase(field_id);
             }
 
             if (!SystemProperty::Instance().IsSystem(field_id)) {
@@ -6837,7 +6910,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
                                "field {} data already loaded",
                                field_id.get());
                 }
-                update_row_count(num_rows);
+                update_row_count(target_runtime, num_rows);
             }
         };
 
@@ -6850,7 +6923,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
                 old_column = it->second;
             }
             if (old_column == nullptr) {
-                old_column = get_column(snapshot->runtime, field_id);
+                old_column = get_column(capture_snapshot()->runtime, field_id);
             }
 
             std::unique_lock lck(mutex_);
@@ -6866,16 +6939,16 @@ ChunkedSegmentSealedImpl::load_field_data_common(
             old_column = it->second;
         }
         if (old_column == nullptr) {
-            old_column = get_column(snapshot->runtime, field_id);
+            old_column = get_column(capture_snapshot()->runtime, field_id);
         }
 
         std::unique_lock lck(mutex_);
-        apply_loaded_column(*runtime, old_column, *snapshot);
+        apply_loaded_column(*runtime, old_column, *capture_snapshot());
         return;
     }
 
     std::unique_lock lck(mutex_);
-    auto current = CapturePublishedState();
+    auto current = capture_snapshot();
     auto next_runtime = CloneRuntimeResourceState(current->runtime);
     auto old_column = get_column(current->runtime, field_id);
 
@@ -7413,7 +7486,7 @@ ChunkedSegmentSealedImpl::fill_empty_field(
         milvus::storage::LocalChunkManagerSingleton::GetInstance()
             .GetChunkManager()
             ->GetRootPath();
-    int64_t size = num_rows_.value();
+    int64_t size = runtime.row_count;
     AssertInfo(size > 0, "Chunked Sealed segment must have more than 0 row");
     auto field_data_info = FieldDataInfo(field_id.get(),
                                          size,
@@ -7436,6 +7509,11 @@ ChunkedSegmentSealedImpl::fill_empty_field(
     auto column = MakeChunkedColumnBase(data_type, std::move(slot), field_meta);
 
     runtime.fields.emplace(field_id, column);
+    if (use_mmap) {
+        runtime.mmap_field_ids.insert(field_id);
+    } else {
+        runtime.mmap_field_ids.erase(field_id);
+    }
     LOG_INFO(
         "fill empty field {} (data type {}) for growing segment {} "
         "done",
@@ -7499,7 +7577,7 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
         fill_empty_field(
             field_meta, schema_snapshot, segment_load_info, *target_runtime);
         EnsureArrayOffsetsForStructField(
-            field_meta, num_rows_.value_or(0), *target_runtime);
+            field_meta, target_runtime->row_count, *target_runtime);
         filled_fields.push_back(field_id);
     }
 
@@ -7567,7 +7645,7 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
             milvus::storage::LocalChunkManagerSingleton::GetInstance()
                 .GetChunkManager()
                 ->GetRootPath();
-        int64_t size = num_rows_.value();
+        int64_t size = committer.runtime()->row_count;
         AssertInfo(size > 0,
                    "Chunked Sealed segment must have more than 0 row");
         auto field_data_info =
@@ -7598,21 +7676,36 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
         return;
     }
 
-    committer.Commit(
-        [&](RuntimeResourceState& runtime, PublishedSegmentState&) {
-            for (auto& [field_meta, column] : fields_to_commit) {
-                auto field_id = field_meta.get_id();
-                runtime.fields.emplace(field_id, std::move(column));
-                EnsureArrayOffsetsForStructField(
-                    field_meta, num_rows_.value_or(0), runtime);
-                LOG_INFO(
-                    "fill empty field {} (data type {}) for growing segment {} "
-                    "done",
-                    field_meta.get_data_type(),
-                    field_id.get(),
-                    id_);
+    committer.Commit([&](RuntimeResourceState& runtime,
+                         PublishedSegmentState&) {
+        for (auto& [field_meta, column] : fields_to_commit) {
+            auto field_id = field_meta.get_id();
+            runtime.fields.emplace(field_id, std::move(column));
+            auto [field_has_setting, field_mmap_enabled] =
+                schema_snapshot->MmapEnabled(field_id);
+            auto is_vector = IsVectorDataType(field_meta.get_data_type());
+            auto& mmap_config =
+                storage::MmapManager::GetInstance().GetMmapConfig();
+            bool global_use_mmap = is_vector
+                                       ? mmap_config.GetVectorFieldEnableMmap()
+                                       : mmap_config.GetScalarFieldEnableMmap();
+            bool use_mmap =
+                field_has_setting ? field_mmap_enabled : global_use_mmap;
+            if (use_mmap) {
+                runtime.mmap_field_ids.insert(field_id);
+            } else {
+                runtime.mmap_field_ids.erase(field_id);
             }
-        });
+            EnsureArrayOffsetsForStructField(
+                field_meta, runtime.row_count, runtime);
+            LOG_INFO(
+                "fill empty field {} (data type {}) for growing segment {} "
+                "done",
+                field_meta.get_data_type(),
+                field_id.get(),
+                id_);
+        }
+    });
 }
 
 void
@@ -7689,7 +7782,8 @@ void
 ChunkedSegmentSealedImpl::SetLoadInfo(
     proto::segcore::SegmentLoadInfo load_info) {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
-    auto schema_snapshot = CaptureSchemaSnapshot();
+    auto current = CapturePublishedState();
+    auto schema_snapshot = current->schema;
     auto commit_ts =
         static_cast<milvus::Timestamp>(load_info.commit_timestamp());
     {
@@ -7701,7 +7795,7 @@ ChunkedSegmentSealedImpl::SetLoadInfo(
     auto published = std::make_shared<const SegmentLoadInfo>(
         std::move(load_info), schema_snapshot);
     PublishState(BuildNextPublishedState(
-        CapturePublishedState(),
+        current,
         MakeStateDelta(
             schema_snapshot, published, static_cast<Timestamp>(commit_ts))));
     LOG_INFO(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3900,7 +3900,12 @@ ChunkedSegmentSealedImpl::DropFieldData(
         runtime->fields.erase(field_id);
         runtime->array_offsets_map.erase(field_id);
         runtime->mmap_field_ids.erase(field_id);
-        runtime->variable_fields_avg_size.erase(field_id);
+        // Average size describes the retrievable field value, not the
+        // resident raw column. Keep it when an index with raw data remains
+        // responsible for retrieval.
+        if (!schema_has_field) {
+            runtime->variable_fields_avg_size.erase(field_id);
+        }
         if (runtime->skip_index != nullptr) {
             runtime->skip_index->Erase(field_id);
         }
@@ -3909,7 +3914,11 @@ ChunkedSegmentSealedImpl::DropFieldData(
         next_runtime->fields.erase(field_id);
         next_runtime->array_offsets_map.erase(field_id);
         next_runtime->mmap_field_ids.erase(field_id);
-        next_runtime->variable_fields_avg_size.erase(field_id);
+        // See the staged-runtime branch above: only schema removal retires
+        // field-level size metadata.
+        if (!schema_has_field) {
+            next_runtime->variable_fields_avg_size.erase(field_id);
+        }
         if (next_runtime->skip_index != nullptr) {
             next_runtime->skip_index->Erase(field_id);
         }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -58,7 +58,6 @@
 #include "common/protobuf_utils.h"
 #include "fmt/core.h"
 #include "folly/FBVector.h"
-#include "folly/Synchronized.h"
 #include "google/protobuf/message.h"
 #include "index/Index.h"
 #include "index/NgramInvertedIndex.h"
@@ -96,9 +95,9 @@ class TimestampIndex;
 
 using namespace milvus::cachinglayer;
 
-// Test-only accessor that pokes private members to simulate v2/v3 segment
-// state (raw timestamp column emplaced into fields_ alongside an overwritten
-// timestamp index). Defined in internal/core/unittest/test_commit_timestamp.cpp.
+// Test-only accessor that simulates v2/v3 segment state (raw timestamp column
+// published in runtime alongside an overwritten timestamp index). Defined in
+// internal/core/unittest/test_commit_timestamp.cpp.
 class CommitTimestampV2TestAccess;
 
 class ChunkedSegmentSealedImpl : public SegmentSealed {
@@ -162,22 +161,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                     PinWrapper<const index::IndexBase*>(std::move(ca), index)};
             }
         }
-
-        auto [scalar_indexings, ngram_fields] =
-            lock(folly::rlock(scalar_indexings_), folly::rlock(ngram_fields_));
-        if (!include_ngram) {
-            if (ngram_fields->find(field_id) != ngram_fields->end()) {
-                return {};
-            }
-        }
-
-        auto iter = scalar_indexings->find(field_id);
-        if (iter == scalar_indexings->end()) {
-            return {};
-        }
-        auto ca = SemiInlineGet(iter->second->PinCells(op_ctx, {0}));
-        auto index = ca->get_cell_of(0);
-        return {PinWrapper<const index::IndexBase*>(std::move(ca), index)};
+        return {};
     }
 
     std::vector<PinWrapper<const index::IndexBase*>>
@@ -373,6 +357,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         std::shared_ptr<CacheSlot<storagev2translator::PkIndexCell>>
             pk_index_slot;
         std::shared_ptr<const OffsetMap> virtual_pk2offset;
+        std::shared_ptr<SkipIndex> skip_index;
+        std::unordered_set<FieldId> mmap_field_ids;
+        std::unordered_map<FieldId, std::pair<int64_t, int64_t>>
+            variable_fields_avg_size;
+        int64_t row_count{0};
     };
 
     struct PublishedSegmentState {
@@ -424,6 +413,17 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     int64_t
     get_row_count() const override;
+
+    int64_t
+    get_field_avg_size(FieldId field_id) const override;
+
+    void
+    set_field_avg_size(FieldId field_id,
+                       int64_t num_rows,
+                       int64_t field_size) override;
+
+    std::shared_ptr<const SkipIndex>
+    GetSkipIndexSnapshot() const;
 
     int64_t
     get_deleted_count() const override;
@@ -1285,8 +1285,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                        int64_t count) const;
 
     void
-    update_row_count(int64_t row_count) {
-        num_rows_ = row_count;
+    update_row_count(RuntimeResourceState& runtime, int64_t row_count) {
+        runtime.row_count = row_count;
         deleted_record_.set_sealed_row_count(row_count);
     }
 
@@ -1843,9 +1843,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
               RuntimeResourceState* runtime = nullptr);
 
     void
-    DropFieldData(const FieldId field_id,
-                  const SchemaPtr& schema_snapshot,
-                  RuntimeResourceState* runtime = nullptr);
+    DropFieldData(
+        const FieldId field_id,
+        const SchemaPtr& schema_snapshot,
+        RuntimeResourceState* runtime = nullptr,
+        const std::shared_ptr<const PublishedSegmentState>& current = nullptr);
 
     void
     LoadFieldData(const LoadFieldDataInfo& load_info,
@@ -2179,25 +2181,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                              int64_t start,
                              int64_t length) const;
 
-    std::optional<int64_t> num_rows_;
-
-    // ngram indexings for json type
-    folly::Synchronized<std::unordered_map<
-        FieldId,
-        std::unordered_map<std::string, index::CacheIndexBasePtr>>>
-        ngram_indexings_;
-
-    // fields that has ngram index
-    folly::Synchronized<std::unordered_set<FieldId>> ngram_fields_;
-
-    // scalar field index
-    folly::Synchronized<std::unordered_map<FieldId, index::CacheIndexBasePtr>>
-        scalar_indexings_;
-
-    folly::Synchronized<
-        std::shared_ptr<CacheSlot<storagev2translator::TimestampIndexCell>>>
-        timestamp_index_slot_;
-
     // deleted pks
     mutable DeletedRecord<true> deleted_record_;
 
@@ -2223,11 +2206,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // PublishedSegmentState.
     uint64_t commit_ts_{0};
 
-    mutable folly::Synchronized<
-        std::unordered_map<FieldId, std::shared_ptr<ChunkedColumnInterface>>>
-        fields_;
     std::unordered_set<FieldId> pending_text_index_fields_;
-    std::unordered_set<FieldId> mmap_field_ids_;
 
     // only useful in binlog
     IndexMetaPtr col_index_meta_;
@@ -2243,13 +2222,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // The reader object itself now lives in RuntimeResourceState snapshots so
     // reopen/load can stage a replacement reader without exposing it early.
     mutable std::mutex reader_mutex_;
-
-    // Array offsets grouped by the shared struct-array parent name.
-    std::unordered_map<std::string, std::shared_ptr<ArrayOffsetsSealed>>
-        struct_to_array_offsets_;
-    // Direct field-id lookup for array/vector-array fields.
-    std::unordered_map<FieldId, std::shared_ptr<ArrayOffsetsSealed>>
-        array_offsets_map_;
 
 #ifdef MILVUS_UNIT_TEST
  public:
@@ -2352,6 +2324,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         auto it = runtime->fields.find(field_ids.front());
         AssertInfo(it != runtime->fields.end(), "test field was not loaded");
         return it->second;
+    }
+
+    void
+    TestPublishRuntimeResourceState(
+        std::shared_ptr<RuntimeResourceState> runtime) {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+        PublishRuntimeStateLocked(ToConstRuntimeState(std::move(runtime)));
     }
 
     void

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -768,8 +768,11 @@ SegmentInternalInterface::set_field_avg_size(FieldId field_id,
     }
 }
 
-const SkipIndex&
+std::shared_ptr<const SkipIndex>
 SegmentInternalInterface::GetSkipIndex() const {
+    if (auto* sealed = dynamic_cast<const ChunkedSegmentSealedImpl*>(this)) {
+        return sealed->GetSkipIndexSnapshot();
+    }
     return skip_index_;
 }
 

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -568,14 +568,14 @@ class SegmentInternalInterface : public SegmentInterface {
         return false;
     }
 
-    const SkipIndex&
+    std::shared_ptr<const SkipIndex>
     GetSkipIndex() const;
 
     void
     LoadSkipIndex(FieldId field_id,
                   DataType data_type,
                   std::shared_ptr<ChunkedColumnInterface> column) {
-        skip_index_.LoadSkip(get_segment_id(), field_id, data_type, column);
+        skip_index_->LoadSkip(get_segment_id(), field_id, data_type, column);
     }
 
     void
@@ -583,7 +583,7 @@ class SegmentInternalInterface : public SegmentInterface {
         FieldId field_id,
         DataType data_type,
         std::vector<std::shared_ptr<parquet::Statistics>> statistics) {
-        skip_index_.LoadSkipFromStatistics(
+        skip_index_->LoadSkipFromStatistics(
             get_segment_id(), field_id, data_type, statistics);
     }
 
@@ -858,7 +858,7 @@ class SegmentInternalInterface : public SegmentInterface {
     // fieldID -> std::pair<num_rows, avg_size>
     std::unordered_map<FieldId, std::pair<int64_t, int64_t>>
         variable_fields_avg_size_;  // bytes;
-    SkipIndex skip_index_;
+    std::shared_ptr<SkipIndex> skip_index_ = std::make_shared<SkipIndex>();
 
     // text-indexes used to do match.
     std::unordered_map<

--- a/internal/core/unittest/test_commit_timestamp.cpp
+++ b/internal/core/unittest/test_commit_timestamp.cpp
@@ -250,14 +250,14 @@ TEST(CommitTimestamp, Boundary_CommitEqualsMaxRowTs) {
 // V2/V3 column-group fixture
 //
 // On v2/v3 import segments the raw timestamp column (original row_ts) is
-// emplaced into fields_ by load_field_data_common, while the timestamp index
-// is built from commit_ts via init_storage_v1_timestamp_index. The V1 fixture
+// published in runtime by load_field_data_common, while the timestamp index is
+// built from commit_ts via init_storage_v1_timestamp_index. The V1 fixture
 // above (CreateImportSegment / LoadGeneratedDataIntoSegment) never reproduces
 // this state because the V1 path stores timestamps in insert_record_ instead
-// of fields_. CommitTimestampV2TestAccess pokes the private fields_ map to
-// simulate exactly the v2/v3 shape, so we can verify that EffectiveCommitTs()
-// short-circuits every timestamp reader regardless of which storage path
-// populated fields_.
+// of runtime. CommitTimestampV2TestAccess publishes the raw column into a
+// cloned runtime to simulate exactly the v2/v3 shape, so we can verify that
+// EffectiveCommitTs() short-circuits every timestamp reader regardless of
+// which storage path populated runtime.
 // ===========================================================================
 
 namespace milvus::segcore {
@@ -302,7 +302,13 @@ class CommitTimestampV2TestAccess {
                 std::move(translator), nullptr);
         auto column =
             std::make_shared<ChunkedColumn>(std::move(slot), ts_field_meta);
-        segment->fields_.wlock()->insert_or_assign(TimestampFieldID, column);
+        auto current = segment->CapturePublishedState();
+        auto runtime = segment->CloneRuntimeResourceState(current->runtime);
+        runtime->fields.insert_or_assign(TimestampFieldID, std::move(column));
+        auto next = segment->ClonePublishedState(current);
+        next->runtime = segment->ToConstRuntimeState(std::move(runtime));
+        segment->NormalizePublishedState(*next);
+        segment->PublishState(std::move(next));
     }
 };
 
@@ -342,7 +348,7 @@ CreateImportSegmentV2(SchemaPtr schema,
 }
 
 // V2.1: MVCC — query_ts < commit_ts must mask every row, even though the
-// raw timestamp column in fields_ would say the rows are old enough to be
+// raw timestamp column in runtime would say the rows are old enough to be
 // visible. This was the latent gap: mask_with_timestamps::do_scan used to
 // scan the raw column inside the index-narrowed range.
 TEST(CommitTimestamp, V2_MVCC_RowsInvisibleBeforeCommitTs) {
@@ -406,7 +412,7 @@ TEST(CommitTimestamp, V2_TTL_RowsNotExpiredWhenCommitTsAboveTtl) {
     EXPECT_EQ(bs.count(), 0UL)
         << "v2: import segment with commit_ts=" << T_commit
         << " must NOT be TTL-expired at threshold=" << TTL_THRESHOLD
-        << " even with raw row_ts=" << T_old << " in fields_";
+        << " even with raw row_ts=" << T_old << " in runtime";
 }
 
 // V2.3: Pre-commit delete must not apply on v2 import segments. The bug was

--- a/internal/core/unittest/test_exec.cpp
+++ b/internal/core/unittest/test_exec.cpp
@@ -925,7 +925,8 @@ TEST(TaskTest, SkipIndexWithBitmapInputAlignment) {
 
     // Verify SkipIndex is working before running the expression:
     // Check if chunk 0 can be skipped for float > 60
-    auto& skip_index = segment->GetSkipIndex();
+    auto skip_index_owner = segment->GetSkipIndex();
+    const auto& skip_index = *skip_index_owner;
     bool chunk0_can_skip = skip_index.CanSkipUnaryRange<float>(
         float_fid, 0, proto::plan::OpType::GreaterThan, 60.0f);
     bool chunk1_can_skip = skip_index.CanSkipUnaryRange<float>(

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -1951,37 +1951,37 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                     {pk_field_data},
                                                     cm);
     segment->LoadFieldData(load_info);
-    auto& skip_index = segment->GetSkipIndex();
+    auto skip_index = segment->GetSkipIndex();
     bool equal_5_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::Equal, 5);
+        skip_index->CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::Equal, 5);
     bool equal_12_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::Equal, 12);
+        skip_index->CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::Equal, 12);
     bool equal_10_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::Equal, 10);
+        skip_index->CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::Equal, 10);
     ASSERT_FALSE(equal_5_skip);
     ASSERT_TRUE(equal_12_skip);
     ASSERT_FALSE(equal_10_skip);
     bool less_than_1_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessThan, 1);
+        skip_index->CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessThan, 1);
     bool less_than_5_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessThan, 5);
+        skip_index->CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessThan, 5);
     ASSERT_TRUE(less_than_1_skip);
     ASSERT_FALSE(less_than_5_skip);
     bool less_equal_than_1_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessEqual, 1);
+        skip_index->CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessEqual, 1);
     bool less_equal_than_15_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessThan, 15);
+        skip_index->CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessThan, 15);
     ASSERT_FALSE(less_equal_than_1_skip);
     ASSERT_FALSE(less_equal_than_15_skip);
-    bool greater_than_10_skip = skip_index.CanSkipUnaryRange<int64_t>(
+    bool greater_than_10_skip = skip_index->CanSkipUnaryRange<int64_t>(
         pk_fid, 0, OpType::GreaterThan, 10);
-    bool greater_than_5_skip = skip_index.CanSkipUnaryRange<int64_t>(
+    bool greater_than_5_skip = skip_index->CanSkipUnaryRange<int64_t>(
         pk_fid, 0, OpType::GreaterThan, 5);
     ASSERT_TRUE(greater_than_10_skip);
     ASSERT_FALSE(greater_than_5_skip);
-    bool greater_equal_than_10_skip = skip_index.CanSkipUnaryRange<int64_t>(
+    bool greater_equal_than_10_skip = skip_index->CanSkipUnaryRange<int64_t>(
         pk_fid, 0, OpType::GreaterEqual, 10);
-    bool greater_equal_than_5_skip = skip_index.CanSkipUnaryRange<int64_t>(
+    bool greater_equal_than_5_skip = skip_index->CanSkipUnaryRange<int64_t>(
         pk_fid, 0, OpType::GreaterEqual, 5);
     ASSERT_FALSE(greater_equal_than_10_skip);
     ASSERT_FALSE(greater_equal_than_5_skip);
@@ -1998,8 +1998,9 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                {int32_field_data},
                                                cm);
     segment->LoadFieldData(load_info);
+    skip_index = segment->GetSkipIndex();
     less_than_1_skip =
-        skip_index.CanSkipUnaryRange<int32_t>(i32_fid, 0, OpType::LessThan, 1);
+        skip_index->CanSkipUnaryRange<int32_t>(i32_fid, 0, OpType::LessThan, 1);
     ASSERT_TRUE(less_than_1_skip);
 
     //test for int16
@@ -2014,8 +2015,9 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                {int16_field_data},
                                                cm);
     segment->LoadFieldData(load_info);
-    bool less_than_12_skip =
-        skip_index.CanSkipUnaryRange<int16_t>(i16_fid, 0, OpType::LessThan, 12);
+    skip_index = segment->GetSkipIndex();
+    bool less_than_12_skip = skip_index->CanSkipUnaryRange<int16_t>(
+        i16_fid, 0, OpType::LessThan, 12);
     ASSERT_FALSE(less_than_12_skip);
 
     //test for int8
@@ -2030,7 +2032,8 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                {int8_field_data},
                                                cm);
     segment->LoadFieldData(load_info);
-    bool greater_than_12_skip = skip_index.CanSkipUnaryRange<int8_t>(
+    skip_index = segment->GetSkipIndex();
+    bool greater_than_12_skip = skip_index->CanSkipUnaryRange<int8_t>(
         i8_fid, 0, OpType::GreaterThan, 12);
     ASSERT_TRUE(greater_than_12_skip);
 
@@ -2047,7 +2050,8 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                {float_field_data},
                                                cm);
     segment->LoadFieldData(load_info);
-    greater_than_10_skip = skip_index.CanSkipUnaryRange<float>(
+    skip_index = segment->GetSkipIndex();
+    greater_than_10_skip = skip_index->CanSkipUnaryRange<float>(
         float_fid, 0, OpType::GreaterThan, 10.0);
     ASSERT_TRUE(greater_than_10_skip);
 
@@ -2064,7 +2068,8 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                {double_field_data},
                                                cm);
     segment->LoadFieldData(load_info);
-    greater_than_10_skip = skip_index.CanSkipUnaryRange<double>(
+    skip_index = segment->GetSkipIndex();
+    greater_than_10_skip = skip_index->CanSkipUnaryRange<double>(
         double_fid, 0, OpType::GreaterThan, 10.0);
     ASSERT_TRUE(greater_than_10_skip);
 }
@@ -2094,7 +2099,8 @@ TEST(Sealed, SkipIndexSkipBinaryRange) {
                                                     {pk_field_data},
                                                     cm);
     segment->LoadFieldData(load_info);
-    auto& skip_index = segment->GetSkipIndex();
+    auto skip_index_owner = segment->GetSkipIndex();
+    const auto& skip_index = *skip_index_owner;
     ASSERT_FALSE(
         skip_index.CanSkipBinaryRange<int64_t>(pk_fid, 0, -3, 1, true, true));
     ASSERT_TRUE(
@@ -2137,7 +2143,8 @@ TEST(Sealed, SkipIndexSkipUnaryRangeNullable) {
                                                     {int64s_field_data},
                                                     cm);
     segment->LoadFieldData(load_info);
-    auto& skip_index = segment->GetSkipIndex();
+    auto skip_index_owner = segment->GetSkipIndex();
+    const auto& skip_index = *skip_index_owner;
     bool equal_5_skip =
         skip_index.CanSkipUnaryRange<int64_t>(i64_fid, 0, OpType::Equal, 5);
     bool equal_4_skip =
@@ -2207,7 +2214,8 @@ TEST(Sealed, SkipIndexSkipBinaryRangeNullable) {
                                                     {int64s_field_data},
                                                     cm);
     segment->LoadFieldData(load_info);
-    auto& skip_index = segment->GetSkipIndex();
+    auto skip_index_owner = segment->GetSkipIndex();
+    const auto& skip_index = *skip_index_owner;
     ASSERT_FALSE(
         skip_index.CanSkipBinaryRange<int64_t>(i64_fid, 0, -3, 1, true, true));
     ASSERT_TRUE(
@@ -2249,7 +2257,8 @@ TEST(Sealed, SkipIndexSkipStringRange) {
                                                     {string_field_data},
                                                     cm);
     segment->LoadFieldData(load_info);
-    auto& skip_index = segment->GetSkipIndex();
+    auto skip_index_owner = segment->GetSkipIndex();
+    const auto& skip_index = *skip_index_owner;
     ASSERT_TRUE(skip_index.CanSkipUnaryRange<std::string>(
         string_fid, 0, OpType::Equal, "w"));
     ASSERT_FALSE(skip_index.CanSkipUnaryRange<std::string>(
@@ -4173,6 +4182,57 @@ TEST(SealedSegmentReopen, TextIndexCreatedWipedByReopen) {
 
     EXPECT_TRUE(
         sealed->TestGetLoadInfoSnapshot()->HasTextIndexCreated(text_fid));
+}
+
+TEST(SealedSegmentCowState, MiscRuntimeStateFollowsSnapshotLifetime) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    std::map<std::string, std::string> analyzer_params;
+    auto payload = schema->AddDebugVarcharField(FieldName("payload"),
+                                                DataType::VARCHAR,
+                                                1024,
+                                                /*nullable=*/false,
+                                                /*enable_match=*/false,
+                                                /*enable_analyzer=*/false,
+                                                analyzer_params,
+                                                std::nullopt);
+    schema->set_primary_field_id(pk);
+
+    constexpr int64_t row_count = 8;
+    auto dataset = DataGen(schema, row_count);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    auto old_state = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(old_state->runtime, nullptr);
+    ASSERT_NE(old_state->runtime->skip_index, nullptr);
+    EXPECT_EQ(old_state->runtime->row_count, row_count);
+    EXPECT_EQ(old_state->runtime->mmap_field_ids.count(payload), 0);
+    ASSERT_EQ(old_state->runtime->variable_fields_avg_size.count(payload), 1);
+    auto old_avg_size =
+        old_state->runtime->variable_fields_avg_size.at(payload).second;
+
+    auto next_runtime = sealed->TestCloneMutableRuntimeResourceState();
+    ASSERT_NE(next_runtime->skip_index, old_state->runtime->skip_index);
+    next_runtime->row_count = row_count + 1;
+    next_runtime->mmap_field_ids.insert(payload);
+    next_runtime->variable_fields_avg_size[payload] = {row_count + 1, 123};
+    next_runtime->skip_index->Erase(payload);
+    sealed->TestPublishRuntimeResourceState(std::move(next_runtime));
+
+    auto new_state = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(new_state->runtime, nullptr);
+    EXPECT_EQ(new_state->runtime->row_count, row_count + 1);
+    EXPECT_EQ(new_state->runtime->mmap_field_ids.count(payload), 1);
+    EXPECT_EQ(new_state->runtime->variable_fields_avg_size.at(payload).second,
+              123);
+
+    EXPECT_EQ(old_state->runtime->row_count, row_count);
+    EXPECT_EQ(old_state->runtime->mmap_field_ids.count(payload), 0);
+    EXPECT_EQ(old_state->runtime->variable_fields_avg_size.at(payload).second,
+              old_avg_size);
+    EXPECT_NE(old_state->runtime->skip_index, new_state->runtime->skip_index);
 }
 
 TEST(SealedSegmentCowState, StagedTextIndexIsInvisibleBeforePublish) {

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -4235,6 +4235,50 @@ TEST(SealedSegmentCowState, MiscRuntimeStateFollowsSnapshotLifetime) {
     EXPECT_NE(old_state->runtime->skip_index, new_state->runtime->skip_index);
 }
 
+TEST(SealedSegmentCowState,
+     DropFieldDataPreservesAvgSizeForSchemaRetainedField) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    std::map<std::string, std::string> analyzer_params;
+    auto payload = schema->AddDebugVarcharField(FieldName("payload"),
+                                                DataType::VARCHAR,
+                                                1024,
+                                                /*nullable=*/false,
+                                                /*enable_match=*/false,
+                                                /*enable_analyzer=*/false,
+                                                analyzer_params,
+                                                std::nullopt);
+    schema->set_primary_field_id(pk);
+
+    constexpr int64_t row_count = 8;
+    auto dataset = DataGen(schema, row_count);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    sealed->set_field_avg_size(payload, 1, 128);
+    auto old_state = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(old_state->runtime, nullptr);
+    ASSERT_EQ(old_state->runtime->fields.count(payload), 1);
+    ASSERT_EQ(old_state->runtime->variable_fields_avg_size.count(payload), 1);
+    auto old_avg_info =
+        old_state->runtime->variable_fields_avg_size.at(payload);
+    ASSERT_GT(old_avg_info.second, 0);
+
+    sealed->DropFieldData(payload);
+
+    auto new_state = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(new_state->runtime, nullptr);
+    EXPECT_EQ(new_state->runtime->fields.count(payload), 0);
+    ASSERT_EQ(new_state->runtime->variable_fields_avg_size.count(payload), 1);
+    EXPECT_EQ(new_state->runtime->variable_fields_avg_size.at(payload),
+              old_avg_info);
+
+    EXPECT_EQ(old_state->runtime->fields.count(payload), 1);
+    EXPECT_EQ(old_state->runtime->variable_fields_avg_size.at(payload),
+              old_avg_info);
+}
+
 TEST(SealedSegmentCowState, StagedTextIndexIsInvisibleBeforePublish) {
     auto schema = std::make_shared<Schema>();
     auto pk = schema->AddDebugField("pk", DataType::INT64);


### PR DESCRIPTION
Related to #51068

- move row count, mmap markers, average field sizes, and skip index into runtime state
- remove duplicated live resource containers from chunked sealed segments
- preserve old and new resource lifetimes through COW publication
- reuse one published snapshot capture within each internal method
- add runtime lifetime and skip index regression coverage