### PR TITLE
test: [3.0] isolate struct array manual compaction

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1096,6 +1096,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             schema=schema,
             index_params=index_params,
             consistency_level="Strong",
+            properties={"collection.autocompaction.enabled": "false"},
         )
 
         def profile(row_id, length, tag_prefix="keep"):


### PR DESCRIPTION
pr: #51689
issue: #51686

### What changed

- Disable collection auto-compaction when creating the collection in `test_struct_array_compaction_preserves_null_empty_offsets_and_indexes`.
- Keep explicit manual compaction as the only compaction trigger.

### Why

Automatic sort/mix compaction can claim all flushed segments before explicit manual compaction on distributed Pulsar. DataCoord then creates no task and `compact()` returns `-1`, causing flaky `ci-v2/e2e-amd` failures.

This is the 3.0 backport of #51689.

### Verification

- `ruff check tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py`
- `git diff --check`
