### PR TITLE
enhance: [3.0] enforce function-field binding principle for function DDL

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -76,6 +76,8 @@ const (
 	AddFunctionAction               = "add_function"
 	AlterFunctionAction             = "alter_function"
 	DropFunctionAction              = "drop_function"
+	AddFunctionFieldAction          = "add_function_field"
+	DropFunctionFieldAction         = "drop_function_field"
 	AddAction                       = `add`
 	DropPropertiesAction            = "drop_properties"
 	CompactAction                   = "compact"

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -90,6 +90,8 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 	"/v2/vectordb/collections/add_function":         "AddCollectionFunction",
 	"/v2/vectordb/collections/alter_function":       "AlterCollectionFunction",
 	"/v2/vectordb/collections/drop_function":        "DropCollectionFunction",
+	"/v2/vectordb/collections/add_function_field":   "AlterCollectionSchema",
+	"/v2/vectordb/collections/drop_function_field":  "AlterCollectionSchema",
 	"/v2/vectordb/collections/drop_properties":      "AlterCollection",
 	"/v2/vectordb/collections/compact":              "ManualCompaction",
 	"/v2/vectordb/collections/get_compaction_state": "GetCompactionState",
@@ -206,6 +208,8 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 	router.POST(CollectionCategory+AddFunctionAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionAddFunction{} }, wrapperTraceLog(h.addCollectionFunction))))
 	router.POST(CollectionCategory+AlterFunctionAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionAlterFunction{} }, wrapperTraceLog(h.alterCollectionFunction))))
 	router.POST(CollectionCategory+DropFunctionAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionDropFunction{} }, wrapperTraceLog(h.dropCollectionFunction))))
+	router.POST(CollectionCategory+AddFunctionFieldAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionAddFunctionField{} }, wrapperTraceLog(h.addCollectionFunctionField))))
+	router.POST(CollectionCategory+DropFunctionFieldAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionDropFunctionField{} }, wrapperTraceLog(h.dropCollectionFunctionField))))
 	router.POST(CollectionCategory+DropPropertiesAction, timeoutMiddleware(wrapperPost(func() any { return &DropCollectionPropertiesReq{} }, wrapperTraceLog(h.dropCollectionProperties))))
 	router.POST(CollectionCategory+CompactAction, timeoutMiddleware(wrapperPost(func() any { return &CompactReq{} }, wrapperTraceLog(h.compact))))
 	router.POST(CollectionCategory+CompactionStateAction, timeoutMiddleware(wrapperPost(func() any { return &GetCompactionStateReq{} }, wrapperTraceLog(h.getcompactionState))))
@@ -994,6 +998,9 @@ func (h *HandlersV2) alterCollectionFunction(ctx context.Context, c *gin.Context
 	return resp, err
 }
 
+// dropCollectionFunction backs the deprecated /collections/drop_function endpoint,
+// which mapped to the legacy detach RPC. A function is coupled to its output field,
+// so the RPC is rejected; use /collections/drop_function_field instead.
 func (h *HandlersV2) dropCollectionFunction(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*CollectionDropFunction)
 	req := &milvuspb.DropCollectionFunctionRequest{
@@ -1004,6 +1011,111 @@ func (h *HandlersV2) dropCollectionFunction(ctx context.Context, c *gin.Context,
 	c.Set(ContextRequest, req)
 	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/DropCollectionFunction", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.DropCollectionFunction(reqCtx, req.(*milvuspb.DropCollectionFunctionRequest))
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}
+
+// addCollectionFunctionField backs /collections/add_function_field: it attaches a
+// BM25/MinHash function together with its output field and index via AlterCollectionSchema.
+// A function is coupled to its output field, so both are added in one request.
+func (h *HandlersV2) addCollectionFunctionField(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*CollectionAddFunctionField)
+	// The index always targets the newly-added output field; reject a mismatched
+	// indexParams.fieldName rather than silently building the index on outputField.
+	if httpReq.IndexParam.FieldName != httpReq.OutputField.FieldName {
+		err := merr.WrapErrParameterInvalidMsg(
+			"indexParams.fieldName %q must match outputField.fieldName %q",
+			httpReq.IndexParam.FieldName, httpReq.OutputField.FieldName)
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
+			HTTPReturnMessage: err.Error(),
+		})
+		return nil, err
+	}
+	fSchema, err := genFunctionSchema(ctx, &httpReq.Function)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
+			HTTPReturnMessage: err.Error(),
+		})
+		return nil, err
+	}
+	fieldSchema, err := httpReq.OutputField.GetProto(ctx)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
+			HTTPReturnMessage: err.Error(),
+		})
+		return nil, err
+	}
+	extraParams, err := convertToExtraParams(httpReq.IndexParam)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
+			HTTPReturnMessage: err.Error(),
+		})
+		return nil, err
+	}
+	req := &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: httpReq.CollectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{
+							FieldSchema: fieldSchema,
+							IndexName:   httpReq.IndexParam.IndexName,
+							ExtraParams: extraParams,
+						},
+					},
+					FuncSchema: []*schemapb.FunctionSchema{fSchema},
+				},
+			},
+		},
+	}
+	c.Set(ContextRequest, req)
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		r, callErr := h.proxy.AlterCollectionSchema(reqCtx, req.(*milvuspb.AlterCollectionSchemaRequest))
+		if callErr == nil {
+			callErr = merr.Error(r.GetAlterStatus())
+		}
+		return r, callErr
+	})
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}
+
+// dropCollectionFunctionField backs /collections/drop_function_field: it detaches a
+// function and drops its output field together via AlterCollectionSchema.
+func (h *HandlersV2) dropCollectionFunctionField(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*CollectionDropFunctionField)
+	req := &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: httpReq.CollectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_DropRequest{
+				DropRequest: &milvuspb.AlterCollectionSchemaRequest_DropRequest{
+					Identifier: &milvuspb.AlterCollectionSchemaRequest_DropRequest_FunctionName{
+						FunctionName: httpReq.FunctionName,
+					},
+					DropFunctionOutputFields: true,
+				},
+			},
+		},
+	}
+	c.Set(ContextRequest, req)
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		r, callErr := h.proxy.AlterCollectionSchema(reqCtx, req.(*milvuspb.AlterCollectionSchemaRequest))
+		if callErr == nil {
+			callErr = merr.Error(r.GetAlterStatus())
+		}
+		return r, callErr
 	})
 	if err == nil {
 		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -4813,6 +4813,80 @@ func (s *CollectionFunctionSuite) TestDropCollectionFunctionNormal() {
 	})
 }
 
+func (s *CollectionFunctionSuite) TestAddCollectionFunctionFieldNormal() {
+	s.Run("success", func() {
+		addFunctionFieldTestCases := []requestBodyTestCase{
+			{
+				path:        versionalV2(CollectionCategory, AddFunctionFieldAction),
+				requestBody: []byte(`{"dbName": "db", "collectionName": "coll", "function": {"name": "bm25_fn", "type": "BM25", "inputFieldNames": ["text"], "outputFieldNames": ["sparse"]}, "outputField": {"fieldName": "sparse", "dataType": "SparseFloatVector"}, "indexParams": {"fieldName": "sparse", "indexName": "sparse_idx", "metricType": "BM25", "indexType": "SPARSE_INVERTED_INDEX"}}`),
+				errCode:     0,
+				errMsg:      "",
+			},
+		}
+		s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success}}, nil).Maybe()
+
+		validateRequestBodyTestCases(s.T(), s.testEngine, addFunctionFieldTestCases, false)
+	})
+
+	s.Run("bad_request", func() {
+		addFunctionFieldTestCases := []requestBodyTestCase{
+			{
+				path:        versionalV2(CollectionCategory, AddFunctionFieldAction),
+				requestBody: []byte(`{"dbName": "db", "collectionName": "", "function": {"name": "bm25_fn", "type": "BM25", "inputFieldNames": ["text"], "outputFieldNames": ["sparse"]}, "outputField": {"fieldName": "sparse", "dataType": "SparseFloatVector"}, "indexParams": {"fieldName": "sparse"}}`),
+				errCode:     1802,
+				errMsg:      "missing required parameters, error: Key: 'CollectionAddFunctionField.CollectionName' Error:Field validation for 'CollectionName' failed on the 'required' tag",
+			},
+			{
+				path:        versionalV2(CollectionCategory, AddFunctionFieldAction),
+				requestBody: []byte(`{"dbName": "db", "collectionName": "coll", "function": {"name": "bm25_fn", "type": "BM25", "inputFieldNames": ["text"], "outputFieldNames": ["sparse"]}, "outputField": {"fieldName": "sparse", "dataType": "SparseFloatVector"}, "indexParams": {"fieldName": "wrong_field", "indexName": "sparse_idx", "metricType": "BM25", "indexType": "SPARSE_INVERTED_INDEX"}}`),
+				errCode:     1100,
+				errMsg:      `indexParams.fieldName "wrong_field" must match outputField.fieldName "sparse": invalid parameter`,
+			},
+			{
+				path:        versionalV2(CollectionCategory, AddFunctionFieldAction),
+				requestBody: []byte(`invalid json`),
+				errCode:     1801,
+				errMsg:      "can only accept json format request, error: invalid character 'i' looking for beginning of value",
+			},
+		}
+		validateRequestBodyTestCases(s.T(), s.testEngine, addFunctionFieldTestCases, false)
+	})
+}
+
+func (s *CollectionFunctionSuite) TestDropCollectionFunctionFieldNormal() {
+	s.Run("success", func() {
+		dropFunctionFieldTestCases := []requestBodyTestCase{
+			{
+				path:        versionalV2(CollectionCategory, DropFunctionFieldAction),
+				requestBody: []byte(`{"dbName": "db", "collectionName": "coll", "functionName": "bm25_fn"}`),
+				errCode:     0,
+				errMsg:      "",
+			},
+		}
+		s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success}}, nil).Maybe()
+
+		validateRequestBodyTestCases(s.T(), s.testEngine, dropFunctionFieldTestCases, false)
+	})
+
+	s.Run("bad_request", func() {
+		dropFunctionFieldTestCases := []requestBodyTestCase{
+			{
+				path:        versionalV2(CollectionCategory, DropFunctionFieldAction),
+				requestBody: []byte(`{"dbName": "db", "collectionName": "coll", "functionName": ""}`),
+				errCode:     1802,
+				errMsg:      "missing required parameters, error: Key: 'CollectionDropFunctionField.FunctionName' Error:Field validation for 'FunctionName' failed on the 'required' tag",
+			},
+			{
+				path:        versionalV2(CollectionCategory, DropFunctionFieldAction),
+				requestBody: []byte(`invalid json`),
+				errCode:     1801,
+				errMsg:      "can only accept json format request, error: invalid character 'i' looking for beginning of value",
+			},
+		}
+		validateRequestBodyTestCases(s.T(), s.testEngine, dropFunctionFieldTestCases, false)
+	})
+}
+
 func TestTruncateCollection(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -124,6 +124,32 @@ func (req *CollectionAddFunction) GetFunction() *FunctionSchema {
 	return &req.Function
 }
 
+type CollectionAddFunctionField struct {
+	DbName         string         `json:"dbName"`
+	CollectionName string         `json:"collectionName" binding:"required"`
+	Function       FunctionSchema `json:"function" binding:"required"`
+	OutputField    FieldSchema    `json:"outputField" binding:"required"`
+	IndexParam     IndexParam     `json:"indexParams" binding:"required"`
+}
+
+func (req *CollectionAddFunctionField) GetDbName() string { return req.DbName }
+
+func (req *CollectionAddFunctionField) GetCollectionName() string {
+	return req.CollectionName
+}
+
+type CollectionDropFunctionField struct {
+	DbName         string `json:"dbName"`
+	CollectionName string `json:"collectionName" binding:"required"`
+	FunctionName   string `json:"functionName" binding:"required"`
+}
+
+func (req *CollectionDropFunctionField) GetDbName() string { return req.DbName }
+
+func (req *CollectionDropFunctionField) GetCollectionName() string {
+	return req.CollectionName
+}
+
 type CollectionAlterFunction struct {
 	DbName         string         `json:"dbName"`
 	CollectionName string         `json:"collectionName" binding:"required"`

--- a/internal/proxy/function_task.go
+++ b/internal/proxy/function_task.go
@@ -42,99 +42,6 @@ func rejectExternalCollectionFunctionMutation(schema *schemapb.CollectionSchema)
 	return nil
 }
 
-type addCollectionFunctionTask struct {
-	baseTask
-	Condition
-	*milvuspb.AddCollectionFunctionRequest
-	ctx      context.Context
-	mixCoord types.MixCoordClient
-	result   *commonpb.Status
-}
-
-func (t *addCollectionFunctionTask) TraceCtx() context.Context {
-	return t.ctx
-}
-
-func (t *addCollectionFunctionTask) ID() UniqueID {
-	return t.Base.MsgID
-}
-
-func (t *addCollectionFunctionTask) SetID(uid UniqueID) {
-	t.Base.MsgID = uid
-}
-
-func (t *addCollectionFunctionTask) Type() commonpb.MsgType {
-	return t.Base.MsgType
-}
-
-func (t *addCollectionFunctionTask) BeginTs() Timestamp {
-	return t.Base.Timestamp
-}
-
-func (t *addCollectionFunctionTask) EndTs() Timestamp {
-	return t.Base.Timestamp
-}
-
-func (t *addCollectionFunctionTask) SetTs(ts Timestamp) {
-	t.Base.Timestamp = ts
-}
-
-func (t *addCollectionFunctionTask) OnEnqueue() error {
-	if t.Base == nil {
-		t.Base = commonpbutil.NewMsgBase()
-	}
-	t.Base.MsgType = commonpb.MsgType_AddCollectionFunction
-	t.Base.SourceID = paramtable.GetNodeID()
-	return nil
-}
-
-func (t *addCollectionFunctionTask) Name() string {
-	return AddCollectionFunctionTask
-}
-
-func (t *addCollectionFunctionTask) PreExecute(ctx context.Context) error {
-	if t.FunctionSchema == nil {
-		return merr.WrapErrParameterInvalidMsg("function schema is empty")
-	}
-
-	if t.FunctionSchema.Type == schemapb.FunctionType_BM25 {
-		return merr.WrapErrParameterInvalidMsg("currently does not support adding BM25 function")
-	}
-	if err := validateAddFunctionRequiresStorageV3(); err != nil {
-		return err
-	}
-	coll, err := getCollectionInfo(ctx, t.GetDbName(), t.GetCollectionName())
-	if err != nil {
-		mlog.Error(t.ctx, "AddCollectionTask, get collection info failed",
-			mlog.String("dbName", t.GetDbName()),
-			mlog.String("collectionName", t.GetCollectionName()),
-			mlog.Err(err))
-		return err
-	}
-	if err := validateAddFunctionInputNotText(coll.schema.CollectionSchema, t.FunctionSchema); err != nil {
-		return err
-	}
-	newColl := proto.Clone(coll.schema.CollectionSchema).(*schemapb.CollectionSchema)
-	newColl.Functions = append(coll.schema.Functions, t.FunctionSchema)
-	if err := validator.ValidateFunction(newColl, t.FunctionSchema.Name, false); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *addCollectionFunctionTask) Execute(ctx context.Context) error {
-	var err error
-	t.result, err = t.mixCoord.AddCollectionFunction(ctx, t.AddCollectionFunctionRequest)
-	if err = merr.CheckRPCCall(t.result, err); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *addCollectionFunctionTask) PostExecute(ctx context.Context) error {
-	return nil
-}
-
 type alterCollectionFunctionTask struct {
 	baseTask
 	Condition
@@ -213,6 +120,9 @@ func (t *alterCollectionFunctionTask) PreExecute(ctx context.Context) error {
 			if fSchema.Type == schemapb.FunctionType_BM25 {
 				return merr.WrapErrParameterInvalidMsg("currently does not support alter BM25 function")
 			}
+			if err := validator.CheckFunctionAlterAllowed(fSchema, t.FunctionSchema); err != nil {
+				return err
+			}
 			newFunctions = append(newFunctions, t.FunctionSchema)
 			funcExist = true
 		} else {
@@ -241,101 +151,6 @@ func (t *alterCollectionFunctionTask) Execute(ctx context.Context) error {
 }
 
 func (t *alterCollectionFunctionTask) PostExecute(ctx context.Context) error {
-	return nil
-}
-
-type dropCollectionFunctionTask struct {
-	baseTask
-	Condition
-	*milvuspb.DropCollectionFunctionRequest
-	ctx      context.Context
-	mixCoord types.MixCoordClient
-
-	result  *commonpb.Status
-	fSchema *schemapb.FunctionSchema
-}
-
-func (t *dropCollectionFunctionTask) TraceCtx() context.Context {
-	return t.ctx
-}
-
-func (t *dropCollectionFunctionTask) ID() UniqueID {
-	return t.Base.MsgID
-}
-
-func (t *dropCollectionFunctionTask) SetID(uid UniqueID) {
-	t.Base.MsgID = uid
-}
-
-func (t *dropCollectionFunctionTask) Type() commonpb.MsgType {
-	return t.Base.MsgType
-}
-
-func (t *dropCollectionFunctionTask) BeginTs() Timestamp {
-	return t.Base.Timestamp
-}
-
-func (t *dropCollectionFunctionTask) EndTs() Timestamp {
-	return t.Base.Timestamp
-}
-
-func (t *dropCollectionFunctionTask) SetTs(ts Timestamp) {
-	t.Base.Timestamp = ts
-}
-
-func (t *dropCollectionFunctionTask) OnEnqueue() error {
-	if t.Base == nil {
-		t.Base = commonpbutil.NewMsgBase()
-	}
-	t.Base.MsgType = commonpb.MsgType_DropCollectionFunction
-	t.Base.SourceID = paramtable.GetNodeID()
-	return nil
-}
-
-func (t *dropCollectionFunctionTask) Name() string {
-	return DropCollectionFunctionTask
-}
-
-func (t *dropCollectionFunctionTask) PreExecute(ctx context.Context) error {
-	coll, err := getCollectionInfo(ctx, t.GetDbName(), t.GetCollectionName())
-	if err != nil {
-		mlog.Error(t.ctx, "DropFunctionTask, get collection info failed",
-			mlog.String("dbName", t.GetDbName()),
-			mlog.String("collectionName", t.GetCollectionName()),
-			mlog.Err(err))
-		return err
-	}
-	if err := rejectExternalCollectionFunctionMutation(coll.schema.CollectionSchema); err != nil {
-		return err
-	}
-
-	for _, f := range coll.schema.Functions {
-		if f.Name == t.FunctionName {
-			t.fSchema = f
-			break
-		}
-	}
-	return nil
-}
-
-func (t *dropCollectionFunctionTask) Execute(ctx context.Context) error {
-	if t.fSchema == nil {
-		return nil
-	}
-
-	if t.fSchema.Type == schemapb.FunctionType_BM25 {
-		return merr.WrapErrParameterInvalidMsg("currently does not support droping BM25 function")
-	}
-
-	var err error
-	t.result, err = t.mixCoord.DropCollectionFunction(ctx, t.DropCollectionFunctionRequest)
-	if err = merr.CheckRPCCall(t.result, err); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *dropCollectionFunctionTask) PostExecute(ctx context.Context) error {
 	return nil
 }
 

--- a/internal/proxy/function_task_test.go
+++ b/internal/proxy/function_task_test.go
@@ -97,34 +97,6 @@ func (f *FunctionTaskSuite) TestValidateAddFunctionInputNotText() {
 
 func (f *FunctionTaskSuite) TestFunctionOnType() {
 	{
-		task := &addCollectionFunctionTask{
-			AddCollectionFunctionRequest: &milvuspb.AddCollectionFunctionRequest{},
-		}
-		err := task.OnEnqueue()
-		f.NoError(err)
-		f.Equal(commonpb.MsgType_AddCollectionFunction, task.Type())
-		f.Equal(task.TraceCtx(), task.ctx)
-		task.SetID(1)
-		f.Equal(task.ID(), int64(1))
-		task.SetTs(2)
-		f.Equal(task.EndTs(), uint64(2))
-		f.Equal(task.Name(), AddCollectionFunctionTask)
-	}
-	{
-		task := &dropCollectionFunctionTask{
-			DropCollectionFunctionRequest: &milvuspb.DropCollectionFunctionRequest{},
-		}
-		err := task.OnEnqueue()
-		f.NoError(err)
-		f.Equal(commonpb.MsgType_DropCollectionFunction, task.Type())
-		f.Equal(task.TraceCtx(), task.ctx)
-		task.SetID(1)
-		f.Equal(task.ID(), int64(1))
-		task.SetTs(2)
-		f.Equal(task.EndTs(), uint64(2))
-		f.Equal(task.Name(), DropCollectionFunctionTask)
-	}
-	{
 		task := &alterCollectionFunctionTask{
 			AlterCollectionFunctionRequest: &milvuspb.AlterCollectionFunctionRequest{},
 		}
@@ -137,136 +109,6 @@ func (f *FunctionTaskSuite) TestFunctionOnType() {
 		task.SetTs(2)
 		f.Equal(task.EndTs(), uint64(2))
 		f.Equal(task.Name(), AlterCollectionFunctionTask)
-	}
-}
-
-func (f *FunctionTaskSuite) TestAddCollectionFunctionTaskPreExecute() {
-	ctx := context.Background()
-	// Adding a function requires StorageV3 + schema-bump/storage-version compaction enabled
-	// (see validateAddFunctionRequiresStorageV3). storageVersion.enabled defaults true;
-	// bumpSchemaVersion.enabled defaults false, so it must be set explicitly.
-	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
-	paramtable.Get().Save(paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key, "true")
-	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
-	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.BumpSchemaVersionCompactionEnabled.Key)
-	{
-		mixc := mocks.NewMockMixCoordClient(f.T())
-		req := &milvuspb.AddCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_AddCollectionFunction,
-			},
-			DbName:         "db",
-			CollectionName: "NotExist",
-			CollectionID:   1,
-			FunctionSchema: &schemapb.FunctionSchema{},
-		}
-
-		task := &addCollectionFunctionTask{
-			Condition:                    NewTaskCondition(ctx),
-			AddCollectionFunctionRequest: req,
-			mixCoord:                     mixc,
-		}
-		cache := NewMockCache(f.T())
-		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(0, fmt.Errorf("Mock Error")).Maybe()
-		globalMetaCache = cache
-
-		err := task.PreExecute(ctx)
-		f.ErrorContains(err, "Mock Error")
-	}
-	{
-		// Test with invalid function schema
-		mixc := mocks.NewMockMixCoordClient(f.T())
-		req := &milvuspb.AddCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_AddCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			CollectionID:   1,
-			FunctionSchema: &schemapb.FunctionSchema{},
-		}
-
-		task := &addCollectionFunctionTask{
-			Condition:                    NewTaskCondition(ctx),
-			AddCollectionFunctionRequest: req,
-			mixCoord:                     mixc,
-		}
-
-		cache := NewMockCache(f.T())
-		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
-		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(nil, fmt.Errorf("Mock info error")).Maybe()
-		globalMetaCache = cache
-
-		err := task.PreExecute(ctx)
-		f.ErrorContains(err, "Mock info error")
-	}
-
-	{
-		// Test with valid request
-		functionSchema := &schemapb.FunctionSchema{
-			Name:             "test_function",
-			Type:             schemapb.FunctionType_BM25,
-			InputFieldNames:  []string{"text_field"},
-			OutputFieldNames: []string{"sparse_field"},
-			Params:           []*commonpb.KeyValuePair{},
-		}
-
-		req := &milvuspb.AddCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_AddCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			CollectionID:   1,
-			FunctionSchema: functionSchema,
-		}
-
-		task := &addCollectionFunctionTask{
-			Condition:                    NewTaskCondition(ctx),
-			AddCollectionFunctionRequest: req,
-		}
-		cache := NewMockCache(f.T())
-		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
-		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(nil, nil).Maybe()
-		globalMetaCache = cache
-		err := task.PreExecute(ctx)
-		f.ErrorContains(err, "not support adding BM25")
-	}
-	{
-		functionSchema := &schemapb.FunctionSchema{
-			Name:             "test_function",
-			Type:             schemapb.FunctionType_TextEmbedding,
-			InputFieldNames:  []string{"text"},
-			OutputFieldNames: []string{"vec"},
-			Params:           []*commonpb.KeyValuePair{},
-		}
-
-		req := &milvuspb.AddCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_AddCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			CollectionID:   1,
-			FunctionSchema: functionSchema,
-		}
-
-		task := &addCollectionFunctionTask{
-			Condition:                    NewTaskCondition(ctx),
-			AddCollectionFunctionRequest: req,
-		}
-		coll := &collectionInfo{
-			schema: &schemaInfo{
-				CollectionSchema: &schemapb.CollectionSchema{
-					Functions: []*schemapb.FunctionSchema{},
-				},
-			},
-		}
-		cache := NewMockCache(f.T())
-		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
-		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(coll, nil).Maybe()
-		m := mockey.Mock(validator.ValidateFunction).Return(nil).Build()
-		defer m.UnPatch()
-		globalMetaCache = cache
-		err := task.PreExecute(ctx)
-		f.NoError(err)
 	}
 }
 
