### PR TITLE
fix: propagate cipher context to worker tasks

### DIFF
--- a/internal/core/src/clustering/analyze_c.cpp
+++ b/internal/core/src/clustering/analyze_c.cpp
@@ -21,6 +21,7 @@
 #include "types.h"
 #include "index/Utils.h"
 #include "index/Meta.h"
+#include "storage/PluginLoader.h"
 #include "storage/StorageV2FSCache.h"
 #include "storage/Util.h"
 #include "pb/clustering.pb.h"
@@ -57,7 +58,8 @@ get_storage_config(const milvus::proto::clustering::StorageConfig& config) {
 CStatus
 Analyze(CAnalyze* res_analyze,
         const uint8_t* serialized_analyze_info,
-        const uint64_t len) {
+        const uint64_t len,
+        const CPluginContext* plugin_context) {
     SCOPE_CGO_CALL_METRIC();
 
     try {
@@ -107,6 +109,15 @@ Analyze(CAnalyze* res_analyze,
 
         milvus::storage::FileManagerContext fileManagerContext(
             field_meta, index_meta, chunk_manager, fs);
+
+        if (plugin_context != nullptr) {
+            fileManagerContext.set_plugin_context(
+                milvus::storage::PluginLoader::GetInstance()
+                    .registerCipherPluginContext(
+                        plugin_context->ez_id,
+                        plugin_context->collection_id,
+                        std::string(plugin_context->key)));
+        }
 
         if (field_type != DataType::VECTOR_FLOAT) {
             throw SegcoreError(

--- a/internal/core/src/clustering/analyze_c.h
+++ b/internal/core/src/clustering/analyze_c.h
@@ -23,7 +23,8 @@ extern "C" {
 CStatus
 Analyze(CAnalyze* res_analyze,
         const uint8_t* serialized_analyze_info,
-        const uint64_t len);
+        const uint64_t len,
+        const CPluginContext* plugin_context);
 
 CStatus
 DeleteAnalyze(CAnalyze analyze);

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -267,20 +267,15 @@ CreateIndex(CIndex* res_index,
         }
 
         if (build_index_info->has_storage_plugin_context()) {
-            auto cipherPlugin =
-                milvus::storage::PluginLoader::GetInstance().getCipherPlugin();
-            AssertInfo(cipherPlugin != nullptr, "failed to get cipher plugin");
-            cipherPlugin->Update(
-                build_index_info->storage_plugin_context().encryption_zone_id(),
-                build_index_info->storage_plugin_context().collection_id(),
-                build_index_info->storage_plugin_context().encryption_key());
-
-            auto plugin_context = std::make_shared<CPluginContext>();
-            plugin_context->ez_id =
-                build_index_info->storage_plugin_context().encryption_zone_id();
-            plugin_context->collection_id =
-                build_index_info->storage_plugin_context().collection_id();
-            fileManagerContext.set_plugin_context(plugin_context);
+            fileManagerContext.set_plugin_context(
+                milvus::storage::PluginLoader::GetInstance()
+                    .registerCipherPluginContext(
+                        build_index_info->storage_plugin_context()
+                            .encryption_zone_id(),
+                        build_index_info->storage_plugin_context()
+                            .collection_id(),
+                        build_index_info->storage_plugin_context()
+                            .encryption_key()));
         }
 
         auto index =
@@ -374,20 +369,15 @@ BuildJsonKeyIndex(ProtoLayoutInterface result,
         }
 
         if (build_index_info->has_storage_plugin_context()) {
-            auto cipherPlugin =
-                milvus::storage::PluginLoader::GetInstance().getCipherPlugin();
-            AssertInfo(cipherPlugin != nullptr, "failed to get cipher plugin");
-            cipherPlugin->Update(
-                build_index_info->storage_plugin_context().encryption_zone_id(),
-                build_index_info->storage_plugin_context().collection_id(),
-                build_index_info->storage_plugin_context().encryption_key());
-
-            auto plugin_context = std::make_shared<CPluginContext>();
-            plugin_context->ez_id =
-                build_index_info->storage_plugin_context().encryption_zone_id();
-            plugin_context->collection_id =
-                build_index_info->storage_plugin_context().collection_id();
-            fileManagerContext.set_plugin_context(plugin_context);
+            fileManagerContext.set_plugin_context(
+                milvus::storage::PluginLoader::GetInstance()
+                    .registerCipherPluginContext(
+                        build_index_info->storage_plugin_context()
+                            .encryption_zone_id(),
+                        build_index_info->storage_plugin_context()
+                            .collection_id(),
+                        build_index_info->storage_plugin_context()
+                            .encryption_key()));
         }
 
         auto field_schema =
@@ -472,19 +462,15 @@ BuildTextIndex(ProtoLayoutInterface result,
         }
 
         if (build_index_info->has_storage_plugin_context()) {
-            auto cipherPlugin =
-                milvus::storage::PluginLoader::GetInstance().getCipherPlugin();
-            AssertInfo(cipherPlugin != nullptr, "failed to get cipher plugin");
-            cipherPlugin->Update(
-                build_index_info->storage_plugin_context().encryption_zone_id(),
-                build_index_info->storage_plugin_context().collection_id(),
-                build_index_info->storage_plugin_context().encryption_key());
-            auto plugin_context = std::make_shared<CPluginContext>();
-            plugin_context->ez_id =
-                build_index_info->storage_plugin_context().encryption_zone_id();
-            plugin_context->collection_id =
-                build_index_info->storage_plugin_context().collection_id();
-            fileManagerContext.set_plugin_context(plugin_context);
+            fileManagerContext.set_plugin_context(
+                milvus::storage::PluginLoader::GetInstance()
+                    .registerCipherPluginContext(
+                        build_index_info->storage_plugin_context()
+                            .encryption_zone_id(),
+                        build_index_info->storage_plugin_context()
+                            .collection_id(),
+                        build_index_info->storage_plugin_context()
+                            .encryption_key()));
         }
 
         auto scalar_index_engine_version =

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -323,9 +323,6 @@ BuildJsonKeyIndex(ProtoLayoutInterface result,
             get_storage_config(build_index_info->storage_config());
         auto config = get_config(build_index_info);
 
-        auto loon_properties =
-            MakePropertiesFromStorageConfig(ToCStorageConfig(storage_config));
-
         // init file manager
         milvus::storage::FieldDataMeta field_meta{
             build_index_info->collectionid(),

--- a/internal/core/src/storage/PluginLoader.h
+++ b/internal/core/src/storage/PluginLoader.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include "common/type_c.h"
 #include "log/Log.h"
 #include "storage/plugin/PluginInterface.h"
 #include "common/EasyAssert.h"
@@ -106,6 +107,32 @@ class PluginLoader {
         }
         return std::dynamic_pointer_cast<
             milvus::storage::plugin::ICipherPlugin>(p);
+    }
+
+    std::shared_ptr<CPluginContext>
+    registerCipherPluginContext(int64_t ez_id,
+                                int64_t collection_id,
+                                const std::string& key) {
+        return registerCipherPluginContext(
+            ez_id, collection_id, key, getCipherPlugin());
+    }
+
+    std::shared_ptr<CPluginContext>
+    registerCipherPluginContext(
+        int64_t ez_id,
+        int64_t collection_id,
+        const std::string& key,
+        const std::shared_ptr<plugin::ICipherPlugin>& cipher_plugin) {
+        AssertInfo(cipher_plugin != nullptr, "failed to get cipher plugin");
+        cipher_plugin->Update(ez_id, collection_id, key);
+
+        // The plugin owns the key copy. Storage operations retain only the IDs
+        // needed for later encryptor/decryptor lookups.
+        auto context = std::make_shared<CPluginContext>();
+        context->ez_id = ez_id;
+        context->collection_id = collection_id;
+        context->key = nullptr;
+        return context;
     }
 
     std::shared_ptr<milvus::storage::plugin::IPlugin>

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -57,6 +57,7 @@ set(MILVUS_TEST_FILES
         test_group_by_json.cpp
         test_growing_concurrent_reopen.cpp
         test_schema_reopen.cpp
+        test_cipher_plugin_context.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )

--- a/internal/core/unittest/test_cipher_plugin_context.cpp
+++ b/internal/core/unittest/test_cipher_plugin_context.cpp
@@ -1,0 +1,157 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "clustering/analyze_c.h"
+#include "indexbuilder/index_c.h"
+#include "pb/clustering.pb.h"
+#include "pb/index_cgo_msg.pb.h"
+#include "storage/PluginLoader.h"
+#include "test_utils/Constants.h"
+
+namespace milvus::storage {
+namespace {
+
+class RecordingCipherPlugin : public plugin::ICipherPlugin {
+ public:
+    void
+    Update(int64_t ez_id,
+           int64_t collection_id,
+           const std::string& key) override {
+        update_count++;
+        updated_ez_id = ez_id;
+        updated_collection_id = collection_id;
+        updated_key = key;
+    }
+
+    std::pair<std::shared_ptr<plugin::IEncryptor>, std::string>
+    GetEncryptor(int64_t, int64_t) const override {
+        return {};
+    }
+
+    std::shared_ptr<plugin::IDecryptor>
+    GetDecryptor(int64_t, int64_t, const std::string&) const override {
+        return nullptr;
+    }
+
+    int update_count = 0;
+    int64_t updated_ez_id = 0;
+    int64_t updated_collection_id = 0;
+    std::string updated_key;
+};
+
+void
+ExpectMissingCipherPlugin(CStatus status) {
+    ASSERT_NE(status.error_code, Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("failed to get cipher plugin"),
+              std::string::npos);
+    free(const_cast<char*>(status.error_msg));
+}
+
+std::string
+BuildIndexInfoWithPluginContext() {
+    proto::indexcgo::BuildIndexInfo build_index_info;
+    build_index_info.mutable_field_schema()->set_data_type(
+        proto::schema::DataType::Int64);
+
+    auto storage_config = build_index_info.mutable_storage_config();
+    storage_config->set_root_path(TestLocalPath);
+    storage_config->set_storage_type("local");
+
+    auto plugin_context = build_index_info.mutable_storage_plugin_context();
+    plugin_context->set_encryption_zone_id(17);
+    plugin_context->set_collection_id(23);
+    plugin_context->set_encryption_key("unsafe-key");
+    return build_index_info.SerializeAsString();
+}
+
+TEST(CipherPluginContextTest, AnalyzeUsesContextWhenPresent) {
+    proto::clustering::AnalyzeInfo analyze_info;
+    analyze_info.mutable_field_schema()->set_data_type(
+        proto::schema::DataType::Int64);
+    auto storage_config = analyze_info.mutable_storage_config();
+    storage_config->set_root_path(TestLocalPath);
+    storage_config->set_storage_type("local");
+    auto serialized = analyze_info.SerializeAsString();
+
+    CAnalyze analyze = nullptr;
+    auto status = Analyze(&analyze,
+                          reinterpret_cast<const uint8_t*>(serialized.data()),
+                          serialized.size(),
+                          nullptr);
+    ASSERT_NE(status.error_code, Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("invalid data type"),
+              std::string::npos);
+    free(const_cast<char*>(status.error_msg));
+
+    CPluginContext plugin_context{17, 23, "unsafe-key"};
+    status = Analyze(&analyze,
+                     reinterpret_cast<const uint8_t*>(serialized.data()),
+                     serialized.size(),
+                     &plugin_context);
+    ExpectMissingCipherPlugin(status);
+    EXPECT_EQ(analyze, nullptr);
+}
+
+TEST(CipherPluginContextTest, IndexApisUseContextWhenPresent) {
+    auto serialized = BuildIndexInfoWithPluginContext();
+    auto data = reinterpret_cast<const uint8_t*>(serialized.data());
+
+    CIndex index = nullptr;
+    ExpectMissingCipherPlugin(CreateIndex(&index, data, serialized.size()));
+    EXPECT_EQ(index, nullptr);
+
+    ExpectMissingCipherPlugin(
+        BuildJsonKeyIndex(nullptr, data, serialized.size()));
+    ExpectMissingCipherPlugin(BuildTextIndex(nullptr, data, serialized.size()));
+}
+
+TEST(CipherPluginContextTest, RegistersPluginAndReturnsOnlyIdentifiers) {
+    constexpr int64_t ez_id = 17;
+    constexpr int64_t collection_id = 23;
+    char key[] = "unsafe-key";
+
+    auto cipher_plugin = std::make_shared<RecordingCipherPlugin>();
+    auto context = PluginLoader::GetInstance().registerCipherPluginContext(
+        ez_id, collection_id, std::string(key), cipher_plugin);
+
+    key[0] = 'X';
+    EXPECT_EQ(cipher_plugin->update_count, 1);
+    EXPECT_EQ(cipher_plugin->updated_ez_id, ez_id);
+    EXPECT_EQ(cipher_plugin->updated_collection_id, collection_id);
+    EXPECT_EQ(cipher_plugin->updated_key, "unsafe-key");
+
+    ASSERT_NE(context, nullptr);
+    EXPECT_EQ(context->ez_id, ez_id);
+    EXPECT_EQ(context->collection_id, collection_id);
+    EXPECT_EQ(context->key, nullptr);
+}
+
+TEST(CipherPluginContextTest, RejectsMissingCipherPlugin) {
+    EXPECT_ANY_THROW(PluginLoader::GetInstance().registerCipherPluginContext(
+        17, 23, "unsafe-key", std::shared_ptr<plugin::ICipherPlugin>()));
+}
+
+}  // namespace
+}  // namespace milvus::storage

--- a/internal/datanode/compactor/mix_compactor_text_index_test.go
+++ b/internal/datanode/compactor/mix_compactor_text_index_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
@@ -414,6 +415,65 @@ func TestBuildTextIndexesForSegment_NoEnableMatchFields(t *testing.T) {
 	got, err := buildTextIndexesForSegment(context.Background(), args)
 	assert.NoError(t, err)
 	assert.Empty(t, got)
+}
+
+func TestBuildTextIndexesForSegment_PropagatesPluginContext(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	const collectionID = int64(7001)
+	requestContext := []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}}
+	pluginContext := &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     collectionID,
+		EncryptionKey:    "unsafe-key",
+	}
+
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).To(
+		func(context []*commonpb.KeyValuePair, gotCollectionID int64) (*indexcgopb.StoragePluginContext, error) {
+			require.Equal(t, requestContext, context)
+			require.Equal(t, collectionID, gotCollectionID)
+			return pluginContext, nil
+		}).Build()
+	defer parseMock.UnPatch()
+
+	captured, cleanup := mockCreateTextIndexCGO(map[string]int64{"text-index": 10})
+	defer cleanup()
+
+	got, err := buildTextIndexesForSegment(context.Background(), buildTextIndexArgs{
+		plan: &datapb.CompactionPlan{
+			PlanID:        1,
+			Schema:        textMatchSchema(101),
+			PluginContext: requestContext,
+		},
+		compactionParams: compaction.GenParams(),
+		collectionID:     collectionID,
+		partitionID:      7002,
+		segmentID:        7003,
+		taskID:           1,
+		storageVersion:   storage.StorageV2,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+	require.NotNil(t, captured.info)
+	require.Equal(t, pluginContext, captured.info.GetStoragePluginContext())
+}
+
+func TestBuildTextIndexesForSegment_PropagatesPluginContextError(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).Return(nil, assert.AnError).Build()
+	defer parseMock.UnPatch()
+
+	_, err := buildTextIndexesForSegment(context.Background(), buildTextIndexArgs{
+		plan:             &datapb.CompactionPlan{PlanID: 1, Schema: textMatchSchema(101)},
+		compactionParams: compaction.GenParams(),
+		collectionID:     1,
+		partitionID:      2,
+		segmentID:        3,
+		taskID:           1,
+		storageVersion:   storage.StorageV2,
+	})
+	require.ErrorIs(t, err, assert.AnError)
 }
 
 // TestSortCompaction_createTextIndex_ForwardsPassedManifest guards the fix that

--- a/internal/datanode/compactor/text_index.go
+++ b/internal/datanode/compactor/text_index.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datanode/util"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -89,6 +90,10 @@ func buildTextIndexesForSegment(ctx context.Context, args buildTextIndexArgs) (m
 	if err != nil {
 		return nil, err
 	}
+	pluginContext, err := hookutil.GetCPluginContext(args.plan.GetPluginContext(), args.collectionID)
+	if err != nil {
+		return nil, err
+	}
 
 	var (
 		mu            sync.Mutex
@@ -123,6 +128,9 @@ func buildTextIndexesForSegment(ctx context.Context, args buildTextIndexArgs) (m
 				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(args.plan.GetCurrentScalarIndexVersion()),
 				StorageVersion:            args.storageVersion,
 				Manifest:                  args.manifest,
+			}
+			if pluginContext != nil {
+				buildIndexParams.StoragePluginContext = pluginContext
 			}
 
 			if args.storageVersion == storage.StorageV2 {

--- a/internal/datanode/index/task_analyze.go
+++ b/internal/datanode/index/task_analyze.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/analyzecgowrapper"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/clusteringpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
@@ -46,20 +47,24 @@ type analyzeTask struct {
 	queueDur time.Duration
 	manager  *TaskManager
 	analyze  analyzecgowrapper.CodecAnalyze
+
+	pluginContext *indexcgopb.StoragePluginContext
 }
 
 func NewAnalyzeTask(ctx context.Context,
 	cancel context.CancelFunc,
 	req *workerpb.AnalyzeRequest,
 	manager *TaskManager,
+	pluginContext *indexcgopb.StoragePluginContext,
 ) *analyzeTask {
 	return &analyzeTask{
-		ident:   fmt.Sprintf("%s/%d", req.GetClusterID(), req.GetTaskID()),
-		ctx:     ctx,
-		cancel:  cancel,
-		req:     req,
-		manager: manager,
-		tr:      timerecord.NewTimeRecorder(fmt.Sprintf("ClusterID: %s, TaskID: %d", req.GetClusterID(), req.GetTaskID())),
+		ident:         fmt.Sprintf("%s/%d", req.GetClusterID(), req.GetTaskID()),
+		ctx:           ctx,
+		cancel:        cancel,
+		req:           req,
+		manager:       manager,
+		pluginContext: pluginContext,
+		tr:            timerecord.NewTimeRecorder(fmt.Sprintf("ClusterID: %s, TaskID: %d", req.GetClusterID(), req.GetTaskID())),
 	}
 }
 
@@ -162,7 +167,7 @@ func (at *analyzeTask) Execute(ctx context.Context) error {
 		FieldSchema:     field,
 	}
 
-	at.analyze, err = analyzecgowrapper.Analyze(ctx, analyzeInfo)
+	at.analyze, err = analyzecgowrapper.Analyze(ctx, analyzeInfo, at.pluginContext)
 	if err != nil {
 		log.Error("failed to analyze data", zap.Error(err))
 		return err
@@ -224,4 +229,5 @@ func (at *analyzeTask) Reset() {
 	at.tr = nil
 	at.queueDur = 0
 	at.manager = nil
+	at.pluginContext = nil
 }

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -71,6 +71,8 @@ type statsTask struct {
 	manager  *TaskManager
 	binlogIO io.BinlogIO
 
+	pluginContext *indexcgopb.StoragePluginContext
+
 	deltaLogs   []string
 	logIDOffset int64
 	currentTime time.Time
@@ -88,17 +90,19 @@ func NewStatsTask(ctx context.Context,
 	req *workerpb.CreateStatsRequest,
 	manager *TaskManager,
 	binlogIO io.BinlogIO,
+	pluginContext *indexcgopb.StoragePluginContext,
 ) *statsTask {
 	return &statsTask{
-		ident:       fmt.Sprintf("%s/%d", req.GetClusterID(), req.GetTaskID()),
-		ctx:         ctx,
-		cancel:      cancel,
-		req:         req,
-		manager:     manager,
-		binlogIO:    binlogIO,
-		tr:          timerecord.NewTimeRecorder(fmt.Sprintf("ClusterID: %s, TaskID: %d", req.GetClusterID(), req.GetTaskID())),
-		currentTime: tsoutil.PhysicalTime(req.GetCurrentTs()),
-		logIDOffset: 0,
+		ident:         fmt.Sprintf("%s/%d", req.GetClusterID(), req.GetTaskID()),
+		ctx:           ctx,
+		cancel:        cancel,
+		req:           req,
+		manager:       manager,
+		binlogIO:      binlogIO,
+		pluginContext: pluginContext,
+		tr:            timerecord.NewTimeRecorder(fmt.Sprintf("ClusterID: %s, TaskID: %d", req.GetClusterID(), req.GetTaskID())),
+		currentTime:   tsoutil.PhysicalTime(req.GetCurrentTs()),
+		logIDOffset:   0,
 	}
 }
 
@@ -386,6 +390,7 @@ func (st *statsTask) Reset() {
 	st.cancel = nil
 	st.tr = nil
 	st.manager = nil
+	st.pluginContext = nil
 }
 
 func serializeWrite(ctx context.Context, rootPath string, startID int64, writer *compactor.SegmentWriter) (binlogNum int64, kvs map[string][]byte, fieldBinlogs map[int64]*datapb.FieldBinlog, err error) {
@@ -502,7 +507,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 
 			req := proto.Clone(st.req).(*workerpb.CreateStatsRequest)
 			req.InsertLogs = insertBinlogs
-			buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, nil)
+			buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, nil, st.pluginContext)
 
 			uploaded, err := indexcgowrapper.CreateTextIndex(egCtx, buildIndexParams)
 			if err != nil {
@@ -638,7 +643,7 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 				JSONStatsShreddingRatio:      jsonStatsShreddingRatioThreshold,
 				JSONStatsWriteBatchSize:      jsonStatsWriteBatchSize,
 			}
-			buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, options)
+			buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, options, st.pluginContext)
 
 			statsResult, err := indexcgowrapper.CreateJSONKeyStats(egCtx, buildIndexParams)
 			if err != nil {
@@ -700,6 +705,7 @@ func buildIndexParams(
 	field *schemapb.FieldSchema,
 	storageConfig *indexcgopb.StorageConfig,
 	options *BuildIndexOptions,
+	pluginContext *indexcgopb.StoragePluginContext,
 ) *indexcgopb.BuildIndexInfo {
 	if options == nil {
 		options = &BuildIndexOptions{}
@@ -732,6 +738,9 @@ func buildIndexParams(
 			req.GetTargetSegmentID(),
 		)
 		log.Info("build index params", zap.Any("segment insert files", params.SegmentInsertFiles))
+	}
+	if pluginContext != nil {
+		params.StoragePluginContext = pluginContext
 	}
 
 	return params

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
@@ -31,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datanode/compactor"
 	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
@@ -119,7 +121,7 @@ func (s *TaskStatsSuite) TestSortSegmentWithBM25() {
 			StorageConfig: &indexpb.StorageConfig{
 				RootPath: "root_path",
 			},
-		}, manager, s.mockBinlogIO)
+		}, manager, s.mockBinlogIO, nil)
 		err = task.PreExecute(ctx)
 		s.Require().NoError(err)
 		binlog, err := task.sort(ctx)
@@ -169,7 +171,7 @@ func (s *TaskStatsSuite) TestSortSegmentWithBM25() {
 			StorageConfig: &indexpb.StorageConfig{
 				RootPath: "root_path",
 			},
-		}, manager, s.mockBinlogIO)
+		}, manager, s.mockBinlogIO, nil)
 		err = task.PreExecute(ctx)
 		s.Require().NoError(err)
 		_, err = task.sort(ctx)
@@ -198,11 +200,81 @@ func (s *TaskStatsSuite) TestBuildIndexParams() {
 			JSONStatsShreddingRatio:      0.3,
 			JSONStatsWriteBatchSize:      81920,
 		}
-		params := buildIndexParams(req, []string{"file1", "file2"}, nil, &indexcgopb.StorageConfig{}, options)
+		pluginContext := &indexcgopb.StoragePluginContext{
+			EncryptionZoneId: 17,
+			CollectionId:     req.GetCollectionID(),
+			EncryptionKey:    "unsafe-key",
+		}
+		params := buildIndexParams(req, []string{"file1", "file2"}, nil, &indexcgopb.StorageConfig{}, options, pluginContext)
 
 		s.Equal(storage.StorageV2, params.StorageVersion)
 		s.Equal(int64(100), params.NumRows)
 		s.NotNil(params.SegmentInsertFiles)
+		s.Equal(pluginContext, params.StoragePluginContext)
+	})
+}
+
+func (s *TaskStatsSuite) TestJSONKeyStatsPropagatesPluginContext() {
+	s.Run("json key stats build", func() {
+		const fieldID = int64(101)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		pluginContext := &indexcgopb.StoragePluginContext{
+			EncryptionZoneId: 17,
+			CollectionId:     s.collectionID,
+			EncryptionKey:    "unsafe-key",
+		}
+		req := &workerpb.CreateStatsRequest{
+			ClusterID:       s.clusterID,
+			TaskID:          100,
+			CollectionID:    s.collectionID,
+			PartitionID:     s.partitionID,
+			TargetSegmentID: 102,
+			TaskVersion:     1,
+			NumRows:         10,
+			StorageVersion:  storage.StorageV2,
+			StorageConfig: &indexpb.StorageConfig{
+				RootPath:    s.T().TempDir(),
+				StorageType: "local",
+			},
+			Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+				{FieldID: fieldID, Name: "json", DataType: schemapb.DataType_JSON},
+			}},
+			InsertLogs: []*datapb.FieldBinlog{{FieldID: fieldID}},
+		}
+		manager := NewTaskManager(ctx)
+		manager.LoadOrStoreStatsTask(s.clusterID, req.GetTaskID(), &StatsTaskInfo{})
+		task := NewStatsTask(ctx, cancel, req, manager, nil, pluginContext)
+
+		var captured *indexcgopb.BuildIndexInfo
+		buildMock := mockey.Mock(indexcgowrapper.CreateJSONKeyStats).To(
+			func(_ context.Context, info *indexcgopb.BuildIndexInfo) (*indexcgowrapper.JSONKeyStatsResult, error) {
+				captured = info
+				return &indexcgowrapper.JSONKeyStatsResult{
+					MemSize: 10,
+					Files:   map[string]int64{"json-stats": 10},
+				}, nil
+			}).Build()
+		defer buildMock.UnPatch()
+
+		err := task.createJSONKeyStats(
+			ctx,
+			req.GetStorageConfig(),
+			req.GetCollectionID(),
+			req.GetPartitionID(),
+			req.GetTargetSegmentID(),
+			req.GetTaskVersion(),
+			req.GetTaskID(),
+			common.JSONStatsDataFormatVersion,
+			req.GetInsertLogs(),
+			256,
+			0.3,
+			81920,
+		)
+		s.Require().NoError(err)
+		s.Require().NotNil(captured)
+		s.Equal(pluginContext, captured.GetStoragePluginContext())
 	})
 }
 

