### PR TITLE
fix: [3.0] restore process-global SegcoreConfig after chunk_rows overrides in tests

### DIFF
--- a/internal/core/unittest/test_offsets_eval_correctness.cpp
+++ b/internal/core/unittest/test_offsets_eval_correctness.cpp
@@ -33,6 +33,7 @@
 #include "segcore/SegcoreConfig.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/GenExprProto.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 
@@ -349,6 +350,11 @@ VerifyNullableElementFullScanLogicalCount(
 
 class OffsetsEvalCorrectnessTest : public ::testing::Test {
  protected:
+    // SegcoreConfig members are process-global (inline static), so the
+    // "copy + set_chunk_rows" below actually mutates every later test in
+    // the process; restore the defaults when this fixture goes away.
+    ScopedSegcoreConfigRestore config_restore_;
+
     void
     SetUp() override {
         schema_ = std::make_shared<Schema>();
@@ -854,6 +860,9 @@ TEST(OffsetsEvalNullableElementTest,
     schema->set_primary_field_id(pk_fid);
 
     auto dataset = DataGen(schema, kRowCount, 600, 0, 1, kArrayLength);
+    // SegcoreConfig members are process-global (inline static): the copy
+    // below does not isolate set_chunk_rows, so restore on scope exit.
+    ScopedSegcoreConfigRestore config_restore;
     SegcoreConfig config = SegcoreConfig::default_config();
     config.set_chunk_rows(kChunkRows);
     auto segment = CreateGrowingSegment(schema, empty_index_meta, 1, config);
@@ -883,6 +892,9 @@ TEST(OffsetsEvalNullableElementTest,
     schema->set_primary_field_id(pk_fid);
 
     auto dataset = DataGen(schema, kRowCount, 650, 0, 1, kArrayLength);
+    // SegcoreConfig members are process-global (inline static): the copy
+    // below does not isolate set_chunk_rows, so restore on scope exit.
+    ScopedSegcoreConfigRestore config_restore;
     SegcoreConfig config = SegcoreConfig::default_config();
     config.set_chunk_rows(kChunkRows);
     auto segment = CreateGrowingSegment(schema, empty_index_meta, 1, config);


### PR DESCRIPTION
issue: #51799
pr: #51800

Clean cherry-pick of #51800 onto 3.0 (the poisoned test file is byte-identical on both branches; #51540's chunk_rows=2 sites arrived on 3.0 via backport).

`SegcoreConfig`'s members are `inline static` (process-global); the "copy + `set_chunk_rows(2)`" pattern in `test_offsets_eval_correctness.cpp` leaks 2-row chunking into every later growing-segment test in the process, turning `ExprTestSuite/ExprTest.TestTermJsonNullable` quadratic (~1.5s → ~120s under coverage). Whichever gtest shard colocates a poison site with the heavy Nullable instances and no restoring test in between deterministically exceeds the 1800s budget ("shard completed with 0 tests captured") — observed on 3.0 in #51488's run [19425](https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-build-ut-ciloop-pipeline/19425/pipeline-overview/) after its rebase onto a 3.0 base containing the backported poison.

Fix: wrap the three sites in the existing `ScopedSegcoreConfigRestore` RAII guard (present on 3.0, already used by three other test files). Red/green verified on master content (identical file) — see #51800 for the two-test reproduction.
