### PR TITLE
enhance: [3.0] support nullable struct arrays in Go SDK and REST v2

### DIFF
--- a/client/column/array.go
+++ b/client/column/array.go
@@ -212,3 +212,9 @@ func NewColumnVarCharArray(fieldName string, data [][]string) *ColumnVarCharArra
 		columnArrayBase: newArrayBase(fieldName, data, entity.FieldTypeVarChar),
 	}
 }
+
+func (c *ColumnVarCharArray) Slice(start, end int) Column {
+	return &ColumnVarCharArray{
+		columnArrayBase: c.columnArrayBase.slice(start, end),
+	}
+}

--- a/client/column/array_test.go
+++ b/client/column/array_test.go
@@ -281,6 +281,13 @@ func (s *ArraySuite) TestBasic() {
 			s.Equal(row, sf.GetStringData().GetData())
 		}
 
+		sliced := column.Slice(0, -1)
+		s.IsType((*ColumnVarCharArray)(nil), sliced)
+		s.Require().NoError(sliced.AppendValue([]string{"after_slice"}))
+		s.NotPanics(func() {
+			sliced.FieldData()
+		})
+
 		result, err := FieldDataColumn(fd, 0, -1)
 		s.NoError(err)
 		parsed, ok := result.(*ColumnVarCharArray)

