### PR TITLE
fix: defer MixCoord session shutdown

### DIFF
--- a/internal/coordinator/mix_coord.go
+++ b/internal/coordinator/mix_coord.go
@@ -350,6 +350,12 @@ func (s *mixCoordImpl) Stop() error {
 	if err := s.rootcoordServer.Stop(); err != nil {
 		log.Error("Failed to stop rootCoord", zap.Error(err))
 	}
+
+	// MixCoord owns the shared session. Revoke it only after all child
+	// coordinators have stopped using it.
+	if s.session != nil {
+		s.session.Stop()
+	}
 	s.cancel()
 	return nil
 }

--- a/internal/coordinator/mix_coord_test.go
+++ b/internal/coordinator/mix_coord_test.go
@@ -32,9 +32,11 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
 	"github.com/milvus-io/milvus/internal/datacoord"
 	"github.com/milvus-io/milvus/internal/querycoordv2"
+	"github.com/milvus-io/milvus/internal/rootcoord"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/internal/util/pathutil"
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
@@ -42,6 +44,36 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/tikv"
 )
+
+func TestMixCoordStopOwnsSharedSession(t *testing.T) {
+	mockey.PatchConvey("shared session stops after child coordinators", t, func() {
+		ctx := context.Background()
+		coord, err := NewMixCoordServer(ctx, dependency.NewDefaultFactory(true))
+		assert.NoError(t, err)
+		coord.session = sessionutil.NewSession(ctx)
+
+		stopOrder := make([]string, 0, 4)
+		mockey.Mock((*querycoordv2.Server).Stop).To(func(*querycoordv2.Server) error {
+			stopOrder = append(stopOrder, "querycoord")
+			return nil
+		}).Build()
+		mockey.Mock((*datacoord.Server).Stop).To(func(*datacoord.Server) error {
+			stopOrder = append(stopOrder, "datacoord")
+			return nil
+		}).Build()
+		mockey.Mock((*rootcoord.Core).Stop).To(func(*rootcoord.Core) error {
+			stopOrder = append(stopOrder, "rootcoord")
+			return nil
+		}).Build()
+		mockey.Mock((*sessionutil.Session).Stop).To(func(*sessionutil.Session) {
+			stopOrder = append(stopOrder, "session")
+		}).Build()
+
+		err = coord.Stop()
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"querycoord", "datacoord", "rootcoord", "session"}, stopOrder)
+	})
+}
 
 func TestMixcoord_EnableActiveStandby(t *testing.T) {
 	randVal := rand.Int()

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -133,7 +133,9 @@ type Server struct {
 	factory         dependency.Factory
 
 	session          sessionutil.SessionInterface
+	sessionOwned     bool
 	icSession        sessionutil.SessionInterface
+	icSessionOwned   bool
 	dnSessionWatcher sessionutil.SessionWatcher
 	qnSessionWatcher sessionutil.SessionWatcher
 
@@ -397,7 +399,9 @@ func (s *Server) SetDataNodeCreator(f func(context.Context, string, int64) (type
 
 func (s *Server) SetSession(session sessionutil.SessionInterface) error {
 	s.session = session
+	s.sessionOwned = false
 	s.icSession = session
+	s.icSessionOwned = false
 	if s.session == nil {
 		return merr.WrapErrServiceNotReadyMsg("session is nil, the etcd client connection may have failed")
 	}
@@ -520,11 +524,13 @@ func (s *Server) initSegmentManager() error {
 func (s *Server) initSession() error {
 	if s.icSession == nil {
 		s.icSession = sessionutil.NewSession(s.ctx)
+		s.icSessionOwned = true
 		s.icSession.Init(typeutil.IndexCoordRole, s.address, true, true)
 		s.icSession.SetEnableActiveStandBy(s.enableActiveStandBy)
 	}
 	if s.session == nil {
 		s.session = sessionutil.NewSession(s.ctx)
+		s.sessionOwned = true
 
 		s.session.Init(typeutil.DataCoordRole, s.address, true, true)
 		s.session.SetEnableActiveStandBy(s.enableActiveStandBy)
@@ -986,18 +992,22 @@ func (s *Server) Stop() error {
 		s.qnSessionWatcher.Stop()
 	}
 
-	if s.session != nil {
-		s.session.Stop()
-	}
-
-	if s.icSession != nil {
-		s.icSession.Stop()
-	}
+	s.stopSessions()
 
 	s.stopServerLoop()
 	log.Info("datacoord serverloop stopped")
 	log.Warn("datacoord stop successful")
 	return nil
+}
+
+func (s *Server) stopSessions() {
+	if s.sessionOwned && s.session != nil {
+		s.session.Stop()
+	}
+
+	if s.icSessionOwned && s.icSession != nil {
+		s.icSession.Stop()
+	}
 }
 
 // CleanMeta only for test

--- a/internal/datacoord/session_ownership_test.go
+++ b/internal/datacoord/session_ownership_test.go
@@ -1,0 +1,45 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
+)
+
+func TestSessionOwnership(t *testing.T) {
+	injectedSession := sessionutil.NewMockSession(t)
+	server := &Server{}
+
+	err := server.SetSession(injectedSession)
+	assert.NoError(t, err)
+	assert.False(t, server.sessionOwned)
+	assert.False(t, server.icSessionOwned)
+	server.stopSessions()
+
+	dataSession := sessionutil.NewMockSession(t)
+	indexSession := sessionutil.NewMockSession(t)
+	dataSession.EXPECT().Stop().Once()
+	indexSession.EXPECT().Stop().Once()
+	server.session = dataSession
+	server.sessionOwned = true
+	server.icSession = indexSession
+	server.icSessionOwned = true
+	server.stopSessions()
+}

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -79,6 +79,7 @@ type Server struct {
 	tikvCli             *txnkv.Client
 	address             string
 	session             sessionutil.SessionInterface
+	sessionOwned        bool
 	sessionWatcher      sessionutil.SessionWatcher
 	sessionWatcherMu    sync.Mutex
 	kv                  kv.MetaKv
@@ -155,6 +156,7 @@ func (s *Server) Register() error {
 
 func (s *Server) SetSession(session sessionutil.SessionInterface) error {
 	s.session = session
+	s.sessionOwned = false
 	if s.session == nil {
 		return merr.WrapErrServiceNotReadyMsg("session is nil, the etcd client connection may have failed")
 	}
@@ -247,6 +249,7 @@ func (s *Server) initSession() error {
 	// Init QueryCoord session
 	if s.session == nil {
 		s.session = sessionutil.NewSession(s.ctx)
+		s.sessionOwned = true
 		s.session.Init(typeutil.QueryCoordRole, s.address, true, true)
 		s.enableActiveStandBy = Params.QueryCoordCfg.EnableActiveStandby.GetAsBool()
 		s.session.SetEnableActiveStandBy(s.enableActiveStandBy)
@@ -587,12 +590,16 @@ func (s *Server) Stop() error {
 	s.cancel()
 	s.wg.Wait()
 
-	if s.session != nil {
-		s.session.Stop()
-	}
+	s.stopSession()
 
 	log.Info("QueryCoord stop successfully")
 	return nil
+}
+
+func (s *Server) stopSession() {
+	if s.sessionOwned && s.session != nil {
+		s.session.Stop()
+	}
 }
 
 // UpdateStateCode updates the status of the coord, including healthy, unhealthy

--- a/internal/querycoordv2/session_ownership_test.go
+++ b/internal/querycoordv2/session_ownership_test.go
@@ -1,0 +1,38 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package querycoordv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
+)
+
+func TestSessionOwnership(t *testing.T) {
+	injectedSession := sessionutil.NewMockSession(t)
+	server := &Server{}
+
+	err := server.SetSession(injectedSession)
+	assert.NoError(t, err)
+	assert.False(t, server.sessionOwned)
+	server.stopSession()
+
+	server.sessionOwned = true
+	injectedSession.EXPECT().Stop().Once()
+	server.stopSession()
+}

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -119,10 +119,11 @@ type Core struct {
 	quotaCenter    *QuotaCenter
 	keyManager     *KeyManager
 
-	stateCode atomic.Int32
-	initOnce  sync.Once
-	startOnce sync.Once
-	session   sessionutil.SessionInterface
+	stateCode    atomic.Int32
+	initOnce     sync.Once
+	startOnce    sync.Once
+	session      sessionutil.SessionInterface
+	sessionOwned bool
 
 	factory dependency.Factory
 
@@ -309,6 +310,7 @@ func (c *Core) SetTiKVClient(client *txnkv.Client) {
 
 func (c *Core) SetSession(session sessionutil.SessionInterface) error {
 	c.session = session
+	c.sessionOwned = false
 	if c.session == nil {
 		return merr.WrapErrServiceNotReadyMsg("session is nil, the etcd client connection may have failed")
 	}
@@ -706,7 +708,7 @@ func (c *Core) cancelIfNotNil() {
 }
 
 func (c *Core) revokeSession() {
-	if c.session != nil {
+	if c.sessionOwned && c.session != nil {
 		// wait at most one second to revoke
 		c.session.Stop()
 		log.Ctx(c.ctx).Info("rootcoord session stop")

--- a/internal/rootcoord/session_ownership_test.go
+++ b/internal/rootcoord/session_ownership_test.go
@@ -1,0 +1,39 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/util/sessionutil"
+)
+
+func TestSessionOwnership(t *testing.T) {
+	injectedSession := sessionutil.NewMockSession(t)
+	core := &Core{}
+
+	err := core.SetSession(injectedSession)
+	assert.NoError(t, err)
+	assert.False(t, core.sessionOwned)
+
+	core.revokeSession()
+
+	core.sessionOwned = true
+	injectedSession.EXPECT().Stop().Once()
+	core.revokeSession()
+}


### PR DESCRIPTION
## What this PR does

Fixes ownership of the shared etcd Session used by MixCoord on the `2.6` branch.

- Tracks whether QueryCoord and DataCoord own Sessions created internally.
- Prevents child coordinators from stopping a Session injected by MixCoord.
- Makes MixCoord revoke its shared Session only after QueryCoord, DataCoord, and RootCoord have stopped.
- Adds ownership and shutdown-order tests.

## Why

QueryCoord could revoke the shared MixCoord Session while DataCoord was still draining compaction and index work. That could activate a new MixCoord before the old coordinator stack had fully stopped.

The Session creator now owns its lifecycle, preserving the lease as the fencing boundary until all child coordinators finish shutdown.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/coordinator ./internal/querycoordv2 ./internal/datacoord ./internal/rootcoord -run "TestMixCoordStopOwnsSharedSession|TestSessionOwnership"`
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/coordinator ./internal/querycoordv2 ./internal/datacoord`
- `MILVUS_CONF_ROCKSMQ_PATH=<isolated-temp-path>/rocksmq go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/rootcoord`

issue: #51769
pr: #48252
