### PR TITLE
fix: [cp2.6]base64-encode encryption key in NewManifestRecordReader

### DIFF
--- a/internal/storage/rw.go
+++ b/internal/storage/rw.go
@@ -342,7 +342,7 @@ func NewManifestRecordReader(ctx context.Context, manifestPath string, schema *s
 					pluginContext = &indexcgopb.StoragePluginContext{
 						EncryptionZoneId: ez.EzID,
 						CollectionId:     ez.CollectionID,
-						EncryptionKey:    string(unsafe),
+						EncryptionKey:    base64.StdEncoding.EncodeToString(unsafe),
 					}
 				}
 			}


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #51480
issue: #51475

## Summary

Cherry-picked from master PR #51480 (open — preemptive backport).

`NewManifestRecordReader` passed the raw encryption key to the cipher plugin instead of base64-encoding it, unlike its four sibling construction sites. On 2.6 this bug is present at `internal/storage/rw.go:345` and reachable via compaction (`compactor/compactor_common.go`) and the external function executor (`external/function_executor.go`) for encryption-enabled StorageV3 collections.

**Note**: Original PR #51480 is still open; update this CP PR if it changes.

## Divergence from master PR (intentional)

The master PR also updated `TestNewManifestRecordReaderBranches` in `serde_events_test.go`. That test — and the surrounding manifest-reader test block — does **not exist on 2.6** (added to master after the 2.6 branch cut). Porting it would drag in ~580 lines of tests referencing APIs not present on 2.6. This CP therefore carries only the one-line `rw.go` fix; there is no pre-existing 2.6 test asserting the buggy behavior to correct.

## Verification

- [x] Code change matches master PR's rw.go fix (1 line)
- [x] `internal/storage` compiles on 2.6
- [x] No conflict markers
- [x] Test change intentionally omitted (see Divergence)
- [ ] make static-check (skipped by cherry-pick workflow)
