### PR TITLE
enhance: [TiKV] bound WalkWithPrefix iterators by page

### DIFF
--- a/internal/kv/tikv/txn_tikv.go
+++ b/internal/kv/tikv/txn_tikv.go
@@ -606,37 +606,67 @@ func (kv *txnTiKV) WalkWithPrefix(ctx context.Context, prefix string, pagination
 	var loggingErr error
 	defer logWarnOnFailure(&loggingErr, "txnTiKV WalkWithPagination error", mlog.String("prefix", prefix))
 
-	// Since only reading, use Snapshot for less overhead
-	ss := getSnapshot(kv.txn, paginationSize)
+	pageSize := paginationSize
+	if pageSize <= 0 {
+		pageSize = txnsnapshot.DefaultScanBatchSize
+	}
+	scanBatchSize := pageSize
+	if pageSize < int(^uint(0)>>1) {
+		scanBatchSize = pageSize + 1
+	}
+
+	// Since only reading, use Snapshot for less overhead. Fetch one lookahead
+	// key per page so exactly full pages can be detected without another
+	// iterator.
+	ss := getSnapshot(kv.txn, scanBatchSize)
 
 	// Retrieve key-value pairs with the specified prefix
-	startKey := []byte(prefix)
+	pageStart := []byte(prefix)
 	endKey := tikv.PrefixNextKey([]byte(prefix))
-	iter, err := ss.Iter(startKey, endKey)
-	if err != nil {
-		loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create iterater for %s during WalkWithPrefix", prefix), err.Error())
-		return loggingErr
-	}
-	defer iter.Close()
 
-	// Iterate over the key-value pairs
-	for iter.Valid() {
-		// Grab value for empty check
-		byteVal := iter.Value()
-		// Check if empty val and replace with placeholder
-		if isEmptyByte(byteVal) {
-			byteVal = []byte{}
-		}
-		err = fn(iter.Key(), byteVal)
+	for {
+		pageCount, lastKey, hasMore, err := func() (int, []byte, bool, error) {
+			iter, err := ss.Iter(pageStart, endKey)
+			if err != nil {
+				loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to create iterater for %s during WalkWithPrefix", prefix), err.Error())
+				return 0, nil, false, loggingErr
+			}
+			defer iter.Close()
+
+			pageCount := 0
+			var lastKey []byte
+			for iter.Valid() && pageCount < pageSize {
+				key := iter.Key()
+				// Grab value for empty check
+				byteVal := iter.Value()
+				// Check if empty val and replace with placeholder
+				if isEmptyByte(byteVal) {
+					byteVal = []byte{}
+				}
+				err = fn(key, byteVal)
+				if err != nil {
+					loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to apply fn to (%s;%s)", string(key), string(byteVal)))
+					return pageCount, nil, false, loggingErr
+				}
+
+				lastKey = append([]byte(nil), key...)
+				pageCount++
+				err = iter.Next()
+				if err != nil {
+					loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to move Iterator after key %s for WalkWithPrefix", string(key)), err.Error())
+					return pageCount, nil, false, loggingErr
+				}
+			}
+
+			return pageCount, lastKey, iter.Valid(), nil
+		}()
 		if err != nil {
-			loggingErr = merr.Wrap(err, fmt.Sprintf("Failed to apply fn to (%s;%s)", string(iter.Key()), string(byteVal)))
-			return loggingErr
+			return err
 		}
-		err = iter.Next()
-		if err != nil {
-			loggingErr = merr.WrapErrIoFailedReason(fmt.Sprintf("Failed to move Iterator after key %s for WalkWithPrefix", string(iter.Key())), err.Error())
-			return loggingErr
+		if pageCount < pageSize || !hasMore {
+			break
 		}
+		pageStart = append(lastKey, 0x00)
 	}
 	CheckElapseAndWarn(start, "Slow txnTiKV WalkWithPagination() operation", mlog.String("prefix", prefix))
 	return nil

--- a/internal/kv/tikv/txn_tikv_test.go
+++ b/internal/kv/tikv/txn_tikv_test.go
@@ -24,12 +24,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tikverr "github.com/tikv/client-go/v2/error"
+	tikvclient "github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
+	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
 	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
@@ -433,6 +436,226 @@ func TestWalkWithPagination(t *testing.T) {
 		testFn(-100)
 		testFn(100)
 	})
+}
+
+type walkWithPrefixIterCounter struct {
+	snapshotCalls          int
+	snapshotScanBatchSizes []int
+	iterCalls              int
+	closeCalls             int
+	nextCalls              int
+	nextErrAfterKey        string
+	nextErr                error
+}
+
+type countingSnapshotIterator struct {
+	tikvclient.Iterator
+	counter *walkWithPrefixIterCounter
+}
+
+func (iter *countingSnapshotIterator) Close() {
+	iter.counter.closeCalls++
+	iter.Iterator.Close()
+}
+
+func (iter *countingSnapshotIterator) Next() error {
+	iter.counter.nextCalls++
+	if iter.counter.nextErrAfterKey != "" && string(iter.Key()) == iter.counter.nextErrAfterKey {
+		return iter.counter.nextErr
+	}
+	return iter.Iterator.Next()
+}
+
+func patchWalkWithPrefixSnapshotIter(t *testing.T) *walkWithPrefixIterCounter {
+	t.Helper()
+
+	counter := &walkWithPrefixIterCounter{}
+	originGetSnapshot := getSnapshot
+	getSnapshot = func(txn *txnkv.Client, paginationSize int) *txnsnapshot.KVSnapshot {
+		counter.snapshotCalls++
+		counter.snapshotScanBatchSizes = append(counter.snapshotScanBatchSizes, paginationSize)
+		return originGetSnapshot(txn, paginationSize)
+	}
+	t.Cleanup(func() {
+		getSnapshot = originGetSnapshot
+	})
+
+	var origin func(*txnsnapshot.KVSnapshot, []byte, []byte) (tikvclient.Iterator, error)
+	mocker := mockey.Mock((*txnsnapshot.KVSnapshot).Iter).To(
+		func(ss *txnsnapshot.KVSnapshot, startKey []byte, endKey []byte) (tikvclient.Iterator, error) {
+			counter.iterCalls++
+			iter, err := origin(ss, startKey, endKey)
+			if err != nil {
+				return nil, err
+			}
+			return &countingSnapshotIterator{
+				Iterator: iter,
+				counter:  counter,
+			}, nil
+		}).Origin(&origin).Build()
+	t.Cleanup(func() {
+		mocker.UnPatch()
+	})
+
+	return counter
+}
+
+func TestWalkWithPrefixOpensIteratorPerPage(t *testing.T) {
+	testCases := []struct {
+		name              string
+		totalKeys         int
+		pagination        int
+		expectedPages     int
+		expectedScanBatch int
+	}{
+		{
+			name:              "not divisible by pagination",
+			totalKeys:         5,
+			pagination:        2,
+			expectedPages:     3,
+			expectedScanBatch: 3,
+		},
+		{
+			name:              "exactly divisible by pagination",
+			totalKeys:         6,
+			pagination:        3,
+			expectedPages:     2,
+			expectedScanBatch: 4,
+		},
+		{
+			name:              "single key pages",
+			totalKeys:         4,
+			pagination:        1,
+			expectedPages:     4,
+			expectedScanBatch: 2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.TODO()
+			rootPath := fmt.Sprintf("/tikv/test/root/walk-prefix-pages/%s", strings.ReplaceAll(testCase.name, " ", "-"))
+			kv := NewTiKV(txnClient, rootPath)
+			require.NoError(t, kv.RemoveWithPrefix(ctx, ""))
+			defer kv.Close()
+			defer kv.RemoveWithPrefix(ctx, "")
+
+			kvs := make(map[string]string)
+			expectedKeys := make([]string, 0, testCase.totalKeys)
+			expectedValues := make([]string, 0, testCase.totalKeys)
+			for i := 0; i < testCase.totalKeys; i++ {
+				key := fmt.Sprintf("A/%03d", i)
+				value := fmt.Sprintf("value-%03d", i)
+				kvs[key] = value
+				expectedKeys = append(expectedKeys, kv.GetPath(key))
+				expectedValues = append(expectedValues, value)
+			}
+			sort.Strings(expectedKeys)
+
+			require.NoError(t, kv.MultiSave(ctx, kvs))
+
+			counter := patchWalkWithPrefixSnapshotIter(t)
+			actualKeys := make([]string, 0, testCase.totalKeys)
+			actualValues := make([]string, 0, testCase.totalKeys)
+			err := kv.WalkWithPrefix(ctx, "A", testCase.pagination, func(key []byte, value []byte) error {
+				actualKeys = append(actualKeys, string(key))
+				actualValues = append(actualValues, string(value))
+				return nil
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, expectedKeys, actualKeys)
+			assert.Equal(t, expectedValues, actualValues)
+			assert.Equal(t, 1, counter.snapshotCalls)
+			assert.Equal(t, []int{testCase.expectedScanBatch}, counter.snapshotScanBatchSizes)
+			assert.Equal(t, testCase.expectedPages, counter.iterCalls)
+			assert.Equal(t, testCase.expectedPages, counter.closeCalls)
+		})
+	}
+}
+
+func TestWalkWithPrefixClosesPageIteratorOnFnError(t *testing.T) {
+	ctx := context.TODO()
+	rootPath := "/tikv/test/root/walk-prefix-pages-fn-error"
+	kv := NewTiKV(txnClient, rootPath)
+	require.NoError(t, kv.RemoveWithPrefix(ctx, ""))
+	defer kv.Close()
+	defer kv.RemoveWithPrefix(ctx, "")
+
+	const (
+		totalKeys  = 7
+		pagination = 3
+		failVisit  = 5
+	)
+	kvs := make(map[string]string)
+	expectedKeys := make([]string, 0, totalKeys)
+	for i := 0; i < totalKeys; i++ {
+		key := fmt.Sprintf("A/%03d", i)
+		kvs[key] = fmt.Sprintf("value-%03d", i)
+		expectedKeys = append(expectedKeys, kv.GetPath(key))
+	}
+	sort.Strings(expectedKeys)
+
+	require.NoError(t, kv.MultiSave(ctx, kvs))
+
+	counter := patchWalkWithPrefixSnapshotIter(t)
+	expectedErr := errors.New("stop walk")
+	actualKeys := make([]string, 0, failVisit)
+	err := kv.WalkWithPrefix(ctx, "A", pagination, func(key []byte, value []byte) error {
+		actualKeys = append(actualKeys, string(key))
+		if len(actualKeys) == failVisit {
+			return expectedErr
+		}
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, expectedKeys[:failVisit], actualKeys)
+	assert.Equal(t, 2, counter.iterCalls)
+	assert.Equal(t, 2, counter.closeCalls)
+}
+
+func TestWalkWithPrefixClosesPageIteratorOnNextError(t *testing.T) {
+	ctx := context.TODO()
+	rootPath := "/tikv/test/root/walk-prefix-pages-next-error"
+	kv := NewTiKV(txnClient, rootPath)
+	require.NoError(t, kv.RemoveWithPrefix(ctx, ""))
+	defer kv.Close()
+	defer kv.RemoveWithPrefix(ctx, "")
+
+	const (
+		totalKeys  = 7
+		pagination = 3
+		failVisit  = 5
+	)
+	kvs := make(map[string]string)
+	expectedKeys := make([]string, 0, totalKeys)
+	for i := 0; i < totalKeys; i++ {
+		key := fmt.Sprintf("A/%03d", i)
+		kvs[key] = fmt.Sprintf("value-%03d", i)
+		expectedKeys = append(expectedKeys, kv.GetPath(key))
+	}
+	sort.Strings(expectedKeys)
+
+	require.NoError(t, kv.MultiSave(ctx, kvs))
+
+	counter := patchWalkWithPrefixSnapshotIter(t)
+	expectedErr := errors.New("next failed")
+	counter.nextErrAfterKey = expectedKeys[failVisit-1]
+	counter.nextErr = expectedErr
+	actualKeys := make([]string, 0, failVisit)
+	err := kv.WalkWithPrefix(ctx, "A", pagination, func(key []byte, value []byte) error {
+		actualKeys = append(actualKeys, string(key))
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), expectedErr.Error())
+	assert.Equal(t, expectedKeys[:failVisit], actualKeys)
+	assert.Equal(t, 1, counter.snapshotCalls)
+	assert.Equal(t, 2, counter.iterCalls)
+	assert.Equal(t, 2, counter.closeCalls)
 }
 
 func TestElapse(t *testing.T) {


### PR DESCRIPTION
- Rewrite TiKV `WalkWithPrefix` to keep one snapshot while opening and closing a fresh iterator for each explicit page.
- Resume each page from `append(lastKey, 0x00)`, cap callback invocations by the requested pagination size, and preserve existing empty-value and `merr` error behavior.
- Add tests for divisible and non-divisible page counts, single-key pages, callback errors, iterator `Next` errors, and one-snapshot behavior.

related: #51760
