### PR TITLE
feat: [cp3.0]Add Go SDK and REST API support for drop field

### DIFF
--- a/client/internal/merr/merr.go
+++ b/client/internal/merr/merr.go
@@ -89,13 +89,15 @@ func (e *RPCError) Is(target error) bool {
 }
 
 var (
-	ErrServiceNotReady = newRPCError("service not ready", 1, commonpb.ErrorCode_NotReadyServe, true, false)
-	ErrServiceInternal = newRPCError("service internal error", 5, commonpb.ErrorCode_UnexpectedError, false, false)
+	ErrServiceNotReady      = newRPCError("service not ready", 1, commonpb.ErrorCode_NotReadyServe, true, false)
+	ErrServiceInternal      = newRPCError("service internal error", 5, commonpb.ErrorCode_UnexpectedError, false, false)
+	ErrServiceUnimplemented = newRPCError("service unimplemented", 10, commonpb.ErrorCode_UnexpectedError, false, false)
 
 	ErrCollectionNotFound       = newRPCError("collection not found", 100, commonpb.ErrorCode_CollectionNotExists, false, false)
 	ErrCollectionSchemaMismatch = newRPCError("collection schema mismatch", 109, commonpb.ErrorCode_SchemaMismatch, false, true)
 	ErrIndexNotFound            = newRPCError("index not found", 700, commonpb.ErrorCode_IndexNotExist, false, false)
 	ErrParameterInvalid         = newRPCError("invalid parameter", 1100, commonpb.ErrorCode_IllegalArgument, false, true)
+	ErrParameterMissing         = newRPCError("missing required parameters", 1101, commonpb.ErrorCode_IllegalArgument, false, true)
 
 	errUnexpected = newRPCError("unexpected error", unexpectedCode, commonpb.ErrorCode_UnexpectedError, false, false)
 )
@@ -326,4 +328,18 @@ func WrapErrParameterInvalid[T any](expected, actual T, messages ...string) erro
 		message = strings.Join(messages, "->") + ": " + message
 	}
 	return cloneWithMessage(ErrParameterInvalid, message)
+}
+
+func WrapErrParameterInvalidMsg(format string, args ...any) error {
+	return cloneWithMessage(ErrParameterInvalid, fmt.Sprintf(format, args...))
+}
+
+// WrapErrParameterInvalidErr reclassifies err as ErrParameterInvalid and only
+// retains the original error text, not its identity or code.
+func WrapErrParameterInvalidErr(err error, message string) error {
+	return cloneWithMessage(ErrParameterInvalid, message+": "+err.Error())
+}
+
+func WrapErrParameterMissingMsg(format string, args ...any) error {
+	return cloneWithMessage(ErrParameterMissing, fmt.Sprintf(format, args...))
 }

--- a/client/internal/merr/merr_test.go
+++ b/client/internal/merr/merr_test.go
@@ -127,6 +127,28 @@ func TestContextCodes(t *testing.T) {
 	require.Equal(t, TimeoutCode, Code(context.DeadlineExceeded))
 }
 
+func TestParameterMissing(t *testing.T) {
+	err := WrapErrParameterMissingMsg("collection name is required")
+	require.ErrorIs(t, err, ErrParameterMissing)
+	require.Equal(t, int32(1101), Code(err))
+	require.Equal(t, commonpb.ErrorCode_IllegalArgument, Status(err).GetErrorCode())
+}
+
+func TestParameterInvalidWrappers(t *testing.T) {
+	t.Run("message", func(t *testing.T) {
+		err := WrapErrParameterInvalidMsg("invalid field %q", "vector")
+		require.ErrorIs(t, err, ErrParameterInvalid)
+		require.Equal(t, int32(1100), Code(err))
+		require.Contains(t, err.Error(), `invalid field "vector"`)
+	})
+
+	t.Run("cause text", func(t *testing.T) {
+		err := WrapErrParameterInvalidErr(errors.New("invalid character"), "invalid legacy params")
+		require.ErrorIs(t, err, ErrParameterInvalid)
+		require.Contains(t, err.Error(), "invalid legacy params: invalid character")
+	})
+}
+
 func TestCheckRPCCall(t *testing.T) {
 	transportErr := errors.New("transport")
 	require.ErrorIs(t, CheckRPCCall(nil, transportErr), transportErr)

--- a/client/milvusclient/collection.go
+++ b/client/milvusclient/collection.go
@@ -21,8 +21,12 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/client/v3/entity"
 	"github.com/milvus-io/milvus/client/v3/internal/merr"
 )
@@ -197,6 +201,30 @@ func (c *Client) GetCollectionStats(ctx context.Context, opt GetCollectionOption
 	return stats, nil
 }
 
+func (c *Client) alterCollectionSchemaRequest(ctx context.Context, req *milvuspb.AlterCollectionSchemaRequest, callOpts ...grpc.CallOption) error {
+	return c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
+		resp, err := milvusService.AlterCollectionSchema(ctx, req, callOpts...)
+		if resp == nil || resp.GetAlterStatus() == nil {
+			return merr.CheckRPCCall(nil, err)
+		}
+		if err := merr.CheckRPCCall(resp.GetAlterStatus(), err); err != nil {
+			return err
+		}
+		c.collCache.Evict(req.GetCollectionName())
+		return nil
+	})
+}
+
+func (c *Client) alterCollectionSchema(ctx context.Context, opt alterCollectionSchemaOption, callOpts ...grpc.CallOption) error {
+	if opt == nil {
+		return merr.WrapErrParameterMissingMsg("alter collection schema option is nil")
+	}
+	if err := opt.Validate(); err != nil {
+		return err
+	}
+	return c.alterCollectionSchemaRequest(ctx, opt.Request(), callOpts...)
+}
+
 // AddCollectionField adds a field to a collection.
 func (c *Client) AddCollectionField(ctx context.Context, opt AddCollectionFieldOption, callOpts ...grpc.CallOption) error {
 	if err := opt.Validate(); err != nil {
@@ -204,12 +232,42 @@ func (c *Client) AddCollectionField(ctx context.Context, opt AddCollectionFieldO
 	}
 
 	req := opt.Request()
+	fieldSchema := &schemapb.FieldSchema{}
+	if err := proto.Unmarshal(req.GetSchema(), fieldSchema); err != nil {
+		return merr.WrapErrParameterInvalidErr(err, "invalid field schema")
+	}
 
-	err := c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
+	alterReq := newAlterCollectionSchemaAddRequest(req.GetCollectionName(), fieldSchema, nil)
+	alterReq.DbName = req.GetDbName()
+	alterReq.CollectionID = req.GetCollectionID()
+	err := c.alterCollectionSchemaRequest(ctx, alterReq, callOpts...)
+	if grpcstatus.Code(err) != codes.Unimplemented && !errors.Is(err, merr.ErrServiceUnimplemented) {
+		return err
+	}
+
+	return c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
 		resp, err := milvusService.AddCollectionField(ctx, req, callOpts...)
-		return merr.CheckRPCCall(resp, err)
+		if err := merr.CheckRPCCall(resp, err); err != nil {
+			return err
+		}
+		c.collCache.Evict(req.GetCollectionName())
+		return nil
 	})
-	return err
+}
+
+// AddFunctionField adds a function and its output field to a collection.
+func (c *Client) AddFunctionField(ctx context.Context, opt AddFunctionFieldOption, callOpts ...grpc.CallOption) error {
+	return c.alterCollectionSchema(ctx, opt, callOpts...)
+}
+
+// DropCollectionField drops a field from a collection.
+func (c *Client) DropCollectionField(ctx context.Context, opt DropCollectionFieldOption, callOpts ...grpc.CallOption) error {
+	return c.alterCollectionSchema(ctx, opt, callOpts...)
+}
+
+// DropFunctionField drops a function and its output field from a collection.
+func (c *Client) DropFunctionField(ctx context.Context, opt DropFunctionFieldOption, callOpts ...grpc.CallOption) error {
+	return c.alterCollectionSchema(ctx, opt, callOpts...)
 }
 
 // AddCollectionStructField adds a struct array field to a collection.

