### PR TITLE
enhance: batch binary chunk payload writes

### DIFF
--- a/internal/core/src/common/ChunkTest.cpp
+++ b/internal/core/src/common/ChunkTest.cpp
@@ -53,6 +53,30 @@
 
 using namespace milvus;
 
+namespace {
+
+std::shared_ptr<arrow::BinaryArray>
+BuildBinaryArray(const std::vector<std::optional<std::string>>& values) {
+    arrow::BinaryBuilder builder;
+    for (const auto& value : values) {
+        arrow::Status status;
+        if (value.has_value()) {
+            status = builder.Append(value->data(),
+                                    static_cast<int32_t>(value->size()));
+        } else {
+            status = builder.AppendNull();
+        }
+        EXPECT_TRUE(status.ok());
+    }
+
+    std::shared_ptr<arrow::Array> array;
+    auto status = builder.Finish(&array);
+    EXPECT_TRUE(status.ok());
+    return std::static_pointer_cast<arrow::BinaryArray>(array);
+}
+
+}  // namespace
+
 TEST(chunk, test_int64_field) {
     FixedVector<int64_t> data = {1, 2, 3, 4, 5};
     auto field_data = milvus::storage::CreateFieldData(storage::DataType::INT64,
@@ -225,6 +249,50 @@ TEST(chunk, test_variable_field_nullable) {
     }
 }
 
+TEST(chunk, test_variable_field_sliced_binary_batches) {
+    auto batch1 = BuildBinaryArray({std::string("skip-a"),
+                                    std::string("alpha"),
+                                    std::nullopt,
+                                    std::string("beta"),
+                                    std::string("skip-b")});
+    auto batch2 = BuildBinaryArray({std::string("skip-c"),
+                                    std::string("gamma"),
+                                    std::string(""),
+                                    std::string("delta"),
+                                    std::string("skip-d")});
+
+    arrow::ArrayVector array_vec{
+        std::static_pointer_cast<arrow::Array>(batch1)->Slice(1, 3),
+        std::static_pointer_cast<arrow::Array>(batch2)->Slice(1, 3),
+    };
+
+    FieldMeta field_meta(FieldName("a"),
+                         milvus::FieldId(1),
+                         DataType::STRING,
+                         true,
+                         std::nullopt);
+    auto chunk = create_chunk(field_meta, array_vec);
+    auto string_chunk = static_cast<StringChunk*>(chunk.get());
+    auto [views, valid] = string_chunk->StringViews(std::nullopt);
+
+    std::vector<std::optional<std::string_view>> expected = {
+        std::string_view("alpha"),
+        std::nullopt,
+        std::string_view("beta"),
+        std::string_view("gamma"),
+        std::string_view(""),
+        std::string_view("delta"),
+    };
+    ASSERT_EQ(views.size(), expected.size());
+    ASSERT_EQ(valid.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(valid[i], expected[i].has_value());
+        if (expected[i].has_value()) {
+            EXPECT_EQ(views[i], expected[i].value());
+        }
+    }
+}
+
 TEST(chunk, test_json_field) {
     auto row_num = 100;
     FixedVector<Json> data;
@@ -341,6 +409,91 @@ TEST(chunk, test_json_field) {
             auto len = 11;
             EXPECT_THROW(json_chunk->StringViews(std::make_pair(start, len)),
                          milvus::SegcoreError);
+        }
+    }
+}
+
+TEST(chunk, test_json_field_sliced_binary_batches) {
+    auto batch1 = BuildBinaryArray({std::string(R"({"skip":0})"),
+                                    std::string(R"({"k":"a"})"),
+                                    std::nullopt,
+                                    std::string(R"({"k":"b"})"),
+                                    std::string(R"({"skip":1})")});
+    auto batch2 = BuildBinaryArray({std::string(R"({"skip":2})"),
+                                    std::string(R"({"k":"c"})"),
+                                    std::string(R"({"k":""})"),
+                                    std::string(R"({"k":"d"})"),
+                                    std::string(R"({"skip":3})")});
+
+    arrow::ArrayVector array_vec{
+        std::static_pointer_cast<arrow::Array>(batch1)->Slice(1, 3),
+        std::static_pointer_cast<arrow::Array>(batch2)->Slice(1, 3),
+    };
+
+    FieldMeta field_meta(
+        FieldName("a"), milvus::FieldId(1), DataType::JSON, true, std::nullopt);
+    auto chunk = create_chunk(field_meta, array_vec);
+    auto json_chunk = static_cast<JSONChunk*>(chunk.get());
+    auto [views, valid] = json_chunk->StringViews(std::nullopt);
+
+    std::vector<std::optional<std::string_view>> expected = {
+        std::string_view(R"({"k":"a"})"),
+        std::nullopt,
+        std::string_view(R"({"k":"b"})"),
+        std::string_view(R"({"k":"c"})"),
+        std::string_view(R"({"k":""})"),
+        std::string_view(R"({"k":"d"})"),
+    };
+    ASSERT_EQ(views.size(), expected.size());
+    ASSERT_EQ(valid.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(valid[i], expected[i].has_value());
+        if (expected[i].has_value()) {
+            EXPECT_EQ(views[i], expected[i].value());
+        }
+    }
+}
+
+TEST(chunk, test_geometry_field_sliced_binary_batches) {
+    auto batch1 = BuildBinaryArray({std::string("skip-a"),
+                                    std::string("wkb-a"),
+                                    std::nullopt,
+                                    std::string("wkb-b"),
+                                    std::string("skip-b")});
+    auto batch2 = BuildBinaryArray({std::string("skip-c"),
+                                    std::string("wkb-c"),
+                                    std::string(""),
+                                    std::string("wkb-d"),
+                                    std::string("skip-d")});
+
+    arrow::ArrayVector array_vec{
+        std::static_pointer_cast<arrow::Array>(batch1)->Slice(1, 3),
+        std::static_pointer_cast<arrow::Array>(batch2)->Slice(1, 3),
+    };
+
+    FieldMeta field_meta(FieldName("a"),
+                         milvus::FieldId(1),
+                         DataType::GEOMETRY,
+                         true,
+                         std::nullopt);
+    auto chunk = create_chunk(field_meta, array_vec);
+    auto geometry_chunk = static_cast<GeometryChunk*>(chunk.get());
+    auto [views, valid] = geometry_chunk->StringViews(std::nullopt);
+
+    std::vector<std::optional<std::string_view>> expected = {
+        std::string_view("wkb-a"),
+        std::nullopt,
+        std::string_view("wkb-b"),
+        std::string_view("wkb-c"),
+        std::string_view(""),
+        std::string_view("wkb-d"),
+    };
+    ASSERT_EQ(views.size(), expected.size());
+    ASSERT_EQ(valid.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(valid[i], expected[i].has_value());
+        if (expected[i].has_value()) {
+            EXPECT_EQ(views[i], expected[i].value());
         }
     }
 }

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -83,10 +83,6 @@ CalculateBinaryLikeChunkSize(
             const auto relative_offset =
                 static_cast<size_t>(array->value_offset(i) - payload_begin);
             const auto absolute_offset = cursor + relative_offset;
-            AssertInfo(absolute_offset <= std::numeric_limits<uint32_t>::max(),
-                       "{} chunk size {} exceeds uint32 offset limit",
-                       chunk_name,
-                       absolute_offset);
             offsets.push_back(static_cast<uint32_t>(absolute_offset));
         }
 

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -786,6 +786,9 @@ create_chunk_buffer(const FieldMeta& field_meta,
             file_path, mmap_populate, aligned_size, io_prio);
     }
     cw->write_to_target(array_vec, target);
