### PR TITLE
enhance: parallelize external-collection index-build raw data reads

### DIFF
--- a/internal/compaction/params.go
+++ b/internal/compaction/params.go
@@ -102,6 +102,9 @@ func CreateStorageConfig() *indexpb.StorageConfig {
 		storageConfig = &indexpb.StorageConfig{
 			RootPath:    paramtable.Get().LocalStorageCfg.Path.GetValue(),
 			StorageType: paramtable.Get().CommonCfg.StorageType.GetValue(),
+			// External collections may reference an s3:// source even when the
+			// primary storage is local, so the connection cap still applies.
+			MaxConnections: uint32(paramtable.Get().MinioCfg.MaxConnections.GetAsInt()),
 		}
 	} else {
 		storageConfig = &indexpb.StorageConfig{

--- a/internal/compaction/params.go
+++ b/internal/compaction/params.go
@@ -119,6 +119,7 @@ func CreateStorageConfig() *indexpb.StorageConfig {
 			UseVirtualHost:    paramtable.Get().MinioCfg.UseVirtualHost.GetAsBool(),
 			CloudProvider:     paramtable.Get().MinioCfg.CloudProvider.GetValue(),
 			RequestTimeoutMs:  paramtable.Get().MinioCfg.RequestTimeoutMs.GetAsInt64(),
+			MaxConnections:    uint32(paramtable.Get().MinioCfg.MaxConnections.GetAsInt()),
 			GcpCredentialJSON: paramtable.Get().MinioCfg.GcpCredentialJSON.GetValue(),
 			SslTlsMinVersion:  paramtable.Get().MinioCfg.SslTLSMinVersion.GetValue(),
 			UseCrc32CChecksum: paramtable.Get().MinioCfg.UseCRC32C.GetAsBool(),

--- a/internal/compaction/params_test.go
+++ b/internal/compaction/params_test.go
@@ -69,6 +69,23 @@ func TestCreateStorageConfigMaxConnections(t *testing.T) {
 	assert.Equal(t, uint32(237), CreateStorageConfig().GetMaxConnections())
 }
 
+// An external collection can reference an s3:// source while the cluster's
+// primary storage is local, so the local branch must carry the connection cap
+// too — otherwise the operator's minio.maxConnections is silently dropped for
+// that topology.
+func TestCreateStorageConfigMaxConnectionsLocalStorage(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "local")
+	pt.Save(pt.MinioCfg.MaxConnections.Key, "237")
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.MinioCfg.MaxConnections.Key)
+	})
+
+	assert.Equal(t, uint32(237), CreateStorageConfig().GetMaxConnections())
+}
+
 func TestGetParamsFromJSON(t *testing.T) {
 	input := `{
 		"storage_version": 0,

--- a/internal/compaction/params_test.go
+++ b/internal/compaction/params_test.go
@@ -56,6 +56,19 @@ func TestGetJSONParams(t *testing.T) {
 	}, result)
 }
 
+func TestCreateStorageConfigMaxConnections(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "minio")
+	pt.Save(pt.MinioCfg.MaxConnections.Key, "237")
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.MinioCfg.MaxConnections.Key)
+	})
+
+	assert.Equal(t, uint32(237), CreateStorageConfig().GetMaxConnections())
+}
+
 func TestGetParamsFromJSON(t *testing.T) {
 	input := `{
 		"storage_version": 0,

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -52,6 +52,7 @@
 #include "storage/PluginLoader.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
+#include "storage/loon_ffi/property_singleton.h"
 #include "storage/loon_ffi/util.h"
 #include "storage/plugin/PluginInterface.h"
 
@@ -218,6 +219,14 @@ configure_manifest_file_manager_context(
                                      build_index_info.external_source(),
                                      build_index_info.external_spec());
     }
+    // Widen the per-round read window for index-build manifest reads when
+    // configured. With loon's 32MB default each prefetch round admits a
+    // single 64MB-class row group, so the whole raw-data download degrades
+    // to one S3 range read at a time; a wider window lets one round span
+    // multiple row groups whose column chunks are prefetched in parallel
+    // on the arrow IO thread pool.
+    milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+        .ApplyIndexBuildReadWindow(*loon_properties);
     file_manager_context.set_loon_ffi_properties(loon_properties);
 
     auto is_milvus_table =

--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <map>
 #include <optional>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -81,12 +82,43 @@ class FlushGrowingSegmentTest : public ::testing::Test {
         std::string manifest_json =
             "{\"base_path\":\"" + segment_path +
             "\",\"ver\":" + std::to_string(result.committed_version) + "}";
-        return storage::GetFieldDatasFromManifest(manifest_json,
-                                                  properties,
-                                                  field_meta,
-                                                  data_type,
-                                                  dim,
-                                                  element_type);
+        auto field_datas = storage::GetFieldDatasFromManifest(manifest_json,
+                                                              properties,
+                                                              field_meta,
+                                                              data_type,
+                                                              dim,
+                                                              element_type);
+
+        // Contract check for the streaming variant every caller of this
+        // helper implicitly covers: IterateFieldDataFromManifest must
+        // deliver identical batches, in order, on the calling thread, even
+        // though decode runs on a thread pool.
+        std::vector<FieldDataPtr> streamed;
+        auto caller_tid = std::this_thread::get_id();
+        storage::IterateFieldDataFromManifest(
+            manifest_json,
+            properties,
+            field_meta,
+            data_type,
+            dim,
+            element_type,
+            std::nullopt,
+            [&](FieldDataPtr fd) {
+                EXPECT_EQ(std::this_thread::get_id(), caller_tid);
+                streamed.push_back(std::move(fd));
+            });
+        EXPECT_EQ(streamed.size(), field_datas.size());
+        for (size_t i = 0; i < std::min(streamed.size(), field_datas.size());
+             ++i) {
+            EXPECT_EQ(streamed[i]->get_num_rows(),
+                      field_datas[i]->get_num_rows());
+            for (int64_t r = 0; r < streamed[i]->get_num_rows(); ++r) {
+                EXPECT_EQ(streamed[i]->is_valid(r),
+                          field_datas[i]->is_valid(r));
+            }
+        }
+
+        return field_datas;
     }
 
     void
