### PR TITLE
fix: [3.0] size the scalar-index valid bitmap by active count on growing segments (#51523)

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -392,8 +392,9 @@ class SegmentExpr : public Expr {
 
     void
     MoveCursorForIndex() {
-        AssertInfo(segment_->type() == SegmentType::Sealed,
-                   "index mode only for sealed segment");
+        // The index cursor is a global row position. This holds for sealed
+        // segments and for growing segments with a segment-level scalar
+        // index (the geometry interim R-Tree, see issue #51237).
         auto size =
             std::min(active_count_ - current_index_chunk_pos_, batch_size_);
 
@@ -2275,13 +2276,28 @@ class SegmentExpr : public Expr {
             cached_index_chunk_id_ = 0;
         }
 
-        // Process current batch
+        // Process current batch.
+        //
+        // The cached bitmap is segment-global (a scalar index always has
+        // exactly one chunk), so slice it by the rows visible to this query
+        // (active_count_). Bounding by size_per_chunk_ would be wrong on a
+        // growing segment, where size_per_chunk_ is the raw-data chunk
+        // granularity (segcore.chunkRows) and unrelated to the index bitmap.
+        // A growing segment reaches this path through the geometry interim
+        // R-Tree index; its bitmap may also run ahead of active_count_ under
+        // concurrent inserts, so active_count_ -- not the bitmap size --
+        // decides how many rows to emit. See issue #51237.
         TargetBitmap valid_result;
         valid_result.set();
 
         auto data_pos = current_index_chunk_pos_;
-        auto size = std::min(std::min(size_per_chunk_ - data_pos, batch_size_),
-                             int64_t(cached_index_chunk_valid_res_->size()));
+        auto size = std::min(active_count_ - data_pos, batch_size_);
+        AssertInfo(
+            int64_t(cached_index_chunk_valid_res_->size()) >= data_pos + size,
+            "index valid bitmap covers {} rows, batch needs rows [{}, {})",
+            cached_index_chunk_valid_res_->size(),
+            data_pos,
+            data_pos + size);
 
         valid_result.append(*cached_index_chunk_valid_res_, data_pos, size);
 

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -2024,11 +2024,43 @@ class SegmentExpr : public Expr {
                 std::move(*cached_index_chunk_res_),
                 std::move(*cached_index_chunk_valid_res_));
         } else {
-            // Normal index or row-level result: batch by rows directly
+            // Normal index or row-level result: batch by rows directly.
+            //
+            // Slice by active_count_ for the same reason as
+            // ProcessIndexChunksForValid(): the cached bitmap is
+            // segment-global (a scalar index always has exactly one chunk),
+            // while size_per_chunk_ is the raw-data chunk granularity
+            // (segcore.chunkRows) and is unrelated to it. On a sealed segment
+            // the two agree -- size_per_chunk() == get_row_count() -- which is
+            // why bounding by size_per_chunk_ has not broken yet; today only
+            // sealed segments reach here, because on growing segments
+            // HasIndex() is true only for vector/geometry fields and real
+            // geometry predicates take the dedicated branch in
+            // GISFunctionFilterExpr::EvalForIndexSegment(). The moment a
+            // scalar field gains an interim index on growing, or geometry is
+            // routed through ProcessIndexChunks, size_per_chunk_ would
+            // over-run the bitmap exactly as in issue #51237.
+            //
+            // The old third min term was also subtly wrong on its own: it
+            // clamped against the bitmap's FULL length rather than the length
+            // remaining after data_pos, so a bitmap shorter than the row count
+            // combined with data_pos > 0 made append() read past its end.
+            // Assert coverage instead, mirroring the sibling function.
             auto data_pos = current_index_chunk_pos_;
-            auto size =
-                std::min(std::min(size_per_chunk_ - data_pos, batch_size_),
-                         int64_t(cached_index_chunk_res_->size()));
+            auto size = std::min(active_count_ - data_pos, batch_size_);
+            AssertInfo(
+                int64_t(cached_index_chunk_res_->size()) >= data_pos + size,
+                "index bitmap covers {} rows, batch needs rows [{}, {})",
+                cached_index_chunk_res_->size(),
+                data_pos,
+                data_pos + size);
+            AssertInfo(
+                int64_t(cached_index_chunk_valid_res_->size()) >=
+                    data_pos + size,
+                "index valid bitmap covers {} rows, batch needs rows [{}, {})",
+                cached_index_chunk_valid_res_->size(),
+                data_pos,
+                data_pos + size);
 
             result.append(*cached_index_chunk_res_, data_pos, size);
             valid_result.append(*cached_index_chunk_valid_res_, data_pos, size);

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -2017,8 +2017,19 @@ class SegmentExpr : public Expr {
                 *cached_index_chunk_valid_res_, elem_start, elem_count);
 
             current_index_chunk_pos_ = data_pos + batch_rows;
-        } else if (execute_all_at_once_) {
-            // Fast path: move cached bitmap directly, no copy
+        } else if (execute_all_at_once_ &&
+                   int64_t(cached_index_chunk_res_->size()) == active_count_ &&
+                   int64_t(cached_index_chunk_valid_res_->size()) ==
+                       active_count_) {
+            // Fast path: the cached bitmap lines up exactly with the rows
+            // this query emits, so move it out with no copy. The size guard
+            // keeps this branch under the same invariant as the slicing
+            // branch below: on a growing segment the interim index bitmap
+            // may run ahead of active_count_ under concurrent inserts (see
+            // issue #51237), and moving an oversized bitmap wholesale would
+            // hand downstream more rows than the batch. That case falls
+            // through to the slicing branch, which bounds by active_count_
+            // and asserts coverage.
             current_index_chunk_pos_ += cached_index_chunk_res_->size();
             return std::make_shared<ColumnVector>(
                 std::move(*cached_index_chunk_res_),

--- a/internal/core/src/exec/expression/ExprGISMiscTest.cpp
+++ b/internal/core/src/exec/expression/ExprGISMiscTest.cpp
@@ -1330,3 +1330,135 @@ TEST_P(ExprTest, TestGeometrySpatialExprOnGrowingWithRTreeIndex) {
         }
     }
 }
+
+// Regression for the short-circuit path on a growing segment:
+// PhyConjunctFilterExpr skips the following exprs of an all-false batch via
+// MoveCursor() instead of Eval(), and PhyGISFunctionFilterExpr::MoveCursor()
+// used to no-op on growing segments. With `int64 >= N/2` evaluated first,
+// every early batch is all-false (DataGen fills the pk column with 0..N-1 in
+// row order), so the GIS expr is skipped -- with a stalled cursor -- until the
+// first batch containing rows >= N/2, where it finally evaluates and used to
+// re-append the index bitmap from row 0 against the conjunction's current row
+// range: silent misalignment, caught below against a ground truth derived
+// from a standalone spatial run. The test above cannot see this: a standalone
+// geometry expr executes all-at-once, so MoveCursor() is never called there.
+TEST_P(ExprTest, TestGeometryConjunctionShortCircuitOnGrowingWithRTreeIndex) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    // Small batch so the conjunction iterates several all-false batches
+    // before the first active one.
+    struct BatchSizeGuard {
+        int64_t saved;
+        ~BatchSizeGuard() {
+            EXEC_EVAL_EXPR_BATCH_SIZE.store(saved);
+        }
+    } batch_guard{EXEC_EVAL_EXPR_BATCH_SIZE.load()};
+    EXEC_EVAL_EXPR_BATCH_SIZE.store(128);
+
+    auto schema = std::make_shared<Schema>();
+    auto int64_fid = schema->AddDebugField("int64", DataType::INT64);
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_fid = schema->AddDebugField("geometry", DataType::GEOMETRY, true);
+    schema->set_primary_field_id(int64_fid);
+
+    const int64_t N = 1000;
+    auto dataset =
+        DataGen(schema, N, 42, 0, 1, 10, 1, false, true, true /*random_valid*/);
+
+    auto build_segment = [&](bool with_rtree_index) {
+        std::shared_ptr<CollectionIndexMeta> index_meta;
+        if (with_rtree_index) {
+            std::map<std::string, std::string> index_params = {
+                {"index_type", "RTREE"}};
+            std::map<std::string, std::string> type_params = {};
+            FieldIndexMeta geo_index_meta(
+                geo_fid, std::move(index_params), std::move(type_params));
+            std::map<FieldId, FieldIndexMeta> metas = {
+                {geo_fid, geo_index_meta}};
+            index_meta =
+                std::make_shared<CollectionIndexMeta>(100000, std::move(metas));
+        } else {
+            index_meta = std::make_shared<CollectionIndexMeta>(
+                100000, std::map<FieldId, FieldIndexMeta>{});
+        }
+        auto config = SegcoreConfig::default_config();
+        config.set_chunk_rows(128);
+        config.set_enable_interim_segment_index(true);
+        auto seg = CreateGrowingSegment(schema, index_meta, 1, config);
+        auto* impl = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+        auto offset = impl->PreInsert(N);
+        impl->Insert(offset,
+                     N,
+                     dataset.row_ids_.data(),
+                     dataset.timestamps_.data(),
+                     dataset.raw_);
+        return seg;
+    };
+
+    auto indexed_seg = build_segment(true);
+    auto raw_seg = build_segment(false);
+    ASSERT_TRUE(dynamic_cast<SegmentGrowingImpl*>(indexed_seg.get())
+                    ->HasIndex(geo_fid));
+    ASSERT_FALSE(
+        dynamic_cast<SegmentGrowingImpl*>(raw_seg.get())->HasIndex(geo_fid));
+
+    const std::string viewport =
+        "POLYGON((-50 -50, 50 -50, 50 50, -50 50, -50 -50))";
+    const auto op = proto::plan::GISFunctionFilterExpr_GISOp_Intersects;
+
+    auto make_gis_expr = [&] {
+        return std::make_shared<expr::GISFunctionFilterExpr>(
+            expr::ColumnInfo(geo_fid, DataType::GEOMETRY, {}, true),
+            op,
+            viewport);
+    };
+
+    // Ground truth from a standalone spatial run on the raw segment: no
+    // conjunction, so no short-circuit and no MoveCursor() involvement --
+    // correct regardless of the bug under test. A differential
+    // indexed-vs-raw check alone could pass with both conjunctions equally
+    // misaligned; anchoring on the standalone result cannot.
+    auto standalone = [&] {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           make_gis_expr());
+        return ExecuteQueryExpr(plan, raw_seg.get(), N, MAX_TIMESTAMP);
+    }();
+    ASSERT_EQ(standalone.size(), static_cast<size_t>(N));
+
+    // Non-vacuity: the active half must actually select something, otherwise
+    // the skipped GIS expr is never evaluated and the test cannot fail.
+    int64_t active_hits = 0;
+    for (int64_t i = N / 2; i < N; i++) {
+        active_hits += standalone[i] ? 1 : 0;
+    }
+    ASSERT_GT(active_hits, 0)
+        << "viewport selects nothing in rows [N/2, N); widen it";
+
+    proto::plan::GenericValue half;
+    half.set_int64_val(N / 2);
+    for (auto* seg : {indexed_seg.get(), raw_seg.get()}) {
+        auto int_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(int64_fid, DataType::INT64),
+            proto::plan::OpType::GreaterEqual,
+            half,
+            std::vector<proto::plan::GenericValue>{});
+        // int_expr FIRST so it decides the short-circuit; the GIS expr is
+        // the one skipped on the all-false early batches.
+        auto expr = std::make_shared<expr::LogicalBinaryExpr>(
+            expr::LogicalBinaryExpr::OpType::And, int_expr, make_gis_expr());
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        auto result = ExecuteQueryExpr(plan, seg, N, MAX_TIMESTAMP);
+        ASSERT_EQ(result.size(), static_cast<size_t>(N));
+        for (int64_t i = 0; i < N; i++) {
+            const bool expected = (i >= N / 2) && standalone[i];
+            ASSERT_EQ(result[i], expected)
+                << "row " << i << " on the "
+                << (seg == indexed_seg.get() ? "indexed" : "raw")
+                << " growing segment";
+        }
+    }
+}

