### PR TITLE
enhance: limit stats task submission by scheduler pending queue

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -843,8 +843,8 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
-  jsonShreddingTriggerCount: 10 # jsonkey stats task count per trigger
-  jsonShreddingTriggerInterval: 10 # jsonkey task interval per trigger
+  jsonShreddingTriggerCount: 10 # Deprecated: JSON stats tasks now use dataCoord.sortCompactionTriggerCount for throttling.
+  jsonShreddingTriggerInterval: 10 # Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -898,8 +898,8 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
-  jsonShreddingTriggerCount: 10 # jsonkey stats task count per trigger
-  jsonShreddingTriggerInterval: 10 # jsonkey task interval per trigger
+  jsonShreddingTriggerCount: 10 # Deprecated: JSON stats tasks now use dataCoord.sortCompactionTriggerCount for throttling.
+  jsonShreddingTriggerInterval: 10 # Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -898,8 +898,6 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
-  jsonShreddingTriggerCount: 10 # jsonkey stats task count per trigger
-  jsonShreddingTriggerInterval: 10 # jsonkey task interval per trigger
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -843,8 +843,6 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
-  jsonShreddingTriggerCount: 10 # jsonkey stats task count per trigger
-  jsonShreddingTriggerInterval: 10 # jsonkey task interval per trigger
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -898,8 +898,6 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
-  jsonShreddingTriggerCount: 10 # Deprecated: JSON stats tasks now use dataCoord.sortCompactionTriggerCount for throttling.
-  jsonShreddingTriggerInterval: 10 # Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -843,6 +843,8 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
+  jsonShreddingTriggerCount: 10 # jsonkey stats task count per trigger
+  jsonShreddingTriggerInterval: 10 # jsonkey task interval per trigger
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -843,8 +843,6 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
-  jsonShreddingTriggerCount: 10 # Deprecated: JSON stats tasks now use dataCoord.sortCompactionTriggerCount for throttling.
-  jsonShreddingTriggerInterval: 10 # Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -898,6 +898,8 @@ dataCoord:
     scalarIndexTaskSlotUsage: 16 # slot usage of scalar index task per 512mb
     statsTaskSlotUsage: 8 # slot usage of stats task per 512mb
     analyzeTaskSlotUsage: 65535 # slot usage of analyze task
+  jsonShreddingTriggerCount: 10 # jsonkey stats task count per trigger
+  jsonShreddingTriggerInterval: 10 # jsonkey task interval per trigger
   jsonShreddingMaxColumns: 1024 # the max number of columns to shred
   jsonShreddingRatioThreshold: 0.3 # the ratio threshold to shred
   jsonShreddingWriteBatchSize: 81920 # the batch size to write

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -129,8 +129,6 @@ func (si *statsInspector) triggerStatsTaskLoop() {
 	ticker := time.NewTicker(Params.DataCoordCfg.TaskCheckInterval.GetAsDuration(time.Second))
 	defer ticker.Stop()
 
-	lastJSONStatsLastTrigger := time.Now().Unix()
-	maxJSONStatsTaskCount := 0
 	for {
 		select {
 		case <-si.ctx.Done():
@@ -139,7 +137,7 @@ func (si *statsInspector) triggerStatsTaskLoop() {
 		case <-ticker.C:
 			si.triggerTextStatsTask()
 			si.triggerBM25StatsTask()
-			lastJSONStatsLastTrigger, maxJSONStatsTaskCount = si.triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger, maxJSONStatsTaskCount)
+			si.triggerJSONKeyIndexStatsTask()
 		}
 	}
 }
@@ -240,7 +238,7 @@ func (si *statsInspector) triggerTextStatsTask() {
 	}
 }
 
-func (si *statsInspector) triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger int64, maxJSONStatsTaskCount int) (int64, int) {
+func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
@@ -260,23 +258,14 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger 
 			}
 			return needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted)
 		}))
-		if time.Now().Unix()-lastJSONStatsLastTrigger > int64(Params.DataCoordCfg.JSONStatsTriggerInterval.GetAsDuration(time.Minute).Seconds()) {
-			lastJSONStatsLastTrigger = time.Now().Unix()
-			maxJSONStatsTaskCount = 0
-		}
 		for _, segment := range segments {
-			if maxJSONStatsTaskCount >= Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() {
-				break
-			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
 				continue
 			}
-			maxJSONStatsTaskCount++
 		}
 	}
-	return lastJSONStatsLastTrigger, maxJSONStatsTaskCount
 }
 
 func (si *statsInspector) triggerBM25StatsTask() {
@@ -360,6 +349,16 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 				mlog.String("subJobType", subJobType.String()))
 			return nil
 		}
+	}
+	pendingTaskCount := si.scheduler.GetPendingTaskCount()
+	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
+	if pendingTaskCount > pendingTaskLimit {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
+			mlog.Int("pendingTaskCount", pendingTaskCount),
+			mlog.Int("pendingTaskLimit", pendingTaskLimit),
+			mlog.FieldSegmentID(originSegmentID),
+			mlog.String("subJobType", subJobType.String()))
+		return nil
 	}
 	taskID, err := si.allocator.AllocID(context.Background())
 	if err != nil {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -350,6 +350,13 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 			return nil
 		}
 	}
+	if si.mt.statsTaskMeta.HasStatsTask(originSegmentID, subJobType) {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "stats task already exists",
+			mlog.FieldCollectionID(originSegment.GetCollectionID()),
+			mlog.FieldSegmentID(originSegmentID),
+			mlog.String("subJobType", subJobType.String()))
+		return nil
+	}
 	pendingTaskCount := si.scheduler.GetPendingTaskCount()
 	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
 	if pendingTaskCount > pendingTaskLimit {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -234,6 +234,11 @@ func (si *statsInspector) triggerTextStatsTask() {
 			}
 			needTriggerFieldIDs = append(needTriggerFieldIDs, field.GetFieldID())
 		}
+		// needDoTextIndex is false for every segment once there is no field to
+		// index, so skip the collection before scanning all of its segments.
+		if len(needTriggerFieldIDs) == 0 {
+			continue
+		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
 			if !needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted) {
@@ -285,6 +290,11 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 				needTriggerFieldIDs = append(needTriggerFieldIDs, field.GetFieldID())
 			}
 		}
+		// Same as the text loop: no field to shred means no candidate segment,
+		// which also short-circuits every collection once JSON shredding is off.
+		if len(needTriggerFieldIDs) == 0 {
+			continue
+		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
 			if collection.IsExternal() && !canBuildExternalJSONKeyIndex(seg) {
@@ -309,6 +319,11 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 }
 
 func (si *statsInspector) triggerBM25StatsTask() {
+	// BM25 stats tasks are not docked yet, so every collection would be scanned
+	// for nothing. Drop out before touching the segment meta at all.
+	if !si.enableBM25() {
+		return
+	}
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil || collection.IsExternal() {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -87,10 +87,42 @@ func newStatsInspector(ctx context.Context,
 }
 
 func (si *statsInspector) Start() {
+	si.warnDeprecatedThrottleConfigs()
 	si.reloadFromMeta()
 	si.loopWg.Add(2)
 	go si.triggerStatsTaskLoop()
 	go si.cleanupStatsTasksLoop()
+}
+
+// warnDeprecatedThrottleConfigs tells operators whose config still carries the
+// old JSON throttle that it no longer has any effect, instead of letting the
+// setting disappear silently on upgrade.
+func (si *statsInspector) warnDeprecatedThrottleConfigs() {
+	for _, item := range []*paramtable.ParamItem{
+		&Params.DataCoordCfg.JSONStatsTriggerCount,
+		&Params.DataCoordCfg.JSONStatsTriggerInterval,
+	} {
+		if item.GetValue() == item.DefaultValue {
+			continue
+		}
+		mlog.Warn(si.ctx, "deprecated config is set and no longer throttles stats tasks, use dataCoord.statsTaskPendingLimit instead",
+			mlog.String("key", item.Key),
+			mlog.String("value", item.GetValue()))
+	}
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.Warn(si.ctx, "dataCoord.jsonShreddingTriggerCount is 0, keeping JSON key index submission disabled for compatibility",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+	}
+}
+
+// jsonShreddingDisabledByDeprecatedConfig reports whether the deprecated
+// jsonShreddingTriggerCount is still being used as a kill switch. The removed
+// limiter broke out of the loop once the submitted count reached the configured
+// value, so 0 disabled JSON key-index submission on the very first segment.
+// Silently re-enabling shredding for an operator who had set 0 would undo a
+// deliberate decision, so that one value keeps its meaning.
+func jsonShreddingDisabledByDeprecatedConfig() bool {
+	return Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() == 0
 }
 
 func (si *statsInspector) Stop() {
@@ -129,17 +161,33 @@ func (si *statsInspector) triggerStatsTaskLoop() {
 	ticker := time.NewTicker(Params.DataCoordCfg.TaskCheckInterval.GetAsDuration(time.Second))
 	defer ticker.Stop()
 
+	round := 0
 	for {
 		select {
 		case <-si.ctx.Done():
 			mlog.Warn(si.ctx, "DataCoord context done, exit checkStatsTaskLoop...")
 			return
 		case <-ticker.C:
-			si.triggerTextStatsTask()
-			si.triggerBM25StatsTask()
-			si.triggerJSONKeyIndexStatsTask()
+			si.triggerStatsTasks(round)
+			round++
 		}
 	}
+}
+
+// triggerStatsTasks runs one discovery round. The sub-jobs share a single
+// admission budget and each trigger returns as soon as it is refused, so
+// whichever runs first claims the capacity. Alternate text and JSON per round,
+// otherwise a long text-index backlog starves JSON shredding for as long as it
+// takes to drain - days on a large collection.
+func (si *statsInspector) triggerStatsTasks(round int) {
+	if round%2 == 0 {
+		si.triggerTextStatsTask()
+		si.triggerJSONKeyIndexStatsTask()
+	} else {
+		si.triggerJSONKeyIndexStatsTask()
+		si.triggerTextStatsTask()
+	}
+	si.triggerBM25StatsTask()
 }
 
 func (si *statsInspector) enableBM25() bool {
@@ -275,6 +323,11 @@ func (si *statsInspector) triggerTextStatsTask() {
 }
 
 func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.RatedWarn(si.ctx, rate.Limit(0.1), "skip JSON key index stats task, dataCoord.jsonShreddingTriggerCount is set to 0",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+		return
+	}
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -198,11 +198,31 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 	return false
 }
 
+// canSubmitStatsTask reports whether the global scheduler still has room for a
+// new stats task. The pending queue is shared by every task type, so a deep
+// queue means the workers are already saturated and adding more stats tasks
+// only grows the backlog. Discovery re-runs on every TaskCheckInterval tick, so
+// a segment skipped here is picked up again once the queue drains.
+func (si *statsInspector) canSubmitStatsTask() bool {
+	pendingTaskCount := si.scheduler.GetPendingTaskCount()
+	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
+	if pendingTaskCount > pendingTaskLimit {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
+			mlog.Int("pendingTaskCount", pendingTaskCount),
+			mlog.Int("pendingTaskLimit", pendingTaskLimit))
+		return false
+	}
+	return true
+}
+
 func (si *statsInspector) triggerTextStatsTask() {
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
 			continue
+		}
+		if !si.canSubmitStatsTask() {
+			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
@@ -215,7 +235,13 @@ func (si *statsInspector) triggerTextStatsTask() {
 		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			return needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted)
+			if !needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted) {
+				return false
+			}
+			// A segment whose task is already in meta must not be re-submitted;
+			// filtering it out here keeps the per-tick work proportional to the
+			// segments that still need a task instead of to all of them.
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_TextIndexJob)
 		}))
 
 		resources := []*internalpb.FileResourceInfo{}
@@ -230,6 +256,9 @@ func (si *statsInspector) triggerTextStatsTask() {
 		}
 
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask() {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_TextIndexJob, true, resources); err != nil {
 				mlog.Warn(si.ctx, "create stats task with text index for segment failed, wait for retry",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -245,6 +274,9 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 		if collection == nil {
 			continue
 		}
+		if !si.canSubmitStatsTask() {
+			return
+		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
 			h := typeutil.CreateFieldSchemaHelper(field)
@@ -257,9 +289,15 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 			if collection.IsExternal() && !canBuildExternalJSONKeyIndex(seg) {
 				return false
 			}
-			return needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted)
+			if !needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted) {
+				return false
+			}
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask() {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -275,6 +313,9 @@ func (si *statsInspector) triggerBM25StatsTask() {
 		if collection == nil || collection.IsExternal() {
 			continue
 		}
+		if !si.canSubmitStatsTask() {
+			return
+		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
 			// TODO: docking bm25 stats task
@@ -283,10 +324,16 @@ func (si *statsInspector) triggerBM25StatsTask() {
 			}
 		}
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			return (seg.GetIsSorted() || seg.GetIsSortedByNamespace()) && needDoBM25(seg, needTriggerFieldIDs)
+			if !(seg.GetIsSorted() || seg.GetIsSortedByNamespace()) || !needDoBM25(seg, needTriggerFieldIDs) {
+				return false
+			}
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_BM25Job)
 		}))
 
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask() {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_BM25Job, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with bm25 for segment failed, wait for retry",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -358,14 +405,7 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 			mlog.String("subJobType", subJobType.String()))
 		return nil
 	}
