### PR TITLE
fix: wait for segment release after lock timeout

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1118,7 +1118,7 @@ common:
     threshold:
       info: 500 # minimum milliseconds for printing durations in info level
       warn: 1000 # minimum milliseconds for printing durations in warn level
-    maxWLockConditionalWaitTime: 600 # maximum seconds for waiting wlock conditional
+    maxWLockConditionalWaitTime: 600 # seconds before logging a wlock conditional wait that is taking long; the wait itself is not bounded by this value
   traceLogMode: 0 # trace request info
   visibilityFilterEnabled: true # whether to apply row visibility filtering (timestamp, delete, and TTL) on querynode. When disabled, all rows are returned regardless of insert/delete timestamps.
   bloomFilterEnabled: true # whether to load and apply bloom filter/pk stats on querynode

--- a/internal/querynodev2/segments/state/load_state_lock.go
+++ b/internal/querynodev2/segments/state/load_state_lock.go
@@ -189,23 +189,18 @@ func (ls *LoadStateLock) canReleaseAll(state loadStateEnum) bool {
 }
 
 func (ls *LoadStateLock) waitOrPanic(ready func(state loadStateEnum) bool, then func()) {
-	ch := make(chan struct{})
 	maxWaitTime := paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.GetAsDuration(time.Second)
-	go func() {
-		ls.cv.L.Lock()
-		defer ls.cv.L.Unlock()
-		defer close(ch)
-		for !ready(ls.state) {
-			ls.cv.Wait()
-		}
-		then()
-	}()
-
-	select {
-	case <-time.After(maxWaitTime):
+	timer := time.AfterFunc(maxWaitTime, func() {
 		mlog.Error(context.TODO(), "load state lock wait timeout", mlog.Duration("maxWaitTime", maxWaitTime))
-	case <-ch:
+	})
+	defer timer.Stop()
+
+	ls.cv.L.Lock()
+	defer ls.cv.L.Unlock()
+	for !ready(ls.state) {
+		ls.cv.Wait()
 	}
+	then()
 }
 
 type StatePredicate func(state loadStateEnum) bool

--- a/internal/querynodev2/segments/state/load_state_lock.go
+++ b/internal/querynodev2/segments/state/load_state_lock.go
@@ -169,13 +169,13 @@ func (ls *LoadStateLock) StartReleaseAll() (g LoadStateLockGuard) {
 	return g
 }
 
-// blockUntilDataLoadedOrReleased blocks until the segment is loaded or released.
-func (ls *LoadStateLock) BlockUntilDataLoadedOrReleased() bool {
-	var ok bool
+// BlockUntilDataLoadedOrReleased blocks until the segment is loaded or released.
+// It has no return value on purpose: waitOrPanic no longer gives up, so any
+// status it could report would be a constant.
+func (ls *LoadStateLock) BlockUntilDataLoadedOrReleased() {
 	ls.waitOrPanic(func(state loadStateEnum) bool {
 		return state == LoadStateDataLoaded || state == LoadStateReleased
-	}, func() { ok = true })
-	return ok
+	}, func() {})
 }
 
 // waitUntilCanReleaseData waits until segment is release data able.
