### PR TITLE
fix: [cp3.0] reject unsupported ARRAY-backed field comparisons

### DIFF
--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/function/rerank"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -2640,6 +2641,8 @@ func Test_ArrayExpr(t *testing.T) {
 
 	exprs := []string{
 		`ArrayField == [1,2,3,4]`,
+		`ArrayField != [1,2,3,4]`,
+		`[1,2,3,4] == ArrayField`,
 		`ArrayField[0] == 1`,
 		`ArrayField[0] > 1`,
 		`1 < ArrayField[0] < 3`,
@@ -2678,6 +2681,25 @@ func Test_ArrayExpr(t *testing.T) {
 			RoundDecimal: 0,
 		}, nil, nil)
 		assert.NoError(t, err, expr)
+	}
+
+	unsupportedFieldComparisons := []string{
+		`ArrayField == ArrayField`,
+		`ArrayField != ArrayField`,
+		`ArrayField == Int64Field`,
+		`Int64Field != ArrayField`,
+		`ArrayField[0] == Int64Field`,
+		`ArrayField[0] < Int64Field`,
+	}
+	for _, expr = range unsupportedFieldComparisons {
+		_, err = CreateSearchPlan(schema, expr, "FloatVectorField", &planpb.QueryInfo{
+			Topk:         0,
+			MetricType:   "",
+			SearchParams: "",
+			RoundDecimal: 0,
+		}, nil, nil)
+		require.ErrorIs(t, err, merr.ErrQueryPlan, expr)
+		assert.Contains(t, err.Error(), "field-to-field comparison involving ARRAY fields is not supported", expr)
 	}
 
 	invalidExprs := []string{

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -444,6 +444,13 @@ func handleCompare(op planpb.OpType, left *ExprWithType, right *ExprWithType) (*
 		return nil, merr.WrapErrQueryPlanMsg("only comparison between two fields is supported")
 	}
 
+	// CompareExpr only carries field IDs and storage data types. It cannot
+	// represent an element path for an ARRAY-backed column, and the executor
+	// does not support ARRAY as an operand type.
+	if typeutil.IsArrayType(leftColumnInfo.GetDataType()) || typeutil.IsArrayType(rightColumnInfo.GetDataType()) {
+		return nil, merr.WrapErrQueryPlanMsg("field-to-field comparison involving ARRAY fields is not supported")
+	}
+
 	// Check if both left and right are non-JSON types
 	if typeutil.IsJSONType(leftColumnInfo.GetDataType()) || typeutil.IsJSONType(rightColumnInfo.GetDataType()) {
 		return nil, merr.WrapErrQueryPlanMsg("two column comparison with JSON type is not supported")


### PR DESCRIPTION
pr: #51742
issue: #51741
related: #51389

## Summary

Backport #51742 to the 3.0 branch.

Reject field-to-field comparisons when either operand is backed by an ARRAY field before constructing `CompareExpr`. This returns an `ErrQueryPlan` input error instead of allowing the unsupported plan to fail later in QueryNode, while preserving ARRAY-to-literal and ARRAY-element-to-literal comparisons.

**Note:** The source PR #51742 is still open. This preemptive backport must not merge before the source PR, and should be updated if the source commit changes.

## Backport notes

- Cherry-picked source commit `09b642571677b22d428f3b27559f41726c3f6346` with provenance and DCO trailers.
- Applied cleanly on `upstream/3.0` at `e5d8f51c83a28cb7d0475fa8922982925a0780df`; no 3.0-specific adaptation was needed.
- Stable patch-id matches the source commit exactly.

## Verification

- `git diff --check upstream/3.0...HEAD` — passed.
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2 -run '^(Test_ArrayExpr|TestExpr_Compare|Test_handleCompare)$'` — passed.
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2/...` — passed.

No live Milvus e2e run was performed for this parser-only backport.