--- a/client/milvusclient/collection_options.go
+++ b/client/milvusclient/collection_options.go
@@ -17,14 +17,18 @@
 package milvusclient
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/samber/lo"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/client/v3/entity"
 	"github.com/milvus-io/milvus/client/v3/index"
+	"github.com/milvus-io/milvus/client/v3/internal/merr"
 )
 
 // CreateCollectionOption is the interface builds CreateCollectionRequest.
@@ -429,6 +433,228 @@ func (opt *getCollectionStatsOption) Request() *milvuspb.GetCollectionStatistics
 
 func NewGetCollectionStatsOption(collectionName string) *getCollectionStatsOption {
 	return &getCollectionStatsOption{collectionName: collectionName}
+}
+
+type alterCollectionSchemaOption interface {
+	Request() *milvuspb.AlterCollectionSchemaRequest
+	Validate() error
+}
+
+func newAlterCollectionSchemaAddRequest(collectionName string, field *schemapb.FieldSchema, function *schemapb.FunctionSchema) *milvuspb.AlterCollectionSchemaRequest {
+	addRequest := &milvuspb.AlterCollectionSchemaRequest_AddRequest{}
+	if field != nil {
+		addRequest.FieldInfos = []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{{FieldSchema: field}}
+	}
+	if function != nil {
+		addRequest.FuncSchema = []*schemapb.FunctionSchema{function}
+	}
+	return &milvuspb.AlterCollectionSchemaRequest{
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{AddRequest: addRequest},
+		},
+	}
+}
+
+func newAlterCollectionSchemaDropRequest(collectionName string, dropRequest *milvuspb.AlterCollectionSchemaRequest_DropRequest) *milvuspb.AlterCollectionSchemaRequest {
+	return &milvuspb.AlterCollectionSchemaRequest{
+		CollectionName: collectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_DropRequest{DropRequest: dropRequest},
+		},
+	}
+}
+
+type AddFunctionFieldOption interface {
+	alterCollectionSchemaOption
+	isAddFunctionFieldOption()
+}
+
+type addFunctionFieldOption struct {
+	collectionName string
+	fieldSch       *entity.Field
+	function       *entity.Function
+	boundIndex     index.Index
+	indexName      string
+}
+
+func (*addFunctionFieldOption) isAddFunctionFieldOption() {}
+
+func (opt *addFunctionFieldOption) Request() *milvuspb.AlterCollectionSchemaRequest {
+	req := newAlterCollectionSchemaAddRequest(opt.collectionName, opt.fieldSch.ProtoMessage(), opt.function.ProtoMessage())
+	fieldInfo := req.GetAction().GetAddRequest().GetFieldInfos()[0]
+	fieldInfo.IndexName = opt.indexName
+	fieldInfo.ExtraParams = entity.MapKvPairs(opt.boundIndex.Params())
+	return req
+}
+
+func getBoundIndexType(params map[string]string) (string, error) {
+	indexType := params[index.IndexTypeKey]
+	legacyParams, hasLegacyParams := params[index.ParamsKey]
+	if !hasLegacyParams {
+		return indexType, nil
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(legacyParams), &decoded); err != nil {
+		return "", merr.WrapErrParameterInvalidErr(err, "invalid legacy bound index params")
+	}
+	legacyIndexType := ""
+	if rawIndexType, ok := decoded[index.IndexTypeKey]; ok {
+		var valid bool
+		legacyIndexType, valid = rawIndexType.(string)
+		if !valid || legacyIndexType == "" {
+			return "", merr.WrapErrParameterInvalidMsg("legacy bound index param %q must be a non-empty string", index.IndexTypeKey)
+		}
+	}
+	for key := range decoded {
+		if _, duplicated := params[key]; duplicated {
+			return "", merr.WrapErrParameterInvalidMsg("duplicated bound index param %q", key)
+		}
+	}
+	if indexType == "" {
+		indexType = legacyIndexType
+	}
+	return indexType, nil
+}
+
+func (opt *addFunctionFieldOption) Validate() error {
+	if opt == nil {
+		return merr.WrapErrParameterMissingMsg("add function field option is nil")
+	}
+	if opt.collectionName == "" {
+		return merr.WrapErrParameterMissingMsg("collection name is required")
+	}
+	if opt.fieldSch == nil {
+		return merr.WrapErrParameterMissingMsg("field schema is required")
+	}
+	if opt.fieldSch.Name == "" {
+		return merr.WrapErrParameterMissingMsg("field name is required")
+	}
+	if opt.function == nil {
+		return merr.WrapErrParameterMissingMsg("function schema is required")
+	}
+	if opt.function.Name == "" {
+		return merr.WrapErrParameterMissingMsg("function name is required")
+	}
+	switch opt.function.Type {
+	case entity.FunctionTypeBM25:
+		if opt.fieldSch.DataType != entity.FieldTypeSparseVector {
+			return merr.WrapErrParameterInvalidMsg("add function field requires SparseFloatVector output field for BM25, got %s", opt.fieldSch.DataType.String())
+		}
+	case entity.FunctionTypeMinHash:
+		if opt.fieldSch.DataType != entity.FieldTypeBinaryVector {
+			return merr.WrapErrParameterInvalidMsg("add function field requires BinaryVector output field for MinHash, got %s", opt.fieldSch.DataType.String())
+		}
+	default:
+		return merr.WrapErrParameterInvalidMsg("add function field only supports BM25 and MinHash, got %s", opt.function.Type.String())
+	}
+	if lo.IsNil(opt.boundIndex) {
+		return merr.WrapErrParameterMissingMsg("bound index option is required")
+	}
+	indexType, err := getBoundIndexType(opt.boundIndex.Params())
+	if err != nil {
+		return err
+	}
+	if indexType == "" {
+		return merr.WrapErrParameterMissingMsg("explicit index type is required for the bound index")
+	}
+	return nil
+}
+
+func (opt *addFunctionFieldOption) WithIndexName(indexName string) *addFunctionFieldOption {
+	opt.indexName = indexName
+	return opt
+}
+
+func NewAddFunctionFieldOption(collectionName string, field *entity.Field, function *entity.Function, boundIndex index.Index) *addFunctionFieldOption {
+	return &addFunctionFieldOption{collectionName: collectionName, fieldSch: field, function: function, boundIndex: boundIndex}
+}
+
+type DropCollectionFieldOption interface {
+	alterCollectionSchemaOption
+	isDropCollectionFieldOption()
+}
+
+type dropCollectionFieldOption struct {
+	collectionName string
+	fieldName      string
+	fieldID        int64
+	byID           bool
+}
+
+func (*dropCollectionFieldOption) isDropCollectionFieldOption() {}
+
+func (opt *dropCollectionFieldOption) Request() *milvuspb.AlterCollectionSchemaRequest {
+	dropRequest := &milvuspb.AlterCollectionSchemaRequest_DropRequest{}
+	if opt.byID {
+		dropRequest.Identifier = &milvuspb.AlterCollectionSchemaRequest_DropRequest_FieldId{FieldId: opt.fieldID}
+	} else {
+		dropRequest.Identifier = &milvuspb.AlterCollectionSchemaRequest_DropRequest_FieldName{FieldName: opt.fieldName}
+	}
+	return newAlterCollectionSchemaDropRequest(opt.collectionName, dropRequest)
+}
+
+func (opt *dropCollectionFieldOption) Validate() error {
+	if opt == nil {
+		return merr.WrapErrParameterMissingMsg("drop collection field option is nil")
+	}
+	if opt.collectionName == "" {
+		return merr.WrapErrParameterMissingMsg("collection name is required")
+	}
+	if opt.byID {
+		if opt.fieldID <= 0 {
+			return merr.WrapErrParameterInvalidMsg("field id must be greater than 0")
+		}
+		return nil
+	}
+	if opt.fieldName == "" {
+		return merr.WrapErrParameterMissingMsg("field name is required")
+	}
+	return nil
+}
+
+func NewDropCollectionFieldOption(collectionName, fieldName string) *dropCollectionFieldOption {
+	return &dropCollectionFieldOption{collectionName: collectionName, fieldName: fieldName}
+}
+
+func NewDropCollectionFieldByIDOption(collectionName string, fieldID int64) *dropCollectionFieldOption {
+	return &dropCollectionFieldOption{collectionName: collectionName, fieldID: fieldID, byID: true}
+}
+
+type DropFunctionFieldOption interface {
+	alterCollectionSchemaOption
+	isDropFunctionFieldOption()
+}
+
+type dropFunctionFieldOption struct {
+	collectionName string
+	functionName   string
+}
+
+func (*dropFunctionFieldOption) isDropFunctionFieldOption() {}
+
+func (opt *dropFunctionFieldOption) Request() *milvuspb.AlterCollectionSchemaRequest {
+	return newAlterCollectionSchemaDropRequest(opt.collectionName, &milvuspb.AlterCollectionSchemaRequest_DropRequest{
+		Identifier:               &milvuspb.AlterCollectionSchemaRequest_DropRequest_FunctionName{FunctionName: opt.functionName},
+		DropFunctionOutputFields: true,
+	})
+}
+
+func (opt *dropFunctionFieldOption) Validate() error {
+	if opt == nil {
+		return merr.WrapErrParameterMissingMsg("drop function field option is nil")
+	}
+	if opt.collectionName == "" {
+		return merr.WrapErrParameterMissingMsg("collection name is required")
+	}
+	if opt.functionName == "" {
+		return merr.WrapErrParameterMissingMsg("function name is required")
+	}
+	return nil
+}
+
+func NewDropFunctionFieldOption(collectionName, functionName string) *dropFunctionFieldOption {
+	return &dropFunctionFieldOption{collectionName: collectionName, functionName: functionName}
 }
 
 type AddCollectionFieldOption interface {

--- a/client/milvusclient/collection_options_test.go
+++ b/client/milvusclient/collection_options_test.go
@@ -1,0 +1,205 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v3/entity"
+	"github.com/milvus-io/milvus/client/v3/index"
+	"github.com/milvus-io/milvus/client/v3/internal/merr"
+)
+
+func TestGetBoundIndexType(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   map[string]string
+		expected string
+		errText  string
+	}{
+		{
+			name:     "top level index type",
+			params:   map[string]string{index.IndexTypeKey: string(index.SparseInverted)},
+			expected: string(index.SparseInverted),
+		},
+		{
+			name:   "no index type",
+			params: map[string]string{},
+		},
+		{
+			name:     "legacy index type",
+			params:   map[string]string{index.ParamsKey: `{"index_type":"SPARSE_WAND","drop_ratio_build":0.2}`},
+			expected: string(index.SparseWAND),
+		},
+		{
+			name:    "invalid legacy json",
+			params:  map[string]string{index.ParamsKey: "{"},
+			errText: "invalid legacy bound index params",
+		},
+		{
+			name:    "legacy index type is not a string",
+			params:  map[string]string{index.ParamsKey: `{"index_type":42}`},
+			errText: `legacy bound index param "index_type" must be a non-empty string`,
+		},
+		{
+			name:    "legacy index type is empty",
+			params:  map[string]string{index.ParamsKey: `{"index_type":""}`},
+			errText: `legacy bound index param "index_type" must be a non-empty string`,
+		},
+		{
+			name: "duplicated index type",
+			params: map[string]string{
+				index.IndexTypeKey: string(index.SparseInverted),
+				index.ParamsKey:    `{"index_type":"SPARSE_WAND"}`,
+			},
+			errText: `duplicated bound index param "index_type"`,
+		},
+		{
+			name: "duplicated extra param",
+			params: map[string]string{
+				"drop_ratio_build": "0.1",
+				index.ParamsKey:    `{"drop_ratio_build":0.2}`,
+			},
+			errText: `duplicated bound index param "drop_ratio_build"`,
+		},
+		{
+			name: "top level index type with legacy extras",
+			params: map[string]string{
+				index.IndexTypeKey: string(index.SparseInverted),
+				index.ParamsKey:    `{"drop_ratio_build":0.2}`,
+			},
+			expected: string(index.SparseInverted),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := getBoundIndexType(test.params)
+			if test.errText != "" {
+				require.ErrorContains(t, err, test.errText)
+				require.ErrorIs(t, err, merr.ErrParameterInvalid)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestAddFunctionFieldOptionValidate(t *testing.T) {
+	sparseField := func() *entity.Field {
+		return entity.NewField().WithName("sparse").WithDataType(entity.FieldTypeSparseVector)
+	}
+	binaryField := func() *entity.Field {
+		return entity.NewField().WithName("minhash").WithDataType(entity.FieldTypeBinaryVector)
+	}
+	function := func(name string, functionType entity.FunctionType) *entity.Function {
+		return entity.NewFunction().WithName(name).WithType(functionType)
+	}
+	sparseIndex := func() index.Index {
+		return index.NewSparseInvertedIndex(entity.BM25, 0.2)
+	}
+
+	invalidLegacyIndex := index.NewGenericIndex("", map[string]string{index.ParamsKey: "{"})
+	missingTypeIndex := index.NewGenericIndex("", map[string]string{index.MetricTypeKey: string(entity.BM25)})
+	var nilOption *addFunctionFieldOption
+	tests := []struct {
+		name   string
+		option *addFunctionFieldOption
+		target error
+	}{
+		{name: "nil option", option: nilOption, target: merr.ErrParameterMissing},
+		{name: "missing collection name", option: NewAddFunctionFieldOption("", sparseField(), function("bm25", entity.FunctionTypeBM25), sparseIndex()), target: merr.ErrParameterMissing},
+		{name: "missing field schema", option: NewAddFunctionFieldOption("coll", nil, function("bm25", entity.FunctionTypeBM25), sparseIndex()), target: merr.ErrParameterMissing},
+		{name: "missing field name", option: NewAddFunctionFieldOption("coll", entity.NewField().WithDataType(entity.FieldTypeSparseVector), function("bm25", entity.FunctionTypeBM25), sparseIndex()), target: merr.ErrParameterMissing},
+		{name: "missing function schema", option: NewAddFunctionFieldOption("coll", sparseField(), nil, sparseIndex()), target: merr.ErrParameterMissing},
+		{name: "missing function name", option: NewAddFunctionFieldOption("coll", sparseField(), function("", entity.FunctionTypeBM25), sparseIndex()), target: merr.ErrParameterMissing},
+		{name: "invalid BM25 output", option: NewAddFunctionFieldOption("coll", binaryField(), function("bm25", entity.FunctionTypeBM25), sparseIndex()), target: merr.ErrParameterInvalid},
+		{name: "invalid MinHash output", option: NewAddFunctionFieldOption("coll", sparseField(), function("minhash", entity.FunctionTypeMinHash), index.NewMinHashLSHIndex(entity.JACCARD, 32)), target: merr.ErrParameterInvalid},
+		{name: "unsupported function", option: NewAddFunctionFieldOption("coll", sparseField(), function("embedding", entity.FunctionTypeTextEmbedding), sparseIndex()), target: merr.ErrParameterInvalid},
+		{name: "missing bound index", option: NewAddFunctionFieldOption("coll", sparseField(), function("bm25", entity.FunctionTypeBM25), nil), target: merr.ErrParameterMissing},
+		{name: "invalid legacy bound index", option: NewAddFunctionFieldOption("coll", sparseField(), function("bm25", entity.FunctionTypeBM25), invalidLegacyIndex), target: merr.ErrParameterInvalid},
+		{name: "missing explicit index type", option: NewAddFunctionFieldOption("coll", sparseField(), function("bm25", entity.FunctionTypeBM25), missingTypeIndex), target: merr.ErrParameterMissing},
+		{name: "valid BM25", option: NewAddFunctionFieldOption("coll", sparseField(), function("bm25", entity.FunctionTypeBM25), sparseIndex())},
+		{name: "valid MinHash", option: NewAddFunctionFieldOption("coll", binaryField(), function("minhash", entity.FunctionTypeMinHash), index.NewMinHashLSHIndex(entity.JACCARD, 32))},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.option.Validate()
+			if test.target != nil {
+				require.ErrorIs(t, err, test.target)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestDropCollectionFieldOptionValidate(t *testing.T) {
+	var nilOption *dropCollectionFieldOption
+	tests := []struct {
+		name   string
+		option *dropCollectionFieldOption
+		target error
+	}{
+		{name: "nil option", option: nilOption, target: merr.ErrParameterMissing},
+		{name: "missing collection name", option: NewDropCollectionFieldOption("", "field"), target: merr.ErrParameterMissing},
+		{name: "invalid field id", option: NewDropCollectionFieldByIDOption("coll", 0), target: merr.ErrParameterInvalid},
+		{name: "missing field name", option: NewDropCollectionFieldOption("coll", ""), target: merr.ErrParameterMissing},
+		{name: "valid field name", option: NewDropCollectionFieldOption("coll", "field")},
+		{name: "valid field id", option: NewDropCollectionFieldByIDOption("coll", 101)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.option.Validate()
+			if test.target != nil {
+				require.ErrorIs(t, err, test.target)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestDropFunctionFieldOptionValidate(t *testing.T) {
+	var nilOption *dropFunctionFieldOption
+	tests := []struct {
+		name   string
+		option *dropFunctionFieldOption
+		target error
+	}{
+		{name: "nil option", option: nilOption, target: merr.ErrParameterMissing},
+		{name: "missing collection name", option: NewDropFunctionFieldOption("", "bm25"), target: merr.ErrParameterMissing},
+		{name: "missing function name", option: NewDropFunctionFieldOption("coll", ""), target: merr.ErrParameterMissing},
+		{name: "valid", option: NewDropFunctionFieldOption("coll", "bm25")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.option.Validate()
+			if test.target != nil {
+				require.ErrorIs(t, err, test.target)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/client/milvusclient/collection_test.go
+++ b/client/milvusclient/collection_test.go
@@ -25,6 +25,10 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -32,11 +36,37 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/client/v3/common"
 	"github.com/milvus-io/milvus/client/v3/entity"
+	"github.com/milvus-io/milvus/client/v3/index"
 	"github.com/milvus-io/milvus/client/v3/internal/merr"
 )
 
 type CollectionSuite struct {
 	MockSuiteBase
+}
+
+type malformedAddCollectionFieldOption struct{}
+
+func (malformedAddCollectionFieldOption) Request() *milvuspb.AddCollectionFieldRequest {
+	return &milvuspb.AddCollectionFieldRequest{
+		CollectionName: "coll",
+		Schema:         []byte{0xff},
+	}
+}
+
+func (malformedAddCollectionFieldOption) Validate() error {
+	return nil
+}
+
+type staticAddCollectionFieldOption struct {
+	req *milvuspb.AddCollectionFieldRequest
+}
+
+func (opt staticAddCollectionFieldOption) Request() *milvuspb.AddCollectionFieldRequest {
+	return opt.req
+}
+
+func (staticAddCollectionFieldOption) Validate() error {
+	return nil
 }
 
 func (s *CollectionSuite) TestListCollection() {
@@ -435,14 +465,17 @@ func (s *CollectionSuite) TestAddCollectionField() {
 	s.Run("success", func() {
 		collName := fmt.Sprintf("coll_%s", s.randString(6))
 		fieldName := fmt.Sprintf("field_%s", s.randString(6))
-		s.mock.EXPECT().AddCollectionField(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, acfr *milvuspb.AddCollectionFieldRequest) (*commonpb.Status, error) {
-			fieldProto := &schemapb.FieldSchema{}
-			err := proto.Unmarshal(acfr.GetSchema(), fieldProto)
-			s.Require().NoError(err)
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *milvuspb.AlterCollectionSchemaRequest) (*milvuspb.AlterCollectionSchemaResponse, error) {
+			s.Equal(collName, req.GetCollectionName())
+			addRequest := req.GetAction().GetAddRequest()
+			s.Require().Len(addRequest.GetFieldInfos(), 1)
+			s.Empty(addRequest.GetFuncSchema())
+			fieldProto := addRequest.GetFieldInfos()[0].GetFieldSchema()
+			s.Require().NotNil(fieldProto)
 			s.Equal(fieldName, fieldProto.GetName())
 			s.Equal(schemapb.DataType_Int64, fieldProto.GetDataType())
 			s.True(fieldProto.GetNullable())
-			return merr.Success(), nil
+			return &milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}, nil
 		}).Once()
 
 		field := entity.NewField().WithName(fieldName).WithDataType(entity.FieldTypeInt64).WithNullable(true)
@@ -454,12 +487,89 @@ func (s *CollectionSuite) TestAddCollectionField() {
 	s.Run("failure", func() {
 		collName := fmt.Sprintf("coll_%s", s.randString(6))
 		fieldName := fmt.Sprintf("field_%s", s.randString(6))
-		s.mock.EXPECT().AddCollectionField(mock.Anything, mock.Anything).Return(merr.Status(errors.New("mocked")), nil).Once()
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(&milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(errors.New("mocked")),
+		}, nil).Once()
 
 		field := entity.NewField().WithName(fieldName).WithDataType(entity.FieldTypeInt64).WithNullable(true)
 
 		err := s.client.AddCollectionField(ctx, NewAddCollectionFieldOption(collName, field))
 		s.Error(err)
+	})
+
+	s.Run("fallback_to_legacy_rpc", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		fieldName := fmt.Sprintf("field_%s", s.randString(6))
+		field := entity.NewField().WithName(fieldName).WithDataType(entity.FieldTypeInt64).WithNullable(true)
+		fieldSchema, err := proto.Marshal(field.ProtoMessage())
+		s.Require().NoError(err)
+		option := staticAddCollectionFieldOption{req: &milvuspb.AddCollectionFieldRequest{
+			DbName:         "fallback_db",
+			CollectionName: collName,
+			CollectionID:   100,
+			Schema:         fieldSchema,
+		}}
+		s.setupCache(collName, entity.NewSchema().WithName(collName))
+
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.MatchedBy(func(req *milvuspb.AlterCollectionSchemaRequest) bool {
+			return req.GetDbName() == "fallback_db" &&
+				req.GetCollectionName() == collName &&
+				req.GetCollectionID() == 100
+		})).Return(nil, grpcstatus.Error(codes.Unimplemented, "method not implemented")).Once()
+		s.mock.EXPECT().AddCollectionField(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *milvuspb.AddCollectionFieldRequest) (*commonpb.Status, error) {
+			s.True(proto.Equal(option.req, req))
+			s.Require().NoError(grpc.SetHeader(ctx, metadata.Pairs("fallback-rpc", "legacy")))
+			return merr.Success(), nil
+		}).Once()
+
+		var header metadata.MD
+		s.NoError(s.client.AddCollectionField(ctx, option, grpc.Header(&header)))
+		s.Equal([]string{"legacy"}, header.Get("fallback-rpc"))
+		_, cached := s.client.collCache.collections.Get(collName)
+		s.False(cached)
+	})
+
+	s.Run("fallback_to_legacy_rpc_on_business_unimplemented", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		fieldName := fmt.Sprintf("field_%s", s.randString(6))
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(&milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: &commonpb.Status{
+				Code:      10,
+				ErrorCode: commonpb.ErrorCode_UnexpectedError,
+				Reason:    "service unimplemented",
+			},
+		}, nil).Once()
+		s.mock.EXPECT().AddCollectionField(mock.Anything, mock.Anything).Return(merr.Success(), nil).Once()
+
+		field := entity.NewField().WithName(fieldName).WithDataType(entity.FieldTypeInt64).WithNullable(true)
+		s.NoError(s.client.AddCollectionField(ctx, NewAddCollectionFieldOption(collName, field)))
+	})
+
+	s.Run("non_unimplemented_error_does_not_fallback", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		fieldName := fmt.Sprintf("field_%s", s.randString(6))
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).
+			Return(nil, grpcstatus.Error(codes.PermissionDenied, "permission denied")).Once()
+
+		field := entity.NewField().WithName(fieldName).WithDataType(entity.FieldTypeInt64).WithNullable(true)
+		err := s.client.AddCollectionField(ctx, NewAddCollectionFieldOption(collName, field))
+		s.Equal(codes.PermissionDenied, grpcstatus.Code(err))
+	})
+
+	s.Run("legacy_rpc_error", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		fieldName := fmt.Sprintf("field_%s", s.randString(6))
+		s.setupCache(collName, entity.NewSchema().WithName(collName))
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).
+			Return(nil, grpcstatus.Error(codes.Unimplemented, "method not implemented")).Once()
+		s.mock.EXPECT().AddCollectionField(mock.Anything, mock.Anything).
+			Return(merr.Status(merr.WrapErrParameterInvalidMsg("legacy add field failed")), nil).Once()
+
+		field := entity.NewField().WithName(fieldName).WithDataType(entity.FieldTypeInt64).WithNullable(true)
+		err := s.client.AddCollectionField(ctx, NewAddCollectionFieldOption(collName, field))
+		s.ErrorIs(err, merr.ErrParameterInvalid)
+		_, cached := s.client.collCache.collections.Get(collName)
+		s.True(cached)
 	})
 
 	s.Run("vector_field_without_nullable", func() {
@@ -477,20 +587,27 @@ func (s *CollectionSuite) TestAddCollectionField() {
 	s.Run("vector_field_with_nullable", func() {
 		collName := fmt.Sprintf("coll_%s", s.randString(6))
 		fieldName := fmt.Sprintf("field_%s", s.randString(6))
-		s.mock.EXPECT().AddCollectionField(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, acfr *milvuspb.AddCollectionFieldRequest) (*commonpb.Status, error) {
-			fieldProto := &schemapb.FieldSchema{}
-			err := proto.Unmarshal(acfr.GetSchema(), fieldProto)
-			s.Require().NoError(err)
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *milvuspb.AlterCollectionSchemaRequest) (*milvuspb.AlterCollectionSchemaResponse, error) {
+			addRequest := req.GetAction().GetAddRequest()
+			s.Require().Len(addRequest.GetFieldInfos(), 1)
+			s.Empty(addRequest.GetFuncSchema())
+			fieldProto := addRequest.GetFieldInfos()[0].GetFieldSchema()
+			s.Require().NotNil(fieldProto)
 			s.Equal(fieldName, fieldProto.GetName())
 			s.Equal(schemapb.DataType_FloatVector, fieldProto.GetDataType())
 			s.True(fieldProto.GetNullable())
-			return merr.Success(), nil
+			return &milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}, nil
 		}).Once()
 
 		field := entity.NewField().WithName(fieldName).WithDataType(entity.FieldTypeFloatVector).WithDim(128).WithNullable(true)
 
 		err := s.client.AddCollectionField(ctx, NewAddCollectionFieldOption(collName, field))
 		s.NoError(err)
+	})
+
+	s.Run("malformed_field_schema", func() {
+		err := s.client.AddCollectionField(ctx, malformedAddCollectionFieldOption{})
+		s.ErrorIs(err, merr.ErrParameterInvalid)
 	})
 }
 
@@ -605,6 +722,99 @@ func (s *CollectionSuite) TestAddCollectionStructField() {
 		err := s.client.AddCollectionStructField(ctx, NewAddCollectionStructFieldOption(collName, field))
 		s.Error(err)
 		s.Contains(err.Error(), "must not be nullable")
+	})
+}
+
+func (s *CollectionSuite) TestAddFunctionField() {
+	ctx := context.Background()
+	field := entity.NewField().WithName("sparse").WithDataType(entity.FieldTypeSparseVector)
+	function := entity.NewFunction().
+		WithName("bm25").
+		WithType(entity.FunctionTypeBM25).
+		WithInputFields("text").
+		WithOutputFields("sparse")
+	boundIndex := index.NewSparseInvertedIndex(entity.BM25, 0.2)
+
+	s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.MatchedBy(func(req *milvuspb.AlterCollectionSchemaRequest) bool {
+		add := req.GetAction().GetAddRequest()
+		if req.GetCollectionName() != "coll" || len(add.GetFieldInfos()) != 1 || len(add.GetFuncSchema()) != 1 {
+			return false
+		}
+		fieldInfo := add.GetFieldInfos()[0]
+		params := entity.KvPairsMap(fieldInfo.GetExtraParams())
+		return fieldInfo.GetFieldSchema().GetName() == "sparse" &&
+			add.GetFuncSchema()[0].GetName() == "bm25" &&
+			params[index.IndexTypeKey] == string(index.SparseInverted)
+	})).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}, nil).Once()
+
+	err := s.client.AddFunctionField(ctx, NewAddFunctionFieldOption("coll", field, function, boundIndex).WithIndexName("sparse_idx"))
+	s.NoError(err)
+
+	err = s.client.AddFunctionField(ctx, NewAddFunctionFieldOption("coll", field, function, nil))
+	s.ErrorIs(err, merr.ErrParameterMissing)
+}
+
+func (s *CollectionSuite) TestDropCollectionField() {
+	ctx := context.Background()
+	s.Run("by_name", func() {
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.MatchedBy(func(req *milvuspb.AlterCollectionSchemaRequest) bool {
+			return req.GetAction().GetDropRequest().GetFieldName() == "field" && req.GetAction().GetDropRequest().GetFieldId() == 0
+		})).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}, nil).Once()
+		s.NoError(s.client.DropCollectionField(ctx, NewDropCollectionFieldOption("coll", "field")))
+	})
+
+	s.Run("by_id", func() {
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.MatchedBy(func(req *milvuspb.AlterCollectionSchemaRequest) bool {
+			return req.GetAction().GetDropRequest().GetFieldId() == 101 && req.GetAction().GetDropRequest().GetFieldName() == ""
+		})).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}, nil).Once()
+		s.NoError(s.client.DropCollectionField(ctx, NewDropCollectionFieldByIDOption("coll", 101)))
+	})
+
+	s.ErrorIs(s.client.DropCollectionField(ctx, NewDropCollectionFieldOption("coll", "")), merr.ErrParameterMissing)
+}
+
+func (s *CollectionSuite) TestDropFunctionField() {
+	ctx := context.Background()
+	s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.MatchedBy(func(req *milvuspb.AlterCollectionSchemaRequest) bool {
+		drop := req.GetAction().GetDropRequest()
+		return drop.GetFunctionName() == "bm25" && drop.GetDropFunctionOutputFields()
+	})).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}, nil).Once()
+
+	s.NoError(s.client.DropFunctionField(ctx, NewDropFunctionFieldOption("coll", "bm25")))
+}
+
+func (s *CollectionSuite) TestAlterCollectionSchemaErrors() {
+	ctx := context.Background()
+	option := NewDropCollectionFieldOption("coll", "field")
+
+	s.Run("nil option", func() {
+		var nilOption DropCollectionFieldOption
+		err := s.client.DropCollectionField(ctx, nilOption)
+		s.ErrorIs(err, merr.ErrParameterMissing)
+	})
+
+	s.Run("nil response", func() {
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(nil, nil).Once()
+		s.Error(s.client.DropCollectionField(ctx, option))
+	})
+
+	s.Run("nil alter status", func() {
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).
+			Return(&milvuspb.AlterCollectionSchemaResponse{}, nil).Once()
+		s.Error(s.client.DropCollectionField(ctx, option))
+	})
+
+	s.Run("transport error", func() {
+		transportErr := errors.New("transport")
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(nil, transportErr).Once()
+		s.ErrorContains(s.client.DropCollectionField(ctx, option), transportErr.Error())
+	})
+
+	s.Run("business error", func() {
+		s.mock.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(&milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(merr.WrapErrParameterInvalidMsg("invalid field")),
+		}, nil).Once()
+		s.ErrorIs(s.client.DropCollectionField(ctx, option), merr.ErrParameterInvalid)
 	})
 }
 

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -98,7 +98,8 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 	"/v2/vectordb/collections/flush":                "Flush",
 
 	"/v2/vectordb/collections/fields/alter_properties": "AlterCollectionField",
