### PR TITLE
test: add pinyin filter end-to-end coverage

### DIFF
--- a/tests/go_client/testcases/pinyin_filter_test.go
+++ b/tests/go_client/testcases/pinyin_filter_test.go
@@ -85,18 +85,21 @@ func flushPinyinRows(t *testing.T, ctx CtxT, mc MC, collectionName string) {
 	require.NoError(t, lastErr)
 }
 
-func queryPinyinIDs(t *testing.T, ctx CtxT, mc MC, collectionName, queryText string) []int64 {
-	result, err := mc.Query(ctx, client.NewQueryOption(collectionName).
+func searchPinyinIDs(t *testing.T, ctx CtxT, mc MC, collectionName, queryText string) []int64 {
+	result, err := mc.Search(ctx, client.NewSearchOption(collectionName, pinyinTotalCount,
+		[]entity.Vector{entity.FloatVector{0, 0}}).
+		WithANNSField("vector").
+		WithSearchParam("nprobe", "64").
 		WithFilter(`text_match(text, "`+queryText+`")`).
 		WithOutputFields("id", "text").
-		WithLimit(pinyinTotalCount).
 		WithConsistencyLevel(entity.ClStrong))
 	require.NoError(t, err)
+	require.Len(t, result, 1)
 
-	idColumn := result.GetColumn("id")
+	idColumn := result[0].GetColumn("id")
 	require.NotNil(t, idColumn)
-	ids := make([]int64, result.ResultCount)
-	for i := 0; i < result.ResultCount; i++ {
+	ids := make([]int64, result[0].ResultCount)
+	for i := 0; i < result[0].ResultCount; i++ {
 		value, err := idColumn.Get(i)
 		require.NoError(t, err)
 		ids[i] = value.(int64)
@@ -105,11 +108,11 @@ func queryPinyinIDs(t *testing.T, ctx CtxT, mc MC, collectionName, queryText str
 	return ids
 }
 
-func queryPinyinIDsUntilExpected(t *testing.T, ctx CtxT, mc MC, collectionName, queryText string) []int64 {
+func searchPinyinIDsUntilExpected(t *testing.T, ctx CtxT, mc MC, collectionName, queryText string) []int64 {
 	deadline := time.Now().Add(30 * time.Second)
 	var ids []int64
 	for time.Now().Before(deadline) {
-		ids = queryPinyinIDs(t, ctx, mc, collectionName, queryText)
+		ids = searchPinyinIDs(t, ctx, mc, collectionName, queryText)
 		if len(ids) == len(pinyinTargetIDs) {
 			matched := true
 			for i := range ids {
@@ -180,7 +183,7 @@ func TestPinyinFilterTextMatchAcrossDataPaths(t *testing.T) {
 		pinyinIndexedSealedCount+pinyinUnindexedSealedCount, pinyinGrowingCount)
 
 	for _, queryText := range []string{"zhongwen", "中文"} {
-		ids := queryPinyinIDsUntilExpected(t, ctx, mc, collectionName, queryText)
+		ids := searchPinyinIDsUntilExpected(t, ctx, mc, collectionName, queryText)
 		require.Equal(t, pinyinTargetIDs, ids)
 	}
 }

--- a/tests/go_client/testcases/pinyin_filter_test.go
+++ b/tests/go_client/testcases/pinyin_filter_test.go
@@ -1,0 +1,186 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// L0 coverage for Pinyin Text Match through the public Go SDK.
+package testcases
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+	"github.com/milvus-io/milvus/client/v3/index"
+	client "github.com/milvus-io/milvus/client/v3/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+const (
+	pinyinIndexedSealedCount   = 3000
+	pinyinUnindexedSealedCount = 500
+	pinyinGrowingCount         = 500
+	pinyinTotalCount           = pinyinIndexedSealedCount + pinyinUnindexedSealedCount + pinyinGrowingCount
+	pinyinVectorDim            = 2
+)
+
+var pinyinTargetIDs = []int64{
+	0,
+	pinyinIndexedSealedCount,
+	pinyinIndexedSealedCount + pinyinUnindexedSealedCount,
+}
+
+func insertPinyinRows(t *testing.T, ctx CtxT, mc MC, collectionName string, start, count int) {
+	ids := make([]int64, count)
+	texts := make([]string, count)
+	vectors := make([][]float32, count)
+	for i := 0; i < count; i++ {
+		rowID := int64(start + i)
+		ids[i] = rowID
+		texts[i] = "向量数据库样本"
+		if rowID == pinyinTargetIDs[0] || rowID == pinyinTargetIDs[1] || rowID == pinyinTargetIDs[2] {
+			texts[i] = "中文测试"
+		}
+		vectors[i] = []float32{float32(rowID % 2), float32((rowID / 2) % 2)}
+	}
+
+	result, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collectionName).
+		WithInt64Column("id", ids).
+		WithVarcharColumn("text", texts).
+		WithFloatVectorColumn("vector", pinyinVectorDim, vectors))
+	require.NoError(t, err)
+	require.EqualValues(t, count, result.InsertCount)
+}
+
+func flushPinyinRows(t *testing.T, ctx CtxT, mc MC, collectionName string) {
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		flushTask, err := mc.Flush(ctx, client.NewFlushOption(collectionName))
+		if err == nil {
+			require.NoError(t, flushTask.Await(ctx))
+			return
+		}
+		lastErr = err
+		require.True(t, strings.Contains(err.Error(), "rate limit exceeded"), err)
+		time.Sleep(2 * time.Second)
+	}
+	require.NoError(t, lastErr)
+}
+
+func queryPinyinIDs(t *testing.T, ctx CtxT, mc MC, collectionName, queryText string) []int64 {
+	result, err := mc.Query(ctx, client.NewQueryOption(collectionName).
+		WithFilter(`text_match(text, "`+queryText+`")`).
+		WithOutputFields("id", "text").
+		WithLimit(pinyinTotalCount).
+		WithConsistencyLevel(entity.ClStrong))
+	require.NoError(t, err)
+
+	idColumn := result.GetColumn("id")
+	require.NotNil(t, idColumn)
+	ids := make([]int64, result.ResultCount)
+	for i := 0; i < result.ResultCount; i++ {
+		value, err := idColumn.Get(i)
+		require.NoError(t, err)
+		ids[i] = value.(int64)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+func queryPinyinIDsUntilExpected(t *testing.T, ctx CtxT, mc MC, collectionName, queryText string) []int64 {
+	deadline := time.Now().Add(30 * time.Second)
+	var ids []int64
+	for time.Now().Before(deadline) {
+		ids = queryPinyinIDs(t, ctx, mc, collectionName, queryText)
+		if len(ids) == len(pinyinTargetIDs) {
+			matched := true
+			for i := range ids {
+				if ids[i] != pinyinTargetIDs[i] {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return ids
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	return ids
+}
+
+func TestPinyinFilterTextMatchAcrossDataPaths(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	collectionName := common.GenRandomString("pinyin_filter", 6)
+
+	analyzerParams := map[string]any{
+		"tokenizer": "jieba",
+		"filter": []any{
+			map[string]any{
+				"type":                       "pinyin",
+				"keep_original":              true,
+				"keep_full_pinyin":           false,
+				"keep_joined_full_pinyin":    true,
+				"keep_separate_first_letter": false,
+			},
+		},
+	}
+	schema := entity.NewSchema().WithName(collectionName).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName("text").WithDataType(entity.FieldTypeVarChar).WithMaxLength(1024).
+			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(analyzerParams)).
+		WithField(entity.NewField().WithName("vector").WithDataType(entity.FieldTypeFloatVector).WithDim(pinyinVectorDim))
+
+	require.NoError(t, mc.CreateCollection(ctx, client.NewCreateCollectionOption(collectionName, schema).
+		WithConsistencyLevel(entity.ClStrong)))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collectionName)))
+	})
+
+	require.NoError(t, mc.AlterCollectionProperties(ctx, client.NewAlterCollectionPropertiesOption(collectionName).
+		WithProperty("collection.autocompaction.enabled", false)))
+
+	insertPinyinRows(t, ctx, mc, collectionName, 0, pinyinIndexedSealedCount)
+	flushPinyinRows(t, ctx, mc, collectionName)
+
+	insertPinyinRows(t, ctx, mc, collectionName, pinyinIndexedSealedCount, pinyinUnindexedSealedCount)
+	flushPinyinRows(t, ctx, mc, collectionName)
+
+	indexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collectionName, "vector",
+		index.NewIvfFlatIndex(entity.L2, 64)))
+	require.NoError(t, err)
+	require.NoError(t, indexTask.Await(ctx))
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collectionName))
+	require.NoError(t, err)
+	require.NoError(t, loadTask.Await(ctx))
+
+	insertPinyinRows(t, ctx, mc, collectionName,
+		pinyinIndexedSealedCount+pinyinUnindexedSealedCount, pinyinGrowingCount)
+
+	for _, queryText := range []string{"zhongwen", "中文"} {
+		ids := queryPinyinIDsUntilExpected(t, ctx, mc, collectionName, queryText)
+		require.Equal(t, pinyinTargetIDs, ids)
+	}
+}

--- a/tests/go_client/testcases/pinyin_filter_test.go
+++ b/tests/go_client/testcases/pinyin_filter_test.go
@@ -47,6 +47,42 @@ var pinyinTargetIDs = []int64{
 	pinyinIndexedSealedCount + pinyinUnindexedSealedCount,
 }
 
+func pinyinAnalyzerParams(keepOriginal bool) map[string]any {
+	return map[string]any{
+		"tokenizer": "jieba",
+		"filter": []any{
+			map[string]any{
+				"type":                       "pinyin",
+				"keep_original":              keepOriginal,
+				"keep_full_pinyin":           false,
+				"keep_joined_full_pinyin":    true,
+				"keep_separate_first_letter": false,
+			},
+		},
+	}
+}
+
+func requirePinyinAnalyzerTokens(
+	t *testing.T,
+	ctx CtxT,
+	mc MC,
+	analyzerParams map[string]any,
+	expected []string,
+) {
+	t.Helper()
+
+	results, err := mc.RunAnalyzer(ctx, client.NewRunAnalyzerOption("中文测试").
+		WithAnalyzerParams(analyzerParams))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	tokens := make([]string, len(results[0].Tokens))
+	for i, token := range results[0].Tokens {
+		tokens[i] = token.Text
+	}
+	require.Equal(t, expected, tokens)
+}
+
 func insertPinyinRows(t *testing.T, ctx CtxT, mc MC, collectionName string, start, count int) {
 	ids := make([]int64, count)
 	texts := make([]string, count)
@@ -135,18 +171,22 @@ func TestPinyinFilterTextMatchAcrossDataPaths(t *testing.T) {
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 	collectionName := common.GenRandomString("pinyin_filter", 6)
 
-	analyzerParams := map[string]any{
-		"tokenizer": "jieba",
-		"filter": []any{
-			map[string]any{
-				"type":                       "pinyin",
-				"keep_original":              true,
-				"keep_full_pinyin":           false,
-				"keep_joined_full_pinyin":    true,
-				"keep_separate_first_letter": false,
-			},
-		},
-	}
+	analyzerParams := pinyinAnalyzerParams(true)
+	requirePinyinAnalyzerTokens(
+		t,
+		ctx,
+		mc,
+		analyzerParams,
+		[]string{"中文", "zhongwen", "测试", "ceshi"},
+	)
+	requirePinyinAnalyzerTokens(
+		t,
+		ctx,
+		mc,
+		pinyinAnalyzerParams(false),
+		[]string{"zhongwen", "ceshi"},
+	)
+
 	schema := entity.NewSchema().WithName(collectionName).
 		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
 		WithField(entity.NewField().WithName("text").WithDataType(entity.FieldTypeVarChar).WithMaxLength(1024).

--- a/tests/go_client/testcases/pinyin_filter_test.go
+++ b/tests/go_client/testcases/pinyin_filter_test.go
@@ -19,6 +19,7 @@ package testcases
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -62,17 +63,59 @@ func pinyinAnalyzerParams(keepOriginal bool) map[string]any {
 	}
 }
 
-func requirePinyinAnalyzerTokens(
+func pinyinCollectionSchema(collectionName string, analyzerParams map[string]any) *entity.Schema {
+	return entity.NewSchema().WithName(collectionName).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName("text").WithDataType(entity.FieldTypeVarChar).WithMaxLength(1024).
+			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(analyzerParams)).
+		WithField(entity.NewField().WithName("vector").WithDataType(entity.FieldTypeFloatVector).WithDim(pinyinVectorDim))
+}
+
+func createPinyinCollection(
 	t *testing.T,
 	ctx CtxT,
 	mc MC,
+	collectionName string,
 	analyzerParams map[string]any,
+) {
+	t.Helper()
+
+	require.NoError(t, mc.CreateCollection(ctx, client.NewCreateCollectionOption(
+		collectionName,
+		pinyinCollectionSchema(collectionName, analyzerParams),
+	).WithConsistencyLevel(entity.ClStrong)))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collectionName)))
+	})
+}
+
+func indexAndLoadPinyinCollection(t *testing.T, ctx CtxT, mc MC, collectionName string) {
+	t.Helper()
+
+	indexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collectionName, "vector",
+		index.NewIvfFlatIndex(entity.L2, 64)))
+	require.NoError(t, err)
+	require.NoError(t, indexTask.Await(ctx))
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collectionName))
+	require.NoError(t, err)
+	require.NoError(t, loadTask.Await(ctx))
+}
+
+func requirePinyinFieldAnalyzerTokens(
+	t *testing.T,
+	ctx CtxT,
+	mc MC,
+	collectionName string,
+	text string,
 	expected []string,
 ) {
 	t.Helper()
 
-	results, err := mc.RunAnalyzer(ctx, client.NewRunAnalyzerOption("中文测试").
-		WithAnalyzerParams(analyzerParams))
+	results, err := mc.RunAnalyzer(ctx, client.NewRunAnalyzerOption(text).
+		WithField(collectionName, "text"))
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
@@ -121,12 +164,23 @@ func flushPinyinRows(t *testing.T, ctx CtxT, mc MC, collectionName string) {
 	require.NoError(t, lastErr)
 }
 
-func searchPinyinIDs(t *testing.T, ctx CtxT, mc MC, collectionName, queryText string) []int64 {
+func searchPinyinIDs(
+	t *testing.T,
+	ctx CtxT,
+	mc MC,
+	collectionName string,
+	queryText string,
+	minimumShouldMatch int,
+) []int64 {
+	filter := fmt.Sprintf("text_match(text, %q)", queryText)
+	if minimumShouldMatch > 0 {
+		filter = fmt.Sprintf("text_match(text, %q, minimum_should_match=%d)", queryText, minimumShouldMatch)
+	}
 	result, err := mc.Search(ctx, client.NewSearchOption(collectionName, pinyinTotalCount,
 		[]entity.Vector{entity.FloatVector{0, 0}}).
 		WithANNSField("vector").
 		WithSearchParam("nprobe", "64").
-		WithFilter(`text_match(text, "`+queryText+`")`).
+		WithFilter(filter).
 		WithOutputFields("id", "text").
 		WithConsistencyLevel(entity.ClStrong))
 	require.NoError(t, err)
@@ -144,15 +198,23 @@ func searchPinyinIDs(t *testing.T, ctx CtxT, mc MC, collectionName, queryText st
 	return ids
 }
 
-func searchPinyinIDsUntilExpected(t *testing.T, ctx CtxT, mc MC, collectionName, queryText string) []int64 {
+func searchPinyinIDsUntilExpected(
+	t *testing.T,
+	ctx CtxT,
+	mc MC,
+	collectionName string,
+	queryText string,
+	minimumShouldMatch int,
+	expectedIDs []int64,
+) []int64 {
 	deadline := time.Now().Add(30 * time.Second)
 	var ids []int64
 	for time.Now().Before(deadline) {
-		ids = searchPinyinIDs(t, ctx, mc, collectionName, queryText)
-		if len(ids) == len(pinyinTargetIDs) {
+		ids = searchPinyinIDs(t, ctx, mc, collectionName, queryText, minimumShouldMatch)
+		if len(ids) == len(expectedIDs) {
 			matched := true
 			for i := range ids {
-				if ids[i] != pinyinTargetIDs[i] {
+				if ids[i] != expectedIDs[i] {
 					matched = false
 					break
 				}
@@ -172,34 +234,19 @@ func TestPinyinFilterTextMatchAcrossDataPaths(t *testing.T) {
 	collectionName := common.GenRandomString("pinyin_filter", 6)
 
 	analyzerParams := pinyinAnalyzerParams(true)
-	requirePinyinAnalyzerTokens(
+	createPinyinCollection(t, ctx, mc, collectionName, analyzerParams)
+
+	withoutOriginalCollectionName := common.GenRandomString("pinyin_filter_no_original", 6)
+	createPinyinCollection(t, ctx, mc, withoutOriginalCollectionName, pinyinAnalyzerParams(false))
+	indexAndLoadPinyinCollection(t, ctx, mc, withoutOriginalCollectionName)
+	requirePinyinFieldAnalyzerTokens(
 		t,
 		ctx,
 		mc,
-		analyzerParams,
-		[]string{"中文", "zhongwen", "测试", "ceshi"},
-	)
-	requirePinyinAnalyzerTokens(
-		t,
-		ctx,
-		mc,
-		pinyinAnalyzerParams(false),
+		withoutOriginalCollectionName,
+		"中文测试",
 		[]string{"zhongwen", "ceshi"},
 	)
-
-	schema := entity.NewSchema().WithName(collectionName).
-		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
-		WithField(entity.NewField().WithName("text").WithDataType(entity.FieldTypeVarChar).WithMaxLength(1024).
-			WithEnableAnalyzer(true).WithEnableMatch(true).WithAnalyzerParams(analyzerParams)).
-		WithField(entity.NewField().WithName("vector").WithDataType(entity.FieldTypeFloatVector).WithDim(pinyinVectorDim))
-
-	require.NoError(t, mc.CreateCollection(ctx, client.NewCreateCollectionOption(collectionName, schema).
-		WithConsistencyLevel(entity.ClStrong)))
-	t.Cleanup(func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		require.NoError(t, mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collectionName)))
-	})
 
 	require.NoError(t, mc.AlterCollectionProperties(ctx, client.NewAlterCollectionPropertiesOption(collectionName).
 		WithProperty("collection.autocompaction.enabled", false)))
@@ -210,20 +257,50 @@ func TestPinyinFilterTextMatchAcrossDataPaths(t *testing.T) {
 	insertPinyinRows(t, ctx, mc, collectionName, pinyinIndexedSealedCount, pinyinUnindexedSealedCount)
 	flushPinyinRows(t, ctx, mc, collectionName)
 
-	indexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collectionName, "vector",
-		index.NewIvfFlatIndex(entity.L2, 64)))
-	require.NoError(t, err)
-	require.NoError(t, indexTask.Await(ctx))
-
-	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collectionName))
-	require.NoError(t, err)
-	require.NoError(t, loadTask.Await(ctx))
+	indexAndLoadPinyinCollection(t, ctx, mc, collectionName)
+	requirePinyinFieldAnalyzerTokens(
+		t,
+		ctx,
+		mc,
+		collectionName,
+		"中文测试",
+		[]string{"中文", "zhongwen", "测试", "ceshi"},
+	)
+	requirePinyinFieldAnalyzerTokens(
+		t,
+		ctx,
+		mc,
+		collectionName,
+		"中文",
+		[]string{"中文", "zhongwen"},
+	)
 
 	insertPinyinRows(t, ctx, mc, collectionName,
 		pinyinIndexedSealedCount+pinyinUnindexedSealedCount, pinyinGrowingCount)
 
-	for _, queryText := range []string{"zhongwen", "中文"} {
-		ids := searchPinyinIDsUntilExpected(t, ctx, mc, collectionName, queryText)
-		require.Equal(t, pinyinTargetIDs, ids)
+	searchCases := []struct {
+		name               string
+		queryText          string
+		minimumShouldMatch int
+		expectedIDs        []int64
+	}{
+		{name: "joined_pinyin", queryText: "zhongwen", expectedIDs: pinyinTargetIDs},
+		{name: "original", queryText: "中文", minimumShouldMatch: 2, expectedIDs: pinyinTargetIDs},
+		{name: "disabled_full_pinyin", queryText: "zhong", expectedIDs: []int64{}},
+		{name: "disabled_first_letters", queryText: "zw", expectedIDs: []int64{}},
+	}
+	for _, searchCase := range searchCases {
+		t.Run(searchCase.name, func(t *testing.T) {
+			ids := searchPinyinIDsUntilExpected(
+				t,
+				ctx,
+				mc,
+				collectionName,
+				searchCase.queryText,
+				searchCase.minimumShouldMatch,
+				searchCase.expectedIDs,
+			)
+			require.Equal(t, searchCase.expectedIDs, ids)
+		})
 	}
 }

--- a/tests/python_client/milvus_client/test_milvus_client_pinyin_filter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_pinyin_filter.py
@@ -26,6 +26,8 @@ PINYIN_OUTPUT_MODES = [
             "keep_separate_first_letter": False,
         },
         "zhong",
+        ["中文", "zhong", "wen", "测试", "ce", "shi"],
+        ["zhongwen", "zw"],
         id="full-pinyin",
     ),
     pytest.param(
@@ -36,6 +38,8 @@ PINYIN_OUTPUT_MODES = [
             "keep_separate_first_letter": False,
         },
         "zhongwen",
+        ["中文", "zhongwen", "测试", "ceshi"],
+        ["zhong", "zw"],
         id="joined-pinyin",
     ),
     pytest.param(
@@ -46,6 +50,8 @@ PINYIN_OUTPUT_MODES = [
             "keep_separate_first_letter": True,
         },
         "zw",
+        ["中文", "zw", "测试", "cs"],
+        ["zhong", "zhongwen"],
         id="first-letters",
     ),
 ]
@@ -74,17 +80,30 @@ def build_rows(start, count, include_vector):
 class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
     """Independent Pinyin filter cases with per-test analyzer configuration."""
 
-    def _query_text_match_until_ids(self, client, collection_name, query_text, expected_ids, timeout=30):
+    @staticmethod
+    def _assert_exact_ids(rows, expected_ids):
+        ids = [row["id"] for row in rows]
+        assert len(ids) == len(expected_ids), ids
+        assert len(ids) == len(set(ids)), ids
+        assert set(ids) == expected_ids, ids
+
+    def _search_text_match_until_ids(self, client, collection_name, query_text, expected_ids, timeout=30):
         deadline = time.monotonic() + timeout
         rows = []
         while time.monotonic() < deadline:
-            rows, _ = self.query(
+            results, _ = self.search(
                 client,
                 collection_name,
+                data=[[0.0, 0.0]],
+                anns_field="vector",
+                search_params={"metric_type": "L2", "params": {"nprobe": 64}},
                 filter=f'text_match(text, "{query_text}")',
+                limit=TOTAL_COUNT,
                 output_fields=["id", "text"],
             )
-            if {row["id"] for row in rows} == expected_ids:
+            rows = results[0] if results else []
+            ids = [row["id"] for row in rows]
+            if len(ids) == len(expected_ids) and len(ids) == len(set(ids)) and set(ids) == expected_ids:
                 return rows
             threading.Event().wait(1)
         return rows
@@ -169,31 +188,74 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("options,pinyin_query", PINYIN_OUTPUT_MODES)
-    def test_pinyin_filter_text_match_output_modes(self, options, pinyin_query):
+    @pytest.mark.parametrize(
+        "options,pinyin_query,expected_tokens,disabled_queries",
+        PINYIN_OUTPUT_MODES,
+    )
+    def test_pinyin_filter_text_match_output_modes(
+        self,
+        options,
+        pinyin_query,
+        expected_tokens,
+        disabled_queries,
+    ):
         """
-        target: verify Pinyin output modes across indexed, unindexed, and growing segments
-        method: build 3000 indexed, 500 unindexed, and 500 growing rows, then query Pinyin and Chinese
-        expected: both query forms return the target row from every segment state
+        target: verify exact Pinyin output modes across indexed, unindexed, and growing search paths
+        method: verify analyzer tokens, then vector-search 3000 indexed, 500 unindexed, and 500 growing rows
+        expected: enabled tokens match every path while tokens from disabled modes do not match
         """
         client = self._client()
-        collection_name = self._create_text_match_collection(client, pinyin_analyzer(options))
+        analyzer_params = pinyin_analyzer(options)
 
-        pinyin_rows = self._query_text_match_until_ids(
+        analyzer_result, _ = self.run_analyzer(client, "中文测试", analyzer_params)
+        assert analyzer_result.tokens == expected_tokens
+
+        collection_name = self._create_text_match_collection(client, analyzer_params)
+
+        pinyin_rows = self._search_text_match_until_ids(
             client,
             collection_name,
             pinyin_query,
             TARGET_IDS,
         )
-        assert {row["id"] for row in pinyin_rows} == TARGET_IDS
+        self._assert_exact_ids(pinyin_rows, TARGET_IDS)
 
-        original_rows = self._query_text_match_until_ids(
+        original_rows = self._search_text_match_until_ids(
             client,
             collection_name,
             "中文",
             TARGET_IDS,
         )
-        assert {row["id"] for row in original_rows} == TARGET_IDS
+        self._assert_exact_ids(original_rows, TARGET_IDS)
+
+        for disabled_query in disabled_queries:
+            disabled_rows = self._search_text_match_until_ids(
+                client,
+                collection_name,
+                disabled_query,
+                set(),
+            )
+            self._assert_exact_ids(disabled_rows, set())
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_pinyin_filter_analyzer_without_original(self):
+        """
+        target: verify keep_original=false removes the original Chinese tokens
+        method: run the joined-Pinyin analyzer directly
+        expected: only joined Pinyin tokens are emitted
+        """
+        client = self._client()
+        analyzer_params = pinyin_analyzer(
+            {
+                "keep_original": False,
+                "keep_full_pinyin": False,
+                "keep_joined_full_pinyin": True,
+                "keep_separate_first_letter": False,
+            }
+        )
+
+        analyzer_result, _ = self.run_analyzer(client, "中文测试", analyzer_params)
+        assert analyzer_result.tokens == ["zhongwen", "ceshi"]
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_pinyin_filter_bm25_search_joined_and_original(self):
@@ -259,5 +321,5 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
                 limit=TOTAL_COUNT,
                 output_fields=["id", "text"],
             )
-            assert {hit["id"] for hit in results[0]} == TARGET_IDS
+            self._assert_exact_ids(results[0], TARGET_IDS)
             assert all(hit["entity"]["text"] == "中文测试" for hit in results[0])

--- a/tests/python_client/milvus_client/test_milvus_client_pinyin_filter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_pinyin_filter.py
@@ -1,14 +1,21 @@
+import threading
+import time
+
 import pytest
 from base.client_v2_base import TestMilvusClientV2Base
 from common import common_func as cf
 from common.common_type import CaseLabel
 from pymilvus import DataType, Function, FunctionType
 
-TEXT_ROWS = [
-    {"id": 0, "text": "中文测试", "vector": [0.0, 0.0]},
-    {"id": 1, "text": "向量数据库", "vector": [1.0, 0.0]},
-    {"id": 2, "text": "机器学习", "vector": [0.0, 1.0]},
-]
+INDEXED_SEALED_COUNT = 3000
+UNINDEXED_SEALED_COUNT = 500
+GROWING_COUNT = 500
+TOTAL_COUNT = INDEXED_SEALED_COUNT + UNINDEXED_SEALED_COUNT + GROWING_COUNT
+
+INDEXED_TARGET_ID = 0
+UNINDEXED_TARGET_ID = INDEXED_SEALED_COUNT
+GROWING_TARGET_ID = INDEXED_SEALED_COUNT + UNINDEXED_SEALED_COUNT
+TARGET_IDS = {INDEXED_TARGET_ID, UNINDEXED_TARGET_ID, GROWING_TARGET_ID}
 
 PINYIN_OUTPUT_MODES = [
     pytest.param(
@@ -51,11 +58,88 @@ def pinyin_analyzer(options):
     }
 
 
+def build_rows(start, count, include_vector):
+    rows = []
+    for row_id in range(start, start + count):
+        row = {
+            "id": row_id,
+            "text": "中文测试" if row_id in TARGET_IDS else f"向量数据库样本{row_id}",
+        }
+        if include_vector:
+            row["vector"] = [float(row_id % 2), float((row_id // 2) % 2)]
+        rows.append(row)
+    return rows
+
+
 class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
     """Independent Pinyin filter cases with per-test analyzer configuration."""
 
-    def _create_text_match_collection(self, client, analyzer_params):
+    def _query_text_match_until_ids(self, client, collection_name, query_text, expected_ids, timeout=30):
+        deadline = time.monotonic() + timeout
+        rows = []
+        while time.monotonic() < deadline:
+            rows, _ = self.query(
+                client,
+                collection_name,
+                filter=f'text_match(text, "{query_text}")',
+                output_fields=["id", "text"],
+            )
+            if {row["id"] for row in rows} == expected_ids:
+                return rows
+            threading.Event().wait(1)
+        return rows
+
+    def _prepare_mixed_segment_collection(
+        self,
+        client,
+        schema,
+        index_params,
+        index_name,
+        include_vector,
+    ):
         collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            consistency_level="Strong",
+        )
+        self.alter_collection_properties(
+            client,
+            collection_name,
+            properties={"collection.autocompaction.enabled": "false"},
+        )
+
+        indexed_rows = build_rows(0, INDEXED_SEALED_COUNT, include_vector)
+        self.insert(client, collection_name, data=indexed_rows)
+        self.flush(client, collection_name)
+
+        unindexed_rows = build_rows(
+            INDEXED_SEALED_COUNT,
+            UNINDEXED_SEALED_COUNT,
+            include_vector,
+        )
+        self.insert(client, collection_name, data=unindexed_rows)
+        self.flush(client, collection_name)
+
+        self.create_index(client, collection_name, index_params=index_params)
+        assert self.wait_for_index_ready(
+            client,
+            collection_name,
+            index_name=index_name,
+            timeout=180,
+        )
+        self.load_collection(client, collection_name, timeout=180)
+
+        growing_rows = build_rows(
+            INDEXED_SEALED_COUNT + UNINDEXED_SEALED_COUNT,
+            GROWING_COUNT,
+            include_vector,
+        )
+        self.insert(client, collection_name, data=growing_rows)
+        return collection_name
+
+    def _create_text_match_collection(self, client, analyzer_params):
         schema = self.create_schema(client, auto_id=False, enable_dynamic_field=False)[0]
         self.add_field(schema, "id", DataType.INT64, is_primary=True)
         self.add_field(
@@ -70,58 +154,55 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
         self.add_field(schema, "vector", DataType.FLOAT_VECTOR, dim=2)
 
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name="vector", index_type="FLAT", metric_type="L2", params={})
-        self.create_collection(
-            client,
-            collection_name,
-            schema=schema,
-            index_params=index_params,
+        index_params.add_index(
+            field_name="vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 64},
         )
-        self.insert(
+        return self._prepare_mixed_segment_collection(
             client,
-            collection_name,
-            data=TEXT_ROWS,
+            schema,
+            index_params,
+            index_name="vector",
+            include_vector=True,
         )
-        self.flush(client, collection_name)
-        self.load_collection(client, collection_name)
-        return collection_name
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("options,pinyin_query", PINYIN_OUTPUT_MODES)
     def test_pinyin_filter_text_match_output_modes(self, options, pinyin_query):
         """
-        target: verify Pinyin output modes through collection indexing and text_match
-        method: insert Chinese rows, then query by configured Pinyin form and original Chinese text
-        expected: both query forms return only the source Chinese row
+        target: verify Pinyin output modes across indexed, unindexed, and growing segments
+        method: build 3000 indexed, 500 unindexed, and 500 growing rows, then query Pinyin and Chinese
+        expected: both query forms return the target row from every segment state
         """
         client = self._client()
         collection_name = self._create_text_match_collection(client, pinyin_analyzer(options))
 
-        pinyin_rows, _ = self.query(
+        pinyin_rows = self._query_text_match_until_ids(
             client,
             collection_name,
-            filter=f'text_match(text, "{pinyin_query}")',
-            output_fields=["id", "text"],
+            pinyin_query,
+            TARGET_IDS,
         )
-        assert {row["id"] for row in pinyin_rows} == {0}
+        assert {row["id"] for row in pinyin_rows} == TARGET_IDS
 
-        original_rows, _ = self.query(
+        original_rows = self._query_text_match_until_ids(
             client,
             collection_name,
-            filter='text_match(text, "中文")',
-            output_fields=["id", "text"],
+            "中文",
+            TARGET_IDS,
         )
-        assert {row["id"] for row in original_rows} == {0}
+        assert {row["id"] for row in original_rows} == TARGET_IDS
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_pinyin_filter_bm25_search_joined_and_original(self):
         """
-        target: verify joined Pinyin participates in BM25 indexing and search
-        method: build a BM25 collection and search the same Chinese row by joined Pinyin and original text
-        expected: both query forms rank the source Chinese row first
+        target: verify joined Pinyin BM25 across indexed, unindexed, and growing segments
+        method: build 3000 indexed, 500 unindexed, and 500 growing rows, then search Pinyin and Chinese
+        expected: both query forms return the target row from every segment state
         """
         client = self._client()
-        collection_name = cf.gen_collection_name_by_testcase_name()
         analyzer_params = pinyin_analyzer(
             {
                 "keep_original": True,
@@ -160,20 +241,13 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
             metric_type="BM25",
             params={},
         )
-        self.create_collection(
+        collection_name = self._prepare_mixed_segment_collection(
             client,
-            collection_name,
-            schema=schema,
-            index_params=index_params,
+            schema,
+            index_params,
+            index_name="sparse",
+            include_vector=False,
         )
-        bm25_rows = [{"id": row["id"], "text": row["text"]} for row in TEXT_ROWS]
-        self.insert(
-            client,
-            collection_name,
-            data=bm25_rows,
-        )
-        self.flush(client, collection_name)
-        self.load_collection(client, collection_name)
 
         for query_text in ["zhongwen", "中文"]:
             results, _ = self.search(
@@ -182,9 +256,8 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
                 data=[query_text],
                 anns_field="sparse",
                 search_params={"metric_type": "BM25", "params": {}},
-                limit=len(bm25_rows),
+                limit=TOTAL_COUNT,
                 output_fields=["id", "text"],
             )
-            assert results[0], f"expected BM25 results for query {query_text!r}"
-            assert results[0][0]["id"] == 0
-            assert results[0][0]["entity"]["text"] == "中文测试"
+            assert {hit["id"] for hit in results[0]} == TARGET_IDS
+            assert all(hit["entity"]["text"] == "中文测试" for hit in results[0])

--- a/tests/python_client/milvus_client/test_milvus_client_pinyin_filter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_pinyin_filter.py
@@ -1,0 +1,190 @@
+import pytest
+from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common.common_type import CaseLabel
+from pymilvus import DataType, Function, FunctionType
+
+TEXT_ROWS = [
+    {"id": 0, "text": "中文测试", "vector": [0.0, 0.0]},
+    {"id": 1, "text": "向量数据库", "vector": [1.0, 0.0]},
+    {"id": 2, "text": "机器学习", "vector": [0.0, 1.0]},
+]
+
+PINYIN_OUTPUT_MODES = [
+    pytest.param(
+        {
+            "keep_original": True,
+            "keep_full_pinyin": True,
+            "keep_joined_full_pinyin": False,
+            "keep_separate_first_letter": False,
+        },
+        "zhong",
+        id="full-pinyin",
+    ),
+    pytest.param(
+        {
+            "keep_original": True,
+            "keep_full_pinyin": False,
+            "keep_joined_full_pinyin": True,
+            "keep_separate_first_letter": False,
+        },
+        "zhongwen",
+        id="joined-pinyin",
+    ),
+    pytest.param(
+        {
+            "keep_original": True,
+            "keep_full_pinyin": False,
+            "keep_joined_full_pinyin": False,
+            "keep_separate_first_letter": True,
+        },
+        "zw",
+        id="first-letters",
+    ),
+]
+
+
+def pinyin_analyzer(options):
+    return {
+        "tokenizer": "jieba",
+        "filter": [{"type": "pinyin", **options}],
+    }
+
+
+class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
+    """Independent Pinyin filter cases with per-test analyzer configuration."""
+
+    def _create_text_match_collection(self, client, analyzer_params):
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        schema = self.create_schema(client, auto_id=False, enable_dynamic_field=False)[0]
+        self.add_field(schema, "id", DataType.INT64, is_primary=True)
+        self.add_field(
+            schema,
+            "text",
+            DataType.VARCHAR,
+            max_length=1024,
+            enable_analyzer=True,
+            enable_match=True,
+            analyzer_params=analyzer_params,
+        )
+        self.add_field(schema, "vector", DataType.FLOAT_VECTOR, dim=2)
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name="vector", index_type="FLAT", metric_type="L2", params={})
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+        )
+        self.insert(
+            client,
+            collection_name,
+            data=TEXT_ROWS,
+        )
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+        return collection_name
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("options,pinyin_query", PINYIN_OUTPUT_MODES)
+    def test_pinyin_filter_text_match_output_modes(self, options, pinyin_query):
+        """
+        target: verify Pinyin output modes through collection indexing and text_match
+        method: insert Chinese rows, then query by configured Pinyin form and original Chinese text
+        expected: both query forms return only the source Chinese row
+        """
+        client = self._client()
+        collection_name = self._create_text_match_collection(client, pinyin_analyzer(options))
+
+        pinyin_rows, _ = self.query(
+            client,
+            collection_name,
+            filter=f'text_match(text, "{pinyin_query}")',
+            output_fields=["id", "text"],
+        )
+        assert {row["id"] for row in pinyin_rows} == {0}
+
+        original_rows, _ = self.query(
+            client,
+            collection_name,
+            filter='text_match(text, "中文")',
+            output_fields=["id", "text"],
+        )
+        assert {row["id"] for row in original_rows} == {0}
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_pinyin_filter_bm25_search_joined_and_original(self):
+        """
+        target: verify joined Pinyin participates in BM25 indexing and search
+        method: build a BM25 collection and search the same Chinese row by joined Pinyin and original text
+        expected: both query forms rank the source Chinese row first
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        analyzer_params = pinyin_analyzer(
+            {
+                "keep_original": True,
+                "keep_full_pinyin": False,
+                "keep_joined_full_pinyin": True,
+                "keep_separate_first_letter": False,
+            }
+        )
+
+        schema = self.create_schema(client, auto_id=False, enable_dynamic_field=False)[0]
+        self.add_field(schema, "id", DataType.INT64, is_primary=True)
+        self.add_field(
+            schema,
+            "text",
+            DataType.VARCHAR,
+            max_length=1024,
+            enable_analyzer=True,
+            enable_match=True,
+            analyzer_params=analyzer_params,
+        )
+        self.add_field(schema, "sparse", DataType.SPARSE_FLOAT_VECTOR)
+        schema.add_function(
+            Function(
+                name="text_bm25",
+                function_type=FunctionType.BM25,
+                input_field_names=["text"],
+                output_field_names=["sparse"],
+                params={},
+            )
+        )
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(
+            field_name="sparse",
+            index_type="SPARSE_INVERTED_INDEX",
+            metric_type="BM25",
+            params={},
+        )
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+        )
+        bm25_rows = [{"id": row["id"], "text": row["text"]} for row in TEXT_ROWS]
+        self.insert(
+            client,
+            collection_name,
+            data=bm25_rows,
+        )
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        for query_text in ["zhongwen", "中文"]:
+            results, _ = self.search(
+                client,
+                collection_name,
+                data=[query_text],
+                anns_field="sparse",
+                search_params={"metric_type": "BM25", "params": {}},
+                limit=len(bm25_rows),
+                output_fields=["id", "text"],
+            )
+            assert results[0], f"expected BM25 results for query {query_text!r}"
+            assert results[0][0]["id"] == 0
+            assert results[0][0]["entity"]["text"] == "中文测试"

--- a/tests/python_client/milvus_client/test_milvus_client_pinyin_filter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_pinyin_filter.py
@@ -17,6 +17,13 @@ UNINDEXED_TARGET_ID = INDEXED_SEALED_COUNT
 GROWING_TARGET_ID = INDEXED_SEALED_COUNT + UNINDEXED_SEALED_COUNT
 TARGET_IDS = {INDEXED_TARGET_ID, UNINDEXED_TARGET_ID, GROWING_TARGET_ID}
 
+BM25_TARGET_TEXTS = {
+    INDEXED_TARGET_ID: "中文 向量 数据库",
+    UNINDEXED_TARGET_ID: "中文 中文 向量",
+    GROWING_TARGET_ID: "中文 中文 中文",
+}
+BM25_EXPECTED_RANKED_IDS = [GROWING_TARGET_ID, UNINDEXED_TARGET_ID, INDEXED_TARGET_ID]
+
 PINYIN_OUTPUT_MODES = [
     pytest.param(
         {
@@ -27,6 +34,7 @@ PINYIN_OUTPUT_MODES = [
         },
         "zhong",
         ["中文", "zhong", "wen", "测试", "ce", "shi"],
+        ["中文", "zhong", "wen"],
         ["zhongwen", "zw"],
         id="full-pinyin",
     ),
@@ -39,6 +47,7 @@ PINYIN_OUTPUT_MODES = [
         },
         "zhongwen",
         ["中文", "zhongwen", "测试", "ceshi"],
+        ["中文", "zhongwen"],
         ["zhong", "zw"],
         id="joined-pinyin",
     ),
@@ -51,6 +60,7 @@ PINYIN_OUTPUT_MODES = [
         },
         "zw",
         ["中文", "zw", "测试", "cs"],
+        ["中文", "zw"],
         ["zhong", "zhongwen"],
         id="first-letters",
     ),
@@ -64,12 +74,16 @@ def pinyin_analyzer(options):
     }
 
 
-def build_rows(start, count, include_vector):
+def build_rows(start, count, include_vector, target_texts=None):
     rows = []
     for row_id in range(start, start + count):
         row = {
             "id": row_id,
-            "text": "中文测试" if row_id in TARGET_IDS else f"向量数据库样本{row_id}",
+            "text": (
+                (target_texts[row_id] if target_texts is not None else "中文测试")
+                if row_id in TARGET_IDS
+                else f"向量数据库样本{row_id}"
+            ),
         }
         if include_vector:
             row["vector"] = [float(row_id % 2), float((row_id // 2) % 2)]
@@ -87,9 +101,28 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
         assert len(ids) == len(set(ids)), ids
         assert set(ids) == expected_ids, ids
 
-    def _search_text_match_until_ids(self, client, collection_name, query_text, expected_ids, timeout=30):
+    def _field_analyzer_tokens(self, client, collection_name, text):
+        analyzer_result, _ = self.run_analyzer(
+            client,
+            text,
+            analyzer_params=None,
+            collection_name=collection_name,
+            field_name="text",
+        )
+        return analyzer_result.tokens
+
+    def _search_text_match_until_ids(
+        self,
+        client,
+        collection_name,
+        query_text,
+        expected_ids,
+        minimum_should_match=None,
+        timeout=30,
+    ):
         deadline = time.monotonic() + timeout
         rows = []
+        match_options = "" if minimum_should_match is None else f", minimum_should_match={minimum_should_match}"
         while time.monotonic() < deadline:
             results, _ = self.search(
                 client,
@@ -97,7 +130,7 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
                 data=[[0.0, 0.0]],
                 anns_field="vector",
                 search_params={"metric_type": "L2", "params": {"nprobe": 64}},
-                filter=f'text_match(text, "{query_text}")',
+                filter=f'text_match(text, "{query_text}"{match_options})',
                 limit=TOTAL_COUNT,
                 output_fields=["id", "text"],
             )
@@ -115,6 +148,7 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
         index_params,
         index_name,
         include_vector,
+        target_texts=None,
     ):
         collection_name = cf.gen_collection_name_by_testcase_name()
         self.create_collection(
@@ -129,7 +163,7 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
             properties={"collection.autocompaction.enabled": "false"},
         )
 
-        indexed_rows = build_rows(0, INDEXED_SEALED_COUNT, include_vector)
+        indexed_rows = build_rows(0, INDEXED_SEALED_COUNT, include_vector, target_texts)
         self.insert(client, collection_name, data=indexed_rows)
         self.flush(client, collection_name)
 
@@ -137,6 +171,7 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
             INDEXED_SEALED_COUNT,
             UNINDEXED_SEALED_COUNT,
             include_vector,
+            target_texts,
         )
         self.insert(client, collection_name, data=unindexed_rows)
         self.flush(client, collection_name)
@@ -154,11 +189,12 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
             INDEXED_SEALED_COUNT + UNINDEXED_SEALED_COUNT,
             GROWING_COUNT,
             include_vector,
+            target_texts,
         )
         self.insert(client, collection_name, data=growing_rows)
         return collection_name
 
-    def _create_text_match_collection(self, client, analyzer_params):
+    def _create_text_match_schema(self, client, analyzer_params):
         schema = self.create_schema(client, auto_id=False, enable_dynamic_field=False)[0]
         self.add_field(schema, "id", DataType.INT64, is_primary=True)
         self.add_field(
@@ -171,6 +207,10 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
             analyzer_params=analyzer_params,
         )
         self.add_field(schema, "vector", DataType.FLOAT_VECTOR, dim=2)
+        return schema
+
+    def _create_text_match_collection(self, client, analyzer_params):
+        schema = self._create_text_match_schema(client, analyzer_params)
 
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(
@@ -187,9 +227,26 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
             include_vector=True,
         )
 
+    def _index_and_load_text_match_collection(self, client, collection_name):
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(
+            field_name="vector",
+            index_type="IVF_FLAT",
+            metric_type="L2",
+            params={"nlist": 64},
+        )
+        self.create_index(client, collection_name, index_params=index_params)
+        assert self.wait_for_index_ready(
+            client,
+            collection_name,
+            index_name="vector",
+            timeout=180,
+        )
+        self.load_collection(client, collection_name, timeout=180)
+
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize(
-        "options,pinyin_query,expected_tokens,disabled_queries",
+        "options,pinyin_query,expected_tokens,original_query_tokens,disabled_queries",
         PINYIN_OUTPUT_MODES,
     )
     def test_pinyin_filter_text_match_output_modes(
@@ -197,6 +254,7 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
         options,
         pinyin_query,
         expected_tokens,
+        original_query_tokens,
         disabled_queries,
     ):
         """
@@ -207,10 +265,9 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
         client = self._client()
         analyzer_params = pinyin_analyzer(options)
 
-        analyzer_result, _ = self.run_analyzer(client, "中文测试", analyzer_params)
-        assert analyzer_result.tokens == expected_tokens
-
         collection_name = self._create_text_match_collection(client, analyzer_params)
+        assert self._field_analyzer_tokens(client, collection_name, "中文测试") == expected_tokens
+        assert self._field_analyzer_tokens(client, collection_name, "中文") == original_query_tokens
 
         pinyin_rows = self._search_text_match_until_ids(
             client,
@@ -225,6 +282,7 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
             collection_name,
             "中文",
             TARGET_IDS,
+            minimum_should_match=len(original_query_tokens),
         )
         self._assert_exact_ids(original_rows, TARGET_IDS)
 
@@ -241,8 +299,8 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
     def test_pinyin_filter_analyzer_without_original(self):
         """
         target: verify keep_original=false removes the original Chinese tokens
-        method: run the joined-Pinyin analyzer directly
-        expected: only joined Pinyin tokens are emitted
+        method: create a field with the joined-Pinyin analyzer and run the analyzer through that field
+        expected: the field configuration emits only joined Pinyin tokens
         """
         client = self._client()
         analyzer_params = pinyin_analyzer(
@@ -254,8 +312,16 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
             }
         )
 
-        analyzer_result, _ = self.run_analyzer(client, "中文测试", analyzer_params)
-        assert analyzer_result.tokens == ["zhongwen", "ceshi"]
+        schema = self._create_text_match_schema(client, analyzer_params)
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            consistency_level="Strong",
+        )
+        self._index_and_load_text_match_collection(client, collection_name)
+        assert self._field_analyzer_tokens(client, collection_name, "中文测试") == ["zhongwen", "ceshi"]
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_pinyin_filter_bm25_search_joined_and_original(self):
@@ -309,6 +375,7 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
             index_params,
             index_name="sparse",
             include_vector=False,
+            target_texts=BM25_TARGET_TEXTS,
         )
 
         for query_text in ["zhongwen", "中文"]:
@@ -318,8 +385,13 @@ class TestMilvusClientPinyinFilterIndependent(TestMilvusClientV2Base):
                 data=[query_text],
                 anns_field="sparse",
                 search_params={"metric_type": "BM25", "params": {}},
-                limit=TOTAL_COUNT,
+                limit=len(BM25_EXPECTED_RANKED_IDS),
                 output_fields=["id", "text"],
             )
-            self._assert_exact_ids(results[0], TARGET_IDS)
-            assert all(hit["entity"]["text"] == "中文测试" for hit in results[0])
+            hits = results[0]
+            assert [hit["id"] for hit in hits] == BM25_EXPECTED_RANKED_IDS
+            distances = [hit["distance"] for hit in hits]
+            assert all(left > right for left, right in zip(distances, distances[1:])), distances
+            assert [hit["entity"]["text"] for hit in hits] == [
+                BM25_TARGET_TEXTS[row_id] for row_id in BM25_EXPECTED_RANKED_IDS
+            ]

--- a/tests/restful_client_v2/testcases/test_pinyin_filter.py
+++ b/tests/restful_client_v2/testcases/test_pinyin_filter.py
@@ -56,30 +56,41 @@ class TestPinyinFilter(TestBase):
         rsp = self._flush_with_rate_limit_retry(collection_name)
         assert rsp["code"] == 0, rsp
 
-    def _query_until_target_ids(self, collection_name, query_text, timeout=30):
+    @staticmethod
+    def _assert_exact_target_ids(rows):
+        ids = [int(row["id"]) for row in rows]
+        assert len(ids) == len(TARGET_IDS), ids
+        assert len(ids) == len(set(ids)), ids
+        assert set(ids) == TARGET_IDS, ids
+
+    def _search_until_target_ids(self, collection_name, query_text, timeout=30):
         deadline = time.monotonic() + timeout
         rows = []
         while time.monotonic() < deadline:
-            rsp = self.vector_client.vector_query(
+            rsp = self.vector_client.vector_search(
                 {
                     "collectionName": collection_name,
+                    "data": [[0.0, 0.0]],
+                    "annsField": "vector",
                     "filter": f'text_match(text, "{query_text}")',
                     "outputFields": ["id", "text"],
                     "limit": TOTAL_COUNT,
+                    "searchParams": {"metricType": "L2", "params": {"nprobe": 64}},
                 },
                 timeout=0,
             )
             assert rsp["code"] == 0, rsp
             rows = rsp["data"]
-            if {int(row["id"]) for row in rows} == TARGET_IDS:
+            ids = [int(row["id"]) for row in rows]
+            if len(ids) == len(TARGET_IDS) and len(ids) == len(set(ids)) and set(ids) == TARGET_IDS:
                 return rows
             time.sleep(1)
         return rows
 
     def test_pinyin_filter_text_match_across_data_paths(self):
         """
-        target: verify Pinyin Text Match through RESTful v2 across three data paths
-        method: build 3000 indexed, 500 unindexed, and 500 growing rows through RESTful v2
+        target: verify filtered Pinyin vector search through RESTful v2 across three data paths
+        method: vector-search 3000 indexed, 500 unindexed, and 500 growing rows through RESTful v2
         expected: joined Pinyin and original Chinese both return the target row from every path
         """
         name = gen_collection_name()
@@ -171,6 +182,6 @@ class TestPinyinFilter(TestBase):
         assert rsp["data"]["insertCount"] == GROWING_COUNT, rsp
 
         for query_text in ["zhongwen", "中文"]:
-            rows = self._query_until_target_ids(name, query_text)
-            assert {int(row["id"]) for row in rows} == TARGET_IDS
+            rows = self._search_until_target_ids(name, query_text)
+            self._assert_exact_target_ids(rows)
             assert all(row["text"] == "中文测试" for row in rows)

--- a/tests/restful_client_v2/testcases/test_pinyin_filter.py
+++ b/tests/restful_client_v2/testcases/test_pinyin_filter.py
@@ -1,0 +1,176 @@
+import time
+
+import pytest
+from base.testbase import TestBase
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+INDEXED_SEALED_COUNT = 3000
+UNINDEXED_SEALED_COUNT = 500
+GROWING_COUNT = 500
+TOTAL_COUNT = INDEXED_SEALED_COUNT + UNINDEXED_SEALED_COUNT + GROWING_COUNT
+
+TARGET_IDS = {
+    0,
+    INDEXED_SEALED_COUNT,
+    INDEXED_SEALED_COUNT + UNINDEXED_SEALED_COUNT,
+}
+
+
+def build_rows(start, count):
+    rows = []
+    for row_id in range(start, start + count):
+        rows.append(
+            {
+                "id": row_id,
+                "text": "中文测试" if row_id in TARGET_IDS else f"向量数据库样本{row_id}",
+                "vector": [float(row_id % 2), float((row_id // 2) % 2)],
+            }
+        )
+    return rows
+
+
+@pytest.mark.tags(CaseLabel.L0)
+class TestPinyinFilter(TestBase):
+    def _flush_with_rate_limit_retry(self, collection_name, timeout=30):
+        deadline = time.monotonic() + timeout
+        rsp = {}
+        while time.monotonic() < deadline:
+            rsp = self.collection_client.flush(collection_name)
+            if rsp["code"] == 0:
+                return rsp
+            assert rsp["code"] == 1807, rsp
+            time.sleep(2)
+        return rsp
+
+    def _insert_and_flush(self, collection_name, start, count):
+        rsp = self.vector_client.vector_insert(
+            {
+                "collectionName": collection_name,
+                "data": build_rows(start, count),
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == count, rsp
+
+        rsp = self._flush_with_rate_limit_retry(collection_name)
+        assert rsp["code"] == 0, rsp
+
+    def _query_until_target_ids(self, collection_name, query_text, timeout=30):
+        deadline = time.monotonic() + timeout
+        rows = []
+        while time.monotonic() < deadline:
+            rsp = self.vector_client.vector_query(
+                {
+                    "collectionName": collection_name,
+                    "filter": f'text_match(text, "{query_text}")',
+                    "outputFields": ["id", "text"],
+                    "limit": TOTAL_COUNT,
+                },
+                timeout=0,
+            )
+            assert rsp["code"] == 0, rsp
+            rows = rsp["data"]
+            if {int(row["id"]) for row in rows} == TARGET_IDS:
+                return rows
+            time.sleep(1)
+        return rows
+
+    def test_pinyin_filter_text_match_across_data_paths(self):
+        """
+        target: verify Pinyin Text Match through RESTful v2 across three data paths
+        method: build 3000 indexed, 500 unindexed, and 500 growing rows through RESTful v2
+        expected: joined Pinyin and original Chinese both return the target row from every path
+        """
+        name = gen_collection_name()
+        self.name = name
+        analyzer_params = {
+            "tokenizer": "jieba",
+            "filter": [
+                {
+                    "type": "pinyin",
+                    "keep_original": True,
+                    "keep_full_pinyin": False,
+                    "keep_joined_full_pinyin": True,
+                    "keep_separate_first_letter": False,
+                }
+            ],
+        }
+        create_payload = {
+            "collectionName": name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {
+                        "fieldName": "id",
+                        "dataType": "Int64",
+                        "isPrimary": True,
+                        "elementTypeParams": {},
+                    },
+                    {
+                        "fieldName": "text",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {
+                            "max_length": "1024",
+                            "enable_analyzer": True,
+                            "enable_match": True,
+                            "analyzer_params": analyzer_params,
+                        },
+                    },
+                    {
+                        "fieldName": "vector",
+                        "dataType": "FloatVector",
+                        "elementTypeParams": {"dim": "2"},
+                    },
+                ],
+            },
+        }
+        rsp = self.collection_client.collection_create(create_payload)
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.collection_client.alter_collection_properties(
+            name,
+            {"collection.autocompaction.enabled": "false"},
+        )
+        assert rsp["code"] == 0, rsp
+
+        self._insert_and_flush(name, 0, INDEXED_SEALED_COUNT)
+        self._insert_and_flush(name, INDEXED_SEALED_COUNT, UNINDEXED_SEALED_COUNT)
+
+        rsp = self.index_client.index_create(
+            {
+                "collectionName": name,
+                "indexParams": [
+                    {
+                        "fieldName": "vector",
+                        "indexName": "vector",
+                        "indexType": "IVF_FLAT",
+                        "metricType": "L2",
+                        "params": {"nlist": 64},
+                    }
+                ],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.collection_client.collection_load(collection_name=name)
+        assert rsp["code"] == 0, rsp
+        self.collection_client.wait_load_completed(name, timeout=180)
+
+        rsp = self.vector_client.vector_insert(
+            {
+                "collectionName": name,
+                "data": build_rows(
+                    INDEXED_SEALED_COUNT + UNINDEXED_SEALED_COUNT,
+                    GROWING_COUNT,
+                ),
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert rsp["data"]["insertCount"] == GROWING_COUNT, rsp
+
+        for query_text in ["zhongwen", "中文"]:
+            rows = self._query_until_target_ids(name, query_text)
+            assert {int(row["id"]) for row in rows} == TARGET_IDS
+            assert all(row["text"] == "中文测试" for row in rows)

--- a/tests/restful_client_v2/testcases/test_pinyin_filter.py
+++ b/tests/restful_client_v2/testcases/test_pinyin_filter.py
@@ -1,4 +1,3 @@
-import json
 import time
 
 import pytest
@@ -33,6 +32,39 @@ def pinyin_analyzer_params(keep_original):
     }
 
 
+def pinyin_collection_payload(collection_name, analyzer_params):
+    return {
+        "collectionName": collection_name,
+        "schema": {
+            "autoId": False,
+            "enableDynamicField": False,
+            "fields": [
+                {
+                    "fieldName": "id",
+                    "dataType": "Int64",
+                    "isPrimary": True,
+                    "elementTypeParams": {},
+                },
+                {
+                    "fieldName": "text",
+                    "dataType": "VarChar",
+                    "elementTypeParams": {
+                        "max_length": "1024",
+                        "enable_analyzer": True,
+                        "enable_match": True,
+                        "analyzer_params": analyzer_params,
+                    },
+                },
+                {
+                    "fieldName": "vector",
+                    "dataType": "FloatVector",
+                    "elementTypeParams": {"dim": "2"},
+                },
+            ],
+        },
+    }
+
+
 def build_rows(start, count):
     rows = []
     for row_id in range(start, start + count):
@@ -48,19 +80,41 @@ def build_rows(start, count):
 
 @pytest.mark.tags(CaseLabel.L0)
 class TestPinyinFilter(TestBase):
-    def _assert_analyzer_tokens(self, analyzer_params, expected_tokens):
+    def _field_analyzer_tokens(self, collection_name, text):
         rsp = self.collection_client.post(
             f"{self.endpoint}/v2/vectordb/common/run_analyzer",
             headers=self.collection_client.update_headers(),
             data={
-                "text": ["中文测试"],
-                "analyzerParams": json.dumps(analyzer_params),
+                "text": [text],
+                "collectionName": collection_name,
+                "fieldName": "text",
             },
         ).json()
         assert rsp["code"] == 0, rsp
         results = rsp["data"]["results"]
         assert len(results) == 1, results
-        assert [token["token"] for token in results[0]["tokens"]] == expected_tokens
+        return [token["token"] for token in results[0]["tokens"]]
+
+    def _index_and_load_collection(self, collection_name):
+        rsp = self.index_client.index_create(
+            {
+                "collectionName": collection_name,
+                "indexParams": [
+                    {
+                        "fieldName": "vector",
+                        "indexName": "vector",
+                        "indexType": "IVF_FLAT",
+                        "metricType": "L2",
+                        "params": {"nlist": 64},
+                    }
+                ],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+
+        rsp = self.collection_client.collection_load(collection_name=collection_name)
+        assert rsp["code"] == 0, rsp
+        self.collection_client.wait_load_completed(collection_name, timeout=180)
 
     def _flush_with_rate_limit_retry(self, collection_name, timeout=30):
         deadline = time.monotonic() + timeout
@@ -87,22 +141,30 @@ class TestPinyinFilter(TestBase):
         assert rsp["code"] == 0, rsp
 
     @staticmethod
-    def _assert_exact_target_ids(rows):
+    def _assert_exact_ids(rows, expected_ids):
         ids = [int(row["id"]) for row in rows]
-        assert len(ids) == len(TARGET_IDS), ids
+        assert len(ids) == len(expected_ids), ids
         assert len(ids) == len(set(ids)), ids
-        assert set(ids) == TARGET_IDS, ids
+        assert set(ids) == expected_ids, ids
 
-    def _search_until_target_ids(self, collection_name, query_text, timeout=30):
+    def _search_until_ids(
+        self,
+        collection_name,
+        query_text,
+        expected_ids,
+        minimum_should_match=None,
+        timeout=30,
+    ):
         deadline = time.monotonic() + timeout
         rows = []
+        match_options = "" if minimum_should_match is None else f", minimum_should_match={minimum_should_match}"
         while time.monotonic() < deadline:
             rsp = self.vector_client.vector_search(
                 {
                     "collectionName": collection_name,
                     "data": [[0.0, 0.0]],
                     "annsField": "vector",
-                    "filter": f'text_match(text, "{query_text}")',
+                    "filter": f'text_match(text, "{query_text}"{match_options})',
                     "outputFields": ["id", "text"],
                     "limit": TOTAL_COUNT,
                     "searchParams": {"metricType": "L2", "params": {"nprobe": 64}},
@@ -112,7 +174,7 @@ class TestPinyinFilter(TestBase):
             assert rsp["code"] == 0, rsp
             rows = rsp["data"]
             ids = [int(row["id"]) for row in rows]
-            if len(ids) == len(TARGET_IDS) and len(ids) == len(set(ids)) and set(ids) == TARGET_IDS:
+            if len(ids) == len(expected_ids) and len(ids) == len(set(ids)) and set(ids) == expected_ids:
                 return rows
             time.sleep(1)
         return rows
@@ -120,53 +182,25 @@ class TestPinyinFilter(TestBase):
     def test_pinyin_filter_text_match_across_data_paths(self):
         """
         target: verify exact Pinyin tokens and filtered vector search through RESTful v2
-        method: run both original modes, then search 3000 indexed, 500 unindexed, and 500 growing rows
-        expected: exact tokens preserve the flag, and both query forms return every target row
+        method: read both field analyzer modes, then search 3000 indexed, 500 unindexed, and 500 growing rows
+        expected: exact field tokens preserve the flags, enabled tokens match, and disabled tokens do not
         """
         name = gen_collection_name()
         self.name = name
         analyzer_params = pinyin_analyzer_params(keep_original=True)
-        self._assert_analyzer_tokens(
-            analyzer_params,
-            ["中文", "zhongwen", "测试", "ceshi"],
-        )
-        self._assert_analyzer_tokens(
-            pinyin_analyzer_params(keep_original=False),
-            ["zhongwen", "ceshi"],
-        )
-
-        create_payload = {
-            "collectionName": name,
-            "schema": {
-                "autoId": False,
-                "enableDynamicField": False,
-                "fields": [
-                    {
-                        "fieldName": "id",
-                        "dataType": "Int64",
-                        "isPrimary": True,
-                        "elementTypeParams": {},
-                    },
-                    {
-                        "fieldName": "text",
-                        "dataType": "VarChar",
-                        "elementTypeParams": {
-                            "max_length": "1024",
-                            "enable_analyzer": True,
-                            "enable_match": True,
-                            "analyzer_params": analyzer_params,
-                        },
-                    },
-                    {
-                        "fieldName": "vector",
-                        "dataType": "FloatVector",
-                        "elementTypeParams": {"dim": "2"},
-                    },
-                ],
-            },
-        }
-        rsp = self.collection_client.collection_create(create_payload)
+        rsp = self.collection_client.collection_create(pinyin_collection_payload(name, analyzer_params))
         assert rsp["code"] == 0, rsp
+
+        without_original_name = gen_collection_name()
+        rsp = self.collection_client.collection_create(
+            pinyin_collection_payload(
+                without_original_name,
+                pinyin_analyzer_params(keep_original=False),
+            )
+        )
+        assert rsp["code"] == 0, rsp
+        self._index_and_load_collection(without_original_name)
+        assert self._field_analyzer_tokens(without_original_name, "中文测试") == ["zhongwen", "ceshi"]
 
         rsp = self.collection_client.alter_collection_properties(
             name,
@@ -177,25 +211,10 @@ class TestPinyinFilter(TestBase):
         self._insert_and_flush(name, 0, INDEXED_SEALED_COUNT)
         self._insert_and_flush(name, INDEXED_SEALED_COUNT, UNINDEXED_SEALED_COUNT)
 
-        rsp = self.index_client.index_create(
-            {
-                "collectionName": name,
-                "indexParams": [
-                    {
-                        "fieldName": "vector",
-                        "indexName": "vector",
-                        "indexType": "IVF_FLAT",
-                        "metricType": "L2",
-                        "params": {"nlist": 64},
-                    }
-                ],
-            }
-        )
-        assert rsp["code"] == 0, rsp
-
-        rsp = self.collection_client.collection_load(collection_name=name)
-        assert rsp["code"] == 0, rsp
-        self.collection_client.wait_load_completed(name, timeout=180)
+        self._index_and_load_collection(name)
+        assert self._field_analyzer_tokens(name, "中文测试") == ["中文", "zhongwen", "测试", "ceshi"]
+        original_query_tokens = self._field_analyzer_tokens(name, "中文")
+        assert original_query_tokens == ["中文", "zhongwen"]
 
         rsp = self.vector_client.vector_insert(
             {
@@ -209,7 +228,19 @@ class TestPinyinFilter(TestBase):
         assert rsp["code"] == 0, rsp
         assert rsp["data"]["insertCount"] == GROWING_COUNT, rsp
 
-        for query_text in ["zhongwen", "中文"]:
-            rows = self._search_until_target_ids(name, query_text)
-            self._assert_exact_target_ids(rows)
-            assert all(row["text"] == "中文测试" for row in rows)
+        search_cases = [
+            ("zhongwen", None, TARGET_IDS),
+            ("中文", len(original_query_tokens), TARGET_IDS),
+            ("zhong", None, set()),
+            ("zw", None, set()),
+        ]
+        for query_text, minimum_should_match, expected_ids in search_cases:
+            rows = self._search_until_ids(
+                name,
+                query_text,
+                expected_ids,
+                minimum_should_match=minimum_should_match,
+            )
+            self._assert_exact_ids(rows, expected_ids)
+            if expected_ids:
+                assert all(row["text"] == "中文测试" for row in rows)

--- a/tests/restful_client_v2/testcases/test_pinyin_filter.py
+++ b/tests/restful_client_v2/testcases/test_pinyin_filter.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 import pytest
@@ -17,6 +18,21 @@ TARGET_IDS = {
 }
 
 
+def pinyin_analyzer_params(keep_original):
+    return {
+        "tokenizer": "jieba",
+        "filter": [
+            {
+                "type": "pinyin",
+                "keep_original": keep_original,
+                "keep_full_pinyin": False,
+                "keep_joined_full_pinyin": True,
+                "keep_separate_first_letter": False,
+            }
+        ],
+    }
+
+
 def build_rows(start, count):
     rows = []
     for row_id in range(start, start + count):
@@ -32,6 +48,20 @@ def build_rows(start, count):
 
 @pytest.mark.tags(CaseLabel.L0)
 class TestPinyinFilter(TestBase):
+    def _assert_analyzer_tokens(self, analyzer_params, expected_tokens):
+        rsp = self.collection_client.post(
+            f"{self.endpoint}/v2/vectordb/common/run_analyzer",
+            headers=self.collection_client.update_headers(),
+            data={
+                "text": ["中文测试"],
+                "analyzerParams": json.dumps(analyzer_params),
+            },
+        ).json()
+        assert rsp["code"] == 0, rsp
+        results = rsp["data"]["results"]
+        assert len(results) == 1, results
+        assert [token["token"] for token in results[0]["tokens"]] == expected_tokens
+
     def _flush_with_rate_limit_retry(self, collection_name, timeout=30):
         deadline = time.monotonic() + timeout
         rsp = {}
@@ -89,24 +119,22 @@ class TestPinyinFilter(TestBase):
 
     def test_pinyin_filter_text_match_across_data_paths(self):
         """
-        target: verify filtered Pinyin vector search through RESTful v2 across three data paths
-        method: vector-search 3000 indexed, 500 unindexed, and 500 growing rows through RESTful v2
-        expected: joined Pinyin and original Chinese both return the target row from every path
+        target: verify exact Pinyin tokens and filtered vector search through RESTful v2
+        method: run both original modes, then search 3000 indexed, 500 unindexed, and 500 growing rows
+        expected: exact tokens preserve the flag, and both query forms return every target row
         """
         name = gen_collection_name()
         self.name = name
-        analyzer_params = {
-            "tokenizer": "jieba",
-            "filter": [
-                {
-                    "type": "pinyin",
-                    "keep_original": True,
-                    "keep_full_pinyin": False,
-                    "keep_joined_full_pinyin": True,
-                    "keep_separate_first_letter": False,
-                }
-            ],
-        }
+        analyzer_params = pinyin_analyzer_params(keep_original=True)
+        self._assert_analyzer_tokens(
+            analyzer_params,
+            ["中文", "zhongwen", "测试", "ceshi"],
+        )
+        self._assert_analyzer_tokens(
+            pinyin_analyzer_params(keep_original=False),
+            ["zhongwen", "ceshi"],
+        )
+
         create_payload = {
             "collectionName": name,
             "schema": {


### PR DESCRIPTION
## Summary

- Add Pinyin analyzer end-to-end coverage for Python MilvusClient, RESTful v2, and the Go SDK.
- Cover full Pinyin, joined Pinyin, first-letter, and original Chinese matching through Python.
- Add L0 coverage for joined Pinyin and original Chinese matching through RESTful v2 and the Go SDK.
- Cover both `text_match` filtering and BM25 search.
- Construct 4,000 deterministic rows by inserting and flushing 3,000 rows, inserting and flushing 500 rows, creating the index and loading the collection, and finally inserting 500 growing rows without flushing.
- Assert the exact target IDs `{0, 3000, 3500}` without inspecting segment metadata.

issue: #45811

## Test Plan

- [x] Python static checks and collection: 4 cases
- [x] Python MilvusClient E2E: `4 passed in 25.67s`
- [x] RESTful v2 L0 E2E: `1 passed in 28.79s`
- [x] Go SDK compile check with `dynamic,test` tags and disabled optimizations
- [x] Go SDK L0 E2E: `TestPinyinFilterTextMatchAcrossDataPaths` passed in `17.56s`