### PR TITLE
fix: stabilize multi-shard target convergence

### DIFF
--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1105,6 +1105,7 @@ func (s *Server) GetRecoveryInfoV2(ctx context.Context, req *datapb.GetRecoveryI
 			Level:               segment.GetLevel(),
 			IsSorted:            segment.GetIsSorted(),
 			IsSortedByNamespace: segment.GetIsSortedByNamespace(),
+			StorageVersion:      segment.GetStorageVersion(),
 			ManifestPath:        segment.GetManifestPath(),
 			DataVersion:         segment.GetDataVersion(),
 		})

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -1428,7 +1428,7 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 		assert.EqualValues(t, binlogReq.SegmentID, resp.GetSegments()[0].GetID())
 		assert.EqualValues(t, 0, len(resp.GetSegments()[0].GetBinlogs()))
 	})
-	t.Run("test data version propagated to querycoord", func(t *testing.T) {
+	t.Run("test data and storage versions propagated to querycoord", func(t *testing.T) {
 		svr := newTestServer(t)
 		defer closeTestServer(t, svr)
 		svr.mixCoordCreator = func(ctx context.Context) (types.MixCoord, error) {
@@ -1438,10 +1438,14 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 			Schema: newTestSchema(),
 		})
 
-		const expectedDataVersion int32 = 7
+		const (
+			expectedDataVersion    int32 = 7
+			expectedStorageVersion       = storage.StorageV2
+		)
 		binlogReq := &datapb.SaveBinlogPathsRequest{
-			SegmentID:    20087,
-			CollectionID: 0,
+			SegmentID:      20087,
+			CollectionID:   0,
+			StorageVersion: expectedStorageVersion,
 			Field2BinlogPaths: []*datapb.FieldBinlog{
 				{
 					FieldID: 1,
@@ -1456,6 +1460,7 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 		}
 		segment := createSegment(binlogReq.SegmentID, 0, 1, 100, 10, "vchan1", commonpb.SegmentState_Growing)
 		segment.DataVersion = expectedDataVersion
+		segment.StorageVersion = expectedStorageVersion
 		err := svr.meta.AddSegment(context.TODO(), NewSegmentInfo(segment))
 		assert.NoError(t, err)
 
@@ -1495,8 +1500,9 @@ func TestGetRecoveryInfoV2(t *testing.T) {
 		assert.NoError(t, merr.Error(resp.Status))
 		assert.EqualValues(t, 1, len(resp.GetSegments()))
 		assert.EqualValues(t, binlogReq.SegmentID, resp.GetSegments()[0].GetID())
-		// Regression: DataVersion must be propagated to the QueryCoord response.
+		// Regression: data and storage versions must be propagated to QueryCoord.
 		assert.EqualValues(t, expectedDataVersion, resp.GetSegments()[0].GetDataVersion())
+		assert.EqualValues(t, expectedStorageVersion, resp.GetSegments()[0].GetStorageVersion())
 	})
 	t.Run("with dropped segments", func(t *testing.T) {
 		svr := newTestServer(t)

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -33,7 +33,6 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
-	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -333,19 +332,12 @@ func (c *SegmentChecker) getSealedSegmentDiff(
 		if !existInDist {
 			return false
 		}
-		// Trigger reopen when storage v2 data version is behind the target.
-		// DataVersion bumps on storage v2 binlog changes that don't necessarily
-		// move the manifest version.
-		// Skip when the QueryNode did not report DataVersion (nil pointer from
-		// proto3 optional): during a mixed-version rollout an old QueryNode has
-		// no way to advance DataVersion, so triggering Reopen would loop forever.
-		if segInDist.DataVersion != nil && *segInDist.DataVersion < segment.GetDataVersion() {
-			return true
-		}
-		// Trigger reopen when dist manifest is older than target manifest.
-		// If dist manifest is same or newer (e.g., loaded after L0 compaction updated DataCoord),
-		// the data is already up-to-date and no reopen is needed.
-		cmp, err := packed.CompareManifestPath(segInDist.ManifestPath, segment.GetManifestPath())
+		// Trigger reopen when the loaded segment is behind the target. The helper
+		// checks DataVersion before manifest readiness, so storage v2 binlog changes
+		// still trigger Reopen when manifest paths are not comparable. A nil
+		// DataVersion from an old QueryNode is treated as compatible to avoid an
+		// endless Reopen loop, while Storage v3 relies on manifest readiness only.
+		ready, err := utils.IsSegmentDataReadyForTarget(segInDist, segment)
 		if err != nil {
 			mlog.RatedWarn(ctx, rate.Limit(10), "manifest path not comparable, skip reopen",
 				mlog.FieldSegmentID(segment.GetID()),
@@ -354,7 +346,7 @@ func (c *SegmentChecker) getSealedSegmentDiff(
 				mlog.Err(err))
 			return false
 		}
-		return cmp < 0
+		return !ready
 	}
 
 	nextTargetExist := c.targetMgr.IsNextTargetExist(ctx, collectionID)
@@ -463,17 +455,39 @@ func (c *SegmentChecker) filterOutSegmentInUse(ctx context.Context, replica *met
 			continue
 		}
 
-		stillInUseByDelegator := false
-		// if delegator has valid target version, and before it update to latest readable version, skip release it's sealed segment
-		for _, delegator := range delegatorList {
-			// Notice: if syncTargetVersion stuck, segment on delegator won't be released
-			readableVersionNotUpdate := delegator.View.TargetVersion != initialTargetVersion && delegator.View.TargetVersion < currentTargetVersion
-			if partition != nil && readableVersionNotUpdate {
-				// leader view version hasn't been updated, segment maybe still in use
-				stillInUseByDelegator = true
-				break
-			}
-		}
+		// Release a sealed segment only after every delegator with a synced target
+		// has converged to the current target version. A delegator on another target
+		// may still serve an older or orphaned readable snapshot that references the
+		// segment. The initial target version means no target has been synced yet and
+		// does not block release.
+		//
+		// This conservative safety barrier has two liveness risks:
+		//
+		//  1. Obsolete segments are retained while target convergence is in progress,
+		//     increasing QueryNode memory usage. If the retained data leaves
+		//     insufficient capacity to load the next target, current-target promotion
+		//     and segment release can stall each other. Increase QueryNode capacity to
+		//     allow the next target to finish loading.
+		//
+		//  2. Replacing the next target while a target transition is in progress can
+		//     cause permanent convergence starvation. For example, current may remain
+		//     at V1 while different delegators are serving V2 and V3. If next is
+		//     replaced from V4 to V5 before all delegators reach V4, and this keeps
+		//     happening, no target generation can be fully synchronized and promoted
+		//     to current. Because release requires every synced delegator to match
+		//     current, obsolete segments will then remain blocked indefinitely.
+		//
+		//     Progress-aware automatic refreshes therefore retain a healthy next target
+		//     while replica-scoped segment and channel readiness keeps advancing. A
+		//     stale target or an explicit manual refresh may intentionally replace the
+		//     selected target and restart the transition.
+		//
+		// Do not bypass this barrier to recover from either condition, since doing so
+		// may release segments still referenced by a readable snapshot.
+		stillInUseByDelegator := partition != nil && lo.ContainsBy(delegatorList, func(delegator *meta.DmChannel) bool {
+			return delegator.View.TargetVersion != initialTargetVersion &&
+				delegator.View.TargetVersion != currentTargetVersion
+		})
 
 		if !stillInUseByDelegator {
 			notUsed = append(notUsed, s)

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -36,12 +37,16 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
+
+type mockeyTargetManager struct{ meta.TargetManagerInterface }
 
 type SegmentCheckerTestSuite struct {
 	suite.Suite
@@ -1136,17 +1141,12 @@ func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentInUse() {
 		utils.CreateTestSegment(collectionID, partitionID, segmentID3, nodeID1, 1, channel),
 	}
 
-	// Setup target to have a current version
-	channels := []*datapb.VchannelInfo{
-		{
-			CollectionID: collectionID,
-			ChannelName:  channel,
-		},
-	}
-	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).Return(
-		channels, []*datapb.SegmentInfo{}, nil).Maybe()
-	checker.targetMgr.UpdateCollectionCurrentTarget(ctx, collectionID)
-	currentTargetVersion := checker.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.CurrentTarget)
+	currentTargetVersion := int64(2)
+	mockTargetVersion := mockey.Mock((*mockeyTargetManager).GetCollectionTargetVersion).
+		Return(currentTargetVersion).
+		Build()
+	defer mockTargetVersion.UnPatch()
+	checker.targetMgr = &mockeyTargetManager{}
 
 	// Helper to get ch2DelegatorList
 	getCh2DelegatorList := func() map[string][]*meta.DmChannel {
@@ -1159,7 +1159,7 @@ func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentInUse() {
 	// Test case 1: No leader views - should skip releasing segments
 	ch2DelegatorList := getCh2DelegatorList()
 	result := checker.filterOutSegmentInUse(ctx, replica, segments, ch2DelegatorList)
-	suite.Equal(0, len(result), "Should return all segments when no leader views")
+	suite.Equal(0, len(result), "No segment should be releasable when there are no leader views")
 
 	// Test case 2: Leader view with outdated target version - segment should be filtered (still in use)
 	leaderView1 := utils.CreateTestLeaderView(nodeID1, collectionID, channel,
@@ -1198,7 +1198,7 @@ func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentInUse() {
 	// Test case 4: Leader view with initial target version - segment should not be filtered
 	leaderView3 := utils.CreateTestLeaderView(nodeID2, collectionID, channel,
 		map[int64]int64{}, map[int64]*meta.Segment{})
-	leaderView3.TargetVersion = initialTargetVersion
+	leaderView3.TargetVersion = 0
 	checker.dist.ChannelDistManager.Update(nodeID2, &meta.DmChannel{
 		VchannelInfo: &datapb.VchannelInfo{
 			CollectionID: collectionID,
@@ -1210,9 +1210,26 @@ func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentInUse() {
 
 	ch2DelegatorList = getCh2DelegatorList()
 	result = checker.filterOutSegmentInUse(ctx, replica, []*meta.Segment{segments[1]}, ch2DelegatorList)
-	suite.Len(result, 1, "Segment should not be filtered when leader has initial target version")
+	suite.Len(result, 1, "Segment should not be filtered when leader has no synced target")
 
-	// Test case 5: Multiple leader views with mixed versions - segment should be filtered (still in use)
+	// Test case 5: Leader view ahead of current target - segment should be filtered (still in use)
+	leaderViewAhead := utils.CreateTestLeaderView(nodeID2, collectionID, channel,
+		map[int64]int64{}, map[int64]*meta.Segment{})
+	leaderViewAhead.TargetVersion = currentTargetVersion + 1
+	checker.dist.ChannelDistManager.Update(nodeID2, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: collectionID,
+			ChannelName:  channel,
+		},
+		Node: nodeID2,
+		View: leaderViewAhead,
+	})
+
+	ch2DelegatorList = getCh2DelegatorList()
+	result = checker.filterOutSegmentInUse(ctx, replica, []*meta.Segment{segments[1]}, ch2DelegatorList)
+	suite.Len(result, 0, "Segment should be filtered when leader is ahead of the current target")
+
+	// Test case 6: Multiple leader views with mixed versions - segment should be filtered (still in use)
 	leaderView4 := utils.CreateTestLeaderView(nodeID1, collectionID, channel,
 		map[int64]int64{}, map[int64]*meta.Segment{})
 	leaderView4.TargetVersion = currentTargetVersion - 1 // Outdated
@@ -1244,13 +1261,13 @@ func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentInUse() {
 
 	ch2DelegatorList = getCh2DelegatorList()
 	result = checker.filterOutSegmentInUse(ctx, replica, testSegments, ch2DelegatorList)
-	suite.Len(result, 0, "Should release all segments when any delegator hasn't updated")
+	suite.Len(result, 0, "No segment should be releasable when any delegator has not updated")
 
-	// Test case 6: Partition is nil - should release all segments (no partition info)
-	checker.meta.RemovePartition(ctx, partitionID)
+	// Test case 7: Partition is nil - should release all segments (no partition info)
+	suite.NoError(checker.meta.RemovePartition(ctx, collectionID, partitionID))
 	ch2DelegatorList = getCh2DelegatorList()
 	result = checker.filterOutSegmentInUse(ctx, replica, []*meta.Segment{segments[0]}, ch2DelegatorList)
-	suite.Len(result, 0, "Should release all segments when partition is nil")
+	suite.Len(result, 1, "Segment should be releasable when partition is nil")
 }
 
 func (suite *SegmentCheckerTestSuite) TestReopenOnStaleDataVersion() {
@@ -1276,10 +1293,11 @@ func (suite *SegmentCheckerTestSuite) TestReopenOnStaleDataVersion() {
 	// target carries a newer DataVersion than the loaded segment in dist
 	segments := []*datapb.SegmentInfo{
 		{
-			ID:            1,
-			PartitionID:   1,
-			InsertChannel: "test-insert-channel",
-			DataVersion:   2,
+			ID:             1,
+			PartitionID:    1,
+			InsertChannel:  "test-insert-channel",
+			DataVersion:    2,
+			StorageVersion: storage.StorageV2,
 		},
 	}
 	channels := []*datapb.VchannelInfo{
@@ -1294,6 +1312,7 @@ func (suite *SegmentCheckerTestSuite) TestReopenOnStaleDataVersion() {
 
 	// dist has the segment loaded with an older DataVersion
 	distSegment := utils.CreateTestSegment(1, 1, 1, 2, 1, "test-insert-channel")
+	distSegment.StorageVersion = storage.StorageV2
 	distSegment.DataVersion = proto.Int32(1)
 	checker.dist.SegmentDistManager.Update(2, distSegment)
 	checker.dist.ChannelDistManager.Update(2, &meta.DmChannel{
@@ -1337,6 +1356,28 @@ func (suite *SegmentCheckerTestSuite) TestReopenOnStaleDataVersion() {
 	// DataVersion must not be used as a Reopen trigger to avoid an infinite loop.
 	addedTasks = nil
 	distSegment.DataVersion = nil
+	checker.dist.SegmentDistManager.Update(2, distSegment)
+	delete(checker.versionCache, int64(1))
+	tasks = checker.Check(context.TODO())
+	suite.Len(tasks, 0)
+	suite.Len(addedTasks, 0)
+
+	// Storage v3 readiness is determined by manifest, so an older DataVersion
+	// alone must not trigger Reopen.
+	addedTasks = nil
+	manifest := packed.MarshalManifestPath("/test/segment", 1)
+	segments[0] = &datapb.SegmentInfo{
+		ID:             1,
+		PartitionID:    1,
+		InsertChannel:  "test-insert-channel",
+		DataVersion:    2,
+		StorageVersion: storage.StorageV3,
+		ManifestPath:   manifest,
+	}
+	suite.NoError(checker.targetMgr.UpdateCollectionNextTarget(ctx, int64(1)))
+	distSegment.StorageVersion = storage.StorageV3
+	distSegment.ManifestPath = manifest
+	distSegment.DataVersion = proto.Int32(1)
 	checker.dist.SegmentDistManager.Update(2, distSegment)
 	delete(checker.versionCache, int64(1))
 	tasks = checker.Check(context.TODO())

--- a/internal/querycoordv2/job/job_release_test.go
+++ b/internal/querycoordv2/job/job_release_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -40,6 +41,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 )
+
+type releaseJobTargetManager struct{ meta.TargetManagerInterface }
 
 type releaseJobCatalog struct {
 	metastore.QueryCoordCatalog
@@ -143,12 +146,33 @@ func newReleaseCollectionJobMeta(t *testing.T, collectionID, replicaID int64, no
 func newReleaseJobDeps(t *testing.T, m *meta.Meta, dist *meta.DistributionManager) (*observers.TargetObserver, *checkers.CheckerController, proxyutil.ProxyClientManagerInterface) {
 	t.Helper()
 
-	targetMgr := meta.NewMockTargetManager(t)
-	targetMgr.EXPECT().IsNextTargetExist(mock.Anything, mock.Anything).Return(true).Maybe()
-	targetMgr.EXPECT().IsCurrentTargetExist(mock.Anything, mock.Anything, mock.Anything).Return(true).Maybe()
-	targetMgr.EXPECT().GetDmChannelsByCollection(mock.Anything, mock.Anything, mock.Anything).Return(map[string]*meta.DmChannel{}).Maybe()
-	targetMgr.EXPECT().UpdateCollectionNextTarget(mock.Anything, mock.Anything).Return(nil).Maybe()
-	targetMgr.EXPECT().RemoveCollection(mock.Anything, mock.Anything).Return().Maybe()
+	targetMgr := &releaseJobTargetManager{}
+	mockIsNextTargetExist := mockey.Mock((*releaseJobTargetManager).IsNextTargetExist).
+		Return(true).
+		Build()
+	mockIsCurrentTargetExist := mockey.Mock((*releaseJobTargetManager).IsCurrentTargetExist).
+		Return(true).
+		Build()
+	mockGetDmChannels := mockey.Mock((*releaseJobTargetManager).GetDmChannelsByCollection).
+		Return(map[string]*meta.DmChannel{}).
+		Build()
+	mockUpdateNextTarget := mockey.Mock((*releaseJobTargetManager).UpdateCollectionNextTarget).
+		Return(nil).
+		Build()
+	mockRemoveCollection := mockey.Mock((*releaseJobTargetManager).RemoveCollection).
+		Return().
+		Build()
+	mockGetTargetVersion := mockey.Mock((*releaseJobTargetManager).GetCollectionTargetVersion).
+		Return(int64(0)).
+		Build()
+	t.Cleanup(func() {
+		mockGetTargetVersion.UnPatch()
+		mockRemoveCollection.UnPatch()
+		mockUpdateNextTarget.UnPatch()
+		mockGetDmChannels.UnPatch()
+		mockIsCurrentTargetExist.UnPatch()
+		mockIsNextTargetExist.UnPatch()
+	})
 	nodeMgr := session.NewNodeManager()
 
 	targetObserver := observers.NewTargetObserver(m, targetMgr, dist, nil, nil, nodeMgr)

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -73,6 +73,15 @@ type targetUpdateRequest struct {
 
 type initRequest struct{}
 
+type nextTargetProgress struct {
+	targetVersion        int64
+	readySegmentReplicas int
+	readyReplicaChannels int
+	// lastUpdated records when this target version was installed or when its
+	// readiness last advanced.
+	lastUpdated time.Time
+}
+
 type TargetObserver struct {
 	cancel    context.CancelFunc
 	wg        sync.WaitGroup
@@ -84,11 +93,16 @@ type TargetObserver struct {
 	nodeMgr   *session.NodeManager
 
 	initChan chan initRequest
-	// nextTargetLastUpdate map[int64]time.Time
-	nextTargetLastUpdate *typeutil.ConcurrentMap[int64, time.Time]
-	updateChan           chan targetUpdateRequest
-	mut                  sync.Mutex                // Guard readyNotifiers
-	readyNotifiers       map[int64][]chan struct{} // CollectionID -> Notifiers
+	// nextTargetProgresses records the loading progress checkpoint for each
+	// collection's next target.
+	nextTargetProgresses *typeutil.ConcurrentMap[int64, nextTargetProgress]
+	// nextTargetStale records collections whose next target must be refreshed.
+	// A refresh consumes the marker before the RPC and restores it on failure or
+	// no-op, so a notification arriving during the RPC remains pending.
+	nextTargetStale *typeutil.ConcurrentSet[int64]
+	updateChan      chan targetUpdateRequest
+	mut             sync.Mutex                // Guard readyNotifiers
+	readyNotifiers  map[int64][]chan struct{} // CollectionID -> Notifiers
 
 	// loadingDispatcher updates targets for collections that are loading (also collections without a current target).
 	loadingDispatcher *taskDispatcher[int64]
@@ -116,7 +130,8 @@ func NewTargetObserver(
 		broker:               broker,
 		cluster:              cluster,
 		nodeMgr:              nodeMgr,
-		nextTargetLastUpdate: typeutil.NewConcurrentMap[int64, time.Time](),
+		nextTargetProgresses: typeutil.NewConcurrentMap[int64, nextTargetProgress](),
+		nextTargetStale:      typeutil.NewConcurrentSet[int64](),
 		updateChan:           make(chan targetUpdateRequest, 10),
 		readyNotifiers:       make(map[int64][]chan struct{}),
 		initChan:             make(chan initRequest),
@@ -298,6 +313,19 @@ func (ob *TargetObserver) TriggerUpdateCurrentTarget(collectionID int64) {
 	ob.loadingDispatcher.AddTask(collectionID)
 }
 
+// MarkNextTargetStale marks the collection's next target as stale when the
+// failed segment still belongs to that target.
+func (ob *TargetObserver) MarkNextTargetStale(collectionID, segmentID int64) {
+	if ob.targetMgr.GetSealedSegment(context.TODO(), collectionID, segmentID, meta.NextTarget) == nil {
+		return
+	}
+
+	// A concurrent target replacement can turn this into a conservative false
+	// positive. That only causes an extra refresh and avoids coupling tasks to a
+	// target generation.
+	ob.nextTargetStale.Upsert(collectionID)
+}
+
 func (ob *TargetObserver) check(ctx context.Context, collectionID int64) {
 	ob.keylocks.Lock(collectionID)
 	defer ob.keylocks.Unlock(collectionID)
@@ -313,7 +341,9 @@ func (ob *TargetObserver) check(ctx context.Context, collectionID int64) {
 
 	if ob.shouldUpdateNextTarget(ctx, collectionID) {
 		// update next target in collection level
-		ob.updateNextTarget(ctx, collectionID)
+		if err := ob.updateNextTarget(ctx, collectionID); err != nil {
+			return
+		}
 
 		// sync next target to delegator if current target not exist, to support partial search
 		if !ob.targetMgr.IsCurrentTargetExist(ctx, collectionID, -1) {
@@ -327,6 +357,7 @@ func (ob *TargetObserver) check(ctx context.Context, collectionID int64) {
 }
 
 func (ob *TargetObserver) init(ctx context.Context, collectionID int64) {
+	ob.keylocks.Lock(collectionID)
 	// pull next target first if not exist
 	if !ob.targetMgr.IsNextTargetExist(ctx, collectionID) {
 		ob.updateNextTarget(ctx, collectionID)
@@ -336,6 +367,8 @@ func (ob *TargetObserver) init(ctx context.Context, collectionID int64) {
 	if ob.shouldUpdateCurrentTarget(ctx, collectionID) {
 		ob.updateCurrentTarget(ctx, collectionID)
 	}
+	ob.keylocks.Unlock(collectionID)
+
 	// refresh collection loading status upon restart
 	ob.check(ctx, collectionID)
 }
@@ -396,10 +429,16 @@ func (ob *TargetObserver) ReleasePartition(collectionID int64, partitionID ...in
 
 func (ob *TargetObserver) clean() {
 	collectionSet := typeutil.NewUniqueSet(ob.meta.GetAll(context.TODO())...)
-	// for collection which has been removed from target, try to clear nextTargetLastUpdate
-	ob.nextTargetLastUpdate.Range(func(collectionID int64, _ time.Time) bool {
+	// Clear next target progress for collections that have been removed.
+	ob.nextTargetProgresses.Range(func(collectionID int64, _ nextTargetProgress) bool {
 		if !collectionSet.Contain(collectionID) {
-			ob.nextTargetLastUpdate.Remove(collectionID)
+			ob.nextTargetProgresses.Remove(collectionID)
+		}
+		return true
+	})
+	ob.nextTargetStale.Range(func(collectionID int64) bool {
+		if !collectionSet.Contain(collectionID) {
+			ob.nextTargetStale.Remove(collectionID)
 		}
 		return true
 	})
@@ -416,37 +455,182 @@ func (ob *TargetObserver) clean() {
 	}
 }
 
+// shouldUpdateNextTarget determines whether the observer should refresh the
+// collection's next target. A missing next target is created normally. An
+// existing next target is force-refreshed by either of these mechanisms:
+//  1. The scheduler marks it stale after a target segment can no longer be
+//     loaded, for example when a load task returns ErrSegmentNotFound.
+//  2. Replica-scoped segment and channel readiness does not advance during
+//     NextTargetSurviveTime. A target version change or progress in any tracked
+//     readiness dimension establishes a new baseline and restarts the timer.
 func (ob *TargetObserver) shouldUpdateNextTarget(ctx context.Context, collectionID int64) bool {
-	return !ob.targetMgr.IsNextTargetExist(ctx, collectionID) || ob.isNextTargetExpired(collectionID)
-}
-
-func (ob *TargetObserver) isNextTargetExpired(collectionID int64) bool {
-	lastUpdated, has := ob.nextTargetLastUpdate.Get(collectionID)
-	if !has {
+	if ob.nextTargetStale.Contain(collectionID) {
+		mlog.Info(ctx, "force update next target",
+			mlog.FieldCollectionID(collectionID),
+			mlog.String("reason", "next target is marked stale"))
 		return true
 	}
-	return time.Since(lastUpdated) > params.Params.QueryCoordCfg.NextTargetSurviveTime.GetAsDuration(time.Second)
+
+	if !ob.targetMgr.IsNextTargetExist(ctx, collectionID) {
+		return true
+	}
+
+	nextVersion := ob.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
+	progress, hasProgress := ob.nextTargetProgresses.Get(collectionID)
+	if !hasProgress {
+		mlog.Info(ctx, "force update next target",
+			mlog.FieldCollectionID(collectionID),
+			mlog.Int64("targetVersion", nextVersion),
+			mlog.String("reason", "next target progress is missing"))
+		return true
+	}
+	if progress.targetVersion != nextVersion {
+		ob.recordNextTargetProgress(collectionID, ob.sampleNextTargetProgress(ctx, collectionID, nextVersion))
+		return false
+	}
+
+	if time.Since(progress.lastUpdated) <= params.Params.QueryCoordCfg.NextTargetSurviveTime.GetAsDuration(time.Second) {
+		return false
+	}
+
+	currentProgress := ob.sampleNextTargetProgress(ctx, collectionID, nextVersion)
+	if currentProgress.readySegmentReplicas > progress.readySegmentReplicas ||
+		currentProgress.readyReplicaChannels > progress.readyReplicaChannels {
+		// Preserve high-water counts so readiness oscillation cannot reset the timer.
+		currentProgress.readySegmentReplicas = max(currentProgress.readySegmentReplicas, progress.readySegmentReplicas)
+		currentProgress.readyReplicaChannels = max(currentProgress.readyReplicaChannels, progress.readyReplicaChannels)
+		ob.recordNextTargetProgress(collectionID, currentProgress)
+		return false
+	}
+
+	mlog.Info(ctx, "force update next target",
+		mlog.FieldCollectionID(collectionID),
+		mlog.Int64("targetVersion", nextVersion),
+		mlog.Int("previousReadySegmentReplicas", progress.readySegmentReplicas),
+		mlog.Int("readySegmentReplicas", currentProgress.readySegmentReplicas),
+		mlog.Int("previousReadyReplicaChannels", progress.readyReplicaChannels),
+		mlog.Int("readyReplicaChannels", currentProgress.readyReplicaChannels),
+		mlog.String("reason", "next target loading made no progress"))
+	return true
 }
 
 func (ob *TargetObserver) updateNextTarget(ctx context.Context, collectionID int64) error {
 	log := mlog.With(mlog.FieldCollectionID(collectionID))
+	oldVersion := ob.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
+	hadStale := ob.nextTargetStale.TryRemove(collectionID)
 
 	log.RatedInfo(ctx, rate.Limit(10), "observer trigger update next target")
 	err := ob.targetMgr.UpdateCollectionNextTarget(ctx, collectionID)
 	if err != nil {
+		if hadStale {
+			ob.nextTargetStale.Upsert(collectionID)
+		}
 		log.Warn(ctx, "failed to update next target for collection",
 			mlog.Err(err))
 		return err
 	}
-	ob.updateNextTargetTimestamp(collectionID)
+
+	newVersion := ob.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
+	if newVersion <= oldVersion {
+		if hadStale {
+			ob.nextTargetStale.Upsert(collectionID)
+		}
+		log.RatedInfo(ctx, rate.Limit(10), "next target refresh did not install a new version",
+			mlog.Int64("oldVersion", oldVersion),
+			mlog.Int64("newVersion", newVersion))
+		return nil
+	}
+
+	ob.recordNextTargetProgress(collectionID, ob.sampleNextTargetProgress(ctx, collectionID, newVersion))
 	return nil
 }
 
-func (ob *TargetObserver) updateNextTargetTimestamp(collectionID int64) {
-	ob.nextTargetLastUpdate.Insert(collectionID, time.Now())
+func (ob *TargetObserver) recordNextTargetProgress(collectionID int64, progress nextTargetProgress) {
+	progress.lastUpdated = time.Now()
+	ob.nextTargetProgresses.Insert(collectionID, progress)
+}
+
+func (ob *TargetObserver) sampleNextTargetProgress(ctx context.Context, collectionID, targetVersion int64) nextTargetProgress {
+	return nextTargetProgress{
+		targetVersion:        targetVersion,
+		readySegmentReplicas: ob.countReadyNextTargetSegmentReplicas(ctx, collectionID),
+		readyReplicaChannels: ob.countReadyNextTargetReplicaChannels(ctx, collectionID, targetVersion),
+	}
+}
+
+func (ob *TargetObserver) countReadyNextTargetSegmentReplicas(ctx context.Context, collectionID int64) int {
+	targetSegments := ob.targetMgr.GetSealedSegmentsByCollection(ctx, collectionID, meta.NextTarget)
+	distSegments := ob.distMgr.SegmentDistManager.GetByFilter(meta.WithCollectionID(collectionID))
+	readySegmentReplicas := 0
+
+	for _, replica := range ob.meta.GetByCollection(ctx, collectionID) {
+		replicaSegments := make(map[int64][]*meta.Segment)
+		for _, segment := range distSegments {
+			if _, ok := targetSegments[segment.GetID()]; ok && replica.Contains(segment.Node) {
+				replicaSegments[segment.GetID()] = append(replicaSegments[segment.GetID()], segment)
+			}
+		}
+
+		for segmentID, targetSegment := range targetSegments {
+			segments := replicaSegments[segmentID]
+			if len(segments) == 0 {
+				continue
+			}
+
+			ready := lo.ContainsBy(segments, func(segment *meta.Segment) bool {
+				segmentReady, err := utils.IsSegmentDataReadyForTarget(segment, targetSegment)
+				// Progress sampling treats comparison errors as not ready. Detailed
+				// diagnostics remain in CheckSegmentDataReady, avoiding log noise from
+				// repeated periodic samples.
+				return err == nil && segmentReady
+			})
+			if ready {
+				readySegmentReplicas++
+			}
+		}
+	}
+
+	return readySegmentReplicas
+}
+
+func (ob *TargetObserver) countReadyNextTargetReplicaChannels(ctx context.Context, collectionID, targetVersion int64) int {
+	targetChannels := ob.targetMgr.GetDmChannelsByCollection(ctx, collectionID, meta.NextTarget)
+	readyReplicaChannels := 0
+
+	for _, replica := range ob.meta.GetByCollection(ctx, collectionID) {
+		for channelName := range targetChannels {
+			delegators := ob.distMgr.ChannelDistManager.GetByFilter(
+				meta.WithReplica2Channel(replica),
+				meta.WithChannelName2Channel(channelName),
+			)
+
+			if lo.ContainsBy(delegators, func(delegator *meta.DmChannel) bool {
+				delegatorDataReady, delegatorSynced, _ := ob.getDelegatorReadiness(delegator, targetVersion)
+				return delegatorDataReady || delegatorSynced
+			}) {
+				readyReplicaChannels++
+			}
+		}
+	}
+
+	return readyReplicaChannels
+}
+
+func (ob *TargetObserver) getDelegatorReadiness(channel *meta.DmChannel, targetVersion int64) (bool, bool, error) {
+	if channel == nil || channel.View == nil {
+		return false, false, nil
+	}
+	err := utils.CheckDelegatorDataReady(ob.nodeMgr, ob.targetMgr, channel.View, meta.NextTarget)
+	dataReady := err == nil
+	synced := targetVersion == channel.View.TargetVersion && channel.IsServiceable()
+	return dataReady, synced, err
 }
 
 func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collectionID int64) bool {
+	if ob.nextTargetStale.Contain(collectionID) {
+		return false
+	}
+
 	replicaNum := ob.meta.GetReplicaNumber(ctx, collectionID)
 	log := mlog.With(
 		mlog.FieldCollectionID(collectionID),
@@ -468,22 +652,28 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 	// 1. Its target version matches the new version and it is serviceable, OR
 	// 2. Its data is ready for the next target (all segments and channels are loaded)
 	checkDelegatorDataReady := func(replica *meta.Replica, channel *meta.DmChannel) bool {
-		err := utils.CheckDelegatorDataReady(ob.nodeMgr, ob.targetMgr, channel.View, meta.NextTarget)
-		dataReadyForNextTarget := err == nil
+		if channel == nil {
+			return false
+		}
+		dataReadyForNextTarget, syncedWithNextTarget, err := ob.getDelegatorReadiness(channel, newVersion)
 		if !dataReadyForNextTarget {
+			delegatorTargetVersion := int64(0)
+			if channel.View != nil {
+				delegatorTargetVersion = channel.View.TargetVersion
+			}
 			log.Info(ctx, "check delegator",
 				mlog.FieldCollectionID(collectionID),
 				mlog.Int64("replicaID", replica.GetID()),
 				mlog.FieldNodeID(channel.Node),
 				mlog.String("channelName", channel.GetChannelName()),
-				mlog.Int64("targetVersion", channel.View.TargetVersion),
+				mlog.Int64("targetVersion", delegatorTargetVersion),
 				mlog.Int64("newTargetVersion", newVersion),
 				mlog.Bool("isServiceable", channel.IsServiceable()),
 				mlog.Int64("version", channel.Version),
 				mlog.Err(err),
 			)
 		}
-		return (newVersion == channel.View.TargetVersion && channel.IsServiceable()) || dataReadyForNextTarget
+		return syncedWithNextTarget || dataReadyForNextTarget
 	}
 
 	// Iterate through each replica to check if all its delegators are ready.
@@ -493,19 +683,14 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 	readyDelegatorsInCollection := make([]*meta.DmChannel, 0)
 	replicas := ob.meta.GetByCollection(ctx, collectionID)
 	for _, replica := range replicas {
-		readyDelegatorsInReplica := make([]*meta.DmChannel, 0)
 		for channel := range channelNames {
 			// Filter delegators by replica to ensure we only check delegators belonging to this replica
 			delegatorList := ob.distMgr.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica), meta.WithChannelName2Channel(channel))
-			readyDelegatorsInChannel := lo.Filter(delegatorList, func(ch *meta.DmChannel, _ int) bool {
-				return checkDelegatorDataReady(replica, ch)
-			})
-
-			if len(readyDelegatorsInChannel) > 0 {
-				readyDelegatorsInReplica = append(readyDelegatorsInReplica, readyDelegatorsInChannel...)
-			}
+			readyDelegatorsInCollection = append(readyDelegatorsInCollection,
+				lo.Filter(delegatorList, func(ch *meta.DmChannel, _ int) bool {
+					return checkDelegatorDataReady(replica, ch)
+				})...)
 		}
-		readyDelegatorsInCollection = append(readyDelegatorsInCollection, readyDelegatorsInReplica...)
 	}
 
 	syncSuccess := ob.syncNextTargetToDelegator(ctx, collectionID, readyDelegatorsInCollection, newVersion)

--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -96,13 +96,14 @@ type TargetObserver struct {
 	// nextTargetProgresses records the loading progress checkpoint for each
 	// collection's next target.
 	nextTargetProgresses *typeutil.ConcurrentMap[int64, nextTargetProgress]
-	// nextTargetStale records collections whose next target must be refreshed.
-	// A refresh consumes the marker before the RPC and restores it on failure or
-	// no-op, so a notification arriving during the RPC remains pending.
-	nextTargetStale *typeutil.ConcurrentSet[int64]
-	updateChan      chan targetUpdateRequest
-	mut             sync.Mutex                // Guard readyNotifiers
-	readyNotifiers  map[int64][]chan struct{} // CollectionID -> Notifiers
+	// nextTargetStaleSegments records the target segments that failed with
+	// ErrSegmentNotFound. A refresh only resolves a cause after that segment is
+	// absent from the refreshed next target.
+	nextTargetStaleMu       sync.RWMutex
+	nextTargetStaleSegments map[int64]typeutil.UniqueSet
+	updateChan              chan targetUpdateRequest
+	mut                     sync.Mutex                // Guard readyNotifiers
+	readyNotifiers          map[int64][]chan struct{} // CollectionID -> Notifiers
 
 	// loadingDispatcher updates targets for collections that are loading (also collections without a current target).
 	loadingDispatcher *taskDispatcher[int64]
@@ -124,18 +125,18 @@ func NewTargetObserver(
 	nodeMgr *session.NodeManager,
 ) *TargetObserver {
 	result := &TargetObserver{
-		meta:                 meta,
-		targetMgr:            targetMgr,
-		distMgr:              distMgr,
-		broker:               broker,
-		cluster:              cluster,
-		nodeMgr:              nodeMgr,
-		nextTargetProgresses: typeutil.NewConcurrentMap[int64, nextTargetProgress](),
-		nextTargetStale:      typeutil.NewConcurrentSet[int64](),
-		updateChan:           make(chan targetUpdateRequest, 10),
-		readyNotifiers:       make(map[int64][]chan struct{}),
-		initChan:             make(chan initRequest),
-		keylocks:             lock.NewKeyLock[int64](),
+		meta:                    meta,
+		targetMgr:               targetMgr,
+		distMgr:                 distMgr,
+		broker:                  broker,
+		cluster:                 cluster,
+		nodeMgr:                 nodeMgr,
+		nextTargetProgresses:    typeutil.NewConcurrentMap[int64, nextTargetProgress](),
+		nextTargetStaleSegments: make(map[int64]typeutil.UniqueSet),
+		updateChan:              make(chan targetUpdateRequest, 10),
+		readyNotifiers:          make(map[int64][]chan struct{}),
+		initChan:                make(chan initRequest),
+		keylocks:                lock.NewKeyLock[int64](),
 	}
 
 	result.loadingDispatcher = newTaskDispatcher(result.check)
@@ -316,14 +317,26 @@ func (ob *TargetObserver) TriggerUpdateCurrentTarget(collectionID int64) {
 // MarkNextTargetStale marks the collection's next target as stale when the
 // failed segment still belongs to that target.
 func (ob *TargetObserver) MarkNextTargetStale(collectionID, segmentID int64) {
+	ob.nextTargetStaleMu.Lock()
+	defer ob.nextTargetStaleMu.Unlock()
+
 	if ob.targetMgr.GetSealedSegment(context.TODO(), collectionID, segmentID, meta.NextTarget) == nil {
 		return
 	}
 
-	// A concurrent target replacement can turn this into a conservative false
-	// positive. That only causes an extra refresh and avoids coupling tasks to a
-	// target generation.
-	ob.nextTargetStale.Upsert(collectionID)
+	staleSegments := ob.nextTargetStaleSegments[collectionID]
+	if staleSegments == nil {
+		staleSegments = typeutil.NewUniqueSet()
+		ob.nextTargetStaleSegments[collectionID] = staleSegments
+	}
+	staleSegments.Insert(segmentID)
+}
+
+func (ob *TargetObserver) isNextTargetStale(collectionID int64) bool {
+	ob.nextTargetStaleMu.RLock()
+	defer ob.nextTargetStaleMu.RUnlock()
+
+	return ob.nextTargetStaleSegments[collectionID].Len() > 0
 }
 
 func (ob *TargetObserver) check(ctx context.Context, collectionID int64) {
@@ -436,12 +449,13 @@ func (ob *TargetObserver) clean() {
 		}
 		return true
 	})
-	ob.nextTargetStale.Range(func(collectionID int64) bool {
+	ob.nextTargetStaleMu.Lock()
+	for collectionID := range ob.nextTargetStaleSegments {
 		if !collectionSet.Contain(collectionID) {
-			ob.nextTargetStale.Remove(collectionID)
+			delete(ob.nextTargetStaleSegments, collectionID)
 		}
-		return true
-	})
+	}
+	ob.nextTargetStaleMu.Unlock()
 
 	ob.mut.Lock()
 	defer ob.mut.Unlock()
@@ -464,7 +478,7 @@ func (ob *TargetObserver) clean() {
 //     NextTargetSurviveTime. A target version change or progress in any tracked
 //     readiness dimension establishes a new baseline and restarts the timer.
 func (ob *TargetObserver) shouldUpdateNextTarget(ctx context.Context, collectionID int64) bool {
-	if ob.nextTargetStale.Contain(collectionID) {
+	if ob.isNextTargetStale(collectionID) {
 		mlog.Info(ctx, "force update next target",
 			mlog.FieldCollectionID(collectionID),
 			mlog.String("reason", "next target is marked stale"))
@@ -517,14 +531,10 @@ func (ob *TargetObserver) shouldUpdateNextTarget(ctx context.Context, collection
 func (ob *TargetObserver) updateNextTarget(ctx context.Context, collectionID int64) error {
 	log := mlog.With(mlog.FieldCollectionID(collectionID))
 	oldVersion := ob.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
-	hadStale := ob.nextTargetStale.TryRemove(collectionID)
 
 	log.RatedInfo(ctx, rate.Limit(10), "observer trigger update next target")
 	err := ob.targetMgr.UpdateCollectionNextTarget(ctx, collectionID)
 	if err != nil {
-		if hadStale {
-			ob.nextTargetStale.Upsert(collectionID)
-		}
 		log.Warn(ctx, "failed to update next target for collection",
 			mlog.Err(err))
 		return err
@@ -532,10 +542,28 @@ func (ob *TargetObserver) updateNextTarget(ctx context.Context, collectionID int
 
 	newVersion := ob.targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
 	if newVersion <= oldVersion {
-		if hadStale {
-			ob.nextTargetStale.Upsert(collectionID)
-		}
 		log.RatedInfo(ctx, rate.Limit(10), "next target refresh did not install a new version",
+			mlog.Int64("oldVersion", oldVersion),
+			mlog.Int64("newVersion", newVersion))
+		return nil
+	}
+
+	ob.nextTargetStaleMu.Lock()
+	staleSegments := ob.nextTargetStaleSegments[collectionID]
+	for segmentID := range staleSegments {
+		if ob.targetMgr.GetSealedSegment(ctx, collectionID, segmentID, meta.NextTarget) == nil {
+			staleSegments.Remove(segmentID)
+		}
+	}
+	remainingStaleSegments := staleSegments.Collect()
+	if len(remainingStaleSegments) == 0 {
+		delete(ob.nextTargetStaleSegments, collectionID)
+	}
+	ob.nextTargetStaleMu.Unlock()
+
+	if len(remainingStaleSegments) > 0 {
+		log.RatedInfo(ctx, rate.Limit(10), "next target refresh still contains stale segments",
+			mlog.Int64s("segmentIDs", remainingStaleSegments),
 			mlog.Int64("oldVersion", oldVersion),
 			mlog.Int64("newVersion", newVersion))
 		return nil
@@ -627,7 +655,7 @@ func (ob *TargetObserver) getDelegatorReadiness(channel *meta.DmChannel, targetV
 }
 
 func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collectionID int64) bool {
-	if ob.nextTargetStale.Contain(collectionID) {
+	if ob.isNextTargetStale(collectionID) {
 		return false
 	}
 

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -36,6 +37,7 @@ import (
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -64,6 +66,107 @@ type TargetObserverSuite struct {
 	nextTargetSegments []*datapb.SegmentInfo
 	nextTargetChannels []*datapb.VchannelInfo
 	ctx                context.Context
+}
+
+type mockeyTargetManager struct{ meta.TargetManagerInterface }
+
+func TestInitSerializesTargetRefresh(t *testing.T) {
+	paramtable.Init()
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	collectionMgr := meta.NewCollectionManager(nil)
+	assert.NoError(t, collectionMgr.PutCollectionWithoutSave(ctx, utils.CreateTestCollection(collectionID, 1)))
+	metaInstance := &meta.Meta{
+		CollectionManager: collectionMgr,
+		ReplicaManager:    meta.NewReplicaManager(nil, nil),
+	}
+
+	updateEntered := make(chan struct{})
+	allowUpdateReturn := make(chan struct{})
+	nextTargetExists := false
+	nextTargetVersion := int64(0)
+	targetMgr := &mockeyTargetManager{}
+	mockNextTargetExists := mockey.Mock((*mockeyTargetManager).IsNextTargetExist).
+		To(func(_ *mockeyTargetManager, _ context.Context, _ int64) bool {
+			return nextTargetExists
+		}).
+		Build()
+	defer mockNextTargetExists.UnPatch()
+	mockUpdateNextTarget := mockey.Mock((*mockeyTargetManager).UpdateCollectionNextTarget).
+		To(func(_ *mockeyTargetManager, _ context.Context, _ int64) error {
+			close(updateEntered)
+			<-allowUpdateReturn
+			nextTargetExists = true
+			nextTargetVersion = 1
+			return nil
+		}).
+		Build()
+	defer mockUpdateNextTarget.UnPatch()
+	mockNextTargetVersion := mockey.Mock((*mockeyTargetManager).GetCollectionTargetVersion).
+		To(func(_ *mockeyTargetManager, _ context.Context, _ int64, _ meta.TargetScope) int64 {
+			return nextTargetVersion
+		}).
+		Build()
+	defer mockNextTargetVersion.UnPatch()
+	mockNextTargetSegments := mockey.Mock((*mockeyTargetManager).GetSealedSegmentsByCollection).
+		Return(map[int64]*datapb.SegmentInfo{}).
+		Build()
+	defer mockNextTargetSegments.UnPatch()
+	mockNextTargetChannels := mockey.Mock((*mockeyTargetManager).GetDmChannelsByCollection).
+		Return(map[string]*meta.DmChannel{}).
+		Build()
+	defer mockNextTargetChannels.UnPatch()
+
+	nodeMgr := session.NewNodeManager()
+	observer := NewTargetObserver(
+		metaInstance,
+		targetMgr,
+		meta.NewDistributionManager(nodeMgr),
+		nil,
+		nil,
+		nodeMgr,
+	)
+
+	initDone := make(chan struct{})
+	go func() {
+		defer close(initDone)
+		observer.init(ctx, collectionID)
+	}()
+
+	select {
+	case <-updateEntered:
+	case <-time.After(5 * time.Second):
+		close(allowUpdateReturn)
+		t.Fatal("target refresh did not start")
+	}
+	lockAcquiredDuringRefresh := observer.keylocks.TryLock(collectionID)
+	if lockAcquiredDuringRefresh {
+		observer.keylocks.Unlock(collectionID)
+	}
+	close(allowUpdateReturn)
+
+	select {
+	case <-initDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("target observer init did not finish")
+	}
+	assert.False(t, lockAcquiredDuringRefresh)
+}
+
+func setNextTargetProgressLastUpdated(
+	t *testing.T,
+	observer *TargetObserver,
+	collectionID int64,
+	lastUpdated time.Time,
+) {
+	t.Helper()
+	progress, ok := observer.nextTargetProgresses.Get(collectionID)
+	if !assert.True(t, ok) {
+		return
+	}
+	progress.lastUpdated = lastUpdated
+	observer.nextTargetProgresses.Insert(collectionID, progress)
 }
 
 func (suite *TargetObserverSuite) SetupSuite() {
@@ -605,7 +708,7 @@ func TestShouldUpdateCurrentTarget_ReplicaReadiness(t *testing.T) {
 
 // TestShouldUpdateCurrentTarget_OnlyReadyDelegatorsSynced verifies that only ready delegators
 // are included in the sync operation. This test specifically validates the fix for the bug where
-// all delegators (including non-ready ones) were being added to readyDelegatorsInReplica.
+// non-ready delegators were included in the collection-wide sync list.
 func TestShouldUpdateCurrentTarget_OnlyReadyDelegatorsSynced(t *testing.T) {
 	paramtable.Init()
 	ctx := context.Background()
@@ -733,11 +836,347 @@ func TestShouldUpdateCurrentTarget_OnlyReadyDelegatorsSynced(t *testing.T) {
 	assert.True(t, result)
 
 	// Verify that ONLY node 1 received SyncDistribution call
-	// This is the key assertion: if the bug existed (using delegatorList instead of readyDelegatorsInChannel),
+	// This is the key assertion: if the unfiltered delegator list were used,
 	// node 2 would also receive a SyncDistribution call
 	assert.Equal(t, 1, len(syncedNodes), "Expected only 1 SyncDistribution call for the ready delegator")
 	assert.Contains(t, syncedNodes, int64(1), "Expected node 1 (ready delegator) to receive SyncDistribution")
 	assert.NotContains(t, syncedNodes, int64(2), "Node 2 (not ready delegator) should NOT receive SyncDistribution")
+}
+
+func TestShouldUpdateNextTarget_TracksSegmentReplicaProgress(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(Params.QueryCoordCfg.NextTargetSurviveTime.Key, "1")
+	defer paramtable.Get().Reset(Params.QueryCoordCfg.NextTargetSurviveTime.Key)
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	nextVersion := int64(100)
+	segment1 := &datapb.SegmentInfo{ID: 1, CollectionID: collectionID}
+	segment2 := &datapb.SegmentInfo{ID: 2, CollectionID: collectionID}
+
+	nodeMgr := session.NewNodeManager()
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 1}))
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 2}))
+	replica1 := meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: collectionID, Nodes: []int64{1}})
+	replica2 := meta.NewReplica(&querypb.Replica{ID: 2, CollectionID: collectionID, Nodes: []int64{2}})
+	replicaMgr := meta.NewReplicaManager(nil, nil)
+	mockReplicas := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica1, replica2}).Build()
+	defer mockReplicas.UnPatch()
+	metaInstance := &meta.Meta{ReplicaManager: replicaMgr}
+
+	targetMgr := &mockeyTargetManager{}
+	nextTargetSegments := map[int64]*datapb.SegmentInfo{
+		segment1.GetID(): segment1,
+		segment2.GetID(): segment2,
+	}
+	mockNextTargetExists := mockey.Mock((*mockeyTargetManager).IsNextTargetExist).Return(true).Build()
+	defer mockNextTargetExists.UnPatch()
+	mockNextTargetVersion := mockey.Mock((*mockeyTargetManager).GetCollectionTargetVersion).Return(nextVersion).Build()
+	defer mockNextTargetVersion.UnPatch()
+	mockNextTargetSegments := mockey.Mock((*mockeyTargetManager).GetSealedSegmentsByCollection).Return(nextTargetSegments).Build()
+	defer mockNextTargetSegments.UnPatch()
+	mockNextTargetChannels := mockey.Mock((*mockeyTargetManager).GetDmChannelsByCollection).Return(map[string]*meta.DmChannel{}).Build()
+	defer mockNextTargetChannels.UnPatch()
+
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	observer := NewTargetObserver(metaInstance, targetMgr, distMgr, nil, nil, nodeMgr)
+
+	distMgr.SegmentDistManager.Update(1, meta.SegmentFromInfo(segment1), meta.SegmentFromInfo(segment2))
+	distMgr.SegmentDistManager.Update(2, meta.SegmentFromInfo(segment1))
+	observer.recordNextTargetProgress(collectionID, observer.sampleNextTargetProgress(ctx, collectionID, nextVersion))
+	setNextTargetProgressLastUpdated(t, observer, collectionID, time.Now().Add(-time.Hour))
+
+	assert.True(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+
+	distMgr.SegmentDistManager.Update(2, meta.SegmentFromInfo(segment1), meta.SegmentFromInfo(segment2))
+	setNextTargetProgressLastUpdated(t, observer, collectionID, time.Now().Add(-time.Hour))
+
+	assert.False(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+	progress, ok := observer.nextTargetProgresses.Get(collectionID)
+	assert.True(t, ok)
+	assert.Equal(t, nextVersion, progress.targetVersion)
+	assert.Equal(t, 4, progress.readySegmentReplicas)
+	assert.Equal(t, 0, progress.readyReplicaChannels)
+	assert.WithinDuration(t, time.Now(), progress.lastUpdated, time.Second)
+}
+
+func TestShouldUpdateNextTarget_TracksDataVersionProgress(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(Params.QueryCoordCfg.NextTargetSurviveTime.Key, "1")
+	defer paramtable.Get().Reset(Params.QueryCoordCfg.NextTargetSurviveTime.Key)
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	nextVersion := int64(100)
+	targetSegment := &datapb.SegmentInfo{
+		ID:             1,
+		CollectionID:   collectionID,
+		DataVersion:    2,
+		StorageVersion: storage.StorageV2,
+	}
+
+	nodeMgr := session.NewNodeManager()
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 1}))
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 2}))
+	replica1 := meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: collectionID, Nodes: []int64{1, 2}})
+	replicaMgr := meta.NewReplicaManager(nil, nil)
+	mockReplicas := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica1}).Build()
+	defer mockReplicas.UnPatch()
+	metaInstance := &meta.Meta{ReplicaManager: replicaMgr}
+
+	targetMgr := &mockeyTargetManager{}
+	mockNextTargetExists := mockey.Mock((*mockeyTargetManager).IsNextTargetExist).Return(true).Build()
+	defer mockNextTargetExists.UnPatch()
+	mockNextTargetVersion := mockey.Mock((*mockeyTargetManager).GetCollectionTargetVersion).Return(nextVersion).Build()
+	defer mockNextTargetVersion.UnPatch()
+	mockNextTargetSegments := mockey.Mock((*mockeyTargetManager).GetSealedSegmentsByCollection).
+		Return(map[int64]*datapb.SegmentInfo{targetSegment.GetID(): targetSegment}).Build()
+	defer mockNextTargetSegments.UnPatch()
+	mockNextTargetChannels := mockey.Mock((*mockeyTargetManager).GetDmChannelsByCollection).Return(map[string]*meta.DmChannel{}).Build()
+	defer mockNextTargetChannels.UnPatch()
+
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	oldDataVersion := int32(1)
+	distMgr.SegmentDistManager.Update(2, &meta.Segment{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             targetSegment.GetID(),
+			CollectionID:   collectionID,
+			StorageVersion: storage.StorageV2,
+		},
+		DataVersion: &oldDataVersion,
+	})
+	observer := NewTargetObserver(metaInstance, targetMgr, distMgr, nil, nil, nodeMgr)
+	observer.recordNextTargetProgress(collectionID, observer.sampleNextTargetProgress(ctx, collectionID, nextVersion))
+	setNextTargetProgressLastUpdated(t, observer, collectionID, time.Now().Add(-time.Hour))
+
+	assert.True(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+
+	newDataVersion := int32(2)
+	distMgr.SegmentDistManager.Update(1, &meta.Segment{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             targetSegment.GetID(),
+			CollectionID:   collectionID,
+			StorageVersion: storage.StorageV2,
+		},
+		DataVersion: &newDataVersion,
+	})
+	setNextTargetProgressLastUpdated(t, observer, collectionID, time.Now().Add(-time.Hour))
+
+	assert.False(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+	progress, ok := observer.nextTargetProgresses.Get(collectionID)
+	assert.True(t, ok)
+	assert.Equal(t, 1, progress.readySegmentReplicas)
+}
+
+func TestShouldUpdateNextTarget_TracksReplicaChannelProgress(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(Params.QueryCoordCfg.NextTargetSurviveTime.Key, "1")
+	defer paramtable.Get().Reset(Params.QueryCoordCfg.NextTargetSurviveTime.Key)
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	nextVersion := int64(100)
+	channelName := "channel-1"
+
+	nodeMgr := session.NewNodeManager()
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 1}))
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 2}))
+	replica1 := meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: collectionID, Nodes: []int64{1}})
+	replica2 := meta.NewReplica(&querypb.Replica{ID: 2, CollectionID: collectionID, Nodes: []int64{2}})
+	replicaMgr := meta.NewReplicaManager(nil, nil)
+	mockReplicas := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica1, replica2}).Build()
+	defer mockReplicas.UnPatch()
+	metaInstance := &meta.Meta{ReplicaManager: replicaMgr}
+
+	targetMgr := &mockeyTargetManager{}
+	mockNextTargetExists := mockey.Mock((*mockeyTargetManager).IsNextTargetExist).Return(true).Build()
+	defer mockNextTargetExists.UnPatch()
+	mockNextTargetVersion := mockey.Mock((*mockeyTargetManager).GetCollectionTargetVersion).Return(nextVersion).Build()
+	defer mockNextTargetVersion.UnPatch()
+	mockNextTargetSegments := mockey.Mock((*mockeyTargetManager).GetSealedSegmentsByCollection).Return(map[int64]*datapb.SegmentInfo{}).Build()
+	defer mockNextTargetSegments.UnPatch()
+	mockNextTargetChannels := mockey.Mock((*mockeyTargetManager).GetDmChannelsByCollection).
+		Return(map[string]*meta.DmChannel{channelName: {VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName}}}).Build()
+	defer mockNextTargetChannels.UnPatch()
+	mockChannelSegments := mockey.Mock((*mockeyTargetManager).GetSealedSegmentsByChannel).Return(map[int64]*datapb.SegmentInfo{}).Build()
+	defer mockChannelSegments.UnPatch()
+
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	distMgr.ChannelDistManager.Update(1, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName},
+		Node:         1,
+		View: &meta.LeaderView{
+			ID:            1,
+			CollectionID:  collectionID,
+			Channel:       channelName,
+			TargetVersion: 0,
+			Status:        &querypb.LeaderViewStatus{Serviceable: false},
+		},
+	})
+	observer := NewTargetObserver(metaInstance, targetMgr, distMgr, nil, nil, nodeMgr)
+	observer.recordNextTargetProgress(collectionID, nextTargetProgress{
+		targetVersion:        nextVersion,
+		readySegmentReplicas: 1,
+	})
+
+	distMgr.ChannelDistManager.Update(2, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{CollectionID: collectionID, ChannelName: channelName},
+		Node:         2,
+		View: &meta.LeaderView{
+			ID:            2,
+			CollectionID:  collectionID,
+			Channel:       channelName,
+			TargetVersion: nextVersion,
+			Status: &querypb.LeaderViewStatus{
+				Serviceable:             true,
+				CatchingUpStreamingData: true,
+			},
+		},
+	})
+	setNextTargetProgressLastUpdated(t, observer, collectionID, time.Now().Add(-time.Hour))
+	assert.False(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+	progress, ok := observer.nextTargetProgresses.Get(collectionID)
+	assert.True(t, ok)
+	assert.Equal(t, 1, progress.readySegmentReplicas)
+	assert.Equal(t, 2, progress.readyReplicaChannels)
+}
+
+func TestShouldUpdateNextTarget_ResetsProgressForNewVersion(t *testing.T) {
+	paramtable.Init()
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	segment := &datapb.SegmentInfo{ID: 1, CollectionID: collectionID}
+
+	nodeMgr := session.NewNodeManager()
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 1}))
+	replica := meta.NewReplica(&querypb.Replica{ID: 1, CollectionID: collectionID, Nodes: []int64{1}})
+	replicaMgr := meta.NewReplicaManager(nil, nil)
+	mockReplicas := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+	defer mockReplicas.UnPatch()
+	targetMgr := &mockeyTargetManager{}
+	nextTargetSegments := map[int64]*datapb.SegmentInfo{
+		segment.GetID(): segment,
+	}
+	mockNextTargetExists := mockey.Mock((*mockeyTargetManager).IsNextTargetExist).Return(true).Build()
+	defer mockNextTargetExists.UnPatch()
+	mockNextTargetVersion := mockey.Mock((*mockeyTargetManager).GetCollectionTargetVersion).Return(int64(101)).Build()
+	defer mockNextTargetVersion.UnPatch()
+	mockNextTargetSegments := mockey.Mock((*mockeyTargetManager).GetSealedSegmentsByCollection).Return(nextTargetSegments).Build()
+	defer mockNextTargetSegments.UnPatch()
+	mockNextTargetChannels := mockey.Mock((*mockeyTargetManager).GetDmChannelsByCollection).Return(map[string]*meta.DmChannel{}).Build()
+	defer mockNextTargetChannels.UnPatch()
+
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	distMgr.SegmentDistManager.Update(1, meta.SegmentFromInfo(segment))
+	metaInstance := &meta.Meta{ReplicaManager: replicaMgr}
+	observer := NewTargetObserver(metaInstance, targetMgr, distMgr, nil, nil, nodeMgr)
+	observer.recordNextTargetProgress(collectionID, nextTargetProgress{
+		targetVersion:        100,
+		readySegmentReplicas: 5,
+		readyReplicaChannels: 5,
+	})
+
+	assert.False(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+	progress, ok := observer.nextTargetProgresses.Get(collectionID)
+	assert.True(t, ok)
+	assert.Equal(t, int64(101), progress.targetVersion)
+	assert.Equal(t, 1, progress.readySegmentReplicas)
+	assert.Equal(t, 0, progress.readyReplicaChannels)
+	assert.WithinDuration(t, time.Now(), progress.lastUpdated, time.Second)
+}
+
+func TestNextTargetStale_RefreshLifecycle(t *testing.T) {
+	paramtable.Init()
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	segment := &datapb.SegmentInfo{ID: 1, CollectionID: collectionID}
+	nextTargetVersion := int64(100)
+	var updateNextTargetErr error
+	advanceTargetVersion := false
+	markDuringUpdate := false
+	targetContainsSegment := true
+
+	nodeMgr := session.NewNodeManager()
+	targetMgr := &mockeyTargetManager{}
+	var observer *TargetObserver
+	nextTargetSegments := map[int64]*datapb.SegmentInfo{
+		segment.GetID(): segment,
+	}
+	mockUpdateNextTarget := mockey.Mock((*mockeyTargetManager).UpdateCollectionNextTarget).
+		To(func(_ *mockeyTargetManager, _ context.Context, _ int64) error {
+			if updateNextTargetErr != nil {
+				return updateNextTargetErr
+			}
+			if markDuringUpdate {
+				observer.MarkNextTargetStale(collectionID, segment.GetID())
+			}
+			if advanceTargetVersion {
+				nextTargetVersion++
+			}
+			return nil
+		}).
+		Build()
+	defer mockUpdateNextTarget.UnPatch()
+	mockNextTargetVersion := mockey.Mock((*mockeyTargetManager).GetCollectionTargetVersion).
+		To(func(_ *mockeyTargetManager, _ context.Context, _ int64, _ meta.TargetScope) int64 {
+			return nextTargetVersion
+		}).
+		Build()
+	defer mockNextTargetVersion.UnPatch()
+	mockNextTargetSegments := mockey.Mock((*mockeyTargetManager).GetSealedSegmentsByCollection).Return(nextTargetSegments).Build()
+	defer mockNextTargetSegments.UnPatch()
+	mockNextTargetChannels := mockey.Mock((*mockeyTargetManager).GetDmChannelsByCollection).Return(map[string]*meta.DmChannel{}).Build()
+	defer mockNextTargetChannels.UnPatch()
+	mockNextTargetExists := mockey.Mock((*mockeyTargetManager).IsNextTargetExist).Return(true).Build()
+	defer mockNextTargetExists.UnPatch()
+	mockNextTargetSegment := mockey.Mock((*mockeyTargetManager).GetSealedSegment).
+		To(func(_ *mockeyTargetManager, _ context.Context, _ int64, segmentID int64, _ meta.TargetScope) *datapb.SegmentInfo {
+			if targetContainsSegment && segmentID == segment.GetID() {
+				return segment
+			}
+			return nil
+		}).
+		Build()
+	defer mockNextTargetSegment.UnPatch()
+
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	metaInstance := &meta.Meta{ReplicaManager: meta.NewReplicaManager(nil, nil)}
+	observer = NewTargetObserver(metaInstance, targetMgr, distMgr, nil, nil, nodeMgr)
+	observer.recordNextTargetProgress(collectionID, nextTargetProgress{
+		targetVersion: nextTargetVersion,
+	})
+
+	observer.MarkNextTargetStale(collectionID, segment.GetID())
+	assert.False(t, observer.shouldUpdateCurrentTarget(ctx, collectionID))
+	assert.True(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+
+	updateNextTargetErr = assert.AnError
+	assert.ErrorIs(t, observer.updateNextTarget(ctx, collectionID), assert.AnError)
+	assert.True(t, observer.nextTargetStale.Contain(collectionID))
+
+	updateNextTargetErr = nil
+	previousProgress, ok := observer.nextTargetProgresses.Get(collectionID)
+	assert.True(t, ok)
+	assert.NoError(t, observer.updateNextTarget(ctx, collectionID))
+	assert.True(t, observer.nextTargetStale.Contain(collectionID))
+	currentProgress, ok := observer.nextTargetProgresses.Get(collectionID)
+	assert.True(t, ok)
+	assert.Equal(t, previousProgress, currentProgress)
+
+	advanceTargetVersion = true
+	markDuringUpdate = true
+	assert.NoError(t, observer.updateNextTarget(ctx, collectionID))
+	assert.True(t, observer.nextTargetStale.Contain(collectionID))
+
+	markDuringUpdate = false
+	assert.NoError(t, observer.updateNextTarget(ctx, collectionID))
+	assert.False(t, observer.nextTargetStale.Contain(collectionID))
+
+	targetContainsSegment = false
+	observer.MarkNextTargetStale(collectionID, segment.GetID())
+	assert.False(t, observer.nextTargetStale.Contain(collectionID))
 }
 
 // TestShouldUpdateCurrentTarget_AllChannelsSynced tests that shouldUpdateCurrentTarget returns true

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -29,13 +29,16 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/metastore/kv/querycoord"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	. "github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	querycoordtask "github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -69,6 +72,8 @@ type TargetObserverSuite struct {
 }
 
 type mockeyTargetManager struct{ meta.TargetManagerInterface }
+
+type mockeyBroker struct{ meta.Broker }
 
 func TestInitSerializesTargetRefresh(t *testing.T) {
 	paramtable.Init()
@@ -1125,7 +1130,14 @@ func TestNextTargetStale_RefreshLifecycle(t *testing.T) {
 		}).
 		Build()
 	defer mockNextTargetVersion.UnPatch()
-	mockNextTargetSegments := mockey.Mock((*mockeyTargetManager).GetSealedSegmentsByCollection).Return(nextTargetSegments).Build()
+	mockNextTargetSegments := mockey.Mock((*mockeyTargetManager).GetSealedSegmentsByCollection).
+		To(func(_ *mockeyTargetManager, _ context.Context, _ int64, _ meta.TargetScope) map[int64]*datapb.SegmentInfo {
+			if targetContainsSegment {
+				return nextTargetSegments
+			}
+			return map[int64]*datapb.SegmentInfo{}
+		}).
+		Build()
 	defer mockNextTargetSegments.UnPatch()
 	mockNextTargetChannels := mockey.Mock((*mockeyTargetManager).GetDmChannelsByCollection).Return(map[string]*meta.DmChannel{}).Build()
 	defer mockNextTargetChannels.UnPatch()
@@ -1154,13 +1166,13 @@ func TestNextTargetStale_RefreshLifecycle(t *testing.T) {
 
 	updateNextTargetErr = assert.AnError
 	assert.ErrorIs(t, observer.updateNextTarget(ctx, collectionID), assert.AnError)
-	assert.True(t, observer.nextTargetStale.Contain(collectionID))
+	assert.True(t, observer.isNextTargetStale(collectionID))
 
 	updateNextTargetErr = nil
 	previousProgress, ok := observer.nextTargetProgresses.Get(collectionID)
 	assert.True(t, ok)
 	assert.NoError(t, observer.updateNextTarget(ctx, collectionID))
-	assert.True(t, observer.nextTargetStale.Contain(collectionID))
+	assert.True(t, observer.isNextTargetStale(collectionID))
 	currentProgress, ok := observer.nextTargetProgresses.Get(collectionID)
 	assert.True(t, ok)
 	assert.Equal(t, previousProgress, currentProgress)
@@ -1168,15 +1180,227 @@ func TestNextTargetStale_RefreshLifecycle(t *testing.T) {
 	advanceTargetVersion = true
 	markDuringUpdate = true
 	assert.NoError(t, observer.updateNextTarget(ctx, collectionID))
-	assert.True(t, observer.nextTargetStale.Contain(collectionID))
+	assert.True(t, observer.isNextTargetStale(collectionID))
 
 	markDuringUpdate = false
 	assert.NoError(t, observer.updateNextTarget(ctx, collectionID))
-	assert.False(t, observer.nextTargetStale.Contain(collectionID))
+	assert.True(t, observer.isNextTargetStale(collectionID))
 
 	targetContainsSegment = false
+	assert.NoError(t, observer.updateNextTarget(ctx, collectionID))
+	assert.False(t, observer.isNextTargetStale(collectionID))
+
 	observer.MarkNextTargetStale(collectionID, segment.GetID())
-	assert.False(t, observer.nextTargetStale.Contain(collectionID))
+	assert.False(t, observer.isNextTargetStale(collectionID))
+}
+
+func TestNextTargetStale_IdenticalRecoveryKeepsCause(t *testing.T) {
+	paramtable.Init()
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	partitionID := int64(100)
+	segmentID := int64(1)
+	channelName := "channel-1"
+	channel := &datapb.VchannelInfo{
+		CollectionID: collectionID,
+		ChannelName:  channelName,
+		SeekPosition: &msgpb.MsgPosition{Timestamp: 1},
+	}
+	segment := &datapb.SegmentInfo{
+		ID:            segmentID,
+		CollectionID:  collectionID,
+		PartitionID:   partitionID,
+		InsertChannel: channelName,
+	}
+
+	collectionMgr := meta.NewCollectionManager(nil)
+	assert.NoError(t, collectionMgr.PutCollectionWithoutSave(ctx, utils.CreateTestCollection(collectionID, 1)))
+	assert.NoError(t, collectionMgr.PutPartitionWithoutSave(ctx, utils.CreateTestPartition(collectionID, partitionID)))
+	metaInstance := &meta.Meta{
+		CollectionManager: collectionMgr,
+		ReplicaManager:    meta.NewReplicaManager(nil, nil),
+	}
+
+	broker := &mockeyBroker{}
+	mockRecovery := mockey.Mock((*mockeyBroker).GetRecoveryInfoV2).
+		To(func(_ *mockeyBroker, _ context.Context, actualCollectionID int64, _ ...int64) ([]*datapb.VchannelInfo, []*datapb.SegmentInfo, error) {
+			assert.Equal(t, collectionID, actualCollectionID)
+			return []*datapb.VchannelInfo{channel}, []*datapb.SegmentInfo{segment}, nil
+		}).
+		Build()
+	defer mockRecovery.UnPatch()
+
+	nodeMgr := session.NewNodeManager()
+	targetMgr := meta.NewTargetManager(broker, metaInstance)
+	observer := NewTargetObserver(
+		metaInstance,
+		targetMgr,
+		meta.NewDistributionManager(nodeMgr),
+		broker,
+		nil,
+		nodeMgr,
+	)
+
+	assert.NoError(t, targetMgr.UpdateCollectionNextTarget(ctx, collectionID))
+	oldVersion := targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
+	observer.MarkNextTargetStale(collectionID, segmentID)
+
+	// Real TargetManager uses a fresh local timestamp even when recovery returns
+	// identical data. The failed segment is therefore the stale identity, not the
+	// target version.
+	time.Sleep(time.Millisecond)
+	assert.NoError(t, observer.updateNextTarget(ctx, collectionID))
+	newVersion := targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
+	assert.Greater(t, newVersion, oldVersion)
+	assert.NotNil(t, targetMgr.GetSealedSegment(ctx, collectionID, segmentID, meta.NextTarget))
+	assert.True(t, observer.isNextTargetStale(collectionID))
+}
+
+func TestNextTargetStale_ErrSegmentNotFoundRefreshesRealTarget(t *testing.T) {
+	paramtable.Init()
+
+	ctx := context.Background()
+	collectionID := int64(1000)
+	partitionID := int64(100)
+	replicaID := int64(10)
+	nodeID := int64(1)
+	segmentID := int64(1)
+	channelName := "channel-1"
+	channel := &datapb.VchannelInfo{
+		CollectionID: collectionID,
+		ChannelName:  channelName,
+		SeekPosition: &msgpb.MsgPosition{Timestamp: 1},
+	}
+	segment := &datapb.SegmentInfo{
+		ID:            segmentID,
+		CollectionID:  collectionID,
+		PartitionID:   partitionID,
+		InsertChannel: channelName,
+	}
+	recoverySegments := []*datapb.SegmentInfo{segment}
+
+	collectionMgr := meta.NewCollectionManager(nil)
+	assert.NoError(t, collectionMgr.PutCollectionWithoutSave(
+		ctx,
+		utils.CreateTestCollectionWithStatus(collectionID, 1, querypb.LoadStatus_Loaded),
+	))
+	assert.NoError(t, collectionMgr.PutPartitionWithoutSave(ctx, utils.CreateTestPartition(collectionID, partitionID)))
+	replicaMgr := meta.NewReplicaManager(nil, nil)
+	replica := meta.NewReplica(&querypb.Replica{
+		ID:            replicaID,
+		CollectionID:  collectionID,
+		ResourceGroup: meta.DefaultResourceGroupName,
+		Nodes:         []int64{nodeID},
+	})
+	mockGetReplica := mockey.Mock((*meta.ReplicaManager).Get).Return(replica).Build()
+	defer mockGetReplica.UnPatch()
+	mockGetReplicas := mockey.Mock((*meta.ReplicaManager).GetByCollection).Return([]*meta.Replica{replica}).Build()
+	defer mockGetReplicas.UnPatch()
+	metaInstance := &meta.Meta{
+		CollectionManager: collectionMgr,
+		ReplicaManager:    replicaMgr,
+	}
+
+	broker := &mockeyBroker{}
+	recoveryCalls := 0
+	mockRecovery := mockey.Mock((*mockeyBroker).GetRecoveryInfoV2).
+		To(func(_ *mockeyBroker, _ context.Context, actualCollectionID int64, _ ...int64) ([]*datapb.VchannelInfo, []*datapb.SegmentInfo, error) {
+			assert.Equal(t, collectionID, actualCollectionID)
+			recoveryCalls++
+			return []*datapb.VchannelInfo{channel}, recoverySegments, nil
+		}).
+		Build()
+	defer mockRecovery.UnPatch()
+	mockDescribeCollection := mockey.Mock((*mockeyBroker).DescribeCollection).
+		Return(&milvuspb.DescribeCollectionResponse{Schema: &schemapb.CollectionSchema{}}, nil).
+		Build()
+	defer mockDescribeCollection.UnPatch()
+	mockGetSegmentInfo := mockey.Mock((*mockeyBroker).GetSegmentInfo).
+		To(func(_ *mockeyBroker, _ context.Context, segmentIDs ...int64) ([]*datapb.SegmentInfo, error) {
+			assert.Equal(t, []int64{segmentID}, segmentIDs)
+			return nil, merr.WrapErrSegmentNotFound(segmentID)
+		}).
+		Build()
+	defer mockGetSegmentInfo.UnPatch()
+
+	nodeMgr := session.NewNodeManager()
+	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: nodeID}))
+	distMgr := meta.NewDistributionManager(nodeMgr)
+	targetMgr := meta.NewTargetManager(broker, metaInstance)
+	assert.NoError(t, targetMgr.UpdateCollectionNextTarget(ctx, collectionID))
+	assert.True(t, targetMgr.UpdateCollectionCurrentTarget(ctx, collectionID))
+	time.Sleep(time.Millisecond)
+	assert.NoError(t, targetMgr.UpdateCollectionNextTarget(ctx, collectionID))
+
+	observer := NewTargetObserver(metaInstance, targetMgr, distMgr, broker, nil, nodeMgr)
+	nextVersion := targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
+	observer.recordNextTargetProgress(collectionID, observer.sampleNextTargetProgress(ctx, collectionID, nextVersion))
+	assert.False(t, observer.shouldUpdateNextTarget(ctx, collectionID))
+
+	oldFailedLoadCache := meta.GlobalFailedLoadCache
+	meta.GlobalFailedLoadCache = meta.NewFailedLoadCache()
+	defer func() {
+		meta.GlobalFailedLoadCache = oldFailedLoadCache
+	}()
+
+	scheduler := querycoordtask.NewScheduler(ctx, metaInstance, distMgr, targetMgr, broker, nil, nodeMgr)
+	scheduler.SetNextTargetStaleHandler(observer.MarkNextTargetStale)
+	scheduler.AddExecutor(nodeID)
+	defer scheduler.Stop()
+
+	loadTask, err := querycoordtask.NewSegmentTask(
+		ctx,
+		10*time.Second,
+		querycoordtask.WrapIDSource(0),
+		collectionID,
+		replica,
+		commonpb.LoadPriority_LOW,
+		querycoordtask.NewSegmentActionWithScope(
+			nodeID,
+			querycoordtask.ActionTypeGrow,
+			channelName,
+			segmentID,
+			querypb.DataScope_Historical,
+			100,
+		),
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, scheduler.Add(loadTask))
+
+	// The first dispatch injects ErrSegmentNotFound through the real executor.
+	// The second removes the failed task and invokes the observer callback.
+	scheduler.Dispatch(nodeID)
+	taskResult := make(chan error, 1)
+	go func() {
+		taskResult <- loadTask.Wait()
+	}()
+	select {
+	case err := <-taskResult:
+		assert.ErrorIs(t, err, merr.ErrSegmentNotFound)
+	case <-time.After(5 * time.Second):
+		t.Fatal("segment task did not finish")
+	}
+	scheduler.Dispatch(nodeID)
+	assert.True(t, observer.isNextTargetStale(collectionID))
+
+	oldVersion := targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
+	time.Sleep(time.Millisecond)
+	observer.check(ctx, collectionID)
+	newVersion := targetMgr.GetCollectionTargetVersion(ctx, collectionID, meta.NextTarget)
+	assert.Greater(t, newVersion, oldVersion)
+	assert.Equal(t, 3, recoveryCalls)
+	assert.True(t, observer.isNextTargetStale(collectionID))
+	assert.NotNil(t, targetMgr.GetSealedSegment(ctx, collectionID, segmentID, meta.NextTarget))
+
+	// Once recovery no longer contains the failed segment, the next refresh
+	// resolves the stale cause.
+	recoverySegments = nil
+	time.Sleep(time.Millisecond)
+	observer.check(ctx, collectionID)
+	assert.Equal(t, 4, recoveryCalls)
+	assert.False(t, observer.isNextTargetStale(collectionID))
+	assert.Nil(t, targetMgr.GetSealedSegment(ctx, collectionID, segmentID, meta.NextTarget))
 }
 
 // TestShouldUpdateCurrentTarget_AllChannelsSynced tests that shouldUpdateCurrentTarget returns true

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -313,7 +313,7 @@ func (s *Server) initQueryCoord() error {
 	// Init schedulers
 	mlog.Info(s.ctx, "init schedulers")
 	s.jobScheduler = job.NewScheduler()
-	s.taskScheduler = task.NewScheduler(
+	taskScheduler := task.NewScheduler(
 		s.ctx,
 		s.meta,
 		s.dist,
@@ -322,6 +322,7 @@ func (s *Server) initQueryCoord() error {
 		s.cluster,
 		s.nodeMgr,
 	)
+	s.taskScheduler = taskScheduler
 
 	// init proxy client manager
 	s.proxyClientManager = proxyutil.NewProxyClientManager(proxyutil.DefaultProxyCreator)
@@ -354,6 +355,7 @@ func (s *Server) initQueryCoord() error {
 
 	// Init observers
 	s.initObserver()
+	taskScheduler.SetNextTargetStaleHandler(s.targetObserver.MarkNextTargetStale)
 
 	// Init heartbeat
 	mlog.Info(s.ctx, "init dist controller")

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -735,7 +735,7 @@ func (suite *ServerSuite) hackServer() {
 	suite.broker = meta.NewMockBroker(suite.T())
 	suite.server.broker = suite.broker
 	suite.server.targetMgr = meta.NewTargetManager(suite.broker, suite.server.meta)
-	suite.server.taskScheduler = task.NewScheduler(
+	taskScheduler := task.NewScheduler(
 		suite.server.ctx,
 		suite.server.meta,
 		suite.server.dist,
@@ -744,6 +744,7 @@ func (suite *ServerSuite) hackServer() {
 		suite.server.cluster,
 		suite.server.nodeMgr,
 	)
+	suite.server.taskScheduler = taskScheduler
 
 	suite.server.distController = dist.NewDistController(
 		suite.server.cluster,
@@ -769,6 +770,7 @@ func (suite *ServerSuite) hackServer() {
 		suite.server.cluster,
 		suite.server.nodeMgr,
 	)
+	taskScheduler.SetNextTargetStaleHandler(suite.server.targetObserver.MarkNextTargetStale)
 	suite.server.collectionObserver = observers.NewCollectionObserver(
 		suite.server.dist,
 		suite.server.meta,

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -568,6 +568,8 @@ type taskScheduler struct {
 	cluster   session.Cluster
 	nodeMgr   *session.NodeManager
 
+	markNextTargetStaleHandler func(collectionID, segmentID int64)
+
 	scheduleMu   sync.Mutex           // guards schedule() and RemoveByNode()
 	collKeyLock  *lock.KeyLock[int64] // guards Add()
 	tasks        *ConcurrentMap[UniqueID, struct{}]
@@ -619,6 +621,12 @@ func NewScheduler(ctx context.Context,
 }
 
 func (scheduler *taskScheduler) Start() {}
+
+// SetNextTargetStaleHandler sets the callback used to mark a next target as
+// stale. It must be configured before the scheduler starts processing tasks.
+func (scheduler *taskScheduler) SetNextTargetStaleHandler(handler func(collectionID, segmentID int64)) {
+	scheduler.markNextTargetStaleHandler = handler
+}
 
 func (scheduler *taskScheduler) Stop() {
 	scheduler.executors.Range(func(nodeID int64, executor *Executor) bool {
@@ -1254,10 +1262,20 @@ func (scheduler *taskScheduler) remove(task Task) {
 		mlog.String("status", task.Status()),
 	)
 
-	if errors.Is(task.Err(), merr.ErrSegmentNotFound) {
-		log.Info(task.Context(), "segment in target has been cleaned, trigger force update next target")
-		// Avoid using task.Ctx as it may be canceled before remove is called.
-		scheduler.targetMgr.UpdateCollectionNextTarget(scheduler.ctx, task.CollectionID())
+	var segmentID int64
+	switch typedTask := task.(type) {
+	case *SegmentTask:
+		segmentID = typedTask.SegmentID()
+	case *LeaderTask:
+		segmentID = typedTask.SegmentID()
+	}
+	if segmentID != 0 && errors.Is(task.Err(), merr.ErrSegmentNotFound) {
+		log.Info(task.Context(), "segment in target has been cleaned, mark next target as stale")
+		if scheduler.markNextTargetStaleHandler == nil {
+			log.Warn(task.Context(), "next target stale handler is not configured")
+		} else {
+			scheduler.markNextTargetStaleHandler(task.CollectionID(), segmentID)
+		}
 	}
 
 	// If task failed due to resource exhaustion (OOM, disk full, GPU OOM, etc.),

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -2212,12 +2212,16 @@ func (suite *TaskSuite) TestRemoveTaskWithError() {
 	ctx := context.Background()
 	scheduler := suite.newScheduler()
 
-	mockTarget := meta.NewMockTargetManager(suite.T())
-	mockTarget.EXPECT().UpdateCollectionNextTarget(mock.Anything, mock.Anything).Return(nil)
-	scheduler.targetMgr = mockTarget
-
 	coll := int64(1001)
 	nodeID := int64(1)
+	staleTargetCollection := int64(0)
+	staleTargetSegment := int64(0)
+	staleCalls := 0
+	scheduler.SetNextTargetStaleHandler(func(collectionID, segmentID int64) {
+		staleTargetCollection = collectionID
+		staleTargetSegment = segmentID
+		staleCalls++
+	})
 	// add segment task for collection
 	task1, err := NewSegmentTask(
 		ctx,
@@ -2232,10 +2236,52 @@ func (suite *TaskSuite) TestRemoveTaskWithError() {
 	err = scheduler.Add(task1)
 	suite.NoError(err)
 
-	task1.Fail(merr.ErrSegmentNotFound)
-	// when try to remove task with ErrSegmentNotFound, should trigger UpdateNextTarget
+	task1.Fail(merr.WrapErrSegmentNotFound(1, "query node failed to load segment"))
+	// When removing a task with ErrSegmentNotFound, mark the next target as stale.
 	scheduler.remove(task1)
-	mockTarget.AssertExpectations(suite.T())
+	suite.Equal(coll, staleTargetCollection)
+	suite.Equal(int64(1), staleTargetSegment)
+	suite.Equal(1, staleCalls)
+
+	channelTask, err := NewChannelTask(
+		ctx,
+		10*time.Second,
+		WrapIDSource(0),
+		coll,
+		suite.replica,
+		NewChannelAction(nodeID, ActionTypeGrow, "channel"),
+	)
+	suite.NoError(err)
+	channelTask.Fail(merr.ErrSegmentNotFound)
+	scheduler.remove(channelTask)
+	suite.Equal(1, staleCalls)
+
+	leaderTask := NewLeaderSegmentTask(
+		ctx,
+		WrapIDSource(0),
+		coll,
+		suite.replica,
+		nodeID,
+		NewLeaderAction(nodeID, nodeID, ActionTypeGrow, "channel", 2, 0),
+	)
+	leaderTask.Fail(merr.CheckRPCCall(merr.Status(merr.WrapErrSegmentNotFound(2)), nil))
+	scheduler.remove(leaderTask)
+	suite.Equal(coll, staleTargetCollection)
+	suite.Equal(int64(2), staleTargetSegment)
+	suite.Equal(2, staleCalls)
+
+	leaderPartStatsTask := NewLeaderPartStatsTask(
+		ctx,
+		WrapIDSource(0),
+		coll,
+		suite.replica,
+		nodeID,
+		NewLeaderUpdatePartStatsAction(nodeID, nodeID, ActionTypeUpdate, "channel", map[int64]int64{1: 1}),
+	)
+	suite.Zero(leaderPartStatsTask.SegmentID())
+	leaderPartStatsTask.Fail(merr.ErrSegmentNotFound)
+	scheduler.remove(leaderPartStatsTask)
+	suite.Equal(2, staleCalls)
 
 	// test remove task with ErrSegmentRequestResourceFailed
 	task2, err := NewSegmentTask(

--- a/internal/querycoordv2/utils/util.go
+++ b/internal/querycoordv2/utils/util.go
@@ -26,8 +26,10 @@ import (
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -96,41 +98,55 @@ func CheckSegmentDataReady(ctx context.Context, collectionID int64, distManager 
 	for segmentID, segmentInfo := range segmentDist {
 		segments := distBySegmentID[segmentID]
 		if len(segments) == 0 {
-			mlog.RatedInfo(context.TODO(), rate.Limit(10), "segment is not available", mlog.Int64("segmentID", segmentID))
+			mlog.RatedInfo(ctx, rate.Limit(10), "segment is not available", mlog.Int64("segmentID", segmentID))
 			return merr.WrapErrSegmentLack(segmentID)
 		}
 
 		for _, segment := range segments {
-			cmp, err := packed.CompareManifestPath(segment.ManifestPath, segmentInfo.GetManifestPath())
+			ready, err := IsSegmentDataReadyForTarget(segment, segmentInfo)
 			if err != nil {
-				mlog.RatedWarn(context.TODO(), rate.Limit(10), "segment manifest path not comparable",
+				mlog.RatedWarn(ctx, rate.Limit(10), "segment manifest path not comparable",
 					mlog.Int64("segmentID", segmentID),
 					mlog.String("distManifest", segment.ManifestPath),
 					mlog.String("targetManifest", segmentInfo.GetManifestPath()),
 					mlog.Err(err))
 				return err
 			}
-			if cmp < 0 {
-				// dist manifest is older than target, segment data is not ready yet
-				mlog.RatedInfo(context.TODO(), rate.Limit(10), "segment manifest is outdated",
+
+			if !ready {
+				mlog.RatedInfo(ctx, rate.Limit(10), "segment data is outdated",
 					mlog.Int64("segmentID", segmentID),
 					mlog.String("distManifest", segment.ManifestPath),
-					mlog.String("targetManifest", segmentInfo.GetManifestPath()))
-				return merr.WrapErrSegmentNotLoaded(segmentID)
-			}
-			// cmp >= 0: dist manifest is same or newer than target.
-			// Still check DataVersion for storage v2 binlog changes that don't move the manifest.
-			// Skip when the QueryNode did not report DataVersion (old node in mixed-version rollout).
-			if segment.DataVersion != nil && *segment.DataVersion < segmentInfo.GetDataVersion() {
-				mlog.RatedInfo(context.TODO(), rate.Limit(10), "segment data version is outdated",
-					mlog.Int64("segmentID", segmentID),
-					mlog.Int32("distDataVersion", *segment.DataVersion),
+					mlog.String("targetManifest", segmentInfo.GetManifestPath()),
+					mlog.Int64("distStorageVersion", segment.GetStorageVersion()),
+					mlog.Int64("targetStorageVersion", segmentInfo.GetStorageVersion()),
+					mlog.Int32p("distDataVersion", segment.DataVersion),
 					mlog.Int32("targetDataVersion", segmentInfo.GetDataVersion()))
 				return merr.WrapErrSegmentNotLoaded(segmentID)
 			}
 		}
 	}
 	return nil
+}
+
+// IsSegmentDataReadyForTarget reports whether the distributed segment is
+// compatible with the target DataVersion and manifest. Storage v3 readiness
+// is represented by its manifest, so DataVersion is ignored. Legacy targets
+// with StorageVersion 0 still compare DataVersion because storage v2 binlog
+// updates may not change the manifest. A nil DataVersion is compatible during
+// mixed-version rollout.
+func IsSegmentDataReadyForTarget(segment *meta.Segment, target *datapb.SegmentInfo) (bool, error) {
+	if target.GetStorageVersion() != storage.StorageV3 &&
+		segment.DataVersion != nil &&
+		*segment.DataVersion < target.GetDataVersion() {
+		return false, nil
+	}
+
+	cmp, err := packed.CompareManifestPath(segment.ManifestPath, target.GetManifestPath())
+	if err != nil {
+		return false, err
+	}
+	return cmp >= 0, nil
 }
 
 func checkLoadStatus(ctx context.Context, m *meta.Meta, collectionID int64, withUnserviceableShards bool) error {

--- a/internal/querycoordv2/utils/util_test.go
+++ b/internal/querycoordv2/utils/util_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
@@ -356,15 +357,16 @@ func (suite *UtilTestSuite) TestCheckSegmentDataReady_DataVersion() {
 		return dm
 	}
 
-	newTargetMgr := func(targetDataVersion int32) meta.TargetManagerInterface {
+	newTargetMgr := func(storageVersion int64, targetDataVersion int32) meta.TargetManagerInterface {
 		m := meta.NewMockTargetManager(suite.T())
 		m.EXPECT().GetSealedSegmentsByCollection(mock.Anything, collectionID, mock.Anything).
 			Return(map[int64]*datapb.SegmentInfo{
 				segmentID: {
-					ID:           segmentID,
-					CollectionID: collectionID,
-					ManifestPath: manifest,
-					DataVersion:  targetDataVersion,
+					ID:             segmentID,
+					CollectionID:   collectionID,
+					ManifestPath:   manifest,
+					DataVersion:    targetDataVersion,
+					StorageVersion: storageVersion,
 				},
 			}).Maybe()
 		return m
@@ -372,35 +374,74 @@ func (suite *UtilTestSuite) TestCheckSegmentDataReady_DataVersion() {
 
 	int32Ptr := func(v int32) *int32 { return &v }
 
-	suite.Run("dist data version older than target - not ready", func() {
+	// Zero may mean a legacy V1 target or an older recovery response that did
+	// not populate StorageVersion. Keep the DataVersion check conservative.
+	suite.Run("zero storage version conservatively checks data version", func() {
 		err := CheckSegmentDataReady(context.Background(), collectionID,
-			newDistManager(int32Ptr(1)), newTargetMgr(5), meta.NextTarget)
+			newDistManager(int32Ptr(1)), newTargetMgr(storage.StorageV1, 5), meta.NextTarget)
+		suite.Error(err)
+	})
+
+	suite.Run("storage v2 checks data version", func() {
+		err := CheckSegmentDataReady(context.Background(), collectionID,
+			newDistManager(int32Ptr(1)), newTargetMgr(storage.StorageV2, 5), meta.NextTarget)
 		suite.Error(err)
 	})
 
 	suite.Run("dist data version equals target - ready", func() {
 		err := CheckSegmentDataReady(context.Background(), collectionID,
-			newDistManager(int32Ptr(5)), newTargetMgr(5), meta.NextTarget)
+			newDistManager(int32Ptr(5)), newTargetMgr(storage.StorageV2, 5), meta.NextTarget)
 		suite.NoError(err)
 	})
 
 	suite.Run("dist data version newer than target - ready", func() {
 		err := CheckSegmentDataReady(context.Background(), collectionID,
-			newDistManager(int32Ptr(10)), newTargetMgr(5), meta.NextTarget)
+			newDistManager(int32Ptr(10)), newTargetMgr(storage.StorageV2, 5), meta.NextTarget)
 		suite.NoError(err)
+	})
+
+	suite.Run("storage v3 ignores data version", func() {
+		err := CheckSegmentDataReady(context.Background(), collectionID,
+			newDistManager(int32Ptr(1)), newTargetMgr(storage.StorageV3, 5), meta.NextTarget)
+		suite.NoError(err)
+	})
+
+	suite.Run("storage v3 still checks manifest", func() {
+		ready, err := IsSegmentDataReadyForTarget(&meta.Segment{
+			ManifestPath: packed.MarshalManifestPath(basePath, 1),
+			DataVersion:  int32Ptr(10),
+		}, &datapb.SegmentInfo{
+			ManifestPath:   packed.MarshalManifestPath(basePath, 5),
+			StorageVersion: storage.StorageV3,
+		})
+		suite.NoError(err)
+		suite.False(ready)
+	})
+
+	suite.Run("stale data version takes precedence over manifest error", func() {
+		ready, err := IsSegmentDataReadyForTarget(&meta.Segment{
+			ManifestPath: "invalid-dist-manifest",
+			DataVersion:  int32Ptr(1),
+		}, &datapb.SegmentInfo{
+			ManifestPath:   "invalid-target-manifest",
+			DataVersion:    5,
+			StorageVersion: storage.StorageV2,
+		})
+		suite.NoError(err)
+		suite.False(ready)
 	})
 
 	// mixed-version rollout: an old QueryNode does not report DataVersion,
 	// so the dist-side pointer is nil. Skip the check rather than loop Reopen forever.
 	suite.Run("dist data version nil (old QueryNode) - ready", func() {
 		err := CheckSegmentDataReady(context.Background(), collectionID,
-			newDistManager(nil), newTargetMgr(5), meta.NextTarget)
+			newDistManager(nil), newTargetMgr(storage.StorageV2, 5), meta.NextTarget)
 		suite.NoError(err)
 	})
 
 	suite.Run("dist data version nil and target zero - ready", func() {
 		err := CheckSegmentDataReady(context.Background(), collectionID,
-			newDistManager(nil), newTargetMgr(0), meta.NextTarget)
+			newDistManager(nil), newTargetMgr(storage.StorageV2, 0), meta.NextTarget)
 		suite.NoError(err)
 	})
 }


### PR DESCRIPTION
issue: [#51564](https://github.com/milvus-io/milvus/issues/51564)

## What changed

This PR stabilizes multi-shard target convergence while keeping sealed
segment release conservative.

### 1. Preserve partial target synchronization

The removed all-delegator
prepare gate and sync-start pin are not restored, so ready delegators
continue to synchronize independently.

### 2. Track replica-scoped next-target progress

Periodic refresh now treats the next target as progressing when either
of these high-water counters increases:

- `readySegmentReplicas`: unique `(replicaID, segmentID)` pairs whose
  observed distribution copies satisfy the target manifest and
  `DataVersion`;
- `readyReplicaChannels`: unique `(replicaID, channelName)` pairs with a
  delegator that is data-ready or already synchronized to the target
  version.

The counters are high-water marks within one target version, so readiness
oscillation cannot repeatedly reset the timeout. A new target version
rebuilds the baseline.

These counters are only liveness signals for deciding whether automatic
refresh should wait. Current-target promotion continues to use the
existing readiness path.

### 3. Route unloadable targets through TargetObserver

When a `SegmentTask` or segment-based `LeaderTask` finishes with
`ErrSegmentNotFound`, the scheduler reports both the collection and
segment to TargetObserver. Channel tasks do not trigger this path.

The observer marks the target stale only when that segment is still in
the current next target. This avoids coupling tasks to a target generation;
a concurrent replacement can cause at most one conservative extra refresh.

Promotion keeps commit-wins semantics. Once readiness and
`SyncDistribution` have started, a late stale event does not veto the
in-flight promotion. The stale revision remains available to drive the
subsequent next-target refresh.

### 4. Preserve stale events across recovery refreshes

The stale boolean is replaced by a per-collection revision. Before a
recovery RPC, the observer snapshots the next-target version and stale
revision.

- RPC failures keep the stale revision and progress baseline.
- Empty or no-op recovery results do not clear stale or reset progress.
- Progress is reset only after a newer next-target version is installed.
- Only the captured stale revision is cleared; an event arriving during
  the RPC increments the revision and survives the compare-and-delete.

### 5. Keep explicit manual refresh semantics

Automatic progress-aware refresh keeps a healthy next target stable while
loading advances. A stale target or an explicit `UpdateNextTarget` /
`UpdatePartition` request may intentionally replace it and restart the
transition. The SegmentChecker comment now states this narrower invariant.

## Why

A delegator on any target version other than current may still serve a
readable snapshot that references an obsolete sealed segment. Releasing
that segment early can break reads. At the same time, repeatedly replacing
a healthy next target can prevent convergence and keep old segments pinned
forever.

The new behavior keeps release safe, gives healthy transitions time to
make measurable progress, and refreshes targets that are stale or no longer
advancing.

## Risks

The conservative release barrier can temporarily increase QueryNode memory
usage while target convergence is in progress. Explicit manual refreshes
can restart an in-progress transition by design.

## Test coverage added

- delegators on non-current versions retaining sealed segments;
- manifest- and `DataVersion`-only segment progress;
- identical segment IDs and channel names progressing across replicas;
- high-water progress resisting readiness oscillation;
- target-version changes rebuilding the progress baseline;
- failed, empty/no-op, and concurrent stale refresh lifecycles;
- stale events ignored when the segment is no longer in next;
- `SegmentTask` and `LeaderTask` stale callbacks, with channel tasks
  excluded.

## Validation

- `git diff --check`
- `GOTOOLCHAIN=auto make milvus`
- `GOTOOLCHAIN=auto go test -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${RPATH}" github.com/milvus-io/milvus/internal/querycoordv2/checkers github.com/milvus-io/milvus/internal/querycoordv2/job -count=1 -timeout 300s`
- `GOTOOLCHAIN=auto make lint-fix`
- `GOTOOLCHAIN=auto CLANG_FORMAT=/opt/homebrew/opt/llvm@15/bin/clang-format make check-proto-product`
- `GOTOOLCHAIN=auto CLANG_FORMAT=/opt/homebrew/opt/llvm@15/bin/clang-format make verifiers`