-	"/v2/vectordb/collections/fields/add":              "AddCollectionField",
+	"/v2/vectordb/collections/fields/add":              "AlterCollectionSchema",
+	"/v2/vectordb/collections/fields/drop":             "AlterCollectionSchema",
 	"/v2/vectordb/collections/struct_fields/add":       "AddCollectionStructField",
 
 	"/v2/vectordb/databases/create":           "CreateDatabase",
@@ -223,6 +224,7 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 
 	// /collections/fields/add
 	router.POST(CollectionFieldCategory+AddAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionFieldReqWithSchema{} }, wrapperTraceLog(h.addCollectionField))))
+	router.POST(CollectionFieldCategory+DropAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionDropField{} }, wrapperTraceLog(h.dropCollectionField))))
 	router.POST(CollectionStructFieldCategory+AddAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionFieldReqWithSchema{} }, wrapperTraceLog(h.addCollectionStructField))))
 
 	router.POST(DataBaseCategory+CreateAction, timeoutMiddleware(wrapperPost(func() any { return &DatabaseReqWithProperties{} }, wrapperTraceLog(h.createDatabase))))
@@ -441,13 +443,7 @@ func wrapperPost(newReq newReqFunc, v2 handlerFuncV2) gin.HandlerFunc {
 		// logged at Warn (actionable); input failures at Info (expected user
 		// mistakes — keeping them at Warn would spam the logs).
 		if label == metrics.FailSystemLabel || label == metrics.FailInputLabel {
-			var status *commonpb.Status
-			switch r := resp.(type) {
-			case interface{ GetStatus() *commonpb.Status }:
-				status = r.GetStatus()
-			case *commonpb.Status:
-				status = r
-			}
+			status, _ := requestutil.GetStatusFromResponse(resp)
 			errType := merr.SystemError
 			if label == metrics.FailInputLabel {
 				errType = merr.InputError
@@ -1282,22 +1278,71 @@ func (h *HandlersV2) addCollectionField(ctx context.Context, c *gin.Context, any
 		return nil, err
 	}
 
-	bs, err := proto.Marshal(schemaProto)
-	if err != nil {
-		return nil, err
-	}
-
-	req := &milvuspb.AddCollectionFieldRequest{
+	req := &milvuspb.AlterCollectionSchemaRequest{
 		DbName:         dbName,
 		CollectionName: httpReq.CollectionName,
-		Schema:         bs,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
+				AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
+					FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
+						{FieldSchema: schemaProto},
+					},
+				},
+			},
+		},
 	}
 
 	c.Set(ContextRequest, req)