--- a/internal/core/src/exec/expression/ExprGISMiscTest.cpp
+++ b/internal/core/src/exec/expression/ExprGISMiscTest.cpp
@@ -30,6 +30,7 @@
 #include "ExprTestBase.h"
 #include "NamedType/named_type_impl.hpp"
 #include "bitset/bitset.h"
+#include "common/Common.h"
 #include "common/Consts.h"
 #include "common/Exception.h"
 #include "common/Geometry.h"
@@ -1065,4 +1066,154 @@ TEST(ExprTest, GISFilterGrowingConjunctSkipKeepsCursorInSync) {
 // data cursor and MoveCursor() must do the same on a skipped batch.
 TEST(ExprTest, GISFilterGrowingIndexConjunctSkipKeepsCursorInSync) {
     RunGrowingConjunctSkipTest(true);
+}
+
+// Regression test for issue #51237.
+//
+// A growing segment carries a segment-level RTree index for a geometry field
+// as soon as the collection has an RTREE index on it. That makes geometry the
+// only field type whose expressions take the ScalarIndex path on a growing
+// segment, where size_per_chunk() is segcore.chunkRows (128 by default) rather
+// than the whole row count. The index result bitmap is global -- it must not be
+// sliced by the data chunk size.
+TEST_P(ExprTest, TestGeometryNullExprOnGrowingWithRTreeIndex) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    // Force a small evaluation batch so the batched conjunction cases below
+    // iterate multiple times and advance current_index_chunk_pos_ past 0.
+    // This is what exercises the non-zero data_pos slicing in
+    // ProcessIndexChunksForValid() and the MoveCursorForIndex() relaxation;
+    // with the 8192 default and N below it, everything collapses into a
+    // single batch and the cursor never moves. Restore on scope exit.
+    struct BatchSizeGuard {
+        int64_t saved;
+        ~BatchSizeGuard() {
+            EXEC_EVAL_EXPR_BATCH_SIZE.store(saved);
+        }
+    } batch_guard{EXEC_EVAL_EXPR_BATCH_SIZE.load()};
+    EXEC_EVAL_EXPR_BATCH_SIZE.store(128);
+
+    auto schema = std::make_shared<Schema>();
+    auto int64_fid = schema->AddDebugField("int64", DataType::INT64);
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_fid = schema->AddDebugField(
+        "geometry", DataType::GEOMETRY, true /*nullable*/);
+    schema->set_primary_field_id(int64_fid);
+
+    // An RTREE index on the geometry field makes IndexingRecord build the
+    // growing interim RTree index for it.
+    std::map<std::string, std::string> index_params = {{"index_type", "RTREE"}};
+    std::map<std::string, std::string> type_params = {};
+    FieldIndexMeta geo_index_meta(
+        geo_fid, std::move(index_params), std::move(type_params));
+    std::map<FieldId, FieldIndexMeta> field_index_metas = {
+        {geo_fid, geo_index_meta}};
+    auto index_meta = std::make_shared<CollectionIndexMeta>(
+        100000, std::move(field_index_metas));
+
+    auto config = SegcoreConfig::default_config();
+    config.set_chunk_rows(128);
+    // SegmentGrowingImpl::Insert only feeds the growing interim index (the
+    // geometry R-Tree included) when interim segment index is enabled.
+    config.set_enable_interim_segment_index(true);
+    auto seg = CreateGrowingSegment(schema, index_meta, 1, config);
+    auto seg_impl = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+
+    // More rows than a single chunk, so a bitmap truncated to size_per_chunk()
+    // is detectably short.
+    const int64_t N = 1000;
+    auto dataset =
+        DataGen(schema, N, 42, 0, 1, 10, 1, false, true, true /*random_valid*/);
+    auto offset = seg_impl->PreInsert(N);
+    seg_impl->Insert(offset,
+                     N,
+                     dataset.row_ids_.data(),
+                     dataset.timestamps_.data(),
+                     dataset.raw_);
+    ASSERT_TRUE(seg_impl->HasIndex(geo_fid));
+
+    auto valid_data = dataset.get_col_valid(geo_fid);
+
+    // Single expression: FilterBitsNode takes the execute-all-at-once path.
+    {
+        auto expr = std::make_shared<expr::NullExpr>(
+            expr::ColumnInfo(geo_fid, DataType::GEOMETRY, {}, true),
+            proto::plan::NullExpr_NullOp_IsNotNull);
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        auto final = ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
+        ASSERT_EQ(final.size(), N);
+        for (int64_t i = 0; i < N; i++) {
+            ASSERT_EQ(final[i], valid_data[i]) << "row " << i;
+        }
+    }
+
+    {
+        auto expr = std::make_shared<expr::NullExpr>(
+            expr::ColumnInfo(geo_fid, DataType::GEOMETRY, {}, true),
+            proto::plan::NullExpr_NullOp_IsNull);
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        auto final = ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
+        ASSERT_EQ(final.size(), N);
+        for (int64_t i = 0; i < N; i++) {
+            ASSERT_EQ(final[i], !valid_data[i]) << "row " << i;
+        }
+    }
+
+    // Conjunction with a raw-data expression: the geometry side keeps the
+    // ScalarIndex path but FilterBitsNode now runs the batched loop, which
+    // moves the index cursor.
+    {
+        proto::plan::GenericValue lower;
+        lower.set_int64_val(0);
+        auto int_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(int64_fid, DataType::INT64),
+            proto::plan::OpType::GreaterEqual,
+            lower,
+            std::vector<proto::plan::GenericValue>{});
+        auto null_expr = std::make_shared<expr::NullExpr>(
+            expr::ColumnInfo(geo_fid, DataType::GEOMETRY, {}, true),
+            proto::plan::NullExpr_NullOp_IsNotNull);
+        auto expr = std::make_shared<expr::LogicalBinaryExpr>(
+            expr::LogicalBinaryExpr::OpType::And, null_expr, int_expr);
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        auto final = ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
+        ASSERT_EQ(final.size(), N);
+        for (int64_t i = 0; i < N; i++) {
+            ASSERT_EQ(final[i], valid_data[i]) << "row " << i;
+        }
+    }
+
+    // Conjunction whose numeric side is all-false: the conjunction
+    // short-circuits and skips the geometry expression via MoveCursor(),
+    // which must advance the growing segment's global index cursor
+    // (MoveCursorForIndex used to assert sealed-only here).
+    {
+        proto::plan::GenericValue upper;
+        upper.set_int64_val(0);
+        auto int_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(int64_fid, DataType::INT64),
+            proto::plan::OpType::LessThan,
+            upper,
+            std::vector<proto::plan::GenericValue>{});
+        auto null_expr = std::make_shared<expr::NullExpr>(
+            expr::ColumnInfo(geo_fid, DataType::GEOMETRY, {}, true),
+            proto::plan::NullExpr_NullOp_IsNotNull);
+        // int_expr first so the all-false numeric side short-circuits the
+        // geometry side regardless of whether expression reordering is on.
+        auto expr = std::make_shared<expr::LogicalBinaryExpr>(
+            expr::LogicalBinaryExpr::OpType::And, int_expr, null_expr);
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        auto final = ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
+        ASSERT_EQ(final.size(), N);
+        for (int64_t i = 0; i < N; i++) {
+            ASSERT_FALSE(final[i]) << "row " << i;
+        }
+    }
 }

