### PR TITLE
enhance: reuse packed index tail reads

### DIFF
--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -38,6 +38,7 @@
 #include "storage/EntryStreamUtils.h"
 #include "storage/Crc32cUtil.h"
 #include "storage/PluginLoader.h"
+#include "storage/TailCachedInputStream.h"
 
 namespace milvus::storage {
 namespace {
@@ -129,6 +130,8 @@ SaturatingAdd(size_t lhs, size_t rhs) {
 }
 
 constexpr size_t kEntryDownloadRangeSize = 16 * 1024 * 1024;
+constexpr size_t kInspectionTailSize = 64 * 1024;
+constexpr size_t kCachedTailMaxSize = 256 * 1024;
 
 void
 DrainFutures(std::vector<std::future<void>>& futures,
@@ -352,7 +355,8 @@ IndexEntryReader::InspectStreamLoadInfo(
     reader->CheckCancelled("IndexEntryReader::InspectStreamLoadInfo");
     // The caller has already selected the V3 path. Actual loading validates
     // the magic; inspection avoids a separate range read at offset zero.
-    reader->ReadFooterAndDirectory();
+    reader->ReadFooterAndDirectory(kInspectionTailSize,
+                                   /*validate_magic=*/false);
     reader->CheckCancelled("IndexEntryReader::InspectStreamLoadInfo");
     return reader->stream_load_info_;
 }
@@ -363,15 +367,32 @@ IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
                        int64_t collection_id,
                        ThreadPoolPriority priority,
                        folly::CancellationToken cancellation_token) {
+    ThrowIfCancelled(cancellation_token, "IndexEntryReader::Open");
+
+    constexpr int64_t kMinFileSize =
+        MILVUS_V3_MAGIC_SIZE + MILVUS_V3_FOOTER_SIZE;
+    AssertInfo(
+        file_size >= kMinFileSize,
+        "V3 index file size {} is smaller than the minimum header and footer "
+        "size {}",
+        file_size,
+        kMinFileSize);
+    if constexpr (sizeof(size_t) < sizeof(uint64_t)) {
+        AssertInfo(static_cast<uint64_t>(file_size) <=
+                       std::numeric_limits<size_t>::max(),
+                   "V3 index file size {} exceeds the addressable range",
+                   file_size);
+    }
+
     auto reader = std::unique_ptr<IndexEntryReader>(new IndexEntryReader());
     reader->input_ = std::move(input);
-    reader->file_size_ = file_size;
+    reader->file_size_ = static_cast<size_t>(file_size);
     reader->collection_id_ = collection_id;
     reader->priority_ = priority;
     reader->cancellation_token_ = cancellation_token;
     reader->CheckCancelled("IndexEntryReader::Open");
-    reader->ValidateMagic();
-    reader->ReadFooterAndDirectory();
+    reader->ReadFooterAndDirectory(kCachedTailMaxSize,
+                                   /*validate_magic=*/true);
     reader->CheckCancelled("IndexEntryReader::Open");
 
     if (reader->is_encrypted_) {
@@ -401,31 +422,36 @@ IndexEntryReader::CheckCancelled(const std::string& operation) const {
 }
 
 void
-IndexEntryReader::ValidateMagic() {
-    CheckCancelled("IndexEntryReader::ValidateMagic");
-    char magic_buf[MILVUS_V3_MAGIC_SIZE];
-    size_t bytes_read = input_->ReadAt(magic_buf, 0, MILVUS_V3_MAGIC_SIZE);
-    CheckCancelled("IndexEntryReader::ValidateMagic");
-    AssertInfo(bytes_read == MILVUS_V3_MAGIC_SIZE,
-               "Failed to read V3 magic number");
-    AssertInfo(
-        std::memcmp(magic_buf, MILVUS_V3_MAGIC, MILVUS_V3_MAGIC_SIZE) == 0,
-        "Invalid V3 magic number");
+IndexEntryReader::ValidateMagic(const uint8_t* magic) const {
+    AssertInfo(std::memcmp(magic, MILVUS_V3_MAGIC, MILVUS_V3_MAGIC_SIZE) == 0,
+               "Invalid V3 magic number");
 }
 
 void
-IndexEntryReader::ReadFooterAndDirectory() {
+IndexEntryReader::ReadFooterAndDirectory(size_t initial_tail_size,
+                                         bool validate_magic) {
     CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
-    constexpr size_t kTailBufferSize = 64 * 1024UL;
-    size_t tail_size =
-        std::min(static_cast<size_t>(file_size_), kTailBufferSize);
+    size_t tail_size = std::min(file_size_, initial_tail_size);
     size_t tail_offset = file_size_ - tail_size;
+
+    if (validate_magic && tail_offset != 0) {
+        uint8_t magic[MILVUS_V3_MAGIC_SIZE];
+        size_t magic_bytes = input_->ReadAt(magic, 0, MILVUS_V3_MAGIC_SIZE);
+        CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
+        AssertInfo(magic_bytes == MILVUS_V3_MAGIC_SIZE,
+                   "Failed to read V3 magic number");
+        ValidateMagic(magic);
+    }
 
     std::vector<uint8_t> tail_data(tail_size);
     size_t bytes_read =
         input_->ReadAt(tail_data.data(), tail_offset, tail_size);
     CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
     AssertInfo(bytes_read == tail_size, "Failed to read file tail");
+
+    if (validate_magic && tail_offset == 0) {
+        ValidateMagic(tail_data.data());
+    }
 
     // Parse 32-byte Footer from the last 32 bytes
     AssertInfo(tail_size >= MILVUS_V3_FOOTER_SIZE,
@@ -448,7 +474,7 @@ IndexEntryReader::ReadFooterAndDirectory() {
     AssertInfo(dir_size > 0, "Directory table size is zero");
     AssertInfo(static_cast<size_t>(dir_size) + meta_entry_size +
                        MILVUS_V3_FOOTER_SIZE + MILVUS_V3_MAGIC_SIZE <=
-                   static_cast<size_t>(file_size_),
+                   file_size_,
                "Directory table + meta entry + footer size exceeds file size");
 
     // Check if the directory itself needs a second read. The meta entry is
@@ -552,6 +578,21 @@ IndexEntryReader::ReadFooterAndDirectory() {
             entry_index_.emplace(std::move(name), std::move(meta));
         }
     }
+
+    std::vector<uint8_t> retained_tail;
+    if (tail_data.size() <= kCachedTailMaxSize) {
+        retained_tail = std::move(tail_data);
+    } else {
+        // vector::erase does not reduce capacity. Copy the final tail into a
+        // fresh bounded allocation so an unusually large directory or meta
+        // parse buffer is not retained for the reader lifetime.
+        retained_tail.assign(tail_data.end() - kCachedTailMaxSize,
+                             tail_data.end());
+    }
+    input_ = std::make_shared<detail::TailCachedInputStream>(
+        std::move(input_),
+        file_size_ - retained_tail.size(),
+        std::move(retained_tail));
 }
 
 std::vector<std::string>
@@ -600,11 +641,6 @@ IndexEntryReader::StreamDownloadTaskCount(const EntryMeta& meta) {
 Entry
 IndexEntryReader::ReadEntry(const std::string& name) {
     CheckCancelled("IndexEntryReader::ReadEntry");
-    auto cache_it = small_entry_cache_.find(name);
-    if (cache_it != small_entry_cache_.end()) {
-        return cache_it->second;
-    }
-
     auto it = entry_index_.find(name);
     AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
     const auto& meta = it->second;
@@ -614,10 +650,6 @@ IndexEntryReader::ReadEntry(const std::string& name) {
         result = ReadEncryptedEntry(meta);
     } else {
         result = ReadPlainEntry(meta);
-    }
-
-    if (result.data.size() <= kSmallEntryCacheThreshold) {
-        small_entry_cache_[name] = result;
     }
 
     return result;
@@ -640,6 +672,7 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
     }
 
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto input = input_;
     auto cancellation_token = cancellation_token_;
     uint8_t* dest = result.data.data();
 
@@ -655,10 +688,10 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
             size_t this_offset = offset;
 
             futures.push_back(pool.Submit(
-                [this, dest, this_offset, len, &pm, cancellation_token]() {
+                [input, dest, this_offset, len, &pm, cancellation_token]() {
                     ThrowIfCancelled(cancellation_token,
                                      "IndexEntryReader::ReadPlainEntry");
-                    size_t n = input_->ReadAt(
+                    size_t n = input->ReadAt(
                         dest + this_offset,
                         MILVUS_V3_MAGIC_SIZE + pm.offset + this_offset,
                         len);
@@ -693,6 +726,11 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
     result.data.resize(em.original_size);
 
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto input = input_;
+    auto cipher_plugin = cipher_plugin_;
+    auto edek = edek_;
+    int64_t ez_id = ez_id_;
+    int64_t collection_id = collection_id_;
     auto cancellation_token = cancellation_token_;
     uint8_t* dest = result.data.data();
 
@@ -708,7 +746,11 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
             size_t plain_len = std::min(remaining, slice_size_);
             cur_output_offset += plain_len;
 
-            futures.push_back(pool.Submit([this,
+            futures.push_back(pool.Submit([input,
+                                           cipher_plugin,
+                                           ez_id,
+                                           collection_id,
+                                           edek,
                                            slice,
                                            dest,
                                            this_output_offset,
@@ -717,15 +759,15 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEncryptedEntry");
                 std::vector<uint8_t> cipher(slice.size);
-                size_t n = input_->ReadAt(cipher.data(),
-                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
-                                          slice.size);
+                size_t n = input->ReadAt(cipher.data(),
+                                         MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                         slice.size);
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEncryptedEntry");
                 AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
                 auto dec =
-                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+                    cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
                 auto plain = dec->Decrypt(cipher.data(), cipher.size());
 
                 AssertInfo(plain.size() == plain_len,
@@ -792,11 +834,16 @@ IndexEntryReader::SubmitEntryDownloadTasks(
     EntryDownloadState& state,
     std::vector<std::future<void>>& futures) {
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto input = input_;
     auto cancellation_token = cancellation_token_;
     futures.reserve(futures.size() + DownloadTaskCount(meta));
 
     if (meta.encrypted) {
         const auto& em = meta.enc;
+        auto cipher_plugin = cipher_plugin_;
+        auto edek = edek_;
+        int64_t ez_id = ez_id_;
+        int64_t collection_id = collection_id_;
         size_t output_offset = 0;
 
         for (size_t i = 0; i < em.slices.size(); i++) {
@@ -806,7 +853,11 @@ IndexEntryReader::SubmitEntryDownloadTasks(
             size_t plain_len = std::min(remaining, slice_size_);
             output_offset += plain_len;
 
-            futures.push_back(pool.Submit([this,
+            futures.push_back(pool.Submit([input,
+                                           cipher_plugin,
+                                           ez_id,
+                                           collection_id,
+                                           edek,
                                            slice,
                                            fd = state.fd,
                                            this_output_offset,
@@ -817,15 +868,15 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesToFiles");
                 std::vector<uint8_t> cipher(slice.size);
-                size_t n = input_->ReadAt(cipher.data(),
-                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
-                                          slice.size);
+                size_t n = input->ReadAt(cipher.data(),
+                                         MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                         slice.size);
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesToFiles");
                 AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
                 auto dec =
-                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+                    cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
                 auto plain = dec->Decrypt(cipher.data(), cipher.size());
 
                 AssertInfo(plain.size() == plain_len,
@@ -857,18 +908,18 @@ IndexEntryReader::SubmitEntryDownloadTasks(
             size_t this_src_offset = src_offset;
             size_t this_range_idx = range_idx;
 
-            futures.push_back(pool.Submit([this,
-                                           this_src_offset,
+            futures.push_back(pool.Submit([this_src_offset,
                                            len,
                                            fd = state.fd,
                                            this_file_offset,
                                            this_range_idx,
                                            &state,
-                                           cancellation_token]() {
+                                           cancellation_token,
+                                           input]() {
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesToFiles");
                 std::vector<uint8_t> buf(len);
-                size_t n = input_->ReadAt(
+                size_t n = input->ReadAt(
                     buf.data(), MILVUS_V3_MAGIC_SIZE + this_src_offset, len);
                 ThrowIfCancelled(cancellation_token,
                                  "IndexEntryReader::ReadEntriesToFiles");

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -169,9 +169,9 @@ class IndexEntryReader {
     IndexEntryReader() = default;
 
     void
-    ReadFooterAndDirectory();
+    ReadFooterAndDirectory(size_t initial_tail_size, bool validate_magic);
     void
-    ValidateMagic();
+    ValidateMagic(const uint8_t* magic) const;
     void
     CheckCancelled(const std::string& operation) const;
 
@@ -258,7 +258,7 @@ class IndexEntryReader {
     FinalizeEntryStreamDownload(EntryStreamDownloadState& state);
 
     std::shared_ptr<milvus::InputStream> input_;
-    int64_t file_size_ = 0;
+    size_t file_size_ = 0;
     int64_t collection_id_ = 0;
     ThreadPoolPriority priority_ = ThreadPoolPriority::HIGH;
     folly::CancellationToken cancellation_token_;
@@ -274,8 +274,6 @@ class IndexEntryReader {
     EntryStreamLoadInfo stream_load_info_;
     std::vector<std::string> entry_names_;
 
-    static constexpr size_t kSmallEntryCacheThreshold = 1 * 1024 * 1024;
-    std::unordered_map<std::string, Entry> small_entry_cache_;
     nlohmann::json meta_json_;
 };
 

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -23,9 +23,11 @@
 #include <future>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -40,14 +42,18 @@
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 #include "storage/IndexEntryReader.h"
 #include "storage/EntryStreamUtils.h"
+#include "storage/Crc32cUtil.h"
 #include "storage/PluginLoader.h"
 #include "storage/RemoteInputStream.h"
 #include "storage/RemoteOutputStream.h"
+#include "storage/TailCachedInputStream.h"
 #include "storage/ThreadPools.h"
 
 using namespace milvus::storage;
 
 namespace {
+
+constexpr size_t kTestCachedTailMaxSize = 256 * 1024;
 
 class IndexEntryStreamConfigGuard {
  public:
@@ -408,6 +414,126 @@ class TrackingDelayedInputStream : public milvus::InputStream {
     std::atomic<size_t> max_active_reads_{0};
 };
 
+class CountingInputStream : public milvus::InputStream {
+ public:
+    struct ReadCall {
+        size_t offset;
+        size_t size;
+    };
+
+    explicit CountingInputStream(std::vector<uint8_t> data)
+        : data_(std::move(data)) {
+    }
+
+    size_t
+    Size() const override {
+        return data_.size();
+    }
+
+    bool
+    Seek(int64_t offset) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (offset < 0 || static_cast<uint64_t>(offset) > data_.size()) {
+            return false;
+        }
+        position_ = static_cast<size_t>(offset);
+        return true;
+    }
+
+    size_t
+    Tell() const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return position_;
+    }
+
+    bool
+    Eof() const override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return position_ >= data_.size();
+    }
+
+    size_t
+    Read(void* ptr, size_t size) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        size_t bytes_read = CopyAt(ptr, position_, size);
+        position_ += bytes_read;
+        return bytes_read;
+    }
+
+    size_t
+    ReadAt(void* ptr, size_t offset, size_t size) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        read_calls_.push_back({offset, size});
+        return CopyAt(ptr, offset, size);
+    }
+
+    size_t
+    Read(int, size_t) override {
+        return 0;
+    }
+
+    size_t
+    ReadCount() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return read_calls_.size();
+    }
+
+    size_t
+    ReadCount(size_t offset, size_t size) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return std::count_if(
+            read_calls_.begin(), read_calls_.end(), [&](const ReadCall& call) {
+                return call.offset == offset && call.size == size;
+            });
+    }
+
+ private:
+    size_t
+    CopyAt(void* ptr, size_t offset, size_t size) const {
+        if (offset > data_.size()) {
+            return 0;
+        }
+        size_t bytes_read = std::min(size, data_.size() - offset);
+        if (bytes_read > 0) {
+            std::memcpy(ptr, data_.data() + offset, bytes_read);
+        }
+        return bytes_read;
+    }
+
+    std::vector<uint8_t> data_;
+    mutable std::mutex mutex_;
+    size_t position_{0};
+    std::vector<ReadCall> read_calls_;
+};
+
+TEST(TailCachedInputStreamTest, ServesOnlyFullyCoveredRanges) {
+    std::vector<uint8_t> data(128);
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = static_cast<uint8_t>(i);
+    }
+    auto inner = std::make_shared<CountingInputStream>(data);
+    std::vector<uint8_t> tail(data.begin() + 96, data.end());
+    detail::TailCachedInputStream stream(inner, 96, std::move(tail));
+
+    std::vector<uint8_t> output(32);
+    EXPECT_EQ(stream.ReadAt(output.data(), 96, output.size()), output.size());
+    EXPECT_EQ(std::memcmp(output.data(), data.data() + 96, output.size()), 0);
+    EXPECT_EQ(stream.ReadAt(nullptr, 128, 0), 0);
+    EXPECT_EQ(inner->ReadCount(), 0);
+
+    EXPECT_EQ(stream.ReadAt(output.data(), 95, 2), 2);
+    EXPECT_EQ(inner->ReadCount(95, 2), 1);
+
+    EXPECT_EQ(stream.ReadAt(output.data(), 120, 16), 8);
+    EXPECT_EQ(inner->ReadCount(120, 16), 1);
+
+    EXPECT_EQ(stream.ReadAt(output.data(), 8, 4), 4);
+    EXPECT_EQ(inner->ReadCount(8, 4), 1);
+
+    EXPECT_EQ(stream.ReadAt(output.data(), 129, 1), 0);
+    EXPECT_EQ(inner->ReadCount(129, 1), 1);
+}
+
 }  // namespace
 
 namespace {
@@ -434,6 +560,93 @@ VerifyPattern(const std::vector<uint8_t>& data, size_t expected_size) {
         ASSERT_EQ(data[i], static_cast<uint8_t>(i % 256))
             << "Mismatch at byte " << i;
     }
+}
+
+struct PackedFileImage {
+    std::vector<uint8_t> bytes;
+    std::unordered_map<std::string, std::pair<size_t, size_t>> entry_ranges;
+    size_t meta_offset = 0;
+    size_t meta_size = 0;
+    size_t directory_size = 0;
+};
+
+PackedFileImage
+BuildPackedFileImage(
+    const std::vector<std::pair<std::string, std::vector<uint8_t>>>& entries,
+    const std::string& meta,
+    size_t prefix_padding = 0) {
+    PackedFileImage image;
+    image.bytes.insert(image.bytes.end(),
+                       MILVUS_V3_MAGIC,
+                       MILVUS_V3_MAGIC + MILVUS_V3_MAGIC_SIZE);
+    image.bytes.insert(image.bytes.end(), prefix_padding, uint8_t{0});
+
+    nlohmann::json directory;
+    directory["entries"] = nlohmann::json::array();
+    for (const auto& [name, data] : entries) {
+        size_t absolute_offset = image.bytes.size();
+        size_t data_region_offset = absolute_offset - MILVUS_V3_MAGIC_SIZE;
+        image.bytes.insert(image.bytes.end(), data.begin(), data.end());
+        image.entry_ranges.emplace(
+            name, std::make_pair(absolute_offset, data.size()));
+        directory["entries"].push_back(
+            {{"name", name},
+             {"offset", data_region_offset},
+             {"size", data.size()},
+             {"crc32", Crc32cToHex(Crc32cValue(data.data(), data.size()))}});
+    }
+
+    image.meta_offset = image.bytes.size();
+    image.meta_size = meta.size();
+    image.bytes.insert(image.bytes.end(), meta.begin(), meta.end());
+    directory["entries"].push_back(
+        {{"name", MILVUS_V3_META_ENTRY_NAME},
+         {"offset", image.meta_offset - MILVUS_V3_MAGIC_SIZE},
+         {"size", meta.size()},
+         {"crc32", Crc32cToHex(Crc32cValue(meta.data(), meta.size()))}});
+
+    std::string directory_data = directory.dump();
+    image.directory_size = directory_data.size();
+    image.bytes.insert(
+        image.bytes.end(), directory_data.begin(), directory_data.end());
+
+    if (meta.size() > std::numeric_limits<uint32_t>::max() ||
+        directory_data.size() > std::numeric_limits<uint32_t>::max()) {
+        throw std::runtime_error("Packed test image footer size overflow");
+    }
+    uint8_t footer[MILVUS_V3_FOOTER_SIZE] = {};
+    uint16_t version = MILVUS_V3_FORMAT_VERSION;
+    uint32_t meta_size = static_cast<uint32_t>(meta.size());
+    uint32_t directory_size = static_cast<uint32_t>(directory_data.size());
+    std::memcpy(footer, &version, sizeof(version));
+    std::memcpy(footer + 24, &meta_size, sizeof(meta_size));
+    std::memcpy(footer + 28, &directory_size, sizeof(directory_size));
+    image.bytes.insert(
+        image.bytes.end(), footer, footer + MILVUS_V3_FOOTER_SIZE);
+    return image;
+}
+
+PackedFileImage
+BuildExactSizePackedFile(size_t target_size) {
+    size_t prefix_padding = 0;
+    for (size_t attempt = 0; attempt < 32; ++attempt) {
+        auto image = BuildPackedFileImage(
+            {{"payload", std::vector<uint8_t>{0x5a}}}, "{}", prefix_padding);
+        if (image.bytes.size() == target_size) {
+            return image;
+        }
+        if (image.bytes.size() < target_size) {
+            prefix_padding += target_size - image.bytes.size();
+        } else {
+            size_t excess = image.bytes.size() - target_size;
+            if (prefix_padding < excess) {
+                throw std::runtime_error(
+                    "Packed test image is larger than target size");
+            }
+            prefix_padding -= excess;
+        }
+    }
+    throw std::runtime_error("Failed to build exact-size packed index image");
 }
 
 }  // namespace
@@ -717,32 +930,6 @@ TEST_F(IndexEntryWriterV3Test, EntryNotFound) {
     EXPECT_THROW(reader->ReadEntry("does_not_exist"), milvus::SegcoreError);
 }
 
-TEST_F(IndexEntryWriterV3Test, SmallEntryCache) {
-    const std::string file_path = kV3FilePath + "_cache";
-    const size_t entry_size = 256;  // well under 1MB cache threshold
-    auto data = GeneratePattern(entry_size);
-
-    {
-        auto output = CreateOutputStream(file_path);
-        IndexEntryDirectStreamWriter writer(output);
-        writer.WriteEntry("cached_entry", data.data(), data.size());
-        writer.Finish();
-    }
-
-    auto input = CreateInputStream(file_path);
-    int64_t file_size = GetFileSize(file_path);
-    auto reader = IndexEntryReader::Open(input, file_size);
-
-    auto entry1 = reader->ReadEntry("cached_entry");
-    auto entry2 = reader->ReadEntry("cached_entry");
-
-    ASSERT_EQ(entry1.data.size(), entry2.data.size());
-    EXPECT_EQ(
-        std::memcmp(entry1.data.data(), entry2.data.data(), entry1.data.size()),
-        0);
-    VerifyPattern(entry1.data, entry_size);
-}
-
 TEST_F(IndexEntryWriterV3Test, GetTotalBytesWritten) {
     const std::string file_path = kV3FilePath + "_totalbytes";
     const size_t entry_size = 1024;
@@ -923,8 +1110,183 @@ TEST_F(IndexEntryWriterV3Test, ReadEntriesToFilesMultiRangeParallel) {
 // Edge Case Tests: Directory Table and Meta Entry size boundaries
 // =============================================================================
 
+TEST(IndexEntryReaderTailCacheTest, ExactTailBoundaryReadCounts) {
+    for (const auto& [file_size, expected_reads] :
+         std::vector<std::pair<size_t, size_t>>{
+             {kTestCachedTailMaxSize - 1, 1},
+             {kTestCachedTailMaxSize, 1},
+             {kTestCachedTailMaxSize + 1, 2}}) {
+        SCOPED_TRACE(file_size);
+        auto image = BuildExactSizePackedFile(file_size);
+        auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+        auto reader = IndexEntryReader::Open(input, image.bytes.size());
+
+        ASSERT_NE(reader, nullptr);
+        EXPECT_EQ(input->ReadCount(), expected_reads);
+    }
+}
+
+TEST(IndexEntryReaderTailCacheTest,
+     FullCoverageHitsButPartialOverlapFallsBack) {
+    auto full_hit_image =
+        BuildPackedFileImage({{"late", std::vector<uint8_t>(32, 0x31)}},
+                             "{}",
+                             kTestCachedTailMaxSize + 16 * 1024);
+    auto full_hit_input =
+        std::make_shared<CountingInputStream>(full_hit_image.bytes);
+    auto full_hit_reader =
+        IndexEntryReader::Open(full_hit_input, full_hit_image.bytes.size());
+    size_t reads_before_full_hit = full_hit_input->ReadCount();
+
+    auto full_hit_entry = full_hit_reader->ReadEntry("late");
+
+    EXPECT_EQ(full_hit_entry.data, std::vector<uint8_t>(32, 0x31));
+    EXPECT_EQ(full_hit_input->ReadCount(), reads_before_full_hit);
+
+    auto partial_image = BuildPackedFileImage(
+        {{"overlap",
+          std::vector<uint8_t>(kTestCachedTailMaxSize + 16 * 1024, 0x42)}},
+        "{}");
+    auto partial_input =
+        std::make_shared<CountingInputStream>(partial_image.bytes);
+    auto partial_reader =
+        IndexEntryReader::Open(partial_input, partial_image.bytes.size());
+    size_t reads_before_partial = partial_input->ReadCount();
+    const auto [entry_offset, entry_size] =
+        partial_image.entry_ranges.at("overlap");
+
+    auto partial_entry = partial_reader->ReadEntry("overlap");
+
+    EXPECT_EQ(partial_entry.data,
+              std::vector<uint8_t>(kTestCachedTailMaxSize + 16 * 1024, 0x42));
+    EXPECT_EQ(partial_input->ReadCount(), reads_before_partial + 1);
+    EXPECT_EQ(partial_input->ReadCount(entry_offset, entry_size), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, ExpandedDirectoryRetainsOnlyFinalTail) {
+    std::vector<std::pair<std::string, std::vector<uint8_t>>> entries;
+    entries.reserve(4000);
+    for (size_t i = 0; i < 4000; ++i) {
+        entries.emplace_back("long_directory_entry_name_" +
+                                 std::string(40, 'x') + std::to_string(i),
+                             std::vector<uint8_t>{});
+    }
+    auto image = BuildPackedFileImage(entries, "{}");
+    ASSERT_GT(image.directory_size, kTestCachedTailMaxSize);
+    auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+    auto reader = IndexEntryReader::Open(input, image.bytes.size());
+
+    ASSERT_NE(reader, nullptr);
+    EXPECT_EQ(input->ReadCount(image.meta_offset, image.meta_size), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, ExpandedMetaRetainsOnlyFinalTail) {
+    const size_t large_meta_size = kTestCachedTailMaxSize + 16 * 1024;
+    std::string meta =
+        nlohmann::json({{"large", std::string(large_meta_size, 'm')}}).dump();
+    auto image = BuildPackedFileImage({}, meta);
+    ASSERT_GT(image.meta_size + image.directory_size + MILVUS_V3_FOOTER_SIZE,
+              kTestCachedTailMaxSize);
+    auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+    auto reader = IndexEntryReader::Open(input, image.bytes.size());
+
+    ASSERT_NE(reader, nullptr);
+    EXPECT_EQ(reader->GetMeta<std::string>("large"),
+              std::string(large_meta_size, 'm'));
+    EXPECT_EQ(input->ReadCount(image.meta_offset, image.meta_size), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, CorruptMagicReportsMagicError) {
+    for (size_t prefix_padding :
+         {size_t{0}, kTestCachedTailMaxSize + 16 * 1024}) {
+        SCOPED_TRACE(prefix_padding);
+        auto image = BuildPackedFileImage({}, "{}", prefix_padding);
+        image.bytes[0] ^= 0xff;
+        auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+        try {
+            IndexEntryReader::Open(input, image.bytes.size());
+            FAIL() << "expected invalid magic error";
+        } catch (const milvus::SegcoreError& e) {
+            EXPECT_NE(std::string(e.what()).find("Invalid V3 magic number"),
+                      std::string::npos);
+        }
+        EXPECT_EQ(input->ReadCount(), 1);
+        if (prefix_padding != 0) {
+            EXPECT_EQ(input->ReadCount(0, MILVUS_V3_MAGIC_SIZE), 1);
+            EXPECT_EQ(
+                input->ReadCount(image.bytes.size() - kTestCachedTailMaxSize,
+                                 kTestCachedTailMaxSize),
+                0);
+        }
+    }
+}
+
+TEST(IndexEntryReaderTailCacheTest, NonV3FileReportsMagicBeforeFooterErrors) {
+    std::vector<uint8_t> bytes(128, 0xa5);
+    auto input = std::make_shared<CountingInputStream>(std::move(bytes));
+
+    try {
+        IndexEntryReader::Open(input, input->Size());
+        FAIL() << "expected invalid magic error";
+    } catch (const milvus::SegcoreError& e) {
+        EXPECT_NE(std::string(e.what()).find("Invalid V3 magic number"),
+                  std::string::npos);
+    }
+    EXPECT_EQ(input->ReadCount(), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, ShortTailReadStillFails) {
+    auto image = BuildPackedFileImage({}, "{}");
+    auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+    EXPECT_ANY_THROW(IndexEntryReader::Open(input, image.bytes.size() + 1));
+    EXPECT_EQ(input->ReadCount(), 1);
+}
+
+TEST(IndexEntryReaderTailCacheTest, PreCancelledOpenDoesNotRead) {
+    auto image = BuildPackedFileImage({}, "{}");
+    folly::CancellationSource source;
+    source.requestCancellation();
+
+    for (int64_t file_size :
+         {static_cast<int64_t>(image.bytes.size()), int64_t{39}}) {
+        SCOPED_TRACE(file_size);
+        auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+        try {
+            IndexEntryReader::Open(input,
+                                   file_size,
+                                   0,
+                                   milvus::ThreadPoolPriority::HIGH,
+                                   source.getToken());
+            FAIL() << "expected cancellation error";
+        } catch (const milvus::SegcoreError& e) {
+            EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
+        }
+        EXPECT_EQ(input->ReadCount(), 0);
+    }
+}
+
+TEST(IndexEntryReaderTailCacheTest, InvalidSignedAndSmallSizesDoNotRead) {
+    auto image = BuildPackedFileImage({}, "{}");
+    for (int64_t invalid_size : {std::numeric_limits<int64_t>::min(),
+                                 int64_t{-1},
+                                 int64_t{0},
+                                 int64_t{39}}) {
+        SCOPED_TRACE(invalid_size);
+        auto input = std::make_shared<CountingInputStream>(image.bytes);
+
+        EXPECT_ANY_THROW(IndexEntryReader::Open(input, invalid_size));
+        EXPECT_EQ(input->ReadCount(), 0);
+    }
+}
+
 TEST_F(IndexEntryWriterV3Test, LargeDirectoryTableNeedsSecondIO) {
-    // Create many entries with long names to make directory table > 64KB
+    // Create many entries with long names to make directory table > 256KB
     // This tests the second IO path in ReadFooterAndDirectory()
     const std::string file_path = kV3FilePath + "_largedir";
     auto small_data = GeneratePattern(64);
@@ -932,8 +1294,8 @@ TEST_F(IndexEntryWriterV3Test, LargeDirectoryTableNeedsSecondIO) {
     // Each entry in directory table is roughly:
     // {"name":"...", "offset":N, "size":N, "crc32":"XXXXXXXX"}
     // ~60 bytes per entry + name length
-    // Need ~1100 entries with 50-char names to exceed 64KB
-    const size_t num_entries = 1200;
+    // Need several thousand entries with long names to exceed 256KB.
+    const size_t num_entries = 4000;
     const std::string name_prefix =
         "entry_with_a_very_long_name_to_inflate_dir_";
 
@@ -959,7 +1321,7 @@ TEST_F(IndexEntryWriterV3Test, LargeDirectoryTableNeedsSecondIO) {
     auto entry0 = reader->ReadEntry(name_prefix + "0");
     VerifyPattern(entry0.data, 64);
 
-    auto entry_last = reader->ReadEntry(name_prefix + "1199");
+    auto entry_last = reader->ReadEntry(name_prefix + "3999");
     VerifyPattern(entry_last.data, 64);
 }
 
@@ -1004,22 +1366,19 @@ TEST_F(IndexEntryWriterV3Test, InspectStreamLoadInfoDoesNotPrefetchLargeMeta) {
     auto info = IndexEntryReader::InspectStreamLoadInfo(input, file_size);
 
     EXPECT_FALSE(info.encrypted);
-    auto non_magic_reads = std::count_if(
-        input->ReadRanges().begin(),
-        input->ReadRanges().end(),
-        [](const RecordingInputStream::ReadRange& range) {
-            return range.offset != 0 || range.size != MILVUS_V3_MAGIC_SIZE;
-        });
-    EXPECT_EQ(non_magic_reads, 1);
+    ASSERT_EQ(input->ReadRanges().size(), 1);
+    auto tail_size = std::min<size_t>(file_size, 64 * 1024);
+    EXPECT_EQ(input->ReadRanges()[0].offset, file_size - tail_size);
+    EXPECT_EQ(input->ReadRanges()[0].size, tail_size);
 }
 
-TEST_F(IndexEntryWriterV3Test, LargeMetaLoadsSeparatelyFromDirectory) {
-    // Directory table fits in the first 64KB. The large meta entry is read
-    // separately by ReadEntry instead of being prefetched with the directory.
+TEST_F(IndexEntryWriterV3Test, DirectoryFitsButMetaDoesNotFitFirstIO) {
+    // Directory table fits in the first 256KB, but meta entry is large enough
+    // that dir_size + meta_entry_size exceeds the initial tail.
+    // This tests the boundary where we need second IO for meta only
     const std::string file_path = kV3FilePath + "_largemetasmalldir";
 
-    // Keep the directory small while making the meta larger than the initial
-    // tail read.
+    // Keep the directory small while making metadata exceed the tail budget.
     auto data = GeneratePattern(1024);
 
     {
@@ -1027,8 +1386,8 @@ TEST_F(IndexEntryWriterV3Test, LargeMetaLoadsSeparatelyFromDirectory) {
         IndexEntryDirectStreamWriter writer(output);
         writer.WriteEntry("data", data.data(), data.size());
 
-        // Add a large meta value (~70KB of repeated string)
-        std::string large_value(70 * 1024, 'X');
+        const size_t large_meta_size = kTestCachedTailMaxSize + 16 * 1024;
+        std::string large_value(large_meta_size, 'X');
         writer.PutMeta("large_field", large_value);
         writer.Finish();
     }
@@ -1039,8 +1398,8 @@ TEST_F(IndexEntryWriterV3Test, LargeMetaLoadsSeparatelyFromDirectory) {
 
     // Verify meta can be read
     auto meta_value = reader->GetMeta<std::string>("large_field");
-    ASSERT_EQ(meta_value.size(), 70 * 1024);
-    ASSERT_EQ(meta_value, std::string(70 * 1024, 'X'));
+    ASSERT_EQ(meta_value.size(), kTestCachedTailMaxSize + 16 * 1024);
+    ASSERT_EQ(meta_value, std::string(kTestCachedTailMaxSize + 16 * 1024, 'X'));
 
     // Verify data entry
     auto entry = reader->ReadEntry("data");
@@ -1831,7 +2190,7 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamConsumerExceptionDoesNotLeak) {
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsActiveTasksAfterError) {
     const std::string file_path = kV3FilePath + "_stream_active_task_error";
     const size_t slice_size = 64 * 1024;
-    const size_t entry_size = 3 * slice_size;
+    const size_t entry_size = 6 * slice_size;
     auto data = GeneratePattern(entry_size);
 
     {

--- a/internal/core/src/storage/TailCachedInputStream.h
+++ b/internal/core/src/storage/TailCachedInputStream.h
@@ -1,0 +1,98 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "common/FastMem.h"
+#include "filemanager/InputStream.h"
+
+namespace milvus::storage::detail {
+
+// Serves fully covered ranges from a retained suffix and forwards every other
+// operation to the wrapped stream.
+class TailCachedInputStream final : public milvus::InputStream {
+ public:
+    TailCachedInputStream(std::shared_ptr<milvus::InputStream> inner,
+                          size_t tail_offset,
+                          std::vector<uint8_t> tail)
+        : inner_(std::move(inner)),
+          tail_offset_(tail_offset),
+          tail_(std::move(tail)) {
+    }
+
+    using milvus::InputStream::Read;
+
+    size_t
+    Size() const override {
+        return inner_->Size();
+    }
+
+    bool
+    Seek(int64_t offset) override {
+        return inner_->Seek(offset);
+    }
+
+    size_t
+    Tell() const override {
+        return inner_->Tell();
+    }
+
+    bool
+    Eof() const override {
+        return inner_->Eof();
+    }
+
+    size_t
+    Read(void* data, size_t size) override {
+        return inner_->Read(data, size);
+    }
+
+    size_t
+    ReadAt(void* data, size_t offset, size_t size) override {
+        // Partial stitching would combine cached and provider reads into one
+        // logical operation and change short-read/provider-error semantics.
+        if (offset >= tail_offset_) {
+            const size_t relative_offset = offset - tail_offset_;
+            if (relative_offset <= tail_.size() &&
+                size <= tail_.size() - relative_offset) {
+                if (size > 0) {
+                    milvus::fastmem::FastMemcpy(
+                        data, tail_.data() + relative_offset, size);
+                }
+                return size;
+            }
+        }
+        return inner_->ReadAt(data, offset, size);
+    }
+
+    size_t
+    Read(int fd, size_t size) override {
+        return inner_->Read(fd, size);
+    }
+
+ private:
+    const std::shared_ptr<milvus::InputStream> inner_;
+    const size_t tail_offset_;
+    const std::vector<uint8_t> tail_;
+};
+
+}  // namespace milvus::storage::detail


### PR DESCRIPTION
issue: #51695

## What does this PR do?

This PR removes redundant object-storage Range GETs while opening and loading V3 packed scalar indexes.

Milvus scalar index engine version 3 made the V3 single-file packed layout the default, and engine version 4 continues to use the same format. A scalar-index build normally creates one packed object for each segment and indexed scalar field. Each object contains a magic header, index entries, a `__meta__` entry, a directory table, and a footer.

`IndexEntryReader::Open()` downloads up to the final 256 KiB of the object to parse the footer and directory. Before this change, subsequent operations could issue separate reads for the magic value, metadata, and entries even when their complete ranges were already present in that downloaded tail. Small packed indexes were particularly inefficient: when the whole object fit in the tail read, portions of the same object could still be fetched repeatedly.

This is request amplification rather than useful index I/O. It is most visible with remote S3-compatible storage, multiple scalar indexes, many segments, and operations that reopen indexes, such as collection load, QueryNode restart, replica scale-out, rebalance, release/load, and loading replacement segments after compaction.

## How it works

- `Open` reads the initial file tail, validates the V3 magic before interpreting the footer or directory, and then parses and retains the tail.
- When the file is no larger than 256 KiB, magic validation uses the already-downloaded full-file buffer. Larger files keep the required separate header read.
- The reader retains at most the final 256 KiB. If directory or metadata parsing temporarily needs a larger buffer, only a fresh bounded final-tail allocation survives for the reader lifetime; the larger parse allocation is released.
- `InspectStreamLoadInfo()` keeps its 64 KiB inspection window because resource estimation only needs the footer and directory and does not retain a reader for subsequent entry loads.

Current master performs this inspection as a separate storage read while estimating resources for non-HYBRID V3 packed scalar-index loads, and as a fallback for HYBRID inspection. In the common small-directory case it adds one 64 KiB tail Range GET before the later `Open()` used by actual loading. The inspection reader is destroyed after returning sizing metadata, so those bytes cannot be reused by this reader-local tail cache; this PR does not eliminate that request.
- A coverage-aware `ReadAt` serves a request from the retained tail only when the complete requested range is covered.
- Cache misses and partial overlaps use the original `InputStream::ReadAt` path unchanged. The implementation intentionally does not stitch cached and provider bytes, so existing short-read and provider-error semantics remain intact.
- Plain, encrypted, in-memory, file-output, and streaming entry paths use the same coverage-aware read source.
- Invalid negative, unaddressable, or smaller-than-header-and-footer file sizes are rejected before issuing a storage read.
- The existing public `IndexEntryReader::Open` API is unchanged. No cipher-plugin injection overload or other test-only production API is added.

The legacy `small_entry_cache_` is removed. That cache copied every entry up to 1 MiB into an unbounded reader-owned map, but the production call graph reads each named auxiliary entry at most once per reader; `__meta__` is parsed during `Open` and is not fetched through `ReadEntry` again. It therefore added allocation and copying without production hits. For encrypted indexes it also retained a second plaintext copy until reader destruction. This was not a security vulnerability, but removing the unused copy gives decrypted data a tighter lifetime and lowers peak memory.

The trade-off is explicit: a future caller that repeatedly reads the same small entry outside the retained final tail would now issue another provider read instead of hitting `small_entry_cache_`. No current production caller has that access pattern. Entries fully covered by the retained tail still avoid provider I/O through the shared `TailCachedInputStream`.

The change does not add a process-wide cache, cross-load reuse, an eviction policy, or stale-object semantics. Existing CRC verification, encryption/decryption, cancellation, and entry-output behavior remain in place.

## Scope and user impact

This directly affects V3 packed scalar and text indexes loaded through `IndexEntryReader`, including STL_SORT, INVERTED, BITMAP, HYBRID, MARISA, JSON/ARRAY/nested scalar indexes, NGRAM, RTREE, and packed text-index variants. Encrypted packed indexes use the same read path.

It does not affect:

- vector-index artifacts such as IVF, HNSW, or DiskANN files;
- insert/field-data Parquet, Vortex/Loon, raw-vector, or LOB objects;
- delta logs, Bloom/PK/JSON/BM25 stats, manifests, WAL, snapshots, or backups;
- legacy pre-V3 scalar-index layouts;
- PUT, HEAD, or LIST requests;
- steady-state search after an index is loaded.

Collections with multiple scalar indexes and many relatively small segments benefit most. Pure-vector collections should see little or no change. For large packed indexes, the main entry data still follows the normal storage path, so the proportional benefit is smaller.

The expected effects are lower object-store request count, request cost, provider pressure, duplicated response bytes, and RTT sensitivity. End-to-end collection-load latency can still be dominated by QueryCoord scheduling, concurrent loads, and large vector-index downloads.

## Latest observed impact

Provider-level A/B testing confirmed a substantial reduction in packed-index GET amplification and showed lower warm-load latency under controlled object-store RTT, with no observed correctness, provider-error, or representative-workload regression.

The full dataset schema, data distribution, vector and scalar index configuration, query mix, run ordering, and results are documented separately in the [provider-level validation comment](https://github.com/milvus-io/milvus/pull/51696#issuecomment-5043387104).

## Validation

`IndexEntryReaderTailCacheTest.*` contains nine focused cases and was executed three times against this change (27/27 passed), covering:

- exact 256 KiB cached-tail boundary reads;
- plaintext full-coverage hits and partial-overlap provider fallback;
- oversized directory and metadata parsing while retaining only the final bounded tail;
- corrupt magic and arbitrary non-V3 input, including magic diagnostics before footer errors;
- provider short-read failure;
- pre-cancelled open;
- negative, unaddressable, and too-small file sizes.

`TailCachedInputStreamTest.ServesOnlyFullyCoveredRanges` directly verifies cache hits, misses, partial overlaps, zero-length reads, and range boundaries independently of entry encoding.

This PR does not include an encrypted-reader GET-count/decryption integration test. Encrypted read methods are structurally routed through the same `TailCachedInputStream`, but the existing mock cipher tests exercise encrypted writing rather than reader-side cache reuse. End-to-end encrypted reader coverage should use a real loadable cipher-plugin fixture instead of adding a test-only `IndexEntryReader::Open` overload.