### PR TITLE
fix: support empty array expression templates

### DIFF
--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -90,6 +90,33 @@ func (s *SearchOptionSuite) TestBasic() {
 	s.Error(err)
 }
 
+func (s *SearchOptionSuite) TestTemplateArrayParams() {
+	req, err := NewSearchOption(
+		"template_array_params",
+		10,
+		[]entity.Vector{entity.FloatVector([]float32{0.1, 0.2})},
+	).
+		WithFilter("array_contains_any(tags, {generic_empty})").
+		WithTemplateParam("generic_empty", []any{}).
+		WithTemplateParam("nested", [][]int64{{1, 2}, {3, 4}}).
+		WithTemplateParam("nested_empty", [][]int64{{}}).
+		Request()
+	s.Require().NoError(err)
+
+	genericEmpty := req.GetExprTemplateValues()["generic_empty"].GetArrayVal()
+	s.Require().NotNil(genericEmpty)
+	s.Nil(genericEmpty.GetData())
+
+	nested := req.GetExprTemplateValues()["nested"].GetArrayVal().GetArrayData().GetData()
+	s.Require().Len(nested, 2)
+	s.Equal([]int64{1, 2}, nested[0].GetLongData().GetData())
+	s.Equal([]int64{3, 4}, nested[1].GetLongData().GetData())
+
+	nestedEmpty := req.GetExprTemplateValues()["nested_empty"].GetArrayVal().GetArrayData().GetData()
+	s.Require().Len(nestedEmpty, 1)
+	s.Nil(nestedEmpty[0].GetData())
+}
+
 func (s *SearchOptionSuite) TestWithNamespace() {
 	collName := "namespace_read_option"
 	namespace := "tenant_a"
@@ -457,13 +484,44 @@ func TestAny2TmplValue(t *testing.T) {
 				assert.EqualValues(t, v[i], val)
 			}
 		})
