### PR TITLE
fix: keep searching replicas in TransferSegment/TransferChannel

### DIFF
--- a/internal/querycoordv2/ops_service_test.go
+++ b/internal/querycoordv2/ops_service_test.go
@@ -981,3 +981,75 @@ func (suite *OpsServiceSuite) TestTransferChannel() {
 func TestOpsService(t *testing.T) {
 	suite.Run(t, new(OpsServiceSuite))
 }
+
+// TestTransferSegmentMultiReplica covers the case where the source node serves several
+// collections and therefore belongs to several replicas. The requested segment lives in
+// exactly one of them, and the other replicas must not abort the whole request.
+func (suite *OpsServiceSuite) TestTransferSegmentMultiReplica() {
+	ctx := context.Background()
+	suite.server.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	const (
+		targetCollection = int64(100)
+		partitionID      = int64(1)
+		segmentID        = int64(1000)
+		channelName      = "channel-multi-replica"
+	)
+	nodes := []int64{1, 2}
+
+	// the source node also serves 5 other collections that hold no segment on it
+	for i, collectionID := range []int64{101, 102, 103, 104, 105, targetCollection} {
+		suite.meta.Put(ctx, utils.CreateTestReplica(int64(200+i), collectionID, nodes))
+		suite.meta.PutCollection(ctx,
+			utils.CreateTestCollection(collectionID, 1),
+			utils.CreateTestPartition(partitionID, collectionID))
+	}
+
+	segments := []*datapb.SegmentInfo{{
+		ID:            segmentID,
+		CollectionID:  targetCollection,
+		PartitionID:   partitionID,
+		InsertChannel: channelName,
+		NumOfRows:     1,
+	}}
+	channels := []*datapb.VchannelInfo{{CollectionID: targetCollection, ChannelName: channelName}}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, targetCollection).Return(channels, segments, nil)
+	suite.targetMgr.UpdateCollectionNextTarget(ctx, targetCollection)
+	suite.targetMgr.UpdateCollectionCurrentTarget(ctx, targetCollection)
+	suite.dist.SegmentDistManager.Update(nodes[0], &meta.Segment{SegmentInfo: segments[0], Node: nodes[0]})
+
+	for _, node := range nodes {
+		suite.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   node,
+			Address:  "localhost",
+			Hostname: "localhost",
+		}))
+		suite.meta.HandleNodeUp(ctx, node)
+	}
+
+	assign.InitGlobalAssignPolicyFactory(suite.taskScheduler, suite.nodeMgr, suite.dist, suite.meta, suite.targetMgr)
+	balance.InitGlobalBalancerFactory(suite.taskScheduler, suite.nodeMgr, suite.dist, suite.targetMgr)
+	suite.taskScheduler.EXPECT().GetSegmentTaskDeltaSnapshot(mock.Anything, mock.Anything).
+		Return(task.NewSegmentTaskDeltaSnapshot(nil, nil)).Maybe()
+	suite.taskScheduler.EXPECT().GetChannelTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
+	suite.taskScheduler.EXPECT().Add(mock.Anything).Return(nil).Maybe()
+
+	// before the fix this returned SegmentNotFound whenever a replica of another
+	// collection happened to be visited before the one holding the segment
+	resp, err := suite.server.TransferSegment(ctx, &querypb.TransferSegmentRequest{
+		SourceNodeID: nodes[0],
+		TargetNodeID: nodes[1],
+		SegmentID:    segmentID,
+	})
+	suite.NoError(err)
+	suite.True(merr.Ok(resp))
+
+	// a segment that exists on no replica must still be reported as not found
+	resp, err = suite.server.TransferSegment(ctx, &querypb.TransferSegmentRequest{
+		SourceNodeID: nodes[0],
+		TargetNodeID: nodes[1],
+		SegmentID:    segmentID + 1,
+	})
+	suite.NoError(err)
+	suite.False(merr.Ok(resp))
+}

--- a/internal/querycoordv2/ops_services.go
+++ b/internal/querycoordv2/ops_services.go
@@ -393,6 +393,7 @@ func (s *Server) TransferSegment(ctx context.Context, req *querypb.TransferSegme
 	}
 
 	replicas := s.meta.GetByNode(ctx, req.GetSourceNodeID())
