### PR TITLE
fix: [2.6] handle mixed-type JSON term expressions

### DIFF
--- a/internal/core/src/common/Array.h
+++ b/internal/core/src/common/Array.h
@@ -30,6 +30,32 @@
 
 namespace milvus {
 
+namespace array_detail {
+
+inline proto::plan::GenericValue::ValCase
+ExpectedLiteralValCase(DataType element_type) {
+    switch (element_type) {
+        case DataType::BOOL:
+            return proto::plan::GenericValue::ValCase::kBoolVal;
+        case DataType::INT8:
+        case DataType::INT16:
+        case DataType::INT32:
+        case DataType::INT64:
+            return proto::plan::GenericValue::ValCase::kInt64Val;
+        case DataType::FLOAT:
+        case DataType::DOUBLE:
+            return proto::plan::GenericValue::ValCase::kFloatVal;
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::GEOMETRY:
+            return proto::plan::GenericValue::ValCase::kStringVal;
+        default:
+            return proto::plan::GenericValue::ValCase::VAL_NOT_SET;
+    }
+}
+
+}  // namespace array_detail
+
 class Array {
  public:
     Array() = default;
@@ -410,9 +436,14 @@ class Array {
         if (!arr2.same_type()) {
             return false;
         }
+        const auto expected_val_case =
+            array_detail::ExpectedLiteralValCase(element_type_);
         switch (element_type_) {
             case DataType::BOOL: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<bool>(i);
                     if (val != arr2.array(i).bool_val()) {
                         return false;
@@ -424,6 +455,9 @@ class Array {
             case DataType::INT16:
             case DataType::INT32: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<int>(i);
                     if (val != arr2.array(i).int64_val()) {
                         return false;
@@ -433,6 +467,9 @@ class Array {
             }
             case DataType::INT64: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<int64_t>(i);
                     if (val != arr2.array(i).int64_val()) {
                         return false;
@@ -442,6 +479,9 @@ class Array {
             }
             case DataType::FLOAT: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<float>(i);
                     if (val != static_cast<float>(arr2.array(i).float_val())) {
                         return false;
@@ -451,6 +491,9 @@ class Array {
             }
             case DataType::DOUBLE: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<double>(i);
                     if (val != arr2.array(i).float_val()) {
                         return false;
@@ -462,6 +505,9 @@ class Array {
             case DataType::STRING:
             case DataType::GEOMETRY: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {
                         return false;
@@ -672,9 +718,14 @@ class ArrayView {
         if (!arr2.same_type()) {
             return false;
         }
+        const auto expected_val_case =
+            array_detail::ExpectedLiteralValCase(element_type_);
         switch (element_type_) {
             case DataType::BOOL: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<bool>(i);
                     if (val != arr2.array(i).bool_val()) {
                         return false;
@@ -686,6 +737,9 @@ class ArrayView {
             case DataType::INT16:
             case DataType::INT32: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<int>(i);
                     if (val != arr2.array(i).int64_val()) {
                         return false;
@@ -695,6 +749,9 @@ class ArrayView {
             }
             case DataType::INT64: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<int64_t>(i);
                     if (val != arr2.array(i).int64_val()) {
                         return false;
@@ -704,6 +761,9 @@ class ArrayView {
             }
             case DataType::FLOAT: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<float>(i);
                     if (val != static_cast<float>(arr2.array(i).float_val())) {
                         return false;
@@ -713,6 +773,9 @@ class ArrayView {
             }
             case DataType::DOUBLE: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<double>(i);
                     if (val != arr2.array(i).float_val()) {
                         return false;
@@ -724,6 +787,9 @@ class ArrayView {
             case DataType::STRING:
             case DataType::GEOMETRY: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {
                         return false;

--- a/internal/core/src/common/ArrayTest.cpp
+++ b/internal/core/src/common/ArrayTest.cpp
@@ -225,3 +225,43 @@ TEST(Array, TestConstructArray) {
     ASSERT_EQ(0, empty_array.byte_size());
     ASSERT_TRUE(empty_array.is_same_array(field_empty_array));
 }
+
+TEST(Array, TestLiteralElementTypeMismatch) {
+    using namespace milvus;
+
+    auto expect_mismatch = [](const Array& array,
+                              const proto::plan::Array& literal) {
+        EXPECT_FALSE(array.is_same_array(literal));
+
+        auto array_view = ArrayView(const_cast<char*>(array.data()),
+                                    array.length(),
+                                    array.byte_size(),
+                                    array.get_element_type(),
+                                    array.get_offsets_data());
+        EXPECT_FALSE(array_view.is_same_array(literal));
+    };
+
+    proto::schema::ScalarField int64_data;
+    int64_data.mutable_long_data()->add_data(0);
+    auto int64_array = Array(int64_data);
+    proto::plan::Array float_literal;
+    float_literal.set_same_type(true);
+    float_literal.mutable_array()->Add()->set_float_val(1.5);
+    expect_mismatch(int64_array, float_literal);
+
+    proto::schema::ScalarField bool_data;
+    bool_data.mutable_bool_data()->add_data(false);
+    auto bool_array = Array(bool_data);
+    proto::plan::Array int_literal;
+    int_literal.set_same_type(true);
+    int_literal.mutable_array()->Add()->set_int64_val(0);
+    expect_mismatch(bool_array, int_literal);
+
+    proto::schema::ScalarField string_data;
+    string_data.mutable_string_data()->add_data("");
+    auto string_array = Array(string_data);
+    proto::plan::Array bool_literal;
+    bool_literal.set_same_type(true);
+    bool_literal.mutable_array()->Add()->set_bool_val(false);
+    expect_mismatch(string_array, bool_literal);
+}

--- a/internal/core/src/common/bson_view.h
+++ b/internal/core/src/common/bson_view.h
@@ -22,9 +22,11 @@
 #include <bsoncxx/types/bson_value/view.hpp>
 #include <bsoncxx/json.hpp>
 #include <bsoncxx/types.hpp>
-#include <string>
-#include <vector>
+#include <cstring>
 #include <optional>
+#include <string>
+#include <variant>
+#include <vector>
 
 #include "fmt/format.h"
 #include "log/Log.h"
@@ -194,6 +196,8 @@ CanConvertToInt64(double x) {
 
 class BsonView {
  public:
+    using NumericValue = std::variant<int64_t, double>;
+
     explicit BsonView(const std::vector<uint8_t>& data)
         : data_(data.data()), size_(data.size()) {
     }
@@ -344,6 +348,81 @@ class BsonView {
                     ErrorCode::Unsupported, "unknown BSON type {}", type_tag);
         }
         return std::nullopt;
+    }
+
+    std::optional<NumericValue>
+    ParseAsNumberAtOffset(size_t offset) {
+        if (offset >= size_) {
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "bson offset:{} out of range:{}",
+                      offset,
+                      size_);
+        }
+        LOG_TRACE("bson hex: {}",
+                  BsonHexDebugString(data_ + offset, size_ - offset));
+
+        const uint8_t* ptr = data_ + offset;
+        const uint8_t* end = data_ + size_;
+        const auto type_byte = *ptr++;
+        auto type_tag = static_cast<bsoncxx::type>(type_byte);
+        const auto* key_end = static_cast<const uint8_t*>(
+            std::memchr(ptr, '\0', static_cast<size_t>(end - ptr)));
+        if (key_end == nullptr) {
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "truncated BSON element key at offset {}",
+                      offset);
+        }
+        ptr = key_end + 1;
+
+        auto read_numeric_payload = [&](auto value) {
+            using T = decltype(value);
+            const auto remaining = static_cast<size_t>(end - ptr);
+            if (remaining < sizeof(T)) {
+                ThrowInfo(ErrorCode::UnexpectedError,
+                          "truncated BSON {} payload at offset {}: need {} "
+                          "bytes, have {}",
+                          type_tag,
+                          offset,
+                          sizeof(T),
+                          remaining);
+            }
+            std::memcpy(&value, ptr, sizeof(T));
+            return value;
+        };
+
+        switch (type_tag) {
+            case bsoncxx::type::k_int32:
+                return NumericValue{
+                    static_cast<int64_t>(read_numeric_payload(int32_t{}))};
+            case bsoncxx::type::k_int64:
+                return NumericValue{read_numeric_payload(int64_t{})};
+            case bsoncxx::type::k_double:
+                return NumericValue{read_numeric_payload(double{})};
+            case bsoncxx::type::k_string:
+            case bsoncxx::type::k_document:
+            case bsoncxx::type::k_array:
+            case bsoncxx::type::k_binary:
+            case bsoncxx::type::k_undefined:
+            case bsoncxx::type::k_oid:
+            case bsoncxx::type::k_bool:
+            case bsoncxx::type::k_date:
+            case bsoncxx::type::k_null:
+            case bsoncxx::type::k_regex:
+            case bsoncxx::type::k_dbpointer:
+            case bsoncxx::type::k_code:
+            case bsoncxx::type::k_symbol:
+            case bsoncxx::type::k_codewscope:
+            case bsoncxx::type::k_timestamp:
+            case bsoncxx::type::k_decimal128:
+            case bsoncxx::type::k_maxkey:
+            case bsoncxx::type::k_minkey:
+                return std::nullopt;
+            default:
+                ThrowInfo(ErrorCode::UnexpectedError,
+                          "unknown BSON type 0x{:02x} at offset {}",
+                          static_cast<unsigned>(type_byte),
+                          offset);
+        }
     }
 
     std::optional<bsoncxx::array::view>

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -98,6 +98,7 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                       expr_->upper_val_.int64_val())));
 
             if (has_unsafe_int_bound) {
+                SetNotUseIndex();
                 result = ExecRangeVisitorImplForJsonPreciseNumeric(context);
             } else if (SegmentExpr::CanUseIndex() && !has_offset_input_) {
                 if (is_numeric) {

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -17,6 +17,7 @@
 #include "BinaryRangeExpr.h"
 
 #include <utility>
+#include <variant>
 
 #include "common/ScopedTimer.h"
 #include "exec/expression/JsonNumberComparison.h"
@@ -75,6 +76,7 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
             break;
         }
         case DataType::JSON: {
+            const auto field_id = expr_->column_.field_id_;
             auto lower_type = expr_->lower_val_.val_case();
             auto upper_type = expr_->upper_val_.val_case();
             // For numeric types, if either bound is float, use double for both.
@@ -88,21 +90,30 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                       proto::plan::GenericValue::ValCase::kFloatVal) &&
                  (upper_type == proto::plan::GenericValue::ValCase::kInt64Val ||
                   upper_type == proto::plan::GenericValue::ValCase::kFloatVal));
-            const auto has_unsafe_int_bound =
-                is_numeric &&
-                ((lower_type == proto::plan::GenericValue::ValCase::kInt64Val &&
-                  !IsInt64SafeForJsonDoubleIndex(
-                      expr_->lower_val_.int64_val())) ||
-                 (upper_type == proto::plan::GenericValue::ValCase::kInt64Val &&
-                  !IsInt64SafeForJsonDoubleIndex(
-                      expr_->upper_val_.int64_val())));
+            const auto requires_precise_int64_comparison =
+                is_numeric && (JsonNumericBoundRequiresPreciseInt64Comparison(
+                                   expr_->lower_val_) ||
+                               JsonNumericBoundRequiresPreciseInt64Comparison(
+                                   expr_->upper_val_));
+            const auto can_use_json_stats = CanUseJsonStats(
+                context, field_id, expr_->column_.nested_path_, true);
+            auto can_use_index =
+                !can_use_json_stats && !requires_precise_int64_comparison &&
+                SegmentExpr::CanUseIndex() &&
+                (!has_offset_input_ || !PinnedJsonIndexIsFlat());
+            if (can_use_index &&
+                lower_type == proto::plan::GenericValue::ValCase::kStringVal) {
+                auto* string_index =
+                    dynamic_cast<const index::ScalarIndex<std::string>*>(
+                        pinned_index_[0].get());
+                can_use_index = !PinnedJsonIndexIsFlat() &&
+                                string_index != nullptr &&
+                                string_index->GetIndexType() !=
+                                    index::ScalarIndexType::NGRAM;
+            }
 
-            if (has_unsafe_int_bound) {
-                SetNotUseIndex();
-                result = ExecRangeVisitorImplForJsonPreciseNumeric(context);
-            } else if (SegmentExpr::CanUseIndex() && !has_offset_input_) {
+            if (can_use_index) {
                 if (is_numeric) {
-                    // Convert both bounds to double for index path
                     proto::plan::GenericValue double_lower_val;
                     if (lower_type ==
                         proto::plan::GenericValue::ValCase::kInt64Val) {
@@ -126,17 +137,24 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                     upper_arg_.SetValue<double>(double_upper_val);
                     arg_inited_ = true;
 
-                    result = ExecRangeVisitorImplForIndex<double>();
+                    result = ExecRangeVisitorImplForIndex<double>(input);
                 } else if (lower_type ==
                            proto::plan::GenericValue::ValCase::kStringVal) {
-                    result = ExecRangeVisitorImplForJson<std::string>(context);
+                    result = ExecRangeVisitorImplForIndex<std::string>(input);
                 } else {
                     ThrowInfo(
                         DataTypeInvalid,
                         fmt::format("unsupported value type {} in expression",
                                     lower_type));
                 }
+            } else if (!can_use_json_stats &&
+                       requires_precise_int64_comparison) {
+                SetNotUseIndex();
+                result = ExecRangeVisitorImplForJsonPreciseNumeric(context);
             } else {
+                if (!can_use_json_stats && SegmentExpr::CanUseIndex()) {
+                    SetNotUseIndex();
+                }
                 if (is_numeric && use_double) {
                     // Use double when either bound is float
                     result = ExecRangeVisitorImplForJson<double>(context);
@@ -251,9 +269,11 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonPreciseNumeric(
                 continue;
             }
             auto lower_comparison =
-                CompareJsonNumberToBound(number.value(), lower_bound);
+                CompareJsonNumberToBoundWithUint64DoubleFallback(number.value(),
+                                                                 lower_bound);
             auto upper_comparison =
-                CompareJsonNumberToBound(number.value(), upper_bound);
+                CompareJsonNumberToBoundWithUint64DoubleFallback(number.value(),
+                                                                 upper_bound);
             if (!lower_comparison.has_value() ||
                 !upper_comparison.has_value()) {
                 res[i] = false;
@@ -362,7 +382,7 @@ PhyBinaryRangeFilterExpr::PreCheckOverflow(HighPrecisionType& val1,
 
 template <typename T>
 VectorPtr
-PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
+PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex(OffsetVector* input) {
     typedef std::
         conditional_t<std::is_same_v<T, std::string_view>, std::string, T>
             IndexInnerType;
@@ -377,12 +397,13 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
     HighPrecisionType val2;
     bool lower_inclusive = false;
     bool upper_inclusive = false;
-    if (auto res =
-            PreCheckOverflow<T>(val1, val2, lower_inclusive, upper_inclusive)) {
+    if (auto res = PreCheckOverflow<T>(
+            val1, val2, lower_inclusive, upper_inclusive, input)) {
         return res;
     }
 
-    auto real_batch_size = GetNextBatchSize();
+    auto real_batch_size =
+        input != nullptr ? input->size() : GetNextBatchSize();
     if (real_batch_size == 0) {
         return nullptr;
     }
@@ -394,6 +415,36 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
         BinaryRangeIndexFunc<T> func;
         return func(index_ptr, val1, val2, lower_inclusive, upper_inclusive);
     };
+    if (input != nullptr) {
+        if (cached_full_index_res_ == nullptr) {
+            TargetBitmap full_result;
+            TargetBitmap full_valid_result;
+            for (size_t i = 0; i < num_index_chunk_; ++i) {
+                auto index_result = GetIndexPtrForChunk<IndexInnerType>(i);
+                auto* index_ptr = index_result.index_ptr;
+                AssertInfo(index_ptr != nullptr, "invalid scalar index type");
+                auto chunk_result = execute_sub_batch(index_ptr, val1, val2);
+                auto chunk_valid_result = index_ptr->IsNotNull();
+                AssertInfo(chunk_result.size() == chunk_valid_result.size(),
+                           "index result and validity sizes differ: {} vs {}",
+                           chunk_result.size(),
+                           chunk_valid_result.size());
+                full_result.append(chunk_result);
+                full_valid_result.append(chunk_valid_result);
+            }
+            cached_full_index_res_ =
+                std::make_shared<TargetBitmap>(std::move(full_result));
+            cached_full_index_valid_res_ =
+                std::make_shared<TargetBitmap>(std::move(full_valid_result));
+            AssertInfo(cached_full_index_res_->size() ==
+                           static_cast<size_t>(active_count_),
+                       "index range result size {} does not match row count {}",
+                       cached_full_index_res_->size(),
+                       active_count_);
+        }
+        return GatherCachedResultByOffsets(
+            *cached_full_index_res_, *cached_full_index_valid_res_, *input);
+    }
     auto res = ProcessIndexChunks<T>(execute_sub_batch, val1, val2);
     AssertInfo(res->size() == real_batch_size,
                "internal error: expr processed rows {} not equal "
@@ -561,12 +612,11 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJson(EvalCtx& context) {
     const auto& bitmap_input = context.get_bitmap_input();
     auto* input = context.get_offset_input();
     FieldId field_id = expr_->column_.field_id_;
-    if (!has_offset_input_ &&
-        CanUseJsonStats(context, field_id, expr_->column_.nested_path_)) {
+    if (CanUseJsonStats(context, field_id, expr_->column_.nested_path_, true)) {
         milvus::ScopedTimer timer(
             "binary_range_json_by_stats",
             [this](double us) { json_filter_stats_latency_us_ += us; });
-        return ExecRangeVisitorImplForJsonStats<ValueType>();
+        return ExecRangeVisitorImplForJsonStats<ValueType>(input);
     }
 
     milvus::ScopedTimer timer(
@@ -701,21 +751,28 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJson(EvalCtx& context) {
 
 template <typename ValueType>
 VectorPtr
-PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
+PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats(
+    OffsetVector* input) {
     using GetType = std::conditional_t<std::is_same_v<ValueType, std::string>,
                                        std::string_view,
                                        ValueType>;
-    auto real_batch_size = GetNextBatchSize();
+    auto real_batch_size =
+        input != nullptr
+            ? input->size()
+            : std::min(batch_size_, active_count_ - current_data_global_pos_);
     if (real_batch_size == 0) {
         return nullptr;
     }
     auto pointer = milvus::index::JsonPointer(expr_->column_.nested_path_);
     bool lower_inclusive = expr_->lower_inclusive_;
     bool upper_inclusive = expr_->upper_inclusive_;
-    // Use GetValueWithCastNumber to handle mixed int64/float types safely.
-    // This allows int64 values to be cast to double when ValueType is double.
-    ValueType val1 = GetValueWithCastNumber<ValueType>(expr_->lower_val_);
-    ValueType val2 = GetValueWithCastNumber<ValueType>(expr_->upper_val_);
+    std::optional<ValueType> val1;
+    std::optional<ValueType> val2;
+    if constexpr (!std::is_same_v<GetType, int64_t> &&
+                  !std::is_same_v<GetType, double>) {
+        val1.emplace(GetValueWithCastNumber<ValueType>(expr_->lower_val_));
+        val2.emplace(GetValueWithCastNumber<ValueType>(expr_->upper_val_));
+    }
 
     if (cached_index_chunk_id_ != 0 &&
         segment_->type() == SegmentType::Sealed) {
@@ -732,6 +789,8 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
 
         // process shredding data
+        const auto& lower_bound = expr_->lower_val_;
+        const auto& upper_bound = expr_->upper_val_;
         auto try_execute = [&](milvus::index::JSONType json_type,
                                auto GetType) {
             auto target_field = index->GetShreddingField(pointer, json_type);
@@ -741,29 +800,51 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
                 TargetBitmapView target_res_view(target_res);
                 TargetBitmap target_valid(active_count_, true);
                 TargetBitmapView target_valid_view(target_valid);
-                auto shredding_executor =
-                    [val1, val2, lower_inclusive, upper_inclusive](
-                        const ColType* src,
-                        const bool* valid,
-                        size_t size,
-                        TargetBitmapView res,
-                        TargetBitmapView valid_res) {
-                        for (size_t i = 0; i < size; ++i) {
-                            if (valid != nullptr && !valid[i]) {
-                                res[i] = valid_res[i] = false;
+                auto shredding_executor = [val1,
+                                           val2,
+                                           lower_inclusive,
+                                           upper_inclusive,
+                                           &lower_bound,
+                                           &upper_bound](
+                                              const ColType* src,
+                                              const bool* valid,
+                                              size_t size,
+                                              TargetBitmapView res,
+                                              TargetBitmapView valid_res) {
+                    for (size_t i = 0; i < size; ++i) {
+                        if (valid != nullptr && !valid[i]) {
+                            res[i] = valid_res[i] = false;
+                            continue;
+                        }
+                        if constexpr (std::is_same_v<ColType, int64_t> ||
+                                      std::is_same_v<ColType, double>) {
+                            auto lower_comparison =
+                                CompareJsonNumberToBound(src[i], lower_bound);
+                            auto upper_comparison =
+                                CompareJsonNumberToBound(src[i], upper_bound);
+                            if (!lower_comparison.has_value() ||
+                                !upper_comparison.has_value()) {
+                                res[i] = false;
                                 continue;
                             }
-                            if (lower_inclusive && upper_inclusive) {
-                                res[i] = src[i] >= val1 && src[i] <= val2;
-                            } else if (lower_inclusive && !upper_inclusive) {
-                                res[i] = src[i] >= val1 && src[i] < val2;
-                            } else if (!lower_inclusive && upper_inclusive) {
-                                res[i] = src[i] > val1 && src[i] <= val2;
-                            } else {
-                                res[i] = src[i] > val1 && src[i] < val2;
-                            }
+                            const auto lower_matches =
+                                lower_inclusive ? *lower_comparison >= 0
+                                                : *lower_comparison > 0;
+                            const auto upper_matches =
+                                upper_inclusive ? *upper_comparison <= 0
+                                                : *upper_comparison < 0;
+                            res[i] = lower_matches && upper_matches;
+                        } else if (lower_inclusive && upper_inclusive) {
+                            res[i] = src[i] >= *val1 && src[i] <= *val2;
+                        } else if (lower_inclusive && !upper_inclusive) {
+                            res[i] = src[i] >= *val1 && src[i] < *val2;
+                        } else if (!lower_inclusive && upper_inclusive) {
+                            res[i] = src[i] > *val1 && src[i] <= *val2;
+                        } else {
+                            res[i] = src[i] > *val1 && src[i] < *val2;
                         }
-                    };
+                    }
+                };
                 index->ExecutorForShreddingData<ColType>(op_ctx_,
                                                          target_field,
                                                          shredding_executor,
@@ -806,6 +887,8 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
                                 val2,
                                 lower_inclusive,
                                 upper_inclusive,
+                                &lower_bound,
+                                &upper_bound,
                                 &res_view,
                                 &valid_res_view](milvus::BsonView bson,
                                                  uint32_t row_id,
@@ -816,32 +899,42 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
             };
             if constexpr (std::is_same_v<GetType, int64_t> ||
                           std::is_same_v<GetType, double>) {
-                auto val = bson.ParseAsValueAtOffset<double>(value_offset);
-                if (!val.has_value()) {
+                auto number = bson.ParseAsNumberAtOffset(value_offset);
+                if (!number.has_value()) {
                     return;
                 }
-                if (lower_inclusive && upper_inclusive) {
-                    set_known(val.value() >= val1 && val.value() <= val2);
-                } else if (lower_inclusive && !upper_inclusive) {
-                    set_known(val.value() >= val1 && val.value() < val2);
-                } else if (!lower_inclusive && upper_inclusive) {
-                    set_known(val.value() > val1 && val.value() <= val2);
-                } else {
-                    set_known(val.value() > val1 && val.value() < val2);
+                auto [lower_comparison, upper_comparison] = std::visit(
+                    [&lower_bound, &upper_bound](auto value) {
+                        return std::make_pair(
+                            CompareJsonNumberToBound(value, lower_bound),
+                            CompareJsonNumberToBound(value, upper_bound));
+                    },
+                    *number);
+                if (!lower_comparison.has_value() ||
+                    !upper_comparison.has_value()) {
+                    set_known(false);
+                    return;
                 }
+                const auto lower_matches = lower_inclusive
+                                               ? *lower_comparison >= 0
+                                               : *lower_comparison > 0;
+                const auto upper_matches = upper_inclusive
+                                               ? *upper_comparison <= 0
+                                               : *upper_comparison < 0;
+                set_known(lower_matches && upper_matches);
             } else {
                 auto val = bson.ParseAsValueAtOffset<GetType>(value_offset);
                 if (!val.has_value()) {
                     return;
                 }
                 if (lower_inclusive && upper_inclusive) {
-                    set_known(val.value() >= val1 && val.value() <= val2);
+                    set_known(val.value() >= *val1 && val.value() <= *val2);
                 } else if (lower_inclusive && !upper_inclusive) {
-                    set_known(val.value() >= val1 && val.value() < val2);
+                    set_known(val.value() >= *val1 && val.value() < *val2);
                 } else if (!lower_inclusive && upper_inclusive) {
-                    set_known(val.value() > val1 && val.value() <= val2);
+                    set_known(val.value() > *val1 && val.value() <= *val2);
                 } else {
-                    set_known(val.value() > val1 && val.value() < val2);
+                    set_known(val.value() > *val1 && val.value() < *val2);
                 }
             }
         };
@@ -855,6 +948,10 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
         cached_index_chunk_id_ = 0;
     }
 
+    if (input != nullptr) {
+        return GatherCachedResultByOffsets(
+            *cached_index_chunk_res_, *cached_index_chunk_valid_res_, *input);
+    }
     auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
                                  *cached_index_chunk_valid_res_,
                                  current_data_global_pos_,

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -15,9 +15,11 @@
 // limitations under the License.
 
 #include "BinaryRangeExpr.h"
+
 #include <utility>
 
 #include "common/ScopedTimer.h"
+#include "exec/expression/JsonNumberComparison.h"
 #include "query/Utils.h"
 #include "index/json_stats/JsonKeyStats.h"
 namespace milvus {
@@ -86,8 +88,18 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                       proto::plan::GenericValue::ValCase::kFloatVal) &&
                  (upper_type == proto::plan::GenericValue::ValCase::kInt64Val ||
                   upper_type == proto::plan::GenericValue::ValCase::kFloatVal));
+            const auto has_unsafe_int_bound =
+                is_numeric &&
+                ((lower_type == proto::plan::GenericValue::ValCase::kInt64Val &&
+                  !IsInt64SafeForJsonDoubleIndex(
+                      expr_->lower_val_.int64_val())) ||
+                 (upper_type == proto::plan::GenericValue::ValCase::kInt64Val &&
+                  !IsInt64SafeForJsonDoubleIndex(
+                      expr_->upper_val_.int64_val())));
 
-            if (SegmentExpr::CanUseIndex() && !has_offset_input_) {
+            if (has_unsafe_int_bound) {
+                result = ExecRangeVisitorImplForJsonPreciseNumeric(context);
+            } else if (SegmentExpr::CanUseIndex() && !has_offset_input_) {
                 if (is_numeric) {
                     // Convert both bounds to double for index path
                     proto::plan::GenericValue double_lower_val;
@@ -177,6 +189,98 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                       "unsupported data type: {}",
                       expr_->column_.data_type_);
     }
+}
+
+VectorPtr
+PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonPreciseNumeric(
+    EvalCtx& context) {
+    const auto& bitmap_input = context.get_bitmap_input();
+    auto* input = context.get_offset_input();
+    auto real_batch_size =
+        has_offset_input_ ? input->size() : GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
+
+    auto res_vec =
+        std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),
+                                       TargetBitmap(real_batch_size, true));
+    TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
+    TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
+    auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
+    auto lower_bound = expr_->lower_val_;
+    auto upper_bound = expr_->upper_val_;
+    const auto lower_inclusive = expr_->lower_inclusive_;
+    const auto upper_inclusive = expr_->upper_inclusive_;
+
+    size_t processed_cursor = 0;
+    auto execute_sub_batch =
+        [
+            pointer,
+            lower_bound,
+            upper_bound,
+            lower_inclusive,
+            upper_inclusive,
+            &bitmap_input,
+            &processed_cursor
+        ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::Json* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res) {
+        const bool has_bitmap_input = !bitmap_input.empty();
+        for (int i = 0; i < size; ++i) {
+            auto offset = i;
+            if constexpr (filter_type == FilterType::random) {
+                offset = offsets ? offsets[i] : i;
+            }
+            if (valid_data != nullptr && !valid_data[offset]) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
+                continue;
+            }
+
+            auto number = data[offset].at_numeric(pointer);
+            if (number.error()) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            auto lower_comparison =
+                CompareJsonNumberToBound(number.value(), lower_bound);
+            auto upper_comparison =
+                CompareJsonNumberToBound(number.value(), upper_bound);
+            if (!lower_comparison.has_value() ||
+                !upper_comparison.has_value()) {
+                res[i] = false;
+                continue;
+            }
+            const auto lower_matches = lower_inclusive ? *lower_comparison >= 0
+                                                       : *lower_comparison > 0;
+            const auto upper_matches = upper_inclusive ? *upper_comparison <= 0
+                                                       : *upper_comparison < 0;
+            res[i] = lower_matches && upper_matches;
+        }
+        processed_cursor += size;
+    };
+
+    int64_t processed_size;
+    if (has_offset_input_) {
+        processed_size = ProcessDataByOffsets<milvus::Json>(
+            execute_sub_batch, std::nullptr_t{}, input, res, valid_res);
+    } else {
+        processed_size = ProcessDataChunks<milvus::Json>(
+            execute_sub_batch, std::nullptr_t{}, res, valid_res);
+    }
+    AssertInfo(processed_size == real_batch_size,
+               "internal error: expr processed rows {} not equal "
+               "expect batch size {}",
+               processed_size,
+               real_batch_size);
+    return res_vec;
 }
 
 template <typename T>

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include <fmt/core.h>
 
 #include "bitset/bitset.h"
@@ -242,6 +244,11 @@ struct BinaryRangeIndexFunc {
                IndexInnerType val2,
                bool lower_inclusive,
                bool upper_inclusive) {
+        if constexpr (std::is_floating_point_v<IndexInnerType>) {
+            if (std::isnan(val1) || std::isnan(val2)) {
+                return TargetBitmap(index->Count(), false);
+            }
+        }
         return index->Range(val1, lower_inclusive, val2, upper_inclusive);
     }
 };
@@ -311,7 +318,7 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
 
     template <typename T>
     VectorPtr
-    ExecRangeVisitorImplForIndex();
+    ExecRangeVisitorImplForIndex(OffsetVector* input = nullptr);
 
     template <typename T>
     VectorPtr
@@ -326,7 +333,7 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
 
     template <typename ValueType>
     VectorPtr
-    ExecRangeVisitorImplForJsonStats();
+    ExecRangeVisitorImplForJsonStats(OffsetVector* input = nullptr);
 
     template <typename ValueType>
     VectorPtr
@@ -342,6 +349,8 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
     SingleElement lower_arg_;
     SingleElement upper_arg_;
     bool arg_inited_{false};
+    std::shared_ptr<TargetBitmap> cached_full_index_res_{nullptr};
+    std::shared_ptr<TargetBitmap> cached_full_index_valid_res_{nullptr};
     PinWrapper<index::JsonKeyStats*> pinned_json_stats_{nullptr};
 };
 }  //namespace exec

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -321,6 +321,9 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
     VectorPtr
     ExecRangeVisitorImplForJson(EvalCtx& context);
 
+    VectorPtr
+    ExecRangeVisitorImplForJsonPreciseNumeric(EvalCtx& context);
+
     template <typename ValueType>
     VectorPtr
     ExecRangeVisitorImplForJsonStats();

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -290,9 +290,15 @@ class SegmentExpr : public Expr {
     MoveCursor() override {
         // when we specify input, do not maintain states
         if (!has_offset_input_) {
-            // CanUseIndex excludes ngram index and this is true even ngram index is used as ExecNgramMatch
-            // uses data cursor.
-            if (SegmentExpr::CanUseIndex()) {
+            const auto next_data_global_pos =
+                current_data_global_pos_ +
+                std::min(batch_size_, active_count_ - current_data_global_pos_);
+            if (use_json_stats_) {
+                current_data_global_pos_ += std::min(
+                    batch_size_, active_count_ - current_data_global_pos_);
+                // CanUseIndex excludes ngram index and this is true even ngram index is used as ExecNgramMatch
+                // uses data cursor.
+            } else if (SegmentExpr::CanUseIndex()) {
                 MoveCursorForIndex();
                 if (segment_->HasFieldData(field_id_)) {
                     MoveCursorForData();
@@ -300,6 +306,11 @@ class SegmentExpr : public Expr {
             } else {
                 MoveCursorForData();
             }
+            // Conjunct short-circuiting can move an expression before its
+            // first Eval determines that JSON stats will be used. Keep the
+            // logical row cursor aligned even when raw field data is absent.
+            current_data_global_pos_ =
+                std::max(current_data_global_pos_, next_data_global_pos);
         }
     }
 
@@ -319,6 +330,10 @@ class SegmentExpr : public Expr {
 
     int64_t
     GetNextBatchSize() {
+        if (use_json_stats_) {
+            return std::min(batch_size_,
+                            active_count_ - current_data_global_pos_);
+        }
         auto current_chunk = SegmentExpr::CanUseIndex() && use_index_
                                  ? current_index_chunk_
                                  : current_data_chunk_;
@@ -669,7 +684,7 @@ class SegmentExpr : public Expr {
         const ValTypes&... values) {
         int64_t processed_size = 0;
         if constexpr (std::is_same_v<T, std::string_view> ||
-                      std::is_same_v<T, Json>) {
+                      std::is_same_v<T, Json> || std::is_same_v<T, ArrayView>) {
             if (segment_->type() == SegmentType::Sealed) {
                 return ProcessChunkForSealedSeg<T, NeedSegmentOffsets>(
                     func, skip_func, res, valid_res, values...);
@@ -1441,6 +1456,12 @@ class SegmentExpr : public Expr {
         return true;
     }
 
+    bool
+    PinnedJsonIndexIsFlat() const {
+        return field_type_ == DataType::JSON && !pinned_index_.empty() &&
+               dynamic_cast<const index::JsonFlatIndex*>(
+                   pinned_index_[0].get()) != nullptr;
+    }
     template <typename T>
     bool
     CanUseIndexForOp(OpType op) const {
@@ -1508,7 +1529,8 @@ class SegmentExpr : public Expr {
     bool
     CanUseJsonStats(EvalCtx& context,
                     FieldId field_id,
-                    const std::vector<std::string>& nested_path) const {
+                    const std::vector<std::string>& nested_path,
+                    bool support_offset_input = false) {
         // if path contains integer, we can't use json stats such as "a.1.b", "a.1",
         // because we can't know the integer is a key or a array indice
         auto path_contains_integer = [](const std::vector<std::string>& path) {
@@ -1522,8 +1544,14 @@ class SegmentExpr : public Expr {
 
         // if path is empty, json stats can not know key name,
         // so we can't use json shredding data
-        return PlanUseJsonStats(context) && HasJsonStats(field_id) &&
-               !nested_path.empty() && !path_contains_integer(nested_path);
+        const auto can_use = PlanUseJsonStats(context) &&
+                             HasJsonStats(field_id) && !nested_path.empty() &&
+                             !path_contains_integer(nested_path) &&
+                             (support_offset_input || !has_offset_input_);
+        if (can_use) {
+            use_json_stats_ = true;
+        }
+        return can_use;
     }
 
     virtual bool
@@ -1531,6 +1559,29 @@ class SegmentExpr : public Expr {
         return false;
     };
 
+    VectorPtr
+    GatherCachedResultByOffsets(const TargetBitmap& cached_res,
+                                const TargetBitmap& cached_valid_res,
+                                const OffsetVector& offsets) const {
+        AssertInfo(cached_res.size() == cached_valid_res.size(),
+                   "cached result and validity sizes differ: {} vs {}",
+                   cached_res.size(),
+                   cached_valid_res.size());
+        TargetBitmap result(offsets.size(), false);
+        TargetBitmap valid_result(offsets.size(), false);
+        for (size_t i = 0; i < offsets.size(); ++i) {
+            const auto offset = offsets[i];
+            AssertInfo(
+                offset >= 0 && static_cast<size_t>(offset) < cached_res.size(),
+                "offset {} is outside cached result size {}",
+                offset,
+                cached_res.size());
+            result[i] = cached_res[offset];
+            valid_result[i] = cached_valid_res[offset];
+        }
+        return std::make_shared<ColumnVector>(std::move(result),
+                                              std::move(valid_result));
+    }
     VectorPtr
     MoveOrSliceBitmap(TargetBitmap& cached_res,
                       TargetBitmap& cached_valid_res,
@@ -1560,6 +1611,9 @@ class SegmentExpr : public Expr {
     // sometimes need to skip index and using raw data
     // default true means use index as much as possible
     bool use_index_{true};
+    // JSON stats produces a full-segment bitmap and advances by global row
+    // position even when raw JSON data is not loaded.
+    bool use_json_stats_{false};
     // used for reducing cache miss latency in tiered storage
     bool prefetched_{false};
     std::vector<PinWrapper<const index::IndexBase*>> pinned_index_{};

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -313,6 +313,103 @@ TEST(JsonIndexTest, TestJsonNotEqualExpr) {
     EXPECT_TRUE(final[11]);
 }
 
+TEST(JsonIndexTest, LargeInt64LiteralFallsBackToPreciseRawComparison) {
+    constexpr int64_t kLargeInt = 9007199254740993LL;
+    auto json_strs = std::vector<std::string>{
+        R"({"a": 9007199254740992})",
+        R"({"a": 9007199254740993})",
+        R"({"a": 9007199254740994})",
+        R"({"a": 9007199254740992.0})",
+        R"({"a": 9007199254740994.0})",
+        R"({"a": "9007199254740993"})",
+        R"({"b": 9007199254740993})",
+    };
+
+    auto schema = std::make_shared<Schema>();
+    auto i64_fid = schema->AddDebugField("id", DataType::INT64);
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    schema->set_primary_field_id(i64_fid);
+    auto seg = CreateSealedSegment(schema);
+
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+    std::vector<milvus::Json> jsons;
+    for (auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+
+    auto file_manager_ctx = storage::FileManagerContext();
+    file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+        milvus::proto::schema::JSON);
+    file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+    file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
+    auto inv_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        index::CreateIndexInfo{
+            .index_type = index::INVERTED_INDEX_TYPE,
+            .json_cast_type = JsonCastType::FromString("DOUBLE"),
+            .json_path = "/a",
+        },
+        file_manager_ctx);
+    using JsonIndex = index::JsonInvertedIndex<double>;
+    auto json_index = std::unique_ptr<JsonIndex>(
+        static_cast<JsonIndex*>(inv_index.release()));
+    json_index->BuildWithFieldData({json_field});
+    json_index->finish();
+    json_index->create_reader(milvus::index::SetBitsetSealed);
+
+    segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_id = json_fid.get();
+    load_index_info.field_type = DataType::JSON;
+    load_index_info.index_params = {{JSON_PATH, "/a"},
+                                    {JSON_CAST_TYPE, "DOUBLE"}};
+    load_index_info.cache_index =
+        CreateTestCacheIndex("large_int_json", std::move(json_index));
+    seg->LoadIndex(load_index_info);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    seg->LoadFieldData(load_info);
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(kLargeInt);
+    auto evaluate_unary = [&](proto::plan::OpType op) {
+        auto unary_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+            op,
+            value,
+            std::vector<proto::plan::GenericValue>());
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           unary_expr);
+        return ExecuteQueryExpr(
+            plan, seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    };
+
+    auto equal = evaluate_unary(proto::plan::OpType::Equal);
+    EXPECT_EQ(equal.count(), 1);
+    EXPECT_TRUE(equal[1]);
+
+    auto greater = evaluate_unary(proto::plan::OpType::GreaterThan);
+    EXPECT_EQ(greater.count(), 2);
+    EXPECT_TRUE(greater[2]);
+    EXPECT_TRUE(greater[4]);
+
+    auto binary_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        value,
+        value,
+        true,
+        true);
+    auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                       binary_expr);
+    auto singleton =
+        ExecuteQueryExpr(plan, seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(singleton.count(), 1);
+    EXPECT_TRUE(singleton[1]);
+}
+
 class JsonIndexExistsTest : public ::testing::TestWithParam<std::string> {};
 
 INSTANTIATE_TEST_SUITE_P(JsonIndexExistsTestParams,

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -16,6 +16,10 @@
 
 #include "ExprTestBase.h"
 
+#include <algorithm>
+#include <limits>
+#include <numeric>
+
 namespace {
 
 struct ExprBatchSizeGuard {
@@ -228,6 +232,241 @@ TYPED_TEST(JsonIndexTestFixture, TestJsonIndexUnaryExpr) {
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, not_expr);
     final = ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
     EXPECT_EQ(final.count(), N - expect_count);
+}
+
+TEST(JsonIndexTest, JsonBinaryRangePathIndexMatchesRawData) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+
+    const std::vector<std::string> json_strs = {
+        R"({"n": 1, "s": "alpha"})",
+        R"({"n": 2, "s": "beta"})",
+        R"({"n": 3.5, "s": "gamma"})",
+        R"({"n": "2", "s": 2})",
+        R"({"other": 0})",
+        R"({"n": null, "s": null})",
+        R"({"n": 4, "s": "delta"})",
+        R"({"n": 5, "s": "epsilon"})",
+        R"({"n": 9007199254740993, "s": "zeta"})",
+    };
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    std::vector<milvus::Json> jsons;
+    jsons.reserve(json_strs.size());
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    auto* valid_data = json_field->ValidData();
+    std::fill(valid_data,
+              valid_data + json_field->ValidDataSize(),
+              static_cast<uint8_t>(0));
+    valid_data[0] = 0b01111111;
+    valid_data[1] = 0b00000001;
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto raw_segment = CreateSealedSegment(schema);
+    auto raw_load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    raw_segment->LoadFieldData(raw_load_info);
+
+    auto make_index_segment = [&](const JsonCastType& cast_type,
+                                  const std::string& path,
+                                  const std::string& cache_key,
+                                  int64_t build_id,
+                                  bool load_raw_json = false) {
+        auto segment = CreateSealedSegment(schema);
+
+        std::vector<int64_t> row_ids(json_strs.size());
+        std::iota(row_ids.begin(), row_ids.end(), 0);
+        auto row_id_field_data =
+            storage::CreateFieldData(DataType::INT64, DataType::NONE, false);
+        row_id_field_data->FillFieldData(row_ids.data(), row_ids.size());
+        auto row_id_load_info = PrepareSingleFieldInsertBinlog(
+            1, 1, 1, RowFieldID.get(), {row_id_field_data}, cm);
+        segment->LoadFieldData(row_id_load_info);
+
+        auto file_manager_ctx = storage::FileManagerContext();
+        file_manager_ctx.fieldDataMeta = {};
+        file_manager_ctx.indexMeta = {};
+        file_manager_ctx.fieldDataMeta.collection_id = 1;
+        file_manager_ctx.fieldDataMeta.partition_id = 1;
+        file_manager_ctx.fieldDataMeta.segment_id = 1;
+        file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+            proto::schema::JSON);
+        file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+        file_manager_ctx.fieldDataMeta.field_schema.set_nullable(true);
+        file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
+        file_manager_ctx.indexMeta.segment_id = 1;
+        file_manager_ctx.indexMeta.field_id = json_fid.get();
+        file_manager_ctx.indexMeta.build_id = build_id;
+        file_manager_ctx.indexMeta.index_version = 1;
+        auto json_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+            index::CreateIndexInfo{
+                .index_type = index::INVERTED_INDEX_TYPE,
+                .json_cast_type = cast_type,
+                .json_path = path,
+            },
+            file_manager_ctx);
+        if (cast_type.data_type() == JsonCastType::DataType::DOUBLE) {
+            auto* typed_index = dynamic_cast<index::JsonInvertedIndex<double>*>(
+                json_index.get());
+            AssertInfo(typed_index != nullptr,
+                       "expected a DOUBLE JSON path index");
+            typed_index->BuildWithFieldData({json_field});
+            typed_index->finish();
+            typed_index->create_reader(milvus::index::SetBitsetSealed);
+        } else {
+            auto* typed_index =
+                dynamic_cast<index::JsonInvertedIndex<std::string>*>(
+                    json_index.get());
+            AssertInfo(typed_index != nullptr,
+                       "expected a VARCHAR JSON path index");
+            typed_index->BuildWithFieldData({json_field});
+            typed_index->finish();
+            typed_index->create_reader(milvus::index::SetBitsetSealed);
+        }
+
+        segcore::LoadIndexInfo load_index_info;
+        load_index_info.field_id = json_fid.get();
+        load_index_info.field_type = DataType::JSON;
+        load_index_info.index_params = {{JSON_PATH, path},
+                                        {JSON_CAST_TYPE, cast_type.ToString()}};
+        load_index_info.cache_index =
+            CreateTestCacheIndex(cache_key, std::move(json_index));
+        segment->LoadIndex(load_index_info);
+        if (load_raw_json) {
+            auto raw_load_info = PrepareSingleFieldInsertBinlog(
+                1, 1, 2, json_fid.get(), {json_field}, cm);
+            segment->LoadFieldData(raw_load_info);
+        } else {
+            AssertInfo(!segment->HasFieldData(json_fid),
+                       "raw JSON must stay unloaded for this test");
+        }
+        return segment;
+    };
+
+    auto number_index_segment =
+        make_index_segment(JsonCastType::FromString("DOUBLE"),
+                           "/n",
+                           "json_binary_range_number",
+                           6101);
+    auto string_index_segment =
+        make_index_segment(JsonCastType::FromString("VARCHAR"),
+                           "/s",
+                           "json_binary_range_string",
+                           6102);
+    auto precise_number_segment =
+        make_index_segment(JsonCastType::FromString("DOUBLE"),
+                           "/n",
+                           "json_binary_range_precise_number",
+                           6103,
+                           true);
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr,
+                        const segcore::SegmentInternalInterface* segment,
+                        exec::OffsetVector* offsets = nullptr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), segment, json_strs.size(), MAX_TIMESTAMP, offsets);
+    };
+    auto expect_same = [&](const ColumnVectorPtr& raw,
+                           const ColumnVectorPtr& indexed) {
+        ASSERT_EQ(raw->size(), indexed->size());
+        TargetBitmapView raw_result(raw->GetRawData(), raw->size());
+        TargetBitmapView raw_valid(raw->GetValidRawData(), raw->size());
+        TargetBitmapView index_result(indexed->GetRawData(), indexed->size());
+        TargetBitmapView index_valid(indexed->GetValidRawData(),
+                                     indexed->size());
+        for (size_t i = 0; i < raw->size(); ++i) {
+            EXPECT_EQ(index_valid[i], raw_valid[i]) << "row " << i;
+            EXPECT_EQ(index_result[i], raw_result[i]) << "row " << i;
+        }
+    };
+
+    proto::plan::GenericValue number_lower;
+    number_lower.set_int64_val(2);
+    proto::plan::GenericValue number_upper;
+    number_upper.set_float_val(4.0);
+    auto number_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+        number_lower,
+        number_upper,
+        true,
+        true);
+    expect_same(evaluate(number_expr, raw_segment.get()),
+                evaluate(number_expr, number_index_segment.get()));
+
+    exec::OffsetVector offsets = {7, 2, 4, 1, 3, 5, 6, 0, 2};
+    expect_same(evaluate(number_expr, raw_segment.get(), &offsets),
+                evaluate(number_expr, number_index_segment.get(), &offsets));
+
+    auto expect_nan_range_matches_raw = [&](bool nan_is_lower) {
+        proto::plan::GenericValue nan_bound;
+        nan_bound.set_float_val(std::numeric_limits<double>::quiet_NaN());
+        proto::plan::GenericValue finite_bound;
+        finite_bound.set_float_val(nan_is_lower ? 4.0 : 0.0);
+        auto nan_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+            expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+            nan_is_lower ? nan_bound : finite_bound,
+            nan_is_lower ? finite_bound : nan_bound,
+            true,
+            true);
+        auto raw_nan = evaluate(nan_expr, raw_segment.get());
+        auto indexed_nan = evaluate(nan_expr, number_index_segment.get());
+        expect_same(raw_nan, indexed_nan);
+        expect_same(evaluate(nan_expr, raw_segment.get(), &offsets),
+                    evaluate(nan_expr, number_index_segment.get(), &offsets));
+
+        TargetBitmapView result(raw_nan->GetRawData(), raw_nan->size());
+        TargetBitmapView validity(raw_nan->GetValidRawData(), raw_nan->size());
+        const std::vector<size_t> numeric_rows = {0, 1, 2, 6, 8};
+        for (size_t i = 0; i < raw_nan->size(); ++i) {
+            EXPECT_FALSE(result[i]) << "row " << i;
+            EXPECT_EQ(validity[i],
+                      std::find(numeric_rows.begin(), numeric_rows.end(), i) !=
+                          numeric_rows.end())
+                << "row " << i;
+        }
+    };
+    expect_nan_range_matches_raw(true);
+    expect_nan_range_matches_raw(false);
+
+    proto::plan::GenericValue string_lower;
+    string_lower.set_string_val("beta");
+    proto::plan::GenericValue string_upper;
+    string_upper.set_string_val("gamma");
+    auto string_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"s"}),
+        string_lower,
+        string_upper,
+        true,
+        false);
+    expect_same(evaluate(string_expr, raw_segment.get()),
+                evaluate(string_expr, string_index_segment.get()));
+    expect_same(evaluate(string_expr, raw_segment.get(), &offsets),
+                evaluate(string_expr, string_index_segment.get(), &offsets));
+
+    proto::plan::GenericValue precise_lower;
+    precise_lower.set_float_val(9007199254740992.0);
+    proto::plan::GenericValue precise_upper;
+    precise_upper.set_float_val(9007199254740994.0);
+    auto precise_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+        precise_lower,
+        precise_upper,
+        false,
+        false);
+    auto raw_precise = evaluate(precise_expr, raw_segment.get());
+    auto indexed_precise = evaluate(precise_expr, precise_number_segment.get());
+    expect_same(raw_precise, indexed_precise);
+    TargetBitmapView precise_result(raw_precise->GetRawData(),
+                                    raw_precise->size());
+    TargetBitmapView precise_valid(raw_precise->GetValidRawData(),
+                                   raw_precise->size());
+    EXPECT_TRUE(precise_valid[8]);
+    EXPECT_TRUE(precise_result[8]);
 }
 
 TEST(JsonIndexTest, TestJsonNotEqualExpr) {
@@ -669,17 +908,13 @@ TEST_P(JsonIndexBinaryExprTest, TestBinaryRangeExpr) {
     file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
     file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
 
-    auto inv_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+    auto json_index = index::IndexFactory::GetInstance().CreateJsonIndex(
         index::CreateIndexInfo{
             .index_type = index::INVERTED_INDEX_TYPE,
             .json_cast_type = GetParam(),
             .json_path = "/a",
         },
         file_manager_ctx);
-
-    using json_index_type = index::JsonInvertedIndex<double>;
-    auto json_index = std::unique_ptr<json_index_type>(
-        static_cast<json_index_type*>(inv_index.release()));
     auto json_field =
         std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
     std::vector<milvus::Json> jsons;
@@ -689,9 +924,22 @@ TEST_P(JsonIndexBinaryExprTest, TestBinaryRangeExpr) {
     }
     json_field->add_json_data(jsons);
 
-    json_index->BuildWithFieldData({json_field});
-    json_index->finish();
-    json_index->create_reader(milvus::index::SetBitsetSealed);
+    if (GetParam().data_type() == JsonCastType::DataType::DOUBLE) {
+        auto* typed_index =
+            dynamic_cast<index::JsonInvertedIndex<double>*>(json_index.get());
+        ASSERT_NE(typed_index, nullptr);
+        typed_index->BuildWithFieldData({json_field});
+        typed_index->finish();
+        typed_index->create_reader(milvus::index::SetBitsetSealed);
+    } else {
+        auto* typed_index =
+            dynamic_cast<index::JsonInvertedIndex<std::string>*>(
+                json_index.get());
+        ASSERT_NE(typed_index, nullptr);
+        typed_index->BuildWithFieldData({json_field});
+        typed_index->finish();
+        typed_index->create_reader(milvus::index::SetBitsetSealed);
+    }
 
     load_index_info.field_id = json_fid.get();
     load_index_info.field_type = DataType::JSON;

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -16,6 +16,22 @@
 
 #include "ExprTestBase.h"
 
+namespace {
+
+struct ExprBatchSizeGuard {
+    explicit ExprBatchSizeGuard(int64_t batch_size)
+        : old_batch_size_(EXEC_EVAL_EXPR_BATCH_SIZE.exchange(batch_size)) {
+    }
+
+    ~ExprBatchSizeGuard() {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(old_batch_size_);
+    }
+
+    int64_t old_batch_size_;
+};
+
+}  // namespace
+
 template <typename T>
 class JsonIndexTestFixture : public testing::Test {
  public:
@@ -314,6 +330,7 @@ TEST(JsonIndexTest, TestJsonNotEqualExpr) {
 }
 
 TEST(JsonIndexTest, LargeInt64LiteralFallsBackToPreciseRawComparison) {
+    ExprBatchSizeGuard batch_size_guard(3);
     constexpr int64_t kLargeInt = 9007199254740993LL;
     auto json_strs = std::vector<std::string>{
         R"({"a": 9007199254740992})",

--- a/internal/core/src/exec/expression/ExprJsonRangeTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonRangeTest.cpp
@@ -18,6 +18,40 @@
 
 EXPR_TEST_INSTANTIATE();
 
+TEST(ExprJsonTermTest, MixedValueTypesReturnError) {
+    auto schema = std::make_shared<Schema>();
+    auto i64_fid = schema->AddDebugField("id", DataType::INT64);
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    schema->set_primary_field_id(i64_fid);
+
+    auto seg = CreateGrowingSegment(schema, empty_index_meta);
+    auto raw_data = DataGen(schema, 1, 0);
+    seg->PreInsert(1);
+    seg->Insert(0,
+                1,
+                raw_data.row_ids_.data(),
+                raw_data.timestamps_.data(),
+                raw_data.raw_);
+
+    proto::plan::GenericValue int_value;
+    int_value.set_int64_val(1);
+    proto::plan::GenericValue string_value;
+    string_value.set_string_val("1");
+    auto term_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"int"}),
+        std::vector<proto::plan::GenericValue>{int_value, string_value},
+        false);
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, term_expr);
+
+    try {
+        ExecuteQueryExpr(plan, seg.get(), 1, MAX_TIMESTAMP);
+        FAIL() << "mixed TermExpr values must be rejected";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), DataTypeInvalid);
+    }
+}
+
 TEST_P(ExprTest, TestBinaryRangeJSON) {
     struct Testcase {
         bool lower_inclusive;

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -12,13 +12,21 @@
 #include <arrow/builder.h>
 #include <fmt/core.h>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "common/Consts.h"
 #include "common/Schema.h"
 #include "common/Types.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/BinaryRangeExpr.h"
+#include "exec/expression/EvalCtx.h"
+#include "exec/expression/Expr.h"
 #include "exec/expression/UnaryExpr.h"
 #include "expr/ITypeExpr.h"
 #include "index/json_stats/JsonKeyStats.h"
@@ -161,6 +169,96 @@ BuildAndLoadJsonKeyStats(const std::vector<std::string>& json_strings,
     return slot;
 }
 
+struct ExprBatchEvalResult {
+    std::vector<int64_t> batch_sizes;
+    ColumnVectorPtr result;
+};
+
+class ExprBatchSizeGuard {
+ public:
+    explicit ExprBatchSizeGuard(int64_t batch_size)
+        : old_batch_size_(EXEC_EVAL_EXPR_BATCH_SIZE.exchange(batch_size)) {
+    }
+
+    ~ExprBatchSizeGuard() {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(old_batch_size_);
+    }
+
+ private:
+    int64_t old_batch_size_;
+};
+
+ExprBatchEvalResult
+EvalExprInBatches(const expr::TypedExprPtr& logical_expr,
+                  const segcore::SegmentInternalInterface* segment,
+                  int64_t active_count) {
+    auto query_context = std::make_shared<exec::QueryContext>(
+        DEAFULT_QUERY_ID, segment, active_count, MAX_TIMESTAMP);
+    exec::ExecContext exec_context(query_context.get());
+    auto compiled =
+        exec::CompileExpressions({logical_expr}, &exec_context, {}, false);
+    AssertInfo(compiled.size() == 1,
+               "expected one compiled expression, got {}",
+               compiled.size());
+
+    exec::EvalCtx eval_context(&exec_context);
+    ExprBatchEvalResult evaluation;
+    TargetBitmap combined_result;
+    TargetBitmap combined_validity;
+    int64_t processed_rows = 0;
+    while (processed_rows < active_count) {
+        VectorPtr result;
+        compiled[0]->Eval(eval_context, result);
+        AssertInfo(result != nullptr,
+                   "expression evaluation stopped after {} of {} rows",
+                   processed_rows,
+                   active_count);
+        auto column = std::dynamic_pointer_cast<ColumnVector>(result);
+        AssertInfo(column != nullptr && column->IsBitmap(),
+                   "expected bitmap column result");
+        const auto batch_size = column->size();
+        AssertInfo(
+            batch_size > 0 && processed_rows + batch_size <= active_count,
+            "invalid expression batch size {} after {} of {} rows",
+            batch_size,
+            processed_rows,
+            active_count);
+        evaluation.batch_sizes.push_back(batch_size);
+        combined_result.append(
+            TargetBitmapView(column->GetRawData(), batch_size));
+        combined_validity.append(
+            TargetBitmapView(column->GetValidRawData(), batch_size));
+        processed_rows += batch_size;
+    }
+    evaluation.result = std::make_shared<ColumnVector>(
+        std::move(combined_result), std::move(combined_validity));
+    return evaluation;
+}
+
+ColumnVectorPtr
+EvalExprOnce(const expr::TypedExprPtr& logical_expr,
+             const segcore::SegmentInternalInterface* segment,
+             int64_t active_count,
+             exec::OffsetVector* offsets = nullptr) {
+    auto query_context = std::make_shared<exec::QueryContext>(
+        DEAFULT_QUERY_ID, segment, active_count, MAX_TIMESTAMP);
+    exec::ExecContext exec_context(query_context.get());
+    auto compiled =
+        exec::CompileExpressions({logical_expr}, &exec_context, {}, false);
+    AssertInfo(compiled.size() == 1,
+               "expected one compiled expression, got {}",
+               compiled.size());
+
+    exec::EvalCtx eval_context(&exec_context);
+    eval_context.set_offset_input(offsets);
+    VectorPtr result;
+    compiled[0]->Eval(eval_context, result);
+    auto column = std::dynamic_pointer_cast<ColumnVector>(result);
+    AssertInfo(column != nullptr && column->IsBitmap(),
+               "expected bitmap column result");
+    return column;
+}
+
 }  // namespace
 
 TEST(JsonContainsByStatsTest, BasicContainsAnyOnArray) {
@@ -263,6 +361,52 @@ TEST(JsonContainsByStatsTest, BasicContainsAnyOnArray) {
     }
 }
 
+TEST(JsonContainsByStatsTest, EmptyElementsAdvanceWithoutRawJson) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    const std::vector<std::string> json_raw_data(8, R"({"a": [1, 2]})");
+
+    auto stats = BuildAndLoadJsonKeyStats(json_raw_data,
+                                          json_fid,
+                                          TestLocalPath,
+                                          1002,
+                                          2002,
+                                          3002,
+                                          json_fid.get(),
+                                          5002,
+                                          1);
+    auto segment = segcore::CreateSealedSegment(schema);
+    segment->LoadJsonStats(json_fid, stats);
+    ASSERT_FALSE(segment->HasFieldData(json_fid));
+
+    for (const auto op : {
+             proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+             proto::plan::JSONContainsExpr_JSONOp_ContainsAll,
+         }) {
+        auto contains_expr = std::make_shared<expr::JsonContainsExpr>(
+            expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+            op,
+            true,
+            std::vector<proto::plan::GenericValue>{});
+
+        ExprBatchSizeGuard batch_size_guard(3);
+        auto batches = EvalExprInBatches(
+            contains_expr, segment.get(), json_raw_data.size());
+        EXPECT_EQ(batches.batch_sizes, (std::vector<int64_t>{3, 3, 2}));
+
+        TargetBitmapView values(batches.result->GetRawData(),
+                                batches.result->size());
+        TargetBitmapView validity(batches.result->GetValidRawData(),
+                                  batches.result->size());
+        for (size_t i = 0; i < batches.result->size(); ++i) {
+            EXPECT_EQ(values[i],
+                      op == proto::plan::JSONContainsExpr_JSONOp_ContainsAll)
+                << "row " << i;
+            EXPECT_TRUE(validity[i]) << "row " << i;
+        }
+    }
+}
+
 TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathUnknownsAndMasksFieldNull) {
     auto schema = std::make_shared<Schema>();
     auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
@@ -332,4 +476,288 @@ TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathUnknownsAndMasksFieldNull) {
     EXPECT_TRUE(result[6]);
     EXPECT_FALSE(result[7]);
     EXPECT_EQ(result.count(), 2);
+}
+
+TEST(JsonStatsBinaryRangeTest, ShreddingMatchesRawData) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+    auto gate_fid = schema->AddDebugField("gate", DataType::INT64);
+
+    const std::vector<std::string> json_raw_data = {
+        R"({"n": 1.0, "s": "alpha", "i": 9007199254740992, "u": 9223372036854775809, "rare": 1.0, "sparse_i": 9007199254740992})",
+        R"({"n": 2.0, "s": "beta", "i": 9007199254740993, "rare": "not-a-number", "sparse_i": 9007199254740993})",
+        R"({"n": 3.5, "s": "gamma", "i": 9007199254740994})",
+        R"({"n": "2", "s": 2, "i": "9007199254740993"})",
+        R"({"other": 0})",
+        R"({"n": null, "s": null, "i": null})",
+        R"({"n": 4.0, "s": "delta", "i": 1})",
+        R"({"n": 5.0, "s": "epsilon", "i": 2})",
+    };
+    const std::vector<uint8_t> valid_data{0b01111111};
+
+    auto stats = BuildAndLoadJsonKeyStats(json_raw_data,
+                                          json_fid,
+                                          TestLocalPath,
+                                          1203,
+                                          2203,
+                                          3203,
+                                          json_fid.get(),
+                                          5203,
+                                          1,
+                                          &valid_data);
+    auto stats_segment = segcore::CreateSealedSegment(schema);
+    stats_segment->LoadJsonStats(json_fid, stats);
+    auto pinned_stats = stats_segment->GetJsonStats(nullptr, json_fid);
+    ASSERT_NE(pinned_stats.get(), nullptr);
+    EXPECT_FALSE(pinned_stats.get()
+                     ->GetShreddingField(milvus::index::JsonPointer({"n"}),
+                                         JSONType::DOUBLE)
+                     .empty());
+    EXPECT_FALSE(pinned_stats.get()
+                     ->GetShreddingField(milvus::index::JsonPointer({"s"}),
+                                         JSONType::STRING)
+                     .empty());
+    EXPECT_FALSE(pinned_stats.get()
+                     ->GetShreddingField(milvus::index::JsonPointer({"i"}),
+                                         JSONType::INT64)
+                     .empty());
+    EXPECT_TRUE(pinned_stats.get()
+                    ->GetShreddingField(milvus::index::JsonPointer({"rare"}),
+                                        JSONType::DOUBLE)
+                    .empty());
+    EXPECT_TRUE(pinned_stats.get()
+                    ->GetShreddingField(milvus::index::JsonPointer({"rare"}),
+                                        JSONType::STRING)
+                    .empty());
+    EXPECT_TRUE(
+        pinned_stats.get()
+            ->GetShreddingField(milvus::index::JsonPointer({"sparse_i"}),
+                                JSONType::INT64)
+            .empty());
+    auto raw_segment = segcore::CreateSealedSegment(schema);
+
+    auto make_json_field = [&] {
+        auto field =
+            std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+        field->FillFieldData(MakeNullableJsonArray(json_raw_data, valid_data));
+        return field;
+    };
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto stats_load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, json_fid.get(), {make_json_field()}, cm);
+    stats_segment->LoadFieldData(stats_load_info);
+    stats_segment->DropFieldData(json_fid);
+    ASSERT_FALSE(stats_segment->HasFieldData(json_fid));
+    auto raw_load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, json_fid.get(), {make_json_field()}, cm);
+    raw_segment->LoadFieldData(raw_load_info);
+
+    std::vector<int64_t> gate_values = {0, 1, 2, 3, 4, 5, 6, 7};
+    auto gate_field =
+        std::make_shared<FieldData<int64_t>>(DataType::INT64, false);
+    gate_field->FillFieldData(gate_values.data(), gate_values.size());
+    auto gate_load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, gate_fid.get(), {gate_field}, cm);
+    stats_segment->LoadFieldData(gate_load_info);
+    raw_segment->LoadFieldData(gate_load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr,
+                        const segcore::SegmentInternalInterface* segment,
+                        exec::OffsetVector* offsets = nullptr) {
+        return EvalExprOnce(
+            filter_expr, segment, json_raw_data.size(), offsets);
+    };
+    auto expect_same = [](const ColumnVectorPtr& raw,
+                          const ColumnVectorPtr& shredded) {
+        ASSERT_EQ(raw->size(), shredded->size());
+        TargetBitmapView raw_result(raw->GetRawData(), raw->size());
+        TargetBitmapView raw_valid(raw->GetValidRawData(), raw->size());
+        TargetBitmapView shredded_result(shredded->GetRawData(),
+                                         shredded->size());
+        TargetBitmapView shredded_valid(shredded->GetValidRawData(),
+                                        shredded->size());
+        for (size_t i = 0; i < raw->size(); ++i) {
+            EXPECT_EQ(shredded_valid[i], raw_valid[i]) << "row " << i;
+            EXPECT_EQ(shredded_result[i], raw_result[i]) << "row " << i;
+        }
+    };
+    auto expect_batched_same = [&](const expr::TypedExprPtr& filter_expr) {
+        ExprBatchSizeGuard batch_size_guard(3);
+        auto raw_batches = EvalExprInBatches(
+            filter_expr, raw_segment.get(), json_raw_data.size());
+        auto stats_batches = EvalExprInBatches(
+            filter_expr, stats_segment.get(), json_raw_data.size());
+        EXPECT_EQ(raw_batches.batch_sizes, (std::vector<int64_t>{3, 3, 2}));
+        EXPECT_EQ(stats_batches.batch_sizes, (std::vector<int64_t>{3, 3, 2}));
+        expect_same(raw_batches.result, stats_batches.result);
+    };
+
+    proto::plan::GenericValue number_lower;
+    number_lower.set_int64_val(2);
+    proto::plan::GenericValue number_upper;
+    number_upper.set_float_val(4.0);
+    auto number_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+        number_lower,
+        number_upper,
+        true,
+        true);
+    expect_same(evaluate(number_expr, raw_segment.get()),
+                evaluate(number_expr, stats_segment.get()));
+    exec::OffsetVector offsets = {7, 2, 4, 1, 3, 5, 6, 0, 2};
+    expect_same(evaluate(number_expr, raw_segment.get(), &offsets),
+                evaluate(number_expr, stats_segment.get(), &offsets));
+    expect_batched_same(number_expr);
+
+    auto unary_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+        proto::plan::OpType::GreaterEqual,
+        number_lower,
+        std::vector<proto::plan::GenericValue>());
+    {
+        ExprBatchSizeGuard batch_size_guard(3);
+        auto raw_batches = EvalExprInBatches(
+            unary_expr, raw_segment.get(), json_raw_data.size());
+        auto stats_batches = EvalExprInBatches(
+            unary_expr, stats_segment.get(), json_raw_data.size());
+        EXPECT_EQ(raw_batches.batch_sizes, (std::vector<int64_t>{3, 3, 2}));
+        EXPECT_EQ(stats_batches.batch_sizes, (std::vector<int64_t>{3, 3, 2}));
+        expect_same(raw_batches.result, stats_batches.result);
+    }
+
+    proto::plan::GenericValue gate_lower;
+    gate_lower.set_int64_val(3);
+    auto gate_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(gate_fid, DataType::INT64),
+        proto::plan::OpType::GreaterEqual,
+        gate_lower,
+        std::vector<proto::plan::GenericValue>());
+    auto conjunct_expr = std::make_shared<expr::LogicalBinaryExpr>(
+        expr::LogicalBinaryExpr::OpType::And, gate_expr, unary_expr);
+    {
+        ExprBatchSizeGuard batch_size_guard(3);
+        auto raw_batches = EvalExprInBatches(
+            conjunct_expr, raw_segment.get(), json_raw_data.size());
+        auto stats_batches = EvalExprInBatches(
+            conjunct_expr, stats_segment.get(), json_raw_data.size());
+        EXPECT_EQ(raw_batches.batch_sizes, (std::vector<int64_t>{3, 3, 2}));
+        EXPECT_EQ(stats_batches.batch_sizes, (std::vector<int64_t>{3, 3, 2}));
+        expect_same(raw_batches.result, stats_batches.result);
+    }
+
+    proto::plan::GenericValue string_lower;
+    string_lower.set_string_val("beta");
+    proto::plan::GenericValue string_upper;
+    string_upper.set_string_val("gamma");
+    auto string_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"s"}),
+        string_lower,
+        string_upper,
+        true,
+        false);
+    expect_same(evaluate(string_expr, raw_segment.get()),
+                evaluate(string_expr, stats_segment.get()));
+    expect_same(evaluate(string_expr, raw_segment.get(), &offsets),
+                evaluate(string_expr, stats_segment.get(), &offsets));
+    expect_batched_same(string_expr);
+
+    proto::plan::GenericValue precise_lower;
+    precise_lower.set_float_val(9007199254740992.0);
+    proto::plan::GenericValue precise_upper;
+    precise_upper.set_float_val(9007199254740994.0);
+    auto precise_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"i"}),
+        precise_lower,
+        precise_upper,
+        false,
+        false);
+    auto raw_precise = evaluate(precise_expr, raw_segment.get());
+    auto shredded_precise = evaluate(precise_expr, stats_segment.get());
+    expect_same(raw_precise, shredded_precise);
+    expect_same(evaluate(precise_expr, raw_segment.get(), &offsets),
+                evaluate(precise_expr, stats_segment.get(), &offsets));
+    TargetBitmapView precise_result(raw_precise->GetRawData(),
+                                    raw_precise->size());
+    TargetBitmapView precise_valid(raw_precise->GetValidRawData(),
+                                   raw_precise->size());
+    EXPECT_TRUE(precise_valid[1]);
+    EXPECT_TRUE(precise_result[1]);
+
+    proto::plan::GenericValue sparse_lower;
+    sparse_lower.set_float_val(9007199254740992.0);
+    proto::plan::GenericValue sparse_upper;
+    sparse_upper.set_float_val(9007199254740994.0);
+    auto sparse_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"sparse_i"}),
+        sparse_lower,
+        sparse_upper,
+        false,
+        false);
+    auto raw_sparse = evaluate(sparse_expr, raw_segment.get());
+    auto stats_sparse = evaluate(sparse_expr, stats_segment.get());
+    expect_same(raw_sparse, stats_sparse);
+    expect_same(evaluate(sparse_expr, raw_segment.get(), &offsets),
+                evaluate(sparse_expr, stats_segment.get(), &offsets));
+    expect_batched_same(sparse_expr);
+    TargetBitmapView sparse_result(raw_sparse->GetRawData(),
+                                   raw_sparse->size());
+    TargetBitmapView sparse_valid(raw_sparse->GetValidRawData(),
+                                  raw_sparse->size());
+    for (size_t i = 0; i < raw_sparse->size(); ++i) {
+        EXPECT_EQ(sparse_valid[i], i < 2) << "row " << i;
+        EXPECT_EQ(sparse_result[i], i == 1) << "row " << i;
+    }
+
+    proto::plan::GenericValue uint64_double;
+    uint64_double.set_float_val(9223372036854775808.0);
+    auto uint64_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"u"}),
+        uint64_double,
+        uint64_double,
+        true,
+        true);
+    auto raw_uint64 = evaluate(uint64_expr, raw_segment.get());
+    auto stats_uint64 = evaluate(uint64_expr, stats_segment.get());
+    expect_same(raw_uint64, stats_uint64);
+    expect_same(evaluate(uint64_expr, raw_segment.get(), &offsets),
+                evaluate(uint64_expr, stats_segment.get(), &offsets));
+    TargetBitmapView uint64_result(raw_uint64->GetRawData(),
+                                   raw_uint64->size());
+    TargetBitmapView uint64_valid(raw_uint64->GetValidRawData(),
+                                  raw_uint64->size());
+    EXPECT_TRUE(uint64_valid[0]);
+    EXPECT_TRUE(uint64_result[0]);
+
+    proto::plan::GenericValue nan_lower;
+    nan_lower.set_float_val(std::numeric_limits<double>::quiet_NaN());
+    proto::plan::GenericValue nan_upper;
+    nan_upper.set_float_val(10.0);
+    auto expect_nan_range_matches_raw =
+        [&](const std::string& path,
+            const std::vector<size_t>& known_numeric_rows) {
+            auto nan_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+                expr::ColumnInfo(json_fid, DataType::JSON, {path}),
+                nan_lower,
+                nan_upper,
+                true,
+                true);
+            auto raw_nan = evaluate(nan_expr, raw_segment.get());
+            auto stats_nan = evaluate(nan_expr, stats_segment.get());
+            expect_same(raw_nan, stats_nan);
+
+            TargetBitmapView result(raw_nan->GetRawData(), raw_nan->size());
+            TargetBitmapView valid(raw_nan->GetValidRawData(), raw_nan->size());
+            for (size_t i = 0; i < raw_nan->size(); ++i) {
+                EXPECT_FALSE(result[i]) << "path " << path << ", row " << i;
+                const auto is_known_numeric =
+                    std::find(known_numeric_rows.begin(),
+                              known_numeric_rows.end(),
+                              i) != known_numeric_rows.end();
+                EXPECT_EQ(valid[i], is_known_numeric)
+                    << "path " << path << ", row " << i;
+            }
+        };
+    expect_nan_range_matches_raw("n", {0, 1, 2, 6});
+    expect_nan_range_matches_raw("rare", {0});
 }

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -143,7 +143,15 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
             break;
         }
         case DataType::JSON: {
-            if (SegmentExpr::CanUseIndex() && !has_offset_input_) {
+            const auto has_array_literal =
+                std::any_of(expr_->vals_.begin(),
+                            expr_->vals_.end(),
+                            [](const auto& value) {
+                                return value.val_case() ==
+                                       proto::plan::GenericValue::kArrayVal;
+                            });
+            if (expr_->same_type_ && !has_array_literal && !has_offset_input_ &&
+                SegmentExpr::CanUseIndex()) {
                 result = EvalArrayContainsForIndexSegment(
                     value_type_ == DataType::INT64 ? DataType::DOUBLE
                                                    : value_type_);

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -156,6 +156,7 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                     value_type_ == DataType::INT64 ? DataType::DOUBLE
                                                    : value_type_);
             } else {
+                SetNotUseIndex();
                 result = EvalJsonContainsForDataSegment(context);
             }
             break;

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -112,9 +112,15 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));
     if (expr_->vals_.empty()) {
-        auto real_batch_size = has_offset_input_
-                                   ? context.get_offset_input()->size()
-                                   : GetNextBatchSize();
+        // This constant-result path does not inspect raw data, an index, or
+        // JSON stats.  Use the logical row cursor directly so it also works
+        // when raw JSON has been dropped and no physical data cursor can
+        // advance.
+        auto real_batch_size =
+            has_offset_input_
+                ? context.get_offset_input()->size()
+                : std::min(batch_size_,
+                           active_count_ - current_data_global_pos_);
         if (real_batch_size == 0) {
             result = nullptr;
             return;

--- a/internal/core/src/exec/expression/JsonNumberComparison.h
+++ b/internal/core/src/exec/expression/JsonNumberComparison.h
@@ -33,6 +33,23 @@ IsInt64SafeForJsonDoubleIndex(int64_t value) {
            value < kFirstNonInjectiveInteger;
 }
 
+inline bool
+JsonNumericBoundRequiresPreciseInt64Comparison(
+    const proto::plan::GenericValue& bound) {
+    if (bound.has_int64_val()) {
+        return !IsInt64SafeForJsonDoubleIndex(bound.int64_val());
+    }
+    if (!bound.has_float_val() || !std::isfinite(bound.float_val())) {
+        return false;
+    }
+
+    constexpr double kFirstNonInjectiveInteger = 0x1p53;
+    constexpr double kInt64Magnitude = 0x1p63;
+    const auto value = bound.float_val();
+    return (value >= kFirstNonInjectiveInteger && value <= kInt64Magnitude) ||
+           (value <= -kFirstNonInjectiveInteger && value >= -kInt64Magnitude);
+}
+
 inline int
 CompareInt64ToDouble(int64_t lhs, double rhs) {
     constexpr double kInt64Lower = -0x1p63;
@@ -151,6 +168,19 @@ CompareJsonNumberToBound(const simdjson::ondemand::number& number,
         return std::nullopt;
     }
     return CompareJsonNumberToBound(number.get_double(), bound);
+}
+
+// JSON stats and typed JSON indexes store uint64 values as double. Preserve
+// that established behavior while comparing int64 JSON values exactly.
+inline std::optional<int>
+CompareJsonNumberToBoundWithUint64DoubleFallback(
+    const simdjson::ondemand::number& number,
+    const proto::plan::GenericValue& bound) {
+    if (number.is_uint64()) {
+        return CompareJsonNumberToBound(
+            static_cast<double>(number.get_uint64()), bound);
+    }
+    return CompareJsonNumberToBound(number, bound);
 }
 
 inline bool

--- a/internal/core/src/exec/expression/JsonNumberComparison.h
+++ b/internal/core/src/exec/expression/JsonNumberComparison.h
@@ -1,0 +1,176 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+
+#include <simdjson.h>
+
+#include "pb/plan.pb.h"
+
+namespace milvus::exec {
+
+inline bool
+IsInt64SafeForJsonDoubleIndex(int64_t value) {
+    constexpr int64_t kFirstNonInjectiveInteger = int64_t{1} << 53;
+    return value > -kFirstNonInjectiveInteger &&
+           value < kFirstNonInjectiveInteger;
+}
+
+inline int
+CompareInt64ToDouble(int64_t lhs, double rhs) {
+    constexpr double kInt64Lower = -0x1p63;
+    constexpr double kInt64Upper = 0x1p63;
+    if (rhs < kInt64Lower) {
+        return 1;
+    }
+    if (rhs >= kInt64Upper) {
+        return -1;
+    }
+
+    const auto rhs_integer = static_cast<int64_t>(rhs);
+    if (lhs < rhs_integer) {
+        return -1;
+    }
+    if (lhs > rhs_integer) {
+        return 1;
+    }
+
+    const auto rhs_integer_as_double = static_cast<double>(rhs_integer);
+    if (rhs > rhs_integer_as_double) {
+        return -1;
+    }
+    if (rhs < rhs_integer_as_double) {
+        return 1;
+    }
+    return 0;
+}
+
+inline int
+CompareUint64ToDouble(uint64_t lhs, double rhs) {
+    constexpr double kUint64Upper = 0x1p64;
+    if (rhs < 0) {
+        return 1;
+    }
+    if (rhs >= kUint64Upper) {
+        return -1;
+    }
+
+    const auto rhs_integer = static_cast<uint64_t>(rhs);
+    if (lhs < rhs_integer) {
+        return -1;
+    }
+    if (lhs > rhs_integer) {
+        return 1;
+    }
+
+    const auto rhs_integer_as_double = static_cast<double>(rhs_integer);
+    if (rhs > rhs_integer_as_double) {
+        return -1;
+    }
+    if (rhs < rhs_integer_as_double) {
+        return 1;
+    }
+    return 0;
+}
+
+inline std::optional<int>
+CompareJsonNumberToBound(int64_t number,
+                         const proto::plan::GenericValue& bound) {
+    if (bound.has_int64_val()) {
+        const auto rhs = bound.int64_val();
+        return number < rhs ? -1 : number > rhs ? 1 : 0;
+    }
+    if (bound.has_float_val()) {
+        const auto rhs = bound.float_val();
+        return std::isnan(rhs)
+                   ? std::nullopt
+                   : std::optional<int>(CompareInt64ToDouble(number, rhs));
+    }
+    return std::nullopt;
+}
+
+inline std::optional<int>
+CompareJsonNumberToBound(double number,
+                         const proto::plan::GenericValue& bound) {
+    if (std::isnan(number)) {
+        return std::nullopt;
+    }
+    if (bound.has_int64_val()) {
+        return -CompareInt64ToDouble(bound.int64_val(), number);
+    }
+    if (bound.has_float_val()) {
+        const auto rhs = bound.float_val();
+        if (std::isnan(rhs)) {
+            return std::nullopt;
+        }
+        return number < rhs ? -1 : number > rhs ? 1 : 0;
+    }
+    return std::nullopt;
+}
+
+inline std::optional<int>
+CompareJsonNumberToBound(const simdjson::ondemand::number& number,
+                         const proto::plan::GenericValue& bound) {
+    if (number.is_int64()) {
+        return CompareJsonNumberToBound(number.get_int64(), bound);
+    }
+    if (number.is_uint64()) {
+        const auto lhs = number.get_uint64();
+        if (bound.has_int64_val()) {
+            const auto rhs = bound.int64_val();
+            if (rhs < 0) {
+                return 1;
+            }
+            const auto unsigned_rhs = static_cast<uint64_t>(rhs);
+            return lhs < unsigned_rhs ? -1 : lhs > unsigned_rhs ? 1 : 0;
+        }
+        if (bound.has_float_val()) {
+            const auto rhs = bound.float_val();
+            if (std::isnan(rhs)) {
+                return std::nullopt;
+            }
+            return CompareUint64ToDouble(lhs, rhs);
+        }
+        return std::nullopt;
+    }
+    return CompareJsonNumberToBound(number.get_double(), bound);
+}
+
+inline bool
+JsonNumberMatchesOp(int comparison, proto::plan::OpType op) {
+    switch (op) {
+        case proto::plan::OpType::Equal:
+            return comparison == 0;
+        case proto::plan::OpType::NotEqual:
+            return comparison != 0;
+        case proto::plan::OpType::GreaterThan:
+            return comparison > 0;
+        case proto::plan::OpType::GreaterEqual:
+            return comparison >= 0;
+        case proto::plan::OpType::LessThan:
+            return comparison < 0;
+        case proto::plan::OpType::LessEqual:
+            return comparison <= 0;
+        default:
+            return false;
+    }
+}
+
+}  // namespace milvus::exec

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -26,21 +26,6 @@ namespace exec {
 
 void
 PhyTermFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
-    if (expr_->column_.data_type_ == DataType::JSON &&
-        expr_->vals_.size() > 1) {
-        const auto expected_type = expr_->vals_[0].val_case();
-        for (size_t i = 1; i < expr_->vals_.size(); ++i) {
-            if (expr_->vals_[i].val_case() != expected_type) {
-                ThrowInfo(DataTypeInvalid,
-                          "TermExpr values must have the same type, value 0 "
-                          "has type {} but value {} has type {}",
-                          static_cast<int>(expected_type),
-                          i,
-                          static_cast<int>(expr_->vals_[i].val_case()));
-            }
-        }
-    }
-
     tracer::AutoSpan span(
         "PhyTermFilterExpr::Eval", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("data_type",

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -26,6 +26,21 @@ namespace exec {
 
 void
 PhyTermFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    if (expr_->column_.data_type_ == DataType::JSON &&
+        expr_->vals_.size() > 1) {
+        const auto expected_type = expr_->vals_[0].val_case();
+        for (size_t i = 1; i < expr_->vals_.size(); ++i) {
+            if (expr_->vals_[i].val_case() != expected_type) {
+                ThrowInfo(DataTypeInvalid,
+                          "TermExpr values must have the same type, value 0 "
+                          "has type {} but value {} has type {}",
+                          static_cast<int>(expected_type),
+                          i,
+                          static_cast<int>(expr_->vals_[i].val_case()));
+            }
+        }
+    }
+
     tracer::AutoSpan span(
         "PhyTermFilterExpr::Eval", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("data_type",

--- a/internal/core/src/exec/expression/TermExpr.h
+++ b/internal/core/src/exec/expression/TermExpr.h
@@ -76,6 +76,21 @@ class PhyTermFilterExpr : public SegmentExpr {
                       consistency_level),
           expr_(expr),
           query_timestamp_(timestamp) {
+        if (expr_->column_.data_type_ == DataType::JSON &&
+            expr_->vals_.size() > 1) {
+            const auto expected_type = expr_->vals_[0].val_case();
+            for (size_t i = 1; i < expr_->vals_.size(); ++i) {
+                if (expr_->vals_[i].val_case() != expected_type) {
+                    ThrowInfo(
+                        DataTypeInvalid,
+                        "TermExpr values must have the same type, value 0 "
+                        "has type {} but value {} has type {}",
+                        static_cast<int>(expected_type),
+                        i,
+                        static_cast<int>(expr_->vals_[i].val_case()));
+                }
+            }
+        }
     }
 
     void

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -1,8 +1,13 @@
 #include "TimestamptzArithCompareExpr.h"
+
+#include <climits>
 #include <cstddef>
+#include <cstdint>
+#include <ctime>
 #include <memory>
-#include "absl/time/civil_time.h"
-#include "absl/time/time.h"
+#include <variant>
+
+#include "bitset/bitset.h"
 #include "common/EasyAssert.h"
 #include "common/Types.h"
 #include "common/Vector.h"
@@ -10,14 +15,169 @@
 #include "exec/expression/Expr.h"
 #include "expr/ITypeExpr.h"
 #include "pb/plan.pb.h"
-#include "BinaryArithOpEvalRangeExpr.h"
 
 namespace milvus {
 namespace exec {
 
+namespace {
+
+int
+SafeAddTimestampField(int base, int64_t delta) {
+    const int64_t min_delta = static_cast<int64_t>(INT_MIN) - base;
+    const int64_t max_delta = static_cast<int64_t>(INT_MAX) - base;
+    AssertInfo(delta >= min_delta && delta <= max_delta,
+               "timestamp interval arithmetic overflow: {} + {} = {}",
+               base,
+               delta,
+               delta < 0 ? "less than INT_MIN" : "greater than INT_MAX");
+    return static_cast<int>(static_cast<int64_t>(base) + delta);
+}
+
+int64_t
+ApplyIntervalSign(int64_t value, int op_sign) {
+    if (op_sign > 0) {
+        return value;
+    }
+    AssertInfo(value != INT64_MIN,
+               "timestamp interval arithmetic overflow: cannot negate {}",
+               value);
+    return -value;
+}
+
+int64_t
+ApplyTimestampInterval(int64_t current_ts_us,
+                       proto::plan::ArithOpType arith_op,
+                       const proto::plan::Interval& interval) {
+    int op_sign;
+    switch (arith_op) {
+        case proto::plan::ArithOpType::Add:
+            op_sign = 1;
+            break;
+        case proto::plan::ArithOpType::Sub:
+            op_sign = -1;
+            break;
+        case proto::plan::ArithOpType::Unknown:
+            return current_ts_us;
+        default:
+            ThrowInfo(UnexpectedError,
+                      "unsupported arithmetic op for "
+                      "timestamptz_arith_compare_expr: {}",
+                      arith_op);
+    }
+
+    // Floor division to correctly handle pre-epoch (negative) timestamps.
+    // Keep the remainder separate so INT64_MIN does not overflow while
+    // reconstructing the sub-second component.
+    int64_t epoch_sec = current_ts_us / 1000000;
+    int64_t sub_sec_us = current_ts_us % 1000000;
+    if (sub_sec_us < 0) {
+        --epoch_sec;
+        sub_sec_us += 1000000;
+    }
+
+    std::time_t epoch_time = epoch_sec;
+    struct std::tm tm_buf;
+    if (::gmtime_r(&epoch_time, &tm_buf) == nullptr) {
+        ThrowInfo(UnexpectedError,
+                  "gmtime_r failed for timestamp {} us",
+                  current_ts_us);
+    }
+
+    // Apply the operation sign without overflowing when an INT64_MIN interval
+    // is subtracted.
+    tm_buf.tm_year = SafeAddTimestampField(
+        tm_buf.tm_year, ApplyIntervalSign(interval.years(), op_sign));
+    tm_buf.tm_mon = SafeAddTimestampField(
+        tm_buf.tm_mon, ApplyIntervalSign(interval.months(), op_sign));
+    tm_buf.tm_mday = SafeAddTimestampField(
+        tm_buf.tm_mday, ApplyIntervalSign(interval.days(), op_sign));
+    tm_buf.tm_hour = SafeAddTimestampField(
+        tm_buf.tm_hour, ApplyIntervalSign(interval.hours(), op_sign));
+    tm_buf.tm_min = SafeAddTimestampField(
+        tm_buf.tm_min, ApplyIntervalSign(interval.minutes(), op_sign));
+    tm_buf.tm_sec = SafeAddTimestampField(
+        tm_buf.tm_sec, ApplyIntervalSign(interval.seconds(), op_sign));
+
+    // timegm normalizes the fields. -1 is a valid epoch second, so it cannot
+    // be used as an error sentinel here.
+    const std::time_t new_epoch_time = ::timegm(&tm_buf);
+    const auto new_epoch_sec = static_cast<int64_t>(new_epoch_time);
+    constexpr int64_t kMaxSec = (INT64_MAX - 999999) / 1000000;
+    constexpr int64_t kMinSec = (INT64_MIN + 999999) / 1000000;
+    AssertInfo(new_epoch_sec >= kMinSec && new_epoch_sec <= kMaxSec,
+               "timestamp after interval arithmetic out of representable "
+               "range: {} seconds from epoch",
+               new_epoch_sec);
+    return new_epoch_sec * 1000000 + sub_sec_us;
+}
+
+bool
+CompareTimestamp(int64_t lhs, int64_t rhs, proto::plan::OpType compare_op) {
+    switch (compare_op) {
+        case proto::plan::OpType::Equal:
+            return lhs == rhs;
+        case proto::plan::OpType::NotEqual:
+            return lhs != rhs;
+        case proto::plan::OpType::GreaterThan:
+            return lhs > rhs;
+        case proto::plan::OpType::GreaterEqual:
+            return lhs >= rhs;
+        case proto::plan::OpType::LessThan:
+            return lhs < rhs;
+        case proto::plan::OpType::LessEqual:
+            return lhs <= rhs;
+        default:
+            ThrowInfo(UnexpectedError,
+                      "unsupported compare op for "
+                      "timestamptz_arith_compare_expr: {}",
+                      compare_op);
+    }
+}
+
+bool
+EvaluateTimestamp(int64_t current_ts_us,
+                  proto::plan::ArithOpType arith_op,
+                  const proto::plan::Interval& interval,
+                  proto::plan::OpType compare_op,
+                  int64_t compare_us) {
+    const auto final_us =
+        ApplyTimestampInterval(current_ts_us, arith_op, interval);
+    return CompareTimestamp(final_us, compare_us, compare_op);
+}
+
+}  // namespace
+
 std::string
 PhyTimestamptzArithCompareExpr::ToString() const {
     return expr_->ToString();
+}
+
+void
+PhyTimestamptzArithCompareExpr::DetermineExecPath() {
+    // Prefer field data when it is present. TIMESTAMPTZ calendar arithmetic
+    // cannot be transformed into a scalar-index range query, and keeping the
+    // raw-data path also preserves its batch cursor when another raw predicate
+    // is evaluated alongside it.
+    if (num_data_chunk_ > 0 || active_count_ == 0) {
+        SetNotUseIndex();
+        return;
+    }
+
+    // An index-only sealed segment can still evaluate the expression if its
+    // scalar index retains the original values for Reverse_Lookup().
+    if (SegmentExpr::CanUseIndex() && num_index_chunk_ == 1) {
+        using Index = index::ScalarIndex<int64_t>;
+        auto index_ptr = dynamic_cast<const Index*>(pinned_index_[0].get());
+        if (index_ptr != nullptr && index_ptr->HasRawData()) {
+            use_index_ = true;
+            return;
+        }
+    }
+
+    ThrowInfo(UnexpectedError,
+              "TIMESTAMPTZ arithmetic comparison requires field data or a "
+              "scalar index with raw data for field {}",
+              field_id_.get());
 }
 
 void
@@ -30,11 +190,70 @@ PhyTimestamptzArithCompareExpr::Eval(EvalCtx& context, VectorPtr& result) {
 template <typename T>
 VectorPtr
 PhyTimestamptzArithCompareExpr::ExecCompareVisitorImpl(OffsetVector* input) {
-    // We can not use index by transforming ts_col + interval > iso_string to ts_col > iso_string - interval
-    // Because year / month interval is not fixed days, it depends on the specific date.
-    // So, currently, we only support the data scanning path.
-    // In the future, one could add a switch here to check for index availability.
+    if (use_index_) {
+        return ExecCompareVisitorImplForIndex<T>(input);
+    }
     return ExecCompareVisitorImplForAll<T>(input);
+}
+
+template <typename T>
+VectorPtr
+PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForIndex(
+    OffsetVector* input) {
+    using Index = index::ScalarIndex<T>;
+    if (!arg_inited_) {
+        interval_ = expr_->interval_;
+        compare_value_.SetValue<T>(expr_->compare_value_);
+        arg_inited_ = true;
+    }
+
+    const auto arith_op = expr_->arith_op_;
+    const auto compare_op = expr_->compare_op_;
+    const auto compare_value = compare_value_.GetValue<T>();
+    const auto interval = interval_;
+    const int64_t real_batch_size =
+        input != nullptr ? input->size() : GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
+    const int64_t eval_size =
+        input != nullptr ? real_batch_size : active_count_;
+
+    auto exec_index =
+        [ arith_op, compare_op,
+          eval_size ]<FilterType filter_type = FilterType::sequential>(
+            Index * index_ptr,
+            T compare_value,
+            const proto::plan::Interval& interval,
+            const int32_t* offsets = nullptr) {
+        TargetBitmap result(eval_size, false);
+        for (int64_t i = 0; i < eval_size; ++i) {
+            size_t offset = i;
+            if constexpr (filter_type == FilterType::random) {
+                offset = offsets == nullptr ? i : offsets[i];
+            }
+            auto raw = index_ptr->Reverse_Lookup(offset);
+            if (raw.has_value()) {
+                result[i] = EvaluateTimestamp(
+                    raw.value(), arith_op, interval, compare_op, compare_value);
+            }
+        }
+        return result;
+    };
+
+    VectorPtr result;
+    if (input != nullptr) {
+        result = ProcessIndexChunksByOffsets<T>(
+            exec_index, input, compare_value, interval);
+    } else {
+        result = ProcessIndexChunks<T>(exec_index, compare_value, interval);
+    }
+    AssertInfo(result != nullptr && result->size() == real_batch_size,
+               "internal error: expr processed rows {} not equal "
+               "expect batch size {}",
+               result == nullptr ? 0 : result->size(),
+               real_batch_size);
+    return result;
 }
 
 template <typename T>
@@ -52,29 +271,6 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
     auto compare_value = this->compare_value_.GetValue<T>();
     auto interval = interval_;
 
-    if (arith_op == proto::plan::ArithOpType::Unknown) {
-        if (!helperPhyExpr_) {  // reconstruct helper expr would cause an error
-            proto::plan::GenericValue zeroRightOperand;
-            zeroRightOperand.set_int64_val(0);
-            auto helperExpr =
-                std::make_shared<milvus::expr::BinaryArithOpEvalRangeExpr>(
-                    expr_->column_,
-                    expr_->compare_op_,
-                    proto::plan::ArithOpType::Add,
-                    expr_->compare_value_,
-                    zeroRightOperand);
-            helperPhyExpr_ = std::make_shared<PhyBinaryArithOpEvalRangeExpr>(
-                inputs_,
-                helperExpr,
-                "PhyTimestamptzArithCompareExprHelper",
-                op_ctx_,
-                segment_,
-                active_count_,
-                batch_size_,
-                consistency_level_);
-        }
-        return helperPhyExpr_->ExecRangeVisitorImpl<T>(input);
-    }
     auto real_batch_size =
         has_offset_input_ ? input->size() : GetNextBatchSize();
     if (real_batch_size == 0) {
@@ -98,50 +294,20 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
             TargetBitmapView valid_res,
             T compare_value,
             proto::plan::Interval interval) {
-        absl::TimeZone utc = absl::UTCTimeZone();
-        absl::Time compare_t = absl::FromUnixMicros(compare_value);
+        if (data == nullptr) {
+            return;
+        }
+        const int64_t compare_us = compare_value;
         for (int i = 0; i < size; ++i) {
-            auto offset = (offsets) ? offsets[i] : i;
-            const int64_t current_ts_us = data[i];
-            const int op_sign =
-                (arith_op == proto::plan::ArithOpType::Add) ? 1 : -1;
-            absl::Time t = absl::FromUnixMicros(current_ts_us);
-            // CivilSecond can handle calendar time for us
-            absl::CivilSecond cs = absl::ToCivilSecond(t, utc);
-            absl::CivilSecond new_cs(
-                cs.year() + (interval.years() * op_sign),
-                cs.month() + (interval.months() * op_sign),
-                cs.day() + (interval.days() * op_sign),
-                cs.hour() + (interval.hours() * op_sign),
-                cs.minute() + (interval.minutes() * op_sign),
-                cs.second() + (interval.seconds() * op_sign));
-            absl::Time final_time = absl::FromCivil(new_cs, utc);
-            bool match = false;
-            switch (compare_op) {
-                case proto::plan::OpType::Equal:
-                    match = (final_time == compare_t);
-                    break;
-                case proto::plan::OpType::NotEqual:
-                    match = (final_time != compare_t);
-                    break;
-                case proto::plan::OpType::GreaterThan:
-                    match = (final_time > compare_t);
-                    break;
-                case proto::plan::OpType::GreaterEqual:
-                    match = (final_time >= compare_t);
-                    break;
-                case proto::plan::OpType::LessThan:
-                    match = (final_time < compare_t);
-                    break;
-                case proto::plan::OpType::LessEqual:
-                    match = (final_time <= compare_t);
-                    break;
-                default:  // Should not happen
-                    ThrowInfo(OpTypeInvalid,
-                              "Unsupported compare op for "
-                              "timestamptz_arith_compare_expr");
+            const auto offset = offsets == nullptr ? i : offsets[i];
+            if (valid_data != nullptr && !valid_data[offset]) {
+                // NULL never matches, under either polarity (three-valued
+                // logic); do not evaluate the storage placeholder value.
+                res[i] = valid_res[i] = false;
+                continue;
             }
-            res[i] = match;
+            res[i] = EvaluateTimestamp(
+                data[offset], arith_op, interval, compare_op, compare_us);
         }
     };
     int64_t processed_size;

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.h
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.h
@@ -13,7 +13,6 @@
 
 #include <memory>
 #include "common/Vector.h"
-#include "exec/expression/BinaryArithOpEvalRangeExpr.h"
 #include "exec/expression/Element.h"
 #include "exec/expression/EvalCtx.h"
 #include "exec/expression/Expr.h"
@@ -44,10 +43,14 @@ class PhyTimestamptzArithCompareExpr : public SegmentExpr {
                       batch_size,
                       consistency_level),
           expr_(expr) {
+        DetermineExecPath();
     }
 
     void
     Eval(EvalCtx& context, VectorPtr& result) override;
+
+    void
+    DetermineExecPath();
 
     std::string
     ToString() const override;
@@ -71,8 +74,11 @@ class PhyTimestamptzArithCompareExpr : public SegmentExpr {
     VectorPtr
     ExecCompareVisitorImplForAll(OffsetVector* input);
 
+    template <typename T>
+    VectorPtr
+    ExecCompareVisitorImplForIndex(OffsetVector* input);
+
  private:
-    std::shared_ptr<PhyBinaryArithOpEvalRangeExpr> helperPhyExpr_;
     std::shared_ptr<const milvus::expr::TimestamptzArithCompareExpr> expr_;
     bool arg_inited_{false};
     proto::plan::Interval interval_;

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1770,6 +1770,10 @@ PhyUnaryRangeFilterExpr::CanUseIndex() {
 
 bool
 PhyUnaryRangeFilterExpr::CanUseIndexForJson(DataType val_type) {
+    if (val_type == DataType::ARRAY) {
+        use_index_ = false;
+        return false;
+    }
     if (!SegmentExpr::CanUseIndex()) {
         use_index_ = false;
         return false;

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -41,7 +41,8 @@ PhyUnaryRangeFilterExpr::CanUseIndexForArray() {
     for (size_t i = current_index_chunk_; i < num_index_chunk_; i++) {
         auto index_ptr = dynamic_cast<const Index*>(pinned_index_[i].get());
 
-        if (index_ptr->GetIndexType() ==
+        if (index_ptr == nullptr ||
+            index_ptr->GetIndexType() ==
                 milvus::index::ScalarIndexType::HYBRID ||
             index_ptr->GetIndexType() ==
                 milvus::index::ScalarIndexType::BITMAP) {
@@ -54,11 +55,31 @@ PhyUnaryRangeFilterExpr::CanUseIndexForArray() {
 template <>
 bool
 PhyUnaryRangeFilterExpr::CanUseIndexForArray<milvus::Array>() {
-    bool res;
-    if (!SegmentExpr::CanUseIndex()) {
-        use_index_ = res = false;
-        return res;
+    const auto val_case = expr_->val_.val_case();
+    if (val_case != proto::plan::GenericValue::ValCase::kArrayVal ||
+        (expr_->op_type_ != proto::plan::OpType::Equal &&
+         expr_->op_type_ != proto::plan::OpType::NotEqual)) {
+        use_index_ = false;
+        return false;
     }
+
+    const auto& literal = expr_->val_.array_val();
+    const auto expected_val_case =
+        array_detail::ExpectedLiteralValCase(expr_->column_.element_type_);
+    const auto literal_matches_index_type =
+        literal.array_size() > 0 && literal.same_type() &&
+        expected_val_case != proto::plan::GenericValue::ValCase::VAL_NOT_SET &&
+        std::all_of(literal.array().begin(),
+                    literal.array().end(),
+                    [expected_val_case](const auto& element) {
+                        return element.val_case() == expected_val_case;
+                    });
+    if (!literal_matches_index_type || !SegmentExpr::CanUseIndex()) {
+        use_index_ = false;
+        return false;
+    }
+
+    bool res = false;
     switch (expr_->column_.element_type_) {
         case DataType::BOOL:
             res = CanUseIndexForArray<bool>();
@@ -85,10 +106,7 @@ PhyUnaryRangeFilterExpr::CanUseIndexForArray<milvus::Array>() {
             res = CanUseIndexForArray<std::string_view>();
             break;
         default:
-            ThrowInfo(DataTypeInvalid,
-                      "unsupported element type when execute array "
-                      "equal for index: {}",
-                      expr_->column_.element_type_);
+            res = false;
     }
     use_index_ = res;
     return res;
@@ -664,87 +682,132 @@ PhyUnaryRangeFilterExpr::ExecArrayEqualForIndex(EvalCtx& context,
         return ExecRangeVisitorImplArray<proto::plan::Array>(context);
     }
 
-    // cache the result to suit the framework.
-    auto batch_res = ProcessIndexChunks<IndexInnerType>([this, &val, reverse](
-                                                            Index* _) {
+    // Build and cache a full row-level result.  ARRAY inverted indexes only
+    // identify rows containing the literal elements; order, duplicates, and
+    // exact length still require raw ARRAY verification.  The index Count()
+    // is not a reliable row count when null or empty arrays have no terms, so
+    // both the result and validity must be based on segment rows.
+    if (cached_index_chunk_res_ == nullptr) {
+        auto full_result = TargetBitmap(active_count_, reverse);
         boost::container::vector<IndexInnerType> elems;
-        for (auto const& element : val.array()) {
-            auto e = GetValueFromProto<IndexInnerType>(element);
-            if (std::find(elems.begin(), elems.end(), e) == elems.end()) {
-                elems.push_back(e);
+        elems.reserve(val.array_size());
+        for (const auto& element : val.array()) {
+            auto value = GetValueFromProto<IndexInnerType>(element);
+            if (std::find(elems.begin(), elems.end(), value) == elems.end()) {
+                elems.push_back(value);
             }
         }
 
-        // filtering by index, get candidates.
-        std::function<bool(milvus::proto::plan::Array& /*val*/,
-                           int64_t /*offset*/)>
-            is_same;
+        // 2.6 sealed segments expose one field-wide scalar index even when
+        // raw ARRAY data is split across several chunks. Index callbacks
+        // therefore return global row offsets, not offsets local to a raw
+        // data chunk.
+        AssertInfo(num_index_chunk_ == 1,
+                   "ARRAY scalar index must be field-wide, got {} chunks",
+                   num_index_chunk_);
+        auto index_result = GetIndexPtrForChunk<IndexInnerType>(0);
+        auto* index_ptr = index_result.index_ptr;
+        AssertInfo(index_ptr != nullptr, "invalid ARRAY scalar index");
 
+        std::function<bool(milvus::proto::plan::Array&, int64_t)> is_same;
         if (segment_->is_chunked()) {
-            is_same = [this, reverse](milvus::proto::plan::Array& val,
+            is_same = [this, reverse](milvus::proto::plan::Array& value,
                                       int64_t offset) -> bool {
                 auto [chunk_idx, chunk_offset] =
                     segment_->get_chunk_by_offset(field_id_, offset);
                 auto pw = segment_->template chunk_view<milvus::ArrayView>(
                     op_ctx_, field_id_, chunk_idx);
                 auto chunk = pw.get();
-                return chunk.first[chunk_offset].is_same_array(val) ^ reverse;
+                return chunk.first[chunk_offset].is_same_array(value) ^ reverse;
             };
         } else {
             auto size_per_chunk = segment_->size_per_chunk();
             is_same = [this, size_per_chunk, reverse](
-                          milvus::proto::plan::Array& val,
+                          milvus::proto::plan::Array& value,
                           int64_t offset) -> bool {
                 auto chunk_idx = offset / size_per_chunk;
                 auto chunk_offset = offset % size_per_chunk;
                 auto pw = segment_->template chunk_data<milvus::ArrayView>(
                     op_ctx_, field_id_, chunk_idx);
                 auto chunk = pw.get();
-                auto array_view = chunk.data() + chunk_offset;
-                return array_view->is_same_array(val) ^ reverse;
+                return chunk.data()[chunk_offset].is_same_array(value) ^
+                       reverse;
             };
         }
 
-        // collect all candidates.
         std::unordered_set<size_t> candidates;
         std::unordered_set<size_t> tmp_candidates;
-        auto first_callback = [&candidates](size_t offset) -> void {
-            candidates.insert(offset);
+        auto first_callback = [this, &candidates](size_t offset) -> void {
+            if (offset < static_cast<size_t>(active_count_)) {
+                candidates.insert(offset);
+            }
         };
-        auto callback = [&candidates, &tmp_candidates](size_t offset) -> void {
-            if (candidates.find(offset) != candidates.end()) {
+        auto callback =
+            [this, &candidates, &tmp_candidates](size_t offset) -> void {
+            if (offset < static_cast<size_t>(active_count_) &&
+                candidates.find(offset) != candidates.end()) {
                 tmp_candidates.insert(offset);
             }
         };
-        auto execute_sub_batch =
-            [](Index* index_ptr,
-               const IndexInnerType& val,
-               const std::function<void(size_t /* offset */)>& callback) {
-                index_ptr->InApplyCallback(1, &val, callback);
-            };
-
-        // run in-filter.
-        for (size_t idx = 0; idx < elems.size(); idx++) {
+        for (size_t idx = 0; idx < elems.size(); ++idx) {
             if (idx == 0) {
-                ProcessIndexChunksV2<IndexInnerType>(
-                    execute_sub_batch, elems[idx], first_callback);
+                index_ptr->InApplyCallback(1, &elems[idx], first_callback);
             } else {
-                ProcessIndexChunksV2<IndexInnerType>(
-                    execute_sub_batch, elems[idx], callback);
+                tmp_candidates.clear();
+                index_ptr->InApplyCallback(1, &elems[idx], callback);
                 candidates = std::move(tmp_candidates);
             }
-            // the size of candidates is small enough.
-            if (candidates.size() * 100 < active_count_) {
+            if (candidates.size() * 100 < static_cast<size_t>(active_count_)) {
                 break;
             }
         }
-        TargetBitmap res(active_count_);
-        // run post-filter. The filter will only be executed once in the framework.
-        for (const auto& candidate : candidates) {
-            res[candidate] = is_same(val, candidate);
+        for (const auto candidate : candidates) {
+            full_result[candidate] = is_same(val, candidate);
         }
-        return res;
-    });
+
+        auto full_validity = TargetBitmap(active_count_, true);
+        int64_t processed_rows = 0;
+        for (int64_t chunk_id = 0;
+             chunk_id < num_data_chunk_ && processed_rows < active_count_;
+             ++chunk_id) {
+            const auto chunk_size =
+                segment_->is_chunked()
+                    ? segment_->chunk_size(field_id_, chunk_id)
+                    : size_per_chunk_;
+            const auto size =
+                std::min(chunk_size, active_count_ - processed_rows);
+            segment_->ApplyFieldValidData(op_ctx_,
+                                          field_id_,
+                                          chunk_id,
+                                          0,
+                                          size,
+                                          full_validity + processed_rows);
+            processed_rows += size;
+        }
+        AssertInfo(processed_rows == active_count_,
+                   "ARRAY field validity covers {} rows, expected {}",
+                   processed_rows,
+                   active_count_);
+        cached_index_chunk_res_ =
+            std::make_shared<TargetBitmap>(std::move(full_result));
+        cached_index_chunk_valid_res_ =
+            std::make_shared<TargetBitmap>(std::move(full_validity));
+        cached_index_chunk_id_ = 0;
+    }
+
+    auto batch_res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                       *cached_index_chunk_valid_res_,
+                                       current_index_chunk_pos_,
+                                       real_batch_size);
+    current_index_chunk_pos_ += real_batch_size;
+    if (reverse) {
+        auto column = std::dynamic_pointer_cast<ColumnVector>(batch_res);
+        AssertInfo(column != nullptr && column->IsBitmap(),
+                   "ARRAY index equality must return a bitmap column");
+        TargetBitmapView data(column->GetRawData(), column->size());
+        TargetBitmapView validity(column->GetValidRawData(), column->size());
+        data.inplace_and(validity, column->size());
+    }
     AssertInfo(batch_res->size() == real_batch_size,
                "internal error: expr processed rows {} not equal "
                "expect batch size {}",

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include "UnaryExpr.h"
+
 #include <optional>
 #include <boost/regex.hpp>
 #include "common/EasyAssert.h"
@@ -25,6 +26,7 @@
 #include "log/Log.h"
 #include "monitor/Monitor.h"
 #include "common/ScopedTimer.h"
+#include "exec/expression/JsonNumberComparison.h"
 
 namespace milvus {
 namespace exec {
@@ -220,7 +222,13 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                 }
             }
 
-            if (CanUseIndexForJson(val_type_inner) && !has_offset_input_) {
+            const auto requires_precise_numeric_comparison =
+                val_type == proto::plan::GenericValue::ValCase::kInt64Val &&
+                !IsInt64SafeForJsonDoubleIndex(expr_->val_.int64_val());
+            if (requires_precise_numeric_comparison) {
+                result = ExecRangeVisitorImplJsonPreciseNumeric(context);
+            } else if (CanUseIndexForJson(val_type_inner) &&
+                       !has_offset_input_) {
                 switch (val_type) {
                     case proto::plan::GenericValue::ValCase::kBoolVal:
                         result = ExecRangeVisitorImplForIndex<bool>();
@@ -322,6 +330,78 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                       "unsupported data type: {}",
                       expr_->column_.data_type_);
     }
+}
+
+VectorPtr
+PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonPreciseNumeric(
+    EvalCtx& context) {
+    const auto& bitmap_input = context.get_bitmap_input();
+    auto* input = context.get_offset_input();
+    auto real_batch_size =
+        has_offset_input_ ? input->size() : GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
+
+    auto res_vec =
+        std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),
+                                       TargetBitmap(real_batch_size, true));
+    TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
+    TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
+    auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
+    auto bound = expr_->val_;
+    const auto op_type = expr_->op_type_;
+
+    size_t processed_cursor = 0;
+    auto execute_sub_batch =
+        [ pointer, bound, op_type, &bitmap_input, &
+          processed_cursor ]<FilterType filter_type = FilterType::sequential>(
+            const milvus::Json* data,
+            const bool* valid_data,
+            const int32_t* offsets,
+            const int size,
+            TargetBitmapView res,
+            TargetBitmapView valid_res) {
+        const bool has_bitmap_input = !bitmap_input.empty();
+        for (int i = 0; i < size; ++i) {
+            auto offset = i;
+            if constexpr (filter_type == FilterType::random) {
+                offset = offsets ? offsets[i] : i;
+            }
+            if (valid_data != nullptr && !valid_data[offset]) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
+                continue;
+            }
+
+            auto number = data[offset].at_numeric(pointer);
+            if (number.error()) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            auto comparison = CompareJsonNumberToBound(number.value(), bound);
+            res[i] = comparison.has_value() &&
+                     JsonNumberMatchesOp(*comparison, op_type);
+        }
+        processed_cursor += size;
+    };
+
+    int64_t processed_size;
+    if (has_offset_input_) {
+        processed_size = ProcessDataByOffsets<milvus::Json>(
+            execute_sub_batch, std::nullptr_t{}, input, res, valid_res);
+    } else {
+        processed_size = ProcessDataChunks<milvus::Json>(
+            execute_sub_batch, std::nullptr_t{}, res, valid_res);
+    }
+    AssertInfo(processed_size == real_batch_size,
+               "internal error: expr processed rows {} not equal "
+               "expect batch size {}",
+               processed_size,
+               real_batch_size);
+    return res_vec;
 }
 
 template <typename ValueType>

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -226,6 +226,7 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                 val_type == proto::plan::GenericValue::ValCase::kInt64Val &&
                 !IsInt64SafeForJsonDoubleIndex(expr_->val_.int64_val());
             if (requires_precise_numeric_comparison) {
+                SetNotUseIndex();
                 result = ExecRangeVisitorImplJsonPreciseNumeric(context);
             } else if (CanUseIndexForJson(val_type_inner) &&
                        !has_offset_input_) {

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -855,6 +855,9 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
     VectorPtr
     ExecRangeVisitorImplJson(EvalCtx& context);
 
+    VectorPtr
+    ExecRangeVisitorImplJsonPreciseNumeric(EvalCtx& context);
+
     template <typename ExprValueType>
     VectorPtr
     ExecRangeVisitorImplJsonByStats();

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -10,9 +10,14 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <gtest/gtest.h>
+#include <atomic>
 #include <regex>
 
 #include "cachinglayer/Manager.h"
+#include "common/Common.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/EvalCtx.h"
+#include "exec/expression/Expr.h"
 #include "pb/plan.pb.h"
 #include "index/InvertedIndexTantivy.h"
 #include "common/Schema.h"
@@ -303,3 +308,338 @@ REGISTER_TYPED_TEST_CASE_P(ArrayInvertedIndexTest,
                            ArrayEqual);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Naive, ArrayInvertedIndexTest, ElementType);
+
+namespace {
+
+ColumnVectorPtr
+EvalFilterInBatches(const expr::TypedExprPtr& logical_expr,
+                    const SegmentInternalInterface* segment,
+                    int64_t active_count) {
+    auto query_context = std::make_shared<exec::QueryContext>(
+        DEAFULT_QUERY_ID, segment, active_count, MAX_TIMESTAMP);
+    exec::ExecContext exec_context(query_context.get());
+    auto compiled =
+        exec::CompileExpressions({logical_expr}, &exec_context, {}, false);
+    AssertInfo(compiled.size() == 1,
+               "expected one compiled expression, got {}",
+               compiled.size());
+
+    exec::EvalCtx eval_context(&exec_context);
+    TargetBitmap combined_result;
+    TargetBitmap combined_validity;
+    int64_t processed_rows = 0;
+    while (processed_rows < active_count) {
+        VectorPtr result;
+        compiled[0]->Eval(eval_context, result);
+        AssertInfo(result != nullptr,
+                   "expression evaluation stopped after {} of {} rows",
+                   processed_rows,
+                   active_count);
+        auto column = std::dynamic_pointer_cast<ColumnVector>(result);
+        AssertInfo(column != nullptr && column->IsBitmap(),
+                   "expected bitmap column result");
+        const auto batch_size = column->size();
+        AssertInfo(
+            batch_size > 0 && processed_rows + batch_size <= active_count,
+            "invalid expression batch size {} after {} of {} rows",
+            batch_size,
+            processed_rows,
+            active_count);
+        combined_result.append(
+            TargetBitmapView(column->GetRawData(), batch_size));
+        combined_validity.append(
+            TargetBitmapView(column->GetValidRawData(), batch_size));
+        processed_rows += batch_size;
+    }
+    return std::make_shared<ColumnVector>(std::move(combined_result),
+                                          std::move(combined_validity));
+}
+
+class NullableInt64ArrayInvertedIndex
+    : public index::InvertedIndexTantivy<int64_t> {
+ public:
+    explicit NullableInt64ArrayInvertedIndex(
+        std::shared_ptr<std::atomic<size_t>> query_count)
+        : query_count_(std::move(query_count)) {
+    }
+
+    void
+    SetNullOffsets(std::vector<size_t> offsets) {
+        null_offset_ = std::move(offsets);
+    }
+
+    void
+    InApplyCallback(size_t n,
+                    const int64_t* values,
+                    const std::function<void(size_t)>& callback) override {
+        query_count_->fetch_add(1, std::memory_order_relaxed);
+        index::InvertedIndexTantivy<int64_t>::InApplyCallback(
+            n, values, callback);
+    }
+
+ private:
+    std::shared_ptr<std::atomic<size_t>> query_count_;
+};
+
+struct ExprBatchSizeGuard {
+    explicit ExprBatchSizeGuard(int64_t batch_size)
+        : old_batch_size_(EXEC_EVAL_EXPR_BATCH_SIZE.exchange(batch_size)) {
+    }
+
+    ~ExprBatchSizeGuard() {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(old_batch_size_);
+    }
+
+    int64_t old_batch_size_;
+};
+
+proto::plan::GenericValue
+MakeInt64ArrayValue(const std::vector<int64_t>& values) {
+    proto::plan::GenericValue value;
+    auto* array = value.mutable_array_val();
+    array->set_element_type(proto::schema::DataType::Int64);
+    array->set_same_type(true);
+    for (auto element : values) {
+        array->add_array()->set_int64_val(element);
+    }
+    return value;
+}
+
+}  // namespace
+
+TEST(ArrayInvertedIndexRegression,
+     ArrayNotEqualUsesIndexCandidatesAsRowLevelPrefilter) {
+    const std::vector<std::vector<int64_t>> arrays = {
+        {1, 1, 2},     // equal
+        {},            // null
+        {1, 2},        // missing duplicate
+        {},            // null
+        {1, 1, 2, 3},  // extra element
+        {},            // null
+        {1, 2, 1},     // different order
+        {},            // null
+        {1, 1, 1, 2},  // different duplicate count
+        {},            // null
+        {1, 3},        // missing indexed element
+        {},            // null
+        {1, 1, 2},     // equal in the second raw data chunk
+        {},            // null
+    };
+    const auto row_count = static_cast<int64_t>(arrays.size());
+    std::vector<bool> expected_validity(row_count);
+    std::vector<bool> expected_values(row_count);
+    const std::vector<int64_t> literal = {1, 1, 2};
+    for (int64_t row = 0; row < row_count; ++row) {
+        const bool valid = row % 2 == 0;
+        expected_validity[row] = valid;
+        expected_values[row] = valid && arrays[row] != literal;
+    }
+
+    ExprBatchSizeGuard batch_size_guard(4);
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fvec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto array_fid = schema->AddDebugArrayField("array", DataType::INT64, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto raw_data = DataGen(schema, row_count, 42, 0, 1, 3);
+    proto::schema::FieldData* array_field = nullptr;
+    for (auto& field : *raw_data.raw_->mutable_fields_data()) {
+        if (field.field_id() == array_fid.get()) {
+            array_field = &field;
+            break;
+        }
+    }
+    ASSERT_NE(array_field, nullptr);
+    auto* array_data = array_field->mutable_scalars()->mutable_array_data();
+    ASSERT_EQ(array_data->data_size(), row_count);
+    auto* valid_data = array_field->mutable_valid_data();
+    ASSERT_EQ(valid_data->size(), row_count);
+
+    std::vector<boost::container::vector<int64_t>> index_arrays;
+    index_arrays.reserve(row_count);
+    std::vector<size_t> null_offsets;
+    for (int64_t row = 0; row < row_count; ++row) {
+        const bool valid = expected_validity[row];
+        valid_data->at(row) = valid;
+
+        auto* values =
+            array_data->mutable_data(row)->mutable_long_data()->mutable_data();
+        values->Clear();
+        values->Add(arrays[row].begin(), arrays[row].end());
+
+        if (valid) {
+            index_arrays.emplace_back(arrays[row].begin(), arrays[row].end());
+        } else {
+            index_arrays.emplace_back();
+            null_offsets.push_back(row);
+        }
+    }
+
+    auto raw_segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+    auto indexed_segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+
+    // Keep the scalar index field-wide, but reload the indexed segment's raw
+    // ARRAY data as two chunks. This matches the 2.6 sealed layout and verifies
+    // that index callback offsets are interpreted as global row offsets.
+    auto full_array_field = segcore::CreateFieldDataFromDataArray(
+        row_count, array_field, schema->operator[](array_fid));
+    auto* full_array_data =
+        static_cast<const milvus::Array*>(full_array_field->Data());
+    auto* full_valid_data = full_array_field->ValidData();
+    std::vector<FieldDataPtr> array_chunks;
+    const int64_t first_chunk_size = row_count / 2;
+    for (const auto [offset, size] : std::vector<std::pair<int64_t, int64_t>>{
+             {0, first_chunk_size},
+             {first_chunk_size, row_count - first_chunk_size}}) {
+        auto chunk = std::make_shared<FieldData<milvus::Array>>(
+            DataType::ARRAY, true, size);
+        chunk->FillFieldData(
+            full_array_data + offset, full_valid_data, size, offset);
+        array_chunks.emplace_back(std::move(chunk));
+    }
+    indexed_segment->DropFieldData(array_fid);
+    auto cm = storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto array_load_info = PrepareSingleFieldInsertBinlog(
+        9101, 9102, 9103, array_fid.get(), array_chunks, cm);
+    indexed_segment->LoadFieldData(array_load_info);
+    ASSERT_EQ(indexed_segment->num_chunk_data(array_fid), 2);
+
+    auto logical_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(array_fid, DataType::ARRAY, DataType::INT64, {}, true),
+        proto::plan::OpType::NotEqual,
+        MakeInt64ArrayValue(literal),
+        std::vector<proto::plan::GenericValue>{});
+    auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                       logical_expr);
+
+    auto index_query_count = std::make_shared<std::atomic<size_t>>(0);
+    auto index =
+        std::make_unique<NullableInt64ArrayInvertedIndex>(index_query_count);
+    Config config;
+    config["is_array"] = true;
+    index->BuildWithRawDataForUT(row_count, index_arrays.data(), config);
+    index->SetNullOffsets(null_offsets);
+
+    LoadIndexInfo load_info{};
+    load_info.field_id = array_fid.get();
+    load_info.field_type = DataType::ARRAY;
+    load_info.element_type = DataType::INT64;
+    load_info.index_params = GenIndexParams(index.get());
+    load_info.cache_index =
+        CreateTestCacheIndex("array_not_equal_row_level", std::move(index));
+    indexed_segment->LoadIndex(load_info);
+
+    auto raw_result =
+        EvalFilterInBatches(logical_expr, raw_segment.get(), row_count);
+    auto indexed_result =
+        EvalFilterInBatches(logical_expr, indexed_segment.get(), row_count);
+    EXPECT_GT(index_query_count->load(std::memory_order_relaxed), 0);
+
+    TargetBitmapView raw_values(raw_result->GetRawData(), row_count);
+    TargetBitmapView raw_validity(raw_result->GetValidRawData(), row_count);
+    TargetBitmapView indexed_values(indexed_result->GetRawData(), row_count);
+    TargetBitmapView indexed_validity(indexed_result->GetValidRawData(),
+                                      row_count);
+    for (int64_t row = 0; row < row_count; ++row) {
+        EXPECT_EQ(indexed_validity[row], expected_validity[row])
+            << "row=" << row;
+        EXPECT_EQ(indexed_validity[row], raw_validity[row]) << "row=" << row;
+        EXPECT_EQ(indexed_values[row], expected_values[row]) << "row=" << row;
+        EXPECT_EQ(indexed_values[row], raw_values[row]) << "row=" << row;
+    }
+
+    auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(array_fid, DataType::ARRAY, DataType::INT64, {}, true),
+        proto::plan::OpType::Equal,
+        MakeInt64ArrayValue(literal),
+        std::vector<proto::plan::GenericValue>{});
+    auto raw_equal =
+        EvalFilterInBatches(equal_expr, raw_segment.get(), row_count);
+    auto indexed_equal =
+        EvalFilterInBatches(equal_expr, indexed_segment.get(), row_count);
+    TargetBitmapView raw_equal_values(raw_equal->GetRawData(), row_count);
+    TargetBitmapView indexed_equal_values(indexed_equal->GetRawData(),
+                                          row_count);
+    TargetBitmapView indexed_equal_validity(indexed_equal->GetValidRawData(),
+                                            row_count);
+    for (int64_t row = 0; row < row_count; ++row) {
+        const auto expected_equal =
+            expected_validity[row] && arrays[row] == literal;
+        EXPECT_EQ(indexed_equal_validity[row], expected_validity[row])
+            << "equal row=" << row;
+        EXPECT_EQ(indexed_equal_values[row], expected_equal)
+            << "equal row=" << row;
+        EXPECT_EQ(indexed_equal_values[row], raw_equal_values[row])
+            << "equal row=" << row;
+    }
+
+    exec::OffsetVector offsets = {0, 1, 2, 4, 6, 8, 10, 12, 13};
+    auto raw_offset_result = milvus::test::gen_filter_res(
+        plan.get(), raw_segment.get(), row_count, MAX_TIMESTAMP, &offsets);
+    auto indexed_offset_result = milvus::test::gen_filter_res(
+        plan.get(), indexed_segment.get(), row_count, MAX_TIMESTAMP, &offsets);
+    TargetBitmapView raw_offset_values(raw_offset_result->GetRawData(),
+                                       offsets.size());
+    TargetBitmapView raw_offset_validity(raw_offset_result->GetValidRawData(),
+                                         offsets.size());
+    TargetBitmapView indexed_offset_values(indexed_offset_result->GetRawData(),
+                                           offsets.size());
+    TargetBitmapView indexed_offset_validity(
+        indexed_offset_result->GetValidRawData(), offsets.size());
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        const auto row = offsets[i];
+        EXPECT_EQ(indexed_offset_validity[i], expected_validity[row])
+            << "offset row=" << row;
+        EXPECT_EQ(indexed_offset_validity[i], raw_offset_validity[i])
+            << "offset row=" << row;
+        EXPECT_EQ(indexed_offset_values[i], expected_values[row])
+            << "offset row=" << row;
+        EXPECT_EQ(indexed_offset_values[i], raw_offset_values[i])
+            << "offset row=" << row;
+    }
+
+    auto mixed_literal = MakeInt64ArrayValue({1});
+    mixed_literal.mutable_array_val()->add_array()->set_float_val(1.5);
+    mixed_literal.mutable_array_val()->set_same_type(false);
+    auto wrong_type_literal = MakeInt64ArrayValue({});
+    wrong_type_literal.mutable_array_val()->add_array()->set_float_val(1.5);
+    std::vector<proto::plan::GenericValue> fallback_literals;
+    fallback_literals.emplace_back(std::move(mixed_literal));
+    fallback_literals.emplace_back(std::move(wrong_type_literal));
+    for (auto& fallback_literal : fallback_literals) {
+        auto fallback_not_equal = std::make_shared<expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(
+                array_fid, DataType::ARRAY, DataType::INT64, {}, true),
+            proto::plan::OpType::NotEqual,
+            std::move(fallback_literal),
+            std::vector<proto::plan::GenericValue>{});
+        auto query_count = index_query_count->load(std::memory_order_relaxed);
+        auto raw_fallback = EvalFilterInBatches(
+            fallback_not_equal, raw_segment.get(), row_count);
+        auto indexed_fallback = EvalFilterInBatches(
+            fallback_not_equal, indexed_segment.get(), row_count);
+        EXPECT_EQ(index_query_count->load(std::memory_order_relaxed),
+                  query_count);
+        TargetBitmapView raw_fallback_values(raw_fallback->GetRawData(),
+                                             row_count);
+        TargetBitmapView raw_fallback_validity(raw_fallback->GetValidRawData(),
+                                               row_count);
+        TargetBitmapView indexed_mixed_values(indexed_fallback->GetRawData(),
+                                              row_count);
+        TargetBitmapView indexed_mixed_validity(
+            indexed_fallback->GetValidRawData(), row_count);
+        for (int64_t row = 0; row < row_count; ++row) {
+            EXPECT_EQ(indexed_mixed_validity[row], expected_validity[row])
+                << "fallback row=" << row;
+            EXPECT_EQ(indexed_mixed_validity[row], raw_fallback_validity[row])
+                << "fallback row=" << row;
+            EXPECT_EQ(indexed_mixed_values[row], expected_validity[row])
+                << "fallback row=" << row;
+            EXPECT_EQ(indexed_mixed_values[row], raw_fallback_values[row])
+                << "fallback row=" << row;
+        }
+    }
+}

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -846,6 +846,63 @@ TEST_F(JsonFlatIndexExprTest, TestComparisonUnknowns) {
     EXPECT_TRUE(final[13]);
 }
 
+TEST_F(JsonFlatIndexExprTest, JSONArrayEqualityFallsBackToRawData) {
+    proto::plan::GenericValue value;
+    auto* array = value.mutable_array_val();
+    array->set_same_type(true);
+    array->add_array()->set_string_val("a");
+    array->add_array()->set_string_val("b");
+
+    auto expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::OpType::Equal,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+    auto final = query::ExecuteQueryExpr(
+        plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+
+    EXPECT_EQ(final.count(), 1);
+    EXPECT_TRUE(final[6]);
+}
+
+TEST_F(JsonFlatIndexExprTest,
+       JSONContainsMixedAndArrayLiteralsFallBackToRawData) {
+    proto::plan::GenericValue string_value;
+    string_value.set_string_val("a");
+    proto::plan::GenericValue int_value;
+    int_value.set_int64_val(1);
+
+    auto mixed_expr = std::make_shared<expr::JsonContainsExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+        false,
+        std::vector<proto::plan::GenericValue>{string_value, int_value});
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, mixed_expr);
+    auto final = query::ExecuteQueryExpr(
+        plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(final.count(), 1);
+    EXPECT_TRUE(final[6]);
+
+    proto::plan::GenericValue array_value;
+    auto* array = array_value.mutable_array_val();
+    array->set_same_type(true);
+    array->add_array()->set_string_val("a");
+    array->add_array()->set_string_val("b");
+    auto array_expr = std::make_shared<expr::JsonContainsExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::JSONContainsExpr_JSONOp_Contains,
+        true,
+        std::vector<proto::plan::GenericValue>{array_value});
+    plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, array_expr);
+    final = query::ExecuteQueryExpr(
+        plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(final.count(), 0);
+}
+
 TEST_F(JsonFlatIndexExprTest, TestExistsExpr) {
     auto expr = std::make_shared<expr::ExistsExpr>(
         expr::ColumnInfo(json_fid_, DataType::JSON, {""}));

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -43,6 +43,22 @@
 using namespace milvus;
 
 namespace milvus::test {
+namespace {
+
+struct ExprBatchSizeGuard {
+    explicit ExprBatchSizeGuard(int64_t batch_size)
+        : old_batch_size_(EXEC_EVAL_EXPR_BATCH_SIZE.exchange(batch_size)) {
+    }
+
+    ~ExprBatchSizeGuard() {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(old_batch_size_);
+    }
+
+    int64_t old_batch_size_;
+};
+
+}  // namespace
+
 struct ChunkManagerWrapper {
     ChunkManagerWrapper(storage::ChunkManagerPtr cm) : cm_(cm) {
     }
@@ -869,6 +885,7 @@ TEST_F(JsonFlatIndexExprTest, JSONArrayEqualityFallsBackToRawData) {
 
 TEST_F(JsonFlatIndexExprTest,
        JSONContainsMixedAndArrayLiteralsFallBackToRawData) {
+    ExprBatchSizeGuard batch_size_guard(7);
     proto::plan::GenericValue string_value;
     string_value.set_string_val("a");
     proto::plan::GenericValue int_value;

--- a/internal/core/src/index/JsonInvertedIndexTest.cpp
+++ b/internal/core/src/index/JsonInvertedIndexTest.cpp
@@ -77,6 +77,18 @@ struct FileSliceSizeGuard {
     int64_t old_slice_size_;
 };
 
+struct ExprBatchSizeGuard {
+    explicit ExprBatchSizeGuard(int64_t batch_size)
+        : old_batch_size_(EXEC_EVAL_EXPR_BATCH_SIZE.exchange(batch_size)) {
+    }
+
+    ~ExprBatchSizeGuard() {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(old_batch_size_);
+    }
+
+    int64_t old_batch_size_;
+};
+
 struct LoadedJsonOffsetStats {
     int64_t count;
     int64_t exists_count;
@@ -227,6 +239,7 @@ TEST(JsonIndexTest, TestJSONErrRecorder) {
 }
 
 TEST(JsonIndexTest, TestJsonContains) {
+    ExprBatchSizeGuard batch_size_guard(8);
     std::vector<std::string> json_raw_data = {
         R"(1)",
         R"("a simple string")",
@@ -251,6 +264,8 @@ TEST(JsonIndexTest, TestJsonContains) {
         R"({"a": ["x", "y"]})",
         R"({"a": [{"nested": true}, {"nested": false}]})",
         R"({"a": []})",
+        R"({"a": [0, 2, 3]})",
+        R"({"a": [{"b": 1}, 2.0, 3.0, "4", true, [1, 3.0], null]})",
     };
 
     auto json_path = "/a";
@@ -308,6 +323,11 @@ TEST(JsonIndexTest, TestJsonContains) {
     value.set_int64_val(1);
     test_cases.push_back(std::make_tuple(value, std::vector<int64_t>{17, 18}));
 
+    proto::plan::GenericValue value2;
+    value2.set_int64_val(2);
+    test_cases.push_back(
+        std::make_tuple(value2, std::vector<int64_t>{17, 18, 23, 24}));
+
     // proto::plan::GenericValue value2;
     // value2.set_bool_val(true);
     // test_cases.push_back(std::make_tuple(value2, std::vector<int64_t>{8}));
@@ -317,12 +337,13 @@ TEST(JsonIndexTest, TestJsonContains) {
     // test_cases.push_back(std::make_tuple(value3, std::vector<int64_t>{9}));
 
     for (auto& test_case : test_cases) {
+        auto query_value = std::get<0>(test_case);
         auto expr = std::make_shared<expr::JsonContainsExpr>(
             expr::ColumnInfo(json_fid, DataType::JSON, {"a"}, true),
             proto::plan::JSONContainsExpr_JSONOp::
                 JSONContainsExpr_JSONOp_Contains,
             true,
-            std::vector<proto::plan::GenericValue>{value});
+            std::vector<proto::plan::GenericValue>{query_value});
 
         auto plan =
             std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);

--- a/internal/core/src/index/JsonInvertedIndexTest.cpp
+++ b/internal/core/src/index/JsonInvertedIndexTest.cpp
@@ -336,6 +336,24 @@ TEST(JsonIndexTest, TestJsonContains) {
             EXPECT_TRUE(result[id]);
         }
     }
+
+    proto::plan::GenericValue int_value;
+    int_value.set_int64_val(1);
+    proto::plan::GenericValue string_value;
+    string_value.set_string_val("4");
+    auto mixed_expr = std::make_shared<expr::JsonContainsExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}, true),
+        proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
+        false,
+        std::vector<proto::plan::GenericValue>{int_value, string_value});
+    auto mixed_plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, mixed_expr);
+    auto mixed_result = query::ExecuteQueryExpr(
+        mixed_plan, segment.get(), json_raw_data.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(mixed_result.count(), 3);
+    EXPECT_TRUE(mixed_result[17]);
+    EXPECT_TRUE(mixed_result[18]);
+    EXPECT_TRUE(mixed_result[24]);
 }
 
 TEST(JsonIndexTest, TestJsonCast) {

--- a/internal/core/unittest/test_json_stats/test_bson_view.cpp
+++ b/internal/core/unittest/test_json_stats/test_bson_view.cpp
@@ -62,6 +62,62 @@ TEST_F(BsonViewTest, ParseAsValueAtOffsetTest) {
     EXPECT_EQ(string_val.value(), "test string");
 }
 
+TEST_F(BsonViewTest, ParseAsNumberAtOffsetTest) {
+    bsoncxx::builder::basic::document doc;
+    doc.append(bsoncxx::builder::basic::kvp("i32", int32_t{42}));
+    doc.append(bsoncxx::builder::basic::kvp("i64", int64_t{9007199254740993}));
+    doc.append(bsoncxx::builder::basic::kvp("dbl", 3.14159));
+    doc.append(bsoncxx::builder::basic::kvp("str", "not a number"));
+
+    BsonView view(doc.view().data(), doc.view().length());
+    const auto offsets = BsonBuilder::ExtractBsonKeyOffsets(doc.view());
+
+    auto int32_value = view.ParseAsNumberAtOffset(offsets[0].second);
+    ASSERT_TRUE(int32_value.has_value());
+    ASSERT_TRUE(std::holds_alternative<int64_t>(*int32_value));
+    EXPECT_EQ(std::get<int64_t>(*int32_value), 42);
+
+    auto int64_value = view.ParseAsNumberAtOffset(offsets[1].second);
+    ASSERT_TRUE(int64_value.has_value());
+    ASSERT_TRUE(std::holds_alternative<int64_t>(*int64_value));
+    EXPECT_EQ(std::get<int64_t>(*int64_value), 9007199254740993);
+
+    auto double_value = view.ParseAsNumberAtOffset(offsets[2].second);
+    ASSERT_TRUE(double_value.has_value());
+    ASSERT_TRUE(std::holds_alternative<double>(*double_value));
+    EXPECT_DOUBLE_EQ(std::get<double>(*double_value), 3.14159);
+
+    EXPECT_FALSE(view.ParseAsNumberAtOffset(offsets[3].second).has_value());
+}
+
+TEST_F(BsonViewTest, ParseAsNumberAtOffsetRejectsMalformedBson) {
+    const auto expect_unexpected_error = [](const std::vector<uint8_t>& data) {
+        BsonView view(data);
+        try {
+            static_cast<void>(view.ParseAsNumberAtOffset(0));
+            FAIL() << "expected malformed BSON to throw";
+        } catch (const SegcoreError& error) {
+            EXPECT_EQ(error.get_error_code(), ErrorCode::UnexpectedError);
+        }
+    };
+
+    expect_unexpected_error(
+        {static_cast<uint8_t>(bsoncxx::type::k_int32), 'k'});
+    expect_unexpected_error(
+        {static_cast<uint8_t>(bsoncxx::type::k_int32), 'k', '\0', 1, 2, 3});
+    expect_unexpected_error({static_cast<uint8_t>(bsoncxx::type::k_int64),
+                             'k',
+                             '\0',
+                             1,
+                             2,
+                             3,
+                             4,
+                             5,
+                             6,
+                             7});
+    expect_unexpected_error({0x42, '\0'});
+}
+
 TEST_F(BsonViewTest, ParseAsArrayAtOffsetTest) {
     // Test case 1: offset = 0 (whole array)
     {

--- a/internal/core/unittest/test_timestamptz_arith_compare.cpp
+++ b/internal/core/unittest/test_timestamptz_arith_compare.cpp
@@ -1,0 +1,306 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+#include "common/Common.h"
+#include "common/Types.h"
+#include "expr/ITypeExpr.h"
+#include "index/ScalarIndex.h"
+#include "knowhere/comp/index_param.h"
+#include "query/ExecPlanNodeVisitor.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "segcore/SegcoreConfig.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/GenExprProto.h"
+#include "test_utils/cachinglayer_test_utils.h"
+#include "test_utils/storage_test_utils.h"
+
+using namespace milvus;
+using namespace milvus::exec;
+using namespace milvus::segcore;
+
+namespace {
+
+struct ExprBatchSizeGuard {
+    explicit ExprBatchSizeGuard(int64_t batch_size)
+        : old_batch_size_(EXEC_EVAL_EXPR_BATCH_SIZE.exchange(batch_size)) {
+    }
+
+    ~ExprBatchSizeGuard() {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(old_batch_size_);
+    }
+
+    int64_t old_batch_size_;
+};
+
+std::shared_ptr<milvus::expr::ITypeExpr>
+MakeTstzCompare(FieldId tstz_fid,
+                proto::plan::ArithOpType arith_op,
+                const proto::plan::Interval& interval,
+                proto::plan::OpType compare_op,
+                int64_t compare_us,
+                bool negated = false) {
+    proto::plan::GenericValue compare_value;
+    compare_value.set_int64_val(compare_us);
+    std::shared_ptr<milvus::expr::ITypeExpr> typed_expr =
+        std::make_shared<milvus::expr::TimestamptzArithCompareExpr>(
+            expr::ColumnInfo(tstz_fid, DataType::TIMESTAMPTZ),
+            arith_op,
+            interval,
+            compare_op,
+            compare_value);
+    if (negated) {
+        typed_expr = std::make_shared<milvus::expr::LogicalUnaryExpr>(
+            expr::LogicalUnaryExpr::OpType::LogicalNot, typed_expr);
+    }
+    return typed_expr;
+}
+
+std::shared_ptr<milvus::expr::ITypeExpr>
+MakeTstzPlusOneMonthCompare(FieldId tstz_fid,
+                            int64_t compare_us,
+                            bool negated) {
+    proto::plan::Interval interval;
+    interval.set_months(1);
+    return MakeTstzCompare(tstz_fid,
+                           proto::plan::ArithOpType::Add,
+                           interval,
+                           proto::plan::OpType::LessThan,
+                           compare_us,
+                           negated);
+}
+
+constexpr int64_t kFarFutureUs = 4102444800LL * 1000000;  // 2100-01-01
+constexpr int64_t kFarPastUs = -2208988800LL * 1000000;   // 1900-01-01
+
+}  // namespace
+
+class TimestamptzArithCompareCorrectnessTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        schema_ = std::make_shared<Schema>();
+        schema_->AddDebugField(
+            "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+        auto pk_fid = schema_->AddDebugField("pk", DataType::INT64);
+        tstz_fid_ = schema_->AddDebugField("ts", DataType::TIMESTAMPTZ, true);
+        schema_->set_primary_field_id(pk_fid);
+
+        dataset_ = std::make_unique<GeneratedData>(DataGen(schema_, N, 42));
+        tstz_valid_ = dataset_->get_col_valid(tstz_fid_);
+
+        SegcoreConfig config = SegcoreConfig::default_config();
+        config.set_chunk_rows(8);
+        growing_ = CreateGrowingSegment(schema_, empty_index_meta, 1, config);
+        growing_->PreInsert(N);
+        growing_->Insert(0,
+                         N,
+                         dataset_->row_ids_.data(),
+                         dataset_->timestamps_.data(),
+                         dataset_->raw_);
+        sealed_ = CreateSealedWithFieldDataLoaded(schema_, *dataset_);
+    }
+
+    void
+    AssertNullSemantics(SegmentInternalInterface* segment) {
+        size_t nulls = 0;
+        for (const auto valid : tstz_valid_) {
+            nulls += valid ? 0 : 1;
+        }
+        ASSERT_GT(nulls, 0u);
+        ASSERT_LT(nulls, N);
+
+        struct Case {
+            int64_t compare_us;
+            bool negated;
+            bool valid_row_expected;
+        };
+        const Case cases[] = {
+            {kFarFutureUs, false, true},
+            {kFarPastUs, true, true},
+            {kFarPastUs, false, false},
+            {kFarFutureUs, true, false},
+        };
+
+        for (const auto& c : cases) {
+            auto typed_expr =
+                MakeTstzPlusOneMonthCompare(tstz_fid_, c.compare_us, c.negated);
+            auto plan = milvus::test::CreateRetrievePlanByExpr(typed_expr);
+            auto final =
+                query::ExecuteQueryExpr(plan, segment, N, MAX_TIMESTAMP);
+            ASSERT_EQ(final.size(), N);
+            for (size_t i = 0; i < N; ++i) {
+                const bool expected =
+                    tstz_valid_[i] ? c.valid_row_expected : false;
+                ASSERT_EQ(final[i], expected)
+                    << "row " << i << " (valid=" << tstz_valid_[i]
+                    << ") compare_us=" << c.compare_us
+                    << " negated=" << c.negated;
+            }
+        }
+    }
+
+    void
+    AssertOffsetInputNullSemantics(SegmentInternalInterface* segment) {
+        std::vector<int32_t> null_rows, valid_rows;
+        for (size_t i = 0; i < N; ++i) {
+            (tstz_valid_[i] ? valid_rows : null_rows)
+                .push_back(static_cast<int32_t>(i));
+        }
+        ASSERT_GE(null_rows.size(), 2u);
+        ASSERT_GE(valid_rows.size(), 2u);
+
+        OffsetVector offsets;
+        offsets.emplace_back(null_rows.back());
+        offsets.emplace_back(valid_rows.back());
+        offsets.emplace_back(null_rows.front());
+        offsets.emplace_back(valid_rows.front());
+
+        auto typed_expr =
+            MakeTstzPlusOneMonthCompare(tstz_fid_, kFarFutureUs, false);
+        auto filter_node = std::make_shared<milvus::plan::FilterBitsNode>(
+            DEFAULT_PLANNODE_ID, typed_expr);
+        auto col_vec = milvus::test::gen_filter_res(
+            filter_node.get(), segment, N, MAX_TIMESTAMP, &offsets);
+        BitsetTypeView res(col_vec->GetRawData(), col_vec->size());
+        ASSERT_EQ(res.size(), offsets.size());
+
+        for (size_t k = 0; k < offsets.size(); ++k) {
+            const bool expected = tstz_valid_[offsets[k]];
+            ASSERT_EQ(res[k], expected)
+                << "candidate k=" << k << " row=" << offsets[k];
+        }
+    }
+
+    void
+    LoadTimestamptzIndex(const int64_t* values, bool drop_field_data) {
+        auto scalar_index = milvus::index::CreateScalarIndexSort<int64_t>();
+        scalar_index->Build(N, values, tstz_valid_.data());
+
+        LoadIndexInfo load_index_info;
+        load_index_info.field_id = tstz_fid_.get();
+        load_index_info.field_type = DataType::TIMESTAMPTZ;
+        load_index_info.index_params = GenIndexParams(scalar_index.get());
+        load_index_info.cache_index = milvus::CreateTestCacheIndex(
+            "timestamptz", std::move(scalar_index));
+        sealed_->LoadIndex(load_index_info);
+
+        if (drop_field_data) {
+            sealed_->DropFieldData(tstz_fid_);
+            ASSERT_FALSE(sealed_->HasFieldData(tstz_fid_));
+        }
+    }
+
+    static constexpr size_t N = 32;
+
+    SchemaPtr schema_;
+    FieldId tstz_fid_;
+    std::unique_ptr<GeneratedData> dataset_;
+    FixedVector<bool> tstz_valid_;
+    SegmentGrowingPtr growing_;
+    std::unique_ptr<SegmentSealed> sealed_;
+};
+
+TEST_F(TimestamptzArithCompareCorrectnessTest, GrowingNullSemantics) {
+    AssertNullSemantics(growing_.get());
+}
+
+TEST_F(TimestamptzArithCompareCorrectnessTest,
+       GrowingOffsetInputNullSemantics) {
+    AssertOffsetInputNullSemantics(growing_.get());
+}
+
+TEST_F(TimestamptzArithCompareCorrectnessTest, SealedNullSemantics) {
+    AssertNullSemantics(sealed_.get());
+}
+
+TEST_F(TimestamptzArithCompareCorrectnessTest,
+       SealedScalarIndexStillUsesRawDataPath) {
+    auto values = dataset_->get_col<int64_t>(tstz_fid_);
+    LoadTimestamptzIndex(values.data(), false);
+
+    ExprBatchSizeGuard batch_size_guard(7);
+    auto typed_expr =
+        MakeTstzPlusOneMonthCompare(tstz_fid_, kFarFutureUs, false);
+    auto plan = milvus::test::CreateRetrievePlanByExpr(typed_expr);
+    auto result =
+        query::ExecuteQueryExpr(plan, sealed_.get(), N, MAX_TIMESTAMP);
+    ASSERT_EQ(result.size(), N);
+    for (size_t i = 0; i < N; ++i) {
+        EXPECT_EQ(result[i], tstz_valid_[i]) << "row " << i;
+    }
+}
+
+TEST_F(TimestamptzArithCompareCorrectnessTest,
+       SealedIndexOnlyFullScanPreservesNullableValidity) {
+    std::vector<int64_t> values(N);
+    std::iota(values.begin(), values.end(), int64_t{0});
+    LoadTimestamptzIndex(values.data(), true);
+
+    proto::plan::Interval interval;
+    interval.set_months(1);
+    constexpr int64_t kFebruaryStartUs = 2678400LL * 1000000;
+    auto typed_expr = MakeTstzCompare(tstz_fid_,
+                                      proto::plan::ArithOpType::Add,
+                                      interval,
+                                      proto::plan::OpType::LessThan,
+                                      kFebruaryStartUs + 16);
+
+    ExprBatchSizeGuard batch_size_guard(7);
+    auto plan = milvus::test::CreateRetrievePlanByExpr(typed_expr);
+    auto all_at_once =
+        query::ExecuteQueryExpr(plan, sealed_.get(), N, MAX_TIMESTAMP);
+    ASSERT_EQ(all_at_once.size(), N);
+    for (size_t i = 0; i < N; ++i) {
+        EXPECT_EQ(all_at_once[i], tstz_valid_[i] && i < 16) << "row " << i;
+    }
+
+    AssertOffsetInputNullSemantics(sealed_.get());
+}
+
+TEST_F(TimestamptzArithCompareCorrectnessTest,
+       SealedIndexOnlyUnknownArithComparesTimestampDirectly) {
+    std::vector<int64_t> values(N);
+    std::iota(values.begin(), values.end(), int64_t{0});
+    LoadTimestamptzIndex(values.data(), true);
+
+    proto::plan::Interval ignored_interval;
+    ignored_interval.set_months(1);
+    auto typed_expr = MakeTstzCompare(tstz_fid_,
+                                      proto::plan::ArithOpType::Unknown,
+                                      ignored_interval,
+                                      proto::plan::OpType::GreaterEqual,
+                                      16);
+
+    auto plan = milvus::test::CreateRetrievePlanByExpr(typed_expr);
+    auto result =
+        query::ExecuteQueryExpr(plan, sealed_.get(), N, MAX_TIMESTAMP);
+    ASSERT_EQ(result.size(), N);
+    for (size_t i = 0; i < N; ++i) {
+        const bool expected = tstz_valid_[i] && i >= 16;
+        EXPECT_EQ(result[i], expected) << "row " << i;
+    }
+}
+
+TEST_F(TimestamptzArithCompareCorrectnessTest, SealedOffsetInputNullSemantics) {
+    AssertOffsetInputNullSemantics(sealed_.get());
+}

--- a/internal/parser/planparserv2/convert_field_data_to_generic_value.go
+++ b/internal/parser/planparserv2/convert_field_data_to_generic_value.go
@@ -12,6 +12,19 @@ import (
 func convertArrayValue(templateName string, templateValue *schemapb.TemplateArrayValue) (*planpb.GenericValue, error) {
 	var arrayValues []*planpb.GenericValue
 	var elementType schemapb.DataType
+	// An empty SDK list has no element from which to infer a concrete oneof
+	// type. Preserve it as an untyped empty array; consumers with field context
+	// can still interpret its semantics (for example, ARRAY == []).
+	if templateValue != nil && templateValue.GetData() == nil {
+		return &planpb.GenericValue{
+			Val: &planpb.GenericValue_ArrayVal{
+				ArrayVal: &planpb.Array{
+					SameType:    true,
+					ElementType: schemapb.DataType_None,
+				},
+			},
+		}, nil
+	}
 	switch templateValue.GetData().(type) {
 	case *schemapb.TemplateArrayValue_BoolData:
 		elements := templateValue.GetBoolData().GetData()

--- a/internal/parser/planparserv2/fill_expression_value.go
+++ b/internal/parser/planparserv2/fill_expression_value.go
@@ -177,24 +177,6 @@ func FillBinaryRangeExpressionValue(expr *planpb.BinaryRangeExpr, templateValues
 		expr.UpperValue = castedUpperValue
 	}
 
-	// For JSON type, normalize numeric types to ensure both bounds have the same type.
-	// If one is float and the other is int, convert the int to float.
-	// This prevents type mismatch assertions in C++ expression execution.
-	if typeutil.IsJSONType(dataType) {
-		lowerVal := expr.GetLowerValue()
-		upperVal := expr.GetUpperValue()
-		lowerIsFloat := IsFloating(lowerVal)
-		upperIsFloat := IsFloating(upperVal)
-		lowerIsInt := IsInteger(lowerVal)
-		upperIsInt := IsInteger(upperVal)
-
-		if lowerIsFloat && upperIsInt {
-			expr.UpperValue = NewFloat(float64(upperVal.GetInt64Val()))
-		} else if lowerIsInt && upperIsFloat {
-			expr.LowerValue = NewFloat(float64(lowerVal.GetInt64Val()))
-		}
-	}
-
 	if !expr.GetLowerInclusive() || !expr.GetUpperInclusive() {
 		if getGenericValue(GreaterEqual(lowerValue, upperValue)).GetBoolVal() {
 			return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
@@ -306,5 +288,43 @@ func FillJSONContainsExpressionValue(expr *planpb.JSONContainsExpr, templateValu
 			expr.Elements = append(expr.Elements, castedValue)
 		}
 	}
+	expr.ElementsSameType = jsonContainsElementsSameType(expr.GetElements())
 	return nil
+}
+
+func jsonContainsElementsSameType(elements []*planpb.GenericValue) bool {
+	if len(elements) == 0 {
+		return true
+	}
+
+	elementType := genericValueDataType(elements[0])
+	if elementType == schemapb.DataType_None {
+		return false
+	}
+	for _, element := range elements[1:] {
+		if genericValueDataType(element) != elementType {
+			return false
+		}
+	}
+	return true
+}
+
+func genericValueDataType(value *planpb.GenericValue) schemapb.DataType {
+	if value == nil {
+		return schemapb.DataType_None
+	}
+	switch value.GetVal().(type) {
+	case *planpb.GenericValue_BoolVal:
+		return schemapb.DataType_Bool
+	case *planpb.GenericValue_Int64Val:
+		return schemapb.DataType_Int64
+	case *planpb.GenericValue_FloatVal:
+		return schemapb.DataType_Double
+	case *planpb.GenericValue_StringVal:
+		return schemapb.DataType_VarChar
+	case *planpb.GenericValue_ArrayVal:
+		return schemapb.DataType_Array
+	default:
+		return schemapb.DataType_None
+	}
 }

--- a/internal/parser/planparserv2/fill_expression_value.go
+++ b/internal/parser/planparserv2/fill_expression_value.go
@@ -161,6 +161,7 @@ func FillBinaryRangeExpressionValue(expr *planpb.BinaryRangeExpr, templateValues
 			return err
 		}
 		expr.LowerValue = castedLowerValue
+		lowerValue = castedLowerValue
 	}
 
 	upperValue := expr.GetUpperValue()
@@ -175,19 +176,10 @@ func FillBinaryRangeExpressionValue(expr *planpb.BinaryRangeExpr, templateValues
 			return err
 		}
 		expr.UpperValue = castedUpperValue
+		upperValue = castedUpperValue
 	}
 
-	if !expr.GetLowerInclusive() || !expr.GetUpperInclusive() {
-		if getGenericValue(GreaterEqual(lowerValue, upperValue)).GetBoolVal() {
-			return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-		}
-	} else {
-		if getGenericValue(Greater(lowerValue, upperValue)).GetBoolVal() {
-			return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-		}
-	}
-
-	return nil
+	return validateBinaryRangeBounds(lowerValue, upperValue, expr.GetLowerInclusive(), expr.GetUpperInclusive())
 }
 
 func FillBinaryArithOpEvalRangeExpressionValue(expr *planpb.BinaryArithOpEvalRangeExpr, templateValues map[string]*planpb.GenericValue) error {

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -3,6 +3,7 @@ package planparserv2
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
@@ -710,29 +711,18 @@ func (s *FillExpressionValueSuite) TestBinaryArithOpEvalRangeDivisionByZero() {
 }
 
 func (s *FillExpressionValueSuite) TestTermExprWithMixedNumericTypesForJSON() {
-	// Test that mixed int64/float types in 'in' expression are normalized to float for JSON fields.
-	// This prevents assertion failures in C++ expression execution.
-	// Related to the BinaryRange fix for issue: https://github.com/milvus-io/milvus/issues/46588
+	// Mixed JSON membership is split into homogeneous predicates so segcore
+	// never receives a TermExpr whose type disagrees with one of its values.
 	schemaH := newTestSchemaHelper(s.T())
 
-	s.Run("mixed int and float should normalize all to float", func() {
+	s.Run("mixed int and float should split by concrete type", func() {
 		// A is a dynamic field (JSON type)
-		// Directly parse expression with mixed int and float values
 		exprStr := `A in [1, 2.5, 3, 4.5]`
 
 		expr, err := ParseExpr(schemaH, exprStr, nil)
 		s.NoError(err)
 		s.NotNil(expr)
-
-		// Verify all values are normalized to float type
-		te := expr.GetTermExpr()
-		s.NotNil(te, "expected TermExpr")
-		s.Len(te.GetValues(), 4)
-		// All integers should be converted to floats
-		s.Equal(float64(1), te.GetValues()[0].GetFloatVal())
-		s.Equal(float64(2.5), te.GetValues()[1].GetFloatVal())
-		s.Equal(float64(3), te.GetValues()[2].GetFloatVal())
-		s.Equal(float64(4.5), te.GetValues()[3].GetFloatVal())
+		assertJSONMembershipKinds(s.T(), expr, map[string]int{"int64": 2, "float": 2})
 	})
 
 	s.Run("all integers should remain int64", func() {
@@ -769,37 +759,24 @@ func (s *FillExpressionValueSuite) TestTermExprWithMixedNumericTypesForJSON() {
 		s.Equal(float64(4.5), te.GetValues()[3].GetFloatVal())
 	})
 
-	s.Run("single float with integers should normalize all to float", func() {
+	s.Run("single float with integers should keep exact literal types", func() {
 		exprStr := `A in [1, 2, 3.0, 4]`
 
 		expr, err := ParseExpr(schemaH, exprStr, nil)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// Verify all values are normalized to float type
-		te := expr.GetTermExpr()
-		s.NotNil(te, "expected TermExpr")
-		s.Len(te.GetValues(), 4)
-		s.Equal(float64(1), te.GetValues()[0].GetFloatVal())
-		s.Equal(float64(2), te.GetValues()[1].GetFloatVal())
-		s.Equal(float64(3.0), te.GetValues()[2].GetFloatVal())
-		s.Equal(float64(4), te.GetValues()[3].GetFloatVal())
+		assertJSONMembershipKinds(s.T(), expr, map[string]int{"int64": 3, "float": 1})
 	})
 
-	s.Run("JSONField with mixed int and float should normalize all to float", func() {
+	s.Run("JSONField with mixed int and float should split", func() {
 		exprStr := `JSONField["x"] in [10, 20.5, 30]`
 
 		expr, err := ParseExpr(schemaH, exprStr, nil)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// Verify all values are normalized to float type
-		te := expr.GetTermExpr()
-		s.NotNil(te, "expected TermExpr")
-		s.Len(te.GetValues(), 3)
-		s.Equal(float64(10), te.GetValues()[0].GetFloatVal())
-		s.Equal(float64(20.5), te.GetValues()[1].GetFloatVal())
-		s.Equal(float64(30), te.GetValues()[2].GetFloatVal())
+		assertJSONMembershipKinds(s.T(), expr, map[string]int{"int64": 2, "float": 1})
 	})
 
 	s.Run("non-JSON field should not be affected by mixed type normalization", func() {
@@ -819,23 +796,91 @@ func (s *FillExpressionValueSuite) TestTermExprWithMixedNumericTypesForJSON() {
 		}
 	})
 
-	s.Run("not in with mixed int and float should normalize all to float", func() {
+	s.Run("not in with mixed int and float should negate split membership", func() {
 		exprStr := `A not in [1, 2.5, 3]`
 
 		expr, err := ParseExpr(schemaH, exprStr, nil)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// The not in expression wraps a TermExpr in a UnaryExpr
 		ue := expr.GetUnaryExpr()
 		s.NotNil(ue, "expected UnaryExpr")
-		te := ue.GetChild().GetTermExpr()
-		s.NotNil(te, "expected TermExpr")
-		s.Len(te.GetValues(), 3)
-		s.Equal(float64(1), te.GetValues()[0].GetFloatVal())
-		s.Equal(float64(2.5), te.GetValues()[1].GetFloatVal())
-		s.Equal(float64(3), te.GetValues()[2].GetFloatVal())
+		s.Equal(planpb.UnaryExpr_Not, ue.GetOp())
+		assertJSONMembershipKinds(s.T(), ue.GetChild(), map[string]int{"int64": 2, "float": 1})
 	})
+
+	s.Run("mixed template values should split by concrete type", func() {
+		expr, err := ParseExpr(schemaH, `A in {list}`, map[string]*schemapb.TemplateValue{
+			"list": generateTemplateValue(schemapb.DataType_Array,
+				generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{
+					generateJSONData(int64(1)),
+					generateJSONData(2.5),
+					generateJSONData("3"),
+					generateJSONData(true),
+				})),
+		})
+		s.NoError(err)
+		s.NotNil(expr)
+		assertJSONMembershipKinds(s.T(), expr, map[string]int{
+			"bool": 1, "int64": 1, "float": 1, "string": 1,
+		})
+	})
+}
+
+func assertJSONMembershipKinds(t *testing.T, expr *planpb.Expr, expected map[string]int) {
+	t.Helper()
+	actual := make(map[string]int)
+	var visit func(*planpb.Expr)
+	visit = func(current *planpb.Expr) {
+		if current == nil {
+			return
+		}
+		if term := current.GetTermExpr(); term != nil {
+			var termKind string
+			for _, value := range term.GetValues() {
+				kind := genericValueKind(value)
+				if termKind == "" {
+					termKind = kind
+				}
+				require.Equal(t, termKind, kind, "TermExpr must be homogeneous")
+				actual[kind]++
+			}
+			return
+		}
+		if unaryRange := current.GetUnaryRangeExpr(); unaryRange != nil {
+			if unaryRange.GetOp() == planpb.OpType_Equal {
+				actual[genericValueKind(unaryRange.GetValue())]++
+			}
+			return
+		}
+		if binary := current.GetBinaryExpr(); binary != nil {
+			visit(binary.GetLeft())
+			visit(binary.GetRight())
+			return
+		}
+		if unary := current.GetUnaryExpr(); unary != nil {
+			visit(unary.GetChild())
+		}
+	}
+	visit(expr)
+	require.Equal(t, expected, actual)
+}
+
+func genericValueKind(value *planpb.GenericValue) string {
+	switch value.GetVal().(type) {
+	case *planpb.GenericValue_BoolVal:
+		return "bool"
+	case *planpb.GenericValue_Int64Val:
+		return "int64"
+	case *planpb.GenericValue_FloatVal:
+		return "float"
+	case *planpb.GenericValue_StringVal:
+		return "string"
+	case *planpb.GenericValue_ArrayVal:
+		return "array"
+	default:
+		return "other"
+	}
 }
 
 // assertNoUnfilledPlaceholder walks the expression tree and asserts that

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -1,6 +1,7 @@
 package planparserv2
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -763,6 +764,52 @@ func (s *FillExpressionValueSuite) TestBinaryRangeWithMixedNumericTypesForJSON()
 		s.NotNil(bre, "expected BinaryRangeExpr")
 		s.Equal(float64(10.5), bre.GetLowerValue().GetFloatVal())
 		s.Equal(float64(100.5), bre.GetUpperValue().GetFloatVal())
+	})
+
+	s.Run("adjacent mixed bounds above 2^53 should remain valid", func() {
+		expr, err := ParseExpr(schemaH, `{min} <= A < {max}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740992)),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740993)),
+		})
+		s.Require().NoError(err)
+
+		bre := expr.GetBinaryRangeExpr()
+		s.Require().NotNil(bre)
+		s.IsType(&planpb.GenericValue_FloatVal{}, bre.GetLowerValue().GetVal())
+		s.Equal(float64(9007199254740992), bre.GetLowerValue().GetFloatVal())
+		s.IsType(&planpb.GenericValue_Int64Val{}, bre.GetUpperValue().GetVal())
+		s.Equal(int64(9007199254740993), bre.GetUpperValue().GetInt64Val())
+	})
+
+	s.Run("reverse adjacent mixed bounds above 2^53 should remain valid", func() {
+		expr, err := ParseExpr(schemaH, `{max} > A >= {min}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740992)),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740993)),
+		})
+		s.Require().NoError(err)
+
+		bre := expr.GetBinaryRangeExpr()
+		s.Require().NotNil(bre)
+		s.IsType(&planpb.GenericValue_FloatVal{}, bre.GetLowerValue().GetVal())
+		s.IsType(&planpb.GenericValue_Int64Val{}, bre.GetUpperValue().GetVal())
+	})
+
+	s.Run("truly reversed mixed bounds should fail", func() {
+		s.assertInvalidExpr(schemaH, `{min} <= A < {max}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740994)),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740993)),
+		})
+	})
+
+	s.Run("NaN and different dynamic types are deferred to execution", func() {
+		s.assertValidExpr(schemaH, `{min} < A < {max}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Double, math.NaN()),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(10)),
+		})
+		s.assertValidExpr(schemaH, `{min} < A < {max}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Int64, int64(1)),
+			"max": generateTemplateValue(schemapb.DataType_String, "z"),
+		})
 	})
 }
 

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -75,6 +75,12 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 			{`Int64Field in {empty_list}`, map[string]*schemapb.TemplateValue{
 				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
 			}},
+			{`A in {empty_list}`, map[string]*schemapb.TemplateValue{
+				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+			}},
+			{`ArrayField in {empty_list}`, map[string]*schemapb.TemplateValue{
+				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+			}},
 		}
 		schemaH := newTestSchemaHelper(s.T())
 		for _, c := range testcases {
@@ -118,6 +124,44 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 			s.assertInvalidExpr(schemaH, c.expr, c.values)
 		}
 	})
+}
+
+func (s *FillExpressionValueSuite) TestEmptyTermRejectsUnsupportedTargetTypes() {
+	schemaH := newTestSchemaHelper(s.T())
+	emptyTemplate := map[string]*schemapb.TemplateValue{
+		"empty": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+	}
+	targetFields := []string{
+		"BinaryVectorField",
+		"FloatVectorField",
+		"Float16VectorField",
+		"BFloat16VectorField",
+		"SparseFloatVectorField",
+		"Int8VectorField",
+		"ArrayOfVectorField",
+		"GeometryField",
+	}
+	rightHandSides := []struct {
+		name   string
+		value  string
+		params map[string]*schemapb.TemplateValue
+	}{
+		{name: "inline", value: "[]"},
+		{name: "template", value: "{empty}", params: emptyTemplate},
+	}
+
+	for _, field := range targetFields {
+		for _, op := range []string{"in", "not in"} {
+			for _, rhs := range rightHandSides {
+				s.Run(field+"/"+op+"/"+rhs.name, func() {
+					expr, err := ParseExpr(schemaH, field+" "+op+" "+rhs.value, rhs.params)
+					s.Require().Error(err)
+					s.Require().Nil(expr)
+					s.Contains(err.Error(), "term expression is not supported")
+				})
+			}
+		}
+	}
 }
 
 func (s *FillExpressionValueSuite) TestEmptyArrayComparisonNormalization() {

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -71,6 +71,9 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 				"list": generateTemplateValue(schemapb.DataType_Array,
 					generateTemplateArrayValue(schemapb.DataType_Int64, []int64{int64(1), int64(2), int64(3)})),
 			}},
+			{`Int64Field in {empty_list}`, map[string]*schemapb.TemplateValue{
+				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+			}},
 		}
 		schemaH := newTestSchemaHelper(s.T())
 		for _, c := range testcases {
@@ -107,9 +110,6 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 			{"Int64Field not in {not_list}", map[string]*schemapb.TemplateValue{
 				"age": generateTemplateValue(schemapb.DataType_Int64, int64(33)),
 			}},
-			{`Int64Field in {empty_list}`, map[string]*schemapb.TemplateValue{
-				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
-			}},
 		}
 
 		schemaH := newTestSchemaHelper(s.T())
@@ -117,6 +117,34 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 			s.assertInvalidExpr(schemaH, c.expr, c.values)
 		}
 	})
+}
+
+func (s *FillExpressionValueSuite) TestEmptyArrayComparisonNormalization() {
+	schemaH := newTestSchemaHelper(s.T())
+	emptyArray := generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{})
+
+	testcases := []struct {
+		expr string
+		op   planpb.OpType
+	}{
+		{expr: `ArrayField == {empty}`, op: planpb.OpType_Equal},
+		{expr: `{empty} == ArrayField`, op: planpb.OpType_Equal},
+		{expr: `ArrayField != {empty}`, op: planpb.OpType_NotEqual},
+		{expr: `{empty} != ArrayField`, op: planpb.OpType_NotEqual},
+	}
+	for _, testcase := range testcases {
+		s.Run(testcase.expr, func() {
+			expr, err := ParseExpr(schemaH, testcase.expr, map[string]*schemapb.TemplateValue{
+				"empty": emptyArray,
+			})
+			s.NoError(err)
+			arrayLength := expr.GetBinaryArithOpEvalRangeExpr()
+			s.NotNil(arrayLength)
+			s.Equal(planpb.ArithOpType_ArrayLength, arrayLength.GetArithOp())
+			s.Equal(testcase.op, arrayLength.GetOp())
+			s.Equal(int64(0), arrayLength.GetValue().GetInt64Val())
+		})
+	}
 }
 
 func (s *FillExpressionValueSuite) TestUnaryRange() {

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -487,6 +487,82 @@ func (s *FillExpressionValueSuite) TestJSONContainsExpression() {
 		}
 	})
 
+	s.Run("template elements same type", func() {
+		schemaH := newTestSchemaHelper(s.T())
+		testcases := []struct {
+			name     string
+			expr     string
+			values   map[string]*schemapb.TemplateValue
+			expected bool
+		}{
+			{
+				name: "typed homogeneous array",
+				expr: `json_contains_any(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_Int64, []int64{1, 2, 3})),
+				},
+				expected: true,
+			},
+			{
+				name: "JSON homogeneous array",
+				expr: `json_contains_all(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{
+							generateJSONData(int64(1)),
+							generateJSONData(int64(2)),
+							generateJSONData(int64(3)),
+						})),
+				},
+				expected: true,
+			},
+			{
+				name: "JSON heterogeneous array",
+				expr: `json_contains_any(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{
+							generateJSONData(int64(1)),
+							generateJSONData("1"),
+						})),
+				},
+				expected: false,
+			},
+			{
+				name: "empty array",
+				expr: `json_contains_any(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{})),
+				},
+				expected: true,
+			},
+			{
+				name: "singleton array",
+				expr: `json_contains_all(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_JSON, [][]byte{
+							generateJSONData(1.5),
+						})),
+				},
+				expected: true,
+			},
+		}
+
+		for _, testcase := range testcases {
+			s.Run(testcase.name, func() {
+				expr, err := ParseExpr(schemaH, testcase.expr, testcase.values)
+				s.NoError(err)
+				s.NotNil(expr)
+				contains := expr.GetJsonContainsExpr()
+				s.NotNil(contains)
+				s.Equal(testcase.expected, contains.GetElementsSameType())
+			})
+		}
+	})
+
 	s.Run("failed case", func() {
 		testcases := []testcase{
 			{`json_contains(ArrayField[0], {str})`, map[string]*schemapb.TemplateValue{
@@ -582,46 +658,47 @@ func (s *FillExpressionValueSuite) TestBinaryExpression() {
 }
 
 func (s *FillExpressionValueSuite) TestBinaryRangeWithMixedNumericTypesForJSON() {
-	// Test that mixed int64/float types are normalized to float for JSON fields.
-	// This prevents assertion failures in C++ expression execution.
-	// Related issue: https://github.com/milvus-io/milvus/issues/46588
+	// Mixed JSON numeric bounds must preserve their concrete literal types so
+	// large int64 values are not rounded before precise segcore comparison.
 	schemaH := newTestSchemaHelper(s.T())
 
-	s.Run("lower int64 upper float should normalize to float", func() {
+	s.Run("lower int64 upper float should preserve types", func() {
 		// A is a dynamic field (JSON type)
 		exprStr := `{min} < A < {max}`
 		templateValues := map[string]*schemapb.TemplateValue{
-			"min": generateTemplateValue(schemapb.DataType_Int64, int64(499)),
-			"max": generateTemplateValue(schemapb.DataType_Double, float64(512.0)),
+			"min": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740993)),
+			"max": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740996)),
 		}
 
 		expr, err := ParseExpr(schemaH, exprStr, templateValues)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// Verify both bounds are normalized to float type
 		bre := expr.GetBinaryRangeExpr()
 		s.NotNil(bre, "expected BinaryRangeExpr")
-		s.Equal(float64(499), bre.GetLowerValue().GetFloatVal())
-		s.Equal(float64(512.0), bre.GetUpperValue().GetFloatVal())
+		s.IsType(&planpb.GenericValue_Int64Val{}, bre.GetLowerValue().GetVal())
+		s.Equal(int64(9007199254740993), bre.GetLowerValue().GetInt64Val())
+		s.IsType(&planpb.GenericValue_FloatVal{}, bre.GetUpperValue().GetVal())
+		s.Equal(float64(9007199254740996), bre.GetUpperValue().GetFloatVal())
 	})
 
-	s.Run("lower float upper int64 should normalize to float", func() {
+	s.Run("lower float upper int64 should preserve types", func() {
 		exprStr := `{min} < A < {max}`
 		templateValues := map[string]*schemapb.TemplateValue{
-			"min": generateTemplateValue(schemapb.DataType_Double, float64(10.5)),
-			"max": generateTemplateValue(schemapb.DataType_Int64, int64(100)),
+			"min": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740992)),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740995)),
 		}
 
 		expr, err := ParseExpr(schemaH, exprStr, templateValues)
 		s.NoError(err)
 		s.NotNil(expr)
 
-		// Verify both bounds are normalized to float type
 		bre := expr.GetBinaryRangeExpr()
 		s.NotNil(bre, "expected BinaryRangeExpr")
-		s.Equal(float64(10.5), bre.GetLowerValue().GetFloatVal())
-		s.Equal(float64(100), bre.GetUpperValue().GetFloatVal())
+		s.IsType(&planpb.GenericValue_FloatVal{}, bre.GetLowerValue().GetVal())
+		s.Equal(float64(9007199254740992), bre.GetLowerValue().GetFloatVal())
+		s.IsType(&planpb.GenericValue_Int64Val{}, bre.GetUpperValue().GetVal())
+		s.Equal(int64(9007199254740995), bre.GetUpperValue().GetInt64Val())
 	})
 
 	s.Run("both int64 should remain int64", func() {

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -189,6 +190,94 @@ func (s *FillExpressionValueSuite) TestEmptyArrayComparisonNormalization() {
 			s.Equal(testcase.op, arrayLength.GetOp())
 			s.Equal(int64(0), arrayLength.GetValue().GetInt64Val())
 		})
+	}
+}
+
+func (s *FillExpressionValueSuite) TestWholeArrayTemplateMembershipNormalization() {
+	schemaH := newTestSchemaHelper(s.T())
+	emptyArray := func() *schemapb.TemplateArrayValue {
+		return &schemapb.TemplateArrayValue{}
+	}
+	intArray := func(values ...int64) *schemapb.TemplateArrayValue {
+		return generateTemplateArrayValue(schemapb.DataType_Int64, values)
+	}
+
+	testcases := []struct {
+		name               string
+		arrays             []*schemapb.TemplateArrayValue
+		expectedLengths    int
+		expectedEqualities int
+	}{
+		{
+			name:            "empty arrays",
+			arrays:          []*schemapb.TemplateArrayValue{emptyArray(), emptyArray()},
+			expectedLengths: 2,
+		},
+		{
+			name: "non-empty arrays",
+			arrays: []*schemapb.TemplateArrayValue{
+				intArray(1, 2),
+				intArray(3, 4),
+			},
+			expectedEqualities: 2,
+		},
+		{
+			name: "mixed empty and non-empty arrays",
+			arrays: []*schemapb.TemplateArrayValue{
+				emptyArray(),
+				intArray(1, 2),
+			},
+			expectedLengths:    1,
+			expectedEqualities: 1,
+		},
+	}
+
+	for _, testcase := range testcases {
+		for _, op := range []string{"in", "not in"} {
+			s.Run(testcase.name+"/"+op, func() {
+				expr, err := ParseExpr(schemaH, "ArrayField "+op+" {arrays}", map[string]*schemapb.TemplateValue{
+					"arrays": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_Array, testcase.arrays)),
+				})
+				s.NoError(err)
+				s.NotNil(expr)
+				if op == "not in" {
+					s.NotNil(expr.GetUnaryExpr())
+					s.Equal(planpb.UnaryExpr_Not, expr.GetUnaryExpr().GetOp())
+				}
+
+				var arrayLengths int
+				var arrayEqualities int
+				var walk func(*planpb.Expr)
+				walk = func(current *planpb.Expr) {
+					if current == nil {
+						return
+					}
+					s.Nil(current.GetTermExpr(), "whole ARRAY membership must not remain a TermExpr")
+					if arrayLength := current.GetBinaryArithOpEvalRangeExpr(); arrayLength != nil &&
+						arrayLength.GetArithOp() == planpb.ArithOpType_ArrayLength &&
+						arrayLength.GetOp() == planpb.OpType_Equal &&
+						arrayLength.GetValue().GetInt64Val() == 0 {
+						arrayLengths++
+					}
+					if equality := current.GetUnaryRangeExpr(); equality != nil &&
+						equality.GetOp() == planpb.OpType_Equal &&
+						equality.GetValue().GetArrayVal() != nil {
+						arrayEqualities++
+					}
+					if binary := current.GetBinaryExpr(); binary != nil {
+						walk(binary.GetLeft())
+						walk(binary.GetRight())
+					}
+					if unary := current.GetUnaryExpr(); unary != nil {
+						walk(unary.GetChild())
+					}
+				}
+				walk(expr)
+				s.Equal(testcase.expectedLengths, arrayLengths)
+				s.Equal(testcase.expectedEqualities, arrayEqualities)
+			})
+		}
 	}
 }
 
@@ -612,6 +701,14 @@ func (s *FillExpressionValueSuite) TestJSONContainsExpression() {
 				expected: true,
 			},
 			{
+				name: "untyped empty array",
+				expr: `json_contains_all(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+				},
+				expected: true,
+			},
+			{
 				name: "singleton array",
 				expr: `json_contains_all(JSONField, {array})`,
 				values: map[string]*schemapb.TemplateValue{
@@ -845,12 +942,44 @@ func (s *FillExpressionValueSuite) TestBinaryRangeWithMixedNumericTypesForJSON()
 		})
 	})
 
-	s.Run("NaN and different dynamic types are deferred to execution", func() {
-		s.assertValidExpr(schemaH, `{min} < A < {max}`, map[string]*schemapb.TemplateValue{
-			"min": generateTemplateValue(schemapb.DataType_Double, math.NaN()),
-			"max": generateTemplateValue(schemapb.DataType_Int64, int64(10)),
-		})
-		s.assertValidExpr(schemaH, `{min} < A < {max}`, map[string]*schemapb.TemplateValue{
+	s.Run("NaN and different dynamic types should fail", func() {
+		bounds := func(min, max *schemapb.TemplateValue) map[string]*schemapb.TemplateValue {
+			return map[string]*schemapb.TemplateValue{"min": min, "max": max}
+		}
+		value := generateTemplateValue
+		mixedBounds := bounds(value(schemapb.DataType_Int64, int64(1)), value(schemapb.DataType_String, "z"))
+		array := func(v int64) *schemapb.TemplateValue {
+			return value(schemapb.DataType_Array, generateTemplateArrayValue(schemapb.DataType_Int64, []int64{v}))
+		}
+		for _, c := range []testcase{
+			{`{min} < A < {max}`, bounds(value(schemapb.DataType_Double, math.NaN()), value(schemapb.DataType_Int64, int64(10)))},
+			{`{min} < A < {max}`, bounds(value(schemapb.DataType_Int64, int64(1)), value(schemapb.DataType_Double, math.NaN()))},
+			{`{min} < A < {max}`, mixedBounds},
+			{`1 < A < {max}`, map[string]*schemapb.TemplateValue{"max": value(schemapb.DataType_String, "z")}},
+			{`{min} < A < "z"`, map[string]*schemapb.TemplateValue{"min": value(schemapb.DataType_Int64, int64(1))}},
+			{`{min} < DoubleField < {max}`, bounds(value(schemapb.DataType_Double, math.NaN()), value(schemapb.DataType_Double, float64(10)))},
+			{`{min} < A < {max}`, bounds(value(schemapb.DataType_Bool, false), value(schemapb.DataType_Bool, true))},
+			{`{min} < A < {max}`, bounds(array(1), array(2))},
+			{`{min} < A < {max} && random_sample(0.1)`, mixedBounds},
+		} {
+			expr, err := ParseExpr(schemaH, c.expr, c.values)
+			s.ErrorIs(err, merr.ErrQueryPlan, c.expr)
+			s.Nil(expr, c.expr)
+		}
+	})
+
+	s.Run("valid template bounds should survive expression wrappers", func() {
+		templateValues := map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Int64, int64(1)),
+			"max": generateTemplateValue(schemapb.DataType_Double, float64(10.5)),
+		}
+		exprStr := `{min} < A < {max} && random_sample(0.1)`
+		expr, err := ParseExpr(schemaH, exprStr, templateValues)
+		s.Require().NoError(err, exprStr)
+		s.NotNil(expr, exprStr)
+		s.assertNoUnfilledPlaceholder(expr)
+
+		s.assertValidExpr(schemaH, `A > {min} AND A < {max}`, map[string]*schemapb.TemplateValue{
 			"min": generateTemplateValue(schemapb.DataType_Int64, int64(1)),
 			"max": generateTemplateValue(schemapb.DataType_String, "z"),
 		})

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -751,6 +751,12 @@ func (v *ParserVisitor) VisitRandomSample(ctx *parser.RandomSampleContext) inter
 	}
 }
 
+func isTermExprTargetSupported(dataType schemapb.DataType) bool {
+	return typeutil.IsPrimitiveType(dataType) ||
+		typeutil.IsJSONType(dataType) ||
+		typeutil.IsArrayType(dataType)
+}
+
 // VisitTerm translates expr to term plan.
 func (v *ParserVisitor) VisitTerm(ctx *parser.TermContext) interface{} {
 	child := ctx.Expr(0).Accept(v)
@@ -771,6 +777,9 @@ func (v *ParserVisitor) VisitTerm(ctx *parser.TermContext) interface{} {
 	dataType := columnInfo.GetDataType()
 	if typeutil.IsArrayType(dataType) && len(columnInfo.GetNestedPath()) != 0 {
 		dataType = columnInfo.GetElementType()
+	}
+	if !isTermExprTargetSupported(dataType) {
+		return merr.WrapErrParameterInvalidMsg("term expression is not supported for data type %s", dataType.String())
 	}
 
 	term := ctx.Expr(1).Accept(v)

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -218,6 +218,31 @@ func checkDirectComparisonBinaryField(columnInfo *planpb.ColumnInfo) error {
 	return nil
 }
 
+// contextualizeEmptyArrayLiteral assigns the element type of a whole ARRAY
+// column to an inline empty array literal. Unlike a non-empty literal, [] has
+// no element from which the parser can infer a type. The field provides that
+// missing context for equality comparisons without relaxing comparisons on
+// ARRAY elements or JSON paths.
+func contextualizeEmptyArrayLiteral(literal, field *ExprWithType) {
+	if literal == nil || field == nil || literal.dataType != schemapb.DataType_Array {
+		return
+	}
+	valueExpr := literal.expr.GetValueExpr()
+	if valueExpr == nil || isTemplateExpr(valueExpr) {
+		return
+	}
+	array := valueExpr.GetValue().GetArrayVal()
+	if array == nil || len(array.GetArray()) != 0 || array.GetElementType() != schemapb.DataType_None {
+		return
+	}
+	columnInfo := toColumnInfo(field)
+	if columnInfo == nil || columnInfo.GetDataType() != schemapb.DataType_Array ||
+		len(columnInfo.GetNestedPath()) != 0 {
+		return
+	}
+	array.ElementType = columnInfo.GetElementType()
+}
+
 // VisitAddSub translates expr to arithmetic plan.
 func (v *ParserVisitor) VisitAddSub(ctx *parser.AddSubContext) interface{} {
 	var err error
@@ -408,6 +433,10 @@ func (v *ParserVisitor) VisitEquality(ctx *parser.EqualityContext) interface{} {
 		return err
 	}
 
+	leftExpr, rightExpr := getExpr(left), getExpr(right)
+	contextualizeEmptyArrayLiteral(leftExpr, rightExpr)
+	contextualizeEmptyArrayLiteral(rightExpr, leftExpr)
+
 	leftValueExpr, rightValueExpr := getValueExpr(left), getValueExpr(right)
 	if leftValueExpr != nil && rightValueExpr != nil {
 		if isTemplateExpr(leftValueExpr) || isTemplateExpr(rightValueExpr) {
@@ -428,8 +457,6 @@ func (v *ParserVisitor) VisitEquality(ctx *parser.EqualityContext) interface{} {
 		}
 		return ret
 	}
-
-	leftExpr, rightExpr := getExpr(left), getExpr(right)
 
 	expr, err := HandleCompare(ctx.GetOp().GetTokenType(), leftExpr, rightExpr)
 	if err != nil {

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -777,28 +777,6 @@ func (v *ParserVisitor) VisitTerm(ctx *parser.TermContext) interface{} {
 			}
 			values[i] = castedValue
 		}
-
-		// For JSON type, ensure all numeric values have consistent type.
-		// If there's a mix of integers and floats, convert all to floats.
-		if typeutil.IsJSONType(dataType) && len(values) > 0 {
-			hasInt := false
-			hasFloat := false
-			for _, val := range values {
-				if IsInteger(val) {
-					hasInt = true
-				} else if IsFloating(val) {
-					hasFloat = true
-				}
-			}
-			// If we have both int and float, convert all ints to floats
-			if hasInt && hasFloat {
-				for i, val := range values {
-					if IsInteger(val) {
-						values[i] = NewFloat(float64(val.GetInt64Val()))
-					}
-				}
-			}
-		}
 	}
 
 	expr := &planpb.Expr{

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -920,14 +920,8 @@ func (v *ParserVisitor) VisitRange(ctx *parser.RangeContext) interface{} {
 	lowerInclusive := ctx.GetOp1().GetTokenType() == parser.PlanParserLE
 	upperInclusive := ctx.GetOp2().GetTokenType() == parser.PlanParserLE
 	if !isTemplateExpr(lowerValueExpr) && !isTemplateExpr(upperValueExpr) {
-		if !lowerInclusive || !upperInclusive {
-			if getGenericValue(GreaterEqual(lowerValue, upperValue)).GetBoolVal() {
-				return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-			}
-		} else {
-			if getGenericValue(Greater(lowerValue, upperValue)).GetBoolVal() {
-				return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-			}
+		if err := validateBinaryRangeBounds(lowerValue, upperValue, lowerInclusive, upperInclusive); err != nil {
+			return err
 		}
 	}
 
@@ -1002,14 +996,8 @@ func (v *ParserVisitor) VisitReverseRange(ctx *parser.ReverseRangeContext) inter
 	lowerInclusive := ctx.GetOp2().GetTokenType() == parser.PlanParserGE
 	upperInclusive := ctx.GetOp1().GetTokenType() == parser.PlanParserGE
 	if !isTemplateExpr(lowerValueExpr) && !isTemplateExpr(upperValueExpr) {
-		if !lowerInclusive || !upperInclusive {
-			if getGenericValue(GreaterEqual(lowerValue, upperValue)).GetBoolVal() {
-				return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-			}
-		} else {
-			if getGenericValue(Greater(lowerValue, upperValue)).GetBoolVal() {
-				return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-			}
+		if err := validateBinaryRangeBounds(lowerValue, upperValue, lowerInclusive, upperInclusive); err != nil {
+			return err
 		}
 	}
 

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -1203,6 +1203,7 @@ func (v *ParserVisitor) VisitLogicalAnd(ctx *parser.LogicalAndContext) interface
 			Expr: &planpb.Expr_RandomSampleExpr{
 				RandomSampleExpr: randomSampleExpr,
 			},
+			IsTemplate: leftExpr.expr.GetIsTemplate() || rightExpr.expr.GetIsTemplate(),
 		}
 	} else {
 		expr = &planpb.Expr{

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -730,6 +730,48 @@ func TestExpr_BinaryRange(t *testing.T) {
 	}
 }
 
+func TestExpr_JSONBinaryRangePreciseBoundValidation(t *testing.T) {
+	schema := newTestSchema(true)
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	require.NoError(t, err)
+
+	for name, exprStr := range map[string]string{
+		"range":         `9007199254740992.0 <= A < 9007199254740993`,
+		"reverse range": `9007199254740993 > A >= 9007199254740992.0`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			expr, err := ParseExpr(helper, exprStr, nil)
+			require.NoError(t, err)
+
+			binaryRange := expr.GetBinaryRangeExpr()
+			require.NotNil(t, binaryRange)
+			assert.IsType(t, &planpb.GenericValue_FloatVal{}, binaryRange.GetLowerValue().GetVal())
+			assert.Equal(t, float64(9007199254740992), binaryRange.GetLowerValue().GetFloatVal())
+			assert.IsType(t, &planpb.GenericValue_Int64Val{}, binaryRange.GetUpperValue().GetVal())
+			assert.Equal(t, int64(9007199254740993), binaryRange.GetUpperValue().GetInt64Val())
+			assert.True(t, binaryRange.GetLowerInclusive())
+			assert.False(t, binaryRange.GetUpperInclusive())
+		})
+	}
+
+	for name, exprStr := range map[string]string{
+		"range lower greater than upper":         `9007199254740994.0 <= A < 9007199254740993`,
+		"reverse range lower greater than upper": `9007199254740993 > A >= 9007199254740994.0`,
+		"equal bounds with open upper":           `9007199254740992.0 <= A < 9007199254740992`,
+		"equal bounds with open lower":           `9007199254740992.0 < A <= 9007199254740992`,
+		"same-type strings in reverse order":     `"z" <= A < "a"`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseExpr(helper, exprStr, nil)
+			assert.Error(t, err)
+		})
+	}
+
+	// Bounds with different JSON dynamic types have no parser-level ordering.
+	// Their runtime type semantics are evaluated by segcore.
+	assertValidExpr(t, helper, `1 <= A < "z"`)
+}
+
 func TestExpr_castValue(t *testing.T) {
 	schema := newTestSchema(true)
 	helper, err := typeutil.CreateSchemaHelper(schema)

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -1697,6 +1697,12 @@ func Test_ArrayExpr(t *testing.T) {
 
 	exprs := []string{
 		`ArrayField == [1,2,3,4]`,
+		`ArrayField != [1,2,3,4]`,
+		`[1,2,3,4] == ArrayField`,
+		`ArrayField == []`,
+		`ArrayField != []`,
+		`[] == ArrayField`,
+		`[] != ArrayField`,
 		`ArrayField[0] == 1`,
 		`ArrayField[0] > 1`,
 		`1 < ArrayField[0] < 3`,
@@ -1759,7 +1765,6 @@ func Test_ArrayExpr(t *testing.T) {
 		`ArrayField[] == 1`,
 		`A[] == 1`,
 		`ArrayField[0] + ArrayField[1] == 1`,
-		`ArrayField == []`,
 	}
 	for _, expr = range invalidExprs {
 		_, err = CreateSearchPlan(schema, expr, "FloatVectorField", &planpb.QueryInfo{
@@ -1770,6 +1775,52 @@ func Test_ArrayExpr(t *testing.T) {
 		}, nil, nil)
 		assert.Error(t, err, expr)
 	}
+}
+
+func Test_EmptyArrayComparisonNormalization(t *testing.T) {
+	schema := newTestSchema(true)
+	for _, field := range schema.GetFields() {
+		if field.GetName() == "ArrayField" {
+			field.Nullable = true
+		}
+	}
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		expr string
+		op   planpb.OpType
+	}{
+		{expr: `ArrayField == []`, op: planpb.OpType_Equal},
+		{expr: `[] == ArrayField`, op: planpb.OpType_Equal},
+		{expr: `ArrayField != []`, op: planpb.OpType_NotEqual},
+		{expr: `[] != ArrayField`, op: planpb.OpType_NotEqual},
+		{expr: `StringArrayField == []`, op: planpb.OpType_Equal},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.expr, func(t *testing.T) {
+			expr, err := ParseExpr(helper, testcase.expr, nil)
+			require.NoError(t, err)
+			arrayLength := expr.GetBinaryArithOpEvalRangeExpr()
+			require.NotNil(t, arrayLength)
+			require.Equal(t, planpb.ArithOpType_ArrayLength, arrayLength.GetArithOp())
+			require.Equal(t, testcase.op, arrayLength.GetOp())
+			require.Equal(t, int64(0), arrayLength.GetValue().GetInt64Val())
+			require.Empty(t, arrayLength.GetColumnInfo().GetNestedPath())
+			if testcase.expr == `ArrayField == []` {
+				require.True(t, arrayLength.GetColumnInfo().GetNullable())
+			}
+		})
+	}
+
+	_, err = ParseExpr(helper, `ArrayField[0] == []`, nil)
+	require.Error(t, err)
+	_, err = ParseExpr(helper, `ArrayField > []`, nil)
+	require.Error(t, err)
+
+	jsonExpr, err := ParseExpr(helper, `JSONField["array"] == []`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, jsonExpr.GetUnaryRangeExpr(), "JSON array comparison must not be rewritten as ARRAY length")
 }
 
 func Test_ArrayLength(t *testing.T) {

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/function/rerank"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -767,9 +768,22 @@ func TestExpr_JSONBinaryRangePreciseBoundValidation(t *testing.T) {
 		})
 	}
 
-	// Bounds with different JSON dynamic types have no parser-level ordering.
-	// Their runtime type semantics are evaluated by segcore.
-	assertValidExpr(t, helper, `1 <= A < "z"`)
+	for _, exprStr := range []string{
+		`1 <= A < "z"`,
+		`"z" > A >= 1`,
+		`false < A < true`,
+		`[1] < A < [2]`,
+	} {
+		_, err := ParseExpr(helper, exprStr, nil)
+		require.ErrorIs(t, err, merr.ErrQueryPlan, exprStr)
+		assert.Contains(t, err.Error(), "bounds are not comparable", exprStr)
+	}
+
+	// Separate comparisons keep their own JSON dynamic-type semantics and must
+	// not be rejected or merged into a mixed-type BinaryRangeExpr.
+	expr, err := ParseExpr(helper, `A >= 1 AND A < "z"`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr.GetBinaryExpr())
 }
 
 func TestExpr_castValue(t *testing.T) {

--- a/internal/parser/planparserv2/rewriter/array.go
+++ b/internal/parser/planparserv2/rewriter/array.go
@@ -1,0 +1,74 @@
+package rewriter
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+)
+
+// normalizeEmptyArrayComparisons lowers whole ARRAY == [] and ARRAY != [] to
+// array_length(ARRAY) == 0 and array_length(ARRAY) != 0. This is semantic
+// normalization rather than an optional optimization: an empty array carries
+// no element type, while ARRAY length has the same nullable semantics and an
+// executable plan representation.
+func normalizeEmptyArrayComparisons(expr *planpb.Expr) *planpb.Expr {
+	if expr == nil {
+		return nil
+	}
+
+	switch real := expr.GetExpr().(type) {
+	case *planpb.Expr_BinaryExpr:
+		real.BinaryExpr.Left = normalizeEmptyArrayComparisons(real.BinaryExpr.GetLeft())
+		real.BinaryExpr.Right = normalizeEmptyArrayComparisons(real.BinaryExpr.GetRight())
+		return expr
+	case *planpb.Expr_UnaryExpr:
+		real.UnaryExpr.Child = normalizeEmptyArrayComparisons(real.UnaryExpr.GetChild())
+		return expr
+	case *planpb.Expr_BinaryArithExpr:
+		real.BinaryArithExpr.Left = normalizeEmptyArrayComparisons(real.BinaryArithExpr.GetLeft())
+		real.BinaryArithExpr.Right = normalizeEmptyArrayComparisons(real.BinaryArithExpr.GetRight())
+		return expr
+	case *planpb.Expr_CallExpr:
+		for i, parameter := range real.CallExpr.GetFunctionParameters() {
+			real.CallExpr.FunctionParameters[i] = normalizeEmptyArrayComparisons(parameter)
+		}
+		return expr
+	case *planpb.Expr_RandomSampleExpr:
+		real.RandomSampleExpr.Predicate = normalizeEmptyArrayComparisons(real.RandomSampleExpr.GetPredicate())
+		return expr
+	case *planpb.Expr_UnaryRangeExpr:
+		return normalizeEmptyArrayUnaryRange(expr, real.UnaryRangeExpr)
+	default:
+		return expr
+	}
+}
+
+func normalizeEmptyArrayUnaryRange(original *planpb.Expr, unaryRange *planpb.UnaryRangeExpr) *planpb.Expr {
+	if unaryRange == nil || unaryRange.GetColumnInfo() == nil {
+		return original
+	}
+	columnInfo := unaryRange.GetColumnInfo()
+	if columnInfo.GetDataType() != schemapb.DataType_Array ||
+		len(columnInfo.GetNestedPath()) != 0 {
+		return original
+	}
+	if unaryRange.GetOp() != planpb.OpType_Equal && unaryRange.GetOp() != planpb.OpType_NotEqual {
+		return original
+	}
+	array := unaryRange.GetValue().GetArrayVal()
+	if array == nil || len(array.GetArray()) != 0 {
+		return original
+	}
+
+	return &planpb.Expr{
+		Expr: &planpb.Expr_BinaryArithOpEvalRangeExpr{
+			BinaryArithOpEvalRangeExpr: &planpb.BinaryArithOpEvalRangeExpr{
+				ColumnInfo: columnInfo,
+				ArithOp:    planpb.ArithOpType_ArrayLength,
+				Op:         unaryRange.GetOp(),
+				Value: &planpb.GenericValue{
+					Val: &planpb.GenericValue_Int64Val{Int64Val: 0},
+				},
+			},
+		},
+	}
+}

--- a/internal/parser/planparserv2/rewriter/array_test.go
+++ b/internal/parser/planparserv2/rewriter/array_test.go
@@ -1,0 +1,116 @@
+package rewriter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter"
+	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+)
+
+func TestRewriteEmptyArrayComparisonWhenOptimizationDisabled(t *testing.T) {
+	for _, op := range []planpb.OpType{planpb.OpType_Equal, planpb.OpType_NotEqual} {
+		t.Run(op.String(), func(t *testing.T) {
+			columnInfo := &planpb.ColumnInfo{
+				FieldId:     101,
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				Nullable:    true,
+			}
+			input := &planpb.Expr{
+				Expr: &planpb.Expr_UnaryRangeExpr{
+					UnaryRangeExpr: &planpb.UnaryRangeExpr{
+						ColumnInfo: columnInfo,
+						Op:         op,
+						Value: &planpb.GenericValue{
+							Val: &planpb.GenericValue_ArrayVal{
+								ArrayVal: &planpb.Array{SameType: true},
+							},
+						},
+					},
+				},
+			}
+
+			result := rewriter.RewriteExprWithConfig(input, false)
+			arrayLength := result.GetBinaryArithOpEvalRangeExpr()
+			require.NotNil(t, arrayLength)
+			require.Equal(t, planpb.ArithOpType_ArrayLength, arrayLength.GetArithOp())
+			require.Equal(t, op, arrayLength.GetOp())
+			require.Equal(t, int64(0), arrayLength.GetValue().GetInt64Val())
+			require.True(t, arrayLength.GetColumnInfo().GetNullable())
+		})
+	}
+}
+
+func TestRewriteEmptyArrayComparisonOnlyForWholeArrayColumns(t *testing.T) {
+	testcases := []struct {
+		name       string
+		columnInfo *planpb.ColumnInfo
+	}{
+		{
+			name: "array element",
+			columnInfo: &planpb.ColumnInfo{
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				NestedPath:  []string{"0"},
+			},
+		},
+		{
+			name: "json path",
+			columnInfo: &planpb.ColumnInfo{
+				DataType:   schemapb.DataType_JSON,
+				NestedPath: []string{"array"},
+			},
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			input := &planpb.Expr{
+				Expr: &planpb.Expr_UnaryRangeExpr{
+					UnaryRangeExpr: &planpb.UnaryRangeExpr{
+						ColumnInfo: testcase.columnInfo,
+						Op:         planpb.OpType_Equal,
+						Value: &planpb.GenericValue{
+							Val: &planpb.GenericValue_ArrayVal{ArrayVal: &planpb.Array{}},
+						},
+					},
+				},
+			}
+
+			result := rewriter.RewriteExprWithConfig(input, false)
+			require.NotNil(t, result.GetUnaryRangeExpr())
+			require.Nil(t, result.GetBinaryArithOpEvalRangeExpr())
+		})
+	}
+}
+
+func TestRewriteNonEmptyArrayComparisonUnchanged(t *testing.T) {
+	input := &planpb.Expr{
+		Expr: &planpb.Expr_UnaryRangeExpr{
+			UnaryRangeExpr: &planpb.UnaryRangeExpr{
+				ColumnInfo: &planpb.ColumnInfo{
+					DataType:    schemapb.DataType_Array,
+					ElementType: schemapb.DataType_Int64,
+				},
+				Op: planpb.OpType_Equal,
+				Value: &planpb.GenericValue{
+					Val: &planpb.GenericValue_ArrayVal{
+						ArrayVal: &planpb.Array{
+							Array: []*planpb.GenericValue{
+								{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+							},
+							SameType:    true,
+							ElementType: schemapb.DataType_Int64,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := rewriter.RewriteExprWithConfig(input, false)
+	require.NotNil(t, result.GetUnaryRangeExpr())
+	require.Nil(t, result.GetBinaryArithOpEvalRangeExpr())
+}

--- a/internal/parser/planparserv2/rewriter/array_test.go
+++ b/internal/parser/planparserv2/rewriter/array_test.go
@@ -114,3 +114,129 @@ func TestRewriteNonEmptyArrayComparisonUnchanged(t *testing.T) {
 	require.NotNil(t, result.GetUnaryRangeExpr())
 	require.Nil(t, result.GetBinaryArithOpEvalRangeExpr())
 }
+
+func TestRewriteWholeArrayMembershipToEqualityBranches(t *testing.T) {
+	for _, optimizeEnabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "optimization disabled", true: "optimization enabled"}[optimizeEnabled], func(t *testing.T) {
+			columnInfo := &planpb.ColumnInfo{
+				FieldId:     101,
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				Nullable:    true,
+			}
+			input := &planpb.Expr{
+				Expr: &planpb.Expr_TermExpr{
+					TermExpr: &planpb.TermExpr{
+						ColumnInfo: columnInfo,
+						Values: []*planpb.GenericValue{
+							newArrayLiteral(),
+							newArrayLiteral(1, 2),
+						},
+					},
+				},
+			}
+
+			result := rewriter.RewriteExprWithConfig(input, optimizeEnabled)
+			require.Nil(t, findTermExpr(result))
+
+			var emptyArrayLengths int
+			var nonEmptyEqualities int
+			walkArrayMembershipExpr(result, func(current *planpb.Expr) {
+				if arrayLength := current.GetBinaryArithOpEvalRangeExpr(); arrayLength != nil &&
+					arrayLength.GetArithOp() == planpb.ArithOpType_ArrayLength &&
+					arrayLength.GetOp() == planpb.OpType_Equal &&
+					arrayLength.GetValue().GetInt64Val() == 0 {
+					emptyArrayLengths++
+				}
+				if equality := current.GetUnaryRangeExpr(); equality != nil &&
+					equality.GetOp() == planpb.OpType_Equal &&
+					len(equality.GetValue().GetArrayVal().GetArray()) > 0 {
+					nonEmptyEqualities++
+				}
+			})
+			require.Equal(t, 1, emptyArrayLengths)
+			require.Equal(t, 1, nonEmptyEqualities)
+		})
+	}
+}
+
+func TestRewriteWholeArrayNotInKeepsOuterNot(t *testing.T) {
+	for _, optimizeEnabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "optimization disabled", true: "optimization enabled"}[optimizeEnabled], func(t *testing.T) {
+			columnInfo := &planpb.ColumnInfo{
+				FieldId:     101,
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				Nullable:    true,
+			}
+			term := &planpb.Expr{
+				Expr: &planpb.Expr_TermExpr{
+					TermExpr: &planpb.TermExpr{
+						ColumnInfo: columnInfo,
+						Values: []*planpb.GenericValue{
+							newArrayLiteral(1, 2),
+							newArrayLiteral(3, 4),
+						},
+					},
+				},
+			}
+			input := &planpb.Expr{
+				Expr: &planpb.Expr_UnaryExpr{
+					UnaryExpr: &planpb.UnaryExpr{
+						Op:    planpb.UnaryExpr_Not,
+						Child: term,
+					},
+				},
+			}
+
+			result := rewriter.RewriteExprWithConfig(input, optimizeEnabled)
+			unary := result.GetUnaryExpr()
+			require.NotNil(t, unary)
+			require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp())
+			require.NotNil(t, unary.GetChild().GetBinaryExpr())
+			require.Nil(t, findTermExpr(result))
+
+			var equalities int
+			walkArrayMembershipExpr(unary.GetChild(), func(current *planpb.Expr) {
+				if equality := current.GetUnaryRangeExpr(); equality != nil &&
+					equality.GetOp() == planpb.OpType_Equal &&
+					equality.GetValue().GetArrayVal() != nil {
+					equalities++
+				}
+			})
+			require.Equal(t, 2, equalities)
+		})
+	}
+}
+
+func newArrayLiteral(values ...int64) *planpb.GenericValue {
+	elements := make([]*planpb.GenericValue, 0, len(values))
+	for _, value := range values {
+		elements = append(elements, &planpb.GenericValue{
+			Val: &planpb.GenericValue_Int64Val{Int64Val: value},
+		})
+	}
+	return &planpb.GenericValue{
+		Val: &planpb.GenericValue_ArrayVal{
+			ArrayVal: &planpb.Array{
+				Array:       elements,
+				SameType:    true,
+				ElementType: schemapb.DataType_Int64,
+			},
+		},
+	}
+}
+
+func walkArrayMembershipExpr(expr *planpb.Expr, visit func(*planpb.Expr)) {
+	if expr == nil {
+		return
+	}
+	visit(expr)
+	if binary := expr.GetBinaryExpr(); binary != nil {
+		walkArrayMembershipExpr(binary.GetLeft(), visit)
+		walkArrayMembershipExpr(binary.GetRight(), visit)
+	}
+	if unary := expr.GetUnaryExpr(); unary != nil {
+		walkArrayMembershipExpr(unary.GetChild(), visit)
+	}
+}

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -15,6 +15,7 @@ func RewriteExprWithConfig(e *planpb.Expr, optimizeEnabled bool) *planpb.Expr {
 	if e == nil {
 		return nil
 	}
+	e = normalizeJSONTermExprs(e)
 	v := &visitor{optimizeEnabled: optimizeEnabled}
 	res := v.visitExpr(e)
 	if out, ok := res.(*planpb.Expr); ok && out != nil {

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -117,7 +117,7 @@ func (v *visitor) visitUnaryExpr(expr *planpb.UnaryExpr) interface{} {
 				}
 				// Let other bool NOT IN flow through to visitTermExpr for bool-specific optimization.
 			} else if col != nil && len(te.GetValues()) == 1 {
-				if hasMissingPathNotEqualSemantics(col, te.GetValues()...) {
+				if !canRewriteNotEqual(col, te.GetValues()[0]) {
 					return notExpr(&planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: te}})
 				}
 				// Single-value NOT IN → != (avoids SIMD setup overhead for trivial case)
@@ -150,7 +150,7 @@ func (v *visitor) visitUnaryExpr(expr *planpb.UnaryExpr) interface{} {
 		// NOT (col == val) → col != val
 		// Handles: bool NOT IN [true] → != true, bool NOT IN [false] → != false
 		if ure := child.GetUnaryRangeExpr(); ure != nil && ure.GetOp() == planpb.OpType_Equal {
-			if hasMissingPathNotEqualSemantics(ure.GetColumnInfo(), ure.GetValue()) {
+			if !canRewriteNotEqual(ure.GetColumnInfo(), ure.GetValue()) {
 				return &planpb.Expr{
 					Expr: &planpb.Expr_UnaryExpr{
 						UnaryExpr: &planpb.UnaryExpr{

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -15,6 +15,7 @@ func RewriteExprWithConfig(e *planpb.Expr, optimizeEnabled bool) *planpb.Expr {
 	if e == nil {
 		return nil
 	}
+	e = normalizeEmptyArrayComparisons(e)
 	e = normalizeJSONTermExprs(e)
 	v := &visitor{optimizeEnabled: optimizeEnabled}
 	res := v.visitExpr(e)

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -112,7 +112,7 @@ func (v *visitor) visitUnaryExpr(expr *planpb.UnaryExpr) interface{} {
 			sortTermValues(te)
 			col := te.GetColumnInfo()
 			if v.optimizeEnabled && effectiveDataType(col) == schemapb.DataType_Bool {
-				if !canFoldBoolDomainToConstant(col) && boolValuesCoverDomain(te.GetValues()) {
+				if !canFoldPredicateToBoolConstant(col) && boolValuesCoverDomain(te.GetValues()) {
 					return notExpr(&planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: te}})
 				}
 				// Let other bool NOT IN flow through to visitTermExpr for bool-specific optimization.
@@ -188,7 +188,7 @@ func (v *visitor) visitTermExpr(expr *planpb.TermExpr) interface{} {
 		values := expr.GetValues()
 		if allBoolVals(values) {
 			if boolValuesCoverDomain(values) {
-				if !canFoldBoolDomainToConstant(expr.GetColumnInfo()) {
+				if !canFoldPredicateToBoolConstant(expr.GetColumnInfo()) {
 					return &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: expr}}
 				}
 				return newAlwaysTrueExpr()

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -15,8 +15,8 @@ func RewriteExprWithConfig(e *planpb.Expr, optimizeEnabled bool) *planpb.Expr {
 	if e == nil {
 		return nil
 	}
+	e = normalizeTermExprs(e)
 	e = normalizeEmptyArrayComparisons(e)
-	e = normalizeJSONTermExprs(e)
 	v := &visitor{optimizeEnabled: optimizeEnabled}
 	res := v.visitExpr(e)
 	if out, ok := res.(*planpb.Expr); ok && out != nil {

--- a/internal/parser/planparserv2/rewriter/json_term.go
+++ b/internal/parser/planparserv2/rewriter/json_term.go
@@ -1,0 +1,146 @@
+package rewriter
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+)
+
+var jsonTermKindOrder = []string{"bool", "int64", "float", "string", "array"}
+
+// normalizeJSONTermExprs enforces the execution invariant that every JSON
+// TermExpr contains one concrete GenericValue kind.  This is correctness
+// normalization, not an optional optimization: segcore selects the executor
+// type from the first term value and therefore cannot safely consume a mixed
+// list.
+func normalizeJSONTermExprs(expr *planpb.Expr) *planpb.Expr {
+	if expr == nil {
+		return nil
+	}
+
+	switch real := expr.GetExpr().(type) {
+	case *planpb.Expr_BinaryExpr:
+		real.BinaryExpr.Left = normalizeJSONTermExprs(real.BinaryExpr.GetLeft())
+		real.BinaryExpr.Right = normalizeJSONTermExprs(real.BinaryExpr.GetRight())
+		return expr
+	case *planpb.Expr_UnaryExpr:
+		real.UnaryExpr.Child = normalizeJSONTermExprs(real.UnaryExpr.GetChild())
+		return expr
+	case *planpb.Expr_BinaryArithExpr:
+		real.BinaryArithExpr.Left = normalizeJSONTermExprs(real.BinaryArithExpr.GetLeft())
+		real.BinaryArithExpr.Right = normalizeJSONTermExprs(real.BinaryArithExpr.GetRight())
+		return expr
+	case *planpb.Expr_CallExpr:
+		for i, parameter := range real.CallExpr.GetFunctionParameters() {
+			real.CallExpr.FunctionParameters[i] = normalizeJSONTermExprs(parameter)
+		}
+		return expr
+	case *planpb.Expr_RandomSampleExpr:
+		real.RandomSampleExpr.Predicate = normalizeJSONTermExprs(real.RandomSampleExpr.GetPredicate())
+		return expr
+	case *planpb.Expr_TermExpr:
+		return normalizeJSONTermExpr(expr, real.TermExpr)
+	default:
+		return expr
+	}
+}
+
+func normalizeJSONTermExpr(original *planpb.Expr, term *planpb.TermExpr) *planpb.Expr {
+	if term == nil || term.GetColumnInfo() == nil || term.GetIsInField() ||
+		term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON || len(term.GetValues()) == 0 {
+		return original
+	}
+
+	buckets := make(map[string][]*planpb.GenericValue)
+	for _, value := range term.GetValues() {
+		kind := valueCaseWithNil(value)
+		buckets[kind] = append(buckets[kind], value)
+	}
+
+	// A homogeneous scalar JSON term is already executable. Array-valued JSON
+	// membership is lowered to equality branches because TermExpr has no array
+	// executor.
+	if len(buckets) == 1 {
+		if _, hasArrays := buckets["array"]; !hasArrays {
+			return original
+		}
+	}
+
+	parts := make([]*planpb.Expr, 0, len(buckets))
+	for _, kind := range jsonTermKindOrder {
+		values := buckets[kind]
+		if len(values) == 0 {
+			continue
+		}
+		if kind == "array" {
+			for _, value := range values {
+				parts = append(parts, newUnaryRangeExpr(
+					term.GetColumnInfo(), planpb.OpType_Equal, value))
+			}
+			continue
+		}
+		if len(values) == 1 {
+			parts = append(parts, newUnaryRangeExpr(
+				term.GetColumnInfo(), planpb.OpType_Equal, values[0]))
+		} else {
+			parts = append(parts, newTermExpr(term.GetColumnInfo(), values))
+		}
+	}
+
+	// Preserve an unexpected kind instead of dropping user values. The final
+	// planner validation/segcore guard remains responsible for rejecting kinds
+	// that cannot be executed.
+	for kind, values := range buckets {
+		known := false
+		for _, orderedKind := range jsonTermKindOrder {
+			if kind == orderedKind {
+				known = true
+				break
+			}
+		}
+		if !known && len(values) > 0 {
+			parts = append(parts, newTermExpr(term.GetColumnInfo(), values))
+		}
+	}
+
+	if len(parts) == 0 {
+		return original
+	}
+	return foldBinary(planpb.BinaryExpr_LogicalOr, parts)
+}
+
+func valueGroupKey(col *planpb.ColumnInfo, value *planpb.GenericValue) (string, bool) {
+	if col == nil || value == nil || value.GetVal() == nil {
+		return "", false
+	}
+	kind := valueCase(value)
+	if kind == "array" || kind == "other" {
+		return "", false
+	}
+	key := columnKey(col)
+	// Statically typed columns are cast before rewriting. JSON is the only
+	// column type whose predicates must remain partitioned by literal kind.
+	if col.GetDataType() == schemapb.DataType_JSON {
+		key += "|" + kind
+	}
+	return key, true
+}
+
+func termGroupKey(term *planpb.TermExpr) (string, bool) {
+	if term == nil || term.GetColumnInfo() == nil || len(term.GetValues()) == 0 {
+		return "", false
+	}
+	kind := valueCaseWithNil(term.GetValues()[0])
+	if kind == "nil" || kind == "other" || kind == "array" {
+		return "", false
+	}
+	key := columnKey(term.GetColumnInfo())
+	if term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON {
+		return key, true
+	}
+	for _, value := range term.GetValues()[1:] {
+		if valueCaseWithNil(value) != kind {
+			return "", false
+		}
+	}
+	return key + "|" + kind, true
+}

--- a/internal/parser/planparserv2/rewriter/json_term.go
+++ b/internal/parser/planparserv2/rewriter/json_term.go
@@ -109,13 +109,10 @@ func normalizeJSONTermExpr(original *planpb.Expr, term *planpb.TermExpr) *planpb
 }
 
 func valueGroupKey(col *planpb.ColumnInfo, value *planpb.GenericValue) (string, bool) {
-	if col == nil || value == nil || value.GetVal() == nil {
+	if col == nil || !canBuildTermExpr(value) {
 		return "", false
 	}
 	kind := valueCase(value)
-	if kind == "array" || kind == "other" {
-		return "", false
-	}
 	key := columnKey(col)
 	// Statically typed columns are cast before rewriting. JSON is the only
 	// column type whose predicates must remain partitioned by literal kind.
@@ -126,23 +123,13 @@ func valueGroupKey(col *planpb.ColumnInfo, value *planpb.GenericValue) (string, 
 }
 
 func termGroupKey(term *planpb.TermExpr) (string, bool) {
-	if term == nil || term.GetColumnInfo() == nil || len(term.GetValues()) == 0 {
+	if term == nil || term.GetColumnInfo() == nil || !canBuildTermExpr(term.GetValues()...) {
 		return "", false
 	}
-	kind := valueCaseWithNil(term.GetValues()[0])
-	if kind == "nil" || kind == "other" || kind == "array" {
-		return "", false
-	}
+	kind := valueCase(term.GetValues()[0])
 	key := columnKey(term.GetColumnInfo())
 	if term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON {
 		return key, true
-	}
-	// this for loop is for defensive. in practice after normalization, all values
-	// in a term should have the same kind. but we still check it here to be safe.
-	for _, value := range term.GetValues()[1:] {
-		if valueCaseWithNil(value) != kind {
-			return "", false
-		}
 	}
 	return key + "|" + kind, true
 }

--- a/internal/parser/planparserv2/rewriter/json_term.go
+++ b/internal/parser/planparserv2/rewriter/json_term.go
@@ -137,6 +137,8 @@ func termGroupKey(term *planpb.TermExpr) (string, bool) {
 	if term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON {
 		return key, true
 	}
+	// this for loop is for defensive. in practice after normalization, all values
+	// in a term should have the same kind. but we still check it here to be safe.
 	for _, value := range term.GetValues()[1:] {
 		if valueCaseWithNil(value) != kind {
 			return "", false

--- a/internal/parser/planparserv2/rewriter/json_term.go
+++ b/internal/parser/planparserv2/rewriter/json_term.go
@@ -7,46 +7,62 @@ import (
 
 var jsonTermKindOrder = []string{"bool", "int64", "float", "string", "array"}
 
-// normalizeJSONTermExprs enforces the execution invariant that every JSON
-// TermExpr contains one concrete GenericValue kind.  This is correctness
-// normalization, not an optional optimization: segcore selects the executor
-// type from the first term value and therefore cannot safely consume a mixed
-// list.
-func normalizeJSONTermExprs(expr *planpb.Expr) *planpb.Expr {
+// normalizeTermExprs enforces the execution invariant that every TermExpr can
+// be dispatched to one scalar executor. JSON terms are partitioned by concrete
+// value kind, while whole-ARRAY membership is lowered to array equality
+// branches because segcore has no array-valued TermExpr executor. This is
+// correctness normalization, not an optional optimization.
+func normalizeTermExprs(expr *planpb.Expr) *planpb.Expr {
 	if expr == nil {
 		return nil
 	}
 
 	switch real := expr.GetExpr().(type) {
 	case *planpb.Expr_BinaryExpr:
-		real.BinaryExpr.Left = normalizeJSONTermExprs(real.BinaryExpr.GetLeft())
-		real.BinaryExpr.Right = normalizeJSONTermExprs(real.BinaryExpr.GetRight())
+		real.BinaryExpr.Left = normalizeTermExprs(real.BinaryExpr.GetLeft())
+		real.BinaryExpr.Right = normalizeTermExprs(real.BinaryExpr.GetRight())
 		return expr
 	case *planpb.Expr_UnaryExpr:
-		real.UnaryExpr.Child = normalizeJSONTermExprs(real.UnaryExpr.GetChild())
+		real.UnaryExpr.Child = normalizeTermExprs(real.UnaryExpr.GetChild())
 		return expr
 	case *planpb.Expr_BinaryArithExpr:
-		real.BinaryArithExpr.Left = normalizeJSONTermExprs(real.BinaryArithExpr.GetLeft())
-		real.BinaryArithExpr.Right = normalizeJSONTermExprs(real.BinaryArithExpr.GetRight())
+		real.BinaryArithExpr.Left = normalizeTermExprs(real.BinaryArithExpr.GetLeft())
+		real.BinaryArithExpr.Right = normalizeTermExprs(real.BinaryArithExpr.GetRight())
 		return expr
 	case *planpb.Expr_CallExpr:
 		for i, parameter := range real.CallExpr.GetFunctionParameters() {
-			real.CallExpr.FunctionParameters[i] = normalizeJSONTermExprs(parameter)
+			real.CallExpr.FunctionParameters[i] = normalizeTermExprs(parameter)
 		}
 		return expr
 	case *planpb.Expr_RandomSampleExpr:
-		real.RandomSampleExpr.Predicate = normalizeJSONTermExprs(real.RandomSampleExpr.GetPredicate())
+		real.RandomSampleExpr.Predicate = normalizeTermExprs(real.RandomSampleExpr.GetPredicate())
 		return expr
 	case *planpb.Expr_TermExpr:
-		return normalizeJSONTermExpr(expr, real.TermExpr)
+		return normalizeTermExpr(expr, real.TermExpr)
 	default:
 		return expr
 	}
 }
 
-func normalizeJSONTermExpr(original *planpb.Expr, term *planpb.TermExpr) *planpb.Expr {
-	if term == nil || term.GetColumnInfo() == nil || term.GetIsInField() ||
-		term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON || len(term.GetValues()) == 0 {
+func normalizeTermExpr(original *planpb.Expr, term *planpb.TermExpr) *planpb.Expr {
+	if term == nil || term.GetColumnInfo() == nil || term.GetIsInField() || len(term.GetValues()) == 0 {
+		return original
+	}
+
+	columnInfo := term.GetColumnInfo()
+	if columnInfo.GetDataType() == schemapb.DataType_Array && len(columnInfo.GetNestedPath()) == 0 {
+		parts := make([]*planpb.Expr, 0, len(term.GetValues()))
+		for _, value := range term.GetValues() {
+			if valueCaseWithNil(value) != "array" {
+				return original
+			}
+			parts = append(parts, newUnaryRangeExpr(
+				columnInfo, planpb.OpType_Equal, value))
+		}
+		return foldBinary(planpb.BinaryExpr_LogicalOr, parts)
+	}
+
+	if columnInfo.GetDataType() != schemapb.DataType_JSON {
 		return original
 	}
 

--- a/internal/parser/planparserv2/rewriter/json_term_test.go
+++ b/internal/parser/planparserv2/rewriter/json_term_test.go
@@ -1,0 +1,223 @@
+package rewriter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	parser "github.com/milvus-io/milvus/internal/parser/planparserv2"
+	"github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter"
+	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+)
+
+func TestRewriteJSONMixedInSplitsHomogeneousTerms(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	for _, exprStr := range []string{
+		`JSONField["v"] in [1, 2, "3", "4", true, 2.5]`,
+		`JSONField["v"] in ["4", 2.5, true, "3", 2, 1]`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+
+		assertHomogeneousTerms(t, expr)
+		require.Equal(t, map[string]int{
+			"bool": 1, "int64": 2, "float": 1, "string": 2,
+		}, collectMembershipKinds(expr), exprStr)
+	}
+}
+
+func TestRewriteJSONMixedNotInNegatesSplitMembership(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] not in [1, 2, "3"]`, nil)
+	require.NoError(t, err)
+
+	unary := expr.GetUnaryExpr()
+	require.NotNil(t, unary)
+	require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp())
+	require.NotNil(t, unary.GetChild().GetBinaryExpr())
+	assertHomogeneousTerms(t, unary.GetChild())
+	require.Equal(t, map[string]int{"int64": 2, "string": 1},
+		collectMembershipKinds(unary.GetChild()))
+}
+
+func TestRewriteJSONMixedOrEqualsDoesNotRecombineTypes(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] == 1 or JSONField["v"] == "1" or JSONField["v"] == 2 or JSONField["v"] == "2"`, nil)
+	require.NoError(t, err)
+
+	assertHomogeneousTerms(t, expr)
+	require.Equal(t, map[string]int{"int64": 2, "string": 2},
+		collectMembershipKinds(expr))
+}
+
+func TestRewriteJSONCrossTypeInWithNotEqualKeepsBothPredicates(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	for _, exprStr := range []string{
+		`JSONField["v"] in [1, 2] and JSONField["v"] != "3"`,
+		`JSONField["v"] in [1, 2] or JSONField["v"] != "3"`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		require.NotNil(t, expr.GetBinaryExpr(), exprStr)
+		require.NotNil(t, findTermExpr(expr), exprStr)
+		require.NotNil(t, findUnaryRangeExpr(expr, planpb.OpType_NotEqual), exprStr)
+		assertHomogeneousTerms(t, expr)
+	}
+}
+
+func TestRewriteJSONMixedNotEqualsMergeOnlyWithinType(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] != 1 and JSONField["v"] != 2 and JSONField["v"] != "3" and JSONField["v"] != "4"`, nil)
+	require.NoError(t, err)
+
+	assertHomogeneousTerms(t, expr)
+	require.Equal(t, map[string]int{"int64": 2, "string": 2},
+		collectMembershipKinds(expr))
+}
+
+func TestRewriteJSONMixedInRunsWhenOptimizationDisabled(t *testing.T) {
+	col := &planpb.ColumnInfo{
+		FieldId:    102,
+		DataType:   schemapb.DataType_JSON,
+		NestedPath: []string{"v"},
+	}
+	input := &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: &planpb.TermExpr{
+		ColumnInfo: col,
+		Values: []*planpb.GenericValue{
+			{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+			{Val: &planpb.GenericValue_StringVal{StringVal: "1"}},
+		},
+	}}}
+
+	expr := rewriter.RewriteExprWithConfig(input, false)
+	require.NotNil(t, expr.GetBinaryExpr())
+	assertHomogeneousTerms(t, expr)
+	require.Equal(t, map[string]int{"int64": 1, "string": 1},
+		collectMembershipKinds(expr))
+}
+
+func TestRewriteJSONMixedTermInsideCallExpr(t *testing.T) {
+	col := &planpb.ColumnInfo{
+		FieldId:    102,
+		DataType:   schemapb.DataType_JSON,
+		NestedPath: []string{"v"},
+	}
+	input := &planpb.Expr{Expr: &planpb.Expr_CallExpr{CallExpr: &planpb.CallExpr{
+		FunctionName: "test",
+		FunctionParameters: []*planpb.Expr{{
+			Expr: &planpb.Expr_TermExpr{TermExpr: &planpb.TermExpr{
+				ColumnInfo: col,
+				Values: []*planpb.GenericValue{
+					{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+					{Val: &planpb.GenericValue_StringVal{StringVal: "1"}},
+				},
+			}},
+		}},
+	}}}
+
+	expr := rewriter.RewriteExprWithConfig(input, false)
+	parameter := expr.GetCallExpr().GetFunctionParameters()[0]
+	require.NotNil(t, parameter.GetBinaryExpr())
+	assertHomogeneousTerms(t, parameter)
+	require.Equal(t, map[string]int{"int64": 1, "string": 1},
+		collectMembershipKinds(parameter))
+}
+
+func TestRewriteJSONMixedNumericPreservesLargeInteger(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [9007199254740993, 1.5]`, nil)
+	require.NoError(t, err)
+
+	var integerValues []int64
+	walkExpr(expr, func(current *planpb.Expr) {
+		if term := current.GetTermExpr(); term != nil {
+			for _, value := range term.GetValues() {
+				if testValueKind(value) == "int64" {
+					integerValues = append(integerValues, value.GetInt64Val())
+				}
+			}
+		}
+		if unary := current.GetUnaryRangeExpr(); unary != nil &&
+			unary.GetOp() == planpb.OpType_Equal && testValueKind(unary.GetValue()) == "int64" {
+			integerValues = append(integerValues, unary.GetValue().GetInt64Val())
+		}
+	})
+	require.Equal(t, []int64{9007199254740993}, integerValues)
+}
+
+func TestRewriteJSONArrayInUsesEqualityBranches(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [[1, 2], [3, 4]]`, nil)
+	require.NoError(t, err)
+	require.Nil(t, findTermExpr(expr))
+	require.Equal(t, map[string]int{"array": 2}, collectMembershipKinds(expr))
+}
+
+func assertHomogeneousTerms(t *testing.T, expr *planpb.Expr) {
+	t.Helper()
+	walkExpr(expr, func(current *planpb.Expr) {
+		term := current.GetTermExpr()
+		if term == nil || len(term.GetValues()) == 0 {
+			return
+		}
+		kind := testValueKind(term.GetValues()[0])
+		for _, value := range term.GetValues()[1:] {
+			require.Equal(t, kind, testValueKind(value),
+				"TermExpr contains mixed value types")
+		}
+	})
+}
+
+func collectMembershipKinds(expr *planpb.Expr) map[string]int {
+	result := make(map[string]int)
+	walkExpr(expr, func(current *planpb.Expr) {
+		if term := current.GetTermExpr(); term != nil {
+			for _, value := range term.GetValues() {
+				result[testValueKind(value)]++
+			}
+			return
+		}
+		if unary := current.GetUnaryRangeExpr(); unary != nil &&
+			unary.GetOp() == planpb.OpType_Equal {
+			result[testValueKind(unary.GetValue())]++
+		}
+	})
+	return result
+}
+
+func walkExpr(expr *planpb.Expr, visit func(*planpb.Expr)) {
+	if expr == nil {
+		return
+	}
+	visit(expr)
+	if binary := expr.GetBinaryExpr(); binary != nil {
+		walkExpr(binary.GetLeft(), visit)
+		walkExpr(binary.GetRight(), visit)
+	}
+	if unary := expr.GetUnaryExpr(); unary != nil {
+		walkExpr(unary.GetChild(), visit)
+	}
+}
+
+func testValueKind(value *planpb.GenericValue) string {
+	switch value.GetVal().(type) {
+	case *planpb.GenericValue_BoolVal:
+		return "bool"
+	case *planpb.GenericValue_Int64Val:
+		return "int64"
+	case *planpb.GenericValue_FloatVal:
+		return "float"
+	case *planpb.GenericValue_StringVal:
+		return "string"
+	case *planpb.GenericValue_ArrayVal:
+		return "array"
+	default:
+		return "other"
+	}
+}

--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -206,7 +206,7 @@ func (v *visitor) combineAndRangePredicates(parts []*planpb.Expr) []*planpb.Expr
 				}
 			}
 
-			if isEmpty && !canFoldBoolDomainToConstant(g.col) {
+			if isEmpty && !canFoldPredicateToBoolConstant(g.col) {
 				continue
 			}
 
@@ -608,7 +608,7 @@ func (v *visitor) combineAndBinaryRanges(parts []*planpb.Expr) []*planpb.Expr {
 				}
 			}
 			if isEmpty {
-				if !canFoldBoolDomainToConstant(g.col) {
+				if !canFoldPredicateToBoolConstant(g.col) {
 					continue
 				}
 				// Empty intersection → constant false

--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -69,6 +69,9 @@ func resolveJSONEffectiveType(v *planpb.GenericValue) (schemapb.DataType, bool) 
 	case *planpb.GenericValue_Int64Val:
 		return schemapb.DataType_Double, true
 	case *planpb.GenericValue_FloatVal:
+		if math.IsNaN(v.GetFloatVal()) {
+			return schemapb.DataType_None, false
+		}
 		return schemapb.DataType_Double, true
 	case *planpb.GenericValue_StringVal:
 		return schemapb.DataType_VarChar, true
@@ -94,7 +97,9 @@ func valueMatchesType(dt schemapb.DataType, v *planpb.GenericValue) bool {
 	case schemapb.DataType_Float, schemapb.DataType_Double:
 		// For float columns, accept both float and int literal values
 		switch v.GetVal().(type) {
-		case *planpb.GenericValue_FloatVal, *planpb.GenericValue_Int64Val:
+		case *planpb.GenericValue_FloatVal:
+			return !math.IsNaN(v.GetFloatVal())
+		case *planpb.GenericValue_Int64Val:
 			return true
 		default:
 			return false
@@ -109,6 +114,27 @@ func valueMatchesType(dt schemapb.DataType, v *planpb.GenericValue) bool {
 	default:
 		return false
 	}
+}
+
+func resolveBinaryRangeEffectiveType(col *planpb.ColumnInfo, lower, upper *planpb.GenericValue) (schemapb.DataType, bool) {
+	effDt, ok := resolveEffectiveType(col)
+	if !ok {
+		return schemapb.DataType_None, false
+	}
+
+	if effDt != schemapb.DataType_JSON {
+		if !valueMatchesType(effDt, lower) || !valueMatchesType(effDt, upper) {
+			return schemapb.DataType_None, false
+		}
+		return effDt, true
+	}
+
+	lowerType, lowerOK := resolveJSONEffectiveType(lower)
+	upperType, upperOK := resolveJSONEffectiveType(upper)
+	if !lowerOK || !upperOK || lowerType != upperType {
+		return schemapb.DataType_None, false
+	}
+	return lowerType, true
 }
 
 func (v *visitor) combineAndRangePredicates(parts []*planpb.Expr) []*planpb.Expr {
@@ -385,7 +411,8 @@ func newBinaryRangeExpr(col *planpb.ColumnInfo, lowerInclusive bool, upperInclus
 // int conversion. This mirrors segcore's JSON numeric comparison semantics.
 func compareInt64ToFloat64(lhs int64, rhs float64) int {
 	if math.IsNaN(rhs) {
-		// Preserve cmpGeneric's existing deterministic handling for NaN.
+		// Range optimizer entry points reject NaN before comparison. Keep this
+		// defensive return deterministic if a future caller misses that gate.
 		return 0
 	}
 	const (
@@ -508,19 +535,10 @@ func (v *visitor) combineAndBinaryRanges(parts []*planpb.Expr) []*planpb.Expr {
 				others = append(others, idx)
 				continue
 			}
-			effDt, ok := resolveEffectiveType(col)
+			effDt, ok := resolveBinaryRangeEffectiveType(col, bre.GetLowerValue(), bre.GetUpperValue())
 			if !ok {
 				others = append(others, idx)
 				continue
-			}
-			// For JSON, determine actual type from lower value
-			if effDt == schemapb.DataType_JSON {
-				var typeOk bool
-				effDt, typeOk = resolveJSONEffectiveType(bre.GetLowerValue())
-				if !typeOk {
-					others = append(others, idx)
-					continue
-				}
 			}
 			key := columnKey(col) + fmt.Sprintf("|%d", effDt)
 			g, exists := groups[key]
@@ -731,18 +749,10 @@ func (v *visitor) combineOrBinaryRanges(parts []*planpb.Expr) []*planpb.Expr {
 				others = append(others, idx)
 				continue
 			}
-			effDt, ok := resolveEffectiveType(col)
+			effDt, ok := resolveBinaryRangeEffectiveType(col, bre.GetLowerValue(), bre.GetUpperValue())
 			if !ok {
 				others = append(others, idx)
 				continue
-			}
-			if effDt == schemapb.DataType_JSON {
-				var typeOk bool
-				effDt, typeOk = resolveJSONEffectiveType(bre.GetLowerValue())
-				if !typeOk {
-					others = append(others, idx)
-					continue
-				}
 			}
 			key := columnKey(col) + fmt.Sprintf("|%d", effDt)
 			g, exists := groups[key]

--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -2,6 +2,7 @@ package rewriter
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
@@ -57,14 +58,15 @@ func resolveEffectiveType(col *planpb.ColumnInfo) (schemapb.DataType, bool) {
 
 // resolveJSONEffectiveType returns the effective type for a JSON field based on the literal value.
 // Returns (type, ok) where ok is false if the value is not suitable for range optimization.
-// For numeric types (int and float), we normalize to Double to allow mixing, similar to scalar Float/Double columns.
+// Numeric literals share the Double comparison group so int and float bounds
+// can still be merged. cmpGeneric preserves their concrete literal kinds and
+// compares int64 against float64 without lossy promotion.
 func resolveJSONEffectiveType(v *planpb.GenericValue) (schemapb.DataType, bool) {
 	if v == nil || v.GetVal() == nil {
 		return schemapb.DataType_None, false
 	}
 	switch v.GetVal().(type) {
 	case *planpb.GenericValue_Int64Val:
-		// Normalize int to Double for JSON to allow mixing with float literals
 		return schemapb.DataType_Double, true
 	case *planpb.GenericValue_FloatVal:
 		return schemapb.DataType_Double, true
@@ -378,6 +380,43 @@ func newBinaryRangeExpr(col *planpb.ColumnInfo, lowerInclusive bool, upperInclus
 	}
 }
 
+// compareInt64ToFloat64 compares an int64 and float64 without converting the
+// integer to float64. The boundary checks also avoid an out-of-range float to
+// int conversion. This mirrors segcore's JSON numeric comparison semantics.
+func compareInt64ToFloat64(lhs int64, rhs float64) int {
+	if math.IsNaN(rhs) {
+		// Preserve cmpGeneric's existing deterministic handling for NaN.
+		return 0
+	}
+	const (
+		int64Lower = -0x1p63
+		int64Upper = 0x1p63
+	)
+	if rhs < int64Lower {
+		return 1
+	}
+	if rhs >= int64Upper {
+		return -1
+	}
+
+	rhsInteger := int64(rhs)
+	if lhs < rhsInteger {
+		return -1
+	}
+	if lhs > rhsInteger {
+		return 1
+	}
+
+	rhsIntegerAsFloat := float64(rhsInteger)
+	if rhs > rhsIntegerAsFloat {
+		return -1
+	}
+	if rhs < rhsIntegerAsFloat {
+		return 1
+	}
+	return 0
+}
+
 // -1 means a < b, 0 means a == b, 1 means a > b
 func cmpGeneric(dt schemapb.DataType, a, b *planpb.GenericValue) int {
 	switch dt {
@@ -394,25 +433,37 @@ func cmpGeneric(dt schemapb.DataType, a, b *planpb.GenericValue) int {
 		}
 		return 0
 	case schemapb.DataType_Float, schemapb.DataType_Double:
-		// Allow comparing int and float by promoting to float
-		toFloat := func(g *planpb.GenericValue) float64 {
-			switch g.GetVal().(type) {
-			case *planpb.GenericValue_FloatVal:
-				return g.GetFloatVal()
+		switch a.GetVal().(type) {
+		case *planpb.GenericValue_Int64Val:
+			switch b.GetVal().(type) {
 			case *planpb.GenericValue_Int64Val:
-				return float64(g.GetInt64Val())
-			default:
-				// Should not happen due to gate; treat as 0 deterministically
+				ai, bi := a.GetInt64Val(), b.GetInt64Val()
+				if ai < bi {
+					return -1
+				}
+				if ai > bi {
+					return 1
+				}
+				return 0
+			case *planpb.GenericValue_FloatVal:
+				return compareInt64ToFloat64(a.GetInt64Val(), b.GetFloatVal())
+			}
+		case *planpb.GenericValue_FloatVal:
+			switch b.GetVal().(type) {
+			case *planpb.GenericValue_Int64Val:
+				return -compareInt64ToFloat64(b.GetInt64Val(), a.GetFloatVal())
+			case *planpb.GenericValue_FloatVal:
+				af, bf := a.GetFloatVal(), b.GetFloatVal()
+				if af < bf {
+					return -1
+				}
+				if af > bf {
+					return 1
+				}
 				return 0
 			}
 		}
-		af, bf := toFloat(a), toFloat(b)
-		if af < bf {
-			return -1
-		}
-		if af > bf {
-			return 1
-		}
+		// Should not happen because callers gate supported literal kinds.
 		return 0
 	case schemapb.DataType_String,
 		schemapb.DataType_VarChar:

--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -406,13 +406,10 @@ func newBinaryRangeExpr(col *planpb.ColumnInfo, lowerInclusive bool, upperInclus
 	}
 }
 
-// compareInt64ToFloat64 compares an int64 and float64 without converting the
-// integer to float64. The boundary checks also avoid an out-of-range float to
-// int conversion. This mirrors segcore's JSON numeric comparison semantics.
+// compareInt64ToFloat64 compares an int64 and float64 without lossy integer
+// promotion. Callers must reject NaN before relying on the result.
 func compareInt64ToFloat64(lhs int64, rhs float64) int {
 	if math.IsNaN(rhs) {
-		// Range optimizer entry points reject NaN before comparison. Keep this
-		// defensive return deterministic if a future caller misses that gate.
 		return 0
 	}
 	const (
@@ -442,6 +439,16 @@ func compareInt64ToFloat64(lhs int64, rhs float64) int {
 		return 1
 	}
 	return 0
+}
+
+// CompareRangeValues compares two supported range literals exactly.
+func CompareRangeValues(a, b *planpb.GenericValue) (int, bool) {
+	aType, aOK := resolveJSONEffectiveType(a)
+	bType, bOK := resolveJSONEffectiveType(b)
+	if !aOK || !bOK || aType != bType {
+		return 0, false
+	}
+	return cmpGeneric(aType, a, b), true
 }
 
 // -1 means a < b, 0 means a == b, 1 means a > b

--- a/internal/parser/planparserv2/rewriter/range_edge_test.go
+++ b/internal/parser/planparserv2/rewriter/range_edge_test.go
@@ -1,0 +1,309 @@
+package rewriter_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter"
+	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
+)
+
+func edgeTestRangeColumn(dataType schemapb.DataType) *planpb.ColumnInfo {
+	column := &planpb.ColumnInfo{
+		FieldId:  101,
+		DataType: dataType,
+	}
+	if dataType == schemapb.DataType_JSON {
+		column.NestedPath = []string{"value"}
+	}
+	return column
+}
+
+func edgeTestIntValue(value int64) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_Int64Val{Int64Val: value}}
+}
+
+func edgeTestFloatValue(value float64) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_FloatVal{FloatVal: value}}
+}
+
+func edgeTestStringValue(value string) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_StringVal{StringVal: value}}
+}
+
+func edgeTestBoolValue(value bool) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_BoolVal{BoolVal: value}}
+}
+
+func edgeTestUnaryRange(column *planpb.ColumnInfo, op planpb.OpType, value *planpb.GenericValue) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_UnaryRangeExpr{
+			UnaryRangeExpr: &planpb.UnaryRangeExpr{
+				ColumnInfo: column,
+				Op:         op,
+				Value:      value,
+			},
+		},
+	}
+}
+
+func edgeTestBinaryRange(column *planpb.ColumnInfo, lower, upper *planpb.GenericValue) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_BinaryRangeExpr{
+			BinaryRangeExpr: &planpb.BinaryRangeExpr{
+				ColumnInfo:     column,
+				LowerInclusive: true,
+				UpperInclusive: true,
+				LowerValue:     lower,
+				UpperValue:     upper,
+			},
+		},
+	}
+}
+
+func edgeTestTerm(column *planpb.ColumnInfo, values ...*planpb.GenericValue) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_TermExpr{
+			TermExpr: &planpb.TermExpr{
+				ColumnInfo: column,
+				Values:     values,
+			},
+		},
+	}
+}
+
+func edgeTestLogical(op planpb.BinaryExpr_BinaryOp, left, right *planpb.Expr) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_BinaryExpr{
+			BinaryExpr: &planpb.BinaryExpr{
+				Op:    op,
+				Left:  left,
+				Right: right,
+			},
+		},
+	}
+}
+
+func edgeTestCountBinaryRanges(expr *planpb.Expr) int {
+	if expr == nil {
+		return 0
+	}
+	if expr.GetBinaryRangeExpr() != nil {
+		return 1
+	}
+	if binary := expr.GetBinaryExpr(); binary != nil {
+		return edgeTestCountBinaryRanges(binary.GetLeft()) + edgeTestCountBinaryRanges(binary.GetRight())
+	}
+	return 0
+}
+
+func edgeTestCountUnaryRanges(expr *planpb.Expr) int {
+	if expr == nil {
+		return 0
+	}
+	if expr.GetUnaryRangeExpr() != nil {
+		return 1
+	}
+	if binary := expr.GetBinaryExpr(); binary != nil {
+		return edgeTestCountUnaryRanges(binary.GetLeft()) + edgeTestCountUnaryRanges(binary.GetRight())
+	}
+	return 0
+}
+
+func TestRewrite_JSONBinaryRangeMixedBoundTypesSkipMerge(t *testing.T) {
+	logicalOps := []struct {
+		name string
+		op   planpb.BinaryExpr_BinaryOp
+	}{
+		{name: "and", op: planpb.BinaryExpr_LogicalAnd},
+		{name: "or", op: planpb.BinaryExpr_LogicalOr},
+	}
+	unsupportedUpperBounds := []struct {
+		name  string
+		value *planpb.GenericValue
+	}{
+		{name: "string", value: edgeTestStringValue("z")},
+		{name: "bool", value: edgeTestBoolValue(true)},
+	}
+
+	for _, logicalOp := range logicalOps {
+		for _, unsupportedUpper := range unsupportedUpperBounds {
+			for _, mixedFirst := range []bool{true, false} {
+				order := "numeric_first"
+				if mixedFirst {
+					order = "mixed_first"
+				}
+				t.Run(logicalOp.name+"_"+unsupportedUpper.name+"_"+order, func(t *testing.T) {
+					column := edgeTestRangeColumn(schemapb.DataType_JSON)
+					mixed := edgeTestBinaryRange(column, edgeTestIntValue(1), unsupportedUpper.value)
+					numeric := edgeTestBinaryRange(column, edgeTestIntValue(2), edgeTestIntValue(4))
+					left, right := numeric, mixed
+					if mixedFirst {
+						left, right = mixed, numeric
+					}
+
+					result := rewriter.RewriteExprWithConfig(edgeTestLogical(logicalOp.op, left, right), true)
+
+					binary := result.GetBinaryExpr()
+					require.NotNil(t, binary)
+					require.Equal(t, logicalOp.op, binary.GetOp())
+					require.Equal(t, 2, edgeTestCountBinaryRanges(result))
+				})
+			}
+		}
+	}
+}
+
+func TestRewrite_JSONBinaryRangeMixedNumericBoundsMerge(t *testing.T) {
+	t.Run("and", func(t *testing.T) {
+		column := edgeTestRangeColumn(schemapb.DataType_JSON)
+		left := edgeTestBinaryRange(column, edgeTestIntValue(1), edgeTestFloatValue(5.5))
+		right := edgeTestBinaryRange(column, edgeTestFloatValue(2.5), edgeTestIntValue(4))
+
+		result := rewriter.RewriteExprWithConfig(edgeTestLogical(planpb.BinaryExpr_LogicalAnd, left, right), true)
+
+		binaryRange := result.GetBinaryRangeExpr()
+		require.NotNil(t, binaryRange)
+		require.InDelta(t, 2.5, binaryRange.GetLowerValue().GetFloatVal(), 1e-9)
+		require.Equal(t, int64(4), binaryRange.GetUpperValue().GetInt64Val())
+	})
+
+	t.Run("or", func(t *testing.T) {
+		column := edgeTestRangeColumn(schemapb.DataType_JSON)
+		left := edgeTestBinaryRange(column, edgeTestIntValue(1), edgeTestFloatValue(3.5))
+		right := edgeTestBinaryRange(column, edgeTestFloatValue(2.5), edgeTestIntValue(5))
+
+		result := rewriter.RewriteExprWithConfig(edgeTestLogical(planpb.BinaryExpr_LogicalOr, left, right), true)
+
+		binaryRange := result.GetBinaryRangeExpr()
+		require.NotNil(t, binaryRange)
+		require.Equal(t, int64(1), binaryRange.GetLowerValue().GetInt64Val())
+		require.Equal(t, int64(5), binaryRange.GetUpperValue().GetInt64Val())
+	})
+}
+
+func TestRewrite_NaNUnaryRangeSkipsMerge(t *testing.T) {
+	columnTypes := []struct {
+		name     string
+		dataType schemapb.DataType
+	}{
+		{name: "json", dataType: schemapb.DataType_JSON},
+		{name: "double", dataType: schemapb.DataType_Double},
+	}
+	logicalOps := []struct {
+		name string
+		op   planpb.BinaryExpr_BinaryOp
+	}{
+		{name: "and", op: planpb.BinaryExpr_LogicalAnd},
+		{name: "or", op: planpb.BinaryExpr_LogicalOr},
+	}
+
+	for _, columnType := range columnTypes {
+		for _, logicalOp := range logicalOps {
+			for _, nanFirst := range []bool{true, false} {
+				order := "finite_first"
+				if nanFirst {
+					order = "nan_first"
+				}
+				t.Run(columnType.name+"_"+logicalOp.name+"_"+order, func(t *testing.T) {
+					column := edgeTestRangeColumn(columnType.dataType)
+					nanRange := edgeTestUnaryRange(column, planpb.OpType_GreaterEqual, edgeTestFloatValue(math.NaN()))
+					finiteRange := edgeTestUnaryRange(column, planpb.OpType_GreaterEqual, edgeTestFloatValue(1))
+					left, right := finiteRange, nanRange
+					if nanFirst {
+						left, right = nanRange, finiteRange
+					}
+
+					result := rewriter.RewriteExprWithConfig(edgeTestLogical(logicalOp.op, left, right), true)
+
+					binary := result.GetBinaryExpr()
+					require.NotNil(t, binary)
+					require.Equal(t, logicalOp.op, binary.GetOp())
+					require.Equal(t, 2, edgeTestCountUnaryRanges(result))
+				})
+			}
+		}
+	}
+}
+
+func TestRewrite_NaNBinaryRangeSkipsMerge(t *testing.T) {
+	columnTypes := []struct {
+		name     string
+		dataType schemapb.DataType
+	}{
+		{name: "json", dataType: schemapb.DataType_JSON},
+		{name: "double", dataType: schemapb.DataType_Double},
+	}
+	logicalOps := []struct {
+		name string
+		op   planpb.BinaryExpr_BinaryOp
+	}{
+		{name: "and", op: planpb.BinaryExpr_LogicalAnd},
+		{name: "or", op: planpb.BinaryExpr_LogicalOr},
+	}
+
+	for _, columnType := range columnTypes {
+		for _, logicalOp := range logicalOps {
+			for _, nanFirst := range []bool{true, false} {
+				order := "finite_first"
+				if nanFirst {
+					order = "nan_first"
+				}
+				t.Run(columnType.name+"_"+logicalOp.name+"_"+order, func(t *testing.T) {
+					column := edgeTestRangeColumn(columnType.dataType)
+					nanRange := edgeTestBinaryRange(column, edgeTestFloatValue(1), edgeTestFloatValue(math.NaN()))
+					finiteRange := edgeTestBinaryRange(column, edgeTestFloatValue(2), edgeTestFloatValue(4))
+					left, right := finiteRange, nanRange
+					if nanFirst {
+						left, right = nanRange, finiteRange
+					}
+
+					result := rewriter.RewriteExprWithConfig(edgeTestLogical(logicalOp.op, left, right), true)
+
+					binary := result.GetBinaryExpr()
+					require.NotNil(t, binary)
+					require.Equal(t, logicalOp.op, binary.GetOp())
+					require.Equal(t, 2, edgeTestCountBinaryRanges(result))
+				})
+			}
+		}
+	}
+}
+
+func TestRewrite_NaNInWithRangeSkipsOptimization(t *testing.T) {
+	testcases := []struct {
+		name      string
+		dataType  schemapb.DataType
+		nanInTerm bool
+	}{
+		{name: "json_range", dataType: schemapb.DataType_JSON},
+		{name: "json_term", dataType: schemapb.DataType_JSON, nanInTerm: true},
+		{name: "double_range", dataType: schemapb.DataType_Double},
+		{name: "double_term", dataType: schemapb.DataType_Double, nanInTerm: true},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			column := edgeTestRangeColumn(testcase.dataType)
+			termValues := []*planpb.GenericValue{edgeTestFloatValue(1), edgeTestFloatValue(2)}
+			rangeValue := edgeTestFloatValue(math.NaN())
+			if testcase.nanInTerm {
+				termValues[0] = edgeTestFloatValue(math.NaN())
+				rangeValue = edgeTestFloatValue(1)
+			}
+			term := edgeTestTerm(column, termValues...)
+			rangeExpr := edgeTestUnaryRange(column, planpb.OpType_GreaterEqual, rangeValue)
+
+			result := rewriter.RewriteExprWithConfig(edgeTestLogical(planpb.BinaryExpr_LogicalAnd, term, rangeExpr), true)
+
+			binary := result.GetBinaryExpr()
+			require.NotNil(t, binary)
+			require.Equal(t, planpb.BinaryExpr_LogicalAnd, binary.GetOp())
+			require.NotNil(t, findTermExpr(result))
+			require.NotNil(t, findUnaryRangeExpr(result, planpb.OpType_GreaterEqual))
+		})
+	}
+}

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -86,7 +86,7 @@ func TestRewrite_JSON_NestedPath_NonNullable_ContradictionsKeepPredicate(t *test
 	}
 }
 
-func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteBlocked(t *testing.T) {
+func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 
 	for _, exprStr := range []string{
@@ -96,9 +96,9 @@ func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteBlocked(t *testing.T) {
 		expr, err := parser.ParseExpr(helper, exprStr, nil)
 		require.NoError(t, err, exprStr)
 		require.NotNil(t, expr, exprStr)
-		unary := expr.GetUnaryExpr()
-		require.NotNil(t, unary, "scalar JSON missing-path NOT must remain explicit: %s", exprStr)
-		require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp(), exprStr)
+		unaryRange := expr.GetUnaryRangeExpr()
+		require.NotNil(t, unaryRange, "scalar JSON NOT equality should become !=: %s", exprStr)
+		require.Equal(t, planpb.OpType_NotEqual, unaryRange.GetOp(), exprStr)
 	}
 }
 

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -86,6 +86,25 @@ func TestRewrite_JSON_NestedPath_NonNullable_ContradictionsKeepPredicate(t *test
 	}
 }
 
+func TestRewrite_JSON_RootValue_DynamicTypeKeepsThreeValuedPredicates(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	for _, exprStr := range []string{
+		`JSONField in [1, 2] or JSONField != 1`,
+		`JSONField in [1, 2] and JSONField == 3`,
+		`JSONField > 100 and JSONField < 50`,
+		`not (JSONField > 100 and JSONField < 50)`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		require.NotNil(t, expr, exprStr)
+		require.False(t, rewriter.IsAlwaysFalseExpr(expr),
+			"JSON type mismatch can be UNKNOWN, so the predicate must not fold to false: %s", exprStr)
+		require.False(t, rewriter.IsAlwaysTrueExpr(expr),
+			"JSON type mismatch can be UNKNOWN, so the predicate must not fold to true: %s", exprStr)
+	}
+}
+
 func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -105,6 +105,44 @@ func TestRewrite_JSON_RootValue_DynamicTypeKeepsThreeValuedPredicates(t *testing
 	}
 }
 
+func TestRewrite_JSON_InWithRangeUsesLiteralType(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [1, 2, 3] and JSONField["v"] >= 2`, nil)
+	require.NoError(t, err)
+	term := expr.GetTermExpr()
+	require.NotNil(t, term)
+	require.Len(t, term.GetValues(), 2)
+	require.Equal(t, []int64{2, 3}, []int64{
+		term.GetValues()[0].GetInt64Val(),
+		term.GetValues()[1].GetInt64Val(),
+	})
+}
+
+func TestRewrite_JSON_InWithRangePreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [9007199254740992, 9007199254740993] and JSONField["v"] >= 9007199254740993`, nil)
+	require.NoError(t, err)
+	term := expr.GetTermExpr()
+	require.NotNil(t, term)
+	require.Len(t, term.GetValues(), 1)
+	require.Equal(t, int64(9007199254740993), term.GetValues()[0].GetInt64Val())
+}
+
+func TestRewrite_JSON_InWithRangeTypeMismatchSkipsOptimization(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	expr, err := parser.ParseExpr(helper,
+		`JSONField["v"] in [1, 2] and JSONField["v"] >= "2"`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr.GetBinaryExpr())
+	require.NotNil(t, findTermExpr(expr))
+	require.NotNil(t, findUnaryRangeExpr(expr, planpb.OpType_GreaterEqual))
+}
+
 func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -159,7 +159,7 @@ func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
 	}
 }
 
-func TestRewrite_JSON_NestedPath_ArrayNotEqualRewriteBlocked(t *testing.T) {
+func TestRewrite_JSON_NestedPath_ArrayNotEqualRewriteAllowed(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 
 	for _, exprStr := range []string{
@@ -169,9 +169,9 @@ func TestRewrite_JSON_NestedPath_ArrayNotEqualRewriteBlocked(t *testing.T) {
 		expr, err := parser.ParseExpr(helper, exprStr, nil)
 		require.NoError(t, err, exprStr)
 		require.NotNil(t, expr, exprStr)
-		unary := expr.GetUnaryExpr()
-		require.NotNil(t, unary, "array-valued JSON missing-path NOT must remain explicit: %s", exprStr)
-		require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp(), exprStr)
+		unaryRange := expr.GetUnaryRangeExpr()
+		require.NotNil(t, unaryRange, "array-valued JSON NOT equality should become !=: %s", exprStr)
+		require.Equal(t, planpb.OpType_NotEqual, unaryRange.GetOp(), exprStr)
 	}
 }
 
@@ -197,6 +197,65 @@ func TestRewrite_JSON_Int_AND_Strengthen(t *testing.T) {
 	// Verify column info
 	require.Equal(t, schemapb.DataType_JSON, ure.GetColumnInfo().GetDataType())
 	require.Equal(t, []string{"price"}, ure.GetColumnInfo().GetNestedPath())
+}
+
+func TestRewrite_JSON_IntRangePreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	for _, exprStr := range []string{
+		`JSONField["v"] >= 9007199254740992 and JSONField["v"] >= 9007199254740993`,
+		`JSONField["v"] >= 9007199254740993 and JSONField["v"] >= 9007199254740992`,
+		`JSONField["v"] >= 9007199254740992.0 and JSONField["v"] >= 9007199254740993`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		unaryRange := expr.GetUnaryRangeExpr()
+		require.NotNil(t, unaryRange, exprStr)
+		require.Equal(t, planpb.OpType_GreaterEqual, unaryRange.GetOp(), exprStr)
+		require.Equal(t, int64(9007199254740993), unaryRange.GetValue().GetInt64Val(), exprStr)
+	}
+}
+
+func TestRewrite_JSON_IntOrRangePreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	for _, exprStr := range []string{
+		`JSONField["v"] >= 9007199254740993 or JSONField["v"] >= 9007199254740992`,
+		`JSONField["v"] >= 9007199254740992 or JSONField["v"] >= 9007199254740993`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		unaryRange := expr.GetUnaryRangeExpr()
+		require.NotNil(t, unaryRange, exprStr)
+		require.Equal(t, planpb.OpType_GreaterEqual, unaryRange.GetOp(), exprStr)
+		require.Equal(t, int64(9007199254740992), unaryRange.GetValue().GetInt64Val(), exprStr)
+	}
+}
+
+func TestRewrite_JSON_AndBinaryRangesPreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`(JSONField["v"] >= 9007199254740992 and JSONField["v"] <= 9007199254740996) and `+
+			`(JSONField["v"] >= 9007199254740993 and JSONField["v"] <= 9007199254740995)`, nil)
+	require.NoError(t, err)
+
+	binaryRange := expr.GetBinaryRangeExpr()
+	require.NotNil(t, binaryRange)
+	require.Equal(t, int64(9007199254740993), binaryRange.GetLowerValue().GetInt64Val())
+	require.Equal(t, int64(9007199254740995), binaryRange.GetUpperValue().GetInt64Val())
+}
+
+func TestRewrite_JSON_OrBinaryRangesPreservesLargeInt64Precision(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+	expr, err := parser.ParseExpr(helper,
+		`(JSONField["v"] >= 9007199254740993 and JSONField["v"] <= 9007199254740995) or `+
+			`(JSONField["v"] >= 9007199254740992 and JSONField["v"] <= 9007199254740996)`, nil)
+	require.NoError(t, err)
+
+	binaryRange := expr.GetBinaryRangeExpr()
+	require.NotNil(t, binaryRange)
+	require.Equal(t, int64(9007199254740992), binaryRange.GetLowerValue().GetInt64Val())
+	require.Equal(t, int64(9007199254740996), binaryRange.GetUpperValue().GetInt64Val())
 }
 
 // Test JSON field with int comparison - AND to BinaryRange

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -1,6 +1,8 @@
 package rewriter
 
 import (
+	"math"
+
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
 )
@@ -337,6 +339,9 @@ func resolveInRangeComparisonType(col *planpb.ColumnInfo, value *planpb.GenericV
 	case "int64":
 		return schemapb.DataType_Int64, true
 	case "float":
+		if math.IsNaN(value.GetFloatVal()) {
+			return schemapb.DataType_None, false
+		}
 		return schemapb.DataType_Double, true
 	case "string":
 		return schemapb.DataType_VarChar, true

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -9,7 +9,6 @@ func (v *visitor) combineOrEqualsToIn(parts []*planpb.Expr) []*planpb.Expr {
 		col         *planpb.ColumnInfo
 		values      []*planpb.GenericValue
 		origIndices []int
-		valCase     string
 	}
 	others := make([]*planpb.Expr, 0, len(parts))
 	groups := make(map[string]*group)
@@ -25,16 +24,15 @@ func (v *visitor) combineOrEqualsToIn(parts []*planpb.Expr) []*planpb.Expr {
 			others = append(others, e)
 			continue
 		}
-		key := columnKey(col)
-		g, ok := groups[key]
-		valCase := valueCase(u.GetValue())
+		key, ok := valueGroupKey(col, u.GetValue())
 		if !ok {
-			g = &group{col: col, values: []*planpb.GenericValue{}, origIndices: []int{}, valCase: valCase}
-			groups[key] = g
-		}
-		if g.valCase != valCase {
 			others = append(others, e)
 			continue
+		}
+		g, ok := groups[key]
+		if !ok {
+			g = &group{col: col, values: []*planpb.GenericValue{}, origIndices: []int{}}
+			groups[key] = g
 		}
 		g.values = append(g.values, u.GetValue())
 		g.origIndices = append(g.origIndices, idx)
@@ -59,7 +57,6 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 		col         *planpb.ColumnInfo
 		values      []*planpb.GenericValue
 		origIndices []int
-		valCase     string
 	}
 	others := make([]*planpb.Expr, 0, len(parts))
 	groups := make(map[string]*group)
@@ -75,16 +72,15 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 			others = append(others, e)
 			continue
 		}
-		key := columnKey(col)
-		g, ok := groups[key]
-		valCase := valueCase(u.GetValue())
+		key, ok := valueGroupKey(col, u.GetValue())
 		if !ok {
-			g = &group{col: col, values: []*planpb.GenericValue{}, origIndices: []int{}, valCase: valCase}
-			groups[key] = g
-		}
-		if g.valCase != valCase {
 			others = append(others, e)
 			continue
+		}
+		g, ok := groups[key]
+		if !ok {
+			g = &group{col: col, values: []*planpb.GenericValue{}, origIndices: []int{}}
+			groups[key] = g
 		}
 		g.values = append(g.values, u.GetValue())
 		g.origIndices = append(g.origIndices, idx)
@@ -135,7 +131,11 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: te.GetColumnInfo()}
@@ -146,7 +146,11 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && ue.GetOp() == planpb.OpType_Equal && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: ue.GetColumnInfo()}
@@ -246,7 +250,11 @@ func (v *visitor) combineOrInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: te.GetColumnInfo()}
@@ -257,7 +265,11 @@ func (v *visitor) combineOrInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && ue.GetOp() == planpb.OpType_Equal && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: ue.GetColumnInfo()}
@@ -316,7 +328,11 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 	}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: te.GetColumnInfo()}
@@ -327,7 +343,11 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && isRange(ue.GetOp()) && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: ue.GetColumnInfo()}
@@ -413,7 +433,11 @@ func (v *visitor) combineOrInWithIn(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: te.GetColumnInfo()}
@@ -464,7 +488,11 @@ func (v *visitor) combineAndInWithIn(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &agg{col: te.GetColumnInfo()}
@@ -541,7 +569,11 @@ func (v *visitor) combineAndInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr 
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: te.GetColumnInfo()}
@@ -552,7 +584,11 @@ func (v *visitor) combineAndInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr 
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && ue.GetOp() == planpb.OpType_NotEqual && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: ue.GetColumnInfo()}
@@ -621,7 +657,11 @@ func (v *visitor) combineOrInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr {
 	others := []int{}
 	for idx, e := range parts {
 		if te := e.GetTermExpr(); te != nil {
-			k := columnKey(te.GetColumnInfo())
+			k, ok := termGroupKey(te)
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: te.GetColumnInfo()}
@@ -632,7 +672,11 @@ func (v *visitor) combineOrInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr {
 			continue
 		}
 		if ue := e.GetUnaryRangeExpr(); ue != nil && ue.GetOp() == planpb.OpType_NotEqual && ue.GetValue() != nil && ue.GetColumnInfo() != nil {
-			k := columnKey(ue.GetColumnInfo())
+			k, ok := valueGroupKey(ue.GetColumnInfo(), ue.GetValue())
+			if !ok {
+				others = append(others, idx)
+				continue
+			}
 			g := groups[k]
 			if g == nil {
 				g = &group{col: ue.GetColumnInfo()}

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -1,6 +1,7 @@
 package rewriter
 
 import (
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
 )
 
@@ -309,17 +310,43 @@ func (v *visitor) combineOrInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 	return out
 }
 
+func resolveInRangeComparisonType(col *planpb.ColumnInfo, value *planpb.GenericValue) (schemapb.DataType, bool) {
+	dt := effectiveDataType(col)
+	if dt != schemapb.DataType_JSON {
+		if !isSupportedScalarForRange(dt) || !valueMatchesType(dt, value) {
+			return schemapb.DataType_None, false
+		}
+		return dt, true
+	}
+
+	// JSON is dynamically typed. Use the literal's exact kind instead of the
+	// schema-level JSON type so cmpGeneric never treats an unsupported type as
+	// equal. Keep int and float separate here to avoid losing int64 precision.
+	switch valueCaseWithNil(value) {
+	case "int64":
+		return schemapb.DataType_Int64, true
+	case "float":
+		return schemapb.DataType_Double, true
+	case "string":
+		return schemapb.DataType_VarChar, true
+	default:
+		return schemapb.DataType_None, false
+	}
+}
+
 // AND: (a IN S) AND (range) -> filter S by range
 func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 	type group struct {
-		col       *planpb.ColumnInfo
-		termIdx   int
-		term      *planpb.TermExpr
-		lower     *planpb.GenericValue
-		lowerInc  bool
-		upper     *planpb.GenericValue
-		upperInc  bool
-		rangeIdxs []int
+		col            *planpb.ColumnInfo
+		comparisonType schemapb.DataType
+		comparable     bool
+		termIdx        int
+		term           *planpb.TermExpr
+		lower          *planpb.GenericValue
+		lowerInc       bool
+		upper          *planpb.GenericValue
+		upperInc       bool
+		rangeIdxs      []int
 	}
 	groups := map[string]*group{}
 	others := []int{}
@@ -333,10 +360,24 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 				others = append(others, idx)
 				continue
 			}
+			comparisonType, comparable := resolveInRangeComparisonType(te.GetColumnInfo(), te.GetValues()[0])
+			for _, value := range te.GetValues()[1:] {
+				valueType, ok := resolveInRangeComparisonType(te.GetColumnInfo(), value)
+				if !ok || valueType != comparisonType {
+					comparable = false
+					break
+				}
+			}
 			g := groups[k]
 			if g == nil {
-				g = &group{col: te.GetColumnInfo()}
+				g = &group{
+					col:            te.GetColumnInfo(),
+					comparisonType: comparisonType,
+					comparable:     comparable,
+				}
 				groups[k] = g
+			} else if !comparable || g.comparisonType != comparisonType {
+				g.comparable = false
 			}
 			g.term = te
 			g.termIdx = idx
@@ -348,18 +389,25 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 				others = append(others, idx)
 				continue
 			}
+			comparisonType, comparable := resolveInRangeComparisonType(ue.GetColumnInfo(), ue.GetValue())
 			g := groups[k]
 			if g == nil {
-				g = &group{col: ue.GetColumnInfo()}
+				g = &group{
+					col:            ue.GetColumnInfo(),
+					comparisonType: comparisonType,
+					comparable:     comparable,
+				}
 				groups[k] = g
+			} else if !comparable || g.comparisonType != comparisonType {
+				g.comparable = false
 			}
-			if ue.GetOp() == planpb.OpType_GreaterThan || ue.GetOp() == planpb.OpType_GreaterEqual {
-				if g.lower == nil || cmpGeneric(effectiveDataType(g.col), ue.GetValue(), g.lower) > 0 || (cmpGeneric(effectiveDataType(g.col), ue.GetValue(), g.lower) == 0 && ue.GetOp() == planpb.OpType_GreaterThan && g.lowerInc) {
+			if g.comparable && (ue.GetOp() == planpb.OpType_GreaterThan || ue.GetOp() == planpb.OpType_GreaterEqual) {
+				if g.lower == nil || cmpGeneric(g.comparisonType, ue.GetValue(), g.lower) > 0 || (cmpGeneric(g.comparisonType, ue.GetValue(), g.lower) == 0 && ue.GetOp() == planpb.OpType_GreaterThan && g.lowerInc) {
 					g.lower = ue.GetValue()
 					g.lowerInc = ue.GetOp() == planpb.OpType_GreaterEqual
 				}
-			} else {
-				if g.upper == nil || cmpGeneric(effectiveDataType(g.col), ue.GetValue(), g.upper) < 0 || (cmpGeneric(effectiveDataType(g.col), ue.GetValue(), g.upper) == 0 && ue.GetOp() == planpb.OpType_LessThan && g.upperInc) {
+			} else if g.comparable {
+				if g.upper == nil || cmpGeneric(g.comparisonType, ue.GetValue(), g.upper) < 0 || (cmpGeneric(g.comparisonType, ue.GetValue(), g.upper) == 0 && ue.GetOp() == planpb.OpType_LessThan && g.upperInc) {
 					g.upper = ue.GetValue()
 					g.upperInc = ue.GetOp() == planpb.OpType_LessEqual
 				}
@@ -376,30 +424,11 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 		used[idx] = true
 	}
 	for _, g := range groups {
-		if g.term == nil || (g.lower == nil && g.upper == nil) {
+		if !g.comparable || g.term == nil || (g.lower == nil && g.upper == nil) {
 			continue
 		}
-		// Skip optimization if any term value is not comparable with the provided bounds
 		termVals := g.term.GetValues()
-		comparable := true
-		for _, tv := range termVals {
-			if g.lower != nil {
-				if !areComparableCases(valueCaseWithNil(tv), valueCaseWithNil(g.lower)) && (!isNumericCase(valueCaseWithNil(tv)) || !isNumericCase(valueCaseWithNil(g.lower))) {
-					comparable = false
-					break
-				}
-			}
-			if comparable && g.upper != nil {
-				if !areComparableCases(valueCaseWithNil(tv), valueCaseWithNil(g.upper)) && (!isNumericCase(valueCaseWithNil(tv)) || !isNumericCase(valueCaseWithNil(g.upper))) {
-					comparable = false
-					break
-				}
-			}
-		}
-		if !comparable {
-			continue
-		}
-		filtered := filterValuesByRange(effectiveDataType(g.col), termVals, g.lower, g.lowerInc, g.upper, g.upperInc)
+		filtered := filterValuesByRange(g.comparisonType, termVals, g.lower, g.lowerInc, g.upper, g.upperInc)
 		if len(filtered) == 0 && !canFoldBoolDomainToConstant(g.col) {
 			continue
 		}

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -90,7 +90,18 @@ func (v *visitor) combineAndNotEqualsToNotIn(parts []*planpb.Expr) []*planpb.Exp
 	out = append(out, others...)
 	for _, g := range groups {
 		if len(g.values) >= 2 {
-			if hasMissingPathNotEqualSemantics(g.col, g.values...) {
+			// This rewrite requires both an executable TermExpr and strict
+			// != == NOT(==) semantics for every predicate under three-valued logic.
+			canRewrite := canBuildTermExpr(g.values...)
+			if canRewrite {
+				for _, value := range g.values {
+					if !canRewriteNotEqual(g.col, value) {
+						canRewrite = false
+						break
+					}
+				}
+			}
+			if !canRewrite {
 				for _, i := range g.origIndices {
 					out = append(out, indexToExpr[i])
 				}

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -190,7 +190,7 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 		}
 		// If multiple different equals present, AND implies contradiction unless identical.
 		if len(eqUnique) > 1 {
-			if !canFoldBoolDomainToConstant(g.col) {
+			if !canFoldPredicateToBoolConstant(g.col) {
 				continue
 			}
 			for _, ti := range g.termIdxs {
@@ -212,7 +212,7 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 				break
 			}
 		}
-		if !inSet && !canFoldBoolDomainToConstant(g.col) {
+		if !inSet && !canFoldPredicateToBoolConstant(g.col) {
 			continue
 		}
 		for _, ti := range g.termIdxs {
@@ -429,7 +429,7 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 		}
 		termVals := g.term.GetValues()
 		filtered := filterValuesByRange(g.comparisonType, termVals, g.lower, g.lowerInc, g.upper, g.upperInc)
-		if len(filtered) == 0 && !canFoldBoolDomainToConstant(g.col) {
+		if len(filtered) == 0 && !canFoldPredicateToBoolConstant(g.col) {
 			continue
 		}
 		used[g.termIdx] = true
@@ -565,7 +565,7 @@ func (v *visitor) combineAndInWithIn(parts []*planpb.Expr) []*planpb.Expr {
 				inter = append(inter, v)
 			}
 		}
-		if len(inter) == 0 && !canFoldBoolDomainToConstant(g.col) {
+		if len(inter) == 0 && !canFoldPredicateToBoolConstant(g.col) {
 			continue
 		}
 		for _, i := range g.idxs {
@@ -652,7 +652,7 @@ func (v *visitor) combineAndInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr 
 				filtered = append(filtered, tv)
 			}
 		}
-		if len(filtered) == 0 && !canFoldBoolDomainToConstant(g.col) {
+		if len(filtered) == 0 && !canFoldPredicateToBoolConstant(g.col) {
 			continue
 		}
 		used[g.termIdx] = true
@@ -741,7 +741,7 @@ func (v *visitor) combineOrInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr {
 			}
 		}
 		if containsAny {
-			if !canFoldBoolDomainToConstant(g.col) {
+			if !canFoldPredicateToBoolConstant(g.col) {
 				continue
 			}
 			used[g.termIdx] = true

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -213,7 +213,8 @@ func hasMissingPathSemantics(col *planpb.ColumnInfo) bool {
 }
 
 func canFoldBoolDomainToConstant(col *planpb.ColumnInfo) bool {
-	return !hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
+	return col != nil && col.GetDataType() != schemapb.DataType_JSON &&
+		!hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
 }
 
 func hasMissingPathNotEqualSemantics(col *planpb.ColumnInfo, values ...*planpb.GenericValue) bool {

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -210,17 +210,42 @@ func canFoldPredicateToBoolConstant(col *planpb.ColumnInfo) bool {
 		!hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
 }
 
-func hasMissingPathNotEqualSemantics(col *planpb.ColumnInfo, values ...*planpb.GenericValue) bool {
-	if col != nil && col.GetDataType() == schemapb.DataType_JSON {
-		for _, value := range values {
-			switch valueCaseWithNil(value) {
-			case "array", "nil", "other":
-				return true
-			}
-		}
+// canRewriteNotEqual reports whether NOT(col == value) can be rewritten as
+// col != value without changing UNKNOWN results. JSON scalar and array
+// comparisons preserve missing paths, nulls, and type mismatches as UNKNOWN.
+// Keep the existing conservative behavior for non-JSON nested access.
+func canRewriteNotEqual(col *planpb.ColumnInfo, value *planpb.GenericValue) bool {
+	if col == nil {
 		return false
 	}
-	return hasMissingPathSemantics(col)
+	switch valueCaseWithNil(value) {
+	case "nil", "other":
+		return false
+	}
+	if col.GetDataType() == schemapb.DataType_JSON {
+		return true
+	}
+	return !hasMissingPathSemantics(col)
+}
+
+// canBuildTermExpr reports whether values can be represented by one segcore
+// TermExpr. TermExpr selects one scalar executor for the entire value list, so
+// the values must be concrete, homogeneous scalars; array-valued literals are
+// lowered to equality expressions instead.
+func canBuildTermExpr(values ...*planpb.GenericValue) bool {
+	if len(values) == 0 {
+		return false
+	}
+	kind := valueCaseWithNil(values[0])
+	if kind == "nil" || kind == "other" || kind == "array" {
+		return false
+	}
+	for _, value := range values[1:] {
+		if valueCaseWithNil(value) != kind {
+			return false
+		}
+	}
+	return true
 }
 
 func newAlwaysFalseExpr() *planpb.Expr {

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -217,6 +217,15 @@ func canFoldBoolDomainToConstant(col *planpb.ColumnInfo) bool {
 }
 
 func hasMissingPathNotEqualSemantics(col *planpb.ColumnInfo, values ...*planpb.GenericValue) bool {
+	if col != nil && col.GetDataType() == schemapb.DataType_JSON {
+		for _, value := range values {
+			switch valueCaseWithNil(value) {
+			case "array", "nil", "other":
+				return true
+			}
+		}
+		return false
+	}
 	return hasMissingPathSemantics(col)
 }
 

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -15,17 +15,9 @@ import (
 
 func columnKey(c *planpb.ColumnInfo) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%d|%d|%d|%t|%t|%t|%t|",
-		c.GetFieldId(),
-		int32(c.GetDataType()),
-		int32(c.GetElementType()),
-		c.GetIsPrimaryKey(),
-		c.GetIsAutoID(),
-		c.GetIsPartitionKey(),
-		c.GetNullable())
+	fmt.Fprintf(&b, "%d|%d|", c.GetFieldId(), len(c.GetNestedPath()))
 	for _, p := range c.GetNestedPath() {
-		b.WriteString(p)
-		b.WriteByte('|')
+		fmt.Fprintf(&b, "%d:%s|", len(p), p)
 	}
 	return b.String()
 }
@@ -212,7 +204,8 @@ func hasMissingPathSemantics(col *planpb.ColumnInfo) bool {
 	return col != nil && len(col.GetNestedPath()) > 0
 }
 
-func canFoldBoolDomainToConstant(col *planpb.ColumnInfo) bool {
+// only non-nullable fields that don't need the true/false/null semantics can be folded to a bool constant.
+func canFoldPredicateToBoolConstant(col *planpb.ColumnInfo) bool {
 	return col != nil && col.GetDataType() != schemapb.DataType_JSON &&
 		!hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
 }
@@ -318,10 +311,4 @@ func filterValuesByRange(dt schemapb.DataType, values []*planpb.GenericValue, lo
 		}
 	}
 	return out
-}
-
-func unionValues(valuesA, valuesB []*planpb.GenericValue) []*planpb.GenericValue {
-	all := append([]*planpb.GenericValue{}, valuesA...)
-	all = append(all, valuesB...)
-	return sortGenericValues(all)
 }

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -2,6 +2,7 @@ package planparserv2
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -699,6 +700,112 @@ func castRangeValue(dataType schemapb.DataType, value *planpb.GenericValue) (*pl
 		}
 	}
 	return value, nil
+}
+
+// compareInt64ToFloat64 compares an int64 and a float64 without converting the
+// integer to float64. It returns whether the values are comparable separately
+// so NaN can be left to execution-time predicate semantics.
+func compareInt64ToFloat64(lhs int64, rhs float64) (int, bool) {
+	if math.IsNaN(rhs) {
+		return 0, false
+	}
+
+	const (
+		int64Lower = -0x1p63
+		int64Upper = 0x1p63
+	)
+	if rhs < int64Lower {
+		return 1, true
+	}
+	if rhs >= int64Upper {
+		return -1, true
+	}
+
+	rhsInteger := int64(rhs)
+	if lhs < rhsInteger {
+		return -1, true
+	}
+	if lhs > rhsInteger {
+		return 1, true
+	}
+
+	rhsIntegerAsFloat := float64(rhsInteger)
+	if rhs > rhsIntegerAsFloat {
+		return -1, true
+	}
+	if rhs < rhsIntegerAsFloat {
+		return 1, true
+	}
+	return 0, true
+}
+
+// compareBinaryRangeBounds returns the exact ordering of supported range
+// bounds. Different JSON dynamic types and unsupported literal kinds are not
+// ordered here; segcore applies their runtime type/missing/null semantics.
+func compareBinaryRangeBounds(lower, upper *planpb.GenericValue) (int, bool) {
+	if lower == nil || upper == nil {
+		return 0, false
+	}
+
+	switch lower.GetVal().(type) {
+	case *planpb.GenericValue_Int64Val:
+		switch upper.GetVal().(type) {
+		case *planpb.GenericValue_Int64Val:
+			if lower.GetInt64Val() < upper.GetInt64Val() {
+				return -1, true
+			}
+			if lower.GetInt64Val() > upper.GetInt64Val() {
+				return 1, true
+			}
+			return 0, true
+		case *planpb.GenericValue_FloatVal:
+			return compareInt64ToFloat64(lower.GetInt64Val(), upper.GetFloatVal())
+		}
+	case *planpb.GenericValue_FloatVal:
+		if math.IsNaN(lower.GetFloatVal()) {
+			return 0, false
+		}
+		switch upper.GetVal().(type) {
+		case *planpb.GenericValue_Int64Val:
+			cmp, comparable := compareInt64ToFloat64(upper.GetInt64Val(), lower.GetFloatVal())
+			return -cmp, comparable
+		case *planpb.GenericValue_FloatVal:
+			if math.IsNaN(upper.GetFloatVal()) {
+				return 0, false
+			}
+			if lower.GetFloatVal() < upper.GetFloatVal() {
+				return -1, true
+			}
+			if lower.GetFloatVal() > upper.GetFloatVal() {
+				return 1, true
+			}
+			return 0, true
+		}
+	case *planpb.GenericValue_StringVal:
+		if !IsString(upper) {
+			return 0, false
+		}
+		if lower.GetStringVal() < upper.GetStringVal() {
+			return -1, true
+		}
+		if lower.GetStringVal() > upper.GetStringVal() {
+			return 1, true
+		}
+		return 0, true
+	}
+
+	return 0, false
+}
+
+func validateBinaryRangeBounds(lower, upper *planpb.GenericValue, lowerInclusive, upperInclusive bool) error {
+	cmp, comparable := compareBinaryRangeBounds(lower, upper)
+	if !comparable {
+		return nil
+	}
+	if cmp > 0 || (cmp == 0 && (!lowerInclusive || !upperInclusive)) {
+		return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
+	}
+	return nil
 }
 
 func checkContainsElement(columnExpr *ExprWithType, op planpb.JSONContainsExpr_JSONOp, elementValue *planpb.GenericValue) error {

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -2,7 +2,6 @@ package planparserv2
 
 import (
 	"fmt"
-	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter"
 	"github.com/milvus-io/milvus/pkg/v2/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -702,105 +702,10 @@ func castRangeValue(dataType schemapb.DataType, value *planpb.GenericValue) (*pl
 	return value, nil
 }
 
-// compareInt64ToFloat64 compares an int64 and a float64 without converting the
-// integer to float64. It returns whether the values are comparable separately
-// so NaN can be left to execution-time predicate semantics.
-func compareInt64ToFloat64(lhs int64, rhs float64) (int, bool) {
-	if math.IsNaN(rhs) {
-		return 0, false
-	}
-
-	const (
-		int64Lower = -0x1p63
-		int64Upper = 0x1p63
-	)
-	if rhs < int64Lower {
-		return 1, true
-	}
-	if rhs >= int64Upper {
-		return -1, true
-	}
-
-	rhsInteger := int64(rhs)
-	if lhs < rhsInteger {
-		return -1, true
-	}
-	if lhs > rhsInteger {
-		return 1, true
-	}
-
-	rhsIntegerAsFloat := float64(rhsInteger)
-	if rhs > rhsIntegerAsFloat {
-		return -1, true
-	}
-	if rhs < rhsIntegerAsFloat {
-		return 1, true
-	}
-	return 0, true
-}
-
-// compareBinaryRangeBounds returns the exact ordering of supported range
-// bounds. Different JSON dynamic types and unsupported literal kinds are not
-// ordered here; segcore applies their runtime type/missing/null semantics.
-func compareBinaryRangeBounds(lower, upper *planpb.GenericValue) (int, bool) {
-	if lower == nil || upper == nil {
-		return 0, false
-	}
-
-	switch lower.GetVal().(type) {
-	case *planpb.GenericValue_Int64Val:
-		switch upper.GetVal().(type) {
-		case *planpb.GenericValue_Int64Val:
-			if lower.GetInt64Val() < upper.GetInt64Val() {
-				return -1, true
-			}
-			if lower.GetInt64Val() > upper.GetInt64Val() {
-				return 1, true
-			}
-			return 0, true
-		case *planpb.GenericValue_FloatVal:
-			return compareInt64ToFloat64(lower.GetInt64Val(), upper.GetFloatVal())
-		}
-	case *planpb.GenericValue_FloatVal:
-		if math.IsNaN(lower.GetFloatVal()) {
-			return 0, false
-		}
-		switch upper.GetVal().(type) {
-		case *planpb.GenericValue_Int64Val:
-			cmp, comparable := compareInt64ToFloat64(upper.GetInt64Val(), lower.GetFloatVal())
-			return -cmp, comparable
-		case *planpb.GenericValue_FloatVal:
-			if math.IsNaN(upper.GetFloatVal()) {
-				return 0, false
-			}
-			if lower.GetFloatVal() < upper.GetFloatVal() {
-				return -1, true
-			}
-			if lower.GetFloatVal() > upper.GetFloatVal() {
-				return 1, true
-			}
-			return 0, true
-		}
-	case *planpb.GenericValue_StringVal:
-		if !IsString(upper) {
-			return 0, false
-		}
-		if lower.GetStringVal() < upper.GetStringVal() {
-			return -1, true
-		}
-		if lower.GetStringVal() > upper.GetStringVal() {
-			return 1, true
-		}
-		return 0, true
-	}
-
-	return 0, false
-}
-
 func validateBinaryRangeBounds(lower, upper *planpb.GenericValue, lowerInclusive, upperInclusive bool) error {
-	cmp, comparable := compareBinaryRangeBounds(lower, upper)
-	if !comparable {
-		return nil
+	cmp, ok := rewriter.CompareRangeValues(lower, upper)
+	if !ok {
+		return merr.WrapErrQueryPlanMsg("invalid range: bounds are not comparable")
 	}
 	if cmp > 0 || (cmp == 0 && (!lowerInclusive || !upperInclusive)) {
 		return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")

--- a/tests/go_client/common/utils.go
+++ b/tests/go_client/common/utils.go
@@ -132,7 +132,7 @@ var InvalidExpressions = []InvalidExprStruct{
 	{Expr: "id in [0]", ErrNil: true, ErrMsg: "fieldName(id) not found"},                                          // not exist field but no error, because enable dynamic
 	{Expr: "int64 in not [0]", ErrNil: false, ErrMsg: "cannot parse expression"},                                  // wrong term expr keyword
 	{Expr: "int64 < floatVec", ErrNil: false, ErrMsg: "not supported"},                                            // unsupported compare field
-	{Expr: "floatVec in [0]", ErrNil: false, ErrMsg: "cannot be casted to FloatVector"},                           // value and field type mismatch
+	{Expr: "floatVec in [0]", ErrNil: false, ErrMsg: "term expression is not supported"},                          // unsupported term target type
 	{Expr: fmt.Sprintf("%s == 1", DefaultJSONFieldName), ErrNil: true, ErrMsg: ""},                                // hist empty
 	{Expr: fmt.Sprintf("%s like 'a%%' ", DefaultJSONFieldName), ErrNil: true, ErrMsg: ""},                         // hist empty
 	{Expr: fmt.Sprintf("%s like `a%%` ", DefaultJSONFieldName), ErrNil: false, ErrMsg: "cannot parse expression"}, // ``


### PR DESCRIPTION
pr: #51625
issue: #51489
issue: #51567
issue: #51568

## What changed

- Canonicalize mixed-type JSON `IN` expressions into homogeneous predicates.
- Partition JSON values by their concrete type: bool, int64, float, string, and array.
- Keep int64 and float values in separate predicates to avoid precision loss around `2^53`.
- Make the following expression optimizations type-aware for JSON:
  - `== OR` to `IN`
  - `!= AND` to `NOT IN`
  - combinations involving `IN`, equality, inequality, and range predicates
- Lower JSON array-valued membership to equality branches because segcore does not support array-valued `TermExpr`.
- Apply JSON term canonicalization even when expression optimization is disabled.
- Allow scalar JSON `NOT(x == value)` to be rewritten as `x != value` while preserving UNKNOWN for null, missing paths, and type mismatches.
- Add a segcore validation guard that rejects heterogeneous JSON `TermExpr` values before selecting raw data, JSON stats, or JSON path index execution paths.

## Root cause

A JSON `TermExpr` could contain values with different protobuf value types. Segcore selected its executor from the first value, causing later values to be interpreted using the wrong type.

The optimizer could also combine different JSON literal types back into a single `TermExpr`. Additionally, converting mixed integer and floating-point values to float could lose int64 precision.

## Behavior

For example:

```text
json["key"] in [1, 2, "3"]
```

is normalized to:

```text
json["key"] in [1, 2] OR json["key"] == "3"
```

Mixed-type `NOT IN` remains a negation of the complete split membership expression, preserving three-valued logic:

```text
NOT(json["key"] in [1, 2] OR json["key"] == "3")
```

Non-JSON columns continue to use their statically determined schema type.

## Verification

- Go parser and rewriter tests:

```bash
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2/...
```

- Segcore mixed JSON Term validation test.
- Raw JSON filtering three-valued semantics tests.
- JSON path index precision and `!=` semantics tests.
- JSON stats/shredding null, missing-path, and large-int64 precision tests.