@@ -496,7 +338,8 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 			schema: &schemaInfo{
 				CollectionSchema: &schemapb.CollectionSchema{
 					Functions: []*schemapb.FunctionSchema{
-						{Name: "test_function", Type: schemapb.FunctionType_TextEmbedding},
+						// identity matches the request; a valid alter changes only params
+						{Name: "test_function", Type: schemapb.FunctionType_TextEmbedding, InputFieldNames: []string{"text"}, OutputFieldNames: []string{"vec"}},
 						{Name: "f2", Type: schemapb.FunctionType_TextEmbedding},
 					},
 				},
@@ -511,130 +354,39 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskPreExecute() {
 		err := task.PreExecute(ctx)
 		f.NoError(err)
 	}
-}
-
-func (f *FunctionTaskSuite) TestDropCollectionFunctionTaskPreExecute() {
-	ctx := context.Background()
 	{
-		// Test with valid request
-		req := &milvuspb.DropCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_DropCollectionFunction,
-			},
+		// Altering the output field is rejected: function identity is immutable.
+		req := &milvuspb.AlterCollectionFunctionRequest{
+			Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_AlterCollectionFunction},
 			CollectionName: "test_collection",
+			CollectionID:   1,
 			FunctionName:   "test_function",
-		}
-
-		task := &dropCollectionFunctionTask{
-			Condition:                     NewTaskCondition(ctx),
-			DropCollectionFunctionRequest: req,
-		}
-
-		cache := NewMockCache(f.T())
-		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
-		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(nil, fmt.Errorf("mock error")).Maybe()
-		globalMetaCache = cache
-
-		err := task.PreExecute(ctx)
-		f.ErrorContains(err, "mock error")
-	}
-	{
-		req := &milvuspb.DropCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_DropCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			FunctionName:   "test_function",
-		}
-
-		task := &dropCollectionFunctionTask{
-			Condition:                     NewTaskCondition(ctx),
-			DropCollectionFunctionRequest: req,
-		}
-
-		coll := &collectionInfo{
-			schema: &schemaInfo{
-				CollectionSchema: &schemapb.CollectionSchema{
-					Functions: []*schemapb.FunctionSchema{},
-				},
+			FunctionSchema: &schemapb.FunctionSchema{
+				Name:             "test_function",
+				Type:             schemapb.FunctionType_TextEmbedding,
+				InputFieldNames:  []string{"text"},
+				OutputFieldNames: []string{"other_vec"},
 			},
 		}
-
-		cache := NewMockCache(f.T())
-		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
-		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(coll, nil).Maybe()
-		globalMetaCache = cache
-
-		err := task.PreExecute(ctx)
-		f.NoError(err)
-	}
-	{
-		req := &milvuspb.DropCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_DropCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			FunctionName:   "test_function",
+		task := &alterCollectionFunctionTask{
+			Condition:                      NewTaskCondition(ctx),
+			AlterCollectionFunctionRequest: req,
 		}
-
-		task := &dropCollectionFunctionTask{
-			Condition:                     NewTaskCondition(ctx),
-			DropCollectionFunctionRequest: req,
-		}
-
 		coll := &collectionInfo{
 			schema: &schemaInfo{
 				CollectionSchema: &schemapb.CollectionSchema{
 					Functions: []*schemapb.FunctionSchema{
-						{Name: req.FunctionName},
+						{Name: "test_function", Type: schemapb.FunctionType_TextEmbedding, InputFieldNames: []string{"text"}, OutputFieldNames: []string{"vec"}},
 					},
 				},
 			},
 		}
-
 		cache := NewMockCache(f.T())
 		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
 		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(coll, nil).Maybe()
 		globalMetaCache = cache
-
 		err := task.PreExecute(ctx)
-		f.NoError(err)
-	}
-	{
-		req := &milvuspb.DropCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_DropCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			FunctionName:   "test_function",
-		}
-
-		task := &dropCollectionFunctionTask{
-			Condition:                     NewTaskCondition(ctx),
-			DropCollectionFunctionRequest: req,
-		}
-
-		coll := &collectionInfo{
-			schema: &schemaInfo{
-				CollectionSchema: &schemapb.CollectionSchema{
-					Fields: []*schemapb.FieldSchema{
-						{Name: "text", DataType: schemapb.DataType_VarChar, ExternalField: "text_col"},
-						{Name: "vec", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true},
-					},
-					Functions: []*schemapb.FunctionSchema{
-						{Name: req.FunctionName},
-					},
-				},
-			},
-		}
-
-		cache := NewMockCache(f.T())
-		cache.EXPECT().GetCollectionID(ctx, req.DbName, req.CollectionName).Return(int64(1), nil).Maybe()
-		cache.EXPECT().GetCollectionInfo(ctx, req.DbName, req.CollectionName, int64(1)).Return(coll, nil).Maybe()
-		globalMetaCache = cache
-
-		err := task.PreExecute(ctx)
-		f.ErrorContains(err, externalCollectionFunctionMutationUnsupportedMsg)
+		f.ErrorContains(err, "output fields cannot be altered")
 	}
 }
 
@@ -732,162 +484,24 @@ func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskExecute() {
 	}
 }
 
-func (f *FunctionTaskSuite) TestAddCollectionFunctionTaskExecute() {
+func (f *FunctionTaskSuite) TestAlterCollectionFunctionTaskExecuteRPCError() {
 	ctx := context.Background()
-
-	{
-		mockRootCoord := mocks.NewMockMixCoordClient(f.T())
-
-		functionSchema := &schemapb.FunctionSchema{
-			Name:             "test_function",
-			Type:             schemapb.FunctionType_BM25,
-			InputFieldNames:  []string{"text_field"},
-			OutputFieldNames: []string{"sparse_field"},
-			Params:           []*commonpb.KeyValuePair{},
-		}
-
-		req := &milvuspb.AddCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_AddCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			CollectionID:   1,
-			FunctionSchema: functionSchema,
-		}
-
-		mockRootCoord.EXPECT().AddCollectionFunction(mock.Anything, req).Return(&commonpb.Status{
-			ErrorCode: commonpb.ErrorCode_Success,
-		}, nil)
-
-		task := &addCollectionFunctionTask{
-			Condition:                    NewTaskCondition(ctx),
-			AddCollectionFunctionRequest: req,
-			mixCoord:                     mockRootCoord,
-		}
-
-		err := task.Execute(ctx)
-		f.NoError(err)
+	mockRootCoord := mocks.NewMockMixCoordClient(f.T())
+	req := &milvuspb.AlterCollectionFunctionRequest{
+		Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_AlterCollectionFunction},
+		CollectionName: "test_collection",
+		FunctionName:   "test_function",
+		FunctionSchema: &schemapb.FunctionSchema{Name: "test_function", Type: schemapb.FunctionType_TextEmbedding},
 	}
-
-	{
-		mockRootCoord := mocks.NewMockMixCoordClient(f.T())
-
-		functionSchema := &schemapb.FunctionSchema{
-			Name:             "test_function",
-			Type:             schemapb.FunctionType_BM25,
-			InputFieldNames:  []string{"text_field"},
-			OutputFieldNames: []string{"sparse_field"},
-			Params:           []*commonpb.KeyValuePair{},
-		}
-
-		req := &milvuspb.AddCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_AddCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			CollectionID:   1,
-			FunctionSchema: functionSchema,
-		}
-
-		mockRootCoord.EXPECT().AddCollectionFunction(mock.Anything, req).Return(&commonpb.Status{
-			ErrorCode: commonpb.ErrorCode_UnexpectedError,
-			Reason:    "test error",
-		}, nil)
-
-		task := &addCollectionFunctionTask{
-			Condition:                    NewTaskCondition(ctx),
-			AddCollectionFunctionRequest: req,
-			mixCoord:                     mockRootCoord,
-		}
-		err := task.Execute(ctx)
-		f.Error(err)
+	mockRootCoord.EXPECT().AlterCollectionFunction(mock.Anything, req).Return(&commonpb.Status{
+		ErrorCode: commonpb.ErrorCode_UnexpectedError,
+		Reason:    "test error",
+	}, nil)
+	task := &alterCollectionFunctionTask{
+		Condition:                      NewTaskCondition(ctx),
+		AlterCollectionFunctionRequest: req,
+		mixCoord:                       mockRootCoord,
 	}
-}
-
-func (f *FunctionTaskSuite) TestDropCollectionFunctionTaskExecute() {
-	ctx := context.Background()
-
-	{
-		mockRootCoord := mocks.NewMockMixCoordClient(f.T())
-
-		req := &milvuspb.DropCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_DropCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			CollectionID:   1,
-			FunctionName:   "test_function",
-		}
-
-		mockRootCoord.EXPECT().DropCollectionFunction(mock.Anything, req).Return(&commonpb.Status{
-			ErrorCode: commonpb.ErrorCode_Success,
-		}, nil)
-
-		task := &dropCollectionFunctionTask{
-			Condition:                     NewTaskCondition(ctx),
-			DropCollectionFunctionRequest: req,
-			mixCoord:                      mockRootCoord,
-			fSchema: &schemapb.FunctionSchema{
-				Type: schemapb.FunctionType_TextEmbedding,
-			},
-		}
-
-		err := task.Execute(ctx)
-		f.NoError(err)
-	}
-
-	{
-		mockRootCoord := mocks.NewMockMixCoordClient(f.T())
-
-		req := &milvuspb.DropCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_DropCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			CollectionID:   1,
-			FunctionName:   "test_function",
-		}
-
-		mockRootCoord.EXPECT().DropCollectionFunction(mock.Anything, req).Return(&commonpb.Status{
-			ErrorCode: commonpb.ErrorCode_UnexpectedError,
-			Reason:    "test error",
-		}, nil)
-
-		task := &dropCollectionFunctionTask{
-			Condition:                     NewTaskCondition(ctx),
-			DropCollectionFunctionRequest: req,
-			mixCoord:                      mockRootCoord,
-			fSchema: &schemapb.FunctionSchema{
-				Type: schemapb.FunctionType_TextEmbedding,
-			},
-		}
-
-		err := task.Execute(ctx)
-		f.Error(err)
-	}
-
-	{
-		mockRootCoord := mocks.NewMockMixCoordClient(f.T())
-
-		req := &milvuspb.DropCollectionFunctionRequest{
-			Base: &commonpb.MsgBase{
-				MsgType: commonpb.MsgType_DropCollectionFunction,
-			},
-			CollectionName: "test_collection",
-			CollectionID:   1,
-			FunctionName:   "test_function",
-		}
-
-		task := &dropCollectionFunctionTask{
-			Condition:                     NewTaskCondition(ctx),
-			DropCollectionFunctionRequest: req,
-			mixCoord:                      mockRootCoord,
-			fSchema: &schemapb.FunctionSchema{
-				Type: schemapb.FunctionType_BM25,
-			},
-		}
-
-		err := task.Execute(ctx)
-		f.ErrorContains(err, "currently does not support droping BM25 function")
-	}
+	err := task.Execute(ctx)
+	f.Error(err)
 }

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -1325,53 +1325,17 @@ func (node *Proxy) AlterCollection(ctx context.Context, request *milvuspb.AlterC
 	return act.result, nil
 }
 
