### PR TITLE
fix: decide growing-source flush layout by materialized marker, not empty() (#51581 3.0)

### DIFF
--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -203,8 +203,24 @@ class VectorBase {
         return empty;
     }
 
+    // Monotonic materialization marker, the canonical flush-layout presence
+    // test. Set on the first set_data_raw (any path, incl. all-null bulk fill),
+    // never cleared. Avoids the race-prone chunk state empty()/valid_count,
+    // which a concurrent insert flips mid set_data_raw and interim-index
+    // raw-vector removal empties for a column that still exists.
+    bool
+    materialized() const {
+        return materialized_.load(std::memory_order_relaxed);
+    }
+
  protected:
+    void
+    mark_materialized() {
+        materialized_.store(true, std::memory_order_relaxed);
+    }
+
     const int64_t size_per_chunk_;
+    std::atomic<bool> materialized_{false};
 };
 
 template <typename Type, bool is_type_entire_row = false>
@@ -288,6 +304,9 @@ class ConcurrentVectorImpl : public VectorBase {
     set_data_raw(ssize_t element_offset,
                  const void* source,
                  ssize_t element_count) override {
+        // Entry, not post-chunk: an all-null column reaches here with
+        // valid_count==0 (no chunk emplaced), yet is still materialized.
+        mark_materialized();
         ssize_t valid_count = 0;
         ssize_t storage_offset = 0;
         if (use_mapping_storage_) {

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1733,21 +1733,30 @@ class InsertRecordGrowing {
         return data_.find(field_id) != data_.end();
     }
 
-    // Field ids that have materialized columns. The exact set the flush
-    // layout must be trimmed to: non-materialized function outputs are
-    // absent here.
+    // True once set_data_raw has run on the field's column (see
+    // VectorBase::materialized).
+    bool
+    materialized(FieldId field_id) const {
+        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
+        auto it = data_.find(field_id);
+        return it != data_.end() && it->second && it->second->materialized();
+    }
+
+    // Field ids in the flush layout: columns the segment has materialized
+    // (see VectorBase::materialized) that are still present in `schema`.
+    // `schema` MUST be the segment's own runtime schema, NOT the staler flush
+    // snapshot — else a dropped field would be wrongly kept. Dropped fields and
+    // never-materialized function outputs (backfilled later by bump-schema
+    // compaction) stay out.
     std::vector<int64_t>
-    get_data_field_ids() const {
+    get_data_field_ids(const Schema& schema) const {
         std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
         std::vector<int64_t> ids;
         ids.reserve(data_.size());
         for (const auto& [field_id, entry] : data_) {
-            // An allocated-but-empty column (e.g. a function output the
-            // replayed older-era inserts never filled) is not materialized.
-            if (!entry || entry->empty()) {
-                continue;
+            if (entry && schema.has_field(field_id) && entry->materialized()) {
+                ids.push_back(field_id.get());
             }
-            ids.push_back(field_id.get());
         }
         return ids;
     }

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -218,6 +218,15 @@ class SegmentGrowingImpl : public SegmentGrowing {
         return *schema_;
     }
 
+    // Reopen swaps schema_ under sch_mutex_; a bare get_schema() reference can
+    // dangle if the swap frees the old Schema mid-use. Snapshot under the lock
+    // (shared_ptr copy keeps the referent alive). Mirrors Collection::get_schema.
+    SchemaPtr
+    get_schema_snapshot() {
+        std::shared_lock<std::shared_mutex> lock(sch_mutex_);
+        return schema_;
+    }
+
     FieldId
     get_primary_key_field_id() const {
         return primary_key_field_id_;

--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -1684,6 +1684,7 @@ TEST_F(FlushGrowingSegmentTest, FlushRejectsEndOffsetBeyondRowCount) {
     ASSERT_NE(status.error_msg, nullptr);
     EXPECT_NE(std::string(status.error_msg).find("exceeds growing segment"),
               std::string::npos);
+    free(const_cast<char*>(status.error_msg));
 
     FreeFlushResult(&result);
 }

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -1686,21 +1686,13 @@ GetGrowingSegmentMaterializedFieldIDs(CSegmentInterface c_segment,
             return milvus::FailureCStatus(milvus::UnexpectedError,
                                           "segment is not a growing segment");
         }
-        auto ids = growing_segment->get_insert_record().get_data_field_ids();
-        std::unordered_set<int64_t> seen(ids.begin(), ids.end());
-        const auto& schema = growing_segment->get_schema();
-        for (const auto& field_id : schema.get_field_ids()) {
-            auto raw_field_id = field_id.get();
-            if (seen.find(raw_field_id) != seen.end()) {
-                continue;
-            }
-            const auto& field_meta = schema[field_id];
-            if (milvus::IsVectorDataType(field_meta.get_data_type()) &&
-                growing_segment->CanReadRawVectorFromIndex(field_id)) {
-                ids.push_back(raw_field_id);
-                seen.insert(raw_field_id);
-            }
-        }
+        // Snapshot under sch_mutex_: Reopen may swap the segment schema
+        // concurrently. Interim-index raw data is only populated after
+        // set_data_raw (which marks the column), so a materialized column set
+        // already covers every index-readable vector field.
+        auto schema_snapshot = growing_segment->get_schema_snapshot();
+        auto ids = growing_segment->get_insert_record().get_data_field_ids(
+            *schema_snapshot);
         if (!ids.empty()) {
             auto* buf =
                 static_cast<int64_t*>(malloc(sizeof(int64_t) * ids.size()));
@@ -1984,6 +1976,10 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         auto flush_schema =
             ParseFlushSchema(config->schema_blob, config->schema_length);
         const auto& schema = *flush_schema;
+        // One runtime-schema snapshot for the whole flush: keeps the Schema
+        // alive across a concurrent Reopen swap and pins every dropped-field
+        // check below to a single schema version.
+        auto runtime_schema = growing_segment->get_schema_snapshot();
         auto& insert_record = growing_segment->get_insert_record();
 
         int64_t total_rows = end_offset - start_offset;
@@ -2021,20 +2017,15 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
 
             // System fields are stored outside the regular field data map.
             const milvus::segcore::VectorBase* vec_base;
-            bool can_read_from_index = false;
             if (field_id == RowFieldID) {
                 vec_base = &insert_record.row_ids_;
             } else if (field_id == TimestampFieldID) {
                 vec_base = &insert_record.timestamps_;
             } else {
-                can_read_from_index =
-                    milvus::IsVectorDataType(data_type) &&
-                    growing_segment->CanReadRawVectorFromIndex(field_id);
-                // HasFieldData, not is_data_exist: a column the ctor
-                // allocated but replayed older-era inserts never filled is
-                // not materialized either.
-                if (!growing_segment->HasFieldData(field_id) &&
-                    !can_read_from_index) {
+                // In the layout iff materialized (see VectorBase::materialized);
+                // this covers interim-index vector fields too, since their raw
+                // data lands in the index only after set_data_raw marked them.
+                if (!insert_record.materialized(field_id)) {
                     // Legally absent: the field is gone from the segment's
                     // own schema (dropped; the flush schema is a staler
                     // snapshot), or it is a function output the segment
@@ -2042,7 +2033,7 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                     // compaction). The Go layer normally trims such columns
                     // from the layout already — this is the defense for
                     // stale layouts.
-                    if (!growing_segment->get_schema().has_field(field_id)) {
+                    if (!runtime_schema->has_field(field_id)) {
                         LOG_INFO(
                             "skip dropped field {} when flushing growing "
                             "segment {}",
@@ -2060,9 +2051,10 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                         skipped_columns.insert(field_id.get());
                         continue;
                     }
-                    // A regular field of the segment's own schema is
-                    // materialized by the ctor/Reopen by construction;
-                    // reaching here is real data loss.
+                    // A non-function-output field of the segment's own schema
+                    // is materialized by Insert/Load once the segment has rows
+                    // (the ctor only allocates its column); reaching here is
+                    // real data loss.
                     return milvus::FailureCStatus(
                         milvus::UnexpectedError,
                         fmt::format("field {} has no field data in growing "

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -489,6 +489,152 @@ TEST_F(StorageTest, FlushGrowingSegmentSkipsEmptyFunctionOutputColumn) {
     cleanup();
 }
 
+// Regression for #51344: an all-null nullable ORDINARY column (schema-legal,
+// valid_data all-false, vector chunk empty) must be flushed as an all-null
+// column, NOT skipped/errored as "real data loss". Its layout must match the
+// write-buffer SyncTask (which always emits the column), otherwise Loon rejects
+// the later append with a column-group-count mismatch and pins the checkpoint.
+// This is the dual of FlushGrowingSegmentSkipsEmptyFunctionOutputColumn: an
+// empty function-output column stays out, an empty nullable ordinary column
+// stays in.
+TEST_F(StorageTest, FlushGrowingSegmentFlushesAllNullNullableColumn) {
+    std::string test_dir =
+        "/tmp/flush_allnull_nullable_" +
+        std::to_string(
+            std::chrono::system_clock::now().time_since_epoch().count());
+    std::filesystem::create_directories(test_dir);
+    auto cleanup = [&]() {
+        if (std::filesystem::exists(test_dir)) {
+            std::filesystem::remove_all(test_dir);
+        }
+    };
+
+    milvus::proto::schema::CollectionSchema schema_proto;
+    schema_proto.set_name("flush_allnull_nullable");
+    auto* row_id_field = schema_proto.add_fields();
+    row_id_field->set_fieldid(0);
+    row_id_field->set_name("RowID");
+    row_id_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* ts_field = schema_proto.add_fields();
+    ts_field->set_fieldid(1);
+    ts_field->set_name("Timestamp");
+    ts_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+    // Ordinary nullable vector field in the segment's own schema: the ctor
+    // allocates its column, and the consume path bulk-fills it all-null
+    // (valid_data all-false, vector chunk empty) because inserts never carry it.
+    auto* vec_field = schema_proto.add_fields();
+    vec_field->set_fieldid(101);
+    vec_field->set_name("nullable_vec");
+    vec_field->set_data_type(milvus::proto::schema::DataType::FloatVector);
+    vec_field->set_nullable(true);
+    auto* dim_param = vec_field->add_type_params();
+    dim_param->set_key("dim");
+    dim_param->set_value("4");
+
+    auto segment_schema = Schema::ParseFrom(schema_proto);
+    auto segment = CreateGrowingSegment(segment_schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    constexpr int N = 3;
+    std::vector<int64_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {10, 11, 12};
+    std::vector<int64_t> pks = {100, 101, 102};
+
+    // Insert carries no data for the nullable vector; the consume path
+    // bulk-fills field 101 all-null (allocated, valid_data all-false, empty).
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(N);
+    insert_data->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(
+            pks.data(), nullptr, N, (*segment_schema)[FieldId(100)])
+            .release());
+
+    segment->PreInsert(N);
+    segment->Insert(0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    // (materialize-predicate side) MaterializedFieldIDs — the set the Go
+    // growing-source trim keeps — must include the all-null nullable column so
+    // the trimmed layout still carries it. Previously get_data_field_ids'
+    // entry->empty() predicate dropped field 101.
+    int64_t* mat_ids = nullptr;
+    int64_t mat_count = 0;
+    auto mat_status = GetGrowingSegmentMaterializedFieldIDs(
+        segment.get(), &mat_ids, &mat_count);
+    ASSERT_EQ(mat_status.error_code, Success) << mat_status.error_msg;
+    bool materialized_101 = false;
+    for (int64_t i = 0; i < mat_count; ++i) {
+        if (mat_ids[i] == 101) {
+            materialized_101 = true;
+        }
+    }
+    EXPECT_TRUE(materialized_101)
+        << "all-null nullable field 101 must be in MaterializedFieldIDs";
+    if (mat_ids != nullptr) {
+        free(mat_ids);
+    }
+
+    std::string schema_blob = schema_proto.SerializeAsString();
+
+    CFlushConfig config{};
+    std::string segment_path = test_dir + "/collection/partition/segment_an";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.schema_blob = schema_blob.data();
+    config.schema_length = static_cast<int64_t>(schema_blob.size());
+    // Exercise the column-group accounting loop (where the production
+    // column-group-count mismatch surfaces): one group over all fields,
+    // including the all-null nullable field 101.
+    int64_t column_group_ids[] = {0};
+    int64_t column_group_field_ids[] = {0, 1, 100, 101};
+    size_t column_group_field_counts[] = {4};
+    config.column_group_ids = column_group_ids;
+    config.column_group_field_ids = column_group_field_ids;
+    config.column_group_field_counts = column_group_field_counts;
+    config.num_column_groups = 1;
+
+    CFlushResult result{};
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+
+    // Must NOT error as "real data loss".
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(result.num_rows, N);
+    // The all-null nullable column MUST be in the flushed layout (regression:
+    // previously dropped by the entry->empty() materialize predicate).
+    bool found_101 = false;
+    for (size_t i = 0; i < result.num_flushed_fields; ++i) {
+        if (result.flushed_field_ids[i] == 101) {
+            found_101 = true;
+        }
+    }
+    EXPECT_TRUE(found_101)
+        << "all-null nullable field 101 must be flushed as an all-null column";
+    // Column-group accounting ran (this loop is where the production mismatch
+    // surfaces).
+    EXPECT_EQ(result.num_column_groups, 1u);
+    // Field 101 is a genuine all-null column (every row null), not garbage:
+    // its per-field null count must equal the row count.
+    bool checked_101_null = false;
+    for (size_t i = 0; i < result.num_field_stats; ++i) {
+        if (result.field_ids[i] == 101) {
+            EXPECT_EQ(result.field_null_counts[i], N)
+                << "field 101 must be flushed all-null (null count == N)";
+            checked_101_null = true;
+        }
+    }
+    EXPECT_TRUE(checked_101_null)
+        << "field 101 null-count summary must be present";
+
+    FreeFlushResult(&result);
+    cleanup();
+}
+
 // A manifest column group whose only field was dropped from the segment
 // schema before recovery is a legal leftover of drop semantics: reloading
 // the growing segment must skip that group instead of failing the whole
@@ -944,4 +1090,109 @@ TEST(MinioChecksumConfig, NeedChecksumOverrideDispatch) {
     EXPECT_FALSE(Mgr::NeedChecksumOverride("aws"));
     EXPECT_FALSE(Mgr::NeedChecksumOverride(""));
     EXPECT_FALSE(Mgr::NeedChecksumOverride("unknown"));
+}
+
+// The monotonic materialized() marker (see VectorBase::materialized) must be set
+// on the first set_data_raw and survive clear(), else a chunk emptied by
+// interim-index removal or an in-flight first insert would drop a still-present
+// column from the flush layout (issue #51344).
+TEST_F(StorageTest, ConcurrentVectorMaterializedMarkerIsMonotonic) {
+    milvus::proto::schema::CollectionSchema proto;
+    auto* pk = proto.add_fields();
+    pk->set_fieldid(100);
+    pk->set_name("pk");
+    pk->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk->set_is_primary_key(true);
+    auto* f1 = proto.add_fields();
+    f1->set_fieldid(101);
+    f1->set_name("f1");
+    f1->set_data_type(milvus::proto::schema::DataType::Int64);
+    auto schema = Schema::ParseFrom(proto);
+
+    constexpr int64_t size_per_chunk = 32;
+    InsertRecordGrowing ir(*schema, size_per_chunk);
+    auto* col = ir.get_data_base(FieldId(101));
+
+    // Fresh column (allocated by the ctor, never written): not materialized.
+    EXPECT_FALSE(ir.materialized(FieldId(101)));
+    EXPECT_TRUE(col->empty());
+
+    constexpr int N = 2;
+    std::vector<int64_t> vals = {1, 2};
+    auto arr =
+        CreateDataArrayFrom(vals.data(), nullptr, N, (*schema)[FieldId(101)]);
+    col->set_data_raw(0, N, arr.get(), (*schema)[FieldId(101)]);
+    EXPECT_TRUE(ir.materialized(FieldId(101)));  // set on first set_data_raw
+    EXPECT_FALSE(col->empty());
+
+    // interim-index raw-vector removal empties the chunk...
+    col->clear();
+    EXPECT_TRUE(col->empty());
+    // ...but the column is still materialized (monotonic).
+    EXPECT_TRUE(ir.materialized(FieldId(101)));
+}
+
+// Covers get_data_field_ids' three arms and the materialized(field_id) accessor:
+// a materialized field present in `schema` is kept; an allocated-but-unwritten
+// field (never set_data_raw) is dropped; a materialized field absent from the
+// passed schema (dropped) is dropped — the has_field arm the C-API flush tests
+// never exercise (they always pass the segment's own schema).
+TEST_F(StorageTest, GetDataFieldIdsSelectsMaterializedFieldsInSchema) {
+    auto make_proto = [](bool with_f1) {
+        milvus::proto::schema::CollectionSchema p;
+        auto add = [&](int64_t id, const char* name, bool pk) {
+            auto* f = p.add_fields();
+            f->set_fieldid(id);
+            f->set_name(name);
+            f->set_data_type(milvus::proto::schema::DataType::Int64);
+            f->set_is_primary_key(pk);
+        };
+        add(100, "pk", true);
+        if (with_f1) {
+            add(101, "f1", false);
+        }
+        add(102, "f2", false);
+        return p;
+    };
+    auto has = [](const std::vector<int64_t>& v, int64_t x) {
+        return std::find(v.begin(), v.end(), x) != v.end();
+    };
+
+    auto schema = Schema::ParseFrom(make_proto(true));
+    constexpr int64_t size_per_chunk = 32;
+    InsertRecordGrowing ir(*schema, size_per_chunk);
+
+    // ctor allocates every column but marks none.
+    EXPECT_TRUE(ir.get_data_field_ids(*schema).empty());
+    EXPECT_FALSE(ir.materialized(FieldId(101)));
+
+    // Materialize pk(100) and f1(101); leave f2(102) allocated-but-unwritten.
+    constexpr int N = 2;
+    std::vector<int64_t> v100 = {1, 2};
+    std::vector<int64_t> v101 = {3, 4};
+    auto a100 =
+        CreateDataArrayFrom(v100.data(), nullptr, N, (*schema)[FieldId(100)]);
+    auto a101 =
+        CreateDataArrayFrom(v101.data(), nullptr, N, (*schema)[FieldId(101)]);
+    ir.get_data_base(FieldId(100))
+        ->set_data_raw(0, N, a100.get(), (*schema)[FieldId(100)]);
+    ir.get_data_base(FieldId(101))
+        ->set_data_raw(0, N, a101.get(), (*schema)[FieldId(101)]);
+
+    EXPECT_TRUE(ir.materialized(FieldId(100)));
+    EXPECT_TRUE(ir.materialized(FieldId(101)));
+    EXPECT_FALSE(ir.materialized(FieldId(102)));   // allocated, never written
+    EXPECT_FALSE(ir.materialized(FieldId(9999)));  // absent from data_
+
+    // Full schema: written fields kept, unwritten f2 dropped.
+    auto ids = ir.get_data_field_ids(*schema);
+    EXPECT_TRUE(has(ids, 100));
+    EXPECT_TRUE(has(ids, 101));
+    EXPECT_FALSE(has(ids, 102));
+
+    // has_field arm: f1 materialized but dropped from the passed schema -> out.
+    auto schema_wo_f1 = Schema::ParseFrom(make_proto(false));
+    auto ids2 = ir.get_data_field_ids(*schema_wo_f1);
+    EXPECT_TRUE(has(ids2, 100));
+    EXPECT_FALSE(has(ids2, 101));
 }


### PR DESCRIPTION
issue: #51344
pr: #51581

Cherry-pick of #51581 to the 3.0 branch.

## Problem
Growing-source flush decided the column-group layout with `entry->empty()`, which dropped an all-null nullable column (created by AddField) from `MaterializedFieldIDs`. The committed manifest then missed a column group; a later write-buffer SyncTask appended the extra group; Loon rejected the commit with a column-group-count mismatch, which is retried forever and pins the channel checkpoint, so `flush()` times out.

## Fix
Decide flush-layout membership from a **monotonic per-column `materialized` marker** (set at the first `set_data_raw` — insert, all-null bulk fill, or Reopen — and never cleared) instead of `empty()`/`valid_count`. This keeps the all-null column in the layout, removes the concurrent insert/flush layout race (mutable chunk state read mid-`set_data_raw`), and survives interim-index raw-vector removal. Also fixes a `get_schema()` UAF by snapshotting the schema under `sch_mutex_`.

See #51581 for the full review discussion (including the known dropped-field follow-up, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
