### PR TITLE
fix: [cp3.0]Return early after parameter validation fails in RESTful v2 function DDL handlers

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -959,6 +959,7 @@ func (h *HandlersV2) addCollectionFunction(ctx context.Context, c *gin.Context, 
 			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 			HTTPReturnMessage: err.Error(),
 		})
+		return nil, err
 	}
 
 	req.FunctionSchema = fSchema
@@ -985,6 +986,7 @@ func (h *HandlersV2) alterCollectionFunction(ctx context.Context, c *gin.Context
 			HTTPReturnCode:    merr.Code(merr.ErrParameterInvalid),
 			HTTPReturnMessage: err.Error(),
 		})
+		return nil, err
 	}
 
 	req.FunctionSchema = fSchema

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -4763,6 +4763,20 @@ func (s *CollectionFunctionSuite) TestAddCollectionFunctionNormal() {
 	})
 }
 
+func (s *CollectionFunctionSuite) TestAddCollectionFunctionInvalidType() {
+	// no expectation on s.mp: an invalid function type must be rejected
+	// before any AddCollectionFunction RPC is issued
+	addFunctionTestCases := []requestBodyTestCase{
+		{
+			path:        versionalV2(CollectionCategory, AddFunctionAction),
+			requestBody: []byte(`{"dbName": "db", "collectionName": "coll", "function": {"name": "test_function", "type": "InvalidType", "inputFieldNames": [], "OutputFieldNames": []}}`),
+			errCode:     1100,
+			errMsg:      "Unsupported function type: InvalidType: invalid parameter",
+		},
+	}
+	validateRequestBodyTestCases(s.T(), s.testEngine, addFunctionTestCases, false)
+}
+
 func (s *CollectionFunctionSuite) TestAlterCollectionFunctionNormal() {
 	s.Run("success", func() {
 		alterFunctionTestCases := []requestBodyTestCase{
@@ -4795,6 +4809,20 @@ func (s *CollectionFunctionSuite) TestAlterCollectionFunctionNormal() {
 		}
 		validateRequestBodyTestCases(s.T(), s.testEngine, alterFunctionTestCases, false)
 	})
+}
+
+func (s *CollectionFunctionSuite) TestAlterCollectionFunctionInvalidType() {
+	// no expectation on s.mp: an invalid function type must be rejected
+	// before any AlterCollectionFunction RPC is issued
+	alterFunctionTestCases := []requestBodyTestCase{
+		{
+			path:        versionalV2(CollectionCategory, AlterFunctionAction),
+			requestBody: []byte(`{"dbName": "db", "collectionName": "coll", "functionName": "test_function", "function": {"name": "test_function", "type": "InvalidType", "inputFieldNames": [], "OutputFieldNames": []}}`),
+			errCode:     1100,
+			errMsg:      "Unsupported function type: InvalidType: invalid parameter",
+		},
+	}
+	validateRequestBodyTestCases(s.T(), s.testEngine, alterFunctionTestCases, false)
 }
 
 func (s *CollectionFunctionSuite) TestDropCollectionFunctionNormal() {


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #51511
issue: #51503

## Summary

Cherry-picked from master PR #51511 (open — preemptive backport). Diff is byte-identical to the master PR (handler_v2.go + handler_v2_test.go, +30 lines).

**Note**: Original PR #51511 is still open; update this CP PR if it changes.

## Verification

- [x] Diff identical to master PR (2 files, +30)
- [x] internal/distributed/proxy/httpserver compiles on 3.0
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)