--- a/internal/datanode/index_services.go
+++ b/internal/datanode/index_services.go
@@ -352,6 +352,10 @@ func (node *DataNode) createAnalyzeTask(ctx context.Context, req *workerpb.Analy
 		log.Ctx(ctx).Warn("receive analyze task with invalid slot, set to 65535", zap.Int64("taskSlot", req.GetTaskSlot()))
 		req.TaskSlot = 65535
 	}
+	pluginContext, err := hookutil.GetCPluginContext(req.GetPluginContext(), req.GetCollectionID())
+	if err != nil {
+		return merr.Status(err), nil
+	}
 
 	taskCtx, taskCancel := context.WithCancel(node.ctx)
 	if oldInfo := node.taskManager.LoadOrStoreAnalyzeTask(req.GetClusterID(), req.GetTaskID(), &index.AnalyzeTaskInfo{
@@ -363,7 +367,7 @@ func (node *DataNode) createAnalyzeTask(ctx context.Context, req *workerpb.Analy
 		log.Warn("duplicated analyze task", zap.Error(err))
 		return merr.Status(err), nil
 	}
-	t := index.NewAnalyzeTask(taskCtx, taskCancel, req, node.taskManager)
+	t := index.NewAnalyzeTask(taskCtx, taskCancel, req, node.taskManager, pluginContext)
 	ret := merr.Success()
 	if err := node.taskScheduler.TaskQueue.Enqueue(t); err != nil {
 		log.Warn("DataNode failed to schedule", zap.Error(err))
@@ -393,6 +397,10 @@ func (node *DataNode) createStatsTask(ctx context.Context, req *workerpb.CreateS
 		log.Ctx(ctx).Warn("receive stats task with invalid slot, set to 64", zap.Int64("taskSlot", req.GetTaskSlot()))
 		req.TaskSlot = 64
 	}
+	pluginContext, err := hookutil.GetCPluginContext(req.GetPluginContext(), req.GetCollectionID())
+	if err != nil {
+		return merr.Status(err), nil
+	}
 
 	taskCtx, taskCancel := context.WithCancel(node.ctx)
 	if oldInfo := node.taskManager.LoadOrStoreStatsTask(req.GetClusterID(), req.GetTaskID(), &index.StatsTaskInfo{
@@ -414,7 +422,7 @@ func (node *DataNode) createStatsTask(ctx context.Context, req *workerpb.CreateS
 		return merr.Status(err), nil
 	}
 
-	t := index.NewStatsTask(taskCtx, taskCancel, req, node.taskManager, io.NewBinlogIO(cm))
+	t := index.NewStatsTask(taskCtx, taskCancel, req, node.taskManager, io.NewBinlogIO(cm), pluginContext)
 	ret := merr.Success()
 	if err := node.taskScheduler.TaskQueue.Enqueue(t); err != nil {
 		log.Warn("DataNode failed to schedule", zap.Error(err))

--- a/internal/datanode/index_services_test.go
+++ b/internal/datanode/index_services_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -32,10 +33,15 @@ import (
 	"github.com/milvus-io/milvus/internal/datanode/index"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/analyzecgowrapper"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/proto/clusteringpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -70,6 +76,168 @@ func TestIndexTaskWhenStoppingNode(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		assert.Fail(t, "timeout task chan")
 	}
+}
+
+func TestCreateAnalyzeTaskPropagatesPluginContext(t *testing.T) {
+	paramtable.Init()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	node := NewDataNode(ctx)
+	defer node.cancel()
+
+	requestContext := []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}}
+	expected := &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     1,
+		EncryptionKey:    "unsafe-key",
+	}
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).To(
+		func(got []*commonpb.KeyValuePair, collectionID int64) (*indexcgopb.StoragePluginContext, error) {
+			require.Equal(t, requestContext, got)
+			require.Equal(t, expected.GetCollectionId(), collectionID)
+			return expected, nil
+		}).Build()
+	defer parseMock.UnPatch()
+
+	var captured *indexcgopb.StoragePluginContext
+	analyzeMock := mockey.Mock(analyzecgowrapper.Analyze).To(
+		func(_ context.Context, _ *clusteringpb.AnalyzeInfo, pluginContext *indexcgopb.StoragePluginContext) (analyzecgowrapper.CodecAnalyze, error) {
+			captured = pluginContext
+			return nil, nil
+		}).Build()
+	defer analyzeMock.UnPatch()
+
+	status, err := node.createAnalyzeTask(ctx, &workerpb.AnalyzeRequest{
+		ClusterID:     "cluster",
+		TaskID:        100,
+		CollectionID:  expected.GetCollectionId(),
+		PartitionID:   2,
+		FieldID:       101,
+		FieldName:     "vector",
+		FieldType:     schemapb.DataType_FloatVector,
+		Dim:           8,
+		PluginContext: requestContext,
+		StorageConfig: &indexpb.StorageConfig{RootPath: t.TempDir(), StorageType: "local"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, merr.Error(status))
+
+	task := node.taskScheduler.TaskQueue.PopUnissuedTask()
+	require.NotNil(t, task)
+	require.NoError(t, task.Execute(ctx))
+	require.Equal(t, expected, captured)
+}
+
+func TestCreateAnalyzeTaskPluginContextErrorDoesNotRegisterTask(t *testing.T) {
+	paramtable.Init()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	node := NewDataNode(ctx)
+	defer node.cancel()
+
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).Return(nil, assert.AnError).Build()
+	defer parseMock.UnPatch()
+
+	const taskID = int64(100)
+	status, err := node.createAnalyzeTask(ctx, &workerpb.AnalyzeRequest{
+		ClusterID:    "cluster",
+		TaskID:       taskID,
+		CollectionID: 1,
+	})
+	require.NoError(t, err)
+	require.Error(t, merr.Error(status))
+	require.Nil(t, node.taskManager.GetAnalyzeTaskInfo("cluster", taskID))
+}
+
+func TestCreateStatsTaskPropagatesPluginContext(t *testing.T) {
+	paramtable.Init()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	node := NewDataNode(ctx)
+	defer node.cancel()
+
+	requestContext := []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}}
+	expected := &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     1,
+		EncryptionKey:    "unsafe-key",
+	}
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).To(
+		func(got []*commonpb.KeyValuePair, collectionID int64) (*indexcgopb.StoragePluginContext, error) {
+			require.Equal(t, requestContext, got)
+			require.Equal(t, expected.GetCollectionId(), collectionID)
+			return expected, nil
+		}).Build()
+	defer parseMock.UnPatch()
+
+	var captured *indexcgopb.BuildIndexInfo
+	buildMock := mockey.Mock(indexcgowrapper.CreateTextIndex).To(
+		func(_ context.Context, info *indexcgopb.BuildIndexInfo) (map[string]int64, error) {
+			captured = info
+			return map[string]int64{"text-index": 10}, nil
+		}).Build()
+	defer buildMock.UnPatch()
+
+	const fieldID = int64(101)
+	status, err := node.createStatsTask(ctx, &workerpb.CreateStatsRequest{
+		ClusterID:       "cluster",
+		TaskID:          100,
+		CollectionID:    expected.GetCollectionId(),
+		PartitionID:     2,
+		SegmentID:       3,
+		TargetSegmentID: 4,
+		SubJobType:      indexpb.StatsSubJob_TextIndexJob,
+		StorageVersion:  storage.StorageV2,
+		PluginContext:   requestContext,
+		StorageConfig:   &indexpb.StorageConfig{RootPath: t.TempDir(), StorageType: "local"},
+		Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  fieldID,
+				Name:     "text",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "enable_match", Value: "true"},
+				},
+			},
+		}},
+		InsertLogs: []*datapb.FieldBinlog{{
+			FieldID: fieldID,
+			Binlogs: []*datapb.Binlog{{LogID: 1}},
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, merr.Error(status))
+
+	task := node.taskScheduler.TaskQueue.PopUnissuedTask()
+	require.NotNil(t, task)
+	require.NoError(t, task.Execute(ctx))
+	require.NotNil(t, captured)
+	require.Equal(t, expected, captured.GetStoragePluginContext())
+}
+
+func TestCreateStatsTaskPluginContextErrorDoesNotRegisterTask(t *testing.T) {
+	paramtable.Init()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	node := NewDataNode(ctx)
+	defer node.cancel()
+
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).Return(nil, assert.AnError).Build()
+	defer parseMock.UnPatch()
+
+	const taskID = int64(100)
+	status, err := node.createStatsTask(ctx, &workerpb.CreateStatsRequest{
+		ClusterID:    "cluster",
+		TaskID:       taskID,
+		CollectionID: 1,
+	})
+	require.NoError(t, err)
+	require.Error(t, merr.Error(status))
+	require.Nil(t, node.taskManager.GetStatsTaskInfo("cluster", taskID))
 }
 
 type IndexServiceSuite struct {

--- a/internal/util/analyzecgowrapper/analyze.go
+++ b/internal/util/analyzecgowrapper/analyze.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/proto/clusteringpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
 )
 
 type CodecAnalyze interface {
@@ -42,7 +43,7 @@ type CodecAnalyze interface {
 	GetResult(size int) (string, int64, []string, []int64, error)
 }
 
-func Analyze(ctx context.Context, analyzeInfo *clusteringpb.AnalyzeInfo) (CodecAnalyze, error) {
+func Analyze(ctx context.Context, analyzeInfo *clusteringpb.AnalyzeInfo, pluginContext *indexcgopb.StoragePluginContext) (CodecAnalyze, error) {
 	analyzeInfoBlob, err := proto.Marshal(analyzeInfo)
 	if err != nil {
 		log.Ctx(ctx).Warn("marshal analyzeInfo failed",
@@ -50,8 +51,23 @@ func Analyze(ctx context.Context, analyzeInfo *clusteringpb.AnalyzeInfo) (CodecA
 			zap.Error(err))
 		return nil, err
 	}
+
+	var pluginContextPtr *C.CPluginContext
+	if pluginContext != nil {
+		// Analyze is synchronous; C++ copies the key before this function
+		// returns.
+		key := C.CString(pluginContext.GetEncryptionKey())
+		defer C.free(unsafe.Pointer(key))
+		cPluginContext := C.CPluginContext{
+			ez_id:         C.int64_t(pluginContext.GetEncryptionZoneId()),
+			collection_id: C.int64_t(pluginContext.GetCollectionId()),
+			key:           key,
+		}
+		pluginContextPtr = &cPluginContext
+	}
+
 	var analyzePtr C.CAnalyze
-	status := C.Analyze(&analyzePtr, (*C.uint8_t)(unsafe.Pointer(&analyzeInfoBlob[0])), (C.uint64_t)(len(analyzeInfoBlob)))
+	status := C.Analyze(&analyzePtr, (*C.uint8_t)(unsafe.Pointer(&analyzeInfoBlob[0])), (C.uint64_t)(len(analyzeInfoBlob)), pluginContextPtr)
 	if err := HandleCStatus(&status, "failed to analyze task"); err != nil {
 		return nil, err
 	}

--- a/internal/util/analyzecgowrapper/analyze_test.go
+++ b/internal/util/analyzecgowrapper/analyze_test.go
@@ -1,0 +1,48 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzecgowrapper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/clusteringpb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
+)
+
+func TestAnalyzePropagatesPluginContextAcrossCGO(t *testing.T) {
+	analyzeInfo := &clusteringpb.AnalyzeInfo{
+		FieldSchema: &schemapb.FieldSchema{DataType: schemapb.DataType_Int64},
+		StorageConfig: &clusteringpb.StorageConfig{
+			RootPath:    t.TempDir(),
+			StorageType: "local",
+		},
+	}
+
+	_, err := Analyze(context.Background(), analyzeInfo, nil)
+	require.ErrorContains(t, err, "invalid data type for clustering")
+
+	_, err = Analyze(context.Background(), analyzeInfo, &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     23,
+		EncryptionKey:    "unsafe-key",
+	})
+	require.ErrorContains(t, err, "failed to get cipher plugin")
+}


### PR DESCRIPTION
Propagate storage plugin context to stats and compaction text-index
builds, and pass it through the analyze CGO boundary so C++ registers
the cipher key before storage access.

Centralize C++ cipher-context registration in PluginLoader and add
focused Go and C++ coverage for index and analyze entry points.

See also: #51752
pr: #51789 

Signed-off-by: yangxuan <xuan.yang@zilliz.com>
