### PR TITLE
fix: NULL 3VL on index-reverse-lookup and JSON-exists offset paths

### DIFF
--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -181,7 +181,10 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegment(EvalCtx& context) {
                 offset = (offsets) ? offsets[i] : i;
             }
             if (valid_data != nullptr && !valid_data[offset]) {
-                res[i] = false;
+                // Column-null row: three-valued logic requires marking it
+                // invalid too, else a wrapping NOT flips res=false to true and
+                // wrongly matches the null row.
+                res[i] = valid_res[i] = false;
                 continue;
             }
             if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -16,7 +16,9 @@
 
 #include "ExistsExpr.h"
 
+#include <numeric>
 #include <set>
+#include <vector>
 
 #include "bitset/bitset.h"
 #include "exec/expression/ExprCacheHelper.h"
@@ -118,7 +120,21 @@ PhyExistsFilterExpr::EvalJsonExistsForIndex() {
                     auto* mutable_index = const_cast<index::IndexBase*>(index);
                     res = mutable_index->Exists();
                 }
+                // Column-level validity (three-valued logic): a NULL-JSON row
+                // is UNKNOWN for exists, so its valid bit must be false — else
+                // a wrapping NOT exists() wrongly matches it. The index only
+                // reports whether the PATH exists, not whether the COLUMN is
+                // null, so apply the field's null bitmap over the whole
+                // segment (the raw-data path does the equivalent per row).
                 TargetBitmap valid(res.size(), true);
+                std::vector<int64_t> all_offsets(res.size());
+                std::iota(all_offsets.begin(), all_offsets.end(), 0);
+                segment_->ApplyFieldValidDataByOffsets(
+                    op_ctx_,
+                    expr_->column_.field_id_,
+                    all_offsets.data(),
+                    static_cast<int64_t>(res.size()),
+                    TargetBitmapView(valid));
                 return {std::move(res), std::move(valid)};
             });
         cached_index_chunk_res_ = cached.result;
@@ -273,7 +289,19 @@ PhyExistsFilterExpr::EvalJsonExistsForDataSegmentByStats() {
                         });
                 }
 
+                // Column-level validity (three-valued logic): a NULL-JSON row
+                // is UNKNOWN for exists, so its valid bit must be false — else
+                // a wrapping NOT exists() wrongly matches it. JSON stats report
+                // path existence, not column null, so apply the field's null
+                // bitmap over the whole segment.
                 TargetBitmap valid(active_count_, true);
+                std::vector<int64_t> all_offsets(active_count_);
+                std::iota(all_offsets.begin(), all_offsets.end(), 0);
+                segment_->ApplyFieldValidDataByOffsets(op_ctx_,
+                                                       field_id,
+                                                       all_offsets.data(),
+                                                       active_count_,
+                                                       TargetBitmapView(valid));
                 return {std::move(res), std::move(valid)};
             });
         cached_index_chunk_res_ = cached.result;

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -735,7 +735,20 @@ class SegmentExpr : public Expr {
                 auto offset = (*input)[i];
                 auto raw = index_ptr->Reverse_Lookup(offset);
                 if (!raw.has_value()) {
-                    res[i] = false;
+                    // Null/absent row: three-valued logic requires res=false
+                    // AND valid=false (else a wrapping NOT matches the null
+                    // row). Still drive the callback on a null batch so
+                    // cursor-tracking callbacks keep processed_cursor aligned
+                    // — otherwise later candidates read the wrong bitmap_input
+                    // bit under iterative-filter AND.
+                    res[i] = valid_res[i] = false;
+                    func.template operator()<FilterType::random>(nullptr,
+                                                                 nullptr,
+                                                                 nullptr,
+                                                                 1,
+                                                                 res + i,
+                                                                 valid_res + i,
+                                                                 values...);
                     continue;
                 }
                 T raw_data = raw.value();
@@ -748,17 +761,24 @@ class SegmentExpr : public Expr {
                                                              valid_res + i,
                                                              values...);
             }
