### PR TITLE
fix: reset growing source handoff mode after release

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -1282,13 +1282,21 @@ func (sd *shardDelegator) ReleaseSegments(ctx context.Context, req *querypb.Rele
 		sd.growingSegmentLock.Unlock()
 	}
 
-	if releaseErr != nil {
-		return releaseErr
-	}
+	// Clear the release-handoff bookkeeping even when the worker release failed.
+	// RemoveDistributions and AddExcludedSegments above already ran
+	// unconditionally, so the delegator has committed to dropping these segments
+	// either way. ClearReleasePrepared is the growing-source counterpart of that
+	// cleanup and is the only place that removes IDs from handoffAllowed on an
+	// active provider: gating it on releaseErr would pin handoffOnly forever and
+	// keep rejecting every unrelated growing segment. A querycoord retry
+	// re-prepares, since prepareReleaseManualFlush filters on IsReleasePrepared.
 	if len(growing) > 0 && sd.growingSourceProvider != nil {
 		for _, entry := range growing {
 			sd.growingSourceProvider.ClearReleasePrepared(entry.SegmentID)
 		}
+	}
+	if releaseErr != nil {
+		return releaseErr
 	}
 	return nil
 }

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1870,6 +1870,95 @@ func (s *DelegatorDataSuite) TestReleaseGrowingSourceAfterPreparedHandoff() {
 	s.Require().NoError(err)
 }
 