+
+		t.Run("interface", func(t *testing.T) {
+			val, err := any2TmplValue([]any{int64(1), int32(2)})
+			assert.NoError(t, err)
+			assert.Equal(t, []int64{1, 2}, val.GetArrayVal().GetLongData().GetData())
+		})
+
+		t.Run("empty interface", func(t *testing.T) {
+			val, err := any2TmplValue([]any{})
+			assert.NoError(t, err)
+			assert.Nil(t, val.GetArrayVal().GetData())
+		})
+
+		t.Run("nested", func(t *testing.T) {
+			val, err := any2TmplValue([][]int64{{1, 2}, {3, 4}})
+			assert.NoError(t, err)
+
+			data := val.GetArrayVal().GetArrayData().GetData()
+			assert.Len(t, data, 2)
+			assert.Equal(t, []int64{1, 2}, data[0].GetLongData().GetData())
+			assert.Equal(t, []int64{3, 4}, data[1].GetLongData().GetData())
+		})
+
+		t.Run("nested empty", func(t *testing.T) {
+			val, err := any2TmplValue([]any{[]any{}})
+			assert.NoError(t, err)
+
+			data := val.GetArrayVal().GetArrayData().GetData()
+			assert.Len(t, data, 1)
+			assert.Nil(t, data[0].GetData())
+		})
 	})
 
 	t.Run("unsupported", func(*testing.T) {
 		_, err := any2TmplValue(struct{}{})
 		assert.Error(t, err)
 
-		_, err = any2TmplValue([]struct{}{})
+		_, err = any2TmplValue([]struct{}{{}})
 		assert.Error(t, err)
 
 		_, err = any2TmplValue(nil)

--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -98,14 +98,20 @@ func (s *SearchOptionSuite) TestTemplateArrayParams() {
 	).
 		WithFilter("array_contains_any(tags, {generic_empty})").
 		WithTemplateParam("generic_empty", []any{}).
+		WithTemplateParam("typed_empty", []int64{}).
 		WithTemplateParam("nested", [][]int64{{1, 2}, {3, 4}}).
 		WithTemplateParam("nested_empty", [][]int64{{}}).
+		WithTemplateParam("nested_outer_empty", [][]int64{}).
 		Request()
 	s.Require().NoError(err)
 
 	genericEmpty := req.GetExprTemplateValues()["generic_empty"].GetArrayVal()
 	s.Require().NotNil(genericEmpty)
 	s.Nil(genericEmpty.GetData())
+
+	typedEmpty := req.GetExprTemplateValues()["typed_empty"].GetArrayVal()
+	s.Require().NotNil(typedEmpty.GetLongData())
+	s.Empty(typedEmpty.GetLongData().GetData())
 
 	nested := req.GetExprTemplateValues()["nested"].GetArrayVal().GetArrayData().GetData()
 	s.Require().Len(nested, 2)
@@ -114,7 +120,12 @@ func (s *SearchOptionSuite) TestTemplateArrayParams() {
 
 	nestedEmpty := req.GetExprTemplateValues()["nested_empty"].GetArrayVal().GetArrayData().GetData()
 	s.Require().Len(nestedEmpty, 1)
-	s.Nil(nestedEmpty[0].GetData())
+	s.Require().NotNil(nestedEmpty[0].GetLongData())
+	s.Empty(nestedEmpty[0].GetLongData().GetData())
+
+	nestedOuterEmpty := req.GetExprTemplateValues()["nested_outer_empty"].GetArrayVal()
+	s.Require().NotNil(nestedOuterEmpty.GetArrayData())
+	s.Empty(nestedOuterEmpty.GetArrayData().GetData())
 }
 
 func (s *SearchOptionSuite) TestWithNamespace() {
@@ -497,6 +508,13 @@ func TestAny2TmplValue(t *testing.T) {
 			assert.Nil(t, val.GetArrayVal().GetData())
 		})
 
+		t.Run("empty typed", func(t *testing.T) {
+			val, err := any2TmplValue([]int64{})
+			assert.NoError(t, err)
+			assert.NotNil(t, val.GetArrayVal().GetLongData())
+			assert.Empty(t, val.GetArrayVal().GetLongData().GetData())
+		})
+
 		t.Run("nested", func(t *testing.T) {
 			val, err := any2TmplValue([][]int64{{1, 2}, {3, 4}})
 			assert.NoError(t, err)
@@ -515,13 +533,30 @@ func TestAny2TmplValue(t *testing.T) {
 			assert.Len(t, data, 1)
 			assert.Nil(t, data[0].GetData())
 		})
+
+		t.Run("nested empty typed", func(t *testing.T) {
+			val, err := any2TmplValue([][]int64{{}})
+			assert.NoError(t, err)
+
+			data := val.GetArrayVal().GetArrayData().GetData()
+			assert.Len(t, data, 1)
+			assert.NotNil(t, data[0].GetLongData())
+			assert.Empty(t, data[0].GetLongData().GetData())
+		})
+
+		t.Run("nested outer empty typed", func(t *testing.T) {
+			val, err := any2TmplValue([][]int64{})
+			assert.NoError(t, err)
+			assert.NotNil(t, val.GetArrayVal().GetArrayData())
+			assert.Empty(t, val.GetArrayVal().GetArrayData().GetData())
+		})
 	})
 
 	t.Run("unsupported", func(*testing.T) {
 		_, err := any2TmplValue(struct{}{})
 		assert.Error(t, err)
 
-		_, err = any2TmplValue([]struct{}{{}})
+		_, err = any2TmplValue([]struct{}{})
 		assert.Error(t, err)
 
 		_, err = any2TmplValue(nil)

--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -465,6 +465,9 @@ func TestAny2TmplValue(t *testing.T) {
 
 		_, err = any2TmplValue([]struct{}{})
 		assert.Error(t, err)
+
+		_, err = any2TmplValue(nil)
+		assert.EqualError(t, err, "unsupported template value type: <nil>")
 	})
 }
 

--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -19,6 +19,7 @@ package milvusclient
 import (
 	"fmt"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -561,6 +562,43 @@ func TestAny2TmplValue(t *testing.T) {
 
 		_, err = any2TmplValue(nil)
 		assert.EqualError(t, err, "unsupported template value type: <nil>")
+	})
+
+	t.Run("invalid array elements", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			value any
+		}{
+			{name: "inconsistent types", value: []any{int64(1), "two"}},
+			{name: "nil integer", value: []any{int64(1), nil}},
+			{name: "nil boolean", value: []any{true, nil}},
+			{name: "nil float", value: []any{float64(1), nil}},
+			{name: "nil string", value: []any{"one", nil}},
+			{name: "nil nested array", value: []any{[]int64{1}, nil}},
+			{name: "invalid nested array element", value: []any{[]any{int64(1)}, []any{nil}}},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := any2TmplValue(tc.value)
+				assert.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("invalid array values", func(t *testing.T) {
+		_, err := slice2TmplArrayValue(reflect.ValueOf(int64(1)))
+		assert.EqualError(t, err, "unsupported template array value type: int64")
+
+		_, _, err = templateArrayElement(reflect.Value{})
+		assert.EqualError(t, err, "unsupported template type: invalid array element")
+
+		nilElement := reflect.ValueOf([]any{nil}).Index(0)
+		_, _, err = templateArrayElement(nilElement)
+		assert.EqualError(t, err, "unsupported template type: nil array element")
+
+		_, _, err = templateArrayElement(reflect.ValueOf(struct{}{}))
+		assert.EqualError(t, err, "unsupported template type: slice of struct")
 	})
 }
 

--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -264,11 +264,18 @@ func slice2TmplArrayValue(rv reflect.Value) (*schemapb.TemplateArrayValue, error
 	}
 
 	result := &schemapb.TemplateArrayValue{}
-	if rv.Len() == 0 {
-		return result, nil
-	}
 
-	_, elementKind, err := templateArrayElement(rv.Index(0))
+	var elementKind reflect.Kind
+	if rv.Len() == 0 {
+		// Preserve the data oneof for typed empty slices so older servers can
+		// decode them. An empty interface slice has no encodable element type.
+		if rv.Type().Elem().Kind() == reflect.Interface {
+			return result, nil
+		}
+		elementKind, err = normalizeTemplateArrayElementKind(rv.Type().Elem().Kind())
+	} else {
+		_, elementKind, err = templateArrayElement(rv.Index(0))
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -365,21 +372,29 @@ func templateArrayElement(rv reflect.Value) (reflect.Value, reflect.Kind, error)
 		return reflect.Value{}, reflect.Invalid, err
 	}
 
-	switch rv.Kind() {
+	kind, err := normalizeTemplateArrayElementKind(rv.Kind())
+	if err != nil {
+		return reflect.Value{}, reflect.Invalid, err
+	}
+	return rv, kind, nil
+}
+
+func normalizeTemplateArrayElementKind(kind reflect.Kind) (reflect.Kind, error) {
+	switch kind {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return rv, reflect.Int64, nil
+		return reflect.Int64, nil
 	case reflect.Bool:
-		return rv, reflect.Bool, nil
+		return reflect.Bool, nil
 	case reflect.Float32, reflect.Float64:
-		return rv, reflect.Float64, nil
+		return reflect.Float64, nil
 	case reflect.String:
-		return rv, reflect.String, nil
+		return reflect.String, nil
 	case reflect.Slice:
-		return rv, reflect.Slice, nil
+		return reflect.Slice, nil
 	default:
-		return reflect.Value{}, reflect.Invalid, fmt.Errorf(
+		return reflect.Invalid, fmt.Errorf(
 			"unsupported template type: slice of %v",
-			rv.Kind(),
+			kind,
 		)
 	}
 }

--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -242,55 +242,159 @@ func slice2TmplValue(val any) (*schemapb.TemplateValue, error) {
 		return &schemapb.TemplateValue{Val: arrVal}, nil
 	}
 
-	rv := reflect.ValueOf(val)
-	switch t := reflect.TypeOf(val).Elem().Kind(); t {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		data := make([]int64, 0, rv.Len())
-		for i := 0; i < rv.Len(); i++ {
-			data = append(data, rv.Index(i).Int())
-		}
-		arrVal.ArrayVal.Data = &schemapb.TemplateArrayValue_LongData{
-			LongData: &schemapb.LongArray{
-				Data: data,
-			},
-		}
-	case reflect.Bool:
-		data := make([]bool, 0, rv.Len())
-		for i := 0; i < rv.Len(); i++ {
-			data = append(data, rv.Index(i).Bool())
-		}
-		arrVal.ArrayVal.Data = &schemapb.TemplateArrayValue_BoolData{
-			BoolData: &schemapb.BoolArray{
-				Data: data,
-			},
-		}
-	case reflect.Float32, reflect.Float64:
-		data := make([]float64, 0, rv.Len())
-		for i := 0; i < rv.Len(); i++ {
-			data = append(data, rv.Index(i).Float())
-		}
-		arrVal.ArrayVal.Data = &schemapb.TemplateArrayValue_DoubleData{
-			DoubleData: &schemapb.DoubleArray{
-				Data: data,
-			},
-		}
-	case reflect.String:
-		data := make([]string, 0, rv.Len())
-		for i := 0; i < rv.Len(); i++ {
-			data = append(data, rv.Index(i).String())
-		}
-		arrVal.ArrayVal.Data = &schemapb.TemplateArrayValue_StringData{
-			StringData: &schemapb.StringArray{
-				Data: data,
-			},
-		}
-	default:
-		return nil, fmt.Errorf("unsupported template type: slice of %v", t)
+	arrayVal, err := slice2TmplArrayValue(reflect.ValueOf(val))
+	if err != nil {
+		return nil, err
 	}
 
 	return &schemapb.TemplateValue{
-		Val: arrVal,
+		Val: &schemapb.TemplateValue_ArrayVal{
+			ArrayVal: arrayVal,
+		},
 	}, nil
+}
+
+func slice2TmplArrayValue(rv reflect.Value) (*schemapb.TemplateArrayValue, error) {
+	rv, err := unwrapTemplateArrayElement(rv)
+	if err != nil {
+		return nil, err
+	}
+	if rv.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("unsupported template array value type: %v", rv.Kind())
+	}
+
+	result := &schemapb.TemplateArrayValue{}
+	if rv.Len() == 0 {
+		return result, nil
+	}
+
+	_, elementKind, err := templateArrayElement(rv.Index(0))
+	if err != nil {
+		return nil, err
+	}
+
+	elementAt := func(index int) (reflect.Value, error) {
+		element, kind, err := templateArrayElement(rv.Index(index))
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		if kind != elementKind {
+			return reflect.Value{}, fmt.Errorf(
+				"template array elements have inconsistent types: %v and %v",
+				elementKind,
+				kind,
+			)
+		}
+		return element, nil
+	}
+
+	switch elementKind {
+	case reflect.Int64:
+		data := make([]int64, rv.Len())
+		for i := range data {
+			element, err := elementAt(i)
+			if err != nil {
+				return nil, err
+			}
+			data[i] = element.Int()
+		}
+		result.Data = &schemapb.TemplateArrayValue_LongData{
+			LongData: &schemapb.LongArray{Data: data},
+		}
+	case reflect.Bool:
+		data := make([]bool, rv.Len())
+		for i := range data {
+			element, err := elementAt(i)
+			if err != nil {
+				return nil, err
+			}
+			data[i] = element.Bool()
+		}
+		result.Data = &schemapb.TemplateArrayValue_BoolData{
+			BoolData: &schemapb.BoolArray{Data: data},
+		}
+	case reflect.Float64:
+		data := make([]float64, rv.Len())
+		for i := range data {
+			element, err := elementAt(i)
+			if err != nil {
+				return nil, err
+			}
+			data[i] = element.Float()
+		}
+		result.Data = &schemapb.TemplateArrayValue_DoubleData{
+			DoubleData: &schemapb.DoubleArray{Data: data},
+		}
+	case reflect.String:
+		data := make([]string, rv.Len())
+		for i := range data {
+			element, err := elementAt(i)
+			if err != nil {
+				return nil, err
+			}
+			data[i] = element.String()
+		}
+		result.Data = &schemapb.TemplateArrayValue_StringData{
+			StringData: &schemapb.StringArray{Data: data},
+		}
+	case reflect.Slice:
+		data := make([]*schemapb.TemplateArrayValue, rv.Len())
+		for i := range data {
+			element, err := elementAt(i)
+			if err != nil {
+				return nil, err
+			}
+			data[i], err = slice2TmplArrayValue(element)
+			if err != nil {
+				return nil, err
+			}
+		}
+		result.Data = &schemapb.TemplateArrayValue_ArrayData{
+			ArrayData: &schemapb.TemplateArrayValueArray{Data: data},
+		}
+	default:
+		return nil, fmt.Errorf("unsupported template type: slice of %v", elementKind)
+	}
+
+	return result, nil
+}
+
+func templateArrayElement(rv reflect.Value) (reflect.Value, reflect.Kind, error) {
+	rv, err := unwrapTemplateArrayElement(rv)
+	if err != nil {
+		return reflect.Value{}, reflect.Invalid, err
+	}
+
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return rv, reflect.Int64, nil
+	case reflect.Bool:
+		return rv, reflect.Bool, nil
+	case reflect.Float32, reflect.Float64:
+		return rv, reflect.Float64, nil
+	case reflect.String:
+		return rv, reflect.String, nil
+	case reflect.Slice:
+		return rv, reflect.Slice, nil
+	default:
+		return reflect.Value{}, reflect.Invalid, fmt.Errorf(
+			"unsupported template type: slice of %v",
+			rv.Kind(),
+		)
+	}
+}
+
+func unwrapTemplateArrayElement(rv reflect.Value) (reflect.Value, error) {
+	for rv.IsValid() && rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return reflect.Value{}, fmt.Errorf("unsupported template type: nil array element")
+		}
+		rv = rv.Elem()
+	}
+	if !rv.IsValid() {
+		return reflect.Value{}, fmt.Errorf("unsupported template type: invalid array element")
+	}
+	return rv, nil
 }
 
 func (r *AnnRequest) WithANNSField(annsField string) *AnnRequest {

--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -204,7 +204,8 @@ func any2TmplValue(val any) (*schemapb.TemplateValue, error) {
 		// base64 inflation.
 		result.Val = &schemapb.TemplateValue_BytesVal{BytesVal: v}
 	default:
-		if reflect.TypeOf(val).Kind() == reflect.Slice {
+		valueType := reflect.TypeOf(val)
+		if valueType != nil && valueType.Kind() == reflect.Slice {
 			return slice2TmplValue(val)
 		}
 		return nil, fmt.Errorf("unsupported template value type: %T", val)

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1406,7 +1406,11 @@ func (h *HandlersV2) query(ctx context.Context, c *gin.Context, anyReq any, dbNa
 		})
 		return nil, err
 	}
-	req.ExprTemplateValues = generateExpressionTemplate(httpReq.ExprParams)
+	req.ExprTemplateValues, err = generateExpressionTemplate(httpReq.ExprParams)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
 	c.Set(ContextRequest, req)
 	if httpReq.Offset > 0 {
 		req.QueryParams = append(req.QueryParams, &commonpb.KeyValuePair{Key: proxy.OffsetKey, Value: strconv.FormatInt(int64(httpReq.Offset), 10)})
@@ -1533,7 +1537,11 @@ func (h *HandlersV2) delete(ctx context.Context, c *gin.Context, anyReq any, dbN
 		PartitionName:  httpReq.PartitionName,
 		Expr:           httpReq.Filter,
 	}
-	req.ExprTemplateValues = generateExpressionTemplate(httpReq.ExprParams)
+	req.ExprTemplateValues, err = generateExpressionTemplate(httpReq.ExprParams)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
 	c.Set(ContextRequest, req)
 	if req.Expr == "" {
 		body, _ := c.Get(gin.BodyBytesKey)
@@ -1992,7 +2000,11 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 	}
 
 	req.SearchParams = searchParams
-	req.ExprTemplateValues = generateExpressionTemplate(httpReq.ExprParams)
+	req.ExprTemplateValues, err = generateExpressionTemplate(httpReq.ExprParams)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
 	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/Search", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.Search(reqCtx, req.(*milvuspb.SearchRequest))
 	})
