### PR TITLE
fix: iterative-filter top-k ordering and segcore NULL 3VL correctness

### DIFF
--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -181,7 +181,10 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
                 offset = (offsets) ? offsets[i] : i;
             }
             if (valid_data != nullptr && !valid_data[offset]) {
-                res[i] = false;
+                // Column-null row: three-valued logic requires marking it
+                // invalid too, else a wrapping NOT flips res=false to true and
+                // wrongly matches the null row.
+                res[i] = valid_res[i] = false;
                 continue;
             }
             if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -735,7 +735,20 @@ class SegmentExpr : public Expr {
                 auto offset = (*input)[i];
                 auto raw = index_ptr->Reverse_Lookup(offset);
                 if (!raw.has_value()) {
-                    res[i] = false;
+                    // Null/absent row: three-valued logic requires res=false
+                    // AND valid=false (else a wrapping NOT matches the null
+                    // row). Still drive the callback on a null batch so
+                    // cursor-tracking callbacks keep processed_cursor aligned
+                    // — otherwise later candidates read the wrong bitmap_input
+                    // bit under iterative-filter AND.
+                    res[i] = valid_res[i] = false;
+                    func.template operator()<FilterType::random>(nullptr,
+                                                                 nullptr,
+                                                                 nullptr,
+                                                                 1,
+                                                                 res + i,
+                                                                 valid_res + i,
+                                                                 values...);
                     continue;
                 }
                 T raw_data = raw.value();
@@ -748,17 +761,24 @@ class SegmentExpr : public Expr {
                                                              valid_res + i,
                                                              values...);
             }
-        } else if (all_valid) {
-            res.set(0, batch_size);
-            valid_res.set(0, batch_size);
         } else {
+            // SkipIndex pruned the whole chunk: no row can match, so res must
+            // stay FALSE (the pre-fix code wrongly set res=true here). Set
+            // validity from the index bitmap for correct 3VL under NOT, and
+            // drive the callback on a null batch per row so cursor-tracking
+            // callbacks keep processed_cursor aligned (mirrors the
+            // ProcessDataByOffsets skip branches).
             for (auto i = 0; i < batch_size; ++i) {
                 auto offset = (*input)[i];
-                // materialize the bool once: chaining proxies would read
-                // back the word just stored into valid_res
-                const bool valid = valid_result[offset];
-                valid_res[i] = valid;
-                res[i] = valid;
+                res[i] = false;
+                valid_res[i] = all_valid || valid_result[offset];
+                func.template operator()<FilterType::random>(nullptr,
+                                                             nullptr,
+                                                             nullptr,
+                                                             1,
+                                                             res + i,
+                                                             valid_res + i,
+                                                             values...);
             }
         }
 
@@ -1040,10 +1060,21 @@ class SegmentExpr : public Expr {
                             valid_res + result_idx,
                             values...);
                     } else {
-                        // Chunk is skipped - handle exactly like ProcessDataByOffsets
+                        // Chunk skipped by SkipIndex: mark null rows invalid,
+                        // then drive the callback on a null batch so cursor-
+                        // tracking callbacks keep processed_cursor aligned
+                        // (mirrors the ProcessDataByOffsets skip branches).
                         if (valid_data.size() > j && !valid_data[j]) {
                             res[result_idx] = valid_res[result_idx] = false;
                         }
+                        func.template operator()<FilterType::random>(
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            1,
+                            res + result_idx,
+                            valid_res + result_idx,
+                            values...);
                     }
 
                     processed_size++;
@@ -1095,10 +1126,21 @@ class SegmentExpr : public Expr {
                         valid_res + processed_size,
                         values...);
                 } else {
-                    // Chunk is skipped
+                    // Chunk skipped by SkipIndex: mark null rows invalid, then
+                    // drive the callback on a null batch so cursor-tracking
+                    // callbacks keep processed_cursor aligned (mirrors the
+                    // ProcessDataByOffsets skip branches).
                     if (valid_data && !valid_data[0]) {
                         res[processed_size] = valid_res[processed_size] = false;
                     }
+                    func.template operator()<FilterType::random>(
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        1,
+                        res + processed_size,
+                        valid_res + processed_size,
+                        values...);
                 }
 
                 processed_size++;
@@ -1334,6 +1376,16 @@ class SegmentExpr : public Expr {
                             res[processed_elems + k] =
                                 valid_res[processed_elems + k] = false;
                         }
