### PR TITLE
fix: [cp3.0] restore dropped load transient budget fixes

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -28,7 +28,7 @@ class MilvusConan(ConanFile):
         "prometheus-cpp/1.2.4#0918d66c13f97acb7809759f9de49b3f",
         "re2/20230301#f8efaf45f98d0193cd0b2ea08b6b4060",
         "folly/2026.04.20.00@milvus/dev#06852bea5b6449f0c4eb0df002b5779c",
-        "milvus-common/1.0.0-a3299ca@milvus/dev#eea0e22b8d5e36ff6f0a5ffbed14703e",
+        "milvus-common/1.0.0-5b3ac69@milvus/dev#9675ca9b93554e6ee797ededdcef82a2",
         "google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43",
         "opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720",
         "librdkafka/1.9.1#ec1a00d5414f618555799be9566adfb7",

--- a/internal/core/src/index/BitmapIndexArrayTest.cpp
+++ b/internal/core/src/index/BitmapIndexArrayTest.cpp
@@ -13,6 +13,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <fmt/core.h>
 #include <folly/FBVector.h>
+#include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 #include <stdint.h>
@@ -48,13 +49,16 @@
 #include "pb/common.pb.h"
 #include "pb/schema.pb.h"
 #include "storage/ChunkManager.h"
+#include "storage/EntryStreamUtils.h"
 #include "storage/FileManager.h"
 #include "storage/InsertData.h"
 #include "storage/PayloadReader.h"
+#include "storage/PluginLoader.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "test_utils/Constants.h"
+#include "test_utils/PlannerCipherPlugin.h"
 
 using namespace milvus::index;
 using namespace milvus::indexbuilder;
@@ -1455,6 +1459,32 @@ TEST(ScalarIndexSortArrayNestedTest, ArraySortIndexDoesNotExposeRawArrayData) {
 
     boost::filesystem::remove_all(numeric_root_path);
     boost::filesystem::remove_all(string_root_path);
+}
+
+TEST(BitmapIndexLoadResourceTest,
+     EncryptedNonMmapIncludesTargetAndStreamMemory) {
+    auto& budget = storage::TransientMemoryBudget::GetLoadTransientBudget();
+    auto old_capacity = budget.CapacityBytes();
+    auto& plugin_loader = storage::PluginLoader::GetInstance();
+    auto cleanup = folly::makeGuard([&]() {
+        budget.SetCapacityBytes(old_capacity);
+        plugin_loader.unload("CipherPlugin");
+    });
+    budget.SetCapacityBytes(0);
+    plugin_loader.addPluginForTest(
+        std::make_shared<milvus::test::PlannerCipherPlugin>());
+
+    constexpr uint64_t index_size = 32 * 1024 * 1024;
+    std::map<std::string, std::string> index_params{
+        {index::INDEX_TYPE, index::BITMAP_INDEX_TYPE},
+        {index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+    auto request = index::IndexFactory::GetInstance().ScalarIndexLoadResource(
+        DataType::INT64, 0, index_size, index_params, false, 1024);
+
+    EXPECT_EQ(request.final_memory_cost, index_size);
+    EXPECT_EQ(request.max_memory_cost, 4 * index_size);
+    EXPECT_EQ(request.final_disk_cost, 0);
+    EXPECT_EQ(request.max_disk_cost, 0);
 }
 
 // Bug #4: ArrayOffsetsSealed::BuildAllZeros is used in the add-field /

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -55,11 +55,13 @@
 #include "storage/InsertData.h"
 #include "storage/PayloadReader.h"
 #include "storage/EntryStreamUtils.h"
+#include "storage/PluginLoader.h"
 #include "storage/ThreadPool.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "test_utils/Constants.h"
+#include "test_utils/PlannerCipherPlugin.h"
 
 using namespace milvus::index;
 using namespace milvus::indexbuilder;
@@ -863,6 +865,29 @@ TYPED_TEST_P(HybridIndexTestInverted,
         max_task_overhead);
     EXPECT_EQ(
         budgeted_translator.meta()->loading_overhead->upper_bound.file_bytes,
+        0);
+
+    budget.SetCapacityBytes(0);
+    auto& plugin_loader = storage::PluginLoader::GetInstance();
+    plugin_loader.addPluginForTest(
+        std::make_shared<milvus::test::PlannerCipherPlugin>());
+    auto plugin_cleanup = folly::makeGuard(
+        [&plugin_loader]() { plugin_loader.unload("CipherPlugin"); });
+    Config encrypted_config = index_params;
+    milvus::segcore::storagev1translator::SealedIndexTranslator
+        encrypted_translator(index_info,
+                             &load_info,
+                             milvus::tracer::TraceContext{},
+                             ctx,
+                             std::move(encrypted_config));
+
+    auto encrypted_index_bound = storage::EntryStreamDataTransientBytes(
+        static_cast<size_t>(load_info.index_size), true);
+    EXPECT_EQ(
+        encrypted_translator.meta()->loading_overhead->upper_bound.memory_bytes,
+        milvus::segcore::LoadTransientPoolUpperBound(encrypted_index_bound));
+    EXPECT_EQ(
+        encrypted_translator.meta()->loading_overhead->upper_bound.file_bytes,
         0);
 }
 

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -754,6 +754,12 @@ TYPED_TEST_SUITE_P(HybridIndexTestInverted);
 
 TYPED_TEST_P(HybridIndexTestInverted,
              ResourceEstimateUsesInternalInvertedIndexType) {
+    auto& plugin_loader = storage::PluginLoader::GetInstance();
+    plugin_loader.addPluginForTest(
+        std::make_shared<milvus::test::PlannerCipherPlugin>());
+    auto plugin_cleanup = folly::makeGuard(
+        [&plugin_loader]() { plugin_loader.unload("CipherPlugin"); });
+
     auto stream_budget = storage::EntryStreamMaxTransientBytes();
     auto index_size = static_cast<uint64_t>(stream_budget);
     if (stream_budget == std::numeric_limits<size_t>::max() ||
@@ -886,23 +892,21 @@ TYPED_TEST_P(HybridIndexTestInverted,
         std::make_shared<milvus::test::PlannerCipherPlugin>());
     auto plugin_cleanup = folly::makeGuard(
         [&plugin_loader]() { plugin_loader.unload("CipherPlugin"); });
-    Config encrypted_config = index_params;
+    Config plugin_loaded_config = index_params;
     milvus::segcore::storagev1translator::SealedIndexTranslator
-        encrypted_translator(index_info,
-                             &load_info,
-                             milvus::tracer::TraceContext{},
-                             ctx,
-                             std::move(encrypted_config));
+        plugin_loaded_translator(index_info,
+                                 &load_info,
+                                 milvus::tracer::TraceContext{},
+                                 ctx,
+                                 std::move(plugin_loaded_config));
 
-    auto encrypted_index_bound = storage::EntryStreamDataTransientBytes(
-        static_cast<size_t>(load_info.index_size), true);
     ASSERT_TRUE(
-        encrypted_translator.meta()->loading_overhead->memory.has_value());
+        plugin_loaded_translator.meta()->loading_overhead->memory.has_value());
     EXPECT_FALSE(
-        encrypted_translator.meta()->loading_overhead->file.has_value());
+        plugin_loaded_translator.meta()->loading_overhead->file.has_value());
     EXPECT_EQ(
-        encrypted_translator.meta()->loading_overhead->memory->upper_bound,
-        milvus::segcore::LoadTransientPoolUpperBound(encrypted_index_bound));
+        plugin_loaded_translator.meta()->loading_overhead->memory->upper_bound,
+        max_load_tasks * max_task_overhead);
 }
 
 template <typename T>

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -36,7 +36,6 @@
 #include "common/TracerBase.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
-#include "cachinglayer/LoadingOverheadTracker.h"
 #include "gtest/gtest.h"
 #include "index/HybridScalarIndex.h"
 #include "index/Index.h"
@@ -56,6 +55,7 @@
 #include "storage/InsertData.h"
 #include "storage/PayloadReader.h"
 #include "storage/EntryStreamUtils.h"
