### PR TITLE
enhance: enforce row-count invariant for semantic highlight inputs

### DIFF
--- a/internal/proxy/highlighter.go
+++ b/internal/proxy/highlighter.go
@@ -576,7 +576,10 @@ func (op *semanticHighlightOperator) run(ctx context.Context, span trace.Span, i
 		if !ok {
 			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, text field not in output field %d", fieldID)
 		}
-		texts := fieldDatas.GetScalars().GetStringData().GetData()
+		texts, err := rowAlignedStringFieldData(fieldDatas, searchResultHitCount(resultData))
+		if err != nil {
+			return nil, err
+		}
 		fieldName := op.highlight.GetFieldName(fieldID)
 
 		highlightResult, err := op.processFieldHighlight(ctx, fieldName, texts, topks)

--- a/internal/proxy/highlighter.go
+++ b/internal/proxy/highlighter.go
@@ -569,6 +569,7 @@ func (op *semanticHighlightOperator) run(ctx context.Context, span trace.Span, i
 	}
 	highlightResults := []*commonpb.HighlightResult{}
 	topks := result.Results.GetTopks()
+	rowNum := searchResultHitCount(resultData)
 
 	// Process schema fields
 	for _, fieldID := range op.highlight.FieldIDs() {
@@ -576,7 +577,7 @@ func (op *semanticHighlightOperator) run(ctx context.Context, span trace.Span, i
 		if !ok {
 			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, text field not in output field %d", fieldID)
 		}
-		texts, err := rowAlignedStringFieldData(fieldDatas, searchResultHitCount(resultData))
+		texts, err := rowAlignedStringFieldData(fieldDatas, rowNum)
 		if err != nil {
 			return nil, err
 		}
@@ -620,6 +621,14 @@ func (op *semanticHighlightOperator) run(ctx context.Context, span trace.Span, i
 
 		for _, dynFieldName := range dynFieldNames {
 			texts := allDynFieldTexts[dynFieldName]
+			// Process slices documents by topks without checking that they sum to
+			// len(documents), so an undersized $meta payload would go out of range
+			// there. Fail with the same error the schema branch returns instead.
+			if len(texts) != rowNum {
+				return nil, merr.WrapErrServiceInternalMsg(
+					"get highlight failed, dynamic field %s has %d rows, expected %d",
+					dynFieldName, len(texts), rowNum)
+			}
 
 			highlightResult, err := op.processFieldHighlight(ctx, dynFieldName, texts, topks)
 			if err != nil {

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -1609,6 +1609,73 @@ func (s *SearchPipelineSuite) TestSemanticHighlightOp() {
 	s.Equal([]string{"<em>highlighted</em> text 3"}, highlightResult.Datas[2].Fragments)
 }
 
+func (s *SearchPipelineSuite) TestSemanticHighlightOpNullableStringAlignsRows() {
+	ctx := context.Background()
+
+	mockProcess := mockey.Mock((*highlight.SemanticHighlight).Process).To(
+		func(h *highlight.SemanticHighlight, ctx context.Context, topks []int64, texts []string) ([][]string, [][]float32, error) {
+			s.Equal([]int64{3}, topks)
+			s.Equal([]string{"text 1", "", "text 3"}, texts)
+			return [][]string{
+					{"highlighted text 1"},
+					{},
+					{"highlighted text 3"},
+				}, [][]float32{
+					{0.9},
+					{},
+					{0.7},
+				}, nil
+		}).Build()
+	defer mockProcess.UnPatch()
+
+	mockFieldIDs := mockey.Mock((*highlight.SemanticHighlight).FieldIDs).Return([]int64{101}).Build()
+	defer mockFieldIDs.UnPatch()
+
+	mockGetFieldName := mockey.Mock((*highlight.SemanticHighlight).GetFieldName).Return(testVarCharField).Build()
+	defer mockGetFieldName.UnPatch()
+
+	op := &semanticHighlightOperator{
+		highlight: &highlight.SemanticHighlight{},
+	}
+
+	searchResults := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids:        testSearchResultIDs(1, 2, 3),
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldId:   101,
+					FieldName: testVarCharField,
+					Type:      schemapb.DataType_VarChar,
+					ValidData: []bool{true, false, true},
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_StringData{
+								StringData: &schemapb.StringArray{
+									Data: []string{"text 1", "text 3"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results, err := op.run(ctx, s.span, searchResults)
+	s.NoError(err)
+	s.Require().Len(results, 1)
+
+	result := results[0].(*milvuspb.SearchResults)
+	s.Require().Len(result.GetResults().GetHighlightResults(), 1)
+	highlightResult := result.GetResults().GetHighlightResults()[0]
+	s.Require().Len(highlightResult.GetDatas(), 3)
+	s.Equal([]string{}, highlightResult.GetDatas()[1].GetFragments())
+	s.Equal([]float32{}, highlightResult.GetDatas()[1].GetScores())
+}
+
 func (s *SearchPipelineSuite) TestSemanticHighlightOpMissingField() {
 	ctx := context.Background()
 

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -1671,9 +1671,15 @@ func (s *SearchPipelineSuite) TestSemanticHighlightOpNullableStringAlignsRows() 
 	result := results[0].(*milvuspb.SearchResults)
 	s.Require().Len(result.GetResults().GetHighlightResults(), 1)
 	highlightResult := result.GetResults().GetHighlightResults()[0]
+	// The fix under test is the row alignment feeding Process: the NULL row
+	// materializes as "" at its own index, asserted on `texts` inside the mock
+	// above. Here we only verify the per-row results survive alignment 1:1 —
+	// the row-1 payload is whatever the mock returned, not a NULL-semantics
+	// guarantee, so we assert positional pass-through across all three rows.
 	s.Require().Len(highlightResult.GetDatas(), 3)
+	s.Equal([]string{"highlighted text 1"}, highlightResult.GetDatas()[0].GetFragments())
 	s.Equal([]string{}, highlightResult.GetDatas()[1].GetFragments())
-	s.Equal([]float32{}, highlightResult.GetDatas()[1].GetScores())
+	s.Equal([]string{"highlighted text 3"}, highlightResult.GetDatas()[2].GetFragments())
 }
 
 func (s *SearchPipelineSuite) TestSemanticHighlightOpMissingField() {

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -2110,6 +2110,72 @@ func (s *SearchPipelineSuite) TestSemanticHighlightOpMixedFields() {
 	s.Equal([]string{"<em>dynamic</em> text"}, result.Results.HighlightResults[1].Datas[0].Fragments)
 }
 
+// Process slices documents by topks without checking that they sum to
+// len(documents), so a $meta payload shorter than the hit count would go out of
+// range there. The dynamic-field branch must reject it up front, the same way
+// the schema branch does.
+func (s *SearchPipelineSuite) TestSemanticHighlightOpDynamicFieldRowCountMismatch() {
+	ctx := context.Background()
+
+	mockProcess := mockey.Mock((*highlight.SemanticHighlight).Process).To(
+		func(h *highlight.SemanticHighlight, ctx context.Context, topks []int64, texts []string) ([][]string, [][]float32, error) {
+			s.Fail("Process must not be called with a row-count mismatch")
+			return nil, nil, nil
+		}).Build()
+	defer mockProcess.UnPatch()
+
+	mockFieldIDs := mockey.Mock((*highlight.SemanticHighlight).FieldIDs).Return([]int64{}).Build()
+	defer mockFieldIDs.UnPatch()
+
+	mockHasDynamicFields := mockey.Mock((*highlight.SemanticHighlight).HasDynamicFields).Return(true).Build()
+	defer mockHasDynamicFields.UnPatch()
+
+	mockDynamicFieldNames := mockey.Mock((*highlight.SemanticHighlight).DynamicFieldNames).Return([]string{"dyn_content"}).Build()
+	defer mockDynamicFieldNames.UnPatch()
+
+	mockDynamicFieldID := mockey.Mock((*highlight.SemanticHighlight).DynamicFieldID).Return(int64(102)).Build()
+	defer mockDynamicFieldID.UnPatch()
+
+	op := &semanticHighlightOperator{
+		highlight: &highlight.SemanticHighlight{},
+	}
+
+	// Topks says 3 hits, $meta carries only 2 rows.
+	searchResults := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids:        testSearchResultIDs(1, 2, 3),
+			Scores:     []float32{0.9, 0.8, 0.7},
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldId:   102,
+					FieldName: "$meta",
+					Type:      schemapb.DataType_JSON,
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_JsonData{
+								JsonData: &schemapb.JSONArray{
+									Data: [][]byte{
+										[]byte(`{"dyn_content": "dynamic content 1"}`),
+										[]byte(`{"dyn_content": "dynamic content 2"}`),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	results, err := op.run(ctx, s.span, searchResults)
+	s.Error(err)
+	s.Nil(results)
+	s.Contains(err.Error(), "dynamic field dyn_content has 2 rows, expected 3")
+}
+
 func (s *SearchPipelineSuite) TestExtractMultipleDynamicFieldTexts() {
 	// Test normal extraction with multiple fields
 	jsonData := [][]byte{


### PR DESCRIPTION
issue: #51574

## What

`SemanticHighlight.Process` slices its `documents` argument by `topks` (`semantic_highlight.go:195`) without checking that they sum to `len(documents)` — the only thing standing behind that is a `//nolint:gosec // bounds are guaranteed by topks summing to len(documents)` comment. A shorter slice panics in the proxy; verified directly: `Process(ctx, []int64{3}, []string{"a","b"})` gives `slice bounds out of range [:3] with capacity 2`.

This PR makes that invariant enforced rather than assumed:

- Schema fields go through `rowAlignedStringFieldData(fieldData, sum(topks))` — the helper the lexical path has used since #50572 — so `texts` always carries exactly one slot per search-result row, NULL rows included.
- The dynamic-field (`$meta`) branch gets the matching length check, so both branches return the same error instead of one of them panicking.

## Scope correction (after review)

An earlier version of this description claimed nullable scalar payloads can arrive compacted and shift later rows left. **I could not substantiate that for the search path and am no longer claiming it**: segcore writes one scalar slot per row unconditionally (`Utils.cpp:651-659`; `MergeDataArray`'s scalar branch likewise, only its vector branch skips invalid rows), `AppendFieldData` indexes string data by logical row (`schema.go:1118-1129`), `queryutil` slices scalars logically (`helpers.go:890`), and compaction is scoped to vector types by `IsCompactNullableVectorFieldData` (`schema.go:2101-2102`). Treat this as hardening of an unchecked invariant, not a fix for observed data corruption. Issue #51574 needs the same correction.

`typeutil.GetDataIterator` (`schema.go:3488-3515`) does branch on both layouts, so `rowAlignedStringFieldData` remains correct either way.

## Follow-ups (not in this PR)

- `pipeline_trace.go:209-212` asserts the **opposite** invariant ("StringData uses compact encoding") and `perNqCardinalityCompact` miscounts cardinality against full-size data with nulls (`topks=[3]`, `ValidData=[t,f,t]`, `Data=["a","","a"]` reports 3, logical answer 2). Observability only; filing separately.
- NULL rows still reach the highlight provider as empty documents.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy -run "TestSearchPipeline|TestHighlighter"`
- `golangci-lint run ./internal/proxy/...` — 0 issues