-	pendingTaskCount := si.scheduler.GetPendingTaskCount()
-	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
-	if pendingTaskCount > pendingTaskLimit {
-		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
-			mlog.Int("pendingTaskCount", pendingTaskCount),
-			mlog.Int("pendingTaskLimit", pendingTaskLimit),
-			mlog.FieldSegmentID(originSegmentID),
-			mlog.String("subJobType", subJobType.String()))
+	if !si.canSubmitStatsTask() {
 		return nil
 	}
 	taskID, err := si.allocator.AllocID(context.Background())

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -62,9 +62,6 @@ type statsInspector struct {
 	handler             Handler
 	compactionInspector CompactionInspector
 	ievm                IndexEngineVersionManager
-
-	lastJSONStatsTrigger int64
-	jsonStatsTaskCount   int
 }
 
 func newStatsInspector(ctx context.Context,
@@ -77,24 +74,55 @@ func newStatsInspector(ctx context.Context,
 ) *statsInspector {
 	ctx, cancel := context.WithCancel(ctx)
 	return &statsInspector{
-		ctx:                  ctx,
-		cancel:               cancel,
-		loopWg:               sync.WaitGroup{},
-		mt:                   mt,
-		scheduler:            scheduler,
-		allocator:            allocator,
-		handler:              handler,
-		compactionInspector:  compactionInspector,
-		ievm:                 ievm,
-		lastJSONStatsTrigger: time.Now().Unix(),
+		ctx:                 ctx,
+		cancel:              cancel,
+		loopWg:              sync.WaitGroup{},
+		mt:                  mt,
+		scheduler:           scheduler,
+		allocator:           allocator,
+		handler:             handler,
+		compactionInspector: compactionInspector,
+		ievm:                ievm,
 	}
 }
 
 func (si *statsInspector) Start() {
+	si.warnDeprecatedThrottleConfigs()
 	si.reloadFromMeta()
 	si.loopWg.Add(2)
 	go si.triggerStatsTaskLoop()
 	go si.cleanupStatsTasksLoop()
+}
+
+// warnDeprecatedThrottleConfigs tells operators whose config still carries the
+// old JSON throttle that it no longer has any effect, instead of letting the
+// setting disappear silently on upgrade.
+func (si *statsInspector) warnDeprecatedThrottleConfigs() {
+	for _, item := range []*paramtable.ParamItem{
+		&Params.DataCoordCfg.JSONStatsTriggerCount,
+		&Params.DataCoordCfg.JSONStatsTriggerInterval,
+	} {
+		if item.GetValue() == item.DefaultValue {
+			continue
+		}
+		mlog.Warn(si.ctx, "deprecated config is set and no longer throttles stats tasks, use dataCoord.statsTaskPendingLimit instead",
+			mlog.String("key", item.Key),
+			mlog.String("value", item.GetValue()))
+	}
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.Warn(si.ctx, "dataCoord.jsonShreddingTriggerCount is 0, keeping JSON key index submission disabled for compatibility",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+	}
+}
+
+// jsonShreddingDisabledByDeprecatedConfig reports whether the deprecated
+// jsonShreddingTriggerCount is still being used as a kill switch. The removed
+// limiter broke out of the loop once the submitted count reached the configured
+// value, so 0 disabled JSON key-index submission on the very first segment.
+// Silently re-enabling shredding for an operator who had set 0 would undo a
+// deliberate decision, so that one value keeps its meaning.
+func jsonShreddingDisabledByDeprecatedConfig() bool {
+	return Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() == 0
 }
 
 func (si *statsInspector) Stop() {
@@ -295,17 +323,11 @@ func (si *statsInspector) triggerTextStatsTask() {
 }
 
 func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
-	now := time.Now().Unix()
-	triggerInterval := int64(Params.DataCoordCfg.JSONStatsTriggerInterval.GetAsDuration(time.Minute).Seconds())
-	if now-si.lastJSONStatsTrigger > triggerInterval {
-		si.lastJSONStatsTrigger = now
-		si.jsonStatsTaskCount = 0
-	}
-	triggerCount := Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt()
-	if si.jsonStatsTaskCount >= triggerCount {
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.RatedWarn(si.ctx, rate.Limit(0.1), "skip JSON key index stats task, dataCoord.jsonShreddingTriggerCount is set to 0",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
 		return
 	}
-
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
@@ -337,9 +359,6 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
 		for _, segment := range segments {
-			if si.jsonStatsTaskCount >= triggerCount {
-				return
-			}
 			if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
 				return
 			}
@@ -347,9 +366,6 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
 				continue
-			}
-			if si.mt.statsTaskMeta.HasStatsTask(segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob) {
-				si.jsonStatsTaskCount++
 			}
 		}
 	}

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -62,9 +62,6 @@ type statsInspector struct {
 	handler             Handler
 	compactionInspector CompactionInspector
 	ievm                IndexEngineVersionManager
-
-	lastJSONStatsTrigger int64
-	jsonStatsTaskCount   int
 }
 
 func newStatsInspector(ctx context.Context,
@@ -77,24 +74,55 @@ func newStatsInspector(ctx context.Context,
 ) *statsInspector {
 	ctx, cancel := context.WithCancel(ctx)
 	return &statsInspector{
-		ctx:                  ctx,
-		cancel:               cancel,
-		loopWg:               sync.WaitGroup{},
-		mt:                   mt,
-		scheduler:            scheduler,
-		allocator:            allocator,
-		handler:              handler,
-		compactionInspector:  compactionInspector,
-		ievm:                 ievm,
-		lastJSONStatsTrigger: time.Now().Unix(),
+		ctx:                 ctx,
+		cancel:              cancel,
+		loopWg:              sync.WaitGroup{},
+		mt:                  mt,
+		scheduler:           scheduler,
+		allocator:           allocator,
+		handler:             handler,
+		compactionInspector: compactionInspector,
+		ievm:                ievm,
 	}
 }
 
 func (si *statsInspector) Start() {
+	si.warnDeprecatedThrottleConfigs()
 	si.reloadFromMeta()
 	si.loopWg.Add(2)
 	go si.triggerStatsTaskLoop()
 	go si.cleanupStatsTasksLoop()
+}
+
+// warnDeprecatedThrottleConfigs tells operators whose config still carries the
+// old JSON throttle that it no longer has any effect, instead of letting the
+// setting disappear silently on upgrade.
+func (si *statsInspector) warnDeprecatedThrottleConfigs() {
+	for _, item := range []*paramtable.ParamItem{
+		&Params.DataCoordCfg.JSONStatsTriggerCount,
+		&Params.DataCoordCfg.JSONStatsTriggerInterval,
+	} {
+		if item.GetValue() == item.DefaultValue {
+			continue
+		}
+		mlog.Warn(si.ctx, "deprecated config is set and no longer throttles stats tasks, use dataCoord.statsTaskPendingLimit instead",
+			mlog.String("key", item.Key),
+			mlog.String("value", item.GetValue()))
+	}
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.Warn(si.ctx, "dataCoord.jsonShreddingTriggerCount is 0, keeping JSON key index submission disabled for compatibility",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+	}
+}
+
+// jsonShreddingDisabledByDeprecatedConfig reports whether the deprecated
+// jsonShreddingTriggerCount is still being used as a kill switch. The removed
+// limiter broke out of the loop once the submitted count reached the configured
+// value, so 0 disabled JSON key-index submission on the very first segment.
+// Silently re-enabling shredding for an operator who had set 0 would undo a
+// deliberate decision, so that one value keeps its meaning.
+func jsonShreddingDisabledByDeprecatedConfig() bool {
+	return Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() == 0
 }
 
 func (si *statsInspector) Stop() {
@@ -296,17 +324,11 @@ func (si *statsInspector) triggerTextStatsTask() {
 }
 
 func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
-	now := time.Now().Unix()
-	triggerInterval := int64(Params.DataCoordCfg.JSONStatsTriggerInterval.GetAsDuration(time.Minute).Seconds())
-	if now-si.lastJSONStatsTrigger > triggerInterval {
-		si.lastJSONStatsTrigger = now
-		si.jsonStatsTaskCount = 0
-	}
-	triggerCount := Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt()
-	if si.jsonStatsTaskCount >= triggerCount {
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.RatedWarn(si.ctx, rate.Limit(0.1), "skip JSON key index stats task, dataCoord.jsonShreddingTriggerCount is set to 0",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
 		return
 	}
-
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
@@ -338,9 +360,6 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
 		for _, segment := range segments {
-			if si.jsonStatsTaskCount >= triggerCount {
-				return
-			}
 			if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
 				return
 			}
@@ -348,9 +367,6 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
 				continue
-			}
-			if si.mt.statsTaskMeta.HasStatsTask(segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob) {
-				si.jsonStatsTaskCount++
 			}
 		}
 	}

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -62,6 +62,9 @@ type statsInspector struct {
 	handler             Handler
 	compactionInspector CompactionInspector
 	ievm                IndexEngineVersionManager
+
+	lastJSONStatsTrigger int64
+	jsonStatsTaskCount   int
 }
 
 func newStatsInspector(ctx context.Context,
@@ -74,55 +77,24 @@ func newStatsInspector(ctx context.Context,
 ) *statsInspector {
 	ctx, cancel := context.WithCancel(ctx)
 	return &statsInspector{
-		ctx:                 ctx,
-		cancel:              cancel,
-		loopWg:              sync.WaitGroup{},
-		mt:                  mt,
-		scheduler:           scheduler,
-		allocator:           allocator,
-		handler:             handler,
-		compactionInspector: compactionInspector,
-		ievm:                ievm,
+		ctx:                  ctx,
+		cancel:               cancel,
+		loopWg:               sync.WaitGroup{},
+		mt:                   mt,
+		scheduler:            scheduler,
+		allocator:            allocator,
+		handler:              handler,
+		compactionInspector:  compactionInspector,
+		ievm:                 ievm,
+		lastJSONStatsTrigger: time.Now().Unix(),
 	}
 }
 
 func (si *statsInspector) Start() {
-	si.warnDeprecatedThrottleConfigs()
 	si.reloadFromMeta()
 	si.loopWg.Add(2)
 	go si.triggerStatsTaskLoop()
 	go si.cleanupStatsTasksLoop()
-}
-
-// warnDeprecatedThrottleConfigs tells operators whose config still carries the
-// old JSON throttle that it no longer has any effect, instead of letting the
-// setting disappear silently on upgrade.
-func (si *statsInspector) warnDeprecatedThrottleConfigs() {
-	for _, item := range []*paramtable.ParamItem{
-		&Params.DataCoordCfg.JSONStatsTriggerCount,
-		&Params.DataCoordCfg.JSONStatsTriggerInterval,
-	} {
-		if item.GetValue() == item.DefaultValue {
-			continue
-		}
-		mlog.Warn(si.ctx, "deprecated config is set and no longer throttles stats tasks, use dataCoord.statsTaskPendingLimit instead",
-			mlog.String("key", item.Key),
-			mlog.String("value", item.GetValue()))
-	}
-	if jsonShreddingDisabledByDeprecatedConfig() {
-		mlog.Warn(si.ctx, "dataCoord.jsonShreddingTriggerCount is 0, keeping JSON key index submission disabled for compatibility",
-			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
-	}
-}
-
-// jsonShreddingDisabledByDeprecatedConfig reports whether the deprecated
-// jsonShreddingTriggerCount is still being used as a kill switch. The removed
-// limiter broke out of the loop once the submitted count reached the configured
-// value, so 0 disabled JSON key-index submission on the very first segment.
-// Silently re-enabling shredding for an operator who had set 0 would undo a
-// deliberate decision, so that one value keeps its meaning.
-func jsonShreddingDisabledByDeprecatedConfig() bool {
-	return Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() == 0
 }
 
 func (si *statsInspector) Stop() {
@@ -247,10 +219,10 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 }
 
 // canSubmitStatsTask reports whether the global scheduler still has room for a
-// new stats task. The pending queue is shared by every task type, so a deep
-// queue means the workers are already saturated and adding more stats tasks
-// only grows the backlog. Discovery re-runs on every TaskCheckInterval tick, so
-// a segment skipped here is picked up again once the queue drains.
+// new stats task. The pending queue is shared by every task type, but tasks in
+// retry backoff are excluded because they are not currently waiting for a
+// worker slot. Discovery re-runs on every TaskCheckInterval tick, so a segment
+// skipped here is picked up again once the runnable queue drains.
 func (si *statsInspector) canSubmitStatsTask(subJobType indexpb.StatsSubJob) bool {
 	pendingTaskCount := si.scheduler.GetPendingTaskCount()
 	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
@@ -323,11 +295,17 @@ func (si *statsInspector) triggerTextStatsTask() {
 }
 
 func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
-	if jsonShreddingDisabledByDeprecatedConfig() {
-		mlog.RatedWarn(si.ctx, rate.Limit(0.1), "skip JSON key index stats task, dataCoord.jsonShreddingTriggerCount is set to 0",
-			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+	now := time.Now().Unix()
+	triggerInterval := int64(Params.DataCoordCfg.JSONStatsTriggerInterval.GetAsDuration(time.Minute).Seconds())
+	if now-si.lastJSONStatsTrigger > triggerInterval {
+		si.lastJSONStatsTrigger = now
+		si.jsonStatsTaskCount = 0
+	}
+	triggerCount := Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt()
+	if si.jsonStatsTaskCount >= triggerCount {
 		return
 	}
+
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
@@ -359,6 +337,9 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
 		for _, segment := range segments {
+			if si.jsonStatsTaskCount >= triggerCount {
+				return
+			}
 			if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
 				return
 			}
@@ -366,6 +347,9 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
 				continue
+			}
+			if si.mt.statsTaskMeta.HasStatsTask(segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob) {
+				si.jsonStatsTaskCount++
 			}
 		}
 	}

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -198,11 +198,31 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 	return false
 }
 
+// canSubmitStatsTask reports whether the global scheduler still has room for a
+// new stats task. The pending queue is shared by every task type, so a deep
+// queue means the workers are already saturated and adding more stats tasks
+// only grows the backlog. Discovery re-runs on every TaskCheckInterval tick, so
+// a segment skipped here is picked up again once the queue drains.
+func (si *statsInspector) canSubmitStatsTask() bool {
+	pendingTaskCount := si.scheduler.GetPendingTaskCount()
+	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
+	if pendingTaskCount > pendingTaskLimit {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
+			mlog.Int("pendingTaskCount", pendingTaskCount),
+			mlog.Int("pendingTaskLimit", pendingTaskLimit))
+		return false
+	}
+	return true
+}
+
 func (si *statsInspector) triggerTextStatsTask() {
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
 			continue
+		}
+		if !si.canSubmitStatsTask() {
+			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
@@ -215,7 +235,13 @@ func (si *statsInspector) triggerTextStatsTask() {
 		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			return needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted)
+			if !needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted) {
+				return false
+			}
+			// A segment whose task is already in meta must not be re-submitted;
+			// filtering it out here keeps the per-tick work proportional to the
+			// segments that still need a task instead of to all of them.
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_TextIndexJob)
 		}))
 
 		resources := []*internalpb.FileResourceInfo{}
@@ -229,6 +255,9 @@ func (si *statsInspector) triggerTextStatsTask() {
 		}
 
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask() {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_TextIndexJob, true, resources); err != nil {
 				mlog.Warn(si.ctx, "create stats task with text index for segment failed, wait for retry",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -244,6 +273,9 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 		if collection == nil {
 			continue
 		}
+		if !si.canSubmitStatsTask() {
+			return
+		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
 			h := typeutil.CreateFieldSchemaHelper(field)
@@ -256,9 +288,15 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 			if collection.IsExternal() && !canBuildExternalJSONKeyIndex(seg) {
 				return false
 			}
-			return needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted)
+			if !needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted) {
+				return false
+			}
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask() {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -274,6 +312,9 @@ func (si *statsInspector) triggerBM25StatsTask() {
 		if collection == nil || collection.IsExternal() {
 			continue
 		}
+		if !si.canSubmitStatsTask() {
+			return
+		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
 		for _, field := range collection.Schema.GetFields() {
 			// TODO: docking bm25 stats task
@@ -282,10 +323,16 @@ func (si *statsInspector) triggerBM25StatsTask() {
 			}
 		}
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			return (seg.GetIsSorted() || seg.GetIsSortedByNamespace()) && needDoBM25(seg, needTriggerFieldIDs)
+			if !(seg.GetIsSorted() || seg.GetIsSortedByNamespace()) || !needDoBM25(seg, needTriggerFieldIDs) {
+				return false
+			}
+			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_BM25Job)
 		}))
 
 		for _, segment := range segments {
+			if !si.canSubmitStatsTask() {
+				return
+			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_BM25Job, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with bm25 for segment failed, wait for retry",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
@@ -357,14 +404,7 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 			mlog.String("subJobType", subJobType.String()))
 		return nil
 	}
-	pendingTaskCount := si.scheduler.GetPendingTaskCount()
-	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
-	if pendingTaskCount > pendingTaskLimit {
-		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
-			mlog.Int("pendingTaskCount", pendingTaskCount),
-			mlog.Int("pendingTaskLimit", pendingTaskLimit),
-			mlog.FieldSegmentID(originSegmentID),
-			mlog.String("subJobType", subJobType.String()))
+	if !si.canSubmitStatsTask() {
 		return nil
 	}
 	taskID, err := si.allocator.AllocID(context.Background())

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -234,6 +234,11 @@ func (si *statsInspector) triggerTextStatsTask() {
 			}
 			needTriggerFieldIDs = append(needTriggerFieldIDs, field.GetFieldID())
 		}
+		// needDoTextIndex is false for every segment once there is no field to
+		// index, so skip the collection before scanning all of its segments.
+		if len(needTriggerFieldIDs) == 0 {
+			continue
+		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
 			if !needDoTextIndex(seg, needTriggerFieldIDs, allowUnsorted) {
@@ -286,6 +291,11 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 				needTriggerFieldIDs = append(needTriggerFieldIDs, field.GetFieldID())
 			}
 		}
