### PR TITLE
fix: [cp3.0] use correct MinIO root path in text LOB layout test

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_text_lob.py
+++ b/tests/python_client/milvus_client/test_milvus_client_text_lob.py
@@ -2345,7 +2345,7 @@ class TestMilvusClientTextLOBEnvironmentGated(TestMilvusClientV2Base):
         assert threshold > 0, f"MILVUS_TEXT_INLINE_THRESHOLD must be positive, got {threshold}"
         minio_client = new_minio_client(minio_host)
         ensure_minio_bucket(minio_client, minio_bucket)
-        root_path = os.getenv("MILVUS_MINIO_ROOT_PATH", "files")
+        root_path = os.getenv("MILVUS_MINIO_ROOT_PATH", "file")
 
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()


### PR DESCRIPTION
Cherry-pick from master
pr: #51535

## Summary

Use the correct default MinIO root path (`file`) in the text LOB layout test so it can locate persisted insert logs in nightly deployments.

issue: #51257

## Test Plan

- [x] Verified the cherry-picked patch matches PR #51535 by stable patch ID.
- [x] Parsed the modified Python file successfully.
- [x] `git diff --check` passes.