+// AddCollectionFunction is the deprecated legacy attach RPC. A function is coupled
+// to its output field: BM25/MinHash add a brand-new output field via
+// add_function_field, and TextEmbedding is defined at collection creation (runtime
+// add awaits embedding backfill). This RPC only allowed the unsafe attach-over-
+// existing-field path, so it is rejected.
 func (node *Proxy) AddCollectionFunction(ctx context.Context, request *milvuspb.AddCollectionFunctionRequest) (*commonpb.Status, error) {
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}
-
-	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-AddCollectionFunction")
-	defer sp.End()
-	method := "AddCollectionFunction"
-	tr := timerecord.NewTimeRecorder(method)
-	task := &addCollectionFunctionTask{
-		ctx:                          ctx,
-		Condition:                    NewTaskCondition(ctx),
-		AddCollectionFunctionRequest: request,
-		mixCoord:                     node.mixCoord,
-	}
-	mlog.Info(ctx, rpcReceived(method))
-
-	if err := node.sched.ddQueue.Enqueue(task); err != nil {
-		mlog.Warn(ctx,
-			rpcFailedToEnqueue(method),
-			mlog.Err(err))
-		return merr.Status(err), nil
-	}
-
-	mlog.Debug(ctx,
-		rpcEnqueued(method),
-		mlog.Uint64("BeginTs", task.BeginTs()),
-		mlog.Uint64("EndTs", task.EndTs()),
-		mlog.Uint64("timestamp", request.Base.Timestamp))
-
-	if err := task.WaitToFinish(); err != nil {
-		mlog.Warn(ctx,
-			rpcFailedToWaitToFinish(method),
-			mlog.Err(err),
-			mlog.Uint64("BeginTs", task.BeginTs()),
-			mlog.Uint64("EndTs", task.EndTs()))
-
-		return merr.Status(err), nil
-	}
-
-	mlog.Info(ctx,
-		rpcDone(method),
-		mlog.Uint64("BeginTs", task.BeginTs()),
-		mlog.Uint64("EndTs", task.EndTs()))
-
-	metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
-	return task.result, nil
+	return merr.Status(merr.WrapErrParameterInvalidMsg(
+		"AddCollectionFunction RPC is no longer supported; add BM25/MinHash via add_function_field, and define a TextEmbedding function at collection creation")), nil
 }
 
 func (node *Proxy) AlterCollectionFunction(ctx context.Context, request *milvuspb.AlterCollectionFunctionRequest) (*commonpb.Status, error) {
@@ -1423,53 +1387,16 @@ func (node *Proxy) AlterCollectionFunction(ctx context.Context, request *milvusp
 	return task.result, nil
 }
 
+// DropCollectionFunction is the deprecated legacy detach RPC. pymilvus
+// drop_collection_function routes through AlterCollectionSchema (drop_function_field
+// / detach) instead, so this RPC is unused; reject to avoid a second, divergent DDL
+// path.
 func (node *Proxy) DropCollectionFunction(ctx context.Context, request *milvuspb.DropCollectionFunctionRequest) (*commonpb.Status, error) {
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}
-
-	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-DropCollectionFunction")
-	defer sp.End()
-	method := "DropCollectionFunction"
-	tr := timerecord.NewTimeRecorder(method)
-	task := &dropCollectionFunctionTask{
-		ctx:                           ctx,
-		Condition:                     NewTaskCondition(ctx),
-		DropCollectionFunctionRequest: request,
-		mixCoord:                      node.mixCoord,
-	}
-	mlog.Info(ctx, rpcReceived(method))
-
-	if err := node.sched.ddQueue.Enqueue(task); err != nil {
-		mlog.Warn(ctx,
-			rpcFailedToEnqueue(method),
-			mlog.Err(err))
-		return merr.Status(err), nil
-	}
-
-	mlog.Debug(ctx,
-		rpcEnqueued(method),
-		mlog.Uint64("BeginTs", task.BeginTs()),
-		mlog.Uint64("EndTs", task.EndTs()),
-		mlog.Uint64("timestamp", request.Base.Timestamp))
-
-	if err := task.WaitToFinish(); err != nil {
-		mlog.Warn(ctx,
-			rpcFailedToWaitToFinish(method),
-			mlog.Err(err),
-			mlog.Uint64("BeginTs", task.BeginTs()),
-			mlog.Uint64("EndTs", task.EndTs()))
-
-		return merr.Status(err), nil
-	}
-
-	mlog.Info(ctx,
-		rpcDone(method),
-		mlog.Uint64("BeginTs", task.BeginTs()),
-		mlog.Uint64("EndTs", task.EndTs()))
-
-	metrics.ProxyReqLatency.WithLabelValues(strconv.FormatInt(paramtable.GetNodeID(), 10), method).Observe(float64(tr.ElapseSpan().Milliseconds()))
-	return task.result, nil
+	return merr.Status(merr.WrapErrParameterInvalidMsg(
+		"DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field")), nil
 }
 
 func (node *Proxy) AlterCollectionField(ctx context.Context, request *milvuspb.AlterCollectionFieldRequest) (*commonpb.Status, error) {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -114,9 +114,7 @@ const (
 	ListAliasesTaskName           = "ListAliasesTask"
 	AlterCollectionTaskName       = "AlterCollectionTask"
 	AlterCollectionFieldTaskName  = "AlterCollectionFieldTask"
-	AddCollectionFunctionTask     = "AddCollectionFunctionTask"
 	AlterCollectionFunctionTask   = "AlterCollectionFunctionTask"
-	DropCollectionFunctionTask    = "DropCollectionFunctionTask"
 	UpsertTaskName                = "UpsertTask"
 	CreateResourceGroupTaskName   = "CreateResourceGroupTask"
 	UpdateResourceGroupsTaskName  = "UpdateResourceGroupsTask"
@@ -1182,6 +1180,9 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 		if err := schemautil.ValidateAlterSchemaAddFunctionPlan(plan); err != nil {
 			return err
 		}
+		if err := schemautil.CheckNoFunctionCascade(t.oldSchema.GetFunctions(), plan.Function); err != nil {
+			return err
+		}
 	}
 
 	// Validate the bound index params against the new field, mirroring the
@@ -1418,18 +1419,15 @@ func validateDropFunction(schema *schemapb.CollectionSchema, functionName string
 	}
 
 	if !dropOutputFields {
-		if targetFunc.GetType() == schemapb.FunctionType_BM25 {
-			return merr.WrapErrParameterInvalidMsg("BM25 function must be dropped with its output field in drop_function_field interface: %s", functionName)
-		}
-		return nil
+		// A function is coupled to its output field for all types: detaching (removing
+		// the function but keeping the field) is never allowed. drop_function always
+		// removes the function together with its output field.
+		return merr.WrapErrParameterInvalidMsg(
+			"detaching a function without dropping its output field is not supported; drop_function always removes the function together with its output field: %s", functionName)
 	}
 
-	switch targetFunc.GetType() {
-	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
-	default:
-		return merr.WrapErrParameterInvalidMsg("only BM25 and MinHash functions support dropping output fields: %s", functionName)
-	}
-
+	// Drop is uniform across function types (no backfill); unlike add_function_field
+	// it is not type-restricted.
 	removedVectors := 0
 	for _, name := range targetFunc.OutputFieldNames {
 		if f := typeutil.GetFieldByName(schema, name); f != nil && typeutil.IsVectorType(f.DataType) {
@@ -2580,9 +2578,11 @@ func validateAlterAnalyzerFieldParam(collSchema *schemapb.CollectionSchema, fiel
 		return merr.WrapErrParameterInvalidMsg("can not alter analyzer params for non-string field %s", fieldName)
 	}
 
-	if typeutil.CreateFieldSchemaHelper(field).EnableMatch() || typeutil.IsBm25FunctionInputField(collSchema, field) {
+	if typeutil.CreateFieldSchemaHelper(field).EnableMatch() ||
+		typeutil.IsBm25FunctionInputField(collSchema, field) ||
+		typeutil.IsMinHashFunctionInputField(collSchema, field) {
 		return merr.WrapErrParameterInvalidMsg(
-			"can not alter analyzer params for field %s after text match is enabled or BM25 function depends on it",
+			"can not alter analyzer params for field %s after text match is enabled or a BM25/MinHash function depends on it",
 			fieldName,
 		)
 	}

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -8012,7 +8012,9 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 	t.Run("PreExecute add function without fieldInfos", func(t *testing.T) {
 		task := buildTask(buildAddFunctionRequest(minHashFunctionOnlySchema), functionOnlyOldSchema)
 		err := task.PreExecute(ctx)
-		assert.NoError(t, err)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorContains(t, err, "adding a function over existing fields is not supported")
 	})
 
 	t.Run("PreExecute rejects function-only BM25 request", func(t *testing.T) {
@@ -8191,7 +8193,7 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 		task := buildTask(req, oldSchema)
 		err := task.PreExecute(ctx)
 		assert.Error(t, err)
-		assert.ErrorContains(t, err, "function output field not found")
+		assert.ErrorContains(t, err, "adding a function over existing fields is not supported")
 	})
 
 	t.Run("PreExecute happy path", func(t *testing.T) {
@@ -8257,16 +8259,13 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 		}
 	})
 
-	t.Run("Execute supports function-only add request", func(t *testing.T) {
+	t.Run("PreExecute rejects function-only add request", func(t *testing.T) {
 		req := buildAddFunctionRequest(minHashFunctionOnlySchema)
 		task := buildTask(req, functionOnlyOldSchema)
 
 		err := task.PreExecute(ctx)
-		assert.NoError(t, err)
-
-		err = task.Execute(ctx)
-		assert.NoError(t, err)
-		assert.Empty(t, req.GetAction().GetAddRequest().GetFieldInfos())
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "adding a function over existing fields is not supported")
 	})
 
 	t.Run("Execute skips nil field infos", func(t *testing.T) {
@@ -8754,7 +8753,7 @@ func TestAlterCollectionSchemaTask_PreExecute(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("drop by function_name - detach minhash success", func(t *testing.T) {
+	t.Run("drop by function_name - detach minhash rejected", func(t *testing.T) {
 		schemaWithFunc := &schemapb.CollectionSchema{
 			Name: "test_collection",
 			Fields: []*schemapb.FieldSchema{
@@ -8783,7 +8782,8 @@ func TestAlterCollectionSchemaTask_PreExecute(t *testing.T) {
 			},
 		}
 		err := task.PreExecute(ctx)
-		assert.NoError(t, err)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "detaching a function without dropping its output field is not supported")
 	})
 
 	t.Run("drop by function_name - bm25 function field success", func(t *testing.T) {
@@ -8976,7 +8976,7 @@ func TestValidateDropFunction(t *testing.T) {
 		assert.Contains(t, err.Error(), "function not found")
 	})
 
-	t.Run("detach minhash function succeeds", func(t *testing.T) {
+	t.Run("detach minhash function rejected", func(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
 				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
@@ -8991,10 +8991,11 @@ func TestValidateDropFunction(t *testing.T) {
 			},
 		}
 		err := validateDropFunction(schema, "minhash_func", false)
-		assert.NoError(t, err)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "detaching a function without dropping its output field is not supported")
 	})
 
-	t.Run("detach bm25 function fails", func(t *testing.T) {
+	t.Run("detach bm25 function rejected", func(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
 				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
@@ -9010,7 +9011,26 @@ func TestValidateDropFunction(t *testing.T) {
 		}
 		err := validateDropFunction(schema, "bm25_func", false)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "BM25 function must be dropped with its output field")
+		assert.Contains(t, err.Error(), "detaching a function without dropping its output field is not supported")
+	})
+
+	t.Run("detach text embedding function rejected (coupled like all types)", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "vec_func_out", DataType: schemapb.DataType_FloatVector},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name: "embed_func", Type: schemapb.FunctionType_TextEmbedding,
+					InputFieldNames: []string{"text"}, OutputFieldNames: []string{"vec_func_out"},
+				},
+			},
+		}
+		err := validateDropFunction(schema, "embed_func", false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "detaching a function without dropping its output field is not supported")
 	})
 
 	t.Run("drop function field leaves another vector field", func(t *testing.T) {
@@ -9051,7 +9071,7 @@ func TestValidateDropFunction(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("drop unsupported function field fails", func(t *testing.T) {
+	t.Run("drop text embedding function field succeeds", func(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
 				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
@@ -9067,8 +9087,7 @@ func TestValidateDropFunction(t *testing.T) {
 			},
 		}
 		err := validateDropFunction(schema, "embed_func", true)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "only BM25 and MinHash functions support dropping output fields")
+		assert.NoError(t, err)
 	})
 
 	t.Run("drop function field would leave no vector field", func(t *testing.T) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field.go
@@ -61,9 +61,11 @@ func validateAlterCollectionFieldAnalyzerMutation(schema *schemapb.CollectionSch
 		return merr.WrapErrParameterInvalidMsg("can not alter analyzer params for non-string field %s", fieldName)
 	}
 	fieldHelper := typeutil.CreateFieldSchemaHelper(field)
-	if fieldHelper.EnableMatch() || typeutil.IsBm25FunctionInputField(schema, field) {
+	if fieldHelper.EnableMatch() ||
+		typeutil.IsBm25FunctionInputField(schema, field) ||
+		typeutil.IsMinHashFunctionInputField(schema, field) {
 		return merr.WrapErrParameterInvalidMsg(
-			"can not alter analyzer params for field %s after text match is enabled or BM25 function depends on it",
+			"can not alter analyzer params for field %s after text match is enabled or a BM25/MinHash function depends on it",
 			fieldName,
 		)
 	}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -108,6 +108,9 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 		if err := schemautil.ValidateAlterSchemaAddFunctionPlan(plan); err != nil {
 			return err
 		}
+		if err := schemautil.CheckNoFunctionCascade(coll.ToCollectionSchemaPB().GetFunctions(), plan.Function); err != nil {
+			return err
+		}
 		for _, function := range coll.Functions {
 			if function.Name == plan.Function.GetName() {
 				return merr.WrapErrParameterInvalidMsg("function already exists, name: %s", plan.Function.GetName())
@@ -371,11 +374,11 @@ func (c *Core) broadcastAlterCollectionSchemaDrop(ctx context.Context, broadcast
 
 	switch id := dropReq.GetIdentifier().(type) {
 	case *milvuspb.AlterCollectionSchemaRequest_DropRequest_FunctionName:
-		if dropReq.GetDropFunctionOutputFields() {
-			schema, properties, droppedFieldIds, err = buildSchemaForDropFunctionField(coll, id.FunctionName)
-		} else {
-			schema, properties, droppedFieldIds, err = buildSchemaForDetachFunction(coll, id.FunctionName)
+		if !dropReq.GetDropFunctionOutputFields() {
+			return merr.WrapErrParameterInvalidMsg(
+				"detaching a function without dropping its output field is not supported; drop_function always removes the function together with its output field: %s", id.FunctionName)
 		}
+		schema, properties, droppedFieldIds, err = buildSchemaForDropFunctionField(coll, id.FunctionName)
 	case *milvuspb.AlterCollectionSchemaRequest_DropRequest_FieldName:
 		schema, properties, droppedFieldIds, err = buildSchemaForDropField(coll, id.FieldName, 0)
 	case *milvuspb.AlterCollectionSchemaRequest_DropRequest_FieldId:
@@ -461,6 +464,12 @@ func buildSchemaForDropField(coll *model.Collection, fieldName string, fieldID i
 		newFields = append(newFields, model.MarshalFieldModel(f))
 	}
 	if droppedField != nil {
+		// Mirror the proxy guard for direct-coord callers: a field a function
+		// depends on must be dropped via the function DDL, not directly, else the
+		// function is orphaned and its stored output invalidated.
+		if fn, kind := functionReferencing(coll.Functions, droppedField.Name); fn != "" {
+			return nil, nil, nil, merr.WrapErrParameterInvalidMsg("field is referenced by function %s as %s, drop function first", fn, kind)
+		}
 		schema = coll.ToCollectionSchemaPB()
 		maxFieldID := maxAssignedFieldIDFromSchema(schema)
 		properties = updateMaxFieldIDProperty(coll.Properties, maxFieldID)
@@ -486,6 +495,11 @@ func buildSchemaForDropField(coll *model.Collection, fieldName string, fieldID i
 		newStructs = append(newStructs, model.MarshalStructArrayFieldModel(s))
 	}
 	if droppedStruct != nil {
+		for _, sub := range droppedStruct.Fields {
+			if fn, kind := functionReferencing(coll.Functions, sub.Name); fn != "" {
+				return nil, nil, nil, merr.WrapErrParameterInvalidMsg("cannot drop struct array field %s: sub-field %s is referenced by function %s as %s", droppedStruct.Name, sub.Name, fn, kind)
+			}
+		}
 		schema = coll.ToCollectionSchemaPB()
 		maxFieldID := maxAssignedFieldIDFromSchema(schema)
 		properties = updateMaxFieldIDProperty(coll.Properties, maxFieldID)
@@ -505,55 +519,44 @@ func buildSchemaForDropField(coll *model.Collection, fieldName string, fieldID i
 	return nil, nil, nil, merr.WrapErrParameterInvalidMsg("field not found with id: %d", fieldID)
 }
 
-func buildSchemaForDetachFunction(coll *model.Collection, functionName string) (
-	schema *schemapb.CollectionSchema,
-	properties []*commonpb.KeyValuePair,
-	droppedFieldIds []int64,
-	err error,
-) {
-	var targetFunc *model.Function
-	for _, fn := range coll.Functions {
-		if fn.Name == functionName {
-			targetFunc = fn
+// resolveOutputFieldIDsFromNames re-derives a function's output field IDs from its
+// OutputFieldNames against the current schema (the authoritative name->id mapping),
+// and rejects if the persisted OutputFieldIDs disagree as a set. A drop deletes by
+// field id, but the proxy guard authorizes by name; a stale/injected persisted id
+// that no name resolves to (e.g. a primary key) would then be deleted past that
+// guard. Re-resolving keeps authorization (name) and action (id) on one carrier.
+// Read-only, unlike resolveFunctionFieldIDs which mutates the schema on add/alter.
+func resolveOutputFieldIDsFromNames(fn *model.Function, fields []*model.Field) ([]int64, error) {
+	nameToID := make(map[string]int64, len(fields))
+	for _, f := range fields {
+		nameToID[f.Name] = f.FieldID
+	}
+	resolved := make([]int64, 0, len(fn.OutputFieldNames))
+	resolvedSet := make(map[int64]struct{}, len(fn.OutputFieldNames))
+	for _, name := range fn.OutputFieldNames {
+		id, ok := nameToID[name]
+		if !ok {
+			return nil, merr.WrapErrParameterInvalidMsg("function %s output field %s not found in schema", fn.Name, name)
+		}
+		resolved = append(resolved, id)
+		resolvedSet[id] = struct{}{}
+	}
+	persistedSet := make(map[int64]struct{}, len(fn.OutputFieldIDs))
+	for _, id := range fn.OutputFieldIDs {
+		persistedSet[id] = struct{}{}
+	}
+	mismatch := len(resolvedSet) != len(persistedSet)
+	for id := range persistedSet {
+		if _, ok := resolvedSet[id]; !ok {
+			mismatch = true
 			break
 		}
 	}
-	if targetFunc == nil {
-		return nil, nil, nil, merr.WrapErrParameterInvalidMsg("function not found: %s", functionName)
+	if mismatch {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"function %s persisted output field ids %v do not align with output field names %v; metadata may be corrupt", fn.Name, fn.OutputFieldIDs, fn.OutputFieldNames)
 	}
-	if targetFunc.Type == schemapb.FunctionType_BM25 {
-		return nil, nil, nil, merr.WrapErrParameterInvalidMsg("BM25 function must be dropped with its output field in drop_function_field interface: %s", functionName)
-	}
-
-	outputFieldIDSet := make(map[int64]struct{}, len(targetFunc.OutputFieldIDs))
-	for _, fid := range targetFunc.OutputFieldIDs {
-		outputFieldIDSet[fid] = struct{}{}
-	}
-
-	newFields := make([]*schemapb.FieldSchema, 0, len(coll.Fields))
-	for _, field := range coll.Fields {
-		fieldSchema := model.MarshalFieldModel(field)
-		if _, ok := outputFieldIDSet[field.FieldID]; ok {
-			fieldSchema.IsFunctionOutput = false
-		}
-		newFields = append(newFields, fieldSchema)
-	}
-
-	newFunctions := make([]*schemapb.FunctionSchema, 0, len(coll.Functions)-1)
-	for _, fn := range coll.Functions {
-		if fn.Name != functionName {
-			newFunctions = append(newFunctions, model.MarshalFunctionModel(fn))
-		}
-	}
-
-	schema = coll.ToCollectionSchemaPB()
-	properties = coll.Properties
-	schema.Fields = newFields
-	schema.Functions = newFunctions
-	schema.Properties = properties
-	schema.Version = coll.SchemaVersion + 1
-
-	return schema, properties, nil, nil
+	return resolved, nil
 }
 
 func buildSchemaForDropFunctionField(coll *model.Collection, functionName string) (
@@ -572,16 +575,29 @@ func buildSchemaForDropFunctionField(coll *model.Collection, functionName string
 	if targetFunc == nil {
 		return nil, nil, nil, merr.WrapErrParameterInvalidMsg("function not found: %s", functionName)
 	}
-	switch targetFunc.Type {
-	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
-	default:
-		return nil, nil, nil, merr.WrapErrParameterInvalidMsg("only BM25 and MinHash functions support dropping output fields: %s", functionName)
+	// Drop is uniform across function types (no backfill); unlike add_function_field
+	// it is not type-restricted. Re-resolve the delete set from names so an injected
+	// persisted id cannot be deleted past the name-based proxy guard.
+	outputFieldIDs, err := resolveOutputFieldIDsFromNames(targetFunc, coll.Fields)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	droppedFieldIds = append(droppedFieldIds, outputFieldIDs...)
+	outputFieldIDSet := make(map[int64]struct{}, len(outputFieldIDs))
+	for _, fid := range outputFieldIDs {
+		outputFieldIDSet[fid] = struct{}{}
 	}
 
-	droppedFieldIds = append(droppedFieldIds, targetFunc.OutputFieldIDs...)
-	outputFieldIDSet := make(map[int64]struct{}, len(targetFunc.OutputFieldIDs))
-	for _, fid := range targetFunc.OutputFieldIDs {
-		outputFieldIDSet[fid] = struct{}{}
+	// Mirror the proxy guard for direct-coord callers: dropping the output vector
+	// field(s) must not leave the collection with no vector field.
+	removedVectors := 0
+	for _, field := range coll.Fields {
+		if _, ok := outputFieldIDSet[field.FieldID]; ok && typeutil.IsVectorType(field.DataType) {
+			removedVectors++
+		}
+	}
+	if removedVectors > 0 && removedVectors >= len(typeutil.GetVectorFieldSchemas(coll.ToCollectionSchemaPB())) {
+		return nil, nil, nil, merr.WrapErrParameterInvalidMsg("cannot drop function %s: it would leave no vector field in the collection", functionName)
 	}
 
 	newFields := make([]*schemapb.FieldSchema, 0, len(coll.Fields))
@@ -607,4 +623,23 @@ func buildSchemaForDropFunctionField(coll *model.Collection, functionName string
 	schema.Version = coll.SchemaVersion + 1
 
 	return schema, properties, droppedFieldIds, nil
+}
+
+// functionReferencing returns the name of the first function referencing fieldName
+// and its role ("input"/"output"), or "" if none. A field a function depends on
+// must not be dropped directly (mirrors the proxy validateDropField guard).
+func functionReferencing(functions []*model.Function, fieldName string) (string, string) {
+	for _, fn := range functions {
+		for _, in := range fn.InputFieldNames {
+			if in == fieldName {
+				return fn.Name, "input"
+			}
+		}
+		for _, out := range fn.OutputFieldNames {
+			if out == fieldName {
+				return fn.Name, "output"
+			}
+		}
+	}
+	return "", ""
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -346,7 +346,7 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 		},
 	})
 	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
-	require.Contains(t, resp.GetAlterStatus().GetReason(), "output field missing_minhash_output")
+	require.Contains(t, resp.GetAlterStatus().GetReason(), "adding a function over existing fields is not supported")
 
 	// case 4.3: BM25 function with multiple output fields is rejected.
 	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{
@@ -608,9 +608,9 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 		},
 	}))
 	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
-	require.Contains(t, resp.GetAlterStatus().GetReason(), "output field missing_minhash_output_late")
+	require.Contains(t, resp.GetAlterStatus().GetReason(), "adding a function over existing fields is not supported")
 
-	// Function-only add cannot relabel an existing field as a function output.
+	// function-only add (marking an existing field as output) is no longer supported.
 	functionOnlyReq := buildAlterSchemaAddFunctionReq(dbName, collectionName, &schemapb.FunctionSchema{
 		Name:             "minhash_existing_fn",
 		Type:             schemapb.FunctionType_MinHash,
@@ -624,36 +624,9 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 		},
 	})
 	resp, err = core.AlterCollectionSchema(ctx, functionOnlyReq)
-	alterErr = merr.CheckRPCCall(resp.GetAlterStatus(), err)
-	require.ErrorIs(t, alterErr, merr.ErrParameterInvalid)
-	require.ErrorContains(t, alterErr, "cannot repurpose existing field")
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 6)
-	coll, err = core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
-	require.NoError(t, err)
-	require.Len(t, coll.Functions, 1)
-	existingOutputFound := false
-	for _, field := range coll.Fields {
-		if field.Name == "existing_minhash_output" {
-			existingOutputFound = true
-			require.False(t, field.IsFunctionOutput)
-		}
-	}
-	require.True(t, existingOutputFound)
-
-	// function-only rejects output fields already owned by another function.
-	resp, err = core.AlterCollectionSchema(ctx, buildAlterSchemaAddFunctionReq(dbName, collectionName, &schemapb.FunctionSchema{
-		Name:             "minhash_existing_fn2",
-		Type:             schemapb.FunctionType_MinHash,
-		InputFieldNames:  []string{"text_input"},
-		OutputFieldNames: []string{"existing_minhash_output"},
-		Params: []*commonpb.KeyValuePair{
-			{Key: "num_hashes", Value: "128"},
-			{Key: "shingle_size", Value: "3"},
-			{Key: "hash_function", Value: "xxhash64"},
-			{Key: "seed", Value: "42"},
-		},
-	}))
-	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+	functionOnlyErr := merr.CheckRPCCall(resp.GetAlterStatus(), err)
+	require.ErrorIs(t, functionOnlyErr, merr.ErrParameterInvalid)
+	require.ErrorContains(t, functionOnlyErr, "adding a function over existing fields is not supported")
 
 	// happy path: add sparse vector output field + BM25 function.
 	firstAlterReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_output", "bm25_fn")
@@ -797,7 +770,7 @@ func TestDDLCallbacksAlterCollectionSchemaAnalyzerFileResourceRefs(t *testing.T)
 	assertFieldNotExists(t, ctx, core, dbName, collectionName, fieldName)
 }
 
-func TestDDLCallbacksAlterCollectionSchemaValidatesFunctionOnlyFinalSchema(t *testing.T) {
+func TestDDLCallbacksAlterCollectionSchemaRejectsFunctionOnlyAdd(t *testing.T) {
 	core := initStreamingSystemAndCore(t)
 
 	ctx := context.Background()
@@ -853,7 +826,7 @@ func TestDDLCallbacksAlterCollectionSchemaValidatesFunctionOnlyFinalSchema(t *te
 	}))
 	alterErr := merr.CheckRPCCall(resp.GetAlterStatus(), err)
 	require.ErrorIs(t, alterErr, merr.ErrParameterInvalid)
-	require.ErrorContains(t, alterErr, "cannot repurpose existing field")
+	require.ErrorContains(t, alterErr, "adding a function over existing fields is not supported")
 	assertSchemaVersion(t, ctx, core, dbName, collectionName, 2)
 }
 
@@ -1084,83 +1057,6 @@ func mustParseInt64(s string) int64 {
 	return v
 }
 
-func TestBuildSchemaForDetachFunction(t *testing.T) {
-	t.Run("function not found", func(t *testing.T) {
-		coll := &model.Collection{
-			Functions: []*model.Function{
-				{Name: "func1", OutputFieldIDs: []int64{103}},
-			},
-		}
-		_, _, _, err := buildSchemaForDetachFunction(coll, "nonexistent")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "function not found")
-	})
-
-	t.Run("detach function keeps output fields", func(t *testing.T) {
-		coll := &model.Collection{
-			Name: "test_coll",
-			Fields: []*model.Field{
-				{FieldID: 100, Name: "pk"},
-				{FieldID: 101, Name: "text"},
-				{FieldID: 102, Name: "minhash_vec", IsFunctionOutput: true},
-				{FieldID: 103, Name: "dense_vec"},
-			},
-			Functions: []*model.Function{
-				{
-					Name:             "minhash_func",
-					Type:             schemapb.FunctionType_MinHash,
-					InputFieldIDs:    []int64{101},
-					InputFieldNames:  []string{"text"},
-					OutputFieldIDs:   []int64{102},
-					OutputFieldNames: []string{"minhash_vec"},
-				},
-				{
-					Name:             "embed_func",
-					Type:             schemapb.FunctionType_TextEmbedding,
-					InputFieldIDs:    []int64{101},
-					InputFieldNames:  []string{"text"},
-					OutputFieldIDs:   []int64{103},
-					OutputFieldNames: []string{"dense_vec"},
-				},
-			},
-			Properties: []*commonpb.KeyValuePair{
-				{Key: common.MaxFieldIDKey, Value: "103"},
-			},
-			SchemaVersion: 3,
-		}
-
-		schema, properties, droppedFieldIDs, err := buildSchemaForDetachFunction(coll, "minhash_func")
-		require.NoError(t, err)
-		require.Empty(t, droppedFieldIDs)
-		require.Equal(t, coll.Properties, properties)
-		require.Equal(t, int32(4), schema.Version)
-
-		require.Len(t, schema.Fields, 4)
-		var minhashField *schemapb.FieldSchema
-		for _, field := range schema.Fields {
-			if field.GetName() == "minhash_vec" {
-				minhashField = field
-				break
-			}
-		}
-		require.NotNil(t, minhashField)
-		require.False(t, minhashField.GetIsFunctionOutput())
-		require.Len(t, schema.Functions, 1)
-		require.Equal(t, "embed_func", schema.Functions[0].GetName())
-	})
-
-	t.Run("detach bm25 function fails", func(t *testing.T) {
-		coll := &model.Collection{
-			Functions: []*model.Function{
-				{Name: "bm25_func", Type: schemapb.FunctionType_BM25, OutputFieldIDs: []int64{102}},
-			},
-		}
-		_, _, _, err := buildSchemaForDetachFunction(coll, "bm25_func")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "BM25 function must be dropped with its output field")
-	})
-}
-
 func TestBuildSchemaForDropFunctionField(t *testing.T) {
 	t.Run("function not found", func(t *testing.T) {
 		coll := &model.Collection{
@@ -1173,15 +1069,43 @@ func TestBuildSchemaForDropFunctionField(t *testing.T) {
 		require.Contains(t, err.Error(), "function not found")
 	})
 
-	t.Run("unsupported function type", func(t *testing.T) {
+	t.Run("dropping the last vector field rejected", func(t *testing.T) {
 		coll := &model.Collection{
-			Functions: []*model.Function{
-				{Name: "embed_func", Type: schemapb.FunctionType_TextEmbedding, OutputFieldIDs: []int64{103}},
+			Fields: []*model.Field{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "only_vec", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true},
 			},
+			Functions: []*model.Function{
+				{Name: "embed_func", Type: schemapb.FunctionType_TextEmbedding, InputFieldIDs: []int64{101}, OutputFieldIDs: []int64{102}, OutputFieldNames: []string{"only_vec"}},
+			},
+			SchemaVersion: 1,
 		}
 		_, _, _, err := buildSchemaForDropFunctionField(coll, "embed_func")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "only BM25 and MinHash functions support dropping output fields")
+		require.ErrorContains(t, err, "leave no vector field")
+	})
+
+	t.Run("text embedding function can be dropped", func(t *testing.T) {
+		coll := &model.Collection{
+			Name: "test_coll",
+			Fields: []*model.Field{
+				{FieldID: 100, Name: "pk"},
+				{FieldID: 101, Name: "text"},
+				{FieldID: 102, Name: "keep_vec"},
+				{FieldID: 103, Name: "dense_vec", IsFunctionOutput: true},
+			},
+			Functions: []*model.Function{
+				{Name: "embed_func", Type: schemapb.FunctionType_TextEmbedding, InputFieldIDs: []int64{101}, OutputFieldIDs: []int64{103}, OutputFieldNames: []string{"dense_vec"}},
+			},
+			SchemaVersion: 2,
+		}
+		schema, _, droppedFieldIDs, err := buildSchemaForDropFunctionField(coll, "embed_func")
+		require.NoError(t, err)
+		require.Equal(t, []int64{103}, droppedFieldIDs)
+		require.Equal(t, 0, len(schema.Functions))
+		for _, f := range schema.Fields {
+			require.NotEqual(t, "dense_vec", f.Name)
+		}
 	})
 
 	t.Run("drop function removes function and output fields", func(t *testing.T) {
@@ -1272,6 +1196,32 @@ func TestBuildSchemaForDropFunctionField(t *testing.T) {
 		require.Equal(t, 1, len(schema.Functions))
 		require.Equal(t, "embed_func", schema.Functions[0].Name)
 	})
+
+	t.Run("corrupt persisted output ids rejected (primary key protection)", func(t *testing.T) {
+		// Stored with output name "sparse_vec" (id 102) but a stale/injected pk id
+		// (100) in OutputFieldIDs; drop must re-resolve from the name and reject the
+		// mismatch instead of deleting the primary key past the name-based guard.
+		coll := &model.Collection{
+			Name: "test_coll",
+			Fields: []*model.Field{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "sparse_vec", DataType: schemapb.DataType_SparseFloatVector},
+				{FieldID: 103, Name: "keep_vec", DataType: schemapb.DataType_FloatVector},
+			},
+			Functions: []*model.Function{
+				{
+					Name: "bm25_func", Type: schemapb.FunctionType_BM25,
+					InputFieldIDs:    []int64{101},
+					OutputFieldIDs:   []int64{100, 102}, // 100 = pk injected
+					OutputFieldNames: []string{"sparse_vec"},
+				},
+			},
+			SchemaVersion: 3,
+		}
+		_, _, _, err := buildSchemaForDropFunctionField(coll, "bm25_func")
+		require.ErrorContains(t, err, "do not align with output field names")
+	})
 }
 
 func TestBuildSchemaForDropField(t *testing.T) {
@@ -1294,6 +1244,18 @@ func TestBuildSchemaForDropField(t *testing.T) {
 		require.NotNil(t, properties)
 		require.Equal(t, []int64{102}, droppedFieldIDs)
 		require.Equal(t, int32(4), schema.Version)
+	})
+
+	t.Run("field referenced by function rejected", func(t *testing.T) {
+		coll := baseColl()
+		coll.Functions = []*model.Function{
+			{Name: "bm25", InputFieldNames: []string{"extra"}, OutputFieldNames: []string{"vec"}},
+		}
+		_, _, _, err := buildSchemaForDropField(coll, "extra", 0)
+		require.ErrorContains(t, err, "referenced by function bm25 as input, drop function first")
+
+		_, _, _, err = buildSchemaForDropField(coll, "vec", 0)
+		require.ErrorContains(t, err, "referenced by function bm25 as output, drop function first")
 	})
 
 	t.Run("drop by field id", func(t *testing.T) {

--- a/internal/rootcoord/ddl_callbacks_collection_function.go
+++ b/internal/rootcoord/ddl_callbacks_collection_function.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
+	"github.com/milvus-io/milvus/internal/util/function/validator"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
@@ -89,6 +90,41 @@ func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.B
 	return nil
 }
 
+// resolveFunctionFieldIDs re-derives the function's input/output field IDs from
+// its field names (the source of truth), discarding any client-supplied IDs — else
+// a request could inject an unrelated field ID that a later drop_function_field
+// would delete. It rejects unknown fields and output fields already owned by
+// another function, and marks the resolved output fields as function outputs.
+func resolveFunctionFieldIDs(ctx context.Context, fSchema *schemapb.FunctionSchema, fieldMapping map[string]*model.Field) error {
+	fSchema.InputFieldIds = make([]int64, 0, len(fSchema.InputFieldNames))
+	for _, name := range fSchema.InputFieldNames {
+		field, exists := fieldMapping[name]
+		if !exists {
+			err := merr.WrapErrParameterInvalidMsg("function's input field %s not exists", name)
+			mlog.Error(ctx, "Incorrect function configuration:", mlog.Err(err))
+			return err
+		}
+		fSchema.InputFieldIds = append(fSchema.InputFieldIds, field.FieldID)
+	}
+	fSchema.OutputFieldIds = make([]int64, 0, len(fSchema.OutputFieldNames))
+	for _, name := range fSchema.OutputFieldNames {
+		field, exists := fieldMapping[name]
+		if !exists {
+			err := merr.WrapErrParameterInvalidMsg("function's output field %s not exists", name)
+			mlog.Error(ctx, "Incorrect function configuration:", mlog.Err(err))
+			return err
+		}
+		if field.IsFunctionOutput {
+			err := merr.WrapErrParameterInvalidMsg("function's output field %s is already of other functions", name)
+			mlog.Error(ctx, "Incorrect function configuration: ", mlog.Err(err))
+			return err
+		}
+		fSchema.OutputFieldIds = append(fSchema.OutputFieldIds, field.FieldID)
+		field.IsFunctionOutput = true
+	}
+	return nil
+}
+
 func alterFunctionGenNewCollection(ctx context.Context, fSchema *schemapb.FunctionSchema, collection *model.Collection) error {
 	if fSchema == nil {
 		return merr.WrapErrParameterInvalidMsg("function schema is empty")
@@ -124,29 +160,8 @@ func alterFunctionGenNewCollection(ctx context.Context, fSchema *schemapb.Functi
 		field.IsFunctionOutput = false
 	}
 
-	for _, name := range fSchema.InputFieldNames {
-		field, exists := fieldMapping[name]
-		if !exists {
-			err := merr.WrapErrParameterInvalidMsg("function's input field %s not exists", name)
-			mlog.Error(ctx, "Incorrect function configuration:", mlog.Err(err))
-			return err
-		}
-		fSchema.InputFieldIds = append(fSchema.InputFieldIds, field.FieldID)
-	}
-	for _, name := range fSchema.OutputFieldNames {
-		field, exists := fieldMapping[name]
-		if !exists {
-			err := merr.WrapErrParameterInvalidMsg("function's output field %s not exists", name)
-			mlog.Error(ctx, "Incorrect function configuration:", mlog.Err(err))
-			return err
-		}
-		if field.IsFunctionOutput {
-			err := merr.WrapErrParameterInvalidMsg("function's output field %s is already of other functions", name)
-			mlog.Error(ctx, "Incorrect function configuration: ", mlog.Err(err))
-			return err
-		}
-		fSchema.OutputFieldIds = append(fSchema.OutputFieldIds, field.FieldID)
-		field.IsFunctionOutput = true
+	if err := resolveFunctionFieldIDs(ctx, fSchema, fieldMapping); err != nil {
+		return err
 	}
 	newFunc := model.UnmarshalFunctionModel(fSchema)
 	newFuncs = append(newFuncs, newFunc)
@@ -169,120 +184,22 @@ func (c *Core) broadcastAlterCollectionForAlterFunction(ctx context.Context, req
 		return err
 	}
 
+	// Only whitelisted params may be altered; function identity (type, name,
+	// input/output fields) is immutable. Skip when the function is absent so the
+	// mutation helper below emits the canonical "not exists" error.
+	for _, fn := range oldColl.Functions {
+		if fn.Name == req.GetFunctionSchema().GetName() {
+			if err := validator.CheckFunctionAlterAllowed(model.MarshalFunctionModel(fn), req.GetFunctionSchema()); err != nil {
+				return err
+			}
+			break
+		}
+	}
+
 	newColl := oldColl.Clone()
 	if err := alterFunctionGenNewCollection(ctx, req.FunctionSchema, newColl); err != nil {
 		return err
 	}
 
-	return callAlterCollection(ctx, c, broadcaster, oldColl, newColl, req.GetDbName(), req.GetCollectionName())
-}
-
-func (c *Core) broadcastAlterCollectionForDropFunction(ctx context.Context, req *milvuspb.DropCollectionFunctionRequest) error {
-	broadcaster, err := c.startBroadcastWithAliasOrCollectionLock(ctx, req.GetDbName(), req.GetCollectionName())
-	if err != nil {
-		return err
-	}
-	defer broadcaster.Close()
-
-	oldColl, err := c.meta.GetCollectionByName(ctx, req.GetDbName(), req.GetCollectionName(), typeutil.MaxTimestamp, false)
-	if err != nil {
-		return err
-	}
-	if err := rejectExternalCollectionFunctionMutation(oldColl.ToCollectionSchemaPB()); err != nil {
-		return err
-	}
-
-	var needDelFunc *model.Function
-	for _, f := range oldColl.Functions {
-		if f.Name == req.FunctionName {
-			needDelFunc = f
-			break
-		}
-	}
-	if needDelFunc == nil {
-		return nil
-	}
-
-	newColl := oldColl.Clone()
-
-	newFuncs := []*model.Function{}
-	for _, f := range newColl.Functions {
-		if f.Name != needDelFunc.Name {
-			newFuncs = append(newFuncs, f)
-		}
-	}
-	newColl.Functions = newFuncs
-
-	fieldMapping := map[int64]*model.Field{}
-	for _, field := range newColl.Fields {
-		fieldMapping[field.FieldID] = field
-	}
-	for _, id := range needDelFunc.OutputFieldIDs {
-		field, exists := fieldMapping[id]
-		if !exists {
-			return merr.WrapErrServiceInternalMsg("function's output field %d not exists", id)
-		}
-		field.IsFunctionOutput = false
-	}
-	return callAlterCollection(ctx, c, broadcaster, oldColl, newColl, req.GetDbName(), req.GetCollectionName())
-}
-
-func (c *Core) broadcastAlterCollectionForAddFunction(ctx context.Context, req *milvuspb.AddCollectionFunctionRequest) error {
-	broadcaster, err := c.startBroadcastWithAliasOrCollectionLock(ctx, req.GetDbName(), req.GetCollectionName())
-	if err != nil {
-		return err
-	}
-	defer broadcaster.Close()
-
-	oldColl, err := c.meta.GetCollectionByName(ctx, req.GetDbName(), req.GetCollectionName(), typeutil.MaxTimestamp, false)
-	if err != nil {
-		return err
-	}
-
-	newColl := oldColl.Clone()
-	fSchema := req.FunctionSchema
-	if fSchema == nil {
-		return merr.WrapErrParameterInvalidMsg("function schema is empty")
-	}
-
-	nextFunctionID := int64(StartOfUserFunctionID)
-	for _, f := range newColl.Functions {
-		if f.Name == fSchema.Name {
-			return merr.WrapErrParameterInvalidMsg("function name already exists: %s", f.Name)
-		}
-		nextFunctionID = max(nextFunctionID, f.ID+1)
-	}
-	fSchema.Id = nextFunctionID
-
-	fieldMapping := map[string]*model.Field{}
-	for _, field := range newColl.Fields {
-		fieldMapping[field.Name] = field
-	}
-	for _, name := range fSchema.InputFieldNames {
-		field, exists := fieldMapping[name]
-		if !exists {
-			err := merr.WrapErrParameterInvalidMsg("function's input field %s not exists", name)
-			mlog.Error(ctx, "Incorrect function configuration:", mlog.Err(err))
-			return err
-		}
-		fSchema.InputFieldIds = append(fSchema.InputFieldIds, field.FieldID)
-	}
-	for _, name := range fSchema.OutputFieldNames {
-		field, exists := fieldMapping[name]
-		if !exists {
-			err := merr.WrapErrParameterInvalidMsg("function's output field %s not exists", name)
-			mlog.Error(ctx, "Incorrect function configuration:", mlog.Err(err))
-			return err
-		}
-		if field.IsFunctionOutput {
-			err := merr.WrapErrParameterInvalidMsg("function's output field %s is already of other functions", name)
-			mlog.Error(ctx, "Incorrect function configuration: ", mlog.Err(err))
-			return err
-		}
-		fSchema.OutputFieldIds = append(fSchema.OutputFieldIds, field.FieldID)
-		field.IsFunctionOutput = true
-	}
-	newFunc := model.UnmarshalFunctionModel(fSchema)
-	newColl.Functions = append(newColl.Functions, newFunc)
 	return callAlterCollection(ctx, c, broadcaster, oldColl, newColl, req.GetDbName(), req.GetCollectionName())
 }

--- a/internal/rootcoord/ddl_callbacks_collection_function_test.go
+++ b/internal/rootcoord/ddl_callbacks_collection_function_test.go
@@ -235,6 +235,28 @@ func (suite *DDLCallbacksCollectionFunctionTestSuite) TestAlterFunctionGenNewCol
 	suite.Len(coll.Functions, 1) // Original + new
 }
 
+func (suite *DDLCallbacksCollectionFunctionTestSuite) TestAlterFunctionGenNewCollection_DiscardsClientFieldIds() {
+	ctx := context.Background()
+	coll := suite.createTestCollection()
+
+	// Client injects bogus field IDs (output_field_ids points at the unrelated
+	// "vector" field 102). Only the name-resolved IDs must persist, else a later
+	// drop_function_field would delete field 102.
+	fSchema := &schemapb.FunctionSchema{
+		Name:             "test_function",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text_field"},
+		InputFieldIds:    []int64{999},
+		OutputFieldNames: []string{"output_field"},
+		OutputFieldIds:   []int64{102},
+	}
+
+	err := alterFunctionGenNewCollection(ctx, fSchema, coll)
+	suite.NoError(err)
+	suite.Equal([]int64{103}, fSchema.InputFieldIds)  // text_field only, 999 discarded
+	suite.Equal([]int64{104}, fSchema.OutputFieldIds) // output_field only, 102 discarded
+}
+
 func (suite *DDLCallbacksCollectionFunctionTestSuite) TestAlterFunctionGenNewCollection_FunctionNotExists() {
 	ctx := context.Background()
 	coll := suite.createTestCollection()
@@ -275,126 +297,6 @@ func (suite *DDLCallbacksCollectionFunctionTestSuite) TestAlterFunctionGenNewCol
 	err := alterFunctionGenNewCollection(ctx, fSchema, coll)
 	suite.Error(err)
 	suite.Contains(err.Error(), "function's output field non_existent_field not exists")
-}
-
-func (suite *DDLCallbacksCollectionFunctionTestSuite) TestBroadcastAlterCollectionForAddFunction_FunctionNameExists() {
-	coll := suite.createTestCollection()
-
-	// Create request with existing function name
-	req := &milvuspb.AddCollectionFunctionRequest{
-		DbName:         "test_db",
-		CollectionName: "test_collection",
-		FunctionSchema: &schemapb.FunctionSchema{
-			Name: "test_function", // Same as existing function
-		},
-	}
-
-	newColl := coll.Clone()
-	fSchema := req.FunctionSchema
-
-	// Check for function name conflict
-	for _, f := range newColl.Functions {
-		if f.Name == fSchema.Name {
-			err := errors.New("function name already exists")
-			suite.Error(err)
-			return
-		}
-	}
-}
-
-// Test broadcastAlterCollectionForDropFunction
-func (suite *DDLCallbacksCollectionFunctionTestSuite) TestBroadcastAlterCollectionForDropFunction_Success() {
-	coll := suite.createTestCollection()
-	req := &milvuspb.DropCollectionFunctionRequest{
-		DbName:         "test_db",
-		CollectionName: "test_collection",
-		FunctionName:   "test_function",
-	}
-
-	// Find function to delete
-	var needDelFunc *model.Function
-	for _, f := range coll.Functions {
-		if f.Name == req.FunctionName {
-			needDelFunc = f
-			break
-		}
-	}
-	suite.NotNil(needDelFunc, "Function should exist")
-
-	newColl := coll.Clone()
-
-	// Remove function from collection
-	newFuncs := []*model.Function{}
-	for _, f := range newColl.Functions {
-		if f.Name != needDelFunc.Name {
-			newFuncs = append(newFuncs, f)
-		}
-	}
-	newColl.Functions = newFuncs
-
-	// Reset output field flags
-	fieldMapping := map[int64]*model.Field{}
-	for _, field := range newColl.Fields {
-		fieldMapping[field.FieldID] = field
-	}
-	for _, id := range needDelFunc.OutputFieldIDs {
-		field, exists := fieldMapping[id]
-		suite.True(exists, "Output field should exist")
-		field.IsFunctionOutput = false
-	}
-
-	// Verify function was removed
-	suite.Len(newColl.Functions, 0)
-
-	// Verify output field is no longer marked as function output
-	outputField := fieldMapping[104] // output_field
-	suite.False(outputField.IsFunctionOutput)
-}
-
-func (suite *DDLCallbacksCollectionFunctionTestSuite) TestBroadcastAlterCollectionForDropFunction_FunctionNotExists() {
-	coll := suite.createTestCollection()
-	req := &milvuspb.DropCollectionFunctionRequest{
-		DbName:         "test_db",
-		CollectionName: "test_collection",
-		FunctionName:   "non_existent_function",
-	}
-
-	// Find function to delete
-	var needDelFunc *model.Function
-	for _, f := range coll.Functions {
-		if f.Name == req.FunctionName {
-			needDelFunc = f
-			break
-		}
-	}
-	suite.Nil(needDelFunc, "Function should not exist")
-	// This should return nil (no error) as per the original implementation
-}
-
-func (suite *DDLCallbacksCollectionFunctionTestSuite) TestBroadcastAlterCollectionForDropFunction_OutputFieldNotExists() {
-	coll := suite.createTestCollection()
-
-	// Create a function with non-existent output field ID
-	needDelFunc := &model.Function{
-		ID:             1001,
-		Name:           "test_function",
-		OutputFieldIDs: []int64{999}, // Non-existent field ID
-	}
-
-	newColl := coll.Clone()
-	fieldMapping := map[int64]*model.Field{}
-	for _, field := range newColl.Fields {
-		fieldMapping[field.FieldID] = field
-	}
-
-	for _, id := range needDelFunc.OutputFieldIDs {
-		_, exists := fieldMapping[id]
-		if !exists {
-			err := errors.New("function's output field not exists")
-			suite.Error(err)
-			return
-		}
-	}
 }
 
 // Test edge cases and error conditions
@@ -468,9 +370,14 @@ func (suite *DDLCallbacksCollectionFunctionTestSuite) TestBroadcastAlterCollecti
 			CollectionName: "test_collection",
 			FunctionSchema: &schemapb.FunctionSchema{
 				Name:             "test_function",
-				Type:             schemapb.FunctionType_BM25,
+				Type:             schemapb.FunctionType_TextEmbedding,
 				InputFieldNames:  []string{"text_field"},
-				OutputFieldNames: []string{"vector"},
+				OutputFieldNames: []string{"output_field"},
+				// identity unchanged; only a whitelisted connection param ("url") is altered
+				Params: []*commonpb.KeyValuePair{
+					{Key: "param1", Value: "value1"},
+					{Key: "url", Value: "http://new-endpoint"},
+				},
 			},
 		}
 		mocker := mockey.Mock(callAlterCollection).Return(nil).Build()
@@ -478,6 +385,30 @@ func (suite *DDLCallbacksCollectionFunctionTestSuite) TestBroadcastAlterCollecti
 
 		err := suite.core.broadcastAlterCollectionForAlterFunction(context.Background(), req)
 		suite.NoError(err)
+	})
+
+	suite.Run("altering non-whitelisted param rejected", func() {
+		coll := suite.createTestCollection()
+
+		mockMeta := mockrootcoord.NewIMetaTable(suite.T())
+		mockMeta.EXPECT().GetCollectionByName(mock.Anything, "test_db", "test_collection", typeutil.MaxTimestamp, mock.Anything).Return(coll, nil)
+		suite.core.meta = mockMeta
+
+		req := &milvuspb.AlterCollectionFunctionRequest{
+			DbName:         "test_db",
+			CollectionName: "test_collection",
+			FunctionSchema: &schemapb.FunctionSchema{
+				Name:             "test_function",
+				Type:             schemapb.FunctionType_TextEmbedding,
+				InputFieldNames:  []string{"text_field"},
+				OutputFieldNames: []string{"output_field"},
+				Params: []*commonpb.KeyValuePair{
+					{Key: "param1", Value: "changed"},
+				},
+			},
+		}
+		err := suite.core.broadcastAlterCollectionForAlterFunction(context.Background(), req)
+		suite.ErrorContains(err, "cannot be altered")
 	})
 
 	suite.Run("external collection rejected", func() {
@@ -500,143 +431,5 @@ func (suite *DDLCallbacksCollectionFunctionTestSuite) TestBroadcastAlterCollecti
 		}
 		err := suite.core.broadcastAlterCollectionForAlterFunction(context.Background(), req)
 		suite.ErrorContains(err, externalCollectionFunctionMutationUnsupportedMsg)
-	})
-}
-
-func (suite *DDLCallbacksCollectionFunctionTestSuite) TestBroadcastAlterCollectionForDropFunction() {
-	suite.Run("success", func() {
-		coll := suite.createTestCollection()
-
-		mockMeta := mockrootcoord.NewIMetaTable(suite.T())
-		mockMeta.EXPECT().GetCollectionByName(mock.Anything, "test_db", "test_collection", typeutil.MaxTimestamp, mock.Anything).Return(coll, nil)
-		suite.core.meta = mockMeta
-
-		req := &milvuspb.DropCollectionFunctionRequest{
-			DbName:         "test_db",
-			CollectionName: "test_collection",
-			FunctionName:   "test_function",
-		}
-
-		mocker := mockey.Mock(callAlterCollection).Return(nil).Build()
-		defer mocker.UnPatch()
-
-		err := suite.core.broadcastAlterCollectionForDropFunction(context.Background(), req)
-		suite.NoError(err)
-	})
-
-	suite.Run("external collection rejected", func() {
-		coll := suite.createTestCollection()
-		coll.Fields[2].ExternalField = "text_col"
-
-		mockMeta := mockrootcoord.NewIMetaTable(suite.T())
-		mockMeta.EXPECT().GetCollectionByName(mock.Anything, "test_db", "test_collection", typeutil.MaxTimestamp, mock.Anything).Return(coll, nil)
-		suite.core.meta = mockMeta
-
-		req := &milvuspb.DropCollectionFunctionRequest{
-			DbName:         "test_db",
-			CollectionName: "test_collection",
-			FunctionName:   "test_function",
-		}
-
-		err := suite.core.broadcastAlterCollectionForDropFunction(context.Background(), req)
-		suite.ErrorContains(err, externalCollectionFunctionMutationUnsupportedMsg)
-	})
-
-	suite.Run("function not exists", func() {
-		coll := suite.createTestCollection()
-
-		mockMeta := mockrootcoord.NewIMetaTable(suite.T())
-		mockMeta.EXPECT().GetCollectionByName(mock.Anything, "test_db", "test_collection", typeutil.MaxTimestamp, mock.Anything).Return(coll, nil)
-		suite.core.meta = mockMeta
-
-		req := &milvuspb.DropCollectionFunctionRequest{
-			DbName:         "test_db",
-			CollectionName: "test_collection",
-			FunctionName:   "non_existent_function",
-		}
-
-		mocker := mockey.Mock(callAlterCollection).Return(nil).Build()
-		defer mocker.UnPatch()
-
-		err := suite.core.broadcastAlterCollectionForDropFunction(context.Background(), req)
-		suite.NoError(err)
-	})
-}
-
-func (suite *DDLCallbacksCollectionFunctionTestSuite) TestBroadcastAlterCollectionForAddFunction() {
-	suite.Run("function name already exists", func() {
-		coll := suite.createTestCollection()
-
-		mockMeta := mockrootcoord.NewIMetaTable(suite.T())
-		mockMeta.EXPECT().GetCollectionByName(mock.Anything, "test_db", "test_collection", typeutil.MaxTimestamp, mock.Anything).Return(coll, nil)
-		suite.core.meta = mockMeta
-
-		req := &milvuspb.AddCollectionFunctionRequest{
-			DbName:         "test_db",
-			CollectionName: "test_collection",
-			FunctionSchema: &schemapb.FunctionSchema{
-				Name:             "test_function",
-				Type:             schemapb.FunctionType_TextEmbedding,
-				InputFieldNames:  []string{"text_field"},
-				OutputFieldNames: []string{"vector"},
-			},
-		}
-
-		mocker := mockey.Mock(callAlterCollection).Return(nil).Build()
-		defer mocker.UnPatch()
-
-		err := suite.core.broadcastAlterCollectionForAddFunction(context.Background(), req)
-		suite.Error(err)
-	})
-
-	suite.Run("function input field not exists", func() {
-		coll := suite.createTestCollection()
-		mockMeta := mockrootcoord.NewIMetaTable(suite.T())
-		mockMeta.EXPECT().GetCollectionByName(mock.Anything, "test_db", "test_collection", typeutil.MaxTimestamp, mock.Anything).Return(coll, nil)
-		suite.core.meta = mockMeta
-
-		req := &milvuspb.AddCollectionFunctionRequest{
-			DbName:         "test_db",
-			CollectionName: "test_collection",
-			FunctionSchema: &schemapb.FunctionSchema{
-				Name:             "new_function",
-				Type:             schemapb.FunctionType_TextEmbedding,
-				InputFieldNames:  []string{"non_existent_field"},
-				OutputFieldNames: []string{"vector"},
-			},
-		}
-
-		mocker := mockey.Mock(callAlterCollection).Return(nil).Build()
-		defer mocker.UnPatch()
-
-		err := suite.core.broadcastAlterCollectionForAddFunction(context.Background(), req)
-		suite.Error(err)
-		suite.Contains(err.Error(), "function's input field non_existent_field not exists")
-	})
-
-	suite.Run("function output field not exists", func() {
-		coll := suite.createTestCollection()
-
-		mockMeta := mockrootcoord.NewIMetaTable(suite.T())
-		mockMeta.EXPECT().GetCollectionByName(mock.Anything, "test_db", "test_collection", typeutil.MaxTimestamp, mock.Anything).Return(coll, nil)
-		suite.core.meta = mockMeta
-
-		req := &milvuspb.AddCollectionFunctionRequest{
-			DbName:         "test_db",
-			CollectionName: "test_collection",
-			FunctionSchema: &schemapb.FunctionSchema{
-				Name:             "new_function2",
-				Type:             schemapb.FunctionType_TextEmbedding,
-				InputFieldNames:  []string{"text_field"},
-				OutputFieldNames: []string{"non_existent_field"},
-			},
-		}
-
-		mocker := mockey.Mock(callAlterCollection).Return(nil).Build()
-		defer mocker.UnPatch()
-
-		err := suite.core.broadcastAlterCollectionForAddFunction(context.Background(), req)
-		suite.Error(err)
-		suite.Contains(err.Error(), "function's output field non_existent_field not exists")
 	})
 }

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -1423,31 +1423,16 @@ func (c *Core) AlterCollection(ctx context.Context, in *milvuspb.AlterCollection
 	return merr.Success(), nil
 }
 
+// AddCollectionFunction is the deprecated legacy attach RPC; it only allowed the
+// unsafe attach-over-existing-field path. A function is coupled to its output field
+// (BM25/MinHash via add_function_field; TextEmbedding at collection creation), so
+// this path is rejected.
 func (c *Core) AddCollectionFunction(ctx context.Context, in *milvuspb.AddCollectionFunctionRequest) (*commonpb.Status, error) {
 	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}
-
-	metrics.RootCoordDDLReqCounter.WithLabelValues("AddCollectionFunction", metrics.TotalLabel).Inc()
-	tr := timerecord.NewTimeRecorder("AddCollectionFunction")
-
-	mlog.Info(context.TODO(), "received request to Add collection function")
-
-	if err := c.broadcastAlterCollectionForAddFunction(ctx, in); err != nil {
-		if errors.Is(err, errIgnoredAlterCollection) {
-			mlog.Info(context.TODO(), "add collection function make no changes, ignore it")
-			metrics.RootCoordDDLReqCounter.WithLabelValues("AddCollectionFunction", metrics.SuccessLabel).Inc()
-			return merr.Success(), nil
-		}
-		mlog.Warn(context.TODO(), "failed to alter collection function", mlog.Err(err))
-		metrics.RootCoordDDLReqCounter.WithLabelValues("AddCollectionFunction", metrics.FailLabel).Inc()
-		return merr.Status(err), nil
-	}
-
-	metrics.RootCoordDDLReqCounter.WithLabelValues("AddCollectionFunction", metrics.SuccessLabel).Inc()
-	metrics.RootCoordDDLReqLatency.WithLabelValues("AddCollectionFunction").Observe(float64(tr.ElapseSpan().Milliseconds()))
-	mlog.Info(context.TODO(), "done to add collection function")
-	return merr.Success(), nil
+	return merr.Status(merr.WrapErrParameterInvalidMsg(
+		"AddCollectionFunction RPC is no longer supported; add BM25/MinHash via add_function_field, and define a TextEmbedding function at collection creation")), nil
 }
 
 func (c *Core) AlterCollectionFunction(ctx context.Context, in *milvuspb.AlterCollectionFunctionRequest) (*commonpb.Status, error) {
@@ -1477,31 +1462,15 @@ func (c *Core) AlterCollectionFunction(ctx context.Context, in *milvuspb.AlterCo
 	return merr.Success(), nil
 }
 
+// DropCollectionFunction is the deprecated legacy detach RPC; pymilvus routes
+// drop through AlterCollectionSchema (drop_function_field / detach), so this path
+// is unused. Reject to avoid a second, divergent DDL path.
 func (c *Core) DropCollectionFunction(ctx context.Context, in *milvuspb.DropCollectionFunctionRequest) (*commonpb.Status, error) {
 	if err := merr.CheckHealthy(c.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}
-
-	metrics.RootCoordDDLReqCounter.WithLabelValues("DropCollectionFunction", metrics.TotalLabel).Inc()
-	tr := timerecord.NewTimeRecorder("DropCollectionFunction")
-
-	mlog.Info(context.TODO(), "received request to drop collection function")
-
-	if err := c.broadcastAlterCollectionForDropFunction(ctx, in); err != nil {
-		if errors.Is(err, errIgnoredAlterCollection) {
-			mlog.Info(context.TODO(), "Drop collection function make no changes, ignore it")
-			metrics.RootCoordDDLReqCounter.WithLabelValues("DropCollectionFunction", metrics.SuccessLabel).Inc()
-			return merr.Success(), nil
-		}
-		mlog.Warn(context.TODO(), "failed to drop collection function", mlog.Err(err))
-		metrics.RootCoordDDLReqCounter.WithLabelValues("DropCollectionFunction", metrics.FailLabel).Inc()
-		return merr.Status(err), nil
-	}
-
-	metrics.RootCoordDDLReqCounter.WithLabelValues("DropCollectionFunction", metrics.SuccessLabel).Inc()
-	metrics.RootCoordDDLReqLatency.WithLabelValues("DropCollectionFunction").Observe(float64(tr.ElapseSpan().Milliseconds()))
-	mlog.Info(context.TODO(), "done to drop collection function")
-	return merr.Success(), nil
+	return merr.Status(merr.WrapErrParameterInvalidMsg(
+		"DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field")), nil
 }
 
 func (c *Core) AlterCollectionField(ctx context.Context, in *milvuspb.AlterCollectionFieldRequest) (*commonpb.Status, error) {

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -1397,26 +1397,14 @@ func TestRootCoord_AddCollectionFunction(t *testing.T) {
 		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetErrorCode())
 	})
 
-	t.Run("run ok", func(t *testing.T) {
+	// Deprecated legacy RPC: always rejects (add BM25/MinHash via add_function_field,
+	// define TextEmbedding at collection creation).
+	t.Run("rejected", func(t *testing.T) {
 		ctx := context.Background()
-		c := initStreamingSystemAndCore(t)
-		defer c.Stop()
-		mocker := mockey.Mock((*Core).broadcastAlterCollectionForAddFunction).Return(nil).Build()
-		defer mocker.UnPatch()
+		c := newTestCore(withHealthyCode())
 		resp, err := c.AddCollectionFunction(ctx, &milvuspb.AddCollectionFunctionRequest{})
 		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_Success, resp.GetErrorCode())
-	})
-
-	t.Run("run failed", func(t *testing.T) {
-		ctx := context.Background()
-		c := initStreamingSystemAndCore(t)
-		defer c.Stop()
-		mocker := mockey.Mock((*Core).broadcastAlterCollectionForAddFunction).Return(fmt.Errorf("")).Build()
-		defer mocker.UnPatch()
-		resp, err := c.AddCollectionFunction(ctx, &milvuspb.AddCollectionFunctionRequest{})
-		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, resp.GetErrorCode())
+		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetErrorCode())
 	})
 }
 
@@ -1429,26 +1417,13 @@ func TestRootCoord_DropCollectionFunction(t *testing.T) {
 		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetErrorCode())
 	})
 
-	t.Run("run ok", func(t *testing.T) {
+	// Deprecated legacy RPC: always rejects (drop routes through drop_function_field).
+	t.Run("rejected", func(t *testing.T) {
 		ctx := context.Background()
-		c := initStreamingSystemAndCore(t)
-		defer c.Stop()
-		mocker := mockey.Mock((*Core).broadcastAlterCollectionForDropFunction).Return(nil).Build()
-		defer mocker.UnPatch()
+		c := newTestCore(withHealthyCode())
 		resp, err := c.DropCollectionFunction(ctx, &milvuspb.DropCollectionFunctionRequest{})
 		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_Success, resp.GetErrorCode())
-	})
-
-	t.Run("run failed", func(t *testing.T) {
-		ctx := context.Background()
-		c := initStreamingSystemAndCore(t)
-		defer c.Stop()
-		mocker := mockey.Mock((*Core).broadcastAlterCollectionForDropFunction).Return(fmt.Errorf("")).Build()
-		defer mocker.UnPatch()
-		resp, err := c.DropCollectionFunction(ctx, &milvuspb.DropCollectionFunctionRequest{})
-		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, resp.GetErrorCode())
+		assert.NotEqual(t, commonpb.ErrorCode_Success, resp.GetErrorCode())
 	})
 }
 

--- a/internal/util/function/validator/alter_whitelist.go
+++ b/internal/util/function/validator/alter_whitelist.go
@@ -1,0 +1,126 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// alterableFunctionParams lists, per function type, the param keys that
+// alter_function may change. Only pure connection/auth/perf knobs are allowed —
+// params that never change the produced vector for a given input. Any param that
+// can change the output vector's semantics or shape is immutable, because altering
+// it on an already-backfilled output field would silently mix incompatible vectors
+// in the same field. A function type absent from this map (BM25, MinHash) has no
+// alterable params.
+//
+// Immutable (semantic) params, by first principle "same input must keep producing a
+// compatible vector":
+//   - dim / model_name / provider / normalization / prompts: change the model or its
+//     output shape.
+//   - endpoint: for TEI the endpoint IS the model's identity, so repointing it can
+//     silently swap to a different model.
+//   - truncate / truncation_direction: for an over-length input they change which
+//     tokens are embedded (truncate on/off, head vs tail), so the produced vector
+//     differs — altering them mixes old and new vector semantics in one field.
+//
+// url stays alterable because model_name providers keep their identity in model_name
+// and use url only as a relocatable API host.
+var alterableFunctionParams = map[schemapb.FunctionType]typeutil.Set[string]{
+	schemapb.FunctionType_TextEmbedding: typeutil.NewSet(
+		models.URLParamKey,
+		models.CredentialParamKey,
+		models.TimeoutMsParamKey,
+		models.MaxClientBatchSizeParamKey,
+		models.RegionParamKey,
+		models.LocationParamKey,
+		models.ProjectIDParamKey,
+		models.UserParamKey,
+	),
+}
+
+// CheckFunctionAlterAllowed rejects an alter_function request that changes
+// anything other than whitelisted params. The function identity (type, name,
+// input/output fields) is immutable; only connection/runtime params may change.
+func CheckFunctionAlterAllowed(oldFn, newFn *schemapb.FunctionSchema) error {
+	if oldFn.GetType() != newFn.GetType() {
+		return merr.WrapErrParameterInvalidMsg("function type cannot be altered: function %s", oldFn.GetName())
+	}
+	if oldFn.GetName() != newFn.GetName() {
+		return merr.WrapErrParameterInvalidMsg("function name cannot be altered: %s -> %s", oldFn.GetName(), newFn.GetName())
+	}
+	if !slices.Equal(oldFn.GetInputFieldNames(), newFn.GetInputFieldNames()) {
+		return merr.WrapErrParameterInvalidMsg("function input fields cannot be altered: function %s", oldFn.GetName())
+	}
+	if !slices.Equal(oldFn.GetOutputFieldNames(), newFn.GetOutputFieldNames()) {
+		return merr.WrapErrParameterInvalidMsg("function output fields cannot be altered: function %s", oldFn.GetName())
+	}
+
+	whitelist := alterableFunctionParams[oldFn.GetType()]
+	if len(whitelist) == 0 {
+		return merr.WrapErrParameterInvalidMsg("function type %s has no alterable params", oldFn.GetType().String())
+	}
+	oldParams, err := normalizeParams(oldFn.GetParams())
+	if err != nil {
+		return err
+	}
+	newParams, err := normalizeParams(newFn.GetParams())
+	if err != nil {
+		return err
+	}
+	changed := typeutil.NewSet[string]()
+	for k, ov := range oldParams {
+		if nv, ok := newParams[k]; !ok || nv != ov {
+			changed.Insert(k)
+		}
+	}
+	for k := range newParams {
+		if _, ok := oldParams[k]; !ok {
+			changed.Insert(k)
+		}
+	}
+	for k := range changed {
+		if !whitelist.Contain(k) {
+			return merr.WrapErrParameterInvalidMsg(
+				"function param %q cannot be altered for function %s; only connection/runtime params may be changed", k, oldFn.GetName())
+		}
+	}
+	return nil
+}
+
+// normalizeParams lowercases param keys (matching how providers read them, e.g.
+// getProvider) and rejects duplicate keys, so a crafted duplicate key cannot slip
+// a non-whitelisted change past the diff while the runtime binds to a different
+// occurrence.
+func normalizeParams(params []*commonpb.KeyValuePair) (map[string]string, error) {
+	m := make(map[string]string, len(params))
+	for _, p := range params {
+		k := strings.ToLower(p.GetKey())
+		if _, dup := m[k]; dup {
+			return nil, merr.WrapErrParameterInvalidMsg("duplicate function param key %q", p.GetKey())
+		}
+		m[k] = p.GetValue()
+	}
+	return m, nil
+}

--- a/internal/util/function/validator/alter_whitelist_test.go
+++ b/internal/util/function/validator/alter_whitelist_test.go
@@ -1,0 +1,127 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+func kv(k, v string) *commonpb.KeyValuePair { return &commonpb.KeyValuePair{Key: k, Value: v} }
+
+func embFn(params ...*commonpb.KeyValuePair) *schemapb.FunctionSchema {
+	return &schemapb.FunctionSchema{
+		Name:             "emb",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vec"},
+		Params:           params,
+	}
+}
+
+func TestCheckFunctionAlterAllowed(t *testing.T) {
+	old := embFn(kv("model_name", "m1"), kv("dim", "8"), kv("url", "http://a"))
+
+	t.Run("change whitelisted param -> ok", func(t *testing.T) {
+		newFn := embFn(kv("model_name", "m1"), kv("dim", "8"), kv("url", "http://b"))
+		assert.NoError(t, CheckFunctionAlterAllowed(old, newFn))
+	})
+
+	t.Run("add whitelisted param -> ok", func(t *testing.T) {
+		newFn := embFn(kv("model_name", "m1"), kv("dim", "8"), kv("url", "http://a"), kv("timeout_ms", "1000"))
+		assert.NoError(t, CheckFunctionAlterAllowed(old, newFn))
+	})
+
+	t.Run("remove whitelisted param -> ok", func(t *testing.T) {
+		newFn := embFn(kv("model_name", "m1"), kv("dim", "8"))
+		assert.NoError(t, CheckFunctionAlterAllowed(old, newFn))
+	})
+
+	t.Run("change truncate/truncation_direction -> rejected (semantic for long inputs)", func(t *testing.T) {
+		oldT := embFn(kv("provider", "TEI"), kv("endpoint", "http://tei"))
+		newT := embFn(kv("provider", "TEI"), kv("endpoint", "http://tei"), kv("truncate", "true"), kv("truncation_direction", "Left"))
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(oldT, newT), "cannot be altered")
+	})
+
+	t.Run("change non-whitelisted param -> rejected", func(t *testing.T) {
+		newFn := embFn(kv("model_name", "m2"), kv("dim", "8"), kv("url", "http://a"))
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(old, newFn), "cannot be altered")
+	})
+
+	t.Run("change dim -> rejected", func(t *testing.T) {
+		newFn := embFn(kv("model_name", "m1"), kv("dim", "16"), kv("url", "http://a"))
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(old, newFn), "cannot be altered")
+	})
+
+	t.Run("change endpoint -> rejected (TEI model identity)", func(t *testing.T) {
+		oldE := embFn(kv("model_name", "m1"), kv("endpoint", "http://tei-a"))
+		newE := embFn(kv("model_name", "m1"), kv("endpoint", "http://tei-b"))
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(oldE, newE), "cannot be altered")
+	})
+
+	t.Run("duplicate provider key -> rejected (no last-wins bypass)", func(t *testing.T) {
+		// last-wins map would see provider unchanged; runtime getProvider is first-wins.
+		oldD := embFn(kv("provider", "openai"), kv("url", "http://a"))
+		newD := embFn(kv("provider", "evil"), kv("provider", "openai"), kv("url", "http://a"))
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(oldD, newD), "duplicate function param key")
+	})
+
+	t.Run("change type -> rejected", func(t *testing.T) {
+		newFn := embFn(kv("model_name", "m1"), kv("dim", "8"), kv("url", "http://a"))
+		newFn.Type = schemapb.FunctionType_BM25
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(old, newFn), "type cannot be altered")
+	})
+
+	t.Run("change input field -> rejected", func(t *testing.T) {
+		newFn := embFn(kv("model_name", "m1"), kv("dim", "8"), kv("url", "http://a"))
+		newFn.InputFieldNames = []string{"other"}
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(old, newFn), "input fields cannot be altered")
+	})
+
+	t.Run("change output field -> rejected", func(t *testing.T) {
+		newFn := embFn(kv("model_name", "m1"), kv("dim", "8"), kv("url", "http://a"))
+		newFn.OutputFieldNames = []string{"other"}
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(old, newFn), "output fields cannot be altered")
+	})
+
+	t.Run("bm25 has no alterable params", func(t *testing.T) {
+		oldBM := &schemapb.FunctionSchema{
+			Name: "b", Type: schemapb.FunctionType_BM25,
+			InputFieldNames: []string{"t"}, OutputFieldNames: []string{"s"},
+		}
+		newBM := &schemapb.FunctionSchema{
+			Name: "b", Type: schemapb.FunctionType_BM25,
+			InputFieldNames: []string{"t"}, OutputFieldNames: []string{"s"},
+			Params: []*commonpb.KeyValuePair{kv("k1", "1.5")},
+		}
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(oldBM, newBM), "has no alterable params")
+	})
+
+	t.Run("minhash has no alterable params (even with no change)", func(t *testing.T) {
+		mh := func() *schemapb.FunctionSchema {
+			return &schemapb.FunctionSchema{
+				Name: "m", Type: schemapb.FunctionType_MinHash,
+				InputFieldNames: []string{"t"}, OutputFieldNames: []string{"sig"},
+			}
+		}
+		assert.ErrorContains(t, CheckFunctionAlterAllowed(mh(), mh()), "has no alterable params")
+	})
+}

