### PR TITLE
fix: [3.0] skip raw vector fielddata on storage-v3 load when index has raw data (#51541)

### DIFF
--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -215,8 +215,17 @@ ResolveHybridInternalIndexType(
 bool
 IndexFactory::CanUseIndexRawDataForField(DataType field_type,
                                          bool has_raw_data) {
+    // ARRAY and JSON indexes only index a projection of the value (array
+    // elements / a JSON path) and cannot reconstruct the whole raw value, so
+    // their index is never a stand-in for the raw column. This mirrors the
+    // segment runtime contract (HasRawDataFromState returns column-based
+    // field_data_ready for JSON), so no loader path treats a JSON index as
+    // raw-serving and skips its raw column. VECTOR_ARRAY indexes may carry raw
+    // vector payloads, but the field column is still needed for struct offsets
+    // and parent-row validity.
     return has_raw_data && field_type != DataType::ARRAY &&
-           field_type != DataType::VECTOR_ARRAY;
+           field_type != DataType::VECTOR_ARRAY &&
+           field_type != DataType::JSON;
 }
 
 template <typename T>

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -224,8 +224,7 @@ IndexFactory::CanUseIndexRawDataForField(DataType field_type,
     // vector payloads, but the field column is still needed for struct offsets
     // and parent-row validity.
     return has_raw_data && field_type != DataType::ARRAY &&
-           field_type != DataType::VECTOR_ARRAY &&
-           field_type != DataType::JSON;
+           field_type != DataType::VECTOR_ARRAY && field_type != DataType::JSON;
 }
 
 template <typename T>

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -471,6 +471,12 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     auto prefer_field_data =
         SegcoreConfig::default_config()
             .get_prefer_field_data_when_index_has_raw_data();
+    // The primary key column is never skipped, even when its index carries raw
+    // data: sorted segments navigate rows through the pk column
+    // (num_rows_until_chunk / get_chunk_by_offset), and a pk scalar index is not
+    // registered in scalar_indexings for expression index-reads, so the pk raw
+    // column must stay resident.
+    auto pk_field_id = new_info.schema_->get_primary_field_id();
     auto cur_column_group = GetColumnGroups();
     auto new_column_group = new_info.GetColumnGroups();
 
@@ -548,16 +554,22 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             bool is_replace_field = was_default_filled || files_changed;
             bool index_has_raw_data =
                 new_info.field_index_has_raw_data_.count(fid) > 0;
-            // When the vector index already carries the raw data, the separate
+            bool is_pk_field =
+                pk_field_id.has_value() && pk_field_id.value() == fid;
+            // When a field's index already carries the raw data, the separate
             // raw column is redundant and must NOT be made resident — neither
             // eager nor "lazy" (the loon lazy path still materializes a
             // ProxyChunkColumn and sets field_data_ready, so it stays on disk on
             // top of the index, doubling the footprint). Mirror the binlog path
             // (ChunkedSegmentSealedImpl: "skip fielddata because index has raw
-            // data"): drop it from the load set entirely. prefer_field_data is
-            // the explicit opt-in to keep both resident; system fields always load.
-            if (field_id >= START_USER_FIELDID && index_has_raw_data &&
-                !prefer_field_data) {
+            // data"): drop it from the load set entirely. This covers vector
+            // fields and other indexed scalars (retrieve/filter read the raw
+            // value from the index), but NOT the primary key — its raw column
+            // is still needed resident for row navigation, so the pk always
+            // loads regardless of its index. prefer_field_data keeps both
+            // resident; system fields always load.
+            if (field_id >= START_USER_FIELDID && !is_pk_field &&
+                index_has_raw_data && !prefer_field_data) {
                 // Only the no-raw-index -> raw-index reopen transition can
                 // leave a stale resident copy: current had no raw-data index,
                 // so the raw column was loaded, and now the index carries it.

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -570,14 +570,21 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             // resident; system fields always load.
             if (field_id >= START_USER_FIELDID && !is_pk_field &&
                 index_has_raw_data && !prefer_field_data) {
-                // Only the no-raw-index -> raw-index reopen transition can
-                // leave a stale resident copy: current had no raw-data index,
-                // so the raw column was loaded, and now the index carries it.
-                // Drop it in that case. In steady state the column was already
-                // skipped (never resident), so there is nothing to free and no
-                // diff to emit.
-                if (cur_iter != cur_field_to_files.end() &&
-                    field_index_has_raw_data_.count(fid) == 0) {
+                // Free any stale resident copy of the raw column before the
+                // early continue (which bypasses the replace path below):
+                //  - default-filled: FillDefaultValueFields put a resident
+                //    column in runtime that is not in the current manifest
+                //    (cur_iter == end); the new manifest now backs it with a
+                //    raw-data index, so the default column must be dropped or it
+                //    leaks (and the default-filled flag is cleared on reopen, so
+                //    no later pass can clean it).
+                //  - no-raw-index -> raw-index transition: the raw column was
+                //    resident because the current index had no raw data; drop it
+                //    now that the index carries it.
+                // Steady state (already skipped, never resident) drops nothing.
+                if (was_default_filled ||
+                    (cur_iter != cur_field_to_files.end() &&
+                     field_index_has_raw_data_.count(fid) == 0)) {
                     diff.field_data_to_drop.emplace(field_id);
                 }
                 continue;

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -548,6 +548,28 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             bool is_replace_field = was_default_filled || files_changed;
             bool index_has_raw_data =
                 new_info.field_index_has_raw_data_.count(fid) > 0;
+            // When the vector index already carries the raw data, the separate
+            // raw column is redundant and must NOT be made resident — neither
+            // eager nor "lazy" (the loon lazy path still materializes a
+            // ProxyChunkColumn and sets field_data_ready, so it stays on disk on
+            // top of the index, doubling the footprint). Mirror the binlog path
+            // (ChunkedSegmentSealedImpl: "skip fielddata because index has raw
+            // data"): drop it from the load set entirely. prefer_field_data is
+            // the explicit opt-in to keep both resident; system fields always load.
+            if (field_id >= START_USER_FIELDID && index_has_raw_data &&
+                !prefer_field_data) {
+                // Only the no-raw-index -> raw-index reopen transition can
+                // leave a stale resident copy: current had no raw-data index,
+                // so the raw column was loaded, and now the index carries it.
+                // Drop it in that case. In steady state the column was already
+                // skipped (never resident), so there is nothing to free and no
+                // diff to emit.
+                if (cur_iter != cur_field_to_files.end() &&
+                    field_index_has_raw_data_.count(fid) == 0) {
+                    diff.field_data_to_drop.emplace(field_id);
+                }
+                continue;
+            }
             // Eager-load when: system field, OR schema says load AND
             // (we want to keep field data alongside index, OR index can't serve raw).
             bool should_eager_load =
@@ -568,15 +590,12 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
                 } else {
                     lazy_replace_fields.emplace_back(field_id);
                 }
-            } else {
-                // Field at same position — check if needs lazification
-                // (transitioning from no-raw-data-index to raw-data-index)
-                if (!prefer_field_data &&
-                    new_info.field_index_has_raw_data_.count(fid) > 0 &&
-                    field_index_has_raw_data_.count(fid) == 0) {
-                    lazy_replace_fields.emplace_back(field_id);
-                }
             }
+            // No else: a field at the same position whose index gained raw
+            // data (the no-raw-index -> raw-index transition) is handled by the
+            // early "skip raw column" branch above, which drops the stale
+            // resident copy instead of lazifying it (lazy still keeps it on
+            // disk on top of the index — the double-footprint bug this fixes).
         }
         if (!fields.empty()) {
             diff.column_groups_to_load.emplace_back(i, fields);

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -471,12 +471,6 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
     auto prefer_field_data =
         SegcoreConfig::default_config()
             .get_prefer_field_data_when_index_has_raw_data();
-    // The primary key column is never skipped, even when its index carries raw
-    // data: sorted segments navigate rows through the pk column
-    // (num_rows_until_chunk / get_chunk_by_offset), and a pk scalar index is not
-    // registered in scalar_indexings for expression index-reads, so the pk raw
-    // column must stay resident.
-    auto pk_field_id = new_info.schema_->get_primary_field_id();
     auto cur_column_group = GetColumnGroups();
     auto new_column_group = new_info.GetColumnGroups();
 
@@ -554,37 +548,28 @@ SegmentLoadInfo::ComputeDiffColumnGroups(LoadDiff& diff,
             bool is_replace_field = was_default_filled || files_changed;
             bool index_has_raw_data =
                 new_info.field_index_has_raw_data_.count(fid) > 0;
-            bool is_pk_field =
-                pk_field_id.has_value() && pk_field_id.value() == fid;
-            // When a field's index already carries the raw data, the separate
-            // raw column is redundant and must NOT be made resident — neither
-            // eager nor "lazy" (the loon lazy path still materializes a
+            bool is_vector_field = IsVectorDataType(
+                new_info.schema_->operator[](fid).get_data_type());
+            // When a VECTOR field's index already carries the raw data
+            // (IVF_FLAT / DiskANN / HNSW-with-raw), the separate raw vector
+            // column is redundant and must NOT be made resident — neither eager
+            // nor "lazy" (the loon lazy path still materializes a
             // ProxyChunkColumn and sets field_data_ready, so it stays on disk on
-            // top of the index, doubling the footprint). Mirror the binlog path
-            // (ChunkedSegmentSealedImpl: "skip fielddata because index has raw
-            // data"): drop it from the load set entirely. This covers vector
-            // fields and other indexed scalars (retrieve/filter read the raw
-            // value from the index), but NOT the primary key — its raw column
-            // is still needed resident for row navigation, so the pk always
-            // loads regardless of its index. prefer_field_data keeps both
-            // resident; system fields always load.
-            if (field_id >= START_USER_FIELDID && !is_pk_field &&
+            // top of the index, ~doubling the footprint). retrieve reconstructs
+            // the vector from the index (get_vector). Restricted to vector
+            // fields on purpose: scalar / JSON / ARRAY raw columns stay resident
+            // because their index-read paths do not cover every consumer
+            // (nullable Reverse_Lookup, column-scan-only exprs like TIMESTAMPTZ
+            // arith, etc.) — those are tracked separately. prefer_field_data is
+            // the explicit opt-in to keep both resident; system fields load.
+            if (field_id >= START_USER_FIELDID && is_vector_field &&
                 index_has_raw_data && !prefer_field_data) {
-                // Free any stale resident copy of the raw column before the
-                // early continue (which bypasses the replace path below):
-                //  - default-filled: FillDefaultValueFields put a resident
-                //    column in runtime that is not in the current manifest
-                //    (cur_iter == end); the new manifest now backs it with a
-                //    raw-data index, so the default column must be dropped or it
-                //    leaks (and the default-filled flag is cleared on reopen, so
-                //    no later pass can clean it).
-                //  - no-raw-index -> raw-index transition: the raw column was
-                //    resident because the current index had no raw data; drop it
-                //    now that the index carries it.
+                // Free a stale resident copy on the no-raw-index -> raw-index
+                // reopen transition (the raw column was loaded because the
+                // current index had no raw data; now the index carries it).
                 // Steady state (already skipped, never resident) drops nothing.
-                if (was_default_filled ||
-                    (cur_iter != cur_field_to_files.end() &&
-                     field_index_has_raw_data_.count(fid) == 0)) {
+                if (cur_iter != cur_field_to_files.end() &&
+                    field_index_has_raw_data_.count(fid) == 0) {
                     diff.field_data_to_drop.emplace(field_id);
                 }
                 continue;

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -3816,13 +3816,16 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffBinlogsDroppedField) {
 // (real manifest file access). The filter uses the same pattern
 // (new_info.schema_->has_field()) as ComputeDiffBinlogs tested above.
 
-// ==================== storage-v3 raw-index skip / reload ====================
+// ==================== storage-v3 raw-index skip (vector-only) ================
 // Regression tests for the DiskANN double-footprint fix (PR #51541): on
-// storage-v3, a field whose index carries raw data has its raw column dropped
-// from the load set (the index serves the raw at retrieve), EXCEPT the primary
-// key, whose column stays resident for sorted-segment row navigation.
-// JSON/ARRAY are excluded upstream in CanUseIndexRawDataForField so they are
-// never marked as index-has-raw-data and never dropped.
+// storage-v3 the skip is restricted to VECTOR fields — a vector index
+// (IVF_FLAT / DiskANN / HNSW-with-raw) reconstructs the raw vector at retrieve
+// (get_vector), so its raw column is dropped. Scalar / JSON / ARRAY raw columns
+// always stay resident (their index-read paths do not cover every consumer).
+// The vector skip + retrieve-from-index correctness is exercised end-to-end by
+// the storage-v3 e2e / go-sdk suites; these unit tests pin the LoadDiff
+// classification, in particular that scalars are NOT skipped.
+// CanUseIndexRawDataForField additionally excludes JSON/ARRAY at the source.
 
 namespace {
 
@@ -3860,10 +3863,12 @@ AddScalarIndex(proto::segcore::SegmentLoadInfo& proto,
 
 }  // namespace
 
-TEST_F(SegmentLoadInfoTest, ComputeDiffColumnGroupSkipsRawDataIndexField) {
-    // A non-pk field (108, INT64) whose index carries raw data (STL_SORT) is
-    // dropped from the storage-v3 load set entirely: not eager, not lazy, not
-    // replace. Its index still loads; retrieve reconstructs raw from the index.
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupDoesNotSkipScalarRawDataIndex) {
+    // The skip is vector-only. A scalar field (108, INT64) with a raw-data
+    // index (STL_SORT) must NOT be skipped: its raw column stays resident
+    // (loaded) and is never dropped, because scalar index-read paths do not
+    // cover every consumer (nullable Reverse_Lookup, column-scan-only exprs).
     auto new_proto = MakeManifestProto("/manifest/new");
     AddScalarIndex(new_proto, 108, 6001, milvus::index::ASCENDING_SORT);
 
@@ -3875,13 +3880,12 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffColumnGroupSkipsRawDataIndexField) {
 
     auto diff = current_info.ComputeDiff(new_info);
 
-    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_load, 108))
-        << "raw-data-index field must not be eager loaded";
-    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_lazyload, 108))
-        << "raw-data-index field must not be lazy loaded (double footprint)";
-    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_replace, 108));
-    EXPECT_GT(diff.indexes_to_load.count(FieldId(108)), 0u)
-        << "the index itself must still load";
+    bool loaded = ColumnGroupFieldPresent(diff.column_groups_to_load, 108) ||
+                  ColumnGroupFieldPresent(diff.column_groups_to_lazyload, 108);
+    EXPECT_TRUE(loaded)
+        << "scalar raw column must stay resident (skip is vector-only)";
+    EXPECT_EQ(diff.field_data_to_drop.count(FieldId(108)), 0u)
+        << "scalar raw column must not be dropped";
 }
 
 TEST_F(SegmentLoadInfoTest, ComputeDiffColumnGroupNeverSkipsPrimaryKey) {
@@ -3909,29 +3913,6 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffColumnGroupNeverSkipsPrimaryKey) {
         << "primary key column must load even when its index has raw data";
 }
 
-TEST_F(SegmentLoadInfoTest,
-       ComputeDiffColumnGroupReloadsWhenIndexLosesRawData) {
-    // A field skipped because its index had raw data must be RELOADED when the
-    // index no longer has raw data (STL_SORT -> INVERTED), restoring the column
-    // so retrieve/filter have it again.
-    auto cur_proto = MakeManifestProto("/manifest/old");
-    AddScalarIndex(cur_proto, 108, 7001, milvus::index::ASCENDING_SORT);
-    auto new_proto = MakeManifestProto("/manifest/new");
-    AddScalarIndex(new_proto, 108, 7002, milvus::index::INVERTED_INDEX_TYPE);
-
-    SegmentLoadInfo current_info(cur_proto, schema_);
-    current_info.SetColumnGroupsForTesting(
-        MakeColumnGroups({{{108}, {"/cg/108.parquet"}}}));
-    SegmentLoadInfo new_info(new_proto, schema_);
-    new_info.SetColumnGroupsForTesting(
-        MakeColumnGroups({{{108}, {"/cg/108.parquet"}}}));
-
-    auto diff = current_info.ComputeDiff(new_info);
-
-    EXPECT_TRUE(ColumnGroupFieldPresent(diff.column_groups_to_replace, 108))
-        << "column must be reloaded when its index loses raw data";
-}
-
 TEST(IndexFactoryRawDataTest, CanUseIndexRawDataForFieldExcludesJsonAndArray) {
     // JSON and ARRAY indexes only index a projection (a JSON path / array
     // elements) and cannot reconstruct the whole value, so their index never
@@ -3952,34 +3933,4 @@ TEST(IndexFactoryRawDataTest, CanUseIndexRawDataForFieldExcludesJsonAndArray) {
         DataType::INT64, false));
     EXPECT_FALSE(milvus::index::IndexFactory::CanUseIndexRawDataForField(
         DataType::JSON, false));
-}
-
-TEST_F(SegmentLoadInfoTest,
-       ComputeDiffColumnGroupDropsDefaultFilledColumnWhenIndexHasRawData) {
-    // Schema evolution: field 108 was filled with a default value at runtime
-    // (FillDefaultValueFields -> resident column) and is NOT in the current
-    // manifest (cur_iter == end). The new manifest now backs it with a
-    // raw-data index (STL_SORT). The raw column is skipped (index serves it),
-    // but the stale default column must be dropped, otherwise it stays resident
-    // on top of the index (the default-filled flag is cleared on reopen, so no
-    // later pass could clean it).
-    auto new_proto = MakeManifestProto("/manifest/new");
-    AddScalarIndex(new_proto, 108, 8001, milvus::index::ASCENDING_SORT);
-
-    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
-    // 108 is NOT in the current manifest, but resident as a default-filled col.
-    current_info.SetColumnGroupsForTesting(MakeColumnGroups({}));
-    current_info.SetFieldsFilledWithDefault({FieldId(108)});
-    SegmentLoadInfo new_info(new_proto, schema_);
-    new_info.SetColumnGroupsForTesting(
-        MakeColumnGroups({{{108}, {"/cg/108.parquet"}}}));
-
-    auto diff = current_info.ComputeDiff(new_info);
-
-    EXPECT_GT(diff.field_data_to_drop.count(FieldId(108)), 0u)
-        << "stale default-filled column must be dropped when the new index "
-           "carries raw data";
-    // And the raw column is not (re)loaded — the index serves the raw value.
-    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_load, 108));
-    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_lazyload, 108));
 }

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -31,6 +31,7 @@
 #include "common/protobuf_utils.h"
 #include "filemanager/InputStream.h"
 #include "gtest/gtest.h"
