### PR TITLE
fix: accept empty-list expression template parameters

### DIFF
--- a/internal/parser/planparserv2/convert_field_data_to_generic_value.go
+++ b/internal/parser/planparserv2/convert_field_data_to_generic_value.go
@@ -90,6 +90,15 @@ func convertArrayValue(templateName string, templateValue *schemapb.TemplateArra
 			arrayValues[i] = parsedValue
 		}
 		elementType = schemapb.DataType_JSON
+	case nil:
+		// An empty list carries no typed elements, so the TemplateArrayValue's
+		// data oneof is left unset and GetData() is nil. Mirror the inline `[]`
+		// literal (ParserVisitor.VisitEmptyArray): an empty, same-type array
+		// with an unknown (None) element type. This keeps parameterized empty
+		// lists behaving identically to inline ones across IN / NOT IN,
+		// array_contains_*, and json_contains_*. See issue #51617.
+		arrayValues = nil
+		elementType = schemapb.DataType_None
 	default:
 		return nil, merr.WrapErrQueryPlanMsg("unknown template variable value type: %v", templateValue.GetData())
 	}

--- a/internal/parser/planparserv2/convert_field_data_to_generic_value_test.go
+++ b/internal/parser/planparserv2/convert_field_data_to_generic_value_test.go
@@ -183,6 +183,36 @@ func Test_ConvertToGenericValue(t *testing.T) {
 	}
 }
 
+// Test_ConvertToGenericValue_EmptyArray verifies that an empty-list template
+// parameter (a TemplateArrayValue whose typed data oneof is unset, which is how
+// an empty list is encoded on the wire) converts to the same empty-array
+// GenericValue produced for the inline `[]` literal by
+// ParserVisitor.VisitEmptyArray: an empty, same-type array with an unknown
+// (None) element type. See issue #51617.
+func Test_ConvertToGenericValue_EmptyArray(t *testing.T) {
+	input := map[string]*schemapb.TemplateValue{
+		"empty": {
+			Val: &schemapb.TemplateValue_ArrayVal{
+				ArrayVal: &schemapb.TemplateArrayValue{},
+			},
+		},
+	}
+	expect := map[string]*planpb.GenericValue{
+		"empty": {
+			Val: &planpb.GenericValue_ArrayVal{
+				ArrayVal: &planpb.Array{
+					Array:       nil,
+					SameType:    true,
+					ElementType: schemapb.DataType_None,
+				},
+			},
+		},
+	}
+	output, err := UnmarshalExpressionValues(input)
+	assert.Nil(t, err)
+	assert.EqualValues(t, expect, output)
+}
+
 func generateTemplateValue(dataType schemapb.DataType, data interface{}) *schemapb.TemplateValue {
 	switch dataType {
 	case schemapb.DataType_Bool:

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
@@ -70,6 +71,11 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 				"list": generateTemplateValue(schemapb.DataType_Array,
 					generateTemplateArrayValue(schemapb.DataType_Int64, []int64{int64(1), int64(2), int64(3)})),
 			}},
+			// An empty-list template parameter is valid and behaves like the
+			// inline `[]` literal. See issue #51617.
+			{`Int64Field in {empty_list}`, map[string]*schemapb.TemplateValue{
+				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+			}},
 		}
 		schemaH := newTestSchemaHelper(s.T())
 		for _, c := range testcases {
@@ -105,9 +111,6 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 			}},
 			{"Int64Field not in {not_list}", map[string]*schemapb.TemplateValue{
 				"age": generateTemplateValue(schemapb.DataType_Int64, int64(33)),
-			}},
-			{`Int64Field in {empty_list}`, map[string]*schemapb.TemplateValue{
-				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
 			}},
 		}
 
