### PR TITLE
enhance: [2.6] remove deprecated num_load_thread/num_threads DiskANN params

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -963,7 +963,6 @@ common:
     PQCodeBudgetGBRatio: 0.125
     BuildNumThreadsRatio: 1
     SearchCacheBudgetGBRatio: 0.1
-    LoadNumThreadRatio: 8
     BeamWidthRatio: 4
   gracefulTime: 5000 # milliseconds. it represents the interval (in ms) by which the request arrival time needs to be subtracted in the case of Bounded Consistency.
   gracefulStopTimeout: 1800 # seconds. it will force quit the server if the graceful stop process is not completed during this time.

--- a/internal/core/src/index/Meta.h
+++ b/internal/core/src/index/Meta.h
@@ -103,10 +103,8 @@ constexpr const char* DISK_ANN_PQ_CODE_BUDGET = "pq_code_budget_gb";
 constexpr const char* DISK_ANN_BUILD_DRAM_BUDGET = "build_dram_budget_gb";
 constexpr const char* DISK_ANN_BUILD_THREAD_NUM = "num_build_thread";
 constexpr const char* DISK_ANN_PQ_DIMS = "disk_pq_dims";
-constexpr const char* DISK_ANN_THREADS_NUM = "num_threads";
 
 // DiskAnn prepare params
-constexpr const char* DISK_ANN_LOAD_THREAD_NUM = "num_load_thread";
 constexpr const char* DISK_ANN_SEARCH_CACHE_BUDGET = "search_cache_budget_gb";
 constexpr const char* DISK_ANN_PREPARE_WARM_UP = "warm_up";
 constexpr const char* DISK_ANN_PREPARE_USE_BFS_CACHE = "use_bfs_cache";

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -458,16 +458,6 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
 
     build_config[DISK_ANN_PREFIX_PATH] = local_index_path_prefix;
 
-    if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
-        auto num_threads = GetValueFromConfig<std::string>(
-            build_config, DISK_ANN_BUILD_THREAD_NUM);
-        AssertInfo(num_threads.has_value(),
-                   "param {} is empty",
-                   DISK_ANN_BUILD_THREAD_NUM);
-        build_config[DISK_ANN_THREADS_NUM] =
-            std::atoi(num_threads.value().c_str());
-    }
-
     auto opt_fields = GetValueFromConfig<OptFieldT>(config, VEC_OPT_FIELDS);
     auto is_partition_key_isolation =
         GetValueFromConfig<bool>(build_config, "partition_key_isolation");
@@ -561,15 +551,6 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         return;
     }
 
-    if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
-        auto num_threads = GetValueFromConfig<std::string>(
-            build_config, DISK_ANN_BUILD_THREAD_NUM);
-        AssertInfo(num_threads.has_value(),
-                   "param {} is empty",
-                   DISK_ANN_BUILD_THREAD_NUM);
-        build_config[DISK_ANN_THREADS_NUM] =
-            std::atoi(num_threads.value().c_str());
-    }
     if (!local_chunk_manager->Exist(local_data_path)) {
         local_chunk_manager->CreateFile(local_data_path);
     }