+    // The writer is one-shot. Release its scratch buffers before a
+    // file-backed target populates the resulting mmap in release().
+    cw.reset();
     auto data = target->release();
     std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard = nullptr;
     if (!file_path.empty()) {
@@ -895,6 +898,9 @@ create_group_chunk(const std::vector<FieldId>& field_ids,
             char padding[ChunkTarget::ALIGNED_SIZE] = {};
             target->write(padding, padding_size);
         }
+        // Release each one-shot writer's scratch buffers before the combined
+        // file-backed mapping is populated in target->release().
+        cws[i].reset();
     }
 
     auto data = target->release();

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -36,42 +36,109 @@
 #include "storage/FileWriter.h"
 
 namespace milvus {
+namespace {
 
-std::pair<size_t, size_t>
-StringChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
-    // Single pass over Arrow: compute row count, absolute offsets, total
-    // size. write_to_target reuses offsets_ and walks Arrow just once more
-    // to emit the string bytes (2 arrow passes total instead of 4).
-    row_nums_ = 0;
+size_t
+CalculateBinaryLikeChunkSize(
+    const arrow::ArrayVector& array_vec,
+    bool nullable,
+    size_t& row_nums,
+    std::vector<uint32_t>& offsets,
+    std::vector<std::pair<const uint8_t*, size_t>>& payload_segments,
+    size_t padding_size,
+    const char* writer_name,
+    const char* chunk_name) {
+    row_nums = 0;
     for (const auto& data : array_vec) {
-        row_nums_ += data->length();
+        row_nums += data->length();
     }
 
-    const int offset_num = row_nums_ + 1;
-    const size_t null_bitmap_bytes = nullable_ ? (row_nums_ + 7) / 8 : 0;
+    const size_t offset_num = row_nums + 1;
+    const size_t null_bitmap_bytes = nullable ? (row_nums + 7) / 8 : 0;
     size_t cursor = null_bitmap_bytes + sizeof(uint32_t) * offset_num;
 
-    offsets_.clear();
-    offsets_.reserve(offset_num);
+    offsets.clear();
+    offsets.reserve(offset_num);
+    payload_segments.clear();
+    payload_segments.reserve(array_vec.size());
+
     for (const auto& data : array_vec) {
         auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
         AssertInfo(array != nullptr,
-                   "StringChunkWriter expects arrow::BinaryArray, got "
-                   "type id {}; upstream normalizer must coerce to BINARY",
+                   "{} expects arrow::BinaryArray, got type id {}; upstream "
+                   "normalizer must coerce to BINARY",
+                   writer_name,
                    data ? static_cast<int>(data->type_id()) : -1);
-        for (int i = 0; i < array->length(); i++) {
-            offsets_.push_back(static_cast<uint32_t>(cursor));
-            cursor += array->GetView(i).size();
-        }
-    }
-    // String chunk uses uint32 offsets on disk; reject oversize chunks loudly
-    // rather than silently wrapping.
-    AssertInfo(cursor <= std::numeric_limits<uint32_t>::max(),
-               "string chunk size {} exceeds uint32 offset limit",
-               cursor);
-    offsets_.push_back(static_cast<uint32_t>(cursor));
 
-    size_t size = cursor + MMAP_STRING_PADDING;
+        const auto length = array->length();
+        const auto payload_begin = array->value_offset(0);
+        const auto payload_end = array->value_offset(length);
+        AssertInfo(payload_end >= payload_begin,
+                   "{} got invalid Arrow binary offsets: begin {}, end {}",
+                   writer_name,
+                   payload_begin,
+                   payload_end);
+
+        for (int64_t i = 0; i < length; ++i) {
+            const auto relative_offset =
+                static_cast<size_t>(array->value_offset(i) - payload_begin);
+            const auto absolute_offset = cursor + relative_offset;
+            AssertInfo(absolute_offset <= std::numeric_limits<uint32_t>::max(),
+                       "{} chunk size {} exceeds uint32 offset limit",
+                       chunk_name,
+                       absolute_offset);
+            offsets.push_back(static_cast<uint32_t>(absolute_offset));
+        }
+
+        const auto payload_size =
+            static_cast<size_t>(payload_end - payload_begin);
+        if (payload_size > 0) {
+            payload_segments.emplace_back(
+                array->value_data()->data() + payload_begin, payload_size);
+        }
+        cursor += payload_size;
+    }
+
+    AssertInfo(cursor <= std::numeric_limits<uint32_t>::max(),
+               "{} chunk size {} exceeds uint32 offset limit",
+               chunk_name,
+               cursor);
+    offsets.push_back(static_cast<uint32_t>(cursor));
+
+    return cursor + padding_size;
+}
+
+void
+WriteBinaryLikePayload(
+    const std::vector<uint32_t>& offsets,
+    const std::vector<std::pair<const uint8_t*, size_t>>& payload_segments,
+    const std::shared_ptr<ChunkTarget>& target,
+    size_t padding_size) {
+    target->write(offsets.data(), offsets.size() * sizeof(uint32_t));
+
+    for (const auto& segment : payload_segments) {
+        target->write(segment.first, segment.second);
+    }
+
+    char padding[simdjson::SIMDJSON_PADDING] = {};
+    target->write(padding, padding_size);
+}
+
+}  // namespace
+
+std::pair<size_t, size_t>
+StringChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
+    // Single pass over Arrow: compute row count, absolute Milvus offsets, and
+    // contiguous Arrow payload segments. write_to_target emits each payload
+    // segment with one write instead of one write per row.
+    auto size = CalculateBinaryLikeChunkSize(array_vec,
+                                             nullable_,
+                                             row_nums_,
+                                             offsets_,
+                                             payload_segments_,
+                                             MMAP_STRING_PADDING,
+                                             "StringChunkWriter",
+                                             "string");
     return {size, row_nums_};
 }
 
