### PR TITLE
fix: [cp3.0] avoid structured binding capture in OpenMP lambdas

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5485,7 +5485,7 @@ ChunkedSegmentSealedImpl::LoadBatchJsonKeyIndexes(
             continue;
         }
         committer.Commit(
-            [field_id, index = std::move(index)](
+            [field_id = field_id, index = std::move(index)](
                 RuntimeResourceState& runtime, PublishedSegmentState&) mutable {
                 runtime.json_stats[field_id] = std::move(index);
             });
@@ -7019,7 +7019,7 @@ ChunkedSegmentSealedImpl::FinalizeLoadDiffForReopen(
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
     for (const auto& [field_id, nested_paths] : diff.json_indexes_to_drop) {
         for (const auto& nested_path : nested_paths) {
-            committer.Commit([&, field_id, nested_path](
+            committer.Commit([&, field_id = field_id, nested_path](
                                  RuntimeResourceState& runtime,
                                  PublishedSegmentState& staged_state) {
                 for (auto& retired :
@@ -8169,7 +8169,7 @@ ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
                    field_id.get());
         auto future = pool.Submit([this,
                                    op_ctx,
-                                   field_id,
+                                   field_id = field_id,
                                    info = std::move(load_text_index_info),
                                    &segment_load_info,
                                    &committer]() mutable -> void {


### PR DESCRIPTION
Cherry-pick from master
pr: #51302

issue: #51231

Use init-captures for structured-binding field IDs in OpenMP lambdas. The 3.0 adaptation also fixes the matching JSON stats callback introduced by the 3.0 runtime-state backport.

## Test Plan

- `/opt/homebrew/opt/llvm@18/bin/clang-format -i --style=file internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp`
- `git diff --check`
- `ninja -C cmake_build -j1 -v src/segcore/CMakeFiles/milvus_segcore.dir/ChunkedSegmentSealedImpl.cpp.o`
