### PR TITLE
fix: [cp3.0] keep bitmap cursors aligned on skipped offset paths

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -603,6 +603,16 @@ class SegmentExpr : public Expr {
                                               std::move(valid_res));
     }
 
+    // Candidate evaluator contract:
+    // - every logical candidate position advances the evaluator exactly once;
+    // - data == nullptr means the reader already decided the candidate result
+    //   (for example SkipIndex pruning or a NULL reverse lookup), so the
+    //   evaluator must only advance position-indexed state by size and return;
+    // - result and validity for a null batch are owned by the reader.
+    //
+    // This contract keeps callback-local bitmap_input cursors aligned across
+    // raw-data, element-level, and scalar-index-only candidate paths.
+
     // when we have scalar index and index contains raw data, could go with index chunk by offsets
     template <typename T, typename BatchEvaluator, typename... ValTypes>
     int64_t
@@ -1052,6 +1062,11 @@ class SegmentExpr : public Expr {
                       "Json element type is not supported for "
                       "element-level filtering");
 
+        auto array_offsets = segment_->GetArrayOffsets(field_id_);
+        AssertInfo(array_offsets != nullptr,
+                   "ArrayOffsets not found for field {}",
+                   field_id_.get());
+
         int64_t processed_rows = 0;
         int64_t processed_elems = 0;
 
