### PR TITLE
enhance: configurable backoff for import write retry

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -907,6 +907,8 @@ dataNode:
     readBufferSizeInMB: 16 # The base insert buffer size (in MB) during import. The actual buffer size will be dynamically calculated based on the number of shards.
     readDeleteBufferSizeInMB: 16 # The delete buffer size (in MB) during import.
     memoryLimitPercentage: 10 # The percentage of memory limit for import/pre-import tasks.
+    writeRetryInitialInterval: 1 # Initial backoff interval in seconds for import write retry.
+    writeRetryMaxInterval: 60 # Maximum backoff interval in seconds for import write retry.
   compaction:
     levelZeroBatchMemoryRatio: 0.5 # The minimal memory ratio of free memory for level zero compaction executing in batch mode
     levelZeroMaxBatchSize: -1 # Max batch size refers to the max number of L1/L2 segments in a batch when executing L0 compaction. Default to -1, any value that is less than 1 means no limit. Valid range: >= 1.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -907,8 +907,13 @@ dataNode:
     readBufferSizeInMB: 16 # The base insert buffer size (in MB) during import. The actual buffer size will be dynamically calculated based on the number of shards.
     readDeleteBufferSizeInMB: 16 # The delete buffer size (in MB) during import.
     memoryLimitPercentage: 10 # The percentage of memory limit for import/pre-import tasks.
-    writeRetryInitialInterval: 1 # Initial backoff interval in seconds for import write retry.
-    writeRetryMaxInterval: 60 # Maximum backoff interval in seconds for import write retry.
+    # Initial backoff interval in seconds for import write retry. Must be a positive integer;
+    # a non-positive or unparseable value falls back to the default.
+    writeRetryInitialInterval: 1
+    # Maximum backoff interval in seconds for import write retry. Must be a positive integer;
+    # a non-positive or unparseable value falls back to the default. Set it to at least twice
+    # writeRetryInitialInterval, otherwise the effective cap is raised to twice the initial interval.
+    writeRetryMaxInterval: 60
   compaction:
     levelZeroBatchMemoryRatio: 0.5 # The minimal memory ratio of free memory for level zero compaction executing in batch mode
     levelZeroMaxBatchSize: -1 # Max batch size refers to the max number of L1/L2 segments in a batch when executing L0 compaction. Default to -1, any value that is less than 1 means no limit. Valid range: >= 1.

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -107,9 +107,12 @@ func NewSyncTask(ctx context.Context,
 	}
 
 	writeRetryAttempts := paramtable.Get().DataNodeCfg.ImportMaxWriteRetryAttempts.GetAsUint()
+	initialInterval := time.Duration(paramtable.Get().DataNodeCfg.ImportWriteRetryInitialInterval.GetAsInt()) * time.Second
+	maxInterval := time.Duration(paramtable.Get().DataNodeCfg.ImportWriteRetryMaxInterval.GetAsInt()) * time.Second
 	retryOpts := []retry.Option{
-		retry.Attempts(writeRetryAttempts), // default retry always
-		retry.MaxSleepTime(10 * time.Second),
+		retry.Attempts(writeRetryAttempts), // 0 = unlimited, preserved on purpose
+		retry.Sleep(initialInterval),
+		retry.MaxSleepTime(maxInterval),
 	}
 	task := syncmgr.NewSyncTask().
 		WithAllocator(allocator).

--- a/internal/datanode/importv2/util.go
+++ b/internal/datanode/importv2/util.go
@@ -106,22 +106,29 @@ func NewSyncTask(ctx context.Context,
 		syncPack.WithBM25Stats(bm25Stats)
 	}
 
-	writeRetryAttempts := paramtable.Get().DataNodeCfg.ImportMaxWriteRetryAttempts.GetAsUint()
-	initialInterval := time.Duration(paramtable.Get().DataNodeCfg.ImportWriteRetryInitialInterval.GetAsInt()) * time.Second
-	maxInterval := time.Duration(paramtable.Get().DataNodeCfg.ImportWriteRetryMaxInterval.GetAsInt()) * time.Second
-	retryOpts := []retry.Option{
-		retry.Attempts(writeRetryAttempts), // 0 = unlimited, preserved on purpose
-		retry.Sleep(initialInterval),
-		retry.MaxSleepTime(maxInterval),
-	}
 	task := syncmgr.NewSyncTask().
 		WithAllocator(allocator).
 		WithMetaCache(metaCache).
 		WithSchema(metaCache.GetSchema(0)). // TODO specify import schema if needed
 		WithSyncPack(syncPack).
 		WithStorageConfig(storageConfig).