--- a/internal/util/function/validator/validator.go
+++ b/internal/util/function/validator/validator.go
@@ -87,6 +87,17 @@ func ValidateFunction(coll *schemapb.CollectionSchema, needValidateFunctionName 
 			return err
 		}
 	}
+	// No cascade: a function's input must not be another function's output. A field
+	// cannot be a function's own input and output (rejected above), so any input in
+	// usedOutputField belongs to a different function. Enforced here so it holds on
+	// every path (create, legacy add, alter), not only add_function_field.
+	for _, function := range coll.GetFunctions() {
+		for _, name := range function.GetInputFieldNames() {
+			if usedOutputField.Contain(name) {
+				return merr.WrapErrParameterInvalidMsg("function %s input field %s is the output of another function; function cascade is not supported", function.GetName(), name)
+			}
+		}
+	}
 	if !disableRuntimeCheck {
 		if err := embedding.ValidateFunctions(coll, needValidateFunctionName, &models.ModelExtraInfo{ClusterID: paramtable.Get().CommonCfg.ClusterPrefix.GetValue(), DBName: coll.DbName}); err != nil {
 			return err

--- a/internal/util/schemautil/alter_schema_add.go
+++ b/internal/util/schemautil/alter_schema_add.go
@@ -113,10 +113,8 @@ func ValidateAlterSchemaAddFunctionPlan(plan *AlterSchemaAddPlan) error {
 	function := plan.Function
 	switch plan.Kind {
 	case AlterSchemaAddFunction:
-		if function.GetType() == schemapb.FunctionType_BM25 {
-			return merr.WrapErrParameterInvalidMsg("BM25 function must be added with its output field in add_function_field interface")
-		}
-		return nil
+		return merr.WrapErrParameterInvalidMsg(
+			"adding a function over existing fields is not supported; use add_function_field to add the function together with its new output field")
 	case AlterSchemaAddFunctionField:
 		if err := validateAddFunctionFieldAllowed(function); err != nil {
 			return err
@@ -172,4 +170,26 @@ func validateAddFunctionFieldInputOutput(function *schemapb.FunctionSchema) erro
 	default:
 		return merr.WrapErrParameterInvalidMsg("unsupported function type in alter schema task: %s", function.GetType().String())
 	}
+}
+
+// CheckNoFunctionCascade rejects a new function whose input field is the output
+// field of an existing function. Cascade (function-on-function) is unsupported:
+// the executor has no topological execution and backfill has no dependency
+// ordering, so a chained output can never be materialized in a defined order.
+func CheckNoFunctionCascade(existingFunctions []*schemapb.FunctionSchema, newFunction *schemapb.FunctionSchema) error {
+	if newFunction == nil {
+		return nil
+	}
+	existingOutputs := typeutil.NewSet[string]()
+	for _, fn := range existingFunctions {
+		existingOutputs.Insert(fn.GetOutputFieldNames()...)
+	}
+	for _, input := range newFunction.GetInputFieldNames() {
+		if existingOutputs.Contain(input) {
+			return merr.WrapErrParameterInvalidMsg(
+				"function %s input field %s is the output of another function; function cascade is not supported",
+				newFunction.GetName(), input)
+		}
+	}
+	return nil
 }

--- a/internal/util/schemautil/alter_schema_add_test.go
+++ b/internal/util/schemautil/alter_schema_add_test.go
@@ -1,0 +1,57 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemautil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+func TestValidateAlterSchemaAddFunctionPlan_StandaloneAddRejected(t *testing.T) {
+	plan := &AlterSchemaAddPlan{
+		Kind:     AlterSchemaAddFunction,
+		Function: &schemapb.FunctionSchema{Name: "f", Type: schemapb.FunctionType_TextEmbedding},
+	}
+	err := ValidateAlterSchemaAddFunctionPlan(plan)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "adding a function over existing fields is not supported")
+}
+
+func TestCheckNoFunctionCascade(t *testing.T) {
+	existing := []*schemapb.FunctionSchema{
+		{Name: "bm25", OutputFieldNames: []string{"sparse"}},
+	}
+
+	t.Run("input is another function's output -> rejected", func(t *testing.T) {
+		newFn := &schemapb.FunctionSchema{Name: "f2", InputFieldNames: []string{"sparse"}, OutputFieldNames: []string{"vec"}}
+		err := CheckNoFunctionCascade(existing, newFn)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cascade is not supported")
+	})
+
+	t.Run("input is a free field -> ok", func(t *testing.T) {
+		newFn := &schemapb.FunctionSchema{Name: "f2", InputFieldNames: []string{"text"}, OutputFieldNames: []string{"vec"}}
+		assert.NoError(t, CheckNoFunctionCascade(existing, newFn))
+	})
+
+	t.Run("nil function -> ok", func(t *testing.T) {
+		assert.NoError(t, CheckNoFunctionCascade(existing, nil))
+	})
+}

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -4073,12 +4073,12 @@ func IsBM25FunctionOutputField(field *schemapb.FieldSchema, collSchema *schemapb
 	return false
 }
 
-func IsBm25FunctionInputField(coll *schemapb.CollectionSchema, field *schemapb.FieldSchema) bool {
+func isFunctionInputFieldOfType(coll *schemapb.CollectionSchema, field *schemapb.FieldSchema, fnType schemapb.FunctionType) bool {
 	if coll == nil || field == nil {
 		return false
 	}
 	for _, fn := range coll.GetFunctions() {
-		if fn.GetType() != schemapb.FunctionType_BM25 {
+		if fn.GetType() != fnType {
 			continue
 		}
 		if field.GetFieldID() != 0 && len(fn.GetInputFieldIds()) > 0 {
@@ -4096,6 +4096,18 @@ func IsBm25FunctionInputField(coll *schemapb.CollectionSchema, field *schemapb.F
 		}
 	}
 	return false
+}
+
+func IsBm25FunctionInputField(coll *schemapb.CollectionSchema, field *schemapb.FieldSchema) bool {
+	return isFunctionInputFieldOfType(coll, field, schemapb.FunctionType_BM25)
+}
+
+// IsMinHashFunctionInputField reports whether field is the input of a MinHash
+// function. Like BM25, MinHash tokenizes the input text through the field's
+// analyzer, so its analyzer params must not change after backfill or stored
+// signatures would silently disagree with newly written ones.
+func IsMinHashFunctionInputField(coll *schemapb.CollectionSchema, field *schemapb.FieldSchema) bool {
+	return isFunctionInputFieldOfType(coll, field, schemapb.FunctionType_MinHash)
 }
 
 func IsMinHashFunctionOutputField(field *schemapb.FieldSchema, collSchema *schemapb.CollectionSchema) bool {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5060,6 +5060,45 @@ func TestIsBm25FunctionInputField(t *testing.T) {
 	assert.False(t, IsBm25FunctionInputField(nilSchema, nilSchema.Fields[0]))
 }
 
+func TestIsMinHashFunctionInputField(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 101, Name: "sig", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true},
+			{FieldID: 102, Name: "bm25_in", DataType: schemapb.DataType_VarChar},
+			{FieldID: 103, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name: "minhash_func", Type: schemapb.FunctionType_MinHash,
+				InputFieldIds: []int64{100}, InputFieldNames: []string{"text"},
+				OutputFieldIds: []int64{101}, OutputFieldNames: []string{"sig"},
+			},
+			{
+				Name: "bm25_func", Type: schemapb.FunctionType_BM25,
+				InputFieldIds: []int64{102}, InputFieldNames: []string{"bm25_in"},
+				OutputFieldIds: []int64{103}, OutputFieldNames: []string{"sparse"},
+			},
+		},
+	}
+	// each helper matches only its own function type's input field
+	assert.True(t, IsMinHashFunctionInputField(schema, schema.Fields[0])) // text -> minhash input
+	assert.False(t, IsBm25FunctionInputField(schema, schema.Fields[0]))
+	assert.True(t, IsBm25FunctionInputField(schema, schema.Fields[2])) // bm25_in -> bm25 input
+	assert.False(t, IsMinHashFunctionInputField(schema, schema.Fields[2]))
+	assert.False(t, IsMinHashFunctionInputField(schema, schema.Fields[1])) // output field
+
+	// name fallback (no field ids assigned yet) + nil safety
+	schemaNoIDs := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{{Name: "text", DataType: schemapb.DataType_VarChar}},
+		Functions: []*schemapb.FunctionSchema{
+			{Name: "mh", Type: schemapb.FunctionType_MinHash, InputFieldNames: []string{"text"}},
+		},
+	}
+	assert.True(t, IsMinHashFunctionInputField(schemaNoIDs, schemaNoIDs.Fields[0]))
+	assert.False(t, IsMinHashFunctionInputField(nil, schemaNoIDs.Fields[0]))
+}
+
 func TestIsMinHashFunctionOutputField(t *testing.T) {
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{

--- a/tests/python_client/milvus_client/test_drop_field_feature.py
+++ b/tests/python_client/milvus_client/test_drop_field_feature.py
@@ -301,7 +301,8 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "BM25 function must be dropped with its output field in drop_function_field interface: "
+                    "detaching a function without dropping its output field is not supported; "
+                    "drop_function always removes the function together with its output field: "
                     "bm25: invalid parameter"
                 ),
             },
@@ -1250,7 +1251,8 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "BM25 function must be dropped with its output field in drop_function_field interface: "
+                    "detaching a function without dropping its output field is not supported; "
+                    "drop_function always removes the function together with its output field: "
                     "bm25: invalid parameter"
                 ),
             },
