### PR TITLE
test: Set CI Helm values index versions

### DIFF
--- a/tests/_helm/values/e2e-amd/distributed-pulsar
+++ b/tests/_helm/values/e2e-amd/distributed-pulsar
@@ -85,6 +85,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -44,6 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-amd/standalone-kafka-mmap
@@ -40,6 +40,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-pulsar
+++ b/tests/_helm/values/e2e-arm/distributed-pulsar
@@ -72,6 +72,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
@@ -1,18 +1,5 @@
-affinity:
-  nodeAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - preference:
-        matchExpressions:
-        - key: jenkins-e2e-amd
-          operator: In
-          values:
-          - "true"
-      weight: 100
-    - preference:
-        matchExpressions:
-        - key: node-role.kubernetes.io/e2e
-          operator: Exists
-      weight: 1
+nodeSelector:
+  jenkins-e2e-arm: "true"
 cluster:
   enabled: true
 woodpecker:
@@ -133,21 +120,8 @@ metrics:
     enabled: true
 # dependencies
 etcd:
-  affinity:
-    nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - preference:
-          matchExpressions:
-          - key: jenkins-e2e-amd
-            operator: In
-            values:
-            - "true"
-        weight: 100
-      - preference:
-          matchExpressions:
-          - key: node-role.kubernetes.io/e2e
-            operator: Exists
-        weight: 1
+  nodeSelector:
+    jenkins-e2e-arm: "true"
   metrics:
     enabled: true
     podMonitor:
@@ -161,29 +135,12 @@ etcd:
       cpu: "1"
       memory: 4Gi
   tolerations:
-  - effect: PreferNoSchedule
-    key: jenkins-milvus-ci-only
-    operator: Equal
-    value: "true"
   - effect: NoSchedule
-    key: node-role.kubernetes.io/e2e
+    key: jenkins-e2e-arm
     operator: Exists
 minio:
-  affinity:
-    nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - preference:
-          matchExpressions:
-          - key: jenkins-e2e-amd
-            operator: In
-            values:
-            - "true"
-        weight: 100
-      - preference:
-          matchExpressions:
-          - key: node-role.kubernetes.io/e2e
-            operator: Exists
-        weight: 1
+  nodeSelector:
+    jenkins-e2e-arm: "true"
   mode: standalone
   resources:
     requests:
@@ -193,12 +150,8 @@ minio:
       cpu: "1"
       memory: 4Gi
   tolerations:
-  - effect: PreferNoSchedule
-    key: jenkins-milvus-ci-only
-    operator: Equal
-    value: "true"
   - effect: NoSchedule
-    key: node-role.kubernetes.io/e2e
+    key: jenkins-e2e-arm
     operator: Exists
 kafka:
   enabled: false
@@ -210,3 +163,7 @@ image:
     pullPolicy: Always
     repository: harbor.milvus.io/milvus/milvus
     tag: nightly-20240821-ed4eaff
+tolerations:
+- effect: NoSchedule
+  key: jenkins-e2e-arm
+  operator: Exists

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -31,6 +31,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-arm/standalone-kafka-mmap
@@ -27,6 +27,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/distributed-pulsar
+++ b/tests/_helm/values/e2e/distributed-pulsar
@@ -85,6 +85,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -44,6 +44,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e/standalone-kafka-mmap
@@ -40,6 +40,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-kafka
+++ b/tests/_helm/values/nightly/distributed-kafka
@@ -86,6 +86,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-pulsar-mmap
+++ b/tests/_helm/values/nightly/distributed-pulsar-mmap
@@ -87,6 +87,9 @@ extraConfigFiles:
         # enable storage v3
         useLoonFFI: true
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker
+++ b/tests/_helm/values/nightly/distributed-woodpecker
@@ -92,6 +92,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker-service
+++ b/tests/_helm/values/nightly/distributed-woodpecker-service
@@ -98,6 +98,9 @@ extraConfigFiles:
       storage:
         format: vortex
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/standalone-authentication-mmap
+++ b/tests/_helm/values/nightly/standalone-authentication-mmap
@@ -37,6 +37,9 @@ log:
 extraConfigFiles:
   user.yaml: |+
     dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
       compaction:
         bumpSchemaVersion:
           enabled: true


### PR DESCRIPTION
pr: #51748

## Summary

- Pin dataCoord.targetVecIndexVersion to 10 in CI Helm values that inject Milvus config
- Enable scalar segment index rebuild and pin dataCoord.targetScalarIndexVersion to 3 for the same CI configs
- Add the ARM distributed woodpecker service boundary values file with ARM scheduling settings

issue: #51791

## Test Plan

- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' tests/_helm/values/*/*
- ruby -e 'require "yaml"; missing=[]; checked=0; ARGV.each do |f| outer=YAML.load_file(f); user=outer.dig("extraConfigFiles", "user.yaml"); next unless user; checked += 1; inner=YAML.safe_load(user); dc=inner["dataCoord"] || {}; ok = dc["targetVecIndexVersion"] == 10 && dc["forceRebuildScalarSegmentIndex"] == true && dc["targetScalarIndexVersion"] == 3; missing << f unless ok; end; puts checked; exit(missing.empty? ? 0 : 1); end' tests/_helm/values/*/*
- ruby -e 'require "yaml"; f="tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary"; outer=YAML.load_file(f); raise "top" unless outer.dig("nodeSelector", "jenkins-e2e-arm") == "true"; raise "etcd" unless outer.dig("etcd", "nodeSelector", "jenkins-e2e-arm") == "true"; raise "minio" unless outer.dig("minio", "nodeSelector", "jenkins-e2e-arm") == "true"; raise "top toleration" unless outer["tolerations"].any? { |t| t["key"] == "jenkins-e2e-arm" }; puts "arm_boundary_scheduling_ok"'