### PR TITLE
fix: [cp3.0]gate collection-rooted index layout behind an explicit opt-in

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -797,6 +797,10 @@ dataCoord:
   syncSegmentsInterval: 300 # The time interval for regularly syncing segments
   index:
     memSizeEstimateMultiplier: 2 # When the memory size is not setup by index procedure, multiplier to estimate the memory size of index data
+    # Object storage layout for newly built segment index files. 0: index_files/{buildID}/{indexVersion}/{partitionID}/{segmentID}, 1: index_v1/{collectionID}/{partitionID}/{segmentID}/{buildID}/{indexVersion}.
+    # Layout 1 cannot be read by 2.6, so enabling it commits the upgrade and gives up the ability to roll back to 2.6. Existing index files keep the layout they were built with, so this switch only affects index files built from now on.
+    # Layout 1 is additionally gated on every QueryNode having been upgraded, so setting this to 1 in a mixed-version cluster still builds layout 0 until the upgrade finishes.
+    storePathVersion: 0
   enableGarbageCollection: true # Switch value to control if to enable garbage collection to clear the discarded data in MinIO or S3 service.
   gc:
     interval: 3600 # The interval at which data coord performs garbage collection, unit: second.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -797,9 +797,9 @@ dataCoord:
   syncSegmentsInterval: 300 # The time interval for regularly syncing segments
   index:
     memSizeEstimateMultiplier: 2 # When the memory size is not setup by index procedure, multiplier to estimate the memory size of index data
-    # Object storage layout for newly built segment index files. 0: index_files/{buildID}/{indexVersion}/{partitionID}/{segmentID}, 1: index_v1/{collectionID}/{partitionID}/{segmentID}/{buildID}/{indexVersion}.
+    # Object storage layout for newly built segment index files. 0: index_files/{buildID}/{indexVersion}/{partitionID}/{segmentID}, 1: index_v1/{collectionID}/{partitionID}/{segmentID}/{buildID}/{indexVersion}. Any other value falls back to 0.
     # Layout 1 cannot be read by 2.6, so enabling it commits the upgrade and gives up the ability to roll back to 2.6. Existing index files keep the layout they were built with, so this switch only affects index files built from now on.
-    # Layout 1 is additionally gated on every QueryNode having been upgraded, so setting this to 1 in a mixed-version cluster still builds layout 0 until the upgrade finishes.
+    # Layout 1 is additionally gated on no QueryNode still reporting an older release line, so setting this to 1 during a 2.6 -> 3.0 upgrade still builds layout 0 until every QueryNode is upgraded. That check reads the version each QueryNode publishes in its session, which is a per-release-line constant, so it separates 2.6.x from 3.0.x but does not differentiate binaries within the same release line.
     storePathVersion: 0
   enableGarbageCollection: true # Switch value to control if to enable garbage collection to clear the discarded data in MinIO or S3 service.
   gc:

--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
+	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 )
 
 // IndexEngineVersionManager manages the index engine versions reported by all QueryNodes in the cluster.
@@ -125,7 +126,22 @@ func (m *versionManagerImpl) Update(session *sessionutil.Session) {
 	m.addOrUpdate(session)
 }
 