--- a/internal/core/src/exec/expression/ExprGISMiscTest.cpp
+++ b/internal/core/src/exec/expression/ExprGISMiscTest.cpp
@@ -1217,3 +1217,116 @@ TEST_P(ExprTest, TestGeometryNullExprOnGrowingWithRTreeIndex) {
         }
     }
 }
+
+// Follow-up coverage for issue #51237's review: the regression test above only
+// exercises NullExpr. Real spatial predicates on a growing segment take a
+// different route -- GISFunctionFilterExpr::EvalForIndexSegment()'s growing
+// branch -- and every other growing GIS case in this file builds its segment
+// with empty index meta, so HasIndex() is false and they all take the raw-data
+// path. That left "spatial predicate + geometry index on a growing segment"
+// with no coverage at all.
+//
+// Pin it by differential comparison: the same rows and the same predicate over
+// two growing segments, one carrying the RTREE index and one without. The
+// index only prunes candidates, so both must select exactly the same rows.
+TEST_P(ExprTest, TestGeometrySpatialExprOnGrowingWithRTreeIndex) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    // Small batch so the batched slicing path runs more than once and
+    // current_index_chunk_pos_ advances past 0.
+    struct BatchSizeGuard {
+        int64_t saved;
+        ~BatchSizeGuard() {
+            EXEC_EVAL_EXPR_BATCH_SIZE.store(saved);
+        }
+    } batch_guard{EXEC_EVAL_EXPR_BATCH_SIZE.load()};
+    EXEC_EVAL_EXPR_BATCH_SIZE.store(128);
+
+    auto make_schema = [] {
+        auto schema = std::make_shared<Schema>();
+        auto int64_fid = schema->AddDebugField("int64", DataType::INT64);
+        schema->AddDebugField(
+            "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+        schema->AddDebugField("geometry", DataType::GEOMETRY, true);
+        schema->set_primary_field_id(int64_fid);
+        return schema;
+    };
+
+    auto schema = make_schema();
+    const auto geo_fid = schema->get_field_id(FieldName("geometry"));
+    const int64_t N = 1000;
+    // One dataset, inserted into both segments, so any difference is the
+    // index path and nothing else.
+    auto dataset =
+        DataGen(schema, N, 42, 0, 1, 10, 1, false, true, true /*random_valid*/);
+
+    auto build_segment = [&](bool with_rtree_index) {
+        std::shared_ptr<CollectionIndexMeta> index_meta;
+        if (with_rtree_index) {
+            std::map<std::string, std::string> index_params = {
+                {"index_type", "RTREE"}};
+            std::map<std::string, std::string> type_params = {};
+            FieldIndexMeta geo_index_meta(
+                geo_fid, std::move(index_params), std::move(type_params));
+            std::map<FieldId, FieldIndexMeta> metas = {
+                {geo_fid, geo_index_meta}};
+            index_meta =
+                std::make_shared<CollectionIndexMeta>(100000, std::move(metas));
+        } else {
+            index_meta = std::make_shared<CollectionIndexMeta>(
+                100000, std::map<FieldId, FieldIndexMeta>{});
+        }
+
+        auto config = SegcoreConfig::default_config();
+        config.set_chunk_rows(128);
+        config.set_enable_interim_segment_index(true);
+        auto seg = CreateGrowingSegment(schema, index_meta, 1, config);
+        auto* impl = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+        auto offset = impl->PreInsert(N);
+        impl->Insert(offset,
+                     N,
+                     dataset.row_ids_.data(),
+                     dataset.timestamps_.data(),
+                     dataset.raw_);
+        return seg;
+    };
+
+    auto indexed_seg = build_segment(true);
+    auto raw_seg = build_segment(false);
+    ASSERT_TRUE(
+        dynamic_cast<SegmentGrowingImpl*>(indexed_seg.get())->HasIndex(geo_fid))
+        << "the indexed segment must actually carry the growing R-Tree, "
+           "otherwise this degenerates into comparing two raw-data runs";
+    ASSERT_FALSE(
+        dynamic_cast<SegmentGrowingImpl*>(raw_seg.get())->HasIndex(geo_fid));
+
+    // A viewport large enough to keep a meaningful subset -- an empty result
+    // on both sides would compare 0 == 0 and pin nothing.
+    const std::string viewport =
+        "POLYGON((-50 -50, 50 -50, 50 50, -50 50, -50 -50))";
+    for (auto op : {proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+                    proto::plan::GISFunctionFilterExpr_GISOp_Within}) {
+        auto run = [&](SegmentInternalInterface* seg) {
+            auto expr = std::make_shared<expr::GISFunctionFilterExpr>(
+                expr::ColumnInfo(geo_fid, DataType::GEOMETRY, {}, true),
+                op,
+                viewport);
+            auto plan = std::make_shared<plan::FilterBitsNode>(
+                DEFAULT_PLANNODE_ID, expr);
+            return ExecuteQueryExpr(plan, seg, N, MAX_TIMESTAMP);
+        };
+
+        auto indexed = run(indexed_seg.get());
+        auto raw = run(raw_seg.get());
+        ASSERT_EQ(indexed.size(), static_cast<size_t>(N));
+        ASSERT_EQ(raw.size(), static_cast<size_t>(N));
+        for (int64_t i = 0; i < N; i++) {
+            ASSERT_EQ(indexed[i], raw[i])
+                << "row " << i << " differs between the growing R-Tree path "
+                << "and the raw-data path, op "
+                << GISFunctionFilterExpr_GISOp_Name(op);
+        }
+    }
+}