@@ -1092,6 +1095,120 @@ func (s *FillExpressionValueSuite) TestUnaryNotWithTemplate() {
 			s.NoError(err, c.templExpr)
 			s.NotNil(expr)
 			s.assertNoUnfilledPlaceholder(expr)
+		})
+	}
+}
+
+// templateFilledValueCount returns the number of concrete values a filled
+// term / json-contains expression holds, and whether the expression is one of
+// those list-bearing kinds.
+func templateFilledValueCount(expr *planpb.Expr) (int, bool) {
+	switch e := expr.GetExpr().(type) {
+	case *planpb.Expr_TermExpr:
+		return len(e.TermExpr.GetValues()), true
+	case *planpb.Expr_JsonContainsExpr:
+		return len(e.JsonContainsExpr.GetElements()), true
+	case *planpb.Expr_UnaryExpr:
+		// `NOT IN` wraps the term in a logical-NOT unary expression.
+		return templateFilledValueCount(e.UnaryExpr.GetChild())
+	default:
+		return 0, false
+	}
+}
+
+// TestEmptyListTemplate covers issue #51617: an empty-list expression template
+// parameter must be accepted and behave exactly like its inline `[]` literal
+// across every list-consuming operation (IN / NOT IN, array_contains_all /
+// array_contains_any, json_contains_all / json_contains_any). Before the fix
+// the empty list failed plan creation with
+// "unknown template variable value type: <nil>".
+func (s *FillExpressionValueSuite) TestEmptyListTemplate() {
+	schemaH := newTestSchemaHelper(s.T())
+	emptyList := func() map[string]*schemapb.TemplateValue {
+		return map[string]*schemapb.TemplateValue{
+			"v": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+		}
+	}
+	cases := []struct {
+		templateExpr string
+		inlineExpr   string
+	}{
+		{`Int64Field in {v}`, `Int64Field in []`},
+		{`Int64Field not in {v}`, `Int64Field not in []`},
+		{`array_contains_all(ArrayField, {v})`, `array_contains_all(ArrayField, [])`},
+		{`array_contains_any(ArrayField, {v})`, `array_contains_any(ArrayField, [])`},
+		{`json_contains_all(JSONField, {v})`, `json_contains_all(JSONField, [])`},
+		{`json_contains_any(JSONField, {v})`, `json_contains_any(JSONField, [])`},
+	}
+	for _, c := range cases {
+		s.Run(c.templateExpr, func() {
+			tmplExpr, err := ParseExpr(schemaH, c.templateExpr, emptyList())
+			s.NoError(err, c.templateExpr)
+			s.NotNil(tmplExpr, c.templateExpr)
+
+			inlineExpr, err := ParseExpr(schemaH, c.inlineExpr, nil)
+			s.NoError(err, c.inlineExpr)
+			s.NotNil(inlineExpr, c.inlineExpr)
+
+			// The filled template plan must carry no concrete values, exactly
+			// like the inline empty-list literal.
+			tmplCount, ok := templateFilledValueCount(tmplExpr)
+			s.True(ok, "unexpected expr kind for %s", c.templateExpr)
+			s.Equal(0, tmplCount, "empty-list template %s should fill to zero values", c.templateExpr)
+
+			inlineCount, _ := templateFilledValueCount(inlineExpr)
+			s.Equal(inlineCount, tmplCount, "template %s and inline %s must agree on value count",
+				c.templateExpr, c.inlineExpr)
+		})
+	}
+}
+
+// TestEmptyListTemplateEqualsInline is a stricter check that the filled plan for
+// an empty-list template is structurally identical to the inline `[]` plan once
+// the residual template-variable name (the only expected difference) is cleared.
+func (s *FillExpressionValueSuite) TestEmptyListTemplateEqualsInline() {
+	schemaH := newTestSchemaHelper(s.T())
+	// normalize clears the fields that legitimately differ between a filled
+	// template plan and its inline equivalent and have no effect for an empty
+	// element list: the residual template-variable name, the is-template
+	// bookkeeping flag, and the elements-same-type hint (irrelevant with zero
+	// elements). Everything else — column info, operator, (empty) elements —
+	// must match.
+	normalize := func(expr *planpb.Expr) {
+		expr.IsTemplate = false
+		switch e := expr.GetExpr().(type) {
+		case *planpb.Expr_TermExpr:
+			e.TermExpr.TemplateVariableName = ""
+		case *planpb.Expr_JsonContainsExpr:
+			e.JsonContainsExpr.TemplateVariableName = ""
+			e.JsonContainsExpr.ElementsSameType = false
+		}
+	}
+	cases := []struct {
+		templateExpr string
+		inlineExpr   string
+	}{
+		{`Int64Field in {v}`, `Int64Field in []`},
+		{`array_contains_all(ArrayField, {v})`, `array_contains_all(ArrayField, [])`},
+		{`json_contains_any(JSONField, {v})`, `json_contains_any(JSONField, [])`},
+	}
+	for _, c := range cases {
+		s.Run(c.templateExpr, func() {
+			tmplExpr, err := ParseExpr(schemaH, c.templateExpr, map[string]*schemapb.TemplateValue{
+				"v": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+			})
+			s.NoError(err, c.templateExpr)
+			s.NotNil(tmplExpr, c.templateExpr)
+
+			inlineExpr, err := ParseExpr(schemaH, c.inlineExpr, nil)
+			s.NoError(err, c.inlineExpr)
+			s.NotNil(inlineExpr, c.inlineExpr)
+
+			normalize(tmplExpr)
+			normalize(inlineExpr)
+			s.True(proto.Equal(tmplExpr, inlineExpr),
+				"empty-list template %s should equal inline %s\n got:  %v\n want: %v",
+				c.templateExpr, c.inlineExpr, tmplExpr, inlineExpr)
 		})
 	}
 }


### PR DESCRIPTION
## What & why

An empty-list expression template parameter — e.g.

```python
filter="array_contains_all(tags, {tags})"
filter_params={"tags": []}
```

— failed plan creation with `unknown template variable value type: <nil>`, while the equivalent inline literal `array_contains_all(tags, [])` succeeded.

Root cause: an empty list is encoded on the wire as a `TemplateArrayValue` whose typed `data` oneof is left unset, so `GetData()` is `nil`. `convertArrayValue` had no case for that and fell through to the `default` error branch.

Per the reporter this affects `IN` / `NOT IN`, `array_contains_all` / `array_contains_any` and `json_contains_all` / `json_contains_any`, across query, search, hybrid search and delete, on both gRPC and REST. All of these funnel through this single conversion point.

## Fix

Handle the unset (empty-list) case explicitly, mirroring the inline `[]` literal produced by `ParserVisitor.VisitEmptyArray`: an empty, same-type array with an unknown (`None`) element type. Parameterized empty lists now build the same plan as their inline equivalents.

## Tests

- `Test_ConvertToGenericValue_EmptyArray`: the conversion output for an empty template list matches the inline `[]` `GenericValue` exactly.
- `TestEmptyListTemplate`: for all six operations, the empty-list template now parses without error and fills to zero values, agreeing with the inline form.
- `TestEmptyListTemplateEqualsInline`: filled template plans are structurally identical to their inline `[]` plans (ignoring the template-only bookkeeping fields, which are inert for an empty list).
- Moved the previously "expected to fail" `Int64Field in {empty_list}` case into the valid set.

## Verification scope

Verified at the plan-parser (Go) level via the unit tests above; end-to-end query/search on a running cluster was **not** exercised in this environment.

issue: #51617