### PR TITLE
test: fix flaky concurrent-close function-runner test under -race

### DIFF
--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -212,9 +212,14 @@ func (s *DelegatorSuite) TestCreateDelegatorWithFunction() {
 
 		initStarted := make(chan struct{})
 		initDone := make(chan struct{})
+		var startedOnce, doneOnce sync.Once
+		// The patch replaces the global builder, so it can be entered more than
+		// once - a schema with several functions, or a re-init of the entry this
+		// mock keeps failing. Signal the first invocation only; closing these
+		// channels per invocation would panic with "close of closed channel".
 		patch := mockey.Mock(function.BuildEmbeddingRunner).To(func(schema *schemapb.CollectionSchema, fn *schemapb.FunctionSchema) (function.FunctionRunner, error) {
-			defer close(initDone)
-			close(initStarted)
+			defer doneOnce.Do(func() { close(initDone) })
+			startedOnce.Do(func() { close(initStarted) })
 			return nil, errors.New("mock runner init failure")
 		}).Build()
 		defer patch.UnPatch()

--- a/internal/util/function/manager_test.go
+++ b/internal/util/function/manager_test.go
@@ -578,11 +578,13 @@ func TestFunctionRunnerManagerReleaseRemovesNotReadyEntry(t *testing.T) {
 	schema := newBM25SignatureTestSchema()
 	started := make(chan struct{})
 	releaseBuild := make(chan struct{})
-	var once sync.Once
 	buildDone := make(chan struct{})
+	var startedOnce, buildDoneOnce sync.Once
 	patchBuildEmbeddingRunner(t, func(schema *schemapb.CollectionSchema, fn *schemapb.FunctionSchema) (FunctionRunner, error) {
-		defer close(buildDone)
-		once.Do(func() {
+		// Signal the first build only: the patched builder is global, so a
+		// second invocation would close an already-closed channel.
+		defer buildDoneOnce.Do(func() { close(buildDone) })
+		startedOnce.Do(func() {
 			close(started)
 		})
 		<-releaseBuild

--- a/internal/util/function/manager_test.go
+++ b/internal/util/function/manager_test.go
@@ -606,21 +606,17 @@ func TestFunctionRunnerManagerReleaseCloseDoesNotBlockManager(t *testing.T) {
 	schema := newBM25SignatureTestSchema()
 	closeStarted := make(chan struct{})
 	releaseClose := make(chan struct{})
-	var buildCount atomic.Int32
 	patchBuildEmbeddingRunner(t, func(schema *schemapb.CollectionSchema, fn *schemapb.FunctionSchema) (FunctionRunner, error) {
-		runner, err := newTestFunctionRunner(schema, fn)
-		if err != nil {
-			return nil, err
-		}
-		if buildCount.Add(1) == 1 {
-			runner.closeStarted = closeStarted
-			runner.releaseClose = releaseClose
-		}
-		return runner, nil
+		return newTestFunctionRunner(schema, fn)
 	})
 
 	require.NoError(t, manager.Alloc(1, "v1", schema))
-	requireRunnerByOutput(t, manager, 1, "v1", 102)
+	// Hook only the installed runner - see the comment in
+	// TestFunctionRunnerManagerRunWithRunnerProtectsConcurrentClose for why this
+	// is bound by instance instead of by build order.
+	runner := requireRunnerByOutput(t, manager, 1, "v1", 102)
+	runner.closeStarted = closeStarted
+	runner.releaseClose = releaseClose
 
 	releaseDone := make(chan struct{})
 	go func() {
@@ -750,14 +746,18 @@ func TestFunctionRunnerManagerRunWithRunnerProtectsConcurrentClose(t *testing.T)
 	schema := newBM25SignatureTestSchema()
 	closeStarted := make(chan struct{})
 	patchBuildEmbeddingRunner(t, func(schema *schemapb.CollectionSchema, fn *schemapb.FunctionSchema) (FunctionRunner, error) {
-		runner, err := newTestFunctionRunner(schema, fn)
-		if err != nil {
-			return nil, err
-		}
-		runner.closeStarted = closeStarted
-		return runner, nil
+		return newTestFunctionRunner(schema, fn)
 	})
 	require.NoError(t, manager.Alloc(1, "v1", schema))
+
+	// Bind the close signal to the runner this test installed, after it is
+	// installed. patchBuildEmbeddingRunner patches the global builder, so wiring
+	// the shared channel inside the builder hands it to every runner built while
+	// the patch is live - including ones a concurrent re-init immediately
+	// discards. Their Close then closes an already-closed channel (the "close of
+	// closed channel" panic this test hit under -race in ci-v2/build-ut-cov) and
+	// reports a close the assertions below are not about.
+	requireRunnerByOutput(t, manager, 1, "v1", 102).closeStarted = closeStarted
 
 	runStarted := make(chan struct{})
 	releaseRun := make(chan struct{})
@@ -808,19 +808,15 @@ func TestFunctionRunnerManagerRunWithRunnerProtectsConcurrentKeyUpdate(t *testin
 	base := newBM25SignatureTestSchema()
 	changedOutput := newSchemaWithChangedOutput(base)
 	closeStarted := make(chan struct{})
-	var buildCount atomic.Int32
 	patchBuildEmbeddingRunner(t, func(schema *schemapb.CollectionSchema, fn *schemapb.FunctionSchema) (FunctionRunner, error) {
-		runner, err := newTestFunctionRunner(schema, fn)
-		if err != nil {
-			return nil, err
-		}
-		if buildCount.Add(1) == 1 {
-			runner.closeStarted = closeStarted
-		}
-		return runner, nil
+		return newTestFunctionRunner(schema, fn)
 	})
 	require.NoError(t, manager.Alloc(1, "v1", base))
+	// Hook only the installed runner - see the comment in
+	// TestFunctionRunnerManagerRunWithRunnerProtectsConcurrentClose for why this
+	// is bound by instance instead of by build order.
 	baseRunner := requireRunnerByOutput(t, manager, 1, "v1", 102)
+	baseRunner.closeStarted = closeStarted
 
 	runStarted := make(chan struct{})
 	releaseRun := make(chan struct{})


### PR DESCRIPTION
issue: #51730

## What

The function-runner concurrency tests wire their `closeStarted` / `releaseClose` signal channels **inside** `patchBuildEmbeddingRunner`'s closure. That closure replaces the *global* `BuildEmbeddingRunner`, so every runner built while the patch is live gets the same channel — not just the one runner the test installs.

`testFunctionRunner.Close` closes that channel guarded only by a **per-instance** `closeOnce`. So when a second runner is built and immediately discarded for the same key (`functionRunnerEntry.init` closing a superseded runner under a concurrent re-init, or a build goroutine that outlived an earlier test and lands on the currently-installed patch), two instances each run their own `closeOnce` and close the shared channel twice → `panic: close of closed channel`. The panic aborts the run and, propagating through the singleflight init goroutine, also trips the race detector on the `mockey` patch — the intermittent red in `ci-v2/build-ut-cov`'s UT-GO stage.

The same sharing has a quieter failure mode: a discarded runner's `Close` can satisfy `<-closeStarted` and trip `require.Fail(t, "runner close started while callback was still running")` for a runner the test never installed.

## Fix

Bind the signal channels to the runner the test **actually installed**, after `Alloc` returns:

```go
require.NoError(t, manager.Alloc(1, "v1", schema))
requireRunnerByOutput(t, manager, 1, "v1", 102).closeStarted = closeStarted
```

Any extra runner built under the same patch is then inert — it has no channel, so it can neither double-close nor report a close the assertions are not about. The two sibling tests (`ReleaseCloseDoesNotBlockManager`, `RunWithRunnerProtectsConcurrentKeyUpdate`) approximated this with a `buildCount.Add(1) == 1` build-order counter, which still binds to whichever build happens to be first rather than to the installed instance; they are switched to the same instance binding.

**Test-only change — no production code is touched.** `functionRunnerEntry.init` already closes both the superseded runner and a runner discarded on a stale `initID`, so the production close path was never the bug.

## Verification

Deterministic red/green, by injecting the extra builder call the flake depends on (one `BuildEmbeddingRunner` + `Close` alongside the installed runner):

| | before | after |
|---|---|---|
| stray runner closed *after* the installed one | `panic: close of closed channel` | ok |
| stray runner closed *before* the run window | `FAIL: runner close started while callback was still running` | ok |

Without the injection:

```
go test -tags dynamic,test -gcflags="all=-N -l" -race -count=20 ./internal/util/function/
ok   github.com/milvus-io/milvus/internal/util/function
```

Whole package, race detector, 20 iterations — no panic, no data race.

## Same trap elsewhere (second commit)

Scanning the repo for the same shape - a channel closed per invocation inside a closure that patches a *global* builder - turned up two more, neither reachable twice on the paths those tests exercise today:

- `TestFunctionRunnerManagerReleaseRemovesNotReadyEntry` - `defer close(buildDone)` runs on every build.
- `internal/querynodev2/delegator` `TestCreateDelegatorWithFunction` - `defer close(initDone)` + `close(initStarted)`, with a mock that always fails the init, so any re-init of that entry would re-enter it.

Both are now `sync.Once`-guarded. Injecting one extra `BuildEmbeddingRunner` call reproduces `panic: close of closed channel` in both before the change and passes after:

```
variant=old        panic: close of closed channel   (internal/util/function)
                   test panicked: close of closed channel (querynodev2/delegator)
variant=hardened   ok  internal/util/function
                   ok  internal/querynodev2/delegator
```

Everything else the scan flagged is already single-shot (`buildCount == 1` / `waitCalls == 1`) or `sync.Once`-guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zJ8JGs3Y5SuUZQ5rGKTzM