@@ -190,8 +190,12 @@ func (ls *LoadStateLock) canReleaseAll(state loadStateEnum) bool {
 
 func (ls *LoadStateLock) waitOrPanic(ready func(state loadStateEnum) bool, then func()) {
 	maxWaitTime := paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.GetAsDuration(time.Second)
+	// Watchdog only: the wait below is deliberately unbounded so that then() always
+	// runs and native cleanup is never skipped. This fires once, purely to surface
+	// a release that is taking longer than expected.
 	timer := time.AfterFunc(maxWaitTime, func() {
-		mlog.Error(context.TODO(), "load state lock wait timeout", mlog.Duration("maxWaitTime", maxWaitTime))
+		mlog.Warn(context.TODO(), "load state lock still waiting, the wait is not bounded and continues until the state is ready",
+			mlog.Duration("maxWaitTime", maxWaitTime))
 	})
 	defer timer.Stop()
 

--- a/internal/querynodev2/segments/state/load_state_lock_test.go
+++ b/internal/querynodev2/segments/state/load_state_lock_test.go
@@ -189,6 +189,42 @@ func TestStartReleaseAll(t *testing.T) {
 	assert.Equal(t, LoadStateReleased, l.state)
 }
 
+func TestStartReleaseAllWaitsAfterTimeoutUntilRefCntZero(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "0.05")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
+
+	l := NewLoadStateLock(LoadStateDataLoaded)
+	assert.True(t, l.PinIfNotReleased())
+
+	ch := make(chan LoadStateLockGuard, 1)
+	go func() {
+		ch <- l.StartReleaseAll()
+	}()
+
+	select {
+	case g := <-ch:
+		if g != nil {
+			g.Done(nil)
+		}
+		l.Unpin()
+		t.Fatal("StartReleaseAll returned before refcnt dropped to zero")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	l.Unpin()
+
+	select {
+	case g := <-ch:
+		assert.NotNil(t, g)
+		g.Done(nil)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("StartReleaseAll did not return after refcnt dropped to zero")
+	}
+
+	assert.False(t, l.PinIfNotReleased())
+}
+
 func TestWaitOrPanic(t *testing.T) {
 	paramtable.Init()
 
@@ -208,19 +244,39 @@ func TestWaitOrPanic(t *testing.T) {
 		assert.True(t, executed)
 	})
 
-	t.Run("timeout_panic", func(t *testing.T) {
-		paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "1")
+	t.Run("timeout_keeps_waiting", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key, "0.05")
 		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.MaxWLockConditionalWaitTime.Key)
 
 		l := NewLoadStateLock(LoadStateOnlyMeta)
 		executed := false
+		ch := make(chan struct{})
 
-		assert.NotPanics(t, func() {
+		go func() {
 			l.waitOrPanic(func(state loadStateEnum) bool {
 				return state == LoadStateDataLoaded
-			}, noop)
-		})
+			}, func() { executed = true })
+			close(ch)
+		}()
+
+		select {
+		case <-ch:
+			t.Fatal("waitOrPanic returned before the predicate became ready")
+		case <-time.After(200 * time.Millisecond):
+		}
 		assert.False(t, executed)
+
+		g, err := l.StartLoadData()
+		assert.NoError(t, err)
+		assert.NotNil(t, g)
+		g.Done(nil)
+
+		select {
+		case <-ch:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("waitOrPanic did not return after the predicate became ready")
+		}
+		assert.True(t, executed)
 	})
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1083,7 +1083,7 @@ Large numeric passwords require double quotes to avoid yaml parsing precision is
 		Key:          "common.locks.maxWLockConditionalWaitTime",
 		Version:      "2.5.4",
 		DefaultValue: "600",
-		Doc:          "maximum seconds for waiting wlock conditional",
+		Doc:          "seconds before logging a wlock conditional wait that is taking long; the wait itself is not bounded by this value",
 		Export:       true,
 	}
 	p.MaxWLockConditionalWaitTime.Init(base.mgr)


### PR DESCRIPTION
issue: #51776

## What this PR changes

`LoadStateLock.waitOrPanic` no longer returns when `common.locks.maxWLockConditionalWaitTime` elapses while the predicate is still false. It now keeps the existing timeout log as a watchdog, but continues waiting until the guarded state transition can run.

This prevents `LocalSegment.Release` from receiving a nil guard after a timeout and treating a still-pinned segment as already released, which skipped native segment deletion and resource cleanup while manager bookkeeping continued.

## Tests

- Repro before fix:
  - `GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/segments/state -run TestStartReleaseAllWaitsAfterTimeoutUntilRefCntZero`
  - failed with `StartReleaseAll returned before refcnt dropped to zero`
- After fix:
  - `GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/segments/state`
  - passed
- Static check:
  - `GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage make static-check`
  - passed with `0 issues`

## Notes

The broader `./internal/querynodev2/segments` package test is still blocked in this local worktree by C++ link dependencies (`libgrpc++.so.1.67` / related grpc symbols from `libmilvus-common.so`), even when pkg-config is pointed at the main checkout artifacts.