+	segmentFound := false
 	for _, replica := range replicas {
 		// when no dst node specified, default to use all other nodes in same
 		dstNodeSet := typeutil.NewUniqueSet()
@@ -425,9 +426,12 @@ func (s *Server) TransferSegment(ctx context.Context, req *querypb.TransferSegme
 			// check whether sealed segment exist
 			segment, ok := lo.Find(segments, func(s *meta.Segment) bool { return s.GetID() == req.GetSegmentID() })
 			if !ok {
-				err := merr.WrapErrSegmentNotFound(req.GetSegmentID(), "segment not found in source node")
-				return merr.Status(err), nil
+				// The source node may serve several collections, so it belongs to several
+				// replicas. The requested segment lives in exactly one of them, keep
+				// searching the remaining replicas instead of failing the whole request.
+				continue
 			}
+			segmentFound = true
 
 			existInTarget := s.targetMgr.GetSealedSegment(ctx, segment.GetCollectionID(), segment.GetID(), meta.CurrentTarget) != nil
 			if !existInTarget {
@@ -443,6 +447,12 @@ func (s *Server) TransferSegment(ctx context.Context, req *querypb.TransferSegme
 			log.Warn(ctx, msg, mlog.Err(err))
 			return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 		}
+	}
+
+	if !req.GetTransferAll() && !segmentFound {
+		err := merr.WrapErrSegmentNotFound(req.GetSegmentID(), "segment not found in source node")
+		log.Warn(ctx, "failed to transfer segment", mlog.Err(err))
+		return merr.Status(err), nil
 	}
 	return merr.Success(), nil
 }
@@ -472,6 +482,7 @@ func (s *Server) TransferChannel(ctx context.Context, req *querypb.TransferChann
 	}
 
 	replicas := s.meta.GetByNode(ctx, req.GetSourceNodeID())
+	channelFound := false
 	for _, replica := range replicas {
 		// when no dst node specified, default to use all other nodes in same
 		dstNodeSet := typeutil.NewUniqueSet()
@@ -500,9 +511,13 @@ func (s *Server) TransferChannel(ctx context.Context, req *querypb.TransferChann
 			// check whether sealed segment exist
 			channel, ok := lo.Find(channels, func(ch *meta.DmChannel) bool { return ch.GetChannelName() == req.GetChannelName() })
 			if !ok {
-				err := merr.WrapErrChannelNotFound(req.GetChannelName(), "channel not found in source node")
-				return merr.Status(err), nil
+				// The source node may serve several collections, so it belongs to several
+				// replicas. The requested channel lives in exactly one of them, keep
+				// searching the remaining replicas instead of failing the whole request.
+				continue
 			}
+			channelFound = true
+
 			existInTarget := s.targetMgr.GetDmChannel(ctx, channel.GetCollectionID(), channel.GetChannelName(), meta.CurrentTarget) != nil
 			if !existInTarget {
 				log.Info(ctx, "channel doesn't exist in current target, skip it", mlog.String("channelName", channel.GetChannelName()))
@@ -517,6 +532,12 @@ func (s *Server) TransferChannel(ctx context.Context, req *querypb.TransferChann
 			log.Warn(ctx, msg, mlog.Err(err))
 			return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 		}
+	}
+
+	if !req.GetTransferAll() && !channelFound {
+		err := merr.WrapErrChannelNotFound(req.GetChannelName(), "channel not found in source node")
+		log.Warn(ctx, "failed to transfer channel", mlog.Err(err))
+		return merr.Status(err), nil
 	}
 	return merr.Success(), nil
 }


### PR DESCRIPTION
issue: #51687

## Problem

`TransferSegment` and `TransferChannel` iterate over every replica the source node belongs to. When the requested segment/channel is not in the replica currently being visited, they abort the whole request instead of moving on:

```go
replicas := s.meta.GetByNode(ctx, req.GetSourceNodeID())
for _, replica := range replicas {
    segments := s.dist.SegmentDistManager.GetByFilter(
        meta.WithCollectionID(replica.GetCollectionID()), meta.WithNodeID(srcNode))
    segment, ok := lo.Find(segments, func(s *meta.Segment) bool { return s.GetID() == req.GetSegmentID() })
    if !ok {
        return merr.Status(merr.WrapErrSegmentNotFound(...)), nil   // <- aborts
    }
```

A query node normally serves many collections and so belongs to many replicas, while the requested segment lives in exactly one of them. `meta.GetByNode` returns replicas in map order, so the call only succeeds when the right replica is visited first. On any cluster with more than one collection both APIs are effectively unusable.

Reproduced on a local 2.6.19 cluster (3 collections, 3 query nodes):

```
$ transfer-segment --sourceNode 10 --targetNode 11 --segmentID 467844892568376490
transfer segment failed: segment not found in source node: segment not found[segment=467844892568376490]

$ get-querynode-distribution --nodeID 10
Sealed Segments (2): [467844892568376490 467844892568817028]      # it is right there
```

`transfer-channel` fails the same way.

## Fix

`continue` to the next replica instead of returning, and report NotFound only after all replicas have been searched. `transferAll` mode is unaffected.

## Test

Adds `TestTransferSegmentMultiReplica`, which puts the source node in 6 replicas where only one holds the requested segment.

- Without the fix the test fails (`Should be true` on the transfer response) on most runs — it only passes when the right replica happens to be first.
- With the fix it passes on every run (`-count=5`).
- It also asserts that a segment present in no replica is still reported as NotFound.

Build, vet and the `TestOpsService` suite (with `-tags dynamic,test`) all pass locally.
