### PR TITLE
test: [3.0] remove index cases unsupported by branch defaults

### DIFF
--- a/tests/python_client/milvus_client/expressions/test_milvus_client_json_filtering.py
+++ b/tests/python_client/milvus_client/expressions/test_milvus_client_json_filtering.py
@@ -496,23 +496,7 @@ class TestJsonFilteringIndexedUnknownSemantics(JsonFilteringUnknownMixin, TestMi
                     (f'not ({json_field}["a"] > 2)', [4]),
                 ],
             ),
-            (
-                "stl_sort_double",
-                [
-                    {
-                        "index_name": "idx_json_a_stl_sort_double",
-                        "index_type": "STL_SORT",
-                        "params": {"json_cast_type": "DOUBLE", "json_path": f"{json_field}['a']"},
-                    }
-                ],
-                [
-                    (f'{json_field}["a"] == 2', [4]),
-                    (f'{json_field}["a"] > 2', [5]),
-                    (f'{json_field}["a"] != 2', [5]),
-                    (f'{json_field}["a"] not in [2]', [5]),
-                    (f'not ({json_field}["a"] > 2)', [4]),
-                ],
-            ),
+            # stl_sort_double removed: STL_SORT on a JSON path requires scalar index engine v4; 3.0 uses v3 (#51745)
             (
                 "inverted_varchar",
                 [

--- a/tests/python_client/milvus_client/test_milvus_client_compact.py
+++ b/tests/python_client/milvus_client/test_milvus_client_compact.py
@@ -116,15 +116,12 @@ class TestMilvusClientCompactInvalid(TestMilvusClientV2Base):
                     check_task=CheckTasks.err_res, check_items=error)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_delete.py
+++ b/tests/python_client/milvus_client/test_milvus_client_delete.py
@@ -113,15 +113,12 @@ class TestMilvusClientDeleteInvalid(TestMilvusClientV2Base):
                                  "err_msg": "The type of expr must be string ,but <class 'NoneType'> is given."})
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_hybrid_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_hybrid_search.py
@@ -269,15 +269,12 @@ class TestMilvusClientHybridSearchInvalid(TestMilvusClientV2Base):
                            check_task=CheckTasks.err_res, check_items=error)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_index.py
@@ -744,15 +744,12 @@ class TestMilvusClientIndexValid(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params_invalid = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 
@@ -787,7 +784,8 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
     def supported_json_cast_type(self, json_index_params):
         yield json_index_params[1]
 
-    @pytest.fixture(scope="function", params=["INVERTED", "STL_SORT"])
+    # STL_SORT on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
+    @pytest.fixture(scope="function", params=["INVERTED"])
     def supported_double_scalar_index(self, request):
         """Index types that support DOUBLE cast type. Use for tests that
         hardcode json_cast_type to 'double'."""
@@ -1167,15 +1165,12 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
                           check_task=CheckTasks.err_res, check_items=error)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params_valid = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_json_path_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_json_path_index.py
