### PR TITLE
fix: restore process-global SegcoreConfig after chunk_rows overrides in tests

### DIFF
--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -33,6 +33,7 @@
 #include "segcore/SegcoreConfig.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/GenExprProto.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 
@@ -349,6 +350,11 @@ VerifyNullableElementFullScanLogicalCount(
 
 class OffsetsEvalCorrectnessTest : public ::testing::Test {
  protected:
+    // SegcoreConfig members are process-global (inline static), so the
+    // "copy + set_chunk_rows" below actually mutates every later test in
+    // the process; restore the defaults when this fixture goes away.
+    ScopedSegcoreConfigRestore config_restore_;
+
     void
     SetUp() override {
         schema_ = std::make_shared<Schema>();
@@ -854,6 +860,9 @@ TEST(OffsetsEvalNullableElementTest,
     schema->set_primary_field_id(pk_fid);
 
     auto dataset = DataGen(schema, kRowCount, 600, 0, 1, kArrayLength);
+    // SegcoreConfig members are process-global (inline static): the copy
+    // below does not isolate set_chunk_rows, so restore on scope exit.
+    ScopedSegcoreConfigRestore config_restore;
     SegcoreConfig config = SegcoreConfig::default_config();
     config.set_chunk_rows(kChunkRows);
     auto segment = CreateGrowingSegment(schema, empty_index_meta, 1, config);
@@ -883,6 +892,9 @@ TEST(OffsetsEvalNullableElementTest,
     schema->set_primary_field_id(pk_fid);
 
     auto dataset = DataGen(schema, kRowCount, 650, 0, 1, kArrayLength);
+    // SegcoreConfig members are process-global (inline static): the copy
+    // below does not isolate set_chunk_rows, so restore on scope exit.
+    ScopedSegcoreConfigRestore config_restore;
     SegcoreConfig config = SegcoreConfig::default_config();
     config.set_chunk_rows(kChunkRows);
     auto segment = CreateGrowingSegment(schema, empty_index_meta, 1, config);


### PR DESCRIPTION
issue: #51799

## What

`SegcoreConfig`'s members are all `inline static`, so the test pattern `SegcoreConfig config = SegcoreConfig::default_config(); config.set_chunk_rows(2);` mutates the **process-global** config rather than a copy. The three such sites in `test_offsets_eval_correctness.cpp` (added in #51540) leave `chunk_rows = 2` behind for every later test in the process: a 100k-row growing segment becomes ~50k chunks, and the nullable access path (`get_span_base` → `ThreadSafeChunkVector::get_element_offset`, O(n) under a shared lock per call) turns quadratic — `ExprTestSuite/ExprTest.TestTermJsonNullable` goes from ~1.5s to ~120s under coverage instrumentation.

Whether CI survives depends only on gtest shard layout: if a `chunk_rows=2` site and the heavy Nullable instances share a shard with no restoring test in between, the shard exceeds the 1800s budget and dies with "shard completed with 0 tests captured". Sharding is deterministic per test set, so an affected PR fails on **every** run (observed: #51486 runs 19208/19278, identical failures; test-set-preserving PRs inherit master's currently-safe layout and pass — until any test-count change re-rolls it, including master's own).

This PR wraps the three sites in the existing `ScopedSegcoreConfigRestore` RAII guard (`test_utils/SegcoreConfigUtils.h`, already used by `SegmentGrowingIndexTest.cpp`, `ChunkedSegmentSealedBinlogIndexTest.cpp`, `flush_growing_segment_test.cpp`). No behavior change for the guarded tests themselves.

## Verification

Minimal reproduction (both tests are on master, unmodified):

```bash
./internal/core/output/unittest/all_tests \
  "--gtest_filter=OffsetsEvalNullableElementTest.GrowingLoadFieldDataUsesLogicalCountForNullPayloadRows:ExprTestSuite/ExprTest.TestTermJsonNullable/0"
```

- Before this fix: probe instances take 19.7–20.9s each (43s under load), after the 2ms poison test.
- After this fix: 1.5–1.8s, identical to running the probe alone. Red/green verified locally under ASAN.

Deeper follow-ups (root `inline static` design, ~11 milder unrestored override sites, O(n) `get_element_offset`) are catalogued in #51799.