@@ -2165,7 +2177,11 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 			PartitionNames: httpReq.PartitionNames,
 			SearchParams:   searchParams,
 		}
-		searchReq.ExprTemplateValues = generateExpressionTemplate(subReq.ExprParams)
+		searchReq.ExprTemplateValues, err = generateExpressionTemplate(subReq.ExprParams)
+		if err != nil {
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
 		req.Requests = append(req.Requests, searchReq)
 	}
 

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3826,6 +3826,150 @@ func TestDML(t *testing.T) {
 	validateTestCases(t, testEngine, queryTestCases, false)
 }
 
+func TestEmptyArrayExprParamsForwardedToProxy(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	hasEmptyTemplate := func(values map[string]*schemapb.TemplateValue) bool {
+		value, ok := values["ids"]
+		return ok && value.GetArrayVal() != nil && value.GetArrayVal().GetData() == nil
+	}
+	describeResponse := &milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}
+
+	t.Run("query", func(t *testing.T) {
+		mp := mocks.NewMockProxy(t)
+		mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(describeResponse, nil).Once()
+		mp.EXPECT().Query(mock.Anything, mock.MatchedBy(func(req *milvuspb.QueryRequest) bool {
+			return hasEmptyTemplate(req.GetExprTemplateValues())
+		})).Return(&milvuspb.QueryResults{Status: commonSuccessStatus}, nil).Once()
+
+		testcase := requestBodyTestCase{
+			path:        versionalV2(EntityCategory, QueryAction),
+			requestBody: []byte(`{"collectionName":"book","filter":"book_id in {ids}","exprParams":{"ids":[]},"limit":10}`),
+		}
+		sendReqAndVerify(t, initHTTPServerV2(mp, false), testcase.path, http.MethodPost, testcase)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		mp := mocks.NewMockProxy(t)
+		mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(describeResponse, nil).Once()
+		mp.EXPECT().Delete(mock.Anything, mock.MatchedBy(func(req *milvuspb.DeleteRequest) bool {
+			return hasEmptyTemplate(req.GetExprTemplateValues())
+		})).Return(&milvuspb.MutationResult{Status: commonSuccessStatus}, nil).Once()
+
+		testcase := requestBodyTestCase{
+			path:        versionalV2(EntityCategory, DeleteAction),
+			requestBody: []byte(`{"collectionName":"book","filter":"book_id in {ids}","exprParams":{"ids":[]}}`),
+		}
+		sendReqAndVerify(t, initHTTPServerV2(mp, false), testcase.path, http.MethodPost, testcase)
+	})
+
+	t.Run("search", func(t *testing.T) {
+		mp := mocks.NewMockProxy(t)
+		mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(describeResponse, nil).Once()
+		mp.EXPECT().Search(mock.Anything, mock.MatchedBy(func(req *milvuspb.SearchRequest) bool {
+			return hasEmptyTemplate(req.GetExprTemplateValues())
+		})).Return(&milvuspb.SearchResults{
+			Status:  commonSuccessStatus,
+			Results: &schemapb.SearchResultData{TopK: 0},
+		}, nil).Once()
+
+		testcase := requestBodyTestCase{
+			path:        versionalV2(EntityCategory, SearchAction),
+			requestBody: []byte(`{"collectionName":"book","data":[[0.1,0.2]],"filter":"book_id in {ids}","exprParams":{"ids":[]},"limit":3}`),
+		}
+		sendReqAndVerify(t, initHTTPServerV2(mp, false), testcase.path, http.MethodPost, testcase)
+	})
+
+	t.Run("hybrid search", func(t *testing.T) {
+		mp := mocks.NewMockProxy(t)
+		mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(describeResponse, nil).Once()
+		mp.EXPECT().HybridSearch(mock.Anything, mock.MatchedBy(func(req *milvuspb.HybridSearchRequest) bool {
+			return len(req.GetRequests()) == 1 && hasEmptyTemplate(req.GetRequests()[0].GetExprTemplateValues())
+		})).Return(&milvuspb.SearchResults{
+			Status:  commonSuccessStatus,
+			Results: &schemapb.SearchResultData{TopK: 0},
+		}, nil).Once()
+
+		testcase := requestBodyTestCase{
+			path: versionalV2(EntityCategory, HybridSearchAction),
+			requestBody: []byte(`{"collectionName":"book","search":[` +
+				`{"data":[[0.1,0.2]],"annsField":"book_intro","filter":"book_id in {ids}","exprParams":{"ids":[]},"metricType":"L2","limit":3}` +
+				`],"rerank":{"strategy":"rrf","params":{}}}`),
+		}
+		sendReqAndVerify(t, initHTTPServerV2(mp, false), testcase.path, http.MethodPost, testcase)
+	})
+}
+
+func TestInvalidExprParamsRejectBeforeProxyDispatch(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	testCases := []struct {
+		name        string
+		path        string
+		body        string
+		proxyMethod string
+	}{
+		{
+			name:        "query null",
+			path:        versionalV2(EntityCategory, QueryAction),
+			body:        `{"collectionName":"book","filter":"book_id in {ids}","exprParams":{"ids":null},"limit":10}`,
+			proxyMethod: "Query",
+		},
+		{
+			name:        "delete object",
+			path:        versionalV2(EntityCategory, DeleteAction),
+			body:        `{"collectionName":"book","filter":"book_id in {ids}","exprParams":{"ids":{"nested":"value"}}}`,
+			proxyMethod: "Delete",
+		},
+		{
+			name:        "search null",
+			path:        versionalV2(EntityCategory, SearchAction),
+			body:        `{"collectionName":"book","data":[[0.1,0.2]],"filter":"book_id in {ids}","exprParams":{"ids":null},"limit":3}`,
+			proxyMethod: "Search",
+		},
+		{
+			name: "hybrid search object",
+			path: versionalV2(EntityCategory, HybridSearchAction),
+			body: `{"collectionName":"book","search":[` +
+				`{"data":[[0.1,0.2]],"annsField":"book_intro","filter":"book_id in {ids}","exprParams":{"ids":{"nested":"value"}},"metricType":"L2","limit":3}` +
+				`],"rerank":{"strategy":"rrf","params":{}}}`,
+			proxyMethod: "HybridSearch",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			mp := mocks.NewMockProxy(t)
+			mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+				CollectionName: DefaultCollectionName,
+				Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+				ShardsNum:      ShardNumDefault,
+				Status:         &StatusSuccess,
+			}, nil).Once()
+
+			req := httptest.NewRequest(http.MethodPost, testCase.path, bytes.NewReader([]byte(testCase.body)))
+			w := httptest.NewRecorder()
+			initHTTPServerV2(mp, false).ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), returnBody))
+			assert.Equal(t, merr.Code(merr.ErrParameterInvalid), returnBody.Code)
+			assert.Contains(t, returnBody.Message, "unsupported exprParams value type")
+			mp.AssertNotCalled(t, testCase.proxyMethod, mock.Anything, mock.Anything)
+		})
+	}
+}
+
 func TestQueryOrderByFields(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -3379,8 +3379,15 @@ func RequestHandlerFunc(c *gin.Context) {
 	c.Next()
 }
 
-func generateTemplateArrayData(list []interface{}) *schemapb.TemplateArrayValue {
-	dtype := getTemplateArrayType(list)
+func generateTemplateArrayData(list []interface{}) (*schemapb.TemplateArrayValue, error) {
+	if len(list) == 0 {
+		return &schemapb.TemplateArrayValue{}, nil
+	}
+
+	dtype, err := getTemplateArrayType(list)
+	if err != nil {
+		return nil, err
+	}
 	var data *schemapb.TemplateArrayValue
 	switch dtype {
 	case schemapb.DataType_Bool:
@@ -3434,7 +3441,11 @@ func generateTemplateArrayData(list []interface{}) *schemapb.TemplateArrayValue 
 	case schemapb.DataType_Array:
 		result := make([]*schemapb.TemplateArrayValue, len(list))
 		for i, item := range list {
-			result[i] = generateTemplateArrayData(item.([]interface{}))
+			arrayData, err := generateTemplateArrayData(item.([]interface{}))
+			if err != nil {
+				return nil, err
+			}
+			result[i] = arrayData
 		}
 		data = &schemapb.TemplateArrayValue{
 			Data: &schemapb.TemplateArrayValue_ArrayData{
@@ -3447,9 +3458,8 @@ func generateTemplateArrayData(list []interface{}) *schemapb.TemplateArrayValue 
 		result := make([][]byte, len(list))
 		for i, item := range list {
 			bytes, err := json.Marshal(item)
-			// won't happen
 			if err != nil {
-				panic(fmt.Sprintf("marshal data(%v) fail, please check it!", item))
+				return nil, merr.WrapErrParameterInvalidErr(err, "failed to marshal exprParams array value")
 			}
 			result[i] = bytes
 		}
@@ -3460,52 +3470,65 @@ func generateTemplateArrayData(list []interface{}) *schemapb.TemplateArrayValue 
 				},
 			},
 		}
-	// won't happen
 	default:
-		panic(fmt.Sprintf("Unexpected data(%v) type when generateTemplateArrayData, please check it!", list))
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported exprParams array value type %s", dtype.String())
 	}
-	return data
+	return data, nil
 }
 
-func getTemplateArrayType(value []interface{}) schemapb.DataType {
-	dtype := getTemplateType(value[0])
+func getTemplateArrayType(value []interface{}) (schemapb.DataType, error) {
+	if len(value) == 0 {
+		return schemapb.DataType_None, nil
+	}
+
+	dtype, err := getTemplateType(value[0])
+	if err != nil {
+		return schemapb.DataType_None, err
+	}
 
 	for _, v := range value {
-		if getTemplateType(v) != dtype {
-			return schemapb.DataType_JSON
+		itemType, err := getTemplateType(v)
+		if err != nil {
+			return schemapb.DataType_None, err
+		}
+		if itemType != dtype {
+			return schemapb.DataType_JSON, nil
 		}
 	}
-	return dtype
+	return dtype, nil
 }
 
-func getTemplateType(value interface{}) schemapb.DataType {
+func getTemplateType(value interface{}) (schemapb.DataType, error) {
 	switch v := value.(type) {
 	case bool:
-		return schemapb.DataType_Bool
+		return schemapb.DataType_Bool, nil
 	case string:
-		return schemapb.DataType_String
+		return schemapb.DataType_String, nil
 	case float64:
 		// note: all passed number is float64 type
 		// if field type is float64, but value in ExpressionTemplate is int64, it's ok to use TemplateValue_Int64Val to store it
 		// it will convert to float64 in ./internal/parser/planparserv2/utils.go, Line 233
 		if v == math.Trunc(v) && v >= math.MinInt64 && v <= math.MaxInt64 {
-			return schemapb.DataType_Int64
+			return schemapb.DataType_Int64, nil
 		}
-		return schemapb.DataType_Float
+		return schemapb.DataType_Float, nil
 	// it won't happen
 	// case int64:
 	case []interface{}:
-		return schemapb.DataType_Array
+		return schemapb.DataType_Array, nil
 	default:
-		panic(fmt.Sprintf("Unexpected data(%v) when getTemplateType, please check it!", value))
+		return schemapb.DataType_None, merr.WrapErrParameterInvalidMsg("unsupported exprParams value type %T", value)
 	}
 }
 
-func generateExpressionTemplate(params map[string]interface{}) map[string]*schemapb.TemplateValue {
+func generateExpressionTemplate(params map[string]interface{}) (map[string]*schemapb.TemplateValue, error) {
 	expressionTemplate := make(map[string]*schemapb.TemplateValue, len(params))
 
 	for name, value := range params {
-		dtype := getTemplateType(value)
+		dtype, err := getTemplateType(value)
+		if err != nil {
+			return nil, err
+		}
 		var data *schemapb.TemplateValue
 		switch dtype {
 		case schemapb.DataType_Bool:
@@ -3533,17 +3556,21 @@ func generateExpressionTemplate(params map[string]interface{}) map[string]*schem
 				},
 			}
 		case schemapb.DataType_Array:
+			arrayData, err := generateTemplateArrayData(value.([]interface{}))
+			if err != nil {
+				return nil, err
+			}
 			data = &schemapb.TemplateValue{
 				Val: &schemapb.TemplateValue_ArrayVal{
-					ArrayVal: generateTemplateArrayData(value.([]interface{})),
+					ArrayVal: arrayData,
 				},
 			}
 		default:
-			panic(fmt.Sprintf("Unexpected data(%v) when generateExpressionTemplate, please check it!", data))
+			return nil, merr.WrapErrParameterInvalidMsg("unsupported exprParams value type %s", dtype.String())
 		}
 		expressionTemplate[name] = data
 	}
-	return expressionTemplate
+	return expressionTemplate, nil
 }
 
 func WrapErrorToResponse(err error) *milvuspb.BoolResponse {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -3477,10 +3477,6 @@ func generateTemplateArrayData(list []interface{}) (*schemapb.TemplateArrayValue
 }
 
 func getTemplateArrayType(value []interface{}) (schemapb.DataType, error) {
-	if len(value) == 0 {
-		return schemapb.DataType_None, nil
-	}
-
 	dtype, err := getTemplateType(value[0])
 	if err != nil {
 		return schemapb.DataType_None, err

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -3202,8 +3202,46 @@ func TestGenerateExpressionTemplate(t *testing.T) {
 		},
 	}
 	for i, template := range expressionTemplates {
-		actual := generateExpressionTemplate(template)
-		assert.Equal(t, actual, ans[i])
+		actual, err := generateExpressionTemplate(template)
+		require.NoError(t, err)
+		assert.Equal(t, ans[i], actual)
+	}
+
+	t.Run("empty array", func(t *testing.T) {
+		actual, err := generateExpressionTemplate(map[string]interface{}{"empty": []interface{}{}})
+		require.NoError(t, err)
+		expected := map[string]*schemapb.TemplateValue{
+			"empty": {
+				Val: &schemapb.TemplateValue_ArrayVal{
+					ArrayVal: &schemapb.TemplateArrayValue{},
+				},
+			},
+		}
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("nested empty arrays", func(t *testing.T) {
+		actual, err := generateExpressionTemplate(map[string]interface{}{
+			"nested": []interface{}{[]interface{}{float64(1)}, []interface{}{}},
+		})
+		require.NoError(t, err)
+
+		arrays := actual["nested"].GetArrayVal().GetArrayData().GetData()
+		require.Len(t, arrays, 2)
+		assert.Equal(t, []int64{1}, arrays[0].GetLongData().GetData())
+		assert.Nil(t, arrays[1].GetData())
+	})
+
+	for name, value := range map[string]interface{}{
+		"null":              nil,
+		"object":            map[string]interface{}{"nested": "value"},
+		"array with null":   []interface{}{nil},
+		"array with object": []interface{}{map[string]interface{}{"nested": "value"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := generateExpressionTemplate(map[string]interface{}{"value": value})
+			assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		})
 	}
 }
 

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -3232,6 +3232,30 @@ func TestGenerateExpressionTemplate(t *testing.T) {
 		assert.Nil(t, arrays[1].GetData())
 	})
 
+	t.Run("invalid array element after valid element", func(t *testing.T) {
+		_, err := generateExpressionTemplate(map[string]interface{}{
+			"value": []interface{}{float64(1), nil},
+		})
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("invalid nested array element", func(t *testing.T) {
+		_, err := generateExpressionTemplate(map[string]interface{}{
+			"value": []interface{}{
+				[]interface{}{float64(1)},
+				[]interface{}{nil},
+			},
+		})
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("unmarshalable mixed array element", func(t *testing.T) {
+		_, err := generateExpressionTemplate(map[string]interface{}{
+			"value": []interface{}{float64(1), "two", func() {}},
+		})
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
 	for name, value := range map[string]interface{}{
 		"null":              nil,
 		"object":            map[string]interface{}{"nested": "value"},

--- a/internal/parser/planparserv2/convert_field_data_to_generic_value.go
+++ b/internal/parser/planparserv2/convert_field_data_to_generic_value.go
@@ -103,6 +103,9 @@ func convertArrayValue(templateName string, templateValue *schemapb.TemplateArra
 			arrayValues[i] = parsedValue
 		}
 		elementType = schemapb.DataType_JSON
+	case nil:
+		arrayValues = make([]*planpb.GenericValue, 0)
+		elementType = schemapb.DataType_None
 	default:
 		return nil, merr.WrapErrQueryPlanMsg("unknown template variable value type: %v", templateValue.GetData())
 	}

--- a/internal/parser/planparserv2/convert_field_data_to_generic_value.go
+++ b/internal/parser/planparserv2/convert_field_data_to_generic_value.go
@@ -103,9 +103,6 @@ func convertArrayValue(templateName string, templateValue *schemapb.TemplateArra
 			arrayValues[i] = parsedValue
 		}
 		elementType = schemapb.DataType_JSON
-	case nil:
-		arrayValues = make([]*planpb.GenericValue, 0)
-		elementType = schemapb.DataType_None
 	default:
 		return nil, merr.WrapErrQueryPlanMsg("unknown template variable value type: %v", templateValue.GetData())
 	}

--- a/internal/parser/planparserv2/convert_field_data_to_generic_value_test.go
+++ b/internal/parser/planparserv2/convert_field_data_to_generic_value_test.go
@@ -130,6 +130,62 @@ func Test_ConvertToGenericValue(t *testing.T) {
 		},
 		{
 			input: map[string]*schemapb.TemplateValue{
+				"empty_array": {
+					Val: &schemapb.TemplateValue_ArrayVal{
+						ArrayVal: &schemapb.TemplateArrayValue{},
+					},
+				},
+			},
+			expect: map[string]*planpb.GenericValue{
+				"empty_array": {
+					Val: &planpb.GenericValue_ArrayVal{
+						ArrayVal: &planpb.Array{
+							Array:       []*planpb.GenericValue{},
+							SameType:    true,
+							ElementType: schemapb.DataType_None,
+						},
+					},
+				},
+			},
+		},
+		{
+			input: map[string]*schemapb.TemplateValue{
+				"nested_empty_array": {
+					Val: &schemapb.TemplateValue_ArrayVal{
+						ArrayVal: &schemapb.TemplateArrayValue{
+							Data: &schemapb.TemplateArrayValue_ArrayData{
+								ArrayData: &schemapb.TemplateArrayValueArray{
+									Data: []*schemapb.TemplateArrayValue{{}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: map[string]*planpb.GenericValue{
+				"nested_empty_array": {
+					Val: &planpb.GenericValue_ArrayVal{
+						ArrayVal: &planpb.Array{
+							Array: []*planpb.GenericValue{
+								{
+									Val: &planpb.GenericValue_ArrayVal{
+										ArrayVal: &planpb.Array{
+											Array:       []*planpb.GenericValue{},
+											SameType:    true,
+											ElementType: schemapb.DataType_None,
+										},
+									},
+								},
+							},
+							SameType:    true,
+							ElementType: schemapb.DataType_Array,
+						},
+					},
+				},
+			},
+		},
+		{
+			input: map[string]*schemapb.TemplateValue{
 				"not_same_array": {
 					Val: &schemapb.TemplateValue_ArrayVal{
 						ArrayVal: &schemapb.TemplateArrayValue{

--- a/internal/parser/planparserv2/convert_field_data_to_generic_value_test.go
+++ b/internal/parser/planparserv2/convert_field_data_to_generic_value_test.go
@@ -140,7 +140,6 @@ func Test_ConvertToGenericValue(t *testing.T) {
 				"empty_array": {
 					Val: &planpb.GenericValue_ArrayVal{
 						ArrayVal: &planpb.Array{
-							Array:       []*planpb.GenericValue{},
 							SameType:    true,
 							ElementType: schemapb.DataType_None,
 						},
@@ -170,7 +169,6 @@ func Test_ConvertToGenericValue(t *testing.T) {
 								{
 									Val: &planpb.GenericValue_ArrayVal{
 										ArrayVal: &planpb.Array{
-											Array:       []*planpb.GenericValue{},
 											SameType:    true,
 											ElementType: schemapb.DataType_None,
 										},

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -282,6 +282,31 @@ func (s *FillExpressionValueSuite) TestWholeArrayTemplateMembershipNormalization
 	}
 }
 
+func (s *FillExpressionValueSuite) TestEmptyArrayTemplate() {
+	emptyArray := generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{})
+	testcases := []testcase{
+		{`Int64Field in {values}`, map[string]*schemapb.TemplateValue{"values": emptyArray}},
+		{`Int64Field not in {values}`, map[string]*schemapb.TemplateValue{"values": emptyArray}},
+		{`array_contains_any(ArrayField, {values})`, map[string]*schemapb.TemplateValue{"values": emptyArray}},
+		{`array_contains_all(ArrayField, {values})`, map[string]*schemapb.TemplateValue{"values": emptyArray}},
+		{`json_contains_any(JSONField["A"], {values})`, map[string]*schemapb.TemplateValue{"values": emptyArray}},
+		{`json_contains_all(JSONField["A"], {values})`, map[string]*schemapb.TemplateValue{"values": emptyArray}},
+		{`Int64Field >= {minimum}`, map[string]*schemapb.TemplateValue{
+			"minimum": generateTemplateValue(schemapb.DataType_Int64, int64(1)),
+			"unused":  emptyArray,
+		}},
+		{`ArrayField in {values}`, map[string]*schemapb.TemplateValue{
+			"values": generateTemplateValue(schemapb.DataType_Array,
+				generateTemplateArrayValue(schemapb.DataType_Array, []*schemapb.TemplateArrayValue{{}})),
+		}},
+	}
+
+	schemaH := newTestSchemaHelper(s.T())
+	for _, c := range testcases {
+		s.assertValidExpr(schemaH, c.expr, c.values)
+	}
+}
+
 func (s *FillExpressionValueSuite) TestUnaryRange() {
 	s.Run("normal case", func() {
 		testcases := []testcase{

--- a/internal/proxy/accesslog/info/util.go
+++ b/internal/proxy/accesslog/info/util.go
@@ -119,6 +119,10 @@ func getLengthFromTemplateValue(tv *schemapb.TemplateValue) int {
 		return len(arrayValues.GetStringData().GetData())
 	case *schemapb.TemplateArrayValue_JsonData:
 		return len(arrayValues.GetJsonData().GetData())
+	case *schemapb.TemplateArrayValue_ArrayData:
+		return len(arrayValues.GetArrayData().GetData())
+	case nil:
+		return 0
 	default:
 		// undefined
 		return -1

--- a/internal/proxy/accesslog/info/util_test.go
+++ b/internal/proxy/accesslog/info/util_test.go
@@ -141,7 +141,23 @@ func TestGetLengthFromTemplateValue(t *testing.T) {
 			},
 		}
 
-		assert.Equal(t, -1, getLengthFromTemplateValue(tv))
+		assert.Equal(t, 0, getLengthFromTemplateValue(tv))
+	})
+
+	t.Run("nested_array", func(t *testing.T) {
+		tv := &schemapb.TemplateValue{
+			Val: &schemapb.TemplateValue_ArrayVal{
+				ArrayVal: &schemapb.TemplateArrayValue{
+					Data: &schemapb.TemplateArrayValue_ArrayData{
+						ArrayData: &schemapb.TemplateArrayValueArray{
+							Data: []*schemapb.TemplateArrayValue{{}, {}},
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, 2, getLengthFromTemplateValue(tv))
 	})
 
 	t.Run("primitive", func(t *testing.T) {

--- a/tests/python_client/milvus_client/test_milvus_client_empty_array_template.py
+++ b/tests/python_client/milvus_client/test_milvus_client_empty_array_template.py
@@ -43,7 +43,8 @@ class TestMilvusClientEmptyArrayTemplate(TestMilvusClientV2Base):
             index_params=index_params,
             consistency_level="Strong",
         )
-        client.insert(
+        self.insert(
+            client,
             collection_name,
             [
                 {"id": 1, "tags": [], "metadata": {"values": []}, "vector": [0.0, 0.0]},
@@ -55,8 +56,8 @@ class TestMilvusClientEmptyArrayTemplate(TestMilvusClientV2Base):
                 },
             ],
         )
-        client.flush(collection_name)
-        client.load_collection(collection_name)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
 
         query_cases = [
             ("id in {values}", "id in []", []),
@@ -75,34 +76,38 @@ class TestMilvusClientEmptyArrayTemplate(TestMilvusClientV2Base):
             ),
         ]
         for template, inline, expected_ids in query_cases:
-            inline_rows = client.query(
+            inline_rows = self.query(
+                client,
                 collection_name,
                 filter=inline,
                 output_fields=["id"],
                 limit=10,
-            )
-            template_rows = client.query(
+            )[0]
+            template_rows = self.query(
+                client,
                 collection_name,
                 filter=template,
                 filter_params={"values": []},
                 output_fields=["id"],
                 limit=10,
-            )
+            )[0]
             assert sorted(row["id"] for row in inline_rows) == expected_ids
             assert sorted(row["id"] for row in template_rows) == expected_ids
 
-        unused_param_rows = client.query(
+        unused_param_rows = self.query(
+            client,
             collection_name,
             filter="id >= {minimum}",
             filter_params={"minimum": 1, "unused": []},
             output_fields=["id"],
             limit=10,
-        )
+        )[0]
         assert sorted(row["id"] for row in unused_param_rows) == [1, 2]
 
         empty_filter = "id in {values}"
         empty_params = {"values": []}
-        search_result = client.search(
+        search_result = self.search(
+            client,
             collection_name,
             data=[[0.0, 0.0]],
             anns_field="vector",
@@ -111,7 +116,7 @@ class TestMilvusClientEmptyArrayTemplate(TestMilvusClientV2Base):
             filter_params=empty_params,
             output_fields=["id"],
             limit=2,
-        )[0]
+        )[0][0]
         assert search_result == []
 
         hybrid_request = AnnSearchRequest(
@@ -122,24 +127,27 @@ class TestMilvusClientEmptyArrayTemplate(TestMilvusClientV2Base):
             expr=empty_filter,
             expr_params=empty_params,
         )
-        hybrid_result = client.hybrid_search(
+        hybrid_result = self.hybrid_search(
+            client,
             collection_name,
             [hybrid_request],
             WeightedRanker(1.0),
             limit=2,
             output_fields=["id"],
-        )[0]
+        )[0][0]
         assert hybrid_result == []
 
-        client.delete(
+        self.delete(
+            client,
             collection_name,
             filter=empty_filter,
             filter_params=empty_params,
         )
-        remaining_rows = client.query(
+        remaining_rows = self.query(
+            client,
             collection_name,
             filter="id >= 1",
             output_fields=["id"],
             limit=10,
-        )
+        )[0]
         assert sorted(row["id"] for row in remaining_rows) == [1, 2]

--- a/tests/python_client/milvus_client/test_milvus_client_empty_array_template.py
+++ b/tests/python_client/milvus_client/test_milvus_client_empty_array_template.py
@@ -1,0 +1,145 @@
+import pytest
+from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common.common_type import CaseLabel
+from pymilvus import AnnSearchRequest, DataType, WeightedRanker
+
+
+class TestMilvusClientEmptyArrayTemplate(TestMilvusClientV2Base):
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_empty_array_template_across_dml_apis(self):
+        """
+        target: verify empty array filter templates match inline empty array semantics
+        method: exercise scalar, Array, and JSON predicates through query, search, hybrid search, and delete
+        expected: every API accepts the template and returns the same result set as the inline expression
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field(
+            "tags",
+            DataType.ARRAY,
+            element_type=DataType.VARCHAR,
+            max_capacity=8,
+            max_length=64,
+        )
+        schema.add_field("metadata", DataType.JSON)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=2)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            "vector",
+            index_type="HNSW",
+            metric_type="L2",
+            params={"M": 8, "efConstruction": 64},
+        )
+
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level="Strong",
+        )
+        client.insert(
+            collection_name,
+            [
+                {"id": 1, "tags": [], "metadata": {"values": []}, "vector": [0.0, 0.0]},
+                {
+                    "id": 2,
+                    "tags": ["blue"],
+                    "metadata": {"values": ["blue"]},
+                    "vector": [1.0, 1.0],
+                },
+            ],
+        )
+        client.flush(collection_name)
+        client.load_collection(collection_name)
+
+        query_cases = [
+            ("id in {values}", "id in []", []),
+            ("id not in {values}", "id not in []", [1, 2]),
+            ("array_contains_any(tags, {values})", "array_contains_any(tags, [])", []),
+            ("array_contains_all(tags, {values})", "array_contains_all(tags, [])", [1, 2]),
+            (
+                'json_contains_any(metadata["values"], {values})',
+                'json_contains_any(metadata["values"], [])',
+                [],
+            ),
+            (
+                'json_contains_all(metadata["values"], {values})',
+                'json_contains_all(metadata["values"], [])',
+                [1, 2],
+            ),
+        ]
+        for template, inline, expected_ids in query_cases:
+            inline_rows = client.query(
+                collection_name,
+                filter=inline,
+                output_fields=["id"],
+                limit=10,
+            )
+            template_rows = client.query(
+                collection_name,
+                filter=template,
+                filter_params={"values": []},
+                output_fields=["id"],
+                limit=10,
+            )
+            assert sorted(row["id"] for row in inline_rows) == expected_ids
+            assert sorted(row["id"] for row in template_rows) == expected_ids
+
+        unused_param_rows = client.query(
+            collection_name,
+            filter="id >= {minimum}",
+            filter_params={"minimum": 1, "unused": []},
+            output_fields=["id"],
+            limit=10,
+        )
+        assert sorted(row["id"] for row in unused_param_rows) == [1, 2]
+
+        empty_filter = "id in {values}"
+        empty_params = {"values": []}
+        search_result = client.search(
+            collection_name,
+            data=[[0.0, 0.0]],
+            anns_field="vector",
+            search_params={"metric_type": "L2", "params": {"ef": 16}},
+            filter=empty_filter,
+            filter_params=empty_params,
+            output_fields=["id"],
+            limit=2,
+        )[0]
+        assert search_result == []
+
+        hybrid_request = AnnSearchRequest(
+            data=[[0.0, 0.0]],
+            anns_field="vector",
+            param={"metric_type": "L2", "params": {"ef": 16}},
+            limit=2,
+            expr=empty_filter,
+            expr_params=empty_params,
+        )
+        hybrid_result = client.hybrid_search(
+            collection_name,
+            [hybrid_request],
+            WeightedRanker(1.0),
+            limit=2,
+            output_fields=["id"],
+        )[0]
+        assert hybrid_result == []
+
+        client.delete(
+            collection_name,
+            filter=empty_filter,
+            filter_params=empty_params,
+        )
+        remaining_rows = client.query(
+            collection_name,
+            filter="id >= 1",
+            output_fields=["id"],
+            limit=10,
+        )
+        assert sorted(row["id"] for row in remaining_rows) == [1, 2]


### PR DESCRIPTION
issue: #51617

## What this PR does

- Preserve empty array expression template parameters instead of treating them as unknown values.
- Keep empty and nested arrays intact through REST and Go SDK conversion paths, and return parameter errors for unsupported nil/object values instead of panicking.
- Report empty and nested array parameter lengths correctly in access logs.
- Reject unsupported nested array-valued `IN` operands during planning.
- Add unit and Python E2E coverage for query, search, hybrid search, and delete.

## How this was tested

- Affected Go unit test packages passed with `milvus-dev-cli`.
- Full `internal/parser/planparserv2` tests passed on commit `f29510b`.
- `tests/python_client/milvus_client/test_milvus_client_empty_array_template.py`: `1 passed in 6.18s`.
- Deployed commit `f29510b` and confirmed the server-reported `git_commit`; teardown left no collections.