@@ -38,15 +38,12 @@ default_int32_field_name = ct.default_int32_field_name
 default_int32_value = ct.default_int32_value
 
 # Valid (index_type, json_cast_type) combinations for JSON path index
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -4745,10 +4745,10 @@ class TestMilvusClientGetValid(TestMilvusClientV2Base):
 
 # Valid (index_type, json_cast_type) combinations for JSON path index
 # @pytest.fixture(scope="function", params=["DOUBLE", "VARCHAR", "json"", "bool", "ARRAY_DOUBLE"])
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params_query = [
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "ARRAY_DOUBLE"),
-    ("STL_SORT", "DOUBLE"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -4078,15 +4078,12 @@ class TestMilvusClientSearchNullExpr(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
@@ -635,15 +635,12 @@ class TestMilvusClientSearchIteratorInValid(TestMilvusClientV2Base):
             it.next()
 
 
+# STL_SORT/BITMAP on a JSON path require scalar index engine v4; 3.0 uses v3 (#51745)
 _json_path_index_params = [
     ("INVERTED", "BOOL"),
     ("INVERTED", "DOUBLE"),
     ("INVERTED", "VARCHAR"),
     ("INVERTED", "JSON"),
-    ("STL_SORT", "DOUBLE"),
-    ("STL_SORT", "VARCHAR"),
-    ("BITMAP", "BOOL"),
-    ("BITMAP", "VARCHAR"),
 ]
 
 

--- a/tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py
@@ -11,10 +11,6 @@ SPARSE_QUERY = {1: 1.0}
 
 IP_INDEX_FIELDS = {
     "sparse_default": {},
-    "sparse_sindi": {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 65535,
-    },
     "sparse_block_maxscore": {
         "inverted_index_algo": "BLOCK_MAX_MAXSCORE",
         "block_max_block_size": 128,
@@ -39,23 +35,9 @@ IP_INDEX_FIELDS = {
         "inverted_index_algo": "DAAT_MAXSCORE",
         "quant_type": "fp32",
     },
-    "sparse_sindi_w1024": {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 1024,
-    },
-    "sparse_sindi_w4096": {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 4096,
-    },
 }
 
 BM25_INDEX_FIELDS = {
-    "bm25_sindi": {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 65535,
-        "bm25_k1": 1.2,
-        "bm25_b": 0.75,
-    },
     "bm25_u16": {
         "inverted_index_algo": "DAAT_MAXSCORE",
         "quant_type": "u16",
@@ -68,43 +50,12 @@ BM25_INDEX_FIELDS = {
         "bm25_k1": 1.2,
         "bm25_b": 0.75,
     },
-    "bm25_sindi_low": {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 65535,
-        "bm25_k1": 0.8,
-        "bm25_b": 0.25,
-    },
-    "bm25_sindi_high": {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 65535,
-        "bm25_k1": 2.0,
-        "bm25_b": 1.0,
-    },
-    "bm25_sindi_implicit": {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 65535,
-    },
-    "bm25_sindi_jieba": {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 65535,
-        "bm25_k1": 1.2,
-        "bm25_b": 0.75,
-    },
-}
-
-BM25_ANALYZER_PARAMS = {
-    "bm25_sindi_jieba": {"tokenizer": "jieba"},
 }
 
 ORDINARY_IP_INDEX_FIELDS = {
     "sparse_taat_naive": {"inverted_index_algo": "TAAT_NAIVE"},
     "sparse_daat_maxscore": {"inverted_index_algo": "DAAT_MAXSCORE"},
     "sparse_daat_wand": {"inverted_index_algo": "DAAT_WAND"},
-    "sparse_sindi_no_drop_build": {"inverted_index_algo": "SINDI"},
-    "sparse_sindi_drop_build": {
-        "inverted_index_algo": "SINDI",
-        "drop_ratio_build": 0.4,
-    },
 }
 
 LIFECYCLE_ENCODING_INDEX_FIELDS = {
@@ -116,22 +67,9 @@ LIFECYCLE_ENCODING_INDEX_FIELDS = {
         "inverted_index_algo": "DAAT_MAXSCORE",
         "inverted_index_codec": "block_maskedvbyte",
     },
-    "sparse_sindi": {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 65535,
-    },
 }
 
-DROP_RATIO_EFFECT_FIELD = "sparse_sindi_drop_ratio_effect"
-DROP_RATIO_EFFECT_QUERY = {1: 1.0, 2: 0.39, 3: 0.38, 4: 0.37, 5: 0.36}
-
-LIFECYCLE_IP_INDEX_FIELDS = {
-    **LIFECYCLE_ENCODING_INDEX_FIELDS,
-    DROP_RATIO_EFFECT_FIELD: {
-        "inverted_index_algo": "SINDI",
-        "sindi_window_size": 65535,
-    },
-}
+LIFECYCLE_IP_INDEX_FIELDS = LIFECYCLE_ENCODING_INDEX_FIELDS
 
 
 def _ip_vector(row_id):
@@ -151,26 +89,6 @@ def _bm25_document(row_id):
     if row_id == 2:
         return "alpha"
     return "gamma delta"
-
-
-def _bm25_jieba_document(row_id):
-    if row_id == 0:
-        return "稀疏 稀疏 稀疏 向量"
-    if row_id == 1:
-        return "稀疏 向量"
-    if row_id == 2:
-        return "稀疏"
-    return "全文 检索"
-
-
-def _drop_ratio_effect_vector(row_id):
-    if row_id == 0:
-        return {1: 1.0}
-    if row_id == 1:
-        return {4: 3.0, 5: 3.0}
-    if row_id == 2:
-        return {2: 1.0, 3: 1.0}
-    return {10000 + row_id: 1.0}
 
 
 class _SparseInvertedIndexV3Base(TestMilvusClientV2Base):
@@ -297,40 +215,6 @@ class TestSparseInvertedIndexV3IPShared(_SparseInvertedIndexV3Base):
 
         request.addfinalizer(teardown)
 
-    @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.parametrize("limit", [1, 10, 100])
-    def test_ip_sindi_search_topk_and_score_order(self, limit):
-        """
-        target: verify SINDI IP search returns deterministic topK results
-        method: search a fixed sparse dimension whose fp16-distinguishable values decrease by id
-        expected: ids are returned in ascending id order with descending scores
-        """
-        client = self._client(alias=self.shared_alias)
-        hits = self._search_hits(client, self.collection_name, "sparse_sindi", [SPARSE_QUERY], limit=limit)
-        self._assert_exact_ip_topk(hits, limit=limit)
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_ip_sindi_search_empty_query(self):
-        """
-        target: verify an empty sparse query is accepted by SINDI
-        method: search with an empty sparse vector
-        expected: search succeeds and returns no correlated entities
-        """
-        client = self._client(alias=self.shared_alias)
-        hits = self._search_hits(client, self.collection_name, "sparse_sindi", [{}])
-        assert hits == []
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_ip_sindi_search_no_overlap_query(self):
-        """
-        target: verify SINDI returns no hit for a query with no indexed dimension overlap
-        method: search using a dimension absent from all inserted vectors
-        expected: result list is empty
-        """
-        client = self._client(alias=self.shared_alias)
-        hits = self._search_hits(client, self.collection_name, "sparse_sindi", [{9999: 1.0}])
-        assert hits == []
-
     @pytest.mark.tags(CaseLabel.L1)
     def test_ip_default_index_params_search_success(self):
         """
@@ -345,12 +229,12 @@ class TestSparseInvertedIndexV3IPShared(_SparseInvertedIndexV3Base):
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize(
         "field_name",
-        ["sparse_block_maxscore", "sparse_block_wand", "sparse_sindi"],
+        ["sparse_block_maxscore", "sparse_block_wand"],
     )
     def test_new_inverted_index_algo_search(self, field_name):
         """
         target: verify new sparse inverted index algorithms support IP search
-        method: search fields built with BLOCK_MAX_MAXSCORE, BLOCK_MAX_WAND, or SINDI
+        method: search fields built with BLOCK_MAX_MAXSCORE or BLOCK_MAX_WAND
         expected: each field returns the deterministic topK results without search-side algorithm parameters
         """
         client = self._client(alias=self.shared_alias)
@@ -376,22 +260,6 @@ class TestSparseInvertedIndexV3IPShared(_SparseInvertedIndexV3Base):
         target: verify valid IP quantization types support search
         method: search fields built with fp16 and fp32 posting values
         expected: each configuration returns ordered valid results
-        """
-        client = self._client(alias=self.shared_alias)
-        hits = self._search_hits(client, self.collection_name, field_name, [SPARSE_QUERY])
-        self._assert_exact_ip_topk(hits)
-        self._assert_index_params(client, self.collection_name, field_name, IP_INDEX_FIELDS[field_name])
-
-    @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize(
-        "field_name",
-        ["sparse_sindi_w1024", "sparse_sindi_w4096", "sparse_sindi"],
-    )
-    def test_sindi_window_size_search(self, field_name):
-        """
-        target: verify valid SINDI window sizes build and search
-        method: search indexes configured with window sizes 1024, 4096, and 65535
-        expected: all configurations return deterministic topK results
         """
         client = self._client(alias=self.shared_alias)
         hits = self._search_hits(client, self.collection_name, field_name, [SPARSE_QUERY])
@@ -454,45 +322,6 @@ class TestSparseInvertedIndexV3IPShared(_SparseInvertedIndexV3Base):
         )
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_ip_sindi_search_with_scalar_filter(self):
-        """
-        target: verify SINDI honors scalar filters
-        method: search while retaining only ids greater than or equal to half the inserted rows
-        expected: all returned ids satisfy the filter and preserve ranking
-        """
-        client = self._client(alias=self.shared_alias)
-        minimum_id = ROW_COUNT // 2
-        hits = self._search_hits(
-            client,
-            self.collection_name,
-            "sparse_sindi",
-            [SPARSE_QUERY],
-            filter=f"id >= {minimum_id}",
-        )
-        assert self._hit_ids(hits) == list(range(minimum_id, minimum_id + 10))
-        self._assert_scores_descending(hits)
-
-    @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("filtered_ratio", [0.4, 0.9])
-    def test_ip_sindi_search_with_high_filter_ratio(self, filtered_ratio):
-        """
-        target: verify SINDI remains valid when scalar filtering removes many candidates
-        method: filter away 40 percent and 90 percent of indexed rows
-        expected: returned ids are legal and results remain ordered
-        """
-        client = self._client(alias=self.shared_alias)
-        minimum_id = int(ROW_COUNT * filtered_ratio)
-        hits = self._search_hits(
-            client,
-            self.collection_name,
-            "sparse_sindi",
-            [SPARSE_QUERY],
-            filter=f"id >= {minimum_id}",
-        )
-        assert self._hit_ids(hits) == list(range(minimum_id, minimum_id + 10))
-        self._assert_scores_descending(hits)
-
-    @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("filtered_ratio", [0.4, 0.9])
     def test_block_max_wand_search_with_high_filter_ratio(self, filtered_ratio):
         """
@@ -513,10 +342,9 @@ class TestSparseInvertedIndexV3IPShared(_SparseInvertedIndexV3Base):
         self._assert_scores_descending(hits)
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("field_name", ["sparse_sindi", "sparse_block_wand"])
-    def test_sparse_search_iterator_returns_valid_ordered_hits(self, field_name):
+    def test_sparse_search_iterator_returns_valid_ordered_hits(self):
         """
-        target: verify iterated sparse search works on SINDI and non-SINDI indexes
+        target: verify iterated sparse search works on a Block-Max index
         method: compare ten iterator hits with regular topK search in iterator batches of four
         expected: iterator returns the same IDs and distances as regular search without duplicates
         """
@@ -524,7 +352,7 @@ class TestSparseInvertedIndexV3IPShared(_SparseInvertedIndexV3Base):
         hits = self._iterator_hits(
             client,
             self.collection_name,
-            field_name,
+            "sparse_block_wand",
             {"metric_type": "IP", "params": {}},
         )
         assert len(hits) == 10
@@ -533,14 +361,14 @@ class TestSparseInvertedIndexV3IPShared(_SparseInvertedIndexV3Base):
         self._assert_scores_descending(hits)
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.parametrize("field_name", ["sparse_sindi", "sparse_block_wand"])
-    def test_sparse_range_search_iterator_respects_ip_bounds(self, field_name):
+    def test_sparse_range_search_iterator_respects_ip_bounds(self):
         """
-        target: verify range iterator bounds work on SINDI and non-SINDI sparse indexes
+        target: verify range iterator bounds work on a Block-Max sparse index
         method: derive IP range bounds from a regular topK search and iterate the same range
         expected: iterator results are unique, score ordered, and satisfy the range bounds
         """
         client = self._client(alias=self.shared_alias)
+        field_name = "sparse_block_wand"
         baseline = self._search_hits(client, self.collection_name, field_name, [SPARSE_QUERY])
         radius = baseline[5]["distance"] - 0.1
         range_filter = baseline[0]["distance"] + 0.1
@@ -559,7 +387,7 @@ class TestSparseInvertedIndexV3IPShared(_SparseInvertedIndexV3Base):
 @pytest.mark.xdist_group("TestSparseInvertedIndexV3OrdinaryIPShared")
 @pytest.mark.tags(CaseLabel.L1)
 class TestSparseInvertedIndexV3OrdinaryIPShared(_SparseInvertedIndexV3Base):
-    """Shared IP collection for ordinary sparse algorithms and legacy build parameter compatibility."""
+    """Shared IP collection for ordinary sparse algorithms."""
 
     shared_alias = "TestSparseInvertedIndexV3OrdinaryIPShared"
 
@@ -617,24 +445,11 @@ class TestSparseInvertedIndexV3OrdinaryIPShared(_SparseInvertedIndexV3Base):
         hits = self._search_hits(client, self.collection_name, field_name, [SPARSE_QUERY])
         self._assert_exact_ip_topk(hits)
 
-    def test_drop_ratio_build_remains_accepted_without_changing_results(self):
-        """
-        target: verify the deprecated drop_ratio_build parameter remains build-compatible
-        method: compare SINDI fields built with and without drop_ratio_build=0.4
-        expected: both indexes reload and return identical deterministic topK results
-        """
-        client = self._client(alias=self.shared_alias)
-        baseline = self._search_hits(client, self.collection_name, "sparse_sindi_no_drop_build", [SPARSE_QUERY])
-        with_drop = self._search_hits(client, self.collection_name, "sparse_sindi_drop_build", [SPARSE_QUERY])
-        self._assert_exact_ip_topk(baseline)
-        assert self._hit_ids(with_drop) == self._hit_ids(baseline)
-        assert [hit["distance"] for hit in with_drop] == pytest.approx([hit["distance"] for hit in baseline])
-
 
 @pytest.mark.xdist_group("TestSparseInvertedIndexV3BM25Shared")
 @pytest.mark.tags(CaseLabel.L1)
 class TestSparseInvertedIndexV3BM25Shared(_SparseInvertedIndexV3Base):
-    """Shared BM25 collection with SINDI and ordinary quantized inverted indexes."""
+    """Shared BM25 collection with ordinary quantized inverted indexes."""
 
     shared_alias = "TestSparseInvertedIndexV3BM25Shared"
 
@@ -654,7 +469,7 @@ class TestSparseInvertedIndexV3BM25Shared(_SparseInvertedIndexV3Base):
                 DataType.VARCHAR,
                 max_length=256,
                 enable_analyzer=True,
-                analyzer_params=BM25_ANALYZER_PARAMS.get(field_name, {"tokenizer": "standard"}),
+                analyzer_params={"tokenizer": "standard"},
             )
             schema.add_field(field_name, DataType.SPARSE_FLOAT_VECTOR)
             schema.add_function(
@@ -672,8 +487,7 @@ class TestSparseInvertedIndexV3BM25Shared(_SparseInvertedIndexV3Base):
         for row_id in range(ROW_COUNT):
             row = {"id": row_id}
             for field_name in BM25_INDEX_FIELDS:
-                document_factory = _bm25_jieba_document if field_name == "bm25_sindi_jieba" else _bm25_document
-                row[f"text_{field_name}"] = document_factory(row_id)
+                row[f"text_{field_name}"] = _bm25_document(row_id)
             rows.append(row)
         self.insert(client, self.collection_name, data=rows)
         self.flush(client, self.collection_name)
@@ -696,31 +510,6 @@ class TestSparseInvertedIndexV3BM25Shared(_SparseInvertedIndexV3Base):
 
         request.addfinalizer(teardown)
 
-    @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.parametrize("field_name", ["bm25_sindi", "bm25_sindi_low", "bm25_sindi_high"])
-    def test_bm25_sindi_search_with_bm25_parameter_combinations(self, field_name):
-        """
-        target: verify full text search works on SINDI indexes with explicit BM25 parameter combinations
-        method: search a fixed standard-analyzer token using three k1/b configurations
-        expected: matching documents are returned and k1/b-sensitive rankings are preserved
-        """
-        client = self._client(alias=self.shared_alias)
-        hits = self._search_hits(
-            client,
-            self.collection_name,
-            field_name,
-            ["alpha"],
-            metric_type="BM25",
-            limit=10,
-        )
-        assert set(self._hit_ids(hits)) == {0, 1, 2}
-        self._assert_scores_descending(hits)
-        self._assert_index_params(client, self.collection_name, field_name, BM25_INDEX_FIELDS[field_name])
-        if field_name == "bm25_sindi_high":
-            assert self._hit_ids(hits)[:2] == [2, 0]
-        else:
-            assert self._hit_ids(hits)[:2] == [0, 2]
-
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("field_name", ["bm25_u16", "bm25_u32"])
     def test_bm25_quant_type_search(self, field_name):
@@ -741,54 +530,6 @@ class TestSparseInvertedIndexV3BM25Shared(_SparseInvertedIndexV3Base):
         assert set(self._hit_ids(hits)) == {0, 1, 2}
         self._assert_scores_descending(hits)
         self._assert_index_params(client, self.collection_name, field_name, BM25_INDEX_FIELDS[field_name])
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_bm25_sindi_uses_default_bm25_params_when_omitted(self):
-        """
-        target: verify BM25 index parameters remain optional on the user path
-        method: build SINDI without k1/b and search standard-analyzed text
-        expected: omitted parameters return the same search results as explicitly configured defaults
-        """
-        client = self._client(alias=self.shared_alias)
-        hits = self._search_hits(
-            client,
-            self.collection_name,
-            "bm25_sindi_implicit",
-            ["alpha"],
-            metric_type="BM25",
-            limit=10,
-        )
-        assert set(self._hit_ids(hits)) == {0, 1, 2}
-        self._assert_scores_descending(hits)
-        explicit_default = self._search_hits(
-            client,
-            self.collection_name,
-            "bm25_sindi",
-            ["alpha"],
-            metric_type="BM25",
-            limit=10,
-        )
-        assert self._hit_ids(hits) == self._hit_ids(explicit_default)
-        assert [hit["distance"] for hit in hits] == pytest.approx([hit["distance"] for hit in explicit_default])
-
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_bm25_sindi_search_with_jieba_analyzer(self):
-        """
-        target: verify SINDI BM25 works with a non-standard analyzer
-        method: search Chinese data analyzed with jieba using a matching query token
-        expected: only documents containing the query token are returned in score order
-        """
-        client = self._client(alias=self.shared_alias)
-        hits = self._search_hits(
-            client,
-            self.collection_name,
-            "bm25_sindi_jieba",
-            ["稀疏"],
-            metric_type="BM25",
-            limit=10,
-        )
-        assert set(self._hit_ids(hits)) == {0, 1, 2}
-        self._assert_scores_descending(hits)
 
 
 @pytest.mark.tags(CaseLabel.L1)
@@ -816,7 +557,6 @@ class TestSparseInvertedIndexV3LifecycleShared(_SparseInvertedIndexV3Base):
             row = {"id": row_id}
             for field_name in LIFECYCLE_ENCODING_INDEX_FIELDS:
                 row[field_name] = _ip_vector(row_id)
-            row[DROP_RATIO_EFFECT_FIELD] = _drop_ratio_effect_vector(row_id)
             rows.append(row)
         self.insert(client, self.collection_name, data=rows)
         self.flush(client, self.collection_name)
@@ -853,7 +593,7 @@ class TestSparseInvertedIndexV3LifecycleShared(_SparseInvertedIndexV3Base):
     def test_encoding_search_stable_after_release_reload(self):
         """
         target: verify encoded sparse index data remains usable across a collection reload
-        method: search streamvbyte, maskedvbyte, and SINDI fields before and after release/load
+        method: search streamvbyte and maskedvbyte fields before and after release/load
         expected: each encoding returns the same IDs and distances after reload
         """
         client = self._client(alias=self.shared_alias)
@@ -920,35 +660,6 @@ class TestSparseInvertedIndexV3LifecycleShared(_SparseInvertedIndexV3Base):
                 assert index_info.get("mmap.enabled") is None
             self.load_collection(client, collection_name)
 
-    @pytest.mark.tags(CaseLabel.L1)
-    def test_sindi_drop_ratio_search_changes_effective_query(self):
-        """
-        target: verify SINDI applies drop_ratio_search instead of only accepting the parameter
-        method: compare a query whose top hit changes when low-weight dimensions are dropped
-        expected: drop_ratio_search=0.4 changes the ranking produced by drop_ratio_search=0.0
-        """
-        client = self._client(alias=self.shared_alias)
-        no_drop = self._search_hits(
-            client,
-            self.collection_name,
-            DROP_RATIO_EFFECT_FIELD,
-            [DROP_RATIO_EFFECT_QUERY],
-            limit=3,
-            params={"drop_ratio_search": 0.0},
-        )
-        with_drop = self._search_hits(
-            client,
-            self.collection_name,
-            DROP_RATIO_EFFECT_FIELD,
-            [DROP_RATIO_EFFECT_QUERY],
-            limit=3,
-            params={"drop_ratio_search": 0.4},
-        )
-
-        assert no_drop[0]["id"] == 1
-        assert with_drop[0]["id"] == 0
-        assert self._hit_ids(no_drop) != self._hit_ids(with_drop)
-
 
 @pytest.mark.xdist_group("TestSparseInvertedIndexV3Negative")
 @pytest.mark.tags(CaseLabel.L2)
@@ -973,8 +684,6 @@ class TestSparseInvertedIndexV3Negative(_SparseInvertedIndexV3Base):
             "bad_ip_quant",
             "bad_ip_quant_literal",
             "bad_algo",
-            "bad_window_low",
-            "bad_window_high",
             "bad_codec",
             "bad_block_size_zero",
             "bad_block_size_negative",
@@ -1095,23 +804,6 @@ class TestSparseInvertedIndexV3Negative(_SparseInvertedIndexV3Base):
             "IP",
             {"inverted_index_algo": "INVALID_ALGO"},
             "sparse inverted index algo INVALID_ALGO not found or not supported",
-        )
-
-    @pytest.mark.parametrize(
-        "field_name, window_size",
-        [("bad_window_low", 512), ("bad_window_high", 65536)],
-    )
-    def test_sindi_rejects_invalid_window_size(self, field_name, window_size):
-        """
-        target: verify SINDI rejects out-of-range docid window sizes
-        method: create SINDI indexes below and above the valid window range
-        expected: index creation fails and reports the SINDI window parameter
-        """
-        self._assert_create_index_fails(
-            field_name,
-            "IP",
-            {"inverted_index_algo": "SINDI", "sindi_window_size": window_size},
-            "sindi_window_size",
         )
 
     def test_sparse_index_rejects_invalid_codec(self):


### PR DESCRIPTION
## Summary

Remove sparse SINDI coverage and JSON-path STL_SORT/BITMAP cases that are not supported by the 3.0 branch defaults, while preserving the remaining sparse and scalar index coverage.

issue: #42937

/kind branch-feature
