### PR TITLE
fix: key proxy shard leader cache by collection id to close alias repoint race

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -139,17 +139,15 @@ func (node *Proxy) InvalidateCollectionMetaCache(ctx context.Context, request *p
 	collectionID := request.CollectionID
 	msgType := request.GetBase().GetMsgType()
 	var aliasName []string
+	// The shard leader cache is keyed by the cluster-unique collection id (issue #51533), so an
+	// alias/collection name is no longer a cache key. Evicting the affected collection id covers
+	// every name/alias that resolves to it; alias repoints and renames don't move a collection's
+	// shard leaders, so for those this is a harmless best-effort refresh. The names argument is
+	// kept only so the call sites (which still pass alias names for the meta-cache path) are
+	// untouched.
 	deprecateShardCaches := func(names ...string) {
-		seen := make(map[string]struct{}, len(names))
-		for _, name := range names {
-			if name == "" {
-				continue
-			}
-			if _, ok := seen[name]; ok {
-				continue
-			}
-			seen[name] = struct{}{}
-			node.shardMgr.DeprecateShardCache(request.GetDbName(), name)
+		if collectionID != UniqueID(0) {
+			node.shardMgr.InvalidateShardLeaderCache([]int64{collectionID})
 		}
 	}
 

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -105,7 +105,7 @@ func TestProxy_InvalidateCollectionMetaCache_AliasScanGating(t *testing.T) {
 		cache := NewMockCache(t)
 		globalMetaCache = cache
 		shard := shardclient.NewMockShardClientManager(t)
-		shard.EXPECT().DeprecateShardCache(mock.Anything, mock.Anything).Return().Maybe()
+		shard.EXPECT().InvalidateShardLeaderCache(mock.Anything).Return().Maybe()
 		node := &Proxy{shardMgr: shard}
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
 		return node, cache

--- a/internal/proxy/shardclient/README.md
+++ b/internal/proxy/shardclient/README.md
@@ -19,7 +19,7 @@ In Milvus, collections are divided into shards (channels), and each shard has mu
 │                                                                │
 │  ┌─────────────────────────────────────────────────────┐    │
 │  │              ShardClientMgr                          │    │
-│  │  • Shard leader cache (database → collection → shards) │
+│  │  • Shard leader cache (collectionID → shards)         │
 │  │  • QueryNode client pool management                   │
 │  │  • Client lifecycle (init, purge, close)             │
 │  └───────────────────────┬──────────────────────────────┘    │
@@ -64,7 +64,7 @@ The central manager for QueryNode client connections and shard leader informatio
 **File**: `manager.go`
 
 **Key Responsibilities**:
-- Cache shard leader mappings from QueryCoord (`database → collectionName → channel → []nodeInfo`)
+- Cache shard leader mappings from QueryCoord, keyed by the cluster-unique collection id (`collectionID → channel → []nodeInfo`); name/alias/database are resolved upstream against the meta cache and are never part of the key
 - Manage `shardClient` instances for each QueryNode
 - Automatically purge expired clients (default: 60 minutes of inactivity)
 - Invalidate cache when shard leaders change
@@ -76,7 +76,6 @@ type ShardClientMgr interface {
              collectionID int64, channel string) ([]nodeInfo, error)
     GetShardLeaderList(ctx context.Context, database, collectionName string,
                        collectionID int64, withCache bool) ([]string, error)
-    DeprecateShardCache(database, collectionName string)
     InvalidateShardLeaderCache(collections []int64)
     GetClient(ctx context.Context, nodeInfo nodeInfo) (types.QueryNodeClient, error)
     Start()
@@ -251,7 +250,7 @@ err := policy.ExecuteOneChannel(ctx, workload)
 The shard leader cache stores the mapping of shards to their leader QueryNodes:
 
 ```
-database → collectionName → shardLeaders {
+collectionID → shardLeaders {
     collectionID: int64
     shardLeaders: map[channel][]nodeInfo
 }
@@ -260,10 +259,9 @@ database → collectionName → shardLeaders {
 **Cache Operations**:
 - **Hit**: When cached shard leaders are used (tracked via `ProxyCacheStatsCounter`)
 - **Miss**: When cache lookup fails, triggers RPC to QueryCoord via `GetShardLeaders`
-- **Invalidation**:
-  - `DeprecateShardCache(db, collection)`: Remove specific collection
-  - `InvalidateShardLeaderCache(collectionIDs)`: Remove collections by ID (called on shard leader changes)
-  - `RemoveDatabase(db)`: Remove entire database
+- **Invalidation** (the cache is keyed by the cluster-unique collection id):
+  - `InvalidateShardLeaderCache(collectionIDs)`: Remove collections by id (called on shard-leader changes, collection drop, and search/query retry). O(len(collectionIDs)) direct deletes.
+  - `RemoveDatabase(db)`: No-op. DropDatabase requires an empty database, so its collections were already dropped and evicted by id; the id-keyed cache does not track database membership.
 
 ### Client Purging
 

--- a/internal/proxy/shardclient/manager.go
+++ b/internal/proxy/shardclient/manager.go
@@ -41,7 +41,6 @@ import (
 type ShardClientMgr interface {
 	GetShard(ctx context.Context, withCache bool, database, collectionName string, collectionID int64, channel string) ([]NodeInfo, error)
 	GetShardLeaderList(ctx context.Context, database, collectionName string, collectionID int64, withCache bool) ([]string, error)
-	DeprecateShardCache(database, collectionName string)
 	InvalidateShardLeaderCache(collections []int64)
 	ListShardLocation() map[int64]NodeInfo
 	RemoveDatabase(database string)
@@ -63,8 +62,13 @@ type shardClientMgrImpl struct {
 
 	mixCoord types.MixCoordClient
 
-	leaderMut  sync.RWMutex
-	collLeader map[string]map[string]*shardLeaders // database -> collectionName -> collection_leaders
+	leaderMut sync.RWMutex
+	// collLeader keys shard leaders by the cluster-unique collection id, so name/alias/database
+	// resolution (done upstream against the meta cache) can never serve one collection's shard
+	// leaders under another's name after an alias repoint or a cross-db rename. Eviction is by
+	// collection id only -- the cache deliberately does not depend on the mutable
+	// collection->database mapping. See issue #51533.
+	collLeader map[int64]*shardLeaders // collectionID -> collection_leaders
 }
 
 const (
@@ -92,7 +96,7 @@ func NewShardClientMgr(mixCoord types.MixCoordClient, options ...shardClientMgrO
 		purgeInterval:   defaultPurgeInterval,
 		expiredDuration: defaultExpiredDuration,
 
-		collLeader: make(map[string]map[string]*shardLeaders),
+		collLeader: make(map[int64]*shardLeaders),
 		mixCoord:   mixCoord,
 	}
 	for _, opt := range options {
@@ -109,7 +113,7 @@ func (c *shardClientMgrImpl) SetClientCreatorFunc(creator queryNodeCreatorFunc) 
 func (m *shardClientMgrImpl) GetShard(ctx context.Context, withCache bool, database, collectionName string, collectionID int64, channel string) ([]NodeInfo, error) {
 	method := "GetShard"
 	// check cache first
-	cacheShardLeaders := m.getCachedShardLeaders(database, collectionName, method)
+	cacheShardLeaders := m.getCachedShardLeaders(collectionID, method)
 	if cacheShardLeaders == nil || !withCache {
 		// refresh shard leader cache
 		newShardLeaders, err := m.updateShardLocationCache(ctx, database, collectionName, collectionID)
@@ -125,7 +129,7 @@ func (m *shardClientMgrImpl) GetShard(ctx context.Context, withCache bool, datab
 func (m *shardClientMgrImpl) GetShardLeaderList(ctx context.Context, database, collectionName string, collectionID int64, withCache bool) ([]string, error) {
 	method := "GetShardLeaderList"
 	// check cache first
-	cacheShardLeaders := m.getCachedShardLeaders(database, collectionName, method)
+	cacheShardLeaders := m.getCachedShardLeaders(collectionID, method)
 	if cacheShardLeaders == nil || !withCache {
 		// refresh shard leader cache
 		newShardLeaders, err := m.updateShardLocationCache(ctx, database, collectionName, collectionID)
@@ -138,15 +142,9 @@ func (m *shardClientMgrImpl) GetShardLeaderList(ctx context.Context, database, c
 	return cacheShardLeaders.GetShardLeaderList(), nil
 }
 
-func (m *shardClientMgrImpl) getCachedShardLeaders(database, collectionName, caller string) *shardLeaders {
+func (m *shardClientMgrImpl) getCachedShardLeaders(collectionID int64, caller string) *shardLeaders {
 	m.leaderMut.RLock()
-	var cacheShardLeaders *shardLeaders
-	db, ok := m.collLeader[database]
-	if !ok {
-		cacheShardLeaders = nil
-	} else {
-		cacheShardLeaders = db[collectionName]
-	}
+	cacheShardLeaders := m.collLeader[collectionID]
 	m.leaderMut.RUnlock()
 
 	if cacheShardLeaders != nil {
@@ -207,10 +205,7 @@ func (m *shardClientMgrImpl) updateShardLocationCache(ctx context.Context, datab
 	}
 
 	m.leaderMut.Lock()
-	if _, ok := m.collLeader[database]; !ok {
-		m.collLeader[database] = make(map[string]*shardLeaders)
-	}
-	m.collLeader[database][collectionName] = newShardLeaders
+	m.collLeader[collectionID] = newShardLeaders
 	m.leaderMut.Unlock()
 
 	return newShardLeaders, nil
@@ -238,53 +233,34 @@ func (m *shardClientMgrImpl) ListShardLocation() map[int64]NodeInfo {
 	defer m.leaderMut.RUnlock()
 	shardLeaderInfo := make(map[int64]NodeInfo)
 
-	for _, dbInfo := range m.collLeader {
-		for _, shardLeaders := range dbInfo {
-			for _, nodeInfos := range shardLeaders.shardLeaders {
-				for _, node := range nodeInfos {
-					shardLeaderInfo[node.NodeID] = node
-				}
+	for _, shardLeaders := range m.collLeader {
+		for _, nodeInfos := range shardLeaders.shardLeaders {
+			for _, node := range nodeInfos {
+				shardLeaderInfo[node.NodeID] = node
 			}
 		}
 	}
 	return shardLeaderInfo
 }
 
-func (m *shardClientMgrImpl) RemoveDatabase(database string) {
-	m.leaderMut.Lock()
-	defer m.leaderMut.Unlock()
-	delete(m.collLeader, database)
-}
+// RemoveDatabase is a no-op for the shard cache. DropDatabase requires the database to be empty
+// first (rootcoord rejects a non-empty drop), so every collection has already been dropped
+// individually and evicted by id via InvalidateShardLeaderCache before this is called. The cache
+// is keyed by the cluster-unique collection id and deliberately does not track database
+// membership -- that mapping is mutable (cross-db rename), so making eviction depend on it would
+// let a stale attribution drop a live collection or leak one that moved. Kept on the interface so
+// the DropDatabase meta-cache invalidation path has a symmetric hook.
+func (m *shardClientMgrImpl) RemoveDatabase(database string) {}
 
-// DeprecateShardCache clear the shard leader cache of a collection
-func (m *shardClientMgrImpl) DeprecateShardCache(database, collectionName string) {
-	mlog.Info(context.TODO(), "deprecate shard cache for collection", mlog.FieldCollectionName(collectionName))
-	m.leaderMut.Lock()
-	defer m.leaderMut.Unlock()
-	dbInfo, ok := m.collLeader[database]
-	if ok {
-		delete(dbInfo, collectionName)
-		if len(dbInfo) == 0 {
-			delete(m.collLeader, database)
-		}
-	}
-}
-
-// InvalidateShardLeaderCache called when Shard leader balance happened
+// InvalidateShardLeaderCache drops the cached shard leaders for the given collection ids.
+// Called on shard-leader balance (querycoord), collection drop, and search/query retry. Because
+// the cache is keyed by id, this is a direct O(len(collections)) delete instead of a full scan.
 func (m *shardClientMgrImpl) InvalidateShardLeaderCache(collections []int64) {
 	mlog.Info(context.TODO(), "Invalidate shard cache for collections", mlog.Int64s("collectionIDs", collections))
 	m.leaderMut.Lock()
 	defer m.leaderMut.Unlock()
-	collectionSet := typeutil.NewUniqueSet(collections...)
-	for dbName, dbInfo := range m.collLeader {
-		for collectionName, shardLeaders := range dbInfo {
-			if collectionSet.Contain(shardLeaders.collectionID) {
-				delete(dbInfo, collectionName)
-			}
-		}
-		if len(dbInfo) == 0 {
-			delete(m.collLeader, dbName)
-		}
+	for _, collectionID := range collections {
+		delete(m.collLeader, collectionID)
 	}
 }
 

--- a/internal/proxy/shardclient/manager_test.go
+++ b/internal/proxy/shardclient/manager_test.go
@@ -1,0 +1,97 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shardclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// singleShardResp builds a GetShardLeadersResponse for one channel served by one node.
+func singleShardResp(channel string, nodeID int64, addr string) *querypb.GetShardLeadersResponse {
+	return &querypb.GetShardLeadersResponse{
+		Status: merr.Success(),
+		Shards: []*querypb.ShardLeadersList{
+			{
+				ChannelName: channel,
+				NodeIds:     []int64{nodeID},
+				NodeAddrs:   []string{addr},
+				Serviceable: []bool{true},
+			},
+		},
+	}
+}
+
+func expectShardLeaders(mixCoord *mocks.MockMixCoordClient, collectionID int64, resp *querypb.GetShardLeadersResponse) {
+	mixCoord.EXPECT().GetShardLeaders(mock.Anything,
+		mock.MatchedBy(func(req *querypb.GetShardLeadersRequest) bool {
+			return req.GetCollectionID() == collectionID
+		}),
+	).Return(resp, nil).Maybe()
+}
+
+// TestShardCacheAliasRepointResolvesByCollectionID reproduces the concurrent-AlterAlias
+// stale-alias race (issue #51533). The shard leader cache must key its entries by the
+// cluster-unique collection id, not by the mutable collection/alias name. Once an alias is
+// repointed from an old collection id to a new one, a request that resolves the alias to the
+// NEW id must never be served the OLD collection's shard leaders.
+func TestShardCacheAliasRepointResolvesByCollectionID(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+
+	const (
+		db          = "default"
+		alias       = "orders"
+		oldID int64 = 100
+		newID int64 = 200
+		oldCh       = "old_ch_100v0"
+		newCh       = "new_ch_200v0"
+	)
+
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	expectShardLeaders(mixCoord, oldID, singleShardResp(oldCh, 7, "10.0.0.7:21123"))
+	expectShardLeaders(mixCoord, newID, singleShardResp(newCh, 12, "10.0.0.12:21123"))
+
+	mgr := NewShardClientMgr(mixCoord)
+
+	// 1. alias -> old collection (100). A request fills the cache for id 100.
+	leaders, err := mgr.GetShardLeaderList(ctx, db, alias, oldID, true)
+	require.NoError(t, err)
+	require.Equal(t, []string{oldCh}, leaders)
+
+	// 2. AlterAlias repoints "orders" -> new collection (200): Layer 1 (meta cache) now resolves
+	//    the alias to id 200 while the shard cache still holds id 100's entry. The request for the
+	//    alias, resolved to the NEW id, must be served the NEW collection's channels — not id 100's.
+	leaders, err = mgr.GetShardLeaderList(ctx, db, alias, newID, true)
+	require.NoError(t, err)
+	require.Equal(t, []string{newCh}, leaders,
+		"alias resolved to new collection id %d must not be served old collection %d's channels", newID, oldID)
+
+	// 3. GetShard for the new id must return the new collection's leader (node 12), not node 7.
+	nodes, err := mgr.GetShard(ctx, true, db, alias, newID, newCh)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	require.Equal(t, int64(12), nodes[0].NodeID)
+}

--- a/internal/proxy/shardclient/mock_shardclient_manager.go
+++ b/internal/proxy/shardclient/mock_shardclient_manager.go
@@ -54,40 +54,6 @@ func (_c *MockShardClientManager_Close_Call) RunAndReturn(run func()) *MockShard
 	return _c
 }
 
-// DeprecateShardCache provides a mock function with given fields: database, collectionName
-func (_m *MockShardClientManager) DeprecateShardCache(database string, collectionName string) {
-	_m.Called(database, collectionName)
-}
-
-// MockShardClientManager_DeprecateShardCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeprecateShardCache'
-type MockShardClientManager_DeprecateShardCache_Call struct {
-	*mock.Call
-}
-
-// DeprecateShardCache is a helper method to define mock.On call
-//   - database string
-//   - collectionName string
-func (_e *MockShardClientManager_Expecter) DeprecateShardCache(database interface{}, collectionName interface{}) *MockShardClientManager_DeprecateShardCache_Call {
-	return &MockShardClientManager_DeprecateShardCache_Call{Call: _e.mock.On("DeprecateShardCache", database, collectionName)}
-}
-
-func (_c *MockShardClientManager_DeprecateShardCache_Call) Run(run func(database string, collectionName string)) *MockShardClientManager_DeprecateShardCache_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *MockShardClientManager_DeprecateShardCache_Call) Return() *MockShardClientManager_DeprecateShardCache_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockShardClientManager_DeprecateShardCache_Call) RunAndReturn(run func(string, string)) *MockShardClientManager_DeprecateShardCache_Call {
-	_c.Run(run)
-	return _c
-}
-
 // GetClient provides a mock function with given fields: ctx, nodeInfo
 func (_m *MockShardClientManager) GetClient(ctx context.Context, nodeInfo NodeInfo) (types.QueryNodeClient, error) {
 	ret := _m.Called(ctx, nodeInfo)

--- a/internal/proxy/shardclient/shard_client_test.go
+++ b/internal/proxy/shardclient/shard_client_test.go
@@ -100,14 +100,12 @@ func TestPurgeClient(t *testing.T) {
 		purgeInterval:   1 * time.Second,
 		expiredDuration: 3 * time.Second,
 
-		collLeader: map[string]map[string]*shardLeaders{
-			"default": {
-				"test": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 1,
-					shardLeaders: map[string][]NodeInfo{
-						"0": {node},
-					},
+		collLeader: map[int64]*shardLeaders{
+			1: {
+				idx:          atomic.NewInt64(0),
+				collectionID: 1,
+				shardLeaders: map[string][]NodeInfo{
+					"0": {node},
 				},
 			},
 		},
@@ -138,7 +136,7 @@ func TestPurgeClient(t *testing.T) {
 	assert.Equal(t, s.clients.Len(), 1)
 	assert.True(t, time.Now().UnixNano()-qnClient.lastActiveTs.Load() > 3*time.Second.Nanoseconds())
 
-	s.DeprecateShardCache("default", "test")
+	s.InvalidateShardLeaderCache([]int64{1})
 	returnEmptyResult.Store(true)
 	time.Sleep(2 * time.Second)
 	// remove client from shard location, expected client should be purged
@@ -147,109 +145,46 @@ func TestPurgeClient(t *testing.T) {
 	}, 10*time.Second, 1*time.Second)
 }
 
-func TestDeprecateShardCache(t *testing.T) {
-	node := NodeInfo{
-		NodeID: 1,
+// seedShardLeaders inserts a single-channel shard leaders entry into the id-keyed cache,
+// mirroring what updateShardLocationCache writes. The database argument only documents which
+// database the collection was filled under; the cache does not key on it.
+func seedShardLeaders(mgr *shardClientMgrImpl, database string, collectionID int64, channel string, node NodeInfo) {
+	mgr.leaderMut.Lock()
+	defer mgr.leaderMut.Unlock()
+	mgr.collLeader[collectionID] = &shardLeaders{
+		idx:          atomic.NewInt64(0),
+		collectionID: collectionID,
+		shardLeaders: map[string][]NodeInfo{channel: {node}},
 	}
+}
 
-	qn := mocks.NewMockQueryNodeClient(t)
-	qn.EXPECT().Close().Return(nil).Maybe()
-	creator := func(ctx context.Context, addr string, nodeID int64) (types.QueryNodeClient, error) {
-		return qn, nil
-	}
+func TestRemoveDatabase(t *testing.T) {
+	node := NodeInfo{NodeID: 1}
 
 	mixcoord := mocks.NewMockMixCoordClient(t)
 	mgr := NewShardClientMgr(mixcoord)
-	mgr.SetClientCreatorFunc(creator)
+	defer mgr.Close()
 
-	t.Run("Clear with no collection info", func(t *testing.T) {
-		mgr.DeprecateShardCache("default", "collection_not_exist")
-		// Should not panic or error
+	// RemoveDatabase must not be the authority that evicts cache entries. A collection can move
+	// databases via cross-db RenameCollection while keeping its id, and DropDatabase requires an
+	// empty database (its collections are already evicted by id). The shard cache is keyed by the
+	// cluster-unique collection id, so eviction is by id only -- never by the mutable database
+	// attribution, which could drop a collection that has moved to (or is live under) another db.
+	t.Run("does not evict live entries; eviction is by id", func(t *testing.T) {
+		seedShardLeaders(mgr, "db1", 100, "channel-1", node)
+
+		mgr.RemoveDatabase("db1")
+		assert.NotNil(t, mgr.getCachedShardLeaders(100, "test"),
+			"RemoveDatabase must not evict a collection by its (mutable) database attribution")
+
+		mgr.InvalidateShardLeaderCache([]int64{100})
+		assert.Nil(t, mgr.getCachedShardLeaders(100, "test"))
 	})
 
-	t.Run("Clear valid collection empty cache", func(t *testing.T) {
-		// Add a collection to cache first
-		mgr.leaderMut.Lock()
-		mgr.collLeader = map[string]map[string]*shardLeaders{
-			"default": {
-				"test_collection": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 100,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-1": {node},
-					},
-				},
-			},
-		}
-		mgr.leaderMut.Unlock()
-
-		mgr.DeprecateShardCache("default", "test_collection")
-
-		// Verify cache is cleared
-		mgr.leaderMut.RLock()
-		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader["default"]["test_collection"]
-		assert.False(t, exists)
+	t.Run("non-existent database is a safe no-op", func(t *testing.T) {
+		mgr.RemoveDatabase("no_such_db")
+		// Should not panic
 	})
-
-	t.Run("Clear one collection, keep others", func(t *testing.T) {
-		mgr.leaderMut.Lock()
-		mgr.collLeader = map[string]map[string]*shardLeaders{
-			"default": {
-				"collection1": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 100,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-1": {node},
-					},
-				},
-				"collection2": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 101,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-2": {node},
-					},
-				},
-			},
-		}
-		mgr.leaderMut.Unlock()
-
-		mgr.DeprecateShardCache("default", "collection1")
-
-		// Verify collection1 is cleared but collection2 remains
-		mgr.leaderMut.RLock()
-		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader["default"]["collection1"]
-		assert.False(t, exists)
-		_, exists = mgr.collLeader["default"]["collection2"]
-		assert.True(t, exists)
-	})
-
-	t.Run("Clear last collection in database removes database", func(t *testing.T) {
-		mgr.leaderMut.Lock()
-		mgr.collLeader = map[string]map[string]*shardLeaders{
-			"test_db": {
-				"last_collection": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 200,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-1": {node},
-					},
-				},
-			},
-		}
-		mgr.leaderMut.Unlock()
-
-		mgr.DeprecateShardCache("test_db", "last_collection")
-
-		// Verify database is also removed
-		mgr.leaderMut.RLock()
-		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader["test_db"]
-		assert.False(t, exists)
-	})
-
-	mgr.Close()
 }
 
 func TestInvalidateShardLeaderCache(t *testing.T) {
@@ -268,168 +203,78 @@ func TestInvalidateShardLeaderCache(t *testing.T) {
 	mgr.SetClientCreatorFunc(creator)
 
 	t.Run("Invalidate single collection", func(t *testing.T) {
-		mgr.leaderMut.Lock()
-		mgr.collLeader = map[string]map[string]*shardLeaders{
-			"default": {
-				"collection1": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 100,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-1": {node},
-					},
-				},
-				"collection2": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 101,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-2": {node},
-					},
-				},
-			},
-		}
-		mgr.leaderMut.Unlock()
+		seedShardLeaders(mgr, "default", 100, "channel-1", node)
+		seedShardLeaders(mgr, "default", 101, "channel-2", node)
 
 		mgr.InvalidateShardLeaderCache([]int64{100})
 
 		// Verify collection with ID 100 is removed, but 101 remains
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader["default"]["collection1"]
+		_, exists := mgr.collLeader[100]
 		assert.False(t, exists)
-		_, exists = mgr.collLeader["default"]["collection2"]
+		_, exists = mgr.collLeader[101]
 		assert.True(t, exists)
 	})
 
 	t.Run("Invalidate multiple collections", func(t *testing.T) {
-		mgr.leaderMut.Lock()
-		mgr.collLeader = map[string]map[string]*shardLeaders{
-			"default": {
-				"collection1": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 100,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-1": {node},
-					},
-				},
-				"collection2": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 101,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-2": {node},
-					},
-				},
-				"collection3": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 102,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-3": {node},
-					},
-				},
-			},
-		}
-		mgr.leaderMut.Unlock()
+		seedShardLeaders(mgr, "default", 100, "channel-1", node)
+		seedShardLeaders(mgr, "default", 101, "channel-2", node)
+		seedShardLeaders(mgr, "default", 102, "channel-3", node)
 
 		mgr.InvalidateShardLeaderCache([]int64{100, 102})
 
 		// Verify collections 100 and 102 are removed, but 101 remains
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader["default"]["collection1"]
+		_, exists := mgr.collLeader[100]
 		assert.False(t, exists)
-		_, exists = mgr.collLeader["default"]["collection2"]
+		_, exists = mgr.collLeader[101]
 		assert.True(t, exists)
-		_, exists = mgr.collLeader["default"]["collection3"]
+		_, exists = mgr.collLeader[102]
 		assert.False(t, exists)
 	})
 
 	t.Run("Invalidate non-existent collection", func(t *testing.T) {
-		mgr.leaderMut.Lock()
-		mgr.collLeader = map[string]map[string]*shardLeaders{
-			"default": {
-				"collection1": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 100,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-1": {node},
-					},
-				},
-			},
-		}
-		mgr.leaderMut.Unlock()
+		seedShardLeaders(mgr, "default", 100, "channel-1", node)
 
 		mgr.InvalidateShardLeaderCache([]int64{999})
 
-		// Verify collection1 still exists
+		// Verify collection 100 still exists
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader["default"]["collection1"]
+		_, exists := mgr.collLeader[100]
 		assert.True(t, exists)
 	})
 
-	t.Run("Invalidate all collections in database removes database", func(t *testing.T) {
-		mgr.leaderMut.Lock()
-		mgr.collLeader = map[string]map[string]*shardLeaders{
-			"test_db": {
-				"collection1": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 200,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-1": {node},
-					},
-				},
-				"collection2": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 201,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-2": {node},
-					},
-				},
-			},
-		}
-		mgr.leaderMut.Unlock()
+	t.Run("Invalidate all collections in a database", func(t *testing.T) {
+		seedShardLeaders(mgr, "test_db", 200, "channel-1", node)
+		seedShardLeaders(mgr, "test_db", 201, "channel-2", node)
 
 		mgr.InvalidateShardLeaderCache([]int64{200, 201})
 
-		// Verify database is removed
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader["test_db"]
+		_, exists := mgr.collLeader[200]
+		assert.False(t, exists)
+		_, exists = mgr.collLeader[201]
 		assert.False(t, exists)
 	})
 
 	t.Run("Invalidate across multiple databases", func(t *testing.T) {
-		mgr.leaderMut.Lock()
-		mgr.collLeader = map[string]map[string]*shardLeaders{
-			"db1": {
-				"collection1": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 100,
-					shardLeaders: map[string][]NodeInfo{
-						"channel-1": {node},
-					},
-				},
-			},
-			"db2": {
-				"collection2": {
-					idx:          atomic.NewInt64(0),
-					collectionID: 100, // Same collection ID in different database
-					shardLeaders: map[string][]NodeInfo{
-						"channel-2": {node},
-					},
-				},
-			},
-		}
-		mgr.leaderMut.Unlock()
+		// collection ids are cluster-unique, so distinct collections carry distinct ids
+		// even across databases.
+		seedShardLeaders(mgr, "db1", 300, "channel-1", node)
+		seedShardLeaders(mgr, "db2", 400, "channel-2", node)
 
-		mgr.InvalidateShardLeaderCache([]int64{100})
+		mgr.InvalidateShardLeaderCache([]int64{300, 400})
 
-		// Verify collection is removed from both databases
 		mgr.leaderMut.RLock()
 		defer mgr.leaderMut.RUnlock()
-		_, exists := mgr.collLeader["db1"]
-		assert.False(t, exists) // db1 should be removed
-		_, exists = mgr.collLeader["db2"]
-		assert.False(t, exists) // db2 should be removed
+		_, exists := mgr.collLeader[300]
+		assert.False(t, exists)
+		_, exists = mgr.collLeader[400]
+		assert.False(t, exists)
 	})
 
 	mgr.Close()

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -1126,12 +1126,12 @@ func (t *queryTask) queryShard(ctx context.Context, nodeID int64, qn types.Query
 	result, err := qn.Query(ctx, req)
 	if err != nil {
 		log.Warn(ctx, "QueryNode query return error", mlog.Err(err))
-		t.shardclientMgr.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
+		t.shardclientMgr.InvalidateShardLeaderCache([]int64{t.GetCollectionID()})
 		return err
 	}
 	if result.GetStatus().GetErrorCode() == commonpb.ErrorCode_NotShardLeader {
 		log.Warn(ctx, "QueryNode is not shardLeader")
-		t.shardclientMgr.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
+		t.shardclientMgr.InvalidateShardLeaderCache([]int64{t.GetCollectionID()})
 		return merr.Error(result.GetStatus())
 	}
 	if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {

--- a/internal/proxy/task_query_test.go
+++ b/internal/proxy/task_query_test.go
@@ -67,7 +67,7 @@ func TestQueryTask_all(t *testing.T) {
 	mgr.EXPECT().GetShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]shardclient.NodeInfo{
 		{NodeID: 1, Address: "mock_qn", Serviceable: true},
 	}, nil).Maybe()
-	mgr.EXPECT().DeprecateShardCache(mock.Anything, mock.Anything).Return().Maybe()
+	mgr.EXPECT().InvalidateShardLeaderCache(mock.Anything).Return().Maybe()
 	lb := shardclient.NewLBPolicyImpl(mgr)
 
 	err = InitMetaCache(ctx, qc)

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -1525,12 +1525,12 @@ func (t *searchTask) searchShard(ctx context.Context, nodeID int64, qn types.Que
 	if err != nil {
 		log.Warn(ctx, "QueryNode search return error", mlog.Err(err))
 		// globalMetaCache.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
-		t.shardClientMgr.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
+		t.shardClientMgr.InvalidateShardLeaderCache([]int64{t.GetCollectionID()})
 		return err
 	}
 	if result.GetStatus().GetErrorCode() == commonpb.ErrorCode_NotShardLeader {
 		log.Warn(ctx, "QueryNode is not shardLeader")
-		t.shardClientMgr.DeprecateShardCache(t.request.GetDbName(), t.collectionName)
+		t.shardClientMgr.InvalidateShardLeaderCache([]int64{t.GetCollectionID()})
 		return merr.Error(result.GetStatus())
 	}
 	if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -3315,7 +3315,7 @@ func TestSearchTask_ErrExecute(t *testing.T) {
 	mgr.EXPECT().GetShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]shardclient.NodeInfo{
 		{NodeID: 1, Address: "mock_qn", Serviceable: true},
 	}, nil).Maybe()
-	mgr.EXPECT().DeprecateShardCache(mock.Anything, mock.Anything).Return().Maybe()
+	mgr.EXPECT().InvalidateShardLeaderCache(mock.Anything).Return().Maybe()
 	lb := shardclient.NewLBPolicyImpl(mgr)
 
 	defer rc.Close()
@@ -4536,7 +4536,7 @@ func TestSearchTask_Requery(t *testing.T) {
 	mgr.EXPECT().GetShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]shardclient.NodeInfo{
 		{NodeID: 1, Address: "mock_qn", Serviceable: true},
 	}, nil).Maybe()
-	mgr.EXPECT().DeprecateShardCache(mock.Anything, mock.Anything).Return().Maybe()
+	mgr.EXPECT().InvalidateShardLeaderCache(mock.Anything).Return().Maybe()
 	node.shardMgr = mgr
 
 	t.Run("Test normal", func(t *testing.T) {

--- a/internal/proxy/task_statistic.go
+++ b/internal/proxy/task_statistic.go
@@ -287,14 +287,14 @@ func (g *getStatisticsTask) getStatisticsShard(ctx context.Context, nodeID int64
 			mlog.Int64("nodeID", nodeID),
 			mlog.String("channel", channel),
 			mlog.Err(err))
-		g.shardclientMgr.DeprecateShardCache(g.request.GetDbName(), g.collectionName)
+		g.shardclientMgr.InvalidateShardLeaderCache([]int64{g.CollectionID})
 		return err
 	}
 	if result.GetStatus().GetErrorCode() == commonpb.ErrorCode_NotShardLeader {
 		mlog.Warn(ctx, "QueryNode is not shardLeader",
 			mlog.Int64("nodeID", nodeID),
 			mlog.String("channel", channel))
-		g.shardclientMgr.DeprecateShardCache(g.request.GetDbName(), g.collectionName)
+		g.shardclientMgr.InvalidateShardLeaderCache([]int64{g.CollectionID})
 		return merr.Error(result.GetStatus())
 	}
 	if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {

--- a/internal/proxy/task_statistic_test.go
+++ b/internal/proxy/task_statistic_test.go
@@ -90,7 +90,7 @@ func (s *StatisticTaskSuite) SetupTest() {
 	mgr.EXPECT().GetShard(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]shardclient.NodeInfo{
 		{NodeID: 1, Address: "mock_qn", Serviceable: true},
 	}, nil).Maybe()
-	mgr.EXPECT().DeprecateShardCache(mock.Anything, mock.Anything).Return().Maybe()
+	mgr.EXPECT().InvalidateShardLeaderCache(mock.Anything).Return().Maybe()
 	s.mgr = mgr
 	s.lb = shardclient.NewLBPolicyImpl(mgr)
 


### PR DESCRIPTION
## Summary

Re-key the proxy shard leader cache by the cluster-unique collection id instead of by `(database, collection name)`, closing the concurrent-`AlterAlias` stale-alias routing race and making shard-cache invalidation O(1).

## Root cause

`shardClientMgrImpl.collLeader` was keyed `map[database]map[collectionName]*shardLeaders`, and `GetShard` / `GetShardLeaderList` never checked the cached entry's `collectionID` against the id resolved for the current request. After `AlterAlias` repoints an alias to a new collection:

1. an in-flight fill for the old target re-inserts the old collection's shard leaders under the alias name (after the invalidation that raced it), and
2. a later request that resolves the alias to the **new** id hits that stale entry and is served the **old** collection's channels and leaders (both come from the same alias-keyed entry).

The result is queries on the alias silently routed to the old collection until the entry ages out.

## Changes

- `collLeader` is now `map[int64]*shardLeaders` (collection id is cluster-unique, so database and name drop out of the key). Name/alias/database resolution stays upstream in the meta cache; the shard cache only ever sees a resolved id.
- `InvalidateShardLeaderCache([]int64)` becomes an O(len(ids)) direct delete instead of a full-cache scan under the write lock.
- The cache deliberately does **not** track database membership. `collection -> database` is mutable (cross-db `RenameCollection` keeps the id), so keying/indexing on it would let a stale attribution drop a live collection or leak one that moved. `RemoveDatabase` is a no-op: `DropDatabase` requires an empty database, so its collections were already dropped and evicted by id first.
- `DeprecateShardCache` is removed and folded into `InvalidateShardLeaderCache`; the search/query/statistic retry paths and the `InvalidateCollectionMetaCache` handler now evict by collection id.

## Test plan

- [x] `TestShardCacheAliasRepointResolvesByCollectionID` fails on the old name-keyed cache (served the old collection's channel) and passes after the re-key.
- [x] `TestRemoveDatabase` fails on a db-indexed version (evicts a live id by stale db attribution) and passes with the id-keyed no-op.
- [x] Migrated `TestInvalidateShardLeaderCache`; `internal/proxy/shardclient` full package suite green; `go build ./internal/proxy/...` clean.
- [ ] Full `internal/proxy` suite and static-check via CI.

## Follow-ups

- Same-id stale-fill after a shard-leader balance still self-heals via the not-shard-leader retry; a fill generation gate to drop late fills is a follow-up (also closes the rare dropped-collection late-fill straggler, memory-only).

issue: #51533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QZmbdsWhTJLB4Nn5yAxdG
