### PR TITLE
fix: revert targetVecIndexVersion bump and set to 8

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -732,7 +732,7 @@ dataCoord:
   # if param forceRebuildSegmentIndex is enabled, the vector index will be rebuilt to aligned with targetVecIndexVersion.
   # if param forceRebuildSegmentIndex is not enabled, the newly created vector index will be aligned with the newer one of index engine's version and targetVecIndexVersion.
   # if param targetVecIndexVersion is not set, the default value is -1, which means no target vec index version, then the vector index will be aligned with index engine's version 
-  targetVecIndexVersion: 10
+  targetVecIndexVersion: 8
   forceRebuildScalarSegmentIndex: false # force rebuild scalar segment index to specified scalar index engine's version
   # if param forceRebuildScalarSegmentIndex is enabled, the scalar index will be rebuilt to aligned with targetScalarIndexVersion.
   # if param forceRebuildScalarSegmentIndex is not enabled, the newly created scalar index will be aligned with the newer one of scalar index engine's version and targetScalarIndexVersion.


### PR DESCRIPTION
## Summary

Revert #50238, which set `dataCoord.targetVecIndexVersion` to `10`, and set it to `8` instead.

issue: #42937