### PR TITLE
enhance: [cp3.0] lock-free readers for ArrayOffsetsGrowing via chunked storage

### DIFF
--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -35,6 +35,36 @@
 
 namespace milvus {
 
+namespace {
+
+// Lock-free random-access reader over the chunk directory. Callers only hand
+// it logical indices covered by an acquire-loaded committed watermark.
+template <typename T>
+class ChunkedReader {
+ public:
+    using Directory = oneapi::tbb::concurrent_vector<std::unique_ptr<T[]>>;
+
+    explicit ChunkedReader(const Directory& dir) : dir_(dir) {
+    }
+
+    T
+    operator[](int64_t idx) const {
+        const int64_t chunk_id = idx >> ArrayOffsetsGrowing::kChunkBits;
+        if (chunk_id != cached_chunk_id_) {
+            cached_chunk_id_ = chunk_id;
+            cached_chunk_ = dir_[static_cast<size_t>(chunk_id)].get();
+        }
+        return cached_chunk_[idx & ArrayOffsetsGrowing::kChunkMask];
+    }
+
+ private:
+    const Directory& dir_;
+    mutable int64_t cached_chunk_id_{-1};
+    mutable const T* cached_chunk_{nullptr};
+};
+
+}  // namespace
+
 std::pair<int32_t, int32_t>
 ArrayOffsetsSealed::ElementIDToRowID(int32_t elem_id) const {
     assert(elem_id >= 0 && elem_id < GetTotalElementCount());
@@ -348,31 +378,42 @@ ArrayOffsetsSealed::BuildFromColumn(const ChunkedColumnInterface& column,
 
 std::pair<int32_t, int32_t>
 ArrayOffsetsGrowing::ElementIDToRowID(int32_t elem_id) const {
-    std::shared_lock lock(mutex_);
-    int64_t total_elements =
-        row_to_element_start_.empty() ? 0 : row_to_element_start_.back();
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
+    ChunkedReader starts(starts_chunks_);
+    const int64_t total_elements = starts[committed];
     assert(elem_id >= 0 && elem_id < total_elements);
+    (void)total_elements;
 
-    // Binary search: find the row where elem_id belongs
-    auto it = std::upper_bound(
-        row_to_element_start_.begin(), row_to_element_start_.end(), elem_id);
-    int32_t row_id = static_cast<int32_t>(
-        std::distance(row_to_element_start_.begin(), it) - 1);
+    // upper_bound over logical starts[0..committed].
+    int64_t lo = 0;
+    int64_t hi = committed + 1;
+    while (lo < hi) {
+        const int64_t mid = lo + ((hi - lo) >> 1);
+        if (starts[mid] <= elem_id) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    const int32_t row_id = static_cast<int32_t>(lo - 1);
 
-    int32_t elem_idx = elem_id - row_to_element_start_[row_id];
+    const int32_t elem_idx = elem_id - starts[row_id];
     return {row_id, elem_idx};
 }
 
 std::pair<int32_t, int32_t>
 ArrayOffsetsGrowing::ElementIDRangeOfRow(int32_t row_id) const {
-    std::shared_lock lock(mutex_);
-    assert(row_id >= 0 && row_id <= committed_row_count_);
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
+    assert(row_id >= 0 && row_id <= committed);
 
-    if (row_id == committed_row_count_) {
-        auto total = row_to_element_start_[committed_row_count_];
+    ChunkedReader starts(starts_chunks_);
+    if (row_id == committed) {
+        const int32_t total = starts[committed];
         return {total, total};
     }
-    return {row_to_element_start_[row_id], row_to_element_start_[row_id + 1]};
+    return {starts[row_id], starts[row_id + 1]};
 }
 
 std::pair<TargetBitmap, TargetBitmap>
@@ -380,18 +421,20 @@ ArrayOffsetsGrowing::RowBitsetToElementBitset(
     const TargetBitmapView& row_bitset,
     const TargetBitmapView& valid_row_bitset,
     int64_t row_start) const {
-    std::shared_lock lock(mutex_);
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
 
     int64_t row_count = row_bitset.size();
-    AssertInfo(row_start >= 0 && row_start + row_count <= committed_row_count_,
+    AssertInfo(row_start >= 0 && row_start + row_count <= committed,
                "row range out of bounds: row_start={}, row_count={}, "
                "committed_rows={}",
                row_start,
                row_count,
-               committed_row_count_);
+               committed);
 
-    int64_t element_start = row_to_element_start_[row_start];
-    int64_t element_end = row_to_element_start_[row_start + row_count];
+    ChunkedReader starts(starts_chunks_);
+    int64_t element_start = starts[row_start];
+    int64_t element_end = starts[row_start + row_count];
     int64_t element_count = element_end - element_start;
 
     TargetBitmap element_bitset(element_count);
@@ -400,8 +443,8 @@ ArrayOffsetsGrowing::RowBitsetToElementBitset(
     // Use row-based iteration (more efficient than element-based)
     for (int64_t i = 0; i < row_count; ++i) {
         int64_t row_id = row_start + i;
-        int64_t start = row_to_element_start_[row_id] - element_start;
-        int64_t end = row_to_element_start_[row_id + 1] - element_start;
+        int64_t start = starts[row_id] - element_start;
+        int64_t end = starts[row_id + 1] - element_start;
         if (start < end) {
             element_bitset.set(start, end - start, row_bitset[i]);
             valid_element_bitset.set(start, end - start, valid_row_bitset[i]);
@@ -414,15 +457,16 @@ ArrayOffsetsGrowing::RowBitsetToElementBitset(
 FixedVector<int32_t>
 ArrayOffsetsGrowing::RowBitsetToElementOffsets(
     const TargetBitmapView& row_bitset, int64_t row_start) const {
-    std::shared_lock lock(mutex_);
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
 
     int64_t row_count = row_bitset.size();
-    AssertInfo(row_start >= 0 && row_start + row_count <= committed_row_count_,
+    AssertInfo(row_start >= 0 && row_start + row_count <= committed,
                "row range out of bounds: row_start={}, row_count={}, "
                "committed_rows={}",
                row_start,
                row_count,
-               committed_row_count_);
+               committed);
 
     int64_t selected_rows = row_bitset.count();
     FixedVector<int32_t> element_offsets;
@@ -430,15 +474,16 @@ ArrayOffsetsGrowing::RowBitsetToElementOffsets(
         return element_offsets;
     }
 
-    int64_t total_elements = row_to_element_start_.back();
-    int64_t avg_elem_per_row = total_elements / committed_row_count_;
+    ChunkedReader starts(starts_chunks_);
+    int64_t total_elements = starts[committed];
+    int64_t avg_elem_per_row = total_elements / committed;
     element_offsets.reserve(selected_rows * avg_elem_per_row);
 
     for (int64_t i = 0; i < row_count; ++i) {
         if (row_bitset[i]) {
             int64_t row_id = row_start + i;
-            int32_t first_elem = row_to_element_start_[row_id];
-            int32_t last_elem = row_to_element_start_[row_id + 1];
+            int32_t first_elem = starts[row_id];
+            int32_t last_elem = starts[row_id + 1];
             for (int32_t elem_id = first_elem; elem_id < last_elem; ++elem_id) {
                 element_offsets.push_back(elem_id);
             }
@@ -451,21 +496,23 @@ ArrayOffsetsGrowing::RowBitsetToElementOffsets(
 FixedVector<int32_t>
 ArrayOffsetsGrowing::RowOffsetsToElementOffsets(
     const FixedVector<int32_t>& row_offsets) const {
-    std::shared_lock lock(mutex_);
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
 
     FixedVector<int32_t> element_offsets;
     if (row_offsets.empty()) {
         return element_offsets;
     }
 
-    int64_t total_elements = row_to_element_start_.back();
-    int64_t avg_elem_per_row = total_elements / committed_row_count_;
+    ChunkedReader starts(starts_chunks_);
+    int64_t total_elements = starts[committed];
+    int64_t avg_elem_per_row = total_elements / committed;
     element_offsets.reserve(row_offsets.size() * avg_elem_per_row);
 
     for (auto row_id : row_offsets) {
-        assert(row_id >= 0 && row_id < committed_row_count_);
-        int32_t first_elem = row_to_element_start_[row_id];
-        int32_t last_elem = row_to_element_start_[row_id + 1];
+        assert(row_id >= 0 && row_id < committed);
+        int32_t first_elem = starts[row_id];
+        int32_t last_elem = starts[row_id + 1];
         for (int32_t elem_id = first_elem; elem_id < last_elem; ++elem_id) {
             element_offsets.push_back(elem_id);
         }
@@ -479,21 +526,23 @@ ArrayOffsetsGrowing::ForEachRowElementRange(
     const ElementRangePredicate& predicate,
     int64_t row_start,
     int64_t row_count) const {
-    std::shared_lock lock(mutex_);
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
 
-    AssertInfo(row_start >= 0 && row_start + row_count <= committed_row_count_,
+    AssertInfo(row_start >= 0 && row_start + row_count <= committed,
                "row range out of bounds: row_start={}, row_count={}, "
                "committed_rows={}",
                row_start,
                row_count,
-               committed_row_count_);
+               committed);
 
+    ChunkedReader starts(starts_chunks_);
     TargetBitmap result(row_count);
 
     for (int64_t i = 0; i < row_count; ++i) {
         int64_t row_id = row_start + i;
-        int32_t elem_start = row_to_element_start_[row_id];
-        int32_t elem_end = row_to_element_start_[row_id + 1];
+        int32_t elem_start = starts[row_id];
+        int32_t elem_end = starts[row_id + 1];
         result[i] = predicate(elem_start, elem_end);
     }
 
@@ -504,84 +553,58 @@ void
 ArrayOffsetsGrowing::Insert(int64_t row_id_start,
                             const int32_t* array_lengths,
                             int64_t count) {
-    std::unique_lock lock(mutex_);
-
-    row_to_element_start_.reserve(row_id_start + count + 1);
+    std::lock_guard lock(write_mutex_);
 
     for (int64_t i = 0; i < count; ++i) {
-        int32_t row_id = row_id_start + i;
+        int64_t row_id = row_id_start + i;
         int32_t array_len = array_lengths[i];
 
-        if (row_id == committed_row_count_) {
-            // Get current total element count (from sentinel or compute)
-            int32_t current_total = row_to_element_start_.empty()
-                                        ? 0
-                                        : row_to_element_start_.back();
-
-            // Record the start position for this row
-            if (row_to_element_start_.size() >
-                static_cast<size_t>(committed_row_count_)) {
-                // Sentinel exists, overwrite it with row start
-                row_to_element_start_[committed_row_count_] = current_total;
-            } else {
-                row_to_element_start_.push_back(current_total);
-            }
-
-            // Update sentinel (new total after this row)
-            int32_t new_total = current_total + array_len;
-            if (row_to_element_start_.size() >
-                static_cast<size_t>(committed_row_count_ + 1)) {
-                row_to_element_start_[committed_row_count_ + 1] = new_total;
-            } else {
-                row_to_element_start_.push_back(new_total);
-            }
-
-            committed_row_count_++;
+        if (row_id == committed_rows_writer_) {
+            CommitRow(array_len);
         } else {
             pending_rows_[row_id] = {row_id, array_len};
         }
     }
 
     DrainPendingRows();
+    PublishCommitted();
+}
+
+void
+ArrayOffsetsGrowing::WriteStart(int64_t idx, int32_t value) {
+    const auto chunk_id = static_cast<size_t>(idx >> kChunkBits);
+    while (starts_chunks_.size() <= chunk_id) {
+        starts_chunks_.push_back(std::make_unique<int32_t[]>(kEntriesPerChunk));
+    }
+    starts_chunks_[chunk_id][idx & kChunkMask] = value;
+}
+
+void
+ArrayOffsetsGrowing::CommitRow(int32_t array_len) {
+    const int32_t row = committed_rows_writer_;
+    const int32_t current_total = LoadStart(row);
+    WriteStart(row + 1, current_total + array_len);
+    committed_rows_writer_ = row + 1;
 }
 
 void
 ArrayOffsetsGrowing::DrainPendingRows() {
     while (true) {
-        auto it = pending_rows_.find(committed_row_count_);
+        auto it = pending_rows_.find(committed_rows_writer_);
         if (it == pending_rows_.end()) {
             break;
         }
 
         const auto& pending = it->second;
-
-        // Get current total element count
-        int32_t current_total =
-            (committed_row_count_ > 0)
-                ? row_to_element_start_[committed_row_count_]
-                : 0;
-
-        // If sentinel exists at current position, overwrite it; otherwise push_back
-        if (row_to_element_start_.size() >
-            static_cast<size_t>(committed_row_count_)) {
-            row_to_element_start_[committed_row_count_] = current_total;
-        } else {
-            row_to_element_start_.push_back(current_total);
-        }
-
-        // Update sentinel for next row
-        int32_t new_total = current_total + pending.array_len;
-        if (row_to_element_start_.size() >
-            static_cast<size_t>(committed_row_count_ + 1)) {
-            row_to_element_start_[committed_row_count_ + 1] = new_total;
-        } else {
-            row_to_element_start_.push_back(new_total);
-        }
-
-        committed_row_count_++;
-
+        CommitRow(pending.array_len);
         pending_rows_.erase(it);
     }
+}
+
+void
+ArrayOffsetsGrowing::PublishCommitted() {
+    committed_row_count_.store(committed_rows_writer_,
+                               std::memory_order_release);
 }
 
 }  // namespace milvus

--- a/internal/core/src/common/ArrayOffsets.h
+++ b/internal/core/src/common/ArrayOffsets.h
@@ -17,12 +17,16 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <shared_mutex>
+#include <mutex>
 #include <utility>
 #include <vector>
+
+#include <oneapi/tbb/concurrent_vector.h>
 
 #include "cachinglayer/Manager.h"
 #include "common/EasyAssert.h"
@@ -169,23 +173,51 @@ class ArrayOffsetsSealed : public IArrayOffsets {
     int64_t resource_size_{0};
 };
 
+// Growing-segment row -> element-start table with lock-free readers.
+//
+// The starts table lives in fixed-size chunks whose addresses never change.
+// Committing row i writes starts[i + 1] exactly once, then a release-store to
+// committed_row_count_ publishes the completed prefix. Readers acquire-load
+// that watermark and only touch immutable entries at or below it, so they do
+// not contend with ingest.
+//
+// Insert calls may arrive concurrently and out of order. A writer-only mutex
+// serializes the pending-row machinery; readers never acquire it. The
+// watermark is published once per Insert call, preserving the old behavior
+// where readers observe an inserted batch atomically.
+//
+// Growing offsets are not charged to the caching layer. Chunked storage
+// eagerly allocates the first starts chunk (32 KiB) and then grows in 32 KiB
+// steps.
 class ArrayOffsetsGrowing : public IArrayOffsets {
  public:
-    ArrayOffsetsGrowing() = default;
+    // Public so tests can target chunk boundaries.
+    static constexpr int64_t kChunkBits = 13;
+    static constexpr int64_t kEntriesPerChunk = int64_t{1} << kChunkBits;
+    static constexpr int64_t kChunkMask = kEntriesPerChunk - 1;
+
+    ArrayOffsetsGrowing() {
+        // starts[0] is the sentinel for an empty table. The constructor
+        // happens-before concurrent use, so this initialization needs no
+        // synchronization.
+        auto chunk = std::make_unique<int32_t[]>(kEntriesPerChunk);
+        chunk[0] = 0;
+        starts_chunks_.push_back(std::move(chunk));
+    }
 
     void
     Insert(int64_t row_id_start, const int32_t* array_lengths, int64_t count);
 
     int64_t
     GetRowCount() const override {
-        std::shared_lock lock(mutex_);
-        return committed_row_count_;
+        return committed_row_count_.load(std::memory_order_acquire);
     }
 
     int64_t
     GetTotalElementCount() const override {
-        std::shared_lock lock(mutex_);
-        return row_to_element_start_.empty() ? 0 : row_to_element_start_.back();
+        const int64_t committed =
+            committed_row_count_.load(std::memory_order_acquire);
+        return LoadStart(committed);
     }
 
     std::pair<int32_t, int32_t>
@@ -218,21 +250,61 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
         int32_t array_len;
     };
 
+    template <typename T>
+    using ChunkDirectory = oneapi::tbb::concurrent_vector<std::unique_ptr<T[]>>;
+
+    // Keep this value stable across compiler and -mtune changes. Homebrew
+    // Clang/libc++ does not expose the C++17 interference-size constants;
+    // GCC 12 uses 256 bytes on AArch64 and 64 bytes on x86-64.
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+    static constexpr std::size_t kDestructiveInterferenceSize = 128;
+#elif defined(__aarch64__) || defined(__arm64__)
+    static constexpr std::size_t kDestructiveInterferenceSize = 256;
+#else
+    static constexpr std::size_t kDestructiveInterferenceSize = 64;
+#endif
+
+    // Reader-side helper. Callers must only pass indices covered by an
+    // acquire-loaded committed_row_count_; those entries are immutable.
+    int32_t
+    LoadStart(int64_t idx) const {
+        return starts_chunks_[idx >> kChunkBits][idx & kChunkMask];
+    }
+
+    // Writer-side helpers; write_mutex_ must be held.
+    void
+    WriteStart(int64_t idx, int32_t value);
+
+    void
+    CommitRow(int32_t array_len);
+
     void
     DrainPendingRows();
 
- private:
-    std::vector<int32_t> row_to_element_start_;
+    void
+    PublishCommitted();
 
-    // Number of rows committed (contiguous from 0)
-    int32_t committed_row_count_ = 0;
+ private:
+    // Logical index i is stored at
+    // starts_chunks_[i >> kChunkBits][i & kChunkMask]. TBB's directory can
+    // grow concurrently without relocating existing entries.
+    ChunkDirectory<int32_t> starts_chunks_;
+
+    // Reader-visible publication watermark. Rows below it, plus the sentinel
+    // at the watermark, are committed and immutable.
+    std::atomic<int32_t> committed_row_count_{0};
+
+    // Writer's working count, published at the end of each Insert call. Keep
+    // it off the reader-hot watermark's cache line: CommitRow updates this for
+    // every row, while readers repeatedly acquire-load the watermark.
+    alignas(kDestructiveInterferenceSize) int32_t committed_rows_writer_{0};
 
     // Pending rows waiting for earlier rows to complete
     // Key: row_id, automatically sorted
     std::map<int64_t, PendingRow> pending_rows_;
 
-    // Protects all member variables
-    mutable std::shared_mutex mutex_;
+    // Serializes writers only; readers never take this lock.
+    std::mutex write_mutex_;
 };
 
 }  // namespace milvus

--- a/internal/core/src/common/ArrayOffsetsTest.cpp
+++ b/internal/core/src/common/ArrayOffsetsTest.cpp
@@ -14,7 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <atomic>
 #include <cstdint>
+#include <random>
 #include <string>
 #include <thread>
 #include <utility>
@@ -692,4 +695,446 @@ TEST_F(ArrayOffsetsTest, GrowingRowBitsetToElementBitsetWithRowStart) {
     EXPECT_FALSE(elem_bitset[3]);
     EXPECT_TRUE(elem_bitset[4]);
     EXPECT_TRUE(elem_bitset[5]);
+}
+
+TEST_F(ArrayOffsetsTest, GrowingEmptyTableRange) {
+    ArrayOffsetsGrowing offsets;
+
+    EXPECT_EQ(offsets.GetRowCount(), 0);
+    EXPECT_EQ(offsets.GetTotalElementCount(), 0);
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(0),
+              (std::pair<int32_t, int32_t>{0, 0}));
+
+    TargetBitmap rows(0);
+    TargetBitmap valid_rows(0);
+    auto [elements, valid_elements] =
+        offsets.RowBitsetToElementBitset(rows.view(), valid_rows.view(), 0);
+    EXPECT_TRUE(elements.empty());
+    EXPECT_TRUE(valid_elements.empty());
+}
+
+TEST_F(ArrayOffsetsTest, GrowingChunkBoundary) {
+    constexpr int64_t kChunk = ArrayOffsetsGrowing::kEntriesPerChunk;
+    constexpr int64_t kTotalRows = 2 * kChunk + 137;
+
+    std::vector<int32_t> lens(kTotalRows);
+    std::vector<int32_t> expected(kTotalRows + 1, 0);
+    for (int64_t i = 0; i < kTotalRows; ++i) {
+        lens[i] = static_cast<int32_t>(i % 4);
+        expected[i + 1] = expected[i] + lens[i];
+    }
+
+    ArrayOffsetsGrowing offsets;
+
+    // Leave a gap before each chunk boundary, insert the following rows as
+    // pending, then fill the gap and drain across the boundary.
+    offsets.Insert(0, lens.data(), kChunk - 3);
+    offsets.Insert(kChunk + 3, lens.data() + kChunk + 3, 37);
+    EXPECT_EQ(offsets.GetRowCount(), kChunk - 3);
+    offsets.Insert(kChunk - 3, lens.data() + kChunk - 3, 6);
+    EXPECT_EQ(offsets.GetRowCount(), kChunk + 40);
+
+    offsets.Insert(2 * kChunk + 1,
+                   lens.data() + 2 * kChunk + 1,
+                   kTotalRows - (2 * kChunk + 1));
+    EXPECT_EQ(offsets.GetRowCount(), kChunk + 40);
+    offsets.Insert(
+        kChunk + 40, lens.data() + kChunk + 40, 2 * kChunk + 1 - (kChunk + 40));
+
+    EXPECT_EQ(offsets.GetRowCount(), kTotalRows);
+    EXPECT_EQ(offsets.GetTotalElementCount(), expected[kTotalRows]);
+
+    for (int64_t row : {int64_t{0},
+                        kChunk - 2,
+                        kChunk - 1,
+                        kChunk,
+                        kChunk + 1,
+                        2 * kChunk - 1,
+                        2 * kChunk,
+                        2 * kChunk + 1,
+                        kTotalRows - 1}) {
+        auto [start, end] =
+            offsets.ElementIDRangeOfRow(static_cast<int32_t>(row));
+        EXPECT_EQ(start, expected[row]) << "row " << row;
+        EXPECT_EQ(end, expected[row + 1]) << "row " << row;
+    }
+    EXPECT_EQ(offsets.ElementIDRangeOfRow(kTotalRows),
+              (std::pair<int32_t, int32_t>{expected[kTotalRows],
+                                           expected[kTotalRows]}));
+
+    auto check_element = [&](int32_t element) {
+        auto it = std::upper_bound(expected.begin(), expected.end(), element);
+        const auto expected_row =
+            static_cast<int32_t>(it - expected.begin()) - 1;
+        auto [row, index] = offsets.ElementIDToRowID(element);
+        EXPECT_EQ(row, expected_row) << "element " << element;
+        EXPECT_EQ(index, element - expected[expected_row])
+            << "element " << element;
+    };
+    for (int32_t element : {0,
+                            expected[kChunk] - 1,
+                            expected[kChunk],
+                            expected[kChunk] + 1,
+                            expected[2 * kChunk] - 1,
+                            expected[2 * kChunk],
+                            expected[kTotalRows] - 1}) {
+        check_element(element);
+    }
+
+    const int64_t row_start = kChunk - 8;
+    const int64_t row_count = 16;
+    TargetBitmap row_bits(row_count);
+    TargetBitmap valid_bits(row_count, true);
+    for (int64_t i = 0; i < row_count; i += 2) {
+        row_bits[i] = true;
+    }
+
+    auto [element_bits, valid_element_bits] = offsets.RowBitsetToElementBitset(
+        row_bits.view(), valid_bits.view(), row_start);
+    ASSERT_EQ(static_cast<int64_t>(element_bits.size()),
+              expected[row_start + row_count] - expected[row_start]);
+    for (int64_t i = 0; i < row_count; ++i) {
+        for (int32_t element = expected[row_start + i];
+             element < expected[row_start + i + 1];
+             ++element) {
+            const auto local = element - expected[row_start];
+            EXPECT_EQ(bool(element_bits[local]), bool(row_bits[i]));
+            EXPECT_TRUE(valid_element_bits[local]);
+        }
+    }
+
+    auto element_offsets =
+        offsets.RowBitsetToElementOffsets(row_bits.view(), row_start);
+    std::vector<int32_t> expected_offsets;
+    for (int64_t i = 0; i < row_count; i += 2) {
+        for (int32_t element = expected[row_start + i];
+             element < expected[row_start + i + 1];
+             ++element) {
+            expected_offsets.push_back(element);
+        }
+    }
+    EXPECT_TRUE(std::equal(element_offsets.begin(),
+                           element_offsets.end(),
+                           expected_offsets.begin(),
+                           expected_offsets.end()));
+
+    FixedVector<int32_t> row_offsets = {static_cast<int32_t>(kChunk - 1),
+                                        static_cast<int32_t>(kChunk),
+                                        static_cast<int32_t>(kChunk + 1),
+                                        static_cast<int32_t>(2 * kChunk)};
+    auto selected = offsets.RowOffsetsToElementOffsets(row_offsets);
+    expected_offsets.clear();
+    for (auto row : row_offsets) {
+        for (int32_t element = expected[row]; element < expected[row + 1];
+             ++element) {
+            expected_offsets.push_back(element);
+        }
+    }
+    EXPECT_TRUE(std::equal(selected.begin(),
+                           selected.end(),
+                           expected_offsets.begin(),
+                           expected_offsets.end()));
+
+    auto ranges = offsets.ForEachRowElementRange(
+        [](int32_t start, int32_t end) { return end - start >= 2; },
+        row_start,
+        row_count);
+    for (int64_t i = 0; i < row_count; ++i) {
+        EXPECT_EQ(bool(ranges[i]), lens[row_start + i] >= 2);
+    }
+}
+
+TEST_F(ArrayOffsetsTest, GrowingConcurrentWriterReaderStress) {
+    constexpr int64_t kTotalRows = 100000;
+    constexpr int64_t kInsertBatch = 32;
+    static_assert(kTotalRows % kInsertBatch == 0);
+
+    std::vector<int32_t> lens(kTotalRows);
+    std::vector<int32_t> expected(kTotalRows + 1, 0);
+    std::mt19937 gen(4242);
+    for (int64_t i = 0; i < kTotalRows; ++i) {
+        lens[i] = static_cast<int32_t>(gen() % 5);
+        expected[i + 1] = expected[i] + lens[i];
+    }
+
+    // Precompute the exact row-count endpoints that the deterministic writer
+    // plan may publish. For an out-of-order pair, the high batch leaves the
+    // watermark unchanged and the following low batch publishes both batches
+    // together; the intermediate prefix is deliberately not an endpoint.
+    std::vector<bool> allowed_counts(kTotalRows + 1, false);
+    allowed_counts[0] = true;
+    std::mt19937 plan_gen(999);
+    int64_t planned_next = 0;
+    while (planned_next < kTotalRows) {
+        if (plan_gen() % 4 == 0 &&
+            planned_next + 2 * kInsertBatch <= kTotalRows) {
+            planned_next += 2 * kInsertBatch;
+        } else {
+            planned_next += kInsertBatch;
+        }
+        allowed_counts[planned_next] = true;
+    }
+
+    ArrayOffsetsGrowing offsets;
+    std::atomic<bool> start{false};
+    std::atomic<bool> done{false};
+    std::atomic<int32_t> ready{0};
+    std::atomic<int64_t> live_reads{0};
+    std::atomic<int64_t> partial_reads{0};
+
+    std::thread writer([&]() {
+        ready.fetch_add(1, std::memory_order_release);
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        while (live_reads.load(std::memory_order_acquire) == 0) {
+            std::this_thread::yield();
+        }
+
+        std::mt19937 writer_gen(999);
+        int64_t next = 0;
+        while (next < kTotalRows) {
+            if (writer_gen() % 4 == 0 &&
+                next + 2 * kInsertBatch <= kTotalRows) {
+                offsets.Insert(next + kInsertBatch,
+                               lens.data() + next + kInsertBatch,
+                               kInsertBatch);
+                offsets.Insert(next, lens.data() + next, kInsertBatch);
+                next += 2 * kInsertBatch;
+            } else {
+                offsets.Insert(next, lens.data() + next, kInsertBatch);
+                next += kInsertBatch;
+            }
+
+            // Keep the first published prefix visible until a reader has
+            // observed it, proving the stress actually overlaps ingest.
+            if (partial_reads.load(std::memory_order_acquire) == 0) {
+                while (partial_reads.load(std::memory_order_acquire) == 0) {
+                    std::this_thread::yield();
+                }
+            }
+            std::this_thread::yield();
+        }
+        done.store(true, std::memory_order_release);
+    });
+
+    std::vector<std::thread> readers;
+    for (int thread_id = 0; thread_id < 4; ++thread_id) {
+        readers.emplace_back([&, thread_id]() {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            std::mt19937 reader_gen(1000 + thread_id);
+            int64_t last_count = 0;
+            int64_t iterations = 0;
+            while (!done.load(std::memory_order_acquire) || iterations < 200) {
+                ++iterations;
+                if (!done.load(std::memory_order_acquire)) {
+                    live_reads.fetch_add(1, std::memory_order_release);
+                }
+                const int64_t count = offsets.GetRowCount();
+                EXPECT_GE(count, last_count);
+                if (count < 0 || count > kTotalRows) {
+                    ADD_FAILURE() << "invalid committed row count " << count;
+                    continue;
+                }
+                EXPECT_TRUE(allowed_counts[count])
+                    << "reader observed a count that was not an Insert-call "
+                       "endpoint: "
+                    << count;
+                last_count = count;
+                if (count > 0 && count < kTotalRows) {
+                    partial_reads.fetch_add(1, std::memory_order_release);
+                }
+
+                const int64_t total = offsets.GetTotalElementCount();
+                if (total < expected[count] || total > expected[kTotalRows]) {
+                    ADD_FAILURE() << "invalid total element count " << total
+                                  << " for committed rows " << count;
+                    continue;
+                }
+                if (count == 0) {
+                    continue;
+                }
+
+                const int64_t row_start = reader_gen() % count;
+                const int64_t row_count =
+                    std::min<int64_t>(128, count - row_start);
+
+                auto [first_start, first_end] =
+                    offsets.ElementIDRangeOfRow(row_start);
+                EXPECT_EQ(first_start, expected[row_start]);
+                EXPECT_EQ(first_end, expected[row_start + 1]);
+                auto [last_start, last_end] =
+                    offsets.ElementIDRangeOfRow(row_start + row_count - 1);
+                EXPECT_EQ(last_start, expected[row_start + row_count - 1]);
+                EXPECT_EQ(last_end, expected[row_start + row_count]);
+
+                if (total > 0) {
+                    const auto element =
+                        static_cast<int32_t>(reader_gen() % total);
+                    auto it = std::upper_bound(
+                        expected.begin(), expected.end(), element);
+                    const auto expected_row =
+                        static_cast<int32_t>(it - expected.begin()) - 1;
+                    auto [row, index] = offsets.ElementIDToRowID(element);
+                    EXPECT_EQ(row, expected_row);
+                    EXPECT_EQ(index, element - expected[expected_row]);
+                }
+
+                TargetBitmap row_bits(row_count);
+                TargetBitmap valid_bits(row_count, true);
+                for (int64_t i = 0; i < row_count; i += 3) {
+                    row_bits[i] = true;
+                }
+                auto [element_bits, valid_element_bits] =
+                    offsets.RowBitsetToElementBitset(
+                        row_bits.view(), valid_bits.view(), row_start);
+                EXPECT_EQ(
+                    static_cast<int64_t>(element_bits.size()),
+                    expected[row_start + row_count] - expected[row_start]);
+                EXPECT_EQ(element_bits.size(), valid_element_bits.count());
+                for (int64_t i = 0; i < row_count; ++i) {
+                    for (int32_t element = expected[row_start + i];
+                         element < expected[row_start + i + 1];
+                         ++element) {
+                        EXPECT_EQ(
+                            bool(element_bits[element - expected[row_start]]),
+                            bool(row_bits[i]));
+                    }
+                }
+
+                auto selected = offsets.RowBitsetToElementOffsets(
+                    row_bits.view(), row_start);
+                int64_t expected_selected = 0;
+                std::vector<int32_t> expected_selected_offsets;
+                for (int64_t i = 0; i < row_count; i += 3) {
+                    expected_selected += lens[row_start + i];
+                    for (int32_t element = expected[row_start + i];
+                         element < expected[row_start + i + 1];
+                         ++element) {
+                        expected_selected_offsets.push_back(element);
+                    }
+                }
+                EXPECT_EQ(static_cast<int64_t>(selected.size()),
+                          expected_selected);
+                EXPECT_TRUE(std::equal(selected.begin(),
+                                       selected.end(),
+                                       expected_selected_offsets.begin(),
+                                       expected_selected_offsets.end()));
+
+                FixedVector<int32_t> rows = {static_cast<int32_t>(row_start)};
+                if (row_count > 1) {
+                    rows.push_back(
+                        static_cast<int32_t>(row_start + row_count - 1));
+                }
+                auto row_elements = offsets.RowOffsetsToElementOffsets(rows);
+                std::vector<int32_t> expected_row_elements;
+                for (auto row : rows) {
+                    for (int32_t element = expected[row];
+                         element < expected[row + 1];
+                         ++element) {
+                        expected_row_elements.push_back(element);
+                    }
+                }
+                EXPECT_TRUE(std::equal(row_elements.begin(),
+                                       row_elements.end(),
+                                       expected_row_elements.begin(),
+                                       expected_row_elements.end()));
+
+                auto ranges = offsets.ForEachRowElementRange(
+                    [](int32_t begin, int32_t end) {
+                        return (end - begin) % 2 == 0;
+                    },
+                    row_start,
+                    row_count);
+                for (int64_t i = 0; i < row_count; ++i) {
+                    EXPECT_EQ(bool(ranges[i]), lens[row_start + i] % 2 == 0);
+                }
+            }
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) != 5) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+    writer.join();
+    for (auto& reader : readers) {
+        reader.join();
+    }
+
+    EXPECT_EQ(offsets.GetRowCount(), kTotalRows);
+    EXPECT_EQ(offsets.GetTotalElementCount(), expected[kTotalRows]);
+    EXPECT_GT(live_reads.load(std::memory_order_relaxed), 0);
+    EXPECT_GT(partial_reads.load(std::memory_order_relaxed), 0);
+    for (int64_t row = 0; row < kTotalRows; ++row) {
+        auto [begin, end] = offsets.ElementIDRangeOfRow(row);
+        ASSERT_EQ(begin, expected[row]) << "row " << row;
+        ASSERT_EQ(end, expected[row + 1]) << "row " << row;
+    }
+}
+
+TEST_F(ArrayOffsetsTest, GrowingConcurrentWriters) {
+    constexpr int64_t kTotalRows = 20000;
+    constexpr int64_t kBatchSize = 25;
+    constexpr int64_t kBatchCount = kTotalRows / kBatchSize;
+    constexpr int32_t kWriterCount = 4;
+
+    std::vector<int32_t> lens(kTotalRows);
+    std::vector<int32_t> expected(kTotalRows + 1, 0);
+    for (int64_t row = 0; row < kTotalRows; ++row) {
+        lens[row] = static_cast<int32_t>(row % 5);
+        expected[row + 1] = expected[row] + lens[row];
+    }
+
+    std::vector<int64_t> batches(kBatchCount);
+    for (int64_t batch = 0; batch < kBatchCount; ++batch) {
+        batches[batch] = batch;
+    }
+    std::mt19937 gen(2026);
+    std::shuffle(batches.begin(), batches.end(), gen);
+
+    ArrayOffsetsGrowing offsets;
+    std::atomic<int64_t> next_batch{0};
+    std::atomic<int32_t> ready{0};
+    std::atomic<bool> start{false};
+    std::vector<std::thread> writers;
+    for (int32_t writer_id = 0; writer_id < kWriterCount; ++writer_id) {
+        writers.emplace_back([&]() {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            while (true) {
+                const int64_t index =
+                    next_batch.fetch_add(1, std::memory_order_relaxed);
+                if (index >= kBatchCount) {
+                    break;
+                }
+                const int64_t batch = batches[index];
+                const int64_t row_start = batch * kBatchSize;
+                offsets.Insert(row_start, lens.data() + row_start, kBatchSize);
+            }
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) != kWriterCount) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& writer : writers) {
+        writer.join();
+    }
+
+    EXPECT_EQ(offsets.GetRowCount(), kTotalRows);
+    EXPECT_EQ(offsets.GetTotalElementCount(), expected[kTotalRows]);
+    for (int64_t row = 0; row < kTotalRows; ++row) {
+        auto [begin, end] = offsets.ElementIDRangeOfRow(row);
+        ASSERT_EQ(begin, expected[row]) << "row " << row;
+        ASSERT_EQ(end, expected[row + 1]) << "row " << row;
+    }
 }


### PR DESCRIPTION
Backport of #51392 to the 3.0 branch.

pr: #51392
issue: #51382

> [!IMPORTANT]
> #51392 is still open on master. Do not merge this PR until #51392 merges; refresh this branch if the source PR changes.

## What changed

- Replace the `ArrayOffsetsGrowing` reader-side shared mutex with fixed 8192-entry chunks stored in `tbb::concurrent_vector`.
- Publish committed row batches through a release/acquire watermark so readers observe immutable prefixes without locking.
- Retain writer serialization and pending-row handling for concurrent or out-of-order inserts.
- Backport coverage for empty tables, chunk boundaries, atomic batch visibility, concurrent readers and writers, and multiple writers.

## Backport notes

- Cherry-picked source commit `6d385f25f7941f97b416d7c3a640256449a5deca` with provenance and DCO trailers.
- Applied cleanly on the latest `upstream/3.0` with no 3.0-specific code changes.
- The three touched pre-existing files are identical between the source commit parent and the 3.0 backport base.
- Stable patch-id matches the source commit exactly; range-diff differs only by cherry-pick provenance and the final Li Liu sign-off.

## Verification

- `git diff --check upstream/3.0...HEAD` — passed.
- `clang-format 22 --dry-run --Werror` on all changed C++ files — passed.
- Source PR CI Loop on the exact current source head passed build and code checks, integration and Go tests, plus 8,238/8,238 C++ tests.
- Source PR Go SDK check passed.
- A local full C++ rebuild was not run to avoid starting the full macOS arm64 third-party dependency rebuild; target-branch CI will provide branch-specific compile and regression coverage.
