### PR TITLE
fix: keep delegator served schema stream-only on add_function_field reopen

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -608,7 +608,17 @@ func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *quer
 	}
 
 	meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), schema)
-	if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
+	// A reopen backfills pre-DDL segments and carries a possibly version-ahead
+	// schema. It must refresh index meta and reserve an APPLIED segcore version
+	// for the reopened segments, but must NOT advance the served collection schema
+	// (that would make the later stream UpdateSchema a no-op and skip the derived-
+	// state rebuild — the #50989/#51062 load-wins race). All other scopes advance
+	// served as before.
+	if req.GetLoadScope() == querypb.LoadScope_Reopen {
+		if err := sd.collectionManager.ReserveAppliedSchemaForReopen(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
+			return err
+		}
+	} else if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
 		return err
 	}
 	sd.collectionManager.Unref(req.GetCollectionID(), 1)

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -43,6 +43,12 @@ type CollectionManager interface {
 	ListWithName() map[int64]string
 	Get(collectionID int64) *Collection
 	PutOrRef(collectionID int64, schema *schemapb.CollectionSchema, meta *segcorepb.CollectionIndexMeta, loadMeta *querypb.LoadMetaInfo) error
+	// ReserveAppliedSchemaForReopen refreshes index meta and reserves an APPLIED
+	// (segment-facing) segcore version for reopened segments WITHOUT advancing the
+	// served schema. It mirrors PutOrRef's existing-collection lease/ref semantics
+	// (returns with a caller-visible Ref(1) held, like applyLoadUpdate). If the
+	// collection is not loaded yet it falls back to PutOrRef to bootstrap it.
+	ReserveAppliedSchemaForReopen(collectionID int64, schema *schemapb.CollectionSchema, meta *segcorepb.CollectionIndexMeta, loadMeta *querypb.LoadMetaInfo) error
 	Ref(collectionID int64, count uint32) bool
 	// unref the collection,
 	// returns true if the collection ref count goes 0, or the collection not exists,
@@ -166,6 +172,64 @@ func (m *collectionManager) putOrRefExisting(collectionID int64, collection *Col
 			mlog.Any("schema", schema),
 		)
 	}
+	return nil
+}
+
+// ReserveAppliedSchemaForReopen handles the LoadScope_Reopen path. Unlike
+// PutOrRef it does NOT advance the served collection schema: it refreshes index
+// meta (KEEP — the stream carries no index meta; dropping it reintroduces #51366)
+// and reserves an APPLIED segcore version for the reopened segments, whose per-
+// segment schema lives in segcore. The stream UpdateSchema remains the sole owner
+// of the served schema advance and its atomic derived-state rebuild.
+//
+// It mirrors PutOrRef's lease/lock/ref handling on the existing-collection path;
+// like applyLoadUpdate it returns holding a caller-visible Ref(1). If the
+// collection is not loaded yet (no lease), a reopen must bootstrap it normally, so
+// it falls back to PutOrRef.
+func (m *collectionManager) ReserveAppliedSchemaForReopen(collectionID int64, schema *schemapb.CollectionSchema, meta *segcorepb.CollectionIndexMeta, loadMeta *querypb.LoadMetaInfo) error {
+	logicalSchemaVersion := getLoadMetaSchemaVersion(schema, loadMeta)
+	schemaBarrierTs := loadMeta.GetSchemaBarrierTs()
+
+	if collection, ok := m.acquireCollectionLease(collectionID); ok {
+		defer m.Unref(collectionID, 1)
+		return m.reserveAppliedForReopenExisting(collection, schema, meta, logicalSchemaVersion, schemaBarrierTs)
+	}
+
+	m.mut.Lock()
+	if collection, ok := m.collections[collectionID]; ok {
+		collection.refCount.Inc()
+		m.mut.Unlock()
+		defer m.Unref(collectionID, 1)
+		return m.reserveAppliedForReopenExisting(collection, schema, meta, logicalSchemaVersion, schemaBarrierTs)
+	}
+	m.mut.Unlock()
+
+	// A reopen on a not-yet-loaded collection must bootstrap it normally.
+	return m.PutOrRef(collectionID, schema, meta, loadMeta)
+}
+
+// reserveAppliedForReopenExisting refreshes index meta, reserves the applied
+// segcore version, and publishes the caller-visible ref, mirroring the ref/lock
+// semantics of applyLoadUpdate (which the served load path uses).
+func (m *collectionManager) reserveAppliedForReopenExisting(collection *Collection, schema *schemapb.CollectionSchema, meta *segcorepb.CollectionIndexMeta, logicalSchemaVersion uint64, schemaBarrierTs uint64) error {
+	// Refresh index meta so newly indexed fields stay visible for search plan
+	// creation. The stream UpdateSchema carries no index meta, so dropping this
+	// reintroduces #51366.
+	if err := collection.updateIndexMeta(meta); err != nil {
+		return err
+	}
+	reserved := collection.reserveAppliedForReopen(schema, logicalSchemaVersion, schemaBarrierTs)
+	// The temporary manager lease keeps the collection alive while this update
+	// waits. Publish the caller-visible ref only after index meta and the applied
+	// reservation that determine the reopen's segcore version are in place,
+	// matching applyLoadUpdate.
+	collection.Ref(1)
+	mlog.Info(context.TODO(), "reserved applied schema for reopen",
+		mlog.Int64("collectionID", collection.ID()),
+		mlog.Uint64("schemaVersion", logicalSchemaVersion),
+		mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
+		mlog.Uint64("appliedSegcoreSchemaVersion", reserved),
+	)
 	return nil
 }
 