-	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddCollectionField", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
-		return h.proxy.AddCollectionField(reqCtx, req.(*milvuspb.AddCollectionFieldRequest))
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		r, callErr := h.proxy.AlterCollectionSchema(reqCtx, req.(*milvuspb.AlterCollectionSchemaRequest))
+		if callErr == nil {
+			callErr = merr.Error(r.GetAlterStatus())
+		}
+		return r, callErr
 	})
 
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}
+
+func (h *HandlersV2) dropCollectionField(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*CollectionDropField)
+	hasFieldName := httpReq.FieldName != ""
+	hasFieldID := httpReq.FieldID != nil
+	if hasFieldName == hasFieldID {
+		err := merr.WrapErrParameterInvalidMsg("exactly one of fieldName or fieldId is required")
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
+	if hasFieldID && *httpReq.FieldID <= 0 {
+		err := merr.WrapErrParameterInvalidMsg("fieldId must be greater than 0")
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
+
+	dropRequest := &milvuspb.AlterCollectionSchemaRequest_DropRequest{}
+	if hasFieldName {
+		dropRequest.Identifier = &milvuspb.AlterCollectionSchemaRequest_DropRequest_FieldName{FieldName: httpReq.FieldName}
+	} else {
+		dropRequest.Identifier = &milvuspb.AlterCollectionSchemaRequest_DropRequest_FieldId{FieldId: *httpReq.FieldID}
+	}
+	req := &milvuspb.AlterCollectionSchemaRequest{
+		DbName:         dbName,
+		CollectionName: httpReq.CollectionName,
+		Action: &milvuspb.AlterCollectionSchemaRequest_Action{
+			Op: &milvuspb.AlterCollectionSchemaRequest_Action_DropRequest{DropRequest: dropRequest},
+		},
+	}
+	c.Set(ContextRequest, req)
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AlterCollectionSchema", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		r, callErr := h.proxy.AlterCollectionSchema(reqCtx, req.(*milvuspb.AlterCollectionSchemaRequest))
+		if callErr == nil {
+			callErr = merr.Error(r.GetAlterStatus())
+		}
+		return r, callErr
+	})
 	if err == nil {
 		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
 	}

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -4467,8 +4467,85 @@ func (s *AddCollectionFieldSuite) TestAddCollectionFieldNormal() {
 			requestBody: []byte(`{"collectionName": "book", "schema": {"fieldName": "new_field", "dataType": "Array", "elementDataType": "Int64", "nullable": true}}`),
 		},
 	}