-		WithWriteRetryOptions(retryOpts...)
+		WithWriteRetryOptions(newWriteRetryOptions()...)
 	return task, nil
+}
+
+// newWriteRetryOptions builds the retry options for import writes. The options are
+// order-sensitive: retry.Sleep raises maxSleepTime to 2*initial, so MaxSleepTime must
+// be applied last. The paramtable formatters guarantee both intervals are positive,
+// which keeps retry.Do from degenerating into a zero-delay loop under attempts=0.
+func newWriteRetryOptions() []retry.Option {
+	params := &paramtable.Get().DataNodeCfg
+	initialInterval := time.Duration(params.ImportWriteRetryInitialInterval.GetAsInt()) * time.Second
+	maxInterval := time.Duration(params.ImportWriteRetryMaxInterval.GetAsInt()) * time.Second
+	return []retry.Option{
+		retry.Attempts(params.ImportMaxWriteRetryAttempts.GetAsUint()), // 0 = unlimited, preserved on purpose
+		retry.Sleep(initialInterval),
+		retry.MaxSleepTime(maxInterval),
+	}
 }
 
 func NewImportSegmentInfo(syncTask syncmgr.Task, metaCaches map[string]metacache.MetaCache) (*datapb.ImportSegmentInfo, error) {

--- a/internal/datanode/importv2/util_test.go
+++ b/internal/datanode/importv2/util_test.go
@@ -17,9 +17,12 @@
 package importv2
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -30,6 +33,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -1051,4 +1056,37 @@ func TestUtil_FillDynamicData(t *testing.T) {
 	err = FillDynamicData(schema, insertData, count)
 	assert.NoError(t, err)
 	assert.Equal(t, count, insertData.Data[dynamicFieldID].RowNum())
+}
+
+func TestNewWriteRetryOptions(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+
+	// A failing write under the shipped defaults must back off, not spin: the first
+	// sleep is writeRetryInitialInterval (1s), so a ctx canceled well before that
+	// lets exactly one attempt through.
+	runUntilCancel := func() int {
+		// Mirror the import task ctx (task_import.go): cancellable but without a
+		// deadline, so retry.Do's deadline escape hatch cannot end the loop.
+		ctx, cancel := context.WithCancel(context.Background())
+		time.AfterFunc(100*time.Millisecond, cancel)
+		defer cancel()
+		calls := 0
+		err := retry.Do(ctx, func() error {
+			calls++
+			return errors.New("write failed")
+		}, newWriteRetryOptions()...)
+		assert.Error(t, err)
+		return calls
+	}
+	assert.LessOrEqual(t, runUntilCancel(), 2)
+
+	// A non-positive interval is rejected by the paramtable formatter, so it cannot
+	// degenerate into retry.Sleep(0) — which, combined with the default
+	// maxWriteRetryAttempts=0 (unlimited), would spin with zero delay.
+	params.Save(params.DataNodeCfg.ImportWriteRetryInitialInterval.Key, "0")
+	params.Save(params.DataNodeCfg.ImportWriteRetryMaxInterval.Key, "0")
+	defer params.Reset(params.DataNodeCfg.ImportWriteRetryInitialInterval.Key)
+	defer params.Reset(params.DataNodeCfg.ImportWriteRetryMaxInterval.Key)
+	assert.LessOrEqual(t, runUntilCancel(), 2)
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -7378,20 +7378,39 @@ if this parameter <= 0, will set it as 10`,
 	p.ImportMaxWriteRetryAttempts.Init(base.mgr)
 
 	p.ImportWriteRetryInitialInterval = ParamItem{
-		Key:          "dataNode.import.writeRetryInitialInterval",
-		Version:      "2.6.9",
-		Doc:          "Initial backoff interval in seconds for import write retry.",
+		Key:     "dataNode.import.writeRetryInitialInterval",
+		Version: "2.6.9",
+		Doc: `Initial backoff interval in seconds for import write retry. Must be a positive integer;
+a non-positive or unparseable value falls back to the default.`,
 		DefaultValue: "1",
 		Export:       true,
+		Formatter: func(v string) string {
+			interval := getAsInt(v)
+			if interval <= 0 {
+				mlog.Warn(context.TODO(), "invalid import write retry initial interval, using default 1s")
+				return "1"
+			}
+			return strconv.Itoa(interval)
+		},
 	}
 	p.ImportWriteRetryInitialInterval.Init(base.mgr)
 
 	p.ImportWriteRetryMaxInterval = ParamItem{
-		Key:          "dataNode.import.writeRetryMaxInterval",
-		Version:      "2.6.9",
-		Doc:          "Maximum backoff interval in seconds for import write retry.",
+		Key:     "dataNode.import.writeRetryMaxInterval",
+		Version: "2.6.9",
+		Doc: `Maximum backoff interval in seconds for import write retry. Must be a positive integer;
+a non-positive or unparseable value falls back to the default. Set it to at least twice
+writeRetryInitialInterval, otherwise the effective cap is raised to twice the initial interval.`,
 		DefaultValue: "60",
 		Export:       true,
+		Formatter: func(v string) string {
+			interval := getAsInt(v)
+			if interval <= 0 {
+				mlog.Warn(context.TODO(), "invalid import write retry max interval, using default 60s")
+				return "60"
+			}
+			return strconv.Itoa(interval)
+		},
 	}
 	p.ImportWriteRetryMaxInterval.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6996,12 +6996,14 @@ type dataNodeConfig struct {
 	ChannelCheckpointUpdateTickInSeconds ParamItem `refreshable:"true"`
 
 	// import
-	ImportConcurrencyPerCPUCore ParamItem `refreshable:"true"`
-	MaxImportFileSizeInGB       ParamItem `refreshable:"true"`
-	ImportBaseBufferSize        ParamItem `refreshable:"true"`
-	ImportDeleteBufferSize      ParamItem `refreshable:"true"`
-	ImportMemoryLimitPercentage ParamItem `refreshable:"true"`
-	ImportMaxWriteRetryAttempts ParamItem `refreshable:"true"`
+	ImportConcurrencyPerCPUCore     ParamItem `refreshable:"true"`
+	MaxImportFileSizeInGB           ParamItem `refreshable:"true"`
+	ImportBaseBufferSize            ParamItem `refreshable:"true"`
+	ImportDeleteBufferSize          ParamItem `refreshable:"true"`
+	ImportMemoryLimitPercentage     ParamItem `refreshable:"true"`
+	ImportMaxWriteRetryAttempts     ParamItem `refreshable:"true"`
+	ImportWriteRetryInitialInterval ParamItem `refreshable:"true"`
+	ImportWriteRetryMaxInterval     ParamItem `refreshable:"true"`
 
 	// Compaction
 	L0BatchMemoryRatio       ParamItem `refreshable:"true"`
@@ -7374,6 +7376,24 @@ if this parameter <= 0, will set it as 10`,
 		DefaultValue: "0",
 	}
 	p.ImportMaxWriteRetryAttempts.Init(base.mgr)
+
+	p.ImportWriteRetryInitialInterval = ParamItem{
+		Key:          "dataNode.import.writeRetryInitialInterval",
+		Version:      "2.6.9",
+		Doc:          "Initial backoff interval in seconds for import write retry.",
+		DefaultValue: "1",
+		Export:       true,
+	}
+	p.ImportWriteRetryInitialInterval.Init(base.mgr)
+
+	p.ImportWriteRetryMaxInterval = ParamItem{
+		Key:          "dataNode.import.writeRetryMaxInterval",
+		Version:      "2.6.9",
+		Doc:          "Maximum backoff interval in seconds for import write retry.",
+		DefaultValue: "60",
+		Export:       true,
+	}
+	p.ImportWriteRetryMaxInterval.Init(base.mgr)
 
 	p.L0BatchMemoryRatio = ParamItem{
 		Key:          "dataNode.compaction.levelZeroBatchMemoryRatio",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -749,6 +749,8 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 16*1024*1024, Params.ImportDeleteBufferSize.GetAsInt())
 		assert.Equal(t, 10.0, Params.ImportMemoryLimitPercentage.GetAsFloat())
 		assert.Equal(t, 0, Params.ImportMaxWriteRetryAttempts.GetAsInt())
+		assert.Equal(t, 1, Params.ImportWriteRetryInitialInterval.GetAsInt())
+		assert.Equal(t, 60, Params.ImportWriteRetryMaxInterval.GetAsInt())
 		params.Save("datanode.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 		assert.Equal(t, 16, Params.SlotCap.GetAsInt())

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -751,6 +751,20 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 0, Params.ImportMaxWriteRetryAttempts.GetAsInt())
 		assert.Equal(t, 1, Params.ImportWriteRetryInitialInterval.GetAsInt())
 		assert.Equal(t, 60, Params.ImportWriteRetryMaxInterval.GetAsInt())
+		// a non-positive or unparseable interval must fall back to the default,
+		// otherwise retry.Sleep(0) yields a zero-delay unbounded retry loop.
+		for _, invalid := range []string{"0", "-1", "1s"} {
+			params.Save(Params.ImportWriteRetryInitialInterval.Key, invalid)
+			assert.Equal(t, 1, Params.ImportWriteRetryInitialInterval.GetAsInt())
+			params.Save(Params.ImportWriteRetryMaxInterval.Key, invalid)
+			assert.Equal(t, 60, Params.ImportWriteRetryMaxInterval.GetAsInt())
+		}
+		params.Save(Params.ImportWriteRetryInitialInterval.Key, "2")
+		assert.Equal(t, 2, Params.ImportWriteRetryInitialInterval.GetAsInt())
+		params.Save(Params.ImportWriteRetryMaxInterval.Key, "120")
+		assert.Equal(t, 120, Params.ImportWriteRetryMaxInterval.GetAsInt())
+		params.Reset(Params.ImportWriteRetryInitialInterval.Key)
+		params.Reset(Params.ImportWriteRetryMaxInterval.Key)
 		params.Save("datanode.gracefulStopTimeout", "100")
 		assert.Equal(t, 100*time.Second, Params.GracefulStopTimeout.GetAsDuration(time.Second))
 		assert.Equal(t, 16, Params.SlotCap.GetAsInt())

--- a/pkg/util/retry/options_test.go
+++ b/pkg/util/retry/options_test.go
@@ -14,6 +14,7 @@ package retry
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -50,4 +51,32 @@ func TestMaxAttemptsFromContextOrDefault(t *testing.T) {
 	// Zero in ctx — returns 0, not default
 	ctx = WithMaxAttemptsContext(context.Background(), 0)
 	assert.Equal(t, uint(0), MaxAttemptsFromContextOrDefault(ctx, 10))
+}
+
+// TestSleepAndMaxSleepTimeOrder pins the order-sensitive interaction between Sleep
+// and MaxSleepTime that the import write-retry path (internal/datanode/importv2)
+// depends on: it applies Sleep(initial) before MaxSleepTime(max).
+func TestSleepAndMaxSleepTimeOrder(t *testing.T) {
+	effective := func(initial, max time.Duration) *config {
+		c := newDefaultConfig()
+		for _, opt := range []Option{Attempts(0), Sleep(initial), MaxSleepTime(max)} {
+			opt(c)
+		}
+		return c
+	}
+
+	// The shipped import defaults produce exactly the advertised 1s -> 60s schedule.
+	c := effective(time.Second, 60*time.Second)
+	assert.Equal(t, time.Second, c.sleep)
+	assert.Equal(t, 60*time.Second, c.maxSleepTime)
+
+	// A zero initial interval is never clamped by either option, so it would yield a
+	// zero-delay retry loop -- callers must reject it before building the options.
+	c = effective(0, 60*time.Second)
+	assert.Equal(t, time.Duration(0), c.sleep)
+
+	// Sleep runs first and raises maxSleepTime to 2*initial, so a configured max
+	// below that floor is not a hard cap.
+	c = effective(60*time.Second, 60*time.Second)
+	assert.Equal(t, 120*time.Second, c.maxSleepTime)
 }


### PR DESCRIPTION
## Summary

Make the import write-retry backoff (initial interval + max cap) configurable and larger by default, while keeping the existing unlimited-retry behavior unchanged. Under sustained object-storage request-rate throttling — e.g. AWS S3 `503 SlowDown` during a large bulk import writing many small objects to a cold bucket prefix — the tight fixed `10s` cap makes the whole-file write retry re-fire too aggressively; larger, tunable backoff reduces that pressure without a rebuild.

issue: #51824

### Changes

- Add two refreshable paramtable items:
  - `dataNode.import.writeRetryInitialInterval` (default `1s`)
  - `dataNode.import.writeRetryMaxInterval` (default `60s`)
- Wire them into the import write retry options in `internal/datanode/importv2/util.go` via `retry.Sleep` / `retry.MaxSleepTime`. `retry.Attempts` is unchanged (`dataNode.import.maxWriteRetryAttempts`, default `0` = unlimited).

### Test Plan

- [x] `pkg/util/paramtable` unit tests pass (new param defaults asserted)
- [x] `internal/datanode/importv2` unit tests pass
- [ ] CI: static-check + full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)