+// TestReleaseGrowingSourceClearsHandoffOnWorkerReleaseFailure pins that a failed
+// worker release still clears the release-handoff bookkeeping. RemoveDistributions
+// and AddExcludedSegments already ran unconditionally by that point, so leaving
+// handoffAllowed populated would keep handoffOnly armed forever and reject every
+// unrelated growing segment -- the same symptom as issue #51635.
+func (s *DelegatorDataSuite) TestReleaseGrowingSourceClearsHandoffOnWorkerReleaseFailure() {
+	ctx := context.Background()
+	s.workerManager = &cluster.MockManager{}
+	s.manager = segments.NewManager()
+	s.loader = &segments.MockLoader{}
+	s.genTextCollection()
+	s.enableGrowingSourceFlush()
+
+	delegator, err := NewShardDelegator(
+		ctx,
+		s.collectionID,
+		s.replicaID,
+		s.vchannelName,
+		s.version,
+		s.workerManager,
+		s.manager,
+		s.loader,
+		10000,
+		nil,
+		s.chunkManager,
+		NewChannelQueryView(nil, nil, nil, initialTargetVersion),
+		nil)
+	s.Require().NoError(err)
+	sd := delegator.(*shardDelegator)
+	defer sd.Close()
+
+	const (
+		segmentID    = int64(1001)
+		partitionID  = int64(500)
+		targetOffset = int64(10)
+	)
+
+	segment := segments.NewMockSegment(s.T())
+	segment.EXPECT().ID().Return(segmentID).Maybe()
+	segment.EXPECT().Version().Return(int64(1)).Maybe()
+	segment.EXPECT().Shard().Return(s.channel).Maybe()
+	segment.EXPECT().Collection().Return(s.collectionID).Maybe()
+	segment.EXPECT().Partition().Return(partitionID).Maybe()
+	segment.EXPECT().Type().Return(segments.SegmentTypeGrowing).Maybe()
+	segment.EXPECT().Level().Return(datapb.SegmentLevel_Legacy).Maybe()
+	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
+	segment.EXPECT().InsertCount().Return(targetOffset).Once()
+	segment.EXPECT().MemSize().Return(int64(1024)).Once()
+	segment.EXPECT().Unpin().Maybe()
+
+	s.manager.Segment.Put(ctx, segments.SegmentTypeGrowing, segment)
+	sd.distribution.AddGrowing(SegmentEntry{
+		NodeID:      paramtable.GetNodeID(),
+		SegmentID:   segmentID,
+		PartitionID: partitionID,
+		Version:     1,
+	})
+
+	releaseErr := merr.WrapErrServiceInternal("mock worker release failure")
+	worker := &cluster.MockWorker{}
+	worker.EXPECT().ReleaseSegments(mock.Anything, mock.AnythingOfType("*querypb.ReleaseSegmentsRequest")).Return(releaseErr).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, paramtable.GetNodeID()).Return(worker, nil).Once()
+
+	err = sd.growingSourceProvider.PrepareGrowingSourceReleaseHandoff(ctx, 10000, []syncmgr.GrowingSourceReleaseHandoffSegment{
+		{
+			SegmentID:    segmentID,
+			TargetOffset: targetOffset,
+		},
+	})
+	s.Require().NoError(err)
+
+	err = sd.ReleaseSegments(ctx, &querypb.ReleaseSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		NodeID:       paramtable.GetNodeID(),
+		CollectionID: s.collectionID,
+		SegmentIDs:   []int64{segmentID},
+		Scope:        querypb.DataScope_Streaming,
+		Shard:        s.vchannelName,
+	}, false)
+	// The release error must still surface to the caller.
+	s.Require().Error(err)
+
+	// ...but the handoff fence must not survive it.
+	sd.growingSourceProvider.mu.Lock()
+	handoffAllowed := len(sd.growingSourceProvider.handoffAllowed)
+	sd.growingSourceProvider.mu.Unlock()
+	s.Require().Zero(handoffAllowed, "handoffAllowed must be cleared even when the worker release fails")
+}
+
 func (s *DelegatorDataSuite) TestReleaseGrowingSourceAfterFencePreparedHandoff() {
 	ctx := context.Background()
 	s.workerManager = &cluster.MockManager{}

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -399,6 +399,7 @@ func (p *delegatorGrowingSourceProvider) ClearReleasePrepared(segmentID int64) {
 	delete(p.releasePrepared, segmentID)
 	delete(p.releaseAllowed, segmentID)
 	delete(p.handoffAllowed, segmentID)
+	p.exitHandoffOnlyIfDrainedLocked()
 }
 
 func (p *delegatorGrowingSourceProvider) ReleasePreparedSegments() []int64 {
@@ -458,7 +459,14 @@ func (p *delegatorGrowingSourceProvider) tryReleaseRetainedLocked(segmentID int6
 		return nil, nil
 	}
 	delete(p.retained, segmentID)
+	p.exitHandoffOnlyIfDrainedLocked()
 	return p.unregisterIfInactiveLocked(), retained
+}
+
+func (p *delegatorGrowingSourceProvider) exitHandoffOnlyIfDrainedLocked() {
+	if p.handoffOnly && len(p.handoffAllowed) == 0 && len(p.retained) == 0 {
+		p.handoffOnly = false
+	}
 }
 
 func (p *delegatorGrowingSourceProvider) releaseRetained(registration *syncmgr.GrowingSourceRegistration, retained *retainedGrowingFlushSource) {

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -51,6 +51,7 @@ type delegatorGrowingSourceProvider struct {
 	releasePrepared map[int64]int64
 	handoffOnly     bool
 	handoffAllowed  map[int64]struct{}
+	handoffInflight int
 }
 
 func newDelegatorGrowingSourceProvider(segmentManager segments.SegmentManager, waitFence func(context.Context, uint64) error, getTSafe ...func() uint64) *delegatorGrowingSourceProvider {
@@ -153,6 +154,11 @@ func (p *delegatorGrowingSourceProvider) PrepareGrowingSourceReleaseHandoff(ctx 
 		return p.prepareDeactivatedGrowingSourceReleaseHandoff(fenceTs, segments)
 	}
 	handoffSnapshot := p.enterHandoffOnly(segments)
+	// Keep the handoff-only fence armed until this in-flight handoff finishes.
+	// enterHandoffOnly releases p.mu before waitFence, so a concurrent
+	// ClearReleasePrepared could otherwise drain handoffAllowed and drop the
+	// fence while we are still parked in waitFence.
+	defer p.leaveHandoffOnlyInflight()
 	if p.waitFence != nil && fenceTs > 0 {
 		if err := p.waitFence(ctx, fenceTs); err != nil {
 			p.rollbackHandoffOnly(handoffSnapshot)
@@ -333,6 +339,7 @@ func (p *delegatorGrowingSourceProvider) enterHandoffOnly(segments []syncmgr.Gro
 	}
 
 	p.handoffOnly = true
+	p.handoffInflight++
 	for _, segment := range segments {
 		p.handoffAllowed[segment.SegmentID] = struct{}{}
 	}
@@ -464,9 +471,22 @@ func (p *delegatorGrowingSourceProvider) tryReleaseRetainedLocked(segmentID int6
 }
 
 func (p *delegatorGrowingSourceProvider) exitHandoffOnlyIfDrainedLocked() {
-	if p.handoffOnly && len(p.handoffAllowed) == 0 && len(p.retained) == 0 {
+	if p.handoffOnly && len(p.handoffAllowed) == 0 && len(p.retained) == 0 && p.handoffInflight == 0 {
 		p.handoffOnly = false
 	}
+}
+
+// leaveHandoffOnlyInflight marks one in-flight PrepareGrowingSourceReleaseHandoff
+// as finished. It re-checks the drain condition so that if the last allowed/
+// retained entry was cleared while this handoff was still in flight (drain was
+// blocked by handoffInflight), the fence is lowered now that it reaches zero.
+func (p *delegatorGrowingSourceProvider) leaveHandoffOnlyInflight() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.handoffInflight > 0 {
+		p.handoffInflight--
+	}
+	p.exitHandoffOnlyIfDrainedLocked()
 }
 
 func (p *delegatorGrowingSourceProvider) releaseRetained(registration *syncmgr.GrowingSourceRegistration, retained *retainedGrowingFlushSource) {

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -50,7 +50,7 @@ type delegatorGrowingSourceProvider struct {
 	releaseAllowed  map[int64]uint64
 	releasePrepared map[int64]int64
 	handoffOnly     bool
-	handoffAllowed  map[int64]struct{}
+	handoffAllowed  map[int64]int
 	handoffInflight int
 }
 
@@ -62,7 +62,7 @@ func newDelegatorGrowingSourceProvider(segmentManager segments.SegmentManager, w
 		retained:        make(map[int64]*retainedGrowingFlushSource),
 		releaseAllowed:  make(map[int64]uint64),
 		releasePrepared: make(map[int64]int64),
-		handoffAllowed:  make(map[int64]struct{}),
+		handoffAllowed:  make(map[int64]int),
 	}
 	if len(getTSafe) > 0 {
 		provider.getTSafe = getTSafe[0]
@@ -358,11 +358,9 @@ func (p *delegatorGrowingSourceProvider) enterHandoffOnlyLocked(segments []syncm
 
 	p.handoffOnly = true
 	for _, segment := range segments {
-		if _, ok := p.handoffAllowed[segment.SegmentID]; ok {
-			// Already allowed by a concurrent handoff: not ours to undo.
-			continue
-		}
-		p.handoffAllowed[segment.SegmentID] = struct{}{}
+		// handoffAllowed is ref-counted: overlapping handoffs each hold one
+		// reference on the same segment, so a rollback gives back only its own.
+		p.handoffAllowed[segment.SegmentID]++
 		snapshot.added[segment.SegmentID] = struct{}{}
 	}
 	return snapshot
@@ -373,6 +371,10 @@ func (p *delegatorGrowingSourceProvider) rollbackHandoffOnly(snapshot handoffSna
 	defer p.mu.Unlock()
 
 	for segmentID := range snapshot.added {
+		if p.handoffAllowed[segmentID] > 1 {
+			p.handoffAllowed[segmentID]--
+			continue
+		}
 		delete(p.handoffAllowed, segmentID)
 	}
 	// Never clear handoffOnly directly. Another handoff may still be parked in
@@ -588,7 +590,7 @@ func (p *delegatorGrowingSourceProvider) Close() {
 	p.releaseAllowed = make(map[int64]uint64)
 	p.releasePrepared = make(map[int64]int64)
 	p.handoffOnly = false
-	p.handoffAllowed = make(map[int64]struct{})
+	p.handoffAllowed = make(map[int64]int)
 	registration := p.registration
 	p.registration = nil
 	p.deleteRetainedMetricsLocked()
@@ -608,7 +610,7 @@ func (p *delegatorGrowingSourceProvider) unregisterIfInactiveLocked() *syncmgr.G
 	p.releaseAllowed = make(map[int64]uint64)
 	p.releasePrepared = make(map[int64]int64)
 	p.handoffOnly = false
-	p.handoffAllowed = make(map[int64]struct{})
+	p.handoffAllowed = make(map[int64]int)
 	p.deleteRetainedMetricsLocked()
 	return registration
 }

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -165,6 +165,23 @@ func (p *delegatorGrowingSourceProvider) PrepareGrowingSourceReleaseHandoff(ctx 
 			return err
 		}
 	}
+	// waitFence parks without holding p.mu, so Deactivate may have landed while we
+	// were there. Resuming into the active path would register a retained entry --
+	// and a segment pin -- on a deactivated provider, which nothing detaches and
+	// which keeps unregisterIfInactiveLocked from ever firing. Take the same route
+	// a handoff arriving after Deactivate takes.
+	if p.isDeactivated() {
+		p.rollbackHandoffOnly(handoffSnapshot)
+		return p.prepareDeactivatedGrowingSourceReleaseHandoff(fenceTs, segments)
+	}
+	// Drop segments retired while we were parked. ClearReleasePrepared wipes a
+	// segment's handoffAllowed entry to mean "this handoff is over, forget it";
+	// republishing releaseAllowed/releasePrepared -- or re-pinning via
+	// registerRetained -- would resurrect state nothing will clear again.
+	segments = p.stillFenced(segments)
+	if len(segments) == 0 {
+		return nil
+	}
 	snapshot := p.snapshotRetained(segments)
 	allowedSegments := make([]syncmgr.GrowingSourceReleaseHandoffSegment, 0, len(segments))
 	preparedSegments := make([]syncmgr.GrowingSourceReleaseHandoffSegment, 0, len(segments))
@@ -186,6 +203,21 @@ func (p *delegatorGrowingSourceProvider) PrepareGrowingSourceReleaseHandoff(ctx 
 	p.markReleaseAllowed(fenceTs, allowedSegments)
 	p.markReleasePrepared(fenceTs, preparedSegments)
 	return nil
+}
+
+// stillFenced keeps only the segments whose handoffAllowed reference this
+// provider still holds. A reference disappears when ClearReleasePrepared retires
+// the segment, which can happen while a handoff is parked in waitFence.
+func (p *delegatorGrowingSourceProvider) stillFenced(segments []syncmgr.GrowingSourceReleaseHandoffSegment) []syncmgr.GrowingSourceReleaseHandoffSegment {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	kept := make([]syncmgr.GrowingSourceReleaseHandoffSegment, 0, len(segments))
+	for _, segment := range segments {
+		if p.handoffAllowed[segment.SegmentID] > 0 {
+			kept = append(kept, segment)
+		}
+	}
+	return kept
 }
 
 func (p *delegatorGrowingSourceProvider) prepareDeactivatedGrowingSourceReleaseHandoff(fenceTs uint64, segments []syncmgr.GrowingSourceReleaseHandoffSegment) error {
@@ -218,6 +250,13 @@ func (p *delegatorGrowingSourceProvider) registerRetained(segmentID int64, targe
 	if p.closing {
 		p.mu.Unlock()
 		return errGrowingSourceProviderClosed
+	}
+	if p.deactivated {
+		p.mu.Unlock()
+		// Classified as channel-not-available on purpose: the provider is
+		// deactivated because the delegator is closing, and the unsubscribe path
+		// treats that as "prepare unavailable, carry on" rather than a failure.
+		return merr.WrapErrChannelNotAvailable(p.channelName, "growing source provider is deactivated")
 	}
 	if retained, ok := p.retained[segmentID]; ok {
 		if retained.targetOffset < targetOffset {
@@ -328,7 +367,10 @@ func (p *delegatorGrowingSourceProvider) rollbackRetained(snapshot map[int64]ret
 // lower handoffOnly without consulting handoffInflight -- while another handoff
 // is still parked in waitFence.
 type handoffSnapshot struct {
-	added map[int64]struct{}
+	// added counts the references this call took per segment, so a rollback
+	// gives back exactly as many as it took even if the caller passed the same
+	// segment twice.
+	added map[int64]int
 }
 
 // enterHandoffOnly arms the handoff-only fence without registering an in-flight
@@ -354,14 +396,14 @@ func (p *delegatorGrowingSourceProvider) enterHandoffOnlyInflight(segments []syn
 }
 
 func (p *delegatorGrowingSourceProvider) enterHandoffOnlyLocked(segments []syncmgr.GrowingSourceReleaseHandoffSegment) handoffSnapshot {
-	snapshot := handoffSnapshot{added: make(map[int64]struct{}, len(segments))}
+	snapshot := handoffSnapshot{added: make(map[int64]int, len(segments))}
 
 	p.handoffOnly = true
 	for _, segment := range segments {
 		// handoffAllowed is ref-counted: overlapping handoffs each hold one
 		// reference on the same segment, so a rollback gives back only its own.
 		p.handoffAllowed[segment.SegmentID]++
-		snapshot.added[segment.SegmentID] = struct{}{}
+		snapshot.added[segment.SegmentID]++
 	}
 	return snapshot
 }
@@ -370,9 +412,9 @@ func (p *delegatorGrowingSourceProvider) rollbackHandoffOnly(snapshot handoffSna
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	for segmentID := range snapshot.added {
-		if p.handoffAllowed[segmentID] > 1 {
-			p.handoffAllowed[segmentID]--
+	for segmentID, taken := range snapshot.added {
+		if p.handoffAllowed[segmentID] > taken {
+			p.handoffAllowed[segmentID] -= taken
 			continue
 		}
 		delete(p.handoffAllowed, segmentID)

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -153,9 +153,9 @@ func (p *delegatorGrowingSourceProvider) PrepareGrowingSourceReleaseHandoff(ctx 
 	if p.isDeactivated() {
 		return p.prepareDeactivatedGrowingSourceReleaseHandoff(fenceTs, segments)
 	}
-	handoffSnapshot := p.enterHandoffOnly(segments)
+	handoffSnapshot := p.enterHandoffOnlyInflight(segments)
 	// Keep the handoff-only fence armed until this in-flight handoff finishes.
-	// enterHandoffOnly releases p.mu before waitFence, so a concurrent
+	// enterHandoffOnlyInflight releases p.mu before waitFence, so a concurrent
 	// ClearReleasePrepared could otherwise drain handoffAllowed and drop the
 	// fence while we are still parked in waitFence.
 	defer p.leaveHandoffOnlyInflight()
@@ -326,10 +326,29 @@ type handoffSnapshot struct {
 	allowed map[int64]struct{}
 }
 
+// enterHandoffOnly arms the handoff-only fence without registering an in-flight
+// handoff. Callers that only park the fence across an external commit/rollback
+// decision (BeginGrowingSourceReleaseHandoff) must use this variant: their
+// rollback closure is not invoked on the committed path, so an in-flight count
+// taken here would never be given back and would pin handoffOnly forever.
 func (p *delegatorGrowingSourceProvider) enterHandoffOnly(segments []syncmgr.GrowingSourceReleaseHandoffSegment) handoffSnapshot {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	return p.enterHandoffOnlyLocked(segments)
+}
 
+// enterHandoffOnlyInflight arms the handoff-only fence and registers one
+// in-flight handoff atomically. The caller MUST pair it with
+// leaveHandoffOnlyInflight on every return path.
+func (p *delegatorGrowingSourceProvider) enterHandoffOnlyInflight(segments []syncmgr.GrowingSourceReleaseHandoffSegment) handoffSnapshot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	snapshot := p.enterHandoffOnlyLocked(segments)
+	p.handoffInflight++
+	return snapshot
+}
+
+func (p *delegatorGrowingSourceProvider) enterHandoffOnlyLocked(segments []syncmgr.GrowingSourceReleaseHandoffSegment) handoffSnapshot {
 	snapshot := handoffSnapshot{
 		enabled: p.handoffOnly,
 		allowed: make(map[int64]struct{}, len(p.handoffAllowed)),
@@ -339,7 +358,6 @@ func (p *delegatorGrowingSourceProvider) enterHandoffOnly(segments []syncmgr.Gro
 	}
 
 	p.handoffOnly = true
-	p.handoffInflight++
 	for _, segment := range segments {
 		p.handoffAllowed[segment.SegmentID] = struct{}{}
 	}

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -321,9 +321,14 @@ func (p *delegatorGrowingSourceProvider) rollbackRetained(snapshot map[int64]ret
 	}
 }
 
+// handoffSnapshot records what one enter-handoff call contributed to the fence,
+// so a failed operation can undo exactly its own contribution. It deliberately
+// does not capture the whole prior state: restoring that wholesale would drop
+// entries a concurrent operation added after the snapshot was taken, and would
+// lower handoffOnly without consulting handoffInflight -- while another handoff
+// is still parked in waitFence.
 type handoffSnapshot struct {
-	enabled bool
-	allowed map[int64]struct{}
+	added map[int64]struct{}
 }
 
 // enterHandoffOnly arms the handoff-only fence without registering an in-flight
@@ -349,17 +354,16 @@ func (p *delegatorGrowingSourceProvider) enterHandoffOnlyInflight(segments []syn
 }
 
 func (p *delegatorGrowingSourceProvider) enterHandoffOnlyLocked(segments []syncmgr.GrowingSourceReleaseHandoffSegment) handoffSnapshot {
-	snapshot := handoffSnapshot{
-		enabled: p.handoffOnly,
-		allowed: make(map[int64]struct{}, len(p.handoffAllowed)),
-	}
-	for segmentID := range p.handoffAllowed {
-		snapshot.allowed[segmentID] = struct{}{}
-	}
+	snapshot := handoffSnapshot{added: make(map[int64]struct{}, len(segments))}
 
 	p.handoffOnly = true
 	for _, segment := range segments {
+		if _, ok := p.handoffAllowed[segment.SegmentID]; ok {
+			// Already allowed by a concurrent handoff: not ours to undo.
+			continue
+		}
 		p.handoffAllowed[segment.SegmentID] = struct{}{}
+		snapshot.added[segment.SegmentID] = struct{}{}
 	}
 	return snapshot
 }
@@ -368,8 +372,16 @@ func (p *delegatorGrowingSourceProvider) rollbackHandoffOnly(snapshot handoffSna
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.handoffOnly = snapshot.enabled
-	p.handoffAllowed = snapshot.allowed
+	for segmentID := range snapshot.added {
+		delete(p.handoffAllowed, segmentID)
+	}
+	// Never clear handoffOnly directly. Another handoff may still be parked in
+	// waitFence, or may still hold allowed/retained entries; the drain check is
+	// the single place that decides, and it is the only one that honors
+	// handoffInflight. For the Prepare path this call is a no-op because the
+	// caller's own in-flight count is still held -- its deferred
+	// leaveHandoffOnlyInflight re-checks once the count reaches zero.
+	p.exitHandoffOnlyIfDrainedLocked()
 }
 
 func (p *delegatorGrowingSourceProvider) markReleaseAllowed(fenceTs uint64, segments []syncmgr.GrowingSourceReleaseHandoffSegment) {

--- a/internal/querynodev2/delegator/growing_flush_source_test.go
+++ b/internal/querynodev2/delegator/growing_flush_source_test.go
@@ -288,6 +288,59 @@ func TestDelegatorGrowingSourceProviderClearsHandoffOnlyAfterReleasePrepared(t *
 	source.Release()
 }
 
+// TestDelegatorGrowingSourceProviderKeepsHandoffOnlyWhileHandoffInflight pins the
+// invariant that a concurrent ClearReleasePrepared must NOT drop the handoff-only
+// fence while a PrepareGrowingSourceReleaseHandoff is still parked in waitFence.
+// enterHandoffOnly releases p.mu before waitFence, so without the in-flight guard
+// the concurrent clear would drain handoffAllowed and lower the fence early,
+// letting a brand-new segment acquire a lease mid-handoff.
+func TestDelegatorGrowingSourceProviderKeepsHandoffOnlyWhileHandoffInflight(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+
+	fenceEntered := make(chan struct{})
+	fenceRelease := make(chan struct{})
+	provider := newDelegatorGrowingSourceProvider(segmentManager, func(ctx context.Context, fenceTs uint64) error {
+		close(fenceEntered) // signal that Prepare is now parked in waitFence
+		<-fenceRelease      // stay parked until the test releases us
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		// TargetOffset=0 keeps the setup minimal: no retained registration, no
+		// segment mock; the segment is only added to handoffAllowed.
+		done <- provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 100,
+			[]syncmgr.GrowingSourceReleaseHandoffSegment{{SegmentID: 1001, TargetOffset: 0}})
+	}()
+
+	// Wait until Prepare has armed the fence and parked in waitFence
+	// (handoffOnly=true, handoffAllowed={1001}, handoffInflight=1, p.mu released).
+	<-fenceEntered
+
+	// Concurrently clear the in-flight segment. Before the fix this drained
+	// handoffAllowed and dropped handoffOnly while the handoff was still in flight.
+	provider.ClearReleasePrepared(1001)
+
+	provider.mu.Lock()
+	stillArmed := provider.handoffOnly
+	provider.mu.Unlock()
+	require.True(t, stillArmed, "handoffOnly must stay armed while a Prepare is parked in waitFence")
+
+	// A brand-new, unrelated segment must still be rejected.
+	require.False(t, provider.acquireLease(2002), "new segment must be rejected while the fence is armed")
+
+	// Let Prepare finish; the fence lowers only after the in-flight count hits zero.
+	close(fenceRelease)
+	require.NoError(t, <-done)
+
+	provider.mu.Lock()
+	drained := provider.handoffOnly
+	inflight := provider.handoffInflight
+	provider.mu.Unlock()
+	require.False(t, drained, "handoffOnly should lower once the in-flight handoff finishes and maps are drained")
+	require.Equal(t, 0, inflight)
+}
+
 func TestDelegatorGrowingSourceProviderDeactivatedOnlyServesRetainedSources(t *testing.T) {
 	segmentManager := segments.NewMockSegmentManager(t)
 	segment := segments.NewMockSegment(t)

--- a/internal/querynodev2/delegator/growing_flush_source_test.go
+++ b/internal/querynodev2/delegator/growing_flush_source_test.go
@@ -264,6 +264,30 @@ func TestDelegatorGrowingSourceProviderHandoffOnlyRejectsNewSegmentsBeforeFence(
 	provider.Close()
 }
 
+func TestDelegatorGrowingSourceProviderClearsHandoffOnlyAfterReleasePrepared(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+	provider := newDelegatorGrowingSourceProvider(segmentManager, nil)
+
+	err := provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 0, []syncmgr.GrowingSourceReleaseHandoffSegment{
+		{SegmentID: 1001},
+	})
+	require.NoError(t, err)
+	require.True(t, provider.IsReleaseAllowed(1001, 0))
+
+	provider.ClearReleasePrepared(1001)
+
+	segment := segments.NewMockSegment(t)
+	segmentManager.EXPECT().GetGrowing(int64(1002)).Return(segment).Once()
+	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
+	segment.EXPECT().InsertCount().Return(int64(1)).Once()
+	segment.EXPECT().Unpin().Once()
+
+	source, state := provider.GetGrowingFlushSource(1002, 1, nil)
+	require.Equal(t, syncmgr.GrowingSourceUsable, state)
+	require.NotNil(t, source)
+	source.Release()
+}
+
 func TestDelegatorGrowingSourceProviderDeactivatedOnlyServesRetainedSources(t *testing.T) {
 	segmentManager := segments.NewMockSegmentManager(t)
 	segment := segments.NewMockSegment(t)

--- a/internal/querynodev2/delegator/growing_flush_source_test.go
+++ b/internal/querynodev2/delegator/growing_flush_source_test.go
@@ -288,10 +288,67 @@ func TestDelegatorGrowingSourceProviderClearsHandoffOnlyAfterReleasePrepared(t *
 	source.Release()
 }
 
+// TestDelegatorGrowingSourceProviderBeginHandoffDoesNotPinFence replays the only
+// production release-handoff sequence: Begin (whose rollback closure is dropped on
+// the committed path) followed by Prepare and ClearReleasePrepared. Begin must not
+// take an in-flight count it never gives back, otherwise handoffOnly stays armed
+// forever and every unrelated growing segment keeps being rejected.
+func TestDelegatorGrowingSourceProviderBeginHandoffDoesNotPinFence(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+	provider := newDelegatorGrowingSourceProvider(segmentManager, nil)
+
+	// Begin arms the fence; the returned rollback is dropped (handoff committed).
+	rollback := provider.BeginGrowingSourceReleaseHandoff([]int64{1001})
+	require.NotNil(t, rollback)
+
+	err := provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 0, []syncmgr.GrowingSourceReleaseHandoffSegment{
+		{SegmentID: 1001},
+	})
+	require.NoError(t, err)
+
+	provider.ClearReleasePrepared(1001)
+
+	provider.mu.Lock()
+	handoffOnly := provider.handoffOnly
+	inflight := provider.handoffInflight
+	provider.mu.Unlock()
+	require.Equal(t, 0, inflight, "Begin must not leak an in-flight handoff count")
+	require.False(t, handoffOnly, "handoffOnly must lower once the handoff drains")
+
+	// An unrelated growing segment must be servable again.
+	segment := segments.NewMockSegment(t)
+	segmentManager.EXPECT().GetGrowing(int64(1002)).Return(segment).Once()
+	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
+	segment.EXPECT().InsertCount().Return(int64(1)).Once()
+	segment.EXPECT().Unpin().Once()
+
+	source, state := provider.GetGrowingFlushSource(1002, 1, nil)
+	require.Equal(t, syncmgr.GrowingSourceUsable, state)
+	require.NotNil(t, source)
+	source.Release()
+}
+
+// TestDelegatorGrowingSourceProviderBeginHandoffRollbackDoesNotPinFence covers the
+// other Begin outcome: the caller aborts and invokes the rollback closure. That
+// path must leave no in-flight count behind either.
+func TestDelegatorGrowingSourceProviderBeginHandoffRollbackDoesNotPinFence(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+	provider := newDelegatorGrowingSourceProvider(segmentManager, nil)
+
+	provider.BeginGrowingSourceReleaseHandoff([]int64{1001})()
+
+	provider.mu.Lock()
+	handoffOnly := provider.handoffOnly
+	inflight := provider.handoffInflight
+	provider.mu.Unlock()
+	require.Equal(t, 0, inflight)
+	require.False(t, handoffOnly)
+}
+
 // TestDelegatorGrowingSourceProviderKeepsHandoffOnlyWhileHandoffInflight pins the
 // invariant that a concurrent ClearReleasePrepared must NOT drop the handoff-only
 // fence while a PrepareGrowingSourceReleaseHandoff is still parked in waitFence.
-// enterHandoffOnly releases p.mu before waitFence, so without the in-flight guard
+// enterHandoffOnlyInflight releases p.mu before waitFence, so without the in-flight guard
 // the concurrent clear would drain handoffAllowed and lower the fence early,
 // letting a brand-new segment acquire a lease mid-handoff.
 func TestDelegatorGrowingSourceProviderKeepsHandoffOnlyWhileHandoffInflight(t *testing.T) {

--- a/internal/querynodev2/delegator/growing_flush_source_test.go
+++ b/internal/querynodev2/delegator/growing_flush_source_test.go
@@ -415,6 +415,44 @@ func TestDelegatorGrowingSourceProviderRollbackKeepsConcurrentHandoff(t *testing
 	provider.Close()
 }
 
+// TestDelegatorGrowingSourceProviderOverlappingBeginRollbackKeepsFence covers the
+// case the test above does not: two handoffs over the SAME segment, both entered
+// through Begin. Two concurrent UnsubDmChannel calls on one vchannel derive their
+// segment list from the same localGrowingSegmentIDs, so overlap is the norm rather
+// than an edge case. Begin deliberately takes no in-flight count, so nothing else
+// holds the fence up here -- if handoffAllowed were a plain set owned by whoever
+// inserted first, A's rollback would revoke B's entry and lower the fence while
+// B's handoff is still running.
+func TestDelegatorGrowingSourceProviderOverlappingBeginRollbackKeepsFence(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+	provider := newDelegatorGrowingSourceProvider(segmentManager, nil)
+
+	rollbackA := provider.BeginGrowingSourceReleaseHandoff([]int64{1001})
+	rollbackB := provider.BeginGrowingSourceReleaseHandoff([]int64{1001})
+
+	rollbackA()
+
+	provider.mu.Lock()
+	stillArmed := provider.handoffOnly
+	refs := provider.handoffAllowed[1001]
+	provider.mu.Unlock()
+	require.True(t, stillArmed, "fence must stay armed while B still holds the handoff")
+	require.Equal(t, 1, refs, "B's reference must survive A's rollback")
+
+	require.False(t, provider.acquireLease(3003), "unrelated segment must not get a lease mid-handoff")
+	require.True(t, provider.acquireLease(1001), "the handed-off segment must stay reachable")
+	provider.releaseLease()
+
+	rollbackB()
+
+	provider.mu.Lock()
+	handoffOnly := provider.handoffOnly
+	_, stillAllowed := provider.handoffAllowed[1001]
+	provider.mu.Unlock()
+	require.False(t, handoffOnly, "fence must drop once the last handoff rolls back")
+	require.False(t, stillAllowed, "no reference may outlive both rollbacks")
+}
+
 // TestDelegatorGrowingSourceProviderKeepsHandoffOnlyWhileHandoffInflight pins the
 // invariant that a concurrent ClearReleasePrepared must NOT drop the handoff-only
 // fence while a PrepareGrowingSourceReleaseHandoff is still parked in waitFence.

--- a/internal/querynodev2/delegator/growing_flush_source_test.go
+++ b/internal/querynodev2/delegator/growing_flush_source_test.go
@@ -18,9 +18,11 @@ package delegator
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -343,6 +345,74 @@ func TestDelegatorGrowingSourceProviderBeginHandoffRollbackDoesNotPinFence(t *te
 	provider.mu.Unlock()
 	require.Equal(t, 0, inflight)
 	require.False(t, handoffOnly)
+}
+
+// TestDelegatorGrowingSourceProviderRollbackKeepsConcurrentHandoff pins that a
+// failed handoff undoes only its own contribution to the fence. Restoring the
+// whole pre-operation snapshot would lower handoffOnly while a second handoff is
+// still parked in waitFence -- letting an unrelated growing segment acquire a
+// lease mid-handoff -- and would also drop the second handoff's segment from
+// handoffAllowed.
+func TestDelegatorGrowingSourceProviderRollbackKeepsConcurrentHandoff(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+
+	var (
+		aEntered = make(chan struct{})
+		aRelease = make(chan struct{})
+		bEntered = make(chan struct{})
+		bRelease = make(chan struct{})
+		fenceMu  sync.Mutex
+		seen     int
+	)
+	provider := newDelegatorGrowingSourceProvider(segmentManager, func(ctx context.Context, fenceTs uint64) error {
+		fenceMu.Lock()
+		seen++
+		first := seen == 1
+		fenceMu.Unlock()
+		if first {
+			close(aEntered)
+			<-aRelease
+			return errors.New("mock fence failure") // A fails
+		}
+		close(bEntered)
+		<-bRelease
+		return nil
+	})
+
+	aDone := make(chan error, 1)
+	go func() {
+		aDone <- provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 100,
+			[]syncmgr.GrowingSourceReleaseHandoffSegment{{SegmentID: 1001, TargetOffset: 0}})
+	}()
+	<-aEntered
+
+	bDone := make(chan error, 1)
+	go func() {
+		bDone <- provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 200,
+			[]syncmgr.GrowingSourceReleaseHandoffSegment{{SegmentID: 2001, TargetOffset: 0}})
+	}()
+	<-bEntered
+
+	// A fails and rolls back while B is still parked in waitFence.
+	close(aRelease)
+	require.Error(t, <-aDone)
+
+	provider.mu.Lock()
+	stillArmed := provider.handoffOnly
+	_, bStillAllowed := provider.handoffAllowed[2001]
+	_, aRolledBack := provider.handoffAllowed[1001]
+	provider.mu.Unlock()
+
+	require.True(t, stillArmed, "fence must stay armed while B is still in flight")
+	require.True(t, bStillAllowed, "B's segment must survive A's rollback")
+	require.False(t, aRolledBack, "A's own segment must be undone")
+
+	// An unrelated segment must still be rejected while the fence is armed.
+	require.False(t, provider.acquireLease(3003), "unrelated segment must not get a lease mid-handoff")
+
+	close(bRelease)
+	require.NoError(t, <-bDone)
+	provider.Close()
 }
 
 // TestDelegatorGrowingSourceProviderKeepsHandoffOnlyWhileHandoffInflight pins the

--- a/internal/querynodev2/delegator/growing_flush_source_test.go
+++ b/internal/querynodev2/delegator/growing_flush_source_test.go
@@ -501,9 +501,111 @@ func TestDelegatorGrowingSourceProviderKeepsHandoffOnlyWhileHandoffInflight(t *t
 	provider.mu.Lock()
 	drained := provider.handoffOnly
 	inflight := provider.handoffInflight
+	handoffAllowed := len(provider.handoffAllowed)
+	releaseAllowed := len(provider.releaseAllowed)
+	releasePrepared := len(provider.releasePrepared)
+	retained := len(provider.retained)
 	provider.mu.Unlock()
 	require.False(t, drained, "handoffOnly should lower once the in-flight handoff finishes and maps are drained")
 	require.Equal(t, 0, inflight)
+	// Assert the maps, not just the fence: a resuming Prepare must not re-create
+	// state for a segment ClearReleasePrepared already retired.
+	require.Equal(t, 0, handoffAllowed, "handoffAllowed must be empty")
+	require.Equal(t, 0, releaseAllowed, "releaseAllowed must not be resurrected")
+	require.Equal(t, 0, releasePrepared, "releasePrepared must not be resurrected")
+	require.Equal(t, 0, retained, "retained must be empty")
+	require.True(t, provider.acquireLease(3003), "an unrelated segment must be servable once drained")
+	provider.releaseLease()
+}
+
+// TestDelegatorGrowingSourceProviderRetiredSegmentIsNotResurrected is the
+// TargetOffset>0 counterpart of the test above. A Prepare parked in waitFence must
+// not re-register a retained entry -- and with it a segment pin -- for a segment
+// ClearReleasePrepared retired while it was parked; nothing would ever detach it.
+// GetGrowing is allowed but not required: with the fix the resume never reaches
+// registerRetained, and without it the resurrection surfaces as a failed map
+// assertion rather than an unexpected-call panic on a background goroutine.
+func TestDelegatorGrowingSourceProviderRetiredSegmentIsNotResurrected(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(nil).Maybe()
+
+	fenceEntered := make(chan struct{})
+	fenceRelease := make(chan struct{})
+	provider := newDelegatorGrowingSourceProvider(segmentManager, func(ctx context.Context, fenceTs uint64) error {
+		close(fenceEntered)
+		<-fenceRelease
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 100,
+			[]syncmgr.GrowingSourceReleaseHandoffSegment{{SegmentID: 1001, TargetOffset: 5}})
+	}()
+	<-fenceEntered
+
+	provider.ClearReleasePrepared(1001)
+	close(fenceRelease)
+	require.NoError(t, <-done)
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	require.Empty(t, provider.retained, "no retained entry may be created for a retired segment")
+	require.Empty(t, provider.releaseAllowed, "releaseAllowed must not be resurrected")
+	require.Empty(t, provider.releasePrepared, "releasePrepared must not be resurrected")
+	require.Empty(t, provider.handoffAllowed)
+	require.False(t, provider.handoffOnly)
+}
+
+// TestDelegatorGrowingSourceProviderDeactivatedDuringFence covers Deactivate landing
+// while a Prepare is parked. Resuming into the active path would register a retained
+// entry, and a segment pin, on a deactivated provider -- nothing detaches it, so
+// unregisterIfInactiveLocked could never fire again. No GetGrowing expectation is
+// set, so reaching registerRetained fails the test.
+func TestDelegatorGrowingSourceProviderDeactivatedDuringFence(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+
+	fenceEntered := make(chan struct{})
+	fenceRelease := make(chan struct{})
+	provider := newDelegatorGrowingSourceProvider(segmentManager, func(ctx context.Context, fenceTs uint64) error {
+		close(fenceEntered)
+		<-fenceRelease
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 100,
+			[]syncmgr.GrowingSourceReleaseHandoffSegment{{SegmentID: 1001, TargetOffset: 5}})
+	}()
+	<-fenceEntered
+
+	provider.Deactivate()
+	close(fenceRelease)
+	require.NoError(t, <-done)
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	require.Empty(t, provider.retained, "no retained entry may be created on a deactivated provider")
+	require.Empty(t, provider.handoffAllowed)
+}
+
+// TestDelegatorGrowingSourceProviderDuplicateSegmentRollback pins that a rollback
+// returns exactly as many references as its call took. While the snapshot was a
+// set, passing one segment twice took two references and gave back one, pinning
+// handoffOnly until some unrelated ClearReleasePrepared wiped the entry. Both
+// production callers dedup today, so this guards the invariant structurally
+// rather than fixing a reachable bug.
+func TestDelegatorGrowingSourceProviderDuplicateSegmentRollback(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+	provider := newDelegatorGrowingSourceProvider(segmentManager, nil)
+
+	provider.BeginGrowingSourceReleaseHandoff([]int64{1001, 1001})()
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	require.Empty(t, provider.handoffAllowed, "both references must be returned")
+	require.False(t, provider.handoffOnly, "the fence must lower once the last reference is returned")
 }
 
 func TestDelegatorGrowingSourceProviderDeactivatedOnlyServesRetainedSources(t *testing.T) {


### PR DESCRIPTION
issue: #51635

## What this PR changes

After a release manual-flush handoff clears the last prepared segment, the querynode growing-source provider now exits `handoffOnly` mode when there are no retained sources and no allowed handoff segment IDs left.

This prevents a still-active provider from rejecting later growing-source flush requests for unrelated segments before checking `SegmentManager.GetGrowing`.

## Verification

- Added `TestDelegatorGrowingSourceProviderClearsHandoffOnlyAfterReleasePrepared`.
- Repro before fix failed with `GrowingSourceUnavailable` and an unmet `GetGrowing` mock expectation.
- After fix:
  - `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator -run TestDelegatorGrowingSourceProviderClearsHandoffOnlyAfterReleasePrepared`
  - `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator`
  - `make static-check`

## Notes

The static-check worktree required regenerating ignored local `cmd/tools/migration/legacy/legacypb` output for analysis only; it is not part of this PR.
