### PR TITLE
fix: [3.0] use scalar index v3 by default

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -125,7 +125,7 @@ const (
 	//   the existing INVERTED / NGRAM)
 	// - On-disk file format is unchanged from v3
 	MinimalScalarIndexEngineVersion = int32(0)
-	CurrentScalarIndexEngineVersion = int32(4)
+	CurrentScalarIndexEngineVersion = int32(3)
 	MaximumScalarIndexEngineVersion = int32(4)
 
 	// MinScalarIndexVersionForJsonPathMultiType is the minimum scalar index


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47417

to ensure backward compatibility