### PR TITLE
fix: use correct MinIO root path in text LOB layout test

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_text_lob.py
+++ b/tests/python_client/milvus_client/test_milvus_client_text_lob.py
@@ -2345,7 +2345,7 @@ class TestMilvusClientTextLOBEnvironmentGated(TestMilvusClientV2Base):
         assert threshold > 0, f"MILVUS_TEXT_INLINE_THRESHOLD must be positive, got {threshold}"
         minio_client = new_minio_client(minio_host)
         ensure_minio_bucket(minio_client, minio_bucket)
-        root_path = os.getenv("MILVUS_MINIO_ROOT_PATH", "files")
+        root_path = os.getenv("MILVUS_MINIO_ROOT_PATH", "file")
 
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()


### PR DESCRIPTION
## What this PR does

- Change the default `MILVUS_MINIO_ROOT_PATH` from `files` to `file` in the Text LOB inline/object layout test.
- Keep the environment-variable override available for deployments using a custom root path.

issue: #51257

## Verification

- `python3 -m py_compile tests/python_client/milvus_client/test_milvus_client_text_lob.py`
- Targeted pytest node collection completed successfully.
- Verified the committed diff contains only the requested one-line default change.