### PR TITLE
fix: reject unsupported ARRAY-backed field comparisons

### DIFF
--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/function/rerank"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -2640,6 +2641,8 @@ func Test_ArrayExpr(t *testing.T) {
 
 	exprs := []string{
 		`ArrayField == [1,2,3,4]`,
+		`ArrayField != [1,2,3,4]`,
+		`[1,2,3,4] == ArrayField`,
 		`ArrayField[0] == 1`,
 		`ArrayField[0] > 1`,
 		`1 < ArrayField[0] < 3`,
@@ -2678,6 +2681,25 @@ func Test_ArrayExpr(t *testing.T) {
 			RoundDecimal: 0,
 		}, nil, nil)
 		assert.NoError(t, err, expr)
+	}
+
+	unsupportedFieldComparisons := []string{
+		`ArrayField == ArrayField`,
+		`ArrayField != ArrayField`,
+		`ArrayField == Int64Field`,
+		`Int64Field != ArrayField`,
+		`ArrayField[0] == Int64Field`,
+		`ArrayField[0] < Int64Field`,
+	}
+	for _, expr = range unsupportedFieldComparisons {
+		_, err = CreateSearchPlan(schema, expr, "FloatVectorField", &planpb.QueryInfo{
+			Topk:         0,
+			MetricType:   "",
+			SearchParams: "",
+			RoundDecimal: 0,
+		}, nil, nil)
+		require.ErrorIs(t, err, merr.ErrQueryPlan, expr)
+		assert.Contains(t, err.Error(), "field-to-field comparison involving ARRAY fields is not supported", expr)
 	}
 
 	invalidExprs := []string{

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -444,6 +444,13 @@ func handleCompare(op planpb.OpType, left *ExprWithType, right *ExprWithType) (*
 		return nil, merr.WrapErrQueryPlanMsg("only comparison between two fields is supported")
 	}
 
+	// CompareExpr only carries field IDs and storage data types. It cannot
+	// represent an element path for an ARRAY-backed column, and the executor
+	// does not support ARRAY as an operand type.
+	if typeutil.IsArrayType(leftColumnInfo.GetDataType()) || typeutil.IsArrayType(rightColumnInfo.GetDataType()) {
+		return nil, merr.WrapErrQueryPlanMsg("field-to-field comparison involving ARRAY fields is not supported")
+	}
+
 	// Check if both left and right are non-JSON types
 	if typeutil.IsJSONType(leftColumnInfo.GetDataType()) || typeutil.IsJSONType(rightColumnInfo.GetDataType()) {
 		return nil, merr.WrapErrQueryPlanMsg("two column comparison with JSON type is not supported")


### PR DESCRIPTION
issue: #51741
related: #51389

## What

- Reject field-to-field comparisons when either operand is backed by an ARRAY field before constructing `CompareExpr`.
- Return an `ErrQueryPlan` input error instead of allowing the unsupported plan to fail later in QueryNode.
- Keep ARRAY-to-literal and ARRAY-element-to-literal comparisons unchanged.
- Add regression coverage for full ARRAY operands, ARRAY element paths, both operand positions, equality/inequality/relational operators, and the preserved literal forms.

## Why

`planparserv2` currently accepts these expressions because their scalar or element types are comparable. However, `CompareExpr` only carries field IDs and storage data types: it does not carry an ARRAY element path, and the C++ executor has no `DataType::ARRAY` operand path. As a result, the request passes planning and fails later with an internal segcore error.

This is a pre-existing parser/executor contract gap. #51389 only preserves the downstream error code; it does not introduce the unsupported expression. Rejecting the request at plan construction keeps that error-propagation change from exposing this planner bug as a newly visible system error.

## Preserved behavior

These forms remain valid:

```text
ArrayField == [1, 2, 3, 4]
[1, 2, 3, 4] == ArrayField
ArrayField != [1, 2, 3, 4]
ArrayField[0] == 1
```

## Verification

```text
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2/...
```

The full `planparserv2` package suite passes locally. No live Milvus e2e run was performed for this parser-only change.