+		// Same as the text loop: no field to shred means no candidate segment,
+		// which also short-circuits every collection once JSON shredding is off.
+		if len(needTriggerFieldIDs) == 0 {
+			continue
+		}
 		allowUnsorted := collection.IsExternal()
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
 			if collection.IsExternal() && !canBuildExternalJSONKeyIndex(seg) {
@@ -310,6 +320,11 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 }
 
 func (si *statsInspector) triggerBM25StatsTask() {
+	// BM25 stats tasks are not docked yet, so every collection would be scanned
+	// for nothing. Drop out before touching the segment meta at all.
+	if !si.enableBM25() {
+		return
+	}
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil || collection.IsExternal() {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -62,6 +62,9 @@ type statsInspector struct {
 	handler             Handler
 	compactionInspector CompactionInspector
 	ievm                IndexEngineVersionManager
+
+	lastJSONStatsTrigger int64
+	jsonStatsTaskCount   int
 }
 
 func newStatsInspector(ctx context.Context,
@@ -74,55 +77,24 @@ func newStatsInspector(ctx context.Context,
 ) *statsInspector {
 	ctx, cancel := context.WithCancel(ctx)
 	return &statsInspector{
-		ctx:                 ctx,
-		cancel:              cancel,
-		loopWg:              sync.WaitGroup{},
-		mt:                  mt,
-		scheduler:           scheduler,
-		allocator:           allocator,
-		handler:             handler,
-		compactionInspector: compactionInspector,
-		ievm:                ievm,
+		ctx:                  ctx,
+		cancel:               cancel,
+		loopWg:               sync.WaitGroup{},
+		mt:                   mt,
+		scheduler:            scheduler,
+		allocator:            allocator,
+		handler:              handler,
+		compactionInspector:  compactionInspector,
+		ievm:                 ievm,
+		lastJSONStatsTrigger: time.Now().Unix(),
 	}
 }
 
 func (si *statsInspector) Start() {
-	si.warnDeprecatedThrottleConfigs()
 	si.reloadFromMeta()
 	si.loopWg.Add(2)
 	go si.triggerStatsTaskLoop()
 	go si.cleanupStatsTasksLoop()
-}
-
-// warnDeprecatedThrottleConfigs tells operators whose config still carries the
-// old JSON throttle that it no longer has any effect, instead of letting the
-// setting disappear silently on upgrade.
-func (si *statsInspector) warnDeprecatedThrottleConfigs() {
-	for _, item := range []*paramtable.ParamItem{
-		&Params.DataCoordCfg.JSONStatsTriggerCount,
-		&Params.DataCoordCfg.JSONStatsTriggerInterval,
-	} {
-		if item.GetValue() == item.DefaultValue {
-			continue
-		}
-		mlog.Warn(si.ctx, "deprecated config is set and no longer throttles stats tasks, use dataCoord.statsTaskPendingLimit instead",
-			mlog.String("key", item.Key),
-			mlog.String("value", item.GetValue()))
-	}
-	if jsonShreddingDisabledByDeprecatedConfig() {
-		mlog.Warn(si.ctx, "dataCoord.jsonShreddingTriggerCount is 0, keeping JSON key index submission disabled for compatibility",
-			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
-	}
-}
-
-// jsonShreddingDisabledByDeprecatedConfig reports whether the deprecated
-// jsonShreddingTriggerCount is still being used as a kill switch. The removed
-// limiter broke out of the loop once the submitted count reached the configured
-// value, so 0 disabled JSON key-index submission on the very first segment.
-// Silently re-enabling shredding for an operator who had set 0 would undo a
-// deliberate decision, so that one value keeps its meaning.
-func jsonShreddingDisabledByDeprecatedConfig() bool {
-	return Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() == 0
 }
 
 func (si *statsInspector) Stop() {
@@ -247,10 +219,10 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 }
 
 // canSubmitStatsTask reports whether the global scheduler still has room for a
-// new stats task. The pending queue is shared by every task type, so a deep
-// queue means the workers are already saturated and adding more stats tasks
-// only grows the backlog. Discovery re-runs on every TaskCheckInterval tick, so
-// a segment skipped here is picked up again once the queue drains.
+// new stats task. The pending queue is shared by every task type, but tasks in
+// retry backoff are excluded because they are not currently waiting for a
+// worker slot. Discovery re-runs on every TaskCheckInterval tick, so a segment
+// skipped here is picked up again once the runnable queue drains.
 func (si *statsInspector) canSubmitStatsTask(subJobType indexpb.StatsSubJob) bool {
 	pendingTaskCount := si.scheduler.GetPendingTaskCount()
 	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
@@ -324,11 +296,17 @@ func (si *statsInspector) triggerTextStatsTask() {
 }
 
 func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
-	if jsonShreddingDisabledByDeprecatedConfig() {
-		mlog.RatedWarn(si.ctx, rate.Limit(0.1), "skip JSON key index stats task, dataCoord.jsonShreddingTriggerCount is set to 0",
-			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+	now := time.Now().Unix()
+	triggerInterval := int64(Params.DataCoordCfg.JSONStatsTriggerInterval.GetAsDuration(time.Minute).Seconds())
+	if now-si.lastJSONStatsTrigger > triggerInterval {
+		si.lastJSONStatsTrigger = now
+		si.jsonStatsTaskCount = 0
+	}
+	triggerCount := Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt()
+	if si.jsonStatsTaskCount >= triggerCount {
 		return
 	}
+
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
@@ -360,6 +338,9 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
 		for _, segment := range segments {
+			if si.jsonStatsTaskCount >= triggerCount {
+				return
+			}
 			if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
 				return
 			}
@@ -367,6 +348,9 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
 				continue
+			}
+			if si.mt.statsTaskMeta.HasStatsTask(segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob) {
+				si.jsonStatsTaskCount++
 			}
 		}
 	}

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -351,6 +351,13 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 			return nil
 		}
 	}
+	if si.mt.statsTaskMeta.HasStatsTask(originSegmentID, subJobType) {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "stats task already exists",
+			mlog.FieldCollectionID(originSegment.GetCollectionID()),
+			mlog.FieldSegmentID(originSegmentID),
+			mlog.String("subJobType", subJobType.String()))
+		return nil
+	}
 	pendingTaskCount := si.scheduler.GetPendingTaskCount()
 	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
 	if pendingTaskCount > pendingTaskLimit {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -341,7 +341,10 @@ func (si *statsInspector) triggerBM25StatsTask() {
 			}
 		}
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			if !(seg.GetIsSorted() || seg.GetIsSortedByNamespace()) || !needDoBM25(seg, needTriggerFieldIDs) {
+			if !seg.GetIsSorted() && !seg.GetIsSortedByNamespace() {
+				return false
+			}
+			if !needDoBM25(seg, needTriggerFieldIDs) {
 				return false
 			}
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_BM25Job)

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	taskcommon "github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -247,12 +248,14 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 }
 
 // canSubmitStatsTask reports whether the global scheduler still has room for a
-// new stats task. The pending queue is shared by every task type, but tasks in
-// retry backoff are excluded because they are not currently waiting for a
-// worker slot. Discovery re-runs on every TaskCheckInterval tick, so a segment
-// skipped here is picked up again once the runnable queue drains.
+// new stats task. The pending queue is shared by every task type, so the count is
+// scoped to stats work: an index or compaction backlog must not starve text-index
+// and JSON-shredding submission. Stats tasks waiting on a retry backoff are
+// counted, because they still occupy queue depth. Discovery re-runs on every
+// TaskCheckInterval tick, so a segment skipped here is picked up again once the
+// stats queue drains.
 func (si *statsInspector) canSubmitStatsTask(subJobType indexpb.StatsSubJob) bool {
-	pendingTaskCount := si.scheduler.GetPendingTaskCount()
+	pendingTaskCount := si.scheduler.GetPendingTaskCount(taskcommon.Stats)
 	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
 	if pendingTaskCount > pendingTaskLimit {
 		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -203,13 +203,14 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 // queue means the workers are already saturated and adding more stats tasks
 // only grows the backlog. Discovery re-runs on every TaskCheckInterval tick, so
 // a segment skipped here is picked up again once the queue drains.
-func (si *statsInspector) canSubmitStatsTask() bool {
+func (si *statsInspector) canSubmitStatsTask(subJobType indexpb.StatsSubJob) bool {
 	pendingTaskCount := si.scheduler.GetPendingTaskCount()
 	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
 	if pendingTaskCount > pendingTaskLimit {
 		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
 			mlog.Int("pendingTaskCount", pendingTaskCount),
-			mlog.Int("pendingTaskLimit", pendingTaskLimit))
+			mlog.Int("pendingTaskLimit", pendingTaskLimit),
+			mlog.String("subJobType", subJobType.String()))
 		return false
 	}
 	return true
@@ -221,7 +222,7 @@ func (si *statsInspector) triggerTextStatsTask() {
 		if collection == nil {
 			continue
 		}
-		if !si.canSubmitStatsTask() {
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_TextIndexJob) {
 			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
@@ -241,6 +242,7 @@ func (si *statsInspector) triggerTextStatsTask() {
 			// A segment whose task is already in meta must not be re-submitted;
 			// filtering it out here keeps the per-tick work proportional to the
 			// segments that still need a task instead of to all of them.
+			// Note this runs under meta.segMu.RLock, so keep it to a map read.
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_TextIndexJob)
 		}))
 
@@ -255,7 +257,7 @@ func (si *statsInspector) triggerTextStatsTask() {
 		}
 
 		for _, segment := range segments {
-			if !si.canSubmitStatsTask() {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_TextIndexJob) {
 				return
 			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_TextIndexJob, true, resources); err != nil {
@@ -273,7 +275,7 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 		if collection == nil {
 			continue
 		}
-		if !si.canSubmitStatsTask() {
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
 			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
@@ -294,7 +296,7 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
 		for _, segment := range segments {
-			if !si.canSubmitStatsTask() {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
 				return
 			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob, true, nil); err != nil {
@@ -312,7 +314,7 @@ func (si *statsInspector) triggerBM25StatsTask() {
 		if collection == nil || collection.IsExternal() {
 			continue
 		}
-		if !si.canSubmitStatsTask() {
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_BM25Job) {
 			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
@@ -330,7 +332,7 @@ func (si *statsInspector) triggerBM25StatsTask() {
 		}))
 
 		for _, segment := range segments {
-			if !si.canSubmitStatsTask() {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_BM25Job) {
 				return
 			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_BM25Job, true, nil); err != nil {
@@ -404,7 +406,9 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 			mlog.String("subJobType", subJobType.String()))
 		return nil
 	}
-	if !si.canSubmitStatsTask() {
+	// The trigger loops check admission before getting here; this guard covers
+	// callers that reach the StatsInspector interface directly.
+	if !si.canSubmitStatsTask(subJobType) {
 		return nil
 	}
 	taskID, err := si.allocator.AllocID(context.Background())

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -203,13 +203,14 @@ func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
 // queue means the workers are already saturated and adding more stats tasks
 // only grows the backlog. Discovery re-runs on every TaskCheckInterval tick, so
 // a segment skipped here is picked up again once the queue drains.
-func (si *statsInspector) canSubmitStatsTask() bool {
+func (si *statsInspector) canSubmitStatsTask(subJobType indexpb.StatsSubJob) bool {
 	pendingTaskCount := si.scheduler.GetPendingTaskCount()
 	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
 	if pendingTaskCount > pendingTaskLimit {
 		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
 			mlog.Int("pendingTaskCount", pendingTaskCount),
-			mlog.Int("pendingTaskLimit", pendingTaskLimit))
+			mlog.Int("pendingTaskLimit", pendingTaskLimit),
+			mlog.String("subJobType", subJobType.String()))
 		return false
 	}
 	return true
@@ -221,7 +222,7 @@ func (si *statsInspector) triggerTextStatsTask() {
 		if collection == nil {
 			continue
 		}
-		if !si.canSubmitStatsTask() {
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_TextIndexJob) {
 			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
@@ -241,6 +242,7 @@ func (si *statsInspector) triggerTextStatsTask() {
 			// A segment whose task is already in meta must not be re-submitted;
 			// filtering it out here keeps the per-tick work proportional to the
 			// segments that still need a task instead of to all of them.
+			// Note this runs under meta.segMu.RLock, so keep it to a map read.
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_TextIndexJob)
 		}))
 
@@ -256,7 +258,7 @@ func (si *statsInspector) triggerTextStatsTask() {
 		}
 
 		for _, segment := range segments {
-			if !si.canSubmitStatsTask() {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_TextIndexJob) {
 				return
 			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_TextIndexJob, true, resources); err != nil {
@@ -274,7 +276,7 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 		if collection == nil {
 			continue
 		}
-		if !si.canSubmitStatsTask() {
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
 			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
@@ -295,7 +297,7 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob)
 		}))
 		for _, segment := range segments {
-			if !si.canSubmitStatsTask() {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_JsonKeyIndexJob) {
 				return
 			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob, true, nil); err != nil {
@@ -313,7 +315,7 @@ func (si *statsInspector) triggerBM25StatsTask() {
 		if collection == nil || collection.IsExternal() {
 			continue
 		}
-		if !si.canSubmitStatsTask() {
+		if !si.canSubmitStatsTask(indexpb.StatsSubJob_BM25Job) {
 			return
 		}
 		needTriggerFieldIDs := make([]UniqueID, 0)
@@ -331,7 +333,7 @@ func (si *statsInspector) triggerBM25StatsTask() {
 		}))
 
 		for _, segment := range segments {
-			if !si.canSubmitStatsTask() {
+			if !si.canSubmitStatsTask(indexpb.StatsSubJob_BM25Job) {
 				return
 			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_BM25Job, true, nil); err != nil {
@@ -405,7 +407,9 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 			mlog.String("subJobType", subJobType.String()))
 		return nil
 	}
-	if !si.canSubmitStatsTask() {
+	// The trigger loops check admission before getting here; this guard covers
+	// callers that reach the StatsInspector interface directly.
+	if !si.canSubmitStatsTask(subJobType) {
 		return nil
 	}
 	taskID, err := si.allocator.AllocID(context.Background())

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -129,8 +129,6 @@ func (si *statsInspector) triggerStatsTaskLoop() {
 	ticker := time.NewTicker(Params.DataCoordCfg.TaskCheckInterval.GetAsDuration(time.Second))
 	defer ticker.Stop()
 
-	lastJSONStatsLastTrigger := time.Now().Unix()
-	maxJSONStatsTaskCount := 0
 	for {
 		select {
 		case <-si.ctx.Done():
@@ -139,7 +137,7 @@ func (si *statsInspector) triggerStatsTaskLoop() {
 		case <-ticker.C:
 			si.triggerTextStatsTask()
 			si.triggerBM25StatsTask()
-			lastJSONStatsLastTrigger, maxJSONStatsTaskCount = si.triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger, maxJSONStatsTaskCount)
+			si.triggerJSONKeyIndexStatsTask()
 		}
 	}
 }
@@ -241,7 +239,7 @@ func (si *statsInspector) triggerTextStatsTask() {
 	}
 }
 
-func (si *statsInspector) triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger int64, maxJSONStatsTaskCount int) (int64, int) {
+func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {
@@ -261,23 +259,14 @@ func (si *statsInspector) triggerJSONKeyIndexStatsTask(lastJSONStatsLastTrigger 
 			}
 			return needDoJSONKeyIndex(seg, needTriggerFieldIDs, allowUnsorted)
 		}))
-		if time.Now().Unix()-lastJSONStatsLastTrigger > int64(Params.DataCoordCfg.JSONStatsTriggerInterval.GetAsDuration(time.Minute).Seconds()) {
-			lastJSONStatsLastTrigger = time.Now().Unix()
-			maxJSONStatsTaskCount = 0
-		}
 		for _, segment := range segments {
-			if maxJSONStatsTaskCount >= Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() {
-				break
-			}
 			if err := si.SubmitStatsTask(segment.GetID(), segment.GetID(), indexpb.StatsSubJob_JsonKeyIndexJob, true, nil); err != nil {
 				mlog.Warn(si.ctx, "create stats task with json key index for segment failed, wait for retry:",
 					mlog.FieldSegmentID(segment.GetID()), mlog.Err(err))
 				continue
 			}
-			maxJSONStatsTaskCount++
 		}
 	}
-	return lastJSONStatsLastTrigger, maxJSONStatsTaskCount
 }
 
 func (si *statsInspector) triggerBM25StatsTask() {
@@ -361,6 +350,16 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 				mlog.String("subJobType", subJobType.String()))
 			return nil
 		}
+	}
+	pendingTaskCount := si.scheduler.GetPendingTaskCount()
+	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
+	if pendingTaskCount > pendingTaskLimit {
+		mlog.RatedInfo(si.ctx, rate.Limit(10), "skip submitting stats task because global scheduler has too many pending tasks",
+			mlog.Int("pendingTaskCount", pendingTaskCount),
+			mlog.Int("pendingTaskLimit", pendingTaskLimit),
+			mlog.FieldSegmentID(originSegmentID),
+			mlog.String("subJobType", subJobType.String()))
+		return nil
 	}
 	taskID, err := si.allocator.AllocID(context.Background())
 	if err != nil {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -340,7 +340,10 @@ func (si *statsInspector) triggerBM25StatsTask() {
 			}
 		}
 		segments := si.mt.SelectSegments(si.ctx, WithCollection(collection.ID), SegmentFilterFunc(func(seg *SegmentInfo) bool {
-			if !(seg.GetIsSorted() || seg.GetIsSortedByNamespace()) || !needDoBM25(seg, needTriggerFieldIDs) {
+			if !seg.GetIsSorted() && !seg.GetIsSortedByNamespace() {
+				return false
+			}
+			if !needDoBM25(seg, needTriggerFieldIDs) {
 				return false
 			}
 			return !si.mt.statsTaskMeta.HasStatsTask(seg.GetID(), indexpb.StatsSubJob_BM25Job)

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -87,10 +87,42 @@ func newStatsInspector(ctx context.Context,
 }
 
 func (si *statsInspector) Start() {
+	si.warnDeprecatedThrottleConfigs()
 	si.reloadFromMeta()
 	si.loopWg.Add(2)
 	go si.triggerStatsTaskLoop()
 	go si.cleanupStatsTasksLoop()
+}
+
+// warnDeprecatedThrottleConfigs tells operators whose config still carries the
+// old JSON throttle that it no longer has any effect, instead of letting the
+// setting disappear silently on upgrade.
+func (si *statsInspector) warnDeprecatedThrottleConfigs() {
+	for _, item := range []*paramtable.ParamItem{
+		&Params.DataCoordCfg.JSONStatsTriggerCount,
+		&Params.DataCoordCfg.JSONStatsTriggerInterval,
+	} {
+		if item.GetValue() == item.DefaultValue {
+			continue
+		}
+		mlog.Warn(si.ctx, "deprecated config is set and no longer throttles stats tasks, use dataCoord.statsTaskPendingLimit instead",
+			mlog.String("key", item.Key),
+			mlog.String("value", item.GetValue()))
+	}
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.Warn(si.ctx, "dataCoord.jsonShreddingTriggerCount is 0, keeping JSON key index submission disabled for compatibility",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+	}
+}
+
+// jsonShreddingDisabledByDeprecatedConfig reports whether the deprecated
+// jsonShreddingTriggerCount is still being used as a kill switch. The removed
+// limiter broke out of the loop once the submitted count reached the configured
+// value, so 0 disabled JSON key-index submission on the very first segment.
+// Silently re-enabling shredding for an operator who had set 0 would undo a
+// deliberate decision, so that one value keeps its meaning.
+func jsonShreddingDisabledByDeprecatedConfig() bool {
+	return Params.DataCoordCfg.JSONStatsTriggerCount.GetAsInt() == 0
 }
 
 func (si *statsInspector) Stop() {
@@ -129,17 +161,33 @@ func (si *statsInspector) triggerStatsTaskLoop() {
 	ticker := time.NewTicker(Params.DataCoordCfg.TaskCheckInterval.GetAsDuration(time.Second))
 	defer ticker.Stop()
 
+	round := 0
 	for {
 		select {
 		case <-si.ctx.Done():
 			mlog.Warn(si.ctx, "DataCoord context done, exit checkStatsTaskLoop...")
 			return
 		case <-ticker.C:
-			si.triggerTextStatsTask()
-			si.triggerBM25StatsTask()
-			si.triggerJSONKeyIndexStatsTask()
+			si.triggerStatsTasks(round)
+			round++
 		}
 	}
+}
+
+// triggerStatsTasks runs one discovery round. The sub-jobs share a single
+// admission budget and each trigger returns as soon as it is refused, so
+// whichever runs first claims the capacity. Alternate text and JSON per round,
+// otherwise a long text-index backlog starves JSON shredding for as long as it
+// takes to drain - days on a large collection.
+func (si *statsInspector) triggerStatsTasks(round int) {
+	if round%2 == 0 {
+		si.triggerTextStatsTask()
+		si.triggerJSONKeyIndexStatsTask()
+	} else {
+		si.triggerJSONKeyIndexStatsTask()
+		si.triggerTextStatsTask()
+	}
+	si.triggerBM25StatsTask()
 }
 
 func (si *statsInspector) enableBM25() bool {
@@ -276,6 +324,11 @@ func (si *statsInspector) triggerTextStatsTask() {
 }
 
 func (si *statsInspector) triggerJSONKeyIndexStatsTask() {
+	if jsonShreddingDisabledByDeprecatedConfig() {
+		mlog.RatedWarn(si.ctx, rate.Limit(0.1), "skip JSON key index stats task, dataCoord.jsonShreddingTriggerCount is set to 0",
+			mlog.String("suggestion", "set common.enabledJSONShredding to false instead"))
+		return
+	}
 	collections := si.mt.GetCollections()
 	for _, collection := range collections {
 		if collection == nil {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -301,20 +301,11 @@ func (s *statsInspectorSuite) TestSubmitStatsTask() {
 	s.Error(err)
 	s.True(errors.Is(err, merr.ErrSegmentNotFound), "Error should be ErrSegmentNotFound")
 
-	s.mt.statsTaskMeta.tasks.Insert(1001, &indexpb.StatsTask{
-		TaskID:     1001,
-		SegmentID:  10,
-		SubJobType: indexpb.StatsSubJob_Sort,
-	})
-	s.mt.statsTaskMeta.segmentID2Tasks.Insert("10-Sort", &indexpb.StatsTask{
-		TaskID:     1001,
-		SegmentID:  10,
-		SubJobType: indexpb.StatsSubJob_Sort,
-	})
-
-	// Simulate duplicate task error
+	// Duplicate tasks are skipped before checking the scheduler or allocating a task ID.
+	s.inspector.scheduler = task.NewMockGlobalScheduler(s.T())
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
 	err = s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_Sort, true, nil)
-	s.NoError(err) // Duplicate tasks are handled as success
+	s.NoError(err)
 }
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -237,6 +237,7 @@ func (s *statsInspectorSuite) SetupTest() {
 	gs := task.NewMockGlobalScheduler(s.T())
 	gs.EXPECT().Enqueue(mock.Anything).Return().Maybe()
 	gs.EXPECT().AbortAndRemoveTask(mock.Anything).Return().Maybe()
+	gs.EXPECT().GetPendingTaskCount().Return(0).Maybe()
 	s.scheduler = gs
 
 	s.inspector = newStatsInspector(
@@ -316,6 +317,31 @@ func (s *statsInspectorSuite) TestSubmitStatsTask() {
 	s.NoError(err) // Duplicate tasks are handled as success
 }
 
+func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
+	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
+
+	s.Run("allow at limit", func() {
+		scheduler := task.NewMockGlobalScheduler(s.T())
+		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit).Once()
+		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
+		s.inspector.scheduler = scheduler
+
+		err := s.inspector.SubmitStatsTask(20, 20, indexpb.StatsSubJob_TextIndexJob, true, nil)
+		s.NoError(err)
+		s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+	})
+
+	s.Run("skip over limit", func() {
+		scheduler := task.NewMockGlobalScheduler(s.T())
+		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit + 1).Once()
+		s.inspector.scheduler = scheduler
+
+		err := s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_TextIndexJob, true, nil)
+		s.NoError(err)
+		s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(10, indexpb.StatsSubJob_TextIndexJob))
+	})
+}
+
 func (s *statsInspectorSuite) TestSubmitStatsTaskSkipExternalCollection() {
 	segmentID := UniqueID(200)
 	s.putExternalSegment(segmentID, true, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/200", 1))
@@ -350,9 +376,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskExternalCollection
 	segmentID := UniqueID(201)
 	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/201", 1))
 
-	lastTrigger := time.Now().Add(-time.Hour).Unix()
-	_, triggered := s.inspector.triggerJSONKeyIndexStatsTask(lastTrigger, 0)
-	s.Equal(1, triggered)
+	s.inspector.triggerJSONKeyIndexStatsTask()
 
 	jsonTask := s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob)
 	s.NotNil(jsonTask)
@@ -383,9 +407,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskExternalCollection
 		s.Run(testCase.name, func() {
 			s.putExternalSegment(testCase.segmentID, false, testCase.storageVersion, testCase.manifestPath)
 
-			lastTrigger := time.Now().Add(-time.Hour).Unix()
-			_, triggered := s.inspector.triggerJSONKeyIndexStatsTask(lastTrigger, 0)
-			s.Equal(0, triggered)
+			s.inspector.triggerJSONKeyIndexStatsTask()
 
 			jsonTask := s.mt.statsTaskMeta.GetStatsTaskBySegmentID(testCase.segmentID, indexpb.StatsSubJob_JsonKeyIndexJob)
 			s.Nil(jsonTask)

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -285,16 +285,6 @@ func (s *statsInspectorSuite) putExternalStatsTask(taskID, segmentID UniqueID, s
 	})
 }
 
-func (s *statsInspectorSuite) countStatsTasks(subJobType indexpb.StatsSubJob) int {
-	count := 0
-	for _, statsTask := range s.mt.statsTaskMeta.GetAllTasks() {
-		if statsTask.GetSubJobType() == subJobType {
-			count++
-		}
-	}
-	return count
-}
-
 func (s *statsInspectorSuite) TestStart() {
 	s.inspector.Start()
 	time.Sleep(10 * time.Millisecond) // Give goroutines some time to start
@@ -404,8 +394,10 @@ func (s *statsInspectorSuite) TestTriggerStatsTasksAlternatesSubJobOrder() {
 	s.Contains(order, indexpb.StatsSubJob_TextIndexJob)
 }
 
-// A trigger count of 0 disables JSON key index submission.
-func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsZeroLimit() {
+// jsonShreddingTriggerCount is deprecated, but 0 used to disable JSON key index
+// submission outright and must keep doing so instead of silently turning
+// shredding back on after an upgrade.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZero() {
 	segmentID := UniqueID(230)
 	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/230", 1))
 
@@ -421,31 +413,6 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsZeroLimit() 
 
 	s.inspector.triggerJSONKeyIndexStatsTask()
 	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
-}
-
-func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskRateLimit() {
-	Params.Save(Params.DataCoordCfg.JSONStatsTriggerCount.Key, "2")
-	Params.Save(Params.DataCoordCfg.JSONStatsTriggerInterval.Key, "10")
-	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerCount.Key)
-	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerInterval.Key)
-
-	segmentIDs := []UniqueID{231, 232, 233, 234}
-	for _, segmentID := range segmentIDs {
-		s.putExternalSegment(segmentID, false, storage.StorageV3,
-			packed.MarshalManifestPath(fmt.Sprintf("files/insert_log/2/3/%d", segmentID), 1))
-	}
-
-	s.inspector.triggerJSONKeyIndexStatsTask()
-	s.Equal(2, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
-
-	// The same interval has no remaining JSON submission budget.
-	s.inspector.triggerJSONKeyIndexStatsTask()
-	s.Equal(2, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
-
-	// Once the interval elapses, the budget resets and two more tasks can be submitted.
-	s.inspector.lastJSONStatsTrigger = time.Now().Add(-11 * time.Minute).Unix()
-	s.inspector.triggerJSONKeyIndexStatsTask()
-	s.Equal(4, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
 }
 
 // Every trigger loop must give up as soon as the scheduler is backlogged instead

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -285,6 +285,16 @@ func (s *statsInspectorSuite) putExternalStatsTask(taskID, segmentID UniqueID, s
 	})
 }
 
+func (s *statsInspectorSuite) countStatsTasks(subJobType indexpb.StatsSubJob) int {
+	count := 0
+	for _, statsTask := range s.mt.statsTaskMeta.GetAllTasks() {
+		if statsTask.GetSubJobType() == subJobType {
+			count++
+		}
+	}
+	return count
+}
+
 func (s *statsInspectorSuite) TestStart() {
 	s.inspector.Start()
 	time.Sleep(10 * time.Millisecond) // Give goroutines some time to start
@@ -394,10 +404,8 @@ func (s *statsInspectorSuite) TestTriggerStatsTasksAlternatesSubJobOrder() {
 	s.Contains(order, indexpb.StatsSubJob_TextIndexJob)
 }
 
-// jsonShreddingTriggerCount is deprecated, but 0 used to disable JSON key index
-// submission outright and must keep doing so instead of silently turning
-// shredding back on after an upgrade.
-func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZero() {
+// A trigger count of 0 disables JSON key index submission.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsZeroLimit() {
 	segmentID := UniqueID(230)
 	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/230", 1))
 
@@ -413,6 +421,31 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZe
 
 	s.inspector.triggerJSONKeyIndexStatsTask()
 	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskRateLimit() {
+	Params.Save(Params.DataCoordCfg.JSONStatsTriggerCount.Key, "2")
+	Params.Save(Params.DataCoordCfg.JSONStatsTriggerInterval.Key, "10")
+	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerCount.Key)
+	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerInterval.Key)
+
+	segmentIDs := []UniqueID{231, 232, 233, 234}
+	for _, segmentID := range segmentIDs {
+		s.putExternalSegment(segmentID, false, storage.StorageV3,
+			packed.MarshalManifestPath(fmt.Sprintf("files/insert_log/2/3/%d", segmentID), 1))
+	}
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Equal(2, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
+
+	// The same interval has no remaining JSON submission budget.
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Equal(2, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
+
+	// Once the interval elapses, the budget resets and two more tasks can be submitted.
+	s.inspector.lastJSONStatsTrigger = time.Now().Add(-11 * time.Minute).Unix()
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Equal(4, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
 }
 
 // Every trigger loop must give up as soon as the scheduler is backlogged instead

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -367,6 +367,54 @@ func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
 	s.Empty(submitted)
 }
 
+// The sub-jobs share one admission budget, so the trigger that runs first wins
+// it. Consecutive rounds must not give the same sub-job first claim.
+func (s *statsInspectorSuite) TestTriggerStatsTasksAlternatesSubJobOrder() {
+	s.putExternalSegment(220, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/220", 1))
+
+	order := make([]indexpb.StatsSubJob, 0)
+	mockSubmit := mockey.Mock((*statsInspector).SubmitStatsTask).To(
+		func(_ *statsInspector, _, _ int64, subJobType indexpb.StatsSubJob, _ bool, _ []*internalpb.FileResourceInfo) error {
+			order = append(order, subJobType)
+			return nil
+		}).Build()
+	defer mockSubmit.UnPatch()
+
+	// Both sub-jobs have candidates, so the first entry is the one that would
+	// have claimed the budget had it been exhausted.
+	s.inspector.triggerStatsTasks(0)
+	s.Require().NotEmpty(order)
+	s.Equal(indexpb.StatsSubJob_TextIndexJob, order[0])
+	s.Contains(order, indexpb.StatsSubJob_JsonKeyIndexJob)
+
+	order = order[:0]
+	s.inspector.triggerStatsTasks(1)
+	s.Require().NotEmpty(order)
+	s.Equal(indexpb.StatsSubJob_JsonKeyIndexJob, order[0])
+	s.Contains(order, indexpb.StatsSubJob_TextIndexJob)
+}
+
+// jsonShreddingTriggerCount is deprecated, but 0 used to disable JSON key index
+// submission outright and must keep doing so instead of silently turning
+// shredding back on after an upgrade.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZero() {
+	segmentID := UniqueID(230)
+	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/230", 1))
+
+	// Sanity check: the segment is a candidate while the deprecated key is unset.
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+	s.NoError(s.mt.statsTaskMeta.DropStatsTask(s.ctx,
+		s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob).GetTaskID()))
+
+	Params.Save(Params.DataCoordCfg.JSONStatsTriggerCount.Key, "0")
+	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerCount.Key)
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
 // Every trigger loop must give up as soon as the scheduler is backlogged instead
 // of walking the remaining collections. The call count is what proves it: the
 // text and JSON loops each ask once for the first collection they look at and

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -375,26 +375,45 @@ func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
 	})
 }
 
-// A segment whose task is already in meta must be filtered out before
-// SubmitStatsTask, so a repeated tick costs no ID allocation and no meta write.
+// A segment whose task is already in meta must be dropped by the segment
+// selector, so a repeated tick never reaches SubmitStatsTask at all. Asserting
+// on side effects (no ID allocated, nothing enqueued) would not prove this:
+// SubmitStatsTask's own duplicate guard produces exactly the same side effects,
+// so the assertion has to be on whether SubmitStatsTask is called.
 func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
-	scheduler := task.NewMockGlobalScheduler(s.T())
-	scheduler.EXPECT().GetPendingTaskCount().Return(0)
-	scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
-	s.inspector.scheduler = scheduler
+	submitted := make([]UniqueID, 0)
+	mockSubmit := mockey.Mock((*statsInspector).SubmitStatsTask).To(
+		func(_ *statsInspector, originSegmentID, _ int64, _ indexpb.StatsSubJob, _ bool, _ []*internalpb.FileResourceInfo) error {
+			submitted = append(submitted, originSegmentID)
+			return nil
+		}).Build()
+	defer mockSubmit.UnPatch()
 
+	// Without a task in meta the segment is a candidate.
 	s.inspector.triggerTextStatsTask()
-	s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+	s.Equal([]UniqueID{20}, submitted)
 
-	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+	// Once the task is recorded the selector must drop the segment.
+	s.NoError(s.mt.statsTaskMeta.AddStatsTask(&indexpb.StatsTask{
+		CollectionID: 1,
+		TaskID:       1001,
+		SegmentID:    20,
+		SubJobType:   indexpb.StatsSubJob_TextIndexJob,
+	}))
+	submitted = submitted[:0]
 	s.inspector.triggerTextStatsTask()
+	s.Empty(submitted)
 }
 
 // Every trigger loop must give up as soon as the scheduler is backlogged instead
-// of walking the remaining collections and segments.
+// of walking the remaining collections. The call count is what proves it: each
+// loop asks once for the first collection it looks at and then returns, so three
+// loops ask exactly three times. Walking on (continue) would ask once per
+// collection instead.
 func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
 	scheduler := task.NewMockGlobalScheduler(s.T())
-	scheduler.EXPECT().GetPendingTaskCount().Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1)
+	scheduler.EXPECT().GetPendingTaskCount().
+		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(3)
 	s.inspector.scheduler = scheduler
 	s.inspector.allocator = allocator.NewMockAllocator(s.T())
 

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -405,6 +405,54 @@ func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
 	s.Empty(submitted)
 }
 
+// The sub-jobs share one admission budget, so the trigger that runs first wins
+// it. Consecutive rounds must not give the same sub-job first claim.
+func (s *statsInspectorSuite) TestTriggerStatsTasksAlternatesSubJobOrder() {
+	s.putExternalSegment(220, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/220", 1))
+
+	order := make([]indexpb.StatsSubJob, 0)
+	mockSubmit := mockey.Mock((*statsInspector).SubmitStatsTask).To(
+		func(_ *statsInspector, _, _ int64, subJobType indexpb.StatsSubJob, _ bool, _ []*internalpb.FileResourceInfo) error {
+			order = append(order, subJobType)
+			return nil
+		}).Build()
+	defer mockSubmit.UnPatch()
+
+	// Both sub-jobs have candidates, so the first entry is the one that would
+	// have claimed the budget had it been exhausted.
+	s.inspector.triggerStatsTasks(0)
+	s.Require().NotEmpty(order)
+	s.Equal(indexpb.StatsSubJob_TextIndexJob, order[0])
+	s.Contains(order, indexpb.StatsSubJob_JsonKeyIndexJob)
+
+	order = order[:0]
+	s.inspector.triggerStatsTasks(1)
+	s.Require().NotEmpty(order)
+	s.Equal(indexpb.StatsSubJob_JsonKeyIndexJob, order[0])
+	s.Contains(order, indexpb.StatsSubJob_TextIndexJob)
+}
+
+// jsonShreddingTriggerCount is deprecated, but 0 used to disable JSON key index
+// submission outright and must keep doing so instead of silently turning
+// shredding back on after an upgrade.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZero() {
+	segmentID := UniqueID(230)
+	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/230", 1))
+
+	// Sanity check: the segment is a candidate while the deprecated key is unset.
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+	s.NoError(s.mt.statsTaskMeta.DropStatsTask(s.ctx,
+		s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob).GetTaskID()))
+
+	Params.Save(Params.DataCoordCfg.JSONStatsTriggerCount.Key, "0")
+	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerCount.Key)
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
 // Every trigger loop must give up as soon as the scheduler is backlogged instead
 // of walking the remaining collections. The call count is what proves it: the
 // text and JSON loops each ask once for the first collection they look at and

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -309,7 +310,7 @@ func (s *statsInspectorSuite) TestSubmitStatsTask() {
 }
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
-	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
+	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
 
 	s.Run("allow at limit", func() {
 		scheduler := task.NewMockGlobalScheduler(s.T())
@@ -326,11 +327,77 @@ func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
 		scheduler := task.NewMockGlobalScheduler(s.T())
 		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit + 1).Once()
 		s.inspector.scheduler = scheduler
+		// A strict allocator asserts the admission check runs before task ID allocation.
+		s.inspector.allocator = allocator.NewMockAllocator(s.T())
 
 		err := s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_TextIndexJob, true, nil)
 		s.NoError(err)
 		s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(10, indexpb.StatsSubJob_TextIndexJob))
 	})
