### PR TITLE
fix: run external collection refresh in one task

### DIFF
--- a/internal/datacoord/external_collection_refresh_manager.go
+++ b/internal/datacoord/external_collection_refresh_manager.go
@@ -35,7 +35,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/externalspec"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -166,7 +165,7 @@ type externalCollectionRefreshManager struct {
 	// initJobsInFlight tracks jobs whose async task-creation (Phase B) is
 	// currently running. SubmitRefreshJobWithID persists the job record in
 	// Init state on the WAL ack callback path and returns immediately; the
-	// S3 explore + task split + scheduler enqueue run in a background
+	// S3 explore + task creation + scheduler enqueue run in a background
 	// goroutine so the broadcaster is never blocked on object-store I/O.
 	// Both the eager Submit path and the periodic checker tick drive the
 	// same entry point (ensureTasksForInitJob) and this map dedups them so
@@ -483,7 +482,7 @@ func (m *externalCollectionRefreshManager) handleJobFinished(ctx context.Context
 //     task creation. The caller (WAL ack callback) is unblocked the moment
 //     the meta write returns.
 //  2. Phase B (asynchronous, ensureTasksForInitJob): explore the external
-//     source, split files into task chunks, persist tasks, and enqueue them.
+//     source, persist the collection-wide task, and enqueue it.
 //     Kicked off from this method via a background goroutine AND retried by
 //     the checker tick if the first attempt fails. The `tryTimeoutJob` path
 //     acts as the final safety net — a job that never advances past Init
@@ -592,7 +591,7 @@ func (m *externalCollectionRefreshManager) SubmitRefreshJobWithID(
 // from multiple paths concurrently — the SubmitRefreshJobWithID eager path
 // after AddJob, and the checker tick that re-triggers Init-stuck jobs.
 // initJobsInFlight dedups concurrent invocations so at most one explore +
-// task split runs per jobID at any moment.
+// task creation runs per jobID at any moment.
 //
 // All work runs in a background goroutine tracked by the manager's wait
 // group so Stop() waits for in-flight explores to finish (or the derived
@@ -686,20 +685,29 @@ func (m *externalCollectionRefreshManager) ensureTasksForInitJob(jobID int64) {
 	}()
 }
 
-// createTasksForJob creates task(s) for a job and persists them to meta.
-// Returns the created tasks for subsequent scheduling.
-//
-// Task count is ceil(totalFiles / ExternalCollectionFilesPerTask), driven by
-// the config — it is independent of the current DataNode count. Each task
-// carries the shared manifest path plus a [FileIndexBegin, FileIndexEnd)
-// slice; DataNodes then read the manifest from object storage once and
-// process only their assigned range, so the FFI explore runs exactly once
-// on DataCoord.
+// createTasksForJob creates one collection-wide task for a new job and
+// persists it to meta. Persisted legacy jobs may still contain multiple tasks.
 func (m *externalCollectionRefreshManager) createTasksForJob(
 	ctx context.Context,
 	job *datapb.ExternalCollectionRefreshJob,
 ) ([]*refreshExternalCollectionTask, error) {
 	log := mlog.With(mlog.FieldJobID(job.GetJobId()), mlog.FieldCollectionID(job.GetCollectionId()))
+
+	// AddTask and AddTaskIDToJob are persisted separately. Reuse an unlinked
+	// task when Phase B retries so one job cannot create a second full-range task.
+	if existingTasks := m.refreshMeta.GetTasksByJobID(job.GetJobId()); len(existingTasks) > 0 {
+		if len(existingTasks) != 1 || existingTasks[0].GetTaskId() != job.GetJobId() {
+			return nil, merr.WrapErrServiceInternalMsg(
+				"job %d has unexpected persisted refresh tasks",
+				job.GetJobId(),
+			)
+		}
+		existingTask := existingTasks[0]
+		if err := m.refreshMeta.AddTaskIDToJob(job.GetJobId(), existingTask.GetTaskId()); err != nil {
+			return nil, err
+		}
+		return []*refreshExternalCollectionTask{m.wrapTask(existingTask)}, nil
+	}
 
 	// ExploreFiles once on DataCoord to get the full file list and manifest path.
 	// Manifest is written to S3 so DataNodes can read file info by range.
@@ -727,86 +735,38 @@ func (m *externalCollectionRefreshManager) createTasksForJob(
 	// parquet metadata, so FileInfo.NumRows carries -1, not a real row count.
 	// The real guard lives at datanode's balanceFragmentsToSegments, where
 	// fragment RowCount is populated from manifest (endRow - startRow).
-	log.Info(ctx, "explored external files for task splitting",
+	log.Info(ctx, "explored external files for refresh task",
 		mlog.Int("totalFiles", len(allFiles)),
 		mlog.String("manifestPath", manifestPath))
 
-	// Determine task count: ceil(totalFiles/filesPerTask).
-	// - filesPerTask: configurable via dataCoord.externalCollectionFilesPerTask
-	// In standalone mode, multiple tasks run concurrently on the single DN's worker pool.
-	minFilesPerTask := int(paramtable.Get().DataCoordCfg.ExternalCollectionFilesPerTask.GetAsInt64())
-
-	type taskChunk struct {
-		fileIndexBegin int64
-		fileIndexEnd   int64
+	// The current task-level concurrency is not correct: every file-range task
+	// independently computes a collection-wide mapping, so sibling ranges can
+	// remap each other's segments. Use one task for correctness until a future
+	// coordinated parallel design restores concurrency safely.
+	// Reuse the globally allocated job ID as the only task ID. Job and task
+	// metadata use separate namespaces, and legacy range tasks always allocated
+	// a different ID, so equality also identifies the new direct-apply path.
+	taskID := job.GetJobId()
+	task := &datapb.ExternalCollectionRefreshTask{
+		TaskId:              taskID,
+		JobId:               job.GetJobId(),
+		CollectionId:        job.GetCollectionId(),
+		State:               indexpb.JobState_JobStateInit,
+		ExternalSource:      job.GetExternalSource(),
+		ExternalSpec:        job.GetExternalSpec(),
+		ExploreManifestPath: manifestPath,
+		FileIndexBegin:      0,
+		FileIndexEnd:        int64(len(allFiles)),
 	}
-	var chunks []taskChunk
-	numTasks := (len(allFiles) + minFilesPerTask - 1) / minFilesPerTask
-	if numTasks < 1 {
-		numTasks = 1
-	}
-	filesPerTask := (len(allFiles) + numTasks - 1) / numTasks // ceil division
-	for i := 0; i < len(allFiles); i += filesPerTask {
-		end := i + filesPerTask
-		if end > len(allFiles) {
-			end = len(allFiles)
-		}
-		chunks = append(chunks, taskChunk{
-			fileIndexBegin: int64(i),
-			fileIndexEnd:   int64(end),
-		})
-	}
-
-	log.Info(ctx, "splitting refresh job into tasks",
-		mlog.Int("totalFiles", len(allFiles)),
-		mlog.Int("numTasks", len(chunks)))
-
-	// Allocate IDs and build every task first (ID allocation order preserved),
-	// then persist all task saves plus the job's updated TaskIds as a single
-	// composite catalog write - the job written last as the commit marker - so
-	// a partial failure can no longer desync the job's TaskIds from the
-	// persisted task set. In-memory bookkeeping is applied only after that
-	// write succeeds.
-	rawTasks := make([]*datapb.ExternalCollectionRefreshTask, 0, len(chunks))
-	for _, chunk := range chunks {
-		taskID, err := m.allocator.AllocID(ctx)
-		if err != nil {
-			log.Warn(ctx, "failed to allocate task ID", mlog.Err(err))
-			return nil, err
-		}
-
-		task := &datapb.ExternalCollectionRefreshTask{
-			TaskId:              taskID,
-			JobId:               job.GetJobId(),
-			CollectionId:        job.GetCollectionId(),
-			Version:             0,
-			NodeId:              0,
-			State:               indexpb.JobState_JobStateInit,
-			ExternalSource:      job.GetExternalSource(),
-			ExternalSpec:        job.GetExternalSpec(),
-			Progress:            0,
-			ExploreManifestPath: manifestPath,
-			FileIndexBegin:      chunk.fileIndexBegin,
-			FileIndexEnd:        chunk.fileIndexEnd,
-		}
-		rawTasks = append(rawTasks, task)
-	}
-
-	if err = m.refreshMeta.AddTasksToJob(job.GetJobId(), rawTasks); err != nil {
+	if err = m.refreshMeta.AddTasksToJob(
+		job.GetJobId(),
+		[]*datapb.ExternalCollectionRefreshTask{task},
+	); err != nil {
 		log.Warn(ctx, "failed to add tasks to job", mlog.Err(err))
 		return nil, err
 	}
 
-	tasks := make([]*refreshExternalCollectionTask, 0, len(rawTasks))
-	for _, task := range rawTasks {
-		tasks = append(tasks, m.wrapTask(task))
-	}
-
-	log.Info(ctx, "tasks created for job",
-		mlog.Int("numTasks", len(tasks)),
-		mlog.FieldJobID(job.GetJobId()))
-
-	return tasks, nil
+	return []*refreshExternalCollectionTask{m.wrapTask(task)}, nil
 }
 
 func normalizeRefreshJobProgress(job *datapb.ExternalCollectionRefreshJob, state indexpb.JobState, progress int64) {

--- a/internal/datacoord/external_collection_refresh_manager_test.go
+++ b/internal/datacoord/external_collection_refresh_manager_test.go
@@ -134,9 +134,15 @@ func TestSubmitRefreshJobWithIDStoresJobMetadata(t *testing.T) {
 	mgr.Stop()
 }
 
-func TestCreateTasksForJobCopiesJobMetadata(t *testing.T) {
+func TestCreateTasksForJobCreatesSingleTaskForAllFiles(t *testing.T) {
 	ctx := context.Background()
 	collectionID := int64(100)
+	filesPerTaskKey := Params.DataCoordCfg.ExternalCollectionFilesPerTask.Key
+	oldFilesPerTask := Params.DataCoordCfg.ExternalCollectionFilesPerTask.GetValue()
+	assert.NoError(t, Params.Save(filesPerTaskKey, "1"))
+	t.Cleanup(func() {
+		_ = Params.Save(filesPerTaskKey, oldFilesPerTask)
+	})
 	schema := &schemapb.CollectionSchema{
 		Name:           "ext",
 		ExternalSource: "s3://bucket/path",
@@ -161,7 +167,10 @@ func TestCreateTasksForJobCopiesJobMetadata(t *testing.T) {
 		refreshMeta, nil, testCollectionGetter(mt), nil, nil).(*externalCollectionRefreshManager)
 
 	mockExplore := mockey.Mock((*externalCollectionRefreshManager).exploreExternalFiles).
-		Return([]*datapb.ExternalFileInfo{{FilePath: "s3://bucket/path/a.parquet", NumRows: 10}}, "manifest-path", nil).
+		Return([]*datapb.ExternalFileInfo{
+			{FilePath: "s3://bucket/path/a.parquet", NumRows: 10},
+			{FilePath: "s3://bucket/path/b.parquet", NumRows: 20},
+		}, "manifest-path", nil).
 		Build()
 	defer mockExplore.UnPatch()
 
@@ -181,6 +190,93 @@ func TestCreateTasksForJobCopiesJobMetadata(t *testing.T) {
 	assert.Equal(t, collectionID, tasks[0].GetCollectionId())
 	assert.Equal(t, "s3://bucket/path", tasks[0].GetExternalSource())
 	assert.Equal(t, `{"format":"parquet"}`, tasks[0].GetExternalSpec())
+	assert.Equal(t, job.GetJobId(), tasks[0].GetTaskId())
+	assert.Equal(t, int64(0), tasks[0].GetFileIndexBegin())
+	assert.Equal(t, int64(2), tasks[0].GetFileIndexEnd())
+	assert.Len(t, refreshMeta.GetTasksByJobID(job.GetJobId()), 1)
+	assert.Len(t, refreshMeta.GetJob(job.GetJobId()).GetTaskIds(), 1)
+}
+
+func TestCreateTasksForJobReusesPersistedUnlinkedTask(t *testing.T) {
+	ctx := context.Background()
+	job := &datapb.ExternalCollectionRefreshJob{
+		JobId:        1001,
+		CollectionId: 100,
+		State:        indexpb.JobState_JobStateInit,
+	}
+	persistedTask := &datapb.ExternalCollectionRefreshTask{
+		TaskId:              job.GetJobId(),
+		JobId:               job.GetJobId(),
+		CollectionId:        job.GetCollectionId(),
+		State:               indexpb.JobState_JobStateInit,
+		ExploreManifestPath: "manifest-path",
+		FileIndexEnd:        2,
+	}
+	refreshMeta := createTestRefreshMetaWithJobs(
+		t,
+		[]*datapb.ExternalCollectionRefreshJob{job},
+		[]*datapb.ExternalCollectionRefreshTask{persistedTask},
+	)
+	mgr := NewExternalCollectionRefreshManager(
+		ctx,
+		nil,
+		newStubScheduler(),
+		&stubAllocator{nextID: 3000},
+		refreshMeta,
+		nil,
+		nil,
+		nil,
+		nil,
+	).(*externalCollectionRefreshManager)
+
+	mockExplore := mockey.Mock((*externalCollectionRefreshManager).exploreExternalFiles).
+		To(func(*externalCollectionRefreshManager, context.Context, *datapb.ExternalCollectionRefreshJob) ([]*datapb.ExternalFileInfo, string, error) {
+			t.Fatal("persisted task should be reused before exploring files")
+			return nil, "", nil
+		}).Build()
+	defer mockExplore.UnPatch()
+
+	tasks, err := mgr.createTasksForJob(ctx, job)
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 1)
+	assert.Equal(t, persistedTask.GetTaskId(), tasks[0].GetTaskId())
+	assert.Equal(t, []int64{persistedTask.GetTaskId()}, refreshMeta.GetJob(job.GetJobId()).GetTaskIds())
+	assert.Len(t, refreshMeta.GetTasksByJobID(job.GetJobId()), 1)
+}
+
+func TestCreateTasksForJobRejectsLegacyUnlinkedTask(t *testing.T) {
+	job := &datapb.ExternalCollectionRefreshJob{
+		JobId:        1001,
+		CollectionId: 100,
+		State:        indexpb.JobState_JobStateInit,
+	}
+	legacyTask := &datapb.ExternalCollectionRefreshTask{
+		TaskId:       2001,
+		JobId:        job.GetJobId(),
+		CollectionId: job.GetCollectionId(),
+		State:        indexpb.JobState_JobStateInit,
+	}
+	refreshMeta := createTestRefreshMetaWithJobs(
+		t,
+		[]*datapb.ExternalCollectionRefreshJob{job},
+		[]*datapb.ExternalCollectionRefreshTask{legacyTask},
+	)
+	mgr := NewExternalCollectionRefreshManager(
+		context.Background(),
+		nil,
+		newStubScheduler(),
+		&stubAllocator{nextID: 3000},
+		refreshMeta,
+		nil,
+		nil,
+		nil,
+		nil,
+	).(*externalCollectionRefreshManager)
+
+	_, err := mgr.createTasksForJob(context.Background(), job)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected persisted refresh tasks")
+	assert.Empty(t, refreshMeta.GetJob(job.GetJobId()).GetTaskIds())
 }
 
 func TestExternalCollectionRefreshManager_ApplyFinishedJobSegmentsMergesTaskResults(t *testing.T) {

--- a/internal/datacoord/task_refresh_external_collection.go
+++ b/internal/datacoord/task_refresh_external_collection.go
@@ -637,18 +637,9 @@ func (t *refreshExternalCollectionTask) CreateTaskOnWorker(nodeID int64, cluster
 
 	mlog.Info(context.TODO(), "collected current segments", mlog.Int("segmentCount", len(currentSegments)))
 
-	// A collection-wide task needs the aggregate ID capacity that the previous
-	// file-range tasks would have received independently.
+	// Use one bounded allocation for the collection-wide task. Multiplying the
+	// range by the former task count can exceed RootCoord's uint32 batch limit.
 	preAllocCount := paramtable.Get().DataCoordCfg.ExternalCollectionPreAllocSegments.GetAsInt64()
-	if t.GetTaskId() == t.GetJobId() {
-		filesPerTask := paramtable.Get().DataCoordCfg.ExternalCollectionFilesPerTask.GetAsInt64()
-		fileCount := t.GetFileIndexEnd() - t.GetFileIndexBegin()
-		virtualTaskCount := int64(1)
-		if fileCount > 0 {
-			virtualTaskCount = 1 + (fileCount-1)/filesPerTask
-		}
-		preAllocCount *= virtualTaskCount
-	}
 
 	idBegin, idEnd, err := t.allocator.AllocN(preAllocCount)
 	if err != nil {

--- a/internal/datacoord/task_refresh_external_collection.go
+++ b/internal/datacoord/task_refresh_external_collection.go
@@ -637,8 +637,18 @@ func (t *refreshExternalCollectionTask) CreateTaskOnWorker(nodeID int64, cluster
 
 	mlog.Info(context.TODO(), "collected current segments", mlog.Int("segmentCount", len(currentSegments)))
 
-	// Pre-allocate segment IDs for data mapping
+	// A collection-wide task needs the aggregate ID capacity that the previous
+	// file-range tasks would have received independently.
 	preAllocCount := paramtable.Get().DataCoordCfg.ExternalCollectionPreAllocSegments.GetAsInt64()
+	if t.GetTaskId() == t.GetJobId() {
+		filesPerTask := paramtable.Get().DataCoordCfg.ExternalCollectionFilesPerTask.GetAsInt64()
+		fileCount := t.GetFileIndexEnd() - t.GetFileIndexBegin()
+		virtualTaskCount := int64(1)
+		if fileCount > 0 {
+			virtualTaskCount = 1 + (fileCount-1)/filesPerTask
+		}
+		preAllocCount *= virtualTaskCount
+	}
 
 	idBegin, idEnd, err := t.allocator.AllocN(preAllocCount)
 	if err != nil {
@@ -733,6 +743,12 @@ func (t *refreshExternalCollectionTask) QueryTaskOnWorker(cluster session.Cluste
 		}
 		return
 	}
+	if job.GetState() == indexpb.JobState_JobStateFinished {
+		if err := t.UpdateStateWithMeta(indexpb.JobState_JobStateFinished, ""); err != nil {
+			mlog.Warn(context.TODO(), "failed to align task with finished job", mlog.Err(err))
+		}
+		return
+	}
 
 	// Query task status from worker
 	resp, err := cluster.QueryRefreshExternalCollectionTask(t.GetNodeId(), t.GetTaskId())
@@ -762,9 +778,38 @@ func (t *refreshExternalCollectionTask) QueryTaskOnWorker(cluster session.Cluste
 			return
 		}
 
-		// Persist the task result. Segment metadata is applied once at the
-		// job level after all sibling tasks have finished, so a single task
-		// cannot drop segments produced by another task of the same job.
+		if t.GetTaskId() == t.GetJobId() {
+			applied, err := t.refreshMeta.UpdateJobStateWithPreApply(
+				t.GetJobId(),
+				indexpb.JobState_JobStateFinished,
+				"",
+				func(*datapb.ExternalCollectionRefreshJob) error {
+					return t.SetJobInfo(context.TODO(), resp)
+				},
+			)
+			if err != nil {
+				mlog.Warn(context.TODO(), "failed to apply refresh task result", mlog.Err(err))
+				return
+			}
+			if !applied {
+				latestJob := t.refreshMeta.GetJob(t.GetJobId())
+				if latestJob != nil {
+					if err := t.UpdateStateWithMeta(latestJob.GetState(), latestJob.GetFailReason()); err != nil {
+						mlog.Warn(context.TODO(), "failed to align task with terminal job", mlog.Err(err))
+					}
+				}
+				return
+			}
+			if err := t.UpdateStateWithMeta(state, ""); err != nil {
+				mlog.Warn(context.TODO(), "failed to update task state to Finished", mlog.Err(err))
+				return
+			}
+			mlog.Info(context.TODO(), "refresh task completed successfully")
+			return
+		}
+
+		// Persist results only for legacy multi-task jobs that still need
+		// job-level aggregation after a rolling upgrade.
 		if err := t.UpdateResultWithMeta(
 			state,
 			"",

--- a/internal/datacoord/task_refresh_external_collection_test.go
+++ b/internal/datacoord/task_refresh_external_collection_test.go
@@ -870,13 +870,18 @@ func TestRefreshExternalCollectionTask_CreateTaskOnWorker(t *testing.T) {
 		const targetRowsPerSegmentKey = "dataNode.externalCollection.targetRowsPerSegment"
 		paramtable.Get().Save(targetRowsPerSegmentKey, "12345")
 		defer paramtable.Get().Reset(targetRowsPerSegmentKey)
+		filesPerTaskKey := paramtable.Get().DataCoordCfg.ExternalCollectionFilesPerTask.Key
+		paramtable.Get().Save(filesPerTaskKey, "1")
+		defer paramtable.Get().Reset(filesPerTaskKey)
 
 		catalog := &stubCatalog{}
 		refreshMeta, err := newExternalCollectionRefreshMeta(context.Background(), catalog)
 		assert.NoError(t, err)
 
-		filesPerTask := paramtable.Get().DataCoordCfg.ExternalCollectionFilesPerTask.GetAsInt64()
-		basePreAllocCount := paramtable.Get().DataCoordCfg.ExternalCollectionPreAllocSegments.GetAsInt64()
+		preAllocCount := paramtable.Get().DataCoordCfg.ExternalCollectionPreAllocSegments.GetAsInt64()
+		assert.Equal(t, int64(10000000), preAllocCount)
+		// This file count previously overflowed RootCoord's uint32 allocation
+		// limit when filesPerTask was set to 1 and the capacity was multiplied.
 		protoTask := &datapb.ExternalCollectionRefreshTask{
 			TaskId:         1001,
 			JobId:          1001,
@@ -885,7 +890,7 @@ func TestRefreshExternalCollectionTask_CreateTaskOnWorker(t *testing.T) {
 			ExternalSource: "s3://bucket/path",
 			ExternalSpec:   "iceberg",
 			FileIndexBegin: 0,
-			FileIndexEnd:   filesPerTask*2 + 1,
+			FileIndexEnd:   8590,
 		}
 		err = refreshMeta.AddTask(protoTask)
 		assert.NoError(t, err)
@@ -923,8 +928,8 @@ func TestRefreshExternalCollectionTask_CreateTaskOnWorker(t *testing.T) {
 		assert.NotNil(t, cluster.refreshReq)
 		assert.Equal(t, int64(10), cluster.refreshReq.GetPartitionID())
 		assert.Equal(t, int64(12345), cluster.refreshReq.GetTargetRowsPerSegment())
-		assert.Equal(t, basePreAllocCount*3, cluster.refreshReq.GetNumSegmentsExpected())
-		assert.Equal(t, basePreAllocCount*3,
+		assert.Equal(t, preAllocCount, cluster.refreshReq.GetNumSegmentsExpected())
+		assert.Equal(t, preAllocCount,
 			cluster.refreshReq.GetPreAllocatedSegmentIds().GetEnd()-cluster.refreshReq.GetPreAllocatedSegmentIds().GetBegin())
 	})
 }

--- a/internal/datacoord/task_refresh_external_collection_test.go
+++ b/internal/datacoord/task_refresh_external_collection_test.go
@@ -875,13 +875,17 @@ func TestRefreshExternalCollectionTask_CreateTaskOnWorker(t *testing.T) {
 		refreshMeta, err := newExternalCollectionRefreshMeta(context.Background(), catalog)
 		assert.NoError(t, err)
 
+		filesPerTask := paramtable.Get().DataCoordCfg.ExternalCollectionFilesPerTask.GetAsInt64()
+		basePreAllocCount := paramtable.Get().DataCoordCfg.ExternalCollectionPreAllocSegments.GetAsInt64()
 		protoTask := &datapb.ExternalCollectionRefreshTask{
 			TaskId:         1001,
-			JobId:          1,
+			JobId:          1001,
 			CollectionId:   100,
 			State:          indexpb.JobState_JobStateInit,
 			ExternalSource: "s3://bucket/path",
 			ExternalSpec:   "iceberg",
+			FileIndexBegin: 0,
+			FileIndexEnd:   filesPerTask*2 + 1,
 		}
 		err = refreshMeta.AddTask(protoTask)
 		assert.NoError(t, err)
@@ -919,6 +923,9 @@ func TestRefreshExternalCollectionTask_CreateTaskOnWorker(t *testing.T) {
 		assert.NotNil(t, cluster.refreshReq)
 		assert.Equal(t, int64(10), cluster.refreshReq.GetPartitionID())
 		assert.Equal(t, int64(12345), cluster.refreshReq.GetTargetRowsPerSegment())
+		assert.Equal(t, basePreAllocCount*3, cluster.refreshReq.GetNumSegmentsExpected())
+		assert.Equal(t, basePreAllocCount*3,
+			cluster.refreshReq.GetPreAllocatedSegmentIds().GetEnd()-cluster.refreshReq.GetPreAllocatedSegmentIds().GetBegin())
 	})
 }
 
@@ -1408,7 +1415,7 @@ func TestRefreshExternalCollectionTask_QueryTaskOnWorker_FinishedSuccess(t *test
 
 	// Add active job with matching source
 	job := &datapb.ExternalCollectionRefreshJob{
-		JobId:          1,
+		JobId:          1001,
 		CollectionId:   100,
 		State:          indexpb.JobState_JobStateInProgress,
 		ExternalSource: "s3://bucket/path",
@@ -1419,7 +1426,7 @@ func TestRefreshExternalCollectionTask_QueryTaskOnWorker_FinishedSuccess(t *test
 
 	protoTask := &datapb.ExternalCollectionRefreshTask{
 		TaskId:         1001,
-		JobId:          1,
+		JobId:          1001,
 		CollectionId:   100,
 		NodeId:         1,
 		State:          indexpb.JobState_JobStateInProgress,
@@ -1428,9 +1435,11 @@ func TestRefreshExternalCollectionTask_QueryTaskOnWorker_FinishedSuccess(t *test
 	}
 	err = refreshMeta.AddTask(protoTask)
 	assert.NoError(t, err)
+	assert.NoError(t, refreshMeta.AddTaskIDToJob(job.GetJobId(), protoTask.GetTaskId()))
 
 	segments := NewSegmentsInfo()
 	mt := &meta{
+		catalog:     catalog,
 		segments:    segments,
 		collections: newTestCollections(100),
 	}
@@ -1450,15 +1459,15 @@ func TestRefreshExternalCollectionTask_QueryTaskOnWorker_FinishedSuccess(t *test
 	}, nil).Build()
 	defer mockQuery.UnPatch()
 
-	// Mock UpdateSegmentsInfo to succeed
-	mockUpdate := mockey.Mock((*meta).UpdateSegmentsInfo).Return(nil).Build()
-	defer mockUpdate.UnPatch()
-
 	task.QueryTaskOnWorker(cluster)
 
-	// Task should be marked as Finished
 	metaTask := refreshMeta.GetTask(1001)
 	assert.Equal(t, indexpb.JobState_JobStateFinished, metaTask.GetState())
+	assert.False(t, metaTask.GetResultReady())
+	assert.Empty(t, metaTask.GetKeptSegments())
+	assert.Empty(t, metaTask.GetUpdatedSegments())
+	assert.Equal(t, indexpb.JobState_JobStateFinished, refreshMeta.GetJob(job.GetJobId()).GetState())
+	assert.NotNil(t, mt.segments.GetSegment(1))
 }
 
 func TestRefreshExternalCollectionTask_QueryTaskOnWorker_DelaysSegmentUpdateUntilJobFinished(t *testing.T) {
@@ -1527,6 +1536,8 @@ func TestRefreshExternalCollectionTask_QueryTaskOnWorker_DelaysSegmentUpdateUnti
 
 	metaTask := refreshMeta.GetTask(1001)
 	assert.Equal(t, indexpb.JobState_JobStateFinished, metaTask.GetState())
+	assert.True(t, metaTask.GetResultReady())
+	assert.Len(t, metaTask.GetUpdatedSegments(), 1)
 	assert.Equal(t, 0, updateCalls)
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6690,7 +6690,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 		Doc: "The number of IDs to pre-allocate for each external collection refresh task. " +
 			"Each segment consumes 2 IDs (1 for segment, 1 for fake binlog logID); " +
 			"milvus-table deltalogs without LogID consume additional fallback IDs.",
-		DefaultValue: "500000",
+		DefaultValue: "10000000",
 		PanicIfEmpty: false,
 	}
 	p.ExternalCollectionPreAllocSegments.Init(base.mgr)
@@ -6698,7 +6698,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.ExternalCollectionFilesPerTask = ParamItem{
 		Key:          "dataCoord.externalCollectionFilesPerTask",
 		Version:      "3.0.0",
-		Doc:          "Minimum number of external files per refresh task. Controls task splitting granularity.",
+		Doc:          "Target number of external files per refresh task. Task splitting is temporarily disabled.",
 		DefaultValue: "10000",
 		PanicIfEmpty: false,
 	}


### PR DESCRIPTION
issue: #45881

## What changed

- Create one collection-wide refresh task for each new job instead of
  splitting the files across concurrent range tasks.
- Apply the single task response directly to segment metadata and finish the
  job without persisting segment results in new task metadata.
- Reuse a persisted but unlinked single task on submission retry.
- Pre-allocate a fixed 10,000,000 segment-ID range for the collection-wide
  task instead of multiplying by the former file-range task count.
- Keep the result-persistence path for legacy multi-task jobs during rolling
  upgrades.

## Why

Each file-range task independently calculated a collection-wide segment
mapping. Sibling tasks could therefore remap the same segments, while their
full results also had to be persisted for later aggregation. Running one task
removes the conflicting mappings and makes task-level result persistence
unnecessary for new jobs.

With one task, multiplying the configured preallocation by the former task
count is unnecessary and can exceed RootCoord's uint32 allocation limit. A
fixed 10,000,000-ID range bounds the request independently of the external
file count.

This is a correctness-first change. A coordinated parallel refresh design and
large-result transport changes remain follow-up work.

## Validation

- `make build-cpp`
- Targeted `internal/datacoord` tests with `-race`,
  `-gcflags="all=-N -l"`, and `-tags dynamic,test`
- Re-ran `TestRefreshExternalCollectionTask_CreateTaskOnWorker` on the latest
  master after bounding the allocation
- `make fmt`
- `make static-check`
- `git diff --check`