@@ -89,61 +156,25 @@ StringChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
         write_null_bit_maps(null_bitmaps, target);
     }
 
-    target->write(offsets_.data(), offsets_.size() * sizeof(uint32_t));
-
-    for (const auto& data : array_vec) {
-        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
-        AssertInfo(array != nullptr,
-                   "StringChunkWriter expects arrow::BinaryArray, got "
-                   "type id {}; upstream normalizer must coerce to BINARY",
-                   data ? static_cast<int>(data->type_id()) : -1);
-        for (int i = 0; i < array->length(); i++) {
-            auto str = array->GetView(i);
-            target->write(str.data(), str.size());
-        }
-    }
-
-    char padding[MMAP_STRING_PADDING] = {};
-    target->write(padding, MMAP_STRING_PADDING);
-
+    WriteBinaryLikePayload(
+        offsets_, payload_segments_, target, MMAP_STRING_PADDING);
     offsets_.clear();
-    offsets_.shrink_to_fit();
+    payload_segments_.clear();
 }
 
 std::pair<size_t, size_t>
 JSONChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
-    // Single pass over Arrow: compute row count, absolute offsets, total
-    // size. No per-row simdjson::padded_string allocation — write_to_target
-    // copies bytes directly from the Arrow buffer and emits a single
-    // SIMDJSON_PADDING region at the tail.
-    row_nums_ = 0;
-    for (const auto& data : array_vec) {
-        row_nums_ += data->length();
-    }
-
-    const int offset_num = row_nums_ + 1;
-    const size_t null_bitmap_bytes = nullable_ ? (row_nums_ + 7) / 8 : 0;
-    size_t cursor = null_bitmap_bytes + sizeof(uint32_t) * offset_num;
-
-    offsets_.clear();
-    offsets_.reserve(offset_num);
-    for (const auto& data : array_vec) {
-        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
-        AssertInfo(array != nullptr,
-                   "JSONChunkWriter expects arrow::BinaryArray, got "
-                   "type id {}; upstream normalizer must coerce to BINARY",
-                   data ? static_cast<int>(data->type_id()) : -1);
-        for (int i = 0; i < array->length(); i++) {
-            offsets_.push_back(static_cast<uint32_t>(cursor));
-            cursor += array->GetView(i).size();
-        }
-    }
-    AssertInfo(cursor <= std::numeric_limits<uint32_t>::max(),
-               "json chunk size {} exceeds uint32 offset limit",
-               cursor);
-    offsets_.push_back(static_cast<uint32_t>(cursor));
-
-    size_t size = cursor + simdjson::SIMDJSON_PADDING;
+    // Single pass over Arrow: compute row count, absolute Milvus offsets, and
+    // contiguous Arrow payload segments. No per-row simdjson::padded_string
+    // allocation — write_to_target emits a single SIMDJSON padding region.
+    auto size = CalculateBinaryLikeChunkSize(array_vec,
+                                             nullable_,
+                                             row_nums_,
+                                             offsets_,
+                                             payload_segments_,
+                                             simdjson::SIMDJSON_PADDING,
+                                             "JSONChunkWriter",
+                                             "json");
     return {size, row_nums_};
 }
 
