### PR TITLE
fix: [cp3.0]base64-encode encryption key in NewManifestRecordReader

### DIFF
--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -382,7 +382,7 @@ func NewManifestRecordReader(ctx context.Context, manifestPath string, schema *s
 					pluginContext = &indexcgopb.StoragePluginContext{
 						EncryptionZoneId: ez.EzID,
 						CollectionId:     ez.CollectionID,
-						EncryptionKey:    string(unsafe),
+						EncryptionKey:    base64.StdEncoding.EncodeToString(unsafe),
 					}
 				}
 			}

--- a/internal/storage/serde_events_test.go
+++ b/internal/storage/serde_events_test.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"math/rand"
@@ -728,7 +729,9 @@ func TestNewManifestRecordReaderBranches(t *testing.T) {
 	require.NotNil(t, capturedPluginContext)
 	require.Equal(t, int64(7), capturedPluginContext.GetEncryptionZoneId())
 	require.Equal(t, int64(2), capturedPluginContext.GetCollectionId())
-	require.Equal(t, "unsafe-key", capturedPluginContext.GetEncryptionKey())
+	// the plugin context contract carries the key base64-encoded, matching
+	// NewBinlogRecordReader/NewBinlogRecordWriter and hookutil.GetCPluginContext
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("unsafe-key")), capturedPluginContext.GetEncryptionKey())
 }
 
 func TestBinlogSerializeWriter(t *testing.T) {


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #51480
issue: #51475

## Summary

Cherry-picked from master PR #51480 (open - preemptive backport).

Every producer of `StoragePluginContext.EncryptionKey` base64-encodes the raw key except `NewManifestRecordReader`, which passed the raw bytes. For encrypted collections stored in StorageV3 manifest format, the reader handed the cipher plugin differently encoded key material than the writer used, breaking decryption on manifest reads (compaction, external function executor). Encode the key with base64 to match the contract, and fix the unit test.

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] File count matches original PR (2 files)
- [x] Code changes verified identical to master commit
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)
