### PR TITLE
test: [3.0] skip JSON-path STL_SORT/BITMAP index cases that require engine v4

### DIFF
--- a/tests/python_client/milvus_client/expressions/test_milvus_client_json_filtering.py
+++ b/tests/python_client/milvus_client/expressions/test_milvus_client_json_filtering.py
@@ -496,23 +496,7 @@ class TestJsonFilteringIndexedUnknownSemantics(JsonFilteringUnknownMixin, TestMi
                     (f'not ({json_field}["a"] > 2)', [4]),
                 ],
             ),
-            (
-                "stl_sort_double",
-                [
-                    {
-                        "index_name": "idx_json_a_stl_sort_double",
-                        "index_type": "STL_SORT",
-                        "params": {"json_cast_type": "DOUBLE", "json_path": f"{json_field}['a']"},
-                    }
-                ],
-                [
-                    (f'{json_field}["a"] == 2', [4]),
-                    (f'{json_field}["a"] > 2', [5]),
-                    (f'{json_field}["a"] != 2', [5]),
-                    (f'{json_field}["a"] not in [2]', [5]),
-                    (f'not ({json_field}["a"] > 2)', [4]),
-                ],
-            ),
+            # stl_sort_double removed: STL_SORT on a JSON path requires scalar index engine v4; 3.0 uses v3 (#51745)
             (
                 "inverted_varchar",
                 [

--- a/tests/python_client/milvus_client/test_milvus_client_compact.py
+++ b/tests/python_client/milvus_client/test_milvus_client_compact.py
@@ -116,15 +116,12 @@ class TestMilvusClientCompactInvalid(TestMilvusClientV2Base):
                     check_task=CheckTasks.err_res, check_items=error)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_delete.py
+++ b/tests/python_client/milvus_client/test_milvus_client_delete.py
@@ -113,15 +113,12 @@ class TestMilvusClientDeleteInvalid(TestMilvusClientV2Base):
                                  "err_msg": "The type of expr must be string ,but <class 'NoneType'> is given."})
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_hybrid_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_hybrid_search.py
@@ -269,15 +269,12 @@ class TestMilvusClientHybridSearchInvalid(TestMilvusClientV2Base):
                            check_task=CheckTasks.err_res, check_items=error)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_index.py
@@ -744,15 +744,12 @@ class TestMilvusClientIndexValid(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params_invalid = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 
@@ -787,7 +784,8 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
     def supported_json_cast_type(self, json_index_params):
         yield json_index_params[1]
 
-    @pytest.fixture(scope="function", params=["INVERTED", "STL_SORT"])
+    # STL_SORT on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
+    @pytest.fixture(scope="function", params=["INVERTED"])
     def supported_double_scalar_index(self, request):
         """Index types that support DOUBLE cast type. Use for tests that
         hardcode json_cast_type to 'double'."""
@@ -1167,15 +1165,12 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
                           check_task=CheckTasks.err_res, check_items=error)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params_valid = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_json_path_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_json_path_index.py
@@ -38,15 +38,12 @@ default_int32_field_name = ct.default_int32_field_name
 default_int32_value = ct.default_int32_value
 
 # Valid (index_type, json_cast_type) combinations for JSON path index
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -4745,10 +4745,10 @@ class TestMilvusClientGetValid(TestMilvusClientV2Base):
 
 # Valid (index_type, json_cast_type) combinations for JSON path index
 # @pytest.fixture(scope="function", params=["DOUBLE", "VARCHAR", "json"", "bool", "ARRAY_DOUBLE"])
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params_query = [
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "ARRAY_DOUBLE"),
-    ("STL_SORT", "DOUBLE"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -4078,15 +4078,12 @@ class TestMilvusClientSearchNullExpr(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
@@ -635,15 +635,12 @@ class TestMilvusClientSearchIteratorInValid(TestMilvusClientV2Base):
             it.next()
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 


### PR DESCRIPTION
## Summary

Unblocks `ci-v2/e2e-amd` on the 3.0 branch, which is currently red on **every** open 3.0 PR.

## Root cause

- #48953 ("support Sort/Bitmap/Hybrid index types for JSON Path Index") added JSON-path `STL_SORT`/`BITMAP` index support **plus e2e tests**, and bumped the scalar index engine to **v4**.
- #51745 ("fix: [3.0] use scalar index v3 by default") then rolled 3.0's scalar index engine back to **v3** — but did not gate #48953's tests.
- Result: on 3.0, every e2e test that creates a JSON-path index with `STL_SORT`/`BITMAP` fails deterministically with `code=1100 ... JSON path index with STL_SORT (or BITMAP) requires scalar index engine version >= 4, current resolved version: 3`. This is unrelated to the content of any individual PR — it reds e2e-amd branch-wide.

## Fix

Trim the `STL_SORT`/`BITMAP` `(index_type, json_cast_type)` combinations from the JSON-path index parametrizations, so the tests only exercise the v3-valid `INVERTED` json-path indexes. This completes #51745's rollback on the test side.

Preserved coverage:
- `INVERTED` json-path indexes (valid on v3) — kept in every list.
- `STL_SORT`/`BITMAP` on **regular** scalar/array fields (valid on v3) — deliberately left untouched (verified each such fixture indexes a non-JSON field).

## Verification

- After this change, no `add_index` call targeting a JSON path uses `STL_SORT`/`BITMAP` anywhere under `tests/python_client` (repo-wide grep).
- Edited files parse (`ast.parse`); every generated json-path parametrize id is now `INVERTED_*` only.
- Local run is collection-level only — the full distributed-pulsar e2e is validated by CI. The message-asserting negative test (`..._not_support_index_type`) is already `params=["TRIE"]` on 3.0, so no v3-vs-v4 error-message changes are involved.

cc @zhengbuqian (#51745) — this is the test-side completion of the v3 rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QZmbdsWhTJLB4Nn5yAxdG