@@ -1327,9 +1329,9 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         """
         TC-L1-07a: Drop Function detach vs cascade semantics for MinHash.
 
-        target: verify MinHash supports both detach-only and cascade-output-field drop paths
-        method: drop_collection_function keeps output field/index; drop_function_field removes output field/index
-        expected: detach removes only the function; cascade removes function, output field, and output index
+        target: verify MinHash detach-only drop is rejected and cascade-output-field drop works
+        method: drop_collection_function (detach) is rejected; drop_function_field removes function + output field/index
+        expected: detach rejected (function/field unchanged); cascade removes function, output field, and output index
         """
         client = self._client()
         detach_collection_name = f"{cf.gen_collection_name_by_testcase_name()}_detach"
@@ -1393,29 +1395,30 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             assert len(search_res[0]) > 0
             assert "doc" in search_res[0][0]["entity"]
 
-        # Step 1: Detach-only MinHash drop removes the function but keeps output field/index.
+        # Step 1: Detach-only MinHash drop is rejected; the function keeps its output field.
         create_minhash_collection(detach_collection_name)
-        client.drop_collection_function(detach_collection_name, "text_to_minhash")
+        self.drop_collection_function(
+            client,
+            detach_collection_name,
+            "text_to_minhash",
+            check_task=ct.CheckTasks.err_res,
+            check_items={
+                ct.err_code: 1100,
+                ct.err_msg: (
+                    "detaching a function without dropping its output field is not supported; "
+                    "drop_function always removes the function together with its output field: "
+                    "text_to_minhash: invalid parameter"
+                ),
+            },
+        )
 
         desc = client.describe_collection(detach_collection_name)
         field_names = [field["name"] for field in desc["fields"]]
         function_names = [func["name"] for func in desc.get("functions", [])]
