### PR TITLE
fix: reject autoID import in replicating cluster

### DIFF
--- a/internal/datacoord/ddl_callbacks_import.go
+++ b/internal/datacoord/ddl_callbacks_import.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 // importV1AckCallback handles the ack callback for import messages.
@@ -88,7 +89,7 @@ func (c *DDLCallbacks) importV1AckCallback(ctx context.Context, result message.B
 
 // validateImportRequest validates the import request before broadcasting.
 // This includes all validation logic previously done in CheckCallback and Proxy.
-func (s *Server) validateImportRequest(ctx context.Context, files []*msgpb.ImportFile, options []*commonpb.KeyValuePair) error {
+func (s *Server) validateImportRequest(ctx context.Context, files []*msgpb.ImportFile, options []*commonpb.KeyValuePair, schema *schemapb.CollectionSchema) error {
 	// Validate timeout
 	_, err := importutilv2.GetTimeoutTs(options)
 	if err != nil {
@@ -109,14 +110,14 @@ func (s *Server) validateImportRequest(ctx context.Context, files []*msgpb.Impor
 		return err
 	}
 
-	if err := s.validateImportReplication(ctx, options); err != nil {
+	if err := s.validateImportReplication(ctx, options, schema); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (s *Server) validateImportReplication(ctx context.Context, options []*commonpb.KeyValuePair) error {
+func (s *Server) validateImportReplication(ctx context.Context, options []*commonpb.KeyValuePair, schema *schemapb.CollectionSchema) error {
 	balancer, err := balance.GetWithContext(ctx)
 	if err != nil {
 		return err
@@ -137,6 +138,14 @@ func (s *Server) validateImportReplication(ctx context.Context, options []*commo
 	}
 	if importutilv2.IsAutoCommit(options) {
 		return merr.WrapErrOperationNotSupportedMsg("auto_commit=true import in replicating cluster is not supported")
+	}
+	if !importutilv2.IsBackup(options) {
+		for _, field := range schema.GetFields() {
+			if typeutil.IsAutoPKField(field) {
+				return merr.WrapErrOperationNotSupportedMsg(
+					"autoID primary key import in replicating cluster is not supported; primary keys would be assigned independently on each cluster")
+			}
+		}
 	}
 	return nil
 }
@@ -187,7 +196,7 @@ func (s *Server) broadcastImport(ctx context.Context,
 	})
 
 	// Validate the request before broadcasting
-	if err := s.validateImportRequest(ctx, msgFiles, options); err != nil {
+	if err := s.validateImportRequest(ctx, msgFiles, options, schema); err != nil {
 		return merr.Wrap(err, "failed to validate import request")
 	}
 

--- a/internal/datacoord/ddl_callbacks_import_test.go
+++ b/internal/datacoord/ddl_callbacks_import_test.go
@@ -79,7 +79,7 @@ func (s *ImportCallbacksSuite) TestValidateImportRequest_InvalidTimeoutReturnsEr
 		{Key: "timeout", Value: "invalid_timeout_format"},
 	}
 
-	err := server.validateImportRequest(ctx, files, options)
+	err := server.validateImportRequest(ctx, files, options, nil)
 
 	s.Error(err)
 	s.Contains(err.Error(), "timeout")
@@ -104,7 +104,7 @@ func (s *ImportCallbacksSuite) TestValidateImportRequest_MaxJobsExceededReturnsE
 		{Key: "timeout", Value: "300s"},
 	}
 
-	err := server.validateImportRequest(ctx, files, options)
+	err := server.validateImportRequest(ctx, files, options, nil)
 
 	s.Error(err)
 	// Job-count backpressure is a server-side condition -> ErrImportSysFailed
@@ -138,7 +138,7 @@ func (s *ImportCallbacksSuite) TestValidateImportRequest_BalancerGetFailsReturns
 		{Key: "timeout", Value: "300s"},
 	}
 
-	err := server.validateImportRequest(ctx, files, options)
+	err := server.validateImportRequest(ctx, files, options, nil)
 
 	s.Error(err)
 	s.Contains(err.Error(), "balancer not available")
@@ -183,7 +183,7 @@ func (s *ImportCallbacksSuite) TestValidateImportRequest_ReplicatingClusterRetur
 		{Key: "timeout", Value: "300s"},
 	}
 
-	err := server.validateImportRequest(ctx, files, options)
+	err := server.validateImportRequest(ctx, files, options, nil)
 
 	s.Error(err)
 	s.True(errors.Is(err, merr.ErrOperationNotSupported))
@@ -229,7 +229,7 @@ func (s *ImportCallbacksSuite) TestValidateImportRequest_ReplicatingClusterEnabl
 
 	err := server.validateImportRequest(ctx, files, []*commonpb.KeyValuePair{
 		{Key: "timeout", Value: "300s"},
-	})
+	}, nil)
 	s.Error(err)
 	s.True(errors.Is(err, merr.ErrOperationNotSupported))
 	s.Contains(err.Error(), "auto_commit=true")
@@ -237,8 +237,67 @@ func (s *ImportCallbacksSuite) TestValidateImportRequest_ReplicatingClusterEnabl
 	err = server.validateImportRequest(ctx, files, []*commonpb.KeyValuePair{
 		{Key: "timeout", Value: "300s"},
 		{Key: importutilv2.AutoCommitKey, Value: "false"},
-	})
+	}, nil)
 	s.NoError(err)