+}
+
+// A segment whose task is already in meta must be filtered out before
+// SubmitStatsTask, so a repeated tick costs no ID allocation and no meta write.
+func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().Return(0)
+	scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
+	s.inspector.scheduler = scheduler
+
+	s.inspector.triggerTextStatsTask()
+	s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+	s.inspector.triggerTextStatsTask()
+}
+
+// Every trigger loop must give up as soon as the scheduler is backlogged instead
+// of walking the remaining collections and segments.
+func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1)
+	s.inspector.scheduler = scheduler
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+	s.putExternalSegment(210, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/210", 1))
+
+	s.inspector.triggerTextStatsTask()
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.inspector.triggerBM25StatsTask()
+
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(210, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+// The loop keeps submitting while the pending count is at the limit and stops on
+// the first segment that would exceed it, mid-collection.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskStopsAtPendingLimit() {
+	Params.Save(Params.DataCoordCfg.StatsTaskPendingLimit.Key, "1")
+	defer Params.Reset(Params.DataCoordCfg.StatsTaskPendingLimit.Key)
+
+	segmentIDs := []UniqueID{301, 302, 303, 304}
+	for _, segmentID := range segmentIDs {
+		s.putExternalSegment(segmentID, false, storage.StorageV3,
+			packed.MarshalManifestPath(fmt.Sprintf("files/insert_log/2/3/%d", segmentID), 1))
+	}
+
+	pending := 0
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().RunAndReturn(func() int { return pending })
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(_ task.Task) { pending++ }).Return()
+	s.inspector.scheduler = scheduler
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+
+	// pending 0 -> allowed, 1 -> allowed (== limit), 2 -> skipped (> limit).
+	submitted := 0
+	for _, segmentID := range segmentIDs {
+		if s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob) != nil {
+			submitted++
+		}
+	}
+	s.Equal(2, submitted)
+	s.Equal(2, pending)
 }
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskSkipExternalCollection() {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -340,20 +340,11 @@ func (s *statsInspectorSuite) TestSubmitStatsTask() {
 	s.Error(err)
 	s.True(errors.Is(err, merr.ErrSegmentNotFound), "Error should be ErrSegmentNotFound")
 
-	s.mt.statsTaskMeta.tasks.Insert(1001, &indexpb.StatsTask{
-		TaskID:     1001,
-		SegmentID:  10,
-		SubJobType: indexpb.StatsSubJob_Sort,
-	})
-	s.mt.statsTaskMeta.segmentID2Tasks.Insert("10-Sort", &indexpb.StatsTask{
-		TaskID:     1001,
-		SegmentID:  10,
-		SubJobType: indexpb.StatsSubJob_Sort,
-	})
-
-	// Simulate duplicate task error
+	// Duplicate tasks are skipped before checking the scheduler or allocating a task ID.
+	s.inspector.scheduler = task.NewMockGlobalScheduler(s.T())
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
 	err = s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_Sort, true, nil)
-	s.NoError(err) // Duplicate tasks are handled as success
+	s.NoError(err)
 }
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -368,14 +368,14 @@ func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
 }
 
 // Every trigger loop must give up as soon as the scheduler is backlogged instead