+// GetClusterMinIndexStorePathVersion returns the index file layout to use for new index builds.
+//
+// COLLECTION_ROOTED requires BOTH:
+//   - the operator to opt in via dataCoord.index.storePathVersion, because a binary older than
+//     this one cannot read that layout and the opt-in is what gives up rollback compatibility;
+//   - every QueryNode to already run this version, because QueryNodes rebuild the remote index
+//     prefix themselves (storage/FileManager.h GetRemoteIndexObjectPrefix), so an older one
+//     would look for the files under the legacy layout.
+//
+// Falling back to BUILD_ROOTED is always safe: the layout is recorded per SegmentIndex, so
+// records built earlier keep being read and GC'd under the layout they were built with.
 func (m *versionManagerImpl) GetClusterMinIndexStorePathVersion() indexpb.IndexStorePathVersion {
+	if !metautil.IsCollectionRooted(indexpb.IndexStorePathVersion(Params.DataCoordCfg.IndexStorePathVersion.GetAsInt32())) {
+		return indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/datacoord/index_engine_version_manager.go
+++ b/internal/datacoord/index_engine_version_manager.go
@@ -3,6 +3,8 @@ package datacoord
 import (
 	"context"
 	"math"
+	"strconv"
+	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/samber/lo"
@@ -13,7 +15,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
-	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 )
 
 // IndexEngineVersionManager manages the index engine versions reported by all QueryNodes in the cluster.
@@ -126,19 +127,41 @@ func (m *versionManagerImpl) Update(session *sessionutil.Session) {
 	m.addOrUpdate(session)
 }
 
+// configuredIndexStorePathVersion parses dataCoord.index.storePathVersion. Only the two layouts
+// the enum defines are accepted; anything else (including a malformed value, which the paramtable
+// getters silently coerce to 0) falls back to the legacy layout and is logged, so an operator typo
+// is visible instead of being read as an opt-in.
+func configuredIndexStorePathVersion() indexpb.IndexStorePathVersion {
+	raw := Params.DataCoordCfg.IndexStorePathVersion.GetValue()
+	parsed, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 32)
+	if err == nil {
+		switch version := indexpb.IndexStorePathVersion(parsed); version {
+		case indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED,
+			indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_COLLECTION_ROOTED:
+			return version
+		}
+	}
+	mlog.RatedWarn(context.TODO(), rate.Limit(60), "unsupported dataCoord.index.storePathVersion, falling back to the legacy index layout",
+		mlog.String("value", raw))
+	return indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED
+}
+
 // GetClusterMinIndexStorePathVersion returns the index file layout to use for new index builds.
 //
 // COLLECTION_ROOTED requires BOTH:
 //   - the operator to opt in via dataCoord.index.storePathVersion, because a binary older than
 //     this one cannot read that layout and the opt-in is what gives up rollback compatibility;
-//   - every QueryNode to already run this version, because QueryNodes rebuild the remote index
-//     prefix themselves (storage/FileManager.h GetRemoteIndexObjectPrefix), so an older one
-//     would look for the files under the legacy layout.
+//   - no QueryNode to still report an older release line, because QueryNodes rebuild the remote
+//     index prefix themselves (storage/FileManager.h GetRemoteIndexObjectPrefix), so an older one
+//     would look for the files under the legacy layout. The comparison below is against the
+//     version each QueryNode publishes in its session, which is the compile-time common.Version
+//     constant, so it only separates release lines (2.6.x vs 3.0.x): two binaries on the same
+//     line report the identical version and cannot be told apart here.
 //
 // Falling back to BUILD_ROOTED is always safe: the layout is recorded per SegmentIndex, so
 // records built earlier keep being read and GC'd under the layout they were built with.
 func (m *versionManagerImpl) GetClusterMinIndexStorePathVersion() indexpb.IndexStorePathVersion {
-	if !metautil.IsCollectionRooted(indexpb.IndexStorePathVersion(Params.DataCoordCfg.IndexStorePathVersion.GetAsInt32())) {
+	if configuredIndexStorePathVersion() != indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_COLLECTION_ROOTED {
 		return indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED
 	}
 

--- a/internal/datacoord/index_engine_version_manager_test.go
+++ b/internal/datacoord/index_engine_version_manager_test.go
@@ -63,6 +63,10 @@ func Test_IndexEngineVersionManager_GetMergedIndexVersion(t *testing.T) {
 }
 
 func Test_IndexEngineVersionManager_IndexStorePathVersionCapabilityFromSessionVersion(t *testing.T) {
+	// the collection-rooted layout is opt-in; this test covers the session-version half of the gate.
+	paramtable.Get().Save(Params.DataCoordCfg.IndexStorePathVersion.Key, "1")
+	defer paramtable.Get().Reset(Params.DataCoordCfg.IndexStorePathVersion.Key)
+
 	m := newIndexEngineVersionManager()
 	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED, m.GetClusterMinIndexStorePathVersion())
 
@@ -94,6 +98,36 @@ func Test_IndexEngineVersionManager_IndexStorePathVersionCapabilityFromSessionVe
 
 	m.RemoveNode(&sessionutil.Session{SessionRaw: sessionutil.SessionRaw{ServerID: 3}})
 	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_COLLECTION_ROOTED, m.GetClusterMinIndexStorePathVersion())
+}
+
+func Test_IndexEngineVersionManager_IndexStorePathVersionConfigGate(t *testing.T) {
+	key := Params.DataCoordCfg.IndexStorePathVersion.Key
+	defer paramtable.Get().Reset(key)
+
+	// a fully upgraded cluster, so only the config decides the layout
+	m := newIndexEngineVersionManager()
+	m.Startup(map[string]*sessionutil.Session{
+		"qn1": {
+			Version:    common.Version,
+			SessionRaw: sessionutil.SessionRaw{ServerID: 1},
+		},
+	})
+
+	// default: legacy layout, so an upgrade never silently writes files an older binary cannot read
+	assert.Equal(t, "0", Params.DataCoordCfg.IndexStorePathVersion.GetValue())
+	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED, m.GetClusterMinIndexStorePathVersion())
+
+	// opted in
+	paramtable.Get().Save(key, "1")
+	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_COLLECTION_ROOTED, m.GetClusterMinIndexStorePathVersion())
+
+	// refreshable, and turning it back off is safe because the layout is recorded per SegmentIndex
+	paramtable.Get().Save(key, "0")
+	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED, m.GetClusterMinIndexStorePathVersion())
+
+	// a malformed value must fall back to the legacy layout, not to the opt-in one
+	paramtable.Get().Save(key, "not-a-number")
+	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED, m.GetClusterMinIndexStorePathVersion())
 }
 
 func Test_IndexEngineVersionManager_GetMergedScalarIndexVersion(t *testing.T) {

--- a/internal/datacoord/index_engine_version_manager_test.go
+++ b/internal/datacoord/index_engine_version_manager_test.go
@@ -128,6 +128,13 @@ func Test_IndexEngineVersionManager_IndexStorePathVersionConfigGate(t *testing.T
 	// a malformed value must fall back to the legacy layout, not to the opt-in one
 	paramtable.Get().Save(key, "not-a-number")
 	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED, m.GetClusterMinIndexStorePathVersion())
+
+	// an out-of-range value is not a layout this binary knows, so it must not be read as opting in
+	paramtable.Get().Save(key, "2")
+	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED, m.GetClusterMinIndexStorePathVersion())
+
+	paramtable.Get().Save(key, "-1")
+	assert.Equal(t, indexpb.IndexStorePathVersion_INDEX_STORE_PATH_VERSION_BUILD_ROOTED, m.GetClusterMinIndexStorePathVersion())
 }
 
 func Test_IndexEngineVersionManager_GetMergedScalarIndexVersion(t *testing.T) {

--- a/internal/datacoord/server_test.go
+++ b/internal/datacoord/server_test.go
@@ -2550,9 +2550,12 @@ func TestServer_initServiceDiscovery_BindIndexNodeDoesNotAffectQueryNodePathVers
 	paramtable.Get().Save(Params.DataCoordCfg.BindIndexNodeMode.Key, "true")
 	paramtable.Get().Save(Params.DataCoordCfg.IndexNodeID.Key, "10001")
 	paramtable.Get().Save(Params.DataCoordCfg.IndexNodeAddress.Key, "localhost:10001")
+	// the collection-rooted layout is opt-in; this test covers the QueryNode-session half of the gate
+	paramtable.Get().Save(Params.DataCoordCfg.IndexStorePathVersion.Key, "1")
 	defer paramtable.Get().Reset(Params.DataCoordCfg.BindIndexNodeMode.Key)
 	defer paramtable.Get().Reset(Params.DataCoordCfg.IndexNodeID.Key)
 	defer paramtable.Get().Reset(Params.DataCoordCfg.IndexNodeAddress.Key)
+	defer paramtable.Get().Reset(Params.DataCoordCfg.IndexStorePathVersion.Key)
 
 	mockSession := sessionutil.NewMockSession(t)
 	mockSession.EXPECT().

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5250,6 +5250,7 @@ type dataCoordConfig struct {
 
 	// Index related configuration
 	IndexMemSizeEstimateMultiplier      ParamItem `refreshable:"true"`
+	IndexStorePathVersion               ParamItem `refreshable:"true"`
 	HybridIndexLowCardinalityIndexType  ParamItem `refreshable:"true"`
 	HybridIndexHighCardinalityIndexType ParamItem `refreshable:"true"`
 
@@ -5970,6 +5971,17 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.IndexMemSizeEstimateMultiplier.Init(base.mgr)
+
+	p.IndexStorePathVersion = ParamItem{
+		Key:          "dataCoord.index.storePathVersion",
+		Version:      "3.0.0",
+		DefaultValue: "0",
+		Doc: `Object storage layout for newly built segment index files. 0: index_files/{buildID}/{indexVersion}/{partitionID}/{segmentID}, 1: index_v1/{collectionID}/{partitionID}/{segmentID}/{buildID}/{indexVersion}.
+Layout 1 cannot be read by 2.6, so enabling it commits the upgrade and gives up the ability to roll back to 2.6. Existing index files keep the layout they were built with, so this switch only affects index files built from now on.
+Layout 1 is additionally gated on every QueryNode having been upgraded, so setting this to 1 in a mixed-version cluster still builds layout 0 until the upgrade finishes.`,
+		Export: true,
+	}
+	p.IndexStorePathVersion.Init(base.mgr)
 
 	p.HybridIndexLowCardinalityIndexType = ParamItem{
 		Key:          "dataCoord.index.hybridIndex.lowCardinalityIndexType",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5976,9 +5976,9 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Key:          "dataCoord.index.storePathVersion",
 		Version:      "3.0.0",
 		DefaultValue: "0",
-		Doc: `Object storage layout for newly built segment index files. 0: index_files/{buildID}/{indexVersion}/{partitionID}/{segmentID}, 1: index_v1/{collectionID}/{partitionID}/{segmentID}/{buildID}/{indexVersion}.
+		Doc: `Object storage layout for newly built segment index files. 0: index_files/{buildID}/{indexVersion}/{partitionID}/{segmentID}, 1: index_v1/{collectionID}/{partitionID}/{segmentID}/{buildID}/{indexVersion}. Any other value falls back to 0.
 Layout 1 cannot be read by 2.6, so enabling it commits the upgrade and gives up the ability to roll back to 2.6. Existing index files keep the layout they were built with, so this switch only affects index files built from now on.
-Layout 1 is additionally gated on every QueryNode having been upgraded, so setting this to 1 in a mixed-version cluster still builds layout 0 until the upgrade finishes.`,
+Layout 1 is additionally gated on no QueryNode still reporting an older release line, so setting this to 1 during a 2.6 -> 3.0 upgrade still builds layout 0 until every QueryNode is upgraded. That check reads the version each QueryNode publishes in its session, which is a per-release-line constant, so it separates 2.6.x from 3.0.x but does not differentiate binaries within the same release line.`,
 		Export: true,
 	}
 	p.IndexStorePathVersion.Init(base.mgr)


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #51802
issue: #51788

## Summary

Cherry-picked from master PR #51802 (open - preemptive backport).

Gates the collection-rooted index layout (`index_v1`) behind `dataCoord.index.storePathVersion`, defaulting to `0` (legacy build-rooted) on 3.0.x. This stops a `2.6 -> 3.0` upgrade from silently writing index files a 2.6 binary cannot address, which otherwise leaves collections query-unserviceable after rolling back to 2.6.

Only `0` and `1` are accepted; any other value — including a malformed string, which the paramtable getters silently coerce to `0` — falls back to layout 0 and logs a rated warning. The QueryNode half of the gate compares the version each QueryNode publishes in its session, which is the compile-time `common.Version` constant, so it separates release lines (2.6.x vs 3.0.x) but does not differentiate binaries within the same release line; the config doc and code comment say so explicitly.

A brand-new 3.0 cluster previously enabled the collection-rooted layout automatically, so with this change a fresh 3.0 deployment builds indexes under the legacy `index_files/` layout until the config is explicitly set to `1`.

**Note**: Original PR is still open (under review). This CP PR should be updated if the original PR changes.

## Verification

- [x] Re-synced with master PR #51802 after its review follow-up commit (unsupported-value rejection + gate doc rewording).
- [x] File count matches original PR (5 files)
- [x] Changed lines identical to master PR
- [x] No conflict markers
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/datacoord/ -run 'Test_IndexEngineVersionManager|TestServer_initServiceDiscovery_BindIndexNodeDoesNotAffectQueryNodePathVersion'` green on this branch.
- [ ] make static-check (skipped by cherry-pick workflow)

