### PR TITLE
fix: [cp2.6]avoid nil worker dereference in delegator ReleaseSegments

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -1005,12 +1005,12 @@ func (sd *shardDelegator) ReleaseSegments(ctx context.Context, req *querypb.Rele
 		if err != nil {
 			log.Warn("delegator failed to find worker", zap.Error(err))
 			releaseErr = err
-		}
-		req.Base.TargetID = targetNodeID
-		err = worker.ReleaseSegments(ctx, req)
-		if err != nil {
-			log.Warn("worker failed to release segments", zap.Error(err))
-			releaseErr = err
+		} else {
+			req.Base.TargetID = targetNodeID
+			if err = worker.ReleaseSegments(ctx, req); err != nil {
+				log.Warn("worker failed to release segments", zap.Error(err))
+				releaseErr = err
+			}
 		}
 	}
 	if len(growing) > 0 {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1783,6 +1783,31 @@ func (s *DelegatorDataSuite) TestDelegatorData_ExcludeSegments() {
 	s.True(s.delegator.VerifyExcludedSegments(1, 5))
 }
 
+func (s *DelegatorDataSuite) TestReleaseSegmentsWorkerNotAvailable() {
+	ctx := context.Background()
+	// the target worker is offline/unhealthy, GetWorker returns no worker
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).
+		Return(nil, merr.WrapErrNodeNotAvailable(1))
+
+	err := s.delegator.ReleaseSegments(ctx, &querypb.ReleaseSegmentsRequest{
+		Base:       commonpbutil.NewMsgBase(),
+		NodeID:     1,
+		SegmentIDs: []int64{1000},
+		Scope:      querypb.DataScope_All,
+	}, false)
+	s.Error(err)
+	// pin the contract: GetWorker's error code must reach the caller unmasked
+	s.ErrorIs(err, merr.ErrNodeNotAvailable)
+
+	// growingSegmentLock must be released even when the remote release fails,
+	// otherwise the channel's insert pipeline blocks forever
+	locked := s.delegator.growingSegmentLock.TryLock()
+	s.True(locked, "growingSegmentLock should be released after failed release")
+	if locked {
+		s.delegator.growingSegmentLock.Unlock()
+	}
+}
+
 func TestDelegatorDataSuite(t *testing.T) {
 	suite.Run(t, new(DelegatorDataSuite))
 }


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #51474
issue: #51472

## Summary

Cherry-picked from master PR #51474 (open — preemptive backport). 2.6 has the same nil-worker dereference: on `GetWorker` error the old code fell through and called `worker.ReleaseSegments` on a nil worker. Fix wraps it in an `else` branch.

## Divergence from master PR (intentional, 2.6 adaptations)

1. **Logging**: 2.6 predates the mlog migration, so the release-failure log keeps the 2.6 signature `log.Warn("...", zap.Error(err))` instead of master's `log.Warn(ctx, "...", mlog.Err(err))`. Logic is identical.
2. **Test**: the master diff's hunk pulled in 6 suite tests; only `TestReleaseSegmentsWorkerNotAvailable` belongs to this PR — the other 5 (`TestReleaseGrowingSource*`) are unrelated master-only features not on 2.6. Only the relevant regression test was ported. Net diff shape matches master (+31/-6).

## Verification

- [x] Fix logic matches master (else-branch guards nil worker)
- [x] Go-level compile clean (`go vet`); full test run needs cgo C++ core (validated by CI)
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)