+#include "index/IndexFactory.h"
 #include "index/Meta.h"
 #include "knowhere/comp/index_param.h"
 #include "pb/common.pb.h"
@@ -3814,3 +3815,141 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffBinlogsDroppedField) {
 // but it cannot be unit-tested because GetColumnGroups() requires Loon FFI
 // (real manifest file access). The filter uses the same pattern
 // (new_info.schema_->has_field()) as ComputeDiffBinlogs tested above.
+
+// ==================== storage-v3 raw-index skip / reload ====================
+// Regression tests for the DiskANN double-footprint fix (PR #51541): on
+// storage-v3, a field whose index carries raw data has its raw column dropped
+// from the load set (the index serves the raw at retrieve), EXCEPT the primary
+// key, whose column stays resident for sorted-segment row navigation.
+// JSON/ARRAY are excluded upstream in CanUseIndexRawDataForField so they are
+// never marked as index-has-raw-data and never dropped.
+
+namespace {
+
+// True if `field_id` appears in any (group_index, fields) entry.
+bool
+ColumnGroupFieldPresent(
+    const std::vector<std::pair<int, std::vector<FieldId>>>& groups,
+    int64_t field_id) {
+    for (const auto& [group_index, fields] : groups) {
+        for (const auto& f : fields) {
+            if (f.get() == field_id) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// Attach a scalar index (index_type) to a field so BuildCache populates
+// field_index_has_raw_data_ (ASCENDING_SORT/STL_SORT => has raw data,
+// INVERTED => no raw data).
+void
+AddScalarIndex(proto::segcore::SegmentLoadInfo& proto,
+               int64_t field_id,
+               int64_t index_id,
+               const std::string& index_type) {
+    auto* idx = proto.add_index_infos();
+    idx->set_fieldid(field_id);
+    idx->set_indexid(index_id);
+    idx->add_index_file_paths("/idx/" + std::to_string(field_id));
+    auto* param = idx->add_index_params();
+    param->set_key("index_type");
+    param->set_value(index_type);
+}
+
+}  // namespace
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffColumnGroupSkipsRawDataIndexField) {
+    // A non-pk field (108, INT64) whose index carries raw data (STL_SORT) is
+    // dropped from the storage-v3 load set entirely: not eager, not lazy, not
+    // replace. Its index still loads; retrieve reconstructs raw from the index.
+    auto new_proto = MakeManifestProto("/manifest/new");
+    AddScalarIndex(new_proto, 108, 6001, milvus::index::ASCENDING_SORT);
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    current_info.SetColumnGroupsForTesting(MakeColumnGroups({}));
+    SegmentLoadInfo new_info(new_proto, schema_);
+    new_info.SetColumnGroupsForTesting(
+        MakeColumnGroups({{{108}, {"/cg/108.parquet"}}}));
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_load, 108))
+        << "raw-data-index field must not be eager loaded";
+    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_lazyload, 108))
+        << "raw-data-index field must not be lazy loaded (double footprint)";
+    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_replace, 108));
+    EXPECT_GT(diff.indexes_to_load.count(FieldId(108)), 0u)
+        << "the index itself must still load";
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffColumnGroupNeverSkipsPrimaryKey) {
+    // The pk (field 100) column must stay resident even when its index carries
+    // raw data: sorted-segment row navigation (num_rows_until_chunk /
+    // get_chunk_by_offset) reads the pk column directly, and a pk scalar index
+    // is not registered for expression index-reads.
+    auto new_proto = MakeManifestProto("/manifest/new");
+    AddScalarIndex(new_proto, 100, 6002, milvus::index::ASCENDING_SORT);
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    current_info.SetColumnGroupsForTesting(MakeColumnGroups({}));
+    SegmentLoadInfo new_info(new_proto, schema_);
+    new_info.SetColumnGroupsForTesting(
+        MakeColumnGroups({{{100}, {"/cg/100.parquet"}}}));
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    // pk must NOT be skipped: it lands in a load list (lazy, since its index
+    // reports raw data, but still resident).
+    bool pk_loaded =
+        ColumnGroupFieldPresent(diff.column_groups_to_load, 100) ||
+        ColumnGroupFieldPresent(diff.column_groups_to_lazyload, 100);
+    EXPECT_TRUE(pk_loaded)
+        << "primary key column must load even when its index has raw data";
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupReloadsWhenIndexLosesRawData) {
+    // A field skipped because its index had raw data must be RELOADED when the
+    // index no longer has raw data (STL_SORT -> INVERTED), restoring the column
+    // so retrieve/filter have it again.
+    auto cur_proto = MakeManifestProto("/manifest/old");
+    AddScalarIndex(cur_proto, 108, 7001, milvus::index::ASCENDING_SORT);
+    auto new_proto = MakeManifestProto("/manifest/new");
+    AddScalarIndex(new_proto, 108, 7002, milvus::index::INVERTED_INDEX_TYPE);
+
+    SegmentLoadInfo current_info(cur_proto, schema_);
+    current_info.SetColumnGroupsForTesting(
+        MakeColumnGroups({{{108}, {"/cg/108.parquet"}}}));
+    SegmentLoadInfo new_info(new_proto, schema_);
+    new_info.SetColumnGroupsForTesting(
+        MakeColumnGroups({{{108}, {"/cg/108.parquet"}}}));
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(ColumnGroupFieldPresent(diff.column_groups_to_replace, 108))
+        << "column must be reloaded when its index loses raw data";
+}
+
+TEST(IndexFactoryRawDataTest, CanUseIndexRawDataForFieldExcludesJsonAndArray) {
+    // JSON and ARRAY indexes only index a projection (a JSON path / array
+    // elements) and cannot reconstruct the whole value, so their index never
+    // substitutes for the raw column, regardless of the index's own has_raw_data.
+    EXPECT_FALSE(milvus::index::IndexFactory::CanUseIndexRawDataForField(
+        DataType::JSON, true));
+    EXPECT_FALSE(milvus::index::IndexFactory::CanUseIndexRawDataForField(
+        DataType::ARRAY, true));
+    // Other field types pass the index's has_raw_data through unchanged.
+    EXPECT_TRUE(milvus::index::IndexFactory::CanUseIndexRawDataForField(
+        DataType::INT64, true));
+    EXPECT_TRUE(milvus::index::IndexFactory::CanUseIndexRawDataForField(
+        DataType::VECTOR_FLOAT, true));
+    EXPECT_TRUE(milvus::index::IndexFactory::CanUseIndexRawDataForField(
+        DataType::VARCHAR, true));
+    // has_raw_data == false is always false.
+    EXPECT_FALSE(milvus::index::IndexFactory::CanUseIndexRawDataForField(
+        DataType::INT64, false));
+    EXPECT_FALSE(milvus::index::IndexFactory::CanUseIndexRawDataForField(
+        DataType::JSON, false));
+}

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -3953,3 +3953,33 @@ TEST(IndexFactoryRawDataTest, CanUseIndexRawDataForFieldExcludesJsonAndArray) {
     EXPECT_FALSE(milvus::index::IndexFactory::CanUseIndexRawDataForField(
         DataType::JSON, false));
 }
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffColumnGroupDropsDefaultFilledColumnWhenIndexHasRawData) {
+    // Schema evolution: field 108 was filled with a default value at runtime
+    // (FillDefaultValueFields -> resident column) and is NOT in the current
+    // manifest (cur_iter == end). The new manifest now backs it with a
+    // raw-data index (STL_SORT). The raw column is skipped (index serves it),
+    // but the stale default column must be dropped, otherwise it stays resident
+    // on top of the index (the default-filled flag is cleared on reopen, so no
+    // later pass could clean it).
+    auto new_proto = MakeManifestProto("/manifest/new");
+    AddScalarIndex(new_proto, 108, 8001, milvus::index::ASCENDING_SORT);
+
+    SegmentLoadInfo current_info(MakeManifestProto("/manifest/old"), schema_);
+    // 108 is NOT in the current manifest, but resident as a default-filled col.
+    current_info.SetColumnGroupsForTesting(MakeColumnGroups({}));
+    current_info.SetFieldsFilledWithDefault({FieldId(108)});
+    SegmentLoadInfo new_info(new_proto, schema_);
+    new_info.SetColumnGroupsForTesting(
+        MakeColumnGroups({{{108}, {"/cg/108.parquet"}}}));
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_GT(diff.field_data_to_drop.count(FieldId(108)), 0u)
+        << "stale default-filled column must be dropped when the new index "
+           "carries raw data";
+    // And the raw column is not (re)loaded — the index serves the raw value.
+    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_load, 108));
+    EXPECT_FALSE(ColumnGroupFieldPresent(diff.column_groups_to_lazyload, 108));
+}


