### PR TITLE
fix: [cp 3.0] flush schema-change alter collection

### DIFF
--- a/docs/agent_guides/streaming-system/message/message-semantic-collection.md
+++ b/docs/agent_guides/streaming-system/message/message-semantic-collection.md
@@ -8,7 +8,7 @@ All broadcast messages implicitly carry **SharedCluster** via the Broadcaster.
 |---------|----------|-------------------|-------------|
 | CreateCollection | Broadcast: VChannels + CChannel | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
 | DropCollection | Broadcast: VChannels + CChannel | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
-| AlterCollection | Broadcast: VChannels + CChannel | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
+| AlterCollection | Broadcast: VChannels + CChannel (AckSyncUp) | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
 | TruncateCollection | Broadcast: VChannels + CChannel (AckSyncUp) | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
 | CreatePartition | Broadcast: VChannels + CChannel | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
 | DropPartition | Broadcast: VChannels + CChannel | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
@@ -34,7 +34,7 @@ All broadcast messages implicitly carry **SharedCluster** via the Broadcaster.
 
 - **CreateCollection**: Creates a new collection with its partitions and VChannels.
 - **DropCollection**: Drops a collection and all its data, indexes, and load config. Implicitly flushes all growing segments.
-- **AlterCollection**: Alters collection properties, description, consistency level, or schema. Schema changes implicitly flush growing segments. When used for **RenameCollection**, the ResourceKey changes to `ExclusiveDBName(srcDB) + ExclusiveDBName(dstDB)` (deduplicated if same DB), blocking all collection DDL in both databases.
+- **AlterCollection**: Alters collection properties, description, consistency level, or schema. Uses AckSyncUp. Schema changes implicitly flush growing segments and wait for channel checkpoints to reach the schema-change timestamp before RootCoord applies the metadata update. When used for **RenameCollection**, the ResourceKey changes to `ExclusiveDBName(srcDB) + ExclusiveDBName(dstDB)` (deduplicated if same DB), blocking all collection DDL in both databases.
 - **TruncateCollection**: Logically truncates by sealing and dropping all segments before the truncation timestamp. Implicitly flushes all growing segments. Uses AckSyncUp.
 - **CreatePartition** / **DropPartition**: Creates or drops a partition. DropPartition implicitly flushes the partition's growing segments.
 - **CreateIndex** / **AlterIndex** / **DropIndex**: Manages indexes on a collection's field. CChannel-only.

--- a/docs/agent_guides/streaming-system/message/message-semantic-collection.md
+++ b/docs/agent_guides/streaming-system/message/message-semantic-collection.md
@@ -8,7 +8,7 @@ All broadcast messages implicitly carry **SharedCluster** via the Broadcaster.
 |---------|----------|-------------------|-------------|
 | CreateCollection | Broadcast: VChannels + CChannel | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
 | DropCollection | Broadcast: VChannels + CChannel | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
-| AlterCollection | Broadcast: VChannels + CChannel (AckSyncUp) | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
+| AlterCollection | Broadcast: VChannels + CChannel (schema-change AckSyncUp) | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
 | TruncateCollection | Broadcast: VChannels + CChannel (AckSyncUp) | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
 | CreatePartition | Broadcast: VChannels + CChannel | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
 | DropPartition | Broadcast: VChannels + CChannel | Yes (VChannel) | SharedDBName + ExclusiveCollectionName |
@@ -34,7 +34,7 @@ All broadcast messages implicitly carry **SharedCluster** via the Broadcaster.
 
 - **CreateCollection**: Creates a new collection with its partitions and VChannels.
 - **DropCollection**: Drops a collection and all its data, indexes, and load config. Implicitly flushes all growing segments.
-- **AlterCollection**: Alters collection properties, description, consistency level, or schema. Uses AckSyncUp. Schema changes implicitly flush growing segments and wait for channel checkpoints to reach the schema-change timestamp before RootCoord applies the metadata update. When used for **RenameCollection**, the ResourceKey changes to `ExclusiveDBName(srcDB) + ExclusiveDBName(dstDB)` (deduplicated if same DB), blocking all collection DDL in both databases.
+- **AlterCollection**: Alters collection properties, description, consistency level, or schema. Schema-change alters use AckSyncUp, implicitly flush growing segments, and wait for channel checkpoints to reach the schema-change timestamp before RootCoord applies the metadata update. Non-schema alters, including property-only alters and renames, keep the fast-ack path. When used for **RenameCollection**, the ResourceKey changes to `ExclusiveDBName(srcDB) + ExclusiveDBName(dstDB)` (deduplicated if same DB), blocking all collection DDL in both databases.
 - **TruncateCollection**: Logically truncates by sealing and dropping all segments before the truncation timestamp. Implicitly flushes all growing segments. Uses AckSyncUp.
 - **CreatePartition** / **DropPartition**: Creates or drops a partition. DropPartition implicitly flushes the partition's growing segments.
 - **CreateIndex** / **AlterIndex** / **DropIndex**: Manages indexes on a collection's field. CChannel-only.

--- a/internal/coordinator/mix_coord.go
+++ b/internal/coordinator/mix_coord.go
@@ -1334,6 +1334,11 @@ func (s *mixCoordImpl) DropSegmentsByTime(ctx context.Context, collectionID int6
 	return s.datacoordServer.DropSegmentsByTime(ctx, collectionID, flushTsList)
 }
 