+                        // Drive the callback on a null batch so cursor-tracking
+                        // callbacks keep processed_cursor aligned with the
+                        // non-skip path (which advances by elem_count per row).
+                        func(nullptr,
+                             nullptr,
+                             nullptr,
+                             elem_count,
+                             res + processed_elems,
+                             valid_res + processed_elems,
+                             values...);
                         processed_elems += elem_count;
                     }
                 } else {
@@ -1348,6 +1400,16 @@ class SegmentExpr : public Expr {
                             res[processed_elems + k] =
                                 valid_res[processed_elems + k] = false;
                         }
+                        // Drive the callback on a null batch so cursor-tracking
+                        // callbacks keep processed_cursor aligned with the
+                        // non-skip path (which advances by elem_count per row).
+                        func(nullptr,
+                             nullptr,
+                             nullptr,
+                             elem_count,
+                             res + processed_elems,
+                             valid_res + processed_elems,
+                             values...);
                         processed_elems += elem_count;
                     }
                 }

--- a/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
@@ -197,36 +197,16 @@ PhyIterativeElementFilterNode::CollectResults(
             auto [doc_id, elem_idx] =
                 array_offsets->ElementIDToRowID(element_id);
 
-            // Find insert position using binary search
-            size_t pos =
-                large_is_better
-                    ? find_binsert_position<true>(search_result.distances_,
-                                                  base_idx,
-                                                  base_idx + count,
-                                                  distance)
-                    : find_binsert_position<false>(search_result.distances_,
-                                                   base_idx,
-                                                   base_idx + count,
-                                                   distance);
-
-            // Shift elements to make room for insertion
-            if (count > 0 && pos < base_idx + count) {
-                std::memmove(&search_result.distances_[pos + 1],
-                             &search_result.distances_[pos],
-                             (base_idx + count - pos) * sizeof(float));
-                std::memmove(&search_result.seg_offsets_[pos + 1],
-                             &search_result.seg_offsets_[pos],
-                             (base_idx + count - pos) * sizeof(int64_t));
-                std::memmove(&search_result.element_indices_[pos + 1],
-                             &search_result.element_indices_[pos],
-                             (base_idx + count - pos) * sizeof(int32_t));
-            }
-
-            // Insert the new result
-            search_result.seg_offsets_[pos] = doc_id;
-            search_result.element_indices_[pos] = elem_idx;
-            search_result.distances_[pos] = distance;
-            ++count;
+            // Insert into the per-query window [base_idx, base_idx + count),
+            // keeping it sorted best-first. Shared single owner with the
+            // iterative filter node so the two insertion paths cannot drift.
+            topk_binsert(search_result,
+                         base_idx,
+                         count,
+                         large_is_better,
+                         distance,
+                         doc_id,
+                         elem_idx);
         }
     }
 

--- a/internal/core/src/exec/operator/IterativeFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeFilterNode.cpp
@@ -88,47 +88,6 @@ PhyIterativeFilterNode::IsFinished() {
     return is_finished_;
 }
 