--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -180,18 +180,8 @@ func parseStructArrayData(fieldName string, structArray *schemapb.StructArrayFie
 
 // parseVectorArrayData converts schemapb.VectorArray (per-row list of vectors) into the
 // matching ColumnXxxVectorArray. Used for ArrayOfVector sub-fields of struct arrays.
-func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, begin, end int) (Column, error) {
+func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, validData []bool, begin, end int) (Column, error) {
 	rows := va.GetData()
-	if end < 0 || end > len(rows) {
-		end = len(rows)
-	}
-	if begin < 0 {
-		begin = 0
-	}
-	if begin > end {
-		begin = end
-	}
-	rows = rows[begin:end]
 	// VectorArray.Dim may be 0 in server search responses; fall back to inner VectorField.Dim.
 	dim := int(va.GetDim())
 	if dim == 0 {
@@ -206,6 +196,64 @@ func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, begin, end
 		return nil, fmt.Errorf("vector array %q has unknown dim", fieldName)
 	}
 
+	nullable := validData != nil
+	sparseMode := false
+	logicalLen := len(rows)
+	if nullable {
+		logicalLen = len(validData)
+		switch len(rows) {
+		case logicalLen:
+			// Query results are row-dense and keep an empty placeholder for null rows.
+			sparseMode = true
+		case countValid(validData):
+			// Insert FieldData keeps only valid payload rows.
+			sparseMode = false
+		default:
+			return nil, fmt.Errorf("vector array %q payload row count %d does not match logical row count %d or valid count %d",
+				fieldName, len(rows), logicalLen, countValid(validData))
+		}
+	}
+	if begin < 0 {
+		begin = 0
+	}
+	if begin > logicalLen {
+		begin = logicalLen
+	}
+	if end < 0 || end > logicalLen {
+		end = logicalLen
+	}
+	if begin > end {
+		begin = end
+	}
+	selectedValidData := validData
+	if nullable {
+		selectedValidData = validData[begin:end]
+		if sparseMode {
+			rows = rows[begin:end]
+		} else {
+			valueBegin := countValid(validData[:begin])
+			valueEnd := valueBegin + countValid(selectedValidData)
+			rows = rows[valueBegin:valueEnd]
+		}
+	} else {
+		rows = rows[begin:end]
+	}
+	finish := func(column Column) (Column, error) {
+		if !nullable {
+			return column, nil
+		}
+		vectorColumn, ok := column.(interface {
+			setNullableData([]bool, bool) error
+		})
+		if !ok {
+			return nil, fmt.Errorf("vector array %q column does not support nullable data", fieldName)
+		}
+		if err := vectorColumn.setNullableData(selectedValidData, sparseMode); err != nil {
+			return nil, errors.Wrapf(err, "invalid vector array %q nullable data", fieldName)
+		}
+		return column, nil
+	}
+
 	switch va.GetElementType() {
 	case schemapb.DataType_FloatVector:
 		out, err := splitVectorArrayRows(fieldName, rows, dim, func(vf *schemapb.VectorField) []float32 {
@@ -218,7 +266,7 @@ func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, begin, end
 		if err != nil {
 			return nil, err
 		}
-		return NewColumnFloatVectorArray(fieldName, dim, out), nil
+		return finish(NewColumnFloatVectorArray(fieldName, dim, out))
 
 	case schemapb.DataType_Float16Vector:
 		out, err := splitVectorArrayRows(fieldName, rows, dim*2, func(vf *schemapb.VectorField) []byte {
@@ -227,7 +275,7 @@ func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, begin, end
 		if err != nil {
 			return nil, err
 		}
-		return NewColumnFloat16VectorArray(fieldName, dim, out), nil
+		return finish(NewColumnFloat16VectorArray(fieldName, dim, out))
 
 	case schemapb.DataType_BFloat16Vector:
 		out, err := splitVectorArrayRows(fieldName, rows, dim*2, func(vf *schemapb.VectorField) []byte {
@@ -236,7 +284,7 @@ func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, begin, end
 		if err != nil {
 			return nil, err
 		}
-		return NewColumnBFloat16VectorArray(fieldName, dim, out), nil
+		return finish(NewColumnBFloat16VectorArray(fieldName, dim, out))
 
 	case schemapb.DataType_BinaryVector:
 		if dim%8 != 0 {
@@ -248,7 +296,7 @@ func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, begin, end
 		if err != nil {
 			return nil, err
 		}
-		return NewColumnBinaryVectorArray(fieldName, dim, out), nil
+		return finish(NewColumnBinaryVectorArray(fieldName, dim, out))
 
 	case schemapb.DataType_Int8Vector:
 		out, err := splitVectorArrayRows(fieldName, rows, dim, func(vf *schemapb.VectorField) []byte {
@@ -263,7 +311,7 @@ func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, begin, end
 		if err != nil {
 			return nil, err
 		}
-		return NewColumnInt8VectorArray(fieldName, dim, out), nil
+		return finish(NewColumnInt8VectorArray(fieldName, dim, out))
 
 	default:
 		return nil, fmt.Errorf("unsupported vector array element type %s", va.GetElementType())
@@ -370,7 +418,7 @@ func FieldDataColumn(fd *schemapb.FieldData, begin, end int) (Column, error) {
 		if va == nil {
 			return nil, errFieldDataTypeNotMatch
 		}
-		return parseVectorArrayData(fd.GetFieldName(), va, begin, end)
+		return parseVectorArrayData(fd.GetFieldName(), va, validData, begin, end)
 
 	case schemapb.DataType_JSON:
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetJsonData().GetData(), begin, end, validData, NewColumnJSONBytes, NewNullableColumnJSONBytes)

--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -171,7 +171,11 @@ func parseStructArrayData(fieldName string, structArray *schemapb.StructArrayFie
 		}
 		fields = append(fields, field)
 	}
-	return NewColumnStructArray(fieldName, fields), nil
+	column := NewColumnStructArray(fieldName, fields)
+	if err := column.ValidateNullable(); err != nil {
+		return nil, errors.Wrapf(err, "invalid struct array %q", fieldName)
+	}
+	return column, nil
 }
 
 // parseVectorArrayData converts schemapb.VectorArray (per-row list of vectors) into the

--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -95,7 +95,7 @@ func parseScalarData[T any, COL Column, NCOL Column](
 	nullableCreator func(string, []T, []bool, ...ColumnOption[T]) (NCOL, error),
 ) (Column, error) {
 	logicalLen := len(data)
-	if len(validData) > 0 {
+	if validData != nil {
 		logicalLen = len(validData)
 	}
 	if start < 0 {
@@ -111,7 +111,7 @@ func parseScalarData[T any, COL Column, NCOL Column](
 		start = end
 	}
 
-	if len(validData) > 0 {
+	if validData != nil {
 		validCount := countValid(validData)
 		sparseMode := false
 		switch len(data) {

--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -94,16 +94,48 @@ func parseScalarData[T any, COL Column, NCOL Column](
 	creator func(string, []T) COL,
 	nullableCreator func(string, []T, []bool, ...ColumnOption[T]) (NCOL, error),
 ) (Column, error) {
-	if end < 0 {
-		end = len(data)
-	}
-	data = data[start:end]
+	logicalLen := len(data)
 	if len(validData) > 0 {
-		validData = validData[start:end]
-		ncol, err := nullableCreator(name, data, validData, WithSparseNullableMode[T](true))
+		logicalLen = len(validData)
+	}
+	if start < 0 {
+		start = 0
+	}
+	if start > logicalLen {
+		start = logicalLen
+	}
+	if end < 0 || end > logicalLen {
+		end = logicalLen
+	}
+	if start > end {
+		start = end
+	}
+
+	if len(validData) > 0 {
+		validCount := countValid(validData)
+		sparseMode := false
+		switch len(data) {
+		case logicalLen:
+			sparseMode = true
+		case validCount:
+		default:
+			return nil, fmt.Errorf("scalar field %q payload row count %d does not match logical row count %d or valid count %d",
+				name, len(data), logicalLen, validCount)
+		}
+
+		selectedValidData := validData[start:end]
+		if sparseMode {
+			data = data[start:end]
+		} else {
+			valueStart := countValid(validData[:start])
+			valueEnd := valueStart + countValid(selectedValidData)
+			data = data[valueStart:valueEnd]
+		}
+		ncol, err := nullableCreator(name, data, selectedValidData, WithSparseNullableMode[T](sparseMode))
 		return ncol, err
 	}
 
+	data = data[start:end]
 	return creator(name, data), nil
 }
 

--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -132,7 +132,13 @@ func parseScalarData[T any, COL Column, NCOL Column](
 			data = data[valueStart:valueEnd]
 		}
 		ncol, err := nullableCreator(name, data, selectedValidData, WithSparseNullableMode[T](sparseMode))
-		return ncol, err
+		if err != nil {
+			return nil, err
+		}
+		// An empty nullable slice has no validity bits, but it must retain the
+		// nullable schema state for its parent struct array.
+		ncol.SetNullable(true)
+		return ncol, ncol.ValidateNullable()
 	}
 
 	data = data[start:end]

--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -104,23 +104,21 @@ func parseScalarData[T any, COL Column, NCOL Column](
 	}
 
 	if validData != nil {
-		validCount := countValid(validData)
-		sparseMode := false
-		switch len(data) {
-		case logicalLen:
-			sparseMode = true
-		case validCount:
-		default:
-			return nil, fmt.Errorf("scalar field %q payload row count %d does not match logical row count %d or valid count %d",
-				name, len(data), logicalLen, validCount)
+		sparseMode := len(data) == logicalLen
+		valueStart, valueEnd := start, end
+		if !sparseMode {
+			var validCount int
+			valueStart, valueEnd, validCount = countValidBounds(validData, start, end)
+			if len(data) != validCount {
+				return nil, fmt.Errorf("scalar field %q payload row count %d does not match logical row count %d or valid count %d",
+					name, len(data), logicalLen, validCount)
+			}
 		}
 
 		selectedValidData := validData[start:end]
 		if sparseMode {
 			data = data[start:end]
 		} else {
-			valueStart := countValid(validData[:start])
-			valueEnd := valueStart + countValid(selectedValidData)
 			data = data[valueStart:valueEnd]
 		}
 		ncol, err := nullableCreator(name, data, selectedValidData, WithSparseNullableMode[T](sparseMode))
@@ -135,6 +133,25 @@ func parseScalarData[T any, COL Column, NCOL Column](
 
 	data = data[start:end]
 	return creator(name, data), nil
+}
+
+func countValidBounds(validData []bool, start, end int) (int, int, int) {
+	valueStart := 0
+	valueEnd := 0
+	validCount := 0
+	for idx, valid := range validData {
+		if !valid {
+			continue
+		}
+		validCount++
+		if idx < start {
+			valueStart++
+		}
+		if idx < end {
+			valueEnd++
+		}
+	}
+	return valueStart, valueEnd, validCount
 }
 
 func normalizeFieldDataRange(fieldName string, start, end, logicalLen int) (int, int, error) {
@@ -246,21 +263,24 @@ func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, validData 
 	logicalLen := len(rows)
 	if nullable {
 		logicalLen = len(validData)
-		switch len(rows) {
-		case logicalLen:
-			// Query results are row-dense and keep an empty placeholder for null rows.
-			sparseMode = true
-		case countValid(validData):
-			// Insert FieldData keeps only valid payload rows.
-			sparseMode = false
-		default:
-			return nil, fmt.Errorf("vector array %q payload row count %d does not match logical row count %d or valid count %d",
-				fieldName, len(rows), logicalLen, countValid(validData))
-		}
 	}
 	begin, end, err := normalizeFieldDataRange(fieldName, begin, end, logicalLen)
 	if err != nil {
 		return nil, err
+	}
+
+	valueBegin, valueEnd := begin, end
+	if nullable {
+		// Query results are row-dense and keep an empty placeholder for null rows.
+		sparseMode = len(rows) == logicalLen
+		if !sparseMode {
+			var validCount int
+			valueBegin, valueEnd, validCount = countValidBounds(validData, begin, end)
+			if len(rows) != validCount {
+				return nil, fmt.Errorf("vector array %q payload row count %d does not match logical row count %d or valid count %d",
+					fieldName, len(rows), logicalLen, validCount)
+			}
+		}
 	}
 	selectedValidData := validData
 	if nullable {
@@ -268,8 +288,6 @@ func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, validData 
 		if sparseMode {
 			rows = rows[begin:end]
 		} else {
-			valueBegin := countValid(validData[:begin])
-			valueEnd := valueBegin + countValid(selectedValidData)
 			rows = rows[valueBegin:valueEnd]
 		}
 	} else {

--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -98,17 +98,9 @@ func parseScalarData[T any, COL Column, NCOL Column](
 	if validData != nil {
 		logicalLen = len(validData)
 	}
-	if start < 0 {
-		start = 0
-	}
-	if start > logicalLen {
-		start = logicalLen
-	}
-	if end < 0 || end > logicalLen {
-		end = logicalLen
-	}
-	if start > end {
-		start = end
+	start, end, err := normalizeFieldDataRange(name, start, end, logicalLen)
+	if err != nil {
+		return nil, err
 	}
 
 	if validData != nil {
@@ -143,6 +135,21 @@ func parseScalarData[T any, COL Column, NCOL Column](
 
 	data = data[start:end]
 	return creator(name, data), nil
+}
+
+func normalizeFieldDataRange(fieldName string, start, end, logicalLen int) (int, int, error) {
+	if start < 0 || start > logicalLen {
+		return 0, 0, fmt.Errorf("field %q row range start %d is outside [0, %d]", fieldName, start, logicalLen)
+	}
+	if end == -1 {
+		end = logicalLen
+	} else if end < 0 || end > logicalLen {
+		return 0, 0, fmt.Errorf("field %q row range end %d is outside [0, %d]", fieldName, end, logicalLen)
+	}
+	if start > end {
+		return 0, 0, fmt.Errorf("field %q row range [%d, %d) has start after end", fieldName, start, end)
+	}
+	return start, end, nil
 }
 
 func parseArrayData(fieldName string, elementType schemapb.DataType, fieldDataList []*schemapb.ScalarField, validData []bool, begin, end int) (Column, error) {
@@ -251,17 +258,9 @@ func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, validData 
 				fieldName, len(rows), logicalLen, countValid(validData))
 		}
 	}
-	if begin < 0 {
-		begin = 0
-	}
-	if begin > logicalLen {
-		begin = logicalLen
-	}
-	if end < 0 || end > logicalLen {
-		end = logicalLen
-	}
-	if begin > end {
-		begin = end
+	begin, end, err := normalizeFieldDataRange(fieldName, begin, end, logicalLen)
+	if err != nil {
+		return nil, err
 	}
 	selectedValidData := validData
 	if nullable {

--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -242,10 +242,15 @@ func parseStructArrayData(fieldName string, structArray *schemapb.StructArrayFie
 
 // parseVectorArrayData converts schemapb.VectorArray (per-row list of vectors) into the
 // matching ColumnXxxVectorArray. Used for ArrayOfVector sub-fields of struct arrays.
-func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, validData []bool, begin, end int) (Column, error) {
+func parseVectorArrayData(fieldName string, va *schemapb.VectorArray, outerDim int64, validData []bool, begin, end int) (Column, error) {
 	rows := va.GetData()
-	// VectorArray.Dim may be 0 in server search responses; fall back to inner VectorField.Dim.
+	// VectorArray.Dim may be 0 in server search responses. Prefer the outer
+	// VectorField dimension, which remains available when every row is null,
+	// then fall back to a non-empty inner row.
 	dim := int(va.GetDim())
+	if dim == 0 {
+		dim = int(outerDim)
+	}
 	if dim == 0 {
 		for _, vf := range rows {
 			if d := int(vf.GetDim()); d > 0 {
@@ -473,7 +478,7 @@ func FieldDataColumn(fd *schemapb.FieldData, begin, end int) (Column, error) {
 		if va == nil {
 			return nil, errFieldDataTypeNotMatch
 		}
-		return parseVectorArrayData(fd.GetFieldName(), va, validData, begin, end)
+		return parseVectorArrayData(fd.GetFieldName(), va, vectors.GetDim(), validData, begin, end)
 
 	case schemapb.DataType_JSON:
 		return parseScalarData(fd.GetFieldName(), fd.GetScalars().GetJsonData().GetData(), begin, end, validData, NewColumnJSONBytes, NewNullableColumnJSONBytes)

--- a/client/column/columns_test.go
+++ b/client/column/columns_test.go
@@ -173,3 +173,37 @@ func TestGetIntData(t *testing.T) {
 		})
 	}
 }
+
+func TestFieldDataColumnRejectsInvalidRange(t *testing.T) {
+	fd := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "age",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+				},
+			},
+		},
+	}
+
+	column, err := FieldDataColumn(fd, 1, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, column.Len())
+
+	for _, tc := range []struct {
+		name       string
+		begin, end int
+	}{
+		{name: "negative begin", begin: -1, end: 1},
+		{name: "begin past rows", begin: 4, end: 4},
+		{name: "unsupported negative end", begin: 0, end: -2},
+		{name: "end past rows", begin: 0, end: 4},
+		{name: "begin after end", begin: 2, end: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := FieldDataColumn(fd, tc.begin, tc.end)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/client/column/dynamic.go
+++ b/client/column/dynamic.go
@@ -45,6 +45,32 @@ func (c *ColumnDynamic) Slice(start, end int) Column {
 	)
 }
 
+// SliceColumns slices columns while preserving shared dynamic JSON storage.
+func SliceColumns(columns []Column, start, end int) []Column {
+	sliced := make([]Column, len(columns))
+	dynamicJSONSlices := make(map[*ColumnJSONBytes]*ColumnJSONBytes)
+	sliceJSON := func(source *ColumnJSONBytes) *ColumnJSONBytes {
+		if result, ok := dynamicJSONSlices[source]; ok {
+			return result
+		}
+		result := source.Slice(start, end).(*ColumnJSONBytes)
+		dynamicJSONSlices[source] = result
+		return result
+	}
+
+	for idx, source := range columns {
+		switch source := source.(type) {
+		case *ColumnDynamic:
+			sliced[idx] = NewColumnDynamic(sliceJSON(source.ColumnJSONBytes), source.outputField)
+		case *ColumnJSONBytes:
+			sliced[idx] = sliceJSON(source)
+		default:
+			sliced[idx] = source.Slice(start, end)
+		}
+	}
+	return sliced
+}
+
 // Get returns element at idx as interface{}.
 // Overrides internal json column behavior, returns raw json data.
 func (c *ColumnDynamic) Get(idx int) (interface{}, error) {

--- a/client/column/dynamic.go
+++ b/client/column/dynamic.go
@@ -38,6 +38,13 @@ func (c *ColumnDynamic) Name() string {
 	return c.outputField
 }
 
+func (c *ColumnDynamic) Slice(start, end int) Column {
+	return NewColumnDynamic(
+		c.ColumnJSONBytes.Slice(start, end).(*ColumnJSONBytes),
+		c.outputField,
+	)
+}
+
 // Get returns element at idx as interface{}.
 // Overrides internal json column behavior, returns raw json data.
 func (c *ColumnDynamic) Get(idx int) (interface{}, error) {

--- a/client/column/dynamic_test.go
+++ b/client/column/dynamic_test.go
@@ -41,6 +41,34 @@ func (s *ColumnDynamicSuite) TestSlicePreservesDynamicColumn() {
 	s.EqualValues(2, value)
 }
 
+func (s *ColumnDynamicSuite) TestSliceColumnsSharesDynamicJSONBase() {
+	base := NewColumnJSONBytes("$meta", [][]byte{
+		[]byte(`{"color": "red", "price": 10}`),
+		[]byte(`{"color": "blue", "price": 20}`),
+	}).WithIsDynamic(true)
+	color := NewColumnDynamic(base, "color")
+	price := NewColumnDynamic(base, "price")
+
+	sliced := SliceColumns([]Column{base, color, price}, 1, -1)
+	s.Require().Len(sliced, 3)
+	slicedBase, ok := sliced[0].(*ColumnJSONBytes)
+	s.Require().True(ok)
+	slicedColor, ok := sliced[1].(*ColumnDynamic)
+	s.Require().True(ok)
+	slicedPrice, ok := sliced[2].(*ColumnDynamic)
+	s.Require().True(ok)
+
+	s.Same(slicedBase, slicedColor.ColumnJSONBytes)
+	s.Same(slicedBase, slicedPrice.ColumnJSONBytes)
+	s.True(slicedBase.FieldData().GetIsDynamic())
+	colorValue, err := slicedColor.GetAsString(0)
+	s.Require().NoError(err)
+	s.Equal("blue", colorValue)
+	priceValue, err := slicedPrice.GetAsInt64(0)
+	s.Require().NoError(err)
+	s.EqualValues(20, priceValue)
+}
+
 func (s *ColumnDynamicSuite) TestGetInt() {
 	cases := []struct {
 		input       string

--- a/client/column/dynamic_test.go
+++ b/client/column/dynamic_test.go
@@ -26,6 +26,21 @@ type ColumnDynamicSuite struct {
 	suite.Suite
 }
 
+func (s *ColumnDynamicSuite) TestSlicePreservesDynamicColumn() {
+	column := NewColumnDynamic(NewColumnJSONBytes("", [][]byte{
+		[]byte(`{"field": 1}`),
+		[]byte(`{"field": 2}`),
+	}), "field")
+
+	sliced := column.Slice(1, -1)
+	dynamic, ok := sliced.(*ColumnDynamic)
+	s.Require().True(ok)
+	s.Equal("field", dynamic.Name())
+	value, err := dynamic.GetAsInt64(0)
+	s.Require().NoError(err)
+	s.EqualValues(2, value)
+}
+
 func (s *ColumnDynamicSuite) TestGetInt() {
 	cases := []struct {
 		input       string

--- a/client/column/generic_base.go
+++ b/client/column/generic_base.go
@@ -249,10 +249,14 @@ func (c *genericColumnBase[T]) SetNullable(nullable bool) {
 	if c.nullable && c.validData == nil {
 		// set valid flag for all exisiting values
 		c.validData = lo.RepeatBy(len(c.values), func(_ int) bool { return true })
+		if !c.sparseMode {
+			_ = c.validateNullableCompact()
+		}
 	}
 
 	if !c.nullable {
 		c.validData = nil
+		c.indexMapping = nil
 	}
 }
 

--- a/client/column/generic_base.go
+++ b/client/column/generic_base.go
@@ -221,7 +221,10 @@ func (c *genericColumnBase[T]) AppendNull() error {
 	}
 
 	c.validData = append(c.validData, false)
-	if !c.sparseMode {
+	if c.sparseMode {
+		var zero T
+		c.values = append(c.values, zero)
+	} else {
 		c.indexMapping = append(c.indexMapping, -1)
 	}
 	return nil
@@ -317,6 +320,7 @@ func (c *genericColumnBase[T]) CompactNullableValues() {
 		cnt++
 	}
 	c.values = c.values[0:cnt]
+	c.sparseMode = false
 }
 
 func (c *genericColumnBase[T]) ValidCount() int {

--- a/client/column/generic_base.go
+++ b/client/column/generic_base.go
@@ -94,24 +94,38 @@ func (c *genericColumnBase[T]) Slice(start, end int) Column {
 	return c.slice(start, end)
 }
 
-// WARNING: this methods works only for sparse mode column
 func (c *genericColumnBase[T]) slice(start, end int) *genericColumnBase[T] {
 	l := c.Len()
+	if start < 0 {
+		start = 0
+	}
 	if start > l {
 		start = l
 	}
 	if end == -1 || end > l {
 		end = l
 	}
+	if start > end {
+		start = end
+	}
+
+	valueStart, valueEnd := start, end
+	if c.nullable && !c.sparseMode {
+		valueStart = countValid(c.validData[:start])
+		valueEnd = valueStart + countValid(c.validData[start:end])
+	}
 	result := &genericColumnBase[T]{
 		name:       c.name,
 		fieldType:  c.fieldType,
-		values:     c.values[start:end],
+		values:     c.values[valueStart:valueEnd],
 		nullable:   c.nullable,
 		sparseMode: c.sparseMode,
 	}
 	if c.nullable {
 		result.validData = c.validData[start:end]
+		if !c.sparseMode {
+			_ = result.validateNullableCompact()
+		}
 	}
 	return result
 }

--- a/client/column/generic_base.go
+++ b/client/column/generic_base.go
@@ -116,12 +116,12 @@ func (c *genericColumnBase[T]) slice(start, end int) *genericColumnBase[T] {
 	result := &genericColumnBase[T]{
 		name:       c.name,
 		fieldType:  c.fieldType,
-		values:     c.values[valueStart:valueEnd],
+		values:     append([]T(nil), c.values[valueStart:valueEnd]...),
 		nullable:   c.nullable,
 		sparseMode: c.sparseMode,
 	}
 	if c.nullable {
-		result.validData = c.validData[start:end]
+		result.validData = append([]bool(nil), c.validData[start:end]...)
 		if !c.sparseMode {
 			_ = result.validateNullableCompact()
 		}

--- a/client/column/generic_base.go
+++ b/client/column/generic_base.go
@@ -111,8 +111,7 @@ func (c *genericColumnBase[T]) slice(start, end int) *genericColumnBase[T] {
 
 	valueStart, valueEnd := start, end
 	if c.nullable && !c.sparseMode {
-		valueStart = countValid(c.validData[:start])
-		valueEnd = valueStart + countValid(c.validData[start:end])
+		valueStart, valueEnd = compactValueRange(c.indexMapping, start, end)
 	}
 	result := &genericColumnBase[T]{
 		name:       c.name,
@@ -128,6 +127,23 @@ func (c *genericColumnBase[T]) slice(start, end int) *genericColumnBase[T] {
 		}
 	}
 	return result
+}
+
+func compactValueRange(indexMapping []int, start, end int) (int, int) {
+	valueStart := 0
+	valueEnd := 0
+	found := false
+	for _, valueIndex := range indexMapping[start:end] {
+		if valueIndex < 0 {
+			continue
+		}
+		if !found {
+			valueStart = valueIndex
+			found = true
+		}
+		valueEnd = valueIndex + 1
+	}
+	return valueStart, valueEnd
 }
 
 func (c *genericColumnBase[T]) FieldData() *schemapb.FieldData {

--- a/client/column/generic_base.go
+++ b/client/column/generic_base.go
@@ -17,6 +17,8 @@
 package column
 
 import (
+	"slices"
+
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
@@ -116,12 +118,12 @@ func (c *genericColumnBase[T]) slice(start, end int) *genericColumnBase[T] {
 	result := &genericColumnBase[T]{
 		name:       c.name,
 		fieldType:  c.fieldType,
-		values:     append([]T(nil), c.values[valueStart:valueEnd]...),
+		values:     slices.Clone(c.values[valueStart:valueEnd]),
 		nullable:   c.nullable,
 		sparseMode: c.sparseMode,
 	}
 	if c.nullable {
-		result.validData = append([]bool(nil), c.validData[start:end]...)
+		result.validData = slices.Clone(c.validData[start:end])
 		if !c.sparseMode {
 			_ = result.validateNullableCompact()
 		}

--- a/client/column/generic_base_test.go
+++ b/client/column/generic_base_test.go
@@ -188,6 +188,40 @@ func (s *GenericBaseSuite) TestSlice() {
 		agb := gb.Slice(10, 10)
 		s.Equal(0, agb.Len())
 	})
+
+	s.Run("compact nullable ranges", func() {
+		nullable := &genericColumnBase[int64]{
+			name:       name,
+			fieldType:  entity.FieldTypeInt64,
+			values:     []int64{10, 40},
+			nullable:   true,
+			validData:  []bool{true, false, false, true},
+			sparseMode: false,
+		}
+		s.Require().NoError(nullable.ValidateNullable())
+
+		first := nullable.Slice(0, 2)
+		s.Equal(2, first.Len())
+		value, err := first.Get(0)
+		s.Require().NoError(err)
+		s.EqualValues(10, value)
+		isNull, err := first.IsNull(1)
+		s.Require().NoError(err)
+		s.True(isNull)
+
+		allNull := nullable.Slice(1, 3)
+		s.Equal(2, allNull.Len())
+		s.Zero(allNull.ValidCount())
+
+		last := nullable.Slice(2, 4)
+		s.Equal(2, last.Len())
+		isNull, err = last.IsNull(0)
+		s.Require().NoError(err)
+		s.True(isNull)
+		value, err = last.Get(1)
+		s.Require().NoError(err)
+		s.EqualValues(40, value)
+	})
 }
 
 func (s *GenericBaseSuite) TestFieldData() {

--- a/client/column/generic_base_test.go
+++ b/client/column/generic_base_test.go
@@ -244,6 +244,23 @@ func (s *GenericBaseSuite) TestSlice() {
 		s.Require().NoError(err)
 		s.EqualValues(40, value)
 	})
+
+	s.Run("empty slice preserves initialized storage", func() {
+		source := &genericColumnBase[int64]{
+			name:       name,
+			fieldType:  entity.FieldTypeInt64,
+			values:     []int64{10},
+			nullable:   true,
+			validData:  []bool{true},
+			sparseMode: true,
+		}
+
+		sliced := source.slice(0, 0)
+		s.NotNil(sliced.values)
+		s.Empty(sliced.values)
+		s.NotNil(sliced.validData)
+		s.Empty(sliced.validData)
+	})
 }
 
 func (s *GenericBaseSuite) TestFieldData() {

--- a/client/column/generic_base_test.go
+++ b/client/column/generic_base_test.go
@@ -222,6 +222,28 @@ func (s *GenericBaseSuite) TestSlice() {
 		s.Require().NoError(err)
 		s.EqualValues(40, value)
 	})
+
+	s.Run("compacting slice does not mutate source", func() {
+		source := &genericColumnBase[int64]{
+			name:       name,
+			fieldType:  entity.FieldTypeInt64,
+			values:     []int64{0, 10, 40},
+			nullable:   true,
+			validData:  []bool{false, true, true},
+			sparseMode: true,
+		}
+		s.Require().NoError(source.ValidateNullable())
+
+		sliced := source.Slice(0, -1)
+		sliced.CompactNullableValues()
+
+		value, err := source.Get(1)
+		s.Require().NoError(err)
+		s.EqualValues(10, value)
+		value, err = source.Get(2)
+		s.Require().NoError(err)
+		s.EqualValues(40, value)
+	})
 }
 
 func (s *GenericBaseSuite) TestFieldData() {

--- a/client/column/geometry.go
+++ b/client/column/geometry.go
@@ -1,8 +1,6 @@
 package column
 
 import (
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/client/v3/entity"
 )
@@ -21,19 +19,12 @@ func (c *ColumnGeometryWKT) Type() entity.FieldType {
 	return entity.FieldTypeGeometry
 }
 
-// Len returns column values length.
+// Len returns the logical row count.
 func (c *ColumnGeometryWKT) Len() int {
-	return len(c.values)
+	return c.genericColumnBase.Len()
 }
 
 func (c *ColumnGeometryWKT) Slice(start, end int) Column {
-	l := c.Len()
-	if start > l {
-		start = l
-	}
-	if end == -1 || end > l {
-		end = l
-	}
 	return &ColumnGeometryWKT{
 		genericColumnBase: c.genericColumnBase.slice(start, end),
 	}
@@ -41,14 +32,11 @@ func (c *ColumnGeometryWKT) Slice(start, end int) Column {
 
 // Get returns value at index as interface{}.
 func (c *ColumnGeometryWKT) Get(idx int) (interface{}, error) {
-	if idx < 0 || idx >= c.Len() {
-		return nil, errors.New("index out of range")
-	}
-	return c.values[idx], nil
+	return c.genericColumnBase.Get(idx)
 }
 
 func (c *ColumnGeometryWKT) GetAsString(idx int) (string, error) {
-	return c.ValueByIdx(idx)
+	return c.genericColumnBase.GetAsString(idx)
 }
 
 // FieldData return column data mapped to schemapb.FieldData.
@@ -59,20 +47,12 @@ func (c *ColumnGeometryWKT) FieldData() *schemapb.FieldData {
 
 // ValueByIdx returns value of the provided index.
 func (c *ColumnGeometryWKT) ValueByIdx(idx int) (string, error) {
-	if idx < 0 || idx >= c.Len() {
-		return "", errors.New("index out of range")
-	}
-	return c.values[idx], nil
+	return c.genericColumnBase.Value(idx)
 }
 
 // AppendValue append value into column.
 func (c *ColumnGeometryWKT) AppendValue(i interface{}) error {
-	s, ok := i.(string)
-	if !ok {
-		return errors.New("expect geometry WKT type(string)")
-	}
-	c.values = append(c.values, s)
-	return nil
+	return c.genericColumnBase.AppendValue(i)
 }
 
 // Data returns column data.

--- a/client/column/geometry_test.go
+++ b/client/column/geometry_test.go
@@ -71,6 +71,40 @@ func (s *ColumnGeometryWKTSuite) TestAttrMethods() {
 	})
 }
 
+func (s *ColumnGeometryWKTSuite) TestNullableLogicalRows() {
+	column, err := NewNullableColumnGeometryWKT(
+		"location",
+		[]string{"POINT (1 2)"},
+		[]bool{false, true},
+	)
+	s.Require().NoError(err)
+	s.Equal(2, column.Len())
+
+	isNull, err := column.IsNull(0)
+	s.Require().NoError(err)
+	s.True(isNull)
+	value, err := column.GetAsString(1)
+	s.Require().NoError(err)
+	s.Equal("POINT (1 2)", value)
+
+	sliced := column.Slice(0, column.Len())
+	geometry, ok := sliced.(*ColumnGeometryWKT)
+	s.Require().True(ok)
+	s.Equal(2, geometry.Len())
+	isNull, err = geometry.IsNull(0)
+	s.Require().NoError(err)
+	s.True(isNull)
+	value, err = geometry.ValueByIdx(1)
+	s.Require().NoError(err)
+	s.Equal("POINT (1 2)", value)
+
+	s.Require().NoError(geometry.AppendValue("POINT (3 4)"))
+	s.Equal(3, geometry.Len())
+	value, err = geometry.GetAsString(2)
+	s.Require().NoError(err)
+	s.Equal("POINT (3 4)", value)
+}
+
 func TestColumnGeometryWKT(t *testing.T) {
 	suite.Run(t, new(ColumnGeometryWKTSuite))
 }

--- a/client/column/json.go
+++ b/client/column/json.go
@@ -45,6 +45,7 @@ func NewColumnJSONBytes(name string, values [][]byte) *ColumnJSONBytes {
 func (c *ColumnJSONBytes) Slice(start, end int) Column {
 	return &ColumnJSONBytes{
 		genericColumnBase: c.genericColumnBase.slice(start, end),
+		isDynamic:         c.isDynamic,
 	}
 }
 

--- a/client/column/nullable.go
+++ b/client/column/nullable.go
@@ -56,7 +56,7 @@ func NewNullableColumnFloatVector(fieldName string, dim int, values [][]float32,
 	col := NewColumnFloatVector(fieldName, dim, values)
 	col.withValidData(validData)
 	col.nullable = true
-	return col, nil
+	return col, col.ValidateNullable()
 }
 
 func NewNullableColumnBinaryVector(fieldName string, dim int, values [][]byte, validData []bool) (*ColumnBinaryVector, error) {
@@ -66,7 +66,7 @@ func NewNullableColumnBinaryVector(fieldName string, dim int, values [][]byte, v
 	col := NewColumnBinaryVector(fieldName, dim, values)
 	col.withValidData(validData)
 	col.nullable = true
-	return col, nil
+	return col, col.ValidateNullable()
 }
 
 func NewNullableColumnFloat16Vector(fieldName string, dim int, values [][]byte, validData []bool) (*ColumnFloat16Vector, error) {
@@ -76,7 +76,7 @@ func NewNullableColumnFloat16Vector(fieldName string, dim int, values [][]byte, 
 	col := NewColumnFloat16Vector(fieldName, dim, values)
 	col.withValidData(validData)
 	col.nullable = true
-	return col, nil
+	return col, col.ValidateNullable()
 }
 
 func NewNullableColumnBFloat16Vector(fieldName string, dim int, values [][]byte, validData []bool) (*ColumnBFloat16Vector, error) {
@@ -86,7 +86,7 @@ func NewNullableColumnBFloat16Vector(fieldName string, dim int, values [][]byte,
 	col := NewColumnBFloat16Vector(fieldName, dim, values)
 	col.withValidData(validData)
 	col.nullable = true
-	return col, nil
+	return col, col.ValidateNullable()
 }
 
 func NewNullableColumnInt8Vector(fieldName string, dim int, values [][]int8, validData []bool) (*ColumnInt8Vector, error) {
@@ -96,7 +96,7 @@ func NewNullableColumnInt8Vector(fieldName string, dim int, values [][]int8, val
 	col := NewColumnInt8Vector(fieldName, dim, values)
 	col.withValidData(validData)
 	col.nullable = true
-	return col, nil
+	return col, col.ValidateNullable()
 }
 
 func NewNullableColumnSparseFloatVector(fieldName string, values []entity.SparseEmbedding, validData []bool) (*ColumnSparseFloatVector, error) {
@@ -106,7 +106,7 @@ func NewNullableColumnSparseFloatVector(fieldName string, values []entity.Sparse
 	col := NewColumnSparseVectors(fieldName, values)
 	col.withValidData(validData)
 	col.nullable = true
-	return col, nil
+	return col, col.ValidateNullable()
 }
 
 func getValidCount(validData []bool) int {

--- a/client/column/nullable_test.go
+++ b/client/column/nullable_test.go
@@ -371,6 +371,73 @@ func (s *NullableScalarSuite) TestBasic() {
 	})
 }
 
+func (s *NullableScalarSuite) TestVectorSlice() {
+	sparse, err := entity.NewSliceSparseEmbedding([]uint32{0}, []float32{1})
+	s.Require().NoError(err)
+
+	cases := []struct {
+		name   string
+		create func() (Column, error)
+	}{
+		{
+			name: "float vector",
+			create: func() (Column, error) {
+				return NewNullableColumnFloatVector("vector", 2, [][]float32{{1, 2}}, []bool{false, true})
+			},
+		},
+		{
+			name: "binary vector",
+			create: func() (Column, error) {
+				return NewNullableColumnBinaryVector("vector", 8, [][]byte{{1}}, []bool{false, true})
+			},
+		},
+		{
+			name: "float16 vector",
+			create: func() (Column, error) {
+				return NewNullableColumnFloat16Vector("vector", 2, [][]byte{{1, 2, 3, 4}}, []bool{false, true})
+			},
+		},
+		{
+			name: "bfloat16 vector",
+			create: func() (Column, error) {
+				return NewNullableColumnBFloat16Vector("vector", 2, [][]byte{{1, 2, 3, 4}}, []bool{false, true})
+			},
+		},
+		{
+			name: "int8 vector",
+			create: func() (Column, error) {
+				return NewNullableColumnInt8Vector("vector", 2, [][]int8{{1, 2}}, []bool{false, true})
+			},
+		},
+		{
+			name: "sparse vector",
+			create: func() (Column, error) {
+				return NewNullableColumnSparseFloatVector("vector", []entity.SparseEmbedding{sparse}, []bool{false, true})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			vector, err := tc.create()
+			s.Require().NoError(err)
+			s.Require().NoError(vector.ValidateNullable())
+
+			var sliced Column
+			s.NotPanics(func() {
+				sliced = vector.Slice(0, vector.Len())
+			})
+			s.Require().NotNil(sliced)
+			s.Equal(2, sliced.Len())
+			isNull, err := sliced.IsNull(0)
+			s.Require().NoError(err)
+			s.True(isNull)
+			_, err = sliced.Get(1)
+			s.NoError(err)
+		})
+	}
+}
+
 func TestNullableScalar(t *testing.T) {
 	suite.Run(t, new(NullableScalarSuite))
 }

--- a/client/column/struct.go
+++ b/client/column/struct.go
@@ -28,8 +28,9 @@ import (
 // "array-of-X" column (e.g. ColumnInt32Array, ColumnFloatVectorArray) so that one entry
 // in the column corresponds to one row's variable-length list of struct elements.
 type columnStructArray struct {
-	fields []Column
-	name   string
+	fields   []Column
+	name     string
+	nullable bool
 }
 
 func NewColumnStructArray(name string, fields []Column) Column {
@@ -125,6 +126,14 @@ func (c *columnStructArray) AppendValue(value any) error {
 }
 
 func (c *columnStructArray) Get(idx int) (any, error) {
+	isNull, err := c.IsNull(idx)
+	if err != nil {
+		return nil, err
+	}
+	if isNull {
+		return nil, nil
+	}
+
 	m := make(map[string]any)
 	for _, field := range c.fields {
 		v, err := field.Get(idx)
@@ -153,19 +162,36 @@ func (c *columnStructArray) GetAsBool(idx int) (bool, error) {
 }
 
 func (c *columnStructArray) IsNull(idx int) (bool, error) {
-	return false, nil
+	if idx < 0 || idx >= c.Len() {
+		return false, errors.Newf("index %d out of range[0, %d)", idx, c.Len())
+	}
+	if !c.nullable {
+		return false, nil
+	}
+	return c.fields[0].IsNull(idx)
 }
 
 func (c *columnStructArray) AppendNull() error {
-	return errors.New("struct array column does not support AppendNull")
+	if !c.nullable {
+		return errors.New("append null to not nullable struct array column")
+	}
+	for _, field := range c.fields {
+		if err := field.AppendNull(); err != nil {
+			return errors.Wrapf(err, "struct array AppendNull: sub-field %q", field.Name())
+		}
+	}
+	return nil
 }
 
 func (c *columnStructArray) Nullable() bool {
-	return false
+	return c.nullable
 }
 
 func (c *columnStructArray) SetNullable(nullable bool) {
-	// Shall not be set
+	c.nullable = nullable
+	for _, field := range c.fields {
+		field.SetNullable(nullable)
+	}
 }
 
 func (c *columnStructArray) ValidateNullable() error {
@@ -184,5 +210,8 @@ func (c *columnStructArray) CompactNullableValues() {
 }
 
 func (c *columnStructArray) ValidCount() int {
-	return c.Len()
+	if len(c.fields) == 0 {
+		return 0
+	}
+	return c.fields[0].ValidCount()
 }

--- a/client/column/struct.go
+++ b/client/column/struct.go
@@ -104,6 +104,9 @@ func (c *columnStructArray) AppendValue(value any) error {
 	if !ok {
 		return errors.Newf("struct array AppendValue expects map[string]any, got %T", value)
 	}
+	if row == nil {
+		return c.AppendNull()
+	}
 	// pre-check all keys exist before mutating any sub-column.
 	for _, sub := range c.fields {
 		if _, present := row[sub.Name()]; !present {

--- a/client/column/struct.go
+++ b/client/column/struct.go
@@ -109,6 +109,9 @@ func (c *columnStructArray) FieldData() *schemapb.FieldData {
 // If any sub-field append fails, previously appended sub-fields are rolled back to their pre-call
 // lengths so sub-columns stay in lock-step.
 func (c *columnStructArray) AppendValue(value any) error {
+	if value == nil {
+		return c.AppendNull()
+	}
 	row, ok := value.(map[string]any)
 	if !ok {
 		return errors.Newf("struct array AppendValue expects map[string]any, got %T", value)

--- a/client/column/struct.go
+++ b/client/column/struct.go
@@ -34,9 +34,17 @@ type columnStructArray struct {
 }
 
 func NewColumnStructArray(name string, fields []Column) Column {
+	nullable := false
+	for _, field := range fields {
+		if field.Nullable() {
+			nullable = true
+			break
+		}
+	}
 	return &columnStructArray{
-		fields: fields,
-		name:   name,
+		fields:   fields,
+		name:     name,
+		nullable: nullable,
 	}
 }
 
@@ -74,8 +82,9 @@ func (c *columnStructArray) Slice(start, end int) Column {
 		fields[idx] = subField.Slice(start, end)
 	}
 	return &columnStructArray{
-		name:   c.name,
-		fields: fields,
+		name:     c.name,
+		fields:   fields,
+		nullable: c.nullable,
 	}
 }
 
@@ -198,9 +207,46 @@ func (c *columnStructArray) SetNullable(nullable bool) {
 }
 
 func (c *columnStructArray) ValidateNullable() error {
+	if c.nullable && len(c.fields) == 0 {
+		return errors.New("nullable struct array requires at least one sub-field")
+	}
 	for _, field := range c.fields {
 		if err := field.ValidateNullable(); err != nil {
-			return err
+			return errors.Wrapf(err, "struct array sub-field %q", field.Name())
+		}
+		if field.Nullable() != c.nullable {
+			return errors.Newf("struct array sub-field %q nullable %t does not match parent nullable %t",
+				field.Name(), field.Nullable(), c.nullable)
+		}
+	}
+	if len(c.fields) == 0 {
+		return nil
+	}
+
+	rowCount := c.fields[0].Len()
+	for _, field := range c.fields[1:] {
+		if field.Len() != rowCount {
+			return errors.Newf("struct array sub-field %q length %d does not match length %d",
+				field.Name(), field.Len(), rowCount)
+		}
+	}
+	if !c.nullable {
+		return nil
+	}
+	for row := 0; row < rowCount; row++ {
+		expected, err := c.fields[0].IsNull(row)
+		if err != nil {
+			return errors.Wrapf(err, "struct array sub-field %q row %d", c.fields[0].Name(), row)
+		}
+		for _, field := range c.fields[1:] {
+			actual, err := field.IsNull(row)
+			if err != nil {
+				return errors.Wrapf(err, "struct array sub-field %q row %d", field.Name(), row)
+			}
+			if actual != expected {
+				return errors.Newf("struct array sub-field %q null state at row %d does not match sub-field %q",
+					field.Name(), row, c.fields[0].Name())
+			}
 		}
 	}
 	return nil

--- a/client/column/struct.go
+++ b/client/column/struct.go
@@ -121,8 +121,12 @@ func (c *columnStructArray) AppendValue(value any) error {
 	}
 	// pre-check all keys exist before mutating any sub-column.
 	for _, sub := range c.fields {
-		if _, present := row[sub.Name()]; !present {
+		value, present := row[sub.Name()]
+		if !present {
 			return errors.Newf("struct array AppendValue: missing sub-field %q", sub.Name())
+		}
+		if value == nil {
+			return errors.Newf("struct array AppendValue: sub-field %q is nil; use a nil struct row to append null", sub.Name())
 		}
 	}
 	preLens := make([]int, len(c.fields))

--- a/client/column/struct.go
+++ b/client/column/struct.go
@@ -195,6 +195,11 @@ func (c *columnStructArray) AppendNull() error {
 		return errors.New("append null to not nullable struct array column")
 	}
 	for _, field := range c.fields {
+		if !field.Nullable() {
+			return errors.Newf("struct array AppendNull: sub-field %q is not nullable", field.Name())
+		}
+	}
+	for _, field := range c.fields {
 		if err := field.AppendNull(); err != nil {
 			return errors.Wrapf(err, "struct array AppendNull: sub-field %q", field.Name())
 		}

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -129,6 +129,17 @@ func (s *StructArraySuite) TestAppendValueWithUntypedNil() {
 	s.True(isNull)
 }
 
+func (s *StructArraySuite) TestAppendNullDoesNotPartiallyMutateMixedNullableFields() {
+	nullableField := NewColumnInt64Array("age", nil)
+	nullableField.SetNullable(true)
+	requiredField := NewColumnVarCharArray("tag", nil)
+	column := NewColumnStructArray("profile", []Column{nullableField, requiredField})
+
+	s.Require().Error(column.AppendNull())
+	s.Zero(nullableField.Len())
+	s.Zero(requiredField.Len())
+}
+
 func (s *StructArraySuite) TestNullableCompactSlice() {
 	column := NewColumnStructArray("profile", []Column{
 		NewColumnInt64Array("id", nil),

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -655,6 +655,26 @@ func (s *StructArraySuite) TestAppendValueRollback() {
 	s.EqualValues(1, col.Len(), "struct array length stays consistent after rollback")
 }
 
+func (s *StructArraySuite) TestAppendValueRollbackPreservesVectorArrayAppendAPI() {
+	vectorCol := NewColumnFloatVectorArray("embedding", 2, nil)
+	strCol := NewColumnVarCharArray("tag", nil)
+	col := NewColumnStructArray("rows", []Column{vectorCol, strCol}).(*columnStructArray)
+
+	err := col.AppendValue(map[string]any{
+		"embedding": [][]float32{{1, 2}},
+		"tag":       42,
+	})
+	s.Require().Error(err)
+	s.IsType((*ColumnFloatVectorArray)(nil), col.fields[0])
+	s.Zero(col.Len())
+
+	s.Require().NoError(col.AppendValue(map[string]any{
+		"embedding": [][]float32{{3, 4}},
+		"tag":       []string{"valid"},
+	}))
+	s.Equal(1, col.Len())
+}
+
 func (s *StructArraySuite) TestLenMismatchPanics() {
 	// Manually drift sub-column lengths to simulate a prior corruption and verify Len reports it.
 	intCol := NewColumnInt32Array("a", [][]int32{{1}, {2}})

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -482,6 +482,24 @@ func (s *StructArraySuite) TestParseNullableStructArrayEmptySlice() {
 	}
 }
 
+func (s *StructArraySuite) TestParseNullableStructArrayEmptyRows() {
+	source := NewColumnStructArray("profile", []Column{
+		NewColumnInt64Array("age", nil),
+		NewColumnFloatVectorArray("embedding", 2, nil),
+	})
+	source.SetNullable(true)
+	for _, fieldData := range source.FieldData().GetStructArrays().GetFields() {
+		s.NotNil(fieldData.ValidData)
+		s.Empty(fieldData.GetValidData())
+	}
+
+	parsed, err := FieldDataColumn(source.FieldData(), 0, -1)
+	s.Require().NoError(err)
+	s.True(parsed.Nullable())
+	s.Zero(parsed.Len())
+	s.Require().NoError(parsed.ValidateNullable())
+}
+
 func (s *StructArraySuite) TestAppendToParsedSparseNullableScalarStructArray() {
 	validData := []bool{true, false, true}
 	age, err := NewNullableColumnInt64Array(

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -299,6 +299,68 @@ func (s *StructArraySuite) TestParseTopLevelArrayOfStruct() {
 	s.Equal([]int32{1, 2}, val.(map[string]any)["x"])
 }
 
+func (s *StructArraySuite) TestParseNullableStructArray() {
+	validData := []bool{true, false, true}
+	intSub := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "id",
+		ValidData: validData,
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+				ElementType: schemapb.DataType_Int64,
+				Data: []*schemapb.ScalarField{
+					{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{10}}}},
+					{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{}}},
+					{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{}}},
+				},
+			}},
+		}},
+	}
+	strSub := &schemapb.FieldData{
+		Type:      schemapb.DataType_Array,
+		FieldName: "tag",
+		ValidData: validData,
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+				ElementType: schemapb.DataType_VarChar,
+				Data: []*schemapb.ScalarField{
+					{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"a"}}}},
+					{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{}}},
+					{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{}}},
+				},
+			}},
+		}},
+	}
+	top := &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfStruct,
+		FieldName: "clips",
+		Field: &schemapb.FieldData_StructArrays{StructArrays: &schemapb.StructArrayField{
+			Fields: []*schemapb.FieldData{intSub, strSub},
+		}},
+	}
+
+	col, err := FieldDataColumn(top, 0, -1)
+	s.Require().NoError(err)
+	s.True(col.Nullable())
+	s.Equal(3, col.Len())
+	value, err := col.Get(1)
+	s.Require().NoError(err)
+	s.Nil(value)
+
+	sliced := col.Slice(1, -1)
+	s.True(sliced.Nullable())
+	s.Equal(2, sliced.Len())
+	value, err = sliced.Get(0)
+	s.Require().NoError(err)
+	s.Nil(value)
+	value, err = sliced.Get(1)
+	s.Require().NoError(err)
+	s.NotNil(value)
+	isNull, err := sliced.IsNull(1)
+	s.Require().NoError(err)
+	s.False(isNull)
+}
+
 func (s *StructArraySuite) TestParseVectorArrayDataErrors() {
 	mkFD := func(elemType schemapb.DataType, dim int64, rows []*schemapb.VectorField) *schemapb.FieldData {
 		return &schemapb.FieldData{

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -149,6 +149,27 @@ func (s *StructArraySuite) TestNullableCompactSlice() {
 	}
 }
 
+func (s *StructArraySuite) TestSetNullableWithExistingRows() {
+	column := NewColumnStructArray("profile", []Column{
+		NewColumnInt64Array("id", [][]int64{{10}, {20}}),
+		NewColumnVarCharArray("tag", [][]string{{"a"}, {"b"}}),
+	})
+	column.SetNullable(true)
+
+	var value any
+	var err error
+	s.NotPanics(func() {
+		value, err = column.Get(0)
+	})
+	s.Require().NoError(err)
+	s.Equal([]int64{10}, value.(map[string]any)["id"])
+	s.Require().NoError(column.AppendNull())
+	s.Equal(3, column.Len())
+	value, err = column.Get(2)
+	s.Require().NoError(err)
+	s.Nil(value)
+}
+
 func (s *StructArraySuite) TestVectorSubField() {
 	dim := 4
 	rows := [][][]float32{

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -114,6 +114,21 @@ func (s *StructArraySuite) TestNullableScalarRows() {
 	}
 }
 
+func (s *StructArraySuite) TestAppendValueWithUntypedNil() {
+	column := NewColumnStructArray("profile", []Column{
+		NewColumnInt64Array("age", nil),
+		NewColumnVarCharArray("tag", nil),
+	})
+	column.SetNullable(true)
+
+	var value any
+	s.Require().NoError(column.AppendValue(value))
+	s.Equal(1, column.Len())
+	isNull, err := column.IsNull(0)
+	s.Require().NoError(err)
+	s.True(isNull)
+}
+
 func (s *StructArraySuite) TestNullableCompactSlice() {
 	column := NewColumnStructArray("profile", []Column{
 		NewColumnInt64Array("id", nil),
@@ -415,6 +430,76 @@ func (s *StructArraySuite) TestParseNullableStructArray() {
 	isNull, err := sliced.IsNull(1)
 	s.Require().NoError(err)
 	s.False(isNull)
+}
+
+func (s *StructArraySuite) TestParseCompactNullableScalarStructArray() {
+	source := NewColumnStructArray("profile", []Column{
+		NewColumnInt64Array("age", nil),
+		NewColumnVarCharArray("tag", nil),
+	})
+	source.SetNullable(true)
+	s.Require().NoError(source.AppendValue(map[string]any{
+		"age": []int64{10},
+		"tag": []string{"first"},
+	}))
+	s.Require().NoError(source.AppendNull())
+	s.Require().NoError(source.AppendValue(map[string]any{
+		"age": []int64{30},
+		"tag": []string{"third"},
+	}))
+
+	parsed, err := FieldDataColumn(source.FieldData(), 0, -1)
+	s.Require().NoError(err)
+	s.Equal(3, parsed.Len())
+	value, err := parsed.Get(1)
+	s.Require().NoError(err)
+	s.Nil(value)
+	value, err = parsed.Get(2)
+	s.Require().NoError(err)
+	s.Equal([]int64{30}, value.(map[string]any)["age"])
+	s.Equal([]string{"third"}, value.(map[string]any)["tag"])
+}
+
+func (s *StructArraySuite) TestAppendToParsedSparseNullableScalarStructArray() {
+	validData := []bool{true, false, true}
+	age, err := NewNullableColumnInt64Array(
+		"age",
+		[][]int64{{10}, nil, {30}},
+		validData,
+		WithSparseNullableMode[[]int64](true),
+	)
+	s.Require().NoError(err)
+	tag, err := NewNullableColumnVarCharArray(
+		"tag",
+		[][]string{{"first"}, nil, {"third"}},
+		validData,
+		WithSparseNullableMode[[]string](true),
+	)
+	s.Require().NoError(err)
+
+	parsed, err := FieldDataColumn(NewColumnStructArray("profile", []Column{age, tag}).FieldData(), 0, -1)
+	s.Require().NoError(err)
+	s.Require().NoError(parsed.AppendNull())
+	s.Require().NoError(parsed.ValidateNullable())
+	s.Require().NoError(parsed.AppendValue(map[string]any{
+		"age": []int64{50},
+		"tag": []string{"fifth"},
+	}))
+	s.Require().NoError(parsed.ValidateNullable())
+	s.Equal(5, parsed.Len())
+	value, err := parsed.Get(3)
+	s.Require().NoError(err)
+	s.Nil(value)
+	value, err = parsed.Get(4)
+	s.Require().NoError(err)
+	s.Equal([]int64{50}, value.(map[string]any)["age"])
+	s.Equal([]string{"fifth"}, value.(map[string]any)["tag"])
+
+	parsed.CompactNullableValues()
+	s.Require().NoError(parsed.ValidateNullable())
+	value, err = parsed.Get(4)
+	s.Require().NoError(err)
+	s.Equal([]int64{50}, value.(map[string]any)["age"])
 }
 
 func (s *StructArraySuite) TestParseNullableStructArrayRejectsMismatchedMasks() {

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -114,6 +114,41 @@ func (s *StructArraySuite) TestNullableScalarRows() {
 	}
 }
 
+func (s *StructArraySuite) TestNullableCompactSlice() {
+	column := NewColumnStructArray("profile", []Column{
+		NewColumnInt64Array("id", nil),
+		NewColumnFloatVectorArray("embedding", 2, nil),
+	})
+	column.SetNullable(true)
+	s.Require().NoError(column.AppendValue(map[string]any{
+		"id":        []int64{10},
+		"embedding": [][]float32{{0.1, 0.2}},
+	}))
+	s.Require().NoError(column.AppendNull())
+	s.Require().NoError(column.AppendValue(map[string]any{
+		"id":        []int64{},
+		"embedding": [][]float32{},
+	}))
+
+	var sliced Column
+	s.NotPanics(func() {
+		sliced = column.Slice(1, -1)
+	})
+	s.Require().NotNil(sliced)
+	s.True(sliced.Nullable())
+	s.Equal(2, sliced.Len())
+	s.Equal(1, sliced.ValidCount())
+	value, err := sliced.Get(0)
+	s.Require().NoError(err)
+	s.Nil(value)
+	value, err = sliced.Get(1)
+	s.Require().NoError(err)
+	s.NotNil(value)
+	for _, fieldData := range sliced.FieldData().GetStructArrays().GetFields() {
+		s.Equal([]bool{false, true}, fieldData.GetValidData())
+	}
+}
+
 func (s *StructArraySuite) TestVectorSubField() {
 	dim := 4
 	rows := [][][]float32{

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -160,6 +160,32 @@ func (s *StructArraySuite) TestSlice() {
 	s.Equal([]bool{false, true}, m["flag"])
 }
 
+func (s *StructArraySuite) TestNullableVectorRows() {
+	column := NewColumnStructArray("clips", []Column{
+		NewColumnInt64Array("id", nil),
+		NewColumnFloatVectorArray("embedding", 2, nil),
+	})
+	column.SetNullable(true)
+
+	s.Require().NoError(column.AppendValue(map[string]any{
+		"id":        []int64{10},
+		"embedding": [][]float32{{0.1, 0.2}},
+	}))
+	s.Require().NoError(column.AppendNull())
+	s.Require().NoError(column.AppendValue(map[string]any{
+		"id":        []int64{},
+		"embedding": [][]float32{},
+	}))
+
+	fields := column.FieldData().GetStructArrays().GetFields()
+	s.Require().Len(fields, 2)
+	for _, fieldData := range fields {
+		s.Equal([]bool{true, false, true}, fieldData.GetValidData())
+	}
+	s.Len(fields[0].GetScalars().GetArrayData().GetData(), 2)
+	s.Len(fields[1].GetVectors().GetVectorArray().GetData(), 2)
+}
+
 func (s *StructArraySuite) TestAppendValue() {
 	intCol := NewColumnInt32Array("a", nil)
 	strCol := NewColumnVarCharArray("b", nil)

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -460,6 +460,28 @@ func (s *StructArraySuite) TestParseCompactNullableScalarStructArray() {
 	s.Equal([]string{"third"}, value.(map[string]any)["tag"])
 }
 
+func (s *StructArraySuite) TestParseNullableStructArrayEmptySlice() {
+	source := NewColumnStructArray("profile", []Column{
+		NewColumnInt64Array("age", nil),
+		NewColumnFloatVectorArray("embedding", 2, nil),
+	})
+	source.SetNullable(true)
+	s.Require().NoError(source.AppendValue(map[string]any{
+		"age":       []int64{10},
+		"embedding": [][]float32{{0.1, 0.2}},
+	}))
+
+	parsed, err := FieldDataColumn(source.FieldData(), 0, 0)
+	s.Require().NoError(err)
+	s.True(parsed.Nullable())
+	s.Zero(parsed.Len())
+	s.Require().NoError(parsed.ValidateNullable())
+	for _, fieldData := range parsed.FieldData().GetStructArrays().GetFields() {
+		s.NotNil(fieldData.ValidData)
+		s.Empty(fieldData.GetValidData())
+	}
+}
+
 func (s *StructArraySuite) TestAppendToParsedSparseNullableScalarStructArray() {
 	validData := []bool{true, false, true}
 	age, err := NewNullableColumnInt64Array(

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -417,6 +417,38 @@ func (s *StructArraySuite) TestParseNullableStructArray() {
 	s.False(isNull)
 }
 
+func (s *StructArraySuite) TestParseNullableStructArrayRejectsMismatchedMasks() {
+	newSubField := func(name string, validData []bool) *schemapb.FieldData {
+		return &schemapb.FieldData{
+			Type:      schemapb.DataType_Array,
+			FieldName: name,
+			ValidData: validData,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_ArrayData{ArrayData: &schemapb.ArrayArray{
+					ElementType: schemapb.DataType_Int64,
+					Data: []*schemapb.ScalarField{
+						{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1}}}},
+						{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{}}},
+					},
+				}},
+			}},
+		}
+	}
+	top := &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfStruct,
+		FieldName: "clips",
+		Field: &schemapb.FieldData_StructArrays{StructArrays: &schemapb.StructArrayField{
+			Fields: []*schemapb.FieldData{
+				newSubField("left", []bool{true, false}),
+				newSubField("right", []bool{false, true}),
+			},
+		}},
+	}
+
+	_, err := FieldDataColumn(top, 0, -1)
+	s.Error(err)
+}
+
 func (s *StructArraySuite) TestParseVectorArrayDataErrors() {
 	mkFD := func(elemType schemapb.DataType, dim int64, rows []*schemapb.VectorField) *schemapb.FieldData {
 		return &schemapb.FieldData{

--- a/client/column/struct_test.go
+++ b/client/column/struct_test.go
@@ -76,6 +76,44 @@ func (s *StructArraySuite) TestBasic() {
 	s.Equal([]int32{4, 5, 6}, m["int_field"])
 }
 
+func (s *StructArraySuite) TestNullableScalarRows() {
+	column := NewColumnStructArray("profile", []Column{
+		NewColumnInt64Array("age", nil),
+		NewColumnVarCharArray("tag", nil),
+	})
+	column.SetNullable(true)
+
+	s.Require().NoError(column.AppendValue(map[string]any{
+		"age": []int64{10, 11},
+		"tag": []string{"a", "b"},
+	}))
+	s.Require().NoError(column.AppendNull())
+	s.Require().NoError(column.AppendValue(map[string]any{
+		"age": []int64{},
+		"tag": []string{},
+	}))
+
+	s.True(column.Nullable())
+	s.Equal(3, column.Len())
+	s.Equal(2, column.ValidCount())
+
+	isNull, err := column.IsNull(1)
+	s.Require().NoError(err)
+	s.True(isNull)
+	value, err := column.Get(1)
+	s.Require().NoError(err)
+	s.Nil(value)
+
+	isNull, err = column.IsNull(2)
+	s.Require().NoError(err)
+	s.False(isNull, "an empty struct array is distinct from null")
+
+	for _, fieldData := range column.FieldData().GetStructArrays().GetFields() {
+		s.Equal([]bool{true, false, true}, fieldData.GetValidData())
+		s.Equal(2, len(fieldData.GetScalars().GetArrayData().GetData()))
+	}
+}
+
 func (s *StructArraySuite) TestVectorSubField() {
 	dim := 4
 	rows := [][][]float32{

--- a/client/column/vector_array.go
+++ b/client/column/vector_array.go
@@ -31,6 +31,12 @@ type columnVectorArrayBase[T entity.Vector] struct {
 	elementType entity.FieldType // underlying vector type, e.g. FieldTypeFloatVector
 	dim         int
 	values      [][]T // values[i] = list of vectors for row i
+
+	// Nullable columns use compact mode for inserts and sparse mode for query results.
+	nullable     bool
+	validData    []bool
+	sparseMode   bool
+	indexMapping []int
 }
 
 func (c *columnVectorArrayBase[T]) Name() string {
@@ -50,22 +56,32 @@ func (c *columnVectorArrayBase[T]) Dim() int {
 }
 
 func (c *columnVectorArrayBase[T]) Len() int {
+	if c.validData != nil {
+		return len(c.validData)
+	}
 	return len(c.values)
 }
 
 func (c *columnVectorArrayBase[T]) Get(idx int) (any, error) {
-	if idx < 0 || idx >= len(c.values) {
-		return nil, errors.Newf("index %d out of range[0, %d)", idx, len(c.values))
+	if err := c.rangeCheck(idx); err != nil {
+		return nil, err
 	}
-	return c.values[idx], nil
+	if c.nullable && !c.validData[idx] {
+		return nil, nil
+	}
+	return c.values[c.valueIndex(idx)], nil
 }
 
 func (c *columnVectorArrayBase[T]) AppendValue(value any) error {
+	if value == nil {
+		return c.AppendNull()
+	}
 	v, ok := value.([]T)
 	if !ok {
 		return errors.Newf("unexpected append value type %T, field type %v", value, c.fieldType)
 	}
 	c.values = append(c.values, v)
+	c.markValueAppended()
 	return nil
 }
 
@@ -85,38 +101,119 @@ func (c *columnVectorArrayBase[T]) GetAsBool(_ int) (bool, error) {
 	return false, errors.New("vector array column does not support GetAsBool")
 }
 
-func (c *columnVectorArrayBase[T]) IsNull(_ int) (bool, error) {
-	return false, nil
+func (c *columnVectorArrayBase[T]) IsNull(idx int) (bool, error) {
+	if err := c.rangeCheck(idx); err != nil {
+		return false, err
+	}
+	return c.nullable && !c.validData[idx], nil
 }
 
 func (c *columnVectorArrayBase[T]) AppendNull() error {
-	return errors.New("vector array column does not support AppendNull")
+	if !c.nullable {
+		return errors.New("append null to not nullable vector array column")
+	}
+	c.validData = append(c.validData, false)
+	if c.sparseMode {
+		c.values = append(c.values, nil)
+	} else {
+		c.indexMapping = append(c.indexMapping, -1)
+	}
+	return nil
 }
 
-func (c *columnVectorArrayBase[T]) Nullable() bool { return false }
+func (c *columnVectorArrayBase[T]) Nullable() bool { return c.nullable }
 
-func (c *columnVectorArrayBase[T]) SetNullable(_ bool) {}
+func (c *columnVectorArrayBase[T]) SetNullable(nullable bool) {
+	c.nullable = nullable
+	if nullable && c.validData == nil {
+		c.validData = make([]bool, len(c.values))
+		c.indexMapping = make([]int, len(c.values))
+		for idx := range c.values {
+			c.validData[idx] = true
+			c.indexMapping[idx] = idx
+		}
+	}
+	if !nullable {
+		c.validData = nil
+		c.indexMapping = nil
+	}
+}
 
-func (c *columnVectorArrayBase[T]) ValidateNullable() error { return nil }
+func (c *columnVectorArrayBase[T]) ValidateNullable() error {
+	if !c.nullable {
+		return nil
+	}
+	if c.sparseMode {
+		if len(c.values) != len(c.validData) {
+			return errors.Newf("values number (%d) does not match valid data len(%d)", len(c.values), len(c.validData))
+		}
+		return nil
+	}
 
-func (c *columnVectorArrayBase[T]) CompactNullableValues() {}
+	c.rebuildIndexMapping()
+	if len(c.values) != c.ValidCount() {
+		return errors.Newf("values number(%d) does not match valid count(%d)", len(c.values), c.ValidCount())
+	}
+	return nil
+}
 
-func (c *columnVectorArrayBase[T]) ValidCount() int { return c.Len() }
+func (c *columnVectorArrayBase[T]) CompactNullableValues() {
+	if !c.nullable || !c.sparseMode {
+		return
+	}
+
+	values := c.values[:0]
+	for idx, valid := range c.validData {
+		if valid {
+			values = append(values, c.values[idx])
+		}
+	}
+	c.values = values
+	c.sparseMode = false
+	c.rebuildIndexMapping()
+}
+
+func (c *columnVectorArrayBase[T]) ValidCount() int {
+	if !c.nullable {
+		return len(c.values)
+	}
+	return countValid(c.validData)
+}
 
 func (c *columnVectorArrayBase[T]) Slice(start, end int) Column {
-	if end == -1 || end > len(c.values) {
-		end = len(c.values)
+	l := c.Len()
+	if start < 0 {
+		start = 0
+	}
+	if start > l {
+		start = l
+	}
+	if end == -1 || end > l {
+		end = l
 	}
 	if start > end {
 		start = end
 	}
-	return &columnVectorArrayBase[T]{
+
+	valueStart, valueEnd := start, end
+	if c.nullable && !c.sparseMode {
+		valueStart = countValid(c.validData[:start])
+		valueEnd = valueStart + countValid(c.validData[start:end])
+	}
+	result := &columnVectorArrayBase[T]{
 		name:        c.name,
 		fieldType:   c.fieldType,
 		elementType: c.elementType,
 		dim:         c.dim,
-		values:      c.values[start:end],
+		values:      c.values[valueStart:valueEnd],
+		nullable:    c.nullable,
+		sparseMode:  c.sparseMode,
 	}
+	if c.nullable {
+		result.validData = c.validData[start:end]
+		result.rebuildIndexMapping()
+	}
+	return result
 }
 
 func (c *columnVectorArrayBase[T]) FieldData() *schemapb.FieldData {
@@ -124,7 +221,7 @@ func (c *columnVectorArrayBase[T]) FieldData() *schemapb.FieldData {
 	for _, row := range c.values {
 		rows = append(rows, values2Vectors(row, c.elementType, int64(c.dim)))
 	}
-	return &schemapb.FieldData{
+	fd := &schemapb.FieldData{
 		Type:      schemapb.DataType_ArrayOfVector,
 		FieldName: c.name,
 		Field: &schemapb.FieldData_Vectors{
@@ -140,6 +237,60 @@ func (c *columnVectorArrayBase[T]) FieldData() *schemapb.FieldData {
 			},
 		},
 	}
+	if c.nullable {
+		fd.ValidData = c.validData
+	}
+	return fd
+}
+
+func (c *columnVectorArrayBase[T]) rangeCheck(idx int) error {
+	if idx < 0 || idx >= c.Len() {
+		return errors.Newf("index %d out of range[0, %d)", idx, c.Len())
+	}
+	return nil
+}
+
+func (c *columnVectorArrayBase[T]) valueIndex(idx int) int {
+	if !c.nullable || c.sparseMode {
+		return idx
+	}
+	return c.indexMapping[idx]
+}
+
+func (c *columnVectorArrayBase[T]) markValueAppended() {
+	if c.nullable {
+		c.validData = append(c.validData, true)
+		if !c.sparseMode {
+			c.indexMapping = append(c.indexMapping, len(c.values)-1)
+		}
+	}
+}
+
+func (c *columnVectorArrayBase[T]) rebuildIndexMapping() {
+	if !c.nullable || c.sparseMode {
+		c.indexMapping = nil
+		return
+	}
+	c.indexMapping = make([]int, len(c.validData))
+	valueIdx := 0
+	for idx, valid := range c.validData {
+		if !valid {
+			c.indexMapping[idx] = -1
+			continue
+		}
+		c.indexMapping[idx] = valueIdx
+		valueIdx++
+	}
+}
+
+func countValid(validData []bool) int {
+	count := 0
+	for _, valid := range validData {
+		if valid {
+			count++
+		}
+	}
+	return count
 }
 
 /* float vector array */
@@ -170,6 +321,9 @@ func NewColumnFloatVectorArray(fieldName string, dim int, data [][][]float32) *C
 
 // AppendValue accepts `[]entity.FloatVector` or `[][]float32` for one row.
 func (c *ColumnFloatVectorArray) AppendValue(value any) error {
+	if value == nil {
+		return c.AppendNull()
+	}
 	switch v := value.(type) {
 	case []entity.FloatVector:
 		c.values = append(c.values, v)
@@ -182,6 +336,7 @@ func (c *ColumnFloatVectorArray) AppendValue(value any) error {
 	default:
 		return errors.Newf("unexpected append value type %T, field type %v", value, c.elementType)
 	}
+	c.markValueAppended()
 	return nil
 }
 
@@ -208,7 +363,14 @@ type ColumnFloat16VectorArray struct {
 }
 
 func (c *ColumnFloat16VectorArray) AppendValue(value any) error {
-	return appendByteVectorArrayRow(&c.values, value)
+	if value == nil {
+		return c.AppendNull()
+	}
+	if err := appendByteVectorArrayRow(&c.values, value); err != nil {
+		return err
+	}
+	c.markValueAppended()
+	return nil
 }
 
 func NewColumnFloat16VectorArray(fieldName string, dim int, data [][][]byte) *ColumnFloat16VectorArray {
@@ -238,7 +400,14 @@ type ColumnBFloat16VectorArray struct {
 }
 
 func (c *ColumnBFloat16VectorArray) AppendValue(value any) error {
-	return appendByteVectorArrayRow(&c.values, value)
+	if value == nil {
+		return c.AppendNull()
+	}
+	if err := appendByteVectorArrayRow(&c.values, value); err != nil {
+		return err
+	}
+	c.markValueAppended()
+	return nil
 }
 
 func NewColumnBFloat16VectorArray(fieldName string, dim int, data [][][]byte) *ColumnBFloat16VectorArray {
@@ -268,7 +437,14 @@ type ColumnBinaryVectorArray struct {
 }
 
 func (c *ColumnBinaryVectorArray) AppendValue(value any) error {
-	return appendByteVectorArrayRow(&c.values, value)
+	if value == nil {
+		return c.AppendNull()
+	}
+	if err := appendByteVectorArrayRow(&c.values, value); err != nil {
+		return err
+	}
+	c.markValueAppended()
+	return nil
 }
 
 func NewColumnBinaryVectorArray(fieldName string, dim int, data [][][]byte) *ColumnBinaryVectorArray {
@@ -299,6 +475,9 @@ type ColumnInt8VectorArray struct {
 
 // AppendValue accepts `[]entity.Int8Vector` or `[][]int8` for one row.
 func (c *ColumnInt8VectorArray) AppendValue(value any) error {
+	if value == nil {
+		return c.AppendNull()
+	}
 	switch v := value.(type) {
 	case []entity.Int8Vector:
 		c.values = append(c.values, v)
@@ -311,6 +490,7 @@ func (c *ColumnInt8VectorArray) AppendValue(value any) error {
 	default:
 		return errors.Newf("unexpected append value type %T, field type %v", value, c.elementType)
 	}
+	c.markValueAppended()
 	return nil
 }
 

--- a/client/column/vector_array.go
+++ b/client/column/vector_array.go
@@ -181,6 +181,10 @@ func (c *columnVectorArrayBase[T]) ValidCount() int {
 }
 
 func (c *columnVectorArrayBase[T]) Slice(start, end int) Column {
+	return c.slice(start, end)
+}
+
+func (c *columnVectorArrayBase[T]) slice(start, end int) *columnVectorArrayBase[T] {
 	l := c.Len()
 	if start < 0 {
 		start = 0
@@ -326,6 +330,12 @@ func NewColumnFloatVectorArray(fieldName string, dim int, data [][][]float32) *C
 	}
 }
 
+func (c *ColumnFloatVectorArray) Slice(start, end int) Column {
+	return &ColumnFloatVectorArray{
+		columnVectorArrayBase: c.columnVectorArrayBase.slice(start, end),
+	}
+}
+
 // AppendValue accepts `[]entity.FloatVector` or `[][]float32` for one row.
 func (c *ColumnFloatVectorArray) AppendValue(value any) error {
 	if value == nil {
@@ -400,6 +410,12 @@ func NewColumnFloat16VectorArray(fieldName string, dim int, data [][][]byte) *Co
 	}
 }
 
+func (c *ColumnFloat16VectorArray) Slice(start, end int) Column {
+	return &ColumnFloat16VectorArray{
+		columnVectorArrayBase: c.columnVectorArrayBase.slice(start, end),
+	}
+}
+
 /* bfloat16 vector array */
 
 type ColumnBFloat16VectorArray struct {
@@ -437,6 +453,12 @@ func NewColumnBFloat16VectorArray(fieldName string, dim int, data [][][]byte) *C
 	}
 }
 
+func (c *ColumnBFloat16VectorArray) Slice(start, end int) Column {
+	return &ColumnBFloat16VectorArray{
+		columnVectorArrayBase: c.columnVectorArrayBase.slice(start, end),
+	}
+}
+
 /* binary vector array */
 
 type ColumnBinaryVectorArray struct {
@@ -471,6 +493,12 @@ func NewColumnBinaryVectorArray(fieldName string, dim int, data [][][]byte) *Col
 			dim:         dim,
 			values:      values,
 		},
+	}
+}
+
+func (c *ColumnBinaryVectorArray) Slice(start, end int) Column {
+	return &ColumnBinaryVectorArray{
+		columnVectorArrayBase: c.columnVectorArrayBase.slice(start, end),
 	}
 }
 
@@ -518,5 +546,11 @@ func NewColumnInt8VectorArray(fieldName string, dim int, data [][][]int8) *Colum
 			dim:         dim,
 			values:      values,
 		},
+	}
+}
+
+func (c *ColumnInt8VectorArray) Slice(start, end int) Column {
+	return &ColumnInt8VectorArray{
+		columnVectorArrayBase: c.columnVectorArrayBase.slice(start, end),
 	}
 }

--- a/client/column/vector_array.go
+++ b/client/column/vector_array.go
@@ -283,6 +283,13 @@ func (c *columnVectorArrayBase[T]) rebuildIndexMapping() {
 	}
 }
 
+func (c *columnVectorArrayBase[T]) setNullableData(validData []bool, sparseMode bool) error {
+	c.nullable = true
+	c.validData = validData
+	c.sparseMode = sparseMode
+	return c.ValidateNullable()
+}
+
 func countValid(validData []bool) int {
 	count := 0
 	for _, valid := range validData {

--- a/client/column/vector_array.go
+++ b/client/column/vector_array.go
@@ -209,12 +209,12 @@ func (c *columnVectorArrayBase[T]) slice(start, end int) *columnVectorArrayBase[
 		fieldType:   c.fieldType,
 		elementType: c.elementType,
 		dim:         c.dim,
-		values:      c.values[valueStart:valueEnd],
+		values:      append([][]T(nil), c.values[valueStart:valueEnd]...),
 		nullable:    c.nullable,
 		sparseMode:  c.sparseMode,
 	}
 	if c.nullable {
-		result.validData = c.validData[start:end]
+		result.validData = append([]bool(nil), c.validData[start:end]...)
 		result.rebuildIndexMapping()
 	}
 	return result

--- a/client/column/vector_array.go
+++ b/client/column/vector_array.go
@@ -201,8 +201,7 @@ func (c *columnVectorArrayBase[T]) slice(start, end int) *columnVectorArrayBase[
 
 	valueStart, valueEnd := start, end
 	if c.nullable && !c.sparseMode {
-		valueStart = countValid(c.validData[:start])
-		valueEnd = valueStart + countValid(c.validData[start:end])
+		valueStart, valueEnd = compactValueRange(c.indexMapping, start, end)
 	}
 	result := &columnVectorArrayBase[T]{
 		name:        c.name,

--- a/client/column/vector_array_test.go
+++ b/client/column/vector_array_test.go
@@ -220,6 +220,52 @@ func (s *VectorArraySuite) TestParseVectorArrayDataFloatSuccess() {
 	s.Equal(dim, fv.Dim())
 }
 
+func (s *VectorArraySuite) TestParseNullableVectorArrayData() {
+	dim := 2
+	row := func(data []float32) *schemapb.VectorField {
+		return &schemapb.VectorField{
+			Dim:  int64(dim),
+			Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: data}},
+		}
+	}
+	fd := &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfVector,
+		FieldName: "emb",
+		ValidData: []bool{true, false, true},
+		Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+			Dim: int64(dim),
+			Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{
+				Dim:         int64(dim),
+				ElementType: schemapb.DataType_FloatVector,
+				Data: []*schemapb.VectorField{
+					row([]float32{0.1, 0.2}),
+					row(nil),
+					row(nil),
+				},
+			}},
+		}},
+	}
+
+	col, err := FieldDataColumn(fd, 0, -1)
+	s.Require().NoError(err)
+	s.True(col.Nullable())
+	s.Equal(3, col.Len())
+	s.Equal(2, col.ValidCount())
+	value, err := col.Get(1)
+	s.Require().NoError(err)
+	s.Nil(value)
+	isNull, err := col.IsNull(2)
+	s.Require().NoError(err)
+	s.False(isNull, "an empty vector array is distinct from null")
+
+	sliced := col.Slice(1, -1)
+	s.True(sliced.Nullable())
+	s.Equal(2, sliced.Len())
+	value, err = sliced.Get(0)
+	s.Require().NoError(err)
+	s.Nil(value)
+}
+
 func (s *VectorArraySuite) TestParseVectorArrayDataByteTypes() {
 	dim := 4
 	// Build a single payload holding 2 inner vectors of `dim*2` bytes each.

--- a/client/column/vector_array_test.go
+++ b/client/column/vector_array_test.go
@@ -459,6 +459,56 @@ func (s *VectorArraySuite) TestSlice() {
 	s.Equal(0, sliced4.Len())
 }
 
+func (s *VectorArraySuite) TestSlicePreservesConcreteTypeAndPublicAppendShape() {
+	byteVector := []byte{1, 2, 3, 4}
+	cases := []struct {
+		name        string
+		column      Column
+		wantType    Column
+		appendValue any
+	}{
+		{
+			name:        "float",
+			column:      NewColumnFloatVectorArray("emb", 2, [][][]float32{{{1, 2}}}),
+			wantType:    (*ColumnFloatVectorArray)(nil),
+			appendValue: [][]float32{{3, 4}},
+		},
+		{
+			name:        "float16",
+			column:      NewColumnFloat16VectorArray("emb", 2, [][][]byte{{byteVector}}),
+			wantType:    (*ColumnFloat16VectorArray)(nil),
+			appendValue: [][]byte{byteVector},
+		},
+		{
+			name:        "bfloat16",
+			column:      NewColumnBFloat16VectorArray("emb", 2, [][][]byte{{byteVector}}),
+			wantType:    (*ColumnBFloat16VectorArray)(nil),
+			appendValue: [][]byte{byteVector},
+		},
+		{
+			name:        "binary",
+			column:      NewColumnBinaryVectorArray("emb", 8, [][][]byte{{{1}}}),
+			wantType:    (*ColumnBinaryVectorArray)(nil),
+			appendValue: [][]byte{{2}},
+		},
+		{
+			name:        "int8",
+			column:      NewColumnInt8VectorArray("emb", 2, [][][]int8{{{1, 2}}}),
+			wantType:    (*ColumnInt8VectorArray)(nil),
+			appendValue: [][]int8{{3, 4}},
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			sliced := tc.column.Slice(0, -1)
+			s.IsType(tc.wantType, sliced)
+			s.Require().NoError(sliced.AppendValue(tc.appendValue))
+			s.Equal(2, sliced.Len())
+		})
+	}
+}
+
 func TestVectorArray(t *testing.T) {
 	suite.Run(t, new(VectorArraySuite))
 }

--- a/client/column/vector_array_test.go
+++ b/client/column/vector_array_test.go
@@ -266,6 +266,26 @@ func (s *VectorArraySuite) TestParseNullableVectorArrayData() {
 	s.Nil(value)
 }
 
+func (s *VectorArraySuite) TestParseCompactNullableVectorArrayData() {
+	source := NewColumnFloatVectorArray("emb", 2, nil)
+	source.SetNullable(true)
+	s.Require().NoError(source.AppendValue([][]float32{{0.1, 0.2}}))
+	s.Require().NoError(source.AppendNull())
+	s.Require().NoError(source.AppendValue([][]float32{}))
+
+	parsed, err := FieldDataColumn(source.FieldData(), 0, -1)
+	s.Require().NoError(err)
+	s.True(parsed.Nullable())
+	s.Equal(3, parsed.Len())
+	s.Equal(2, parsed.ValidCount())
+	value, err := parsed.Get(1)
+	s.Require().NoError(err)
+	s.Nil(value)
+	isNull, err := parsed.IsNull(2)
+	s.Require().NoError(err)
+	s.False(isNull)
+}
+
 func (s *VectorArraySuite) TestParseVectorArrayDataByteTypes() {
 	dim := 4
 	// Build a single payload holding 2 inner vectors of `dim*2` bytes each.

--- a/client/column/vector_array_test.go
+++ b/client/column/vector_array_test.go
@@ -67,20 +67,30 @@ func (s *VectorArraySuite) TestFloatVectorArrayBasic() {
 	_, err = col.GetAsBool(0)
 	s.Error(err)
 
-	// Nullable helpers are no-ops / zero-valued for vector arrays.
+	// Nullable rows use logical indexes while payload rows stay compact.
 	isNull, err := col.IsNull(0)
 	s.NoError(err)
 	s.False(isNull)
 	s.Error(col.AppendNull())
 	col.SetNullable(true)
-	s.False(col.Nullable())
+	s.True(col.Nullable())
+	s.NoError(col.AppendNull())
+	s.Equal(3, col.Len())
+	s.Equal(2, col.ValidCount())
+	isNull, err = col.IsNull(2)
+	s.NoError(err)
+	s.True(isNull)
+	v, err = col.Get(2)
+	s.NoError(err)
+	s.Nil(v)
 	s.NoError(col.ValidateNullable())
 	col.CompactNullableValues()
 
 	// AppendValue via both canonical shapes.
 	s.NoError(col.AppendValue([]entity.FloatVector{entity.FloatVector([]float32{2.1, 2.2, 2.3, 2.4})}))
 	s.NoError(col.AppendValue([][]float32{{3.1, 3.2, 3.3, 3.4}}))
-	s.Equal(4, col.Len())
+	s.Equal(5, col.Len())
+	s.Equal(4, col.ValidCount())
 
 	// AppendValue rejects bad shapes.
 	s.Error(col.AppendValue([]int{1, 2, 3}))
@@ -94,6 +104,7 @@ func (s *VectorArraySuite) TestFloatVectorArrayBasic() {
 	s.EqualValues(dim, va.GetDim())
 	s.Equal(schemapb.DataType_FloatVector, va.GetElementType())
 	s.Equal(4, len(va.GetData()))
+	s.Equal([]bool{true, true, false, true, true}, fd.GetValidData())
 }
 
 func (s *VectorArraySuite) TestFloat16VectorArrayBasic() {

--- a/client/column/vector_array_test.go
+++ b/client/column/vector_array_test.go
@@ -459,6 +459,50 @@ func (s *VectorArraySuite) TestSlice() {
 	s.Equal(0, sliced4.Len())
 }
 
+func (s *VectorArraySuite) TestCompactSliceDoesNotMutateSource() {
+	row := func(data []float32) *schemapb.VectorField {
+		return &schemapb.VectorField{
+			Dim: 2,
+			Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: data},
+			},
+		}
+	}
+	fd := &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfVector,
+		FieldName: "emb",
+		ValidData: []bool{false, true, true},
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_VectorArray{
+					VectorArray: &schemapb.VectorArray{
+						Dim:         2,
+						ElementType: schemapb.DataType_FloatVector,
+						Data: []*schemapb.VectorField{
+							row(nil),
+							row([]float32{1, 2}),
+							row([]float32{3, 4}),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	source, err := FieldDataColumn(fd, 0, -1)
+	s.Require().NoError(err)
+	sliced := source.Slice(0, -1)
+	sliced.CompactNullableValues()
+
+	value, err := source.Get(1)
+	s.Require().NoError(err)
+	s.Equal([]entity.FloatVector{{1, 2}}, value)
+	value, err = source.Get(2)
+	s.Require().NoError(err)
+	s.Equal([]entity.FloatVector{{3, 4}}, value)
+}
+
 func (s *VectorArraySuite) TestSlicePreservesConcreteTypeAndPublicAppendShape() {
 	byteVector := []byte{1, 2, 3, 4}
 	cases := []struct {

--- a/client/column/vector_array_test.go
+++ b/client/column/vector_array_test.go
@@ -436,6 +436,33 @@ func (s *VectorArraySuite) TestParseVectorArrayDataFallbackDim() {
 	s.Equal(4, fv.Dim())
 }
 
+func (s *VectorArraySuite) TestParseAllNullVectorArrayUsesOuterDim() {
+	fd := &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfVector,
+		FieldName: "emb",
+		ValidData: []bool{false, false},
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_VectorArray{
+					VectorArray: &schemapb.VectorArray{
+						ElementType: schemapb.DataType_FloatVector,
+					},
+				},
+			},
+		},
+	}
+
+	parsed, err := FieldDataColumn(fd, 0, -1)
+	s.Require().NoError(err)
+	vectorArray, ok := parsed.(*ColumnFloatVectorArray)
+	s.Require().True(ok)
+	s.Equal(2, vectorArray.Dim())
+	s.Equal(2, vectorArray.Len())
+	s.Zero(vectorArray.ValidCount())
+	s.Require().NoError(vectorArray.ValidateNullable())
+}
+
 func (s *VectorArraySuite) TestSlice() {
 	dim := 2
 	rows := [][][]float32{

--- a/client/column/vector_array_test.go
+++ b/client/column/vector_array_test.go
@@ -367,7 +367,7 @@ func (s *VectorArraySuite) TestParseVectorArrayDataUnsupportedElement() {
 	s.Error(err)
 }
 
-func (s *VectorArraySuite) TestParseVectorArrayDataBeginEndClamping() {
+func (s *VectorArraySuite) TestParseVectorArrayDataRangeValidation() {
 	dim := 2
 	row := &schemapb.VectorField{
 		Dim: int64(dim),
@@ -391,15 +391,18 @@ func (s *VectorArraySuite) TestParseVectorArrayDataBeginEndClamping() {
 			},
 		},
 	}
-	// negative begin gets clamped to 0; end > len clamped to len.
-	col, err := FieldDataColumn(fd, -5, 10)
+	col, err := FieldDataColumn(fd, 1, -1)
 	s.NoError(err)
-	s.Equal(3, col.Len())
+	s.Equal(2, col.Len())
 
-	// begin > end collapses to empty.
-	col2, err := FieldDataColumn(fd, 10, 1)
-	s.NoError(err)
-	s.Equal(0, col2.Len())
+	_, err = FieldDataColumn(fd, -1, 2)
+	s.Error(err)
+	_, err = FieldDataColumn(fd, 0, 4)
+	s.Error(err)
+	_, err = FieldDataColumn(fd, 0, -2)
+	s.Error(err)
+	_, err = FieldDataColumn(fd, 2, 1)
+	s.Error(err)
 }
 
 func (s *VectorArraySuite) TestParseVectorArrayDataFallbackDim() {

--- a/client/milvusclient/read.go
+++ b/client/milvusclient/read.go
@@ -146,6 +146,31 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 		schemaFields[field.Name] = field
 	}
 	dynamicNames := outputSet.Complement(schemaFieldSet)
+	structOutputParents := make(map[string]string)
+	structOutputSelections := make(map[string]map[string]struct{})
+	for _, field := range sch.Fields {
+		if field.DataType != entity.FieldTypeArray || field.ElementType != entity.FieldTypeStruct || field.StructSchema == nil {
+			continue
+		}
+		_, parentRequested := outputSet[field.Name]
+		for _, subField := range field.StructSchema.Fields {
+			outputName := field.Name + "[" + subField.Name + "]"
+			if _, requested := outputSet[outputName]; !requested {
+				continue
+			}
+			delete(dynamicNames, outputName)
+			structOutputParents[outputName] = field.Name
+			if parentRequested {
+				continue
+			}
+			selection := structOutputSelections[field.Name]
+			if selection == nil {
+				selection = make(map[string]struct{})
+				structOutputSelections[field.Name] = selection
+			}
+			selection[subField.Name] = struct{}{}
+		}
+	}
 
 	columns := make([]column.Column, 0, len(outputFields))
 	var dynamicColumn *column.ColumnJSONBytes
@@ -183,16 +208,20 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 	if len(fieldDataList) == 0 {
 		seen := make(map[string]struct{}, len(outputFields))
 		for _, fieldName := range outputFields {
-			if _, ok := seen[fieldName]; ok {
+			parentName := fieldName
+			if name, ok := structOutputParents[fieldName]; ok {
+				parentName = name
+			}
+			if _, ok := seen[parentName]; ok {
 				continue
 			}
-			seen[fieldName] = struct{}{}
+			seen[parentName] = struct{}{}
 
-			field := schemaFields[fieldName]
+			field := schemaFields[parentName]
 			if field == nil || field.DataType != entity.FieldTypeArray || field.ElementType != entity.FieldTypeStruct {
 				continue
 			}
-			col, err := newEmptyStructArrayColumn(field)
+			col, err := newEmptyStructArrayColumn(field, structOutputSelections[parentName])
 			if err != nil {
 				return nil, err
 			}
@@ -220,13 +249,18 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 	return columns, nil
 }
 
-func newEmptyStructArrayColumn(field *entity.Field) (column.Column, error) {
+func newEmptyStructArrayColumn(field *entity.Field, selectedSubFields map[string]struct{}) (column.Column, error) {
 	if field.StructSchema == nil {
 		return nil, errors.Newf("struct array field %q has no struct schema", field.Name)
 	}
 
 	subColumns := make([]column.Column, 0, len(field.StructSchema.Fields))
 	for _, subField := range field.StructSchema.Fields {
+		if selectedSubFields != nil {
+			if _, ok := selectedSubFields[subField.Name]; !ok {
+				continue
+			}
+		}
 		subColumn, err := newStructSubColumn(subField)
 		if err != nil {
 			return nil, errors.Wrapf(err, "create empty struct array field %q", field.Name)

--- a/client/milvusclient/read.go
+++ b/client/milvusclient/read.go
@@ -263,7 +263,11 @@ func (c *Client) Query(ctx context.Context, option QueryOption, callOptions ...g
 			return err
 		}
 
-		columns, err := c.parseSearchResult(collection.Schema, resp.GetOutputFields(), resp.GetFieldsData(), 0, 0, -1)
+		outputFields := resp.GetOutputFields()
+		if len(outputFields) == 0 {
+			outputFields = req.GetOutputFields()
+		}
+		columns, err := c.parseSearchResult(collection.Schema, outputFields, resp.GetFieldsData(), 0, 0, -1)
 		if err != nil {
 			return err
 		}

--- a/client/milvusclient/read.go
+++ b/client/milvusclient/read.go
@@ -198,6 +198,9 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 			}
 			columns = append(columns, col)
 		}
+		if sch.EnableDynamicField && len(dynamicNames) > 0 {
+			dynamicColumn = column.NewColumnJSONBytes("", nil)
+		}
 	}
 
 	// extra name found and not json output

--- a/client/milvusclient/read.go
+++ b/client/milvusclient/read.go
@@ -141,6 +141,10 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 	schemaFieldSet := typeutil.NewSet(lo.Map(sch.Fields, func(f *entity.Field, _ int) string {
 		return f.Name
 	})...)
+	schemaFields := make(map[string]*entity.Field, len(sch.Fields))
+	for _, field := range sch.Fields {
+		schemaFields[field.Name] = field
+	}
 	dynamicNames := outputSet.Complement(schemaFieldSet)
 
 	columns := make([]column.Column, 0, len(outputFields))
@@ -149,6 +153,12 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 		col, err := column.FieldDataColumn(fieldData, from, to)
 		if err != nil {
 			return nil, err
+		}
+		if field := schemaFields[fieldData.GetFieldName()]; field != nil && field.Nullable && !col.Nullable() {
+			col.SetNullable(true)
+			if err := col.ValidateNullable(); err != nil {
+				return nil, errors.Wrapf(err, "restore nullable state for field %q", fieldData.GetFieldName())
+			}
 		}
 
 		// if output data contains dynamic json, setup dynamicColumn

--- a/client/milvusclient/read.go
+++ b/client/milvusclient/read.go
@@ -180,6 +180,25 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 
 		columns = append(columns, col)
 	}
+	if len(fieldDataList) == 0 {
+		seen := make(map[string]struct{}, len(outputFields))
+		for _, fieldName := range outputFields {
+			if _, ok := seen[fieldName]; ok {
+				continue
+			}
+			seen[fieldName] = struct{}{}
+
+			field := schemaFields[fieldName]
+			if field == nil || field.DataType != entity.FieldTypeArray || field.ElementType != entity.FieldTypeStruct {
+				continue
+			}
+			col, err := newEmptyStructArrayColumn(field)
+			if err != nil {
+				return nil, err
+			}
+			columns = append(columns, col)
+		}
+	}
 
 	// extra name found and not json output
 	if len(dynamicNames) > 0 && dynamicColumn == nil {
@@ -196,6 +215,27 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 	}
 
 	return columns, nil
+}
+
+func newEmptyStructArrayColumn(field *entity.Field) (column.Column, error) {
+	if field.StructSchema == nil {
+		return nil, errors.Newf("struct array field %q has no struct schema", field.Name)
+	}
+
+	subColumns := make([]column.Column, 0, len(field.StructSchema.Fields))
+	for _, subField := range field.StructSchema.Fields {
+		subColumn, err := newStructSubColumn(subField)
+		if err != nil {
+			return nil, errors.Wrapf(err, "create empty struct array field %q", field.Name)
+		}
+		subColumns = append(subColumns, subColumn)
+	}
+	col := column.NewColumnStructArray(field.Name, subColumns)
+	col.SetNullable(field.Nullable)
+	if err := col.ValidateNullable(); err != nil {
+		return nil, errors.Wrapf(err, "create empty struct array field %q", field.Name)
+	}
+	return col, nil
 }
 
 func (c *Client) Query(ctx context.Context, option QueryOption, callOptions ...grpc.CallOption) (ResultSet, error) {

--- a/client/milvusclient/read.go
+++ b/client/milvusclient/read.go
@@ -76,7 +76,32 @@ func (c *Client) handleSearchResult(schema *entity.Schema, outputFields []string
 	offset := 0
 	fieldDataList := results.GetFieldsData()
 	gb := results.GetGroupByFieldValue()
-	for i := 0; i < int(results.GetNumQueries()); i++ {
+	queryCount := int(results.GetNumQueries())
+
+	parseWholeResult := queryCount > 0 && len(results.GetTopks()) >= queryCount
+	totalResultCount := 0
+	if parseWholeResult {
+		for _, topk := range results.GetTopks()[:queryCount] {
+			if topk < 0 {
+				parseWholeResult = false
+				break
+			}
+			totalResultCount += int(topk)
+		}
+	}
+
+	var fields []column.Column
+	var fieldsErr error
+	var groupBy column.Column
+	var groupByErr error
+	if parseWholeResult && (!isAggregationResult || totalResultCount > 0) {
+		fields, fieldsErr = c.parseSearchResult(schema, outputFields, fieldDataList, 0, 0, totalResultCount)
+		if gb != nil {
+			groupBy, groupByErr = column.FieldDataColumn(gb, 0, totalResultCount)
+		}
+	}
+
+	for i := 0; i < queryCount; i++ {
 		func() {
 			var rc int
 			entry := ResultSet{
@@ -112,15 +137,39 @@ func (c *Client) handleSearchResult(schema *entity.Schema, outputFields []string
 			}
 			// parse group-by values
 			if gb != nil {
-				entry.GroupByValue, entry.Err = column.FieldDataColumn(gb, offset, offset+rc)
+				if parseWholeResult {
+					if groupByErr != nil {
+						entry.Err = groupByErr
+						return
+					}
+					entry.GroupByValue = groupBy.Slice(offset, offset+rc)
+				} else {
+					entry.GroupByValue, entry.Err = column.FieldDataColumn(gb, offset, offset+rc)
+				}
 				if entry.Err != nil {
 					return
 				}
 			}
-			entry.Fields, entry.Err = c.parseSearchResult(schema, outputFields, fieldDataList, i, offset, offset+rc)
+			if parseWholeResult {
+				if fieldsErr != nil {
+					entry.Err = fieldsErr
+					return
+				}
+				entry.Fields = sliceSearchResultColumns(fields, offset, offset+rc)
+			} else {
+				entry.Fields, entry.Err = c.parseSearchResult(schema, outputFields, fieldDataList, i, offset, offset+rc)
+			}
 		}()
 	}
 	return sr, nil
+}
+
+func sliceSearchResultColumns(columns []column.Column, start, end int) []column.Column {
+	sliced := make([]column.Column, len(columns))
+	for idx, field := range columns {
+		sliced[idx] = field.Slice(start, end)
+	}
+	return sliced
 }
 
 func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fieldDataList []*schemapb.FieldData, _, from, to int) ([]column.Column, error) {

--- a/client/milvusclient/read.go
+++ b/client/milvusclient/read.go
@@ -191,8 +191,12 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 		return f.Name
 	})...)
 	schemaFields := make(map[string]*entity.Field, len(sch.Fields))
+	var dynamicSchemaField *entity.Field
 	for _, field := range sch.Fields {
 		schemaFields[field.Name] = field
+		if field.IsDynamic {
+			dynamicSchemaField = field
+		}
 	}
 	dynamicNames := outputSet.Complement(schemaFieldSet)
 	structOutputParents := make(map[string]string)
@@ -276,8 +280,27 @@ func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fi
 			}
 			columns = append(columns, col)
 		}
-		if sch.EnableDynamicField && len(dynamicNames) > 0 {
-			dynamicColumn = column.NewColumnJSONBytes("", nil)
+		if sch.EnableDynamicField && (dynamicSchemaField != nil || len(dynamicNames) > 0) {
+			dynamicFieldName := ""
+			dynamicFieldNullable := false
+			dynamicFieldRequested := false
+			if dynamicSchemaField != nil {
+				dynamicFieldName = dynamicSchemaField.Name
+				dynamicFieldNullable = dynamicSchemaField.Nullable
+				_, dynamicFieldRequested = outputSet[dynamicFieldName]
+			}
+			if dynamicFieldRequested || len(dynamicNames) > 0 {
+				dynamicColumn = column.NewColumnJSONBytes(dynamicFieldName, nil).WithIsDynamic(true)
+				if dynamicFieldNullable {
+					dynamicColumn.SetNullable(true)
+					if err := dynamicColumn.ValidateNullable(); err != nil {
+						return nil, errors.Wrapf(err, "create empty dynamic field %q", dynamicFieldName)
+					}
+				}
+				if dynamicFieldRequested {
+					columns = append(columns, dynamicColumn)
+				}
+			}
 		}
 	}
 

--- a/client/milvusclient/read.go
+++ b/client/milvusclient/read.go
@@ -155,21 +155,13 @@ func (c *Client) handleSearchResult(schema *entity.Schema, outputFields []string
 					entry.Err = fieldsErr
 					return
 				}
-				entry.Fields = sliceSearchResultColumns(fields, offset, offset+rc)
+				entry.Fields = column.SliceColumns(fields, offset, offset+rc)
 			} else {
 				entry.Fields, entry.Err = c.parseSearchResult(schema, outputFields, fieldDataList, i, offset, offset+rc)
 			}
 		}()
 	}
 	return sr, nil
-}
-
-func sliceSearchResultColumns(columns []column.Column, start, end int) []column.Column {
-	sliced := make([]column.Column, len(columns))
-	for idx, field := range columns {
-		sliced[idx] = field.Slice(start, end)
-	}
-	return sliced
 }
 
 func (c *Client) parseSearchResult(sch *entity.Schema, outputFields []string, fieldDataList []*schemapb.FieldData, _, from, to int) ([]column.Column, error) {

--- a/client/milvusclient/read_test.go
+++ b/client/milvusclient/read_test.go
@@ -396,6 +396,39 @@ func (s *ReadSuite) TestQuery() {
 		s.Require().NoError(clips.ValidateNullable())
 	})
 
+	s.Run("empty nullable struct array sub-field", func() {
+		collectionName := fmt.Sprintf("coll_%s", s.randString(6))
+		structSchema := entity.NewStructSchema().
+			WithField(entity.NewField().WithName("label").WithDataType(entity.FieldTypeInt64)).
+			WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(2))
+		schema := entity.NewSchema().
+			WithField(entity.NewField().WithName("ID").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+			WithField(entity.NewField().
+				WithName("clips").
+				WithDataType(entity.FieldTypeArray).
+				WithElementType(entity.FieldTypeStruct).
+				WithNullable(true).
+				WithStructSchema(structSchema))
+		s.setupCache(collectionName, schema)
+
+		s.mock.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, qr *milvuspb.QueryRequest) (*milvuspb.QueryResults, error) {
+			s.Equal([]string{"clips[label]"}, qr.GetOutputFields())
+			return &milvuspb.QueryResults{}, nil
+		}).Once()
+
+		rs, err := s.client.Query(ctx, NewQueryOption(collectionName).
+			WithFilter("ID < 0").
+			WithOutputFields("clips[label]"))
+		s.Require().NoError(err)
+		clips := rs.GetColumn("clips")
+		s.Require().NotNil(clips)
+		s.True(clips.Nullable())
+		s.Zero(clips.Len())
+		s.Require().NoError(clips.ValidateNullable())
+		s.Require().Len(clips.FieldData().GetStructArrays().GetFields(), 1)
+		s.Equal("label", clips.FieldData().GetStructArrays().GetFields()[0].GetFieldName())
+	})
+
 	s.Run("empty dynamic field", func() {
 		collectionName := fmt.Sprintf("coll_%s", s.randString(6))
 		schema := entity.NewSchema().WithDynamicFieldEnabled(true).

--- a/client/milvusclient/read_test.go
+++ b/client/milvusclient/read_test.go
@@ -365,6 +365,37 @@ func (s *ReadSuite) TestQuery() {
 		s.NotNil(rs.sch)
 	})
 
+	s.Run("empty nullable struct array", func() {
+		collectionName := fmt.Sprintf("coll_%s", s.randString(6))
+		structSchema := entity.NewStructSchema().
+			WithField(entity.NewField().WithName("label").WithDataType(entity.FieldTypeInt64)).
+			WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(2))
+		schema := entity.NewSchema().
+			WithField(entity.NewField().WithName("ID").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+			WithField(entity.NewField().
+				WithName("clips").
+				WithDataType(entity.FieldTypeArray).
+				WithElementType(entity.FieldTypeStruct).
+				WithNullable(true).
+				WithStructSchema(structSchema))
+		s.setupCache(collectionName, schema)
+
+		s.mock.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, qr *milvuspb.QueryRequest) (*milvuspb.QueryResults, error) {
+			s.Equal([]string{"clips"}, qr.GetOutputFields())
+			return &milvuspb.QueryResults{}, nil
+		}).Once()
+
+		rs, err := s.client.Query(ctx, NewQueryOption(collectionName).
+			WithFilter("ID < 0").
+			WithOutputFields("clips"))
+		s.Require().NoError(err)
+		clips := rs.GetColumn("clips")
+		s.Require().NotNil(clips)
+		s.True(clips.Nullable())
+		s.Zero(clips.Len())
+		s.Require().NoError(clips.ValidateNullable())
+	})
+
 	s.Run("bad_request", func() {
 		collectionName := fmt.Sprintf("coll_%s", s.randString(6))
 		s.setupCache(collectionName, s.schema)

--- a/client/milvusclient/read_test.go
+++ b/client/milvusclient/read_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/client/v3/column"
 	"github.com/milvus-io/milvus/client/v3/entity"
 	"github.com/milvus-io/milvus/client/v3/index"
 	"github.com/milvus-io/milvus/client/v3/internal/merr"
@@ -189,6 +191,34 @@ func (s *ReadSuite) TestSearch() {
 		}))
 		s.Error(err)
 	})
+}
+
+func (s *ReadSuite) TestParseEmptyNullableStructArrayFromWire() {
+	schema := entity.NewSchema().WithField(entity.NewField().
+		WithName("clips").
+		WithDataType(entity.FieldTypeArray).
+		WithElementType(entity.FieldTypeStruct).
+		WithNullable(true))
+	source := column.NewColumnStructArray("clips", []column.Column{
+		column.NewColumnInt64Array("label", nil),
+		column.NewColumnFloatVectorArray("embedding", 2, nil),
+	})
+	source.SetNullable(true)
+
+	wire, err := proto.Marshal(source.FieldData())
+	s.Require().NoError(err)
+	decoded := &schemapb.FieldData{}
+	s.Require().NoError(proto.Unmarshal(wire, decoded))
+	for _, subField := range decoded.GetStructArrays().GetFields() {
+		s.Nil(subField.ValidData)
+	}
+
+	columns, err := s.client.parseSearchResult(schema, []string{"clips"}, []*schemapb.FieldData{decoded}, 0, 0, 0)
+	s.Require().NoError(err)
+	s.Require().Len(columns, 1)
+	s.True(columns[0].Nullable())
+	s.Zero(columns[0].Len())
+	s.Require().NoError(columns[0].ValidateNullable())
 }
 
 // TestSearch_TextMatch tests the text match search functionality.

--- a/client/milvusclient/read_test.go
+++ b/client/milvusclient/read_test.go
@@ -396,6 +396,26 @@ func (s *ReadSuite) TestQuery() {
 		s.Require().NoError(clips.ValidateNullable())
 	})
 
+	s.Run("empty dynamic field", func() {
+		collectionName := fmt.Sprintf("coll_%s", s.randString(6))
+		schema := entity.NewSchema().WithDynamicFieldEnabled(true).
+			WithField(entity.NewField().WithName("ID").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true))
+		s.setupCache(collectionName, schema)
+
+		s.mock.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, qr *milvuspb.QueryRequest) (*milvuspb.QueryResults, error) {
+			s.Equal([]string{"dynamic_key"}, qr.GetOutputFields())
+			return &milvuspb.QueryResults{}, nil
+		}).Once()
+
+		rs, err := s.client.Query(ctx, NewQueryOption(collectionName).
+			WithFilter("ID < 0").
+			WithOutputFields("dynamic_key"))
+		s.Require().NoError(err)
+		dynamic := rs.GetColumn("dynamic_key")
+		s.Require().NotNil(dynamic)
+		s.Zero(dynamic.Len())
+	})
+
 	s.Run("bad_request", func() {
 		collectionName := fmt.Sprintf("coll_%s", s.randString(6))
 		s.setupCache(collectionName, s.schema)

--- a/client/milvusclient/read_test.go
+++ b/client/milvusclient/read_test.go
@@ -221,6 +221,24 @@ func (s *ReadSuite) TestParseEmptyNullableStructArrayFromWire() {
 	s.Require().NoError(columns[0].ValidateNullable())
 }
 
+func (s *ReadSuite) TestParseEmptyNullableStructArrayWithoutFieldData() {
+	schema := entity.NewSchema().WithField(entity.NewField().
+		WithName("clips").
+		WithDataType(entity.FieldTypeArray).
+		WithElementType(entity.FieldTypeStruct).
+		WithNullable(true).
+		WithStructSchema(entity.NewStructSchema().
+			WithField(entity.NewField().WithName("label").WithDataType(entity.FieldTypeInt64)).
+			WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(2))))
+
+	columns, err := s.client.parseSearchResult(schema, []string{"clips"}, nil, 0, 0, 0)
+	s.Require().NoError(err)
+	s.Require().Len(columns, 1)
+	s.True(columns[0].Nullable())
+	s.Zero(columns[0].Len())
+	s.Require().NoError(columns[0].ValidateNullable())
+}
+
 // TestSearch_TextMatch tests the text match search functionality.
 // It tests the minimum_should_match parameter in the expression.
 func (s *ReadSuite) TestSearch_TextMatch() {

--- a/client/milvusclient/read_test.go
+++ b/client/milvusclient/read_test.go
@@ -239,6 +239,73 @@ func (s *ReadSuite) TestParseEmptyNullableStructArrayWithoutFieldData() {
 	s.Require().NoError(columns[0].ValidateNullable())
 }
 
+func (s *ReadSuite) TestHandleSearchResultSlicesCompactNullableFields() {
+	schema := entity.NewSchema().
+		WithField(entity.NewField().WithName("ID").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName("age").WithDataType(entity.FieldTypeInt64).WithNullable(true))
+	age := s.getInt64FieldData("age", []int64{10, 40})
+	age.ValidData = []bool{true, false, false, true}
+	resp := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 2,
+			Topks:      []int64{2, 2},
+			Scores:     []float32{0.4, 0.3, 0.2, 0.1},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4}},
+				},
+			},
+			FieldsData: []*schemapb.FieldData{age},
+		},
+	}
+
+	results, err := s.client.handleSearchResult(schema, []string{"age"}, 2, resp)
+	s.Require().NoError(err)
+	s.Require().Len(results, 2)
+	for _, result := range results {
+		s.Require().NoError(result.Err)
+		s.Require().Len(result.Fields, 1)
+		s.Equal(2, result.Fields[0].Len())
+	}
+
+	value, err := results[0].Fields[0].Get(0)
+	s.Require().NoError(err)
+	s.EqualValues(10, value)
+	isNull, err := results[0].Fields[0].IsNull(1)
+	s.Require().NoError(err)
+	s.True(isNull)
+	isNull, err = results[1].Fields[0].IsNull(0)
+	s.Require().NoError(err)
+	s.True(isNull)
+	value, err = results[1].Fields[0].Get(1)
+	s.Require().NoError(err)
+	s.EqualValues(40, value)
+}
+
+func (s *ReadSuite) TestHandleSearchResultRejectsTruncatedFieldData() {
+	resp := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 2,
+			Topks:      []int64{1, 1},
+			Scores:     []float32{0.2, 0.1},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2}},
+				},
+			},
+			FieldsData: []*schemapb.FieldData{
+				s.getInt64FieldData("ID", []int64{1}),
+			},
+		},
+	}
+
+	results, err := s.client.handleSearchResult(s.schema, []string{"ID"}, 2, resp)
+	s.Require().NoError(err)
+	s.Require().Len(results, 2)
+	s.Error(results[0].Err)
+	s.Error(results[1].Err)
+}
+
 // TestSearch_TextMatch tests the text match search functionality.
 // It tests the minimum_should_match parameter in the expression.
 func (s *ReadSuite) TestSearch_TextMatch() {

--- a/client/milvusclient/read_test.go
+++ b/client/milvusclient/read_test.go
@@ -344,6 +344,38 @@ func (s *ReadSuite) TestHandleSearchResultPreservesNullableGeometryRows() {
 	s.Equal("POINT (1 2)", value)
 }
 
+func (s *ReadSuite) TestHandleSearchResultSharesDynamicProjectionBase() {
+	resp := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			Topks:      []int64{2},
+			Scores:     []float32{0.2, 0.1},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2}},
+				},
+			},
+			FieldsData: []*schemapb.FieldData{
+				s.getJSONBytesFieldData("$meta", [][]byte{
+					[]byte(`{"color": "red", "price": 10}`),
+					[]byte(`{"color": "blue", "price": 20}`),
+				}, true),
+			},
+		},
+	}
+
+	results, err := s.client.handleSearchResult(s.schemaDyn, []string{"color", "price"}, 1, resp)
+	s.Require().NoError(err)
+	s.Require().Len(results, 1)
+	s.Require().NoError(results[0].Err)
+	s.Require().Len(results[0].Fields, 2)
+	color, ok := results[0].Fields[0].(*column.ColumnDynamic)
+	s.Require().True(ok)
+	price, ok := results[0].Fields[1].(*column.ColumnDynamic)
+	s.Require().True(ok)
+	s.Same(color.ColumnJSONBytes, price.ColumnJSONBytes)
+}
+
 func (s *ReadSuite) TestHandleSearchResultRejectsTruncatedFieldData() {
 	resp := &milvuspb.SearchResults{
 		Results: &schemapb.SearchResultData{

--- a/client/milvusclient/read_test.go
+++ b/client/milvusclient/read_test.go
@@ -239,6 +239,34 @@ func (s *ReadSuite) TestParseEmptyNullableStructArrayWithoutFieldData() {
 	s.Require().NoError(columns[0].ValidateNullable())
 }
 
+func (s *ReadSuite) TestParseEmptyDynamicFieldWithoutFieldData() {
+	schema := entity.NewSchema().
+		WithDynamicFieldEnabled(true).
+		WithField(entity.NewField().
+			WithName("$meta").
+			WithDataType(entity.FieldTypeJSON).
+			WithIsDynamic(true).
+			WithNullable(true))
+
+	for _, outputFields := range [][]string{{"$meta"}, {"*"}} {
+		columns, err := s.client.parseSearchResult(schema, outputFields, nil, 0, 0, 0)
+		s.Require().NoError(err)
+		s.Require().Len(columns, 1)
+		s.Equal("$meta", columns[0].Name())
+		s.Equal(entity.FieldTypeJSON, columns[0].Type())
+		s.True(columns[0].Nullable())
+		s.Zero(columns[0].Len())
+		s.True(columns[0].FieldData().GetIsDynamic())
+	}
+
+	columns, err := s.client.parseSearchResult(schema, []string{"color"}, nil, 0, 0, 0)
+	s.Require().NoError(err)
+	s.Require().Len(columns, 1)
+	s.Equal("color", columns[0].Name())
+	s.True(columns[0].Nullable())
+	s.Zero(columns[0].Len())
+}
+
 func (s *ReadSuite) TestHandleSearchResultSlicesCompactNullableFields() {
 	schema := entity.NewSchema().
 		WithField(entity.NewField().WithName("ID").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).

--- a/client/milvusclient/read_test.go
+++ b/client/milvusclient/read_test.go
@@ -282,6 +282,40 @@ func (s *ReadSuite) TestHandleSearchResultSlicesCompactNullableFields() {
 	s.EqualValues(40, value)
 }
 
+func (s *ReadSuite) TestHandleSearchResultPreservesNullableGeometryRows() {
+	schema := entity.NewSchema().
+		WithField(entity.NewField().WithName("ID").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName("location").WithDataType(entity.FieldTypeGeometry).WithNullable(true))
+	location := s.getGeometryWktFieldData("location", []string{"POINT (1 2)"})
+	location.ValidData = []bool{false, true}
+	resp := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			Topks:      []int64{2},
+			Scores:     []float32{0.2, 0.1},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2}},
+				},
+			},
+			FieldsData: []*schemapb.FieldData{location},
+		},
+	}
+
+	results, err := s.client.handleSearchResult(schema, []string{"location"}, 1, resp)
+	s.Require().NoError(err)
+	s.Require().Len(results, 1)
+	s.Require().NoError(results[0].Err)
+	s.Require().Len(results[0].Fields, 1)
+	s.Equal(2, results[0].Fields[0].Len())
+	isNull, err := results[0].Fields[0].IsNull(0)
+	s.Require().NoError(err)
+	s.True(isNull)
+	value, err := results[0].Fields[0].GetAsString(1)
+	s.Require().NoError(err)
+	s.Equal("POINT (1 2)", value)
+}
+
 func (s *ReadSuite) TestHandleSearchResultRejectsTruncatedFieldData() {
 	resp := &milvuspb.SearchResults{
 		Results: &schemapb.SearchResultData{

--- a/client/milvusclient/write_option_test.go
+++ b/client/milvusclient/write_option_test.go
@@ -165,6 +165,32 @@ func (s *ColumnBasedDataOptionSuite) TestWithNullableStructArrayColumn() {
 	s.Len(subs[1].GetVectors().GetVectorArray().GetData(), 2)
 }
 
+func (s *ColumnBasedDataOptionSuite) TestWithNullableStructArrayColumnRejectsNilSubField() {
+	structSchema := entity.NewStructSchema().
+		WithField(entity.NewField().WithName("clip_str").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64)).
+		WithField(entity.NewField().WithName("clip_emb").WithDataType(entity.FieldTypeFloatVector).WithDim(2))
+	collSchema := entity.NewSchema().WithName("c").
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().
+			WithName("clips").
+			WithDataType(entity.FieldTypeArray).
+			WithElementType(entity.FieldTypeStruct).
+			WithMaxCapacity(16).
+			WithStructSchema(structSchema).
+			WithNullable(true))
+
+	opt := NewColumnBasedInsertOption("c").
+		WithInt64Column("id", []int64{1, 2}).
+		WithStructArrayColumn("clips", structSchema, []map[string]any{
+			nil,
+			{"clip_str": nil, "clip_emb": [][]float32{{0.1, 0.2}}},
+		})
+
+	_, err := opt.InsertRequest(&entity.Collection{Schema: collSchema})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "clip_str")
+}
+
 func (s *ColumnBasedDataOptionSuite) TestWithStructArrayColumnDeferredError() {
 	structSchema := entity.NewStructSchema().
 		WithField(entity.NewField().WithName("clip_str").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64))

--- a/client/milvusclient/write_option_test.go
+++ b/client/milvusclient/write_option_test.go
@@ -120,6 +120,51 @@ func (s *ColumnBasedDataOptionSuite) TestWithStructArrayColumn() {
 	s.EqualValues(1*dim, len(va.GetData()[1].GetFloatVector().GetData()))
 }
 
+func (s *ColumnBasedDataOptionSuite) TestWithNullableStructArrayColumn() {
+	dim := 2
+	structSchema := entity.NewStructSchema().
+		WithField(entity.NewField().WithName("clip_str").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64)).
+		WithField(entity.NewField().WithName("clip_emb").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(dim)))
+	collSchema := entity.NewSchema().WithName("c").
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().
+			WithName("clips").
+			WithDataType(entity.FieldTypeArray).
+			WithElementType(entity.FieldTypeStruct).
+			WithMaxCapacity(16).
+			WithStructSchema(structSchema).
+			WithNullable(true))
+
+	rows := []map[string]any{
+		{"clip_str": []string{"a"}, "clip_emb": [][]float32{{0.1, 0.2}}},
+		nil,
+		{"clip_str": []string{}, "clip_emb": [][]float32{}},
+	}
+	opt := NewColumnBasedInsertOption("c").
+		WithInt64Column("id", []int64{1, 2, 3}).
+		WithStructArrayColumn("clips", structSchema, rows)
+
+	req, err := opt.InsertRequest(&entity.Collection{Schema: collSchema})
+	s.Require().NoError(err)
+	s.EqualValues(3, req.GetNumRows())
+
+	var clipsFD *schemapb.FieldData
+	for _, fd := range req.GetFieldsData() {
+		if fd.GetFieldName() == "clips" {
+			clipsFD = fd
+			break
+		}
+	}
+	s.Require().NotNil(clipsFD)
+	subs := clipsFD.GetStructArrays().GetFields()
+	s.Require().Len(subs, 2)
+	for _, sub := range subs {
+		s.Equal([]bool{true, false, true}, sub.GetValidData())
+	}
+	s.Len(subs[0].GetScalars().GetArrayData().GetData(), 2)
+	s.Len(subs[1].GetVectors().GetVectorArray().GetData(), 2)
+}
+
 func (s *ColumnBasedDataOptionSuite) TestWithStructArrayColumnDeferredError() {
 	structSchema := entity.NewStructSchema().
 		WithField(entity.NewField().WithName("clip_str").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64))

--- a/client/milvusclient/write_options.go
+++ b/client/milvusclient/write_options.go
@@ -314,6 +314,12 @@ func buildStructArrayColumn(colName string, structSchema *entity.StructSchema, r
 		subColumns = append(subColumns, subColumn)
 	}
 	structCol := column.NewColumnStructArray(colName, subColumns)
+	for _, row := range rows {
+		if row == nil {
+			structCol.SetNullable(true)
+			break
+		}
+	}
 	for i, row := range rows {
 		if err := structCol.AppendValue(row); err != nil {
 			return nil, errors.Wrapf(err, "row %d", i)

--- a/client/milvusclient/write_options.go
+++ b/client/milvusclient/write_options.go
@@ -275,9 +275,10 @@ func (opt *columnBasedDataOption) WithInt8VectorColumn(colName string, dim int, 
 // WithStructArrayColumn appends a struct-array column built from a row-based representation,
 // inferring the per-sub-field array type from the corresponding field in `structSchema`.
 //
-// `rows` is a per-collection-row list; each entry is a map keyed by sub-field name. The value
-// for a scalar sub-field must be `[]<T>` (e.g. []int32, []string); the value for a vector
-// sub-field must be `[][]float32` / `[][]byte` / `[][]int8` matching the vector type.
+// `rows` is a per-collection-row list; a nil entry represents a null StructArray row. Each
+// non-null entry is a map keyed by sub-field name. The value for a scalar sub-field must be
+// `[]<T>` (e.g. []int32, []string); the value for a vector sub-field must be
+// `[][]float32` / `[][]byte` / `[][]int8` matching the vector type.
 //
 // Example:
 //

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"net/http"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -489,6 +490,13 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 				rawValue := gjson.Get(data.Raw, structField.GetName())
 				if partialUpdate && !rawValue.Exists() {
 					continue
+				}
+				if structField.GetNullable() {
+					if rawValue.Type == gjson.Null {
+						validDataMap[structField.GetName()] = append(validDataMap[structField.GetName()], false)
+						continue
+					}
+					validDataMap[structField.GetName()] = append(validDataMap[structField.GetName()], true)
 				}
 				structRow, err := parseStructArrayRow(rawValue.Raw, structField)
 				if err != nil {
@@ -1290,8 +1298,29 @@ func encodeEmbListQuery(vecs []gjson.Result, elemType schemapb.DataType, dim int
 }
 
 func buildStructArrayFieldData(structSchema *schemapb.StructArrayFieldSchema, perRow []structArrayRow) (*schemapb.FieldData, error) {
-	if len(perRow) == 0 {
+	return buildStructArrayFieldDataInternal(structSchema, perRow, nil)
+}
+
+func buildNullableStructArrayFieldData(structSchema *schemapb.StructArrayFieldSchema, perRow []structArrayRow, validData []bool) (*schemapb.FieldData, error) {
+	return buildStructArrayFieldDataInternal(structSchema, perRow, validData)
+}
+
+func buildStructArrayFieldDataInternal(structSchema *schemapb.StructArrayFieldSchema, perRow []structArrayRow, validData []bool) (*schemapb.FieldData, error) {
+	if len(perRow) == 0 && len(validData) == 0 {
 		return nil, merr.WrapErrParameterInvalidMsg("struct array field %s has no rows", structSchema.GetName())
+	}
+	if len(validData) > 0 {
+		validCount := 0
+		for _, valid := range validData {
+			if valid {
+				validCount++
+			}
+		}
+		if validCount != len(perRow) {
+			return nil, merr.WrapErrServiceInternalMsg(
+				"struct array field %s has %d valid rows but %d payload rows",
+				structSchema.GetName(), validCount, len(perRow))
+		}
 	}
 	subs := structSchema.GetFields()
 	subFieldData := make([]*schemapb.FieldData, 0, len(subs))
@@ -1320,6 +1349,7 @@ func buildStructArrayFieldData(structSchema *schemapb.StructArrayFieldSchema, pe
 				Type:      schemapb.DataType_Array,
 				FieldName: short,
 				FieldId:   sub.GetFieldID(),
+				ValidData: validData,
 				Field: &schemapb.FieldData_Scalars{
 					Scalars: &schemapb.ScalarField{
 						Data: &schemapb.ScalarField_ArrayData{ArrayData: arrayArray},
@@ -1353,6 +1383,7 @@ func buildStructArrayFieldData(structSchema *schemapb.StructArrayFieldSchema, pe
 				Type:      schemapb.DataType_ArrayOfVector,
 				FieldName: short,
 				FieldId:   sub.GetFieldID(),
+				ValidData: validData,
 				Field: &schemapb.FieldData_Vectors{
 					Vectors: &schemapb.VectorField{
 						Dim: dim,
@@ -1381,13 +1412,44 @@ func extractStructArrayRow(fd *schemapb.FieldData, rowIdx int, schema *schemapb.
 	if len(subs) == 0 {
 		return []map[string]interface{}{}, nil
 	}
+	rowIndices := make([]int, len(subs))
+	rowValid := true
+	expectedValidData := subs[0].GetValidData()
+	for idx, sub := range subs {
+		if !slices.Equal(expectedValidData, sub.GetValidData()) {
+			return nil, merr.WrapErrServiceInternalMsg(
+				"struct array field %s sub-field %s has inconsistent valid data",
+				fd.GetFieldName(), sub.GetFieldName())
+		}
+		accessor, err := newFieldDataRowAccessor(sub)
+		if err != nil {
+			return nil, merr.WrapErrServiceInternalErr(err,
+				"invalid struct array field %s sub-field %s", fd.GetFieldName(), sub.GetFieldName())
+		}
+		dataIdx, valid, err := accessor.rowIndex(int64(rowIdx))
+		if err != nil {
+			return nil, merr.WrapErrServiceInternalErr(err,
+				"read struct array field %s sub-field %s", fd.GetFieldName(), sub.GetFieldName())
+		}
+		if idx == 0 {
+			rowValid = valid
+		} else if valid != rowValid {
+			return nil, merr.WrapErrServiceInternalMsg(
+				"struct array field %s sub-field %s has inconsistent null state at row %d",
+				fd.GetFieldName(), sub.GetFieldName(), rowIdx)
+		}
+		rowIndices[idx] = int(dataIdx)
+	}
+	if !rowValid {
+		return nil, nil
+	}
 
 	subDims, err := structArraySubDims(fd.GetFieldName(), schema)
 	if err != nil {
 		return nil, err
 	}
 
-	elemCount, err := structSubElemCount(subs[0], rowIdx, subDims)
+	elemCount, err := structSubElemCount(subs[0], rowIndices[0], subDims)
 	if err != nil {
 		return nil, err
 	}
@@ -1395,15 +1457,16 @@ func extractStructArrayRow(fd *schemapb.FieldData, rowIdx int, schema *schemapb.
 	for i := 0; i < elemCount; i++ {
 		out[i] = make(map[string]interface{}, len(subs))
 	}
-	for _, sub := range subs {
+	for subIdx, sub := range subs {
+		dataIdx := rowIndices[subIdx]
 		short := structFieldShortName(sub.GetFieldName())
 		switch sub.GetType() {
 		case schemapb.DataType_Array:
 			rowData := sub.GetScalars().GetArrayData().GetData()
-			if rowIdx >= len(rowData) {
-				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s missing row %d", short, rowIdx)
+			if dataIdx >= len(rowData) {
+				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s missing row %d", short, dataIdx)
 			}
-			values := scalarArrayToInterfaces(rowData[rowIdx])
+			values := scalarArrayToInterfaces(rowData[dataIdx])
 			if len(values) != elemCount {
 				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s element count mismatch: expect %d got %d",
 					short, elemCount, len(values))
@@ -1416,14 +1479,14 @@ func extractStructArrayRow(fd *schemapb.FieldData, rowIdx int, schema *schemapb.
 			if va == nil {
 				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s has no vector array", short)
 			}
-			if rowIdx >= len(va.GetData()) {
-				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s missing row %d", short, rowIdx)
+			if dataIdx >= len(va.GetData()) {
+				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s missing row %d", short, dataIdx)
 			}
 			dim, ok := subDims[short]
 			if !ok || dim <= 0 {
 				return nil, merr.WrapErrParameterInvalidMsg("schema missing dim for struct sub-field %s", short)
 			}
-			values, err := vectorFieldToInterfaces(va.GetData()[rowIdx], va.GetElementType(), dim)
+			values, err := vectorFieldToInterfaces(va.GetData()[dataIdx], va.GetElementType(), dim)
 			if err != nil {
 				return nil, err
 			}
@@ -2203,9 +2266,21 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 		})
 	}
 	for _, structField := range sch.GetStructArrayFields() {
+		validData, hasValidData := validDataMap[structField.GetName()]
+		if hasValidData && len(validData) != rowsLen {
+			return nil, merr.WrapErrParameterInvalidMsg("struct field %s valid data has length %d, expected %d",
+				structField.GetName(), len(validData), rowsLen)
+		}
 		perRow := make([]structArrayRow, 0, rowsLen)
 		for rowIdx, row := range rows {
 			val, ok := row[structField.GetName()]
+			if hasValidData && !validData[rowIdx] {
+				if ok {
+					return nil, merr.WrapErrParameterInvalidMsg("row %d struct field %s is null but contains data",
+						rowIdx, structField.GetName())
+				}
+				continue
+			}
 			if !ok {
 				if partialUpdate {
 					continue
@@ -2219,10 +2294,16 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 			}
 			perRow = append(perRow, sr)
 		}
-		if len(perRow) == 0 {
+		if len(perRow) == 0 && !hasValidData {
 			continue
 		}
-		structFieldData, err := buildStructArrayFieldData(structField, perRow)
+		var structFieldData *schemapb.FieldData
+		var err error
+		if hasValidData {
+			structFieldData, err = buildNullableStructArrayFieldData(structField, perRow, validData)
+		} else {
+			structFieldData, err = buildStructArrayFieldData(structField, perRow)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -2424,6 +2505,8 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 		return int64(len(fieldData.GetScalars().GetStringData().GetData())), nil
 	case schemapb.DataType_Array:
 		return int64(len(fieldData.GetScalars().GetArrayData().GetData())), nil
+	case schemapb.DataType_ArrayOfVector:
+		return int64(len(fieldData.GetVectors().GetVectorArray().GetData())), nil
 	case schemapb.DataType_JSON:
 		return int64(len(fieldData.GetScalars().GetJsonData().GetData())), nil
 	case schemapb.DataType_Geometry:
@@ -2470,6 +2553,9 @@ func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
 		subs := fieldData.GetStructArrays().GetFields()
 		if len(subs) == 0 {
 			return 0, nil
+		}
+		if len(subs[0].GetValidData()) > 0 {
+			return int64(len(subs[0].GetValidData())), nil
 		}
 		switch subs[0].GetType() {
 		case schemapb.DataType_Array:

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -1407,26 +1407,57 @@ func buildStructArrayFieldDataInternal(structSchema *schemapb.StructArrayFieldSc
 	}, nil
 }
 
-func extractStructArrayRow(fd *schemapb.FieldData, rowIdx int, schema *schemapb.CollectionSchema) ([]map[string]interface{}, error) {
+type structArrayRowAccessor struct {
+	fieldData    *schemapb.FieldData
+	subFields    []*schemapb.FieldData
+	subAccessors []*fieldDataRowAccessor
+	subDims      map[string]int64
+}
+
+func newStructArrayRowAccessor(fd *schemapb.FieldData, schema *schemapb.CollectionSchema) (*structArrayRowAccessor, error) {
 	subs := fd.GetStructArrays().GetFields()
-	if len(subs) == 0 {
-		return []map[string]interface{}{}, nil
+	accessor := &structArrayRowAccessor{
+		fieldData: fd,
+		subFields: subs,
 	}
-	rowIndices := make([]int, len(subs))
-	rowValid := true
+	if len(subs) == 0 {
+		return accessor, nil
+	}
+
 	expectedValidData := subs[0].GetValidData()
-	for idx, sub := range subs {
+	accessor.subAccessors = make([]*fieldDataRowAccessor, 0, len(subs))
+	for _, sub := range subs {
 		if !slices.Equal(expectedValidData, sub.GetValidData()) {
 			return nil, merr.WrapErrServiceInternalMsg(
 				"struct array field %s sub-field %s has inconsistent valid data",
 				fd.GetFieldName(), sub.GetFieldName())
 		}
-		accessor, err := newFieldDataRowAccessor(sub)
+		subAccessor, err := newFieldDataRowAccessor(sub)
 		if err != nil {
 			return nil, merr.WrapErrServiceInternalErr(err,
 				"invalid struct array field %s sub-field %s", fd.GetFieldName(), sub.GetFieldName())
 		}
-		dataIdx, valid, err := accessor.rowIndex(int64(rowIdx))
+		accessor.subAccessors = append(accessor.subAccessors, subAccessor)
+	}
+
+	var err error
+	accessor.subDims, err = structArraySubDims(fd.GetFieldName(), schema)
+	if err != nil {
+		return nil, err
+	}
+	return accessor, nil
+}
+
+func (accessor *structArrayRowAccessor) row(rowIdx int) ([]map[string]interface{}, error) {
+	fd := accessor.fieldData
+	subs := accessor.subFields
+	if len(subs) == 0 {
+		return []map[string]interface{}{}, nil
+	}
+	rowIndices := make([]int, len(subs))
+	rowValid := true
+	for idx, sub := range subs {
+		dataIdx, valid, err := accessor.subAccessors[idx].rowIndex(int64(rowIdx))
 		if err != nil {
 			return nil, merr.WrapErrServiceInternalErr(err,
 				"read struct array field %s sub-field %s", fd.GetFieldName(), sub.GetFieldName())
@@ -1444,12 +1475,7 @@ func extractStructArrayRow(fd *schemapb.FieldData, rowIdx int, schema *schemapb.
 		return nil, nil
 	}
 
-	subDims, err := structArraySubDims(fd.GetFieldName(), schema)
-	if err != nil {
-		return nil, err
-	}
-
-	elemCount, err := structSubElemCount(subs[0], rowIndices[0], subDims)
+	elemCount, err := structSubElemCount(subs[0], rowIndices[0], accessor.subDims)
 	if err != nil {
 		return nil, err
 	}
@@ -1482,7 +1508,7 @@ func extractStructArrayRow(fd *schemapb.FieldData, rowIdx int, schema *schemapb.
 			if dataIdx >= len(va.GetData()) {
 				return nil, merr.WrapErrParameterInvalidMsg("struct sub-field %s missing row %d", short, dataIdx)
 			}
-			dim, ok := subDims[short]
+			dim, ok := accessor.subDims[short]
 			if !ok || dim <= 0 {
 				return nil, merr.WrapErrParameterInvalidMsg("schema missing dim for struct sub-field %s", short)
 			}
@@ -2667,12 +2693,20 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 		return []map[string]interface{}{}, nil
 	}
 	fieldDataAccessors := make([]*fieldDataRowAccessor, 0, columnNum)
-	for _, fieldData := range fieldDataList {
+	structArrayAccessors := make([]*structArrayRowAccessor, columnNum)
+	for idx, fieldData := range fieldDataList {
 		accessor, err := newFieldDataRowAccessor(fieldData)
 		if err != nil {
 			return nil, err
 		}
 		fieldDataAccessors = append(fieldDataAccessors, accessor)
+		if fieldData.GetType() == schemapb.DataType_ArrayOfStruct {
+			structAccessor, err := newStructArrayRowAccessor(fieldData, collectionSchema)
+			if err != nil {
+				return nil, err
+			}
+			structArrayAccessors[idx] = structAccessor
+		}
 	}
 	queryResp := make([]map[string]interface{}, 0, rowsNum)
 	dynamicOutputFields := genDynamicFields(needFields, fieldDataList)
@@ -2778,7 +2812,7 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryWktData().Data[dataIdx]
 					}
 				case schemapb.DataType_ArrayOfStruct:
-					structRow, err := extractStructArrayRow(fieldDataList[j], int(dataIdx), collectionSchema)
+					structRow, err := structArrayAccessors[j].row(int(dataIdx))
 					if err != nil {
 						return nil, err
 					}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -4085,6 +4085,82 @@ func TestAnyToColumnsRejectsSchemaWithoutVectorOrFunction(t *testing.T) {
 	require.ErrorContains(t, err, "has no vector field or functions")
 }
 
+func TestAnyToColumnsNullableStructArray(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	schema.GetStructArrayFields()[0].Nullable = true
+	body := []byte(`{
+		"data": [
+			{
+				"id": 1,
+				"vec": [0.1, 0.2, 0.3, 0.4],
+				"my_struct": [{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]
+			},
+			{
+				"id": 2,
+				"vec": [0.5, 0.6, 0.7, 0.8],
+				"my_struct": null
+			},
+			{
+				"id": 3,
+				"vec": [0.9, 1.0, 1.1, 1.2],
+				"my_struct": []
+			}
+		]
+	}`)
+	rows, validData, err := checkAndSetData(body, schema, false)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, false, true}, validData["my_struct"])
+
+	fds, err := anyToColumns(rows, validData, schema, true, false)
+	require.NoError(t, err)
+	var structFD *schemapb.FieldData
+	for _, fd := range fds {
+		if fd.GetType() == schemapb.DataType_ArrayOfStruct {
+			structFD = fd
+			break
+		}
+	}
+	require.NotNil(t, structFD)
+	subs := structFD.GetStructArrays().GetFields()
+	require.Len(t, subs, 2)
+	for _, sub := range subs {
+		assert.Equal(t, []bool{true, false, true}, sub.GetValidData())
+	}
+	assert.Len(t, subs[0].GetScalars().GetArrayData().GetData(), 2)
+	assert.Len(t, subs[1].GetVectors().GetVectorArray().GetData(), 2)
+}
+
+func TestAnyToColumnsNullableStructArrayAllNull(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	schema.GetStructArrayFields()[0].Nullable = true
+	body := []byte(`{
+		"data": [
+			{"id": 1, "vec": [0.1, 0.2, 0.3, 0.4], "my_struct": null},
+			{"id": 2, "vec": [0.5, 0.6, 0.7, 0.8]}
+		]
+	}`)
+	rows, validData, err := checkAndSetData(body, schema, false)
+	require.NoError(t, err)
+
+	fds, err := anyToColumns(rows, validData, schema, true, false)
+	require.NoError(t, err)
+	var structFD *schemapb.FieldData
+	for _, fd := range fds {
+		if fd.GetType() == schemapb.DataType_ArrayOfStruct {
+			structFD = fd
+			break
+		}
+	}
+	require.NotNil(t, structFD)
+	subs := structFD.GetStructArrays().GetFields()
+	require.Len(t, subs, 2)
+	for _, sub := range subs {
+		assert.Equal(t, []bool{false, false}, sub.GetValidData())
+	}
+	assert.Empty(t, subs[0].GetScalars().GetArrayData().GetData())
+	assert.Empty(t, subs[1].GetVectors().GetVectorArray().GetData())
+}
+
 func TestBuildQueryRespStructArrayRoundTrip(t *testing.T) {
 	schema := buildStructArrayTestSchema()
 	body := []byte(`{
@@ -4123,6 +4199,72 @@ func TestBuildQueryRespStructArrayRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(blob, &decoded))
 	require.Len(t, decoded, 2)
 	assert.EqualValues(t, 10, decoded[0]["sub_int"])
+}
+
+func TestBuildQueryRespNullableStructArrayCompact(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	structSchema := schema.GetStructArrayFields()[0]
+	structSchema.Nullable = true
+	first, err := parseStructArrayRow(
+		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema)
+	require.NoError(t, err)
+	third, err := parseStructArrayRow(`[]`, structSchema)
+	require.NoError(t, err)
+	structFD, err := buildNullableStructArrayFieldData(
+		structSchema, []structArrayRow{first, third}, []bool{true, false, true})
+	require.NoError(t, err)
+
+	resp, err := buildQueryResp(0, []string{"my_struct"}, []*schemapb.FieldData{structFD}, nil, nil, true, schema)
+	require.NoError(t, err)
+	require.Len(t, resp, 3)
+	assert.NotNil(t, resp[0]["my_struct"])
+	assert.Nil(t, resp[1]["my_struct"])
+	assert.Equal(t, []map[string]interface{}{}, resp[2]["my_struct"])
+}
+
+func TestBuildQueryRespNullableStructArrayDense(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	structSchema := schema.GetStructArrayFields()[0]
+	structSchema.Nullable = true
+	first, err := parseStructArrayRow(
+		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema)
+	require.NoError(t, err)
+	nullPlaceholder, err := parseStructArrayRow(`[]`, structSchema)
+	require.NoError(t, err)
+	third, err := parseStructArrayRow(
+		`[{"sub_int": 30, "sub_vec": [3.1, 3.2, 3.3, 3.4]}]`, structSchema)
+	require.NoError(t, err)
+	structFD, err := buildStructArrayFieldData(
+		structSchema, []structArrayRow{first, nullPlaceholder, third})
+	require.NoError(t, err)
+	for _, sub := range structFD.GetStructArrays().GetFields() {
+		sub.ValidData = []bool{true, false, true}
+	}
+
+	resp, err := buildQueryResp(0, []string{"my_struct"}, []*schemapb.FieldData{structFD}, nil, nil, true, schema)
+	require.NoError(t, err)
+	require.Len(t, resp, 3)
+	assert.NotNil(t, resp[0]["my_struct"])
+	assert.Nil(t, resp[1]["my_struct"])
+	assert.NotNil(t, resp[2]["my_struct"])
+}
+
+func TestBuildQueryRespNullableStructArrayRejectsMismatchedValidData(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	structSchema := schema.GetStructArrayFields()[0]
+	row, err := parseStructArrayRow(
+		`[{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}]`, structSchema)
+	require.NoError(t, err)
+	structFD, err := buildStructArrayFieldData(structSchema, []structArrayRow{row})
+	require.NoError(t, err)
+	subs := structFD.GetStructArrays().GetFields()
+	require.Len(t, subs, 2)
+	subs[0].ValidData = []bool{true}
+	subs[1].ValidData = []bool{false}
+
+	_, err = buildQueryResp(0, []string{"my_struct"}, []*schemapb.FieldData{structFD}, nil, nil, true, schema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inconsistent valid data")
 }
 
 func TestIsEmbeddingListData(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -3978,13 +3978,15 @@ func TestBuildStructArrayFieldDataRoundTrip(t *testing.T) {
 	assert.Equal(t, schemapb.DataType_ArrayOfVector, subs[1].GetType())
 	assert.Len(t, subs[1].GetVectors().GetVectorArray().GetData(), 2)
 
-	extracted0, err := extractStructArrayRow(fd, 0, buildStructArrayTestSchema())
+	accessor, err := newStructArrayRowAccessor(fd, buildStructArrayTestSchema())
+	require.NoError(t, err)
+	extracted0, err := accessor.row(0)
 	require.NoError(t, err)
 	require.Len(t, extracted0, 2)
 	assert.EqualValues(t, int32(1), extracted0[0]["sub_int"])
 	assert.EqualValues(t, []float32{0.1, 0.2, 0.3, 0.4}, extracted0[0]["sub_vec"])
 
-	extracted1, err := extractStructArrayRow(fd, 1, buildStructArrayTestSchema())
+	extracted1, err := accessor.row(1)
 	require.NoError(t, err)
 	require.Len(t, extracted1, 1)
 	assert.EqualValues(t, int32(3), extracted1[0]["sub_int"])
@@ -4577,12 +4579,14 @@ func TestStructArrayFieldDataErrorPaths(t *testing.T) {
 }
 
 func TestExtractStructArrayRowErrorPaths(t *testing.T) {
-	empty, err := extractStructArrayRow(&schemapb.FieldData{
+	accessor, err := newStructArrayRowAccessor(&schemapb.FieldData{
 		Type: schemapb.DataType_ArrayOfStruct,
 		Field: &schemapb.FieldData_StructArrays{
 			StructArrays: &schemapb.StructArrayField{},
 		},
-	}, 0, buildStructArrayTestSchema())
+	}, buildStructArrayTestSchema())
+	require.NoError(t, err)
+	empty, err := accessor.row(0)
 	require.NoError(t, err)
 	assert.Empty(t, empty)
 
@@ -4592,7 +4596,9 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 	fd, err := buildStructArrayFieldData(schema.GetStructArrayFields()[0], []structArrayRow{row})
 	require.NoError(t, err)
 
-	_, err = extractStructArrayRow(fd, 2, schema)
+	accessor, err = newStructArrayRowAccessor(fd, schema)
+	require.NoError(t, err)
+	_, err = accessor.row(2)
 	assert.Error(t, err)
 
 	mismatch := &schemapb.FieldData{
@@ -4626,13 +4632,17 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 			}},
 		},
 	}
-	_, err = extractStructArrayRow(mismatch, 0, schema)
+	accessor, err = newStructArrayRowAccessor(mismatch, schema)
+	require.NoError(t, err)
+	_, err = accessor.row(0)
 	assert.Error(t, err)
 
 	missingDimSchema := &schemapb.CollectionSchema{
 		StructArrayFields: []*schemapb.StructArrayFieldSchema{{Name: "my_struct"}},
 	}
-	_, err = extractStructArrayRow(mismatch, 0, missingDimSchema)
+	accessor, err = newStructArrayRowAccessor(mismatch, missingDimSchema)
+	require.NoError(t, err)
+	_, err = accessor.row(0)
 	assert.Error(t, err)
 
 	unsupported := &schemapb.FieldData{
@@ -4655,7 +4665,9 @@ func TestExtractStructArrayRowErrorPaths(t *testing.T) {
 			}},
 		},
 	}
-	_, err = extractStructArrayRow(unsupported, 0, schema)
+	accessor, err = newStructArrayRowAccessor(unsupported, schema)
+	require.NoError(t, err)
+	_, err = accessor.row(0)
 	assert.Error(t, err)
 }
 

--- a/tests/go_client/testcases/struct_array_test.go
+++ b/tests/go_client/testcases/struct_array_test.go
@@ -228,6 +228,16 @@ func TestStructArrayNullableInsertNil(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, value)
 
+	emptyQueryResult, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter("id < 0").WithOutputFields("clips").WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Zero(t, emptyQueryResult.ResultCount)
+	emptyQueryClips := emptyQueryResult.GetColumn("clips")
+	require.NotNil(t, emptyQueryClips)
+	require.True(t, emptyQueryClips.Nullable())
+	require.Zero(t, emptyQueryClips.Len())
+	require.NoError(t, emptyQueryClips.ValidateNullable())
+
 	// A null vector produces an empty result set while a valid vector produces a
 	// non-empty one. The empty slice must retain every struct sub-column's
 	// nullable state.

--- a/tests/go_client/testcases/struct_array_test.go
+++ b/tests/go_client/testcases/struct_array_test.go
@@ -159,6 +159,72 @@ func TestStructArrayInsertBasic(t *testing.T) {
 	require.EqualValues(t, structArrayTestNb, res.InsertCount)
 }
 
+// TestStructArrayNullableInsertNil ports test_embedding_list_field_nullable_insert_none_supported.
+func TestStructArrayNullableInsertNil(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	dim := 8
+	collName := common.GenRandomString(hp.StructArrayPrefix+"_nullable", 6)
+	structSchema := entity.NewStructSchema().
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(dim))).
+		WithField(entity.NewField().WithName("label").WithDataType(entity.FieldTypeVarChar).WithMaxLength(128))
+	schema := entity.NewSchema().WithName(collName).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName("normal_vector").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(dim))).
+		WithField(entity.NewField().
+			WithName("clips").
+			WithDataType(entity.FieldTypeArray).
+			WithElementType(entity.FieldTypeStruct).
+			WithMaxCapacity(100).
+			WithStructSchema(structSchema).
+			WithNullable(true))
+	common.CheckErr(t, mc.CreateCollection(ctx,
+		client.NewCreateCollectionOption(collName, schema).WithConsistencyLevel(entity.ClStrong)), true)
+
+	rows := []map[string]any{
+		nil,
+		{"embedding": [][]float32{hp.RandFloatVector(dim)}, "label": []string{"valid"}},
+	}
+	res, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).
+		WithInt64Column("id", []int64{0, 1}).
+		WithFloatVectorColumn("normal_vector", dim, [][]float32{hp.RandFloatVector(dim), hp.RandFloatVector(dim)}).
+		WithStructArrayColumn("clips", structSchema, rows))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, 2, res.InsertCount)
+
+	_, err = mc.Flush(ctx, client.NewFlushOption(collName))
+	common.CheckErr(t, err, true)
+	_, err = mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "normal_vector",
+		index.NewHNSWIndex(entity.COSINE, 16, 200)))
+	common.CheckErr(t, err, true)
+	_, err = mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "clips[embedding]",
+		index.NewHNSWIndex(entity.MaxSimCosine, 16, 200)))
+	common.CheckErr(t, err, true)
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, loadTask.Await(ctx), true)
+
+	nullResult, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter("id == 0").WithOutputFields("id", "clips").WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, nullResult.ResultCount)
+	clips := nullResult.GetColumn("clips")
+	require.NotNil(t, clips)
+	require.True(t, clips.Nullable())
+	value, err := clips.Get(0)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	validResult, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter("id == 1").WithOutputFields("clips").WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, validResult.ResultCount)
+	value, err = validResult.GetColumn("clips").Get(0)
+	require.NoError(t, err)
+	require.NotNil(t, value)
+}
+
 // TestStructArrayCreateEmbListHNSWIndexCosine ports test_create_emb_list_hnsw_index_cosine.
 func TestStructArrayCreateEmbListHNSWIndexCosine(t *testing.T) {
 	runEmbListHNSWIndex(t, entity.MaxSimCosine)

--- a/tests/go_client/testcases/struct_array_test.go
+++ b/tests/go_client/testcases/struct_array_test.go
@@ -171,7 +171,7 @@ func TestStructArrayNullableInsertNil(t *testing.T) {
 		WithField(entity.NewField().WithName("label").WithDataType(entity.FieldTypeVarChar).WithMaxLength(128))
 	schema := entity.NewSchema().WithName(collName).
 		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
-		WithField(entity.NewField().WithName("normal_vector").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(dim))).
+		WithField(entity.NewField().WithName("normal_vector").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(dim)).WithNullable(true)).
 		WithField(entity.NewField().
 			WithName("clips").
 			WithDataType(entity.FieldTypeArray).
@@ -186,9 +186,13 @@ func TestStructArrayNullableInsertNil(t *testing.T) {
 		nil,
 		{"embedding": [][]float32{hp.RandFloatVector(dim)}, "label": []string{"valid"}},
 	}
+	secondVector := make([]float32, dim)
+	secondVector[1] = 1
+	normalVectors, err := column.NewNullableColumnFloatVector("normal_vector", dim,
+		[][]float32{secondVector}, []bool{false, true})
+	require.NoError(t, err)
 	res, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).
-		WithInt64Column("id", []int64{0, 1}).
-		WithFloatVectorColumn("normal_vector", dim, [][]float32{hp.RandFloatVector(dim), hp.RandFloatVector(dim)}).
+		WithColumns(column.NewColumnInt64("id", []int64{0, 1}), normalVectors).
 		WithStructArrayColumn("clips", structSchema, rows))
 	common.CheckErr(t, err, true)
 	require.EqualValues(t, 2, res.InsertCount)
@@ -223,6 +227,25 @@ func TestStructArrayNullableInsertNil(t *testing.T) {
 	value, err = validResult.GetColumn("clips").Get(0)
 	require.NoError(t, err)
 	require.NotNil(t, value)
+
+	// A null vector produces an empty result set while a valid vector produces a
+	// non-empty one. The empty slice must retain every struct sub-column's
+	// nullable state.
+	searchResults, err := mc.Search(ctx, client.NewSearchByIDsOption(collName, 10,
+		column.NewColumnInt64("id", []int64{0, 1})).
+		WithANNSField("normal_vector").
+		WithOutputFields("clips").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Len(t, searchResults, 2)
+	require.NoError(t, searchResults[0].Err)
+	require.Zero(t, searchResults[0].ResultCount)
+	emptyClips := searchResults[0].GetColumn("clips")
+	require.NotNil(t, emptyClips)
+	require.True(t, emptyClips.Nullable())
+	require.Zero(t, emptyClips.Len())
+	require.NoError(t, searchResults[1].Err)
+	require.Greater(t, searchResults[1].ResultCount, 0)
 }
 
 // TestStructArrayCreateEmbListHNSWIndexCosine ports test_create_emb_list_hnsw_index_cosine.

--- a/tests/go_client/testcases/struct_array_test.go
+++ b/tests/go_client/testcases/struct_array_test.go
@@ -231,21 +231,29 @@ func TestStructArrayNullableInsertNil(t *testing.T) {
 	// A null vector produces an empty result set while a valid vector produces a
 	// non-empty one. The empty slice must retain every struct sub-column's
 	// nullable state.
-	searchResults, err := mc.Search(ctx, client.NewSearchByIDsOption(collName, 10,
-		column.NewColumnInt64("id", []int64{0, 1})).
+	emptySearchResults, err := mc.Search(ctx, client.NewSearchByIDsOption(collName, 10,
+		column.NewColumnInt64("id", []int64{0})).
 		WithANNSField("normal_vector").
 		WithOutputFields("clips").
 		WithConsistencyLevel(entity.ClStrong))
 	common.CheckErr(t, err, true)
-	require.Len(t, searchResults, 2)
-	require.NoError(t, searchResults[0].Err)
-	require.Zero(t, searchResults[0].ResultCount)
-	emptyClips := searchResults[0].GetColumn("clips")
+	require.Len(t, emptySearchResults, 1)
+	require.NoError(t, emptySearchResults[0].Err)
+	require.Zero(t, emptySearchResults[0].ResultCount)
+	emptyClips := emptySearchResults[0].GetColumn("clips")
 	require.NotNil(t, emptyClips)
 	require.True(t, emptyClips.Nullable())
 	require.Zero(t, emptyClips.Len())
-	require.NoError(t, searchResults[1].Err)
-	require.Greater(t, searchResults[1].ResultCount, 0)
+
+	validSearchResults, err := mc.Search(ctx, client.NewSearchByIDsOption(collName, 10,
+		column.NewColumnInt64("id", []int64{1})).
+		WithANNSField("normal_vector").
+		WithOutputFields("clips").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Len(t, validSearchResults, 1)
+	require.NoError(t, validSearchResults[0].Err)
+	require.Greater(t, validSearchResults[0].ResultCount, 0)
 }
 
 // TestStructArrayCreateEmbListHNSWIndexCosine ports test_create_emb_list_hnsw_index_cosine.

--- a/tests/go_client/testcases/struct_array_test.go
+++ b/tests/go_client/testcases/struct_array_test.go
@@ -238,6 +238,18 @@ func TestStructArrayNullableInsertNil(t *testing.T) {
 	require.Zero(t, emptyQueryClips.Len())
 	require.NoError(t, emptyQueryClips.ValidateNullable())
 
+	emptySubFieldQueryResult, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter("id < 0").WithOutputFields("clips[label]").WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Zero(t, emptySubFieldQueryResult.ResultCount)
+	emptySubFieldQueryClips := emptySubFieldQueryResult.GetColumn("clips")
+	require.NotNil(t, emptySubFieldQueryClips)
+	require.True(t, emptySubFieldQueryClips.Nullable())
+	require.Zero(t, emptySubFieldQueryClips.Len())
+	require.NoError(t, emptySubFieldQueryClips.ValidateNullable())
+	require.Len(t, emptySubFieldQueryClips.FieldData().GetStructArrays().GetFields(), 1)
+	require.Equal(t, "label", emptySubFieldQueryClips.FieldData().GetStructArrays().GetFields()[0].GetFieldName())
+
 	// A null vector produces an empty result set while a valid vector produces a
 	// non-empty one. The empty slice must retain every struct sub-column's
 	// nullable state.
@@ -254,6 +266,22 @@ func TestStructArrayNullableInsertNil(t *testing.T) {
 	require.NotNil(t, emptyClips)
 	require.True(t, emptyClips.Nullable())
 	require.Zero(t, emptyClips.Len())
+
+	emptySubFieldSearchResults, err := mc.Search(ctx, client.NewSearchByIDsOption(collName, 10,
+		column.NewColumnInt64("id", []int64{0})).
+		WithANNSField("normal_vector").
+		WithOutputFields("clips[label]").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Len(t, emptySubFieldSearchResults, 1)
+	require.NoError(t, emptySubFieldSearchResults[0].Err)
+	require.Zero(t, emptySubFieldSearchResults[0].ResultCount)
+	emptySubFieldSearchClips := emptySubFieldSearchResults[0].GetColumn("clips")
+	require.NotNil(t, emptySubFieldSearchClips)
+	require.True(t, emptySubFieldSearchClips.Nullable())
+	require.Zero(t, emptySubFieldSearchClips.Len())
+	require.Len(t, emptySubFieldSearchClips.FieldData().GetStructArrays().GetFields(), 1)
+	require.Equal(t, "label", emptySubFieldSearchClips.FieldData().GetStructArrays().GetFields()[0].GetFieldName())
 
 	validSearchResults, err := mc.Search(ctx, client.NewSearchByIDsOption(collName, 10,
 		column.NewColumnInt64("id", []int64{1})).

--- a/tests/go_client/testcases/struct_array_test.go
+++ b/tests/go_client/testcases/struct_array_test.go
@@ -159,6 +159,179 @@ func TestStructArrayInsertBasic(t *testing.T) {
 	require.EqualValues(t, structArrayTestNb, res.InsertCount)
 }
 
+func createStructArrayMutationCollection(
+	t *testing.T,
+	ctx CtxT,
+	mc MC,
+	suffix string,
+	dim int,
+	nullable bool,
+) string {
+	t.Helper()
+
+	collName := common.GenRandomString(hp.StructArrayPrefix+suffix, 6)
+	structSchema := entity.NewStructSchema().
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(dim))).
+		WithField(entity.NewField().WithName("label").WithDataType(entity.FieldTypeVarChar).WithMaxLength(128))
+	schema := entity.NewSchema().WithName(collName).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName("normal_vector").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(dim))).
+		WithField(entity.NewField().
+			WithName("clips").
+			WithDataType(entity.FieldTypeArray).
+			WithElementType(entity.FieldTypeStruct).
+			WithMaxCapacity(100).
+			WithStructSchema(structSchema).
+			WithNullable(nullable))
+	common.CheckErr(t, mc.CreateCollection(ctx,
+		client.NewCreateCollectionOption(collName, schema).WithConsistencyLevel(entity.ClStrong)), true)
+	return collName
+}
+
+func loadStructArrayMutationCollection(t *testing.T, ctx CtxT, mc MC, collName string) {
+	t.Helper()
+
+	_, err := mc.Flush(ctx, client.NewFlushOption(collName))
+	common.CheckErr(t, err, true)
+	_, err = mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "normal_vector",
+		index.NewHNSWIndex(entity.COSINE, 16, 200)))
+	common.CheckErr(t, err, true)
+	_, err = mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "clips[embedding]",
+		index.NewHNSWIndex(entity.MaxSimCosine, 16, 200)))
+	common.CheckErr(t, err, true)
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, loadTask.Await(ctx), true)
+}
+
+func TestStructArrayVectorSliceAndRollbackRemainAppendable(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	const dim = 8
+	collName := createStructArrayMutationCollection(t, ctx, mc, "_slice_rollback", dim, false)
+	clips := column.NewColumnStructArray("clips", []column.Column{
+		column.NewColumnFloatVectorArray("embedding", dim, nil),
+		column.NewColumnVarCharArray("label", nil),
+	})
+	require.NoError(t, clips.AppendValue(map[string]any{
+		"embedding": [][]float32{hp.RandFloatVector(dim)},
+		"label":     []string{"before_slice"},
+	}))
+
+	clips = clips.Slice(0, -1)
+	require.NoError(t, clips.AppendValue(map[string]any{
+		"embedding": [][]float32{hp.RandFloatVector(dim)},
+		"label":     []string{"after_slice"},
+	}))
+	require.Error(t, clips.AppendValue(map[string]any{
+		"embedding": [][]float32{hp.RandFloatVector(dim)},
+		"label":     42,
+	}))
+	require.NoError(t, clips.AppendValue(map[string]any{
+		"embedding": [][]float32{hp.RandFloatVector(dim)},
+		"label":     []string{"after_rollback"},
+	}))
+	require.Equal(t, 3, clips.Len())
+
+	res, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).
+		WithColumns(
+			column.NewColumnInt64("id", []int64{0, 1, 2}),
+			column.NewColumnFloatVector("normal_vector", dim, [][]float32{
+				hp.RandFloatVector(dim),
+				hp.RandFloatVector(dim),
+				hp.RandFloatVector(dim),
+			}),
+			clips,
+		))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, 3, res.InsertCount)
+
+	loadStructArrayMutationCollection(t, ctx, mc, collName)
+	result, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter("id >= 0").
+		WithOutputFields("id", "clips").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 3, result.ResultCount)
+
+	wantLabels := map[int64]string{0: "before_slice", 1: "after_slice", 2: "after_rollback"}
+	ids := result.GetColumn("id")
+	queriedClips := result.GetColumn("clips")
+	for i := 0; i < result.ResultCount; i++ {
+		id, err := ids.GetAsInt64(i)
+		require.NoError(t, err)
+		value, err := queriedClips.Get(i)
+		require.NoError(t, err)
+		row := value.(map[string]any)
+		require.Equal(t, []string{wantLabels[id]}, row["label"])
+		require.Len(t, row["embedding"].([]entity.FloatVector), 1)
+	}
+}
+
+func TestStructArrayAppendNullFailureRemainsRecoverable(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	const dim = 8
+	collName := createStructArrayMutationCollection(t, ctx, mc, "_append_null", dim, true)
+	embedding := column.NewColumnFloatVectorArray("embedding", dim, nil)
+	embedding.SetNullable(true)
+	clips := column.NewColumnStructArray("clips", []column.Column{
+		embedding,
+		column.NewColumnVarCharArray("label", nil),
+	})
+
+	require.Error(t, clips.AppendNull())
+	var rowCount int
+	require.NotPanics(t, func() {
+		rowCount = clips.Len()
+	})
+	require.Zero(t, rowCount)
+
+	clips.SetNullable(true)
+	require.NoError(t, clips.AppendNull())
+	require.NoError(t, clips.AppendValue(map[string]any{
+		"embedding": [][]float32{hp.RandFloatVector(dim)},
+		"label":     []string{"valid_after_failure"},
+	}))
+	require.Equal(t, 2, clips.Len())
+	require.NoError(t, clips.ValidateNullable())
+
+	res, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).
+		WithColumns(
+			column.NewColumnInt64("id", []int64{0, 1}),
+			column.NewColumnFloatVector("normal_vector", dim, [][]float32{
+				hp.RandFloatVector(dim),
+				hp.RandFloatVector(dim),
+			}),
+			clips,
+		))
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, 2, res.InsertCount)
+
+	loadStructArrayMutationCollection(t, ctx, mc, collName)
+	nullResult, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter("id == 0").
+		WithOutputFields("clips").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, nullResult.ResultCount)
+	value, err := nullResult.GetColumn("clips").Get(0)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	validResult, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter("id == 1").
+		WithOutputFields("clips").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, validResult.ResultCount)
+	value, err = validResult.GetColumn("clips").Get(0)
+	require.NoError(t, err)
+	require.Equal(t, []string{"valid_after_failure"}, value.(map[string]any)["label"])
+}
+
 // TestStructArrayNullableInsertNil ports test_embedding_list_field_nullable_insert_none_supported.
 func TestStructArrayNullableInsertNil(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)

--- a/tests/restful_client_v2/testcases/test_struct_array_nullable.py
+++ b/tests/restful_client_v2/testcases/test_struct_array_nullable.py
@@ -72,7 +72,8 @@ class TestRestfulStructArrayNullable(TestBase):
                     "fieldName": "normal_vector",
                     "indexName": "normal_vector",
                     "metricType": "L2",
-                    "indexType": "FLAT",
+                    "indexType": "HNSW",
+                    "params": {"M": 16, "efConstruction": 200},
                 }
             ],
             "params": {"consistencyLevel": "Strong"},
@@ -153,7 +154,7 @@ class TestRestfulStructArrayNullable(TestBase):
                 "annsField": "normal_vector",
                 "limit": len(rows),
                 "outputFields": ["id", "doc_tag", "profile"],
-                "searchParams": {"metricType": "L2", "params": {}},
+                "searchParams": {"metricType": "L2", "params": {"ef": 64}},
             }
         )
         assert rsp["code"] == 0
@@ -206,7 +207,7 @@ class TestRestfulStructArrayNullable(TestBase):
                 "annsField": "normal_vector",
                 "limit": len(rows),
                 "outputFields": ["id", "profile"],
-                "searchParams": {"metricType": "L2", "params": {}},
+                "searchParams": {"metricType": "L2", "params": {"ef": 64}},
             }
         )
         assert rsp["code"] == 0
@@ -239,7 +240,8 @@ class TestRestfulStructArrayNullable(TestBase):
                     "fieldName": "normal_vector",
                     "indexName": "normal_vector",
                     "metricType": "L2",
-                    "indexType": "FLAT",
+                    "indexType": "HNSW",
+                    "params": {"M": 16, "efConstruction": 200},
                 }
             ],
             "params": {"consistencyLevel": "Strong"},
@@ -294,7 +296,8 @@ class TestRestfulStructArrayNullable(TestBase):
                     "fieldName": "normal_vector",
                     "indexName": "normal_vector",
                     "metricType": "L2",
-                    "indexType": "FLAT",
+                    "indexType": "HNSW",
+                    "params": {"M": 16, "efConstruction": 200},
                 }
             ],
             "params": {"consistencyLevel": "Strong"},

--- a/tests/restful_client_v2/testcases/test_struct_array_nullable.py
+++ b/tests/restful_client_v2/testcases/test_struct_array_nullable.py
@@ -164,6 +164,54 @@ class TestRestfulStructArrayNullable(TestBase):
             assert hit["doc_tag"] == expected["doc_tag"]
             assert_profile_equal(hit["profile"], expected["profile"])
 
+    def test_rest_v2_nullable_struct_array_insert_query_search(self):
+        """
+        target: test REST v2 nullable Struct Array data round trip
+        method: insert null, non-empty, and empty Struct Array rows, then query and search them
+        expected: REST preserves null separately from an empty Struct Array
+        """
+        name = gen_collection_name()
+        self.name = name
+        self._create_struct_array_collection(name, struct_nullable=True)
+
+        rows = [
+            {"id": 1, "normal_vector": gen_vector(1), "doc_tag": "null", "profile": None},
+            {"id": 2, "normal_vector": gen_vector(2), "doc_tag": "valid", "profile": gen_profile(2)},
+            {"id": 3, "normal_vector": gen_vector(3), "doc_tag": "empty", "profile": []},
+        ]
+        expected = {row["id"]: row["profile"] for row in rows}
+
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": rows})
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == len(rows)
+
+        rsp = self.collection_client.flush(name)
+        assert rsp["code"] == 0
+
+        rsp = self.vector_client.vector_query(
+            {
+                "collectionName": name,
+                "filter": "id >= 0",
+                "outputFields": ["id", "profile"],
+                "limit": len(rows),
+            }
+        )
+        assert rsp["code"] == 0
+        assert {row["id"]: row["profile"] for row in rsp["data"]} == expected
+
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": name,
+                "data": [gen_vector(2)],
+                "annsField": "normal_vector",
+                "limit": len(rows),
+                "outputFields": ["id", "profile"],
+                "searchParams": {"metricType": "L2", "params": {}},
+            }
+        )
+        assert rsp["code"] == 0
+        assert {hit["id"]: hit["profile"] for hit in rsp["data"]} == expected
+
     def test_rest_v2_add_struct_array_field_rejected(self):
         """
         target: test REST v2 dynamic add rejects unsupported Struct Array field shape


### PR DESCRIPTION
issue: #51681
pr: #51682

## What changed

- Backport all 40 ordered commits from #51682.
- Support nullable StructArray scalar and vector sub-fields in the Go SDK and REST v2.
- Preserve NULL versus empty-array semantics for inserts, queries, and searches.
- Support compact nullable insert payloads and row-dense query/search results.
- Restore nullable StructArray columns for zero-row results, including sub-field selections such as `clips[label]`.
- Preserve dynamic-field behavior for empty query results.
- Preserve concrete scalar and vector array column types across slicing.
- Keep StructArray mutations recoverable after append rollback and failed `AppendNull`.
- Isolate sliced scalar and vector array storage from source-column mutation while preserving nil versus empty-slice semantics.
- Reject invalid FieldData row ranges instead of silently clamping them.
- Decode batched search field data once and slice the decoded columns per query.
- Initialize nullable vector indexes before validation and slicing.
- Preserve nullable geometry logical rows.
- Preserve vector-array dimensions for all-null results.
- Restore explicitly requested empty dynamic JSON result columns.
- Share sliced dynamic JSON storage across dynamic projections.
- Keep the end-to-end cases independent of FLAT indexes.

## Why

The Go SDK and REST v2 paths did not consistently preserve nullable StructArray logical-row alignment, nullable schema state, concrete sub-column types, vector dimensions, dynamic projections, and isolated slice storage across compact inserts, dense results, empty results, slicing, and failed mutations.

## Backport notes

- Rebased onto `upstream/3.0` at `34342a8364`.
- Synced all 40 ordered commits through `ed4a2772e6` from #51682.
- One conflict in `internal/distributed/proxy/httpserver/utils_test.go` was resolved by retaining both the current 3.0 REST StructArray validation cases and the nullable StructArray coverage.
- `git range-diff` confirms all 40 commits are patch-identical to the master PR.
- The cumulative file set and diffstat match master: 25 files, 2611 insertions, and 141 deletions.
- Every commit includes a DCO sign-off.

## Validation

- `milvus-dev-cli go-ut local . -b 3.0 -n 4 -f -t client/column`
- `milvus-dev-cli go-ut local . -b 3.0 -n 1 -f -t client/milvusclient`
- `GOTOOLCHAIN=local GOCACHE=/tmp/milvus-go-cache-struct-array-40 go test -tags dynamic,test -gcflags='all=-N -l' -count=1 ./column ./milvusclient`
- `git diff --check upstream/3.0...HEAD`
- `git range-diff`: all 40 commits are patch-identical to #51682.
- Go SDK and REST v2 nullable StructArray end-to-end cases are included without FLAT-index dependencies.