### PR DESCRIPTION
issue: #51237
pr: #51523

Backport of #51523 to 3.0 (clean cherry-pick — the net diff is identical to #51523's).

## Root cause

A growing segment carries a segment-level interim R-Tree index for a geometry field as soon as the collection has an `RTREE` index on it, making geometry the only field type whose expressions take the **ScalarIndex** path on a growing segment. The index bitmap is segment-global (a scalar index always has exactly one chunk), but the batching code sliced it with `size_per_chunk_` as the upper bound — on a growing segment that is the raw-data chunk granularity (`segcore.chunkRows`, 128 by default), not the row count. A `geometry_field is not null` query over more than one chunk of growing rows returned a truncated bitmap and crashed `FilterBitsNode`:

```
Assert "col_vec_size == need_process_rows_" => bitset size: 128, need_process_rows_: 5000
```

## Fix

- `ProcessIndexChunksForValid()`: slice the cached valid bitmap by `active_count_` instead of `size_per_chunk_`, and assert the bitmap covers the requested range.
- `ProcessIndexChunks()`: same slicing for the result bitmap. The old third `min` term was also wrong on its own — it clamped against the bitmap's *full* length rather than the length remaining after `data_pos`, so a short bitmap plus `data_pos > 0` made `append()` read past the end.
- The `execute_all_at_once_` fast path: only move the cached bitmap wholesale when it lines up exactly with `active_count_`; otherwise fall through to the slicing branch, which bounds by `active_count_` and asserts coverage.
- `MoveCursorForIndex()`: drop the sealed-only assert — the index cursor is a global row position for growing segments with a segment-level index too.

## Note on the GIS cursor fix

An earlier revision of this branch also carried a `PhyGISFunctionFilterExpr::MoveCursor()` change, because 3.0 lacked master's equivalent and the short-circuit regression test below failed without it. #51488 ("[3.0] gate GIS filters out of the offset-input path") has since landed on 3.0 and provides it, so that commit was dropped on rebase. This PR is now exactly #51523.

## Tests

- `TestGeometryNullExprOnGrowingWithRTreeIndex` — `is not null` / `is null` on a growing segment with the R-Tree index, plus a batched conjunction and the short-circuit path.
- `TestGeometrySpatialExprOnGrowingWithRTreeIndex` — real spatial predicates, indexed vs raw growing segment over the same rows, must select identical rows.
- `TestGeometryConjunctionShortCircuitOnGrowingWithRTreeIndex` — conjunction whose numeric side short-circuits the early batches, anchored on a standalone spatial run rather than an indexed-vs-raw comparison alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