@@ -1092,16 +1107,16 @@ class SegmentExpr : public Expr {
                     auto [data_vec, valid_data] = pw.get();
 
                     for (size_t j = 0; j < static_cast<size_t>(size); j++) {
-                        auto elem_count = data_vec[j].length();
-                        bool is_row_valid = !valid_data.data() || valid_data[j];
+                        const bool is_row_valid =
+                            !valid_data.data() || valid_data[j];
+                        // ArrayOffsets defines a NULL array row as having zero
+                        // logical elements even when its physical payload is
+                        // non-empty. Keep the flattened result aligned with
+                        // that logical address space.
+                        const auto elem_count =
+                            is_row_valid ? data_vec[j].length() : 0;
 
-                        if (!is_row_valid) {
-                            // Row is invalid, mark all elements as false
-                            for (size_t k = 0; k < elem_count; k++) {
-                                res[processed_elems + k] =
-                                    valid_res[processed_elems + k] = false;
-                            }
-                        } else {
+                        if (is_row_valid) {
                             // Row is valid, process array elements
                             if constexpr (std::is_same_v<ElementType,
                                                          std::string_view> ||
@@ -1178,16 +1193,15 @@ class SegmentExpr : public Expr {
                     }
 
                     for (size_t j = 0; j < static_cast<size_t>(size); j++) {
-                        auto elem_count = data[j].length();
-                        bool is_row_valid = !valid_data || valid_data[j];
+                        const bool is_row_valid = !valid_data || valid_data[j];
+                        // ArrayOffsets defines a NULL array row as having zero
+                        // logical elements even when its physical payload is
+                        // non-empty. Keep the flattened result aligned with
+                        // that logical address space.
+                        const auto elem_count =
+                            is_row_valid ? data[j].length() : 0;
 
-                        if (!is_row_valid) {
-                            // Row is invalid, mark all elements as false
-                            for (size_t k = 0; k < elem_count; k++) {
-                                res[processed_elems + k] =
-                                    valid_res[processed_elems + k] = false;
-                            }
-                        } else {
+                        if (is_row_valid) {
                             // Row is valid, process array elements
                             if constexpr (std::is_same_v<ElementType,
                                                          std::string_view> ||
@@ -1254,59 +1268,31 @@ class SegmentExpr : public Expr {
                     }
                 }
             } else {
-                // Chunk is skipped. Preserve NULL validity and advance the
-                // evaluator once for every logical element so callbacks that
-                // index bitmap_input with a local cursor stay aligned.
-                const auto skipped_start = processed_elems;
-                if (segment_->type() == SegmentType::Sealed) {
-                    auto pw = segment_->get_batch_views<ArrayView>(
-                        op_ctx_, field_id_, i, data_pos, size);
-                    auto [data_vec, valid_data] = pw.get();
-
-                    for (size_t j = 0; j < static_cast<size_t>(size); j++) {
-                        auto elem_count = data_vec[j].length();
-                        const bool row_valid =
-                            !valid_data.data() || valid_data[j];
-                        if (!row_valid) {
-                            for (size_t k = 0; k < elem_count; k++) {
-                                res[processed_elems + k] =
-                                    valid_res[processed_elems + k] = false;
-                            }
-                        }
-                        processed_elems += elem_count;
-                    }
-                } else {
-                    auto pw =
-                        segment_->chunk_data<Array>(op_ctx_, field_id_, i);
-                    auto chunk = pw.get();
-                    const Array* data = chunk.data() + data_pos;
-                    const bool* valid_data = chunk.valid_data();
-                    if (valid_data != nullptr) {
-                        valid_data += data_pos;
-                    }
-
-                    for (size_t j = 0; j < static_cast<size_t>(size); j++) {
-                        auto elem_count = data[j].length();
-                        const bool row_valid = !valid_data || valid_data[j];
-                        if (!row_valid) {
-                            for (size_t k = 0; k < elem_count; k++) {
-                                res[processed_elems + k] =
-                                    valid_res[processed_elems + k] = false;
-                            }
-                        }
-                        processed_elems += elem_count;
-                    }
-                }
-                const auto skipped_elems = processed_elems - skipped_start;
+                // Chunk is skipped. ArrayOffsets is the source of truth for
+                // the logical element address space: nullable rows contribute
+                // zero elements even if storage retains a physical payload.
+                // Derive the skipped span without inspecting that payload.
+                const int64_t row_start =
+                    segment_->is_chunked()
+                        ? segment_->num_rows_until_chunk(field_id_, i) +
+                              data_pos
+                        : static_cast<int64_t>(i) * size_per_chunk_ + data_pos;
+                const auto start_range =
+                    array_offsets->ElementIDRangeOfRow(row_start);
+                const auto end_range =
+                    array_offsets->ElementIDRangeOfRow(row_start + size);
+                const auto skipped_elems =
+                    int64_t{end_range.first - start_range.first};
                 if (skipped_elems > 0) {
                     evaluate_batch(nullptr,
                                    nullptr,
                                    nullptr,
                                    skipped_elems,
-                                   res + skipped_start,
-                                   valid_res + skipped_start,
+                                   res + processed_elems,
+                                   valid_res + processed_elems,
                                    values...);
                 }
+                processed_elems += skipped_elems;
             }
 
             processed_rows += size;

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -575,100 +575,6 @@ class SegmentExpr : public Expr {
         return {batch_rows, elem_count};
     }
 
-    // used for processing raw data expr for sealed segments.
-    // now only used for std::string_view && json
-    // TODO: support more types
-    template <typename T,
-              bool NeedSegmentOffsets = false,
-              typename FUNC,
-              typename... ValTypes>
-    int64_t
-    ProcessChunkForSealedSeg(
-        FUNC func,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
-        TargetBitmapView res,
-        TargetBitmapView valid_res,
-        const ValTypes&... values) {
-        // For sealed segment, only single chunk
-        Assert(num_data_chunk_ == 1);
-        auto need_size =
-            std::min(active_count_ - current_data_chunk_pos_, batch_size_);
-        if (need_size == 0)
-            return 0;  //do not go empty-loop at the bound of the chunk
-
-        auto skip_index = segment_->GetSkipIndex();
-        auto pw = segment_->get_batch_views<T>(
-            op_ctx_, field_id_, 0, current_data_chunk_pos_, need_size);
-        auto views_info = pw.get();
-        if (!skip_func || !skip_func(*skip_index, field_id_, 0)) {
-            // first is the raw data, second is valid_data
-            // use valid_data to see if raw data is null
-            if constexpr (NeedSegmentOffsets) {
-                // For GIS functions: construct segment offsets array
-                std::vector<int32_t> segment_offsets_array(need_size);
-                for (int64_t j = 0; j < need_size; ++j) {
-                    segment_offsets_array[j] =
-                        static_cast<int32_t>(current_data_chunk_pos_ + j);
-                }
-                func(views_info.first.data(),
-                     views_info.second.data(),
-                     nullptr,
-                     segment_offsets_array.data(),
-                     need_size,
-                     res,
-                     valid_res,
-                     values...);
-            } else {
-                func(views_info.first.data(),
-                     views_info.second.data(),
-                     nullptr,
-                     need_size,
-                     res,
-                     valid_res,
-                     values...);
-            }
-        } else {
-            ApplyValidData(views_info.second.data(), res, valid_res, need_size);
-        }
-        current_data_chunk_pos_ += need_size;
-        return need_size;
-    }
-
-    // accept offsets array and process on the scalar data by offsets
-    // stateless! Just check and set bitset as result, does not need to move cursor
-    // used for processing raw data expr for sealed segments.
-    // now only used for std::string_view && json
-    // TODO: support more types
-    template <typename T, typename FUNC, typename... ValTypes>
-    int64_t
-    ProcessDataByOffsetsForSealedSeg(
-        FUNC func,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
-        OffsetVector* input,
-        TargetBitmapView res,
-        TargetBitmapView valid_res,
-        const ValTypes&... values) {
-        // For non_chunked sealed segment, only single chunk
-        Assert(num_data_chunk_ == 1);
-
-        auto skip_index = segment_->GetSkipIndex();
-        auto pw =
-            segment_->get_views_by_offsets<T>(op_ctx_, field_id_, 0, *input);
-        auto [data_vec, valid_data] = pw.get();
-        if (!skip_func || !skip_func(*skip_index, field_id_, 0)) {
-            func(data_vec.data(),
-                 valid_data.data(),
-                 nullptr,
-                 input->size(),
-                 res,
-                 valid_res,
-                 values...);
-        } else {
-            ApplyValidData(valid_data.data(), res, valid_res, input->size());
-        }
-        return input->size();
-    }
-
     template <typename T, typename FUNC, typename... ValTypes>
     VectorPtr
     ProcessIndexChunksByOffsets(FUNC func,
@@ -698,18 +604,14 @@ class SegmentExpr : public Expr {
     }
 
     // when we have scalar index and index contains raw data, could go with index chunk by offsets
-    template <typename T, typename FUNC, typename... ValTypes>
+    template <typename T, typename BatchEvaluator, typename... ValTypes>
     int64_t
-    ProcessIndexLookupByOffsets(
-        FUNC func,
-        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
-        OffsetVector* input,
-        TargetBitmapView res,
-        TargetBitmapView valid_res,
-        const ValTypes&... values) {
+    ProcessIndexLookupByOffsets(BatchEvaluator evaluate_batch,
+                                OffsetVector* input,
+                                TargetBitmapView res,
+                                TargetBitmapView valid_res,
+                                const ValTypes&... values) {
         AssertInfo(num_index_chunk_ == 1, "scalar index chunk num must be 1");
-        auto skip_index = segment_->GetSkipIndex();
-
         using IndexInnerType = std::
             conditional_t<std::is_same_v<T, std::string_view>, std::string, T>;
         using Index = index::ScalarIndex<IndexInnerType>;
@@ -719,47 +621,48 @@ class SegmentExpr : public Expr {
         const bool all_valid = cached_index_all_valid_;
         auto batch_size = input->size();
 
-        if (!skip_func || !skip_func(*skip_index, field_id_, 0)) {
-            for (auto i = 0; i < batch_size; ++i) {
-                auto offset = (*input)[i];
-                auto raw = index_ptr->Reverse_Lookup(offset);
-                if (!raw.has_value()) {
-                    res[i] = false;
-                    continue;
-                }
-                T raw_data = raw.value();
-                bool valid_data = all_valid || valid_result[offset];
-                func.template operator()<FilterType::random>(&raw_data,
-                                                             &valid_data,
-                                                             nullptr,
-                                                             1,
-                                                             res + i,
-                                                             valid_res + i,
-                                                             values...);
+        // A scalar index is one logical index chunk for the whole segment,
+        // while SkipIndex statistics remain partitioned by the original data
+        // chunks. Once raw field data is dropped, this path cannot recover an
+        // offset's original chunk boundary, so applying chunk-0 SkipIndex to
+        // the whole candidate batch is incorrect. Reverse lookup is already
+        // candidate-local; evaluate every offset instead.
+        for (auto i = 0; i < batch_size; ++i) {
+            auto offset = (*input)[i];
+            auto raw = index_ptr->Reverse_Lookup(offset);
+            if (!raw.has_value()) {
+                res[i] = valid_res[i] = false;
+                evaluate_batch.template operator()<FilterType::random>(
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    1,
+                    res + i,
+                    valid_res + i,
+                    values...);
+                continue;
             }
-        } else if (all_valid) {
-            res.set(0, batch_size);
-            valid_res.set(0, batch_size);
-        } else {
-            for (auto i = 0; i < batch_size; ++i) {
-                auto offset = (*input)[i];
-                // materialize the bool once: chaining proxies would read
-                // back the word just stored into valid_res
-                const bool valid = valid_result[offset];
-                valid_res[i] = valid;
-                res[i] = valid;
-            }
+            T raw_data = raw.value();
+            bool valid_data = all_valid || valid_result[offset];
+            evaluate_batch.template operator()<FilterType::random>(
+                &raw_data,
+                &valid_data,
+                nullptr,
+                1,
+                res + i,
+                valid_res + i,
+                values...);
         }
 
         return batch_size;
     }
 
-    // accept offsets array and process on the scalar data by offsets
-    // stateless! Just check and set bitset as result, does not need to move cursor
-    template <typename T, typename FUNC, typename... ValTypes>
+    // Evaluate scalar candidates selected by offset input. The segment cursor
+    // does not move, but the callback may maintain a batch-local bitmap cursor.
+    template <typename T, typename BatchEvaluator, typename... ValTypes>
     int64_t
     ProcessDataByOffsets(
-        FUNC func,
+        BatchEvaluator evaluate_batch,
         std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
         OffsetVector* input,
         TargetBitmapView res,
@@ -771,7 +674,7 @@ class SegmentExpr : public Expr {
         if constexpr (!std::is_same_v<T, VectorArrayView>) {
             if (UseIndexCursor() && num_data_chunk_ == 0) {
                 return ProcessIndexLookupByOffsets<T>(
-                    func, skip_func, input, res, valid_res, values...);
+                    evaluate_batch, input, res, valid_res, values...);
             }
         }
 
@@ -793,7 +696,7 @@ class SegmentExpr : public Expr {
                 const auto& [data_vec, valid_data] = pw.get();
                 if (!skip_func ||
                     !skip_func(*skip_index, field_id_, chunk_id)) {
-                    func.template operator()<FilterType::random>(
+                    evaluate_batch.template operator()<FilterType::random>(
                         data_vec.data(),
                         valid_data.data(),
                         nullptr,
@@ -802,106 +705,111 @@ class SegmentExpr : public Expr {
                         valid_res + processed_size,
                         values...);
                 } else {
+                    // Chunk skipped by SkipIndex: apply valid mask, then still drive the
+                    // callback on a null batch so cursor-tracking callbacks (which index
+                    // bitmap_input by batch position via their processed_cursor) stay
+                    // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
                     ApplyValidData(valid_data.data(),
                                    res + processed_size,
                                    valid_res + processed_size,
                                    1);
+                    evaluate_batch.template operator()<FilterType::random>(
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        1,
+                        res + processed_size,
+                        valid_res + processed_size,
+                        values...);
                 }
                 processed_size++;
             }
             return input->size();
         } else if (segment_->type() == SegmentType::Sealed) {
-            // raw data scan
-            // sealed segment
-            if (segment_->is_chunked()) {
-                if constexpr (std::is_same_v<T, std::string_view> ||
-                              std::is_same_v<T, Json> ||
-                              std::is_same_v<T, ArrayView>) {
-                    for (size_t i = 0; i < input->size(); ++i) {
-                        int64_t offset = (*input)[i];
-                        auto [chunk_id, chunk_offset] =
-                            segment_->get_chunk_by_offset(field_id_, offset);
-                        auto pw = segment_->get_views_by_offsets<T>(
-                            op_ctx_,
-                            field_id_,
-                            chunk_id,
-                            {int32_t(chunk_offset)});
-                        auto [data_vec, valid_data] = pw.get();
-                        if (!skip_func ||
-                            !skip_func(*skip_index, field_id_, chunk_id)) {
-                            func.template operator()<FilterType::random>(
-                                data_vec.data(),
-                                valid_data.data(),
-                                nullptr,
-                                1,
-                                res + processed_size,
-                                valid_res + processed_size,
-                                values...);
-                        } else {
-                            if (!valid_data.empty() && !valid_data[0]) {
-                                res[processed_size] =
-                                    valid_res[processed_size] = false;
-                            }
-                        }
-                        processed_size++;
-                    }
-                    return input->size();
-                }
+            if constexpr (std::is_same_v<T, std::string_view> ||
+                          std::is_same_v<T, Json> ||
+                          std::is_same_v<T, ArrayView>) {
                 for (size_t i = 0; i < input->size(); ++i) {
                     int64_t offset = (*input)[i];
                     auto [chunk_id, chunk_offset] =
                         segment_->get_chunk_by_offset(field_id_, offset);
-                    auto pw =
-                        segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id);
-                    auto chunk = pw.get();
-                    const T* data = chunk.data() + chunk_offset;
-                    const bool* valid_data = chunk.valid_data();
-                    if (valid_data != nullptr) {
-                        valid_data += chunk_offset;
-                    }
+                    auto pw = segment_->get_views_by_offsets<T>(
+                        op_ctx_, field_id_, chunk_id, {int32_t(chunk_offset)});
+                    auto [data_vec, valid_data] = pw.get();
                     if (!skip_func ||
                         !skip_func(*skip_index, field_id_, chunk_id)) {
-                        func.template operator()<FilterType::random>(
-                            data,
-                            valid_data,
+                        evaluate_batch.template operator()<FilterType::random>(
+                            data_vec.data(),
+                            valid_data.data(),
                             nullptr,
                             1,
                             res + processed_size,
                             valid_res + processed_size,
                             values...);
                     } else {
-                        ApplyValidData(valid_data,
-                                       res + processed_size,
-                                       valid_res + processed_size,
-                                       1);
+                        // Chunk skipped by SkipIndex: apply valid mask, then still drive the
+                        // callback on a null batch so cursor-tracking callbacks (which index
+                        // bitmap_input by batch position via their processed_cursor) stay
+                        // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
+                        if (!valid_data.empty() && !valid_data[0]) {
+                            res[processed_size] = valid_res[processed_size] =
+                                false;
+                        }
+                        evaluate_batch.template operator()<FilterType::random>(
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            1,
+                            res + processed_size,
+                            valid_res + processed_size,
+                            values...);
                     }
                     processed_size++;
                 }
                 return input->size();
-            } else {
-                if constexpr (std::is_same_v<T, std::string_view> ||
-                              std::is_same_v<T, Json> ||
-                              std::is_same_v<T, ArrayView>) {
-                    return ProcessDataByOffsetsForSealedSeg<T>(
-                        func, skip_func, input, res, valid_res, values...);
-                }
-                auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, 0);
-                auto chunk = pw.get();
-                const T* data = chunk.data();
-                const bool* valid_data = chunk.valid_data();
-                if (!skip_func || !skip_func(*skip_index, field_id_, 0)) {
-                    func.template operator()<FilterType::random>(data,
-                                                                 valid_data,
-                                                                 input->data(),
-                                                                 input->size(),
-                                                                 res,
-                                                                 valid_res,
-                                                                 values...);
-                } else {
-                    ApplyValidData(valid_data, res, valid_res, input->size());
-                }
-                return input->size();
             }
+            for (size_t i = 0; i < input->size(); ++i) {
+                int64_t offset = (*input)[i];
+                auto [chunk_id, chunk_offset] =
+                    segment_->get_chunk_by_offset(field_id_, offset);
+                auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id);
+                auto chunk = pw.get();
+                const T* data = chunk.data() + chunk_offset;
+                const bool* valid_data = chunk.valid_data();
+                if (valid_data != nullptr) {
+                    valid_data += chunk_offset;
+                }
+                if (!skip_func ||
+                    !skip_func(*skip_index, field_id_, chunk_id)) {
+                    evaluate_batch.template operator()<FilterType::random>(
+                        data,
+                        valid_data,
+                        nullptr,
+                        1,
+                        res + processed_size,
+                        valid_res + processed_size,
+                        values...);
+                } else {
+                    // Chunk skipped by SkipIndex: apply valid mask, then still drive the
+                    // callback on a null batch so cursor-tracking callbacks (which index
+                    // bitmap_input by batch position via their processed_cursor) stay
+                    // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
+                    ApplyValidData(valid_data,
+                                   res + processed_size,
+                                   valid_res + processed_size,
+                                   1);
+                    evaluate_batch.template operator()<FilterType::random>(
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        1,
+                        res + processed_size,
+                        valid_res + processed_size,
+                        values...);
+                }
+                processed_size++;
+            }
+            return input->size();
         } else {
             // growing segment
             for (size_t i = 0; i < input->size(); ++i) {
@@ -917,7 +825,7 @@ class SegmentExpr : public Expr {
                 }
                 if (!skip_func ||
                     !skip_func(*skip_index, field_id_, chunk_id)) {
-                    func.template operator()<FilterType::random>(
+                    evaluate_batch.template operator()<FilterType::random>(
                         data,
                         valid_data,
                         nullptr,
@@ -926,10 +834,22 @@ class SegmentExpr : public Expr {
                         valid_res + processed_size,
                         values...);
                 } else {
+                    // Chunk skipped by SkipIndex: apply valid mask, then still drive the
+                    // callback on a null batch so cursor-tracking callbacks (which index
+                    // bitmap_input by batch position via their processed_cursor) stay
+                    // aligned — mirrors the ProcessDataChunksForMultipleChunk skip branch.
                     ApplyValidData(valid_data,
                                    res + processed_size,
                                    valid_res + processed_size,
                                    1);
+                    evaluate_batch.template operator()<FilterType::random>(
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        1,
+                        res + processed_size,
+                        valid_res + processed_size,
+                        values...);
                 }
                 processed_size++;
             }
@@ -939,11 +859,13 @@ class SegmentExpr : public Expr {
 
     // Process element-level data by element IDs
     // Handles the type mismatch between storage (ArrayView) and element type
-    // Currently only implemented for sealed chunked segments
-    template <typename ElementType, typename FUNC, typename... ValTypes>
+    // Sealed data is read as ArrayView; growing data is read as Array.
+    template <typename ElementType,
+              typename BatchEvaluator,
+              typename... ValTypes>
     int64_t
     ProcessElementLevelByOffsets(
-        FUNC func,
+        BatchEvaluator evaluate_batch,
         std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
         OffsetVector* element_ids,
         TargetBitmapView res,
@@ -951,10 +873,6 @@ class SegmentExpr : public Expr {
         const ValTypes&... values) {
         auto skip_index = segment_->GetSkipIndex();
         if (segment_->type() == SegmentType::Sealed) {
-            AssertInfo(
-                segment_->is_chunked(),
-                "Element-level filtering requires chunked segment for sealed");
-
             auto array_offsets = segment_->GetArrayOffsets(field_id_);
             if (!array_offsets) {
                 ThrowInfo(ErrorCode::UnexpectedError,
@@ -1022,7 +940,7 @@ class SegmentExpr : public Expr {
                                 elem_indices[j]);
                         bool is_valid = !valid_data.data() || valid_data[j];
 
-                        func.template operator()<FilterType::random>(
+                        evaluate_batch.template operator()<FilterType::random>(
                             &value,
                             &is_valid,
                             nullptr,
@@ -1031,10 +949,18 @@ class SegmentExpr : public Expr {
                             valid_res + result_idx,
                             values...);
                     } else {
-                        // Chunk is skipped - handle exactly like ProcessDataByOffsets
+                        // Keep cursor-tracking evaluators aligned with offset input.
                         if (valid_data.size() > j && !valid_data[j]) {
                             res[result_idx] = valid_res[result_idx] = false;
                         }
+                        evaluate_batch.template operator()<FilterType::random>(
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            1,
+                            res + result_idx,
+                            valid_res + result_idx,
+                            values...);
                     }
 
                     processed_size++;
@@ -1078,7 +1004,7 @@ class SegmentExpr : public Expr {
                     auto value = array_ptr->get_data<ElementType>(elem_idx);
                     bool is_valid = !valid_data || valid_data[0];
 
-                    func.template operator()<FilterType::random>(
+                    evaluate_batch.template operator()<FilterType::random>(
                         &value,
                         &is_valid,
                         nullptr,
@@ -1087,10 +1013,18 @@ class SegmentExpr : public Expr {
                         valid_res + processed_size,
                         values...);
                 } else {
-                    // Chunk is skipped
+                    // Keep cursor-tracking evaluators aligned with offset input.
                     if (valid_data && !valid_data[0]) {
                         res[processed_size] = valid_res[processed_size] = false;
                     }
+                    evaluate_batch.template operator()<FilterType::random>(
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        1,
+                        res + processed_size,
+                        valid_res + processed_size,
+                        values...);
                 }
 
                 processed_size++;
@@ -1104,10 +1038,12 @@ class SegmentExpr : public Expr {
     // This is the counterpart of ProcessDataChunks for element-level expressions
     // Iterates over rows in batch, but returns element-level results
     // The caller must pre-allocate res/valid_res with elem_count size (from GetNextBatchSizeForElementLevel)
-    template <typename ElementType, typename FUNC, typename... ValTypes>
+    template <typename ElementType,
+              typename BatchEvaluator,
+              typename... ValTypes>
     int64_t
     ProcessDataChunksForElementLevel(
-        FUNC func,
+        BatchEvaluator evaluate_batch,
         std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
         TargetBitmapView res,
         TargetBitmapView valid_res,
@@ -1178,13 +1114,14 @@ class SegmentExpr : public Expr {
                                             .template get_data<
                                                 std::string_view>(k);
                                     ElementType str_val(str_view);
-                                    func(&str_val,
-                                         nullptr,
-                                         nullptr,
-                                         1,
-                                         res + processed_elems + k,
-                                         valid_res + processed_elems + k,
-                                         values...);
+                                    evaluate_batch(
+                                        &str_val,
+                                        nullptr,
+                                        nullptr,
+                                        1,
+                                        res + processed_elems + k,
+                                        valid_res + processed_elems + k,
+                                        values...);
                                 }
                             } else {
                                 // Fixed-length numeric types
@@ -1202,26 +1139,27 @@ class SegmentExpr : public Expr {
                                 if constexpr (std::is_same_v<StorageType,
                                                              ElementType>) {
                                     // Types match, batch process
-                                    func(raw_data,
-                                         nullptr,
-                                         nullptr,
-                                         elem_count,
-                                         res + processed_elems,
-                                         valid_res + processed_elems,
-                                         values...);
+                                    evaluate_batch(raw_data,
+                                                   nullptr,
+                                                   nullptr,
+                                                   elem_count,
+                                                   res + processed_elems,
+                                                   valid_res + processed_elems,
+                                                   values...);
                                 } else {
                                     // int8_t/int16_t: need conversion
                                     for (size_t k = 0; k < elem_count; k++) {
                                         ElementType val =
                                             static_cast<ElementType>(
                                                 raw_data[k]);
-                                        func(&val,
-                                             nullptr,
-                                             nullptr,
-                                             1,
-                                             res + processed_elems + k,
-                                             valid_res + processed_elems + k,
-                                             values...);
+                                        evaluate_batch(
+                                            &val,
+                                            nullptr,
+                                            nullptr,
+                                            1,
+                                            res + processed_elems + k,
+                                            valid_res + processed_elems + k,
+                                            values...);
                                     }
                                 }
                             }
@@ -1262,13 +1200,14 @@ class SegmentExpr : public Expr {
                                             .template get_data<
                                                 std::string_view>(k);
                                     ElementType str_val(str_view);
-                                    func(&str_val,
-                                         nullptr,
-                                         nullptr,
-                                         1,
-                                         res + processed_elems + k,
-                                         valid_res + processed_elems + k,
-                                         values...);
+                                    evaluate_batch(
+                                        &str_val,
+                                        nullptr,
+                                        nullptr,
+                                        1,
+                                        res + processed_elems + k,
+                                        valid_res + processed_elems + k,
+                                        values...);
                                 }
                             } else {
                                 // Fixed-length numeric types
@@ -1286,26 +1225,27 @@ class SegmentExpr : public Expr {
                                 if constexpr (std::is_same_v<StorageType,
                                                              ElementType>) {
                                     // Types match, batch process
-                                    func(raw_data,
-                                         nullptr,
-                                         nullptr,
-                                         elem_count,
-                                         res + processed_elems,
-                                         valid_res + processed_elems,
-                                         values...);
+                                    evaluate_batch(raw_data,
+                                                   nullptr,
+                                                   nullptr,
+                                                   elem_count,
+                                                   res + processed_elems,
+                                                   valid_res + processed_elems,
+                                                   values...);
                                 } else {
                                     // int8_t/int16_t: need conversion
                                     for (size_t k = 0; k < elem_count; k++) {
                                         ElementType val =
                                             static_cast<ElementType>(
                                                 raw_data[k]);
-                                        func(&val,
-                                             nullptr,
-                                             nullptr,
-                                             1,
-                                             res + processed_elems + k,
-                                             valid_res + processed_elems + k,
-                                             values...);
+                                        evaluate_batch(
+                                            &val,
+                                            nullptr,
+                                            nullptr,
+                                            1,
+                                            res + processed_elems + k,
+                                            valid_res + processed_elems + k,
+                                            values...);
                                     }
                                 }
                             }
@@ -1314,7 +1254,10 @@ class SegmentExpr : public Expr {
                     }
                 }
             } else {
-                // Chunk is skipped, mark all elements as false
+                // Chunk is skipped. Preserve NULL validity and advance the
+                // evaluator once for every logical element so callbacks that
+                // index bitmap_input with a local cursor stay aligned.
+                const auto skipped_start = processed_elems;
                 if (segment_->type() == SegmentType::Sealed) {
                     auto pw = segment_->get_batch_views<ArrayView>(
                         op_ctx_, field_id_, i, data_pos, size);
@@ -1322,9 +1265,13 @@ class SegmentExpr : public Expr {
 
                     for (size_t j = 0; j < static_cast<size_t>(size); j++) {
                         auto elem_count = data_vec[j].length();
-                        for (size_t k = 0; k < elem_count; k++) {
-                            res[processed_elems + k] =
-                                valid_res[processed_elems + k] = false;
+                        const bool row_valid =
+                            !valid_data.data() || valid_data[j];
+                        if (!row_valid) {
+                            for (size_t k = 0; k < elem_count; k++) {
+                                res[processed_elems + k] =
+                                    valid_res[processed_elems + k] = false;
+                            }
                         }
                         processed_elems += elem_count;
                     }
@@ -1333,15 +1280,32 @@ class SegmentExpr : public Expr {
                         segment_->chunk_data<Array>(op_ctx_, field_id_, i);
                     auto chunk = pw.get();
                     const Array* data = chunk.data() + data_pos;
+                    const bool* valid_data = chunk.valid_data();
+                    if (valid_data != nullptr) {
+                        valid_data += data_pos;
+                    }
 
                     for (size_t j = 0; j < static_cast<size_t>(size); j++) {
                         auto elem_count = data[j].length();
-                        for (size_t k = 0; k < elem_count; k++) {
-                            res[processed_elems + k] =
-                                valid_res[processed_elems + k] = false;
+                        const bool row_valid = !valid_data || valid_data[j];
+                        if (!row_valid) {
+                            for (size_t k = 0; k < elem_count; k++) {
+                                res[processed_elems + k] =
+                                    valid_res[processed_elems + k] = false;
+                            }
                         }
                         processed_elems += elem_count;
                     }
+                }
+                const auto skipped_elems = processed_elems - skipped_start;
+                if (skipped_elems > 0) {
+                    evaluate_batch(nullptr,
+                                   nullptr,
+                                   nullptr,
+                                   skipped_elems,
+                                   res + skipped_start,
+                                   valid_res + skipped_start,
+                                   values...);
                 }
             }
 
@@ -1369,25 +1333,14 @@ class SegmentExpr : public Expr {
         TargetBitmapView valid_res,
         const ValTypes&... values) {
         int64_t processed_size = 0;
-        if constexpr (std::is_same_v<T, std::string_view> ||
-                      std::is_same_v<T, Json>) {
-            if (segment_->type() == SegmentType::Sealed) {
-                return ProcessChunkForSealedSeg<T, NeedSegmentOffsets>(
-                    func, skip_func, res, valid_res, values...);
-            }
-        }
 
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            auto size =
-                (i == (num_data_chunk_ - 1))
-                    ? (segment_->type() == SegmentType::Growing
-                           ? (active_count_ % size_per_chunk_ == 0
-                                  ? size_per_chunk_ - data_pos
-                                  : active_count_ % size_per_chunk_ - data_pos)
-                           : active_count_ - data_pos)
-                    : size_per_chunk_ - data_pos;
+            auto size = (i == (num_data_chunk_ - 1) &&
+                         active_count_ % size_per_chunk_ != 0)
+                            ? active_count_ % size_per_chunk_ - data_pos
+                            : size_per_chunk_ - data_pos;
 
             size = std::min(size, batch_size_ - processed_size);
             if (size == 0)
@@ -1700,8 +1653,6 @@ class SegmentExpr : public Expr {
                       "ProcessDataChunkForRange only supports string_view, "
                       "Json, and ArrayView types");
 
-        AssertInfo(segment_->is_chunked(),
-                   "ProcessDataChunkForRange requires chunked segment");
         AssertInfo(segment_->type() == SegmentType::Sealed,
                    "ProcessDataChunkForRange requires sealed segment");
 

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -106,6 +106,9 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
             TargetBitmapView valid_res,
             T compare_value,
             proto::plan::Interval interval) {
+        if (data == nullptr) {
+            return;
+        }
         const int64_t compare_us = compare_value;
         for (int i = 0; i < size; ++i) {
             if (valid_data != nullptr && !valid_data[i]) {

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -473,6 +473,10 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplArray(EvalCtx& context) {
             TargetBitmapView valid_res,
             ValueType val,
             int index) {
+        if (data == nullptr) {
+            processed_cursor += size;
+            return;
+        }
         switch (op_type) {
             case proto::plan::GreaterThan: {
                 UnaryElementFuncForArray<ValueType,
@@ -889,6 +893,10 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
             TargetBitmapView res,
             TargetBitmapView valid_res,
             ExprValueType val) {
+        if (data == nullptr) {
+            processed_cursor += size;
+            return;
+        }
         bool has_bitmap_input = !bitmap_input.empty();
         switch (op_type) {
             case proto::plan::GreaterThan: {

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -209,9 +209,14 @@ ExtractArrayLengthsFromFieldData(const std::vector<FieldDataPtr>& field_data,
                 array_lengths[offset + i] = raw_data[source_index].length();
             }
         } else {
-            // For regular array types (INT32, FLOAT, etc.)
-            auto* raw_data = static_cast<const ArrayView*>(data->Data());
+            // Regular nullable ARRAY FieldData is dense: invalid rows retain
+            // their physical Array slot but contribute no logical elements.
+            auto* raw_data = static_cast<const Array*>(data->Data());
             for (int64_t i = 0; i < num_rows; ++i) {
+                if (data->IsNullable() && !data->is_valid(i)) {
+                    array_lengths[offset + i] = 0;
+                    continue;
+                }
                 array_lengths[offset + i] = raw_data[i].length();
             }
         }

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -40,6 +40,7 @@ set(MILVUS_TEST_FILES
         test_loading.cpp
         test_exec.cpp
         test_timestamptz_arith_compare.cpp
+        test_offsets_eval_correctness.cpp
         test_expr_materialized_view.cpp
         test_float16.cpp
         test_search_group_by.cpp

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -1,0 +1,762 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "common/Types.h"
+#include "exec/expression/Expr.h"
+#include "expr/ITypeExpr.h"
+#include "index/ScalarIndexSort.h"
+#include "knowhere/comp/index_param.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "segcore/SegcoreConfig.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/GenExprProto.h"
+#include "test_utils/cachinglayer_test_utils.h"
+#include "test_utils/storage_test_utils.h"
+
+using namespace milvus;
+using namespace milvus::exec;
+using namespace milvus::segcore;
+
+namespace {
+
+std::unique_ptr<SegmentSealed>
+CreateTwoChunkSealed(const SchemaPtr& schema,
+                     const GeneratedData& first,
+                     const GeneratedData& second) {
+    std::unordered_map<int64_t, std::vector<FieldDataPtr>> field_chunks;
+
+    auto append_dataset = [&](const GeneratedData& dataset) {
+        const auto row_count = dataset.row_ids_.size();
+
+        auto row_ids =
+            std::make_shared<FieldData<int64_t>>(DataType::INT64, false);
+        row_ids->FillFieldData(dataset.row_ids_.data(), row_count);
+        field_chunks[RowFieldID.get()].push_back(std::move(row_ids));
+
+        auto timestamps =
+            std::make_shared<FieldData<int64_t>>(DataType::INT64, false);
+        timestamps->FillFieldData(dataset.timestamps_.data(), row_count);
+        field_chunks[TimestampFieldID.get()].push_back(std::move(timestamps));
+
+        const auto fields = schema->get_fields();
+        for (const auto& data : dataset.raw_->fields_data()) {
+            const auto field_id = data.field_id();
+            field_chunks[field_id].push_back(CreateFieldDataFromDataArray(
+                row_count, &data, fields.at(FieldId(field_id))));
+        }
+    };
+
+    append_dataset(first);
+    append_dataset(second);
+
+    LoadFieldDataInfo combined_load_info;
+    auto cm = storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    for (auto& [field_id, chunks] : field_chunks) {
+        auto field_load_info = PrepareSingleFieldInsertBinlog(kCollectionID,
+                                                              kPartitionID,
+                                                              kSegmentID,
+                                                              field_id,
+                                                              std::move(chunks),
+                                                              cm);
+        combined_load_info.field_infos.merge(field_load_info.field_infos);
+    }
+
+    auto segment = CreateSealedSegment(schema, empty_index_meta);
+    const auto status = LoadFieldData(segment.get(), &combined_load_info);
+    AssertInfo(status.error_code == Success,
+               "Failed to load two-chunk sealed data: {}",
+               status.error_msg);
+    return segment;
+}
+
+template <typename T>
+void
+VerifySkipCursorContract(SegmentExpr& segment_expr,
+                         OffsetVector* input,
+                         int skipped_chunk_id) {
+    TargetBitmap bitmap_input(input->size(), false);
+    for (size_t i = input->size() / 2; i < input->size(); ++i) {
+        bitmap_input[i] = true;
+    }
+
+    auto skip_chunk = [skipped_chunk_id](
+                          const SkipIndex&, FieldId, int chunk_id) {
+        return chunk_id == skipped_chunk_id;
+    };
+
+    int64_t processed_cursor = 0;
+    int64_t null_rows = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const T* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res) {
+        if (data == nullptr) {
+            null_rows += size;
+            processed_cursor += size;
+            return;
+        }
+        for (int i = 0; i < size; ++i) {
+            if (bitmap_input[processed_cursor + i]) {
+                res[i] = true;
+            }
+        }
+        processed_cursor += size;
+    };
+
+    TargetBitmap res(input->size(), false);
+    TargetBitmap valid(input->size(), true);
+    const auto processed =
+        segment_expr.ProcessDataByOffsets<T>(evaluate_batch,
+                                             skip_chunk,
+                                             input,
+                                             TargetBitmapView(res),
+                                             TargetBitmapView(valid));
+
+    EXPECT_EQ(processed, int64_t(input->size()));
+    EXPECT_EQ(processed_cursor, int64_t(input->size()));
+    EXPECT_EQ(null_rows, int64_t(input->size() / 2));
+    for (size_t i = 0; i < input->size(); ++i) {
+        EXPECT_EQ(bool(res[i]), i >= input->size() / 2)
+            << "candidate " << i
+            << ": cursor desync shifted the bitmap_input read";
+    }
+}
+
+void
+VerifyElementFullScanSkipCursor(SegmentExpr& segment_expr,
+                                int64_t element_count,
+                                int skipped_chunk_id,
+                                int64_t expected_skipped_elements) {
+    TargetBitmap bitmap_input(element_count, false);
+    for (int64_t i = expected_skipped_elements; i < element_count; ++i) {
+        bitmap_input[i] = true;
+    }
+
+    auto skip_chunk = [skipped_chunk_id](
+                          const SkipIndex&, FieldId, int chunk_id) {
+        return chunk_id == skipped_chunk_id;
+    };
+
+    int64_t processed_cursor = 0;
+    int64_t null_elements = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res) {
+        if (data == nullptr) {
+            null_elements += size;
+            processed_cursor += size;
+            return;
+        }
+        for (int i = 0; i < size; ++i) {
+            if (bitmap_input[processed_cursor + i]) {
+                res[i] = true;
+            }
+        }
+        processed_cursor += size;
+    };
+
+    TargetBitmap res(element_count, false);
+    TargetBitmap valid(element_count, true);
+    const auto processed =
+        segment_expr.ProcessDataChunksForElementLevel<int64_t>(
+            evaluate_batch,
+            skip_chunk,
+            TargetBitmapView(res),
+            TargetBitmapView(valid));
+
+    EXPECT_EQ(processed, element_count);
+    EXPECT_EQ(processed_cursor, element_count);
+    EXPECT_EQ(null_elements, expected_skipped_elements);
+    for (int64_t i = 0; i < element_count; ++i) {
+        EXPECT_EQ(bool(res[i]), i >= expected_skipped_elements)
+            << "element " << i
+            << ": skipped chunk desynced the full-scan bitmap cursor";
+        EXPECT_TRUE(valid[i]);
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Every logical row or element must advance the evaluator callback cursor.
+// SkipIndex-pruned candidates and nullable scalar-index reverse lookups arrive
+// as null batches (data == nullptr). The tests cover growing and sealed raw
+// offsets, scalar-index-only offsets, element offsets, and element full scans.
+// ---------------------------------------------------------------------------
+
+class OffsetsEvalCorrectnessTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        schema_ = std::make_shared<Schema>();
+        schema_->AddDebugField(
+            "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+        auto pk_fid = schema_->AddDebugField("pk", DataType::INT64);
+        i64_fid_ = schema_->AddDebugField("value", DataType::INT64);
+        varchar_fid_ = schema_->AddDebugField("text", DataType::VARCHAR);
+        array_fid_ = schema_->AddDebugArrayField(
+            "structA[element_value]", DataType::INT64, false);
+        vector_array_fid_ =
+            schema_->AddDebugVectorArrayField("structA[vector_array]",
+                                              DataType::VECTOR_FLOAT,
+                                              4,
+                                              knowhere::metric::L2);
+        schema_->set_primary_field_id(pk_fid);
+
+        // Keep one element per array row so element IDs equal row offsets in
+        // the direct ProcessElementLevelByOffsets regression below.
+        auto dataset = DataGen(schema_, N, 42, 0, 1, 1);
+        // Growing segment with small chunks so one offset batch spans
+        // multiple chunks (required to interleave skipped and probed rows).
+        SegcoreConfig config = SegcoreConfig::default_config();
+        config.set_chunk_rows(kChunkRows);
+        growing_ = CreateGrowingSegment(schema_, empty_index_meta, 1, config);
+        growing_->PreInsert(N);
+        growing_->Insert(0,
+                         N,
+                         dataset.row_ids_.data(),
+                         dataset.timestamps_.data(),
+                         dataset.raw_);
+
+        auto sealed_first = DataGen(schema_, N / 2, 43, 0, 1, 1);
+        auto sealed_second = DataGen(schema_, N / 2, 44, 0, 1, 1);
+        sealed_ = CreateTwoChunkSealed(schema_, sealed_first, sealed_second);
+    }
+
+    std::shared_ptr<SegmentExpr>
+    MakeDirectSegmentExpr(const SegmentInternalInterface* segment,
+                          FieldId field_id,
+                          DataType value_type,
+                          QueryContext& query_context) {
+        return std::make_shared<SegmentExpr>(
+            std::vector<ExprPtr>{},
+            "offset contract probe",
+            query_context.get_op_context(),
+            segment,
+            field_id,
+            std::vector<std::string>{},
+            value_type,
+            N,
+            N,
+            query_context.get_consistency_level());
+    }
+
+    static constexpr int64_t kChunkRows = 8;
+    static constexpr size_t N = 32;  // 4 growing chunks
+
+    SchemaPtr schema_;
+    FieldId i64_fid_, varchar_fid_, array_fid_, vector_array_fid_;
+    SegmentGrowingPtr growing_;
+    std::unique_ptr<SegmentSealed> sealed_;
+};
+
+// Every candidate must reach the callback: skipped rows as null batches.
+TEST_F(OffsetsEvalCorrectnessTest, SkipBranchDrivesCallbackPerCandidate) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, growing_.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        growing_.get(), i64_fid_, DataType::INT64, *query_context);
+
+    // Interleave chunk-0 rows (skipped below) with rows of other chunks.
+    OffsetVector input;
+    for (auto o : std::vector<int32_t>{8, 0, 9, 1, 16, 2, 24, 3}) {
+        input.emplace_back(o);
+    }
+    const int expected_skipped = 4;  // offsets 0,1,2,3 live in chunk 0
+
+    auto skip_chunk0 = [](const milvus::SkipIndex&,
+                          FieldId,
+                          int chunk_id) -> bool { return chunk_id == 0; };
+
+    int64_t rows_seen = 0;
+    int64_t null_rows = 0;
+    int64_t data_rows = 0;
+    auto probe = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res) {
+        rows_seen += size;
+        if (data == nullptr) {
+            null_rows += size;
+            return;
+        }
+        data_rows += size;
+    };
+
+    TargetBitmap res(input.size(), false);
+    TargetBitmap valid(input.size(), true);
+    auto processed =
+        seg_expr->ProcessDataByOffsets<int64_t>(probe,
+                                                skip_chunk0,
+                                                &input,
+                                                TargetBitmapView(res),
+                                                TargetBitmapView(valid));
+
+    EXPECT_EQ(processed, int64_t(input.size()));
+    // The contract this fix pins: no candidate row may bypass the callback.
+    EXPECT_EQ(rows_seen, int64_t(input.size()))
+        << "skipped rows must still reach the callback as null batches";
+    EXPECT_EQ(null_rows, expected_skipped);
+    EXPECT_EQ(data_rows, int64_t(input.size()) - expected_skipped);
+}
+
+// The user-visible consequence: emulate the exact cursor-tracking pattern the
+// production callbacks use (processed_cursor indexes bitmap_input by batch
+// position) and prove a skipped span does not shift later reads.
+TEST_F(OffsetsEvalCorrectnessTest, SkipBranchKeepsBitmapCursorAligned) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, growing_.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        growing_.get(), i64_fid_, DataType::INT64, *query_context);
+
+    // First 4 candidates in chunk 0 (skipped), next 4 in chunk 1 (probed).
+    OffsetVector input;
+    for (auto o : std::vector<int32_t>{0, 1, 2, 3, 8, 9, 10, 11}) {
+        input.emplace_back(o);
+    }
+    // bitmap_input by BATCH POSITION: the AND conjunct passed bit=1 exactly
+    // for the probed candidates.
+    TargetBitmap bitmap_input(input.size(), false);
+    for (size_t i = 4; i < 8; ++i) {
+        bitmap_input[i] = true;
+    }
+
+    auto skip_chunk0 = [](const milvus::SkipIndex&,
+                          FieldId,
+                          int chunk_id) -> bool { return chunk_id == 0; };
+
+    // Mirror of the production pattern (e.g. UnaryExpr): a closure-local
+    // processed_cursor advanced by every invocation, including null batches.
+    int64_t processed_cursor = 0;
+    auto probe = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res) {
+        if (data == nullptr) {
+            processed_cursor += size;
+            return;
+        }
+        for (int i = 0; i < size; ++i) {
+            if (bitmap_input[processed_cursor + i]) {
+                res[i] = true;  // probe passes for every real value here
+            }
+        }
+        processed_cursor += size;
+    };
+
+    TargetBitmap res(input.size(), false);
+    TargetBitmap valid(input.size(), true);
+    seg_expr->ProcessDataByOffsets<int64_t>(probe,
+                                            skip_chunk0,
+                                            &input,
+                                            TargetBitmapView(res),
+                                            TargetBitmapView(valid));
+
+    for (size_t k = 0; k < input.size(); ++k) {
+        const bool expected = k >= 4;  // skipped rows false, probed rows true
+        EXPECT_EQ(bool(res[k]), expected)
+            << "candidate " << k
+            << ": cursor desync shifted the bitmap_input read";
+    }
+}
+
+// Element-level filters use a separate offsets helper. It must invoke the
+// evaluator for skipped candidates too, or its bitmap cursor shifts exactly as
+// it did in the scalar offset path.
+TEST_F(OffsetsEvalCorrectnessTest,
+       ElementLevelSkipBranchKeepsBitmapCursorAligned) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, growing_.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        growing_.get(), array_fid_, DataType::INT64, *query_context);
+
+    // One element per row: element IDs 0..3 are in skipped chunk 0; 8..11
+    // are in chunk 1 and must retain their batch-position bitmap bits.
+    OffsetVector element_ids;
+    for (auto id : std::vector<int32_t>{0, 1, 2, 3, 8, 9, 10, 11}) {
+        element_ids.emplace_back(id);
+    }
+    TargetBitmap bitmap_input(element_ids.size(), false);
+    for (size_t i = 4; i < element_ids.size(); ++i) {
+        bitmap_input[i] = true;
+    }
+
+    auto skip_chunk0 = [](const milvus::SkipIndex&,
+                          FieldId,
+                          int chunk_id) -> bool { return chunk_id == 0; };
+
+    int64_t processed_cursor = 0;
+    int64_t null_batches = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res) {
+        if (data == nullptr) {
+            null_batches += size;
+            processed_cursor += size;
+            return;
+        }
+        for (int i = 0; i < size; ++i) {
+            if (bitmap_input[processed_cursor + i]) {
+                res[i] = true;
+            }
+        }
+        processed_cursor += size;
+    };
+
+    TargetBitmap res(element_ids.size(), false);
+    TargetBitmap valid(element_ids.size(), true);
+    const auto processed = seg_expr->ProcessElementLevelByOffsets<int64_t>(
+        evaluate_batch,
+        skip_chunk0,
+        &element_ids,
+        TargetBitmapView(res),
+        TargetBitmapView(valid));
+
+    EXPECT_EQ(processed, int64_t(element_ids.size()));
+    EXPECT_EQ(null_batches, 4);
+    for (size_t i = 0; i < element_ids.size(); ++i) {
+        EXPECT_EQ(bool(res[i]), i >= 4)
+            << "element candidate " << i
+            << ": cursor desync shifted the bitmap_input read";
+    }
+}
+
+// Sealed raw data is chunked by binlog. Cover the fixed-width branch with
+// candidates from a skipped first binlog followed by a probed second binlog.
+TEST_F(OffsetsEvalCorrectnessTest,
+       SealedScalarSkipBranchKeepsBitmapCursorAligned) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        sealed_.get(), i64_fid_, DataType::INT64, *query_context);
+    OffsetVector offsets;
+    for (auto offset : std::vector<int32_t>{0, 1, 2, 3, 16, 17, 18, 19}) {
+        offsets.emplace_back(offset);
+    }
+
+    VerifySkipCursorContract<int64_t>(*seg_expr, &offsets, 0);
+}
+
+// VARCHAR/JSON/ARRAY use get_views_by_offsets rather than chunk_data. Pin the
+// view branch separately because its validity storage and ownership differ.
+TEST_F(OffsetsEvalCorrectnessTest,
+       SealedViewSkipBranchKeepsBitmapCursorAligned) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        sealed_.get(), varchar_fid_, DataType::VARCHAR, *query_context);
+    OffsetVector offsets;
+    for (auto offset : std::vector<int32_t>{0, 1, 2, 3, 16, 17, 18, 19}) {
+        offsets.emplace_back(offset);
+    }
+
+    VerifySkipCursorContract<std::string_view>(*seg_expr, &offsets, 0);
+}
+
+// VECTOR_ARRAY has its own chunk_view branch. There is no production
+// SkipIndex predicate for vector-array length today, but the generic helper
+// accepts one; keep its null-batch contract covered so future callers cannot
+// silently reintroduce cursor drift.
+TEST_F(OffsetsEvalCorrectnessTest,
+       VectorArrayViewSkipBranchKeepsBitmapCursorAligned) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(sealed_.get(),
+                                          vector_array_fid_,
+                                          DataType::VECTOR_ARRAY,
+                                          *query_context);
+    OffsetVector offsets;
+    for (auto offset : std::vector<int32_t>{0, 1, 2, 3, 16, 17, 18, 19}) {
+        offsets.emplace_back(offset);
+    }
+
+    VerifySkipCursorContract<VectorArrayView>(*seg_expr, &offsets, 0);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SealedElementLevelSkipBranchKeepsBitmapCursorAligned) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        sealed_.get(), array_fid_, DataType::INT64, *query_context);
+
+    // Each array row contains one element, so element IDs map directly to
+    // row offsets. The two groups therefore live in sealed chunks 0 and 1.
+    OffsetVector element_ids;
+    for (auto id : std::vector<int32_t>{0, 1, 2, 3, 16, 17, 18, 19}) {
+        element_ids.emplace_back(id);
+    }
+    TargetBitmap bitmap_input(element_ids.size(), false);
+    for (size_t i = element_ids.size() / 2; i < element_ids.size(); ++i) {
+        bitmap_input[i] = true;
+    }
+
+    auto skip_chunk0 = [](const SkipIndex&, FieldId, int chunk_id) {
+        return chunk_id == 0;
+    };
+    int64_t processed_cursor = 0;
+    int64_t null_rows = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res) {
+        if (data == nullptr) {
+            null_rows += size;
+            processed_cursor += size;
+            return;
+        }
+        for (int i = 0; i < size; ++i) {
+            if (bitmap_input[processed_cursor + i]) {
+                res[i] = true;
+            }
+        }
+        processed_cursor += size;
+    };
+
+    TargetBitmap res(element_ids.size(), false);
+    TargetBitmap valid(element_ids.size(), true);
+    const auto processed = seg_expr->ProcessElementLevelByOffsets<int64_t>(
+        evaluate_batch,
+        skip_chunk0,
+        &element_ids,
+        TargetBitmapView(res),
+        TargetBitmapView(valid));
+
+    EXPECT_EQ(processed, int64_t(element_ids.size()));
+    EXPECT_EQ(processed_cursor, int64_t(element_ids.size()));
+    EXPECT_EQ(null_rows, int64_t(element_ids.size() / 2));
+    for (size_t i = 0; i < element_ids.size(); ++i) {
+        EXPECT_EQ(bool(res[i]), i >= element_ids.size() / 2)
+            << "element candidate " << i
+            << ": cursor desync shifted the bitmap_input read";
+    }
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       GrowingElementFullScanSkipKeepsBitmapCursorAligned) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, growing_.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        growing_.get(), array_fid_, DataType::INT64, *query_context);
+
+    VerifyElementFullScanSkipCursor(
+        *seg_expr, N, 0, OffsetsEvalCorrectnessTest::kChunkRows);
+}
+
+TEST_F(OffsetsEvalCorrectnessTest,
+       SealedElementFullScanSkipKeepsBitmapCursorAligned) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, sealed_.get(), N, MAX_TIMESTAMP);
+    auto seg_expr = MakeDirectSegmentExpr(
+        sealed_.get(), array_fid_, DataType::INT64, *query_context);
+
+    VerifyElementFullScanSkipCursor(*seg_expr, N, 0, N / 2);
+}
+
+TEST(OffsetsEvalIndexOnlyCorrectnessTest,
+     NullableReverseLookupAdvancesCursorAndIgnoresChunkSkip) {
+    constexpr int64_t kRowCount = 8;
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 4, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto value_fid = schema->AddDebugField("value", DataType::INT64, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto first = DataGen(schema, kRowCount / 2, 100, 0, 1, 1);
+    auto second = DataGen(schema, kRowCount / 2, 101, 0, 1, 1);
+    auto segment = CreateTwoChunkSealed(schema, first, second);
+
+    std::vector<int64_t> index_values(kRowCount);
+    std::iota(index_values.begin(), index_values.end(), int64_t{0});
+    auto index_valid = std::make_unique<bool[]>(kRowCount);
+    for (int64_t i = 0; i < kRowCount; ++i) {
+        index_valid[i] = true;
+    }
+    index_valid[1] = false;
+
+    auto scalar_index = index::CreateScalarIndexSort<int64_t>();
+    scalar_index->Build(kRowCount, index_values.data(), index_valid.get());
+    LoadIndexInfo load_index_info;
+    load_index_info.field_id = value_fid.get();
+    load_index_info.field_type = DataType::INT64;
+    load_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    load_index_info.index_params = GenIndexParams(scalar_index.get());
+    load_index_info.cache_index =
+        CreateTestCacheIndex("offset-index-only", std::move(scalar_index));
+    segment->LoadIndex(load_index_info);
+    segment->DropFieldData(value_fid);
+    ASSERT_FALSE(segment->HasFieldData(value_fid));
+
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, segment.get(), kRowCount, MAX_TIMESTAMP);
+    auto seg_expr =
+        std::make_shared<SegmentExpr>(std::vector<ExprPtr>{},
+                                      "index-only offset contract probe",
+                                      query_context->get_op_context(),
+                                      segment.get(),
+                                      value_fid,
+                                      std::vector<std::string>{},
+                                      DataType::INT64,
+                                      kRowCount,
+                                      kRowCount,
+                                      query_context->get_consistency_level());
+
+    OffsetVector input{0, 1, 2, 5};
+    TargetBitmap bitmap_input(input.size(), true);
+    int64_t processed_cursor = 0;
+    int64_t null_rows = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res) {
+        if (data == nullptr) {
+            null_rows += size;
+            processed_cursor += size;
+            return;
+        }
+        for (int i = 0; i < size; ++i) {
+            if (bitmap_input[processed_cursor + i]) {
+                res[i] = true;
+            }
+        }
+        processed_cursor += size;
+    };
+    auto skip_everything = [](const SkipIndex&, FieldId, int) { return true; };
+
+    TargetBitmap res(input.size(), false);
+    TargetBitmap valid(input.size(), true);
+    const auto processed =
+        seg_expr->ProcessDataByOffsets<int64_t>(evaluate_batch,
+                                                skip_everything,
+                                                &input,
+                                                TargetBitmapView(res),
+                                                TargetBitmapView(valid));
+
+    EXPECT_EQ(processed, int64_t(input.size()));
+    EXPECT_EQ(processed_cursor, int64_t(input.size()));
+    EXPECT_EQ(null_rows, 1);
+    EXPECT_TRUE(res[0]);
+    EXPECT_FALSE(res[1]);
+    EXPECT_TRUE(res[2]);
+    EXPECT_TRUE(res[3]);
+    EXPECT_TRUE(valid[0]);
+    EXPECT_FALSE(valid[1]);
+    EXPECT_TRUE(valid[2]);
+    EXPECT_TRUE(valid[3]);
+}
+
+TEST(OffsetsEvalIndexOnlyCorrectnessTest,
+     NullableTimestamptzCallbackHandlesNullData) {
+    constexpr int64_t kRowCount = 8;
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 4, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto timestamp_fid =
+        schema->AddDebugField("ts", DataType::TIMESTAMPTZ, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto first = DataGen(schema, kRowCount / 2, 200, 0, 1, 1);
+    auto second = DataGen(schema, kRowCount / 2, 201, 0, 1, 1);
+    auto segment = CreateTwoChunkSealed(schema, first, second);
+
+    std::vector<int64_t> index_values(kRowCount);
+    std::iota(index_values.begin(), index_values.end(), int64_t{0});
+    auto index_valid = std::make_unique<bool[]>(kRowCount);
+    for (int64_t i = 0; i < kRowCount; ++i) {
+        index_valid[i] = true;
+    }
+    index_valid[1] = false;
+
+    auto scalar_index = index::CreateScalarIndexSort<int64_t>();
+    scalar_index->Build(kRowCount, index_values.data(), index_valid.get());
+    LoadIndexInfo load_index_info;
+    load_index_info.field_id = timestamp_fid.get();
+    load_index_info.field_type = DataType::TIMESTAMPTZ;
+    load_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    load_index_info.index_params = GenIndexParams(scalar_index.get());
+    load_index_info.cache_index = CreateTestCacheIndex(
+        "offset-timestamptz-index-only", std::move(scalar_index));
+    segment->LoadIndex(load_index_info);
+    segment->DropFieldData(timestamp_fid);
+    ASSERT_FALSE(segment->HasFieldData(timestamp_fid));
+
+    proto::plan::Interval interval;
+    interval.set_months(1);
+    proto::plan::GenericValue compare_value;
+    compare_value.set_int64_val(4102444800LL * 1000000);  // 2100-01-01
+    auto typed_expr =
+        std::make_shared<milvus::expr::TimestamptzArithCompareExpr>(
+            expr::ColumnInfo(timestamp_fid, DataType::TIMESTAMPTZ),
+            proto::plan::ArithOpType::Add,
+            interval,
+            proto::plan::OpType::LessThan,
+            compare_value);
+    auto filter_node = std::make_shared<milvus::plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, typed_expr);
+
+    OffsetVector input{0, 1, 2, 5};
+    auto col_vec = milvus::test::gen_filter_res(
+        filter_node.get(), segment.get(), kRowCount, MAX_TIMESTAMP, &input);
+    ASSERT_EQ(col_vec->size(), input.size());
+
+    TargetBitmapView result(col_vec->GetRawData(), col_vec->size());
+    TargetBitmapView valid(col_vec->GetValidRawData(), col_vec->size());
+    EXPECT_TRUE(result[0]);
+    EXPECT_FALSE(result[1]);
+    EXPECT_TRUE(result[2]);
+    EXPECT_TRUE(result[3]);
+    EXPECT_TRUE(valid[0]);
+    EXPECT_FALSE(valid[1]);
+    EXPECT_TRUE(valid[2]);
+    EXPECT_TRUE(valid[3]);
+}

--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "common/Types.h"
+#include "exec/expression/ConjunctExpr.h"
 #include "exec/expression/Expr.h"
 #include "expr/ITypeExpr.h"
 #include "index/ScalarIndexSort.h"
@@ -90,6 +91,46 @@ CreateTwoChunkSealed(const SchemaPtr& schema,
                "Failed to load two-chunk sealed data: {}",
                status.error_msg);
     return segment;
+}
+
+void
+SetInt64FieldData(GeneratedData& dataset,
+                  FieldId field_id,
+                  const std::vector<int64_t>& values) {
+    AssertInfo(dataset.raw_->num_rows() == values.size(),
+               "values size must match row count");
+    for (int i = 0; i < dataset.raw_->fields_data_size(); ++i) {
+        auto* field_data = dataset.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != field_id.get()) {
+            continue;
+        }
+        auto* data =
+            field_data->mutable_scalars()->mutable_long_data()->mutable_data();
+        data->Clear();
+        data->Add(values.data(), values.data() + values.size());
+        return;
+    }
+    ThrowInfo(FieldIDInvalid, "field id {} not found", field_id.get());
+}
+
+void
+SetFloatFieldData(GeneratedData& dataset,
+                  FieldId field_id,
+                  const std::vector<float>& values) {
+    AssertInfo(dataset.raw_->num_rows() == values.size(),
+               "values size must match row count");
+    for (int i = 0; i < dataset.raw_->fields_data_size(); ++i) {
+        auto* field_data = dataset.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != field_id.get()) {
+            continue;
+        }
+        auto* data =
+            field_data->mutable_scalars()->mutable_float_data()->mutable_data();
+        data->Clear();
+        data->Add(values.data(), values.data() + values.size());
+        return;
+    }
+    ThrowInfo(FieldIDInvalid, "field id {} not found", field_id.get());
 }
 
 template <typename T>
@@ -205,6 +246,98 @@ VerifyElementFullScanSkipCursor(SegmentExpr& segment_expr,
     }
 }
 
+void
+VerifyNullableElementFullScanLogicalCount(
+    const SegmentInternalInterface* segment,
+    FieldId array_fid,
+    int64_t row_count,
+    int skipped_chunk_id,
+    int64_t expected_skipped_elements,
+    int64_t expected_live_elements) {
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, segment, row_count, MAX_TIMESTAMP);
+    auto array_offsets = segment->GetArrayOffsets(array_fid);
+    ASSERT_NE(array_offsets, nullptr);
+    ASSERT_EQ(array_offsets->GetTotalElementCount(),
+              expected_skipped_elements + expected_live_elements);
+
+    // DataGen keeps a physical payload for nullable ARRAY rows in growing
+    // storage even when the row validity bit is false. Sealed binlog
+    // serialization may discard that payload, but ArrayOffsets maps the NULL
+    // row to zero logical elements in either layout.
+    if (segment->type() == SegmentType::Sealed) {
+        auto pw = segment->get_batch_views<ArrayView>(
+            query_context->get_op_context(), array_fid, 0, 0, 2);
+        const auto& [data, valid] = pw.get();
+        ASSERT_EQ(data.size(), 2);
+        ASSERT_EQ(valid.size(), 2);
+        EXPECT_FALSE(valid[1]);
+    } else {
+        auto pw = segment->chunk_data<Array>(
+            query_context->get_op_context(), array_fid, 0);
+        auto chunk = pw.get();
+        ASSERT_EQ(chunk.row_count(), 2);
+        ASSERT_NE(chunk.valid_data(), nullptr);
+        EXPECT_FALSE(chunk.valid_data()[1]);
+        EXPECT_EQ(chunk.data()[1].length(), 2);
+    }
+    const auto null_row_range = array_offsets->ElementIDRangeOfRow(1);
+    EXPECT_EQ(null_row_range.first, null_row_range.second);
+
+    SegmentExpr segment_expr(std::vector<ExprPtr>{},
+                             "nullable element full-scan probe",
+                             query_context->get_op_context(),
+                             segment,
+                             array_fid,
+                             std::vector<std::string>{},
+                             DataType::INT64,
+                             row_count,
+                             row_count,
+                             query_context->get_consistency_level());
+
+    auto skip_chunk = [skipped_chunk_id](
+                          const SkipIndex&, FieldId, int chunk_id) {
+        return chunk_id == skipped_chunk_id;
+    };
+    int64_t processed_cursor = 0;
+    int64_t null_elements = 0;
+    int64_t live_elements = 0;
+    auto evaluate_batch = [&]<FilterType filter_type = FilterType::sequential>(
+        const int64_t* data,
+        const bool* valid_data,
+        const int32_t* offsets,
+        const int size,
+        TargetBitmapView res,
+        TargetBitmapView valid_res) {
+        processed_cursor += size;
+        if (data == nullptr) {
+            null_elements += size;
+            return;
+        }
+        live_elements += size;
+        res.set(0, size, true);
+    };
+
+    const auto logical_elements = array_offsets->GetTotalElementCount();
+    TargetBitmap res(logical_elements, false);
+    TargetBitmap valid(logical_elements, true);
+    const auto processed =
+        segment_expr.ProcessDataChunksForElementLevel<int64_t>(
+            evaluate_batch,
+            skip_chunk,
+            TargetBitmapView(res),
+            TargetBitmapView(valid));
+
+    EXPECT_EQ(processed, logical_elements);
+    EXPECT_EQ(processed_cursor, logical_elements);
+    EXPECT_EQ(null_elements, expected_skipped_elements);
+    EXPECT_EQ(live_elements, expected_live_elements);
+    for (int64_t i = 0; i < logical_elements; ++i) {
+        EXPECT_EQ(bool(res[i]), i >= expected_skipped_elements);
+        EXPECT_TRUE(valid[i]);
+    }
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -247,10 +380,12 @@ class OffsetsEvalCorrectnessTest : public ::testing::Test {
                          dataset.row_ids_.data(),
                          dataset.timestamps_.data(),
                          dataset.raw_);
+        ASSERT_NE(growing_->GetArrayOffsets(array_fid_), nullptr);
 
         auto sealed_first = DataGen(schema_, N / 2, 43, 0, 1, 1);
         auto sealed_second = DataGen(schema_, N / 2, 44, 0, 1, 1);
         sealed_ = CreateTwoChunkSealed(schema_, sealed_first, sealed_second);
+        ASSERT_NE(sealed_->GetArrayOffsets(array_fid_), nullptr);
     }
 
     std::shared_ptr<SegmentExpr>
@@ -477,6 +612,114 @@ TEST_F(OffsetsEvalCorrectnessTest,
     VerifySkipCursorContract<int64_t>(*seg_expr, &offsets, 0);
 }
 
+// Exercise the production expression stack used by iterative filtering:
+// logical AND -> PhyConjunctFilterExpr -> offset-input Unary evaluators.  The
+// first predicate creates bitmap_input=[0,0,1,0].  The second predicate is
+// pruned by real SkipIndex statistics for chunk 0; it must still advance past
+// the first two candidates before reading bitmap_input for chunk 1.
+TEST(OffsetsEvalProductionRegressionTest,
+     ConjunctOffsetInputKeepsMatchAfterRealSkipIndexPruning) {
+    constexpr int64_t kChunkRows = 4;
+    constexpr int64_t kRowCount = kChunkRows * 2;
+
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 4, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto gate_fid = schema->AddDebugField("gate", DataType::INT64);
+    auto prune_fid = schema->AddDebugField("prune", DataType::FLOAT);
+    schema->set_primary_field_id(pk_fid);
+
+    auto first = DataGen(schema, kChunkRows, 500, 0, 1, 1);
+    auto second = DataGen(schema, kChunkRows, 501, 0, 1, 1);
+
+    // gate==999 matches an unselected row in chunk 0, so its SkipIndex cannot
+    // prune that chunk.  Among the selected candidates, only global offset 4
+    // (the first row of chunk 1) passes the gate.
+    SetInt64FieldData(first, gate_fid, {1, 2, 999, 4});
+    SetInt64FieldData(second, gate_fid, {999, 6, 7, 8});
+
+    // prune>60 rejects all of chunk 0 by statistics and accepts chunk 1.
+    SetFloatFieldData(first, prune_fid, {10.0F, 20.0F, 30.0F, 40.0F});
+    SetFloatFieldData(second, prune_fid, {70.0F, 80.0F, 90.0F, 100.0F});
+
+    auto segment = CreateTwoChunkSealed(schema, first, second);
+    auto skip_index = segment->GetSkipIndex();
+    ASSERT_FALSE(skip_index->CanSkipUnaryRange<int64_t>(
+        gate_fid, 0, proto::plan::OpType::Equal, 999));
+    ASSERT_FALSE(skip_index->CanSkipUnaryRange<int64_t>(
+        gate_fid, 1, proto::plan::OpType::Equal, 999));
+    ASSERT_TRUE(skip_index->CanSkipUnaryRange<float>(
+        prune_fid, 0, proto::plan::OpType::GreaterThan, 60.0F));
+    ASSERT_FALSE(skip_index->CanSkipUnaryRange<float>(
+        prune_fid, 1, proto::plan::OpType::GreaterThan, 60.0F));
+
+    proto::plan::GenericValue gate_value;
+    gate_value.set_int64_val(999);
+    auto gate_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(gate_fid, DataType::INT64),
+        proto::plan::OpType::Equal,
+        gate_value,
+        std::vector<proto::plan::GenericValue>{});
+
+    proto::plan::GenericValue prune_value;
+    prune_value.set_float_val(60.0F);
+    auto prune_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(prune_fid, DataType::FLOAT),
+        proto::plan::OpType::GreaterThan,
+        prune_value,
+        std::vector<proto::plan::GenericValue>{});
+    auto and_expr = std::make_shared<expr::LogicalBinaryExpr>(
+        expr::LogicalBinaryExpr::OpType::And, gate_expr, prune_expr);
+
+    // The normal full scan is the ground truth for the candidate-only run.
+    auto filter_node =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, and_expr);
+    auto full_output = milvus::test::gen_filter_res(
+        filter_node.get(), segment.get(), kRowCount, MAX_TIMESTAMP);
+    ASSERT_EQ(full_output->size(), kRowCount);
+    TargetBitmapView full_result(full_output->GetRawData(),
+                                 full_output->size());
+    ASSERT_EQ(full_result.count(), 1);
+    ASSERT_TRUE(full_result[4]);
+
+    auto query_context = std::make_shared<QueryContext>(
+        DEAFULT_QUERY_ID, segment.get(), kRowCount, MAX_TIMESTAMP);
+    ExecContext exec_context(query_context.get());
+    ExprSet expr_set({and_expr}, &exec_context);
+    ASSERT_EQ(expr_set.size(), 1);
+    auto conjunct =
+        std::dynamic_pointer_cast<PhyConjunctFilterExpr>(expr_set.expr(0));
+    ASSERT_NE(conjunct, nullptr);
+    ASSERT_EQ(conjunct->GetReorder(), (std::vector<size_t>{0, 1}));
+
+    // The candidate order is exactly what iterative filtering supplies: two
+    // offsets from the pruned chunk followed by two from the live chunk.
+    OffsetVector offsets{0, 1, 4, 5};
+    EvalCtx eval_context(&exec_context, &offsets);
+    std::vector<VectorPtr> results;
+    expr_set.Eval(eval_context, results);
+
+    ASSERT_EQ(results.size(), 1);
+    auto output = milvus::test::GetColumnVectorForTest(results[0]);
+    ASSERT_NE(output, nullptr);
+    ASSERT_EQ(output->size(), offsets.size());
+    TargetBitmapView result(output->GetRawData(), output->size());
+    TargetBitmapView valid(output->GetValidRawData(), output->size());
+
+    EXPECT_FALSE(result[0]);
+    EXPECT_FALSE(result[1]);
+    EXPECT_TRUE(result[2])
+        << "global offset 4 was lost after chunk-0 SkipIndex pruning";
+    EXPECT_FALSE(result[3]);
+    EXPECT_TRUE(valid.all());
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        EXPECT_EQ(result[i], full_result[offsets[i]])
+            << "candidate " << i << " (global offset " << offsets[i]
+            << ") differs from full-scan ground truth";
+    }
+}
+
 // VARCHAR/JSON/ARRAY use get_views_by_offsets rather than chunk_data. Pin the
 // view branch separately because its validity storage and ownership differ.
 TEST_F(OffsetsEvalCorrectnessTest,
@@ -594,6 +837,101 @@ TEST_F(OffsetsEvalCorrectnessTest,
         sealed_.get(), array_fid_, DataType::INT64, *query_context);
 
     VerifyElementFullScanSkipCursor(*seg_expr, N, 0, N / 2);
+}
+
+TEST(OffsetsEvalNullableElementTest,
+     GrowingFullScanUsesLogicalCountForNullPayloadRows) {
+    constexpr int64_t kRowCount = 4;
+    constexpr int64_t kChunkRows = 2;
+    constexpr int64_t kArrayLength = 2;
+
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 4, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto array_fid = schema->AddDebugArrayField(
+        "structA[nullable_values]", DataType::INT64, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto dataset = DataGen(schema, kRowCount, 600, 0, 1, kArrayLength);
+    SegcoreConfig config = SegcoreConfig::default_config();
+    config.set_chunk_rows(kChunkRows);
+    auto segment = CreateGrowingSegment(schema, empty_index_meta, 1, config);
+    segment->PreInsert(kRowCount);
+    segment->Insert(0,
+                    kRowCount,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+
+    VerifyNullableElementFullScanLogicalCount(
+        segment.get(), array_fid, kRowCount, 0, 2, 2);
+}
+
+TEST(OffsetsEvalNullableElementTest,
+     GrowingLoadFieldDataUsesLogicalCountForNullPayloadRows) {
+    constexpr int64_t kRowCount = 4;
+    constexpr int64_t kChunkRows = 2;
+    constexpr int64_t kArrayLength = 2;
+
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 4, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto array_fid = schema->AddDebugArrayField(
+        "structA[nullable_values]", DataType::INT64, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto dataset = DataGen(schema, kRowCount, 650, 0, 1, kArrayLength);
+    SegcoreConfig config = SegcoreConfig::default_config();
+    config.set_chunk_rows(kChunkRows);
+    auto segment = CreateGrowingSegment(schema, empty_index_meta, 1, config);
+    ASSERT_EQ(segment->PreInsert(kRowCount), 0);
+
+    // Mimic the growing recovery path after storage decoding.  FieldData<Array>
+    // keeps dense physical payloads for invalid rows, so the offsets producer
+    // must consult validity rather than count those payloads as elements.
+    auto* growing = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing, nullptr);
+    const auto& field_meta = schema->operator[](array_fid);
+    bool loaded = false;
+    for (const auto& data : dataset.raw_->fields_data()) {
+        if (data.field_id() != array_fid.get()) {
+            continue;
+        }
+        auto field_data =
+            CreateFieldDataFromDataArray(kRowCount, &data, field_meta);
+        growing->load_field_data_common(
+            array_fid, 0, {field_data}, pk_fid, kRowCount);
+        loaded = true;
+        break;
+    }
+    ASSERT_TRUE(loaded);
+
+    VerifyNullableElementFullScanLogicalCount(
+        segment.get(), array_fid, kRowCount, 0, 2, 2);
+}
+
+TEST(OffsetsEvalNullableElementTest,
+     SealedFullScanUsesLogicalCountForNullPayloadRows) {
+    constexpr int64_t kRowsPerChunk = 2;
+    constexpr int64_t kRowCount = kRowsPerChunk * 2;
+    constexpr int64_t kArrayLength = 2;
+
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 4, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto array_fid = schema->AddDebugArrayField(
+        "structA[nullable_values]", DataType::INT64, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto first = DataGen(schema, kRowsPerChunk, 700, 0, 1, kArrayLength);
+    auto second = DataGen(schema, kRowsPerChunk, 701, 0, 1, kArrayLength);
+    auto segment = CreateTwoChunkSealed(schema, first, second);
+
+    VerifyNullableElementFullScanLogicalCount(
+        segment.get(), array_fid, kRowCount, 0, 2, 2);
 }
 
 TEST(OffsetsEvalIndexOnlyCorrectnessTest,


### PR DESCRIPTION
Backport of #51540 to the 3.0 branch.

pr: #51540
issue: #51537
follow-up issue: #51736
proposed master fix: #51737

## What changed

- Preserve the evaluator callback contract for SkipIndex-pruned row and element candidates by applying validity first, then invoking the evaluator with a null batch so callback-local bitmap cursors still advance.
- Keep nullable scalar-index reverse-lookup misses aligned and stop applying raw chunk-0 SkipIndex statistics to the segment-wide scalar index.
- Use `IArrayOffsets` as the logical source of truth for flattened ARRAY elements, including nullable rows with retained physical payloads.
- Fix growing-segment ARRAY length recovery to read the dense `Array` layout and assign zero logical elements to invalid rows.
- Make the remaining TIMESTAMPTZ, unary ARRAY, and unary JSON offset evaluators safe for null batches produced by reverse-lookup misses.
- Backport 15 focused regressions covering growing and sealed row offsets, element offsets, element full scans, nullable ARRAY accounting, and scalar-index-only evaluation.

## Scope

This backport keeps the scope of #51540. It fixes logical-candidate accounting when an evaluated batch contains elements.

It does not change the existing framework behavior for a whole row batch whose logical element count is zero. That distinct follow-up is tracked in #51736, with the proposed master fix in #51737.

## Backport notes

- Cherry-picked source commits `dc33021eb740d7e6c2f56756f72850540ab919c1` and `193e29e9a313d76df7f911ebec7f3080b46ca331` in source order with provenance and DCO trailers.
- Both commits applied cleanly on the latest `upstream/3.0` with no 3.0-specific code changes.
- Each stable patch-id matches its source commit exactly; range-diff differs only by cherry-pick provenance and Li Liu sign-off trailers.
- The only source-parent versus 3.0-base differences in touched pre-existing files are unrelated null-rejecting expression support and a growing column-load unwind guard; neither overlaps the backported hunks.
- Audited all 3.0 production callers of the affected offset and element helpers; their evaluators are null-batch safe after this patch.

## Verification

- `git diff --check upstream/3.0...HEAD` — passed.
- `clang-format-15 --dry-run --Werror` on all changed C++ files — passed.
- Source PR CI Loop on the exact current head `193e29e9` passed build, code-check, integration and Go tests, plus 8,249/8,249 C++ tests.
- Local full C++ rebuild was not completed because the macOS arm64 Conan profile has no compatible binaries and began rebuilding the full third-party dependency graph; target-branch CI for this backport must provide branch-specific compile and regression coverage.
