### PR TITLE
fix: reject invalid import commit timestamp

### DIFF
--- a/internal/datacoord/commit_timestamp_test.go
+++ b/internal/datacoord/commit_timestamp_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 )
 
@@ -122,9 +123,7 @@ func TestUpdateCommitTimestamp_RejectBelowMaxTimestampTo(t *testing.T) {
 	assert.NoError(t, meta.AddSegment(context.Background(), segWithBinlogs(1, 5000)))
 
 	err = meta.UpdateSegmentsInfo(context.Background(), UpdateCommitTimestamp(1, 3000))
-	// UpdateSegmentsInfo returns nil when the operator returns false (no-op);
-	// the assertion is on the persisted state, not the error.
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, merr.ErrImportSysFailed)
 	assert.Equal(t, uint64(0), meta.GetSegment(context.Background(), 1).GetCommitTimestamp(),
 		"rejected update must leave commit_timestamp unchanged")
 }

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1846,7 +1846,15 @@ func UpdateCommitTimestamp(segmentID int64, ts uint64) UpdateOperator {
 					mlog.Int64("segmentID", segmentID),
 					mlog.Uint64("commitTs", ts),
 					mlog.Uint64("maxBinlogTimestampTo", maxTsTo))
-				return false
+				// Fail-stop. Unreachable for a normal import: its rows carry the
+				// Import message's timetick and the commit fence is a later
+				// timetick on the same WAL. Keep the error retriable so the
+				// flusher blocks on the fence instead of failing the job — a
+				// blocked pchannel surfaces as WAL lag, whereas a replica that
+				// commits what the source rejected can no longer be rolled back.
+				return modPack.fail(merr.WrapErrImportSysFailedMsg(
+					"commit timestamp %d is less than max binlog timestamp %d for import segment %d",
+					ts, maxTsTo, segmentID))
 			}
 		}
 		segment.CommitTimestamp = ts

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -1813,6 +1813,27 @@ func UpdateIsImporting(segmentID int64, isImporting bool) UpdateOperator {
 	}
 }
 
+// maxBinlogTimestampTo returns the highest TimestampTo across a segment's insert
+// binlogs, or 0 when the arrays are absent.
+//
+// Absent is not the same as "no rows": a V3 (manifest-backed) segment never
+// persists these arrays -- buildAlterSegmentsKvs skips the per-FieldBinlog KVs
+// for it (kv_catalog.go:357) and the SegmentInfo is written without them -- so a
+// V3 segment reloaded after a DataCoord restart reports 0 here regardless of the
+// row timestamps it actually holds. Callers therefore get a bound that is safe
+// to compare against but that does not fire for reloaded V3 segments.
+func maxBinlogTimestampTo(fieldBinlogs []*datapb.FieldBinlog) uint64 {
+	var maxTsTo uint64
+	for _, fb := range fieldBinlogs {
+		for _, l := range fb.GetBinlogs() {
+			if l.GetTimestampTo() > maxTsTo {
+				maxTsTo = l.GetTimestampTo()
+			}
+		}
+	}
+	return maxTsTo
+}
+
 // UpdateCommitTimestamp sets the commit_timestamp on an import/CDC segment.
 // Non-zero marks it as committed at that transaction time, overriding
 // start_position.Timestamp for all temporal decisions.
