### PR TITLE
enhance: pin and consolidate sealed-segment runtime snapshots

### DIFF
--- a/docs/design-docs/design_docs/20260717-sealed-segment-op-snapshot-pinning.md
+++ b/docs/design-docs/design_docs/20260717-sealed-segment-op-snapshot-pinning.md
@@ -54,11 +54,11 @@ Non-goals:
 
 ### Carrier: a type-erased slot on `milvus::OpContext`
 
-`OpContext` (milvus-common, `common/OpContext.h`) is already created one-per-operation
-per segment at the segcore C API boundary (`segment_c.cpp`: `AsyncSearch`,
-`AsyncRetrieve`, `SegmentLoad`, `AsyncReopenSegment`) and threaded through roughly half
-of the read accessors. It is the natural carrier for the pin. milvus-common must not
-know segcore types, so the slot is type-erased:
+`OpContext` (milvus-common, `common/OpContext.h`) is the existing operation-scoped
+carrier for cancellation, load priority, tracing, and storage accounting. Query
+execution creates its per-segment context in `ExecPlanNodeVisitor`; load/reopen paths
+create their own contexts at the segcore C API boundary. It is the natural carrier for
+the pin. milvus-common must not know segcore types, so the slot is type-erased:
 
 ```cpp
 // milvus-common: common/OpContext.h
@@ -94,9 +94,11 @@ The query visitor creates the per-segment `OpContext` and calls `PinOpSnapshot()
 before deriving `active_count` or constructing the plan fragment. This is after schema
 preparation at the C API / segment entry and before any layout-derived expression
 state is created. Once the `QueryContext` exists, it is the exec/query layer's single
-source of the operation context: operators and expressions obtain
-`query_context->get_op_context()` and pass only the resulting `OpContext*` across the
-lower-level segcore accessor boundary.
+source of the operation context: operators obtain
+`query_context->get_op_context()` at the point of use, while `CompileExpression`
+resolves the same pointer from `QueryContext` into the physical expression tree's
+pre-existing `op_ctx_` slot. Only the resulting `OpContext*` crosses the lower-level
+segcore accessor boundary; there is no second query-side propagation chain.
 Offset-driven `RetrieveByOffsets` is a separate sealed-segment read operation and pins
 at its own entry.
 
@@ -106,6 +108,13 @@ deferred ORDER BY fields). The visitor therefore copies its pin into `RetrieveRe
 and `SegmentInternalInterface::Retrieve()` reconstructs the fill `OpContext` from that
 exact pin. **Re-pinning between these phases is forbidden**: filter coordinates from
 snapshot A must never be applied to columns or schema from snapshot B.
+
+Search has the same lifetime split: the per-segment visitor returns before cross-segment
+reduce, PK fill, global-refine reads, extra-field export, and ordered target-field fill.
+Each `SearchResult` therefore carries its segment's type-erased pin. Reduce/export
+reconstructs a separate temporary `OpContext` for each result/segment; a shared
+cross-segment pin slot is forbidden because parallel segments must not overwrite or
+reuse one another's snapshot identity.
 
 Writers never pin. If a writer that shares an op_ctx with a subsequent read path ever
 publishes, it must clear the pin (`pinned_segment_state.reset()`) before that later read
@@ -170,8 +179,11 @@ mechanical parameter-passing with no behavior change when unpinned.
   "decisions from A applied to B's layout" scenario becomes unrepresentable.
 - Readers get *faster*: one atomic shared_ptr load per operation instead of one per
   accessor call.
-- Writers are untouched: publish/Reopen semantics, staged commit, rollback — all
-  unchanged. A mid-operation publish simply takes effect for the next operation.
+- Reopen's final staged publication synchronizes the live delete-state row-count
+  metadata and swaps the new published state under the segment mutex. Staged row-count
+  mutations touch only the staged `RuntimeResourceState`, so cancellation/failure
+  before publication cannot leak a future row count into `deleted_record_`.
+- A mid-operation publish simply takes effect for the next operation.
 
 ## Completeness: why one pointer is enough
 
@@ -189,6 +201,11 @@ Deliberately outside the snapshot, and correctly so: `deleted_record_` (deletes
 are monotonic and timestamp-filtered; they must keep applying to in-flight
 reads), growing-segment mutable records (growing has no Reopen), and
 non-query-semantic load progress / statistics bookkeeping.
+
+Although delete contents remain live, the sealed row-count used to size delete masks
+must advance atomically with the runtime publication. It is derived from
+`RuntimeResourceState::row_count` only at the final publish boundary; it is not an
+independent staged state container.
 
 ### Write-side proof
 
@@ -254,6 +271,12 @@ snapshot-isolation intuition.
    then verify `bulk_subscript` still returns exact vectors from the pinned column.
    The reverse raw-index to raw-column transition is covered by the same invariant:
    `IndexHasRawData`, `get_vector`, and `get_raw_data` all resolve the same pin.
+6. **Result handoff**: exercise QueryContext -> `RetrieveResult` and QueryContext ->
+   `SearchResult`, republish the raw-index transition, then run retrieve materialization
+   and search reduce/PK/target fill from the carried per-segment pins.
+7. **Staged row-count rollback**: stage a different runtime row count, abort before
+   publish, and assert both the published row count and delete-state row count remain
+   unchanged; then publish and assert they advance together.
 
 ## Alternatives considered
 
@@ -266,8 +289,12 @@ snapshot-isolation intuition.
   Rejected for auditability.
 - **Thread-local pin with RAII guard**: no signature changes, but segcore operations
   hop threads under folly executors; thread identity is not operation identity.
-- **Read locks around operations**: rejected outright — blocks Reopen behind slow
-  scans and violates the lock-free-reader rule this subsystem is built on.
+- **Extend segment read locks across the full logical operation**: the initial
+  `Search`/`Retrieve` call already takes the segment's shared mutex, but that lock ends
+  before cross-segment reduce, PK/target-field fill, and export. Holding it across
+  those later phases would couple segment lifetime to cross-component work and block
+  Reopen behind slow reduce/export. Snapshot pinning preserves the original view
+  without extending lock scope.
 
 ## Rollout
 
@@ -280,23 +307,21 @@ snapshot-isolation intuition.
 Steps 2–3 can be one PR; the behavior flips on with the `PinOpSnapshot` calls and is
 trivially revertible by removing them.
 
-## Implementation status (2026-07-18, gaps closed)
+## Implementation status (2026-07-19, gaps closed)
 
 The implementation lives on branch `feat/sealed-op-snapshot-pinning`. The five
 spec-review bypasses are fixed, a follow-up sweep closed the remaining read-path
-bypasses, and the Reopen-race regression test is in place. One open question
-remains a product decision (does not gate correctness):
+bypasses, and the Reopen-race regression tests are in place.
 
-1. **Is the race reachable in production?** The common Reopen (add/drop field)
-   carries existing columns over unchanged (`CloneRuntimeResourceState`:
-   `state->fields = current->fields`), so a query reading field F is unaffected
-   by schema changes to other fields — zero mismatch. The residual window only
-   opens when the *queried* field's column is replaced mid-query via
-   `fields_to_reload` (index raw-data transition), `column_groups_to_replace`,
-   or v3 manifest advance (compaction) — AND only if those paths are not already
-   drained against in-flight queries by the query scheduler. No reproduction has
-   been demonstrated; it is a logical-mismatch (wrong rows / OOB assert), NOT a
-   use-after-free (the read snapshot is held alive per accessor call).
+1. **The race is reachable at representation transitions.** Ordinary schema changes
+   that leave queried field F untouched carry its column forward, so they do not
+   create a layout mismatch for F. The concrete failure window is a transition of F
+   itself, such as no-raw vector index -> raw-data-capable vector index, where the new
+   published state drops the raw column while changing the accessor decision. The
+   retrieve and search regression tests below reproduce that transition between query
+   execution and output materialization. The failure is a cross-snapshot logical
+   mismatch/assertion, not a use-after-free: the old immutable state and its resources
+   remain alive through the operation pin.
 
 2. **The first implementation only partially achieved the pin** (spec review) —
    now RESOLVED. The five bypasses below have been fixed so every read path
@@ -326,13 +351,17 @@ remains a product decision (does not gate correctness):
    constructors `PhyColumnExpr` / `PhyUnaryRangeFilterExpr` plus
    `ReorderConjunctExpr` and `CreateTTLFieldFilterExpression`.
 
-   Intentionally left unpinned (documented): cross-segment / cross-operation
-   reduce+export paths (`search_result_export_c.cpp`, `Reduce.cpp`) — their
-   op_ctx is shared across segments so the owner guard rejects any pin, matching
-   the "each operation pins independently" non-goal; `GetJsonFlatIndexNestedPath`
-   (pre-pin exec-path metadata probe, boolean decision only); standalone PK-lookup /
-   delete accessors (`Contain` and delete ingestion) that are off the pinned
-   search/retrieve read path; and the load-immutable member reads
+   The final query-chain sweep also closed the later-lifetime gaps: `SearchResult`
+   carries the visitor pin through reduce/export, where each segment gets a separate
+   temporary op context for row-count validation, global refine, PK fill, extra-field
+   reads, and ordered target-field fill. `GetJsonFlatIndexNestedPath`, element-level
+   array-offset lookup, Project field existence, struct validity chunk coordinates,
+   group-by raw/index routing, and external-manifest/field-access admission all resolve
+   the QueryContext pin.
+
+   Intentionally left unpinned (documented): standalone PK-lookup / delete accessors
+   (`Contain` and delete ingestion) that are off the pinned search/retrieve read path;
+   and the load-immutable member reads
    (`col_index_meta_`, `is_sorted_by_pk_`, and load/publish/reopen internals)
    which never pin by design.
 
@@ -354,10 +383,14 @@ the fault-injection witness is `num_chunk_data(F, nullptr)==0` vs
 `PinIdentityAcrossConcurrentPublish` (every `Capture*` on one op_ctx returns the
 same snapshot pointer across a concurrent publish), and `OwnerGuardRejectsForeignPin`
 (segment X's pin, consulted by segment Y, returns Y's live state).
-`PinnedVectorRetrieveSurvivesRawIndexTransition` directly exercises #51594's
-no-raw-index to raw-index transition: the live state drops the vector column and
-advertises index raw data after the operation pins, while pinned `bulk_subscript`
-continues to return the exact vectors from its original column snapshot.
+`PinnedVectorRetrieveSurvivesRawIndexTransition` exercises #51594's no-raw-index to
+raw-index transition through the production QueryContext -> `RetrieveResult` handoff:
+the live state drops the vector column and advertises index raw data after query
+execution, while materialization through the carried pin returns exact vectors.
+`SearchResultPinSurvivesRawIndexTransitionDuringOutputFill` performs the equivalent
+search handoff and proves reduce PK fill plus target-vector fill stay on the original
+per-segment snapshot. `StagedRowCountDoesNotMutateDeleteStateBeforePublish` covers
+rollback and final row-count/delete-state publication.
 
 milvus-common with the two OpContext fields is landed and `conanfile.py` is
 bumped to `milvus-common/1.0.0-6b16d93`. Note: the package bump also changed

--- a/docs/design-docs/design_docs/20260717-sealed-segment-op-snapshot-pinning.md
+++ b/docs/design-docs/design_docs/20260717-sealed-segment-op-snapshot-pinning.md
@@ -1,0 +1,327 @@
+# Sealed-Segment Per-Operation Snapshot Pinning
+
+- Status: Draft
+- Date: 2026-07-17
+- Related: PR #51441 (stats skip index cell alignment), PR #51395 (PK state in runtime snapshot), master commit 158b1dc38a (text-index runtime-state migration)
+
+## Motivation
+
+`ChunkedSegmentSealedImpl` publishes all query-visible resources as one immutable
+`PublishedSegmentState` (schema, load info, `RuntimeResourceState` with the column map,
+indexes, skip-index metrics, readiness bitsets), swapped atomically by load / `Reopen` /
+staged-commit publishers. Readers are lock-free: every accessor independently calls
+`CapturePublishedState()` and works on whatever snapshot is current *at that call*.
+
+That per-call capture is the residual correctness window:
+
+- An expression caches layout-derived state for its whole lifetime
+  (`SegmentExpr::InitSegmentExpr` caches `num_data_chunk_`; `CompareExpr` caches
+  `left_num_chunk_` / `right_num_chunk_`; after #51441, `GetChunkSkipDecisions()`
+  memoizes per-cell skip decisions from one `GetSkipIndex()` snapshot).
+- Later per-batch calls (`chunk_size`, `num_rows_until_chunk`, `get_batch_views`,
+  `chunk_data`, `ApplyFieldValidData`, `prefetch_chunks`) each re-capture the
+  *current* published state.
+- A concurrent `Reopen` (schema change, `fields_to_reload`, `column_groups_to_replace`,
+  external-manifest advance) can publish a runtime whose columns have a different
+  row-group/cell layout between those two reads. Coordinates computed against snapshot
+  A are then applied to snapshot B: misaligned batch windows, wrong skip pruning,
+  or out-of-range chunk ids. `Reopen` explicitly does not block readers
+  (`reopen_mutex_` is writer-only), so the window is real by design.
+
+#51441 already made *(skip metrics, column, cell layout)* inseparable inside one
+snapshot (metrics are owned by the column group). What is still missing is the
+guarantee that **one operation uses one snapshot for everything** — chunk counts, row
+offsets, skip decisions, data views, validity, prefetch. This document specifies that
+guarantee.
+
+## Goal
+
+Within one segcore operation on one sealed segment (a search, a retrieve, or any
+expression evaluation spawned by them), every read of published state observes exactly
+one `PublishedSegmentState` — the one current when the operation started. Writers stay
+lock-free and unblocked; readers stay lock-free.
+
+Non-goals:
+
+- Growing segments. They have no published state; accessors read live mutable state
+  (`insert_record_`, `deleted_record_`) and are correct by their own model.
+- Deletes. `deleted_record_` is intentionally outside the snapshot: deletes are
+  monotonic and timestamp-filtered, and must keep applying to in-flight reads.
+- Cross-segment or cross-operation consistency. Each operation pins independently.
+
+## Design
+
+### Carrier: a type-erased slot on `milvus::OpContext`
+
+`OpContext` (milvus-common, `common/OpContext.h`) is already created one-per-operation
+per segment at the segcore C API boundary (`segment_c.cpp`: `AsyncSearch`,
+`AsyncRetrieve`, `SegmentLoad`, `AsyncReopenSegment`) and threaded through roughly half
+of the read accessors. It is the natural carrier for the pin. milvus-common must not
+know segcore types, so the slot is type-erased:
+
+```cpp
+// milvus-common: common/OpContext.h
+struct OpContext {
+    ...
+    // Pinned read snapshot for the segment this operation runs on.
+    // Set once by the segment at operation entry; readers static_pointer_cast
+    // it back. `pinned_state_owner` guards against an OpContext ever being
+    // reused across segments: a mismatched owner means "do not use the pin".
+    std::shared_ptr<const void> pinned_segment_state;
+    const void* pinned_state_owner = nullptr;
+};
+```
+
+This requires a milvus-common PR and a version bump in milvus; the slot is generic
+("extensible operation metadata" is OpContext's charter) and adds no dependency.
+
+### Pinning: eager, at the operation's semantic entry
+
+```cpp
+// ChunkedSegmentSealedImpl
+void PinOpSnapshot(milvus::OpContext* op_ctx) const {
+    if (op_ctx == nullptr) return;
+    auto state = CapturePublishedState();          // one atomic load
+    op_ctx->pinned_segment_state = state;          // shared_ptr<const void>
+    op_ctx->pinned_state_owner = this;
+}
+```
+
+Called at the top of `ChunkedSegmentSealedImpl::Search()` and `::Retrieve()` — i.e.
+**after** `LazyCheckSchema` (which may itself Reopen and republish; pinning before it
+would freeze the pre-upgrade schema the operation was just upgraded to see). Writers
+never pin. If a writer that shares an op_ctx with a subsequent read path ever publishes
+(`LazyCheckSchema` today), it must clear the pin (`pinned_segment_state.reset()`)
+so the read path re-pins the post-publish state; with eager pinning at Search/Retrieve
+entry this is automatic, and the clear is only a defensive invariant.
+
+Eager (not pin-on-first-capture) because it makes the snapshot's birthline auditable —
+"the operation sees the world as of Search() entry" — and avoids ordering surprises
+between reader and writer calls earlier in the same task.
+
+### Capture: one choke point honors the pin
+
+```cpp
+std::shared_ptr<const PublishedSegmentState>
+CapturePublishedState(milvus::OpContext* op_ctx = nullptr) const {
+    if (op_ctx != nullptr && op_ctx->pinned_state_owner == this &&
+        op_ctx->pinned_segment_state != nullptr) {
+        return std::static_pointer_cast<const PublishedSegmentState>(
+            op_ctx->pinned_segment_state);
+    }
+    return std::atomic_load(&published_state_);
+}
+```
+
+`CaptureRuntimeResourceState`, `CaptureSchemaSnapshot`, `CaptureLoadInfoSnapshot`,
+`get_column`, `GetSkipIndex` gain the same optional `op_ctx` parameter and forward it.
+With no op_ctx (tests, tools, writer internals) behavior is unchanged.
+
+### Plumbing: give the layout-coordinate accessors an op_ctx
+
+Accessors already carrying `OpContext*` (data/validity/prefetch/index pins:
+`get_batch_views`, `get_views_by_offsets`, `chunk_data`, `chunk_view`,
+`ApplyFieldValidData*`, `prefetch_chunks`, `PinIndex`, `GetTextIndex`, `GetJsonStats`,
+`GetNgramIndex*`, `bulk_subscript` overloads) only change internally: their
+`CapturePublishedState()` becomes `CapturePublishedState(op_ctx)`.
+
+Accessors that read published state but have no op_ctx today gain
+`milvus::OpContext* op_ctx = nullptr` (appended, defaulted — source-compatible):
+
+| Accessor | Used by |
+| --- | --- |
+| `num_chunk_data`, `num_chunk` | `SegmentExpr::InitSegmentExpr`, `CompareExpr` ctor |
+| `chunk_size` | every `ProcessDataChunks` batch loop |
+| `num_rows_until_chunk`, `get_chunk_by_offset` | scan offsets, `SegmentChunkReader::MoveCursor*` |
+| `GetSkipIndex` | `GetChunkSkipDecisions`, `PrefetchRawData` |
+| `HasFieldData`, `HasIndex`, `HasJsonIndex`, `IndexHasRawData`, `HasRawData` | exec-path selection |
+| `get_schema`, `is_nullable`, `is_field_exist`, `GetFieldDataType` | expression init |
+| `GetArrayOffsets`, `get_max_timestamp` | struct-array exprs, ts pruning |
+
+Call-site sweep: `SegmentExpr` (`Expr.h`), the four `PrefetchRawData` overrides,
+`SegmentChunkReader`, `CompareExpr`, and the query paths under `query/` that mix
+coordinates with data reads. All of these already hold `op_ctx_`; the sweep is
+mechanical parameter-passing with no behavior change when unpinned.
+
+### What this buys
+
+- The #51441 memoized skip decisions, the chunk count cached at expression
+  construction, every `chunk_size`/offset computation, every data/validity view, and
+  the prefetch filter all come from one `PublishedSegmentState`. The reviewer's
+  "decisions from A applied to B's layout" scenario becomes unrepresentable.
+- Readers get *faster*: one atomic shared_ptr load per operation instead of one per
+  accessor call.
+- Writers are untouched: publish/Reopen semantics, staged commit, rollback — all
+  unchanged. A mid-operation publish simply takes effect for the next operation.
+
+## Completeness: why one pointer is enough
+
+Add-field / drop-field (and every other Reopen flavor) can only affect resources
+that live inside `PublishedSegmentState`, because the preceding migrations
+deliberately moved them there: the schema itself (`PublishedSegmentState::schema`),
+columns (`runtime->fields`), scalar/vector/text/json/ngram indexes
+(158b1dc38a), readiness bitsets, PK index and offset maps (#51395), timestamps
+and their index, skip metrics (#51441), and the load info. Pinning the root
+pointer therefore freezes all of them as one version — there is no second
+carrier to add to OpContext.
+
+Deliberately outside the snapshot, and correctly so: `deleted_record_` (deletes
+are monotonic and timestamp-filtered; they must keep applying to in-flight
+reads), growing-segment mutable records (growing has no Reopen), and
+non-query-semantic bookkeeping (mmap field set, load progress).
+
+### Write-side proof
+
+The completeness claim is best checked from the write side: what does an
+add-field / drop-field Reopen actually mutate? It builds a staged
+`PublishedSegmentState` (`DropFieldFromState` / `DropFieldData` operate on a
+staged copy, never the live one) and atomically swaps the `shared_ptr`. It
+writes no segment member. The members that reads reach directly (bypassing
+`Capture*`) are all load-immutable:
+
+| Member | Only write site | Touched by add/drop-field? |
+| --- | --- | --- |
+| `num_rows_` | set-once at load (ChunkedSegmentSealedImpl.cpp:2843, guarded by an equality assert that any reload matches); cleared only in `ClearData()` (full teardown, needs in-flight ops drained) | No — add/drop-field changes fields, not row count; the assert enforces reload equality |
+| `col_index_meta_` | ctor init-list only (:4501), zero reassignment | No — immutable |
+| `is_sorted_by_pk_` | ctor init-list only (:4502), zero reassignment | No — immutable |
+| `schema_` | no raw member; schema lives in `PublishedSegmentState` | In the snapshot |
+
+So pinning one pointer captures 100% of what a schema-change Reopen can alter;
+everything read outside the snapshot is written once and never touched by
+Reopen. These immutable members get an immutability comment (so a future edit
+that adds a Reopen write to them cannot silently break the pin) but need no
+migration.
+
+Two further consequences worth naming:
+
+- `get_schema()` returns `const Schema&` into the published state; today two
+  quick republishes can theoretically free the schema under a long-lived
+  reference. Resolving it against the pinned snapshot removes that hazard.
+- The guarantee holds only for reads that go through `Capture*`. The
+  implementation includes the bypass audit above; the four immutable-member
+  reads are documented as intentionally live, not migrated.
+
+## Lifetime and memory
+
+The pin holds the old snapshot (columns, cache slots, metas) alive for the operation's
+duration — the same ownership model the #51441 `SkipIndex` view and every `PinWrapper`
+already use, extended from "one call" to "one operation". Cost is bounded by operation
+latency. Old cells remain evictable; re-fetch goes through the old column's translator
+against the old files. That requires the existing operational invariant that file GC
+grants a grace period covering in-flight operations — pinning does not lengthen the
+window beyond the operation lifetimes that PinWrapper already imposes.
+
+## Semantics changes
+
+An operation no longer observes resources published mid-flight (e.g. an interim index
+becoming ready between two batches). Today whether it observes them is a race; after
+pinning it deterministically does not. This is strictly more predictable and matches
+snapshot-isolation intuition.
+
+## Testing
+
+1. **Reopen race regression** (the test the pinning makes writable): load a storage-v2
+   segment with the skip-index flag on, start an expression eval, use the #51395
+   staged-commit test hooks (`TestStageLoadFieldDataThenPublish`) to republish a
+   runtime with a different cell layout mid-scan, assert exact query results and no
+   OOB — the eval must complete entirely on its pinned snapshot.
+2. **Pin identity**: within one op_ctx, assert every `Capture*` returns the same
+   snapshot pointer while a concurrent publisher swaps state.
+3. **Unpinned compatibility**: null op_ctx keeps today's behavior (existing suites).
+4. **Owner guard**: an op_ctx pinned by segment X, passed to segment Y, must not
+   return X's state.
+
+## Alternatives considered
+
+- **Per-expression pinned column handle** (the follow-up sketched in #51441): fixes
+  only `SegmentExpr`, needs new view/dispatch APIs on `ChunkedColumnInterface` or
+  column-taking overloads of every segment view method, and leaves `CompareExpr`,
+  `SegmentChunkReader`, and retrieve incoherent. More churn, less coverage.
+- **Pin-on-first-capture (lazy)**: transparent but makes the snapshot's birth depend
+  on incidental call order (and `LazyCheckSchema` would pin pre-upgrade state).
+  Rejected for auditability.
+- **Thread-local pin with RAII guard**: no signature changes, but segcore operations
+  hop threads under folly executors; thread identity is not operation identity.
+- **Read locks around operations**: rejected outright — blocks Reopen behind slow
+  scans and violates the lock-free-reader rule this subsystem is built on.
+
+## Rollout
+
+1. milvus-common: add the two OpContext fields (independent, backward compatible).
+2. milvus: bump milvus-common; add `PinOpSnapshot` + op_ctx-aware `Capture*`; pin in
+   `Search`/`Retrieve`.
+3. milvus: mechanical op_ctx sweep through the accessor table above and the exec
+   call sites; add the tests.
+
+Steps 2–3 can be one PR; the behavior flips on with the `PinOpSnapshot` calls and is
+trivially revertible by removing them.
+
+## Implementation status (2026-07-18, gaps closed)
+
+The implementation lives on branch `feat/sealed-op-snapshot-pinning`. The five
+spec-review bypasses are fixed, a follow-up sweep closed the remaining read-path
+bypasses, and the Reopen-race regression test is in place. One open question
+remains a product decision (does not gate correctness):
+
+1. **Is the race reachable in production?** The common Reopen (add/drop field)
+   carries existing columns over unchanged (`CloneRuntimeResourceState`:
+   `state->fields = current->fields`), so a query reading field F is unaffected
+   by schema changes to other fields — zero mismatch. The residual window only
+   opens when the *queried* field's column is replaced mid-query via
+   `fields_to_reload` (index raw-data transition), `column_groups_to_replace`,
+   or v3 manifest advance (compaction) — AND only if those paths are not already
+   drained against in-flight queries by the query scheduler. No reproduction has
+   been demonstrated; it is a logical-mismatch (wrong rows / OOB assert), NOT a
+   use-after-free (the read snapshot is held alive per accessor call).
+
+2. **The first implementation only partially achieved the pin** (spec review) —
+   now RESOLVED. The five bypasses below have been fixed so every read path
+   routes through the operation's pinned op_ctx:
+     a. `RetrieveByOffsets` (SegmentInterface.cpp) — `TryTakeForRetrieve` now
+        calls `CapturePublishedState(op_ctx)`, and `FillTargetEntry`'s slow-path
+        `local_ctx` copies the pin fields (`pinned_segment_state` +
+        `pinned_state_owner`) so its `bulk_subscript` / `is_field_exist` reads
+        resolve the pin. The main `Retrieve` fill phase now pins too.
+     b. `CompareExpr::CanUseBothDataFastPath` — `num_chunk_data` /
+        `num_rows_until_chunk` now pass `op_ctx_`.
+     c. `MatchExpr::Eval` — `get_schema(op_ctx_)`.
+     d. `GISFunctionFilterExpr::EvalForIndexSegment` — the fresh local op_ctx is
+        gone; `bulk_subscript` uses `op_ctx_`.
+     e. `SegmentChunkReader::GetIndexAndBaseOffset` — gained an `op_ctx` param;
+        callers pass the reader's `op_ctx_`.
+
+   A follow-up bypass sweep also routed these read-path accessors through the
+   pin: `vector_search`, `get_vector`, `get_emb_list`, `get_raw_data`,
+   `CalcDistByIDs`, `pk_range`, `pk_binary_range`, `prefetch_vector`,
+   `IsIndexRefineEnabled`, `bulk_subscript_text_impl`, `TryTakeForSearch`, the
+   sealed search-result `FillTargetEntry` / `FillPrimaryKeys`, `fill_with_empty`
+   (gained an op_ctx param; its `CaptureSchemaSnapshot` was the last live-schema
+   read reachable from a pinned `bulk_subscript`), and the exec-path
+   constructors `PhyColumnExpr` / `PhyUnaryRangeFilterExpr` plus
+   `ReorderConjunctExpr` and `CreateTTLFieldFilterExpression`.
+
+   Intentionally left unpinned (documented): cross-segment / cross-operation
+   reduce+export paths (`search_result_export_c.cpp`, `Reduce.cpp`) — their
+   op_ctx is shared across segments so the owner guard rejects any pin, matching
+   the "each operation pins independently" non-goal; `GetJsonFlatIndexNestedPath`
+   (pre-pin exec-path metadata probe, boolean decision only); PK-lookup /
+   delete / timestamp-mask accessors (`Contain`, `search_pks`, `find_first_n`,
+   `mask_with_timestamps`) that have no op_ctx param and are off the pinned
+   search/retrieve read path; and the four load-immutable member reads
+   (`num_rows_`, `col_index_meta_`, `is_sorted_by_pk_`, and load/publish/reopen
+   internals) which never pin by design.
+
+Regression test: `test_sealed.cpp` adds `SealedSegmentOpSnapshotPin.*` —
+`PinnedScanSurvivesMidScanFieldDrop` (load scalar F, pin, read F, `Reopen` to a
+schema that drops F mid-scan, then re-read F through the pin and get exact rows;
+the fault-injection witness is `num_chunk_data(F, nullptr)==0` vs
+`num_chunk_data(F, &pinned)==1`, and the unpinned RawData read would abort at
+`AssertInfo(field_data_ready_bitset[F])` in `chunk_data_impl`),
+`PinIdentityAcrossConcurrentPublish` (every `Capture*` on one op_ctx returns the
+same snapshot pointer across a concurrent publish), and `OwnerGuardRejectsForeignPin`
+(segment X's pin, consulted by segment Y, returns Y's live state).
+
+milvus-common with the two OpContext fields is landed and `conanfile.py` is
+bumped to `milvus-common/1.0.0-6b16d93`. Note: the package bump also changed
+`cachinglayer::LoadingOverheadConfig`'s shape, so `HybridScalarIndexTest.cpp`
+was adapted to the new `memory`/`file` dimension members.

--- a/docs/design-docs/design_docs/20260717-sealed-segment-op-snapshot-pinning.md
+++ b/docs/design-docs/design_docs/20260717-sealed-segment-op-snapshot-pinning.md
@@ -1,14 +1,15 @@
 # Sealed-Segment Per-Operation Snapshot Pinning
 
-- Status: Draft
+- Status: Implemented on PR #51602
 - Date: 2026-07-17
-- Related: PR #51441 (stats skip index cell alignment), PR #51395 (PK state in runtime snapshot), master commit 158b1dc38a (text-index runtime-state migration)
+- Related: PR #51602 (operation snapshot pinning), PR #51531 (misc runtime-state migration), PR #51441 (stats skip index cell alignment), PR #51395 (PK state in runtime snapshot), master commit 158b1dc38a (text-index runtime-state migration)
 
 ## Motivation
 
 `ChunkedSegmentSealedImpl` publishes all query-visible resources as one immutable
 `PublishedSegmentState` (schema, load info, `RuntimeResourceState` with the column map,
-indexes, skip-index metrics, readiness bitsets), swapped atomically by load / `Reopen` /
+indexes, skip-index metrics, readiness bitsets, row count, mmap-field markers, and
+variable-field average-size estimates), swapped atomically by load / `Reopen` /
 staged-commit publishers. Readers are lock-free: every accessor independently calls
 `CapturePublishedState()` and works on whatever snapshot is current *at that call*.
 
@@ -81,19 +82,34 @@ This requires a milvus-common PR and a version bump in milvus; the slot is gener
 // ChunkedSegmentSealedImpl
 void PinOpSnapshot(milvus::OpContext* op_ctx) const {
     if (op_ctx == nullptr) return;
+    if (op_ctx->pinned_state_owner == this &&
+        op_ctx->pinned_segment_state != nullptr) return;
     auto state = CapturePublishedState();          // one atomic load
     op_ctx->pinned_segment_state = state;          // shared_ptr<const void>
     op_ctx->pinned_state_owner = this;
 }
 ```
 
-Called at the top of `ChunkedSegmentSealedImpl::Search()` and `::Retrieve()` — i.e.
-**after** `LazyCheckSchema` (which may itself Reopen and republish; pinning before it
-would freeze the pre-upgrade schema the operation was just upgraded to see). Writers
-never pin. If a writer that shares an op_ctx with a subsequent read path ever publishes
-(`LazyCheckSchema` today), it must clear the pin (`pinned_segment_state.reset()`)
-so the read path re-pins the post-publish state; with eager pinning at Search/Retrieve
-entry this is automatic, and the clear is only a defensive invariant.
+The query visitor creates the per-segment `OpContext` and calls `PinOpSnapshot()`
+before deriving `active_count` or constructing the plan fragment. This is after schema
+preparation at the C API / segment entry and before any layout-derived expression
+state is created. Once the `QueryContext` exists, it is the exec/query layer's single
+source of the operation context: operators and expressions obtain
+`query_context->get_op_context()` and pass only the resulting `OpContext*` across the
+lower-level segcore accessor boundary.
+Offset-driven `RetrieveByOffsets` is a separate sealed-segment read operation and pins
+at its own entry.
+
+Ordinary Retrieve has two internal phases: plan execution computes offsets, then the
+caller performs output-size estimation and materializes target fields (including
+deferred ORDER BY fields). The visitor therefore copies its pin into `RetrieveResult`,
+and `SegmentInternalInterface::Retrieve()` reconstructs the fill `OpContext` from that
+exact pin. **Re-pinning between these phases is forbidden**: filter coordinates from
+snapshot A must never be applied to columns or schema from snapshot B.
+
+Writers never pin. If a writer that shares an op_ctx with a subsequent read path ever
+publishes, it must clear the pin (`pinned_segment_state.reset()`) before that later read
+selects its operation snapshot.
 
 Eager (not pin-on-first-capture) because it makes the snapshot's birthline auditable —
 "the operation sees the world as of Search() entry" — and avoids ordering surprises
@@ -131,12 +147,15 @@ Accessors that read published state but have no op_ctx today gain
 | Accessor | Used by |
 | --- | --- |
 | `num_chunk_data`, `num_chunk` | `SegmentExpr::InitSegmentExpr`, `CompareExpr` ctor |
-| `chunk_size` | every `ProcessDataChunks` batch loop |
+| `chunk_size`, `size_per_chunk` | every `ProcessDataChunks` batch loop and chunk-reader cursor |
 | `num_rows_until_chunk`, `get_chunk_by_offset` | scan offsets, `SegmentChunkReader::MoveCursor*` |
 | `GetSkipIndex` | `GetChunkSkipDecisions`, `PrefetchRawData` |
 | `HasFieldData`, `HasIndex`, `HasJsonIndex`, `IndexHasRawData`, `HasRawData` | exec-path selection |
 | `get_schema`, `is_nullable`, `is_field_exist`, `GetFieldDataType` | expression init |
 | `GetArrayOffsets`, `get_max_timestamp` | struct-array exprs, ts pruning |
+| `get_active_count`, `get_row_count` | query range and chunk-reader cursor bounds |
+| `get_field_avg_size`, `is_mmap_field` | Retrieve size guard and field-state probes |
+| `find_first_n`, `find_first_n_element` | bitmap-to-offset conversion and PK ordering |
 
 Call-site sweep: `SegmentExpr` (`Expr.h`), the four `PrefetchRawData` overrides,
 `SegmentChunkReader`, `CompareExpr`, and the query paths under `query/` that mix