+// WaitForChannelCheckpoint waits for channel checkpoints without mutating segment state.
+func (s *mixCoordImpl) WaitForChannelCheckpoint(ctx context.Context, flushTsList map[string]uint64) error {
+	return s.datacoordServer.WaitForChannelCheckpoint(ctx, flushTsList)
+}
+
 // ManualUpdateCurrentTarget manually update current target for TruncateCollection
 func (s *mixCoordImpl) ManualUpdateCurrentTarget(ctx context.Context, collectionID int64) error {
 	return s.queryCoordServer.ManualUpdateCurrentTarget(ctx, collectionID)

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -2751,6 +2751,7 @@ func (m *meta) UpdateChannelCheckpoint(ctx context.Context, vChannel string, pos
 			return err
 		}
 		m.channelCPs.checkpoints[vChannel] = pos
+		m.channelCPs.cond.UnsafeBroadcast()
 		ts, _ := tsoutil.ParseTS(pos.Timestamp)
 		mlog.Info(context.TODO(), "UpdateChannelCheckpoint done",
 			mlog.String("vChannel", vChannel),
@@ -2783,6 +2784,7 @@ func (m *meta) MarkChannelCheckpointDropped(ctx context.Context, channel string)
 	}
 
 	m.channelCPs.checkpoints[channel] = cp
+	m.channelCPs.cond.UnsafeBroadcast()
 
 	metrics.DataCoordCheckpointUnixSeconds.DeleteLabelValues(paramtable.GetStringNodeID(), channel)
 	return nil
@@ -2853,6 +2855,7 @@ func (m *meta) DropChannelCheckpoint(vChannel string) error {
 		return err
 	}
 	delete(m.channelCPs.checkpoints, vChannel)
+	m.channelCPs.cond.UnsafeBroadcast()
 	metrics.DataCoordCheckpointUnixSeconds.DeleteLabelValues(paramtable.GetStringNodeID(), vChannel)
 	mlog.Info(context.TODO(), "DropChannelCheckpoint done", mlog.String("vChannel", vChannel))
 	return nil
@@ -3580,7 +3583,7 @@ func (m *meta) WatchChannelCheckpoint(ctx context.Context, vChannel string, targ
 
 	for {
 		cp, ok := m.channelCPs.checkpoints[vChannel]
-		if ok && cp != nil && cp.GetTimestamp() >= targetTs {
+		if !ok || cp == nil || funcutil.IsDroppedChannelCheckpoint(cp) || cp.GetTimestamp() >= targetTs {
 			m.channelCPs.cond.L.Unlock()
 			return nil
 		}

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -4982,6 +4982,97 @@ func TestChannelCP(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("WatchChannelCheckpointReturnsWhenChannelMissing", func(t *testing.T) {
+		meta, err := newMemoryMeta(t)
+		require.NoError(t, err)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- meta.WatchChannelCheckpoint(context.Background(), mockVChannel, pos.Timestamp)
+		}()
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("watching a missing channel checkpoint should return")
+		}
+	})
+
+	t.Run("WatchChannelCheckpointWakesOnSingleCheckpointUpdate", func(t *testing.T) {
+		meta, err := newMemoryMeta(t)
+		require.NoError(t, err)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- meta.WatchChannelCheckpoint(context.Background(), mockVChannel, pos.Timestamp)
+		}()
+
+		err = meta.UpdateChannelCheckpoint(context.Background(), mockVChannel, pos)
+		require.NoError(t, err)
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("watching channel checkpoint should wake after single checkpoint update")
+		}
+	})
+
+	t.Run("WatchChannelCheckpointWakesOnDropChannelCheckpoint", func(t *testing.T) {
+		meta, err := newMemoryMeta(t)
+		require.NoError(t, err)
+
+		err = meta.UpdateChannelCheckpoint(context.Background(), mockVChannel, &msgpb.MsgPosition{
+			ChannelName: mockVChannel,
+			MsgID:       []byte{1},
+			Timestamp:   pos.Timestamp - 1,
+		})
+		require.NoError(t, err)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- meta.WatchChannelCheckpoint(context.Background(), mockVChannel, pos.Timestamp)
+		}()
+
+		err = meta.DropChannelCheckpoint(mockVChannel)
+		require.NoError(t, err)
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("watching channel checkpoint should wake after checkpoint drop")
+		}
+	})
+
+	t.Run("WatchChannelCheckpointWakesOnMarkChannelCheckpointDropped", func(t *testing.T) {
+		meta, err := newMemoryMeta(t)
+		require.NoError(t, err)
+
+		err = meta.UpdateChannelCheckpoint(context.Background(), mockVChannel, &msgpb.MsgPosition{
+			ChannelName: mockVChannel,
+			MsgID:       []byte{1},
+			Timestamp:   pos.Timestamp - 1,
+		})
+		require.NoError(t, err)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- meta.WatchChannelCheckpoint(context.Background(), mockVChannel, pos.Timestamp)
+		}()
+
+		err = meta.MarkChannelCheckpointDropped(context.Background(), mockVChannel)
+		require.NoError(t, err)
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("watching channel checkpoint should wake after checkpoint marked dropped")
+		}
+	})
+
 	t.Run("TruncateChannelByTime", func(t *testing.T) {
 		meta, err := newMemoryMeta(t)
 		assert.NoError(t, err)

--- a/internal/datacoord/mock_test.go
+++ b/internal/datacoord/mock_test.go
@@ -1033,6 +1033,10 @@ func (s *mockMixCoord) DropSegmentsByTime(ctx context.Context, collectionID int6
 	panic("implement me")
 }
 
+func (s *mockMixCoord) WaitForChannelCheckpoint(ctx context.Context, flushTsList map[string]uint64) error {
+	panic("implement me")
+}
+
 func (s *mockMixCoord) ManualUpdateCurrentTarget(ctx context.Context, collectionID int64) error {
 	panic("implement me")
 }

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -2172,6 +2172,22 @@ func (s *Server) DropSegmentsByTime(ctx context.Context, collectionID int64, flu
 	return nil
 }
 
+// WaitForChannelCheckpoint waits until every channel checkpoint reaches its target timestamp.
+func (s *Server) WaitForChannelCheckpoint(ctx context.Context, flushTsList map[string]uint64) error {
+	if err := merr.CheckHealthy(s.GetStateCode()); err != nil {
+		return err
+	}
+
+	mlog.Info(ctx, "receive WaitForChannelCheckpoint request")
+	for channelName, flushTs := range flushTsList {
+		if err := s.meta.WatchChannelCheckpoint(ctx, channelName, flushTs); err != nil {
+			mlog.Warn(ctx, "WatchChannelCheckpoint failed", mlog.String("channelName", channelName), mlog.Err(err))
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Server) CreateSnapshot(ctx context.Context, req *datapb.CreateSnapshotRequest) (*commonpb.Status, error) {
 	if err := merr.CheckHealthy(s.GetStateCode()); err != nil {
 		return merr.Status(err), nil

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -2346,6 +2346,12 @@ func TestServer_DropSegmentsByTime(t *testing.T) {
 		meta, err := newMemoryMeta(t)
 		assert.NoError(t, err)
 		s.meta = meta
+		err = meta.UpdateChannelCheckpoint(ctx, channelName, &msgpb.MsgPosition{
+			ChannelName: channelName,
+			MsgID:       []byte{0},
+			Timestamp:   flushTs - 1,
+		})
+		assert.NoError(t, err)
 
 		// WatchChannelCheckpoint will wait indefinitely, so we use a context with timeout
 		ctxWithTimeout, cancel := context.WithTimeout(ctx, 100*time.Millisecond)

--- a/internal/mocks/mock_mixcoord.go
+++ b/internal/mocks/mock_mixcoord.go
@@ -3622,6 +3622,53 @@ func (_c *MixCoord_DropSegmentsByTime_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
+// WaitForChannelCheckpoint provides a mock function with given fields: ctx, flushTsList
+func (_m *MixCoord) WaitForChannelCheckpoint(ctx context.Context, flushTsList map[string]uint64) error {
+	ret := _m.Called(ctx, flushTsList)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WaitForChannelCheckpoint")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]uint64) error); ok {
+		r0 = rf(ctx, flushTsList)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MixCoord_WaitForChannelCheckpoint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WaitForChannelCheckpoint'
+type MixCoord_WaitForChannelCheckpoint_Call struct {
+	*mock.Call
+}
+
+// WaitForChannelCheckpoint is a helper method to define mock.On call
+//   - ctx context.Context
+//   - flushTsList map[string]uint64
+func (_e *MixCoord_Expecter) WaitForChannelCheckpoint(ctx interface{}, flushTsList interface{}) *MixCoord_WaitForChannelCheckpoint_Call {
+	return &MixCoord_WaitForChannelCheckpoint_Call{Call: _e.mock.On("WaitForChannelCheckpoint", ctx, flushTsList)}
+}
+
+func (_c *MixCoord_WaitForChannelCheckpoint_Call) Run(run func(ctx context.Context, flushTsList map[string]uint64)) *MixCoord_WaitForChannelCheckpoint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(map[string]uint64))
+	})
+	return _c
+}
+
+func (_c *MixCoord_WaitForChannelCheckpoint_Call) Return(_a0 error) *MixCoord_WaitForChannelCheckpoint_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MixCoord_WaitForChannelCheckpoint_Call) RunAndReturn(run func(context.Context, map[string]uint64) error) *MixCoord_WaitForChannelCheckpoint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DropSnapshot provides a mock function with given fields: _a0, _a1
 func (_m *MixCoord) DropSnapshot(_a0 context.Context, _a1 *datapb.DropSnapshotRequest) (*commonpb.Status, error) {
 	ret := _m.Called(_a0, _a1)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_ack_sync_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_ack_sync_test.go
@@ -34,20 +34,36 @@ func requireAlterCollectionAckSyncUp(t *testing.T, msg message.BroadcastMutableM
 	require.True(t, msg.BroadcastHeader().AckSyncUp)
 }
 
-func expectAlterCollectionAckSyncUpBroadcast(t *testing.T) *mock_broadcaster.MockBroadcastAPI {
+func requireAlterCollectionNoAckSyncUp(t *testing.T, msg message.BroadcastMutableMessage) {
+	t.Helper()
+	require.Equal(t, message.MessageTypeAlterCollection, msg.MessageType())
+	require.False(t, msg.BroadcastHeader().AckSyncUp)
+}
+
+func expectAlterCollectionBroadcast(t *testing.T, requireBroadcast func(*testing.T, message.BroadcastMutableMessage)) *mock_broadcaster.MockBroadcastAPI {
 	t.Helper()
 	bc := mock_broadcaster.NewMockBroadcastAPI(t)
 	bc.EXPECT().Close().Maybe()
 	bc.EXPECT().Broadcast(mock.Anything, mock.Anything).
 		Run(func(_ context.Context, msg message.BroadcastMutableMessage) {
-			requireAlterCollectionAckSyncUp(t, msg)
+			requireBroadcast(t, msg)
 		}).
 		Return(&types.BroadcastAppendResult{}, nil).
 		Once()
 	return bc
 }
 
-func TestAlterCollectionPropertyBroadcastUsesAckSyncUp(t *testing.T) {
+func expectAlterCollectionAckSyncUpBroadcast(t *testing.T) *mock_broadcaster.MockBroadcastAPI {
+	t.Helper()
+	return expectAlterCollectionBroadcast(t, requireAlterCollectionAckSyncUp)
+}
+
+func expectAlterCollectionNoAckSyncUpBroadcast(t *testing.T) *mock_broadcaster.MockBroadcastAPI {
+	t.Helper()
+	return expectAlterCollectionBroadcast(t, requireAlterCollectionNoAckSyncUp)
+}
+
+func TestAlterCollectionPropertyBroadcastSkipsAckSyncUp(t *testing.T) {
 	streaming.SetupNoopWALForTest()
 	defer streaming.SetWALForTest(nil)
 
@@ -62,7 +78,7 @@ func TestAlterCollectionPropertyBroadcastUsesAckSyncUp(t *testing.T) {
 		},
 	}
 
-	bc := expectAlterCollectionAckSyncUpBroadcast(t)
+	bc := expectAlterCollectionNoAckSyncUpBroadcast(t)
 	lockMocker := mockey.Mock((*Core).startBroadcastWithAliasOrCollectionLock).Return(bc, nil).Build()
 	defer lockMocker.UnPatch()
 
@@ -147,7 +163,7 @@ func TestAlterCollectionSchemaBroadcastUsesAckSyncUp(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRenameCollectionBroadcastUsesAckSyncUp(t *testing.T) {
+func TestRenameCollectionBroadcastSkipsAckSyncUp(t *testing.T) {
 	streaming.SetupNoopWALForTest()
 	defer streaming.SetWALForTest(nil)
 
@@ -164,7 +180,7 @@ func TestRenameCollectionBroadcastUsesAckSyncUp(t *testing.T) {
 	meta.EXPECT().ListAliases(mock.Anything, dbName, collectionName, typeutil.MaxTimestamp).Return(nil, nil).Maybe()
 	core := newTestCore(withMeta(meta), withValidMixCoord())
 
-	bc := expectAlterCollectionAckSyncUpBroadcast(t)
+	bc := expectAlterCollectionNoAckSyncUpBroadcast(t)
 	lockMocker := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).
 		To(func(context.Context, ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
 			return bc, nil
@@ -248,7 +264,6 @@ func TestAlterCollectionSchemaAckCallbackWaitsForChannelCheckpoint(t *testing.T)
 
 func TestAlterCollectionNonSchemaAckCallbackSkipsChannelCheckpoint(t *testing.T) {
 	mixCoord := imocks.NewMixCoord(t)
-	mixCoord.EXPECT().WaitForChannelCheckpoint(mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	meta := mockrootcoord.NewIMetaTable(t)
 	meta.EXPECT().AlterCollection(mock.Anything, mock.Anything).Return(nil).Once()

--- a/internal/rootcoord/ddl_callbacks_alter_collection_ack_sync_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_ack_sync_test.go
@@ -1,0 +1,322 @@
+package rootcoord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/distributed/streaming"
+	"github.com/milvus-io/milvus/internal/metastore/model"
+	imocks "github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/mocks/streamingcoord/server/mock_broadcaster"
+	mockrootcoord "github.com/milvus-io/milvus/internal/rootcoord/mocks"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func requireAlterCollectionAckSyncUp(t *testing.T, msg message.BroadcastMutableMessage) {
+	t.Helper()
+	require.Equal(t, message.MessageTypeAlterCollection, msg.MessageType())
+	require.True(t, msg.BroadcastHeader().AckSyncUp)
+}
+
+func expectAlterCollectionAckSyncUpBroadcast(t *testing.T) *mock_broadcaster.MockBroadcastAPI {
+	t.Helper()
+	bc := mock_broadcaster.NewMockBroadcastAPI(t)
+	bc.EXPECT().Close().Maybe()
+	bc.EXPECT().Broadcast(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, msg message.BroadcastMutableMessage) {
+			requireAlterCollectionAckSyncUp(t, msg)
+		}).
+		Return(&types.BroadcastAppendResult{}, nil).
+		Once()
+	return bc
+}
+
+func TestAlterCollectionPropertyBroadcastUsesAckSyncUp(t *testing.T) {
+	streaming.SetupNoopWALForTest()
+	defer streaming.SetWALForTest(nil)
+
+	coll := new(DDLCallbacksCollectionFunctionTestSuite).createTestCollection()
+	core := newTestCore(withValidMixCoord())
+	core.meta = &mockMetaTable{
+		GetCollectionByNameFunc: func(ctx context.Context, collectionName string, ts typeutil.Timestamp, allowUnavailable bool) (*model.Collection, error) {
+			return coll, nil
+		},
+		ListAliasesFunc: func(ctx context.Context, dbName string, collectionName string, ts typeutil.Timestamp) ([]string, error) {
+			return nil, nil
+		},
+	}
+
+	bc := expectAlterCollectionAckSyncUpBroadcast(t)
+	lockMocker := mockey.Mock((*Core).startBroadcastWithAliasOrCollectionLock).Return(bc, nil).Build()
+	defer lockMocker.UnPatch()
+
+	err := core.broadcastAlterCollectionForAlterCollection(context.Background(), &milvuspb.AlterCollectionRequest{
+		DbName:         "test_db",
+		CollectionName: "test_collection",
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.CollectionDescription, Value: "new description"},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestAlterCollectionTTLFieldBroadcastMarksSchemaChange(t *testing.T) {
+	streaming.SetupNoopWALForTest()
+	defer streaming.SetWALForTest(nil)
+
+	coll := new(DDLCallbacksCollectionFunctionTestSuite).createTestCollection()
+	core := newTestCore(withValidMixCoord())
+	core.meta = &mockMetaTable{
+		GetCollectionByNameFunc: func(ctx context.Context, collectionName string, ts typeutil.Timestamp, allowUnavailable bool) (*model.Collection, error) {
+			return coll, nil
+		},
+		ListAliasesFunc: func(ctx context.Context, dbName string, collectionName string, ts typeutil.Timestamp) ([]string, error) {
+			return nil, nil
+		},
+	}
+
+	bc := mock_broadcaster.NewMockBroadcastAPI(t)
+	bc.EXPECT().Close().Maybe()
+	bc.EXPECT().Broadcast(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, msg message.BroadcastMutableMessage) {
+			requireAlterCollectionAckSyncUp(t, msg)
+			alterMsg := message.MustAsBroadcastAlterCollectionMessageV2(msg)
+			paths := alterMsg.Header().GetUpdateMask().GetPaths()
+			require.True(t, funcutil.SliceContain(paths, message.FieldMaskCollectionProperties))
+			require.True(t, funcutil.SliceContain(paths, message.FieldMaskCollectionSchema))
+
+			schema := alterMsg.MustBody().Updates.GetSchema()
+			require.NotNil(t, schema)
+			require.Equal(t, "text_field", common.CloneKeyValuePairs(schema.GetProperties()).ToMap()[common.CollectionTTLFieldKey])
+		}).
+		Return(&types.BroadcastAppendResult{}, nil).
+		Once()
+
+	lockMocker := mockey.Mock((*Core).startBroadcastWithAliasOrCollectionLock).Return(bc, nil).Build()
+	defer lockMocker.UnPatch()
+
+	err := core.broadcastAlterCollectionForAlterCollection(context.Background(), &milvuspb.AlterCollectionRequest{
+		DbName:         "test_db",
+		CollectionName: "test_collection",
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.CollectionTTLFieldKey, Value: "text_field"},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestAlterCollectionSchemaBroadcastUsesAckSyncUp(t *testing.T) {
+	streaming.SetupNoopWALForTest()
+	defer streaming.SetWALForTest(nil)
+
+	ctx := context.Background()
+	dbName := "test_db"
+	collectionName := "test_collection"
+	coll := new(DDLCallbacksCollectionFunctionTestSuite).createTestCollection()
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().GetCollectionByName(mock.Anything, dbName, collectionName, typeutil.MaxTimestamp, mock.Anything).Return(coll, nil).Maybe()
+	meta.EXPECT().ListAliases(mock.Anything, dbName, collectionName, typeutil.MaxTimestamp).Return(nil, nil).Maybe()
+	core := newTestCore(withMeta(meta), withValidMixCoord())
+
+	bc := expectAlterCollectionAckSyncUpBroadcast(t)
+	lockMocker := mockey.Mock((*Core).startBroadcastWithAliasOrCollectionLock).Return(bc, nil).Build()
+	defer lockMocker.UnPatch()
+
+	err := core.broadcastAlterCollectionForAddField(ctx, &milvuspb.AddCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         getFieldSchema("field2"),
+	})
+	require.NoError(t, err)
+}
+
+func TestRenameCollectionBroadcastUsesAckSyncUp(t *testing.T) {
+	streaming.SetupNoopWALForTest()
+	defer streaming.SetWALForTest(nil)
+
+	ctx := context.Background()
+	dbName := "test_db"
+	collectionName := "test_collection"
+	coll := new(DDLCallbacksCollectionFunctionTestSuite).createTestCollection()
+	coll.Name = collectionName
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().CheckIfCollectionRenamable(mock.Anything, dbName, collectionName, dbName, "new_"+collectionName).Return(nil).Once()
+	meta.EXPECT().GetDatabaseByName(mock.Anything, dbName, typeutil.MaxTimestamp).Return(&model.Database{ID: coll.DBID, Name: dbName}, nil).Once()
+	meta.EXPECT().GetCollectionByName(mock.Anything, dbName, collectionName, typeutil.MaxTimestamp, false).Return(coll, nil).Maybe()
+	meta.EXPECT().ListAliases(mock.Anything, dbName, collectionName, typeutil.MaxTimestamp).Return(nil, nil).Maybe()
+	core := newTestCore(withMeta(meta), withValidMixCoord())
+
+	bc := expectAlterCollectionAckSyncUpBroadcast(t)
+	lockMocker := mockey.Mock(broadcast.StartBroadcastWithResourceKeys).
+		To(func(context.Context, ...message.ResourceKey) (broadcaster.BroadcastAPI, error) {
+			return bc, nil
+		}).
+		Build()
+	defer lockMocker.UnPatch()
+
+	err := core.broadcastAlterCollectionForRenameCollection(ctx, &milvuspb.RenameCollectionRequest{
+		DbName:  dbName,
+		OldName: collectionName,
+		NewName: "new_" + collectionName,
+	})
+	require.NoError(t, err)
+}
+
+func TestAlterCollectionFunctionBroadcastUsesAckSyncUp(t *testing.T) {
+	streaming.SetupNoopWALForTest()
+	defer streaming.SetWALForTest(nil)
+
+	suite := new(DDLCallbacksCollectionFunctionTestSuite)
+	oldColl := suite.createTestCollection()
+	newColl := oldColl.Clone()
+	newColl.Description = "changed"
+
+	core := newTestCore(withMeta(&mockMetaTable{
+		GetCollectionByNameFunc: func(ctx context.Context, collectionName string, ts typeutil.Timestamp, allowUnavailable bool) (*model.Collection, error) {
+			return oldColl, nil
+		},
+		ListAliasesFunc: func(ctx context.Context, dbName string, collectionName string, ts typeutil.Timestamp) ([]string, error) {
+			return nil, nil
+		},
+	}))
+
+	bc := expectAlterCollectionAckSyncUpBroadcast(t)
+	err := callAlterCollection(context.Background(), core, bc, oldColl, newColl, "test_db", "test_collection")
+	require.NoError(t, err)
+}
+
+func TestAlterCollectionSchemaAckCallbackWaitsForChannelCheckpoint(t *testing.T) {
+	mixCoord := imocks.NewMixCoord(t)
+	mixCoord.EXPECT().WaitForChannelCheckpoint(mock.Anything, map[string]uint64{
+		"v1": 10,
+		"v2": 20,
+	}).Return(nil).Once()
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterCollection(mock.Anything, mock.Anything).Return(nil).Once()
+
+	core := newTestCore(withMeta(meta), withMixCoord(mixCoord), withValidProxyManager())
+	core.broker = &mockBroker{
+		BroadcastAlteredCollectionFunc: func(ctx context.Context, collectionID UniqueID) error {
+			require.Equal(t, UniqueID(100), collectionID)
+			return nil
+		},
+	}
+	cb := &DDLCallback{Core: core}
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId:     100,
+			UpdateMask:       &fieldmaskpb.FieldMask{Paths: []string{message.FieldMaskCollectionSchema}},
+			CacheExpirations: &message.CacheExpirations{},
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				Schema: &schemapb.CollectionSchema{Name: "test_collection"},
+			},
+		}).
+		WithBroadcast([]string{funcutil.GetControlChannel("test"), "v1", "v2"}).
+		MustBuildBroadcast()
+
+	err := cb.alterCollectionV2AckCallback(context.Background(), message.BroadcastResultAlterCollectionMessageV2{
+		Message: message.MustAsBroadcastAlterCollectionMessageV2(raw),
+		Results: map[string]*message.AppendResult{
+			funcutil.GetControlChannel("test"): {TimeTick: 5},
+			"v1":                               {TimeTick: 10},
+			"v2":                               {TimeTick: 20},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestAlterCollectionNonSchemaAckCallbackSkipsChannelCheckpoint(t *testing.T) {
+	mixCoord := imocks.NewMixCoord(t)
+	mixCoord.EXPECT().WaitForChannelCheckpoint(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	meta := mockrootcoord.NewIMetaTable(t)
+	meta.EXPECT().AlterCollection(mock.Anything, mock.Anything).Return(nil).Once()
+
+	core := newTestCore(withMeta(meta), withMixCoord(mixCoord), withValidProxyManager())
+	core.broker = &mockBroker{
+		BroadcastAlteredCollectionFunc: func(ctx context.Context, collectionID UniqueID) error {
+			require.Equal(t, UniqueID(100), collectionID)
+			return nil
+		},
+	}
+	cb := &DDLCallback{Core: core}
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId:     100,
+			UpdateMask:       &fieldmaskpb.FieldMask{Paths: []string{message.FieldMaskCollectionDescription}},
+			CacheExpirations: &message.CacheExpirations{},
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				Description: "new description",
+			},
+		}).
+		WithBroadcast([]string{funcutil.GetControlChannel("test"), "v1"}).
+		MustBuildBroadcast()
+
+	err := cb.alterCollectionV2AckCallback(context.Background(), message.BroadcastResultAlterCollectionMessageV2{
+		Message: message.MustAsBroadcastAlterCollectionMessageV2(raw),
+		Results: map[string]*message.AppendResult{
+			funcutil.GetControlChannel("test"): {TimeTick: 5},
+			"v1":                               {TimeTick: 10},
+		},
+	})
+	require.NoError(t, err)
+	mixCoord.AssertNotCalled(t, "WaitForChannelCheckpoint", mock.Anything, mock.Anything)
+}
+
+func TestAlterCollectionSchemaAckCallbackPropagatesChannelCheckpointError(t *testing.T) {
+	mixCoord := imocks.NewMixCoord(t)
+	waitErr := merr.WrapErrServiceInternal("wait checkpoint failed")
+	mixCoord.EXPECT().WaitForChannelCheckpoint(mock.Anything, mock.Anything).Return(waitErr).Once()
+
+	meta := mockrootcoord.NewIMetaTable(t)
+
+	core := newTestCore(withMeta(meta), withMixCoord(mixCoord), withValidProxyManager())
+	core.broker = newValidMockBroker()
+	cb := &DDLCallback{Core: core}
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId:     100,
+			UpdateMask:       &fieldmaskpb.FieldMask{Paths: []string{message.FieldMaskCollectionSchema}},
+			CacheExpirations: &message.CacheExpirations{},
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				Schema: &schemapb.CollectionSchema{Name: "test_collection"},
+			},
+		}).
+		WithBroadcast([]string{funcutil.GetControlChannel("test"), "v1"}).
+		MustBuildBroadcast()
+
+	err := cb.alterCollectionV2AckCallback(context.Background(), message.BroadcastResultAlterCollectionMessageV2{
+		Message: message.MustAsBroadcastAlterCollectionMessageV2(raw),
+		Results: map[string]*message.AppendResult{
+			funcutil.GetControlChannel("test"): {TimeTick: 5},
+			"v1":                               {TimeTick: 10},
+		},
+	})
+	require.ErrorIs(t, err, waitErr)
+	meta.AssertNotCalled(t, "AlterCollection", mock.Anything, mock.Anything)
+}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
@@ -115,7 +115,7 @@ func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *mil
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
@@ -100,22 +100,23 @@ func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *mil
 	channels = append(channels, streaming.WAL().ControlChannel())
 	channels = append(channels, coll.VirtualChannelNames...)
 	// broadcast the put collection v2 message.
+	header := &messagespb.AlterCollectionMessageHeader{
+		DbId:         coll.DBID,
+		CollectionId: coll.CollectionID,
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
+		},
+		CacheExpirations: cacheExpirations,
+	}
 	msg := message.NewAlterCollectionMessageBuilderV2().
-		WithHeader(&messagespb.AlterCollectionMessageHeader{
-			DbId:         coll.DBID,
-			CollectionId: coll.CollectionID,
-			UpdateMask: &fieldmaskpb.FieldMask{
-				Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
-			},
-			CacheExpirations: cacheExpirations,
-		}).
+		WithHeader(header).
 		WithBody(&messagespb.AlterCollectionMessageBody{
 			Updates: &messagespb.AlterCollectionMessageUpdates{
 				Schema:     schema,
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_struct_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_struct_field.go
@@ -90,22 +90,23 @@ func (c *Core) broadcastAlterCollectionForAddStructField(ctx context.Context, re
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
 	channels = append(channels, coll.VirtualChannelNames...)
+	header := &messagespb.AlterCollectionMessageHeader{
+		DbId:         coll.DBID,
+		CollectionId: coll.CollectionID,
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
+		},
+		CacheExpirations: cacheExpirations,
+	}
 	msg := message.NewAlterCollectionMessageBuilderV2().
-		WithHeader(&messagespb.AlterCollectionMessageHeader{
-			DbId:         coll.DBID,
-			CollectionId: coll.CollectionID,
-			UpdateMask: &fieldmaskpb.FieldMask{
-				Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
-			},
-			CacheExpirations: cacheExpirations,
-		}).
+		WithHeader(header).
 		WithBody(&messagespb.AlterCollectionMessageBody{
 			Updates: &messagespb.AlterCollectionMessageUpdates{
 				Schema:     schema,
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_struct_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_struct_field.go
@@ -105,7 +105,7 @@ func (c *Core) broadcastAlterCollectionForAddStructField(ctx context.Context, re
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field.go
@@ -166,7 +166,7 @@ func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Con
 	msg := message.NewAlterCollectionMessageBuilderV2().
 		WithHeader(header).
 		WithBody(body).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := broadcastAPI.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field.go
@@ -166,7 +166,7 @@ func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Con
 	msg := message.NewAlterCollectionMessageBuilderV2().
 		WithHeader(header).
 		WithBody(body).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	if _, err := broadcastAPI.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_name.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_name.go
@@ -84,17 +84,18 @@ func (c *Core) broadcastAlterCollectionForRenameCollection(ctx context.Context, 
 		return err
 	}
 
+	header := &message.AlterCollectionMessageHeader{
+		DbId:             coll.DBID,
+		CollectionId:     coll.CollectionID,
+		UpdateMask:       updateMask,
+		CacheExpirations: cacheExpirations,
+	}
 	msg := message.NewAlterCollectionMessageBuilderV2().
-		WithHeader(&message.AlterCollectionMessageHeader{
-			DbId:             coll.DBID,
-			CollectionId:     coll.CollectionID,
-			UpdateMask:       updateMask,
-			CacheExpirations: cacheExpirations,
-		}).
+		WithHeader(header).
 		WithBody(&message.AlterCollectionMessageBody{
 			Updates: updates,
 		}).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err

--- a/internal/rootcoord/ddl_callbacks_alter_collection_name.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_name.go
@@ -94,7 +94,7 @@ func (c *Core) broadcastAlterCollectionForRenameCollection(ctx context.Context, 
 		WithBody(&message.AlterCollectionMessageBody{
 			Updates: updates,
 		}).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -15,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
+	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -24,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/ce"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/messageutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/timestamptz"
@@ -208,7 +210,7 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		WithBody(&messagespb.AlterCollectionMessageBody{
 			Updates: udpates,
 		}).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err
@@ -336,7 +338,7 @@ func (c *Core) broadcastAlterCollectionForAlterDynamicField(ctx context.Context,
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err
@@ -398,7 +400,7 @@ func (c *Core) broadcastDisableDynamicField(ctx context.Context, req *milvuspb.A
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := bc.Broadcast(ctx, msg); err != nil {
 		return err
@@ -453,9 +455,31 @@ func (c *Core) getAlterLoadConfigOfAlterCollection(oldProps []*commonpb.KeyValue
 	}
 }
 
+func waitForAlterCollectionSchemaChangeFlush(ctx context.Context, mixCoord types.MixCoord, result message.BroadcastResultAlterCollectionMessageV2) error {
+	flushTsList := make(map[string]uint64)
+	for vchannel, appendResult := range result.Results {
+		if funcutil.IsControlChannel(vchannel) {
+			continue
+		}
+		flushTsList[vchannel] = appendResult.TimeTick
+	}
+	if len(flushTsList) == 0 {
+		return nil
+	}
+	if err := mixCoord.WaitForChannelCheckpoint(ctx, flushTsList); err != nil {
+		return merr.Wrap(err, "when waiting for alter collection schema change flush")
+	}
+	return nil
+}
+
 func (c *DDLCallback) alterCollectionV2AckCallback(ctx context.Context, result message.BroadcastResultAlterCollectionMessageV2) error {
 	header := result.Message.Header()
 	body := result.Message.MustBody()
+	if messageutil.IsSchemaChange(header) {
+		if err := waitForAlterCollectionSchemaChangeFlush(ctx, c.mixCoord, result); err != nil {
+			return err
+		}
+	}
 	if err := c.meta.AlterCollection(ctx, result); err != nil {
 		if errors.Is(err, errAlterCollectionNotFound) {
 			mlog.Warn(ctx, "alter a non-existent collection, ignore it", mlog.FieldMessage(result.Message))

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -210,7 +210,7 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		WithBody(&messagespb.AlterCollectionMessageBody{
 			Updates: udpates,
 		}).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err
@@ -323,22 +323,23 @@ func (c *Core) broadcastAlterCollectionForAlterDynamicField(ctx context.Context,
 		return err
 	}
 	// broadcast the put collection v2 message.
+	header := &messagespb.AlterCollectionMessageHeader{
+		DbId:         coll.DBID,
+		CollectionId: coll.CollectionID,
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
+		},
+		CacheExpirations: cacheExpirations,
+	}
 	msg := message.NewAlterCollectionMessageBuilderV2().
-		WithHeader(&messagespb.AlterCollectionMessageHeader{
-			DbId:         coll.DBID,
-			CollectionId: coll.CollectionID,
-			UpdateMask: &fieldmaskpb.FieldMask{
-				Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
-			},
-			CacheExpirations: cacheExpirations,
-		}).
+		WithHeader(header).
 		WithBody(&messagespb.AlterCollectionMessageBody{
 			Updates: &messagespb.AlterCollectionMessageUpdates{
 				Schema:     schema,
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err
@@ -381,26 +382,27 @@ func (c *Core) broadcastDisableDynamicField(ctx context.Context, req *milvuspb.A
 	if err != nil {
 		return err
 	}
-	msg := message.NewAlterCollectionMessageBuilderV2().
-		WithHeader(&messagespb.AlterCollectionMessageHeader{
-			DbId:         coll.DBID,
-			CollectionId: coll.CollectionID,
-			UpdateMask: &fieldmaskpb.FieldMask{
-				Paths: []string{
-					message.FieldMaskCollectionSchema,
-					message.FieldMaskCollectionProperties,
-				},
+	header := &messagespb.AlterCollectionMessageHeader{
+		DbId:         coll.DBID,
+		CollectionId: coll.CollectionID,
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{
+				message.FieldMaskCollectionSchema,
+				message.FieldMaskCollectionProperties,
 			},
-			CacheExpirations: cacheExpirations,
-			DroppedFieldIds:  []int64{dynamicFieldID},
-		}).
+		},
+		CacheExpirations: cacheExpirations,
+		DroppedFieldIds:  []int64{dynamicFieldID},
+	}
+	msg := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(header).
 		WithBody(&messagespb.AlterCollectionMessageBody{
 			Updates: &messagespb.AlterCollectionMessageUpdates{
 				Schema:     schema,
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	if _, err := bc.Broadcast(ctx, msg); err != nil {
 		return err
@@ -453,6 +455,13 @@ func (c *Core) getAlterLoadConfigOfAlterCollection(oldProps []*commonpb.KeyValue
 		ReplicaNumber:  int32(newReplicaNumber),
 		ResourceGroups: newResourceGroups,
 	}
+}
+
+func alterCollectionBroadcastOptions(header *messagespb.AlterCollectionMessageHeader) []message.OptBuildBroadcast {
+	if messageutil.IsSchemaChange(header) {
+		return []message.OptBuildBroadcast{message.OptBuildBroadcastAckSyncUp()}
+	}
+	return nil
 }
 
 func waitForAlterCollectionSchemaChangeFlush(ctx context.Context, mixCoord types.MixCoord, result message.BroadcastResultAlterCollectionMessageV2) error {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -178,7 +178,7 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 				BoundFieldIndexes: boundFieldIndexes,
 			},
 		}).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)
@@ -421,7 +421,7 @@ func (c *Core) broadcastAlterCollectionSchemaDrop(ctx context.Context, broadcast
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -162,15 +162,16 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
 	channels = append(channels, coll.VirtualChannelNames...)
+	header := &messagespb.AlterCollectionMessageHeader{
+		DbId:         coll.DBID,
+		CollectionId: coll.CollectionID,
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
+		},
+		CacheExpirations: cacheExpirations,
+	}
 	msg := message.NewAlterCollectionMessageBuilderV2().
-		WithHeader(&messagespb.AlterCollectionMessageHeader{
-			DbId:         coll.DBID,
-			CollectionId: coll.CollectionID,
-			UpdateMask: &fieldmaskpb.FieldMask{
-				Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
-			},
-			CacheExpirations: cacheExpirations,
-		}).
+		WithHeader(header).
 		WithBody(&messagespb.AlterCollectionMessageBody{
 			Updates: &messagespb.AlterCollectionMessageUpdates{
 				Schema:            schema,
@@ -178,7 +179,7 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 				BoundFieldIndexes: boundFieldIndexes,
 			},
 		}).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)
@@ -405,23 +406,24 @@ func (c *Core) broadcastAlterCollectionSchemaDrop(ctx context.Context, broadcast
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
 	channels = append(channels, coll.VirtualChannelNames...)
+	header := &messagespb.AlterCollectionMessageHeader{
+		DbId:         coll.DBID,
+		CollectionId: coll.CollectionID,
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
+		},
+		CacheExpirations: cacheExpirations,
+		DroppedFieldIds:  droppedFieldIds,
+	}
 	msg := message.NewAlterCollectionMessageBuilderV2().
-		WithHeader(&messagespb.AlterCollectionMessageHeader{
-			DbId:         coll.DBID,
-			CollectionId: coll.CollectionID,
-			UpdateMask: &fieldmaskpb.FieldMask{
-				Paths: []string{message.FieldMaskCollectionSchema, message.FieldMaskCollectionProperties},
-			},
-			CacheExpirations: cacheExpirations,
-			DroppedFieldIds:  droppedFieldIds,
-		}).
+		WithHeader(header).
 		WithBody(&messagespb.AlterCollectionMessageBody{
 			Updates: &messagespb.AlterCollectionMessageUpdates{
 				Schema:     schema,
 				Properties: properties,
 			},
 		}).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)

--- a/internal/rootcoord/ddl_callbacks_collection_function.go
+++ b/internal/rootcoord/ddl_callbacks_collection_function.go
@@ -81,7 +81,7 @@ func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.B
 	msg := message.NewAlterCollectionMessageBuilderV2().
 		WithHeader(header).
 		WithBody(body).
-		WithBroadcast(channels).
+		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, newColl.CollectionID, addedFileResourceIds, err)

--- a/internal/rootcoord/ddl_callbacks_collection_function.go
+++ b/internal/rootcoord/ddl_callbacks_collection_function.go
@@ -81,7 +81,7 @@ func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.B
 	msg := message.NewAlterCollectionMessageBuilderV2().
 		WithHeader(header).
 		WithBody(body).
-		WithBroadcast(channels, message.OptBuildBroadcastAckSyncUp()).
+		WithBroadcast(channels, alterCollectionBroadcastOptions(header)...).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, newColl.CollectionID, addedFileResourceIds, err)

--- a/internal/rootcoord/mock_test.go
+++ b/internal/rootcoord/mock_test.go
@@ -750,6 +750,8 @@ func withValidMixCoord() Opt {
 
 	mixc.EXPECT().DropSegmentsByTime(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
+	mixc.EXPECT().WaitForChannelCheckpoint(mock.Anything, mock.Anything).Return(nil).Maybe()
+
 	mixc.EXPECT().ShowLoadCollections(mock.Anything, mock.Anything).Return(
 		&querypb.ShowCollectionsResponse{
 			Status: merr.Status(merr.WrapErrCollectionNotLoaded("test")),

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -137,11 +137,11 @@ func (impl *msgHandlerImpl) HandleSchemaChange(ctx context.Context, msg message.
 
 func (impl *msgHandlerImpl) HandleAlterCollection(ctx context.Context, putCollectionMsg message.ImmutableAlterCollectionMessageV2) error {
 	vchannel := putCollectionMsg.VChannel()
-	if err := impl.wbMgr.SealSegments(context.Background(), vchannel, putCollectionMsg.Header().FlushedSegmentIds); err != nil {
+	if err := impl.wbMgr.SealSegments(ctx, vchannel, putCollectionMsg.Header().FlushedSegmentIds); err != nil {
 		return errors.Wrap(err, "failed to seal segments")
 	}
 	if messageutil.IsSchemaChange(putCollectionMsg.Header()) {
-		if err := impl.wbMgr.FlushChannel(context.Background(), vchannel, putCollectionMsg.TimeTick()); err != nil {
+		if err := impl.wbMgr.FlushChannel(ctx, vchannel, putCollectionMsg.TimeTick()); err != nil {
 			return errors.Wrap(err, "failed to flush channel")
 		}
 	}

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/messageutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 )
@@ -135,7 +136,16 @@ func (impl *msgHandlerImpl) HandleSchemaChange(ctx context.Context, msg message.
 }
 
 func (impl *msgHandlerImpl) HandleAlterCollection(ctx context.Context, putCollectionMsg message.ImmutableAlterCollectionMessageV2) error {
-	return impl.wbMgr.SealSegments(context.Background(), putCollectionMsg.VChannel(), putCollectionMsg.Header().FlushedSegmentIds)
+	vchannel := putCollectionMsg.VChannel()
+	if err := impl.wbMgr.SealSegments(context.Background(), vchannel, putCollectionMsg.Header().FlushedSegmentIds); err != nil {
+		return errors.Wrap(err, "failed to seal segments")
+	}
+	if messageutil.IsSchemaChange(putCollectionMsg.Header()) {
+		if err := impl.wbMgr.FlushChannel(context.Background(), vchannel, putCollectionMsg.TimeTick()); err != nil {
+			return errors.Wrap(err, "failed to flush channel")
+		}
+	}
+	return nil
 }
 
 func (impl *msgHandlerImpl) HandleTruncateCollection(flushMsg message.ImmutableTruncateCollectionMessageV2) error {

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl_test.go
@@ -23,6 +23,9 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 
 	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
 	"github.com/milvus-io/milvus/pkg/v3/mocks/streaming/util/mock_message"
@@ -221,6 +224,39 @@ func TestFlushMsgHandler_HandlSchemaChange(t *testing.T) {
 	wbMgr.EXPECT().SealSegments(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	err = handler.HandleSchemaChange(context.Background(), im)
+	assert.NoError(t, err)
+}
+
+func TestFlushMsgHandler_HandleAlterCollectionSchemaChangeFlushesChannel(t *testing.T) {
+	vchannel := "ch-0"
+	timeTick := uint64(1000)
+
+	msg := message.NewAlterCollectionMessageBuilderV2().
+		WithBroadcast([]string{vchannel}).
+		WithHeader(&message.AlterCollectionMessageHeader{
+			CollectionId:      0,
+			FlushedSegmentIds: []int64{1, 2},
+			UpdateMask:        &fieldmaskpb.FieldMask{Paths: []string{message.FieldMaskCollectionSchema}},
+		}).
+		WithBody(&message.AlterCollectionMessageBody{
+			Updates: &message.AlterCollectionMessageUpdates{
+				Schema: &schemapb.CollectionSchema{Name: "test"},
+			},
+		}).
+		MustBuildBroadcast().
+		WithBroadcastID(1).
+		SplitIntoMutableMessage()[0]
+	msg.WithTimeTick(timeTick)
+
+	msgID := mock_message.NewMockMessageID(t)
+	im := message.MustAsImmutableAlterCollectionMessageV2(msg.IntoImmutableMessage(msgID))
+
+	wbMgr := writebuffer.NewMockBufferManager(t)
+	wbMgr.EXPECT().SealSegments(mock.Anything, vchannel, []int64{1, 2}).Return(nil).Once()
+	wbMgr.EXPECT().FlushChannel(mock.Anything, vchannel, timeTick).Return(nil).Once()
+
+	handler := newMsgHandler(wbMgr)
+	err := handler.HandleAlterCollection(context.Background(), im)
 	assert.NoError(t, err)
 }
 

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl_test.go
@@ -230,6 +230,11 @@ func TestFlushMsgHandler_HandlSchemaChange(t *testing.T) {
 func TestFlushMsgHandler_HandleAlterCollectionSchemaChangeFlushesChannel(t *testing.T) {
 	vchannel := "ch-0"
 	timeTick := uint64(1000)
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "alter-collection")
+	ctxMatcher := mock.MatchedBy(func(ctx context.Context) bool {
+		return ctx.Value(contextKey{}) == "alter-collection"
+	})
 
 	msg := message.NewAlterCollectionMessageBuilderV2().
 		WithBroadcast([]string{vchannel}).
@@ -252,8 +257,38 @@ func TestFlushMsgHandler_HandleAlterCollectionSchemaChangeFlushesChannel(t *test
 	im := message.MustAsImmutableAlterCollectionMessageV2(msg.IntoImmutableMessage(msgID))
 
 	wbMgr := writebuffer.NewMockBufferManager(t)
+	wbMgr.EXPECT().SealSegments(ctxMatcher, vchannel, []int64{1, 2}).Return(nil).Once()
+	wbMgr.EXPECT().FlushChannel(ctxMatcher, vchannel, timeTick).Return(nil).Once()
+
+	handler := newMsgHandler(wbMgr)
+	err := handler.HandleAlterCollection(ctx, im)
+	assert.NoError(t, err)
+}
+
+func TestFlushMsgHandler_HandleAlterCollectionNonSchemaChangeSkipsFlushChannel(t *testing.T) {
+	vchannel := "ch-0"
+	timeTick := uint64(1000)
+
+	msg := message.NewAlterCollectionMessageBuilderV2().
+		WithBroadcast([]string{vchannel}).
+		WithHeader(&message.AlterCollectionMessageHeader{
+			CollectionId:      0,
+			FlushedSegmentIds: []int64{1, 2},
+			UpdateMask:        &fieldmaskpb.FieldMask{Paths: []string{message.FieldMaskCollectionProperties}},
+		}).
+		WithBody(&message.AlterCollectionMessageBody{
+			Updates: &message.AlterCollectionMessageUpdates{},
+		}).
+		MustBuildBroadcast().
+		WithBroadcastID(1).
+		SplitIntoMutableMessage()[0]
+	msg.WithTimeTick(timeTick)
+
+	msgID := mock_message.NewMockMessageID(t)
+	im := message.MustAsImmutableAlterCollectionMessageV2(msg.IntoImmutableMessage(msgID))
+
+	wbMgr := writebuffer.NewMockBufferManager(t)
 	wbMgr.EXPECT().SealSegments(mock.Anything, vchannel, []int64{1, 2}).Return(nil).Once()
-	wbMgr.EXPECT().FlushChannel(mock.Anything, vchannel, timeTick).Return(nil).Once()
 
 	handler := newMsgHandler(wbMgr)
 	err := handler.HandleAlterCollection(context.Background(), im)

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl_test.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
-
 	"github.com/milvus-io/milvus/internal/flushcommon/writebuffer"
 	"github.com/milvus-io/milvus/pkg/v3/mocks/streaming/util/mock_message"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -310,6 +310,8 @@ type MixCoord interface {
 
 	DropSegmentsByTime(ctx context.Context, collectionID int64, flushTsList map[string]uint64) error
 
+	WaitForChannelCheckpoint(ctx context.Context, flushTsList map[string]uint64) error
+
 	ManualUpdateCurrentTarget(ctx context.Context, collectionID int64) error
 }
 


### PR DESCRIPTION
issue: #51655
pr: #51660

- rootcoord: broadcast AlterCollection with AckSyncUp and wait for schema-change vchannel checkpoints before applying metadata
- streamingnode: flush channels for schema-change AlterCollection so pending L0 deletes and sealed L1 segments reach the checkpoint
- datacoord: expose an internal checkpoint wait path backed by WatchChannelCheckpoint