@@ -848,15 +829,6 @@ VectorDiskAnnIndex<T>::update_load_json(const Config& config) {
         // set base info
         load_config[DISK_ANN_PREPARE_WARM_UP] = false;
         load_config[DISK_ANN_PREPARE_USE_BFS_CACHE] = false;
-
-        // set threads number
-        auto num_threads = GetValueFromConfig<std::string>(
-            load_config, DISK_ANN_LOAD_THREAD_NUM);
-        AssertInfo(num_threads.has_value(),
-                   "param {} is empty",
-                   DISK_ANN_LOAD_THREAD_NUM);
-        load_config[DISK_ANN_THREADS_NUM] =
-            std::atoi(num_threads.value().c_str());
 
         // update search_beamwidth
         auto beamwidth = GetValueFromConfig<std::string>(

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -1554,7 +1554,6 @@ TEST_F(DiskAnnFileManagerTest, LoadAllNullNullableDiskVectorIndexFromDataset) {
 
     milvus::Config load_config;
     load_config[DIM_KEY] = dim;
-    load_config[milvus::index::DISK_ANN_LOAD_THREAD_NUM] = "1";
     load_config["index_files"] = files;
 
     loaded_index.Load(milvus::tracer::TraceContext{}, load_config);

--- a/internal/core/unittest/test_utils/indexbuilder_test_utils.h
+++ b/internal/core/unittest/test_utils/indexbuilder_test_utils.h
@@ -136,7 +136,6 @@ generate_load_conf(const milvus::IndexType& index_type,
         return knowhere::Json{
             {knowhere::meta::METRIC_TYPE, metric_type},
             {knowhere::meta::DIM, std::to_string(DIM)},
-            {milvus::index::DISK_ANN_LOAD_THREAD_NUM, std::to_string(2)},
             {milvus::index::DISK_ANN_SEARCH_CACHE_BUDGET,
              std::to_string(0.05 * sizeof(DataType) * nb /
                             (1024.0 * 1024.0 * 1024.0))},

--- a/pkg/util/indexparams/index_params.go
+++ b/pkg/util/indexparams/index_params.go
@@ -35,7 +35,6 @@ const (
 	PQCodeBudgetRatioKey      = "pq_code_budget_gb_ratio"
 	NumBuildThreadRatioKey    = "num_build_thread_ratio"
 	SearchCacheBudgetRatioKey = "search_cache_budget_gb_ratio"
-	NumLoadThreadRatioKey     = "num_load_thread_ratio"
 	BeamWidthRatioKey         = "beamwidth_ratio"
 
 	MaxDegreeKey         = "max_degree"
@@ -44,11 +43,9 @@ const (
 	BuildDramBudgetKey   = "build_dram_budget_gb"
 	NumBuildThreadKey    = "num_build_thread"
 	SearchCacheBudgetKey = "search_cache_budget_gb"
-	NumLoadThreadKey     = "num_load_thread"
 	BeamWidthKey         = "beamwidth"
 
-	MaxLoadThread = 64
-	MaxBeamWidth  = 16
+	MaxBeamWidth = 16
 )
 
 var configableIndexParams = typeutil.NewSet[string]()
@@ -73,7 +70,6 @@ type BigDataIndexExtraParams struct {
 	PQCodeBudgetGBRatio      float64
 	BuildNumThreadsRatio     float64
 	SearchCacheBudgetGBRatio float64
-	LoadNumThreadRatio       float64
 	BeamWidthRatio           float64
 }
 
@@ -83,7 +79,6 @@ const (
 	DefaultPQCodeBudgetGBRatio      = 0.125
 	DefaultBuildNumThreadsRatio     = 1.0
 	DefaultSearchCacheBudgetGBRatio = 0.10
-	DefaultLoadNumThreadRatio       = 8.0
 	DefaultBeamWidthRatio           = 4.0
 )
 
@@ -132,7 +127,6 @@ func NewBigDataExtraParamsFromMap(value map[string]string) (*BigDataIndexExtraPa
 	prepareRatio, ok := value[PrepareRatioKey]
 	if !ok {
 		ret.SearchCacheBudgetGBRatio = DefaultSearchCacheBudgetGBRatio
-		ret.LoadNumThreadRatio = DefaultLoadNumThreadRatio
 	} else {
 		valueMap2 := make(map[string]float64)
 		err = json.Unmarshal([]byte(prepareRatio), &valueMap2)
@@ -142,12 +136,6 @@ func NewBigDataExtraParamsFromMap(value map[string]string) (*BigDataIndexExtraPa
 		SearchCacheBudgetGBRatio, ok := valueMap2["search_cache_budget_gb"]
 		if ok && !setSearchCache {
 			ret.SearchCacheBudgetGBRatio = SearchCacheBudgetGBRatio
-		}
-		LoadNumThreadRatio, ok := valueMap2["num_threads"]
-		if !ok {
-			ret.LoadNumThreadRatio = DefaultLoadNumThreadRatio
-		} else {
-			ret.LoadNumThreadRatio = LoadNumThreadRatio
 		}
 	}
 	beamWidthRatioStr, ok := value[BeamWidthRatioKey]
@@ -324,7 +312,6 @@ func SetDiskIndexLoadParams(params *paramtable.ComponentParam, indexParams map[s
 	}
 
 	var searchCacheBudgetGBRatio float64
-	var loadNumThreadRatio float64
 	var beamWidthRatio float64
 
 	if params.AutoIndexConfig.Enable.GetAsBool() {
@@ -333,14 +320,9 @@ func SetDiskIndexLoadParams(params *paramtable.ComponentParam, indexParams map[s
 			return err
 		}
 		searchCacheBudgetGBRatio = extraParams.SearchCacheBudgetGBRatio
-		loadNumThreadRatio = extraParams.LoadNumThreadRatio
 		beamWidthRatio = extraParams.BeamWidthRatio
 	} else {
 		searchCacheBudgetGBRatio, err = strconv.ParseFloat(params.CommonCfg.SearchCacheBudgetGBRatio.GetValue(), 64)
-		if err != nil {
-			return err
-		}
-		loadNumThreadRatio, err = strconv.ParseFloat(params.CommonCfg.LoadNumThreadRatio.GetValue(), 64)
 		if err != nil {
 			return err
 		}
@@ -352,12 +334,6 @@ func SetDiskIndexLoadParams(params *paramtable.ComponentParam, indexParams map[s
 
 	indexParams[SearchCacheBudgetKey] = fmt.Sprintf("%f",
 		float32(getRowDataSizeOfFloatVector(numRows, dim))*float32(searchCacheBudgetGBRatio)/(1<<30))
-
-	numLoadThread := int(float32(hardware.GetCPUNum()) * float32(loadNumThreadRatio))
-	if numLoadThread > MaxLoadThread {
-		numLoadThread = MaxLoadThread
-	}
-	indexParams[NumLoadThreadKey] = strconv.Itoa(numLoadThread)
 
 	beamWidth := int(float32(hardware.GetCPUNum()) * float32(beamWidthRatio))
 	if beamWidth > MaxBeamWidth {

--- a/pkg/util/indexparams/index_params_test.go
+++ b/pkg/util/indexparams/index_params_test.go
@@ -268,16 +268,6 @@ func TestDiskIndexParams(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("%f", float32(getRowDataSizeOfFloatVector(100, 128))*float32(searchCacheBudgetRatio)/(1<<30)), searchCacheBudget)
 
-		numLoadThread, ok := indexParams[NumLoadThreadKey]
-		assert.True(t, ok)
-		numLoadThreadRatio, err := strconv.ParseFloat(params.CommonCfg.LoadNumThreadRatio.GetValue(), 64)
-		assert.NoError(t, err)
-		expectedNumLoadThread := int(float32(hardware.GetCPUNum()) * float32(numLoadThreadRatio))
-		if expectedNumLoadThread > MaxLoadThread {
-			expectedNumLoadThread = MaxLoadThread
-		}
-		assert.Equal(t, strconv.Itoa(expectedNumLoadThread), numLoadThread)
-
 		beamWidth, ok := indexParams[BeamWidthKey]
 		assert.True(t, ok)
 		beamWidthRatio, err := strconv.ParseFloat(params.CommonCfg.BeamWidthRatio.GetValue(), 64)
@@ -293,11 +283,6 @@ func TestDiskIndexParams(t *testing.T) {
 		assert.Error(t, err)
 
 		params.Save(params.CommonCfg.SearchCacheBudgetGBRatio.Key, "0.1")
-		params.Save(params.CommonCfg.LoadNumThreadRatio.Key, "w1")
-		err = SetDiskIndexLoadParams(&params, indexParams, 100)
-		assert.Error(t, err)
-
-		params.Save(params.CommonCfg.LoadNumThreadRatio.Key, "8.0")
 		params.Save(params.CommonCfg.BeamWidthRatio.Key, "w1")
 		err = SetDiskIndexLoadParams(&params, indexParams, 100)
 		assert.Error(t, err)
@@ -328,14 +313,6 @@ func TestDiskIndexParams(t *testing.T) {
 		searchCacheBudget, ok := indexParams[SearchCacheBudgetKey]
 		assert.True(t, ok)
 		assert.Equal(t, fmt.Sprintf("%f", float32(getRowDataSizeOfFloatVector(100, 128))*float32(extraParams.SearchCacheBudgetGBRatio)/(1<<30)), searchCacheBudget)
-
-		numLoadThread, ok := indexParams[NumLoadThreadKey]
-		assert.True(t, ok)
-		expectedNumLoadThread := int(float32(hardware.GetCPUNum()) * float32(extraParams.LoadNumThreadRatio))
-		if expectedNumLoadThread > MaxLoadThread {
-			expectedNumLoadThread = MaxLoadThread
-		}
-		assert.Equal(t, strconv.Itoa(expectedNumLoadThread), numLoadThread)
 
 		beamWidth, ok := indexParams[BeamWidthKey]
 		assert.True(t, ok)
@@ -399,7 +376,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromMap(mapString)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.225, extraParams.SearchCacheBudgetGBRatio)
 
@@ -409,7 +385,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err = NewBigDataExtraParamsFromMap(mapString)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.20, extraParams.SearchCacheBudgetGBRatio)
 	})
@@ -421,7 +396,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromMap(mapString)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.15, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.225, extraParams.SearchCacheBudgetGBRatio)
 
@@ -431,7 +405,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err = NewBigDataExtraParamsFromMap(mapString)
 		assert.NoError(t, err)
 		assert.Equal(t, 2.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.225, extraParams.SearchCacheBudgetGBRatio)
 
@@ -456,7 +429,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromMap(mapString)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.25, extraParams.SearchCacheBudgetGBRatio)
 
@@ -466,7 +438,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err = NewBigDataExtraParamsFromMap(mapString)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 4.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 
@@ -483,7 +454,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromMap(mapString)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 	})
@@ -494,7 +464,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromMap(mapString)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.225, extraParams.SearchCacheBudgetGBRatio)
 	})
@@ -504,7 +473,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromMap(mapString)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 	})
@@ -513,7 +481,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromMap(nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 	})
@@ -529,7 +496,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromJSON(jsonStr)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.225, extraParams.SearchCacheBudgetGBRatio)
 		assert.Equal(t, 8.0, extraParams.BeamWidthRatio)
@@ -544,7 +510,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromJSON(jsonStr)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 		assert.Equal(t, 4.0, extraParams.BeamWidthRatio)
@@ -558,7 +523,6 @@ func TestBigDataIndex_parse(t *testing.T) {
 		extraParams, err := NewBigDataExtraParamsFromJSON(jsonStr)
 		assert.NoError(t, err)
 		assert.Equal(t, 1.0, extraParams.BuildNumThreadsRatio)
-		assert.Equal(t, 8.0, extraParams.LoadNumThreadRatio)
 		assert.Equal(t, 0.125, extraParams.PQCodeBudgetGBRatio)
 		assert.Equal(t, 0.10, extraParams.SearchCacheBudgetGBRatio)
 		assert.Equal(t, 4.0, extraParams.BeamWidthRatio)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -60,7 +60,6 @@ const (
 	DefaultPQCodeBudgetGBRatio      = 0.125
 	DefaultBuildNumThreadsRatio     = 1.0
 	DefaultSearchCacheBudgetGBRatio = 0.10
-	DefaultLoadNumThreadRatio       = 8.0
 	DefaultBeamWidthRatio           = 4.0
 	MaxClusterIDBits                = 3
 )
@@ -251,7 +250,6 @@ type commonConfig struct {
 	PQCodeBudgetGBRatio                 ParamItem `refreshable:"true"`
 	BuildNumThreadsRatio                ParamItem `refreshable:"true"`
 	SearchCacheBudgetGBRatio            ParamItem `refreshable:"true"`
-	LoadNumThreadRatio                  ParamItem `refreshable:"true"`
 	BeamWidthRatio                      ParamItem `refreshable:"true"`
 	GracefulTime                        ParamItem `refreshable:"true"`
 	GracefulStopTimeout                 ParamItem `refreshable:"true"`
@@ -632,14 +630,6 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.SearchCacheBudgetGBRatio.Init(base.mgr)
-
-	p.LoadNumThreadRatio = ParamItem{
-		Key:          "common.DiskIndex.LoadNumThreadRatio",
-		Version:      "2.0.0",
-		DefaultValue: strconv.Itoa(DefaultLoadNumThreadRatio),
-		Export:       true,
-	}
-	p.LoadNumThreadRatio.Init(base.mgr)
 
 	p.BeamWidthRatio = ParamItem{
 		Key:          "common.DiskIndex.BeamWidthRatio",


### PR DESCRIPTION
## Summary

Cherry-pick of #51713 to the 2.6 branch.

knowhere removed the OpenMP-based `num_threads` field from the DiskANN index configuration in favor of an internal thread pool (https://github.com/milvus-io/knowhere/pull/759). This removes the now-dead Milvus-side logic that computed `num_load_thread` and derived the `num_threads` value passed to knowhere:

- **Go**: `NumLoadThreadKey` / `NumLoadThreadRatioKey` / `MaxLoadThread`, the `LoadNumThreadRatio` field and its computation in `SetDiskIndexLoadParams`, and the `common.DiskIndex.LoadNumThreadRatio` config item.
- **C++**: `DISK_ANN_THREADS_NUM` and `DISK_ANN_LOAD_THREAD_NUM` meta keys and the code populating `num_threads` at build/load time in `VectorDiskAnnIndex`.

`num_build_thread` is kept as a still-legal passthrough key.

issue: #51712
pr: #51713

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCog6sFfrSi4U2nJC5X43q