+}
+
+func (s *ImportCallbacksSuite) TestValidateImportRequest_ReplicatingClusterRejectsAutoIDSchema() {
+	ctx := context.Background()
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.ImportInReplicatingCluster.Key, "true")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.ImportInReplicatingCluster.Key)
+
+	mockCount := mockey.Mock((*importMeta).CountJobBy).To(func(_ *importMeta, _ context.Context, _ ...ImportJobFilter) int {
+		return 1
+	}).Build()
+	defer mockCount.UnPatch()
+
+	mockBalancer := &mockBalancerImpl{}
+	mockBalance := mockey.Mock(balance.GetWithContext).To(func(ctx context.Context) (balancer.Balancer, error) {
+		return mockBalancer, nil
+	}).Build()
+	defer mockBalance.UnPatch()
+
+	mockAssignment := mockey.Mock((*mockBalancerImpl).GetLatestChannelAssignment).To(
+		func(_ *mockBalancerImpl) (*channel.WatchChannelAssignmentsCallbackParam, error) {
+			return &channel.WatchChannelAssignmentsCallbackParam{
+				ReplicateConfiguration: &commonpb.ReplicateConfiguration{
+					Clusters: []*commonpb.MilvusCluster{
+						{ClusterId: "cluster1"},
+						{ClusterId: "cluster2"},
+					},
+				},
+			}, nil
+		}).Build()
+	defer mockAssignment.UnPatch()
+
+	server := &Server{
+		importMeta: &importMeta{},
+	}
+	files := []*msgpb.ImportFile{
+		{Id: 1, Paths: []string{"/test/file1.json"}},
+	}
+	options := []*commonpb.KeyValuePair{
+		{Key: "timeout", Value: "300s"},
+		{Key: importutilv2.AutoCommitKey, Value: "false"},
+	}
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "id",
+				DataType:     schemapb.DataType_Int64,
+				IsPrimaryKey: true,
+				AutoID:       true,
+			},
+		},
+	}
+
+	err := server.validateImportRequest(ctx, files, options, schema)
+
+	s.Error(err)
+	s.True(errors.Is(err, merr.ErrOperationNotSupported))
+	s.Contains(err.Error(), "autoID")
 }
 
 func (s *ImportCallbacksSuite) TestValidateImportRequest_SuccessWithValidInput() {
@@ -274,7 +333,7 @@ func (s *ImportCallbacksSuite) TestValidateImportRequest_SuccessWithValidInput()
 		{Key: "timeout", Value: "300s"},
 	}
 
-	err := server.validateImportRequest(ctx, files, options)
+	err := server.validateImportRequest(ctx, files, options, nil)
 
 	s.NoError(err)
 }
@@ -626,6 +685,17 @@ func (m *mockBalancerImpl) GetLatestChannelAssignment() (*channel.WatchChannelAs
 	// Ensure the function body is long enough for mockey to patch
 	result := &channel.WatchChannelAssignmentsCallbackParam{}
 	return result, nil
+}
+
+func (m *mockBalancerImpl) WatchChannelAssignments(ctx context.Context, cb balancer.WatchChannelAssignmentsCallback) error {
+	assignment, err := m.GetLatestChannelAssignment()
+	if err != nil {
+		return err
+	}
+	if cb != nil && assignment != nil {
+		cb(*assignment)
+	}
+	return nil
 }
 
 // mockBroadcastAPIImpl is a mock implementation for broadcaster.BroadcastAPI interface


### PR DESCRIPTION
issue: #51667

This PR rejects non-backup import into autoID primary-key collections when the cluster is currently in CDC replication mode and import in a replicating cluster is enabled.

Why:
- The replicated import path broadcasts the import instruction, including schema/files/options, but not a materialized autoID assignment result.
- Non-backup DataNode import assigns autoID primary keys locally while processing the files, so primary and secondary clusters can assign different PKs for the same logical rows.
- Backup/binlog import remains allowed because it clears autoID on the import schema and preserves primary keys from the imported binlogs.

Verification:
- go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord -run 'TestImportCallbacksSuite/TestValidateImportRequest_(ReplicatingClusterRejectsAutoIDSchema|ReplicatingClusterEnabledRequiresManualCommit)'
- make static-check