@@ -331,9 +395,18 @@ type Collection struct {
 	// so we don't need to update resource group in Collection.
 	// if resource group is not updated, the reference count of collection manager works failed.
 	metricType atomic.String // deprecated
-	schema     atomic.Pointer[collectionSchemaSnapshot]
-	isGpuIndex bool
-	loadFields typeutil.Set[int64]
+	// schema is the SERVED snapshot: the single ccollection schema used for
+	// search-plan creation and the delegator's derived state (idfOracle, function
+	// runner). It advances only via the stream UpdateSchema (or a full load).
+	schema atomic.Pointer[collectionSchemaSnapshot]
+	// appliedSchema is the APPLIED (segment-facing) snapshot: the schema+segcore
+	// version reserved for reopened segments that carry their own per-segment
+	// schema in segcore. It is nil until the first reopen reserves it, and lets a
+	// reopened segment adopt a version-ahead (V2, N+1) schema while the served
+	// schema stays V1.
+	appliedSchema atomic.Pointer[collectionSchemaSnapshot]
+	isGpuIndex    bool
+	loadFields    typeutil.Set[int64]
 
 	refCount *atomic.Uint32
 }
@@ -519,6 +592,66 @@ func (c *Collection) SchemaAndVersion() (*schemapb.CollectionSchema, uint64) {
 func (c *Collection) SchemaAndSegcoreVersion() (*schemapb.CollectionSchema, uint64) {
 	schema, _, _, segcoreSchemaVersion := c.schemaSnapshotWithSegcoreSchemaVersion()
 	return schema, segcoreSchemaVersion
+}
+
+// AppliedSchemaAndSegcoreVersion returns the schema+segcore version a reopened
+// segment must load at. It is the APPLIED (segment-facing) snapshot when it is set
+// AND strictly ahead of the served segcore version, otherwise it falls back to the
+// served SchemaAndSegcoreVersion. So segments always load at max(applied, served):
+// a reopen that reserved N+1 loads at N+1 while served stays at N, and once the
+// stream advances served to N+1 the applied snapshot is no longer strictly greater
+// and this falls back to served (they reconcile with no extra reopen).
+func (c *Collection) AppliedSchemaAndSegcoreVersion() (*schemapb.CollectionSchema, uint64) {
+	_, _, _, servedSegcoreVersion := c.schemaSnapshotWithSegcoreSchemaVersion()
+	applied := c.appliedSchema.Load()
+	if applied != nil && applied.segcoreSchemaVersion > servedSegcoreVersion {
+		return applied.schema, applied.segcoreSchemaVersion
+	}
+	return c.SchemaAndSegcoreVersion()
+}
+
+// reserveAppliedForReopen reserves an APPLIED segcore version for a reopen without
+// advancing the served schema. It runs under lockSchemaTransitionForUpdate so the
+// reservation is serialized against served schema transitions.
+//
+// The reserved version is deterministic: it is exactly the segcore version the
+// stream WILL assign when it advances served to this logical version. Served bumps
+// its segcore counter once per accepted schema update, so a delta d logical
+// versions ahead lands at servedSegcore+d. Deriving the reservation from the
+// logical distance (not from a per-call max()+1) makes it IDEMPOTENT per logical
+// version: the same additive delta reopened again — multiple pre-DDL segments,
+// retries, or the co-located worker+delegator legs of one load — reserves the SAME
+// value instead of drifting the applied counter ahead by the reopen count. A
+// per-reopen bump would push applied past what the stream assigns and, on a later
+// delta, collide with the served segcore version and defeat segcore's
+// ValidateSchemaCompatibility gate. This reservation never exceeds the stream's
+// assignment (barrier-only updates can add extra served bumps), so a reopened
+// segment is at worst behind and safely reopened, never wrongly ahead.
+func (c *Collection) reserveAppliedForReopen(schema *schemapb.CollectionSchema, logicalSchemaVersion, schemaBarrierTs uint64) uint64 {
+	c.lockSchemaTransitionForUpdate()
+	defer c.unlockSchemaTransitionForUpdate()
+
+	_, servedLogicalVersion, _, servedSegcoreVersion := c.schemaSnapshotWithSegcoreSchemaVersion()
+
+	// Served already covers this delta: the reopen loads at the served version
+	// (AppliedSchemaAndSegcoreVersion falls back to served). Reserving here would
+	// push applied past served again for no reason.
+	if logicalSchemaVersion <= servedLogicalVersion {
+		return servedSegcoreVersion
+	}
+
+	reserved := servedSegcoreVersion + (logicalSchemaVersion - servedLogicalVersion)
+	appliedBarrierTs := schemaBarrierTs
+	if applied := c.appliedSchema.Load(); applied != nil && applied.schemaBarrierTs > appliedBarrierTs {
+		appliedBarrierTs = applied.schemaBarrierTs
+	}
+	c.appliedSchema.Store(&collectionSchemaSnapshot{
+		schema:               schema,
+		logicalSchemaVersion: logicalSchemaVersion,
+		schemaBarrierTs:      appliedBarrierTs,
+		segcoreSchemaVersion: reserved,
+	})
+	return reserved
 }
 
 // Schema returns the schema of collection

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -974,6 +974,167 @@ func (s *CollectionManagerSuite) TestPutOrRef() {
 	})
 }
 