-	s.mp.EXPECT().AddCollectionField(mock.Anything, mock.Anything).Return(merr.Success(), nil)
+	s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.MatchedBy(func(req *milvuspb.AlterCollectionSchemaRequest) bool {
+		addRequest := req.GetAction().GetAddRequest()
+		return req.GetDbName() == DefaultDbName &&
+			req.GetCollectionName() == "book" &&
+			len(addRequest.GetFieldInfos()) == 1 &&
+			addRequest.GetFieldInfos()[0].GetFieldSchema().GetName() == "new_field" &&
+			len(addRequest.GetFuncSchema()) == 0
+	})).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}, nil).Times(len(addFieldTestCases))
 	validateRequestBodyTestCases(s.T(), s.testEngine, addFieldTestCases, false)
+}
+
+func (s *AddCollectionFieldSuite) TestDropCollectionField() {
+	s.Run("field_name", func() {
+		s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.MatchedBy(func(req *milvuspb.AlterCollectionSchemaRequest) bool {
+			dropRequest := req.GetAction().GetDropRequest()
+			return req.GetDbName() == "db" && req.GetCollectionName() == "book" && dropRequest.GetFieldName() == "old_field"
+		})).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}, nil).Once()
+		validateRequestBodyTestCases(s.T(), s.testEngine, []requestBodyTestCase{
+			{
+				path:        versionalV2(CollectionFieldCategory, DropAction),
+				requestBody: []byte(`{"dbName":"db","collectionName":"book","fieldName":"old_field"}`),
+			},
+		}, false)
+	})
+
+	s.Run("field_id", func() {
+		s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.MatchedBy(func(req *milvuspb.AlterCollectionSchemaRequest) bool {
+			dropRequest := req.GetAction().GetDropRequest()
+			return req.GetDbName() == "db" && req.GetCollectionName() == "book" && dropRequest.GetFieldId() == 101
+		})).Return(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Success()}, nil).Once()
+		validateRequestBodyTestCases(s.T(), s.testEngine, []requestBodyTestCase{
+			{
+				path:        versionalV2(CollectionFieldCategory, DropAction),
+				requestBody: []byte(`{"dbName":"db","collectionName":"book","fieldId":101}`),
+			},
+		}, false)
+	})
+
+	s.Run("bad_request", func() {
+		dropFieldTestCases := []requestBodyTestCase{
+			{
+				path:        versionalV2(CollectionFieldCategory, DropAction),
+				requestBody: []byte(`{"dbName":"db","collectionName":"book"}`),
+				errCode:     1100,
+				errMsg:      "exactly one of fieldName or fieldId is required: invalid parameter",
+			},
+			{
+				path:        versionalV2(CollectionFieldCategory, DropAction),
+				requestBody: []byte(`{"dbName":"db","collectionName":"book","fieldName":"old_field","fieldId":101}`),
+				errCode:     1100,
+				errMsg:      "exactly one of fieldName or fieldId is required: invalid parameter",
+			},
+			{
+				path:        versionalV2(CollectionFieldCategory, DropAction),
+				requestBody: []byte(`{"dbName":"db","collectionName":"book","fieldId":0}`),
+				errCode:     1100,
+				errMsg:      "fieldId must be greater than 0: invalid parameter",
+			},
+		}
+		validateRequestBodyTestCases(s.T(), s.testEngine, dropFieldTestCases, false)
+	})
+}
+
+func (s *AddCollectionFieldSuite) TestDropCollectionFieldAlterStatusError() {
+	dropFieldTestCases := []requestBodyTestCase{
+		{
+			path:        versionalV2(CollectionFieldCategory, DropAction),
+			requestBody: []byte(`{"dbName":"db","collectionName":"book","fieldName":"server_error"}`),
+			errCode:     5,
+			errMsg:      "service internal error: mock error",
+		},
+	}
+	s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.MatchedBy(func(req *milvuspb.AlterCollectionSchemaRequest) bool {
+		return req.GetDbName() == "db" && req.GetCollectionName() == "book" && req.GetAction().GetDropRequest().GetFieldName() == "server_error"
+	})).Return(&milvuspb.AlterCollectionSchemaResponse{
+		AlterStatus: merr.Status(merr.WrapErrServiceInternal("mock error")),
+	}, nil).Once()
+
+	validateRequestBodyTestCases(s.T(), s.testEngine, dropFieldTestCases, false)
 }
 
 func (s *AddCollectionFieldSuite) TestAddCollectionStructFieldNormal() {
@@ -4686,7 +4763,9 @@ func (s *AddCollectionFieldSuite) TestAddCollectionFieldFail() {
 				errMsg:      "service internal error: mock error",
 			},
 		}