-// of walking the remaining collections. The call count is what proves it: each
-// loop asks once for the first collection it looks at and then returns, so three
-// loops ask exactly three times. Walking on (continue) would ask once per
-// collection instead.
+// of walking the remaining collections. The call count is what proves it: the
+// text and JSON loops each ask once for the first collection they look at and
+// then return, while the BM25 loop returns before asking because BM25 is not
+// docked yet. Walking on (continue) would ask once per collection instead.
 func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
 	scheduler := task.NewMockGlobalScheduler(s.T())
 	scheduler.EXPECT().GetPendingTaskCount().
-		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(3)
+		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(2)
 	s.inspector.scheduler = scheduler
 	s.inspector.allocator = allocator.NewMockAllocator(s.T())
 

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	taskcommon "github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -240,7 +241,7 @@ func (s *statsInspectorSuite) SetupTest() {
 	gs := task.NewMockGlobalScheduler(s.T())
 	gs.EXPECT().Enqueue(mock.Anything).Return().Maybe()
 	gs.EXPECT().AbortAndRemoveTask(mock.Anything).Return().Maybe()
-	gs.EXPECT().GetPendingTaskCount().Return(0).Maybe()
+	gs.EXPECT().GetPendingTaskCount(taskcommon.Stats).Return(0).Maybe()
 	s.scheduler = gs
 
 	s.inspector = newStatsInspector(
@@ -353,7 +354,7 @@ func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
 
 	s.Run("allow at limit", func() {
 		scheduler := task.NewMockGlobalScheduler(s.T())
-		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit).Once()
+		scheduler.EXPECT().GetPendingTaskCount(taskcommon.Stats).Return(pendingTaskLimit).Once()
 		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
 		s.inspector.scheduler = scheduler
 
@@ -364,7 +365,7 @@ func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
 
 	s.Run("skip over limit", func() {
 		scheduler := task.NewMockGlobalScheduler(s.T())
-		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit + 1).Once()
+		scheduler.EXPECT().GetPendingTaskCount(taskcommon.Stats).Return(pendingTaskLimit + 1).Once()
 		s.inspector.scheduler = scheduler
 		// A strict allocator asserts the admission check runs before task ID allocation.
 		s.inspector.allocator = allocator.NewMockAllocator(s.T())
@@ -460,7 +461,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZe
 // docked yet. Walking on (continue) would ask once per collection instead.
 func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
 	scheduler := task.NewMockGlobalScheduler(s.T())
-	scheduler.EXPECT().GetPendingTaskCount().
+	scheduler.EXPECT().GetPendingTaskCount(taskcommon.Stats).
 		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(2)
 	s.inspector.scheduler = scheduler
 	s.inspector.allocator = allocator.NewMockAllocator(s.T())
@@ -489,7 +490,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskStopsAtPendingLimi
 
 	pending := 0
 	scheduler := task.NewMockGlobalScheduler(s.T())
-	scheduler.EXPECT().GetPendingTaskCount().RunAndReturn(func() int { return pending })
+	scheduler.EXPECT().GetPendingTaskCount(taskcommon.Stats).RunAndReturn(func(taskcommon.Type) int { return pending })
 	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(_ task.Task) { pending++ }).Return()
 	s.inspector.scheduler = scheduler
 

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -336,26 +337,45 @@ func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
 	})
 }
 
-// A segment whose task is already in meta must be filtered out before
-// SubmitStatsTask, so a repeated tick costs no ID allocation and no meta write.
+// A segment whose task is already in meta must be dropped by the segment
+// selector, so a repeated tick never reaches SubmitStatsTask at all. Asserting
+// on side effects (no ID allocated, nothing enqueued) would not prove this:
+// SubmitStatsTask's own duplicate guard produces exactly the same side effects,
+// so the assertion has to be on whether SubmitStatsTask is called.
 func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
-	scheduler := task.NewMockGlobalScheduler(s.T())
-	scheduler.EXPECT().GetPendingTaskCount().Return(0)
-	scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
-	s.inspector.scheduler = scheduler
+	submitted := make([]UniqueID, 0)
+	mockSubmit := mockey.Mock((*statsInspector).SubmitStatsTask).To(
+		func(_ *statsInspector, originSegmentID, _ int64, _ indexpb.StatsSubJob, _ bool, _ []*internalpb.FileResourceInfo) error {
+			submitted = append(submitted, originSegmentID)
+			return nil
+		}).Build()
+	defer mockSubmit.UnPatch()
 
+	// Without a task in meta the segment is a candidate.
 	s.inspector.triggerTextStatsTask()
-	s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+	s.Equal([]UniqueID{20}, submitted)
 
-	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+	// Once the task is recorded the selector must drop the segment.
+	s.NoError(s.mt.statsTaskMeta.AddStatsTask(&indexpb.StatsTask{
+		CollectionID: 1,
+		TaskID:       1001,
+		SegmentID:    20,
+		SubJobType:   indexpb.StatsSubJob_TextIndexJob,
+	}))
+	submitted = submitted[:0]
 	s.inspector.triggerTextStatsTask()
+	s.Empty(submitted)
 }
 
 // Every trigger loop must give up as soon as the scheduler is backlogged instead
-// of walking the remaining collections and segments.
+// of walking the remaining collections. The call count is what proves it: each
+// loop asks once for the first collection it looks at and then returns, so three
+// loops ask exactly three times. Walking on (continue) would ask once per
+// collection instead.
 func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
 	scheduler := task.NewMockGlobalScheduler(s.T())
-	scheduler.EXPECT().GetPendingTaskCount().Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1)
+	scheduler.EXPECT().GetPendingTaskCount().
+		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(3)
 	s.inspector.scheduler = scheduler
 	s.inspector.allocator = allocator.NewMockAllocator(s.T())
 

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -286,16 +286,6 @@ func (s *statsInspectorSuite) putExternalStatsTask(taskID, segmentID UniqueID, s
 	})
 }
 
-func (s *statsInspectorSuite) countStatsTasks(subJobType indexpb.StatsSubJob) int {
-	count := 0
-	for _, statsTask := range s.mt.statsTaskMeta.GetAllTasks() {
-		if statsTask.GetSubJobType() == subJobType {
-			count++
-		}
-	}
-	return count
-}
-
 func (s *statsInspectorSuite) TestStart() {
 	s.inspector.Start()
 	time.Sleep(10 * time.Millisecond) // Give goroutines some time to start
@@ -442,8 +432,10 @@ func (s *statsInspectorSuite) TestTriggerStatsTasksAlternatesSubJobOrder() {
 	s.Contains(order, indexpb.StatsSubJob_TextIndexJob)
 }
 
-// A trigger count of 0 disables JSON key index submission.
-func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsZeroLimit() {
+// jsonShreddingTriggerCount is deprecated, but 0 used to disable JSON key index
+// submission outright and must keep doing so instead of silently turning
+// shredding back on after an upgrade.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZero() {
 	segmentID := UniqueID(230)
 	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/230", 1))
 
@@ -459,31 +451,6 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsZeroLimit() 
 
 	s.inspector.triggerJSONKeyIndexStatsTask()
 	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
-}
-
-func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskRateLimit() {
-	Params.Save(Params.DataCoordCfg.JSONStatsTriggerCount.Key, "2")
-	Params.Save(Params.DataCoordCfg.JSONStatsTriggerInterval.Key, "10")
-	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerCount.Key)
-	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerInterval.Key)
-
-	segmentIDs := []UniqueID{231, 232, 233, 234}
-	for _, segmentID := range segmentIDs {
-		s.putExternalSegment(segmentID, false, storage.StorageV3,
-			packed.MarshalManifestPath(fmt.Sprintf("files/insert_log/2/3/%d", segmentID), 1))
-	}
-
-	s.inspector.triggerJSONKeyIndexStatsTask()
-	s.Equal(2, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
-
-	// The same interval has no remaining JSON submission budget.
-	s.inspector.triggerJSONKeyIndexStatsTask()
-	s.Equal(2, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
-
-	// Once the interval elapses, the budget resets and two more tasks can be submitted.
-	s.inspector.lastJSONStatsTrigger = time.Now().Add(-11 * time.Minute).Unix()
-	s.inspector.triggerJSONKeyIndexStatsTask()
-	s.Equal(4, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
 }
 
 // Every trigger loop must give up as soon as the scheduler is backlogged instead

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -348,7 +349,7 @@ func (s *statsInspectorSuite) TestSubmitStatsTask() {
 }
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
-	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
+	pendingTaskLimit := Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt()
 
 	s.Run("allow at limit", func() {
 		scheduler := task.NewMockGlobalScheduler(s.T())
@@ -365,11 +366,77 @@ func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
 		scheduler := task.NewMockGlobalScheduler(s.T())
 		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit + 1).Once()
 		s.inspector.scheduler = scheduler
+		// A strict allocator asserts the admission check runs before task ID allocation.
+		s.inspector.allocator = allocator.NewMockAllocator(s.T())
 
 		err := s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_TextIndexJob, true, nil)
 		s.NoError(err)
 		s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(10, indexpb.StatsSubJob_TextIndexJob))
 	})