+// TestLoadWinsRaceDoesNotSuppressStreamSchemaUpdate reproduces the add_function_field
+// load-wins race (#50989 / #51062). The segment reopen path and the stream DDL path both
+// advance the delegator collection schema, but only the stream path rebuilds the delegator's
+// derived state (idfOracle / function runners). If a reopen advances the SERVED schema version
+// first, the stream's later UpdateSchema at the same version is judged a no-op and the derived-
+// state rebuild is skipped, leaving a newly added BM25/MinHash function field unsearchable.
+//
+// The applied-vs-served split makes the reopen path advance the per-segment applied schema +
+// index meta but NOT the collection SERVED schema version, so a same-version stream UpdateSchema
+// still applies and rebuilds derived state.
+func (s *CollectionManagerSuite) TestLoadWinsRaceDoesNotSuppressStreamSchemaUpdate() {
+	cm := NewCollectionManager()
+	const collID = 20
+
+	baseSchema := mock_segcore.GenTestCollectionSchema("load_wins_v1", schemapb.DataType_Int64, false)
+	baseSchema.Version = 1
+	s.Require().NoError(cm.PutOrRef(collID, baseSchema, mock_segcore.GenTestIndexMeta(collID, baseSchema), &querypb.LoadMetaInfo{
+		LoadType:        querypb.LoadType_LoadCollection,
+		SchemaBarrierTs: 100,
+	}))
+	defer cm.Unref(collID, 1)
+
+	// add_function_field bumps the collection to V2 (stands in for the new function output field).
+	v2Schema := mock_segcore.GenTestCollectionSchema("load_wins_v2", schemapb.DataType_Int64, false)
+	v2Schema.Version = 2
+	v2Schema.Fields = append(v2Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  common.StartOfUserFieldID + int64(len(v2Schema.Fields)),
+		Name:     "added_function_field",
+		DataType: schemapb.DataType_Bool,
+		Nullable: true,
+	})
+
+	// Capture the served segcore version before the reopen so we can assert the applied
+	// reservation lands at exactly served+1 for a single-version delta.
+	_, servedSegcoreBefore := cm.Get(collID).SchemaAndSegcoreVersion()
+
+	// The reopen reaches the delegator first. It reserves an APPLIED segcore version for the
+	// reopened segments + refreshes index meta, but MUST NOT advance the served schema.
+	s.Require().NoError(cm.ReserveAppliedSchemaForReopen(collID, v2Schema, mock_segcore.GenTestIndexMeta(collID, v2Schema), &querypb.LoadMetaInfo{
+		LoadType:        querypb.LoadType_LoadCollection,
+		SchemaBarrierTs: 100,
+	}))
+	// ReserveAppliedSchemaForReopen publishes a caller-visible Ref(1) like the load path; the
+	// delegator immediately Unrefs it in syncCollectionIndexMeta, so mirror that here.
+	cm.Unref(collID, 1)
+
+	// The reopen did NOT advance the served schema: it is still V1.
+	servedSchema, servedVersion := cm.Get(collID).SchemaAndVersion()
+	s.Equal(uint64(1), servedVersion, "reopen must not advance the served logical schema version")
+	s.Same(baseSchema, servedSchema, "reopen must not swap the served schema payload")
+	_, servedSegcoreAfter := cm.Get(collID).SchemaAndSegcoreVersion()
+	s.Equal(servedSegcoreBefore, servedSegcoreAfter, "reopen must not advance the served segcore version")
+
+	// The APPLIED (segment-facing) snapshot IS the V2 schema, reserved at served+1.
+	appliedSchema, appliedSegcore := cm.Get(collID).AppliedSchemaAndSegcoreVersion()
+	s.Same(v2Schema, appliedSchema, "applied (segment-facing) schema must be V2 after a reopen")
+	s.Equal(servedSegcoreBefore+1, appliedSegcore, "applied segcore version must be reserved at served+1")
+
+	// The stream DDL (which rebuilds idfOracle / function runners) arrives afterwards at the same
+	// V2 and MUST still be applied so the derived-state rebuild runs.
+	s.True(
+		ShouldUpdateCollectionSchema(cm.Get(collID), v2Schema, 100),
+		"stream UpdateSchema(V2) after a load-wins V2 must still apply so derived state is rebuilt; a no-op here is the #50989/#51062 race",
+	)
+
+	// After the stream advances served to V2, the applied snapshot is no longer strictly ahead,
+	// so AppliedSchemaAndSegcoreVersion falls back to served (reconcile with no extra reopen).
+	s.Require().NoError(cm.UpdateSchema(collID, v2Schema, 100))
+	servedSchema, servedVersion = cm.Get(collID).SchemaAndVersion()
+	s.Equal(uint64(2), servedVersion, "stream UpdateSchema(V2) must advance the served logical schema version")
+	s.Same(v2Schema, servedSchema)
+	_, servedSegcoreReconciled := cm.Get(collID).SchemaAndSegcoreVersion()
+	s.Equal(servedSegcoreBefore+1, servedSegcoreReconciled, "stream advance must reach the reserved applied segcore version")
+	_, reconciledSegcore := cm.Get(collID).AppliedSchemaAndSegcoreVersion()
+	s.Equal(servedSegcoreReconciled, reconciledSegcore, "applied must fall back to served once served catches up")
+}
+
+// TestReopenReservationIsIdempotentPerSchemaVersion is the Tier A drift/collision regression.
+// On a co-located node the worker leg (services.go) and the delegator relay (syncCollectionIndexMeta)
+// both reserve for the same reopen, and multiple pre-DDL segments / retries reopen the same
+// version. The applied segcore version must stay pinned to what the stream will assign (served +
+// logical distance), NOT drift ahead by one per reserve call. A drifting counter would, on a
+// later delta, collide with the served segcore version and defeat segcore's
+// ValidateSchemaCompatibility gate. This test fails under a naive max(served, applied)+1 reserve.
+func (s *CollectionManagerSuite) TestReopenReservationIsIdempotentPerSchemaVersion() {
+	cm := NewCollectionManager()
+	const collID = 22
+
+	baseSchema := mock_segcore.GenTestCollectionSchema("reopen_idem_v1", schemapb.DataType_Int64, false)
+	baseSchema.Version = 1
+	s.Require().NoError(cm.PutOrRef(collID, baseSchema, mock_segcore.GenTestIndexMeta(collID, baseSchema), &querypb.LoadMetaInfo{
+		LoadType:        querypb.LoadType_LoadCollection,
+		SchemaBarrierTs: 100,
+	}))
+	defer cm.Unref(collID, 1)
+
+	_, servedSegcoreBefore := cm.Get(collID).SchemaAndSegcoreVersion()
+
+	v2Schema := mock_segcore.GenTestCollectionSchema("reopen_idem_v2", schemapb.DataType_Int64, false)
+	v2Schema.Version = 2
+
+	reopenV2 := func() uint64 {
+		s.Require().NoError(cm.ReserveAppliedSchemaForReopen(collID, v2Schema, mock_segcore.GenTestIndexMeta(collID, v2Schema), &querypb.LoadMetaInfo{
+			LoadType:        querypb.LoadType_LoadCollection,
+			SchemaBarrierTs: 100,
+		}))
+		cm.Unref(collID, 1)
+		_, appliedSegcore := cm.Get(collID).AppliedSchemaAndSegcoreVersion()
+		return appliedSegcore
+	}
+
+	first := reopenV2()
+	second := reopenV2()
+	third := reopenV2()
+
+	s.Equal(servedSegcoreBefore+1, first, "first reopen of V2 reserves served+1")
+	s.Equal(first, second, "a second reopen of the SAME V2 must reuse the reservation, not drift")
+	s.Equal(first, third, "further reopens of the same V2 must not drift the applied segcore version")
+
+	// No number of reopens may touch the served schema.
+	_, servedVersion := cm.Get(collID).SchemaAndVersion()
+	s.Equal(uint64(1), servedVersion, "reopens must not advance the served logical schema version")
+	_, servedSegcoreAfter := cm.Get(collID).SchemaAndSegcoreVersion()
+	s.Equal(servedSegcoreBefore, servedSegcoreAfter, "reopens must not advance the served segcore version")
+}
+
+// TestFullLoadStillAdvancesServedSchema guards against accidentally gating the full-load path
+// behind the applied-vs-served split. A LoadScope_Full PutOrRef of a version-ahead schema (a
+// genuinely post-DDL segment born at the new version) MUST still advance the served schema; only
+// LoadScope_Reopen reserves applied-only.
+func (s *CollectionManagerSuite) TestFullLoadStillAdvancesServedSchema() {
+	cm := NewCollectionManager()
+	const collID = 21
+
+	baseSchema := mock_segcore.GenTestCollectionSchema("full_load_v1", schemapb.DataType_Int64, false)
+	baseSchema.Version = 1
+	s.Require().NoError(cm.PutOrRef(collID, baseSchema, mock_segcore.GenTestIndexMeta(collID, baseSchema), &querypb.LoadMetaInfo{
+		LoadType:        querypb.LoadType_LoadCollection,
+		SchemaBarrierTs: 100,
+	}))
+	defer cm.Unref(collID, 1)
+
+	v2Schema := mock_segcore.GenTestCollectionSchema("full_load_v2", schemapb.DataType_Int64, false)
+	v2Schema.Version = 2
+
+	// A full load of a genuinely-V2 segment advances the served schema as before (PutOrRef).
+	s.Require().NoError(cm.PutOrRef(collID, v2Schema, mock_segcore.GenTestIndexMeta(collID, v2Schema), &querypb.LoadMetaInfo{
+		LoadType:        querypb.LoadType_LoadCollection,
+		SchemaBarrierTs: 100,
+	}))
+	cm.Unref(collID, 1)
+
+	servedSchema, servedVersion := cm.Get(collID).SchemaAndVersion()
+	s.Equal(uint64(2), servedVersion, "full load must still advance the served logical schema version")
+	s.Same(v2Schema, servedSchema, "full load must swap the served schema payload to V2")
+	s.False(
+		ShouldUpdateCollectionSchema(cm.Get(collID), v2Schema, 100),
+		"full load already advanced served, so a same-version stream UpdateSchema is a no-op",
+	)
+}
+
 func TestCollectionManager(t *testing.T) {
 	suite.Run(t, new(CollectionManagerSuite))
 }

