### PR TITLE
enhance: use inverted index for LIKE match

### DIFF
--- a/internal/core/src/common/RegexQueryTest.cpp
+++ b/internal/core/src/common/RegexQueryTest.cpp
@@ -468,9 +468,8 @@ TEST_F(SealedSegmentRegexQueryTest, InnerMatchOnInvertedIndexStringField) {
     ASSERT_TRUE(final[4]);
 }
 
-TEST_F(SealedSegmentRegexQueryTest,
-       MatchQueryFallsBackToRawDataWithInvertedIndex) {
-    std::string operand = "a%b%";
+TEST_F(SealedSegmentRegexQueryTest, RegexQueryOnInvertedIndexStringField) {
+    std::string operand = "a%";
     const auto& str_meta = schema->operator[](FieldName("str"));
     auto column_info = test::GenColumnInfo(str_meta.get_id().get(),
                                            proto::schema::DataType::VarChar,
@@ -492,8 +491,8 @@ TEST_F(SealedSegmentRegexQueryTest,
     BitsetType final;
     final = ExecuteQueryExpr(parsed, segpromote, N, MAX_TIMESTAMP);
     ASSERT_FALSE(final[0]);
-    ASSERT_FALSE(final[1]);
-    ASSERT_FALSE(final[2]);
+    ASSERT_TRUE(final[1]);
+    ASSERT_TRUE(final[2]);
     ASSERT_TRUE(final[3]);
     ASSERT_TRUE(final[4]);
 }

--- a/internal/core/src/index/InvertedIndexTantivy.h
+++ b/internal/core/src/index/InvertedIndexTantivy.h
@@ -289,14 +289,13 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
 
     bool
     ShouldUseOp(proto::plan::OpType op) const override {
-        // Generic LIKE, suffix/contains LIKE, and regex can be executed
-        // correctly over indexed terms, but for short varchar values they are
-        // often slower than raw scan. Keep only prefix matching on the
-        // inverted-index path.
+        // Suffix/contains LIKE and regex can be executed correctly over indexed
+        // terms, but for short varchar values they are often slower than raw
+        // scan. Keep only prefix/LIKE Match on the inverted-index path.
         switch (op) {
+            case proto::plan::OpType::Match:
             case proto::plan::OpType::PrefixMatch:
                 return SupportPatternMatch() || HasRawData();
-            case proto::plan::OpType::Match:
             case proto::plan::OpType::RegexMatch:
             case proto::plan::OpType::PostfixMatch:
             case proto::plan::OpType::InnerMatch:

--- a/internal/core/src/index/InvertedIndexTest.cpp
+++ b/internal/core/src/index/InvertedIndexTest.cpp
@@ -83,7 +83,7 @@ TEST(InvertedIndex, PatternMatchPlannerPolicy) {
     EXPECT_TRUE(index.ShouldUseOp(proto::plan::OpType::PrefixMatch));
     EXPECT_FALSE(index.ShouldUseOp(proto::plan::OpType::RegexMatch));
     EXPECT_TRUE(index.ShouldUseOp(proto::plan::OpType::Equal));
-    EXPECT_FALSE(index.ShouldUseOp(proto::plan::OpType::Match));
+    EXPECT_TRUE(index.ShouldUseOp(proto::plan::OpType::Match));
     EXPECT_FALSE(index.ShouldUseOp(proto::plan::OpType::InnerMatch));
     EXPECT_FALSE(index.ShouldUseOp(proto::plan::OpType::PostfixMatch));
 


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/51477

## Summary
Route generic LIKE Match operations through the varchar inverted index again instead of falling back to raw-data scan.