### PR TITLE
enhance: [cp3.0] speed up struct-array element-match fold and offsets lookups

### DIFF
--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -39,6 +39,47 @@ namespace milvus {
 
 namespace {
 
+ElementRowInfo
+LocateElement(const std::vector<int32_t>& row_to_element_start,
+              int32_t elem_id) {
+    assert(!row_to_element_start.empty() && elem_id >= 0 &&
+           elem_id < row_to_element_start.back());
+
+    auto it = std::upper_bound(
+        row_to_element_start.begin(), row_to_element_start.end(), elem_id);
+    const int32_t row_id = static_cast<int32_t>(
+        std::distance(row_to_element_start.begin(), it) - 1);
+    const int32_t row_element_start = *(it - 1);
+    return {row_id, elem_id - row_element_start, row_element_start, *it};
+}
+
+template <typename Starts>
+ElementRowInfo
+LocateElement(const Starts& starts, int64_t row_count, int32_t elem_id) {
+    const int64_t total_elements = starts[row_count];
+    assert(elem_id >= 0 && elem_id < total_elements);
+    (void)total_elements;
+
+    // upper_bound over logical starts[0..row_count].
+    int64_t lo = 0;
+    int64_t hi = row_count + 1;
+    while (lo < hi) {
+        const int64_t mid = lo + ((hi - lo) >> 1);
+        if (starts[mid] <= elem_id) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    const int32_t row_id = static_cast<int32_t>(lo - 1);
+    const int32_t row_element_start = starts[row_id];
+    const int32_t row_element_end = starts[row_id + 1];
+    return {row_id,
+            elem_id - row_element_start,
+            row_element_start,
+            row_element_end};
+}
+
 // Lock-free random-access reader over the chunk directory. Callers only hand
 // it logical indices covered by an acquire-loaded committed watermark.
 template <typename T>
@@ -142,17 +183,13 @@ ElementBitsetAnyReduce(const Starts& starts,
 
 std::pair<int32_t, int32_t>
 ArrayOffsetsSealed::ElementIDToRowID(int32_t elem_id) const {
-    assert(elem_id >= 0 && elem_id < GetTotalElementCount());
+    const auto info = LocateElement(row_to_element_start_, elem_id);
+    return {info.row_id, info.element_index};
+}
 
-    // Binary search: find the row where elem_id belongs
-    // row_to_element_start_[row_id] <= elem_id < row_to_element_start_[row_id + 1]
-    auto it = std::upper_bound(
-        row_to_element_start_.begin(), row_to_element_start_.end(), elem_id);
-    int32_t row_id = static_cast<int32_t>(
-        std::distance(row_to_element_start_.begin(), it) - 1);
-
-    int32_t elem_idx = elem_id - row_to_element_start_[row_id];
-    return {row_id, elem_idx};
+ElementRowInfo
+ArrayOffsetsSealed::ElementIDToRowInfo(int32_t elem_id) const {
+    return LocateElement(row_to_element_start_, elem_id);
 }
 
 std::pair<int32_t, int32_t>
@@ -176,12 +213,11 @@ ArrayOffsetsSealed::CopyRowElementRanges(
     const int32_t* starts = row_to_element_start_.data();
     for (int64_t i = 0; i < count; ++i) {
         const int32_t row_id = row_ids[i];
-        assert(row_id >= 0 && row_id <= row_count);
-        if (row_id == row_count) {
-            out[i] = {starts[row_count], starts[row_count]};
-        } else {
-            out[i] = {starts[row_id], starts[row_id + 1]};
-        }
+        AssertInfo(row_id >= 0 && row_id < row_count,
+                   "row id out of bounds: row_id={}, row_count={}",
+                   row_id,
+                   row_count);
+        out[i] = {starts[row_id], starts[row_id + 1]};
     }
 }
 
@@ -511,26 +547,16 @@ std::pair<int32_t, int32_t>
 ArrayOffsetsGrowing::ElementIDToRowID(int32_t elem_id) const {
     const int64_t committed =
         committed_row_count_.load(std::memory_order_acquire);
-    ChunkedReader starts(starts_chunks_);
-    const int64_t total_elements = starts[committed];
-    assert(elem_id >= 0 && elem_id < total_elements);
-    (void)total_elements;
+    const auto info =
+        LocateElement(ChunkedReader(starts_chunks_), committed, elem_id);
+    return {info.row_id, info.element_index};
+}
 
-    // upper_bound over logical starts[0..committed].
-    int64_t lo = 0;
-    int64_t hi = committed + 1;
-    while (lo < hi) {
-        const int64_t mid = lo + ((hi - lo) >> 1);
-        if (starts[mid] <= elem_id) {
-            lo = mid + 1;
-        } else {
-            hi = mid;
-        }
-    }
-    const int32_t row_id = static_cast<int32_t>(lo - 1);
-
-    const int32_t elem_idx = elem_id - starts[row_id];
-    return {row_id, elem_idx};
+ElementRowInfo
+ArrayOffsetsGrowing::ElementIDToRowInfo(int32_t elem_id) const {
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
+    return LocateElement(ChunkedReader(starts_chunks_), committed, elem_id);
 }
 
 std::pair<int32_t, int32_t>
@@ -558,8 +584,10 @@ ArrayOffsetsGrowing::CopyRowElementRanges(
     const int32_t total = starts[committed];
     for (int64_t i = 0; i < count; ++i) {
         const int32_t row_id = row_ids[i];
+        AssertInfo(
+            row_id >= 0, "row id must be non-negative: row_id={}", row_id);
         // A not-yet-committed row has no published range yet.
-        if (row_id < 0 || row_id > committed) {
+        if (row_id > committed) {
             out[i] = {0, 0};
             continue;
         }

--- a/internal/core/src/common/ArrayOffsets.cpp
+++ b/internal/core/src/common/ArrayOffsets.cpp
@@ -17,7 +17,9 @@
 #include "ArrayOffsets.h"
 
 #include <assert.h>
+#include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <type_traits>
 
 #include "bitset/bitset.h"
@@ -63,6 +65,79 @@ class ChunkedReader {
     mutable const T* cached_chunk_{nullptr};
 };
 
+// Word-wise ANY-semantics reduction shared by the sealed and growing
+// implementations of ElementBitsetToRowBitsetAny.
+//
+// `starts` is the row -> element-start table, indexable over
+// [row_start, row_start + row_count]. Bit j of `elem_bitset` corresponds to
+// global element id (elem_offset + j).
+//
+// Linear merge of the element bitmap (consumed one 64-bit word at a time)
+// with the sorted row-start table: zero words are skipped with a single
+// compare, a set bit advances the monotone row cursor (amortized
+// O(row_count) over the whole call, no binary search), and once a row is
+// marked the scan jumps directly to the row's end, skipping its remaining
+// words. Complexity is O(total_elements / 64 + row_count + hit_rows)
+// instead of the per-bit O(total_elements).
+template <typename Starts>
+void
+ElementBitsetAnyReduce(const Starts& starts,
+                       const TargetBitmapView& elem_bitset,
+                       int64_t elem_offset,
+                       int64_t row_start,
+                       int64_t row_count,
+                       TargetBitmapView row_result) {
+    using word_t = TargetBitmapView::policy_type::data_type;
+    constexpr int64_t kWordBits = static_cast<int64_t>(8 * sizeof(word_t));
+
+    if (row_count == 0) {
+        return;
+    }
+    const int64_t first_bit = starts[row_start] - elem_offset;
+    const int64_t last_bit = starts[row_start + row_count] - elem_offset;
+    AssertInfo(
+        first_bit >= 0 && last_bit <= static_cast<int64_t>(elem_bitset.size()),
+        "element bitset does not cover rows [{}, {}): bits [{}, {}), "
+        "bitset size {}",
+        row_start,
+        row_start + row_count,
+        first_bit,
+        last_bit,
+        elem_bitset.size());
+
+    int64_t pos = first_bit;
+    int64_t row = row_start;
+    while (pos < last_bit) {
+        const int64_t n = std::min(kWordBits, last_bit - pos);
+        word_t word =
+            elem_bitset.read(static_cast<size_t>(pos), static_cast<size_t>(n));
+        if (word == 0) {
+            pos += n;
+            continue;
+        }
+        int64_t next_pos = pos + n;
+        do {
+            const int64_t bit = pos + __builtin_ctzll(word);
+            const int32_t elem_id = static_cast<int32_t>(bit + elem_offset);
+            // Monotone row cursor; empty rows are skipped by the same loop.
+            while (starts[row + 1] <= elem_id) {
+                ++row;
+            }
+            row_result[row - row_start] = true;
+            // Skip the rest of this row's elements.
+            const int64_t row_end = starts[row + 1] - elem_offset;
+            if (row_end >= pos + n) {
+                next_pos = row_end;
+                break;
+            }
+            // row_end falls inside the current word: clear bits below it.
+            // (0 < row_end - pos < kWordBits, so the shift is well-defined.)
+            word &= ~word_t(0) << (row_end - pos);
+        } while (word != 0);
+        pos = next_pos;
+    }
+}
+
 }  // namespace
 
 std::pair<int32_t, int32_t>
@@ -90,6 +165,40 @@ ArrayOffsetsSealed::ElementIDRangeOfRow(int32_t row_id) const {
         return {total, total};
     }
     return {row_to_element_start_[row_id], row_to_element_start_[row_id + 1]};
+}
+
+void
+ArrayOffsetsSealed::CopyRowElementRanges(
+    const int32_t* row_ids,
+    int64_t count,
+    std::pair<int32_t, int32_t>* out) const {
+    const auto row_count = static_cast<int32_t>(GetRowCount());
+    const int32_t* starts = row_to_element_start_.data();
+    for (int64_t i = 0; i < count; ++i) {
+        const int32_t row_id = row_ids[i];
+        assert(row_id >= 0 && row_id <= row_count);
+        if (row_id == row_count) {
+            out[i] = {starts[row_count], starts[row_count]};
+        } else {
+            out[i] = {starts[row_id], starts[row_id + 1]};
+        }
+    }
+}
+
+void
+ArrayOffsetsSealed::CopyRowElementStarts(int64_t row_start,
+                                         int64_t row_count,
+                                         int32_t* out) const {
+    AssertInfo(row_start >= 0 && row_count >= 0 &&
+                   row_start + row_count <= GetRowCount(),
+               "row range out of bounds: row_start={}, row_count={}, "
+               "total_rows={}",
+               row_start,
+               row_count,
+               GetRowCount());
+    std::memcpy(out,
+                row_to_element_start_.data() + row_start,
+                sizeof(int32_t) * (row_count + 1));
 }
 
 std::pair<TargetBitmap, TargetBitmap>
@@ -207,6 +316,28 @@ ArrayOffsetsSealed::ForEachRowElementRange(
     }
 
     return result;
+}
+
+void
+ArrayOffsetsSealed::ElementBitsetToRowBitsetAny(
+    const TargetBitmapView& elem_bitset,
+    int64_t elem_offset,
+    int64_t row_start,
+    TargetBitmapView row_result) const {
+    const int64_t row_count = row_result.size();
+    AssertInfo(row_start >= 0 && row_start + row_count <= GetRowCount(),
+               "row range out of bounds: row_start={}, row_count={}, "
+               "total_rows={}",
+               row_start,
+               row_count,
+               GetRowCount());
+
+    ElementBitsetAnyReduce(row_to_element_start_.data(),
+                           elem_bitset,
+                           elem_offset,
+                           row_start,
+                           row_count,
+                           row_result);
 }
 
 std::shared_ptr<ArrayOffsetsSealed>
@@ -416,6 +547,75 @@ ArrayOffsetsGrowing::ElementIDRangeOfRow(int32_t row_id) const {
     return {starts[row_id], starts[row_id + 1]};
 }
 
+void
+ArrayOffsetsGrowing::CopyRowElementRanges(
+    const int32_t* row_ids,
+    int64_t count,
+    std::pair<int32_t, int32_t>* out) const {
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
+    ChunkedReader starts(starts_chunks_);
+    const int32_t total = starts[committed];
+    for (int64_t i = 0; i < count; ++i) {
+        const int32_t row_id = row_ids[i];
+        // A not-yet-committed row has no published range yet.
+        if (row_id < 0 || row_id > committed) {
+            out[i] = {0, 0};
+            continue;
+        }
+        if (row_id == committed) {
+            out[i] = {total, total};
+        } else {
+            out[i] = {starts[row_id], starts[row_id + 1]};
+        }
+    }
+}
+
+void
+ArrayOffsetsGrowing::CopyStartsSlice(int64_t first_idx,
+                                     int64_t entry_count,
+                                     int32_t* out) const {
+    int64_t idx = first_idx;
+    int64_t copied = 0;
+    while (copied < entry_count) {
+        const int64_t chunk_id = idx >> kChunkBits;
+        const int64_t off = idx & kChunkMask;
+        const int64_t run =
+            std::min(kEntriesPerChunk - off, entry_count - copied);
+        std::memcpy(out + copied,
+                    starts_chunks_[static_cast<size_t>(chunk_id)].get() + off,
+                    sizeof(int32_t) * run);
+        idx += run;
+        copied += run;
+    }
+}
+
+void
+ArrayOffsetsGrowing::CopyRowElementStarts(int64_t row_start,
+                                          int64_t row_count,
+                                          int32_t* out) const {
+    AssertInfo(row_start >= 0 && row_count >= 0,
+               "invalid row range: row_start={}, row_count={}",
+               row_start,
+               row_count);
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
+    if (row_start + row_count <= committed) {
+        CopyStartsSlice(row_start, row_count + 1, out);
+        return;
+    }
+    // Rows at or beyond the committed count clamp to the committed total
+    // ({total, total}-style safety: not-yet-committed rows read as empty).
+    const int32_t total = LoadStart(committed);
+    int64_t i = 0;
+    if (row_start <= committed) {
+        const int64_t prefix = committed - row_start + 1;
+        CopyStartsSlice(row_start, prefix, out);
+        i = prefix;
+    }
+    std::fill(out + i, out + row_count + 1, total);
+}
+
 std::pair<TargetBitmap, TargetBitmap>
 ArrayOffsetsGrowing::RowBitsetToElementBitset(
     const TargetBitmapView& row_bitset,
@@ -550,11 +750,31 @@ ArrayOffsetsGrowing::ForEachRowElementRange(
 }
 
 void
+ArrayOffsetsGrowing::ElementBitsetToRowBitsetAny(
+    const TargetBitmapView& elem_bitset,
+    int64_t elem_offset,
+    int64_t row_start,
+    TargetBitmapView row_result) const {
+    const int64_t committed =
+        committed_row_count_.load(std::memory_order_acquire);
+    const int64_t row_count = row_result.size();
+    AssertInfo(row_start >= 0 && row_start + row_count <= committed,
+               "row range out of bounds: row_start={}, row_count={}, "
+               "committed_rows={}",
+               row_start,
+               row_count,
+               committed);
+
+    ChunkedReader starts(starts_chunks_);
+    ElementBitsetAnyReduce(
+        starts, elem_bitset, elem_offset, row_start, row_count, row_result);
+}
+
+void
 ArrayOffsetsGrowing::Insert(int64_t row_id_start,
                             const int32_t* array_lengths,
                             int64_t count) {
     std::lock_guard lock(write_mutex_);
-
     for (int64_t i = 0; i < count; ++i) {
         int64_t row_id = row_id_start + i;
         int32_t array_len = array_lengths[i];

--- a/internal/core/src/common/ArrayOffsets.h
+++ b/internal/core/src/common/ArrayOffsets.h
@@ -38,6 +38,13 @@ namespace milvus {
 
 class ChunkedColumnInterface;
 
+struct ElementRowInfo {
+    int32_t row_id;
+    int32_t element_index;
+    int32_t row_element_start;
+    int32_t row_element_end;
+};
+
 class IArrayOffsets {
  public:
     virtual ~IArrayOffsets() = default;
@@ -54,17 +61,24 @@ class IArrayOffsets {
     virtual std::pair<int32_t, int32_t>
     ElementIDToRowID(int32_t elem_id) const = 0;
 
+    // Convert an element ID to its row and return the row's element range in
+    // the same lookup. The growing implementation reads one published
+    // lock-free snapshot; the binary search that finds the row also identifies
+    // row_element_end.
+    virtual ElementRowInfo
+    ElementIDToRowInfo(int32_t elem_id) const = 0;
+
     // Convert row ID to element ID range
     // elements with id in [ret.first, ret.last) belong to row_id
     virtual std::pair<int32_t, int32_t>
     ElementIDRangeOfRow(int32_t row_id) const = 0;
 
-    // Batched form of ElementIDRangeOfRow: out[i] = element range of
-    // row_ids[i]. Semantics per entry match the per-row method. The growing
-    // implementation acquire-loads one publication watermark for the whole
-    // batch, and the caller pays one virtual call instead of one per row. A
-    // row id outside [0, committed rows] yields {0, 0} on growing
-    // (out-of-range insurance: a not-yet-committed row has no range yet).
+    // Batched row-range lookup. Sealed row IDs must be in [0, row_count).
+    // Growing rejects negative row IDs, but rows not yet committed yield an
+    // empty range so concurrent readers never observe a half-written range.
+    // The growing implementation acquire-loads one publication watermark for
+    // the whole batch, and the caller pays one virtual call instead of one per
+    // row.
     virtual void
     CopyRowElementRanges(const int32_t* row_ids,
                          int64_t count,
@@ -178,6 +192,9 @@ class ArrayOffsetsSealed : public IArrayOffsets {
     std::pair<int32_t, int32_t>
     ElementIDToRowID(int32_t elem_id) const override;
 
+    ElementRowInfo
+    ElementIDToRowInfo(int32_t elem_id) const override;
+
     std::pair<int32_t, int32_t>
     ElementIDRangeOfRow(int32_t row_id) const override;
 
@@ -277,6 +294,9 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
 
     std::pair<int32_t, int32_t>
     ElementIDToRowID(int32_t elem_id) const override;
+
+    ElementRowInfo
+    ElementIDToRowInfo(int32_t elem_id) const override;
 
     std::pair<int32_t, int32_t>
     ElementIDRangeOfRow(int32_t row_id) const override;

--- a/internal/core/src/common/ArrayOffsets.h
+++ b/internal/core/src/common/ArrayOffsets.h
@@ -59,6 +59,30 @@ class IArrayOffsets {
     virtual std::pair<int32_t, int32_t>
     ElementIDRangeOfRow(int32_t row_id) const = 0;
 
+    // Batched form of ElementIDRangeOfRow: out[i] = element range of
+    // row_ids[i]. Semantics per entry match the per-row method. The growing
+    // implementation acquire-loads one publication watermark for the whole
+    // batch, and the caller pays one virtual call instead of one per row. A
+    // row id outside [0, committed rows] yields {0, 0} on growing
+    // (out-of-range insurance: a not-yet-committed row has no range yet).
+    virtual void
+    CopyRowElementRanges(const int32_t* row_ids,
+                         int64_t count,
+                         std::pair<int32_t, int32_t>* out) const = 0;
+
+    // Contiguous form for the common sequential-batch case: copy
+    // starts[row_start .. row_start + row_count] into out (row_count + 1
+    // entries), so [out[i], out[i+1]) is row (row_start + i)'s element
+    // range. Sealed is a straight memcpy; growing reads one lock-free snapshot,
+    // copies committed entries per chunk-run, and clamps rows beyond the
+    // committed count to the last committed total (equivalent to the per-row
+    // method's {total, total} for row == committed_row_count_, extended to any
+    // not-yet-committed row).
+    virtual void
+    CopyRowElementStarts(int64_t row_start,
+                         int64_t row_count,
+                         int32_t* out) const = 0;
+
     // Convert row-level bitsets to element-level bitsets
     // row_start: starting row index (0-based)
     // row_bitset.size(): number of rows to process
@@ -91,6 +115,21 @@ class IArrayOffsets {
     ForEachRowElementRange(const ElementRangePredicate& predicate,
                            int64_t row_start,
                            int64_t row_count) const = 0;
+
+    // Word-wise ANY-semantics reduction of an element-level bitmap to row
+    // level. Bit j of elem_bitset corresponds to global element id
+    // (elem_offset + j). For each i in [0, row_result.size()), sets
+    // row_result[i] = true iff any element bit of row (row_start + i) is set.
+    // Bits in row_result are only ever set, never cleared. elem_bitset must
+    // cover the element ranges of all addressed rows.
+    // This is the hot path used to fold element-level match bits back to
+    // rows (MATCH_ANY over an all-valid element bitmap); it skips zero words
+    // instead of testing element bits one by one.
+    virtual void
+    ElementBitsetToRowBitsetAny(const TargetBitmapView& elem_bitset,
+                                int64_t elem_offset,
+                                int64_t row_start,
+                                TargetBitmapView row_result) const = 0;
 };
 
 class ArrayOffsetsSealed : public IArrayOffsets {
@@ -142,6 +181,16 @@ class ArrayOffsetsSealed : public IArrayOffsets {
     std::pair<int32_t, int32_t>
     ElementIDRangeOfRow(int32_t row_id) const override;
 
+    void
+    CopyRowElementRanges(const int32_t* row_ids,
+                         int64_t count,
+                         std::pair<int32_t, int32_t>* out) const override;
+
+    void
+    CopyRowElementStarts(int64_t row_start,
+                         int64_t row_count,
+                         int32_t* out) const override;
+
     std::pair<TargetBitmap, TargetBitmap>
     RowBitsetToElementBitset(const TargetBitmapView& row_bitset,
                              const TargetBitmapView& valid_row_bitset,
@@ -159,6 +208,12 @@ class ArrayOffsetsSealed : public IArrayOffsets {
     ForEachRowElementRange(const ElementRangePredicate& predicate,
                            int64_t row_start,
                            int64_t row_count) const override;
+
+    void
+    ElementBitsetToRowBitsetAny(const TargetBitmapView& elem_bitset,
+                                int64_t elem_offset,
+                                int64_t row_start,
+                                TargetBitmapView row_result) const override;
 
     static std::shared_ptr<ArrayOffsetsSealed>
     BuildFromSegment(const void* segment, const FieldMeta& field_meta);
@@ -226,6 +281,16 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
     std::pair<int32_t, int32_t>
     ElementIDRangeOfRow(int32_t row_id) const override;
 
+    void
+    CopyRowElementRanges(const int32_t* row_ids,
+                         int64_t count,
+                         std::pair<int32_t, int32_t>* out) const override;
+
+    void
+    CopyRowElementStarts(int64_t row_start,
+                         int64_t row_count,
+                         int32_t* out) const override;
+
     std::pair<TargetBitmap, TargetBitmap>
     RowBitsetToElementBitset(const TargetBitmapView& row_bitset,
                              const TargetBitmapView& valid_row_bitset,
@@ -243,6 +308,12 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
     ForEachRowElementRange(const ElementRangePredicate& predicate,
                            int64_t row_start,
                            int64_t row_count) const override;
+
+    void
+    ElementBitsetToRowBitsetAny(const TargetBitmapView& elem_bitset,
+                                int64_t elem_offset,
+                                int64_t row_start,
+                                TargetBitmapView row_result) const override;
 
  private:
     struct PendingRow {
@@ -270,6 +341,9 @@ class ArrayOffsetsGrowing : public IArrayOffsets {
     LoadStart(int64_t idx) const {
         return starts_chunks_[idx >> kChunkBits][idx & kChunkMask];
     }
+
+    void
+    CopyStartsSlice(int64_t first_idx, int64_t entry_count, int32_t* out) const;
 
     // Writer-side helpers; write_mutex_ must be held.
     void

--- a/internal/core/src/common/ArrayOffsetsTest.cpp
+++ b/internal/core/src/common/ArrayOffsetsTest.cpp
@@ -697,6 +697,327 @@ TEST_F(ArrayOffsetsTest, GrowingRowBitsetToElementBitsetWithRowStart) {
     EXPECT_TRUE(elem_bitset[5]);
 }
 
+// ============ ElementBitsetToRowBitsetAny (word-wise ANY reduction) ============
+
+namespace {
+
+// Per-bit reference implementation of ANY-semantics element->row reduction.
+TargetBitmap
+ReferenceAnyReduce(const IArrayOffsets& offsets,
+                   const TargetBitmap& elem_bitset,
+                   int64_t elem_offset,
+                   int64_t row_start,
+                   int64_t row_count) {
+    TargetBitmap expected(row_count);
+    for (int64_t i = 0; i < row_count; ++i) {
+        auto [start, end] = offsets.ElementIDRangeOfRow(row_start + i);
+        for (int64_t e = start; e < end; ++e) {
+            if (elem_bitset[e - elem_offset]) {
+                expected[i] = true;
+                break;
+            }
+        }
+    }
+    return expected;
+}
+
+void
+CheckAnyReduce(const IArrayOffsets& offsets,
+               const TargetBitmap& elem_bitset,
+               int64_t elem_offset,
+               int64_t row_start,
+               int64_t row_count) {
+    TargetBitmap actual(row_count);
+    offsets.ElementBitsetToRowBitsetAny(
+        elem_bitset.view(), elem_offset, row_start, actual.view());
+    TargetBitmap expected = ReferenceAnyReduce(
+        offsets, elem_bitset, elem_offset, row_start, row_count);
+    ASSERT_EQ(actual.size(), expected.size());
+    for (int64_t i = 0; i < row_count; ++i) {
+        ASSERT_EQ(actual[i], expected[i])
+            << "row " << i << " (row_start=" << row_start
+            << ", elem_offset=" << elem_offset << ")";
+    }
+}
+
+}  // namespace
+
+TEST_F(ArrayOffsetsTest, SealedElementBitsetToRowBitsetAnyBasic) {
+    // row 0: elems [0,2), row 1: elems [2,5), row 2: empty, row 3: elems [5,6)
+    ArrayOffsetsSealed offsets({0, 2, 5, 5, 6});
+
+    TargetBitmap elem_bitset(6);
+    elem_bitset[3] = true;  // row 1
+    elem_bitset[5] = true;  // row 3
+
+    TargetBitmap row_bitset(4);
+    offsets.ElementBitsetToRowBitsetAny(
+        elem_bitset.view(), 0, 0, row_bitset.view());
+    EXPECT_FALSE(row_bitset[0]);
+    EXPECT_TRUE(row_bitset[1]);
+    EXPECT_FALSE(row_bitset[2]);  // empty row never matches
+    EXPECT_TRUE(row_bitset[3]);
+
+    // Never clears pre-set bits.
+    TargetBitmap preset(4);
+    preset[0] = true;
+    offsets.ElementBitsetToRowBitsetAny(
+        elem_bitset.view(), 0, 0, preset.view());
+    EXPECT_TRUE(preset[0]);
+    EXPECT_TRUE(preset[1]);
+    EXPECT_FALSE(preset[2]);
+    EXPECT_TRUE(preset[3]);
+}
+
+TEST_F(ArrayOffsetsTest, SealedElementBitsetToRowBitsetAnyEdgeCases) {
+    ArrayOffsetsSealed offsets({0, 2, 5, 5, 6});
+
+    // All-zero element bitmap -> no rows.
+    {
+        TargetBitmap elem_bitset(6);
+        TargetBitmap row_bitset(4);
+        offsets.ElementBitsetToRowBitsetAny(
+            elem_bitset.view(), 0, 0, row_bitset.view());
+        EXPECT_EQ(row_bitset.count(), 0);
+    }
+    // All-one element bitmap -> all non-empty rows.
+    {
+        TargetBitmap elem_bitset(6, true);
+        TargetBitmap row_bitset(4);
+        offsets.ElementBitsetToRowBitsetAny(
+            elem_bitset.view(), 0, 0, row_bitset.view());
+        EXPECT_TRUE(row_bitset[0]);
+        EXPECT_TRUE(row_bitset[1]);
+        EXPECT_FALSE(row_bitset[2]);
+        EXPECT_TRUE(row_bitset[3]);
+    }
+    // Empty row range.
+    {
+        TargetBitmap elem_bitset(6, true);
+        TargetBitmap row_bitset(0);
+        offsets.ElementBitsetToRowBitsetAny(
+            elem_bitset.view(), 0, 0, row_bitset.view());
+    }
+    // Sub-range of rows with a batch-local bitmap (elem_offset != 0):
+    // rows [1, 4) cover elements [2, 6).
+    {
+        TargetBitmap elem_bitset(4);
+        elem_bitset[0] = true;  // global elem 2 -> row 1
+        elem_bitset[3] = true;  // global elem 5 -> row 3
+        TargetBitmap row_bitset(3);
+        offsets.ElementBitsetToRowBitsetAny(elem_bitset.view(),
+                                            /*elem_offset=*/2,
+                                            /*row_start=*/1,
+                                            row_bitset.view());
+        EXPECT_TRUE(row_bitset[0]);
+        EXPECT_FALSE(row_bitset[1]);
+        EXPECT_TRUE(row_bitset[2]);
+    }
+    // Global bitmap but only a sub-range of rows: hits outside the row range
+    // must be ignored.
+    {
+        TargetBitmap elem_bitset(6);
+        elem_bitset[0] = true;  // row 0, outside range
+        elem_bitset[3] = true;  // row 1, inside
+        TargetBitmap row_bitset(2);
+        offsets.ElementBitsetToRowBitsetAny(
+            elem_bitset.view(), 0, /*row_start=*/1, row_bitset.view());
+        EXPECT_TRUE(row_bitset[0]);   // row 1
+        EXPECT_FALSE(row_bitset[1]);  // row 2 (empty)
+    }
+}
+
+TEST_F(ArrayOffsetsTest, ElementBitsetToRowBitsetAnyRandomized) {
+    std::mt19937 rng(12345);
+    for (int iter = 0; iter < 20; ++iter) {
+        // Random layout: mixes empty rows, short and long (multi-word) rows.
+        int64_t num_rows = 1 + rng() % 300;
+        std::vector<int32_t> starts(num_rows + 1, 0);
+        std::vector<int32_t> lengths(num_rows);
+        for (int64_t i = 0; i < num_rows; ++i) {
+            int pick = rng() % 4;
+            lengths[i] = pick == 0 ? 0 : (pick == 1 ? rng() % 3 : rng() % 200);
+            starts[i + 1] = starts[i] + lengths[i];
+        }
+        int64_t total = starts[num_rows];
+
+        ArrayOffsetsSealed sealed(starts);
+        ArrayOffsetsGrowing growing;
+        growing.Insert(0, lengths.data(), num_rows);
+
+        for (double density : {0.0, 0.005, 0.1, 0.9, 1.0}) {
+            TargetBitmap elem_bitset(total);
+            for (int64_t e = 0; e < total; ++e) {
+                if (rng() % 1000 < density * 1000) {
+                    elem_bitset[e] = true;
+                }
+            }
+            CheckAnyReduce(sealed, elem_bitset, 0, 0, num_rows);
+            CheckAnyReduce(growing, elem_bitset, 0, 0, num_rows);
+
+            // Random row sub-range with a batch-local element bitmap.
+            int64_t row_start = rng() % num_rows;
+            int64_t row_count = rng() % (num_rows - row_start + 1);
+            int64_t elem_lo = starts[row_start];
+            int64_t elem_hi = starts[row_start + row_count];
+            TargetBitmap local(elem_hi - elem_lo);
+            for (int64_t e = elem_lo; e < elem_hi; ++e) {
+                if (elem_bitset[e]) {
+                    local[e - elem_lo] = true;
+                }
+            }
+            CheckAnyReduce(sealed, local, elem_lo, row_start, row_count);
+            CheckAnyReduce(growing, local, elem_lo, row_start, row_count);
+        }
+    }
+}
+
+// ==== CopyRowElementStarts / CopyRowElementRanges (batched row lookups) ====
+
+TEST_F(ArrayOffsetsTest, SealedCopyRowElementStarts) {
+    // row 0: [0,2), row 1: [2,5), row 2: empty, row 3: [5,6)
+    ArrayOffsetsSealed offsets({0, 2, 5, 5, 6});
+
+    // Full range: row_count + 1 entries.
+    {
+        std::vector<int32_t> out(5, -1);
+        offsets.CopyRowElementStarts(0, 4, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 2, 5, 5, 6}));
+    }
+    // Sub-range starting mid-way (covers the empty row 2).
+    {
+        std::vector<int32_t> out(3, -1);
+        offsets.CopyRowElementStarts(1, 2, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{2, 5, 5}));
+    }
+    // row_count == 0: single entry, the start of row_start (here the total,
+    // since row_start == row count).
+    {
+        int32_t out = -1;
+        offsets.CopyRowElementStarts(4, 0, &out);
+        EXPECT_EQ(out, 6);
+    }
+    // Consistency with the per-row method.
+    {
+        std::vector<int32_t> out(5, -1);
+        offsets.CopyRowElementStarts(0, 4, out.data());
+        for (int32_t row = 0; row < 4; ++row) {
+            auto [start, end] = offsets.ElementIDRangeOfRow(row);
+            EXPECT_EQ(out[row], start);
+            EXPECT_EQ(out[row + 1], end);
+        }
+    }
+}
+
+TEST_F(ArrayOffsetsTest, GrowingCopyRowElementStartsClamp) {
+    ArrayOffsetsGrowing offsets;
+
+    // No committed rows yet: every entry clamps to 0.
+    {
+        std::vector<int32_t> out(4, -1);
+        offsets.CopyRowElementStarts(0, 3, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 0, 0, 0}));
+    }
+
+    std::vector<int32_t> lens = {2, 3, 0, 1};
+    offsets.Insert(0, lens.data(), 4);
+
+    // Fully committed range, including the empty row 2.
+    {
+        std::vector<int32_t> out(5, -1);
+        offsets.CopyRowElementStarts(0, 4, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 2, 5, 5, 6}));
+    }
+    // Row 6 arrives out of order and stays PENDING (row 4/5 missing): rows
+    // at or beyond the committed count clamp to the committed total, so
+    // pending rows read as empty instead of exposing garbage.
+    std::vector<int32_t> lens6 = {7};
+    offsets.Insert(6, lens6.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 4);
+    {
+        std::vector<int32_t> out(8, -1);
+        offsets.CopyRowElementStarts(0, 7, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 2, 5, 5, 6, 6, 6, 6}));
+    }
+    // Range entirely beyond the committed rows.
+    {
+        std::vector<int32_t> out(3, -1);
+        offsets.CopyRowElementStarts(5, 2, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{6, 6, 6}));
+    }
+    // Committing the gap drains the pending row and un-clamps it.
+    std::vector<int32_t> lens45 = {1, 0};
+    offsets.Insert(4, lens45.data(), 2);
+    EXPECT_EQ(offsets.GetRowCount(), 7);
+    {
+        std::vector<int32_t> out(8, -1);
+        offsets.CopyRowElementStarts(0, 7, out.data());
+        EXPECT_EQ(out, (std::vector<int32_t>{0, 2, 5, 5, 6, 7, 7, 14}));
+    }
+}
+
+TEST_F(ArrayOffsetsTest, SealedCopyRowElementRanges) {
+    // row 0: [0,2), row 1: [2,5), row 2: empty, row 3: [5,6)
+    ArrayOffsetsSealed offsets({0, 2, 5, 5, 6});
+
+    // Arbitrary order + duplicates + the end sentinel row (== row_count).
+    std::vector<int32_t> rows = {3, 0, 2, 0, 4};
+    std::vector<std::pair<int32_t, int32_t>> out(rows.size());
+    offsets.CopyRowElementRanges(
+        rows.data(), static_cast<int64_t>(rows.size()), out.data());
+    EXPECT_EQ(out[0], (std::pair<int32_t, int32_t>{5, 6}));
+    EXPECT_EQ(out[1], (std::pair<int32_t, int32_t>{0, 2}));
+    EXPECT_EQ(out[2], (std::pair<int32_t, int32_t>{5, 5}));  // empty row
+    EXPECT_EQ(out[3], (std::pair<int32_t, int32_t>{0, 2}));
+    EXPECT_EQ(out[4], (std::pair<int32_t, int32_t>{6, 6}));  // == row_count
+    // Consistency with the per-row method.
+    for (size_t i = 0; i < rows.size(); ++i) {
+        EXPECT_EQ(out[i], offsets.ElementIDRangeOfRow(rows[i]));
+    }
+}
+
+TEST_F(ArrayOffsetsTest, GrowingCopyRowElementRanges) {
+    ArrayOffsetsGrowing offsets;
+
+    // No committed rows: {0, 0} out-of-range insurance.
+    {
+        std::vector<int32_t> rows = {0};
+        std::pair<int32_t, int32_t> out{-1, -1};
+        offsets.CopyRowElementRanges(rows.data(), 1, &out);
+        EXPECT_EQ(out, (std::pair<int32_t, int32_t>{0, 0}));
+    }
+
+    std::vector<int32_t> lens = {2, 0, 3};
+    offsets.Insert(0, lens.data(), 3);
+
+    std::vector<int32_t> rows = {2, 1, 0, 3};
+    std::vector<std::pair<int32_t, int32_t>> out(rows.size());
+    offsets.CopyRowElementRanges(
+        rows.data(), static_cast<int64_t>(rows.size()), out.data());
+    EXPECT_EQ(out[0], (std::pair<int32_t, int32_t>{2, 5}));
+    EXPECT_EQ(out[1], (std::pair<int32_t, int32_t>{2, 2}));  // empty row
+    EXPECT_EQ(out[2], (std::pair<int32_t, int32_t>{0, 2}));
+    // committed_row_count_ itself reads as {total, total}.
+    EXPECT_EQ(out[3], (std::pair<int32_t, int32_t>{5, 5}));
+    for (size_t i = 0; i < rows.size(); ++i) {
+        EXPECT_EQ(out[i], offsets.ElementIDRangeOfRow(rows[i]));
+    }
+
+    // Row 5 arrives out of order and stays pending: it is beyond the
+    // committed count and reads as {0, 0} (out-of-range insurance) rather
+    // than exposing a half-written range.
+    std::vector<int32_t> lens5 = {4};
+    offsets.Insert(5, lens5.data(), 1);
+    EXPECT_EQ(offsets.GetRowCount(), 3);
+    {
+        std::vector<int32_t> pending_rows = {5, 4};
+        std::vector<std::pair<int32_t, int32_t>> pending_out(2);
+        offsets.CopyRowElementRanges(pending_rows.data(), 2, pending_out.data());
+        EXPECT_EQ(pending_out[0], (std::pair<int32_t, int32_t>{0, 0}));
+        EXPECT_EQ(pending_out[1], (std::pair<int32_t, int32_t>{0, 0}));
+    }
+}
+
 TEST_F(ArrayOffsetsTest, GrowingEmptyTableRange) {
     ArrayOffsetsGrowing offsets;
 
@@ -803,6 +1124,20 @@ TEST_F(ArrayOffsetsTest, GrowingChunkBoundary) {
         }
     }
 
+    std::vector<int32_t> copied_starts(row_count + 1, -1);
+    offsets.CopyRowElementStarts(row_start, row_count, copied_starts.data());
+    for (int64_t i = 0; i <= row_count; ++i) {
+        EXPECT_EQ(copied_starts[i], expected[row_start + i]);
+    }
+
+    TargetBitmap any_rows(row_count);
+    offsets.ElementBitsetToRowBitsetAny(
+        element_bits.view(), expected[row_start], row_start, any_rows.view());
+    for (int64_t i = 0; i < row_count; ++i) {
+        EXPECT_EQ(bool(any_rows[i]),
+                  bool(row_bits[i]) && lens[row_start + i] > 0);
+    }
+
     auto element_offsets =
         offsets.RowBitsetToElementOffsets(row_bits.view(), row_start);
     std::vector<int32_t> expected_offsets;
@@ -822,6 +1157,17 @@ TEST_F(ArrayOffsetsTest, GrowingChunkBoundary) {
                                         static_cast<int32_t>(kChunk),
                                         static_cast<int32_t>(kChunk + 1),
                                         static_cast<int32_t>(2 * kChunk)};
+    std::vector<std::pair<int32_t, int32_t>> copied_ranges(row_offsets.size());
+    offsets.CopyRowElementRanges(row_offsets.data(),
+                                 static_cast<int64_t>(row_offsets.size()),
+                                 copied_ranges.data());
+    for (size_t i = 0; i < row_offsets.size(); ++i) {
+        const int32_t row = row_offsets[i];
+        EXPECT_EQ(
+            copied_ranges[i],
+            (std::pair<int32_t, int32_t>{expected[row], expected[row + 1]}));
+    }
+
     auto selected = offsets.RowOffsetsToElementOffsets(row_offsets);
     expected_offsets.clear();
     for (auto row : row_offsets) {
@@ -972,6 +1318,26 @@ TEST_F(ArrayOffsetsTest, GrowingConcurrentWriterReaderStress) {
                 EXPECT_EQ(last_start, expected[row_start + row_count - 1]);
                 EXPECT_EQ(last_end, expected[row_start + row_count]);
 
+                int32_t copied_starts[129];
+                offsets.CopyRowElementStarts(
+                    row_start, row_count, copied_starts);
+                for (int64_t i = 0; i <= row_count; ++i) {
+                    EXPECT_EQ(copied_starts[i], expected[row_start + i]);
+                }
+
+                int32_t copied_rows[2] = {
+                    static_cast<int32_t>(row_start),
+                    static_cast<int32_t>(row_start + row_count - 1)};
+                std::pair<int32_t, int32_t> copied_ranges[2];
+                offsets.CopyRowElementRanges(copied_rows, 2, copied_ranges);
+                EXPECT_EQ(copied_ranges[0],
+                          (std::pair<int32_t, int32_t>{
+                              expected[row_start], expected[row_start + 1]}));
+                EXPECT_EQ(copied_ranges[1],
+                          (std::pair<int32_t, int32_t>{
+                              expected[row_start + row_count - 1],
+                              expected[row_start + row_count]}));
+
                 if (total > 0) {
                     const auto element =
                         static_cast<int32_t>(reader_gen() % total);
@@ -1004,6 +1370,16 @@ TEST_F(ArrayOffsetsTest, GrowingConcurrentWriterReaderStress) {
                             bool(element_bits[element - expected[row_start]]),
                             bool(row_bits[i]));
                     }
+                }
+
+                TargetBitmap any_rows(row_count);
+                offsets.ElementBitsetToRowBitsetAny(element_bits.view(),
+                                                    expected[row_start],
+                                                    row_start,
+                                                    any_rows.view());
+                for (int64_t i = 0; i < row_count; ++i) {
+                    EXPECT_EQ(bool(any_rows[i]),
+                              bool(row_bits[i]) && lens[row_start + i] > 0);
                 }
 
                 auto selected = offsets.RowBitsetToElementOffsets(

--- a/internal/core/src/common/ArrayOffsetsTest.cpp
+++ b/internal/core/src/common/ArrayOffsetsTest.cpp
@@ -404,6 +404,40 @@ TEST_F(ArrayOffsetsTest, SingleElementPerRow) {
     }
 }
 
+TEST_F(ArrayOffsetsTest, SealedElementIDToRowInfo) {
+    // Adjacent singleton rows, an empty row, a multi-element row, and a final
+    // singleton row.
+    ArrayOffsetsSealed offsets({0, 1, 2, 2, 5, 6});
+
+    for (int32_t element_id = 0; element_id < 6; ++element_id) {
+        const auto info = offsets.ElementIDToRowInfo(element_id);
+        const auto [row_id, element_index] =
+            offsets.ElementIDToRowID(element_id);
+        const auto [row_start, row_end] = offsets.ElementIDRangeOfRow(row_id);
+        EXPECT_EQ(info.row_id, row_id);
+        EXPECT_EQ(info.element_index, element_index);
+        EXPECT_EQ(info.row_element_start, row_start);
+        EXPECT_EQ(info.row_element_end, row_end);
+    }
+}
+
+TEST_F(ArrayOffsetsTest, GrowingElementIDToRowInfo) {
+    ArrayOffsetsGrowing offsets;
+    std::vector<int32_t> lengths = {1, 1, 0, 3, 1};
+    offsets.Insert(0, lengths.data(), lengths.size());
+
+    for (int32_t element_id = 0; element_id < 6; ++element_id) {
+        const auto info = offsets.ElementIDToRowInfo(element_id);
+        const auto [row_id, element_index] =
+            offsets.ElementIDToRowID(element_id);
+        const auto [row_start, row_end] = offsets.ElementIDRangeOfRow(row_id);
+        EXPECT_EQ(info.row_id, row_id);
+        EXPECT_EQ(info.element_index, element_index);
+        EXPECT_EQ(info.row_element_start, row_start);
+        EXPECT_EQ(info.row_element_end, row_end);
+    }
+}
+
 TEST_F(ArrayOffsetsTest, LargeArrayLength) {
     ArrayOffsetsGrowing offsets;
 
@@ -960,8 +994,8 @@ TEST_F(ArrayOffsetsTest, SealedCopyRowElementRanges) {
     // row 0: [0,2), row 1: [2,5), row 2: empty, row 3: [5,6)
     ArrayOffsetsSealed offsets({0, 2, 5, 5, 6});
 
-    // Arbitrary order + duplicates + the end sentinel row (== row_count).
-    std::vector<int32_t> rows = {3, 0, 2, 0, 4};
+    // Arbitrary order + duplicates.
+    std::vector<int32_t> rows = {3, 0, 2, 0};
     std::vector<std::pair<int32_t, int32_t>> out(rows.size());
     offsets.CopyRowElementRanges(
         rows.data(), static_cast<int64_t>(rows.size()), out.data());
@@ -969,15 +1003,35 @@ TEST_F(ArrayOffsetsTest, SealedCopyRowElementRanges) {
     EXPECT_EQ(out[1], (std::pair<int32_t, int32_t>{0, 2}));
     EXPECT_EQ(out[2], (std::pair<int32_t, int32_t>{5, 5}));  // empty row
     EXPECT_EQ(out[3], (std::pair<int32_t, int32_t>{0, 2}));
-    EXPECT_EQ(out[4], (std::pair<int32_t, int32_t>{6, 6}));  // == row_count
     // Consistency with the per-row method.
     for (size_t i = 0; i < rows.size(); ++i) {
         EXPECT_EQ(out[i], offsets.ElementIDRangeOfRow(rows[i]));
+    }
+
+    for (const int32_t invalid_row : {-1, 4}) {
+        std::pair<int32_t, int32_t> invalid_out;
+        try {
+            offsets.CopyRowElementRanges(&invalid_row, 1, &invalid_out);
+            FAIL() << "expected invalid sealed row id to throw";
+        } catch (const SegcoreError& error) {
+            EXPECT_EQ(error.get_error_code(), ErrorCode::UnexpectedError);
+        }
     }
 }
 
 TEST_F(ArrayOffsetsTest, GrowingCopyRowElementRanges) {
     ArrayOffsetsGrowing offsets;
+
+    {
+        const int32_t invalid_row = -1;
+        std::pair<int32_t, int32_t> invalid_out;
+        try {
+            offsets.CopyRowElementRanges(&invalid_row, 1, &invalid_out);
+            FAIL() << "expected negative growing row id to throw";
+        } catch (const SegcoreError& error) {
+            EXPECT_EQ(error.get_error_code(), ErrorCode::UnexpectedError);
+        }
+    }
 
     // No committed rows: {0, 0} out-of-range insurance.
     {
@@ -1012,7 +1066,8 @@ TEST_F(ArrayOffsetsTest, GrowingCopyRowElementRanges) {
     {
         std::vector<int32_t> pending_rows = {5, 4};
         std::vector<std::pair<int32_t, int32_t>> pending_out(2);
-        offsets.CopyRowElementRanges(pending_rows.data(), 2, pending_out.data());
+        offsets.CopyRowElementRanges(
+            pending_rows.data(), 2, pending_out.data());
         EXPECT_EQ(pending_out[0], (std::pair<int32_t, int32_t>{0, 0}));
         EXPECT_EQ(pending_out[1], (std::pair<int32_t, int32_t>{0, 0}));
     }
@@ -1090,6 +1145,14 @@ TEST_F(ArrayOffsetsTest, GrowingChunkBoundary) {
         auto [row, index] = offsets.ElementIDToRowID(element);
         EXPECT_EQ(row, expected_row) << "element " << element;
         EXPECT_EQ(index, element - expected[expected_row])
+            << "element " << element;
+        const auto info = offsets.ElementIDToRowInfo(element);
+        EXPECT_EQ(info.row_id, expected_row) << "element " << element;
+        EXPECT_EQ(info.element_index, element - expected[expected_row])
+            << "element " << element;
+        EXPECT_EQ(info.row_element_start, expected[expected_row])
+            << "element " << element;
+        EXPECT_EQ(info.row_element_end, expected[expected_row + 1])
             << "element " << element;
     };
     for (int32_t element : {0,
@@ -1348,6 +1411,12 @@ TEST_F(ArrayOffsetsTest, GrowingConcurrentWriterReaderStress) {
                     auto [row, index] = offsets.ElementIDToRowID(element);
                     EXPECT_EQ(row, expected_row);
                     EXPECT_EQ(index, element - expected[expected_row]);
+                    const auto info = offsets.ElementIDToRowInfo(element);
+                    EXPECT_EQ(info.row_id, expected_row);
+                    EXPECT_EQ(info.element_index,
+                              element - expected[expected_row]);
+                    EXPECT_EQ(info.row_element_start, expected[expected_row]);
+                    EXPECT_EQ(info.row_element_end, expected[expected_row + 1]);
                 }
 
                 TargetBitmap row_bits(row_count);

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -971,90 +971,130 @@ class SegmentExpr : public Expr {
                           field_id_.get());
             }
 
-            // Batch process consecutive elements belonging to the same chunk
+            // The element ids arriving here come from
+            // RowOffsetsToElementOffsets, which emits each row's element ids
+            // CONSECUTIVELY ASCENDING. Exploit that: resolve (row, elem_idx)
+            // ONCE per run of consecutive ids inside one row, instead of one
+            // binary search + one chunk lookup + one ArrayView fetch per
+            // element. The run assumption is guarded per element (any id
+            // that is not the expected consecutive one simply starts a fresh
+            // run), so correctness never depends on the input being sorted.
             size_t processed_size = 0;
             size_t i = 0;
 
-            // Reuse these vectors to avoid repeated heap allocations
+            // Reuse these vectors to avoid repeated heap allocations.
+            // One entry per RUN (not per element): the run's row chunk
+            // offset, the run's first element index within the row, and the
+            // run length in elements.
             FixedVector<int32_t> offsets;
-            FixedVector<int32_t> elem_indices;
+            FixedVector<int32_t> first_elem_indices;
+            FixedVector<int32_t> run_lengths;
+
+            struct RunInfo {
+                int32_t row_id;
+                int32_t first_elem_idx;
+                int32_t length;
+            };
+            // Resolve the run starting at input position pos: one row
+            // resolution covers every consecutive element id of that row.
+            auto resolve_run = [&](size_t pos) -> RunInfo {
+                int32_t element_id = (*element_ids)[pos];
+                auto [row_id, elem_idx] =
+                    array_offsets->ElementIDToRowID(element_id);
+                const int32_t row_last =
+                    array_offsets->ElementIDRangeOfRow(row_id).second;
+                int64_t max_run = std::min<int64_t>(row_last - element_id,
+                                                    element_ids->size() - pos);
+                int64_t run_len = 1;
+                while (run_len < max_run &&
+                       (*element_ids)[pos + run_len] == element_id + run_len) {
+                    ++run_len;
+                }
+                return {row_id, elem_idx, static_cast<int32_t>(run_len)};
+            };
 
             while (i < element_ids->size()) {
                 // Start of a new chunk batch
-                int64_t element_id = (*element_ids)[i];
-                auto [doc_id, elem_idx] =
-                    array_offsets->ElementIDToRowID(element_id);
+                auto run = resolve_run(i);
                 auto [chunk_id, chunk_offset] =
-                    segment_->get_chunk_by_offset(field_id_, doc_id);
+                    segment_->get_chunk_by_offset(field_id_, run.row_id);
 
-                // Collect consecutive elements belonging to the same chunk
+                // Collect consecutive runs belonging to the same chunk
                 offsets.clear();
-                elem_indices.clear();
+                first_elem_indices.clear();
+                run_lengths.clear();
                 offsets.push_back(chunk_offset);
-                elem_indices.push_back(elem_idx);
+                first_elem_indices.push_back(run.first_elem_idx);
+                run_lengths.push_back(run.length);
 
                 size_t batch_start = i;
-                i++;
+                i += run.length;
 
-                // Look ahead for more elements in the same chunk
+                // Look ahead for more runs in the same chunk
                 while (i < element_ids->size()) {
-                    int64_t next_element_id = (*element_ids)[i];
-                    auto [next_doc_id, next_elem_idx] =
-                        array_offsets->ElementIDToRowID(next_element_id);
+                    auto next_run = resolve_run(i);
                     auto [next_chunk_id, next_chunk_offset] =
-                        segment_->get_chunk_by_offset(field_id_, next_doc_id);
+                        segment_->get_chunk_by_offset(field_id_,
+                                                      next_run.row_id);
 
                     if (next_chunk_id != chunk_id) {
                         break;  // Different chunk, process current batch
                     }
 
                     offsets.push_back(next_chunk_offset);
-                    elem_indices.push_back(next_elem_idx);
-                    i++;
+                    first_elem_indices.push_back(next_run.first_elem_idx);
+                    run_lengths.push_back(next_run.length);
+                    i += next_run.length;
                 }
 
-                // Batch fetch all ArrayViews for this chunk
+                // Batch fetch ONE ArrayView per run (per row) in this chunk
                 auto pw = segment_->get_views_by_offsets<ArrayView>(
                     op_ctx_, field_id_, chunk_id, offsets);
 
                 auto [array_vec, valid_data] = pw.get();
 
-                // Process each element in this batch
+                const bool chunk_active =
+                    !skip_func || !skip_func(*skip_index, field_id_, chunk_id);
+
+                // Process each run's elements in this batch
+                size_t result_idx = batch_start;
                 for (size_t j = 0; j < offsets.size(); j++) {
-                    size_t result_idx = batch_start + j;
+                    for (int32_t t = 0; t < run_lengths[j]; ++t, ++result_idx) {
+                        if (chunk_active) {
+                            // Extract element from ArrayView
+                            auto value =
+                                array_vec[j].template get_data<ElementType>(
+                                    first_elem_indices[j] + t);
+                            bool is_valid = !valid_data.data() || valid_data[j];
 
-                    if (!skip_func ||
-                        !skip_func(*skip_index, field_id_, chunk_id)) {
-                        // Extract element from ArrayView
-                        auto value =
-                            array_vec[j].template get_data<ElementType>(
-                                elem_indices[j]);
-                        bool is_valid = !valid_data.data() || valid_data[j];
-
-                        evaluate_batch.template operator()<FilterType::random>(
-                            &value,
-                            &is_valid,
-                            nullptr,
-                            1,
-                            res + result_idx,
-                            valid_res + result_idx,
-                            values...);
-                    } else {
-                        // Keep cursor-tracking evaluators aligned with offset input.
-                        if (valid_data.size() > j && !valid_data[j]) {
-                            res[result_idx] = valid_res[result_idx] = false;
+                            evaluate_batch
+                                .template operator()<FilterType::random>(
+                                    &value,
+                                    &is_valid,
+                                    nullptr,
+                                    1,
+                                    res + result_idx,
+                                    valid_res + result_idx,
+                                    values...);
+                        } else {
+                            // Keep cursor-tracking evaluators aligned with
+                            // offset input.
+                            if (valid_data.size() > j && !valid_data[j]) {
+                                res[result_idx] = valid_res[result_idx] = false;
+                            }
+                            evaluate_batch
+                                .template operator()<FilterType::random>(
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    1,
+                                    res + result_idx,
+                                    valid_res + result_idx,
+                                    values...);
                         }
-                        evaluate_batch.template operator()<FilterType::random>(
-                            nullptr,
-                            nullptr,
-                            nullptr,
-                            1,
-                            res + result_idx,
-                            valid_res + result_idx,
-                            values...);
-                    }
 
-                    processed_size++;
+                        processed_size++;
+                    }
                 }
             }
             return processed_size;
@@ -1068,12 +1108,29 @@ class SegmentExpr : public Expr {
 
             auto skip_index = segment_->GetSkipIndex();
             size_t processed_size = 0;
+            size_t i = 0;
 
-            for (size_t i = 0; i < element_ids->size(); i++) {
-                int64_t element_id = (*element_ids)[i];
+            // Same run exploitation as the sealed branch: element ids from
+            // RowOffsetsToElementOffsets list each row's elements
+            // consecutively ascending, so resolve the row with two virtual
+            // calls against published growing-offset snapshots and pin the
+            // Array chunk ONCE per run instead of once per element. The
+            // consecutive-id guard below keeps this correct for arbitrary
+            // input orders.
+            while (i < element_ids->size()) {
+                int32_t element_id = (*element_ids)[i];
 
                 auto [doc_id, elem_idx] =
                     array_offsets->ElementIDToRowID(element_id);
+                const int32_t row_last =
+                    array_offsets->ElementIDRangeOfRow(doc_id).second;
+                int64_t max_run = std::min<int64_t>(row_last - element_id,
+                                                    element_ids->size() - i);
+                int64_t run_len = 1;
+                while (run_len < max_run &&
+                       (*element_ids)[i + run_len] == element_id + run_len) {
+                    ++run_len;
+                }
 
                 // Calculate chunk_id and chunk_offset for this doc
                 auto chunk_id = doc_id / size_per_chunk_;
@@ -1089,36 +1146,44 @@ class SegmentExpr : public Expr {
                     valid_data += chunk_offset;
                 }
 
-                if (!skip_func ||
-                    !skip_func(*skip_index, field_id_, chunk_id)) {
-                    // Extract element from Array
-                    auto value = array_ptr->get_data<ElementType>(elem_idx);
-                    bool is_valid = !valid_data || valid_data[0];
+                const bool chunk_active =
+                    !skip_func || !skip_func(*skip_index, field_id_, chunk_id);
 
-                    evaluate_batch.template operator()<FilterType::random>(
-                        &value,
-                        &is_valid,
-                        nullptr,
-                        1,
-                        res + processed_size,
-                        valid_res + processed_size,
-                        values...);
-                } else {
-                    // Keep cursor-tracking evaluators aligned with offset input.
-                    if (valid_data && !valid_data[0]) {
-                        res[processed_size] = valid_res[processed_size] = false;
+                for (int64_t t = 0; t < run_len; ++t) {
+                    if (chunk_active) {
+                        // Extract element from Array
+                        auto value =
+                            array_ptr->get_data<ElementType>(elem_idx + t);
+                        bool is_valid = !valid_data || valid_data[0];
+
+                        evaluate_batch.template operator()<FilterType::random>(
+                            &value,
+                            &is_valid,
+                            nullptr,
+                            1,
+                            res + processed_size,
+                            valid_res + processed_size,
+                            values...);
+                    } else {
+                        // Keep cursor-tracking evaluators aligned with offset
+                        // input.
+                        if (valid_data && !valid_data[0]) {
+                            res[processed_size] = valid_res[processed_size] =
+                                false;
+                        }
+                        evaluate_batch.template operator()<FilterType::random>(
+                            nullptr,
+                            nullptr,
+                            nullptr,
+                            1,
+                            res + processed_size,
+                            valid_res + processed_size,
+                            values...);
                     }
-                    evaluate_batch.template operator()<FilterType::random>(
-                        nullptr,
-                        nullptr,
-                        nullptr,
-                        1,
-                        res + processed_size,
-                        valid_res + processed_size,
-                        values...);
-                }
 
-                processed_size++;
+                    processed_size++;
+                }
+                i += run_len;
             }
 
             return processed_size;

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -999,18 +999,18 @@ class SegmentExpr : public Expr {
             // resolution covers every consecutive element id of that row.
             auto resolve_run = [&](size_t pos) -> RunInfo {
                 int32_t element_id = (*element_ids)[pos];
-                auto [row_id, elem_idx] =
-                    array_offsets->ElementIDToRowID(element_id);
-                const int32_t row_last =
-                    array_offsets->ElementIDRangeOfRow(row_id).second;
-                int64_t max_run = std::min<int64_t>(row_last - element_id,
-                                                    element_ids->size() - pos);
+                const auto row = array_offsets->ElementIDToRowInfo(element_id);
+                int64_t max_run =
+                    std::min<int64_t>(row.row_element_end - element_id,
+                                      element_ids->size() - pos);
                 int64_t run_len = 1;
                 while (run_len < max_run &&
                        (*element_ids)[pos + run_len] == element_id + run_len) {
                     ++run_len;
                 }
-                return {row_id, elem_idx, static_cast<int32_t>(run_len)};
+                return {row.row_id,
+                        row.element_index,
+                        static_cast<int32_t>(run_len)};
             };
 
             while (i < element_ids->size()) {
@@ -1112,20 +1112,17 @@ class SegmentExpr : public Expr {
 
             // Same run exploitation as the sealed branch: element ids from
             // RowOffsetsToElementOffsets list each row's elements
-            // consecutively ascending, so resolve the row with two virtual
-            // calls against published growing-offset snapshots and pin the
-            // Array chunk ONCE per run instead of once per element. The
+            // consecutively ascending, so resolve the row and its range with
+            // one virtual call against a published offsets snapshot and pin
+            // the Array chunk ONCE per run instead of once per element. The
             // consecutive-id guard below keeps this correct for arbitrary
             // input orders.
             while (i < element_ids->size()) {
                 int32_t element_id = (*element_ids)[i];
 
-                auto [doc_id, elem_idx] =
-                    array_offsets->ElementIDToRowID(element_id);
-                const int32_t row_last =
-                    array_offsets->ElementIDRangeOfRow(doc_id).second;
-                int64_t max_run = std::min<int64_t>(row_last - element_id,
-                                                    element_ids->size() - i);
+                const auto row = array_offsets->ElementIDToRowInfo(element_id);
+                int64_t max_run = std::min<int64_t>(
+                    row.row_element_end - element_id, element_ids->size() - i);
                 int64_t run_len = 1;
                 while (run_len < max_run &&
                        (*element_ids)[i + run_len] == element_id + run_len) {
@@ -1133,8 +1130,8 @@ class SegmentExpr : public Expr {
                 }
 
                 // Calculate chunk_id and chunk_offset for this doc
-                auto chunk_id = doc_id / size_per_chunk_;
-                auto chunk_offset = doc_id % size_per_chunk_;
+                auto chunk_id = row.row_id / size_per_chunk_;
+                auto chunk_offset = row.row_id % size_per_chunk_;
 
                 // Get the Array chunk (Growing segment stores Array, not ArrayView)
                 auto pw =
@@ -1152,8 +1149,8 @@ class SegmentExpr : public Expr {
                 for (int64_t t = 0; t < run_len; ++t) {
                     if (chunk_active) {
                         // Extract element from Array
-                        auto value =
-                            array_ptr->get_data<ElementType>(elem_idx + t);
+                        auto value = array_ptr->get_data<ElementType>(
+                            row.element_index + t);
                         bool is_valid = !valid_data || valid_data[0];
 
                         evaluate_batch.template operator()<FilterType::random>(

--- a/internal/core/src/exec/expression/MatchExpr.cpp
+++ b/internal/core/src/exec/expression/MatchExpr.cpp
@@ -36,6 +36,12 @@ using MatchType = milvus::expr::MatchType;
 
 // Core matching logic for a single row's elements
 // Returns true if the row matches the condition
+//
+// Word-wise implementation: the row's element bits are consumed in 64-bit
+// chunks (bitmap word width) instead of bit by bit. Invalid elements are
+// masked out with the valid bitmap, which preserves the per-bit semantics:
+// only valid elements are counted, and MatchAll requires every *valid*
+// element to match (vacuously true when the row has no valid elements).
 template <MatchType match_type, bool all_valid>
 bool
 MatchSingleRow(int64_t bitset_start,
@@ -43,68 +49,62 @@ MatchSingleRow(int64_t bitset_start,
                const TargetBitmapView& match_bitset,
                const TargetBitmapView& valid_bitset,
                int64_t threshold) {
+    using word_t = TargetBitmapView::policy_type::data_type;
+    constexpr int64_t kWordBits = static_cast<int64_t>(8 * sizeof(word_t));
+
     int64_t hit_count = 0;
-    int64_t element_count = row_elem_count;
 
-    if constexpr (all_valid) {
-        for (int64_t j = 0; j < row_elem_count; ++j) {
-            bool matched = match_bitset[bitset_start + j];
-            if (matched) {
-                ++hit_count;
-            }
-
-            // Early exit conditions
-            if constexpr (match_type == MatchType::MatchAny) {
-                if (hit_count > 0)
-                    return true;
-            } else if constexpr (match_type == MatchType::MatchAll) {
-                if (!matched)
+    for (int64_t done = 0; done < row_elem_count; done += kWordBits) {
+        const size_t n =
+            static_cast<size_t>(std::min(kWordBits, row_elem_count - done));
+        const size_t pos = static_cast<size_t>(bitset_start + done);
+        word_t m = match_bitset.read(pos, n);
+        if constexpr (all_valid) {
+            if constexpr (match_type == MatchType::MatchAll) {
+                const word_t full = (n == static_cast<size_t>(kWordBits))
+                                        ? ~word_t(0)
+                                        : ((word_t(1) << n) - 1);
+                if (m != full) {
                     return false;
-            } else if constexpr (match_type == MatchType::MatchLeast) {
-                if (hit_count >= threshold)
-                    return true;
-            } else if constexpr (match_type == MatchType::MatchMost ||
-                                 match_type == MatchType::MatchExact) {
-                if (hit_count > threshold)
-                    return false;
-            }
-        }
-    } else {
-        element_count = 0;
-        for (int64_t j = 0; j < row_elem_count; ++j) {
-            if (!valid_bitset[bitset_start + j]) {
+                }
                 continue;
             }
-            ++element_count;
-            bool matched = match_bitset[bitset_start + j];
-            if (matched) {
-                ++hit_count;
+        } else {
+            const word_t v = valid_bitset.read(pos, n);
+            m &= v;
+            if constexpr (match_type == MatchType::MatchAll) {
+                // Some valid element unmatched?
+                if (m != v) {
+                    return false;
+                }
+                continue;
             }
-
-            // Early exit conditions
-            if constexpr (match_type == MatchType::MatchAny) {
-                if (hit_count > 0)
-                    return true;
-            } else if constexpr (match_type == MatchType::MatchAll) {
-                if (!matched)
-                    return false;
-            } else if constexpr (match_type == MatchType::MatchLeast) {
-                if (hit_count >= threshold)
-                    return true;
-            } else if constexpr (match_type == MatchType::MatchMost ||
-                                 match_type == MatchType::MatchExact) {
-                if (hit_count > threshold)
-                    return false;
+        }
+        if constexpr (match_type == MatchType::MatchAny) {
+            if (m != 0) {
+                return true;
+            }
+        } else if constexpr (match_type == MatchType::MatchLeast) {
+            hit_count += __builtin_popcountll(m);
+            if (hit_count >= threshold) {
+                return true;
+            }
+        } else if constexpr (match_type == MatchType::MatchMost ||
+                             match_type == MatchType::MatchExact) {
+            hit_count += __builtin_popcountll(m);
+            if (hit_count > threshold) {
+                return false;
             }
         }
     }
 
     // Final match decision
     if constexpr (match_type == MatchType::MatchAny) {
-        return hit_count > 0;
+        return false;
     } else if constexpr (match_type == MatchType::MatchAll) {
-        // Empty array returns true (vacuous truth)
-        return hit_count == element_count;
+        // Every (valid) element matched; empty array returns true
+        // (vacuous truth).
+        return true;
     } else if constexpr (match_type == MatchType::MatchLeast) {
         return hit_count >= threshold;
     } else if constexpr (match_type == MatchType::MatchMost) {
@@ -147,11 +147,25 @@ ProcessContiguousRows(int64_t row_count,
                       const TargetBitmapView& valid_bitset,
                       TargetBitmapView& result_bitset,
                       int64_t threshold) {
+    if constexpr (match_type == MatchType::MatchAny && all_valid) {
+        // Fast path: ANY-semantics reduction over contiguous rows. The match
+        // bitmap covers exactly the element ranges of
+        // [row_start, row_start + row_count) shifted by elem_start; jump
+        // between set bits word-wise instead of walking rows element by
+        // element.
+        array_offsets->ElementBitsetToRowBitsetAny(
+            match_bitset, elem_start, row_start, result_bitset);
+        return;
+    }
+    // ONE batched virtual call for the whole batch instead of one
+    // ElementIDRangeOfRow per row. Growing segments acquire-load one published
+    // watermark and read the whole batch from that lock-free snapshot.
+    FixedVector<int32_t> row_elem_starts(row_count + 1);
+    array_offsets->CopyRowElementStarts(
+        row_start, row_count, row_elem_starts.data());
     for (int64_t i = 0; i < row_count; ++i) {
-        auto [first_elem, last_elem] =
-            array_offsets->ElementIDRangeOfRow(row_start + i);
-        int64_t bitset_start = first_elem - elem_start;
-        int64_t row_elem_count = last_elem - first_elem;
+        int64_t bitset_start = row_elem_starts[i] - elem_start;
+        int64_t row_elem_count = row_elem_starts[i + 1] - row_elem_starts[i];
 
         bool matched = MatchSingleRow<match_type, all_valid>(bitset_start,
                                                              row_elem_count,
@@ -173,11 +187,16 @@ ProcessOffsetRows(const OffsetVector* row_offsets,
                   const TargetBitmapView& valid_bitset,
                   TargetBitmapView& result_bitset,
                   int64_t threshold) {
+    // ONE batched virtual call for all requested rows instead of one
+    // ElementIDRangeOfRow per row (one lock-free snapshot on growing).
+    const auto row_count = static_cast<int64_t>(row_offsets->size());
+    FixedVector<std::pair<int32_t, int32_t>> ranges(row_count);
+    array_offsets->CopyRowElementRanges(
+        row_offsets->data(), row_count, ranges.data());
+
     int64_t elem_cursor = 0;
-    for (size_t i = 0; i < row_offsets->size(); ++i) {
-        auto [first_elem, last_elem] =
-            array_offsets->ElementIDRangeOfRow((*row_offsets)[i]);
-        int64_t row_elem_count = last_elem - first_elem;
+    for (int64_t i = 0; i < row_count; ++i) {
+        int64_t row_elem_count = ranges[i].second - ranges[i].first;
 
         if (MatchSingleRow<match_type, all_valid>(elem_cursor,
                                                   row_elem_count,

--- a/internal/core/src/exec/expression/MatchExprTest.cpp
+++ b/internal/core/src/exec/expression/MatchExprTest.cpp
@@ -40,7 +40,12 @@
 #include "common/QueryResult.h"
 #include "common/Schema.h"
 #include "common/Types.h"
+#include "common/Vector.h"
 #include "common/protobuf_utils.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/EvalCtx.h"
+#include "exec/expression/MatchExpr.h"
+#include "expr/ITypeExpr.h"
 #include "gtest/gtest.h"
 #include "index/Index.h"
 #include "index/InvertedIndexTantivy.h"
@@ -434,6 +439,238 @@ TEST_F(MatchExprTest, MatchExactZero) {
         [](int match_count, int /*element_count*/, int64_t threshold) {
             return match_count == threshold;
         });
+}
+
+namespace {
+
+class FixedBitmapExpr : public exec::Expr {
+ public:
+    FixedBitmapExpr(TargetBitmap data, TargetBitmap valid)
+        : Expr(DataType::BOOL, {}, "FixedBitmapExpr", nullptr),
+          data_(std::move(data)),
+          valid_(std::move(valid)) {
+    }
+
+    void
+    Eval(exec::EvalCtx&, VectorPtr& result) override {
+        result = std::make_shared<ColumnVector>(data_.clone(), valid_.clone());
+    }
+
+    std::string
+    ToString() const override {
+        return "FixedBitmapExpr";
+    }
+
+    std::optional<expr::ColumnInfo>
+    GetColumnInfo() const override {
+        return std::nullopt;
+    }
+
+ private:
+    TargetBitmap data_;
+    TargetBitmap valid_;
+};
+
+bool
+MatchSingleRowReference(int64_t bitset_start,
+                        int64_t row_elem_count,
+                        const TargetBitmap& match_bitmap,
+                        const TargetBitmap& valid_bitmap,
+                        expr::MatchType match_type,
+                        int64_t threshold) {
+    int64_t hit_count = 0;
+    for (int64_t i = 0; i < row_elem_count; ++i) {
+        const auto bit = bitset_start + i;
+        if (!valid_bitmap[bit]) {
+            continue;
+        }
+        if (match_bitmap[bit]) {
+            ++hit_count;
+        } else if (match_type == expr::MatchType::MatchAll) {
+            return false;
+        }
+    }
+
+    switch (match_type) {
+        case expr::MatchType::MatchAny:
+            return hit_count > 0;
+        case expr::MatchType::MatchAll:
+            return true;
+        case expr::MatchType::MatchLeast:
+            return hit_count >= threshold;
+        case expr::MatchType::MatchMost:
+            return hit_count <= threshold;
+        case expr::MatchType::MatchExact:
+            return hit_count == threshold;
+        default:
+            return false;
+    }
+}
+
+}  // namespace
+
+TEST(MatchExprWordFoldTest, OffsetRowsMatchPerBitReference) {
+    const std::vector<int64_t> row_lengths = {0, 1, 63, 64, 65, 200};
+    const int64_t row_count = row_lengths.size();
+
+    auto schema = std::make_shared<Schema>();
+    auto int64_fid = schema->AddDebugField("id", DataType::INT64);
+    schema->set_primary_field_id(int64_fid);
+    auto sub_int_fid = schema->AddDebugArrayField(
+        "struct_array[sub_int]", DataType::INT32, false);
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    std::vector<int64_t> ids(row_count);
+    std::vector<idx_t> row_ids(row_count);
+    std::vector<Timestamp> timestamps(row_count);
+    std::vector<milvus::proto::schema::ScalarField> sub_int_data(row_count);
+    for (int64_t row = 0; row < row_count; ++row) {
+        ids[row] = row;
+        row_ids[row] = row;
+        timestamps[row] = row;
+        for (int64_t i = 0; i < row_lengths[row]; ++i) {
+            sub_int_data[row].mutable_int_data()->add_data(i);
+        }
+    }
+
+    auto id_array = CreateDataArrayFrom(
+        ids.data(), nullptr, row_count, schema->operator[](int64_fid));
+    insert_data->mutable_fields_data()->AddAllocated(id_array.release());
+    auto sub_int_array = CreateDataArrayFrom(sub_int_data.data(),
+                                             nullptr,
+                                             row_count,
+                                             schema->operator[](sub_int_fid));
+    insert_data->mutable_fields_data()->AddAllocated(sub_int_array.release());
+    insert_data->set_num_rows(row_count);
+
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    const auto reserved_offset = segment->PreInsert(row_count);
+    segment->Insert(reserved_offset,
+                    row_count,
+                    row_ids.data(),
+                    timestamps.data(),
+                    insert_data.get());
+
+    exec::OffsetVector offsets = {1, 3, 4, 5, 0, 2};
+    std::vector<int64_t> bitset_starts(offsets.size() + 1, 0);
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        bitset_starts[i + 1] = bitset_starts[i] + row_lengths[offsets[i]];
+    }
+    const int64_t elem_count = bitset_starts.back();
+
+    TargetBitmap boundary_matches(elem_count, false);
+    TargetBitmap boundary_valid(elem_count, true);
+    TargetBitmap random_matches(elem_count, false);
+    TargetBitmap random_valid(elem_count, true);
+    std::mt19937 random(0x51390);
+    std::bernoulli_distribution random_match(0.5);
+    std::bernoulli_distribution random_is_valid(0.75);
+    for (size_t output_row = 0; output_row < offsets.size(); ++output_row) {
+        const auto row_length = row_lengths[offsets[output_row]];
+        for (int64_t i = 0; i < row_length; ++i) {
+            const auto bit = bitset_starts[output_row] + i;
+            const bool local_boundary = i == 0 || i + 1 == row_length ||
+                                        i == 62 || i == 63 || i == 64 ||
+                                        i == 199;
+            const bool word_boundary = bit % 64 == 0 || bit % 64 == 63;
+            boundary_matches[bit] = local_boundary || word_boundary;
+            boundary_valid[bit] =
+                !((local_boundary && output_row % 2 == 0) || bit % 17 == 0);
+            random_matches[bit] = random_match(random);
+            random_valid[bit] = random_is_valid(random);
+        }
+    }
+
+    struct BitmapCase {
+        std::string name;
+        TargetBitmap matches;
+        TargetBitmap valid;
+    };
+    std::vector<BitmapCase> bitmap_cases;
+    bitmap_cases.push_back({"all-match/all-valid",
+                            TargetBitmap(elem_count, true),
+                            TargetBitmap(elem_count, true)});
+    bitmap_cases.push_back({"no-match/all-valid",
+                            TargetBitmap(elem_count, false),
+                            TargetBitmap(elem_count, true)});
+    bitmap_cases.push_back({"boundary/all-valid",
+                            boundary_matches.clone(),
+                            TargetBitmap(elem_count, true)});
+    bitmap_cases.push_back({"boundary/mixed-valid",
+                            boundary_matches.clone(),
+                            boundary_valid.clone()});
+    bitmap_cases.push_back({"random/all-valid",
+                            random_matches.clone(),
+                            TargetBitmap(elem_count, true)});
+    bitmap_cases.push_back(
+        {"random/mixed-valid", random_matches.clone(), random_valid.clone()});
+
+    const std::vector<expr::MatchType> match_types = {
+        expr::MatchType::MatchAny,
+        expr::MatchType::MatchAll,
+        expr::MatchType::MatchLeast,
+        expr::MatchType::MatchMost,
+        expr::MatchType::MatchExact,
+    };
+    const std::vector<int64_t> thresholds = {
+        0, 1, 2, 62, 63, 64, 65, 66, 199, 200, 201};
+
+    exec::QueryContext query_context(
+        "match_word_fold_test", segment.get(), row_count, MAX_TIMESTAMP);
+    exec::ExecContext exec_context(&query_context);
+    for (const auto& bitmap_case : bitmap_cases) {
+        for (const auto match_type : match_types) {
+            for (const auto threshold : thresholds) {
+                SCOPED_TRACE(::testing::Message()
+                             << "bitmap=" << bitmap_case.name << ", type="
+                             << proto::plan::MatchType_Name(match_type)
+                             << ", threshold=" << threshold);
+
+                auto child = std::make_shared<FixedBitmapExpr>(
+                    bitmap_case.matches.clone(), bitmap_case.valid.clone());
+                std::vector<std::shared_ptr<exec::Expr>> inputs = {child};
+                auto logical_expr =
+                    std::make_shared<expr::MatchExpr>("struct_array",
+                                                      match_type,
+                                                      threshold,
+                                                      expr::TypedExprPtr{});
+                exec::PhyMatchFilterExpr physical_expr(inputs,
+                                                       logical_expr,
+                                                       "PhyMatchFilterExpr",
+                                                       nullptr,
+                                                       segment.get(),
+                                                       row_count,
+                                                       row_count);
+                exec::EvalCtx eval_context(&exec_context);
+                eval_context.set_offset_input(&offsets);
+
+                VectorPtr result;
+                physical_expr.Eval(eval_context, result);
+                auto output = std::dynamic_pointer_cast<ColumnVector>(result);
+                ASSERT_NE(output, nullptr);
+                ASSERT_EQ(output->size(), offsets.size());
+                TargetBitmapView output_data(output->GetRawData(),
+                                             output->size());
+                TargetBitmapView output_valid(output->GetValidRawData(),
+                                              output->size());
+                for (size_t output_row = 0; output_row < offsets.size();
+                     ++output_row) {
+                    const bool expected = MatchSingleRowReference(
+                        bitset_starts[output_row],
+                        row_lengths[offsets[output_row]],
+                        bitmap_case.matches,
+                        bitmap_case.valid,
+                        match_type,
+                        threshold);
+                    EXPECT_EQ(output_data[output_row], expected)
+                        << "output_row=" << output_row
+                        << ", source_row=" << offsets[output_row]
+                        << ", row_length=" << row_lengths[offsets[output_row]];
+                    EXPECT_TRUE(output_valid[output_row]);
+                }
+            }
+        }
+    }
 }
 
 TEST(MatchExprZeroElementBatch, MatchAnyTreatsEmptyRowsAsNoMatch) {

--- a/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
@@ -211,17 +211,14 @@ PhyIterativeElementFilterNode::CollectResults(
             if (element_id >= cached_first_elem &&
                 element_id < cached_last_elem) {
                 doc_id = cached_doc_id;
-                elem_idx = static_cast<int32_t>(element_id) -
-                           cached_first_elem;
+                elem_idx = static_cast<int32_t>(element_id) - cached_first_elem;
             } else {
-                const auto row = array_offsets->ElementIDToRowID(element_id);
-                doc_id = row.first;
-                elem_idx = row.second;
-                cached_doc_id = doc_id;
-                cached_first_elem =
-                    static_cast<int32_t>(element_id) - elem_idx;
-                cached_last_elem =
-                    array_offsets->ElementIDRangeOfRow(doc_id).second;
+                const auto row = array_offsets->ElementIDToRowInfo(element_id);
+                doc_id = row.row_id;
+                elem_idx = row.element_index;
+                cached_doc_id = row.row_id;
+                cached_first_elem = row.row_element_start;
+                cached_last_elem = row.row_element_end;
             }
 
             // Find insert position using binary search

--- a/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeElementFilterNode.cpp
@@ -182,6 +182,18 @@ PhyIterativeElementFilterNode::CollectResults(
     search_result.distances_.resize(nq * topk, 0.0f);
     search_result.element_indices_.resize(nq * topk, -1);
 
+    // Resolve element_id -> (doc_id, elem_idx) once per run of ids that
+    // land in the same row: iterator output is distance-ordered, but ids
+    // from one row still arrive in clusters. Cache the last resolved
+    // row's element range [first, last) and answer in-range ids without
+    // the virtual binary-search lookup; any other id falls back to the
+    // per-element lookup, so correctness never depends on the output
+    // order. A resolved row's range is immutable, so the cache stays
+    // valid across iterators.
+    int32_t cached_doc_id = 0;
+    int32_t cached_first_elem = 0;
+    int32_t cached_last_elem = 0;  // empty range: first lookup always misses
+
     for (int64_t q = 0; q < nq; ++q) {
         auto& iterator = iterators[q];
         int64_t count = 0;
@@ -194,8 +206,23 @@ PhyIterativeElementFilterNode::CollectResults(
             }
 
             auto [element_id, distance] = result.value();
-            auto [doc_id, elem_idx] =
-                array_offsets->ElementIDToRowID(element_id);
+            int32_t doc_id;
+            int32_t elem_idx;
+            if (element_id >= cached_first_elem &&
+                element_id < cached_last_elem) {
+                doc_id = cached_doc_id;
+                elem_idx = static_cast<int32_t>(element_id) -
+                           cached_first_elem;
+            } else {
+                const auto row = array_offsets->ElementIDToRowID(element_id);
+                doc_id = row.first;
+                elem_idx = row.second;
+                cached_doc_id = doc_id;
+                cached_first_elem =
+                    static_cast<int32_t>(element_id) - elem_idx;
+                cached_last_elem =
+                    array_offsets->ElementIDRangeOfRow(doc_id).second;
+            }
 
             // Find insert position using binary search
             size_t pos =

--- a/internal/core/src/exec/operator/IterativeFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeFilterNode.cpp
@@ -178,6 +178,16 @@ PhyIterativeFilterNode::GetOutput() {
         std::vector<std::pair<int32_t, int32_t>> element_to_doc_mapping;
         std::unordered_map<int64_t, bool> doc_eval_cache;
         std::unordered_set<int64_t> unique_doc_ids;
+        // Cached element range of the last resolved row: element ids from
+        // one row arrive in clusters even though iterator output is
+        // distance-ordered, so ids inside the cached range resolve without
+        // the virtual binary-search lookup and anything else falls back to
+        // the per-element lookup (correctness never depends on ordering).
+        // A resolved row's range is immutable, so the cache stays valid
+        // across batches and nqs.
+        int32_t cached_doc_id = 0;
+        int32_t cached_first_elem = 0;
+        int32_t cached_last_elem = 0;  // empty: first lookup always misses
 
         for (auto& iterator : search_result.vector_iterators_.value()) {
             EvalCtx eval_ctx(operator_context_->get_exec_context());
@@ -223,8 +233,23 @@ PhyIterativeFilterNode::GetOutput() {
                     element_to_doc_mapping.reserve(offsets.size());
 
                     for (auto element_id : offsets) {
-                        auto [doc_id, elem_idx] =
-                            array_offsets->ElementIDToRowID(element_id);
+                        int32_t doc_id;
+                        int32_t elem_idx;
+                        if (element_id >= cached_first_elem &&
+                            element_id < cached_last_elem) {
+                            doc_id = cached_doc_id;
+                            elem_idx = element_id - cached_first_elem;
+                        } else {
+                            const auto row =
+                                array_offsets->ElementIDToRowID(element_id);
+                            doc_id = row.first;
+                            elem_idx = row.second;
+                            cached_doc_id = doc_id;
+                            cached_first_elem = element_id - elem_idx;
+                            cached_last_elem =
+                                array_offsets->ElementIDRangeOfRow(doc_id)
+                                    .second;
+                        }
                         element_to_doc_mapping.push_back({doc_id, elem_idx});
                         unique_doc_ids.insert(doc_id);
                     }

--- a/internal/core/src/exec/operator/IterativeFilterNode.cpp
+++ b/internal/core/src/exec/operator/IterativeFilterNode.cpp
@@ -174,7 +174,8 @@ PhyIterativeFilterNode::GetOutput() {
         FixedVector<int32_t> offsets;
         FixedVector<float> distances;
         FixedVector<int32_t> doc_offsets;
-        // For element-level: cache (doc_id, elem_idx) to avoid duplicate ElementIDToRowID calls
+        // For element-level: cache resolved (doc_id, elem_idx) pairs to avoid
+        // repeated element-to-row lookups.
         std::vector<std::pair<int32_t, int32_t>> element_to_doc_mapping;
         std::unordered_map<int64_t, bool> doc_eval_cache;
         std::unordered_set<int64_t> unique_doc_ids;
@@ -229,7 +230,8 @@ PhyIterativeFilterNode::GetOutput() {
                 if (element_level) {
                     // 1. Convert element_ids to doc_ids and do filter on those doc_ids
                     // 2. element_ids with doc_ids that pass the filter are what we interested in
-                    // Cache both doc_id and elem_idx to avoid duplicate ElementIDToRowID calls
+                    // Cache both doc_id and elem_idx so later stages can reuse
+                    // the resolved mapping.
                     element_to_doc_mapping.reserve(offsets.size());
 
                     for (auto element_id : offsets) {
@@ -241,14 +243,12 @@ PhyIterativeFilterNode::GetOutput() {
                             elem_idx = element_id - cached_first_elem;
                         } else {
                             const auto row =
-                                array_offsets->ElementIDToRowID(element_id);
-                            doc_id = row.first;
-                            elem_idx = row.second;
-                            cached_doc_id = doc_id;
-                            cached_first_elem = element_id - elem_idx;
-                            cached_last_elem =
-                                array_offsets->ElementIDRangeOfRow(doc_id)
-                                    .second;
+                                array_offsets->ElementIDToRowInfo(element_id);
+                            doc_id = row.row_id;
+                            elem_idx = row.element_index;
+                            cached_doc_id = row.row_id;
+                            cached_first_elem = row.row_element_start;
+                            cached_last_elem = row.row_element_end;
                         }
                         element_to_doc_mapping.push_back({doc_id, elem_idx});
                         unique_doc_ids.insert(doc_id);

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -497,20 +497,63 @@ class OffsetOrderedMap : public OffsetMap {
         auto more_hit_than_limit = cnt > limit;
         limit = std::min(limit, cnt);
 
-        // Traverse map_ in PK order
+        // Traverse map_ in PK order; for each PK visit offsets from back to
+        // front to obtain the latest offset, and only use the first (newest)
+        // offset that has matching elements (same as find_first_n_by_index)
+        // to avoid returning stale versions.
+        // Element ranges are resolved in windows: gather the next
+        // kRangeBatchSize candidate doc offsets in traversal order and
+        // resolve them with ONE CopyRowElementRanges call (one shared lock
+        // for the whole window on growing) instead of one locking virtual
+        // call per doc. Ranges prefetched for docs the traversal ends up
+        // skipping (older offsets of an already-hit PK, or docs past the
+        // limit) are simply unused — the lookups are pure.
+        constexpr int64_t kRangeBatchSize = 64;
+        int64_t batch_docs[kRangeBatchSize];
+        int32_t batch_rows[kRangeBatchSize];
+        std::pair<int32_t, int32_t> batch_ranges[kRangeBatchSize];
+        const typename OrderedMap::value_type* batch_pks[kRangeBatchSize];
+
         std::vector<int32_t> matching_indices;
-        auto it = map_.begin();
-        for (; hit_num < limit && it != map_.end(); ++it) {
-            // For each PK, traverse from back to front to obtain the latest offset.
-            // Same as find_first_n_by_index: only use the first (newest) offset
-            // that has matching elements, then break to avoid returning stale versions.
-            for (int i = it->second.size() - 1; i >= 0 && hit_num < limit;
-                 --i) {
-                auto doc_offset = it->second[i];
+        // Gather cursor over the flattened (pk, offset) traversal.
+        auto gather_it = map_.begin();
+        int64_t gather_idx =
+            gather_it == map_.end()
+                ? -1
+                : static_cast<int64_t>(gather_it->second.size()) - 1;
+        // PK entry whose remaining (older) offsets must be skipped — the
+        // batched equivalent of the per-doc inner-loop `break`.
+        const typename OrderedMap::value_type* skip_pk = nullptr;
+        while (hit_num < limit && gather_it != map_.end()) {
+            // Gather the next window of candidate docs.
+            int64_t n = 0;
+            while (n < kRangeBatchSize && gather_it != map_.end()) {
+                if (gather_idx < 0) {
+                    ++gather_it;
+                    if (gather_it == map_.end()) {
+                        break;
+                    }
+                    gather_idx =
+                        static_cast<int64_t>(gather_it->second.size()) - 1;
+                    continue;
+                }
+                batch_docs[n] = gather_it->second[gather_idx];
+                batch_rows[n] = static_cast<int32_t>(batch_docs[n]);
+                batch_pks[n] = &*gather_it;
+                ++n;
+                --gather_idx;
+            }
+            array_offsets->CopyRowElementRanges(batch_rows, n, batch_ranges);
+
+            for (int64_t k = 0; k < n && hit_num < limit; ++k) {
+                const auto* pk_entry = batch_pks[k];
+                if (pk_entry == skip_pk) {
+                    continue;
+                }
+                auto doc_offset = batch_docs[k];
 
                 // Get element range for this doc
-                auto [first_elem, last_elem] =
-                    array_offsets->ElementIDRangeOfRow(doc_offset);
+                auto [first_elem, last_elem] = batch_ranges[k];
 
                 // Collect all matching element indices for this doc
                 matching_indices.clear();
@@ -521,7 +564,7 @@ class OffsetOrderedMap : public OffsetMap {
                         continue;
                     }
                     if (is_skipped_by_cursor(
-                            it->first, elem_id - first_elem, cursor)) {
+                            pk_entry->first, elem_id - first_elem, cursor)) {
                         continue;
                     }
                     if (!element_bitset[elem_id]) {  // 0 means pass filter
@@ -536,12 +579,11 @@ class OffsetOrderedMap : public OffsetMap {
                     doc_offsets.push_back(doc_offset);
                     element_indices.push_back(std::move(matching_indices));
                     // PK hit, no need to continue traversing older offsets with the same PK.
-                    break;
-                }
-                if (is_cursor_pk(it->first, cursor)) {
+                    skip_pk = pk_entry;
+                } else if (is_cursor_pk(pk_entry->first, cursor)) {
                     // The cursor applies to the newest visible row for this PK.
                     // Do not fall through to older offsets of the same PK.
-                    break;
+                    skip_pk = pk_entry;
                 }
             }
         }
@@ -776,39 +818,56 @@ class OffsetOrderedArray : public OffsetMap {
         auto more_hit_than_limit = cnt > limit;
         limit = std::min(limit, cnt);
 
-        // Traverse array_ in PK order (already sorted)
+        // Traverse array_ in PK order (already sorted). Element ranges are
+        // resolved in windows of kRangeBatchSize docs with one
+        // CopyRowElementRanges call each instead of one virtual call per
+        // doc; ranges prefetched past an early limit-exit are unused (the
+        // lookups are pure).
+        constexpr int64_t kRangeBatchSize = 64;
+        int32_t batch_rows[kRangeBatchSize];
+        std::pair<int32_t, int32_t> batch_ranges[kRangeBatchSize];
+
         std::vector<int32_t> matching_indices;
-        auto it = array_.begin();
-        for (; hit_num < limit && it != array_.end(); ++it) {
-            auto doc_offset = it->second;
-
-            // Get element range for this doc
-            auto [first_elem, last_elem] =
-                array_offsets->ElementIDRangeOfRow(doc_offset);
-
-            // Collect all matching element indices for this doc
-            matching_indices.clear();
-            for (int64_t elem_id = first_elem;
-                 elem_id < last_elem && hit_num < limit;
-                 ++elem_id) {
-                if (elem_id >= element_size) {
-                    continue;
-                }
-                if (is_skipped_by_cursor(
-                        it->first, elem_id - first_elem, cursor)) {
-                    continue;
-                }
-                if (!element_bitset[elem_id]) {  // 0 means pass filter
-                    matching_indices.push_back(
-                        static_cast<int32_t>(elem_id - first_elem));
-                    hit_num++;
-                }
+        const int64_t total = static_cast<int64_t>(array_.size());
+        for (int64_t base = 0; base < total && hit_num < limit;
+             base += kRangeBatchSize) {
+            const int64_t n = std::min(kRangeBatchSize, total - base);
+            for (int64_t k = 0; k < n; ++k) {
+                batch_rows[k] = array_[base + k].second;
             }
+            array_offsets->CopyRowElementRanges(batch_rows, n, batch_ranges);
 
-            // Only add doc if it has matching elements
-            if (!matching_indices.empty()) {
-                doc_offsets.push_back(doc_offset);
-                element_indices.push_back(std::move(matching_indices));
+            for (int64_t k = 0; k < n && hit_num < limit; ++k) {
+                const auto& entry = array_[base + k];
+                auto doc_offset = entry.second;
+
+                // Get element range for this doc
+                auto [first_elem, last_elem] = batch_ranges[k];
+
+                // Collect all matching element indices for this doc
+                matching_indices.clear();
+                for (int64_t elem_id = first_elem;
+                     elem_id < last_elem && hit_num < limit;
+                     ++elem_id) {
+                    if (elem_id >= element_size) {
+                        continue;
+                    }
+                    if (is_skipped_by_cursor(
+                            entry.first, elem_id - first_elem, cursor)) {
+                        continue;
+                    }
+                    if (!element_bitset[elem_id]) {  // 0 means pass filter
+                        matching_indices.push_back(
+                            static_cast<int32_t>(elem_id - first_elem));
+                        hit_num++;
+                    }
+                }
+
+                // Only add doc if it has matching elements
+                if (!matching_indices.empty()) {
+                    doc_offsets.push_back(doc_offset);
+                    element_indices.push_back(std::move(matching_indices));
+                }
             }
         }
 
@@ -992,21 +1051,35 @@ class VirtualPKOffsetMap : public OffsetMap {
         std::vector<std::vector<int32_t>> element_indices;
         int64_t hit_num = 0;
 
-        for (int64_t doc = 0; doc < num_rows_ && hit_num < limit; doc++) {
-            auto [first_elem, last_elem] =
-                array_offsets->ElementIDRangeOfRow(doc);
-            std::vector<int32_t> matching;
-            for (int64_t e = first_elem; e < last_elem && hit_num < limit;
-                 e++) {
-                if (e < element_size && !element_bitset[e] &&
-                    !is_skipped_by_cursor(doc, e - first_elem, cursor)) {
-                    matching.push_back(static_cast<int32_t>(e - first_elem));
-                    hit_num++;
+        // Docs are scanned sequentially, so resolve element ranges with one
+        // contiguous CopyRowElementStarts call per window of kRowBatchSize
+        // rows ([starts[i], starts[i+1]) is row (base + i)'s range) instead
+        // of one virtual call per row.
+        constexpr int64_t kRowBatchSize = 64;
+        int32_t batch_starts[kRowBatchSize + 1];
+
+        for (int64_t base = 0; base < num_rows_ && hit_num < limit;
+             base += kRowBatchSize) {
+            const int64_t n = std::min(kRowBatchSize, num_rows_ - base);
+            array_offsets->CopyRowElementStarts(base, n, batch_starts);
+            for (int64_t i = 0; i < n && hit_num < limit; i++) {
+                const int64_t doc = base + i;
+                const int32_t first_elem = batch_starts[i];
+                const int32_t last_elem = batch_starts[i + 1];
+                std::vector<int32_t> matching;
+                for (int64_t e = first_elem; e < last_elem && hit_num < limit;
+                     e++) {
+                    if (e < element_size && !element_bitset[e] &&
+                        !is_skipped_by_cursor(doc, e - first_elem, cursor)) {
+                        matching.push_back(
+                            static_cast<int32_t>(e - first_elem));
+                        hit_num++;
+                    }
                 }
-            }
-            if (!matching.empty()) {
-                doc_offsets.push_back(doc);
-                element_indices.push_back(std::move(matching));
+                if (!matching.empty()) {
+                    doc_offsets.push_back(doc);
+                    element_indices.push_back(std::move(matching));
+                }
             }
         }
         return {std::move(doc_offsets),

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -503,14 +503,13 @@ class OffsetOrderedMap : public OffsetMap {
         // to avoid returning stale versions.
         // Element ranges are resolved in windows: gather the next
         // kRangeBatchSize candidate doc offsets in traversal order and
-        // resolve them with ONE CopyRowElementRanges call (one shared lock
-        // for the whole window on growing) instead of one locking virtual
-        // call per doc. Ranges prefetched for docs the traversal ends up
+        // resolve them with ONE CopyRowElementRanges call (one lock-free
+        // published snapshot for the whole window on growing) instead of one
+        // virtual call per doc. Ranges prefetched for docs the traversal ends up
         // skipping (older offsets of an already-hit PK, or docs past the
         // limit) are simply unused — the lookups are pure.
         constexpr int64_t kRangeBatchSize = 64;
-        int64_t batch_docs[kRangeBatchSize];
-        int32_t batch_rows[kRangeBatchSize];
+        int32_t batch_offsets[kRangeBatchSize];
         std::pair<int32_t, int32_t> batch_ranges[kRangeBatchSize];
         const typename OrderedMap::value_type* batch_pks[kRangeBatchSize];
 
@@ -537,20 +536,20 @@ class OffsetOrderedMap : public OffsetMap {
                         static_cast<int64_t>(gather_it->second.size()) - 1;
                     continue;
                 }
-                batch_docs[n] = gather_it->second[gather_idx];
-                batch_rows[n] = static_cast<int32_t>(batch_docs[n]);
+                batch_offsets[n] =
+                    static_cast<int32_t>(gather_it->second[gather_idx]);
                 batch_pks[n] = &*gather_it;
                 ++n;
                 --gather_idx;
             }
-            array_offsets->CopyRowElementRanges(batch_rows, n, batch_ranges);
+            array_offsets->CopyRowElementRanges(batch_offsets, n, batch_ranges);
 
             for (int64_t k = 0; k < n && hit_num < limit; ++k) {
                 const auto* pk_entry = batch_pks[k];
                 if (pk_entry == skip_pk) {
                     continue;
                 }
-                auto doc_offset = batch_docs[k];
+                const int64_t doc_offset = batch_offsets[k];
 
                 // Get element range for this doc
                 auto [first_elem, last_elem] = batch_ranges[k];


### PR DESCRIPTION
Backport of #51390 to the 3.0 branch.

pr: #51390
issue: #51380

## What changed

- Restore geometric growth for growing array-offset storage instead of reallocating the full row-to-element table on every insert batch.
- Add batched row-element start/range lookups and use them in MATCH folding and remaining iterative-filter / InsertRecord hot paths.
- Fold struct-array MATCH results word-wise, including the all-valid MATCH_ANY fast path.
- Resolve consecutive element IDs once per row run on element-offset evaluation, while preserving SkipIndex cursor alignment.
- Backport the review follow-ups for single-snapshot element-to-row lookup and randomized nullable / multi-word MATCH coverage.

## Backport notes

- The source PR #51390 is merged as `f113bdbc8e39efa8821b7b3f7151287ce1bd0b9c`.
- The stacked bitset prerequisite from #51387 is already present on 3.0 through #51665, so it was not picked again.
- Rebased the three source commits onto `upstream/3.0` at `8e122a727b2bc74b9552dd42cecd3299dc8f1752`:
  - `9f35d417865e616a3c98d92422355124d7e27cb6`
  - `43fc3220681d9d23bcf72d925fa10f7f03eb1259`
  - `57f24e1cb9f77e4f7615c35c7447b10d312a0b90`
- The target branch includes #51743, the 3.0 backport of the lock-free chunked `ArrayOffsetsGrowing` implementation from #51392, and #51739's segcore error-code classification changes.
- Rebase conflicts in `ArrayOffsets.cpp`, `ArrayOffsets.h`, `ArrayOffsetsTest.cpp`, and `Expr.h` were resolved by combining the reviewed source integration with the 3.0-specific lock-free storage, `BatchEvaluator` contract, SkipIndex behavior, and `UnexpectedError` classifications.
- The final contents of all nine touched files are byte-for-byte identical to the previously verified conflict-resolution tree `6496573ddd24aa36acf9d0dd3343a59e9256800c`. Seven files are also byte-for-byte identical to the merged source result; `Expr.h` and `IterativeFilterNode.cpp` retain intentional 3.0 branch differences while their element-offset performance hunks match the source.

## Verification

- Latest `upstream/3.0` is an ancestor of the PR head; the PR contains exactly three linear commits.
- `git diff --check upstream/3.0...HEAD` — passed.
- `clang-format 22.1.0 --dry-run --Werror` on all nine changed C++ files — passed.
- `ArrayOffsets.cpp`, `ArrayOffsets.h`, and `ArrayOffsetsTest.cpp` match source merge `f113bdbc8e39` exactly; the combined test file contains all 38 tests from both the performance and lock-free changes.
- DCO — passed.
- A local C++ build was not run because this isolated worktree does not have a prepared C++ dependency build. Target-branch PR CI is the authoritative compile and regression validation.
