### PR TITLE
fix: [cp 3.0] make release manual flush local only

### DIFF
--- a/internal/distributed/streaming/local.go
+++ b/internal/distributed/streaming/local.go
@@ -20,6 +20,15 @@ func (w localServiceImpl) GetLatestMVCCTimestampIfLocal(ctx context.Context, vch
 	return w.handlerClient.GetLatestMVCCTimestampIfLocal(ctx, vchannel)
 }
 
+func (w localServiceImpl) PrepareReleaseManualFlushIfLocal(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
+	if !w.lifetime.Add(typeutil.LifetimeStateWorking) {
+		return false, ErrWALAccesserClosed
+	}
+	defer w.lifetime.Done()
+
+	return w.handlerClient.PrepareReleaseManualFlushIfLocal(ctx, collectionID, vchannel, releaseSegmentIDs)
+}
+
 // GetMetrics gets the metrics of the wal.
 func (w localServiceImpl) GetMetricsIfLocal(ctx context.Context) (*types.StreamingNodeMetrics, error) {
 	if !w.lifetime.Add(typeutil.LifetimeStateWorking) {

--- a/internal/distributed/streaming/streaming.go
+++ b/internal/distributed/streaming/streaming.go
@@ -173,11 +173,6 @@ type WALAccesser interface {
 	// Local returns the local services.
 	Local() Local
 
-	// PrepareReleaseManualFlush prepares process-local release handoff.
-	// Returns false when the current process is not the local flush owner or
-	// the channel does not need growing-source retention.
-	PrepareReleaseManualFlush(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error)
-
 	// RawAppend writes a records to the log.
 	RawAppend(ctx context.Context, msgs message.MutableMessage, opts ...AppendOption) (*types.AppendResult, error)
 
@@ -203,6 +198,10 @@ type Local interface {
 	// GetLatestMVCCTimestampIfLocal gets the latest mvcc timestamp of the vchannel.
 	// If the wal is located at remote, it will return 0, error.
 	GetLatestMVCCTimestampIfLocal(ctx context.Context, vchannel string) (uint64, error)
+
+	// PrepareReleaseManualFlushIfLocal prepares process-local release handoff.
+	// If the wal is located at remote, it will return false, error.
+	PrepareReleaseManualFlushIfLocal(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error)
 
 	// GetMetricsIfLocal gets the metrics of the local wal.
 	// It will only return the metrics of the local wal but not the remote wal.

--- a/internal/distributed/streaming/test_streaming.go
+++ b/internal/distributed/streaming/test_streaming.go
@@ -117,6 +117,10 @@ func (n *noopLocal) GetLatestMVCCTimestampIfLocal(ctx context.Context, vchannel 
 	return 0, errors.New("not implemented")
 }
 
+func (n *noopLocal) PrepareReleaseManualFlushIfLocal(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
+	return false, getExpectErr()
+}
+
 func (n *noopLocal) GetMetricsIfLocal(ctx context.Context) (*types.StreamingNodeMetrics, error) {
 	return &types.StreamingNodeMetrics{}, nil
 }
@@ -186,10 +190,6 @@ func (n *noopWALAccesser) WALName() string {
 
 func (n *noopWALAccesser) Local() Local {
 	return &noopLocal{}
-}
-
-func (n *noopWALAccesser) PrepareReleaseManualFlush(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
-	return false, getExpectErr()
 }
 
 func (n *noopWALAccesser) RawAppend(ctx context.Context, msgs message.MutableMessage, opts ...AppendOption) (*types.AppendResult, error) {

--- a/internal/distributed/streaming/wal.go
+++ b/internal/distributed/streaming/wal.go
@@ -83,10 +83,6 @@ func (w *walAccesserImpl) Local() Local {
 	return localServiceImpl{w}
 }
 
-func (w *walAccesserImpl) PrepareReleaseManualFlush(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
-	return w.handlerClient.PrepareReleaseManualFlush(ctx, collectionID, vchannel, releaseSegmentIDs)
-}
-
 // ControlChannel returns the control channel name of the wal.
 func (w *walAccesserImpl) ControlChannel() string {
 	last, err := w.streamingCoordClient.Assignment().GetLatestAssignments(context.Background())

--- a/internal/distributed/streaming/wal_test.go
+++ b/internal/distributed/streaming/wal_test.go
@@ -192,16 +192,16 @@ func TestReleaseTimeout(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
-func TestWALAccesserPrepareReleaseManualFlush(t *testing.T) {
+func TestWALAccesserPrepareReleaseManualFlushIfLocal(t *testing.T) {
 	ctx := context.Background()
 	w, _, _, handler := createMockWAL(t)
 	defer w.Close()
 
 	handler.EXPECT().
-		PrepareReleaseManualFlush(mock.Anything, int64(100), vChannel1, []int64{1001}).
+		PrepareReleaseManualFlushIfLocal(mock.Anything, int64(100), vChannel1, []int64{1001}).
 		Return(true, nil)
 
-	prepared, err := w.PrepareReleaseManualFlush(ctx, 100, vChannel1, []int64{1001})
+	prepared, err := w.Local().PrepareReleaseManualFlushIfLocal(ctx, 100, vChannel1, []int64{1001})
 	assert.NoError(t, err)
 	assert.True(t, prepared)
 }

--- a/internal/mocks/distributed/mock_streaming/mock_Local.go
+++ b/internal/mocks/distributed/mock_streaming/mock_Local.go
@@ -80,6 +80,65 @@ func (_c *MockLocal_GetLatestMVCCTimestampIfLocal_Call) RunAndReturn(run func(co
 	return _c
 }
 
+// PrepareReleaseManualFlushIfLocal provides a mock function with given fields: ctx, collectionID, vchannel, releaseSegmentIDs
+func (_m *MockLocal) PrepareReleaseManualFlushIfLocal(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
+	ret := _m.Called(ctx, collectionID, vchannel, releaseSegmentIDs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareReleaseManualFlushIfLocal")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string, []int64) (bool, error)); ok {
+		return rf(ctx, collectionID, vchannel, releaseSegmentIDs)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64, string, []int64) bool); ok {
+		r0 = rf(ctx, collectionID, vchannel, releaseSegmentIDs)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int64, string, []int64) error); ok {
+		r1 = rf(ctx, collectionID, vchannel, releaseSegmentIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockLocal_PrepareReleaseManualFlushIfLocal_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareReleaseManualFlushIfLocal'
+type MockLocal_PrepareReleaseManualFlushIfLocal_Call struct {
+	*mock.Call
+}
+
+// PrepareReleaseManualFlushIfLocal is a helper method to define mock.On call
+//   - ctx context.Context
+//   - collectionID int64
+//   - vchannel string
+//   - releaseSegmentIDs []int64
+func (_e *MockLocal_Expecter) PrepareReleaseManualFlushIfLocal(ctx interface{}, collectionID interface{}, vchannel interface{}, releaseSegmentIDs interface{}) *MockLocal_PrepareReleaseManualFlushIfLocal_Call {
+	return &MockLocal_PrepareReleaseManualFlushIfLocal_Call{Call: _e.mock.On("PrepareReleaseManualFlushIfLocal", ctx, collectionID, vchannel, releaseSegmentIDs)}
+}
+
+func (_c *MockLocal_PrepareReleaseManualFlushIfLocal_Call) Run(run func(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64)) *MockLocal_PrepareReleaseManualFlushIfLocal_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(int64), args[2].(string), args[3].([]int64))
+	})
+	return _c
+}
+
+func (_c *MockLocal_PrepareReleaseManualFlushIfLocal_Call) Return(_a0 bool, _a1 error) *MockLocal_PrepareReleaseManualFlushIfLocal_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockLocal_PrepareReleaseManualFlushIfLocal_Call) RunAndReturn(run func(context.Context, int64, string, []int64) (bool, error)) *MockLocal_PrepareReleaseManualFlushIfLocal_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetMetricsIfLocal provides a mock function with given fields: ctx
 func (_m *MockLocal) GetMetricsIfLocal(ctx context.Context) (*types.StreamingNodeMetrics, error) {
 	ret := _m.Called(ctx)

--- a/internal/mocks/distributed/mock_streaming/mock_WALAccesser.go
+++ b/internal/mocks/distributed/mock_streaming/mock_WALAccesser.go
@@ -320,65 +320,6 @@ func (_c *MockWALAccesser_Local_Call) RunAndReturn(run func() streaming.Local) *
 	return _c
 }
 
-// PrepareReleaseManualFlush provides a mock function with given fields: ctx, collectionID, vchannel, releaseSegmentIDs
-func (_m *MockWALAccesser) PrepareReleaseManualFlush(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
-	ret := _m.Called(ctx, collectionID, vchannel, releaseSegmentIDs)
-
-	if len(ret) == 0 {
-		panic("no return value specified for PrepareReleaseManualFlush")
-	}
-
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, string, []int64) (bool, error)); ok {
-		return rf(ctx, collectionID, vchannel, releaseSegmentIDs)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64, string, []int64) bool); ok {
-		r0 = rf(ctx, collectionID, vchannel, releaseSegmentIDs)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, int64, string, []int64) error); ok {
-		r1 = rf(ctx, collectionID, vchannel, releaseSegmentIDs)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockWALAccesser_PrepareReleaseManualFlush_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareReleaseManualFlush'
-type MockWALAccesser_PrepareReleaseManualFlush_Call struct {
-	*mock.Call
-}
-
-// PrepareReleaseManualFlush is a helper method to define mock.On call
-//   - ctx context.Context
-//   - collectionID int64
-//   - vchannel string
-//   - releaseSegmentIDs []int64
-func (_e *MockWALAccesser_Expecter) PrepareReleaseManualFlush(ctx interface{}, collectionID interface{}, vchannel interface{}, releaseSegmentIDs interface{}) *MockWALAccesser_PrepareReleaseManualFlush_Call {
-	return &MockWALAccesser_PrepareReleaseManualFlush_Call{Call: _e.mock.On("PrepareReleaseManualFlush", ctx, collectionID, vchannel, releaseSegmentIDs)}
-}
-
-func (_c *MockWALAccesser_PrepareReleaseManualFlush_Call) Run(run func(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64)) *MockWALAccesser_PrepareReleaseManualFlush_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int64), args[2].(string), args[3].([]int64))
-	})
-	return _c
-}
-
-func (_c *MockWALAccesser_PrepareReleaseManualFlush_Call) Return(_a0 bool, _a1 error) *MockWALAccesser_PrepareReleaseManualFlush_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockWALAccesser_PrepareReleaseManualFlush_Call) RunAndReturn(run func(context.Context, int64, string, []int64) (bool, error)) *MockWALAccesser_PrepareReleaseManualFlush_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // RawAppend provides a mock function with given fields: ctx, msgs, opts
 func (_m *MockWALAccesser) RawAppend(ctx context.Context, msgs message.MutableMessage, opts ...streaming.AppendOption) (*types.AppendResult, error) {
 	_va := make([]interface{}, len(opts))

--- a/internal/mocks/streamingnode/client/mock_handler/mock_HandlerClient.go
+++ b/internal/mocks/streamingnode/client/mock_handler/mock_HandlerClient.go
@@ -414,12 +414,12 @@ func (_c *MockHandlerClient_GetWALMetricsIfLocal_Call) RunAndReturn(run func(con
 	return _c
 }
 
-// PrepareReleaseManualFlush provides a mock function with given fields: ctx, collectionID, vchannel, releaseSegmentIDs
-func (_m *MockHandlerClient) PrepareReleaseManualFlush(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
+// PrepareReleaseManualFlushIfLocal provides a mock function with given fields: ctx, collectionID, vchannel, releaseSegmentIDs
+func (_m *MockHandlerClient) PrepareReleaseManualFlushIfLocal(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
 	ret := _m.Called(ctx, collectionID, vchannel, releaseSegmentIDs)
 
 	if len(ret) == 0 {
-		panic("no return value specified for PrepareReleaseManualFlush")
+		panic("no return value specified for PrepareReleaseManualFlushIfLocal")
 	}
 
 	var r0 bool
@@ -442,33 +442,33 @@ func (_m *MockHandlerClient) PrepareReleaseManualFlush(ctx context.Context, coll
 	return r0, r1
 }
 
-// MockHandlerClient_PrepareReleaseManualFlush_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareReleaseManualFlush'
-type MockHandlerClient_PrepareReleaseManualFlush_Call struct {
+// MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PrepareReleaseManualFlushIfLocal'
+type MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call struct {
 	*mock.Call
 }
 
-// PrepareReleaseManualFlush is a helper method to define mock.On call
+// PrepareReleaseManualFlushIfLocal is a helper method to define mock.On call
 //   - ctx context.Context
 //   - collectionID int64
 //   - vchannel string
 //   - releaseSegmentIDs []int64
-func (_e *MockHandlerClient_Expecter) PrepareReleaseManualFlush(ctx interface{}, collectionID interface{}, vchannel interface{}, releaseSegmentIDs interface{}) *MockHandlerClient_PrepareReleaseManualFlush_Call {
-	return &MockHandlerClient_PrepareReleaseManualFlush_Call{Call: _e.mock.On("PrepareReleaseManualFlush", ctx, collectionID, vchannel, releaseSegmentIDs)}
+func (_e *MockHandlerClient_Expecter) PrepareReleaseManualFlushIfLocal(ctx interface{}, collectionID interface{}, vchannel interface{}, releaseSegmentIDs interface{}) *MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call {
+	return &MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call{Call: _e.mock.On("PrepareReleaseManualFlushIfLocal", ctx, collectionID, vchannel, releaseSegmentIDs)}
 }
 
-func (_c *MockHandlerClient_PrepareReleaseManualFlush_Call) Run(run func(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64)) *MockHandlerClient_PrepareReleaseManualFlush_Call {
+func (_c *MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call) Run(run func(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64)) *MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(int64), args[2].(string), args[3].([]int64))
 	})
 	return _c
 }
 
-func (_c *MockHandlerClient_PrepareReleaseManualFlush_Call) Return(_a0 bool, _a1 error) *MockHandlerClient_PrepareReleaseManualFlush_Call {
+func (_c *MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call) Return(_a0 bool, _a1 error) *MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockHandlerClient_PrepareReleaseManualFlush_Call) RunAndReturn(run func(context.Context, int64, string, []int64) (bool, error)) *MockHandlerClient_PrepareReleaseManualFlush_Call {
+func (_c *MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call) RunAndReturn(run func(context.Context, int64, string, []int64) (bool, error)) *MockHandlerClient_PrepareReleaseManualFlushIfLocal_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -720,7 +720,7 @@ func (node *QueryNode) prepareReleaseManualFlush(ctx context.Context, collection
 	if wal == nil {
 		return false, merr.WrapErrServiceUnavailable("streaming WAL is not initialized")
 	}
-	return wal.PrepareReleaseManualFlush(ctx, collectionID, channel, segmentIDs)
+	return wal.Local().PrepareReleaseManualFlushIfLocal(ctx, collectionID, channel, segmentIDs)
 }
 
 func isReleaseManualFlushPrepareUnavailable(err error) bool {
@@ -730,6 +730,8 @@ func isReleaseManualFlushPrepareUnavailable(err error) bool {
 	if errors.Is(err, merr.ErrServiceUnavailable) ||
 		errors.Is(err, merr.ErrChannelNotAvailable) ||
 		errors.Is(err, handler.ErrClientClosed) ||
+		errors.Is(err, handler.ErrClientAssignmentNotReady) ||
+		errors.Is(err, handler.ErrReadOnlyWAL) ||
 		errors.Is(err, registry.ErrNoStreamingNodeDeployed) ||
 		errors.Is(err, registry.ErrNoReleaseManualFlushPreparer) {
 		return true

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -730,13 +730,13 @@ func isReleaseManualFlushPrepareUnavailable(err error) bool {
 	if errors.Is(err, merr.ErrServiceUnavailable) ||
 		errors.Is(err, merr.ErrChannelNotAvailable) ||
 		errors.Is(err, handler.ErrClientClosed) ||
-		errors.Is(err, handler.ErrClientAssignmentNotReady) ||
 		errors.Is(err, handler.ErrReadOnlyWAL) ||
 		errors.Is(err, registry.ErrNoStreamingNodeDeployed) ||
 		errors.Is(err, registry.ErrNoReleaseManualFlushPreparer) {
 		return true
 	}
-	return streamingstatus.AsStreamingError(err).IsOnShutdown()
+	streamingErr := streamingstatus.AsStreamingError(err)
+	return streamingErr.IsOnShutdown() || streamingErr.IsWrongStreamingNode()
 }
 
 // GetSegmentInfo returns segment information of the collection on the queryNode, and the information includes memSize, numRow, indexName, indexID ...

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -592,11 +592,6 @@ func TestIsReleaseManualFlushPrepareUnavailable(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "handler client assignment not ready",
-			err:  handler.ErrClientAssignmentNotReady,
-			want: true,
-		},
-		{
 			name: "read only local wal",
 			err:  handler.ErrReadOnlyWAL,
 			want: true,
@@ -614,6 +609,16 @@ func TestIsReleaseManualFlushPrepareUnavailable(t *testing.T) {
 		{
 			name: "streaming on shutdown",
 			err:  streamingstatus.NewOnShutdownError("wal is on shutdown"),
+			want: true,
+		},
+		{
+			name: "local wal channel not exist",
+			err:  streamingstatus.NewChannelNotExist("pchannel"),
+			want: true,
+		},
+		{
+			name: "local wal channel term unmatched",
+			err:  streamingstatus.NewUnmatchedChannelTerm("pchannel", 1, 2),
 			want: true,
 		},
 		{

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -592,6 +592,16 @@ func TestIsReleaseManualFlushPrepareUnavailable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "handler client assignment not ready",
+			err:  handler.ErrClientAssignmentNotReady,
+			want: true,
+		},
+		{
+			name: "read only local wal",
+			err:  handler.ErrReadOnlyWAL,
+			want: true,
+		},
+		{
 			name: "no streaming node deployed",
 			err:  registry.ErrNoStreamingNodeDeployed,
 			want: true,
@@ -2596,6 +2606,7 @@ func TestQueryNodeService(t *testing.T) {
 	wal := mock_streaming.NewMockWALAccesser(t)
 	local := mock_streaming.NewMockLocal(t)
 	local.EXPECT().GetLatestMVCCTimestampIfLocal(mock.Anything, mock.Anything).Return(0, nil).Maybe()
+	local.EXPECT().PrepareReleaseManualFlushIfLocal(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	local.EXPECT().GetMetricsIfLocal(mock.Anything).Return(&types.StreamingNodeMetrics{}, nil).Maybe()
 	wal.EXPECT().Local().Return(local).Maybe()
 	scanner := mock_streaming.NewMockScanner(t)
@@ -2603,7 +2614,6 @@ func TestQueryNodeService(t *testing.T) {
 	scanner.EXPECT().Error().Return(nil).Maybe()
 	scanner.EXPECT().Close().Return().Maybe()
 	wal.EXPECT().Read(mock.Anything, mock.Anything).Return(scanner).Maybe()
-	wal.EXPECT().PrepareReleaseManualFlush(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Maybe()
 	paramtable.SetRole(typeutil.StandaloneRole)
 	paramtable.Get().MQCfg.Type.SwapTempValue(message.WALNameRocksmq.String())
 	util.InitAndSelectWALName()

--- a/internal/streamingnode/client/handler/handler_client.go
+++ b/internal/streamingnode/client/handler/handler_client.go
@@ -86,10 +86,9 @@ type HandlerClient interface {
 	// Returns an empty slice if no force promote has occurred.
 	GetSalvageCheckpoint(ctx context.Context, channelName string) ([]*wal.ReplicateCheckpoint, error)
 
-	// PrepareReleaseManualFlush prepares process-local release handoff.
-	// Returns false when the current process is not the local flush owner or
-	// the channel does not need growing-source retention.
-	PrepareReleaseManualFlush(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error)
+	// PrepareReleaseManualFlushIfLocal prepares process-local release handoff.
+	// If the wal is located at remote, it will return false, error.
+	PrepareReleaseManualFlushIfLocal(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error)
 
 	// GetWALMetricsIfLocal gets the metrics of the local wal.
 	// It will only return the metrics of the local wal but not the remote wal.

--- a/internal/streamingnode/client/handler/handler_client_impl.go
+++ b/internal/streamingnode/client/handler/handler_client_impl.go
@@ -149,52 +149,32 @@ func (hc *handlerClientImpl) GetSalvageCheckpoint(ctx context.Context, pchannel 
 	return cps.([]*wal.ReplicateCheckpoint), nil
 }
 
-// PrepareReleaseManualFlush appends a normal ManualFlush and prepares local growing-source retention.
-func (hc *handlerClientImpl) PrepareReleaseManualFlush(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
+// PrepareReleaseManualFlushIfLocal appends a normal ManualFlush and prepares local growing-source retention if the WAL is local.
+func (hc *handlerClientImpl) PrepareReleaseManualFlushIfLocal(ctx context.Context, collectionID int64, vchannel string, releaseSegmentIDs []int64) (bool, error) {
 	if !hc.lifetime.Add(typeutil.LifetimeStateWorking) {
 		return false, ErrClientClosed
 	}
 	defer hc.lifetime.Done()
 
 	pchannel := funcutil.ToPhysicalChannel(vchannel)
-	logger := mlog.With(
-		mlog.String("pchannel", pchannel),
-		mlog.String("vchannel", vchannel),
-		mlog.Int64("collectionID", collectionID),
-		mlog.Int64s("releaseSegmentIDs", releaseSegmentIDs),
-		mlog.String("handler", "prepare release manual flush"),
-	)
-	result, err := hc.createHandlerAfterStreamingNodeReady(ctx, logger, pchannel, func(ctx context.Context, assign *types.PChannelInfoAssigned) (any, error) {
-		if assign.Channel.AccessMode != types.AccessModeRW {
-			logger.Info(ctx, "skip release manual flush prepare because channel is not RW",
-				mlog.String("accessMode", assign.Channel.AccessMode.String()))
-			return false, nil
-		}
+	assign := hc.watcher.Get(ctx, pchannel)
+	if assign == nil {
+		return false, ErrClientAssignmentNotReady
+	}
 
-		_, err := registry.GetLocalAvailableWAL(assign.Channel)
-		if err != nil {
-			if errors.Is(err, registry.ErrNoStreamingNodeDeployed) ||
-				status.AsStreamingError(err).IsWrongStreamingNode() {
-				logger.Info(ctx, "skip release manual flush prepare because channel is not owned by local streaming node",
-					mlog.Err(err))
-				return false, nil
-			}
-			return false, err
-		}
-
-		preparer, err := registry.GetLocalReleaseManualFlushPreparer()
-		if err != nil {
-			return false, err
-		}
-		return preparer.PrepareReleaseManualFlush(ctx, assign.Channel, collectionID, vchannel, releaseSegmentIDs)
-	})
+	w, err := registry.GetLocalAvailableWAL(assign.Channel)
 	if err != nil {
 		return false, err
 	}
-	if result == nil {
-		return false, nil
+	if w.Channel().AccessMode != types.AccessModeRW {
+		return false, ErrReadOnlyWAL
 	}
-	return result.(bool), nil
+
+	preparer, err := registry.GetLocalReleaseManualFlushPreparer()
+	if err != nil {
+		return false, err
+	}
+	return preparer.PrepareReleaseManualFlush(ctx, assign.Channel, collectionID, vchannel, releaseSegmentIDs)
 }
 
 // GetWALMetricsIfLocal gets the metrics of the local wal.

--- a/internal/streamingnode/client/handler/handler_client_impl.go
+++ b/internal/streamingnode/client/handler/handler_client_impl.go
@@ -158,8 +158,11 @@ func (hc *handlerClientImpl) PrepareReleaseManualFlushIfLocal(ctx context.Contex
 
 	pchannel := funcutil.ToPhysicalChannel(vchannel)
 	assign := hc.watcher.Get(ctx, pchannel)
-	if assign == nil {
-		return false, ErrClientAssignmentNotReady
+	for assign == nil {
+		if err := hc.watcher.Watch(ctx, pchannel, nil); err != nil {
+			return false, err
+		}
+		assign = hc.watcher.Get(ctx, pchannel)
 	}
 
 	w, err := registry.GetLocalAvailableWAL(assign.Channel)

--- a/internal/streamingnode/client/handler/handler_client_test.go
+++ b/internal/streamingnode/client/handler/handler_client_test.go
@@ -320,14 +320,13 @@ func TestHandlerClient_PrepareReleaseManualFlushIfLocalReturnsLocalWALShutdown(t
 	assert.False(t, prepared)
 }
 
-func TestHandlerClient_PrepareReleaseManualFlushIfLocalReturnsAssignmentNotReady(t *testing.T) {
+func TestHandlerClient_PrepareReleaseManualFlushIfLocalWaitsForAssignmentReady(t *testing.T) {
 	vchannel := "pchannel_100v0"
 	releaseSegmentIDs := []int64{1001}
 
 	w := mock_assignment.NewMockWatcher(t)
 	w.EXPECT().Get(mock.Anything, "pchannel").Return(nil)
-	// Watch is intentionally not expected: local-only prepare follows the MVCC
-	// local path and returns the current assignment error directly.
+	w.EXPECT().Watch(mock.Anything, "pchannel", (*types.PChannelInfoAssigned)(nil)).Return(context.Canceled)
 
 	handler := &handlerClientImpl{
 		lifetime: typeutil.NewLifetime(),
@@ -335,7 +334,7 @@ func TestHandlerClient_PrepareReleaseManualFlushIfLocalReturnsAssignmentNotReady
 	}
 
 	prepared, err := handler.PrepareReleaseManualFlushIfLocal(context.Background(), 100, vchannel, releaseSegmentIDs)
-	assert.ErrorIs(t, err, ErrClientAssignmentNotReady)
+	assert.ErrorIs(t, err, context.Canceled)
 	assert.False(t, prepared)
 }
 

--- a/internal/streamingnode/client/handler/handler_client_test.go
+++ b/internal/streamingnode/client/handler/handler_client_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/util/streamingutil/service/mock_resolver"
 	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/consumer"
 	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/producer"
+	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/registry"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/contextutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/mocks/proto/mock_streamingpb"
@@ -29,6 +31,16 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+type shutdownWALManager struct{}
+
+func (m shutdownWALManager) GetAvailableWAL(channel types.PChannelInfo) (wal.WAL, error) {
+	return nil, status.NewOnShutdownError("wal manager is closed")
+}
+
+func (m shutdownWALManager) Metrics() (*types.StreamingNodeMetrics, error) {
+	return nil, status.NewOnShutdownError("wal manager is closed")
+}
 
 func TestHandlerClient(t *testing.T) {
 	assignment := &types.PChannelInfoAssigned{
@@ -247,7 +259,7 @@ func TestHandlerClientReadOnlyAssignmentWaitsForNextAssignment(t *testing.T) {
 	}
 }
 
-func TestHandlerClient_PrepareReleaseManualFlush(t *testing.T) {
+func TestHandlerClient_PrepareReleaseManualFlushIfLocal(t *testing.T) {
 	assignment := &types.PChannelInfoAssigned{
 		Channel: types.PChannelInfo{Name: "pchannel", Term: 1, AccessMode: types.AccessModeRO},
 		Node:    types.StreamingNodeInfo{ServerID: 1, Address: "localhost"},
@@ -271,13 +283,59 @@ func TestHandlerClient_PrepareReleaseManualFlush(t *testing.T) {
 		watcher:  w,
 	}
 
-	prepared, err := handler.PrepareReleaseManualFlush(context.Background(), 100, vchannel, releaseSegmentIDs)
-	assert.NoError(t, err)
+	prepared, err := handler.PrepareReleaseManualFlushIfLocal(context.Background(), 100, vchannel, releaseSegmentIDs)
+	assert.Error(t, err)
 	assert.False(t, prepared)
 
 	handler.Close()
-	prepared, err = handler.PrepareReleaseManualFlush(context.Background(), 100, vchannel, releaseSegmentIDs)
+	prepared, err = handler.PrepareReleaseManualFlushIfLocal(context.Background(), 100, vchannel, releaseSegmentIDs)
 	assert.ErrorIs(t, err, ErrClientClosed)
+	assert.False(t, prepared)
+}
+
+func TestHandlerClient_PrepareReleaseManualFlushIfLocalReturnsLocalWALShutdown(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetLocalComponentEnabled(typeutil.StreamingNodeRole)
+	registry.RegisterLocalWALManager(shutdownWALManager{})
+
+	assignment := &types.PChannelInfoAssigned{
+		Channel: types.PChannelInfo{Name: "pchannel", Term: 1, AccessMode: types.AccessModeRW},
+		Node:    types.StreamingNodeInfo{ServerID: 1, Address: "localhost"},
+	}
+	vchannel := "pchannel_100v0"
+	releaseSegmentIDs := []int64{1001}
+
+	w := mock_assignment.NewMockWatcher(t)
+	w.EXPECT().Get(mock.Anything, "pchannel").Return(assignment)
+	// Watch is intentionally not expected: local WAL shutdown is returned to
+	// the caller like GetLatestMVCCTimestampIfLocal, not retried on assignment.
+
+	handler := &handlerClientImpl{
+		lifetime: typeutil.NewLifetime(),
+		watcher:  w,
+	}
+
+	prepared, err := handler.PrepareReleaseManualFlushIfLocal(context.Background(), 100, vchannel, releaseSegmentIDs)
+	assert.True(t, status.AsStreamingError(err).IsOnShutdown())
+	assert.False(t, prepared)
+}
+
+func TestHandlerClient_PrepareReleaseManualFlushIfLocalReturnsAssignmentNotReady(t *testing.T) {
+	vchannel := "pchannel_100v0"
+	releaseSegmentIDs := []int64{1001}
+
+	w := mock_assignment.NewMockWatcher(t)
+	w.EXPECT().Get(mock.Anything, "pchannel").Return(nil)
+	// Watch is intentionally not expected: local-only prepare follows the MVCC
+	// local path and returns the current assignment error directly.
+
+	handler := &handlerClientImpl{
+		lifetime: typeutil.NewLifetime(),
+		watcher:  w,
+	}
+
+	prepared, err := handler.PrepareReleaseManualFlushIfLocal(context.Background(), 100, vchannel, releaseSegmentIDs)
+	assert.ErrorIs(t, err, ErrClientAssignmentNotReady)
 	assert.False(t, prepared)
 }
 


### PR DESCRIPTION
issue: #51332
pr: #51559

- streaming local WAL: expose release manual flush through Local().PrepareReleaseManualFlushIfLocal and remove the remote handler retry path
- QueryNode unsubscribe: treat local-only prepare errors as unavailable so channel release can continue