### PR TITLE
fix: [cp3.0] validate struct-array sub-field consistency at import

### DIFF
--- a/internal/datanode/importv2/task_import.go
+++ b/internal/datanode/importv2/task_import.go
@@ -228,6 +228,12 @@ func (t *ImportTask) importFile(reader importutilv2.Reader) error {
 			mlog.Info(t.ctx, "0 row was imported, the data may have been deleted", WrapLogFields(t)...)
 			continue
 		}
+		// the same check has been done in preimport task, double-check here since
+		// the actual import task re-reads the files
+		err = CheckStructArrayConsistency(t.GetSchema(), data)
+		if err != nil {
+			return err
+		}
 		err = AppendSystemFieldsData(t, data, rowNum)
 		if err != nil {
 			return err

--- a/internal/datanode/importv2/task_preimport.go
+++ b/internal/datanode/importv2/task_preimport.go
@@ -212,6 +212,10 @@ func (t *PreImportTask) readFileStat(reader importutilv2.Reader, fileIdx int) er
 		if err != nil {
 			return err
 		}
+		err = CheckStructArrayConsistency(t.GetSchema(), data)
+		if err != nil {
+			return err
+		}
 		rowsCount, err := GetRowsStats(t, data)
 		if err != nil {
 			return err

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -182,6 +182,195 @@ func CheckRowsEqual(schema *schemapb.CollectionSchema, data *storage.InsertData)
 	return nil
 }
 
+// CheckStructArrayConsistency verifies that within each StructArrayField all
+// sub-field columns are row-wise consistent: for every row, the sub-fields
+// must agree on null-ness, and, when the row is valid, on the number of
+// struct elements (array length for scalar Array sub-fields, vector count
+// for ArrayOfVector sub-fields). The proxy enforces this invariant on the
+// insert path (checkAndFlattenStructFieldData), and JSON/CSV/Parquet/NumPy
+// importers produce consistent columns by construction, but binlog import
+// deserializes each sub-field's binlogs independently — divergent sub-field
+// data would otherwise be persisted and poison the segment (query-time
+// assertion failures or silently wrong element-level filter results).
+// Cost is O(rows * subFields), negligible compared with reading the data.
+func CheckStructArrayConsistency(schema *schemapb.CollectionSchema, data *storage.InsertData) error {
+	type subColumn struct {
+		name string
+		data storage.FieldData
+	}
+	for _, structField := range schema.GetStructArrayFields() {
+		subFields := structField.GetFields()
+		columns := make([]subColumn, 0, len(subFields))
+		var firstAbsent string
+		for _, subField := range subFields {
+			fieldData, ok := data.Data[subField.GetFieldID()]
+			if !ok || fieldData == nil || fieldData.RowNum() == 0 {
+				if firstAbsent == "" {
+					firstAbsent = subField.GetName()
+				}
+				continue
+			}
+			columns = append(columns, subColumn{name: subField.GetName(), data: fieldData})
+		}
+		// A struct must be supplied whole: either all sub-fields present or all
+		// absent. A partial set is malformed input — the absent sub-fields get
+		// backfilled as all-NULL (AppendNullableDefaultFieldsData) while the
+		// present ones carry real elements, producing per-row element-count
+		// mismatches that poison the segment. (checkAndFlattenStructFieldData
+		// enforces the same on the proxy insert path.)
+		if len(columns) == 0 {
+			continue
+		}
+		if len(columns) < len(subFields) {
+			return merr.WrapErrImportFailedMsg(
+				"struct field '%s' has a partial sub-field set: sub-field '%s' is present but sub-field '%s' is missing; provide all sub-fields or none",
+				structField.GetName(), columns[0].name, firstAbsent)
+		}
+		if len(columns) < 2 {
+			continue
+		}
+
+		ref := columns[0]
+		rows := ref.data.RowNum()
+		for _, col := range columns[1:] {
+			if col.data.RowNum() != rows {
+				return merr.WrapErrImportFailedMsg(
+					"struct field '%s' has misaligned sub-fields, sub-field '%s' with '%d' rows, sub-field '%s' with '%d' rows",
+					structField.GetName(), ref.name, rows, col.name, col.data.RowNum())
+			}
+		}
+
+		for i := 0; i < rows; i++ {
+			refValid := structSubFieldRowValid(ref.data, i)
+			refCount := -1
+			if refValid {
+				var err error
+				refCount, err = structSubFieldRowElementCount(ref.data, i, structField.GetName(), ref.name)
+				if err != nil {
+					return err
+				}
+			}
+			for _, col := range columns[1:] {
+				valid := structSubFieldRowValid(col.data, i)
+				if valid != refValid {
+					return merr.WrapErrImportFailedMsg(
+						"struct field '%s' has inconsistent sub-field null-ness at row %d, sub-field '%s' valid=%t, sub-field '%s' valid=%t",
+						structField.GetName(), i, ref.name, refValid, col.name, valid)
+				}
+				if !valid {
+					continue
+				}
+				count, err := structSubFieldRowElementCount(col.data, i, structField.GetName(), col.name)
+				if err != nil {
+					return err
+				}
+				if count != refCount {
+					return merr.WrapErrImportFailedMsg(
+						"struct field '%s' has inconsistent element count at row %d, sub-field '%s' with %d elements, sub-field '%s' with %d elements",
+						structField.GetName(), i, ref.name, refCount, col.name, count)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// structSubFieldRowValid reports whether row i of a struct sub-field column is
+// valid (non-null).
+func structSubFieldRowValid(fieldData storage.FieldData, i int) bool {
+	if !fieldData.GetNullable() {
+		return true
+	}
+	var validData []bool
+	switch fd := fieldData.(type) {
+	case *storage.ArrayFieldData:
+		validData = fd.ValidData
+	case *storage.VectorArrayFieldData:
+		validData = fd.ValidData
+	default:
+		// struct sub-fields are always Array or ArrayOfVector columns;
+		// fall back to the interface-level null representation
+		return fieldData.GetRow(i) != nil
+	}
+	if i >= len(validData) {
+		return true
+	}
+	return validData[i]
+}
+
+// structSubFieldRowElementCount returns the number of struct elements in row i
+// of a struct sub-field column: the array length for scalar Array sub-fields,
+// or the number of vectors for ArrayOfVector sub-fields.
+func structSubFieldRowElementCount(fieldData storage.FieldData, i int, structName, subFieldName string) (int, error) {
+	switch fd := fieldData.(type) {
+	case *storage.ArrayFieldData:
+		return scalarFieldElementCount(fd.Data[i]), nil
+	case *storage.VectorArrayFieldData:
+		row := fd.Data[i]
+		var payloadLen, width int
+		dim := int(fd.Dim)
+		switch fd.ElementType {
+		case schemapb.DataType_FloatVector:
+			payloadLen = len(row.GetFloatVector().GetData())
+			width = dim
+		case schemapb.DataType_BinaryVector:
+			payloadLen = len(row.GetBinaryVector())
+			width = (dim + 7) / 8
+		case schemapb.DataType_Float16Vector:
+			payloadLen = len(row.GetFloat16Vector())
+			width = dim * 2
+		case schemapb.DataType_BFloat16Vector:
+			payloadLen = len(row.GetBfloat16Vector())
+			width = dim * 2
+		case schemapb.DataType_Int8Vector:
+			payloadLen = len(row.GetInt8Vector())
+			width = dim
+		default:
+			return 0, merr.WrapErrImportSysFailedMsg(
+				"unsupported vector element type '%s' for sub-field '%s' of struct field '%s'",
+				fd.ElementType.String(), subFieldName, structName)
+		}
+		if width <= 0 || payloadLen%width != 0 {
+			return 0, merr.WrapErrImportFailedMsg(
+				"corrupted vector array data at row %d of sub-field '%s' of struct field '%s', payload length %d is not a multiple of vector width %d",
+				i, subFieldName, structName, payloadLen, width)
+		}
+		return payloadLen / width, nil
+	default:
+		return 0, merr.WrapErrImportSysFailedMsg(
+			"unexpected column type '%s' for sub-field '%s' of struct field '%s'",
+			fieldData.GetDataType().String(), subFieldName, structName)
+	}
+}
+
+// scalarFieldElementCount returns the number of elements held by one Array row.
+func scalarFieldElementCount(sf *schemapb.ScalarField) int {
+	switch d := sf.GetData().(type) {
+	case *schemapb.ScalarField_BoolData:
+		return len(d.BoolData.GetData())
+	case *schemapb.ScalarField_IntData:
+		return len(d.IntData.GetData())
+	case *schemapb.ScalarField_LongData:
+		return len(d.LongData.GetData())
+	case *schemapb.ScalarField_FloatData:
+		return len(d.FloatData.GetData())
+	case *schemapb.ScalarField_DoubleData:
+		return len(d.DoubleData.GetData())
+	case *schemapb.ScalarField_StringData:
+		return len(d.StringData.GetData())
+	case *schemapb.ScalarField_BytesData:
+		return len(d.BytesData.GetData())
+	case *schemapb.ScalarField_ArrayData:
+		return len(d.ArrayData.GetData())
+	case *schemapb.ScalarField_JsonData:
+		return len(d.JsonData.GetData())
+	case *schemapb.ScalarField_TimestamptzData:
+		return len(d.TimestamptzData.GetData())
+	default:
+		return 0
+	}
+}
+
 func AppendSystemFieldsData(task *ImportTask, data *storage.InsertData, rowNum int) error {
 	pkField, err := typeutil.GetPrimaryFieldSchema(task.GetSchema())
 	if err != nil {

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -195,8 +195,9 @@ func CheckRowsEqual(schema *schemapb.CollectionSchema, data *storage.InsertData)
 // Cost is O(rows * subFields), negligible compared with reading the data.
 func CheckStructArrayConsistency(schema *schemapb.CollectionSchema, data *storage.InsertData) error {
 	type subColumn struct {
-		name string
-		data storage.FieldData
+		name      string
+		data      storage.FieldData
+		validData []bool
 	}
 	for _, structField := range schema.GetStructArrayFields() {
 		subFields := structField.GetFields()
@@ -204,13 +205,39 @@ func CheckStructArrayConsistency(schema *schemapb.CollectionSchema, data *storag
 		var firstAbsent string
 		for _, subField := range subFields {
 			fieldData, ok := data.Data[subField.GetFieldID()]
-			if !ok || fieldData == nil || fieldData.RowNum() == 0 {
+			if !ok || fieldData == nil {
 				if firstAbsent == "" {
 					firstAbsent = subField.GetName()
 				}
 				continue
 			}
-			columns = append(columns, subColumn{name: subField.GetName(), data: fieldData})
+
+			var validData []bool
+			if fieldData.GetNullable() {
+				switch fd := fieldData.(type) {
+				case *storage.ArrayFieldData:
+					validData = fd.ValidData
+				case *storage.VectorArrayFieldData:
+					validData = fd.ValidData
+				default:
+					return merr.WrapErrImportSysFailedMsg(
+						"unexpected nullable column type '%s' for sub-field '%s' of struct field '%s'",
+						fieldData.GetDataType().String(), subField.GetName(), structField.GetName())
+				}
+				if len(validData) != fieldData.RowNum() {
+					return merr.WrapErrImportSysFailedMsg(
+						"nullable sub-field '%s' of struct field '%s' has invalid ValidData length %d, expected %d",
+						subField.GetName(), structField.GetName(), len(validData), fieldData.RowNum())
+				}
+			}
+
+			if fieldData.RowNum() == 0 {
+				if firstAbsent == "" {
+					firstAbsent = subField.GetName()
+				}
+				continue
+			}
+			columns = append(columns, subColumn{name: subField.GetName(), data: fieldData, validData: validData})
 		}
 		// A struct must be supplied whole: either all sub-fields present or all
 		// absent. A partial set is malformed input — the absent sub-fields get
@@ -226,10 +253,6 @@ func CheckStructArrayConsistency(schema *schemapb.CollectionSchema, data *storag
 				"struct field '%s' has a partial sub-field set: sub-field '%s' is present but sub-field '%s' is missing; provide all sub-fields or none",
 				structField.GetName(), columns[0].name, firstAbsent)
 		}
-		if len(columns) < 2 {
-			continue
-		}
-
 		ref := columns[0]
 		rows := ref.data.RowNum()
 		for _, col := range columns[1:] {
@@ -241,7 +264,7 @@ func CheckStructArrayConsistency(schema *schemapb.CollectionSchema, data *storag
 		}
 
 		for i := 0; i < rows; i++ {
-			refValid := structSubFieldRowValid(ref.data, i)
+			refValid := !ref.data.GetNullable() || ref.validData[i]
 			refCount := -1
 			if refValid {
 				var err error
@@ -251,7 +274,7 @@ func CheckStructArrayConsistency(schema *schemapb.CollectionSchema, data *storag
 				}
 			}
 			for _, col := range columns[1:] {
-				valid := structSubFieldRowValid(col.data, i)
+				valid := !col.data.GetNullable() || col.validData[i]
 				if valid != refValid {
 					return merr.WrapErrImportFailedMsg(
 						"struct field '%s' has inconsistent sub-field null-ness at row %d, sub-field '%s' valid=%t, sub-field '%s' valid=%t",
@@ -275,36 +298,19 @@ func CheckStructArrayConsistency(schema *schemapb.CollectionSchema, data *storag
 	return nil
 }
 
-// structSubFieldRowValid reports whether row i of a struct sub-field column is
-// valid (non-null).
-func structSubFieldRowValid(fieldData storage.FieldData, i int) bool {
-	if !fieldData.GetNullable() {
-		return true
-	}
-	var validData []bool
-	switch fd := fieldData.(type) {
-	case *storage.ArrayFieldData:
-		validData = fd.ValidData
-	case *storage.VectorArrayFieldData:
-		validData = fd.ValidData
-	default:
-		// struct sub-fields are always Array or ArrayOfVector columns;
-		// fall back to the interface-level null representation
-		return fieldData.GetRow(i) != nil
-	}
-	if i >= len(validData) {
-		return true
-	}
-	return validData[i]
-}
-
 // structSubFieldRowElementCount returns the number of struct elements in row i
 // of a struct sub-field column: the array length for scalar Array sub-fields,
 // or the number of vectors for ArrayOfVector sub-fields.
 func structSubFieldRowElementCount(fieldData storage.FieldData, i int, structName, subFieldName string) (int, error) {
 	switch fd := fieldData.(type) {
 	case *storage.ArrayFieldData:
-		return scalarFieldElementCount(fd.Data[i]), nil
+		count, ok := scalarFieldElementCount(fd.Data[i])
+		if !ok {
+			return 0, merr.WrapErrImportFailedMsg(
+				"invalid scalar array data at row %d of sub-field '%s' of struct field '%s': missing or unsupported scalar payload",
+				i, subFieldName, structName)
+		}
+		return count, nil
 	case *storage.VectorArrayFieldData:
 		row := fd.Data[i]
 		var payloadLen, width int
@@ -343,31 +349,33 @@ func structSubFieldRowElementCount(fieldData storage.FieldData, i int, structNam
 	}
 }
 
-// scalarFieldElementCount returns the number of elements held by one Array row.
-func scalarFieldElementCount(sf *schemapb.ScalarField) int {
+// scalarFieldElementCount returns the number of elements held by one Array row
+// and whether its scalar payload type is recognized. A typed empty payload is
+// valid and returns (0, true); a nil or unset payload returns (0, false).
+func scalarFieldElementCount(sf *schemapb.ScalarField) (int, bool) {
 	switch d := sf.GetData().(type) {
 	case *schemapb.ScalarField_BoolData:
-		return len(d.BoolData.GetData())
+		return len(d.BoolData.GetData()), true
 	case *schemapb.ScalarField_IntData:
-		return len(d.IntData.GetData())
+		return len(d.IntData.GetData()), true
 	case *schemapb.ScalarField_LongData:
-		return len(d.LongData.GetData())
+		return len(d.LongData.GetData()), true
 	case *schemapb.ScalarField_FloatData:
-		return len(d.FloatData.GetData())
+		return len(d.FloatData.GetData()), true
 	case *schemapb.ScalarField_DoubleData:
-		return len(d.DoubleData.GetData())
+		return len(d.DoubleData.GetData()), true
 	case *schemapb.ScalarField_StringData:
-		return len(d.StringData.GetData())
+		return len(d.StringData.GetData()), true
 	case *schemapb.ScalarField_BytesData:
-		return len(d.BytesData.GetData())
+		return len(d.BytesData.GetData()), true
 	case *schemapb.ScalarField_ArrayData:
-		return len(d.ArrayData.GetData())
+		return len(d.ArrayData.GetData()), true
 	case *schemapb.ScalarField_JsonData:
-		return len(d.JsonData.GetData())
+		return len(d.JsonData.GetData()), true
 	case *schemapb.ScalarField_TimestamptzData:
-		return len(d.TimestamptzData.GetData())
+		return len(d.TimestamptzData.GetData()), true
 	default:
-		return 0
+		return 0, false
 	}
 }
 

--- a/internal/datanode/importv2/util_test.go
+++ b/internal/datanode/importv2/util_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func Test_AppendSystemFieldsData(t *testing.T) {
@@ -299,6 +301,209 @@ func Test_CheckRowsEqual(t *testing.T) {
 	assert.NoError(t, err)
 	err = CheckRowsEqual(schema, insertData)
 	assert.NoError(t, err)
+}
+
+func Test_CheckStructArrayConsistency(t *testing.T) {
+	const (
+		structName = "struct_field"
+		intSubID   = int64(111)
+		strSubID   = int64(112)
+		vecSubID   = int64(113)
+		dim        = 2
+	)
+
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "pk",
+				DataType:     schemapb.DataType_Int64,
+				IsPrimaryKey: true,
+			},
+		},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{
+				FieldID:  110,
+				Name:     structName,
+				Nullable: true,
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:     intSubID,
+						Name:        typeutil.ConcatStructFieldName(structName, "sub_int"),
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_Int64,
+						Nullable:    true,
+					},
+					{
+						FieldID:     strSubID,
+						Name:        typeutil.ConcatStructFieldName(structName, "sub_str"),
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_VarChar,
+						Nullable:    true,
+					},
+					{
+						FieldID:     vecSubID,
+						Name:        typeutil.ConcatStructFieldName(structName, "sub_vec"),
+						DataType:    schemapb.DataType_ArrayOfVector,
+						ElementType: schemapb.DataType_FloatVector,
+						Nullable:    true,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.DimKey, Value: fmt.Sprintf("%d", dim)},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	longRow := func(vals ...int64) *schemapb.ScalarField {
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_LongData{
+				LongData: &schemapb.LongArray{Data: vals},
+			},
+		}
+	}
+	strRow := func(vals ...string) *schemapb.ScalarField {
+		return &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_StringData{
+				StringData: &schemapb.StringArray{Data: vals},
+			},
+		}
+	}
+	vecRow := func(numVectors int) *schemapb.VectorField {
+		return &schemapb.VectorField{
+			Dim: int64(dim),
+			Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: make([]float32, numVectors*dim)},
+			},
+		}
+	}
+	// 3 rows: row 0 has 2 struct elements, row 1 is null, row 2 has 1 element
+	buildConsistentData := func() *storage.InsertData {
+		return &storage.InsertData{
+			Data: map[int64]storage.FieldData{
+				common.RowIDField: &storage.Int64FieldData{Data: []int64{1, 2, 3}},
+				intSubID: &storage.ArrayFieldData{
+					ElementType: schemapb.DataType_Int64,
+					Data:        []*schemapb.ScalarField{longRow(1, 2), nil, longRow(3)},
+					ValidData:   []bool{true, false, true},
+					Nullable:    true,
+				},
+				strSubID: &storage.ArrayFieldData{
+					ElementType: schemapb.DataType_VarChar,
+					Data:        []*schemapb.ScalarField{strRow("a", "b"), nil, strRow("c")},
+					ValidData:   []bool{true, false, true},
+					Nullable:    true,
+				},
+				vecSubID: &storage.VectorArrayFieldData{
+					Dim:         dim,
+					ElementType: schemapb.DataType_FloatVector,
+					Data:        []*schemapb.VectorField{vecRow(2), vecRow(0), vecRow(1)},
+					ValidData:   []bool{true, false, true},
+					Nullable:    true,
+				},
+			},
+		}
+	}
+
+	t.Run("consistent struct data", func(t *testing.T) {
+		err := CheckStructArrayConsistency(schema, buildConsistentData())
+		assert.NoError(t, err)
+	})
+
+	t.Run("no struct fields in schema", func(t *testing.T) {
+		plainSchema := &schemapb.CollectionSchema{
+			Fields: schema.GetFields(),
+		}
+		err := CheckStructArrayConsistency(plainSchema, buildConsistentData())
+		assert.NoError(t, err)
+	})
+
+	t.Run("struct columns absent from data", func(t *testing.T) {
+		insertData := buildConsistentData()
+		delete(insertData.Data, intSubID)
+		delete(insertData.Data, strSubID)
+		delete(insertData.Data, vecSubID)
+		err := CheckStructArrayConsistency(schema, insertData)
+		assert.NoError(t, err)
+	})
+
+	t.Run("diverging scalar element count", func(t *testing.T) {
+		insertData := buildConsistentData()
+		// row 2: sub_str has 2 elements while sub_int has 1
+		insertData.Data[strSubID].(*storage.ArrayFieldData).Data[2] = strRow("c", "d")
+		err := CheckStructArrayConsistency(schema, insertData)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrImportFailed)
+		assert.Contains(t, err.Error(), "row 2")
+		assert.Contains(t, err.Error(), structName)
+		assert.Contains(t, err.Error(), typeutil.ConcatStructFieldName(structName, "sub_int"))
+		assert.Contains(t, err.Error(), typeutil.ConcatStructFieldName(structName, "sub_str"))
+	})
+
+	t.Run("diverging vector array element count", func(t *testing.T) {
+		insertData := buildConsistentData()
+		// row 0: sub_vec has 3 vectors while scalar sub-fields have 2 elements
+		insertData.Data[vecSubID].(*storage.VectorArrayFieldData).Data[0] = vecRow(3)
+		err := CheckStructArrayConsistency(schema, insertData)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrImportFailed)
+		assert.Contains(t, err.Error(), "row 0")
+		assert.Contains(t, err.Error(), typeutil.ConcatStructFieldName(structName, "sub_vec"))
+	})
+
+	t.Run("diverging valid data", func(t *testing.T) {
+		insertData := buildConsistentData()
+		// row 1: sub_str claims valid while the siblings claim null
+		strData := insertData.Data[strSubID].(*storage.ArrayFieldData)
+		strData.Data[1] = strRow()
+		strData.ValidData[1] = true
+		err := CheckStructArrayConsistency(schema, insertData)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrImportFailed)
+		assert.Contains(t, err.Error(), "row 1")
+		assert.Contains(t, err.Error(), "null-ness")
+	})
+
+	t.Run("misaligned sub-field row count", func(t *testing.T) {
+		insertData := buildConsistentData()
+		intData := insertData.Data[intSubID].(*storage.ArrayFieldData)
+		intData.Data = intData.Data[:2]
+		intData.ValidData = intData.ValidData[:2]
+		err := CheckStructArrayConsistency(schema, insertData)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrImportFailed)
+		assert.Contains(t, err.Error(), "misaligned")
+	})
+
+	t.Run("partial sub-field set: one present, others absent", func(t *testing.T) {
+		// Only sub_int is supplied; sub_str/sub_vec would be backfilled as
+		// all-NULL, so the present column's real elements would diverge from
+		// the NULL columns. Must be rejected, not silently accepted.
+		insertData := buildConsistentData()
+		delete(insertData.Data, strSubID)
+		delete(insertData.Data, vecSubID)
+		err := CheckStructArrayConsistency(schema, insertData)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrImportFailed)
+		assert.Contains(t, err.Error(), "partial sub-field set")
+	})
+
+	t.Run("partial sub-field set: one present, one zero-row", func(t *testing.T) {
+		insertData := buildConsistentData()
+		delete(insertData.Data, vecSubID)
+		// sub_str present but empty (zero rows) -> treated as absent -> partial
+		insertData.Data[strSubID] = &storage.ArrayFieldData{
+			ElementType: schemapb.DataType_VarChar,
+			Data:        []*schemapb.ScalarField{},
+			ValidData:   []bool{},
+			Nullable:    true,
+		}
+		err := CheckStructArrayConsistency(schema, insertData)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrImportFailed)
+		assert.Contains(t, err.Error(), "partial sub-field set")
+	})
 }
 
 func Test_AppendNullableDefaultFieldsData(t *testing.T) {

--- a/internal/datanode/importv2/util_test.go
+++ b/internal/datanode/importv2/util_test.go
@@ -411,6 +411,15 @@ func Test_CheckStructArrayConsistency(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("typed empty arrays are valid", func(t *testing.T) {
+		insertData := buildConsistentData()
+		insertData.Data[intSubID].(*storage.ArrayFieldData).Data[0] = longRow()
+		insertData.Data[strSubID].(*storage.ArrayFieldData).Data[0] = strRow()
+		insertData.Data[vecSubID].(*storage.VectorArrayFieldData).Data[0] = vecRow(0)
+		err := CheckStructArrayConsistency(schema, insertData)
+		assert.NoError(t, err)
+	})
+
 	t.Run("no struct fields in schema", func(t *testing.T) {
 		plainSchema := &schemapb.CollectionSchema{
 			Fields: schema.GetFields(),
@@ -424,6 +433,18 @@ func Test_CheckStructArrayConsistency(t *testing.T) {
 		delete(insertData.Data, intSubID)
 		delete(insertData.Data, strSubID)
 		delete(insertData.Data, vecSubID)
+		err := CheckStructArrayConsistency(schema, insertData)
+		assert.NoError(t, err)
+	})
+
+	t.Run("zero-row struct columns are absent", func(t *testing.T) {
+		insertData := buildConsistentData()
+		intData := insertData.Data[intSubID].(*storage.ArrayFieldData)
+		intData.Data, intData.ValidData = nil, nil
+		strData := insertData.Data[strSubID].(*storage.ArrayFieldData)
+		strData.Data, strData.ValidData = nil, nil
+		vecData := insertData.Data[vecSubID].(*storage.VectorArrayFieldData)
+		vecData.Data, vecData.ValidData = nil, nil
 		err := CheckStructArrayConsistency(schema, insertData)
 		assert.NoError(t, err)
 	})
@@ -463,6 +484,102 @@ func Test_CheckStructArrayConsistency(t *testing.T) {
 		assert.ErrorIs(t, err, merr.ErrImportFailed)
 		assert.Contains(t, err.Error(), "row 1")
 		assert.Contains(t, err.Error(), "null-ness")
+	})
+
+	t.Run("invalid nullable valid data length", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			fieldName string
+			mutate    func(*storage.InsertData)
+		}{
+			{
+				name:      "empty scalar mask",
+				fieldName: typeutil.ConcatStructFieldName(structName, "sub_int"),
+				mutate: func(insertData *storage.InsertData) {
+					fieldData := insertData.Data[intSubID].(*storage.ArrayFieldData)
+					fieldData.ValidData = nil
+				},
+			},
+			{
+				name:      "long vector mask",
+				fieldName: typeutil.ConcatStructFieldName(structName, "sub_vec"),
+				mutate: func(insertData *storage.InsertData) {
+					fieldData := insertData.Data[vecSubID].(*storage.VectorArrayFieldData)
+					fieldData.ValidData = append(fieldData.ValidData, true)
+				},
+			},
+			{
+				name:      "non-empty mask for zero-row column",
+				fieldName: typeutil.ConcatStructFieldName(structName, "sub_str"),
+				mutate: func(insertData *storage.InsertData) {
+					fieldData := insertData.Data[strSubID].(*storage.ArrayFieldData)
+					fieldData.Data = nil
+					fieldData.ValidData = []bool{true}
+				},
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				insertData := buildConsistentData()
+				test.mutate(insertData)
+				err := CheckStructArrayConsistency(schema, insertData)
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, merr.ErrImportSysFailed)
+				assert.Equal(t, merr.SystemError, merr.GetErrorType(err))
+				assert.Contains(t, err.Error(), "ValidData length")
+				assert.Contains(t, err.Error(), test.fieldName)
+			})
+		}
+	})
+
+	t.Run("single sub-field still validates nullable mask", func(t *testing.T) {
+		singleFieldSchema := &schemapb.CollectionSchema{
+			StructArrayFields: []*schemapb.StructArrayFieldSchema{
+				{
+					FieldID:  110,
+					Name:     structName,
+					Nullable: true,
+					Fields:   []*schemapb.FieldSchema{schema.GetStructArrayFields()[0].GetFields()[0]},
+				},
+			},
+		}
+		insertData := &storage.InsertData{
+			Data: map[int64]storage.FieldData{
+				intSubID: &storage.ArrayFieldData{
+					ElementType: schemapb.DataType_Int64,
+					Data:        []*schemapb.ScalarField{longRow(1)},
+					Nullable:    true,
+				},
+			},
+		}
+		err := CheckStructArrayConsistency(singleFieldSchema, insertData)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrImportSysFailed)
+		assert.Equal(t, merr.SystemError, merr.GetErrorType(err))
+		assert.Contains(t, err.Error(), "ValidData length")
+	})
+
+	t.Run("invalid scalar array payload", func(t *testing.T) {
+		tests := []struct {
+			name string
+			row  *schemapb.ScalarField
+		}{
+			{name: "nil payload", row: nil},
+			{name: "unset payload", row: &schemapb.ScalarField{}},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				insertData := buildConsistentData()
+				insertData.Data[intSubID].(*storage.ArrayFieldData).Data[0] = test.row
+				err := CheckStructArrayConsistency(schema, insertData)
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, merr.ErrImportFailed)
+				assert.Equal(t, merr.InputError, merr.GetErrorType(err))
+				assert.Contains(t, err.Error(), "row 0")
+				assert.Contains(t, err.Error(), typeutil.ConcatStructFieldName(structName, "sub_int"))
+				assert.Contains(t, err.Error(), "missing or unsupported scalar payload")
+			})
+		}
 	})
 
 	t.Run("misaligned sub-field row count", func(t *testing.T) {


### PR DESCRIPTION
Backport of #51388 to the 3.0 branch.

pr: #51388
issue: #51383

> [!IMPORTANT]
> #51388 is still open on master. Do not merge this PR until #51388 merges; refresh this branch if the source PR changes.

## What changed

- Validate StructArray sibling sub-fields have matching per-row nullness and element counts at both import funnels.
- Strictly validate nullable `ValidData` shape against `RowNum()`.
- Reject nil, unset, or unsupported scalar array payloads instead of treating them as empty; typed empty arrays remain valid.
- Preserve the source PR vector validation scope without expansion.

## Backport notes

- Cherry-picked both commits from #51388 in source order with provenance and DCO trailers.
- Both commits applied cleanly with no 3.0-specific changes.
- Range-diff differs only by cherry-pick provenance and Li Liu sign-off trailers.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datanode/importv2` — passed in 59.914s
- `git diff --check` — passed
- Source-versus-backport `git range-diff` — code patches identical
- Independent AI review — no blocking or actionable correctness findings