@@ -161,56 +192,23 @@ JSONChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
         write_null_bit_maps(null_bitmaps, target);
     }
 
-    target->write(offsets_.data(), offsets_.size() * sizeof(uint32_t));
-
-    for (const auto& data : array_vec) {
-        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
-        for (int i = 0; i < array->length(); i++) {
-            auto str = array->GetView(i);
-            target->write(str.data(), str.size());
-        }
-    }
-
-    char padding[simdjson::SIMDJSON_PADDING] = {};
-    target->write(padding, simdjson::SIMDJSON_PADDING);
-
+    WriteBinaryLikePayload(
+        offsets_, payload_segments_, target, simdjson::SIMDJSON_PADDING);
     offsets_.clear();
-    offsets_.shrink_to_fit();
+    payload_segments_.clear();
 }
 
 std::pair<size_t, size_t>
 GeometryChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
-    // Same pattern as String/JSON: single Arrow pass produces offsets_ and
-    // total size; write_to_target reuses offsets_ + walks Arrow once for
-    // the WKB bytes.
-    row_nums_ = 0;
-    for (const auto& data : array_vec) {
-        row_nums_ += data->length();
-    }
-
-    const int offset_num = row_nums_ + 1;
-    const size_t null_bitmap_bytes = nullable_ ? (row_nums_ + 7) / 8 : 0;
-    size_t cursor = null_bitmap_bytes + sizeof(uint32_t) * offset_num;
-
-    offsets_.clear();
-    offsets_.reserve(offset_num);
-    for (const auto& data : array_vec) {
-        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
-        AssertInfo(array != nullptr,
-                   "GeometryChunkWriter expects arrow::BinaryArray, got "
-                   "type id {}; upstream normalizer must coerce to BINARY",
-                   data ? static_cast<int>(data->type_id()) : -1);
-        for (int64_t i = 0; i < array->length(); ++i) {
-            offsets_.push_back(static_cast<uint32_t>(cursor));
-            cursor += array->GetView(i).size();
-        }
-    }
-    AssertInfo(cursor <= std::numeric_limits<uint32_t>::max(),
-               "geometry chunk size {} exceeds uint32 offset limit",
-               cursor);
-    offsets_.push_back(static_cast<uint32_t>(cursor));
-
-    size_t size = cursor + MMAP_GEOMETRY_PADDING;
+    // Same layout as String/JSON; only the tail padding size differs.
+    auto size = CalculateBinaryLikeChunkSize(array_vec,
+                                             nullable_,
+                                             row_nums_,
+                                             offsets_,
+                                             payload_segments_,
+                                             MMAP_GEOMETRY_PADDING,
+                                             "GeometryChunkWriter",
+                                             "geometry");
     return {size, row_nums_};
 }
 