+#include "storage/ThreadPool.h"
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
@@ -789,7 +789,7 @@ TYPED_TEST_P(HybridIndexTestInverted,
 }
 
 TYPED_TEST_P(HybridIndexTestInverted,
-             ScalarIndexLoadingOverheadDoesNotCapFileDimension) {
+             ScalarIndexLoadingOverheadUsesPoolBoundForMemoryOnly) {
     auto& budget = storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
     auto cleanup = folly::makeGuard(
@@ -837,9 +837,15 @@ TYPED_TEST_P(HybridIndexTestInverted,
     ASSERT_TRUE(translator.meta()->loading_overhead.has_value());
     EXPECT_EQ(translator.meta()->loading_overhead->group,
               milvus::segcore::kLoadTransientOverheadGroup);
-    EXPECT_EQ(
-        translator.meta()->loading_overhead->upper_bound.memory_bytes,
-        milvus::cachinglayer::LoadingOverheadTracker::kUnlimited.memory_bytes);
+    auto max_load_tasks =
+        milvus::ComputeThreadPoolMaxThreads(
+            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()) +
+        milvus::ComputeThreadPoolMaxThreads(
+            milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load());
+    auto max_task_overhead =
+        storage::DefaultStreamSliceSize() + storage::kTailMergeGrace;
+    EXPECT_EQ(translator.meta()->loading_overhead->upper_bound.memory_bytes,
+              max_load_tasks * max_task_overhead);
     EXPECT_EQ(translator.meta()->loading_overhead->upper_bound.file_bytes, 0);
 }
 
@@ -1037,9 +1043,10 @@ REGISTER_TYPED_TEST_SUITE_P(HybridIndexTestV4,
                             CompareValFuncTest,
                             TestRangeCompareFuncTest);
 
-REGISTER_TYPED_TEST_SUITE_P(HybridIndexTestInverted,
-                            ResourceEstimateUsesInternalInvertedIndexType,
-                            ScalarIndexLoadingOverheadDoesNotCapFileDimension);
+REGISTER_TYPED_TEST_SUITE_P(
+    HybridIndexTestInverted,
+    ResourceEstimateUsesInternalInvertedIndexType,
+    ScalarIndexLoadingOverheadUsesPoolBoundForMemoryOnly);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(HybridIndexE2ECheck_HighCardinality,
                                HybridIndexTestV2,

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -827,9 +827,25 @@ TYPED_TEST_P(HybridIndexTestInverted,
              ScalarIndexLoadingOverheadUsesPoolAndSingleTaskBounds) {
     auto& budget = storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
-    auto cleanup = folly::makeGuard(
-        [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
+    auto& high_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    auto& low_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto old_high_max = high_pool.GetMaxThreadNum();
+    auto old_low_max = low_pool.GetMaxThreadNum();
+    auto cleanup = folly::makeGuard([&budget,
+                                     old_capacity,
+                                     &high_pool,
+                                     &low_pool,
+                                     old_high_max,
+                                     old_low_max]() {
+        budget.SetCapacityBytes(old_capacity);
+        high_pool.Resize(old_high_max);
+        low_pool.Resize(old_low_max);
+    });
     budget.SetCapacityBytes(0);
+    high_pool.Resize(2);
+    low_pool.Resize(3);
 
     std::map<std::string, std::string> index_params{
         {"index_type", milvus::index::HYBRID_INDEX_TYPE},
@@ -880,11 +896,7 @@ TYPED_TEST_P(HybridIndexTestInverted,
     EXPECT_FALSE(translator.meta()->loading_overhead->file.has_value());
     EXPECT_EQ(translator.meta()->loading_overhead->memory->group,
               milvus::segcore::kLoadTransientOverheadGroup);
-    auto max_load_tasks =
-        milvus::ComputeThreadPoolMaxThreads(
-            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()) +
-        milvus::ComputeThreadPoolMaxThreads(
-            milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load());
+    constexpr int64_t max_load_tasks = 5;
     auto max_task_overhead = storage::PlainEntryFileStreamTaskTransientBytes();
     EXPECT_EQ(translator.meta()->loading_overhead->memory->upper_bound,
               max_load_tasks * max_task_overhead);

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -55,6 +55,7 @@
 #include "storage/InsertData.h"
 #include "storage/PayloadReader.h"
 #include "storage/EntryStreamUtils.h"
+#include "storage/IndexEntryEncryptedLocalWriter.h"
 #include "storage/PluginLoader.h"
 #include "storage/ThreadPool.h"
 #include "storage/ThreadPools.h"
@@ -824,7 +825,7 @@ TYPED_TEST_P(HybridIndexTestInverted,
 }
 
 TYPED_TEST_P(HybridIndexTestInverted,
-             ScalarIndexLoadingOverheadUsesPoolAndSingleTaskBounds) {
+             ScalarIndexLoadingOverheadUsesBudgetAndSingleTaskBounds) {
     auto& budget = storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
     auto& high_pool =
@@ -891,15 +892,8 @@ TYPED_TEST_P(HybridIndexTestInverted,
         ctx,
         std::move(config));
 
-    ASSERT_TRUE(translator.meta()->loading_overhead.has_value());
-    ASSERT_TRUE(translator.meta()->loading_overhead->memory.has_value());
-    EXPECT_FALSE(translator.meta()->loading_overhead->file.has_value());
-    EXPECT_EQ(translator.meta()->loading_overhead->memory->group,
-              milvus::segcore::kLoadTransientOverheadGroup);
-    constexpr int64_t max_load_tasks = 5;
+    EXPECT_FALSE(translator.meta()->loading_overhead.has_value());
     auto max_task_overhead = storage::PlainEntryFileStreamTaskTransientBytes();
-    EXPECT_EQ(translator.meta()->loading_overhead->memory->upper_bound,
-              max_load_tasks * max_task_overhead);
     auto [loaded_resource, loading_overhead] =
         translator.estimated_byte_size_of_cell(0);
     EXPECT_EQ(loaded_resource,
@@ -938,13 +932,64 @@ TYPED_TEST_P(HybridIndexTestInverted,
                                  ctx,
                                  std::move(plugin_loaded_config));
 
-    ASSERT_TRUE(
-        plugin_loaded_translator.meta()->loading_overhead->memory.has_value());
-    EXPECT_FALSE(
-        plugin_loaded_translator.meta()->loading_overhead->file.has_value());
-    EXPECT_EQ(
-        plugin_loaded_translator.meta()->loading_overhead->memory->upper_bound,
-        max_load_tasks * max_task_overhead);
+    EXPECT_FALSE(plugin_loaded_translator.meta()->loading_overhead.has_value());
+}
+
+TYPED_TEST_P(HybridIndexTestInverted,
+             EncryptedResourceEstimateUsesCollectionId) {
+    auto collection_id = this->field_meta_.collection_id;
+    auto cipher_plugin =
+        std::make_shared<milvus::test::CollectionBoundPlannerCipherPlugin>(
+            collection_id);
+    auto& plugin_loader = storage::PluginLoader::GetInstance();
+    plugin_loader.addPluginForTest(cipher_plugin);
+    auto plugin_cleanup = folly::makeGuard(
+        [&plugin_loader]() { plugin_loader.unload("CipherPlugin"); });
+
+    storage::FileManagerContext ctx(
+        this->field_meta_, this->index_meta_, this->chunk_manager_, this->fs_);
+    ctx.set_for_loading_index(true);
+    storage::MemFileManagerImpl file_manager(ctx);
+    auto file_name = fmt::format("encrypted_hybrid_collection_{}",
+                                 static_cast<int>(this->type_));
+    auto remote_path =
+        file_manager.GetRemoteIndexObjectPrefix() + "/" + file_name;
+
+    {
+        storage::IndexEntryEncryptedLocalWriter writer(
+            remote_path,
+            this->fs_,
+            cipher_plugin,
+            /*ez_id=*/7,
+            collection_id,
+            this->chunk_manager_->GetRootPath());
+        writer.PutMeta(INDEX_TYPE,
+                       static_cast<uint8_t>(ScalarIndexType::INVERTED));
+        writer.Finish();
+    }
+
+    auto file_info = this->fs_->GetFileInfo(remote_path).ValueOrDie();
+    auto index_size = static_cast<uint64_t>(file_info.size());
+    std::map<std::string, std::string> index_params{
+        {"index_type", milvus::index::HYBRID_INDEX_TYPE},
+        {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+    std::optional<storage::EntryStreamLoadInfo> stream_load_info;
+
+    auto request = index::IndexFactory::GetInstance().ScalarIndexLoadResource(
+        this->type_,
+        0,
+        index_size,
+        index_params,
+        false,
+        this->nb_,
+        {remote_path},
+        ctx,
+        &stream_load_info);
+
+    ASSERT_TRUE(stream_load_info.has_value());
+    EXPECT_TRUE(stream_load_info->encrypted);
+    EXPECT_EQ(request.final_memory_cost, 0);
+    EXPECT_EQ(request.final_disk_cost, index_size);
 }
 
 TYPED_TEST_P(HybridIndexTestInverted, ScalarV3LoadingRequiresStreamLoadInfo) {
@@ -1190,7 +1235,8 @@ REGISTER_TYPED_TEST_SUITE_P(HybridIndexTestV4,
 REGISTER_TYPED_TEST_SUITE_P(
     HybridIndexTestInverted,
     ResourceEstimateUsesInternalInvertedIndexType,
-    ScalarIndexLoadingOverheadUsesPoolAndSingleTaskBounds,
+    ScalarIndexLoadingOverheadUsesBudgetAndSingleTaskBounds,
+    EncryptedResourceEstimateUsesCollectionId,
     ScalarV3LoadingRequiresStreamLoadInfo);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(HybridIndexE2ECheck_HighCardinality,

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -68,6 +68,28 @@ using namespace milvus::indexbuilder;
 using namespace milvus;
 using namespace milvus::index;
 
+class CountingOpenFileSystem : public arrow::fs::SubTreeFileSystem {
+ public:
+    explicit CountingOpenFileSystem(
+        std::shared_ptr<arrow::fs::FileSystem> base_fs)
+        : arrow::fs::SubTreeFileSystem("", std::move(base_fs)) {
+    }
+
+    arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>>
+    OpenInputFile(const std::string& path) override {
+        ++open_input_file_count_;
+        return arrow::fs::SubTreeFileSystem::OpenInputFile(path);
+    }
+
+    size_t
+    OpenInputFileCount() const {
+        return open_input_file_count_;
+    }
+
+ private:
+    size_t open_input_file_count_{0};
+};
+
 TEST(HybridScalarIndexPlannerPolicy, ShouldUseOpDelegatesToInternalIndex) {
     HybridScalarIndex<int64_t> int_index(7);
     std::vector<int64_t> int_data{1, 2, 3, 4};
@@ -776,8 +798,11 @@ TYPED_TEST_P(HybridIndexTestInverted,
         {"index_type", milvus::index::HYBRID_INDEX_TYPE},
         {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
 
-    storage::FileManagerContext ctx(
-        this->field_meta_, this->index_meta_, this->chunk_manager_, this->fs_);
+    auto counting_fs = std::make_shared<CountingOpenFileSystem>(this->fs_);
+    storage::FileManagerContext ctx(this->field_meta_,
+                                    this->index_meta_,
+                                    this->chunk_manager_,
+                                    counting_fs);
     ctx.set_for_loading_index(true);
 
     auto request = index::IndexFactory::GetInstance().ScalarIndexLoadResource(
@@ -795,6 +820,7 @@ TYPED_TEST_P(HybridIndexTestInverted,
     EXPECT_EQ(request.max_memory_cost, stream_overhead);
     EXPECT_EQ(request.max_disk_cost, index_size);
     EXPECT_FALSE(request.has_raw_data);
+    EXPECT_EQ(counting_fs->OpenInputFileCount(), 1);
 }
 
 TYPED_TEST_P(HybridIndexTestInverted,

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -763,8 +763,9 @@ TYPED_TEST_P(HybridIndexTestInverted,
     } else {
         index_size += 1024;
     }
-    auto stream_overhead = static_cast<uint64_t>(
-        std::min<size_t>(index_size, storage::EntryStreamMaxTransientBytes()));
+    auto stream_overhead = static_cast<uint64_t>(std::min<size_t>(
+        storage::PlainEntryFileStreamTransientBytes(index_size),
+        storage::PlainEntryFileStreamMaxTransientBytes()));
     std::map<std::string, std::string> index_params{
         {"index_type", milvus::index::HYBRID_INDEX_TYPE},
         {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
@@ -818,6 +819,12 @@ TYPED_TEST_P(HybridIndexTestInverted,
     load_info.index_size = 1024;
     load_info.num_rows = this->nb_;
     load_info.dim = 0;
+    load_info.load_resource_request =
+        LoadResourceRequest{/*max_memory_cost=*/2048,
+                            /*max_disk_cost=*/512,
+                            /*final_memory_cost=*/1024,
+                            /*final_disk_cost=*/128,
+                            /*has_raw_data=*/true};
 
     index::CreateIndexInfo index_info{};
     index_info.index_type = milvus::index::HYBRID_INDEX_TYPE;
@@ -837,18 +844,24 @@ TYPED_TEST_P(HybridIndexTestInverted,
         std::move(config));
 
     ASSERT_TRUE(translator.meta()->loading_overhead.has_value());
-    EXPECT_EQ(translator.meta()->loading_overhead->group,
+    ASSERT_TRUE(translator.meta()->loading_overhead->memory.has_value());
+    EXPECT_FALSE(translator.meta()->loading_overhead->file.has_value());
+    EXPECT_EQ(translator.meta()->loading_overhead->memory->group,
               milvus::segcore::kLoadTransientOverheadGroup);
     auto max_load_tasks =
         milvus::ComputeThreadPoolMaxThreads(
             milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()) +
         milvus::ComputeThreadPoolMaxThreads(
             milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load());
-    auto max_task_overhead =
-        storage::DefaultStreamSliceSize() + storage::kTailMergeGrace;
-    EXPECT_EQ(translator.meta()->loading_overhead->upper_bound.memory_bytes,
+    auto max_task_overhead = storage::PlainEntryFileStreamTaskTransientBytes();
+    EXPECT_EQ(translator.meta()->loading_overhead->memory->upper_bound,
               max_load_tasks * max_task_overhead);
-    EXPECT_EQ(translator.meta()->loading_overhead->upper_bound.file_bytes, 0);
+    auto [loaded_resource, loading_overhead] =
+        translator.estimated_byte_size_of_cell(0);
+    EXPECT_EQ(loaded_resource,
+              (milvus::cachinglayer::ResourceUsage{1024, 128}));
+    EXPECT_EQ(loading_overhead,
+              (milvus::cachinglayer::ResourceUsage{1024, 896}));
 
     budget.SetCapacityBytes(storage::kTailMergeGrace);
     Config budgeted_config = index_params;
@@ -860,12 +873,12 @@ TYPED_TEST_P(HybridIndexTestInverted,
                             std::move(budgeted_config));
 
     ASSERT_TRUE(budgeted_translator.meta()->loading_overhead.has_value());
-    EXPECT_EQ(
-        budgeted_translator.meta()->loading_overhead->upper_bound.memory_bytes,
-        max_task_overhead);
-    EXPECT_EQ(
-        budgeted_translator.meta()->loading_overhead->upper_bound.file_bytes,
-        0);
+    ASSERT_TRUE(
+        budgeted_translator.meta()->loading_overhead->memory.has_value());
+    EXPECT_FALSE(
+        budgeted_translator.meta()->loading_overhead->file.has_value());
+    EXPECT_EQ(budgeted_translator.meta()->loading_overhead->memory->upper_bound,
+              max_task_overhead);
 
     budget.SetCapacityBytes(0);
     auto& plugin_loader = storage::PluginLoader::GetInstance();
@@ -883,12 +896,13 @@ TYPED_TEST_P(HybridIndexTestInverted,
 
     auto encrypted_index_bound = storage::EntryStreamDataTransientBytes(
         static_cast<size_t>(load_info.index_size), true);
+    ASSERT_TRUE(
+        encrypted_translator.meta()->loading_overhead->memory.has_value());
+    EXPECT_FALSE(
+        encrypted_translator.meta()->loading_overhead->file.has_value());
     EXPECT_EQ(
-        encrypted_translator.meta()->loading_overhead->upper_bound.memory_bytes,
+        encrypted_translator.meta()->loading_overhead->memory->upper_bound,
         milvus::segcore::LoadTransientPoolUpperBound(encrypted_index_bound));
-    EXPECT_EQ(
-        encrypted_translator.meta()->loading_overhead->upper_bound.file_bytes,
-        0);
 }
 
 template <typename T>

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -947,6 +947,52 @@ TYPED_TEST_P(HybridIndexTestInverted,
         max_load_tasks * max_task_overhead);
 }
 
+TYPED_TEST_P(HybridIndexTestInverted, ScalarV3LoadingRequiresStreamLoadInfo) {
+    std::map<std::string, std::string> index_params{
+        {"index_type", milvus::index::HYBRID_INDEX_TYPE},
+        {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+    milvus::segcore::LoadIndexInfo load_info{};
+    load_info.collection_id = 1;
+    load_info.partition_id = 2;
+    load_info.segment_id = 3;
+    load_info.field_id = 101;
+    load_info.field_type = this->type_;
+    load_info.element_type = DataType::NONE;
+    load_info.enable_mmap = false;
+    load_info.index_id = this->index_build_id_;
+    load_info.index_build_id = this->index_build_id_;
+    load_info.index_version = this->index_version_;
+    load_info.index_params = index_params;
+    load_info.index_engine_version = this->index_version_;
+    load_info.index_size = 1024;
+    load_info.num_rows = this->nb_;
+    load_info.dim = 0;
+    load_info.load_resource_request =
+        LoadResourceRequest{/*max_memory_cost=*/2048,
+                            /*max_disk_cost=*/512,
+                            /*final_memory_cost=*/1024,
+                            /*final_disk_cost=*/128,
+                            /*has_raw_data=*/true};
+
+    index::CreateIndexInfo index_info{};
+    index_info.index_type = milvus::index::HYBRID_INDEX_TYPE;
+    index_info.field_type = this->type_;
+    index_info.index_engine_version = this->index_version_;
+
+    storage::FileManagerContext ctx(
+        this->field_meta_, this->index_meta_, this->chunk_manager_, this->fs_);
+    ctx.set_for_loading_index(true);
+
+    Config config = index_params;
+    EXPECT_THROW(milvus::segcore::storagev1translator::SealedIndexTranslator(
+                     index_info,
+                     &load_info,
+                     milvus::tracer::TraceContext{},
+                     ctx,
+                     std::move(config)),
+                 milvus::SegcoreError);
+}
+
 template <typename T>
 class HybridIndexTestNullable : public HybridIndexTestV1<T> {
  public:
@@ -1144,7 +1190,8 @@ REGISTER_TYPED_TEST_SUITE_P(HybridIndexTestV4,
 REGISTER_TYPED_TEST_SUITE_P(
     HybridIndexTestInverted,
     ResourceEstimateUsesInternalInvertedIndexType,
-    ScalarIndexLoadingOverheadUsesPoolAndSingleTaskBounds);
+    ScalarIndexLoadingOverheadUsesPoolAndSingleTaskBounds,
+    ScalarV3LoadingRequiresStreamLoadInfo);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(HybridIndexE2ECheck_HighCardinality,
                                HybridIndexTestV2,

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -789,7 +789,7 @@ TYPED_TEST_P(HybridIndexTestInverted,
 }
 
 TYPED_TEST_P(HybridIndexTestInverted,
-             ScalarIndexLoadingOverheadUsesPoolBoundForMemoryOnly) {
+             ScalarIndexLoadingOverheadUsesPoolAndSingleTaskBounds) {
     auto& budget = storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
     auto cleanup = folly::makeGuard(
@@ -847,6 +847,23 @@ TYPED_TEST_P(HybridIndexTestInverted,
     EXPECT_EQ(translator.meta()->loading_overhead->upper_bound.memory_bytes,
               max_load_tasks * max_task_overhead);
     EXPECT_EQ(translator.meta()->loading_overhead->upper_bound.file_bytes, 0);
+
+    budget.SetCapacityBytes(storage::kTailMergeGrace);
+    Config budgeted_config = index_params;
+    milvus::segcore::storagev1translator::SealedIndexTranslator
+        budgeted_translator(index_info,
+                            &load_info,
+                            milvus::tracer::TraceContext{},
+                            ctx,
+                            std::move(budgeted_config));
+
+    ASSERT_TRUE(budgeted_translator.meta()->loading_overhead.has_value());
+    EXPECT_EQ(
+        budgeted_translator.meta()->loading_overhead->upper_bound.memory_bytes,
+        max_task_overhead);
+    EXPECT_EQ(
+        budgeted_translator.meta()->loading_overhead->upper_bound.file_bytes,
+        0);
 }
 
 template <typename T>
@@ -1046,7 +1063,7 @@ REGISTER_TYPED_TEST_SUITE_P(HybridIndexTestV4,
 REGISTER_TYPED_TEST_SUITE_P(
     HybridIndexTestInverted,
     ResourceEstimateUsesInternalInvertedIndexType,
-    ScalarIndexLoadingOverheadUsesPoolBoundForMemoryOnly);
+    ScalarIndexLoadingOverheadUsesPoolAndSingleTaskBounds);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(HybridIndexE2ECheck_HighCardinality,
                                HybridIndexTestV2,

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -72,10 +72,13 @@ namespace milvus::index {
 namespace {
 
 uint64_t
-ScalarIndexStreamMemoryOverhead(uint64_t index_size_in_bytes,
-                                int32_t scalar_version,
-                                bool encrypted,
-                                bool file_stream) {
+ScalarIndexStreamMemoryOverhead(
+    uint64_t index_size_in_bytes,
+    int32_t scalar_version,
+    bool encrypted,
+    bool file_stream,
+    const std::optional<storage::EntryStreamLoadInfo>& stream_load_info =
+        std::nullopt) {
     if (index_size_in_bytes == 0) {
         return 0;
     }
@@ -83,6 +86,11 @@ ScalarIndexStreamMemoryOverhead(uint64_t index_size_in_bytes,
         return index_size_in_bytes;
     }
     if (encrypted) {
+        if (stream_load_info.has_value()) {
+            return storage::EncryptedEntryStreamMaxTransientBytes(
+                stream_load_info->total_transient_bytes,
+                stream_load_info->max_task_transient_bytes);
+        }
         auto stream_data_bound = milvus::storage::EntryStreamDataTransientBytes(
             index_size_in_bytes, true);
         return std::min<uint64_t>(
@@ -229,6 +237,23 @@ ResolveHybridInternalIndexType(
     return std::nullopt;
 }
 
+std::optional<storage::EntryStreamLoadInfo>
+InspectScalarIndexStreamLoadInfo(
+    const std::vector<std::string>& index_files,
+    const storage::FileManagerContext& file_manager_context) {
+    if (index_files.size() != 1 || !file_manager_context.Valid()) {
+        return std::nullopt;
+    }
+
+    storage::MemFileManagerImpl file_manager(file_manager_context);
+    auto input = file_manager.OpenInputStream(index_files[0]);
+    AssertInfo(input != nullptr,
+               "failed to open packed scalar index file: {}",
+               index_files[0]);
+    return storage::IndexEntryReader::InspectStreamLoadInfo(input,
+                                                            input->Size());
+}
+
 }  // namespace
 
 bool
@@ -343,7 +368,11 @@ IndexFactory::IndexLoadResource(
     int64_t num_rows,
     int64_t dim,
     const std::vector<std::string>& index_files,
-    const storage::FileManagerContext& file_manager_context) {
+    const storage::FileManagerContext& file_manager_context,
+    std::optional<storage::EntryStreamLoadInfo>* stream_load_info) {
+    if (stream_load_info != nullptr) {
+        stream_load_info->reset();
+    }
     if (milvus::IsVectorDataType(field_type)) {
         return VecIndexLoadResource(field_type,
                                     element_type,
@@ -361,7 +390,8 @@ IndexFactory::IndexLoadResource(
                                    mmap_enable,
                                    num_rows,
                                    index_files,
-                                   file_manager_context);
+                                   file_manager_context,
+                                   stream_load_info);
 }
 
 LoadResourceRequest
@@ -576,6 +606,24 @@ IndexFactory::ScalarIndexLoadResource(
     const std::map<std::string, std::string>& index_params,
     bool mmap_enable,
     int64_t num_rows) {
+    return ScalarIndexLoadResourceImpl(field_type,
+                                       index_version,
+                                       index_size_in_bytes,
+                                       index_params,
+                                       mmap_enable,
+                                       num_rows,
+                                       std::nullopt);
+}
+
+LoadResourceRequest
+IndexFactory::ScalarIndexLoadResourceImpl(
+    DataType field_type,
+    IndexVersion index_version,
+    uint64_t index_size_in_bytes,
+    const std::map<std::string, std::string>& index_params,
+    bool mmap_enable,
+    int64_t num_rows,
+    const std::optional<storage::EntryStreamLoadInfo>& stream_load_info) {
     auto config = milvus::index::ParseConfigFromIndexParams(index_params);
 
     auto index_type_it = index_params.find("index_type");
@@ -587,17 +635,23 @@ IndexFactory::ScalarIndexLoadResource(
         milvus::index::GetValueFromConfig<int32_t>(
             config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
             .value_or(1);
-    // The plugin is loaded only when cluster disk encryption is enabled.
-    // Plaintext clusters keep the original, lower stream estimate.
+    // File-aware callers use the persisted __edek__ marker. Keep plugin state
+    // only as a compatibility fallback for callers without file context.
     auto encrypted_stream =
         scalar_version >= 3 &&
-        milvus::storage::PluginLoader::GetInstance().getCipherPlugin() !=
-            nullptr;
+        (stream_load_info.has_value()
+             ? stream_load_info->encrypted
+             : milvus::storage::PluginLoader::GetInstance().getCipherPlugin() !=
+                   nullptr);
     auto file_stream = index_type == milvus::index::INVERTED_INDEX_TYPE ||
                        index_type == milvus::index::NGRAM_INDEX_TYPE ||
                        index_type == milvus::index::RTREE_INDEX_TYPE;
-    auto stream_memory_overhead = ScalarIndexStreamMemoryOverhead(
-        index_size_in_bytes, scalar_version, encrypted_stream, file_stream);
+    auto stream_memory_overhead =
+        ScalarIndexStreamMemoryOverhead(index_size_in_bytes,
+                                        scalar_version,
+                                        encrypted_stream,
+                                        file_stream,
+                                        stream_load_info);
 
     LoadResourceRequest request{};
     request.has_raw_data = false;
@@ -706,53 +760,55 @@ IndexFactory::ScalarIndexLoadResource(
     bool mmap_enable,
     int64_t num_rows,
     const std::vector<std::string>& index_files,
-    const storage::FileManagerContext& file_manager_context) {
+    const storage::FileManagerContext& file_manager_context,
+    std::optional<storage::EntryStreamLoadInfo>* stream_load_info) {
     auto index_type_it = index_params.find("index_type");
     AssertInfo(index_type_it != index_params.end(), "index type is empty");
-    if (index_type_it->second != milvus::index::HYBRID_INDEX_TYPE) {
-        return ScalarIndexLoadResource(field_type,
+    std::optional<storage::EntryStreamLoadInfo> inspected_stream_load_info;
+    auto config = milvus::index::ParseConfigFromIndexParams(index_params);
+    auto scalar_version =
+        milvus::index::GetValueFromConfig<int32_t>(
+            config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
+            .value_or(1);
+    if (scalar_version >= 3) {
+        inspected_stream_load_info =
+            InspectScalarIndexStreamLoadInfo(index_files, file_manager_context);
+    }
+    if (stream_load_info != nullptr) {
+        *stream_load_info = inspected_stream_load_info;
+    }
+
+    auto resolved_params = index_params;
+    if (index_type_it->second == milvus::index::HYBRID_INDEX_TYPE) {
+        try {
+            auto internal_index_type = ResolveHybridInternalIndexType(
+                index_files, file_manager_context);
+            if (internal_index_type.has_value()) {
+                auto resolved_index_type = HybridInternalIndexTypeToIndexType(
+                    internal_index_type.value());
+                if (!resolved_index_type.empty()) {
+                    resolved_params["index_type"] = resolved_index_type;
+                    LOG_INFO(
+                        "estimate hybrid scalar index load resource by "
+                        "internal index type: {}",
+                        resolved_index_type);
+                }
+            }
+        } catch (std::exception& e) {
+            LOG_WARN(
+                "failed to resolve hybrid scalar internal index type, "
+                "fallback to hybrid estimate: {}",
+                e.what());
+        }
+    }
+
+    return ScalarIndexLoadResourceImpl(field_type,
                                        index_version,
                                        index_size_in_bytes,
-                                       index_params,
+                                       resolved_params,
                                        mmap_enable,
-                                       num_rows);
-    }
-
-    try {
-        auto internal_index_type =
-            ResolveHybridInternalIndexType(index_files, file_manager_context);
-        if (internal_index_type.has_value()) {
-            auto resolved_index_type =
-                HybridInternalIndexTypeToIndexType(internal_index_type.value());
-            if (!resolved_index_type.empty()) {
-                auto resolved_params = index_params;
-                resolved_params["index_type"] = resolved_index_type;
-                auto request = ScalarIndexLoadResource(field_type,
-                                                       index_version,
-                                                       index_size_in_bytes,
-                                                       resolved_params,
-                                                       mmap_enable,
-                                                       num_rows);
-                LOG_INFO(
-                    "estimate hybrid scalar index load resource by internal "
-                    "index type: {}",
-                    resolved_index_type);
-                return request;
-            }
-        }
-    } catch (std::exception& e) {
-        LOG_WARN(
-            "failed to resolve hybrid scalar internal index type, fallback to "
-            "hybrid estimate: {}",
-            e.what());
-    }
-
-    return ScalarIndexLoadResource(field_type,
-                                   index_version,
-                                   index_size_in_bytes,
-                                   index_params,
-                                   mmap_enable,
-                                   num_rows);
+                                       num_rows,
+                                       inspected_stream_load_info);
 }
 
 IndexBasePtr

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -64,6 +64,7 @@
 #include "storage/EntryStreamUtils.h"
 #include "storage/IndexEntryReader.h"
 #include "storage/MemFileManagerImpl.h"
+#include "storage/PluginLoader.h"
 #include "storage/Types.h"
 
 namespace milvus::index {
@@ -72,15 +73,19 @@ namespace {
 
 uint64_t
 ScalarIndexStreamMemoryOverhead(uint64_t index_size_in_bytes,
-                                int32_t scalar_version) {
+                                int32_t scalar_version,
+                                bool encrypted) {
     if (index_size_in_bytes == 0) {
         return 0;
     }
     if (scalar_version < 3) {
         return index_size_in_bytes;
     }
-    return std::min<uint64_t>(index_size_in_bytes,
-                              milvus::storage::EntryStreamMaxTransientBytes());
+    auto stream_data_bound = milvus::storage::EntryStreamDataTransientBytes(
+        index_size_in_bytes, encrypted);
+    return std::min<uint64_t>(
+        stream_data_bound,
+        milvus::storage::EntryStreamMaxTransientBytes(encrypted));
 }
 
 uint64_t
@@ -568,8 +573,14 @@ IndexFactory::ScalarIndexLoadResource(
         milvus::index::GetValueFromConfig<int32_t>(
             config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
             .value_or(1);
-    auto stream_memory_overhead =
-        ScalarIndexStreamMemoryOverhead(index_size_in_bytes, scalar_version);
+    // The plugin is loaded only when cluster disk encryption is enabled.
+    // Plaintext clusters keep the original, lower stream estimate.
+    auto encrypted_stream =
+        scalar_version >= 3 &&
+        milvus::storage::PluginLoader::GetInstance().getCipherPlugin() !=
+            nullptr;
+    auto stream_memory_overhead = ScalarIndexStreamMemoryOverhead(
+        index_size_in_bytes, scalar_version, encrypted_stream);
 
     LoadResourceRequest request{};
     request.has_raw_data = false;

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -229,7 +229,10 @@ ResolveHybridInternalIndexType(
         AssertInfo(input != nullptr,
                    "failed to open packed hybrid index file: {}",
                    index_files[0]);
-        auto reader = storage::IndexEntryReader::Open(input, input->Size());
+        auto reader = storage::IndexEntryReader::Open(
+            input,
+            input->Size(),
+            file_manager_context.fieldDataMeta.collection_id);
         AssertInfo(reader != nullptr,
                    "failed to create IndexEntryReader for hybrid index file");
         if (stream_load_info != nullptr) {

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -656,7 +656,9 @@ IndexFactory::ScalarIndexLoadResource(
             // V3 streaming: pre-allocate buffer + deserialize
             request.final_memory_cost = index_size_in_bytes;
             request.final_disk_cost = 0;
-            request.max_memory_cost = 2 * index_size_in_bytes;
+            request.max_memory_cost =
+                std::max(2 * index_size_in_bytes,
+                         index_size_in_bytes + stream_memory_overhead);
             request.max_disk_cost = 0;
         }
 

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -194,7 +194,11 @@ HybridInternalIndexTypeToIndexType(ScalarIndexType type) {
 std::optional<ScalarIndexType>
 ResolveHybridInternalIndexType(
     const std::vector<std::string>& index_files,
-    const storage::FileManagerContext& file_manager_context) {
+    const storage::FileManagerContext& file_manager_context,
+    std::optional<storage::EntryStreamLoadInfo>* stream_load_info = nullptr) {
+    if (stream_load_info != nullptr) {
+        stream_load_info->reset();
+    }
     if (index_files.empty() || !file_manager_context.Valid()) {
         return std::nullopt;
     }
@@ -228,6 +232,9 @@ ResolveHybridInternalIndexType(
         auto reader = storage::IndexEntryReader::Open(input, input->Size());
         AssertInfo(reader != nullptr,
                    "failed to create IndexEntryReader for hybrid index file");
+        if (stream_load_info != nullptr) {
+            *stream_load_info = reader->GetStreamLoadInfo();
+        }
         if (reader->HasMeta(INDEX_TYPE)) {
             return static_cast<ScalarIndexType>(
                 reader->GetMeta<uint8_t>(INDEX_TYPE));
@@ -770,7 +777,23 @@ IndexFactory::ScalarIndexLoadResource(
         milvus::index::GetValueFromConfig<int32_t>(
             config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
             .value_or(1);
-    if (scalar_version >= 3) {
+    std::optional<ScalarIndexType> internal_index_type;
+    if (index_type_it->second == milvus::index::HYBRID_INDEX_TYPE) {
+        try {
+            internal_index_type = ResolveHybridInternalIndexType(
+                index_files, file_manager_context, &inspected_stream_load_info);
+        } catch (std::exception& e) {
+            if (scalar_version >= 3 &&
+                !inspected_stream_load_info.has_value()) {
+                inspected_stream_load_info = InspectScalarIndexStreamLoadInfo(
+                    index_files, file_manager_context);
+            }
+            LOG_WARN(
+                "failed to resolve hybrid scalar internal index type, "
+                "fallback to hybrid estimate: {}",
+                e.what());
+        }
+    } else if (scalar_version >= 3) {
         inspected_stream_load_info =
             InspectScalarIndexStreamLoadInfo(index_files, file_manager_context);
     }
@@ -779,26 +802,15 @@ IndexFactory::ScalarIndexLoadResource(
     }
 
     auto resolved_params = index_params;
-    if (index_type_it->second == milvus::index::HYBRID_INDEX_TYPE) {
-        try {
-            auto internal_index_type = ResolveHybridInternalIndexType(
-                index_files, file_manager_context);
-            if (internal_index_type.has_value()) {
-                auto resolved_index_type = HybridInternalIndexTypeToIndexType(
-                    internal_index_type.value());
-                if (!resolved_index_type.empty()) {
-                    resolved_params["index_type"] = resolved_index_type;
-                    LOG_INFO(
-                        "estimate hybrid scalar index load resource by "
-                        "internal index type: {}",
-                        resolved_index_type);
-                }
-            }
-        } catch (std::exception& e) {
-            LOG_WARN(
-                "failed to resolve hybrid scalar internal index type, "
-                "fallback to hybrid estimate: {}",
-                e.what());
+    if (internal_index_type.has_value()) {
+        auto resolved_index_type =
+            HybridInternalIndexTypeToIndexType(internal_index_type.value());
+        if (!resolved_index_type.empty()) {
+            resolved_params["index_type"] = resolved_index_type;
+            LOG_INFO(
+                "estimate hybrid scalar index load resource by internal index "
+                "type: {}",
+                resolved_index_type);
         }
     }
 

--- a/internal/core/src/index/IndexFactory.cpp
+++ b/internal/core/src/index/IndexFactory.cpp
@@ -74,18 +74,32 @@ namespace {
 uint64_t
 ScalarIndexStreamMemoryOverhead(uint64_t index_size_in_bytes,
                                 int32_t scalar_version,
-                                bool encrypted) {
+                                bool encrypted,
+                                bool file_stream) {
     if (index_size_in_bytes == 0) {
         return 0;
     }
     if (scalar_version < 3) {
         return index_size_in_bytes;
     }
-    auto stream_data_bound = milvus::storage::EntryStreamDataTransientBytes(
-        index_size_in_bytes, encrypted);
+    if (encrypted) {
+        auto stream_data_bound = milvus::storage::EntryStreamDataTransientBytes(
+            index_size_in_bytes, true);
+        return std::min<uint64_t>(
+            stream_data_bound,
+            milvus::storage::EntryStreamMaxTransientBytes(true));
+    }
+    if (file_stream) {
+        auto stream_data_bound =
+            milvus::storage::PlainEntryFileStreamTransientBytes(
+                index_size_in_bytes);
+        return std::min<uint64_t>(
+            stream_data_bound,
+            milvus::storage::PlainEntryFileStreamMaxTransientBytes());
+    }
     return std::min<uint64_t>(
-        stream_data_bound,
-        milvus::storage::EntryStreamMaxTransientBytes(encrypted));
+        index_size_in_bytes,
+        milvus::storage::EntryStreamMaxTransientBytes(false));
 }
 
 uint64_t
@@ -579,8 +593,11 @@ IndexFactory::ScalarIndexLoadResource(
         scalar_version >= 3 &&
         milvus::storage::PluginLoader::GetInstance().getCipherPlugin() !=
             nullptr;
+    auto file_stream = index_type == milvus::index::INVERTED_INDEX_TYPE ||
+                       index_type == milvus::index::NGRAM_INDEX_TYPE ||
+                       index_type == milvus::index::RTREE_INDEX_TYPE;
     auto stream_memory_overhead = ScalarIndexStreamMemoryOverhead(
-        index_size_in_bytes, scalar_version, encrypted_stream);
+        index_size_in_bytes, scalar_version, encrypted_stream, file_stream);
 
     LoadResourceRequest request{};
     request.has_raw_data = false;

--- a/internal/core/src/index/IndexFactory.h
+++ b/internal/core/src/index/IndexFactory.h
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -29,6 +30,7 @@
 #include "index/IndexInfo.h"
 #include "index/ScalarIndex.h"
 #include "storage/FileManager.h"
+#include "storage/IndexEntryReader.h"
 
 namespace milvus::index {
 
@@ -71,7 +73,9 @@ class IndexFactory {
                       int64_t num_rows,
                       int64_t dim,
                       const std::vector<std::string>& index_files,
-                      const storage::FileManagerContext& file_manager_context);
+                      const storage::FileManagerContext& file_manager_context,
+                      std::optional<storage::EntryStreamLoadInfo>*
+                          stream_load_info = nullptr);
 
     LoadResourceRequest
     VecIndexLoadResource(DataType field_type,
@@ -101,7 +105,9 @@ class IndexFactory {
         bool mmap_enable,
         int64_t num_rows,
         const std::vector<std::string>& index_files,
-        const storage::FileManagerContext& file_manager_context);
+        const storage::FileManagerContext& file_manager_context,
+        std::optional<storage::EntryStreamLoadInfo>* stream_load_info =
+            nullptr);
 
     IndexBasePtr
     CreateIndex(const CreateIndexInfo& create_index_info,
@@ -184,6 +190,16 @@ class IndexFactory {
     // CreateIndex(DataType dtype, const IndexType& index_type);
  private:
     FRIEND_TEST(StringIndexMarisaTest, Reverse);
+
+    LoadResourceRequest
+    ScalarIndexLoadResourceImpl(
+        DataType field_type,
+        IndexVersion index_version,
+        uint64_t index_size_in_bytes,
+        const std::map<std::string, std::string>& index_params,
+        bool mmap_enable,
+        int64_t num_rows,
+        const std::optional<storage::EntryStreamLoadInfo>& stream_load_info);
 
     template <typename T>
     ScalarIndexPtr<T>

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -283,6 +283,36 @@ TEST(FieldDataLoadingOverheadUpperBound, UsesBudgetWithMaxOverheadFloor) {
     EXPECT_EQ(mmap_larger_file_overhead.file_bytes, 32 * MB);
 }
 
+TEST(LoadTransientSharedOverheadUpperBound, UsesProcessWideConcurrencyBound) {
+    auto& budget =
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
+    auto old_capacity = budget.CapacityBytes();
+    auto& high_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    auto& low_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto old_high_max = high_pool.GetMaxThreadNum();
+    auto old_low_max = low_pool.GetMaxThreadNum();
+    auto cleanup = folly::makeGuard([&]() {
+        budget.SetCapacityBytes(old_capacity);
+        high_pool.Resize(old_high_max);
+        low_pool.Resize(old_low_max);
+    });
+
+    high_pool.Resize(2);
+    low_pool.Resize(3);
+    constexpr size_t task_overhead = 128;
+
+    budget.SetCapacityBytes(0);
+    EXPECT_EQ(LoadTransientSharedOverheadUpperBound(task_overhead), 5 * 128);
+
+    budget.SetCapacityBytes(512);
+    EXPECT_EQ(LoadTransientSharedOverheadUpperBound(task_overhead), 512);
+
+    budget.SetCapacityBytes(64);
+    EXPECT_EQ(LoadTransientSharedOverheadUpperBound(task_overhead), 128);
+}
+
 // ---- LoadCellBatchAsync tests ----
 
 namespace {

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -17,10 +17,12 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
@@ -283,34 +285,84 @@ TEST(FieldDataLoadingOverheadUpperBound, UsesBudgetWithMaxOverheadFloor) {
     EXPECT_EQ(mmap_larger_file_overhead.file_bytes, 32 * MB);
 }
 
-TEST(LoadTransientSharedOverheadUpperBound, UsesProcessWideConcurrencyBound) {
+TEST(LoadTransientSharedOverheadUpperBound, UsesBudgetAndSingleTaskBounds) {
     auto& budget =
         milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
+    auto cleanup =
+        folly::makeGuard([&]() { budget.SetCapacityBytes(old_capacity); });
+    constexpr size_t task_overhead = 128;
+
+    budget.SetCapacityBytes(512);
+    EXPECT_EQ(LoadTransientSharedOverheadUpperBound(task_overhead), 512);
+
+    budget.SetCapacityBytes(1024);
+    EXPECT_EQ(LoadTransientSharedOverheadUpperBound(task_overhead), 1024);
+
+    budget.SetCapacityBytes(64);
+    EXPECT_EQ(LoadTransientSharedOverheadUpperBound(task_overhead), 128);
+}
+
+TEST(LoadTransientPoolUpperBound, UsesLiveWorkersDuringShrink) {
     auto& high_pool =
         milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
     auto& low_pool =
         milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
     auto old_high_max = high_pool.GetMaxThreadNum();
     auto old_low_max = low_pool.GetMaxThreadNum();
-    auto cleanup = folly::makeGuard([&]() {
-        budget.SetCapacityBytes(old_capacity);
+    auto old_thread_limit = milvus::THREAD_POOL_MAX_THREADS_SIZE.load();
+    auto pool_cleanup = folly::makeGuard([&]() {
+        milvus::SetThreadPoolMaxThreadsSize(old_thread_limit);
         high_pool.Resize(old_high_max);
         low_pool.Resize(old_low_max);
     });
 
-    high_pool.Resize(2);
-    low_pool.Resize(3);
+    milvus::SetThreadPoolMaxThreadsSize(
+        std::max(old_thread_limit, static_cast<int>(3)));
+    high_pool.Resize(3);
+    low_pool.Resize(1);
+
+    std::mutex started_mu;
+    std::condition_variable started_cv;
+    size_t started = 0;
+    std::promise<void> release;
+    auto release_future = release.get_future().share();
+    std::vector<std::future<void>> blockers;
+    auto blocker_cleanup = folly::makeGuard([&]() {
+        release.set_value();
+        for (auto& blocker : blockers) {
+            blocker.get();
+        }
+    });
+
+    for (size_t i = 0; i < 3; ++i) {
+        blockers.push_back(high_pool.Submit([&]() {
+            {
+                std::lock_guard<std::mutex> lock(started_mu);
+                ++started;
+            }
+            started_cv.notify_one();
+            release_future.wait();
+        }));
+    }
+
+    {
+        std::unique_lock<std::mutex> lock(started_mu);
+        ASSERT_TRUE(started_cv.wait_for(
+            lock, std::chrono::seconds(2), [&]() { return started == 3; }));
+    }
+
+    high_pool.Resize(1);
+    auto effective_high =
+        std::max(high_pool.GetMaxThreadNum(), high_pool.GetThreadNum());
+    auto effective_low =
+        std::max(low_pool.GetMaxThreadNum(), low_pool.GetThreadNum());
+    ASSERT_GT(effective_high, high_pool.GetMaxThreadNum());
+
     constexpr size_t task_overhead = 128;
-
-    budget.SetCapacityBytes(0);
-    EXPECT_EQ(LoadTransientSharedOverheadUpperBound(task_overhead), 5 * 128);
-
-    budget.SetCapacityBytes(512);
-    EXPECT_EQ(LoadTransientSharedOverheadUpperBound(task_overhead), 512);
-
-    budget.SetCapacityBytes(64);
-    EXPECT_EQ(LoadTransientSharedOverheadUpperBound(task_overhead), 128);
+    EXPECT_EQ(
+        LoadTransientPoolUpperBound(task_overhead),
+        static_cast<int64_t>((effective_high + effective_low) * task_overhead));
 }
 
 // ---- LoadCellBatchAsync tests ----

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -290,24 +290,28 @@ MakeMockCellFinalizer() {
            int64_t /*cid*/) { return std::make_unique<milvus::GroupChunk>(); };
 }
 
+LoadedCellBatch
+CollectLoadedCells(std::vector<CellLoadFuture>& futures) {
+    LoadedCellBatch loaded_cells;
+    for (auto& future : futures) {
+        auto batch = future.get();
+        for (auto& loaded_cell : batch) {
+            loaded_cells.push_back(std::move(loaded_cell));
+        }
+    }
+    return loaded_cells;
+}
+
 // Helper to run LoadCellBatchAsync and return future count (= batch count).
 size_t
 RunAndCountBatches(std::vector<CellSpec> cell_specs, int64_t memory_limit) {
-    auto channel = std::make_shared<CellReaderChannel>();
     auto futures = LoadCellBatchAsync(nullptr,
                                       std::move(cell_specs),
                                       MakeMockReaderFactory(),
-                                      channel,
                                       memory_limit,
                                       milvus::proto::common::LoadPriority::HIGH,
                                       MakeMockCellFinalizer());
-    std::shared_ptr<CellLoadResult> cell_data;
-    while (channel->pop(cell_data)) {
-        ReleaseCellLoadResultBudget(cell_data);
-    }
-    for (auto& f : futures) {
-        f.get();
-    }
+    CollectLoadedCells(futures);
     return futures.size();
 }
 
@@ -364,21 +368,13 @@ TEST(LoadCellBatchAsync, LoadingOverheadBasedSplitKeepsReaderMemoryLimit) {
          /*loading_overhead_size=*/64 * MB},
     };
 
-    auto channel = std::make_shared<CellReaderChannel>();
     auto futures = LoadCellBatchAsync(nullptr,
                                       std::move(specs),
                                       std::move(factory),
-                                      channel,
                                       96 * MB,
                                       milvus::proto::common::LoadPriority::HIGH,
                                       MakeMockCellFinalizer());
-    std::shared_ptr<CellLoadResult> cell_data;
-    while (channel->pop(cell_data)) {
-        ReleaseCellLoadResultBudget(cell_data);
-    }
-    for (auto& future : futures) {
-        future.get();
-    }
+    CollectLoadedCells(futures);
 
     EXPECT_EQ(futures.size(), 2);
     EXPECT_EQ(read_calls.load(), 2);
@@ -448,26 +444,18 @@ TEST(LoadCellBatchAsync, ReaderMemoryLimitUsesReadWindowFloor) {
                                     /*rg_count=*/1,
                                     /*memory_size=*/1}};
 
-    auto channel = std::make_shared<CellReaderChannel>();
     auto futures = LoadCellBatchAsync(nullptr,
                                       std::move(specs),
                                       std::move(factory),
-                                      channel,
                                       1,
                                       milvus::proto::common::LoadPriority::HIGH,
                                       MakeMockCellFinalizer());
-    std::shared_ptr<CellLoadResult> cell_data;
-    while (channel->pop(cell_data)) {
-        ReleaseCellLoadResultBudget(cell_data);
-    }
-    for (auto& future : futures) {
-        future.get();
-    }
+    CollectLoadedCells(futures);
 
     EXPECT_EQ(observed_reader_memory_limit.load(), FieldDataReadWindowBytes());
 }
 
-TEST(LoadCellBatchAsync, FinalizeCellBeforePush) {
+TEST(LoadCellBatchAsync, FinalizesCellsBeforeFutureCompletion) {
     constexpr int64_t MB = 1 << 20;
     std::vector<CellSpec> specs = {
         {0, 0, 0, 1, 8 * MB},
@@ -475,12 +463,10 @@ TEST(LoadCellBatchAsync, FinalizeCellBeforePush) {
     };
 
     std::atomic<int> finalized{0};
-    auto channel = std::make_shared<CellReaderChannel>();
     auto futures = LoadCellBatchAsync(
         nullptr,
         std::move(specs),
         MakeMockReaderFactory(),
-        channel,
         32 * MB,
         milvus::proto::common::LoadPriority::HIGH,
         [&finalized](const std::vector<std::shared_ptr<arrow::Table>>& tables,
@@ -490,25 +476,16 @@ TEST(LoadCellBatchAsync, FinalizeCellBeforePush) {
             return std::make_unique<milvus::GroupChunk>();
         });
 
-    int received = 0;
-    std::shared_ptr<CellLoadResult> cell_data;
-    while (channel->pop(cell_data)) {
-        ASSERT_NE(cell_data, nullptr);
-        EXPECT_NE(cell_data->chunk, nullptr);
-        EXPECT_TRUE(cell_data->tables.empty());
-        EXPECT_EQ(cell_data->loading_overhead_bytes, 0);
-        ReleaseCellLoadResultBudget(cell_data);
-        ++received;
-    }
-    for (auto& future : futures) {
-        future.get();
+    auto loaded_cells = CollectLoadedCells(futures);
+    for (const auto& loaded_cell : loaded_cells) {
+        EXPECT_NE(loaded_cell.chunk, nullptr);
     }
 
-    EXPECT_EQ(received, 2);
+    EXPECT_EQ(loaded_cells.size(), 2);
     EXPECT_EQ(finalized.load(), 2);
 }
 
-TEST(LoadCellBatchAsync, ReleasesBatchBudgetBeforeChannelPush) {
+TEST(LoadCellBatchAsync, ReleasesBatchBudgetBeforeFutureCompletion) {
     auto& budget =
         milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
@@ -522,12 +499,10 @@ TEST(LoadCellBatchAsync, ReleasesBatchBudgetBeforeChannelPush) {
     };
 
     std::atomic<int> finalized{0};
-    auto channel = std::make_shared<CellReaderChannel>(1);
     auto futures = LoadCellBatchAsync(
         nullptr,
         std::move(specs),
         MakeMockReaderFactory(),
-        channel,
         2,
         milvus::proto::common::LoadPriority::HIGH,
         [&finalized](const std::vector<std::shared_ptr<arrow::Table>>&,
@@ -564,15 +539,31 @@ TEST(LoadCellBatchAsync, ReleasesBatchBudgetBeforeChannelPush) {
         budget.Release(2);
     }
 
-    std::shared_ptr<CellLoadResult> cell_data;
-    ASSERT_TRUE(channel->pop(cell_data));
-    ReleaseCellLoadResultBudget(cell_data);
-    ASSERT_TRUE(channel->pop(cell_data));
-    ReleaseCellLoadResultBudget(cell_data);
-    futures[0].get();
-    EXPECT_FALSE(channel->pop(cell_data));
-    EXPECT_TRUE(acquired)
-        << "budget stayed held while worker was blocked on channel push";
+    auto loaded_cells = futures[0].get();
+    EXPECT_EQ(loaded_cells.size(), 2);
+    EXPECT_TRUE(acquired) << "budget stayed held after cells were finalized";
+}
+
+TEST(LoadCellBatchAsync, CompletedBatchDoesNotRequireResultConsumer) {
+    std::vector<CellSpec> specs = {
+        {0, 0, 0, 1, 1},
+        {1, 0, 1, 1, 1},
+    };
+
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      std::move(specs),
+                                      MakeMockReaderFactory(),
+                                      2,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
+    ASSERT_EQ(futures.size(), 1);
+
+    auto completion_status =
+        futures[0].wait_for(std::chrono::milliseconds(100));
+
+    EXPECT_EQ(completion_status, std::future_status::ready);
+    auto loaded_cells = futures[0].get();
+    EXPECT_EQ(loaded_cells.size(), 2);
 }
 
 TEST(LoadCellBatchAsync, FileBoundarySplit) {
@@ -606,18 +597,16 @@ TEST(LoadCellBatchAsync, ContiguityBreak) {
 }
 
 TEST(LoadCellBatchAsync, EmptyCells) {
-    auto channel = std::make_shared<CellReaderChannel>(64);
     auto futures = LoadCellBatchAsync(nullptr,
                                       {},
                                       MakeMockReaderFactory(),
-                                      channel,
                                       128 << 20,
                                       milvus::proto::common::LoadPriority::HIGH,
                                       MakeMockCellFinalizer());
     EXPECT_EQ(futures.size(), 0);
 }
 
-TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
+TEST(LoadCellBatchAsync, CancellationStopsMidBatchFinalize) {
     constexpr int64_t MB = 1 << 20;
     std::vector<CellSpec> specs = {
         {0, 0, 0, 1, 8 * MB},
@@ -628,31 +617,22 @@ TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
 
     folly::CancellationSource source;
     milvus::OpContext op_ctx(source.getToken());
-    auto channel = std::make_shared<CellReaderChannel>(1);
-    auto futures = LoadCellBatchAsync(&op_ctx,
-                                      specs,
-                                      MakeMockReaderFactory(),
-                                      channel,
-                                      128 * MB,
-                                      milvus::proto::common::LoadPriority::HIGH,
-                                      MakeMockCellFinalizer());
+    std::atomic<size_t> finalized{0};
+    auto futures = LoadCellBatchAsync(
+        &op_ctx,
+        specs,
+        MakeMockReaderFactory(),
+        128 * MB,
+        milvus::proto::common::LoadPriority::HIGH,
+        [&source, &finalized](const std::vector<std::shared_ptr<arrow::Table>>&,
+                              int64_t) {
+            if (finalized.fetch_add(1) == 0) {
+                source.requestCancellation();
+            }
+            return std::make_unique<milvus::GroupChunk>();
+        });
 
     ASSERT_EQ(futures.size(), 1);
-
-    std::shared_ptr<CellLoadResult> cell_data;
-    ASSERT_TRUE(channel->pop(cell_data));
-    ASSERT_NE(cell_data, nullptr);
-    EXPECT_EQ(cell_data->cid, 0);
-    ReleaseCellLoadResultBudget(cell_data);
-
-    source.requestCancellation();
-
-    size_t received = 1;
-    while (channel->pop(cell_data)) {
-        ASSERT_NE(cell_data, nullptr);
-        ReleaseCellLoadResultBudget(cell_data);
-        ++received;
-    }
 
     try {
         futures[0].get();
@@ -660,7 +640,7 @@ TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
     } catch (const milvus::SegcoreError& e) {
         EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
     }
-    EXPECT_LT(received, specs.size());
+    EXPECT_LT(finalized.load(), specs.size());
 }
 
 TEST(LoadCellBatchAsync, CancellationWhileWaitingForBudgetSkipsRead) {
@@ -691,7 +671,6 @@ TEST(LoadCellBatchAsync, CancellationWhileWaitingForBudgetSkipsRead) {
 
     folly::CancellationSource source;
     milvus::OpContext op_ctx(source.getToken());
-    auto channel = std::make_shared<CellReaderChannel>(1);
     std::vector<CellSpec> specs = {{/*cid=*/0,
                                     /*file_idx=*/0,
                                     /*local_rg_offset=*/0,
@@ -701,13 +680,11 @@ TEST(LoadCellBatchAsync, CancellationWhileWaitingForBudgetSkipsRead) {
         std::launch::async,
         [&op_ctx,
          specs = std::move(specs),
-         factory = std::move(factory),
-         channel]() mutable {
+         factory = std::move(factory)]() mutable {
             return LoadCellBatchAsync(
                 &op_ctx,
                 std::move(specs),
                 std::move(factory),
-                channel,
                 1,
                 milvus::proto::common::LoadPriority::HIGH,
                 [](const std::vector<std::shared_ptr<arrow::Table>>&, int64_t) {
@@ -733,9 +710,6 @@ TEST(LoadCellBatchAsync, CancellationWhileWaitingForBudgetSkipsRead) {
     } catch (const milvus::SegcoreError& e) {
         EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
     }
-
-    std::shared_ptr<CellLoadResult> cell_data;
-    EXPECT_FALSE(channel->pop(cell_data));
     EXPECT_EQ(read_calls.load(), 0);
 }
 
@@ -786,7 +760,6 @@ TEST(LoadCellBatchAsync, WaitingForBudgetDoesNotOccupyLoadPoolWorker) {
 
     folly::CancellationSource source;
     milvus::OpContext op_ctx(source.getToken());
-    auto channel = std::make_shared<CellReaderChannel>(1);
     std::vector<CellSpec> specs = {{/*cid=*/0,
                                     /*file_idx=*/0,
                                     /*local_rg_offset=*/0,
@@ -797,13 +770,11 @@ TEST(LoadCellBatchAsync, WaitingForBudgetDoesNotOccupyLoadPoolWorker) {
         [&op_ctx,
          specs = std::move(specs),
          factory = std::move(factory),
-         channel,
          priority]() mutable {
             return LoadCellBatchAsync(
                 &op_ctx,
                 std::move(specs),
                 std::move(factory),
-                channel,
                 1,
                 priority,
                 [](const std::vector<std::shared_ptr<arrow::Table>>&, int64_t) {
@@ -834,8 +805,5 @@ TEST(LoadCellBatchAsync, WaitingForBudgetDoesNotOccupyLoadPoolWorker) {
     } catch (const milvus::SegcoreError& e) {
         EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
     }
-
-    std::shared_ptr<CellLoadResult> cell_data;
-    EXPECT_FALSE(channel->pop(cell_data));
     EXPECT_EQ(read_calls.load(), 0);
 }

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -218,20 +218,30 @@ TEST(FieldDataLoadingOverheadUpperBound, UsesPoolBoundWhenBudgetDisabled) {
         milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
     auto old_batch_target = FieldDataLoadBatchTargetBytes();
-    auto cleanup =
-        folly::makeGuard([&budget, old_capacity, old_batch_target]() {
-            budget.SetCapacityBytes(old_capacity);
-            SetFieldDataLoadBatchTargetBytes(old_batch_target);
-        });
+    auto& high_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    auto& low_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto old_high_max = high_pool.GetMaxThreadNum();
+    auto old_low_max = low_pool.GetMaxThreadNum();
+    auto cleanup = folly::makeGuard([&budget,
+                                     old_capacity,
+                                     old_batch_target,
+                                     &high_pool,
+                                     &low_pool,
+                                     old_high_max,
+                                     old_low_max]() {
+        budget.SetCapacityBytes(old_capacity);
+        SetFieldDataLoadBatchTargetBytes(old_batch_target);
+        high_pool.Resize(old_high_max);
+        low_pool.Resize(old_low_max);
+    });
 
     budget.SetCapacityBytes(0);
     SetFieldDataLoadBatchTargetBytes(64);
-
-    auto max_load_tasks =
-        milvus::ComputeThreadPoolMaxThreads(
-            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()) +
-        milvus::ComputeThreadPoolMaxThreads(
-            milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load());
+    high_pool.Resize(2);
+    low_pool.Resize(3);
+    constexpr int64_t max_load_tasks = 5;
 
     auto upper_bound =
         FieldDataLoadingOverheadUpperBound(/*max_memory_overhead=*/128);

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
@@ -22,6 +23,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "arrow/api.h"
@@ -33,6 +35,7 @@
 #include "milvus-storage/common/metadata.h"
 #include "segcore/memory_planner.h"
 #include "storage/EntryStreamUtils.h"
+#include "storage/ThreadPools.h"
 
 using namespace milvus::segcore;
 
@@ -268,8 +271,7 @@ MakeMockReaderFactory() {
     return [](size_t /*batch_key*/,
               int64_t /*rg_offset*/,
               int64_t total_rg_count,
-              int64_t /*reader_memory_limit*/,
-              uint64_t /*read_parallelism*/)
+              int64_t /*reader_memory_limit*/)
                -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         // Return one empty table per row group
         auto schema = arrow::schema({arrow::field("x", arrow::int64())});
@@ -281,6 +283,13 @@ MakeMockReaderFactory() {
     };
 }
 
+CellFinalizeFunc
+MakeMockCellFinalizer() {
+    return
+        [](const std::vector<std::shared_ptr<arrow::Table>>& /*tables*/,
+           int64_t /*cid*/) { return std::make_unique<milvus::GroupChunk>(); };
+}
+
 // Helper to run LoadCellBatchAsync and return future count (= batch count).
 size_t
 RunAndCountBatches(std::vector<CellSpec> cell_specs, int64_t memory_limit) {
@@ -289,7 +298,9 @@ RunAndCountBatches(std::vector<CellSpec> cell_specs, int64_t memory_limit) {
                                       std::move(cell_specs),
                                       MakeMockReaderFactory(),
                                       channel,
-                                      memory_limit);
+                                      memory_limit,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
     std::shared_ptr<CellLoadResult> cell_data;
     while (channel->pop(cell_data)) {
         ReleaseCellLoadResultBudget(cell_data);
@@ -315,6 +326,63 @@ TEST(LoadCellBatchAsync, MemoryBasedSplit) {
     }
     auto batches = RunAndCountBatches(specs, 128 * MB);
     EXPECT_EQ(batches, 5);
+}
+
+TEST(LoadCellBatchAsync, LoadingOverheadBasedSplitKeepsReaderMemoryLimit) {
+    constexpr int64_t MB = 1 << 20;
+
+    std::atomic<int> read_calls{0};
+    std::atomic<int64_t> reader_memory_limit_sum{0};
+    BatchReaderFactory factory = [&read_calls, &reader_memory_limit_sum](
+                                     size_t /*batch_key*/,
+                                     int64_t /*rg_offset*/,
+                                     int64_t total_rg_count,
+                                     int64_t reader_memory_limit)
+        -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+        read_calls.fetch_add(1);
+        reader_memory_limit_sum.fetch_add(reader_memory_limit);
+        auto schema = arrow::schema({arrow::field("x", arrow::int64())});
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        for (int64_t i = 0; i < total_rg_count; ++i) {
+            tables.push_back(arrow::Table::MakeEmpty(schema).ValueOrDie());
+        }
+        return tables;
+    };
+
+    std::vector<CellSpec> specs = {
+        {/*cid=*/0,
+         /*file_idx=*/0,
+         /*local_rg_offset=*/0,
+         /*rg_count=*/1,
+         /*memory_size=*/32 * MB,
+         /*loading_overhead_size=*/64 * MB},
+        {/*cid=*/1,
+         /*file_idx=*/0,
+         /*local_rg_offset=*/1,
+         /*rg_count=*/1,
+         /*memory_size=*/32 * MB,
+         /*loading_overhead_size=*/64 * MB},
+    };
+
+    auto channel = std::make_shared<CellReaderChannel>();
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      std::move(specs),
+                                      std::move(factory),
+                                      channel,
+                                      96 * MB,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
+    std::shared_ptr<CellLoadResult> cell_data;
+    while (channel->pop(cell_data)) {
+        ReleaseCellLoadResultBudget(cell_data);
+    }
+    for (auto& future : futures) {
+        future.get();
+    }
+
+    EXPECT_EQ(futures.size(), 2);
+    EXPECT_EQ(read_calls.load(), 2);
+    EXPECT_EQ(reader_memory_limit_sum.load(), 64 * MB);
 }
 
 TEST(LoadCellBatchAsync, ZeroMemorySizeAsserts) {
@@ -357,20 +425,14 @@ TEST(LoadCellBatchAsync, SingleCellExceedsLimit) {
     EXPECT_EQ(batches, 1);
 }
 
-TEST(LoadCellBatchAsync, ReadParallelismScalesWithBatchBudget) {
-    constexpr int64_t MB = 1 << 20;
-
-    std::atomic<uint64_t> observed_parallelism{0};
+TEST(LoadCellBatchAsync, ReaderMemoryLimitUsesReadWindowFloor) {
     std::atomic<int64_t> observed_reader_memory_limit{0};
-    BatchReaderFactory factory = [&observed_parallelism,
-                                  &observed_reader_memory_limit](
+    BatchReaderFactory factory = [&observed_reader_memory_limit](
                                      size_t /*batch_key*/,
                                      int64_t /*rg_offset*/,
                                      int64_t total_rg_count,
-                                     int64_t reader_memory_limit,
-                                     uint64_t read_parallelism)
+                                     int64_t reader_memory_limit)
         -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
-        observed_parallelism.store(read_parallelism);
         observed_reader_memory_limit.store(reader_memory_limit);
         auto schema = arrow::schema({arrow::field("x", arrow::int64())});
         std::vector<std::shared_ptr<arrow::Table>> tables;
@@ -383,12 +445,17 @@ TEST(LoadCellBatchAsync, ReadParallelismScalesWithBatchBudget) {
     std::vector<CellSpec> specs = {{/*cid=*/0,
                                     /*file_idx=*/0,
                                     /*local_rg_offset=*/0,
-                                    /*rg_count=*/8,
-                                    /*memory_size=*/128 * MB}};
+                                    /*rg_count=*/1,
+                                    /*memory_size=*/1}};
 
     auto channel = std::make_shared<CellReaderChannel>();
-    auto futures = LoadCellBatchAsync(
-        nullptr, std::move(specs), std::move(factory), channel, 32 * MB);
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      std::move(specs),
+                                      std::move(factory),
+                                      channel,
+                                      1,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
     std::shared_ptr<CellLoadResult> cell_data;
     while (channel->pop(cell_data)) {
         ReleaseCellLoadResultBudget(cell_data);
@@ -397,8 +464,7 @@ TEST(LoadCellBatchAsync, ReadParallelismScalesWithBatchBudget) {
         future.get();
     }
 
-    EXPECT_EQ(observed_parallelism.load(), 8);
-    EXPECT_EQ(observed_reader_memory_limit.load(), 32 * MB);
+    EXPECT_EQ(observed_reader_memory_limit.load(), FieldDataReadWindowBytes());
 }
 
 TEST(LoadCellBatchAsync, FinalizeCellBeforePush) {
@@ -430,7 +496,7 @@ TEST(LoadCellBatchAsync, FinalizeCellBeforePush) {
         ASSERT_NE(cell_data, nullptr);
         EXPECT_NE(cell_data->chunk, nullptr);
         EXPECT_TRUE(cell_data->tables.empty());
-        EXPECT_EQ(cell_data->budget_bytes, 0);
+        EXPECT_EQ(cell_data->loading_overhead_bytes, 0);
         ReleaseCellLoadResultBudget(cell_data);
         ++received;
     }
@@ -440,6 +506,73 @@ TEST(LoadCellBatchAsync, FinalizeCellBeforePush) {
 
     EXPECT_EQ(received, 2);
     EXPECT_EQ(finalized.load(), 2);
+}
+
+TEST(LoadCellBatchAsync, ReleasesBatchBudgetBeforeChannelPush) {
+    auto& budget =
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
+    auto old_capacity = budget.CapacityBytes();
+    budget.SetCapacityBytes(2);
+    auto cleanup = folly::makeGuard(
+        [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
+
+    std::vector<CellSpec> specs = {
+        {0, 0, 0, 1, 1},
+        {1, 0, 1, 1, 1},
+    };
+
+    std::atomic<int> finalized{0};
+    auto channel = std::make_shared<CellReaderChannel>(1);
+    auto futures = LoadCellBatchAsync(
+        nullptr,
+        std::move(specs),
+        MakeMockReaderFactory(),
+        channel,
+        2,
+        milvus::proto::common::LoadPriority::HIGH,
+        [&finalized](const std::vector<std::shared_ptr<arrow::Table>>&,
+                     int64_t) {
+            finalized.fetch_add(1);
+            return std::make_unique<milvus::GroupChunk>();
+        });
+
+    ASSERT_EQ(futures.size(), 1);
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (finalized.load() < 2 &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_EQ(finalized.load(), 2);
+
+    folly::CancellationSource cancel_source;
+    auto acquire_future = std::async(
+        std::launch::async, [&budget, token = cancel_source.getToken()] {
+            return budget.AcquireUntil(2, token);
+        });
+    bool acquired = false;
+    if (acquire_future.wait_for(std::chrono::seconds(2)) ==
+        std::future_status::ready) {
+        acquired = acquire_future.get();
+    } else {
+        cancel_source.requestCancellation();
+        ASSERT_EQ(acquire_future.wait_for(std::chrono::seconds(2)),
+                  std::future_status::ready);
+        acquired = acquire_future.get();
+    }
+    if (acquired) {
+        budget.Release(2);
+    }
+
+    std::shared_ptr<CellLoadResult> cell_data;
+    ASSERT_TRUE(channel->pop(cell_data));
+    ReleaseCellLoadResultBudget(cell_data);
+    ASSERT_TRUE(channel->pop(cell_data));
+    ReleaseCellLoadResultBudget(cell_data);
+    futures[0].get();
+    EXPECT_FALSE(channel->pop(cell_data));
+    EXPECT_TRUE(acquired)
+        << "budget stayed held while worker was blocked on channel push";
 }
 
 TEST(LoadCellBatchAsync, FileBoundarySplit) {
@@ -474,8 +607,13 @@ TEST(LoadCellBatchAsync, ContiguityBreak) {
 
 TEST(LoadCellBatchAsync, EmptyCells) {
     auto channel = std::make_shared<CellReaderChannel>(64);
-    auto futures = LoadCellBatchAsync(
-        nullptr, {}, MakeMockReaderFactory(), channel, 128 << 20);
+    auto futures = LoadCellBatchAsync(nullptr,
+                                      {},
+                                      MakeMockReaderFactory(),
+                                      channel,
+                                      128 << 20,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
     EXPECT_EQ(futures.size(), 0);
 }
 
@@ -491,8 +629,13 @@ TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
     folly::CancellationSource source;
     milvus::OpContext op_ctx(source.getToken());
     auto channel = std::make_shared<CellReaderChannel>(1);
-    auto futures = LoadCellBatchAsync(
-        &op_ctx, specs, MakeMockReaderFactory(), channel, 128 * MB);
+    auto futures = LoadCellBatchAsync(&op_ctx,
+                                      specs,
+                                      MakeMockReaderFactory(),
+                                      channel,
+                                      128 * MB,
+                                      milvus::proto::common::LoadPriority::HIGH,
+                                      MakeMockCellFinalizer());
 
     ASSERT_EQ(futures.size(), 1);
 
@@ -535,8 +678,7 @@ TEST(LoadCellBatchAsync, CancellationWhileWaitingForBudgetSkipsRead) {
     BatchReaderFactory factory = [&read_calls](size_t /*batch_key*/,
                                                int64_t /*rg_offset*/,
                                                int64_t total_rg_count,
-                                               int64_t /*reader_memory_limit*/,
-                                               uint64_t /*read_parallelism*/)
+                                               int64_t /*reader_memory_limit*/)
         -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         read_calls.fetch_add(1);
         auto schema = arrow::schema({arrow::field("x", arrow::int64())});
@@ -555,16 +697,135 @@ TEST(LoadCellBatchAsync, CancellationWhileWaitingForBudgetSkipsRead) {
                                     /*local_rg_offset=*/0,
                                     /*rg_count=*/1,
                                     /*memory_size=*/1}};
-    auto futures = LoadCellBatchAsync(
-        &op_ctx, std::move(specs), std::move(factory), channel, 1);
+    auto load_future = std::async(
+        std::launch::async,
+        [&op_ctx,
+         specs = std::move(specs),
+         factory = std::move(factory),
+         channel]() mutable {
+            return LoadCellBatchAsync(
+                &op_ctx,
+                std::move(specs),
+                std::move(factory),
+                channel,
+                1,
+                milvus::proto::common::LoadPriority::HIGH,
+                [](const std::vector<std::shared_ptr<arrow::Table>>&, int64_t) {
+                    return std::make_unique<milvus::GroupChunk>();
+                });
+        });
 
-    ASSERT_EQ(futures.size(), 1);
-    EXPECT_EQ(futures[0].wait_for(std::chrono::milliseconds(50)),
+    EXPECT_EQ(load_future.wait_for(std::chrono::milliseconds(50)),
               std::future_status::timeout);
     EXPECT_EQ(read_calls.load(), 0);
 
     source.requestCancellation();
 
+    ASSERT_EQ(load_future.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    auto futures = load_future.get();
+    ASSERT_EQ(futures.size(), 1);
+    ASSERT_EQ(futures[0].wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    try {
+        futures[0].get();
+        FAIL() << "expected cancellation";
+    } catch (const milvus::SegcoreError& e) {
+        EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
+    }
+
+    std::shared_ptr<CellLoadResult> cell_data;
+    EXPECT_FALSE(channel->pop(cell_data));
+    EXPECT_EQ(read_calls.load(), 0);
+}
+
+TEST(LoadCellBatchAsync, WaitingForBudgetDoesNotOccupyLoadPoolWorker) {
+    auto& budget =
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
+    auto old_capacity = budget.CapacityBytes();
+    budget.SetCapacityBytes(1);
+    budget.Acquire(1);
+    auto budget_cleanup = folly::makeGuard([&budget, old_capacity]() {
+        budget.Release(1);
+        budget.SetCapacityBytes(old_capacity);
+    });
+
+    auto priority = milvus::proto::common::LoadPriority::LOW;
+    auto pool_priority = milvus::PriorityForLoad(priority);
+    auto& pool = milvus::ThreadPools::GetThreadPool(pool_priority);
+    auto old_max_threads = pool.GetMaxThreadNum();
+    auto cpu_num = std::max(1, milvus::CPU_NUM);
+    milvus::ThreadPools::ResizeThreadPool(pool_priority,
+                                          1.0F / static_cast<float>(cpu_num));
+    auto pool_cleanup =
+        folly::makeGuard([pool_priority, old_max_threads, cpu_num]() {
+            milvus::ThreadPools::ResizeThreadPool(
+                pool_priority,
+                static_cast<float>(old_max_threads) /
+                    static_cast<float>(cpu_num));
+        });
+    ASSERT_EQ(pool.GetMaxThreadNum(), 1);
+    if (pool.GetThreadNum() > 1) {
+        GTEST_SKIP() << "load pool already has more than one worker";
+    }
+
+    std::atomic<int> read_calls{0};
+    BatchReaderFactory factory = [&read_calls](size_t /*batch_key*/,
+                                               int64_t /*rg_offset*/,
+                                               int64_t total_rg_count,
+                                               int64_t /*reader_memory_limit*/)
+        -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+        read_calls.fetch_add(1);
+        auto schema = arrow::schema({arrow::field("x", arrow::int64())});
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        for (int64_t i = 0; i < total_rg_count; ++i) {
+            tables.push_back(arrow::Table::MakeEmpty(schema).ValueOrDie());
+        }
+        return tables;
+    };
+
+    folly::CancellationSource source;
+    milvus::OpContext op_ctx(source.getToken());
+    auto channel = std::make_shared<CellReaderChannel>(1);
+    std::vector<CellSpec> specs = {{/*cid=*/0,
+                                    /*file_idx=*/0,
+                                    /*local_rg_offset=*/0,
+                                    /*rg_count=*/1,
+                                    /*memory_size=*/1}};
+    auto load_future = std::async(
+        std::launch::async,
+        [&op_ctx,
+         specs = std::move(specs),
+         factory = std::move(factory),
+         channel,
+         priority]() mutable {
+            return LoadCellBatchAsync(
+                &op_ctx,
+                std::move(specs),
+                std::move(factory),
+                channel,
+                1,
+                priority,
+                [](const std::vector<std::shared_ptr<arrow::Table>>&, int64_t) {
+                    return std::make_unique<milvus::GroupChunk>();
+                });
+        });
+
+    ASSERT_EQ(load_future.wait_for(std::chrono::milliseconds(50)),
+              std::future_status::timeout);
+    EXPECT_EQ(read_calls.load(), 0);
+
+    auto marker = pool.Submit([]() { return 42; });
+    ASSERT_EQ(marker.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    EXPECT_EQ(marker.get(), 42);
+
+    source.requestCancellation();
+
+    ASSERT_EQ(load_future.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    auto futures = load_future.get();
+    ASSERT_EQ(futures.size(), 1);
     ASSERT_EQ(futures[0].wait_for(std::chrono::seconds(2)),
               std::future_status::ready);
     try {

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -27,7 +27,6 @@
 #include <vector>
 
 #include "arrow/api.h"
-#include "cachinglayer/LoadingOverheadTracker.h"
 #include <folly/CancellationToken.h>
 #include "folly/ScopeGuard.h"
 #include "common/EasyAssert.h"
@@ -214,24 +213,38 @@ TEST(FieldDataLoadBatchSplitTargetBytes, CapsTargetByConfiguredBudget) {
     EXPECT_EQ(FieldDataLoadBatchSplitTargetBytes(), 8 * MB);
 }
 
-TEST(FieldDataLoadingOverheadUpperBound, UsesUnlimitedWhenBudgetDisabled) {
+TEST(FieldDataLoadingOverheadUpperBound, UsesPoolBoundWhenBudgetDisabled) {
     auto& budget =
         milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
-    auto cleanup = folly::makeGuard(
-        [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
+    auto old_batch_target = FieldDataLoadBatchTargetBytes();
+    auto cleanup =
+        folly::makeGuard([&budget, old_capacity, old_batch_target]() {
+            budget.SetCapacityBytes(old_capacity);
+            SetFieldDataLoadBatchTargetBytes(old_batch_target);
+        });
 
     budget.SetCapacityBytes(0);
+    SetFieldDataLoadBatchTargetBytes(64);
+
+    auto max_load_tasks =
+        milvus::ComputeThreadPoolMaxThreads(
+            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()) +
+        milvus::ComputeThreadPoolMaxThreads(
+            milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load());
 
     auto upper_bound =
         FieldDataLoadingOverheadUpperBound(/*max_memory_overhead=*/128);
 
-    EXPECT_EQ(
-        upper_bound.memory_bytes,
-        milvus::cachinglayer::LoadingOverheadTracker::kUnlimited.memory_bytes);
-    EXPECT_EQ(
-        upper_bound.file_bytes,
-        milvus::cachinglayer::LoadingOverheadTracker::kUnlimited.file_bytes);
+    EXPECT_EQ(upper_bound.memory_bytes, max_load_tasks * 128);
+    EXPECT_EQ(upper_bound.file_bytes, 0);
+
+    auto mmap_upper_bound = FieldDataLoadingOverheadUpperBound(
+        /*max_memory_overhead=*/128,
+        /*max_file_overhead=*/std::optional<int64_t>{256});
+
+    EXPECT_EQ(mmap_upper_bound.memory_bytes, max_load_tasks * 128);
+    EXPECT_EQ(mmap_upper_bound.file_bytes, max_load_tasks * 256);
 }
 
 TEST(FieldDataLoadingOverheadUpperBound, UsesBudgetWithMaxOverheadFloor) {

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -220,43 +220,29 @@ TEST(FieldDataLoadingOverheadUpperBound, UsesPoolBoundWhenBudgetDisabled) {
         milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
     auto old_batch_target = FieldDataLoadBatchTargetBytes();
-    auto& high_pool =
-        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
-    auto& low_pool =
-        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
-    auto old_high_max = high_pool.GetMaxThreadNum();
-    auto old_low_max = low_pool.GetMaxThreadNum();
-    auto cleanup = folly::makeGuard([&budget,
-                                     old_capacity,
-                                     old_batch_target,
-                                     &high_pool,
-                                     &low_pool,
-                                     old_high_max,
-                                     old_low_max]() {
-        budget.SetCapacityBytes(old_capacity);
-        SetFieldDataLoadBatchTargetBytes(old_batch_target);
-        high_pool.Resize(old_high_max);
-        low_pool.Resize(old_low_max);
-    });
+    auto cleanup =
+        folly::makeGuard([&budget, old_capacity, old_batch_target]() {
+            budget.SetCapacityBytes(old_capacity);
+            SetFieldDataLoadBatchTargetBytes(old_batch_target);
+        });
 
     budget.SetCapacityBytes(0);
     SetFieldDataLoadBatchTargetBytes(64);
-    high_pool.Resize(2);
-    low_pool.Resize(3);
-    constexpr int64_t max_load_tasks = 5;
+    auto expected_memory_ub = LoadTransientPoolUpperBound(128);
+    auto expected_file_ub = LoadTransientPoolUpperBound(256);
 
     auto upper_bound =
         FieldDataLoadingOverheadUpperBound(/*max_memory_overhead=*/128);
 
-    EXPECT_EQ(upper_bound.memory_bytes, max_load_tasks * 128);
+    EXPECT_EQ(upper_bound.memory_bytes, expected_memory_ub);
     EXPECT_EQ(upper_bound.file_bytes, 0);
 
     auto mmap_upper_bound = FieldDataLoadingOverheadUpperBound(
         /*max_memory_overhead=*/128,
         /*max_file_overhead=*/std::optional<int64_t>{256});
 
-    EXPECT_EQ(mmap_upper_bound.memory_bytes, max_load_tasks * 128);
-    EXPECT_EQ(mmap_upper_bound.file_bytes, max_load_tasks * 256);
+    EXPECT_EQ(mmap_upper_bound.memory_bytes, expected_memory_ub);
+    EXPECT_EQ(mmap_upper_bound.file_bytes, expected_file_ub);
 }
 
 TEST(FieldDataLoadingOverheadUpperBound, UsesBudgetWithMaxOverheadFloor) {

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -1231,10 +1231,17 @@ class SegmentLoadInfo {
                 &index_info, info_.segmentid());
             auto index_type_it =
                 load_index_info.index_params.find(milvus::index::INDEX_TYPE);
-            auto needs_file_context =
+            auto scalar_version_it = load_index_info.index_params.find(
+                milvus::index::SCALAR_INDEX_ENGINE_VERSION);
+            auto scalar_v3 =
                 !IsVectorDataType(load_index_info.field_type) &&
-                index_type_it != load_index_info.index_params.end() &&
-                index_type_it->second == milvus::index::HYBRID_INDEX_TYPE;
+                scalar_version_it != load_index_info.index_params.end() &&
+                std::stoi(scalar_version_it->second) >= 3;
+            auto needs_file_context =
+                scalar_v3 ||
+                (!IsVectorDataType(load_index_info.field_type) &&
+                 index_type_it != load_index_info.index_params.end() &&
+                 index_type_it->second == milvus::index::HYBRID_INDEX_TYPE);
             if (!needs_file_context) {
                 load_index_info.load_resource_request =
                     milvus::index::IndexFactory::GetInstance()

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -286,7 +286,7 @@ TEST_F(SegmentLoadInfoTest,
                   INDEX_STORE_PATH_VERSION_COLLECTION_ROOTED);
 }
 
-TEST_F(SegmentLoadInfoTest, BuildCacheSkipsHybridScalarResourceEstimate) {
+TEST_F(SegmentLoadInfoTest, BuildCacheDefersFileAwareScalarResourceEstimate) {
     proto::segcore::SegmentLoadInfo proto;
     proto.set_segmentid(100);
     proto.set_num_of_rows(1000);
@@ -302,10 +302,20 @@ TEST_F(SegmentLoadInfoTest, BuildCacheSkipsHybridScalarResourceEstimate) {
     auto* inverted_index = proto.add_index_infos();
     inverted_index->set_fieldid(109);
     inverted_index->set_indexid(5002);
+    inverted_index->set_current_scalar_index_version(3);
     inverted_index->add_index_file_paths("/path/to/inverted_index");
     auto* inverted_param = inverted_index->add_index_params();
     inverted_param->set_key(milvus::index::INDEX_TYPE);
     inverted_param->set_value(milvus::index::INVERTED_INDEX_TYPE);
+
+    auto* legacy_inverted_index = proto.add_index_infos();
+    legacy_inverted_index->set_fieldid(110);
+    legacy_inverted_index->set_indexid(5003);
+    legacy_inverted_index->add_index_file_paths(
+        "/path/to/legacy_inverted_index");
+    auto* legacy_inverted_param = legacy_inverted_index->add_index_params();
+    legacy_inverted_param->set_key(milvus::index::INDEX_TYPE);
+    legacy_inverted_param->set_value(milvus::index::INVERTED_INDEX_TYPE);
 
     SegmentLoadInfo segment_info(proto, schema_);
 
@@ -315,7 +325,11 @@ TEST_F(SegmentLoadInfoTest, BuildCacheSkipsHybridScalarResourceEstimate) {
 
     auto inverted_infos = segment_info.GetFieldIndexInfos(FieldId(109));
     ASSERT_EQ(inverted_infos.size(), 1);
-    EXPECT_TRUE(inverted_infos[0].load_resource_request.has_value());
+    EXPECT_FALSE(inverted_infos[0].load_resource_request.has_value());
+
+    auto legacy_inverted_infos = segment_info.GetFieldIndexInfos(FieldId(110));
+    ASSERT_EQ(legacy_inverted_infos.size(), 1);
+    EXPECT_TRUE(legacy_inverted_infos[0].load_resource_request.has_value());
 }
 
 TEST_F(SegmentLoadInfoTest, CompactRuntimeInfoForManifest) {

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -53,7 +53,6 @@
 #include "pb/schema.pb.h"
 #include "segcore/Types.h"
 #include "segcore/Utils.h"
-#include "segcore/default_fs.h"
 #include "segcore/storagev1translator/V1SealedIndexTranslator.h"
 #include "storage/FileManager.h"
 #include "storage/LocalChunkManager.h"
@@ -163,49 +162,10 @@ EstimateLoadIndexResource(CLoadIndexInfo c_load_index_info) {
         AssertInfo(find_index_type == true,
                    "Can't find index type in index_params");
 
-        auto config = milvus::index::ParseConfigFromIndexParams(index_params);
-        auto scalar_version =
-            milvus::index::GetValueFromConfig<int32_t>(
-                config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
-                .value_or(1);
-        // Production V3 callers have completed FinishLoadIndexInfo and carry
-        // the field schema needed to resolve the packed remote object.
-        auto use_file_context = !milvus::IsVectorDataType(field_type) &&
-                                scalar_version >= 3 &&
-                                !load_index_info->index_files.empty() &&
-                                load_index_info->schema.ByteSizeLong() > 0;
-        if (!use_file_context) {
-            return milvus::index::IndexFactory::GetInstance().IndexLoadResource(
-                field_type,
-                element_type,
-                load_index_info->index_engine_version,
-                load_index_info->index_size,
-                index_params,
-                load_index_info->enable_mmap,
-                load_index_info->num_rows,
-                load_index_info->dim);
-        }
-
-        milvus::storage::FieldDataMeta field_meta{
-            load_index_info->collection_id,
-            load_index_info->partition_id,
-            load_index_info->segment_id,
-            load_index_info->field_id,
-            load_index_info->schema};
-        milvus::storage::IndexMeta index_meta{load_index_info->segment_id,
-                                              load_index_info->field_id,
-                                              load_index_info->index_build_id,
-                                              load_index_info->index_version};
-        index_meta.index_store_path_version =
-            load_index_info->index_store_path_version;
-        auto remote_chunk_manager =
-            milvus::storage::RemoteChunkManagerSingleton::GetInstance()
-                .GetRemoteChunkManager();
-        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
-        milvus::storage::FileManagerContext file_manager_context(
-            field_meta, index_meta, remote_chunk_manager, fs);
-        file_manager_context.set_for_loading_index(true);
-
+        // Segment Loader calls this API while deciding whether a segment may
+        // start loading. Keep that admission path metadata-only: exact scalar
+        // V3 directory inspection belongs to SealedIndexTranslator, where the
+        // result is used for the actual MCL loading reservation.
         return milvus::index::IndexFactory::GetInstance().IndexLoadResource(
             field_type,
             element_type,
@@ -214,9 +174,7 @@ EstimateLoadIndexResource(CLoadIndexInfo c_load_index_info) {
             index_params,
             load_index_info->enable_mmap,
             load_index_info->num_rows,
-            load_index_info->dim,
-            load_index_info->index_files,
-            file_manager_context);
+            load_index_info->dim);
     } catch (std::exception& e) {
         ThrowInfo(milvus::UnexpectedError,
                   fmt::format("failed to estimate index load resource, "

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -53,6 +53,7 @@
 #include "pb/schema.pb.h"
 #include "segcore/Types.h"
 #include "segcore/Utils.h"
+#include "segcore/default_fs.h"
 #include "segcore/storagev1translator/V1SealedIndexTranslator.h"
 #include "storage/FileManager.h"
 #include "storage/LocalChunkManager.h"
@@ -162,8 +163,19 @@ EstimateLoadIndexResource(CLoadIndexInfo c_load_index_info) {
         AssertInfo(find_index_type == true,
                    "Can't find index type in index_params");
 
-        LoadResourceRequest request =
-            milvus::index::IndexFactory::GetInstance().IndexLoadResource(
+        auto config = milvus::index::ParseConfigFromIndexParams(index_params);
+        auto scalar_version =
+            milvus::index::GetValueFromConfig<int32_t>(
+                config, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
+                .value_or(1);
+        // Production V3 callers have completed FinishLoadIndexInfo and carry
+        // the field schema needed to resolve the packed remote object.
+        auto use_file_context = !milvus::IsVectorDataType(field_type) &&
+                                scalar_version >= 3 &&
+                                !load_index_info->index_files.empty() &&
+                                load_index_info->schema.ByteSizeLong() > 0;
+        if (!use_file_context) {
+            return milvus::index::IndexFactory::GetInstance().IndexLoadResource(
                 field_type,
                 element_type,
                 load_index_info->index_engine_version,
@@ -172,7 +184,39 @@ EstimateLoadIndexResource(CLoadIndexInfo c_load_index_info) {
                 load_index_info->enable_mmap,
                 load_index_info->num_rows,
                 load_index_info->dim);
-        return request;
+        }
+
+        milvus::storage::FieldDataMeta field_meta{
+            load_index_info->collection_id,
+            load_index_info->partition_id,
+            load_index_info->segment_id,
+            load_index_info->field_id,
+            load_index_info->schema};
+        milvus::storage::IndexMeta index_meta{load_index_info->segment_id,
+                                              load_index_info->field_id,
+                                              load_index_info->index_build_id,
+                                              load_index_info->index_version};
+        index_meta.index_store_path_version =
+            load_index_info->index_store_path_version;
+        auto remote_chunk_manager =
+            milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                .GetRemoteChunkManager();
+        auto fs = milvus::segcore::GetDefaultArrowFileSystem();
+        milvus::storage::FileManagerContext file_manager_context(
+            field_meta, index_meta, remote_chunk_manager, fs);
+        file_manager_context.set_for_loading_index(true);
+
+        return milvus::index::IndexFactory::GetInstance().IndexLoadResource(
+            field_type,
+            element_type,
+            load_index_info->index_engine_version,
+            load_index_info->index_size,
+            index_params,
+            load_index_info->enable_mmap,
+            load_index_info->num_rows,
+            load_index_info->dim,
+            load_index_info->index_files,
+            file_manager_context);
     } catch (std::exception& e) {
         ThrowInfo(milvus::UnexpectedError,
                   fmt::format("failed to estimate index load resource, "

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -53,8 +53,21 @@ std::atomic<int64_t> FIELD_DATA_LOAD_BATCH_TARGET_BYTES(
     kDefaultFieldDataLoadBatchTargetBytes);
 std::atomic<int64_t> FIELD_DATA_READ_WINDOW_BYTES(
     kDefaultFieldDataReadWindowBytes);
-std::atomic<int64_t> FIELD_DATA_MAX_READ_PARALLELISM(
-    kDefaultFieldDataMaxReadParallelism);
+
+void
+CompleteCellBatchFuture(const std::shared_ptr<std::promise<void>>& promise,
+                        const std::shared_ptr<CellReaderChannel>& channel,
+                        const std::shared_ptr<std::atomic<size_t>>& remaining,
+                        std::exception_ptr error = nullptr) {
+    if (error) {
+        promise->set_exception(std::move(error));
+    } else {
+        promise->set_value();
+    }
+    if (remaining->fetch_sub(1) == 1) {
+        channel->close();
+    }
+}
 
 int64_t
 PositiveBytes(int64_t bytes, int64_t fallback) {
@@ -88,11 +101,6 @@ FieldDataReadWindowBytes() {
                          kDefaultFieldDataReadWindowBytes);
 }
 
-int64_t
-FieldDataMaxReadParallelism() {
-    return std::max<int64_t>(FIELD_DATA_MAX_READ_PARALLELISM.load(), 1);
-}
-
 void
 SetFieldDataLoadBatchTargetBytes(int64_t bytes) {
     FIELD_DATA_LOAD_BATCH_TARGET_BYTES.store(
@@ -107,13 +115,6 @@ SetFieldDataReadWindowBytes(int64_t bytes) {
         PositiveBytes(bytes, kDefaultFieldDataReadWindowBytes));
     LOG_INFO("set field data read window bytes: {}",
              FIELD_DATA_READ_WINDOW_BYTES.load());
-}
-
-void
-SetFieldDataMaxReadParallelism(int64_t parallelism) {
-    FIELD_DATA_MAX_READ_PARALLELISM.store(std::max<int64_t>(parallelism, 1));
-    LOG_INFO("set field data max read parallelism: {}",
-             FIELD_DATA_MAX_READ_PARALLELISM.load());
 }
 
 milvus::cachinglayer::ResourceUsage
@@ -137,58 +138,24 @@ FieldDataLoadingOverheadUpperBound(int64_t max_memory_overhead,
 namespace {
 
 size_t
-CellLoadingBudgetBytes(const CellSpec& cell) {
-    auto overhead_size = cell.loading_overhead_size > 0
-                             ? cell.loading_overhead_size
-                             : cell.memory_size;
-    AssertInfo(overhead_size > 0,
+CellLoadingOverheadBytes(const CellSpec& cell) {
+    auto loading_overhead_size = cell.loading_overhead_size > 0
+                                     ? cell.loading_overhead_size
+                                     : cell.memory_size;
+    AssertInfo(loading_overhead_size > 0,
                "[StorageV2] Cell loading overhead size must be positive, "
                "cid={}, got {}, memory_size={}",
                cell.cid,
-               overhead_size,
+               loading_overhead_size,
                cell.memory_size);
-    return static_cast<size_t>(overhead_size);
-}
-
-size_t
-BatchLoadingBudgetBytes(const std::vector<CellSpec>& cells) {
-    size_t total = 0;
-    for (const auto& cell : cells) {
-        auto bytes = CellLoadingBudgetBytes(cell);
-        if (bytes > std::numeric_limits<size_t>::max() - total) {
-            return std::numeric_limits<size_t>::max();
-        }
-        total += bytes;
-    }
-    return total;
+    return static_cast<size_t>(loading_overhead_size);
 }
 
 int64_t
-BatchReaderMemoryLimit(int64_t batch_memory, int64_t memory_limit) {
-    auto capped = std::min(batch_memory, memory_limit);
+BatchReaderMemoryLimit(int64_t batch_loaded_memory_bytes,
+                       int64_t memory_limit) {
+    auto capped = std::min(batch_loaded_memory_bytes, memory_limit);
     return std::max<int64_t>(capped, FieldDataReadWindowBytes());
-}
-
-uint64_t
-BatchReadParallelism(size_t batch_budget_bytes, int64_t total_rg_count) {
-    if (total_rg_count <= 1) {
-        return 1;
-    }
-
-    auto read_window = std::max<int64_t>(FieldDataReadWindowBytes(), 1);
-    auto budget_capacity =
-        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
-            .CapacityBytes();
-    auto bounded_budget = budget_capacity == 0
-                              ? batch_budget_bytes
-                              : std::min(batch_budget_bytes, budget_capacity);
-    auto parallelism_by_budget =
-        std::max<size_t>(1, bounded_budget / static_cast<size_t>(read_window));
-    auto max_parallelism = FieldDataMaxReadParallelism();
-    auto parallelism = std::min<size_t>(parallelism_by_budget,
-                                        static_cast<size_t>(max_parallelism));
-    return std::min<uint64_t>(static_cast<uint64_t>(parallelism),
-                              static_cast<uint64_t>(total_rg_count));
 }
 
 arrow::Result<std::vector<std::shared_ptr<arrow::Table>>>
@@ -463,18 +430,24 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
         size_t file_idx;
         int64_t rg_offset;
         int64_t rg_count;
-        int64_t batch_memory = 0;
+        int64_t batch_loaded_memory_bytes = 0;
+        size_t batch_loading_overhead_bytes = 0;
         std::vector<CellSpec> cells;
     };
 
+    auto batch_limit_bytes =
+        static_cast<size_t>(std::max<int64_t>(memory_limit, 1));
     std::vector<CellBatch> batches;
     CellBatch current{};
 
     for (const auto& spec : cell_specs) {
+        auto cell_loading_overhead_bytes = CellLoadingOverheadBytes(spec);
         bool should_split = false;
         if (!current.cells.empty()) {
             bool batch_full =
-                (current.batch_memory + spec.memory_size > memory_limit);
+                current.batch_loading_overhead_bytes > batch_limit_bytes ||
+                cell_loading_overhead_bytes >
+                    batch_limit_bytes - current.batch_loading_overhead_bytes;
             if (spec.file_idx != current.file_idx ||
                 spec.local_rg_offset != current.rg_offset + current.rg_count ||
                 batch_full) {
@@ -489,10 +462,19 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
             current.file_idx = spec.file_idx;
             current.rg_offset = spec.local_rg_offset;
             current.rg_count = 0;
-            current.batch_memory = 0;
+            current.batch_loaded_memory_bytes = 0;
+            current.batch_loading_overhead_bytes = 0;
         }
         current.rg_count += spec.rg_count;
-        current.batch_memory += spec.memory_size;
+        current.batch_loaded_memory_bytes += spec.memory_size;
+        if (cell_loading_overhead_bytes >
+            std::numeric_limits<size_t>::max() -
+                current.batch_loading_overhead_bytes) {
+            current.batch_loading_overhead_bytes =
+                std::numeric_limits<size_t>::max();
+        } else {
+            current.batch_loading_overhead_bytes += cell_loading_overhead_bytes;
+        }
         current.cells.push_back(spec);
     }
     if (!current.cells.empty()) {
@@ -504,26 +486,16 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
         return {};
     }
 
-    uint64_t max_read_parallelism = 1;
-    for (const auto& batch : batches) {
-        max_read_parallelism =
-            std::max(max_read_parallelism,
-                     BatchReadParallelism(BatchLoadingBudgetBytes(batch.cells),
-                                          batch.rg_count));
-    }
-
     LOG_INFO(
         "[StorageV2] LoadCellBatchAsync: {} cells -> {} batches "
-        "(memory_limit={}MB, budget_capacity={}MB, read_window={}MB, "
-        "max_read_parallelism={})",
+        "(memory_limit={}MB, budget_capacity={}MB, read_window={}MB)",
         cell_specs.size(),
         batches.size(),
         memory_limit >> 20,
         milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                 .CapacityBytes() >>
             20,
-        FieldDataReadWindowBytes() >> 20,
-        max_read_parallelism);
+        FieldDataReadWindowBytes() >> 20);
 
     auto& pool = ThreadPools::GetThreadPool(milvus::PriorityForLoad(priority));
     auto remaining = std::make_shared<std::atomic<size_t>>(batches.size());
@@ -531,94 +503,119 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
         std::make_shared<BatchReaderFactory>(std::move(reader_factory));
     auto shared_finalizer =
         std::make_shared<CellFinalizeFunc>(std::move(finalize_cell));
+    AssertInfo(static_cast<bool>(*shared_finalizer),
+               "[StorageV2] LoadCellBatchAsync requires a cell finalizer");
 
     std::vector<std::future<void>> futures;
     futures.reserve(batches.size());
 
-    for (auto& batch : batches) {
-        auto batch_budget_bytes = BatchLoadingBudgetBytes(batch.cells);
-        auto read_parallelism =
-            BatchReadParallelism(batch_budget_bytes, batch.rg_count);
-        auto reader_memory_limit =
-            BatchReaderMemoryLimit(batch.batch_memory, memory_limit);
-        futures.emplace_back(pool.Submit([batch = std::move(batch),
-                                          shared_factory,
-                                          batch_budget_bytes,
-                                          reader_memory_limit,
-                                          read_parallelism,
-                                          channel,
-                                          remaining,
-                                          shared_finalizer,
-                                          op_ctx]() {
-            auto task_guard = folly::makeGuard([&channel, &remaining]() {
-                if (remaining->fetch_sub(1) == 1) {
-                    channel->close();
-                }
-            });
-            CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
+    auto append_failed_future = [&](std::exception_ptr error) {
+        auto promise = std::make_shared<std::promise<void>>();
+        futures.emplace_back(promise->get_future());
+        CompleteCellBatchFuture(promise, channel, remaining, error);
+    };
 
-            auto& budget = milvus::storage::TransientMemoryBudget::
-                GetLoadTransientBudget();
-            auto acquired = budget.AcquireUntil(batch_budget_bytes, [op_ctx]() {
-                return op_ctx &&
-                       op_ctx->cancellation_token.isCancellationRequested();
-            });
-            if (!acquired) {
-                CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
-                return;
-            }
-            size_t transferred_budget_bytes = 0;
-            auto release_guard = folly::makeGuard(
-                [&budget, batch_budget_bytes, &transferred_budget_bytes]() {
-                    if (transferred_budget_bytes < batch_budget_bytes) {
-                        budget.Release(batch_budget_bytes -
-                                       transferred_budget_bytes);
+    for (auto& batch : batches) {
+        auto batch_loading_overhead_bytes = batch.batch_loading_overhead_bytes;
+        auto reader_memory_limit = BatchReaderMemoryLimit(
+            batch.batch_loaded_memory_bytes, memory_limit);
+        auto& budget =
+            milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
+        auto cancellation_token =
+            op_ctx ? op_ctx->cancellation_token : folly::CancellationToken();
+        auto budget_admitted = budget.AcquireUntil(batch_loading_overhead_bytes,
+                                                   cancellation_token);
+        if (!budget_admitted) {
+            // AcquireUntil waits for budget and returns false only when the
+            // caller's lifecycle ends before admission.
+            append_failed_future(std::make_exception_ptr(SegcoreError(
+                ErrorCode::FollyCancel, "LoadCellBatchAsync cancelled")));
+            continue;
+        }
+
+        try {
+            futures.emplace_back(pool.Submit([batch = std::move(batch),
+                                              shared_factory,
+                                              batch_loading_overhead_bytes,
+                                              reader_memory_limit,
+                                              channel,
+                                              remaining,
+                                              shared_finalizer,
+                                              op_ctx]() mutable {
+                auto task_guard = folly::makeGuard([&channel, &remaining]() {
+                    if (remaining->fetch_sub(1) == 1) {
+                        channel->close();
                     }
                 });
-            CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
-            auto tables_result = (*shared_factory)(batch.file_idx,
-                                                   batch.rg_offset,
-                                                   batch.rg_count,
-                                                   reader_memory_limit,
-                                                   read_parallelism);
-            AssertInfo(tables_result.ok(),
-                       "[StorageV2] Failed to read batch: " +
-                           tables_result.status().ToString());
-            auto all_tables = std::move(tables_result).ValueOrDie();
-            AssertInfo(all_tables.size() == static_cast<size_t>(batch.rg_count),
-                       "reader returns less tables than expected, batch rg "
-                       "count: {}, result size: {}",
-                       batch.rg_count,
-                       all_tables.size());
-            CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
-
-            int64_t table_offset = 0;
-            for (const auto& cell : batch.cells) {
+                auto& budget = milvus::storage::TransientMemoryBudget::
+                    GetLoadTransientBudget();
+                size_t transferred_loading_overhead_bytes = 0;
+                auto release_guard =
+                    folly::makeGuard([&budget,
+                                      batch_loading_overhead_bytes,
+                                      &transferred_loading_overhead_bytes]() {
+                        if (transferred_loading_overhead_bytes <
+                            batch_loading_overhead_bytes) {
+                            budget.Release(batch_loading_overhead_bytes -
+                                           transferred_loading_overhead_bytes);
+                        }
+                    });
                 CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
-                auto cell_result = std::make_shared<CellLoadResult>();
-                cell_result->cid = cell.cid;
-                auto cell_budget_bytes = CellLoadingBudgetBytes(cell);
-                cell_result->budget_bytes = cell_budget_bytes;
-                cell_result->tables.reserve(cell.rg_count);
-                for (int64_t i = 0; i < cell.rg_count; ++i) {
-                    cell_result->tables.push_back(
-                        std::move(all_tables[table_offset + i]));
-                }
-                table_offset += cell.rg_count;
-                if (*shared_finalizer) {
+
+                auto tables_result = (*shared_factory)(batch.file_idx,
+                                                       batch.rg_offset,
+                                                       batch.rg_count,
+                                                       reader_memory_limit);
+                AssertInfo(tables_result.ok(),
+                           "[StorageV2] Failed to read batch: " +
+                               tables_result.status().ToString());
+                auto all_tables = std::move(tables_result).ValueOrDie();
+                AssertInfo(
+                    all_tables.size() == static_cast<size_t>(batch.rg_count),
+                    "reader returns less tables than expected, batch rg "
+                    "count: {}, result size: {}",
+                    batch.rg_count,
+                    all_tables.size());
+                CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
+
+                int64_t table_offset = 0;
+                std::vector<std::shared_ptr<CellLoadResult>> cell_results;
+                cell_results.reserve(batch.cells.size());
+                for (const auto& cell : batch.cells) {
+                    CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
+                    auto cell_result = std::make_shared<CellLoadResult>();
+                    cell_result->cid = cell.cid;
+                    auto cell_loading_overhead_bytes =
+                        CellLoadingOverheadBytes(cell);
+                    cell_result->loading_overhead_bytes =
+                        cell_loading_overhead_bytes;
+                    cell_result->tables.reserve(cell.rg_count);
+                    for (int64_t i = 0; i < cell.rg_count; ++i) {
+                        cell_result->tables.push_back(
+                            std::move(all_tables[table_offset + i]));
+                    }
+                    table_offset += cell.rg_count;
                     cell_result->chunk =
                         (*shared_finalizer)(cell_result->tables, cell.cid);
                     ReleaseCellLoadResultBudget(cell_result);
-                    transferred_budget_bytes += cell_budget_bytes;
+                    transferred_loading_overhead_bytes +=
+                        cell_loading_overhead_bytes;
+                    cell_results.push_back(std::move(cell_result));
+                }
+
+                for (auto& cell_result : cell_results) {
                     CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
                     channel->push(std::move(cell_result));
-                    continue;
                 }
-                channel->push(std::move(cell_result));
-                transferred_budget_bytes += cell_budget_bytes;
+            }));
+        } catch (...) {
+            if (budget_admitted) {
+                milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
+                    .Release(batch_loading_overhead_bytes);
             }
-        }));
+            append_failed_future(std::current_exception());
+        }
     }
 
     return futures;
@@ -631,12 +628,12 @@ ReleaseCellLoadResultBudget(
         return;
     }
     cell_load_result->tables.clear();
-    if (cell_load_result->budget_bytes == 0) {
+    if (cell_load_result->loading_overhead_bytes == 0) {
         return;
     }
     milvus::storage::TransientMemoryBudget::GetLoadTransientBudget().Release(
-        cell_load_result->budget_bytes);
-    cell_load_result->budget_bytes = 0;
+        cell_load_result->loading_overhead_bytes);
+    cell_load_result->loading_overhead_bytes = 0;
 }
 
 BatchReaderFactory
@@ -647,8 +644,7 @@ MakeFileReaderFactory(std::vector<std::string> remote_files,
     return [files, fs](size_t batch_key,
                        int64_t rg_offset,
                        int64_t total_rg_count,
-                       int64_t reader_memory_limit,
-                       uint64_t /*read_parallelism*/)
+                       int64_t reader_memory_limit)
                -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         const auto& file = (*files)[batch_key];
         return ReadFileRowGroupBlock(
@@ -662,8 +658,7 @@ MakeChunkReaderFactory(
     return [chunk_reader](size_t /*batch_key*/,
                           int64_t rg_offset,
                           int64_t total_rg_count,
-                          int64_t /*reader_memory_limit*/,
-                          uint64_t /*read_parallelism*/)
+                          int64_t /*reader_memory_limit*/)
                -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         std::vector<int64_t> rg_indices(total_rg_count);
         std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -27,7 +27,6 @@
 #include <vector>
 
 #include "arrow/api.h"
-#include "cachinglayer/LoadingOverheadTracker.h"
 #include "common/Channel.h"
 #include "common/Common.h"
 #include "common/EasyAssert.h"
@@ -86,6 +85,22 @@ FieldDataReadWindowBytes() {
                          kDefaultFieldDataReadWindowBytes);
 }
 
+int64_t
+LoadTransientPoolUpperBound(size_t max_task_overhead_bytes) {
+    // Load work can run concurrently in both pools because PriorityForLoad
+    // maps foreground loads to HIGH and background loads to LOW.
+    auto max_load_tasks = static_cast<size_t>(
+        milvus::ComputeThreadPoolMaxThreads(
+            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()) +
+        milvus::ComputeThreadPoolMaxThreads(
+            milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
+    auto max_int64 = static_cast<size_t>(std::numeric_limits<int64_t>::max());
+    if (max_task_overhead_bytes > max_int64 / max_load_tasks) {
+        return std::numeric_limits<int64_t>::max();
+    }
+    return static_cast<int64_t>(max_load_tasks * max_task_overhead_bytes);
+}
+
 void
 SetFieldDataLoadBatchTargetBytes(int64_t bytes) {
     FIELD_DATA_LOAD_BATCH_TARGET_BYTES.store(
@@ -108,15 +123,24 @@ FieldDataLoadingOverheadUpperBound(int64_t max_memory_overhead,
     auto budget_capacity = static_cast<int64_t>(
         milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
             .CapacityBytes());
-    if (budget_capacity == 0) {
-        return milvus::cachinglayer::LoadingOverheadTracker::kUnlimited;
+    if (budget_capacity != 0) {
+        auto memory_ub =
+            std::max<int64_t>(budget_capacity, max_memory_overhead);
+        auto file_ub =
+            max_file_overhead.has_value()
+                ? std::max<int64_t>(budget_capacity, max_file_overhead.value())
+                : int64_t{0};
+        return {memory_ub, file_ub};
     }
 
-    auto memory_ub = std::max<int64_t>(budget_capacity, max_memory_overhead);
-    auto file_ub =
-        max_file_overhead.has_value()
-            ? std::max<int64_t>(budget_capacity, max_file_overhead.value())
-            : int64_t{0};
+    auto batch_target = FieldDataLoadBatchSplitTargetBytes();
+    auto memory_task_overhead =
+        static_cast<size_t>(std::max(batch_target, max_memory_overhead));
+    auto memory_ub = LoadTransientPoolUpperBound(memory_task_overhead);
+    auto file_ub = max_file_overhead.has_value()
+                       ? LoadTransientPoolUpperBound(static_cast<size_t>(
+                             std::max(batch_target, max_file_overhead.value())))
+                       : int64_t{0};
     return {memory_ub, file_ub};
 }
 

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -89,20 +89,13 @@ int64_t
 LoadTransientPoolUpperBound(size_t max_task_overhead_bytes) {
     // Load work can run concurrently in both pools because PriorityForLoad
     // maps foreground loads to HIGH and background loads to LOW.
-    auto configured_high =
-        static_cast<size_t>(milvus::ComputeThreadPoolMaxThreads(
-            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
-    auto configured_low =
-        static_cast<size_t>(milvus::ComputeThreadPoolMaxThreads(
-            milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
-    auto live_high =
+    auto max_high =
         milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH)
-            .GetThreadNum();
-    auto live_low =
+            .GetMaxThreadNum();
+    auto max_low =
         milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW)
-            .GetThreadNum();
-    auto max_load_tasks = std::max(configured_high, live_high) +
-                          std::max(configured_low, live_low);
+            .GetMaxThreadNum();
+    auto max_load_tasks = max_high + max_low;
     auto max_int64 = static_cast<size_t>(std::numeric_limits<int64_t>::max());
     if (max_task_overhead_bytes > max_int64 / max_load_tasks) {
         return std::numeric_limits<int64_t>::max();

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -103,6 +103,26 @@ LoadTransientPoolUpperBound(size_t max_task_overhead_bytes) {
     return static_cast<int64_t>(max_load_tasks * max_task_overhead_bytes);
 }
 
+int64_t
+LoadTransientSharedOverheadUpperBound(size_t max_task_overhead_bytes) {
+    auto pool_upper_bound =
+        LoadTransientPoolUpperBound(max_task_overhead_bytes);
+    auto budget_capacity =
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
+            .CapacityBytes();
+    if (budget_capacity == 0) {
+        return pool_upper_bound;
+    }
+
+    auto max_int64 = static_cast<size_t>(std::numeric_limits<int64_t>::max());
+    auto task_overhead =
+        static_cast<int64_t>(std::min(max_task_overhead_bytes, max_int64));
+    auto budget_upper_bound =
+        static_cast<int64_t>(std::min(budget_capacity, max_int64));
+    return std::min(std::max(budget_upper_bound, task_overhead),
+                    pool_upper_bound);
+}
+
 void
 SetFieldDataLoadBatchTargetBytes(int64_t bytes) {
     FIELD_DATA_LOAD_BATCH_TARGET_BYTES.store(

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -89,11 +89,20 @@ int64_t
 LoadTransientPoolUpperBound(size_t max_task_overhead_bytes) {
     // Load work can run concurrently in both pools because PriorityForLoad
     // maps foreground loads to HIGH and background loads to LOW.
-    auto max_load_tasks = static_cast<size_t>(
-        milvus::ComputeThreadPoolMaxThreads(
-            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()) +
-        milvus::ComputeThreadPoolMaxThreads(
+    auto configured_high =
+        static_cast<size_t>(milvus::ComputeThreadPoolMaxThreads(
+            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
+    auto configured_low =
+        static_cast<size_t>(milvus::ComputeThreadPoolMaxThreads(
             milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
+    auto live_high =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH)
+            .GetThreadNum();
+    auto live_low =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW)
+            .GetThreadNum();
+    auto max_load_tasks = std::max(configured_high, live_high) +
+                          std::max(configured_low, live_low);
     auto max_int64 = static_cast<size_t>(std::numeric_limits<int64_t>::max());
     if (max_task_overhead_bytes > max_int64 / max_load_tasks) {
         return std::numeric_limits<int64_t>::max();

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -54,21 +54,6 @@ std::atomic<int64_t> FIELD_DATA_LOAD_BATCH_TARGET_BYTES(
 std::atomic<int64_t> FIELD_DATA_READ_WINDOW_BYTES(
     kDefaultFieldDataReadWindowBytes);
 
-void
-CompleteCellBatchFuture(const std::shared_ptr<std::promise<void>>& promise,
-                        const std::shared_ptr<CellReaderChannel>& channel,
-                        const std::shared_ptr<std::atomic<size_t>>& remaining,
-                        std::exception_ptr error = nullptr) {
-    if (error) {
-        promise->set_exception(std::move(error));
-    } else {
-        promise->set_value();
-    }
-    if (remaining->fetch_sub(1) == 1) {
-        channel->close();
-    }
-}
-
 int64_t
 PositiveBytes(int64_t bytes, int64_t fallback) {
     return bytes > 0 ? bytes : fallback;
@@ -394,16 +379,14 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
     }
 }
 
-std::vector<std::future<void>>
+std::vector<CellLoadFuture>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    std::vector<CellSpec> cell_specs,
                    BatchReaderFactory reader_factory,
-                   std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
                    milvus::proto::common::LoadPriority priority,
                    CellFinalizeFunc finalize_cell) {
     if (cell_specs.empty()) {
-        channel->close();
         return {};
     }
 
@@ -482,7 +465,6 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     }
 
     if (batches.empty()) {
-        channel->close();
         return {};
     }
 
@@ -498,7 +480,6 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
         FieldDataReadWindowBytes() >> 20);
 
     auto& pool = ThreadPools::GetThreadPool(milvus::PriorityForLoad(priority));
-    auto remaining = std::make_shared<std::atomic<size_t>>(batches.size());
     auto shared_factory =
         std::make_shared<BatchReaderFactory>(std::move(reader_factory));
     auto shared_finalizer =
@@ -506,13 +487,13 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     AssertInfo(static_cast<bool>(*shared_finalizer),
                "[StorageV2] LoadCellBatchAsync requires a cell finalizer");
 
-    std::vector<std::future<void>> futures;
+    std::vector<CellLoadFuture> futures;
     futures.reserve(batches.size());
 
     auto append_failed_future = [&](std::exception_ptr error) {
-        auto promise = std::make_shared<std::promise<void>>();
-        futures.emplace_back(promise->get_future());
-        CompleteCellBatchFuture(promise, channel, remaining, error);
+        std::promise<LoadedCellBatch> promise;
+        futures.emplace_back(promise.get_future());
+        promise.set_exception(std::move(error));
     };
 
     for (auto& batch : batches) {
@@ -538,16 +519,8 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                                               shared_factory,
                                               batch_loading_overhead_bytes,
                                               reader_memory_limit,
-                                              channel,
-                                              remaining,
                                               shared_finalizer,
                                               op_ctx]() mutable {
-                auto task_guard = folly::makeGuard([&channel, &remaining]() {
-                    if (remaining->fetch_sub(1) == 1) {
-                        channel->close();
-                    }
-                });
-
                 auto& budget = milvus::storage::TransientMemoryBudget::
                     GetLoadTransientBudget();
                 size_t transferred_loading_overhead_bytes = 0;
@@ -580,34 +553,28 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                 CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
                 int64_t table_offset = 0;
-                std::vector<std::shared_ptr<CellLoadResult>> cell_results;
-                cell_results.reserve(batch.cells.size());
+                LoadedCellBatch loaded_cells;
+                loaded_cells.reserve(batch.cells.size());
                 for (const auto& cell : batch.cells) {
                     CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
-                    auto cell_result = std::make_shared<CellLoadResult>();
-                    cell_result->cid = cell.cid;
                     auto cell_loading_overhead_bytes =
                         CellLoadingOverheadBytes(cell);
-                    cell_result->loading_overhead_bytes =
-                        cell_loading_overhead_bytes;
-                    cell_result->tables.reserve(cell.rg_count);
+                    std::vector<std::shared_ptr<arrow::Table>> cell_tables;
+                    cell_tables.reserve(cell.rg_count);
                     for (int64_t i = 0; i < cell.rg_count; ++i) {
-                        cell_result->tables.push_back(
+                        cell_tables.push_back(
                             std::move(all_tables[table_offset + i]));
                     }
                     table_offset += cell.rg_count;
-                    cell_result->chunk =
-                        (*shared_finalizer)(cell_result->tables, cell.cid);
-                    ReleaseCellLoadResultBudget(cell_result);
+                    auto chunk = (*shared_finalizer)(cell_tables, cell.cid);
+                    cell_tables.clear();
+                    budget.Release(cell_loading_overhead_bytes);
                     transferred_loading_overhead_bytes +=
                         cell_loading_overhead_bytes;
-                    cell_results.push_back(std::move(cell_result));
-                }
-
-                for (auto& cell_result : cell_results) {
                     CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
-                    channel->push(std::move(cell_result));
+                    loaded_cells.push_back({cell.cid, std::move(chunk)});
                 }
+                return loaded_cells;
             }));
         } catch (...) {
             if (budget_admitted) {
@@ -619,21 +586,6 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     }
 
     return futures;
-}
-
-void
-ReleaseCellLoadResultBudget(
-    const std::shared_ptr<CellLoadResult>& cell_load_result) {
-    if (cell_load_result == nullptr) {
-        return;
-    }
-    cell_load_result->tables.clear();
-    if (cell_load_result->loading_overhead_bytes == 0) {
-        return;
-    }
-    milvus::storage::TransientMemoryBudget::GetLoadTransientBudget().Release(
-        cell_load_result->loading_overhead_bytes);
-    cell_load_result->loading_overhead_bytes = 0;
 }
 
 BatchReaderFactory

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -89,14 +89,23 @@ int64_t
 LoadTransientPoolUpperBound(size_t max_task_overhead_bytes) {
     // Load work can run concurrently in both pools because PriorityForLoad
     // maps foreground loads to HIGH and background loads to LOW.
-    auto max_high =
-        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH)
-            .GetMaxThreadNum();
-    auto max_low =
-        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW)
-            .GetMaxThreadNum();
-    auto max_load_tasks = max_high + max_low;
+    auto& high_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    auto& low_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto high_workers =
+        std::max(high_pool.GetMaxThreadNum(), high_pool.GetThreadNum());
+    auto low_workers =
+        std::max(low_pool.GetMaxThreadNum(), low_pool.GetThreadNum());
     auto max_int64 = static_cast<size_t>(std::numeric_limits<int64_t>::max());
+
+    if (high_workers > max_int64 || low_workers > max_int64 - high_workers) {
+        return std::numeric_limits<int64_t>::max();
+    }
+    auto max_load_tasks = high_workers + low_workers;
+    if (max_load_tasks == 0 || max_task_overhead_bytes == 0) {
+        return 0;
+    }
     if (max_task_overhead_bytes > max_int64 / max_load_tasks) {
         return std::numeric_limits<int64_t>::max();
     }
@@ -105,22 +114,15 @@ LoadTransientPoolUpperBound(size_t max_task_overhead_bytes) {
 
 int64_t
 LoadTransientSharedOverheadUpperBound(size_t max_task_overhead_bytes) {
-    auto pool_upper_bound =
-        LoadTransientPoolUpperBound(max_task_overhead_bytes);
     auto budget_capacity =
         milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
             .CapacityBytes();
-    if (budget_capacity == 0) {
-        return pool_upper_bound;
-    }
-
     auto max_int64 = static_cast<size_t>(std::numeric_limits<int64_t>::max());
     auto task_overhead =
         static_cast<int64_t>(std::min(max_task_overhead_bytes, max_int64));
     auto budget_upper_bound =
         static_cast<int64_t>(std::min(budget_capacity, max_int64));
-    return std::min(std::max(budget_upper_bound, task_overhead),
-                    pool_upper_bound);
+    return std::max(budget_upper_bound, task_overhead);
 }
 
 void

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -144,15 +144,13 @@ struct CellSpec {
         0;  // extra transient bytes during loading; 0 = memory_size
 };
 
-// Result of loading a single cell: cid + finalized group chunk.
-struct CellLoadResult {
+struct LoadedCell {
     int64_t cid;
-    size_t loading_overhead_bytes{0};
-    std::vector<std::shared_ptr<arrow::Table>> tables;
     std::unique_ptr<milvus::GroupChunk> chunk;
 };
 
-using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
+using LoadedCellBatch = std::vector<LoadedCell>;
+using CellLoadFuture = std::future<LoadedCellBatch>;
 
 // Creates a batch reader for a range of contiguous row groups.
 // Returns all row groups as a vector of tables in one call.
@@ -173,36 +171,29 @@ using CellFinalizeFunc = std::function<std::unique_ptr<milvus::GroupChunk>(
 /**
  * Load cells in batches using a pluggable reader factory. Cells are sorted by
  * (file_idx, local_rg_offset) and grouped into IO-merged batches.
- * Each completed cell is finalized and pushed to the channel immediately.
+ * Each completed cell is finalized and returned in its batch future.
  * Batch admission waits on the global transient memory budget before
  * submitting work to the load pool. After finalize_cell returns, the batch task
- * releases transient Arrow tables before pushing the result, so admitted budget
- * is not held while a producer waits on the bounded channel.
+ * releases transient Arrow tables before storing the result in the future.
  *
  * @param op_ctx operation context for cancellation
  * @param cell_specs cell specifications (sorted internally)
  * @param reader_factory factory that reads all row groups for a batch
- * @param channel channel to receive loaded cell data; closed when all done
  * @param memory_limit split target for per-batch loading overhead and
  * per-reader upper bound for final loaded memory. A global transient memory
  * budget gates concurrent batch loading across calls.
  * @param priority load priority
  * @param finalize_cell converts loaded Arrow tables into the final GroupChunk
- * before the cell is pushed to the channel
- * @return vector of futures for the batch loading tasks
+ * before the cell is stored in the batch result
+ * @return futures containing finalized cells for each batch
  */
-std::vector<std::future<void>>
+std::vector<CellLoadFuture>
 LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    std::vector<CellSpec> cell_specs,
                    BatchReaderFactory reader_factory,
-                   std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
                    milvus::proto::common::LoadPriority priority,
                    CellFinalizeFunc finalize_cell);
-
-void
-ReleaseCellLoadResultBudget(
-    const std::shared_ptr<CellLoadResult>& cell_load_result);
 
 /**
  * Creates a BatchReaderFactory that reads from Parquet files via

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -131,6 +131,12 @@ SetFieldDataReadWindowBytes(int64_t bytes);
 int64_t
 LoadTransientPoolUpperBound(size_t max_task_overhead_bytes);
 
+// Process-wide upper bound for loading overhead shared by all load readers.
+// Individual cells still report their own file-local overhead; this value only
+// caps the sum of concurrently loading cells in the shared MCL group.
+int64_t
+LoadTransientSharedOverheadUpperBound(size_t max_task_overhead_bytes);
+
 milvus::cachinglayer::ResourceUsage
 FieldDataLoadingOverheadUpperBound(
     int64_t max_memory_overhead,

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -131,9 +131,9 @@ SetFieldDataReadWindowBytes(int64_t bytes);
 int64_t
 LoadTransientPoolUpperBound(size_t max_task_overhead_bytes);
 
-// Process-wide upper bound for loading overhead shared by all load readers.
-// Individual cells still report their own file-local overhead; this value only
-// caps the sum of concurrently loading cells in the shared MCL group.
+// Process-wide upper bound enforced by the configured load transient budget.
+// A single oversized task can exceed the budget and therefore supplies the
+// lower bound. Callers must not register a shared cap when the budget is zero.
 int64_t
 LoadTransientSharedOverheadUpperBound(size_t max_task_overhead_bytes);
 

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -103,11 +103,6 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
 
 // ---- Cell-batch loading ----
 
-// The channel capacity multiplier relative to pool size.
-// The bounded channel holds at most (pool_size * kChannelCapacityMultiplier) items,
-// providing backpressure to producer threads while keeping them busy.
-constexpr double kChannelCapacityMultiplier = 1.5;
-
 // Load-time readers use one process-wide transient memory budget, so all
 // translators backed by that budget must share one MCL overhead group.
 constexpr const char* kLoadTransientOverheadGroup = "LoadTransientOverhead";
@@ -118,9 +113,6 @@ constexpr int64_t kDefaultFieldDataLoadBatchTargetBytes =
 constexpr int64_t kDefaultFieldDataReadWindowBytes =
     DEFAULT_INDEX_FILE_SLICE_SIZE;
 
-constexpr int64_t kDefaultFieldDataMaxReadParallelism =
-    DEFAULT_FIELD_MAX_MEMORY_LIMIT / DEFAULT_INDEX_FILE_SLICE_SIZE;
-
 int64_t
 FieldDataLoadBatchTargetBytes();
 
@@ -130,17 +122,11 @@ FieldDataLoadBatchSplitTargetBytes();
 int64_t
 FieldDataReadWindowBytes();
 
-int64_t
-FieldDataMaxReadParallelism();
-
 void
 SetFieldDataLoadBatchTargetBytes(int64_t bytes);
 
 void
 SetFieldDataReadWindowBytes(int64_t bytes);
-
-void
-SetFieldDataMaxReadParallelism(int64_t parallelism);
 
 milvus::cachinglayer::ResourceUsage
 FieldDataLoadingOverheadUpperBound(
@@ -153,16 +139,15 @@ struct CellSpec {
     size_t file_idx;          // index into the remote_files list
     int64_t local_rg_offset;  // file-local row group start offset
     int64_t rg_count;         // number of row groups in this cell
-    int64_t memory_size = 0;  // estimated Arrow memory in bytes; 0 = unknown
+    int64_t memory_size = 0;  // estimated final loaded memory in bytes
     int64_t loading_overhead_size =
-        0;  // transient overhead budget; 0 = memory_size
+        0;  // extra transient bytes during loading; 0 = memory_size
 };
 
-// Result of loading a single cell: cid + either the loaded Arrow tables or the
-// finalized group chunk when a cell finalizer is provided.
+// Result of loading a single cell: cid + finalized group chunk.
 struct CellLoadResult {
     int64_t cid;
-    size_t budget_bytes{0};
+    size_t loading_overhead_bytes{0};
     std::vector<std::shared_ptr<arrow::Table>> tables;
     std::unique_ptr<milvus::GroupChunk> chunk;
 };
@@ -175,15 +160,12 @@ using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
 // rg_offset: start row group index for this batch
 // total_rg_count: total row groups across all cells in this batch
 // reader_memory_limit: per-reader window size for this batch
-// read_parallelism: max number of readers/chunks to run within this batch for
-// factories that support intra-batch parallel reads.
 using BatchReaderFactory =
     std::function<arrow::Result<std::vector<std::shared_ptr<arrow::Table>>>(
         size_t batch_key,
         int64_t rg_offset,
         int64_t total_rg_count,
-        int64_t reader_memory_limit,
-        uint64_t read_parallelism)>;
+        int64_t reader_memory_limit)>;
 
 using CellFinalizeFunc = std::function<std::unique_ptr<milvus::GroupChunk>(
     const std::vector<std::shared_ptr<arrow::Table>>& tables, int64_t cid)>;
@@ -191,17 +173,22 @@ using CellFinalizeFunc = std::function<std::unique_ptr<milvus::GroupChunk>(
 /**
  * Load cells in batches using a pluggable reader factory. Cells are sorted by
  * (file_idx, local_rg_offset) and grouped into IO-merged batches.
- * Each completed cell is pushed to the channel immediately. When finalize_cell
- * is provided, the batch task converts Arrow tables into the final GroupChunk
- * before pushing and releases the transient Arrow budget immediately.
+ * Each completed cell is finalized and pushed to the channel immediately.
+ * Batch admission waits on the global transient memory budget before
+ * submitting work to the load pool. After finalize_cell returns, the batch task
+ * releases transient Arrow tables before pushing the result, so admitted budget
+ * is not held while a producer waits on the bounded channel.
  *
  * @param op_ctx operation context for cancellation
  * @param cell_specs cell specifications (sorted internally)
  * @param reader_factory factory that reads all row groups for a batch
  * @param channel channel to receive loaded cell data; closed when all done
- * @param memory_limit batch split target and per-reader upper bound. A global
- * transient memory budget gates concurrent batch loading across calls.
+ * @param memory_limit split target for per-batch loading overhead and
+ * per-reader upper bound for final loaded memory. A global transient memory
+ * budget gates concurrent batch loading across calls.
  * @param priority load priority
+ * @param finalize_cell converts loaded Arrow tables into the final GroupChunk
+ * before the cell is pushed to the channel
  * @return vector of futures for the batch loading tasks
  */
 std::vector<std::future<void>>
@@ -210,9 +197,8 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    BatchReaderFactory reader_factory,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
-                   milvus::proto::common::LoadPriority priority =
-                       milvus::proto::common::LoadPriority::HIGH,
-                   CellFinalizeFunc finalize_cell = nullptr);
+                   milvus::proto::common::LoadPriority priority,
+                   CellFinalizeFunc finalize_cell);
 
 void
 ReleaseCellLoadResultBudget(

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -128,6 +128,9 @@ SetFieldDataLoadBatchTargetBytes(int64_t bytes);
 void
 SetFieldDataReadWindowBytes(int64_t bytes);
 
+int64_t
+LoadTransientPoolUpperBound(size_t max_task_overhead_bytes);
+
 milvus::cachinglayer::ResourceUsage
 FieldDataLoadingOverheadUpperBound(
     int64_t max_memory_overhead,

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -108,7 +108,8 @@ SealedIndexTranslator::SealedIndexTranslator(
                 static_cast<size_t>(std::numeric_limits<int64_t>::max()));
         };
         auto memory_upper_bound =
-            budget_capacity != 0 ? budget_capacity
+            budget_capacity != 0
+                ? std::max<int64_t>(budget_capacity, max_task_overhead)
             : encrypted_stream
                 ? static_cast<int64_t>(encrypted_stream_upper_bound())
                 : milvus::segcore::LoadTransientPoolUpperBound(

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -1,7 +1,6 @@
 #include "segcore/storagev1translator/SealedIndexTranslator.h"
 
 #include <filesystem>
-#include <limits>
 #include <optional>
 #include <utility>
 
@@ -93,43 +92,20 @@ SealedIndexTranslator::SealedIndexTranslator(
     if (scalar_version >= 3 && !IsVectorDataType(index_load_info_.field_type)) {
         AssertInfo(stream_load_info.has_value(),
                    "missing stream load info for packed scalar V3 index");
+        auto encrypted_stream = stream_load_info->encrypted;
+
+        // Plaintext tasks retain a read buffer and an aligned-write copy. A
+        // configured budget still permits one oversized task; budget=0 uses
+        // the aggregate load-pool concurrency bound.
+        auto plaintext_task_overhead =
+            milvus::storage::PlainEntryFileStreamTaskTransientBytes();
         auto budget_capacity = static_cast<int64_t>(
             milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                 .CapacityBytes());
-        auto encrypted_stream = stream_load_info->encrypted;
-
-        // The packed-file footer records exact encrypted slice sizes. They
-        // give encrypted loading two independent ceilings:
-        //   1. the sum of cipher_len + 2 * plain_len across all slices;
-        //   2. the largest such task multiplied by load-pool concurrency.
-        // A non-zero process-wide budget adds a third ceiling, but is floored
-        // at one task because oversized tasks are admitted exclusively.
-        auto exact_encrypted_upper_bound = [&]() {
-            auto total_transient_bytes = static_cast<int64_t>(std::min(
-                stream_load_info->total_transient_bytes,
-                static_cast<size_t>(std::numeric_limits<int64_t>::max())));
-            auto task_transient_bytes = static_cast<int64_t>(std::min(
-                stream_load_info->max_task_transient_bytes,
-                static_cast<size_t>(std::numeric_limits<int64_t>::max())));
-            auto pool_upper_bound =
-                milvus::segcore::LoadTransientPoolUpperBound(
-                    stream_load_info->max_task_transient_bytes);
-            auto budget_upper_bound =
-                budget_capacity == 0
-                    ? pool_upper_bound
-                    : std::min(std::max(budget_capacity, task_transient_bytes),
-                               pool_upper_bound);
-            return std::min(total_transient_bytes, budget_upper_bound);
-        };
-
-        // Plaintext tasks have a fixed per-task bound: the read buffer plus
-        // the aligned-write copy. A configured budget bounds aggregate
-        // in-flight bytes but still permits one oversized task; budget=0 is
-        // unlimited, so pool concurrency supplies the aggregate bound.
-        auto plaintext_task_overhead =
-            milvus::storage::PlainEntryFileStreamTaskTransientBytes();
         auto memory_upper_bound =
-            encrypted_stream ? exact_encrypted_upper_bound()
+            encrypted_stream
+                ? milvus::segcore::LoadTransientSharedOverheadUpperBound(
+                      stream_load_info->max_task_transient_bytes)
             : budget_capacity != 0
                 ? std::max<int64_t>(budget_capacity, plaintext_task_overhead)
                 : milvus::segcore::LoadTransientPoolUpperBound(

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -1,6 +1,7 @@
 #include "segcore/storagev1translator/SealedIndexTranslator.h"
 
 #include <filesystem>
+#include <limits>
 #include <optional>
 #include <utility>
 
@@ -98,10 +99,20 @@ SealedIndexTranslator::SealedIndexTranslator(
                 ? milvus::storage::EncryptedEntryStreamTaskTransientBytes()
                 : milvus::storage::DefaultStreamSliceSize() +
                       milvus::storage::kTailMergeGrace;
+        auto encrypted_stream_upper_bound = [&]() {
+            auto index_size = static_cast<size_t>(
+                std::max<int64_t>(0, index_load_info_.index_size));
+            return std::min(
+                milvus::storage::EntryStreamDataTransientBytes(index_size,
+                                                               true),
+                static_cast<size_t>(std::numeric_limits<int64_t>::max()));
+        };
         auto memory_upper_bound =
-            budget_capacity == 0 ? milvus::segcore::LoadTransientPoolUpperBound(
-                                       max_task_overhead)
-                                 : budget_capacity;
+            budget_capacity != 0 ? budget_capacity
+            : encrypted_stream
+                ? static_cast<int64_t>(encrypted_stream_upper_bound())
+                : milvus::segcore::LoadTransientPoolUpperBound(
+                      max_task_overhead);
         auto upper_bound =
             milvus::cachinglayer::ResourceUsage{memory_upper_bound, int64_t{0}};
         meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -4,7 +4,6 @@
 #include <optional>
 #include <utility>
 
-#include "cachinglayer/LoadingOverheadTracker.h"
 #include "common/EasyAssert.h"
 #include "common/common_type_c.h"
 #include "common/resource_c.h"
@@ -21,6 +20,7 @@
 #include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
 #include "storage/EntryStreamUtils.h"
+#include "storage/PluginLoader.h"
 
 namespace milvus::segcore::storagev1translator {
 
@@ -90,11 +90,18 @@ SealedIndexTranslator::SealedIndexTranslator(
         auto budget_capacity = static_cast<int64_t>(
             milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                 .CapacityBytes());
+        auto encrypted_stream =
+            milvus::storage::PluginLoader::GetInstance().getCipherPlugin() !=
+            nullptr;
+        auto max_task_overhead =
+            encrypted_stream
+                ? milvus::storage::EncryptedEntryStreamTaskTransientBytes()
+                : milvus::storage::DefaultStreamSliceSize() +
+                      milvus::storage::kTailMergeGrace;
         auto memory_upper_bound =
-            budget_capacity == 0
-                ? milvus::cachinglayer::LoadingOverheadTracker::kUnlimited
-                      .memory_bytes
-                : budget_capacity;
+            budget_capacity == 0 ? milvus::segcore::LoadTransientPoolUpperBound(
+                                       max_task_overhead)
+                                 : budget_capacity;
         auto upper_bound =
             milvus::cachinglayer::ResourceUsage{memory_upper_bound, int64_t{0}};
         meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -21,7 +21,6 @@
 #include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
 #include "storage/EntryStreamUtils.h"
-#include "storage/PluginLoader.h"
 
 namespace milvus::segcore::storagev1translator {
 
@@ -92,28 +91,19 @@ SealedIndexTranslator::SealedIndexTranslator(
             config_, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
             .value_or(1);
     if (scalar_version >= 3 && !IsVectorDataType(index_load_info_.field_type)) {
+        AssertInfo(stream_load_info.has_value(),
+                   "missing stream load info for packed scalar V3 index");
         auto budget_capacity = static_cast<int64_t>(
             milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                 .CapacityBytes());
-        auto encrypted_stream =
-            stream_load_info.has_value()
-                ? stream_load_info->encrypted
-                : milvus::storage::PluginLoader::GetInstance()
-                          .getCipherPlugin() != nullptr;
-        auto max_task_overhead =
-            encrypted_stream && stream_load_info.has_value()
-                ? stream_load_info->max_task_transient_bytes
-            : encrypted_stream
-                ? milvus::storage::EncryptedEntryStreamTaskTransientBytes()
-                : milvus::storage::PlainEntryFileStreamTaskTransientBytes();
-        auto encrypted_stream_upper_bound = [&]() {
-            auto index_size = static_cast<size_t>(
-                std::max<int64_t>(0, index_load_info_.index_size));
-            return std::min(
-                milvus::storage::EntryStreamDataTransientBytes(index_size,
-                                                               true),
-                static_cast<size_t>(std::numeric_limits<int64_t>::max()));
-        };
+        auto encrypted_stream = stream_load_info->encrypted;
+
+        // The packed-file footer records exact encrypted slice sizes. They
+        // give encrypted loading two independent ceilings:
+        //   1. the sum of cipher_len + 2 * plain_len across all slices;
+        //   2. the largest such task multiplied by load-pool concurrency.
+        // A non-zero process-wide budget adds a third ceiling, but is floored
+        // at one task because oversized tasks are admitted exclusively.
         auto exact_encrypted_upper_bound = [&]() {
             auto total_transient_bytes = static_cast<int64_t>(std::min(
                 stream_load_info->total_transient_bytes,
@@ -131,15 +121,19 @@ SealedIndexTranslator::SealedIndexTranslator(
                                pool_upper_bound);
             return std::min(total_transient_bytes, budget_upper_bound);
         };
+
+        // Plaintext tasks have a fixed per-task bound: the read buffer plus
+        // the aligned-write copy. A configured budget bounds aggregate
+        // in-flight bytes but still permits one oversized task; budget=0 is
+        // unlimited, so pool concurrency supplies the aggregate bound.
+        auto plaintext_task_overhead =
+            milvus::storage::PlainEntryFileStreamTaskTransientBytes();
         auto memory_upper_bound =
-            encrypted_stream && stream_load_info.has_value()
-                ? exact_encrypted_upper_bound()
+            encrypted_stream ? exact_encrypted_upper_bound()
             : budget_capacity != 0
-                ? std::max<int64_t>(budget_capacity, max_task_overhead)
-            : encrypted_stream ? milvus::segcore::LoadTransientPoolUpperBound(
-                                     encrypted_stream_upper_bound())
-                               : milvus::segcore::LoadTransientPoolUpperBound(
-                                     max_task_overhead);
+                ? std::max<int64_t>(budget_capacity, plaintext_task_overhead)
+                : milvus::segcore::LoadTransientPoolUpperBound(
+                      plaintext_task_overhead);
         meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{
             milvus::cachinglayer::LoadingOverheadDimensionConfig{
                 memory_upper_bound,

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -100,8 +100,7 @@ SealedIndexTranslator::SealedIndexTranslator(
         auto max_task_overhead =
             encrypted_stream
                 ? milvus::storage::EncryptedEntryStreamTaskTransientBytes()
-                : milvus::storage::DefaultStreamSliceSize() +
-                      milvus::storage::kTailMergeGrace;
+                : milvus::storage::PlainEntryFileStreamTaskTransientBytes();
         auto encrypted_stream_upper_bound = [&]() {
             auto index_size = static_cast<size_t>(
                 std::max<int64_t>(0, index_load_info_.index_size));
@@ -117,10 +116,11 @@ SealedIndexTranslator::SealedIndexTranslator(
                                      encrypted_stream_upper_bound())
                                : milvus::segcore::LoadTransientPoolUpperBound(
                                      max_task_overhead);
-        auto upper_bound =
-            milvus::cachinglayer::ResourceUsage{memory_upper_bound, int64_t{0}};
         meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{
-            upper_bound, milvus::segcore::kLoadTransientOverheadGroup};
+            milvus::cachinglayer::LoadingOverheadDimensionConfig{
+                memory_upper_bound,
+                milvus::segcore::kLoadTransientOverheadGroup},
+            std::nullopt};
     }
 }
 

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -81,6 +81,9 @@ SealedIndexTranslator::SealedIndexTranslator(
                 index_info_.index_type, knowhere::feature::LAZY_LOAD)),
           std::nullopt,
           milvus::segcore::MetricAttributionFromShard(load_index_info->shard)) {
+    // TODO: Recompute scalar V3 stream estimates and the registered loading
+    // overhead upper bound when refreshable load-pool sizes grow. CacheSlot
+    // snapshots both at translator construction and reuses them on reload.
     load_resource_request_ = EstimateLoadResource();
 
     auto scalar_version =
@@ -110,10 +113,10 @@ SealedIndexTranslator::SealedIndexTranslator(
         auto memory_upper_bound =
             budget_capacity != 0
                 ? std::max<int64_t>(budget_capacity, max_task_overhead)
-            : encrypted_stream
-                ? static_cast<int64_t>(encrypted_stream_upper_bound())
-                : milvus::segcore::LoadTransientPoolUpperBound(
-                      max_task_overhead);
+            : encrypted_stream ? milvus::segcore::LoadTransientPoolUpperBound(
+                                     encrypted_stream_upper_bound())
+                               : milvus::segcore::LoadTransientPoolUpperBound(
+                                     max_task_overhead);
         auto upper_bound =
             milvus::cachinglayer::ResourceUsage{memory_upper_bound, int64_t{0}};
         meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -84,7 +84,8 @@ SealedIndexTranslator::SealedIndexTranslator(
     // TODO: Recompute scalar V3 stream estimates and the registered loading
     // overhead upper bound when refreshable load-pool sizes grow. CacheSlot
     // snapshots both at translator construction and reuses them on reload.
-    load_resource_request_ = EstimateLoadResource();
+    std::optional<milvus::storage::EntryStreamLoadInfo> stream_load_info;
+    load_resource_request_ = EstimateLoadResource(&stream_load_info);
 
     auto scalar_version =
         milvus::index::GetValueFromConfig<int32_t>(
@@ -95,10 +96,14 @@ SealedIndexTranslator::SealedIndexTranslator(
             milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                 .CapacityBytes());
         auto encrypted_stream =
-            milvus::storage::PluginLoader::GetInstance().getCipherPlugin() !=
-            nullptr;
+            stream_load_info.has_value()
+                ? stream_load_info->encrypted
+                : milvus::storage::PluginLoader::GetInstance()
+                          .getCipherPlugin() != nullptr;
         auto max_task_overhead =
-            encrypted_stream
+            encrypted_stream && stream_load_info.has_value()
+                ? stream_load_info->max_task_transient_bytes
+            : encrypted_stream
                 ? milvus::storage::EncryptedEntryStreamTaskTransientBytes()
                 : milvus::storage::PlainEntryFileStreamTaskTransientBytes();
         auto encrypted_stream_upper_bound = [&]() {
@@ -109,8 +114,27 @@ SealedIndexTranslator::SealedIndexTranslator(
                                                                true),
                 static_cast<size_t>(std::numeric_limits<int64_t>::max()));
         };
+        auto exact_encrypted_upper_bound = [&]() {
+            auto total_transient_bytes = static_cast<int64_t>(std::min(
+                stream_load_info->total_transient_bytes,
+                static_cast<size_t>(std::numeric_limits<int64_t>::max())));
+            auto task_transient_bytes = static_cast<int64_t>(std::min(
+                stream_load_info->max_task_transient_bytes,
+                static_cast<size_t>(std::numeric_limits<int64_t>::max())));
+            auto pool_upper_bound =
+                milvus::segcore::LoadTransientPoolUpperBound(
+                    stream_load_info->max_task_transient_bytes);
+            auto budget_upper_bound =
+                budget_capacity == 0
+                    ? pool_upper_bound
+                    : std::min(std::max(budget_capacity, task_transient_bytes),
+                               pool_upper_bound);
+            return std::min(total_transient_bytes, budget_upper_bound);
+        };
         auto memory_upper_bound =
-            budget_capacity != 0
+            encrypted_stream && stream_load_info.has_value()
+                ? exact_encrypted_upper_bound()
+            : budget_capacity != 0
                 ? std::max<int64_t>(budget_capacity, max_task_overhead)
             : encrypted_stream ? milvus::segcore::LoadTransientPoolUpperBound(
                                      encrypted_stream_upper_bound())
@@ -125,21 +149,26 @@ SealedIndexTranslator::SealedIndexTranslator(
 }
 
 LoadResourceRequest
-SealedIndexTranslator::EstimateLoadResource() const {
+SealedIndexTranslator::EstimateLoadResource(
+    std::optional<milvus::storage::EntryStreamLoadInfo>* stream_load_info)
+    const {
+    auto estimated =
+        milvus::index::IndexFactory::GetInstance().IndexLoadResource(
+            index_load_info_.field_type,
+            index_load_info_.element_type,
+            index_load_info_.index_engine_version,
+            index_load_info_.index_size,
+            index_load_info_.index_params,
+            index_load_info_.enable_mmap,
+            index_load_info_.num_rows,
+            index_load_info_.dim,
+            index_load_info_.index_files,
+            file_manager_context_,
+            stream_load_info);
     if (index_load_info_.load_resource_request.has_value()) {
         return *index_load_info_.load_resource_request;
     }
-    return milvus::index::IndexFactory::GetInstance().IndexLoadResource(
-        index_load_info_.field_type,
-        index_load_info_.element_type,
-        index_load_info_.index_engine_version,
-        index_load_info_.index_size,
-        index_load_info_.index_params,
-        index_load_info_.enable_mmap,
-        index_load_info_.num_rows,
-        index_load_info_.dim,
-        index_load_info_.index_files,
-        file_manager_context_);
+    return estimated;
 }
 
 size_t

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -92,29 +92,27 @@ SealedIndexTranslator::SealedIndexTranslator(
     if (scalar_version >= 3 && !IsVectorDataType(index_load_info_.field_type)) {
         AssertInfo(stream_load_info.has_value(),
                    "missing stream load info for packed scalar V3 index");
-        auto encrypted_stream = stream_load_info->encrypted;
-
-        // Plaintext tasks retain a read buffer and an aligned-write copy. A
-        // configured budget still permits one oversized task; budget=0 uses
-        // the aggregate load-pool concurrency bound.
-        auto plaintext_task_overhead =
-            milvus::storage::PlainEntryFileStreamTaskTransientBytes();
-        auto budget_capacity = static_cast<int64_t>(
+        auto budget_capacity =
             milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
-                .CapacityBytes());
-        auto memory_upper_bound =
-            encrypted_stream
-                ? milvus::segcore::LoadTransientSharedOverheadUpperBound(
-                      stream_load_info->max_task_transient_bytes)
-            : budget_capacity != 0
-                ? std::max<int64_t>(budget_capacity, plaintext_task_overhead)
-                : milvus::segcore::LoadTransientPoolUpperBound(
-                      plaintext_task_overhead);
-        meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{
-            milvus::cachinglayer::LoadingOverheadDimensionConfig{
-                memory_upper_bound,
-                milvus::segcore::kLoadTransientOverheadGroup},
-            std::nullopt};
+                .CapacityBytes();
+        // With no runtime budget there is no truthful process-wide stream
+        // buffer cap. Leave the group unregistered so MCL reserves each
+        // concurrently loading slot's estimated overhead independently.
+        if (budget_capacity != 0) {
+            auto max_task_overhead =
+                stream_load_info->encrypted
+                    ? stream_load_info->max_task_transient_bytes
+                    : milvus::storage::PlainEntryFileStreamTaskTransientBytes();
+            auto memory_upper_bound =
+                milvus::segcore::LoadTransientSharedOverheadUpperBound(
+                    max_task_overhead);
+            meta_.loading_overhead =
+                milvus::cachinglayer::LoadingOverheadConfig{
+                    milvus::cachinglayer::LoadingOverheadDimensionConfig{
+                        memory_upper_bound,
+                        milvus::segcore::kLoadTransientOverheadGroup},
+                    std::nullopt};
+        }
     }
 }
 

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
@@ -61,7 +61,8 @@ class SealedIndexTranslator
 
  private:
     LoadResourceRequest
-    EstimateLoadResource() const;
+    EstimateLoadResource(std::optional<milvus::storage::EntryStreamLoadInfo>*
+                             stream_load_info) const;
 
     struct IndexLoadInfo {
         bool enable_mmap;

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -52,7 +52,6 @@
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/KeyRetriever.h"
 #include "storage/EntryStreamUtils.h"
-#include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
 namespace milvus::segcore::storagev2translator {
@@ -348,11 +347,8 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     }
 
     // Submit cell-batch loading tasks
-    auto& pool = milvus::ThreadPools::GetThreadPool(
-        milvus::PriorityForLoad(load_priority_));
     auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
-        static_cast<size_t>(pool.GetMaxThreadNum() *
-                            milvus::segcore::kChannelCapacityMultiplier));
+        std::max<size_t>(1, cids.size()));
     auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
     auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -226,8 +226,16 @@ GroupChunkTranslator::GroupChunkTranslator(
         // Keep MCL reservation aligned with the process-wide transient load
         // budget rather than multiplying it by translator type.
         auto group = milvus::segcore::kLoadTransientOverheadGroup;
-        meta_.loading_overhead =
-            milvus::cachinglayer::LoadingOverheadConfig{upper_bound, group};
+        meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{
+            milvus::cachinglayer::LoadingOverheadDimensionConfig{
+                upper_bound.memory_bytes, group},
+            use_mmap_
+                ? std::optional<
+                      milvus::cachinglayer::
+                          LoadingOverheadDimensionConfig>{{upper_bound
+                                                               .file_bytes,
+                                                           group}}
+                : std::nullopt};
     }
 }
 

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -347,8 +347,6 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     }
 
     // Submit cell-batch loading tasks
-    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
-        std::max<size_t>(1, cids.size()));
     auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
     auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);
@@ -362,7 +360,6 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
         ctx,
         std::move(cell_specs),
         std::move(factory),
-        channel,
         FieldDataLoadBatchSplitTargetBytes(),
         load_priority_,
         std::move(finalize_cell));
@@ -373,59 +370,42 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
         load_futures.size(),
         column_group_info_.field_id);
 
-    // Pop loop — batch tasks finalize cells before pushing.
     std::unordered_map<cachinglayer::cid_t, std::unique_ptr<milvus::GroupChunk>>
         completed_cells;
     completed_cells.reserve(cids.size());
 
-    try {
-        std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
-        while (channel->pop(cell_data)) {
-            try {
-                CheckCancellation(
-                    ctx, segment_id_, "GroupChunkTranslator::get_cells()");
-                AssertInfo(cell_data->chunk != nullptr,
-                           "[StorageV2] translator {} cell {} is not "
-                           "finalized by batch task",
-                           key_,
-                           cell_data->cid);
-                completed_cells[cell_data->cid] = std::move(cell_data->chunk);
-                milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
-            } catch (...) {
-                milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
-                throw;
-            }
-        }
-    } catch (...) {
-        // Drain the channel to unblock producers that may be stuck on push()
-        // to a full bounded channel. Without draining, producers block forever
-        // and their task_guard (which calls channel->close()) never executes.
-        std::shared_ptr<milvus::segcore::CellLoadResult> discard;
+    std::exception_ptr first_error = nullptr;
+    for (auto& future : load_futures) {
         try {
-            while (channel->pop(discard)) {
-                milvus::segcore::ReleaseCellLoadResultBudget(discard);
+            auto loaded_cells = future.get();
+            if (first_error) {
+                continue;
+            }
+            for (auto& loaded_cell : loaded_cells) {
+                try {
+                    CheckCancellation(
+                        ctx, segment_id_, "GroupChunkTranslator::get_cells()");
+                    AssertInfo(loaded_cell.chunk != nullptr,
+                               "[StorageV2] translator {} cell {} is not "
+                               "finalized by batch task",
+                               key_,
+                               loaded_cell.cid);
+                    completed_cells[loaded_cell.cid] =
+                        std::move(loaded_cell.chunk);
+                } catch (...) {
+                    first_error = std::current_exception();
+                    break;
+                }
             }
         } catch (...) {
-            LOG_WARN("drain channel exception swallowed");
+            if (!first_error) {
+                first_error = std::current_exception();
+            }
         }
-        try {
-            storage::WaitAllFutures(load_futures);
-        } catch (const std::exception& e) {
-            LOG_WARN(
-                "[StorageV2] translator {} cleanup ignored background load "
-                "exception after cancellation: {}",
-                key_,
-                e.what());
-        } catch (...) {
-            LOG_WARN(
-                "[StorageV2] translator {} cleanup ignored unknown background "
-                "load exception after cancellation",
-                key_);
-        }
-        throw;
     }
-
-    storage::WaitAllFutures(load_futures);
+    if (first_error) {
+        std::rethrow_exception(first_error);
+    }
 
     for (auto cid : cids) {
         auto it = completed_cells.find(cid);

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -48,6 +48,7 @@
 #include "pb/common.pb.h"
 #include "segcore/Collection.h"
 #include "segcore/Utils.h"
+#include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/storagev2translator/GroupChunkTranslator.h"
@@ -134,6 +135,20 @@ TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
         schema_->get_field_ids().size(),
         milvus::proto::common::LoadPriority::LOW,
         /* warmup_policy */ "");
+
+    ASSERT_TRUE(translator->meta()->loading_overhead.has_value());
+    ASSERT_TRUE(translator->meta()->loading_overhead->memory.has_value());
+    EXPECT_EQ(translator->meta()->loading_overhead->memory->group,
+              milvus::segcore::kLoadTransientOverheadGroup);
+    EXPECT_GT(translator->meta()->loading_overhead->memory->upper_bound, 0);
+    if (use_mmap) {
+        ASSERT_TRUE(translator->meta()->loading_overhead->file.has_value());
+        EXPECT_EQ(translator->meta()->loading_overhead->file->group,
+                  milvus::segcore::kLoadTransientOverheadGroup);
+        EXPECT_GT(translator->meta()->loading_overhead->file->upper_bound, 0);
+    } else {
+        EXPECT_FALSE(translator->meta()->loading_overhead->file.has_value());
+    }
 
     // num cells - get the expected number from the file directly
     auto reader_result =

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -183,6 +183,11 @@ ManifestGroupTranslator::ManifestGroupTranslator(
         // metadata reports disk/encoded size which varies by format
         // (parquet=uncompressed column chunk size, iceberg/vortex=often 0)
         // and is not a reliable proxy for in-memory Arrow buffer size.
+        // TODO: Preserve the per-field bytes/row produced by DataNode Take
+        // sampling and use only the estimate for fields selected by this
+        // translator. The current fallback is aggregated across the whole row,
+        // so applying it to each lazy field translator can greatly overestimate
+        // narrow fields.
         //
         // Non-external: use format metadata; only if it reports zero
         // (e.g. Vortex without size stats) fall back to a 4KB/row

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -302,14 +302,10 @@ ManifestGroupTranslator::get_cells(
     auto factory = milvus::segcore::MakeChunkReaderFactory(chunk_reader_);
 
     // Submit cell-batch loading tasks
-    auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
-        std::max<size_t>(1, cids.size()));
-
     auto load_futures = milvus::segcore::LoadCellBatchAsync(
         ctx,
         std::move(cell_specs),
         std::move(factory),
-        channel,
         FieldDataLoadBatchSplitTargetBytes(),
         load_priority_,
         [this](const std::vector<std::shared_ptr<arrow::Table>>& tables,
@@ -325,60 +321,44 @@ ManifestGroupTranslator::get_cells(
         load_futures.size(),
         column_group_index_);
 
-    // Pop loop — batch tasks finalize cells before pushing.
     std::unordered_map<milvus::cachinglayer::cid_t,
                        std::unique_ptr<milvus::GroupChunk>>
         completed_cells;
     completed_cells.reserve(cids.size());
 
-    try {
-        std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
-        while (channel->pop(cell_data)) {
-            try {
-                CheckCancellation(
-                    ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
-                AssertInfo(cell_data->chunk != nullptr,
-                           "[StorageV2] translator {} cell {} is not "
-                           "finalized by batch task",
-                           key_,
-                           cell_data->cid);
-                completed_cells[cell_data->cid] = std::move(cell_data->chunk);
-                milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
-            } catch (...) {
-                milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
-                throw;
-            }
-        }
-    } catch (...) {
-        // Drain the channel to unblock producers that may be stuck on push()
-        // to a full bounded channel. Without draining, producers block forever
-        // and their task_guard (which calls channel->close()) never executes.
-        std::shared_ptr<milvus::segcore::CellLoadResult> discard;
+    std::exception_ptr first_error = nullptr;
+    for (auto& future : load_futures) {
         try {
-            while (channel->pop(discard)) {
-                milvus::segcore::ReleaseCellLoadResultBudget(discard);
+            auto loaded_cells = future.get();
+            if (first_error) {
+                continue;
+            }
+            for (auto& loaded_cell : loaded_cells) {
+                try {
+                    CheckCancellation(ctx,
+                                      segment_id_,
+                                      "ManifestGroupTranslator::get_cells()");
+                    AssertInfo(loaded_cell.chunk != nullptr,
+                               "[StorageV2] translator {} cell {} is not "
+                               "finalized by batch task",
+                               key_,
+                               loaded_cell.cid);
+                    completed_cells[loaded_cell.cid] =
+                        std::move(loaded_cell.chunk);
+                } catch (...) {
+                    first_error = std::current_exception();
+                    break;
+                }
             }
         } catch (...) {
-            LOG_WARN("drain channel exception swallowed");
+            if (!first_error) {
+                first_error = std::current_exception();
+            }
         }
-        try {
-            storage::WaitAllFutures(load_futures);
-        } catch (const std::exception& e) {
-            LOG_WARN(
-                "[StorageV2] translator {} cleanup ignored background load "
-                "exception after cancellation: {}",
-                key_,
-                e.what());
-        } catch (...) {
-            LOG_WARN(
-                "[StorageV2] translator {} cleanup ignored unknown background "
-                "load exception after cancellation",
-                key_);
-        }
-        throw;
     }
-
-    storage::WaitAllFutures(load_futures);
+    if (first_error) {
+        std::rethrow_exception(first_error);
+    }
 
     for (auto cid : cids) {
         auto it = completed_cells.find(cid);

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -50,7 +50,6 @@
 #include "milvus-storage/reader.h"
 #include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
-#include "storage/ThreadPools.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/EntryStreamUtils.h"
 #include "storage/Util.h"
@@ -303,11 +302,8 @@ ManifestGroupTranslator::get_cells(
     auto factory = milvus::segcore::MakeChunkReaderFactory(chunk_reader_);
 
     // Submit cell-batch loading tasks
-    auto& pool = milvus::ThreadPools::GetThreadPool(
-        milvus::PriorityForLoad(load_priority_));
     auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
-        static_cast<size_t>(pool.GetMaxThreadNum() *
-                            milvus::segcore::kChannelCapacityMultiplier));
+        std::max<size_t>(1, cids.size()));
 
     auto load_futures = milvus::segcore::LoadCellBatchAsync(
         ctx,

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -226,8 +226,16 @@ ManifestGroupTranslator::ManifestGroupTranslator(
         // Keep MCL reservation aligned with the process-wide transient load
         // budget rather than multiplying it by translator type.
         auto group = milvus::segcore::kLoadTransientOverheadGroup;
-        meta_.loading_overhead =
-            milvus::cachinglayer::LoadingOverheadConfig{upper_bound, group};
+        meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{
+            milvus::cachinglayer::LoadingOverheadDimensionConfig{
+                upper_bound.memory_bytes, group},
+            use_mmap_
+                ? std::optional<
+                      milvus::cachinglayer::
+                          LoadingOverheadDimensionConfig>{{upper_bound
+                                                               .file_bytes,
+                                                           group}}
+                : std::nullopt};
     }
 }
 

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslatorTest.cpp
@@ -32,6 +32,7 @@
 #include "gtest/gtest.h"
 #include "mmap/ChunkedColumnGroup.h"
 #include "pb/common.pb.h"
+#include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "segcore/storagev2translator/ManifestGroupTranslator.h"
 #include "test_utils/Constants.h"
@@ -100,6 +101,20 @@ TEST_P(ManifestGroupTranslatorTest, TestScalarColumnGroup) {
 
     auto use_mmap = GetParam();
     auto translator = MakeTranslator(/*cg_index=*/0, use_mmap);
+
+    ASSERT_TRUE(translator->meta()->loading_overhead.has_value());
+    ASSERT_TRUE(translator->meta()->loading_overhead->memory.has_value());
+    EXPECT_EQ(translator->meta()->loading_overhead->memory->group,
+              milvus::segcore::kLoadTransientOverheadGroup);
+    EXPECT_GT(translator->meta()->loading_overhead->memory->upper_bound, 0);
+    if (use_mmap) {
+        ASSERT_TRUE(translator->meta()->loading_overhead->file.has_value());
+        EXPECT_EQ(translator->meta()->loading_overhead->file->group,
+                  milvus::segcore::kLoadTransientOverheadGroup);
+        EXPECT_GT(translator->meta()->loading_overhead->file->upper_bound, 0);
+    } else {
+        EXPECT_FALSE(translator->meta()->loading_overhead->file.has_value());
+    }
 
     // Verify scalar group field metas
     auto field_metas = test_data_->GetFieldMetas(0);

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -59,7 +59,7 @@ ThrowIfCancelled(const folly::CancellationToken& cancellation_token,
 /// A slice read from a V3 entry. `error` carries an exception captured in
 /// the producer task so the consumer can rethrow instead of hanging.
 struct StreamSliceResult {
-    size_t budget_bytes{0};
+    size_t slice_transient_bytes{0};
     std::vector<uint8_t> data;
     std::exception_ptr error = nullptr;
 };
@@ -69,8 +69,8 @@ struct StreamSliceResult {
 ///
 /// Usage:
 ///   - Call Acquire(bytes) to block until budget is available.
-///   - Call AcquireUntil(bytes, stop_waiting) to block until budget is
-///     available or the caller's lifecycle ends.
+///   - Call AcquireUntil(bytes, cancellation_token) to block until budget is
+///     available or cancellation is requested.
 ///   - Call TryAcquire(bytes) for non-blocking replenish in refill loops.
 ///   - Call Release(bytes) after the transient data has been consumed.
 ///   - Oversized requests are allowed to run exclusively to guarantee progress.
@@ -96,23 +96,34 @@ class TransientMemoryBudget {
         inflight_bytes_ += bytes;
     }
 
-    /// Block until enough budget is available, or stop_waiting returns true.
-    /// The callback must be cheap and non-blocking. Returning false means no
-    /// budget was acquired and the caller should stop its work.
-    template <typename StopWaiting>
+    /// Block until enough budget is available, or cancellation is requested.
+    /// Returning false means no budget was acquired and the caller should stop
+    /// its work.
     bool
-    AcquireUntil(size_t bytes, StopWaiting stop_waiting) {
-        std::unique_lock<std::mutex> lock(mu_);
-        while (true) {
-            if (stop_waiting()) {
-                return false;
-            }
-            if (CanAcquireLocked(bytes)) {
+    AcquireUntil(size_t bytes,
+                 const folly::CancellationToken& cancellation_token) {
+        folly::CancellationCallback cancel_callback(
+            cancellation_token, [this]() noexcept {
+                // Pair with wait(lock, predicate) to avoid losing a cancel
+                // notification between predicate check and wait.
+                std::lock_guard<std::mutex> lock(mu_);
+                cv_.notify_all();
+            });
+
+        bool acquired = false;
+        {
+            std::unique_lock<std::mutex> lock(mu_);
+            cv_.wait(lock, [this, bytes, &cancellation_token] {
+                return cancellation_token.isCancellationRequested() ||
+                       CanAcquireLocked(bytes);
+            });
+            if (!cancellation_token.isCancellationRequested()) {
                 inflight_bytes_ += bytes;
-                return true;
+                acquired = true;
             }
-            cv_.wait_for(lock, std::chrono::milliseconds(10));
         }
+
+        return acquired;
     }
 
     /// Try to claim budget. Returns true if under budget.
@@ -193,16 +204,31 @@ class TransientMemoryBudget {
 };
 
 inline size_t
+EntryStreamPoolBoundTransientBytes() {
+    auto max_threads = milvus::ComputeThreadPoolMaxThreads(
+        milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load());
+    auto max_tasks = static_cast<size_t>(max_threads);
+    auto slice_size = DefaultStreamSliceSize();
+    if (slice_size >
+        (std::numeric_limits<size_t>::max() - kTailMergeGrace) / max_tasks) {
+        return std::numeric_limits<size_t>::max();
+    }
+    return max_tasks * slice_size + kTailMergeGrace;
+}
+
+inline size_t
 EntryStreamMaxTransientBytes() {
     auto capacity =
         TransientMemoryBudget::GetLoadTransientBudget().CapacityBytes();
+    auto pool_bound = EntryStreamPoolBoundTransientBytes();
     if (capacity == 0) {
-        return std::numeric_limits<size_t>::max();
+        return pool_bound;
     }
-    if (capacity > std::numeric_limits<size_t>::max() - kTailMergeGrace) {
-        return std::numeric_limits<size_t>::max();
-    }
-    return capacity + kTailMergeGrace;
+    auto configured_bound =
+        capacity > std::numeric_limits<size_t>::max() - kTailMergeGrace
+            ? std::numeric_limits<size_t>::max()
+            : capacity + kTailMergeGrace;
+    return std::min(configured_bound, pool_bound);
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -37,6 +37,9 @@ namespace milvus::storage {
 constexpr size_t kMinStreamSliceSize = 64 * 1024;
 constexpr size_t kStreamSliceAlignment = 4 * 1024;
 constexpr size_t kTailMergeGrace = 1 * 1024 * 1024;
+// Encrypted reads may simultaneously retain ciphertext, decrypted plaintext,
+// and the returned plaintext buffer.
+constexpr size_t kEncryptedStreamBufferMultiplier = 3;
 
 inline bool
 IsStreamSliceSizeAligned(size_t slice_size) {
@@ -204,10 +207,37 @@ class TransientMemoryBudget {
 };
 
 inline size_t
-EntryStreamPoolBoundTransientBytes() {
+EntryStreamDataTransientBytes(size_t stream_bytes, bool encrypted) {
+    if (!encrypted) {
+        return stream_bytes;
+    }
+    if (stream_bytes >
+        std::numeric_limits<size_t>::max() / kEncryptedStreamBufferMultiplier) {
+        return std::numeric_limits<size_t>::max();
+    }
+    return stream_bytes * kEncryptedStreamBufferMultiplier;
+}
+
+inline size_t
+EncryptedEntryStreamTaskTransientBytes() {
+    // Reuse the tail grace as a conservative allowance for cipher expansion.
+    return EntryStreamDataTransientBytes(
+        DefaultStreamSliceSize() + kTailMergeGrace, true);
+}
+
+inline size_t
+EntryStreamPoolBoundTransientBytes(bool encrypted = false) {
     auto max_threads = milvus::ComputeThreadPoolMaxThreads(
         milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load());
     auto max_tasks = static_cast<size_t>(max_threads);
+    if (encrypted) {
+        auto task_bound = EncryptedEntryStreamTaskTransientBytes();
+        if (task_bound > std::numeric_limits<size_t>::max() / max_tasks) {
+            return std::numeric_limits<size_t>::max();
+        }
+        return max_tasks * task_bound;
+    }
+
     auto slice_size = DefaultStreamSliceSize();
     if (slice_size >
         (std::numeric_limits<size_t>::max() - kTailMergeGrace) / max_tasks) {
@@ -217,13 +247,19 @@ EntryStreamPoolBoundTransientBytes() {
 }
 
 inline size_t
-EntryStreamMaxTransientBytes() {
+EntryStreamMaxTransientBytes(bool encrypted = false) {
     auto capacity =
         TransientMemoryBudget::GetLoadTransientBudget().CapacityBytes();
-    auto pool_bound = EntryStreamPoolBoundTransientBytes();
+    auto pool_bound = EntryStreamPoolBoundTransientBytes(encrypted);
     if (capacity == 0) {
         return pool_bound;
     }
+    if (encrypted) {
+        return std::min(
+            std::max(capacity, EncryptedEntryStreamTaskTransientBytes()),
+            pool_bound);
+    }
+
     auto configured_bound =
         capacity > std::numeric_limits<size_t>::max() - kTailMergeGrace
             ? std::numeric_limits<size_t>::max()

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -231,7 +231,8 @@ PlainEntryFileStreamTransientBytes(size_t stream_bytes) {
 
 inline size_t
 EncryptedEntryStreamTaskTransientBytes() {
-    // Reuse the tail grace as a conservative allowance for cipher expansion.
+    // Compatibility fallback for callers that cannot inspect a concrete V3
+    // directory. File-aware planning uses persisted ciphertext slice sizes.
     return EntryStreamDataTransientBytes(
         DefaultStreamSliceSize() + kTailMergeGrace, true);
 }
@@ -302,6 +303,29 @@ EntryStreamMaxTransientBytes(bool encrypted = false) {
 
     return std::min(std::max(capacity, PlainEntryStreamTaskTransientBytes()),
                     pool_bound);
+}
+
+inline size_t
+EncryptedEntryStreamMaxTransientBytes(size_t total_transient_bytes,
+                                      size_t max_task_transient_bytes) {
+    if (total_transient_bytes == 0 || max_task_transient_bytes == 0) {
+        return 0;
+    }
+
+    auto capacity =
+        TransientMemoryBudget::GetLoadTransientBudget().CapacityBytes();
+    auto& high_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    auto& low_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto pool_bound = EntryStreamPoolBoundTransientBytesForTask(
+        max_task_transient_bytes,
+        std::max(high_pool.GetThreadNum(), low_pool.GetThreadNum()));
+    auto budget_bound =
+        capacity == 0 ? pool_bound
+                      : std::min(std::max(capacity, max_task_transient_bytes),
+                                 pool_bound);
+    return std::min(total_transient_bytes, budget_bound);
 }
 
 inline size_t

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -234,8 +234,11 @@ PlainEntryStreamTaskTransientBytes() {
 inline size_t
 EntryStreamPoolBoundTransientBytes(bool encrypted = false,
                                    size_t live_worker_count = 0) {
-    auto configured_threads = milvus::ComputeThreadPoolMaxThreads(
-        milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load());
+    auto configured_threads =
+        std::max(milvus::ComputeThreadPoolMaxThreads(
+                     milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()),
+                 milvus::ComputeThreadPoolMaxThreads(
+                     milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
     auto max_tasks =
         std::max(static_cast<size_t>(configured_threads), live_worker_count);
     auto task_bound = encrypted ? EncryptedEntryStreamTaskTransientBytes()
@@ -250,10 +253,12 @@ inline size_t
 EntryStreamMaxTransientBytes(bool encrypted = false) {
     auto capacity =
         TransientMemoryBudget::GetLoadTransientBudget().CapacityBytes();
-    auto& pool =
+    auto& high_pool =
         milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
-    auto pool_bound =
-        EntryStreamPoolBoundTransientBytes(encrypted, pool.GetThreadNum());
+    auto& low_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto pool_bound = EntryStreamPoolBoundTransientBytes(
+        encrypted, std::max(high_pool.GetThreadNum(), low_pool.GetThreadNum()));
     if (capacity == 0) {
         // The runtime reservation for encrypted streams includes the actual
         // ciphertext length, which has no static upper bound in ICipherPlugin.

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -220,6 +220,16 @@ EntryStreamDataTransientBytes(size_t stream_bytes, bool encrypted) {
 }
 
 inline size_t
+PlainEntryFileStreamTransientBytes(size_t stream_bytes) {
+    constexpr size_t kFileStreamBufferMultiplier = 2;
+    if (stream_bytes >
+        std::numeric_limits<size_t>::max() / kFileStreamBufferMultiplier) {
+        return std::numeric_limits<size_t>::max();
+    }
+    return stream_bytes * kFileStreamBufferMultiplier;
+}
+
+inline size_t
 EncryptedEntryStreamTaskTransientBytes() {
     // Reuse the tail grace as a conservative allowance for cipher expansion.
     return EntryStreamDataTransientBytes(
@@ -232,8 +242,8 @@ PlainEntryStreamTaskTransientBytes() {
 }
 
 inline size_t
-EntryStreamPoolBoundTransientBytes(bool encrypted = false,
-                                   size_t live_worker_count = 0) {
+EntryStreamPoolBoundTransientBytesForTask(size_t task_bound,
+                                          size_t live_worker_count) {
     auto configured_threads =
         std::max(milvus::ComputeThreadPoolMaxThreads(
                      milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()),
@@ -241,12 +251,31 @@ EntryStreamPoolBoundTransientBytes(bool encrypted = false,
                      milvus::LOW_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
     auto max_tasks =
         std::max(static_cast<size_t>(configured_threads), live_worker_count);
-    auto task_bound = encrypted ? EncryptedEntryStreamTaskTransientBytes()
-                                : PlainEntryStreamTaskTransientBytes();
     if (task_bound > std::numeric_limits<size_t>::max() / max_tasks) {
         return std::numeric_limits<size_t>::max();
     }
     return max_tasks * task_bound;
+}
+
+inline size_t
+EntryStreamPoolBoundTransientBytes(bool encrypted = false,
+                                   size_t live_worker_count = 0) {
+    auto task_bound = encrypted ? EncryptedEntryStreamTaskTransientBytes()
+                                : PlainEntryStreamTaskTransientBytes();
+    return EntryStreamPoolBoundTransientBytesForTask(task_bound,
+                                                     live_worker_count);
+}
+
+inline size_t
+PlainEntryFileStreamTaskTransientBytes() {
+    return PlainEntryFileStreamTransientBytes(
+        PlainEntryStreamTaskTransientBytes());
+}
+
+inline size_t
+PlainEntryFileStreamPoolBoundTransientBytes(size_t live_worker_count = 0) {
+    return EntryStreamPoolBoundTransientBytesForTask(
+        PlainEntryFileStreamTaskTransientBytes(), live_worker_count);
 }
 
 inline size_t
@@ -273,6 +302,23 @@ EntryStreamMaxTransientBytes(bool encrypted = false) {
 
     return std::min(std::max(capacity, PlainEntryStreamTaskTransientBytes()),
                     pool_bound);
+}
+
+inline size_t
+PlainEntryFileStreamMaxTransientBytes() {
+    auto capacity =
+        TransientMemoryBudget::GetLoadTransientBudget().CapacityBytes();
+    auto& high_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    auto& low_pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::LOW);
+    auto pool_bound = PlainEntryFileStreamPoolBoundTransientBytes(
+        std::max(high_pool.GetThreadNum(), low_pool.GetThreadNum()));
+    auto task_bound = PlainEntryFileStreamTaskTransientBytes();
+    if (capacity == 0) {
+        return pool_bound;
+    }
+    return std::min(std::max(capacity, task_bound), pool_bound);
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -31,6 +31,7 @@
 #include "common/Common.h"
 #include "common/EasyAssert.h"
 #include "folly/CancellationToken.h"
+#include "storage/ThreadPools.h"
 
 namespace milvus::storage {
 
@@ -226,33 +227,38 @@ EncryptedEntryStreamTaskTransientBytes() {
 }
 
 inline size_t
-EntryStreamPoolBoundTransientBytes(bool encrypted = false) {
-    auto max_threads = milvus::ComputeThreadPoolMaxThreads(
-        milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load());
-    auto max_tasks = static_cast<size_t>(max_threads);
-    if (encrypted) {
-        auto task_bound = EncryptedEntryStreamTaskTransientBytes();
-        if (task_bound > std::numeric_limits<size_t>::max() / max_tasks) {
-            return std::numeric_limits<size_t>::max();
-        }
-        return max_tasks * task_bound;
-    }
+PlainEntryStreamTaskTransientBytes() {
+    return DefaultStreamSliceSize() + kTailMergeGrace;
+}
 
-    auto slice_size = DefaultStreamSliceSize();
-    if (slice_size >
-        (std::numeric_limits<size_t>::max() - kTailMergeGrace) / max_tasks) {
+inline size_t
+EntryStreamPoolBoundTransientBytes(bool encrypted = false,
+                                   size_t live_worker_count = 0) {
+    auto configured_threads = milvus::ComputeThreadPoolMaxThreads(
+        milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load());
+    auto max_tasks =
+        std::max(static_cast<size_t>(configured_threads), live_worker_count);
+    auto task_bound = encrypted ? EncryptedEntryStreamTaskTransientBytes()
+                                : PlainEntryStreamTaskTransientBytes();
+    if (task_bound > std::numeric_limits<size_t>::max() / max_tasks) {
         return std::numeric_limits<size_t>::max();
     }
-    return max_tasks * slice_size + kTailMergeGrace;
+    return max_tasks * task_bound;
 }
 
 inline size_t
 EntryStreamMaxTransientBytes(bool encrypted = false) {
     auto capacity =
         TransientMemoryBudget::GetLoadTransientBudget().CapacityBytes();
-    auto pool_bound = EntryStreamPoolBoundTransientBytes(encrypted);
+    auto& pool =
+        milvus::ThreadPools::GetThreadPool(milvus::ThreadPoolPriority::HIGH);
+    auto pool_bound =
+        EntryStreamPoolBoundTransientBytes(encrypted, pool.GetThreadNum());
     if (capacity == 0) {
-        return pool_bound;
+        // The runtime reservation for encrypted streams includes the actual
+        // ciphertext length, which has no static upper bound in ICipherPlugin.
+        // Let the caller cap the estimate by its concrete index size instead.
+        return encrypted ? std::numeric_limits<size_t>::max() : pool_bound;
     }
     if (encrypted) {
         return std::min(
@@ -260,11 +266,8 @@ EntryStreamMaxTransientBytes(bool encrypted = false) {
             pool_bound);
     }
 
-    auto configured_bound =
-        capacity > std::numeric_limits<size_t>::max() - kTailMergeGrace
-            ? std::numeric_limits<size_t>::max()
-            : capacity + kTailMergeGrace;
-    return std::min(configured_bound, pool_bound);
+    return std::min(std::max(capacity, PlainEntryStreamTaskTransientBytes()),
+                    pool_bound);
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -43,26 +43,24 @@ namespace milvus::storage {
 namespace {
 
 using SliceLoader = std::function<std::vector<uint8_t>(size_t seq)>;
-using SliceBudgetBytes = std::function<size_t(size_t seq)>;
+using SliceTransientBytes = std::function<size_t(size_t seq)>;
 
 struct ActiveSliceTask {
-    size_t budget_bytes{0};
+    size_t slice_transient_bytes{0};
     std::shared_ptr<StreamSliceResult> result;
     std::future<void> future;
 };
 
 class TransientBudgetGuard {
  public:
-    TransientBudgetGuard(size_t bytes,
+    TransientBudgetGuard(size_t slice_transient_bytes,
                          const folly::CancellationToken& cancellation_token,
                          const std::string& operation)
-        : bytes_(bytes) {
+        : slice_transient_bytes_(slice_transient_bytes) {
         ThrowIfCancelled(cancellation_token, operation);
         auto acquired =
             TransientMemoryBudget::GetLoadTransientBudget().AcquireUntil(
-                bytes_, [&cancellation_token]() {
-                    return cancellation_token.isCancellationRequested();
-                });
+                slice_transient_bytes_, cancellation_token);
         if (!acquired) {
             ThrowIfCancelled(cancellation_token, operation);
             ThrowInfo(ErrorCode::FollyCancel, "{} cancelled", operation);
@@ -70,7 +68,8 @@ class TransientBudgetGuard {
     }
 
     ~TransientBudgetGuard() {
-        TransientMemoryBudget::GetLoadTransientBudget().Release(bytes_);
+        TransientMemoryBudget::GetLoadTransientBudget().Release(
+            slice_transient_bytes_);
     }
 
     TransientBudgetGuard(const TransientBudgetGuard&) = delete;
@@ -78,7 +77,7 @@ class TransientBudgetGuard {
     operator=(const TransientBudgetGuard&) = delete;
 
  private:
-    size_t bytes_;
+    size_t slice_transient_bytes_;
 };
 
 bool
@@ -148,7 +147,7 @@ ReadOrderedEntryStream(
     ThreadPoolPriority priority,
     const folly::CancellationToken& cancellation_token,
     const std::function<void(const uint8_t* data, size_t len)>& slice_consumer,
-    const SliceBudgetBytes& slice_budget_bytes,
+    const SliceTransientBytes& slice_transient_bytes,
     const SliceLoader& load_slice) {
     ThrowIfCancelled(cancellation_token, "ReadEntryStream");
     if (num_slices == 0) {
@@ -199,44 +198,42 @@ ReadOrderedEntryStream(
                     rememberError(std::current_exception());
                 }
             }
-            budget.Release(task.budget_bytes);
+            budget.Release(task.slice_transient_bytes);
         }
     };
 
     auto submitOne = [&](bool block_for_budget) -> bool {
         size_t seq = next_submit;
-        size_t budget_bytes = 0;
+        size_t slice_transient_byte_count = 0;
         std::shared_ptr<StreamSliceResult> result;
         try {
-            budget_bytes = slice_budget_bytes(seq);
+            slice_transient_byte_count = slice_transient_bytes(seq);
             result = std::make_shared<StreamSliceResult>();
-            result->budget_bytes = budget_bytes;
+            result->slice_transient_bytes = slice_transient_byte_count;
         } catch (...) {
             rememberError(std::current_exception());
             return false;
         }
 
         if (block_for_budget) {
-            auto acquired =
-                budget.AcquireUntil(budget_bytes, [&cancellation_token]() {
-                    return cancellation_token.isCancellationRequested();
-                });
+            auto acquired = budget.AcquireUntil(slice_transient_byte_count,
+                                                cancellation_token);
             if (!acquired) {
                 rememberCancellation();
                 return false;
             }
-        } else if (!budget.TryAcquire(budget_bytes)) {
+        } else if (!budget.TryAcquire(slice_transient_byte_count)) {
             return false;
         }
 
         if (rememberCancellation()) {
-            budget.Release(budget_bytes);
+            budget.Release(slice_transient_byte_count);
             return false;
         }
 
         try {
-            active_tasks.push_back(
-                ActiveSliceTask{budget_bytes, result, std::future<void>()});
+            active_tasks.push_back(ActiveSliceTask{
+                slice_transient_byte_count, result, std::future<void>()});
             active_tasks.back().future =
                 pool.Submit([result, load_slice, seq, cancellation_token]() {
                     try {
@@ -252,7 +249,7 @@ ReadOrderedEntryStream(
                 !active_tasks.back().future.valid()) {
                 active_tasks.pop_back();
             }
-            budget.Release(budget_bytes);
+            budget.Release(slice_transient_byte_count);
             rememberError(std::current_exception());
             return false;
         }
@@ -305,7 +302,7 @@ ReadOrderedEntryStream(
             deliverSlice(task.result);
         }
 
-        budget.Release(task.budget_bytes);
+        budget.Release(task.slice_transient_bytes);
 
         if (first_error) {
             drainActiveTasks();
@@ -1223,15 +1220,19 @@ IndexEntryReader::ReadPlainEntryStream(
                slice_size);
     auto entry_size = static_cast<size_t>(pm.size);
     auto num_slices = PlainStreamSliceCount(entry_size, slice_size);
-    auto sliceBytes = [entry_size, slice_size, num_slices](size_t seq) {
+    auto sliceTransientBytes = [entry_size, slice_size, num_slices](
+                                   size_t seq) {
         return PlainStreamSliceBytes(entry_size, slice_size, num_slices, seq);
     };
     auto input = input_;
     auto cancellation_token = cancellation_token_;
-    auto load_slice = [input, pm, slice_size, sliceBytes, cancellation_token](
-                          size_t seq) {
+    auto load_slice = [input,
+                       pm,
+                       slice_size,
+                       sliceTransientBytes,
+                       cancellation_token](size_t seq) {
         size_t off = seq * slice_size;
-        size_t len = sliceBytes(seq);
+        size_t len = sliceTransientBytes(seq);
         size_t src = pm.offset + off;
         std::vector<uint8_t> data(len);
         ThrowIfCancelled(cancellation_token,
@@ -1249,7 +1250,7 @@ IndexEntryReader::ReadPlainEntryStream(
                            priority_,
                            cancellation_token_,
                            slice_consumer,
-                           sliceBytes,
+                           sliceTransientBytes,
                            load_slice);
 }
 
@@ -1268,7 +1269,7 @@ IndexEntryReader::ReadEncryptedEntryStream(
         size_t remaining = em.original_size - output_offset;
         return std::min(remaining, slice_size_);
     };
-    auto sliceBudgetBytes = [&](size_t seq) {
+    auto sliceTransientBytes = [&](size_t seq) {
         auto plain_len = slicePlainBytes(seq);
         auto cipher_len = em.slices[seq].size;
         AssertInfo(plain_len <= (std::numeric_limits<size_t>::max() / 2) &&
@@ -1323,7 +1324,7 @@ IndexEntryReader::ReadEncryptedEntryStream(
                            priority_,
                            cancellation_token_,
                            slice_consumer,
-                           sliceBudgetBytes,
+                           sliceTransientBytes,
                            load_slice);
 }
 

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -979,7 +979,7 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                 PlainStreamSliceBytes(pm.size, slice_size, num_slices, seq);
             size_t src_offset = pm.offset + output_offset;
             auto budget_guard = std::make_shared<TransientBudgetGuard>(
-                len,
+                PlainEntryFileStreamTransientBytes(len),
                 cancellation_token,
                 "IndexEntryReader::ReadEntriesStreamToFiles");
 

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -120,6 +120,14 @@ EncryptedStreamBudgetBytes(size_t cipher_len, size_t plain_len) {
     return cipher_len + 2 * plain_len;
 }
 
+size_t
+SaturatingAdd(size_t lhs, size_t rhs) {
+    if (rhs > std::numeric_limits<size_t>::max() - lhs) {
+        return std::numeric_limits<size_t>::max();
+    }
+    return lhs + rhs;
+}
+
 constexpr size_t kEntryDownloadRangeSize = 16 * 1024 * 1024;
 
 void
@@ -330,6 +338,22 @@ DefaultEntryStreamSliceSize() {
     return DefaultStreamSliceSize();
 }
 
+EntryStreamLoadInfo
+IndexEntryReader::InspectStreamLoadInfo(
+    std::shared_ptr<milvus::InputStream> input,
+    int64_t file_size,
+    folly::CancellationToken cancellation_token) {
+    auto reader = std::unique_ptr<IndexEntryReader>(new IndexEntryReader());
+    reader->input_ = std::move(input);
+    reader->file_size_ = file_size;
+    reader->cancellation_token_ = cancellation_token;
+    reader->CheckCancelled("IndexEntryReader::InspectStreamLoadInfo");
+    reader->ValidateMagic();
+    reader->ReadFooterAndDirectory();
+    reader->CheckCancelled("IndexEntryReader::InspectStreamLoadInfo");
+    return reader->stream_load_info_;
+}
+
 std::unique_ptr<IndexEntryReader>
 IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
                        int64_t file_size,
@@ -346,6 +370,12 @@ IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
     reader->ValidateMagic();
     reader->ReadFooterAndDirectory();
     reader->CheckCancelled("IndexEntryReader::Open");
+
+    if (reader->is_encrypted_) {
+        reader->cipher_plugin_ = PluginLoader::GetInstance().getCipherPlugin();
+        AssertInfo(reader->cipher_plugin_ != nullptr,
+                   "Cipher plugin required for encrypted V3 index");
+    }
 
     // Parse __meta__ entry
     auto meta_entry = reader->ReadEntry(MILVUS_V3_META_ENTRY_NAME);
@@ -462,6 +492,7 @@ IndexEntryReader::ReadFooterAndDirectory() {
 
     if (dir_json.contains("__edek__")) {
         is_encrypted_ = true;
+        stream_load_info_.encrypted = true;
         edek_ = dir_json["__edek__"].get<std::string>();
         ez_id_ = std::stoll(dir_json["__ez_id__"].get<std::string>());
         slice_size_ = dir_json["slice_size"].get<size_t>();
@@ -470,19 +501,37 @@ IndexEntryReader::ReadFooterAndDirectory() {
                    kStreamSliceAlignment,
                    slice_size_);
 
-        cipher_plugin_ = PluginLoader::GetInstance().getCipherPlugin();
-        AssertInfo(cipher_plugin_ != nullptr,
-                   "Cipher plugin required for encrypted V3 index");
-
         for (const auto& entry : dir_json["entries"]) {
             EntryMeta meta;
             meta.encrypted = true;
             meta.enc.original_size = entry["original_size"].get<uint64_t>();
             meta.enc.crc32 = Crc32cFromHex(entry["crc32"].get<std::string>());
+            size_t output_offset = 0;
             for (const auto& s : entry["slices"]) {
-                meta.enc.slices.push_back(
-                    {s["offset"].get<uint64_t>(), s["size"].get<uint64_t>()});
+                auto slice = SliceMeta{s["offset"].get<uint64_t>(),
+                                       s["size"].get<uint64_t>()};
+                meta.enc.slices.push_back(slice);
+
+                AssertInfo(output_offset < meta.enc.original_size,
+                           "Encrypted slice exceeds original entry size {}",
+                           meta.enc.original_size);
+                auto remaining =
+                    static_cast<size_t>(meta.enc.original_size - output_offset);
+                auto plain_len = std::min(remaining, slice_size_);
+                auto task_transient_bytes = EncryptedStreamBudgetBytes(
+                    static_cast<size_t>(slice.size), plain_len);
+                stream_load_info_.total_transient_bytes =
+                    SaturatingAdd(stream_load_info_.total_transient_bytes,
+                                  task_transient_bytes);
+                stream_load_info_.max_task_transient_bytes =
+                    std::max(stream_load_info_.max_task_transient_bytes,
+                             task_transient_bytes);
+                output_offset += plain_len;
             }
+            AssertInfo(output_offset == meta.enc.original_size,
+                       "Encrypted slices cover {} bytes, expected {}",
+                       output_offset,
+                       meta.enc.original_size);
             std::string name = entry["name"].get<std::string>();
             entry_names_.push_back(name);
             entry_index_.emplace(std::move(name), std::move(meta));

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -63,7 +63,7 @@ class TransientBudgetGuard {
                 slice_transient_bytes_, cancellation_token);
         if (!acquired) {
             ThrowIfCancelled(cancellation_token, operation);
-            ThrowInfo(ErrorCode::FollyCancel, "{} cancelled", operation);
+            ThrowInfo(ErrorCode::UnexpectedError, "{} cancelled", operation);
         }
     }
 

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -920,6 +920,10 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                        em.original_size);
             size_t remaining = em.original_size - output_offset;
             size_t plain_len = std::min(remaining, slice_size_);
+            auto budget_guard = std::make_shared<TransientBudgetGuard>(
+                EncryptedStreamBudgetBytes(slice.size, plain_len),
+                cancellation_token,
+                "IndexEntryReader::ReadEntriesStreamToFiles");
 
             futures.push_back(pool.Submit([input,
                                            cipher_plugin,
@@ -932,11 +936,10 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                                            plain_len,
                                            i,
                                            &state,
-                                           cancellation_token]() {
-                TransientBudgetGuard budget_guard(
-                    EncryptedStreamBudgetBytes(slice.size, plain_len),
-                    cancellation_token,
-                    "IndexEntryReader::ReadEntriesStreamToFiles");
+                                           cancellation_token,
+                                           budget_guard =
+                                               std::move(budget_guard)]() {
+                (void)budget_guard;
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesStreamToFiles");
 
@@ -975,6 +978,10 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
             size_t len =
                 PlainStreamSliceBytes(pm.size, slice_size, num_slices, seq);
             size_t src_offset = pm.offset + output_offset;
+            auto budget_guard = std::make_shared<TransientBudgetGuard>(
+                len,
+                cancellation_token,
+                "IndexEntryReader::ReadEntriesStreamToFiles");
 
             futures.push_back(pool.Submit([input,
                                            writer,
@@ -983,11 +990,10 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                                            len,
                                            seq,
                                            &state,
-                                           cancellation_token]() {
-                TransientBudgetGuard budget_guard(
-                    len,
-                    cancellation_token,
-                    "IndexEntryReader::ReadEntriesStreamToFiles");
+                                           cancellation_token,
+                                           budget_guard =
+                                               std::move(budget_guard)]() {
+                (void)budget_guard;
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesStreamToFiles");
 

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -348,7 +348,8 @@ IndexEntryReader::InspectStreamLoadInfo(
     reader->file_size_ = file_size;
     reader->cancellation_token_ = cancellation_token;
     reader->CheckCancelled("IndexEntryReader::InspectStreamLoadInfo");
-    reader->ValidateMagic();
+    // The caller has already selected the V3 path. Actual loading validates
+    // the magic; inspection avoids a separate range read at offset zero.
     reader->ReadFooterAndDirectory();
     reader->CheckCancelled("IndexEntryReader::InspectStreamLoadInfo");
     return reader->stream_load_info_;
@@ -448,13 +449,12 @@ IndexEntryReader::ReadFooterAndDirectory() {
                    static_cast<size_t>(file_size_),
                "Directory table + meta entry + footer size exceeds file size");
 
-    // Check if we need a second read
-    size_t needed =
-        static_cast<size_t>(dir_size) + meta_entry_size + MILVUS_V3_FOOTER_SIZE;
+    // Check if the directory itself needs a second read. The meta entry is
+    // loaded separately by Open() and is not needed for directory parsing.
+    size_t needed = static_cast<size_t>(dir_size) + MILVUS_V3_FOOTER_SIZE;
     size_t available_before_footer = tail_size - MILVUS_V3_FOOTER_SIZE;
 
-    if (static_cast<size_t>(dir_size) + meta_entry_size >
-        available_before_footer) {
+    if (static_cast<size_t>(dir_size) > available_before_footer) {
         size_t new_tail_size = needed;
         size_t new_tail_offset = file_size_ - new_tail_size;
 

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -43,8 +43,22 @@ struct Entry {
     std::vector<uint8_t> data;
 };
 
+struct EntryStreamLoadInfo {
+    // Exact encrypted-stream task bounds derived from persisted V3 directory
+    // slice metadata. Plaintext files leave both byte counts at zero.
+    bool encrypted{false};
+    size_t total_transient_bytes{0};
+    size_t max_task_transient_bytes{0};
+};
+
 class IndexEntryReader {
  public:
+    static EntryStreamLoadInfo
+    InspectStreamLoadInfo(std::shared_ptr<milvus::InputStream> input,
+                          int64_t file_size,
+                          folly::CancellationToken cancellation_token =
+                              folly::CancellationToken());
+
     static std::unique_ptr<IndexEntryReader>
     Open(std::shared_ptr<milvus::InputStream> input,
          int64_t file_size,
@@ -252,6 +266,7 @@ class IndexEntryReader {
     std::shared_ptr<plugin::ICipherPlugin> cipher_plugin_;
 
     std::unordered_map<std::string, EntryMeta> entry_index_;
+    EntryStreamLoadInfo stream_load_info_;
     std::vector<std::string> entry_names_;
 
     static constexpr size_t kSmallEntryCacheThreshold = 1 * 1024 * 1024;

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -67,6 +67,11 @@ class IndexEntryReader {
          folly::CancellationToken cancellation_token =
              folly::CancellationToken());
 
+    const EntryStreamLoadInfo&
+    GetStreamLoadInfo() const {
+        return stream_load_info_;
+    }
+
     std::vector<std::string>
     GetEntryNames() const;
 

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -158,6 +158,51 @@ class MockCipherPlugin : public plugin::ICipherPlugin {
     }
 };
 
+class ExpandingMockEncryptor : public plugin::IEncryptor {
+ public:
+    std::string
+    Encrypt(const std::string& plaintext) const override {
+        return Encrypt(plaintext.data(), plaintext.size());
+    }
+
+    std::string
+    Encrypt(std::string_view plaintext) const override {
+        return Encrypt(plaintext.data(), plaintext.size());
+    }
+
+    std::string
+    Encrypt(const void*, size_t len) const override {
+        return std::string(4 * len + 17, 'E');
+    }
+
+    std::string
+    GetKey() const override {
+        return {};
+    }
+};
+
+class ExpandingMockCipherPlugin : public plugin::ICipherPlugin {
+ public:
+    std::string
+    getPluginName() const override {
+        return "ExpandingCipherPlugin";
+    }
+
+    void
+    Update(int64_t, int64_t, const std::string&) override {
+    }
+
+    std::pair<std::shared_ptr<plugin::IEncryptor>, std::string>
+    GetEncryptor(int64_t, int64_t) const override {
+        return {std::make_shared<ExpandingMockEncryptor>(), "expanding_edek"};
+    }
+
+    std::shared_ptr<plugin::IDecryptor>
+    GetDecryptor(int64_t, int64_t, const std::string&) const override {
+        return nullptr;
+    }
+};
+
 class DelayedFailingInputStream : public milvus::InputStream {
  public:
     struct Rule {
@@ -1004,6 +1049,48 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedMultiSliceEntry) {
     auto info = fs_->GetFileInfo(file_path);
     ASSERT_TRUE(info.ok());
     EXPECT_GT(info.ValueOrDie().size(), entry_size);
+}
+
+TEST_F(IndexEntryEncryptedV3Test,
+       InspectStreamLoadInfoUsesPersistedCiphertextSizes) {
+    IndexEntryStreamConfigGuard guard;
+    const std::string file_path = kV3FilePath + "_enc_stream_load_info";
+    const size_t slice_size = kStreamSliceAlignment;
+    const size_t entry_size = 2 * slice_size + 100;
+    auto data = GeneratePattern(entry_size);
+    auto expanding_cipher = std::make_shared<ExpandingMockCipherPlugin>();
+
+    {
+        IndexEntryEncryptedLocalWriter writer(file_path,
+                                              fs_,
+                                              expanding_cipher,
+                                              /*ez_id=*/1,
+                                              /*collection_id=*/100,
+                                              GetRootPath(),
+                                              slice_size);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    auto info = IndexEntryReader::InspectStreamLoadInfo(input, input->Size());
+
+    // The encryptor expands ciphertext beyond 3x plaintext. The directory also
+    // contains the encrypted two-byte "{}" metadata entry.
+    EXPECT_TRUE(info.encrypted);
+    EXPECT_EQ(info.max_task_transient_bytes, 6 * slice_size + 17);
+    EXPECT_EQ(info.total_transient_bytes,
+              2 * (6 * slice_size + 17) + (6 * 100 + 17) + 29);
+
+    milvus::SetLoadTransientBudgetBytes(0);
+    EXPECT_EQ(EncryptedEntryStreamMaxTransientBytes(
+                  info.total_transient_bytes, info.max_task_transient_bytes),
+              info.total_transient_bytes);
+
+    milvus::SetLoadTransientBudgetBytes(1);
+    EXPECT_EQ(EncryptedEntryStreamMaxTransientBytes(
+                  info.total_transient_bytes, info.max_task_transient_bytes),
+              info.max_task_transient_bytes);
 }
 
 TEST_F(IndexEntryEncryptedV3Test, EncryptedMultipleEntriesMultiSlice) {

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -1202,8 +1202,20 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultSliceSize) {
     ASSERT_EQ(DefaultStreamSliceSize(), slice_size);
     milvus::SetLoadTransientBudgetBytes(0);
     ASSERT_EQ(budget.CapacityBytes(), 0);
-    ASSERT_EQ(EntryStreamMaxTransientBytes(),
+    ASSERT_NE(EntryStreamMaxTransientBytes(),
               std::numeric_limits<size_t>::max());
+    ASSERT_EQ(EntryStreamMaxTransientBytes(),
+              EntryStreamPoolBoundTransientBytes());
+
+    const size_t pool_bound_transient_bytes =
+        EntryStreamPoolBoundTransientBytes();
+    ASSERT_LT(
+        pool_bound_transient_bytes,
+        static_cast<size_t>(std::numeric_limits<int64_t>::max()) - slice_size);
+    const size_t oversized_budget = pool_bound_transient_bytes + slice_size;
+    milvus::SetLoadTransientBudgetBytes(static_cast<int64_t>(oversized_budget));
+    ASSERT_EQ(budget.CapacityBytes(), oversized_budget);
+    ASSERT_EQ(EntryStreamMaxTransientBytes(), pool_bound_transient_bytes);
 
     const size_t configured_budget = 3 * slice_size;
     milvus::SetLoadTransientBudgetBytes(

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -265,6 +265,63 @@ class DelayedFailingInputStream : public milvus::InputStream {
     std::vector<Rule> rules_;
 };
 
+class RecordingInputStream : public milvus::InputStream {
+ public:
+    struct ReadRange {
+        size_t offset;
+        size_t size;
+    };
+
+    explicit RecordingInputStream(std::shared_ptr<milvus::InputStream> base)
+        : base_(std::move(base)) {
+    }
+
+    const std::vector<ReadRange>&
+    ReadRanges() const {
+        return read_ranges_;
+    }
+
+    size_t
+    Size() const override {
+        return base_->Size();
+    }
+
+    bool
+    Seek(int64_t offset) override {
+        return base_->Seek(offset);
+    }
+
+    size_t
+    Tell() const override {
+        return base_->Tell();
+    }
+
+    bool
+    Eof() const override {
+        return base_->Eof();
+    }
+
+    size_t
+    Read(void* ptr, size_t size) override {
+        return base_->Read(ptr, size);
+    }
+
+    size_t
+    ReadAt(void* ptr, size_t offset, size_t size) override {
+        read_ranges_.push_back({offset, size});
+        return base_->ReadAt(ptr, offset, size);
+    }
+
+    size_t
+    Read(int fd, size_t size) override {
+        return base_->Read(fd, size);
+    }
+
+ private:
+    std::shared_ptr<milvus::InputStream> base_;
+    std::vector<ReadRange> read_ranges_;
+};
+
 class TrackingDelayedInputStream : public milvus::InputStream {
  public:
     TrackingDelayedInputStream(std::shared_ptr<milvus::InputStream> base,
@@ -906,15 +963,63 @@ TEST_F(IndexEntryWriterV3Test, LargeDirectoryTableNeedsSecondIO) {
     VerifyPattern(entry_last.data, 64);
 }
 
-TEST_F(IndexEntryWriterV3Test, DirectoryFitsButMetaDoesNotFitFirstIO) {
-    // Directory table fits in first 64KB, but meta entry is large enough
-    // that dir_size + meta_entry_size > 64KB - 32
-    // This tests the boundary where we need second IO for meta only
+TEST_F(IndexEntryWriterV3Test, InspectStreamLoadInfoReadsOnlyFileTail) {
+    const std::string file_path = kV3FilePath + "_inspect_tail_only";
+    auto data = GeneratePattern(1024);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input =
+        std::make_shared<RecordingInputStream>(CreateInputStream(file_path));
+    auto file_size = input->Size();
+    auto info = IndexEntryReader::InspectStreamLoadInfo(input, file_size);
+
+    EXPECT_FALSE(info.encrypted);
+    ASSERT_EQ(input->ReadRanges().size(), 1);
+    auto tail_size = std::min<size_t>(file_size, 64 * 1024);
+    EXPECT_EQ(input->ReadRanges()[0].offset, file_size - tail_size);
+    EXPECT_EQ(input->ReadRanges()[0].size, tail_size);
+}
+
+TEST_F(IndexEntryWriterV3Test, InspectStreamLoadInfoDoesNotPrefetchLargeMeta) {
+    const std::string file_path = kV3FilePath + "_inspect_large_meta";
+    auto data = GeneratePattern(1024);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.PutMeta("large_field", std::string(70 * 1024, 'X'));
+        writer.Finish();
+    }
+
+    auto input =
+        std::make_shared<RecordingInputStream>(CreateInputStream(file_path));
+    auto file_size = input->Size();
+    auto info = IndexEntryReader::InspectStreamLoadInfo(input, file_size);
+
+    EXPECT_FALSE(info.encrypted);
+    auto non_magic_reads = std::count_if(
+        input->ReadRanges().begin(),
+        input->ReadRanges().end(),
+        [](const RecordingInputStream::ReadRange& range) {
+            return range.offset != 0 || range.size != MILVUS_V3_MAGIC_SIZE;
+        });
+    EXPECT_EQ(non_magic_reads, 1);
+}
+
+TEST_F(IndexEntryWriterV3Test, LargeMetaLoadsSeparatelyFromDirectory) {
+    // Directory table fits in the first 64KB. The large meta entry is read
+    // separately by ReadEntry instead of being prefetched with the directory.
     const std::string file_path = kV3FilePath + "_largemetasmalldir";
 
-    // Create a large meta JSON
-    // We need meta_entry_size to be large (> ~60KB)
-    // but directory table should be small (< 64KB - 32 - meta_size)
+    // Keep the directory small while making the meta larger than the initial
+    // tail read.
     auto data = GeneratePattern(1024);
 
     {

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -1424,6 +1424,77 @@ TEST_F(IndexEntryWriterV3Test, ReadEntriesStreamToFilesRunsFilesConcurrently) {
     ::unlink(file_c.c_str());
 }
 
+TEST_F(IndexEntryWriterV3Test,
+       ReadEntriesStreamBudgetWaitDoesNotOccupyLoadPoolWorker) {
+    const std::string file_path = kV3FilePath + "_stream_budget_admission";
+    const size_t entry_size = kMinStreamSliceSize;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto& budget = TransientMemoryBudget::GetLoadTransientBudget();
+    auto old_capacity = budget.CapacityBytes();
+    budget.SetCapacityBytes(entry_size);
+    budget.Acquire(entry_size);
+    bool budget_held = true;
+    auto budget_cleanup = folly::makeGuard([&]() {
+        if (budget_held) {
+            budget.Release(entry_size);
+        }
+        budget.SetCapacityBytes(old_capacity);
+    });
+
+    auto pool_priority = milvus::ThreadPoolPriority::LOW;
+    auto& pool = milvus::ThreadPools::GetThreadPool(pool_priority);
+    auto old_max_threads = pool.GetMaxThreadNum();
+    auto cpu_num = std::max(1, milvus::CPU_NUM);
+    milvus::ThreadPools::ResizeThreadPool(pool_priority,
+                                          1.0F / static_cast<float>(cpu_num));
+    auto pool_cleanup =
+        folly::makeGuard([pool_priority, old_max_threads, cpu_num]() {
+            milvus::ThreadPools::ResizeThreadPool(
+                pool_priority,
+                static_cast<float>(old_max_threads) /
+                    static_cast<float>(cpu_num));
+        });
+    ASSERT_EQ(pool.GetMaxThreadNum(), 1);
+    if (pool.GetThreadNum() > 1) {
+        GTEST_SKIP() << "LOW load thread pool already has more than one worker";
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size, 0, milvus::LOW);
+    std::string local_file = GetRootPath() + "/stream_budget_admission.bin";
+    auto load_future = std::async(std::launch::async, [&]() {
+        reader->ReadEntriesStreamToFiles({{"data", local_file}},
+                                         milvus::storage::io::Priority::LOW);
+    });
+
+    EXPECT_EQ(load_future.wait_for(std::chrono::milliseconds(50)),
+              std::future_status::timeout);
+    auto marker_future = pool.Submit([]() {});
+    auto marker_status = marker_future.wait_for(std::chrono::milliseconds(200));
+
+    budget.Release(entry_size);
+    budget_held = false;
+
+    ASSERT_EQ(load_future.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    load_future.get();
+    ASSERT_EQ(marker_future.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    marker_future.get();
+    EXPECT_EQ(marker_status, std::future_status::ready);
+
+    ::unlink(local_file.c_str());
+}
+
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamConsumerExceptionDoesNotLeak) {
     const std::string file_path = kV3FilePath + "_stream_consumer_throw";
     const size_t slice_size = 64 * 1024;

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -1252,6 +1252,42 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultSliceSize) {
               (std::vector<size_t>{slice_size, slice_size, tail_size}));
 }
 
+TEST_F(IndexEntryWriterV3Test, EncryptedEntryStreamUsesThreeBufferPoolBound) {
+    IndexEntryStreamConfigGuard guard;
+    milvus::SetLoadTransientBudgetBytes(0);
+
+    const auto max_tasks =
+        static_cast<size_t>(milvus::ComputeThreadPoolMaxThreads(
+            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
+    const auto per_task_bound =
+        3 * (DefaultStreamSliceSize() + kTailMergeGrace);
+    const auto encrypted_pool_bound = max_tasks * per_task_bound;
+
+    EXPECT_EQ(EntryStreamPoolBoundTransientBytes(true), encrypted_pool_bound);
+    EXPECT_EQ(EntryStreamMaxTransientBytes(true), encrypted_pool_bound);
+}
+
+TEST_F(IndexEntryWriterV3Test, EncryptedEntryStreamAccountsForPlaintextCopies) {
+    constexpr size_t stream_bytes = 8 * 1024 * 1024;
+
+    EXPECT_EQ(EntryStreamDataTransientBytes(stream_bytes, false), stream_bytes);
+    EXPECT_EQ(EntryStreamDataTransientBytes(stream_bytes, true),
+              3 * stream_bytes);
+    EXPECT_EQ(
+        EntryStreamDataTransientBytes(std::numeric_limits<size_t>::max(), true),
+        std::numeric_limits<size_t>::max());
+}
+
+TEST_F(IndexEntryWriterV3Test,
+       EncryptedEntryStreamIncludesOversizedSingleTask) {
+    IndexEntryStreamConfigGuard guard;
+    const auto slice_size = DefaultStreamSliceSize();
+    milvus::SetLoadTransientBudgetBytes(static_cast<int64_t>(slice_size));
+
+    const auto per_task_bound = 3 * (slice_size + kTailMergeGrace);
+    EXPECT_EQ(EntryStreamMaxTransientBytes(true), per_task_bound);
+}
+
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMergesSmallTail) {
     const size_t slice_size = DEFAULT_INDEX_FILE_SLICE_SIZE;
     const size_t tail_size = kTailMergeGrace / 2;

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -1221,8 +1221,7 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultSliceSize) {
     milvus::SetLoadTransientBudgetBytes(
         static_cast<int64_t>(configured_budget));
     ASSERT_EQ(budget.CapacityBytes(), configured_budget);
-    ASSERT_EQ(EntryStreamMaxTransientBytes(),
-              configured_budget + kTailMergeGrace);
+    ASSERT_EQ(EntryStreamMaxTransientBytes(), configured_budget);
 
     const std::string file_path = kV3FilePath + "_stream_configured_default";
     const size_t tail_size = kTailMergeGrace + 17;
@@ -1264,7 +1263,8 @@ TEST_F(IndexEntryWriterV3Test, EncryptedEntryStreamUsesThreeBufferPoolBound) {
     const auto encrypted_pool_bound = max_tasks * per_task_bound;
 
     EXPECT_EQ(EntryStreamPoolBoundTransientBytes(true), encrypted_pool_bound);
-    EXPECT_EQ(EntryStreamMaxTransientBytes(true), encrypted_pool_bound);
+    EXPECT_EQ(EntryStreamMaxTransientBytes(true),
+              std::numeric_limits<size_t>::max());
 }
 
 TEST_F(IndexEntryWriterV3Test, EncryptedEntryStreamAccountsForPlaintextCopies) {
@@ -1286,6 +1286,33 @@ TEST_F(IndexEntryWriterV3Test,
 
     const auto per_task_bound = 3 * (slice_size + kTailMergeGrace);
     EXPECT_EQ(EntryStreamMaxTransientBytes(true), per_task_bound);
+}
+
+TEST_F(IndexEntryWriterV3Test, PlainEntryStreamIncludesOversizedSingleTask) {
+    IndexEntryStreamConfigGuard guard;
+    milvus::SetLoadTransientBudgetBytes(1 * 1024 * 1024);
+
+    EXPECT_EQ(EntryStreamMaxTransientBytes(),
+              DefaultStreamSliceSize() + kTailMergeGrace);
+}
+
+TEST_F(IndexEntryWriterV3Test, PlainEntryStreamPoolBoundCountsTailPerTask) {
+    const auto configured_tasks =
+        static_cast<size_t>(milvus::ComputeThreadPoolMaxThreads(
+            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
+
+    EXPECT_EQ(EntryStreamPoolBoundTransientBytes(),
+              configured_tasks * (DefaultStreamSliceSize() + kTailMergeGrace));
+}
+
+TEST_F(IndexEntryWriterV3Test, EntryStreamPoolBoundUsesLiveWorkerFloor) {
+    const auto configured_tasks =
+        static_cast<size_t>(milvus::ComputeThreadPoolMaxThreads(
+            milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
+    const auto live_workers = configured_tasks + 1;
+
+    EXPECT_EQ(EntryStreamPoolBoundTransientBytes(false, live_workers),
+              live_workers * (DefaultStreamSliceSize() + kTailMergeGrace));
 }
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMergesSmallTail) {

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -1279,6 +1279,19 @@ TEST_F(IndexEntryWriterV3Test, EncryptedEntryStreamAccountsForPlaintextCopies) {
 }
 
 TEST_F(IndexEntryWriterV3Test,
+       PlainEntryFileStreamAccountsForAlignedWriteCopy) {
+    constexpr size_t stream_bytes = 8 * 1024 * 1024;
+
+    EXPECT_EQ(PlainEntryFileStreamTransientBytes(stream_bytes),
+              2 * stream_bytes);
+    EXPECT_EQ(PlainEntryFileStreamTaskTransientBytes(),
+              2 * (DefaultStreamSliceSize() + kTailMergeGrace));
+    EXPECT_EQ(
+        PlainEntryFileStreamTransientBytes(std::numeric_limits<size_t>::max()),
+        std::numeric_limits<size_t>::max());
+}
+
+TEST_F(IndexEntryWriterV3Test,
        EncryptedEntryStreamIncludesOversizedSingleTask) {
     IndexEntryStreamConfigGuard guard;
     const auto slice_size = DefaultStreamSliceSize();
@@ -1502,7 +1515,7 @@ TEST_F(IndexEntryWriterV3Test,
 
     auto& budget = TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
-    budget.SetCapacityBytes(entry_size);
+    budget.SetCapacityBytes(2 * entry_size);
     budget.Acquire(entry_size);
     bool budget_held = true;
     auto budget_cleanup = folly::makeGuard([&]() {

--- a/internal/core/src/storage/PluginLoader.h
+++ b/internal/core/src/storage/PluginLoader.h
@@ -125,6 +125,14 @@ class PluginLoader {
         return names;
     }
 
+#ifdef MILVUS_UNIT_TEST
+    void
+    addPluginForTest(std::shared_ptr<milvus::storage::plugin::IPlugin> plugin) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        plugins_[plugin->getPluginName()] = std::move(plugin);
+    }
+#endif
+
     void
     unload(const std::string& name) {
         std::lock_guard<std::mutex> lock(mutex_);

--- a/internal/core/src/storage/ThreadPool.cpp
+++ b/internal/core/src/storage/ThreadPool.cpp
@@ -70,9 +70,7 @@ void
 ThreadPool::Init() {
     std::lock_guard<std::mutex> lock(mutex_);
     for (int i = 0; i < min_threads_size_; i++) {
-        std::thread t(&ThreadPool::Worker, this);
-        assert(threads_.find(t.get_id()) == threads_.end());
-        threads_[t.get_id()] = std::move(t);
+        threads_.emplace_back(&ThreadPool::Worker, this);
         current_threads_size_++;
     }
 }
@@ -86,8 +84,8 @@ ThreadPool::ShutDown() {
     }
     condition_lock_.notify_all();
     for (auto& thread : threads_) {
-        if (thread.second.joinable()) {
-            thread.second.join();
+        if (thread.joinable()) {
+            thread.join();
         }
     }
     LOG_INFO("Finish shutting down {}", name_);
@@ -99,10 +97,13 @@ ThreadPool::FinishThreads() {
         std::thread::id id;
         auto dequeue = need_finish_threads_.dequeue(id);
         if (dequeue) {
-            auto iter = threads_.find(id);
+            auto iter = std::find_if(
+                threads_.begin(), threads_.end(), [id](const std::thread& t) {
+                    return t.get_id() == id;
+                });
             assert(iter != threads_.end());
-            if (iter->second.joinable()) {
-                iter->second.join();
+            if (iter->joinable()) {
+                iter->join();
             }
             threads_.erase(iter);
         }

--- a/internal/core/src/storage/ThreadPool.h
+++ b/internal/core/src/storage/ThreadPool.h
@@ -21,8 +21,9 @@
 #include <algorithm>
 #include <atomic>
 #include <cassert>
-#include <condition_variable>
 #include <chrono>
+#include <cmath>
+#include <condition_variable>
 #include <functional>
 #include <future>
 #include <memory>
@@ -73,6 +74,22 @@ InitCpuNum(const int core);
 void
 SetThreadPoolMaxThreadsSize(const int size);
 
+inline int
+ClampThreadPoolMaxThreads(int size) {
+    size = std::max(1, size);
+    auto max_limit = THREAD_POOL_MAX_THREADS_SIZE.load();
+    if (max_limit > 0 && size > max_limit) {
+        size = max_limit;
+    }
+    return size;
+}
+
+inline int
+ComputeThreadPoolMaxThreads(float thread_core_coefficient) {
+    return ClampThreadPoolMaxThreads(
+        static_cast<int>(std::round(CPU_NUM * thread_core_coefficient)));
+}
+
 class ThreadPool {
  public:
     explicit ThreadPool(const float thread_core_coefficient, std::string name)
@@ -80,14 +97,8 @@ class ThreadPool {
         idle_threads_size_ = 0;
         current_threads_size_ = 0;
         min_threads_size_ = 1;
-        max_threads_size_.store(std::max(
-            1,
-            static_cast<int>(std::round(CPU_NUM * thread_core_coefficient))));
-
-        int max_limit = THREAD_POOL_MAX_THREADS_SIZE.load();
-        if (max_limit > 0 && max_threads_size_.load() > max_limit) {
-            max_threads_size_.store(max_limit);
-        }
+        max_threads_size_.store(
+            ComputeThreadPoolMaxThreads(thread_core_coefficient));
         LOG_INFO("Init thread pool:{}", name_)
             << " with min worker num:" << min_threads_size_
             << " and max worker num:" << max_threads_size_.load();
@@ -195,11 +206,7 @@ class ThreadPool {
     Resize(int new_size) {
         //no need to hold mutex here as we don't require
         //max_threads_size to take effect instantly, just guaranteed atomic
-        new_size = std::max(1, new_size);
-        int max_limit = THREAD_POOL_MAX_THREADS_SIZE.load();
-        if (max_limit > 0 && new_size > max_limit) {
-            new_size = max_limit;
-        }
+        new_size = ClampThreadPoolMaxThreads(new_size);
         max_threads_size_.store(new_size);
         if (metric_capacity_) {
             metric_capacity_->Set(new_size);

--- a/internal/core/src/storage/ThreadPool.h
+++ b/internal/core/src/storage/ThreadPool.h
@@ -26,12 +26,12 @@
 #include <condition_variable>
 #include <functional>
 #include <future>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <ostream>
 #include <string>
 #include <thread>
-#include <unordered_map>
 #include <utility>
 
 #include <prometheus/counter.h>
@@ -171,15 +171,10 @@ class ThreadPool {
             observe_execute();
         };
 
-        work_queue_.enqueue(wrap_func);
-        if (metric_submitted_) {
-            metric_submitted_->Increment();
-        }
-        if (metric_queue_depth_) {
-            metric_queue_depth_->Set(work_queue_.size());
-        }
+        auto future = task_ptr->get_future();
 
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::unique_lock<std::mutex> lock(mutex_);
+        work_queue_.enqueue(std::move(wrap_func));
 
         if (idle_threads_size_ > 0) {
             condition_lock_.notify_one();
@@ -187,13 +182,37 @@ class ThreadPool {
         if (work_queue_.size() > static_cast<size_t>(idle_threads_size_) &&
             current_threads_size_ < max_threads_size_.load()) {
             // Dynamic increase thread number
-            std::thread t(&ThreadPool::Worker, this);
-            assert(threads_.find(t.get_id()) == threads_.end());
-            threads_[t.get_id()] = std::move(t);
-            current_threads_size_++;
+            try {
+                if (worker_spawn_hook_for_test_) {
+                    worker_spawn_hook_for_test_();
+                }
+                threads_.emplace_back(&ThreadPool::Worker, this);
+                current_threads_size_++;
+            } catch (const std::exception& e) {
+                LOG_WARN(
+                    "Failed to expand thread pool {}: {}", name_, e.what());
+            } catch (...) {
+                LOG_WARN("Failed to expand thread pool {}", name_);
+            }
+        }
+        lock.unlock();
+
+        try {
+            if (metric_submitted_) {
+                metric_submitted_->Increment();
+            }
+            if (metric_queue_depth_) {
+                metric_queue_depth_->Set(work_queue_.size());
+            }
+        } catch (const std::exception& e) {
+            LOG_WARN("Failed to update thread pool {} submit metrics: {}",
+                     name_,
+                     e.what());
+        } catch (...) {
+            LOG_WARN("Failed to update thread pool {} submit metrics", name_);
         }
 
-        return task_ptr->get_future();
+        return future;
     }
 
     void
@@ -253,7 +272,7 @@ class ThreadPool {
     bool shutdown_;
     static constexpr size_t WAIT_SECONDS = 2;
     SafeQueue<std::function<void()>> work_queue_;
-    std::unordered_map<std::thread::id, std::thread> threads_;
+    std::list<std::thread> threads_;
     SafeQueue<std::thread::id> need_finish_threads_;
     std::mutex mutex_;
     std::condition_variable condition_lock_;
@@ -268,6 +287,12 @@ class ThreadPool {
     prometheus::Counter* metric_completed_{nullptr};
     prometheus::Histogram* metric_queue_duration_{nullptr};
     prometheus::Histogram* metric_execute_duration_{nullptr};
+
+ private:
+    friend class ThreadPoolTest_WorkerSpawnFailureDoesNotFailQueuedTask_Test;
+
+    // Deterministic test seam for worker-spawn failure coverage.
+    std::function<void()> worker_spawn_hook_for_test_;
 };
 
 }  // namespace milvus

--- a/internal/core/src/storage/ThreadPoolTest.cpp
+++ b/internal/core/src/storage/ThreadPoolTest.cpp
@@ -14,8 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <future>
 #include <string>
+#include <system_error>
 
 #include "gtest/gtest.h"
 #include "storage/ThreadPool.h"
@@ -136,6 +139,39 @@ TEST_F(ThreadPoolTest, DynamicMaxThreadsSizeUpdate) {
     SetThreadPoolMaxThreadsSize(8);
     pool.Resize(20);
     EXPECT_EQ(pool.GetMaxThreadNum(), 8);
+}
+
+TEST_F(ThreadPoolTest, WorkerSpawnFailureDoesNotFailQueuedTask) {
+    ThreadPool pool(1.0, "test_pool");
+
+    std::promise<void> blocker_started;
+    std::promise<void> unblock_worker;
+    auto unblock_future = unblock_worker.get_future().share();
+    auto blocker = pool.Submit([&blocker_started, unblock_future]() {
+        blocker_started.set_value();
+        unblock_future.wait();
+    });
+    ASSERT_EQ(blocker_started.get_future().wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+
+    pool.worker_spawn_hook_for_test_ = []() {
+        throw std::system_error(
+            std::make_error_code(std::errc::resource_unavailable_try_again));
+    };
+
+    std::atomic<int> task_runs{0};
+    std::future<void> task_future;
+    EXPECT_NO_THROW(
+        task_future = pool.Submit([&task_runs]() { task_runs.fetch_add(1); }));
+
+    unblock_worker.set_value();
+    blocker.get();
+
+    ASSERT_TRUE(task_future.valid());
+    ASSERT_EQ(task_future.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    task_future.get();
+    EXPECT_EQ(task_runs.load(), 1);
 }
 
 }  // namespace milvus

--- a/internal/core/unittest/test_loading.cpp
+++ b/internal/core/unittest/test_loading.cpp
@@ -356,6 +356,39 @@ TEST(IndexLoadTest, LoadResourceRequestCacheIsOptional) {
     ASSERT_TRUE(loadIndexInfo.load_resource_request.has_value());
 }
 
+TEST(IndexLoadTest, SegmentAdmissionEstimateDoesNotOpenScalarV3File) {
+    constexpr uint64_t kIndexSize = 1024UL * 1024;
+
+    milvus::segcore::LoadIndexInfo loadIndexInfo;
+    loadIndexInfo.collection_id = 1;
+    loadIndexInfo.partition_id = 2;
+    loadIndexInfo.segment_id = 3;
+    loadIndexInfo.field_id = 4;
+    loadIndexInfo.field_type = milvus::DataType::INT64;
+    loadIndexInfo.element_type = milvus::DataType::NONE;
+    loadIndexInfo.enable_mmap = false;
+    loadIndexInfo.index_id = 5;
+    loadIndexInfo.index_build_id = 6;
+    loadIndexInfo.index_version = 1;
+    loadIndexInfo.index_params = {
+        {"index_type", milvus::index::BITMAP_INDEX_TYPE},
+        {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"},
+    };
+    loadIndexInfo.index_files = {"/path/that/must/not/be-opened"};
+    loadIndexInfo.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    loadIndexInfo.index_size = kIndexSize;
+    loadIndexInfo.num_rows = 1024;
+    loadIndexInfo.schema.set_fieldid(loadIndexInfo.field_id);
+    loadIndexInfo.schema.set_data_type(milvus::proto::schema::DataType::Int64);
+
+    auto request = EstimateLoadIndexResource(&loadIndexInfo);
+
+    EXPECT_EQ(request.final_memory_cost, kIndexSize);
+    EXPECT_EQ(request.final_disk_cost, 0);
+    EXPECT_TRUE(request.max_memory_cost >= request.final_memory_cost);
+}
+
 TEST(IndexLoadTest, ScalarSortMmapEstimateReservesLegacyAux) {
     constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
     constexpr int64_t kNumRows = 1025;

--- a/internal/core/unittest/test_utils/PlannerCipherPlugin.h
+++ b/internal/core/unittest/test_utils/PlannerCipherPlugin.h
@@ -12,7 +12,9 @@
 #pragma once
 
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "storage/plugin/PluginInterface.h"
@@ -39,6 +41,93 @@ class PlannerCipherPlugin : public storage::plugin::ICipherPlugin {
     GetDecryptor(int64_t, int64_t, const std::string&) const override {
         return nullptr;
     }
+};
+
+class PlannerIdentityEncryptor : public storage::plugin::IEncryptor {
+ public:
+    std::string
+    Encrypt(const std::string& plaintext) const override {
+        return plaintext;
+    }
+
+    std::string
+    Encrypt(std::string_view plaintext) const override {
+        return std::string(plaintext);
+    }
+
+    std::string
+    Encrypt(const void* data, size_t len) const override {
+        return std::string(static_cast<const char*>(data), len);
+    }
+
+    std::string
+    GetKey() const override {
+        return {};
+    }
+};
+
+class PlannerIdentityDecryptor : public storage::plugin::IDecryptor {
+ public:
+    std::string
+    Decrypt(const std::string& ciphertext) const override {
+        return ciphertext;
+    }
+
+    std::string
+    Decrypt(std::string_view ciphertext) const override {
+        return std::string(ciphertext);
+    }
+
+    std::string
+    Decrypt(const void* data, size_t len) const override {
+        return std::string(static_cast<const char*>(data), len);
+    }
+
+    std::string
+    GetKey() const override {
+        return {};
+    }
+};
+
+class CollectionBoundPlannerCipherPlugin
+    : public storage::plugin::ICipherPlugin {
+ public:
+    explicit CollectionBoundPlannerCipherPlugin(int64_t collection_id)
+        : collection_id_(collection_id) {
+    }
+
+    std::string
+    getPluginName() const override {
+        return "CipherPlugin";
+    }
+
+    void
+    Update(int64_t, int64_t, const std::string&) override {
+    }
+
+    std::pair<std::shared_ptr<storage::plugin::IEncryptor>, std::string>
+    GetEncryptor(int64_t, int64_t collection_id) const override {
+        CheckCollection(collection_id);
+        return {std::make_shared<PlannerIdentityEncryptor>(), "planner_edek"};
+    }
+
+    std::shared_ptr<storage::plugin::IDecryptor>
+    GetDecryptor(int64_t,
+                 int64_t collection_id,
+                 const std::string&) const override {
+        CheckCollection(collection_id);
+        return std::make_shared<PlannerIdentityDecryptor>();
+    }
+
+ private:
+    void
+    CheckCollection(int64_t collection_id) const {
+        if (collection_id != collection_id_) {
+            throw std::runtime_error("unexpected collection id");
+        }
+    }
+
+    int64_t collection_id_;
 };
 
 }  // namespace milvus::test

--- a/internal/core/unittest/test_utils/PlannerCipherPlugin.h
+++ b/internal/core/unittest/test_utils/PlannerCipherPlugin.h
@@ -1,0 +1,44 @@
+// Copyright (C) 2019-2026 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "storage/plugin/PluginInterface.h"
+
+namespace milvus::test {
+
+class PlannerCipherPlugin : public storage::plugin::ICipherPlugin {
+ public:
+    std::string
+    getPluginName() const override {
+        return "CipherPlugin";
+    }
+
+    void
+    Update(int64_t, int64_t, const std::string&) override {
+    }
+
+    std::pair<std::shared_ptr<storage::plugin::IEncryptor>, std::string>
+    GetEncryptor(int64_t, int64_t) const override {
+        return {nullptr, {}};
+    }
+
+    std::shared_ptr<storage::plugin::IDecryptor>
+    GetDecryptor(int64_t, int64_t, const std::string&) const override {
+        return nullptr;
+    }
+};
+
+}  // namespace milvus::test


### PR DESCRIPTION
pr: #51403
issue: #49499

## What changed

- Backport the load transient-budget admission fixes from #51403 to 3.0.
- Preserve the master branch's per-dimension load-overhead accounting and encrypted V3 stream estimates.
- Make the disabled-budget pool-bound test independent of asynchronous thread-pool resize state.

## Test

- C++ unittest build
- 91 targeted load admission, entry stream, scalar index, and thread pool tests passed
- `make verifiers`
