### PR TITLE
fix: [3.0] inject QueryNode-local index load params on segment Reopen

### DIFF
--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1303,6 +1303,13 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 	}
 	defer s.ptrLock.Unpin()
 
+	// Reopen forwards the SegmentLoadInfo straight to segcore, so it must inject
+	// the QueryNode-local index load params (e.g. DISKANN num_load_thread) that
+	// the full-load path injects; otherwise segcore asserts on load. See #51249.
+	if err := prepareIndexLoadParams(newLoadInfo.GetIndexInfos()); err != nil {
+		return err
+	}
+
 	schema, schemaVersion := s.collection.SchemaAndSegcoreVersion()
 	err := s.csegment.Reopen(ctx, &segcore.ReopenRequest{
 		LoadInfo:      newLoadInfo,

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -276,26 +276,8 @@ func (loader *segmentLoader) Load(ctx context.Context,
 	for _, info := range infos {
 		loadInfo := info
 
-		for _, indexInfo := range loadInfo.IndexInfos {
-			indexParams := funcutil.KeyValuePair2Map(indexInfo.IndexParams)
-
-			// some build params also exist in indexParams, which are useless during loading process
-			if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexParams["index_type"]) {
-				if err := indexparams.SetDiskIndexLoadParams(paramtable.Get(), indexParams, indexInfo.GetNumRows()); err != nil {
-					return nil, err
-				}
-			}
-
-			// set whether enable offset cache for bitmap index
-			if indexParams["index_type"] == indexparamcheck.IndexBitmap {
-				indexparams.SetBitmapIndexLoadParams(paramtable.Get(), indexParams)
-			}
-
-			if err := indexparams.AppendPrepareLoadParams(paramtable.Get(), indexParams); err != nil {
-				return nil, err
-			}
-
-			indexInfo.IndexParams = funcutil.Map2KeyValuePair(indexParams)
+		if err := prepareIndexLoadParams(loadInfo.GetIndexInfos()); err != nil {
+			return nil, err
 		}
 
 		segment, err := NewSegment(
@@ -2422,6 +2404,41 @@ func SupportInterimIndexDataType(dataType schemapb.DataType) bool {
 		dataType == schemapb.DataType_SparseFloatVector ||
 		dataType == schemapb.DataType_Float16Vector ||
 		dataType == schemapb.DataType_BFloat16Vector
+}
+
+// prepareIndexLoadParams injects QueryNode-local index load parameters into each
+// index's IndexParams in place. These params (e.g. DISKANN num_load_thread) are
+// derived from local QueryNode resources/config and are never persisted in the
+// index metadata, so they must be re-injected on every load path before the load
+// info reaches segcore. Both full-load (Load) and Reopen call this; skipping it
+// on Reopen was the root cause of issue #51249 (segcore asserts
+// "param num_load_thread is empty" while loading a DISKANN index).
+func prepareIndexLoadParams(indexInfos []*querypb.FieldIndexInfo) error {
+	for _, indexInfo := range indexInfos {
+		if indexInfo == nil {
+			continue
+		}
+		indexParams := funcutil.KeyValuePair2Map(indexInfo.GetIndexParams())
+
+		// some build params also exist in indexParams, which are useless during loading process
+		if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexParams["index_type"]) {
+			if err := indexparams.SetDiskIndexLoadParams(paramtable.Get(), indexParams, indexInfo.GetNumRows()); err != nil {
+				return err
+			}
+		}
+
+		// set whether enable offset cache for bitmap index
+		if indexParams["index_type"] == indexparamcheck.IndexBitmap {
+			indexparams.SetBitmapIndexLoadParams(paramtable.Get(), indexParams)
+		}
+
+		if err := indexparams.AppendPrepareLoadParams(paramtable.Get(), indexParams); err != nil {
+			return err
+		}
+
+		indexInfo.IndexParams = funcutil.Map2KeyValuePair(indexParams)
+	}
+	return nil
 }
 
 func (loader *segmentLoader) ReopenSegments(ctx context.Context,

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/indexparams"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -891,6 +893,81 @@ func TestLocalSegmentReopenErrorDoesNotAdvanceLoadInfo(t *testing.T) {
 	err := segment.Reopen(context.Background(), newLoadInfo)
 	assert.ErrorIs(t, err, merr.ErrCollectionSchemaVersionNotReady)
 	assert.Equal(t, int32(1), segment.LoadInfo().GetDataVersion())
+}
+
+// TestLocalSegmentReopenInjectsDiskIndexLoadParams reproduces issue #51249:
+// the Reopen path must inject QueryNode-local index load params (e.g. DISKANN
+// num_load_thread) before handing the load info to segcore. Without the fix,
+// the DISKANN index params reaching segcore lack num_load_thread and segcore
+// asserts "param num_load_thread is empty".
+func TestLocalSegmentReopenInjectsDiskIndexLoadParams(t *testing.T) {
+	paramtable.Init()
+
+	schema := mock_segcore.GenTestCollectionSchema("collection_v1", schemapb.DataType_Int64, false)
+	schema.Version = 1
+
+	collection := &Collection{}
+	collection.setSchema(schema, 1, 100, 101)
+
+	getParam := func(kvs []*commonpb.KeyValuePair, key string) (string, bool) {
+		for _, kv := range kvs {
+			if kv.GetKey() == key {
+				return kv.GetValue(), true
+			}
+		}
+		return "", false
+	}
+
+	var captured *querypb.SegmentLoadInfo
+	csegment := mock_segcore.NewMockCSegment(t)
+	csegment.EXPECT().
+		Reopen(mock.Anything, mock.MatchedBy(func(request *segcore.ReopenRequest) bool {
+			captured = request.LoadInfo
+			return true
+		})).
+		Return(nil)
+
+	// DISKANN index carrying build-time params but NOT the QueryNode-local
+	// num_load_thread (the exact shape QueryCoord sends on a Reopen task).
+	newLoadInfo := &querypb.SegmentLoadInfo{
+		CollectionID:  10,
+		SegmentID:     20,
+		PartitionID:   30,
+		InsertChannel: "by-dev-rootcoord-dml_0_10v0",
+		IndexInfos: []*querypb.FieldIndexInfo{
+			{
+				FieldID: 100,
+				IndexID: 1000,
+				NumRows: 5000,
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "DISKANN"},
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+		},
+	}
+	segment := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:         collection,
+			loadInfo:           atomic.NewPointer(newLoadInfo),
+			version:            atomic.NewInt64(0),
+			resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+			needUpdatedVersion: atomic.NewInt64(0),
+		},
+		ptrLock:        state.NewLoadStateLock(state.LoadStateDataLoaded),
+		csegment:       csegment,
+		fieldIndexes:   typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
+		fieldJSONStats: make(map[int64]*querypb.JsonStatsInfo),
+	}
+
+	require.NoError(t, segment.Reopen(context.Background(), newLoadInfo))
+	require.NotNil(t, captured)
+	require.Len(t, captured.GetIndexInfos(), 1)
+
+	// The load info handed to segcore must now carry num_load_thread.
+	numLoadThread, ok := getParam(captured.GetIndexInfos()[0].GetIndexParams(), indexparams.NumLoadThreadKey)
+	assert.True(t, ok, "num_load_thread must be injected into DISKANN index params on Reopen")
+	assert.NotEmpty(t, numLoadThread)
 }
 
 // TestBaseSegment_SkipGrowingBF tests that skipGrowingBF bypasses PK candidate checks.


### PR DESCRIPTION
## Summary

The segment Reopen path handed the `SegmentLoadInfo` to segcore without injecting the QueryNode-local index load parameters that the normal load path injects. For a DISKANN index the required `num_load_thread` (derived from local QueryNode resources, not persisted in index metadata) was therefore missing, and segcore aborted index loading with `param num_load_thread is empty` (VectorDiskIndex). Reopen tasks failed and were recreated indefinitely, adding sustained scheduler / index-loading / logging pressure while the new DISKANN index never loaded on the affected segments.

This extracts the per-index load-parameter preparation from `segmentLoader.Load` into a shared `prepareIndexLoadParams` helper and calls it from `LocalSegment.Reopen` as well, so the full-load and Reopen paths inject the same parameters. A unit test reproduces the missing parameter (fails before the fix, passes after).

issue: #51249
pr: #51716