### PR TITLE
enhance: [2.6] update knowhere version

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( KNOWHERE_VERSION v2.6.17 )
+set( KNOWHERE_VERSION v2.6.18 )
 set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")


### PR DESCRIPTION
issue: #42937

/kind branch-feature

## Summary
- Update Knowhere dependency from `v2.6.17` to `v2.6.18`.
- Use the Knowhere `v2.6.18` tag from the 2.6 branch: https://github.com/zilliztech/knowhere/tree/v2.6.18

## Changes included in v2.6.18 (since v2.6.17)
- fix: handle int8 cosine normalization for GPU CAGRA (zilliztech/knowhere#1724)

> Note: this is a 2.6-branch-specific dependency bump; knowhere 2.6 is not tracked on milvus master (master follows knowhere v3.x), so there is no corresponding master PR.

## Test plan
- [x] `git diff --check upstream/2.6..HEAD`
- [x] `git ls-remote --tags https://github.com/zilliztech/knowhere.git refs/tags/v2.6.18`
