### PR TITLE
enhance: amortize per-row chunk resolution in storage-v2 bulk access and expr offset paths

### DIFF
--- a/internal/core/src/common/GroupChunk.h
+++ b/internal/core/src/common/GroupChunk.h
@@ -44,6 +44,22 @@ class GroupChunk {
         return it->second;
     }
 
+    // Borrow the chunk for a field WITHOUT sharing ownership. The returned
+    // pointer is valid only while this GroupChunk stays pinned/resident (e.g.
+    // for the lifetime of the CellAccessor that pinned it). Bulk accessors use
+    // this on the hot path to avoid the per-row shared_ptr refcount bump that
+    // GetChunk() incurs — an atomic RMW on a shared control block that contends
+    // across concurrent search threads. For anything that must outlive the pin,
+    // use GetChunk() instead.
+    Chunk*
+    GetChunkRaw(FieldId field_id) const {
+        auto it = chunks_.find(field_id);
+        if (it == chunks_.end()) {
+            return nullptr;
+        }
+        return it->second.get();
+    }
+
     // Add a chunk for a specific field
     void
     AddChunk(FieldId field_id, std::shared_ptr<Chunk> chunk) {

--- a/internal/core/src/exec/expression/ColumnExpr.cpp
+++ b/internal/core/src/exec/expression/ColumnExpr.cpp
@@ -99,6 +99,15 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
         valid_res.set();
 
         int64_t processed_rows = 0;
+        // Keep the chunk's data accessor (which pins the chunk) across
+        // iterations and rebuild only when the chunk id changes, avoiding a
+        // per-row chunk pin + accessor construction. Safe on both sealed
+        // (CellAccessor keeps the chunk resident) and growing (data and the
+        // chunked validity storage have stable per-chunk buffers). The pinned
+        // index view is chunk-independent, so it is resolved once.
+        const auto pinned_index = PinnedIndexForRawLookup();
+        int64_t cached_chunk_id = -1;
+        segcore::ChunkDataAccessor cda;
         for (auto i = 0; i < real_batch_size; ++i) {
             auto offset = (*input)[i];
             auto [chunk_id,
@@ -117,11 +126,14 @@ PhyColumnExpr::DoEval(OffsetVector* input) {
                     return {0, offset};
                 }
             }();
-            auto cda = segment_chunk_reader_.GetChunkDataAccessor(
-                expr_->GetColumn().data_type_,
-                expr_->GetColumn().field_id_,
-                chunk_id,
-                PinnedIndexForRawLookup());
+            if (chunk_id != cached_chunk_id) {
+                cda = segment_chunk_reader_.GetChunkDataAccessor(
+                    expr_->GetColumn().data_type_,
+                    expr_->GetColumn().field_id_,
+                    chunk_id,
+                    pinned_index);
+                cached_chunk_id = chunk_id;
+            }
             auto chunk_data_by_offset = cda(chunk_offset);
             if (!chunk_data_by_offset.has_value()) {
                 valid_res[processed_rows] = false;

--- a/internal/core/src/exec/expression/CompareExpr.cpp
+++ b/internal/core/src/exec/expression/CompareExpr.cpp
@@ -111,37 +111,55 @@ PhyCompareFilterExpr::ExecCompareExprDispatcher(OpType op, EvalCtx& context) {
 
         int64_t processed_rows = 0;
         const auto size_per_chunk = segment_chunk_reader_.SizePerChunk();
+        auto get_chunk_id_and_offset =
+            [&](const FieldId field,
+                const int64_t raw_data_chunk_count,
+                int64_t offset) -> std::pair<int64_t, int64_t> {
+            if (segment_chunk_reader_.segment_->type() ==
+                SegmentType::Growing) {
+                return {offset / size_per_chunk, offset % size_per_chunk};
+            } else if (segment_chunk_reader_.segment_->is_chunked() &&
+                       raw_data_chunk_count > 0) {
+                return segment_chunk_reader_.segment_->get_chunk_by_offset(
+                    field, offset);
+            } else {
+                return {0, offset};
+            }
+        };
+        // Consecutive offsets frequently fall in the same left/right chunk;
+        // keep each column's data accessor (which pins its chunk) across
+        // iterations and rebuild it only when that column's chunk id changes.
+        // Safe on both sealed and growing (data and the chunked validity
+        // storage have stable per-chunk buffers). The pinned index views are
+        // chunk-independent, so they are resolved once.
+        const auto left_pinned_index = LeftPinnedIndexForRawLookup();
+        const auto right_pinned_index = RightPinnedIndexForRawLookup();
+        int64_t cached_left_chunk_id = -1;
+        int64_t cached_right_chunk_id = -1;
+        segcore::ChunkDataAccessor left;
+        segcore::ChunkDataAccessor right;
         for (auto i = 0; i < real_batch_size; ++i) {
             auto offset = (*input)[i];
-            auto get_chunk_id_and_offset =
-                [&](const FieldId field, const int64_t raw_data_chunk_count)
-                -> std::pair<int64_t, int64_t> {
-                if (segment_chunk_reader_.segment_->type() ==
-                    SegmentType::Growing) {
-                    return {offset / size_per_chunk, offset % size_per_chunk};
-                } else if (segment_chunk_reader_.segment_->is_chunked() &&
-                           raw_data_chunk_count > 0) {
-                    return segment_chunk_reader_.segment_->get_chunk_by_offset(
-                        field, offset);
-                } else {
-                    return {0, offset};
-                }
-            };
-
-            auto [left_chunk_id, left_chunk_offset] =
-                get_chunk_id_and_offset(left_field_, left_raw_data_chunk_count);
+            auto [left_chunk_id, left_chunk_offset] = get_chunk_id_and_offset(
+                left_field_, left_raw_data_chunk_count, offset);
             auto [right_chunk_id, right_chunk_offset] = get_chunk_id_and_offset(
-                right_field_, right_raw_data_chunk_count);
-            auto left = segment_chunk_reader_.GetChunkDataAccessor(
-                expr_->left_data_type_,
-                expr_->left_field_id_,
-                left_chunk_id,
-                LeftPinnedIndexForRawLookup());
-            auto right = segment_chunk_reader_.GetChunkDataAccessor(
-                expr_->right_data_type_,
-                expr_->right_field_id_,
-                right_chunk_id,
-                RightPinnedIndexForRawLookup());
+                right_field_, right_raw_data_chunk_count, offset);
+            if (left_chunk_id != cached_left_chunk_id) {
+                left = segment_chunk_reader_.GetChunkDataAccessor(
+                    expr_->left_data_type_,
+                    expr_->left_field_id_,
+                    left_chunk_id,
+                    left_pinned_index);
+                cached_left_chunk_id = left_chunk_id;
+            }
+            if (right_chunk_id != cached_right_chunk_id) {
+                right = segment_chunk_reader_.GetChunkDataAccessor(
+                    expr_->right_data_type_,
+                    expr_->right_field_id_,
+                    right_chunk_id,
+                    right_pinned_index);
+                cached_right_chunk_id = right_chunk_id;
+            }
             auto left_opt = left(left_chunk_offset);
             auto right_opt = right(right_chunk_offset);
             if (!left_opt.has_value() || !right_opt.has_value()) {

--- a/internal/core/src/exec/expression/CompareExpr.h
+++ b/internal/core/src/exec/expression/CompareExpr.h
@@ -335,49 +335,72 @@ class PhyCompareFilterExpr : public Expr {
         int64_t processed_size = 0;
         if (segment_chunk_reader_.segment_->is_chunked() ||
             segment_chunk_reader_.segment_->type() == SegmentType::Growing) {
+            auto get_chunk_id_and_offset =
+                [&](const FieldId field,
+                    int64_t offset) -> std::pair<int64_t, int64_t> {
+                if (segment_chunk_reader_.segment_->type() ==
+                    SegmentType::Growing) {
+                    auto size_per_chunk = segment_chunk_reader_.SizePerChunk();
+                    return {offset / size_per_chunk, offset % size_per_chunk};
+                } else {
+                    return segment_chunk_reader_.segment_->get_chunk_by_offset(
+                        field, offset);
+                }
+            };
+
+            // Consecutive offsets frequently fall in the same left/right chunk;
+            // keep both pinned chunks across iterations and only re-pin/resolve
+            // when a chunk id changes, avoiding a per-row GroupChunk pin +
+            // shared_ptr lookup for each of the two columns. Safe on both
+            // sealed and growing (data and the chunked validity storage have
+            // stable per-chunk buffers).
+            int64_t cached_left_chunk_id = -1;
+            int64_t cached_right_chunk_id = -1;
+            std::optional<PinWrapper<Span<T>>> pw_left;
+            std::optional<PinWrapper<Span<U>>> pw_right;
+            const T* left_base = nullptr;
+            const bool* left_valid_base = nullptr;
+            const U* right_base = nullptr;
+            const bool* right_valid_base = nullptr;
             for (auto i = 0; i < size; ++i) {
                 auto offset = (*input)[i];
-                auto get_chunk_id_and_offset =
-                    [&](const FieldId field) -> std::pair<int64_t, int64_t> {
-                    if (segment_chunk_reader_.segment_->type() ==
-                        SegmentType::Growing) {
-                        auto size_per_chunk =
-                            segment_chunk_reader_.SizePerChunk();
-                        return {offset / size_per_chunk,
-                                offset % size_per_chunk};
-                    } else {
-                        return segment_chunk_reader_.segment_
-                            ->get_chunk_by_offset(field, offset);
-                    }
-                };
-
                 auto [left_chunk_id, left_chunk_offset] =
-                    get_chunk_id_and_offset(left_field_);
+                    get_chunk_id_and_offset(left_field_, offset);
                 auto [right_chunk_id, right_chunk_offset] =
-                    get_chunk_id_and_offset(right_field_);
+                    get_chunk_id_and_offset(right_field_, offset);
 
-                auto pw_left = segment_chunk_reader_.segment_->chunk_data<T>(
-                    op_ctx_, left_field_, left_chunk_id);
-                auto left_chunk = pw_left.get();
-                auto pw_right = segment_chunk_reader_.segment_->chunk_data<U>(
-                    op_ctx_, right_field_, right_chunk_id);
-                auto right_chunk = pw_right.get();
-                const bool* left_valid_data = left_chunk.valid_data();
-                const bool* right_valid_data = right_chunk.valid_data();
-                if (left_valid_data && !left_valid_data[left_chunk_offset]) {
+                if (left_chunk_id != cached_left_chunk_id) {
+                    pw_left.emplace(
+                        segment_chunk_reader_.segment_->chunk_data<T>(
+                            op_ctx_, left_field_, left_chunk_id));
+                    auto left_chunk = pw_left->get();
+                    left_base = left_chunk.data();
+                    left_valid_base = left_chunk.valid_data();
+                    cached_left_chunk_id = left_chunk_id;
+                }
+                if (right_chunk_id != cached_right_chunk_id) {
+                    pw_right.emplace(
+                        segment_chunk_reader_.segment_->chunk_data<U>(
+                            op_ctx_, right_field_, right_chunk_id));
+                    auto right_chunk = pw_right->get();
+                    right_base = right_chunk.data();
+                    right_valid_base = right_chunk.valid_data();
+                    cached_right_chunk_id = right_chunk_id;
+                }
+                if (left_valid_base && !left_valid_base[left_chunk_offset]) {
                     res[processed_size] = false;
                     valid_res[processed_size] = false;
                     processed_size++;
                     continue;
                 }
-                if (right_valid_data && !right_valid_data[right_chunk_offset]) {
+                if (right_valid_base && !right_valid_base[right_chunk_offset]) {
                     res[processed_size] = false;
                     valid_res[processed_size] = false;
                     processed_size++;
                     continue;
                 }
-                const T* left_data = left_chunk.data() + left_chunk_offset;
-                const U* right_data = right_chunk.data() + right_chunk_offset;
+                const T* left_data = left_base + left_chunk_offset;
+                const U* right_data = right_base + right_chunk_offset;
                 func.template operator()<FilterType::random>(
                     left_data,
                     right_data,

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -750,58 +750,123 @@ class SegmentExpr : public Expr {
             if constexpr (std::is_same_v<T, std::string_view> ||
                           std::is_same_v<T, Json> ||
                           std::is_same_v<T, ArrayView>) {
-                for (size_t i = 0; i < input->size(); ++i) {
-                    int64_t offset = (*input)[i];
-                    auto [chunk_id, chunk_offset] =
-                        segment_->get_chunk_by_offset(field_id_, offset);
-                    auto pw = segment_->get_views_by_offsets<T>(
-                        op_ctx_, field_id_, chunk_id, {int32_t(chunk_offset)});
-                    auto [data_vec, valid_data] = pw.get();
-                    if (!skip_func ||
-                        !skip_func(*skip_index, field_id_, chunk_id)) {
-                        evaluate_batch.template operator()<FilterType::random>(
-                            data_vec.data(),
-                            valid_data.data(),
-                            nullptr,
-                            1,
-                            res + processed_size,
-                            valid_res + processed_size,
-                            values...);
-                    } else {
-                        // Chunk skipped by SkipIndex: apply valid mask, then still drive the
-                        // callback on a null batch so cursor-tracking callbacks (which index
-                        // bitmap_input by batch position via their processed_cursor) stay
-                        // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
-                        if (!valid_data.empty() && !valid_data[0]) {
-                            res[processed_size] = valid_res[processed_size] =
-                                false;
+                // Group runs of consecutive offsets that fall in the same
+                // chunk and fetch their views with one get_views_by_offsets
+                // call per run (same shape as ProcessElementLevelByOffsets)
+                // instead of a per-row call that pins the chunk and heap-
+                // allocates a one-element view vector every row. Row order
+                // and per-row callback invocation are unchanged.
+                FixedVector<int32_t> batch_offsets;
+                size_t i = 0;
+                // Resolve each offset's chunk exactly once. The lookahead that
+                // ends a run is the same offset the next run starts on, so its
+                // resolution is carried across the outer iteration instead of
+                // being recomputed — otherwise every run boundary (i.e. every
+                // row when score-ordered offsets scatter one per chunk) pays a
+                // second get_chunk_by_offset.
+                int64_t chunk_id = 0;
+                int64_t chunk_offset = 0;
+                if (!input->empty()) {
+                    auto resolved =
+                        segment_->get_chunk_by_offset(field_id_, (*input)[0]);
+                    chunk_id = resolved.first;
+                    chunk_offset = resolved.second;
+                }
+                while (i < input->size()) {
+                    const int64_t run_chunk_id = chunk_id;
+                    batch_offsets.clear();
+                    batch_offsets.push_back(int32_t(chunk_offset));
+                    ++i;
+                    while (i < input->size()) {
+                        auto resolved = segment_->get_chunk_by_offset(
+                            field_id_, (*input)[i]);
+                        chunk_id = resolved.first;
+                        chunk_offset = resolved.second;
+                        if (chunk_id != run_chunk_id) {
+                            break;
                         }
-                        evaluate_batch.template operator()<FilterType::random>(
-                            nullptr,
-                            nullptr,
-                            nullptr,
-                            1,
-                            res + processed_size,
-                            valid_res + processed_size,
-                            values...);
+                        batch_offsets.push_back(int32_t(chunk_offset));
+                        ++i;
                     }
-                    processed_size++;
+                    auto pw = segment_->get_views_by_offsets<T>(
+                        op_ctx_, field_id_, run_chunk_id, batch_offsets);
+                    // Bind by reference: get() returns the pinned pair by
+                    // reference; copying it would duplicate the whole run's
+                    // view vector + validity vector on every run.
+                    const auto& [data_vec, valid_data] = pw.get();
+                    const bool skip =
+                        skip_func &&
+                        skip_func(*skip_index, field_id_, run_chunk_id);
+                    for (size_t j = 0; j < batch_offsets.size(); ++j) {
+                        if (!skip) {
+                            const bool* valid_ptr = valid_data.empty()
+                                                        ? nullptr
+                                                        : valid_data.data() + j;
+                            evaluate_batch
+                                .template operator()<FilterType::random>(
+                                    data_vec.data() + j,
+                                    valid_ptr,
+                                    nullptr,
+                                    1,
+                                    res + processed_size,
+                                    valid_res + processed_size,
+                                    values...);
+                        } else {
+                            // Chunk skipped by SkipIndex: apply valid mask,
+                            // then still drive the callback on a null batch so
+                            // cursor-tracking callbacks (which index
+                            // bitmap_input by batch position via their
+                            // processed_cursor) stay aligned — mirrors the
+                            // ProcessDataChunksForMultipleChunk skip branch.
+                            if (!valid_data.empty() && !valid_data[j]) {
+                                res[processed_size] =
+                                    valid_res[processed_size] = false;
+                            }
+                            evaluate_batch
+                                .template operator()<FilterType::random>(
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    1,
+                                    res + processed_size,
+                                    valid_res + processed_size,
+                                    values...);
+                        }
+                        processed_size++;
+                    }
                 }
                 return input->size();
             }
+            // Consecutive offsets frequently fall in the same chunk; keep the
+            // pinned chunk across iterations and only re-pin/resolve when the
+            // chunk id actually changes, avoiding a per-row GroupChunk pin +
+            // shared_ptr lookup on storage v2.
+            int64_t cached_chunk_id = -1;
+            std::optional<PinWrapper<Span<T>>> pw;
+            const T* chunk_base = nullptr;
+            const bool* chunk_valid_base = nullptr;
+            bool cached_skip = false;
             for (size_t i = 0; i < input->size(); ++i) {
                 int64_t offset = (*input)[i];
                 auto [chunk_id, chunk_offset] =
                     segment_->get_chunk_by_offset(field_id_, offset);
-                auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id);
-                auto chunk = pw.get();
-                const T* data = chunk.data() + chunk_offset;
-                const bool* valid_data = chunk.valid_data();
-                if (valid_data != nullptr) {
-                    valid_data += chunk_offset;
+                if (chunk_id != cached_chunk_id) {
+                    pw.emplace(
+                        segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id));
+                    auto chunk = pw->get();
+                    chunk_base = chunk.data();
+                    chunk_valid_base = chunk.valid_data();
+                    // SkipIndex is keyed by chunk alone; evaluate it once per
+                    // chunk instead of once per row.
+                    cached_skip = skip_func &&
+                                  skip_func(*skip_index, field_id_, chunk_id);
+                    cached_chunk_id = chunk_id;
                 }
-                if (!skip_func ||
-                    !skip_func(*skip_index, field_id_, chunk_id)) {
+                const T* data = chunk_base + chunk_offset;
+                const bool* valid_data = chunk_valid_base != nullptr
+                                             ? chunk_valid_base + chunk_offset
+                                             : nullptr;
+                if (!cached_skip) {
                     evaluate_batch.template operator()<FilterType::random>(
                         data,
                         valid_data,
@@ -832,20 +897,36 @@ class SegmentExpr : public Expr {
             }
             return input->size();
         } else {
-            // growing segment
+            // growing segment. Validity lives in chunked, append-only storage
+            // (ThreadSafeValidData) whose per-chunk buffers never move, so —
+            // like the sealed branch — keep the chunk base across iterations
+            // and re-resolve only when the chunk id changes.
+            int64_t cached_chunk_id = -1;
+            std::optional<PinWrapper<Span<T>>> pw;
+            const T* chunk_base = nullptr;
+            const bool* chunk_valid_base = nullptr;
+            bool cached_skip = false;
             for (size_t i = 0; i < input->size(); ++i) {
                 int64_t offset = (*input)[i];
                 auto chunk_id = offset / size_per_chunk_;
                 auto chunk_offset = offset % size_per_chunk_;
-                auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id);
-                auto chunk = pw.get();
-                const T* data = chunk.data() + chunk_offset;
-                const bool* valid_data = chunk.valid_data();
-                if (valid_data != nullptr) {
-                    valid_data += chunk_offset;
+                if (chunk_id != cached_chunk_id) {
+                    pw.emplace(
+                        segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id));
+                    auto chunk = pw->get();
+                    chunk_base = chunk.data();
+                    chunk_valid_base = chunk.valid_data();
+                    // SkipIndex is keyed by chunk alone; evaluate it once per
+                    // chunk instead of once per row.
+                    cached_skip = skip_func &&
+                                  skip_func(*skip_index, field_id_, chunk_id);
+                    cached_chunk_id = chunk_id;
                 }
-                if (!skip_func ||
-                    !skip_func(*skip_index, field_id_, chunk_id)) {
+                const T* data = chunk_base + chunk_offset;
+                const bool* valid_data = chunk_valid_base != nullptr
+                                             ? chunk_valid_base + chunk_offset
+                                             : nullptr;
+                if (!cached_skip) {
                     evaluate_batch.template operator()<FilterType::random>(
                         data,
                         valid_data,

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -17,10 +17,12 @@
 
 #include <folly/io/IOBuf.h>
 #include <sys/mman.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 #include <cmath>
 
@@ -275,17 +277,30 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
             return;
         }
         // nullable:
-        if (count == 0) {
+        if (offsets == nullptr) {
+            // Interface contract: null offsets means iterate over ALL rows
+            // (see ChunkedColumnInterface::BulkIsValid). Scan chunk by chunk,
+            // pinning each group chunk once — mirrors the BulkRawStringAt
+            // full-scan branch.
+            int64_t current_offset = 0;
+            for (cid_t cid = 0; cid < num_chunks(); ++cid) {
+                auto group_chunk = group_->GetGroupChunk(op_ctx, cid);
+                auto chunk = group_chunk.get()->GetChunk(field_id_);
+                auto chunk_rows = chunk->RowNums();
+                for (int64_t i = 0; i < chunk_rows; ++i) {
+                    fn(chunk->isValid(i), current_offset + i);
+                }
+                current_offset += chunk_rows;
+            }
             return;
         }
-        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
-        auto ca = group_->GetGroupChunks(op_ctx, cids);
-        for (int64_t i = 0; i < count; i++) {
-            auto* group_chunk = ca->get_cell_of(cids[i]);
-            auto chunk = group_chunk->GetChunk(field_id_);
-            auto valid = chunk->isValid(offsets_in_chunk[i]);
-            fn(valid, i);
-        }
+        ForEachResolvedRow(
+            op_ctx,
+            offsets,
+            count,
+            [&fn](Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+                fn(chunk->isValid(offset_in_chunk), i);
+            });
     }
 
     bool
@@ -491,17 +506,17 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                 std::function<void(const char*, size_t)> fn,
                 const int64_t* offsets,
                 int64_t count) override {
-        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
-        auto ca = group_->GetGroupChunks(op_ctx, cids);
-        for (int64_t i = 0; i < count; i++) {
-            auto* group_chunk = ca->get_cell_of(cids[i]);
-            auto chunk = group_chunk->GetChunk(field_id_);
-            auto offset = offsets_in_chunk[i];
-            if (field_meta_.is_nullable() && IsVectorDataType(data_type_)) {
-                offset = chunk->PhysicalOffsetOf(offset);
-            }
-            fn(chunk->ValueAt(offset), i);
-        }
+        ForEachResolvedRow(
+            op_ctx,
+            offsets,
+            count,
+            [this, &fn](Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+                auto offset = offset_in_chunk;
+                if (field_meta_.is_nullable() && IsVectorDataType(data_type_)) {
+                    offset = chunk->PhysicalOffsetOf(offset);
+                }
+                fn(chunk->ValueAt(offset), i);
+            });
     }
 
     template <typename S, typename T>
@@ -511,16 +526,16 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                              const int64_t* offsets,
                              int64_t count) {
         static_assert(std::is_fundamental_v<S> && std::is_fundamental_v<T>);
-        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
-        auto ca = group_->GetGroupChunks(op_ctx, cids);
         auto typed_dst = static_cast<T*>(dst);
-        for (int64_t i = 0; i < count; i++) {
-            auto* group_chunk = ca->get_cell_of(cids[i]);
-            auto chunk = group_chunk->GetChunk(field_id_);
-            auto value = chunk->ValueAt(offsets_in_chunk[i]);
-            typed_dst[i] =
-                *static_cast<const S*>(static_cast<const void*>(value));
-        }
+        ForEachResolvedRow(
+            op_ctx,
+            offsets,
+            count,
+            [typed_dst](Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+                auto value = chunk->ValueAt(offset_in_chunk);
+                typed_dst[i] =
+                    *static_cast<const S*>(static_cast<const void*>(value));
+            });
     }
 
     void
@@ -596,20 +611,21 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                       const int64_t* offsets,
                       int64_t element_sizeof,
                       int64_t count) override {
-        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
-        auto ca = group_->GetGroupChunks(op_ctx, cids);
         auto dst_vec = reinterpret_cast<char*>(dst);
-        for (int64_t i = 0; i < count; i++) {
-            auto* group_chunk = ca->get_cell_of(cids[i]);
-            auto chunk = group_chunk->GetChunk(field_id_);
-            auto offset = offsets_in_chunk[i];
-            if (field_meta_.is_nullable()) {
-                offset = chunk->PhysicalOffsetOf(offset);
-            }
-            auto value = chunk->ValueAt(offset);
-            milvus::fastmem::FastMemcpy(
-                dst_vec + i * element_sizeof, value, element_sizeof);
-        }
+        ForEachResolvedRow(
+            op_ctx,
+            offsets,
+            count,
+            [this, dst_vec, element_sizeof](
+                Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+                auto offset = offset_in_chunk;
+                if (field_meta_.is_nullable()) {
+                    offset = chunk->PhysicalOffsetOf(offset);
+                }
+                auto value = chunk->ValueAt(offset);
+                milvus::fastmem::FastMemcpy(
+                    dst_vec + i * element_sizeof, value, element_sizeof);
+            });
     }
 
     void
@@ -639,22 +655,16 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                 current_offset += chunk_rows;
             }
         } else {
-            auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
-            auto ca = group_->GetGroupChunks(op_ctx, cids);
-            std::vector<std::shared_ptr<Chunk>> chunks(num_chunks());
-            for (int64_t i = 0; i < count; i++) {
-                auto cid = cids[i];
-                auto& chunk = chunks[cid];
-                if (chunk == nullptr) {
-                    auto* group_chunk = ca->get_cell_of(cid);
-                    chunk = group_chunk->GetChunk(field_id_);
-                }
-                auto valid = chunk->isValid(offsets_in_chunk[i]);
-                auto value = static_cast<StringChunk*>(chunk.get())
-                                 ->
-                                 operator[](offsets_in_chunk[i]);
-                fn(value, i, valid);
-            }
+            ForEachResolvedRow(
+                op_ctx,
+                offsets,
+                count,
+                [&fn](Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+                    auto valid = chunk->isValid(offset_in_chunk);
+                    auto value = static_cast<StringChunk*>(chunk)->operator[](
+                        offset_in_chunk);
+                    fn(value, i, valid);
+                });
         }
     }
 
@@ -672,18 +682,16 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         if (count == 0) {
             return;
         }
-        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
-        auto ca = group_->GetGroupChunks(op_ctx, cids);
-
-        for (int64_t i = 0; i < count; i++) {
-            auto* group_chunk = ca->get_cell_of(cids[i]);
-            auto chunk = group_chunk->GetChunk(field_id_);
-            auto valid = chunk->isValid(offsets_in_chunk[i]);
-            auto str_view = static_cast<StringChunk*>(chunk.get())
-                                ->
-                                operator[](offsets_in_chunk[i]);
-            fn(Json(str_view.data(), str_view.size()), i, valid);
-        }
+        ForEachResolvedRow(
+            op_ctx,
+            offsets,
+            count,
+            [&fn](Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+                auto valid = chunk->isValid(offset_in_chunk);
+                auto str_view = static_cast<StringChunk*>(chunk)->operator[](
+                    offset_in_chunk);
+                fn(Json(str_view.data(), str_view.size()), i, valid);
+            });
     }
 
     void
@@ -702,20 +710,19 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         }
 
         AssertInfo(row_offsets != nullptr, "row_offsets is nullptr");
-        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(row_offsets, count);
-        auto ca = group_->GetGroupChunks(op_ctx, cids);
-
-        for (int64_t i = 0; i < count; i++) {
-            auto* group_chunk = ca->get_cell_of(cids[i]);
-            auto chunk = group_chunk->GetChunk(field_id_);
-            auto str_view = static_cast<StringChunk*>(chunk.get())
-                                ->
-                                operator[](offsets_in_chunk[i]);
-            fn(BsonView(reinterpret_cast<const uint8_t*>(str_view.data()),
-                        str_view.size()),
-               row_offsets[i],
-               value_offsets[i]);
-        }
+        ForEachResolvedRow(
+            op_ctx,
+            row_offsets,
+            count,
+            [&fn, row_offsets, value_offsets](
+                Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+                auto str_view = static_cast<StringChunk*>(chunk)->operator[](
+                    offset_in_chunk);
+                fn(BsonView(reinterpret_cast<const uint8_t*>(str_view.data()),
+                            str_view.size()),
+                   row_offsets[i],
+                   value_offsets[i]);
+            });
     }
 
     void
@@ -728,15 +735,15 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                       "[StorageV2] BulkArrayAt only supported for "
                       "ChunkedArrayColumn");
         }
-        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
-        auto ca = group_->GetGroupChunks(op_ctx, cids);
-        for (int64_t i = 0; i < count; i++) {
-            auto* group_chunk = ca->get_cell_of(cids[i]);
-            auto chunk = group_chunk->GetChunk(field_id_);
-            auto view = static_cast<ArrayChunk*>(chunk.get())
-                            ->View(offsets_in_chunk[i]);
-            fn(view, i);
-        }
+        ForEachResolvedRow(
+            op_ctx,
+            offsets,
+            count,
+            [&fn](Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+                auto view =
+                    static_cast<ArrayChunk*>(chunk)->View(offset_in_chunk);
+                fn(view, i);
+            });
     }
 
     void
@@ -749,20 +756,71 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                       "[StorageV2] BulkVectorArrayAt only supported for "
                       "ChunkedVectorArrayColumn");
         }
-        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
-        auto ca = group_->GetGroupChunks(op_ctx, cids);
-        for (int64_t i = 0; i < count; i++) {
-            auto* group_chunk = ca->get_cell_of(cids[i]);
-            auto chunk = group_chunk->GetChunk(field_id_);
-            auto offset = offsets_in_chunk[i];
-            auto array = static_cast<VectorArrayChunk*>(chunk.get())
-                             ->View(offset)
-                             .output_data();
-            fn(std::move(array), i);
-        }
+        ForEachResolvedRow(
+            op_ctx,
+            offsets,
+            count,
+            [&fn](Chunk* chunk, int64_t offset_in_chunk, int64_t i) {
+                auto array = static_cast<VectorArrayChunk*>(chunk)
+                                 ->View(offset_in_chunk)
+                                 .output_data();
+                fn(std::move(array), i);
+            });
     }
 
  private:
+    // Resolve, for each requested offset, the chunk that owns it and invoke
+    // fn(chunk, offset_in_chunk, i), preserving the original row order.
+    //
+    // Two costs are amortized here:
+    //   1. borrow: resolution goes through GroupChunk::GetChunkRaw(), which
+    //      returns a borrowed Chunk* and never bumps a shared_ptr refcount, so
+    //      no atomic RMW contends on shared chunk control blocks under
+    //      concurrent search.
+    //   2. dedup: each distinct requested chunk is resolved exactly once (the
+    //      resolution is a lookup on the GroupChunk field map that, over a
+    //      large segment, hits a cache-cold map node), so a batch of N rows
+    //      spanning D distinct chunks pays D resolutions, not N.
+    // The dedup table is sized by the distinct requested chunks (<= count), NOT
+    // by the segment's total chunk count, so a small count on a large segment
+    // never allocates memory proportional to the whole segment. A last-cid
+    // guard keeps chunk-clustered offsets (sorted retrieve, per-chunk fill
+    // runs) on a single comparison and only touches the table at run
+    // boundaries; scattered offsets fall back to the table.
+    //
+    // Row order is preserved (offsets are never reordered), so order-coupled
+    // callers stay correct. The pinned CellAccessor `ca` keeps every touched
+    // chunk alive for the whole loop, so borrowing a raw Chunk* is safe.
+    template <typename OffsetT, typename Fn>
+    void
+    ForEachResolvedRow(milvus::OpContext* op_ctx,
+                       const OffsetT* offsets,
+                       int64_t count,
+                       Fn&& fn) const {
+        if (count == 0) {
+            return;
+        }
+        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
+        auto ca = group_->GetGroupChunks(op_ctx, cids);
+        std::unordered_map<cachinglayer::cid_t, Chunk*> resolved;
+        resolved.reserve(std::min<int64_t>(
+            count, static_cast<int64_t>(group_->num_chunks())));
+        int64_t cached_cid = -1;
+        Chunk* cached_chunk = nullptr;
+        for (int64_t i = 0; i < count; i++) {
+            auto cid = cids[i];
+            if (int64_t(cid) != cached_cid) {
+                auto [it, inserted] = resolved.try_emplace(cid, nullptr);
+                if (inserted) {
+                    it->second = ca->get_cell_of(cid)->GetChunkRaw(field_id_);
+                }
+                cached_chunk = it->second;
+                cached_cid = cid;
+            }
+            fn(cached_chunk, offsets_in_chunk[i], i);
+        }
+    }
+
     std::shared_ptr<ChunkedColumnGroup> group_;
     FieldId field_id_;
     const FieldMeta field_meta_;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -277,6 +277,21 @@ ChunkedSegmentSealedImpl::ReadTimestamp(
     if (timestamps != nullptr && !timestamps->empty()) {
         return (*timestamps)[offset];
     }
+    // Fallback: read one row straight from the timestamp column. On current
+    // master this is effectively unreachable in production — every load path
+    // that publishes the timestamp column also publishes a fully-pinned
+    // zero-copy TimestampData (init_storage_v2_timestamp_index /
+    // init_storage_v1_timestamp_index) in the same atomic runtime snapshot,
+    // so the short-circuit above always hits; only tests and degenerate
+    // states reach here.
+    //
+    // NOTE for anyone making this path live (e.g. an evictable timestamp
+    // column for tiered storage): this access pattern pins a cell and
+    // resolves the chunk PER CALL. Do not drive it from a per-row loop
+    // (mask_with_timestamps grey-zone scan, search_batch_pks) — introduce a
+    // batched ReadTimestamps(offsets, count) that pins all involved chunks
+    // once and dedups resolution per distinct chunk (see ForEachResolvedRow
+    // in mmap/ChunkedColumnGroup.h for the shape).
     auto column = get_column(runtime, TimestampFieldID);
     AssertInfo(column != nullptr, "timestamp data is not ready");
     const auto chunk_pos = column->GetChunkIDByOffset(offset);
@@ -4894,9 +4909,15 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                "field {} must be ready when doing bulk_subscript",
                field_id.get());
     if (column->IsNullable()) {
-        for (auto i = 0; i < count; i++) {
-            valid_map.set(i, column->IsValid(op_ctx, seg_offsets[i]));
-        }
+        // Batched validity: pin all involved chunks once and dedup chunk
+        // resolution, instead of column->IsValid() per row (which pins a cell
+        // and resolves a chunk on every call). BulkIsValid preserves row order,
+        // invoking the callback with the original row index.
+        column->BulkIsValid(
+            op_ctx,
+            [&valid_map](bool valid, size_t i) { valid_map.set(i, valid); },
+            seg_offsets,
+            count);
     } else {
         valid_map.set();
     }

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -39,29 +39,36 @@
 
 namespace milvus::segcore {
 
+// Validity (null bitmap) storage for growing segments.
+//
+// Backed by fixed-size per-chunk buffers held in a std::deque so that, once a
+// chunk is appended, its buffer never moves. A raw pointer returned by
+// get_chunk_data() therefore stays valid across concurrent inserts (which only
+// append — never relocate existing chunks). This replaces a single resizable
+// FixedVector<bool> whose reallocation on insert could dangle a validity
+// pointer that a concurrent query had cached.
+//
+// Contract: a get_chunk_data() borrow may only be read within its own chunk
+// ([offset, chunk end)). All current readers apply validity per chunk (see
+// ApplyFieldValidData and InsertRecord::get_span_base), so this holds.
 class ThreadSafeValidData {
  public:
-    explicit ThreadSafeValidData() = default;
-    explicit ThreadSafeValidData(FixedVector<bool> data)
-        : data_(std::move(data)) {
+    explicit ThreadSafeValidData(int64_t size_per_chunk)
+        : size_per_chunk_(size_per_chunk) {
+        AssertInfo(size_per_chunk_ > 0,
+                   "size_per_chunk must be positive, got {}",
+                   size_per_chunk_);
     }
 
     void
     set_data_raw(const std::vector<FieldDataPtr>& datas) {
         std::unique_lock<std::shared_mutex> lck(mutex_);
-        auto total = 0;
-        for (auto& field_data : datas) {
-            total += field_data->get_num_rows();
-        }
-        if (length_ + total > data_.size()) {
-            data_.resize(length_ + total);
-        }
-
         for (auto& field_data : datas) {
             auto num_row = field_data->get_num_rows();
-            for (size_t i = 0; i < num_row; i++) {
-                data_[length_ + i] = field_data->is_valid(i);
-            }
+            reserve_to(length_ + num_row);
+            write_bits(length_, num_row, [&field_data](size_t i) {
+                return field_data->is_valid(i);
+            });
             length_ += num_row;
         }
     }
@@ -72,11 +79,8 @@ class ThreadSafeValidData {
                  const FieldMeta& field_meta) {
         std::unique_lock<std::shared_mutex> lck(mutex_);
         if (field_meta.is_nullable()) {
-            if (length_ + num_rows > data_.size()) {
-                data_.resize(length_ + num_rows);
-            }
-            auto src = data->valid_data().data();
-            std::copy_n(src, num_rows, data_.data() + length_);
+            reserve_to(length_ + num_rows);
+            write_from(length_, num_rows, data->valid_data().data());
             length_ += num_rows;
         }
     }
@@ -88,9 +92,12 @@ class ThreadSafeValidData {
                    "offset out of range, offset={}, length_={}",
                    offset,
                    length_);
-        return data_[offset];
+        return chunks_[offset / size_per_chunk_][offset % size_per_chunk_];
     }
 
+    // Borrow a pointer into the validity bitmap at `offset`. Valid only for
+    // reads within the same chunk ([offset, chunk end)); the pointed-to chunk
+    // buffer never moves, so the borrow survives concurrent inserts.
     bool*
     get_chunk_data(size_t offset) {
         std::shared_lock<std::shared_mutex> lck(mutex_);
@@ -98,18 +105,105 @@ class ThreadSafeValidData {
                    "offset out of range, offset={}, length_={}",
                    offset,
                    length_);
-        return &data_[offset];
+        return &chunks_[offset / size_per_chunk_][offset % size_per_chunk_];
     }
 
+    // Fill out[i] with the validity of offsets[i] for `count` offsets under a
+    // single lock acquisition. Out-of-range offsets yield false (not an
+    // assert), matching the tolerant semantics of offset-driven read paths.
+    void
+    bulk_is_valid(const int64_t* offsets, int64_t count, bool* out) const {
+        std::shared_lock<std::shared_mutex> lck(mutex_);
+        const size_t spc = static_cast<size_t>(size_per_chunk_);
+        for (int64_t i = 0; i < count; ++i) {
+            auto offset = offsets[i];
+            out[i] = offset >= 0 && static_cast<size_t>(offset) < length_ &&
+                     chunks_[offset / spc][offset % spc];
+        }
+    }
+
+    // WARNING: materializes a flat copy of the WHOLE bitmap (O(segment rows))
+    // — avoid on hot paths. Prefer empty() for emptiness checks,
+    // is_valid()/bulk_is_valid() for point/batch lookups, or get_chunk_data()
+    // to borrow within a chunk.
     FixedVector<bool>
     get_data() const {
         std::shared_lock<std::shared_mutex> lck(mutex_);
-        return data_;
+        FixedVector<bool> out(length_);
+        const size_t spc = static_cast<size_t>(size_per_chunk_);
+        size_t copied = 0;
+        for (const auto& chunk : chunks_) {
+            if (copied >= length_) {
+                break;
+            }
+            const size_t n = std::min(spc, length_ - copied);
+            std::copy_n(chunk.begin(), n, out.begin() + copied);
+            copied += n;
+        }
+        return out;
+    }
+
+    bool
+    empty() const {
+        std::shared_lock<std::shared_mutex> lck(mutex_);
+        return length_ == 0;
     }
 
  private:
+    // Ensure enough chunks exist to hold `n` elements. Caller holds the lock.
+    void
+    reserve_to(size_t n) {
+        const size_t spc = static_cast<size_t>(size_per_chunk_);
+        const size_t need = (n + spc - 1) / spc;
+        while (chunks_.size() < need) {
+            chunks_.emplace_back(spc, false);
+        }
+    }
+
+    // Write `count` bits starting at global offset `at` from a contiguous
+    // source array, chunk by chunk via copy_n. Caller holds the lock and has
+    // already reserved capacity.
+    void
+    write_from(size_t at, size_t count, const bool* src) {
+        const size_t spc = static_cast<size_t>(size_per_chunk_);
+        size_t written = 0;
+        while (written < count) {
+            const size_t g = at + written;
+            const size_t ci = g / spc;
+            const size_t oi = g % spc;
+            const size_t n = std::min(count - written, spc - oi);
+            std::copy_n(src + written, n, chunks_[ci].begin() + oi);
+            written += n;
+        }
+    }
+
+    // Write `count` bits starting at global offset `at`, taking bit k from
+    // f(k). Splits across chunk boundaries. Caller holds the lock and has
+    // already reserved capacity.
+    template <typename F>
+    void
+    write_bits(size_t at, size_t count, F&& f) {
+        const size_t spc = static_cast<size_t>(size_per_chunk_);
+        size_t written = 0;
+        while (written < count) {
+            const size_t g = at + written;
+            const size_t ci = g / spc;
+            const size_t oi = g % spc;
+            const size_t room = spc - oi;
+            const size_t n =
+                (count - written < room) ? (count - written) : room;
+            auto& chunk = chunks_[ci];
+            for (size_t k = 0; k < n; ++k) {
+                chunk[oi + k] = f(written + k);
+            }
+            written += n;
+        }
+    }
+
     mutable std::shared_mutex mutex_{};
-    FixedVector<bool> data_;
+    // Fixed-size (size_per_chunk_) buffers; deque keeps existing buffers put.
+    std::deque<FixedVector<bool>> chunks_;
+    const int64_t size_per_chunk_;
     // number of actual elements
     size_t length_{0};
 };

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1607,7 +1607,7 @@ class InsertRecordGrowing {
         int64_t size_per_chunk,
         const storage::MmapChunkDescriptorPtr mmap_descriptor = nullptr) {
         if (field_meta.is_nullable()) {
-            this->append_valid_data(field_id);
+            this->append_valid_data(field_id, size_per_chunk);
         }
         const milvus::storage::MmapConfig mmap_config =
             storage::MmapManager::GetInstance().GetMmapConfig();
@@ -1853,8 +1853,8 @@ class InsertRecordGrowing {
 
     // append a column of scalar type
     void
-    append_valid_data(FieldId field_id) {
-        auto valid_data = std::make_shared<ThreadSafeValidData>();
+    append_valid_data(FieldId field_id, int64_t size_per_chunk) {
+        auto valid_data = std::make_shared<ThreadSafeValidData>(size_per_chunk);
         std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
         valid_data_.emplace(field_id, std::move(valid_data));
     }

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2723,7 +2723,7 @@ SegmentGrowingImpl::FillAbsentFields() {
             if (field_meta.is_nullable() &&
                 insert_record_.is_data_exist(field_id) &&
                 insert_record_.is_valid_data_exist(field_id) &&
-                insert_record_.get_valid_data(field_id)->get_data().empty()) {
+                insert_record_.get_valid_data(field_id)->empty()) {
                 fill_empty_field(field_meta);
                 EnsureArrayOffsetsForStructField(field_meta,
                                                  insert_record_.row_count());
@@ -3185,9 +3185,15 @@ SegmentGrowingImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
     } else {
         auto vec_base = insert_record_.get_data_base(field_id);
         if (vec_base != nullptr) {
-            auto valid_data_vec = vec_base->get_valid_data();
+            // Avoid vec_base->get_valid_data(): it materializes a flat copy of
+            // the WHOLE validity bitmap (O(segment rows)) while this path only
+            // needs `count` offsets (and, on the mapping-storage branch, only
+            // an emptiness check).
+            auto valid_data_ptr = insert_record_.is_valid_data_exist(field_id)
+                                      ? insert_record_.get_valid_data(field_id)
+                                      : nullptr;
             bool is_mapping_storage = vec_base->is_mapping_storage();
-            if (!valid_data_vec.empty()) {
+            if (valid_data_ptr != nullptr && !valid_data_ptr->empty()) {
                 result.valid_data = std::make_unique<bool[]>(count);
 
                 if (is_mapping_storage) {
@@ -3198,14 +3204,8 @@ SegmentGrowingImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
                         result.valid_offsets);
                 } else {
                     result.valid_offsets.reserve(count);
-                    for (int64_t i = 0; i < count; ++i) {
-                        auto offset = seg_offsets[i];
-                        bool is_valid = offset >= 0 &&
-                                        offset < static_cast<int64_t>(
-                                                     valid_data_vec.size()) &&
-                                        valid_data_vec[offset];
-                        result.valid_data[i] = is_valid;
-                    }
+                    valid_data_ptr->bulk_is_valid(
+                        seg_offsets, count, result.valid_data.get());
                 }
                 result.valid_count = result.valid_offsets.size();
             }


### PR DESCRIPTION
## Summary

issue: #50991

Storage-v2 hot paths resolved the chunk that owns a row **once per row** even when
thousands of score-ordered offsets map to only a few distinct chunks. Two layers had
the problem:

1. **Column layer** — `ProxyChunkColumn` bulk accessors: `GroupChunk::GetChunk(field_id_)`
   returns a `shared_ptr<Chunk>` by value, so every row paid a field-map lookup plus an
   atomic refcount bump. Under concurrent search the per-row atomic RMW on shared chunk
   control blocks contends across cores.
2. **Expression layer** — the by-offsets eval paths re-pinned a fresh chunk *and*
   re-resolved it per row (the string/json/array branch heap-allocated a one-element view
   vector per row); the offset-input paths in `PhyColumnExpr` / `PhyCompareFilterExpr`
   rebuilt a `ChunkDataAccessor` (re-pinning the chunk) every row.

## Changes (single commit)

**Column layer (`ChunkedColumnGroup.h`, `GroupChunk.h`)**

- New `GroupChunk::GetChunkRaw(field_id) -> Chunk*` **borrows** the chunk (no shared
  ownership, no atomic; valid while the pinned `CellAccessor` keeps the GroupChunk
  resident).
- All per-row bulk accessors route through one helper, `ForEachResolvedRow`, which pins
  the involved chunks once, then **dedups resolution per distinct chunk id** via a
  last-cid fast path + a hash map reserved to `min(count, num_chunks)` — allocation is
  proportional to the *request*, never to the segment's total chunk count, so a small
  top-K read on a large segment stays cheap (addresses the earlier review comment).
- `BulkIsValid` now honors the interface contract's `offsets == nullptr` full-scan mode
  on the nullable path (previously silently returned; storage-v1 and the non-nullable
  branch already honored it).

**Expression layer (`Expr.h`, `CompareExpr.h`, `ColumnExpr.cpp`, `CompareExpr.cpp`)**

- `SegmentExpr::ProcessDataByOffsets` fixed-width branch (sealed **and** growing): keep
  the pinned chunk across iterations, re-pin only when the chunk id changes; the
  SkipIndex decision is evaluated once per chunk instead of once per row.
- `SegmentExpr::ProcessDataByOffsets` string/json/array branch: group runs of
  consecutive same-chunk offsets and fetch each run with one `get_views_by_offsets`
  call (views bound by reference — no per-run copies), eliminating the per-row pin +
  per-row one-element vector allocation. Per-row callback invocation and row order
  unchanged.
- `PhyCompareFilterExpr::ProcessBothDataByOffsets`: cache both left and right pinned
  chunks, re-pin each only on its chunk-id change.
- `PhyColumnExpr::DoEval` and the `PhyCompareFilterExpr` offset-input path: cache the
  `ChunkDataAccessor` per chunk id instead of rebuilding (and re-pinning) it every row;
  the chunk-independent pinned-index view is resolved once.

**Segcore (`ChunkedSegmentSealedImpl.cpp`)**

- `bulk_subscript` nullable validity uses the batched `BulkIsValid` (pins the involved
  chunks once) instead of per-row `IsValid` (which pins a cell on every call).
- Documented the `ReadTimestamp` StorageV2 fallback's per-row-pin access pattern (see
  Follow-ups).

**Growing validity lookups (`ConcurrentVector.h`, `SegmentGrowingImpl.cpp`)**

- New `ThreadSafeValidData::bulk_is_valid(offsets, count, out)`: answers `count`
  offsets under one lock acquisition (out-of-range yields `false`, matching the
  loop it replaces). `FilterVectorValidOffsets` (growing `bulk_subscript`,
  nullable vector fields) no longer copies the whole validity bitmap per query —
  previously an O(segment rows) `get_valid_data()` copy used only for `count`
  lookups (and, on the mapping-storage branch, an emptiness check now served by
  `empty()`). `get_data()` is documented as a whole-bitmap copy to avoid on hot
  paths.

**Enabling change for growing segments (`ConcurrentVector.h`, `InsertRecord.h`)**

`ThreadSafeValidData` (the growing nullable validity bitmap) previously stored one flat
`FixedVector<bool>` that could **reallocate on a concurrent insert**, so a validity
pointer cached across rows could dangle (a pre-existing one-row race that cross-row
caching would have widened). It now stores fixed-size per-chunk buffers in a deque
(chunk size = `size_per_chunk`, threaded through `append_valid_data`): appends only add
new buffers and never move existing ones, so a borrowed validity pointer stays valid for
reads within its chunk. All raw-pointer readers were audited to read within a single
chunk (`ApplyFieldValidData` callers, `InsertRecord::get_span_base`, expr span
consumers). This is what makes the cross-row caching above safe on growing segments —
the root fix requested in review, instead of gating growing out of the optimization.

Storage v1 `ChunkedColumn` needed no change: its `get_cell_of` already returns a raw
`Chunk*` with no shared_ptr or per-row field-map lookup.

## Performance

Qualitative, by mechanism:
- **Concurrent search** (primary target): the per-row shared_ptr refcount atomic on
  shared chunk control blocks is gone (`GetChunk` → borrowed `GetChunkRaw`), removing
  cross-core contention on hot segments.
- **Single-thread**: chunk resolution (a cache-cold map lookup on large segments) runs
  once per distinct chunk instead of once per row; the variable-length expr path
  additionally saves a per-row heap allocation.
- Microbenchmarks on an earlier prototype of this change (same borrow + once-per-distinct-
  chunk dedup semantics; cache structure since reworked per review) showed ~1.5–1.7×
  single-thread and ~5× 8-thread concurrent on 10k random-offset reads, with no
  regression at count=1. Not re-measured on the final form; treat as indicative only.

## Testing

- Covered by the existing mmap / expression / StorageV2 regression suites and CI; no new
  test files in this PR.
- The `ThreadSafeValidData` rewrite preserves the public interface (`set_data_raw` /
  `is_valid` / `get_chunk_data` / `get_data`, plus a new `empty()`), so existing nullable
  growing-segment suites exercise it directly.

## Notes for reviewers

- `folly::F14FastMap` was tried for the dedup cache and reverted: its hash requires
  SSE4.2 crc32 (`_mm_crc32_u64`) and fails to compile under the core build's runtime
  SIMD dispatch (no `-msse4.2` on these TUs); `std::unordered_map` reserved to
  `min(count, num_chunks)` is used instead.

## Follow-ups (separate PRs)

- `ReadTimestamp`'s StorageV2 fallback re-pins per row, but is effectively unreachable
  in production (every v2 load path materializes a fully-pinned zero-copy
  `TimestampData`); a NOTE in code documents the batched design it needs if the
  timestamp column ever becomes evictable.
- The `VectorArrayView` by-offsets branch still resolves per row — needs a batch
  by-offsets column API first.
- Cleanups: lazy-create the dedup map in `ForEachResolvedRow` (skip the allocation for
  single-chunk requests); unify the sealed/growing fixed-width loops and the duplicated
  offset→(chunk, offset) resolution lambdas behind one helper.

Supersedes #50992 (closed; predated master's `ToChunkIdAndOffset`/`GetGroupChunks`
batch-resolve, and its bundled `BulkIsValid` fix already merged as #51598).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Md98mTWZSM9xDmLjeVYdvh
