### PR TITLE
enhance: keep milvus-proto checkout pinned

### DIFF
--- a/scripts/download_milvus_proto.sh
+++ b/scripts/download_milvus_proto.sh
@@ -8,18 +8,22 @@ if [ ! -d "$THIRD_PARTY_DIR/milvus-proto" ]; then
   mkdir -p $THIRD_PARTY_DIR
   pushd $THIRD_PARTY_DIR
   git clone https://github.com/milvus-io/milvus-proto.git
-  cd milvus-proto
-  # try tagged version first
-  COMMIT_ID=$(git ls-remote https://github.com/milvus-io/milvus-proto.git refs/tags/${API_VERSION} | cut -f 1)
-  if [[ -z $COMMIT_ID ]]; then
-    # parse commit from pseudo version (eg v0.0.0-20230608062631-c453ef1b870a => c453ef1b870a)  
-    COMMIT_ID=$(echo $API_VERSION | awk -F'-' '{print $3}')
-  fi
-  echo "version: $API_VERSION, commitID: $COMMIT_ID"
-  if [ -z $COMMIT_ID ]; then
-      git checkout -b $API_VERSION $API_VERSION
-  else
-      git reset --hard $COMMIT_ID
-  fi
   popd
 fi
+
+pushd "$THIRD_PARTY_DIR/milvus-proto"
+# Always enforce the version selected by go.mod. A previously created checkout
+# may otherwise remain on a newer branch and generate incompatible Go sources.
+git fetch --tags origin
+COMMIT_ID=$(git ls-remote https://github.com/milvus-io/milvus-proto.git refs/tags/${API_VERSION} | cut -f 1)
+if [[ -z $COMMIT_ID ]]; then
+  # parse commit from pseudo version (eg v0.0.0-20230608062631-c453ef1b870a => c453ef1b870a)
+  COMMIT_ID=$(echo $API_VERSION | awk -F'-' '{print $3}')
+fi
+echo "version: $API_VERSION, commitID: $COMMIT_ID"
+if [ -z $COMMIT_ID ]; then
+    git checkout -B "$API_VERSION" "$API_VERSION"
+else
+    git checkout --detach --force "$COMMIT_ID"
+fi
+popd


### PR DESCRIPTION
Always select the milvus-proto revision required by go.mod, even when a cached checkout already exists. Otherwise, switching Milvus branches can generate sources from an incompatible proto revision.

This backports the version-selection behavior introduced on master by commit 99097abea8f5eacb275b29cc8042b7836cf10425 (#48953). Use a detached checkout so pinning the dependency does not move its local branch.

backport pr: #48953

Assisted by gpt-5.6-sol.