### PR TITLE
fix: keep raw fallback cursors consistent

### DIFF
--- a/internal/core/src/common/Array.h
+++ b/internal/core/src/common/Array.h
@@ -31,6 +31,32 @@
 
 namespace milvus {
 
+namespace array_detail {
+
+inline proto::plan::GenericValue::ValCase
+ExpectedLiteralValCase(DataType element_type) {
+    switch (element_type) {
+        case DataType::BOOL:
+            return proto::plan::GenericValue::ValCase::kBoolVal;
+        case DataType::INT8:
+        case DataType::INT16:
+        case DataType::INT32:
+        case DataType::INT64:
+            return proto::plan::GenericValue::ValCase::kInt64Val;
+        case DataType::FLOAT:
+        case DataType::DOUBLE:
+            return proto::plan::GenericValue::ValCase::kFloatVal;
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::GEOMETRY:
+            return proto::plan::GenericValue::ValCase::kStringVal;
+        default:
+            return proto::plan::GenericValue::ValCase::VAL_NOT_SET;
+    }
+}
+
+}  // namespace array_detail
+
 class Array {
  public:
     Array() = default;
@@ -414,9 +440,14 @@ class Array {
         if (!arr2.same_type()) {
             return false;
         }
+        const auto expected_val_case =
+            array_detail::ExpectedLiteralValCase(element_type_);
         switch (element_type_) {
             case DataType::BOOL: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<bool>(i);
                     if (val != arr2.array(i).bool_val()) {
                         return false;
@@ -428,6 +459,9 @@ class Array {
             case DataType::INT16:
             case DataType::INT32: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<int>(i);
                     if (val != arr2.array(i).int64_val()) {
                         return false;
@@ -437,6 +471,9 @@ class Array {
             }
             case DataType::INT64: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<int64_t>(i);
                     if (val != arr2.array(i).int64_val()) {
                         return false;
@@ -446,6 +483,9 @@ class Array {
             }
             case DataType::FLOAT: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<float>(i);
                     if (val != static_cast<float>(arr2.array(i).float_val())) {
                         return false;
@@ -455,6 +495,9 @@ class Array {
             }
             case DataType::DOUBLE: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<double>(i);
                     if (val != arr2.array(i).float_val()) {
                         return false;
@@ -466,6 +509,9 @@ class Array {
             case DataType::STRING:
             case DataType::GEOMETRY: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {
                         return false;
@@ -692,9 +738,14 @@ class ArrayView {
         if (!arr2.same_type()) {
             return false;
         }
+        const auto expected_val_case =
+            array_detail::ExpectedLiteralValCase(element_type_);
         switch (element_type_) {
             case DataType::BOOL: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<bool>(i);
                     if (val != arr2.array(i).bool_val()) {
                         return false;
@@ -706,6 +757,9 @@ class ArrayView {
             case DataType::INT16:
             case DataType::INT32: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<int>(i);
                     if (val != arr2.array(i).int64_val()) {
                         return false;
@@ -715,6 +769,9 @@ class ArrayView {
             }
             case DataType::INT64: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<int64_t>(i);
                     if (val != arr2.array(i).int64_val()) {
                         return false;
@@ -724,6 +781,9 @@ class ArrayView {
             }
             case DataType::FLOAT: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<float>(i);
                     if (val != static_cast<float>(arr2.array(i).float_val())) {
                         return false;
@@ -733,6 +793,9 @@ class ArrayView {
             }
             case DataType::DOUBLE: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<double>(i);
                     if (val != arr2.array(i).float_val()) {
                         return false;
@@ -744,6 +807,9 @@ class ArrayView {
             case DataType::STRING:
             case DataType::GEOMETRY: {
                 for (int i = 0; i < length_; i++) {
+                    if (arr2.array(i).val_case() != expected_val_case) {
+                        return false;
+                    }
                     auto val = get_data<std::string>(i);
                     if (val != arr2.array(i).string_val()) {
                         return false;

--- a/internal/core/src/common/ArrayTest.cpp
+++ b/internal/core/src/common/ArrayTest.cpp
@@ -231,3 +231,43 @@ TEST(Array, TestConstructArray) {
     ASSERT_EQ(0, empty_array.byte_size());
     ASSERT_TRUE(empty_array.is_same_array(field_empty_array));
 }
+
+TEST(Array, TestLiteralElementTypeMismatch) {
+    using namespace milvus;
+
+    auto expect_mismatch = [](const Array& array,
+                              const proto::plan::Array& literal) {
+        EXPECT_FALSE(array.is_same_array(literal));
+
+        auto array_view = ArrayView(const_cast<char*>(array.data()),
+                                    array.length(),
+                                    array.byte_size(),
+                                    array.get_element_type(),
+                                    array.get_offsets_data());
+        EXPECT_FALSE(array_view.is_same_array(literal));
+    };
+
+    proto::schema::ScalarField int64_data;
+    int64_data.mutable_long_data()->add_data(0);
+    auto int64_array = Array(int64_data);
+    proto::plan::Array float_literal;
+    float_literal.set_same_type(true);
+    float_literal.mutable_array()->Add()->set_float_val(1.5);
+    expect_mismatch(int64_array, float_literal);
+
+    proto::schema::ScalarField bool_data;
+    bool_data.mutable_bool_data()->add_data(false);
+    auto bool_array = Array(bool_data);
+    proto::plan::Array int_literal;
+    int_literal.set_same_type(true);
+    int_literal.mutable_array()->Add()->set_int64_val(0);
+    expect_mismatch(bool_array, int_literal);
+
+    proto::schema::ScalarField string_data;
+    string_data.mutable_string_data()->add_data("");
+    auto string_array = Array(string_data);
+    proto::plan::Array bool_literal;
+    bool_literal.set_same_type(true);
+    bool_literal.mutable_array()->Add()->set_bool_val(false);
+    expect_mismatch(string_array, bool_literal);
+}

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -127,8 +127,15 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                                JsonNumericBoundRequiresPreciseInt64Comparison(
                                    expr_->upper_val_));
 
+            // Keep sparse JsonFlat offset batches candidate-local when raw
+            // JSON is resident.  An index-only segment cannot use the generic
+            // JSON reverse-lookup path, so it must query the typed JsonFlat
+            // executor and gather the requested rows instead.
+            const bool use_json_flat_raw_offsets =
+                exec_path_ == ExprExecPath::ScalarIndex && has_offset_input_ &&
+                PinnedJsonIndexIsFlat() && num_data_chunk_ > 0;
             if (exec_path_ == ExprExecPath::ScalarIndex &&
-                (!has_offset_input_ || !PinnedJsonIndexIsFlat())) {
+                !use_json_flat_raw_offsets) {
                 if (is_numeric) {
                     if (!use_double && PinnedJsonIndexIsFlat()) {
                         result = ExecRangeVisitorImplForIndex<int64_t>(input);
@@ -437,6 +444,10 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex(OffsetVector* input) {
         return func(index_ptr, val1, val2, lower_inclusive, upper_inclusive);
     };
     if (input != nullptr) {
+        if (PinnedJsonIndexIsFlat()) {
+            return ProcessIndexChunksAndGatherByOffsets<T>(
+                execute_sub_batch, *input, val1, val2);
+        }
         if (cached_result_ == nullptr) {
             auto scalar_index =
                 dynamic_cast<const Index*>(pinned_index_[0].get());

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -132,10 +132,7 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
 
             if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
                 if (is_numeric) {
-                    if (has_unsafe_int_bound) {
-                        result =
-                            ExecRangeVisitorImplForJsonPreciseNumeric(context);
-                    } else if (!use_double && PinnedJsonIndexIsFlat()) {
+                    if (!use_double && PinnedJsonIndexIsFlat()) {
                         result = ExecRangeVisitorImplForIndex<int64_t>();
                     } else {
                         proto::plan::GenericValue double_lower_val;
@@ -1167,19 +1164,41 @@ PhyBinaryRangeFilterExpr::DetermineExecPath() {
         return;
     }
 
-    SegmentExpr::DetermineExecPath();
-    if (exec_path_ != ExprExecPath::ScalarIndex) {
-        return;
-    }
-
     auto data_type = expr_->column_.data_type_;
     if (expr_->column_.element_level_) {
         data_type = expr_->column_.element_type_;
     }
 
-    // ARRAY type cannot use scalar index
+    if (data_type == DataType::JSON) {
+        const auto lower_type = expr_->lower_val_.val_case();
+        const auto upper_type = expr_->upper_val_.val_case();
+        const auto is_numeric =
+            (lower_type == proto::plan::GenericValue::ValCase::kInt64Val ||
+             lower_type == proto::plan::GenericValue::ValCase::kFloatVal) &&
+            (upper_type == proto::plan::GenericValue::ValCase::kInt64Val ||
+             upper_type == proto::plan::GenericValue::ValCase::kFloatVal);
+        const auto has_unsafe_int_bound =
+            is_numeric &&
+            ((lower_type == proto::plan::GenericValue::ValCase::kInt64Val &&
+              !IsInt64SafeForJsonDoubleIndex(expr_->lower_val_.int64_val())) ||
+             (upper_type == proto::plan::GenericValue::ValCase::kInt64Val &&
+              !IsInt64SafeForJsonDoubleIndex(expr_->upper_val_.int64_val())));
+        if (lower_type == proto::plan::GenericValue::ValCase::kStringVal ||
+            has_unsafe_int_bound) {
+            exec_path_ = ExprExecPath::RawData;
+            return;
+        }
+    }
+
+    // ARRAY type cannot use scalar index.
     if (data_type == DataType::ARRAY) {
         exec_path_ = ExprExecPath::RawData;
+        return;
+    }
+
+    SegmentExpr::DetermineExecPath();
+    if (exec_path_ != ExprExecPath::ScalarIndex) {
+        return;
     }
 }
 

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -121,19 +121,17 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                       proto::plan::GenericValue::ValCase::kFloatVal) &&
                  (upper_type == proto::plan::GenericValue::ValCase::kInt64Val ||
                   upper_type == proto::plan::GenericValue::ValCase::kFloatVal));
-            const auto has_unsafe_int_bound =
-                is_numeric &&
-                ((lower_type == proto::plan::GenericValue::ValCase::kInt64Val &&
-                  !IsInt64SafeForJsonDoubleIndex(
-                      expr_->lower_val_.int64_val())) ||
-                 (upper_type == proto::plan::GenericValue::ValCase::kInt64Val &&
-                  !IsInt64SafeForJsonDoubleIndex(
-                      expr_->upper_val_.int64_val())));
+            const auto requires_precise_int64_comparison =
+                is_numeric && (JsonNumericBoundRequiresPreciseInt64Comparison(
+                                   expr_->lower_val_) ||
+                               JsonNumericBoundRequiresPreciseInt64Comparison(
+                                   expr_->upper_val_));
 
-            if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
+            if (exec_path_ == ExprExecPath::ScalarIndex &&
+                (!has_offset_input_ || !PinnedJsonIndexIsFlat())) {
                 if (is_numeric) {
                     if (!use_double && PinnedJsonIndexIsFlat()) {
-                        result = ExecRangeVisitorImplForIndex<int64_t>();
+                        result = ExecRangeVisitorImplForIndex<int64_t>(input);
                     } else {
                         proto::plan::GenericValue double_lower_val;
                         if (lower_type ==
@@ -158,11 +156,11 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                         upper_arg_.SetValue<double>(double_upper_val);
                         arg_inited_ = true;
 
-                        result = ExecRangeVisitorImplForIndex<double>();
+                        result = ExecRangeVisitorImplForIndex<double>(input);
                     }
                 } else if (lower_type ==
                            proto::plan::GenericValue::ValCase::kStringVal) {
-                    result = ExecRangeVisitorImplForJson<std::string>(context);
+                    result = ExecRangeVisitorImplForIndex<std::string>(input);
                 } else {
                     ThrowInfo(
                         UnexpectedError,
@@ -170,9 +168,8 @@ PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                                     lower_type));
                 }
             } else {
-                if (has_unsafe_int_bound &&
-                    (has_offset_input_ ||
-                     exec_path_ != ExprExecPath::JsonStats)) {
+                if (requires_precise_int64_comparison &&
+                    exec_path_ != ExprExecPath::JsonStats) {
                     result = ExecRangeVisitorImplForJsonPreciseNumeric(context);
                 } else if (is_numeric && use_double) {
                     // Use double when either bound is float
@@ -289,9 +286,11 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonPreciseNumeric(
                 continue;
             }
             auto lower_comparison =
-                CompareJsonNumberToBound(number.value(), lower_bound);
+                CompareJsonNumberToBoundWithUint64DoubleFallback(number.value(),
+                                                                 lower_bound);
             auto upper_comparison =
-                CompareJsonNumberToBound(number.value(), upper_bound);
+                CompareJsonNumberToBoundWithUint64DoubleFallback(number.value(),
+                                                                 upper_bound);
             if (!lower_comparison.has_value() ||
                 !upper_comparison.has_value()) {
                 res[i] = false;
@@ -404,7 +403,7 @@ PhyBinaryRangeFilterExpr::PreCheckOverflow(HighPrecisionType& val1,
 
 template <typename T>
 VectorPtr
-PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
+PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex(OffsetVector* input) {
     typedef std::
         conditional_t<std::is_same_v<T, std::string_view>, std::string, T>
             IndexInnerType;
@@ -419,13 +418,13 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
     HighPrecisionType val2;
     bool lower_inclusive = false;
     bool upper_inclusive = false;
-    if (auto res =
-            PreCheckOverflow<T>(val1, val2, lower_inclusive, upper_inclusive)) {
+    if (auto res = PreCheckOverflow<T>(
+            val1, val2, lower_inclusive, upper_inclusive, input)) {
         return res;
     }
 
     auto real_batch_size =
-        GetNextRealBatchSize(nullptr, expr_->column_.element_level_);
+        GetNextRealBatchSize(input, expr_->column_.element_level_);
     if (real_batch_size == 0) {
         return nullptr;
     }
@@ -437,6 +436,25 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForIndex() {
         BinaryRangeIndexFunc<T> func;
         return func(index_ptr, val1, val2, lower_inclusive, upper_inclusive);
     };
+    if (input != nullptr) {
+        if (cached_result_ == nullptr) {
+            auto scalar_index =
+                dynamic_cast<const Index*>(pinned_index_[0].get());
+            AssertInfo(scalar_index != nullptr, "invalid scalar index type");
+            auto* index_ptr = const_cast<Index*>(scalar_index);
+            cached_result_ = std::make_shared<TargetBitmap>(
+                execute_sub_batch(index_ptr, val1, val2));
+            cached_valid_result_ = std::make_shared<TargetBitmap>(
+                GetCachedIndexValidBitmap(index_ptr).clone());
+            AssertInfo(
+                cached_result_->size() == static_cast<size_t>(active_count_),
+                "index range result size {} does not match row count {}",
+                cached_result_->size(),
+                active_count_);
+        }
+        return GatherCachedResultByOffsets(
+            *cached_result_, *cached_valid_result_, *input);
+    }
     auto res = ProcessIndexChunks<T>(execute_sub_batch, val1, val2);
     AssertInfo(res->size() == real_batch_size,
                "internal error: expr processed rows {} not equal "
@@ -619,11 +637,11 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJson(EvalCtx& context) {
     const auto& bitmap_input = context.get_bitmap_input();
     auto* input = context.get_offset_input();
     FieldId field_id = expr_->column_.field_id_;
-    if (!has_offset_input_ && exec_path_ == ExprExecPath::JsonStats) {
+    if (exec_path_ == ExprExecPath::JsonStats) {
         milvus::ScopedTimer timer(
             "binary_range_json_by_stats",
             [this](double us) { json_filter_stats_latency_us_ += us; });
-        return ExecRangeVisitorImplForJsonStats<ValueType>();
+        return ExecRangeVisitorImplForJsonStats<ValueType>(input);
     }
 
     milvus::ScopedTimer timer(
@@ -758,11 +776,15 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJson(EvalCtx& context) {
 
 template <typename ValueType>
 VectorPtr
-PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
+PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats(
+    OffsetVector* input) {
     using GetType = std::conditional_t<std::is_same_v<ValueType, std::string>,
                                        std::string_view,
                                        ValueType>;
-    auto real_batch_size = GetNextBatchSize();
+    auto real_batch_size =
+        input != nullptr
+            ? input->size()
+            : std::min(batch_size_, active_count_ - current_data_global_pos_);
     if (real_batch_size == 0) {
         return nullptr;
     }
@@ -960,6 +982,10 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
         CachePut(CacheElapsedUs(cache_compute_start));
     }
 
+    if (input != nullptr) {
+        return GatherCachedResultByOffsets(
+            *cached_index_chunk_res_, *cached_index_chunk_valid_res_, *input);
+    }
     auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
                                  *cached_index_chunk_valid_res_,
                                  current_data_global_pos_,
@@ -1177,14 +1203,12 @@ PhyBinaryRangeFilterExpr::DetermineExecPath() {
              lower_type == proto::plan::GenericValue::ValCase::kFloatVal) &&
             (upper_type == proto::plan::GenericValue::ValCase::kInt64Val ||
              upper_type == proto::plan::GenericValue::ValCase::kFloatVal);
-        const auto has_unsafe_int_bound =
+        const auto requires_precise_int64_comparison =
             is_numeric &&
-            ((lower_type == proto::plan::GenericValue::ValCase::kInt64Val &&
-              !IsInt64SafeForJsonDoubleIndex(expr_->lower_val_.int64_val())) ||
-             (upper_type == proto::plan::GenericValue::ValCase::kInt64Val &&
-              !IsInt64SafeForJsonDoubleIndex(expr_->upper_val_.int64_val())));
-        if (lower_type == proto::plan::GenericValue::ValCase::kStringVal ||
-            has_unsafe_int_bound) {
+            (JsonNumericBoundRequiresPreciseInt64Comparison(
+                 expr_->lower_val_) ||
+             JsonNumericBoundRequiresPreciseInt64Comparison(expr_->upper_val_));
+        if (requires_precise_int64_comparison) {
             exec_path_ = ExprExecPath::RawData;
             return;
         }
@@ -1199,6 +1223,23 @@ PhyBinaryRangeFilterExpr::DetermineExecPath() {
     SegmentExpr::DetermineExecPath();
     if (exec_path_ != ExprExecPath::ScalarIndex) {
         return;
+    }
+
+    if (data_type == DataType::JSON &&
+        expr_->lower_val_.val_case() ==
+            proto::plan::GenericValue::ValCase::kStringVal) {
+        auto* index_ptr = dynamic_cast<const index::ScalarIndex<std::string>*>(
+            pinned_index_[0].get());
+        const auto supports_range =
+            index_ptr != nullptr &&
+            index_ptr->GetIndexType() != index::ScalarIndexType::NGRAM &&
+            SegmentExpr::CanUseIndexForOp<std::string>(
+                proto::plan::OpType::GreaterEqual) &&
+            SegmentExpr::CanUseIndexForOp<std::string>(
+                proto::plan::OpType::LessEqual);
+        if (!supports_range) {
+            exec_path_ = ExprExecPath::RawData;
+        }
     }
 }
 

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -336,7 +336,7 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
 
     template <typename T>
     VectorPtr
-    ExecRangeVisitorImplForIndex();
+    ExecRangeVisitorImplForIndex(OffsetVector* input = nullptr);
 
     template <typename T>
     VectorPtr
@@ -351,7 +351,7 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
 
     template <typename ValueType>
     VectorPtr
-    ExecRangeVisitorImplForJsonStats();
+    ExecRangeVisitorImplForJsonStats(OffsetVector* input = nullptr);
 
     template <typename ValueType>
     VectorPtr

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1870,7 +1870,20 @@ class SegmentExpr : public Expr {
     VectorPtr
     ProcessIndexChunks(FUNC func, const ValTypes&... values) {
         return ProcessIndexChunksImpl<T>(
-            func, false, IndexValidityMode::Default, values...);
+            func, false, IndexValidityMode::Default, nullptr, values...);
+    }
+
+    // Execute an index query once for the whole segment and gather only the
+    // requested rows. Unlike ProcessIndexChunksByOffsets, this also supports
+    // JSON indexes whose query APIs return a full row-level bitmap (including
+    // JsonFlatIndexQueryExecutor).
+    template <typename T, typename FUNC, typename... ValTypes>
+    VectorPtr
+    ProcessIndexChunksAndGatherByOffsets(FUNC func,
+                                         const OffsetVector& offsets,
+                                         const ValTypes&... values) {
+        return ProcessIndexChunksImpl<T>(
+            func, false, IndexValidityMode::Default, &offsets, values...);
     }
 
     // ProcessIndexChunks with func_returns_row_level flag
@@ -1881,7 +1894,8 @@ class SegmentExpr : public Expr {
     ProcessIndexChunksWithRowLevel(FUNC func,
                                    IndexValidityMode validity_mode,
                                    const ValTypes&... values) {
-        return ProcessIndexChunksImpl<T>(func, true, validity_mode, values...);
+        return ProcessIndexChunksImpl<T>(
+            func, true, validity_mode, nullptr, values...);
     }
 
     TargetBitmap
@@ -1922,6 +1936,7 @@ class SegmentExpr : public Expr {
     ProcessIndexChunksImpl(FUNC func,
                            bool func_returns_row_level,
                            IndexValidityMode validity_mode,
+                           const OffsetVector* offsets,
                            const ValTypes&... values) {
         typedef std::
             conditional_t<std::is_same_v<T, std::string_view>, std::string, T>
@@ -2039,6 +2054,20 @@ class SegmentExpr : public Expr {
         // If func already returns row-level bitset, skip element-to-row conversion
         bool need_element_slicing =
             cached_is_nested_index_ && !func_returns_row_level;
+
+        if (offsets != nullptr) {
+            AssertInfo(!need_element_slicing,
+                       "cannot gather row offsets from an element-level "
+                       "index result");
+            AssertInfo(cached_index_chunk_res_->size() ==
+                           static_cast<size_t>(active_count_),
+                       "index result size {} does not match row count {}",
+                       cached_index_chunk_res_->size(),
+                       active_count_);
+            return GatherCachedResultByOffsets(*cached_index_chunk_res_,
+                                               *cached_index_chunk_valid_res_,
+                                               *offsets);
+        }
 
         if (need_element_slicing) {
             // Nested index with element-level result: batch by rows, slice elements

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <bit>
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -445,8 +446,11 @@ class SegmentExpr : public Expr {
                 if (segment_->HasFieldData(field_id_)) {
                     MoveCursorForData();
                 }
+            } else if (exec_path_ == ExprExecPath::JsonStats) {
+                current_data_global_pos_ += std::min(
+                    batch_size_, active_count_ - current_data_global_pos_);
             } else {
-                // RawData, PkIndex, TextIndex, JsonStats all use data cursor.
+                // RawData, PkIndex, and TextIndex use the data cursor.
                 MoveCursorForData();
             }
         }
@@ -535,6 +539,11 @@ class SegmentExpr : public Expr {
 
     int64_t
     GetNextBatchSize() {
+        EnsureExecPathDetermined();
+        if (exec_path_ == ExprExecPath::JsonStats) {
+            return std::min(batch_size_,
+                            active_count_ - current_data_global_pos_);
+        }
         auto current_chunk =
             UseIndexCursor() ? current_index_chunk_ : current_data_chunk_;
         auto current_chunk_pos = UseIndexCursor() ? current_index_chunk_pos_
@@ -2496,6 +2505,28 @@ class SegmentExpr : public Expr {
                value < kFirstNonInjectiveInteger;
     }
 
+    static bool
+    JsonNumericBoundRequiresPreciseInt64Comparison(
+        const proto::plan::GenericValue& bound) {
+        if (bound.has_int64_val()) {
+            return !IsInt64SafeForJsonDoubleIndex(bound.int64_val());
+        }
+        if (!bound.has_float_val() || !std::isfinite(bound.float_val())) {
+            return false;
+        }
+
+        // A double bound in this interval can alias a neighboring int64 when
+        // JSON data or a path index converts the integer to double. Bounds
+        // outside the int64 domain cannot have that ambiguity.
+        constexpr double kFirstNonInjectiveInteger = 0x1p53;
+        constexpr double kInt64Magnitude = 0x1p63;
+        const auto value = bound.float_val();
+        return (value >= kFirstNonInjectiveInteger &&
+                value <= kInt64Magnitude) ||
+               (value <= -kFirstNonInjectiveInteger &&
+                value >= -kInt64Magnitude);
+    }
+
  public:
     bool
     CanUseNestedIndex() const override {
@@ -2649,6 +2680,30 @@ class SegmentExpr : public Expr {
         valid_result.append(
             *cached_valid_result_, current_data_global_pos_, real_batch_size);
         MoveCursor();
+        return std::make_shared<ColumnVector>(std::move(result),
+                                              std::move(valid_result));
+    }
+
+    VectorPtr
+    GatherCachedResultByOffsets(const TargetBitmap& cached_res,
+                                const TargetBitmap& cached_valid_res,
+                                const OffsetVector& offsets) const {
+        AssertInfo(cached_res.size() == cached_valid_res.size(),
+                   "cached result and validity sizes differ: {} vs {}",
+                   cached_res.size(),
+                   cached_valid_res.size());
+        TargetBitmap result(offsets.size(), false);
+        TargetBitmap valid_result(offsets.size(), false);
+        for (size_t i = 0; i < offsets.size(); ++i) {
+            const auto offset = offsets[i];
+            AssertInfo(
+                offset >= 0 && static_cast<size_t>(offset) < cached_res.size(),
+                "offset {} is outside cached result size {}",
+                offset,
+                cached_res.size());
+            result[i] = cached_res[offset];
+            valid_result[i] = cached_valid_res[offset];
+        }
         return std::make_shared<ColumnVector>(std::move(result),
                                               std::move(valid_result));
     }

--- a/internal/core/src/exec/expression/ExprBatchTestUtils.h
+++ b/internal/core/src/exec/expression/ExprBatchTestUtils.h
@@ -1,0 +1,119 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "common/Common.h"
+#include "common/Consts.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/EvalCtx.h"
+#include "exec/expression/Expr.h"
+
+namespace milvus::test {
+
+struct ExprBatchEvalResult {
+    std::vector<int64_t> batch_sizes;
+    ColumnVectorPtr result;
+};
+
+class ExprBatchSizeGuard {
+ public:
+    explicit ExprBatchSizeGuard(int64_t batch_size)
+        : old_batch_size_(EXEC_EVAL_EXPR_BATCH_SIZE.exchange(batch_size)) {
+    }
+
+    ~ExprBatchSizeGuard() {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(old_batch_size_);
+    }
+
+ private:
+    int64_t old_batch_size_;
+};
+
+inline ExprBatchEvalResult
+EvalExprInBatches(const expr::TypedExprPtr& logical_expr,
+                  const segcore::SegmentInternalInterface* segment,
+                  int64_t active_count) {
+    auto query_context = std::make_shared<exec::QueryContext>(
+        DEAFULT_QUERY_ID, segment, active_count, MAX_TIMESTAMP);
+    exec::ExecContext exec_context(query_context.get());
+    auto compiled =
+        exec::CompileExpressions({logical_expr}, &exec_context, {}, false);
+    AssertInfo(compiled.size() == 1,
+               "expected one compiled expression, got {}",
+               compiled.size());
+
+    exec::EvalCtx eval_context(&exec_context);
+    ExprBatchEvalResult evaluation;
+    TargetBitmap combined_result;
+    TargetBitmap combined_validity;
+    int64_t processed_rows = 0;
+    while (processed_rows < active_count) {
+        VectorPtr result;
+        compiled[0]->Eval(eval_context, result);
+        AssertInfo(result != nullptr,
+                   "expression evaluation stopped after {} of {} rows",
+                   processed_rows,
+                   active_count);
+        auto column = std::dynamic_pointer_cast<ColumnVector>(result);
+        AssertInfo(column != nullptr && column->IsBitmap(),
+                   "expected bitmap column result");
+        const auto batch_size = column->size();
+        AssertInfo(
+            batch_size > 0 && processed_rows + batch_size <= active_count,
+            "invalid expression batch size {} after {} of {} rows",
+            batch_size,
+            processed_rows,
+            active_count);
+        evaluation.batch_sizes.push_back(batch_size);
+        combined_result.append(
+            TargetBitmapView(column->GetRawData(), batch_size));
+        combined_validity.append(
+            TargetBitmapView(column->GetValidRawData(), batch_size));
+        processed_rows += batch_size;
+    }
+    evaluation.result = std::make_shared<ColumnVector>(
+        std::move(combined_result), std::move(combined_validity));
+    return evaluation;
+}
+
+inline std::vector<int64_t>
+EvalExprBatchSizes(const expr::TypedExprPtr& logical_expr,
+                   const segcore::SegmentInternalInterface* segment,
+                   int64_t active_count) {
+    return EvalExprInBatches(logical_expr, segment, active_count).batch_sizes;
+}
+
+inline bool
+CanExprExecuteAllAtOnce(const expr::TypedExprPtr& logical_expr,
+                        const segcore::SegmentInternalInterface* segment,
+                        int64_t active_count) {
+    auto query_context = std::make_shared<exec::QueryContext>(
+        DEAFULT_QUERY_ID, segment, active_count, MAX_TIMESTAMP);
+    exec::ExecContext exec_context(query_context.get());
+    auto compiled =
+        exec::CompileExpressions({logical_expr}, &exec_context, {}, false);
+    AssertInfo(compiled.size() == 1,
+               "expected one compiled expression, got {}",
+               compiled.size());
+    return compiled[0]->CanExecuteAllAtOnce();
+}
+
+}  // namespace milvus::test

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -17,6 +17,8 @@
 #include "ExprTestBase.h"
 #include "ExprBatchTestUtils.h"
 
+#include <numeric>
+
 template <typename T>
 class JsonIndexTestFixture : public testing::Test {
  public:
@@ -319,6 +321,198 @@ TEST(JsonIndexTest, JsonSortLikeUsesIndexWithoutRawJson) {
             EXPECT_EQ(valid_view[i], i < 5) << "op " << op << ", row " << i;
         }
     }
+}
+
+TEST(JsonIndexTest, JsonBinaryRangePathIndexMatchesRawData) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+
+    const std::vector<std::string> json_strs = {
+        R"({"n": 1, "s": "alpha"})",
+        R"({"n": 2, "s": "beta"})",
+        R"({"n": 3.5, "s": "gamma"})",
+        R"({"n": "2", "s": 2})",
+        R"({"other": 0})",
+        R"({"n": null, "s": null})",
+        R"({"n": 4, "s": "delta"})",
+        R"({"n": 5, "s": "epsilon"})",
+        R"({"n": 9007199254740993, "s": "zeta"})",
+    };
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    std::vector<milvus::Json> jsons;
+    jsons.reserve(json_strs.size());
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    auto* valid_data = json_field->ValidData();
+    std::fill(valid_data,
+              valid_data + json_field->ValidDataSize(),
+              static_cast<uint8_t>(0));
+    valid_data[0] = 0b01111111;
+    valid_data[1] = 0b00000001;
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto raw_segment = CreateSealedSegment(schema);
+    auto raw_load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    raw_segment->LoadFieldData(raw_load_info);
+
+    auto make_index_segment = [&](const JsonCastType& cast_type,
+                                  const std::string& path,
+                                  const std::string& cache_key,
+                                  bool load_raw_json = false) {
+        auto segment = CreateSealedSegment(schema);
+
+        std::vector<int64_t> row_ids(json_strs.size());
+        std::iota(row_ids.begin(), row_ids.end(), 0);
+        auto row_id_field_data =
+            storage::CreateFieldData(DataType::INT64, DataType::NONE, false);
+        row_id_field_data->FillFieldData(row_ids.data(), row_ids.size());
+        auto row_id_load_info = PrepareSingleFieldInsertBinlog(
+            1, 1, 1, RowFieldID.get(), {row_id_field_data}, cm);
+        segment->LoadFieldData(row_id_load_info);
+
+        auto file_manager_ctx = storage::FileManagerContext();
+        file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+            proto::schema::JSON);
+        file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+        file_manager_ctx.fieldDataMeta.field_schema.set_nullable(true);
+        file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
+        auto json_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+            index::CreateIndexInfo{
+                .index_type = index::INVERTED_INDEX_TYPE,
+                .json_cast_type = cast_type,
+                .json_path = path,
+            },
+            file_manager_ctx);
+        if (cast_type.data_type() == JsonCastType::DataType::DOUBLE) {
+            auto* typed_index = dynamic_cast<index::JsonInvertedIndex<double>*>(
+                json_index.get());
+            AssertInfo(typed_index != nullptr,
+                       "expected a DOUBLE JSON path index");
+            typed_index->BuildWithFieldData({json_field});
+            typed_index->finish();
+            typed_index->create_reader(milvus::index::SetBitsetSealed);
+        } else {
+            auto* typed_index =
+                dynamic_cast<index::JsonInvertedIndex<std::string>*>(
+                    json_index.get());
+            AssertInfo(typed_index != nullptr,
+                       "expected a VARCHAR JSON path index");
+            typed_index->BuildWithFieldData({json_field});
+            typed_index->finish();
+            typed_index->create_reader(milvus::index::SetBitsetSealed);
+        }
+
+        segcore::LoadIndexInfo load_index_info;
+        load_index_info.field_id = json_fid.get();
+        load_index_info.field_type = DataType::JSON;
+        load_index_info.index_params = {{JSON_PATH, path},
+                                        {JSON_CAST_TYPE, cast_type.ToString()}};
+        load_index_info.cache_index =
+            CreateTestCacheIndex(cache_key, std::move(json_index));
+        segment->LoadIndex(load_index_info);
+        if (load_raw_json) {
+            auto raw_load_info = PrepareSingleFieldInsertBinlog(
+                1, 1, 2, json_fid.get(), {json_field}, cm);
+            segment->LoadFieldData(raw_load_info);
+        } else {
+            AssertInfo(!segment->HasFieldData(json_fid),
+                       "raw JSON must stay unloaded for this test");
+        }
+        return segment;
+    };
+
+    auto number_index_segment = make_index_segment(
+        JsonCastType::FromString("DOUBLE"), "/n", "json_binary_range_number");
+    auto string_index_segment = make_index_segment(
+        JsonCastType::FromString("VARCHAR"), "/s", "json_binary_range_string");
+    auto precise_number_segment =
+        make_index_segment(JsonCastType::FromString("DOUBLE"),
+                           "/n",
+                           "json_binary_range_precise_number",
+                           true);
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr,
+                        const segcore::SegmentInternalInterface* segment,
+                        exec::OffsetVector* offsets = nullptr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), segment, json_strs.size(), MAX_TIMESTAMP, offsets);
+    };
+    auto expect_same = [&](const ColumnVectorPtr& raw,
+                           const ColumnVectorPtr& indexed) {
+        ASSERT_EQ(raw->size(), indexed->size());
+        TargetBitmapView raw_result(raw->GetRawData(), raw->size());
+        TargetBitmapView raw_valid(raw->GetValidRawData(), raw->size());
+        TargetBitmapView index_result(indexed->GetRawData(), indexed->size());
+        TargetBitmapView index_valid(indexed->GetValidRawData(),
+                                     indexed->size());
+        for (size_t i = 0; i < raw->size(); ++i) {
+            EXPECT_EQ(index_valid[i], raw_valid[i]) << "row " << i;
+            EXPECT_EQ(index_result[i], raw_result[i]) << "row " << i;
+        }
+    };
+
+    proto::plan::GenericValue number_lower;
+    number_lower.set_int64_val(2);
+    proto::plan::GenericValue number_upper;
+    number_upper.set_float_val(4.0);
+    auto number_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+        number_lower,
+        number_upper,
+        true,
+        true);
+    expect_same(evaluate(number_expr, raw_segment.get()),
+                evaluate(number_expr, number_index_segment.get()));
+
+    // Keep the indexed segment path-index-only: before the offset index path
+    // was supported, evaluation tried to reverse-lookup raw Json values from
+    // ScalarIndex<double> and crashed instead of producing candidate results.
+    exec::OffsetVector offsets = {7, 2, 4, 1, 3, 5, 6, 0, 2};
+    expect_same(evaluate(number_expr, raw_segment.get(), &offsets),
+                evaluate(number_expr, number_index_segment.get(), &offsets));
+
+    proto::plan::GenericValue string_lower;
+    string_lower.set_string_val("beta");
+    proto::plan::GenericValue string_upper;
+    string_upper.set_string_val("gamma");
+    auto string_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"s"}),
+        string_lower,
+        string_upper,
+        true,
+        false);
+    expect_same(evaluate(string_expr, raw_segment.get()),
+                evaluate(string_expr, string_index_segment.get()));
+    expect_same(evaluate(string_expr, raw_segment.get(), &offsets),
+                evaluate(string_expr, string_index_segment.get(), &offsets));
+
+    proto::plan::GenericValue precise_lower;
+    precise_lower.set_float_val(9007199254740992.0);
+    proto::plan::GenericValue precise_upper;
+    precise_upper.set_float_val(9007199254740994.0);
+    auto precise_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+        precise_lower,
+        precise_upper,
+        false,
+        false);
+    EXPECT_FALSE(milvus::test::CanExprExecuteAllAtOnce(
+        precise_expr, precise_number_segment.get(), json_strs.size()));
+    auto raw_precise = evaluate(precise_expr, raw_segment.get());
+    auto indexed_precise = evaluate(precise_expr, precise_number_segment.get());
+    expect_same(raw_precise, indexed_precise);
+    TargetBitmapView precise_result(raw_precise->GetRawData(),
+                                    raw_precise->size());
+    TargetBitmapView precise_valid(raw_precise->GetValidRawData(),
+                                   raw_precise->size());
+    EXPECT_TRUE(precise_valid[8]);
+    EXPECT_TRUE(precise_result[8]);
 }
 
 TEST(JsonIndexTest, EmptyJsonInIsDeterministicForEveryRow) {
@@ -972,17 +1166,13 @@ TEST_P(JsonIndexBinaryExprTest, TestBinaryRangeExpr) {
     file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
     file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
 
-    auto inv_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+    auto json_index = index::IndexFactory::GetInstance().CreateJsonIndex(
         index::CreateIndexInfo{
             .index_type = index::INVERTED_INDEX_TYPE,
             .json_cast_type = GetParam(),
             .json_path = "/a",
         },
         file_manager_ctx);
-
-    using json_index_type = index::JsonInvertedIndex<double>;
-    auto json_index = std::unique_ptr<json_index_type>(
-        static_cast<json_index_type*>(inv_index.release()));
     auto json_field =
         std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
     std::vector<milvus::Json> jsons;
@@ -991,10 +1181,22 @@ TEST_P(JsonIndexBinaryExprTest, TestBinaryRangeExpr) {
         jsons.push_back(milvus::Json(simdjson::padded_string(json)));
     }
     json_field->add_json_data(jsons);
-
-    json_index->BuildWithFieldData({json_field});
-    json_index->finish();
-    json_index->create_reader(milvus::index::SetBitsetSealed);
+    if (GetParam().data_type() == JsonCastType::DataType::DOUBLE) {
+        auto* typed_index =
+            dynamic_cast<index::JsonInvertedIndex<double>*>(json_index.get());
+        ASSERT_NE(typed_index, nullptr);
+        typed_index->BuildWithFieldData({json_field});
+        typed_index->finish();
+        typed_index->create_reader(milvus::index::SetBitsetSealed);
+    } else {
+        auto* typed_index =
+            dynamic_cast<index::JsonInvertedIndex<std::string>*>(
+                json_index.get());
+        ASSERT_NE(typed_index, nullptr);
+        typed_index->BuildWithFieldData({json_field});
+        typed_index->finish();
+        typed_index->create_reader(milvus::index::SetBitsetSealed);
+    }
 
     load_index_info.field_id = json_fid.get();
     load_index_info.field_type = DataType::JSON;

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include "ExprTestBase.h"
+#include "ExprBatchTestUtils.h"
 
 template <typename T>
 class JsonIndexTestFixture : public testing::Test {
@@ -409,6 +410,7 @@ TEST(JsonIndexTest, EmptyJsonInIsDeterministicForEveryRow) {
 }
 
 TEST(JsonIndexTest, LargeInt64LiteralDoesNotAliasInDoublePathIndex) {
+    milvus::test::ExprBatchSizeGuard batch_size_guard(2);
     auto schema = std::make_shared<Schema>();
     schema->AddDebugField(
         "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
@@ -462,6 +464,14 @@ TEST(JsonIndexTest, LargeInt64LiteralDoesNotAliasInDoublePathIndex) {
         1, 1, 1, json_fid.get(), {json_field}, cm);
     seg->LoadFieldData(load_info);
 
+    const auto evaluate = [&](const expr::TypedExprPtr& expr) {
+        milvus::test::ExprBatchEvalResult evaluation;
+        EXPECT_NO_THROW(evaluation = milvus::test::EvalExprInBatches(
+                            expr, seg.get(), json_strs.size()));
+        EXPECT_EQ(evaluation.batch_sizes, (std::vector<int64_t>{2, 1}));
+        return evaluation.result;
+    };
+
     proto::plan::GenericValue value;
     value.set_int64_val(9007199254740993LL);
     auto equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
@@ -469,10 +479,7 @@ TEST(JsonIndexTest, LargeInt64LiteralDoesNotAliasInDoublePathIndex) {
         proto::plan::OpType::Equal,
         value,
         std::vector<proto::plan::GenericValue>());
-    auto plan =
-        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, equal_expr);
-    auto result = milvus::test::gen_filter_res(
-        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    auto result = evaluate(equal_expr);
     TargetBitmapView result_view(result->GetRawData(), result->size());
     TargetBitmapView valid_view(result->GetValidRawData(), result->size());
     for (size_t i = 0; i < result->size(); ++i) {
@@ -486,10 +493,7 @@ TEST(JsonIndexTest, LargeInt64LiteralDoesNotAliasInDoublePathIndex) {
         expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
         std::vector<proto::plan::GenericValue>{value},
         false);
-    plan =
-        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, term_expr);
-    result = milvus::test::gen_filter_res(
-        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    result = evaluate(term_expr);
     result_view = TargetBitmapView(result->GetRawData(), result->size());
     valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
     EXPECT_FALSE(result_view[0]);
@@ -501,10 +505,7 @@ TEST(JsonIndexTest, LargeInt64LiteralDoesNotAliasInDoublePathIndex) {
         proto::plan::OpType::GreaterThan,
         value,
         std::vector<proto::plan::GenericValue>());
-    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
-                                                  greater_expr);
-    result = milvus::test::gen_filter_res(
-        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    result = evaluate(greater_expr);
     result_view = TargetBitmapView(result->GetRawData(), result->size());
     valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
     EXPECT_FALSE(result_view[0]);
@@ -517,10 +518,7 @@ TEST(JsonIndexTest, LargeInt64LiteralDoesNotAliasInDoublePathIndex) {
         value,
         true,
         true);
-    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
-                                                  between_expr);
-    result = milvus::test::gen_filter_res(
-        plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP);
+    result = evaluate(between_expr);
     result_view = TargetBitmapView(result->GetRawData(), result->size());
     valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
     EXPECT_FALSE(result_view[0]);
@@ -860,6 +858,7 @@ INSTANTIATE_TEST_SUITE_P(JsonIndexBinaryExprTestParams,
                                          JsonCastType::FromString("VARCHAR")));
 
 TEST_P(JsonIndexBinaryExprTest, TestBinaryRangeExpr) {
+    milvus::test::ExprBatchSizeGuard batch_size_guard(7);
     auto json_strs = std::vector<std::string>{
         R"({"a": 1})",
         R"({"a": 2})",
@@ -1044,6 +1043,10 @@ TEST_P(JsonIndexBinaryExprTest, TestBinaryRangeExpr) {
             upper_val,
             lower_inclusive,
             upper_inclusive);
+        std::vector<int64_t> batch_sizes;
+        EXPECT_NO_THROW(batch_sizes = milvus::test::EvalExprBatchSizes(
+                            binary_expr, seg.get(), json_strs.size()));
+        EXPECT_EQ(batch_sizes, (std::vector<int64_t>{7, 7, 1}));
         auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
                                                            binary_expr);
         auto res =

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -515,6 +515,117 @@ TEST(JsonIndexTest, JsonBinaryRangePathIndexMatchesRawData) {
     EXPECT_TRUE(precise_result[8]);
 }
 
+TEST(JsonIndexTest, JsonBinaryRangeFlatIndexSupportsOffsetInputWithoutRawJson) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+
+    const std::vector<std::string> json_strs = {
+        R"({"n": 1})",
+        R"({"n": 2})",
+        R"({"n": 3.5})",
+        R"({"n": "3"})",
+        R"({"other": 4})",
+        R"({"n": null})",
+        R"({"n": 4})",
+        R"({"n": 5})",
+    };
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    std::vector<milvus::Json> jsons;
+    jsons.reserve(json_strs.size());
+    for (const auto& json : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json));
+    }
+    json_field->add_json_data(jsons);
+    auto* valid_data = json_field->ValidData();
+    std::fill(valid_data,
+              valid_data + json_field->ValidDataSize(),
+              static_cast<uint8_t>(0));
+    valid_data[0] = 0b01111111;
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto raw_segment = CreateSealedSegment(schema);
+    auto raw_load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    raw_segment->LoadFieldData(raw_load_info);
+
+    auto flat_segment = CreateSealedSegment(schema);
+    std::vector<int64_t> row_ids(json_strs.size());
+    std::iota(row_ids.begin(), row_ids.end(), 0);
+    auto row_id_field_data =
+        storage::CreateFieldData(DataType::INT64, DataType::NONE, false);
+    row_id_field_data->FillFieldData(row_ids.data(), row_ids.size());
+    auto row_id_load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, RowFieldID.get(), {row_id_field_data}, cm);
+    flat_segment->LoadFieldData(row_id_load_info);
+
+    auto file_manager_ctx = storage::FileManagerContext();
+    file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+        proto::schema::JSON);
+    file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(json_fid.get());
+    file_manager_ctx.fieldDataMeta.field_schema.set_nullable(true);
+    file_manager_ctx.fieldDataMeta.field_id = json_fid.get();
+    auto json_index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        index::CreateIndexInfo{
+            .index_type = index::INVERTED_INDEX_TYPE,
+            .json_cast_type = JsonCastType::FromString("JSON"),
+            .json_path = "",
+        },
+        file_manager_ctx);
+    auto* flat_index = dynamic_cast<index::JsonFlatIndex*>(json_index.get());
+    ASSERT_NE(flat_index, nullptr);
+    flat_index->BuildWithFieldData({json_field});
+    flat_index->finish();
+    flat_index->create_reader(milvus::index::SetBitsetSealed);
+
+    segcore::LoadIndexInfo load_index_info;
+    load_index_info.field_id = json_fid.get();
+    load_index_info.field_type = DataType::JSON;
+    load_index_info.index_params = {{JSON_PATH, ""}, {JSON_CAST_TYPE, "JSON"}};
+    load_index_info.cache_index =
+        CreateTestCacheIndex("json_binary_range_flat", std::move(json_index));
+    flat_segment->LoadIndex(load_index_info);
+    ASSERT_FALSE(flat_segment->HasFieldData(json_fid));
+
+    proto::plan::GenericValue lower;
+    lower.set_int64_val(2);
+    proto::plan::GenericValue upper;
+    upper.set_int64_val(4);
+    auto range_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+        lower,
+        upper,
+        true,
+        true);
+    auto evaluate = [&](const segcore::SegmentInternalInterface* segment,
+                        exec::OffsetVector* offsets) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           range_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), segment, json_strs.size(), MAX_TIMESTAMP, offsets);
+    };
+
+    exec::OffsetVector offsets = {6, 2, 4, 1, 3, 5, 7, 0, 2};
+    auto raw_result = evaluate(raw_segment.get(), &offsets);
+    ColumnVectorPtr flat_result;
+    EXPECT_NO_THROW(flat_result = evaluate(flat_segment.get(), &offsets));
+    ASSERT_NE(flat_result, nullptr);
+    ASSERT_EQ(raw_result->size(), flat_result->size());
+
+    TargetBitmapView raw_values(raw_result->GetRawData(), raw_result->size());
+    TargetBitmapView raw_validity(raw_result->GetValidRawData(),
+                                  raw_result->size());
+    TargetBitmapView flat_values(flat_result->GetRawData(),
+                                 flat_result->size());
+    TargetBitmapView flat_validity(flat_result->GetValidRawData(),
+                                   flat_result->size());
+    for (size_t i = 0; i < offsets.size(); ++i) {
+        EXPECT_EQ(flat_values[i], raw_values[i]) << "candidate " << i;
+        EXPECT_EQ(flat_validity[i], raw_validity[i]) << "candidate " << i;
+    }
+}
+
 TEST(JsonIndexTest, EmptyJsonInIsDeterministicForEveryRow) {
     auto schema = std::make_shared<Schema>();
     schema->AddDebugField(

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -32,6 +32,7 @@
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
 #include "exec/expression/BinaryRangeExpr.h"
+#include "exec/expression/ExprBatchTestUtils.h"
 #include "exec/expression/TermExpr.h"
 #include "exec/expression/UnaryExpr.h"
 #include "expr/ITypeExpr.h"
@@ -928,6 +929,182 @@ TEST(JsonStatsThreeValuedAuditTest,
     check(evaluate(between_expr),
           {false, true, false, false, false, false, false},
           numeric_valid);
+}
+
+TEST(JsonStatsBinaryRangeTest, ShreddingMatchesRawData) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+
+    const std::vector<std::string> json_raw_data = {
+        R"({"n": 1.0, "s": "alpha", "i": 9007199254740992, "u": 9223372036854775809})",
+        R"({"n": 2.0, "s": "beta", "i": 9007199254740993})",
+        R"({"n": 3.5, "s": "gamma", "i": 9007199254740994})",
+        R"({"n": "2", "s": 2, "i": "9007199254740993"})",
+        R"({"other": 0})",
+        R"({"n": null, "s": null, "i": null})",
+        R"({"n": 4.0, "s": "delta", "i": 1})",
+        R"({"n": 5.0, "s": "epsilon", "i": 2})",
+    };
+    const std::vector<uint8_t> valid_data{0b01111111};
+
+    auto stats = BuildAndLoadJsonKeyStats(json_raw_data,
+                                          json_fid,
+                                          TestLocalPath,
+                                          1203,
+                                          2203,
+                                          3203,
+                                          json_fid.get(),
+                                          5203,
+                                          1,
+                                          &valid_data);
+    EXPECT_FALSE(stats
+                     ->GetShreddingField(milvus::index::JsonPointer({"n"}),
+                                         JSONType::DOUBLE)
+                     .empty());
+    EXPECT_FALSE(stats
+                     ->GetShreddingField(milvus::index::JsonPointer({"s"}),
+                                         JSONType::STRING)
+                     .empty());
+    EXPECT_FALSE(stats
+                     ->GetShreddingField(milvus::index::JsonPointer({"i"}),
+                                         JSONType::INT64)
+                     .empty());
+
+    auto stats_segment = segcore::CreateSealedSegment(schema);
+    auto* sealed =
+        dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(stats_segment.get());
+    ASSERT_NE(sealed, nullptr);
+    sealed->SetJsonStatsForTesting(json_fid, stats);
+    auto raw_segment = segcore::CreateSealedSegment(schema);
+
+    auto make_json_field = [&] {
+        auto field =
+            std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+        field->FillFieldData(MakeNullableJsonArray(json_raw_data, valid_data));
+        return field;
+    };
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto stats_load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, json_fid.get(), {make_json_field()}, cm);
+    stats_segment->LoadFieldData(stats_load_info);
+    stats_segment->DropFieldData(json_fid);
+    ASSERT_FALSE(stats_segment->HasFieldData(json_fid));
+    auto raw_load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, json_fid.get(), {make_json_field()}, cm);
+    raw_segment->LoadFieldData(raw_load_info);
+
+    auto evaluate = [&](const expr::TypedExprPtr& filter_expr,
+                        const segcore::SegmentInternalInterface* segment,
+                        exec::OffsetVector* offsets = nullptr) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           filter_expr);
+        return milvus::test::gen_filter_res(
+            plan.get(), segment, json_raw_data.size(), MAX_TIMESTAMP, offsets);
+    };
+    auto expect_same = [](const ColumnVectorPtr& raw,
+                          const ColumnVectorPtr& shredded) {
+        ASSERT_EQ(raw->size(), shredded->size());
+        TargetBitmapView raw_result(raw->GetRawData(), raw->size());
+        TargetBitmapView raw_valid(raw->GetValidRawData(), raw->size());
+        TargetBitmapView shredded_result(shredded->GetRawData(),
+                                         shredded->size());
+        TargetBitmapView shredded_valid(shredded->GetValidRawData(),
+                                        shredded->size());
+        for (size_t i = 0; i < raw->size(); ++i) {
+            EXPECT_EQ(shredded_valid[i], raw_valid[i]) << "row " << i;
+            EXPECT_EQ(shredded_result[i], raw_result[i]) << "row " << i;
+        }
+    };
+
+    proto::plan::GenericValue number_lower;
+    number_lower.set_int64_val(2);
+    proto::plan::GenericValue number_upper;
+    number_upper.set_float_val(4.0);
+    auto number_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+        number_lower,
+        number_upper,
+        true,
+        true);
+    expect_same(evaluate(number_expr, raw_segment.get()),
+                evaluate(number_expr, stats_segment.get()));
+    exec::OffsetVector offsets = {7, 2, 4, 1, 3, 5, 6, 0, 2};
+    expect_same(evaluate(number_expr, raw_segment.get(), &offsets),
+                evaluate(number_expr, stats_segment.get(), &offsets));
+
+    auto unary_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"n"}),
+        proto::plan::OpType::GreaterEqual,
+        number_lower,
+        std::vector<proto::plan::GenericValue>());
+    {
+        milvus::test::ExprBatchSizeGuard batch_size_guard(3);
+        auto raw_batches = milvus::test::EvalExprInBatches(
+            unary_expr, raw_segment.get(), json_raw_data.size());
+        auto stats_batches = milvus::test::EvalExprInBatches(
+            unary_expr, stats_segment.get(), json_raw_data.size());
+        EXPECT_EQ(raw_batches.batch_sizes, (std::vector<int64_t>{3, 3, 2}));
+        EXPECT_EQ(stats_batches.batch_sizes, (std::vector<int64_t>{3, 3, 2}));
+        expect_same(raw_batches.result, stats_batches.result);
+    }
+
+    proto::plan::GenericValue string_lower;
+    string_lower.set_string_val("beta");
+    proto::plan::GenericValue string_upper;
+    string_upper.set_string_val("gamma");
+    auto string_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"s"}),
+        string_lower,
+        string_upper,
+        true,
+        false);
+    expect_same(evaluate(string_expr, raw_segment.get()),
+                evaluate(string_expr, stats_segment.get()));
+    expect_same(evaluate(string_expr, raw_segment.get(), &offsets),
+                evaluate(string_expr, stats_segment.get(), &offsets));
+
+    proto::plan::GenericValue precise_lower;
+    precise_lower.set_float_val(9007199254740992.0);
+    proto::plan::GenericValue precise_upper;
+    precise_upper.set_float_val(9007199254740994.0);
+    auto precise_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"i"}),
+        precise_lower,
+        precise_upper,
+        false,
+        false);
+    auto raw_precise = evaluate(precise_expr, raw_segment.get());
+    auto shredded_precise = evaluate(precise_expr, stats_segment.get());
+    expect_same(raw_precise, shredded_precise);
+    expect_same(evaluate(precise_expr, raw_segment.get(), &offsets),
+                evaluate(precise_expr, stats_segment.get(), &offsets));
+    TargetBitmapView precise_result(raw_precise->GetRawData(),
+                                    raw_precise->size());
+    TargetBitmapView precise_valid(raw_precise->GetValidRawData(),
+                                   raw_precise->size());
+    EXPECT_TRUE(precise_valid[1]);
+    EXPECT_TRUE(precise_result[1]);
+
+    proto::plan::GenericValue uint64_double;
+    uint64_double.set_float_val(9223372036854775808.0);
+    auto uint64_expr = std::make_shared<expr::BinaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"u"}),
+        uint64_double,
+        uint64_double,
+        true,
+        true);
+    auto raw_uint64 = evaluate(uint64_expr, raw_segment.get());
+    auto stats_uint64 = evaluate(uint64_expr, stats_segment.get());
+    expect_same(raw_uint64, stats_uint64);
+    expect_same(evaluate(uint64_expr, raw_segment.get(), &offsets),
+                evaluate(uint64_expr, stats_segment.get(), &offsets));
+    TargetBitmapView uint64_result(raw_uint64->GetRawData(),
+                                   raw_uint64->size());
+    TargetBitmapView uint64_valid(raw_uint64->GetValidRawData(),
+                                  raw_uint64->size());
+    EXPECT_TRUE(uint64_valid[0]);
+    EXPECT_TRUE(uint64_result[0]);
 }
 
 TEST(JsonStatsThreeValuedAuditTest,

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -184,22 +184,8 @@ PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
         }
         case DataType::JSON: {
             if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
-                const auto has_unsafe_int_literal =
-                    std::any_of(expr_->vals_.begin(),
-                                expr_->vals_.end(),
-                                [this](const auto& value) {
-                                    return value.has_int64_val() &&
-                                           !IsInt64SafeForJsonDoubleIndex(
-                                               value.int64_val());
-                                });
-                const auto all_int_literals = std::all_of(
-                    expr_->vals_.begin(),
-                    expr_->vals_.end(),
-                    [](const auto& value) { return value.has_int64_val(); });
-                if (all_int_literals && PinnedJsonIndexIsFlat()) {
+                if (value_type_ == DataType::INT64 && PinnedJsonIndexIsFlat()) {
                     result = EvalArrayContainsForIndexSegment(DataType::INT64);
-                } else if (has_unsafe_int_literal) {
-                    result = EvalJsonContainsForDataSegment(context);
                 } else {
                     result = EvalArrayContainsForIndexSegment(
                         value_type_ == DataType::INT64 ? DataType::DOUBLE

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -514,6 +514,20 @@ class PhyJsonContainsFilterExpr : public SegmentExpr {
             return;
         }
         SegmentExpr::DetermineExecPath();
+        if (exec_path_ != ExprExecPath::ScalarIndex ||
+            expr_->column_.data_type_ != DataType::JSON ||
+            value_type_ != DataType::INT64 || PinnedJsonIndexIsFlat()) {
+            return;
+        }
+        const auto has_unsafe_int_literal = std::any_of(
+            expr_->vals_.begin(),
+            expr_->vals_.end(),
+            [this](const auto& value) {
+                return !IsInt64SafeForJsonDoubleIndex(value.int64_val());
+            });
+        if (has_unsafe_int_literal) {
+            exec_path_ = ExprExecPath::RawData;
+        }
     }
 
  private:

--- a/internal/core/src/exec/expression/JsonNumberComparison.h
+++ b/internal/core/src/exec/expression/JsonNumberComparison.h
@@ -270,6 +270,19 @@ CompareJsonNumberToBound(const simdjson::ondemand::number& number,
     return CompareJsonNumberToBound(number.get_double(), bound);
 }
 
+// JSON stats and typed JSON indexes store uint64 values as double. Preserve
+// that established behavior while comparing int64 JSON values exactly.
+inline std::optional<int>
+CompareJsonNumberToBoundWithUint64DoubleFallback(
+    const simdjson::ondemand::number& number,
+    const proto::plan::GenericValue& bound) {
+    if (number.is_uint64()) {
+        return CompareJsonNumberToBound(
+            static_cast<double>(number.get_uint64()), bound);
+    }
+    return CompareJsonNumberToBound(number, bound);
+}
+
 inline bool
 JsonNumberMatchesOp(int comparison, proto::plan::OpType op) {
     switch (op) {

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -263,16 +263,6 @@ PhyTermFilterExpr::ExecVisitorImplTemplateJson(EvalCtx& context) {
     } else {
         if (exec_path_ == ExprExecPath::ScalarIndex && !has_offset_input_) {
             if constexpr (std::is_same_v<ValueType, int64_t>) {
-                const auto has_unsafe_literal = std::any_of(
-                    expr_->vals_.begin(),
-                    expr_->vals_.end(),
-                    [this](const auto& val) {
-                        return val.has_int64_val() &&
-                               !IsInt64SafeForJsonDoubleIndex(val.int64_val());
-                    });
-                if (has_unsafe_literal) {
-                    return ExecTermJsonFieldInVariable<int64_t>(context);
-                }
                 if (PinnedJsonIndexIsFlat()) {
                     return ExecVisitorImplForIndex<int64_t>();
                 }
@@ -1268,14 +1258,14 @@ PhyTermFilterExpr::DetermineExecPath() {
         return;
     }
 
-    // JsonStats
-    if (CanUseJsonStatsAtInit()) {
-        exec_path_ = ExprExecPath::JsonStats;
+    if (expr_->column_.data_type_ == DataType::JSON && expr_->is_in_field_) {
+        exec_path_ = ExprExecPath::RawData;
         return;
     }
 
-    SegmentExpr::DetermineExecPath();
-    if (exec_path_ != ExprExecPath::ScalarIndex) {
+    // JsonStats
+    if (CanUseJsonStatsAtInit()) {
+        exec_path_ = ExprExecPath::JsonStats;
         return;
     }
 
@@ -1284,9 +1274,28 @@ PhyTermFilterExpr::DetermineExecPath() {
         data_type = expr_->column_.element_type_;
     }
 
-    // ARRAY type cannot use scalar index
+    // ARRAY type cannot use scalar index.
     if (data_type == DataType::ARRAY) {
         exec_path_ = ExprExecPath::RawData;
+        return;
+    }
+
+    SegmentExpr::DetermineExecPath();
+    if (exec_path_ != ExprExecPath::ScalarIndex) {
+        return;
+    }
+
+    if (data_type == DataType::JSON && !expr_->vals_.empty() &&
+        expr_->vals_[0].val_case() ==
+            proto::plan::GenericValue::ValCase::kInt64Val) {
+        const auto has_unsafe_literal = std::any_of(
+            expr_->vals_.begin(), expr_->vals_.end(), [this](const auto& val) {
+                return !IsInt64SafeForJsonDoubleIndex(val.int64_val());
+            });
+        if (has_unsafe_literal && !PinnedJsonIndexIsFlat()) {
+            exec_path_ = ExprExecPath::RawData;
+        }
+        return;
     }
 }
 

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <variant>
 
-#include "BinaryArithOpEvalRangeExpr.h"
 #include "bitset/bitset.h"
 #include "common/EasyAssert.h"
 #include "common/Types.h"
@@ -21,9 +20,165 @@
 namespace milvus {
 namespace exec {
 
+namespace {
+
+int
+SafeAddTimestampField(int base, int64_t delta) {
+    const int64_t min_delta = static_cast<int64_t>(INT_MIN) - base;
+    const int64_t max_delta = static_cast<int64_t>(INT_MAX) - base;
+    AssertInfo(delta >= min_delta && delta <= max_delta,
+               "timestamp interval arithmetic overflow: {} + {} = {}",
+               base,
+               delta,
+               delta < 0 ? "less than INT_MIN" : "greater than INT_MAX");
+    return static_cast<int>(static_cast<int64_t>(base) + delta);
+}
+
+int64_t
+ApplyIntervalSign(int64_t value, int op_sign) {
+    if (op_sign > 0) {
+        return value;
+    }
+    AssertInfo(value != INT64_MIN,
+               "timestamp interval arithmetic overflow: cannot negate {}",
+               value);
+    return -value;
+}
+
+int64_t
+ApplyTimestampInterval(int64_t current_ts_us,
+                       proto::plan::ArithOpType arith_op,
+                       const proto::plan::Interval& interval) {
+    int op_sign;
+    switch (arith_op) {
+        case proto::plan::ArithOpType::Add:
+            op_sign = 1;
+            break;
+        case proto::plan::ArithOpType::Sub:
+            op_sign = -1;
+            break;
+        case proto::plan::ArithOpType::Unknown:
+            return current_ts_us;
+        default:
+            ThrowInfo(UnexpectedError,
+                      "unsupported arithmetic op for "
+                      "timestamptz_arith_compare_expr: {}",
+                      arith_op);
+    }
+
+    // Floor division to correctly handle pre-epoch (negative) timestamps.
+    // Keep the remainder separate so INT64_MIN does not overflow while
+    // reconstructing the sub-second component.
+    int64_t epoch_sec = current_ts_us / 1000000;
+    int64_t sub_sec_us = current_ts_us % 1000000;
+    if (sub_sec_us < 0) {
+        --epoch_sec;
+        sub_sec_us += 1000000;
+    }
+
+    std::time_t epoch_time = epoch_sec;
+    struct std::tm tm_buf;
+    if (::gmtime_r(&epoch_time, &tm_buf) == nullptr) {
+        ThrowInfo(UnexpectedError,
+                  "gmtime_r failed for timestamp {} us",
+                  current_ts_us);
+    }
+
+    // Apply the operation sign without overflowing when an INT64_MIN interval
+    // is subtracted.
+    tm_buf.tm_year = SafeAddTimestampField(
+        tm_buf.tm_year, ApplyIntervalSign(interval.years(), op_sign));
+    tm_buf.tm_mon = SafeAddTimestampField(
+        tm_buf.tm_mon, ApplyIntervalSign(interval.months(), op_sign));
+    tm_buf.tm_mday = SafeAddTimestampField(
+        tm_buf.tm_mday, ApplyIntervalSign(interval.days(), op_sign));
+    tm_buf.tm_hour = SafeAddTimestampField(
+        tm_buf.tm_hour, ApplyIntervalSign(interval.hours(), op_sign));
+    tm_buf.tm_min = SafeAddTimestampField(
+        tm_buf.tm_min, ApplyIntervalSign(interval.minutes(), op_sign));
+    tm_buf.tm_sec = SafeAddTimestampField(
+        tm_buf.tm_sec, ApplyIntervalSign(interval.seconds(), op_sign));
+
+    // timegm normalizes the fields. -1 is a valid epoch second, so it cannot
+    // be used as an error sentinel here.
+    const std::time_t new_epoch_time = ::timegm(&tm_buf);
+    const auto new_epoch_sec = static_cast<int64_t>(new_epoch_time);
+    constexpr int64_t kMaxSec = (INT64_MAX - 999999) / 1000000;
+    constexpr int64_t kMinSec = (INT64_MIN + 999999) / 1000000;
+    AssertInfo(new_epoch_sec >= kMinSec && new_epoch_sec <= kMaxSec,
+               "timestamp after interval arithmetic out of representable "
+               "range: {} seconds from epoch",
+               new_epoch_sec);
+    return new_epoch_sec * 1000000 + sub_sec_us;
+}
+
+bool
+CompareTimestamp(int64_t lhs, int64_t rhs, proto::plan::OpType compare_op) {
+    switch (compare_op) {
+        case proto::plan::OpType::Equal:
+            return lhs == rhs;
+        case proto::plan::OpType::NotEqual:
+            return lhs != rhs;
+        case proto::plan::OpType::GreaterThan:
+            return lhs > rhs;
+        case proto::plan::OpType::GreaterEqual:
+            return lhs >= rhs;
+        case proto::plan::OpType::LessThan:
+            return lhs < rhs;
+        case proto::plan::OpType::LessEqual:
+            return lhs <= rhs;
+        default:
+            ThrowInfo(UnexpectedError,
+                      "unsupported compare op for "
+                      "timestamptz_arith_compare_expr: {}",
+                      compare_op);
+    }
+}
+
+bool
+EvaluateTimestamp(int64_t current_ts_us,
+                  proto::plan::ArithOpType arith_op,
+                  const proto::plan::Interval& interval,
+                  proto::plan::OpType compare_op,
+                  int64_t compare_us) {
+    const auto final_us =
+        ApplyTimestampInterval(current_ts_us, arith_op, interval);
+    return CompareTimestamp(final_us, compare_us, compare_op);
+}
+
+}  // namespace
+
 std::string
 PhyTimestamptzArithCompareExpr::ToString() const {
     return expr_->ToString();
+}
+
+void
+PhyTimestamptzArithCompareExpr::DetermineExecPath() {
+    // Prefer field data when it is present. TIMESTAMPTZ calendar arithmetic
+    // cannot be transformed into a scalar-index range query, and keeping the
+    // raw-data path also preserves its batch cursor when another raw predicate
+    // is evaluated alongside it.
+    if (num_data_chunk_ > 0 || active_count_ == 0) {
+        exec_path_ = ExprExecPath::RawData;
+        return;
+    }
+
+    // An index-only sealed segment can still evaluate the expression if its
+    // scalar index retains the original values for Reverse_Lookup().
+    SegmentExpr::DetermineExecPath();
+    if (exec_path_ == ExprExecPath::ScalarIndex && num_index_chunk_ == 1) {
+        using Index = index::ScalarIndex<int64_t>;
+        auto index_ptr = dynamic_cast<const Index*>(pinned_index_[0].get());
+        if (index_ptr != nullptr && index_ptr->HasRawData()) {
+            return;
+        }
+    }
+
+    ThrowInfo(UnexpectedError,
+              "TIMESTAMPTZ arithmetic comparison requires field data or a "
+              "scalar index with raw data for field {}",
+              field_id_.get());
 }
 
 void
@@ -37,11 +192,72 @@ PhyTimestamptzArithCompareExpr::Eval(EvalCtx& context, VectorPtr& result) {
 template <typename T>
 VectorPtr
 PhyTimestamptzArithCompareExpr::ExecCompareVisitorImpl(OffsetVector* input) {
-    // We can not use index by transforming ts_col + interval > iso_string to ts_col > iso_string - interval
-    // Because year / month interval is not fixed days, it depends on the specific date.
-    // So, currently, we only support the data scanning path.
-    // In the future, one could add a switch here to check for index availability.
+    if (exec_path_ == ExprExecPath::ScalarIndex) {
+        return ExecCompareVisitorImplForIndex<T>(input);
+    }
     return ExecCompareVisitorImplForAll<T>(input);
+}
+
+template <typename T>
+VectorPtr
+PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForIndex(
+    OffsetVector* input) {
+    using Index = index::ScalarIndex<T>;
+    if (!arg_inited_) {
+        interval_ = expr_->interval_;
+        compare_value_.SetValue<T>(expr_->compare_value_);
+        arg_inited_ = true;
+    }
+
+    const auto arith_op = expr_->arith_op_;
+    const auto compare_op = expr_->compare_op_;
+    const auto compare_value = compare_value_.GetValue<T>();
+    const auto interval = interval_;
+    const int64_t real_batch_size =
+        input != nullptr ? input->size() : GetNextBatchSize();
+    if (real_batch_size == 0) {
+        return nullptr;
+    }
+    const int64_t eval_size =
+        input != nullptr ? real_batch_size : active_count_;
+
+    auto exec_index =
+        [ arith_op,
+          compare_op ]<FilterType filter_type = FilterType::sequential>(
+            Index * index_ptr,
+            int64_t size,
+            T compare_value,
+            const proto::plan::Interval& interval,
+            const int32_t* offsets = nullptr) {
+        TargetBitmap result(size, false);
+        for (int64_t i = 0; i < size; ++i) {
+            size_t offset = i;
+            if constexpr (filter_type == FilterType::random) {
+                offset = offsets == nullptr ? i : offsets[i];
+            }
+            auto raw = index_ptr->Reverse_Lookup(offset);
+            if (raw.has_value()) {
+                result[i] = EvaluateTimestamp(
+                    raw.value(), arith_op, interval, compare_op, compare_value);
+            }
+        }
+        return result;
+    };
+
+    VectorPtr result;
+    if (input != nullptr) {
+        result = ProcessIndexChunksByOffsets<T>(
+            exec_index, input, eval_size, compare_value, interval);
+    } else {
+        result = ProcessIndexChunks<T>(
+            exec_index, eval_size, compare_value, interval);
+    }
+    AssertInfo(result != nullptr && result->size() == real_batch_size,
+               "internal error: expr processed rows {} not equal "
+               "expect batch size {}",
+               result == nullptr ? 0 : result->size(),
+               real_batch_size);
+    return result;
 }
 
 template <typename T>
@@ -59,30 +275,6 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
     auto compare_value = this->compare_value_.GetValue<T>();
     auto interval = interval_;
 
-    if (arith_op == proto::plan::ArithOpType::Unknown) {
-        if (!helperPhyExpr_) {  // reconstruct helper expr would cause an error
-            proto::plan::GenericValue zeroRightOperand;
-            zeroRightOperand.set_int64_val(0);
-            auto helperExpr =
-                std::make_shared<milvus::expr::BinaryArithOpEvalRangeExpr>(
-                    expr_->column_,
-                    expr_->compare_op_,
-                    proto::plan::ArithOpType::Add,
-                    expr_->compare_value_,
-                    zeroRightOperand);
-            helperPhyExpr_ = std::make_shared<PhyBinaryArithOpEvalRangeExpr>(
-                inputs_,
-                helperExpr,
-                "PhyTimestamptzArithCompareExprHelper",
-                op_ctx_,
-                segment_,
-                active_count_,
-                batch_size_,
-                consistency_level_);
-            helperPhyExpr_->EnsureExecPathDetermined();
-        }
-        return helperPhyExpr_->ExecRangeVisitorImpl<T>(input);
-    }
     auto real_batch_size =
         has_offset_input_ ? input->size() : GetNextBatchSize();
     if (real_batch_size == 0) {
@@ -117,99 +309,8 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
                 res[i] = valid_res[i] = false;
                 continue;
             }
-            const int64_t current_ts_us = data[i];
-            const int op_sign =
-                (arith_op == proto::plan::ArithOpType::Add) ? 1 : -1;
-            // Floor division to correctly handle pre-epoch (negative) timestamps:
-            // C++ truncates toward zero, but we need floor for time decomposition.
-            // e.g., -1500000 us should be epoch_sec=-2, sub_sec_us=500000
-            //        not epoch_sec=-1, sub_sec_us=-500000
-            // Uses div-then-adjust pattern to avoid signed overflow near INT64_MIN.
-            std::time_t epoch_sec =
-                current_ts_us / 1000000 - (current_ts_us % 1000000 < 0 ? 1 : 0);
-            int64_t sub_sec_us = current_ts_us - epoch_sec * 1000000;
-            struct std::tm tm_buf;
-            if (::gmtime_r(&epoch_sec, &tm_buf) == nullptr) {
-                ThrowInfo(UnexpectedError,
-                          "gmtime_r failed for timestamp {} us",
-                          current_ts_us);
-            }
-            // Apply interval fields using int64_t intermediate arithmetic
-            // to avoid int overflow UB, then validate range before assigning
-            // back to struct tm (which uses int fields).
-            auto safe_add = [](int base, int64_t delta) -> int {
-                int64_t result = static_cast<int64_t>(base) + delta;
-                AssertInfo(result >= INT_MIN && result <= INT_MAX,
-                           "timestamp interval arithmetic overflow: "
-                           "{} + {} = {}",
-                           base,
-                           delta,
-                           result);
-                return static_cast<int>(result);
-            };
-            // Cast to int64_t before multiplying to avoid int * int overflow
-            // (e.g. interval.years() == INT32_MIN, op_sign == -1).
-            tm_buf.tm_year =
-                safe_add(tm_buf.tm_year,
-                         static_cast<int64_t>(interval.years()) * op_sign);
-            tm_buf.tm_mon =
-                safe_add(tm_buf.tm_mon,
-                         static_cast<int64_t>(interval.months()) * op_sign);
-            tm_buf.tm_mday =
-                safe_add(tm_buf.tm_mday,
-                         static_cast<int64_t>(interval.days()) * op_sign);
-            tm_buf.tm_hour =
-                safe_add(tm_buf.tm_hour,
-                         static_cast<int64_t>(interval.hours()) * op_sign);
-            tm_buf.tm_min =
-                safe_add(tm_buf.tm_min,
-                         static_cast<int64_t>(interval.minutes()) * op_sign);
-            tm_buf.tm_sec =
-                safe_add(tm_buf.tm_sec,
-                         static_cast<int64_t>(interval.seconds()) * op_sign);
-            // timegm normalizes the tm fields and converts back to epoch.
-            // It succeeds for all normalized inputs from gmtime_r + safe_add.
-            // No -1 check: -1 is a valid epoch second (1969-12-31T23:59:59Z)
-            // and is reachable via legal interval arithmetic (e.g., epoch 0 - 1s).
-            std::time_t new_epoch_sec = ::timegm(&tm_buf);
-            // Guard against overflow in epoch_sec * 1000000.
-            // INT64_MAX / 1000000 ≈ ±9.2e12 sec ≈ ±292,271 years from epoch.
-            constexpr int64_t kMaxSec = (INT64_MAX - 999999) / 1000000;
-            constexpr int64_t kMinSec = (INT64_MIN + 999999) / 1000000;
-            AssertInfo(
-                new_epoch_sec >= kMinSec && new_epoch_sec <= kMaxSec,
-                "timestamp after interval arithmetic out of representable "
-                "range: {} seconds from epoch",
-                static_cast<int64_t>(new_epoch_sec));
-            // Restore sub-second microseconds from the original timestamp
-            int64_t final_us =
-                static_cast<int64_t>(new_epoch_sec) * 1000000 + sub_sec_us;
-            bool match = false;
-            switch (compare_op) {
-                case proto::plan::OpType::Equal:
-                    match = (final_us == compare_us);
-                    break;
-                case proto::plan::OpType::NotEqual:
-                    match = (final_us != compare_us);
-                    break;
-                case proto::plan::OpType::GreaterThan:
-                    match = (final_us > compare_us);
-                    break;
-                case proto::plan::OpType::GreaterEqual:
-                    match = (final_us >= compare_us);
-                    break;
-                case proto::plan::OpType::LessThan:
-                    match = (final_us < compare_us);
-                    break;
-                case proto::plan::OpType::LessEqual:
-                    match = (final_us <= compare_us);
-                    break;
-                default:  // Should not happen
-                    ThrowInfo(UnexpectedError,
-                              "Unsupported compare op for "
-                              "timestamptz_arith_compare_expr");
-            }
-            res[i] = match;
+            res[i] = EvaluateTimestamp(
+                data[i], arith_op, interval, compare_op, compare_us);
         }
     };
     int64_t processed_size;

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.h
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.h
@@ -50,6 +50,11 @@ class PhyTimestamptzArithCompareExpr : public SegmentExpr {
     void
     Eval(EvalCtx& context, VectorPtr& result) override;
 
+    void
+    DetermineExecPath() override {
+        exec_path_ = ExprExecPath::RawData;
+    }
+
     std::string
     ToString() const override;
 

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.h
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.h
@@ -13,7 +13,6 @@
 
 #include <memory>
 #include "common/Vector.h"
-#include "exec/expression/BinaryArithOpEvalRangeExpr.h"
 #include "exec/expression/Element.h"
 #include "exec/expression/EvalCtx.h"
 #include "exec/expression/Expr.h"
@@ -51,9 +50,7 @@ class PhyTimestamptzArithCompareExpr : public SegmentExpr {
     Eval(EvalCtx& context, VectorPtr& result) override;
 
     void
-    DetermineExecPath() override {
-        exec_path_ = ExprExecPath::RawData;
-    }
+    DetermineExecPath() override;
 
     std::string
     ToString() const override;
@@ -77,8 +74,11 @@ class PhyTimestamptzArithCompareExpr : public SegmentExpr {
     VectorPtr
     ExecCompareVisitorImplForAll(OffsetVector* input);
 
+    template <typename T>
+    VectorPtr
+    ExecCompareVisitorImplForIndex(OffsetVector* input);
+
  private:
-    std::shared_ptr<PhyBinaryArithOpEvalRangeExpr> helperPhyExpr_;
     std::shared_ptr<const milvus::expr::TimestamptzArithCompareExpr> expr_;
     bool arg_inited_{false};
     proto::plan::Interval interval_;

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -259,11 +259,7 @@ PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
                         result = ExecRangeVisitorImplForIndex<bool>();
                         break;
                     case proto::plan::GenericValue::ValCase::kInt64Val:
-                        if (!IsInt64SafeForJsonDoubleIndex(
-                                expr_->val_.int64_val())) {
-                            result =
-                                ExecRangeVisitorImplJsonPreciseNumeric(context);
-                        } else if (PinnedJsonIndexIsFlat()) {
+                        if (PinnedJsonIndexIsFlat()) {
                             result = ExecRangeVisitorImplForIndex<int64_t>();
                         } else {
                             proto::plan::GenericValue double_val;
@@ -2016,6 +2012,34 @@ PhyUnaryRangeFilterExpr::DetermineExecPath() {
         return;
     }
 
+    auto data_type = expr_->column_.data_type_;
+    if (expr_->column_.element_level_) {
+        data_type = expr_->column_.element_type_;
+    }
+
+    if (data_type == DataType::JSON &&
+        expr_->val_.val_case() ==
+            proto::plan::GenericValue::ValCase::kInt64Val &&
+        !IsInt64SafeForJsonDoubleIndex(expr_->val_.int64_val()) &&
+        expr_->op_type_ != proto::plan::OpType::Equal &&
+        expr_->op_type_ != proto::plan::OpType::NotEqual) {
+        exec_path_ = ExprExecPath::RawData;
+        return;
+    }
+
+    if (data_type == DataType::ARRAY) {
+        const auto val_case = expr_->val_.val_case();
+        const auto can_use_array_index =
+            val_case == proto::plan::GenericValue::ValCase::kArrayVal &&
+            expr_->val_.array_val().array_size() > 0 &&
+            (expr_->op_type_ == proto::plan::OpType::Equal ||
+             expr_->op_type_ == proto::plan::OpType::NotEqual);
+        if (!can_use_array_index) {
+            exec_path_ = ExprExecPath::RawData;
+            return;
+        }
+    }
+
     SegmentExpr::DetermineExecPath();
     if (exec_path_ != ExprExecPath::ScalarIndex) {
         return;
@@ -2023,10 +2047,6 @@ PhyUnaryRangeFilterExpr::DetermineExecPath() {
 
     // Refine: check if the index supports this specific operation/type.
     // May downgrade from ScalarIndex to RawData.
-    auto data_type = expr_->column_.data_type_;
-    if (expr_->column_.element_level_) {
-        data_type = expr_->column_.element_type_;
-    }
 
     bool can_use = false;
     switch (data_type) {
@@ -2058,7 +2078,17 @@ PhyUnaryRangeFilterExpr::DetermineExecPath() {
                 SegmentExpr::CanUseIndexForOp<std::string>(expr_->op_type_);
             break;
         case DataType::JSON: {
-            auto val_type = FromValCase(expr_->val_.val_case());
+            const auto val_case = expr_->val_.val_case();
+            if (val_case == proto::plan::GenericValue::ValCase::kInt64Val &&
+                !IsInt64SafeForJsonDoubleIndex(expr_->val_.int64_val())) {
+                const auto is_equality =
+                    expr_->op_type_ == proto::plan::OpType::Equal ||
+                    expr_->op_type_ == proto::plan::OpType::NotEqual;
+                can_use = PinnedJsonIndexIsFlat() && is_equality;
+                break;
+            }
+
+            auto val_type = FromValCase(val_case);
             switch (val_type) {
                 case DataType::STRING:
                 case DataType::VARCHAR:
@@ -2074,7 +2104,11 @@ PhyUnaryRangeFilterExpr::DetermineExecPath() {
             auto val_type = expr_->val_.val_case();
             switch (val_type) {
                 case proto::plan::GenericValue::ValCase::kArrayVal:
-                    can_use = CanUseIndexForArray<milvus::Array>();
+                    can_use =
+                        expr_->val_.array_val().array_size() > 0 &&
+                        (expr_->op_type_ == proto::plan::OpType::Equal ||
+                         expr_->op_type_ == proto::plan::OpType::NotEqual) &&
+                        CanUseIndexForArray<milvus::Array>();
                     break;
                 default:
                     can_use = false;

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -720,86 +720,114 @@ PhyUnaryRangeFilterExpr::ExecArrayEqualForIndex(EvalCtx& context,
     }
 
     // cache the result to suit the framework.
-    auto batch_res = ProcessIndexChunks<IndexInnerType>([this, &val, reverse](
-                                                            Index* _) {
-        boost::container::vector<IndexInnerType> elems;
-        for (auto const& element : val.array()) {
-            auto e = GetValueFromProto<IndexInnerType>(element);
-            if (std::find(elems.begin(), elems.end(), e) == elems.end()) {
-                elems.push_back(e);
+    auto batch_res = ProcessIndexChunksWithRowLevel<IndexInnerType>(
+        [this, &val, reverse](Index* index_ptr) {
+            boost::container::vector<IndexInnerType> elems;
+            elems.reserve(val.array_size());
+            for (auto const& element : val.array()) {
+                auto e = GetValueFromProto<IndexInnerType>(element);
+                if (std::find(elems.begin(), elems.end(), e) == elems.end()) {
+                    elems.push_back(e);
+                }
             }
-        }
 
-        // filtering by index, get candidates.
-        std::function<bool(milvus::proto::plan::Array& /*val*/,
-                           int64_t /*offset*/)>
-            is_same;
-
-        if (segment_->is_chunked()) {
-            is_same = [this, reverse](milvus::proto::plan::Array& val,
-                                      int64_t offset) -> bool {
-                auto [chunk_idx, chunk_offset] =
-                    segment_->get_chunk_by_offset(field_id_, offset);
-                auto pw = segment_->template chunk_view<milvus::ArrayView>(
-                    op_ctx_, field_id_, chunk_idx);
-                auto chunk = pw.get();
-                return chunk.first[chunk_offset].is_same_array(val) ^ reverse;
-            };
-        } else {
-            auto size_per_chunk = segment_->size_per_chunk();
-            is_same = [this, size_per_chunk, reverse](
-                          milvus::proto::plan::Array& val,
-                          int64_t offset) -> bool {
-                auto chunk_idx = offset / size_per_chunk;
-                auto chunk_offset = offset % size_per_chunk;
-                auto pw = segment_->template chunk_data<milvus::ArrayView>(
-                    op_ctx_, field_id_, chunk_idx);
-                auto chunk = pw.get();
-                auto array_view = chunk.data() + chunk_offset;
-                return array_view->is_same_array(val) ^ reverse;
-            };
-        }
-
-        // collect all candidates.
-        std::unordered_set<size_t> candidates;
-        std::unordered_set<size_t> tmp_candidates;
-        auto first_callback = [&candidates](size_t offset) -> void {
-            candidates.insert(offset);
-        };
-        auto callback = [&candidates, &tmp_candidates](size_t offset) -> void {
-            if (candidates.find(offset) != candidates.end()) {
-                tmp_candidates.insert(offset);
+            std::shared_ptr<const IArrayOffsets> array_offsets;
+            if (index_ptr->IsNestedIndex()) {
+                array_offsets = segment_->GetArrayOffsets(field_id_);
+                AssertInfo(array_offsets != nullptr,
+                           "array offsets are required for nested ARRAY index");
             }
-        };
-        auto execute_sub_batch =
-            [](Index* index_ptr,
-               const IndexInnerType& val,
-               const std::function<void(size_t /* offset */)>& callback) {
-                index_ptr->InApplyCallback(1, &val, callback);
+
+            auto to_row_offset = [&array_offsets](size_t offset) -> size_t {
+                if (array_offsets == nullptr) {
+                    return offset;
+                }
+                auto [row_id, _] = array_offsets->ElementIDToRowID(
+                    static_cast<int32_t>(offset));
+                return static_cast<size_t>(row_id);
             };
 
-        // run in-filter.
-        for (size_t idx = 0; idx < elems.size(); idx++) {
-            if (idx == 0) {
-                ProcessIndexChunksV2<IndexInnerType>(
-                    execute_sub_batch, elems[idx], first_callback);
+            // filtering by index, get candidates.
+            std::function<bool(milvus::proto::plan::Array& /*val*/,
+                               int64_t /*offset*/)>
+                is_same;
+
+            if (segment_->is_chunked()) {
+                is_same = [this, reverse](milvus::proto::plan::Array& val,
+                                          int64_t offset) -> bool {
+                    auto [chunk_idx, chunk_offset] =
+                        segment_->get_chunk_by_offset(field_id_, offset);
+                    auto pw = segment_->template chunk_view<milvus::ArrayView>(
+                        op_ctx_, field_id_, chunk_idx);
+                    auto chunk = pw.get();
+                    return chunk.first[chunk_offset].is_same_array(val) ^
+                           reverse;
+                };
             } else {
-                ProcessIndexChunksV2<IndexInnerType>(
-                    execute_sub_batch, elems[idx], callback);
-                candidates = std::move(tmp_candidates);
+                auto size_per_chunk = segment_->size_per_chunk();
+                is_same = [this, size_per_chunk, reverse](
+                              milvus::proto::plan::Array& val,
+                              int64_t offset) -> bool {
+                    auto chunk_idx = offset / size_per_chunk;
+                    auto chunk_offset = offset % size_per_chunk;
+                    auto pw = segment_->template chunk_data<milvus::ArrayView>(
+                        op_ctx_, field_id_, chunk_idx);
+                    auto chunk = pw.get();
+                    auto array_view = chunk.data() + chunk_offset;
+                    return array_view->is_same_array(val) ^ reverse;
+                };
             }
-            // the size of candidates is small enough.
-            if (candidates.size() * 100 < active_count_) {
-                break;
+
+            // collect all candidates.
+            std::unordered_set<size_t> candidates;
+            std::unordered_set<size_t> tmp_candidates;
+            auto first_callback =
+                [this, &candidates, &to_row_offset](size_t offset) -> void {
+                auto row_offset = to_row_offset(offset);
+                if (row_offset < static_cast<size_t>(active_count_)) {
+                    candidates.insert(row_offset);
+                }
+            };
+            auto callback = [this,
+                             &candidates,
+                             &tmp_candidates,
+                             &to_row_offset](size_t offset) -> void {
+                auto row_offset = to_row_offset(offset);
+                if (row_offset < static_cast<size_t>(active_count_) &&
+                    candidates.find(row_offset) != candidates.end()) {
+                    tmp_candidates.insert(row_offset);
+                }
+            };
+            // run in-filter.
+            for (size_t idx = 0; idx < elems.size(); idx++) {
+                if (idx == 0) {
+                    index_ptr->InApplyCallback(1, &elems[idx], first_callback);
+                } else {
+                    tmp_candidates.clear();
+                    index_ptr->InApplyCallback(1, &elems[idx], callback);
+                    candidates = std::move(tmp_candidates);
+                }
+                // the size of candidates is small enough.
+                if (candidates.size() * 100 < active_count_) {
+                    break;
+                }
             }
-        }
-        TargetBitmap res(active_count_);
-        // run post-filter. The filter will only be executed once in the framework.
-        for (const auto& candidate : candidates) {
-            res[candidate] = is_same(val, candidate);
-        }
-        return res;
-    });
+            TargetBitmap res(active_count_, reverse);
+            // run post-filter. The filter will only be executed once in the framework.
+            for (const auto& candidate : candidates) {
+                res[candidate] = is_same(val, candidate);
+            }
+            return res;
+        },
+        IndexValidityMode::Default);
+    if (reverse) {
+        auto column = std::dynamic_pointer_cast<ColumnVector>(batch_res);
+        AssertInfo(column != nullptr && column->IsBitmap(),
+                   "ARRAY index equality must return a bitmap column");
+        TargetBitmapView data(column->GetRawData(), column->size());
+        TargetBitmapView validity(column->GetValidRawData(), column->size());
+        data.inplace_and(validity, column->size());
+    }
     AssertInfo(batch_res->size() == real_batch_size,
                "internal error: expr processed rows {} not equal "
                "expect batch size {}",
@@ -2029,9 +2057,47 @@ PhyUnaryRangeFilterExpr::DetermineExecPath() {
 
     if (data_type == DataType::ARRAY) {
         const auto val_case = expr_->val_.val_case();
+        const auto& array = expr_->val_.array_val();
+        auto literal_matches_index_type = [&]() {
+            if (!array.same_type()) {
+                return false;
+            }
+
+            proto::plan::GenericValue::ValCase expected_case;
+            switch (expr_->column_.element_type_) {
+                case DataType::BOOL:
+                    expected_case =
+                        proto::plan::GenericValue::ValCase::kBoolVal;
+                    break;
+                case DataType::INT8:
+                case DataType::INT16:
+                case DataType::INT32:
+                case DataType::INT64:
+                    expected_case =
+                        proto::plan::GenericValue::ValCase::kInt64Val;
+                    break;
+                case DataType::FLOAT:
+                case DataType::DOUBLE:
+                    expected_case =
+                        proto::plan::GenericValue::ValCase::kFloatVal;
+                    break;
+                case DataType::VARCHAR:
+                case DataType::STRING:
+                    expected_case =
+                        proto::plan::GenericValue::ValCase::kStringVal;
+                    break;
+                default:
+                    return false;
+            }
+            return std::all_of(array.array().begin(),
+                               array.array().end(),
+                               [expected_case](const auto& element) {
+                                   return element.val_case() == expected_case;
+                               });
+        };
         const auto can_use_array_index =
             val_case == proto::plan::GenericValue::ValCase::kArrayVal &&
-            expr_->val_.array_val().array_size() > 0 &&
+            array.array_size() > 0 && literal_matches_index_type() &&
             (expr_->op_type_ == proto::plan::OpType::Equal ||
              expr_->op_type_ == proto::plan::OpType::NotEqual);
         if (!can_use_array_index) {

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -26,6 +26,7 @@
 #include "common/Schema.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "exec/expression/ExprBatchTestUtils.h"
 #include "gtest/gtest.h"
 #include "index/InvertedIndexTantivy.h"
 #include "knowhere/comp/index_param.h"
@@ -286,6 +287,34 @@ TYPED_TEST_P(ArrayInvertedIndexTest, ArrayEqual) {
 
     auto parser = ProtoParser(this->schema_);
     auto typed_expr = parser.ParseExprs(*expr);
+    milvus::test::ExprBatchSizeGuard batch_size_guard(1024);
+    EXPECT_TRUE(milvus::test::CanExprExecuteAllAtOnce(
+        typed_expr, this->seg_.get(), this->N_));
+    EXPECT_EQ(milvus::test::EvalExprBatchSizes(
+                  typed_expr, this->seg_.get(), this->N_),
+              (std::vector<int64_t>{1024, 1024, 952}));
+
+    auto unary_expr =
+        std::dynamic_pointer_cast<const expr::UnaryRangeFilterExpr>(typed_expr);
+    ASSERT_NE(unary_expr, nullptr);
+    auto greater_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        unary_expr->column_,
+        proto::plan::OpType::GreaterThan,
+        unary_expr->val_,
+        std::vector<proto::plan::GenericValue>{});
+    EXPECT_FALSE(milvus::test::CanExprExecuteAllAtOnce(
+        greater_expr, this->seg_.get(), this->N_));
+
+    auto empty_value = unary_expr->val_;
+    empty_value.mutable_array_val()->clear_array();
+    auto empty_equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        unary_expr->column_,
+        proto::plan::OpType::Equal,
+        empty_value,
+        std::vector<proto::plan::GenericValue>{});
+    EXPECT_FALSE(milvus::test::CanExprExecuteAllAtOnce(
+        empty_equal_expr, this->seg_.get(), this->N_));
+
     auto parsed =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, typed_expr);
 

--- a/internal/core/src/index/InvertedIndexArrayTest.cpp
+++ b/internal/core/src/index/InvertedIndexArrayTest.cpp
@@ -351,3 +351,229 @@ REGISTER_TYPED_TEST_CASE_P(ArrayInvertedIndexTest,
                            ArrayEqual);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Naive, ArrayInvertedIndexTest, ElementType);
+
+namespace {
+
+class NullableInt64ArrayInvertedIndex
+    : public index::InvertedIndexTantivy<int64_t> {
+ public:
+    void
+    SetNullOffsets(std::vector<size_t> offsets) {
+        null_offset_ = std::move(offsets);
+    }
+};
+
+proto::plan::GenericValue
+MakeInt64ArrayValue(const std::vector<int64_t>& values) {
+    proto::plan::GenericValue value;
+    auto* array = value.mutable_array_val();
+    array->set_element_type(proto::schema::DataType::Int64);
+    array->set_same_type(true);
+    for (auto element : values) {
+        array->add_array()->set_int64_val(element);
+    }
+    return value;
+}
+
+}  // namespace
+
+TEST(ArrayInvertedIndexRegression,
+     ArrayNotEqualUsesIndexCandidatesAsRowLevelPrefilter) {
+    const std::vector<std::vector<int64_t>> arrays = {
+        {1, 1, 2},     // equal
+        {},            // null
+        {1, 2},        // missing duplicate
+        {},            // null
+        {1, 1, 2, 3},  // extra element
+        {},            // null
+        {1, 2, 1},     // different order
+        {},            // null
+        {1, 1, 1, 2},  // different duplicate count
+        {},            // null
+        {1, 3},        // missing indexed element
+        {},            // null
+        {3, 4},        // no indexed element
+        {},            // null
+    };
+    const auto row_count = static_cast<int64_t>(arrays.size());
+    std::vector<bool> expected_validity(row_count);
+    std::vector<bool> expected_values(row_count);
+    const std::vector<int64_t> literal = {1, 1, 2};
+    for (int64_t row = 0; row < row_count; ++row) {
+        const bool valid = row % 2 == 0;
+        expected_validity[row] = valid;
+        expected_values[row] = valid && arrays[row] != literal;
+    }
+
+    milvus::test::ExprBatchSizeGuard batch_size_guard(4);
+    for (bool nested_index : {false, true}) {
+        auto schema = std::make_shared<Schema>();
+        schema->AddDebugField(
+            "fvec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+        auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+        auto array_fid = schema->AddDebugArrayField(
+            nested_index ? "structA[array]" : "array", DataType::INT64, true);
+        schema->set_primary_field_id(pk_fid);
+
+        auto raw_data = DataGen(schema, row_count, 42, 0, 1, 3);
+        proto::schema::FieldData* array_field = nullptr;
+        for (auto& field : *raw_data.raw_->mutable_fields_data()) {
+            if (field.field_id() == array_fid.get()) {
+                array_field = &field;
+                break;
+            }
+        }
+        ASSERT_NE(array_field, nullptr);
+        auto* array_data = array_field->mutable_scalars()->mutable_array_data();
+        ASSERT_EQ(array_data->data_size(), row_count);
+        auto* valid_data = array_field->mutable_valid_data();
+        ASSERT_EQ(valid_data->size(), row_count);
+
+        std::vector<boost::container::vector<int64_t>> index_arrays;
+        index_arrays.reserve(row_count);
+        std::vector<size_t> null_offsets;
+        for (int64_t row = 0; row < row_count; ++row) {
+            const bool valid = expected_validity[row];
+            valid_data->at(row) = valid;
+
+            auto* values = array_data->mutable_data(row)
+                               ->mutable_long_data()
+                               ->mutable_data();
+            values->Clear();
+            values->Add(arrays[row].begin(), arrays[row].end());
+
+            if (valid) {
+                index_arrays.emplace_back(arrays[row].begin(),
+                                          arrays[row].end());
+            } else {
+                index_arrays.emplace_back();
+                null_offsets.push_back(row);
+            }
+        }
+
+        auto raw_segment = CreateSealedWithFieldDataLoaded(schema, raw_data);
+        auto indexed_segment =
+            CreateSealedWithFieldDataLoaded(schema, raw_data);
+        auto logical_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(
+                array_fid, DataType::ARRAY, DataType::INT64, {}, true),
+            proto::plan::OpType::NotEqual,
+            MakeInt64ArrayValue(literal),
+            std::vector<proto::plan::GenericValue>{});
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           logical_expr);
+
+        auto raw_eval = milvus::test::EvalExprInBatches(
+            logical_expr, raw_segment.get(), row_count);
+        EXPECT_EQ(raw_eval.batch_sizes, (std::vector<int64_t>{4, 4, 4, 2}));
+        EXPECT_FALSE(milvus::test::CanExprExecuteAllAtOnce(
+            logical_expr, raw_segment.get(), row_count));
+
+        auto index = std::make_unique<NullableInt64ArrayInvertedIndex>();
+        Config config;
+        config["is_array"] = true;
+        if (nested_index) {
+            config["is_nested_index"] = true;
+        }
+        index->BuildWithRawDataForUT(row_count, index_arrays.data(), config);
+        index->SetNullOffsets(null_offsets);
+
+        LoadIndexInfo load_info{};
+        load_info.field_id = array_fid.get();
+        load_info.field_type = DataType::ARRAY;
+        load_info.element_type = DataType::INT64;
+        load_info.index_params = GenIndexParams(index.get());
+        load_info.cache_index =
+            CreateTestCacheIndex(nested_index ? "array_not_equal_nested"
+                                              : "array_not_equal_row_level",
+                                 std::move(index));
+        indexed_segment->LoadIndex(load_info);
+
+        EXPECT_TRUE(milvus::test::CanExprExecuteAllAtOnce(
+            logical_expr, indexed_segment.get(), row_count));
+        auto indexed_eval = milvus::test::EvalExprInBatches(
+            logical_expr, indexed_segment.get(), row_count);
+        EXPECT_EQ(indexed_eval.batch_sizes, (std::vector<int64_t>{4, 4, 4, 2}));
+
+        TargetBitmapView raw_values(raw_eval.result->GetRawData(), row_count);
+        TargetBitmapView raw_validity(raw_eval.result->GetValidRawData(),
+                                      row_count);
+        TargetBitmapView indexed_values(indexed_eval.result->GetRawData(),
+                                        row_count);
+        TargetBitmapView indexed_validity(
+            indexed_eval.result->GetValidRawData(), row_count);
+        for (int64_t row = 0; row < row_count; ++row) {
+            EXPECT_EQ(indexed_validity[row], expected_validity[row])
+                << "nested=" << nested_index << ", row=" << row;
+            EXPECT_EQ(indexed_validity[row], raw_validity[row])
+                << "nested=" << nested_index << ", row=" << row;
+            EXPECT_EQ(indexed_values[row], expected_values[row])
+                << "nested=" << nested_index << ", row=" << row;
+            EXPECT_EQ(indexed_values[row], raw_values[row])
+                << "nested=" << nested_index << ", row=" << row;
+        }
+
+        exec::OffsetVector offsets = {0, 1, 2, 4, 6, 8, 10, 12, 13};
+        auto raw_offset_result = milvus::test::gen_filter_res(
+            plan.get(), raw_segment.get(), row_count, MAX_TIMESTAMP, &offsets);
+        auto indexed_offset_result =
+            milvus::test::gen_filter_res(plan.get(),
+                                         indexed_segment.get(),
+                                         row_count,
+                                         MAX_TIMESTAMP,
+                                         &offsets);
+        TargetBitmapView raw_offset_values(raw_offset_result->GetRawData(),
+                                           offsets.size());
+        TargetBitmapView raw_offset_validity(
+            raw_offset_result->GetValidRawData(), offsets.size());
+        TargetBitmapView indexed_offset_values(
+            indexed_offset_result->GetRawData(), offsets.size());
+        TargetBitmapView indexed_offset_validity(
+            indexed_offset_result->GetValidRawData(), offsets.size());
+        for (size_t i = 0; i < offsets.size(); ++i) {
+            const auto row = offsets[i];
+            EXPECT_EQ(indexed_offset_validity[i], expected_validity[row])
+                << "nested=" << nested_index << ", offset row=" << row;
+            EXPECT_EQ(indexed_offset_validity[i], raw_offset_validity[i])
+                << "nested=" << nested_index << ", offset row=" << row;
+            EXPECT_EQ(indexed_offset_values[i], expected_values[row])
+                << "nested=" << nested_index << ", offset row=" << row;
+            EXPECT_EQ(indexed_offset_values[i], raw_offset_values[i])
+                << "nested=" << nested_index << ", offset row=" << row;
+        }
+
+        auto mixed_literal = MakeInt64ArrayValue({1});
+        mixed_literal.mutable_array_val()->add_array()->set_float_val(1.5);
+        mixed_literal.mutable_array_val()->set_same_type(false);
+        auto mixed_not_equal = std::make_shared<expr::UnaryRangeFilterExpr>(
+            expr::ColumnInfo(
+                array_fid, DataType::ARRAY, DataType::INT64, {}, true),
+            proto::plan::OpType::NotEqual,
+            std::move(mixed_literal),
+            std::vector<proto::plan::GenericValue>{});
+        EXPECT_FALSE(milvus::test::CanExprExecuteAllAtOnce(
+            mixed_not_equal, indexed_segment.get(), row_count));
+        auto raw_mixed = milvus::test::EvalExprInBatches(
+            mixed_not_equal, raw_segment.get(), row_count);
+        auto indexed_mixed = milvus::test::EvalExprInBatches(
+            mixed_not_equal, indexed_segment.get(), row_count);
+        TargetBitmapView raw_mixed_values(raw_mixed.result->GetRawData(),
+                                          row_count);
+        TargetBitmapView raw_mixed_validity(raw_mixed.result->GetValidRawData(),
+                                            row_count);
+        TargetBitmapView indexed_mixed_values(
+            indexed_mixed.result->GetRawData(), row_count);
+        TargetBitmapView indexed_mixed_validity(
+            indexed_mixed.result->GetValidRawData(), row_count);
+        for (int64_t row = 0; row < row_count; ++row) {
+            EXPECT_EQ(indexed_mixed_validity[row], expected_validity[row])
+                << "nested=" << nested_index << ", mixed row=" << row;
+            EXPECT_EQ(indexed_mixed_validity[row], raw_mixed_validity[row])
+                << "nested=" << nested_index << ", mixed row=" << row;
+            EXPECT_EQ(indexed_mixed_values[row], expected_validity[row])
+                << "nested=" << nested_index << ", mixed row=" << row;
+            EXPECT_EQ(indexed_mixed_values[row], raw_mixed_values[row])
+                << "nested=" << nested_index << ", mixed row=" << row;
+        }
+    }
+}

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -35,6 +35,7 @@
 #include "common/Tracer.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "exec/expression/ExprBatchTestUtils.h"
 #include "exec/expression/ExprCache.h"
 #include "expr/ITypeExpr.h"
 #include "filemanager/InputStream.h"
@@ -1047,10 +1048,8 @@ class JsonFlatIndexContainsExprTest : public ::testing::Test {
             filter_expr = std::make_shared<expr::LogicalUnaryExpr>(
                 expr::LogicalUnaryExpr::OpType::LogicalNot, contains_expr);
         }
-        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
-                                                           filter_expr);
-        return gen_filter_res(
-            plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+        return EvalExprInBatches(filter_expr, segment_.get(), json_data_.size())
+            .result;
     }
 
     void
@@ -1164,6 +1163,20 @@ TEST_F(JsonFlatIndexContainsExprTest, UsesExactPathThreeValuedValidity) {
 }
 
 TEST_F(JsonFlatIndexContainsExprTest, PreservesLargeInt64LiteralPrecision) {
+    ExprBatchSizeGuard batch_size_guard(5);
+    proto::plan::GenericValue value;
+    value.set_int64_val(9007199254740993LL);
+    auto contains_expr = std::make_shared<expr::JsonContainsExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::JSONContainsExpr_JSONOp_Contains,
+        true,
+        std::vector<proto::plan::GenericValue>{value});
+    EXPECT_TRUE(CanExprExecuteAllAtOnce(
+        contains_expr, segment_.get(), json_data_.size()));
+    EXPECT_EQ(
+        EvalExprBatchSizes(contains_expr, segment_.get(), json_data_.size()),
+        (std::vector<int64_t>{5, 5, 4}));
+
     CheckResult(Evaluate(proto::plan::JSONContainsExpr_JSONOp_Contains,
                          {9007199254740993LL}),
                 {false,
@@ -1294,6 +1307,14 @@ TEST_F(JsonFlatIndexExprTest, JSONArrayEqualityFallsBackToRawData) {
 
 TEST_F(JsonFlatIndexExprTest,
        JSONContainsMixedAndArrayLiteralsFallBackToRawData) {
+    ExprBatchSizeGuard batch_size_guard(7);
+    const auto expect_three_batches = [&](const expr::TypedExprPtr& expr) {
+        std::vector<int64_t> batch_sizes;
+        EXPECT_NO_THROW(batch_sizes = EvalExprBatchSizes(
+                            expr, segment_.get(), json_data_.size()));
+        EXPECT_EQ(batch_sizes, (std::vector<int64_t>{7, 7, 5}));
+    };
+
     proto::plan::GenericValue string_value;
     string_value.set_string_val("a");
     proto::plan::GenericValue int_value;
@@ -1304,6 +1325,7 @@ TEST_F(JsonFlatIndexExprTest,
         proto::plan::JSONContainsExpr_JSONOp_ContainsAny,
         false,
         std::vector<proto::plan::GenericValue>{string_value, int_value});
+    expect_three_batches(mixed_expr);
     auto plan =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, mixed_expr);
     auto final = query::ExecuteQueryExpr(
@@ -1321,11 +1343,24 @@ TEST_F(JsonFlatIndexExprTest,
         proto::plan::JSONContainsExpr_JSONOp_Contains,
         true,
         std::vector<proto::plan::GenericValue>{array_value});
+    expect_three_batches(array_expr);
     plan =
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, array_expr);
     final = query::ExecuteQueryExpr(
         plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
     EXPECT_EQ(final.count(), 0);
+
+    auto in_field_expr = std::make_shared<expr::TermFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        std::vector<proto::plan::GenericValue>{string_value},
+        true);
+    expect_three_batches(in_field_expr);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  in_field_expr);
+    final = query::ExecuteQueryExpr(
+        plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(final.count(), 1);
+    EXPECT_TRUE(final[6]);
 }
 
 TEST_F(JsonFlatIndexExprTest, ReusesValidityAcrossLiteralsAndOperators) {
@@ -1400,6 +1435,19 @@ TEST_F(JsonFlatIndexExprTest, ReusesValidityAcrossLiteralsAndOperators) {
 }
 
 TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
+    ExprBatchSizeGuard batch_size_guard(7);
+    const auto evaluate = [&](const expr::TypedExprPtr& expr,
+                              bool can_execute_all_at_once) {
+        EXPECT_EQ(
+            CanExprExecuteAllAtOnce(expr, segment_.get(), json_data_.size()),
+            can_execute_all_at_once);
+        ExprBatchEvalResult evaluation;
+        EXPECT_NO_THROW(evaluation = EvalExprInBatches(
+                            expr, segment_.get(), json_data_.size()));
+        EXPECT_EQ(evaluation.batch_sizes, (std::vector<int64_t>{7, 7, 5}));
+        return evaluation.result;
+    };
+
     proto::plan::GenericValue value;
     value.set_int64_val(9007199254740993LL);
 
@@ -1408,10 +1456,7 @@ TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
         proto::plan::OpType::Equal,
         value,
         std::vector<proto::plan::GenericValue>());
-    auto plan =
-        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, equal_expr);
-    auto result = gen_filter_res(
-        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    auto result = evaluate(equal_expr, true);
     TargetBitmapView result_view(result->GetRawData(), result->size());
     TargetBitmapView valid_view(result->GetValidRawData(), result->size());
     EXPECT_TRUE(valid_view[16]);
@@ -1425,10 +1470,7 @@ TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
         expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
         std::vector<proto::plan::GenericValue>{value},
         false);
-    plan =
-        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, term_expr);
-    result = gen_filter_res(
-        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result = evaluate(term_expr, true);
     result_view = TargetBitmapView(result->GetRawData(), result->size());
     valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
     EXPECT_TRUE(valid_view[16]);
@@ -1443,10 +1485,7 @@ TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
         proto::plan::OpType::GreaterThan,
         value,
         std::vector<proto::plan::GenericValue>());
-    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
-                                                  greater_expr);
-    result = gen_filter_res(
-        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result = evaluate(greater_expr, false);
     result_view = TargetBitmapView(result->GetRawData(), result->size());
     valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
     EXPECT_TRUE(valid_view[16]);
@@ -1462,10 +1501,7 @@ TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
         value,
         true,
         true);
-    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
-                                                  between_expr);
-    result = gen_filter_res(
-        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result = evaluate(between_expr, false);
     result_view = TargetBitmapView(result->GetRawData(), result->size());
     valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
     EXPECT_TRUE(valid_view[16]);
@@ -1483,10 +1519,7 @@ TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
         upper_float,
         true,
         true);
-    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
-                                                  mixed_lower_expr);
-    result = gen_filter_res(
-        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result = evaluate(mixed_lower_expr, false);
     result_view = TargetBitmapView(result->GetRawData(), result->size());
     valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
     EXPECT_FALSE(result_view[16]);
@@ -1501,10 +1534,7 @@ TEST_F(JsonFlatIndexExprTest, PreservesLargeInt64LiteralPrecision) {
         value,
         true,
         true);
-    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
-                                                  mixed_upper_expr);
-    result = gen_filter_res(
-        plan.get(), segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    result = evaluate(mixed_upper_expr, false);
     result_view = TargetBitmapView(result->GetRawData(), result->size());
     valid_view = TargetBitmapView(result->GetValidRawData(), result->size());
     EXPECT_TRUE(result_view[16]);

--- a/internal/core/src/index/JsonIndexTest.cpp
+++ b/internal/core/src/index/JsonIndexTest.cpp
@@ -35,6 +35,7 @@
 #include "common/Schema.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "exec/expression/ExprBatchTestUtils.h"
 #include "expr/ITypeExpr.h"
 #include "filemanager/InputStream.h"
 #include "gtest/gtest.h"
@@ -178,6 +179,7 @@ BuildAndLoadJsonInvertedIndexForOffsetRegression(
 }  // namespace
 
 TEST(JsonIndexTest, TestJsonContains) {
+    milvus::test::ExprBatchSizeGuard batch_size_guard(8);
     std::vector<std::string> json_raw_data = {
         R"(1)",
         R"("a simple string")",
@@ -204,6 +206,9 @@ TEST(JsonIndexTest, TestJsonContains) {
         R"({"a": []})",
         R"({"a": [0, 2, 3]})",
         R"({"a": [{"b": 1}, 2.0, 3.0, "4", true, [1, 3.0], null]})",
+        R"({"a": [9007199254740992]})",
+        R"({"a": [9007199254740993]})",
+        R"({"a": [9007199254740994]})",
     };
 
     auto json_path = "/a";
@@ -312,6 +317,25 @@ TEST(JsonIndexTest, TestJsonContains) {
     EXPECT_TRUE(mixed_result[17]);
     EXPECT_TRUE(mixed_result[18]);
     EXPECT_TRUE(mixed_result[24]);
+
+    proto::plan::GenericValue large_int_value;
+    large_int_value.set_int64_val(9007199254740993LL);
+    auto large_int_expr = std::make_shared<expr::JsonContainsExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}, true),
+        proto::plan::JSONContainsExpr_JSONOp_Contains,
+        true,
+        std::vector<proto::plan::GenericValue>{large_int_value});
+    EXPECT_FALSE(milvus::test::CanExprExecuteAllAtOnce(
+        large_int_expr, segment.get(), json_raw_data.size()));
+    EXPECT_EQ(milvus::test::EvalExprBatchSizes(
+                  large_int_expr, segment.get(), json_raw_data.size()),
+              (std::vector<int64_t>{8, 8, 8, 4}));
+    auto large_int_plan = std::make_shared<plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, large_int_expr);
+    auto large_int_result = query::ExecuteQueryExpr(
+        large_int_plan, segment.get(), json_raw_data.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(large_int_result.count(), 1);
+    EXPECT_TRUE(large_int_result[26]);
 }
 
 TEST(JsonIndexTest, TestJsonCast) {

--- a/internal/core/unittest/test_timestamptz_arith_compare.cpp
+++ b/internal/core/unittest/test_timestamptz_arith_compare.cpp
@@ -21,13 +21,16 @@
 #include <vector>
 
 #include "common/Types.h"
+#include "exec/expression/ExprBatchTestUtils.h"
 #include "expr/ITypeExpr.h"
+#include "index/ScalarIndex.h"
 #include "knowhere/comp/index_param.h"
 #include "query/ExecPlanNodeVisitor.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "segcore/SegcoreConfig.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/GenExprProto.h"
+#include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
@@ -181,6 +184,29 @@ TEST_F(TimestamptzArithCompareCorrectnessTest,
 
 TEST_F(TimestamptzArithCompareCorrectnessTest, SealedNullSemantics) {
     AssertNullSemantics(sealed_.get());
+}
+
+TEST_F(TimestamptzArithCompareCorrectnessTest,
+       SealedScalarIndexStillUsesRawDataPath) {
+    auto values = dataset_->get_col<int64_t>(tstz_fid_);
+    auto scalar_index = milvus::index::CreateScalarIndexSort<int64_t>();
+    scalar_index->Build(N, values.data());
+
+    LoadIndexInfo load_index_info;
+    load_index_info.field_id = tstz_fid_.get();
+    load_index_info.field_type = DataType::TIMESTAMPTZ;
+    load_index_info.index_params = GenIndexParams(scalar_index.get());
+    load_index_info.cache_index =
+        milvus::CreateTestCacheIndex("timestamptz", std::move(scalar_index));
+    sealed_->LoadIndex(load_index_info);
+
+    milvus::test::ExprBatchSizeGuard batch_size_guard(7);
+    auto typed_expr =
+        MakeTstzPlusOneMonthCompare(tstz_fid_, kFarFutureUs, false);
+    EXPECT_FALSE(
+        milvus::test::CanExprExecuteAllAtOnce(typed_expr, sealed_.get(), N));
+    EXPECT_EQ(milvus::test::EvalExprBatchSizes(typed_expr, sealed_.get(), N),
+              (std::vector<int64_t>{7, 7, 7, 7, 4}));
 }
 
 TEST_F(TimestamptzArithCompareCorrectnessTest, SealedOffsetInputNullSemantics) {

--- a/internal/core/unittest/test_timestamptz_arith_compare.cpp
+++ b/internal/core/unittest/test_timestamptz_arith_compare.cpp
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <numeric>
 #include <vector>
 
 #include "common/Types.h"
@@ -40,25 +41,40 @@ using namespace milvus::segcore;
 namespace {
 
 std::shared_ptr<milvus::expr::ITypeExpr>
-MakeTstzPlusOneMonthCompare(FieldId tstz_fid,
-                            int64_t compare_us,
-                            bool negated) {
-    proto::plan::Interval interval;
-    interval.set_months(1);
+MakeTstzCompare(FieldId tstz_fid,
+                proto::plan::ArithOpType arith_op,
+                const proto::plan::Interval& interval,
+                proto::plan::OpType compare_op,
+                int64_t compare_us,
+                bool negated = false) {
     proto::plan::GenericValue compare_value;
     compare_value.set_int64_val(compare_us);
     std::shared_ptr<milvus::expr::ITypeExpr> typed_expr =
         std::make_shared<milvus::expr::TimestamptzArithCompareExpr>(
             expr::ColumnInfo(tstz_fid, DataType::TIMESTAMPTZ),
-            proto::plan::ArithOpType::Add,
+            arith_op,
             interval,
-            proto::plan::OpType::LessThan,
+            compare_op,
             compare_value);
     if (negated) {
         typed_expr = std::make_shared<milvus::expr::LogicalUnaryExpr>(
             expr::LogicalUnaryExpr::OpType::LogicalNot, typed_expr);
     }
     return typed_expr;
+}
+
+std::shared_ptr<milvus::expr::ITypeExpr>
+MakeTstzPlusOneMonthCompare(FieldId tstz_fid,
+                            int64_t compare_us,
+                            bool negated) {
+    proto::plan::Interval interval;
+    interval.set_months(1);
+    return MakeTstzCompare(tstz_fid,
+                           proto::plan::ArithOpType::Add,
+                           interval,
+                           proto::plan::OpType::LessThan,
+                           compare_us,
+                           negated);
 }
 
 constexpr int64_t kFarFutureUs = 4102444800LL * 1000000;  // 2100-01-01
@@ -163,6 +179,25 @@ class TimestamptzArithCompareCorrectnessTest : public ::testing::Test {
         }
     }
 
+    void
+    LoadTimestamptzIndex(const int64_t* values, bool drop_field_data) {
+        auto scalar_index = milvus::index::CreateScalarIndexSort<int64_t>();
+        scalar_index->Build(N, values, tstz_valid_.data());
+
+        LoadIndexInfo load_index_info;
+        load_index_info.field_id = tstz_fid_.get();
+        load_index_info.field_type = DataType::TIMESTAMPTZ;
+        load_index_info.index_params = GenIndexParams(scalar_index.get());
+        load_index_info.cache_index = milvus::CreateTestCacheIndex(
+            "timestamptz", std::move(scalar_index));
+        sealed_->LoadIndex(load_index_info);
+
+        if (drop_field_data) {
+            sealed_->DropFieldData(tstz_fid_);
+            ASSERT_FALSE(sealed_->HasFieldData(tstz_fid_));
+        }
+    }
+
     static constexpr size_t N = 32;
 
     SchemaPtr schema_;
@@ -189,16 +224,7 @@ TEST_F(TimestamptzArithCompareCorrectnessTest, SealedNullSemantics) {
 TEST_F(TimestamptzArithCompareCorrectnessTest,
        SealedScalarIndexStillUsesRawDataPath) {
     auto values = dataset_->get_col<int64_t>(tstz_fid_);
-    auto scalar_index = milvus::index::CreateScalarIndexSort<int64_t>();
-    scalar_index->Build(N, values.data());
-
-    LoadIndexInfo load_index_info;
-    load_index_info.field_id = tstz_fid_.get();
-    load_index_info.field_type = DataType::TIMESTAMPTZ;
-    load_index_info.index_params = GenIndexParams(scalar_index.get());
-    load_index_info.cache_index =
-        milvus::CreateTestCacheIndex("timestamptz", std::move(scalar_index));
-    sealed_->LoadIndex(load_index_info);
+    LoadTimestamptzIndex(values.data(), false);
 
     milvus::test::ExprBatchSizeGuard batch_size_guard(7);
     auto typed_expr =
@@ -207,6 +233,72 @@ TEST_F(TimestamptzArithCompareCorrectnessTest,
         milvus::test::CanExprExecuteAllAtOnce(typed_expr, sealed_.get(), N));
     EXPECT_EQ(milvus::test::EvalExprBatchSizes(typed_expr, sealed_.get(), N),
               (std::vector<int64_t>{7, 7, 7, 7, 4}));
+}
+
+TEST_F(TimestamptzArithCompareCorrectnessTest,
+       SealedIndexOnlyFullScanPreservesNullableValidity) {
+    std::vector<int64_t> values(N);
+    std::iota(values.begin(), values.end(), int64_t{0});
+    LoadTimestamptzIndex(values.data(), true);
+
+    proto::plan::Interval interval;
+    interval.set_months(1);
+    constexpr int64_t kFebruaryStartUs = 2678400LL * 1000000;
+    auto typed_expr = MakeTstzCompare(tstz_fid_,
+                                      proto::plan::ArithOpType::Add,
+                                      interval,
+                                      proto::plan::OpType::LessThan,
+                                      kFebruaryStartUs + 16);
+
+    milvus::test::ExprBatchSizeGuard batch_size_guard(7);
+    EXPECT_TRUE(
+        milvus::test::CanExprExecuteAllAtOnce(typed_expr, sealed_.get(), N));
+    auto evaluation =
+        milvus::test::EvalExprInBatches(typed_expr, sealed_.get(), N);
+    EXPECT_EQ(evaluation.batch_sizes, (std::vector<int64_t>{7, 7, 7, 7, 4}));
+
+    TargetBitmapView result(evaluation.result->GetRawData(), N);
+    TargetBitmapView valid(evaluation.result->GetValidRawData(), N);
+    for (size_t i = 0; i < N; ++i) {
+        const bool expected = tstz_valid_[i] && i < 16;
+        EXPECT_EQ(result[i], expected) << "row " << i;
+        EXPECT_EQ(valid[i], tstz_valid_[i]) << "row " << i;
+    }
+
+    auto plan = milvus::test::CreateRetrievePlanByExpr(typed_expr);
+    auto all_at_once =
+        query::ExecuteQueryExpr(plan, sealed_.get(), N, MAX_TIMESTAMP);
+    ASSERT_EQ(all_at_once.size(), N);
+    for (size_t i = 0; i < N; ++i) {
+        EXPECT_EQ(all_at_once[i], tstz_valid_[i] && i < 16) << "row " << i;
+    }
+}
+
+TEST_F(TimestamptzArithCompareCorrectnessTest,
+       SealedIndexOnlyUnknownArithComparesTimestampDirectly) {
+    std::vector<int64_t> values(N);
+    std::iota(values.begin(), values.end(), int64_t{0});
+    LoadTimestamptzIndex(values.data(), true);
+
+    proto::plan::Interval ignored_interval;
+    ignored_interval.set_months(1);
+    auto typed_expr = MakeTstzCompare(tstz_fid_,
+                                      proto::plan::ArithOpType::Unknown,
+                                      ignored_interval,
+                                      proto::plan::OpType::GreaterEqual,
+                                      16);
+
+    EXPECT_TRUE(
+        milvus::test::CanExprExecuteAllAtOnce(typed_expr, sealed_.get(), N));
+    auto evaluation =
+        milvus::test::EvalExprInBatches(typed_expr, sealed_.get(), N);
+    TargetBitmapView result(evaluation.result->GetRawData(), N);
+    TargetBitmapView valid(evaluation.result->GetValidRawData(), N);
+    for (size_t i = 0; i < N; ++i) {
+        const bool expected = tstz_valid_[i] && i >= 16;
+        EXPECT_EQ(result[i], expected) << "row " << i;
+        EXPECT_EQ(valid[i], tstz_valid_[i]) << "row " << i;
+    }
 }
 
 TEST_F(TimestamptzArithCompareCorrectnessTest, SealedOffsetInputNullSemantics) {

--- a/internal/parser/planparserv2/convert_field_data_to_generic_value.go
+++ b/internal/parser/planparserv2/convert_field_data_to_generic_value.go
@@ -12,6 +12,19 @@ import (
 func convertArrayValue(templateName string, templateValue *schemapb.TemplateArrayValue) (*planpb.GenericValue, error) {
 	var arrayValues []*planpb.GenericValue
 	var elementType schemapb.DataType
+	// An empty SDK list has no element from which to infer a concrete oneof
+	// type. Preserve it as an untyped empty array; consumers with field context
+	// can still interpret its semantics (for example, ARRAY == []).
+	if templateValue != nil && templateValue.GetData() == nil {
+		return &planpb.GenericValue{
+			Val: &planpb.GenericValue_ArrayVal{
+				ArrayVal: &planpb.Array{
+					SameType:    true,
+					ElementType: schemapb.DataType_None,
+				},
+			},
+		}, nil
+	}
 	switch templateValue.GetData().(type) {
 	case *schemapb.TemplateArrayValue_BoolData:
 		elements := templateValue.GetBoolData().GetData()

--- a/internal/parser/planparserv2/fill_expression_value.go
+++ b/internal/parser/planparserv2/fill_expression_value.go
@@ -21,7 +21,20 @@ func FillExpressionValue(expr *planpb.Expr, templateValues map[string]*planpb.Ge
 		if err := FillExpressionValue(e.BinaryExpr.GetLeft(), templateValues); err != nil {
 			return err
 		}
-		return FillExpressionValue(e.BinaryExpr.GetRight(), templateValues)
+		if err := FillExpressionValue(e.BinaryExpr.GetRight(), templateValues); err != nil {
+			return err
+		}
+		switch e.BinaryExpr.GetOp() {
+		case planpb.BinaryExpr_LogicalOr:
+			if hasBoolValue(e.BinaryExpr.GetLeft(), true) || hasBoolValue(e.BinaryExpr.GetRight(), true) {
+				*expr = *alwaysTrueExpr()
+			}
+		case planpb.BinaryExpr_LogicalAnd:
+			if hasBoolValue(e.BinaryExpr.GetLeft(), false) || hasBoolValue(e.BinaryExpr.GetRight(), false) {
+				*expr = *alwaysFalseExpr()
+			}
+		}
+		return nil
 	case *planpb.Expr_UnaryRangeExpr:
 		return FillUnaryRangeExpressionValue(e.UnaryRangeExpr, templateValues)
 	case *planpb.Expr_BinaryRangeExpr:
@@ -60,6 +73,11 @@ func FillExpressionValue(expr *planpb.Expr, templateValues map[string]*planpb.Ge
 	default:
 		return merr.WrapErrQueryPlanMsg("this expression no need to fill placeholder with expr type: %T", e)
 	}
+}
+
+func hasBoolValue(expr *planpb.Expr, target bool) bool {
+	value := expr.GetValueExpr().GetValue()
+	return IsBool(value) && value.GetBoolVal() == target
 }
 
 func FillTermExpressionValue(expr *planpb.TermExpr, templateValues map[string]*planpb.GenericValue) error {

--- a/internal/parser/planparserv2/fill_expression_value.go
+++ b/internal/parser/planparserv2/fill_expression_value.go
@@ -199,6 +199,7 @@ func FillBinaryRangeExpressionValue(expr *planpb.BinaryRangeExpr, templateValues
 			return err
 		}
 		expr.LowerValue = castedLowerValue
+		lowerValue = castedLowerValue
 	}
 
 	upperValue := expr.GetUpperValue()
@@ -213,19 +214,10 @@ func FillBinaryRangeExpressionValue(expr *planpb.BinaryRangeExpr, templateValues
 			return err
 		}
 		expr.UpperValue = castedUpperValue
+		upperValue = castedUpperValue
 	}
 
-	if !expr.GetLowerInclusive() || !expr.GetUpperInclusive() {
-		if getGenericValue(GreaterEqual(lowerValue, upperValue)).GetBoolVal() {
-			return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-		}
-	} else {
-		if getGenericValue(Greater(lowerValue, upperValue)).GetBoolVal() {
-			return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-		}
-	}
-
-	return nil
+	return validateBinaryRangeBounds(lowerValue, upperValue, expr.GetLowerInclusive(), expr.GetUpperInclusive())
 }
 
 func FillBinaryArithOpEvalRangeExpressionValue(expr *planpb.BinaryArithOpEvalRangeExpr, templateValues map[string]*planpb.GenericValue) error {

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -75,6 +75,12 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 			{`Int64Field in {empty_list}`, map[string]*schemapb.TemplateValue{
 				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
 			}},
+			{`A in {empty_list}`, map[string]*schemapb.TemplateValue{
+				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+			}},
+			{`ArrayField in {empty_list}`, map[string]*schemapb.TemplateValue{
+				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+			}},
 		}
 		schemaH := newTestSchemaHelper(s.T())
 		for _, c := range testcases {
@@ -118,6 +124,44 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 			s.assertInvalidExpr(schemaH, c.expr, c.values)
 		}
 	})
+}
+
+func (s *FillExpressionValueSuite) TestEmptyTermRejectsUnsupportedTargetTypes() {
+	schemaH := newTestSchemaHelper(s.T())
+	emptyTemplate := map[string]*schemapb.TemplateValue{
+		"empty": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+	}
+	targetFields := []string{
+		"BinaryVectorField",
+		"FloatVectorField",
+		"Float16VectorField",
+		"BFloat16VectorField",
+		"SparseFloatVectorField",
+		"Int8VectorField",
+		"ArrayOfVectorField",
+		"GeometryField",
+	}
+	rightHandSides := []struct {
+		name   string
+		value  string
+		params map[string]*schemapb.TemplateValue
+	}{
+		{name: "inline", value: "[]"},
+		{name: "template", value: "{empty}", params: emptyTemplate},
+	}
+
+	for _, field := range targetFields {
+		for _, op := range []string{"in", "not in"} {
+			for _, rhs := range rightHandSides {
+				s.Run(field+"/"+op+"/"+rhs.name, func() {
+					expr, err := ParseExpr(schemaH, field+" "+op+" "+rhs.value, rhs.params)
+					s.Require().Error(err)
+					s.Require().Nil(expr)
+					s.Contains(err.Error(), "term expression is not supported")
+				})
+			}
+		}
+	}
 }
 
 func (s *FillExpressionValueSuite) TestEmptyArrayComparisonNormalization() {

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -71,6 +71,9 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 				"list": generateTemplateValue(schemapb.DataType_Array,
 					generateTemplateArrayValue(schemapb.DataType_Int64, []int64{int64(1), int64(2), int64(3)})),
 			}},
+			{`Int64Field in {empty_list}`, map[string]*schemapb.TemplateValue{
+				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+			}},
 		}
 		schemaH := newTestSchemaHelper(s.T())
 		for _, c := range testcases {
@@ -107,9 +110,6 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 			{"Int64Field not in {not_list}", map[string]*schemapb.TemplateValue{
 				"age": generateTemplateValue(schemapb.DataType_Int64, int64(33)),
 			}},
-			{`Int64Field in {empty_list}`, map[string]*schemapb.TemplateValue{
-				"empty_list": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
-			}},
 		}
 
 		schemaH := newTestSchemaHelper(s.T())
@@ -117,6 +117,34 @@ func (s *FillExpressionValueSuite) TestTermExpr() {
 			s.assertInvalidExpr(schemaH, c.expr, c.values)
 		}
 	})
+}
+
+func (s *FillExpressionValueSuite) TestEmptyArrayComparisonNormalization() {
+	schemaH := newTestSchemaHelper(s.T())
+	emptyArray := generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{})
+
+	testcases := []struct {
+		expr string
+		op   planpb.OpType
+	}{
+		{expr: `ArrayField == {empty}`, op: planpb.OpType_Equal},
+		{expr: `{empty} == ArrayField`, op: planpb.OpType_Equal},
+		{expr: `ArrayField != {empty}`, op: planpb.OpType_NotEqual},
+		{expr: `{empty} != ArrayField`, op: planpb.OpType_NotEqual},
+	}
+	for _, testcase := range testcases {
+		s.Run(testcase.expr, func() {
+			expr, err := ParseExpr(schemaH, testcase.expr, map[string]*schemapb.TemplateValue{
+				"empty": emptyArray,
+			})
+			s.NoError(err)
+			arrayLength := expr.GetBinaryArithOpEvalRangeExpr()
+			s.NotNil(arrayLength)
+			s.Equal(planpb.ArithOpType_ArrayLength, arrayLength.GetArithOp())
+			s.Equal(testcase.op, arrayLength.GetOp())
+			s.Equal(int64(0), arrayLength.GetValue().GetInt64Val())
+		})
+	}
 }
 
 func (s *FillExpressionValueSuite) TestUnaryRange() {

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -1,6 +1,7 @@
 package planparserv2
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -844,6 +845,52 @@ func (s *FillExpressionValueSuite) TestBinaryRangeWithMixedNumericTypesForJSON()
 		s.NotNil(bre, "expected BinaryRangeExpr")
 		s.Equal(float64(10.5), bre.GetLowerValue().GetFloatVal())
 		s.Equal(float64(100.5), bre.GetUpperValue().GetFloatVal())
+	})
+
+	s.Run("adjacent mixed bounds above 2^53 should remain valid", func() {
+		expr, err := ParseExpr(schemaH, `{min} <= A < {max}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740992)),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740993)),
+		})
+		s.Require().NoError(err)
+
+		bre := expr.GetBinaryRangeExpr()
+		s.Require().NotNil(bre)
+		s.IsType(&planpb.GenericValue_FloatVal{}, bre.GetLowerValue().GetVal())
+		s.Equal(float64(9007199254740992), bre.GetLowerValue().GetFloatVal())
+		s.IsType(&planpb.GenericValue_Int64Val{}, bre.GetUpperValue().GetVal())
+		s.Equal(int64(9007199254740993), bre.GetUpperValue().GetInt64Val())
+	})
+
+	s.Run("reverse adjacent mixed bounds above 2^53 should remain valid", func() {
+		expr, err := ParseExpr(schemaH, `{max} > A >= {min}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740992)),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740993)),
+		})
+		s.Require().NoError(err)
+
+		bre := expr.GetBinaryRangeExpr()
+		s.Require().NotNil(bre)
+		s.IsType(&planpb.GenericValue_FloatVal{}, bre.GetLowerValue().GetVal())
+		s.IsType(&planpb.GenericValue_Int64Val{}, bre.GetUpperValue().GetVal())
+	})
+
+	s.Run("truly reversed mixed bounds should fail", func() {
+		s.assertInvalidExpr(schemaH, `{min} <= A < {max}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Double, float64(9007199254740994)),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(9007199254740993)),
+		})
+	})
+
+	s.Run("NaN and different dynamic types are deferred to execution", func() {
+		s.assertValidExpr(schemaH, `{min} < A < {max}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Double, math.NaN()),
+			"max": generateTemplateValue(schemapb.DataType_Int64, int64(10)),
+		})
+		s.assertValidExpr(schemaH, `{min} < A < {max}`, map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Int64, int64(1)),
+			"max": generateTemplateValue(schemapb.DataType_String, "z"),
+		})
 	})
 }
 

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -1022,15 +1024,71 @@ func (s *FillExpressionValueSuite) TestBinaryRangeWithMixedNumericTypesForJSON()
 		})
 	})
 
-	s.Run("NaN and different dynamic types are deferred to execution", func() {
-		s.assertValidExpr(schemaH, `{min} < A < {max}`, map[string]*schemapb.TemplateValue{
-			"min": generateTemplateValue(schemapb.DataType_Double, math.NaN()),
-			"max": generateTemplateValue(schemapb.DataType_Int64, int64(10)),
-		})
-		s.assertValidExpr(schemaH, `{min} < A < {max}`, map[string]*schemapb.TemplateValue{
+	s.Run("NaN and different dynamic types should fail", func() {
+		bounds := func(min, max *schemapb.TemplateValue) map[string]*schemapb.TemplateValue {
+			return map[string]*schemapb.TemplateValue{"min": min, "max": max}
+		}
+		value := generateTemplateValue
+		mixedBounds := bounds(value(schemapb.DataType_Int64, int64(1)), value(schemapb.DataType_String, "z"))
+		array := func(v int64) *schemapb.TemplateValue {
+			return value(schemapb.DataType_Array, generateTemplateArrayValue(schemapb.DataType_Int64, []int64{v}))
+		}
+		for _, c := range []testcase{
+			{`{min} < A < {max}`, bounds(value(schemapb.DataType_Double, math.NaN()), value(schemapb.DataType_Int64, int64(10)))},
+			{`{min} < A < {max}`, bounds(value(schemapb.DataType_Int64, int64(1)), value(schemapb.DataType_Double, math.NaN()))},
+			{`{min} < A < {max}`, mixedBounds},
+			{`1 < A < {max}`, map[string]*schemapb.TemplateValue{"max": value(schemapb.DataType_String, "z")}},
+			{`{min} < A < "z"`, map[string]*schemapb.TemplateValue{"min": value(schemapb.DataType_Int64, int64(1))}},
+			{`{min} < DoubleField < {max}`, bounds(value(schemapb.DataType_Double, math.NaN()), value(schemapb.DataType_Double, float64(10)))},
+			{`{min} < A < {max}`, bounds(value(schemapb.DataType_Bool, false), value(schemapb.DataType_Bool, true))},
+			{`{min} < A < {max}`, bounds(array(1), array(2))},
+			{`{min} < A < {max} && random_sample(0.1)`, mixedBounds},
+			{`true OR ({min} < A < {max})`, mixedBounds},
+			{`({min} < A < {max}) OR true`, mixedBounds},
+			{`false AND ({min} < A < {max})`, mixedBounds},
+			{`({min} < A < {max}) AND false`, mixedBounds},
+		} {
+			expr, err := ParseExpr(schemaH, c.expr, c.values)
+			s.ErrorIs(err, merr.ErrQueryPlan, c.expr)
+			s.Nil(expr, c.expr)
+		}
+	})
+
+	s.Run("valid template bounds should survive expression wrappers", func() {
+		templateValues := map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Int64, int64(1)),
+			"max": generateTemplateValue(schemapb.DataType_Double, float64(10.5)),
+		}
+		exprStr := `{min} < A < {max} && random_sample(0.1)`
+		expr, err := ParseExpr(schemaH, exprStr, templateValues)
+		s.Require().NoError(err, exprStr)
+		s.NotNil(expr, exprStr)
+		s.assertNoUnfilledPlaceholder(expr)
+
+		s.assertValidExpr(schemaH, `A > {min} AND A < {max}`, map[string]*schemapb.TemplateValue{
 			"min": generateTemplateValue(schemapb.DataType_Int64, int64(1)),
 			"max": generateTemplateValue(schemapb.DataType_String, "z"),
 		})
+	})
+
+	s.Run("template validation preserves constant short circuit when optimization is disabled", func() {
+		old := paramtable.Get().CommonCfg.EnabledOptimizeExpr.SwapTempValue("false")
+		defer paramtable.Get().CommonCfg.EnabledOptimizeExpr.SwapTempValue(old)
+
+		templateValues := map[string]*schemapb.TemplateValue{
+			"min": generateTemplateValue(schemapb.DataType_Int64, int64(1)),
+			"max": generateTemplateValue(schemapb.DataType_Double, float64(10.5)),
+		}
+		for exprStr, want := range map[string]*planpb.Expr{
+			`true OR ({min} < A < {max})`:   alwaysTrueExpr(),
+			`({min} < A < {max}) OR true`:   alwaysTrueExpr(),
+			`false AND ({min} < A < {max})`: alwaysFalseExpr(),
+			`({min} < A < {max}) AND false`: alwaysFalseExpr(),
+		} {
+			expr, err := ParseExpr(schemaH, exprStr, templateValues)
+			s.Require().NoError(err, exprStr)
+			s.Equal(want, expr, exprStr)
+		}
 	})
 }
 

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -192,6 +192,94 @@ func (s *FillExpressionValueSuite) TestEmptyArrayComparisonNormalization() {
 	}
 }
 
+func (s *FillExpressionValueSuite) TestWholeArrayTemplateMembershipNormalization() {
+	schemaH := newTestSchemaHelper(s.T())
+	emptyArray := func() *schemapb.TemplateArrayValue {
+		return &schemapb.TemplateArrayValue{}
+	}
+	intArray := func(values ...int64) *schemapb.TemplateArrayValue {
+		return generateTemplateArrayValue(schemapb.DataType_Int64, values)
+	}
+
+	testcases := []struct {
+		name               string
+		arrays             []*schemapb.TemplateArrayValue
+		expectedLengths    int
+		expectedEqualities int
+	}{
+		{
+			name:            "empty arrays",
+			arrays:          []*schemapb.TemplateArrayValue{emptyArray(), emptyArray()},
+			expectedLengths: 2,
+		},
+		{
+			name: "non-empty arrays",
+			arrays: []*schemapb.TemplateArrayValue{
+				intArray(1, 2),
+				intArray(3, 4),
+			},
+			expectedEqualities: 2,
+		},
+		{
+			name: "mixed empty and non-empty arrays",
+			arrays: []*schemapb.TemplateArrayValue{
+				emptyArray(),
+				intArray(1, 2),
+			},
+			expectedLengths:    1,
+			expectedEqualities: 1,
+		},
+	}
+
+	for _, testcase := range testcases {
+		for _, op := range []string{"in", "not in"} {
+			s.Run(testcase.name+"/"+op, func() {
+				expr, err := ParseExpr(schemaH, "ArrayField "+op+" {arrays}", map[string]*schemapb.TemplateValue{
+					"arrays": generateTemplateValue(schemapb.DataType_Array,
+						generateTemplateArrayValue(schemapb.DataType_Array, testcase.arrays)),
+				})
+				s.NoError(err)
+				s.NotNil(expr)
+				if op == "not in" {
+					s.NotNil(expr.GetUnaryExpr())
+					s.Equal(planpb.UnaryExpr_Not, expr.GetUnaryExpr().GetOp())
+				}
+
+				var arrayLengths int
+				var arrayEqualities int
+				var walk func(*planpb.Expr)
+				walk = func(current *planpb.Expr) {
+					if current == nil {
+						return
+					}
+					s.Nil(current.GetTermExpr(), "whole ARRAY membership must not remain a TermExpr")
+					if arrayLength := current.GetBinaryArithOpEvalRangeExpr(); arrayLength != nil &&
+						arrayLength.GetArithOp() == planpb.ArithOpType_ArrayLength &&
+						arrayLength.GetOp() == planpb.OpType_Equal &&
+						arrayLength.GetValue().GetInt64Val() == 0 {
+						arrayLengths++
+					}
+					if equality := current.GetUnaryRangeExpr(); equality != nil &&
+						equality.GetOp() == planpb.OpType_Equal &&
+						equality.GetValue().GetArrayVal() != nil {
+						arrayEqualities++
+					}
+					if binary := current.GetBinaryExpr(); binary != nil {
+						walk(binary.GetLeft())
+						walk(binary.GetRight())
+					}
+					if unary := current.GetUnaryExpr(); unary != nil {
+						walk(unary.GetChild())
+					}
+				}
+				walk(expr)
+				s.Equal(testcase.expectedLengths, arrayLengths)
+				s.Equal(testcase.expectedEqualities, arrayEqualities)
+			})
+		}
+	}
+}
+
 func (s *FillExpressionValueSuite) TestUnaryRange() {
 	s.Run("normal case", func() {
 		testcases := []testcase{

--- a/internal/parser/planparserv2/fill_expression_value_test.go
+++ b/internal/parser/planparserv2/fill_expression_value_test.go
@@ -781,6 +781,14 @@ func (s *FillExpressionValueSuite) TestJSONContainsExpression() {
 				expected: true,
 			},
 			{
+				name: "untyped empty array",
+				expr: `json_contains_all(JSONField, {array})`,
+				values: map[string]*schemapb.TemplateValue{
+					"array": generateTemplateValue(schemapb.DataType_Array, &schemapb.TemplateArrayValue{}),
+				},
+				expected: true,
+			},
+			{
 				name: "singleton array",
 				expr: `json_contains_all(JSONField, {array})`,
 				values: map[string]*schemapb.TemplateValue{

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -1144,6 +1144,12 @@ func (v *ParserVisitor) VisitRandomSample(ctx *parser.RandomSampleContext) inter
 	}
 }
 
+func isTermExprTargetSupported(dataType schemapb.DataType) bool {
+	return typeutil.IsPrimitiveType(dataType) ||
+		typeutil.IsJSONType(dataType) ||
+		typeutil.IsArrayType(dataType)
+}
+
 // VisitTerm translates expr to term plan.
 func (v *ParserVisitor) VisitTerm(ctx *parser.TermContext) interface{} {
 	child := ctx.Expr(0).Accept(v)
@@ -1167,6 +1173,9 @@ func (v *ParserVisitor) VisitTerm(ctx *parser.TermContext) interface{} {
 	// 2. Array with element level flag (e.g., $[intField] IN [1, 2] in MATCH_ALL/ElementFilter)
 	if typeutil.IsArrayType(dataType) && (len(columnInfo.GetNestedPath()) != 0 || columnInfo.GetIsElementLevel()) {
 		dataType = columnInfo.GetElementType()
+	}
+	if !isTermExprTargetSupported(dataType) {
+		return merr.WrapErrParameterInvalidMsg("term expression is not supported for data type %s", dataType.String())
 	}
 
 	term := ctx.Expr(1).Accept(v)

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -306,6 +306,31 @@ func checkDirectComparisonBinaryField(columnInfo *planpb.ColumnInfo) error {
 	return nil
 }
 
+// contextualizeEmptyArrayLiteral assigns the element type of a whole ARRAY
+// column to an inline empty array literal. Unlike a non-empty literal, [] has
+// no element from which the parser can infer a type. The field provides that
+// missing context for equality comparisons without relaxing comparisons on
+// ARRAY elements or JSON paths.
+func contextualizeEmptyArrayLiteral(literal, field *ExprWithType) {
+	if literal == nil || field == nil || literal.dataType != schemapb.DataType_Array {
+		return
+	}
+	valueExpr := literal.expr.GetValueExpr()
+	if valueExpr == nil || isTemplateExpr(valueExpr) {
+		return
+	}
+	array := valueExpr.GetValue().GetArrayVal()
+	if array == nil || len(array.GetArray()) != 0 || array.GetElementType() != schemapb.DataType_None {
+		return
+	}
+	columnInfo := toColumnInfo(field)
+	if columnInfo == nil || columnInfo.GetDataType() != schemapb.DataType_Array ||
+		len(columnInfo.GetNestedPath()) != 0 || columnInfo.GetIsElementLevel() {
+		return
+	}
+	array.ElementType = columnInfo.GetElementType()
+}
+
 // VisitAddSub translates expr to arithmetic plan.
 func (v *ParserVisitor) VisitAddSub(ctx *parser.AddSubContext) interface{} {
 	var err error
@@ -496,6 +521,10 @@ func (v *ParserVisitor) VisitEquality(ctx *parser.EqualityContext) interface{} {
 		return err
 	}
 
+	leftExpr, rightExpr := getExpr(left), getExpr(right)
+	contextualizeEmptyArrayLiteral(leftExpr, rightExpr)
+	contextualizeEmptyArrayLiteral(rightExpr, leftExpr)
+
 	leftValueExpr, rightValueExpr := getValueExpr(left), getValueExpr(right)
 	if leftValueExpr != nil && rightValueExpr != nil {
 		if isTemplateExpr(leftValueExpr) || isTemplateExpr(rightValueExpr) {
@@ -516,8 +545,6 @@ func (v *ParserVisitor) VisitEquality(ctx *parser.EqualityContext) interface{} {
 		}
 		return ret
 	}
-
-	leftExpr, rightExpr := getExpr(left), getExpr(right)
 
 	expr, err := HandleCompare(ctx.GetOp().GetTokenType(), leftExpr, rightExpr)
 	if err != nil {

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -1524,14 +1524,8 @@ func (v *ParserVisitor) VisitRange(ctx *parser.RangeContext) interface{} {
 	lowerInclusive := ctx.GetOp1().GetTokenType() == parser.PlanParserLE
 	upperInclusive := ctx.GetOp2().GetTokenType() == parser.PlanParserLE
 	if !isTemplateExpr(lowerValueExpr) && !isTemplateExpr(upperValueExpr) {
-		if !lowerInclusive || !upperInclusive {
-			if getGenericValue(GreaterEqual(lowerValue, upperValue)).GetBoolVal() {
-				return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-			}
-		} else {
-			if getGenericValue(Greater(lowerValue, upperValue)).GetBoolVal() {
-				return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-			}
+		if err := validateBinaryRangeBounds(lowerValue, upperValue, lowerInclusive, upperInclusive); err != nil {
+			return err
 		}
 	}
 
@@ -1611,14 +1605,8 @@ func (v *ParserVisitor) VisitReverseRange(ctx *parser.ReverseRangeContext) inter
 	lowerInclusive := ctx.GetOp2().GetTokenType() == parser.PlanParserGE
 	upperInclusive := ctx.GetOp1().GetTokenType() == parser.PlanParserGE
 	if !isTemplateExpr(lowerValueExpr) && !isTemplateExpr(upperValueExpr) {
-		if !lowerInclusive || !upperInclusive {
-			if getGenericValue(GreaterEqual(lowerValue, upperValue)).GetBoolVal() {
-				return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-			}
-		} else {
-			if getGenericValue(Greater(lowerValue, upperValue)).GetBoolVal() {
-				return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
-			}
+		if err := validateBinaryRangeBounds(lowerValue, upperValue, lowerInclusive, upperInclusive); err != nil {
+			return err
 		}
 	}
 

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -1765,6 +1765,22 @@ func (v *ParserVisitor) VisitUnary(ctx *parser.UnaryContext) interface{} {
 	}
 }
 
+func newLogicalBinaryExpr(leftExpr, rightExpr *ExprWithType, op planpb.BinaryExpr_BinaryOp) *ExprWithType {
+	return &ExprWithType{
+		expr: &planpb.Expr{
+			Expr: &planpb.Expr_BinaryExpr{
+				BinaryExpr: &planpb.BinaryExpr{
+					Left:  leftExpr.expr,
+					Right: rightExpr.expr,
+					Op:    op,
+				},
+			},
+			IsTemplate: leftExpr.expr.GetIsTemplate() || rightExpr.expr.GetIsTemplate(),
+		},
+		dataType: schemapb.DataType_Bool,
+	}
+}
+
 // VisitLogicalOr apply logical or to two boolean expressions.
 func (v *ParserVisitor) VisitLogicalOr(ctx *parser.LogicalOrContext) interface{} {
 	left := ctx.Expr(0).Accept(v)
@@ -1798,6 +1814,9 @@ func (v *ParserVisitor) VisitLogicalOr(ctx *parser.LogicalOrContext) interface{}
 			return merr.WrapErrQueryPlanMsg("'or' can only be used between boolean expressions")
 		}
 		if boolLiteral.GetBoolVal() {
+			if otherExpr != nil && canBeExecuted(otherExpr) && otherExpr.expr.GetIsTemplate() {
+				return newLogicalBinaryExpr(getExpr(left), getExpr(right), planpb.BinaryExpr_LogicalOr)
+			}
 			// true or expr → always true
 			return &ExprWithType{
 				expr:     alwaysTrueExpr(),
@@ -1811,10 +1830,7 @@ func (v *ParserVisitor) VisitLogicalOr(ctx *parser.LogicalOrContext) interface{}
 		return otherExpr
 	}
 
-	var leftExpr *ExprWithType
-	var rightExpr *ExprWithType
-	leftExpr = getExpr(left)
-	rightExpr = getExpr(right)
+	leftExpr, rightExpr := getExpr(left), getExpr(right)
 	if isRandomSampleExpr(leftExpr) || isRandomSampleExpr(rightExpr) {
 		return merr.WrapErrQueryPlanMsg("random sample expression cannot be used in logical and expression")
 	}
@@ -1826,21 +1842,7 @@ func (v *ParserVisitor) VisitLogicalOr(ctx *parser.LogicalOrContext) interface{}
 	if !canBeExecuted(leftExpr) || !canBeExecuted(rightExpr) {
 		return merr.WrapErrQueryPlanMsg("'or' can only be used between boolean expressions")
 	}
-	expr := &planpb.Expr{
-		Expr: &planpb.Expr_BinaryExpr{
-			BinaryExpr: &planpb.BinaryExpr{
-				Left:  leftExpr.expr,
-				Right: rightExpr.expr,
-				Op:    planpb.BinaryExpr_LogicalOr,
-			},
-		},
-		IsTemplate: leftExpr.expr.GetIsTemplate() || rightExpr.expr.GetIsTemplate(),
-	}
-
-	return &ExprWithType{
-		expr:     expr,
-		dataType: schemapb.DataType_Bool,
-	}
+	return newLogicalBinaryExpr(leftExpr, rightExpr, planpb.BinaryExpr_LogicalOr)
 }
 
 // VisitLogicalAnd apply logical and to two boolean expressions.
@@ -1876,6 +1878,9 @@ func (v *ParserVisitor) VisitLogicalAnd(ctx *parser.LogicalAndContext) interface
 			return merr.WrapErrQueryPlanMsg("'and' can only be used between boolean expressions")
 		}
 		if !boolLiteral.GetBoolVal() {
+			if otherExpr != nil && canBeExecuted(otherExpr) && otherExpr.expr.GetIsTemplate() {
+				return newLogicalBinaryExpr(getExpr(left), getExpr(right), planpb.BinaryExpr_LogicalAnd)
+			}
 			// false and expr → always false
 			return &ExprWithType{
 				expr:     alwaysFalseExpr(),
@@ -1889,10 +1894,7 @@ func (v *ParserVisitor) VisitLogicalAnd(ctx *parser.LogicalAndContext) interface
 		return otherExpr
 	}
 
-	var leftExpr *ExprWithType
-	var rightExpr *ExprWithType
-	leftExpr = getExpr(left)
-	rightExpr = getExpr(right)
+	leftExpr, rightExpr := getExpr(left), getExpr(right)
 	if isRandomSampleExpr(leftExpr) {
 		return merr.WrapErrQueryPlanMsg("random sample expression can only be the last expression in the logical and expression")
 	}
@@ -1905,47 +1907,39 @@ func (v *ParserVisitor) VisitLogicalAnd(ctx *parser.LogicalAndContext) interface
 		return merr.WrapErrQueryPlanMsg("'and' can only be used between boolean expressions")
 	}
 
-	var expr *planpb.Expr
 	if isRandomSampleExpr(rightExpr) {
 		randomSampleExpr := rightExpr.expr.GetRandomSampleExpr()
 		randomSampleExpr.Predicate = leftExpr.expr
-		expr = &planpb.Expr{
-			Expr: &planpb.Expr_RandomSampleExpr{
-				RandomSampleExpr: randomSampleExpr,
+		return &ExprWithType{
+			expr: &planpb.Expr{
+				Expr: &planpb.Expr_RandomSampleExpr{
+					RandomSampleExpr: randomSampleExpr,
+				},
+				// The wrapper must carry the predicate's template flag, or the
+				// top-level IsTemplate short-circuit skips FillExpressionValue and
+				// an unfilled placeholder (e.g. a deferred bloom_match) fans out
+				// to QueryNodes. Mirrors the element_filter branch below.
+				IsTemplate: leftExpr.expr.GetIsTemplate() || rightExpr.expr.GetIsTemplate(),
 			},
-			// The wrapper must carry the predicate's template flag, or the
-			// top-level IsTemplate short-circuit skips FillExpressionValue and
-			// an unfilled placeholder (e.g. a deferred bloom_match) fans out
-			// to QueryNodes. Mirrors the element_filter branch below.
-			IsTemplate: leftExpr.expr.GetIsTemplate() || rightExpr.expr.GetIsTemplate(),
+			dataType: schemapb.DataType_Bool,
 		}
-	} else if isElementFilterExpr(rightExpr) {
+	}
+	if isElementFilterExpr(rightExpr) {
 		// Similar to RandomSampleExpr, extract doc-level predicate
 		elementFilterExpr := rightExpr.expr.GetElementFilterExpr()
 		elementFilterExpr.Predicate = leftExpr.expr
-		expr = &planpb.Expr{
-			Expr: &planpb.Expr_ElementFilterExpr{
-				ElementFilterExpr: elementFilterExpr,
-			},
-			IsTemplate: leftExpr.expr.GetIsTemplate() || rightExpr.expr.GetIsTemplate(),
-		}
-	} else {
-		expr = &planpb.Expr{
-			Expr: &planpb.Expr_BinaryExpr{
-				BinaryExpr: &planpb.BinaryExpr{
-					Left:  leftExpr.expr,
-					Right: rightExpr.expr,
-					Op:    planpb.BinaryExpr_LogicalAnd,
+		return &ExprWithType{
+			expr: &planpb.Expr{
+				Expr: &planpb.Expr_ElementFilterExpr{
+					ElementFilterExpr: elementFilterExpr,
 				},
+				IsTemplate: leftExpr.expr.GetIsTemplate() || rightExpr.expr.GetIsTemplate(),
 			},
-			IsTemplate: leftExpr.expr.GetIsTemplate() || rightExpr.expr.GetIsTemplate(),
+			dataType: schemapb.DataType_Bool,
 		}
 	}
 
-	return &ExprWithType{
-		expr:     expr,
-		dataType: schemapb.DataType_Bool,
-	}
+	return newLogicalBinaryExpr(leftExpr, rightExpr, planpb.BinaryExpr_LogicalAnd)
 }
 
 // visitBitwiseBinaryOp is the shared implementation for VisitBitAnd/VisitBitOr/VisitBitXor.

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -1547,6 +1547,48 @@ func TestExpr_BinaryRange(t *testing.T) {
 	}
 }
 
+func TestExpr_JSONBinaryRangePreciseBoundValidation(t *testing.T) {
+	schema := newTestSchema(true)
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	require.NoError(t, err)
+
+	for name, exprStr := range map[string]string{
+		"range":         `9007199254740992.0 <= A < 9007199254740993`,
+		"reverse range": `9007199254740993 > A >= 9007199254740992.0`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			expr, err := ParseExpr(helper, exprStr, nil)
+			require.NoError(t, err)
+
+			binaryRange := expr.GetBinaryRangeExpr()
+			require.NotNil(t, binaryRange)
+			assert.IsType(t, &planpb.GenericValue_FloatVal{}, binaryRange.GetLowerValue().GetVal())
+			assert.Equal(t, float64(9007199254740992), binaryRange.GetLowerValue().GetFloatVal())
+			assert.IsType(t, &planpb.GenericValue_Int64Val{}, binaryRange.GetUpperValue().GetVal())
+			assert.Equal(t, int64(9007199254740993), binaryRange.GetUpperValue().GetInt64Val())
+			assert.True(t, binaryRange.GetLowerInclusive())
+			assert.False(t, binaryRange.GetUpperInclusive())
+		})
+	}
+
+	for name, exprStr := range map[string]string{
+		"range lower greater than upper":         `9007199254740994.0 <= A < 9007199254740993`,
+		"reverse range lower greater than upper": `9007199254740993 > A >= 9007199254740994.0`,
+		"equal bounds with open upper":           `9007199254740992.0 <= A < 9007199254740992`,
+		"equal bounds with open lower":           `9007199254740992.0 < A <= 9007199254740992`,
+		"same-type strings in reverse order":     `"z" <= A < "a"`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseExpr(helper, exprStr, nil)
+			assert.Error(t, err)
+		})
+	}
+
+	// Bounds with different JSON dynamic types have no parser-level ordering.
+	// Their runtime type semantics are evaluated by segcore.
+	assertValidExpr(t, helper, `1 <= A < "z"`)
+}
+
 func TestExpr_castValue(t *testing.T) {
 	schema := newTestSchema(true)
 	helper, err := typeutil.CreateSchemaHelper(schema)

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -172,6 +172,8 @@ func TestExpr_NullLiteral(t *testing.T) {
 		`Int64Field != NULL`,
 		// range comparison
 		`1 < NULL < 5`,
+		`NULL < Int64Field < 5`,
+		`1 < Int64Field < NULL`,
 		`Int64Field < NULL`,
 		// logical / unary operands
 		`NULL and Int64Field > 0`,
@@ -1584,9 +1586,22 @@ func TestExpr_JSONBinaryRangePreciseBoundValidation(t *testing.T) {
 		})
 	}
 
-	// Bounds with different JSON dynamic types have no parser-level ordering.
-	// Their runtime type semantics are evaluated by segcore.
-	assertValidExpr(t, helper, `1 <= A < "z"`)
+	for _, exprStr := range []string{
+		`1 <= A < "z"`,
+		`"z" > A >= 1`,
+		`false < A < true`,
+		`[1] < A < [2]`,
+	} {
+		_, err := ParseExpr(helper, exprStr, nil)
+		require.ErrorIs(t, err, merr.ErrQueryPlan, exprStr)
+		assert.Contains(t, err.Error(), "bounds are not comparable", exprStr)
+	}
+
+	// Separate comparisons keep their own JSON dynamic-type semantics and must
+	// not be rejected or merged into a mixed-type BinaryRangeExpr.
+	expr, err := ParseExpr(helper, `A >= 1 AND A < "z"`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, expr.GetBinaryExpr())
 }
 
 func TestExpr_castValue(t *testing.T) {

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -2693,6 +2693,10 @@ func Test_ArrayExpr(t *testing.T) {
 		`ArrayField == [1,2,3,4]`,
 		`ArrayField != [1,2,3,4]`,
 		`[1,2,3,4] == ArrayField`,
+		`ArrayField == []`,
+		`ArrayField != []`,
+		`[] == ArrayField`,
+		`[] != ArrayField`,
 		`ArrayField[0] == 1`,
 		`ArrayField[0] > 1`,
 		`1 < ArrayField[0] < 3`,
@@ -2774,7 +2778,6 @@ func Test_ArrayExpr(t *testing.T) {
 		`ArrayField[] == 1`,
 		`A[] == 1`,
 		`ArrayField[0] + ArrayField[1] == 1`,
-		`ArrayField == []`,
 	}
 	for _, expr = range invalidExprs {
 		_, err = CreateSearchPlan(schema, expr, "FloatVectorField", &planpb.QueryInfo{
@@ -2785,6 +2788,53 @@ func Test_ArrayExpr(t *testing.T) {
 		}, nil, nil)
 		assert.Error(t, err, expr)
 	}
+}
+
+func Test_EmptyArrayComparisonNormalization(t *testing.T) {
+	schema := newTestSchema(true)
+	for _, field := range schema.GetFields() {
+		if field.GetName() == "ArrayField" {
+			field.Nullable = true
+		}
+	}
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	require.NoError(t, err)
+
+	testcases := []struct {
+		expr string
+		op   planpb.OpType
+	}{
+		{expr: `ArrayField == []`, op: planpb.OpType_Equal},
+		{expr: `[] == ArrayField`, op: planpb.OpType_Equal},
+		{expr: `ArrayField != []`, op: planpb.OpType_NotEqual},
+		{expr: `[] != ArrayField`, op: planpb.OpType_NotEqual},
+		{expr: `StringArrayField == []`, op: planpb.OpType_Equal},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.expr, func(t *testing.T) {
+			expr, err := ParseExpr(helper, testcase.expr, nil)
+			require.NoError(t, err)
+			arrayLength := expr.GetBinaryArithOpEvalRangeExpr()
+			require.NotNil(t, arrayLength)
+			require.Equal(t, planpb.ArithOpType_ArrayLength, arrayLength.GetArithOp())
+			require.Equal(t, testcase.op, arrayLength.GetOp())
+			require.Equal(t, int64(0), arrayLength.GetValue().GetInt64Val())
+			require.Empty(t, arrayLength.GetColumnInfo().GetNestedPath())
+			require.False(t, arrayLength.GetColumnInfo().GetIsElementLevel())
+			if testcase.expr == `ArrayField == []` {
+				require.True(t, arrayLength.GetColumnInfo().GetNullable())
+			}
+		})
+	}
+
+	_, err = ParseExpr(helper, `ArrayField[0] == []`, nil)
+	require.Error(t, err)
+	_, err = ParseExpr(helper, `ArrayField > []`, nil)
+	require.Error(t, err)
+
+	jsonExpr, err := ParseExpr(helper, `JSONField["array"] == []`, nil)
+	require.NoError(t, err)
+	require.NotNil(t, jsonExpr.GetUnaryRangeExpr(), "JSON array comparison must not be rewritten as ARRAY length")
 }
 
 func Test_ArrayLength(t *testing.T) {

--- a/internal/parser/planparserv2/rewriter/array.go
+++ b/internal/parser/planparserv2/rewriter/array.go
@@ -1,0 +1,81 @@
+package rewriter
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+)
+
+// normalizeEmptyArrayComparisons lowers whole ARRAY == [] and ARRAY != [] to
+// array_length(ARRAY) == 0 and array_length(ARRAY) != 0. This is semantic
+// normalization rather than an optional optimization: an empty array carries
+// no element type, while ARRAY length has the same nullable semantics and an
+// executable plan representation.
+func normalizeEmptyArrayComparisons(expr *planpb.Expr) *planpb.Expr {
+	if expr == nil {
+		return nil
+	}
+
+	switch real := expr.GetExpr().(type) {
+	case *planpb.Expr_BinaryExpr:
+		real.BinaryExpr.Left = normalizeEmptyArrayComparisons(real.BinaryExpr.GetLeft())
+		real.BinaryExpr.Right = normalizeEmptyArrayComparisons(real.BinaryExpr.GetRight())
+		return expr
+	case *planpb.Expr_UnaryExpr:
+		real.UnaryExpr.Child = normalizeEmptyArrayComparisons(real.UnaryExpr.GetChild())
+		return expr
+	case *planpb.Expr_BinaryArithExpr:
+		real.BinaryArithExpr.Left = normalizeEmptyArrayComparisons(real.BinaryArithExpr.GetLeft())
+		real.BinaryArithExpr.Right = normalizeEmptyArrayComparisons(real.BinaryArithExpr.GetRight())
+		return expr
+	case *planpb.Expr_CallExpr:
+		for i, parameter := range real.CallExpr.GetFunctionParameters() {
+			real.CallExpr.FunctionParameters[i] = normalizeEmptyArrayComparisons(parameter)
+		}
+		return expr
+	case *planpb.Expr_RandomSampleExpr:
+		real.RandomSampleExpr.Predicate = normalizeEmptyArrayComparisons(real.RandomSampleExpr.GetPredicate())
+		return expr
+	case *planpb.Expr_ElementFilterExpr:
+		real.ElementFilterExpr.ElementExpr = normalizeEmptyArrayComparisons(real.ElementFilterExpr.GetElementExpr())
+		real.ElementFilterExpr.Predicate = normalizeEmptyArrayComparisons(real.ElementFilterExpr.GetPredicate())
+		return expr
+	case *planpb.Expr_MatchExpr:
+		real.MatchExpr.Predicate = normalizeEmptyArrayComparisons(real.MatchExpr.GetPredicate())
+		return expr
+	case *planpb.Expr_UnaryRangeExpr:
+		return normalizeEmptyArrayUnaryRange(expr, real.UnaryRangeExpr)
+	default:
+		return expr
+	}
+}
+
+func normalizeEmptyArrayUnaryRange(original *planpb.Expr, unaryRange *planpb.UnaryRangeExpr) *planpb.Expr {
+	if unaryRange == nil || unaryRange.GetColumnInfo() == nil {
+		return original
+	}
+	columnInfo := unaryRange.GetColumnInfo()
+	if columnInfo.GetDataType() != schemapb.DataType_Array ||
+		len(columnInfo.GetNestedPath()) != 0 || columnInfo.GetIsElementLevel() {
+		return original
+	}
+	if unaryRange.GetOp() != planpb.OpType_Equal && unaryRange.GetOp() != planpb.OpType_NotEqual {
+		return original
+	}
+	array := unaryRange.GetValue().GetArrayVal()
+	if array == nil || len(array.GetArray()) != 0 {
+		return original
+	}
+
+	return &planpb.Expr{
+		Expr: &planpb.Expr_BinaryArithOpEvalRangeExpr{
+			BinaryArithOpEvalRangeExpr: &planpb.BinaryArithOpEvalRangeExpr{
+				ColumnInfo: columnInfo,
+				ArithOp:    planpb.ArithOpType_ArrayLength,
+				Op:         unaryRange.GetOp(),
+				Value: &planpb.GenericValue{
+					Val: &planpb.GenericValue_Int64Val{Int64Val: 0},
+				},
+			},
+		},
+	}
+}

--- a/internal/parser/planparserv2/rewriter/array_test.go
+++ b/internal/parser/planparserv2/rewriter/array_test.go
@@ -1,0 +1,124 @@
+package rewriter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+)
+
+func TestRewriteEmptyArrayComparisonWhenOptimizationDisabled(t *testing.T) {
+	for _, op := range []planpb.OpType{planpb.OpType_Equal, planpb.OpType_NotEqual} {
+		t.Run(op.String(), func(t *testing.T) {
+			columnInfo := &planpb.ColumnInfo{
+				FieldId:     101,
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				Nullable:    true,
+			}
+			input := &planpb.Expr{
+				Expr: &planpb.Expr_UnaryRangeExpr{
+					UnaryRangeExpr: &planpb.UnaryRangeExpr{
+						ColumnInfo: columnInfo,
+						Op:         op,
+						Value: &planpb.GenericValue{
+							Val: &planpb.GenericValue_ArrayVal{
+								ArrayVal: &planpb.Array{SameType: true},
+							},
+						},
+					},
+				},
+			}
+
+			result := rewriter.RewriteExprWithConfig(input, false)
+			arrayLength := result.GetBinaryArithOpEvalRangeExpr()
+			require.NotNil(t, arrayLength)
+			require.Equal(t, planpb.ArithOpType_ArrayLength, arrayLength.GetArithOp())
+			require.Equal(t, op, arrayLength.GetOp())
+			require.Equal(t, int64(0), arrayLength.GetValue().GetInt64Val())
+			require.True(t, arrayLength.GetColumnInfo().GetNullable())
+		})
+	}
+}
+
+func TestRewriteEmptyArrayComparisonOnlyForWholeArrayColumns(t *testing.T) {
+	testcases := []struct {
+		name       string
+		columnInfo *planpb.ColumnInfo
+	}{
+		{
+			name: "array element",
+			columnInfo: &planpb.ColumnInfo{
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				NestedPath:  []string{"0"},
+			},
+		},
+		{
+			name: "element level",
+			columnInfo: &planpb.ColumnInfo{
+				DataType:       schemapb.DataType_Array,
+				ElementType:    schemapb.DataType_Int64,
+				IsElementLevel: true,
+			},
+		},
+		{
+			name: "json path",
+			columnInfo: &planpb.ColumnInfo{
+				DataType:   schemapb.DataType_JSON,
+				NestedPath: []string{"array"},
+			},
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			input := &planpb.Expr{
+				Expr: &planpb.Expr_UnaryRangeExpr{
+					UnaryRangeExpr: &planpb.UnaryRangeExpr{
+						ColumnInfo: testcase.columnInfo,
+						Op:         planpb.OpType_Equal,
+						Value: &planpb.GenericValue{
+							Val: &planpb.GenericValue_ArrayVal{ArrayVal: &planpb.Array{}},
+						},
+					},
+				},
+			}
+
+			result := rewriter.RewriteExprWithConfig(input, false)
+			require.NotNil(t, result.GetUnaryRangeExpr())
+			require.Nil(t, result.GetBinaryArithOpEvalRangeExpr())
+		})
+	}
+}
+
+func TestRewriteNonEmptyArrayComparisonUnchanged(t *testing.T) {
+	input := &planpb.Expr{
+		Expr: &planpb.Expr_UnaryRangeExpr{
+			UnaryRangeExpr: &planpb.UnaryRangeExpr{
+				ColumnInfo: &planpb.ColumnInfo{
+					DataType:    schemapb.DataType_Array,
+					ElementType: schemapb.DataType_Int64,
+				},
+				Op: planpb.OpType_Equal,
+				Value: &planpb.GenericValue{
+					Val: &planpb.GenericValue_ArrayVal{
+						ArrayVal: &planpb.Array{
+							Array: []*planpb.GenericValue{
+								{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+							},
+							SameType:    true,
+							ElementType: schemapb.DataType_Int64,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := rewriter.RewriteExprWithConfig(input, false)
+	require.NotNil(t, result.GetUnaryRangeExpr())
+	require.Nil(t, result.GetBinaryArithOpEvalRangeExpr())
+}

--- a/internal/parser/planparserv2/rewriter/array_test.go
+++ b/internal/parser/planparserv2/rewriter/array_test.go
@@ -122,3 +122,129 @@ func TestRewriteNonEmptyArrayComparisonUnchanged(t *testing.T) {
 	require.NotNil(t, result.GetUnaryRangeExpr())
 	require.Nil(t, result.GetBinaryArithOpEvalRangeExpr())
 }
+
+func TestRewriteWholeArrayMembershipToEqualityBranches(t *testing.T) {
+	for _, optimizeEnabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "optimization disabled", true: "optimization enabled"}[optimizeEnabled], func(t *testing.T) {
+			columnInfo := &planpb.ColumnInfo{
+				FieldId:     101,
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				Nullable:    true,
+			}
+			input := &planpb.Expr{
+				Expr: &planpb.Expr_TermExpr{
+					TermExpr: &planpb.TermExpr{
+						ColumnInfo: columnInfo,
+						Values: []*planpb.GenericValue{
+							newArrayLiteral(),
+							newArrayLiteral(1, 2),
+						},
+					},
+				},
+			}
+
+			result := rewriter.RewriteExprWithConfig(input, optimizeEnabled)
+			require.Nil(t, findTermExpr(result))
+
+			var emptyArrayLengths int
+			var nonEmptyEqualities int
+			walkArrayMembershipExpr(result, func(current *planpb.Expr) {
+				if arrayLength := current.GetBinaryArithOpEvalRangeExpr(); arrayLength != nil &&
+					arrayLength.GetArithOp() == planpb.ArithOpType_ArrayLength &&
+					arrayLength.GetOp() == planpb.OpType_Equal &&
+					arrayLength.GetValue().GetInt64Val() == 0 {
+					emptyArrayLengths++
+				}
+				if equality := current.GetUnaryRangeExpr(); equality != nil &&
+					equality.GetOp() == planpb.OpType_Equal &&
+					len(equality.GetValue().GetArrayVal().GetArray()) > 0 {
+					nonEmptyEqualities++
+				}
+			})
+			require.Equal(t, 1, emptyArrayLengths)
+			require.Equal(t, 1, nonEmptyEqualities)
+		})
+	}
+}
+
+func TestRewriteWholeArrayNotInKeepsOuterNot(t *testing.T) {
+	for _, optimizeEnabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "optimization disabled", true: "optimization enabled"}[optimizeEnabled], func(t *testing.T) {
+			columnInfo := &planpb.ColumnInfo{
+				FieldId:     101,
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+				Nullable:    true,
+			}
+			term := &planpb.Expr{
+				Expr: &planpb.Expr_TermExpr{
+					TermExpr: &planpb.TermExpr{
+						ColumnInfo: columnInfo,
+						Values: []*planpb.GenericValue{
+							newArrayLiteral(1, 2),
+							newArrayLiteral(3, 4),
+						},
+					},
+				},
+			}
+			input := &planpb.Expr{
+				Expr: &planpb.Expr_UnaryExpr{
+					UnaryExpr: &planpb.UnaryExpr{
+						Op:    planpb.UnaryExpr_Not,
+						Child: term,
+					},
+				},
+			}
+
+			result := rewriter.RewriteExprWithConfig(input, optimizeEnabled)
+			unary := result.GetUnaryExpr()
+			require.NotNil(t, unary)
+			require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp())
+			require.NotNil(t, unary.GetChild().GetBinaryExpr())
+			require.Nil(t, findTermExpr(result))
+
+			var equalities int
+			walkArrayMembershipExpr(unary.GetChild(), func(current *planpb.Expr) {
+				if equality := current.GetUnaryRangeExpr(); equality != nil &&
+					equality.GetOp() == planpb.OpType_Equal &&
+					equality.GetValue().GetArrayVal() != nil {
+					equalities++
+				}
+			})
+			require.Equal(t, 2, equalities)
+		})
+	}
+}
+
+func newArrayLiteral(values ...int64) *planpb.GenericValue {
+	elements := make([]*planpb.GenericValue, 0, len(values))
+	for _, value := range values {
+		elements = append(elements, &planpb.GenericValue{
+			Val: &planpb.GenericValue_Int64Val{Int64Val: value},
+		})
+	}
+	return &planpb.GenericValue{
+		Val: &planpb.GenericValue_ArrayVal{
+			ArrayVal: &planpb.Array{
+				Array:       elements,
+				SameType:    true,
+				ElementType: schemapb.DataType_Int64,
+			},
+		},
+	}
+}
+
+func walkArrayMembershipExpr(expr *planpb.Expr, visit func(*planpb.Expr)) {
+	if expr == nil {
+		return
+	}
+	visit(expr)
+	if binary := expr.GetBinaryExpr(); binary != nil {
+		walkArrayMembershipExpr(binary.GetLeft(), visit)
+		walkArrayMembershipExpr(binary.GetRight(), visit)
+	}
+	if unary := expr.GetUnaryExpr(); unary != nil {
+		walkArrayMembershipExpr(unary.GetChild(), visit)
+	}
+}

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -15,6 +15,7 @@ func RewriteExprWithConfig(e *planpb.Expr, optimizeEnabled bool) *planpb.Expr {
 	if e == nil {
 		return nil
 	}
+	e = normalizeEmptyArrayComparisons(e)
 	e = normalizeJSONTermExprs(e)
 	v := &visitor{optimizeEnabled: optimizeEnabled}
 	res := v.visitExpr(e)

--- a/internal/parser/planparserv2/rewriter/entry.go
+++ b/internal/parser/planparserv2/rewriter/entry.go
@@ -15,8 +15,8 @@ func RewriteExprWithConfig(e *planpb.Expr, optimizeEnabled bool) *planpb.Expr {
 	if e == nil {
 		return nil
 	}
+	e = normalizeTermExprs(e)
 	e = normalizeEmptyArrayComparisons(e)
-	e = normalizeJSONTermExprs(e)
 	v := &visitor{optimizeEnabled: optimizeEnabled}
 	res := v.visitExpr(e)
 	if out, ok := res.(*planpb.Expr); ok && out != nil {

--- a/internal/parser/planparserv2/rewriter/json_term.go
+++ b/internal/parser/planparserv2/rewriter/json_term.go
@@ -7,53 +7,70 @@ import (
 
 var jsonTermKindOrder = []string{"bool", "int64", "float", "string", "array"}
 
-// normalizeJSONTermExprs enforces the execution invariant that every JSON
-// TermExpr contains one concrete GenericValue kind.  This is correctness
-// normalization, not an optional optimization: segcore selects the executor
-// type from the first term value and therefore cannot safely consume a mixed
-// list.
-func normalizeJSONTermExprs(expr *planpb.Expr) *planpb.Expr {
+// normalizeTermExprs enforces the execution invariant that every TermExpr can
+// be dispatched to one scalar executor. JSON terms are partitioned by concrete
+// value kind, while whole-ARRAY membership is lowered to array equality
+// branches because segcore has no array-valued TermExpr executor. This is
+// correctness normalization, not an optional optimization.
+func normalizeTermExprs(expr *planpb.Expr) *planpb.Expr {
 	if expr == nil {
 		return nil
 	}
 
 	switch real := expr.GetExpr().(type) {
 	case *planpb.Expr_BinaryExpr:
-		real.BinaryExpr.Left = normalizeJSONTermExprs(real.BinaryExpr.GetLeft())
-		real.BinaryExpr.Right = normalizeJSONTermExprs(real.BinaryExpr.GetRight())
+		real.BinaryExpr.Left = normalizeTermExprs(real.BinaryExpr.GetLeft())
+		real.BinaryExpr.Right = normalizeTermExprs(real.BinaryExpr.GetRight())
 		return expr
 	case *planpb.Expr_UnaryExpr:
-		real.UnaryExpr.Child = normalizeJSONTermExprs(real.UnaryExpr.GetChild())
+		real.UnaryExpr.Child = normalizeTermExprs(real.UnaryExpr.GetChild())
 		return expr
 	case *planpb.Expr_BinaryArithExpr:
-		real.BinaryArithExpr.Left = normalizeJSONTermExprs(real.BinaryArithExpr.GetLeft())
-		real.BinaryArithExpr.Right = normalizeJSONTermExprs(real.BinaryArithExpr.GetRight())
+		real.BinaryArithExpr.Left = normalizeTermExprs(real.BinaryArithExpr.GetLeft())
+		real.BinaryArithExpr.Right = normalizeTermExprs(real.BinaryArithExpr.GetRight())
 		return expr
 	case *planpb.Expr_CallExpr:
 		for i, parameter := range real.CallExpr.GetFunctionParameters() {
-			real.CallExpr.FunctionParameters[i] = normalizeJSONTermExprs(parameter)
+			real.CallExpr.FunctionParameters[i] = normalizeTermExprs(parameter)
 		}
 		return expr
 	case *planpb.Expr_RandomSampleExpr:
-		real.RandomSampleExpr.Predicate = normalizeJSONTermExprs(real.RandomSampleExpr.GetPredicate())
+		real.RandomSampleExpr.Predicate = normalizeTermExprs(real.RandomSampleExpr.GetPredicate())
 		return expr
 	case *planpb.Expr_ElementFilterExpr:
-		real.ElementFilterExpr.ElementExpr = normalizeJSONTermExprs(real.ElementFilterExpr.GetElementExpr())
-		real.ElementFilterExpr.Predicate = normalizeJSONTermExprs(real.ElementFilterExpr.GetPredicate())
+		real.ElementFilterExpr.ElementExpr = normalizeTermExprs(real.ElementFilterExpr.GetElementExpr())
+		real.ElementFilterExpr.Predicate = normalizeTermExprs(real.ElementFilterExpr.GetPredicate())
 		return expr
 	case *planpb.Expr_MatchExpr:
-		real.MatchExpr.Predicate = normalizeJSONTermExprs(real.MatchExpr.GetPredicate())
+		real.MatchExpr.Predicate = normalizeTermExprs(real.MatchExpr.GetPredicate())
 		return expr
 	case *planpb.Expr_TermExpr:
-		return normalizeJSONTermExpr(expr, real.TermExpr)
+		return normalizeTermExpr(expr, real.TermExpr)
 	default:
 		return expr
 	}
 }
 
-func normalizeJSONTermExpr(original *planpb.Expr, term *planpb.TermExpr) *planpb.Expr {
-	if term == nil || term.GetColumnInfo() == nil || term.GetIsInField() ||
-		term.GetColumnInfo().GetDataType() != schemapb.DataType_JSON || len(term.GetValues()) == 0 {
+func normalizeTermExpr(original *planpb.Expr, term *planpb.TermExpr) *planpb.Expr {
+	if term == nil || term.GetColumnInfo() == nil || term.GetIsInField() || len(term.GetValues()) == 0 {
+		return original
+	}
+
+	columnInfo := term.GetColumnInfo()
+	if columnInfo.GetDataType() == schemapb.DataType_Array &&
+		len(columnInfo.GetNestedPath()) == 0 && !columnInfo.GetIsElementLevel() {
+		parts := make([]*planpb.Expr, 0, len(term.GetValues()))
+		for _, value := range term.GetValues() {
+			if valueCaseWithNil(value) != "array" {
+				return original
+			}
+			parts = append(parts, newUnaryRangeExpr(
+				columnInfo, planpb.OpType_Equal, value))
+		}
+		return foldBinary(planpb.BinaryExpr_LogicalOr, parts)
+	}
+
+	if columnInfo.GetDataType() != schemapb.DataType_JSON {
 		return original
 	}
 

--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -69,6 +69,9 @@ func resolveJSONEffectiveType(v *planpb.GenericValue) (schemapb.DataType, bool) 
 	case *planpb.GenericValue_Int64Val:
 		return schemapb.DataType_Double, true
 	case *planpb.GenericValue_FloatVal:
+		if math.IsNaN(v.GetFloatVal()) {
+			return schemapb.DataType_None, false
+		}
 		return schemapb.DataType_Double, true
 	case *planpb.GenericValue_StringVal:
 		return schemapb.DataType_VarChar, true
@@ -94,7 +97,9 @@ func valueMatchesType(dt schemapb.DataType, v *planpb.GenericValue) bool {
 	case schemapb.DataType_Float, schemapb.DataType_Double:
 		// For float columns, accept both float and int literal values
 		switch v.GetVal().(type) {
-		case *planpb.GenericValue_FloatVal, *planpb.GenericValue_Int64Val:
+		case *planpb.GenericValue_FloatVal:
+			return !math.IsNaN(v.GetFloatVal())
+		case *planpb.GenericValue_Int64Val:
 			return true
 		default:
 			return false
@@ -109,6 +114,27 @@ func valueMatchesType(dt schemapb.DataType, v *planpb.GenericValue) bool {
 	default:
 		return false
 	}
+}
+
+func resolveBinaryRangeEffectiveType(col *planpb.ColumnInfo, lower, upper *planpb.GenericValue) (schemapb.DataType, bool) {
+	effDt, ok := resolveEffectiveType(col)
+	if !ok {
+		return schemapb.DataType_None, false
+	}
+
+	if effDt != schemapb.DataType_JSON {
+		if !valueMatchesType(effDt, lower) || !valueMatchesType(effDt, upper) {
+			return schemapb.DataType_None, false
+		}
+		return effDt, true
+	}
+
+	lowerType, lowerOK := resolveJSONEffectiveType(lower)
+	upperType, upperOK := resolveJSONEffectiveType(upper)
+	if !lowerOK || !upperOK || lowerType != upperType {
+		return schemapb.DataType_None, false
+	}
+	return lowerType, true
 }
 
 func (v *visitor) combineAndRangePredicates(parts []*planpb.Expr) []*planpb.Expr {
@@ -385,7 +411,8 @@ func newBinaryRangeExpr(col *planpb.ColumnInfo, lowerInclusive bool, upperInclus
 // int conversion. This mirrors segcore's JSON numeric comparison semantics.
 func compareInt64ToFloat64(lhs int64, rhs float64) int {
 	if math.IsNaN(rhs) {
-		// Preserve cmpGeneric's existing deterministic handling for NaN.
+		// Range optimizer entry points reject NaN before comparison. Keep this
+		// defensive return deterministic if a future caller misses that gate.
 		return 0
 	}
 	const (
@@ -508,19 +535,10 @@ func (v *visitor) combineAndBinaryRanges(parts []*planpb.Expr) []*planpb.Expr {
 				others = append(others, idx)
 				continue
 			}
-			effDt, ok := resolveEffectiveType(col)
+			effDt, ok := resolveBinaryRangeEffectiveType(col, bre.GetLowerValue(), bre.GetUpperValue())
 			if !ok {
 				others = append(others, idx)
 				continue
-			}
-			// For JSON, determine actual type from lower value
-			if effDt == schemapb.DataType_JSON {
-				var typeOk bool
-				effDt, typeOk = resolveJSONEffectiveType(bre.GetLowerValue())
-				if !typeOk {
-					others = append(others, idx)
-					continue
-				}
 			}
 			key := columnKey(col) + fmt.Sprintf("|%d", effDt)
 			g, exists := groups[key]
@@ -731,18 +749,10 @@ func (v *visitor) combineOrBinaryRanges(parts []*planpb.Expr) []*planpb.Expr {
 				others = append(others, idx)
 				continue
 			}
-			effDt, ok := resolveEffectiveType(col)
+			effDt, ok := resolveBinaryRangeEffectiveType(col, bre.GetLowerValue(), bre.GetUpperValue())
 			if !ok {
 				others = append(others, idx)
 				continue
-			}
-			if effDt == schemapb.DataType_JSON {
-				var typeOk bool
-				effDt, typeOk = resolveJSONEffectiveType(bre.GetLowerValue())
-				if !typeOk {
-					others = append(others, idx)
-					continue
-				}
 			}
 			key := columnKey(col) + fmt.Sprintf("|%d", effDt)
 			g, exists := groups[key]

--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -406,13 +406,10 @@ func newBinaryRangeExpr(col *planpb.ColumnInfo, lowerInclusive bool, upperInclus
 	}
 }
 
-// compareInt64ToFloat64 compares an int64 and float64 without converting the
-// integer to float64. The boundary checks also avoid an out-of-range float to
-// int conversion. This mirrors segcore's JSON numeric comparison semantics.
+// compareInt64ToFloat64 compares an int64 and float64 without lossy integer
+// promotion. Callers must reject NaN before relying on the result.
 func compareInt64ToFloat64(lhs int64, rhs float64) int {
 	if math.IsNaN(rhs) {
-		// Range optimizer entry points reject NaN before comparison. Keep this
-		// defensive return deterministic if a future caller misses that gate.
 		return 0
 	}
 	const (
@@ -442,6 +439,16 @@ func compareInt64ToFloat64(lhs int64, rhs float64) int {
 		return 1
 	}
 	return 0
+}
+
+// CompareRangeValues compares two supported range literals exactly.
+func CompareRangeValues(a, b *planpb.GenericValue) (int, bool) {
+	aType, aOK := resolveJSONEffectiveType(a)
+	bType, bOK := resolveJSONEffectiveType(b)
+	if !aOK || !bOK || aType != bType {
+		return 0, false
+	}
+	return cmpGeneric(aType, a, b), true
 }
 
 // -1 means a < b, 0 means a == b, 1 means a > b

--- a/internal/parser/planparserv2/rewriter/range_edge_test.go
+++ b/internal/parser/planparserv2/rewriter/range_edge_test.go
@@ -1,0 +1,309 @@
+package rewriter_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+)
+
+func edgeTestRangeColumn(dataType schemapb.DataType) *planpb.ColumnInfo {
+	column := &planpb.ColumnInfo{
+		FieldId:  101,
+		DataType: dataType,
+	}
+	if dataType == schemapb.DataType_JSON {
+		column.NestedPath = []string{"value"}
+	}
+	return column
+}
+
+func edgeTestIntValue(value int64) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_Int64Val{Int64Val: value}}
+}
+
+func edgeTestFloatValue(value float64) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_FloatVal{FloatVal: value}}
+}
+
+func edgeTestStringValue(value string) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_StringVal{StringVal: value}}
+}
+
+func edgeTestBoolValue(value bool) *planpb.GenericValue {
+	return &planpb.GenericValue{Val: &planpb.GenericValue_BoolVal{BoolVal: value}}
+}
+
+func edgeTestUnaryRange(column *planpb.ColumnInfo, op planpb.OpType, value *planpb.GenericValue) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_UnaryRangeExpr{
+			UnaryRangeExpr: &planpb.UnaryRangeExpr{
+				ColumnInfo: column,
+				Op:         op,
+				Value:      value,
+			},
+		},
+	}
+}
+
+func edgeTestBinaryRange(column *planpb.ColumnInfo, lower, upper *planpb.GenericValue) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_BinaryRangeExpr{
+			BinaryRangeExpr: &planpb.BinaryRangeExpr{
+				ColumnInfo:     column,
+				LowerInclusive: true,
+				UpperInclusive: true,
+				LowerValue:     lower,
+				UpperValue:     upper,
+			},
+		},
+	}
+}
+
+func edgeTestTerm(column *planpb.ColumnInfo, values ...*planpb.GenericValue) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_TermExpr{
+			TermExpr: &planpb.TermExpr{
+				ColumnInfo: column,
+				Values:     values,
+			},
+		},
+	}
+}
+
+func edgeTestLogical(op planpb.BinaryExpr_BinaryOp, left, right *planpb.Expr) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_BinaryExpr{
+			BinaryExpr: &planpb.BinaryExpr{
+				Op:    op,
+				Left:  left,
+				Right: right,
+			},
+		},
+	}
+}
+
+func edgeTestCountBinaryRanges(expr *planpb.Expr) int {
+	if expr == nil {
+		return 0
+	}
+	if expr.GetBinaryRangeExpr() != nil {
+		return 1
+	}
+	if binary := expr.GetBinaryExpr(); binary != nil {
+		return edgeTestCountBinaryRanges(binary.GetLeft()) + edgeTestCountBinaryRanges(binary.GetRight())
+	}
+	return 0
+}
+
+func edgeTestCountUnaryRanges(expr *planpb.Expr) int {
+	if expr == nil {
+		return 0
+	}
+	if expr.GetUnaryRangeExpr() != nil {
+		return 1
+	}
+	if binary := expr.GetBinaryExpr(); binary != nil {
+		return edgeTestCountUnaryRanges(binary.GetLeft()) + edgeTestCountUnaryRanges(binary.GetRight())
+	}
+	return 0
+}
+
+func TestRewrite_JSONBinaryRangeMixedBoundTypesSkipMerge(t *testing.T) {
+	logicalOps := []struct {
+		name string
+		op   planpb.BinaryExpr_BinaryOp
+	}{
+		{name: "and", op: planpb.BinaryExpr_LogicalAnd},
+		{name: "or", op: planpb.BinaryExpr_LogicalOr},
+	}
+	unsupportedUpperBounds := []struct {
+		name  string
+		value *planpb.GenericValue
+	}{
+		{name: "string", value: edgeTestStringValue("z")},
+		{name: "bool", value: edgeTestBoolValue(true)},
+	}
+
+	for _, logicalOp := range logicalOps {
+		for _, unsupportedUpper := range unsupportedUpperBounds {
+			for _, mixedFirst := range []bool{true, false} {
+				order := "numeric_first"
+				if mixedFirst {
+					order = "mixed_first"
+				}
+				t.Run(logicalOp.name+"_"+unsupportedUpper.name+"_"+order, func(t *testing.T) {
+					column := edgeTestRangeColumn(schemapb.DataType_JSON)
+					mixed := edgeTestBinaryRange(column, edgeTestIntValue(1), unsupportedUpper.value)
+					numeric := edgeTestBinaryRange(column, edgeTestIntValue(2), edgeTestIntValue(4))
+					left, right := numeric, mixed
+					if mixedFirst {
+						left, right = mixed, numeric
+					}
+
+					result := rewriter.RewriteExprWithConfig(edgeTestLogical(logicalOp.op, left, right), true)
+
+					binary := result.GetBinaryExpr()
+					require.NotNil(t, binary)
+					require.Equal(t, logicalOp.op, binary.GetOp())
+					require.Equal(t, 2, edgeTestCountBinaryRanges(result))
+				})
+			}
+		}
+	}
+}
+
+func TestRewrite_JSONBinaryRangeMixedNumericBoundsMerge(t *testing.T) {
+	t.Run("and", func(t *testing.T) {
+		column := edgeTestRangeColumn(schemapb.DataType_JSON)
+		left := edgeTestBinaryRange(column, edgeTestIntValue(1), edgeTestFloatValue(5.5))
+		right := edgeTestBinaryRange(column, edgeTestFloatValue(2.5), edgeTestIntValue(4))
+
+		result := rewriter.RewriteExprWithConfig(edgeTestLogical(planpb.BinaryExpr_LogicalAnd, left, right), true)
+
+		binaryRange := result.GetBinaryRangeExpr()
+		require.NotNil(t, binaryRange)
+		require.InDelta(t, 2.5, binaryRange.GetLowerValue().GetFloatVal(), 1e-9)
+		require.Equal(t, int64(4), binaryRange.GetUpperValue().GetInt64Val())
+	})
+
+	t.Run("or", func(t *testing.T) {
+		column := edgeTestRangeColumn(schemapb.DataType_JSON)
+		left := edgeTestBinaryRange(column, edgeTestIntValue(1), edgeTestFloatValue(3.5))
+		right := edgeTestBinaryRange(column, edgeTestFloatValue(2.5), edgeTestIntValue(5))
+
+		result := rewriter.RewriteExprWithConfig(edgeTestLogical(planpb.BinaryExpr_LogicalOr, left, right), true)
+
+		binaryRange := result.GetBinaryRangeExpr()
+		require.NotNil(t, binaryRange)
+		require.Equal(t, int64(1), binaryRange.GetLowerValue().GetInt64Val())
+		require.Equal(t, int64(5), binaryRange.GetUpperValue().GetInt64Val())
+	})
+}
+
+func TestRewrite_NaNUnaryRangeSkipsMerge(t *testing.T) {
+	columnTypes := []struct {
+		name     string
+		dataType schemapb.DataType
+	}{
+		{name: "json", dataType: schemapb.DataType_JSON},
+		{name: "double", dataType: schemapb.DataType_Double},
+	}
+	logicalOps := []struct {
+		name string
+		op   planpb.BinaryExpr_BinaryOp
+	}{
+		{name: "and", op: planpb.BinaryExpr_LogicalAnd},
+		{name: "or", op: planpb.BinaryExpr_LogicalOr},
+	}
+
+	for _, columnType := range columnTypes {
+		for _, logicalOp := range logicalOps {
+			for _, nanFirst := range []bool{true, false} {
+				order := "finite_first"
+				if nanFirst {
+					order = "nan_first"
+				}
+				t.Run(columnType.name+"_"+logicalOp.name+"_"+order, func(t *testing.T) {
+					column := edgeTestRangeColumn(columnType.dataType)
+					nanRange := edgeTestUnaryRange(column, planpb.OpType_GreaterEqual, edgeTestFloatValue(math.NaN()))
+					finiteRange := edgeTestUnaryRange(column, planpb.OpType_GreaterEqual, edgeTestFloatValue(1))
+					left, right := finiteRange, nanRange
+					if nanFirst {
+						left, right = nanRange, finiteRange
+					}
+
+					result := rewriter.RewriteExprWithConfig(edgeTestLogical(logicalOp.op, left, right), true)
+
+					binary := result.GetBinaryExpr()
+					require.NotNil(t, binary)
+					require.Equal(t, logicalOp.op, binary.GetOp())
+					require.Equal(t, 2, edgeTestCountUnaryRanges(result))
+				})
+			}
+		}
+	}
+}
+
+func TestRewrite_NaNBinaryRangeSkipsMerge(t *testing.T) {
+	columnTypes := []struct {
+		name     string
+		dataType schemapb.DataType
+	}{
+		{name: "json", dataType: schemapb.DataType_JSON},
+		{name: "double", dataType: schemapb.DataType_Double},
+	}
+	logicalOps := []struct {
+		name string
+		op   planpb.BinaryExpr_BinaryOp
+	}{
+		{name: "and", op: planpb.BinaryExpr_LogicalAnd},
+		{name: "or", op: planpb.BinaryExpr_LogicalOr},
+	}
+
+	for _, columnType := range columnTypes {
+		for _, logicalOp := range logicalOps {
+			for _, nanFirst := range []bool{true, false} {
+				order := "finite_first"
+				if nanFirst {
+					order = "nan_first"
+				}
+				t.Run(columnType.name+"_"+logicalOp.name+"_"+order, func(t *testing.T) {
+					column := edgeTestRangeColumn(columnType.dataType)
+					nanRange := edgeTestBinaryRange(column, edgeTestFloatValue(1), edgeTestFloatValue(math.NaN()))
+					finiteRange := edgeTestBinaryRange(column, edgeTestFloatValue(2), edgeTestFloatValue(4))
+					left, right := finiteRange, nanRange
+					if nanFirst {
+						left, right = nanRange, finiteRange
+					}
+
+					result := rewriter.RewriteExprWithConfig(edgeTestLogical(logicalOp.op, left, right), true)
+
+					binary := result.GetBinaryExpr()
+					require.NotNil(t, binary)
+					require.Equal(t, logicalOp.op, binary.GetOp())
+					require.Equal(t, 2, edgeTestCountBinaryRanges(result))
+				})
+			}
+		}
+	}
+}
+
+func TestRewrite_NaNInWithRangeSkipsOptimization(t *testing.T) {
+	testcases := []struct {
+		name      string
+		dataType  schemapb.DataType
+		nanInTerm bool
+	}{
+		{name: "json_range", dataType: schemapb.DataType_JSON},
+		{name: "json_term", dataType: schemapb.DataType_JSON, nanInTerm: true},
+		{name: "double_range", dataType: schemapb.DataType_Double},
+		{name: "double_term", dataType: schemapb.DataType_Double, nanInTerm: true},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			column := edgeTestRangeColumn(testcase.dataType)
+			termValues := []*planpb.GenericValue{edgeTestFloatValue(1), edgeTestFloatValue(2)}
+			rangeValue := edgeTestFloatValue(math.NaN())
+			if testcase.nanInTerm {
+				termValues[0] = edgeTestFloatValue(math.NaN())
+				rangeValue = edgeTestFloatValue(1)
+			}
+			term := edgeTestTerm(column, termValues...)
+			rangeExpr := edgeTestUnaryRange(column, planpb.OpType_GreaterEqual, rangeValue)
+
+			result := rewriter.RewriteExprWithConfig(edgeTestLogical(planpb.BinaryExpr_LogicalAnd, term, rangeExpr), true)
+
+			binary := result.GetBinaryExpr()
+			require.NotNil(t, binary)
+			require.Equal(t, planpb.BinaryExpr_LogicalAnd, binary.GetOp())
+			require.NotNil(t, findTermExpr(result))
+			require.NotNil(t, findUnaryRangeExpr(result, planpb.OpType_GreaterEqual))
+		})
+	}
+}

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -1,6 +1,8 @@
 package rewriter
 
 import (
+	"math"
+
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 )
@@ -337,6 +339,9 @@ func resolveInRangeComparisonType(col *planpb.ColumnInfo, value *planpb.GenericV
 	case "int64":
 		return schemapb.DataType_Int64, true
 	case "float":
+		if math.IsNaN(value.GetFloatVal()) {
+			return schemapb.DataType_None, false
+		}
 		return schemapb.DataType_Double, true
 	case "string":
 		return schemapb.DataType_VarChar, true

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -2,6 +2,7 @@ package planparserv2
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -771,6 +772,112 @@ func castRangeValue(dataType schemapb.DataType, value *planpb.GenericValue) (*pl
 		}
 	}
 	return value, nil
+}
+
+// compareInt64ToFloat64 compares an int64 and a float64 without converting the
+// integer to float64. It returns whether the values are comparable separately
+// so NaN can be left to execution-time predicate semantics.
+func compareInt64ToFloat64(lhs int64, rhs float64) (int, bool) {
+	if math.IsNaN(rhs) {
+		return 0, false
+	}
+
+	const (
+		int64Lower = -0x1p63
+		int64Upper = 0x1p63
+	)
+	if rhs < int64Lower {
+		return 1, true
+	}
+	if rhs >= int64Upper {
+		return -1, true
+	}
+
+	rhsInteger := int64(rhs)
+	if lhs < rhsInteger {
+		return -1, true
+	}
+	if lhs > rhsInteger {
+		return 1, true
+	}
+
+	rhsIntegerAsFloat := float64(rhsInteger)
+	if rhs > rhsIntegerAsFloat {
+		return -1, true
+	}
+	if rhs < rhsIntegerAsFloat {
+		return 1, true
+	}
+	return 0, true
+}
+
+// compareBinaryRangeBounds returns the exact ordering of supported range
+// bounds. Different JSON dynamic types and unsupported literal kinds are not
+// ordered here; segcore applies their runtime type/missing/null semantics.
+func compareBinaryRangeBounds(lower, upper *planpb.GenericValue) (int, bool) {
+	if lower == nil || upper == nil {
+		return 0, false
+	}
+
+	switch lower.GetVal().(type) {
+	case *planpb.GenericValue_Int64Val:
+		switch upper.GetVal().(type) {
+		case *planpb.GenericValue_Int64Val:
+			if lower.GetInt64Val() < upper.GetInt64Val() {
+				return -1, true
+			}
+			if lower.GetInt64Val() > upper.GetInt64Val() {
+				return 1, true
+			}
+			return 0, true
+		case *planpb.GenericValue_FloatVal:
+			return compareInt64ToFloat64(lower.GetInt64Val(), upper.GetFloatVal())
+		}
+	case *planpb.GenericValue_FloatVal:
+		if math.IsNaN(lower.GetFloatVal()) {
+			return 0, false
+		}
+		switch upper.GetVal().(type) {
+		case *planpb.GenericValue_Int64Val:
+			cmp, comparable := compareInt64ToFloat64(upper.GetInt64Val(), lower.GetFloatVal())
+			return -cmp, comparable
+		case *planpb.GenericValue_FloatVal:
+			if math.IsNaN(upper.GetFloatVal()) {
+				return 0, false
+			}
+			if lower.GetFloatVal() < upper.GetFloatVal() {
+				return -1, true
+			}
+			if lower.GetFloatVal() > upper.GetFloatVal() {
+				return 1, true
+			}
+			return 0, true
+		}
+	case *planpb.GenericValue_StringVal:
+		if !IsString(upper) {
+			return 0, false
+		}
+		if lower.GetStringVal() < upper.GetStringVal() {
+			return -1, true
+		}
+		if lower.GetStringVal() > upper.GetStringVal() {
+			return 1, true
+		}
+		return 0, true
+	}
+
+	return 0, false
+}
+
+func validateBinaryRangeBounds(lower, upper *planpb.GenericValue, lowerInclusive, upperInclusive bool) error {
+	cmp, comparable := compareBinaryRangeBounds(lower, upper)
+	if !comparable {
+		return nil
+	}
+	if cmp > 0 || (cmp == 0 && (!lowerInclusive || !upperInclusive)) {
+		return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")
+	}
+	return nil
 }
 
 func checkContainsElement(columnExpr *ExprWithType, op planpb.JSONContainsExpr_JSONOp, elementValue *planpb.GenericValue) error {

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -2,7 +2,6 @@ package planparserv2
 
 import (
 	"fmt"
-	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -774,105 +774,10 @@ func castRangeValue(dataType schemapb.DataType, value *planpb.GenericValue) (*pl
 	return value, nil
 }
 
-// compareInt64ToFloat64 compares an int64 and a float64 without converting the
-// integer to float64. It returns whether the values are comparable separately
-// so NaN can be left to execution-time predicate semantics.
-func compareInt64ToFloat64(lhs int64, rhs float64) (int, bool) {
-	if math.IsNaN(rhs) {
-		return 0, false
-	}
-
-	const (
-		int64Lower = -0x1p63
-		int64Upper = 0x1p63
-	)
-	if rhs < int64Lower {
-		return 1, true
-	}
-	if rhs >= int64Upper {
-		return -1, true
-	}
-
-	rhsInteger := int64(rhs)
-	if lhs < rhsInteger {
-		return -1, true
-	}
-	if lhs > rhsInteger {
-		return 1, true
-	}
-
-	rhsIntegerAsFloat := float64(rhsInteger)
-	if rhs > rhsIntegerAsFloat {
-		return -1, true
-	}
-	if rhs < rhsIntegerAsFloat {
-		return 1, true
-	}
-	return 0, true
-}
-
-// compareBinaryRangeBounds returns the exact ordering of supported range
-// bounds. Different JSON dynamic types and unsupported literal kinds are not
-// ordered here; segcore applies their runtime type/missing/null semantics.
-func compareBinaryRangeBounds(lower, upper *planpb.GenericValue) (int, bool) {
-	if lower == nil || upper == nil {
-		return 0, false
-	}
-
-	switch lower.GetVal().(type) {
-	case *planpb.GenericValue_Int64Val:
-		switch upper.GetVal().(type) {
-		case *planpb.GenericValue_Int64Val:
-			if lower.GetInt64Val() < upper.GetInt64Val() {
-				return -1, true
-			}
-			if lower.GetInt64Val() > upper.GetInt64Val() {
-				return 1, true
-			}
-			return 0, true
-		case *planpb.GenericValue_FloatVal:
-			return compareInt64ToFloat64(lower.GetInt64Val(), upper.GetFloatVal())
-		}
-	case *planpb.GenericValue_FloatVal:
-		if math.IsNaN(lower.GetFloatVal()) {
-			return 0, false
-		}
-		switch upper.GetVal().(type) {
-		case *planpb.GenericValue_Int64Val:
-			cmp, comparable := compareInt64ToFloat64(upper.GetInt64Val(), lower.GetFloatVal())
-			return -cmp, comparable
-		case *planpb.GenericValue_FloatVal:
-			if math.IsNaN(upper.GetFloatVal()) {
-				return 0, false
-			}
-			if lower.GetFloatVal() < upper.GetFloatVal() {
-				return -1, true
-			}
-			if lower.GetFloatVal() > upper.GetFloatVal() {
-				return 1, true
-			}
-			return 0, true
-		}
-	case *planpb.GenericValue_StringVal:
-		if !IsString(upper) {
-			return 0, false
-		}
-		if lower.GetStringVal() < upper.GetStringVal() {
-			return -1, true
-		}
-		if lower.GetStringVal() > upper.GetStringVal() {
-			return 1, true
-		}
-		return 0, true
-	}
-
-	return 0, false
-}
-
 func validateBinaryRangeBounds(lower, upper *planpb.GenericValue, lowerInclusive, upperInclusive bool) error {
-	cmp, comparable := compareBinaryRangeBounds(lower, upper)
-	if !comparable {
-		return nil
+	cmp, ok := rewriter.CompareRangeValues(lower, upper)
+	if !ok {
+		return merr.WrapErrQueryPlanMsg("invalid range: bounds are not comparable")
 	}
 	if cmp > 0 || (cmp == 0 && (!lowerInclusive || !upperInclusive)) {
 		return merr.WrapErrQueryPlanMsg("invalid range: lowerbound is greater than upperbound")

--- a/tests/go_client/common/utils.go
+++ b/tests/go_client/common/utils.go
@@ -132,7 +132,7 @@ var InvalidExpressions = []InvalidExprStruct{
 	{Expr: "id in [0]", ErrNil: true, ErrMsg: "fieldName(id) not found"},                                          // not exist field but no error, because enable dynamic
 	{Expr: "int64 in not [0]", ErrNil: false, ErrMsg: "cannot parse expression"},                                  // wrong term expr keyword
 	{Expr: "int64 < floatVec", ErrNil: false, ErrMsg: "not supported"},                                            // unsupported compare field
-	{Expr: "floatVec in [0]", ErrNil: false, ErrMsg: "cannot be casted to FloatVector"},                           // value and field type mismatch
+	{Expr: "floatVec in [0]", ErrNil: false, ErrMsg: "term expression is not supported"},                          // unsupported term target type
 	{Expr: fmt.Sprintf("%s == 1", DefaultJSONFieldName), ErrNil: true, ErrMsg: ""},                                // hist empty
 	{Expr: fmt.Sprintf("%s like 'a%%' ", DefaultJSONFieldName), ErrNil: true, ErrMsg: ""},                         // hist empty
 	{Expr: fmt.Sprintf("%s like `a%%` ", DefaultJSONFieldName), ErrNil: false, ErrMsg: "cannot parse expression"}, // ``

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -1284,7 +1284,6 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
                 f"array_contains_all({STRUCT_TAG_FIELD}, [])",
                 False,
                 False,
-                marks=pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/51416", strict=True),
                 id="contains_all_empty_list",
             ),
         ],


### PR DESCRIPTION
issue: #51489
issue: #51567
issue: #51568

This PR fixes the following issues:

- Corrects predicate rewriting for dynamically typed JSON values: `IN`/`NOT IN`, `== OR`, and `!= AND` are merged only within the same literal type.
- Prevents precision loss in JSON `int64`/floating-point comparisons near `2^53`, including range rewriting and template filling.
- Enables JSON BinaryRange predicates to use JSON path indexes and JSON shredding, with consistent semantics across raw-data, stats, and index paths.
- Rejects BinaryRange predicates with incomparable bounds, including incompatible types, NaN, null, boolean, and array values.
- Determines index-to-raw-data fallback before execution, preventing cursor/offset corruption across multiple batches.
- Fixes missing same-type metadata for templated `json_contains_any/all` expressions and prevents unsupported index execution.
- Improves ARRAY semantics, including empty-array comparisons, non-empty `==`/`!=`, NULL handling, nested offsets, whole-array `IN`/`NOT IN`, and element-type validation.
- Fixes TIMESTAMPTZ arithmetic comparisons when an index cannot provide raw-value lookup.
- Adds proper TermExpr target-type validation so unsupported fields such as vectors and geometry are rejected even with empty or templated RHS values.
- Updates the related Go SDK, E2E, and unit-test expectations.