### PR TITLE
fix: retry missing import job on commit ack

### DIFF
--- a/internal/datacoord/ddl_callbacks_import.go
+++ b/internal/datacoord/ddl_callbacks_import.go
@@ -245,8 +245,8 @@ func (c *DDLCallbacks) commitImportV2AckCallback(ctx context.Context, result mes
 
 	job := c.importMeta.GetJob(ctx, jobID)
 	if job == nil {
-		mlog.Warn(ctx, "CommitImport: job not found, skipping", mlog.FieldJobID(jobID))
-		return nil
+		mlog.Info(ctx, "CommitImport: job not found, retry later", mlog.FieldJobID(jobID))
+		return merr.WrapErrImportSysFailedMsg("job %d not found, waiting for import job creation", jobID)
 	}
 	switch job.GetState() {
 	case internalpb.ImportJobState_Uncommitted:

--- a/internal/datacoord/ddl_callbacks_import_test.go
+++ b/internal/datacoord/ddl_callbacks_import_test.go
@@ -969,6 +969,35 @@ func TestCommitImportCallback_BeforeUncommitted_Retry(t *testing.T) {
 	assert.Equal(t, internalpb.ImportJobState_Importing, updatedJob.GetState())
 }
 
+func TestCommitImportCallback_MissingJob_Retry(t *testing.T) {
+	ctx := context.Background()
+	importMeta, _ := newTestImportMeta(t)
+
+	callbacks := &DDLCallbacks{Server: &Server{importMeta: importMeta}}
+	err := callbacks.commitImportV2AckCallback(ctx, buildCommitImportBroadcastResult(13))
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrImportSysFailed))
+	assert.Nil(t, importMeta.GetJob(ctx, 13))
+
+	job := &importJob{
+		ImportJob: &datapb.ImportJob{
+			JobID:      13,
+			State:      internalpb.ImportJobState_Uncommitted,
+			AutoCommit: false,
+		},
+		tr: timerecord.NewTimeRecorder("test"),
+	}
+	err = importMeta.AddJob(ctx, job)
+	assert.NoError(t, err)
+
+	err = callbacks.commitImportV2AckCallback(ctx, buildCommitImportBroadcastResult(13))
+	assert.NoError(t, err)
+
+	updatedJob := importMeta.GetJob(ctx, 13)
+	assert.NotNil(t, updatedJob)
+	assert.Equal(t, internalpb.ImportJobState_Committing, updatedJob.GetState())
+}
+
 func TestCommitImportCallback_RetryAfterUncommitted(t *testing.T) {
 	ctx := context.Background()
 	importMeta, _ := newTestImportMeta(t)


### PR DESCRIPTION
issue: #51721

## What
- Return a retryable `ErrImportSysFailed` when `CommitImport` ACK callback runs before the local import job exists.
- Add a regression test covering missing job -> retry error -> job created as `Uncommitted` -> callback succeeds and moves to `Committing`.

## Why
Returning nil for the missing-job state lets the broadcaster mark the callback done. In a replicated 2PC import flow, the later-created `Uncommitted` job can then be left without a pending `CommitImport` callback, keeping imported data invisible on the secondary.

## Verification
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord -run 'TestCommitImportCallback_(MissingJob_Retry|BeforeUncommitted_Retry|RetryAfterUncommitted|UncommittedToCommitting|AfterAbort_NoOp)|TestRollbackImportCallback_TransitionToFailed|TestImportAckCallbacks_CommitVsAbort_Race'`\n- `make static-check`\n\n## Notes\n- Full `./internal/datacoord` package test was also attempted, but this local environment failed in unrelated test setup while connecting to localhost etcd (`TestGetQueryVChanPositionsRetrieveM2N`).\n