@@ -229,25 +227,10 @@ GeometryChunkWriter::write_to_target(
         write_null_bit_maps(null_bitmaps, target);
     }
 
-    target->write(offsets_.data(), offsets_.size() * sizeof(uint32_t));
-
-    for (const auto& data : array_vec) {
-        auto array = std::dynamic_pointer_cast<arrow::BinaryArray>(data);
-        AssertInfo(array != nullptr,
-                   "GeometryChunkWriter expects arrow::BinaryArray, got "
-                   "type id {}; upstream normalizer must coerce to BINARY",
-                   data ? static_cast<int>(data->type_id()) : -1);
-        for (int64_t i = 0; i < array->length(); ++i) {
-            auto str = array->GetView(i);
-            target->write(str.data(), str.size());
-        }
-    }
-
-    char padding[MMAP_GEOMETRY_PADDING] = {};
-    target->write(padding, MMAP_GEOMETRY_PADDING);
-
+    WriteBinaryLikePayload(
+        offsets_, payload_segments_, target, MMAP_GEOMETRY_PADDING);
     offsets_.clear();
-    offsets_.shrink_to_fit();
+    payload_segments_.clear();
 }
 
 std::pair<size_t, size_t>

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -232,9 +232,10 @@ class StringChunkWriter : public ChunkWriterBase {
  private:
     // Pre-computed absolute offsets (offsets_[i] = byte offset of row i from
     // chunk start, offsets_[row_nums_] = end offset). Populated in
-    // calculate_size, consumed in write_to_target to avoid a second pass over
-    // Arrow for sizing.
+    // calculate_size, consumed in write_to_target together with borrowed Arrow
+    // payload segments while the input array_vec is still alive.
     std::vector<uint32_t> offsets_;
+    std::vector<std::pair<const uint8_t*, size_t>> payload_segments_;
 };
 
 class JSONChunkWriter : public ChunkWriterBase {
@@ -253,6 +254,7 @@ class JSONChunkWriter : public ChunkWriterBase {
     // buffer is kept — we write Arrow bytes directly and emit a single
     // SIMDJSON_PADDING region at the tail.
     std::vector<uint32_t> offsets_;
+    std::vector<std::pair<const uint8_t*, size_t>> payload_segments_;
 };
 
 class GeometryChunkWriter : public ChunkWriterBase {
@@ -268,6 +270,7 @@ class GeometryChunkWriter : public ChunkWriterBase {
 
  private:
     std::vector<uint32_t> offsets_;
+    std::vector<std::pair<const uint8_t*, size_t>> payload_segments_;
 };
 
 class ArrayChunkWriter : public ChunkWriterBase {


### PR DESCRIPTION
issue: #51673

## What changed

- Write STRING, JSON, and GEOMETRY payloads once per non-empty Arrow batch instead of once per row.
- Reuse precomputed offsets and preserve nullable, sliced-array, and padding layouts.
- Check the uint32 chunk-size limit once after the monotonic offset scan instead of on every row.
- Add sliced multi-batch coverage for all three field types.

## Local microbenchmark

The benchmark harness is not included in this PR. Five-repetition CPU-time means using an in-memory target:

- 100k rows × 16 B, 1/16/256 Arrow batches: 2.03× / 1.94× / 1.84× faster; write calls drop from 100,002 to 3/18/258.
- 100k rows × 128 B, 16 batches: 1.25× faster.
- 10k rows × 1024 B, 16 batches: 1.21× faster.

The host had a high load average and CPU scaling enabled, so these are relative microbenchmark results only; mmap and disk I/O are excluded.