-        } else if (all_valid) {
-            res.set(0, batch_size);
-            valid_res.set(0, batch_size);
         } else {
+            // SkipIndex pruned the whole chunk: no row can match, so res must
+            // stay FALSE (the pre-fix code wrongly set res=true here). Set
+            // validity from the index bitmap for correct 3VL under NOT, and
+            // drive the callback on a null batch per row so cursor-tracking
+            // callbacks keep processed_cursor aligned (mirrors the
+            // ProcessDataByOffsets skip branches).
             for (auto i = 0; i < batch_size; ++i) {
                 auto offset = (*input)[i];
-                // materialize the bool once: chaining proxies would read
-                // back the word just stored into valid_res
-                const bool valid = valid_result[offset];
-                valid_res[i] = valid;
-                res[i] = valid;
+                res[i] = false;
+                valid_res[i] = all_valid || valid_result[offset];
+                func.template operator()<FilterType::random>(nullptr,
+                                                             nullptr,
+                                                             nullptr,
+                                                             1,
+                                                             res + i,
+                                                             valid_res + i,
+                                                             values...);
             }
         }
 

--- a/internal/core/src/exec/expression/ExprArithOpTest.cpp
+++ b/internal/core/src/exec/expression/ExprArithOpTest.cpp
@@ -2406,6 +2406,17 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeWithScalarSortIndexNullable) {
     std::vector<
         std::tuple<std::string, std::function<bool(int, bool)>, DataType>>
         testcases = {
+            // NOT over a nullable, scalar-index-only field: a NULL row must be
+            // excluded (3VL: NOT(unknown)=unknown). Exercises
+            // ProcessIndexLookupByOffsets' null path — the pre-fix code left
+            // valid_res=true for a Reverse_Lookup==nullopt row, so NOT flipped
+            // it to a (wrong) match.
+            {"not (age8 + 4 == 8)",
+             [](int8_t v, bool valid) { return valid && !((v + 4) == 8); },
+             DataType::INT8},
+            {"not (age641 / 2 == 1000)",
+             [](int64_t v, bool valid) { return valid && !((v / 2) == 1000); },
+             DataType::INT64},
             // EQ tests
             {"age8 + 4 == 8",
              [](int8_t v, bool valid) { return valid && (v + 4) == 8; },

--- a/internal/core/src/exec/expression/ExprJsonAdvancedTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonAdvancedTest.cpp
@@ -910,6 +910,26 @@ TEST_P(ExprTest, TestExistsWithJSONNullable) {
     std::vector<
         std::tuple<std::string, std::function<bool(bool, bool)>, std::string>>
         testcases = {
+            // NOT over exists on a nullable JSON column: a NULL-JSON row must
+            // be excluded (3VL: NOT(unknown)=unknown). Pre-fix ExistsExpr left
+            // valid_res=true for a column-null row, so NOT flipped res=false to
+            // a wrong match.
+            {R"(not (exists json["bool"]))",
+             [](bool v, bool valid) {
+                 if (!valid) {
+                     return false;
+                 }
+                 return !v;
+             },
+             "bool"},
+            {R"(not (exists json["int"]))",
+             [](bool v, bool valid) {
+                 if (!valid) {
+                     return false;
+                 }
+                 return !v;
+             },
+             "int"},
             {R"(exists json["bool"])",
              [](bool v, bool valid) {
                  if (!valid) {


### PR DESCRIPTION
Two sibling NULL-3VL fixes on the expression **offset (iterative-filter) path**, found by the same review that produced #51540 (which fixed the raw `ProcessDataByOffsets` skip branches). These are the sibling paths that PR missed.

## 1. `ProcessIndexLookupByOffsets` (scalar-index reverse-lookup)
- A null/absent row (`Reverse_Lookup == nullopt`) set `res=false` but left `valid_res=true`, so a wrapping `NOT` flipped it to a wrong match; it also never drove the callback, desyncing the cursor-tracking `processed_cursor` under an iterative-filter `AND`. Now `res=valid=false` + null-batch callback.
- The SkipIndex skip branch set `res=true`, but a pruned chunk cannot match → `res=false` with validity from the index + null-batch callback, matching every other skip branch.

## 2. `ExistsExpr`
A column-null row set `res=false` but left `valid_res=true`, so `NOT exists(json[path])` wrongly matched null-JSON rows → `res=valid=false`.

## Tests
Adds `not (...)` cases over a nullable scalar-sort-indexed field (`TestBinaryArithOpEvalRangeWithScalarSortIndexNullable`) and over `exists` on a nullable JSON column (`TestExistsWithJSONNullable`), asserting NULL rows are excluded under NOT on both the sequential and offset-input paths.

issue: #51385

🤖 Generated with [Claude Code](https://claude.com/claude-code)
