### PR TITLE
fix: [3.0] reconcile BM25 IDF oracle from the stream when a load races the schema DDL

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -213,6 +213,41 @@ func (sd *shardDelegator) publishIDFOracle(idfOracle IDFOracle) {
 	sd.idfOracle.Store(&idfOracleHolder{oracle: idfOracle})
 }
 
+// reconcileFunctionRuntimeLocked reconciles the delegator's function runtime —
+// the per-vchannel function runner and the BM25 IDF oracle — to the collection's
+// current schema. The caller MUST hold schemaChangeMutex.
+//
+// Both artifacts are driven only by UpdateSchema (the stream/DDL path); the load
+// path never touches them. A segment load can advance the collection schema ahead
+// of the DDL and gate that UpdateSchema out as a no-op (#51062), so the no-op
+// branch calls this to still refresh the runner and create/sync the oracle. It
+// reconciles against sd.collection.Schema() (monotonic:
+// prepareCollectionSchemaUpdate rejects older versions), so a stale schema can never
+// roll either back; the oracle is never torn down and is published once, so a
+// later schema that adds a BM25 field must SyncFunctions, not just create.
+func (sd *shardDelegator) reconcileFunctionRuntimeLocked() error {
+	schema := sd.collection.Schema()
+	if err := function.GetManager().Update(sd.collectionID, delegatorFunctionRunnerKey(sd.vchannelName), schema); err != nil {
+		// Runner construction failures are retried asynchronously by the manager.
+		// A synchronous error here means the internal function metadata is invalid.
+		panic(err)
+	}
+	if idfOracle := sd.getIDFOracle(); idfOracle != nil {
+		return idfOracle.SyncFunctions(schema.GetFunctions())
+	}
+	if len(newBM25FunctionSet(schema)) == 0 {
+		return nil
+	}
+	idfOracle := NewIDFOracle(sd.vchannelName, schema.GetFunctions())
+	idfOracle.Start()
+	sd.distribution.SetIDFOracle(idfOracle)
+	if current := sd.distribution.current.Load(); current != nil {
+		idfOracle.SetNext(current)
+	}
+	sd.publishIDFOracle(idfOracle)
+	return nil
+}
+
 func (sd *shardDelegator) NotStopped(state lifetime.State) error {
 	if state != lifetime.Stopped {
 		return nil
@@ -1255,11 +1290,23 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 	defer sd.schemaChangeMutex.Unlock()
 
 	if !segments.ShouldUpdateCollectionSchema(sd.collection, schema, schemaBarrierTs) {
-		mlog.Info(ctx, "delegator skip stale or no-op schema event",
+		// Collection schema is already current (e.g. a segment load advanced it ahead
+		// of this DDL), so the schema/worker apply below is a no-op. But the delegator
+		// function runtime (runner + IDF oracle) is driven only by the stream, so
+		// still reconcile it here to the collection's current schema (#51062).
+		mlog.Info(ctx, "delegator collection schema current, reconcile function runtime only",
 			mlog.Uint64("schemaVersion", schemaVersion),
 			mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
 		)
-		return nil
+		// Adopt the load barrier from the applied collection snapshot, not from the
+		// possibly stale event: the racing load advanced the collection past this
+		// event, and older in-flight loads must not republish pre-DDL segments
+		// through addDistributionIfSchemaBarrierOK.
+		_, _, currentBarrierTs := sd.collection.SchemaSnapshot()
+		if sd.schemaBarrierTs < currentBarrierTs {
+			sd.schemaBarrierTs = currentBarrierTs
+		}
+		return sd.reconcileFunctionRuntimeLocked()
 	}
 	oldSet := newBM25FunctionSet(sd.collection.Schema())
 	newSet := newBM25FunctionSet(schema)
@@ -1322,27 +1369,12 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 		return err
 	}
 
-	// Publish the manager schema after the delegator schema update. Queries use
-	// the previous function schema until this point.
-	if err := function.GetManager().Update(sd.collectionID, delegatorFunctionRunnerKey(sd.vchannelName), schema); err != nil {
-		// Runner construction failures are retried asynchronously by the manager.
-		// A synchronous error here means the internal function metadata is invalid.
-		panic(err)
-	}
-	if idfOracle == nil && len(newSet) > 0 {
-		// StreamingNode schema changes flush and fence old growings before UpdateSchema and new-schema inserts.
-		// Old growings cannot receive stats for newly added BM25 fields; ProcessInsert registers only new growings.
-		idfOracle = NewIDFOracle(sd.vchannelName, schema.GetFunctions())
-		idfOracle.Start()
-		sd.distribution.SetIDFOracle(idfOracle)
-		if current := sd.distribution.current.Load(); current != nil {
-			idfOracle.SetNext(current)
-		}
-		sd.publishIDFOracle(idfOracle)
-	} else if idfOracle != nil && !newSet.Equal(oldSet) {
-		if err := idfOracle.SyncFunctions(schema.GetFunctions()); err != nil {
-			return err
-		}
+	// Reconcile the delegator function runtime (runner + IDF oracle) to the
+	// now-current schema, after the delegator schema update and sharing the same
+	// path as the gated no-op branch above (one place, no duplication). Queries
+	// use the previous function schema until this point.
+	if err := sd.reconcileFunctionRuntimeLocked(); err != nil {
+		return err
 	}
 	mlog.Info(ctx, "delegator finished update schema event",
 		mlog.Uint64("schemaVersion", schemaVersion),

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -497,6 +497,24 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.SegmentLoadInfo, req *querypb.LoadSegmentsRequest) error {
 	idfOracle := sd.getIDFOracle()
 	if idfOracle == nil {
+		// A nil oracle is legal when the current schema has no BM25 function
+		// (never had one, or it was dropped and old segments still carry stats).
+		if len(newBM25FunctionSet(sd.collection.Schema())) == 0 {
+			return nil
+		}
+		// The schema has BM25 but the stream has not installed the oracle yet
+		// (#51062 race). Skipping would lose these segments' stats forever, so
+		// fail stats-bearing loads; QueryCoord retries until the stream installs
+		// the oracle via UpdateSchema.
+		for _, info := range infos {
+			paths, err := packed.NewStatsResolverFromLoadInfo(info).BM25StatsPaths()
+			if err != nil {
+				return err
+			}
+			if len(paths) > 0 {
+				return merr.WrapErrServiceInternal("BM25 stats load before delegator BM25 oracle is initialized, retry after the stream installs it")
+			}
+		}
 		return nil
 	}
 
@@ -526,24 +544,32 @@ func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.Se
 	return nil
 }
 
+// bm25StatsBearingInfos returns the load infos that carry BM25 stats logs.
+func bm25StatsBearingInfos(ctx context.Context, log *mlog.Logger, infos []*querypb.SegmentLoadInfo) ([]*querypb.SegmentLoadInfo, error) {
+	withStats := make([]*querypb.SegmentLoadInfo, 0, len(infos))
+	for _, info := range infos {
+		bm25Paths, err := packed.NewStatsResolverFromLoadInfo(info).BM25StatsPaths()
+		if err != nil {
+			log.Warn(ctx, "resolve bm25 stats paths failed", mlog.FieldSegmentID(info.GetSegmentID()), mlog.Err(err))
+			return nil, err
+		}
+		if len(bm25Paths) > 0 {
+			withStats = append(withStats, info)
+		}
+	}
+	return withStats, nil
+}
+
 func (sd *shardDelegator) handleReopenPostLoad(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
 	log := sd.getLogger(ctx).With(
 		mlog.Int64s("segments", lo.Map(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) int64 { return info.GetSegmentID() })),
 		mlog.String("loadScope", req.GetLoadScope().String()),
 	)
 
-	infosWithBM25Stats := make([]*querypb.SegmentLoadInfo, 0, len(req.GetInfos()))
-	for _, info := range req.GetInfos() {
-		bm25Paths, err := packed.NewStatsResolverFromLoadInfo(info).BM25StatsPaths()
-		if err != nil {
-			log.Warn(ctx, "resolve reopened bm25 stats failed", mlog.FieldSegmentID(info.GetSegmentID()), mlog.Err(err))
-			return err
-		}
-		if len(bm25Paths) > 0 {
-			infosWithBM25Stats = append(infosWithBM25Stats, info)
-		}
+	infosWithBM25Stats, err := bm25StatsBearingInfos(ctx, log, req.GetInfos())
+	if err != nil {
+		return err
 	}
-
 	if len(infosWithBM25Stats) == 0 {
 		return nil
 	}
@@ -553,6 +579,11 @@ func (sd *shardDelegator) handleReopenPostLoad(ctx context.Context, req *querypb
 func (sd *shardDelegator) loadBM25StatsForReopen(ctx context.Context, infos []*querypb.SegmentLoadInfo, req *querypb.LoadSegmentsRequest) error {
 	idfOracle := sd.getIDFOracle()
 	if idfOracle == nil {
+		// Dropped-function leftovers: the schema has no BM25, the stats are
+		// orphaned, and no oracle will ever be installed — skip, don't error.
+		if len(newBM25FunctionSet(sd.collection.Schema())) == 0 {
+			return nil
+		}
 		return merr.WrapErrServiceInternal("reopen contains BM25 stats before delegator BM25 oracle is initialized")
 	}
 
@@ -627,6 +658,37 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 
 	if req.GetInfos()[0].GetLevel() == datapb.SegmentLevel_L0 {
 		return merr.WrapErrServiceInternal("load L0 segment is not supported, l0 segment should only be loaded by watchChannel")
+	}
+
+	// A reopen carrying BM25 stats needs the oracle BEFORE the worker commits the
+	// new version: failing after the commit leaves no checker-visible diff (the
+	// segment already matches the target), so QueryCoord would never re-issue the
+	// reopen and the stats would be lost permanently. Fail here so the version
+	// diff persists and the task retries until the stream installs the oracle.
+	if req.GetLoadScope() == querypb.LoadScope_Reopen && sd.getIDFOracle() == nil {
+		// Judge whether the stats matter against the NEWER of the request and
+		// collection schemas (same monotonic version domain): the first racing
+		// reopen carries the post-DDL schema while the collection still lags, and
+		// a stale pre-drop request can carry BM25 the collection no longer has.
+		// When the newer view has no BM25 (function dropped, delegator rebuilt),
+		// no oracle will ever be installed and rejecting would retry forever, so
+		// such loads pass and their orphaned stats are skipped.
+		// Single snapshot: schema and version must come from one atomic load, or a
+		// concurrent PutOrRef between two loads can yield an old schema with a new
+		// version and bypass the guard.
+		schema, collectionVersion, _ := sd.collection.SchemaSnapshot()
+		if reqSchema := req.GetSchema(); reqSchema != nil && uint64(reqSchema.GetVersion()) > collectionVersion {
+			schema = reqSchema
+		}
+		if len(newBM25FunctionSet(schema)) > 0 {
+			statsBearing, err := bm25StatsBearingInfos(ctx, log, req.GetInfos())
+			if err != nil {
+				return err
+			}
+			if len(statsBearing) > 0 {
+				return merr.WrapErrServiceInternal("reopen contains BM25 stats before delegator BM25 oracle is initialized")
+			}
+		}
 	}
 
 	// pin all segments to prevent delete buffer has been cleaned up during worker load segments
@@ -773,7 +835,20 @@ func (sd *shardDelegator) withPostLoadLimit(ctx context.Context, fn func() error
 func (sd *shardDelegator) addDistributionIfSchemaBarrierOK(schemaBarrierTs uint64, entries ...SegmentEntry) error {
 	sd.schemaChangeMutex.RLock()
 	defer sd.schemaChangeMutex.RUnlock()
-	if schemaBarrierTs < sd.schemaBarrierTs {
+	// Fence barrier-carrying loads against the applied collection barrier too, not
+	// only the stream-adopted field: a load can advance the collection without
+	// schemaChangeMutex, so the delegator field may lag right after adoption.
+	// Reading the monotonic snapshot at decision time closes that window; rejected
+	// loads retry with a fresh barrier. Barrier-less requests (legacy paths) keep
+	// the field-only check — the collection barrier is nonzero from creation and
+	// would reject them permanently.
+	fence := sd.schemaBarrierTs
+	if schemaBarrierTs > 0 {
+		if _, _, collectionBarrierTs := sd.collection.SchemaSnapshot(); collectionBarrierTs > fence {
+			fence = collectionBarrierTs
+		}
+	}
+	if schemaBarrierTs < fence {
 		return merr.WrapErrServiceInternal("schema barrier changed")
 	}
 

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -224,7 +224,10 @@ func (s *DelegatorDataSuite) genTextCollection() {
 	})
 }
 
-func (s *DelegatorDataSuite) genCollectionWithFunction() {
+// putFunctionCollection advances the shared collection to a BM25-function schema
+// WITHOUT rebuilding the delegator, modeling a load racing ahead of the stream
+// DDL (schema advanced, function runtime not yet installed).
+func (s *DelegatorDataSuite) putFunctionCollection() {
 	s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
 		Name:    "TestCollection",
 		Version: 1,
@@ -258,6 +261,10 @@ func (s *DelegatorDataSuite) genCollectionWithFunction() {
 			OutputFieldIds: []int64{101},
 		}},
 	}, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now())})
+}
+
+func (s *DelegatorDataSuite) genCollectionWithFunction() {
+	s.putFunctionCollection()
 
 	delegator, err := NewShardDelegator(context.Background(), s.collectionID, s.replicaID, s.vchannelName, s.version, s.workerManager, s.manager, s.loader, 10000, nil, s.chunkManager, NewChannelQueryView(nil, nil, nil, initialTargetVersion), nil)
 	s.NoError(err)
@@ -868,6 +875,10 @@ func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsMergesReadableSegmen
 }
 
 func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsRequiresOracleForRetry() {
+	// Schema already advanced (by a racing load) to include BM25, oracle not yet
+	// installed by the stream: the reopen must fail retriably BEFORE the worker
+	// commit. Without BM25 in the schema the guard must NOT fire (drop case).
+	s.putFunctionCollection()
 	worker1 := &cluster.MockWorker{}
 	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
 	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
@@ -2395,7 +2396,12 @@ func TestUpdateSchemaSyncsAdditiveIDFOracleFunctions(t *testing.T) {
 
 	newSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema(), newAdditionalBM25FunctionSchema())
 	collectionManager := segments.NewMockCollectionManager(t)
-	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Return(nil).Once()
+	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).RunAndReturn(func(collectionID int64, schema *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
+		// Mirror the real manager's contract: a successful UpdateSchema leaves
+		// the delegator-visible collection at the applied schema.
+		sd.collection = segments.NewCollectionWithoutSegcoreForTest(collectionID, schema)
+		return nil
+	}).Once()
 	sd.collectionManager = collectionManager
 
 	err := sd.UpdateSchema(context.Background(), newSchema, 100)
@@ -2459,7 +2465,12 @@ func TestUpdateSchemaInitializesIDFOracleWhenBM25Added(t *testing.T) {
 
 	newSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
 	collectionManager := segments.NewMockCollectionManager(t)
-	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Return(nil).Once()
+	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).RunAndReturn(func(collectionID int64, schema *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
+		// Mirror the real manager's contract: a successful UpdateSchema leaves
+		// the delegator-visible collection at the applied schema.
+		sd.collection = segments.NewCollectionWithoutSegcoreForTest(collectionID, schema)
+		return nil
+	}).Once()
 	sd.collectionManager = collectionManager
 
 	err := sd.UpdateSchema(context.Background(), newSchema, 100)
@@ -2467,6 +2478,254 @@ func TestUpdateSchemaInitializesIDFOracleWhenBM25Added(t *testing.T) {
 	require.NotNil(t, sd.getIDFOracle())
 
 	_, _, err = sd.getIDFOracle().BuildIDF(102, &schemapb.SparseFloatArray{Contents: [][]byte{typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{7: 1})}, Dim: 1})
+	require.NoError(t, err)
+}
+
+// newReconcileIDFOracleTestDelegator builds a minimal delegator (no segcore) whose
+// collection carries the given schema, for exercising reconcileFunctionRuntimeLocked directly.
+func newReconcileIDFOracleTestDelegator(t *testing.T, schema *schemapb.CollectionSchema) *shardDelegator {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+	// Mirror NewShardDelegator: the runner key is allocated at build with the
+	// (possibly pre-DDL) schema; reconcile then updates it. Released by Close.
+	require.NoError(t, function.GetManager().Alloc(1000, delegatorFunctionRunnerKey("test-channel"), newFunctionRuntimeTestSchema()))
+	return &shardDelegator{
+		collectionID:               1000,
+		vchannelName:               "test-channel",
+		collection:                 segments.NewCollectionWithoutSegcoreForTest(1000, schema),
+		lifetime:                   lifetime.NewLifetime(lifetime.Working),
+		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		workerManager:              cluster.NewMockManager(t),
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+	}
+}
+
+// reconcileFunctionRuntimeUnderLock calls reconcileFunctionRuntimeLocked while
+// holding schemaChangeMutex, matching how UpdateSchema invokes it.
+func reconcileFunctionRuntimeUnderLock(sd *shardDelegator) error {
+	sd.schemaChangeMutex.Lock()
+	defer sd.schemaChangeMutex.Unlock()
+	return sd.reconcileFunctionRuntimeLocked()
+}
+
+// A load can advance the collection schema to include a BM25 function ahead of the
+// DDL and gate out UpdateSchema; reconcileFunctionRuntimeLocked must create the oracle
+// and refresh the function runner from the collection's current schema so the field
+// is searchable (#51062).
+func TestReconcileIDFOracleCreatesWhenBM25Present(t *testing.T) {
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema()))
+	defer sd.Close()
+
+	require.Nil(t, sd.getIDFOracle())
+	require.NoError(t, reconcileFunctionRuntimeUnderLock(sd))
+	require.NotNil(t, sd.getIDFOracle())
+
+	sparse := &schemapb.SparseFloatArray{Contents: [][]byte{typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{7: 1})}, Dim: 1}
+	_, _, err := sd.getIDFOracle().BuildIDF(102, sparse)
+	require.NoError(t, err)
+
+	// The runner must serve the BM25 output field after reconcile.
+	ok, err := function.GetManager().RunWithRunner(context.Background(), 1000, delegatorFunctionRunnerKey("test-channel"), 102, func(function.FunctionRunner) error { return nil })
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+// The oracle is never torn down, so a later load that adds a BM25 output field must
+// sync it into the existing oracle, not just create it (#51062).
+func TestReconcileIDFOracleSyncsAddedBM25Field(t *testing.T) {
+	// Collection already advanced (by the load) to fields 102 + 105.
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchemaWithVersion(2, newBM25FunctionSchema(), newAdditionalBM25FunctionSchema()))
+	defer sd.Close()
+
+	// Existing oracle only knows field 102.
+	oldOracle := NewIDFOracle("test-channel", newFunctionRuntimeTestSchema(newBM25FunctionSchema()).GetFunctions())
+	sd.publishIDFOracle(oldOracle)
+
+	sparse := &schemapb.SparseFloatArray{Contents: [][]byte{typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{7: 1})}, Dim: 1}
+	_, _, err := sd.getIDFOracle().BuildIDF(105, sparse)
+	require.Error(t, err) // field 105 unknown before reconcile
+
+	require.NoError(t, reconcileFunctionRuntimeUnderLock(sd))
+	require.Same(t, oldOracle, sd.getIDFOracle()) // synced in place, not replaced
+
+	_, _, err = sd.getIDFOracle().BuildIDF(105, sparse)
+	require.NoError(t, err)
+	_, _, err = sd.getIDFOracle().BuildIDF(102, sparse) // existing field preserved
+	require.NoError(t, err)
+}
+
+// reconcileFunctionRuntimeLocked creates no oracle when the collection schema has
+// no BM25 function.
+func TestReconcileIDFOracleNoopWhenNoBM25(t *testing.T) {
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchema())
+	defer sd.Close()
+
+	require.NoError(t, reconcileFunctionRuntimeUnderLock(sd))
+	require.Nil(t, sd.getIDFOracle())
+}
+
+// End-to-end #51062 regression: the collection schema was already advanced (by a
+// load) past the DDL event, so UpdateSchema takes the gated no-op branch — which
+// must still reconcile the function runtime so the runner serves the new BM25
+// output field and the oracle exists.
+func TestUpdateSchemaGatedBranchReconcilesFunctionRuntime(t *testing.T) {
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchemaWithVersion(2, newBM25FunctionSchema()))
+	// The racing load advanced the collection to barrier 150 while the delegator
+	// load barrier lags at 100.
+	sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, newFunctionRuntimeTestSchemaWithVersion(2, newBM25FunctionSchema()), 150)
+	sd.schemaBarrierTs = 100
+	defer sd.Close()
+
+	require.Nil(t, sd.getIDFOracle())
+	// Stale DDL event: gated by the schema version check.
+	require.NoError(t, sd.UpdateSchema(context.Background(), newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema()), 100))
+
+	require.NotNil(t, sd.getIDFOracle())
+	ok, err := function.GetManager().RunWithRunner(context.Background(), 1000, delegatorFunctionRunnerKey("test-channel"), 102, func(function.FunctionRunner) error { return nil })
+	require.NoError(t, err)
+	require.True(t, ok)
+	// The gated branch adopts the load barrier from the applied collection
+	// snapshot so older in-flight loads cannot republish pre-DDL segments.
+	require.Equal(t, uint64(150), sd.schemaBarrierTs)
+}
+
+// loadBM25Stats with a nil oracle: legal when the schema has no BM25 function;
+// a stats-bearing load must fail (retryable) when the schema already has BM25,
+// so the stats are not silently lost before the stream installs the oracle (#51062).
+func TestLoadBM25StatsNilOracle(t *testing.T) {
+	ctx := context.Background()
+	statsInfo := &querypb.SegmentLoadInfo{
+		SegmentID: 1,
+		Bm25Logs:  []*datapb.FieldBinlog{{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "l1"}}}},
+	}
+	plainInfo := &querypb.SegmentLoadInfo{SegmentID: 2}
+
+	// Schema without BM25 (never had one, or dropped): stats leftovers pass.
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchema())
+	defer sd.Close()
+	require.NoError(t, sd.loadBM25Stats(ctx, []*querypb.SegmentLoadInfo{statsInfo}, &querypb.LoadSegmentsRequest{}))
+
+	// Schema with BM25 but oracle not yet installed by the stream.
+	sdBM25 := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema()))
+	defer sdBM25.Close()
+	err := sdBM25.loadBM25Stats(ctx, []*querypb.SegmentLoadInfo{plainInfo, statsInfo}, &querypb.LoadSegmentsRequest{})
+	require.Error(t, err)
+
+	// Stats-less load in the same window passes.
+	require.NoError(t, sdBM25.loadBM25Stats(ctx, []*querypb.SegmentLoadInfo{plainInfo}, &querypb.LoadSegmentsRequest{}))
+}
+
+// addDistributionIfSchemaBarrierOK fences against the applied collection barrier
+// at decision time, not only the stream-adopted field, so a load racing ahead of
+// the stream cannot let an older in-flight load publish pre-DDL segments.
+func TestAddDistributionFencesOnCollectionBarrier(t *testing.T) {
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchema())
+	sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, newFunctionRuntimeTestSchema(), 150)
+	sd.schemaBarrierTs = 100
+	defer sd.Close()
+
+	// Clears the delegator field (100) but not the collection barrier (150).
+	require.Error(t, sd.addDistributionIfSchemaBarrierOK(120))
+	// At the collection barrier: accepted.
+	require.NoError(t, sd.addDistributionIfSchemaBarrierOK(150))
+	// Barrier-less (legacy) requests keep the field-only check: the delegator
+	// field is 100, so 0 is still rejected by it, and once the field is 0 they pass.
+	sd.schemaBarrierTs = 0
+	require.NoError(t, sd.addDistributionIfSchemaBarrierOK(0))
+}
+
+// A reopen carrying BM25 stats must fail BEFORE the worker commits the new
+// version when the oracle is missing: failing after the commit leaves no
+// checker-visible diff (the segment already matches the target), so QueryCoord
+// would never re-issue the reopen and the stats would be lost permanently.
+func TestLoadSegmentsReopenFailsBeforeWorkerCommitWhenOracleNil(t *testing.T) {
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema()))
+	defer sd.Close()
+
+	err := sd.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		DstNodeID: 1,
+		LoadScope: querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{{
+			SegmentID: 1,
+			Bm25Logs:  []*datapb.FieldBinlog{{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "l1"}}}},
+		}},
+	})
+	require.Error(t, err)
+	// The workerManager mock carries no expectations, so reaching the worker
+	// forward would fail this test: the error must fire before the commit.
+}
+
+// The FIRST racing reopen carries the post-DDL schema (with BM25) while the local
+// collection still lags without it; the guard must judge by the newer request
+// schema and reject before the worker commit, or the stats are lost permanently
+// once the worker matches the target (#51062).
+func TestLoadSegmentsReopenFailsWhenRequestSchemaAddsBM25(t *testing.T) {
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchema()) // local schema without BM25
+	defer sd.Close()
+
+	err := sd.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		DstNodeID: 1,
+		LoadScope: querypb.LoadScope_Reopen,
+		Schema:    newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema()),
+		Infos: []*querypb.SegmentLoadInfo{{
+			SegmentID: 1,
+			Bm25Logs:  []*datapb.FieldBinlog{{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "l1"}}}},
+		}},
+	})
+	require.Error(t, err)
+	// The workerManager mock carries no expectations: the error must fire before
+	// the worker commit.
+}
+
+// A stale pre-drop request can carry BM25 the collection no longer has; the
+// version-newer collection view wins, so the reopen passes instead of retrying
+// forever against an oracle that will never be installed.
+func TestLoadSegmentsReopenPassesWhenStaleRequestCarriesDroppedBM25(t *testing.T) {
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchemaWithVersion(2)) // post-drop schema, no BM25
+	worker := cluster.NewMockWorker(t)
+	worker.EXPECT().LoadSegments(mock.Anything, mock.Anything).Return(nil).Once()
+	workerManager := cluster.NewMockManager(t)
+	workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+	sd.workerManager = workerManager
+	defer sd.Close()
+
+	err := sd.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		Base:      &commonpb.MsgBase{},
+		DstNodeID: 1,
+		LoadScope: querypb.LoadScope_Reopen,
+		Schema:    newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema()), // stale pre-drop schema
+		Infos: []*querypb.SegmentLoadInfo{{
+			SegmentID: 1,
+			Bm25Logs:  []*datapb.FieldBinlog{{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "l1"}}}},
+		}},
+	})
+	require.NoError(t, err)
+}
+
+// After the BM25 function is dropped and the delegator rebuilt, the oracle is
+// correctly absent while historical segments still carry BM25 logs. Such reopens
+// must pass end-to-end (guard skips, post-load skips orphaned stats) — rejecting
+// them would retry forever because no oracle will ever be installed.
+func TestLoadSegmentsReopenPassesWhenBM25Dropped(t *testing.T) {
+	sd := newReconcileIDFOracleTestDelegator(t, newFunctionRuntimeTestSchema()) // schema without BM25
+	worker := cluster.NewMockWorker(t)
+	worker.EXPECT().LoadSegments(mock.Anything, mock.Anything).Return(nil).Once()
+	workerManager := cluster.NewMockManager(t)
+	workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+	sd.workerManager = workerManager
+	defer sd.Close()
+
+	err := sd.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		Base:      &commonpb.MsgBase{},
+		DstNodeID: 1,
+		LoadScope: querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{{
+			SegmentID: 1,
+			Bm25Logs:  []*datapb.FieldBinlog{{FieldID: 102, Binlogs: []*datapb.Binlog{{LogPath: "l1"}}}},
+		}},
+	})
 	require.NoError(t, err)
 }
 