@@ -161,14 +180,15 @@ that live inside `PublishedSegmentState`, because the preceding migrations
 deliberately moved them there: the schema itself (`PublishedSegmentState::schema`),
 columns (`runtime->fields`), scalar/vector/text/json/ngram indexes
 (158b1dc38a), readiness bitsets, PK index and offset maps (#51395), timestamps
-and their index, skip metrics (#51441), and the load info. Pinning the root
-pointer therefore freezes all of them as one version — there is no second
-carrier to add to OpContext.
+and their index, skip metrics (#51441), row count, mmap-field markers,
+variable-field average-size estimates, and the load info. Pinning the root pointer
+therefore freezes all of them as one version — there is no second carrier to add to
+OpContext.
 
 Deliberately outside the snapshot, and correctly so: `deleted_record_` (deletes
 are monotonic and timestamp-filtered; they must keep applying to in-flight
 reads), growing-segment mutable records (growing has no Reopen), and
-non-query-semantic bookkeeping (mmap field set, load progress).
+non-query-semantic load progress / statistics bookkeeping.
 
 ### Write-side proof
 
@@ -181,14 +201,13 @@ writes no segment member. The members that reads reach directly (bypassing
 
 | Member | Only write site | Touched by add/drop-field? |
 | --- | --- | --- |
-| `num_rows_` | set-once at load (ChunkedSegmentSealedImpl.cpp:2843, guarded by an equality assert that any reload matches); cleared only in `ClearData()` (full teardown, needs in-flight ops drained) | No — add/drop-field changes fields, not row count; the assert enforces reload equality |
 | `col_index_meta_` | ctor init-list only (:4501), zero reassignment | No — immutable |
 | `is_sorted_by_pk_` | ctor init-list only (:4502), zero reassignment | No — immutable |
 | `schema_` | no raw member; schema lives in `PublishedSegmentState` | In the snapshot |
 
 So pinning one pointer captures 100% of what a schema-change Reopen can alter;
-everything read outside the snapshot is written once and never touched by
-Reopen. These immutable members get an immutability comment (so a future edit
+everything query-semantic read outside the snapshot is written once and never touched
+by Reopen. These immutable members get an immutability comment (so a future edit
 that adds a Reopen write to them cannot silently break the pin) but need no
 migration.
 
@@ -230,6 +249,11 @@ snapshot-isolation intuition.
 3. **Unpinned compatibility**: null op_ctx keeps today's behavior (existing suites).
 4. **Owner guard**: an op_ctx pinned by segment X, passed to segment Y, must not
    return X's state.
+5. **#51594 raw-index transition**: pin while vector output routes to the raw
+   column, publish a state that advertises index raw data and removes the column,
+   then verify `bulk_subscript` still returns exact vectors from the pinned column.
+   The reverse raw-index to raw-column transition is covered by the same invariant:
+   `IndexHasRawData`, `get_vector`, and `get_raw_data` all resolve the same pin.
 
 ## Alternatives considered
 
@@ -249,7 +273,7 @@ snapshot-isolation intuition.
 
 1. milvus-common: add the two OpContext fields (independent, backward compatible).
 2. milvus: bump milvus-common; add `PinOpSnapshot` + op_ctx-aware `Capture*`; pin in
-   `Search`/`Retrieve`.
+   the per-segment query visitor and offset-driven Retrieve entry.
 3. milvus: mechanical op_ctx sweep through the accessor table above and the exec
    call sites; add the tests.
 
@@ -281,7 +305,9 @@ remains a product decision (does not gate correctness):
         calls `CapturePublishedState(op_ctx)`, and `FillTargetEntry`'s slow-path
         `local_ctx` copies the pin fields (`pinned_segment_state` +
         `pinned_state_owner`) so its `bulk_subscript` / `is_field_exist` reads
-        resolve the pin. The main `Retrieve` fill phase now pins too.
+        resolve the pin. The main `Retrieve` passes the visitor's original pin
+        through `RetrieveResult` into size estimation and materialization; it
+        never re-pins between filter and fill.
      b. `CompareExpr::CanUseBothDataFastPath` — `num_chunk_data` /
         `num_rows_until_chunk` now pass `op_ctx_`.
      c. `MatchExpr::Eval` — `get_schema(op_ctx_)`.
@@ -304,12 +330,20 @@ remains a product decision (does not gate correctness):
    reduce+export paths (`search_result_export_c.cpp`, `Reduce.cpp`) — their
    op_ctx is shared across segments so the owner guard rejects any pin, matching
    the "each operation pins independently" non-goal; `GetJsonFlatIndexNestedPath`
-   (pre-pin exec-path metadata probe, boolean decision only); PK-lookup /
-   delete / timestamp-mask accessors (`Contain`, `search_pks`, `find_first_n`,
-   `mask_with_timestamps`) that have no op_ctx param and are off the pinned
-   search/retrieve read path; and the four load-immutable member reads
-   (`num_rows_`, `col_index_meta_`, `is_sorted_by_pk_`, and load/publish/reopen
-   internals) which never pin by design.
+   (pre-pin exec-path metadata probe, boolean decision only); standalone PK-lookup /
+   delete accessors (`Contain` and delete ingestion) that are off the pinned
+   search/retrieve read path; and the load-immutable member reads
+   (`col_index_meta_`, `is_sorted_by_pk_`, and load/publish/reopen internals)
+   which never pin by design.
+
+3. **The useful sealed-state consolidation from #51531 is absorbed** — row count,
+   mmap-field markers, and variable-field average-size estimates now live in
+   `RuntimeResourceState` and follow the same clone/freeze/publish COW lifecycle as
+   columns and indexes. The duplicated live sealed-segment containers were removed.
+   Dropping raw field data clears its mmap marker but preserves its average-size
+   estimate while the schema still contains the field, because an index with raw data
+   may continue to serve Retrieve after raw-column reclamation. The estimate is erased
+   only when the field is actually removed from the schema.
 
 Regression test: `test_sealed.cpp` adds `SealedSegmentOpSnapshotPin.*` —
 `PinnedScanSurvivesMidScanFieldDrop` (load scalar F, pin, read F, `Reopen` to a
@@ -320,6 +354,10 @@ the fault-injection witness is `num_chunk_data(F, nullptr)==0` vs
 `PinIdentityAcrossConcurrentPublish` (every `Capture*` on one op_ctx returns the
 same snapshot pointer across a concurrent publish), and `OwnerGuardRejectsForeignPin`
 (segment X's pin, consulted by segment Y, returns Y's live state).
+`PinnedVectorRetrieveSurvivesRawIndexTransition` directly exercises #51594's
+no-raw-index to raw-index transition: the live state drops the vector column and
+advertises index raw data after the operation pins, while pinned `bulk_subscript`
+continues to return the exact vectors from its original column snapshot.
 
 milvus-common with the two OpContext fields is landed and `conanfile.py` is
 bumped to `milvus-common/1.0.0-6b16d93`. Note: the package bump also changed

--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -28,7 +28,7 @@ class MilvusConan(ConanFile):
         "prometheus-cpp/1.2.4#0918d66c13f97acb7809759f9de49b3f",
         "re2/20230301#f8efaf45f98d0193cd0b2ea08b6b4060",
         "folly/2026.04.20.00@milvus/dev#06852bea5b6449f0c4eb0df002b5779c",
-        "milvus-common/1.0.0-a3299ca@milvus/dev#eea0e22b8d5e36ff6f0a5ffbed14703e",
+        "milvus-common/1.0.0-6b16d93@milvus/dev#5cbcdcdd6fcc12c4660702f38e2f2751",
         "google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43",
         "opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720",
         "librdkafka/1.9.1#ec1a00d5414f618555799be9566adfb7",

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -383,6 +383,13 @@ struct RetrieveResult {
     // record the storage usage in retrieve
     StorageCost retrieve_storage_cost_;
 
+    // Carry the sealed segment's operation snapshot from the execution
+    // visitor into the later size-check / materialization phases.  The state
+    // is type-erased for the same reason as OpContext: common code must not
+    // depend on segcore's PublishedSegmentState type.
+    std::shared_ptr<const void> pinned_segment_state_;
+    const void* pinned_state_owner_{nullptr};
+
     // Element-level query support
     // When element_level_ is true:
     //   - result_offsets_ contains unique doc_ids (no duplicates)

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -348,6 +348,13 @@ struct SearchResult {
     // record the storage usage in search
     StorageCost search_storage_cost_;
 
+    // Carry the sealed segment's operation snapshot from query execution into
+    // the later reduce / output-fill phases.  SearchResult may outlive the
+    // QueryContext whose OpContext owns the original pin, so retain the
+    // type-erased state directly on the result.
+    std::shared_ptr<const void> pinned_segment_state_;
+    const void* pinned_state_owner_{nullptr};
+
     bool element_level_{false};
     std::vector<int32_t> element_indices_;
     std::optional<std::vector<std::shared_ptr<VectorIterator>>>

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -2672,7 +2672,7 @@ PhyBinaryArithOpEvalRangeExpr::PrefetchRawData() {
         std::conditional_t<std::is_integral_v<T> && !std::is_same_v<bool, T>,
                            int64_t,
                            T>;
-    auto& skip_index = segment_->GetSkipIndex();
+    auto& skip_index = segment_->GetSkipIndex(op_ctx_);
     auto value = GetValueWithCastNumber<H>(expr_->value_);
     auto right_value = GetValueWithCastNumber<H>(expr_->right_operand_);
 

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -1220,7 +1220,7 @@ PhyBinaryRangeFilterExpr::PrefetchRawData() {
                            U>;
     H lower_val = GetValueWithCastNumber<H>(expr_->lower_val_);
     H upper_val = GetValueWithCastNumber<H>(expr_->upper_val_);
-    auto& skip_index = segment_->GetSkipIndex();
+    auto& skip_index = segment_->GetSkipIndex(op_ctx_);
 
     std::vector<int64_t> chunks_may_hit;
     for (size_t i = 0; i < num_data_chunk_; ++i) {

--- a/internal/core/src/exec/expression/CallExpr.h
+++ b/internal/core/src/exec/expression/CallExpr.h
@@ -52,7 +52,7 @@ class PhyCallExpr : public Expr {
           active_count_(active_count),
           segment_(segment),
           batch_size_(batch_size) {
-        size_per_chunk_ = segment_->size_per_chunk();
+        size_per_chunk_ = segment_->size_per_chunk(op_ctx);
         num_chunk_ = upper_div(active_count_, size_per_chunk_);
         AssertInfo(
             batch_size_ > 0,

--- a/internal/core/src/exec/expression/ColumnExpr.cpp
+++ b/internal/core/src/exec/expression/ColumnExpr.cpp
@@ -110,9 +110,9 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                     return {offset / size_per_chunk, offset % size_per_chunk};
                 } else if (segment_chunk_reader_.segment_->is_chunked() &&
                            segment_chunk_reader_.segment_->num_chunk_data(
-                               expr_->GetColumn().field_id_) > 0) {
+                               expr_->GetColumn().field_id_, op_ctx_) > 0) {
                     return segment_chunk_reader_.segment_->get_chunk_by_offset(
-                        expr_->GetColumn().field_id_, offset);
+                        expr_->GetColumn().field_id_, offset, op_ctx_);
                 } else {
                     return {0, offset};
                 }

--- a/internal/core/src/exec/expression/ColumnExpr.h
+++ b/internal/core/src/exec/expression/ColumnExpr.h
@@ -55,18 +55,18 @@ class PhyColumnExpr : public Expr {
           segment_chunk_reader_(op_ctx, segment, active_count),
           batch_size_(batch_size),
           expr_(expr) {
-        auto& schema = segment->get_schema();
+        auto& schema = segment->get_schema(op_ctx_);
         auto& field_meta = schema[expr_->GetColumn().field_id_];
         pinned_index_ = PinIndex(op_ctx_, segment, field_meta);
         is_indexed_ = pinned_index_.size() > 0;
         use_index_data_ =
             is_indexed_ &&
-            segment->HasRawData(expr_->GetColumn().field_id_.get());
+            segment->HasRawData(expr_->GetColumn().field_id_.get(), op_ctx_);
         if (segment->is_chunked()) {
-            num_chunk_ =
-                use_index_data_
-                    ? pinned_index_.size()
-                    : segment->num_chunk_data(expr_->GetColumn().field_id_);
+            num_chunk_ = use_index_data_
+                             ? pinned_index_.size()
+                             : segment->num_chunk_data(
+                                   expr_->GetColumn().field_id_, op_ctx_);
         } else {
             num_chunk_ = use_index_data_
                              ? pinned_index_.size()
@@ -123,7 +123,9 @@ class PhyColumnExpr : public Expr {
                                        SegmentType::Sealed
                     ? current_chunk_pos_
                     : segment_chunk_reader_.segment_->num_rows_until_chunk(
-                          expr_->GetColumn().field_id_, current_chunk_id_) +
+                          expr_->GetColumn().field_id_,
+                          current_chunk_id_,
+                          op_ctx_) +
                           current_chunk_pos_;
             return current_rows;
         } else {

--- a/internal/core/src/exec/expression/CompareExpr.cpp
+++ b/internal/core/src/exec/expression/CompareExpr.cpp
@@ -58,16 +58,16 @@ PhyCompareFilterExpr::CanUseBothDataFastPath() {
         return true;
     }
 
-    auto left_chunks = segment->num_chunk_data(left_field_);
-    auto right_chunks = segment->num_chunk_data(right_field_);
+    auto left_chunks = segment->num_chunk_data(left_field_, op_ctx_);
+    auto right_chunks = segment->num_chunk_data(right_field_, op_ctx_);
     if (left_chunks <= 0 || right_chunks <= 0 || left_chunks != right_chunks) {
         can_use_both_data_sequential_fast_path_ = false;
         return false;
     }
 
     for (int64_t i = 0; i <= left_chunks; ++i) {
-        if (segment->num_rows_until_chunk(left_field_, i) !=
-            segment->num_rows_until_chunk(right_field_, i)) {
+        if (segment->num_rows_until_chunk(left_field_, i, op_ctx_) !=
+            segment->num_rows_until_chunk(right_field_, i, op_ctx_)) {
             can_use_both_data_sequential_fast_path_ = false;
             return false;
         }
@@ -104,10 +104,10 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
 
         auto left_raw_data_chunk_count =
             segment_chunk_reader_.segment_->num_chunk_data(
-                expr_->left_field_id_);
+                expr_->left_field_id_, op_ctx_);
         auto right_raw_data_chunk_count =
             segment_chunk_reader_.segment_->num_chunk_data(
-                expr_->right_field_id_);
+                expr_->right_field_id_, op_ctx_);
 
         int64_t processed_rows = 0;
         const auto size_per_chunk = segment_chunk_reader_.SizePerChunk();
@@ -122,7 +122,7 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
                 } else if (segment_chunk_reader_.segment_->is_chunked() &&
                            raw_data_chunk_count > 0) {
                     return segment_chunk_reader_.segment_->get_chunk_by_offset(
-                        field, offset);
+                        field, offset, op_ctx_);
                 } else {
                     return {0, offset};
                 }

--- a/internal/core/src/exec/expression/CompareExpr.h
+++ b/internal/core/src/exec/expression/CompareExpr.h
@@ -158,7 +158,10 @@ class PhyCompareFilterExpr : public Expr {
           segment_chunk_reader_(op_ctx, segment, active_count),
           batch_size_(batch_size),
           expr_(expr) {
-        auto& schema = segment->get_schema();
+        // op_ctx_ carries the operation's pinned snapshot (installed at
+        // ExecPlanNodeVisitor entry). Forward it to every published-state read
+        // so this expression's cached chunk counts match the scan's snapshot.
+        auto& schema = segment->get_schema(op_ctx_);
         auto& left_field_meta = schema[left_field_];
         auto& right_field_meta = schema[right_field_];
         pinned_index_left_ = PinIndex(op_ctx_, segment, left_field_meta);
@@ -166,22 +169,23 @@ class PhyCompareFilterExpr : public Expr {
         is_left_indexed_ = pinned_index_left_.size() > 0;
         is_right_indexed_ = pinned_index_right_.size() > 0;
         left_use_index_data_ =
-            is_left_indexed_ && segment->HasRawData(left_field_.get());
+            is_left_indexed_ && segment->HasRawData(left_field_.get(), op_ctx_);
         right_use_index_data_ =
-            is_right_indexed_ && segment->HasRawData(right_field_.get());
+            is_right_indexed_ &&
+            segment->HasRawData(right_field_.get(), op_ctx_);
         if (segment->is_chunked()) {
             left_num_chunk_ =
                 left_use_index_data_ ? pinned_index_left_.size()
                 : segment->type() == SegmentType::Growing
                     ? upper_div(segment_chunk_reader_.active_count_,
                                 segment_chunk_reader_.SizePerChunk())
-                    : segment->num_chunk_data(left_field_);
+                    : segment->num_chunk_data(left_field_, op_ctx_);
             right_num_chunk_ =
                 right_use_index_data_ ? pinned_index_right_.size()
                 : segment->type() == SegmentType::Growing
                     ? upper_div(segment_chunk_reader_.active_count_,
                                 segment_chunk_reader_.SizePerChunk())
-                    : segment->num_chunk_data(right_field_);
+                    : segment->num_chunk_data(right_field_, op_ctx_);
             num_chunk_ = left_num_chunk_;
         } else {
             num_chunk_ = left_use_index_data_
@@ -283,7 +287,7 @@ class PhyCompareFilterExpr : public Expr {
                 left_use_index_data_
                     ? left_current_chunk_pos_
                     : segment_chunk_reader_.segment_->num_rows_until_chunk(
-                          left_field_, left_current_chunk_id_) +
+                          left_field_, left_current_chunk_id_, op_ctx_) +
                           left_current_chunk_pos_;
             return current_rows;
         } else {
@@ -532,9 +536,9 @@ class PhyCompareFilterExpr : public Expr {
                                      data_pos)
                         : segment_chunk_reader_.SizePerChunk() - data_pos;
             } else {
-                size =
-                    segment_chunk_reader_.segment_->chunk_size(left_field_, i) -
-                    data_pos;
+                size = segment_chunk_reader_.segment_->chunk_size(
+                           left_field_, i, op_ctx_) -
+                       data_pos;
             }
 
             if (processed_size + size >= batch_size_) {

--- a/internal/core/src/exec/expression/CompareExpr.h
+++ b/internal/core/src/exec/expression/CompareExpr.h
@@ -351,7 +351,7 @@ class PhyCompareFilterExpr : public Expr {
                                 offset % size_per_chunk};
                     } else {
                         return segment_chunk_reader_.segment_
-                            ->get_chunk_by_offset(field, offset);
+                            ->get_chunk_by_offset(field, offset, op_ctx_);
                     }
                 };
 

--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -99,7 +99,9 @@ ExprSet::Eval(int32_t begin,
 expr::TypedExprPtr
 CreateTTLFieldFilterExpression(QueryContext* query_context) {
     auto segment = query_context->get_segment();
-    auto& schema = segment->get_schema();
+    // Resolve the TTL-field schema against the operation's pinned snapshot so
+    // it matches the snapshot the rest of the query uses.
+    auto& schema = segment->get_schema(query_context->get_op_context());
     if (!schema.get_ttl_field_id().has_value()) {
         return nullptr;
     }
@@ -489,11 +491,16 @@ inline void
 ReorderConjunctExpr(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
                     ExecContext* context,
                     bool& has_heavy_operation) {
-    auto* segment = context->get_query_context()->get_segment();
+    auto* query_context = context->get_query_context();
+    auto* segment = query_context->get_segment();
     if (!segment || !expr) {
         return;
     }
-    auto schema = segment->get_schema();
+    // Route through the operation's pinned snapshot so schema/index probing
+    // used to reorder the conjunction agrees with the snapshot the expression
+    // evaluation itself uses.
+    auto* op_ctx = query_context->get_op_context();
+    auto schema = segment->get_schema(op_ctx);
     auto namespace_field_id = schema.get_namespace_field_id();
     std::vector<size_t> reorder;
     std::vector<size_t> numeric_expr;
@@ -535,7 +542,8 @@ ReorderConjunctExpr(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
                 numeric_expr.push_back(i);
                 continue;
             }
-            if (segment->HasIndex(column.field_id_) && !IsLikeExpr(input)) {
+            if (segment->HasIndex(column.field_id_, op_ctx) &&
+                !IsLikeExpr(input)) {
                 indexed_expr.push_back(i);
                 continue;
             }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -273,7 +273,7 @@ class SegmentExpr : public Expr {
           consistency_level_(consistency_level),
           is_json_contains_(is_json_contains),
           plan_options_(plan_options) {
-        size_per_chunk_ = segment_->size_per_chunk();
+        size_per_chunk_ = segment_->size_per_chunk(op_ctx_);
         AssertInfo(
             batch_size_ > 0,
             fmt::format("expr batch size should greater than zero, but now: {}",
@@ -1788,9 +1788,10 @@ class SegmentExpr : public Expr {
         for (int64_t chunk_id = 0;
              chunk_id < num_data_chunk_ && processed_size < row_count;
              ++chunk_id) {
-            auto chunk_size = segment_->is_chunked()
-                                  ? segment_->chunk_size(field_id_, chunk_id)
-                                  : size_per_chunk_;
+            auto chunk_size =
+                segment_->is_chunked()
+                    ? segment_->chunk_size(field_id_, chunk_id, op_ctx_)
+                    : size_per_chunk_;
             auto size = std::min(chunk_size, row_count - processed_size);
             if (size == 0) {
                 continue;
@@ -2284,8 +2285,8 @@ class SegmentExpr : public Expr {
         }
 
         auto query_path = milvus::Json::pointer(nested_path_);
-        auto index_path =
-            segment_->GetJsonFlatIndexNestedPath(field_id_, query_path);
+        auto index_path = segment_->GetJsonFlatIndexNestedPath(
+            field_id_, query_path, op_ctx_);
         if (index_path.empty()) {
             // No JsonFlatIndex covers this path; nothing JSON-specific to
             // reject here. The caller will decide between ScalarIndex and

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -285,7 +285,7 @@ class SegmentExpr : public Expr {
 
     void
     InitSegmentExpr() {
-        auto& schema = segment_->get_schema();
+        auto& schema = segment_->get_schema(op_ctx_);
         auto& field_meta = schema[field_id_];
         field_type_ = field_meta.get_data_type();
 
@@ -308,9 +308,9 @@ class SegmentExpr : public Expr {
         // PinCells() cold fetch under tiered storage.
 
         // if index not include raw data, also need load data
-        if (segment_->HasFieldData(field_id_)) {
+        if (segment_->HasFieldData(field_id_, op_ctx_)) {
             if (segment_->is_chunked()) {
-                num_data_chunk_ = segment_->num_chunk_data(field_id_);
+                num_data_chunk_ = segment_->num_chunk_data(field_id_, op_ctx_);
             } else {
                 num_data_chunk_ = upper_div(active_count_, size_per_chunk_);
             }
@@ -328,7 +328,7 @@ class SegmentExpr : public Expr {
             return;
         }
         pinned_index_initialized_ = true;
-        auto& schema = segment_->get_schema();
+        auto& schema = segment_->get_schema(op_ctx_);
         auto& field_meta = schema[field_id_];
         pinned_index_ = PinIndex(op_ctx_,
                                  segment_,
@@ -352,7 +352,8 @@ class SegmentExpr : public Expr {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
             // if segment is chunked, type won't be growing
-            int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
+            int64_t size =
+                segment_->chunk_size(field_id_, i, op_ctx_) - data_pos;
 
             size = std::min(size, batch_size_ - processed_size);
 
@@ -420,7 +421,7 @@ class SegmentExpr : public Expr {
             }
             if (UseIndexCursor()) {
                 MoveCursorForIndex();
-                if (segment_->HasFieldData(field_id_)) {
+                if (segment_->HasFieldData(field_id_, op_ctx_)) {
                     MoveCursorForData();
                 }
             } else {
@@ -522,7 +523,8 @@ class SegmentExpr : public Expr {
             current_rows =
                 UseIndexCursor() && segment_->type() == SegmentType::Sealed
                     ? current_chunk_pos
-                    : segment_->num_rows_until_chunk(field_id_, current_chunk) +
+                    : segment_->num_rows_until_chunk(
+                          field_id_, current_chunk, op_ctx_) +
                           current_chunk_pos;
         } else {
             current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
@@ -548,7 +550,7 @@ class SegmentExpr : public Expr {
     // and elem_count is the total number of elements in those rows
     std::pair<int64_t, int64_t>
     GetNextBatchSizeForElementLevel() {
-        auto array_offsets = segment_->GetArrayOffsets(field_id_);
+        auto array_offsets = segment_->GetArrayOffsets(field_id_, op_ctx_);
         AssertInfo(array_offsets != nullptr,
                    "ArrayOffsets not found for field {}",
                    field_id_.get());
@@ -564,9 +566,9 @@ class SegmentExpr : public Expr {
             // For sealed segment with index, position is already global
             current_rows = current_chunk_pos;
         } else if (segment_->is_chunked()) {
-            current_rows =
-                segment_->num_rows_until_chunk(field_id_, current_chunk) +
-                current_chunk_pos;
+            current_rows = segment_->num_rows_until_chunk(
+                               field_id_, current_chunk, op_ctx_) +
+                           current_chunk_pos;
         } else {
             current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
         }
@@ -607,7 +609,7 @@ class SegmentExpr : public Expr {
         if (need_size == 0)
             return 0;  //do not go empty-loop at the bound of the chunk
 
-        auto& skip_index = segment_->GetSkipIndex();
+        auto& skip_index = segment_->GetSkipIndex(op_ctx_);
         auto pw = segment_->get_batch_views<T>(
             op_ctx_, field_id_, 0, current_data_chunk_pos_, need_size);
         auto views_info = pw.get();
@@ -662,7 +664,7 @@ class SegmentExpr : public Expr {
         // For non_chunked sealed segment, only single chunk
         Assert(num_data_chunk_ == 1);
 
-        auto& skip_index = segment_->GetSkipIndex();
+        auto& skip_index = segment_->GetSkipIndex(op_ctx_);
         auto pw =
             segment_->get_views_by_offsets<T>(op_ctx_, field_id_, 0, *input);
         auto [data_vec, valid_data] = pw.get();
@@ -719,7 +721,7 @@ class SegmentExpr : public Expr {
         TargetBitmapView valid_res,
         const ValTypes&... values) {
         AssertInfo(num_index_chunk_ == 1, "scalar index chunk num must be 1");
-        auto& skip_index = segment_->GetSkipIndex();
+        auto& skip_index = segment_->GetSkipIndex(op_ctx_);
 
         using IndexInnerType = std::
             conditional_t<std::is_same_v<T, std::string_view>, std::string, T>;
@@ -786,13 +788,13 @@ class SegmentExpr : public Expr {
             }
         }
 
-        auto& skip_index = segment_->GetSkipIndex();
+        auto& skip_index = segment_->GetSkipIndex(op_ctx_);
 
         if constexpr (std::is_same_v<T, VectorArrayView>) {
             for (size_t i = 0; i < input->size(); ++i) {
                 int64_t offset = (*input)[i];
                 auto [chunk_id, chunk_offset] =
-                    segment_->get_chunk_by_offset(field_id_, offset);
+                    segment_->get_chunk_by_offset(field_id_, offset, op_ctx_);
                 // chunk_data<VectorArrayView> would read the wrong layout:
                 // storage holds VectorArray, and nullable rows may be compacted.
                 // Use chunk_view to build logical VectorArrayView rows.
@@ -830,7 +832,8 @@ class SegmentExpr : public Expr {
                     for (size_t i = 0; i < input->size(); ++i) {
                         int64_t offset = (*input)[i];
                         auto [chunk_id, chunk_offset] =
-                            segment_->get_chunk_by_offset(field_id_, offset);
+                            segment_->get_chunk_by_offset(
+                                field_id_, offset, op_ctx_);
                         auto pw = segment_->get_views_by_offsets<T>(
                             op_ctx_,
                             field_id_,
@@ -860,7 +863,8 @@ class SegmentExpr : public Expr {
                 for (size_t i = 0; i < input->size(); ++i) {
                     int64_t offset = (*input)[i];
                     auto [chunk_id, chunk_offset] =
-                        segment_->get_chunk_by_offset(field_id_, offset);
+                        segment_->get_chunk_by_offset(
+                            field_id_, offset, op_ctx_);
                     auto pw =
                         segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id);
                     auto chunk = pw.get();
@@ -958,13 +962,13 @@ class SegmentExpr : public Expr {
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
-        auto& skip_index = segment_->GetSkipIndex();
+        auto& skip_index = segment_->GetSkipIndex(op_ctx_);
         if (segment_->type() == SegmentType::Sealed) {
             AssertInfo(
                 segment_->is_chunked(),
                 "Element-level filtering requires chunked segment for sealed");
 
-            auto array_offsets = segment_->GetArrayOffsets(field_id_);
+            auto array_offsets = segment_->GetArrayOffsets(field_id_, op_ctx_);
             if (!array_offsets) {
                 ThrowInfo(ErrorCode::UnexpectedError,
                           "IArrayOffsets not found for field {}",
@@ -985,7 +989,7 @@ class SegmentExpr : public Expr {
                 auto [doc_id, elem_idx] =
                     array_offsets->ElementIDToRowID(element_id);
                 auto [chunk_id, chunk_offset] =
-                    segment_->get_chunk_by_offset(field_id_, doc_id);
+                    segment_->get_chunk_by_offset(field_id_, doc_id, op_ctx_);
 
                 // Collect consecutive elements belonging to the same chunk
                 offsets.clear();
@@ -1002,7 +1006,8 @@ class SegmentExpr : public Expr {
                     auto [next_doc_id, next_elem_idx] =
                         array_offsets->ElementIDToRowID(next_element_id);
                     auto [next_chunk_id, next_chunk_offset] =
-                        segment_->get_chunk_by_offset(field_id_, next_doc_id);
+                        segment_->get_chunk_by_offset(
+                            field_id_, next_doc_id, op_ctx_);
 
                     if (next_chunk_id != chunk_id) {
                         break;  // Different chunk, process current batch
@@ -1051,14 +1056,14 @@ class SegmentExpr : public Expr {
             }
             return processed_size;
         } else {
-            auto array_offsets = segment_->GetArrayOffsets(field_id_);
+            auto array_offsets = segment_->GetArrayOffsets(field_id_, op_ctx_);
             if (!array_offsets) {
                 ThrowInfo(ErrorCode::UnexpectedError,
                           "IArrayOffsets not found for field {}",
                           field_id_.get());
             }
 
-            auto& skip_index = segment_->GetSkipIndex();
+            auto& skip_index = segment_->GetSkipIndex(op_ctx_);
             size_t processed_size = 0;
 
             for (size_t i = 0; i < element_ids->size(); i++) {
@@ -1143,7 +1148,7 @@ class SegmentExpr : public Expr {
                 i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
             int64_t size;
             if (segment_->is_chunked()) {
-                size = segment_->chunk_size(field_id_, i) - data_pos;
+                size = segment_->chunk_size(field_id_, i, op_ctx_) - data_pos;
             } else {
                 size = (i == num_data_chunk_ - 1)
                            ? (active_count_ % size_per_chunk_ == 0
@@ -1156,7 +1161,7 @@ class SegmentExpr : public Expr {
                 continue;
             }
 
-            auto& skip_index = segment_->GetSkipIndex();
+            auto& skip_index = segment_->GetSkipIndex(op_ctx_);
             if ((!skip_func || !skip_func(skip_index, field_id_, i))) {
                 if (segment_->type() == SegmentType::Sealed) {
                     auto pw = segment_->get_batch_views<ArrayView>(
@@ -1401,7 +1406,7 @@ class SegmentExpr : public Expr {
             if (size == 0)
                 continue;  //do not go empty-loop at the bound of the chunk
 
-            auto& skip_index = segment_->GetSkipIndex();
+            auto& skip_index = segment_->GetSkipIndex(op_ctx_);
             auto process_chunk = [&](const T* data, const bool* valid_data) {
                 auto skipped = skip_func && skip_func(skip_index, field_id_, i);
                 if (!skipped) {
@@ -1524,19 +1529,21 @@ class SegmentExpr : public Expr {
                 i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
 
             // if segment is chunked, type won't be growing
-            int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
+            int64_t size =
+                segment_->chunk_size(field_id_, i, op_ctx_) - data_pos;
             size = std::min(size, batch_size_ - processed_size);
 
             if (size == 0)
                 continue;  //do not go empty-loop at the bound of the chunk
             std::vector<int32_t> segment_offsets_array(size);
             auto start_offset =
-                segment_->num_rows_until_chunk(field_id_, i) + data_pos;
+                segment_->num_rows_until_chunk(field_id_, i, op_ctx_) +
+                data_pos;
             for (int64_t j = 0; j < size; ++j) {
                 int64_t offset = start_offset + j;
                 segment_offsets_array[j] = static_cast<int32_t>(offset);
             }
-            auto& skip_index = segment_->GetSkipIndex();
+            auto& skip_index = segment_->GetSkipIndex(op_ctx_);
             if (!skip_func || !skip_func(skip_index, field_id_, i)) {
                 bool is_seal = false;
                 if constexpr (std::is_same_v<T, std::string_view> ||
@@ -1717,12 +1724,13 @@ class SegmentExpr : public Expr {
 
         // Find starting chunk and offset
         auto [start_chunk_id, start_chunk_offset] =
-            segment_->get_chunk_by_offset(field_id_, segment_offset);
+            segment_->get_chunk_by_offset(field_id_, segment_offset, op_ctx_);
 
         for (size_t chunk_id = start_chunk_id;
              chunk_id < num_data_chunk_ && remaining > 0;
              chunk_id++) {
-            int64_t chunk_size = segment_->chunk_size(field_id_, chunk_id);
+            int64_t chunk_size =
+                segment_->chunk_size(field_id_, chunk_id, op_ctx_);
             int64_t chunk_offset =
                 (chunk_id == start_chunk_id) ? start_chunk_offset : 0;
 
@@ -1927,7 +1935,7 @@ class SegmentExpr : public Expr {
 
         if (need_element_slicing) {
             // Nested index with element-level result: batch by rows, slice elements
-            auto array_offsets = segment_->GetArrayOffsets(field_id_);
+            auto array_offsets = segment_->GetArrayOffsets(field_id_, op_ctx_);
 
             auto data_pos = current_index_chunk_pos_;
             auto batch_rows = std::min(batch_size_, active_count_ - data_pos);
@@ -1976,8 +1984,8 @@ class SegmentExpr : public Expr {
                 // when T is ArrayView, the ScalarIndex<T> shall be ScalarIndex<ElementType>
                 // NOT ScalarIndex<ArrayView>
                 if (std::is_same_v<T, ArrayView>) {
-                    auto element_type =
-                        segment_->get_schema()[field_id_].get_element_type();
+                    auto element_type = segment_->get_schema(op_ctx_)[field_id_]
+                                            .get_element_type();
                     switch (element_type) {
                         case DataType::BOOL: {
                             return ProcessIndexChunksForValid<bool>();
@@ -2050,8 +2058,8 @@ class SegmentExpr : public Expr {
                 // when T is ArrayView, the ScalarIndex<T> shall be ScalarIndex<ElementType>
                 // NOT ScalarIndex<ArrayView>
                 if (std::is_same_v<T, ArrayView>) {
-                    auto element_type =
-                        segment_->get_schema()[field_id_].get_element_type();
+                    auto element_type = segment_->get_schema(op_ctx_)[field_id_]
+                                            .get_element_type();
                     switch (element_type) {
                         case DataType::BOOL: {
                             return ProcessChunksForValidByOffsets<bool>(
@@ -2119,7 +2127,7 @@ class SegmentExpr : public Expr {
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
             int64_t size = 0;
             if (segment_->is_chunked()) {
-                size = segment_->chunk_size(field_id_, i) - data_pos;
+                size = segment_->chunk_size(field_id_, i, op_ctx_) - data_pos;
             } else {
                 size = (i == (num_data_chunk_ - 1))
                            ? (segment_->type() == SegmentType::Growing
@@ -2251,8 +2259,8 @@ class SegmentExpr : public Expr {
         // field type to avoid widening HasIndex() semantics -- which
         // ReorderConjunctExpr and other callers rely on remaining narrow.
         bool has = (field_type_ == DataType::JSON)
-                       ? segment_->HasJsonIndex(field_id_)
-                       : segment_->HasIndex(field_id_);
+                       ? segment_->HasJsonIndex(field_id_, op_ctx_)
+                       : segment_->HasIndex(field_id_, op_ctx_);
         return has && !CanUseNgramIndex();
     }
 

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -550,9 +550,13 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                     }
                 }
             } else {
-                milvus::OpContext op_ctx;
+                // Route bulk_subscript through the operation's pinned op_ctx
+                // (op_ctx_) so the sealed geometry column is read from the same
+                // published-state snapshot as the rest of this evaluation,
+                // instead of a fresh unpinned context that would re-capture
+                // live state.
                 auto data_array = segment_->bulk_subscript(
-                    &op_ctx, field_id_, hit_offsets.data(), hit_offsets.size());
+                    op_ctx_, field_id_, hit_offsets.data(), hit_offsets.size());
 
                 auto geometry_array =
                     static_cast<const milvus::proto::schema::GeometryArray*>(
@@ -602,7 +606,8 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
+            int64_t size =
+                segment_->chunk_size(field_id_, i, op_ctx_) - data_pos;
             size = std::min(size, real_batch_size - processed_rows);
 
             if (size > 0) {

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -2394,7 +2394,8 @@ PhyJsonContainsFilterExpr::ExecArrayContainsForIndexSegmentImpl() {
     boost::container::vector<GetType> elems(elements.begin(), elements.end());
 
     // Get array offsets for nested index (needed for element-to-row conversion)
-    auto array_offsets = segment_->GetArrayOffsets(expr_->column_.field_id_);
+    auto array_offsets =
+        segment_->GetArrayOffsets(expr_->column_.field_id_, op_ctx_);
 
     auto execute_sub_batch =
         [this, &array_offsets](

--- a/internal/core/src/exec/expression/MatchExpr.cpp
+++ b/internal/core/src/exec/expression/MatchExpr.cpp
@@ -228,11 +228,12 @@ PhyMatchFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     auto input = context.get_offset_input();
     SetHasOffsetInput(input != nullptr);
 
-    auto schema = segment_->get_schema();
+    auto schema = segment_->get_schema(op_ctx_);
     auto field_meta =
         schema.GetFirstArrayFieldInStruct(expr_->get_struct_name());
 
-    auto array_offsets = segment_->GetArrayOffsets(field_meta.get_id());
+    auto array_offsets =
+        segment_->GetArrayOffsets(field_meta.get_id(), op_ctx_);
     AssertInfo(array_offsets != nullptr, "Array offsets not available");
 
     int64_t batch_rows;

--- a/internal/core/src/exec/expression/MatchExpr.cpp
+++ b/internal/core/src/exec/expression/MatchExpr.cpp
@@ -419,10 +419,11 @@ PhyMatchFilterExpr::ApplyStructRowValidity(ColumnVector* col_vec,
         int64_t row_offset = current_pos_;
         while (processed < batch_rows) {
             auto [chunk_id, offset_in_chunk] =
-                segment_->get_chunk_by_offset(field_id, row_offset);
-            auto count = std::min(
-                batch_rows - processed,
-                segment_->chunk_size(field_id, chunk_id) - offset_in_chunk);
+                segment_->get_chunk_by_offset(field_id, row_offset, op_ctx_);
+            auto count =
+                std::min(batch_rows - processed,
+                         segment_->chunk_size(field_id, chunk_id, op_ctx_) -
+                             offset_in_chunk);
             AssertInfo(count > 0,
                        "invalid field validity range at row offset {} for "
                        "field {}",

--- a/internal/core/src/exec/expression/MatchExpr.h
+++ b/internal/core/src/exec/expression/MatchExpr.h
@@ -43,7 +43,7 @@ class PhyMatchFilterExpr : public Expr {
           segment_(segment),
           active_count_(active_count),
           batch_size_(batch_size) {
-        size_per_chunk_ = segment_->size_per_chunk();
+        size_per_chunk_ = segment_->size_per_chunk(op_ctx);
     }
 
     void

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -175,7 +175,7 @@ PhyTermFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
 template <typename T>
 bool
 PhyTermFilterExpr::CanSkipSegment() {
-    const auto& skip_index = segment_->GetSkipIndex();
+    const auto& skip_index = segment_->GetSkipIndex(op_ctx_);
     T min, max;
     for (auto i = 0; i < expr_->vals_.size(); i++) {
         auto val = GetValueFromProto<T>(expr_->vals_[i]);
@@ -1308,7 +1308,7 @@ PhyTermFilterExpr::PrefetchRawData() {
 template <typename T>
 void
 PhyTermFilterExpr::PrefetchRawData() {
-    auto& skip_index = segment_->GetSkipIndex();
+    auto& skip_index = segment_->GetSkipIndex(op_ctx_);
 
     std::vector<T> elements;
     elements.reserve(expr_->vals_.size());

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -234,7 +234,7 @@ PhyTermFilterExpr::InitPkCacheOffset() {
     }
 
     cached_bits_.resize(active_count_, false);
-    segment_->search_ids(cached_bits_, *id_array);
+    segment_->search_ids(cached_bits_, *id_array, op_ctx_);
     cached_bits_inited_ = true;
 }
 

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -738,7 +738,7 @@ PhyUnaryRangeFilterExpr::ExecArrayEqualForIndex(EvalCtx& context,
                 return chunk.first[chunk_offset].is_same_array(val) ^ reverse;
             };
         } else {
-            auto size_per_chunk = segment_->size_per_chunk();
+            auto size_per_chunk = segment_->size_per_chunk(op_ctx_);
             is_same = [this, size_per_chunk, reverse](
                           milvus::proto::plan::Array& val,
                           int64_t offset) -> bool {

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -731,7 +731,7 @@ PhyUnaryRangeFilterExpr::ExecArrayEqualForIndex(EvalCtx& context,
             is_same = [this, reverse](milvus::proto::plan::Array& val,
                                       int64_t offset) -> bool {
                 auto [chunk_idx, chunk_offset] =
-                    segment_->get_chunk_by_offset(field_id_, offset);
+                    segment_->get_chunk_by_offset(field_id_, offset, op_ctx_);
                 auto pw = segment_->template chunk_view<milvus::ArrayView>(
                     op_ctx_, field_id_, chunk_idx);
                 auto chunk = pw.get();
@@ -1194,7 +1194,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
              i < num_data_chunk_ && valid_processed_size < active_count_;
              ++i) {
             int64_t size = segment_->is_chunked()
-                               ? segment_->chunk_size(field_id_, i)
+                               ? segment_->chunk_size(field_id_, i, op_ctx_)
                                : (i == num_data_chunk_ - 1
                                       ? active_count_ - valid_processed_size
                                       : size_per_chunk_);
@@ -2359,7 +2359,7 @@ PhyUnaryRangeFilterExpr::PrefetchRawData() {
     using U =
         std::conditional_t<std::is_same_v<T, std::string_view>, std::string, T>;
     auto op_type = expr_->op_type_;
-    auto& skip_index = segment_->GetSkipIndex();
+    auto& skip_index = segment_->GetSkipIndex(op_ctx_);
     U val = GetValueFromProto<U>(expr_->val_);
 
     std::vector<int64_t> chunks_may_hit;

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -1008,7 +1008,7 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
              expr_->op_type_ == proto::plan::OpType::RegexMatch)) {
             // try to pin ngram index for json
             auto field_id = expr_->column_.field_id_;
-            auto schema = segment->get_schema();
+            auto schema = segment->get_schema(op_ctx_);
             auto field_meta = schema[field_id];
 
             if (field_meta.is_json()) {

--- a/internal/core/src/exec/operator/ElementFilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/ElementFilterBitsNode.cpp
@@ -90,10 +90,11 @@ PhyElementFilterBitsNode::GetOutput() {
 
     // Step 1: Get array offsets
     auto segment = query_context_->get_segment();
+    auto* op_ctx = query_context_->get_op_context();
     auto& field_meta =
-        segment->get_schema().GetFirstArrayFieldInStruct(struct_name_);
+        segment->get_schema(op_ctx).GetFirstArrayFieldInStruct(struct_name_);
     auto field_id = field_meta.get_id();
-    auto array_offsets = segment->GetArrayOffsets(field_id);
+    auto array_offsets = segment->GetArrayOffsets(field_id, op_ctx);
     if (array_offsets == nullptr) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   "IArrayOffsets not found for field {}",

--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -46,7 +46,9 @@ BuildExprCacheKey(const plan::FilterBitsNode& filter,
     auto* segment =
         query_context != nullptr ? query_context->get_segment() : nullptr;
     if (segment != nullptr &&
-        segment->get_schema().get_ttl_field_id().has_value()) {
+        segment->get_schema(query_context->get_op_context())
+            .get_ttl_field_id()
+            .has_value()) {
         key += fmt::format("|entity_ttl_physical_time_us:{}",
                            query_context->get_entity_ttl_physical_time_us());
     }

--- a/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
@@ -102,10 +102,11 @@ PhyIterativeElementFilterNode::GetOutput() {
     }
 
     auto segment = query_context_->get_segment();
+    auto* op_ctx = query_context_->get_op_context();
     auto& field_meta =
-        segment->get_schema().GetFirstArrayFieldInStruct(struct_name_);
+        segment->get_schema(op_ctx).GetFirstArrayFieldInStruct(struct_name_);
     auto field_id = field_meta.get_id();
-    auto array_offsets = segment->GetArrayOffsets(field_id);
+    auto array_offsets = segment->GetArrayOffsets(field_id, op_ctx);
     if (array_offsets == nullptr) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   "IArrayOffsets not found for field {}",

--- a/internal/core/src/exec/operator/MvccNode.cpp
+++ b/internal/core/src/exec/operator/MvccNode.cpp
@@ -98,7 +98,8 @@ PhyMvccNode::GetOutput() {
     // get_deleted_count() check.
     if (is_source_node_ && segment_->type() == SegmentType::Sealed &&
         collection_ttl_timestamp_ == 0 &&
-        query_timestamp_ >= segment_->get_max_timestamp()) {
+        query_timestamp_ >=
+            segment_->get_max_timestamp(query_context->get_op_context())) {
         auto col_input = std::make_shared<ColumnVector>(
             TargetBitmap(active_count_), TargetBitmap(active_count_));
         TargetBitmapView data(col_input->GetRawData(), col_input->size());
@@ -121,8 +122,10 @@ PhyMvccNode::GetOutput() {
                                      : GetColumnVector(input_);
 
     TargetBitmapView data(col_input->GetRawData(), col_input->size());
-    segment_->mask_with_timestamps(
-        data, query_timestamp_, collection_ttl_timestamp_);
+    segment_->mask_with_timestamps(data,
+                                   query_timestamp_,
+                                   collection_ttl_timestamp_,
+                                   query_context->get_op_context());
     segment_->mask_with_delete(data, active_count_, query_timestamp_);
     is_finished_ = true;
 

--- a/internal/core/src/exec/operator/ProjectNode.cpp
+++ b/internal/core/src/exec/operator/ProjectNode.cpp
@@ -119,13 +119,12 @@ PhyProjectNode::PhyProjectNode(
                projectNode->id(),
                "Project"),
       fields_to_project_(projectNode->FieldsToProject()),
-      query_context_(nullptr),
-      op_context_(nullptr) {
+      query_context_(nullptr) {
     auto exec_context = operator_context_->get_exec_context();
     query_context_ = exec_context->get_query_context();
     segment_ = query_context_->get_segment();
-    op_context_ = query_context_->get_op_context();
-    AssertInfo(op_context_, "op_context_ cannot be nullptr for ProjectNode");
+    AssertInfo(query_context_->get_op_context(),
+               "QueryContext has no OpContext for ProjectNode");
     AssertInfo(segment_, "segment_ cannot be nullptr for ProjectNode");
 }
 
@@ -171,6 +170,8 @@ PhyProjectNode::GetOutput() {
         return nullptr;
     }
     auto row_type = OutputType();
+    auto* op_context = query_context_->get_op_context();
+    AssertInfo(op_context, "QueryContext has no OpContext for ProjectNode");
     std::vector<VectorPtr> column_vectors;
     column_vectors.reserve(fields_to_project_.size());
     for (int i = 0; i < fields_to_project_.size(); i++) {
@@ -193,7 +194,7 @@ PhyProjectNode::GetOutput() {
             continue;
         }
 
-        if (!segment_->is_field_exist(field_id)) {
+        if (!segment_->is_field_exist(field_id, op_context)) {
             auto field_data =
                 InitScalarFieldDataWithLength(column_type, selected_count);
             auto valid_map = TargetBitmap(selected_count, false);
@@ -204,7 +205,7 @@ PhyProjectNode::GetOutput() {
         }
 
         TargetBitmap valid_map(selected_count);
-        auto field_data = bulk_script_field_data(op_context_,
+        auto field_data = bulk_script_field_data(op_context,
                                                  field_id,
                                                  column_type,
                                                  selected_offsets.data(),

--- a/internal/core/src/exec/operator/ProjectNode.cpp
+++ b/internal/core/src/exec/operator/ProjectNode.cpp
@@ -46,8 +46,8 @@ SelectOffsets(const TargetBitmapView& raw_data_view,
               QueryContext* query_context,
               const segcore::SegmentInternalInterface* segment) {
     if (!query_context->bitset_is_element_level()) {
-        auto result_pair =
-            segment->find_first_n(segcore::Unlimited, raw_data_view);
+        auto result_pair = segment->find_first_n(
+            segcore::Unlimited, raw_data_view, query_context->get_op_context());
         return {std::move(result_pair.first), {}};
     }
 
@@ -59,7 +59,8 @@ SelectOffsets(const TargetBitmapView& raw_data_view,
         segment->find_first_n_element(segcore::Unlimited,
                                       raw_data_view,
                                       array_offsets.get(),
-                                      std::nullopt);
+                                      std::nullopt,
+                                      query_context->get_op_context());
 
     size_t selected_count = 0;
     for (const auto& element_indices : element_indices_by_doc) {

--- a/internal/core/src/exec/operator/ProjectNode.h
+++ b/internal/core/src/exec/operator/ProjectNode.h
@@ -73,7 +73,6 @@ class PhyProjectNode : public Operator {
     bool is_finished_{false};
     const std::vector<FieldId> fields_to_project_;
     QueryContext* query_context_;
-    OpContext* op_context_;
 };
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -105,7 +105,8 @@ PhyVectorSearchNode::GetOutput() {
     auto num_queries = ph.num_of_queries_;
     std::shared_ptr<const IArrayOffsets> array_offsets = nullptr;
     if (ph.element_level_) {
-        array_offsets = segment_->GetArrayOffsets(search_info_.field_id_);
+        array_offsets = segment_->GetArrayOffsets(
+            search_info_.field_id_, query_context_->get_op_context());
         AssertInfo(array_offsets != nullptr, "Array offsets not available");
         query_context_->set_array_offsets(array_offsets);
         search_info_.array_offsets_ = array_offsets;

--- a/internal/core/src/exec/operator/search-groupby/SearchGroupByOperator.h
+++ b/internal/core/src/exec/operator/search-groupby/SearchGroupByOperator.h
@@ -214,7 +214,7 @@ class SealedDataGetter : public DataGetter<OutputType> {
                      std::optional<DataType> json_type,
                      bool strict_cast)
         : op_ctx_(op_ctx), segment_(segment), field_id_(field_id) {
-        from_data_ = segment_.HasFieldData(field_id_);
+        from_data_ = segment_.HasFieldData(field_id_, op_ctx_);
         if (!from_data_) {
             auto index = segment_.PinIndex(op_ctx_, field_id_);
             if (index.empty()) {
@@ -235,7 +235,8 @@ class SealedDataGetter : public DataGetter<OutputType> {
     std::optional<OutputType>
     Get(int64_t idx) const {
         if (from_data_) {
-            auto id_offset_pair = segment_.get_chunk_by_offset(field_id_, idx);
+            auto id_offset_pair =
+                segment_.get_chunk_by_offset(field_id_, idx, op_ctx_);
             auto chunk_id = id_offset_pair.first;
             auto inner_offset = id_offset_pair.second;
             if constexpr (std::is_same_v<InnerRawType, std::string>) {

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -834,13 +834,21 @@ TYPED_TEST_P(HybridIndexTestInverted,
         ctx,
         std::move(config));
 
+    // milvus-common now models loading overhead per dimension
+    // (LoadingOverheadConfig::memory / ::file), replacing the former
+    // single {group, upper_bound(ResourceUsage)} shape. The SealedIndexTranslator
+    // still builds it via the compatibility ctor
+    // LoadingOverheadConfig{upper_bound={mem, 0}, group}, which populates both
+    // dimensions with that group; assert against the new shape.
     ASSERT_TRUE(translator.meta()->loading_overhead.has_value());
-    EXPECT_EQ(translator.meta()->loading_overhead->group,
+    ASSERT_TRUE(translator.meta()->loading_overhead->memory.has_value());
+    ASSERT_TRUE(translator.meta()->loading_overhead->file.has_value());
+    EXPECT_EQ(translator.meta()->loading_overhead->memory->group,
               milvus::segcore::kLoadTransientOverheadGroup);
     EXPECT_EQ(
-        translator.meta()->loading_overhead->upper_bound.memory_bytes,
+        translator.meta()->loading_overhead->memory->upper_bound,
         milvus::cachinglayer::LoadingOverheadTracker::kUnlimited.memory_bytes);
-    EXPECT_EQ(translator.meta()->loading_overhead->upper_bound.file_bytes, 0);
+    EXPECT_EQ(translator.meta()->loading_overhead->file->upper_bound, 0);
 }
 
 template <typename T>

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -301,6 +301,10 @@ ExecPlanNodeVisitor::visit(RetrievePlanNode& node) {
 
     // Set op context to query context
     query_context->set_op_context(&op_context);
+    segment->ValidateExternalFieldsInLoadedManifest(
+        access_entries_,
+        skipped_access_entries_,
+        query_context->get_op_context());
 
     // Do task execution
     auto result = ExecuteTask(plan, query_context);
@@ -419,6 +423,40 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
     segment->PinOpSnapshot(&op_context);
     auto active_count = segment->get_active_count(timestamp_, &op_context);
 
+    auto query_context = std::make_shared<milvus::exec::QueryContext>(
+        DEAFULT_QUERY_ID,
+        segment,
+        active_count,
+        timestamp_,
+        collection_ttl_timestamp_,
+        consistency_level_,
+        node.plan_options_,
+        std::make_shared<milvus::exec::QueryConfig>(),
+        nullptr,
+        std::unordered_map<std::string,
+                           std::shared_ptr<milvus::exec::BaseConfig>>(),
+        entity_ttl_physical_time_us_);
+    query_context->set_search_info(node.search_info_);
+    query_context->set_placeholder_group(placeholder_group_);
+    if (enable_expr_cache_) {
+        query_context->set_enable_expr_cache(true);
+        query_context->set_enable_sub_expr_cache_write(false);
+    }
+    query_context->set_op_context(&op_context);
+
+    segment->ValidateExternalFieldsInLoadedManifest(
+        access_entries_,
+        skipped_access_entries_,
+        query_context->get_op_context());
+
+    auto attach_snapshot = [&](SearchResult& result) {
+        auto* query_op_context = query_context->get_op_context();
+        AssertInfo(query_op_context != nullptr,
+                   "QueryContext has no OpContext");
+        result.pinned_segment_state_ = query_op_context->pinned_segment_state;
+        result.pinned_state_owner_ = query_op_context->pinned_state_owner;
+    };
+
     // Handle filter-only mode: execute only the filter and return valid_count
     if (filter_only_) {
         SearchResult filter_only_result;
@@ -431,6 +469,7 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
 
         if (active_count == 0) {
             filter_only_result.valid_count_ = 0;
+            attach_snapshot(filter_only_result);
             search_result_opt_ = std::move(filter_only_result);
             return;
         }
@@ -449,27 +488,6 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
                 active_count);
         } else {
             auto plan_fragment = plan::PlanFragment(filter_only_plan);
-            auto query_context = std::make_shared<milvus::exec::QueryContext>(
-                DEAFULT_QUERY_ID,
-                segment,
-                active_count,
-                timestamp_,
-                collection_ttl_timestamp_,
-                consistency_level_,
-                node.plan_options_,
-                std::make_shared<milvus::exec::QueryConfig>(),
-                nullptr,
-                std::unordered_map<std::string,
-                                   std::shared_ptr<milvus::exec::BaseConfig>>(),
-                entity_ttl_physical_time_us_);
-
-            if (enable_expr_cache_) {
-                query_context->set_enable_expr_cache(true);
-                query_context->set_enable_sub_expr_cache_write(false);
-            }
-
-            query_context->set_op_context(&op_context);
-
             auto result = ExecuteTask(plan_fragment, query_context);
 
             if (result != nullptr && !result->childrens().empty()) {
@@ -488,45 +506,33 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
                   valid_count,
                   active_count);
         filter_only_result.valid_count_ = valid_count;
+        attach_snapshot(filter_only_result);
         search_result_opt_ = std::move(filter_only_result);
+        return;
+    }
+
+    if (!segment->FieldAccessible(node.search_info_.field_id_,
+                                  query_context->get_op_context())) {
+        const auto& placeholder = placeholder_group_->at(0);
+        auto empty = empty_search_result(placeholder.num_of_queries_,
+                                         placeholder.element_level_);
+        attach_snapshot(empty);
+        search_result_opt_ = std::move(empty);
         return;
     }
 
     // PreExecute: skip all calculation
     if (active_count == 0) {
         const auto& placeholder = placeholder_group_->at(0);
-        search_result_opt_ = empty_search_result(placeholder.num_of_queries_,
-                                                 placeholder.element_level_);
+        auto empty = empty_search_result(placeholder.num_of_queries_,
+                                         placeholder.element_level_);
+        attach_snapshot(empty);
+        search_result_opt_ = std::move(empty);
         return;
     }
 
     // Construct plan fragment
     auto plan = plan::PlanFragment(node.plannodes_);
-
-    // Set query context
-    auto query_context = std::make_shared<milvus::exec::QueryContext>(
-        DEAFULT_QUERY_ID,
-        segment,
-        active_count,
-        timestamp_,
-        collection_ttl_timestamp_,
-        consistency_level_,
-        node.plan_options_,
-        std::make_shared<milvus::exec::QueryConfig>(),
-        nullptr,
-        std::unordered_map<std::string,
-                           std::shared_ptr<milvus::exec::BaseConfig>>(),
-        entity_ttl_physical_time_us_);
-
-    query_context->set_search_info(node.search_info_);
-    query_context->set_placeholder_group(placeholder_group_);
-    if (enable_expr_cache_) {
-        query_context->set_enable_expr_cache(true);
-        query_context->set_enable_sub_expr_cache_write(false);
-    }
-
-    // Set op context to query context
-    query_context->set_op_context(&op_context);
 
     // Do plan fragment task work
     auto result = ExecuteTask(plan, query_context);
@@ -535,6 +541,7 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
     search_result_opt_ = std::move(query_context->get_search_result());
     auto* query_op_context = query_context->get_op_context();
     AssertInfo(query_op_context != nullptr, "QueryContext has no OpContext");
+    attach_snapshot(*search_result_opt_);
     search_result_opt_->search_storage_cost_.scanned_remote_bytes =
         query_op_context->storage_usage.scanned_cold_bytes.load();
     search_result_opt_->search_storage_cost_.scanned_total_bytes =

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -275,7 +275,11 @@ ExecPlanNodeVisitor::visit(RetrievePlanNode& node) {
     RetrieveResult retrieve_result;
     retrieve_result.total_data_cnt_ = 0;
 
-    auto active_count = segment->get_active_count(timestamp_);
+    // Select the operation snapshot before deriving active_count or any other
+    // layout coordinate from the segment.
+    auto op_context = milvus::OpContext(cancel_token_);
+    segment->PinOpSnapshot(&op_context);
+    auto active_count = segment->get_active_count(timestamp_, &op_context);
 
     // Get plan
     auto plan = plan::PlanFragment(node.plannodes_);
@@ -296,28 +300,30 @@ ExecPlanNodeVisitor::visit(RetrievePlanNode& node) {
         entity_ttl_physical_time_us_);
 
     // Set op context to query context
-    auto op_context = milvus::OpContext(cancel_token_);
     query_context->set_op_context(&op_context);
-
-    // Pin one published-state snapshot for the whole retrieve on this segment,
-    // so every accessor reading through this op_context sees a consistent
-    // layout even if a concurrent Reopen republishes. No-op for growing.
-    segment->PinOpSnapshot(&op_context);
 
     // Do task execution
     auto result = ExecuteTask(plan, query_context);
-    setupRetrieveResult(
-        result, op_context, node, retrieve_result, segment, query_context);
+    setupRetrieveResult(result, node, retrieve_result, segment, query_context);
 }
 
 void
 ExecPlanNodeVisitor::setupRetrieveResult(
     const milvus::RowVectorPtr& result,
-    const OpContext& op_context,
     const RetrievePlanNode& node,
     RetrieveResult& tmp_retrieve_result,
     const segcore::SegmentInternalInterface* segment,
     std::shared_ptr<milvus::exec::QueryContext> query_context) {
+    auto* op_context = query_context->get_op_context();
+    AssertInfo(op_context != nullptr, "QueryContext has no OpContext");
+
+    // Preserve the exact operation snapshot selected before execution so the
+    // caller's later size-check and materialization phases cannot re-pin a
+    // newer published state.
+    tmp_retrieve_result.pinned_segment_state_ =
+        op_context->pinned_segment_state;
+    tmp_retrieve_result.pinned_state_owner_ = op_context->pinned_state_owner;
+
     if (result == nullptr) {
         // Return empty field_data arrays with correct schema (0 rows, N columns)
         // to ensure result structure matches the expected output type.
@@ -355,13 +361,15 @@ ExecPlanNodeVisitor::setupRetrieveResult(
                 segment->find_first_n_element(node.limit_,
                                               view,
                                               array_offsets.get(),
-                                              node.query_iterator_cursor_);
+                                              node.query_iterator_cursor_,
+                                              op_context);
             tmp_retrieve_result.result_offsets_ = std::move(doc_offsets);
             tmp_retrieve_result.element_indices_ = std::move(element_indices);
             tmp_retrieve_result.has_more_result = has_more;
         } else {
             tracer::AutoSpan _("Find Limit Pk", tracer::GetRootSpan());
-            auto results_pair = segment->find_first_n(node.limit_, view);
+            auto results_pair =
+                segment->find_first_n(node.limit_, view, op_context);
             tmp_retrieve_result.result_offsets_ = std::move(results_pair.first);
             tmp_retrieve_result.has_more_result = results_pair.second;
         }
@@ -392,9 +400,9 @@ ExecPlanNodeVisitor::setupRetrieveResult(
         retrieve_result_opt_ = std::move(tmp_retrieve_result);
     }
     retrieve_result_opt_->retrieve_storage_cost_.scanned_remote_bytes =
-        op_context.storage_usage.scanned_cold_bytes.load();
+        op_context->storage_usage.scanned_cold_bytes.load();
     retrieve_result_opt_->retrieve_storage_cost_.scanned_total_bytes =
-        op_context.storage_usage.scanned_total_bytes.load();
+        op_context->storage_usage.scanned_total_bytes.load();
 }
 
 void
@@ -404,7 +412,12 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
         dynamic_cast<const segcore::SegmentInternalInterface*>(&segment_);
     AssertInfo(segment, "support SegmentSmallIndex Only");
 
-    auto active_count = segment->get_active_count(timestamp_);
+    // Select the operation snapshot before deriving active_count or any other
+    // layout coordinate from the segment.
+    auto op_context = milvus::OpContext(cancel_token_);
+    op_context.trace_span = trace_span_;
+    segment->PinOpSnapshot(&op_context);
+    auto active_count = segment->get_active_count(timestamp_, &op_context);
 
     // Handle filter-only mode: execute only the filter and return valid_count
     if (filter_only_) {
@@ -455,12 +468,7 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
                 query_context->set_enable_sub_expr_cache_write(false);
             }
 
-            auto op_context = milvus::OpContext(cancel_token_);
-            op_context.trace_span = trace_span_;
             query_context->set_op_context(&op_context);
-
-            // Pin one published-state snapshot for this filter-only pass.
-            segment->PinOpSnapshot(&op_context);
 
             auto result = ExecuteTask(plan_fragment, query_context);
 
@@ -518,22 +526,19 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
     }
 
     // Set op context to query context
-    auto op_context = milvus::OpContext(cancel_token_);
-    op_context.trace_span = trace_span_;
     query_context->set_op_context(&op_context);
-
-    // Pin one published-state snapshot for the whole search on this segment.
-    segment->PinOpSnapshot(&op_context);
 
     // Do plan fragment task work
     auto result = ExecuteTask(plan, query_context);
 
     // Store result
     search_result_opt_ = std::move(query_context->get_search_result());
+    auto* query_op_context = query_context->get_op_context();
+    AssertInfo(query_op_context != nullptr, "QueryContext has no OpContext");
     search_result_opt_->search_storage_cost_.scanned_remote_bytes =
-        op_context.storage_usage.scanned_cold_bytes.load();
+        query_op_context->storage_usage.scanned_cold_bytes.load();
     search_result_opt_->search_storage_cost_.scanned_total_bytes =
-        op_context.storage_usage.scanned_total_bytes.load();
+        query_op_context->storage_usage.scanned_total_bytes.load();
 }
 
 }  // namespace milvus::query

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -299,6 +299,11 @@ ExecPlanNodeVisitor::visit(RetrievePlanNode& node) {
     auto op_context = milvus::OpContext(cancel_token_);
     query_context->set_op_context(&op_context);
 
+    // Pin one published-state snapshot for the whole retrieve on this segment,
+    // so every accessor reading through this op_context sees a consistent
+    // layout even if a concurrent Reopen republishes. No-op for growing.
+    segment->PinOpSnapshot(&op_context);
+
     // Do task execution
     auto result = ExecuteTask(plan, query_context);
     setupRetrieveResult(
@@ -454,6 +459,9 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
             op_context.trace_span = trace_span_;
             query_context->set_op_context(&op_context);
 
+            // Pin one published-state snapshot for this filter-only pass.
+            segment->PinOpSnapshot(&op_context);
+
             auto result = ExecuteTask(plan_fragment, query_context);
 
             if (result != nullptr && !result->childrens().empty()) {
@@ -513,6 +521,9 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
     auto op_context = milvus::OpContext(cancel_token_);
     op_context.trace_span = trace_span_;
     query_context->set_op_context(&op_context);
+
+    // Pin one published-state snapshot for the whole search on this segment.
+    segment->PinOpSnapshot(&op_context);
 
     // Do plan fragment task work
     auto result = ExecuteTask(plan, query_context);

--- a/internal/core/src/query/ExecPlanNodeVisitor.h
+++ b/internal/core/src/query/ExecPlanNodeVisitor.h
@@ -154,6 +154,13 @@ class ExecPlanNodeVisitor : public PlanNodeVisitor {
         return filter_only_;
     }
 
+    void
+    SetAccessEntries(std::vector<FieldId> access_entries,
+                     std::vector<FieldId> skipped_access_entries = {}) {
+        access_entries_ = std::move(access_entries);
+        skipped_access_entries_ = std::move(skipped_access_entries);
+    }
+
     ExecPlanNodeVisitor&
     SetEnableExprCache(bool enable) {
         enable_expr_cache_ = enable;
@@ -193,6 +200,8 @@ class ExecPlanNodeVisitor : public PlanNodeVisitor {
     bool filter_only_ = false;
     bool enable_expr_cache_ = false;
     milvus::tracer::SpanPtr trace_span_ = nullptr;
+    std::vector<FieldId> access_entries_;
+    std::vector<FieldId> skipped_access_entries_;
 };
 
 // for test use only

--- a/internal/core/src/query/ExecPlanNodeVisitor.h
+++ b/internal/core/src/query/ExecPlanNodeVisitor.h
@@ -172,7 +172,6 @@ class ExecPlanNodeVisitor : public PlanNodeVisitor {
     void
     setupRetrieveResult(
         const RowVectorPtr& result,
-        const OpContext& op_context,
         const RetrievePlanNode& node,
         RetrieveResult& tmp_retrieve_result,
         const segcore::SegmentInternalInterface* segment,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -353,7 +353,7 @@ ChunkedSegmentSealedImpl::PinJsonIndex(milvus::OpContext* op_ctx,
                                        DataType data_type,
                                        bool any_type,
                                        bool is_array) const {
-    auto runtime = CaptureRuntimeResourceState();
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
     int path_len_diff = std::numeric_limits<int>::max();
     index::CacheIndexBasePtr best_match = nullptr;
     std::string_view path_view = path;
@@ -930,27 +930,51 @@ ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
 }
 
 SchemaPtr
-ChunkedSegmentSealedImpl::CaptureSchemaSnapshot() const {
-    return CapturePublishedState()->schema;
+ChunkedSegmentSealedImpl::CaptureSchemaSnapshot(
+    milvus::OpContext* op_ctx) const {
+    return CapturePublishedState(op_ctx)->schema;
 }
 
 std::shared_ptr<const SegmentLoadInfo>
-ChunkedSegmentSealedImpl::CaptureLoadInfoSnapshot() const {
-    return CapturePublishedState()->load_info;
+ChunkedSegmentSealedImpl::CaptureLoadInfoSnapshot(
+    milvus::OpContext* op_ctx) const {
+    return CapturePublishedState(op_ctx)->load_info;
 }
 
 std::shared_ptr<const ChunkedSegmentSealedImpl::PublishedSegmentState>
-ChunkedSegmentSealedImpl::CapturePublishedState() const {
+ChunkedSegmentSealedImpl::CapturePublishedState(
+    milvus::OpContext* op_ctx) const {
+    // Return the pinned snapshot iff op_ctx carries a pin installed by THIS
+    // segment. The owner guard prevents an op_ctx reused across segments from
+    // handing back a foreign segment's state.
+    if (op_ctx != nullptr && op_ctx->pinned_state_owner == this &&
+        op_ctx->pinned_segment_state != nullptr) {
+        return std::static_pointer_cast<const PublishedSegmentState>(
+            op_ctx->pinned_segment_state);
+    }
     return std::atomic_load(&published_state_);
 }
 
 std::shared_ptr<const ChunkedSegmentSealedImpl::RuntimeResourceState>
-ChunkedSegmentSealedImpl::CaptureRuntimeResourceState() const {
-    auto state = CapturePublishedState();
+ChunkedSegmentSealedImpl::CaptureRuntimeResourceState(
+    milvus::OpContext* op_ctx) const {
+    auto state = CapturePublishedState(op_ctx);
     if (state == nullptr || state->runtime == nullptr) {
         return BuildRuntimeResourceState();
     }
     return state->runtime;
+}
+
+void
+ChunkedSegmentSealedImpl::PinOpSnapshot(milvus::OpContext* op_ctx) const {
+    if (op_ctx == nullptr) {
+        return;
+    }
+    // Eager capture of the live state (one atomic load) as the operation's
+    // birthline. All later Capture*(op_ctx) reads return this exact snapshot.
+    auto state = CapturePublishedState();
+    op_ctx->pinned_segment_state = state;
+    op_ctx->pinned_state_owner = this;
 }
 
 std::shared_ptr<const ChunkedSegmentSealedImpl::RuntimeResourceState>
@@ -1826,7 +1850,7 @@ ChunkedSegmentSealedImpl::PublishRuntimeStateLocked(
 PinWrapper<index::TextMatchIndex*>
 ChunkedSegmentSealedImpl::GetTextIndex(milvus::OpContext* op_ctx,
                                        FieldId field_id) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto runtime = snapshot != nullptr ? snapshot->runtime : nullptr;
     if (runtime == nullptr) {
         ThrowInfo(milvus::ErrorCode::TextIndexNotFound,
@@ -1869,7 +1893,7 @@ ChunkedSegmentSealedImpl::GetTextIndex(milvus::OpContext* op_ctx,
 std::shared_ptr<index::JsonKeyStats>
 ChunkedSegmentSealedImpl::GetJsonStats(milvus::OpContext* op_ctx,
                                        FieldId field_id) const {
-    auto runtime = CaptureRuntimeResourceState();
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
     if (runtime == nullptr) {
         return nullptr;
     }
@@ -3125,8 +3149,9 @@ ChunkedSegmentSealedImpl::AddFieldDataInfoForSealed(
 }
 
 int64_t
-ChunkedSegmentSealedImpl::num_chunk_data(FieldId field_id) const {
-    auto snapshot = CapturePublishedState();
+ChunkedSegmentSealedImpl::num_chunk_data(FieldId field_id,
+                                         milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
     if (!get_bit(snapshot->field_data_ready_bitset, field_id)) {
         return 0;
     }
@@ -3135,8 +3160,9 @@ ChunkedSegmentSealedImpl::num_chunk_data(FieldId field_id) const {
 }
 
 int64_t
-ChunkedSegmentSealedImpl::num_chunk(FieldId field_id) const {
-    auto snapshot = CapturePublishedState();
+ChunkedSegmentSealedImpl::num_chunk(FieldId field_id,
+                                    milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
     if (!get_bit(snapshot->field_data_ready_bitset, field_id)) {
         return 1;
     }
@@ -3150,8 +3176,10 @@ ChunkedSegmentSealedImpl::size_per_chunk() const {
 }
 
 int64_t
-ChunkedSegmentSealedImpl::chunk_size(FieldId field_id, int64_t chunk_id) const {
-    auto snapshot = CapturePublishedState();
+ChunkedSegmentSealedImpl::chunk_size(FieldId field_id,
+                                     int64_t chunk_id,
+                                     milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
     if (!get_bit(snapshot->field_data_ready_bitset, field_id)) {
         return 0;
     }
@@ -3161,8 +3189,9 @@ ChunkedSegmentSealedImpl::chunk_size(FieldId field_id, int64_t chunk_id) const {
 
 std::pair<int64_t, int64_t>
 ChunkedSegmentSealedImpl::get_chunk_by_offset(FieldId field_id,
-                                              int64_t offset) const {
-    auto snapshot = CapturePublishedState();
+                                              int64_t offset,
+                                              milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
     auto column = get_column(snapshot->runtime, field_id);
     AssertInfo(column != nullptr,
                "field {} must exist when getting chunk by offset",
@@ -3171,9 +3200,9 @@ ChunkedSegmentSealedImpl::get_chunk_by_offset(FieldId field_id,
 }
 
 int64_t
-ChunkedSegmentSealedImpl::num_rows_until_chunk(FieldId field_id,
-                                               int64_t chunk_id) const {
-    auto snapshot = CapturePublishedState();
+ChunkedSegmentSealedImpl::num_rows_until_chunk(
+    FieldId field_id, int64_t chunk_id, milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
     auto column = get_column(snapshot->runtime, field_id);
     AssertInfo(column != nullptr,
                "field {} must exist when getting rows until chunk",
@@ -3192,7 +3221,7 @@ ChunkedSegmentSealedImpl::prefetch_chunks(
     milvus::OpContext* op_ctx,
     FieldId field_id,
     const std::vector<int64_t>& chunk_ids) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
     if (auto column = get_column(snapshot->runtime, field_id)) {
@@ -3203,7 +3232,7 @@ ChunkedSegmentSealedImpl::prefetch_chunks(
 void
 ChunkedSegmentSealedImpl::prefetch_chunks_locked(milvus::OpContext* op_ctx,
                                                  FieldId field_id) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     if (auto column = get_column(snapshot->runtime, field_id)) {
         auto num_chunks = column->num_chunks();
         std::vector<int64_t> ids(num_chunks);
@@ -3231,7 +3260,7 @@ ChunkedSegmentSealedImpl::ApplyFieldValidData(
         return;
     }
 
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     std::shared_ptr<ChunkedColumnInterface> column;
     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -3257,7 +3286,7 @@ ChunkedSegmentSealedImpl::ApplyFieldValidDataByOffsets(
         return;
     }
 
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     std::shared_ptr<ChunkedColumnInterface> column;
     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -3284,7 +3313,7 @@ PinWrapper<SpanBase>
 ChunkedSegmentSealedImpl::chunk_data_impl(milvus::OpContext* op_ctx,
                                           FieldId field_id,
                                           int64_t chunk_id) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
     if (auto column = get_column(snapshot->runtime, field_id)) {
@@ -3300,7 +3329,7 @@ ChunkedSegmentSealedImpl::chunk_array_view_impl(
     FieldId field_id,
     int64_t chunk_id,
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
     if (auto column = get_column(snapshot->runtime, field_id)) {
@@ -3316,7 +3345,7 @@ ChunkedSegmentSealedImpl::chunk_vector_array_view_impl(
     FieldId field_id,
     int64_t chunk_id,
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
     if (auto column = get_column(snapshot->runtime, field_id)) {
@@ -3332,7 +3361,7 @@ ChunkedSegmentSealedImpl::chunk_string_view_impl(
     FieldId field_id,
     int64_t chunk_id,
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
     if (auto column = get_column(snapshot->runtime, field_id)) {
@@ -3348,7 +3377,7 @@ ChunkedSegmentSealedImpl::chunk_string_views_by_offsets(
     FieldId field_id,
     int64_t chunk_id,
     const FixedVector<int32_t>& offsets) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
     if (auto column = get_column(snapshot->runtime, field_id)) {
@@ -3364,7 +3393,7 @@ ChunkedSegmentSealedImpl::chunk_array_views_by_offsets(
     FieldId field_id,
     int64_t chunk_id,
     const FixedVector<int32_t>& offsets) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
     if (auto column = get_column(snapshot->runtime, field_id)) {
@@ -3378,7 +3407,7 @@ ChunkedSegmentSealedImpl::chunk_array_views_by_offsets(
 PinWrapper<index::NgramInvertedIndex*>
 ChunkedSegmentSealedImpl::GetNgramIndex(milvus::OpContext* op_ctx,
                                         FieldId field_id) const {
-    auto runtime = CaptureRuntimeResourceState();
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
     if (runtime->ngram_fields.find(field_id) == runtime->ngram_fields.end()) {
         return PinWrapper<index::NgramInvertedIndex*>(nullptr);
     }
@@ -3401,7 +3430,7 @@ ChunkedSegmentSealedImpl::GetNgramIndexForJson(
     milvus::OpContext* op_ctx,
     FieldId field_id,
     const std::string& nested_path) const {
-    auto runtime = CaptureRuntimeResourceState();
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
     auto iter = runtime->ngram_indexings.find(field_id);
     if (iter == runtime->ngram_indexings.end()) {
         return PinWrapper<index::NgramInvertedIndex*>(nullptr);
@@ -3434,8 +3463,12 @@ ChunkedSegmentSealedImpl::get_deleted_count() const {
 }
 
 const Schema&
-ChunkedSegmentSealedImpl::get_schema() const {
-    return *CapturePublishedState()->schema;
+ChunkedSegmentSealedImpl::get_schema(milvus::OpContext* op_ctx) const {
+    // The returned reference aliases into the captured PublishedSegmentState's
+    // schema. When op_ctx carries a pin, that snapshot is held alive for the
+    // whole operation, so the reference stays valid across concurrent
+    // republishes; unpinned callers keep today's per-call lifetime.
+    return *CapturePublishedState(op_ctx)->schema;
 }
 
 void
@@ -3455,7 +3488,7 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
                                         milvus::OpContext* op_context,
                                         SearchResult& output) const {
     std::shared_lock vector_state_lck(mutex_);
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_context);
     AssertInfo(snapshot->system_field_ready, "System field is not ready");
     auto field_id = search_info.field_id_;
     auto runtime = snapshot->runtime;
@@ -3589,13 +3622,13 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
                                      const int64_t* ids,
                                      int64_t count) const {
     std::shared_lock vector_state_lck(mutex_);
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto& field_meta = snapshot->schema->operator[](field_id);
     AssertInfo(field_meta.is_vector(), "vector field is not vector type");
 
     if (!get_bit(snapshot->index_ready_bitset, field_id) &&
         !get_bit(snapshot->binlog_index_bitset, field_id)) {
-        return fill_with_empty(field_id, count);
+        return fill_with_empty(field_id, count, 0, nullptr, op_ctx);
     }
 
     auto vector_entry = GetVectorIndexing(snapshot->runtime, field_id);
@@ -3657,13 +3690,13 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
                                        const int64_t* seg_offsets,
                                        int64_t count) const {
     std::shared_lock vector_state_lck(mutex_);
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(field_meta.get_data_type() == DataType::VECTOR_ARRAY,
                "get_emb_list only supports VECTOR_ARRAY");
 
     if (!get_bit(snapshot->index_ready_bitset, field_id) &&
         !get_bit(snapshot->binlog_index_bitset, field_id)) {
-        return fill_with_empty(field_id, count);
+        return fill_with_empty(field_id, count, 0, nullptr, op_ctx);
     }
 
     auto vector_entry = GetVectorIndexing(snapshot->runtime, field_id);
@@ -4169,7 +4202,7 @@ ChunkedSegmentSealedImpl::pk_range(milvus::OpContext* op_ctx,
                                    proto::plan::OpType op,
                                    const PkType& pk,
                                    BitsetTypeView& bitset) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto runtime = snapshot->runtime;
     // See Contain() — same zero-storage pk2offset fast path.
     if (runtime != nullptr && runtime->virtual_pk2offset != nullptr) {
@@ -4229,7 +4262,7 @@ ChunkedSegmentSealedImpl::pk_binary_range(milvus::OpContext* op_ctx,
                                           const PkType& upper_pk,
                                           bool upper_inclusive,
                                           BitsetTypeView& bitset) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto runtime = snapshot->runtime;
     // See Contain() — same zero-storage pk2offset fast path.
     if (runtime != nullptr && runtime->virtual_pk2offset != nullptr) {
@@ -4620,7 +4653,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                          const int64_t* seg_offsets,
                                          int64_t count,
                                          void* output) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(snapshot->system_field_ready,
                "System field isn't ready when do bulk_insert, segID:{}",
                id_);
@@ -4660,7 +4693,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                          void* data,
                                          TargetBitmap& valid_map,
                                          bool small_int_raw_type) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto& field_meta = snapshot->schema->operator[](field_id);
     // DO NOT directly access the column by map like: `fields_.at(field_id)->Data()`,
     // we have to clone the shared pointer, to make sure it won't get released
@@ -4952,7 +4985,7 @@ ChunkedSegmentSealedImpl::bulk_subscript_text_impl(
     const int64_t* seg_offsets,
     int64_t count,
     google::protobuf::RepeatedPtrField<std::string>* dst) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto runtime = snapshot->runtime != nullptr ? snapshot->runtime
                                                 : BuildRuntimeResourceState();
     auto it = runtime->text_lob_paths.find(field_id);
@@ -5034,8 +5067,12 @@ std::unique_ptr<DataArray>
 ChunkedSegmentSealedImpl::fill_with_empty(FieldId field_id,
                                           int64_t count,
                                           int64_t valid_count,
-                                          const void* valid_data) const {
-    auto schema_snapshot = CaptureSchemaSnapshot();
+                                          const void* valid_data,
+                                          milvus::OpContext* op_ctx) const {
+    // Resolve the field meta against the operation's pinned snapshot so a
+    // concurrent Reopen that drops this field mid-operation cannot make the
+    // schema lookup fail (or read a mismatched layout).
+    auto schema_snapshot = CaptureSchemaSnapshot(op_ctx);
     auto& field_meta = schema_snapshot->operator[](field_id);
     if (IsVectorDataType(field_meta.get_data_type())) {
         return CreateEmptyVectorDataArray(
@@ -5542,7 +5579,7 @@ ChunkedSegmentSealedImpl::FillPrimaryKeys(const query::Plan* plan,
         AssertInfo(results.seg_offsets_.size() == size,
                    "Size of result distances is not equal to size of ids");
 
-        auto snapshot = CapturePublishedState();
+        auto snapshot = CapturePublishedState(op_ctx);
         auto schema_snapshot = snapshot->schema;
         auto pk_field_id_opt = schema_snapshot->get_primary_field_id();
         AssertInfo(pk_field_id_opt.has_value(),
@@ -5605,7 +5642,7 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
     // DO NOT directly access the column by map like: `fields_.at(field_id)->Data()`,
     // we have to clone the shared pointer,
     // to make sure it won't get released if segment released
-    auto column = get_column(field_id);
+    auto column = get_column(field_id, op_ctx);
     AssertInfo(column != nullptr,
                "field {} must exist when getting raw data",
                field_id.get());
@@ -5623,7 +5660,8 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
         valid_data = filter_result.valid_data.get();
         valid_offsets = filter_result.valid_offsets.data();
     }
-    auto ret = fill_with_empty(field_id, count, valid_count, valid_data);
+    auto ret =
+        fill_with_empty(field_id, count, valid_count, valid_data, op_ctx);
     if (field_meta.is_vector() && valid_count == 0) {
         return ret;
     }
@@ -5651,7 +5689,7 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
 
         case DataType::TEXT: {
             // TEXT type is only supported in StorageV3 with LOB files.
-            auto snapshot = CapturePublishedState();
+            auto snapshot = CapturePublishedState(op_ctx);
             auto runtime = snapshot->runtime != nullptr
                                ? snapshot->runtime
                                : BuildRuntimeResourceState();
@@ -5918,11 +5956,11 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                          FieldId field_id,
                                          const int64_t* seg_offsets,
                                          int64_t count) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto& field_meta = snapshot->schema->operator[](field_id);
     // if count == 0, return empty data array
     if (count == 0) {
-        return fill_with_empty(field_id, count);
+        return fill_with_empty(field_id, count, 0, nullptr, op_ctx);
     }
 
     // Fast path for int64 PK field: use compressed offset2pk index
@@ -5931,7 +5969,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
     if (pk_field_id.has_value() && pk_field_id.value() == field_id &&
         field_meta.get_data_type() == DataType::INT64 &&
         pk_index.get() != nullptr && pk_index.get()->has_int64_pk_index()) {
-        auto ret = fill_with_empty(field_id, count);
+        auto ret = fill_with_empty(field_id, count, 0, nullptr, op_ctx);
         auto* output = ret->mutable_scalars()
                            ->mutable_long_data()
                            ->mutable_data()
@@ -5948,7 +5986,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
     bool use_field_data =
         SegcoreConfig::default_config()
             .get_prefer_field_data_when_index_has_raw_data() &&
-        HasFieldData(field_id);
+        HasFieldData(field_id, op_ctx);
 
     if (!IsVectorDataType(field_meta.get_data_type())) {
         // === Scalar field ===
@@ -5958,7 +5996,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
             auto scalar_indexes = PinIndex(op_ctx, field_id);
             if (!scalar_indexes.empty()) {
                 pin_scalar_index_ptr = std::move(scalar_indexes[0]);
-                if (IndexHasRawData(field_id)) {
+                if (IndexHasRawData(field_id, op_ctx)) {
                     return ReverseDataFromIndex(pin_scalar_index_ptr.get(),
                                                 seg_offsets,
                                                 count,
@@ -5975,7 +6013,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
 
     std::unique_ptr<DataArray> vector{nullptr};
     // Try index first: if vector index exists and has raw data, read from index
-    if (!use_field_data && IndexHasRawData(field_id)) {
+    if (!use_field_data && IndexHasRawData(field_id, op_ctx)) {
         if (IsVectorArrayDataType(field_meta.get_data_type())) {
             vector =
                 get_emb_list(op_ctx, field_id, field_meta, seg_offsets, count);
@@ -5987,7 +6025,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
         // we could reject remote vector output if the vector is not loaded in local cache
         // for performance needs
         if (SegcoreConfig::default_config().get_reject_remote_vector_output()) {
-            auto column = get_column(field_id);
+            auto column = get_column(field_id, op_ctx);
             AssertInfo(column != nullptr,
                        "field {} must exist when getting raw data",
                        field_id.get());
@@ -6015,17 +6053,17 @@ ChunkedSegmentSealedImpl::bulk_subscript(
     const int64_t* seg_offsets,
     int64_t count,
     const std::vector<std::string>& dynamic_field_names) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     Assert(!dynamic_field_names.empty());
     if (count == 0) {
-        return fill_with_empty(field_id, 0);
+        return fill_with_empty(field_id, 0, 0, nullptr, op_ctx);
     }
 
-    auto column = get_column(field_id);
+    auto column = get_column(field_id, op_ctx);
     AssertInfo(column != nullptr,
                "json field {} must exist when bulk_subscript",
                field_id.get());
-    auto ret = fill_with_empty(field_id, count);
+    auto ret = fill_with_empty(field_id, count, 0, nullptr, op_ctx);
     if (column->IsNullable()) {
         auto dst = ret->mutable_valid_data()->mutable_data();
         column->BulkIsValid(
@@ -6046,8 +6084,9 @@ ChunkedSegmentSealedImpl::bulk_subscript(
 }
 
 bool
-ChunkedSegmentSealedImpl::HasIndex(FieldId field_id) const {
-    auto snapshot = CapturePublishedState();
+ChunkedSegmentSealedImpl::HasIndex(FieldId field_id,
+                                   milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
     if (!SystemProperty::Instance().IsSystem(field_id) &&
         !field_exists_in_schema(snapshot->schema, field_id)) {
         return false;
@@ -6057,11 +6096,12 @@ ChunkedSegmentSealedImpl::HasIndex(FieldId field_id) const {
 }
 
 bool
-ChunkedSegmentSealedImpl::HasJsonIndex(FieldId field_id) const {
+ChunkedSegmentSealedImpl::HasJsonIndex(FieldId field_id,
+                                       milvus::OpContext* op_ctx) const {
     // JSON indexes (JsonFlatIndex + JSON-cast) remain distinct from the
     // scalar/vector/binlog readiness bitsets, but their ownership now follows
     // the published runtime snapshot.
-    auto runtime = CaptureRuntimeResourceState();
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
     for (const auto& index : runtime->json_indices) {
         if (index.field_id == field_id) {
             return true;
@@ -6071,8 +6111,9 @@ ChunkedSegmentSealedImpl::HasJsonIndex(FieldId field_id) const {
 }
 
 bool
-ChunkedSegmentSealedImpl::HasFieldData(FieldId field_id) const {
-    auto snapshot = CapturePublishedState();
+ChunkedSegmentSealedImpl::HasFieldData(FieldId field_id,
+                                       milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
     if (SystemProperty::Instance().IsSystem(field_id)) {
         return snapshot->system_field_ready;
     }
@@ -6119,9 +6160,10 @@ ChunkedSegmentSealedImpl::GetFieldDataIfExist(FieldId field_id) const {
 }
 
 bool
-ChunkedSegmentSealedImpl::HasRawData(int64_t field_id) const {
+ChunkedSegmentSealedImpl::HasRawData(int64_t field_id,
+                                     milvus::OpContext* op_ctx) const {
     std::shared_lock lck(mutex_);
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto fieldID = FieldId(field_id);
     const auto& field_meta = snapshot->schema->operator[](fieldID);
 
@@ -6138,8 +6180,9 @@ ChunkedSegmentSealedImpl::HasRawData(int64_t field_id) const {
 }
 
 bool
-ChunkedSegmentSealedImpl::IndexHasRawData(FieldId field_id) const {
-    auto snapshot = CapturePublishedState();
+ChunkedSegmentSealedImpl::IndexHasRawData(FieldId field_id,
+                                          milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
     return IndexHasRawDataFromState(*snapshot, field_id);
 }
 
@@ -6153,7 +6196,7 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
     bool is_cosine,
     float* distances) const {
     std::shared_lock vector_state_lck(mutex_);
-    auto runtime = CaptureRuntimeResourceState();
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
     auto vector_entry = GetVectorIndexing(runtime, field_id);
     if (vector_entry == nullptr) {
         return false;
@@ -6212,12 +6255,13 @@ ChunkedSegmentSealedImpl::IsIndexRefineEnabled(milvus::OpContext* op_ctx,
                                                FieldId field_id) const {
     std::shared_lock vector_state_lck(mutex_);
     return IsIndexRefineEnabledLocked(
-        op_ctx, field_id, CaptureRuntimeResourceState());
+        op_ctx, field_id, CaptureRuntimeResourceState(op_ctx));
 }
 
 DataType
-ChunkedSegmentSealedImpl::GetFieldDataType(milvus::FieldId field_id) const {
-    auto schema_snapshot = CaptureSchemaSnapshot();
+ChunkedSegmentSealedImpl::GetFieldDataType(milvus::FieldId field_id,
+                                           milvus::OpContext* op_ctx) const {
+    auto schema_snapshot = CaptureSchemaSnapshot(op_ctx);
     auto& field_meta = schema_snapshot->operator[](field_id);
     return field_meta.get_data_type();
 }
@@ -8559,7 +8603,11 @@ void
 ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
                                           SearchResult& results,
                                           milvus::OpContext* op_ctx) const {
-    auto snapshot = CapturePublishedState();
+    // Honor the operation's pin (if op_ctx carries one for this segment) so
+    // the take path and the bulk_subscript fallback below agree on layout.
+    // When op_ctx has no pin (e.g. the cross-segment reduce/export op_ctx),
+    // this resolves to live state exactly as before.
+    auto snapshot = CapturePublishedState(op_ctx);
     AssertInfo(plan, "empty plan");
     auto size = results.distances_.size();
     AssertInfo(results.seg_offsets_.size() == size,
@@ -8575,11 +8623,15 @@ ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
     std::unique_ptr<DataArray> field_data;
     // Per-call OpContext keeps storage_usage scoped to this segment;
     // sharing op_ctx across segments would double-count bytes. See
-    // SegmentInternalInterface::FillPrimaryKeys for the same pattern.
+    // SegmentInternalInterface::FillPrimaryKeys for the same pattern. The pin
+    // fields are copied over so the bulk_subscript reads observe the same
+    // snapshot as the take path (inert when op_ctx carries no matching pin).
     milvus::OpContext local_ctx;
     if (op_ctx != nullptr) {
         local_ctx.cancellation_token = op_ctx->cancellation_token;
         local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+        local_ctx.pinned_segment_state = op_ctx->pinned_segment_state;
+        local_ctx.pinned_state_owner = op_ctx->pinned_state_owner;
     }
     for (auto field_id : plan->target_entries_) {
         // Skip fields already filled by take
@@ -8598,7 +8650,7 @@ ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
                                         results.seg_offsets_.data(),
                                         size,
                                         target_dynamic_fields);
-        } else if (!is_field_exist(field_id)) {
+        } else if (!is_field_exist(field_id, &local_ctx)) {
             field_data = bulk_subscript_not_exist_field(field_meta, size);
         } else {
             field_data = bulk_subscript(
@@ -9111,7 +9163,10 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
     bool ignore_non_pk,
     bool fill_ids,
     milvus::OpContext* op_ctx) const {
-    auto snapshot = CapturePublishedState();
+    // Resolve the operation's pinned snapshot (installed by RetrieveByOffsets
+    // via PinOpSnapshot) so the take path reads the same published state -
+    // and therefore the same column layout - as the rest of the retrieve.
+    auto snapshot = CapturePublishedState(op_ctx);
     auto schema_snapshot = snapshot->schema;
     if (size == 0 || !snapshot->use_take_for_output) {
         return false;
@@ -9401,7 +9456,7 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
                                            int64_t size,
                                            SearchResult& results,
                                            milvus::OpContext* op_ctx) const {
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto schema_snapshot = snapshot->schema;
     if (size == 0 || !snapshot->use_take_for_output) {
         return false;
@@ -9579,7 +9634,7 @@ void
 ChunkedSegmentSealedImpl::prefetch_vector(milvus::OpContext* op_ctx,
                                           FieldId field_id) const {
     std::shared_lock vector_state_lck(mutex_);
-    auto runtime = CaptureRuntimeResourceState();
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
     auto vector_entry = GetVectorIndexing(runtime, field_id);
     if (vector_entry != nullptr) {
         SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -242,60 +242,11 @@ cancel_and_erase_scalar_index(
     }
 }
 
-static inline void
-cancel_and_clear_scalar_indexings(
-    std::unordered_map<FieldId, index::CacheIndexBasePtr>& scalar_indexings) {
-    for (auto& [_, index] : scalar_indexings) {
-        cancel_warmup(index);
-    }
-    scalar_indexings.clear();
-}
-
-static inline void
-cancel_and_erase_ngram_index(
-    std::unordered_map<
-        FieldId,
-        std::unordered_map<std::string, index::CacheIndexBasePtr>>&
-        ngram_indexings,
-    FieldId field_id,
-    const std::string& nested_path) {
-    auto field_it = ngram_indexings.find(field_id);
-    if (field_it == ngram_indexings.end()) {
-        return;
-    }
-
-    auto& path_indexings = field_it->second;
-    if (auto path_it = path_indexings.find(nested_path);
-        path_it != path_indexings.end()) {
-        cancel_warmup(path_it->second);
-        path_indexings.erase(path_it);
-    }
-
-    if (path_indexings.empty()) {
-        ngram_indexings.erase(field_it);
-    }
-}
-
-static inline void
-cancel_and_clear_ngram_indexings(
-    std::unordered_map<
-        FieldId,
-        std::unordered_map<std::string, index::CacheIndexBasePtr>>&
-        ngram_indexings) {
-    for (auto& [_, path_indexings] : ngram_indexings) {
-        for (auto& [__, index] : path_indexings) {
-            cancel_warmup(index);
-        }
-    }
-    ngram_indexings.clear();
-}
-
 PinWrapper<const storagev2translator::TimestampIndexCell*>
 ChunkedSegmentSealedImpl::PinTimestampIndex(
     const std::shared_ptr<const RuntimeResourceState>& runtime,
     milvus::OpContext* op_ctx) const {
-    auto slot = runtime != nullptr ? runtime->timestamp_index_slot
-                                   : *timestamp_index_slot_.rlock();
+    auto slot = runtime != nullptr ? runtime->timestamp_index_slot : nullptr;
     if (!slot) {
         return PinWrapper<const storagev2translator::TimestampIndexCell*>(
             nullptr);
@@ -309,7 +260,7 @@ ChunkedSegmentSealedImpl::PinTimestampIndex(
 
 PinWrapper<const storagev2translator::TimestampIndexCell*>
 ChunkedSegmentSealedImpl::PinTimestampIndex(milvus::OpContext* op_ctx) const {
-    return PinTimestampIndex(CaptureRuntimeResourceState(), op_ctx);
+    return PinTimestampIndex(CaptureRuntimeResourceState(op_ctx), op_ctx);
 }
 
 Timestamp
@@ -895,7 +846,7 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
                 info.index_size,
                 info.index_params,
                 info.enable_mmap,
-                num_rows_.value_or(0));
+                target_runtime->row_count);
     }
 
     request.has_raw_data =
@@ -970,6 +921,10 @@ ChunkedSegmentSealedImpl::PinOpSnapshot(milvus::OpContext* op_ctx) const {
     if (op_ctx == nullptr) {
         return;
     }
+    if (op_ctx->pinned_state_owner == this &&
+        op_ctx->pinned_segment_state != nullptr) {
+        return;
+    }
     // Eager capture of the live state (one atomic load) as the operation's
     // birthline. All later Capture*(op_ctx) reads return this exact snapshot.
     auto state = CapturePublishedState();
@@ -1007,6 +962,9 @@ ChunkedSegmentSealedImpl::CloneRuntimeResourceState(
     state->timestamp_index_slot = current->timestamp_index_slot;
     state->pk_index_slot = current->pk_index_slot;
     state->virtual_pk2offset = current->virtual_pk2offset;
+    state->mmap_field_ids = current->mmap_field_ids;
+    state->variable_fields_avg_size = current->variable_fields_avg_size;
+    state->row_count = current->row_count;
     return state;
 }
 
@@ -1403,6 +1361,9 @@ ChunkedSegmentSealedImpl::FreezeRuntimeResourceState(
     runtime->timestamp_index_slot = current.timestamp_index_slot;
     runtime->pk_index_slot = current.pk_index_slot;
     runtime->virtual_pk2offset = current.virtual_pk2offset;
+    runtime->mmap_field_ids = current.mmap_field_ids;
+    runtime->variable_fields_avg_size = current.variable_fields_avg_size;
+    runtime->row_count = current.row_count;
     return ToConstRuntimeState(std::move(runtime));
 }
 
@@ -2241,7 +2202,7 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
         runtime->timestamp_index_slot.reset();
         {
             std::unique_lock lck(mutex_);
-            update_row_count(0);
+            update_row_count(*runtime, 0);
         }
         return;
     }
@@ -2290,7 +2251,7 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
     // Row count
     {
         std::unique_lock lck(mutex_);
-        update_row_count(num_rows);
+        update_row_count(*runtime, num_rows);
     }
 }
 
@@ -2817,9 +2778,14 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
 
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
+    auto visible_runtime_owner =
+        runtime == nullptr ? CaptureRuntimeResourceState() : nullptr;
+    auto visible_runtime =
+        runtime != nullptr ? runtime : visible_runtime_owner.get();
     AssertInfo(
-        !num_rows_.has_value() || num_rows_ == num_rows,
-        "num_rows_ is set but not equal to num_rows of LoadFieldDataInfo");
+        visible_runtime == nullptr || visible_runtime->row_count == 0 ||
+            visible_runtime->row_count == num_rows,
+        "published row count is not equal to num_rows of LoadFieldDataInfo");
 
     for (auto& [id, info] : load_info.field_infos) {
         AssertInfo(info.row_count > 0, "The row count of field data is 0");
@@ -2929,9 +2895,10 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
 
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
+    auto* staged_runtime = committer.runtime();
     AssertInfo(
-        !num_rows_.has_value() || num_rows_ == num_rows,
-        "num_rows_ is set but not equal to num_rows of LoadFieldDataInfo");
+        staged_runtime->row_count == 0 || staged_runtime->row_count == num_rows,
+        "staged row count is not equal to num_rows of LoadFieldDataInfo");
 
     for (auto& [id, info] : load_info.field_infos) {
         AssertInfo(info.row_count > 0, "The row count of field data is 0");
@@ -3002,6 +2969,8 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                     runtime.timestamps = std::move(timestamp_data);
                     runtime.timestamp_index = std::move(timestamp_index);
                     runtime.timestamp_index_slot.reset();
+                    std::unique_lock lck(mutex_);
+                    update_row_count(runtime, num_rows);
                     stats_.mem_size += sizeof(Timestamp) * num_rows;
                 });
             } else {
@@ -3010,8 +2979,11 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                 std::shared_ptr<milvus::ArrowDataWrapper> r;
                 while (field_data_info.arrow_reader_channel->pop(r)) {
                 }
-                std::unique_lock lck(mutex_);
-                update_row_count(num_rows);
+                committer.Commit([this, num_rows](RuntimeResourceState& runtime,
+                                                  PublishedSegmentState&) {
+                    std::unique_lock lck(mutex_);
+                    update_row_count(runtime, num_rows);
+                });
             }
             LOG_INFO("segment {} loads system field {} mmap false done",
                      this->get_segment_id(),
@@ -3075,6 +3047,12 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
     SCOPE_CGO_CALL_METRIC();
 
     auto num_rows = data.row_count;
+    std::shared_ptr<RuntimeResourceState> owned_runtime;
+    auto* target_runtime = runtime;
+    if (target_runtime == nullptr) {
+        owned_runtime = CloneMutableRuntimeResourceState();
+        target_runtime = owned_runtime.get();
+    }
     AssertInfo(SystemProperty::Instance().IsSystem(field_id),
                "system field is not system field");
     auto system_field_type =
@@ -3100,10 +3078,7 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
             std::fill(timestamps.begin(), timestamps.end(), commit_ts_);
         }
         init_storage_v1_timestamp_index(
-            std::move(timestamps), num_rows, runtime);
-        if (publish_ready) {
-            PublishSystemFieldStateLocked();
-        }
+            std::move(timestamps), num_rows, target_runtime);
     } else {
         AssertInfo(system_field_type == SystemFieldType::RowId,
                    "System field type of id column is not RowId");
@@ -3115,7 +3090,11 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
     }
     {
         std::unique_lock lck(mutex_);
-        update_row_count(num_rows);
+        update_row_count(*target_runtime, num_rows);
+    }
+    if (owned_runtime != nullptr && publish_ready) {
+        PublishRuntimeStateLocked(
+            ToConstRuntimeState(std::move(owned_runtime)));
     }
 }
 
@@ -3171,8 +3150,8 @@ ChunkedSegmentSealedImpl::num_chunk(FieldId field_id,
 }
 
 int64_t
-ChunkedSegmentSealedImpl::size_per_chunk() const {
-    return get_row_count();
+ChunkedSegmentSealedImpl::size_per_chunk(milvus::OpContext* op_ctx) const {
+    return get_row_count(op_ctx);
 }
 
 int64_t
@@ -3184,7 +3163,8 @@ ChunkedSegmentSealedImpl::chunk_size(FieldId field_id,
         return 0;
     }
     auto column = get_column(snapshot->runtime, field_id);
-    return column ? column->chunk_row_nums(chunk_id) : num_rows_.value();
+    return column ? column->chunk_row_nums(chunk_id)
+                  : snapshot->runtime->row_count;
 }
 
 std::pair<int64_t, int64_t>
@@ -3211,9 +3191,11 @@ ChunkedSegmentSealedImpl::num_rows_until_chunk(
 }
 
 bool
-ChunkedSegmentSealedImpl::is_mmap_field(FieldId field_id) const {
-    std::shared_lock lck(mutex_);
-    return mmap_field_ids_.find(field_id) != mmap_field_ids_.end();
+ChunkedSegmentSealedImpl::is_mmap_field(FieldId field_id,
+                                        milvus::OpContext* op_ctx) const {
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
+    return runtime != nullptr && runtime->mmap_field_ids.find(field_id) !=
+                                     runtime->mmap_field_ids.end();
 }
 
 void
@@ -3451,9 +3433,61 @@ ChunkedSegmentSealedImpl::GetNgramIndexForJson(
 }
 
 int64_t
-ChunkedSegmentSealedImpl::get_row_count() const {
-    std::shared_lock lck(mutex_);
-    return num_rows_.value_or(0);
+ChunkedSegmentSealedImpl::get_row_count(milvus::OpContext* op_ctx) const {
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
+    return runtime != nullptr ? runtime->row_count : 0;
+}
+
+int64_t
+ChunkedSegmentSealedImpl::get_field_avg_size(FieldId field_id,
+                                             milvus::OpContext* op_ctx) const {
+    AssertInfo(field_id.get() >= 0,
+               "invalid field id, should be greater than or equal to 0");
+    if (SystemProperty::Instance().IsSystem(field_id)) {
+        if (field_id == TimestampFieldID || field_id == RowFieldID) {
+            return sizeof(int64_t);
+        }
+        ThrowInfo(FieldIDInvalid, "unsupported system field id");
+    }
+
+    auto snapshot = CapturePublishedState(op_ctx);
+    auto& field_meta = snapshot->schema->operator[](field_id);
+    if (!IsVariableDataType(field_meta.get_data_type())) {
+        return field_meta.get_sizeof();
+    }
+    if (snapshot->runtime == nullptr) {
+        return 0;
+    }
+    auto it = snapshot->runtime->variable_fields_avg_size.find(field_id);
+    return it != snapshot->runtime->variable_fields_avg_size.end()
+               ? it->second.second
+               : 0;
+}
+
+void
+ChunkedSegmentSealedImpl::set_field_avg_size(FieldId field_id,
+                                             int64_t num_rows,
+                                             int64_t field_size) {
+    AssertInfo(field_id.get() >= 0,
+               "invalid field id, should be greater than or equal to 0");
+    AssertInfo(num_rows > 0,
+               "The num rows of field data should be greater than 0");
+
+    std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+    auto current = CapturePublishedState();
+    auto& field_meta = current->schema->operator[](field_id);
+    if (!IsVariableDataType(field_meta.get_data_type())) {
+        return;
+    }
+
+    auto runtime = CloneRuntimeResourceState(current->runtime);
+    auto& field_info = runtime->variable_fields_avg_size[field_id];
+    auto size = field_info.first * field_info.second + field_size;
+    field_info.first += num_rows;
+    field_info.second = size / field_info.first;
+    auto next = ClonePublishedState(current);
+    next->runtime = ToConstRuntimeState(std::move(runtime));
+    PublishState(std::move(next));
 }
 
 int64_t
@@ -3541,8 +3575,10 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
         AssertInfo(
             get_bit(snapshot->field_data_ready_bitset, field_id),
             "Field Data is not loaded: " + std::to_string(field_id.get()));
-        AssertInfo(num_rows_.has_value(), "Can't get row count value");
-        auto row_count = num_rows_.value();
+        AssertInfo(
+            snapshot->runtime != nullptr && snapshot->runtime->row_count > 0,
+            "Can't get row count value");
+        auto row_count = snapshot->runtime->row_count;
         auto vec_data = get_column(snapshot->runtime, field_id);
         AssertInfo(
             vec_data != nullptr, "vector field {} not loaded", field_id.get());
@@ -3829,19 +3865,25 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
 void
 ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id) {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
-    auto snapshot = CapturePublishedState();
-    DropFieldData(field_id, snapshot->schema);
+    auto current = CapturePublishedState();
+    DropFieldData(field_id, current->schema, nullptr, current);
 }
 
 void
-ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id,
-                                        const SchemaPtr& schema_snapshot,
-                                        RuntimeResourceState* runtime) {
+ChunkedSegmentSealedImpl::DropFieldData(
+    const FieldId field_id,
+    const SchemaPtr& schema_snapshot,
+    RuntimeResourceState* runtime,
+    const std::shared_ptr<const PublishedSegmentState>& current_snapshot) {
     AssertInfo(!SystemProperty::Instance().IsSystem(field_id),
                "Dropping system field is not supported, field id: {}",
                field_id.get());
-    auto snapshot = CapturePublishedState();
+    auto snapshot = current_snapshot;
+    if (snapshot == nullptr && runtime == nullptr) {
+        snapshot = CapturePublishedState();
+    }
     bool has_binlog_index =
+        snapshot != nullptr &&
         has_bit_position(snapshot->binlog_index_bitset, field_id) &&
         get_bit(snapshot->binlog_index_bitset, field_id);
     auto schema_has_field = field_exists_in_schema(schema_snapshot, field_id);
@@ -3854,7 +3896,7 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id,
         LOG_INFO(
             "Skip dropping pk field {} in segment {}", field_id.get(), id_);
         if (runtime == nullptr && has_binlog_index) {
-            auto next_runtime = CloneMutableRuntimeResourceState();
+            auto next_runtime = CloneRuntimeResourceState(snapshot->runtime);
             DropVectorIndexing(*next_runtime, field_id);
             next_runtime->vec_binlog_config.erase(field_id);
             auto published_runtime =
@@ -3873,17 +3915,36 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id,
         return;
     }
 
-    auto old_column = get_column(field_id);
+    std::shared_ptr<ChunkedColumnInterface> old_column;
+    if (runtime != nullptr) {
+        auto it = runtime->fields.find(field_id);
+        if (it != runtime->fields.end()) {
+            old_column = it->second;
+        }
+    } else {
+        old_column = get_column(snapshot->runtime, field_id);
+    }
     if (old_column) {
         old_column->CancelWarmup();
     }
     if (runtime != nullptr) {
         runtime->fields.erase(field_id);
         runtime->array_offsets_map.erase(field_id);
+        runtime->mmap_field_ids.erase(field_id);
+        // Raw data may be reclaimed while an index with raw data still serves
+        // retrieval.  Keep the field-size estimate until the schema itself no
+        // longer contains the field.
+        if (!schema_has_field) {
+            runtime->variable_fields_avg_size.erase(field_id);
+        }
     } else {
-        auto next_runtime = CloneMutableRuntimeResourceState();
+        auto next_runtime = CloneRuntimeResourceState(snapshot->runtime);
         next_runtime->fields.erase(field_id);
         next_runtime->array_offsets_map.erase(field_id);
+        next_runtime->mmap_field_ids.erase(field_id);
+        if (!schema_has_field) {
+            next_runtime->variable_fields_avg_size.erase(field_id);
+        }
         if (has_binlog_index) {
             DropVectorIndexing(*next_runtime, field_id);
             next_runtime->vec_binlog_config.erase(field_id);
@@ -3988,11 +4049,12 @@ ChunkedSegmentSealedImpl::check_search(const query::Plan* plan) const {
 
 void
 ChunkedSegmentSealedImpl::search_pks(BitsetType& bitset,
-                                     const std::vector<PkType>& pks) const {
+                                     const std::vector<PkType>& pks,
+                                     milvus::OpContext* op_ctx) const {
     if (pks.empty()) {
         return;
     }
-    auto snapshot = CapturePublishedState();
+    auto snapshot = CapturePublishedState(op_ctx);
     auto runtime = snapshot->runtime;
     BitsetTypeView bitset_view(bitset);
 
@@ -4008,7 +4070,7 @@ ChunkedSegmentSealedImpl::search_pks(BitsetType& bitset,
     }
 
     if (!is_sorted_by_pk_) {
-        auto pk_index = PinPkIndex(runtime, nullptr);
+        auto pk_index = PinPkIndex(runtime, op_ctx);
         auto* pk_cell = pk_index.get();
         AssertInfo(pk_cell != nullptr && pk_cell->has_pk2offset(),
                    "primary key index is not ready");
@@ -4338,20 +4400,21 @@ ChunkedSegmentSealedImpl::pk_binary_range(milvus::OpContext* op_ctx,
 
 std::pair<std::vector<OffsetMap::OffsetType>, bool>
 ChunkedSegmentSealedImpl::find_first_n(int64_t limit,
-                                       const BitsetTypeView& bitset) const {
-    auto runtime = CaptureRuntimeResourceState();
+                                       const BitsetTypeView& bitset,
+                                       milvus::OpContext* op_ctx) const {
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
     if (runtime != nullptr && runtime->virtual_pk2offset != nullptr) {
         return runtime->virtual_pk2offset->find_first_n(limit, bitset);
     }
     if (!is_sorted_by_pk_) {
-        auto pk_index = PinPkIndex(runtime, nullptr);
+        auto pk_index = PinPkIndex(runtime, op_ctx);
         auto* pk_cell = pk_index.get();
         AssertInfo(pk_cell != nullptr && pk_cell->has_pk2offset(),
                    "primary key index is not ready");
         return pk_cell->pk2offset().find_first_n(limit, bitset);
     }
     if (limit == Unlimited || limit == NoLimit) {
-        limit = num_rows_.value();
+        limit = runtime->row_count;
     }
 
     int64_t hit_num = 0;  // avoid counting the number everytime.
@@ -4383,15 +4446,16 @@ ChunkedSegmentSealedImpl::find_first_n_element(
     int64_t limit,
     const BitsetTypeView& element_bitset,
     const IArrayOffsets* array_offsets,
-    const std::optional<QueryIteratorCursor>& cursor) const {
-    auto snapshot = CapturePublishedState();
+    const std::optional<QueryIteratorCursor>& cursor,
+    milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
     auto runtime = snapshot->runtime;
     if (runtime != nullptr && runtime->virtual_pk2offset != nullptr) {
         return runtime->virtual_pk2offset->find_first_n_element(
             limit, element_bitset, array_offsets, cursor);
     }
     if (!is_sorted_by_pk_) {
-        auto pk_index = PinPkIndex(runtime, nullptr);
+        auto pk_index = PinPkIndex(runtime, op_ctx);
         auto* pk_cell = pk_index.get();
         AssertInfo(pk_cell != nullptr && pk_cell->has_pk2offset(),
                    "primary key index is not ready");
@@ -4482,9 +4546,6 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
     int64_t segment_id,
     bool is_sorted_by_pk)
     : segcore_config_(segcore_config),
-      ngram_fields_(std::unordered_set<FieldId>(schema->size())),
-      scalar_indexings_(std::unordered_map<FieldId, index::CacheIndexBasePtr>(
-          schema->size())),
       mmap_descriptor_(storage::MmapManager::GetInstance()
                            .GetMmapChunkManager()
                            ->Register()),
@@ -4662,8 +4723,8 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
             auto* dst = static_cast<Timestamp*>(output);
             // Import/CDC segments: every row carries commit_ts_, including
             // v2/v3 column-group segments where the raw timestamp column is
-            // emplaced into fields_ but never overwritten. Short-circuit
-            // before consulting the column.
+            // retained in the published runtime but never overwritten.
+            // Short-circuit before consulting the column.
             auto runtime = snapshot->runtime;
             auto effective_commit_ts =
                 snapshot->commit_ts != 0
@@ -4695,9 +4756,8 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                          bool small_int_raw_type) const {
     auto snapshot = CapturePublishedState(op_ctx);
     auto& field_meta = snapshot->schema->operator[](field_id);
-    // DO NOT directly access the column by map like: `fields_.at(field_id)->Data()`,
-    // we have to clone the shared pointer, to make sure it won't get released
-    // if segment released
+    // Keep a shared column handle from the captured runtime so segment release
+    // cannot invalidate the column while this call is using it.
     auto column = get_column(snapshot->runtime, field_id);
     AssertInfo(column != nullptr,
                "field {} must exist when doing bulk_subscript",
@@ -5030,6 +5090,9 @@ ChunkedSegmentSealedImpl::ClearData() {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
     auto runtime_snapshot = CaptureRuntimeResourceState();
     if (runtime_snapshot != nullptr) {
+        for (const auto& [_, indexing] : runtime_snapshot->scalar_indexings) {
+            cancel_warmup(indexing);
+        }
         for (const auto& [_, entry] : runtime_snapshot->vector_indexings) {
             if (entry != nullptr && entry->indexing_ != nullptr) {
                 entry->indexing_->CancelWarmup();
@@ -5047,17 +5110,6 @@ ChunkedSegmentSealedImpl::ClearData() {
     }
     {
         std::unique_lock lck(mutex_);
-        num_rows_ = std::nullopt;
-        ngram_fields_.wlock()->clear();
-        scalar_indexings_.withWLock([&](auto& scalar_indexings) {
-            cancel_and_clear_scalar_indexings(scalar_indexings);
-        });
-        ngram_indexings_.withWLock([&](auto& ngram_indexings) {
-            cancel_and_clear_ngram_indexings(ngram_indexings);
-        });
-        timestamp_index_slot_.wlock()->reset();
-        fields_.wlock()->clear();
-        variable_fields_avg_size_.clear();
         stats_.mem_size = 0;
     }
     ClearPublishedStateLocked();
@@ -5605,6 +5657,10 @@ ChunkedSegmentSealedImpl::FillPrimaryKeys(const query::Plan* plan,
                     local_ctx.cancellation_token = op_ctx->cancellation_token;
                     local_ctx.runtime_load_priority =
                         op_ctx->runtime_load_priority;
+                    local_ctx.pinned_segment_state =
+                        op_ctx->pinned_segment_state;
+                    local_ctx.pinned_state_owner =
+                        op_ctx->pinned_state_owner;
                 }
                 // Intentionally bypass bulk_subscript's scalar-index raw-data
                 // routing here: the sealed VARCHAR PK fast path reads the
@@ -5639,9 +5695,8 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
                                        const FieldMeta& field_meta,
                                        const int64_t* seg_offsets,
                                        int64_t count) const {
-    // DO NOT directly access the column by map like: `fields_.at(field_id)->Data()`,
-    // we have to clone the shared pointer,
-    // to make sure it won't get released if segment released
+    // Keep a shared column handle from the captured runtime so segment release
+    // cannot invalidate the column while this call is using it.
     auto column = get_column(field_id, op_ctx);
     AssertInfo(column != nullptr,
                "field {} must exist when getting raw data",
@@ -6268,8 +6323,9 @@ ChunkedSegmentSealedImpl::GetFieldDataType(milvus::FieldId field_id,
 
 void
 ChunkedSegmentSealedImpl::search_ids(BitsetType& bitset,
-                                     const IdArray& id_array) const {
-    auto schema_snapshot = CaptureSchemaSnapshot();
+                                     const IdArray& id_array,
+                                     milvus::OpContext* op_ctx) const {
+    auto schema_snapshot = CaptureSchemaSnapshot(op_ctx);
     auto field_id =
         schema_snapshot->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(field_id.get() != -1, "Primary key is -1");
@@ -6279,7 +6335,7 @@ ChunkedSegmentSealedImpl::search_ids(BitsetType& bitset,
     std::vector<PkType> pks(ids_size);
     ParsePksFromIDs(pks, data_type, id_array);
 
-    this->search_pks(bitset, pks);
+    this->search_pks(bitset, pks, op_ctx);
 }
 
 SegcoreError
@@ -6348,9 +6404,10 @@ ChunkedSegmentSealedImpl::LoadSegmentMeta(
 }
 
 int64_t
-ChunkedSegmentSealedImpl::get_active_count(Timestamp ts) const {
+ChunkedSegmentSealedImpl::get_active_count(Timestamp ts,
+                                           milvus::OpContext* op_ctx) const {
     // TODO optimize here to reduce expr search range
-    return this->get_row_count();
+    return this->get_row_count(op_ctx);
 }
 
 // Helper: apply a per-element timestamp scan over a range [beg, end),
@@ -6408,20 +6465,25 @@ scan_timestamp_range(const ChunkedColumnInterface& column,
 }
 
 void
-ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
-                                               Timestamp timestamp,
-                                               Timestamp collection_ttl) const {
-    auto schema_snapshot = CaptureSchemaSnapshot();
+ChunkedSegmentSealedImpl::mask_with_timestamps(
+    BitsetTypeView& bitset_chunk,
+    Timestamp timestamp,
+    Timestamp collection_ttl,
+    milvus::OpContext* op_ctx) const {
+    auto snapshot = CapturePublishedState(op_ctx);
+    auto schema_snapshot = snapshot->schema;
     // External collections have no timestamps; all data is always visible
     if (schema_snapshot->is_external_collection()) {
         return;
     }
-    auto runtime = CaptureRuntimeResourceState();
+    auto runtime = snapshot->runtime;
     AssertInfo(runtime != nullptr && runtime->timestamp_index != nullptr,
                "timestamp index is not ready");
     auto& ts_index_data = *runtime->timestamp_index;
-    auto effective_commit_ts = EffectiveCommitTs();
-    auto total_size = static_cast<int64_t>(get_row_count());
+    auto effective_commit_ts =
+        snapshot->commit_ts != 0 ? std::optional<Timestamp>{snapshot->commit_ts}
+                                 : std::nullopt;
+    auto total_size = static_cast<int64_t>(get_row_count(op_ctx));
 
     auto do_scan = [&](int64_t beg, int64_t end, auto pred) {
         for (int64_t i = beg; i < end; ++i) {
@@ -6447,10 +6509,10 @@ ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
         }
     }
 
-    AssertInfo(total_size == get_row_count(),
+    AssertInfo(total_size == get_row_count(op_ctx),
                fmt::format("Timestamp size not equal to row count: {}, {}",
                            total_size,
-                           get_row_count()));
+                           get_row_count(op_ctx)));
     auto range = ts_index_data.get_active_range(timestamp);
 
     // range == (size_, size_): all data is useful, no filtering needed.
@@ -6776,13 +6838,6 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     bool is_replace,
     StagedStateCommitter* committer) {
     auto snapshot = CapturePublishedState();
-
-    if (!enable_mmap) {
-        if (IsVariableDataType(data_type)) {
-            SegmentInternalInterface::set_field_avg_size(
-                field_id, num_rows, column->DataByteSize());
-        }
-    }
     if (!IsVariableDataType(data_type) || IsStringDataType(data_type)) {
         if (statistics) {
             LoadSkipIndexFromStatistics(
@@ -6836,6 +6891,19 @@ ChunkedSegmentSealedImpl::load_field_data_common(
             const PublishedSegmentState& state_snapshot) {
             prepare_array_offsets(target_runtime);
 
+            if (IsVariableDataType(data_type)) {
+                if (enable_mmap) {
+                    target_runtime.variable_fields_avg_size.erase(field_id);
+                } else {
+                    auto& field_info =
+                        target_runtime.variable_fields_avg_size[field_id];
+                    auto total_size = field_info.first * field_info.second +
+                                      column->DataByteSize();
+                    field_info.first += num_rows;
+                    field_info.second = total_size / field_info.first;
+                }
+            }
+
             if (is_primary_field) {
                 target_runtime.pk_index_slot = pk_index_slot;
                 target_runtime.virtual_pk2offset.reset();
@@ -6867,7 +6935,9 @@ ChunkedSegmentSealedImpl::load_field_data_common(
             }
 
             if (enable_mmap) {
-                mmap_field_ids_.insert(field_id);
+                target_runtime.mmap_field_ids.insert(field_id);
+            } else {
+                target_runtime.mmap_field_ids.erase(field_id);
             }
 
             if (!SystemProperty::Instance().IsSystem(field_id)) {
@@ -6884,7 +6954,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
                                "field {} data already loaded",
                                field_id.get());
                 }
-                update_row_count(num_rows);
+                update_row_count(target_runtime, num_rows);
             }
         };
 
@@ -7460,7 +7530,7 @@ ChunkedSegmentSealedImpl::fill_empty_field(
         milvus::storage::LocalChunkManagerSingleton::GetInstance()
             .GetChunkManager()
             ->GetRootPath();
-    int64_t size = num_rows_.value();
+    int64_t size = runtime.row_count;
     AssertInfo(size > 0, "Chunked Sealed segment must have more than 0 row");
     auto field_data_info = FieldDataInfo(field_id.get(),
                                          size,
@@ -7483,6 +7553,11 @@ ChunkedSegmentSealedImpl::fill_empty_field(
     auto column = MakeChunkedColumnBase(data_type, std::move(slot), field_meta);
 
     runtime.fields.emplace(field_id, column);
+    if (use_mmap) {
+        runtime.mmap_field_ids.insert(field_id);
+    } else {
+        runtime.mmap_field_ids.erase(field_id);
+    }
     LOG_INFO(
         "fill empty field {} (data type {}) for growing segment {} "
         "done",
@@ -7546,7 +7621,7 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
         fill_empty_field(
             field_meta, schema_snapshot, segment_load_info, *target_runtime);
         EnsureArrayOffsetsForStructField(
-            field_meta, num_rows_.value_or(0), *target_runtime);
+            field_meta, target_runtime->row_count, *target_runtime);
         filled_fields.push_back(field_id);
     }
 
@@ -7614,7 +7689,7 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
             milvus::storage::LocalChunkManagerSingleton::GetInstance()
                 .GetChunkManager()
                 ->GetRootPath();
-        int64_t size = num_rows_.value();
+        int64_t size = committer.runtime()->row_count;
         AssertInfo(size > 0,
                    "Chunked Sealed segment must have more than 0 row");
         auto field_data_info =
@@ -7650,8 +7725,23 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
             for (auto& [field_meta, column] : fields_to_commit) {
                 auto field_id = field_meta.get_id();
                 runtime.fields.emplace(field_id, std::move(column));
+                auto [field_has_setting, field_mmap_enabled] =
+                    schema_snapshot->MmapEnabled(field_id);
+                auto is_vector = IsVectorDataType(field_meta.get_data_type());
+                auto& mmap_config =
+                    storage::MmapManager::GetInstance().GetMmapConfig();
+                bool global_use_mmap =
+                    is_vector ? mmap_config.GetVectorFieldEnableMmap()
+                              : mmap_config.GetScalarFieldEnableMmap();
+                bool use_mmap =
+                    field_has_setting ? field_mmap_enabled : global_use_mmap;
+                if (use_mmap) {
+                    runtime.mmap_field_ids.insert(field_id);
+                } else {
+                    runtime.mmap_field_ids.erase(field_id);
+                }
                 EnsureArrayOffsetsForStructField(
-                    field_meta, num_rows_.value_or(0), runtime);
+                    field_meta, runtime.row_count, runtime);
                 LOG_INFO(
                     "fill empty field {} (data type {}) for growing segment {} "
                     "done",
@@ -9302,8 +9392,7 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
             auto system_type =
                 SystemProperty::Instance().GetSystemFieldType(field_id);
             FixedVector<int64_t> output(size);
-            milvus::OpContext op_ctx;
-            bulk_subscript(&op_ctx, system_type, offsets, size, output.data());
+            bulk_subscript(op_ctx, system_type, offsets, size, output.data());
             auto data_array = std::make_unique<DataArray>();
             data_array->set_field_id(field_id.get());
             data_array->set_type(milvus::proto::schema::DataType::Int64);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -351,8 +351,10 @@ ChunkedSegmentSealedImpl::PinJsonIndex(milvus::OpContext* op_ctx,
 
 std::string
 ChunkedSegmentSealedImpl::GetJsonFlatIndexNestedPath(
-    FieldId field_id, std::string_view query_path) const {
-    auto runtime = CaptureRuntimeResourceState();
+    FieldId field_id,
+    std::string_view query_path,
+    milvus::OpContext* op_ctx) const {
+    auto runtime = CaptureRuntimeResourceState(op_ctx);
     std::string best_path;
     int path_len_diff = std::numeric_limits<int>::max();
     for (const auto& index : runtime->json_indices) {
@@ -2200,10 +2202,7 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
         runtime->timestamps = std::move(timestamps);
         runtime->timestamp_index = std::make_shared<const TimestampIndex>();
         runtime->timestamp_index_slot.reset();
-        {
-            std::unique_lock lck(mutex_);
-            update_row_count(*runtime, 0);
-        }
+        update_row_count(*runtime, 0);
         return;
     }
 
@@ -2249,10 +2248,7 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
     }
 
     // Row count
-    {
-        std::unique_lock lck(mutex_);
-        update_row_count(*runtime, num_rows);
-    }
+    update_row_count(*runtime, num_rows);
 }
 
 void
@@ -2981,7 +2977,6 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                 }
                 committer.Commit([this, num_rows](RuntimeResourceState& runtime,
                                                   PublishedSegmentState&) {
-                    std::unique_lock lck(mutex_);
                     update_row_count(runtime, num_rows);
                 });
             }
@@ -3091,10 +3086,11 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
     {
         std::unique_lock lck(mutex_);
         update_row_count(*target_runtime, num_rows);
-    }
-    if (owned_runtime != nullptr && publish_ready) {
-        PublishRuntimeStateLocked(
-            ToConstRuntimeState(std::move(owned_runtime)));
+        if (owned_runtime != nullptr && publish_ready) {
+            SyncDeletedRecordRowCount(*target_runtime);
+            PublishRuntimeStateLocked(
+                ToConstRuntimeState(std::move(owned_runtime)));
+        }
     }
 }
 
@@ -5659,8 +5655,7 @@ ChunkedSegmentSealedImpl::FillPrimaryKeys(const query::Plan* plan,
                         op_ctx->runtime_load_priority;
                     local_ctx.pinned_segment_state =
                         op_ctx->pinned_segment_state;
-                    local_ctx.pinned_state_owner =
-                        op_ctx->pinned_state_owner;
+                    local_ctx.pinned_state_owner = op_ctx->pinned_state_owner;
                 }
                 // Intentionally bypass bulk_subscript's scalar-index raw-data
                 // routing here: the sealed VARCHAR PK fast path reads the
@@ -6185,8 +6180,8 @@ ChunkedSegmentSealedImpl::HasFieldData(FieldId field_id,
 // Checks the cached loaded manifest instead of field-data/index bitsets.
 bool
 ChunkedSegmentSealedImpl::HasColumnInLoadedManifest(
-    const std::string& column_name) const {
-    auto load_info = CaptureLoadInfoSnapshot();
+    const std::string& column_name, milvus::OpContext* op_ctx) const {
+    auto load_info = CaptureLoadInfoSnapshot(op_ctx);
     if (load_info == nullptr || !load_info->HasManifestPath()) {
         return true;
     }
@@ -6999,6 +6994,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     apply_loaded_column(*next_runtime, old_column, *current);
 
     auto published_runtime = ToConstRuntimeState(std::move(next_runtime));
+    SyncDeletedRecordRowCount(*published_runtime);
     if (SystemProperty::Instance().IsSystem(field_id)) {
         PublishRuntimeStateLocked(published_runtime);
     } else {
@@ -7720,36 +7716,36 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
         return;
     }
 
-    committer.Commit(
-        [&](RuntimeResourceState& runtime, PublishedSegmentState&) {
-            for (auto& [field_meta, column] : fields_to_commit) {
-                auto field_id = field_meta.get_id();
-                runtime.fields.emplace(field_id, std::move(column));
-                auto [field_has_setting, field_mmap_enabled] =
-                    schema_snapshot->MmapEnabled(field_id);
-                auto is_vector = IsVectorDataType(field_meta.get_data_type());
-                auto& mmap_config =
-                    storage::MmapManager::GetInstance().GetMmapConfig();
-                bool global_use_mmap =
-                    is_vector ? mmap_config.GetVectorFieldEnableMmap()
-                              : mmap_config.GetScalarFieldEnableMmap();
-                bool use_mmap =
-                    field_has_setting ? field_mmap_enabled : global_use_mmap;
-                if (use_mmap) {
-                    runtime.mmap_field_ids.insert(field_id);
-                } else {
-                    runtime.mmap_field_ids.erase(field_id);
-                }
-                EnsureArrayOffsetsForStructField(
-                    field_meta, runtime.row_count, runtime);
-                LOG_INFO(
-                    "fill empty field {} (data type {}) for growing segment {} "
-                    "done",
-                    field_meta.get_data_type(),
-                    field_id.get(),
-                    id_);
+    committer.Commit([&](RuntimeResourceState& runtime,
+                         PublishedSegmentState&) {
+        for (auto& [field_meta, column] : fields_to_commit) {
+            auto field_id = field_meta.get_id();
+            runtime.fields.emplace(field_id, std::move(column));
+            auto [field_has_setting, field_mmap_enabled] =
+                schema_snapshot->MmapEnabled(field_id);
+            auto is_vector = IsVectorDataType(field_meta.get_data_type());
+            auto& mmap_config =
+                storage::MmapManager::GetInstance().GetMmapConfig();
+            bool global_use_mmap = is_vector
+                                       ? mmap_config.GetVectorFieldEnableMmap()
+                                       : mmap_config.GetScalarFieldEnableMmap();
+            bool use_mmap =
+                field_has_setting ? field_mmap_enabled : global_use_mmap;
+            if (use_mmap) {
+                runtime.mmap_field_ids.insert(field_id);
+            } else {
+                runtime.mmap_field_ids.erase(field_id);
             }
-        });
+            EnsureArrayOffsetsForStructField(
+                field_meta, runtime.row_count, runtime);
+            LOG_INFO(
+                "fill empty field {} (data type {}) for growing segment {} "
+                "done",
+                field_meta.get_data_type(),
+                field_id.get(),
+                id_);
+        }
+    });
 }
 
 void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -58,7 +58,6 @@
 #include "common/protobuf_utils.h"
 #include "fmt/core.h"
 #include "folly/FBVector.h"
-#include "folly/Synchronized.h"
 #include "google/protobuf/message.h"
 #include "index/Index.h"
 #include "index/NgramInvertedIndex.h"
@@ -97,8 +96,9 @@ class TimestampIndex;
 using namespace milvus::cachinglayer;
 
 // Test-only accessor that pokes private members to simulate v2/v3 segment
-// state (raw timestamp column emplaced into fields_ alongside an overwritten
-// timestamp index). Defined in internal/core/unittest/test_commit_timestamp.cpp.
+// state (raw timestamp column retained in the published runtime alongside an
+// overwritten timestamp index). Defined in
+// internal/core/unittest/test_commit_timestamp.cpp.
 class CommitTimestampV2TestAccess;
 
 class ChunkedSegmentSealedImpl : public SegmentSealed {
@@ -165,22 +165,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                     PinWrapper<const index::IndexBase*>(std::move(ca), index)};
             }
         }
-
-        auto [scalar_indexings, ngram_fields] =
-            lock(folly::rlock(scalar_indexings_), folly::rlock(ngram_fields_));
-        if (!include_ngram) {
-            if (ngram_fields->find(field_id) != ngram_fields->end()) {
-                return {};
-            }
-        }
-
-        auto iter = scalar_indexings->find(field_id);
-        if (iter == scalar_indexings->end()) {
-            return {};
-        }
-        auto ca = SemiInlineGet(iter->second->PinCells(op_ctx, {0}));
-        auto index = ca->get_cell_of(0);
-        return {PinWrapper<const index::IndexBase*>(std::move(ca), index)};
+        return {};
     }
 
     std::vector<PinWrapper<const index::IndexBase*>>
@@ -380,6 +365,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         std::shared_ptr<CacheSlot<storagev2translator::PkIndexCell>>
             pk_index_slot;
         std::shared_ptr<const OffsetMap> virtual_pk2offset;
+        std::unordered_set<FieldId> mmap_field_ids;
+        std::unordered_map<FieldId, std::pair<int64_t, int64_t>>
+            variable_fields_avg_size;
+        int64_t row_count{0};
     };
 
     struct PublishedSegmentState {
@@ -430,7 +419,16 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     }
 
     int64_t
-    get_row_count() const override;
+    get_row_count(milvus::OpContext* op_ctx = nullptr) const override;
+
+    int64_t
+    get_field_avg_size(FieldId field_id,
+                       milvus::OpContext* op_ctx = nullptr) const override;
+
+    void
+    set_field_avg_size(FieldId field_id,
+                       int64_t num_rows,
+                       int64_t field_size) override;
 
     int64_t
     get_deleted_count() const override;
@@ -495,7 +493,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     }
 
     void
-    search_pks(BitsetType& bitset, const std::vector<PkType>& pks) const;
+    search_pks(BitsetType& bitset,
+               const std::vector<PkType>& pks,
+               milvus::OpContext* op_ctx = nullptr) const;
 
     void
     search_batch_pks(
@@ -529,7 +529,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     // return size_per_chunk for each chunk, renaming against confusion
     int64_t
-    size_per_chunk() const override;
+    size_per_chunk(milvus::OpContext* op_ctx = nullptr) const override;
 
     int64_t
     chunk_size(FieldId field_id,
@@ -552,14 +552,16 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
            const Timestamp* timestamps) override;
 
     std::pair<std::vector<OffsetMap::OffsetType>, bool>
-    find_first_n(int64_t limit, const BitsetTypeView& bitset) const override;
+    find_first_n(int64_t limit,
+                 const BitsetTypeView& bitset,
+                 milvus::OpContext* op_ctx = nullptr) const override;
 
     std::tuple<std::vector<int64_t>, std::vector<std::vector<int32_t>>, bool>
-    find_first_n_element(
-        int64_t limit,
-        const BitsetTypeView& element_bitset,
-        const IArrayOffsets* array_offsets,
-        const std::optional<QueryIteratorCursor>& cursor) const override;
+    find_first_n_element(int64_t limit,
+                         const BitsetTypeView& element_bitset,
+                         const IArrayOffsets* array_offsets,
+                         const std::optional<QueryIteratorCursor>& cursor,
+                         milvus::OpContext* op_ctx = nullptr) const override;
 
     // Calculate: output[i] = Vec[seg_offset[i]]
     // where Vec is determined from field_offset
@@ -578,7 +580,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::vector<std::string>& dynamic_field_names) const override;
 
     bool
-    is_mmap_field(FieldId id) const override;
+    is_mmap_field(FieldId id,
+                  milvus::OpContext* op_ctx = nullptr) const override;
 
     void
     ClearData() override;
@@ -727,7 +730,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     check_search(const query::Plan* plan) const override;
 
     int64_t
-    get_active_count(Timestamp ts) const override;
+    get_active_count(Timestamp ts,
+                     milvus::OpContext* op_ctx = nullptr) const override;
 
     const ConcurrentVector<Timestamp>&
     get_timestamps() const override {
@@ -1303,15 +1307,16 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                        int64_t count) const;
 
     void
-    update_row_count(int64_t row_count) {
-        num_rows_ = row_count;
+    update_row_count(RuntimeResourceState& runtime, int64_t row_count) {
+        runtime.row_count = row_count;
         deleted_record_.set_sealed_row_count(row_count);
     }
 
     void
     mask_with_timestamps(BitsetTypeView& bitset_chunk,
                          Timestamp timestamp,
-                         Timestamp collection_ttl) const override;
+                         Timestamp collection_ttl,
+                         milvus::OpContext* op_ctx = nullptr) const override;
 
     void
     vector_search(SearchInfo& search_info,
@@ -1332,7 +1337,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     is_system_field_ready() const;
 
     void
-    search_ids(BitsetType& bitset, const IdArray& id_array) const override;
+    search_ids(BitsetType& bitset,
+               const IdArray& id_array,
+               milvus::OpContext* op_ctx = nullptr) const override;
 
     class StagedStateCommitter;
 
@@ -1873,9 +1880,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
               RuntimeResourceState* runtime = nullptr);
 
     void
-    DropFieldData(const FieldId field_id,
-                  const SchemaPtr& schema_snapshot,
-                  RuntimeResourceState* runtime = nullptr);
+    DropFieldData(
+        const FieldId field_id,
+        const SchemaPtr& schema_snapshot,
+        RuntimeResourceState* runtime = nullptr,
+        const std::shared_ptr<const PublishedSegmentState>& current = nullptr);
 
     void
     LoadFieldData(const LoadFieldDataInfo& load_info,
@@ -2209,30 +2218,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                              int64_t start,
                              int64_t length) const;
 
-    // Load-immutable: set once at load (a reload asserts equality) and cleared
-    // only by ClearData() teardown. Read directly by scan paths, bypassing
-    // Capture*(), so per-operation snapshot pinning does NOT cover it -- it MUST
-    // NOT gain a Reopen write path (that would let a concurrent republish
-    // change the row count mid-operation and defeat the pin).
-    std::optional<int64_t> num_rows_;
-
-    // ngram indexings for json type
-    folly::Synchronized<std::unordered_map<
-        FieldId,
-        std::unordered_map<std::string, index::CacheIndexBasePtr>>>
-        ngram_indexings_;
-
-    // fields that has ngram index
-    folly::Synchronized<std::unordered_set<FieldId>> ngram_fields_;
-
-    // scalar field index
-    folly::Synchronized<std::unordered_map<FieldId, index::CacheIndexBasePtr>>
-        scalar_indexings_;
-
-    folly::Synchronized<
-        std::shared_ptr<CacheSlot<storagev2translator::TimestampIndexCell>>>
-        timestamp_index_slot_;
-
     // deleted pks
     mutable DeletedRecord<true> deleted_record_;
 
@@ -2258,11 +2243,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // PublishedSegmentState.
     uint64_t commit_ts_{0};
 
-    mutable folly::Synchronized<
-        std::unordered_map<FieldId, std::shared_ptr<ChunkedColumnInterface>>>
-        fields_;
     std::unordered_set<FieldId> pending_text_index_fields_;
-    std::unordered_set<FieldId> mmap_field_ids_;
 
     // only useful in binlog
     // Load-immutable: ctor init-list only, never reassigned. Read directly
@@ -2284,13 +2265,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // The reader object itself now lives in RuntimeResourceState snapshots so
     // reopen/load can stage a replacement reader without exposing it early.
     mutable std::mutex reader_mutex_;
-
-    // Array offsets grouped by the shared struct-array parent name.
-    std::unordered_map<std::string, std::shared_ptr<ArrayOffsetsSealed>>
-        struct_to_array_offsets_;
-    // Direct field-id lookup for array/vector-array fields.
-    std::unordered_map<FieldId, std::shared_ptr<ArrayOffsetsSealed>>
-        array_offsets_map_;
 
 #ifdef MILVUS_UNIT_TEST
  public:
@@ -2406,6 +2380,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     std::shared_ptr<const RuntimeResourceState>
     TestCaptureRuntimeResourceState(milvus::OpContext* op_ctx) const {
         return CaptureRuntimeResourceState(op_ctx);
+    }
+
+    void
+    TestPublishRuntimeResourceState(
+        std::shared_ptr<RuntimeResourceState> runtime) {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+        PublishRuntimeStateLocked(ToConstRuntimeState(std::move(runtime)));
     }
 
     void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -130,11 +130,14 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     DropFieldData(const FieldId field_id) override;
     bool
-    HasIndex(FieldId field_id) const override;
+    HasIndex(FieldId field_id,
+             milvus::OpContext* op_ctx = nullptr) const override;
     bool
-    HasJsonIndex(FieldId field_id) const override;
+    HasJsonIndex(FieldId field_id,
+                 milvus::OpContext* op_ctx = nullptr) const override;
     bool
-    HasFieldData(FieldId field_id) const override;
+    HasFieldData(FieldId field_id,
+                 milvus::OpContext* op_ctx = nullptr) const override;
     // Checks the loaded external manifest for a storage column.
     bool
     HasColumnInLoadedManifest(const std::string& column_name) const override;
@@ -146,7 +149,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     PinIndex(milvus::OpContext* op_ctx,
              FieldId field_id,
              bool include_ngram = false) const override {
-        auto snapshot = CapturePublishedState();
+        auto snapshot = CapturePublishedState(op_ctx);
         if (snapshot != nullptr && snapshot->runtime != nullptr) {
             const auto& runtime = *snapshot->runtime;
             if (!include_ngram && runtime.ngram_fields.find(field_id) !=
@@ -210,12 +213,14 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     }
 
     bool
-    HasRawData(int64_t field_id) const override;
+    HasRawData(int64_t field_id,
+               milvus::OpContext* op_ctx = nullptr) const override;
 
     // Returns true only if the index itself contains raw data,
     // without considering whether field data is loaded.
     bool
-    IndexHasRawData(FieldId field_id) const;
+    IndexHasRawData(FieldId field_id,
+                    milvus::OpContext* op_ctx = nullptr) const;
 
     bool
     CalcDistByIDs(FieldId field_id,
@@ -252,7 +257,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                          FieldId field_id) const override;
 
     DataType
-    GetFieldDataType(FieldId fieldId) const override;
+    GetFieldDataType(FieldId fieldId,
+                     milvus::OpContext* op_ctx = nullptr) const override;
 
     void
     RemoveFieldFile(const FieldId field_id) override;
@@ -276,8 +282,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                          const std::string& nested_path) const override;
 
     std::shared_ptr<const IArrayOffsets>
-    GetArrayOffsets(FieldId field_id) const override {
-        auto runtime = CaptureRuntimeResourceState();
+    GetArrayOffsets(FieldId field_id,
+                    milvus::OpContext* op_ctx = nullptr) const override {
+        auto runtime = CaptureRuntimeResourceState(op_ctx);
         auto it = runtime->array_offsets_map.find(field_id);
         if (it != runtime->array_offsets_map.end()) {
             return it->second;
@@ -291,7 +298,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                     const std::function<void(milvus::Json, size_t, bool)>& fn,
                     const int64_t* offsets,
                     int64_t count) const override {
-        auto column = get_column(field_id);
+        auto column = get_column(field_id, op_ctx);
         AssertInfo(column != nullptr,
                    "json field {} must exist when bulk reading raw data",
                    field_id.get());
@@ -429,15 +436,15 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     get_deleted_count() const override;
 
     Timestamp
-    get_max_timestamp() const override {
-        auto runtime = CaptureRuntimeResourceState();
+    get_max_timestamp(milvus::OpContext* op_ctx = nullptr) const override {
+        auto runtime = CaptureRuntimeResourceState(op_ctx);
         return runtime != nullptr && runtime->timestamp_index != nullptr
                    ? runtime->timestamp_index->get_max_timestamp()
                    : 0;
     }
 
     const Schema&
-    get_schema() const override;
+    get_schema(milvus::OpContext* op_ctx = nullptr) const override;
 
     void
     pk_range(milvus::OpContext* op_ctx,
@@ -475,8 +482,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                  int64_t count) const;
 
     bool
-    is_nullable(FieldId field_id) const override {
-        auto schema_snapshot = CaptureSchemaSnapshot();
+    is_nullable(FieldId field_id,
+                milvus::OpContext* op_ctx = nullptr) const override {
+        auto schema_snapshot = CaptureSchemaSnapshot(op_ctx);
         auto& field_meta = schema_snapshot->operator[](field_id);
         return field_meta.is_nullable();
     };
@@ -512,23 +520,31 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     // count of chunk that has raw data
     int64_t
-    num_chunk_data(FieldId field_id) const override;
+    num_chunk_data(FieldId field_id,
+                   milvus::OpContext* op_ctx = nullptr) const override;
 
     int64_t
-    num_chunk(FieldId field_id) const override;
+    num_chunk(FieldId field_id,
+              milvus::OpContext* op_ctx = nullptr) const override;
 
     // return size_per_chunk for each chunk, renaming against confusion
     int64_t
     size_per_chunk() const override;
 
     int64_t
-    chunk_size(FieldId field_id, int64_t chunk_id) const override;
+    chunk_size(FieldId field_id,
+               int64_t chunk_id,
+               milvus::OpContext* op_ctx = nullptr) const override;
 
     std::pair<int64_t, int64_t>
-    get_chunk_by_offset(FieldId field_id, int64_t offset) const override;
+    get_chunk_by_offset(FieldId field_id,
+                        int64_t offset,
+                        milvus::OpContext* op_ctx = nullptr) const override;
 
     int64_t
-    num_rows_until_chunk(FieldId field_id, int64_t chunk_id) const override;
+    num_rows_until_chunk(FieldId field_id,
+                         int64_t chunk_id,
+                         milvus::OpContext* op_ctx = nullptr) const override;
 
     SegcoreError
     Delete(int64_t size,
@@ -568,8 +584,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     ClearData() override;
 
     bool
-    is_field_exist(FieldId field_id) const override {
-        auto schema_snapshot = CaptureSchemaSnapshot();
+    is_field_exist(FieldId field_id,
+                   milvus::OpContext* op_ctx = nullptr) const override {
+        auto schema_snapshot = CaptureSchemaSnapshot(op_ctx);
         return schema_snapshot->get_fields().find(field_id) !=
                schema_snapshot->get_fields().end();
     }
@@ -1257,7 +1274,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     fill_with_empty(FieldId field_id,
                     int64_t count,
                     int64_t valid_count = 0,
-                    const void* valid_data = nullptr) const;
+                    const void* valid_data = nullptr,
+                    milvus::OpContext* op_ctx = nullptr) const;
 
     std::unique_ptr<DataArray>
     get_raw_data(milvus::OpContext* op_ctx,
@@ -1389,16 +1407,28 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::string& explicit_warmup_policy = "") const;
 
     SchemaPtr
-    CaptureSchemaSnapshot() const;
+    CaptureSchemaSnapshot(milvus::OpContext* op_ctx = nullptr) const;
 
     std::shared_ptr<const SegmentLoadInfo>
-    CaptureLoadInfoSnapshot() const;
+    CaptureLoadInfoSnapshot(milvus::OpContext* op_ctx = nullptr) const;
 
+    // Capture choke point: honors a per-operation pin installed by
+    // PinOpSnapshot() so every read within one operation observes one
+    // immutable snapshot (see sealed-segment per-operation snapshot pinning).
+    // When op_ctx is null / unpinned / owned by a different segment, falls
+    // back to the atomic load of the live published_state_.
     std::shared_ptr<const PublishedSegmentState>
-    CapturePublishedState() const;
+    CapturePublishedState(milvus::OpContext* op_ctx = nullptr) const;
 
     std::shared_ptr<const RuntimeResourceState>
-    CaptureRuntimeResourceState() const;
+    CaptureRuntimeResourceState(milvus::OpContext* op_ctx = nullptr) const;
+
+    // Installs the per-operation read pin on op_ctx: the current published
+    // state becomes the one snapshot all subsequent Capture*(op_ctx) reads in
+    // this operation see, even if a concurrent Reopen republishes. No-op when
+    // op_ctx is null. Idempotent for a given operation.
+    void
+    PinOpSnapshot(milvus::OpContext* op_ctx) const override;
 
     std::shared_ptr<const PublishedSegmentState>
     BuildPublishedState(const SchemaPtr& schema,
@@ -2139,8 +2169,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     }
 
     std::shared_ptr<ChunkedColumnInterface>
-    get_column(FieldId field_id) const {
-        return get_column(CaptureRuntimeResourceState(), field_id);
+    get_column(FieldId field_id, milvus::OpContext* op_ctx = nullptr) const {
+        return get_column(CaptureRuntimeResourceState(op_ctx), field_id);
     }
 
     PinWrapper<const storagev2translator::TimestampIndexCell*>
@@ -2179,6 +2209,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                              int64_t start,
                              int64_t length) const;
 
+    // Load-immutable: set once at load (a reload asserts equality) and cleared
+    // only by ClearData() teardown. Read directly by scan paths, bypassing
+    // Capture*(), so per-operation snapshot pinning does NOT cover it -- it MUST
+    // NOT gain a Reopen write path (that would let a concurrent republish
+    // change the row count mid-operation and defeat the pin).
     std::optional<int64_t> num_rows_;
 
     // ngram indexings for json type
@@ -2230,6 +2265,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     std::unordered_set<FieldId> mmap_field_ids_;
 
     // only useful in binlog
+    // Load-immutable: ctor init-list only, never reassigned. Read directly
+    // (bypassing Capture*()), so it is outside per-operation snapshot pinning
+    // and MUST NOT gain a Reopen write path.
     IndexMetaPtr col_index_meta_;
     SegcoreConfig segcore_config_;
 
@@ -2237,6 +2275,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     // whether the segment is sorted by the pk
     // 1. will skip index loading for primary key field
+    // Load-immutable: ctor init-list only, never reassigned. Read directly
+    // (bypassing Capture*()), so it is outside per-operation snapshot pinning
+    // and MUST NOT gain a Reopen write path.
     bool is_sorted_by_pk_ = false;
 
     // Query-time reader calls remain non-thread-safe and must be serialized.
@@ -2352,6 +2393,19 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         auto it = runtime->fields.find(field_ids.front());
         AssertInfo(it != runtime->fields.end(), "test field was not loaded");
         return it->second;
+    }
+
+    // Route a capture through the op_ctx-aware choke point so tests can assert
+    // pin identity (same snapshot pointer returned for a pinned op_ctx while a
+    // concurrent publish swaps the live state) and the owner guard.
+    std::shared_ptr<const PublishedSegmentState>
+    TestCapturePublishedState(milvus::OpContext* op_ctx) const {
+        return CapturePublishedState(op_ctx);
+    }
+
+    std::shared_ptr<const RuntimeResourceState>
+    TestCaptureRuntimeResourceState(milvus::OpContext* op_ctx) const {
+        return CaptureRuntimeResourceState(op_ctx);
     }
 
     void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -140,7 +140,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                  milvus::OpContext* op_ctx = nullptr) const override;
     // Checks the loaded external manifest for a storage column.
     bool
-    HasColumnInLoadedManifest(const std::string& column_name) const override;
+    HasColumnInLoadedManifest(
+        const std::string& column_name,
+        milvus::OpContext* op_ctx = nullptr) const override;
 
     std::pair<std::shared_ptr<ChunkedColumnInterface>, bool>
     GetFieldDataIfExist(FieldId field_id) const;
@@ -177,8 +179,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                  bool is_array) const override;
 
     std::string
-    GetJsonFlatIndexNestedPath(FieldId field_id,
-                               std::string_view query_path) const override;
+    GetJsonFlatIndexNestedPath(
+        FieldId field_id,
+        std::string_view query_path,
+        milvus::OpContext* op_ctx = nullptr) const override;
 
     bool
     Contain(const PkType& pk) const override;
@@ -1309,7 +1313,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     update_row_count(RuntimeResourceState& runtime, int64_t row_count) {
         runtime.row_count = row_count;
-        deleted_record_.set_sealed_row_count(row_count);
+    }
+
+    void
+    SyncDeletedRecordRowCount(const RuntimeResourceState& runtime) {
+        deleted_record_.set_sealed_row_count(runtime.row_count);
     }
 
     void
@@ -1582,8 +1590,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
             std::vector<index::CacheIndexBasePtr> retired_cache_indexings;
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-                segment_.PublishState(
-                    segment_.BuildNextPublishedState(current, delta));
+                auto next = segment_.BuildNextPublishedState(current, delta);
+                std::unique_lock segment_lock(segment_.mutex_);
+                segment_.SyncDeletedRecordRowCount(*next->runtime);
+                segment_.PublishState(std::move(next));
                 retired_indexings.swap(retired_vector_indexings_);
                 retired_cache_indexings.swap(retired_cache_indexings_);
             }
@@ -2288,6 +2298,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         return FieldAccessible(field_id);
     }
 
+    int32_t
+    TestDeletedRecordRowCount() const {
+        std::shared_lock lck(mutex_);
+        return deleted_record_.sealed_row_count();
+    }
+
     std::shared_ptr<const IArrayOffsets>
     TestGetArrayOffsets(FieldId field_id) const {
         return GetArrayOffsets(field_id);
@@ -2386,6 +2402,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     TestPublishRuntimeResourceState(
         std::shared_ptr<RuntimeResourceState> runtime) {
         std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+        std::unique_lock segment_lock(mutex_);
+        SyncDeletedRecordRowCount(*runtime);
         PublishRuntimeStateLocked(ToConstRuntimeState(std::move(runtime)));
     }
 

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -406,6 +406,11 @@ class DeletedRecord {
         deleted_mask_.resize(row_count);
     }
 
+    int32_t
+    sealed_row_count() const {
+        return sealed_row_count_;
+    }
+
     std::vector<std::pair<Timestamp, BitsetType>>
     get_snapshots() const {
         std::shared_lock<std::shared_mutex> lock(snap_lock_);
@@ -429,7 +434,7 @@ class DeletedRecord {
     std::shared_ptr<SortedDeleteList> deleted_lists_;
     // max timestamp of deleted records which replayed in load process
     Timestamp max_load_timestamp_{0};
-    int32_t sealed_row_count_;
+    int32_t sealed_row_count_{0};
     // used to remove duplicated deleted records for fast access
     BitsetType deleted_mask_;
 

--- a/internal/core/src/segcore/SegmentChunkReader.cpp
+++ b/internal/core/src/segcore/SegmentChunkReader.cpp
@@ -36,16 +36,20 @@ std::pair<const index::IndexBase*, int64_t>
 GetIndexAndBaseOffset(const SegmentInternalInterface* segment,
                       FieldId field_id,
                       int chunk_id,
-                      PinnedIndexView pinned_index) {
+                      PinnedIndexView pinned_index,
+                      milvus::OpContext* op_ctx = nullptr) {
     if (pinned_index.empty()) {
         return {nullptr, 0};
     }
 
     if (chunk_id >= 0 && segment->type() == SegmentType::Sealed &&
         segment->is_chunked() && pinned_index.size() == 1) {
-        auto base_offset =
-            chunk_id == 0 ? 0
-                          : segment->num_rows_until_chunk(field_id, chunk_id);
+        // Resolve the base row offset against the operation's pinned snapshot
+        // (op_ctx) so the offset matches the layout the rest of the reader
+        // reads; without it this would re-capture live published state.
+        auto base_offset = chunk_id == 0 ? 0
+                                         : segment->num_rows_until_chunk(
+                                               field_id, chunk_id, op_ctx);
         return {pinned_index[0].get(), base_offset};
     }
 
@@ -85,7 +89,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
                 };
         }
     }
-    auto num_chunks = segment_->num_chunk_data(field_id);
+    auto num_chunks = segment_->num_chunk_data(field_id, op_ctx_);
     AssertInfo(current_chunk_id < num_chunks,
                "field {} cursor chunk_id {} exceeds num_chunks {}",
                field_id.get(),
@@ -97,7 +101,8 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
     auto chunk_info = pw.get();
     auto chunk_data = chunk_info.data();
     auto chunk_valid_data = chunk_info.valid_data();
-    auto current_chunk_size = segment_->chunk_size(field_id, current_chunk_id);
+    auto current_chunk_size =
+        segment_->chunk_size(field_id, current_chunk_id, op_ctx_);
     return [=,
             this,
             pw = std::move(pw),
@@ -116,7 +121,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor(
             chunk_data = pw.get().data();
             chunk_valid_data = pw.get().valid_data();
             current_chunk_size =
-                segment_->chunk_size(field_id, current_chunk_id);
+                segment_->chunk_size(field_id, current_chunk_id, op_ctx_);
         }
         if (chunk_valid_data && !chunk_valid_data[current_chunk_pos]) {
             current_chunk_pos++;
@@ -154,7 +159,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
             };
         }
     }
-    auto num_chunks = segment_->num_chunk_data(field_id);
+    auto num_chunks = segment_->num_chunk_data(field_id, op_ctx_);
     AssertInfo(current_chunk_id < num_chunks,
                "field {} cursor chunk_id {} exceeds num_chunks {}",
                field_id.get(),
@@ -170,7 +175,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
         auto chunk_data = chunk_info.data();
         auto chunk_valid_data = chunk_info.valid_data();
         auto current_chunk_size =
-            segment_->chunk_size(field_id, current_chunk_id);
+            segment_->chunk_size(field_id, current_chunk_id, op_ctx_);
         return [pw = std::move(pw),
                 this,
                 field_id,
@@ -194,7 +199,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                 chunk_data = pw.get().data();
                 chunk_valid_data = pw.get().valid_data();
                 current_chunk_size =
-                    segment_->chunk_size(field_id, current_chunk_id);
+                    segment_->chunk_size(field_id, current_chunk_id, op_ctx_);
             }
             if (chunk_valid_data && !chunk_valid_data[current_chunk_pos]) {
                 current_chunk_pos++;
@@ -207,7 +212,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
         auto pw = segment_->chunk_view<std::string_view>(
             op_ctx_, field_id, current_chunk_id);
         auto current_chunk_size =
-            segment_->chunk_size(field_id, current_chunk_id);
+            segment_->chunk_size(field_id, current_chunk_id, op_ctx_);
         return [=,
                 this,
                 pw = std::move(pw),
@@ -224,7 +229,7 @@ SegmentChunkReader::GetMultipleChunkDataAccessor<std::string>(
                 pw = segment_->chunk_view<std::string_view>(
                     op_ctx_, field_id, current_chunk_id);
                 current_chunk_size =
-                    segment_->chunk_size(field_id, current_chunk_id);
+                    segment_->chunk_size(field_id, current_chunk_id, op_ctx_);
             }
             auto& chunk_data = pw.get().first;
             auto& chunk_valid_data = pw.get().second;
@@ -284,8 +289,8 @@ ChunkDataAccessor
 SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
                                          int chunk_id,
                                          PinnedIndexView pinned_index) const {
-    auto index_and_base_offset =
-        GetIndexAndBaseOffset(segment_, field_id, chunk_id, pinned_index);
+    auto index_and_base_offset = GetIndexAndBaseOffset(
+        segment_, field_id, chunk_id, pinned_index, op_ctx_);
     auto index = index_and_base_offset.first;
     auto base_offset = index_and_base_offset.second;
     auto index_ptr = dynamic_cast<const index::ScalarIndex<T>*>(index);
@@ -299,7 +304,7 @@ SegmentChunkReader::GetChunkDataAccessor(FieldId field_id,
                 return raw.value();
             };
     }
-    auto num_chunks = segment_->num_chunk_data(field_id);
+    auto num_chunks = segment_->num_chunk_data(field_id, op_ctx_);
     AssertInfo(chunk_id >= 0 && chunk_id < num_chunks,
                "field {} chunk_id {} exceeds raw data chunks {}",
                field_id.get(),
@@ -321,8 +326,8 @@ template <>
 ChunkDataAccessor
 SegmentChunkReader::GetChunkDataAccessor<std::string>(
     FieldId field_id, int chunk_id, PinnedIndexView pinned_index) const {
-    auto index_and_base_offset =
-        GetIndexAndBaseOffset(segment_, field_id, chunk_id, pinned_index);
+    auto index_and_base_offset = GetIndexAndBaseOffset(
+        segment_, field_id, chunk_id, pinned_index, op_ctx_);
     auto index = index_and_base_offset.first;
     auto base_offset = index_and_base_offset.second;
     auto index_ptr =
@@ -337,7 +342,7 @@ SegmentChunkReader::GetChunkDataAccessor<std::string>(
                 return raw.value();
             };
     }
-    auto num_chunks = segment_->num_chunk_data(field_id);
+    auto num_chunks = segment_->num_chunk_data(field_id, op_ctx_);
     AssertInfo(chunk_id >= 0 && chunk_id < num_chunks,
                "field {} chunk_id {} exceeds raw data chunks {}",
                field_id.get(),

--- a/internal/core/src/segcore/SegmentChunkReader.h
+++ b/internal/core/src/segcore/SegmentChunkReader.h
@@ -123,20 +123,20 @@ class SegmentChunkReader {
                                const int64_t num_chunk,
                                const int64_t batch_size) const {
         int64_t segment_row_count = segment_->get_row_count();
-        int64_t current_offset =
-            segment_->num_rows_until_chunk(field_id, current_chunk_id) +
-            current_chunk_pos;
+        int64_t current_offset = segment_->num_rows_until_chunk(
+                                     field_id, current_chunk_id, op_ctx_) +
+                                 current_chunk_pos;
         int64_t target_offset = current_offset + batch_size;
 
         if (target_offset >= segment_row_count) {
             current_chunk_id = num_chunk - 1;
             current_chunk_pos =
-                segment_row_count -
-                segment_->num_rows_until_chunk(field_id, current_chunk_id);
+                segment_row_count - segment_->num_rows_until_chunk(
+                                        field_id, current_chunk_id, op_ctx_);
             return;
         }
         auto [chunk_id, chunk_pos] =
-            segment_->get_chunk_by_offset(field_id, target_offset);
+            segment_->get_chunk_by_offset(field_id, target_offset, op_ctx_);
         current_chunk_id = chunk_id;
         current_chunk_pos = chunk_pos;
     }

--- a/internal/core/src/segcore/SegmentChunkReader.h
+++ b/internal/core/src/segcore/SegmentChunkReader.h
@@ -99,7 +99,7 @@ class SegmentChunkReader {
                        int64_t active_count)
         : segment_(segment),
           active_count_(active_count),
-          size_per_chunk_(segment->size_per_chunk()),
+          size_per_chunk_(segment->size_per_chunk(op_ctx)),
           op_ctx_(op_ctx) {
     }
 
@@ -122,7 +122,7 @@ class SegmentChunkReader {
                                const FieldId field_id,
                                const int64_t num_chunk,
                                const int64_t batch_size) const {
-        int64_t segment_row_count = segment_->get_row_count();
+        int64_t segment_row_count = segment_->get_row_count(op_ctx_);
         int64_t current_offset = segment_->num_rows_until_chunk(
                                      field_id, current_chunk_id, op_ctx_) +
                                  current_chunk_pos;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1480,13 +1480,15 @@ SegmentGrowingImpl::chunk_array_views_by_offsets(
 }
 
 int64_t
-SegmentGrowingImpl::num_chunk(FieldId field_id) const {
+SegmentGrowingImpl::num_chunk(FieldId field_id,
+                              milvus::OpContext* op_ctx) const {
     auto size = get_insert_record().ack_responder_.GetAck();
     return upper_div(size, segcore_config_.get_chunk_rows());
 }
 
 DataType
-SegmentGrowingImpl::GetFieldDataType(milvus::FieldId field_id) const {
+SegmentGrowingImpl::GetFieldDataType(milvus::FieldId field_id,
+                                     milvus::OpContext* op_ctx) const {
     auto& field_meta = schema_->operator[](field_id);
     return field_meta.get_data_type();
 }

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2242,7 +2242,8 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
 
 void
 SegmentGrowingImpl::search_ids(BitsetType& bitset,
-                               const IdArray& id_array) const {
+                               const IdArray& id_array,
+                               milvus::OpContext* op_ctx) const {
     auto field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(field_id.get() != -1, "Primary key is -1");
     auto& field_meta = schema_->operator[](field_id);
@@ -2259,8 +2260,9 @@ SegmentGrowingImpl::search_ids(BitsetType& bitset,
 }
 
 int64_t
-SegmentGrowingImpl::get_active_count(Timestamp ts) const {
-    auto row_count = this->get_row_count();
+SegmentGrowingImpl::get_active_count(Timestamp ts,
+                                     milvus::OpContext* op_ctx) const {
+    auto row_count = this->get_row_count(op_ctx);
     auto& ts_vec = this->get_insert_record().timestamps_;
     auto iter = std::upper_bound(
         boost::make_counting_iterator(static_cast<int64_t>(0)),
@@ -2273,7 +2275,8 @@ SegmentGrowingImpl::get_active_count(Timestamp ts) const {
 void
 SegmentGrowingImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
                                          Timestamp timestamp,
-                                         Timestamp collection_ttl) const {
+                                         Timestamp collection_ttl,
+                                         milvus::OpContext* op_ctx) const {
     if (collection_ttl > 0) {
         auto& timestamps = get_timestamps();
         auto size = bitset_chunk.size();

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -117,7 +117,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     bool
-    is_nullable(FieldId field_id) const override {
+    is_nullable(FieldId field_id,
+                milvus::OpContext* op_ctx = nullptr) const override {
         AssertInfo(insert_record_.is_data_exist(field_id),
                    "Cannot find field_data with field_id: " +
                        std::to_string(field_id.get()));
@@ -204,7 +205,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     Timestamp
-    get_max_timestamp() const override {
+    get_max_timestamp(milvus::OpContext* op_ctx = nullptr) const override {
         return insert_record_.timestamp_index_.get_max_timestamp();
     }
 
@@ -214,7 +215,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     const Schema&
-    get_schema() const override {
+    get_schema(milvus::OpContext* op_ctx = nullptr) const override {
         return *schema_;
     }
 
@@ -236,7 +237,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     // count of chunk that has raw data
     int64_t
-    num_chunk_data(FieldId field_id) const final {
+    num_chunk_data(FieldId field_id,
+                   milvus::OpContext* op_ctx = nullptr) const final {
         auto size = get_insert_record().ack_responder_.GetAck();
         return upper_div(size, segcore_config_.get_chunk_rows());
     }
@@ -256,18 +258,24 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     int64_t
-    chunk_size(FieldId field_id, int64_t chunk_id) const final {
+    chunk_size(FieldId field_id,
+               int64_t chunk_id,
+               milvus::OpContext* op_ctx = nullptr) const final {
         return segcore_config_.get_chunk_rows();
     }
 
     std::pair<int64_t, int64_t>
-    get_chunk_by_offset(FieldId field_id, int64_t offset) const override {
+    get_chunk_by_offset(FieldId field_id,
+                        int64_t offset,
+                        milvus::OpContext* op_ctx = nullptr) const override {
         auto size_per_chunk = segcore_config_.get_chunk_rows();
         return {offset / size_per_chunk, offset % size_per_chunk};
     }
 
     int64_t
-    num_rows_until_chunk(FieldId field_id, int64_t chunk_id) const override {
+    num_rows_until_chunk(FieldId field_id,
+                         int64_t chunk_id,
+                         milvus::OpContext* op_ctx = nullptr) const override {
         return chunk_id * segcore_config_.get_chunk_rows();
     }
 
@@ -510,7 +518,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
                   SearchResult& output) const override;
 
     DataType
-    GetFieldDataType(FieldId fieldId) const override;
+    GetFieldDataType(FieldId fieldId,
+                     milvus::OpContext* op_ctx = nullptr) const override;
 
  public:
     void
@@ -522,7 +531,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     search_ids(BitsetType& bitset, const IdArray& id_array) const override;
 
     bool
-    HasIndex(FieldId field_id) const override {
+    HasIndex(FieldId field_id,
+             milvus::OpContext* op_ctx = nullptr) const override {
         if (!is_field_exist(field_id)) {
             return false;
         }
@@ -569,7 +579,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     bool
-    HasFieldData(FieldId field_id) const override {
+    HasFieldData(FieldId field_id,
+                 milvus::OpContext* op_ctx = nullptr) const override {
         if (SystemProperty::Instance().IsSystem(field_id)) {
             return insert_record_.row_count() > 0;
         }
@@ -580,7 +591,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     bool
-    HasRawData(int64_t field_id) const override {
+    HasRawData(int64_t field_id,
+               milvus::OpContext* op_ctx = nullptr) const override {
         //growing index hold raw data when
         // 1. growing index enabled and it holds raw data
         // 2. growing index disabled then raw data held by chunk
@@ -633,7 +645,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     bool
-    is_field_exist(FieldId field_id) const override {
+    is_field_exist(FieldId field_id,
+                   milvus::OpContext* op_ctx = nullptr) const override {
         return schema_->get_fields().find(field_id) !=
                schema_->get_fields().end();
     }
@@ -661,7 +674,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     std::shared_ptr<const IArrayOffsets>
-    GetArrayOffsets(FieldId field_id) const override {
+    GetArrayOffsets(FieldId field_id,
+                    milvus::OpContext* op_ctx = nullptr) const override {
         std::shared_lock lock(array_offsets_map_mutex_);
         auto it = array_offsets_map_.find(field_id);
         if (it != array_offsets_map_.end()) {
@@ -714,7 +728,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
  protected:
     int64_t
-    num_chunk(FieldId field_id) const override;
+    num_chunk(FieldId field_id,
+              milvus::OpContext* op_ctx = nullptr) const override;
 
     PinWrapper<SpanBase>
     chunk_data_impl(milvus::OpContext* op_ctx,

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -253,7 +253,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     int64_t
-    size_per_chunk() const final {
+    size_per_chunk(milvus::OpContext* op_ctx = nullptr) const final {
         return segcore_config_.get_chunk_rows();
     }
 
@@ -310,7 +310,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     int64_t
-    get_row_count() const override {
+    get_row_count(milvus::OpContext* op_ctx = nullptr) const override {
         return insert_record_.ack_responder_.GetAck();
     }
 
@@ -320,7 +320,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     int64_t
-    get_active_count(Timestamp ts) const override;
+    get_active_count(Timestamp ts,
+                     milvus::OpContext* op_ctx = nullptr) const override;
 
     // for scalar vectors
     template <typename S, typename T = S>
@@ -505,7 +506,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     void
     mask_with_timestamps(BitsetTypeView& bitset_chunk,
                          Timestamp timestamp,
-                         Timestamp ttl = 0) const override;
+                         Timestamp ttl = 0,
+                         milvus::OpContext* op_ctx = nullptr) const override;
 
     void
     vector_search(SearchInfo& search_info,
@@ -528,7 +530,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
                      Timestamp timestamp) const override;
 
     void
-    search_ids(BitsetType& bitset, const IdArray& id_array) const override;
+    search_ids(BitsetType& bitset,
+               const IdArray& id_array,
+               milvus::OpContext* op_ctx = nullptr) const override;
 
     bool
     HasIndex(FieldId field_id,
@@ -617,22 +621,25 @@ class SegmentGrowingImpl : public SegmentGrowing {
     }
 
     std::pair<std::vector<OffsetMap::OffsetType>, bool>
-    find_first_n(int64_t limit, const BitsetTypeView& bitset) const override {
+    find_first_n(int64_t limit,
+                 const BitsetTypeView& bitset,
+                 milvus::OpContext* op_ctx = nullptr) const override {
         return insert_record_.pk2offset_->find_first_n(limit, bitset);
     }
 
     std::tuple<std::vector<int64_t>, std::vector<std::vector<int32_t>>, bool>
-    find_first_n_element(
-        int64_t limit,
-        const BitsetTypeView& element_bitset,
-        const IArrayOffsets* array_offsets,
-        const std::optional<QueryIteratorCursor>& cursor) const override {
+    find_first_n_element(int64_t limit,
+                         const BitsetTypeView& element_bitset,
+                         const IArrayOffsets* array_offsets,
+                         const std::optional<QueryIteratorCursor>& cursor,
+                         milvus::OpContext* op_ctx = nullptr) const override {
         return insert_record_.pk2offset_->find_first_n_element(
             limit, element_bitset, array_offsets, cursor);
     }
 
     bool
-    is_mmap_field(FieldId id) const override {
+    is_mmap_field(FieldId id,
+                  milvus::OpContext* op_ctx = nullptr) const override {
         return false;
     }
 

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -76,6 +76,8 @@ SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,
     if (op_ctx != nullptr) {
         local_ctx.cancellation_token = op_ctx->cancellation_token;
         local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+        local_ctx.pinned_segment_state = op_ctx->pinned_segment_state;
+        local_ctx.pinned_state_owner = op_ctx->pinned_state_owner;
     }
     auto field_data = bulk_subscript(
         &local_ctx, pk_field_id, results.seg_offsets_.data(), size);
@@ -105,6 +107,8 @@ SegmentInternalInterface::FillTargetEntry(const query::Plan* plan,
     if (op_ctx != nullptr) {
         local_ctx.cancellation_token = op_ctx->cancellation_token;
         local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+        local_ctx.pinned_segment_state = op_ctx->pinned_segment_state;
+        local_ctx.pinned_state_owner = op_ctx->pinned_state_owner;
     }
     // fill other entries except primary key by result_offset
     for (auto field_id : plan->target_entries_) {
@@ -220,6 +224,11 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
                                        entity_ttl_physical_time_us);
     auto retrieve_results = visitor.get_retrieve_result(*plan->plan_node_);
 
+    milvus::OpContext fte_op_ctx;
+    fte_op_ctx.cancellation_token = cancel_token;
+    fte_op_ctx.pinned_segment_state = retrieve_results.pinned_segment_state_;
+    fte_op_ctx.pinned_state_owner = retrieve_results.pinned_state_owner_;
+
     retrieve_results.segment_ = (void*)this;
     results->set_has_more_result(retrieve_results.has_more_result);
     results->set_scanned_remote_bytes(
@@ -230,7 +239,8 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
     auto result_rows = GetResultRowCount(retrieve_results);
     int64_t output_data_size = 0;
     for (auto field_id : plan->field_ids_) {
-        output_data_size += get_field_avg_size(field_id) * result_rows;
+        output_data_size +=
+            get_field_avg_size(field_id, &fte_op_ctx) * result_rows;
     }
     if (output_data_size > limit_size) {
         ThrowInfo(
@@ -255,15 +265,9 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
 
     std::chrono::high_resolution_clock::time_point get_target_entry_start =
         std::chrono::high_resolution_clock::now();
-    // Carry the upstream cancel_token down into FillTargetEntry so the
-    // take()/Arrow-convert path can short-circuit on abort.
-    milvus::OpContext fte_op_ctx;
-    fte_op_ctx.cancellation_token = cancel_token;
-    // Pin one published-state snapshot for the fill phase so its column reads
-    // stay layout-consistent even if a concurrent Reopen republishes between
-    // the scan (already pinned inside the visitor) and this fill. No-op for
-    // growing segments.
-    PinOpSnapshot(&fte_op_ctx);
+    // Reuse the visitor's operation snapshot for materialization.  Re-pinning
+    // here would allow filter coordinates from snapshot A to be applied to
+    // fields from a newer snapshot B.
     if (retrieve_results.field_data_.empty()) {
         FillTargetEntry(trace_ctx,
                         plan,
@@ -283,7 +287,7 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
         //
         // Aggregation + ORDER BY does NOT set pipeline_field_ids_ and produces
         // final columns directly, falling through to FillTargetEntryDirectly.
-        FillOrderByResult(plan, results, retrieve_results);
+        FillOrderByResult(plan, results, retrieve_results, &fte_op_ctx);
     } else {
         FillTargetEntryDirectly(trace_ctx, results, retrieve_results);
     }
@@ -316,7 +320,8 @@ void
 SegmentInternalInterface::FillOrderByResult(
     const query::RetrievePlan* plan,
     const std::unique_ptr<proto::segcore::RetrieveResults>& results,
-    RetrieveResult& retrieveResult) const {
+    RetrieveResult& retrieveResult,
+    milvus::OpContext* op_ctx) const {
     auto fields_data = results->mutable_fields_data();
     auto& deferred = plan->plan_node_->deferred_field_ids_;
 
@@ -393,7 +398,13 @@ SegmentInternalInterface::FillOrderByResult(
         }
     }
 
-    milvus::OpContext op_ctx;
+    milvus::OpContext local_ctx;
+    if (op_ctx != nullptr) {
+        local_ctx.cancellation_token = op_ctx->cancellation_token;
+        local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+        local_ctx.pinned_segment_state = op_ctx->pinned_segment_state;
+        local_ctx.pinned_state_owner = op_ctx->pinned_state_owner;
+    }
 
     // Two-project mode: bulk-fetch deferred fields using segment offsets.
     if (!deferred.empty()) {
@@ -404,18 +415,18 @@ SegmentInternalInterface::FillOrderByResult(
                 dynamic_field_id.value() == field_id &&
                 !plan->target_dynamic_fields_.empty()) {
                 // Dynamic subfield projection.
-                col = bulk_subscript(&op_ctx,
+                col = bulk_subscript(&local_ctx,
                                      field_id,
                                      offset_data.data(),
                                      topk_count,
                                      plan->target_dynamic_fields_);
-            } else if (!is_field_exist(field_id)) {
+            } else if (!is_field_exist(field_id, &local_ctx)) {
                 // Field absent in this segment (schema evolution).
                 auto& field_meta = plan->schema_->operator[](field_id);
                 col = bulk_subscript_not_exist_field(field_meta, topk_count);
             } else {
                 col = bulk_subscript(
-                    &op_ctx, field_id, offset_data.data(), topk_count);
+                    &local_ctx, field_id, offset_data.data(), topk_count);
             }
             auto& field_meta = plan->schema_->operator[](field_id);
             if (field_meta.get_data_type() == DataType::ARRAY) {
@@ -436,7 +447,7 @@ SegmentInternalInterface::FillOrderByResult(
         auto system_type =
             SystemProperty::Instance().GetSystemFieldType(field_id);
         FixedVector<int64_t> output(topk_count);
-        bulk_subscript(&op_ctx,
+        bulk_subscript(&local_ctx,
                        system_type,
                        offset_data.data(),
                        topk_count,
@@ -457,10 +468,10 @@ SegmentInternalInterface::FillOrderByResult(
     // Write back IO statistics from deferred bulk_subscript calls.
     results->set_scanned_remote_bytes(
         results->scanned_remote_bytes() +
-        op_ctx.storage_usage.scanned_cold_bytes.load());
+        local_ctx.storage_usage.scanned_cold_bytes.load());
     results->set_scanned_total_bytes(
         results->scanned_total_bytes() +
-        op_ctx.storage_usage.scanned_total_bytes.load());
+        local_ctx.storage_usage.scanned_total_bytes.load());
 
     // Populate IDs from PK column (position 0) for proxy ReduceByPK.
     if (results->fields_data_size() > 0) {
@@ -729,7 +740,8 @@ SegmentInternalInterface::get_real_count() const {
 }
 
 int64_t
-SegmentInternalInterface::get_field_avg_size(FieldId field_id) const {
+SegmentInternalInterface::get_field_avg_size(FieldId field_id,
+                                             milvus::OpContext* op_ctx) const {
     AssertInfo(field_id.get() >= 0,
                "invalid field id, should be greater than or equal to 0");
     if (SystemProperty::Instance().IsSystem(field_id)) {
@@ -740,7 +752,7 @@ SegmentInternalInterface::get_field_avg_size(FieldId field_id) const {
         ThrowInfo(FieldIDInvalid, "unsupported system field id");
     }
 
-    auto& schema = get_schema();
+    auto& schema = get_schema(op_ctx);
     auto& field_meta = schema[field_id];
     auto data_type = field_meta.get_data_type();
 

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -50,6 +50,40 @@
 namespace milvus::segcore {
 
 void
+SegmentInternalInterface::ValidateExternalFieldsInLoadedManifest(
+    const std::vector<FieldId>& fields,
+    const std::vector<FieldId>& skipped_fields,
+    milvus::OpContext* op_ctx) const {
+    const auto& schema = get_schema(op_ctx);
+    if (!schema.is_external_collection()) {
+        return;
+    }
+
+    for (auto field_id : fields) {
+        if (std::find(skipped_fields.begin(), skipped_fields.end(), field_id) !=
+                skipped_fields.end() ||
+            !schema.has_field(field_id) ||
+            !schema.IsExternalManifestStoredField(field_id)) {
+            continue;
+        }
+
+        const auto& field_meta = schema[field_id];
+        auto column_name = schema.GetPhysicalColumnName(field_id);
+        if (!HasColumnInLoadedManifest(column_name, op_ctx)) {
+            throw milvus::SegcoreError(
+                milvus::FieldNotLoaded,
+                fmt::format(
+                    "external field \"{}\" (storage column \"{}\") is not "
+                    "available in the current loaded external collection "
+                    "manifest; run RefreshExternalCollection and reload the "
+                    "collection before accessing this field",
+                    field_meta.get_name().get(),
+                    column_name));
+        }
+    }
+}
+
+void
 SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,
                                           SearchResult& results,
                                           milvus::OpContext* op_ctx) const {
@@ -61,11 +95,12 @@ SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,
     Assert(results.primary_keys_.size() == 0);
     results.primary_keys_.resize(size);
 
-    auto pk_field_id_opt = get_schema().get_primary_field_id();
+    const auto& schema = get_schema(op_ctx);
+    auto pk_field_id_opt = schema.get_primary_field_id();
     AssertInfo(pk_field_id_opt.has_value(),
                "Cannot get primary key offset from schema");
     auto pk_field_id = pk_field_id_opt.value();
-    AssertInfo(IsPrimaryKeyDataType(get_schema()[pk_field_id].get_data_type()),
+    AssertInfo(IsPrimaryKeyDataType(schema[pk_field_id].get_data_type()),
                "Primary key field is not INT64 or VARCHAR type");
 
     segcore::CheckCancellation(op_ctx, get_segment_id(), "FillPrimaryKeys");
@@ -124,7 +159,7 @@ SegmentInternalInterface::FillTargetEntry(const query::Plan* plan,
                                         results.seg_offsets_.data(),
                                         size,
                                         target_dynamic_fields);
-        } else if (!is_field_exist(field_id)) {
+        } else if (!is_field_exist(field_id, &local_ctx)) {
             field_data = bulk_subscript_not_exist_field(field_meta, size);
         } else {
             field_data = bulk_subscript(
@@ -164,6 +199,16 @@ SegmentInternalInterface::Search(
                                        std::move(trace_span));
     visitor.SetFilterOnly(filter_only);
     visitor.SetEnableExprCache(enable_expr_cache);
+    std::vector<FieldId> skipped_access_entries;
+    if (filter_only) {
+        skipped_access_entries.push_back(
+            plan->plan_node_->search_info_.field_id_);
+        skipped_access_entries.insert(skipped_access_entries.end(),
+                                      plan->target_entries_.begin(),
+                                      plan->target_entries_.end());
+    }
+    visitor.SetAccessEntries(plan->access_entries_,
+                             std::move(skipped_access_entries));
     auto results = std::make_unique<SearchResult>();
     *results = visitor.get_moved_result(*plan->plan_node_);
     results->segment_ = (void*)this;
@@ -222,6 +267,7 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
                                        consistency_level,
                                        collection_ttl,
                                        entity_ttl_physical_time_us);
+    visitor.SetAccessEntries(plan->access_entries_);
     auto retrieve_results = visitor.get_retrieve_result(*plan->plan_node_);
 
     milvus::OpContext fte_op_ctx;
@@ -658,6 +704,8 @@ SegmentInternalInterface::Retrieve(
     // Pin one published-state snapshot for this offset-driven retrieve so the
     // FillTargetEntry read path stays layout-consistent. No-op for growing.
     PinOpSnapshot(&fte_op_ctx);
+    ValidateExternalFieldsInLoadedManifest(
+        Plan->access_entries_, {}, &fte_op_ctx);
     FillTargetEntry(
         trace_ctx, Plan, results, offsets, size, false, false, &fte_op_ctx);
     std::chrono::high_resolution_clock::time_point get_target_entry_end =

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -259,6 +259,11 @@ SegmentInternalInterface::Retrieve(tracer::TraceContext* trace_ctx,
     // take()/Arrow-convert path can short-circuit on abort.
     milvus::OpContext fte_op_ctx;
     fte_op_ctx.cancellation_token = cancel_token;
+    // Pin one published-state snapshot for the fill phase so its column reads
+    // stay layout-consistent even if a concurrent Reopen republishes between
+    // the scan (already pinned inside the visitor) and this fill. No-op for
+    // growing segments.
+    PinOpSnapshot(&fte_op_ctx);
     if (retrieve_results.field_data_.empty()) {
         FillTargetEntry(trace_ctx,
                         plan,
@@ -518,11 +523,16 @@ SegmentInternalInterface::FillTargetEntry(
     // Per-call OpContext keeps storage_usage scoped to this segment;
     // sharing the caller's op_ctx across segments would double-count
     // bytes. Inherit the caller's cancellation_token and load priority so
-    // in-loop cancellation still propagates.
+    // in-loop cancellation still propagates. Also carry over the pinned
+    // published-state snapshot (set by RetrieveByOffsets::PinOpSnapshot) so
+    // every bulk_subscript below reads the operation's pinned layout instead
+    // of re-capturing live state.
     milvus::OpContext local_ctx;
     if (op_ctx != nullptr) {
         local_ctx.cancellation_token = op_ctx->cancellation_token;
         local_ctx.runtime_load_priority = op_ctx->runtime_load_priority;
+        local_ctx.pinned_segment_state = op_ctx->pinned_segment_state;
+        local_ctx.pinned_state_owner = op_ctx->pinned_state_owner;
     }
     for (auto field_id : plan->field_ids_) {
         if (SystemProperty::Instance().IsSystem(field_id)) {
@@ -560,7 +570,9 @@ SegmentInternalInterface::FillTargetEntry(
         }
         std::unique_ptr<DataArray> col;
         auto& field_meta = plan->schema_->operator[](field_id);
-        if (!is_field_exist(field_id)) {
+        // Resolve field existence against the pinned snapshot carried in
+        // local_ctx so it agrees with the schema the bulk_subscript reads use.
+        if (!is_field_exist(field_id, &local_ctx)) {
             col = bulk_subscript_not_exist_field(field_meta, size);
         } else {
             col = bulk_subscript(&local_ctx, field_id, offsets, size);
@@ -632,6 +644,9 @@ SegmentInternalInterface::Retrieve(
     // path so RetrieveByOffsets on external fields can short-circuit.
     milvus::OpContext fte_op_ctx;
     fte_op_ctx.cancellation_token = cancel_token;
+    // Pin one published-state snapshot for this offset-driven retrieve so the
+    // FillTargetEntry read path stays layout-consistent. No-op for growing.
+    PinOpSnapshot(&fte_op_ctx);
     FillTargetEntry(
         trace_ctx, Plan, results, offsets, size, false, false, &fte_op_ctx);
     std::chrono::high_resolution_clock::time_point get_target_entry_end =
@@ -769,7 +784,7 @@ SegmentInternalInterface::set_field_avg_size(FieldId field_id,
 }
 
 const SkipIndex&
-SegmentInternalInterface::GetSkipIndex() const {
+SegmentInternalInterface::GetSkipIndex(milvus::OpContext* op_ctx) const {
     return skip_index_;
 }
 

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -168,7 +168,7 @@ class SegmentInterface {
     get_row_count() const = 0;
 
     virtual const Schema&
-    get_schema() const = 0;
+    get_schema(milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual int64_t
     get_deleted_count() const = 0;
@@ -201,13 +201,15 @@ class SegmentInterface {
     type() const = 0;
 
     virtual bool
-    HasRawData(int64_t field_id) const = 0;
+    HasRawData(int64_t field_id, milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual bool
-    HasFieldData(FieldId field_id) const = 0;
+    HasFieldData(FieldId field_id,
+                 milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual bool
-    is_nullable(FieldId field_id) const = 0;
+    is_nullable(FieldId field_id,
+                milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual void
     CreateTextIndex(FieldId field_id, milvus::OpContext* op_ctx = nullptr) = 0;
@@ -341,13 +343,25 @@ class SegmentInterface {
     // Get IArrayOffsets for element-level filtering on array fields
     // Returns nullptr if the field doesn't have IArrayOffsets
     virtual std::shared_ptr<const IArrayOffsets>
-    GetArrayOffsets(FieldId field_id) const = 0;
+    GetArrayOffsets(FieldId field_id,
+                    milvus::OpContext* op_ctx = nullptr) const = 0;
 };
 
 // internal API for DSL calculation
 // only for implementation
 class SegmentInternalInterface : public SegmentInterface {
  public:
+    // Installs a per-operation read pin on op_ctx so every published-state read
+    // in this operation observes one immutable snapshot even if a concurrent
+    // Reopen republishes (see sealed-segment per-operation snapshot pinning).
+    // Called once at operation entry with the op_ctx that is threaded to the
+    // operation's expressions/accessors. Default is a no-op: growing segments
+    // have no published state; only sealed segments pin.
+    virtual void
+    PinOpSnapshot(milvus::OpContext* op_ctx) const {
+        // do nothing
+    }
+
     virtual void
     prefetch_chunks(milvus::OpContext* op_ctx,
                     FieldId field_id,
@@ -529,7 +543,7 @@ class SegmentInternalInterface : public SegmentInterface {
              const folly::CancellationToken& cancel_token) const override;
 
     virtual bool
-    HasIndex(FieldId field_id) const = 0;
+    HasIndex(FieldId field_id, milvus::OpContext* op_ctx = nullptr) const = 0;
 
     bool
     FieldAccessible(FieldId field_id) const {
@@ -549,7 +563,7 @@ class SegmentInternalInterface : public SegmentInterface {
     // Default returns false for segment types that never build JSON indexes
     // (e.g. growing segments); sealed segments override.
     virtual bool
-    HasJsonIndex(FieldId field_id) const {
+    HasJsonIndex(FieldId field_id, milvus::OpContext* op_ctx = nullptr) const {
         return false;
     }
 
@@ -569,7 +583,7 @@ class SegmentInternalInterface : public SegmentInterface {
     }
 
     const SkipIndex&
-    GetSkipIndex() const;
+    GetSkipIndex(milvus::OpContext* op_ctx = nullptr) const;
 
     void
     LoadSkipIndex(FieldId field_id,
@@ -588,7 +602,8 @@ class SegmentInternalInterface : public SegmentInterface {
     }
 
     virtual DataType
-    GetFieldDataType(FieldId fieldId) const = 0;
+    GetFieldDataType(FieldId fieldId,
+                     milvus::OpContext* op_ctx = nullptr) const = 0;
 
     PinWrapper<index::TextMatchIndex*>
     GetTextIndex(milvus::OpContext* op_ctx, FieldId field_id) const override;
@@ -631,10 +646,13 @@ class SegmentInternalInterface : public SegmentInterface {
 
     // count of chunk that has raw data
     virtual int64_t
-    num_chunk_data(FieldId field_id) const = 0;
+    num_chunk_data(FieldId field_id,
+                   milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual int64_t
-    num_rows_until_chunk(FieldId field_id, int64_t chunk_id) const = 0;
+    num_rows_until_chunk(FieldId field_id,
+                         int64_t chunk_id,
+                         milvus::OpContext* op_ctx = nullptr) const = 0;
 
     // bitset 1 means not hit. 0 means hit.
     virtual void
@@ -644,13 +662,17 @@ class SegmentInternalInterface : public SegmentInterface {
 
     // count of chunks
     virtual int64_t
-    num_chunk(FieldId field_id) const = 0;
+    num_chunk(FieldId field_id, milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual int64_t
-    chunk_size(FieldId field_id, int64_t chunk_id) const = 0;
+    chunk_size(FieldId field_id,
+               int64_t chunk_id,
+               milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual std::pair<int64_t, int64_t>
-    get_chunk_by_offset(FieldId field_id, int64_t offset) const = 0;
+    get_chunk_by_offset(FieldId field_id,
+                        int64_t offset,
+                        milvus::OpContext* op_ctx = nullptr) const = 0;
 
     // element size in each chunk
     virtual int64_t
@@ -660,7 +682,7 @@ class SegmentInternalInterface : public SegmentInterface {
     get_active_count(Timestamp ts) const = 0;
 
     virtual Timestamp
-    get_max_timestamp() const = 0;
+    get_max_timestamp(milvus::OpContext* op_ctx = nullptr) const = 0;
 
     /**
      * search offset by possible pk values and mvcc timestamp
@@ -795,7 +817,8 @@ class SegmentInternalInterface : public SegmentInterface {
 
  public:
     virtual bool
-    is_field_exist(FieldId field_id) const = 0;
+    is_field_exist(FieldId field_id,
+                   milvus::OpContext* op_ctx = nullptr) const = 0;
     // calculate output[i] = Vec[seg_offsets[i]}, where Vec binds to system_type
     virtual void
     bulk_subscript(milvus::OpContext* op_ctx,

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -165,7 +165,7 @@ class SegmentInterface {
     GetMemoryUsageInBytes() const = 0;
 
     virtual int64_t
-    get_row_count() const = 0;
+    get_row_count(milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual const Schema&
     get_schema(milvus::OpContext* op_ctx = nullptr) const = 0;
@@ -177,7 +177,8 @@ class SegmentInterface {
     get_real_count() const = 0;
 
     virtual int64_t
-    get_field_avg_size(FieldId field_id) const = 0;
+    get_field_avg_size(FieldId field_id,
+                       milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual void
     set_field_avg_size(FieldId field_id,
@@ -571,7 +572,8 @@ class SegmentInternalInterface : public SegmentInterface {
     get_real_count() const override;
 
     int64_t
-    get_field_avg_size(FieldId field_id) const override;
+    get_field_avg_size(FieldId field_id,
+                       milvus::OpContext* op_ctx = nullptr) const override;
 
     void
     set_field_avg_size(FieldId field_id,
@@ -658,7 +660,8 @@ class SegmentInternalInterface : public SegmentInterface {
     virtual void
     mask_with_timestamps(BitsetTypeView& bitset_chunk,
                          Timestamp timestamp,
-                         Timestamp collection_ttl) const = 0;
+                         Timestamp collection_ttl,
+                         milvus::OpContext* op_ctx = nullptr) const = 0;
 
     // count of chunks
     virtual int64_t
@@ -676,10 +679,11 @@ class SegmentInternalInterface : public SegmentInterface {
 
     // element size in each chunk
     virtual int64_t
-    size_per_chunk() const = 0;
+    size_per_chunk(milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual int64_t
-    get_active_count(Timestamp ts) const = 0;
+    get_active_count(Timestamp ts,
+                     milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual Timestamp
     get_max_timestamp(milvus::OpContext* op_ctx = nullptr) const = 0;
@@ -694,7 +698,9 @@ class SegmentInternalInterface : public SegmentInterface {
      * so no need timestamp parameter, mvcc node prove the timestamp is already filtered.
      */
     virtual void
-    search_ids(BitsetType& bitset, const IdArray& id_array) const = 0;
+    search_ids(BitsetType& bitset,
+               const IdArray& id_array,
+               milvus::OpContext* op_ctx = nullptr) const = 0;
 
     /**
      * Sort all candidates in ascending order, and then return the limit smallest.
@@ -708,7 +714,9 @@ class SegmentInternalInterface : public SegmentInterface {
      * @return All candidates offsets.
      */
     virtual std::pair<std::vector<OffsetMap::OffsetType>, bool>
-    find_first_n(int64_t limit, const BitsetTypeView& bitset) const = 0;
+    find_first_n(int64_t limit,
+                 const BitsetTypeView& bitset,
+                 milvus::OpContext* op_ctx = nullptr) const = 0;
 
     /**
      * Element-level version of find_first_n.
@@ -724,11 +732,11 @@ class SegmentInternalInterface : public SegmentInterface {
      */
     virtual std::
         tuple<std::vector<int64_t>, std::vector<std::vector<int32_t>>, bool>
-        find_first_n_element(
-            int64_t limit,
-            const BitsetTypeView& element_bitset,
-            const IArrayOffsets* array_offsets,
-            const std::optional<QueryIteratorCursor>& cursor) const = 0;
+        find_first_n_element(int64_t limit,
+                             const BitsetTypeView& element_bitset,
+                             const IArrayOffsets* array_offsets,
+                             const std::optional<QueryIteratorCursor>& cursor,
+                             milvus::OpContext* op_ctx = nullptr) const = 0;
 
     void
     FillTargetEntryDirectly(
@@ -742,7 +750,8 @@ class SegmentInternalInterface : public SegmentInterface {
     FillOrderByResult(
         const query::RetrievePlan* plan,
         const std::unique_ptr<proto::segcore::RetrieveResults>& results,
-        RetrieveResult& retrieveResult) const;
+        RetrieveResult& retrieveResult,
+        milvus::OpContext* op_ctx) const;
 
     void
     FillTargetEntry(
@@ -757,7 +766,8 @@ class SegmentInternalInterface : public SegmentInterface {
 
     // return whether field mmap or not
     virtual bool
-    is_mmap_field(FieldId field_id) const = 0;
+    is_mmap_field(FieldId field_id,
+                  milvus::OpContext* op_ctx = nullptr) const = 0;
 
     virtual std::unique_ptr<DataArray>
     bulk_subscript_not_exist_field(const milvus::FieldMeta& field_meta,

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -236,7 +236,8 @@ class SegmentInterface {
     // fetch when the decision is going to be RawData anyway.
     virtual std::string
     GetJsonFlatIndexNestedPath(FieldId field_id,
-                               std::string_view query_path) const {
+                               std::string_view query_path,
+                               milvus::OpContext* op_ctx = nullptr) const {
         return "";
     }
 
@@ -547,16 +548,24 @@ class SegmentInternalInterface : public SegmentInterface {
     HasIndex(FieldId field_id, milvus::OpContext* op_ctx = nullptr) const = 0;
 
     bool
-    FieldAccessible(FieldId field_id) const {
-        return HasFieldData(field_id) || HasIndex(field_id);
+    FieldAccessible(FieldId field_id,
+                    milvus::OpContext* op_ctx = nullptr) const {
+        return HasFieldData(field_id, op_ctx) || HasIndex(field_id, op_ctx);
     }
 
     // Returns whether the segment's loaded manifest contains the storage
     // column. Non-manifest segment types default to true.
     virtual bool
-    HasColumnInLoadedManifest(const std::string&) const {
+    HasColumnInLoadedManifest(const std::string&,
+                              milvus::OpContext* op_ctx = nullptr) const {
         return true;
     }
+
+    void
+    ValidateExternalFieldsInLoadedManifest(
+        const std::vector<FieldId>& fields,
+        const std::vector<FieldId>& skipped_fields,
+        milvus::OpContext* op_ctx) const;
 
     // JSON indexes (JsonFlatIndex + JSON-cast scalar) live in a separate
     // per-segment container from the scalar/vector/binlog index bitsets, so

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -38,6 +38,25 @@
 
 namespace milvus::segcore {
 
+namespace {
+
+void
+InitSearchResultOpContext(const SearchResult& search_result,
+                          const milvus::OpContext* source,
+                          milvus::OpContext& target) {
+    if (source != nullptr) {
+        target.cancellation_token = source->cancellation_token;
+        target.runtime_load_priority = source->runtime_load_priority;
+        target.coload_fields = source->coload_fields;
+        target.trace_context = source->trace_context;
+        target.trace_span = source->trace_span;
+    }
+    target.pinned_segment_state = search_result.pinned_segment_state_;
+    target.pinned_state_owner = search_result.pinned_state_owner_;
+}
+
+}  // namespace
+
 void
 ReduceHelper::Initialize() {
     AssertInfo(search_results_.size() > 0, "empty search result");
@@ -114,8 +133,10 @@ ReduceHelper::IsSearchResultRefineEnabled(SearchResult* search_result) const {
         return false;
     }
     auto segment = static_cast<SegmentInterface*>(search_result->segment_);
+    milvus::OpContext result_op_ctx;
+    InitSearchResultOpContext(*search_result, op_ctx_, result_op_ctx);
     return segment->IsIndexRefineEnabled(
-        op_ctx_, plan_->plan_node_->search_info_.field_id_);
+        &result_op_ctx, plan_->plan_node_->search_info_.field_id_);
 }
 
 void
@@ -136,7 +157,9 @@ ReduceHelper::FilterInvalidSearchResult(SearchResult* search_result) {
     auto& offsets = search_result->seg_offsets_;
     auto& distances = search_result->distances_;
 
-    int segment_row_count = segment->get_row_count();
+    milvus::OpContext result_op_ctx;
+    InitSearchResultOpContext(*search_result, op_ctx_, result_op_ctx);
+    int segment_row_count = segment->get_row_count(&result_op_ctx);
     //1. for sealed segment, segment_row_count will not change as delete records will take effect as bitset
     //2. for growing segment, segment_row_count is the minimum position acknowledged, which will only increase after
     //the time at which the search operation is executed, so it's safe here to keep this value inside stack
@@ -213,7 +236,10 @@ ReduceHelper::FillPrimaryKey() {
             auto future = pool.Submit([this, search_result] {
                 auto segment =
                     static_cast<SegmentInterface*>(search_result->segment_);
-                segment->FillPrimaryKeys(plan_, *search_result, op_ctx_);
+                milvus::OpContext result_op_ctx;
+                InitSearchResultOpContext(
+                    *search_result, op_ctx_, result_op_ctx);
+                segment->FillPrimaryKeys(plan_, *search_result, &result_op_ctx);
             });
             futures.emplace_back(std::move(future));
         }
@@ -233,7 +259,9 @@ ReduceHelper::FillPrimaryKey() {
     } else if (num_segments_ == 1) {
         auto segment =
             static_cast<SegmentInterface*>(search_results_[0]->segment_);
-        segment->FillPrimaryKeys(plan_, *search_results_[0], op_ctx_);
+        milvus::OpContext result_op_ctx;
+        InitSearchResultOpContext(*search_results_[0], op_ctx_, result_op_ctx);
+        segment->FillPrimaryKeys(plan_, *search_results_[0], &result_op_ctx);
     }
 }
 
@@ -370,6 +398,8 @@ ReduceHelper::RefineOneSegment(SearchResult* search_result,
                                int64_t element_size,
                                const char* dense_blob) {
     auto segment = static_cast<SegmentInterface*>(search_result->segment_);
+    milvus::OpContext result_op_ctx;
+    InitSearchResultOpContext(*search_result, op_ctx_, result_op_ctx);
     auto nq = search_result->total_nq_;
     std::vector<size_t> indices;
     std::vector<float> new_distances;
@@ -392,7 +422,7 @@ ReduceHelper::RefineOneSegment(SearchResult* search_result,
         auto result_count = static_cast<size_t>(count);
         auto* offsets = &search_result->seg_offsets_[nq_begin];
         new_distances.resize(result_count);
-        bool ok = segment->CalcDistByIDs(op_ctx_,
+        bool ok = segment->CalcDistByIDs(&result_op_ctx,
                                          field_id,
                                          query_dataset,
                                          offsets,

--- a/internal/core/src/segcore/search_result_export_c.cpp
+++ b/internal/core/src/segcore/search_result_export_c.cpp
@@ -69,6 +69,21 @@ using CBufferPtr = std::unique_ptr<void, CFreeDeleter>;
 using ChunkSizesPtr = std::unique_ptr<int64_t, CFreeDeleter>;
 
 void
+InitSearchResultOpContext(const SearchResult& search_result,
+                          const milvus::OpContext* source,
+                          milvus::OpContext& target) {
+    if (source != nullptr) {
+        target.cancellation_token = source->cancellation_token;
+        target.runtime_load_priority = source->runtime_load_priority;
+        target.coload_fields = source->coload_fields;
+        target.trace_context = source->trace_context;
+        target.trace_span = source->trace_span;
+    }
+    target.pinned_segment_state = search_result.pinned_segment_state_;
+    target.pinned_state_owner = search_result.pinned_state_owner_;
+}
+
+void
 ReleaseArrowSchemaIfNeeded(ArrowSchema* schema) {
     if (schema != nullptr && schema->release != nullptr) {
         schema->release(schema);
@@ -774,18 +789,23 @@ BuildSearchResultFullBatch(CSearchResult c_search_result,
     if (num_extra_fields > 0 && extra_field_ids != nullptr &&
         search_result->get_total_result_count() > 0) {
         auto size = search_result->seg_offsets_.size();
-        milvus::OpContext op_ctx(cancel_token);
+        milvus::OpContext source_ctx(cancel_token);
+        milvus::OpContext result_op_ctx;
+        InitSearchResultOpContext(*search_result, &source_ctx, result_op_ctx);
         for (int64_t i = 0; i < num_extra_fields; i++) {
             milvus::futures::throwIfCancelled(cancel_token);
             auto field_id = milvus::FieldId(extra_field_ids[i]);
-            auto field_data = segment->bulk_subscript(
-                &op_ctx, field_id, search_result->seg_offsets_.data(), size);
+            auto field_data =
+                segment->bulk_subscript(&result_op_ctx,
+                                        field_id,
+                                        search_result->seg_offsets_.data(),
+                                        size);
             extra_fields[field_id] = std::move(field_data);
         }
         search_result->search_storage_cost_.scanned_remote_bytes +=
-            op_ctx.storage_usage.scanned_cold_bytes.load();
+            result_op_ctx.storage_usage.scanned_cold_bytes.load();
         search_result->search_storage_cost_.scanned_total_bytes +=
-            op_ctx.storage_usage.scanned_total_bytes.load();
+            result_op_ctx.storage_usage.scanned_total_bytes.load();
     }
 
     milvus::futures::throwIfCancelled(cancel_token);
@@ -934,6 +954,9 @@ FillOutputFieldsOrderedImpl(CSearchResult* search_results,
 
             auto& seg_res = seg_results[seg_idx];
             seg_res.temp_result.segment_ = sr->segment_;
+            seg_res.temp_result.pinned_segment_state_ =
+                sr->pinned_segment_state_;
+            seg_res.temp_result.pinned_state_owner_ = sr->pinned_state_owner_;
             seg_res.result_positions.reserve(pairs.size());
 
             for (auto& [pos, offset] : pairs) {
@@ -965,9 +988,11 @@ FillOutputFieldsOrderedImpl(CSearchResult* search_results,
                         sr->segment_);
                 auto* seg_res_ptr = &seg_res;
                 futures.emplace_back(
-                    pool.Submit([segment, plan, seg_res_ptr, &op_ctx] {
+                    pool.Submit([segment, plan, sr, seg_res_ptr, &op_ctx] {
+                        milvus::OpContext result_op_ctx;
+                        InitSearchResultOpContext(*sr, &op_ctx, result_op_ctx);
                         segment->FillTargetEntry(
-                            plan, seg_res_ptr->temp_result, &op_ctx);
+                            plan, seg_res_ptr->temp_result, &result_op_ctx);
                     }));
             }
             for (auto& future : futures) {
@@ -979,7 +1004,9 @@ FillOutputFieldsOrderedImpl(CSearchResult* search_results,
             auto segment =
                 static_cast<milvus::segcore::SegmentInternalInterface*>(
                     sr->segment_);
-            segment->FillTargetEntry(plan, seg_res.temp_result, &op_ctx);
+            milvus::OpContext result_op_ctx;
+            InitSearchResultOpContext(*sr, &op_ctx, result_op_ctx);
+            segment->FillTargetEntry(plan, seg_res.temp_result, &result_op_ctx);
         }
 
         // Write storage cost back to original search results

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -365,50 +365,6 @@ GetSearchResultValidCount(CSearchResult search_result) {
     return res->valid_count_;
 }
 
-// Verifies the plan's external field references against the loaded manifest,
-// after LazyCheckSchema refreshed the segment schema and manifest view.
-// Optionally ignores fields that the current execution path will not access.
-void
-CheckExternalFieldsInLoadedManifest(
-    const milvus::SchemaPtr& schema,
-    milvus::segcore::SegmentInternalInterface* segment,
-    const std::vector<milvus::FieldId>& fields,
-    const std::vector<milvus::FieldId>& skipped_fields = {}) {
-    if (!schema || !schema->is_external_collection()) {
-        return;
-    }
-
-    for (auto field_id : fields) {
-        if (std::find(skipped_fields.begin(), skipped_fields.end(), field_id) !=
-            skipped_fields.end()) {
-            continue;
-        }
-        if (!schema->has_field(field_id)) {
-            continue;
-        }
-
-        if (!schema->IsExternalManifestStoredField(field_id)) {
-            continue;
-        }
-        const auto& field_meta = schema->operator[](field_id);
-        auto column_name = schema->GetPhysicalColumnName(field_id);
-        // External output may be served through take(), so "ready" here means
-        // the loaded manifest contains the storage column. It intentionally
-        // does not require field data or index accessibility.
-        if (!segment->HasColumnInLoadedManifest(column_name)) {
-            throw milvus::SegcoreError(
-                milvus::FieldNotLoaded,
-                fmt::format(
-                    "external field \"{}\" (storage column \"{}\") is not "
-                    "available in the current loaded external collection "
-                    "manifest; run RefreshExternalCollection and reload the "
-                    "collection before accessing this field",
-                    field_meta.get_name().get(),
-                    column_name));
-        }
-    }
-}
-
 //////////////////////////////    public C API wrappers    //////////////////////////////
 
 CFuture*  // Future<milvus::SearchResult*>
@@ -449,45 +405,19 @@ AsyncSearch(CTraceContext c_trace,
             milvus::tracer::SetRootSpan(span);
             AssertInfo(phg_ptr != nullptr && !phg_ptr->empty(),
                        "search requires non-empty placeholder group");
-            const int64_t num_queries = milvus::query::GetNumOfQueries(phg_ptr);
-            auto target_vector_field_id =
-                plan->plan_node_->search_info_.field_id_;
 
             milvus::OpContext op_ctx(cancel_token);
             segment->LazyCheckSchema(plan->schema_, &op_ctx);
-            auto internal_segment =
-                static_cast<milvus::segcore::SegmentInternalInterface*>(
-                    segment);
-            std::vector<milvus::FieldId> skipped_manifest_fields;
-            if (filter_only) {
-                skipped_manifest_fields.push_back(target_vector_field_id);
-                for (auto field_id : plan->target_entries_) {
-                    skipped_manifest_fields.push_back(field_id);
-                }
-            }
-            CheckExternalFieldsInLoadedManifest(plan->schema_,
-                                                internal_segment,
-                                                plan->access_entries_,
-                                                skipped_manifest_fields);
-            std::unique_ptr<milvus::SearchResult> search_result;
-            if (!filter_only &&
-                !internal_segment->FieldAccessible(target_vector_field_id)) {
-                search_result = std::make_unique<milvus::SearchResult>();
-                search_result->total_nq_ = num_queries;
-                search_result->unity_topK_ = 0;
-                search_result->total_data_cnt_ = 0;
-            } else {
-                search_result = segment->Search(plan,
-                                                phg_ptr,
-                                                timestamp,
-                                                cancel_token,
-                                                consistency_level,
-                                                collection_ttl,
-                                                entity_ttl_physical_time_us,
-                                                filter_only,
-                                                enable_expr_cache,
-                                                span);
-            }
+            auto search_result = segment->Search(plan,
+                                                 phg_ptr,
+                                                 timestamp,
+                                                 cancel_token,
+                                                 consistency_level,
+                                                 collection_ttl,
+                                                 entity_ttl_physical_time_us,
+                                                 filter_only,
+                                                 enable_expr_cache,
+                                                 span);
             if (!filter_only &&
                 !milvus::PositivelyRelated(
                     plan->plan_node_->search_info_.metric_type_)) {
@@ -562,11 +492,6 @@ AsyncRetrieve(CTraceContext c_trace,
 
             milvus::OpContext op_ctx(cancel_token);
             segment->LazyCheckSchema(plan->schema_, &op_ctx);
-            auto internal_segment =
-                static_cast<milvus::segcore::SegmentInternalInterface*>(
-                    segment);
-            CheckExternalFieldsInLoadedManifest(
-                plan->schema_, internal_segment, plan->access_entries_);
 
             auto retrieve_result =
                 segment->Retrieve(&trace_ctx,
@@ -607,11 +532,6 @@ AsyncRetrieveByOffsets(CTraceContext c_trace,
 
             milvus::OpContext op_ctx(cancel_token);
             segment->LazyCheckSchema(plan->schema_, &op_ctx);
-            auto internal_segment =
-                static_cast<milvus::segcore::SegmentInternalInterface*>(
-                    segment);
-            CheckExternalFieldsInLoadedManifest(
-                plan->schema_, internal_segment, plan->access_entries_);
 
             auto retrieve_result =
                 segment->Retrieve(&trace_ctx, plan, offsets, len, cancel_token);

--- a/internal/core/unittest/test_commit_timestamp.cpp
+++ b/internal/core/unittest/test_commit_timestamp.cpp
@@ -250,12 +250,13 @@ TEST(CommitTimestamp, Boundary_CommitEqualsMaxRowTs) {
 // V2/V3 column-group fixture
 //
 // On v2/v3 import segments the raw timestamp column (original row_ts) is
-// emplaced into fields_ by load_field_data_common, while the timestamp index
+// published in RuntimeResourceState::fields by load_field_data_common, while
+// the timestamp index
 // is built from commit_ts via init_storage_v1_timestamp_index. The V1 fixture
 // above (CreateImportSegment / LoadGeneratedDataIntoSegment) never reproduces
 // this state because the V1 path stores timestamps in insert_record_ instead
-// of fields_. CommitTimestampV2TestAccess pokes the private fields_ map to
-// simulate exactly the v2/v3 shape, so we can verify that EffectiveCommitTs()
+// of the published runtime fields. CommitTimestampV2TestAccess publishes that
+// exact v2/v3 shape, so we can verify that EffectiveCommitTs()
 // short-circuits every timestamp reader regardless of which storage path
 // populated fields_.
 // ===========================================================================
@@ -302,7 +303,9 @@ class CommitTimestampV2TestAccess {
                 std::move(translator), nullptr);
         auto column =
             std::make_shared<ChunkedColumn>(std::move(slot), ts_field_meta);
-        segment->fields_.wlock()->insert_or_assign(TimestampFieldID, column);
+        auto runtime = segment->TestCloneMutableRuntimeResourceState();
+        runtime->fields.insert_or_assign(TimestampFieldID, column);
+        segment->TestPublishRuntimeResourceState(std::move(runtime));
     }
 };
 

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -68,6 +68,7 @@
 #include "pb/common.pb.h"
 #include "pb/schema.pb.h"
 #include "query/Plan.h"
+#include "query/ExecPlanNodeVisitor.h"
 #include "query/PlanImpl.h"
 #include "query/Utils.h"
 #include "segcore/ChunkedSegmentSealedImpl.h"
@@ -77,6 +78,7 @@
 #include "segcore/SegmentLoadInfo.h"
 #include "segcore/SegmentSealed.h"
 #include "segcore/Types.h"
+#include "segcore/reduce/Reduce.h"
 #include "segcore/storagev2translator/SystemIndexTranslator.h"
 #include "storage/FileManager.h"
 #include "storage/InsertData.h"
@@ -87,6 +89,7 @@
 #include "storage/Util.h"
 #include "test_utils/Constants.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/GenExprProto.h"
 #include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/indexbuilder_test_utils.h"
 #include "test_utils/storage_test_utils.h"
@@ -4981,6 +4984,88 @@ TEST(SealedSegmentCowState, ReplacePkStateIsInvisibleUntilFinalPublish) {
     EXPECT_EQ(current->runtime->pk_index_slot, old_pk_index_slot);
 }
 
+TEST(SealedSegmentCowState,
+     StagedRowCountDoesNotMutateDeleteStateBeforePublish) {
+    constexpr int64_t old_row_count = 8;
+    constexpr int64_t new_row_count = 13;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto value = schema->AddDebugField("value", DataType::INT64);
+    schema->set_primary_field_id(pk);
+
+    auto old_dataset = DataGen(schema, old_row_count);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, old_dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    ASSERT_EQ(sealed->get_row_count(), old_row_count);
+    ASSERT_EQ(sealed->TestDeletedRecordRowCount(), old_row_count);
+
+    auto replacement_dataset = DataGen(schema, new_row_count);
+    auto replacement_segment =
+        CreateSealedWithFieldDataLoaded(schema, replacement_dataset);
+    auto* replacement_sealed =
+        dynamic_cast<ChunkedSegmentSealedImpl*>(replacement_segment.get());
+    ASSERT_NE(replacement_sealed, nullptr);
+    auto replacement_column =
+        replacement_sealed->TestGetPublishedStateSnapshot()->runtime->fields.at(
+            value);
+
+    auto current = sealed->TestGetPublishedStateSnapshot();
+    auto stage = [&](bool abort_before_publish) {
+        auto runtime = sealed->TestCloneMutableRuntimeResourceState();
+        ChunkedSegmentSealedImpl::StateDelta initial_delta;
+        initial_delta.schema = current->schema;
+        initial_delta.load_info = current->load_info;
+        initial_delta.runtime = sealed->TestFreezeRuntimeResourceState(runtime);
+        initial_delta.commit_ts = current->commit_ts;
+        auto staged =
+            sealed->TestBuildNextPublishedState(current, initial_delta);
+
+        ChunkedSegmentSealedImpl::StateDelta final_delta;
+        final_delta.schema = current->schema;
+        final_delta.load_info = current->load_info;
+        final_delta.commit_ts = current->commit_ts;
+
+        auto stage_and_publish = [&] {
+            sealed->TestStageLoadFieldDataThenPublish(
+                value,
+                replacement_column,
+                new_row_count,
+                DataType::INT64,
+                schema,
+                runtime,
+                staged.get(),
+                current,
+                final_delta,
+                [&] {
+                    EXPECT_EQ(runtime->row_count, new_row_count);
+                    EXPECT_EQ(sealed->get_row_count(), old_row_count);
+                    EXPECT_EQ(sealed->TestDeletedRecordRowCount(),
+                              old_row_count);
+                    if (abort_before_publish) {
+                        throw std::runtime_error(
+                            "abort staged row-count publish");
+                    }
+                });
+        };
+
+        if (abort_before_publish) {
+            EXPECT_THROW(stage_and_publish(), std::runtime_error);
+        } else {
+            EXPECT_NO_THROW(stage_and_publish());
+        }
+    };
+
+    stage(true);
+    EXPECT_EQ(sealed->get_row_count(), old_row_count);
+    EXPECT_EQ(sealed->TestDeletedRecordRowCount(), old_row_count);
+
+    stage(false);
+    EXPECT_EQ(sealed->get_row_count(), new_row_count);
+    EXPECT_EQ(sealed->TestDeletedRecordRowCount(), new_row_count);
+}
+
 TEST(SealedSegmentCowState, ClearPublishedStateDropsRuntimeSnapshot) {
     auto schema = std::make_shared<Schema>();
     auto pk = schema->AddDebugField("pk", DataType::INT64);
@@ -5724,12 +5809,34 @@ TEST(SealedSegmentOpSnapshotPin,
 
     auto dataset = DataGen(schema, N);
     auto expected = dataset.get_col<float>(vec_id);
+    auto pks = dataset.get_col<int64_t>(pk_id);
     auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
     auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
     ASSERT_NE(sealed, nullptr);
 
+    std::vector<int64_t> requested_offsets = {0, 3, 7, 15};
+    std::vector<proto::plan::GenericValue> values;
+    for (auto offset : requested_offsets) {
+        proto::plan::GenericValue value;
+        value.set_int64_val(pks[offset]);
+        values.push_back(std::move(value));
+    }
+    auto term_expr = std::make_shared<milvus::expr::TermFilterExpr>(
+        milvus::expr::ColumnInfo(pk_id, DataType::INT64), values);
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->plan_node_ = std::make_unique<query::RetrievePlanNode>();
+    plan->plan_node_->plannodes_ =
+        milvus::test::CreateRetrievePlanByExpr(term_expr);
+
+    query::ExecPlanNodeVisitor visitor(*sealed, MAX_TIMESTAMP);
+    auto retrieve_result = visitor.get_retrieve_result(*plan->plan_node_);
+    ASSERT_NE(retrieve_result.pinned_segment_state_, nullptr);
+    ASSERT_EQ(retrieve_result.pinned_state_owner_, sealed);
+    ASSERT_EQ(retrieve_result.result_offsets_, requested_offsets);
+
     milvus::OpContext op_ctx;
-    static_cast<SegmentInternalInterface*>(sealed)->PinOpSnapshot(&op_ctx);
+    op_ctx.pinned_segment_state = retrieve_result.pinned_segment_state_;
+    op_ctx.pinned_state_owner = retrieve_result.pinned_state_owner_;
     ASSERT_TRUE(sealed->HasFieldData(vec_id, &op_ctx));
     ASSERT_FALSE(sealed->IndexHasRawData(vec_id, &op_ctx));
 
@@ -5746,7 +5853,7 @@ TEST(SealedSegmentOpSnapshotPin,
     ASSERT_FALSE(sealed->HasFieldData(vec_id));
     ASSERT_TRUE(sealed->IndexHasRawData(vec_id));
 
-    std::vector<int64_t> offsets = {0, 3, 7, 15};
+    const auto& offsets = retrieve_result.result_offsets_;
     auto result =
         sealed->bulk_subscript(&op_ctx, vec_id, offsets.data(), offsets.size());
     const auto& actual = result->vectors().float_vector().data();
@@ -5755,6 +5862,96 @@ TEST(SealedSegmentOpSnapshotPin,
         for (int64_t d = 0; d < DIM; ++d) {
             EXPECT_FLOAT_EQ(actual[i * DIM + d],
                             expected[offsets[i] * DIM + d]);
+        }
+    }
+}
+
+TEST(SealedSegmentOpSnapshotPin,
+     SearchResultPinSurvivesRawIndexTransitionDuringOutputFill) {
+    constexpr int64_t N = 32;
+    constexpr int64_t DIM = 4;
+    constexpr int64_t TOPK = 4;
+
+    auto schema = std::make_shared<Schema>();
+    auto vec_id = schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, DIM, knowhere::metric::L2);
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+
+    auto dataset = DataGen(schema, N);
+    auto vectors = dataset.get_col<float>(vec_id);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    ASSERT_TRUE(sealed->HasFieldData(pk_id));
+    ASSERT_TRUE(sealed->HasFieldData(vec_id));
+    ASSERT_TRUE(sealed->FieldAccessible(vec_id));
+    ASSERT_EQ(sealed->get_row_count(), N);
+
+    ScopedSchemaHandle schema_handle(*schema);
+    auto plan_bytes =
+        schema_handle.ParseSearch("", "vec", TOPK, "L2", R"({"nprobe": 10})");
+    auto plan =
+        CreateSearchPlanByExpr(schema, plan_bytes.data(), plan_bytes.size());
+    plan->target_entries_ = {vec_id};
+    auto ph_group_raw = CreatePlaceholderGroupFromBlob(1, DIM, vectors.data());
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+
+    auto search_result =
+        segment->Search(plan.get(), ph_group.get(), MAX_TIMESTAMP);
+    ASSERT_NE(search_result, nullptr);
+    ASSERT_EQ(search_result->total_data_cnt_, N);
+    ASSERT_EQ(search_result->seg_offsets_.size(), TOPK);
+    for (auto offset : search_result->seg_offsets_) {
+        ASSERT_GE(offset, 0);
+        ASSERT_LT(offset, N);
+    }
+    ASSERT_NE(search_result->pinned_segment_state_, nullptr);
+    ASSERT_EQ(search_result->pinned_state_owner_, sealed);
+
+    auto next_runtime = sealed->TestCloneMutableRuntimeResourceState();
+    next_runtime->fields.erase(pk_id);
+    next_runtime->fields.erase(vec_id);
+    next_runtime->mmap_field_ids.erase(vec_id);
+    sealed->TestPublishRuntimeResourceState(std::move(next_runtime));
+    sealed->TestPublishVectorIndexFacts(vec_id,
+                                        /*ready=*/true,
+                                        /*binlog_ready=*/false,
+                                        /*has_raw_data=*/true);
+    ASSERT_FALSE(sealed->HasFieldData(vec_id));
+    ASSERT_FALSE(sealed->HasFieldData(pk_id));
+    ASSERT_TRUE(sealed->IndexHasRawData(vec_id));
+
+    std::vector<SearchResult*> reduce_results{search_result.get()};
+    int64_t slice_nq = 1;
+    int64_t slice_topk = TOPK;
+    milvus::OpContext reduce_ctx;
+    ReduceHelper reduce_helper(reduce_results,
+                               plan.get(),
+                               ph_group.get(),
+                               &slice_nq,
+                               &slice_topk,
+                               1,
+                               nullptr,
+                               &reduce_ctx);
+    ASSERT_NO_THROW(reduce_helper.PreReduce());
+    ASSERT_EQ(search_result->primary_keys_.size(), TOPK);
+
+    milvus::OpContext fill_ctx;
+    fill_ctx.pinned_segment_state = search_result->pinned_segment_state_;
+    fill_ctx.pinned_state_owner = search_result->pinned_state_owner_;
+    static_cast<SegmentInternalInterface*>(sealed)->FillTargetEntry(
+        plan.get(), *search_result, &fill_ctx);
+
+    auto it = search_result->output_fields_data_.find(vec_id);
+    ASSERT_NE(it, search_result->output_fields_data_.end());
+    const auto& actual = it->second->vectors().float_vector().data();
+    ASSERT_EQ(actual.size(), TOPK * DIM);
+    for (int64_t i = 0; i < TOPK; ++i) {
+        auto offset = search_result->seg_offsets_[i];
+        for (int64_t d = 0; d < DIM; ++d) {
+            EXPECT_FLOAT_EQ(actual[i * DIM + d], vectors[offset * DIM + d]);
         }
     }
 }

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -5514,3 +5514,199 @@ TEST(SealedSegmentCowState, ExternalWrapperSynthesizeRequiresRuntime) {
 
     EXPECT_ANY_THROW(sealed->TestSynthesizeExternalSystemFields(nullptr));
 }
+
+// ==================== Per-Operation Snapshot Pinning Tests ====================
+//
+// These exercise the sealed-segment per-operation snapshot pin (see
+// docs/design-docs/design_docs/20260717-sealed-segment-op-snapshot-pinning.md).
+// The pin lives on milvus::OpContext: PinOpSnapshot() captures the segment's
+// current PublishedSegmentState into the op_ctx, and every op_ctx-aware
+// accessor (num_chunk_data / chunk_data / bulk_subscript / Capture*) resolves
+// reads against that pinned snapshot instead of re-loading the live state.
+
+// Reopen-race regression + fault-injection proof.
+//
+// An in-flight scan of scalar field F must complete on its pinned snapshot even
+// if a concurrent Reopen drops F from the live published state mid-scan. This
+// is the race the pin was built to close: without it, a read of F after the
+// drop resolves the new (F-less) live snapshot and the RawData accessor aborts
+// at AssertInfo(field_data_ready_bitset[F]) inside chunk_data_impl().
+TEST(SealedSegmentOpSnapshotPin, PinnedScanSurvivesMidScanFieldDrop) {
+    const int64_t N = 100;
+
+    auto old_schema = std::make_shared<Schema>();
+    auto pk_id = old_schema->AddDebugField("pk", DataType::INT64);
+    // F: the scalar field the in-flight scan reads on the RawData path.
+    auto scan_field = old_schema->AddDebugField("scan_field", DataType::INT64);
+    old_schema->set_primary_field_id(pk_id);
+    old_schema->set_schema_version(100);
+
+    auto dataset = DataGen(old_schema, N);
+    auto expected = dataset.get_col<int64_t>(scan_field);
+
+    auto segment = CreateSealedWithFieldDataLoaded(old_schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    // Begin the operation: pin the current published state (snapshot S0, which
+    // contains scan_field). PinOpSnapshot is public on the segment interface.
+    milvus::OpContext op_ctx;
+    segment->PinOpSnapshot(&op_ctx);
+
+    // First half of the scan reads scan_field through the pinned op_ctx.
+    ASSERT_EQ(sealed->num_chunk_data(scan_field, &op_ctx), 1);
+    {
+        auto pinned_span = sealed->chunk_data<int64_t>(&op_ctx, scan_field, 0);
+        const int64_t* data = pinned_span.get().data();
+        for (int64_t i = 0; i < N; ++i) {
+            ASSERT_EQ(data[i], expected[i]) << "pre-drop row " << i;
+        }
+    }
+
+    // Mid-scan republish: Reopen with a schema that no longer contains
+    // scan_field. Reopen does not block readers (reopen_mutex_ is writer-only),
+    // so this atomically swaps the live published state to S1 while our op_ctx
+    // still pins S0. This is exactly the concurrent-Reopen window from the
+    // design doc, made deterministic.
+    auto new_schema = std::make_shared<Schema>();
+    auto new_pk_id = new_schema->AddDebugField("pk", DataType::INT64);
+    new_schema->set_primary_field_id(new_pk_id);
+    new_schema->set_schema_version(200);
+    EXPECT_NO_THROW(sealed->Reopen(new_schema));
+
+    // The live (unpinned) state has dropped scan_field: a fresh read with no
+    // op_ctx now sees zero data chunks for it.
+    EXPECT_FALSE(sealed->HasFieldData(scan_field));
+    EXPECT_EQ(sealed->num_chunk_data(scan_field, /*op_ctx=*/nullptr), 0);
+
+    // Second half of the scan, AFTER the drop, still reads scan_field correctly
+    // because the pinned op_ctx resolves S0 -- the field's column is held alive
+    // by the pin and the field_data_ready_bitset it checks is S0's, not S1's.
+    ASSERT_EQ(sealed->num_chunk_data(scan_field, &op_ctx), 1);
+    {
+        auto pinned_span = sealed->chunk_data<int64_t>(&op_ctx, scan_field, 0);
+        const int64_t* data = pinned_span.get().data();
+        for (int64_t i = 0; i < N; ++i) {
+            ASSERT_EQ(data[i], expected[i]) << "post-drop row " << i;
+        }
+    }
+
+    // A bulk_subscript through the pinned op_ctx also stays on S0.
+    std::vector<int64_t> offsets(N);
+    for (int64_t i = 0; i < N; ++i) {
+        offsets[i] = i;
+    }
+    auto pinned_result =
+        sealed->bulk_subscript(&op_ctx, scan_field, offsets.data(), N);
+    ASSERT_EQ(pinned_result->scalars().long_data().data_size(), N);
+    for (int64_t i = 0; i < N; ++i) {
+        ASSERT_EQ(pinned_result->scalars().long_data().data(i), expected[i])
+            << "bulk_subscript row " << i;
+    }
+
+    // Fault-injection argument (documented, not executed):
+    //   The same post-drop read WITHOUT the pin -- e.g.
+    //     sealed->chunk_data<int64_t>(nullptr, scan_field, 0);
+    //   resolves the live S1 state, whose field_data_ready_bitset has
+    //   scan_field cleared, and aborts inside chunk_data_impl() at
+    //     AssertInfo(get_bit(snapshot->field_data_ready_bitset, field_id), ...)
+    //   Because AssertInfo aborts the process (SIGABRT), it cannot be caught
+    //   in-process to make a clean negative assertion here. num_chunk_data with
+    //   a null op_ctx returning 0 above (versus 1 with the pin) is the
+    //   in-process witness of the same live-vs-pinned divergence: an unpinned
+    //   scan that had cached num_chunk_data==1 from S0 and then re-read the
+    //   column would drive chunk_id past the (now empty) live column and hit
+    //   that assert. The pin makes the whole operation observe S0 only.
+}
+
+// Pin identity: within one op_ctx, every capture through the choke point
+// returns the exact same snapshot pointer, even while the writer publishes new
+// state. Mirrors the "one operation, one snapshot" guarantee.
+TEST(SealedSegmentOpSnapshotPin, PinIdentityAcrossConcurrentPublish) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    auto field_id = schema->AddDebugField("val", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+    schema->set_schema_version(100);
+
+    auto dataset = DataGen(schema, 16);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    milvus::OpContext op_ctx;
+    segment->PinOpSnapshot(&op_ctx);
+
+    auto pinned_state = sealed->TestCapturePublishedState(&op_ctx);
+    auto pinned_runtime = sealed->TestCaptureRuntimeResourceState(&op_ctx);
+    ASSERT_NE(pinned_state, nullptr);
+    ASSERT_NE(pinned_runtime, nullptr);
+    // The pinned runtime is the pinned state's runtime -- one snapshot for all.
+    EXPECT_EQ(pinned_runtime.get(), pinned_state->runtime.get());
+
+    // The pinned snapshot differs from the live one only after a publish; hold
+    // a reference to the live snapshot now to compare identity across a publish.
+    auto live_before = sealed->TestGetPublishedStateSnapshot();
+    EXPECT_EQ(pinned_state.get(), live_before.get());
+
+    // Publish a new state via Reopen (drops "val", swaps the live pointer).
+    auto new_schema = std::make_shared<Schema>();
+    auto new_pk_id = new_schema->AddDebugField("pk", DataType::INT64);
+    new_schema->set_primary_field_id(new_pk_id);
+    new_schema->set_schema_version(200);
+    EXPECT_NO_THROW(sealed->Reopen(new_schema));
+
+    // Live state has advanced...
+    auto live_after = sealed->TestGetPublishedStateSnapshot();
+    EXPECT_NE(live_after.get(), pinned_state.get());
+
+    // ...but every capture through the pinned op_ctx still returns S0.
+    EXPECT_EQ(sealed->TestCapturePublishedState(&op_ctx).get(),
+              pinned_state.get());
+    EXPECT_EQ(sealed->TestCaptureRuntimeResourceState(&op_ctx).get(),
+              pinned_runtime.get());
+    // The pinned snapshot still carries "val"; the live one does not.
+    EXPECT_EQ(sealed->num_chunk_data(field_id, &op_ctx), 1);
+    EXPECT_EQ(sealed->num_chunk_data(field_id, /*op_ctx=*/nullptr), 0);
+}
+
+// Owner guard: an op_ctx pinned by segment X must NOT hand back X's snapshot
+// when consulted by a different segment Y. Y's accessors must observe Y's own
+// live state. This prevents an op_ctx reused across segments from leaking one
+// segment's layout into another.
+TEST(SealedSegmentOpSnapshotPin, OwnerGuardRejectsForeignPin) {
+    auto build = [](int64_t version) {
+        auto schema = std::make_shared<Schema>();
+        auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+        auto val_id = schema->AddDebugField("val", DataType::INT64);
+        schema->set_primary_field_id(pk_id);
+        schema->set_schema_version(version);
+        auto dataset = DataGen(schema, 8);
+        auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+        return std::make_pair(std::move(segment), val_id);
+    };
+
+    auto [seg_x, val_x] = build(100);
+    auto [seg_y, val_y] = build(200);
+    auto* sealed_x = dynamic_cast<ChunkedSegmentSealedImpl*>(seg_x.get());
+    auto* sealed_y = dynamic_cast<ChunkedSegmentSealedImpl*>(seg_y.get());
+    ASSERT_NE(sealed_x, nullptr);
+    ASSERT_NE(sealed_y, nullptr);
+
+    // Pin op_ctx on segment X.
+    milvus::OpContext op_ctx;
+    seg_x->PinOpSnapshot(&op_ctx);
+    auto x_pinned = sealed_x->TestCapturePublishedState(&op_ctx);
+    ASSERT_NE(x_pinned, nullptr);
+
+    // X honors its own pin.
+    EXPECT_EQ(sealed_x->TestCapturePublishedState(&op_ctx).get(),
+              x_pinned.get());
+
+    // Y sees the same op_ctx but the owner (pinned_state_owner) is X, not Y --
+    // so Y's capture ignores the foreign pin and returns Y's live state.
+    auto y_live = sealed_y->TestGetPublishedStateSnapshot();
+    auto y_via_foreign_ctx = sealed_y->TestCapturePublishedState(&op_ctx);
+    EXPECT_EQ(y_via_foreign_ctx.get(), y_live.get());
+    EXPECT_NE(y_via_foreign_ctx.get(), x_pinned.get());
+}

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -5515,6 +5515,93 @@ TEST(SealedSegmentCowState, ExternalWrapperSynthesizeRequiresRuntime) {
     EXPECT_ANY_THROW(sealed->TestSynthesizeExternalSystemFields(nullptr));
 }
 
+TEST(SealedSegmentCowState, MiscRuntimeStateFollowsPinnedSnapshotLifetime) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    std::map<std::string, std::string> analyzer_params;
+    auto payload = schema->AddDebugVarcharField(FieldName("payload"),
+                                                DataType::VARCHAR,
+                                                1024,
+                                                /*nullable=*/false,
+                                                /*enable_match=*/false,
+                                                /*enable_analyzer=*/false,
+                                                analyzer_params,
+                                                std::nullopt);
+    schema->set_primary_field_id(pk);
+
+    constexpr int64_t row_count = 8;
+    auto dataset = DataGen(schema, row_count);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    milvus::OpContext pinned;
+    static_cast<SegmentInternalInterface*>(sealed)->PinOpSnapshot(&pinned);
+    auto old_state = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(old_state->runtime, nullptr);
+    ASSERT_EQ(old_state->runtime->row_count, row_count);
+    ASSERT_EQ(old_state->runtime->variable_fields_avg_size.count(payload), 1);
+    auto old_avg_size = sealed->get_field_avg_size(payload, &pinned);
+    auto old_mmap = sealed->is_mmap_field(payload, &pinned);
+
+    auto next_runtime = sealed->TestCloneMutableRuntimeResourceState();
+    next_runtime->row_count = row_count + 1;
+    if (old_mmap) {
+        next_runtime->mmap_field_ids.erase(payload);
+    } else {
+        next_runtime->mmap_field_ids.insert(payload);
+    }
+    next_runtime->variable_fields_avg_size[payload] = {row_count + 1, 123};
+    sealed->TestPublishRuntimeResourceState(std::move(next_runtime));
+
+    EXPECT_EQ(sealed->get_row_count(), row_count + 1);
+    EXPECT_EQ(sealed->get_field_avg_size(payload), 123);
+    EXPECT_EQ(sealed->is_mmap_field(payload), !old_mmap);
+
+    EXPECT_EQ(sealed->get_row_count(&pinned), row_count);
+    EXPECT_EQ(sealed->get_field_avg_size(payload, &pinned), old_avg_size);
+    EXPECT_EQ(sealed->is_mmap_field(payload, &pinned), old_mmap);
+}
+
+TEST(SealedSegmentCowState,
+     DropFieldDataPreservesAvgSizeForSchemaRetainedField) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    std::map<std::string, std::string> analyzer_params;
+    auto payload = schema->AddDebugVarcharField(FieldName("payload"),
+                                                DataType::VARCHAR,
+                                                1024,
+                                                /*nullable=*/false,
+                                                /*enable_match=*/false,
+                                                /*enable_analyzer=*/false,
+                                                analyzer_params,
+                                                std::nullopt);
+    schema->set_primary_field_id(pk);
+
+    auto dataset = DataGen(schema, 8);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    sealed->set_field_avg_size(payload, 1, 128);
+    auto old_state = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_EQ(old_state->runtime->fields.count(payload), 1);
+    ASSERT_EQ(old_state->runtime->variable_fields_avg_size.count(payload), 1);
+    auto old_avg_info =
+        old_state->runtime->variable_fields_avg_size.at(payload);
+
+    sealed->DropFieldData(payload);
+
+    auto new_state = sealed->TestGetPublishedStateSnapshot();
+    EXPECT_EQ(new_state->runtime->fields.count(payload), 0);
+    ASSERT_EQ(new_state->runtime->variable_fields_avg_size.count(payload), 1);
+    EXPECT_EQ(new_state->runtime->variable_fields_avg_size.at(payload),
+              old_avg_info);
+    EXPECT_EQ(old_state->runtime->fields.count(payload), 1);
+    EXPECT_EQ(old_state->runtime->variable_fields_avg_size.at(payload),
+              old_avg_info);
+}
+
 // ==================== Per-Operation Snapshot Pinning Tests ====================
 //
 // These exercise the sealed-segment per-operation snapshot pin (see
@@ -5619,6 +5706,59 @@ TEST(SealedSegmentOpSnapshotPin, PinnedScanSurvivesMidScanFieldDrop) {
     //   that assert. The pin makes the whole operation observe S0 only.
 }
 
+// Regression for #51594's no-raw-index -> raw-index transition.  The
+// operation starts while vector output must use the raw column.  A concurrent
+// publish then advertises index raw data and removes that column.  The pinned
+// bulk_subscript must keep both its routing decision and its column lookup on
+// the pre-transition snapshot.
+TEST(SealedSegmentOpSnapshotPin,
+     PinnedVectorRetrieveSurvivesRawIndexTransition) {
+    constexpr int64_t N = 16;
+    constexpr int64_t DIM = 4;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    auto vec_id = schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, DIM, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_id);
+
+    auto dataset = DataGen(schema, N);
+    auto expected = dataset.get_col<float>(vec_id);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    milvus::OpContext op_ctx;
+    static_cast<SegmentInternalInterface*>(sealed)->PinOpSnapshot(&op_ctx);
+    ASSERT_TRUE(sealed->HasFieldData(vec_id, &op_ctx));
+    ASSERT_FALSE(sealed->IndexHasRawData(vec_id, &op_ctx));
+
+    // Publish the post-Reopen shape from the reported race: the live state no
+    // longer has the raw column and routes vector output to index raw data.
+    auto next_runtime = sealed->TestCloneMutableRuntimeResourceState();
+    next_runtime->fields.erase(vec_id);
+    next_runtime->mmap_field_ids.erase(vec_id);
+    sealed->TestPublishRuntimeResourceState(std::move(next_runtime));
+    sealed->TestPublishVectorIndexFacts(vec_id,
+                                        /*ready=*/true,
+                                        /*binlog_ready=*/false,
+                                        /*has_raw_data=*/true);
+    ASSERT_FALSE(sealed->HasFieldData(vec_id));
+    ASSERT_TRUE(sealed->IndexHasRawData(vec_id));
+
+    std::vector<int64_t> offsets = {0, 3, 7, 15};
+    auto result =
+        sealed->bulk_subscript(&op_ctx, vec_id, offsets.data(), offsets.size());
+    const auto& actual = result->vectors().float_vector().data();
+    ASSERT_EQ(actual.size(), offsets.size() * DIM);
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        for (int64_t d = 0; d < DIM; ++d) {
+            EXPECT_FLOAT_EQ(actual[i * DIM + d],
+                            expected[offsets[i] * DIM + d]);
+        }
+    }
+}
+
 // Pin identity: within one op_ctx, every capture through the choke point
 // returns the exact same snapshot pointer, even while the writer publishes new
 // state. Mirrors the "one operation, one snapshot" guarantee.
@@ -5659,6 +5799,10 @@ TEST(SealedSegmentOpSnapshotPin, PinIdentityAcrossConcurrentPublish) {
     // Live state has advanced...
     auto live_after = sealed->TestGetPublishedStateSnapshot();
     EXPECT_NE(live_after.get(), pinned_state.get());
+
+    // Re-entering the pin API within the same operation is idempotent and must
+    // not replace S0 with the now-current S1.
+    segment->PinOpSnapshot(&op_ctx);
 
     // ...but every capture through the pinned op_ctx still returns S0.
     EXPECT_EQ(sealed->TestCapturePublishedState(&op_ctx).get(),


### PR DESCRIPTION
## What & why

Sealed-segment readers previously captured `published_state_` independently at multiple accessor calls. A concurrent `Reopen` could make one logical read derive routing/layout from snapshot A and fetch data from snapshot B.

The concrete #51594 failure is a no-raw-index -> raw-data-capable-index transition: query execution chooses the raw column from the old state, `Reopen` publishes the new index state and reclaims that column, then later Retrieve/Search materialization consults the new state and asserts.

This PR makes each sealed-segment Search/Retrieve operation observe one immutable published snapshot from query entry through reduce and output materialization.

## Design

- `ExecPlanNodeVisitor` pins before deriving `active_count`.
- `QueryContext` is the exec/query layer's single source of `OpContext`; operators call `query_context_->get_op_context()`, and `CompileExpression` resolves that same pointer into the physical expression tree's existing `op_ctx_`.
- Segcore accessors accept the resulting `OpContext*`; segcore does not depend on `QueryContext`.
- `RetrieveResult` and `SearchResult` retain the type-erased segment pin after `QueryContext` is destroyed.
- Reduce/export reconstruct one temporary context per result/segment, so parallel segments never share a mutable pin slot.
- Offset-driven Retrieve pins independently.
- Deletes remain live; sealed delete-mask row count advances only with the final runtime-state publication.

## Completeness: absorb #51531 into #51602

This PR supersedes #51531 and keeps its useful sealed runtime-state consolidation:

- row count, mmap-field markers, and variable-field average-size metadata live in `RuntimeResourceState`;
- fields, indexes, array offsets, timestamp state, and misc runtime metadata follow one clone/freeze/publish COW lifecycle;
- aborted Reopen staging cannot leak a future row count into `deleted_record_`;
- average-size metadata survives raw-column reclamation while the schema still retains the field.

It intentionally does not adopt a mutable `shared_ptr<SkipIndex>`. Skip-index ownership remains immutable and column/runtime-snapshot aligned.

## #51594 coverage

The routing and data reads in the reported chain now resolve the same pin:

`IndexHasRawData / HasFieldData -> bulk_subscript -> get_raw_data / get_vector / get_emb_list`

Regression coverage includes:

- `PinnedVectorRetrieveSurvivesRawIndexTransition`;
- `SearchResultPinSurvivesRawIndexTransitionDuringOutputFill`;
- `PinIdentityAcrossConcurrentPublish`;
- `OwnerGuardRejectsForeignPin`;
- `StagedRowCountDoesNotMutateDeleteStateBeforePublish`.

## Validation

- `cmake --build cmake_build --target milvus_core all_tests -j4`;
- 41/41 `SealedSegmentCowState.*`, `SealedSegmentOpSnapshotPin.*`, and `CommitTimestamp.*`;
- 121/121 external-take, Match expression, JSON flat-index, and element-filter tests;
- clang-format 15 idempotence and `git diff --check`;
- five unrelated broader-test failures were reproduced identically on committed baseline `4fa0143`.

issue: #51594
