### PR TITLE
fix: refresh shard cache when alias collection ID changes

### DIFF
--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
@@ -472,6 +473,47 @@ type MetaCache struct {
 	closeOnce sync.Once
 }
 
+const (
+	metaCacheOpCollectionFill       = "collection_fill"
+	metaCacheOpPartitionFill        = "partition_fill"
+	metaCacheOpDatabaseFill         = "database_fill"
+	metaCacheOpCollectionInvalidate = "collection_invalidate"
+	metaCacheOpAliasInvalidate      = "alias_invalidate"
+	metaCacheOpAliasHolderFallback  = "alias_holder_fallback"
+	metaCacheOpPartitionInvalidate  = "partition_invalidate"
+	metaCacheOpDatabaseDrop         = "database_drop"
+	metaCacheOpDatabaseInvalidate   = "database_info_invalidate"
+)
+
+func (m *MetaCache) lockFillRead(operation string) func() {
+	observer := metrics.ProxyMetaCacheLockWaitLatency.
+		WithLabelValues(paramtable.GetStringNodeID(), "read", operation)
+	started := time.Now()
+	m.fillMu.RLock()
+	elapsed := time.Since(started)
+	observer.Observe(float64(elapsed.Microseconds()) / 1000.0)
+	return m.fillMu.RUnlock
+}
+
+func (m *MetaCache) lockFillWrite(operation string) func() {
+	observer := metrics.ProxyMetaCacheLockWaitLatency.
+		WithLabelValues(paramtable.GetStringNodeID(), "write", operation)
+	started := time.Now()
+	m.fillMu.Lock()
+	elapsed := time.Since(started)
+	observer.Observe(float64(elapsed.Microseconds()) / 1000.0)
+	return m.fillMu.Unlock
+}
+
+func observeMetaCacheInvalidation(operation string) func() {
+	observer := metrics.ProxyMetaCacheInvalidationLatency.
+		WithLabelValues(paramtable.GetStringNodeID(), operation)
+	started := time.Now()
+	return func() {
+		observer.Observe(float64(time.Since(started).Microseconds()) / 1000.0)
+	}
+}
+
 // globalMetaCache is singleton instance of Cache
 var globalMetaCache Cache
 