-		s.mp.EXPECT().AddCollectionField(mock.Anything, mock.Anything).Return(merr.Status(merr.WrapErrServiceInternal("mock error")), nil).Maybe()
+		s.mp.EXPECT().AlterCollectionSchema(mock.Anything, mock.Anything).Return(&milvuspb.AlterCollectionSchemaResponse{
+			AlterStatus: merr.Status(merr.WrapErrServiceInternal("mock error")),
+		}, nil).Once()
 
 		validateRequestBodyTestCases(s.T(), s.testEngine, addFieldTestCases, false)
 	})

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -249,6 +249,19 @@ type CollectionFieldReqWithParams struct {
 	FieldParams    map[string]interface{} `json:"fieldParams"`
 }
 
+type CollectionDropField struct {
+	DbName         string `json:"dbName"`
+	CollectionName string `json:"collectionName" binding:"required"`
+	FieldName      string `json:"fieldName"`
+	FieldID        *int64 `json:"fieldId"`
+}
+
+func (req *CollectionDropField) GetDbName() string { return req.DbName }
+
+func (req *CollectionDropField) GetCollectionName() string {
+	return req.CollectionName
+}
+
 func (req *CollectionFieldReqWithParams) GetDbName() string { return req.DbName }
 
 func (req *CollectionFieldReqWithParams) GetCollectionName() string {

--- a/internal/distributed/proxy/request_interceptor.go
+++ b/internal/distributed/proxy/request_interceptor.go
@@ -24,7 +24,6 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
@@ -82,13 +81,7 @@ func UnaryRequestStatsInterceptor(ctx context.Context, req any, rpcInfo *grpc.Un
 	// failures are logged at Warn (actionable for SRE); input failures at Info
 	// (expected user mistakes — keeping them at Warn would spam the logs).
 	if label == metrics.FailSystemLabel || label == metrics.FailInputLabel {
-		var status *commonpb.Status
-		switch r := resp.(type) {
-		case interface{ GetStatus() *commonpb.Status }:
-			status = r.GetStatus()
-		case *commonpb.Status:
-			status = r
-		}
+		status, _ := requestutil.GetStatusFromResponse(resp)
 		errType := merr.SystemError
 		if label == metrics.FailInputLabel {
 			errType = merr.InputError

--- a/pkg/util/requestutil/getter.go
+++ b/pkg/util/requestutil/getter.go
@@ -168,16 +168,26 @@ type StatusGetter interface {
 	GetStatus() *commonpb.Status
 }
 
+type AlterStatusGetter interface {
+	GetAlterStatus() *commonpb.Status
+}
+
 func GetStatusFromResponse(resp interface{}) (*commonpb.Status, bool) {
 	status, ok := resp.(*commonpb.Status)
 	if ok {
-		return status, true
+		return status, status != nil
 	}
 	getter, ok := resp.(StatusGetter)
-	if !ok {
-		return nil, false
+	if ok {
+		status := getter.GetStatus()
+		return status, status != nil
 	}
-	return getter.GetStatus(), true
+	alterGetter, ok := resp.(AlterStatusGetter)
+	if ok {
+		status := alterGetter.GetAlterStatus()
+		return status, status != nil
+	}
+	return nil, false
 }
 
 type ConsistencyLevelGetter interface {
@@ -243,13 +253,7 @@ func ParseMetricLabel(resp any, err error) string {
 	// wrappers reconstruct err = merr.Error(status) from that same response,
 	// which previously routed every processed REST failure into the rejected_*
 	// buckets and left the fail_* series blind to the entire REST surface.
-	var st *commonpb.Status
-	switch resp := resp.(type) {
-	case interface{ GetStatus() *commonpb.Status }:
-		st = resp.GetStatus()
-	case *commonpb.Status:
-		st = resp
-	}
+	st, _ := GetStatusFromResponse(resp)
 	if st != nil && !merr.Ok(st) {
 		// Client cancellation is neither party's failure.
 		if st.GetCode() == merr.CanceledCode {

--- a/pkg/util/requestutil/getter_test.go
+++ b/pkg/util/requestutil/getter_test.go
@@ -495,6 +495,48 @@ func TestGetStatusFromResponse(t *testing.T) {
 			want1: true,
 		},
 		{
+			name: "alter collection schema response",
+			args: args{
+				resp: &milvuspb.AlterCollectionSchemaResponse{
+					AlterStatus: &commonpb.Status{
+						ErrorCode: commonpb.ErrorCode_Success,
+					},
+				},
+			},
+			want: &commonpb.Status{
+				ErrorCode: commonpb.ErrorCode_Success,
+			},
+			want1: true,
+		},
+		{
+			name: "nil common status",
+			args: args{
+				resp: (*commonpb.Status)(nil),
+			},
+			want1: false,
+		},
+		{
+			name: "response with nil status",
+			args: args{
+				resp: &milvuspb.DescribeCollectionResponse{},
+			},
+			want1: false,
+		},
+		{
+			name: "alter response with nil status",
+			args: args{
+				resp: &milvuspb.AlterCollectionSchemaResponse{},
+			},
+			want1: false,
+		},
+		{
+			name: "typed nil alter response",
+			args: args{
+				resp: (*milvuspb.AlterCollectionSchemaResponse)(nil),
+			},
+			want1: false,
+		},
+		{
 			name: "invalid response",
 			args: args{
 				resp: "foo",
@@ -540,6 +582,13 @@ func TestParseMetricLabel(t *testing.T) {
 	// response that itself implements GetStatus
 	assert.Equal(t, metrics.FailInputLabel,
 		ParseMetricLabel(&milvuspb.BoolResponse{Status: merr.Status(inputErr)}, nil))
+
+	// AlterCollectionSchemaResponse reports the RPC status through AlterStatus.
+	assert.Equal(t, metrics.FailInputLabel,
+		ParseMetricLabel(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: merr.Status(inputErr)}, nil))
+	alterSys := merr.Status(merr.ErrSegcore)
+	assert.Equal(t, metrics.FailSystemLabel,
+		ParseMetricLabel(&milvuspb.AlterCollectionSchemaResponse{AlterStatus: alterSys}, merr.Error(alterSys)))
 
 	// merr input error through the err path (REST v2 handlers abort with merr
 	// directly; no GRPCStatus, so the gRPC switch alone would misbucket it as

--- a/tests/go_client/testcases/add_field_test.go
+++ b/tests/go_client/testcases/add_field_test.go
@@ -76,6 +76,72 @@ func TestAddCollectionField(t *testing.T) {
 	}
 }
 
+func TestAlterCollectionSchemaFunctionField(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	previousStorageV3, err := hp.AlterServerConfig("common.storage.useLoonFFI", "true")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = hp.AlterServerConfig("common.storage.useLoonFFI", previousStorageV3)
+	})
+
+	previousSchemaBump, err := hp.AlterServerConfig("dataCoord.compaction.bumpSchemaVersion.enabled", "true")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = hp.AlterServerConfig("dataCoord.compaction.bumpSchemaVersion.enabled", previousSchemaBump)
+	})
+
+	collectionName := common.GenRandomString("alter_function_field", 6)
+	schema := entity.NewSchema().
+		WithName(collectionName).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true).WithIsAutoID(true)).
+		WithField(entity.NewField().WithName("text").WithDataType(entity.FieldTypeVarChar).WithMaxLength(1024).WithEnableAnalyzer(true).WithAnalyzerParams(map[string]any{"tokenizer": "standard"})).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(8))
+	require.NoError(t, mc.CreateCollection(ctx, client.NewCreateCollectionOption(collectionName, schema)))
+
+	outputField := entity.NewField().WithName("sparse").WithDataType(entity.FieldTypeSparseVector)
+	function := entity.NewFunction().
+		WithName("bm25").
+		WithType(entity.FunctionTypeBM25).
+		WithInputFields("text").
+		WithOutputFields("sparse")
+	require.NoError(t, mc.AddFunctionField(ctx, client.NewAddFunctionFieldOption(collectionName, outputField, function, index.NewSparseInvertedIndex(entity.BM25, 0.2)).WithIndexName("sparse_idx")))
+
+	collection, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collectionName))
+	require.NoError(t, err)
+	require.Contains(t, mapFieldsByName(collection.Schema.Fields), "sparse")
+	require.Contains(t, mapFunctionsByName(collection.Schema.Functions), "bm25")
+
+	require.NoError(t, mc.DropFunctionField(ctx, client.NewDropFunctionFieldOption(collectionName, "bm25")))
+	collection, err = mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collectionName))
+	require.NoError(t, err)
+	require.NotContains(t, mapFieldsByName(collection.Schema.Fields), "sparse")
+	require.NotContains(t, mapFunctionsByName(collection.Schema.Functions), "bm25")
+
+	field := entity.NewField().WithName("status").WithDataType(entity.FieldTypeInt32).WithNullable(true)
+	require.NoError(t, mc.AddCollectionField(ctx, client.NewAddCollectionFieldOption(collectionName, field)))
+	require.NoError(t, mc.DropCollectionField(ctx, client.NewDropCollectionFieldOption(collectionName, "status")))
+	collection, err = mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collectionName))
+	require.NoError(t, err)
+	require.NotContains(t, mapFieldsByName(collection.Schema.Fields), "status")
+}
+
+func mapFieldsByName(fields []*entity.Field) map[string]*entity.Field {
+	result := make(map[string]*entity.Field, len(fields))
+	for _, field := range fields {
+		result[field.Name] = field
+	}
+	return result
+}
+
+func mapFunctionsByName(functions []*entity.Function) map[string]*entity.Function {
+	result := make(map[string]*entity.Function, len(functions))
+	for _, function := range functions {
+		result[function.Name] = function
+	}
+	return result
+}
+
 func TestAddCollectionStructField(t *testing.T) {
 	t.Parallel()
 

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -20,7 +20,10 @@ import (
 	miniogo "github.com/minio/minio-go/v7"
 	miniocreds "github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/client/v3/column"
 	"github.com/milvus-io/milvus/client/v3/entity"
 	"github.com/milvus-io/milvus/client/v3/index"
@@ -1551,7 +1554,21 @@ func TestRefreshExternalCollectionAfterAddColumnReturnsCorrectData(t *testing.T)
 		WithNullable(true).
 		WithExternalField("score")
 	err = mc.AddCollectionField(ctx, client.NewAddCollectionFieldOption(collName, scoreField))
-	common.CheckErr(t, err, true)
+	require.ErrorContains(t, err, "alter collection schema operation is not supported for external collection")
+
+	// Keep the server-side external add-field and refresh coverage on the legacy
+	// RPC. The public Go SDK routes AddCollectionField through AlterCollectionSchema,
+	// which intentionally rejects external collections.
+	fieldSchema, err := proto.Marshal(scoreField.ProtoMessage())
+	require.NoError(t, err)
+	status, err := mc.GetService().AddCollectionField(ctx, &milvuspb.AddCollectionFieldRequest{
+		CollectionName: collName,
+		Schema:         fieldSchema,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, commonpb.ErrorCode_Success, status.GetErrorCode(), status.GetReason())
+	require.Zero(t, status.GetCode(), status.GetReason())
 
 	described, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
 	common.CheckErr(t, err, true)

--- a/tests/restful_client_v2/api/milvus.py
+++ b/tests/restful_client_v2/api/milvus.py
@@ -544,6 +544,21 @@ class CollectionClient(Requests):
         response = self.post(url, headers=self.update_headers(), data=payload)
         return response.json()
 
+    def drop_field(self, collection_name, field_name=None, field_id=None, db_name="default"):
+        """Drop field by field name or field ID"""
+        url = f"{self.endpoint}/v2/vectordb/collections/fields/drop"
+        payload = {"collectionName": collection_name}
+        if field_name is not None:
+            payload["fieldName"] = field_name
+        if field_id is not None:
+            payload["fieldId"] = field_id
+        if self.db_name is not None:
+            payload["dbName"] = self.db_name
+        if db_name != "default":
+            payload["dbName"] = db_name
+        response = self.post(url, headers=self.update_headers(), data=payload)
+        return response.json()
+
     def add_struct_field(self, collection_name, field_params, db_name="default"):
         """Add struct field"""
         url = f"{self.endpoint}/v2/vectordb/collections/struct_fields/add"

--- a/tests/restful_client_v2/testcases/test_collection_operations.py
+++ b/tests/restful_client_v2/testcases/test_collection_operations.py
@@ -1933,6 +1933,53 @@ class TestCollectionAddField(TestBase):
         assert rsp["code"] == 0
         assert len(rsp["data"]) > 0
 
+    def test_drop_field_by_name_and_id(self):
+        name = gen_collection_name("drop_collection_field")
+        client = self.collection_client
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {"fieldName": "dense", "dataType": "FloatVector", "elementTypeParams": {"dim": "4"}},
+                ],
+            },
+            "indexParams": [
+                {"fieldName": "dense", "indexName": "dense_idx", "indexType": "AUTOINDEX", "metricType": "L2"}
+            ],
+        }
+        rsp = client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+
+        rsp = client.add_field(
+            name,
+            {
+                "fieldName": "tag",
+                "dataType": "VarChar",
+                "nullable": True,
+                "elementTypeParams": {"max_length": "64"},
+            },
+        )
+        assert rsp["code"] == 0, rsp
+        rsp = client.collection_describe(name)
+        assert any(field["name"] == "tag" for field in rsp["data"]["fields"]), rsp
+
+        rsp = client.drop_field(name, field_name="tag")
+        assert rsp["code"] == 0, rsp
+        rsp = client.collection_describe(name)
+        assert not any(field["name"] == "tag" for field in rsp["data"]["fields"]), rsp
+
+        rsp = client.add_field(name, {"fieldName": "score", "dataType": "Int64", "nullable": True})
+        assert rsp["code"] == 0, rsp
+        rsp = client.collection_describe(name)
+        score_id = next(field["id"] for field in rsp["data"]["fields"] if field["name"] == "score")
+
+        rsp = client.drop_field(name, field_id=score_id)
+        assert rsp["code"] == 0, rsp
+        rsp = client.collection_describe(name)
+        assert not any(field["name"] == "score" for field in rsp["data"]["fields"]), rsp
+
     @pytest.mark.parametrize(
         "schema_variant,field_params",
         [


### PR DESCRIPTION
Cherry-pick from master
pr: #51411

issue: #48983

Design doc: docs/design-docs/design_docs/20260413-drop-collection-field-design.md

## Summary

- Add Go SDK APIs for schema field additions and removals through `AlterCollectionSchema`, retaining the legacy AddCollectionField compatibility fallback.
- Add REST v2 support for dropping a collection field by name or ID and route field additions through `AlterCollectionSchema`.
- Preserve AlterCollectionSchema status propagation for REST responses, request metrics, and logs on the 3.0 fail_input/fail_system metric model.

## Test Plan

- [x] Go client `internal/merr` and `milvusclient` tests
- [x] `make build-go`
- [x] `make static-check`
- [x] Targeted requestutil and REST/proxy tests
- [x] 3.0 Go client against a 2.6 standalone: AddCollectionField falls back from AlterCollectionSchema to the legacy RPC, then insert/query/search succeeds
- [x] Ruff check and format check for changed REST client files
- [x] `git diff --check`
