### PR TITLE
fix: free CStatus error_msg in flush growing segment test

### DIFF
--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -1684,6 +1684,7 @@ TEST_F(FlushGrowingSegmentTest, FlushRejectsEndOffsetBeyondRowCount) {
     ASSERT_NE(status.error_msg, nullptr);
     EXPECT_NE(std::string(status.error_msg).find("exceeds growing segment"),
               std::string::npos);
+    free(const_cast<char*>(status.error_msg));
 
     FreeFlushResult(&result);
 }


### PR DESCRIPTION
issue: #51679

## Summary

`FlushGrowingSegmentTest.FlushRejectsEndOffsetBeyondRowCount` (added in #51532 / 42f6bcb69a) drives `FlushGrowingSegmentData` down an error path and asserts on `status.error_msg` without freeing it. `FailureCStatus` strdup's the message (EasyAssert.h:130), so ownership passes to the caller. LeakSanitizer reports the 64-byte direct leak at process exit, ASan exits non-zero, and `all_tests` returns 255 — which makes the **ci-v2/ut-cpp check fail deterministically for every PR branch containing 42f6bcb69a**, even though all ~7800 gtests pass (19 of the last 30 ut-cpp builds failed with a byte-identical signature; details in the issue). The ciloop UT-CPP-Cov job doesn't catch it because it runs without ASan/LSan.

## Fix

One line: free the message after the assertions, matching the existing convention used by the other failure-path test in this same file (`FlushRejectsSealedSegment`-style, line ~2906: `free(const_cast<char*>(status.error_msg))`) and sibling segcore C-API tests. Audited the file: these are the only two failure-path `CStatus` sites; both now free.

## Test

Not run locally under ASan (the leak only reproduces in the sanitizer-instrumented build). The authoritative verification is the `ci-v2/ut-cpp` job on this PR itself — it currently fails deterministically on every up-to-date branch, so this PR going green there is the end-to-end proof.

/cc @zhagnlu

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2wVTn3u4oDTVYkxjtjtto