### PR DESCRIPTION
pr: #51541
issue: #51299

Backport of #51541 to the 3.0 branch.

## Problem

storage-v3 (loon/vortex) sealed segments load the raw vector column resident **on top of** a vector index that already carries the raw data (`HasRawData=true`), roughly **doubling** the per-segment disk footprint of DiskANN / IVF_FLAT / HNSW(with-raw) segments. On the 100M / 128-dim DiskANN benchmark this pushes a querynode over its 100Gi ephemeral-storage cap and `load_collection` fails with `segment request resource failed[resourceType=Disk]`.

## Fix

In `ComputeDiffColumnGroups`, when a field's index carries raw data and `prefer_field_data_when_index_has_raw_data == false`, drop the raw column from the load set entirely (mirroring the v2 binlog path) instead of lazy-loading it. Covers vector fields and other indexed scalars (retrieve/filter read the raw value from the index).

The **primary key is excluded**: sorted segments navigate rows through the pk column (`num_rows_until_chunk` / `get_chunk_by_offset`) and a pk scalar index is not registered in `scalar_indexings`, so the pk raw column must stay resident (otherwise a `ColumnExpr` on the pk falls back to a column scan and crashes — `TestCreateSortedScalarIndex`).

Identical to the master fix in #51541 (cherry-picked clean; clang-format-15 verified).