--- a/internal/querynodev2/segments/mock_collection_manager.go
+++ b/internal/querynodev2/segments/mock_collection_manager.go
@@ -213,6 +213,55 @@ func (_c *MockCollectionManager_PutOrRef_Call) RunAndReturn(run func(int64, *sch
 	return _c
 }
 
+// ReserveAppliedSchemaForReopen provides a mock function with given fields: collectionID, schema, meta, loadMeta
+func (_m *MockCollectionManager) ReserveAppliedSchemaForReopen(collectionID int64, schema *schemapb.CollectionSchema, meta *segcorepb.CollectionIndexMeta, loadMeta *querypb.LoadMetaInfo) error {
+	ret := _m.Called(collectionID, schema, meta, loadMeta)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReserveAppliedSchemaForReopen")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, *schemapb.CollectionSchema, *segcorepb.CollectionIndexMeta, *querypb.LoadMetaInfo) error); ok {
+		r0 = rf(collectionID, schema, meta, loadMeta)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockCollectionManager_ReserveAppliedSchemaForReopen_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReserveAppliedSchemaForReopen'
+type MockCollectionManager_ReserveAppliedSchemaForReopen_Call struct {
+	*mock.Call
+}
+
+// ReserveAppliedSchemaForReopen is a helper method to define mock.On call
+//   - collectionID int64
+//   - schema *schemapb.CollectionSchema
+//   - meta *segcorepb.CollectionIndexMeta
+//   - loadMeta *querypb.LoadMetaInfo
+func (_e *MockCollectionManager_Expecter) ReserveAppliedSchemaForReopen(collectionID interface{}, schema interface{}, meta interface{}, loadMeta interface{}) *MockCollectionManager_ReserveAppliedSchemaForReopen_Call {
+	return &MockCollectionManager_ReserveAppliedSchemaForReopen_Call{Call: _e.mock.On("ReserveAppliedSchemaForReopen", collectionID, schema, meta, loadMeta)}
+}
+
+func (_c *MockCollectionManager_ReserveAppliedSchemaForReopen_Call) Run(run func(collectionID int64, schema *schemapb.CollectionSchema, meta *segcorepb.CollectionIndexMeta, loadMeta *querypb.LoadMetaInfo)) *MockCollectionManager_ReserveAppliedSchemaForReopen_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(*schemapb.CollectionSchema), args[2].(*segcorepb.CollectionIndexMeta), args[3].(*querypb.LoadMetaInfo))
+	})
+	return _c
+}
+
+func (_c *MockCollectionManager_ReserveAppliedSchemaForReopen_Call) Return(_a0 error) *MockCollectionManager_ReserveAppliedSchemaForReopen_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockCollectionManager_ReserveAppliedSchemaForReopen_Call) RunAndReturn(run func(int64, *schemapb.CollectionSchema, *segcorepb.CollectionIndexMeta, *querypb.LoadMetaInfo) error) *MockCollectionManager_ReserveAppliedSchemaForReopen_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Ref provides a mock function with given fields: collectionID, count
 func (_m *MockCollectionManager) Ref(collectionID int64, count uint32) bool {
 	ret := _m.Called(collectionID, count)

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1324,7 +1324,11 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 		return err
 	}
 