-        assert "text_to_minhash" not in function_names
+        assert "text_to_minhash" in function_names
         assert "mh" in field_names
         assert "vec" in field_names
         assert "mh" in client.list_indexes(detach_collection_name)
-
-        # Once detached, mh is a normal field and new writes must provide it or fail clearly.
-        self.insert(
-            client,
-            collection_name=detach_collection_name,
-            data=[{"id": 100, "doc": "after detach", "vec": [1.0, 0.0, 0.0, 0.0]}],
-            check_task=ct.CheckTasks.err_res,
-            check_items={
-                ct.err_code: 1,
-                ct.err_msg: "Insert missed an field `mh` to collection without set nullable==true or set default_value",
-            },
-        )
 
         # Step 2: Cascade MinHash drop removes the function, output field, and output index.
         create_minhash_collection(cascade_collection_name)

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -815,49 +815,19 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
     ******************************************************************
     """
 
-    # ==================== add_collection_function positive tests ====================
+    # ============ deprecated add/drop_collection_function RPCs (rejected) ============
+    # A function is coupled to its output field: BM25/MinHash are added via
+    # add_function_field, TextEmbedding is defined at collection creation, and a
+    # function is always dropped together with its output field (drop_function_field).
+    # The legacy attach (add_collection_function) / detach (drop_collection_function)
+    # RPCs are therefore rejected.
 
-    def test_add_collection_function_text_embedding(self, tei_endpoint):
+    def test_add_collection_function_rejected(self, tei_endpoint):
         """