@@ -3014,6 +3046,93 @@ TEST_F(FlushGrowingSegmentTest, FlushNullableEmbListMixedRows) {
     for (int d = 0; d < dim; ++d) {
         EXPECT_FLOAT_EQ(target_out.float_vector().data(d), 1.0f + d);
     }
+
+    FreeFlushResult(&result);
+}
+
+// The streaming reader decodes batches on a thread pool and delivers them on
+// the calling thread. Comparing it against GetFieldDatasFromManifest would be
+// circular (that helper now delegates to it), and single-batch cases cannot
+// expose ordering bugs at all. This test forces multiple record batches by
+// inserting well past loon's per-batch row limit (reader.record_batch_max_rows
+// defaults to 8192) and validates the concatenated result against the values
+// that were originally inserted, in order.
+TEST_F(FlushGrowingSegmentTest,
+       IterateFieldDataFromManifestMultiBatchOrdering) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto val_fid = schema->AddDebugField("val", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    // > 2x the default 8192-row batch limit, so the reader must produce
+    // several batches and their delivery order becomes observable.
+    const int N = 20000;
+    auto dataset = DataGen(schema, N);
+    segment->PreInsert(N);
+    segment->Insert(0,
+                    N,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+
+    C_FLUSH_CONFIG_WITH_SCHEMA(config, schema);
+    std::string segment_path = test_dir_ + "/segment_multibatch";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+
+    CFlushResult result{};
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(result.num_rows, N);
+
+    auto properties =
+        storage::LoonFFIPropertiesSingleton::GetInstance().GetProperties();
+    ASSERT_NE(properties, nullptr);
+    auto field_meta = gen_field_meta(
+        1, 2, 3, val_fid.get(), DataType::INT64, DataType::NONE, false);
+    std::string manifest_json =
+        "{\"base_path\":\"" + segment_path +
+        "\",\"ver\":" + std::to_string(result.committed_version) + "}";
+
+    std::vector<FieldDataPtr> streamed;
+    auto caller_tid = std::this_thread::get_id();
+    storage::IterateFieldDataFromManifest(
+        manifest_json,
+        properties,
+        field_meta,
+        DataType::INT64,
+        0,
+        DataType::NONE,
+        std::nullopt,
+        [&](FieldDataPtr fd) {
+            EXPECT_EQ(std::this_thread::get_id(), caller_tid);
+            streamed.push_back(std::move(fd));
+        });
+
+    // The point of the test: this must actually span multiple batches,
+    // otherwise ordering is trivially satisfied and nothing is verified.
+    ASSERT_GT(streamed.size(), 1u)
+        << "expected multiple record batches for " << N << " rows";
+
+    // Compare values against the originally inserted column, in order.
+    auto expected = dataset.get_col<int64_t>(val_fid);
+    ASSERT_EQ(expected.size(), static_cast<size_t>(N));
+    int64_t seen = 0;
+    for (const auto& fd : streamed) {
+        for (int64_t i = 0; i < fd->get_num_rows(); ++i) {
+            ASSERT_LT(seen, N);
+            EXPECT_EQ(*static_cast<const int64_t*>(fd->RawValue(i)),
+                      expected[seen])
+                << "value mismatch at row " << seen;
+            ++seen;
+        }
+    }
+    EXPECT_EQ(seen, N);
 
     FreeFlushResult(&result);
 }

--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -3134,5 +3134,33 @@ TEST_F(FlushGrowingSegmentTest,
     }
     EXPECT_EQ(seen, N);
 
+    // The in-flight budget is a throughput/memory knob, never a correctness
+    // one: accumulating callers pass kAccumulatingInflightBytes so the window
+    // does not add half a gigabyte of pinned arrow batches on top of a column
+    // they retain anyway. A budget small enough that every batch exceeds it
+    // must still deliver every batch, in the same order — the loop keeps one
+    // batch in flight unconditionally, so it cannot stall.
+    std::vector<FieldDataPtr> tiny_window;
+    storage::IterateFieldDataFromManifest(
+        manifest_json,
+        properties,
+        field_meta,
+        DataType::INT64,
+        0,
+        DataType::NONE,
+        std::nullopt,
+        [&](FieldDataPtr fd) { tiny_window.push_back(std::move(fd)); },
+        /*max_inflight_bytes=*/1);
+
+    ASSERT_EQ(tiny_window.size(), streamed.size());
+    for (size_t b = 0; b < tiny_window.size(); ++b) {
+        ASSERT_EQ(tiny_window[b]->get_num_rows(), streamed[b]->get_num_rows());
+        for (int64_t i = 0; i < tiny_window[b]->get_num_rows(); ++i) {
+            EXPECT_EQ(*static_cast<const int64_t*>(tiny_window[b]->RawValue(i)),
+                      *static_cast<const int64_t*>(streamed[b]->RawValue(i)))
+                << "batch " << b << " row " << i;
+        }
+    }
+
     FreeFlushResult(&result);
 }

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -965,58 +965,35 @@ DiskFileManagerImpl::cache_raw_data_to_disk_storage_v2(const Config& config) {
     uint32_t var_dim = 0;
     int64_t write_offset = sizeof(num_rows) + sizeof(var_dim);
 
-    std::vector<FieldDataPtr> field_datas;
-    auto manifest =
-        index::GetValueFromConfig<std::string>(config, SEGMENT_MANIFEST_KEY);
-    auto manifest_path_str = manifest.value_or("");
-    if (manifest_path_str != "") {
-        AssertInfo(
-            loon_ffi_properties_ != nullptr,
-            "loon ffi properties is null when build index with manifest");
-        field_datas = GetFieldDatasFromManifest(
-            manifest_path_str,
-            loon_ffi_properties_,
-            field_meta_,
-            data_type,
-            dim,
-            element_type,
-            GetStorageColumnMapping(field_meta_.field_id));
-    } else {
-        field_datas = GetFieldDatasFromStorageV2(all_remote_files,
-                                                 GetFieldDataMeta().field_id,
-                                                 data_type.value(),
-                                                 element_type.value(),
-                                                 dim,
-                                                 fs_);
-    }
-
     bool nullable = false;
     uint64_t total_num_rows = 0;
-    if (valid_data_path.has_value()) {
-        for (auto& field_data : field_datas) {
+    std::vector<uint8_t> valid_bitmap;
+
+    // Consumes one batch: accumulate row/validity bookkeeping, then append
+    // the batch to the local raw-data file. The validity bitmap grows
+    // incrementally (mirroring cache_raw_data_to_disk_internal) because in
+    // the streaming manifest path the total row count is unknown upfront.
+    // Nullability is uniform across batches of one column (it comes from
+    // the field schema), so growth from the first batch covers all rows.
+    auto consume_field_data = [&](const FieldDataPtr& field_data) {
+        num_rows += uint32_t(field_data->get_valid_rows());
+        if (valid_data_path.has_value()) {
+            auto rows = field_data->get_num_rows();
             if (field_data->IsNullable()) {
                 nullable = true;
             }
-            total_num_rows += field_data->get_num_rows();
-        }
-    }
-
-    std::vector<uint8_t> valid_bitmap;
-    if (nullable) {
-        valid_bitmap.resize((total_num_rows + 7) / 8, 0);
-    }
-
-    int64_t chunk_offset = 0;
-    for (auto& field_data : field_datas) {
-        num_rows += uint32_t(field_data->get_valid_rows());
-        if (nullable) {
-            auto rows = field_data->get_num_rows();
-            for (int64_t i = 0; i < rows; ++i) {
-                if (field_data->is_valid(i)) {
-                    set_bit(valid_bitmap, chunk_offset + i);
+            if (nullable && rows > 0) {
+                auto new_size = (total_num_rows + rows + 7) / 8;
+                if (new_size > static_cast<int64_t>(valid_bitmap.size())) {
+                    valid_bitmap.resize(new_size, 0);
+                }
+                for (int64_t i = 0; i < rows; ++i) {
+                    if (field_data->is_valid(i)) {
+                        set_bit(valid_bitmap, total_num_rows + i);
+                    }
                 }
             }
-            chunk_offset += rows;
+            total_num_rows += rows;
         }
 
         cache_raw_data_to_disk_common<T>(field_data,
@@ -1026,6 +1003,40 @@ DiskFileManagerImpl::cache_raw_data_to_disk_storage_v2(const Config& config) {
                                          var_dim,
                                          write_offset,
                                          is_vector_array ? &offsets : nullptr);
+    };
+
+    auto manifest =
+        index::GetValueFromConfig<std::string>(config, SEGMENT_MANIFEST_KEY);
+    auto manifest_path_str = manifest.value_or("");
+    if (manifest_path_str != "") {
+        AssertInfo(
+            loon_ffi_properties_ != nullptr,
+            "loon ffi properties is null when build index with manifest");
+        // Stream batches straight to the local file instead of
+        // materializing the whole column in memory first, so this task's
+        // retention drops from the full raw column to the reader's prefetch
+        // window plus the bounded decode window, and the disk write
+        // overlaps with fetch/decode.
+        IterateFieldDataFromManifest(
+            manifest_path_str,
+            loon_ffi_properties_,
+            field_meta_,
+            data_type,
+            dim,
+            element_type,
+            GetStorageColumnMapping(field_meta_.field_id),
+            consume_field_data);
+    } else {
+        auto field_datas =
+            GetFieldDatasFromStorageV2(all_remote_files,
+                                       GetFieldDataMeta().field_id,
+                                       data_type.value(),
+                                       element_type.value(),
+                                       dim,
+                                       fs_);
+        for (auto& field_data : field_datas) {
+            consume_field_data(field_data);
+        }
     }
 
     // For vector arrays, num_rows should be the total flattened vector count,

--- a/internal/core/src/storage/RecordBatchSize.h
+++ b/internal/core/src/storage/RecordBatchSize.h
@@ -23,16 +23,26 @@ namespace milvus::storage {
 
 // Returns the bytes referenced by this record-batch slice. Unlike
 // TotalBufferSize, this accounts for array offsets and does not charge every
-// slice for its entire shared backing buffer. Falls back to the row count if
-// Arrow cannot compute the referenced ranges.
+// slice for its entire shared backing buffer.
+//
+// ReferencedBufferSize cannot walk every layout. On the pinned arrow 17 its
+// byte-range visitor has no overload for STRING_VIEW / BINARY_VIEW /
+// LIST_VIEW and falls through to a TypeError catch-all, which
+// ReferencedBufferSize(RecordBatch) propagates for the whole batch -- and
+// external (vortex schemaless) readers do produce those layouts, on the
+// pre-normalization batch this is called with. Fall back to the plain buffer
+// sum, which works for any type. It over-charges slices that share a backing
+// buffer, but for a memory cap over-charging is the safe direction: the row
+// count would charge a 64MB batch as 8192 bytes and silently disable byte
+// backpressure altogether, leaving only the batch-count limit.
 inline int64_t
 EstimateRecordBatchBytes(const arrow::RecordBatch& batch) {
     auto size_result = arrow::util::ReferencedBufferSize(batch);
-    if (!size_result.ok()) {
-        return batch.num_rows();
+    if (size_result.ok() && size_result.ValueOrDie() > 0) {
+        return size_result.ValueOrDie();
     }
-    auto referenced_bytes = size_result.ValueOrDie();
-    return referenced_bytes > 0 ? referenced_bytes : batch.num_rows();
+    auto total_bytes = arrow::util::TotalBufferSize(batch);
+    return total_bytes > 0 ? total_bytes : batch.num_rows();
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/RecordBatchSize.h
+++ b/internal/core/src/storage/RecordBatchSize.h
@@ -1,0 +1,38 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "arrow/record_batch.h"
+#include "arrow/util/byte_size.h"
+
+namespace milvus::storage {
+
+// Returns the bytes referenced by this record-batch slice. Unlike
+// TotalBufferSize, this accounts for array offsets and does not charge every
+// slice for its entire shared backing buffer. Falls back to the row count if
+// Arrow cannot compute the referenced ranges.
+inline int64_t
+EstimateRecordBatchBytes(const arrow::RecordBatch& batch) {
+    auto size_result = arrow::util::ReferencedBufferSize(batch);
+    if (!size_result.ok()) {
+        return batch.num_rows();
+    }
+    auto referenced_bytes = size_result.ValueOrDie();
+    return referenced_bytes > 0 ? referenced_bytes : batch.num_rows();
+}
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -24,7 +24,6 @@
 
 #include "arrow/array/builder_binary.h"
 #include "arrow/array/builder_nested.h"
-#include "arrow/util/byte_size.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/array/concatenate.h"
 #include "arrow/buffer_builder.h"
@@ -56,6 +55,7 @@
 #include "storage/LocalChunkManager.h"
 #include "storage/MemFileManagerImpl.h"
 #include "storage/minio/MinioChunkManager.h"
+#include "storage/RecordBatchSize.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "common/Common.h"
@@ -1761,15 +1761,10 @@ IterateFieldDataFromManifest(
             continue;
         }
 
-        // Estimate the decoded footprint of this batch for the byte budget.
-        // The arrow buffers backing the batch are the best available proxy
-        // for the FieldData it will materialize into; fall back to the row
-        // count when the size cannot be computed.
-        int64_t batch_bytes = 0;
-        {
-            auto size_result = arrow::util::TotalBufferSize(*batch);
-            batch_bytes = size_result > 0 ? size_result : num_rows;
-        }
+        // Estimate the decoded footprint of this slice for the byte budget.
+        // A record batch may share a large row-group backing buffer with
+        // adjacent slices, so count only the ranges this slice references.
+        auto batch_bytes = EstimateRecordBatchBytes(*batch);
 
         auto decode_future = pool.Submit([batch,
                                           column_name,

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -14,12 +14,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+#include <deque>
 #include <filesystem>
+#include <functional>
+#include <future>
 #include <memory>
 #include "common/FastMem.h"
 
 #include "arrow/array/builder_binary.h"
 #include "arrow/array/builder_nested.h"
+#include "arrow/util/byte_size.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/array/concatenate.h"
 #include "arrow/buffer_builder.h"
@@ -1550,15 +1555,16 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
     return field_data_list;
 }
 
-std::vector<FieldDataPtr>
-GetFieldDatasFromManifest(
+void
+IterateFieldDataFromManifest(
     const std::string& manifest_path,
     const std::shared_ptr<milvus_storage::api::Properties>& loon_ffi_properties,
     const FieldDataMeta& field_meta,
     std::optional<DataType> data_type,
     int64_t dim,
     std::optional<DataType> element_type,
-    std::optional<StorageColumnMapping> storage_column_mapping) {
+    std::optional<StorageColumnMapping> storage_column_mapping,
+    const std::function<void(FieldDataPtr)>& consumer) {
     auto loon_manifest = GetLoonManifest(manifest_path, loon_ffi_properties);
     auto column_groups = std::make_shared<milvus_storage::api::ColumnGroups>(
         loon_manifest->columnGroups());
@@ -1595,19 +1601,20 @@ GetFieldDatasFromManifest(
     };
     bool field_exists = column_exists(column_name);
     if (!field_exists) {
-        return {};
+        return;
     }
 
     std::vector<std::string> needed_columns = {column_name};
 
     bool nullable = field_meta.field_schema.nullable();
-    std::optional<FieldMeta> normalize_field_meta;
+    std::shared_ptr<const FieldMeta> normalize_field_meta;
     if (is_external) {
         auto schema = field_meta.field_schema;
         if (schema.fieldid() == 0) {
             schema.set_fieldid(field_meta.field_id);
         }
-        normalize_field_meta.emplace(FieldMeta::ParseFrom(schema));
+        normalize_field_meta =
+            std::make_shared<const FieldMeta>(FieldMeta::ParseFrom(schema));
     }
 
     // External tables: schemaless reader - let the reader derive types from
@@ -1655,11 +1662,78 @@ GetFieldDatasFromManifest(
 
     auto record_batch_reader = reader_result.ValueOrDie();
 
-    std::vector<FieldDataPtr> field_datas;
+    // Decode batches on the MIDDLE thread pool while this thread keeps
+    // draining the record batch reader. ReadNext must stay single-threaded
+    // (the reader is not thread-safe), but everything after it — external
+    // normalization plus FieldData materialization — is pure per-batch work
+    // and is the dominant cost. Offloading it keeps the reader thread free
+    // to trigger the next prefetch round, so network fetch and decode
+    // overlap instead of strictly alternating. Results are delivered to
+    // `consumer` on this thread in batch order; the bounded in-flight
+    // window provides backpressure so decoded-but-undelivered batches
+    // cannot pile up without limit.
+    //
+    // The window is bounded by bytes, not by batch count: a count-based cap
+    // scales with the pool size and the per-batch size, so on a large pool
+    // with 64MB batches it would admit gigabytes of decoded data per build
+    // (and several builds may run concurrently). The byte budget below caps
+    // the decoded-but-undelivered bytes regardless of batch size and thread
+    // count; at least two batches are always admitted so decode can still
+    // overlap with fetch when a single batch exceeds the budget.
+    auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::MIDDLE);
+    constexpr int64_t kMaxInflightBytes = 512LL << 20;
+    const size_t max_inflight_batches =
+        std::max<size_t>(2, pool.GetMaxThreadNum() * 2);
+    std::deque<std::pair<std::future<FieldDataPtr>, int64_t>> pending;
+    int64_t pending_bytes = 0;
+
+    // Phase accounting for the streaming loop, reported once at the end.
+    // fetch = ReadNext (network/prefetch wait), decode_wait = blocking on
+    // the decode future, consume = the consumer callback (for index build:
+    // the local disk write). The three phases run on this thread and are
+    // mutually exclusive, so comparing their totals against the wall time
+    // shows where the pipeline actually spends its time — in particular
+    // whether a blocking consumer is starving ReadNext (fetch_max grows)
+    // or the writes themselves are slow (consume dominates).
+    int64_t fetch_ns = 0, fetch_max_ns = 0;
+    int64_t decode_wait_ns = 0;
+    int64_t consume_ns = 0, consume_max_ns = 0;
+    int64_t total_batch_bytes = 0;
+    size_t batch_count = 0;
+    auto wall_start = std::chrono::steady_clock::now();
+    auto now_ns = []() {
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(
+                   std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+    };
+
+    auto deliver_front = [&]() {
+        auto t0 = now_ns();
+        auto field_data = pending.front().first.get();
+        auto t1 = now_ns();
+        pending_bytes -= pending.front().second;
+        pending.pop_front();
+        consumer(std::move(field_data));
+        auto t2 = now_ns();
+        decode_wait_ns += t1 - t0;
+        consume_ns += t2 - t1;
+        consume_max_ns = std::max(consume_max_ns, t2 - t1);
+    };
+
+    auto data_type_v = data_type.value();
+    auto element_type_v = element_type.value();
     while (true) {
         std::shared_ptr<arrow::RecordBatch> batch;
+        auto fetch_start = now_ns();
         auto status = record_batch_reader->ReadNext(&batch);
+        auto fetch_elapsed = now_ns() - fetch_start;
+        fetch_ns += fetch_elapsed;
+        fetch_max_ns = std::max(fetch_max_ns, fetch_elapsed);
         if (!status.ok()) {
+            // Drain workers before throwing so no task outlives this scope.
+            for (auto& f : pending) {
+                f.first.wait();
+            }
             auto error = milvus_storage::ToSegcoreError(status);
             ThrowInfo(error.get_error_code(),
                       "Failed to read record batch: {}",
@@ -1674,23 +1748,108 @@ GetFieldDatasFromManifest(
             continue;
         }
 
-        auto raw_column = batch->GetColumnByName(column_name);
-        if (is_external) {
-            raw_column =
-                NormalizeExternalArrowByType(raw_column,
-                                             data_type.value(),
-                                             dim,
-                                             nullable,
-                                             element_type.value(),
-                                             normalize_field_meta.value());
+        // Estimate the decoded footprint of this batch for the byte budget.
+        // The arrow buffers backing the batch are the best available proxy
+        // for the FieldData it will materialize into; fall back to the row
+        // count when the size cannot be computed.
+        int64_t batch_bytes = 0;
+        {
+            auto size_result = arrow::util::TotalBufferSize(*batch);
+            batch_bytes = size_result > 0 ? size_result : num_rows;
         }
-        auto chunked_array = std::make_shared<arrow::ChunkedArray>(raw_column);
-        auto field_data = CreateFieldData(
-            data_type.value(), element_type.value(), nullable, dim, num_rows);
-        field_data->FillFieldData(chunked_array);
-        field_datas.push_back(field_data);
+
+        auto decode_future = pool.Submit([batch,
+                                          column_name,
+                                          is_external,
+                                          data_type_v,
+                                          element_type_v,
+                                          dim,
+                                          nullable,
+                                          normalize_field_meta,
+                                          num_rows]() -> FieldDataPtr {
+            auto raw_column = batch->GetColumnByName(column_name);
+            if (is_external) {
+                raw_column =
+                    NormalizeExternalArrowByType(raw_column,
+                                                 data_type_v,
+                                                 dim,
+                                                 nullable,
+                                                 element_type_v,
+                                                 *normalize_field_meta);
+            }
+            auto chunked_array =
+                std::make_shared<arrow::ChunkedArray>(raw_column);
+            auto field_data = CreateFieldData(
+                data_type_v, element_type_v, nullable, dim, num_rows);
+            field_data->FillFieldData(chunked_array);
+            return field_data;
+        });
+        pending.emplace_back(std::move(decode_future), batch_bytes);
+        pending_bytes += batch_bytes;
+        total_batch_bytes += batch_bytes;
+        ++batch_count;
+
+        // Backpressure: block on the oldest batch once the window is full
+        // by bytes or by count. Always keep at least one in flight so a
+        // single oversized batch cannot deadlock the loop.
+        while (pending.size() > 1 && (pending_bytes > kMaxInflightBytes ||
+                                      pending.size() >= max_inflight_batches)) {
+            deliver_front();
+        }
+        // Opportunistically deliver whatever is already done, keeping
+        // consumer-side work (e.g. disk writes) interleaved with fetching.
+        while (!pending.empty() &&
+               pending.front().first.wait_for(std::chrono::seconds(0)) ==
+                   std::future_status::ready) {
+            deliver_front();
+        }
     }
 
+    while (!pending.empty()) {
+        deliver_front();
+    }
+
+    if (batch_count > 0) {
+        auto wall_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::steady_clock::now() - wall_start)
+                           .count();
+        LOG_INFO(
+            "[ManifestReadStats] column={} batches={} MB={} wall_ms={} "
+            "fetch_ms={} fetch_max_ms={} decode_wait_ms={} consume_ms={} "
+            "consume_max_ms={}",
+            column_name,
+            batch_count,
+            total_batch_bytes >> 20,
+            wall_ms,
+            fetch_ns / 1'000'000,
+            fetch_max_ns / 1'000'000,
+            decode_wait_ns / 1'000'000,
+            consume_ns / 1'000'000,
+            consume_max_ns / 1'000'000);
+    }
+}
+
+std::vector<FieldDataPtr>
+GetFieldDatasFromManifest(
+    const std::string& manifest_path,
+    const std::shared_ptr<milvus_storage::api::Properties>& loon_ffi_properties,
+    const FieldDataMeta& field_meta,
+    std::optional<DataType> data_type,
+    int64_t dim,
+    std::optional<DataType> element_type,
+    std::optional<StorageColumnMapping> storage_column_mapping) {
+    std::vector<FieldDataPtr> field_datas;
+    IterateFieldDataFromManifest(
+        manifest_path,
+        loon_ffi_properties,
+        field_meta,
+        data_type,
+        dim,
+        element_type,
+        std::move(storage_column_mapping),
+        [&](FieldDataPtr field_data) {
+            field_datas.push_back(std::move(field_data));
+        });
     return field_datas;
 }
 

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1676,10 +1676,22 @@ IterateFieldDataFromManifest(
     // The window is bounded by bytes, not by batch count: a count-based cap
     // scales with the pool size and the per-batch size, so on a large pool
     // with 64MB batches it would admit gigabytes of decoded data per build
-    // (and several builds may run concurrently). The byte budget below caps
-    // the decoded-but-undelivered bytes regardless of batch size and thread
-    // count; at least two batches are always admitted so decode can still
-    // overlap with fetch when a single batch exceeds the budget.
+    // (and several builds may run concurrently). The byte budget below bounds
+    // the window regardless of batch size and thread count; at least two
+    // batches are always admitted so decode can still overlap with fetch when
+    // a single batch exceeds the budget.
+    //
+    // What is charged is each batch's *input* arrow bytes
+    // (EstimateRecordBatchBytes on the source slice), not the decoded
+    // FieldData that actually accumulates in `pending`. For internal native
+    // types the two are close, but on the external path
+    // NormalizeExternalArrowByType can inflate the decoded footprint by a
+    // type-dependent factor, so peak retained bytes can exceed
+    // kMaxInflightBytes by roughly that factor. Charging post-decode would
+    // need the decode to finish before admission, which is exactly the
+    // serialization this pipeline exists to avoid; the accounting is
+    // symmetric (deliver_front discharges what emplace_back charged), so this
+    // is a looser bound, not a leak.
     //
     // The decode tasks go to the LOW pool, not MIDDLE. Every production
     // caller of this function is an index build (DiskFileManagerImpl /
@@ -1779,7 +1791,8 @@ IterateFieldDataFromManifest(
             continue;
         }
 
-        // Estimate the decoded footprint of this slice for the byte budget.
+        // Charge this slice's arrow input bytes against the byte budget (see
+        // the note on the budget above for why input, not decoded, bytes).
         // A record batch may share a large row-group backing buffer with
         // adjacent slices, so count only the ranges this slice references.
         auto batch_bytes = EstimateRecordBatchBytes(*batch);

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1564,7 +1564,11 @@ IterateFieldDataFromManifest(
     int64_t dim,
     std::optional<DataType> element_type,
     std::optional<StorageColumnMapping> storage_column_mapping,
-    const std::function<void(FieldDataPtr)>& consumer) {
+    const std::function<void(FieldDataPtr)>& consumer,
+    int64_t max_inflight_bytes) {
+    AssertInfo(max_inflight_bytes > 0,
+               "max_inflight_bytes must be positive, got {}",
+               max_inflight_bytes);
     auto loon_manifest = GetLoonManifest(manifest_path, loon_ffi_properties);
     auto column_groups = std::make_shared<milvus_storage::api::ColumnGroups>(
         loon_manifest->columnGroups());
@@ -1687,11 +1691,22 @@ IterateFieldDataFromManifest(
     // types the two are close, but on the external path
     // NormalizeExternalArrowByType can inflate the decoded footprint by a
     // type-dependent factor, so peak retained bytes can exceed
-    // kMaxInflightBytes by roughly that factor. Charging post-decode would
+    // max_inflight_bytes by roughly that factor. Charging post-decode would
     // need the decode to finish before admission, which is exactly the
     // serialization this pipeline exists to avoid; the accounting is
     // symmetric (deliver_front discharges what emplace_back charged), so this
     // is a looser bound, not a leak.
+    //
+    // The budget is a parameter because what it buys depends on the caller.
+    // For a streaming consumer (DiskFileManagerImpl spilling to local disk)
+    // the window *replaces* full-column retention, so a large one is a net
+    // reduction. For an accumulating caller — GetFieldDatasFromManifest, and
+    // through it every storage-v3 index build that goes via
+    // MemFileManagerImpl — the whole column is retained regardless, so the
+    // window only adds the source arrow batches that in-flight futures keep
+    // alive: pure extra peak RSS, on top of a column the Go-side build memory
+    // estimate already sized without it. Those callers pass
+    // kAccumulatingInflightBytes.
     //
     // The decode tasks go to the LOW pool, not MIDDLE. Every production
     // caller of this function is an index build (DiskFileManagerImpl /
@@ -1706,7 +1721,6 @@ IterateFieldDataFromManifest(
     // so this function must not be called from a LOW-pool thread. Index
     // build tasks enter segcore from Go, so no caller does today.
     auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::LOW);
-    constexpr int64_t kMaxInflightBytes = 512LL << 20;
     const size_t max_inflight_batches =
         std::max<size_t>(2, pool.GetMaxThreadNum() * 2);
     std::deque<std::pair<std::future<FieldDataPtr>, int64_t>> pending;
@@ -1831,7 +1845,7 @@ IterateFieldDataFromManifest(
         // Backpressure: block on the oldest batch once the window is full
         // by bytes or by count. Always keep at least one in flight so a
         // single oversized batch cannot deadlock the loop.
-        while (pending.size() > 1 && (pending_bytes > kMaxInflightBytes ||
+        while (pending.size() > 1 && (pending_bytes > max_inflight_bytes ||
                                       pending.size() >= max_inflight_batches)) {
             deliver_front();
         }
@@ -1888,7 +1902,12 @@ GetFieldDatasFromManifest(
         std::move(storage_column_mapping),
         [&](FieldDataPtr field_data) {
             field_datas.push_back(std::move(field_data));
-        });
+        },
+        // Every decoded batch is retained below, so a large in-flight window
+        // would only pin extra source arrow batches on top of the full
+        // column. Keep it small; overlap still happens, the peak does not
+        // grow by half a gigabyte per concurrent build.
+        kAccumulatingInflightBytes);
     return field_datas;
 }
 

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1700,6 +1700,26 @@ IterateFieldDataFromManifest(
     std::deque<std::pair<std::future<FieldDataPtr>, int64_t>> pending;
     int64_t pending_bytes = 0;
 
+    // No decode task may outlive this scope, on any exit path: ReadNext
+    // failing, a decode task rethrowing out of future::get(), or `consumer`
+    // throwing (for index build it writes to local disk). Only the first of
+    // those used to drain, which is safe today solely because the decode
+    // lambda below captures everything by value; a scope guard makes the
+    // guarantee structural instead of something every future edit has to
+    // re-derive. A future already consumed by a throwing get() is invalid
+    // and is skipped.
+    struct PendingDrainGuard {
+        std::deque<std::pair<std::future<FieldDataPtr>, int64_t>>& pending;
+
+        ~PendingDrainGuard() {
+            for (auto& entry : pending) {
+                if (entry.first.valid()) {
+                    entry.first.wait();
+                }
+            }
+        }
+    } pending_drain_guard{pending};
+
     // Phase accounting for the streaming loop, reported once at the end.
     // fetch = ReadNext (network/prefetch wait), decode_wait = blocking on
     // the decode future, consume = the consumer callback (for index build:
@@ -1743,10 +1763,8 @@ IterateFieldDataFromManifest(
         fetch_ns += fetch_elapsed;
         fetch_max_ns = std::max(fetch_max_ns, fetch_elapsed);
         if (!status.ok()) {
-            // Drain workers before throwing so no task outlives this scope.
-            for (auto& f : pending) {
-                f.first.wait();
-            }
+            // pending_drain_guard waits for the outstanding decode tasks
+            // while this throw unwinds.
             auto error = milvus_storage::ToSegcoreError(status);
             ThrowInfo(error.get_error_code(),
                       "Failed to read record batch: {}",

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1662,7 +1662,7 @@ IterateFieldDataFromManifest(
 
     auto record_batch_reader = reader_result.ValueOrDie();
 
-    // Decode batches on the MIDDLE thread pool while this thread keeps
+    // Decode batches on a background thread pool while this thread keeps
     // draining the record batch reader. ReadNext must stay single-threaded
     // (the reader is not thread-safe), but everything after it — external
     // normalization plus FieldData materialization — is pure per-batch work
@@ -1680,7 +1680,20 @@ IterateFieldDataFromManifest(
     // the decoded-but-undelivered bytes regardless of batch size and thread
     // count; at least two batches are always admitted so decode can still
     // overlap with fetch when a single batch exceeds the budget.
-    auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::MIDDLE);
+    //
+    // The decode tasks go to the LOW pool, not MIDDLE. Every production
+    // caller of this function is an index build (DiskFileManagerImpl /
+    // MemFileManagerImpl), i.e. background batch work, while MIDDLE is where
+    // ReduceHelper submits search reduce tasks and then blocks on
+    // future.get(). In standalone both share one ThreadPools singleton, so
+    // submitting a whole decode window to MIDDLE would queue CPU-bound
+    // tasks ahead of reduce and hold search latency up for the entire
+    // download phase. LOW carries only background segment loads and, being
+    // CPU_NUM-sized, still saturates the cores for this CPU-bound decode.
+    // Invariant this relies on: the calling thread blocks on decode futures,
+    // so this function must not be called from a LOW-pool thread. Index
+    // build tasks enter segcore from Go, so no caller does today.
+    auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::LOW);
     constexpr int64_t kMaxInflightBytes = 512LL << 20;
     const size_t max_inflight_batches =
         std::max<size_t>(2, pool.GetMaxThreadNum() * 2);

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -25,6 +25,7 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <functional>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -321,6 +322,28 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
                            DataType element_type,
                            int64_t dim,
                            milvus_storage::ArrowFileSystemPtr fs);
+
+// Streams the field's data out of a storage-v3 manifest batch by batch,
+// invoking `consumer` on the calling thread in batch order. Batch decoding
+// (external-type normalization + FieldData materialization) runs in
+// parallel on the MIDDLE thread pool and overlaps with the reader's next
+// prefetch round. Decoded-but-undelivered batches are bounded by a byte
+// budget, so this caps the decode window only — the reader's own prefetch
+// window, arrow's buffers and the consumer's own retention are additional
+// and concurrent builds multiply all of them. Prefer this over
+// GetFieldDatasFromManifest when the caller can process batches
+// incrementally (e.g. spilling to a local file) instead of holding the
+// whole column in memory.
+void
+IterateFieldDataFromManifest(
+    const std::string& manifest_path,
+    const std::shared_ptr<milvus_storage::api::Properties>& loon_ffi_properties,
+    const FieldDataMeta& field_meta,
+    std::optional<DataType> data_type,
+    int64_t dim,
+    std::optional<DataType> element_type,
+    std::optional<StorageColumnMapping> storage_column_mapping,
+    const std::function<void(FieldDataPtr)>& consumer);
 
 std::vector<FieldDataPtr>
 GetFieldDatasFromManifest(

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -326,7 +326,7 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
 // Streams the field's data out of a storage-v3 manifest batch by batch,
 // invoking `consumer` on the calling thread in batch order. Batch decoding
 // (external-type normalization + FieldData materialization) runs in
-// parallel on the MIDDLE thread pool and overlaps with the reader's next
+// parallel on the LOW (background) thread pool and overlaps with the next
 // prefetch round. Decoded-but-undelivered batches are bounded by a byte
 // budget, so this caps the decode window only — the reader's own prefetch
 // window, arrow's buffers and the consumer's own retention are additional

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -327,10 +327,12 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
 // invoking `consumer` on the calling thread in batch order. Batch decoding
 // (external-type normalization + FieldData materialization) runs in
 // parallel on the LOW (background) thread pool and overlaps with the next
-// prefetch round. Decoded-but-undelivered batches are bounded by a byte
-// budget, so this caps the decode window only — the reader's own prefetch
+// prefetch round. The number of undelivered batches is bounded by a byte
+// budget charged on each batch's *input* arrow bytes, so it caps the decode
+// window only, and only in input terms: normalization can inflate the
+// decoded FieldData beyond its arrow source, and the reader's own prefetch
 // window, arrow's buffers and the consumer's own retention are additional
-// and concurrent builds multiply all of them. Prefer this over
+// on top. Concurrent builds multiply all of them. Prefer this over
 // GetFieldDatasFromManifest when the caller can process batches
 // incrementally (e.g. spilling to a local file) instead of holding the
 // whole column in memory.

--- a/internal/core/src/storage/Util.h
+++ b/internal/core/src/storage/Util.h
@@ -336,6 +336,20 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
 // GetFieldDatasFromManifest when the caller can process batches
 // incrementally (e.g. spilling to a local file) instead of holding the
 // whole column in memory.
+//
+// `max_inflight_bytes` sizes that window. For a streaming caller it replaces
+// full-column retention, so the default is generous; a caller that retains
+// everything anyway (see kAccumulatingInflightBytes) gains nothing from a
+// large window and should pass a small one, because for it the window is
+// pure additional peak memory on top of the column.
+constexpr int64_t kStreamingInflightBytes = 512LL << 20;
+
+// Window for callers that accumulate the whole column regardless. The decoded
+// batches are retained either way, so the only memory the window adds is the
+// source arrow batches held alive by in-flight decode futures; a few batches
+// are enough to keep fetch and decode overlapped.
+constexpr int64_t kAccumulatingInflightBytes = 64LL << 20;
+
 void
 IterateFieldDataFromManifest(
     const std::string& manifest_path,
@@ -345,7 +359,8 @@ IterateFieldDataFromManifest(
     int64_t dim,
     std::optional<DataType> element_type,
     std::optional<StorageColumnMapping> storage_column_mapping,
-    const std::function<void(FieldDataPtr)>& consumer);
+    const std::function<void(FieldDataPtr)>& consumer,
+    int64_t max_inflight_bytes = kStreamingInflightBytes);
 
 std::vector<FieldDataPtr>
 GetFieldDatasFromManifest(

--- a/internal/core/src/storage/loon_ffi/property_singleton.h
+++ b/internal/core/src/storage/loon_ffi/property_singleton.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -26,6 +27,14 @@
 #include "util.h"
 
 namespace milvus::storage {
+
+// Arrow parquet prebuffer range-coalescing limits. Published and consumed as
+// one unit: the parquet reader validates range_size_limit > hole_size_limit,
+// so a mix of values from two generations is rejected downstream.
+struct ArrowReaderLimits {
+    int64_t hole_size_limit_bytes = 0;
+    int64_t range_size_limit_bytes = 0;
+};
 
 class LoonFFIPropertiesSingleton {
  private:
@@ -62,9 +71,18 @@ class LoonFFIPropertiesSingleton {
     void
     SetArrowReaderConfig(int64_t hole_size_limit_bytes,
                          int64_t range_size_limit_bytes) {
+        // Publish both limits as one snapshot. They are validated against
+        // each other downstream (the parquet reader rejects
+        // range_size_limit <= hole_size_limit), so a reader must never
+        // observe one value from the new generation and the other from the
+        // old one — e.g. updating 1MiB/4MiB to 8MiB/16MiB could otherwise
+        // transiently expose 8MiB/4MiB and fail the build task.
+        {
+            std::unique_lock cfg_lck(config_mutex_);
+            arrow_reader_limits_ = {hole_size_limit_bytes,
+                                    range_size_limit_bytes};
+        }
         std::unique_lock lck(mutex_);
-        arrow_reader_hole_size_limit_bytes_ = hole_size_limit_bytes;
-        arrow_reader_range_size_limit_bytes_ = range_size_limit_bytes;
         if (properties_ != nullptr) {
             auto properties =
                 std::make_shared<milvus_storage::api::Properties>(*properties_);
@@ -79,23 +97,74 @@ class LoonFFIPropertiesSingleton {
         return properties_;
     }
 
- private:
+    // Sets the per-round read window (loon's reader.record_batch_max_size)
+    // applied to index-build manifest reads. 0 keeps loon's built-in default
+    // (32MB, which admits only one 64MB-class row group per prefetch round
+    // and therefore serializes the raw-data download to one S3 GET at a
+    // time). Applied per task via ApplyIndexBuildReadWindow — deliberately
+    // NOT part of ApplyArrowReaderConfig so query-node load paths keep
+    // their small default window.
+    void
+    SetIndexBuildReadWindow(int64_t window_bytes) {
+        index_build_read_window_bytes_.store(window_bytes,
+                                             std::memory_order_relaxed);
+    }
+
+    int64_t
+    GetIndexBuildReadWindow() const {
+        return index_build_read_window_bytes_.load(std::memory_order_relaxed);
+    }
+
+    // Stamps the index-build read window into `properties` when configured
+    // (> 0). Lock-free; no-op when unset so loon's default applies.
+    void
+    ApplyIndexBuildReadWindow(
+        milvus_storage::api::Properties& properties) const {
+        auto window =
+            index_build_read_window_bytes_.load(std::memory_order_relaxed);
+        if (window <= 0) {
+            return;
+        }
+        milvus_storage::api::SetValue(properties,
+                                      PROPERTY_READER_RECORD_BATCH_MAX_SIZE,
+                                      std::to_string(window).c_str());
+    }
+
+    // Returns the currently published limits as one coherent snapshot.
+    ArrowReaderLimits
+    GetArrowReaderLimits() const {
+        std::shared_lock cfg_lck(config_mutex_);
+        return arrow_reader_limits_;
+    }
+
+    // Applies the configured arrow reader prebuffer limits to `properties`.
+    // Reads one coherent snapshot, so the two values always come from the
+    // same generation. Guarded by config_mutex_ rather than mutex_, so it
+    // stays callable from MakeInternalPropertiesFromStorageConfig while
+    // Init holds mutex_ (lock order is always mutex_ -> config_mutex_;
+    // SetArrowReaderConfig releases config_mutex_ before taking mutex_).
+    // A value of 0 means "keep the arrow default" downstream.
     void
     ApplyArrowReaderConfig(milvus_storage::api::Properties& properties) const {
+        auto limits = GetArrowReaderLimits();
         milvus_storage::api::SetValue(
             properties,
             PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT,
-            std::to_string(arrow_reader_hole_size_limit_bytes_).c_str());
+            std::to_string(limits.hole_size_limit_bytes).c_str());
         milvus_storage::api::SetValue(
             properties,
             PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT,
-            std::to_string(arrow_reader_range_size_limit_bytes_).c_str());
+            std::to_string(limits.range_size_limit_bytes).c_str());
     }
 
+ private:
     mutable std::shared_mutex mutex_;
     std::shared_ptr<milvus_storage::api::Properties> properties_ = nullptr;
-    int64_t arrow_reader_hole_size_limit_bytes_ = 0;
-    int64_t arrow_reader_range_size_limit_bytes_ = 0;
+    // Guards arrow_reader_limits_ only. Separate from mutex_ so the limits
+    // can be read while mutex_ is held; see ApplyArrowReaderConfig.
+    mutable std::shared_mutex config_mutex_;
+    ArrowReaderLimits arrow_reader_limits_{};
+    std::atomic<int64_t> index_build_read_window_bytes_{0};
 };
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -41,6 +41,7 @@
 #include "nlohmann/json_fwd.hpp"
 #include "storage/Types.h"
 #include "storage/loon_ffi/external_spec_c.h"
+#include "storage/loon_ffi/property_singleton.h"
 #include "storage/loon_ffi/util.h"
 
 using json = nlohmann::json;
@@ -257,6 +258,16 @@ MakeInternalPropertiesFromStorageConfig(CStorageConfig c_storage_config) {
         *properties_map,
         PROPERTY_FS_USE_CRC32C_CHECKSUM,
         c_storage_config.use_crc32c_checksum ? "true" : "false");
+
+    // Carry the configured arrow reader prebuffer limits into every
+    // freshly-built properties map. Index build (index_c.cpp) and the FFI
+    // readers construct properties per task through this helper instead of
+    // going through LoonFFIPropertiesSingleton's cached map, so without this
+    // the common.arrow.reader.* configuration never reaches those reads and
+    // external-table index builds are stuck with arrow's default range
+    // coalescing (effectively one in-flight S3 range per file).
+    milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+        .ApplyArrowReaderConfig(*properties_map);
 
     return properties_map;
 }

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -124,10 +124,18 @@ MakePropertiesFromStorageConfig(CStorageConfig c_storage_config) {
     keys.emplace_back(PROPERTY_FS_REQUEST_TIMEOUT_MS);
     values.emplace_back(timeout_str.c_str());
 
+    // 0 means "not set by the producer": leave the key absent so
+    // milvus-storage applies its registered default (100) instead of taking an
+    // explicit 0, which would drop the S3 connection cap to
+    // max(io_capacity, 25) and change the filesystem cache key. Same
+    // convention as ChunkManager.cpp / MinioChunkManager.cpp and the Go
+    // producer in storagev2/packed/ffi_common.go.
     std::string max_connections_str =
         std::to_string(c_storage_config.max_connections);
-    keys.emplace_back(PROPERTY_FS_MAX_CONNECTIONS);
-    values.emplace_back(max_connections_str.c_str());
+    if (c_storage_config.max_connections > 0) {
+        keys.emplace_back(PROPERTY_FS_MAX_CONNECTIONS);
+        values.emplace_back(max_connections_str.c_str());
+    }
 
     if (c_storage_config.tls_min_version != nullptr) {
         std::string tls_ver(c_storage_config.tls_min_version);
@@ -243,10 +251,13 @@ MakeInternalPropertiesFromStorageConfig(CStorageConfig c_storage_config) {
         *properties_map,
         PROPERTY_FS_REQUEST_TIMEOUT_MS,
         std::to_string(c_storage_config.requestTimeoutMs).c_str());
-    milvus_storage::api::SetValue(
-        *properties_map,
-        PROPERTY_FS_MAX_CONNECTIONS,
-        std::to_string(c_storage_config.max_connections).c_str());
+    // Absent when unset -- see the note in MakePropertiesFromStorageConfig.
+    if (c_storage_config.max_connections > 0) {
+        milvus_storage::api::SetValue(
+            *properties_map,
+            PROPERTY_FS_MAX_CONNECTIONS,
+            std::to_string(c_storage_config.max_connections).c_str());
+    }
 
     if (c_storage_config.tls_min_version != nullptr) {
         std::string tls_ver(c_storage_config.tls_min_version);
@@ -535,12 +546,22 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
     // kAllowedExtfsSpecKeys nor derived from the URI, so no other layer
     // writes them; it sits next to Layer 0 because both are defaults rather
     // than external-source-derived values.
+    // "0" is treated as unset, like the empty string: for every fs.* tunable
+    // inherited here, 0 means "producer did not set it" (the convention in
+    // ChunkManager.cpp, MinioChunkManager.cpp and the Go producer). Mirroring
+    // it would be worse than not mirroring at all — before this key existed on
+    // the extfs side, ExtractExternalFsProperties fell back to the library
+    // default (100 connections), whereas an explicit "0" overrides it and
+    // caps the external S3 client at max(io_capacity, 25). The producers are
+    // guarded too; this is the last line of defence for the read path this
+    // whole change exists to widen.
     for (const auto& [fs_key, extfs_suffix] : kExtfsInheritedFsFields) {
-        if (auto value = PropertyValueAsString(properties, fs_key)) {
-            milvus_storage::api::SetValue(properties,
-                                          (extfs_prefix + extfs_suffix).c_str(),
-                                          value->c_str());
+        auto value = PropertyValueAsString(properties, fs_key);
+        if (!value.has_value() || *value == "0") {
+            continue;
         }
+        milvus_storage::api::SetValue(
+            properties, (extfs_prefix + extfs_suffix).c_str(), value->c_str());
     }
 
     // Layer 1: derive bucket / address / storage_type / use_ssl from URI.

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -328,9 +328,6 @@ static const std::vector<std::pair<std::string, bool /*is_bool*/>>
         {"use_iam", true},
         {"use_virtual_host", true},
         {"anonymous", true},
-        // Not derived from the external source or its spec — mirrored from
-        // the process-level fs.max_connections. See kExtfsInheritedFsFields.
-        {"max_connections", false},
 };
 
 // kExtfsInheritedFsFields lists fs.* properties that extfs.{collectionID}.*

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -18,11 +18,14 @@
 #include <initializer_list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "arrow/result.h"
@@ -325,7 +328,58 @@ static const std::vector<std::pair<std::string, bool /*is_bool*/>>
         {"use_iam", true},
         {"use_virtual_host", true},
         {"anonymous", true},
+        // Not derived from the external source or its spec — mirrored from
+        // the process-level fs.max_connections. See kExtfsInheritedFsFields.
+        {"max_connections", false},
 };
+
+// kExtfsInheritedFsFields lists fs.* properties that extfs.{collectionID}.*
+// inherits verbatim from the process-level storage config.
+//
+// milvus-storage builds each external filesystem purely from its own
+// extfs.<name>.* keys (ExtractExternalFsProperties) — there is no fallback to
+// fs.*, and a missing key silently takes the library's built-in default. So
+// anything that is server-side capacity/tuning config rather than part of the
+// external source's identity has to be copied across explicitly, or it is a
+// no-op on every external read.
+//
+// These are deliberately NOT in kAllowedExtfsSpecKeys: they come from
+// milvus.yaml, not from a user-supplied external_spec.
+static const std::vector<
+    std::pair<const char* /*fs key*/, const char* /*extfs suffix*/>>
+    kExtfsInheritedFsFields = {
+        {PROPERTY_FS_MAX_CONNECTIONS, "max_connections"},
+};
+
+// PropertyValueAsString renders a PropertyVariant back to the string form
+// SetValue accepts. Both variant shapes reach here: the C++ index-build path
+// goes through SetValue, which stores registry-typed values (max_connections
+// is UINT32), while loon_properties_inject_external_spec rebuilds the map
+// from a flat LoonProperties and stores everything as std::string.
+static std::optional<std::string>
+PropertyValueAsString(const milvus_storage::api::Properties& properties,
+                      const char* key) {
+    auto it = properties.find(key);
+    if (it == properties.end()) {
+        return std::nullopt;
+    }
+    return std::visit(
+        [](const auto& v) -> std::optional<std::string> {
+            using T = std::decay_t<decltype(v)>;
+            if constexpr (std::is_same_v<T, std::string>) {
+                return v.empty() ? std::nullopt : std::optional<std::string>(v);
+            } else if constexpr (std::is_same_v<T, bool>) {
+                return std::optional<std::string>(v ? "true" : "false");
+            } else if constexpr (std::is_integral_v<T>) {
+                return std::optional<std::string>(std::to_string(v));
+            } else {
+                // vector<string> / nullptr_t: no scalar rendering, and no
+                // inherited field uses them.
+                return std::nullopt;
+            }
+        },
+        it->second);
+}
 
 static std::string
 DeriveUseSSLFromScheme(const std::string& scheme) {
@@ -476,6 +530,19 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
     for (const auto& [name, is_bool] : kExtfsFields) {
         if (is_bool && name != "anonymous") {
             properties[extfs_prefix + name] = std::string("false");
+        }
+    }
+
+    // Layer 0b: inherit process-level fs.* tuning. Position relative to the
+    // later layers is arbitrary — none of these keys is in
+    // kAllowedExtfsSpecKeys nor derived from the URI, so no other layer
+    // writes them; it sits next to Layer 0 because both are defaults rather
+    // than external-source-derived values.
+    for (const auto& [fs_key, extfs_suffix] : kExtfsInheritedFsFields) {
+        if (auto value = PropertyValueAsString(properties, fs_key)) {
+            milvus_storage::api::SetValue(properties,
+                                          (extfs_prefix + extfs_suffix).c_str(),
+                                          value->c_str());
         }
     }
 

--- a/internal/core/src/storage/storage_c.cpp
+++ b/internal/core/src/storage/storage_c.cpp
@@ -33,6 +33,7 @@
 #include "storage/KeyRetriever.h"
 #include "storage/Types.h"
 #include "storage/loon_ffi/property_singleton.h"
+#include "milvus-storage/thread_pool.h"
 
 CStatus
 GetLocalUsedSize(const char* c_dir, int64_t* size) {
@@ -193,6 +194,62 @@ InitArrowReaderConfig(CArrowReaderConfig c_arrow_reader_config) {
         milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
             .SetArrowReaderConfig(c_arrow_reader_config.hole_size_limit_bytes,
                                   c_arrow_reader_config.range_size_limit_bytes);
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
+InitLoonReaderThreadPool(int32_t num_threads) {
+    try {
+        if (num_threads < 0) {
+            return milvus::FailureCStatus(
+                milvus::ConfigInvalid,
+                "loon reader thread pool size must be non-negative");
+        }
+        // 0 = leave the pool uninitialized (loon reads stay sequential,
+        // the pre-existing behavior). Non-zero values resize an existing
+        // pool in either direction, but 0 cannot destroy it, so a rollback
+        // to 0 is a no-op — callers must surface
+        // GetLoonReaderThreadPoolSize() rather than the requested value,
+        // otherwise the rollback looks applied while the old pool is still
+        // serving reads.
+        if (num_threads == 0) {
+            return milvus::SuccessCStatus();
+        }
+        milvus_storage::ThreadPoolHolder::WithSingleton(num_threads);
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+int32_t
+GetLoonReaderThreadPoolSize() {
+    return static_cast<int32_t>(
+        milvus_storage::ThreadPoolHolder::GetParallelism());
+}
+
+CStatus
+InitIndexBuildReadWindow(int64_t window_bytes) {
+    try {
+        if (window_bytes < 0) {
+            return milvus::FailureCStatus(
+                milvus::ConfigInvalid,
+                "index build read window must be non-negative");
+        }
+        // milvus-storage validates reader.record_batch_max_size in
+        // [1, 4GB]; reject out-of-range here so a bad config fails at
+        // init/update time instead of at the first build task.
+        constexpr int64_t kMaxWindowBytes = 4LL * 1024 * 1024 * 1024;
+        if (window_bytes > kMaxWindowBytes) {
+            return milvus::FailureCStatus(
+                milvus::ConfigInvalid,
+                "index build read window must not exceed 4GB");
+        }
+        milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+            .SetIndexBuildReadWindow(window_bytes);
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);

--- a/internal/core/src/storage/storage_c.h
+++ b/internal/core/src/storage/storage_c.h
@@ -48,6 +48,19 @@ InitDiskFileWriterConfig(CDiskWriteConfig c_disk_write_config);
 CStatus
 InitArrowReaderConfig(CArrowReaderConfig c_arrow_reader_config);
 
+CStatus
+InitLoonReaderThreadPool(int32_t num_threads);
+
+// Returns the effective loon reader thread pool size: the number of threads
+// actually in use, which is 1 (no pool) until one is created. Needed because
+// the pool cannot be destroyed at runtime, so a requested size of 0 after
+// creation is a no-op and callers must report what is really in effect.
+int32_t
+GetLoonReaderThreadPoolSize();
+
+CStatus
+InitIndexBuildReadWindow(int64_t window_bytes);
+
 // Plugin related APIs
 CStatus
 InitPluginLoader(const char* plugin_path);

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -2991,6 +2991,51 @@ TEST(InjectExtfsInheritedFields, MaxConnectionsAbsentWhenUnset) {
     EXPECT_EQ(props.count("extfs.42.max_connections"), 0u);
 }
 
+// Present-but-zero must be treated as unset, in both variant shapes. A
+// producer that leaves MaxConnections at 0 -- a pre-upgrade DataCoord, or
+// common.storageType=local while the external data lives on S3 -- would
+// otherwise have that 0 mirrored into the extfs scope, where it *overrides*
+// milvus-storage's registered default of 100 and caps the external S3 client
+// at max(io_capacity, 25). Leaving the key absent keeps the 100.
+TEST(InjectExtfsInheritedFields, MaxConnectionsZeroTreatedAsUnset) {
+    {
+        milvus_storage::api::Properties props;
+        props["fs.max_connections"] = std::string("0");
+
+        ::InjectExternalSpecProperties(props, 42, "s3://my-bucket/key", "");
+
+        EXPECT_EQ(props.count("extfs.42.max_connections"), 0u)
+            << "string \"0\" must not be mirrored";
+    }
+    {
+        milvus_storage::api::Properties props;
+        props["fs.max_connections"] = uint32_t(0);
+
+        ::InjectExternalSpecProperties(props, 42, "s3://my-bucket/key", "");
+
+        EXPECT_EQ(props.count("extfs.42.max_connections"), 0u)
+            << "integral 0 must not be mirrored either";
+    }
+}
+
+// The producers themselves must not emit fs.max_connections when unset, so the
+// zero never reaches the extfs mirror (or the internal bucket's S3 client) in
+// the first place.
+TEST(MakePropertiesFromStorageConfig, MaxConnectionsZeroOmitted) {
+    CStorageConfig config{};
+    config.max_connections = 0;
+    auto props = MakeInternalPropertiesFromStorageConfig(config);
+    ASSERT_NE(props, nullptr);
+    EXPECT_EQ(props->count(PROPERTY_FS_MAX_CONNECTIONS), 0u);
+
+    config.max_connections = 237;
+    auto props_set = MakeInternalPropertiesFromStorageConfig(config);
+    ASSERT_NE(props_set, nullptr);
+    ASSERT_EQ(props_set->count(PROPERTY_FS_MAX_CONNECTIONS), 1u);
+    EXPECT_EQ(std::get<uint32_t>(props_set->at(PROPERTY_FS_MAX_CONNECTIONS)),
+              uint32_t(237));
+}
+
 // max_connections is server-side capacity config, not part of the external
 // source's identity: a user-supplied external_spec must not be able to set it.
 TEST(InjectExtfsInheritedFields, MaxConnectionsNotOverridableBySpec) {

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -2946,6 +2946,65 @@ TEST(InjectExtfsAllowlist, NoBaselineLeakFromFsProperties) {
               "MILVUS_INTERNAL_AK");
 }
 
+// minio.maxConnections must reach the external read path. milvus-storage
+// builds each external filesystem from its extfs.<name>.* keys alone, with no
+// fs.* fallback, so without this mirroring the setting is a silent no-op on
+// every external read and the library's built-in default applies instead.
+// The Go FFI path (loon_properties_inject_external_spec) rebuilds the map from
+// a flat LoonProperties, so fs.max_connections arrives as a std::string.
+TEST(InjectExtfsInheritedFields, MaxConnectionsMirroredFromStringVariant) {
+    milvus_storage::api::Properties props;
+    props["fs.max_connections"] = std::string("237");
+
+    ::InjectExternalSpecProperties(props, 42, "s3://my-bucket/key", "");
+
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.max_connections")),
+              "237");
+    // The fs.* baseline is left intact for the Milvus-internal bucket.
+    EXPECT_EQ(std::get<std::string>(props.at("fs.max_connections")), "237");
+}
+
+// The C++ index-build path goes through MakeInternalPropertiesFromStorageConfig
+// -> api::SetValue, which resolves fs.max_connections against the registry and
+// stores it as UINT32 rather than a string.
+TEST(InjectExtfsInheritedFields, MaxConnectionsMirroredFromTypedVariant) {
+    milvus_storage::api::Properties props;
+    ASSERT_EQ(
+        milvus_storage::api::SetValue(props, PROPERTY_FS_MAX_CONNECTIONS, "64"),
+        std::nullopt);
+    ASSERT_TRUE(
+        std::holds_alternative<uint32_t>(props.at("fs.max_connections")))
+        << "precondition: the registry types fs.max_connections as UINT32";
+
+    ::InjectExternalSpecProperties(props, 7, "s3://my-bucket/key", "");
+
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.7.max_connections")), "64");
+}
+
+// Nothing to inherit: the key stays absent so milvus-storage applies its own
+// default instead of a bogus zero.
+TEST(InjectExtfsInheritedFields, MaxConnectionsAbsentWhenUnset) {
+    milvus_storage::api::Properties props;
+
+    ::InjectExternalSpecProperties(props, 42, "s3://my-bucket/key", "");
+
+    EXPECT_EQ(props.count("extfs.42.max_connections"), 0u);
+}
+
+// max_connections is server-side capacity config, not part of the external
+// source's identity: a user-supplied external_spec must not be able to set it.
+TEST(InjectExtfsInheritedFields, MaxConnectionsNotOverridableBySpec) {
+    milvus_storage::api::Properties props;
+    props["fs.max_connections"] = std::string("100");
+    std::string spec =
+        R"({"format":"parquet","extfs":{"max_connections":"9999"}})";
+
+    ::InjectExternalSpecProperties(props, 42, "s3://my-bucket/key", spec);
+
+    EXPECT_EQ(std::get<std::string>(props.at("extfs.42.max_connections")),
+              "100");
+}
+
 // Azure endpoint derivation: AWS-form URI with cp=azure + region resolves via
 // DeriveEndpoint to the sovereign-cloud bare authority. Swap relocates URI
 // host (container) into bucket_name. AzureFileSystemProducer requires

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -435,6 +435,42 @@ TEST_F(StorageTest, RecordBatchSizeAccountsForReferencedSlice) {
     EXPECT_EQ(first_bytes + second_bytes, backing_bytes);
 }
 
+// Arrow's byte-range visitor has no overload for the view layouts, so
+// ReferencedBufferSize fails outright for a batch containing one — and the
+// external (vortex schemaless) reader produces exactly those, on the
+// pre-normalization batch the in-flight budget is charged from. Falling back
+// to the row count there would charge a multi-MB batch as a few thousand
+// bytes and disable byte backpressure; the estimate must stay in bytes.
+TEST_F(StorageTest, RecordBatchSizeHandlesArrowViewTypes) {
+    constexpr int64_t kRows = 4096;
+    const std::string value(256, 'x');
+
+    arrow::StringViewBuilder builder;
+    ASSERT_TRUE(builder.Reserve(kRows).ok());
+    for (int64_t i = 0; i < kRows; ++i) {
+        ASSERT_TRUE(builder.Append(value).ok());
+    }
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(builder.Finish(&values).ok());
+
+    auto batch = arrow::RecordBatch::Make(
+        arrow::schema({arrow::field("value", arrow::utf8_view())}),
+        kRows,
+        {values});
+
+    // Precondition: this is the layout arrow cannot walk. If a future arrow
+    // bump adds the overload, this assertion flips and the fallback below
+    // stops being the code under test — fail loudly rather than silently.
+    EXPECT_FALSE(arrow::util::ReferencedBufferSize(*batch).ok())
+        << "arrow now supports view types; revisit the fallback";
+
+    auto estimated = EstimateRecordBatchBytes(*batch);
+    EXPECT_EQ(estimated, arrow::util::TotalBufferSize(*batch));
+    // The real payload is ~1MB; the row count would have been 4096.
+    EXPECT_GT(estimated, kRows * 10)
+        << "view-typed batch must not be charged its row count";
+}
+
 // A growing segment born while a function output field was absent from the
 // schema (add/drop-function churn) never materializes that column —
 // Reopen/FillAbsentFields skip function outputs by design. Flushing with a

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -22,6 +22,7 @@
 #include <iosfwd>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -371,6 +372,27 @@ TEST_F(StorageTest, TextFieldDataFromManifestResolvesLobRefs) {
             ASSERT_EQ(streamed[i]->is_valid(r), raw_datas[i]->is_valid(r));
         }
     }
+
+    // A throwing consumer must still leave no decode task running: for index
+    // build the consumer writes to local disk and can fail mid-stream, and
+    // the tasks live on a shared pool, so one outliving this frame would run
+    // against a destroyed stack scope. The drain guard covers this exit path
+    // (previously only ReadNext failures drained).
+    EXPECT_THROW(
+        {
+            IterateFieldDataFromManifest(
+                manifest_json,
+                properties,
+                field_meta,
+                DataType::TEXT,
+                0,
+                DataType::NONE,
+                std::nullopt,
+                [](FieldDataPtr) {
+                    throw std::runtime_error("consumer failed");
+                });
+        },
+        std::runtime_error);
 
     FreeFlushResult(&result);
     cleanup();

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -13,6 +13,7 @@
 #include <boost/filesystem/path.hpp>
 #include <gtest/gtest.h>
 #include <chrono>
+#include <thread>
 #include <cstdlib>
 #include <cstdint>
 #include <filesystem>
@@ -43,6 +44,7 @@
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "storage/azure/AzureChunkManager.h"
+#include "milvus-storage/thread_pool.h"
 #include "storage/loon_ffi/property_singleton.h"
 #include "storage/loon_ffi/util.h"
 #include "storage/gcp-native-storage/GcpNativeChunkManager.h"
@@ -340,6 +342,32 @@ TEST_F(StorageTest, TextFieldDataFromManifestResolvesLobRefs) {
               texts[0]);
     EXPECT_EQ(*static_cast<const std::string*>(text_datas[0]->RawValue(2)),
               texts[2]);
+
+    // The streaming variant must deliver the same batches, in order, on the
+    // calling thread — GetFieldDatasFromManifest is a thin wrapper over it,
+    // but assert the contract directly too (decode runs on a thread pool;
+    // ordering and delivery-thread guarantees are what callers rely on).
+    std::vector<FieldDataPtr> streamed;
+    auto caller_tid = std::this_thread::get_id();
+    IterateFieldDataFromManifest(manifest_json,
+                                 properties,
+                                 field_meta,
+                                 DataType::TEXT,
+                                 0,
+                                 DataType::NONE,
+                                 std::nullopt,
+                                 [&](FieldDataPtr fd) {
+                                     EXPECT_EQ(std::this_thread::get_id(),
+                                               caller_tid);
+                                     streamed.push_back(std::move(fd));
+                                 });
+    ASSERT_EQ(streamed.size(), raw_datas.size());
+    for (size_t i = 0; i < streamed.size(); ++i) {
+        ASSERT_EQ(streamed[i]->get_num_rows(), raw_datas[i]->get_num_rows());
+        for (int64_t r = 0; r < streamed[i]->get_num_rows(); ++r) {
+            ASSERT_EQ(streamed[i]->is_valid(r), raw_datas[i]->is_valid(r));
+        }
+    }
 
     FreeFlushResult(&result);
     cleanup();
@@ -818,6 +846,190 @@ TEST_F(StorageTest, InitArrowReaderConfig) {
               default_cache_options.hole_size_limit);
     EXPECT_EQ(cache_options.range_size_limit,
               default_cache_options.range_size_limit);
+}
+
+// Freshly-built loon properties (index build / FFI reader paths construct
+// them per task via MakeInternalPropertiesFromStorageConfig, bypassing
+// LoonFFIPropertiesSingleton's cached map) must still carry the configured
+// arrow reader prebuffer limits — otherwise external-table index builds
+// silently fall back to arrow defaults regardless of
+// common.arrow.reader.* configuration.
+TEST_F(StorageTest, ArrowReaderConfigAppliesToFreshLoonProperties) {
+    auto status =
+        InitArrowReaderConfig(CArrowReaderConfig{32 * 1024, 4 * 1024 * 1024});
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+
+    auto properties =
+        MakeInternalPropertiesFromStorageConfig(get_azure_storage_config());
+    ASSERT_NE(properties, nullptr);
+
+    auto hole_size_limit = milvus_storage::api::GetValue<int64_t>(
+        *properties, PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT);
+    ASSERT_TRUE(hole_size_limit.ok()) << hole_size_limit.status().ToString();
+    EXPECT_EQ(hole_size_limit.ValueOrDie(), 32 * 1024);
+
+    auto range_size_limit = milvus_storage::api::GetValue<int64_t>(
+        *properties, PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT);
+    ASSERT_TRUE(range_size_limit.ok()) << range_size_limit.status().ToString();
+    EXPECT_EQ(range_size_limit.ValueOrDie(), 4 * 1024 * 1024);
+
+    // Reset to unset: fresh properties must carry 0 (= keep arrow default
+    // downstream), not stale values from the previous configuration.
+    status = InitArrowReaderConfig(CArrowReaderConfig{0, 0});
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+
+    properties =
+        MakeInternalPropertiesFromStorageConfig(get_azure_storage_config());
+    ASSERT_NE(properties, nullptr);
+
+    hole_size_limit = milvus_storage::api::GetValue<int64_t>(
+        *properties, PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT);
+    ASSERT_TRUE(hole_size_limit.ok()) << hole_size_limit.status().ToString();
+    EXPECT_EQ(hole_size_limit.ValueOrDie(), 0);
+
+    range_size_limit = milvus_storage::api::GetValue<int64_t>(
+        *properties, PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT);
+    ASSERT_TRUE(range_size_limit.ok()) << range_size_limit.status().ToString();
+    EXPECT_EQ(range_size_limit.ValueOrDie(), 0);
+}
+
+TEST_F(StorageTest, InitLoonReaderThreadPool) {
+    auto status = InitLoonReaderThreadPool(-1);
+    EXPECT_EQ(status.error_code, ConfigInvalid);
+    FreeErrorStatus(status);
+
+    // 0 = keep the pool uninitialized (sequential reads, prior behavior).
+    status = InitLoonReaderThreadPool(0);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+
+    status = InitLoonReaderThreadPool(4);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    EXPECT_EQ(milvus_storage::ThreadPoolHolder::GetParallelism(), 4);
+
+    // Updates resize the existing pool.
+    status = InitLoonReaderThreadPool(8);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    EXPECT_EQ(milvus_storage::ThreadPoolHolder::GetParallelism(), 8);
+
+    // 0 after creation leaves the pool untouched.
+    status = InitLoonReaderThreadPool(0);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    EXPECT_EQ(milvus_storage::ThreadPoolHolder::GetParallelism(), 8);
+
+    // Restore the no-pool state so other tests keep sequential reads.
+    milvus_storage::ThreadPoolHolder::Release();
+    EXPECT_EQ(milvus_storage::ThreadPoolHolder::GetParallelism(), 1);
+}
+
+TEST_F(StorageTest, InitIndexBuildReadWindow) {
+    auto status = InitIndexBuildReadWindow(-1);
+    EXPECT_EQ(status.error_code, ConfigInvalid);
+    FreeErrorStatus(status);
+    status = InitIndexBuildReadWindow(5LL * 1024 * 1024 * 1024);
+    EXPECT_EQ(status.error_code, ConfigInvalid);
+    FreeErrorStatus(status);
+
+    status = InitIndexBuildReadWindow(512LL * 1024 * 1024);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    EXPECT_EQ(
+        LoonFFIPropertiesSingleton::GetInstance().GetIndexBuildReadWindow(),
+        512LL * 1024 * 1024);
+
+    // The configured window stamps into per-task properties.
+    milvus_storage::api::Properties props;
+    LoonFFIPropertiesSingleton::GetInstance().ApplyIndexBuildReadWindow(props);
+    auto window = milvus_storage::api::GetValue<int64_t>(
+        props, PROPERTY_READER_RECORD_BATCH_MAX_SIZE);
+    ASSERT_TRUE(window.ok()) << window.status().ToString();
+    EXPECT_EQ(window.ValueOrDie(), 512LL * 1024 * 1024);
+
+    // Reset to 0: no stamping, the registry default (32MB) applies.
+    status = InitIndexBuildReadWindow(0);
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    milvus_storage::api::Properties fresh;
+    LoonFFIPropertiesSingleton::GetInstance().ApplyIndexBuildReadWindow(fresh);
+    window = milvus_storage::api::GetValue<int64_t>(
+        fresh, PROPERTY_READER_RECORD_BATCH_MAX_SIZE);
+    ASSERT_TRUE(window.ok()) << window.status().ToString();
+    EXPECT_EQ(window.ValueOrDie(), 32LL * 1024 * 1024);
+}
+
+// The two prebuffer limits are validated against each other downstream (the
+// parquet reader rejects range_size_limit <= hole_size_limit), so a task
+// building fresh properties must never observe one value from the new
+// generation and the other from the old one. Hot-reload concurrently with
+// property creation and assert every observed pair is self-consistent.
+TEST_F(StorageTest, ArrowReaderConfigSnapshotIsAtomicUnderHotReload) {
+    // Two generations, each individually valid, whose crosswise mixes are
+    // not: (8M, 16M) mixed with (1M, 4M) yields 8M/4M, which is rejected.
+    constexpr int64_t kHoleA = 1LL << 20, kRangeA = 4LL << 20;
+    constexpr int64_t kHoleB = 8LL << 20, kRangeB = 16LL << 20;
+
+    // Publish generation A before any reader starts. The singleton's
+    // pre-test state is the unset (0, 0) generation — StorageTest.
+    // InitArrowReaderConfig restores it — and a reader that samples that
+    // state before the writer thread is first scheduled would be counted as
+    // torn even though it observed one coherent generation. The invariant
+    // under test is "never a mix of two generations", not "the config is
+    // already set", so the initial generation must be excluded from the
+    // sample rather than raced against.
+    LoonFFIPropertiesSingleton::GetInstance().SetArrowReaderConfig(kHoleA,
+                                                                   kRangeA);
+
+    std::atomic<bool> stop{false};
+    std::atomic<int> torn{0};
+    std::atomic<int> observations{0};
+
+    std::thread writer([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            LoonFFIPropertiesSingleton::GetInstance().SetArrowReaderConfig(
+                kHoleA, kRangeA);
+            LoonFFIPropertiesSingleton::GetInstance().SetArrowReaderConfig(
+                kHoleB, kRangeB);
+        }
+    });
+
+    std::vector<std::thread> readers;
+    for (int t = 0; t < 4; ++t) {
+        readers.emplace_back([&]() {
+            while (!stop.load(std::memory_order_relaxed)) {
+                auto properties = MakeInternalPropertiesFromStorageConfig(
+                    get_azure_storage_config());
+                auto hole = milvus_storage::api::GetValue<int64_t>(
+                    *properties,
+                    PROPERTY_READER_PARQUET_PREBUFFER_HOLE_SIZE_LIMIT);
+                auto range = milvus_storage::api::GetValue<int64_t>(
+                    *properties,
+                    PROPERTY_READER_PARQUET_PREBUFFER_RANGE_SIZE_LIMIT);
+                if (!hole.ok() || !range.ok()) {
+                    torn.fetch_add(1);
+                    continue;
+                }
+                auto h = hole.ValueOrDie(), r = range.ValueOrDie();
+                bool consistent = (h == kHoleA && r == kRangeA) ||
+                                  (h == kHoleB && r == kRangeB);
+                if (!consistent) {
+                    torn.fetch_add(1);
+                }
+                observations.fetch_add(1);
+            }
+        });
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    stop.store(true, std::memory_order_relaxed);
+    writer.join();
+    for (auto& r : readers) {
+        r.join();
+    }
+
+    EXPECT_GT(observations.load(), 0) << "no observations were made";
+    EXPECT_EQ(torn.load(), 0)
+        << "observed a mix of prebuffer limits from different generations";
+
+    // Restore the unset state for the tests that follow.
+    auto status = InitArrowReaderConfig(CArrowReaderConfig{0, 0});
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
 }
 
 class StorageUtilTest : public testing::Test {

--- a/internal/core/unittest/test_storage.cpp
+++ b/internal/core/unittest/test_storage.cpp
@@ -9,7 +9,9 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <arrow/array/builder_primitive.h>
 #include <arrow/scalar.h>
+#include <arrow/util/byte_size.h>
 #include <boost/filesystem/path.hpp>
 #include <gtest/gtest.h>
 #include <chrono>
@@ -41,6 +43,7 @@
 #include "storage/LocalChunkManager.h"
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/RemoteChunkManagerSingleton.h"
+#include "storage/RecordBatchSize.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "storage/azure/AzureChunkManager.h"
@@ -371,6 +374,43 @@ TEST_F(StorageTest, TextFieldDataFromManifestResolvesLobRefs) {
 
     FreeFlushResult(&result);
     cleanup();
+}
+
+// milvus-storage splits a parquet row group into record-batch slices according
+// to reader.record_batch_max_rows. Those slices share backing buffers, so the
+// in-flight byte budget must charge each referenced range rather than the
+// entire row-group buffer once per slice.
+TEST_F(StorageTest, RecordBatchSizeAccountsForReferencedSlice) {
+    constexpr int64_t kSliceRows = 8192;
+    constexpr int64_t kTotalRows = kSliceRows * 2;
+
+    arrow::Int64Builder builder;
+    ASSERT_TRUE(builder.Reserve(kTotalRows).ok());
+    for (int64_t i = 0; i < kTotalRows; ++i) {
+        ASSERT_TRUE(builder.Append(i).ok());
+    }
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(builder.Finish(&values).ok());
+
+    auto batch = arrow::RecordBatch::Make(
+        arrow::schema({arrow::field("value", arrow::int64())}),
+        kTotalRows,
+        {values});
+    auto first = batch->Slice(0, kSliceRows);
+    auto second = batch->Slice(kSliceRows, kSliceRows);
+
+    // Demonstrate the regression condition: TotalBufferSize charges both
+    // slices for the full shared buffers, while the slice-aware estimates
+    // partition the backing bytes between the two equal, byte-aligned slices.
+    auto backing_bytes = arrow::util::TotalBufferSize(*batch);
+    EXPECT_EQ(arrow::util::TotalBufferSize(*first), backing_bytes);
+    EXPECT_EQ(arrow::util::TotalBufferSize(*second), backing_bytes);
+
+    auto first_bytes = EstimateRecordBatchBytes(*first);
+    auto second_bytes = EstimateRecordBatchBytes(*second);
+    EXPECT_LT(first_bytes, backing_bytes);
+    EXPECT_EQ(first_bytes, second_bytes);
+    EXPECT_EQ(first_bytes + second_bytes, backing_bytes);
 }
 
 // A growing segment born while a function output field was absent from the

--- a/internal/core/unittest/test_storage_v2_index_raw_data.cpp
+++ b/internal/core/unittest/test_storage_v2_index_raw_data.cpp
@@ -14,7 +14,10 @@
 #include <nlohmann/json.hpp>
 #include <parquet/properties.h>
 #include <atomic>
+#include <cmath>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <exception>
 #include <iostream>
 #include <map>
@@ -46,11 +49,13 @@
 #include "storage/BinlogReader.h"
 #include "storage/ChunkManager.h"
 #include "storage/DiskFileManagerImpl.h"
+#include "storage/loon_ffi/property_singleton.h"
 #include "storage/FileManager.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "test_utils/Constants.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/ManifestTestUtil.h"
 #include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
@@ -271,5 +276,103 @@ TEST_F(StorageV2IndexRawDataTest, TestGetRawData) {
         } catch (const std::exception& e) {
             std::cout << "Exception: " << e.what() << std::endl;
         }
+    }
+}
+// End-to-end coverage for the raw-data spill used by disk index build:
+// manifest -> CacheRawDataToDisk -> local file, asserting the on-disk
+// header and payload against the source data. The pre-existing
+// TestGetRawData above is skipped, which left this path — the one that
+// downloads and writes tens of GB per build — without any effective test.
+// A regression that changed this path's file-creation semantics shipped
+// unnoticed because of that gap; this case reproduces it in one run.
+class CacheRawDataToDiskTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        auto storage_config = gen_local_storage_config(path_);
+        fs_ = storage::InitArrowFileSystem(storage_config);
+        cm_ = storage::CreateChunkManager(storage_config);
+    }
+
+    storage::ChunkManagerPtr cm_;
+    milvus_storage::ArrowFileSystemPtr fs_;
+    std::string path_ = TestLocalPath;
+    int64_t collection_id = 1;
+    int64_t partition_id = 2;
+    int64_t segment_id = 3;
+    int64_t index_build_id = 4101;
+    int64_t index_version = 4101;
+};
+
+TEST_F(CacheRawDataToDiskTest, ManifestRoundTripHeaderAndPayload) {
+    constexpr int64_t kDim = 16;
+    constexpr int64_t kPerBatch = 500;
+    constexpr int64_t kNumBatch = 3;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto vec_fid =
+        schema->AddDebugField("vec", DataType::VECTOR_FLOAT, kDim, "L2");
+    schema->set_primary_field_id(pk_fid);
+
+    std::string base_path = "cache_raw_data_e2e_seg";
+    milvus::test::V3SegmentTestData data(
+        schema, kNumBatch, kPerBatch, kDim, path_, base_path);
+    const int64_t total_rows = data.TotalRows();
+
+    auto field_meta = gen_field_meta(collection_id,
+                                     partition_id,
+                                     segment_id,
+                                     vec_fid.get(),
+                                     DataType::VECTOR_FLOAT,
+                                     DataType::NONE,
+                                     false);
+    auto index_meta = gen_index_meta(
+        segment_id, vec_fid.get(), index_build_id, index_version);
+    storage::FileManagerContext ctx(field_meta, index_meta, cm_, fs_);
+    ctx.set_loon_ffi_properties(
+        storage::LoonFFIPropertiesSingleton::GetInstance().GetProperties());
+
+    milvus::Config config;
+    config[STORAGE_VERSION_KEY] = STORAGE_V3;
+    config[SEGMENT_MANIFEST_KEY] = data.ManifestPathJson();
+    config[DATA_TYPE_KEY] = DataType::VECTOR_FLOAT;
+    config[ELEMENT_TYPE_KEY] = DataType::NONE;
+    config[DIM_KEY] = kDim;
+    config[INDEX_NUM_ROWS_KEY] = total_rows;
+    config[SEGMENT_INSERT_FILES_KEY] =
+        std::vector<std::vector<std::string>>{{}};
+
+    auto file_manager =
+        std::make_shared<milvus::storage::DiskFileManagerImpl>(ctx);
+    auto local_path = file_manager->CacheRawDataToDisk<float>(config);
+    ASSERT_EQ(local_path,
+              file_manager->GetLocalRawDataObjectPrefix() + "raw_data");
+
+    // The file must exist and be exactly header + payload; a wrong size
+    // means the header reservation or the tail handling is broken.
+    ASSERT_TRUE(std::filesystem::exists(local_path)) << local_path;
+    const int64_t expected_size =
+        2 * sizeof(uint32_t) + total_rows * kDim * sizeof(float);
+    EXPECT_EQ(std::filesystem::file_size(local_path),
+              static_cast<uintmax_t>(expected_size));
+
+    std::ifstream in(local_path, std::ios::binary);
+    ASSERT_TRUE(in.is_open());
+    uint32_t got_rows = 0, got_dim = 0;
+    in.read(reinterpret_cast<char*>(&got_rows), sizeof(got_rows));
+    in.read(reinterpret_cast<char*>(&got_dim), sizeof(got_dim));
+    EXPECT_EQ(got_rows, static_cast<uint32_t>(total_rows));
+    EXPECT_EQ(got_dim, static_cast<uint32_t>(kDim));
+
+    // Payload must be finite and fully written; a short read here would
+    // mean the tail of the last batch never reached the file.
+    std::vector<float> payload(total_rows * kDim);
+    in.read(reinterpret_cast<char*>(payload.data()),
+            payload.size() * sizeof(float));
+    EXPECT_EQ(in.gcount(),
+              static_cast<std::streamsize>(payload.size() * sizeof(float)));
+    for (size_t i = 0; i < payload.size(); ++i) {
+        ASSERT_TRUE(std::isfinite(payload[i])) << "row-major offset " << i;
     }
 }

--- a/internal/datacoord/garbage_collector_lob.go
+++ b/internal/datacoord/garbage_collector_lob.go
@@ -206,6 +206,7 @@ func (gc *garbageCollector) getStorageConfig() *indexpb.StorageConfig {
 		UseVirtualHost:    params.MinioCfg.UseVirtualHost.GetAsBool(),
 		CloudProvider:     params.MinioCfg.CloudProvider.GetValue(),
 		RequestTimeoutMs:  params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
+		MaxConnections:    uint32(params.MinioCfg.MaxConnections.GetAsInt()),
 		GcpCredentialJSON: params.MinioCfg.GcpCredentialJSON.GetValue(),
 	}
 }

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -397,6 +397,7 @@ func createStorageConfig() *indexpb.StorageConfig {
 			UseVirtualHost:    Params.MinioCfg.UseVirtualHost.GetAsBool(),
 			CloudProvider:     Params.MinioCfg.CloudProvider.GetValue(),
 			RequestTimeoutMs:  Params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
+			MaxConnections:    uint32(Params.MinioCfg.MaxConnections.GetAsInt()),
 			GcpCredentialJSON: Params.MinioCfg.GcpCredentialJSON.GetValue(),
 			SslTlsMinVersion:  Params.MinioCfg.SslTLSMinVersion.GetValue(),
 			UseCrc32CChecksum: Params.MinioCfg.UseCRC32C.GetAsBool(),

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -380,6 +380,9 @@ func createStorageConfig() *indexpb.StorageConfig {
 		storageConfig = &indexpb.StorageConfig{
 			RootPath:    Params.LocalStorageCfg.Path.GetValue(),
 			StorageType: Params.CommonCfg.StorageType.GetValue(),
+			// External collections may reference an s3:// source even when the
+			// primary storage is local, so the connection cap still applies.
+			MaxConnections: uint32(Params.MinioCfg.MaxConnections.GetAsInt()),
 		}
 	} else {
 		storageConfig = &indexpb.StorageConfig{

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -186,15 +186,18 @@ func (suite *UtilSuite) TestCreateStorageConfig() {
 		paramtable.Get().Save(Params.CommonCfg.StorageType.Key, "minio")
 		paramtable.Get().Save(Params.MinioCfg.SslTLSMinVersion.Key, "1.2")
 		paramtable.Get().Save(Params.MinioCfg.UseCRC32C.Key, "true")
+		paramtable.Get().Save(Params.MinioCfg.MaxConnections.Key, "237")
 		defer paramtable.Get().Reset(Params.CommonCfg.StorageType.Key)
 		defer paramtable.Get().Reset(Params.MinioCfg.SslTLSMinVersion.Key)
 		defer paramtable.Get().Reset(Params.MinioCfg.UseCRC32C.Key)
+		defer paramtable.Get().Reset(Params.MinioCfg.MaxConnections.Key)
 
 		config := createStorageConfig()
 		suite.Equal("minio", config.StorageType)
 		suite.Equal(Params.MinioCfg.Address.GetValue(), config.Address)
 		suite.Equal("1.2", config.SslTlsMinVersion)
 		suite.True(config.UseCrc32CChecksum)
+		suite.Equal(uint32(237), config.MaxConnections)
 	})
 }
 

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -174,12 +174,17 @@ func (suite *UtilSuite) TestCreateStorageConfig() {
 	suite.Run("local", func() {
 		paramtable.Get().Save(Params.CommonCfg.StorageType.Key, "local")
 		paramtable.Get().Save(Params.LocalStorageCfg.Path.Key, "/tmp/milvus-local")
+		paramtable.Get().Save(Params.MinioCfg.MaxConnections.Key, "237")
 		defer paramtable.Get().Reset(Params.CommonCfg.StorageType.Key)
 		defer paramtable.Get().Reset(Params.LocalStorageCfg.Path.Key)
+		defer paramtable.Get().Reset(Params.MinioCfg.MaxConnections.Key)
 
 		config := createStorageConfig()
 		suite.Equal("local", config.StorageType)
 		suite.Equal("/tmp/milvus-local", config.RootPath)
+		// An external collection can still read from s3:// while the primary
+		// storage is local, so the connection cap must survive this branch.
+		suite.Equal(uint32(237), config.MaxConnections)
 	})
 
 	suite.Run("remote", func() {

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -102,10 +102,18 @@ func InitSegcore(nodeID int64) error {
 		return err
 	}
 
+	// Apply milvus-storage reader concurrency config: the global reader
+	// thread pool (chunk/file-level fan-out) and the index-build read
+	// window (row groups prefetched in parallel per round).
+	if err := initcore.InitLoonReaderConfig(paramtable.Get()); err != nil {
+		return err
+	}
+
 	// Wire hot-reload watchers so capacity / coalescing-limit changes take effect
 	// without restart, matching QueryNode behavior.
 	initcore.RegisterArrowIOThreadPoolWatchers(paramtable.Get(), "datanode")
 	initcore.RegisterArrowReaderConfigWatchers(paramtable.Get(), "datanode")
+	initcore.RegisterLoonReaderConfigWatchers(paramtable.Get(), "datanode")
 
 	// init paramtable change callback for core related config
 	initcore.SetupCoreConfigChangelCallback()

--- a/internal/datanode/index/task_analyze.go
+++ b/internal/datanode/index/task_analyze.go
@@ -111,6 +111,7 @@ func (at *analyzeTask) Execute(ctx context.Context) error {
 		Region:            at.req.GetStorageConfig().GetRegion(),
 		CloudProvider:     at.req.GetStorageConfig().GetCloudProvider(),
 		RequestTimeoutMs:  at.req.GetStorageConfig().GetRequestTimeoutMs(),
+		MaxConnections:    at.req.GetStorageConfig().GetMaxConnections(),
 		SslCACert:         at.req.GetStorageConfig().GetSslCACert(),
 		GcpCredentialJSON: at.req.GetStorageConfig().GetGcpCredentialJSON(),
 		SslTlsMinVersion:  at.req.GetStorageConfig().GetSslTlsMinVersion(),

--- a/internal/datanode/index/task_index.go
+++ b/internal/datanode/index/task_index.go
@@ -286,6 +286,7 @@ func (it *indexBuildTask) Execute(ctx context.Context) error {
 		Region:            it.req.GetStorageConfig().GetRegion(),
 		CloudProvider:     it.req.GetStorageConfig().GetCloudProvider(),
 		RequestTimeoutMs:  it.req.GetStorageConfig().GetRequestTimeoutMs(),
+		MaxConnections:    it.req.GetStorageConfig().GetMaxConnections(),
 		SslCACert:         it.req.GetStorageConfig().GetSslCACert(),
 		GcpCredentialJSON: it.req.GetStorageConfig().GetGcpCredentialJSON(),
 		SslTlsMinVersion:  it.req.GetStorageConfig().GetSslTlsMinVersion(),

--- a/internal/datanode/index/task_test.go
+++ b/internal/datanode/index/task_test.go
@@ -20,14 +20,19 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/analyzecgowrapper"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/clusteringpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
@@ -129,6 +134,44 @@ func (suite *IndexBuildTaskSuite) TestBuildMemoryIndex() {
 	suite.NoError(err)
 	err = t.PostExecute(context.Background())
 	suite.NoError(err)
+}
+
+func (suite *IndexBuildTaskSuite) TestMaxConnectionsReachesCreateIndex() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var captured *indexcgopb.BuildIndexInfo
+	patch := mockey.Mock(indexcgowrapper.CreateIndex).To(
+		func(_ context.Context, info *indexcgopb.BuildIndexInfo) (indexcgowrapper.CodecIndex, error) {
+			captured = info
+			return nil, nil
+		}).Build()
+	defer patch.UnPatch()
+
+	req := &workerpb.CreateJobRequest{
+		BuildID:     1,
+		NumRows:     int64(suite.numRows),
+		Dim:         int64(suite.dim),
+		IndexParams: []*commonpb.KeyValuePair{{Key: common.IndexTypeKey, Value: "FLAT"}},
+		Field: &schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     "vec",
+			DataType: schemapb.DataType_FloatVector,
+		},
+		StorageConfig: &indexpb.StorageConfig{
+			StorageType:    "minio",
+			MaxConnections: 237,
+		},
+	}
+	task := NewIndexBuildTask(ctx, cancel, req, nil, NewTaskManager(context.Background()), nil)
+	task.newIndexParams = map[string]string{common.IndexTypeKey: "FLAT"}
+	task.newTypeParams = map[string]string{"dim": "128"}
+	task.tr = timerecord.NewTimeRecorder("test-max-connections")
+
+	err := task.Execute(ctx)
+	suite.NoError(err)
+	suite.Require().NotNil(captured)
+	suite.Equal(uint32(237), captured.GetStorageConfig().GetMaxConnections())
 }
 
 func TestIndexBuildTask(t *testing.T) {
@@ -233,6 +276,45 @@ func (suite *AnalyzeTaskSuite) TestAnalyze() {
 
 	err = t.PreExecute(context.Background())
 	suite.NoError(err)
+}
+
+func (suite *AnalyzeTaskSuite) TestMaxConnectionsReachesAnalyze() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var captured *clusteringpb.AnalyzeInfo
+	patch := mockey.Mock(analyzecgowrapper.Analyze).To(
+		func(_ context.Context, info *clusteringpb.AnalyzeInfo) (analyzecgowrapper.CodecAnalyze, error) {
+			captured = info
+			return nil, nil
+		}).Build()
+	defer patch.UnPatch()
+
+	req := &workerpb.AnalyzeRequest{
+		TaskID:       suite.taskID,
+		CollectionID: suite.collectionID,
+		PartitionID:  suite.partitionID,
+		FieldID:      suite.fieldID,
+		FieldName:    "vec",
+		FieldType:    schemapb.DataType_FloatVector,
+		Dim:          128,
+		StorageConfig: &indexpb.StorageConfig{
+			StorageType:    "minio",
+			RootPath:       "files",
+			MaxConnections: 237,
+		},
+	}
+	task := &analyzeTask{
+		ctx:    ctx,
+		cancel: cancel,
+		req:    req,
+		tr:     timerecord.NewTimeRecorder("test-analyze-max-connections"),
+	}
+
+	err := task.Execute(ctx)
+	suite.NoError(err)
+	suite.Require().NotNil(captured)
+	suite.Equal(uint32(237), captured.GetStorageConfig().GetMaxConnections())
 }
 
 func TestAnalyzeTaskSuite(t *testing.T) {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1589,6 +1589,7 @@ func createStorageConfig() *indexpb.StorageConfig {
 		UseVirtualHost:    params.MinioCfg.UseVirtualHost.GetAsBool(),
 		CloudProvider:     params.MinioCfg.CloudProvider.GetValue(),
 		RequestTimeoutMs:  params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
+		MaxConnections:    uint32(params.MinioCfg.MaxConnections.GetAsInt()),
 		GcpCredentialJSON: params.MinioCfg.GcpCredentialJSON.GetValue(),
 		SslTlsMinVersion:  params.MinioCfg.SslTLSMinVersion.GetValue(),
 		UseCrc32CChecksum: params.MinioCfg.UseCRC32C.GetAsBool(),

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1572,6 +1572,9 @@ func createStorageConfig() *indexpb.StorageConfig {
 		return &indexpb.StorageConfig{
 			RootPath:    params.LocalStorageCfg.Path.GetValue(),
 			StorageType: params.CommonCfg.StorageType.GetValue(),
+			// External collections may reference an s3:// source even when the
+			// primary storage is local, so the connection cap still applies.
+			MaxConnections: uint32(params.MinioCfg.MaxConnections.GetAsInt()),
 		}
 	}
 	return &indexpb.StorageConfig{

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -589,6 +589,7 @@ func createMilvusTableSnapshotStorageConfig() *indexpb.StorageConfig {
 		UseVirtualHost:    params.MinioCfg.UseVirtualHost.GetAsBool(),
 		CloudProvider:     params.MinioCfg.CloudProvider.GetValue(),
 		RequestTimeoutMs:  params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
+		MaxConnections:    uint32(params.MinioCfg.MaxConnections.GetAsInt()),
 		GcpCredentialJSON: params.MinioCfg.GcpCredentialJSON.GetValue(),
 		SslTlsMinVersion:  params.MinioCfg.SslTLSMinVersion.GetValue(),
 		UseCrc32CChecksum: params.MinioCfg.UseCRC32C.GetAsBool(),

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -572,6 +572,9 @@ func createMilvusTableSnapshotStorageConfig() *indexpb.StorageConfig {
 		return &indexpb.StorageConfig{
 			RootPath:    params.LocalStorageCfg.Path.GetValue(),
 			StorageType: params.CommonCfg.StorageType.GetValue(),
+			// External collections may reference an s3:// source even when the
+			// primary storage is local, so the connection cap still applies.
+			MaxConnections: uint32(params.MinioCfg.MaxConnections.GetAsInt()),
 		}
 	}
 	return &indexpb.StorageConfig{

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -162,8 +162,13 @@ func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonPrope
 
 	keys = append(keys, propRequestTimeoutMS)
 	values = append(values, strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10))
-	keys = append(keys, propMaxConnections)
-	values = append(values, strconv.FormatUint(uint64(storageConfig.GetMaxConnections()), 10))
+	// Absent when unset, so milvus-storage's registered default applies. See
+	// the same guard in packed.MakePropertiesFromStorageConfig for why an
+	// explicit "0" is not equivalent.
+	if maxConns := storageConfig.GetMaxConnections(); maxConns > 0 {
+		keys = append(keys, propMaxConnections)
+		values = append(values, strconv.FormatUint(uint64(maxConns), 10))
+	}
 
 	if v := storageConfig.GetSslTlsMinVersion(); v != "" && v != "default" {
 		keys = append(keys, propTLSMinVersion)

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -93,6 +93,7 @@ var (
 	propUseVirtualHost      = C.GoString(C.loon_properties_fs_use_virtual_host)
 	propUseCustomPartUpload = C.GoString(C.loon_properties_fs_use_custom_part_upload)
 	propRequestTimeoutMS    = C.GoString(C.loon_properties_fs_request_timeout_ms)
+	propMaxConnections      = C.GoString(C.loon_properties_fs_max_connections)
 	propTLSMinVersion       = C.GoString(C.loon_properties_fs_tls_min_version)
 	propUseCRC32CChecksum   = C.GoString(C.loon_properties_fs_use_crc32c_checksum)
 )
@@ -161,6 +162,8 @@ func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonPrope
 
 	keys = append(keys, propRequestTimeoutMS)
 	values = append(values, strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10))
+	keys = append(keys, propMaxConnections)
+	values = append(values, strconv.FormatUint(uint64(storageConfig.GetMaxConnections()), 10))
 
 	if v := storageConfig.GetSslTlsMinVersion(); v != "" && v != "default" {
 		keys = append(keys, propTLSMinVersion)
@@ -284,6 +287,7 @@ func PublishDefaultFilesystemMetrics() (*FilesystemMetrics, error) {
 			UseVirtualHost:    params.MinioCfg.UseVirtualHost.GetAsBool(),
 			CloudProvider:     params.MinioCfg.CloudProvider.GetValue(),
 			RequestTimeoutMs:  params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
+			MaxConnections:    uint32(params.MinioCfg.MaxConnections.GetAsInt()),
 			GcpCredentialJSON: params.MinioCfg.GcpCredentialJSON.GetValue(),
 			SslTlsMinVersion:  params.MinioCfg.SslTLSMinVersion.GetValue(),
 			UseCrc32CChecksum: params.MinioCfg.UseCRC32C.GetAsBool(),

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -275,6 +275,9 @@ func PublishDefaultFilesystemMetrics() (*FilesystemMetrics, error) {
 		storageConfig = &indexpb.StorageConfig{
 			RootPath:    params.LocalStorageCfg.Path.GetValue(),
 			StorageType: params.CommonCfg.StorageType.GetValue(),
+			// External collections may reference an s3:// source even when the
+			// primary storage is local, so the connection cap still applies.
+			MaxConnections: uint32(params.MinioCfg.MaxConnections.GetAsInt()),
 		}
 	} else {
 		storageConfig = &indexpb.StorageConfig{

--- a/internal/storagev2/filesystem_metrics_test.go
+++ b/internal/storagev2/filesystem_metrics_test.go
@@ -200,6 +200,21 @@ func TestGetFilesystemMetricsWithConfig(t *testing.T) {
 	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
 	assert.GreaterOrEqual(t, metrics.MultiPartUploadCreated, int64(0))
 	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
+
+	// makePropertiesFromConfig omits fs.max_connections when the producer left
+	// it at 0, so milvus-storage keeps its registered default instead of being
+	// handed an explicit "0" that lowers the connection cap. Drive both sides
+	// of that branch through the public entry point.
+	for _, maxConns := range []uint32{0, 64} {
+		cfg := &indexpb.StorageConfig{
+			StorageType:    "local",
+			RootPath:       dir,
+			MaxConnections: maxConns,
+		}
+		m, err := GetFilesystemMetricsWithConfig(cfg)
+		require.NoError(t, err, "MaxConnections=%d must build valid properties", maxConns)
+		require.NotNil(t, m)
+	}
 }
 
 // TestPublishFilesystemMetricsWithLocalConfig tests PublishFilesystemMetricsWithConfig

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -1553,6 +1553,32 @@ func TestMakePropertiesFromStorageConfig_AllFields(t *testing.T) {
 	assert.Equal(t, "237", loonPropertyString(props, PropertyFSMaxConnections))
 }
 
+// An unset MaxConnections must leave the key absent, not emit "0".
+// milvus-storage only falls back to its registered default (100) when the key
+// is missing; an explicit "0" survives into s3_client_builder, which takes
+// max(max(io_capacity, 25), max_connections), lowering the connection cap.
+// It also feeds ArrowFileSystemConfig's cache key, so a "0" producer and a
+// "100" producer would resolve to two different cached filesystems.
+func TestMakePropertiesFromStorageConfig_MaxConnectionsUnsetOmitsKey(t *testing.T) {
+	config := &indexpb.StorageConfig{
+		Address:          "localhost:9000",
+		BucketName:       "test-bucket",
+		StorageType:      "minio",
+		RequestTimeoutMs: 5000,
+		// MaxConnections deliberately left at its zero value.
+	}
+	props, err := MakePropertiesFromStorageConfig(config, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, props)
+	defer FreeProperties(props)
+
+	assert.Empty(t, loonPropertyString(props, PropertyFSMaxConnections),
+		"unset MaxConnections must not be emitted as \"0\"")
+	// The neighboring integer field is still emitted, so this is a targeted
+	// guard rather than the whole block going missing.
+	assert.Equal(t, "5000", loonPropertyString(props, PropertyFSRequestTimeoutMS))
+}
+
 // ==================== FetchFragmentsFromExternalSourceWithRange Tests ====================
 
 func TestFetchFragmentsFromExternalSourceWithRange_HappyPath(t *testing.T) {

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -1544,11 +1544,13 @@ func TestMakePropertiesFromStorageConfig_AllFields(t *testing.T) {
 		UseIAM:            true,
 		UseVirtualHost:    true,
 		RequestTimeoutMs:  5000,
+		MaxConnections:    237,
 	}
 	props, err := MakePropertiesFromStorageConfig(config, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, props)
 	defer FreeProperties(props)
+	assert.Equal(t, "237", loonPropertyString(props, PropertyFSMaxConnections))
 }
 
 // ==================== FetchFragmentsFromExternalSourceWithRange Tests ====================

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -163,9 +163,11 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 	keys = append(keys, PropertyFSUseCustomPartUpload)
 	values = append(values, "true") // hardcoded to true as in the original code
 
-	// Add integer field
+	// Add integer fields
 	keys = append(keys, PropertyFSRequestTimeoutMS)
 	values = append(values, strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10))
+	keys = append(keys, PropertyFSMaxConnections)
+	values = append(values, strconv.FormatUint(uint64(storageConfig.GetMaxConnections()), 10))
 
 	// Add TLS min version (skip "default" — consistent with C++ layer filtering)
 	if v := storageConfig.GetSslTlsMinVersion(); v != "" && v != "default" {

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -166,8 +166,19 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 	// Add integer fields
 	keys = append(keys, PropertyFSRequestTimeoutMS)
 	values = append(values, strconv.FormatInt(storageConfig.GetRequestTimeoutMs(), 10))
-	keys = append(keys, PropertyFSMaxConnections)
-	values = append(values, strconv.FormatUint(uint64(storageConfig.GetMaxConnections()), 10))
+	// 0 means "not set by the producer" — leave the key absent so
+	// milvus-storage applies its registered default (100). Emitting "0"
+	// instead would clobber that default: the registry only falls back when
+	// the key is missing, and s3_client_builder takes
+	// max(max(io_capacity, 25), max_connections), so an explicit 0 lowers the
+	// connection cap. It would also change ArrowFileSystemConfig's cache key
+	// and split the filesystem cache against producers that do set it. Same
+	// convention as ChunkManager.cpp / MinioChunkManager.cpp, which apply the
+	// value only when > 0.
+	if maxConns := storageConfig.GetMaxConnections(); maxConns > 0 {
+		keys = append(keys, PropertyFSMaxConnections)
+		values = append(values, strconv.FormatUint(uint64(maxConns), 10))
+	}
 
 	// Add TLS min version (skip "default" — consistent with C++ layer filtering)
 	if v := storageConfig.GetSslTlsMinVersion(); v != "" && v != "default" {

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -49,6 +49,9 @@ func CreateStorageConfig() *indexpb.StorageConfig {
 		storageConfig = &indexpb.StorageConfig{
 			RootPath:    paramtable.Get().LocalStorageCfg.Path.GetValue(),
 			StorageType: paramtable.Get().CommonCfg.StorageType.GetValue(),
+			// External collections may reference an s3:// source even when the
+			// primary storage is local, so the connection cap still applies.
+			MaxConnections: uint32(paramtable.Get().MinioCfg.MaxConnections.GetAsInt()),
 		}
 	} else {
 		storageConfig = &indexpb.StorageConfig{

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -66,6 +66,7 @@ func CreateStorageConfig() *indexpb.StorageConfig {
 			UseVirtualHost:    paramtable.Get().MinioCfg.UseVirtualHost.GetAsBool(),
 			CloudProvider:     paramtable.Get().MinioCfg.CloudProvider.GetValue(),
 			RequestTimeoutMs:  paramtable.Get().MinioCfg.RequestTimeoutMs.GetAsInt64(),
+			MaxConnections:    uint32(paramtable.Get().MinioCfg.MaxConnections.GetAsInt()),
 			GcpCredentialJSON: paramtable.Get().MinioCfg.GcpCredentialJSON.GetValue(),
 			SslTlsMinVersion:  paramtable.Get().MinioCfg.SslTLSMinVersion.GetValue(),
 			UseCrc32CChecksum: paramtable.Get().MinioCfg.UseCRC32C.GetAsBool(),

--- a/internal/storagev2/packed/packed_writer_ffi_test.go
+++ b/internal/storagev2/packed/packed_writer_ffi_test.go
@@ -31,6 +31,19 @@ func TestFFIPackedWriterDestroyIsIdempotent(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCreateStorageConfigMaxConnections(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.StorageType.Key, "minio")
+	pt.Save(pt.MinioCfg.MaxConnections.Key, "237")
+	t.Cleanup(func() {
+		pt.Reset(pt.CommonCfg.StorageType.Key)
+		pt.Reset(pt.MinioCfg.MaxConnections.Key)
+	})
+
+	assert.Equal(t, uint32(237), CreateStorageConfig().GetMaxConnections())
+}
+
 func TestFFIPackedWriter_AsNewColumnGroupsAddsFields(t *testing.T) {
 	writer := &FFIPackedWriter{}
 	returned := writer.AsNewColumnGroups()

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -501,6 +501,30 @@ func InitDiskFileWriterConfig(params *paramtable.ComponentParam) error {
 	return HandleCStatus(&status, "InitDiskFileWriterConfig failed")
 }
 
+// InitLoonReaderConfig applies the milvus-storage (loon) reader concurrency
+// settings: the global reader thread pool size (chunk/file-level read
+// fan-out) and the index-build read window (how many bytes one prefetch
+// round may span, which bounds how many row groups download in parallel per
+// round). Both default to 0 = pre-existing sequential behavior.
+func InitLoonReaderConfig(params *paramtable.ComponentParam) error {
+	poolSize := params.CommonCfg.StorageReaderThreadPoolSize.GetAsInt32()
+	status := C.InitLoonReaderThreadPool(C.int32_t(poolSize))
+	if err := HandleCStatus(&status, "InitLoonReaderThreadPool failed"); err != nil {
+		return err
+	}
+	window := params.CommonCfg.IndexBuildReadWindowBytes.GetAsInt64()
+	status = C.InitIndexBuildReadWindow(C.int64_t(window))
+	return HandleCStatus(&status, "InitIndexBuildReadWindow failed")
+}
+
+// EffectiveLoonReaderThreadPoolSize returns the pool size actually in effect,
+// which differs from the configured value when the pool already exists: it
+// cannot be destroyed at runtime, so lowering the setting to 0 does not take
+// effect until restart.
+func EffectiveLoonReaderThreadPoolSize() int32 {
+	return int32(C.GetLoonReaderThreadPoolSize())
+}
+
 func InitArrowReaderConfig(params *paramtable.ComponentParam) error {
 	arrowReaderConfig := C.CArrowReaderConfig{
 		hole_size_limit_bytes:  C.int64_t(params.CommonCfg.ArrowReaderHoleSizeLimitBytes.GetAsInt64()),

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -501,18 +501,46 @@ func InitDiskFileWriterConfig(params *paramtable.ComponentParam) error {
 	return HandleCStatus(&status, "InitDiskFileWriterConfig failed")
 }
 
+// maxStorageReaderThreadPoolSize bounds common.storage.readerThreadPoolSize.
+// The value is operational sanity far above any useful pool (reads are
+// network-bound); its real job is to reject values that would wrap when
+// narrowed to int32 (e.g. 4294967296 -> 0, silently disabling the pool).
+const maxStorageReaderThreadPoolSize = 1024
+
+// maxIndexBuildReadWindowBytes mirrors the limit enforced by
+// InitIndexBuildReadWindow in storage_c.cpp (milvus-storage validates
+// reader.record_batch_max_size in [1, 4GB]). It is duplicated here so both
+// values can be checked before either one is applied; the C side stays
+// authoritative for callers that bypass this function.
+const maxIndexBuildReadWindowBytes = 4 << 30
+
 // InitLoonReaderConfig applies the milvus-storage (loon) reader concurrency
 // settings: the global reader thread pool size (chunk/file-level read
 // fan-out) and the index-build read window (how many bytes one prefetch
 // round may span, which bounds how many row groups download in parallel per
 // round). Both default to 0 = pre-existing sequential behavior.
+//
+// Both values are validated before either is applied. Resizing the global
+// reader pool is not revertible through config (it cannot be destroyed at
+// runtime), so applying it and only then rejecting the window would leave a
+// hot-reload half-applied with nothing but a generic failure log to show it.
 func InitLoonReaderConfig(params *paramtable.ComponentParam) error {
-	poolSize := params.CommonCfg.StorageReaderThreadPoolSize.GetAsInt32()
+	poolSize := params.CommonCfg.StorageReaderThreadPoolSize.GetAsInt64()
+	if poolSize < 0 || poolSize > maxStorageReaderThreadPoolSize {
+		return merr.WrapErrParameterInvalidMsg(
+			"common.storage.readerThreadPoolSize must be in [0, %d], got %d",
+			maxStorageReaderThreadPoolSize, poolSize)
+	}
+	window := params.CommonCfg.IndexBuildReadWindowBytes.GetAsInt64()
+	if window < 0 || window > maxIndexBuildReadWindowBytes {
+		return merr.WrapErrParameterInvalidMsg(
+			"common.storage.indexBuildReadWindowBytes must be in [0, %d], got %d",
+			maxIndexBuildReadWindowBytes, window)
+	}
 	status := C.InitLoonReaderThreadPool(C.int32_t(poolSize))
 	if err := HandleCStatus(&status, "InitLoonReaderThreadPool failed"); err != nil {
 		return err
 	}
-	window := params.CommonCfg.IndexBuildReadWindowBytes.GetAsInt64()
 	status = C.InitIndexBuildReadWindow(C.int64_t(window))
 	return HandleCStatus(&status, "InitIndexBuildReadWindow failed")
 }

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -514,6 +514,17 @@ const maxStorageReaderThreadPoolSize = 1024
 // authoritative for callers that bypass this function.
 const maxIndexBuildReadWindowBytes = 4 << 30
 
+// loonReaderConfigMu serializes InitLoonReaderConfig. Config-event handlers
+// run inline on the updating goroutine and the dispatcher gives no ordering
+// guarantee across concurrent updates, so two writers (say 16 then 8) could
+// otherwise read the paramtable in one order and reach
+// C.InitLoonReaderThreadPool in the reverse one, leaving the pool at 16 while
+// the paramtable reports 8 — and the resize is not idempotent, so nothing
+// later repairs it. The lock covers read-then-apply rather than just the
+// apply, so whichever caller acquires it last also reads the newest values
+// and installs them last.
+var loonReaderConfigMu sync.Mutex
+
 // InitLoonReaderConfig applies the milvus-storage (loon) reader concurrency
 // settings: the global reader thread pool size (chunk/file-level read
 // fan-out) and the index-build read window (how many bytes one prefetch
@@ -525,6 +536,9 @@ const maxIndexBuildReadWindowBytes = 4 << 30
 // runtime), so applying it and only then rejecting the window would leave a
 // hot-reload half-applied with nothing but a generic failure log to show it.
 func InitLoonReaderConfig(params *paramtable.ComponentParam) error {
+	loonReaderConfigMu.Lock()
+	defer loonReaderConfigMu.Unlock()
+
 	poolSize := params.CommonCfg.StorageReaderThreadPoolSize.GetAsInt64()
 	if poolSize < 0 || poolSize > maxStorageReaderThreadPoolSize {
 		return merr.WrapErrParameterInvalidMsg(

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -17,8 +17,10 @@
 package initcore
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -184,6 +186,72 @@ func TestInitLoonReaderConfig(t *testing.T) {
 	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 	assert.Equal(t, before, EffectiveLoonReaderThreadPoolSize(),
 		"the reader pool must not be resized when the window is rejected")
+}
+
+// TestInitLoonReaderConfigSerialized pins the read-then-apply critical
+// section. Config-event handlers run inline on the updating goroutine with no
+// cross-handler ordering guarantee, and resizing the reader pool is not
+// idempotent, so a call that read a stale paramtable value must not be able to
+// apply after a newer one. Holding the lock must therefore block the whole
+// call, not just the C-side apply.
+func TestInitLoonReaderConfigSerialized(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.StorageReaderThreadPoolSize.Key)
+	defer pt.Reset(pt.CommonCfg.IndexBuildReadWindowBytes.Key)
+
+	loonReaderConfigMu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			loonReaderConfigMu.Unlock()
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- InitLoonReaderConfig(pt) }()
+
+	select {
+	case <-done:
+		t.Fatal("InitLoonReaderConfig completed while the config lock was held; read-then-apply is not serialized")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	loonReaderConfigMu.Unlock()
+	locked = false
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("InitLoonReaderConfig did not finish after the lock was released")
+	}
+}
+
+// TestInitLoonReaderConfigConcurrent exercises the same path from several
+// goroutines so `go test -race` covers the lock itself. Values stay at the
+// defaults: a non-zero pool size cannot be undone at runtime and would leak
+// into every later test in this binary.
+func TestInitLoonReaderConfigConcurrent(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.StorageReaderThreadPoolSize.Key)
+	defer pt.Reset(pt.CommonCfg.IndexBuildReadWindowBytes.Key)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 8)
+	for i := range errs {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = InitLoonReaderConfig(pt)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		assert.NoError(t, err, "concurrent call %d", i)
+	}
+	assert.LessOrEqual(t, EffectiveLoonReaderThreadPoolSize(), int32(1))
 }
 
 // TestRegisterLoonReaderConfigWatchers verifies the helper registers a handler

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -147,6 +148,79 @@ func TestInitArrowReaderConfig(t *testing.T) {
 	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, "32768"))
 	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "1048576"))
 	assert.NoError(t, InitArrowReaderConfig(pt))
+}
+
+func TestInitLoonReaderConfig(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.StorageReaderThreadPoolSize.Key)
+	defer pt.Reset(pt.CommonCfg.IndexBuildReadWindowBytes.Key)
+
+	// Defaults (0/0) keep the pre-existing sequential behavior and must not
+	// create the pool: GetParallelism() reports 1 when no pool exists.
+	assert.NoError(t, InitLoonReaderConfig(pt))
+	assert.LessOrEqual(t, EffectiveLoonReaderThreadPoolSize(), int32(1))
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.IndexBuildReadWindowBytes.Key, "536870912"))
+	assert.NoError(t, InitLoonReaderConfig(pt))
+
+	// Out-of-range pool sizes are rejected instead of being narrowed to
+	// int32: 4294967296 would wrap to 0 and silently disable the pool.
+	for _, invalid := range []string{"-1", "4294967296", "1025"} {
+		assert.NoError(t, pt.Save(pt.CommonCfg.StorageReaderThreadPoolSize.Key, invalid))
+		err := InitLoonReaderConfig(pt)
+		assert.Error(t, err, "pool size %s must be rejected", invalid)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	}
+	assert.NoError(t, pt.Reset(pt.CommonCfg.StorageReaderThreadPoolSize.Key))
+
+	// An out-of-range window is rejected before the (non-destroyable)
+	// reader pool is resized, so a rejected update leaves nothing applied.
+	before := EffectiveLoonReaderThreadPoolSize()
+	assert.NoError(t, pt.Save(pt.CommonCfg.StorageReaderThreadPoolSize.Key, "8"))
+	assert.NoError(t, pt.Save(pt.CommonCfg.IndexBuildReadWindowBytes.Key, "8589934592"))
+	err := InitLoonReaderConfig(pt)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.Equal(t, before, EffectiveLoonReaderThreadPoolSize(),
+		"the reader pool must not be resized when the window is rejected")
+}
+
+// TestRegisterLoonReaderConfigWatchers verifies the helper registers a handler
+// under both loon reader keys and that the handler survives a rejected update.
+func TestRegisterLoonReaderConfigWatchers(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.StorageReaderThreadPoolSize.Key)
+	defer pt.Reset(pt.CommonCfg.IndexBuildReadWindowBytes.Key)
+
+	assert.NotPanics(t, func() { RegisterLoonReaderConfigWatchers(pt, "test") })
+
+	var poolFires, windowFires atomic.Int32
+	poolSentinel := config.NewHandler("sentinel-loon-pool", func(*config.Event) { poolFires.Add(1) })
+	windowSentinel := config.NewHandler("sentinel-loon-window", func(*config.Event) { windowFires.Add(1) })
+	pt.Watch(pt.CommonCfg.StorageReaderThreadPoolSize.Key, poolSentinel)
+	pt.Watch(pt.CommonCfg.IndexBuildReadWindowBytes.Key, windowSentinel)
+	defer pt.Unwatch(pt.CommonCfg.StorageReaderThreadPoolSize.Key, poolSentinel)
+	defer pt.Unwatch(pt.CommonCfg.IndexBuildReadWindowBytes.Key, windowSentinel)
+
+	// Updating only the window must not warn about the pool: with the pool
+	// disabled (default 0) the effective size reads back as 1 because the
+	// singleton does not exist, which is not a failure to destroy it.
+	assert.NoError(t, pt.Save(pt.CommonCfg.IndexBuildReadWindowBytes.Key, "536870912"))
+	assert.Positive(t, windowFires.Load(),
+		"helper must have registered a handler on IndexBuildReadWindowBytes")
+
+	// Drive the handler's error branch: an out-of-range window is rejected
+	// by InitLoonReaderConfig, so the handler logs and returns.
+	assert.NotPanics(t, func() {
+		_ = pt.Save(pt.CommonCfg.IndexBuildReadWindowBytes.Key, "8589934592")
+	})
+	assert.NoError(t, pt.Save(pt.CommonCfg.IndexBuildReadWindowBytes.Key, "0"))
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.StorageReaderThreadPoolSize.Key, "0"))
+	assert.Positive(t, poolFires.Load(),
+		"helper must have registered a handler on StorageReaderThreadPoolSize")
 }
 
 func TestUpdateLoadTransientBudgetBytes(t *testing.T) {

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -189,6 +189,48 @@ func RegisterArrowReaderConfigWatchers(pt *paramtable.ComponentParam, source str
 		config.NewHandler(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, handler))
 }
 
+// RegisterLoonReaderConfigWatchers wires hot-reload of the milvus-storage
+// reader thread pool size and the index-build read window. `source` is
+// included in the log entry for the same reason as in
+// RegisterArrowIOThreadPoolWatchers. Note the thread pool cannot be
+// destroyed once created — updating the size to 0 leaves the current pool
+// unchanged.
+func RegisterLoonReaderConfigWatchers(pt *paramtable.ComponentParam, source string) {
+	handler := func(evt *config.Event) {
+		if !evt.HasUpdated {
+			return
+		}
+		if err := InitLoonReaderConfig(pt); err != nil {
+			mlog.Warn(context.TODO(), "failed to reconfigure loon reader params",
+				mlog.String("source", source), mlog.Err(err))
+			return
+		}
+		// Report the effective pool size, not the requested one: non-zero
+		// values resize the pool either way, but 0 cannot destroy it, so
+		// rolling back to 0 leaves the existing pool serving reads.
+		// Readers also latch parallelism when they open, so a change only
+		// affects tasks started afterwards.
+		requested := pt.CommonCfg.StorageReaderThreadPoolSize.GetAsInt64()
+		effective := int64(EffectiveLoonReaderThreadPoolSize())
+		if requested != effective {
+			mlog.Warn(context.TODO(),
+				"loon reader thread pool size not fully applied; the pool cannot be destroyed at runtime, restart to disable it",
+				mlog.String("source", source),
+				mlog.Int64("requested", requested),
+				mlog.Int64("effective", effective))
+		}
+		mlog.Info(context.TODO(), "loon reader params reconfigured",
+			mlog.String("source", source),
+			mlog.Int64("readerThreadPoolSizeRequested", requested),
+			mlog.Int64("readerThreadPoolSizeEffective", effective),
+			mlog.Int64("indexBuildReadWindowBytes", pt.CommonCfg.IndexBuildReadWindowBytes.GetAsInt64()))
+	}
+	pt.Watch(pt.CommonCfg.StorageReaderThreadPoolSize.Key,
+		config.NewHandler(pt.CommonCfg.StorageReaderThreadPoolSize.Key, handler))
+	pt.Watch(pt.CommonCfg.IndexBuildReadWindowBytes.Key,
+		config.NewHandler(pt.CommonCfg.IndexBuildReadWindowBytes.Key, handler))
+}
+
 func UpdateStorageV2CellTargetSizeBytes(bytes int64) {
 	C.SetStorageV2CellTargetSizeBytes(C.int64_t(bytes))
 }

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -203,7 +203,11 @@ func RegisterLoonReaderConfigWatchers(pt *paramtable.ComponentParam, source stri
 		// InitLoonReaderConfig range-checks both values before applying
 		// either, so an out-of-range update leaves the running settings
 		// untouched rather than resizing the (non-destroyable) reader pool
-		// and only then failing on the window.
+		// and only then failing on the window. It also serializes
+		// read-then-apply internally, so concurrent updates cannot land in
+		// the reverse order of the config writes; the logging below reads
+		// the paramtable again outside that critical section, so under
+		// concurrent updates the logged values may lag the applied ones.
 		if err := InitLoonReaderConfig(pt); err != nil {
 			mlog.Warn(context.TODO(),
 				"failed to reconfigure loon reader params, previous settings stay in effect",

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -200,19 +200,33 @@ func RegisterLoonReaderConfigWatchers(pt *paramtable.ComponentParam, source stri
 		if !evt.HasUpdated {
 			return
 		}
+		// InitLoonReaderConfig range-checks both values before applying
+		// either, so an out-of-range update leaves the running settings
+		// untouched rather than resizing the (non-destroyable) reader pool
+		// and only then failing on the window.
 		if err := InitLoonReaderConfig(pt); err != nil {
-			mlog.Warn(context.TODO(), "failed to reconfigure loon reader params",
-				mlog.String("source", source), mlog.Err(err))
+			mlog.Warn(context.TODO(),
+				"failed to reconfigure loon reader params, previous settings stay in effect",
+				mlog.String("source", source),
+				mlog.Int64("readerThreadPoolSize", pt.CommonCfg.StorageReaderThreadPoolSize.GetAsInt64()),
+				mlog.Int64("indexBuildReadWindowBytes", pt.CommonCfg.IndexBuildReadWindowBytes.GetAsInt64()),
+				mlog.Err(err))
 			return
 		}
 		// Report the effective pool size, not the requested one: non-zero
 		// values resize the pool either way, but 0 cannot destroy it, so
-		// rolling back to 0 leaves the existing pool serving reads.
-		// Readers also latch parallelism when they open, so a change only
-		// affects tasks started afterwards.
+		// rolling back to 0 leaves the existing pool serving reads. Note a
+		// reader latches the parallelism it saw at open only as an on/off
+		// gate; a reader opened with parallelism > 1 follows the pool's
+		// current size on every later round, so resizes also affect
+		// already-open readers.
+		// GetParallelism() reports 1 when the pool does not exist, so
+		// requested == 0 with effective == 1 is the pool being absent (or
+		// sized 1) - not a failure to destroy it. Only warn when a real
+		// pool survives a disable request.
 		requested := pt.CommonCfg.StorageReaderThreadPoolSize.GetAsInt64()
 		effective := int64(EffectiveLoonReaderThreadPoolSize())
-		if requested != effective {
+		if requested == 0 && effective > 1 {
 			mlog.Warn(context.TODO(),
 				"loon reader thread pool size not fully applied; the pool cannot be destroyed at runtime, restart to disable it",
 				mlog.String("source", source),

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -247,6 +247,8 @@ type commonConfig struct {
 	ArrowIOThreadPoolMaxCapacity        ParamItem `refreshable:"true"`
 	ArrowReaderHoleSizeLimitBytes       ParamItem `refreshable:"true"`
 	ArrowReaderRangeSizeLimitBytes      ParamItem `refreshable:"true"`
+	StorageReaderThreadPoolSize         ParamItem `refreshable:"true"`
+	IndexBuildReadWindowBytes           ParamItem `refreshable:"true"`
 	EnableMaterializedView              ParamItem `refreshable:"false"`
 	BuildIndexThreadPoolRatio           ParamItem `refreshable:"false"`
 	MaxDegree                           ParamItem `refreshable:"true"`
@@ -787,6 +789,54 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export: false,
 	}
 	p.ArrowReaderRangeSizeLimitBytes.Init(base.mgr)
+
+	p.StorageReaderThreadPoolSize = ParamItem{
+		Key:          "common.storage.readerThreadPoolSize",
+		Version:      "3.0.0",
+		DefaultValue: "0",
+		Doc: `Size of milvus-storage's global reader thread pool. When > 0, chunk ` +
+			`(row-group) reads issued by one storage-v3/external reader may be ` +
+			`fanned out across this pool. 0 keeps the pre-existing sequential ` +
+			`behavior. ` +
+			`IMPORTANT: milvus-storage splits a round's chunks into contiguous ` +
+			`blocks and merges them without limit when the chunk count does not ` +
+			`exceed the pool size, so a round whose chunks are contiguous and ` +
+			`fewer than or equal to this value is submitted as a SINGLE task and ` +
+			`gains no fan-out. To get real per-chunk parallelism the number of ` +
+			`chunks per round must exceed this value — see ` +
+			`common.storage.indexBuildReadWindowBytes. Range-level parallelism ` +
+			`from arrow's parquet prebuffer (common.arrow.ioThreadPoolCoefficient) ` +
+			`is independent of this pool. ` +
+			`Values > 0 resize the pool in both directions at runtime. Setting ` +
+			`0 after the pool exists is a no-op — the pool cannot be destroyed, ` +
+			`so disabling it entirely requires a restart. Readers latch the ` +
+			`parallelism when they open, so any change only affects tasks ` +
+			`started afterwards.`,
+		Export: false,
+	}
+	p.StorageReaderThreadPoolSize.Init(base.mgr)
+
+	p.IndexBuildReadWindowBytes = ParamItem{
+		Key:          "common.storage.indexBuildReadWindowBytes",
+		Version:      "3.0.0",
+		DefaultValue: "0",
+		Doc: `Per-round read window in bytes (milvus-storage reader.record_batch_max_size) ` +
+			`for index-build manifest reads. The default window (0 = milvus-storage's ` +
+			`32MB) admits a single 64MB-class parquet row group per prefetch round, ` +
+			`serializing the raw-data download to one object-storage range read at a ` +
+			`time. Set to N x row-group-size so one round spans multiple row groups, ` +
+			`whose column chunks are then prefetched in parallel by arrow ` +
+			`(common.arrow.ioThreadPoolCoefficient). ` +
+			`If you also want per-chunk fan-out on the milvus-storage reader pool, ` +
+			`N must be strictly greater than common.storage.readerThreadPoolSize: ` +
+			`at or below the pool size, contiguous chunks are merged into one task ` +
+			`(e.g. a 1GB window over 64MB row groups is 16 chunks, which a 16-thread ` +
+			`pool executes as a single task). Memory cost: up to this many bytes ` +
+			`buffered per running build task, on top of the decode window. Max 4GB. ` +
+			`Only affects index build; query-node loads keep the default window.`,
+		Export: false,
+	}
+	p.IndexBuildReadWindowBytes.Init(base.mgr)
 
 	p.DiskWriteMode = ParamItem{
 		Key:          "common.diskWriteMode",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -798,9 +798,14 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 			`(row-group) reads issued by one storage-v3/external reader may be ` +
 			`fanned out across this pool. 0 keeps the pre-existing sequential ` +
 			`behavior. ` +
-			`Applies to DataNode only: the pool is created during DataNode's ` +
-			`segcore init, so query-node readers are unaffected and keep ` +
-			`parallelism 1 no matter what this is set to. ` +
+			`Only DataNode's segcore init creates the pool, but the pool itself ` +
+			`is a process-wide singleton in milvus-storage. In a cluster ` +
+			`deployment QueryNode runs in its own process, never creates one, ` +
+			`and keeps parallelism 1 no matter what this is set to. In ` +
+			`standalone all roles share one process, so QueryNode readers ` +
+			`opened after DataNode's segcore init pick up this pool too and ` +
+			`fan out on it — size it with the co-located search traffic in ` +
+			`mind. ` +
 			`IMPORTANT: milvus-storage splits a round's chunks into contiguous ` +
 			`blocks and merges them without limit when the chunk count does not ` +
 			`exceed the pool size, so a round whose chunks are contiguous and ` +

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -798,6 +798,9 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 			`(row-group) reads issued by one storage-v3/external reader may be ` +
 			`fanned out across this pool. 0 keeps the pre-existing sequential ` +
 			`behavior. ` +
+			`Applies to DataNode only: the pool is created during DataNode's ` +
+			`segcore init, so query-node readers are unaffected and keep ` +
+			`parallelism 1 no matter what this is set to. ` +
 			`IMPORTANT: milvus-storage splits a round's chunks into contiguous ` +
 			`blocks and merges them without limit when the chunk count does not ` +
 			`exceed the pool size, so a round whose chunks are contiguous and ` +
@@ -809,9 +812,12 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 			`is independent of this pool. ` +
 			`Values > 0 resize the pool in both directions at runtime. Setting ` +
 			`0 after the pool exists is a no-op — the pool cannot be destroyed, ` +
-			`so disabling it entirely requires a restart. Readers latch the ` +
-			`parallelism when they open, so any change only affects tasks ` +
-			`started afterwards.`,
+			`so disabling it entirely requires a restart. A reader latches the ` +
+			`parallelism it observed at open only as an on/off gate: opened ` +
+			`with <= 1 it stays sequential for its lifetime, while opened ` +
+			`with > 1 it follows the pool's current size on each subsequent ` +
+			`round — so a runtime resize also affects the later rounds of ` +
+			`already-open readers. Max 1024.`,
 		Export: false,
 	}
 	p.StorageReaderThreadPoolSize.Init(base.mgr)
@@ -833,7 +839,10 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 			`(e.g. a 1GB window over 64MB row groups is 16 chunks, which a 16-thread ` +
 			`pool executes as a single task). Memory cost: up to this many bytes ` +
 			`buffered per running build task, on top of the decode window. Max 4GB. ` +
-			`Only affects index build; query-node loads keep the default window.`,
+			`Only affects index build; query-node loads keep the default window. ` +
+			`Batch decode for these reads runs on the segcore LOW-priority pool ` +
+			`(common.threadCoreCoefficient.lowPriority), deliberately not the ` +
+			`MIDDLE pool that serves search reduce.`,
 		Export: false,
 	}
 	p.IndexBuildReadWindowBytes.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -93,6 +93,13 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, int64(1048576), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
 		assert.Equal(t, int64(67108864), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())
 
+		assert.Equal(t, int32(0), Params.StorageReaderThreadPoolSize.GetAsInt32())
+		assert.Equal(t, int64(0), Params.IndexBuildReadWindowBytes.GetAsInt64())
+		params.Save(Params.StorageReaderThreadPoolSize.Key, "16")
+		params.Save(Params.IndexBuildReadWindowBytes.Key, "536870912")
+		assert.Equal(t, int32(16), Params.StorageReaderThreadPoolSize.GetAsInt32())
+		assert.Equal(t, int64(536870912), Params.IndexBuildReadWindowBytes.GetAsInt64())
+
 		assert.Equal(t, Params.GracefulTime.GetAsInt64(), int64(DefaultGracefulTime))
 		t.Logf("default grafeful time = %d", Params.GracefulTime.GetAsInt64())
 


### PR DESCRIPTION
issue: #51707

Master port of #51651 (3.0 branch). The touched read-path code is identical on master. See #51651 for the full measurement history.

## Problem

For external-collection index build, downloading the raw vector data dominates wall time: ~63% of task time with CPU near idle and exactly **one** S3 connection open. Four independent causes can serialize the read path:

1. Arrow reader prebuffer config (`holeSizeLimitBytes`/`rangeSizeLimitBytes`) only reaches the cached singleton properties; index build creates per-task properties and bypasses that map.
2. The milvus-storage global reader thread pool is never initialized (`GetParallelism() == 1`).
3. The per-round prefetch window (32MB default) is smaller than one 64MB-class row group.
4. Batch decode runs single-threaded and alternates with fetch; the raw-data spill materializes the whole raw column before writing.

## Changes

- Stamp prebuffer limits into every freshly built properties map as one coherent snapshot.
- Add two opt-in knobs with C API, DataNode wiring and hot-reload watchers: `common.storage.readerThreadPoolSize` and `common.storage.indexBuildReadWindowBytes`.
- Stream manifest batches through `IterateFieldDataFromManifest`: `ReadNext` remains single-threaded, per-batch decode runs on the LOW background pool under byte/count backpressure, and delivery remains ordered on the caller thread.
- Account in-flight bytes with Arrow referenced-buffer ranges so slices from one row group are charged only for the ranges they reference.
- Stream the raw-data spill so download-phase retention is bounded by the prefetch and decode windows instead of the full raw column.
- Propagate `minio.maxConnections` through DataCoord and all DataNode storage-config conversion paths into the C++ clients. The default remains 100.
- Emit one `[ManifestReadStats]` line per streamed read with fetch, decode-wait and consume phase timing.

## Measured (historical MIDDLE-pool iteration; not the current head)

The earlier 3.0 A/B run used the previous MIDDLE-pool decode implementation: laion 1B external parquet, 768-dim fp32, 8C/32Gi worker, 283s average to 151s average per task, with observed S3 connections increasing from 1 to 19+.

The final head uses the LOW pool, which changes worker count and the derived in-flight batch limit. That variant has not yet been re-benchmarked in the same environment, so the historical numbers do not validate a current-head ~2x claim. A same-environment LOW-pool A/B benchmark is follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)