-	schema, schemaVersion := s.collection.SchemaAndSegcoreVersion()
+	// Use the APPLIED (segment-facing) schema so a reopened segment adopts the
+	// version-ahead (V2, N+1) schema reserved for it by the reopen load path, even
+	// while the served collection schema stays V1. Falls back to the served schema
+	// when no reopen reservation is ahead.
+	schema, schemaVersion := s.collection.AppliedSchemaAndSegcoreVersion()
 	err := s.csegment.Reopen(ctx, &segcore.ReopenRequest{
 		LoadInfo:      newLoadInfo,
 		Schema:        schema,

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -536,8 +536,21 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 		return merr.Success(), nil
 	}
 
-	err := node.manager.Collection.PutOrRef(req.GetCollectionID(), req.GetSchema(),
-		segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), req.GetSchema()), req.GetLoadMeta())
+	// A reopen carries a possibly version-ahead schema and must reserve an APPLIED
+	// segcore version for the reopened segments WITHOUT advancing the served
+	// collection schema. This worker leg runs on the same shared *Collection as a
+	// co-located delegator and executes BEFORE the delegator's own
+	// syncCollectionIndexMeta relay, so advancing served here would pre-empt the
+	// stream UpdateSchema and skip the derived-state rebuild — the #50989/#51062
+	// load-wins race. Mirror the delegator relay; all other scopes advance served.
+	var err error
+	if req.GetLoadScope() == querypb.LoadScope_Reopen {
+		err = node.manager.Collection.ReserveAppliedSchemaForReopen(req.GetCollectionID(), req.GetSchema(),
+			segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), req.GetSchema()), req.GetLoadMeta())
+	} else {
+		err = node.manager.Collection.PutOrRef(req.GetCollectionID(), req.GetSchema(),
+			segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), req.GetSchema()), req.GetLoadMeta())
+	}
 	if err != nil {
 		log.Warn(ctx, "failed to ref collection", mlog.Err(err))
 		return merr.Status(err), nil

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -1016,6 +1016,62 @@ func (suite *ServiceSuite) TestLoadSegmentsReopenReportsDelta() {
 	}
 }
 
