### PR TITLE
fix: [cp 3.0] prevent WAL recovery deadlock

### DIFF
--- a/internal/streamingnode/server/wal/adaptor/opener.go
+++ b/internal/streamingnode/server/wal/adaptor/opener.go
@@ -80,6 +80,38 @@ type openerAdaptorImpl struct {
 	interceptorBuilders []interceptors.InterceptorBuilder
 }
 
+type walOpenResources struct {
+	once            sync.Once
+	released        bool
+	roWAL           *roWALAdaptorImpl
+	param           *interceptors.InterceptorBuildParam
+	recoveryStorage recovery.RecoveryStorage
+	flusher         *flusherimpl.WALFlusherImpl
+}
+
+func (r *walOpenResources) Close() {
+	if r.released {
+		return
+	}
+	r.once.Do(func() {
+		if r.flusher != nil {
+			r.flusher.Close()
+		} else if r.recoveryStorage != nil {
+			r.recoveryStorage.Close()
+		}
+		if r.param != nil {
+			r.param.Clear()
+		}
+		if r.roWAL != nil {
+			r.roWAL.Close()
+		}
+	})
+}
+
+func (r *walOpenResources) Release() {
+	r.released = true
+}
+
 // Open opens a wal instance for the channel.
 func (o *openerAdaptorImpl) Open(ctx context.Context, opt *wal.OpenOption) (wal.WAL, error) {
 	if !o.lifetime.Add(typeutil.LifetimeStateWorking) {
@@ -190,6 +222,9 @@ func (o *openerAdaptorImpl) openRWWAL(ctx context.Context, l walimpls.WALImpls, 
 	roWAL := adaptImplsToROWAL(l, func() {
 		o.walInstances.Remove(id)
 	})
+	resources := &walOpenResources{roWAL: roWAL}
+	defer resources.Close()
+
 	cpProto, err := resource.Resource().StreamingNodeCatalog().GetConsumeCheckpoint(ctx, opt.Channel.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get checkpoint from catalog")
@@ -199,20 +234,19 @@ func (o *openerAdaptorImpl) openRWWAL(ctx context.Context, l walimpls.WALImpls, 
 	// recover the wal state.
 	param, err := buildInterceptorParams(ctx, l, cp)
 	if err != nil {
-		roWAL.Close()
 		return nil, errors.Wrap(err, "when building interceptor params")
 	}
+	resources.param = param
 	rs, snapshot, err := recovery.RecoverRecoveryStorage(ctx, newRecoveryStreamBuilder(roWAL), cp, param.LastTimeTickMessage)
 	if err != nil {
-		param.Clear()
-		roWAL.Close()
 		return nil, errors.Wrap(err, "when recovering recovery storage")
 	}
+	resources.recoveryStorage = rs
 
 	// Handle alter WAL if found in snapshot
 	// This flushes all remaining data and triggers WAL switch to the target implementation
 	if snapshot.AlterWALInfo != nil && snapshot.AlterWALInfo.FoundAlterWALMsg {
-		return o.handleAlterWAL(ctx, l, opt, roWAL, param, rs, snapshot)
+		return o.handleAlterWAL(ctx, opt, roWAL, rs, resources, snapshot)
 	}
 
 	param.LastConfirmedMessageID = determineLastConfirmedMessageID(param.LastTimeTickMessage.MessageID(), snapshot.TxnBuffer)
@@ -255,9 +289,11 @@ func (o *openerAdaptorImpl) openRWWAL(ctx context.Context, l walimpls.WALImpls, 
 			RecoverySnapshot:   snapshot,
 			RateLimitComponent: roWAL.WALRateLimitComponent,
 		})
+		resources.flusher = flusher
 	}
 	wal := adaptImplsToRWWAL(roWAL, o.interceptorBuilders, param, flusher)
 	o.walInstances.Insert(id, wal)
+	resources.Release()
 	return wal, nil
 }
 
@@ -279,8 +315,9 @@ func determineLastConfirmedMessageID(lastTimeTickMessageID message.MessageID, tx
 // Stage 1 (FLUSHING): Flush all growing segments and wait for completion
 // Stage 2 (ADVANCE_CHECKPOINT): Update vchannel checkpoints and pchannel consume checkpoint
 // Returns an error to trigger WAL re-opening after successful switch
-func (o *openerAdaptorImpl) handleAlterWAL(ctx context.Context, l walimpls.WALImpls, opt *wal.OpenOption,
-	roWAL *roWALAdaptorImpl, param *interceptors.InterceptorBuildParam, rs recovery.RecoveryStorage, snapshot *recovery.RecoverySnapshot,
+func (o *openerAdaptorImpl) handleAlterWAL(ctx context.Context, opt *wal.OpenOption,
+	roWAL *roWALAdaptorImpl, rs recovery.RecoveryStorage,
+	resources *walOpenResources, snapshot *recovery.RecoverySnapshot,
 ) (wal.WAL, error) {
 	mlog.Info(ctx, "detected alter WAL message in snapshot",
 		mlog.String("channel", opt.Channel.String()),
@@ -291,7 +328,7 @@ func (o *openerAdaptorImpl) handleAlterWAL(ctx context.Context, l walimpls.WALIm
 		mlog.Any("alterWALConfig", snapshot.AlterWALInfo.AlterWALConfig))
 
 	if snapshot.Checkpoint.AlterWalState != nil && snapshot.Checkpoint.AlterWalState.Stage == streamingpb.AlterWALStage_FLUSHING {
-		flushingErr := o.handleAlterWALFlushingStage(ctx, opt, roWAL, param, rs, snapshot)
+		flushingErr := o.handleAlterWALFlushingStage(ctx, opt, roWAL, rs, resources, snapshot)
 		if flushingErr != nil {
 			return nil, errors.Wrap(flushingErr, "failed to handle alter WAL flushing stage")
 		}
@@ -309,7 +346,8 @@ func (o *openerAdaptorImpl) handleAlterWAL(ctx context.Context, l walimpls.WALIm
 }
 
 func (o *openerAdaptorImpl) handleAlterWALFlushingStage(ctx context.Context, opt *wal.OpenOption, roWAL *roWALAdaptorImpl,
-	param *interceptors.InterceptorBuildParam, rs recovery.RecoveryStorage, snapshot *recovery.RecoverySnapshot,
+	rs recovery.RecoveryStorage,
+	resources *walOpenResources, snapshot *recovery.RecoverySnapshot,
 ) error {
 	// Start flusher to flush all growing segments
 	var flusher *flusherimpl.WALFlusherImpl
@@ -324,6 +362,7 @@ func (o *openerAdaptorImpl) handleAlterWALFlushingStage(ctx context.Context, opt
 			RecoverySnapshot:   snapshot,
 			RateLimitComponent: roWAL.WALRateLimitComponent,
 		})
+		resources.flusher = flusher
 	}
 
 	// Wait for all data up to target time tick to be flushed
@@ -375,12 +414,7 @@ func (o *openerAdaptorImpl) handleAlterWALFlushingStage(ctx context.Context, opt
 
 	// Close recovery storage and related resources to persist final state
 	mlog.Info(ctx, "closing recovery storage to persist WAL switch snapshot")
-	rs.Close()
-	if flusher != nil {
-		flusher.Close()
-	}
-	param.Clear()
-	roWAL.Close()
+	resources.Close()
 
 	// Update checkpoint stage to ADVANCE_CHECKPOINT and persist to catalog
 	snapshot.Checkpoint.AlterWalState.Stage = streamingpb.AlterWALStage_ADVANCE_CHECKPOINT

--- a/internal/streamingnode/server/wal/adaptor/opener.go
+++ b/internal/streamingnode/server/wal/adaptor/opener.go
@@ -80,38 +80,6 @@ type openerAdaptorImpl struct {
 	interceptorBuilders []interceptors.InterceptorBuilder
 }
 
-type walOpenResources struct {
-	once            sync.Once
-	released        bool
-	roWAL           *roWALAdaptorImpl
-	param           *interceptors.InterceptorBuildParam
-	recoveryStorage recovery.RecoveryStorage
-	flusher         *flusherimpl.WALFlusherImpl
-}
-
-func (r *walOpenResources) Close() {
-	if r.released {
-		return
-	}
-	r.once.Do(func() {
-		if r.flusher != nil {
-			r.flusher.Close()
-		} else if r.recoveryStorage != nil {
-			r.recoveryStorage.Close()
-		}
-		if r.param != nil {
-			r.param.Clear()
-		}
-		if r.roWAL != nil {
-			r.roWAL.Close()
-		}
-	})
-}
-
-func (r *walOpenResources) Release() {
-	r.released = true
-}
-
 // Open opens a wal instance for the channel.
 func (o *openerAdaptorImpl) Open(ctx context.Context, opt *wal.OpenOption) (wal.WAL, error) {
 	if !o.lifetime.Add(typeutil.LifetimeStateWorking) {

--- a/internal/streamingnode/server/wal/adaptor/opener_test.go
+++ b/internal/streamingnode/server/wal/adaptor/opener_test.go
@@ -13,11 +13,13 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/mocks/mock_metastore"
+	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/wal/interceptors/shard/mock_utils"
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/wal/mock_recovery"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/flusher/flusherimpl"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/replicate/replicates"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/recovery"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
@@ -29,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/rmq"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func TestMain(m *testing.M) {
@@ -55,6 +58,70 @@ func TestOpenerAdaptorFailure(t *testing.T) {
 	l, err := opener.Open(context.Background(), &wal.OpenOption{})
 	assert.ErrorIs(t, err, errExpected)
 	assert.Nil(t, l)
+}
+
+func TestOpenRWWALCleansRecoveredShardManagerOnReplicateRecoveryFailure(t *testing.T) {
+	channel := types.PChannelInfo{
+		Name:       "replicate-recovery-failure-cleanup",
+		Term:       1,
+		AccessMode: types.AccessModeRW,
+	}
+	catalog := mock_metastore.NewMockStreamingNodeCataLog(t)
+	catalog.EXPECT().GetConsumeCheckpoint(mock.Anything, channel.Name).Return(
+		&streamingpb.WALCheckpoint{MessageId: &commonpb.MessageID{
+			Id:      "0",
+			WALName: commonpb.WALName_Test,
+		}}, nil)
+	catalog.EXPECT().GetSalvageCheckpoint(mock.Anything, channel.Name).Return(nil, nil)
+	resource.InitForTest(t, resource.OptStreamingNodeCatalog(catalog))
+
+	walImpls := &firstTimeTickWALImpls{
+		channel: channel,
+		appendFunc: func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			return rmq.NewRmqID(1), nil
+		},
+	}
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+	rs.EXPECT().Close().Return().Once()
+	snapshot := &recovery.RecoverySnapshot{
+		VChannels:          map[string]*streamingpb.VChannelMeta{},
+		SegmentAssignments: map[int64]*streamingpb.SegmentAssignmentMeta{},
+		Checkpoint: &recovery.WALCheckpoint{
+			MessageID: rmq.NewRmqID(1),
+			TimeTick:  1,
+		},
+		TxnBuffer: utility.NewTxnBuffer(
+			mlog.With(),
+			metricsutil.NewScanMetrics(channel).NewScannerMetrics(),
+		),
+	}
+	mockRecoverStorage := mockey.Mock(recovery.RecoverRecoveryStorage).
+		Return(rs, snapshot, nil).
+		Build()
+	defer mockRecoverStorage.UnPatch()
+
+	errExpected := errors.New("replicate recovery failed")
+	mockRecoverReplicateManager := mockey.Mock(replicates.RecoverReplicateManager).
+		Return(nil, errExpected).
+		Build()
+	defer mockRecoverReplicateManager.UnPatch()
+
+	opener := &openerAdaptorImpl{
+		idAllocator:  typeutil.NewIDAllocator(),
+		walInstances: typeutil.NewConcurrentMap[int64, wal.WAL](),
+	}
+	l, err := opener.openRWWAL(context.Background(), walImpls, &wal.OpenOption{Channel: channel, DisableFlusher: true})
+	require.ErrorIs(t, err, errExpected)
+	assert.Nil(t, l)
+
+	sealOperator := mock_utils.NewMockSealOperator(t)
+	sealOperator.EXPECT().Channel().Return(channel).Maybe()
+	registered := assert.NotPanics(t, func() {
+		resource.Resource().SegmentStatsManager().RegisterSealOperator(sealOperator, nil, nil)
+	})
+	if registered {
+		resource.Resource().SegmentStatsManager().UnregisterSealOperator(sealOperator)
+	}
 }
 
 func TestDetermineLastConfirmedMessageID(t *testing.T) {
@@ -158,17 +225,28 @@ func TestHandleAlterWALFlushingStagePassesRateLimitComponent(t *testing.T) {
 		Build()
 	defer mockRecoverFlusher.UnPatch()
 
-	mockFlusherClose := mockey.Mock((*flusherimpl.WALFlusherImpl).Close).Return().Build()
+	mockFlusherClose := mockey.Mock((*flusherimpl.WALFlusherImpl).Close).
+		To(func(*flusherimpl.WALFlusherImpl) {
+			rs.Close()
+		}).
+		Build()
 	defer mockFlusherClose.UnPatch()
+	param := &interceptors.InterceptorBuildParam{}
+	resources := &walOpenResources{
+		roWAL:           roWAL,
+		param:           param,
+		recoveryStorage: rs,
+	}
 
 	err := (&openerAdaptorImpl{}).handleAlterWALFlushingStage(
 		context.Background(),
 		&wal.OpenOption{Channel: channel},
 		roWAL,
-		&interceptors.InterceptorBuildParam{},
 		rs,
+		resources,
 		snapshot,
 	)
+	resources.Close()
 
 	require.NoError(t, err)
 	require.NotNil(t, capturedParam)

--- a/internal/streamingnode/server/wal/adaptor/wal_open_resources.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_open_resources.go
@@ -1,0 +1,41 @@
+package adaptor
+
+import (
+	"sync"
+
+	"github.com/milvus-io/milvus/internal/streamingnode/server/flusher/flusherimpl"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/recovery"
+)
+
+type walOpenResources struct {
+	once            sync.Once
+	released        bool
+	roWAL           *roWALAdaptorImpl
+	param           *interceptors.InterceptorBuildParam
+	recoveryStorage recovery.RecoveryStorage
+	flusher         *flusherimpl.WALFlusherImpl
+}
+
+func (r *walOpenResources) Close() {
+	if r.released {
+		return
+	}
+	r.once.Do(func() {
+		if r.flusher != nil {
+			r.flusher.Close()
+		} else if r.recoveryStorage != nil {
+			r.recoveryStorage.Close()
+		}
+		if r.param != nil {
+			r.param.Clear()
+		}
+		if r.roWAL != nil {
+			r.roWAL.Close()
+		}
+	})
+}
+
+func (r *walOpenResources) Release() {
+	r.released = true
+}

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/segment_flush_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/segment_flush_worker.go
@@ -20,17 +20,27 @@ func (m *partitionManager) asyncFlushSegment(
 	ctx context.Context,
 	segment *segmentAllocManager,
 ) {
-	// create a new segment flush worker.
-	w := &segmentFlushWorker{
-		txnManager:   m.txnManager,
-		ctx:          ctx,
-		collectionID: m.collectionID,
-		vchannel:     m.vchannel,
-		segment:      segment,
-		wal:          m.wal.Get(),
-	}
-	w.SetLogger(m.Logger())
-	go w.do()
+	go func() {
+		l, err := m.wal.GetWithContext(ctx)
+		if err != nil {
+			m.Logger().Info(ctx, "stop flushing segment before wal is ready",
+				mlog.FieldSegmentID(segment.GetSegmentID()),
+				mlog.Err(err))
+			return
+		}
+
+		// create a new segment flush worker.
+		w := &segmentFlushWorker{
+			txnManager:   m.txnManager,
+			ctx:          ctx,
+			collectionID: m.collectionID,
+			vchannel:     m.vchannel,
+			segment:      segment,
+			wal:          l,
+		}
+		w.SetLogger(m.Logger())
+		w.do()
+	}()
 }
 
 // segmentFlusherWorker is the worker that flushes segments into the WAL.

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
@@ -714,6 +714,69 @@ func newShardManagerWithGrowingSegment(t *testing.T, collID, partID, segID int64
 	}).(*shardManagerImpl)
 }
 
+func TestAsyncFlushSegmentDoesNotHoldShardManagerLockWhileWaitingForWAL(t *testing.T) {
+	paramtable.Init()
+	resource.InitForTest(t)
+
+	const (
+		collID = int64(10)
+		partID = int64(20)
+		segID  = int64(3001)
+	)
+	m := newShardManagerWithGrowingSegment(t, collID, partID, segID)
+	readyWAL := m.wal.Get()
+	pendingWAL := syncutil.NewFuture[wal.WAL]()
+	m.wal = pendingWAL
+	for _, pm := range m.partitionManagers {
+		pm.wal = pendingWAL
+	}
+
+	flushDone := make(chan struct{})
+	go func() {
+		m.AsyncFlushSegment(utils.SealSegmentSignal{
+			SegmentBelongs: utils.SegmentBelongs{
+				PChannel:     m.Channel().Name,
+				VChannel:     "v_alter",
+				CollectionID: collID,
+				PartitionID:  partID,
+				SegmentID:    segID,
+			},
+			SealPolicy: policy.PolicyCapacity(),
+		})
+		close(flushDone)
+	}()
+	select {
+	case <-flushDone:
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	schemaReadDone := make(chan struct{})
+	go func() {
+		m.GetAllCollectionSchemaInfos()
+		close(schemaReadDone)
+	}()
+
+	select {
+	case <-schemaReadDone:
+	case <-time.After(200 * time.Millisecond):
+		pendingWAL.Set(readyWAL)
+		<-flushDone
+		<-schemaReadDone
+		m.Close()
+		t.Fatal("schema read blocked on shard manager lock while flush waited for WAL readiness")
+	}
+
+	select {
+	case <-flushDone:
+	case <-time.After(time.Second):
+		pendingWAL.Set(readyWAL)
+		<-flushDone
+		m.Close()
+		t.Fatal("async flush blocked while waiting for WAL readiness")
+	}
+	m.Close()
+}
+
 func TestAlterCollectionSchemaChange(t *testing.T) {
 	paramtable.Init()
 	resource.InitForTest(t)

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker.go
@@ -38,10 +38,10 @@ type sealWorker struct {
 
 // NotifySealSegment is used to notify the seal worker to seal the segment.
 func (m *sealWorker) NotifySealSegment(segmentID int64, sealPolicy policy.SealPolicy) {
-	go func() {
-		// we should async notify the seal worker to avoid blocking the caller.
-		m.sealNotifier <- sealSegmentIDWithPolicy{segmentID: segmentID, sealPolicy: sealPolicy}
-	}()
+	select {
+	case m.sealNotifier <- sealSegmentIDWithPolicy{segmentID: segmentID, sealPolicy: sealPolicy}:
+	default:
+	}
 }
 
 // NotifyGrowingBytes is used to notify the seal worker to seal the segment when the total size exceeds the threshold.

--- a/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/stats/stats_seal_worker_test.go
@@ -1,0 +1,30 @@
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/policy"
+)
+
+func TestNotifySealSegmentDropsWhenQueueIsFull(t *testing.T) {
+	worker := &sealWorker{
+		sealNotifier: make(chan sealSegmentIDWithPolicy, 1),
+	}
+	worker.sealNotifier <- sealSegmentIDWithPolicy{
+		segmentID:  1,
+		sealPolicy: policy.PolicyCapacity(),
+	}
+
+	worker.NotifySealSegment(2, policy.PolicyCapacity())
+	first := <-worker.sealNotifier
+	assert.Equal(t, int64(1), first.segmentID)
+
+	select {
+	case notification := <-worker.sealNotifier:
+		t.Fatalf("received notification for segment %d after the full queue should have dropped it", notification.segmentID)
+	case <-time.After(200 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
issue: #51765
pr: #51803

- WAL recovery: wait for WAL readiness asynchronously and stop pending flush work on cancellation
- seal scheduling: bound seal notifications without spawning one goroutine per event
- WAL open lifecycle: clean partially initialized resources exactly once on failure