### PR TITLE
fix: [3.0] keep BM25/MinHash searchable after add_function_field with stale segment index meta

### DIFF
--- a/internal/core/src/common/QueryInfo.h
+++ b/internal/core/src/common/QueryInfo.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "ArrayOffsets.h"
 #include "common/Tracer.h"
@@ -31,6 +32,16 @@ struct SearchIteratorV2Info {
     std::optional<float> last_bound = std::nullopt;
 };
 
+// Brute-force index params sourced from the collection-level index metadata at
+// plan creation. Used only by brute force when a segment predates a field added
+// by add_function_field, so its per-segment metadata does not carry the field.
+struct BruteForceIndexParams {
+    std::optional<float> bm25_k1_;
+    std::optional<float> bm25_b_;
+    std::optional<int64_t> minhash_lsh_band_;
+    std::optional<int64_t> minhash_element_bit_width_;
+};
+
 struct SearchInfo {
     int64_t topk_{0};
     int64_t group_size_{1};
@@ -39,6 +50,7 @@ struct SearchInfo {
     FieldId field_id_;
     MetricType metric_type_;
     knowhere::Json search_params_;
+    BruteForceIndexParams brute_force_index_params_;
     std::vector<FieldId>
         group_by_field_ids_;  // Group by field IDs (single or multi-field)
     tracer::TraceContext trace_ctx_;

--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -87,30 +87,93 @@ PrepareBFSearchParams(const SearchInfo& search_info,
             search_info.trace_ctx_.traceFlags;
     }
 
+    // Per-segment index_info is authoritative when present. A segment that
+    // predates a field added by add_function_field lacks the field there, so
+    // brute force falls back to brute_force_index_params_, sourced from the
+    // collection metadata at plan creation (never routed through search_params_,
+    // so the query hook cannot drop it).
     if (search_info.metric_type_ == knowhere::metric::BM25) {
         search_cfg[knowhere::meta::BM25_AVGDL] =
             search_info.search_params_[knowhere::meta::BM25_AVGDL];
-        search_cfg[knowhere::meta::BM25_K1] =
-            std::stof(index_info.at(knowhere::meta::BM25_K1));
-        search_cfg[knowhere::meta::BM25_B] =
-            std::stof(index_info.at(knowhere::meta::BM25_B));
+        if (index_info.empty()) {
+            const auto& fallback = search_info.brute_force_index_params_;
+            if (fallback.bm25_k1_.has_value()) {
+                search_cfg[knowhere::meta::BM25_K1] = fallback.bm25_k1_.value();
+            }
+            if (fallback.bm25_b_.has_value()) {
+                search_cfg[knowhere::meta::BM25_B] = fallback.bm25_b_.value();
+            }
+        } else {
+            auto it_k1 = index_info.find(knowhere::meta::BM25_K1);
+            if (it_k1 != index_info.end()) {
+                search_cfg[knowhere::meta::BM25_K1] = std::stof(it_k1->second);
+            }
+            auto it_b = index_info.find(knowhere::meta::BM25_B);
+            if (it_b != index_info.end()) {
+                search_cfg[knowhere::meta::BM25_B] = std::stof(it_b->second);
+            }
+        }
     }
 
     if (search_info.metric_type_ == knowhere::metric::MHJACCARD) {
-        auto it_band = index_info.find(knowhere::indexparam::MH_LSH_BAND);
-        if (it_band != index_info.end()) {
-            search_cfg[knowhere::indexparam::MH_LSH_BAND] =
-                std::stoi(it_band->second);
-        }
+        if (index_info.empty()) {
+            const auto& fallback = search_info.brute_force_index_params_;
+            if (fallback.minhash_lsh_band_.has_value()) {
+                search_cfg[knowhere::indexparam::MH_LSH_BAND] =
+                    fallback.minhash_lsh_band_.value();
+            }
+            if (fallback.minhash_element_bit_width_.has_value()) {
+                search_cfg[knowhere::indexparam::MH_ELEMENT_BIT_WIDTH] =
+                    fallback.minhash_element_bit_width_.value();
+            }
+        } else {
+            auto it_band = index_info.find(knowhere::indexparam::MH_LSH_BAND);
+            if (it_band != index_info.end()) {
+                search_cfg[knowhere::indexparam::MH_LSH_BAND] =
+                    std::stoi(it_band->second);
+            }
 
-        auto it_width =
-            index_info.find(knowhere::indexparam::MH_ELEMENT_BIT_WIDTH);
-        if (it_width != index_info.end()) {
-            search_cfg[knowhere::indexparam::MH_ELEMENT_BIT_WIDTH] =
-                std::stoi(it_width->second);
+            auto it_width =
+                index_info.find(knowhere::indexparam::MH_ELEMENT_BIT_WIDTH);
+            if (it_width != index_info.end()) {
+                search_cfg[knowhere::indexparam::MH_ELEMENT_BIT_WIDTH] =
+                    std::stoi(it_width->second);
+            }
         }
     }
     return search_cfg;
+}
+
+void
+PopulateBruteForceIndexParams(SearchInfo& search_info,
+                              const FieldIndexMeta& field_index_meta) {
+    const auto& index_params = field_index_meta.GetIndexParams();
+    auto& params = search_info.brute_force_index_params_;
+
+    if (search_info.metric_type_ == knowhere::metric::BM25) {
+        auto it = index_params.find(knowhere::meta::BM25_K1);
+        if (it != index_params.end()) {
+            params.bm25_k1_ = std::stof(it->second);
+        }
+        it = index_params.find(knowhere::meta::BM25_B);
+        if (it != index_params.end()) {
+            params.bm25_b_ = std::stof(it->second);
+        }
+    } else if (search_info.metric_type_ == knowhere::metric::MHJACCARD) {
+        // Knowhere's construction defaults, materialized so a stale segment
+        // uses the same values as an index whose metadata omitted the optional
+        // params.
+        params.minhash_lsh_band_ = 1;
+        params.minhash_element_bit_width_ = 8;
+        auto it = index_params.find(knowhere::indexparam::MH_LSH_BAND);
+        if (it != index_params.end()) {
+            params.minhash_lsh_band_ = std::stoll(it->second);
+        }
+        it = index_params.find(knowhere::indexparam::MH_ELEMENT_BIT_WIDTH);
+        if (it != index_params.end()) {
+            params.minhash_element_bit_width_ = std::stoll(it->second);
+        }
+    }
 }
 
 std::pair<knowhere::DataSetPtr, knowhere::DataSetPtr>

--- a/internal/core/src/query/SearchBruteForce.h
+++ b/internal/core/src/query/SearchBruteForce.h
@@ -17,6 +17,7 @@
 
 #include "common/BitsetView.h"
 #include "common/FieldMeta.h"
+#include "common/IndexMeta.h"
 #include "common/OpContext.h"
 #include "common/QueryInfo.h"
 #include "common/Types.h"
@@ -30,6 +31,21 @@ namespace milvus::query {
 void
 CheckBruteForceSearchParam(const FieldMeta& field,
                            const SearchInfo& search_info);
+
+// Assemble the knowhere config for a brute-force search. BM25/MinHash params
+// are taken from index_info when present, otherwise from the plan-delivered
+// search_params_. Exposed for unit testing.
+knowhere::Json
+PrepareBFSearchParams(const SearchInfo& search_info,
+                      const std::map<std::string, std::string>& index_info);
+
+// Populate SearchInfo::brute_force_index_params_ from a field's collection-level
+// index metadata (BM25 k1/b, MinHash band/width). Called at plan creation so
+// brute force has a fallback when a segment predates a field added by
+// add_function_field. Exposed for unit testing.
+void
+PopulateBruteForceIndexParams(SearchInfo& search_info,
+                              const FieldIndexMeta& field_index_meta);
 
 SubSearchResult
 BruteForceSearch(const dataset::SearchDataset& query_ds,

--- a/internal/core/src/query/SearchBruteForceSparseTest.cpp
+++ b/internal/core/src/query/SearchBruteForceSparseTest.cpp
@@ -204,3 +204,43 @@ TEST_F(TestSparseFloatSearchBruteForce, IP) {
     Run(100, 10, 5, "IP");
     Run(100, 10, 5, "ip");
 }
+
+// Behavioral regression for #51366: a segment that predates a BM25 field added
+// by add_function_field keeps its original per-segment index meta, so the
+// brute-force path receives an empty index_info. k1/b then come from
+// brute_force_index_params_ (sourced from the collection meta at plan creation);
+// the search must run instead of tripping the missing-field assert.
+TEST(SparseBM25BruteForce, RunsWithEmptyIndexInfoUsingFallbackParams) {
+    const int nb = 100, nq = 5, topk = 5;
+    auto bitset = std::make_shared<BitsetType>();
+    bitset->resize(nb);
+    auto bitset_view = BitsetView(*bitset);
+
+    auto base = milvus::segcore::GenerateRandomSparseFloatVector(nb);
+    auto query = milvus::segcore::GenerateRandomSparseFloatVector(nq);
+    dataset::SearchDataset query_dataset{
+        knowhere::metric::BM25, nq, topk, -1, kTestSparseDim, query.get()};
+    auto raw_dataset =
+        query::dataset::RawDataset{0, kTestSparseDim, nb, base.get()};
+
+    SearchInfo search_info;
+    search_info.topk_ = topk;
+    search_info.metric_type_ = knowhere::metric::BM25;
+    // avgdl still rides the plan (typed field); k1/b come from the fallback.
+    search_info.search_params_[knowhere::meta::BM25_AVGDL] = 5.0;
+    search_info.brute_force_index_params_.bm25_k1_ = 1.2f;
+    search_info.brute_force_index_params_.bm25_b_ = 0.75f;
+
+    std::map<std::string, std::string> empty_index_info;
+    ASSERT_NO_THROW({
+        auto result = BruteForceSearch(query_dataset,
+                                       raw_dataset,
+                                       search_info,
+                                       empty_index_info,
+                                       bitset_view,
+                                       DataType::VECTOR_SPARSE_U32_F32,
+                                       DataType::NONE,
+                                       nullptr);
+        (void)result;
+    });
+}

--- a/internal/core/src/query/SearchBruteForceTest.cpp
+++ b/internal/core/src/query/SearchBruteForceTest.cpp
@@ -188,3 +188,98 @@ TEST_F(TestFloatSearchBruteForce, IP) {
 TEST_F(TestFloatSearchBruteForce, NotSupported) {
     Run(100, 10, 5, 128, "aaaaaaaaaaaa");
 }
+
+TEST(PrepareBFSearchParams, BM25ParamsFromIndexInfo) {
+    SearchInfo search_info;
+    search_info.metric_type_ = knowhere::metric::BM25;
+    search_info.search_params_[knowhere::meta::BM25_AVGDL] = 5.0;
+    std::map<std::string, std::string> index_info{
+        {knowhere::meta::BM25_K1, "2.0"},
+        {knowhere::meta::BM25_B, "0.5"},
+    };
+    auto cfg = PrepareBFSearchParams(search_info, index_info);
+    ASSERT_FLOAT_EQ(cfg[knowhere::meta::BM25_K1].get<float>(), 2.0f);
+    ASSERT_FLOAT_EQ(cfg[knowhere::meta::BM25_B].get<float>(), 0.5f);
+    ASSERT_DOUBLE_EQ(cfg[knowhere::meta::BM25_AVGDL].get<double>(), 5.0);
+}
+
+// A field added by add_function_field leaves the per-segment index_info empty;
+// k1/b then come from brute_force_index_params_ (sourced from the collection
+// metadata at plan creation), not the stale segment meta, and must not throw.
+TEST(PrepareBFSearchParams, BM25ParamsFromCollectionMetaWhenIndexInfoEmpty) {
+    SearchInfo search_info;
+    search_info.metric_type_ = knowhere::metric::BM25;
+    search_info.search_params_[knowhere::meta::BM25_AVGDL] = 5.0;
+    search_info.brute_force_index_params_.bm25_k1_ = 1.2f;
+    search_info.brute_force_index_params_.bm25_b_ = 0.75f;
+    std::map<std::string, std::string> empty_index_info;
+    knowhere::Json cfg;
+    ASSERT_NO_THROW(cfg = PrepareBFSearchParams(search_info, empty_index_info));
+    ASSERT_FLOAT_EQ(cfg[knowhere::meta::BM25_K1].get<float>(), 1.2f);
+    ASSERT_FLOAT_EQ(cfg[knowhere::meta::BM25_B].get<float>(), 0.75f);
+}
+
+TEST(PrepareBFSearchParams, MinHashParams) {
+    // present per-segment params are parsed from index_info
+    SearchInfo search_info;
+    search_info.metric_type_ = knowhere::metric::MHJACCARD;
+    std::map<std::string, std::string> index_info{
+        {knowhere::indexparam::MH_LSH_BAND, "8"},
+        {knowhere::indexparam::MH_ELEMENT_BIT_WIDTH, "16"},
+    };
+    auto cfg = PrepareBFSearchParams(search_info, index_info);
+    ASSERT_EQ(cfg[knowhere::indexparam::MH_LSH_BAND].get<int>(), 8);
+    ASSERT_EQ(cfg[knowhere::indexparam::MH_ELEMENT_BIT_WIDTH].get<int>(), 16);
+
+    // a stale segment leaves index_info empty; band/width then come from
+    // brute_force_index_params_ (collection metadata), not knowhere defaults.
+    SearchInfo stale_info;
+    stale_info.metric_type_ = knowhere::metric::MHJACCARD;
+    stale_info.brute_force_index_params_.minhash_lsh_band_ = 4;
+    stale_info.brute_force_index_params_.minhash_element_bit_width_ = 32;
+    std::map<std::string, std::string> empty_index_info;
+    knowhere::Json cfg2;
+    ASSERT_NO_THROW(cfg2 = PrepareBFSearchParams(stale_info, empty_index_info));
+    ASSERT_EQ(cfg2[knowhere::indexparam::MH_LSH_BAND].get<int>(), 4);
+    ASSERT_EQ(cfg2[knowhere::indexparam::MH_ELEMENT_BIT_WIDTH].get<int>(), 32);
+}
+
+// plan-creation side: params are sourced from the collection-level field index
+// meta into brute_force_index_params_.
+TEST(PopulateBruteForceIndexParams, BM25) {
+    SearchInfo search_info;
+    search_info.metric_type_ = knowhere::metric::BM25;
+    FieldIndexMeta meta(
+        FieldId(100),
+        {{knowhere::meta::BM25_K1, "2.0"}, {knowhere::meta::BM25_B, "0.5"}},
+        {});
+    PopulateBruteForceIndexParams(search_info, meta);
+    const auto& p = search_info.brute_force_index_params_;
+    ASSERT_TRUE(p.bm25_k1_.has_value());
+    ASSERT_FLOAT_EQ(p.bm25_k1_.value(), 2.0f);
+    ASSERT_TRUE(p.bm25_b_.has_value());
+    ASSERT_FLOAT_EQ(p.bm25_b_.value(), 0.5f);
+}
+
+TEST(PopulateBruteForceIndexParams, MinHashDefaultsWhenAbsent) {
+    SearchInfo search_info;
+    search_info.metric_type_ = knowhere::metric::MHJACCARD;
+    FieldIndexMeta meta(FieldId(100), {}, {});
+    PopulateBruteForceIndexParams(search_info, meta);
+    const auto& p = search_info.brute_force_index_params_;
+    ASSERT_EQ(p.minhash_lsh_band_.value(), 1);
+    ASSERT_EQ(p.minhash_element_bit_width_.value(), 8);
+}
+
+TEST(PopulateBruteForceIndexParams, MinHashOverridesFromMeta) {
+    SearchInfo search_info;
+    search_info.metric_type_ = knowhere::metric::MHJACCARD;
+    FieldIndexMeta meta(FieldId(100),
+                        {{knowhere::indexparam::MH_LSH_BAND, "4"},
+                         {knowhere::indexparam::MH_ELEMENT_BIT_WIDTH, "32"}},
+                        {});
+    PopulateBruteForceIndexParams(search_info, meta);
+    const auto& p = search_info.brute_force_index_params_;
+    ASSERT_EQ(p.minhash_lsh_band_.value(), 4);
+    ASSERT_EQ(p.minhash_element_bit_width_.value(), 32);
+}

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -170,10 +170,15 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                                               query_offsets};
         int32_t current_chunk_id = 0;
 
-        // get index params for bm25 and minhash brute force
+        // get index params for bm25 and minhash brute force.
+        // A field added by add_function_field is absent from the growing
+        // record's index_meta_ snapshot, so guard with has_field_index_meta:
+        // BM25 k1/b are delivered through the plan, MinHash falls back to
+        // defaults for the brief window before the segment is reloaded.
         std::map<std::string, std::string> index_info;
-        if (metric_type == knowhere::metric::BM25 ||
-            metric_type == knowhere::metric::MHJACCARD) {
+        if ((metric_type == knowhere::metric::BM25 ||
+             metric_type == knowhere::metric::MHJACCARD) &&
+            segment.get_indexing_record().has_field_index_meta(vecfield_id)) {
             index_info = segment.get_indexing_record()
                              .get_field_index_meta(vecfield_id)
                              .GetIndexParams();

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3555,10 +3555,15 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
         AssertInfo(
             vec_data != nullptr, "vector field {} not loaded", field_id.get());
 
-        // get index params for bm25 and minhash brute force
+        // get index params for bm25 and minhash brute force.
+        // A field added by add_function_field is absent from this segment's
+        // construction-time col_index_meta_ snapshot, so guard with HasField:
+        // BM25 k1/b are delivered through the plan, MinHash falls back to
+        // defaults for the brief window before the segment is reloaded.
         std::map<std::string, std::string> index_info;
-        if (search_info.metric_type_ == knowhere::metric::BM25 ||
-            search_info.metric_type_ == knowhere::metric::MHJACCARD) {
+        if ((search_info.metric_type_ == knowhere::metric::BM25 ||
+             search_info.metric_type_ == knowhere::metric::MHJACCARD) &&
+            col_index_meta_ != nullptr && col_index_meta_->HasField(field_id)) {
             index_info =
                 col_index_meta_->GetFieldIndexMeta(field_id).GetIndexParams();
         }

--- a/internal/core/src/segcore/FieldIndexing.h
+++ b/internal/core/src/segcore/FieldIndexing.h
@@ -523,6 +523,11 @@ class IndexingRecord {
     }
 
     bool
+    has_field_index_meta(FieldId fieldId) const {
+        return index_meta_ != nullptr && index_meta_->HasField(fieldId);
+    }
+
+    bool
     is_in(FieldId field_id) const {
         return field_indexings_.count(field_id);
     }

--- a/internal/core/src/segcore/plan_c.cpp
+++ b/internal/core/src/segcore/plan_c.cpp
@@ -28,6 +28,7 @@
 #include "query/Plan.h"
 #include "query/PlanImpl.h"
 #include "query/PlanNode.h"
+#include "query/SearchBruteForce.h"
 #include "segcore/Collection.h"
 #include "segcore/plan_c.h"
 
@@ -62,8 +63,10 @@ CreateSearchPlanByExpr(CCollection c_col,
 
         auto field_index_meta =
             col_index_meta->GetFieldIndexMeta(milvus::FieldId(field_id));
-        res->plan_node_->search_info_.metric_type_ =
-            field_index_meta.GeMetricType();
+        auto& search_info = res->plan_node_->search_info_;
+        search_info.metric_type_ = field_index_meta.GeMetricType();
+        milvus::query::PopulateBruteForceIndexParams(search_info,
+                                                     field_index_meta);
 
         auto status = CStatus();
         status.error_code = milvus::Success;


### PR DESCRIPTION
issue: #51366
pr: #51692

Cherry-pick of #51692 to the 3.0 branch.

## Problem

A field added by `add_function_field` (a BM25 or MinHash function output field) can stay unsearchable: the search keeps failing with `field index meta not found for field N` (an `AssertInfo` in `IndexMeta.cpp`) even though `describe_index` reports the index `Finished`, until the collection is released and loaded again.

Root cause: a segment captures its index meta at construction time — the per-segment `ChunkedSegmentSealedImpl::col_index_meta_`, and the growing `IndexingRecord::index_meta_`. A schema-only reopen refreshes the schema but not this snapshot, so a field added by `add_function_field` is missing from it. On segments without a built sparse index (sealed segments below the index-build threshold, and growing segments), BM25/MinHash brute force fetched the field's index params via `GetFieldIndexMeta`, which asserts on the missing field.

## Fix

- Guard the brute-force index-param fetch at both `vector_search` entry points (`ChunkedSegmentSealedImpl` and `SegmentGrowingImpl` via `SearchOnGrowing`) with `HasField`, so a field missing from the stale snapshot no longer trips the assert.
- Source the brute-force index params (BM25 `k1`/`b`, MinHash `mh_lsh_band`/`mh_element_bit_width`) from the collection-level index meta at plan creation (`plan_c.cpp`) into `SearchInfo::brute_force_index_params_` — the same source already used for `metric_type`. Brute force falls back to it when the per-segment meta lacks the field. These params never route through `search_params`, so the query hook cannot drop them, and MinHash defaults to knowhere's construction values when the index omits them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