+}
+
+// A segment whose task is already in meta must be filtered out before
+// SubmitStatsTask, so a repeated tick costs no ID allocation and no meta write.
+func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().Return(0)
+	scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
+	s.inspector.scheduler = scheduler
+
+	s.inspector.triggerTextStatsTask()
+	s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+	s.inspector.triggerTextStatsTask()
+}
+
+// Every trigger loop must give up as soon as the scheduler is backlogged instead
+// of walking the remaining collections and segments.
+func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1)
+	s.inspector.scheduler = scheduler
+	s.inspector.allocator = allocator.NewMockAllocator(s.T())
+
+	s.putExternalSegment(210, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/210", 1))
+
+	s.inspector.triggerTextStatsTask()
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.inspector.triggerBM25StatsTask()
+
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(210, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+// The loop keeps submitting while the pending count is at the limit and stops on
+// the first segment that would exceed it, mid-collection.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskStopsAtPendingLimit() {
+	Params.Save(Params.DataCoordCfg.StatsTaskPendingLimit.Key, "1")
+	defer Params.Reset(Params.DataCoordCfg.StatsTaskPendingLimit.Key)
+
+	segmentIDs := []UniqueID{301, 302, 303, 304}
+	for _, segmentID := range segmentIDs {
+		s.putExternalSegment(segmentID, false, storage.StorageV3,
+			packed.MarshalManifestPath(fmt.Sprintf("files/insert_log/2/3/%d", segmentID), 1))
+	}
+
+	pending := 0
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().GetPendingTaskCount().RunAndReturn(func() int { return pending })
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(_ task.Task) { pending++ }).Return()
+	s.inspector.scheduler = scheduler
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+
+	// pending 0 -> allowed, 1 -> allowed (== limit), 2 -> skipped (> limit).
+	submitted := 0
+	for _, segmentID := range segmentIDs {
+		if s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob) != nil {
+			submitted++
+		}
+	}
+	s.Equal(2, submitted)
+	s.Equal(2, pending)
 }
 
 func (s *statsInspectorSuite) TestSubmitStatsTaskSkipExternalCollection() {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -239,6 +239,7 @@ func (s *statsInspectorSuite) SetupTest() {
 	gs := task.NewMockGlobalScheduler(s.T())
 	gs.EXPECT().Enqueue(mock.Anything).Return().Maybe()
 	gs.EXPECT().AbortAndRemoveTask(mock.Anything).Return().Maybe()
+	gs.EXPECT().GetPendingTaskCount().Return(0).Maybe()
 	s.scheduler = gs
 
 	s.inspector = newStatsInspector(
@@ -355,6 +356,31 @@ func (s *statsInspectorSuite) TestSubmitStatsTask() {
 	s.NoError(err) // Duplicate tasks are handled as success
 }
 
+func (s *statsInspectorSuite) TestSubmitStatsTaskPendingLimit() {
+	pendingTaskLimit := Params.DataCoordCfg.SortCompactionTriggerCount.GetAsInt()
+
+	s.Run("allow at limit", func() {
+		scheduler := task.NewMockGlobalScheduler(s.T())
+		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit).Once()
+		scheduler.EXPECT().Enqueue(mock.Anything).Return().Once()
+		s.inspector.scheduler = scheduler
+
+		err := s.inspector.SubmitStatsTask(20, 20, indexpb.StatsSubJob_TextIndexJob, true, nil)
+		s.NoError(err)
+		s.NotNil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(20, indexpb.StatsSubJob_TextIndexJob))
+	})
+
+	s.Run("skip over limit", func() {
+		scheduler := task.NewMockGlobalScheduler(s.T())
+		scheduler.EXPECT().GetPendingTaskCount().Return(pendingTaskLimit + 1).Once()
+		s.inspector.scheduler = scheduler
+
+		err := s.inspector.SubmitStatsTask(10, 10, indexpb.StatsSubJob_TextIndexJob, true, nil)
+		s.NoError(err)
+		s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(10, indexpb.StatsSubJob_TextIndexJob))
+	})
+}
+
 func (s *statsInspectorSuite) TestSubmitStatsTaskSkipExternalCollection() {
 	segmentID := UniqueID(200)
 	s.putExternalSegment(segmentID, true, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/200", 1))
@@ -389,9 +415,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskExternalCollection
 	segmentID := UniqueID(201)
 	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/201", 1))
 
-	lastTrigger := time.Now().Add(-time.Hour).Unix()
-	_, triggered := s.inspector.triggerJSONKeyIndexStatsTask(lastTrigger, 0)
-	s.Equal(1, triggered)
+	s.inspector.triggerJSONKeyIndexStatsTask()
 
 	jsonTask := s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob)
 	s.NotNil(jsonTask)
@@ -422,9 +446,7 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskExternalCollection
 		s.Run(testCase.name, func() {
 			s.putExternalSegment(testCase.segmentID, false, testCase.storageVersion, testCase.manifestPath)
 
-			lastTrigger := time.Now().Add(-time.Hour).Unix()
-			_, triggered := s.inspector.triggerJSONKeyIndexStatsTask(lastTrigger, 0)
-			s.Equal(0, triggered)
+			s.inspector.triggerJSONKeyIndexStatsTask()
 
 			jsonTask := s.mt.statsTaskMeta.GetStatsTaskBySegmentID(testCase.segmentID, indexpb.StatsSubJob_JsonKeyIndexJob)
 			s.Nil(jsonTask)

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -406,14 +406,14 @@ func (s *statsInspectorSuite) TestTriggerTextStatsTaskSkipsSubmittedSegments() {
 }
 
 // Every trigger loop must give up as soon as the scheduler is backlogged instead
-// of walking the remaining collections. The call count is what proves it: each
-// loop asks once for the first collection it looks at and then returns, so three
-// loops ask exactly three times. Walking on (continue) would ask once per
-// collection instead.
+// of walking the remaining collections. The call count is what proves it: the
+// text and JSON loops each ask once for the first collection they look at and
+// then return, while the BM25 loop returns before asking because BM25 is not
+// docked yet. Walking on (continue) would ask once per collection instead.
 func (s *statsInspectorSuite) TestTriggerStatsTaskStopsWhenSchedulerBacklogged() {
 	scheduler := task.NewMockGlobalScheduler(s.T())
 	scheduler.EXPECT().GetPendingTaskCount().
-		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(3)
+		Return(Params.DataCoordCfg.StatsTaskPendingLimit.GetAsInt() + 1).Times(2)
 	s.inspector.scheduler = scheduler
 	s.inspector.allocator = allocator.NewMockAllocator(s.T())
 

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -286,6 +286,16 @@ func (s *statsInspectorSuite) putExternalStatsTask(taskID, segmentID UniqueID, s
 	})
 }
 
+func (s *statsInspectorSuite) countStatsTasks(subJobType indexpb.StatsSubJob) int {
+	count := 0
+	for _, statsTask := range s.mt.statsTaskMeta.GetAllTasks() {
+		if statsTask.GetSubJobType() == subJobType {
+			count++
+		}
+	}
+	return count
+}
+
 func (s *statsInspectorSuite) TestStart() {
 	s.inspector.Start()
 	time.Sleep(10 * time.Millisecond) // Give goroutines some time to start
@@ -432,10 +442,8 @@ func (s *statsInspectorSuite) TestTriggerStatsTasksAlternatesSubJobOrder() {
 	s.Contains(order, indexpb.StatsSubJob_TextIndexJob)
 }
 
-// jsonShreddingTriggerCount is deprecated, but 0 used to disable JSON key index
-// submission outright and must keep doing so instead of silently turning
-// shredding back on after an upgrade.
-func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZero() {
+// A trigger count of 0 disables JSON key index submission.
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsZeroLimit() {
 	segmentID := UniqueID(230)
 	s.putExternalSegment(segmentID, false, storage.StorageV3, packed.MarshalManifestPath("files/insert_log/2/3/230", 1))
 
@@ -451,6 +459,31 @@ func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskHonorsDeprecatedZe
 
 	s.inspector.triggerJSONKeyIndexStatsTask()
 	s.Nil(s.mt.statsTaskMeta.GetStatsTaskBySegmentID(segmentID, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+func (s *statsInspectorSuite) TestTriggerJSONKeyIndexStatsTaskRateLimit() {
+	Params.Save(Params.DataCoordCfg.JSONStatsTriggerCount.Key, "2")
+	Params.Save(Params.DataCoordCfg.JSONStatsTriggerInterval.Key, "10")
+	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerCount.Key)
+	defer Params.Reset(Params.DataCoordCfg.JSONStatsTriggerInterval.Key)
+
+	segmentIDs := []UniqueID{231, 232, 233, 234}
+	for _, segmentID := range segmentIDs {
+		s.putExternalSegment(segmentID, false, storage.StorageV3,
+			packed.MarshalManifestPath(fmt.Sprintf("files/insert_log/2/3/%d", segmentID), 1))
+	}
+
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Equal(2, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
+
+	// The same interval has no remaining JSON submission budget.
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Equal(2, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
+
+	// Once the interval elapses, the budget resets and two more tasks can be submitted.
+	s.inspector.lastJSONStatsTrigger = time.Now().Add(-11 * time.Minute).Unix()
+	s.inspector.triggerJSONKeyIndexStatsTask()
+	s.Equal(4, s.countStatsTasks(indexpb.StatsSubJob_JsonKeyIndexJob))
 }
 
 // Every trigger loop must give up as soon as the scheduler is backlogged instead

--- a/internal/datacoord/stats_task_meta.go
+++ b/internal/datacoord/stats_task_meta.go
@@ -315,6 +315,12 @@ func (stm *statsTaskMeta) GetStatsTaskStateBySegmentID(segmentID int64, subJobTy
 	return state
 }
 
+func (stm *statsTaskMeta) HasStatsTask(segmentID int64, subJobType indexpb.StatsSubJob) bool {
+	secondaryKey := createSecondaryIndexKey(segmentID, subJobType.String())
+	_, exists := stm.segmentID2Tasks.Get(secondaryKey)
+	return exists
+}
+
 func (stm *statsTaskMeta) CanCleanedTasks() []int64 {
 	needCleanedTaskIDs := make([]int64, 0)
 	stm.tasks.Range(func(key UniqueID, value *indexpb.StatsTask) bool {

--- a/internal/datacoord/stats_task_meta.go
+++ b/internal/datacoord/stats_task_meta.go
@@ -315,6 +315,10 @@ func (stm *statsTaskMeta) GetStatsTaskStateBySegmentID(segmentID int64, subJobTy
 	return state
 }
 
+// HasStatsTask reports whether a task for (segmentID, subJobType) is recorded in
+// meta, regardless of its state: a Finished or Failed task still counts until GC
+// recycles it, which is exactly the condition under which AddStatsTask would
+// reject a resubmission.
 func (stm *statsTaskMeta) HasStatsTask(segmentID int64, subJobType indexpb.StatsSubJob) bool {
 	secondaryKey := createSecondaryIndexKey(segmentID, subJobType.String())
 	_, exists := stm.segmentID2Tasks.Get(secondaryKey)

--- a/internal/datacoord/stats_task_meta_test.go
+++ b/internal/datacoord/stats_task_meta_test.go
@@ -265,6 +265,12 @@ func (s *statsTaskMetaSuite) Test_Method() {
 		})
 	})
 
+	s.Run("HasStatsTask", func() {
+		s.False(m.HasStatsTask(100, indexpb.StatsSubJob_Sort))
+		s.False(m.HasStatsTask(s.segmentID, indexpb.StatsSubJob_BM25Job))
+		s.True(m.HasStatsTask(s.segmentID, indexpb.StatsSubJob_Sort))
+	})
+
 	s.Run("DropStatsTask", func() {
 		s.Run("failed case", func() {
 			catalog.EXPECT().DropStatsTask(mock.Anything, mock.Anything).Return(errors.New("mock error")).Once()

--- a/internal/datacoord/stats_task_meta_test.go
+++ b/internal/datacoord/stats_task_meta_test.go
@@ -268,6 +268,9 @@ func (s *statsTaskMetaSuite) Test_Method() {
 	s.Run("HasStatsTask", func() {
 		s.False(m.HasStatsTask(100, indexpb.StatsSubJob_Sort))
 		s.False(m.HasStatsTask(s.segmentID, indexpb.StatsSubJob_BM25Job))
+		// The task is already Finished here: it keeps blocking resubmission
+		// until GC recycles it, matching AddStatsTask's duplicate guard.
+		s.Equal(indexpb.JobState_JobStateFinished, m.GetStatsTaskStateBySegmentID(s.segmentID, indexpb.StatsSubJob_Sort))
 		s.True(m.HasStatsTask(s.segmentID, indexpb.StatsSubJob_Sort))
 	})
 
@@ -286,6 +289,8 @@ func (s *statsTaskMetaSuite) Test_Method() {
 			s.NoError(m.DropStatsTask(context.TODO(), 1))
 			_, ok := m.tasks.Get(1)
 			s.False(ok)
+			// Once recycled the segment becomes submittable again.
+			s.False(m.HasStatsTask(s.segmentID, indexpb.StatsSubJob_Sort))
 
 			s.NoError(m.DropStatsTask(context.TODO(), 1000))
 		})

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -36,6 +36,7 @@ const NullNodeID = -1
 type GlobalScheduler interface {
 	Enqueue(task Task)
 	AbortAndRemoveTask(taskID int64)
+	GetPendingTaskCount() int
 
 	Start()
 	Stop()
@@ -121,6 +122,10 @@ func (s *globalTaskScheduler) Enqueue(task Task) {
 		s.runningTasks.Insert(task.GetTaskID(), task)
 	}
 	mlog.Info(s.ctx, "task enqueued", WrapTaskLog(task)...)
+}
+
+func (s *globalTaskScheduler) GetPendingTaskCount() int {
+	return s.pendingTasks.TaskCount()
 }
 
 func (s *globalTaskScheduler) AbortAndRemoveTask(taskID int64) {

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -39,9 +39,13 @@ const NullNodeID = -1
 type GlobalScheduler interface {
 	Enqueue(task Task)
 	AbortAndRemoveTask(taskID int64)
-	// GetPendingTaskCount returns tasks that are eligible for dispatch now;
-	// tasks waiting for their retry backoff deadline are excluded.
-	GetPendingTaskCount() int
+	// GetPendingTaskCount returns the number of queued tasks of the given type.
+	// The queue is shared by every task type, so callers that gate admission for
+	// one kind of work must scope the count to that kind, otherwise an unrelated
+	// backlog starves them. Tasks waiting on a retry backoff deadline ARE counted:
+	// they still occupy queue depth, and excluding them would let a worker-side
+	// failure storm silently disable the caller's admission gate.
+	GetPendingTaskCount(taskType taskcommon.Type) int
 
 	Start()
 	Stop()
@@ -129,11 +133,9 @@ func (s *globalTaskScheduler) Enqueue(task Task) {
 	mlog.Info(s.ctx, "task enqueued", WrapTaskLog(task)...)
 }
 
-func (s *globalTaskScheduler) GetPendingTaskCount() int {
-	now := time.Now()
+func (s *globalTaskScheduler) GetPendingTaskCount(taskType taskcommon.Type) int {
 	return s.pendingTasks.TaskCountBy(func(task Task) bool {
-		backoff, ok := s.backoffs.Get(task.GetTaskID())
-		return !ok || !now.Before(backoff.notBefore)
+		return task.GetTaskType() == taskType
 	})
 }
 

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -253,7 +253,7 @@ func (s *globalTaskScheduler) pickNode(slotHeap typeutil.Heap[*nodeSlotEntry], t
 }
 
 func (s *globalTaskScheduler) schedule() {
-	pendingNum := len(s.pendingTasks.TaskIDs())
+	pendingNum := s.pendingTasks.TaskCount()
 	if pendingNum == 0 {
 		return
 	}

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -39,6 +39,7 @@ const NullNodeID = -1
 type GlobalScheduler interface {
 	Enqueue(task Task)
 	AbortAndRemoveTask(taskID int64)
+	GetPendingTaskCount() int
 
 	Start()
 	Stop()
@@ -124,6 +125,10 @@ func (s *globalTaskScheduler) Enqueue(task Task) {
 		s.runningTasks.Insert(task.GetTaskID(), task)
 	}
 	mlog.Info(s.ctx, "task enqueued", WrapTaskLog(task)...)
+}
+
+func (s *globalTaskScheduler) GetPendingTaskCount() int {
+	return s.pendingTasks.TaskCount()
 }
 
 func (s *globalTaskScheduler) AbortAndRemoveTask(taskID int64) {

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -39,6 +39,8 @@ const NullNodeID = -1
 type GlobalScheduler interface {
 	Enqueue(task Task)
 	AbortAndRemoveTask(taskID int64)
+	// GetPendingTaskCount returns tasks that are eligible for dispatch now;
+	// tasks waiting for their retry backoff deadline are excluded.
 	GetPendingTaskCount() int
 
 	Start()
@@ -128,7 +130,11 @@ func (s *globalTaskScheduler) Enqueue(task Task) {
 }
 
 func (s *globalTaskScheduler) GetPendingTaskCount() int {
-	return s.pendingTasks.TaskCount()
+	now := time.Now()
+	return s.pendingTasks.TaskCountBy(func(task Task) bool {
+		backoff, ok := s.backoffs.Get(task.GetTaskID())
+		return !ok || !now.Before(backoff.notBefore)
+	})
 }
 
 func (s *globalTaskScheduler) AbortAndRemoveTask(taskID int64) {

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -36,6 +36,8 @@ const NullNodeID = -1
 type GlobalScheduler interface {
 	Enqueue(task Task)
 	AbortAndRemoveTask(taskID int64)
+	// GetPendingTaskCount returns tasks that are eligible for dispatch now;
+	// tasks waiting for their retry backoff deadline are excluded.
 	GetPendingTaskCount() int
 
 	Start()
@@ -125,7 +127,11 @@ func (s *globalTaskScheduler) Enqueue(task Task) {
 }
 
 func (s *globalTaskScheduler) GetPendingTaskCount() int {
-	return s.pendingTasks.TaskCount()
+	now := time.Now()
+	return s.pendingTasks.TaskCountBy(func(task Task) bool {
+		backoff, ok := s.backoffs.Get(task.GetTaskID())
+		return !ok || !now.Before(backoff.notBefore)
+	})
 }
 
 func (s *globalTaskScheduler) AbortAndRemoveTask(taskID int64) {

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -312,7 +312,7 @@ func minimumWorkerVersion(task Task) (semver.Version, bool) {
 }
 
 func (s *globalTaskScheduler) schedule() {
-	pendingNum := len(s.pendingTasks.TaskIDs())
+	pendingNum := s.pendingTasks.TaskCount()
 	if pendingNum == 0 {
 		return
 	}

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -45,8 +45,10 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
 
 	task = NewMockTask(t)
 	task.EXPECT().GetTaskID().Return(2)
@@ -55,6 +57,7 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
 }

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -62,6 +62,33 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
 }
 
+func TestGlobalScheduler_GetPendingTaskCountExcludesBackoff(t *testing.T) {
+	pt := paramtable.Get()
+	pt.Save(pt.DataCoordCfg.TaskRetryBackoffInterval.Key, "60")
+	defer pt.Reset(pt.DataCoordCfg.TaskRetryBackoffInterval.Key)
+
+	cluster := session.NewMockCluster(t)
+	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster)
+	globalScheduler := scheduler.(*globalTaskScheduler)
+
+	tasks := make(map[int64]Task)
+	for taskID := int64(1); taskID <= 2; taskID++ {
+		task := NewMockTask(t)
+		task.EXPECT().GetTaskID().Return(taskID)
+		task.EXPECT().GetTaskState().Return(taskcommon.Init)
+		task.EXPECT().GetTaskType().Return(taskcommon.Compaction)
+		task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
+		scheduler.Enqueue(task)
+		tasks[taskID] = task
+	}
+
+	globalScheduler.recordTaskFailure(tasks[2])
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
+
+	globalScheduler.backoffs.Insert(2, &taskBackoff{notBefore: time.Now().Add(-time.Minute)})
+	assert.Equal(t, 2, scheduler.GetPendingTaskCount())
+}
+
 func TestGlobalScheduler_AbortAndRemoveTask(t *testing.T) {
 	cluster := session.NewMockCluster(t)
 	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster)

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -90,8 +90,10 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
 
 	task = NewMockTask(t)
 	task.EXPECT().GetTaskID().Return(2)
@@ -100,6 +102,7 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
 }

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -90,10 +90,10 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
-	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Compaction))
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, len(scheduler.(*globalTaskScheduler).pendingTasks.TaskIDs()))
-	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Compaction))
 
 	task = NewMockTask(t)
 	task.EXPECT().GetTaskID().Return(2)
@@ -102,12 +102,36 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
-	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Compaction))
 	scheduler.Enqueue(task)
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
 }
 
-func TestGlobalScheduler_GetPendingTaskCountExcludesBackoff(t *testing.T) {
+func TestGlobalScheduler_GetPendingTaskCountIsScopedByTaskType(t *testing.T) {
+	cluster := session.NewMockCluster(t)
+	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster)
+
+	enqueue := func(taskID int64, taskType taskcommon.Type) {
+		task := NewMockTask(t)
+		task.EXPECT().GetTaskID().Return(taskID)
+		task.EXPECT().GetTaskState().Return(taskcommon.Init)
+		task.EXPECT().GetTaskType().Return(taskType)
+		task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
+		scheduler.Enqueue(task)
+	}
+
+	enqueue(1, taskcommon.Stats)
+	enqueue(2, taskcommon.Compaction)
+	enqueue(3, taskcommon.Index)
+	enqueue(4, taskcommon.Compaction)
+
+	// An index/compaction backlog must not consume the stats admission budget.
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Stats))
+	assert.Equal(t, 2, scheduler.GetPendingTaskCount(taskcommon.Compaction))
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount(taskcommon.Index))
+}
+
+func TestGlobalScheduler_GetPendingTaskCountIncludesBackoff(t *testing.T) {
 	pt := paramtable.Get()
 	pt.Save(pt.DataCoordCfg.TaskRetryBackoffInterval.Key, "60")
 	defer pt.Reset(pt.DataCoordCfg.TaskRetryBackoffInterval.Key)
@@ -121,17 +145,16 @@ func TestGlobalScheduler_GetPendingTaskCountExcludesBackoff(t *testing.T) {
 		task := NewMockTask(t)
 		task.EXPECT().GetTaskID().Return(taskID)
 		task.EXPECT().GetTaskState().Return(taskcommon.Init)
-		task.EXPECT().GetTaskType().Return(taskcommon.Compaction)
+		task.EXPECT().GetTaskType().Return(taskcommon.Stats)
 		task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
 		scheduler.Enqueue(task)
 		tasks[taskID] = task
 	}
 
+	// A task waiting on its retry backoff still occupies queue depth: excluding it
+	// would let a worker-side failure storm silently disable the admission gate.
 	globalScheduler.recordTaskFailure(tasks[2])
-	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
-
-	globalScheduler.backoffs.Insert(2, &taskBackoff{notBefore: time.Now().Add(-time.Minute)})
-	assert.Equal(t, 2, scheduler.GetPendingTaskCount())
+	assert.Equal(t, 2, scheduler.GetPendingTaskCount(taskcommon.Stats))
 }
 
 func TestGlobalScheduler_AbortAndRemoveTask(t *testing.T) {

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -107,6 +107,33 @@ func TestGlobalScheduler_Enqueue(t *testing.T) {
 	assert.Equal(t, 1, scheduler.(*globalTaskScheduler).runningTasks.Len())
 }
 
+func TestGlobalScheduler_GetPendingTaskCountExcludesBackoff(t *testing.T) {
+	pt := paramtable.Get()
+	pt.Save(pt.DataCoordCfg.TaskRetryBackoffInterval.Key, "60")
+	defer pt.Reset(pt.DataCoordCfg.TaskRetryBackoffInterval.Key)
+
+	cluster := session.NewMockCluster(t)
+	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster)
+	globalScheduler := scheduler.(*globalTaskScheduler)
+
+	tasks := make(map[int64]Task)
+	for taskID := int64(1); taskID <= 2; taskID++ {
+		task := NewMockTask(t)
+		task.EXPECT().GetTaskID().Return(taskID)
+		task.EXPECT().GetTaskState().Return(taskcommon.Init)
+		task.EXPECT().GetTaskType().Return(taskcommon.Compaction)
+		task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return()
+		scheduler.Enqueue(task)
+		tasks[taskID] = task
+	}
+
+	globalScheduler.recordTaskFailure(tasks[2])
+	assert.Equal(t, 1, scheduler.GetPendingTaskCount())
+
+	globalScheduler.backoffs.Insert(2, &taskBackoff{notBefore: time.Now().Add(-time.Minute)})
+	assert.Equal(t, 2, scheduler.GetPendingTaskCount())
+}
+
 func TestGlobalScheduler_AbortAndRemoveTask(t *testing.T) {
 	cluster := session.NewMockCluster(t)
 	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster)

--- a/internal/datacoord/task/mock_global_scheduler.go
+++ b/internal/datacoord/task/mock_global_scheduler.go
@@ -83,6 +83,51 @@ func (_c *MockGlobalScheduler_Enqueue_Call) RunAndReturn(run func(Task)) *MockGl
 	return _c
 }
 
+// GetPendingTaskCount provides a mock function with no fields
+func (_m *MockGlobalScheduler) GetPendingTaskCount() int {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPendingTaskCount")
+	}
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
+// MockGlobalScheduler_GetPendingTaskCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPendingTaskCount'
+type MockGlobalScheduler_GetPendingTaskCount_Call struct {
+	*mock.Call
+}
+
+// GetPendingTaskCount is a helper method to define mock.On call
+func (_e *MockGlobalScheduler_Expecter) GetPendingTaskCount() *MockGlobalScheduler_GetPendingTaskCount_Call {
+	return &MockGlobalScheduler_GetPendingTaskCount_Call{Call: _e.mock.On("GetPendingTaskCount")}
+}
+
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Run(run func()) *MockGlobalScheduler_GetPendingTaskCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Return(_a0 int) *MockGlobalScheduler_GetPendingTaskCount_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) RunAndReturn(run func() int) *MockGlobalScheduler_GetPendingTaskCount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Start provides a mock function with no fields
 func (_m *MockGlobalScheduler) Start() {
 	_m.Called()

--- a/internal/datacoord/task/mock_global_scheduler.go
+++ b/internal/datacoord/task/mock_global_scheduler.go
@@ -83,17 +83,17 @@ func (_c *MockGlobalScheduler_Enqueue_Call) RunAndReturn(run func(Task)) *MockGl
 	return _c
 }
 
-// GetPendingTaskCount provides a mock function with no fields
-func (_m *MockGlobalScheduler) GetPendingTaskCount() int {
-	ret := _m.Called()
+// GetPendingTaskCount provides a mock function with given fields: taskType
+func (_m *MockGlobalScheduler) GetPendingTaskCount(taskType string) int {
+	ret := _m.Called(taskType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPendingTaskCount")
 	}
 
 	var r0 int
-	if rf, ok := ret.Get(0).(func() int); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string) int); ok {
+		r0 = rf(taskType)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
@@ -107,13 +107,14 @@ type MockGlobalScheduler_GetPendingTaskCount_Call struct {
 }
 
 // GetPendingTaskCount is a helper method to define mock.On call
-func (_e *MockGlobalScheduler_Expecter) GetPendingTaskCount() *MockGlobalScheduler_GetPendingTaskCount_Call {
-	return &MockGlobalScheduler_GetPendingTaskCount_Call{Call: _e.mock.On("GetPendingTaskCount")}
+//   - taskType string
+func (_e *MockGlobalScheduler_Expecter) GetPendingTaskCount(taskType interface{}) *MockGlobalScheduler_GetPendingTaskCount_Call {
+	return &MockGlobalScheduler_GetPendingTaskCount_Call{Call: _e.mock.On("GetPendingTaskCount", taskType)}
 }
 
-func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Run(run func()) *MockGlobalScheduler_GetPendingTaskCount_Call {
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Run(run func(taskType string)) *MockGlobalScheduler_GetPendingTaskCount_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -123,7 +124,7 @@ func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) Return(_a0 int) *MockGlo
 	return _c
 }
 
-func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) RunAndReturn(run func() int) *MockGlobalScheduler_GetPendingTaskCount_Call {
+func (_c *MockGlobalScheduler_GetPendingTaskCount_Call) RunAndReturn(run func(string) int) *MockGlobalScheduler_GetPendingTaskCount_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/datacoord/task/priority_queue.go
+++ b/internal/datacoord/task/priority_queue.go
@@ -28,6 +28,7 @@ type PriorityQueue interface {
 	Pop() Task
 	Get(taskID int64) Task
 	Remove(taskID int64)
+	TaskCount() int
 	TaskIDs() []int64
 }
 
@@ -99,6 +100,13 @@ func (pqp *priorityQueuePolicy) Get(taskID int64) Task {
 	defer pqp.lock.RUnlock()
 
 	return pqp.tasks[taskID]
+}
+
+func (pqp *priorityQueuePolicy) TaskCount() int {
+	pqp.lock.RLock()
+	defer pqp.lock.RUnlock()
+
+	return len(pqp.tasks)
 }
 
 func (pqp *priorityQueuePolicy) TaskIDs() []int64 {

--- a/internal/datacoord/task/priority_queue.go
+++ b/internal/datacoord/task/priority_queue.go
@@ -29,6 +29,7 @@ type PriorityQueue interface {
 	Get(taskID int64) Task
 	Remove(taskID int64)
 	TaskCount() int
+	TaskCountBy(filter func(Task) bool) int
 	TaskIDs() []int64
 }
 
@@ -107,6 +108,19 @@ func (pqp *priorityQueuePolicy) TaskCount() int {
 	defer pqp.lock.RUnlock()
 
 	return len(pqp.tasks)
+}
+
+func (pqp *priorityQueuePolicy) TaskCountBy(filter func(Task) bool) int {
+	pqp.lock.RLock()
+	defer pqp.lock.RUnlock()
+
+	count := 0
+	for _, task := range pqp.tasks {
+		if filter(task) {
+			count++
+		}
+	}
+	return count
 }
 
 func (pqp *priorityQueuePolicy) TaskIDs() []int64 {

--- a/internal/datacoord/task/priority_queue_test.go
+++ b/internal/datacoord/task/priority_queue_test.go
@@ -17,6 +17,7 @@ func TestFIFOQueue_Push(t *testing.T) {
 
 	queue.Push(task1)
 	queue.Push(task2)
+	assert.Equal(t, 2, queue.TaskCount())
 
 	// Verify task ID list
 	taskIDs := queue.TaskIDs()
@@ -28,6 +29,7 @@ func TestFIFOQueue_Push(t *testing.T) {
 	queue.Push(task1)
 	taskIDs = queue.TaskIDs()
 	assert.Equal(t, 2, len(taskIDs))
+	assert.Equal(t, 2, queue.TaskCount())
 }
 
 func TestFIFOQueue_Pop(t *testing.T) {
@@ -46,11 +48,11 @@ func TestFIFOQueue_Pop(t *testing.T) {
 
 	poppedTask := queue.Pop()
 	assert.Equal(t, int64(1), poppedTask.GetTaskID())
-	assert.Equal(t, 1, len(queue.TaskIDs()))
+	assert.Equal(t, 1, queue.TaskCount())
 
 	poppedTask = queue.Pop()
 	assert.Equal(t, int64(2), poppedTask.GetTaskID())
-	assert.Equal(t, 0, len(queue.TaskIDs()))
+	assert.Equal(t, 0, queue.TaskCount())
 }
 
 func TestFIFOQueue_Get(t *testing.T) {
@@ -90,6 +92,7 @@ func TestFIFOQueue_Remove(t *testing.T) {
 	queue.Remove(2)
 	taskIDs := queue.TaskIDs()
 	assert.Equal(t, 2, len(taskIDs))
+	assert.Equal(t, 2, queue.TaskCount())
 	assert.Equal(t, int64(1), taskIDs[0])
 	assert.Equal(t, int64(3), taskIDs[1])
 

--- a/internal/datacoord/task/priority_queue_test.go
+++ b/internal/datacoord/task/priority_queue_test.go
@@ -30,6 +30,9 @@ func TestFIFOQueue_Push(t *testing.T) {
 	taskIDs = queue.TaskIDs()
 	assert.Equal(t, 2, len(taskIDs))
 	assert.Equal(t, 2, queue.TaskCount())
+	assert.Equal(t, 1, queue.TaskCountBy(func(task Task) bool {
+		return task.GetTaskID() == 2
+	}))
 }
 
 func TestFIFOQueue_Pop(t *testing.T) {

--- a/internal/datacoord/task/priority_queue_test.go
+++ b/internal/datacoord/task/priority_queue_test.go
@@ -48,10 +48,12 @@ func TestFIFOQueue_Pop(t *testing.T) {
 
 	poppedTask := queue.Pop()
 	assert.Equal(t, int64(1), poppedTask.GetTaskID())
+	assert.Equal(t, 1, len(queue.TaskIDs()))
 	assert.Equal(t, 1, queue.TaskCount())
 
 	poppedTask = queue.Pop()
 	assert.Equal(t, int64(2), poppedTask.GetTaskID())
+	assert.Equal(t, 0, len(queue.TaskIDs()))
 	assert.Equal(t, 0, queue.TaskCount())
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5361,10 +5361,12 @@ type dataCoordConfig struct {
 	StatsTaskSlotUsage                   ParamItem `refreshable:"true"`
 	AnalyzeTaskSlotUsage                 ParamItem `refreshable:"true"`
 
-	EnableSortCompaction             ParamItem `refreshable:"true"`
-	TaskCheckInterval                ParamItem `refreshable:"true"`
-	SortCompactionTriggerCount       ParamItem `refreshable:"true"`
-	JSONStatsTriggerCount            ParamItem `refreshable:"true"`
+	EnableSortCompaction       ParamItem `refreshable:"true"`
+	TaskCheckInterval          ParamItem `refreshable:"true"`
+	SortCompactionTriggerCount ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks now use SortCompactionTriggerCount for throttling.
+	JSONStatsTriggerCount ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
 	JSONStatsMaxShreddingColumns     ParamItem `refreshable:"true"`
 	JSONStatsShreddingRatioThreshold ParamItem `refreshable:"true"`
@@ -6857,7 +6859,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "jsonkey stats task count per trigger",
+		Doc:          "Deprecated: JSON stats tasks now use dataCoord.sortCompactionTriggerCount for throttling.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
@@ -6868,7 +6870,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.JSONStatsTriggerInterval = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerInterval",
 		Version:      "2.6.5",
-		Doc:          "jsonkey task interval per trigger",
+		Doc:          "Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5612,13 +5612,11 @@ type dataCoordConfig struct {
 	StatsTaskSlotUsage                   ParamItem `refreshable:"true"`
 	AnalyzeTaskSlotUsage                 ParamItem `refreshable:"true"`
 
-	EnableSortCompaction       ParamItem `refreshable:"true"`
-	TaskCheckInterval          ParamItem `refreshable:"true"`
-	SortCompactionTriggerCount ParamItem `refreshable:"true"`
-	StatsTaskPendingLimit      ParamItem `refreshable:"true"`
-	// Deprecated: JSON stats tasks are throttled by StatsTaskPendingLimit.
-	JSONStatsTriggerCount ParamItem `refreshable:"true"`
-	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
+	EnableSortCompaction             ParamItem `refreshable:"true"`
+	TaskCheckInterval                ParamItem `refreshable:"true"`
+	SortCompactionTriggerCount       ParamItem `refreshable:"true"`
+	StatsTaskPendingLimit            ParamItem `refreshable:"true"`
+	JSONStatsTriggerCount            ParamItem `refreshable:"true"`
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
 	JSONStatsMaxShreddingColumns     ParamItem `refreshable:"true"`
 	JSONStatsShreddingRatioThreshold ParamItem `refreshable:"true"`
@@ -7237,22 +7235,22 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "Deprecated: JSON stats tasks are throttled by dataCoord.statsTaskPendingLimit.",
+		Doc:          "jsonkey stats task count per trigger",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
-		Export:       false,
+		Export:       true,
 	}
 	p.JSONStatsTriggerCount.Init(base.mgr)
 
 	p.JSONStatsTriggerInterval = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerInterval",
 		Version:      "2.6.5",
-		Doc:          "Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.",
+		Doc:          "jsonkey task interval per trigger",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,
-		Export:       false,
+		Export:       true,
 	}
 	p.JSONStatsTriggerInterval.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5361,11 +5361,13 @@ type dataCoordConfig struct {
 	StatsTaskSlotUsage                   ParamItem `refreshable:"true"`
 	AnalyzeTaskSlotUsage                 ParamItem `refreshable:"true"`
 
-	EnableSortCompaction             ParamItem `refreshable:"true"`
-	TaskCheckInterval                ParamItem `refreshable:"true"`
-	SortCompactionTriggerCount       ParamItem `refreshable:"true"`
-	StatsTaskPendingLimit            ParamItem `refreshable:"true"`
-	JSONStatsTriggerCount            ParamItem `refreshable:"true"`
+	EnableSortCompaction       ParamItem `refreshable:"true"`
+	TaskCheckInterval          ParamItem `refreshable:"true"`
+	SortCompactionTriggerCount ParamItem `refreshable:"true"`
+	StatsTaskPendingLimit      ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks are throttled by StatsTaskPendingLimit.
+	JSONStatsTriggerCount ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
 	JSONStatsMaxShreddingColumns     ParamItem `refreshable:"true"`
 	JSONStatsShreddingRatioThreshold ParamItem `refreshable:"true"`
@@ -6868,22 +6870,22 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "jsonkey stats task count per trigger",
+		Doc:          "Deprecated: JSON stats tasks are throttled by dataCoord.statsTaskPendingLimit.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerCount.Init(base.mgr)
 
 	p.JSONStatsTriggerInterval = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerInterval",
 		Version:      "2.6.5",
-		Doc:          "jsonkey task interval per trigger",
+		Doc:          "Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerInterval.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5361,13 +5361,11 @@ type dataCoordConfig struct {
 	StatsTaskSlotUsage                   ParamItem `refreshable:"true"`
 	AnalyzeTaskSlotUsage                 ParamItem `refreshable:"true"`
 
-	EnableSortCompaction       ParamItem `refreshable:"true"`
-	TaskCheckInterval          ParamItem `refreshable:"true"`
-	SortCompactionTriggerCount ParamItem `refreshable:"true"`
-	StatsTaskPendingLimit      ParamItem `refreshable:"true"`
-	// Deprecated: JSON stats tasks are throttled by StatsTaskPendingLimit.
-	JSONStatsTriggerCount ParamItem `refreshable:"true"`
-	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
+	EnableSortCompaction             ParamItem `refreshable:"true"`
+	TaskCheckInterval                ParamItem `refreshable:"true"`
+	SortCompactionTriggerCount       ParamItem `refreshable:"true"`
+	StatsTaskPendingLimit            ParamItem `refreshable:"true"`
+	JSONStatsTriggerCount            ParamItem `refreshable:"true"`
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
 	JSONStatsMaxShreddingColumns     ParamItem `refreshable:"true"`
 	JSONStatsShreddingRatioThreshold ParamItem `refreshable:"true"`
@@ -6870,22 +6868,22 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "Deprecated: JSON stats tasks are throttled by dataCoord.statsTaskPendingLimit.",
+		Doc:          "jsonkey stats task count per trigger",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
-		Export:       false,
+		Export:       true,
 	}
 	p.JSONStatsTriggerCount.Init(base.mgr)
 
 	p.JSONStatsTriggerInterval = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerInterval",
 		Version:      "2.6.5",
-		Doc:          "Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.",
+		Doc:          "jsonkey task interval per trigger",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,
-		Export:       false,
+		Export:       true,
 	}
 	p.JSONStatsTriggerInterval.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5615,7 +5615,8 @@ type dataCoordConfig struct {
 	EnableSortCompaction       ParamItem `refreshable:"true"`
 	TaskCheckInterval          ParamItem `refreshable:"true"`
 	SortCompactionTriggerCount ParamItem `refreshable:"true"`
-	// Deprecated: JSON stats tasks now use SortCompactionTriggerCount for throttling.
+	StatsTaskPendingLimit      ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks are throttled by StatsTaskPendingLimit.
 	JSONStatsTriggerCount ParamItem `refreshable:"true"`
 	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
@@ -7223,14 +7224,24 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	}
 	p.SortCompactionTriggerCount.Init(base.mgr)
 
+	p.StatsTaskPendingLimit = ParamItem{
+		Key:          "dataCoord.statsTaskPendingLimit",
+		Version:      "2.7.0",
+		Doc:          "skip submitting new stats tasks when the global scheduler holds more pending tasks than this limit",
+		DefaultValue: "100",
+		PanicIfEmpty: false,
+		Export:       false,
+	}
+	p.StatsTaskPendingLimit.Init(base.mgr)
+
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "Deprecated: JSON stats tasks now use dataCoord.sortCompactionTriggerCount for throttling.",
+		Doc:          "Deprecated: JSON stats tasks are throttled by dataCoord.statsTaskPendingLimit.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerCount.Init(base.mgr)
 
@@ -7241,7 +7252,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerInterval.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5364,7 +5364,8 @@ type dataCoordConfig struct {
 	EnableSortCompaction       ParamItem `refreshable:"true"`
 	TaskCheckInterval          ParamItem `refreshable:"true"`
 	SortCompactionTriggerCount ParamItem `refreshable:"true"`
-	// Deprecated: JSON stats tasks now use SortCompactionTriggerCount for throttling.
+	StatsTaskPendingLimit      ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks are throttled by StatsTaskPendingLimit.
 	JSONStatsTriggerCount ParamItem `refreshable:"true"`
 	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
@@ -6856,14 +6857,24 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	}
 	p.SortCompactionTriggerCount.Init(base.mgr)
 
+	p.StatsTaskPendingLimit = ParamItem{
+		Key:          "dataCoord.statsTaskPendingLimit",
+		Version:      "2.7.0",
+		Doc:          "skip submitting new stats tasks when the global scheduler holds more pending tasks than this limit",
+		DefaultValue: "100",
+		PanicIfEmpty: false,
+		Export:       false,
+	}
+	p.StatsTaskPendingLimit.Init(base.mgr)
+
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "Deprecated: JSON stats tasks now use dataCoord.sortCompactionTriggerCount for throttling.",
+		Doc:          "Deprecated: JSON stats tasks are throttled by dataCoord.statsTaskPendingLimit.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerCount.Init(base.mgr)
 
@@ -6874,7 +6885,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerInterval.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5612,10 +5612,12 @@ type dataCoordConfig struct {
 	StatsTaskSlotUsage                   ParamItem `refreshable:"true"`
 	AnalyzeTaskSlotUsage                 ParamItem `refreshable:"true"`
 
-	EnableSortCompaction             ParamItem `refreshable:"true"`
-	TaskCheckInterval                ParamItem `refreshable:"true"`
-	SortCompactionTriggerCount       ParamItem `refreshable:"true"`
-	JSONStatsTriggerCount            ParamItem `refreshable:"true"`
+	EnableSortCompaction       ParamItem `refreshable:"true"`
+	TaskCheckInterval          ParamItem `refreshable:"true"`
+	SortCompactionTriggerCount ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks now use SortCompactionTriggerCount for throttling.
+	JSONStatsTriggerCount ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
 	JSONStatsMaxShreddingColumns     ParamItem `refreshable:"true"`
 	JSONStatsShreddingRatioThreshold ParamItem `refreshable:"true"`
@@ -7224,7 +7226,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "jsonkey stats task count per trigger",
+		Doc:          "Deprecated: JSON stats tasks now use dataCoord.sortCompactionTriggerCount for throttling.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
@@ -7235,7 +7237,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.JSONStatsTriggerInterval = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerInterval",
 		Version:      "2.6.5",
-		Doc:          "jsonkey task interval per trigger",
+		Doc:          "Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -7226,7 +7226,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 
 	p.StatsTaskPendingLimit = ParamItem{
 		Key:          "dataCoord.statsTaskPendingLimit",
-		Version:      "2.7.0",
+		Version:      "3.0.0",
 		Doc:          "skip submitting new stats tasks when the global scheduler holds more pending tasks than this limit",
 		DefaultValue: "100",
 		PanicIfEmpty: false,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5612,11 +5612,13 @@ type dataCoordConfig struct {
 	StatsTaskSlotUsage                   ParamItem `refreshable:"true"`
 	AnalyzeTaskSlotUsage                 ParamItem `refreshable:"true"`
 
-	EnableSortCompaction             ParamItem `refreshable:"true"`
-	TaskCheckInterval                ParamItem `refreshable:"true"`
-	SortCompactionTriggerCount       ParamItem `refreshable:"true"`
-	StatsTaskPendingLimit            ParamItem `refreshable:"true"`
-	JSONStatsTriggerCount            ParamItem `refreshable:"true"`
+	EnableSortCompaction       ParamItem `refreshable:"true"`
+	TaskCheckInterval          ParamItem `refreshable:"true"`
+	SortCompactionTriggerCount ParamItem `refreshable:"true"`
+	StatsTaskPendingLimit      ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks are throttled by StatsTaskPendingLimit.
+	JSONStatsTriggerCount ParamItem `refreshable:"true"`
+	// Deprecated: JSON stats tasks now run on TaskCheckInterval.
 	JSONStatsTriggerInterval         ParamItem `refreshable:"true"`
 	JSONStatsMaxShreddingColumns     ParamItem `refreshable:"true"`
 	JSONStatsShreddingRatioThreshold ParamItem `refreshable:"true"`
@@ -7235,22 +7237,22 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 	p.JSONStatsTriggerCount = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerCount",
 		Version:      "2.6.5",
-		Doc:          "jsonkey stats task count per trigger",
+		Doc:          "Deprecated: JSON stats tasks are throttled by dataCoord.statsTaskPendingLimit.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerCount"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerCount.Init(base.mgr)
 
 	p.JSONStatsTriggerInterval = ParamItem{
 		Key:          "dataCoord.jsonShreddingTriggerInterval",
 		Version:      "2.6.5",
-		Doc:          "jsonkey task interval per trigger",
+		Doc:          "Deprecated: JSON stats tasks now run on dataCoord.taskCheckInterval.",
 		DefaultValue: "10",
 		FallbackKeys: []string{"dataCoord.jsonStatsTriggerInterval"},
 		PanicIfEmpty: false,
-		Export:       true,
+		Export:       false,
 	}
 	p.JSONStatsTriggerInterval.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -786,6 +786,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 500*time.Second, Params.TaskCheckInterval.GetAsDuration(time.Second))
 		params.Save("datacoord.statsTaskTriggerCount", "3")
 		assert.Equal(t, 3, Params.SortCompactionTriggerCount.GetAsInt())
+		// The stats admission limit is independent from the sort compaction trigger count.
+		assert.Equal(t, 100, Params.StatsTaskPendingLimit.GetAsInt())
+		params.Save("datacoord.statsTaskPendingLimit", "7")
+		assert.Equal(t, 7, Params.StatsTaskPendingLimit.GetAsInt())
 
 		assert.Equal(t, 100, Params.MaxSegmentsPerCopyTask.GetAsInt())
 		params.Save("dataCoord.import.maxSegmentsPerCopyTask", "200")

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -690,6 +690,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 500*time.Second, Params.TaskCheckInterval.GetAsDuration(time.Second))
 		params.Save("datacoord.statsTaskTriggerCount", "3")
 		assert.Equal(t, 3, Params.SortCompactionTriggerCount.GetAsInt())
+		// The stats admission limit is independent from the sort compaction trigger count.
+		assert.Equal(t, 100, Params.StatsTaskPendingLimit.GetAsInt())
+		params.Save("datacoord.statsTaskPendingLimit", "7")
+		assert.Equal(t, 7, Params.StatsTaskPendingLimit.GetAsInt())
 
 		assert.Equal(t, 100, Params.MaxSegmentsPerCopyTask.GetAsInt())
 		params.Save("dataCoord.import.maxSegmentsPerCopyTask", "200")

--- a/tests/go_client/testcases/external_table_json_shredding_e2e_test.go
+++ b/tests/go_client/testcases/external_table_json_shredding_e2e_test.go
@@ -44,10 +44,9 @@ func TestExternalTableJSONShreddingE2E(t *testing.T) {
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
 
 	restoreConfig := alterMilvusConfigForExternalJSONShredding(t, map[string]string{
-		"common.enabledJSONShredding":         "true",
-		"common.usingJSONShreddingForQuery":   "true",
-		"dataCoord.jsonShreddingMaxColumns":   "2",
-		"dataCoord.jsonShreddingTriggerCount": "10",
+		"common.enabledJSONShredding":       "true",
+		"common.usingJSONShreddingForQuery": "true",
+		"dataCoord.jsonShreddingMaxColumns": "2",
 	})
 	t.Cleanup(restoreConfig)
 


### PR DESCRIPTION
issue: #51815

## What this PR does

- Skips new stats-task submission when the global scheduler already holds more pending **stats** tasks than `dataCoord.statsTaskPendingLimit` (100 by default).
- Counts only stats tasks (`GetPendingTaskCount(taskcommon.Stats)`), so index-build / compaction / import / analyze backlog no longer consumes the stats admission budget. Tasks waiting for a retry-backoff deadline **are counted**: they still sit in the pending queue and will be dispatched as soon as the deadline passes, and counting them keeps the gate closed during a stats failure storm instead of letting it fail open. Tasks already dispatched to workers remain excluded as before.
- Uses queue depth as admission control, not as a submission-rate limit. The scheduler can drain and refill the queue as worker capacity becomes available, which is intentional for improving stats-task throughput.
- Removes the separate JSON key-index limit of 10 tasks per 10 minutes. JSON discovery continues on `dataCoord.taskCheckInterval` and shares the runnable scheduler-backlog limit with text stats tasks.
- Alternates whether text indexing or JSON shredding gets first claim on the shared backlog budget each discovery round, preventing either sub-job from being permanently starved by fixed ordering.
- Filters segments whose stats task is already recorded in meta inside each trigger's selector, and skips collections with no eligible field before scanning segments.
- Checks admission before task-ID allocation, metadata persistence, and enqueue. `SubmitStatsTask` retains the check for direct callers and `AddStatsTask` retains the final duplicate guard.
- Exposes a per-type pending-task count through the global scheduler (`GetPendingTaskCount(taskType)`) and priority queue (`TaskCountBy`), while the scheduler's own queue-depth log continues to use the allocation-free total count.
- Marks `dataCoord.jsonShreddingTriggerCount` and `dataCoord.jsonShreddingTriggerInterval` deprecated. The keys remain accepted, `jsonShreddingTriggerCount: 0` remains a compatibility kill switch, and DataCoord warns when deprecated non-default values are configured.

## Throughput and upgrade behavior

The global gate bounds stats pending-queue depth rather than submission rate. When workers drain pending tasks, later discovery rounds can submit more work up to the configured backlog limit. This allows JSON shredding and text-index stats tasks to use available worker capacity instead of remaining capped at 10 JSON tasks per 10 minutes.

On upgrade, segments with an old or missing JSON stats format can become candidates together. Operators who need to pause that migration can set `common.enabledJSONShredding=false` or keep `dataCoord.jsonShreddingTriggerCount=0`; `dataCoord.statsTaskPendingLimit` controls the shared stats backlog.

## Review fixes

- Fixed the admission accuracy issue: the count is scoped to `taskcommon.Stats` so unrelated index/compaction/import backlog cannot starve stats submission, and backoff tasks are counted (both `CreateTaskOnWorker` and `QueryTaskOnWorker` failures converge on `recordTaskFailure` and re-push into the pending queue), so a worker-side failure storm cannot make the gate fail open.
- Did not restore the old JSON rate limiter because removing that throughput ceiling is the purpose of this PR. The upgrade behavior and operator controls are documented explicitly instead.

## Verification

- Passed: `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord/...`
- Passed from `pkg/`: `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./util/paramtable -run 'TestComponentParam$'`
- Passed: `go test -count=1 ./cmd/tools/config -run TestYamlFile`
- Passed with golangci-lint v2.11.3 over `./internal/datacoord/...` and `pkg/util/paramtable/...`
- Added focused coverage for stats-only pending counts (`TestGlobalScheduler_GetPendingTaskCountIsScopedByTaskType`: other task types excluded; `TestGlobalScheduler_GetPendingTaskCountIncludesBackoff`: backoff tasks included). Existing tests cover global admission boundaries, alternating sub-job order, duplicate filtering, and the deprecated JSON zero-value kill switch.

