### PR TITLE
fix: fail stale schema reopen instead of silent success

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -150,8 +150,7 @@
 namespace milvus::segcore {
 using namespace milvus::cachinglayer;
 
-constexpr auto kCollectionSchemaVersionNotReady =
-    static_cast<ErrorCode>(2046);
+constexpr auto kCollectionSchemaVersionNotReady = static_cast<ErrorCode>(2046);
 
 static std::string
 FormatFieldIds(const std::vector<FieldId>& field_ids) {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -150,6 +150,9 @@
 namespace milvus::segcore {
 using namespace milvus::cachinglayer;
 
+constexpr auto kCollectionSchemaVersionNotReady =
+    static_cast<ErrorCode>(2046);
+
 static std::string
 FormatFieldIds(const std::vector<FieldId>& field_ids) {
     std::vector<int64_t> ids;
@@ -7293,13 +7296,12 @@ ChunkedSegmentSealedImpl::Reopen(
     auto current_schema = current->schema;
     if (new_schema && new_schema->get_schema_version() <
                           current_schema->get_schema_version()) {
-        LOG_WARN(
-            "Skip stale reopen segment {}, current schema version {}, incoming "
-            "schema version {}",
-            id_,
-            current_schema->get_schema_version(),
-            new_schema->get_schema_version());
-        return;
+        ThrowInfo(kCollectionSchemaVersionNotReady,
+                  "stale reopen segment {}, current schema version {}, "
+                  "incoming schema version {}",
+                  id_,
+                  current_schema->get_schema_version(),
+                  new_schema->get_schema_version());
     }
 
     auto target_schema = new_schema ? std::move(new_schema) : current_schema;

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -3965,7 +3965,12 @@ TEST(SealedSegmentReopen, SchemaAwareReopenDiscardsOlderSchema) {
     proto::segcore::SegmentLoadInfo stale_proto =
         sealed->TestGetSegmentLoadInfo()->GetProto();
     milvus::OpContext op_ctx;
-    EXPECT_NO_THROW(sealed->Reopen(&op_ctx, stale_proto, stale_schema));
+    try {
+        sealed->Reopen(&op_ctx, stale_proto, stale_schema);
+        FAIL() << "stale reopen should fail";
+    } catch (SegcoreError& err) {
+        EXPECT_EQ(err.get_error_code(), static_cast<ErrorCode>(2046));
+    }
 
     auto snapshot = sealed->TestGetLoadInfoSnapshot();
     EXPECT_TRUE(snapshot->HasFieldInSchema(new_field));

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -843,6 +844,53 @@ func TestLocalSegmentReopenUsesSegcoreSchemaVersion(t *testing.T) {
 	}
 
 	assert.NoError(t, segment.Reopen(context.Background(), loadInfo))
+}
+
+func TestLocalSegmentReopenErrorDoesNotAdvanceLoadInfo(t *testing.T) {
+	paramtable.Init()
+
+	schema := mock_segcore.GenTestCollectionSchema("collection_v1", schemapb.DataType_Int64, false)
+	schema.Version = 1
+
+	collection := &Collection{}
+	collection.setSchema(schema, 1, 100, 101)
+
+	csegment := mock_segcore.NewMockCSegment(t)
+	csegment.EXPECT().
+		Reopen(mock.Anything, mock.AnythingOfType("*segcore.ReopenRequest")).
+		Return(merr.WrapErrCollectionSchemaVersionNotReady("collection_v1", 0, 1))
+
+	oldLoadInfo := &querypb.SegmentLoadInfo{
+		CollectionID:  10,
+		SegmentID:     20,
+		PartitionID:   30,
+		InsertChannel: "by-dev-rootcoord-dml_0_10v0",
+		DataVersion:   1,
+	}
+	newLoadInfo := &querypb.SegmentLoadInfo{
+		CollectionID:  oldLoadInfo.GetCollectionID(),
+		SegmentID:     oldLoadInfo.GetSegmentID(),
+		PartitionID:   oldLoadInfo.GetPartitionID(),
+		InsertChannel: oldLoadInfo.GetInsertChannel(),
+		DataVersion:   2,
+	}
+	segment := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:         collection,
+			loadInfo:           atomic.NewPointer(oldLoadInfo),
+			version:            atomic.NewInt64(0),
+			resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+			needUpdatedVersion: atomic.NewInt64(0),
+		},
+		ptrLock:        state.NewLoadStateLock(state.LoadStateDataLoaded),
+		csegment:       csegment,
+		fieldIndexes:   typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
+		fieldJSONStats: make(map[int64]*querypb.JsonStatsInfo),
+	}
+
+	err := segment.Reopen(context.Background(), newLoadInfo)
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaVersionNotReady)
+	assert.Equal(t, int32(1), segment.LoadInfo().GetDataVersion())
 }
 
 // TestBaseSegment_SkipGrowingBF tests that skipGrowingBF bypasses PK candidate checks.

--- a/pkg/util/merr/segcore.go
+++ b/pkg/util/merr/segcore.go
@@ -83,11 +83,12 @@ var segcoreCodeTable = map[int32]segcoreClass{
 	// pretend-finished code is C++ ClusterSkip 2033. Keep generic so a failed
 	// build retries instead of being reported as JobStateFinished.
 	2002: {sentinel: ErrSegcore},
-	2037: {sentinel: ErrSegcoreFollyOtherException, retriable: true}, // FollyOtherException (folly async failure; retry/reroute)
-	2038: {sentinel: ErrSegcoreFollyCancel},                          // FollyCancel (cancellation; not a pretend-finished signal — sentinel identity preserved, scheduler retries)
-	2039: {sentinel: ErrSegcoreOutOfRange},                           // OutOfRange (internal bounds bug, not a signal)
-	2040: {sentinel: ErrSegcoreGCPNativeError, retriable: true},      // GcpNativeError (object storage; transient)
-	2099: {sentinel: KnowhereError},                                  // KnowhereError
+	2037: {sentinel: ErrSegcoreFollyOtherException, retriable: true},      // FollyOtherException (folly async failure; retry/reroute)
+	2038: {sentinel: ErrSegcoreFollyCancel},                               // FollyCancel (cancellation; not a pretend-finished signal — sentinel identity preserved, scheduler retries)
+	2039: {sentinel: ErrSegcoreOutOfRange},                                // OutOfRange (internal bounds bug, not a signal)
+	2040: {sentinel: ErrSegcoreGCPNativeError, retriable: true},           // GcpNativeError (object storage; transient)
+	2046: {sentinel: ErrCollectionSchemaVersionNotReady, retriable: true}, // CollectionSchemaVersionNotReady (stale QueryNode schema snapshot; retry with fresh schema)
+	2099: {sentinel: KnowhereError},                                       // KnowhereError
 
 	// Wrapper-path special cases (preserve existing errors.Is behavior that
 	// datanode/index/scheduler.go relies on):
@@ -143,6 +144,8 @@ var segcoreCodeTable = map[int32]segcoreClass{
 	2030: {sentinel: ErrSegcore},                   // UnistdError: syscall failure
 	2035: {sentinel: ErrSegcore},                   // MemAllocateSizeNotMatch: size logic bug (not OOM)
 	2041: {sentinel: ErrSegcore},                   // TextIndexNotFound
+	2044: {sentinel: ErrSegcore},                   // StorageError: permanent storage fallback
+	2045: {sentinel: ErrSegcore, retriable: true},  // StorageTransientError: transient storage fallback
 }
 
 // classifySegcoreError converts a C++ segcore error code + message into a

--- a/pkg/util/merr/segcore_test.go
+++ b/pkg/util/merr/segcore_test.go
@@ -70,6 +70,7 @@ func TestSegcoreErrorClassification(t *testing.T) {
 	t.Run("named_sentinels", func(t *testing.T) {
 		assert.ErrorIs(t, SegcoreError(2038, "x"), ErrSegcoreFollyCancel)
 		assert.ErrorIs(t, SegcoreError(2039, "x"), ErrSegcoreOutOfRange)
+		assert.ErrorIs(t, SegcoreError(2046, "x"), ErrCollectionSchemaVersionNotReady)
 		assert.ErrorIs(t, SegcoreError(2099, "x"), KnowhereError)
 	})
 
@@ -174,13 +175,14 @@ func TestSegcoreCodeTableCoverage(t *testing.T) {
 		2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2009, 2010, 2011,
 		2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022,
 		2023, 2024, 2025, 2026, 2027, 2028, 2030, 2031, 2032, 2033, 2034,
-		2035, 2036, 2037, 2038, 2039, 2040, 2041, 2042, 2043, 2099,
+		2035, 2036, 2037, 2038, 2039, 2040, 2041, 2042, 2043, 2044, 2045,
+		2046, 2099,
 	}
 
 	// Regression guard: the codes we classified on purpose must stay registered
 	// with the intended property.
 	wantInput := []int32{2007, 2020, 2021, 2022, 2023, 2025, 2026, 2028, 2031, 2032, 2042}
-	wantRetriable := []int32{2012, 2013, 2014, 2015, 2018, 2027, 2034, 2036, 2037, 2040, 2043}
+	wantRetriable := []int32{2012, 2013, 2014, 2015, 2018, 2027, 2034, 2036, 2037, 2040, 2043, 2045, 2046}
 	for _, c := range wantInput {
 		cls, ok := segcoreCodeTable[c]
 		assert.True(t, ok && cls.inputError, "code %d must stay registered as inputError", c)


### PR DESCRIPTION
Related to #51068

Stale schema reopen used to return success from segcore, which let the Go caller update LocalSegment loadInfo even though the core state was not reopened. Return a retriable schema-version error instead so QueryCoord can retry with a fresh schema.

Map the new segcore code to ErrCollectionSchemaVersionNotReady and add tests for both the C++ stale reopen path and the Go-side loadInfo guard.