@@ -2537,7 +2796,12 @@ func TestUpdateSchemaSyncsFunctionRunnerMetadata(t *testing.T) {
 
 	newSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema(), newMinHashFunctionSchema())
 	collectionManager := segments.NewMockCollectionManager(t)
-	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Return(nil).Once()
+	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).RunAndReturn(func(collectionID int64, schema *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
+		// Mirror the real manager's contract: a successful UpdateSchema leaves
+		// the delegator-visible collection at the applied schema.
+		sd.collection = segments.NewCollectionWithoutSegcoreForTest(collectionID, schema)
+		return nil
+	}).Once()
 	sd.collectionManager = collectionManager
 
 	err := sd.UpdateSchema(context.Background(), newSchema, 100)
@@ -2591,7 +2855,12 @@ func TestUpdateSchemaPanicsOnInvalidFunctionMetadata(t *testing.T) {
 	invalidFunction.OutputFieldIds = []int64{999}
 	invalidSchema := newFunctionRuntimeTestSchemaWithVersion(1, invalidFunction)
 	collectionManager := segments.NewMockCollectionManager(t)
-	collectionManager.EXPECT().UpdateSchema(int64(1000), invalidSchema, uint64(100)).Return(nil).Once()
+	collectionManager.EXPECT().UpdateSchema(int64(1000), invalidSchema, uint64(100)).RunAndReturn(func(collectionID int64, schema *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
+		// Mirror the real manager's contract: a successful UpdateSchema leaves
+		// the delegator-visible collection at the applied schema.
+		sd.collection = segments.NewCollectionWithoutSegcoreForTest(collectionID, schema)
+		return nil
+	}).Once()
 	sd.collectionManager = collectionManager
 
 	_, expectedErr := function.EmbeddingOutputFieldIDs(invalidSchema)

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -654,14 +654,18 @@ func NewTestCollection(collectionID int64, loadType querypb.LoadType, schema *sc
 
 // new collection without segcore prepare
 // ONLY FOR TEST
-func NewCollectionWithoutSegcoreForTest(collectionID int64, schema *schemapb.CollectionSchema) *Collection {
+func NewCollectionWithoutSegcoreForTest(collectionID int64, schema *schemapb.CollectionSchema, schemaBarrierTs ...uint64) *Collection {
 	coll := &Collection{
 		id:         collectionID,
 		partitions: typeutil.NewConcurrentSet[int64](),
 		refCount:   atomic.NewUint32(0),
 	}
+	barrier := uint64(0)
+	if len(schemaBarrierTs) > 0 {
+		barrier = schemaBarrierTs[0]
+	}
 	logicalSchemaVersion := uint64(schema.GetVersion())
-	coll.setSchema(schema, logicalSchemaVersion, 0, initialSegcoreSchemaVersion(logicalSchemaVersion, 0))
+	coll.setSchema(schema, logicalSchemaVersion, barrier, initialSegcoreSchemaVersion(logicalSchemaVersion, barrier))
 	return coll
 }
 


### PR DESCRIPTION
Backport of #51753 to the 3.0 branch.

A segment load can advance the delegator collection schema ahead of the AlterCollection DDL, which makes the stream's `UpdateSchema` a no-op and skips its BM25 IDF-oracle creation/sync. A BM25 search over a newly added function-output field then fails with "bm25 oracle is not initialized".

Drive the IDF oracle's function-set lifecycle entirely from `UpdateSchema` (the stream/DDL path): reconcile it even on the no-op branch, against the collection's monotonic schema so a stale load cannot roll it back. The load path stays a relay and only feeds per-segment BM25 stats; the reopen path already guards those stats until the oracle is installed.

issue: #51062
pr: #51753

🤖 Generated with [Claude Code](https://claude.com/claude-code)