@@ -1833,14 +1854,7 @@ func UpdateCommitTimestamp(segmentID int64, ts uint64) UpdateOperator {
 			return false
 		}
 		if ts != 0 {
-			var maxTsTo uint64
-			for _, fieldBinlogs := range segment.GetBinlogs() {
-				for _, l := range fieldBinlogs.GetBinlogs() {
-					if l.GetTimestampTo() > maxTsTo {
-						maxTsTo = l.GetTimestampTo()
-					}
-				}
-			}
+			maxTsTo := maxBinlogTimestampTo(segment.GetBinlogs())
 			if ts < maxTsTo {
 				mlog.Error(context.TODO(), "meta update: update commit timestamp rejected - commit_ts < max(binlog.TimestampTo)",
 					mlog.Int64("segmentID", segmentID),
@@ -1852,6 +1866,14 @@ func UpdateCommitTimestamp(segmentID int64, ts uint64) UpdateOperator {
 				// flusher blocks on the fence instead of failing the job — a
 				// blocked pchannel surfaces as WAL lag, whereas a replica that
 				// commits what the source rejected can no longer be rolled back.
+				//
+				// Recovery from here is out of band. The job is already
+				// Committing by the time this runs -- commitImportV2AckCallback
+				// persists that state on the broadcast FastAck, independent of
+				// this fence -- and Committing is terminal for AbortImport while
+				// tryTimeoutJob never reaches it (TimeoutTs defaults to
+				// math.MaxUint64). Validating earlier does not change that: the
+				// ack path flips the state regardless of what this check says.
 				return modPack.fail(merr.WrapErrImportSysFailedMsg(
 					"commit timestamp %d is less than max binlog timestamp %d for import segment %d",
 					ts, maxTsTo, segmentID))

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -5979,3 +5979,67 @@ func TestAbortImport_CommittingRejected(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, merr.Ok(resp))
 }
+
+// TestHandleCommitVchannelRPC_V3SegmentIsNotFencedYet pins a pre-existing gap
+// that this PR does not close: the fence derives its bound from the segment's
+// binlog arrays, and a V3 (manifest-backed) segment never persists those --
+// buildAlterSegmentsKvs skips the per-FieldBinlog KVs for it and the SegmentInfo
+// is written without them -- so a V3 segment reloaded after a DataCoord restart
+// compares against 0 and admits any commit timestamp, however low.
+//
+// Import segments become V3 as soon as UpdateManifest runs, so this is the main
+// import path, not a corner. The follow-up that reads Stats.TimestampTo instead
+// should flip these assertions; until then the current behavior is recorded
+// rather than left to be discovered.
+func TestHandleCommitVchannelRPC_V3SegmentIsNotFencedYet(t *testing.T) {
+	ctx := context.Background()
+
+	importMetaMock := NewMockImportMeta(t)
+	importMetaMock.EXPECT().HandleCommitVchannel(mock.Anything, int64(3002), "vchan-0", mock.AnythingOfType("func() error")).
+		RunAndReturn(func(ctx context.Context, jobID int64, vchannel string, callback func() error) error {
+			return callback()
+		})
+
+	segIDs := []int64{11}
+	getSegIDsMock := mockey.Mock((*Server).getImportSegmentIDsByVchannel).
+		Return(segIDs).Build()
+	defer getSegIDsMock.UnPatch()
+
+	segments := NewSegmentsInfo()
+	// Exactly the shape a reloaded V3 import segment has: a manifest, no binlog
+	// arrays, and Stats carrying the row timestamps that did survive the restart.
+	segments.SetSegment(11, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:            11,
+		CollectionID:  100,
+		PartitionID:   10,
+		InsertChannel: "vchan-0",
+		State:         commonpb.SegmentState_Flushed,
+		IsImporting:   true,
+		ManifestPath:  "files/insert_log/100/10/11/manifest",
+		Stats:         &datapb.Statistics{TimestampTo: 500},
+	}})
+
+	server := &Server{
+		importMeta: importMetaMock,
+		meta: &meta{
+			catalog:  &datacoordkv.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segments,
+		},
+	}
+	server.stateCode.Store(commonpb.StateCode_Healthy)
+
+	resp, err := server.HandleCommitVchannel(ctx, &datapb.HandleCommitVchannelRequest{
+		JobId:           3002,
+		Vchannel:        "vchan-0",
+		CommitTimestamp: 300, // below Stats.TimestampTo=500, yet admitted
+	})
+	assert.NoError(t, err)
+	assert.True(t, merr.Ok(resp), "the fence does not fire for a reloaded V3 segment")
+
+	seg := server.meta.GetSegment(ctx, 11)
+	require.NotNil(t, seg)
+	assert.EqualValues(t, 300, seg.GetCommitTimestamp())
+	assert.False(t, seg.GetIsImporting())
+	assert.EqualValues(t, 0, maxBinlogTimestampTo(seg.GetBinlogs()),
+		"the bound the fence compares against is 0 despite Stats.TimestampTo=500")
+}

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -5827,6 +5827,61 @@ func TestHandleCommitVchannelRPC_StoresCommitTimestamp(t *testing.T) {
 	}
 }
 