-        target: test add text embedding function to existing collection
-        method: create collection without function, then add function via API
-        expected: function added successfully, describe shows 1 function
-        """
-        self._connect()
-        dim = 768
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-        c_name = cf.gen_unique_str(prefix)
-        collection_w = self.init_collection_wrap(name=c_name, schema=schema)
-
-        # Verify no functions initially
-        res, _ = collection_w.describe()
-        assert len(res.get("functions", [])) == 0
-
-        # Create and add function
-        embedding_function = Function(
-            name="text_embedding",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["document"],
-            output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-        self.client.add_collection_function(collection_name=c_name, function=embedding_function)
-
-        # Verify function is added
-        res, _ = collection_w.describe()
-        assert len(res["functions"]) == 1
-        assert res["functions"][0]["name"] == "text_embedding"
-
-    def test_add_collection_function_then_crud(self, tei_endpoint):
-        """
-        target: test that added function works for all CRUD operations
-        method: create collection without function, add function, then verify insert/query/search/upsert/delete
-        expected: all CRUD operations work correctly with dynamically added function
+        target: add_collection_function (legacy attach RPC) is rejected
+        method: create a collection, then call add_collection_function
+        expected: rejected - no longer supported (use add_function_field, or define
+                  a TextEmbedding function at collection creation)
         """
         self._connect()
         dim = 768
@@ -868,178 +838,56 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         ]
         schema = CollectionSchema(fields=fields, description="test collection")
         c_name = cf.gen_unique_str(prefix)
-        collection_w = self.init_collection_wrap(name=c_name, schema=schema)
+        self.init_collection_wrap(name=c_name, schema=schema)
 
-        # Add function
         embedding_function = Function(
-            name="text_embedding",
+            name="tei",
             function_type=FunctionType.TEXTEMBEDDING,
             input_field_names=["document"],
             output_field_names="dense",
             params={"provider": "TEI", "endpoint": tei_endpoint},
         )
-        self.client.add_collection_function(collection_name=c_name, function=embedding_function)
+        try:
+            self.client.add_collection_function(collection_name=c_name, function=embedding_function)
+            assert False, "Expected exception: add_collection_function is no longer supported"
+        except Exception as e:
+            log.info(f"Expected error: {e}")
+            assert "no longer supported" in str(e)
 
-        # === INSERT ===
-        nb = 10
-        data = [{"id": i, "document": f"This is document number {i}"} for i in range(nb)]
-        collection_w.insert(data)
-        assert collection_w.num_entities == nb
-
-        # Create index and load
-        index_params = {
-            "index_type": "AUTOINDEX",
-            "metric_type": "COSINE",
-            "params": {},
-        }
-        collection_w.create_index("dense", index_params)
-        collection_w.load()
-
-        # === QUERY ===
-        res, _ = collection_w.query(expr="id >= 0", output_fields=["dense", "document"])
-        assert len(res) == nb
-        for row in res:
-            assert len(row["dense"]) == dim
-
-        # === SEARCH with text ===
-        search_params = {"metric_type": "COSINE", "params": {}}
-        res, _ = collection_w.search(
-            data=["document number 5"],
-            anns_field="dense",
-            param=search_params,
-            limit=5,
-            output_fields=["document"],
-        )
-        assert len(res) == 1
-        assert len(res[0]) == 5
-
-        # === UPSERT - update existing record ===
-        old_res, _ = collection_w.query(expr="id == 0", output_fields=["dense"])
-        old_embedding = old_res[0]["dense"]
-
-        upsert_data = [{"id": 0, "document": "This is a completely different updated text"}]
-        collection_w.upsert(upsert_data)
-
-        new_res, _ = collection_w.query(expr="id == 0", output_fields=["dense"])
-        new_embedding = new_res[0]["dense"]
-
-        # Verify embedding changed after upsert
-        assert not np.allclose(old_embedding, new_embedding)
-
-        # === UPSERT - insert new record ===
-        upsert_new_data = [{"id": 100, "document": "This is a brand new document"}]
-        collection_w.upsert(upsert_new_data)
-        count_res, _ = collection_w.query(expr="", output_fields=["count(*)"])
-        assert count_res[0]["count(*)"] == nb + 1
-
-        # Verify new record has vector
-        res, _ = collection_w.query(expr="id == 100", output_fields=["dense"])
-        assert len(res) == 1
-        assert len(res[0]["dense"]) == dim
-
-        # === DELETE ===
-        collection_w.delete("id in [1, 2, 3]")
-
-        # Verify deleted records are not searchable
-        res, _ = collection_w.search(
-            data=["document number 1"],
-            anns_field="dense",
-            param=search_params,
-            limit=10,
-            output_fields=["id"],
-        )
-        deleted_ids = {1, 2, 3}
-        for hit in res[0]:
-            assert hit.entity.get("id") not in deleted_ids
-
-        # Verify count decreased
-        res, _ = collection_w.query(expr="id >= 0", output_fields=["id"])
-        assert len(res) == nb + 1 - 3  # original + 1 upserted - 3 deleted
-
-    def test_add_collection_function_multiple_text_embedding(self, tei_endpoint):
+    def test_drop_collection_function_rejected(self, tei_endpoint):
         """
-        target: test add multiple text embedding functions to different output fields
-        method: create collection with two vector fields, add text_embedding function to each
-        expected: both functions added successfully
+        target: drop_collection_function (legacy detach RPC) is rejected
+        method: create a collection with a TextEmbedding function, call drop_collection_function
+        expected: rejected - detaching a function without dropping its output field is
+                  not supported (use drop_function_field)
         """
         self._connect()
         dim = 768
         fields = [
             FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="title", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="content", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="title_vector", dtype=DataType.FLOAT_VECTOR, dim=dim),
-            FieldSchema(name="content_vector", dtype=DataType.FLOAT_VECTOR, dim=dim),
+            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
+            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
         ]
         schema = CollectionSchema(fields=fields, description="test collection")
+        text_embedding_function = Function(
+            name="tei",
+            function_type=FunctionType.TEXTEMBEDDING,
+            input_field_names=["document"],
+            output_field_names="dense",
+            params={"provider": "TEI", "endpoint": tei_endpoint},
+        )
+        schema.add_function(text_embedding_function)
         c_name = cf.gen_unique_str(prefix)
-        collection_w = self.init_collection_wrap(name=c_name, schema=schema)
+        self.init_collection_wrap(name=c_name, schema=schema)
 
-        # Add text embedding function for title
-        title_embedding_function = Function(
-            name="title_embedding",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["title"],
-            output_field_names="title_vector",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-        self.client.add_collection_function(collection_name=c_name, function=title_embedding_function)
+        try:
+            self.client.drop_collection_function(collection_name=c_name, function_name="tei")
+            assert False, "Expected exception: drop_collection_function is no longer supported"
+        except Exception as e:
+            log.info(f"Expected error: {e}")
+            assert "not supported" in str(e)
 
-        # Add text embedding function for content
-        content_embedding_function = Function(
-            name="content_embedding",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["content"],
-            output_field_names="content_vector",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-        self.client.add_collection_function(collection_name=c_name, function=content_embedding_function)
-
-        # Verify both functions are added
-        res, _ = collection_w.describe()
-        assert len(res["functions"]) == 2
-        function_names = [f["name"] for f in res["functions"]]
-        assert "title_embedding" in function_names
-        assert "content_embedding" in function_names
-
-        # Verify CRUD works with both functions
-        # Insert
-        nb = 5
-        data = [{"id": i, "title": fake_en.sentence(), "content": fake_en.text()} for i in range(nb)]
-        collection_w.insert(data)
-        assert collection_w.num_entities == nb
-
-        # Create index and load
-        index_params = {"index_type": "AUTOINDEX", "metric_type": "COSINE", "params": {}}
-        collection_w.create_index("title_vector", index_params)
-        collection_w.create_index("content_vector", index_params)
-        collection_w.load()
-
-        # Query - verify vectors are generated
-        res, _ = collection_w.query(expr="id >= 0", output_fields=["title_vector", "content_vector"])
-        for row in res:
-            assert len(row["title_vector"]) == dim
-            assert len(row["content_vector"]) == dim
-
-        # Search on both vector fields
-        search_params = {"metric_type": "COSINE", "params": {}}
-        res, _ = collection_w.search(
-            data=[fake_en.sentence()],
-            anns_field="title_vector",
-            param=search_params,
-            limit=3,
-        )
-        assert len(res[0]) == 3
-
-        res, _ = collection_w.search(
-            data=[fake_en.text()],
-            anns_field="content_vector",
-            param=search_params,
-            limit=3,
-        )
-        assert len(res[0]) == 3
-
-    # ==================== alter_collection_function positive tests ====================
+    # ==================== alter_collection_function tests ====================
 
     def test_alter_collection_function_change_endpoint(self, tei_endpoint):
         """
@@ -1088,9 +936,11 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
 
     def test_alter_collection_function_change_params(self, tei_endpoint):
         """
-        target: test alter function parameters (truncate settings)
-        method: create collection with function, alter truncate params
-        expected: params changed successfully
+        target: test altering semantic params (truncate/truncation_direction) is rejected
+        method: create collection with function, try to alter truncate params
+        expected: rejected - truncate/truncation_direction change the embedding of
+                  over-length inputs, so they are immutable (altering them would mix
+                  vector semantics in the same output field)
         """
         self._connect()
         dim = 768
@@ -1113,7 +963,8 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(name=c_name, schema=schema)
 
-        # Alter function with new truncate params
+        # truncate / truncation_direction are semantic params (immutable): altering them
+        # is rejected.
         new_function = Function(
             name="tei",
             function_type=FunctionType.TEXTEMBEDDING,
@@ -1121,24 +972,24 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             output_field_names="dense",
             params={"provider": "TEI", "endpoint": tei_endpoint, "truncate": True, "truncation_direction": "Left"},
         )
-        self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
+        try:
+            self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
+            assert False, "Expected exception: truncate/truncation_direction are immutable"
+        except Exception as e:
+            log.info(f"Expected error: {e}")
+            assert "cannot be altered" in str(e)
 
-        # Verify function params are updated correctly
+        # function params unchanged
         res, _ = collection_w.describe()
-        assert len(res["functions"]) == 1
         func = res["functions"][0]
-        assert func["name"] == "tei"
-        assert func["params"]["provider"] == "TEI"
-        assert func["params"]["endpoint"] == tei_endpoint
-        # Note: params values are returned as strings
-        assert func["params"]["truncate"] == "True"
-        assert func["params"]["truncation_direction"] == "Left"
+        assert "truncate" not in func["params"]
 
     def test_alter_collection_function_verify_crud(self, tei_endpoint):
         """
-        target: test altered function works correctly for all CRUD operations
-        method: create collection with function, insert data, alter function, verify all CRUD operations
-        expected: all CRUD operations continue to work after function alteration
+        target: test the function keeps serving all CRUD after a rejected immutable-param alter
+        method: create collection with function, insert data, attempt an immutable-param
+                (truncate) alter which is rejected, then verify all CRUD operations
+        expected: alter is rejected and the intact function keeps serving CRUD
         """
         self._connect()
         dim = 768
@@ -1178,7 +1029,8 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         res_before, _ = collection_w.query(expr="id == 0", output_fields=["dense"])
         embedding_before_alter = res_before[0]["dense"]
 
-        # === ALTER FUNCTION ===
+        # === ALTER FUNCTION: truncate is a semantic param (immutable) -> rejected;
+        # the function stays intact and CRUD keeps working below ===
         new_function = Function(
             name="tei",
             function_type=FunctionType.TEXTEMBEDDING,
@@ -1186,7 +1038,12 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             output_field_names="dense",
             params={"provider": "TEI", "endpoint": tei_endpoint, "truncate": True},
         )
-        self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
+        try:
+            self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
+            assert False, "Expected exception: truncate is immutable"
+        except Exception as e:
+            log.info(f"Expected error: {e}")
+            assert "cannot be altered" in str(e)
 
         # === INSERT after alter ===
         data2 = [{"id": i + 5, "document": f"Document after alter {i}"} for i in range(5)]
@@ -1252,9 +1109,9 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
     @pytest.mark.tags(CaseLabel.L3)
     def test_alter_collection_function_change_to_different_endpoint(self, tei_endpoint, tei_endpoint_2):
         """
-        target: test alter function to use a different valid endpoint
-        method: create collection with function using endpoint1, alter to endpoint2, verify CRUD
-        expected: function works with new endpoint after alteration
+        target: test altering to a different endpoint is rejected (endpoint immutable)
+        method: create with endpoint1, insert, attempt to alter to endpoint2 (rejected)
+        expected: rejected; the function keeps using endpoint1 and serving CRUD
         """
         self._connect()
         dim = 768
@@ -1286,7 +1143,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         collection_w.create_index("dense", index_params)
         collection_w.load()
 
-        # Alter to use different endpoint
+        # endpoint is immutable: altering to a different endpoint is rejected.
         new_function = Function(
             name="tei",
             function_type=FunctionType.TEXTEMBEDDING,
@@ -1294,30 +1151,17 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             output_field_names="dense",
             params={"provider": "TEI", "endpoint": tei_endpoint_2},
         )
-        self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
+        try:
+            self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
+            assert False, "Expected exception: endpoint is immutable"
+        except Exception as e:
+            log.info(f"Expected error: {e}")
+            assert "cannot be altered" in str(e)
 
-        # Insert data with new endpoint
-        data2 = [{"id": i + 10, "document": f"Document with endpoint2 {i}"} for i in range(3)]
+        # function still uses the original endpoint and keeps serving CRUD
+        data2 = [{"id": i + 10, "document": f"Document with endpoint1 again {i}"} for i in range(3)]
         collection_w.insert(data2)
         assert collection_w.num_entities == 6
-
-        # Search should work
-        search_params = {"metric_type": "COSINE", "params": {}}
-        res, _ = collection_w.search(
-            data=["Document with endpoint2"],
-            anns_field="dense",
-            param=search_params,
-            limit=6,
-            output_fields=["document"],
-        )
-        assert len(res[0]) == 6
-
-        # Upsert should work with new endpoint
-        upsert_data = [{"id": 0, "document": "Updated document with new endpoint"}]
-        collection_w.upsert(upsert_data)
-
-        res, _ = collection_w.query(expr="id == 0", output_fields=["document"])
-        assert "Updated document" in res[0]["document"]
 
     @pytest.mark.tags(CaseLabel.L3)
     def test_alter_function_when_other_function_is_invalid(self, host):
@@ -1396,25 +1240,25 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             mock_server_1.set_error_mode(enabled=True, status_code=400, message="Model integration is not active")
 
             # Now title_embedding function is invalid, but we should still be able to
-            # alter content_embedding function (PR #46984 fix)
+            # alter content_embedding. Alter a whitelisted connection param (timeout_ms),
+            # since semantic params (truncate/endpoint/...) are immutable.
             new_content_embedding = Function(
                 name="content_embedding",
                 function_type=FunctionType.TEXTEMBEDDING,
                 input_field_names=["content"],
                 output_field_names="content_vector",
-                params={"provider": "TEI", "endpoint": endpoint_2, "truncate": True},
+                params={"provider": "TEI", "endpoint": endpoint_2, "timeout_ms": "30000"},
             )
 
-            # This should succeed after PR #46984 fix
-            # Before the fix, this would fail because it validated ALL functions
+            # This should succeed: altering the target function must not be blocked by
+            # the other function being invalid (validate only the target function).
             self.client.alter_collection_function(
                 collection_name=c_name, function_name="content_embedding", function=new_content_embedding
             )
 
-            # Verify function params are updated
+            # alter succeeded (did not raise) and both functions are still present
             res, _ = collection_w.describe()
-            content_func = next(f for f in res["functions"] if f["name"] == "content_embedding")
-            assert content_func["params"]["truncate"] == str(True)
+            assert len(res["functions"]) == 2
 
             log.info("Successfully altered content_embedding function while title_embedding is invalid")
 
