### PR TITLE
test: prevent empty advcases teardown from racing TestDatabase

### DIFF
--- a/tests/go_client/testcases/advcases/main_test.go
+++ b/tests/go_client/testcases/advcases/main_test.go
@@ -1,3 +1,5 @@
+//go:build rbac || rg
+
 package advcases
 
 import (


### PR DESCRIPTION
## What this PR does

Fixes the flaky `testcases.TestDatabase` failure observed in [go-sdk pipeline #8856](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-go-sdk-pipeline/8856/).

Every test in `testcases/advcases` is guarded by either the `rbac` or `rg` build tag, but its `main_test.go` was untagged. As a result, the default `./testcases/...` suite still built an empty `advcases` test binary. Its `TestMain` called the shared teardown, which deletes every non-default database, while Go was running package test binaries concurrently. That teardown could remove the database owned by `TestDatabase`, causing its expected failing `DropDatabase` call to return `nil` instead.

This change gives `advcases/main_test.go` the same `rbac || rg` build constraint. The empty destructive package is no longer present in the default suite, while both tagged suites retain their existing `TestMain` behavior.

## Reproduction

On the unfixed revision, 97 real `TestDatabase` executions were run against a locally built Milvus. The first 62 were natural wildcard runs; all passed because the local scheduler consistently finished the empty `advcases` teardown before `TestDatabase` created its database. To exercise the package race seen in Jenkins, 35 controlled scheduling attempts then used the real `TestDatabase` binary and the real empty `advcases` `TestMain` teardown. The exact Jenkins failure was reproduced three times (controlled attempts 28, 29, and 35); in the other 32 attempts, the same teardown interfered earlier in the test rather than at the target assertion:

```text
database_test.go:97: An error is expected but got nil
```

## Validation

- Ran 97 independent default wildcard `TestDatabase` executions after the fix: **97/97 passed**.
- Confirmed `go list -test -tags=dynamic,test ./testcases/...` no longer includes `testcases/advcases`.
- Confirmed adding either `rbac` or `rg` still includes `testcases/advcases`.
- Ran `rg/TestCreateRgInvalidNames` against the local standalone: passed.

The ancillary RBAC runtime smoke was not claimed green: the local standalone was not configured for RBAC enforcement, and one existing error-message expectation also differed. The package was successfully selected and executed with the `rbac` tag; the target default-suite behavior is covered by the 97/97 validation above.

This narrowly removes the unintended empty-package teardown from the default suite. It does not claim to solve every possible cleanup race in explicitly tagged `rbac`/`rg` wildcard suites.