+func TestHandleCommitVchannelRPC_RejectsCommitTimestampBelowBinlogTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	importMetaMock := NewMockImportMeta(t)
+	importMetaMock.EXPECT().HandleCommitVchannel(mock.Anything, int64(3001), "vchan-0", mock.AnythingOfType("func() error")).
+		RunAndReturn(func(ctx context.Context, jobID int64, vchannel string, callback func() error) error {
+			return callback()
+		})
+
+	segIDs := []int64{10}
+	getSegIDsMock := mockey.Mock((*Server).getImportSegmentIDsByVchannel).
+		Return(segIDs).Build()
+	defer getSegIDsMock.UnPatch()
+
+	segments := NewSegmentsInfo()
+	segments.SetSegment(10, &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+		ID:            10,
+		CollectionID:  100,
+		PartitionID:   10,
+		InsertChannel: "vchan-0",
+		State:         commonpb.SegmentState_Flushed,
+		IsImporting:   true,
+		Binlogs: []*datapb.FieldBinlog{{
+			FieldID: 100,
+			Binlogs: []*datapb.Binlog{{
+				LogID:       10,
+				TimestampTo: 500,
+			}},
+		}},
+	}})
+
+	server := &Server{
+		importMeta: importMetaMock,
+		meta: &meta{
+			catalog:  &datacoordkv.Catalog{MetaKv: NewMetaMemoryKV()},
+			segments: segments,
+		},
+	}
+	server.stateCode.Store(commonpb.StateCode_Healthy)
+
+	resp, err := server.HandleCommitVchannel(ctx, &datapb.HandleCommitVchannelRequest{
+		JobId:           3001,
+		Vchannel:        "vchan-0",
+		CommitTimestamp: 300,
+	})
+	assert.NoError(t, err)
+	assert.False(t, merr.Ok(resp))
+	assert.ErrorIs(t, merr.Error(resp), merr.ErrImportSysFailed)
+
+	seg := server.meta.GetSegment(ctx, 10)
+	require.NotNil(t, seg)
+	assert.EqualValues(t, 0, seg.GetCommitTimestamp())
+	assert.True(t, seg.GetIsImporting())
+}
+
 func TestHandleCommitVchannelRPC_MissingJobReturnsError(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
issue: #51588

## What

`UpdateCommitTimestamp` detects the `commit_ts < max(binlog.TimestampTo)`
invariant violation but returned `false` without setting an error on the update
pack. `UpdateSegmentsInfo` ignores an operator's bool return and aborts only on
`updatePack.err`, so the batch issued by `HandleCommitVchannel` continued into
`UpdateIsImporting(false)`, persisted the segment and returned success — the
segment was published with `commit_timestamp` still 0, which is precisely the
state the invariant exists to prevent.

This makes the rejection abort the batch, so `is_importing` stays set and the
commit fence is not acknowledged.

## Why this blocks instead of failing the job

The error is deliberately left retriable (`ErrImportSysFailed`, SystemError).
`retry.Do` aborts by default only on `InputError`, and the StreamingNode flusher
wraps `HandleCommitVchannel` in `retry.Do(..., retry.AttemptAlways())`, so a
rejected fence blocks that pchannel's WAL replay until an operator intervenes.
That is the intent, not an oversight:

- The violation is expected to be **unreachable** for a normal import: its rows
  are stamped with the Import message's timetick (`DataTs` =
  `BroadcastResult.GetMaxTimeTick()`) and the commit fence is a later timetick on
  the same WAL. Only a binlog/backup import, whose rows keep the source cluster's
  original timestamps, can carry `max(binlog.TimestampTo)` above the local fence.
- Reaching it means an assumption has broken, so stopping beats proceeding on it.
- Blocking is observable: a stalled pchannel shows up in WAL/replication lag.
- Failing the import job instead would be worse under replication. The predicate
  is evaluated independently on each cluster against its own local TSO, so the
  source can reject a fence the replica accepts. Once the replica's job is
  `Committing`/`Completed`, `rollbackImportV2AckCallback` no-ops, so that
  divergence cannot be rolled back by any existing path. A wedged pchannel stops
  the cluster loudly; a diverged replica corrupts it quietly.

### What "an operator intervenes" means here

Recovery is deliberately manual. Once `HandleCommitVchannel` has flipped the job
to `Committing` — persisted before the callback runs (`import_meta.go:365-374`) —
every automatic path out is closed, and that is accepted rather than overlooked:

- `AbortImport` rejects `Committing` (`services.go:3028-3031`).
- The `RollbackImport` ack callback no-ops on `Committing`
  (`ddl_callbacks_import.go:304-310`).
- `tryTimeoutJob` does cover `Committing`, but compares against `TimeoutTs`,
  which `importutilv2.GetTimeoutTs` leaves at `math.MaxUint64` when the request
  carries no `timeout` option (`option.go:79`) — so by default it never fires.
  An import submitted **with** a `timeout` option does fail automatically, and
  the fence then clears via the `Failed` branch (`import_meta.go:351-352`).
- `checkCommittingJob` has only a success branch (`import_checker.go:522-541`),
  and `checkGC` handles `Completed`/`Failed` only (`:609-611`).
- The flusher retries forever, so a restart replays the same WAL message into the
  same rejection.

Detection is therefore by monitoring rather than by job state: the pchannel stops
advancing (WAL / replication lag) and the rejection is logged at `Error` on every
attempt (~1 line / 3 s per stuck vchannel). Resolution is an operator diagnosing
why the invariant broke — clock skew between the source of a binlog/backup import
and this cluster being the realistic cause — and then clearing the job out of
band. That cost is accepted in exchange for never publishing a segment with
`commit_timestamp = 0`.

## Tests

- `GOWORK=off PKG_CONFIG_PATH=$PWD/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=$PWD/internal/core/output/lib go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord -run 'Test(UpdateCommitTimestamp|HandleCommitVchannelRPC)'`
- `GOWORK=off PKG_CONFIG_PATH=$PWD/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=$PWD/internal/core/output/lib go build -tags dynamic ./internal/datacoord/`

## Not verified

- No end-to-end reproduction of the violation; the unreachability argument above
  is derived from code, not measured.
- Import in a replicating cluster is gated by
  `dataCoord.import.enableInReplicatingCluster` (default `false`), so the
  cross-cluster case only applies when that switch is enabled.
- `make static-check` currently fails in my local checkout with
  `no go files to analyze` on an unmodified tree as well, so it is an
  environment issue rather than a result of this change; CI covers it.

