### PR TITLE
enhance: decouple local format split from writer format

### DIFF
--- a/docs/design-docs/design_docs/20260305-local_format.md
+++ b/docs/design-docs/design_docs/20260305-local_format.md
@@ -84,7 +84,8 @@ validates it as a field type parameter.
 
 Validation rules:
 
-- Missing `local_format` means `raw`.
+- Missing `local_format` uses the server default, which initially resolves to
+  `raw`.
 - `local_format=vortex` is accepted for non-primary-key, non-vector fields.
 - Primary-key fields reject `local_format=vortex`.
 - Vector fields reject `local_format=vortex`.
@@ -94,10 +95,14 @@ Validation rules:
 
 `local_format` is only effective for Storage V3 sealed segments.
 
-For write-time column group planning, fields marked `local_format=vortex` are
-partitioned away from fields using the raw local format. A column group whose
-remaining fields all use Vortex local format is written with physical format
-`vortex`; other column groups use the normal fallback storage format.
+For write-time column group planning, fields with a default (empty), `raw`, or
+`vortex` local format are partitioned away from each other. The default value
+remains a separate partition so a future server-level default can be changed
+without mixing fields that explicitly requested `raw` or `vortex`.
+
+Local format does not select the physical writer format. New column groups use
+the writer's configured format, and existing column groups preserve the format
+recorded in the Storage V3 manifest.
 
 For read-time loading, Vortex local format is used only when both conditions are
 true:
@@ -162,18 +167,18 @@ The key ownership split is:
 
 ### Column Group Splitting
 
-Column group splitting partitions fields by `local_format` before subsequent
-split policies finalize physical groups. This prevents raw and Vortex local
-format fields from sharing one physical column group.
+Column group splitting partitions fields by the default (empty), `raw`, or
+`vortex` `local_format` value before subsequent split policies finalize physical
+groups. This gives each physical group an unambiguous local-format intent while
+keeping physical writer-format selection independent.
 
 The split policy behavior is:
 
-1. Partition pending fields by `local_format`.
-2. Keep the partition's format metadata through later split policies.
-3. Emit physical column groups with `Format=vortex` only for Vortex local format
-   groups.
-4. Leave raw groups with an empty format override so they use the configured
-   fallback storage format.
+1. Partition pending fields by the exact `local_format` value, keeping default
+   (empty), `raw`, and `vortex` separate.
+2. Keep the partition boundary through later split policies.
+3. Leave the resulting column group's writer `Format` unset so normal writer
+   configuration or existing manifest metadata determines the physical format.
 
 System, vector, text, average-size, and remanent-short split policies still
 apply after the local-format partitioning. They split within the current local
@@ -479,11 +484,11 @@ level so all field proxies in the same physical group share the same state.
 
 ## Compatibility, Deprecation, and Migration Plan
 
-- Backward compatible by default: fields without `local_format` behave as
-  `raw`.
+- Backward compatible by default: fields without `local_format` use the server
+  default, which initially behaves as `raw`.
 - Existing non-Vortex segments continue to load through the raw path.
-- A schema can contain both raw and Vortex local format fields; column group
-  splitting keeps them physically separate.
+- A schema can contain default (empty), raw, and Vortex local format fields;
+  column group splitting keeps the three intents physically separate.
 - During the transition, QueryNode keeps both access paths: raw fields continue
   to use the `ChunkedBase` chunk-oriented path, while Vortex fields use the
   `ChunkedColumnInterface` column-oriented path.