+// TestLoadSegmentsReopenDoesNotAdvanceServedSchema verifies the Tier A worker-leg fix
+// (#50989/#51062). A LoadScope_Reopen carrying a version-ahead schema, routed through the worker
+// leg of node.LoadSegments (NeedTransfer=false), must reserve the APPLIED (segment-facing) schema
+// WITHOUT advancing the served collection schema. This worker leg runs on the same shared
+// *Collection as a co-located delegator and executes before the delegator's own relay, so
+// advancing served here would pre-empt the stream UpdateSchema and skip the derived-state rebuild.
+func (suite *ServiceSuite) TestLoadSegmentsReopenDoesNotAdvanceServedSchema() {
+	ctx := context.Background()
+	suite.TestLoadSegments_Int64()
+
+	coll := suite.node.manager.Collection.Get(suite.collectionID)
+	suite.Require().NotNil(coll)
+	_, servedVersionBefore := coll.SchemaAndVersion()
+	_, servedSegcoreBefore := coll.SchemaAndSegcoreVersion()
+
+	// The reopen carries a version-ahead schema (a post-DDL add_function_field bump).
+	schema := mock_segcore.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
+	schema.Version = 100
+	indexInfos := mock_segcore.GenTestIndexInfoList(suite.collectionID, schema)
+	infos := suite.genSegmentLoadInfos(schema, indexInfos)[:1]
+
+	loader := suite.node.loader
+	mockLoader := segments.NewMockLoader(suite.T())
+	suite.node.loader = mockLoader
+	defer func() { suite.node.loader = loader }()
+
+	req := &querypb.LoadSegmentsRequest{
+		Base: &commonpb.MsgBase{
+			MsgID:    rand.Int63(),
+			TargetID: suite.node.session.ServerID,
+		},
+		CollectionID:  suite.collectionID,
+		DstNodeID:     suite.node.session.ServerID,
+		Infos:         infos,
+		Schema:        schema,
+		NeedTransfer:  false,
+		LoadScope:     querypb.LoadScope_Reopen,
+		IndexInfoList: indexInfos,
+	}
+	mockLoader.EXPECT().ReopenSegments(mock.Anything, req.GetInfos()).Return(nil).Once()
+
+	status, err := suite.node.LoadSegments(ctx, req)
+	suite.Require().NoError(err)
+	suite.Equal(commonpb.ErrorCode_Success, status.GetErrorCode())
+
+	// The worker-leg reopen must NOT advance the served schema...
+	_, servedVersionAfter := coll.SchemaAndVersion()
+	suite.Equal(servedVersionBefore, servedVersionAfter, "reopen worker leg must not advance the served logical schema version")
+	_, servedSegcoreAfter := coll.SchemaAndSegcoreVersion()
+	suite.Equal(servedSegcoreBefore, servedSegcoreAfter, "reopen worker leg must not advance the served segcore version")
+
+	// ...but it must reserve the version-ahead APPLIED schema for the reopened segments.
+	_, appliedSegcore := coll.AppliedSchemaAndSegcoreVersion()
+	suite.Greater(appliedSegcore, servedSegcoreBefore, "reopen worker leg must reserve an applied segcore version ahead of served")
+}
+
 func (suite *ServiceSuite) TestLoadSegments_Failed() {
 	ctx := context.Background()
 	// data


### PR DESCRIPTION
## Issue

A BM25/MinHash function output field can stay unsearchable after `add_function_field` on a live collection (a raw VARCHAR placeholder reaches segcore for the sparse field, or the idfOracle is never created).

issue: #51062

## Root cause

A `LoadScope_Reopen` backfilling pre-DDL segments advances the delegator's **served** collection schema — via `syncCollectionIndexMeta`, and on a co-located node also via the worker leg in `services.go`, which runs before the delegator relay on the same shared `*Collection`. The later stream `UpdateSchema` at the same version is then judged a no-op (`ShouldUpdateCollectionSchema` false), so the delegator's derived-state rebuild (idfOracle / function runners) is skipped and the newly added function field stays unsearchable.

## Fix — applied-vs-served schema split

Split the querynode collection schema into **applied** (segment-facing) and **served** (search plan + derived state). Served advances only via the stream `UpdateSchema` (and full load); a reopen reserves an applied segcore version for the reopened segments without advancing served.

- `collection.go`: add an `appliedSchema` snapshot; `ReserveAppliedSchemaForReopen` refreshes index meta and reserves an applied segcore version **without** touching served. `reserveAppliedForReopen` derives the reserved version deterministically (`servedSegcore + logical distance`) — the exact value the stream will later assign — so repeated reopens of the same delta (multiple pre-DDL segments, retries, or the co-located worker+delegator legs of one load) reuse it instead of drifting the counter ahead and colliding with the served version on a later delta.
- `delegator_data.go` / `services.go`: both the delegator relay and the worker leg route `LoadScope_Reopen` to the reserve path; all other scopes (including full load) advance served as before.
- `segment.go`: `LocalSegment.Reopen` loads at `AppliedSchemaAndSegcoreVersion` = `max(applied, served)`, falling back to served once the stream catches up (reconcile with no extra reopen).

No C++ change: segcore already supports a segment ahead of the collection (`ValidateSchemaCompatibility` rejects only `published < plan`). Additive changes only; drop-field (needs served-first) is out of scope.

## Tests

Adds unit tests for the split behavior (reopen does not advance served, stream `UpdateSchema` still applies and reconciles), the deterministic/idempotent reservation (drift regression that fails under a naive `max()+1`), full load still advancing served, and the worker-leg reopen not advancing served through the node RPC.
