### PR TITLE
fix: advance element filters across zero-element batches

### DIFF
--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -1246,11 +1246,12 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForIndex(
                                int64_t,
                                T>
         HighPrecisionType;
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
     if (!arg_inited_) {
         value_arg_.SetValue<HighPrecisionType>(expr_->value_);
         right_operand_arg_.SetValue<HighPrecisionType>(expr_->right_operand_);
@@ -2002,11 +2003,12 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForData(
                                T>
         HighPrecisionType;
 
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
 
     auto res_vec =
         std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -1366,10 +1366,15 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForIndex(
                                int64_t,
                                T>
         HighPrecisionType;
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = AdvanceEmptyElementBatch(
+            input, expr_->column_.element_level_, real_batch_size)) {
+        return res;
     }
     if (!arg_inited_) {
         value_arg_.SetValue<HighPrecisionType>(expr_->value_);
@@ -2278,10 +2283,15 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForData(
                                T>
         HighPrecisionType;
 
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = AdvanceEmptyElementBatch(
+            input, expr_->column_.element_level_, real_batch_size)) {
+        return res;
     }
 
     auto res_vec =
@@ -3061,7 +3071,7 @@ PhyBinaryArithOpEvalRangeExpr::PrefetchRawData() {
     auto right_value = GetValueWithCastNumber<H>(expr_->right_operand_);
 
     std::vector<int64_t> chunks_may_hit;
-    for (size_t i = 0; i < num_data_chunk_; ++i) {
+    for (size_t i = RawDataPrefetchStartChunk(); i < num_data_chunk_; ++i) {
         auto skip =
             skip_index->CanSkipBinaryArithRange<T>(field_id_,
                                                    i,

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
@@ -802,6 +802,11 @@ class PhyBinaryArithOpEvalRangeExpr : public SegmentExpr {
         return expr_->column_;
     }
 
+    bool
+    IsElementLevelExpression() const override {
+        return expr_->column_.element_level_;
+    }
+
     void
     PrefetchRawData() override;
 

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -346,6 +346,7 @@ PhyBinaryRangeFilterExpr::PreCheckOverflow(HighPrecisionType& val1,
                                            HighPrecisionType& val2,
                                            bool& lower_inclusive,
                                            bool& upper_inclusive,
+                                           int64_t batch_size,
                                            OffsetVector* input) {
     lower_inclusive = expr_->lower_inclusive_;
     upper_inclusive = expr_->upper_inclusive_;
@@ -358,21 +359,19 @@ PhyBinaryRangeFilterExpr::PreCheckOverflow(HighPrecisionType& val1,
     val1 = lower_arg_.GetValue<HighPrecisionType>();
     val2 = upper_arg_.GetValue<HighPrecisionType>();
     auto get_next_overflow_batch =
-        [this](OffsetVector* input) -> ColumnVectorPtr {
-        int64_t batch_size;
-        if (input != nullptr) {
-            batch_size = input->size();
+        [this, batch_size](OffsetVector* input) -> ColumnVectorPtr {
+        TargetBitmap valid_res;
+        if (expr_->column_.element_level_) {
+            valid_res = TargetBitmap(batch_size, true);
+            if (input == nullptr) {
+                MoveCursor();
+            }
         } else {
-            batch_size = overflow_check_pos_ + batch_size_ >= active_count_
-                             ? active_count_ - overflow_check_pos_
-                             : batch_size_;
-            overflow_check_pos_ += batch_size;
+            valid_res = (input != nullptr)
+                            ? ProcessChunksForValidByOffsets<T>(
+                                  UseIndexCursor(), *input)
+                            : ProcessChunksForValid<T>(UseIndexCursor());
         }
-        auto valid_res =
-            (input != nullptr)
-                ? ProcessChunksForValidByOffsets<T>(UseIndexCursor(), *input)
-                : ProcessChunksForValid<T>(UseIndexCursor());
-
         auto res_vec = std::make_shared<ColumnVector>(TargetBitmap(batch_size),
                                                       std::move(valid_res));
         return res_vec;
@@ -413,15 +412,15 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
     HighPrecisionType val2;
     bool lower_inclusive = false;
     bool upper_inclusive = false;
-    if (auto res =
-            PreCheckOverflow<T>(val1, val2, lower_inclusive, upper_inclusive)) {
-        return res;
-    }
-
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(nullptr, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = PreCheckOverflow<T>(
+            val1, val2, lower_inclusive, upper_inclusive, real_batch_size)) {
+        return res;
     }
 
     auto execute_sub_batch = [lower_inclusive, upper_inclusive](
@@ -458,15 +457,19 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
     HighPrecisionType val2;
     bool lower_inclusive = false;
     bool upper_inclusive = false;
-    if (auto res = PreCheckOverflow<T>(
-            val1, val2, lower_inclusive, upper_inclusive, input)) {
-        return res;
-    }
-
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = PreCheckOverflow<T>(val1,
+                                       val2,
+                                       lower_inclusive,
+                                       upper_inclusive,
+                                       real_batch_size,
+                                       input)) {
+        return res;
     }
     auto res_vec =
         std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -352,6 +352,7 @@ PhyBinaryRangeFilterExpr::PreCheckOverflow(HighPrecisionType& val1,
                                            HighPrecisionType& val2,
                                            bool& lower_inclusive,
                                            bool& upper_inclusive,
+                                           int64_t batch_size,
                                            OffsetVector* input) {
     lower_inclusive = expr_->lower_inclusive_;
     upper_inclusive = expr_->upper_inclusive_;
@@ -364,15 +365,9 @@ PhyBinaryRangeFilterExpr::PreCheckOverflow(HighPrecisionType& val1,
     val1 = lower_arg_.GetValue<HighPrecisionType>();
     val2 = upper_arg_.GetValue<HighPrecisionType>();
     auto get_next_overflow_batch =
-        [this](OffsetVector* input) -> ColumnVectorPtr {
+        [this, batch_size](OffsetVector* input) -> ColumnVectorPtr {
         TargetBitmap valid_res;
         if (expr_->column_.element_level_) {
-            // Element batches are derived from the row cursor so
-            // MoveCursor()-based short-circuiting stays aligned.
-            // Individual elements cannot be null; their containing row's
-            // validity is applied by the element consumer.
-            auto batch_size =
-                GetNextRealBatchSize(input, /*element_level=*/true);
             valid_res = TargetBitmap(batch_size, true);
             if (input == nullptr) {
                 MoveCursor();
@@ -383,8 +378,6 @@ PhyBinaryRangeFilterExpr::PreCheckOverflow(HighPrecisionType& val1,
         } else {
             valid_res = ProcessChunksForValid<T>(UseIndexCursor());
         }
-
-        auto batch_size = valid_res.size();
         auto res_vec = std::make_shared<ColumnVector>(TargetBitmap(batch_size),
                                                       std::move(valid_res));
         return res_vec;
@@ -425,15 +418,23 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex(OffsetVector* input) {
     HighPrecisionType val2;
     bool lower_inclusive = false;
     bool upper_inclusive = false;
-    if (auto res = PreCheckOverflow<T>(
-            val1, val2, lower_inclusive, upper_inclusive, input)) {
+    auto next_batch_size =
+        GetNextRealBatchSize(input, expr_->column_.element_level_);
+    if (!next_batch_size.has_value()) {
+        return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = AdvanceEmptyElementBatch(
+            input, expr_->column_.element_level_, real_batch_size)) {
         return res;
     }
-
-    auto real_batch_size =
-        GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
-        return nullptr;
+    if (auto res = PreCheckOverflow<T>(val1,
+                                       val2,
+                                       lower_inclusive,
+                                       upper_inclusive,
+                                       real_batch_size,
+                                       input)) {
+        return res;
     }
 
     auto execute_sub_batch = [lower_inclusive, upper_inclusive](
@@ -493,15 +494,23 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
     HighPrecisionType val2;
     bool lower_inclusive = false;
     bool upper_inclusive = false;
-    if (auto res = PreCheckOverflow<T>(
-            val1, val2, lower_inclusive, upper_inclusive, input)) {
+    auto next_batch_size =
+        GetNextRealBatchSize(input, expr_->column_.element_level_);
+    if (!next_batch_size.has_value()) {
+        return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = AdvanceEmptyElementBatch(
+            input, expr_->column_.element_level_, real_batch_size)) {
         return res;
     }
-
-    auto real_batch_size =
-        GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
-        return nullptr;
+    if (auto res = PreCheckOverflow<T>(val1,
+                                       val2,
+                                       lower_inclusive,
+                                       upper_inclusive,
+                                       real_batch_size,
+                                       input)) {
+        return res;
     }
     auto res_vec =
         std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),
@@ -1333,7 +1342,7 @@ PhyBinaryRangeFilterExpr::PrefetchRawData() {
     auto skip_index = segment_->GetSkipIndex();
 
     std::vector<int64_t> chunks_may_hit;
-    for (size_t i = 0; i < num_data_chunk_; ++i) {
+    for (size_t i = RawDataPrefetchStartChunk(); i < num_data_chunk_; ++i) {
         auto skip = skip_index->CanSkipBinaryRange(field_id_,
                                                    i,
                                                    lower_val,

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -328,6 +328,7 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
                      HighPrecisionType& val2,
                      bool& lower_inclusive,
                      bool& upper_inclusive,
+                     int64_t batch_size,
                      OffsetVector* input = nullptr);
 
     template <typename T>
@@ -370,7 +371,6 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
 
  private:
     std::shared_ptr<const milvus::expr::BinaryRangeFilterExpr> expr_;
-    int64_t overflow_check_pos_{0};
     SingleElement lower_arg_;
     SingleElement upper_arg_;
     bool arg_inited_{false};

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -313,6 +313,11 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
         return expr_->column_;
     }
 
+    bool
+    IsElementLevelExpression() const override {
+        return expr_->column_.element_level_;
+    }
+
  private:
     // Check overflow and cache result for performace
     template <
@@ -328,6 +333,7 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
                      HighPrecisionType& val2,
                      bool& lower_inclusive,
                      bool& upper_inclusive,
+                     int64_t batch_size,
                      OffsetVector* input = nullptr);
 
     template <typename T>

--- a/internal/core/src/exec/expression/BloomFilterExpr.cpp
+++ b/internal/core/src/exec/expression/BloomFilterExpr.cpp
@@ -203,10 +203,11 @@ PhyBloomFilterExpr::ExecVisitorImpl(EvalCtx& context) {
             field_id_.get());
     }
 
-    auto real_batch_size = GetNextRealBatchSize(input, false);
-    if (real_batch_size == 0) {
+    auto next_batch_size = GetNextRealBatchSize(input, false);
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
 
     const auto& bitmap_input = context.get_bitmap_input();
     AssertInfo(bitmap_input.empty() ||
@@ -283,10 +284,11 @@ PhyBloomFilterExpr::ExecVisitorImplForIndex(EvalCtx& context) {
     // per row, so the same execute_sub_batch as the raw-data path works here.
     auto* input = context.get_offset_input();
 
-    auto real_batch_size = GetNextRealBatchSize(input, false);
-    if (real_batch_size == 0) {
+    auto next_batch_size = GetNextRealBatchSize(input, false);
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
 
     auto res_vec =
         std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),
@@ -381,10 +383,11 @@ PhyBloomFilterExpr::ExecVisitorImplJson(EvalCtx& context) {
                   field_id_.get());
     }
 
-    auto real_batch_size = GetNextRealBatchSize(input, false);
-    if (real_batch_size == 0) {
+    auto next_batch_size = GetNextRealBatchSize(input, false);
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
 
     const auto& bitmap_input = context.get_bitmap_input();
     AssertInfo(bitmap_input.empty() ||

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -532,15 +532,28 @@ class SegmentExpr : public Expr {
                    : batch_size_;
     }
 
-    int64_t
+    std::optional<int64_t>
     GetNextRealBatchSize(const OffsetVector* input, bool element_level) {
         if (input != nullptr) {
+            if (input->empty()) {
+                return std::nullopt;
+            }
             return input->size();
         } else if (element_level) {
-            auto [_, elem_count] = GetNextBatchSizeForElementLevel();
+            auto [batch_rows, elem_count] = GetNextBatchSizeForElementLevel();
+            // A non-empty row batch can legitimately contain no logical
+            // elements. Keep 0 distinct from exhaustion so callers still
+            // advance their row cursor for this batch.
+            if (batch_rows == 0) {
+                return std::nullopt;
+            }
             return elem_count;
         }
-        return GetNextBatchSize();
+        auto batch_size = GetNextBatchSize();
+        if (batch_size == 0) {
+            return std::nullopt;
+        }
+        return batch_size;
     }
 
     // Get the next batch size for element-level processing

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -414,27 +414,43 @@ class SegmentExpr : public Expr {
         return true;
     }
 
+    int64_t
+    DataCursorRow(size_t chunk, int64_t chunk_pos) const {
+        return segment_->is_chunked()
+                   ? segment_->num_rows_until_chunk(field_id_, chunk) +
+                         chunk_pos
+                   : static_cast<int64_t>(chunk) * size_per_chunk_ + chunk_pos;
+    }
+
     void
     MoveCursorForDataMultipleChunk() {
         int64_t processed_size = 0;
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
+            const auto active_remaining =
+                active_count_ - DataCursorRow(i, data_pos);
+            if (active_remaining <= 0) {
+                break;
+            }
             // if segment is chunked, type won't be growing
             int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
 
-            size = std::min(size, batch_size_ - processed_size);
+            size = std::min(
+                {size, batch_size_ - processed_size, active_remaining});
+            if (size <= 0) {
+                continue;
+            }
 
             processed_size += size;
+            current_data_chunk_ = i;
+            current_data_chunk_pos_ = data_pos + size;
             if (processed_size >= batch_size_) {
-                current_data_chunk_ = i;
-                current_data_chunk_pos_ = data_pos + size;
-                current_data_global_pos_ =
-                    current_data_global_pos_ + processed_size;
                 break;
             }
-            // }
         }
+        current_data_global_pos_ =
+            DataCursorRow(current_data_chunk_, current_data_chunk_pos_);
     }
     // Non-chunked segments are always Growing (Sealed is always chunked).
     void
@@ -443,22 +459,31 @@ class SegmentExpr : public Expr {
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
+            const auto active_remaining =
+                active_count_ - DataCursorRow(i, data_pos);
+            if (active_remaining <= 0) {
+                break;
+            }
             auto size = (i == (num_data_chunk_ - 1) &&
                          active_count_ % size_per_chunk_ != 0)
                             ? active_count_ % size_per_chunk_ - data_pos
                             : size_per_chunk_ - data_pos;
 
-            size = std::min(size, batch_size_ - processed_size);
+            size = std::min(
+                {size, batch_size_ - processed_size, active_remaining});
+            if (size <= 0) {
+                continue;
+            }
 
             processed_size += size;
+            current_data_chunk_ = i;
+            current_data_chunk_pos_ = data_pos + size;
             if (processed_size >= batch_size_) {
-                current_data_chunk_ = i;
-                current_data_chunk_pos_ = data_pos + size;
-                current_data_global_pos_ =
-                    current_data_global_pos_ + processed_size;
                 break;
             }
         }
+        current_data_global_pos_ =
+            DataCursorRow(current_data_chunk_, current_data_chunk_pos_);
     }
 
     void
@@ -475,8 +500,11 @@ class SegmentExpr : public Expr {
         // The index cursor is a global row position. This holds for sealed
         // segments and for growing segments with a segment-level scalar
         // index (the geometry interim R-Tree, see issue #51237).
-        auto size =
-            std::min(active_count_ - current_index_chunk_pos_, batch_size_);
+        const auto remaining = active_count_ - current_index_chunk_pos_;
+        if (remaining <= 0) {
+            return;
+        }
+        auto size = std::min(remaining, batch_size_);
 
         current_index_chunk_pos_ += size;
     }
@@ -588,8 +616,8 @@ class SegmentExpr : public Expr {
     GetNextBatchSize() {
         EnsureExecPathDetermined();
         if (exec_path_ == ExprExecPath::JsonStats) {
-            return std::min(batch_size_,
-                            active_count_ - current_data_global_pos_);
+            const auto remaining = active_count_ - current_data_global_pos_;
+            return remaining <= 0 ? 0 : std::min(batch_size_, remaining);
         }
         auto current_chunk =
             UseIndexCursor() ? current_index_chunk_ : current_data_chunk_;
@@ -605,20 +633,52 @@ class SegmentExpr : public Expr {
         } else {
             current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
         }
-        return current_rows + batch_size_ >= active_count_
-                   ? active_count_ - current_rows
-                   : batch_size_;
+        const auto remaining = active_count_ - current_rows;
+        return remaining <= 0 ? 0 : std::min(batch_size_, remaining);
     }
 
-    int64_t
+    // nullopt means exhaustion (or an empty offset input). An engaged 0 is a
+    // real, non-empty row batch containing no logical ARRAY elements; positive
+    // values are result counts. Every engaged batch without offset input must
+    // advance its row cursor exactly once, including the engaged-zero case.
+    std::optional<int64_t>
     GetNextRealBatchSize(const OffsetVector* input, bool element_level) {
         if (input != nullptr) {
+            if (input->empty()) {
+                return std::nullopt;
+            }
             return input->size();
         } else if (element_level) {
-            auto [_, elem_count] = GetNextBatchSizeForElementLevel();
+            auto [batch_rows, elem_count] = GetNextBatchSizeForElementLevel();
+            // A non-empty row batch can legitimately contain no logical
+            // elements. Keep 0 distinct from exhaustion so callers still
+            // advance their row cursor for this batch.
+            if (batch_rows <= 0) {
+                return std::nullopt;
+            }
             return elem_count;
         }
-        return GetNextBatchSize();
+        auto batch_size = GetNextBatchSize();
+        if (batch_size <= 0) {
+            return std::nullopt;
+        }
+        return batch_size;
+    }
+
+    VectorPtr
+    AdvanceEmptyElementBatch(const OffsetVector* input,
+                             bool element_level,
+                             int64_t result_count) {
+        if (!element_level || input != nullptr || result_count != 0) {
+            return nullptr;
+        }
+
+        // ArrayOffsets already proved that this row batch has no logical
+        // elements. Do not fetch or inspect ARRAY payloads just to make
+        // progress; nullptr is reserved for expression exhaustion.
+        MoveCursor();
+        return std::make_shared<ColumnVector>(TargetBitmap(0, false),
+                                              TargetBitmap(0, true));
     }
 
     // Get the next batch size for element-level processing
@@ -649,9 +709,11 @@ class SegmentExpr : public Expr {
             current_rows = current_chunk * size_per_chunk_ + current_chunk_pos;
         }
 
-        auto batch_rows = std::min(batch_size_, active_count_ - current_rows);
+        const auto remaining = active_count_ - current_rows;
+        auto batch_rows =
+            remaining <= 0 ? int64_t{0} : std::min(batch_size_, remaining);
 
-        if (batch_rows == 0) {
+        if (batch_rows <= 0) {
             return {0, 0};
         }
 
@@ -1141,6 +1203,13 @@ class SegmentExpr : public Expr {
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
+        if (element_ids->empty()) {
+            return 0;
+        }
+        if (raw_data_prefetch_deferred_) {
+            EnsureRawDataPrefetched();
+        }
+
         auto skip_index = segment_->GetSkipIndex();
         if (segment_->type() == SegmentType::Sealed) {
             auto array_offsets = segment_->GetArrayOffsets(field_id_);
@@ -1389,20 +1458,16 @@ class SegmentExpr : public Expr {
         int64_t processed_rows = 0;
         int64_t processed_elems = 0;
 
-        // Prefetch chunks to reduce cache miss latency
-        if (!prefetched_) {
-            std::vector<int64_t> pf_chunk_ids;
-            pf_chunk_ids.reserve(num_data_chunk_ - current_data_chunk_);
-            for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-                pf_chunk_ids.push_back(i);
-            }
-            segment_->prefetch_chunks(op_ctx_, field_id_, pf_chunk_ids);
-            prefetched_ = true;
-        }
+        EnsureRawDataPrefetched();
 
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
+            const auto row_start = DataCursorRow(i, data_pos);
+            const auto active_remaining = active_count_ - row_start;
+            if (active_remaining <= 0) {
+                break;
+            }
             int64_t size;
             if (segment_->is_chunked()) {
                 size = segment_->chunk_size(field_id_, i) - data_pos;
@@ -1413,7 +1478,8 @@ class SegmentExpr : public Expr {
                                   : active_count_ % size_per_chunk_ - data_pos)
                            : size_per_chunk_ - data_pos;
             }
-            size = std::min(size, batch_size_ - processed_rows);
+            size = std::min(
+                {size, batch_size_ - processed_rows, active_remaining});
             if (size <= 0) {
                 continue;
             }
@@ -1587,11 +1653,6 @@ class SegmentExpr : public Expr {
                 // the logical element address space: nullable rows contribute
                 // zero elements even if storage retains a physical payload.
                 // Derive the skipped span without inspecting that payload.
-                const int64_t row_start =
-                    segment_->is_chunked()
-                        ? segment_->num_rows_until_chunk(field_id_, i) +
-                              data_pos
-                        : static_cast<int64_t>(i) * size_per_chunk_ + data_pos;
                 const auto start_range =
                     array_offsets->ElementIDRangeOfRow(row_start);
                 const auto end_range =
@@ -1611,13 +1672,15 @@ class SegmentExpr : public Expr {
             }
 
             processed_rows += size;
+            current_data_chunk_ = i;
+            current_data_chunk_pos_ = data_pos + size;
             if (processed_rows >= batch_size_) {
-                current_data_chunk_ = i;
-                current_data_chunk_pos_ = data_pos + size;
                 break;
             }
         }
 
+        current_data_global_pos_ =
+            DataCursorRow(current_data_chunk_, current_data_chunk_pos_);
         return processed_elems;
     }
 
@@ -2916,10 +2979,67 @@ class SegmentExpr : public Expr {
             }
             self->EnsureExecPathDetermined();
             if (self->exec_path_ == ExprExecPath::RawData) {
-                self->PrefetchRawData();
-                self->prefetched_ = true;
+                if (self->ShouldPrefetchRawDataEagerly()) {
+                    self->PrefetchRawData();
+                    self->prefetched_ = true;
+                } else {
+                    self->raw_data_prefetch_deferred_ = true;
+                }
             }
         }));
+    }
+
+    bool
+    ShouldPrefetchRawDataEagerly() {
+        if (!IsElementLevelExpression()) {
+            return true;
+        }
+
+        // The prefetch worker can race with compound-expression cursor moves,
+        // so inspect immutable initial-batch geometry rather than live cursor
+        // state. A leading zero-element batch must not touch ARRAY payloads.
+        auto array_offsets = segment_->GetArrayOffsets(field_id_);
+        AssertInfo(array_offsets != nullptr,
+                   "ArrayOffsets not found for field {}",
+                   field_id_.get());
+        const auto initial_rows = std::min(batch_size_, active_count_);
+        const auto elem_start = array_offsets->ElementIDRangeOfRow(0).first;
+        const auto elem_end =
+            array_offsets->ElementIDRangeOfRow(initial_rows).first;
+        return elem_end > elem_start;
+    }
+
+    // RawData prefetch remains eager unless a leaf explicitly opts into the
+    // ARRAY element-batch contract. SegmentExpr subclasses are not required to
+    // implement GetColumnInfo(), so this hook must stay total at the base.
+    virtual bool
+    IsElementLevelExpression() const {
+        return false;
+    }
+
+    size_t
+    ComputeRawDataPrefetchStartChunk() const {
+        auto first_chunk = current_data_chunk_;
+        if (first_chunk >= num_data_chunk_) {
+            return first_chunk;
+        }
+
+        const auto chunk_rows =
+            segment_->is_chunked()
+                ? segment_->chunk_size(field_id_, first_chunk)
+                : (first_chunk == num_data_chunk_ - 1 &&
+                           active_count_ % size_per_chunk_ != 0
+                       ? active_count_ % size_per_chunk_
+                       : size_per_chunk_);
+        if (current_data_chunk_pos_ >= chunk_rows) {
+            ++first_chunk;
+        }
+        return first_chunk;
+    }
+
+    size_t
+    RawDataPrefetchStartChunk() const {
+        return raw_data_prefetch_start_chunk_;
     }
 
     virtual void
@@ -2928,8 +3048,35 @@ class SegmentExpr : public Expr {
     }
 
     void
+    EnsureRawDataPrefetched() {
+        if (prefetched_) {
+            return;
+        }
+
+        // Eval has joined the eager future before reaching raw-data readers.
+        // A deferred element-level prefetch can therefore snapshot the cursor
+        // after any leading zero-element batches and keep SkipIndex pruning in
+        // the expression-specific PrefetchRawData() implementation.
+        raw_data_prefetch_start_chunk_ = ComputeRawDataPrefetchStartChunk();
+        PrefetchRawData();
+        prefetched_ = true;
+        raw_data_prefetch_deferred_ = false;
+    }
+
+    void
     PrefetchRawData(FieldId field_id) {
-        segment_->prefetch_chunks(op_ctx_, field_id);
+        const auto first_chunk = RawDataPrefetchStartChunk();
+        if (first_chunk == 0) {
+            segment_->prefetch_chunks(op_ctx_, field_id);
+            return;
+        }
+
+        std::vector<int64_t> chunk_ids;
+        chunk_ids.reserve(num_data_chunk_ - first_chunk);
+        for (size_t i = first_chunk; i < num_data_chunk_; ++i) {
+            chunk_ids.push_back(i);
+        }
+        segment_->prefetch_chunks(op_ctx_, field_id, chunk_ids);
     }
 
     void
@@ -2978,6 +3125,11 @@ class SegmentExpr : public Expr {
     bool execute_all_at_once_{false};
     // used for reducing cache miss latency in tiered storage
     bool prefetched_{false};
+    // True only when PrefetchAsync() was requested but deliberately deferred
+    // for a leading zero-element batch. A by-offset reader may resume this
+    // request; iterative readers that never requested prefetch stay lazy.
+    bool raw_data_prefetch_deferred_{false};
+    size_t raw_data_prefetch_start_chunk_{0};
     // Scalar index is pinned lazily by EnsurePinnedIndex(). Pre-pin
     // existence checks (HasCompatibleScalarIndex) query segment metadata
     // directly, so expressions on short-circuit paths (TextIndex, PkIndex,

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -414,85 +414,57 @@ class SegmentExpr : public Expr {
         return true;
     }
 
+    // Global row offset of (chunk, chunk_pos) within the segment.
     int64_t
-    DataCursorRow(size_t chunk, int64_t chunk_pos) const {
+    RowOffsetInSegment(size_t chunk, int64_t chunk_pos) const {
         return segment_->is_chunked()
                    ? segment_->num_rows_until_chunk(field_id_, chunk) +
                          chunk_pos
                    : static_cast<int64_t>(chunk) * size_per_chunk_ + chunk_pos;
     }
 
-    void
-    MoveCursorForDataMultipleChunk() {
-        int64_t processed_size = 0;
-        for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-            auto data_pos =
-                (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            const auto active_remaining =
-                active_count_ - DataCursorRow(i, data_pos);
-            if (active_remaining <= 0) {
-                break;
-            }
-            // if segment is chunked, type won't be growing
-            int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
-
-            size = std::min(
-                {size, batch_size_ - processed_size, active_remaining});
-            if (size <= 0) {
-                continue;
-            }
-
-            processed_size += size;
-            current_data_chunk_ = i;
-            current_data_chunk_pos_ = data_pos + size;
-            if (processed_size >= batch_size_) {
-                break;
-            }
+    // Row count of `chunk`. Non-chunked segments are always Growing (Sealed is
+    // always chunked) and use a fixed chunk size, so only the trailing chunk is
+    // partial and is bounded by active_count_. Callers must pass a chunk below
+    // num_data_chunk_.
+    int64_t
+    ChunkRowCount(size_t chunk) const {
+        if (segment_->is_chunked()) {
+            return segment_->chunk_size(field_id_, chunk);
         }
-        current_data_global_pos_ =
-            DataCursorRow(current_data_chunk_, current_data_chunk_pos_);
-    }
-    // Non-chunked segments are always Growing (Sealed is always chunked).
-    void
-    MoveCursorForDataSingleChunk() {
-        int64_t processed_size = 0;
-        for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
-            auto data_pos =
-                (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
-            const auto active_remaining =
-                active_count_ - DataCursorRow(i, data_pos);
-            if (active_remaining <= 0) {
-                break;
-            }
-            auto size = (i == (num_data_chunk_ - 1) &&
-                         active_count_ % size_per_chunk_ != 0)
-                            ? active_count_ % size_per_chunk_ - data_pos
-                            : size_per_chunk_ - data_pos;
-
-            size = std::min(
-                {size, batch_size_ - processed_size, active_remaining});
-            if (size <= 0) {
-                continue;
-            }
-
-            processed_size += size;
-            current_data_chunk_ = i;
-            current_data_chunk_pos_ = data_pos + size;
-            if (processed_size >= batch_size_) {
-                break;
-            }
-        }
-        current_data_global_pos_ =
-            DataCursorRow(current_data_chunk_, current_data_chunk_pos_);
+        return std::min(
+            size_per_chunk_,
+            active_count_ - static_cast<int64_t>(chunk) * size_per_chunk_);
     }
 
     void
     MoveCursorForData() {
-        if (segment_->is_chunked()) {
-            MoveCursorForDataMultipleChunk();
-        } else {
-            MoveCursorForDataSingleChunk();
+        int64_t processed_size = 0;
+        for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
+            auto data_pos =
+                (i == current_data_chunk_) ? current_data_chunk_pos_ : 0;
+            const auto active_remaining =
+                active_count_ - RowOffsetInSegment(i, data_pos);
+            if (active_remaining <= 0) {
+                break;
+            }
+            int64_t size = ChunkRowCount(i) - data_pos;
+
+            size = std::min(
+                {size, batch_size_ - processed_size, active_remaining});
+            if (size <= 0) {
+                continue;
+            }
+
+            processed_size += size;
+            current_data_chunk_ = i;
+            current_data_chunk_pos_ = data_pos + size;
+            if (processed_size >= batch_size_) {
+                break;
+            }
         }
+        current_data_global_pos_ =
+            RowOffsetInSegment(current_data_chunk_, current_data_chunk_pos_);
     }
 
     void
@@ -1463,7 +1435,7 @@ class SegmentExpr : public Expr {
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
-            const auto row_start = DataCursorRow(i, data_pos);
+            const auto row_start = RowOffsetInSegment(i, data_pos);
             const auto active_remaining = active_count_ - row_start;
             if (active_remaining <= 0) {
                 break;
@@ -1680,7 +1652,7 @@ class SegmentExpr : public Expr {
         }
 
         current_data_global_pos_ =
-            DataCursorRow(current_data_chunk_, current_data_chunk_pos_);
+            RowOffsetInSegment(current_data_chunk_, current_data_chunk_pos_);
         return processed_elems;
     }
 
@@ -3024,13 +2996,7 @@ class SegmentExpr : public Expr {
             return first_chunk;
         }
 
-        const auto chunk_rows =
-            segment_->is_chunked()
-                ? segment_->chunk_size(field_id_, first_chunk)
-                : (first_chunk == num_data_chunk_ - 1 &&
-                           active_count_ % size_per_chunk_ != 0
-                       ? active_count_ % size_per_chunk_
-                       : size_per_chunk_);
+        const auto chunk_rows = ChunkRowCount(first_chunk);
         if (current_data_chunk_pos_ >= chunk_rows) {
             ++first_chunk;
         }

--- a/internal/core/src/exec/expression/RoaringFilterExpr.cpp
+++ b/internal/core/src/exec/expression/RoaringFilterExpr.cpp
@@ -153,10 +153,11 @@ PhyRoaringFilterExpr::ExecVisitorImpl(EvalCtx& context) {
 
     const auto& bitmap_input = context.get_bitmap_input();
 
-    auto real_batch_size = GetNextRealBatchSize(input, false);
-    if (real_batch_size == 0) {
+    auto next_batch_size = GetNextRealBatchSize(input, false);
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
     // bitmap_input is indexed by batch-local position below, so a size that
     // disagrees with the batch would silently read past its end.
     AssertInfo(bitmap_input.empty() ||
@@ -240,10 +241,11 @@ PhyRoaringFilterExpr::ExecVisitorImplForIndex(EvalCtx& context) {
     // per row, so the same execute_sub_batch shape as the raw-data path works.
     auto* input = context.get_offset_input();
 
-    auto real_batch_size = GetNextRealBatchSize(input, false);
-    if (real_batch_size == 0) {
+    auto next_batch_size = GetNextRealBatchSize(input, false);
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
 
     auto res_vec =
         std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -923,11 +923,12 @@ PhyTermFilterExpr::ExecVisitorImplForIndex() {
         conditional_t<std::is_same_v<T, std::string_view>, std::string, T>
             IndexInnerType;
     using Index = index::ScalarIndex<IndexInnerType>;
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(nullptr, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
 
     if (!arg_inited_) {
         std::vector<IndexInnerType> vals;
@@ -977,11 +978,12 @@ template <>
 VectorPtr
 PhyTermFilterExpr::ExecVisitorImplForIndex<bool>() {
     using Index = index::ScalarIndex<bool>;
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(nullptr, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
 
     if (!arg_inited_) {
         std::vector<uint8_t> vals;
@@ -1013,11 +1015,12 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
     auto* input = context.get_offset_input();
     const auto& bitmap_input = context.get_bitmap_input();
 
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
     }
+    auto real_batch_size = *next_batch_size;
 
     auto res_vec =
         std::make_shared<ColumnVector>(TargetBitmap(real_batch_size, false),

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -929,10 +929,15 @@ PhyTermFilterExpr::ExecVisitorImplForIndex() {
         conditional_t<std::is_same_v<T, std::string_view>, std::string, T>
             IndexInnerType;
     using Index = index::ScalarIndex<IndexInnerType>;
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(nullptr, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = AdvanceEmptyElementBatch(
+            nullptr, expr_->column_.element_level_, real_batch_size)) {
+        return res;
     }
 
     if (!arg_inited_) {
@@ -983,10 +988,15 @@ template <>
 VectorPtr
 PhyTermFilterExpr::ExecVisitorImplForIndex<bool>() {
     using Index = index::ScalarIndex<bool>;
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(nullptr, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = AdvanceEmptyElementBatch(
+            nullptr, expr_->column_.element_level_, real_batch_size)) {
+        return res;
     }
 
     if (!arg_inited_) {
@@ -1019,10 +1029,15 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
     auto* input = context.get_offset_input();
     const auto& bitmap_input = context.get_bitmap_input();
 
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = AdvanceEmptyElementBatch(
+            input, expr_->column_.element_level_, real_batch_size)) {
+        return res;
     }
 
     auto res_vec =
@@ -1364,7 +1379,7 @@ PhyTermFilterExpr::PrefetchRawData() {
     }
 
     std::vector<int64_t> chunks_may_hit;
-    for (size_t i = 0; i < num_data_chunk_; ++i) {
+    for (size_t i = RawDataPrefetchStartChunk(); i < num_data_chunk_; ++i) {
         auto skip = skip_index->CanSkipInQuery(field_id_, i, elements);
         if (!skip) {
             chunks_may_hit.push_back(i);

--- a/internal/core/src/exec/expression/TermExpr.h
+++ b/internal/core/src/exec/expression/TermExpr.h
@@ -105,6 +105,11 @@ class PhyTermFilterExpr : public SegmentExpr {
         return expr_->column_;
     }
 
+    bool
+    IsElementLevelExpression() const override {
+        return expr_->column_.element_level_;
+    }
+
     void
     PrefetchRawData() override;
 

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1539,13 +1539,12 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForPk(EvalCtx& context) {
         value_arg_.SetValue<IndexInnerType>(expr_->val_);
         arg_inited_ = true;
     }
-    if (auto res = PreCheckOverflow<T>()) {
-        return res;
-    }
-
     auto real_batch_size = GetNextBatchSize();
     if (real_batch_size == 0) {
         return nullptr;
+    }
+    if (auto res = PreCheckOverflow<T>(real_batch_size)) {
+        return res;
     }
 
     if (cached_index_chunk_id_ != 0) {
@@ -1580,14 +1579,14 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
         value_arg_.SetValue<IndexInnerType>(expr_->val_);
         arg_inited_ = true;
     }
-    if (auto res = PreCheckOverflow<T>()) {
-        return res;
-    }
-
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(nullptr, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = PreCheckOverflow<T>(real_batch_size)) {
+        return res;
     }
     auto op_type = expr_->op_type_;
     auto execute_sub_batch = [op_type](Index* index_ptr, IndexInnerType val) {
@@ -1668,24 +1667,24 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
 
 template <typename T>
 ColumnVectorPtr
-PhyUnaryRangeFilterExpr::PreCheckOverflow(OffsetVector* input) {
+PhyUnaryRangeFilterExpr::PreCheckOverflow(int64_t batch_size,
+                                          OffsetVector* input) {
     if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
         auto val = GetValueFromProto<int64_t>(expr_->val_);
 
         if (milvus::query::out_of_range<T>(val)) {
-            int64_t batch_size;
-            if (input != nullptr) {
-                batch_size = input->size();
+            TargetBitmap valid;
+            if (expr_->column_.element_level_) {
+                valid = TargetBitmap(batch_size, true);
+                if (input == nullptr) {
+                    MoveCursor();
+                }
             } else {
-                batch_size = overflow_check_pos_ + batch_size_ >= active_count_
-                                 ? active_count_ - overflow_check_pos_
-                                 : batch_size_;
-                overflow_check_pos_ += batch_size;
+                valid = (input != nullptr)
+                            ? ProcessChunksForValidByOffsets<T>(
+                                  UseIndexCursor(), *input)
+                            : ProcessChunksForValid<T>(UseIndexCursor());
             }
-            auto valid = (input != nullptr)
-                             ? ProcessChunksForValidByOffsets<T>(
-                                   UseIndexCursor(), *input)
-                             : ProcessChunksForValid<T>(UseIndexCursor());
             auto res_vec = std::make_shared<ColumnVector>(
                 TargetBitmap(batch_size), std::move(valid));
             TargetBitmapView res(res_vec->GetRawData(), batch_size);
@@ -1738,14 +1737,14 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
     auto* input = context.get_offset_input();
     const auto& bitmap_input = context.get_bitmap_input();
 
-    if (auto res = PreCheckOverflow<T>(input)) {
-        return res;
-    }
-
-    auto real_batch_size =
+    auto next_batch_size =
         GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
+    if (!next_batch_size.has_value()) {
         return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = PreCheckOverflow<T>(real_batch_size, input)) {
+        return res;
     }
 
     if (!arg_inited_) {

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1559,13 +1559,12 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForPk(EvalCtx& context) {
         value_arg_.SetValue<IndexInnerType>(expr_->val_);
         arg_inited_ = true;
     }
-    if (auto res = PreCheckOverflow<T>()) {
-        return res;
-    }
-
     auto real_batch_size = GetNextBatchSize();
     if (real_batch_size == 0) {
         return nullptr;
+    }
+    if (auto res = PreCheckOverflow<T>(real_batch_size)) {
+        return res;
     }
 
     if (cached_index_chunk_id_ != 0) {
@@ -1600,14 +1599,18 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
         value_arg_.SetValue<IndexInnerType>(expr_->val_);
         arg_inited_ = true;
     }
-    if (auto res = PreCheckOverflow<T>()) {
+    auto next_batch_size =
+        GetNextRealBatchSize(nullptr, expr_->column_.element_level_);
+    if (!next_batch_size.has_value()) {
+        return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = AdvanceEmptyElementBatch(
+            nullptr, expr_->column_.element_level_, real_batch_size)) {
         return res;
     }
-
-    auto real_batch_size =
-        GetNextRealBatchSize(nullptr, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
-        return nullptr;
+    if (auto res = PreCheckOverflow<T>(real_batch_size)) {
+        return res;
     }
     auto op_type = expr_->op_type_;
     auto execute_sub_batch = [op_type](Index* index_ptr, IndexInnerType val) {
@@ -1688,21 +1691,20 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
 
 template <typename T>
 ColumnVectorPtr
-PhyUnaryRangeFilterExpr::PreCheckOverflow(OffsetVector* input) {
+PhyUnaryRangeFilterExpr::PreCheckOverflow(int64_t batch_size,
+                                          OffsetVector* input) {
     if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
         auto val = GetValueFromProto<int64_t>(expr_->val_);
 
         if (milvus::query::out_of_range<T>(val)) {
             auto make_overflow_result =
-                [this, input](bool match_value) -> ColumnVectorPtr {
+                [this, input, batch_size](bool match_value) -> ColumnVectorPtr {
                 TargetBitmap valid;
                 if (expr_->column_.element_level_) {
                     // Element batches are derived from the row cursor so
                     // MoveCursor()-based short-circuiting stays aligned.
                     // Individual elements cannot be null; their containing
                     // row's validity is applied by the element consumer.
-                    auto batch_size =
-                        GetNextRealBatchSize(input, /*element_level=*/true);
                     valid = TargetBitmap(batch_size, true);
                     if (input == nullptr) {
                         MoveCursor();
@@ -1713,8 +1715,6 @@ PhyUnaryRangeFilterExpr::PreCheckOverflow(OffsetVector* input) {
                 } else {
                     valid = ProcessChunksForValid<T>(UseIndexCursor());
                 }
-
-                auto batch_size = valid.size();
                 TargetBitmap res(batch_size, match_value);
                 if (match_value) {
                     res &= valid;
@@ -1763,14 +1763,18 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
     auto* input = context.get_offset_input();
     const auto& bitmap_input = context.get_bitmap_input();
 
-    if (auto res = PreCheckOverflow<T>(input)) {
+    auto next_batch_size =
+        GetNextRealBatchSize(input, expr_->column_.element_level_);
+    if (!next_batch_size.has_value()) {
+        return nullptr;
+    }
+    auto real_batch_size = *next_batch_size;
+    if (auto res = AdvanceEmptyElementBatch(
+            input, expr_->column_.element_level_, real_batch_size)) {
         return res;
     }
-
-    auto real_batch_size =
-        GetNextRealBatchSize(input, expr_->column_.element_level_);
-    if (real_batch_size == 0) {
-        return nullptr;
+    if (auto res = PreCheckOverflow<T>(real_batch_size, input)) {
+        return res;
     }
 
     if (!arg_inited_) {
@@ -2512,7 +2516,7 @@ PhyUnaryRangeFilterExpr::PrefetchRawData() {
     U val = GetValueFromProto<U>(expr_->val_);
 
     std::vector<int64_t> chunks_may_hit;
-    for (size_t i = 0; i < num_data_chunk_; i++) {
+    for (size_t i = RawDataPrefetchStartChunk(); i < num_data_chunk_; i++) {
         if (skip_index->CanSkipUnaryRange<U>(field_id_, i, op_type, val)) {
             continue;
         }

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -1141,7 +1141,7 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
     // Check overflow and cache result for performace
     template <typename T>
     ColumnVectorPtr
-    PreCheckOverflow(OffsetVector* input = nullptr);
+    PreCheckOverflow(int64_t batch_size, OffsetVector* input = nullptr);
 
     template <typename T>
     bool
@@ -1171,7 +1171,6 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
 
  private:
     std::shared_ptr<const milvus::expr::UnaryRangeFilterExpr> expr_;
-    int64_t overflow_check_pos_{0};
     bool arg_inited_{false};
     SingleElement value_arg_;
     PinWrapper<index::NgramInvertedIndex*> pinned_ngram_index_{nullptr};

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -1034,6 +1034,11 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
     }
 
     bool
+    IsElementLevelExpression() const override {
+        return expr_->column_.element_level_;
+    }
+
+    bool
     IsSource() const override {
         return true;
     }
@@ -1136,7 +1141,7 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
     // Check overflow and cache result for performace
     template <typename T>
     ColumnVectorPtr
-    PreCheckOverflow(OffsetVector* input = nullptr);
+    PreCheckOverflow(int64_t batch_size, OffsetVector* input = nullptr);
 
     template <typename T>
     bool

--- a/internal/core/src/segcore/SegmentChunkReaderTest.cpp
+++ b/internal/core/src/segcore/SegmentChunkReaderTest.cpp
@@ -63,7 +63,7 @@ TEST(SegmentChunkReader, StringVariantMismatchIsSystemError) {
 // batch_size the condition stayed true for every remaining row, so the loops ran
 // to the end of the segment and left the cursor on the last row instead of on
 // batch_size. Compare MoveCursorForMultipleChunk (same class) and
-// MoveCursorForDataSingleChunk (exec/expression/Expr.h), which both stop.
+// MoveCursorForData (exec/expression/Expr.h), which both stop.
 TEST(SegmentChunkReader, MoveCursorForSingleChunkStopsAtBatchBoundary) {
     auto schema = std::make_shared<Schema>();
     auto pk = schema->AddDebugField("pk", DataType::INT64);

--- a/internal/core/unittest/test_element_filter.cpp
+++ b/internal/core/unittest/test_element_filter.cpp
@@ -2446,6 +2446,174 @@ TEST_P(ElementFilterEmptyDocHit, ActiveDocsWithZeroElements) {
     ASSERT_EQ(retrieve_results->offset_size(), 0);
 }
 
+TEST_P(ElementFilterEmptyDocHit, FullModeAdvancesPastZeroElementBatches) {
+    struct BatchSizeGuard {
+        int64_t saved_batch_size;
+
+        ~BatchSizeGuard() {
+            EXEC_EVAL_EXPR_BATCH_SIZE.store(saved_batch_size);
+        }
+    } guard{EXEC_EVAL_EXPR_BATCH_SIZE.load()};
+    EXEC_EVAL_EXPR_BATCH_SIZE.store(4);
+
+    bool with_sealed = GetParam();
+    auto schema = std::make_shared<Schema>();
+    auto int_array_fid = schema->AddDebugArrayField(
+        "structA[price_array]", DataType::INT32, true);
+    auto int64_fid = schema->AddDebugField("id", DataType::INT64);
+    schema->set_primary_field_id(int64_fid);
+
+    constexpr size_t kRowCount = 9;
+    constexpr size_t kTargetRow = 8;
+    auto raw_data = DataGen(schema, kRowCount, 42, 0, 1, 1);
+    for (int i = 0; i < raw_data.raw_->fields_data_size(); ++i) {
+        auto* field_data = raw_data.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != int_array_fid.get()) {
+            continue;
+        }
+
+        auto* array_data = field_data->mutable_scalars()->mutable_array_data();
+        // Batch 1 contains NULL arrays with retained physical payloads.
+        for (size_t row = 0; row < 4; ++row) {
+            auto* values = array_data->mutable_data(row)
+                               ->mutable_int_data()
+                               ->mutable_data();
+            values->Clear();
+            values->Add(100 + row);
+        }
+        // Batch 2 contains valid but empty arrays.
+        for (size_t row = 4; row < kTargetRow; ++row) {
+            array_data->mutable_data(row)
+                ->mutable_int_data()
+                ->mutable_data()
+                ->Clear();
+        }
+        auto* target_values = array_data->mutable_data(kTargetRow)
+                                  ->mutable_int_data()
+                                  ->mutable_data();
+        target_values->Clear();
+        target_values->Add(7);
+        target_values->Add(9);
+
+        auto* valid_data = field_data->mutable_valid_data();
+        valid_data->Clear();
+        for (size_t row = 0; row < kTargetRow; ++row) {
+            valid_data->Add(row >= 4);
+        }
+        valid_data->Add(true);
+        break;
+    }
+
+    std::shared_ptr<SegmentInterface> segment;
+    if (with_sealed) {
+        segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+    } else {
+        auto growing = CreateGrowingSegment(schema, empty_index_meta);
+        growing->PreInsert(kRowCount);
+        growing->Insert(0,
+                        kRowCount,
+                        raw_data.row_ids_.data(),
+                        raw_data.timestamps_.data(),
+                        raw_data.raw_);
+        segment = std::move(growing);
+    }
+
+    auto array_offsets = segment->GetArrayOffsets(int_array_fid);
+    ASSERT_NE(array_offsets, nullptr);
+    ASSERT_EQ(array_offsets->GetTotalElementCount(), 2);
+    for (size_t row = 0; row < kTargetRow; ++row) {
+        EXPECT_EQ(array_offsets->ElementIDRangeOfRow(row),
+                  std::make_pair(0, 0));
+    }
+    EXPECT_EQ(array_offsets->ElementIDRangeOfRow(kTargetRow),
+              std::make_pair(0, 2));
+
+    enum class PredicateMode {
+        Normal,
+        UnaryOverflow,
+        BinaryRangeOverflow,
+    };
+    auto run_retrieve = [&](PredicateMode mode) {
+        proto::plan::PlanNode plan_node;
+        auto* query = plan_node.mutable_query();
+        query->set_is_count(false);
+        query->set_limit(100);
+
+        auto* element_filter =
+            query->mutable_predicates()->mutable_element_filter_expr();
+        element_filter->set_struct_name("structA");
+
+        auto* binary =
+            element_filter->mutable_element_expr()->mutable_binary_expr();
+        binary->set_op(mode == PredicateMode::BinaryRangeOverflow
+                           ? proto::plan::BinaryExpr::LogicalOr
+                           : proto::plan::BinaryExpr::LogicalAnd);
+        auto set_element_column = [&](proto::plan::ColumnInfo* column) {
+            column->set_field_id(int_array_fid.get());
+            column->set_data_type(proto::schema::DataType::Int32);
+            column->set_element_type(proto::schema::DataType::Int32);
+            column->set_is_element_level(true);
+        };
+        auto set_element_range = [&](proto::plan::Expr* expr,
+                                     proto::plan::OpType op,
+                                     int64_t value) {
+            auto* range = expr->mutable_unary_range_expr();
+            set_element_column(range->mutable_column_info());
+            range->set_op(op);
+            range->mutable_value()->set_int64_val(value);
+        };
+        if (mode == PredicateMode::BinaryRangeOverflow) {
+            auto* range = binary->mutable_left()->mutable_binary_range_expr();
+            set_element_column(range->mutable_column_info());
+            range->set_lower_inclusive(true);
+            range->set_upper_inclusive(true);
+            range->mutable_lower_value()->set_int64_val(2147483648LL);
+            range->mutable_upper_value()->set_int64_val(2147483649LL);
+        } else {
+            auto lower_bound =
+                mode == PredicateMode::UnaryOverflow ? -2147483649LL : 0LL;
+            set_element_range(binary->mutable_left(),
+                              proto::plan::OpType::GreaterEqual,
+                              lower_bound);
+        }
+        set_element_range(
+            binary->mutable_right(), proto::plan::OpType::Equal, 9);
+
+        plan_node.add_output_field_ids(int64_fid.get());
+        plan_node.add_output_field_ids(int_array_fid.get());
+
+        auto parser = ProtoParser(schema);
+        auto plan = parser.CreateRetrievePlan(plan_node);
+        return segment->Retrieve(nullptr,
+                                 plan.get(),
+                                 1L << 63,
+                                 INT64_MAX,
+                                 false,
+                                 folly::CancellationToken(),
+                                 0,
+                                 0);
+    };
+
+    auto assert_target_element = [&](const auto& retrieve_results) {
+        ASSERT_NE(retrieve_results, nullptr);
+        ASSERT_TRUE(retrieve_results->element_level());
+        ASSERT_EQ(retrieve_results->offset_size(), 1);
+        EXPECT_EQ(retrieve_results->offset(0), kTargetRow);
+        ASSERT_EQ(retrieve_results->element_indices(0).indices_size(), 1);
+        EXPECT_EQ(retrieve_results->element_indices(0).indices(0), 1);
+    };
+
+    std::unique_ptr<proto::segcore::RetrieveResults> retrieve_results;
+    for (auto mode : {PredicateMode::Normal,
+                      PredicateMode::UnaryOverflow,
+                      PredicateMode::BinaryRangeOverflow}) {
+        // The overflow fast paths must use element counts and the same
+        // row-batch cursor contract as normal visitors.
+        ASSERT_NO_THROW(retrieve_results = run_retrieve(mode));
+        assert_target_element(retrieve_results);
+    }
+}
+
 TEST(ElementFilter, GrowingNullableArrayTailChunkUsesActiveRows) {
     auto schema = std::make_shared<Schema>();
     auto int_array_fid = schema->AddDebugArrayField(

--- a/internal/core/unittest/test_element_filter.cpp
+++ b/internal/core/unittest/test_element_filter.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <folly/FBVector.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <gtest/gtest.h>
 #include <stddef.h>
 #include <cstdint>
@@ -34,6 +35,8 @@
 #include "common/Types.h"
 #include "common/VectorTrait.h"
 #include "common/protobuf_utils.h"
+#include "exec/expression/ExprBatchTestUtils.h"
+#include "exec/expression/UnaryExpr.h"
 #include "gtest/gtest.h"
 #include "index/Index.h"
 #include "index/Meta.h"
@@ -2371,11 +2374,13 @@ INSTANTIATE_TEST_SUITE_P(ElementFilter,
                              return info.param ? "Sealed" : "Growing";
                          });
 
+class ElementFilterZeroElementBatch : public ::testing::TestWithParam<bool> {};
+
 // Element-level filters can legitimately produce a zero-length element bitmap
 // even when the segment has active rows: every active document may have an
 // empty/null struct array. ExecPlanNodeVisitor must still treat that bitmap as
 // element-level instead of comparing it with the row count.
-TEST_P(ElementFilterEmptyDocHit, ActiveDocsWithZeroElements) {
+TEST_P(ElementFilterZeroElementBatch, ActiveDocsWithZeroElements) {
     bool with_sealed = GetParam();
 
     int dim = 4;
@@ -2446,6 +2451,407 @@ TEST_P(ElementFilterEmptyDocHit, ActiveDocsWithZeroElements) {
     ASSERT_NE(retrieve_results, nullptr);
     ASSERT_EQ(retrieve_results->offset_size(), 0);
 }
+
+TEST_P(ElementFilterZeroElementBatch, FullModeAdvancesPastZeroElementBatches) {
+    milvus::test::ExprBatchSizeGuard batch_size_guard(4);
+
+    bool with_sealed = GetParam();
+    auto schema = std::make_shared<Schema>();
+    auto int_array_fid = schema->AddDebugArrayField(
+        "structA[price_array]", DataType::INT32, true);
+    auto int64_fid = schema->AddDebugField("id", DataType::INT64);
+    schema->set_primary_field_id(int64_fid);
+
+    constexpr size_t kRowCount = 9;
+    constexpr size_t kTargetRow = 8;
+    auto raw_data = DataGen(schema, kRowCount, 42, 0, 1, 1);
+    for (int i = 0; i < raw_data.raw_->fields_data_size(); ++i) {
+        auto* field_data = raw_data.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != int_array_fid.get()) {
+            continue;
+        }
+
+        auto* array_data = field_data->mutable_scalars()->mutable_array_data();
+        // Batch 1 contains NULL arrays with retained physical payloads.
+        for (size_t row = 0; row < 4; ++row) {
+            auto* values = array_data->mutable_data(row)
+                               ->mutable_int_data()
+                               ->mutable_data();
+            values->Clear();
+            values->Add(100 + row);
+        }
+        // Batch 2 contains valid but empty arrays.
+        for (size_t row = 4; row < kTargetRow; ++row) {
+            array_data->mutable_data(row)
+                ->mutable_int_data()
+                ->mutable_data()
+                ->Clear();
+        }
+        auto* target_values = array_data->mutable_data(kTargetRow)
+                                  ->mutable_int_data()
+                                  ->mutable_data();
+        target_values->Clear();
+        target_values->Add(7);
+        target_values->Add(9);
+
+        auto* valid_data = MutableFieldDataRowValidData(field_data);
+        valid_data->Clear();
+        for (size_t row = 0; row < kTargetRow; ++row) {
+            valid_data->Add(row >= 4);
+        }
+        valid_data->Add(true);
+        break;
+    }
+
+    std::shared_ptr<SegmentInterface> segment;
+    if (with_sealed) {
+        segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+    } else {
+        SegcoreConfig config;
+        config.set_chunk_rows(4);
+        auto growing =
+            CreateGrowingSegment(schema, empty_index_meta, 1, config);
+        growing->PreInsert(kRowCount);
+        growing->Insert(0,
+                        kRowCount,
+                        raw_data.row_ids_.data(),
+                        raw_data.timestamps_.data(),
+                        raw_data.raw_);
+        segment = std::move(growing);
+    }
+    auto* internal_segment =
+        dynamic_cast<SegmentInternalInterface*>(segment.get());
+    ASSERT_NE(internal_segment, nullptr);
+
+    auto array_offsets = segment->GetArrayOffsets(int_array_fid);
+    ASSERT_NE(array_offsets, nullptr);
+    ASSERT_EQ(array_offsets->GetTotalElementCount(), 2);
+    for (size_t row = 0; row < kTargetRow; ++row) {
+        EXPECT_EQ(array_offsets->ElementIDRangeOfRow(row),
+                  std::make_pair(0, 0));
+    }
+    EXPECT_EQ(array_offsets->ElementIDRangeOfRow(kTargetRow),
+              std::make_pair(0, 2));
+
+    enum class PredicateMode {
+        UnaryRange,
+        UnaryOverflow,
+        BinaryRange,
+        BinaryRangeOverflow,
+        Term,
+        BinaryArithmetic,
+    };
+    auto run_retrieve = [&](PredicateMode mode) {
+        proto::plan::PlanNode plan_node;
+        auto* query = plan_node.mutable_query();
+        query->set_is_count(false);
+        query->set_limit(100);
+
+        auto* element_filter =
+            query->mutable_predicates()->mutable_element_filter_expr();
+        element_filter->set_struct_name("structA");
+
+        auto* binary =
+            element_filter->mutable_element_expr()->mutable_binary_expr();
+        binary->set_op(mode == PredicateMode::BinaryRangeOverflow
+                           ? proto::plan::BinaryExpr::LogicalOr
+                           : proto::plan::BinaryExpr::LogicalAnd);
+        auto set_element_column = [&](proto::plan::ColumnInfo* column) {
+            column->set_field_id(int_array_fid.get());
+            column->set_data_type(proto::schema::DataType::Int32);
+            column->set_element_type(proto::schema::DataType::Int32);
+            column->set_is_element_level(true);
+        };
+        auto set_element_range = [&](proto::plan::Expr* expr,
+                                     proto::plan::OpType op,
+                                     int64_t value) {
+            auto* range = expr->mutable_unary_range_expr();
+            set_element_column(range->mutable_column_info());
+            range->set_op(op);
+            range->mutable_value()->set_int64_val(value);
+        };
+        switch (mode) {
+            case PredicateMode::BinaryRange:
+            case PredicateMode::BinaryRangeOverflow: {
+                auto* range =
+                    binary->mutable_left()->mutable_binary_range_expr();
+                set_element_column(range->mutable_column_info());
+                range->set_lower_inclusive(true);
+                range->set_upper_inclusive(true);
+                range->mutable_lower_value()->set_int64_val(
+                    mode == PredicateMode::BinaryRangeOverflow ? 2147483648LL
+                                                               : 0LL);
+                range->mutable_upper_value()->set_int64_val(
+                    mode == PredicateMode::BinaryRangeOverflow ? 2147483649LL
+                                                               : 10LL);
+                break;
+            }
+            case PredicateMode::Term: {
+                auto* term = binary->mutable_left()->mutable_term_expr();
+                set_element_column(term->mutable_column_info());
+                term->add_values()->set_int64_val(7);
+                term->add_values()->set_int64_val(9);
+                break;
+            }
+            case PredicateMode::BinaryArithmetic: {
+                auto* arith = binary->mutable_left()
+                                  ->mutable_binary_arith_op_eval_range_expr();
+                set_element_column(arith->mutable_column_info());
+                arith->set_arith_op(proto::plan::ArithOpType::Add);
+                arith->mutable_right_operand()->set_int64_val(0);
+                arith->set_op(proto::plan::OpType::GreaterEqual);
+                arith->mutable_value()->set_int64_val(0);
+                break;
+            }
+            case PredicateMode::UnaryRange:
+            case PredicateMode::UnaryOverflow: {
+                auto lower_bound =
+                    mode == PredicateMode::UnaryOverflow ? -2147483649LL : 0LL;
+                set_element_range(binary->mutable_left(),
+                                  proto::plan::OpType::GreaterEqual,
+                                  lower_bound);
+                break;
+            }
+        }
+        set_element_range(
+            binary->mutable_right(), proto::plan::OpType::Equal, 9);
+
+        plan_node.add_output_field_ids(int64_fid.get());
+        plan_node.add_output_field_ids(int_array_fid.get());
+
+        auto parser = ProtoParser(schema);
+        auto plan = parser.CreateRetrievePlan(plan_node);
+        return segment->Retrieve(nullptr,
+                                 plan.get(),
+                                 1L << 63,
+                                 INT64_MAX,
+                                 false,
+                                 folly::CancellationToken(),
+                                 0,
+                                 0);
+    };
+
+    auto assert_target_element = [&](const auto& retrieve_results) {
+        ASSERT_NE(retrieve_results, nullptr);
+        ASSERT_TRUE(retrieve_results->element_level());
+        ASSERT_EQ(retrieve_results->offset_size(), 1);
+        EXPECT_EQ(retrieve_results->offset(0), kTargetRow);
+        ASSERT_EQ(retrieve_results->element_indices(0).indices_size(), 1);
+        EXPECT_EQ(retrieve_results->element_indices(0).indices(0), 1);
+    };
+
+    std::unique_ptr<proto::segcore::RetrieveResults> retrieve_results;
+    auto run_all_modes = [&] {
+        for (auto mode : {PredicateMode::UnaryRange,
+                          PredicateMode::UnaryOverflow,
+                          PredicateMode::BinaryRange,
+                          PredicateMode::BinaryRangeOverflow,
+                          PredicateMode::Term,
+                          PredicateMode::BinaryArithmetic}) {
+            // Every visitor family and both overflow fast paths must keep the
+            // child expressions aligned across zero-element batches.
+            ASSERT_NO_THROW(retrieve_results = run_retrieve(mode));
+            assert_target_element(retrieve_results);
+        }
+    };
+    run_all_modes();
+
+    class CountingPrefetchUnaryExpr final
+        : public exec::PhyUnaryRangeFilterExpr {
+     public:
+        using exec::PhyUnaryRangeFilterExpr::PhyUnaryRangeFilterExpr;
+
+        int
+        prefetch_count() const {
+            return prefetch_count_;
+        }
+
+        size_t
+        prefetch_start_chunk() const {
+            return prefetch_start_chunk_;
+        }
+
+     private:
+        void
+        PrefetchRawData() override {
+            prefetch_start_chunk_ = RawDataPrefetchStartChunk();
+            ++prefetch_count_;
+        }
+
+        int prefetch_count_{0};
+        size_t prefetch_start_chunk_{0};
+    };
+
+    auto assert_leaf_batches_to_eof = [&](bool expect_nested_index) {
+        auto column =
+            expr::ColumnInfo(int_array_fid, DataType::ARRAY, DataType::INT32);
+        column.element_level_ = true;
+        proto::plan::GenericValue lower_bound;
+        lower_bound.set_int64_val(0);
+        auto logical = std::make_shared<expr::UnaryRangeFilterExpr>(
+            column, proto::plan::OpType::GreaterEqual, lower_bound);
+        auto make_physical = [&](const std::string& name,
+                                 int64_t active_count) {
+            return std::make_shared<CountingPrefetchUnaryExpr>(
+                std::vector<exec::ExprPtr>{},
+                logical,
+                name,
+                nullptr,
+                internal_segment,
+                active_count,
+                4,
+                0);
+        };
+        auto physical = make_physical("CountingPrefetchUnaryExpr", kRowCount);
+
+        auto prefetch_pool = std::make_shared<folly::CPUThreadPoolExecutor>(1);
+        physical->PrefetchAsync(prefetch_pool);
+        physical->WaitPrefetch();
+        EXPECT_EQ(physical->prefetch_count(), 0);
+        EXPECT_EQ(physical->CanUseNestedIndex(), expect_nested_index);
+
+        auto query_context = std::make_shared<exec::QueryContext>(
+            DEAFULT_QUERY_ID, internal_segment, kRowCount, MAX_TIMESTAMP);
+        exec::ExecContext exec_context(query_context.get());
+        exec::OffsetVector empty_offsets;
+        exec::EvalCtx empty_offset_context(&exec_context, &empty_offsets);
+        VectorPtr result;
+        physical->Eval(empty_offset_context, result);
+        EXPECT_EQ(result, nullptr);
+        EXPECT_EQ(physical->prefetch_count(), 0);
+
+        // An empty offset input is exhaustion for that invocation only; it
+        // must neither touch payload nor advance the full-mode row cursor.
+        exec::EvalCtx eval_context(&exec_context);
+        for (auto expected_size : {0, 0, 2}) {
+            physical->Eval(eval_context, result);
+            auto column_result =
+                std::dynamic_pointer_cast<ColumnVector>(result);
+            ASSERT_NE(column_result, nullptr);
+            EXPECT_EQ(column_result->size(), expected_size);
+        }
+        EXPECT_EQ(physical->prefetch_count(), expect_nested_index ? 0 : 1);
+        if (!expect_nested_index) {
+            const auto [target_chunk, _] =
+                internal_segment->get_chunk_by_offset(int_array_fid,
+                                                      kTargetRow);
+            EXPECT_EQ(physical->prefetch_start_chunk(), target_chunk);
+        }
+
+        physical->Eval(eval_context, result);
+        EXPECT_EQ(result, nullptr);
+
+        if (!expect_nested_index) {
+            exec::OffsetVector element_offsets;
+            element_offsets.emplace_back(0);
+            element_offsets.emplace_back(1);
+
+            auto deferred_offset_physical = make_physical(
+                "DeferredOffsetCountingPrefetchUnaryExpr", kRowCount);
+            deferred_offset_physical->PrefetchAsync(prefetch_pool);
+            deferred_offset_physical->WaitPrefetch();
+            EXPECT_EQ(deferred_offset_physical->prefetch_count(), 0);
+            exec::EvalCtx deferred_offset_context(&exec_context,
+                                                  &element_offsets);
+            deferred_offset_physical->Eval(deferred_offset_context, result);
+            auto offset_column =
+                std::dynamic_pointer_cast<ColumnVector>(result);
+            ASSERT_NE(offset_column, nullptr);
+            EXPECT_EQ(offset_column->size(), element_offsets.size());
+            EXPECT_EQ(deferred_offset_physical->prefetch_count(), 1);
+
+            auto iterative_offset_physical = make_physical(
+                "IterativeOffsetCountingPrefetchUnaryExpr", kRowCount);
+            exec::EvalCtx iterative_offset_context(&exec_context,
+                                                   &element_offsets);
+            iterative_offset_physical->Eval(iterative_offset_context, result);
+            offset_column = std::dynamic_pointer_cast<ColumnVector>(result);
+            ASSERT_NE(offset_column, nullptr);
+            EXPECT_EQ(offset_column->size(), element_offsets.size());
+            EXPECT_EQ(iterative_offset_physical->prefetch_count(), 0);
+        }
+
+        constexpr int64_t kZeroTailRowCount = 7;
+        auto zero_tail_physical = make_physical(
+            "ZeroTailCountingPrefetchUnaryExpr", kZeroTailRowCount);
+        zero_tail_physical->PrefetchAsync(prefetch_pool);
+        zero_tail_physical->WaitPrefetch();
+        auto zero_tail_query_context =
+            std::make_shared<exec::QueryContext>(DEAFULT_QUERY_ID,
+                                                 internal_segment,
+                                                 kZeroTailRowCount,
+                                                 MAX_TIMESTAMP);
+        exec::ExecContext zero_tail_exec_context(zero_tail_query_context.get());
+        exec::EvalCtx zero_tail_eval_context(&zero_tail_exec_context);
+        for (auto expected_size : {0, 0}) {
+            zero_tail_physical->Eval(zero_tail_eval_context, result);
+            auto column_result =
+                std::dynamic_pointer_cast<ColumnVector>(result);
+            ASSERT_NE(column_result, nullptr);
+            EXPECT_EQ(column_result->size(), expected_size);
+        }
+        EXPECT_EQ(zero_tail_physical->prefetch_count(), 0);
+        zero_tail_physical->Eval(zero_tail_eval_context, result);
+        EXPECT_EQ(result, nullptr);
+
+        auto skipped_batch_physical =
+            make_physical("SkippedBatchCountingPrefetchUnaryExpr", kRowCount);
+        skipped_batch_physical->PrefetchAsync(prefetch_pool);
+        skipped_batch_physical->WaitPrefetch();
+        auto skipped_query_context = std::make_shared<exec::QueryContext>(
+            DEAFULT_QUERY_ID, internal_segment, kRowCount, MAX_TIMESTAMP);
+        exec::ExecContext skipped_exec_context(skipped_query_context.get());
+        exec::EvalCtx skipped_eval_context(&skipped_exec_context);
+
+        skipped_batch_physical->Eval(skipped_eval_context, result);
+        auto skipped_column = std::dynamic_pointer_cast<ColumnVector>(result);
+        ASSERT_NE(skipped_column, nullptr);
+        EXPECT_EQ(skipped_column->size(), 0);
+        skipped_batch_physical->MoveCursor();
+        skipped_batch_physical->Eval(skipped_eval_context, result);
+        skipped_column = std::dynamic_pointer_cast<ColumnVector>(result);
+        ASSERT_NE(skipped_column, nullptr);
+        EXPECT_EQ(skipped_column->size(), 2);
+        EXPECT_EQ(skipped_batch_physical->prefetch_count(),
+                  expect_nested_index ? 0 : 1);
+        skipped_batch_physical->Eval(skipped_eval_context, result);
+        EXPECT_EQ(result, nullptr);
+    };
+    assert_leaf_batches_to_eof(false);
+
+    if (with_sealed) {
+        std::vector<int32_t> indexed_elements = {7, 9};
+        auto nested_index =
+            std::make_unique<milvus::index::ScalarIndexSort<int32_t>>(
+                storage::FileManagerContext(), true /* is_nested */);
+        nested_index->Build(
+            indexed_elements.size(), indexed_elements.data(), nullptr);
+
+        LoadIndexInfo load_info;
+        load_info.field_id = int_array_fid.get();
+        load_info.field_type = DataType::ARRAY;
+        load_info.element_type = DataType::INT32;
+        load_info.index_params["index_type"] = milvus::index::ASCENDING_SORT;
+        load_info.cache_index = CreateTestCacheIndex("zero_element_nested",
+                                                     std::move(nested_index));
+        auto* sealed_segment = dynamic_cast<SegmentSealed*>(segment.get());
+        ASSERT_NE(sealed_segment, nullptr);
+        sealed_segment->LoadIndex(load_info);
+
+        // Re-run the compound cases after the nested index is present. Binary
+        // arithmetic remains a raw fallback, so this also covers mixed
+        // raw/index children sharing the same zero-element cursor contract.
+        run_all_modes();
+        assert_leaf_batches_to_eof(true);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(ElementFilter,
+                         ElementFilterZeroElementBatch,
+                         ::testing::Values(true, false),
+                         [](const ::testing::TestParamInfo<bool>& info) {
+                             return info.param ? "Sealed" : "Growing";
+                         });
 
 TEST(ElementFilter, GrowingNullableArrayTailChunkUsesActiveRows) {
     auto schema = std::make_shared<Schema>();


### PR DESCRIPTION
issue: #51736

Follow-up to #51540.

Found during review of #51717: https://github.com/milvus-io/milvus/pull/51717#discussion_r3632208484

## What changed

- Make `GetNextRealBatchSize()` distinguish true exhaustion from a non-empty row batch containing zero logical ARRAY elements.
- Let unary range, binary range, term, and binary arithmetic element visitors return a valid zero-length bitmap and advance exactly one row batch.
- Make unary and binary-range integer-overflow fast paths use element counts and the same cursor contract.
- Add sealed and growing regressions with one full NULL-array batch, one full valid-empty-array batch, and later matching elements. Compound AND/OR predicates verify skipped children stay aligned.

## Why

A complete row batch can contain rows but contribute zero logical elements. Treating its element count of zero as EOF returns `nullptr` before the row cursor advances. Full-mode `ElementFilterBitsNode` still has later segment elements to evaluate and fails its non-null expression-result assertion.

The fix preserves one evaluation per row batch: zero-element batches produce zero-length results instead of being collapsed inside a leaf, so compound-expression cursor movement remains synchronized.

## Scope

This fixes the batch contract for the scalar element visitors that use `GetNextRealBatchSize()` (unary range, binary range, term, and binary arithmetic). Other element-expression families are unchanged.

## Verification

- `git diff --check upstream/master...HEAD` — passed.
- `clang-format-15 --dry-run --Werror` on all changed C++ files — passed.
- Audited all 9 production callers of `GetNextRealBatchSize()` and both integer-overflow fast paths.
- Added deterministic sealed/growing regression coverage for two consecutive zero-element row batches, compound cursor alignment, and unary/binary-range overflow paths.
- Local full C++ build was not completed because the macOS arm64 Conan profile has no compatible binaries and would rebuild the full third-party dependency graph; target-branch CI is pending for compile and test execution.
