### PR TITLE
fix: handle mixed-type JSON term expressions

### DIFF
--- a/internal/core/src/exec/Driver.cpp
+++ b/internal/core/src/exec/Driver.cpp
@@ -17,6 +17,7 @@
 #include "Driver.h"
 
 #include <folly/ExceptionWrapper.h>
+#include <folly/ScopeGuard.h>
 #include <folly/Try.h>
 #include <algorithm>
 #include <atomic>
@@ -235,19 +236,46 @@ Driver::Init(std::unique_ptr<DriverContext> ctx,
 }
 
 void
+Driver::CloseByTask() noexcept {
+    try {
+        Close();
+    } catch (const std::exception& e) {
+        LOG_WARN("Ignore driver cleanup error while terminating task: {}",
+                 e.what());
+    } catch (...) {
+        LOG_WARN("Ignore unknown driver cleanup error while terminating task");
+    }
+}
+
+void
 Driver::Close() {
-    if (closed_) {
+    if (closed_.exchange(true, std::memory_order_acq_rel)) {
         return;
     }
 
+    auto remove_driver_guard = folly::makeGuard(
+        [task = ctx_->task_, this]() { Task::RemoveDriver(task, this); });
+    std::exception_ptr close_error;
     for (auto& op : operators_) {
-        op->WaitPrefetch();
-        op->Close();
+        try {
+            op->WaitPrefetch();
+        } catch (...) {
+            if (close_error == nullptr) {
+                close_error = std::current_exception();
+            }
+        }
+        try {
+            op->Close();
+        } catch (...) {
+            if (close_error == nullptr) {
+                close_error = std::current_exception();
+            }
+        }
     }
 
-    closed_ = true;
-
-    Task::RemoveDriver(ctx_->task_, this);
+    if (close_error != nullptr) {
+        std::rethrow_exception(close_error);
+    }
 }
 
 RowVectorPtr

--- a/internal/core/src/exec/Driver.h
+++ b/internal/core/src/exec/Driver.h
@@ -213,9 +213,7 @@ class Driver : public std::enable_shared_from_this<Driver> {
          std::vector<std::shared_ptr<Operator>> operators);
 
     void
-    CloseByTask() {
-        Close();
-    }
+    CloseByTask() noexcept;
 
  private:
     Driver() = default;

--- a/internal/core/src/exec/Task.cpp
+++ b/internal/core/src/exec/Task.cpp
@@ -147,8 +147,13 @@ Task::CreateDriversLocked(std::shared_ptr<Task>& self,
 
 void
 Task::Terminate(TaskState state) {
-    for (auto& driver : drivers_) {
-        driver->CloseByTask();
+    for (auto& driver_ptr : drivers_) {
+        // RemoveDriver clears the entry while CloseByTask is running. Keep a
+        // local owner so the Driver cannot be destroyed inside its own method.
+        auto driver = driver_ptr;
+        if (driver != nullptr) {
+            driver->CloseByTask();
+        }
     }
 }
 

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -121,18 +121,17 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                       proto::plan::GenericValue::ValCase::kFloatVal) &&
                  (upper_type == proto::plan::GenericValue::ValCase::kInt64Val ||
                   upper_type == proto::plan::GenericValue::ValCase::kFloatVal));
+            const auto has_unsafe_int_bound =
+                is_numeric &&
+                ((lower_type == proto::plan::GenericValue::ValCase::kInt64Val &&
+                  !IsInt64SafeForJsonDoubleIndex(
+                      expr_->lower_val_.int64_val())) ||
+                 (upper_type == proto::plan::GenericValue::ValCase::kInt64Val &&
+                  !IsInt64SafeForJsonDoubleIndex(
+                      expr_->upper_val_.int64_val())));
 
             if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
                 if (is_numeric) {
-                    const auto has_unsafe_int_bound =
-                        (lower_type ==
-                             proto::plan::GenericValue::ValCase::kInt64Val &&
-                         !IsInt64SafeForJsonDoubleIndex(
-                             expr_->lower_val_.int64_val())) ||
-                        (upper_type ==
-                             proto::plan::GenericValue::ValCase::kInt64Val &&
-                         !IsInt64SafeForJsonDoubleIndex(
-                             expr_->upper_val_.int64_val()));
                     if (has_unsafe_int_bound) {
                         result =
                             ExecRangeVisitorImplForJsonPreciseNumeric(context);
@@ -174,7 +173,11 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                                     lower_type));
                 }
             } else {
-                if (is_numeric && use_double) {
+                if (has_unsafe_int_bound &&
+                    (has_offset_input_ ||
+                     exec_path_ != ExprExecPath::JsonStats)) {
+                    result = ExecRangeVisitorImplForJsonPreciseNumeric(context);
+                } else if (is_numeric && use_double) {
                     // Use double when either bound is float
                     result = ExecRangeVisitorImplForJson<double>(context);
                 } else if (lower_type ==

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -536,6 +536,7 @@ TEST(JsonRawScanTest, EmptyInAndLargeInt64KeepThreeValuedSemantics) {
     const std::vector<std::string> json_strs = {R"({"a": 9007199254740992})",
                                                 R"({"a": 9007199254740993})",
                                                 R"({"a": 9007199254740994})",
+                                                R"({"a": 9007199254740992.0})",
                                                 R"({"a": "abc"})",
                                                 R"({})",
                                                 R"({"a": null})",
@@ -551,7 +552,7 @@ TEST(JsonRawScanTest, EmptyInAndLargeInt64KeepThreeValuedSemantics) {
     std::fill(valid_data,
               valid_data + json_field->ValidDataSize(),
               static_cast<uint8_t>(0));
-    valid_data[0] = 0b00111111;
+    valid_data[0] = 0b01111111;
 
     auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
                   .GetRemoteChunkManager();
@@ -593,14 +594,14 @@ TEST(JsonRawScanTest, EmptyInAndLargeInt64KeepThreeValuedSemantics) {
     proto::plan::GenericValue value;
     value.set_int64_val(9007199254740993LL);
     const std::vector<bool> numeric_valid = {
-        true, true, true, false, false, false, false};
+        true, true, true, true, false, false, false, false};
     auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
         expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
         proto::plan::OpType::Equal,
         value,
         std::vector<proto::plan::GenericValue>());
     check(evaluate(equal_expr),
-          {false, true, false, false, false, false, false},
+          {false, true, false, false, false, false, false, false},
           numeric_valid);
 
     auto term_expr = std::make_shared<expr::TermFilterExpr>(
@@ -608,7 +609,7 @@ TEST(JsonRawScanTest, EmptyInAndLargeInt64KeepThreeValuedSemantics) {
         std::vector<proto::plan::GenericValue>{value},
         false);
     check(evaluate(term_expr),
-          {false, true, false, false, false, false, false},
+          {false, true, false, false, false, false, false, false},
           numeric_valid);
 
     auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
@@ -617,7 +618,7 @@ TEST(JsonRawScanTest, EmptyInAndLargeInt64KeepThreeValuedSemantics) {
         value,
         std::vector<proto::plan::GenericValue>());
     check(evaluate(greater_expr),
-          {false, false, true, false, false, false, false},
+          {false, false, true, false, false, false, false, false},
           numeric_valid);
 
     auto between_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
@@ -627,7 +628,7 @@ TEST(JsonRawScanTest, EmptyInAndLargeInt64KeepThreeValuedSemantics) {
         true,
         true);
     check(evaluate(between_expr),
-          {false, true, false, false, false, false, false},
+          {false, true, false, false, false, false, false, false},
           numeric_valid);
 }
 

--- a/internal/core/src/exec/expression/ExprJsonRangeTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonRangeTest.cpp
@@ -31,6 +31,7 @@
 #include "bitset/bitset.h"
 #include "common/Consts.h"
 #include "common/EasyAssert.h"
+#include "common/Exception.h"
 #include "common/IndexMeta.h"
 #include "common/Json.h"
 #include "common/Schema.h"
@@ -83,8 +84,10 @@ TEST(ExprJsonTermTest, MixedValueTypesReturnError) {
     try {
         ExecuteQueryExpr(plan, seg.get(), 1, MAX_TIMESTAMP);
         FAIL() << "mixed TermExpr values must be rejected";
-    } catch (const SegcoreError& error) {
-        EXPECT_EQ(error.get_error_code(), DataTypeInvalid);
+    } catch (const ExecOperatorException& error) {
+        EXPECT_NE(std::string_view(error.what())
+                      .find("TermExpr values must have the same type"),
+                  std::string_view::npos);
     }
 }
 

--- a/internal/core/src/exec/expression/ExprJsonRangeTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonRangeTest.cpp
@@ -54,6 +54,40 @@
 
 EXPR_TEST_INSTANTIATE();
 
+TEST(ExprJsonTermTest, MixedValueTypesReturnError) {
+    auto schema = std::make_shared<Schema>();
+    auto i64_fid = schema->AddDebugField("id", DataType::INT64);
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    schema->set_primary_field_id(i64_fid);
+
+    auto seg = CreateGrowingSegment(schema, empty_index_meta);
+    auto raw_data = DataGen(schema, 1, 0);
+    seg->PreInsert(1);
+    seg->Insert(0,
+                1,
+                raw_data.row_ids_.data(),
+                raw_data.timestamps_.data(),
+                raw_data.raw_);
+
+    proto::plan::GenericValue int_value;
+    int_value.set_int64_val(1);
+    proto::plan::GenericValue string_value;
+    string_value.set_string_val("1");
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"int"}),
+        std::vector<proto::plan::GenericValue>{int_value, string_value},
+        false);
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, term_expr);
+
+    try {
+        ExecuteQueryExpr(plan, seg.get(), 1, MAX_TIMESTAMP);
+        FAIL() << "mixed TermExpr values must be rejected";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), DataTypeInvalid);
+    }
+}
+
 TEST_P(ExprTest, TestBinaryRangeJSON) {
     struct Testcase {
         bool lower_inclusive;

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -183,15 +183,7 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
             break;
         }
         case DataType::JSON: {
-            const auto has_array_literal =
-                std::any_of(expr_->vals_.begin(),
-                            expr_->vals_.end(),
-                            [](const auto& value) {
-                                return value.val_case() ==
-                                       proto::plan::GenericValue::kArrayVal;
-                            });
-            if (exec_path_ == ExprExecPath::ScalarIndex && expr_->same_type_ &&
-                !has_array_literal && !has_offset_input_) {
+            if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
                 const auto has_unsafe_int_literal =
                     std::any_of(expr_->vals_.begin(),
                                 expr_->vals_.end(),

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -183,7 +183,15 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
             break;
         }
         case DataType::JSON: {
-            if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
+            const auto has_array_literal =
+                std::any_of(expr_->vals_.begin(),
+                            expr_->vals_.end(),
+                            [](const auto& value) {
+                                return value.val_case() ==
+                                       proto::plan::GenericValue::kArrayVal;
+                            });
+            if (exec_path_ == ExprExecPath::ScalarIndex && expr_->same_type_ &&
+                !has_array_literal && !has_offset_input_) {
                 const auto has_unsafe_int_literal =
                     std::any_of(expr_->vals_.begin(),
                                 expr_->vals_.end(),

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <fmt/core.h>
 
 #include "common/EasyAssert.h"
@@ -493,6 +495,17 @@ class PhyJsonContainsFilterExpr : public SegmentExpr {
     DetermineExecPath() override {
         if (CanUseJsonStatsAtInit()) {
             exec_path_ = ExprExecPath::JsonStats;
+            return;
+        }
+        if (expr_->column_.data_type_ == DataType::JSON &&
+            (!expr_->same_type_ ||
+             std::any_of(expr_->vals_.begin(),
+                         expr_->vals_.end(),
+                         [](const auto& value) {
+                             return value.val_case() ==
+                                    proto::plan::GenericValue::kArrayVal;
+                         }))) {
+            exec_path_ = ExprExecPath::RawData;
             return;
         }
         if (expr_->column_.data_type_ == DataType::ARRAY &&

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -1229,6 +1229,23 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
 
 void
 PhyTermFilterExpr::DetermineExecPath() {
+    // Validate before execution-path selection or asynchronous prefetch can
+    // consume values using the type selected from vals_[0].
+    if (expr_->column_.data_type_ == DataType::JSON &&
+        expr_->vals_.size() > 1) {
+        const auto expected_type = expr_->vals_[0].val_case();
+        for (size_t i = 1; i < expr_->vals_.size(); ++i) {
+            if (expr_->vals_[i].val_case() != expected_type) {
+                ThrowInfo(DataTypeInvalid,
+                          "TermExpr values must have the same type, value 0 "
+                          "has type {} but value {} has type {}",
+                          static_cast<int>(expected_type),
+                          i,
+                          static_cast<int>(expr_->vals_[i].val_case()));
+            }
+        }
+    }
+
     // PkIndex
     if (is_pk_field_) {
         exec_path_ = ExprExecPath::PkIndex;

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -253,7 +253,9 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                 }
             }
 
-            if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
+            if (exec_path_ == ExprExecPath::ScalarIndex &&
+                val_type != proto::plan::GenericValue::ValCase::kArrayVal &&
+                !has_offset_input_) {
                 switch (val_type) {
                     case proto::plan::GenericValue::ValCase::kBoolVal:
                         result = ExecRangeVisitorImplForIndex<bool>();
@@ -2041,6 +2043,9 @@ PhyUnaryRangeFilterExpr::DetermineExecPath() {
         case DataType::JSON: {
             auto val_type = FromValCase(expr_->val_.val_case());
             switch (val_type) {
+                case DataType::ARRAY:
+                    can_use = false;
+                    break;
                 case DataType::STRING:
                 case DataType::VARCHAR:
                     can_use = SegmentExpr::CanUseIndexForOp<std::string>(

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -292,7 +292,15 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                         result = ExecRangeVisitorImplJson<bool>(context);
                         break;
                     case proto::plan::GenericValue::ValCase::kInt64Val:
-                        result = ExecRangeVisitorImplJson<int64_t>(context);
+                        if ((has_offset_input_ ||
+                             exec_path_ != ExprExecPath::JsonStats) &&
+                            !IsInt64SafeForJsonDoubleIndex(
+                                expr_->val_.int64_val())) {
+                            result =
+                                ExecRangeVisitorImplJsonPreciseNumeric(context);
+                        } else {
+                            result = ExecRangeVisitorImplJson<int64_t>(context);
+                        }
                         break;
                     case proto::plan::GenericValue::ValCase::kFloatVal:
                         result = ExecRangeVisitorImplJson<double>(context);
@@ -1996,6 +2004,16 @@ PhyUnaryRangeFilterExpr::DetermineExecPath() {
     // JsonStats: use JSON statistics to skip segments when possible.
     if (CanUseJsonStatsAtInit()) {
         exec_path_ = ExprExecPath::JsonStats;
+        return;
+    }
+
+    // JSON array literals are only executable from raw data. Decide this
+    // before the base selector pins a JSON index so a cold or failed index
+    // fetch cannot affect an otherwise executable array comparison.
+    if (expr_->column_.data_type_ == DataType::JSON &&
+        expr_->val_.val_case() ==
+            proto::plan::GenericValue::ValCase::kArrayVal) {
+        exec_path_ = ExprExecPath::RawData;
         return;
     }
 

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -253,9 +253,7 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                 }
             }
 
-            if (exec_path_ == ExprExecPath::ScalarIndex &&
-                val_type != proto::plan::GenericValue::ValCase::kArrayVal &&
-                !has_offset_input_) {
+            if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
                 switch (val_type) {
                     case proto::plan::GenericValue::ValCase::kBoolVal:
                         result = ExecRangeVisitorImplForIndex<bool>();
@@ -2061,9 +2059,6 @@ PhyUnaryRangeFilterExpr::DetermineExecPath() {
         case DataType::JSON: {
             auto val_type = FromValCase(expr_->val_.val_case());
             switch (val_type) {
-                case DataType::ARRAY:
-                    can_use = false;
-                    break;
                 case DataType::STRING:
                 case DataType::VARCHAR:
                     can_use = SegmentExpr::CanUseIndexForOp<std::string>(

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -912,8 +912,8 @@ class JsonFlatIndexExprTest : public ::testing::Test {
         load_index_info.field_type = DataType::JSON;
         load_index_info.index_params = {{JSON_PATH, json_index_path},
                                         {JSON_CAST_TYPE, "JSON"}};
-        load_index_info.cache_index =
-            CreateTestCacheIndex("", std::move(json_index_));
+        load_index_info.cache_index = CreateTestCacheIndex(
+            "", std::move(json_index_), &observed_index_pin_ctx_);
         segment_->LoadIndex(load_index_info);
         auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
                       .GetRemoteChunkManager();
@@ -933,6 +933,7 @@ class JsonFlatIndexExprTest : public ::testing::Test {
     std::vector<std::string> json_data_;
     std::unique_ptr<index::JsonFlatIndex> json_index_;
     segcore::SegmentSealedUPtr segment_;
+    OpContext* observed_index_pin_ctx_{nullptr};
 };
 
 class JsonFlatIndexContainsExprTest : public ::testing::Test {
@@ -1288,6 +1289,7 @@ TEST_F(JsonFlatIndexExprTest, JSONArrayEqualityFallsBackToRawData) {
 
     EXPECT_EQ(final.count(), 1);
     EXPECT_TRUE(final[6]);
+    EXPECT_EQ(observed_index_pin_ctx_, nullptr);
 }
 
 TEST_F(JsonFlatIndexExprTest,

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -1269,6 +1269,63 @@ TEST_F(JsonFlatIndexExprTest, TestComparisonUnknowns) {
     EXPECT_TRUE(final[13]);
 }
 
+TEST_F(JsonFlatIndexExprTest, JSONArrayEqualityFallsBackToRawData) {
+    proto::plan::GenericValue value;
+    auto* array = value.mutable_array_val();
+    array->set_same_type(true);
+    array->add_array()->set_string_val("a");
+    array->add_array()->set_string_val("b");
+
+    auto expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+    auto final = query::ExecuteQueryExpr(
+        plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+
+    EXPECT_EQ(final.count(), 1);
+    EXPECT_TRUE(final[6]);
+}
+
+TEST_F(JsonFlatIndexExprTest,
+       JSONContainsMixedAndArrayLiteralsFallBackToRawData) {
+    proto::plan::GenericValue string_value;
+    string_value.set_string_val("a");
+    proto::plan::GenericValue int_value;
+    int_value.set_int64_val(1);
+
+    auto mixed_expr = std::make_shared<expr::JsonContainsExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+        false,
+        std::vector<proto::plan::GenericValue>{string_value, int_value});
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, mixed_expr);
+    auto final = query::ExecuteQueryExpr(
+        plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(final.count(), 1);
+    EXPECT_TRUE(final[6]);
+
+    proto::plan::GenericValue array_value;
+    auto* array = array_value.mutable_array_val();
+    array->set_same_type(true);
+    array->add_array()->set_string_val("a");
+    array->add_array()->set_string_val("b");
+    auto array_expr = std::make_shared<expr::JsonContainsExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::JSONContainsExpr_JSONOp_Contains,
+        true,
+        std::vector<proto::plan::GenericValue>{array_value});
+    plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, array_expr);
+    final = query::ExecuteQueryExpr(
+        plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(final.count(), 0);
+}
+
 TEST_F(JsonFlatIndexExprTest, ReusesValidityAcrossLiteralsAndOperators) {
     auto& cache = exec::ExprResCacheManager::Instance();
     exec::CacheConfig config;

--- a/internal/core/src/index/JsonIndexTest.cpp
+++ b/internal/core/src/index/JsonIndexTest.cpp
@@ -294,6 +294,24 @@ TEST(JsonIndexTest, TestJsonContains) {
             EXPECT_TRUE(result[id]);
         }
     }
+
+    proto::plan::GenericValue int_value;
+    int_value.set_int64_val(1);
+    proto::plan::GenericValue string_value;
+    string_value.set_string_val("4");
+    auto mixed_expr = std::make_shared<expr::JsonContainsExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}, true),
+        proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+        false,
+        std::vector<proto::plan::GenericValue>{int_value, string_value});
+    auto mixed_plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, mixed_expr);
+    auto mixed_result = query::ExecuteQueryExpr(
+        mixed_plan, segment.get(), json_raw_data.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(mixed_result.count(), 3);
+    EXPECT_TRUE(mixed_result[17]);
+    EXPECT_TRUE(mixed_result[18]);
+    EXPECT_TRUE(mixed_result[24]);
 }
 
 TEST(JsonIndexTest, TestJsonCast) {

--- a/internal/core/unittest/test_exec.cpp
+++ b/internal/core/unittest/test_exec.cpp
@@ -385,6 +385,35 @@ TEST_P(TaskTest, UnaryExpr) {
     EXPECT_EQ(num_rows, num_rows_);
 }
 
+TEST_P(TaskTest, DetermineExecPathFailureReleasesTaskDriverCycle) {
+    proto::plan::GenericValue int_value;
+    int_value.set_int64_val(1);
+    proto::plan::GenericValue string_value;
+    string_value.set_string_val("1");
+    auto logical_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(field_map_["json"], DataType::JSON, {"v"}),
+        std::vector<proto::plan::GenericValue>{int_value, string_value},
+        false);
+    auto filter_node = std::make_shared<plan::FilterBitsNode>(
+        "mixed-json-term", logical_expr, std::vector<plan::PlanNodePtr>{});
+    auto query_context =
+        std::make_shared<QueryContext>("mixed-json-term",
+                                       segment_.get(),
+                                       num_rows_,
+                                       MAX_TIMESTAMP,
+                                       0,
+                                       0,
+                                       query::PlanOptions{false},
+                                       std::make_shared<QueryConfig>());
+
+    auto task = Task::Create(
+        "mixed-json-term", plan::PlanFragment(filter_node), 0, query_context);
+    std::weak_ptr<Task> weak_task = task;
+    EXPECT_ANY_THROW(task->Next());
+    task.reset();
+    EXPECT_TRUE(weak_task.expired());
+}
+
 TEST_P(TaskTest, LogicalExpr) {
     ::milvus::proto::plan::GenericValue value;
     value.set_int64_val(-1);

--- a/internal/parser/planparserv2/fill_expression_value.go
+++ b/internal/parser/planparserv2/fill_expression_value.go
@@ -207,24 +207,6 @@ func FillBinaryRangeExpressionValue(expr *planpb.BinaryRangeExpr, templateValues
 		expr.UpperValue = castedUpperValue
 	}
 
-	// For JSON type, normalize numeric types to ensure both bounds have the same type.
-	// If one is float and the other is int, convert the int to float.
-	// This prevents type mismatch assertions in C++ expression execution.
-	if typeutil.IsJSONType(dataType) {
-		lowerVal := expr.GetLowerValue()
-		upperVal := expr.GetUpperValue()
-		lowerIsFloat := IsFloating(lowerVal)
-		upperIsFloat := IsFloating(upperVal)
-		lowerIsInt := IsInteger(lowerVal)
-		upperIsInt := IsInteger(upperVal)
-
-		if lowerIsFloat && upperIsInt {
-			expr.UpperValue = NewFloat(float64(upperVal.GetInt64Val()))
-		} else if lowerIsInt && upperIsFloat {
-			expr.LowerValue = NewFloat(float64(lowerVal.GetInt64Val()))
-		}
-	}
-
 	if !expr.GetLowerInclusive() || !expr.GetUpperInclusive() {
 		if getGenericValue(GreaterEqual(lowerValue, upperValue)).GetBoolVal() {
 			return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
@@ -336,5 +318,43 @@ func FillJSONContainsExpressionValue(expr *planpb.JSONContainsExpr, templateValu
 			expr.Elements = append(expr.Elements, castedValue)
 		}
 	}
+	expr.ElementsSameType = jsonContainsElementsSameType(expr.GetElements())
 	return nil
+}
+
+func jsonContainsElementsSameType(elements []*planpb.GenericValue) bool {
+	if len(elements) == 0 {
+		return true
+	}
+
+	elementType := genericValueDataType(elements[0])
+	if elementType == schemapb.DataType_None {
+		return false
+	}
+	for _, element := range elements[1:] {
+		if genericValueDataType(element) != elementType {
+			return false
+		}
+	}
+	return true
+}
+
+func genericValueDataType(value *planpb.GenericValue) schemapb.DataType {
+	if value == nil {
+		return schemapb.DataType_None
+	}
+	switch value.GetVal().(type) {
+	case *planpb.GenericValue_BoolVal:
+		return schemapb.DataType_Bool
+	case *planpb.GenericValue_Int64Val:
+		return schemapb.DataType_Int64
+	case *planpb.GenericValue_FloatVal:
+		return schemapb.DataType_Double
+	case *planpb.GenericValue_StringVal:
+		return schemapb.DataType_VarChar
+	case *planpb.GenericValue_ArrayVal:
+		return schemapb.DataType_Array
+	default:
+		return schemapb.DataType_None
+	}
 }

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -3,6 +3,7 @@ package planparserv2
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -767,29 +768,18 @@ func (s *FillExpressionValueSuite) TestBinaryArithOpEvalRangeDivisionByZero() {
 }
 
 func (s *FillExpressionValueSuite) TestTermExprWithMixedNumericTypesForJSON() {
-	// Test that mixed int64/float types in 'in' expression are normalized to float for JSON fields.
-	// This prevents assertion failures in C++ expression execution.
-	// Related to the BinaryRange fix for issue: https://github.com/milvus-io/milvus/issues/46588
+	// Mixed JSON membership is split into homogeneous predicates so segcore
+	// never receives a TermExpr whose type disagrees with one of its values.
 	schemaH := newTestSchemaHelper(s.T())
 
-	s.Run("mixed int and float should normalize all to float", func() {
+	s.Run("mixed int and float should split by concrete type", func() {
 		// A is a dynamic field (JSON type)
-		// Directly parse expression with mixed int and float values
 		exprStr := `A in [1, 2.5, 3, 4.5]`
 
 		expr, err := ParseExpr(schemaH, exprStr, nil)
 		s.NoError(err)
 		s.NotNil(expr)
-
-		// Verify all values are normalized to float type
-		te := expr.GetTermExpr()
-		s.NotNil(te, "expected TermExpr")
-		s.Len(te.GetValues(), 4)
-		// All integers should be converted to floats
-		s.Equal(float64(1), te.GetValues()[0].GetFloatVal())
-		s.Equal(float64(2.5), te.GetValues()[1].GetFloatVal())
-		s.Equal(float64(3), te.GetValues()[2].GetFloatVal())
-		s.Equal(float64(4.5), te.GetValues()[3].GetFloatVal())
+		assertJSONMembershipKinds(s.T(), expr, map[string]int{"int64": 2, "float": 2})
 	})
 
 	s.Run("all integers should remain int64", func() {
@@ -826,37 +816,24 @@ func (s *FillExpressionValueSuite) TestTermExprWithMixedNumericTypesForJSON() {
 		s.Equal(float64(4.5), te.GetValues()[3].GetFloatVal())
 	})
 
-	s.Run("single float with integers should normalize all to float", func() {
+	s.Run("single float with integers should keep exact literal types", func() {
 		exprStr := `A in [1, 2, 3.0, 4]`
 
 		expr, err := ParseExpr(schemaH, exprStr, nil)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// Verify all values are normalized to float type
-		te := expr.GetTermExpr()
-		s.NotNil(te, "expected TermExpr")
-		s.Len(te.GetValues(), 4)
-		s.Equal(float64(1), te.GetValues()[0].GetFloatVal())
-		s.Equal(float64(2), te.GetValues()[1].GetFloatVal())
-		s.Equal(float64(3.0), te.GetValues()[2].GetFloatVal())
-		s.Equal(float64(4), te.GetValues()[3].GetFloatVal())
+		assertJSONMembershipKinds(s.T(), expr, map[string]int{"int64": 3, "float": 1})
 	})
 
-	s.Run("JSONField with mixed int and float should normalize all to float", func() {
+	s.Run("JSONField with mixed int and float should split", func() {
 		exprStr := `JSONField["x"] in [10, 20.5, 30]`
 
 		expr, err := ParseExpr(schemaH, exprStr, nil)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// Verify all values are normalized to float type
-		te := expr.GetTermExpr()
-		s.NotNil(te, "expected TermExpr")
-		s.Len(te.GetValues(), 3)
-		s.Equal(float64(10), te.GetValues()[0].GetFloatVal())
-		s.Equal(float64(20.5), te.GetValues()[1].GetFloatVal())
-		s.Equal(float64(30), te.GetValues()[2].GetFloatVal())
+		assertJSONMembershipKinds(s.T(), expr, map[string]int{"int64": 2, "float": 1})
 	})
 
 	s.Run("non-JSON field should not be affected by mixed type normalization", func() {
@@ -877,23 +854,91 @@ func (s *FillExpressionValueSuite) TestTermExprWithMixedNumericTypesForJSON() {
 		}
 	})
 
-	s.Run("not in with mixed int and float should normalize all to float", func() {
+	s.Run("not in with mixed int and float should negate split membership", func() {
 		exprStr := `A not in [1, 2.5, 3]`
 
 		expr, err := ParseExpr(schemaH, exprStr, nil)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// The not in expression wraps a TermExpr in a UnaryExpr
 		ue := expr.GetUnaryExpr()
 		s.NotNil(ue, "expected UnaryExpr")
-		te := ue.GetChild().GetTermExpr()
-		s.NotNil(te, "expected TermExpr")
-		s.Len(te.GetValues(), 3)
-		s.Equal(float64(1), te.GetValues()[0].GetFloatVal())
-		s.Equal(float64(2.5), te.GetValues()[1].GetFloatVal())
-		s.Equal(float64(3), te.GetValues()[2].GetFloatVal())
+		s.Equal(planpb.UnaryExpr_Not, ue.GetOp())
+		assertJSONMembershipKinds(s.T(), ue.GetChild(), map[string]int{"int64": 2, "float": 1})
 	})
+
+	s.Run("mixed template values should split by concrete type", func() {
+		expr, err := ParseExpr(schemaH, `A in {list}`, map[string]*schemapb.TemplateValue{
+			"list": generateTemplateValue(schemapb.DataType_Array,
+				generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{
+					generateJSONData(int64(1)),
+					generateJSONData(2.5),
+					generateJSONData("3"),
+					generateJSONData(true),
+				})),
+		})
+		s.NoError(err)
+		s.NotNil(expr)
+		assertJSONMembershipKinds(s.T(), expr, map[string]int{
+			"bool": 1, "int64": 1, "float": 1, "string": 1,
+		})
+	})
+}
+
+func assertJSONMembershipKinds(t *testing.T, expr *planpb.Expr, expected map[string]int) {
+	t.Helper()
+	actual := make(map[string]int)
+	var visit func(*planpb.Expr)
+	visit = func(current *planpb.Expr) {
+		if current == nil {
+			return
+		}
+		if term := current.GetTermExpr(); term != nil {
+			var termKind string
+			for _, value := range term.GetValues() {
+				kind := genericValueKind(value)
+				if termKind == "" {
+					termKind = kind
+				}
+				require.Equal(t, termKind, kind, "TermExpr must be homogeneous")
+				actual[kind]++
+			}
+			return
+		}
+		if unaryRange := current.GetUnaryRangeExpr(); unaryRange != nil {
+			if unaryRange.GetOp() == planpb.OpType_Equal {
+				actual[genericValueKind(unaryRange.GetValue())]++
+			}
+			return
+		}
+		if binary := current.GetBinaryExpr(); binary != nil {
+			visit(binary.GetLeft())
+			visit(binary.GetRight())
+			return
+		}
+		if unary := current.GetUnaryExpr(); unary != nil {
+			visit(unary.GetChild())
+		}
+	}
+	visit(expr)
+	require.Equal(t, expected, actual)
+}
+
+func genericValueKind(value *planpb.GenericValue) string {
+	switch value.GetVal().(type) {
+	case *planpb.GenericValue_BoolVal:
+		return "bool"
+	case *planpb.GenericValue_Int64Val:
+		return "int64"
+	case *planpb.GenericValue_FloatVal:
+		return "float"
+	case *planpb.GenericValue_StringVal:
+		return "string"
+	case *planpb.GenericValue_ArrayVal:
+		return "array"
+	default:
+		return "other"
+	}
 }
 
 // assertNoUnfilledPlaceholder walks the expression tree and asserts that

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -544,6 +544,82 @@ func (s *FillExpressionValueSuite) TestJSONContainsExpression() {
 		}
 	})
 
+	s.Run("template elements same type", func() {
+		schemaH := newTestSchemaHelper(s.T())
+		testcases := []struct {
+			name     string
+			expr     string
+			values   map[string]*schemapb.TemplateValue
+			expected bool
+		}{
+			{
+				name: "typed homogeneous array",
+				expr: `json_contains_any(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_Int64, []int64{1, 2, 3})),
+				},
+				expected: true,
+			},
+			{
+				name: "JSON homogeneous array",
+				expr: `json_contains_all(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{
+							generateJSONData(int64(1)),
+							generateJSONData(int64(2)),
+							generateJSONData(int64(3)),
+						})),
+				},
+				expected: true,
+			},
+			{
+				name: "JSON heterogeneous array",
+				expr: `json_contains_any(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{
+							generateJSONData(int64(1)),
+							generateJSONData("1"),
+						})),
+				},
+				expected: false,
+			},
+			{
+				name: "empty array",
+				expr: `json_contains_any(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{})),
+				},
+				expected: true,
+			},
+			{
+				name: "singleton array",
+				expr: `json_contains_all(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{
+							generateJSONData(1.5),
+						})),
+				},
+				expected: true,
+			},
+		}
+
+		for _, testcase := range testcases {
+			s.Run(testcase.name, func() {
+				expr, err := ParseExpr(schemaH, testcase.expr, testcase.values)
+				s.NoError(err)
+				s.NotNil(expr)
+				contains := expr.GetJsonContainsExpr()
+				s.NotNil(contains)
+				s.Equal(testcase.expected, contains.GetElementsSameType())
+			})
+		}
+	})
+
 	s.Run("failed case", func() {
 		testcases := []testcase{
 			{`json_contains(ArrayField[0], {str})`, map[string]*schemapb.TemplateValue{
@@ -639,46 +715,47 @@ func (s *FillExpressionValueSuite) TestBinaryExpression() {
 }
 
 func (s *FillExpressionValueSuite) TestBinaryRangeWithMixedNumericTypesForJSON() {
-	// Test that mixed int64/float types are normalized to float for JSON fields.
-	// This prevents assertion failures in C++ expression execution.
-	// Related issue: https://github.com/milvus-io/milvus/issues/46588
+	// Mixed JSON numeric bounds must preserve their concrete literal types so
+	// large int64 values are not rounded before precise segcore comparison.
 	schemaH := newTestSchemaHelper(s.T())
 
-	s.Run("lower int64 upper float should normalize to float", func() {
+	s.Run("lower int64 upper float should preserve types", func() {
 		// A is a dynamic field (JSON type)
 		exprStr := `{min} < A < {max}`
 		templateValues := map[string]*schemapb.TemplateValue{
-			"min": generateTemplateValue(schemapb.DataType_Int64, int64(499)),
-			"max": generateTemplateValue(schemapb.DataType_Double, float64(512.0)),
+			"min": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740993)),
+			"max": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740996)),
 		}
 
 		expr, err := ParseExpr(schemaH, exprStr, templateValues)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// Verify both bounds are normalized to float type
 		bre := expr.GetBinaryRangeExpr()
 		s.NotNil(bre, "expected BinaryRangeExpr")
-		s.Equal(float64(499), bre.GetLowerValue().GetFloatVal())
-		s.Equal(float64(512.0), bre.GetUpperValue().GetFloatVal())
+		s.IsType(&planpb.GenericValue_Int64Val{}, bre.GetLowerValue().GetVal())
+		s.Equal(int64(9007199254740993), bre.GetLowerValue().GetInt64Val())
+		s.IsType(&planpb.GenericValue_FloatVal{}, bre.GetUpperValue().GetVal())
+		s.Equal(float64(9007199254740996), bre.GetUpperValue().GetFloatVal())
 	})
 
-	s.Run("lower float upper int64 should normalize to float", func() {
+	s.Run("lower float upper int64 should preserve types", func() {
 		exprStr := `{min} < A < {max}`
 		templateValues := map[string]*schemapb.TemplateValue{
-			"min": generateTemplateValue(schemapb.DataType_Double, float64(10.5)),
-			"max": generateTemplateValue(schemapb.DataType_Int64, int64(100)),
+			"min": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740992)),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740995)),
 		}
 
 		expr, err := ParseExpr(schemaH, exprStr, templateValues)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// Verify both bounds are normalized to float type
 		bre := expr.GetBinaryRangeExpr()
 		s.NotNil(bre, "expected BinaryRangeExpr")
-		s.Equal(float64(10.5), bre.GetLowerValue().GetFloatVal())
-		s.Equal(float64(100), bre.GetUpperValue().GetFloatVal())
+		s.IsType(&planpb.GenericValue_FloatVal{}, bre.GetLowerValue().GetVal())
+		s.Equal(float64(9007199254740992), bre.GetLowerValue().GetFloatVal())
+		s.IsType(&planpb.GenericValue_Int64Val{}, bre.GetUpperValue().GetVal())
+		s.Equal(int64(9007199254740995), bre.GetUpperValue().GetInt64Val())
 	})
 
 	s.Run("both int64 should remain int64", func() {

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -1173,28 +1173,6 @@ func (v *ParserVisitor) VisitTerm(ctx *parser.TermContext) interface{} {
 			}
 			values[i] = castedValue
 		}
-
-		// For JSON type, ensure all numeric values have consistent type.
-		// If there's a mix of integers and floats, convert all to floats.
-		if typeutil.IsJSONType(dataType) && len(values) > 0 {
-			hasInt := false
-			hasFloat := false
-			for _, val := range values {
-				if IsInteger(val) {
-					hasInt = true
-				} else if IsFloating(val) {
-					hasFloat = true
-				}
-			}
-			// If we have both int and float, convert all ints to floats
-			if hasInt && hasFloat {
-				for i, val := range values {
-					if IsInteger(val) {
-						values[i] = NewFloat(float64(val.GetInt64Val()))
-					}
-				}
-			}
-		}
 	}
 
 	expr := &planpb.Expr{

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -15,6 +15,7 @@ func RewriteExprWithConfig(e *planpb.Expr, optimizeEnabled bool) *planpb.Expr {
 	if e == nil {
 		return nil
 	}
+	e = normalizeJSONTermExprs(e)
 	v := &visitor{optimizeEnabled: optimizeEnabled}
 	res := v.visitExpr(e)
 	if out, ok := res.(*planpb.Expr); ok && out != nil {

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -117,7 +117,7 @@ func (v *visitor) visitUnaryExpr(expr *planpb.UnaryExpr) interface{} {
 				}
 				// Let other bool NOT IN flow through to visitTermExpr for bool-specific optimization.
 			} else if col != nil && len(te.GetValues()) == 1 {
-				if hasMissingPathNotEqualSemantics(col, te.GetValues()...) {
+				if !canRewriteNotEqual(col, te.GetValues()[0]) {
 					return notExpr(&planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: te}})
 				}
 				// Single-value NOT IN → != (avoids SIMD setup overhead for trivial case)
@@ -150,7 +150,7 @@ func (v *visitor) visitUnaryExpr(expr *planpb.UnaryExpr) interface{} {
 		// NOT (col == val) → col != val
 		// Handles: bool NOT IN [true] → != true, bool NOT IN [false] → != false
 		if ure := child.GetUnaryRangeExpr(); ure != nil && ure.GetOp() == planpb.OpType_Equal {
-			if hasMissingPathNotEqualSemantics(ure.GetColumnInfo(), ure.GetValue()) {
+			if !canRewriteNotEqual(ure.GetColumnInfo(), ure.GetValue()) {
 				return &planpb.Expr{
 					Expr: &planpb.Expr_UnaryExpr{
 						UnaryExpr: &planpb.UnaryExpr{

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -112,7 +112,7 @@ func (v *visitor) visitUnaryExpr(expr *planpb.UnaryExpr) interface{} {
 			sortTermValues(te)
 			col := te.GetColumnInfo()
 			if v.optimizeEnabled && effectiveDataType(col) == schemapb.DataType_Bool {
-				if !canFoldBoolDomainToConstant(col) && boolValuesCoverDomain(te.GetValues()) {
+				if !canFoldPredicateToBoolConstant(col) && boolValuesCoverDomain(te.GetValues()) {
 					return notExpr(&planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: te}})
 				}
 				// Let other bool NOT IN flow through to visitTermExpr for bool-specific optimization.
@@ -188,7 +188,7 @@ func (v *visitor) visitTermExpr(expr *planpb.TermExpr) interface{} {
 		values := expr.GetValues()
 		if allBoolVals(values) {
 			if boolValuesCoverDomain(values) {
-				if !canFoldBoolDomainToConstant(expr.GetColumnInfo()) {
+				if !canFoldPredicateToBoolConstant(expr.GetColumnInfo()) {
 					return &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: expr}}
 				}
 				return newAlwaysTrueExpr()

--- a/internal/parser/planparserv2/rewriter/json_term.go
+++ b/internal/parser/planparserv2/rewriter/json_term.go
@@ -144,6 +144,8 @@ func termGroupKey(term *planpb.TermExpr) (string, bool) {
 	if term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON {
 		return key, true
 	}
+	// this for loop is for defensive. in practice after normalization, all values
+	// in a term should have the same kind. but we still check it here to be safe.
 	for _, value := range term.GetValues()[1:] {
 		if valueCaseWithNil(value) != kind {
 			return "", false

--- a/internal/parser/planparserv2/rewriter/json_term.go
+++ b/internal/parser/planparserv2/rewriter/json_term.go
@@ -1,0 +1,153 @@
+package rewriter
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+)
+
+var jsonTermKindOrder = []string{"bool", "int64", "float", "string", "array"}
+
+// normalizeJSONTermExprs enforces the execution invariant that every JSON
+// TermExpr contains one concrete GenericValue kind.  This is correctness
+// normalization, not an optional optimization: segcore selects the executor
+// type from the first term value and therefore cannot safely consume a mixed
+// list.
+func normalizeJSONTermExprs(expr *planpb.Expr) *planpb.Expr {
+	if expr == nil {
+		return nil
+	}
+
+	switch real := expr.GetExpr().(type) {
+	case *planpb.Expr_BinaryExpr:
+		real.BinaryExpr.Left = normalizeJSONTermExprs(real.BinaryExpr.GetLeft())
+		real.BinaryExpr.Right = normalizeJSONTermExprs(real.BinaryExpr.GetRight())
+		return expr
+	case *planpb.Expr_UnaryExpr:
+		real.UnaryExpr.Child = normalizeJSONTermExprs(real.UnaryExpr.GetChild())
+		return expr
+	case *planpb.Expr_BinaryArithExpr:
+		real.BinaryArithExpr.Left = normalizeJSONTermExprs(real.BinaryArithExpr.GetLeft())
+		real.BinaryArithExpr.Right = normalizeJSONTermExprs(real.BinaryArithExpr.GetRight())
+		return expr
+	case *planpb.Expr_CallExpr:
+		for i, parameter := range real.CallExpr.GetFunctionParameters() {
+			real.CallExpr.FunctionParameters[i] = normalizeJSONTermExprs(parameter)
+		}
+		return expr
+	case *planpb.Expr_RandomSampleExpr:
+		real.RandomSampleExpr.Predicate = normalizeJSONTermExprs(real.RandomSampleExpr.GetPredicate())
+		return expr
+	case *planpb.Expr_ElementFilterExpr:
+		real.ElementFilterExpr.ElementExpr = normalizeJSONTermExprs(real.ElementFilterExpr.GetElementExpr())
+		real.ElementFilterExpr.Predicate = normalizeJSONTermExprs(real.ElementFilterExpr.GetPredicate())
+		return expr
+	case *planpb.Expr_MatchExpr:
+		real.MatchExpr.Predicate = normalizeJSONTermExprs(real.MatchExpr.GetPredicate())
+		return expr
+	case *planpb.Expr_TermExpr:
+		return normalizeJSONTermExpr(expr, real.TermExpr)
+	default:
+		return expr
+	}
+}
+
+func normalizeJSONTermExpr(original *planpb.Expr, term *planpb.TermExpr) *planpb.Expr {
+	if term == nil || term.GetColumnInfo() == nil || term.GetIsInField() ||
+		term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON || len(term.GetValues()) == 0 {
+		return original
+	}
+
+	buckets := make(map[string][]*planpb.GenericValue)
+	for _, value := range term.GetValues() {
+		kind := valueCaseWithNil(value)
+		buckets[kind] = append(buckets[kind], value)
+	}
+
+	// A homogeneous scalar JSON term is already executable. Array-valued JSON
+	// membership is lowered to equality branches because TermExpr has no array
+	// executor.
+	if len(buckets) == 1 {
+		if _, hasArrays := buckets["array"]; !hasArrays {
+			return original
+		}
+	}
+
+	parts := make([]*planpb.Expr, 0, len(buckets))
+	for _, kind := range jsonTermKindOrder {
+		values := buckets[kind]
+		if len(values) == 0 {
+			continue
+		}
+		if kind == "array" {
+			for _, value := range values {
+				parts = append(parts, newUnaryRangeExpr(
+					term.GetColumnInfo(), planpb.OpType_Equal, value))
+			}
+			continue
+		}
+		if len(values) == 1 {
+			parts = append(parts, newUnaryRangeExpr(
+				term.GetColumnInfo(), planpb.OpType_Equal, values[0]))
+		} else {
+			parts = append(parts, newTermExpr(term.GetColumnInfo(), values))
+		}
+	}
+
+	// Preserve an unexpected kind instead of dropping user values. The final
+	// planner validation/segcore guard remains responsible for rejecting kinds
+	// that cannot be executed.
+	for kind, values := range buckets {
+		known := false
+		for _, orderedKind := range jsonTermKindOrder {
+			if kind == orderedKind {
+				known = true
+				break
+			}
+		}
+		if !known && len(values) > 0 {
+			parts = append(parts, newTermExpr(term.GetColumnInfo(), values))
+		}
+	}
+
+	if len(parts) == 0 {
+		return original
+	}
+	return foldBinary(planpb.BinaryExpr_LogicalOr, parts)
+}
+
+func valueGroupKey(col *planpb.ColumnInfo, value *planpb.GenericValue) (string, bool) {
+	if col == nil || value == nil || value.GetVal() == nil {
+		return "", false
+	}
+	kind := valueCase(value)
+	if kind == "array" || kind == "other" {
+		return "", false
+	}
+	key := columnKey(col)
+	// Statically typed columns are cast before rewriting. JSON is the only
+	// column type whose predicates must remain partitioned by literal kind.
+	if col.GetDataType() == schemapb.DataType_JSON {
+		key += "|" + kind
+	}
+	return key, true
+}
+
+func termGroupKey(term *planpb.TermExpr) (string, bool) {
+	if term == nil || term.GetColumnInfo() == nil || len(term.GetValues()) == 0 {
+		return "", false
+	}
+	kind := valueCaseWithNil(term.GetValues()[0])
+	if kind == "nil" || kind == "other" || kind == "array" {
+		return "", false
+	}
+	key := columnKey(term.GetColumnInfo())
+	if term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON {
+		return key, true
+	}
+	for _, value := range term.GetValues()[1:] {
+		if valueCaseWithNil(value) != kind {
+			return "", false
+		}
+	}
+	return key + "|" + kind, true
+}

--- a/internal/parser/planparserv2/rewriter/json_term.go
+++ b/internal/parser/planparserv2/rewriter/json_term.go
@@ -116,13 +116,10 @@ func normalizeJSONTermExpr(original *planpb.Expr, term *planpb.TermExpr) *planpb
 }
 
 func valueGroupKey(col *planpb.ColumnInfo, value *planpb.GenericValue) (string, bool) {
-	if col == nil || value == nil || value.GetVal() == nil {
+	if col == nil || !canBuildTermExpr(value) {
 		return "", false
 	}
 	kind := valueCase(value)
-	if kind == "array" || kind == "other" {
-		return "", false
-	}
 	key := columnKey(col)
 	// Statically typed columns are cast before rewriting. JSON is the only
 	// column type whose predicates must remain partitioned by literal kind.
@@ -133,23 +130,13 @@ func valueGroupKey(col *planpb.ColumnInfo, value *planpb.GenericValue) (string, 
 }
 
 func termGroupKey(term *planpb.TermExpr) (string, bool) {
-	if term == nil || term.GetColumnInfo() == nil || len(term.GetValues()) == 0 {
+	if term == nil || term.GetColumnInfo() == nil || !canBuildTermExpr(term.GetValues()...) {
 		return "", false
 	}
-	kind := valueCaseWithNil(term.GetValues()[0])
-	if kind == "nil" || kind == "other" || kind == "array" {
-		return "", false
-	}
+	kind := valueCase(term.GetValues()[0])
 	key := columnKey(term.GetColumnInfo())
 	if term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON {
 		return key, true
-	}
-	// this for loop is for defensive. in practice after normalization, all values
-	// in a term should have the same kind. but we still check it here to be safe.
-	for _, value := range term.GetValues()[1:] {
-		if valueCaseWithNil(value) != kind {
-			return "", false
-		}
 	}
 	return key + "|" + kind, true
 }

--- a/internal/parser/planparserv2/rewriter/json_term_test.go
+++ b/internal/parser/planparserv2/rewriter/json_term_test.go
@@ -1,0 +1,223 @@
+package rewriter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	parser "github.com/milvus-io/milvus/internal/parser/planparserv2"
+	"github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+)
+
+func TestRewriteJSONMixedInSplitsHomogeneousTerms(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	for _, exprStr := range []string{
+		`JSONField["v"] in [1, 2, "3", "4", true, 2.5]`,
+		`JSONField["v"] in ["4", 2.5, true, "3", 2, 1]`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+
+		assertHomogeneousTerms(t, expr)
+		require.Equal(t, map[string]int{
+			"bool": 1, "int64": 2, "float": 1, "string": 2,
+		}, collectMembershipKinds(expr), exprStr)
+	}
+}
+
+func TestRewriteJSONMixedNotInNegatesSplitMembership(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] not in [1, 2, "3"]`, nil)
+	require.NoError(t, err)
+
+	unary := expr.GetUnaryExpr()
+	require.NotNil(t, unary)
+	require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp())
+	require.NotNil(t, unary.GetChild().GetBinaryExpr())
+	assertHomogeneousTerms(t, unary.GetChild())
+	require.Equal(t, map[string]int{"int64": 2, "string": 1},
+		collectMembershipKinds(unary.GetChild()))
+}
+
+func TestRewriteJSONMixedOrEqualsDoesNotRecombineTypes(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] == 1 or JSONField["v"] == "1" or JSONField["v"] == 2 or JSONField["v"] == "2"`, nil)
+	require.NoError(t, err)
+
+	assertHomogeneousTerms(t, expr)
+	require.Equal(t, map[string]int{"int64": 2, "string": 2},
+		collectMembershipKinds(expr))
+}
+
+func TestRewriteJSONCrossTypeInWithNotEqualKeepsBothPredicates(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	for _, exprStr := range []string{
+		`JSONField["v"] in [1, 2] and JSONField["v"] != "3"`,
+		`JSONField["v"] in [1, 2] or JSONField["v"] != "3"`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		require.NotNil(t, expr.GetBinaryExpr(), exprStr)
+		require.NotNil(t, findTermExpr(expr), exprStr)
+		require.NotNil(t, findUnaryRangeExpr(expr, planpb.OpType_NotEqual), exprStr)
+		assertHomogeneousTerms(t, expr)
+	}
+}
+
+func TestRewriteJSONMixedNotEqualsMergeOnlyWithinType(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] != 1 and JSONField["v"] != 2 and JSONField["v"] != "3" and JSONField["v"] != "4"`, nil)
+	require.NoError(t, err)
+
+	assertHomogeneousTerms(t, expr)
+	require.Equal(t, map[string]int{"int64": 2, "string": 2},
+		collectMembershipKinds(expr))
+}
+
+func TestRewriteJSONMixedInRunsWhenOptimizationDisabled(t *testing.T) {
+	col := &planpb.ColumnInfo{
+		FieldId:    102,
+		DataType:   schemapb.DataType_JSON,
+		NestedPath: []string{"v"},
+	}
+	input := &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: &planpb.TermExpr{
+		ColumnInfo: col,
+		Values: []*planpb.GenericValue{
+			{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+			{Val: &planpb.GenericValue_StringVal{StringVal: "1"}},
+		},
+	}}}
+
+	expr := rewriter.RewriteExprWithConfig(input, false)
+	require.NotNil(t, expr.GetBinaryExpr())
+	assertHomogeneousTerms(t, expr)
+	require.Equal(t, map[string]int{"int64": 1, "string": 1},
+		collectMembershipKinds(expr))
+}
+
+func TestRewriteJSONMixedTermInsideCallExpr(t *testing.T) {
+	col := &planpb.ColumnInfo{
+		FieldId:    102,
+		DataType:   schemapb.DataType_JSON,
+		NestedPath: []string{"v"},
+	}
+	input := &planpb.Expr{Expr: &planpb.Expr_CallExpr{CallExpr: &planpb.CallExpr{
+		FunctionName: "test",
+		FunctionParameters: []*planpb.Expr{{
+			Expr: &planpb.Expr_TermExpr{TermExpr: &planpb.TermExpr{
+				ColumnInfo: col,
+				Values: []*planpb.GenericValue{
+					{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+					{Val: &planpb.GenericValue_StringVal{StringVal: "1"}},
+				},
+			}},
+		}},
+	}}}
+
+	expr := rewriter.RewriteExprWithConfig(input, false)
+	parameter := expr.GetCallExpr().GetFunctionParameters()[0]
+	require.NotNil(t, parameter.GetBinaryExpr())
+	assertHomogeneousTerms(t, parameter)
+	require.Equal(t, map[string]int{"int64": 1, "string": 1},
+		collectMembershipKinds(parameter))
+}
+
+func TestRewriteJSONMixedNumericPreservesLargeInteger(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [9007199254740993, 1.5]`, nil)
+	require.NoError(t, err)
+
+	var integerValues []int64
+	walkExpr(expr, func(current *planpb.Expr) {
+		if term := current.GetTermExpr(); term != nil {
+			for _, value := range term.GetValues() {
+				if testValueKind(value) == "int64" {
+					integerValues = append(integerValues, value.GetInt64Val())
+				}
+			}
+		}
+		if unary := current.GetUnaryRangeExpr(); unary != nil &&
+			unary.GetOp() == planpb.OpType_Equal && testValueKind(unary.GetValue()) == "int64" {
+			integerValues = append(integerValues, unary.GetValue().GetInt64Val())
+		}
+	})
+	require.Equal(t, []int64{9007199254740993}, integerValues)
+}
+
+func TestRewriteJSONArrayInUsesEqualityBranches(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [[1, 2], [3, 4]]`, nil)
+	require.NoError(t, err)
+	require.Nil(t, findTermExpr(expr))
+	require.Equal(t, map[string]int{"array": 2}, collectMembershipKinds(expr))
+}
+
+func assertHomogeneousTerms(t *testing.T, expr *planpb.Expr) {
+	t.Helper()
+	walkExpr(expr, func(current *planpb.Expr) {
+		term := current.GetTermExpr()
+		if term == nil || len(term.GetValues()) == 0 {
+			return
+		}
+		kind := testValueKind(term.GetValues()[0])
+		for _, value := range term.GetValues()[1:] {
+			require.Equal(t, kind, testValueKind(value),
+				"TermExpr contains mixed value types")
+		}
+	})
+}
+
+func collectMembershipKinds(expr *planpb.Expr) map[string]int {
+	result := make(map[string]int)
+	walkExpr(expr, func(current *planpb.Expr) {
+		if term := current.GetTermExpr(); term != nil {
+			for _, value := range term.GetValues() {
+				result[testValueKind(value)]++
+			}
+			return
+		}
+		if unary := current.GetUnaryRangeExpr(); unary != nil &&
+			unary.GetOp() == planpb.OpType_Equal {
+			result[testValueKind(unary.GetValue())]++
+		}
+	})
+	return result
+}
+
+func walkExpr(expr *planpb.Expr, visit func(*planpb.Expr)) {
+	if expr == nil {
+		return
+	}
+	visit(expr)
+	if binary := expr.GetBinaryExpr(); binary != nil {
+		walkExpr(binary.GetLeft(), visit)
+		walkExpr(binary.GetRight(), visit)
+	}
+	if unary := expr.GetUnaryExpr(); unary != nil {
+		walkExpr(unary.GetChild(), visit)
+	}
+}
+
+func testValueKind(value *planpb.GenericValue) string {
+	switch value.GetVal().(type) {
+	case *planpb.GenericValue_BoolVal:
+		return "bool"
+	case *planpb.GenericValue_Int64Val:
+		return "int64"
+	case *planpb.GenericValue_FloatVal:
+		return "float"
+	case *planpb.GenericValue_StringVal:
+		return "string"
+	case *planpb.GenericValue_ArrayVal:
+		return "array"
+	default:
+		return "other"
+	}
+}

--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -206,7 +206,7 @@ func (v *visitor) combineAndRangePredicates(parts []*planpb.Expr) []*planpb.Expr
 				}
 			}
 
-			if isEmpty && !canFoldBoolDomainToConstant(g.col) {
+			if isEmpty && !canFoldPredicateToBoolConstant(g.col) {
 				continue
 			}
 
@@ -608,7 +608,7 @@ func (v *visitor) combineAndBinaryRanges(parts []*planpb.Expr) []*planpb.Expr {
 				}
 			}
 			if isEmpty {
-				if !canFoldBoolDomainToConstant(g.col) {
+				if !canFoldPredicateToBoolConstant(g.col) {
 					continue
 				}
 				// Empty intersection → constant false

--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -2,6 +2,7 @@ package rewriter
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
@@ -57,14 +58,15 @@ func resolveEffectiveType(col *planpb.ColumnInfo) (schemapb.DataType, bool) {
 
 // resolveJSONEffectiveType returns the effective type for a JSON field based on the literal value.
 // Returns (type, ok) where ok is false if the value is not suitable for range optimization.
-// For numeric types (int and float), we normalize to Double to allow mixing, similar to scalar Float/Double columns.
+// Numeric literals share the Double comparison group so int and float bounds
+// can still be merged. cmpGeneric preserves their concrete literal kinds and
+// compares int64 against float64 without lossy promotion.
 func resolveJSONEffectiveType(v *planpb.GenericValue) (schemapb.DataType, bool) {
 	if v == nil || v.GetVal() == nil {
 		return schemapb.DataType_None, false
 	}
 	switch v.GetVal().(type) {
 	case *planpb.GenericValue_Int64Val:
-		// Normalize int to Double for JSON to allow mixing with float literals
 		return schemapb.DataType_Double, true
 	case *planpb.GenericValue_FloatVal:
 		return schemapb.DataType_Double, true
@@ -378,6 +380,43 @@ func newBinaryRangeExpr(col *planpb.ColumnInfo, lowerInclusive bool, upperInclus
 	}
 }
 
+// compareInt64ToFloat64 compares an int64 and float64 without converting the
+// integer to float64. The boundary checks also avoid an out-of-range float to
+// int conversion. This mirrors segcore's JSON numeric comparison semantics.
+func compareInt64ToFloat64(lhs int64, rhs float64) int {
+	if math.IsNaN(rhs) {
+		// Preserve cmpGeneric's existing deterministic handling for NaN.
+		return 0
+	}
+	const (
+		int64Lower = -0x1p63
+		int64Upper = 0x1p63
+	)
+	if rhs < int64Lower {
+		return 1
+	}
+	if rhs >= int64Upper {
+		return -1
+	}
+
+	rhsInteger := int64(rhs)
+	if lhs < rhsInteger {
+		return -1
+	}
+	if lhs > rhsInteger {
+		return 1
+	}
+
+	rhsIntegerAsFloat := float64(rhsInteger)
+	if rhs > rhsIntegerAsFloat {
+		return -1
+	}
+	if rhs < rhsIntegerAsFloat {
+		return 1
+	}
+	return 0
+}
+
 // -1 means a < b, 0 means a == b, 1 means a > b
 func cmpGeneric(dt schemapb.DataType, a, b *planpb.GenericValue) int {
 	switch dt {
@@ -394,25 +433,37 @@ func cmpGeneric(dt schemapb.DataType, a, b *planpb.GenericValue) int {
 		}
 		return 0
 	case schemapb.DataType_Float, schemapb.DataType_Double:
-		// Allow comparing int and float by promoting to float
-		toFloat := func(g *planpb.GenericValue) float64 {
-			switch g.GetVal().(type) {
-			case *planpb.GenericValue_FloatVal:
-				return g.GetFloatVal()
+		switch a.GetVal().(type) {
+		case *planpb.GenericValue_Int64Val:
+			switch b.GetVal().(type) {
 			case *planpb.GenericValue_Int64Val:
-				return float64(g.GetInt64Val())
-			default:
-				// Should not happen due to gate; treat as 0 deterministically
+				ai, bi := a.GetInt64Val(), b.GetInt64Val()
+				if ai < bi {
+					return -1
+				}
+				if ai > bi {
+					return 1
+				}
+				return 0
+			case *planpb.GenericValue_FloatVal:
+				return compareInt64ToFloat64(a.GetInt64Val(), b.GetFloatVal())
+			}
+		case *planpb.GenericValue_FloatVal:
+			switch b.GetVal().(type) {
+			case *planpb.GenericValue_Int64Val:
+				return -compareInt64ToFloat64(b.GetInt64Val(), a.GetFloatVal())
+			case *planpb.GenericValue_FloatVal:
+				af, bf := a.GetFloatVal(), b.GetFloatVal()
+				if af < bf {
+					return -1
+				}
+				if af > bf {
+					return 1
+				}
 				return 0
 			}
 		}
-		af, bf := toFloat(a), toFloat(b)
-		if af < bf {
-			return -1
-		}
-		if af > bf {
-			return 1
-		}
+		// Should not happen because callers gate supported literal kinds.
 		return 0
 	case schemapb.DataType_String,
 		schemapb.DataType_VarChar:

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -86,7 +86,7 @@ func TestRewrite_JSON_NestedPath_NonNullable_ContradictionsKeepPredicate(t *test
 	}
 }
 
-func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteBlocked(t *testing.T) {
+func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 
 	for _, exprStr := range []string{
@@ -96,9 +96,9 @@ func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteBlocked(t *testing.T) {
 		expr, err := parser.ParseExpr(helper, exprStr, nil)
 		require.NoError(t, err, exprStr)
 		require.NotNil(t, expr, exprStr)
-		unary := expr.GetUnaryExpr()
-		require.NotNil(t, unary, "scalar JSON missing-path NOT must remain explicit: %s", exprStr)
-		require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp(), exprStr)
+		unaryRange := expr.GetUnaryRangeExpr()
+		require.NotNil(t, unaryRange, "scalar JSON NOT equality should become !=: %s", exprStr)
+		require.Equal(t, planpb.OpType_NotEqual, unaryRange.GetOp(), exprStr)
 	}
 }
 

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -86,6 +86,25 @@ func TestRewrite_JSON_NestedPath_NonNullable_ContradictionsKeepPredicate(t *test
 	}
 }
 
+func TestRewrite_JSON_RootValue_DynamicTypeKeepsThreeValuedPredicates(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	for _, exprStr := range []string{
+		`JSONField in [1, 2] or JSONField != 1`,
+		`JSONField in [1, 2] and JSONField == 3`,
+		`JSONField > 100 and JSONField < 50`,
+		`not (JSONField > 100 and JSONField < 50)`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		require.NotNil(t, expr, exprStr)
+		require.False(t, rewriter.IsAlwaysFalseExpr(expr),
+			"JSON type mismatch can be UNKNOWN, so the predicate must not fold to false: %s", exprStr)
+		require.False(t, rewriter.IsAlwaysTrueExpr(expr),
+			"JSON type mismatch can be UNKNOWN, so the predicate must not fold to true: %s", exprStr)
+	}
+}
+
 func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -105,6 +105,44 @@ func TestRewrite_JSON_RootValue_DynamicTypeKeepsThreeValuedPredicates(t *testing
 	}
 }
 
+func TestRewrite_JSON_InWithRangeUsesLiteralType(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [1, 2, 3] and JSONField["v"] >= 2`, nil)
+	require.NoError(t, err)
+	term := expr.GetTermExpr()
+	require.NotNil(t, term)
+	require.Len(t, term.GetValues(), 2)
+	require.Equal(t, []int64{2, 3}, []int64{
+		term.GetValues()[0].GetInt64Val(),
+		term.GetValues()[1].GetInt64Val(),
+	})
+}
+
+func TestRewrite_JSON_InWithRangePreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [9007199254740992, 9007199254740993] and JSONField["v"] >= 9007199254740993`, nil)
+	require.NoError(t, err)
+	term := expr.GetTermExpr()
+	require.NotNil(t, term)
+	require.Len(t, term.GetValues(), 1)
+	require.Equal(t, int64(9007199254740993), term.GetValues()[0].GetInt64Val())
+}
+
+func TestRewrite_JSON_InWithRangeTypeMismatchSkipsOptimization(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [1, 2] and JSONField["v"] >= "2"`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr.GetBinaryExpr())
+	require.NotNil(t, findTermExpr(expr))
+	require.NotNil(t, findUnaryRangeExpr(expr, planpb.OpType_GreaterEqual))
+}
+
 func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -159,7 +159,7 @@ func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
 	}
 }
 
-func TestRewrite_JSON_NestedPath_ArrayNotEqualRewriteBlocked(t *testing.T) {
+func TestRewrite_JSON_NestedPath_ArrayNotEqualRewriteAllowed(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 
 	for _, exprStr := range []string{
@@ -169,9 +169,9 @@ func TestRewrite_JSON_NestedPath_ArrayNotEqualRewriteBlocked(t *testing.T) {
 		expr, err := parser.ParseExpr(helper, exprStr, nil)
 		require.NoError(t, err, exprStr)
 		require.NotNil(t, expr, exprStr)
-		unary := expr.GetUnaryExpr()
-		require.NotNil(t, unary, "array-valued JSON missing-path NOT must remain explicit: %s", exprStr)
-		require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp(), exprStr)
+		unaryRange := expr.GetUnaryRangeExpr()
+		require.NotNil(t, unaryRange, "array-valued JSON NOT equality should become !=: %s", exprStr)
+		require.Equal(t, planpb.OpType_NotEqual, unaryRange.GetOp(), exprStr)
 	}
 }
 
@@ -197,6 +197,65 @@ func TestRewrite_JSON_Int_AND_Strengthen(t *testing.T) {
 	// Verify column info
 	require.Equal(t, schemapb.DataType_JSON, ure.GetColumnInfo().GetDataType())
 	require.Equal(t, []string{"price"}, ure.GetColumnInfo().GetNestedPath())
+}
+
+func TestRewrite_JSON_IntRangePreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	for _, exprStr := range []string{
+		`JSONField["v"] >= 9007199254740992 and JSONField["v"] >= 9007199254740993`,
+		`JSONField["v"] >= 9007199254740993 and JSONField["v"] >= 9007199254740992`,
+		`JSONField["v"] >= 9007199254740992.0 and JSONField["v"] >= 9007199254740993`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		unaryRange := expr.GetUnaryRangeExpr()
+		require.NotNil(t, unaryRange, exprStr)
+		require.Equal(t, planpb.OpType_GreaterEqual, unaryRange.GetOp(), exprStr)
+		require.Equal(t, int64(9007199254740993), unaryRange.GetValue().GetInt64Val(), exprStr)
+	}
+}
+
+func TestRewrite_JSON_IntOrRangePreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	for _, exprStr := range []string{
+		`JSONField["v"] >= 9007199254740993 or JSONField["v"] >= 9007199254740992`,
+		`JSONField["v"] >= 9007199254740992 or JSONField["v"] >= 9007199254740993`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		unaryRange := expr.GetUnaryRangeExpr()
+		require.NotNil(t, unaryRange, exprStr)
+		require.Equal(t, planpb.OpType_GreaterEqual, unaryRange.GetOp(), exprStr)
+		require.Equal(t, int64(9007199254740992), unaryRange.GetValue().GetInt64Val(), exprStr)
+	}
+}
+
+func TestRewrite_JSON_AndBinaryRangesPreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`(JSONField["v"] >= 9007199254740992 and JSONField["v"] <= 9007199254740996) and `+
+			`(JSONField["v"] >= 9007199254740993 and JSONField["v"] <= 9007199254740995)`, nil)
+	require.NoError(t, err)
+
+	binaryRange := expr.GetBinaryRangeExpr()
+	require.NotNil(t, binaryRange)
+	require.Equal(t, int64(9007199254740993), binaryRange.GetLowerValue().GetInt64Val())
+	require.Equal(t, int64(9007199254740995), binaryRange.GetUpperValue().GetInt64Val())
+}
+
+func TestRewrite_JSON_OrBinaryRangesPreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`(JSONField["v"] >= 9007199254740993 and JSONField["v"] <= 9007199254740995) or `+
+			`(JSONField["v"] >= 9007199254740992 and JSONField["v"] <= 9007199254740996)`, nil)
+	require.NoError(t, err)
+
+	binaryRange := expr.GetBinaryRangeExpr()
+	require.NotNil(t, binaryRange)
+	require.Equal(t, int64(9007199254740992), binaryRange.GetLowerValue().GetInt64Val())
+	require.Equal(t, int64(9007199254740996), binaryRange.GetUpperValue().GetInt64Val())
 }
 
 // Test JSON field with int comparison - AND to BinaryRange

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -9,7 +9,6 @@ func (v *visitor) combineOrEqualsToIn(parts []*planpb.Expr) []*planpb.Expr {
 		col         *planpb.ColumnInfo
 		values      []*planpb.GenericValue
 		origIndices []int
-		valCase     string
 	}
 	others := make([]*planpb.Expr, 0, len(parts))
 	groups := make(map[string]*group)
@@ -25,16 +24,15 @@ func (v *visitor) combineOrEqualsToIn(parts []*planpb.Expr) []*planpb.Expr {
 			others = append(others, e)
 			continue
 		}
-		key := columnKey(col)
-		g, ok := groups[key]
-		valCase := valueCase(u.GetValue())
+		key, ok := valueGroupKey(col, u.GetValue())
 		if !ok {
-			g = &group{col: col, values: []*planpb.GenericValue{}, origIndices: []int{}, valCase: valCase}
-			groups[key] = g
-		}
-		if g.valCase != valCase {
 			others = append(others, e)
 			continue
+		}
+		g, ok := groups[key]
+		if !ok {
+			g = &group{col: col, values: []*planpb.GenericValue{}, origIndices: []int{}}
+			groups[key] = g
 		}
 		g.values = append(g.values, u.GetValue())
 		g.origIndices = append(g.origIndices, idx)
@@ -59,7 +57,6 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 		col         *planpb.ColumnInfo
 		values      []*planpb.GenericValue
 		origIndices []int
-		valCase     string
 	}
 	others := make([]*planpb.Expr, 0, len(parts))
 	groups := make(map[string]*group)
@@ -75,16 +72,15 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 			others = append(others, e)
 			continue
 		}
-		key := columnKey(col)
-		g, ok := groups[key]
-		valCase := valueCase(u.GetValue())
+		key, ok := valueGroupKey(col, u.GetValue())
 		if !ok {
-			g = &group{col: col, values: []*planpb.GenericValue{}, origIndices: []int{}, valCase: valCase}
-			groups[key] = g
-		}
-		if g.valCase != valCase {
 			others = append(others, e)
 			continue
+		}
+		g, ok := groups[key]
+		if !ok {
+			g = &group{col: col, values: []*planpb.GenericValue{}, origIndices: []int{}}
+			groups[key] = g
 		}
 		g.values = append(g.values, u.GetValue())
 		g.origIndices = append(g.origIndices, idx)
@@ -135,7 +131,11 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: te.GetColumnInfo()}
@@ -146,7 +146,11 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && ue.GetOp() == planpb.OpType_Equal && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: ue.GetColumnInfo()}
@@ -246,7 +250,11 @@ func (v *visitor) combineOrInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: te.GetColumnInfo()}
@@ -257,7 +265,11 @@ func (v *visitor) combineOrInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && ue.GetOp() == planpb.OpType_Equal && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: ue.GetColumnInfo()}
@@ -316,7 +328,11 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 	}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: te.GetColumnInfo()}
@@ -327,7 +343,11 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && isRange(ue.GetOp()) && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: ue.GetColumnInfo()}
@@ -413,7 +433,11 @@ func (v *visitor) combineOrInWithIn(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: te.GetColumnInfo()}
@@ -464,7 +488,11 @@ func (v *visitor) combineAndInWithIn(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: te.GetColumnInfo()}
@@ -541,7 +569,11 @@ func (v *visitor) combineAndInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr 
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: te.GetColumnInfo()}
@@ -552,7 +584,11 @@ func (v *visitor) combineAndInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr 
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && ue.GetOp() == planpb.OpType_NotEqual && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: ue.GetColumnInfo()}
@@ -621,7 +657,11 @@ func (v *visitor) combineOrInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: te.GetColumnInfo()}
@@ -632,7 +672,11 @@ func (v *visitor) combineOrInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr {
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && ue.GetOp() == planpb.OpType_NotEqual && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: ue.GetColumnInfo()}

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -90,7 +90,18 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 	out = append(out, others...)
 	for _, g := range groups {
 		if len(g.values) >= 2 {
-			if hasMissingPathNotEqualSemantics(g.col, g.values...) {
+			// This rewrite requires both an executable TermExpr and strict
+			// != == NOT(==) semantics for every predicate under three-valued logic.
+			canRewrite := canBuildTermExpr(g.values...)
+			if canRewrite {
+				for _, value := range g.values {
+					if !canRewriteNotEqual(g.col, value) {
+						canRewrite = false
+						break
+					}
+				}
+			}
+			if !canRewrite {
 				for _, i := range g.origIndices {
 					out = append(out, indexToExpr[i])
 				}

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -190,7 +190,7 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 		}
 		// If multiple different equals present, AND implies contradiction unless identical.
 		if len(eqUnique) > 1 {
-			if !canFoldBoolDomainToConstant(g.col) {
+			if !canFoldPredicateToBoolConstant(g.col) {
 				continue
 			}
 			for _, ti := range g.termIdxs {
@@ -212,7 +212,7 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 				break
 			}
 		}
-		if !inSet && !canFoldBoolDomainToConstant(g.col) {
+		if !inSet && !canFoldPredicateToBoolConstant(g.col) {
 			continue
 		}
 		for _, ti := range g.termIdxs {
@@ -429,7 +429,7 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 		}
 		termVals := g.term.GetValues()
 		filtered := filterValuesByRange(g.comparisonType, termVals, g.lower, g.lowerInc, g.upper, g.upperInc)
-		if len(filtered) == 0 && !canFoldBoolDomainToConstant(g.col) {
+		if len(filtered) == 0 && !canFoldPredicateToBoolConstant(g.col) {
 			continue
 		}
 		used[g.termIdx] = true
@@ -565,7 +565,7 @@ func (v *visitor) combineAndInWithIn(parts []*planpb.Expr) []*planpb.Expr {
 				inter = append(inter, v)
 			}
 		}
-		if len(inter) == 0 && !canFoldBoolDomainToConstant(g.col) {
+		if len(inter) == 0 && !canFoldPredicateToBoolConstant(g.col) {
 			continue
 		}
 		for _, i := range g.idxs {
@@ -652,7 +652,7 @@ func (v *visitor) combineAndInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr 
 				filtered = append(filtered, tv)
 			}
 		}
-		if len(filtered) == 0 && !canFoldBoolDomainToConstant(g.col) {
+		if len(filtered) == 0 && !canFoldPredicateToBoolConstant(g.col) {
 			continue
 		}
 		used[g.termIdx] = true
@@ -741,7 +741,7 @@ func (v *visitor) combineOrInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr {
 			}
 		}
 		if containsAny {
-			if !canFoldBoolDomainToConstant(g.col) {
+			if !canFoldPredicateToBoolConstant(g.col) {
 				continue
 			}
 			used[g.termIdx] = true

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -1,6 +1,7 @@
 package rewriter
 
 import (
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 )
 
@@ -309,17 +310,43 @@ func (v *visitor) combineOrInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 	return out
 }
 
+func resolveInRangeComparisonType(col *planpb.ColumnInfo, value *planpb.GenericValue) (schemapb.DataType, bool) {
+	dt := effectiveDataType(col)
+	if dt != schemapb.DataType_JSON {
+		if !isSupportedScalarForRange(dt) || !valueMatchesType(dt, value) {
+			return schemapb.DataType_None, false
+		}
+		return dt, true
+	}
+
+	// JSON is dynamically typed. Use the literal's exact kind instead of the
+	// schema-level JSON type so cmpGeneric never treats an unsupported type as
+	// equal. Keep int and float separate here to avoid losing int64 precision.
+	switch valueCaseWithNil(value) {
+	case "int64":
+		return schemapb.DataType_Int64, true
+	case "float":
+		return schemapb.DataType_Double, true
+	case "string":
+		return schemapb.DataType_VarChar, true
+	default:
+		return schemapb.DataType_None, false
+	}
+}
+
 // AND: (a IN S) AND (range) -> filter S by range
 func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 	type group struct {
-		col       *planpb.ColumnInfo
-		termIdx   int
-		term      *planpb.TermExpr
-		lower     *planpb.GenericValue
-		lowerInc  bool
-		upper     *planpb.GenericValue
-		upperInc  bool
-		rangeIdxs []int
+		col            *planpb.ColumnInfo
+		comparisonType schemapb.DataType
+		comparable     bool
+		termIdx        int
+		term           *planpb.TermExpr
+		lower          *planpb.GenericValue
+		lowerInc       bool
+		upper          *planpb.GenericValue
+		upperInc       bool
+		rangeIdxs      []int
 	}
 	groups := map[string]*group{}
 	others := []int{}
@@ -333,10 +360,24 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 				others = append(others, idx)
 				continue
 			}
+			comparisonType, comparable := resolveInRangeComparisonType(te.GetColumnInfo(), te.GetValues()[0])
+			for _, value := range te.GetValues()[1:] {
+				valueType, ok := resolveInRangeComparisonType(te.GetColumnInfo(), value)
+				if !ok || valueType != comparisonType {
+					comparable = false
+					break
+				}
+			}
 			g := groups[k]
 			if g == nil {
-				g = &group{col: te.GetColumnInfo()}
+				g = &group{
+					col:            te.GetColumnInfo(),
+					comparisonType: comparisonType,
+					comparable:     comparable,
+				}
 				groups[k] = g
+			} else if !comparable || g.comparisonType != comparisonType {
+				g.comparable = false
 			}
 			g.term = te
 			g.termIdx = idx
@@ -348,18 +389,25 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 				others = append(others, idx)
 				continue
 			}
+			comparisonType, comparable := resolveInRangeComparisonType(ue.GetColumnInfo(), ue.GetValue())
 			g := groups[k]
 			if g == nil {
-				g = &group{col: ue.GetColumnInfo()}
+				g = &group{
+					col:            ue.GetColumnInfo(),
+					comparisonType: comparisonType,
+					comparable:     comparable,
+				}
 				groups[k] = g
+			} else if !comparable || g.comparisonType != comparisonType {
+				g.comparable = false
 			}
-			if ue.GetOp() == planpb.OpType_GreaterThan || ue.GetOp() == planpb.OpType_GreaterEqual {
-				if g.lower == nil || cmpGeneric(effectiveDataType(g.col), ue.GetValue(), g.lower) > 0 || (cmpGeneric(effectiveDataType(g.col), ue.GetValue(), g.lower) == 0 && ue.GetOp() == planpb.OpType_GreaterThan && g.lowerInc) {
+			if g.comparable && (ue.GetOp() == planpb.OpType_GreaterThan || ue.GetOp() == planpb.OpType_GreaterEqual) {
+				if g.lower == nil || cmpGeneric(g.comparisonType, ue.GetValue(), g.lower) > 0 || (cmpGeneric(g.comparisonType, ue.GetValue(), g.lower) == 0 && ue.GetOp() == planpb.OpType_GreaterThan && g.lowerInc) {
 					g.lower = ue.GetValue()
 					g.lowerInc = ue.GetOp() == planpb.OpType_GreaterEqual
 				}
-			} else {
-				if g.upper == nil || cmpGeneric(effectiveDataType(g.col), ue.GetValue(), g.upper) < 0 || (cmpGeneric(effectiveDataType(g.col), ue.GetValue(), g.upper) == 0 && ue.GetOp() == planpb.OpType_LessThan && g.upperInc) {
+			} else if g.comparable {
+				if g.upper == nil || cmpGeneric(g.comparisonType, ue.GetValue(), g.upper) < 0 || (cmpGeneric(g.comparisonType, ue.GetValue(), g.upper) == 0 && ue.GetOp() == planpb.OpType_LessThan && g.upperInc) {
 					g.upper = ue.GetValue()
 					g.upperInc = ue.GetOp() == planpb.OpType_LessEqual
 				}
@@ -376,30 +424,11 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 		used[idx] = true
 	}
 	for _, g := range groups {
-		if g.term == nil || (g.lower == nil && g.upper == nil) {
+		if !g.comparable || g.term == nil || (g.lower == nil && g.upper == nil) {
 			continue
 		}
-		// Skip optimization if any term value is not comparable with the provided bounds
 		termVals := g.term.GetValues()
-		comparable := true
-		for _, tv := range termVals {
-			if g.lower != nil {
-				if !areComparableCases(valueCaseWithNil(tv), valueCaseWithNil(g.lower)) && (!isNumericCase(valueCaseWithNil(tv)) || !isNumericCase(valueCaseWithNil(g.lower))) {
-					comparable = false
-					break
-				}
-			}
-			if comparable && g.upper != nil {
-				if !areComparableCases(valueCaseWithNil(tv), valueCaseWithNil(g.upper)) && (!isNumericCase(valueCaseWithNil(tv)) || !isNumericCase(valueCaseWithNil(g.upper))) {
-					comparable = false
-					break
-				}
-			}
-		}
-		if !comparable {
-			continue
-		}
-		filtered := filterValuesByRange(effectiveDataType(g.col), termVals, g.lower, g.lowerInc, g.upper, g.upperInc)
+		filtered := filterValuesByRange(g.comparisonType, termVals, g.lower, g.lowerInc, g.upper, g.upperInc)
 		if len(filtered) == 0 && !canFoldBoolDomainToConstant(g.col) {
 			continue
 		}

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -15,18 +15,12 @@ import (
 
 func columnKey(c *planpb.ColumnInfo) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%d|%d|%d|%t|%t|%t|%t|%t|",
+	fmt.Fprintf(&b, "%d|%t|%d|",
 		c.GetFieldId(),
-		int32(c.GetDataType()),
-		int32(c.GetElementType()),
-		c.GetIsPrimaryKey(),
-		c.GetIsAutoID(),
-		c.GetIsPartitionKey(),
-		c.GetNullable(),
-		c.GetIsElementLevel())
+		c.GetIsElementLevel(),
+		len(c.GetNestedPath()))
 	for _, p := range c.GetNestedPath() {
-		b.WriteString(p)
-		b.WriteByte('|')
+		fmt.Fprintf(&b, "%d:%s|", len(p), p)
 	}
 	return b.String()
 }
@@ -213,7 +207,8 @@ func hasMissingPathSemantics(col *planpb.ColumnInfo) bool {
 	return col != nil && len(col.GetNestedPath()) > 0
 }
 
-func canFoldBoolDomainToConstant(col *planpb.ColumnInfo) bool {
+// only non-nullable fields that don't need the true/false/null semantics can be folded to a bool constant.
+func canFoldPredicateToBoolConstant(col *planpb.ColumnInfo) bool {
 	return col != nil && col.GetDataType() != schemapb.DataType_JSON &&
 		!hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
 }
@@ -319,10 +314,4 @@ func filterValuesByRange(dt schemapb.DataType, values []*planpb.GenericValue, lo
 		}
 	}
 	return out
-}
-
-func unionValues(valuesA, valuesB []*planpb.GenericValue) []*planpb.GenericValue {
-	all := append([]*planpb.GenericValue{}, valuesA...)
-	all = append(all, valuesB...)
-	return sortGenericValues(all)
 }

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -214,7 +214,8 @@ func hasMissingPathSemantics(col *planpb.ColumnInfo) bool {
 }
 
 func canFoldBoolDomainToConstant(col *planpb.ColumnInfo) bool {
-	return !hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
+	return col != nil && col.GetDataType() != schemapb.DataType_JSON &&
+		!hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
 }
 
 func hasMissingPathNotEqualSemantics(col *planpb.ColumnInfo, values ...*planpb.GenericValue) bool {

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -218,6 +218,15 @@ func canFoldBoolDomainToConstant(col *planpb.ColumnInfo) bool {
 }
 
 func hasMissingPathNotEqualSemantics(col *planpb.ColumnInfo, values ...*planpb.GenericValue) bool {
+	if col != nil && col.GetDataType() == schemapb.DataType_JSON {
+		for _, value := range values {
+			switch valueCaseWithNil(value) {
+			case "array", "nil", "other":
+				return true
+			}
+		}
+		return false
+	}
 	return hasMissingPathSemantics(col)
 }
 

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -213,17 +213,42 @@ func canFoldPredicateToBoolConstant(col *planpb.ColumnInfo) bool {
 		!hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
 }
 
-func hasMissingPathNotEqualSemantics(col *planpb.ColumnInfo, values ...*planpb.GenericValue) bool {
-	if col != nil && col.GetDataType() == schemapb.DataType_JSON {
-		for _, value := range values {
-			switch valueCaseWithNil(value) {
-			case "array", "nil", "other":
-				return true
-			}
-		}
+// canRewriteNotEqual reports whether NOT(col == value) can be rewritten as
+// col != value without changing UNKNOWN results. JSON scalar and array
+// comparisons preserve missing paths, nulls, and type mismatches as UNKNOWN.
+// Keep the existing conservative behavior for non-JSON nested access.
+func canRewriteNotEqual(col *planpb.ColumnInfo, value *planpb.GenericValue) bool {
+	if col == nil {
 		return false
 	}
-	return hasMissingPathSemantics(col)
+	switch valueCaseWithNil(value) {
+	case "nil", "other":
+		return false
+	}
+	if col.GetDataType() == schemapb.DataType_JSON {
+		return true
+	}
+	return !hasMissingPathSemantics(col)
+}
+
+// canBuildTermExpr reports whether values can be represented by one segcore
+// TermExpr. TermExpr selects one scalar executor for the entire value list, so
+// the values must be concrete, homogeneous scalars; array-valued literals are
+// lowered to equality expressions instead.
+func canBuildTermExpr(values ...*planpb.GenericValue) bool {
+	if len(values) == 0 {
+		return false
+	}
+	kind := valueCaseWithNil(values[0])
+	if kind == "nil" || kind == "other" || kind == "array" {
+		return false
+	}
+	for _, value := range values[1:] {
+		if valueCaseWithNil(value) != kind {
+			return false
+		}
+	}
+	return true
 }
 
 func newAlwaysFalseExpr() *planpb.Expr {


### PR DESCRIPTION

issue: #51489
issue: #51567
issue: #51568

## What changed

- Canonicalize mixed-type JSON `IN` expressions into homogeneous predicates.
- Partition JSON values by their concrete type: bool, int64, float, string, and array.
- Keep int64 and float values in separate predicates to avoid precision loss around `2^53`.
- Make the following expression optimizations type-aware for JSON:
  - `== OR` to `IN`
  - `!= AND` to `NOT IN`
  - combinations involving `IN`, equality, inequality, and range predicates
- Lower JSON array-valued membership to equality branches because segcore does not support array-valued `TermExpr`.
- Apply JSON term canonicalization even when expression optimization is disabled.
- Allow scalar JSON `NOT(x == value)` to be rewritten as `x != value` while preserving UNKNOWN for null, missing paths, and type mismatches.
- Add a segcore validation guard that rejects heterogeneous JSON `TermExpr` values before selecting raw data, JSON stats, or JSON path index execution paths.

## Root cause

A JSON `TermExpr` could contain values with different protobuf value types. Segcore selected its executor from the first value, causing later values to be interpreted using the wrong type.

The optimizer could also combine different JSON literal types back into a single `TermExpr`. Additionally, converting mixed integer and floating-point values to float could lose int64 precision.

## Behavior

For example:

```text
json["key"] in [1, 2, "3"]
```

is normalized to:

```text
json["key"] in [1, 2] OR json["key"] == "3"
```

Mixed-type `NOT IN` remains a negation of the complete split membership expression, preserving three-valued logic:

```text
NOT(json["key"] in [1, 2] OR json["key"] == "3")
```

Non-JSON columns continue to use their statically determined schema type.

## Verification

- Go parser and rewriter tests:

```bash
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2/...
```

- Segcore mixed JSON Term validation test.
- Raw JSON filtering three-valued semantics tests.
- JSON path index precision and `!=` semantics tests.
- JSON stats/shredding null, missing-path, and large-int64 precision tests.
