### PR TITLE
test: isolate struct array manual compaction

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1097,6 +1097,11 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             index_params=index_params,
             consistency_level="Strong",
         )
+        self.alter_collection_properties(
+            client,
+            collection_name,
+            properties={"collection.autocompaction.enabled": "false"},
+        )
 
         def profile(row_id, length, tag_prefix="keep"):
             result = []

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1096,10 +1096,6 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             schema=schema,
             index_params=index_params,
             consistency_level="Strong",
-        )
-        self.alter_collection_properties(
-            client,
-            collection_name,
             properties={"collection.autocompaction.enabled": "false"},
         )
 


### PR DESCRIPTION
issue: #51686

### What changed

- Disable collection auto-compaction before inserting data in `test_struct_array_compaction_preserves_null_empty_offsets_and_indexes`.
- Keep explicit manual compaction as the only compaction trigger for this test.

### Why

The test expects `compact()` to create a manual compaction task and return a positive ID. On the distributed Pulsar CI deployment, automatic sort/mix compaction can claim all flushed segments before the explicit request. DataCoord then creates zero tasks for the manual request and returns `-1`.

Disabling collection auto-compaction removes this scheduler race while preserving all post-compaction data, offset, predicate, search, and index assertions.

### Verification

- Before the change: `1 failed in 13.98s` with `compact_id == -1`
- After the change: `1 passed in 19.38s`
- Concurrent repetition: `12 passed in 47.62s` with 6 workers
- `ruff check tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py`