@@ -733,8 +775,8 @@ func (m *MetaCache) updateWithSingleflight(
 	// runs. Releasing fillMu inside update would let an invalidation evict the
 	// write-back while a post-invalidation caller could still join that old flight
 	// and receive its pre-DDL result directly, bypassing the cache maps.
-	m.fillMu.RLock()
-	defer m.fillMu.RUnlock()
+	unlockFill := m.lockFillRead(metaCacheOpCollectionFill)
+	defer unlockFill()
 
 	collection, err, _ := m.sfGlobal.Do(key, func() (*collectionInfo, error) {
 		info, err := m.update(ctx, database, collectionName, collectionID)
@@ -899,10 +941,11 @@ func (m *MetaCache) removeAliasLocked(database, alias string) {
 }
 
 func (m *MetaCache) RemoveAlias(ctx context.Context, database, alias string) {
+	defer observeMetaCacheInvalidation(metaCacheOpAliasInvalidate)()
 	// Invalidation: drain in-flight fills (e.g. a DescribeAlias write-back racing
 	// this alias DDL) before removing, see fillMu.
-	m.fillMu.Lock()
-	defer m.fillMu.Unlock()
+	unlockFill := m.lockFillWrite(metaCacheOpAliasInvalidate)
+	defer unlockFill()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.removeAliasLocked(database, alias)
@@ -922,9 +965,10 @@ func (m *MetaCache) RemoveAlias(ctx context.Context, database, alias string) {
 // unrelated eviction (a stable, name-addressed collection might never get one).
 // O(cached collections), paid only when the old target id is absent.
 func (m *MetaCache) RemoveAliasHolders(ctx context.Context, database, alias string) {
+	defer observeMetaCacheInvalidation(metaCacheOpAliasHolderFallback)()
 	// Invalidation: drain in-flight fills first, see fillMu.
-	m.fillMu.Lock()
-	defer m.fillMu.Unlock()
+	unlockFill := m.lockFillWrite(metaCacheOpAliasHolderFallback)
+	defer unlockFill()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1088,8 +1132,8 @@ func (m *MetaCache) GetPartitionInfos(ctx context.Context, database, collectionN
 	// Keep the fill lock through singleflight cleanup, not only its callback.
 	// Otherwise a partition invalidation can finish after the callback unlocks
 	// while a new caller still joins the completed pre-invalidation flight.
-	m.fillMu.RLock()
-	defer m.fillMu.RUnlock()
+	unlockFill := m.lockFillRead(metaCacheOpPartitionFill)
+	defer unlockFill()
 	partitionsInfo, err, _ := m.sfPartitionCache.Do(key, func() (*partitionInfos, error) {
 		// Describe/show BY ID (collectionID resolved above), not by name: the
 		// cache key is that id, and resolving by name here would let a
@@ -1319,9 +1363,10 @@ func (m *MetaCache) removeCollectionByAliasLocked(ctx context.Context, database,
 }
 
 func (m *MetaCache) RemoveCollection(ctx context.Context, database, collectionName string) {
+	defer observeMetaCacheInvalidation(metaCacheOpCollectionInvalidate)()
 	// Invalidation: drain in-flight fills first, see fillMu.
-	m.fillMu.Lock()
-	defer m.fillMu.Unlock()
+	unlockFill := m.lockFillWrite(metaCacheOpCollectionInvalidate)
+	defer unlockFill()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1356,8 +1401,9 @@ func (m *MetaCache) InvalidateCollectionMeta(
 	collectionID UniqueID,
 	removeAlias bool,
 ) []string {
-	m.fillMu.Lock()
-	defer m.fillMu.Unlock()
+	defer observeMetaCacheInvalidation(metaCacheOpCollectionInvalidate)()
+	unlockFill := m.lockFillWrite(metaCacheOpCollectionInvalidate)
+	defer unlockFill()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1413,9 +1459,10 @@ func (m *MetaCache) InvalidateCollectionMeta(
 }
 
 func (m *MetaCache) RemoveCollectionsByID(ctx context.Context, collectionID UniqueID) []string {
+	defer observeMetaCacheInvalidation(metaCacheOpCollectionInvalidate)()
 	// Invalidation: drain in-flight fills first, see fillMu.
-	m.fillMu.Lock()
-	defer m.fillMu.Unlock()
+	unlockFill := m.lockFillWrite(metaCacheOpCollectionInvalidate)
+	defer unlockFill()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1481,6 +1528,7 @@ func (m *MetaCache) removeCollectionByID(ctx context.Context, collectionID Uniqu
 }
 
 func (m *MetaCache) RemoveDatabase(ctx context.Context, database string) {
+	defer observeMetaCacheInvalidation(metaCacheOpDatabaseDrop)()
 	mlog.Debug(ctx, "remove database", mlog.String("name", database))
 	// Invalidation: drain in-flight fills first, so a describe issued before the
 	// DropDatabase broadcast cannot write its pre-DDL response back
@@ -1501,7 +1549,7 @@ func (m *MetaCache) RemoveDatabase(ctx context.Context, database string) {
 	// validating name hint in its database's nameIdx bucket -- update() writes
 	// both together, and a hint is only removed by the eviction that removes
 	// its entry -- so the bucket reaches every entry of this db.
-	m.fillMu.Lock()
+	unlockFill := m.lockFillWrite(metaCacheOpDatabaseDrop)
 	m.mu.Lock()
 	// O(1) under the lock: DETACH the db's hint bucket by reference and drop it
 	// from the maps -- do NOT iterate it here. Once detached, no fill or eviction
@@ -1515,7 +1563,7 @@ func (m *MetaCache) RemoveDatabase(ctx context.Context, database string) {
 	delete(m.nameIdx, database)
 	delete(m.aliasInfo, database)
 	m.mu.Unlock()
-	m.fillMu.Unlock()
+	unlockFill()
 
 	// Collect the doomed ids from the detached bucket OUTSIDE the locks.
 	ids := make([]UniqueID, 0, len(bucket))
@@ -1555,8 +1603,9 @@ func (m *MetaCache) RemoveDatabase(ctx context.Context, database string) {
 // properties after this method returns. Collection metadata is deliberately
 // left untouched: AlterDatabase changes database properties only.
 func (m *MetaCache) RemoveDatabaseInfo(ctx context.Context, database string) {
-	m.fillMu.Lock()
-	defer m.fillMu.Unlock()
+	defer observeMetaCacheInvalidation(metaCacheOpDatabaseInvalidate)()
+	unlockFill := m.lockFillWrite(metaCacheOpDatabaseInvalidate)
+	defer unlockFill()
 
 	m.mu.Lock()
 	delete(m.dbInfo, database)
@@ -1581,8 +1630,8 @@ func (m *MetaCache) GetDatabaseInfo(ctx context.Context, database string) (*data
 	// Keep the fill lock through singleflight cleanup, matching collection and
 	// partition fills. RemoveDatabase/RemoveDatabaseInfo must not finish while a
 	// new caller can still join a completed pre-invalidation database flight.
-	m.fillMu.RLock()
-	defer m.fillMu.RUnlock()
+	unlockFill := m.lockFillRead(metaCacheOpDatabaseFill)
+	defer unlockFill()
 	dbInfo, err, _ := m.sfDB.Do(database, func() (*databaseInfo, error) {
 		resp, err := m.describeDatabase(ctx, database)
 		if err != nil {
@@ -1644,9 +1693,10 @@ func (m *MetaCache) AllocID(ctx context.Context) (int64, error) {
 }
 
 func (m *MetaCache) RemovePartition(ctx context.Context, database string, collectionID UniqueID, collectionName string, partitionName string) {
+	defer observeMetaCacheInvalidation(metaCacheOpPartitionInvalidate)()
 	// Invalidation: drain in-flight fills first, see fillMu.
-	m.fillMu.Lock()
-	defer m.fillMu.Unlock()
+	unlockFill := m.lockFillWrite(metaCacheOpPartitionInvalidate)
+	defer unlockFill()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/proxy/meta_cache_benchmark_test.go
+++ b/internal/proxy/meta_cache_benchmark_test.go
@@ -1,0 +1,388 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+const metaCacheBenchmarkSizesEnv = "MILVUS_METACACHE_BENCH_SIZES"
+
+type metaCacheBenchShape struct {
+	entries            int
+	databases          int
+	aliasesPerEntry    int
+	withPartitionCache bool
+}
+
+func metaCacheBenchmarkSizes(tb testing.TB) []int {
+	tb.Helper()
+	raw := strings.TrimSpace(os.Getenv(metaCacheBenchmarkSizesEnv))
+	if raw == "" {
+		return []int{100_000}
+	}
+
+	parts := strings.Split(raw, ",")
+	sizes := make([]int, 0, len(parts))
+	for _, part := range parts {
+		value, err := strconv.Atoi(strings.TrimSpace(part))
+		require.NoError(tb, err, "parse %s=%q", metaCacheBenchmarkSizesEnv, raw)
+		require.Positive(tb, value, "benchmark sizes must be positive")
+		sizes = append(sizes, value)
+	}
+	return sizes
+}
+
+func newMetaCacheBench(shape metaCacheBenchShape) *MetaCache {
+	if shape.databases <= 0 {
+		shape.databases = 1
+	}
+	cache := &MetaCache{
+		collections:    make(map[UniqueID]*collectionInfo, shape.entries),
+		nameIdx:        make(map[string]map[string]UniqueID, shape.databases),
+		aliasInfo:      make(map[string]map[string]string, shape.databases),
+		partitionCache: make(map[string]*partitionInfos),
+	}
+	for i := 0; i < shape.entries; i++ {
+		seedMetaCacheBenchEntry(cache, shape, i)
+	}
+	return cache
+}
+
+func seedMetaCacheBenchEntry(cache *MetaCache, shape metaCacheBenchShape, index int) {
+	id := UniqueID(index + 1)
+	db := fmt.Sprintf("db_%04d", index%shape.databases)
+	name := fmt.Sprintf("collection_%09d", index)
+	aliases := make([]string, 0, shape.aliasesPerEntry)
+
+	if _, ok := cache.nameIdx[db]; !ok {
+		cache.nameIdx[db] = make(map[string]UniqueID)
+	}
+	if shape.aliasesPerEntry > 0 {
+		if _, ok := cache.aliasInfo[db]; !ok {
+			cache.aliasInfo[db] = make(map[string]string)
+		}
+		for aliasIndex := 0; aliasIndex < shape.aliasesPerEntry; aliasIndex++ {
+			alias := fmt.Sprintf("alias_%09d_%02d", index, aliasIndex)
+			aliases = append(aliases, alias)
+			cache.aliasInfo[db][alias] = name
+		}
+	}
+
+	cache.collections[id] = &collectionInfo{
+		collID:  id,
+		dbName:  db,
+		schema:  &schemaInfo{CollectionSchema: &schemapb.CollectionSchema{Name: name}},
+		aliases: aliases,
+	}
+	cache.nameIdx[db][name] = id
+
+	if shape.withPartitionCache {
+		partition := &partitionInfo{name: "_default", partitionID: UniqueID(index + 10_000_000), isDefault: true}
+		cache.partitionCache[buildPartitionCacheKey(id)] = &partitionInfos{
+			partitionInfos: []*partitionInfo{partition},
+			name2Info:      map[string]*partitionInfo{partition.name: partition},
+			name2ID:        map[string]int64{partition.name: partition.partitionID},
+		}
+	}
+}
+
+func validateMetaCacheBench(tb testing.TB, cache *MetaCache) {
+	tb.Helper()
+	cache.mu.RLock()
+	violations := metaCacheConsistencyViolations(cache)
+	cache.mu.RUnlock()
+	require.Empty(tb, violations)
+}
+
+func BenchmarkMetaCacheHit(b *testing.B) {
+	for _, entries := range metaCacheBenchmarkSizes(b) {
+		shape := metaCacheBenchShape{entries: entries, databases: 100, aliasesPerEntry: 1}
+		cache := newMetaCacheBench(shape)
+		validateMetaCacheBench(b, cache)
+
+		b.Run(fmt.Sprintf("by-id/%d", entries), func(b *testing.B) {
+			var cursor atomic.Uint64
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					index := int(cursor.Add(1)-1) % entries
+					entry, ok := cache.getCollection("", "", UniqueID(index+1))
+					if !ok || entry.collID != UniqueID(index+1) {
+						b.Fatalf("by-id miss for index %d", index)
+					}
+				}
+			})
+		})
+
+		b.Run(fmt.Sprintf("by-name/%d", entries), func(b *testing.B) {
+			var cursor atomic.Uint64
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					index := int(cursor.Add(1)-1) % entries
+					db := fmt.Sprintf("db_%04d", index%shape.databases)
+					name := fmt.Sprintf("collection_%09d", index)
+					entry, ok := cache.getCollection(db, name, 0)
+					if !ok || entry.collID != UniqueID(index+1) {
+						b.Fatalf("by-name miss for index %d", index)
+					}
+				}
+			})
+		})
+
+		b.Run(fmt.Sprintf("by-alias/%d", entries), func(b *testing.B) {
+			var cursor atomic.Uint64
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					index := int(cursor.Add(1)-1) % entries
+					db := fmt.Sprintf("db_%04d", index%shape.databases)
+					alias := fmt.Sprintf("alias_%09d_00", index)
+					entry, ok := cache.getCollection(db, alias, 0)
+					if !ok || entry.collID != UniqueID(index+1) {
+						b.Fatalf("by-alias miss for index %d", index)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkMetaCacheInvalidateByID(b *testing.B) {
+	ctx := context.Background()
+	for _, entries := range metaCacheBenchmarkSizes(b) {
+		shape := metaCacheBenchShape{entries: entries, databases: 100, aliasesPerEntry: 1, withPartitionCache: true}
+		cache := newMetaCacheBench(shape)
+		index := entries / 2
+		id := UniqueID(index + 1)
+
+		b.Run(fmt.Sprintf("%d", entries), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				cache.RemoveCollectionsByID(ctx, id)
+				b.StopTimer()
+				seedMetaCacheBenchEntry(cache, shape, index)
+			}
+		})
+		validateMetaCacheBench(b, cache)
+	}
+}
+
+func BenchmarkMetaCacheInvalidateKnownAliasTargets(b *testing.B) {
+	ctx := context.Background()
+	for _, entries := range metaCacheBenchmarkSizes(b) {
+		shape := metaCacheBenchShape{entries: entries, databases: 100, aliasesPerEntry: 1, withPartitionCache: true}
+		cache := newMetaCacheBench(shape)
+		index := entries / 2
+		id := UniqueID(index + 1)
+		db := fmt.Sprintf("db_%04d", index%shape.databases)
+		alias := fmt.Sprintf("alias_%09d_00", index)
+
+		b.Run(fmt.Sprintf("%d", entries), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				cache.InvalidateCollectionMeta(ctx, db, alias, id, true)
+				b.StopTimer()
+				seedMetaCacheBenchEntry(cache, shape, index)
+			}
+		})
+		validateMetaCacheBench(b, cache)
+	}
+}
+
+func BenchmarkMetaCachePartitionInvalidation(b *testing.B) {
+	ctx := context.Background()
+	for _, entries := range metaCacheBenchmarkSizes(b) {
+		shape := metaCacheBenchShape{entries: entries, databases: 100, aliasesPerEntry: 1, withPartitionCache: true}
+		cache := newMetaCacheBench(shape)
+		index := entries / 2
+		id := UniqueID(index + 1)
+		db := fmt.Sprintf("db_%04d", index%shape.databases)
+		name := fmt.Sprintf("collection_%09d", index)
+
+		b.Run(fmt.Sprintf("%d", entries), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				cache.RemovePartition(ctx, db, id, name, "_default")
+				b.StopTimer()
+				seedMetaCacheBenchEntry(cache, shape, index)
+			}
+		})
+		validateMetaCacheBench(b, cache)
+	}
+}
+
+func BenchmarkMetaCacheDropDatabase(b *testing.B) {
+	ctx := context.Background()
+	for _, entries := range metaCacheBenchmarkSizes(b) {
+		shape := metaCacheBenchShape{entries: entries, databases: 10, aliasesPerEntry: 1, withPartitionCache: true}
+		entriesPerDatabase := entries / shape.databases
+		b.Run(fmt.Sprintf("total_%d/db_entries_%d", entries, entriesPerDatabase), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				cache := newMetaCacheBench(shape)
+				b.StartTimer()
+				cache.RemoveDatabase(ctx, "db_0000")
+			}
+		})
+	}
+}
+
+func BenchmarkMetaCacheOldRootcoordAliasHolderFallback(b *testing.B) {
+	ctx := context.Background()
+	for _, entries := range metaCacheBenchmarkSizes(b) {
+		shape := metaCacheBenchShape{entries: entries, databases: 10, aliasesPerEntry: 1}
+		b.Run(fmt.Sprintf("%d", entries), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				cache := newMetaCacheBench(shape)
+				alias := "alias_000000000_00"
+				b.StartTimer()
+				cache.RemoveAliasHolders(ctx, "db_0000", alias)
+			}
+		})
+	}
+}
+
+func BenchmarkMetaCacheGlobalFillGate(b *testing.B) {
+	operations := []struct {
+		name      string
+		operation string
+	}{
+		{name: "collection_invalidate", operation: metaCacheOpCollectionInvalidate},
+		{name: "database_drop", operation: metaCacheOpDatabaseDrop},
+	}
+	for _, delay := range []time.Duration{10 * time.Millisecond, 100 * time.Millisecond, time.Second, 5 * time.Second} {
+		for _, inflight := range []int{1, 10, 100} {
+			for _, operation := range operations {
+				name := fmt.Sprintf("delay_%s/inflight_%d/%s", delay, inflight, operation.name)
+				b.Run(name, func(b *testing.B) {
+					cache := &MetaCache{}
+					b.ReportAllocs()
+					for i := 0; i < b.N; i++ {
+						b.StopTimer()
+						readerUnlocks := make([]func(), 0, inflight)
+						for j := 0; j < inflight; j++ {
+							readerUnlocks = append(readerUnlocks, cache.lockFillRead(metaCacheOpCollectionFill))
+						}
+						released := make(chan struct{})
+						go func() {
+							time.Sleep(delay)
+							for _, unlock := range readerUnlocks {
+								unlock()
+							}
+							close(released)
+						}()
+
+						started := time.Now()
+						b.StartTimer()
+						writerUnlock := cache.lockFillWrite(operation.operation)
+						b.StopTimer()
+						wait := time.Since(started)
+						writerUnlock()
+						<-released
+						if wait < delay/2 {
+							b.Fatalf("writer wait %s was shorter than expected delay %s", wait, delay)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+type metaCacheMemorySample struct {
+	heapBytes   uint64
+	heapObjects uint64
+}
+
+func measureMetaCacheMemory(t *testing.T, shape metaCacheBenchShape) metaCacheMemorySample {
+	t.Helper()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	cache := newMetaCacheBench(shape)
+	validateMetaCacheBench(t, cache)
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	sample := metaCacheMemorySample{}
+	if after.HeapAlloc > before.HeapAlloc {
+		sample.heapBytes = after.HeapAlloc - before.HeapAlloc
+	}
+	if after.HeapObjects > before.HeapObjects {
+		sample.heapObjects = after.HeapObjects - before.HeapObjects
+	}
+	runtime.KeepAlive(cache)
+	return sample
+}
+
+func positiveMemoryDelta(after, before uint64) uint64 {
+	if after <= before {
+		return 0
+	}
+	return after - before
+}
+
+func TestMetaCacheMemoryFootprint(t *testing.T) {
+	if strings.TrimSpace(os.Getenv(metaCacheBenchmarkSizesEnv)) == "" {
+		t.Skipf("set %s=100000,1000000 to run the memory footprint test", metaCacheBenchmarkSizesEnv)
+	}
+
+	for _, entries := range metaCacheBenchmarkSizes(t) {
+		primary := measureMetaCacheMemory(t, metaCacheBenchShape{entries: entries, databases: 100})
+		withAliases := measureMetaCacheMemory(t, metaCacheBenchShape{entries: entries, databases: 100, aliasesPerEntry: 1})
+		withPartitions := measureMetaCacheMemory(t, metaCacheBenchShape{
+			entries: entries, databases: 100, aliasesPerEntry: 1, withPartitionCache: true,
+		})
+		aliasBytes := positiveMemoryDelta(withAliases.heapBytes, primary.heapBytes)
+		partitionBytes := positiveMemoryDelta(withPartitions.heapBytes, withAliases.heapBytes)
+		t.Logf("entries=%d primary_heap_bytes=%d bytes_per_primary_entry=%.2f alias_heap_bytes=%d bytes_per_alias=%.2f partition_heap_bytes=%d bytes_per_partition_list=%.2f combined_heap_objects=%d",
+			entries,
+			primary.heapBytes,
+			float64(primary.heapBytes)/float64(entries),
+			aliasBytes,
+			float64(aliasBytes)/float64(entries),
+			partitionBytes,
+			float64(partitionBytes)/float64(entries),
+			withPartitions.heapObjects,
+		)
+	}
+}

--- a/internal/proxy/meta_cache_test.go
+++ b/internal/proxy/meta_cache_test.go
@@ -26,9 +26,12 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -53,6 +56,130 @@ import (
 )
 
 var dbName = GetCurDBNameFromContextOrDefault(context.Background())
+
+func histogramSampleCount(t *testing.T, observer prometheus.Observer) uint64 {
+	t.Helper()
+	metric, ok := observer.(prometheus.Metric)
+	require.True(t, ok)
+	pb := &dto.Metric{}
+	require.NoError(t, metric.Write(pb))
+	return pb.GetHistogram().GetSampleCount()
+}
+
+func TestMetaCacheFillGateMetrics(t *testing.T) {
+	cache := &MetaCache{}
+	nodeID := paramtable.GetStringNodeID()
+	readObserver := metrics.ProxyMetaCacheLockWaitLatency.WithLabelValues(nodeID, "read", metaCacheOpCollectionFill)
+	writeObserver := metrics.ProxyMetaCacheLockWaitLatency.WithLabelValues(nodeID, "write", metaCacheOpCollectionInvalidate)
+	invalidationObserver := metrics.ProxyMetaCacheInvalidationLatency.WithLabelValues(nodeID, metaCacheOpCollectionInvalidate)
+
+	readBefore := histogramSampleCount(t, readObserver)
+	readUnlock := cache.lockFillRead(metaCacheOpCollectionFill)
+	readUnlock()
+	assert.Equal(t, readBefore+1, histogramSampleCount(t, readObserver))
+
+	writeBefore := histogramSampleCount(t, writeObserver)
+	writeUnlock := cache.lockFillWrite(metaCacheOpCollectionInvalidate)
+	writeUnlock()
+	assert.Equal(t, writeBefore+1, histogramSampleCount(t, writeObserver))
+
+	invalidationBefore := histogramSampleCount(t, invalidationObserver)
+	observeMetaCacheInvalidation(metaCacheOpCollectionInvalidate)()
+	assert.Equal(t, invalidationBefore+1, histogramSampleCount(t, invalidationObserver))
+}
+
+func TestMetaCacheGlobalFillGateBlocksAcrossDatabases(t *testing.T) {
+	cache := &MetaCache{
+		collections: make(map[UniqueID]*collectionInfo),
+		nameIdx:     make(map[string]map[string]UniqueID),
+		aliasInfo:   make(map[string]map[string]string),
+	}
+	seedCollection(cache, "db-c", "cached", 1)
+
+	// DB-A has a slow fill in progress. Holding the shared gate directly keeps
+	// the test independent of coordinator timing while exercising the same gate
+	// used by collection, partition, and database fills.
+	releaseDBAFill := cache.lockFillRead(metaCacheOpCollectionFill)
+
+	// DB-B queues an invalidation writer behind DB-A's fill and deliberately
+	// holds the writer gate once acquired so DB-C's later fill can be observed.
+	writerAcquired := make(chan struct{})
+	releaseWriter := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		unlock := cache.lockFillWrite(metaCacheOpCollectionInvalidate)
+		close(writerAcquired)
+		<-releaseWriter
+		unlock()
+	}()
+
+	// TryRLock succeeds while only readers exist and fails once an RWMutex
+	// writer is queued. This gives a deterministic queued-writer gate without a
+	// scheduler-dependent sleep.
+	require.Eventually(t, func() bool {
+		if cache.fillMu.TryRLock() {
+			cache.fillMu.RUnlock()
+			return false
+		}
+		return true
+	}, time.Second, time.Millisecond, "DB-B invalidation did not queue behind DB-A fill")
+
+	// A DB-C cache hit uses only m.mu and must remain available even while the
+	// global fill writer is queued.
+	hitDone := make(chan struct{})
+	go func() {
+		defer close(hitDone)
+		entry, ok := cache.getCollection("db-c", "cached", 0)
+		assert.True(t, ok)
+		assert.Equal(t, UniqueID(1), entry.collID)
+	}()
+	select {
+	case <-hitDone:
+	case <-time.After(time.Second):
+		t.Fatal("DB-C cache hit was blocked by the global fill gate")
+	}
+
+	// A new DB-C fill arrives after DB-B's writer is queued. Go's RWMutex gives
+	// the queued writer priority, so this unrelated database is blocked too.
+	dbcFillAcquired := make(chan struct{})
+	dbcFillDone := make(chan struct{})
+	go func() {
+		defer close(dbcFillDone)
+		unlock := cache.lockFillRead(metaCacheOpCollectionFill)
+		close(dbcFillAcquired)
+		unlock()
+	}()
+	select {
+	case <-dbcFillAcquired:
+		t.Fatal("DB-C fill bypassed the queued DB-B invalidation writer")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	releaseDBAFill()
+	select {
+	case <-writerAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("DB-B invalidation did not acquire after DB-A fill released")
+	}
+	select {
+	case <-dbcFillAcquired:
+		t.Fatal("DB-C fill acquired while DB-B invalidation held the writer gate")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseWriter)
+	select {
+	case <-writerDone:
+	case <-time.After(time.Second):
+		t.Fatal("DB-B invalidation did not release the writer gate")
+	}
+	select {
+	case <-dbcFillDone:
+	case <-time.After(time.Second):
+		t.Fatal("DB-C fill did not proceed after the invalidation released")
+	}
+}
 
 type MockMixCoordClientInterface struct {
 	types.MixCoordClient

--- a/internal/proxy/shardclient/README.md
+++ b/internal/proxy/shardclient/README.md
@@ -65,7 +65,10 @@ The central manager for QueryNode client connections and shard leader informatio
 
 **Key Responsibilities**:
 - Cache shard leader mappings from QueryCoord, keyed by the cluster-unique collection id (`collectionID → channel → []nodeInfo`); name/alias/database are resolved upstream against the meta cache and are never part of the key
+- Coalesce refreshes per `(collectionID, force)` while allowing each caller to honor its own context
+- Fence in-flight refreshes so an invalidated collection id cannot be written back by an older RPC
 - Manage `shardClient` instances for each QueryNode
+- Expire idle shard-cache entries before deciding which QueryNode clients remain protected
 - Automatically purge expired clients (default: 60 minutes of inactivity)
 - Invalidate cache when shard leaders change
 
@@ -86,6 +89,8 @@ type ShardClientMgr interface {
 **Configuration**:
 - `purgeInterval`: Interval for checking expired clients (default: 600s)
 - `expiredDuration`: Time after which inactive clients are purged (default: 60min)
+- `shardCacheRefreshTimeout`: Hard timeout for a shared QueryCoord refresh (default: 10s)
+- `shardCacheTTL`: Idle lifetime of a shard leader cache entry (default: 600s)
 
 ### 2. shardClient
 
@@ -259,9 +264,11 @@ collectionID → shardLeaders {
 **Cache Operations**:
 - **Hit**: When cached shard leaders are used (tracked via `ProxyCacheStatsCounter`)
 - **Miss**: When cache lookup fails, triggers RPC to QueryCoord via `GetShardLeaders`
+- **Refresh coalescing**: Concurrent misses for the same collection id share one RPC, but callers wait using their own contexts. The shared RPC does not inherit the first caller's cancellation and has a ten-second hard timeout.
 - **Invalidation** (the cache is keyed by the cluster-unique collection id):
-  - `InvalidateShardLeaderCache(collectionIDs)`: Remove collections by id (called on shard-leader changes, collection drop, and search/query retry). O(len(collectionIDs)) direct deletes.
+  - `InvalidateShardLeaderCache(collectionIDs)`: Remove collections by id and revoke their in-flight refresh generations (called on shard-leader changes, collection drop, and search/query retry). O(len(collectionIDs)) direct deletes.
   - `RemoveDatabase(db)`: No-op. DropDatabase requires an empty database, so its collections were already dropped and evicted by id; the id-keyed cache does not track database membership.
+- **Idle cleanup**: `ListShardLocation` scans with a read lock, then briefly takes the write lock to revalidate and delete expired entries. Cache hits remain concurrent with the scan.
 
 ### Client Purging
 
@@ -345,5 +352,4 @@ Potential areas for enhancement:
 1. **Adaptive pooling**: Dynamically adjust connection pool size based on load
 2. **Circuit breaker**: Add circuit breaker pattern for consistently failing nodes
 3. **Advanced metrics**: Export more detailed metrics (per-node latency, error rates, etc.)
-4. **Smart caching**: Use TTL-based cache expiration instead of invalidation-only
-5. **Connection warming**: Pre-establish connections to known QueryNodes
+4. **Connection warming**: Pre-establish connections to known QueryNodes

--- a/internal/proxy/shardclient/README.md
+++ b/internal/proxy/shardclient/README.md
@@ -268,7 +268,7 @@ collectionID → shardLeaders {
 - **Invalidation** (the cache is keyed by the cluster-unique collection id):
   - `InvalidateShardLeaderCache(collectionIDs)`: Remove collections by id and revoke their in-flight refresh generations (called on shard-leader changes, collection drop, and search/query retry). O(len(collectionIDs)) direct deletes.
   - `RemoveDatabase(db)`: No-op. DropDatabase requires an empty database, so its collections were already dropped and evicted by id; the id-keyed cache does not track database membership.
-- **Idle cleanup**: `ListShardLocation` scans with a read lock, then briefly takes the write lock to revalidate and delete expired entries. Cache hits remain concurrent with the scan.
+- **Idle cleanup**: `ListShardLocation` scans the concurrent collection-id map without the refresh lifecycle lock, then briefly takes that lock per candidate to revalidate and delete expired entries. Cache hits, refresh publications, and unrelated invalidations remain concurrent with the full scan.
 
 ### Client Purging
 

--- a/internal/proxy/shardclient/manager.go
+++ b/internal/proxy/shardclient/manager.go
@@ -63,23 +63,30 @@ type shardClientMgrImpl struct {
 
 	mixCoord types.MixCoordClient
 
+	// leaderMut guards refresh lifecycle state and coordinates cache mutations
+	// with lookup-and-touch operations. collLeader itself is concurrent so an
+	// O(N) idle scan never holds this mutex and cannot stall unrelated hits,
+	// refresh publications, or invalidations.
 	leaderMut sync.RWMutex
 	// collLeader keys shard leaders by the cluster-unique collection id, so name/alias/database
 	// resolution (done upstream against the meta cache) can never serve one collection's shard
 	// leaders under another's name after an alias repoint or a cross-db rename. Eviction is by
 	// collection id only -- the cache deliberately does not depend on the mutable
 	// collection->database mapping. See issue #51533.
-	collLeader   map[int64]*shardLeaders // collectionID -> collection_leaders
+	collLeader   *typeutil.ConcurrentMap[int64, *shardLeaders] // collectionID -> collection_leaders
 	sfShardCache conc.Singleflight[*shardLeaders]
 	refreshSeq   uint64
 	refreshes    map[shardCacheRefreshKey]*shardCacheRefreshToken
+	// refreshWriteSeq fences cache publication across normal and forced refresh flights.
+	refreshWriteSeq map[int64]uint64
 
 	shardCacheRefreshTimeout time.Duration
 	shardCacheTTL            time.Duration
 
-	testHookAfterShardCacheDoChan       func()
-	testHookListShardLocationReadLocked func()
-	testHookBeforeShardLocationDelete   func()
+	testHookAfterShardCacheDoChan     func()
+	testHookAfterShardCacheLoad       func()
+	testHookListShardLocationScan     func()
+	testHookBeforeShardLocationDelete func()
 }
 
 type (
@@ -124,9 +131,10 @@ func NewShardClientMgr(mixCoord types.MixCoordClient, options ...shardClientMgrO
 		purgeInterval:   defaultPurgeInterval,
 		expiredDuration: defaultExpiredDuration,
 
-		collLeader: make(map[int64]*shardLeaders),
-		refreshes:  make(map[shardCacheRefreshKey]*shardCacheRefreshToken),
-		mixCoord:   mixCoord,
+		collLeader:      typeutil.NewConcurrentMap[int64, *shardLeaders](),
+		refreshes:       make(map[shardCacheRefreshKey]*shardCacheRefreshToken),
+		refreshWriteSeq: make(map[int64]uint64),
+		mixCoord:        mixCoord,
 
 		shardCacheRefreshTimeout: defaultShardCacheRefreshTimeout,
 		shardCacheTTL:            defaultShardCacheTTL,
@@ -163,19 +171,41 @@ func (m *shardClientMgrImpl) GetShardLeaderList(ctx context.Context, database, c
 func (m *shardClientMgrImpl) loadCachedShardLeaders(collectionID int64) *shardLeaders {
 	m.leaderMut.RLock()
 	defer m.leaderMut.RUnlock()
-	return m.collLeader[collectionID]
+	leaders, _ := m.collLeader.Get(collectionID)
+	return leaders
 }
 
-func (m *shardClientMgrImpl) getCachedShardLeaders(collectionID int64, caller string) *shardLeaders {
-	cacheShardLeaders := m.loadCachedShardLeaders(collectionID)
+func (m *shardClientMgrImpl) loadCachedShardLeadersAndTouch(collectionID int64) *shardLeaders {
+	m.leaderMut.RLock()
+	defer m.leaderMut.RUnlock()
+	leaders, _ := m.collLeader.Get(collectionID)
+	if leaders != nil {
+		if h := m.testHookAfterShardCacheLoad; h != nil {
+			h()
+		}
+		leaders.touch(time.Now())
+	}
+	return leaders
+}
 
-	if cacheShardLeaders != nil {
+func recordShardCacheLookup(caller string, leaders *shardLeaders) {
+	if leaders != nil {
 		metrics.ProxyCacheStatsCounter.WithLabelValues(paramtable.GetStringNodeID(), caller, metrics.CacheHitLabel).Inc()
 	} else {
 		metrics.ProxyCacheStatsCounter.WithLabelValues(paramtable.GetStringNodeID(), caller, metrics.CacheMissLabel).Inc()
 	}
+}
 
-	return cacheShardLeaders
+func (m *shardClientMgrImpl) getCachedShardLeaders(collectionID int64, caller string) *shardLeaders {
+	leaders := m.loadCachedShardLeaders(collectionID)
+	recordShardCacheLookup(caller, leaders)
+	return leaders
+}
+
+func (m *shardClientMgrImpl) getCachedShardLeadersAndTouch(collectionID int64, caller string) *shardLeaders {
+	leaders := m.loadCachedShardLeadersAndTouch(collectionID)
+	recordShardCacheLookup(caller, leaders)
+	return leaders
 }
 
 func (m *shardClientMgrImpl) acquireShardCacheRefresh(key shardCacheRefreshKey) *shardCacheRefreshToken {
@@ -188,9 +218,13 @@ func (m *shardClientMgrImpl) acquireShardCacheRefresh(key shardCacheRefreshKey) 
 	if m.refreshes == nil {
 		m.refreshes = make(map[shardCacheRefreshKey]*shardCacheRefreshToken)
 	}
+	if m.refreshWriteSeq == nil {
+		m.refreshWriteSeq = make(map[int64]uint64)
+	}
 	m.refreshSeq++
 	refresh := &shardCacheRefreshToken{id: m.refreshSeq}
 	m.refreshes[key] = refresh
+	m.refreshWriteSeq[key.collectionID] = refresh.id
 	return refresh
 }
 
@@ -199,6 +233,9 @@ func (m *shardClientMgrImpl) finishShardCacheRefresh(key shardCacheRefreshKey, r
 	defer m.leaderMut.Unlock()
 	if m.refreshes[key] == refresh {
 		delete(m.refreshes, key)
+	}
+	if m.refreshWriteSeq[key.collectionID] == refresh.id {
+		delete(m.refreshWriteSeq, key.collectionID)
 	}
 }
 
@@ -214,9 +251,13 @@ func (m *shardClientMgrImpl) getShardLeaders(
 		return nil, err
 	}
 
-	cacheShardLeaders := m.getCachedShardLeaders(collectionID, caller)
+	var cacheShardLeaders *shardLeaders
+	if withCache {
+		cacheShardLeaders = m.getCachedShardLeadersAndTouch(collectionID, caller)
+	} else {
+		cacheShardLeaders = m.getCachedShardLeaders(collectionID, caller)
+	}
 	if cacheShardLeaders != nil && withCache {
-		cacheShardLeaders.touch(time.Now())
 		return cacheShardLeaders, nil
 	}
 
@@ -226,8 +267,7 @@ func (m *shardClientMgrImpl) getShardLeaders(
 	resultCh := m.sfShardCache.DoChanRaw(singleflightKey, func() (*shardLeaders, error) {
 		defer m.finishShardCacheRefresh(refreshKey, refresh)
 		if withCache {
-			if cached := m.loadCachedShardLeaders(collectionID); cached != nil {
-				cached.touch(time.Now())
+			if cached := m.loadCachedShardLeadersAndTouch(collectionID); cached != nil {
 				return cached, nil
 			}
 		}
@@ -322,10 +362,10 @@ func (m *shardClientMgrImpl) cacheShardLeaders(
 ) {
 	m.leaderMut.Lock()
 	defer m.leaderMut.Unlock()
-	if m.refreshes[refreshKey] != refresh {
+	if m.refreshes[refreshKey] != refresh || m.refreshWriteSeq[collectionID] != refresh.id {
 		return
 	}
-	m.collLeader[collectionID] = leaders
+	m.collLeader.Insert(collectionID, leaders)
 }
 
 func parseShardLeaderList2QueryNode(shardsLeaders []*querypb.ShardLeadersList) map[string][]NodeInfo {
@@ -354,22 +394,21 @@ func (m *shardClientMgrImpl) ListShardLocation() map[int64]NodeInfo {
 	cutoff := time.Now().Add(-ttl)
 	expired := make([]shardCacheEntryRef, 0)
 
-	m.leaderMut.RLock()
-	if m.testHookListShardLocationReadLocked != nil {
-		m.testHookListShardLocationReadLocked()
+	if m.testHookListShardLocationScan != nil {
+		m.testHookListShardLocationScan()
 	}
-	for collectionID, leaders := range m.collLeader {
+	m.collLeader.Range(func(collectionID int64, leaders *shardLeaders) bool {
 		if leaders.idleBefore(cutoff) {
 			expired = append(expired, shardCacheEntryRef{collectionID: collectionID, leaders: leaders})
-			continue
+			return true
 		}
 		for _, nodeInfos := range leaders.shardLeaders {
 			for _, node := range nodeInfos {
 				shardLeaderInfo[node.NodeID] = node
 			}
 		}
-	}
-	m.leaderMut.RUnlock()
+		return true
+	})
 
 	if len(expired) == 0 {
 		return shardLeaderInfo
@@ -378,17 +417,24 @@ func (m *shardClientMgrImpl) ListShardLocation() map[int64]NodeInfo {
 		m.testHookBeforeShardLocationDelete()
 	}
 
-	m.leaderMut.Lock()
-	defer m.leaderMut.Unlock()
 	for _, candidate := range expired {
-		leaders := m.collLeader[candidate.collectionID]
+		m.leaderMut.Lock()
+		leaders, _ := m.collLeader.Get(candidate.collectionID)
 		if leaders == nil {
+			m.leaderMut.Unlock()
 			continue
 		}
 		if leaders == candidate.leaders && leaders.idleBefore(cutoff) {
-			delete(m.collLeader, candidate.collectionID)
+			m.collLeader.Remove(candidate.collectionID)
+			m.leaderMut.Unlock()
 			continue
 		}
+		m.leaderMut.Unlock()
+
+		// shardLeaders is immutable apart from its atomic access timestamp, so
+		// nodes can be collected after releasing the mutation lock. A concurrent
+		// invalidation may make this result conservative for one purge cycle, which
+		// only retains an idle client longer and is safer than closing a live one.
 		for _, nodeInfos := range leaders.shardLeaders {
 			for _, node := range nodeInfos {
 				shardLeaderInfo[node.NodeID] = node
@@ -415,9 +461,10 @@ func (m *shardClientMgrImpl) InvalidateShardLeaderCache(collections []int64) {
 	m.leaderMut.Lock()
 	defer m.leaderMut.Unlock()
 	for _, collectionID := range collections {
-		delete(m.collLeader, collectionID)
+		m.collLeader.Remove(collectionID)
 		delete(m.refreshes, shardCacheRefreshKey{collectionID: collectionID})
 		delete(m.refreshes, shardCacheRefreshKey{collectionID: collectionID, force: true})
+		delete(m.refreshWriteSeq, collectionID)
 	}
 }
 

--- a/internal/proxy/shardclient/manager.go
+++ b/internal/proxy/shardclient/manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
@@ -68,12 +69,39 @@ type shardClientMgrImpl struct {
 	// leaders under another's name after an alias repoint or a cross-db rename. Eviction is by
 	// collection id only -- the cache deliberately does not depend on the mutable
 	// collection->database mapping. See issue #51533.
-	collLeader map[int64]*shardLeaders // collectionID -> collection_leaders
+	collLeader   map[int64]*shardLeaders // collectionID -> collection_leaders
+	sfShardCache conc.Singleflight[*shardLeaders]
+	refreshSeq   uint64
+	refreshes    map[shardCacheRefreshKey]*shardCacheRefreshToken
+
+	shardCacheRefreshTimeout time.Duration
+	shardCacheTTL            time.Duration
+
+	testHookAfterShardCacheDoChan       func()
+	testHookListShardLocationReadLocked func()
+	testHookBeforeShardLocationDelete   func()
 }
+
+type (
+	shardCacheRefreshKey struct {
+		collectionID int64
+		force        bool
+	}
+	shardCacheRefreshToken struct {
+		id uint64
+	}
+	shardCacheEntryRef struct {
+		collectionID int64
+		leaders      *shardLeaders
+	}
+)
 
 const (
 	defaultPurgeInterval   = 600 * time.Second
 	defaultExpiredDuration = 60 * time.Minute
+
+	defaultShardCacheRefreshTimeout = 10 * time.Second
+	defaultShardCacheTTL            = defaultPurgeInterval
 )
 
 // SessionOpt provides a way to set params in ShardClientMgr
@@ -97,7 +125,11 @@ func NewShardClientMgr(mixCoord types.MixCoordClient, options ...shardClientMgrO
 		expiredDuration: defaultExpiredDuration,
 
 		collLeader: make(map[int64]*shardLeaders),
+		refreshes:  make(map[shardCacheRefreshKey]*shardCacheRefreshToken),
 		mixCoord:   mixCoord,
+
+		shardCacheRefreshTimeout: defaultShardCacheRefreshTimeout,
+		shardCacheTTL:            defaultShardCacheTTL,
 	}
 	for _, opt := range options {
 		opt(s)
@@ -111,41 +143,31 @@ func (c *shardClientMgrImpl) SetClientCreatorFunc(creator queryNodeCreatorFunc) 
 }
 
 func (m *shardClientMgrImpl) GetShard(ctx context.Context, withCache bool, database, collectionName string, collectionID int64, channel string) ([]NodeInfo, error) {
-	method := "GetShard"
-	// check cache first
-	cacheShardLeaders := m.getCachedShardLeaders(collectionID, method)
-	if cacheShardLeaders == nil || !withCache {
-		// refresh shard leader cache
-		newShardLeaders, err := m.updateShardLocationCache(ctx, database, collectionName, collectionID)
-		if err != nil {
-			return nil, err
-		}
-		cacheShardLeaders = newShardLeaders
+	shardLeaders, err := m.getShardLeaders(ctx, withCache, database, collectionName, collectionID, "GetShard")
+	if err != nil {
+		return nil, err
 	}
 
-	return cacheShardLeaders.Get(channel), nil
+	return shardLeaders.Get(channel), nil
 }
 
 func (m *shardClientMgrImpl) GetShardLeaderList(ctx context.Context, database, collectionName string, collectionID int64, withCache bool) ([]string, error) {
-	method := "GetShardLeaderList"
-	// check cache first
-	cacheShardLeaders := m.getCachedShardLeaders(collectionID, method)
-	if cacheShardLeaders == nil || !withCache {
-		// refresh shard leader cache
-		newShardLeaders, err := m.updateShardLocationCache(ctx, database, collectionName, collectionID)
-		if err != nil {
-			return nil, err
-		}
-		cacheShardLeaders = newShardLeaders
+	shardLeaders, err := m.getShardLeaders(ctx, withCache, database, collectionName, collectionID, "GetShardLeaderList")
+	if err != nil {
+		return nil, err
 	}
 
-	return cacheShardLeaders.GetShardLeaderList(), nil
+	return shardLeaders.GetShardLeaderList(), nil
+}
+
+func (m *shardClientMgrImpl) loadCachedShardLeaders(collectionID int64) *shardLeaders {
+	m.leaderMut.RLock()
+	defer m.leaderMut.RUnlock()
+	return m.collLeader[collectionID]
 }
 
 func (m *shardClientMgrImpl) getCachedShardLeaders(collectionID int64, caller string) *shardLeaders {
-	m.leaderMut.RLock()
-	cacheShardLeaders := m.collLeader[collectionID]
-	m.leaderMut.RUnlock()
+	cacheShardLeaders := m.loadCachedShardLeaders(collectionID)
 
 	if cacheShardLeaders != nil {
 		metrics.ProxyCacheStatsCounter.WithLabelValues(paramtable.GetStringNodeID(), caller, metrics.CacheHitLabel).Inc()
@@ -156,7 +178,89 @@ func (m *shardClientMgrImpl) getCachedShardLeaders(collectionID int64, caller st
 	return cacheShardLeaders
 }
 
-func (m *shardClientMgrImpl) updateShardLocationCache(ctx context.Context, database, collectionName string, collectionID int64) (*shardLeaders, error) {
+func (m *shardClientMgrImpl) acquireShardCacheRefresh(key shardCacheRefreshKey) *shardCacheRefreshToken {
+	m.leaderMut.Lock()
+	defer m.leaderMut.Unlock()
+
+	if refresh := m.refreshes[key]; refresh != nil {
+		return refresh
+	}
+	if m.refreshes == nil {
+		m.refreshes = make(map[shardCacheRefreshKey]*shardCacheRefreshToken)
+	}
+	m.refreshSeq++
+	refresh := &shardCacheRefreshToken{id: m.refreshSeq}
+	m.refreshes[key] = refresh
+	return refresh
+}
+
+func (m *shardClientMgrImpl) finishShardCacheRefresh(key shardCacheRefreshKey, refresh *shardCacheRefreshToken) {
+	m.leaderMut.Lock()
+	defer m.leaderMut.Unlock()
+	if m.refreshes[key] == refresh {
+		delete(m.refreshes, key)
+	}
+}
+
+func (m *shardClientMgrImpl) getShardLeaders(
+	ctx context.Context,
+	withCache bool,
+	database string,
+	collectionName string,
+	collectionID int64,
+	caller string,
+) (*shardLeaders, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	cacheShardLeaders := m.getCachedShardLeaders(collectionID, caller)
+	if cacheShardLeaders != nil && withCache {
+		cacheShardLeaders.touch(time.Now())
+		return cacheShardLeaders, nil
+	}
+
+	refreshKey := shardCacheRefreshKey{collectionID: collectionID, force: !withCache}
+	refresh := m.acquireShardCacheRefresh(refreshKey)
+	singleflightKey := fmt.Sprintf("%d/%t/%d", collectionID, refreshKey.force, refresh.id)
+	resultCh := m.sfShardCache.DoChanRaw(singleflightKey, func() (*shardLeaders, error) {
+		defer m.finishShardCacheRefresh(refreshKey, refresh)
+		if withCache {
+			if cached := m.loadCachedShardLeaders(collectionID); cached != nil {
+				cached.touch(time.Now())
+				return cached, nil
+			}
+		}
+
+		refreshTimeout := m.shardCacheRefreshTimeout
+		if refreshTimeout <= 0 {
+			refreshTimeout = defaultShardCacheRefreshTimeout
+		}
+		refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
+		defer cancel()
+		return m.updateShardLocationCache(refreshCtx, database, collectionName, collectionID, refreshKey, refresh)
+	})
+	if m.testHookAfterShardCacheDoChan != nil {
+		m.testHookAfterShardCacheDoChan()
+	}
+
+	select {
+	case result := <-resultCh:
+		leaders, err, _ := conc.UnwrapSingleflightRawResult[*shardLeaders](result)
+		return leaders, err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (m *shardClientMgrImpl) updateShardLocationCache(
+	ctx context.Context,
+	database string,
+	collectionName string,
+	collectionID int64,
+	refreshKey shardCacheRefreshKey,
+	refresh *shardCacheRefreshToken,
+) (*shardLeaders, error) {
 	log := mlog.With(
 		mlog.String("db", database),
 		mlog.FieldCollectionName(collectionName),
@@ -203,12 +307,25 @@ func (m *shardClientMgrImpl) updateShardLocationCache(ctx context.Context, datab
 		shardLeaders: shards,
 		idx:          atomic.NewInt64(0),
 	}
+	newShardLeaders.touch(time.Now())
 
-	m.leaderMut.Lock()
-	m.collLeader[collectionID] = newShardLeaders
-	m.leaderMut.Unlock()
+	m.cacheShardLeaders(collectionID, refreshKey, refresh, newShardLeaders)
 
 	return newShardLeaders, nil
+}
+
+func (m *shardClientMgrImpl) cacheShardLeaders(
+	collectionID int64,
+	refreshKey shardCacheRefreshKey,
+	refresh *shardCacheRefreshToken,
+	leaders *shardLeaders,
+) {
+	m.leaderMut.Lock()
+	defer m.leaderMut.Unlock()
+	if m.refreshes[refreshKey] != refresh {
+		return
+	}
+	m.collLeader[collectionID] = leaders
 }
 
 func parseShardLeaderList2QueryNode(shardsLeaders []*querypb.ShardLeadersList) map[string][]NodeInfo {
@@ -229,12 +346,50 @@ func parseShardLeaderList2QueryNode(shardsLeaders []*querypb.ShardLeadersList) m
 
 // used for Garbage collection shard client
 func (m *shardClientMgrImpl) ListShardLocation() map[int64]NodeInfo {
-	m.leaderMut.RLock()
-	defer m.leaderMut.RUnlock()
 	shardLeaderInfo := make(map[int64]NodeInfo)
+	ttl := m.shardCacheTTL
+	if ttl <= 0 {
+		ttl = defaultShardCacheTTL
+	}
+	cutoff := time.Now().Add(-ttl)
+	expired := make([]shardCacheEntryRef, 0)
 
-	for _, shardLeaders := range m.collLeader {
-		for _, nodeInfos := range shardLeaders.shardLeaders {
+	m.leaderMut.RLock()
+	if m.testHookListShardLocationReadLocked != nil {
+		m.testHookListShardLocationReadLocked()
+	}
+	for collectionID, leaders := range m.collLeader {
+		if leaders.idleBefore(cutoff) {
+			expired = append(expired, shardCacheEntryRef{collectionID: collectionID, leaders: leaders})
+			continue
+		}
+		for _, nodeInfos := range leaders.shardLeaders {
+			for _, node := range nodeInfos {
+				shardLeaderInfo[node.NodeID] = node
+			}
+		}
+	}
+	m.leaderMut.RUnlock()
+
+	if len(expired) == 0 {
+		return shardLeaderInfo
+	}
+	if m.testHookBeforeShardLocationDelete != nil {
+		m.testHookBeforeShardLocationDelete()
+	}
+
+	m.leaderMut.Lock()
+	defer m.leaderMut.Unlock()
+	for _, candidate := range expired {
+		leaders := m.collLeader[candidate.collectionID]
+		if leaders == nil {
+			continue
+		}
+		if leaders == candidate.leaders && leaders.idleBefore(cutoff) {
+			delete(m.collLeader, candidate.collectionID)
+			continue
+		}
+		for _, nodeInfos := range leaders.shardLeaders {
 			for _, node := range nodeInfos {
 				shardLeaderInfo[node.NodeID] = node
 			}
@@ -261,6 +416,8 @@ func (m *shardClientMgrImpl) InvalidateShardLeaderCache(collections []int64) {
 	defer m.leaderMut.Unlock()
 	for _, collectionID := range collections {
 		delete(m.collLeader, collectionID)
+		delete(m.refreshes, shardCacheRefreshKey{collectionID: collectionID})
+		delete(m.refreshes, shardCacheRefreshKey{collectionID: collectionID, force: true})
 	}
 }
 

--- a/internal/proxy/shardclient/manager.go
+++ b/internal/proxy/shardclient/manager.go
@@ -73,6 +73,8 @@ type shardClientMgrImpl struct {
 	sfShardCache conc.Singleflight[*shardLeaders]
 	refreshSeq   uint64
 	refreshes    map[shardCacheRefreshKey]*shardCacheRefreshToken
+	// refreshWriteSeq fences cache publication across normal and forced refresh flights.
+	refreshWriteSeq map[int64]uint64
 
 	shardCacheRefreshTimeout time.Duration
 	shardCacheTTL            time.Duration
@@ -124,9 +126,10 @@ func NewShardClientMgr(mixCoord types.MixCoordClient, options ...shardClientMgrO
 		purgeInterval:   defaultPurgeInterval,
 		expiredDuration: defaultExpiredDuration,
 
-		collLeader: make(map[int64]*shardLeaders),
-		refreshes:  make(map[shardCacheRefreshKey]*shardCacheRefreshToken),
-		mixCoord:   mixCoord,
+		collLeader:      make(map[int64]*shardLeaders),
+		refreshes:       make(map[shardCacheRefreshKey]*shardCacheRefreshToken),
+		refreshWriteSeq: make(map[int64]uint64),
+		mixCoord:        mixCoord,
 
 		shardCacheRefreshTimeout: defaultShardCacheRefreshTimeout,
 		shardCacheTTL:            defaultShardCacheTTL,
@@ -188,9 +191,13 @@ func (m *shardClientMgrImpl) acquireShardCacheRefresh(key shardCacheRefreshKey) 
 	if m.refreshes == nil {
 		m.refreshes = make(map[shardCacheRefreshKey]*shardCacheRefreshToken)
 	}
+	if m.refreshWriteSeq == nil {
+		m.refreshWriteSeq = make(map[int64]uint64)
+	}
 	m.refreshSeq++
 	refresh := &shardCacheRefreshToken{id: m.refreshSeq}
 	m.refreshes[key] = refresh
+	m.refreshWriteSeq[key.collectionID] = refresh.id
 	return refresh
 }
 
@@ -199,6 +206,9 @@ func (m *shardClientMgrImpl) finishShardCacheRefresh(key shardCacheRefreshKey, r
 	defer m.leaderMut.Unlock()
 	if m.refreshes[key] == refresh {
 		delete(m.refreshes, key)
+	}
+	if m.refreshWriteSeq[key.collectionID] == refresh.id {
+		delete(m.refreshWriteSeq, key.collectionID)
 	}
 }
 
@@ -322,7 +332,7 @@ func (m *shardClientMgrImpl) cacheShardLeaders(
 ) {
 	m.leaderMut.Lock()
 	defer m.leaderMut.Unlock()
-	if m.refreshes[refreshKey] != refresh {
+	if m.refreshes[refreshKey] != refresh || m.refreshWriteSeq[collectionID] != refresh.id {
 		return
 	}
 	m.collLeader[collectionID] = leaders
@@ -418,6 +428,7 @@ func (m *shardClientMgrImpl) InvalidateShardLeaderCache(collections []int64) {
 		delete(m.collLeader, collectionID)
 		delete(m.refreshes, shardCacheRefreshKey{collectionID: collectionID})
 		delete(m.refreshes, shardCacheRefreshKey{collectionID: collectionID, force: true})
+		delete(m.refreshWriteSeq, collectionID)
 	}
 }
 

--- a/internal/proxy/shardclient/manager_lifecycle_test.go
+++ b/internal/proxy/shardclient/manager_lifecycle_test.go
@@ -167,6 +167,83 @@ func TestShardCacheCoalescesConcurrentRefreshPerCollectionID(t *testing.T) {
 	assert.Equal(t, int32(1), coordCalls.Load())
 }
 
+func TestShardCacheNewerForcedRefreshWinsWriteRace(t *testing.T) {
+	const (
+		channel      = "test_channel"
+		collectionID = int64(200)
+	)
+
+	normalStarted := make(chan struct{})
+	forcedStarted := make(chan struct{})
+	releaseNormal := make(chan struct{})
+	releaseForced := make(chan struct{})
+	var releaseNormalOnce sync.Once
+	var releaseForcedOnce sync.Once
+	defer releaseNormalOnce.Do(func() { close(releaseNormal) })
+	defer releaseForcedOnce.Do(func() { close(releaseForced) })
+
+	coordCalls := atomic.NewInt32(0)
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	mixCoord.EXPECT().GetShardLeaders(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ *querypb.GetShardLeadersRequest, _ ...grpc.CallOption) (*querypb.GetShardLeadersResponse, error) {
+			switch coordCalls.Inc() {
+			case 1:
+				close(normalStarted)
+				<-releaseNormal
+				return singleShardResp(channel, collectionID, "old:19530"), nil
+			case 2:
+				close(forcedStarted)
+				<-releaseForced
+				return singleShardResp(channel, collectionID, "new:19530"), nil
+			default:
+				return nil, fmt.Errorf("unexpected extra GetShardLeaders call")
+			}
+		}).Twice()
+
+	type shardResult struct {
+		nodes []NodeInfo
+		err   error
+	}
+	mgr := NewShardClientMgr(mixCoord)
+	normalDone := make(chan shardResult, 1)
+	go func() {
+		nodes, err := mgr.GetShard(context.Background(), true, "db", "alias", collectionID, channel)
+		normalDone <- shardResult{nodes: nodes, err: err}
+	}()
+	<-normalStarted
+
+	forcedDone := make(chan shardResult, 1)
+	go func() {
+		nodes, err := mgr.GetShard(context.Background(), false, "db", "alias", collectionID, channel)
+		forcedDone <- shardResult{nodes: nodes, err: err}
+	}()
+	<-forcedStarted
+
+	releaseForcedOnce.Do(func() { close(releaseForced) })
+	forcedResult := <-forcedDone
+	assert.NoError(t, forcedResult.err)
+	if assert.Len(t, forcedResult.nodes, 1) {
+		assert.Equal(t, "new:19530", forcedResult.nodes[0].Address)
+	}
+
+	releaseNormalOnce.Do(func() { close(releaseNormal) })
+	normalResult := <-normalDone
+	assert.NoError(t, normalResult.err)
+	if assert.Len(t, normalResult.nodes, 1) {
+		assert.Equal(t, "old:19530", normalResult.nodes[0].Address)
+	}
+
+	cached := mgr.loadCachedShardLeaders(collectionID)
+	if assert.NotNil(t, cached) {
+		assert.Equal(t, "new:19530", cached.Get(channel)[0].Address)
+	}
+	assert.Equal(t, int32(2), coordCalls.Load())
+	mgr.leaderMut.RLock()
+	assert.Empty(t, mgr.refreshes)
+	assert.Empty(t, mgr.refreshWriteSeq)
+	mgr.leaderMut.RUnlock()
+}
+
 func TestShardCacheLeaderCancellationDoesNotCancelSharedRefresh(t *testing.T) {
 	const (
 		channel      = "test_channel"
@@ -330,6 +407,8 @@ func TestInvalidateShardLeaderCacheRevokesRefreshTokensByID(t *testing.T) {
 	assert.NotContains(t, mgr.refreshes, shardCacheRefreshKey{collectionID: 100})
 	assert.NotContains(t, mgr.refreshes, shardCacheRefreshKey{collectionID: 100, force: true})
 	assert.Contains(t, mgr.refreshes, shardCacheRefreshKey{collectionID: 200})
+	assert.NotContains(t, mgr.refreshWriteSeq, int64(100))
+	assert.Contains(t, mgr.refreshWriteSeq, int64(200))
 }
 
 func TestListShardLocationDropsIdleEntries(t *testing.T) {

--- a/internal/proxy/shardclient/manager_lifecycle_test.go
+++ b/internal/proxy/shardclient/manager_lifecycle_test.go
@@ -167,6 +167,83 @@ func TestShardCacheCoalescesConcurrentRefreshPerCollectionID(t *testing.T) {
 	assert.Equal(t, int32(1), coordCalls.Load())
 }
 
+func TestShardCacheNewerForcedRefreshWinsWriteRace(t *testing.T) {
+	const (
+		channel      = "test_channel"
+		collectionID = int64(200)
+	)
+
+	normalStarted := make(chan struct{})
+	forcedStarted := make(chan struct{})
+	releaseNormal := make(chan struct{})
+	releaseForced := make(chan struct{})
+	var releaseNormalOnce sync.Once
+	var releaseForcedOnce sync.Once
+	defer releaseNormalOnce.Do(func() { close(releaseNormal) })
+	defer releaseForcedOnce.Do(func() { close(releaseForced) })
+
+	coordCalls := atomic.NewInt32(0)
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	mixCoord.EXPECT().GetShardLeaders(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ *querypb.GetShardLeadersRequest, _ ...grpc.CallOption) (*querypb.GetShardLeadersResponse, error) {
+			switch coordCalls.Inc() {
+			case 1:
+				close(normalStarted)
+				<-releaseNormal
+				return singleShardResp(channel, collectionID, "old:19530"), nil
+			case 2:
+				close(forcedStarted)
+				<-releaseForced
+				return singleShardResp(channel, collectionID, "new:19530"), nil
+			default:
+				return nil, fmt.Errorf("unexpected extra GetShardLeaders call")
+			}
+		}).Twice()
+
+	type shardResult struct {
+		nodes []NodeInfo
+		err   error
+	}
+	mgr := NewShardClientMgr(mixCoord)
+	normalDone := make(chan shardResult, 1)
+	go func() {
+		nodes, err := mgr.GetShard(context.Background(), true, "db", "alias", collectionID, channel)
+		normalDone <- shardResult{nodes: nodes, err: err}
+	}()
+	<-normalStarted
+
+	forcedDone := make(chan shardResult, 1)
+	go func() {
+		nodes, err := mgr.GetShard(context.Background(), false, "db", "alias", collectionID, channel)
+		forcedDone <- shardResult{nodes: nodes, err: err}
+	}()
+	<-forcedStarted
+
+	releaseForcedOnce.Do(func() { close(releaseForced) })
+	forcedResult := <-forcedDone
+	assert.NoError(t, forcedResult.err)
+	if assert.Len(t, forcedResult.nodes, 1) {
+		assert.Equal(t, "new:19530", forcedResult.nodes[0].Address)
+	}
+
+	releaseNormalOnce.Do(func() { close(releaseNormal) })
+	normalResult := <-normalDone
+	assert.NoError(t, normalResult.err)
+	if assert.Len(t, normalResult.nodes, 1) {
+		assert.Equal(t, "old:19530", normalResult.nodes[0].Address)
+	}
+
+	cached := mgr.loadCachedShardLeaders(collectionID)
+	if assert.NotNil(t, cached) {
+		assert.Equal(t, "new:19530", cached.Get(channel)[0].Address)
+	}
+	assert.Equal(t, int32(2), coordCalls.Load())
+	mgr.leaderMut.RLock()
+	assert.Empty(t, mgr.refreshes)
+	assert.Empty(t, mgr.refreshWriteSeq)
+	mgr.leaderMut.RUnlock()
+}
+
 func TestShardCacheLeaderCancellationDoesNotCancelSharedRefresh(t *testing.T) {
 	const (
 		channel      = "test_channel"
@@ -317,7 +394,7 @@ func TestShardCacheInvalidationFencesInFlightRefresh(t *testing.T) {
 
 func TestInvalidateShardLeaderCacheRevokesRefreshTokensByID(t *testing.T) {
 	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
-	mgr.collLeader[100] = &shardLeaders{}
+	mgr.collLeader.Insert(100, &shardLeaders{})
 	mgr.acquireShardCacheRefresh(shardCacheRefreshKey{collectionID: 100})
 	mgr.acquireShardCacheRefresh(shardCacheRefreshKey{collectionID: 100, force: true})
 	mgr.acquireShardCacheRefresh(shardCacheRefreshKey{collectionID: 200})
@@ -326,10 +403,12 @@ func TestInvalidateShardLeaderCacheRevokesRefreshTokensByID(t *testing.T) {
 
 	mgr.leaderMut.RLock()
 	defer mgr.leaderMut.RUnlock()
-	assert.NotContains(t, mgr.collLeader, int64(100))
+	assert.False(t, mgr.collLeader.Contain(100))
 	assert.NotContains(t, mgr.refreshes, shardCacheRefreshKey{collectionID: 100})
 	assert.NotContains(t, mgr.refreshes, shardCacheRefreshKey{collectionID: 100, force: true})
 	assert.Contains(t, mgr.refreshes, shardCacheRefreshKey{collectionID: 200})
+	assert.NotContains(t, mgr.refreshWriteSeq, int64(100))
+	assert.Contains(t, mgr.refreshWriteSeq, int64(200))
 }
 
 func TestListShardLocationDropsIdleEntries(t *testing.T) {
@@ -348,14 +427,14 @@ func TestListShardLocationDropsIdleEntries(t *testing.T) {
 
 	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
 	mgr.shardCacheTTL = time.Minute
-	mgr.collLeader[100] = oldLeaders
-	mgr.collLeader[200] = newLeaders
+	mgr.collLeader.Insert(100, oldLeaders)
+	mgr.collLeader.Insert(200, newLeaders)
 
 	locations := mgr.ListShardLocation()
 	assert.NotContains(t, locations, int64(1))
 	assert.Contains(t, locations, int64(2))
-	assert.NotContains(t, mgr.collLeader, int64(100))
-	assert.Contains(t, mgr.collLeader, int64(200))
+	assert.False(t, mgr.collLeader.Contain(100))
+	assert.True(t, mgr.collLeader.Contain(200))
 }
 
 func TestListShardLocationAllowsConcurrentCacheHits(t *testing.T) {
@@ -368,13 +447,13 @@ func TestListShardLocationAllowsConcurrentCacheHits(t *testing.T) {
 	leaders.touch(time.Now())
 
 	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
-	mgr.collLeader[collectionID] = leaders
-	readLocked := make(chan struct{})
+	mgr.collLeader.Insert(collectionID, leaders)
+	scanStarted := make(chan struct{})
 	releaseScan := make(chan struct{})
 	var releaseOnce sync.Once
 	defer releaseOnce.Do(func() { close(releaseScan) })
-	mgr.testHookListShardLocationReadLocked = func() {
-		close(readLocked)
+	mgr.testHookListShardLocationScan = func() {
+		close(scanStarted)
 		<-releaseScan
 	}
 
@@ -383,7 +462,7 @@ func TestListShardLocationAllowsConcurrentCacheHits(t *testing.T) {
 		defer close(listDone)
 		mgr.ListShardLocation()
 	}()
-	<-readLocked
+	<-scanStarted
 
 	hitDone := make(chan error, 1)
 	go func() {
@@ -401,6 +480,107 @@ func TestListShardLocationAllowsConcurrentCacheHits(t *testing.T) {
 	<-listDone
 }
 
+func TestListShardLocationScanDoesNotBlockInvalidation(t *testing.T) {
+	leaders100 := &shardLeaders{
+		idx:          atomic.NewInt64(0),
+		collectionID: 100,
+		shardLeaders: map[string][]NodeInfo{"channel-100": {{NodeID: 1, Address: "node-1:19530", Serviceable: true}}},
+	}
+	leaders200 := &shardLeaders{
+		idx:          atomic.NewInt64(0),
+		collectionID: 200,
+		shardLeaders: map[string][]NodeInfo{"channel-200": {{NodeID: 2, Address: "node-2:19530", Serviceable: true}}},
+	}
+	leaders100.touch(time.Now())
+	leaders200.touch(time.Now())
+
+	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
+	mgr.collLeader.Insert(100, leaders100)
+	mgr.collLeader.Insert(200, leaders200)
+	scanStarted := make(chan struct{})
+	releaseScan := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseScan) })
+	mgr.testHookListShardLocationScan = func() {
+		close(scanStarted)
+		<-releaseScan
+	}
+
+	listDone := make(chan struct{})
+	go func() {
+		defer close(listDone)
+		mgr.ListShardLocation()
+	}()
+	<-scanStarted
+
+	invalidationDone := make(chan struct{})
+	go func() {
+		defer close(invalidationDone)
+		mgr.InvalidateShardLeaderCache([]int64{100})
+	}()
+	select {
+	case <-invalidationDone:
+	case <-time.After(time.Second):
+		t.Fatal("shard cache scan blocked an unrelated invalidation")
+	}
+
+	hitDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetShard(context.Background(), true, "db", "name", 200, "channel-200")
+		hitDone <- err
+	}()
+	select {
+	case err := <-hitDone:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("cache hit was blocked while the shard cache scan was paused")
+	}
+
+	releaseOnce.Do(func() { close(releaseScan) })
+	<-listDone
+}
+
+func TestShardCacheHitTouchesBeforeIdleDelete(t *testing.T) {
+	const collectionID = int64(200)
+	leaders := &shardLeaders{
+		idx:          atomic.NewInt64(0),
+		collectionID: collectionID,
+		shardLeaders: map[string][]NodeInfo{"channel": {{NodeID: 1, Address: "node:19530", Serviceable: true}}},
+	}
+	leaders.touch(time.Now().Add(-2 * time.Minute))
+
+	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
+	mgr.shardCacheTTL = time.Minute
+	mgr.collLeader.Insert(collectionID, leaders)
+	cacheLoaded := make(chan struct{})
+	releaseHit := make(chan struct{})
+	var releaseHitOnce sync.Once
+	defer releaseHitOnce.Do(func() { close(releaseHit) })
+	mgr.testHookAfterShardCacheLoad = func() {
+		close(cacheLoaded)
+		<-releaseHit
+	}
+
+	hitDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetShard(context.Background(), true, "db", "name", collectionID, "channel")
+		hitDone <- err
+	}()
+	<-cacheLoaded
+
+	beforeDelete := make(chan struct{})
+	mgr.testHookBeforeShardLocationDelete = func() { close(beforeDelete) }
+	locationsDone := make(chan map[int64]NodeInfo, 1)
+	go func() { locationsDone <- mgr.ListShardLocation() }()
+	<-beforeDelete
+
+	releaseHitOnce.Do(func() { close(releaseHit) })
+	assert.NoError(t, <-hitDone)
+	locations := <-locationsDone
+	assert.Contains(t, locations, int64(1))
+	assert.Same(t, leaders, mgr.loadCachedShardLeaders(collectionID))
+}
+
 func TestListShardLocationRechecksExpiredCandidateBeforeDelete(t *testing.T) {
 	const collectionID = int64(200)
 	leaders := &shardLeaders{
@@ -412,7 +592,7 @@ func TestListShardLocationRechecksExpiredCandidateBeforeDelete(t *testing.T) {
 
 	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
 	mgr.shardCacheTTL = time.Minute
-	mgr.collLeader[collectionID] = leaders
+	mgr.collLeader.Insert(collectionID, leaders)
 	beforeDelete := make(chan struct{})
 	resumeDelete := make(chan struct{})
 	var resumeOnce sync.Once

--- a/internal/proxy/shardclient/manager_lifecycle_test.go
+++ b/internal/proxy/shardclient/manager_lifecycle_test.go
@@ -1,0 +1,436 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+)
+
+func blockingShardLeaderRefresh(
+	t *testing.T,
+	channel string,
+	collectionID int64,
+) (types.MixCoordClient, <-chan struct{}, func(), *atomic.Int32) {
+	rpcStarted := make(chan struct{})
+	releaseRPC := make(chan struct{})
+	var releaseOnce sync.Once
+	coordCalls := atomic.NewInt32(0)
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	mixCoord.EXPECT().GetShardLeaders(mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, _ *querypb.GetShardLeadersRequest, _ ...grpc.CallOption) (*querypb.GetShardLeadersResponse, error) {
+			coordCalls.Inc()
+			close(rpcStarted)
+			select {
+			case <-releaseRPC:
+				return singleShardResp(channel, collectionID, "new:19530"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}).Once()
+
+	release := func() {
+		releaseOnce.Do(func() { close(releaseRPC) })
+	}
+	return mixCoord, rpcStarted, release, coordCalls
+}
+
+func TestShardCacheDoesNotPingPongBetweenAliasCollectionIDs(t *testing.T) {
+	const (
+		database        = "test_db"
+		alias           = "test_alias"
+		channel         = "test_channel"
+		oldCollectionID = int64(100)
+		newCollectionID = int64(200)
+	)
+
+	coordCalls := atomic.NewInt32(0)
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	mixCoord.EXPECT().GetShardLeaders(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, req *querypb.GetShardLeadersRequest, _ ...grpc.CallOption) (*querypb.GetShardLeadersResponse, error) {
+			coordCalls.Inc()
+			collectionID := req.GetCollectionID()
+			return singleShardResp(channel, collectionID, fmt.Sprintf("node-%d:19530", collectionID)), nil
+		}).Maybe()
+
+	mgr := NewShardClientMgr(mixCoord)
+	for i := 0; i < 10; i++ {
+		for _, collectionID := range []int64{oldCollectionID, newCollectionID} {
+			nodes, err := mgr.GetShard(context.Background(), true, database, alias, collectionID, channel)
+			assert.NoError(t, err)
+			if assert.Len(t, nodes, 1) {
+				assert.Equal(t, collectionID, nodes[0].NodeID)
+			}
+		}
+	}
+
+	assert.Equal(t, int32(2), coordCalls.Load())
+}
+
+func TestShardCacheRefreshKeyIgnoresMutableDatabaseAndName(t *testing.T) {
+	const (
+		channel      = "test_channel"
+		collectionID = int64(200)
+	)
+
+	mixCoord, rpcStarted, releaseRPC, coordCalls := blockingShardLeaderRefresh(t, channel, collectionID)
+	mgr := NewShardClientMgr(mixCoord)
+	joined := make(chan struct{}, 2)
+	mgr.testHookAfterShardCacheDoChan = func() { joined <- struct{}{} }
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetShard(context.Background(), true, "db_before", "name_before", collectionID, channel)
+		firstDone <- err
+	}()
+	<-rpcStarted
+	<-joined
+
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetShard(context.Background(), true, "db_after", "name_after", collectionID, channel)
+		secondDone <- err
+	}()
+	<-joined
+	releaseRPC()
+
+	assert.NoError(t, <-firstDone)
+	assert.NoError(t, <-secondDone)
+	assert.Equal(t, int32(1), coordCalls.Load(), "database/name changes must not split a collection-ID refresh")
+}
+
+func TestShardCacheCoalescesConcurrentRefreshPerCollectionID(t *testing.T) {
+	const (
+		channel      = "test_channel"
+		collectionID = int64(200)
+		workers      = 32
+	)
+
+	rpcStarted := make(chan struct{})
+	releaseRPC := make(chan struct{})
+	coordCalls := atomic.NewInt32(0)
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	mixCoord.EXPECT().GetShardLeaders(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ *querypb.GetShardLeadersRequest, _ ...grpc.CallOption) (*querypb.GetShardLeadersResponse, error) {
+			coordCalls.Inc()
+			close(rpcStarted)
+			<-releaseRPC
+			return singleShardResp(channel, collectionID, "new:19530"), nil
+		}).Once()
+
+	mgr := NewShardClientMgr(mixCoord)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			nodes, err := mgr.GetShard(context.Background(), true, "db", "alias", collectionID, channel)
+			assert.NoError(t, err)
+			if assert.Len(t, nodes, 1) {
+				assert.Equal(t, collectionID, nodes[0].NodeID)
+			}
+		}()
+	}
+
+	close(start)
+	<-rpcStarted
+	close(releaseRPC)
+	wg.Wait()
+	assert.Equal(t, int32(1), coordCalls.Load())
+}
+
+func TestShardCacheLeaderCancellationDoesNotCancelSharedRefresh(t *testing.T) {
+	const (
+		channel      = "test_channel"
+		collectionID = int64(200)
+	)
+
+	mixCoord, rpcStarted, releaseRPC, coordCalls := blockingShardLeaderRefresh(t, channel, collectionID)
+	mgr := NewShardClientMgr(mixCoord)
+	joined := make(chan struct{}, 2)
+	mgr.testHookAfterShardCacheDoChan = func() { joined <- struct{}{} }
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetShard(leaderCtx, true, "db", "alias", collectionID, channel)
+		leaderDone <- err
+	}()
+	<-rpcStarted
+	<-joined
+
+	waiterDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetShard(context.Background(), true, "db", "alias", collectionID, channel)
+		waiterDone <- err
+	}()
+	<-joined
+
+	started := time.Now()
+	cancelLeader()
+	assert.ErrorIs(t, <-leaderDone, context.Canceled)
+	assert.Less(t, time.Since(started), 200*time.Millisecond)
+
+	select {
+	case err := <-waiterDone:
+		t.Fatalf("shared refresh ended after leader cancellation: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	releaseRPC()
+	assert.NoError(t, <-waiterDone)
+	assert.Equal(t, int32(1), coordCalls.Load())
+}
+
+func TestShardCacheWaiterHonorsOwnDeadline(t *testing.T) {
+	const (
+		channel      = "test_channel"
+		collectionID = int64(200)
+	)
+
+	mixCoord, rpcStarted, releaseRPC, coordCalls := blockingShardLeaderRefresh(t, channel, collectionID)
+	mgr := NewShardClientMgr(mixCoord)
+	leaderDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetShard(context.Background(), true, "db", "alias", collectionID, channel)
+		leaderDone <- err
+	}()
+	<-rpcStarted
+
+	waiterCtx, cancelWaiter := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelWaiter()
+	started := time.Now()
+	_, waiterErr := mgr.GetShard(waiterCtx, true, "db", "alias", collectionID, channel)
+	assert.ErrorIs(t, waiterErr, context.DeadlineExceeded)
+	assert.Less(t, time.Since(started), 200*time.Millisecond)
+
+	releaseRPC()
+	assert.NoError(t, <-leaderDone)
+	assert.Equal(t, int32(1), coordCalls.Load())
+}
+
+func TestShardCacheSharedRefreshHasTimeout(t *testing.T) {
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	mixCoord.EXPECT().GetShardLeaders(mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, _ *querypb.GetShardLeadersRequest, _ ...grpc.CallOption) (*querypb.GetShardLeadersResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Once()
+
+	mgr := NewShardClientMgr(mixCoord)
+	mgr.shardCacheRefreshTimeout = 50 * time.Millisecond
+	started := time.Now()
+	_, err := mgr.GetShard(context.Background(), true, "db", "alias", 200, "channel")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(started), 200*time.Millisecond)
+}
+
+func TestShardCacheInvalidationFencesInFlightRefresh(t *testing.T) {
+	const (
+		channel      = "test_channel"
+		collectionID = int64(200)
+	)
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseFirst) })
+
+	coordCalls := atomic.NewInt32(0)
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	mixCoord.EXPECT().GetShardLeaders(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ *querypb.GetShardLeadersRequest, _ ...grpc.CallOption) (*querypb.GetShardLeadersResponse, error) {
+			switch coordCalls.Inc() {
+			case 1:
+				close(firstStarted)
+				<-releaseFirst
+				return singleShardResp(channel, collectionID, "old:19530"), nil
+			case 2:
+				close(secondStarted)
+				return singleShardResp(channel, collectionID, "new:19530"), nil
+			default:
+				return nil, fmt.Errorf("unexpected extra GetShardLeaders call")
+			}
+		}).Twice()
+
+	mgr := NewShardClientMgr(mixCoord)
+	firstDone := make(chan []NodeInfo, 1)
+	go func() {
+		nodes, err := mgr.GetShard(context.Background(), true, "db", "alias", collectionID, channel)
+		assert.NoError(t, err)
+		firstDone <- nodes
+	}()
+	<-firstStarted
+
+	mgr.InvalidateShardLeaderCache([]int64{collectionID})
+	secondDone := make(chan []NodeInfo, 1)
+	go func() {
+		nodes, err := mgr.GetShard(context.Background(), true, "db", "alias", collectionID, channel)
+		assert.NoError(t, err)
+		secondDone <- nodes
+	}()
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("post-invalidation request joined the pre-invalidation refresh")
+	}
+	assert.Equal(t, "new:19530", (<-secondDone)[0].Address)
+
+	releaseOnce.Do(func() { close(releaseFirst) })
+	assert.Equal(t, "old:19530", (<-firstDone)[0].Address)
+	cached := mgr.loadCachedShardLeaders(collectionID)
+	assert.NotNil(t, cached)
+	assert.Equal(t, "new:19530", cached.Get(channel)[0].Address)
+	assert.Equal(t, int32(2), coordCalls.Load())
+	mgr.leaderMut.RLock()
+	assert.Empty(t, mgr.refreshes)
+	mgr.leaderMut.RUnlock()
+}
+
+func TestInvalidateShardLeaderCacheRevokesRefreshTokensByID(t *testing.T) {
+	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
+	mgr.collLeader[100] = &shardLeaders{}
+	mgr.acquireShardCacheRefresh(shardCacheRefreshKey{collectionID: 100})
+	mgr.acquireShardCacheRefresh(shardCacheRefreshKey{collectionID: 100, force: true})
+	mgr.acquireShardCacheRefresh(shardCacheRefreshKey{collectionID: 200})
+
+	mgr.InvalidateShardLeaderCache([]int64{100})
+
+	mgr.leaderMut.RLock()
+	defer mgr.leaderMut.RUnlock()
+	assert.NotContains(t, mgr.collLeader, int64(100))
+	assert.NotContains(t, mgr.refreshes, shardCacheRefreshKey{collectionID: 100})
+	assert.NotContains(t, mgr.refreshes, shardCacheRefreshKey{collectionID: 100, force: true})
+	assert.Contains(t, mgr.refreshes, shardCacheRefreshKey{collectionID: 200})
+}
+
+func TestListShardLocationDropsIdleEntries(t *testing.T) {
+	oldLeaders := &shardLeaders{
+		idx:          atomic.NewInt64(0),
+		collectionID: 100,
+		shardLeaders: map[string][]NodeInfo{"old-channel": {{NodeID: 1, Address: "old:19530", Serviceable: true}}},
+	}
+	newLeaders := &shardLeaders{
+		idx:          atomic.NewInt64(0),
+		collectionID: 200,
+		shardLeaders: map[string][]NodeInfo{"new-channel": {{NodeID: 2, Address: "new:19530", Serviceable: true}}},
+	}
+	oldLeaders.touch(time.Now().Add(-2 * time.Minute))
+	newLeaders.touch(time.Now())
+
+	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
+	mgr.shardCacheTTL = time.Minute
+	mgr.collLeader[100] = oldLeaders
+	mgr.collLeader[200] = newLeaders
+
+	locations := mgr.ListShardLocation()
+	assert.NotContains(t, locations, int64(1))
+	assert.Contains(t, locations, int64(2))
+	assert.NotContains(t, mgr.collLeader, int64(100))
+	assert.Contains(t, mgr.collLeader, int64(200))
+}
+
+func TestListShardLocationAllowsConcurrentCacheHits(t *testing.T) {
+	const collectionID = int64(200)
+	leaders := &shardLeaders{
+		idx:          atomic.NewInt64(0),
+		collectionID: collectionID,
+		shardLeaders: map[string][]NodeInfo{"channel": {{NodeID: 1, Address: "node:19530", Serviceable: true}}},
+	}
+	leaders.touch(time.Now())
+
+	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
+	mgr.collLeader[collectionID] = leaders
+	readLocked := make(chan struct{})
+	releaseScan := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseScan) })
+	mgr.testHookListShardLocationReadLocked = func() {
+		close(readLocked)
+		<-releaseScan
+	}
+
+	listDone := make(chan struct{})
+	go func() {
+		defer close(listDone)
+		mgr.ListShardLocation()
+	}()
+	<-readLocked
+
+	hitDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.GetShard(context.Background(), true, "db", "name", collectionID, "channel")
+		hitDone <- err
+	}()
+	select {
+	case err := <-hitDone:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("cache hit was blocked by ListShardLocation scan")
+	}
+
+	releaseOnce.Do(func() { close(releaseScan) })
+	<-listDone
+}
+
+func TestListShardLocationRechecksExpiredCandidateBeforeDelete(t *testing.T) {
+	const collectionID = int64(200)
+	leaders := &shardLeaders{
+		idx:          atomic.NewInt64(0),
+		collectionID: collectionID,
+		shardLeaders: map[string][]NodeInfo{"channel": {{NodeID: 1, Address: "node:19530", Serviceable: true}}},
+	}
+	leaders.touch(time.Now().Add(-2 * time.Minute))
+
+	mgr := NewShardClientMgr(mocks.NewMockMixCoordClient(t))
+	mgr.shardCacheTTL = time.Minute
+	mgr.collLeader[collectionID] = leaders
+	beforeDelete := make(chan struct{})
+	resumeDelete := make(chan struct{})
+	var resumeOnce sync.Once
+	defer resumeOnce.Do(func() { close(resumeDelete) })
+	mgr.testHookBeforeShardLocationDelete = func() {
+		close(beforeDelete)
+		<-resumeDelete
+	}
+
+	locationsDone := make(chan map[int64]NodeInfo, 1)
+	go func() { locationsDone <- mgr.ListShardLocation() }()
+	<-beforeDelete
+
+	_, err := mgr.GetShard(context.Background(), true, "db", "name", collectionID, "channel")
+	assert.NoError(t, err)
+	resumeOnce.Do(func() { close(resumeDelete) })
+
+	locations := <-locationsDone
+	assert.Contains(t, locations, int64(1))
+	assert.Same(t, leaders, mgr.loadCachedShardLeaders(collectionID))
+}

--- a/internal/proxy/shardclient/model.go
+++ b/internal/proxy/shardclient/model.go
@@ -18,6 +18,7 @@ package shardclient
 
 import (
 	"math/rand"
+	"time"
 
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
@@ -25,9 +26,19 @@ import (
 
 // shardLeaders wraps shard leader mapping for iteration.
 type shardLeaders struct {
-	idx          *atomic.Int64
-	collectionID int64
-	shardLeaders map[string][]NodeInfo
+	idx                *atomic.Int64
+	lastAccessUnixNano atomic.Int64
+	collectionID       int64
+	shardLeaders       map[string][]NodeInfo
+}
+
+func (sl *shardLeaders) touch(at time.Time) {
+	sl.lastAccessUnixNano.Store(at.UnixNano())
+}
+
+func (sl *shardLeaders) idleBefore(cutoff time.Time) bool {
+	lastAccess := sl.lastAccessUnixNano.Load()
+	return lastAccess > 0 && lastAccess <= cutoff.UnixNano()
 }
 
 func (sl *shardLeaders) Get(channel string) []NodeInfo {

--- a/internal/proxy/shardclient/shard_client_test.go
+++ b/internal/proxy/shardclient/shard_client_test.go
@@ -93,22 +93,22 @@ func TestPurgeClient(t *testing.T) {
 		return qn, nil
 	}
 
+	collLeader := typeutil.NewConcurrentMap[int64, *shardLeaders]()
+	collLeader.Insert(1, &shardLeaders{
+		idx:          atomic.NewInt64(0),
+		collectionID: 1,
+		shardLeaders: map[string][]NodeInfo{
+			"0": {node},
+		},
+	})
+
 	s := &shardClientMgrImpl{
 		clients:         typeutil.NewConcurrentMap[UniqueID, *shardClient](),
 		clientCreator:   creator,
 		closeCh:         make(chan struct{}),
 		purgeInterval:   1 * time.Second,
 		expiredDuration: 3 * time.Second,
-
-		collLeader: map[int64]*shardLeaders{
-			1: {
-				idx:          atomic.NewInt64(0),
-				collectionID: 1,
-				shardLeaders: map[string][]NodeInfo{
-					"0": {node},
-				},
-			},
-		},
+		collLeader:      collLeader,
 	}
 
 	go s.PurgeClient()
@@ -151,11 +151,11 @@ func TestPurgeClient(t *testing.T) {
 func seedShardLeaders(mgr *shardClientMgrImpl, database string, collectionID int64, channel string, node NodeInfo) {
 	mgr.leaderMut.Lock()
 	defer mgr.leaderMut.Unlock()
-	mgr.collLeader[collectionID] = &shardLeaders{
+	mgr.collLeader.Insert(collectionID, &shardLeaders{
 		idx:          atomic.NewInt64(0),
 		collectionID: collectionID,
 		shardLeaders: map[string][]NodeInfo{channel: {node}},
-	}
+	})
 }
 
 func TestRemoveDatabase(t *testing.T) {
@@ -211,9 +211,9 @@ func TestInvalidateShardLeaderCache(t *testing.T) {
 		// Verify collection with ID 100 is removed, but 101 remains
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader[100]
+		_, exists := mgr.collLeader.Get(100)
 		assert.False(t, exists)
-		_, exists = mgr.collLeader[101]
+		_, exists = mgr.collLeader.Get(101)
 		assert.True(t, exists)
 	})
 
@@ -227,11 +227,11 @@ func TestInvalidateShardLeaderCache(t *testing.T) {
 		// Verify collections 100 and 102 are removed, but 101 remains
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader[100]
+		_, exists := mgr.collLeader.Get(100)
 		assert.False(t, exists)
-		_, exists = mgr.collLeader[101]
+		_, exists = mgr.collLeader.Get(101)
 		assert.True(t, exists)
-		_, exists = mgr.collLeader[102]
+		_, exists = mgr.collLeader.Get(102)
 		assert.False(t, exists)
 	})
 
@@ -243,7 +243,7 @@ func TestInvalidateShardLeaderCache(t *testing.T) {
 		// Verify collection 100 still exists
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader[100]
+		_, exists := mgr.collLeader.Get(100)
 		assert.True(t, exists)
 	})
 
@@ -255,9 +255,9 @@ func TestInvalidateShardLeaderCache(t *testing.T) {
 
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader[200]
+		_, exists := mgr.collLeader.Get(200)
 		assert.False(t, exists)
-		_, exists = mgr.collLeader[201]
+		_, exists = mgr.collLeader.Get(201)
 		assert.False(t, exists)
 	})
 
@@ -271,9 +271,9 @@ func TestInvalidateShardLeaderCache(t *testing.T) {
 
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader[300]
+		_, exists := mgr.collLeader.Get(300)
 		assert.False(t, exists)
-		_, exists = mgr.collLeader[400]
+		_, exists = mgr.collLeader.Get(400)
 		assert.False(t, exists)
 	})
 

--- a/internal/proxy/task_index_test.go
+++ b/internal/proxy/task_index_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -47,6 +48,9 @@ import (
 
 func TestMain(m *testing.M) {
 	paramtable.Init()
+	if os.Getenv("MILVUS_METACACHE_BENCH_QUIET") == "1" {
+		mlog.SetLevel(mlog.ErrorLevel)
+	}
 	gin.SetMode(gin.TestMode)
 	streaming.SetupNoopWALForTest()
 	code := m.Run()

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -732,12 +732,13 @@ func (ex *Executor) getCollectionInfo(ctx context.Context, collectionID int64) (
 		return nil, err
 	}
 
-	ch := ex.collectionInfoSingleflight.DoChan(fmt.Sprint(collectionID), func() (*milvuspb.DescribeCollectionResponse, error) {
+	ch := ex.collectionInfoSingleflight.DoChanRaw(fmt.Sprint(collectionID), func() (*milvuspb.DescribeCollectionResponse, error) {
 		return ex.broker.DescribeCollection(context.WithoutCancel(ctx), collectionID)
 	})
 	select {
 	case result := <-ch:
-		return result.Val, result.Err
+		collection, err, _ := conc.UnwrapSingleflightRawResult[*milvuspb.DescribeCollectionResponse](result)
+		return collection, err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -40,6 +41,24 @@ func TestRegisterMetrics(t *testing.T) {
 		RegisterStreamingNode(r)
 		RegisterLoggingMetrics(r)
 	})
+}
+
+func TestRegisterProxyMetaCacheMetrics(t *testing.T) {
+	r := prometheus.NewRegistry()
+	RegisterProxy(r)
+
+	ProxyMetaCacheLockWaitLatency.WithLabelValues("1", "read", "collection_fill").Observe(1)
+	ProxyMetaCacheInvalidationLatency.WithLabelValues("1", "collection_invalidate").Observe(1)
+
+	families, err := r.Gather()
+	require.NoError(t, err)
+
+	names := make(map[string]struct{}, len(families))
+	for _, family := range families {
+		names[family.GetName()] = struct{}{}
+	}
+	assert.Contains(t, names, "milvus_proxy_metacache_lock_wait_latency")
+	assert.Contains(t, names, "milvus_proxy_metacache_invalidation_latency")
 }
 
 func TestGetRegisterer(t *testing.T) {

--- a/pkg/metrics/proxy_metrics.go
+++ b/pkg/metrics/proxy_metrics.go
@@ -197,6 +197,30 @@ var (
 			Buckets:   buckets, // unit: ms
 		}, []string{nodeIDLabelName, cacheNameLabelName})
 
+	// ProxyMetaCacheLockWaitLatency records how long MetaCache fills and
+	// invalidations wait to acquire the global fill gate. Labels are deliberately
+	// bounded: operation is selected from a fixed set in meta_cache.go and never
+	// contains database, collection, alias, or partition names.
+	ProxyMetaCacheLockWaitLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.ProxyRole,
+			Name:      "metacache_lock_wait_latency",
+			Help:      "latency in milliseconds waiting for the Proxy MetaCache fill gate",
+			Buckets:   subMsBuckets,
+		}, []string{nodeIDLabelName, "mode", "operation"})
+
+	// ProxyMetaCacheInvalidationLatency records end-to-end cache invalidation
+	// time, including any wait for in-flight fills to drain.
+	ProxyMetaCacheInvalidationLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.ProxyRole,
+			Name:      "metacache_invalidation_latency",
+			Help:      "end-to-end Proxy MetaCache invalidation latency in milliseconds",
+			Buckets:   subMsBuckets,
+		}, []string{nodeIDLabelName, "operation"})
+
 	// ProxySyncTimeTickLag record Proxy synchronization timestamp statistics, differentiated by Channel.
 	ProxySyncTimeTickLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -519,6 +543,8 @@ func RegisterProxy(registry *prometheus.Registry) {
 
 	registry.MustRegister(ProxyCacheStatsCounter)
 	registry.MustRegister(ProxyUpdateCacheLatency)
+	registry.MustRegister(ProxyMetaCacheLockWaitLatency)
+	registry.MustRegister(ProxyMetaCacheInvalidationLatency)
 
 	registry.MustRegister(ProxySyncTimeTickLag)
 	registry.MustRegister(ProxyApplyPrimaryKeyLatency)

--- a/pkg/util/conc/singleflight.go
+++ b/pkg/util/conc/singleflight.go
@@ -14,6 +14,10 @@ type SingleflightResult[T any] struct {
 	Shared bool
 }
 
+// SingleflightRawResult is the asynchronous result returned by DoChanRaw.
+// Val contains a value of the Singleflight type parameter when it is non-nil.
+type SingleflightRawResult = singleflight.Result
+
 func (sf *Singleflight[T]) Do(key string, fn func() (T, error)) (T, error, bool) {
 	raw, err, shared := sf.internal.Do(key, func() (any, error) {
 		return fn()
@@ -36,6 +40,23 @@ func (sf *Singleflight[T]) DoChan(key string, fn func() (T, error)) <-chan Singl
 		}
 	}()
 	return ch
+}
+
+// DoChanRaw provides the native singleflight asynchronous path without an
+// adapter goroutine for each caller.
+func (sf *Singleflight[T]) DoChanRaw(key string, fn func() (T, error)) <-chan SingleflightRawResult {
+	return sf.internal.DoChan(key, func() (any, error) {
+		return fn()
+	})
+}
+
+// UnwrapSingleflightRawResult converts a DoChanRaw result back to its generic value.
+func UnwrapSingleflightRawResult[T any](result SingleflightRawResult) (T, error, bool) {
+	var value T
+	if result.Val != nil {
+		value = result.Val.(T)
+	}
+	return value, result.Err, result.Shared
 }
 
 func (sf *Singleflight[T]) Forget(key string) {

--- a/pkg/util/conc/singleflight_test.go
+++ b/pkg/util/conc/singleflight_test.go
@@ -1,8 +1,10 @@
 package conc
 
 import (
+	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
@@ -65,6 +67,45 @@ func (s *SingleflightSuite) TestDoChan() {
 	if hasShared.Load() {
 		s.Less(counter.Load(), int32(10))
 	}
+}
+
+func (s *SingleflightSuite) TestDoChanKeepsTypedResult() {
+	sf := Singleflight[int]{}
+	result := <-sf.DoChan("test_dochan_typed", func() (int, error) {
+		return 42, nil
+	})
+
+	var value int = result.Val
+	s.Equal(42, value)
+	s.NoError(result.Err)
+}
+
+func (s *SingleflightSuite) TestDoChanRawDoesNotRetainGoroutinePerWaiter() {
+	sf := Singleflight[any]{}
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	first := sf.DoChanRaw("test_dochan_goroutines", func() (any, error) {
+		close(started)
+		<-release
+		return struct{}{}, nil
+	})
+	<-started
+
+	baseline := runtime.NumGoroutine()
+	const waiters = 2000
+	for i := 0; i < waiters; i++ {
+		_ = sf.DoChanRaw("test_dochan_goroutines", func() (any, error) {
+			s.FailNow("singleflight callback unexpectedly ran twice")
+			return nil, nil
+		})
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	s.Less(runtime.NumGoroutine(), baseline+50)
+
+	close(release)
+	<-first
 }
 
 func (s *SingleflightSuite) TestForget() {


### PR DESCRIPTION
## Summary

Extend the canonical collection-ID-keyed shard leader cache with cancellation-safe refresh sharing, cross-flight publication fencing, idle cleanup, and the MetaCache observability needed to validate the behavior.

- keep `collLeader map[collectionID]*shardLeaders` from #51779
- coalesce refreshes by `(collectionID, force)` without sharing caller cancellation/deadline behavior
- use a collection-ID-level write generation so an older normal/forced RPC cannot overwrite a newer refresh result
- revoke normal, forced, and publication generations during ID invalidation
- expire collection-ID entries after ten minutes idle
- scan purge candidates under `RLock`, then briefly revalidate and delete under `Lock`
- preserve the exported typed `conc.Singleflight.DoChan` API and use `DoChanRaw` internally where waiter goroutines must be avoided
- move Prometheus observer lookup outside the measured invalidation/lock interval

issue: #51533

## Root cause and review follow-up

#51779 made collection ID the canonical shard-cache key, which closes the alias repoint race without depending on mutable database/name attribution. This PR remains based on that implementation and does not reintroduce the old database/name/ID hierarchy, `DeprecateShardCache`, or scan-based ID invalidation.

The follow-up addresses the remaining refresh lifecycle risks:

1. Every caller selects on its own context while the shared Coord RPC uses `context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)`.
2. The raw native singleflight result path avoids one adapter goroutine per waiter.
3. Per-ID invalidation generations prevent an old RPC from repopulating cache after invalidation.
4. Normal and forced flights share a per-collection publication generation; only the latest-started flight may update `collLeader`.
5. ID-specific invalidation remains O(ids) and directly revokes normal, forced, and publication generations.
6. Idle purge performs the full scan under a read lock and uses only a short pointer/last-access recheck under the write lock.
7. `RemoveDatabase` remains the canonical no-op because shard entries are not attributed by mutable database/name metadata.

## Functional and compatibility impact

- shard leaders remain keyed only by collection ID
- alias repoints and cross-database renames do not depend on mutable names
- same-ID refreshes remain singleflight-coalesced, including forced refreshes as a separate flight
- a later-started forced refresh cannot be overwritten by an earlier normal refresh that completes later
- every caller returns on its own deadline; leader cancellation does not abort a useful shared refresh
- invalidated in-flight RPCs cannot recreate removed cache entries
- idle entries expire without a global write-lock scan blocking all cache hits
- downstream users of `pkg/v3/util/conc.Singleflight.DoChan` retain the typed source-compatible result API
- Prometheus label lookup is excluded from reported invalidation and lock-wait latency

## Current fixed inputs

- master source: `f2d1137b389fcd710ddf72a87f4432f2fc5cf490`
- master base: `785ab5117c061b914ea58401944186e5ce25dede`
- 3.0 port: #51764 at `45b7451c0d6d31a1acc1c71815751e8453a81d0d`
- 3.0 base: `d742be0fa493dc68aab8218be7bd0e3ed4eb46cf`
- Agentic source: `84a934bc0df5d14a8d8650f658a2bead25bb044a`
- build: `build-pr-51764-45b7451` - succeeded in 5m42s
- image tag: `harbor.milvus.io/manta/milvus:pr-51764-45b7451`
- image digest: `harbor.milvus.io/manta/milvus@sha256:136e3d900b2ccc587bce80940f82ac87aeb6f6afcc43b2301cd417b6aab39ca8`
- source and target registries expose the same manifest digest

## Exact-head unit validation

- master full shardclient: `go-ut-local-yanliang-codex-proxy-f2d1137-8c8cc35a` - succeeded in 3m26s
- master QueryCoord call site: `go-ut-local-yanliang-codex-proxy-f2d1137-16f536bb` - succeeded in 2m41s
- 3.0 full shardclient: `go-ut-local-yanliang-codex-proxy-45b7451-8c8cc35a` - succeeded in 7m31s
- 3.0 QueryCoord call site: `go-ut-local-yanliang-codex-proxy-45b7451-16f536bb` - succeeded in 3m57s
- master and 3.0 `pkg/util/conc`: race `-count=10` passed
- master and 3.0 `go vet ./util/conc`: passed

## Exact-head 4am black-box

- workflow: `proxy-metacache-4am-xmrrc` - Succeeded, 11/11
- topology: 3 Proxies, 100 alias switches, 32 concurrent workers
- system suite: 30 tests, 29 passed, 1 expected HTTP ID-only skip, 0 failures/errors
- requests: 202,953 total; 195,326 overlapped DDL; 7,627 stable and correct
- post-ack coverage: 100/100 windows
- correctness: `stale_after_ack=0`, `identity_mismatch=0`, `wrong_search_route=0`, `request_errors=0`, `ghost_alias=0`
- shard refreshes: `304 <= 3 * (2 * 100 + 4) = 612`
- deployed server version: `pr-51764-20260725-45b7451c0d`
- every Milvus component and all 3 Proxies reported digest `sha256:136e3d900b2ccc587bce80940f82ac87aeb6f6afcc43b2301cd417b6aab39ca8`
- system/white-box stage exit codes: 0; raw report run status: success; final exit code: 0
- analysis: success; cleanup: success; `kept_resources=[]`

The run is not baseline-eligible only because Milvus 3.0 port 9091 has no ID-only DescribeCollection route. Raw gRPC remains the authoritative ID-only oracle and passed on every Proxy.

This run is the smoke profile with externally recorded white-box jobs. It does not claim execution of the formal 100K/1M benchmark/profile suite or the mixed-version compatibility matrix.

## Regression coverage

- `TestDoChanKeepsTypedResult`
- `TestDoChanRawDoesNotRetainGoroutinePerWaiter`
- `TestShardCacheAliasRepointResolvesByCollectionID`
- `TestShardCacheDoesNotPingPongBetweenAliasCollectionIDs`
- `TestShardCacheRefreshKeyIgnoresMutableDatabaseAndName`
- `TestShardCacheCoalescesConcurrentRefreshPerCollectionID`
- `TestShardCacheNewerForcedRefreshWinsWriteRace`
- leader cancellation, waiter deadline, shared RPC timeout, invalidation fence, and per-ID token revocation tests
- idle cleanup, concurrent-hit, purge revalidation, and `RemoveDatabase` no-op tests

## Checks

- [x] rebased on the canonical ID-keyed shard cache
- [x] normal/forced publication order fenced per collection ID
- [x] exported `Singleflight.DoChan` source compatibility retained
- [x] no per-waiter goroutine on shardclient and QueryCoord raw paths
- [x] master and 3.0 exact-head unit validation
- [x] exact 3.0 image build and source/target digest verification
- [x] Agentic stage/run/final-exit negative gates and success-path regression
- [x] exact-head 4am workflow, artifact analysis, and cleanup
- [x] gofmt and `git diff --check`
- [ ] local `make static-check`; macOS lacks the supported LLVM/C++ runtime dependencies, so Draft CI remains authoritative