--- a/internal/storagecommon/split_policy.go
+++ b/internal/storagecommon/split_policy.go
@@ -44,7 +44,7 @@ func newCurrentSplit(fields []*schemapb.FieldSchema, stats map[int64]ColumnStats
 	pendingGroup := localFormatGroup{
 		fields:      make([]int64, 0, len(fields)),
 		indices:     make([]int, 0, len(fields)),
-		localFormat: "",
+		localFormat: localFormatDefault,
 	}
 	for idx, field := range fields {
 		pendingGroup.fields = append(pendingGroup.fields, field.GetFieldID())
@@ -59,28 +59,8 @@ func newCurrentSplit(fields []*schemapb.FieldSchema, stats map[int64]ColumnStats
 }
 
 func (c *currentSplit) SplitFields(groupID int64, fields []int64, indices []int) {
-	c.SplitFieldsWithFormat(groupID, fields, indices, c.columnGroupFormat(indices))
-}
-
-func (c *currentSplit) SplitFieldsWithFormat(groupID int64, fields []int64, indices []int, format string) {
 	c.processFields.Insert(fields...)
-	c.outputGroups = append(c.outputGroups, ColumnGroup{Columns: indices, GroupID: groupID, Fields: fields, Format: format})
-}
-
-func (c *currentSplit) columnGroupFormat(indices []int) string {
-	if len(indices) == 0 {
-		return ""
-	}
-	format := fieldLocalFormat(c.fields[indices[0]])
-	if format == common.LocalFormatRaw {
-		return ""
-	}
-	for _, idx := range indices[1:] {
-		if fieldLocalFormat(c.fields[idx]) != format {
-			return ""
-		}
-	}
-	return storageFormatForLocalFormat(format)
+	c.outputGroups = append(c.outputGroups, ColumnGroup{Columns: indices, GroupID: groupID, Fields: fields})
 }
 
 func (c *currentSplit) NextGroupID() int64 {
@@ -140,7 +120,7 @@ func (c *currentSplit) PartitionRemainingByLocalFormat() {
 	nextGroups := make([]localFormatGroup, 0, len(c.pendingGroups))
 	for _, pendingGroup := range c.RangeGroups(nil) {
 		groupsByFormat := make(map[string]*localFormatGroup)
-		formats := make([]string, 0, 2)
+		formats := make([]string, 0, 3)
 		for _, idx := range pendingGroup.indices {
 			field := c.fields[idx]
 			format := fieldLocalFormat(field)
@@ -182,7 +162,12 @@ func NewSelectedDataTypePolicy() ColumnGroupSplitPolicy {
 	return &selectedDataTypePolicy{}
 }
 
+// localFormatPolicy only partitions fields by local loading intent. It must not
+// set ColumnGroup.Format, which is physical writer metadata owned by the writer
+// configuration and existing manifests.
 type localFormatPolicy struct{}
+
+const localFormatDefault = ""
 
 type localFormatGroup struct {
 	fields      []int64
@@ -196,14 +181,9 @@ func fieldLocalFormat(field *schemapb.FieldSchema) string {
 			return kv.GetValue()
 		}
 	}
-	return common.LocalFormatRaw
-}
-
-func storageFormatForLocalFormat(format string) string {
-	if format == common.LocalFormatVortex {
-		return common.LocalFormatVortex
-	}
-	return ""
+	// Keep the default value distinct from explicit raw so a server-level default
+	// can be introduced without merging fields with different local intent.
+	return localFormatDefault
 }
 
 func (p *localFormatPolicy) Split(currentSplit *currentSplit) *currentSplit {

--- a/internal/storagecommon/split_policy_test.go
+++ b/internal/storagecommon/split_policy_test.go
@@ -45,13 +45,13 @@ func AssertSplitEqual(t *testing.T, expect, actual *currentSplit) {
 	}
 }
 
-func AssertPendingGroupsEqual(t *testing.T, expect []ColumnGroup, actual *currentSplit) {
+func AssertPendingGroupsEqual(t *testing.T, expect []localFormatGroup, actual *currentSplit) {
 	groups := actual.RangeGroups(nil)
 	assert.Equal(t, len(expect), len(groups))
 	for i := range expect {
-		assert.Equal(t, expect[i].Columns, groups[i].indices)
-		assert.Equal(t, expect[i].Fields, groups[i].fields)
-		assert.Equal(t, expect[i].Format, storageFormatForLocalFormat(groups[i].localFormat))
+		assert.Equal(t, expect[i].indices, groups[i].indices)
+		assert.Equal(t, expect[i].fields, groups[i].fields)
+		assert.Equal(t, expect[i].localFormat, groups[i].localFormat)
 	}
 }
 
@@ -119,7 +119,6 @@ func TestWideDataTypePolicy(t *testing.T) {
 						GroupID: 101,
 						Columns: []int{1},
 						Fields:  []int64{101},
-						Format:  common.LocalFormatVortex,
 					},
 				},
 			},
@@ -214,13 +213,23 @@ func TestLocalFormatPolicy(t *testing.T) {
 					TypeParams: localFormatParam(common.LocalFormatVortex),
 				},
 				{
-					FieldID:  102,
-					DataType: schemapb.DataType_Double,
+					FieldID:    102,
+					DataType:   schemapb.DataType_Double,
+					TypeParams: localFormatParam(common.LocalFormatRaw),
 				},
 				{
-					FieldID:    103,
+					FieldID:  103,
+					DataType: schemapb.DataType_Int64,
+				},
+				{
+					FieldID:    104,
 					DataType:   schemapb.DataType_Int64,
 					TypeParams: localFormatParam(common.LocalFormatVortex),
+				},
+				{
+					FieldID:    105,
+					DataType:   schemapb.DataType_Double,
+					TypeParams: localFormatParam(common.LocalFormatRaw),
 				},
 			}, nil),
 			expect: &currentSplit{
@@ -255,23 +264,29 @@ func TestLocalFormatPolicy(t *testing.T) {
 			AssertSplitEqual(t, tc.expect, result)
 			switch tc.tag {
 			case "mixed_local_formats":
-				AssertPendingGroupsEqual(t, []ColumnGroup{
+				AssertPendingGroupsEqual(t, []localFormatGroup{
 					{
-						Columns: []int{0, 2},
-						Fields:  []int64{100, 102},
+						indices:     []int{0, 3},
+						fields:      []int64{100, 103},
+						localFormat: localFormatDefault,
 					},
 					{
-						Columns: []int{1, 3},
-						Fields:  []int64{101, 103},
-						Format:  common.LocalFormatVortex,
+						indices:     []int{1, 4},
+						fields:      []int64{101, 104},
+						localFormat: common.LocalFormatVortex,
+					},
+					{
+						indices:     []int{2, 5},
+						fields:      []int64{102, 105},
+						localFormat: common.LocalFormatRaw,
 					},
 				}, result)
 			case "single_vortex_local_format_partitions_without_output":
-				AssertPendingGroupsEqual(t, []ColumnGroup{
+				AssertPendingGroupsEqual(t, []localFormatGroup{
 					{
-						Columns: []int{0, 1},
-						Fields:  []int64{100, 101},
-						Format:  common.LocalFormatVortex,
+						indices:     []int{0, 1},
+						fields:      []int64{100, 101},
+						localFormat: common.LocalFormatVortex,
 					},
 				}, result)
 			}
@@ -279,7 +294,7 @@ func TestLocalFormatPolicy(t *testing.T) {
 	}
 }
 
-func TestSplitColumnsSeparatesLocalFormatsBeforeRemanent(t *testing.T) {
+func TestSplitColumnsSeparatesLocalFormatsWithoutSelectingWriterFormat(t *testing.T) {
 	localFormatParam := func(format string) []*commonpb.KeyValuePair {
 		return []*commonpb.KeyValuePair{
 			{
@@ -312,6 +327,16 @@ func TestSplitColumnsSeparatesLocalFormatsBeforeRemanent(t *testing.T) {
 			DataType:   schemapb.DataType_Int64,
 			TypeParams: localFormatParam(common.LocalFormatVortex),
 		},
+		{
+			FieldID:    105,
+			DataType:   schemapb.DataType_Int64,
+			TypeParams: localFormatParam(common.LocalFormatRaw),
+		},
+		{
+			FieldID:    106,
+			DataType:   schemapb.DataType_Double,
+			TypeParams: localFormatParam(common.LocalFormatRaw),
+		},
 	}
 
 	result := SplitColumns(fields,
@@ -330,7 +355,11 @@ func TestSplitColumnsSeparatesLocalFormatsBeforeRemanent(t *testing.T) {
 			GroupID: 1,
 			Columns: []int{1, 4},
 			Fields:  []int64{101, 104},
-			Format:  common.LocalFormatVortex,
+		},
+		{
+			GroupID: 2,
+			Columns: []int{5, 6},
+			Fields:  []int64{105, 106},
 		},
 		{
 			GroupID: 102,
@@ -338,9 +367,18 @@ func TestSplitColumnsSeparatesLocalFormatsBeforeRemanent(t *testing.T) {
 			Fields:  []int64{102},
 		},
 	}, result)
+
+	for _, group := range result {
+		assert.Empty(t, group.Format)
+	}
+	for _, writerFormat := range []string{"parquet", "vortex"} {
+		for _, group := range FillColumnGroupFormats(result, writerFormat) {
+			assert.Equal(t, writerFormat, group.Format)
+		}
+	}
 }
 
-func TestLocalFormatPolicyKeepsLaterSplitsWithinFormat(t *testing.T) {
+func TestLocalFormatPolicyKeepsLaterSplitsWithinPartitions(t *testing.T) {
 	localFormatParam := func(format string) []*commonpb.KeyValuePair {
 		return []*commonpb.KeyValuePair{
 			{
@@ -391,13 +429,11 @@ func TestLocalFormatPolicyKeepsLaterSplitsWithinFormat(t *testing.T) {
 			GroupID: 2,
 			Columns: []int{1},
 			Fields:  []int64{101},
-			Format:  common.LocalFormatVortex,
 		},
 		{
 			GroupID: 3,
 			Columns: []int{3},
 			Fields:  []int64{103},
-			Format:  common.LocalFormatVortex,
 		},
 	}, result)
 }
@@ -494,7 +530,6 @@ func TestSystemColumnPolicy(t *testing.T) {
 						GroupID: 1,
 						Columns: []int{2},
 						Fields:  []int64{100},
-						Format:  common.LocalFormatVortex,
 					},
 				},
 			},
@@ -856,7 +891,7 @@ func TestAvgSizePolicy(t *testing.T) {
 			},
 		},
 		{
-			tag: "over_threshold_preserves_vortex_local_format",
+			tag: "over_threshold_does_not_select_writer_format",
 			input: newCurrentSplit([]*schemapb.FieldSchema{
 				{
 					FieldID:  100,
@@ -886,7 +921,6 @@ func TestAvgSizePolicy(t *testing.T) {
 						GroupID: 101,
 						Columns: []int{1},
 						Fields:  []int64{101},
-						Format:  common.LocalFormatVortex,
 					},
 				},
 			},


### PR DESCRIPTION
issue: #50304
pr: https://github.com/milvus-io/milvus/pull/51204

## Summary
Partition fields with default (empty), raw, and Vortex local formats into separate column-group policy partitions. Keep column-group writer format unset so physical format continues to follow writer configuration or existing manifest metadata.