### PR TITLE
enhance: [3.0] add request-level read leases for sealed segment reopen

### DIFF
--- a/docs/design-docs/design_docs/20260720-segment-reopen-request-read-lease-drain-design.md
+++ b/docs/design-docs/design_docs/20260720-segment-reopen-request-read-lease-drain-design.md
@@ -1,0 +1,1190 @@
+# Segment Reopen Request-Level ReadLease and Sealed Drain Design
+
+## Document Information
+
+- Date: 2026-07-20
+- Status: Draft for final design review
+- Language: English (canonical)
+- Components: Segcore / QueryNode
+- Primary scope:
+  - `internal/core/src/segcore/ChunkedSegmentSealedImpl.{h,cpp}`
+  - `internal/core/src/segcore/segment_c.cpp`
+  - `internal/core/src/segcore/search_result_export_c.cpp`
+  - `internal/core/src/common/QueryResult.h`
+  - `internal/querynodev2/tasks/search_task.go`
+- Related documents:
+  - [Chinese version](./20260720-segment-reopen-request-read-lease-drain-design_zh.md)
+  - [Segment Reopen Atomic Read & Update with Copy-on-Write](./20260627-segment-reopen-atomic-read-update-cow.md)
+  - [Segment Reopen Review Page](./20260627-segment-reopen-generation-review/index.html)
+
+---
+
+## 1. Summary
+
+This design retains the existing `PublishedSegmentState` and runtime
+copy-on-write publication framework in `ChunkedSegmentSealedImpl`, but narrows
+the serving consistency boundary for sealed segments to a
+**request-level read lease**:
+
+- A growing segment returns a no-op read lease.
+- `AsyncSearch` on a sealed segment acquires a cross-thread-safe
+  `SegmentReadLease`.
+- The lease is transferred to `SearchResult` and remains alive until
+  `DeleteSearchResult`.
+- Reduce, export, and output-field fill reuse the lease already owned by the
+  original `SearchResult`. They do not acquire a new lease.
+- Before publication, Reopen marks a writer as pending and waits for all
+  existing request leases to be released.
+- New escaping Search lease acquisition fails fast while the publisher is
+  pending or active. QueryNode releases every partial `SearchResult` from the
+  rejected attempt, then retries the complete sealed segment batch with jitter
+  under the request context.
+- New call-scoped Retrieve lease acquisition fails fast while publication is
+  pending or active. QueryNode retries only that Retrieve call with jitter under
+  the request context. Growing reads remain no-op.
+- After the drain completes, Reopen atomically publishes the complete metadata
+  and runtime snapshot exactly once.
+
+As a result, one search request observes one sealed snapshot from Segcore
+search through reduce, export, and output-field fill.
+
+This design explicitly stops supporting the following behavior:
+
+> Different CGO phases of the same search request may observe different sealed
+> snapshots.
+
+The design accepts a longer Reopen publication wait in exchange for:
+
+- a simpler consistency model;
+- a much smaller reader-accessor migration surface;
+- no whole-snapshot pin solely for Reopen lifetime;
+- a direct proof that schema, readiness, and runtime do not change during a
+  request.
+
+---
+
+## 2. Background and Problem Statement
+
+The sealed segment implementation is already moving schema, load information,
+readiness, and runtime resources into `PublishedSegmentState`. Writers clone
+the current state, prepare the next state, and publish it with an atomic store.
+
+With a call-scoped read guard, the following sequence is possible:
+
+```text
+AsyncSearch reads S0
+        ↓
+Search returns and releases the guard
+        ↓
+Reopen publishes S1
+        ↓
+PrepareSearchResults / FillOutputFields reads S1
+```
+
+This can be made logically valid with strict row-mapping invariants, but
+`SearchResult` may also carry iterators, offset mappings, or cache-backed
+resources created from S0. The ownership model then becomes part of every
+escaped resource.
+
+Because Reopen is infrequent and publication is allowed to temporarily reject
+and retry new sealed searches, this design extends read protection through the
+entire `SearchResult` lifetime.
+
+---
+
+## 3. Goals
+
+### 3.1 Functional Goals
+
+1. One sealed search request observes one `PublishedSegmentState`.
+2. Reopen drains all old search requests before publishing.
+3. Once a writer is pending, new sealed searches fail admission and cannot
+   bypass it; QueryNode retries only after releasing the entire attempt.
+4. Call-scoped Retrieve reads fail admission behind a pending or active
+   publisher and retry only the current segment call without blocking a Segcore
+   executor thread.
+5. Growing segments do not receive a new operation gate.
+6. Reopen preparation remains non-blocking for readers; only final publication
+   performs the drain.
+7. Reopen performs one externally visible publication.
+8. `LazyCheckSchema` remains available as a transitional mechanism, runs
+   before gate acquisition, and fails fast instead of waiting for either the
+   publication gate or another reopen.
+9. Cancellation, timeout, and error paths cannot leak a lease or leave the read
+   gate closed.
+
+### 3.2 Engineering Goals
+
+1. Do not directly replace the existing `mutex_` with a writer-priority mutex.
+2. Avoid adding SegmentInterface virtual methods and the associated CGO vtable
+   layout risk.
+3. Allow a lease to be acquired and released on different threads.
+4. Encode the publisher contract in APIs instead of relying on comments.
+5. Provide production visibility into long leases and long drains.
+
+---
+
+## 4. Non-Goals
+
+This design does not attempt to:
+
+- keep an old request running after a new snapshot has been published;
+- apply request-level drain semantics to growing segments;
+- immediately remove all historical sealed-segment mutexes;
+- use the segment gate to solve independent cache-manager eviction ownership;
+- immediately move all schema synchronization out of the search executor;
+- support a Reopen that changes row count, row order, or offset-to-PK mapping.
+
+---
+
+## 5. Terminology
+
+### 5.1 Published Snapshot
+
+A complete reader-visible `PublishedSegmentState`:
+
+```text
+PublishedSegmentState
+  ├─ schema
+  ├─ load_info
+  ├─ commit_ts
+  ├─ readiness
+  └─ runtime resource graph
+```
+
+### 5.2 SegmentReadLease
+
+A request-scoped claim on the currently published sealed snapshot.
+
+The lease does not select an arbitrary historical snapshot. Its contract is:
+
+> While the lease is alive, the sealed segment cannot publish its next
+> snapshot.
+
+### 5.3 Writer Pending
+
+A writer has completed, or nearly completed, preparation and is ready to
+publish:
+
+- new escaping Search leases fail admission;
+- new call-scoped Retrieve leases fail admission without entering;
+- existing leases may continue reduce and fill work;
+- the writer waits for the active lease count to reach zero.
+
+---
+
+## 6. Consistency Model
+
+### 6.1 Growing Segment
+
+`AcquireSegmentReadLease` returns an empty lease for a growing segment.
+
+Growing continues to rely on its existing synchronization:
+
+- `mutex_`;
+- `sch_mutex_`;
+- `chunk_mutex_`;
+- InsertRecord internal locks.
+
+This design does not change the lock relationship among Insert, AddTexts,
+Growing Reopen, and query execution.
+
+### 6.2 Sealed Segment
+
+Sealed search lifetime:
+
+```text
+LazyCheckSchema
+        ↓
+Acquire SegmentReadLease for S0
+        ↓
+Search
+        ↓
+Prepare / Reduce / Export / Fill
+        ↓
+DeleteSearchResult
+        ↓
+Release SegmentReadLease
+```
+
+Reopen lifetime:
+
+```text
+Prepare S1 while the gate is open
+        ↓
+writer_pending = true
+        ↓
+reject new sealed search leases
+        ↓
+wait for active_readers == 0
+        ↓
+publish S1 exactly once
+        ↓
+open the gate
+```
+
+### 6.3 Request-Level Guarantee
+
+For one sealed segment:
+
+- schema, load information, readiness, and runtime remain stable after lease
+  acquisition;
+- search offsets, PK fill, refine, and output fill all operate on the same
+  snapshot;
+- a new snapshot can only be published after the request releases its lease.
+
+---
+
+## 7. Invariants
+
+Even though the request lease prevents cross-snapshot reads, Reopen must still
+preserve:
+
+1. segment ID;
+2. row count;
+3. row order;
+4. segment offset to PK mapping;
+5. insert-timestamp semantics;
+6. the data type, vector dimension, and primary-key meaning of an existing
+   FieldID;
+7. readiness/runtime consistency;
+8. prepare isolation from the currently published state.
+
+Any operation that changes row layout or PK mapping must use full segment
+replacement instead of this Reopen protocol.
+
+---
+
+## 8. Gate Data Structure
+
+### 8.1 Why Not Store a Folly Shared Lock in SearchResult
+
+`AsyncSearch` may acquire a lease on a Segcore search executor thread, while
+`DeleteSearchResult` may execute on a different CGO thread.
+
+Therefore, `SearchResult` must not own:
+
+```cpp
+std::shared_lock<folly::SharedMutexWritePriority>
+```
+
+and release it from another thread. Request-level protection should use a
+cross-thread-safe reference-counted token.
+
+### 8.2 GateState
+
+Conceptual structure:
+
+```cpp
+struct GateState {
+    std::mutex mutex;
+    std::condition_variable cv;
+
+    uint64_t active_readers = 0;
+    bool writer_pending = false;
+    bool writer_active = false;
+
+    // Optional observability state.
+    uint64_t blocked_readers = 0;
+    std::chrono::steady_clock::time_point oldest_reader_start;
+};
+```
+
+`ChunkedSegmentSealedImpl` and all outstanding leases share ownership of:
+
+```cpp
+std::shared_ptr<GateState> operation_gate_;
+```
+
+This separates the gate lifetime from the segment object lifetime and prevents
+a lease destructor from dereferencing an already-destroyed segment.
+
+### 8.3 SegmentReadLease
+
+```cpp
+class SegmentReadLease {
+ public:
+    SegmentReadLease() = default;  // Growing/no-op.
+    SegmentReadLease(SegmentReadLease&&) = default;
+    SegmentReadLease& operator=(SegmentReadLease&&) = default;
+    ~SegmentReadLease();
+
+    bool
+    valid() const;
+
+ private:
+    explicit SegmentReadLease(std::shared_ptr<GateState> state);
+
+    std::shared_ptr<GateState> state_;
+};
+```
+
+Escaping Search read acquisition:
+
+```text
+lock gate mutex
+if writer_pending || writer_active:
+    increment rejection counter
+    return the narrow transient gate-busy error
+active_readers++
+unlock gate mutex
+```
+
+Escaping read admission must not wait inside one segment while the same
+QueryNode attempt retains leases from other segments. Otherwise two requests
+that visit segments in opposite orders can retain partial leases and deadlock
+two publishers. The Search retry boundary is therefore the complete sealed
+segment batch, not one segment or one goroutine.
+
+Call-scoped Retrieve acquisition uses the same fail-fast gate operation:
+
+```text
+lock gate mutex
+if writer_pending || writer_active:
+    increment rejection counter
+    return the narrow transient gate-busy error
+active_readers++
+unlock gate mutex
+```
+
+Because Retrieve releases its lease before the CGO call returns, QueryNode can
+retry only the rejected segment call. No reader waits inside the Search CPU
+executor, so queued Retrieve work cannot prevent Search consume callbacks from
+transferring results to Go for eventual lease release.
+
+Read release:
+
+```text
+lock gate mutex
+active_readers--
+if active_readers == 0:
+    notify writer
+unlock gate mutex
+```
+
+### 8.4 PublishLease
+
+Writer acquisition:
+
+```text
+lock gate mutex
+check cancellation
+writer_pending = true
+wait, with cancellation polling and a bounded deadline, until
+    active_readers == 0 && !writer_active
+check cancellation again
+writer_active = true
+unlock gate mutex
+```
+
+The second cancellation check is the cancellation linearization point. A
+cancellation observed by that check aborts publication and reopens the gate.
+Cancellation arriving after the check may not prevent publication and does not
+roll back a publication that has already been admitted.
+
+The production drain deadline defaults to 30 seconds, including callers that
+do not provide an `OpContext`. Cancellation or timeout clears
+`writer_pending`, wakes waiters, discards the staged state, and leaves the old
+snapshot active.
+
+Writer release:
+
+```text
+lock gate mutex
+writer_active = false
+writer_pending = false
+notify all readers
+unlock gate mutex
+```
+
+All online publishers must first serialize on `reopen_mutex_` before entering
+the writer protocol. The mutex may be renamed to `publication_mutex_` after
+publisher convergence, but the single-publisher property is required: a
+boolean `writer_pending` is not a correct queue for multiple concurrent
+publishers.
+
+---
+
+## 9. Read Path
+
+### 9.1 AsyncSearch
+
+Recommended order:
+
+```cpp
+milvus::OpContext op_ctx(cancel_token);
+
+// Reopen is allowed before entering the gate.
+segment->LazyCheckSchema(plan->schema_, &op_ctx);
+
+// The request snapshot is stable from this point.
+auto lease = AcquireSegmentReadLease(segment);
+
+// Only pure reads and validation are allowed inside the gate.
+auto snapshot = CapturePublishedStateForValidation(segment);
+ValidatePlanAgainstSnapshot(plan, snapshot);
+
+CheckExternalFieldsInLoadedManifest(...);
+
+std::unique_ptr<SearchResult> result;
+if (!filter_only && !segment->FieldAccessible(target_field)) {
+    result = BuildEmptySearchResult(...);
+} else {
+    result = segment->Search(...);
+}
+
+result->read_lease_ = std::move(lease);
+return result;
+```
+
+Every successfully returned result must receive the lease:
+
+- normal search results;
+- inaccessible-target empty results;
+- filter-only results;
+- iterator and group-by results;
+- zero-hit results.
+
+If an exception occurs before result ownership is established, the local lease
+releases through RAII.
+
+### 9.2 LazyCheckSchema Before the Gate
+
+`LazyCheckSchema` must execute before lease acquisition.
+
+Executing it inside the gate would produce deterministic self-deadlock:
+
+```text
+request increments active_readers
+        ↓
+LazyCheckSchema calls Reopen
+        ↓
+Reopen waits for active_readers == 0
+        ↓
+the request waits for itself
+```
+
+The lazy path must also avoid blocking on older requests. Search result consume
+callbacks run on the same Search CPU executor as AsyncSearch and Retrieve. If a
+lazy reopen waits for an old lease while enough newer-schema requests occupy
+the executor, those callbacks cannot run and the old lease cannot be released.
+
+Sealed LazyCheckSchema therefore uses a fail-fast publication mode:
+
+```text
+compare schema version
+        ↓
+try_lock reopen_mutex; fail gate-busy if another reopen owns it
+        ↓
+recheck schema version
+        ↓
+if readers or a publisher are already present: fail gate-busy
+        ↓
+prepare the staged schema/runtime snapshot
+        ↓
+atomically try to acquire publication with active_readers == 0
+        ↓
+publish, or discard the staged snapshot and fail gate-busy
+```
+
+The early gate check avoids known-unnecessary preparation but is not the
+linearization point: a reader may enter during preparation, so final
+publication must repeat the check while holding the gate mutex. A failed lazy
+publication does not set `writer_pending` and leaves the old snapshot readable.
+QueryNode handles the narrow gate-busy signal using the existing whole-batch
+Search retry or per-segment Retrieve retry.
+
+Explicit Reopen continues to serialize with a blocking `reopen_mutex_` and use
+bounded drain on the Load executor. Only the read-triggered lazy path is
+fail-fast.
+
+### 9.3 Race Between Lazy Check and Gate Acquisition
+
+The following sequence is allowed:
+
+```text
+LazyCheckSchema publishes S1
+        ↓
+another writer publishes compatible S2
+        ↓
+the request acquires a lease on S2
+```
+
+Therefore, LazyCheckSchema only guarantees:
+
+```text
+acquired snapshot schema version >= plan schema version
+```
+
+It does not guarantee that the acquired snapshot is exactly the one published
+by the request's own lazy reopen.
+
+The race is valid only if:
+
+- schema versions are monotonic;
+- schema rollback is not allowed;
+- a newer snapshot remains forward-compatible with an older plan;
+- existing FieldID types and vector dimensions cannot change;
+- dropped/default-field behavior has explicit compatibility semantics.
+
+### 9.4 Post-Acquisition Compatibility Validation
+
+After lease acquisition, validate the stable snapshot without mutation:
+
+1. `snapshot.schema_version >= plan.schema_version`;
+2. the target vector FieldID exists or follows the explicit inaccessible path;
+3. vector type and dimension are compatible with the plan;
+4. plan access entries are serviceable by the snapshot;
+5. dropped/default fields follow a supported path;
+6. external manifest state includes all required storage columns;
+7. readiness and runtime resources describe the same visible state.
+
+If the snapshot is unexpectedly older than the plan:
+
+```text
+release lease
+        ↓
+retry LazyCheckSchema
+        ↓
+reacquire lease
+```
+
+Reopen must never execute while a request lease is held.
+
+If the snapshot is newer but incompatible:
+
+- do not repair it inside the gate;
+- return a well-defined error or trigger an upper-layer plan rebuild/retry;
+- finalize the error and retry contract before implementation.
+
+### 9.5 Later Search CGO Phases
+
+The following entry points must not acquire another lease:
+
+- `PrepareSearchResultsForExport`;
+- `ExportSearchResultAsArrowRecordBatch`;
+- `FillOutputFieldsOrdered`;
+- worker tasks launched by reduce or fill.
+
+They rely on the original `SearchResult` remaining alive and validate that a
+sealed result already owns a valid lease.
+
+Temporary `SearchResult` objects borrow protection from the original result;
+they do not copy or release lease ownership.
+
+Reacquisition would deadlock:
+
+```text
+old SearchResult holds a lease
+writer_pending waits for the old lease
+Fill tries to acquire a new lease and waits for the writer
+Fill cannot finish
+the old lease cannot be released
+```
+
+### 9.6 Retrieve and Direct Read APIs
+
+`AsyncRetrieve`, `AsyncRetrieveByOffsets`, and direct read APIs without a
+long-lived C++ result use a fail-fast call-scoped lease with per-call retry:
+
+```text
+LazyCheckSchema before the gate, when applicable
+attempt fail-fast lease acquisition
+if gate busy: return without entering and retry this segment call in QueryNode
+validate
+read and serialize
+release before returning across CGO
+```
+
+The serialized protobuf no longer refers to the sealed snapshot, so Query
+reduce and QueryStream send do not retain the lease. Separate Retrieve calls
+may observe different compatible snapshots; the Reopen row/offset invariants
+remain mandatory.
+
+`GetRowCount`, `GetRealCount`, `HasRawData`, `HasFieldData`, and similar APIs
+must be audited according to whether they consume published/runtime state.
+
+---
+
+## 10. SearchResult Ownership
+
+### 10.1 Proposed Field
+
+`QueryResult.h` can forward-declare the lease token and let `SearchResult` own
+either:
+
+```cpp
+std::shared_ptr<segcore::SegmentReadLease> read_lease_;
+```
+
+or a move-only lease directly, depending on the final audit of
+`SearchResult` move and copy behavior.
+
+Requirements:
+
+- a growing result may have an empty lease;
+- a sealed result must have a valid lease;
+- the lease is released exactly once;
+- temporary results cannot release the original result's lease.
+
+### 10.2 Release Point
+
+`DeleteSearchResult` remains the ownership boundary:
+
+```cpp
+void
+DeleteSearchResult(CSearchResult search_result) {
+    delete static_cast<SearchResult*>(search_result);
+}
+```
+
+Destroying `SearchResult` releases the lease.
+
+No separate “release lease” C API should be added because it would create
+double-release and missed-release risks across Go and C++.
+
+---
+
+## 11. Publish Path
+
+### 11.1 Reopen Flow
+
+```text
+lock reopen_mutex_
+capture current state
+compute load/schema diff
+prepare cloned runtime
+load/build/drop resources in staged state
+normalize final state
+compact manifest load info in staged state
+freeze next state and retired resource list
+release committer/internal/cache/reader locks
+set writer_pending
+wait for active_readers == 0
+atomic_store final state exactly once
+clear writer_pending and wake readers
+retire old resources / cancel warmup
+unlock reopen_mutex_
+```
+
+### 11.2 Locks Forbidden During Drain
+
+While waiting for active requests, a publisher must not hold:
+
+- `mutex_`;
+- `reader_mutex_`;
+- the StagedStateCommitter mutex;
+- cache accessor or cache slot internal locks;
+- any other lock required by reduce/fill of an active request.
+
+Otherwise:
+
+```text
+writer holds an internal mutex
+        ↓
+writer waits for active request lease
+        ↓
+active request waits for the internal mutex
+```
+
+and the drain cannot complete.
+
+### 11.3 Single Publication
+
+Current Reopen paths may call `CompactRuntimeLoadInfoForManifest()` after
+`committer.Publish(...)`, producing a second publication.
+
+This design requires:
+
+- compacting manifest load information in the staged state;
+- one atomic store after the drain;
+- readers observing either the complete old state or the complete new state.
+
+### 11.4 All Online Publishers
+
+The gate must cover every serving-time publication, not only Reopen:
+
+- field and index readiness;
+- runtime resource publication;
+- field and index drop;
+- text, JSON, and interim index publication;
+- `SetCommitTimestamp`;
+- serving-time `SetLoadInfo`;
+- `ClearData`;
+- other `PublishState` helpers.
+
+Initial load may use an explicit initialization publication only when a
+lifecycle assertion proves that the segment is not yet visible to readers.
+
+Recommended API split:
+
+```cpp
+PublishStateUnsafe(...);           // Constructor/initialization only.
+PublishState(PublishLease&, ...);  // Online serving publication.
+```
+
+Ordinary helpers should not acquire the writer gate implicitly. Hidden gate
+acquisition could begin a drain while the caller still owns an old mutex.
+
+### 11.5 Cancellation
+
+Writer wait must be cancellation-aware:
+
+- cancellation is checked before setting writer pending, while draining, and
+  once more after the final reader leaves;
+- cancellation observed by the final pre-publication check clears writer
+  pending, wakes readers, discards staged state, and keeps the old snapshot
+  active;
+- that final check is the cancellation linearization point; cancellation
+  arriving later may not prevent publication and does not roll it back;
+- a bounded drain timeout applies even when `OpContext` is null and follows the
+  same rollback path;
+- cancellation cleanup cannot hold locks required by active requests.
+
+---
+
+## 12. Relationship With Existing Mutexes
+
+The first implementation keeps the existing shared `mutex_` acquisition in
+`SegmentInternalInterface::Search/Retrieve`.
+
+Sealed search therefore uses:
+
+```text
+Acquire request lease
+        ↓
+SegmentInternalInterface::Search
+        ↓
+mutex_ shared lock
+```
+
+These are different mechanisms:
+
+- the request lease controls publication;
+- `mutex_` continues to protect live state that has not completed snapshot
+  migration.
+
+Growing receives a no-op lease and continues to use only its existing locks.
+
+Historical sealed mutexes may be removed incrementally after all
+reader-visible live state and accessors are audited. That cleanup is not a
+prerequisite for the first drain implementation.
+
+---
+
+## 13. Resource Lifetime
+
+### 13.1 Snapshot Runtime
+
+The request lease prevents Reopen publication, so the active
+`PublishedSegmentState` and runtime graph are not replaced during the request.
+
+Therefore, `SearchResult` does not need a separate whole-snapshot pin solely
+for Reopen lifetime.
+
+### 13.2 Cache Cell Exception
+
+The cache manager may evict resources independently from Segment Reopen.
+
+The current sealed index search uses a local cache accessor while a Knowhere
+iterator may survive beyond the search CGO call.
+
+The implementation must determine:
+
+- whether the Knowhere iterator independently owns the underlying index;
+- whether a cache cell can be evicted after the accessor is destroyed;
+- whether `OffsetMapping*` points into an independently evictable object.
+
+If the iterator is not self-owning:
+
+- the iterator wrapper must retain the cache accessor; or
+- `SearchResult` must retain the corresponding cache cell pin.
+
+This is a cache-lifetime pin, not a snapshot-selection pin.
+
+---
+
+## 14. Go Lifetime
+
+The current successful QueryNode search path effectively registers:
+
+```go
+defer Segment.Unpin(searchedSegments)
+...
+defer DeleteSearchResults(results)
+```
+
+Go defers execute in LIFO order, so successful requests release
+`SearchResult` and its lease before unpinning the segment.
+
+For a multi-segment sealed attempt, fail-fast admission may leave successful
+partial results from other goroutines. The error path must therefore release
+all non-null results only after all attempt goroutines have completed, then
+retry the complete segment batch:
+
+```go
+for {
+    results, err := searchSegmentsAttempt(...)
+    if err == nil {
+        return results, nil
+    }
+    DeleteSearchResults(nonNil(results))
+    if !isSealedReadGateBusy(err) {
+        return nil, err
+    }
+    waitJitteredBackoff(ctx)
+}
+```
+
+The gate-busy classifier must require both the Segcore
+`FollyOtherException` code and the stable `segment read gate busy` marker so
+unrelated 2037 errors are not retried. Growing searches and other errors return
+immediately.
+
+The final contract must guarantee lease release for:
+
+- partial-result errors;
+- filter-only early return;
+- cancellation;
+- serialization failure.
+
+---
+
+## 15. File-Level Change List
+
+### 15.1 New or Extracted Gate Types
+
+Suggested files:
+
+- `internal/core/src/segcore/SegmentReadLease.h`;
+- `internal/core/src/segcore/SegmentReadLease.cpp`.
+
+Responsibilities:
+
+- GateState;
+- SegmentReadLease;
+- PublishLease;
+- dynamic-cast-based acquire factory;
+- metrics hooks.
+
+### 15.2 ChunkedSegmentSealedImpl.h
+
+- add `shared_ptr<GateState> operation_gate_`;
+- add non-virtual fail-fast `AcquireReadLease`;
+- add writer acquisition;
+- require an explicit PublishLease token for online publication;
+- add test hooks.
+
+### 15.3 ChunkedSegmentSealedImpl.cpp
+
+- separate Reopen prepare and publish;
+- move manifest compaction before publication;
+- route all online publishers through the gate;
+- release internal locks before drain;
+- implement cancellation-aware writer wait;
+- add generation and wait metrics.
+
+### 15.4 segment_c.cpp
+
+- run `LazyCheckSchema` before gate acquisition;
+- perform pure snapshot compatibility validation after acquisition;
+- transfer the lease to every `AsyncSearch` result branch;
+- use fail-fast scoped leases for retrieve;
+- audit direct read C APIs;
+- release the lease through `DeleteSearchResult` destruction.
+- expose cancellable async index-drop entry points so the request context
+  reaches online publication drain.
+
+### 15.5 search_result_export_c.cpp
+
+- do not acquire a new lease;
+- validate that sealed results already own a lease;
+- keep original results alive through worker completion;
+- let temporary results borrow protection.
+
+### 15.6 QueryResult.h
+
+- add lease ownership;
+- audit move, copy, and destruction behavior;
+- add a cache cell pin only if required by the iterator audit.
+
+### 15.7 search.go and services.go
+
+- guarantee result deletion before segment unpin;
+- release all partial results before whole-batch gate retry;
+- use bounded jittered retry under the request context;
+- propagate `DropIndex` publication cancellation/timeout instead of returning
+  success.
+
+---
+
+## 16. Delivery Phases
+
+### Phase 1: Gate and Request Lifetime
+
+- implement GateState and SegmentReadLease;
+- add growing no-op behavior;
+- attach lease ownership to SearchResult;
+- forbid reacquisition in later phases;
+- add basic concurrency tests.
+
+### Phase 2: Publisher Convergence
+
+- make Reopen publish once;
+- move manifest compaction before publication;
+- audit all online `PublishState` call sites;
+- add cancellation and lock-order tests.
+
+### Phase 3: Schema and Cache Completeness
+
+- implement pre-gate LazyCheckSchema and post-gate validation;
+- add schema compatibility tests;
+- audit iterator/cache ownership;
+- harden Go partial-result cleanup;
+- add metrics and stress tests.
+
+### Phase 4: Historical Lock Cleanup
+
+- audit the remaining responsibilities of sealed `mutex_`;
+- remove only locks fully covered by immutable snapshots or request leases;
+- do not change the growing lock model.
+
+---
+
+## 17. Observability
+
+At minimum, expose:
+
+- `segcore_segment_active_read_leases`;
+- `segcore_segment_oldest_read_lease_seconds`;
+- `segcore_segment_publish_drain_wait_seconds`;
+- `segcore_segment_writer_pending_seconds`;
+- `segcore_segment_blocked_read_requests_total`;
+- `segcore_segment_published_generation`.
+
+Recommended structured log fields:
+
+- segment ID;
+- current and target schema versions;
+- published generation;
+- active lease count;
+- oldest lease age;
+- drain wait duration;
+- cancellation state.
+
+Normal read-lease acquire/release must not emit INFO logs per query.
+
+---
+
+## 18. Verification Plan
+
+### 18.1 Gate Behavior
+
+1. Reopen remains blocked after Search returns.
+2. Reopen completes after `DeleteSearchResult`.
+3. New sealed Search fails fast and cannot bypass a pending writer.
+4. A call-scoped Retrieve fails fast while a publisher is pending or active.
+5. QueryNode retries only the rejected Retrieve call and obeys request cancellation.
+6. Non-gate Folly errors are not retried.
+7. Reduce/fill under an existing lease completes after writer pending.
+8. Growing Search and Retrieve do not increment the active lease count.
+
+### 18.2 Lazy Schema
+
+1. LazyCheckSchema publishes before gate acquisition without self-deadlock.
+2. Without an intervening publisher, the request acquires the snapshot
+   produced by the lazy refresh.
+3. A newer compatible snapshot published between lazy check and acquisition
+   is accepted.
+4. An unexpectedly older snapshot causes release-before-retry.
+5. A newer incompatible snapshot returns an error without Reopen under lease.
+6. Lazy cancellation or failure does not create a lease.
+7. An active read lease makes lazy schema reopen return gate-busy without
+   setting writer pending.
+8. A lazy schema reopen does not wait behind an explicit reopen holding
+   `reopen_mutex_`.
+
+### 18.3 Publication
+
+1. Reopen increments generation exactly once.
+2. Published load information is already compacted.
+3. Prepare failure or cancellation does not publish.
+4. Drain cancellation clears writer pending.
+5. The writer does not hold `mutex_` or `reader_mutex_` while waiting.
+6. Every online publisher passes through the gate.
+
+### 18.4 SearchResult Lifetime
+
+1. Empty results hold and release a lease.
+2. Filter-only results release their lease.
+3. Group-by and iterator results release their lease.
+4. Partial-result errors release all leases before retrying the complete sealed
+   segment batch.
+5. A multi-segment request owns one lease per sealed segment result.
+6. Duplicate result release cannot decrement the gate twice.
+
+### 18.5 Cache Lifetime
+
+1. Iterators remain valid while publication is blocked.
+2. Iterator consumption is safe during cache eviction.
+3. Cache accessor pins release when the result is destroyed.
+
+### 18.6 Stress and Fault Injection
+
+1. Long search plus Reopen plus new searches.
+2. Concurrent lazy-schema requests.
+3. Search executor saturation.
+4. Reopen prepare cancellation.
+5. Reopen drain cancellation.
+6. Intentionally delayed SearchResult release.
+7. Segment release racing with result release.
+8. Two multi-segment requests visiting segments in opposite orders while both
+   segments publish.
+9. Null-context publisher drain timeout.
+
+---
+
+## 19. Risks and Trade-Offs
+
+### 19.1 Reopen Latency Amplification
+
+Reopen waits for the slowest outstanding `SearchResult`.
+
+This is accepted because:
+
+- Reopen is infrequent;
+- publication may temporarily reject and retry new sealed readers;
+- request-level consistency materially simplifies correctness.
+
+Mitigations:
+
+- oldest-lease-age metrics;
+- request timeout and cancellation;
+- result leak detection;
+- drain-wait alerts.
+
+### 19.2 Localized Search Retry After Writer Pending
+
+Once a writer is pending, new sealed searches fail admission. QueryNode cleans
+up the full attempt and retries the complete segment batch with jitter. This
+avoids retaining partial cross-segment leases, but can increase retry traffic
+while a long-lived old request is draining.
+
+The publisher has a bounded wait and returns cancellation/timeout instead of
+forcing publication by ignoring a live lease, which would reintroduce
+mixed-snapshot and resource-lifetime risks.
+
+### 19.3 Fail-fast Scoped Retrieve Retry
+
+Retrieve uses the same fail-fast admission signal as Search, but retries only
+the rejected segment call because no lease escapes the CGO call. Retry uses
+bounded jitter under the request context and never waits inside a Segcore
+executor task.
+
+A long drain can increase retry traffic and latency, but it cannot occupy every
+Search CPU executor thread with gate waits or prevent Search consume callbacks
+from progressing. Rejection counts and retry duration should be observable.
+
+### 19.4 Lazy Reopen on the Search Executor
+
+LazyCheckSchema may still perform I/O and loading on one Search CPU executor
+thread, but it never waits for active readers or queues behind
+`reopen_mutex_`. Competing requests fail fast so consume callbacks retain
+executor capacity and can release old SearchResult leases.
+
+Preparation can still increase latency, and a reader racing with the final
+publication check can cause the staged work to be discarded and retried.
+Long-term alternatives include:
+
+- explicit QueryNode schema refresh;
+- a dedicated reopen executor;
+- stale-plan retry;
+- removing mutation from the search path.
+
+### 19.5 Cache Pins May Still Be Required
+
+The request lease protects Segment publication but does not automatically
+protect independent cache eviction.
+
+If a Knowhere iterator is not self-owning, a resource-level cache pin remains
+necessary.
+
+---
+
+## 20. Decisions
+
+1. Search uses request-level consistency and cannot switch sealed snapshots
+   across CGO phases.
+2. Separate call-scoped Retrieve operations may observe different compatible
+   snapshots.
+3. Growing segment read leases are no-op.
+4. Sealed segments use cross-thread counting leases instead of storing a Folly
+   shared lock in SearchResult.
+5. SearchResult owns the lease until `DeleteSearchResult`.
+6. Search and call-scoped Retrieve acquisition both fail fast; Search retries
+   the complete sealed batch after cleanup, while Retrieve retries only the
+   rejected segment call.
+7. Reduce, export, and fill do not reacquire a lease.
+8. LazyCheckSchema runs before gate acquisition.
+9. Only pure compatibility validation is allowed after gate acquisition.
+10. Reopen performs one drain and one publication.
+11. Existing `mutex_` use remains in the first implementation.
+12. A whole-snapshot pin is unnecessary; cache cell pins are audited
+    separately.
+
+---
+
+## 21. Open Questions
+
+The following items must be resolved before the final design is approved:
+
+1. **Gate type location**
+   - standalone `SegmentReadLease.{h,cpp}`;
+   - or private sealed-implementation types.
+
+2. **SearchResult field type**
+   - move-only `SegmentReadLease`;
+   - or `shared_ptr<SegmentReadLease>`.
+
+3. **Schema incompatibility error**
+   - which Segcore error code to use;
+   - whether Go retries or rebuilds the plan;
+   - whether one transparent retry is allowed.
+
+4. **Maximum lease duration**
+   - metrics only;
+   - alerting;
+   - active request cancellation;
+   - forced publication must not bypass a live lease.
+
+5. **Writer-wait cancellation implementation**
+   - timed condition-variable wait plus cancellation checks;
+   - or a Folly cancellation callback.
+
+6. **Cache iterator ownership**
+   - whether Knowhere iterator already owns its index;
+   - whether CacheCellAccessor must be retained.
+
+7. **Initial versus online publication**
+   - whether to introduce a lifecycle assertion;
+   - which SetLoadInfo/Load paths can skip the gate before serving.
+
+8. **Direct read C API scope**
+   - which APIs read immutable or local counters only;
+   - which APIs require a scoped lease.
+
+---
+
+## 22. Final Principle
+
+The final serving principle is:
+
+> A sealed segment fixes one published snapshot when a request starts. Reopen
+> stops admitting new requests after preparation, waits for all old requests
+> to finish, and publishes one complete new snapshot.
+
+In addition:
+
+> LazyCheckSchema may prepare or reopen schema before gate acquisition. After
+> gate acquisition, only pure validation is allowed; every repair or retry
+> must release the lease first.

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -38,6 +38,10 @@
 
 namespace milvus {
 
+namespace segcore {
+class SegmentReadLease;
+}
+
 // scan cost in each search/query
 struct StorageCost {
     int64_t scanned_remote_bytes = 0;
@@ -310,10 +314,18 @@ struct SearchResult {
     }
 
  public:
-    int64_t total_nq_;
-    int64_t unity_topK_;
-    int64_t total_data_cnt_;
-    void* segment_;
+    int64_t total_nq_{0};
+    int64_t unity_topK_{0};
+    int64_t total_data_cnt_{0};
+    void* segment_{nullptr};
+
+    // Sealed search requests keep publication blocked until the result is
+    // deleted. Growing search results leave this empty.
+    std::shared_ptr<segcore::SegmentReadLease> read_lease_;
+
+    // Pins resources whose iterators or offset mappings may outlive the
+    // original search call independently from segment snapshot publication.
+    std::vector<std::shared_ptr<void>> resource_pins_;
 
     // first fill data during search, and then update data after reducing search results
     std::vector<float> distances_;

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -152,6 +152,9 @@ SearchOnSealedIndex(const Schema& schema,
         search_result,
         offset_mapping,
         use_iterator ? nullptr : search_info.array_offsets_.get());
+    if (use_iterator) {
+        search_result.resource_pins_.emplace_back(std::move(accessor));
+    }
     search_result.total_nq_ = num_queries;
     search_result.unity_topK_ = topK;
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -792,6 +792,7 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
                     owned_runtime != nullptr
                         ? ToConstRuntimeState(std::move(owned_runtime))
                         : FreezeRuntimeResourceState(*target_runtime);
+                lck.unlock();
                 PublishIndexReadyLocked(field_id, false, published_runtime);
                 cancel_retired_indexings();
             }
@@ -811,6 +812,7 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
             } else if (owned_runtime != nullptr) {
                 auto published_runtime =
                     ToConstRuntimeState(std::move(owned_runtime));
+                lck.unlock();
                 MutatePublishedStateLocked([&](PublishedSegmentState& state) {
                     state.runtime = published_runtime;
                     SyncJsonNgramIndexState(
@@ -885,6 +887,67 @@ ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
 SchemaPtr
 ChunkedSegmentSealedImpl::CaptureSchemaSnapshot() const {
     return CapturePublishedState()->schema;
+}
+
+void
+ChunkedSegmentSealedImpl::ValidateSchemaCompatibility(
+    const SchemaPtr& plan_schema) const {
+    if (plan_schema == nullptr) {
+        return;
+    }
+
+    auto published_schema = CaptureSchemaSnapshot();
+    AssertInfo(published_schema != nullptr,
+               "published schema is null for segment {}",
+               id_);
+    if (published_schema->get_schema_version() <
+        plan_schema->get_schema_version()) {
+        ThrowInfo(UnexpectedError,
+                  "published schema version {} is older than plan schema "
+                  "version {} for segment {}",
+                  published_schema->get_schema_version(),
+                  plan_schema->get_schema_version(),
+                  id_);
+    }
+
+    auto plan_primary = plan_schema->get_primary_field_id();
+    auto published_primary = published_schema->get_primary_field_id();
+    if (plan_primary.has_value() && published_primary.has_value() &&
+        plan_primary.value() != published_primary.value()) {
+        ThrowInfo(UnexpectedError,
+                  "primary field changed from {} to {} across schema "
+                  "versions for segment {}",
+                  plan_primary.value().get(),
+                  published_primary.value().get(),
+                  id_);
+    }
+
+    for (const auto& [field_id, plan_field] : plan_schema->get_fields()) {
+        if (!published_schema->has_field(field_id)) {
+            continue;
+        }
+        const auto& published_field = published_schema->operator[](field_id);
+        if (plan_field.get_data_type() != published_field.get_data_type() ||
+            plan_field.get_element_type() !=
+                published_field.get_element_type()) {
+            ThrowInfo(UnexpectedError,
+                      "field {} type changed across schema versions for "
+                      "segment {}",
+                      field_id.get(),
+                      id_);
+        }
+        if (plan_field.is_vector() &&
+            !IsSparseFloatVectorDataType(plan_field.get_data_type()) &&
+            plan_field.get_dim() != published_field.get_dim()) {
+            ThrowInfo(UnexpectedError,
+                      "field {} dimension changed from {} to {} across "
+                      "schema versions for segment {}",
+                      field_id.get(),
+                      plan_field.get_dim(),
+                      published_field.get_dim(),
+                      id_);
+        }
+    }
 }
 
 std::shared_ptr<const SegmentLoadInfo>
@@ -1501,7 +1564,7 @@ void
 ChunkedSegmentSealedImpl::PublishReopenState(
     const std::shared_ptr<const PublishedSegmentState>& current,
     const StateDelta& delta) {
-    PublishState(BuildNextPublishedState(current, delta));
+    PublishStateOnline(BuildNextPublishedState(current, delta));
 }
 
 void
@@ -1587,7 +1650,7 @@ ChunkedSegmentSealedImpl::SetUseTakeForOutputForTestingLocked(bool val) {
     auto current = CapturePublishedState();
     auto next = ClonePublishedState(current);
     next->use_take_for_output = val;
-    PublishState(std::move(next));
+    PublishStateOnline(std::move(next));
 }
 
 void
@@ -1768,13 +1831,16 @@ ChunkedSegmentSealedImpl::PublishFieldDroppedLocked(
 void
 ChunkedSegmentSealedImpl::PublishIndexDroppedLocked(
     FieldId field_id,
-    const std::shared_ptr<const RuntimeResourceState>& runtime) {
-    MutatePublishedStateLocked([&](PublishedSegmentState& state) {
-        if (runtime != nullptr) {
-            state.runtime = runtime;
-        }
-        DropIndexFromState(state, field_id);
-    });
+    const std::shared_ptr<const RuntimeResourceState>& runtime,
+    milvus::OpContext* op_ctx) {
+    MutatePublishedStateLocked(
+        [&](PublishedSegmentState& state) {
+            if (runtime != nullptr) {
+                state.runtime = runtime;
+            }
+            DropIndexFromState(state, field_id);
+        },
+        op_ctx);
 }
 
 void
@@ -1784,7 +1850,7 @@ ChunkedSegmentSealedImpl::PublishRuntimeStateLocked(
         return;
     }
     auto current = CapturePublishedState();
-    PublishState(BuildNextPublishedState(
+    PublishStateOnline(BuildNextPublishedState(
         current,
         MakeStateDelta(
             current->schema, current->load_info, runtime, current->commit_ts)));
@@ -1851,7 +1917,7 @@ ChunkedSegmentSealedImpl::RefreshPublishedLoadInfoLocked(
     const std::shared_ptr<const SegmentLoadInfo>& load_info,
     Timestamp commit_ts) {
     auto current = CapturePublishedState();
-    PublishState(BuildNextPublishedState(
+    PublishStateOnline(BuildNextPublishedState(
         current, MakeStateDelta(current->schema, load_info, commit_ts)));
 }
 
@@ -1859,7 +1925,7 @@ void
 ChunkedSegmentSealedImpl::RefreshPublishedSchemaLocked(
     const SchemaPtr& schema_snapshot) {
     auto current = CapturePublishedState();
-    PublishState(BuildNextPublishedState(
+    PublishStateOnline(BuildNextPublishedState(
         current,
         MakeStateDelta(
             schema_snapshot, current->load_info, current->commit_ts)));
@@ -1871,7 +1937,7 @@ ChunkedSegmentSealedImpl::RefreshPublishedStateLocked(
     const std::shared_ptr<const SegmentLoadInfo>& load_info,
     Timestamp commit_ts) {
     auto current = CapturePublishedState();
-    PublishState(BuildNextPublishedState(
+    PublishStateOnline(BuildNextPublishedState(
         current, MakeStateDelta(schema_snapshot, load_info, commit_ts)));
 }
 
@@ -1888,18 +1954,48 @@ ChunkedSegmentSealedImpl::PrepareMutableStateForPublish(
 
 void
 ChunkedSegmentSealedImpl::PublishState(
+    PublishLease& publish_lease,
     const std::shared_ptr<const PublishedSegmentState>& state) {
     if (!state) {
         return;
     }
+    AssertInfo(publish_lease.valid(), "online publication requires a lease");
     std::atomic_store(&published_state_, state);
+    publish_lease.MarkPublished();
 }
 
 void
 ChunkedSegmentSealedImpl::PublishState(
-    std::shared_ptr<PublishedSegmentState> state) {
+    PublishLease& publish_lease, std::shared_ptr<PublishedSegmentState> state) {
     PublishState(
+        publish_lease,
         std::const_pointer_cast<const PublishedSegmentState>(std::move(state)));
+}
+
+void
+ChunkedSegmentSealedImpl::PublishStateOnline(
+    const std::shared_ptr<const PublishedSegmentState>& state,
+    milvus::OpContext* op_ctx,
+    PublishMode publish_mode) {
+    if (!state) {
+        return;
+    }
+    auto publish_lease =
+        publish_mode == PublishMode::FailFast
+            ? operation_gate_.AcquirePublishFailFast(op_ctx, id_)
+            : operation_gate_.AcquirePublish(op_ctx, id_);
+    PublishState(publish_lease, state);
+}
+
+void
+ChunkedSegmentSealedImpl::PublishStateOnline(
+    std::shared_ptr<PublishedSegmentState> state,
+    milvus::OpContext* op_ctx,
+    PublishMode publish_mode) {
+    PublishStateOnline(
+        std::const_pointer_cast<const PublishedSegmentState>(std::move(state)),
+        op_ctx,
+        publish_mode);
 }
 
 void
@@ -3458,7 +3554,7 @@ ChunkedSegmentSealedImpl::set_field_avg_size(FieldId field_id,
     field_info.second = size / field_info.first;
     auto next = ClonePublishedState(current);
     next->runtime = ToConstRuntimeState(std::move(runtime));
-    PublishState(std::move(next));
+    PublishStateOnline(std::move(next));
 }
 
 std::shared_ptr<const SkipIndex>
@@ -3937,16 +4033,18 @@ ChunkedSegmentSealedImpl::DropFieldData(
 }
 
 void
-ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id) {
+ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id,
+                                    milvus::OpContext* op_ctx) {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
     auto snapshot = CapturePublishedState();
-    DropIndex(field_id, snapshot->schema);
+    DropIndex(field_id, snapshot->schema, nullptr, op_ctx);
 }
 
 void
 ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id,
                                     const SchemaPtr& schema_snapshot,
-                                    RuntimeResourceState* runtime) {
+                                    RuntimeResourceState* runtime,
+                                    milvus::OpContext* op_ctx) {
     AssertInfo(!SystemProperty::Instance().IsSystem(field_id),
                "Field id:" + std::to_string(field_id.get()) +
                    " isn't one of system type when drop index");
@@ -3964,23 +4062,26 @@ ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id,
         next_runtime->ngram_fields.erase(field_id);
         DropVectorIndexing(*next_runtime, field_id);
         next_runtime->vec_binlog_config.erase(field_id);
-        PublishIndexDroppedLocked(field_id,
-                                  ToConstRuntimeState(std::move(next_runtime)));
+        PublishIndexDroppedLocked(
+            field_id, ToConstRuntimeState(std::move(next_runtime)), op_ctx);
     }
 }
 
 void
 ChunkedSegmentSealedImpl::DropJSONIndex(const FieldId field_id,
-                                        const std::string& nested_path) {
+                                        const std::string& nested_path,
+                                        milvus::OpContext* op_ctx) {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
     auto next_runtime = CloneMutableRuntimeResourceState();
     auto retired_indexings =
         EraseJsonIndexesAtPath(*next_runtime, field_id, nested_path);
     auto published_runtime = ToConstRuntimeState(std::move(next_runtime));
-    MutatePublishedStateLocked([&](PublishedSegmentState& state) {
-        state.runtime = published_runtime;
-        SyncJsonNgramIndexState(state, *published_runtime, field_id);
-    });
+    MutatePublishedStateLocked(
+        [&](PublishedSegmentState& state) {
+            state.runtime = published_runtime;
+            SyncJsonNgramIndexState(state, *published_runtime, field_id);
+        },
+        op_ctx);
     for (auto& indexing : retired_indexings) {
         if (indexing != nullptr) {
             indexing->CancelWarmup();
@@ -5355,7 +5456,7 @@ ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
                 CloneLoadInfoWithTextIndexCreated(next->load_info, field_id);
         }
         NormalizePublishedState(*next);
-        PublishState(std::move(next));
+        PublishStateOnline(std::move(next));
     }
 }
 
@@ -6769,16 +6870,48 @@ ChunkedSegmentSealedImpl::LazyCheckSchema(SchemaPtr sch,
     auto current_schema = CaptureSchemaSnapshot();
     auto current_schema_version = current_schema->get_schema_version();
 
-    if (sch->get_schema_version() > current_schema_version) {
-        LOG_INFO(
-            "lazy check schema segment {} found newer schema version, "
-            "current "
-            "schema version {}, new schema version {}",
-            id_,
-            current_schema_version,
-            sch->get_schema_version());
-        Reopen(op_ctx, std::move(sch));
+    if (sch->get_schema_version() <= current_schema_version) {
+        return;
     }
+
+    if (op_ctx != nullptr &&
+        op_ctx->cancellation_token.isCancellationRequested()) {
+        ThrowInfo(ErrorCode::FollyCancel,
+                  "lazy schema reopen cancelled for segment {}",
+                  id_);
+    }
+
+    std::unique_lock<std::mutex> reopen_guard(reopen_mutex_, std::try_to_lock);
+    if (!reopen_guard.owns_lock()) {
+        ThrowInfo(ErrorCode::FollyOtherException,
+                  "segment read gate busy for segment {} while another "
+                  "schema reopen is in progress",
+                  id_);
+    }
+
+    current_schema = CaptureSchemaSnapshot();
+    current_schema_version = current_schema->get_schema_version();
+    if (sch->get_schema_version() <= current_schema_version) {
+        return;
+    }
+
+    // Avoid preparing a new snapshot while an old SearchResult is known to
+    // hold a lease. This is only a preflight optimization; the final
+    // fail-fast publish check is the linearization point.
+    if (!operation_gate_.CanAcquirePublishImmediately()) {
+        ThrowInfo(ErrorCode::FollyOtherException,
+                  "segment read gate busy for segment {} during lazy schema "
+                  "reopen",
+                  id_);
+    }
+
+    LOG_INFO(
+        "lazy check schema segment {} found newer schema version, current "
+        "schema version {}, new schema version {}",
+        id_,
+        current_schema_version,
+        sch->get_schema_version());
+    ReopenSchemaLocked(op_ctx, std::move(sch), PublishMode::FailFast);
 }
 
 void
@@ -6970,6 +7103,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     apply_loaded_column(*next_runtime, old_column, *current);
 
     auto published_runtime = ToConstRuntimeState(std::move(next_runtime));
+    lck.unlock();
     if (SystemProperty::Instance().IsSystem(field_id)) {
         PublishRuntimeStateLocked(published_runtime);
     } else {
@@ -7006,23 +7140,6 @@ void
 ChunkedSegmentSealedImpl::ApplySchemaForReopen(SchemaPtr sch) {
     PrepareSchemaForReopen(sch);
     PublishReopenState(sch, nullptr);
-}
-
-void
-ChunkedSegmentSealedImpl::CompactRuntimeLoadInfoForManifest() {
-    auto current = CapturePublishedState();
-    if (current == nullptr || current->load_info == nullptr ||
-        !current->load_info->HasManifestPath()) {
-        return;
-    }
-
-    auto compacted = std::make_shared<SegmentLoadInfo>(*current->load_info);
-    compacted->CompactRuntimeInfoForManifest();
-    auto published = std::const_pointer_cast<const SegmentLoadInfo>(compacted);
-    PublishReopenState(
-        current,
-        MakeStateDelta(
-            current->schema, published, current->runtime, current->commit_ts));
 }
 
 void
@@ -7312,6 +7429,17 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
     }
 
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+    ReopenSchemaLocked(op_ctx, std::move(sch), PublishMode::Drain);
+}
+
+void
+ChunkedSegmentSealedImpl::ReopenSchemaLocked(milvus::OpContext* op_ctx,
+                                             SchemaPtr sch,
+                                             PublishMode publish_mode) {
+    if (!sch) {
+        return;
+    }
+
     auto current = CapturePublishedState();
     auto current_schema = current->schema;
     if (sch->get_schema_version() <= current_schema->get_schema_version()) {
@@ -7344,6 +7472,7 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
     StagedStateCommitter committer(*this, next_runtime.get(), staged.get());
     PrepareLoadDiffForReopen(op_ctx, new_local, diff, sch, committer);
     FinalizeLoadDiffForReopen(op_ctx, new_local, diff, sch, committer);
+    new_local.CompactRuntimeInfoForManifest();
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
     auto delta = MakeStateDelta(sch,
                                 published,
@@ -7354,8 +7483,7 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
     delta.published_binlog_index_ready_bitset =
         staged->published_binlog_index_ready_bitset.clone();
     delta.published_index_has_raw_data = staged->published_index_has_raw_data;
-    committer.Publish(current, delta);
-    CompactRuntimeLoadInfoForManifest();
+    committer.Publish(current, delta, op_ctx, publish_mode);
 
     LOG_INFO("Schema-only reopen segment {} done", id_);
 }
@@ -7420,6 +7548,7 @@ ChunkedSegmentSealedImpl::Reopen(
     PrepareLoadDiffForReopen(op_ctx, new_local, diff, target_schema, committer);
     FinalizeLoadDiffForReopen(
         op_ctx, new_local, diff, target_schema, committer);
+    new_local.CompactRuntimeInfoForManifest();
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
     auto delta = MakeStateDelta(target_schema,
                                 published,
@@ -7430,8 +7559,7 @@ ChunkedSegmentSealedImpl::Reopen(
     delta.published_binlog_index_ready_bitset =
         staged->published_binlog_index_ready_bitset.clone();
     delta.published_index_has_raw_data = staged->published_index_has_raw_data;
-    committer.Publish(current, delta);
-    CompactRuntimeLoadInfoForManifest();
+    committer.Publish(current, delta, op_ctx);
 
     LOG_INFO("Reopen segment {} done", id_);
 }
@@ -7455,6 +7583,7 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
         op_ctx, segment_load_info, diff, schema_snapshot, committer);
     FinalizeLoadDiffForReopen(
         op_ctx, segment_load_info, diff, schema_snapshot, committer);
+    segment_load_info.CompactRuntimeInfoForManifest();
     auto published = std::make_shared<const SegmentLoadInfo>(segment_load_info);
     auto delta = MakeStateDelta(schema_snapshot,
                                 published,
@@ -7465,7 +7594,7 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
     delta.published_binlog_index_ready_bitset =
         staged->published_binlog_index_ready_bitset.clone();
     delta.published_index_has_raw_data = staged->published_index_has_raw_data;
-    committer.Publish(current, delta);
+    committer.Publish(current, delta, op_ctx);
 }
 
 void
@@ -7601,15 +7730,19 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
 
     if (owned_runtime != nullptr) {
         auto published_runtime = ToConstRuntimeState(std::move(owned_runtime));
-        for (const auto& field_id : filled_fields) {
-            PublishFieldDataReadyLocked(field_id, published_runtime);
-        }
+        MutatePublishedStateLocked([&](PublishedSegmentState& state) {
+            state.runtime = published_runtime;
+            for (const auto& field_id : filled_fields) {
+                set_bit(state.field_data_ready_bitset, field_id, true);
+            }
+        });
     }
 }
 
 void
 ChunkedSegmentSealedImpl::FillDefaultValueFields(
     const std::vector<FieldId>& field_ids) {
+    std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
     auto snapshot = CapturePublishedState();
     FillDefaultValueFields(
         field_ids, *snapshot->load_info, snapshot->schema, nullptr);
@@ -7808,7 +7941,7 @@ ChunkedSegmentSealedImpl::SetLoadInfo(
     // pre-cancelled OpContext before any storage/manifest IO happens.
     auto published = std::make_shared<const SegmentLoadInfo>(
         std::move(load_info), schema_snapshot);
-    PublishState(BuildNextPublishedState(
+    PublishStateOnline(BuildNextPublishedState(
         current,
         MakeStateDelta(
             schema_snapshot, published, static_cast<Timestamp>(commit_ts))));
@@ -8655,7 +8788,6 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     LOG_WARN("Load segment {} with diff {}", id_, diff.ToString());
 
     ApplyLoadDiff(op_ctx, mutable_copy, diff);
-    CompactRuntimeLoadInfoForManifest();
 
     LOG_INFO("Successfully loaded segment {} with {} rows", id_, num_rows);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -77,6 +77,7 @@
 #include "segcore/IndexConfigGenerator.h"
 #include "segcore/InsertRecord.h"
 #include "segcore/SegcoreConfig.h"
+#include "segcore/SegmentReadLease.h"
 #include "segcore/SegmentInterface.h"
 #include "segcore/SegmentLoadInfo.h"
 #include "segcore/Types.h"
@@ -122,10 +123,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     LoadSegmentMeta(
         const milvus::proto::segcore::LoadSegmentMeta& segment_meta) override;
     void
-    DropIndex(const FieldId field_id) override;
+    DropIndex(const FieldId field_id,
+              milvus::OpContext* op_ctx = nullptr) override;
     void
     DropJSONIndex(const FieldId field_id,
-                  const std::string& nested_path) override;
+                  const std::string& nested_path,
+                  milvus::OpContext* op_ctx = nullptr) override;
     void
     DropFieldData(const FieldId field_id) override;
     bool
@@ -192,6 +195,14 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     get_segment_id() const override {
         return id_;
     }
+
+    std::shared_ptr<SegmentReadLease>
+    AcquireReadLease(const folly::CancellationToken& cancel_token) const {
+        return operation_gate_.AcquireRead(cancel_token, id_);
+    }
+
+    void
+    ValidateSchemaCompatibility(const SchemaPtr& plan_schema) const;
 
     bool
     HasRawData(int64_t field_id) const override;
@@ -1473,6 +1484,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     NormalizePublishedState(PublishedSegmentState& state) const;
 
+    enum class PublishMode {
+        Drain,
+        FailFast,
+    };
+
     class StagedStateCommitter {
      public:
         StagedStateCommitter(ChunkedSegmentSealedImpl& segment,
@@ -1540,16 +1556,19 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
         void
         Publish(const std::shared_ptr<const PublishedSegmentState>& current,
-                const StateDelta& delta) {
+                const StateDelta& delta,
+                milvus::OpContext* op_ctx = nullptr,
+                PublishMode publish_mode = PublishMode::Drain) {
             std::vector<SealedIndexingEntryPtr> retired_indexings;
             std::vector<index::CacheIndexBasePtr> retired_cache_indexings;
+            std::shared_ptr<PublishedSegmentState> next;
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-                segment_.PublishState(
-                    segment_.BuildNextPublishedState(current, delta));
+                next = segment_.BuildNextPublishedState(current, delta);
                 retired_indexings.swap(retired_vector_indexings_);
                 retired_cache_indexings.swap(retired_cache_indexings_);
             }
+            segment_.PublishStateOnline(std::move(next), op_ctx, publish_mode);
             for (auto& entry : retired_indexings) {
                 if (entry != nullptr && entry->indexing_ != nullptr) {
                     entry->indexing_->CancelWarmup();
@@ -1587,10 +1606,23 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     };
 
     void
-    PublishState(const std::shared_ptr<const PublishedSegmentState>& state);
+    PublishState(PublishLease& publish_lease,
+                 const std::shared_ptr<const PublishedSegmentState>& state);
 
     void
-    PublishState(std::shared_ptr<PublishedSegmentState> state);
+    PublishState(PublishLease& publish_lease,
+                 std::shared_ptr<PublishedSegmentState> state);
+
+    void
+    PublishStateOnline(
+        const std::shared_ptr<const PublishedSegmentState>& state,
+        milvus::OpContext* op_ctx = nullptr,
+        PublishMode publish_mode = PublishMode::Drain);
+
+    void
+    PublishStateOnline(std::shared_ptr<PublishedSegmentState> state,
+                       milvus::OpContext* op_ctx = nullptr,
+                       PublishMode publish_mode = PublishMode::Drain);
 
     std::shared_ptr<index::JsonKeyStats>
     BuildJsonKeyStatsIndex(
@@ -1610,12 +1642,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     template <typename Mutator>
     void
-    MutatePublishedStateLocked(Mutator&& mutator) {
+    MutatePublishedStateLocked(Mutator&& mutator,
+                               milvus::OpContext* op_ctx = nullptr) {
         auto current = CapturePublishedState();
         auto next = ClonePublishedState(current);
         mutator(*next);
         NormalizePublishedState(*next);
-        PublishState(std::move(next));
+        PublishStateOnline(std::move(next), op_ctx);
     }
 
     static bool
@@ -1783,7 +1816,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     PublishIndexDroppedLocked(
         FieldId field_id,
-        const std::shared_ptr<const RuntimeResourceState>& runtime = nullptr);
+        const std::shared_ptr<const RuntimeResourceState>& runtime = nullptr,
+        milvus::OpContext* op_ctx = nullptr);
 
     void
     PublishRuntimeStateLocked(
@@ -1840,7 +1874,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     DropIndex(const FieldId field_id,
               const SchemaPtr& schema_snapshot,
-              RuntimeResourceState* runtime = nullptr);
+              RuntimeResourceState* runtime = nullptr,
+              milvus::OpContext* op_ctx = nullptr);
 
     void
     DropFieldData(
@@ -2094,6 +2129,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     Reopen(milvus::OpContext* op_ctx, SchemaPtr sch);
 
     void
+    ReopenSchemaLocked(milvus::OpContext* op_ctx,
+                       SchemaPtr sch,
+                       PublishMode publish_mode);
+
+    void
     ApplySchemaForReopen(SchemaPtr sch);
 
     void
@@ -2111,9 +2151,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         milvus::OpContext* op_ctx = nullptr,
         bool is_replace = false,
         StagedStateCommitter* committer = nullptr);
-
-    void
-    CompactRuntimeLoadInfoForManifest();
 
     void
     load_field_data_common(
@@ -2199,6 +2236,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // and reader paths that take mutex_ must not take reopen_mutex_.
     std::mutex reopen_mutex_;
 
+    // Cross-thread request leases block online publication while a sealed
+    // SearchResult remains alive. Growing segments do not use this gate.
+    mutable SegmentReadGate operation_gate_;
+
     storage::MmapChunkDescriptorPtr mmap_descriptor_ = nullptr;
     int64_t id_;
     // commit_ts_ remains the writer-side source of truth for load-time data
@@ -2228,6 +2269,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // Test-only: inject a mock Reader for unit testing take() paths.
     void
     SetReaderForTesting(std::unique_ptr<milvus_storage::api::Reader> r) {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
         auto runtime = CloneMutableRuntimeResourceState();
         runtime->reader =
             std::shared_ptr<milvus_storage::api::Reader>(std::move(r));
@@ -2258,6 +2300,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     SchemaPtr
     TestGetSchemaSnapshot() const {
         return CapturePublishedState()->schema;
+    }
+
+    bool
+    TestReadGateWriterPending() const {
+        return operation_gate_.WriterPending();
     }
 
     std::shared_ptr<const PublishedSegmentState>
@@ -2335,6 +2382,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     TestPublishSystemFieldState() {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
         PublishSystemFieldStateLocked();
     }
 
@@ -2389,6 +2437,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<const PublishedSegmentState>& current,
         StateDelta& final_delta,
         Verifier&& verifier) {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
         StagedStateCommitter committer(*this, runtime.get(), staged_state);
         committer.Commit([&](RuntimeResourceState& staged_runtime,
                              PublishedSegmentState& staged) {
@@ -2423,6 +2472,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const std::shared_ptr<const PublishedSegmentState>& current,
         StateDelta& final_delta,
         Verifier&& verifier) {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
         StagedStateCommitter committer(*this, runtime.get(), staged_state);
         load_field_data_common(field_id,
                                column,
@@ -2456,6 +2506,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         int64_t num_rows,
         milvus::OpContext* op_ctx,
         Verifier&& verifier) {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
         StagedStateCommitter committer(*this, runtime.get(), staged_state);
         committer.Commit([&](RuntimeResourceState& staged_runtime,
                              PublishedSegmentState& staged) {
@@ -2503,6 +2554,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                 bool ready,
                                 bool binlog_ready,
                                 std::optional<bool> has_raw_data) {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
         PublishVectorIndexFactsLocked(
             field_id, ready, binlog_ready, has_raw_data);
     }
@@ -2540,7 +2592,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         auto runtime = CloneRuntimeResourceState(current->runtime);
         runtime->text_lob_paths[field_id] = std::move(lob_base_path);
         next->runtime = ToConstRuntimeState(std::move(runtime));
-        PublishState(std::move(next));
+        PublishStateOnline(std::move(next));
     }
 
     void
@@ -2553,7 +2605,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         runtime->json_stats[field_id] = std::move(stats);
         next->runtime = ToConstRuntimeState(std::move(runtime));
         NormalizePublishedState(*next);
-        PublishState(std::move(next));
+        PublishStateOnline(std::move(next));
     }
 
     std::shared_ptr<const SegmentLoadInfo>
@@ -2602,6 +2654,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     TestClearPublishedState() {
+        std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
         ClearPublishedStateLocked();
     }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -612,6 +612,9 @@ TEST_P(TestChunkSegmentStorageV2, ReduceStringPkWithSimulatedAnnResult) {
     plan.plan_node_->search_info_.metric_type_ = knowhere::metric::L2;
     plan.target_entries_.push_back(fields.at("string1"));
 
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
     auto offset_at = [this, candidate_topk](int64_t qi, int64_t rank) {
         auto lookup_index = qi * candidate_topk + rank;
         return (lookup_index * 499979 + qi * 9973) % RowCount();
@@ -623,6 +626,8 @@ TEST_P(TestChunkSegmentStorageV2, ReduceStringPkWithSimulatedAnnResult) {
         result.unity_topK_ = candidate_topk;
         result.total_data_cnt_ = RowCount();
         result.segment_ = segment.get();
+        result.read_lease_ =
+            sealed->AcquireReadLease(folly::CancellationToken());
         result.seg_offsets_.resize(nq * candidate_topk);
         result.distances_.resize(nq * candidate_topk);
         for (int64_t qi = 0; qi < nq; ++qi) {

--- a/internal/core/src/segcore/SegmentReadLease.h
+++ b/internal/core/src/segcore/SegmentReadLease.h
@@ -1,0 +1,321 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+#include <folly/CancellationToken.h>
+#include <folly/ScopeGuard.h>
+
+#include "common/EasyAssert.h"
+#include "common/OpContext.h"
+
+namespace milvus::segcore {
+
+struct SegmentReadGateState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    uint64_t active_readers = 0;
+    uint64_t blocked_readers_total = 0;
+    uint64_t published_generation = 0;
+    bool writer_pending = false;
+    bool writer_active = false;
+};
+
+class SegmentReadGate;
+
+class SegmentReadLease {
+ public:
+    SegmentReadLease(const SegmentReadLease&) = delete;
+    SegmentReadLease&
+    operator=(const SegmentReadLease&) = delete;
+
+    SegmentReadLease(SegmentReadLease&& other) noexcept
+        : state_(std::move(other.state_)) {
+    }
+
+    SegmentReadLease&
+    operator=(SegmentReadLease&& other) noexcept {
+        if (this != &other) {
+            Release();
+            state_ = std::move(other.state_);
+        }
+        return *this;
+    }
+
+    ~SegmentReadLease() {
+        Release();
+    }
+
+    bool
+    valid() const {
+        return state_ != nullptr;
+    }
+
+ private:
+    friend class SegmentReadGate;
+
+    SegmentReadLease() = default;
+
+    void
+    Release() noexcept {
+        auto state = std::move(state_);
+        if (state == nullptr) {
+            return;
+        }
+
+        bool notify_writer = false;
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            if (state->active_readers > 0) {
+                --state->active_readers;
+                notify_writer = state->active_readers == 0;
+            }
+        }
+        if (notify_writer) {
+            state->cv.notify_all();
+        }
+    }
+
+    std::shared_ptr<SegmentReadGateState> state_;
+};
+
+class PublishLease {
+ public:
+    PublishLease(const PublishLease&) = delete;
+    PublishLease&
+    operator=(const PublishLease&) = delete;
+
+    PublishLease(PublishLease&& other) noexcept
+        : state_(std::move(other.state_)) {
+    }
+
+    PublishLease&
+    operator=(PublishLease&& other) noexcept {
+        if (this != &other) {
+            Release();
+            state_ = std::move(other.state_);
+        }
+        return *this;
+    }
+
+    ~PublishLease() {
+        Release();
+    }
+
+    bool
+    valid() const {
+        return state_ != nullptr;
+    }
+
+    void
+    MarkPublished() {
+        AssertInfo(state_ != nullptr, "publish lease is not active");
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        ++state_->published_generation;
+    }
+
+ private:
+    friend class SegmentReadGate;
+
+    explicit PublishLease(std::shared_ptr<SegmentReadGateState> state)
+        : state_(std::move(state)) {
+    }
+
+    void
+    Release() noexcept {
+        auto state = std::move(state_);
+        if (state == nullptr) {
+            return;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            state->writer_active = false;
+            state->writer_pending = false;
+        }
+        state->cv.notify_all();
+    }
+
+    std::shared_ptr<SegmentReadGateState> state_;
+};
+
+class SegmentReadGate {
+ public:
+    static constexpr auto kDefaultPublishDrainTimeout =
+        std::chrono::seconds(30);
+
+    explicit SegmentReadGate(std::chrono::milliseconds publish_drain_timeout =
+                                 kDefaultPublishDrainTimeout)
+        : state_(std::make_shared<SegmentReadGateState>()),
+          publish_drain_timeout_(publish_drain_timeout) {
+        AssertInfo(publish_drain_timeout_ > std::chrono::milliseconds::zero(),
+                   "segment publish drain timeout must be positive");
+    }
+
+    std::shared_ptr<SegmentReadLease>
+    AcquireRead(const folly::CancellationToken& cancel_token,
+                int64_t segment_id) const {
+        auto lease = std::shared_ptr<SegmentReadLease>(new SegmentReadLease());
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        if (cancel_token.isCancellationRequested()) {
+            ThrowInfo(ErrorCode::FollyCancel,
+                      "read lease acquisition cancelled for segment {}",
+                      segment_id);
+        }
+        if (state_->writer_pending || state_->writer_active) {
+            ++state_->blocked_readers_total;
+            ThrowInfo(ErrorCode::FollyOtherException,
+                      "segment read gate busy for segment {}",
+                      segment_id);
+        }
+        ++state_->active_readers;
+        lease->state_ = state_;
+        return lease;
+    }
+
+    PublishLease
+    AcquirePublish(milvus::OpContext* op_ctx, int64_t segment_id) const {
+        std::unique_lock<std::mutex> lock(state_->mutex);
+        AssertInfo(!state_->writer_pending && !state_->writer_active,
+                   "concurrent publisher entered segment {} read gate",
+                   segment_id);
+
+        auto cancellation_requested = [&] {
+            return op_ctx != nullptr &&
+                   op_ctx->cancellation_token.isCancellationRequested();
+        };
+        if (cancellation_requested()) {
+            ThrowInfo(ErrorCode::FollyCancel,
+                      "publication drain cancelled for segment {}",
+                      segment_id);
+        }
+
+        state_->writer_pending = true;
+        auto rollback_pending = folly::makeGuard([&] {
+            state_->writer_pending = false;
+            if (lock.owns_lock()) {
+                lock.unlock();
+            }
+            state_->cv.notify_all();
+        });
+
+        const auto deadline =
+            std::chrono::steady_clock::now() + publish_drain_timeout_;
+
+        while (state_->active_readers != 0) {
+            if (cancellation_requested()) {
+                ThrowInfo(ErrorCode::FollyCancel,
+                          "publication drain cancelled for segment {}",
+                          segment_id);
+            }
+            const auto wakeup = std::min(deadline,
+                                         std::chrono::steady_clock::now() +
+                                             std::chrono::milliseconds(10));
+            state_->cv.wait_until(lock, wakeup);
+            if (std::chrono::steady_clock::now() >= deadline &&
+                state_->active_readers != 0) {
+                ThrowInfo(ErrorCode::FollyOtherException,
+                          "publication drain timed out for segment {} after "
+                          "{} ms",
+                          segment_id,
+                          publish_drain_timeout_.count());
+            }
+        }
+
+        // This is the cancellation linearization point. Once writer_active is
+        // set below, a later cancellation may not prevent publication.
+        if (cancellation_requested()) {
+            ThrowInfo(ErrorCode::FollyCancel,
+                      "publication drain cancelled for segment {}",
+                      segment_id);
+        }
+
+        state_->writer_active = true;
+        rollback_pending.dismiss();
+        return PublishLease(state_);
+    }
+
+    bool
+    CanAcquirePublishImmediately() const {
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        return state_->active_readers == 0 && !state_->writer_pending &&
+               !state_->writer_active;
+    }
+
+    PublishLease
+    AcquirePublishFailFast(milvus::OpContext* op_ctx,
+                           int64_t segment_id) const {
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        if (op_ctx != nullptr &&
+            op_ctx->cancellation_token.isCancellationRequested()) {
+            ThrowInfo(ErrorCode::FollyCancel,
+                      "publication cancelled for segment {}",
+                      segment_id);
+        }
+        if (state_->active_readers != 0 || state_->writer_pending ||
+            state_->writer_active) {
+            ThrowInfo(ErrorCode::FollyOtherException,
+                      "segment read gate busy for segment {} during lazy "
+                      "schema reopen",
+                      segment_id);
+        }
+
+        // No drain is needed because the reader count was checked while
+        // holding the gate mutex. Mark the writer active before releasing the
+        // mutex so a new reader cannot race with publication.
+        state_->writer_pending = true;
+        state_->writer_active = true;
+        return PublishLease(state_);
+    }
+
+    uint64_t
+    ActiveReaders() const {
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        return state_->active_readers;
+    }
+
+    uint64_t
+    BlockedReadersTotal() const {
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        return state_->blocked_readers_total;
+    }
+
+    uint64_t
+    PublishedGeneration() const {
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        return state_->published_generation;
+    }
+
+    bool
+    WriterPending() const {
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        return state_->writer_pending;
+    }
+
+ private:
+    std::shared_ptr<SegmentReadGateState> state_;
+    std::chrono::milliseconds publish_drain_timeout_;
+};
+
+}  // namespace milvus::segcore

--- a/internal/core/src/segcore/SegmentSealed.h
+++ b/internal/core/src/segcore/SegmentSealed.h
@@ -37,9 +37,11 @@ class SegmentSealed : public SegmentInternalInterface {
     virtual void
     LoadSegmentMeta(const milvus::proto::segcore::LoadSegmentMeta& meta) = 0;
     virtual void
-    DropIndex(const FieldId field_id) = 0;
+    DropIndex(const FieldId field_id, milvus::OpContext* op_ctx = nullptr) = 0;
     virtual void
-    DropJSONIndex(const FieldId field_id, const std::string& nested_path) = 0;
+    DropJSONIndex(const FieldId field_id,
+                  const std::string& nested_path,
+                  milvus::OpContext* op_ctx = nullptr) = 0;
     virtual void
     DropFieldData(const FieldId field_id) = 0;
 

--- a/internal/core/src/segcore/search_result_export_c.cpp
+++ b/internal/core/src/segcore/search_result_export_c.cpp
@@ -39,6 +39,7 @@
 #include "prometheus/histogram.h"
 #include "query/PlanImpl.h"
 #include "segcore/SegmentInterface.h"
+#include "segcore/SegmentReadLease.h"
 #include "segcore/Utils.h"
 #include "segcore/reduce/Reduce.h"
 #include "storage/ThreadPools.h"
@@ -87,6 +88,23 @@ AssertEmptyCProto(const CProto* proto) {
     AssertInfo(proto != nullptr, "null CProto output");
     AssertInfo(proto->proto_blob == nullptr && proto->proto_size == 0,
                "CProto output must be empty before FillOutputFieldsOrdered");
+}
+
+void
+AssertSearchResultReadLease(const SearchResult* result) {
+    AssertInfo(result != nullptr, "null search result");
+    if (result->segment_ == nullptr) {
+        return;
+    }
+
+    auto segment =
+        static_cast<const milvus::segcore::SegmentInterface*>(result->segment_);
+    if (segment->type() == SegmentType::Sealed) {
+        AssertInfo(
+            result->read_lease_ != nullptr && result->read_lease_->valid(),
+            "sealed search result for segment {} has no read lease",
+            segment->get_segment_id());
+    }
 }
 
 constexpr const char* kMilvusFieldIDMetadataKey = "milvus.field_id";
@@ -820,6 +838,8 @@ ExportSearchResultAsArrowRecordBatch(CSearchResult c_search_result,
                    "ArrowSchema output must be empty before export");
         AssertInfo(out_array->release == nullptr,
                    "ArrowArray output must be empty before export");
+        AssertSearchResultReadLease(
+            static_cast<SearchResult*>(c_search_result));
         auto cancel_token = folly::CancellationToken();
         if (cancellation_source != nullptr) {
             auto source =
@@ -876,6 +896,11 @@ FillOutputFieldsOrderedImpl(CSearchResult* search_results,
         AssertEmptyCProto(out_result);
         auto plan = static_cast<milvus::query::Plan*>(c_plan);
         milvus::OpContext op_ctx(cancel_token);
+
+        for (int64_t i = 0; i < num_search_results; ++i) {
+            AssertSearchResultReadLease(
+                static_cast<SearchResult*>(search_results[i]));
+        }
 
         if (plan->target_entries_.empty()) {
             return milvus::SuccessCStatus();
@@ -1131,8 +1156,10 @@ PrepareSearchResultsForExportImpl(
             AssertInfo(c_search_results[i] != nullptr,
                        "null search result at index {}",
                        i);
-            search_results.push_back(
-                static_cast<milvus::SearchResult*>(c_search_results[i]));
+            auto result =
+                static_cast<milvus::SearchResult*>(c_search_results[i]);
+            AssertSearchResultReadLease(result);
+            search_results.push_back(result);
         }
 
         milvus::OpContext op_ctx(cancel_token);

--- a/internal/core/src/segcore/search_result_export_c_test.cpp
+++ b/internal/core/src/segcore/search_result_export_c_test.cpp
@@ -31,6 +31,7 @@
 #include "query/PlanImpl.h"
 #include "query/PlanNode.h"
 #include "query/PlanProto.h"
+#include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegcoreConfig.h"
 #include "segcore/Utils.h"
 #include "segcore/reduce/Reduce.h"
@@ -68,6 +69,16 @@ using ChunkSizesPtr = std::unique_ptr<int64_t, decltype(&ReleaseChunkSizes)>;
 static ChunkSizesPtr
 AdoptChunkSizes(int64_t* chunk_sizes) {
     return ChunkSizesPtr(chunk_sizes, ReleaseChunkSizes);
+}
+
+static void
+AttachSealedRequestLease(SearchResult& result,
+                         milvus::segcore::SegmentInterface* segment) {
+    auto* sealed =
+        dynamic_cast<milvus::segcore::ChunkedSegmentSealedImpl*>(segment);
+    ASSERT_NE(sealed, nullptr);
+    result.segment_ = segment;
+    result.read_lease_ = sealed->AcquireReadLease(folly::CancellationToken());
 }
 
 // ---------------------------------------------------------------------------
@@ -843,7 +854,7 @@ TEST(SearchResultExport,
     sr.total_nq_ = 1;
     sr.unity_topK_ = 3;
     sr.pk_type_ = DataType::INT64;
-    sr.segment_ = segment.get();
+    AttachSealedRequestLease(sr, segment.get());
     sr.seg_offsets_ = {0, 1, 2};
     sr.distances_ = {0.9f, 0.8f, 0.7f};
     sr.primary_keys_ = {
@@ -1038,7 +1049,7 @@ TEST(SearchResultExport,
     non_empty_sr.total_nq_ = 1;
     non_empty_sr.unity_topK_ = 2;
     non_empty_sr.pk_type_ = DataType::INT64;
-    non_empty_sr.segment_ = segment.get();
+    AttachSealedRequestLease(non_empty_sr, segment.get());
     non_empty_sr.seg_offsets_ = {0, 1};
     non_empty_sr.distances_ = {0.9f, 0.8f};
     non_empty_sr.primary_keys_ = {PkType(int64_t(100)), PkType(int64_t(101))};
@@ -1098,7 +1109,7 @@ TEST(SearchResultExport, ExportSearchResultAsArrowRecordBatch_ExtraFieldIds) {
     sr.total_nq_ = 1;
     sr.unity_topK_ = 3;
     sr.pk_type_ = DataType::INT64;
-    sr.segment_ = segment.get();
+    AttachSealedRequestLease(sr, segment.get());
     sr.seg_offsets_ = {0, 1, 2};
     sr.distances_ = {0.9f, 0.8f, 0.7f};
     sr.primary_keys_ = {
@@ -1155,7 +1166,7 @@ TEST(SearchResultExport, FillOutputFieldsOrdered_Basic) {
     EXPECT_TRUE(HasTargetEntries(reinterpret_cast<CSearchPlan>(plan.get())));
 
     SearchResult sr;
-    sr.segment_ = segment.get();
+    AttachSealedRequestLease(sr, segment.get());
 
     std::vector<CSearchResult> c_results = {
         reinterpret_cast<CSearchResult>(&sr)};
@@ -1369,7 +1380,7 @@ TEST(SearchResultExport, PrepareSearchResultsForExport_FillsPrimaryKeys) {
     sr_a.total_nq_ = 1;
     sr_a.unity_topK_ = 3;
     sr_a.total_data_cnt_ = N;
-    sr_a.segment_ = seg_a.get();
+    AttachSealedRequestLease(sr_a, seg_a.get());
     sr_a.seg_offsets_ = {0, INVALID_SEG_OFFSET, 5};
     sr_a.distances_ = {1.0f, 2.0f, 3.0f};
 
@@ -1377,7 +1388,7 @@ TEST(SearchResultExport, PrepareSearchResultsForExport_FillsPrimaryKeys) {
     sr_b.total_nq_ = 1;
     sr_b.unity_topK_ = 3;
     sr_b.total_data_cnt_ = N;
-    sr_b.segment_ = seg_b.get();
+    AttachSealedRequestLease(sr_b, seg_b.get());
     sr_b.seg_offsets_ = {1, 7, 10};
     sr_b.distances_ = {1.5f, 2.5f, 3.5f};
 
@@ -1385,7 +1396,7 @@ TEST(SearchResultExport, PrepareSearchResultsForExport_FillsPrimaryKeys) {
     sr_no_hit.total_nq_ = 1;
     sr_no_hit.unity_topK_ = 3;
     sr_no_hit.total_data_cnt_ = N;
-    sr_no_hit.segment_ = seg_b.get();
+    AttachSealedRequestLease(sr_no_hit, seg_b.get());
     sr_no_hit.seg_offsets_ = {
         INVALID_SEG_OFFSET, INVALID_SEG_OFFSET, INVALID_SEG_OFFSET};
     sr_no_hit.distances_ = {4.0f, 5.0f, 6.0f};

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -409,6 +409,36 @@ CheckExternalFieldsInLoadedManifest(
     }
 }
 
+std::shared_ptr<milvus::segcore::SegmentReadLease>
+AcquireSegmentReadLease(milvus::segcore::SegmentInterface* segment,
+                        const folly::CancellationToken& cancel_token) {
+    if (segment->type() == SegmentType::Growing) {
+        return nullptr;
+    }
+
+    auto sealed =
+        dynamic_cast<milvus::segcore::ChunkedSegmentSealedImpl*>(segment);
+    AssertInfo(sealed != nullptr,
+               "sealed segment {} does not support request read leases",
+               segment->get_segment_id());
+    return sealed->AcquireReadLease(cancel_token);
+}
+
+void
+ValidateSegmentSchemaCompatibility(milvus::segcore::SegmentInterface* segment,
+                                   const milvus::SchemaPtr& plan_schema) {
+    if (segment->type() == SegmentType::Growing) {
+        return;
+    }
+
+    auto sealed =
+        dynamic_cast<milvus::segcore::ChunkedSegmentSealedImpl*>(segment);
+    AssertInfo(sealed != nullptr,
+               "sealed segment {} does not support schema validation",
+               segment->get_segment_id());
+    sealed->ValidateSchemaCompatibility(plan_schema);
+}
+
 //////////////////////////////    public C API wrappers    //////////////////////////////
 
 CFuture*  // Future<milvus::SearchResult*>
@@ -455,6 +485,8 @@ AsyncSearch(CTraceContext c_trace,
 
             milvus::OpContext op_ctx(cancel_token);
             segment->LazyCheckSchema(plan->schema_, &op_ctx);
+            auto read_lease = AcquireSegmentReadLease(segment, cancel_token);
+            ValidateSegmentSchemaCompatibility(segment, plan->schema_);
             auto internal_segment =
                 static_cast<milvus::segcore::SegmentInternalInterface*>(
                     segment);
@@ -476,6 +508,7 @@ AsyncSearch(CTraceContext c_trace,
                 search_result->total_nq_ = num_queries;
                 search_result->unity_topK_ = 0;
                 search_result->total_data_cnt_ = 0;
+                search_result->segment_ = internal_segment;
             } else {
                 search_result = segment->Search(plan,
                                                 phg_ptr,
@@ -488,6 +521,7 @@ AsyncSearch(CTraceContext c_trace,
                                                 enable_expr_cache,
                                                 span);
             }
+            search_result->read_lease_ = std::move(read_lease);
             if (!filter_only &&
                 !milvus::PositivelyRelated(
                     plan->plan_node_->search_info_.metric_type_)) {
@@ -562,6 +596,8 @@ AsyncRetrieve(CTraceContext c_trace,
 
             milvus::OpContext op_ctx(cancel_token);
             segment->LazyCheckSchema(plan->schema_, &op_ctx);
+            auto read_lease = AcquireSegmentReadLease(segment, cancel_token);
+            ValidateSegmentSchemaCompatibility(segment, plan->schema_);
             auto internal_segment =
                 static_cast<milvus::segcore::SegmentInternalInterface*>(
                     segment);
@@ -579,8 +615,10 @@ AsyncRetrieve(CTraceContext c_trace,
                                   collection_ttl,
                                   entity_ttl_physical_time_us);
 
-            return CreateLeakedCRetrieveResultFromProto(
+            auto c_result = CreateLeakedCRetrieveResultFromProto(
                 std::move(retrieve_result));
+            read_lease.reset();
+            return c_result;
         });
     return static_cast<CFuture*>(static_cast<void*>(
         static_cast<milvus::futures::IFuture*>(future.release())));
@@ -607,6 +645,8 @@ AsyncRetrieveByOffsets(CTraceContext c_trace,
 
             milvus::OpContext op_ctx(cancel_token);
             segment->LazyCheckSchema(plan->schema_, &op_ctx);
+            auto read_lease = AcquireSegmentReadLease(segment, cancel_token);
+            ValidateSegmentSchemaCompatibility(segment, plan->schema_);
             auto internal_segment =
                 static_cast<milvus::segcore::SegmentInternalInterface*>(
                     segment);
@@ -616,8 +656,10 @@ AsyncRetrieveByOffsets(CTraceContext c_trace,
             auto retrieve_result =
                 segment->Retrieve(&trace_ctx, plan, offsets, len, cancel_token);
 
-            return CreateLeakedCRetrieveResultFromProto(
+            auto c_result = CreateLeakedCRetrieveResultFromProto(
                 std::move(retrieve_result));
+            read_lease.reset();
+            return c_result;
         });
     return static_cast<CFuture*>(static_cast<void*>(
         static_cast<milvus::futures::IFuture*>(future.release())));
@@ -822,6 +864,27 @@ DropSealedSegmentIndex(CSegmentInterface c_segment, int64_t field_id) {
     }
 }
 
+CFuture*
+AsyncDropSealedSegmentIndex(CSegmentInterface c_segment, int64_t field_id) {
+    auto segment_interface =
+        reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
+    auto future = milvus::futures::Future<bool>::async(
+        milvus::futures::getLoadCPUExecutor(),
+        milvus::futures::ExecutePriority::NORMAL,
+        [segment_interface,
+         field_id](folly::CancellationToken cancel_token) -> bool* {
+            auto segment = dynamic_cast<milvus::segcore::SegmentSealed*>(
+                segment_interface);
+            AssertInfo(segment != nullptr, "segment conversion failed");
+            milvus::OpContext op_ctx(cancel_token);
+            segment->DropIndex(milvus::FieldId(field_id), &op_ctx);
+            return nullptr;
+        },
+        milvus::futures::PoolType::kLoad);
+    return static_cast<CFuture*>(static_cast<void*>(
+        static_cast<milvus::futures::IFuture*>(future.release())));
+}
+
 CStatus
 DropSealedSegmentJSONIndex(CSegmentInterface c_segment,
                            int64_t field_id,
@@ -839,6 +902,30 @@ DropSealedSegmentJSONIndex(CSegmentInterface c_segment,
     } catch (std::exception& e) {
         return milvus::FailureCStatus(&e);
     }
+}
+
+CFuture*
+AsyncDropSealedSegmentJSONIndex(CSegmentInterface c_segment,
+                                int64_t field_id,
+                                const char* nested_path) {
+    auto segment_interface =
+        reinterpret_cast<milvus::segcore::SegmentInterface*>(c_segment);
+    std::string path(nested_path);
+    auto future = milvus::futures::Future<bool>::async(
+        milvus::futures::getLoadCPUExecutor(),
+        milvus::futures::ExecutePriority::NORMAL,
+        [segment_interface, field_id, path = std::move(path)](
+            folly::CancellationToken cancel_token) -> bool* {
+            auto segment = dynamic_cast<milvus::segcore::SegmentSealed*>(
+                segment_interface);
+            AssertInfo(segment != nullptr, "segment conversion failed");
+            milvus::OpContext op_ctx(cancel_token);
+            segment->DropJSONIndex(milvus::FieldId(field_id), path, &op_ctx);
+            return nullptr;
+        },
+        milvus::futures::PoolType::kLoad);
+    return static_cast<CFuture*>(static_cast<void*>(
+        static_cast<milvus::futures::IFuture*>(future.release())));
 }
 
 void

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -252,10 +252,18 @@ DropFieldData(CSegmentInterface c_segment, int64_t field_id);
 CStatus
 DropSealedSegmentIndex(CSegmentInterface c_segment, int64_t field_id);
 
+CFuture*
+AsyncDropSealedSegmentIndex(CSegmentInterface c_segment, int64_t field_id);
+
 CStatus
 DropSealedSegmentJSONIndex(CSegmentInterface c_segment,
                            int64_t field_id,
                            const char* nested_path);
+
+CFuture*
+AsyncDropSealedSegmentJSONIndex(CSegmentInterface c_segment,
+                                int64_t field_id,
+                                const char* nested_path);
 
 //////////////////////////////    interfaces for SegmentInterface    //////////////////////////////
 CStatus

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -72,6 +72,7 @@ set(MILVUS_TEST_FILES
         test_commit_timestamp.cpp
         test_schema_reopen.cpp
         test_growing_concurrent_reopen.cpp
+        test_segment_read_lease.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )

--- a/internal/core/unittest/test_commit_timestamp.cpp
+++ b/internal/core/unittest/test_commit_timestamp.cpp
@@ -308,7 +308,8 @@ class CommitTimestampV2TestAccess {
         auto next = segment->ClonePublishedState(current);
         next->runtime = segment->ToConstRuntimeState(std::move(runtime));
         segment->NormalizePublishedState(*next);
-        segment->PublishState(std::move(next));
+        std::lock_guard<std::mutex> reopen_guard(segment->reopen_mutex_);
+        segment->PublishStateOnline(std::move(next));
     }
 };
 

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -27,9 +27,10 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <string_view>
-#include <stdexcept>
+#include <thread>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -3927,6 +3928,115 @@ TEST(SealedDropFieldData, PKFieldStillDropsBinlogIndex) {
     // Drop again - should be a no-op (idempotent)
     segment->DropFieldData(pk_id);
     EXPECT_TRUE(segment->HasFieldData(pk_id));
+}
+
+TEST(SealedSegmentReopen, LazySchemaReopenFailsFastWhileReadLeaseActive) {
+    auto old_schema = std::make_shared<Schema>();
+    auto old_pk_id = old_schema->AddDebugField("pk", DataType::INT64);
+    old_schema->set_primary_field_id(old_pk_id);
+    old_schema->set_schema_version(100);
+
+    auto new_schema = std::make_shared<Schema>();
+    auto new_pk_id = new_schema->AddDebugField("pk", DataType::INT64);
+    auto new_field = new_schema->AddDebugField("new_field", DataType::INT64);
+    new_schema->set_primary_field_id(new_pk_id);
+    new_schema->set_schema_version(200);
+
+    auto dataset = DataGen(old_schema, 1);
+    auto segment = CreateSealedWithFieldDataLoaded(old_schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    auto read_lease = sealed->AcquireReadLease(folly::CancellationToken());
+    auto started = std::chrono::steady_clock::now();
+    bool rejected = false;
+    try {
+        sealed->LazyCheckSchema(new_schema, nullptr);
+    } catch (const SegcoreError& error) {
+        rejected = true;
+        EXPECT_EQ(error.get_error_code(), ErrorCode::FollyOtherException);
+        EXPECT_NE(std::string(error.what()).find("segment read gate busy"),
+                  std::string::npos);
+    }
+    auto elapsed = std::chrono::steady_clock::now() - started;
+
+    EXPECT_TRUE(rejected);
+    EXPECT_LT(elapsed, std::chrono::seconds(1));
+    EXPECT_FALSE(sealed->TestReadGateWriterPending());
+    EXPECT_EQ(sealed->TestGetSchemaSnapshot()->get_schema_version(), 100);
+
+    // The failed lazy publisher must leave the gate open.
+    auto second_read_lease =
+        sealed->AcquireReadLease(folly::CancellationToken());
+    EXPECT_TRUE(second_read_lease->valid());
+    read_lease.reset();
+    second_read_lease.reset();
+
+    EXPECT_NO_THROW(sealed->LazyCheckSchema(new_schema, nullptr));
+    EXPECT_EQ(sealed->TestGetSchemaSnapshot()->get_schema_version(), 200);
+    EXPECT_TRUE(sealed->HasFieldData(new_field));
+}
+
+TEST(SealedSegmentReopen, LazySchemaReopenDoesNotWaitForReopenMutex) {
+    auto old_schema = std::make_shared<Schema>();
+    auto old_pk_id = old_schema->AddDebugField("pk", DataType::INT64);
+    old_schema->set_primary_field_id(old_pk_id);
+    old_schema->set_schema_version(100);
+
+    auto middle_schema = std::make_shared<Schema>();
+    auto middle_pk_id = middle_schema->AddDebugField("pk", DataType::INT64);
+    middle_schema->AddDebugField("middle_field", DataType::INT64);
+    middle_schema->set_primary_field_id(middle_pk_id);
+    middle_schema->set_schema_version(200);
+
+    auto newest_schema = std::make_shared<Schema>();
+    auto newest_pk_id = newest_schema->AddDebugField("pk", DataType::INT64);
+    newest_schema->AddDebugField("middle_field", DataType::INT64);
+    newest_schema->AddDebugField("newest_field", DataType::INT64);
+    newest_schema->set_primary_field_id(newest_pk_id);
+    newest_schema->set_schema_version(300);
+
+    auto dataset = DataGen(old_schema, 1);
+    auto segment = CreateSealedWithFieldDataLoaded(old_schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    auto read_lease = sealed->AcquireReadLease(folly::CancellationToken());
+    std::thread explicit_reopen([&] { sealed->Reopen(middle_schema); });
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!sealed->TestReadGateWriterPending() &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    bool writer_pending = sealed->TestReadGateWriterPending();
+
+    bool rejected = false;
+    auto started = std::chrono::steady_clock::now();
+    if (writer_pending) {
+        try {
+            sealed->LazyCheckSchema(newest_schema, nullptr);
+        } catch (const SegcoreError& error) {
+            rejected = true;
+            EXPECT_EQ(error.get_error_code(), ErrorCode::FollyOtherException);
+            EXPECT_NE(std::string(error.what()).find("segment read gate busy"),
+                      std::string::npos);
+        }
+    }
+    auto elapsed = std::chrono::steady_clock::now() - started;
+
+    // Always release and join before asserting so a failure cannot leave a
+    // joinable thread behind.
+    read_lease.reset();
+    explicit_reopen.join();
+
+    ASSERT_TRUE(writer_pending);
+    EXPECT_TRUE(rejected);
+    EXPECT_LT(elapsed, std::chrono::seconds(1));
+    EXPECT_EQ(sealed->TestGetSchemaSnapshot()->get_schema_version(), 200);
+
+    EXPECT_NO_THROW(sealed->LazyCheckSchema(newest_schema, nullptr));
+    EXPECT_EQ(sealed->TestGetSchemaSnapshot()->get_schema_version(), 300);
 }
 
 TEST(SealedSegmentReopen, SchemaOnlyReopenPublishesDefaultFilledState) {

--- a/internal/core/unittest/test_segment_read_lease.cpp
+++ b/internal/core/unittest/test_segment_read_lease.cpp
@@ -1,0 +1,264 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include <folly/CancellationToken.h>
+
+#include "common/EasyAssert.h"
+#include "common/OpContext.h"
+#include "segcore/SegmentReadLease.h"
+
+namespace milvus::segcore {
+namespace {
+
+using namespace std::chrono_literals;
+
+template <typename Predicate>
+bool
+WaitUntil(Predicate&& predicate, std::chrono::milliseconds timeout = 2s) {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate()) {
+            return true;
+        }
+        std::this_thread::sleep_for(1ms);
+    }
+    return predicate();
+}
+
+TEST(SegmentReadGateTest, PendingWriterRejectsNewReaders) {
+    SegmentReadGate gate;
+    auto first_reader = gate.AcquireRead(folly::CancellationToken(), 100);
+
+    std::atomic<bool> writer_acquired{false};
+    std::atomic<bool> release_writer{false};
+    std::thread writer([&] {
+        auto publish_lease = gate.AcquirePublish(nullptr, 100);
+        writer_acquired.store(true, std::memory_order_release);
+        while (!release_writer.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        publish_lease.MarkPublished();
+    });
+
+    EXPECT_TRUE(WaitUntil([&] { return gate.WriterPending(); }));
+
+    try {
+        auto lease = gate.AcquireRead(folly::CancellationToken(), 100);
+        FAIL() << "expected pending writer to reject a new reader";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::FollyOtherException);
+    }
+    EXPECT_EQ(gate.ActiveReaders(), 1);
+
+    first_reader.reset();
+    EXPECT_TRUE(WaitUntil(
+        [&] { return writer_acquired.load(std::memory_order_acquire); }));
+
+    release_writer.store(true, std::memory_order_release);
+    writer.join();
+
+    auto next_reader = gate.AcquireRead(folly::CancellationToken(), 100);
+    EXPECT_TRUE(next_reader->valid());
+    EXPECT_EQ(gate.PublishedGeneration(), 1);
+    EXPECT_EQ(gate.BlockedReadersTotal(), 1);
+}
+
+TEST(SegmentReadGateTest, ReadLeaseCanReleaseOnAnotherThread) {
+    SegmentReadGate gate;
+    auto lease = gate.AcquireRead(folly::CancellationToken(), 101);
+    EXPECT_EQ(gate.ActiveReaders(), 1);
+
+    std::thread releaser(
+        [lease = std::move(lease)]() mutable { lease.reset(); });
+    releaser.join();
+
+    EXPECT_EQ(gate.ActiveReaders(), 0);
+}
+
+TEST(SegmentReadGateTest, CancelledPublisherReopensGate) {
+    SegmentReadGate gate;
+    auto first_reader = gate.AcquireRead(folly::CancellationToken(), 102);
+
+    folly::CancellationSource cancellation_source;
+    milvus::OpContext op_ctx(cancellation_source.getToken());
+    std::atomic<bool> cancelled{false};
+    std::thread writer([&] {
+        try {
+            auto publish_lease = gate.AcquirePublish(&op_ctx, 102);
+        } catch (const SegcoreError& error) {
+            cancelled.store(error.get_error_code() == ErrorCode::FollyCancel,
+                            std::memory_order_release);
+        }
+    });
+
+    EXPECT_TRUE(WaitUntil([&] { return gate.WriterPending(); }));
+    cancellation_source.requestCancellation();
+    writer.join();
+
+    EXPECT_TRUE(cancelled.load(std::memory_order_acquire));
+    EXPECT_FALSE(gate.WriterPending());
+    EXPECT_EQ(gate.PublishedGeneration(), 0);
+
+    first_reader.reset();
+    auto next_reader = gate.AcquireRead(folly::CancellationToken(), 102);
+    EXPECT_TRUE(next_reader->valid());
+}
+
+TEST(SegmentReadGateTest, PreCancelledPublisherDoesNotPublish) {
+    SegmentReadGate gate;
+    folly::CancellationSource cancellation_source;
+    cancellation_source.requestCancellation();
+    milvus::OpContext op_ctx(cancellation_source.getToken());
+
+    try {
+        auto publish_lease = gate.AcquirePublish(&op_ctx, 103);
+        FAIL() << "expected pre-cancelled publisher to fail";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::FollyCancel);
+    }
+
+    EXPECT_FALSE(gate.WriterPending());
+    EXPECT_EQ(gate.PublishedGeneration(), 0);
+    auto reader = gate.AcquireRead(folly::CancellationToken(), 103);
+    EXPECT_TRUE(reader->valid());
+}
+
+TEST(SegmentReadGateTest, CancellationAtLastReaderReleaseDoesNotPublish) {
+    SegmentReadGate gate;
+    auto reader = gate.AcquireRead(folly::CancellationToken(), 104);
+
+    folly::CancellationSource cancellation_source;
+    milvus::OpContext op_ctx(cancellation_source.getToken());
+    std::atomic<bool> cancelled{false};
+    std::thread writer([&] {
+        try {
+            auto publish_lease = gate.AcquirePublish(&op_ctx, 104);
+        } catch (const SegcoreError& error) {
+            cancelled.store(error.get_error_code() == ErrorCode::FollyCancel,
+                            std::memory_order_release);
+        }
+    });
+
+    EXPECT_TRUE(WaitUntil([&] { return gate.WriterPending(); }));
+    cancellation_source.requestCancellation();
+    reader.reset();
+    writer.join();
+
+    EXPECT_TRUE(cancelled.load(std::memory_order_acquire));
+    EXPECT_FALSE(gate.WriterPending());
+    EXPECT_EQ(gate.PublishedGeneration(), 0);
+}
+
+TEST(SegmentReadGateTest, NullContextPublisherTimesOutAndReopensGate) {
+    SegmentReadGate gate(20ms);
+    auto reader = gate.AcquireRead(folly::CancellationToken(), 105);
+
+    try {
+        auto publish_lease = gate.AcquirePublish(nullptr, 105);
+        FAIL() << "expected publication drain timeout";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::FollyOtherException);
+    }
+
+    EXPECT_FALSE(gate.WriterPending());
+    EXPECT_EQ(gate.PublishedGeneration(), 0);
+    reader.reset();
+    auto next_reader = gate.AcquireRead(folly::CancellationToken(), 105);
+    EXPECT_TRUE(next_reader->valid());
+}
+
+TEST(SegmentReadGateTest, FailFastPublisherDoesNotWaitOrCloseGate) {
+    SegmentReadGate gate;
+    auto first_reader = gate.AcquireRead(folly::CancellationToken(), 106);
+
+    try {
+        auto publish_lease = gate.AcquirePublishFailFast(nullptr, 106);
+        FAIL() << "expected fail-fast publisher rejection";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::FollyOtherException);
+        EXPECT_NE(std::string(error.what()).find("segment read gate busy"),
+                  std::string::npos);
+    }
+
+    EXPECT_FALSE(gate.WriterPending());
+    EXPECT_EQ(gate.ActiveReaders(), 1);
+
+    // A rejected fail-fast publisher must not close the gate.
+    auto second_reader = gate.AcquireRead(folly::CancellationToken(), 106);
+    EXPECT_TRUE(second_reader->valid());
+    EXPECT_EQ(gate.ActiveReaders(), 2);
+
+    first_reader.reset();
+    second_reader.reset();
+
+    {
+        auto publish_lease = gate.AcquirePublishFailFast(nullptr, 106);
+        EXPECT_TRUE(publish_lease.valid());
+        EXPECT_TRUE(gate.WriterPending());
+        publish_lease.MarkPublished();
+    }
+
+    EXPECT_FALSE(gate.WriterPending());
+    EXPECT_EQ(gate.PublishedGeneration(), 1);
+}
+
+TEST(SegmentReadGateTest, CrossSegmentRequestsReleaseAndRetryWithoutDeadlock) {
+    SegmentReadGate first_gate;
+    SegmentReadGate second_gate;
+    auto first_request_lease =
+        first_gate.AcquireRead(folly::CancellationToken(), 201);
+    auto second_request_lease =
+        second_gate.AcquireRead(folly::CancellationToken(), 202);
+
+    std::atomic<bool> first_writer_acquired{false};
+    std::atomic<bool> second_writer_acquired{false};
+    std::thread first_writer([&] {
+        auto publish_lease = first_gate.AcquirePublish(nullptr, 201);
+        first_writer_acquired.store(true, std::memory_order_release);
+    });
+    std::thread second_writer([&] {
+        auto publish_lease = second_gate.AcquirePublish(nullptr, 202);
+        second_writer_acquired.store(true, std::memory_order_release);
+    });
+
+    EXPECT_TRUE(WaitUntil([&] { return first_gate.WriterPending(); }));
+    EXPECT_TRUE(WaitUntil([&] { return second_gate.WriterPending(); }));
+
+    EXPECT_THROW(second_gate.AcquireRead(folly::CancellationToken(), 202),
+                 SegcoreError);
+    EXPECT_THROW(first_gate.AcquireRead(folly::CancellationToken(), 201),
+                 SegcoreError);
+
+    // Whole-request retry first releases every lease acquired by the failed
+    // attempt. Both publishers can then drain independently.
+    first_request_lease.reset();
+    second_request_lease.reset();
+    first_writer.join();
+    second_writer.join();
+
+    EXPECT_TRUE(first_writer_acquired.load(std::memory_order_acquire));
+    EXPECT_TRUE(second_writer_acquired.load(std::memory_order_acquire));
+}
+
+}  // namespace
+}  // namespace milvus::segcore

--- a/internal/querynodev2/segments/read_gate_retry.go
+++ b/internal/querynodev2/segments/read_gate_retry.go
@@ -1,0 +1,71 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segments
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+
+	segcoreutil "github.com/milvus-io/milvus/internal/util/segcore"
+)
+
+const (
+	segmentReadGateRetryInitialBackoff = 5 * time.Millisecond
+	segmentReadGateRetryMaxBackoff     = 100 * time.Millisecond
+)
+
+type segmentReadGateRetryWait func(context.Context, int) error
+
+func waitSegmentReadGateRetry(ctx context.Context, retryCount int) error {
+	shift := min(max(retryCount-1, 0), 5)
+	backoff := segmentReadGateRetryInitialBackoff << shift
+	backoff = min(backoff, segmentReadGateRetryMaxBackoff)
+	half := backoff / 2
+	delay := half + time.Duration(rand.Int64N(int64(half)+1))
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func retrySegmentReadGate[T any](
+	ctx context.Context,
+	segmentType SegmentType,
+	operation func() (T, error),
+	waitRetry segmentReadGateRetryWait,
+) (T, error) {
+	retryCount := 0
+	for {
+		result, err := operation()
+		if err == nil || segmentType != SegmentTypeSealed ||
+			!segcoreutil.IsSegmentReadGateBusy(err) {
+			return result, err
+		}
+
+		retryCount++
+		if err := waitRetry(ctx, retryCount); err != nil {
+			var zero T
+			return zero, err
+		}
+	}
+}

--- a/internal/querynodev2/segments/read_gate_retry_test.go
+++ b/internal/querynodev2/segments/read_gate_retry_test.go
@@ -1,0 +1,179 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segments
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/state"
+	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func TestRetrySegmentReadGate(t *testing.T) {
+	t.Run("sealed retries gate busy", func(t *testing.T) {
+		calls := 0
+		waits := 0
+		result, err := retrySegmentReadGate(
+			context.Background(),
+			SegmentTypeSealed,
+			func() (int, error) {
+				calls++
+				if calls == 1 {
+					return 0, merr.SegcoreError(
+						2037, "segment read gate busy for segment 1")
+				}
+				return 42, nil
+			},
+			func(context.Context, int) error {
+				waits++
+				return nil
+			},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 42, result)
+		assert.Equal(t, 2, calls)
+		assert.Equal(t, 1, waits)
+	})
+
+	t.Run("growing does not retry", func(t *testing.T) {
+		calls := 0
+		waits := 0
+		_, err := retrySegmentReadGate(
+			context.Background(),
+			SegmentTypeGrowing,
+			func() (int, error) {
+				calls++
+				return 0, merr.SegcoreError(
+					2037, "segment read gate busy for segment 2")
+			},
+			func(context.Context, int) error {
+				waits++
+				return nil
+			},
+		)
+		require.Error(t, err)
+		assert.Equal(t, 1, calls)
+		assert.Zero(t, waits)
+	})
+
+	t.Run("unrelated folly error does not retry", func(t *testing.T) {
+		calls := 0
+		waits := 0
+		_, err := retrySegmentReadGate(
+			context.Background(),
+			SegmentTypeSealed,
+			func() (int, error) {
+				calls++
+				return 0, merr.SegcoreError(
+					2037, "unrelated folly failure")
+			},
+			func(context.Context, int) error {
+				waits++
+				return nil
+			},
+		)
+		require.Error(t, err)
+		assert.Equal(t, 1, calls)
+		assert.Zero(t, waits)
+	})
+
+	t.Run("retry obeys context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		result, err := retrySegmentReadGate(
+			ctx,
+			SegmentTypeSealed,
+			func() (int, error) {
+				calls++
+				return 0, merr.SegcoreError(
+					2037, "segment read gate busy for segment 3")
+			},
+			func(ctx context.Context, _ int) error {
+				cancel()
+				return ctx.Err()
+			},
+		)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Zero(t, result)
+		assert.Equal(t, 1, calls)
+	})
+}
+
+func TestLocalSegmentRetrieveRetriesReadGateBusy(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("retrieve", func(t *testing.T) {
+		ctx := context.Background()
+		plan := new(segcore.RetrievePlan)
+		csegment := mock_segcore.NewMockCSegment(t)
+		csegment.EXPECT().
+			Retrieve(ctx, plan).
+			Return(nil, merr.SegcoreError(
+				2037, "segment read gate busy for segment 10")).
+			Once()
+		csegment.EXPECT().Retrieve(ctx, plan).Return(nil, nil).Once()
+
+		base := newTestBaseSegment(10, 20)
+		base.segmentType = SegmentTypeSealed
+		segment := &LocalSegment{
+			baseSegment: base,
+			ptrLock:     state.NewLoadStateLock(state.LoadStateDataLoaded),
+			csegment:    csegment,
+		}
+
+		result, err := segment.retrieve(ctx, plan, mlog.With())
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("retrieve by offsets", func(t *testing.T) {
+		ctx := context.Background()
+		plan := &segcore.RetrievePlanWithOffsets{
+			Offsets: []int64{1},
+		}
+		csegment := mock_segcore.NewMockCSegment(t)
+		csegment.EXPECT().
+			RetrieveByOffsets(ctx, plan).
+			Return(nil, merr.SegcoreError(
+				2037, "segment read gate busy for segment 11")).
+			Once()
+		csegment.EXPECT().
+			RetrieveByOffsets(ctx, plan).
+			Return(nil, nil).
+			Once()
+
+		base := newTestBaseSegment(11, 20)
+		base.segmentType = SegmentTypeSealed
+		segment := &LocalSegment{
+			baseSegment: base,
+			ptrLock:     state.NewLoadStateLock(state.LoadStateDataLoaded),
+			csegment:    csegment,
+		}
+
+		result, err := segment.retrieveByOffsets(ctx, plan, mlog.With())
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}

--- a/internal/querynodev2/segments/search.go
+++ b/internal/querynodev2/segments/search.go
@@ -23,15 +23,59 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments/metricsutil"
+	segcoreutil "github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 )
 
+type searchResultsCleanup func([]*SearchResult)
+
 // searchOnSegments performs search on listed segments
 // all segment ids are validated before calling this function
 func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segType SegmentType, searchReq *SearchRequest) ([]*SearchResult, error) {
+	return searchSegmentsWithRetry(ctx, mgr, segments, segType, searchReq, DeleteSearchResults, waitSegmentReadGateRetry)
+}
+
+func searchSegmentsWithRetry(
+	ctx context.Context,
+	mgr *Manager,
+	segments []Segment,
+	segType SegmentType,
+	searchReq *SearchRequest,
+	cleanup searchResultsCleanup,
+	waitRetry segmentReadGateRetryWait,
+) ([]*SearchResult, error) {
+	retryCount := 0
+	for {
+		searchResults, err := searchSegmentsAttempt(ctx, mgr, segments, segType, searchReq)
+		if err == nil {
+			return searchResults, nil
+		}
+
+		validResults := make([]*SearchResult, 0, len(searchResults))
+		for _, result := range searchResults {
+			if result != nil {
+				validResults = append(validResults, result)
+			}
+		}
+		cleanup(validResults)
+
+		if segType != SegmentTypeSealed || !segcoreutil.IsSegmentReadGateBusy(err) {
+			return nil, err
+		}
+
+		retryCount++
+		mlog.Debug(ctx, "retry sealed segment search after publish gate rejection",
+			mlog.Int("retryCount", retryCount))
+		if err := waitRetry(ctx, retryCount); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func searchSegmentsAttempt(ctx context.Context, mgr *Manager, segments []Segment, segType SegmentType, searchReq *SearchRequest) ([]*SearchResult, error) {
 	searchLabel := metrics.SealedSegmentLabel
 	if segType == commonpb.SegmentState_Growing {
 		searchLabel = metrics.GrowingSegmentLabel
@@ -92,15 +136,7 @@ func searchSegments(ctx context.Context, mgr *Manager, segments []Segment, segTy
 	}
 
 	if err != nil {
-		// Collect non-nil results for cleanup
-		validResults := make([]*SearchResult, 0, len(segments))
-		for _, r := range searchResults {
-			if r != nil {
-				validResults = append(validResults, r)
-			}
-		}
-		DeleteSearchResults(validResults)
-		return nil, err
+		return searchResults, err
 	}
 
 	if len(segmentsWithoutIndex) > 0 {

--- a/internal/querynodev2/segments/search_test.go
+++ b/internal/querynodev2/segments/search_test.go
@@ -19,8 +19,10 @@ package segments
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -29,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -314,6 +317,107 @@ func (suite *SearchSuite) TestSearchStreamingWithFilterDoesNotPruneGrowing() {
 	for _, segID := range growingSegIDs {
 		suite.manager.Segment.Remove(ctx, segID, querypb.DataScope_Streaming)
 	}
+}
+
+func (suite *SearchSuite) TestSearchSegmentsReleasesCompletedResultsBeforeGateRetry() {
+	ctx := context.Background()
+	searchReq, err := mock_segcore.GenSearchPlanAndRequests(
+		suite.collection.GetCCollection(),
+		[]int64{suite.segmentID, suite.segmentID + 1},
+		mock_segcore.IndexFaissIDMap,
+		1,
+	)
+	suite.Require().NoError(err)
+	defer searchReq.Delete()
+
+	firstResultReady := make(chan struct{})
+	var firstSearchCalls atomic.Int32
+	var secondSearchCalls atomic.Int32
+	firstSegment := NewMockSegment(suite.T())
+	secondSegment := NewMockSegment(suite.T())
+	for _, segment := range []*MockSegment{firstSegment, secondSegment} {
+		segment.EXPECT().DatabaseName().Return("default").Maybe()
+		segment.EXPECT().ResourceGroup().Return("rg").Maybe()
+		segment.EXPECT().ExistIndex(mock.Anything).Return(true).Twice()
+	}
+
+	firstSegment.EXPECT().Search(mock.Anything, searchReq).
+		RunAndReturn(func(context.Context, *SearchRequest) (*SearchResult, error) {
+			if firstSearchCalls.Add(1) == 1 {
+				close(firstResultReady)
+			}
+			return new(SearchResult), nil
+		}).Twice()
+	secondSegment.EXPECT().Search(mock.Anything, searchReq).
+		RunAndReturn(func(context.Context, *SearchRequest) (*SearchResult, error) {
+			if secondSearchCalls.Add(1) == 1 {
+				<-firstResultReady
+				return nil, merr.SegcoreError(
+					2037, "segment read gate busy for segment 2")
+			}
+			return new(SearchResult), nil
+		}).Twice()
+
+	cleanupCalled := false
+	cleanup := func(results []*SearchResult) {
+		suite.Len(results, 1)
+		cleanupCalled = true
+	}
+	waitRetry := func(context.Context, int) error {
+		suite.True(cleanupCalled, "partial results must be released before retry")
+		return nil
+	}
+
+	results, err := searchSegmentsWithRetry(
+		ctx,
+		nil,
+		[]Segment{firstSegment, secondSegment},
+		SegmentTypeSealed,
+		searchReq,
+		cleanup,
+		waitRetry,
+	)
+	suite.NoError(err)
+	suite.Len(results, 2)
+	suite.True(cleanupCalled)
+	suite.Equal(int32(2), firstSearchCalls.Load())
+	suite.Equal(int32(2), secondSearchCalls.Load())
+}
+
+func (suite *SearchSuite) TestSearchSegmentsGateRetryObeysContext() {
+	ctx, cancel := context.WithCancel(context.Background())
+	searchReq, err := mock_segcore.GenSearchPlanAndRequests(
+		suite.collection.GetCCollection(),
+		[]int64{suite.segmentID},
+		mock_segcore.IndexFaissIDMap,
+		1,
+	)
+	suite.Require().NoError(err)
+	defer searchReq.Delete()
+
+	segment := NewMockSegment(suite.T())
+	segment.EXPECT().DatabaseName().Return("default").Maybe()
+	segment.EXPECT().ResourceGroup().Return("rg").Maybe()
+	segment.EXPECT().ExistIndex(mock.Anything).Return(true).Once()
+	segment.EXPECT().Search(mock.Anything, searchReq).
+		Return(nil, merr.SegcoreError(
+			2037, "segment read gate busy for segment 1")).Once()
+
+	waitRetry := func(ctx context.Context, _ int) error {
+		cancel()
+		return ctx.Err()
+	}
+	results, err := searchSegmentsWithRetry(
+		ctx,
+		nil,
+		[]Segment{segment},
+		SegmentTypeSealed,
+		searchReq,
+		func([]*SearchResult) {},
+		waitRetry,
+	)
+	suite.Nil(results)
+	suite.ErrorIs(err, context.Canceled)
 }
 
 func TestSearch(t *testing.T) {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -844,7 +844,14 @@ func (s *LocalSegment) retrieve(ctx context.Context, plan *segcore.RetrievePlan,
 	log.Debug(ctx, "begin to retrieve")
 
 	tr := timerecord.NewTimeRecorder("cgoRetrieve")
-	result, err := s.csegment.Retrieve(ctx, plan)
+	result, err := retrySegmentReadGate(
+		ctx,
+		s.segmentType,
+		func() (*segcore.RetrieveResult, error) {
+			return s.csegment.Retrieve(ctx, plan)
+		},
+		waitSegmentReadGateRetry,
+	)
 	if err != nil {
 		log.Warn(ctx, "Retrieve failed")
 		return nil, err
@@ -890,7 +897,14 @@ func (s *LocalSegment) retrieveByOffsets(ctx context.Context, plan *segcore.Retr
 
 	log.Debug(ctx, "begin to retrieve by offsets")
 	tr := timerecord.NewTimeRecorder("cgoRetrieveByOffsets")
-	result, err := s.csegment.RetrieveByOffsets(ctx, plan)
+	result, err := retrySegmentReadGate(
+		ctx,
+		s.segmentType,
+		func() (*segcore.RetrieveResult, error) {
+			return s.csegment.RetrieveByOffsets(ctx, plan)
+		},
+		waitSegmentReadGateRetry,
+	)
 	if err != nil {
 		log.Warn(ctx, "RetrieveByOffsets failed")
 		return nil, err

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -1795,7 +1795,9 @@ func (node *QueryNode) DropIndex(ctx context.Context, req *querypb.DropIndexRequ
 	segment := segments[0]
 	indexIDs := req.GetIndexIDs()
 	for _, indexID := range indexIDs {
-		segment.DropIndex(ctx, indexID)
+		if err := segment.DropIndex(ctx, indexID); err != nil {
+			return merr.Status(err), nil
+		}
 	}
 
 	return merr.Success(), nil

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/protobuf/proto"
@@ -96,6 +97,27 @@ type ServiceSuite struct {
 
 	// Mock
 	factory *dependency.MockFactory
+}
+
+func TestDropIndexPropagatesSegmentError(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+	segment := segments.NewMockSegment(t)
+	dropErr := merr.SegcoreError(2038, "publication drain canceled")
+
+	segmentManager.EXPECT().GetAndPinBy(mock.Anything).
+		Return([]segments.Segment{segment}, nil).Once()
+	segmentManager.EXPECT().Unpin(mock.Anything).Once()
+	segment.EXPECT().DropIndex(mock.Anything, int64(10)).Return(dropErr).Once()
+
+	node := &QueryNode{
+		manager: &segments.Manager{Segment: segmentManager},
+	}
+	status, err := node.DropIndex(context.Background(), &querypb.DropIndexRequest{
+		SegmentID: 1,
+		IndexIDs:  []int64{10},
+	})
+	require.NoError(t, err)
+	require.ErrorIs(t, merr.Error(status), merr.ErrSegcoreFollyCancel)
 }
 
 func (suite *ServiceSuite) SetupSuite() {

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -183,10 +183,10 @@ func (t *SearchTask) Execute() error {
 		)
 	}
 	defer t.segmentManager.Segment.Unpin(searchedSegments)
+	defer segments.DeleteSearchResults(results)
 	if err != nil {
 		return err
 	}
-	defer segments.DeleteSearchResults(results)
 
 	// In filter-only mode, extract filter statistics and return early.
 	// This supports two-stage search: stage-1 collects per-segment valid

--- a/internal/util/segcore/cgo_util.go
+++ b/internal/util/segcore/cgo_util.go
@@ -30,8 +30,10 @@ import "C"
 import (
 	"math"
 	"reflect"
+	"strings"
 	"unsafe"
 
+	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/internal/util/cgoconverter"
@@ -39,6 +41,17 @@ import (
 )
 
 type CStatus = C.CStatus
+
+const segmentReadGateBusyMessage = "segment read gate busy"
+
+// IsSegmentReadGateBusy reports the narrowly-scoped FollyOtherException used
+// by sealed-segment read admission while an online publisher is draining.
+// FollyOtherException is shared by other async failures, so both the typed
+// code and the stable message marker are required before retrying.
+func IsSegmentReadGateBusy(err error) bool {
+	return errors.Is(err, merr.ErrSegcoreFollyOtherException) &&
+		strings.Contains(err.Error(), segmentReadGateBusyMessage)
+}
 
 // ConsumeCStatusIntoError consumes the CStatus and returns the error
 func ConsumeCStatusIntoError(status *C.CStatus) error {

--- a/internal/util/segcore/cgo_util_test.go
+++ b/internal/util/segcore/cgo_util_test.go
@@ -4,15 +4,26 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/cgopb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func TestConsumeCStatusIntoError(t *testing.T) {
 	err := ConsumeCStatusIntoError(nil)
 	assert.NoError(t, err)
+}
+
+func TestIsSegmentReadGateBusy(t *testing.T) {
+	assert.True(t, IsSegmentReadGateBusy(merr.SegcoreError(
+		2037, "segment read gate busy for segment 100")))
+	assert.False(t, IsSegmentReadGateBusy(merr.SegcoreError(
+		2037, "unrelated folly async failure")))
+	assert.False(t, IsSegmentReadGateBusy(errors.New(
+		"segment read gate busy for segment 100")))
 }
 
 func TestGetLocalUsedSize(t *testing.T) {

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -394,16 +394,39 @@ func (s *cSegmentImpl) Reopen(ctx context.Context, req *ReopenRequest) error {
 }
 
 func (s *cSegmentImpl) DropIndex(ctx context.Context, fieldID int64) error {
-	status := C.DropSealedSegmentIndex(s.ptr, C.int64_t(fieldID))
-	if err := ConsumeCStatusIntoError(&status); err != nil {
+	future := cgo.Async(ctx,
+		func() cgo.CFuturePtr {
+			return (cgo.CFuturePtr)(C.AsyncDropSealedSegmentIndex(
+				s.ptr,
+				C.int64_t(fieldID),
+			))
+		},
+		cgo.WithName("segment-drop-index"),
+	)
+	defer future.Release()
+	_, err := future.BlockAndLeakyGet()
+	if err != nil {
 		return merr.Wrap(err, "failed to drop index")
 	}
 	return nil
 }
 
 func (s *cSegmentImpl) DropJSONIndex(ctx context.Context, fieldID int64, nestedPath string) error {
-	status := C.DropSealedSegmentJSONIndex(s.ptr, C.int64_t(fieldID), C.CString(nestedPath))
-	if err := ConsumeCStatusIntoError(&status); err != nil {
+	cNestedPath := C.CString(nestedPath)
+	defer C.free(unsafe.Pointer(cNestedPath))
+	future := cgo.Async(ctx,
+		func() cgo.CFuturePtr {
+			return (cgo.CFuturePtr)(C.AsyncDropSealedSegmentJSONIndex(
+				s.ptr,
+				C.int64_t(fieldID),
+				cNestedPath,
+			))
+		},
+		cgo.WithName("segment-drop-json-index"),
+	)
+	defer future.Release()
+	_, err := future.BlockAndLeakyGet()
+	if err != nil {
 		return merr.Wrap(err, "failed to drop json index")
 	}
 	return nil


### PR DESCRIPTION
Cherry-pick from master
pr: #51623
Related to #51068

- retain sealed read leases throughout the SearchResult lifecycle
- drain active readers before publishing reopened segment snapshots
- keep growing reads ungated and validate schemas after lease acquisition
- reuse existing leases during reduce, export, and output-field fill
- add concurrency tests, regression coverage, and design documentation