### PR TITLE
fix: disable growing source flush by default

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1054,7 +1054,7 @@ common:
         enabled: true # enable split by average size policy in storage v2
         threshold: 1024 # split by average size policy threshold(in bytes) in storage v2
     useLoonFFI: false
-    enableGrowingSourceFlush: true # enable flushing growing segment payload from QueryNode growing source through StorageV3 manifest path
+    enableGrowingSourceFlush: false # enable flushing growing segment payload from QueryNode growing source through StorageV3 manifest path
   # Default value: auto
   # Valid values: [auto, avx512, avx2, avx, sse4_2]
   # This configuration is only used by querynode and indexnode, it selects CPU instruction set for Searching and Index-building.

--- a/internal/flushcommon/writebuffer/write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/write_buffer_test.go
@@ -204,7 +204,7 @@ func (s *WriteBufferSuite) TestCreateNewGrowingSegmentStorageVersion() {
 		s.NoError(err)
 	})
 
-	s.Run("text_schema_uses_v3_manifest_when_ffi_enabled", func() {
+	s.Run("text_schema_uses_v3_manifest_with_writer_buffer_when_ffi_enabled", func() {
 		param.Save(param.CommonCfg.UseLoonFFI.Key, "true")
 		defer param.Save(param.CommonCfg.UseLoonFFI.Key, "false")
 
@@ -224,7 +224,7 @@ func (s *WriteBufferSuite) TestCreateNewGrowingSegmentStorageVersion() {
 
 		wb, err := newWriteBufferBase(s.channelName, mc, s.syncMgr, &writeBufferOption{})
 		s.Require().NoError(err)
-		s.True(wb.AllowGrowingSourceFlush())
+		s.False(wb.AllowGrowingSourceFlush())
 
 		mc.EXPECT().GetSegmentByID(int64(2004)).Return(nil, false).Once()
 		mc.EXPECT().AddSegment(mock.MatchedBy(func(info *datapb.SegmentInfo) bool {

--- a/internal/storage/binlog_record_writer.go
+++ b/internal/storage/binlog_record_writer.go
@@ -517,7 +517,7 @@ func (pw *PackedManifestRecordWriter) Close() error {
 // storage, and appends StatEntry records onto updates so the surrounding
 // commit registers inserts + stats atomically. Leaves pw.statsLog and
 // pw.bm25StatsLog nil so callers know stats are embedded in the manifest.
-func (pw *PackedManifestRecordWriter) appendV3Stats(updates *packed.ManifestUpdates) error {
+func (pw *packedBinlogRecordWriterBase) appendV3Stats(updates *packed.ManifestUpdates) error {
 	statsBlob, pkFieldID, err := pw.pkCollector.SerializeBlob(pw.rowNum)
 	if err != nil {
 		return err
@@ -709,7 +709,7 @@ func (pw *PackedTextManifestRecordWriter) finalizeBinlogs() {
 // pattern as PackedManifestRecordWriter.Close.
 func (pw *PackedTextManifestRecordWriter) Close() error {
 	if pw.writer == nil {
-		return pw.writeStats()
+		return nil
 	}
 	out, err := pw.writer.Close()
 	if err != nil {
@@ -720,16 +720,20 @@ func (pw *PackedTextManifestRecordWriter) Close() error {
 	}
 	pw.finalizeBinlogs()
 	if out == nil {
-		return pw.writeStats()
+		return nil
 	}
 
+	updates := &packed.ManifestUpdates{NewFiles: out}
+	if err := pw.appendV3Stats(updates); err != nil {
+		return err
+	}
 	newManifest, err := packed.CommitManifestUpdates(pw.basePath, packed.ManifestEarliest, pw.storageConfig,
-		&packed.ManifestUpdates{NewFiles: out})
+		updates)
 	if err != nil {
 		return merr.Wrap(err, "PackedTextManifestRecordWriter.Close commit")
 	}
 	pw.manifest = newManifest
-	return pw.writeStats()
+	return nil
 }
 
 // NewPackedTextManifestRecordWriter creates a new BinlogRecordWriter for TEXT column compaction.

--- a/internal/storage/binlog_record_writer_v3_test.go
+++ b/internal/storage/binlog_record_writer_v3_test.go
@@ -11,6 +11,8 @@
 package storage
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -26,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 )
 
 // TestPackedManifestRecordWriter_CloseWithoutWrite verifies the no-data
@@ -75,11 +78,62 @@ func TestPackedTextManifestRecordWriter_CloseWithoutWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	// No Write before Close. The text writer's nil-handling path must
-	// fall through to writeStats() and exit cleanly.
+	// exit cleanly without producing legacy stats.
 	require.NoError(t, w.Close())
 
 	_, _, _, manifestPath, _ := w.GetLogs()
 	assert.Empty(t, manifestPath, "no Write means no manifest should be produced")
+}
+
+func TestPackedTextManifestRecordWriter_AppendsV3StatsToManifest(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &indexpb.StorageConfig{StorageType: "local", RootPath: dir}
+	schema := genCollectionSchemaWithBM25()
+	collectionID := UniqueID(10)
+	partitionID := UniqueID(20)
+	segmentID := UniqueID(30)
+
+	w, err := NewPackedTextManifestRecordWriter(collectionID, partitionID, segmentID, schema,
+		ChunkedBlobsWriter(func(_ []*Blob) error { return nil }),
+		allocator.NewLocalAllocator(1000, 1<<20),
+		1024, 0, 0, nil, cfg, nil, "")
+	require.NoError(t, err)
+
+	value := &Value{
+		PK:        NewVarCharPrimaryKey("0"),
+		Timestamp: int64(tsoutil.ComposeTSByTime(getMilvusBirthday())),
+		Value:     genRowWithBM25(0),
+	}
+	rec, err := ValueSerializer([]*Value{value}, schema)
+	require.NoError(t, err)
+	require.NoError(t, w.Write(rec))
+	require.NoError(t, w.Close())
+
+	_, statsLog, bm25Logs, manifestPath, _ := w.GetLogs()
+	require.NotEmpty(t, manifestPath)
+
+	stats, err := packed.GetManifestStats(manifestPath, cfg)
+	require.NoError(t, err)
+
+	bfKey := "bloom_filter.100"
+	bfStat, ok := stats[bfKey]
+	require.True(t, ok, "TEXT manifest writer must register PK BF stats under %q", bfKey)
+	require.NotEmpty(t, bfStat.Paths)
+	bfMemorySize, err := strconv.ParseInt(bfStat.Metadata["memory_size"], 10, 64)
+	require.NoError(t, err)
+	require.Positive(t, bfMemorySize)
+	assert.True(t, strings.Contains(bfStat.Paths[0], "/_stats/bloom_filter.100/"))
+	assert.NotContains(t, bfStat.Paths[0], "stats_log")
+
+	bm25Key := "bm25.102"
+	bm25Stat, ok := stats[bm25Key]
+	require.True(t, ok, "TEXT manifest writer must register BM25 stats under %q", bm25Key)
+	require.NotEmpty(t, bm25Stat.Paths)
+	assert.True(t, strings.Contains(bm25Stat.Paths[0], "/_stats/bm25.102/"))
+	assert.NotContains(t, bm25Stat.Paths[0], "stats_log")
+
+	assert.Nil(t, statsLog, "V3 manifest stats must not be returned as legacy PK statslog")
+	assert.Empty(t, bm25Logs, "V3 manifest stats must not be returned as legacy BM25 statslog")
 }
 
 func TestPackedManifestRecordWriter_FillsV3ColumnGroupFormats(t *testing.T) {

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
@@ -494,7 +494,8 @@ func TestShardManagerSchemaVersionCheck(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int32(4), ver)
 	assert.True(t, m.collections[104].HasTextField())
-	assert.True(t, m.collections[104].AllowGrowingSourceFlush())
+	assert.True(t, m.collections[104].RequiresStorageV3())
+	assert.False(t, m.collections[104].AllowGrowingSourceFlush())
 
 	// Test 3: Create collection without schema (legacy), then check version
 	createMsgNoSchema := message.NewCreateCollectionMessageBuilderV1().
@@ -880,6 +881,8 @@ func TestCollectionInfoAllowGrowingSourceFlush_TextField(t *testing.T) {
 	assert.False(t, ci.AllowGrowingSourceFlush())
 	assert.True(t, ci.RequiresStorageV3())
 	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	assert.False(t, ci.AllowGrowingSourceFlush())
+	paramtable.Get().Save(paramtable.Get().CommonCfg.EnableGrowingSourceFlush.Key, "true")
 	assert.True(t, ci.AllowGrowingSourceFlush())
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1099,7 +1099,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 	p.EnableGrowingSourceFlush = ParamItem{
 		Key:          "common.storage.enableGrowingSourceFlush",
 		Version:      "3.0.0",
-		DefaultValue: "true",
+		DefaultValue: "false",
 		Doc:          "enable flushing growing segment payload from QueryNode growing source through StorageV3 manifest path",
 		Export:       true,
 	}

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -120,7 +120,7 @@ func AllowGrowingSourceFlush(schema *schemapb.CollectionSchema, storageV3Enabled
 	if !storageV3Enabled {
 		return false
 	}
-	return HasTextField(schema) || enableGrowingSourceFlush
+	return enableGrowingSourceFlush
 }
 
 // UseGrowingSourceFlush is kept for compatibility. Prefer

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -353,7 +353,8 @@ func TestAllowGrowingSourceFlush(t *testing.T) {
 	assert.False(t, AllowGrowingSourceFlush(textSchema, false, true))
 	assert.False(t, AllowGrowingSourceFlush(ordinarySchema, true, false))
 	assert.True(t, AllowGrowingSourceFlush(ordinarySchema, true, true))
-	assert.True(t, AllowGrowingSourceFlush(textSchema, true, false))
+	assert.False(t, AllowGrowingSourceFlush(textSchema, true, false))
+	assert.True(t, AllowGrowingSourceFlush(textSchema, true, true))
 	assert.False(t, AllowGrowingSourceFlush(nil, true, false))
 	assert.True(t, AllowGrowingSourceFlush(nil, true, true))
 	assert.Equal(t,


### PR DESCRIPTION
issue: #50425 
Disable growing-source flush by default so TEXT collections use the writer-buffer path unless the feature is explicitly enabled.

Also write TEXT V3 bloom filter and BM25 stats into the manifest instead of returning legacy stats logs.