@@ -1425,14 +1269,15 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
     @pytest.mark.tags(CaseLabel.L3)
     def test_alter_invalid_function_to_valid_endpoint(self, host):
         """
-        target: test user can fix an invalid function by altering it to a valid endpoint
+        target: test that repointing a broken function to a new endpoint is rejected
         method:
             1. create collection with function using mock TEI server
             2. make mock server return errors (function becomes invalid)
-            3. start a new valid server and alter function to use it
-        expected: alter should succeed, allowing user to fix the broken function
+            3. try to alter the function to a new valid endpoint
+        expected: rejected - endpoint is the TEI model identity and immutable. This
+                  supersedes the earlier #46984 repoint flow; a broken endpoint must be
+                  fixed at the infra level, or the function dropped and re-added.
         issue: https://github.com/milvus-io/milvus/issues/46949
-        pr: https://github.com/milvus-io/milvus/pull/46984
 
         NOTE: This test requires the Milvus server to be able to access the local mock TEI server.
         - localhost/127.0.0.1: uses host.docker.internal for Docker containers
@@ -1490,8 +1335,8 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             # Simulate the original endpoint becoming unavailable
             mock_server.set_error_mode(enabled=True, status_code=400, message="Model integration is not active")
 
-            # User wants to fix the function by switching to backup endpoint
-            # This is the exact scenario from issue #46949
+            # endpoint is immutable: repointing to a different endpoint is rejected,
+            # even to recover a broken function (supersedes #46984).
             new_function = Function(
                 name="tei",
                 function_type=FunctionType.TEXTEMBEDDING,
@@ -1499,491 +1344,22 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
                 output_field_names="dense",
                 params={"provider": "TEI", "endpoint": backup_endpoint},
             )
+            try:
+                self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
+                assert False, "Expected exception: endpoint is immutable"
+            except Exception as e:
+                log.info(f"Expected error: {e}")
+                assert "cannot be altered" in str(e)
 
-            # After PR #46984, this should succeed
-            self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
-
-            # Verify function is updated
+            # function still points at the original endpoint (unchanged)
             res, _ = collection_w.describe()
             func = res["functions"][0]
-            assert func["params"]["endpoint"] == backup_endpoint
-
-            # Verify the function works with new endpoint
-            new_data = [{"id": 10, "document": "New document after fix"}]
-            collection_w.insert(new_data)
-            assert collection_w.num_entities == 4
-
-            # Search should work
-            search_params = {"metric_type": "COSINE", "params": {}}
-            res, _ = collection_w.search(
-                data=["New document"],
-                anns_field="dense",
-                param=search_params,
-                limit=4,
-            )
-            assert len(res[0]) == 4
-
-            log.info("Successfully fixed invalid function by altering to valid endpoint")
+            assert func["params"]["endpoint"] == endpoint
 
         finally:
             mock_server.stop()
             backup_server.stop()
 
-    # ==================== drop_collection_function positive tests ====================
-
-    def test_drop_collection_function_verify_crud(self, tei_endpoint):
-        """
-        target: test CRUD behavior changes after dropping function
-        method: create collection with function, insert data, drop function, verify CRUD behavior
-        expected: after drop, insert requires manual vector, existing data still queryable/searchable
-        """
-        self._connect()
-        dim = 768
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-
-        text_embedding_function = Function(
-            name="tei",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["document"],
-            output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-        schema.add_function(text_embedding_function)
-
-        c_name = cf.gen_unique_str(prefix)
-        collection_w = self.init_collection_wrap(name=c_name, schema=schema)
-
-        # === INSERT with function (auto-generate vector) ===
-        data_with_func = [{"id": i, "document": f"Document with function {i}"} for i in range(5)]
-        collection_w.insert(data_with_func)
-        assert collection_w.num_entities == 5
-
-        # Create index and load
-        index_params = {
-            "index_type": "AUTOINDEX",
-            "metric_type": "COSINE",
-            "params": {},
-        }
-        collection_w.create_index("dense", index_params)
-        collection_w.load()
-
-        # Verify vectors are generated
-        res, _ = collection_w.query(expr="id >= 0", output_fields=["dense"])
-        for row in res:
-            assert len(row["dense"]) == dim
-
-        # === DROP FUNCTION ===
-        self.client.drop_collection_function(collection_name=c_name, function_name="tei")
-
-        # Verify function is removed
-        res, _ = collection_w.describe()
-        assert len(res.get("functions", [])) == 0
-
-        # === QUERY - existing data still accessible ===
-        res, _ = collection_w.query(expr="id >= 0", output_fields=["dense", "document"])
-        assert len(res) == 5
-        for row in res:
-            assert len(row["dense"]) == dim
-
-        # === SEARCH - existing data still searchable with vector ===
-        search_params = {"metric_type": "COSINE", "params": {}}
-        search_vector = [[random.random() for _ in range(dim)]]
-        res, _ = collection_w.search(
-            data=search_vector,
-            anns_field="dense",
-            param=search_params,
-            limit=5,
-            output_fields=["document"],
-        )
-        assert len(res[0]) == 5
-
-        # === INSERT after drop - must provide vector manually ===
-        manual_vector = [random.random() for _ in range(dim)]
-        data_manual = [{"id": 10, "document": "Manual vector document", "dense": manual_vector}]
-        collection_w.insert(data_manual)
-        assert collection_w.num_entities == 6
-
-        # Verify manual insert succeeded
-        res, _ = collection_w.query(expr="id == 10", output_fields=["dense"])
-        assert len(res) == 1
-        assert len(res[0]["dense"]) == dim
-
-        # === INSERT after drop without vector - should fail ===
-        data_no_vector = [{"id": 11, "document": "No vector document"}]
-        collection_w.insert(
-            data_no_vector,
-            check_task=CheckTasks.err_res,
-            check_items={"err_code": 65535, "err_msg": ""},
-        )
-
-        # === UPSERT after drop - must provide vector manually ===
-        upsert_vector = [random.random() for _ in range(dim)]
-        upsert_data = [{"id": 0, "document": "Updated via upsert", "dense": upsert_vector}]
-        collection_w.upsert(upsert_data)
-
-        res, _ = collection_w.query(expr="id == 0", output_fields=["dense"])
-        # Verify vector is updated to manual one
-        assert np.allclose(res[0]["dense"], upsert_vector, rtol=1e-5)
-
-        # === DELETE after drop - still works ===
-        collection_w.delete("id in [1, 2]")
-        res, _ = collection_w.query(expr="id >= 0", output_fields=["id"])
-        assert len(res) == 4  # 6 - 2
-
-    def test_drop_collection_function_one_of_multiple(self, tei_endpoint):
-        """
-        target: test drop one function when multiple text embedding functions exist
-        method: create collection with two text_embedding functions, drop one, verify CRUD
-        expected: only specified function is dropped, other still works for CRUD
-        """
-        self._connect()
-        dim = 768
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="title", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="content", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="title_vector", dtype=DataType.FLOAT_VECTOR, dim=dim),
-            FieldSchema(name="content_vector", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-
-        # Add two text embedding functions
-        title_embedding = Function(
-            name="title_embedding",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["title"],
-            output_field_names="title_vector",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-        schema.add_function(title_embedding)
-
-        content_embedding = Function(
-            name="content_embedding",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["content"],
-            output_field_names="content_vector",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-        schema.add_function(content_embedding)
-
-        c_name = cf.gen_unique_str(prefix)
-        collection_w = self.init_collection_wrap(name=c_name, schema=schema)
-
-        # Verify both functions exist
-        res, _ = collection_w.describe()
-        assert len(res["functions"]) == 2
-
-        # === INSERT with both functions ===
-        data = [{"id": i, "title": f"Title {i}", "content": f"Content {i}"} for i in range(3)]
-        collection_w.insert(data)
-        assert collection_w.num_entities == 3
-
-        # Create indexes and load
-        index_params = {"index_type": "AUTOINDEX", "metric_type": "COSINE", "params": {}}
-        collection_w.create_index("title_vector", index_params)
-        collection_w.create_index("content_vector", index_params)
-        collection_w.load()
-
-        # Verify both vectors generated
-        res, _ = collection_w.query(expr="id >= 0", output_fields=["title_vector", "content_vector"])
-        for row in res:
-            assert len(row["title_vector"]) == dim
-            assert len(row["content_vector"]) == dim
-
-        # === DROP one function (title_embedding) ===
-        self.client.drop_collection_function(collection_name=c_name, function_name="title_embedding")
-
-        # Verify only content_embedding remains
-        res, _ = collection_w.describe()
-        assert len(res["functions"]) == 1
-        assert res["functions"][0]["name"] == "content_embedding"
-
-        # === INSERT after drop - content_vector auto-generated, title_vector manual ===
-        manual_title_vector = [random.random() for _ in range(dim)]
-        data_after_drop = [
-            {"id": 10, "title": "New title", "content": "New content", "title_vector": manual_title_vector}
-        ]
-        collection_w.insert(data_after_drop)
-        assert collection_w.num_entities == 4
-
-        # Verify vectors
-        res, _ = collection_w.query(expr="id == 10", output_fields=["title_vector", "content_vector"])
-        assert np.allclose(res[0]["title_vector"], manual_title_vector, rtol=1e-5)
-        assert len(res[0]["content_vector"]) == dim
-
-        # === SEARCH on both fields still works ===
-        search_params = {"metric_type": "COSINE", "params": {}}
-        # Search title_vector with manual vector
-        res, _ = collection_w.search(
-            data=[manual_title_vector],
-            anns_field="title_vector",
-            param=search_params,
-            limit=4,
-        )
-        assert len(res[0]) == 4
-
-        # Search content_vector with text (function still active)
-        res, _ = collection_w.search(
-            data=["New content"],
-            anns_field="content_vector",
-            param=search_params,
-            limit=4,
-        )
-        assert len(res[0]) == 4
-
-        # === UPSERT - content function still works ===
-        upsert_title_vector = [random.random() for _ in range(dim)]
-        upsert_data = [
-            {"id": 0, "title": "Updated title", "content": "Updated content", "title_vector": upsert_title_vector}
-        ]
-        collection_w.upsert(upsert_data)
-
-        res, _ = collection_w.query(expr="id == 0", output_fields=["title_vector", "content_vector"])
-        assert np.allclose(res[0]["title_vector"], upsert_title_vector, rtol=1e-5)
-
-        # === DELETE still works ===
-        collection_w.delete("id == 1")
-        res, _ = collection_w.query(expr="id >= 0", output_fields=["id"])
-        assert len(res) == 3
-
-    def test_drop_collection_function_then_add_again(self, tei_endpoint):
-        """
-        target: test can re-add function after dropping
-        method: create collection with function, drop it, add function again
-        expected: function can be re-added after drop
-        """
-        self._connect()
-        dim = 768
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-
-        text_embedding_function = Function(
-            name="tei",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["document"],
-            output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-        schema.add_function(text_embedding_function)
-
-        c_name = cf.gen_unique_str(prefix)
-        collection_w = self.init_collection_wrap(name=c_name, schema=schema)
-
-        # Drop function
-        self.client.drop_collection_function(collection_name=c_name, function_name="tei")
-
-        # Verify function is removed
-        res, _ = collection_w.describe()
-        assert len(res.get("functions", [])) == 0
-
-        # Add function again
-        new_function = Function(
-            name="text_embedding_v2",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["document"],
-            output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-        self.client.add_collection_function(collection_name=c_name, function=new_function)
-
-        # Verify function is added
-        res, _ = collection_w.describe()
-        assert len(res["functions"]) == 1
-        assert res["functions"][0]["name"] == "text_embedding_v2"
-
-
-@pytest.mark.tags(CaseLabel.L2)
-class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
-    """
-    ******************************************************************
-      The following cases are negative tests for add/alter/drop collection function APIs
-    ******************************************************************
-    """
-
-    # ==================== add_collection_function negative tests ====================
-
-    def test_add_collection_function_nonexistent_collection(self, tei_endpoint):
-        """
-        target: test add function to nonexistent collection
-        method: call add_collection_function on collection that doesn't exist
-        expected: error with collection not found (code=100)
-        """
-        self._connect()
-        embedding_function = Function(
-            name="text_embedding",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["document"],
-            output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-
-        try:
-            self.client.add_collection_function(
-                collection_name="nonexistent_collection_12345", function=embedding_function
-            )
-            assert False, "Expected exception for nonexistent collection"
-        except Exception as e:
-            log.info(f"Expected error: {e}")
-            assert e.code == 100
-            assert "collection not found" in str(e)
-
-    def test_add_collection_function_duplicate_name(self, tei_endpoint):
-        """
-        target: test add function with duplicate name
-        method: create collection with function, try to add another function with same name
-        expected: error indicating duplicate function name (code=1100)
-        """
-        self._connect()
-        dim = 768
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-
-        # Add function to schema first
-        text_embedding_function = Function(
-            name="tei",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["document"],
-            output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-        schema.add_function(text_embedding_function)
-
-        c_name = cf.gen_unique_str(prefix)
-        self.init_collection_wrap(name=c_name, schema=schema)
-
-        # Try to add another function with same name
-        duplicate_function = Function(
-            name="tei",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["document"],
-            output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-
-        try:
-            self.client.add_collection_function(collection_name=c_name, function=duplicate_function)
-            assert False, "Expected exception for duplicate function name"
-        except Exception as e:
-            log.info(f"Expected error: {e}")
-            assert e.code == 1100
-            assert "duplicate function name" in str(e)
-
-    def test_add_collection_function_missing_input_field(self, tei_endpoint):
-        """
-        target: test add function with input field that doesn't exist
-        method: add function referencing non-existent input field
-        expected: error indicating input field not found (code=1100)
-        """
-        self._connect()
-        dim = 768
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-        c_name = cf.gen_unique_str(prefix)
-        self.init_collection_wrap(name=c_name, schema=schema)
-
-        # Create function with non-existent input field
-        embedding_function = Function(
-            name="text_embedding",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["nonexistent_field"],
-            output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-
-        try:
-            self.client.add_collection_function(collection_name=c_name, function=embedding_function)
-            assert False, "Expected exception for missing input field"
-        except Exception as e:
-            log.info(f"Expected error: {e}")
-            assert e.code == 1100
-            assert "function input field not found" in str(e)
-
-    def test_add_collection_function_missing_output_field(self, tei_endpoint):
-        """
-        target: test add function with output field that doesn't exist
-        method: add function referencing non-existent output field
-        expected: error indicating output field not found (code=1100)
-        """
-        self._connect()
-        dim = 768
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-        c_name = cf.gen_unique_str(prefix)
-        self.init_collection_wrap(name=c_name, schema=schema)
-
-        # Create function with non-existent output field
-        embedding_function = Function(
-            name="text_embedding",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["document"],
-            output_field_names="nonexistent_vector_field",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-
-        try:
-            self.client.add_collection_function(collection_name=c_name, function=embedding_function)
-            assert False, "Expected exception for missing output field"
-        except Exception as e:
-            log.info(f"Expected error: {e}")
-            assert e.code == 1100
-            assert "function output field not found" in str(e)
-
-    def test_add_collection_function_dim_mismatch(self, tei_endpoint):
-        """
-        target: test add function with dimension mismatch
-        method: create collection with vector field dim=512, add function for model that outputs dim=768
-        expected: error indicating dimension mismatch (code=2400)
-        """
-        self._connect()
-        dim = 512  # Mismatched dimension (TEI model outputs 768)
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-        c_name = cf.gen_unique_str(prefix)
-        self.init_collection_wrap(name=c_name, schema=schema)
-
-        # Create function (model outputs 768 dim, but field is 512)
-        embedding_function = Function(
-            name="text_embedding",
-            function_type=FunctionType.TEXTEMBEDDING,
-            input_field_names=["document"],
-            output_field_names="dense",
-            params={"provider": "TEI", "endpoint": tei_endpoint},
-        )
-
-        try:
-            self.client.add_collection_function(collection_name=c_name, function=embedding_function)
-            assert False, "Expected exception for dimension mismatch"
-        except Exception as e:
-            log.info(f"Expected error: {e}")
-            assert e.code == 2400
-            assert "embedding dim" in str(e)
-
-    # ==================== alter_collection_function negative tests ====================
 
     def test_alter_collection_function_nonexistent_collection(self, tei_endpoint):
         """
@@ -2047,10 +1423,10 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
 
     def test_alter_collection_function_invalid_new_endpoint(self, tei_endpoint):
         """
-        target: test alter function with invalid endpoint
-        method: create collection with valid function, alter to use invalid endpoint
-        expected: error indicating endpoint unreachable (code=2, ServiceUnavailable:
-                  a transport/connect failure to the model backend is retryable)
+        target: test altering the endpoint is rejected (endpoint is immutable)
+        method: create collection with valid function, try to alter to a different endpoint
+        expected: rejected before any connect attempt - for TEI the endpoint is the
+                  model's identity, so it is immutable
         """
         self._connect()
         dim = 768
@@ -2073,7 +1449,8 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         self.init_collection_wrap(name=c_name, schema=schema)
 
-        # Try to alter with invalid endpoint
+        # endpoint is immutable, so altering it (even to an invalid one) is rejected
+        # before any connect attempt.
         new_function = Function(
             name="tei",
             function_type=FunctionType.TEXTEMBEDDING,
@@ -2084,78 +1461,7 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
 
         try:
             self.client.alter_collection_function(collection_name=c_name, function_name="tei", function=new_function)
-            assert False, "Expected exception for invalid endpoint"
+            assert False, "Expected exception: endpoint is immutable"
         except Exception as e:
             log.info(f"Expected error: {e}")
-            # transport/connect failure to the model backend is now classified as
-            # ServiceUnavailable (2, retryable) rather than FunctionFailed (2400)
-            assert e.code == 2
-            assert "invalid_endpoint_12345" in str(e).lower()
-
-    # ==================== drop_collection_function negative tests ====================
-
-    def test_drop_collection_function_nonexistent_collection(self):
-        """
-        target: test drop function from nonexistent collection
-        method: call drop_collection_function on collection that doesn't exist
-        expected: error with collection not found (code=100)
-        """
-        self._connect()
-
-        try:
-            self.client.drop_collection_function(collection_name="nonexistent_collection_12345", function_name="tei")
-            assert False, "Expected exception for nonexistent collection"
-        except Exception as e:
-            log.info(f"Expected error: {e}")
-            assert e.code == 100
-            assert "can't find collection[database=default][collection=nonexistent_collection_12345]" in str(e)
-
-    def test_drop_collection_function_nonexistent_function(self):
-        """
-        target: test drop function that doesn't exist
-        method: create collection without function, try to drop non-existent function
-        expected: error with function not found (code=1100)
-        """
-        self._connect()
-        dim = 768
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-        c_name = cf.gen_unique_str(prefix)
-        self.init_collection_wrap(name=c_name, schema=schema)
-
-        try:
-            self.client.drop_collection_function(collection_name=c_name, function_name="nonexistent_function")
-            assert False, "Expected exception for nonexistent function"
-        except Exception as e:
-            log.info(f"Expected error: {e}")
-            assert e.code == 1100
-            assert "function not found: nonexistent_function" in str(e)
-
-    def test_drop_collection_function_empty_name(self):
-        """
-        target: test drop function with empty name
-        method: call drop_collection_function with function_name=""
-        expected: param error with invalid drop identifier (code=1)
-        """
-        self._connect()
-        dim = 768
-        fields = [
-            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-            FieldSchema(name="document", dtype=DataType.VARCHAR, max_length=65535),
-            FieldSchema(name="dense", dtype=DataType.FLOAT_VECTOR, dim=dim),
-        ]
-        schema = CollectionSchema(fields=fields, description="test collection")
-        c_name = cf.gen_unique_str(prefix)
-        self.init_collection_wrap(name=c_name, schema=schema)
-
-        try:
-            self.client.drop_collection_function(collection_name=c_name, function_name="")
-            assert False, "Expected exception for empty function name"
-        except Exception as e:
-            log.info(f"Expected error: {e}")
-            assert e.code == 1
-            assert "Must specify exactly one valid Drop identifier" in str(e)
+            assert "cannot be altered" in str(e)


### PR DESCRIPTION
Cherry-pick of #51360 (function-field binding principle for function DDL) to the 3.0 branch.

issue: #51348
pr: #51360

This branch keeps two separate commits (not squashed):
1. `enhance: allow updating inactive field analyzer params (#50492)` — the prerequisite by @aoiasd. #51360 builds on it (the `validateAlterAnalyzerFieldParam` guard and the `callAlterCollection` signature), and its own 3.0 cherry-pick (#51279) is not yet merged, so it is bundled here as the first commit so this PR applies cleanly on 3.0.
2. `enhance: enforce function-field binding principle for function DDL` — the cherry-pick of #51360 itself.