-inline void
-insert_helper(milvus::SearchResult& search_result,
-              int& topk,
-              const bool large_is_better,
-              const FixedVector<float>& distances,
-              const int64_t nq_index,
-              const int64_t unity_topk,
-              const int i,
-              int64_t doc_id,
-              std::optional<int32_t> elem_idx) {
-    auto pos = large_is_better
-                   ? find_binsert_position<true>(search_result.distances_,
-                                                 nq_index * unity_topk,
-                                                 nq_index * unity_topk + topk,
-                                                 distances[i])
-                   : find_binsert_position<false>(search_result.distances_,
-                                                  nq_index * unity_topk,
-                                                  nq_index * unity_topk + topk,
-                                                  distances[i]);
-
-    if (topk > pos) {
-        std::memmove(&search_result.distances_[pos + 1],
-                     &search_result.distances_[pos],
-                     (topk - pos) * sizeof(float));
-        std::memmove(&search_result.seg_offsets_[pos + 1],
-                     &search_result.seg_offsets_[pos],
-                     (topk - pos) * sizeof(int64_t));
-        if (elem_idx.has_value()) {
-            std::memmove(&search_result.element_indices_[pos + 1],
-                         &search_result.element_indices_[pos],
-                         (topk - pos) * sizeof(int32_t));
-        }
-    }
-    search_result.seg_offsets_[pos] = doc_id;
-    if (elem_idx.has_value()) {
-        search_result.element_indices_[pos] = elem_idx.value();
-    }
-    search_result.distances_[pos] = distances[i];
-    ++topk;
-}
-
 RowVectorPtr
 PhyIterativeFilterNode::GetOutput() {
     milvus::exec::checkCancellation(query_context_);
@@ -231,7 +190,7 @@ PhyIterativeFilterNode::GetOutput() {
 
         for (auto& iterator : search_result.vector_iterators_.value()) {
             EvalCtx eval_ctx(operator_context_->get_exec_context());
-            int topk = 0;
+            int64_t topk = 0;
             while (iterator->HasNext() && topk < unity_topk) {
                 offsets.clear();
                 distances.clear();
@@ -319,15 +278,13 @@ PhyIterativeFilterNode::GetOutput() {
                         for (size_t i = 0; i < offsets.size(); ++i) {
                             auto [doc_id, elem_idx] = element_to_doc_mapping[i];
                             if (doc_eval_cache[doc_id]) {
-                                insert_helper(search_result,
-                                              topk,
-                                              large_is_better,
-                                              distances,
-                                              nq_index,
-                                              unity_topk,
-                                              i,
-                                              doc_id,
-                                              elem_idx);
+                                topk_binsert(search_result,
+                                             nq_index * unity_topk,
+                                             topk,
+                                             large_is_better,
+                                             distances[i],
+                                             doc_id,
+                                             elem_idx);
                                 if (topk == unity_topk) {
                                     break;
                                 }
@@ -338,15 +295,13 @@ PhyIterativeFilterNode::GetOutput() {
                         Assert(bitsetview.size() == offsets.size());
                         for (auto i = 0; i < offsets.size(); ++i) {
                             if (bitsetview[i]) {
-                                insert_helper(search_result,
-                                              topk,
-                                              large_is_better,
-                                              distances,
-                                              nq_index,
-                                              unity_topk,
-                                              i,
-                                              offsets[i],
-                                              std::nullopt);
+                                topk_binsert(search_result,
+                                             nq_index * unity_topk,
+                                             topk,
+                                             large_is_better,
+                                             distances[i],
+                                             offsets[i],
+                                             std::nullopt);
                                 if (topk == unity_topk) {
                                     break;
                                 }
@@ -357,15 +312,13 @@ PhyIterativeFilterNode::GetOutput() {
                     Assert(!element_level);
                     for (auto i = 0; i < offsets.size(); ++i) {
                         if (bitset[offsets[i]] > 0) {
-                            insert_helper(search_result,
-                                          topk,
-                                          large_is_better,
-                                          distances,
-                                          nq_index,
-                                          unity_topk,
-                                          i,
-                                          offsets[i],
-                                          std::nullopt);
+                            topk_binsert(search_result,
+                                         nq_index * unity_topk,
+                                         topk,
+                                         large_is_better,
+                                         distances[i],
+                                         offsets[i],
+                                         std::nullopt);
                             if (topk == unity_topk) {
                                 break;
                             }

--- a/internal/core/src/exec/operator/Utils.h
+++ b/internal/core/src/exec/operator/Utils.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <cstddef>
+#include <cstring>
+#include <optional>
 #include "common/OpContext.h"
 #include "common/QueryInfo.h"
 #include "common/QueryResult.h"
@@ -45,6 +47,58 @@ find_binsert_position(const std::vector<float>& distances,
                   ? std::upper_bound(first, last, dist, std::greater<float>{})
                   : std::upper_bound(first, last, dist);
     return static_cast<size_t>(it - distances.begin());
+}
+
+// Insert one (distance, seg_offset[, elem_idx]) into the per-query result
+// window [base_idx, base_idx + count) of search_result, keeping that window
+// sorted best-first for the metric. Advances count. elem_idx == std::nullopt
+// means non-element-level (element_indices_ is left untouched).
+//
+// Single owner of the top-k insertion invariant, shared by the iterative
+// filter and iterative element filter nodes so the two cannot drift apart.
+inline void
+topk_binsert(SearchResult& search_result,
+             size_t base_idx,
+             int64_t& count,
+             bool large_is_better,
+             float distance,
+             int64_t seg_offset,
+             std::optional<int32_t> elem_idx) {
+    size_t pos = large_is_better
+                     ? find_binsert_position<true>(search_result.distances_,
+                                                   base_idx,
+                                                   base_idx + count,
+                                                   distance)
+                     : find_binsert_position<false>(search_result.distances_,
+                                                    base_idx,
+                                                    base_idx + count,
+                                                    distance);
+
+    // The window is [base_idx, base_idx + count); shift only when inserting
+    // before its current end. Guard/size with the ABSOLUTE window end
+    // (base_idx + count), not the relative count — otherwise for nq_index >= 1
+    // (base_idx > 0) the shift is wrongly skipped and out-of-order insertions
+    // overwrite existing top-k entries.
+    if (count > 0 && pos < base_idx + count) {
+        size_t n = base_idx + count - pos;
+        std::memmove(&search_result.distances_[pos + 1],
+                     &search_result.distances_[pos],
+                     n * sizeof(float));
+        std::memmove(&search_result.seg_offsets_[pos + 1],
+                     &search_result.seg_offsets_[pos],
+                     n * sizeof(int64_t));
+        if (elem_idx.has_value()) {
+            std::memmove(&search_result.element_indices_[pos + 1],
+                         &search_result.element_indices_[pos],
+                         n * sizeof(int32_t));
+        }
+    }
+    search_result.seg_offsets_[pos] = seg_offset;
+    if (elem_idx.has_value()) {
+        search_result.element_indices_[pos] = elem_idx.value();
+    }
+    search_result.distances_[pos] = distance;
+    ++count;
 }
 
 [[maybe_unused]] static bool

--- a/internal/core/src/exec/operator/search-groupby/SearchGroupByOperator.h
+++ b/internal/core/src/exec/operator/search-groupby/SearchGroupByOperator.h
@@ -282,7 +282,6 @@ class SealedDataGetter : public DataGetter<OutputType> {
                 return raw;
             }
         } else {
-            // null is not supported for indexed fields
             AssertInfo(index_ptr_.get() != nullptr,
                        "indexed field {} has no valid index pointer",
                        field_id_.get());
@@ -294,7 +293,13 @@ class SealedDataGetter : public DataGetter<OutputType> {
                        "ScalarIndex<OutputType>",
                        field_id_.get());
             auto raw = chunk_index->Reverse_Lookup(idx);
-            AssertInfo(raw.has_value(), "field data not found");
+            // A null row has no value in the index (Reverse_Lookup ==
+            // nullopt). Return nullopt so it forms a distinct null group,
+            // consistent with the from-data getter branches above — instead
+            // of asserting and failing the whole group-by query.
+            if (!raw.has_value()) {
+                return std::nullopt;
+            }
             return raw.value();
         }
     }

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -175,6 +175,10 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
                     fn(true, i);
                 }
             }
+            // Non-nullable is fully handled above; without this return the
+            // control falls through into the nullable block and invokes fn a
+            // second time per row.
+            return;
         }
         // nullable:
         if (offsets == nullptr) {

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -262,6 +262,10 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                     fn(true, i);
                 }
             }
+            // Non-nullable is fully handled above; without this return the
+            // control falls through into the nullable block and invokes fn a
+            // second time per row.
+            return;
         }
         // nullable:
         if (count == 0) {

--- a/internal/core/unittest/test_iterative_filter.cpp
+++ b/internal/core/unittest/test_iterative_filter.cpp
@@ -29,6 +29,7 @@
 #include "common/TracerBase.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "exec/operator/Utils.h"
 #include "filemanager/InputStream.h"
 #include "gtest/gtest.h"
 #include "index/Index.h"
@@ -430,5 +431,50 @@ TEST(IterativeFilter, GrowingIndex) {
             plan2.get(), ph_group.get(), MAX_TIMESTAMP);
         CheckFilterSearchResult(
             *search_result, *search_result2, topK, num_queries);
+    }
+}
+
+// Directly exercises the shared top-k insertion helper across multiple query
+// windows. The per-query window starts at base_idx = nq_index * unity_topk;
+// an out-of-order insertion (a better distance arriving after worse ones) must
+// shift the entries already in that window. The pre-fix math guarded/sized the
+// shift with the relative count instead of the absolute window end, so the
+// shift was skipped for every query beyond the first (nq_index >= 1),
+// corrupting their results. nq_index == 0 stayed correct, which is why the
+// nq == 1 unit tests above never caught it.
+TEST(IterativeFilterInsert, MultiQueryWindowOrdering) {
+    const int64_t unity_topk = 4;
+    const int64_t nq = 2;
+    const bool large_is_better = false;  // L2: smaller distance ranks first
+
+    SearchResult sr;
+    sr.distances_.assign(nq * unity_topk, 0.0f);
+    sr.seg_offsets_.assign(nq * unity_topk, -1);
+
+    // Insert stream (distance, seg_offset): 1/100, 3/300, 2/200, 4/400.
+    // The 2/200 arrives after 3/300, so it must be shifted into the middle.
+    const std::vector<std::pair<float, int64_t>> stream = {
+        {1.0f, 100}, {3.0f, 300}, {2.0f, 200}, {4.0f, 400}};
+    const std::vector<int64_t> expected_offsets = {100, 200, 300, 400};
+
+    for (int64_t q = 0; q < nq; ++q) {
+        int64_t count = 0;
+        for (const auto& [dist, off] : stream) {
+            milvus::exec::topk_binsert(sr,
+                                       q * unity_topk,
+                                       count,
+                                       large_is_better,
+                                       dist,
+                                       off,
+                                       std::nullopt);
+        }
+        ASSERT_EQ(count, unity_topk);
+        for (int64_t k = 0; k < unity_topk; ++k) {
+            ASSERT_EQ(sr.seg_offsets_[q * unity_topk + k], expected_offsets[k])
+                << "nq_index=" << q << " k=" << k;
+            ASSERT_FLOAT_EQ(sr.distances_[q * unity_topk + k],
+                            static_cast<float>(k + 1))
+                << "nq_index=" << q << " k=" << k;
+        }
     }
 }


### PR DESCRIPTION
Two groups of correctness fixes found while adversarially reviewing the iterative-filter / expression-eval **offset path**. Filed together per request; see the sections below for independent review.

## 1. Multi-query iterative-filter top-k insertion

`insert_helper` indexed the per-query result window by the **relative** `count` instead of the **absolute** window end (`base_idx + count`). For `nq_index >= 1` (`base_idx > 0`) the shift guard `count > pos` is always false, so an out-of-order candidate (a closer distance arriving after farther ones — which approximate vector iterators do emit) overwrote an existing top-k entry instead of shifting it, corrupting the top-k of **every query vector after the first** in a multi-query filtered search.

Fix: extracted the insertion into a single shared `Utils.h::topk_binsert` with the correct absolute-window math, used by **both** iterative-filter nodes so the two paths cannot diverge again. The sibling `IterativeElementFilterNode` already had the correct math — this removes the divergent copy that caused the bug.

Regression test: `IterativeFilterInsert.MultiQueryWindowOrdering` (deterministic; inserts an out-of-order stream into the second query window and asserts the correct sorted result — the previous relative-count math corrupts it).

## 2. NULL 3VL / null-batch-callback correctness on the offset path

- **`ExistsExpr`**: a column-null row set `res=false` but left `valid_res=true`, so `NOT exists(json[path])` wrongly matched null-JSON rows → `res=valid=false`.
- **`ProcessIndexLookupByOffsets`**: (a) null/absent index row (`Reverse_Lookup == nullopt`) left `valid_res=true` and never drove the callback, desyncing `processed_cursor` under iterative-filter `AND` → now `res=valid=false` + null-batch callback; (b) the SkipIndex skip branch set `res=true`, but a pruned chunk cannot match → `res=false` with validity from the index + null-batch callback, matching every other skip branch.
- **`ProcessElementLevelByOffsets` / `ProcessDataChunksForElementLevel`** skip branches now drive the null-batch callback, keeping cursor-tracking callbacks aligned with the doc-level skip branches.
- **`SearchGroupByOperator`**: group-by on an index-only nullable scalar field threw `AssertInfo("field data not found")` on a null row → returns `std::nullopt` to form a distinct null group, consistent with the from-data getters.
- **`ChunkedColumn` / `ProxyChunkColumn` `BulkIsValid`**: the non-nullable branch fell through into the nullable branch (invoking the callback twice per row) → added the missing `return`.

## Verification

Group 1 has a deterministic unit test (green with the fix). Group 2 applies the established null-rejecting / null-batch-callback contract and is covered here by compilation + no-regression against the existing expression suite; dedicated null regression tests (NOT exists on nullable JSON, NOT over a nullable indexed field via offset input, index-only nullable group-by) are a planned follow-up.

Deferred (documented, low priority): `LogicalBinaryExpr` 3VL merge (dead code — all AND/OR route to `ConjunctExpr`), `BitmapIndex` empty-array-on-legacy-file (narrow, safe direction), `UnaryExpr` array `is_same_array` valid-bit (unverified).

issue: #51586

🤖 Generated with [Claude Code](https://claude.com/claude-code)
