### PR TITLE
fix: propagate cipher context to worker tasks

### DIFF
--- a/internal/core/src/clustering/analyze_c.cpp
+++ b/internal/core/src/clustering/analyze_c.cpp
@@ -27,6 +27,7 @@
 #include "pb/clustering.pb.h"
 #include "pb/schema.pb.h"
 #include "storage/FileManager.h"
+#include "storage/PluginLoader.h"
 #include "storage/StorageV2FSCache.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
@@ -62,7 +63,8 @@ get_storage_config(const milvus::proto::clustering::StorageConfig& config) {
 CStatus
 Analyze(CAnalyze* res_analyze,
         const uint8_t* serialized_analyze_info,
-        const uint64_t len) {
+        const uint64_t len,
+        const CPluginContext* plugin_context) {
     SCOPE_CGO_CALL_METRIC();
 
     try {
@@ -112,6 +114,17 @@ Analyze(CAnalyze* res_analyze,
 
         milvus::storage::FileManagerContext fileManagerContext(
             field_meta, index_meta, chunk_manager, fs);
+
+        if (plugin_context != nullptr) {
+            AssertInfo(plugin_context->key != nullptr,
+                       "cipher plugin context key is null");
+            fileManagerContext.set_plugin_context(
+                milvus::storage::PluginLoader::GetInstance()
+                    .registerCipherPluginContext(
+                        plugin_context->ez_id,
+                        plugin_context->collection_id,
+                        std::string(plugin_context->key)));
+        }
 
         if (field_type != DataType::VECTOR_FLOAT) {
             throw SegcoreError(

--- a/internal/core/src/clustering/analyze_c.h
+++ b/internal/core/src/clustering/analyze_c.h
@@ -23,7 +23,8 @@ extern "C" {
 CStatus
 Analyze(CAnalyze* res_analyze,
         const uint8_t* serialized_analyze_info,
-        const uint64_t len);
+        const uint64_t len,
+        const CPluginContext* plugin_context);
 
 CStatus
 DeleteAnalyze(CAnalyze analyze);

--- a/internal/core/src/indexbuilder/index_c.cpp
+++ b/internal/core/src/indexbuilder/index_c.cpp
@@ -355,20 +355,15 @@ CreateIndex(CIndex* res_index,
             fileManagerContext, *build_index_info, storage_config);
 
         if (build_index_info->has_storage_plugin_context()) {
-            auto cipherPlugin =
-                milvus::storage::PluginLoader::GetInstance().getCipherPlugin();
-            AssertInfo(cipherPlugin != nullptr, "failed to get cipher plugin");
-            cipherPlugin->Update(
-                build_index_info->storage_plugin_context().encryption_zone_id(),
-                build_index_info->storage_plugin_context().collection_id(),
-                build_index_info->storage_plugin_context().encryption_key());
-
-            auto plugin_context = std::make_shared<CPluginContext>();
-            plugin_context->ez_id =
-                build_index_info->storage_plugin_context().encryption_zone_id();
-            plugin_context->collection_id =
-                build_index_info->storage_plugin_context().collection_id();
-            fileManagerContext.set_plugin_context(plugin_context);
+            fileManagerContext.set_plugin_context(
+                milvus::storage::PluginLoader::GetInstance()
+                    .registerCipherPluginContext(
+                        build_index_info->storage_plugin_context()
+                            .encryption_zone_id(),
+                        build_index_info->storage_plugin_context()
+                            .collection_id(),
+                        build_index_info->storage_plugin_context()
+                            .encryption_key()));
         }
 
         auto index =
@@ -458,20 +453,15 @@ BuildJsonKeyIndex(ProtoLayoutInterface result,
             fileManagerContext, *build_index_info, storage_config);
 
         if (build_index_info->has_storage_plugin_context()) {
-            auto cipherPlugin =
-                milvus::storage::PluginLoader::GetInstance().getCipherPlugin();
-            AssertInfo(cipherPlugin != nullptr, "failed to get cipher plugin");
-            cipherPlugin->Update(
-                build_index_info->storage_plugin_context().encryption_zone_id(),
-                build_index_info->storage_plugin_context().collection_id(),
-                build_index_info->storage_plugin_context().encryption_key());
-
-            auto plugin_context = std::make_shared<CPluginContext>();
-            plugin_context->ez_id =
-                build_index_info->storage_plugin_context().encryption_zone_id();
-            plugin_context->collection_id =
-                build_index_info->storage_plugin_context().collection_id();
-            fileManagerContext.set_plugin_context(plugin_context);
+            fileManagerContext.set_plugin_context(
+                milvus::storage::PluginLoader::GetInstance()
+                    .registerCipherPluginContext(
+                        build_index_info->storage_plugin_context()
+                            .encryption_zone_id(),
+                        build_index_info->storage_plugin_context()
+                            .collection_id(),
+                        build_index_info->storage_plugin_context()
+                            .encryption_key()));
         }
 
         auto field_schema =
@@ -555,19 +545,15 @@ BuildTextIndex(ProtoLayoutInterface result,
             fileManagerContext, *build_index_info, storage_config);
 
         if (build_index_info->has_storage_plugin_context()) {
-            auto cipherPlugin =
-                milvus::storage::PluginLoader::GetInstance().getCipherPlugin();
-            AssertInfo(cipherPlugin != nullptr, "failed to get cipher plugin");
-            cipherPlugin->Update(
-                build_index_info->storage_plugin_context().encryption_zone_id(),
-                build_index_info->storage_plugin_context().collection_id(),
-                build_index_info->storage_plugin_context().encryption_key());
-            auto plugin_context = std::make_shared<CPluginContext>();
-            plugin_context->ez_id =
-                build_index_info->storage_plugin_context().encryption_zone_id();
-            plugin_context->collection_id =
-                build_index_info->storage_plugin_context().collection_id();
-            fileManagerContext.set_plugin_context(plugin_context);
+            fileManagerContext.set_plugin_context(
+                milvus::storage::PluginLoader::GetInstance()
+                    .registerCipherPluginContext(
+                        build_index_info->storage_plugin_context()
+                            .encryption_zone_id(),
+                        build_index_info->storage_plugin_context()
+                            .collection_id(),
+                        build_index_info->storage_plugin_context()
+                            .encryption_key()));
         }
 
         auto scalar_index_engine_version =

--- a/internal/core/src/storage/PluginLoader.h
+++ b/internal/core/src/storage/PluginLoader.h
@@ -15,6 +15,9 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
+
+#include "common/type_c.h"
 #include "log/Log.h"
 #include "storage/plugin/PluginInterface.h"
 #include "common/EasyAssert.h"
@@ -106,6 +109,32 @@ class PluginLoader {
         }
         return std::dynamic_pointer_cast<
             milvus::storage::plugin::ICipherPlugin>(p);
+    }
+
+    std::shared_ptr<CPluginContext>
+    registerCipherPluginContext(int64_t ez_id,
+                                int64_t collection_id,
+                                const std::string& key) {
+        return registerCipherPluginContext(
+            ez_id, collection_id, key, getCipherPlugin());
+    }
+
+    std::shared_ptr<CPluginContext>
+    registerCipherPluginContext(
+        int64_t ez_id,
+        int64_t collection_id,
+        const std::string& key,
+        const std::shared_ptr<plugin::ICipherPlugin>& cipher_plugin) {
+        AssertInfo(cipher_plugin != nullptr, "failed to get cipher plugin");
+        cipher_plugin->Update(ez_id, collection_id, key);
+
+        // The plugin owns the key copy. Storage operations retain only the IDs
+        // needed for later encryptor/decryptor lookups.
+        auto context = std::make_shared<CPluginContext>();
+        context->ez_id = ez_id;
+        context->collection_id = collection_id;
+        context->key = nullptr;
+        return context;
     }
 
     std::shared_ptr<milvus::storage::plugin::IPlugin>

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -74,6 +74,7 @@ set(MILVUS_TEST_FILES
         test_schema_reopen.cpp
         test_growing_concurrent_reopen.cpp
         test_segment_read_lease.cpp
+        CipherPluginContextTest.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )

--- a/internal/core/unittest/CipherPluginContextTest.cpp
+++ b/internal/core/unittest/CipherPluginContextTest.cpp
@@ -1,0 +1,156 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "clustering/analyze_c.h"
+#include "indexbuilder/index_c.h"
+#include "pb/clustering.pb.h"
+#include "pb/index_cgo_msg.pb.h"
+#include "storage/PluginLoader.h"
+#include "test_utils/Constants.h"
+
+namespace milvus::storage {
+namespace {
+
+class RecordingCipherPlugin : public plugin::ICipherPlugin {
+ public:
+    void
+    Update(int64_t ez_id,
+           int64_t collection_id,
+           const std::string& key) override {
+        update_count++;
+        updated_ez_id = ez_id;
+        updated_collection_id = collection_id;
+        updated_key = key;
+    }
+
+    std::pair<std::shared_ptr<plugin::IEncryptor>, std::string>
+    GetEncryptor(int64_t, int64_t) const override {
+        return {};
+    }
+
+    std::shared_ptr<plugin::IDecryptor>
+    GetDecryptor(int64_t, int64_t, const std::string&) const override {
+        return nullptr;
+    }
+
+    int update_count = 0;
+    int64_t updated_ez_id = 0;
+    int64_t updated_collection_id = 0;
+    std::string updated_key;
+};
+
+void
+ExpectMissingCipherPlugin(CStatus status) {
+    ASSERT_NE(status.error_code, Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("failed to get cipher plugin"),
+              std::string::npos);
+    free(const_cast<char*>(status.error_msg));
+}
+
+std::string
+BuildIndexInfoWithPluginContext() {
+    proto::indexcgo::BuildIndexInfo build_index_info;
+    build_index_info.mutable_field_schema()->set_data_type(
+        proto::schema::DataType::Int64);
+
+    auto storage_config = build_index_info.mutable_storage_config();
+    storage_config->set_root_path(TestLocalPath);
+    storage_config->set_storage_type("local");
+
+    auto plugin_context = build_index_info.mutable_storage_plugin_context();
+    plugin_context->set_encryption_zone_id(17);
+    plugin_context->set_collection_id(23);
+    plugin_context->set_encryption_key("unsafe-key");
+    return build_index_info.SerializeAsString();
+}
+
+TEST(CipherPluginContextTest, AnalyzeUsesContextWhenPresent) {
+    proto::clustering::AnalyzeInfo analyze_info;
+    analyze_info.mutable_field_schema()->set_data_type(
+        proto::schema::DataType::Int64);
+    auto storage_config = analyze_info.mutable_storage_config();
+    storage_config->set_root_path(TestLocalPath);
+    storage_config->set_storage_type("local");
+    auto serialized = analyze_info.SerializeAsString();
+
+    CAnalyze analyze = nullptr;
+    auto status = Analyze(&analyze,
+                          reinterpret_cast<const uint8_t*>(serialized.data()),
+                          serialized.size(),
+                          nullptr);
+    ASSERT_NE(status.error_code, Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("invalid data type"),
+              std::string::npos);
+    free(const_cast<char*>(status.error_msg));
+
+    CPluginContext plugin_context{17, 23, "unsafe-key"};
+    status = Analyze(&analyze,
+                     reinterpret_cast<const uint8_t*>(serialized.data()),
+                     serialized.size(),
+                     &plugin_context);
+    ExpectMissingCipherPlugin(status);
+    EXPECT_EQ(analyze, nullptr);
+}
+
+TEST(CipherPluginContextTest, IndexApisUseContextWhenPresent) {
+    auto serialized = BuildIndexInfoWithPluginContext();
+    auto data = reinterpret_cast<const uint8_t*>(serialized.data());
+
+    CIndex index = nullptr;
+    ExpectMissingCipherPlugin(CreateIndex(&index, data, serialized.size()));
+    EXPECT_EQ(index, nullptr);
+
+    ExpectMissingCipherPlugin(
+        BuildJsonKeyIndex(nullptr, data, serialized.size()));
+}
+
+TEST(CipherPluginContextTest, RegistersPluginAndReturnsOnlyIdentifiers) {
+    constexpr int64_t ez_id = 17;
+    constexpr int64_t collection_id = 23;
+    char key[] = "unsafe-key";
+
+    auto cipher_plugin = std::make_shared<RecordingCipherPlugin>();
+    auto context = PluginLoader::GetInstance().registerCipherPluginContext(
+        ez_id, collection_id, std::string(key), cipher_plugin);
+
+    key[0] = 'X';
+    EXPECT_EQ(cipher_plugin->update_count, 1);
+    EXPECT_EQ(cipher_plugin->updated_ez_id, ez_id);
+    EXPECT_EQ(cipher_plugin->updated_collection_id, collection_id);
+    EXPECT_EQ(cipher_plugin->updated_key, "unsafe-key");
+
+    ASSERT_NE(context, nullptr);
+    EXPECT_EQ(context->ez_id, ez_id);
+    EXPECT_EQ(context->collection_id, collection_id);
+    EXPECT_EQ(context->key, nullptr);
+}
+
+TEST(CipherPluginContextTest, RejectsMissingCipherPlugin) {
+    EXPECT_ANY_THROW(PluginLoader::GetInstance().registerCipherPluginContext(
+        17, 23, "unsafe-key", std::shared_ptr<plugin::ICipherPlugin>()));
+}
+
+}  // namespace
+}  // namespace milvus::storage

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -720,13 +721,29 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRejectsWriterStats
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRebuildsTextStats() {
 	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+	requestContext := []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}}
+	pluginContext := &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     1,
+		EncryptionKey:    "unsafe-key",
+	}
+	s.task.plan.PluginContext = requestContext
 	for _, field := range s.task.plan.GetSchema().GetFields() {
 		if field.GetName() == "text" {
 			field.TypeParams = append(field.GetTypeParams(), &commonpb.KeyValuePair{Key: "enable_match", Value: "true"})
 		}
 	}
+	parseContext := func(got []*commonpb.KeyValuePair, collectionID int64) (*indexcgopb.StoragePluginContext, error) {
+		s.Equal(requestContext, got)
+		s.EqualValues(1, collectionID)
+		return pluginContext, nil
+	}
+	parsePatch := mockey.Mock(hookutil.GetCPluginContext).To(parseContext).Build()
+	defer parsePatch.UnPatch()
 
-	createIndexPatch := mockey.Mock(indexcgowrapper.CreateIndex).To(func(context.Context, *indexcgopb.BuildIndexInfo) (indexcgowrapper.CodecIndex, error) {
+	var captured *indexcgopb.BuildIndexInfo
+	createIndexPatch := mockey.Mock(indexcgowrapper.CreateIndex).To(func(_ context.Context, info *indexcgopb.BuildIndexInfo) (indexcgowrapper.CodecIndex, error) {
+		captured = info
 		return fakeTextIndex{}, nil
 	}).Build()
 	defer createIndexPatch.UnPatch()
@@ -744,6 +761,8 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRebuildsTextStats(
 	s.NotNil(result)
 
 	segment := result.GetSegments()[0]
+	s.Require().NotNil(captured)
+	s.Equal(pluginContext, captured.GetStoragePluginContext())
 	s.Contains(segment.GetTextStatsLogs(), int64(101))
 	s.EqualValues(42, segment.GetTextStatsLogs()[101].GetLogSize())
 	files := segment.GetTextStatsLogs()[101].GetFiles()

--- a/internal/datanode/compactor/compactor_common.go
+++ b/internal/datanode/compactor/compactor_common.go
@@ -39,6 +39,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -93,6 +94,10 @@ func createTextIndex(ctx context.Context,
 	}
 
 	newStorageConfig, err := util.ParseStorageConfig(compactionParams.StorageConfig)
+	if err != nil {
+		return nil, err
+	}
+	pluginContext, err := hookutil.GetCPluginContext(plan.GetPluginContext(), collectionID)
 	if err != nil {
 		return nil, err
 	}
@@ -154,6 +159,7 @@ func createTextIndex(ctx context.Context,
 				StorageVersion:            storageVersion,
 				Manifest:                  segment.GetManifest(),
 				StatsBasePath:             statsBasePath,
+				StoragePluginContext:      pluginContext,
 				IndexParams: []*commonpb.KeyValuePair{
 					{Key: "index_type", Value: "INVERTED"},
 					{Key: "is_text_match", Value: "true"},

--- a/internal/datanode/compactor/mix_compactor_text_index_test.go
+++ b/internal/datanode/compactor/mix_compactor_text_index_test.go
@@ -30,7 +30,10 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -67,8 +70,14 @@ func TestMixCompaction_createTextIndex_Delegates(t *testing.T) {
 		storageVer   = int64(2)
 		textFieldID  = int64(101)
 	)
+	requestContext := []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}}
 
-	plan := &datapb.CompactionPlan{PlanID: planID, Schema: textMatchSchema(textFieldID), Type: datapb.CompactionType_MixCompaction}
+	plan := &datapb.CompactionPlan{
+		PlanID:        planID,
+		Schema:        textMatchSchema(textFieldID),
+		Type:          datapb.CompactionType_MixCompaction,
+		PluginContext: requestContext,
+	}
 	task := &mixCompactionTask{
 		plan:             plan,
 		collectionID:     collectionID,
@@ -81,6 +90,7 @@ func TestMixCompaction_createTextIndex_Delegates(t *testing.T) {
 			gotStorageVer, gotColl, gotPart, gotSeg, gotTask int64, _ *datapb.CompactionSegment,
 		) (map[int64]*datapb.TextIndexStats, error) {
 			assert.Equal(t, plan, gotPlan)
+			assert.Equal(t, requestContext, gotPlan.GetPluginContext())
 			assert.Equal(t, storageVer, gotStorageVer)
 			assert.Equal(t, collectionID, gotColl)
 			assert.Equal(t, partitionID, gotPart)
@@ -114,6 +124,171 @@ func TestMixCompaction_createTextIndex_PropagatesError(t *testing.T) {
 
 	_, err := task.createTextIndex(context.Background(), &datapb.CompactionSegment{SegmentID: 99})
 	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestCreateTextIndexPropagatesPluginContext(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	const (
+		collectionID = int64(7001)
+		partitionID  = int64(7002)
+		segmentID    = int64(7003)
+		fieldID      = int64(101)
+	)
+	requestContext := []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}}
+	pluginContext := &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     collectionID,
+		EncryptionKey:    "unsafe-key",
+	}
+
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).To(
+		func(got []*commonpb.KeyValuePair, gotCollectionID int64) (*indexcgopb.StoragePluginContext, error) {
+			require.Equal(t, requestContext, got)
+			require.Equal(t, collectionID, gotCollectionID)
+			return pluginContext, nil
+		}).Build()
+	defer parseMock.UnPatch()
+
+	var captured *indexcgopb.BuildIndexInfo
+	buildMock := mockey.Mock(indexcgowrapper.CreateIndex).To(
+		func(_ context.Context, info *indexcgopb.BuildIndexInfo) (indexcgowrapper.CodecIndex, error) {
+			captured = info
+			return fakeTextIndex{}, nil
+		}).Build()
+	defer buildMock.UnPatch()
+
+	manifest := packed.MarshalManifestPath(t.TempDir(), packed.ManifestEarliest)
+	segment := &datapb.CompactionSegment{
+		SegmentID:      segmentID,
+		StorageVersion: storage.StorageV3,
+		Manifest:       manifest,
+	}
+	params := compaction.GenParams()
+	params.StorageConfig = &indexpb.StorageConfig{RootPath: t.TempDir(), StorageType: "local"}
+	got, err := createTextIndex(
+		context.Background(),
+		nil,
+		&datapb.CompactionPlan{
+			PlanID:        1,
+			Schema:        textMatchSchema(fieldID),
+			PluginContext: requestContext,
+		},
+		params,
+		storage.StorageV3,
+		collectionID,
+		partitionID,
+		segmentID,
+		1,
+		segment,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+	require.NotNil(t, captured)
+	require.Equal(t, pluginContext, captured.GetStoragePluginContext())
+	require.Equal(t, manifest, captured.GetManifest())
+	require.EqualValues(t, storage.StorageV3, captured.GetStorageVersion())
+}
+
+func TestCreateTextIndexPropagatesPluginContextError(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).Return(nil, assert.AnError).Build()
+	defer parseMock.UnPatch()
+
+	buildCalled := false
+	buildMock := mockey.Mock(indexcgowrapper.CreateIndex).To(
+		func(context.Context, *indexcgopb.BuildIndexInfo) (indexcgowrapper.CodecIndex, error) {
+			buildCalled = true
+			return fakeTextIndex{}, nil
+		}).Build()
+	defer buildMock.UnPatch()
+
+	params := compaction.GenParams()
+	params.StorageConfig = &indexpb.StorageConfig{RootPath: t.TempDir(), StorageType: "local"}
+	_, err := createTextIndex(
+		context.Background(),
+		nil,
+		&datapb.CompactionPlan{
+			PlanID:        1,
+			Schema:        textMatchSchema(101),
+			PluginContext: []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}},
+		},
+		params,
+		storage.StorageV2,
+		1,
+		2,
+		3,
+		1,
+		&datapb.CompactionSegment{SegmentID: 3, StorageVersion: storage.StorageV2},
+	)
+	require.ErrorIs(t, err, assert.AnError)
+	require.False(t, buildCalled)
+}
+
+func TestCreateTextIndexWithoutPluginContext(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).Return(nil, nil).Build()
+	defer parseMock.UnPatch()
+
+	var captured *indexcgopb.BuildIndexInfo
+	buildMock := mockey.Mock(indexcgowrapper.CreateIndex).To(
+		func(_ context.Context, info *indexcgopb.BuildIndexInfo) (indexcgowrapper.CodecIndex, error) {
+			captured = info
+			return fakeTextIndex{}, nil
+		}).Build()
+	defer buildMock.UnPatch()
+
+	params := compaction.GenParams()
+	params.StorageConfig = &indexpb.StorageConfig{RootPath: t.TempDir(), StorageType: "local"}
+	_, err := createTextIndex(
+		context.Background(),
+		nil,
+		&datapb.CompactionPlan{PlanID: 1, Schema: textMatchSchema(101)},
+		params,
+		storage.StorageV2,
+		1,
+		2,
+		3,
+		1,
+		&datapb.CompactionSegment{SegmentID: 3, StorageVersion: storage.StorageV2},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.Nil(t, captured.GetStoragePluginContext())
+}
+
+func TestSortCompaction_createTextIndex_ForwardsPlan(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	requestContext := []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}}
+	plan := &datapb.CompactionPlan{PlanID: 42, PluginContext: requestContext}
+	task := &sortCompactionTask{
+		plan:             plan,
+		compactionParams: compaction.GenParams(),
+		storageVersion:   storage.StorageV3,
+	}
+	segment := &datapb.CompactionSegment{SegmentID: 3, StorageVersion: storage.StorageV3}
+
+	mockHelper := mockey.Mock(createTextIndex).To(
+		func(_ context.Context, _ storage.ChunkManager, gotPlan *datapb.CompactionPlan, _ compaction.Params,
+			gotStorageVersion, gotCollectionID, gotPartitionID, gotSegmentID, gotTaskID int64,
+			gotSegment *datapb.CompactionSegment,
+		) (map[int64]*datapb.TextIndexStats, error) {
+			require.Equal(t, plan, gotPlan)
+			require.Equal(t, requestContext, gotPlan.GetPluginContext())
+			require.EqualValues(t, storage.StorageV3, gotStorageVersion)
+			require.EqualValues(t, 1, gotCollectionID)
+			require.EqualValues(t, 2, gotPartitionID)
+			require.EqualValues(t, 3, gotSegmentID)
+			require.EqualValues(t, 42, gotTaskID)
+			require.Equal(t, segment, gotSegment)
+			return map[int64]*datapb.TextIndexStats{}, nil
+		}).Build()
+	defer mockHelper.UnPatch()
+
+	_, err := task.createTextIndex(context.Background(), 1, 2, 3, 42, segment)
+	require.NoError(t, err)
 }
 
 // TestMixCompaction_Compact_InlineTextIndex drives the real mixCompactionTask.Compact()

--- a/internal/datanode/index/task_analyze.go
+++ b/internal/datanode/index/task_analyze.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/analyzecgowrapper"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/clusteringpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
@@ -44,20 +45,24 @@ type analyzeTask struct {
 	queueDur time.Duration
 	manager  *TaskManager
 	analyze  analyzecgowrapper.CodecAnalyze
+
+	pluginContext *indexcgopb.StoragePluginContext
 }
 
 func NewAnalyzeTask(ctx context.Context,
 	cancel context.CancelFunc,
 	req *workerpb.AnalyzeRequest,
 	manager *TaskManager,
+	pluginContext *indexcgopb.StoragePluginContext,
 ) *analyzeTask {
 	return &analyzeTask{
-		ident:   fmt.Sprintf("%s/%d", req.GetClusterID(), req.GetTaskID()),
-		ctx:     ctx,
-		cancel:  cancel,
-		req:     req,
-		manager: manager,
-		tr:      timerecord.NewTimeRecorder(fmt.Sprintf("ClusterID: %s, TaskID: %d", req.GetClusterID(), req.GetTaskID())),
+		ident:         fmt.Sprintf("%s/%d", req.GetClusterID(), req.GetTaskID()),
+		ctx:           ctx,
+		cancel:        cancel,
+		req:           req,
+		manager:       manager,
+		pluginContext: pluginContext,
+		tr:            timerecord.NewTimeRecorder(fmt.Sprintf("ClusterID: %s, TaskID: %d", req.GetClusterID(), req.GetTaskID())),
 	}
 }
 
@@ -161,7 +166,7 @@ func (at *analyzeTask) Execute(ctx context.Context) error {
 		FieldSchema:     field,
 	}
 
-	at.analyze, err = analyzecgowrapper.Analyze(ctx, analyzeInfo)
+	at.analyze, err = analyzecgowrapper.Analyze(ctx, analyzeInfo, at.pluginContext)
 	if err != nil {
 		log.Error(ctx, "failed to analyze data", mlog.Err(err))
 		return err
@@ -223,4 +228,5 @@ func (at *analyzeTask) Reset() {
 	at.tr = nil
 	at.queueDur = 0
 	at.manager = nil
+	at.pluginContext = nil
 }

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -75,6 +75,8 @@ type statsTask struct {
 	binlogIO io.BinlogIO
 	cm       storage.ChunkManager
 
+	pluginContext *indexcgopb.StoragePluginContext
+
 	logIDOffset  int64
 	currentTime  time.Time
 	manifestPath string // current manifest version, updated after each AddStatsToManifest
@@ -92,18 +94,20 @@ func NewStatsTask(ctx context.Context,
 	req *workerpb.CreateStatsRequest,
 	manager *TaskManager,
 	cm storage.ChunkManager,
+	pluginContext *indexcgopb.StoragePluginContext,
 ) *statsTask {
 	return &statsTask{
-		ident:       fmt.Sprintf("%s/%d", req.GetClusterID(), req.GetTaskID()),
-		ctx:         ctx,
-		cancel:      cancel,
-		req:         req,
-		manager:     manager,
-		binlogIO:    io.NewBinlogIO(cm),
-		cm:          cm,
-		tr:          timerecord.NewTimeRecorder(fmt.Sprintf("ClusterID: %s, TaskID: %d", req.GetClusterID(), req.GetTaskID())),
-		currentTime: tsoutil.PhysicalTime(req.GetCurrentTs()),
-		logIDOffset: 0,
+		ident:         fmt.Sprintf("%s/%d", req.GetClusterID(), req.GetTaskID()),
+		ctx:           ctx,
+		cancel:        cancel,
+		req:           req,
+		manager:       manager,
+		binlogIO:      io.NewBinlogIO(cm),
+		cm:            cm,
+		pluginContext: pluginContext,
+		tr:            timerecord.NewTimeRecorder(fmt.Sprintf("ClusterID: %s, TaskID: %d", req.GetClusterID(), req.GetTaskID())),
+		currentTime:   tsoutil.PhysicalTime(req.GetCurrentTs()),
+		logIDOffset:   0,
 	}
 }
 
@@ -428,6 +432,7 @@ func (st *statsTask) Reset() {
 	st.cancel = nil
 	st.tr = nil
 	st.manager = nil
+	st.pluginContext = nil
 }
 
 func serializeWrite(ctx context.Context, rootPath string, startID int64, writer *compactor.SegmentWriter) (binlogNum int64, kvs map[string][]byte, fieldBinlogs map[int64]*datapb.FieldBinlog, err error) {
@@ -563,7 +568,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			if err != nil {
 				return err
 			}
-			buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, nil, statsBasePath)
+			buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, nil, statsBasePath, st.pluginContext)
 			buildIndexParams.IndexParams = []*commonpb.KeyValuePair{
 				{Key: "index_type", Value: "INVERTED"},
 				{Key: "is_text_match", Value: "true"},
@@ -746,7 +751,7 @@ func (st *statsTask) createJSONKeyStats(ctx context.Context,
 			if err != nil {
 				return err
 			}
-			buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, options, statsBasePath)
+			buildIndexParams := buildIndexParams(req, files, field, newStorageConfig, options, statsBasePath, st.pluginContext)
 
 			statsResult, err := indexcgowrapper.CreateJSONKeyStats(egCtx, buildIndexParams)
 			if err != nil {
@@ -867,6 +872,7 @@ func buildIndexParams(
 	storageConfig *indexcgopb.StorageConfig,
 	options *BuildIndexOptions,
 	statsBasePath string,
+	pluginContext *indexcgopb.StoragePluginContext,
 ) *indexcgopb.BuildIndexInfo {
 	if options == nil {
 		options = &BuildIndexOptions{}
@@ -889,6 +895,9 @@ func buildIndexParams(
 		JsonStatsWriteBatchSize:          options.JSONStatsWriteBatchSize,
 		Manifest:                         req.GetManifestPath(),
 		StatsBasePath:                    statsBasePath,
+	}
+	if pluginContext != nil {
+		params.StoragePluginContext = pluginContext
 	}
 
 	if req.GetStorageVersion() == storage.StorageV2 || req.GetStorageVersion() == storage.StorageV3 {

--- a/internal/datanode/index/task_stats_test.go
+++ b/internal/datanode/index/task_stats_test.go
@@ -125,7 +125,7 @@ func (s *TaskStatsSuite) TestSortSegmentWithBM25() {
 			StorageConfig: &indexpb.StorageConfig{
 				RootPath: "root_path",
 			},
-		}, manager, s.mockChunkManager)
+		}, manager, s.mockChunkManager, nil)
 		task.binlogIO = s.mockBinlogIO
 
 		err = task.PreExecute(ctx)
@@ -177,7 +177,7 @@ func (s *TaskStatsSuite) TestSortSegmentWithBM25() {
 			StorageConfig: &indexpb.StorageConfig{
 				RootPath: "root_path",
 			},
-		}, manager, s.mockChunkManager)
+		}, manager, s.mockChunkManager, nil)
 		task.binlogIO = s.mockBinlogIO
 
 		err = task.PreExecute(ctx)
@@ -207,13 +207,19 @@ func (s *TaskStatsSuite) TestBuildIndexParams() {
 			JSONStatsShreddingRatio:      0.3,
 			JSONStatsWriteBatchSize:      81920,
 		}
-		params := buildIndexParams(req, []string{"file1", "file2"}, nil, &indexcgopb.StorageConfig{}, options, "")
+		params := buildIndexParams(req, []string{"file1", "file2"}, nil, &indexcgopb.StorageConfig{}, options, "", nil)
 
 		s.Equal(storage.StorageV2, params.StorageVersion)
 		s.NotNil(params.SegmentInsertFiles)
+		s.Nil(params.GetStoragePluginContext())
 	})
 
 	s.Run("test external source spec params", func() {
+		pluginContext := &indexcgopb.StoragePluginContext{
+			EncryptionZoneId: 17,
+			CollectionId:     2,
+			EncryptionKey:    "unsafe-key",
+		}
 		req := &workerpb.CreateStatsRequest{
 			TaskID:                    1,
 			CollectionID:              2,
@@ -222,6 +228,7 @@ func (s *TaskStatsSuite) TestBuildIndexParams() {
 			TaskVersion:               5,
 			CurrentScalarIndexVersion: int32(1),
 			StorageVersion:            storage.StorageV3,
+			ManifestPath:              "manifest-path",
 			InsertLogs:                []*datapb.FieldBinlog{},
 			StorageConfig:             &indexpb.StorageConfig{RootPath: "/test/path"},
 			Schema: &schemapb.CollectionSchema{
@@ -230,11 +237,80 @@ func (s *TaskStatsSuite) TestBuildIndexParams() {
 			},
 		}
 
-		params := buildIndexParams(req, nil, nil, &indexcgopb.StorageConfig{}, nil, "")
+		params := buildIndexParams(req, nil, nil, &indexcgopb.StorageConfig{}, nil, "stats-base-path", pluginContext)
 
 		s.Equal(req.GetSchema().GetExternalSource(), params.GetExternalSource())
 		s.Equal(req.GetSchema().GetExternalSpec(), params.GetExternalSpec())
+		s.Equal(req.GetManifestPath(), params.GetManifest())
+		s.Equal("stats-base-path", params.GetStatsBasePath())
+		s.Equal(pluginContext, params.GetStoragePluginContext())
 	})
+}
+
+func (s *TaskStatsSuite) TestJSONKeyStatsPropagatesPluginContext() {
+	const fieldID = int64(101)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pluginContext := &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     s.collectionID,
+		EncryptionKey:    "unsafe-key",
+	}
+	req := &workerpb.CreateStatsRequest{
+		ClusterID:       s.clusterID,
+		TaskID:          100,
+		CollectionID:    s.collectionID,
+		PartitionID:     s.partitionID,
+		TargetSegmentID: 102,
+		TaskVersion:     1,
+		NumRows:         10,
+		StorageVersion:  storage.StorageV2,
+		StorageConfig: &indexpb.StorageConfig{
+			RootPath:    s.T().TempDir(),
+			StorageType: "local",
+		},
+		Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  fieldID,
+				Name:     "json",
+				DataType: schemapb.DataType_JSON,
+			},
+		}},
+		InsertLogs: []*datapb.FieldBinlog{{FieldID: fieldID}},
+	}
+	manager := NewTaskManager(ctx)
+	manager.LoadOrStoreStatsTask(s.clusterID, req.GetTaskID(), &StatsTaskInfo{})
+	task := NewStatsTask(ctx, cancel, req, manager, nil, pluginContext)
+
+	var captured *indexcgopb.BuildIndexInfo
+	buildMock := mockey.Mock(indexcgowrapper.CreateJSONKeyStats).To(
+		func(_ context.Context, info *indexcgopb.BuildIndexInfo) (*indexcgowrapper.JSONKeyStatsResult, error) {
+			captured = info
+			return &indexcgowrapper.JSONKeyStatsResult{
+				MemSize: 10,
+				Files:   map[string]int64{"json-stats": 10},
+			}, nil
+		}).Build()
+	defer buildMock.UnPatch()
+
+	err := task.createJSONKeyStats(
+		ctx,
+		req.GetStorageConfig(),
+		req.GetCollectionID(),
+		req.GetPartitionID(),
+		req.GetTargetSegmentID(),
+		req.GetTaskVersion(),
+		req.GetTaskID(),
+		common.JSONStatsDataFormatVersion,
+		req.GetInsertLogs(),
+		256,
+		0.3,
+		81920,
+	)
+	s.Require().NoError(err)
+	s.Require().NotNil(captured)
+	s.Equal(pluginContext, captured.GetStoragePluginContext())
 }
 
 func genCollectionSchemaWithBM25() *schemapb.CollectionSchema {
@@ -332,7 +408,7 @@ func TestCreateJSONKeyStats_NullableJSONMissingFieldBinlog(t *testing.T) {
 	}
 	ctx2, cancel := context.WithCancel(ctx)
 	defer cancel()
-	st := NewStatsTask(ctx2, cancel, req, mgr, nil)
+	st := NewStatsTask(ctx2, cancel, req, mgr, nil, nil)
 
 	insertBinlogs := []*datapb.FieldBinlog{
 		{FieldID: 100, Binlogs: []*datapb.Binlog{{LogID: 1}}},
@@ -385,7 +461,7 @@ func TestCreateJSONKeyStats_NonNullableJSONMissingFieldBinlog(t *testing.T) {
 	}
 	ctx2, cancel := context.WithCancel(ctx)
 	defer cancel()
-	st := NewStatsTask(ctx2, cancel, req, mgr, nil)
+	st := NewStatsTask(ctx2, cancel, req, mgr, nil, nil)
 
 	insertBinlogs := []*datapb.FieldBinlog{
 		{FieldID: 100, Binlogs: []*datapb.Binlog{{LogID: 1}}},

--- a/internal/datanode/index/task_test.go
+++ b/internal/datanode/index/task_test.go
@@ -284,7 +284,7 @@ func (suite *AnalyzeTaskSuite) TestMaxConnectionsReachesAnalyze() {
 
 	var captured *clusteringpb.AnalyzeInfo
 	patch := mockey.Mock(analyzecgowrapper.Analyze).To(
-		func(_ context.Context, info *clusteringpb.AnalyzeInfo) (analyzecgowrapper.CodecAnalyze, error) {
+		func(_ context.Context, info *clusteringpb.AnalyzeInfo, _ *indexcgopb.StoragePluginContext) (analyzecgowrapper.CodecAnalyze, error) {
 			captured = info
 			return nil, nil
 		}).Build()

--- a/internal/datanode/index_services.go
+++ b/internal/datanode/index_services.go
@@ -336,6 +336,10 @@ func (node *DataNode) createAnalyzeTask(ctx context.Context, req *workerpb.Analy
 		mlog.Warn(ctx, "receive analyze task with invalid slot, set to 65535", mlog.Int64("taskSlot", req.GetTaskSlot()))
 		req.TaskSlot = 65535
 	}
+	pluginContext, err := hookutil.GetCPluginContext(req.GetPluginContext(), req.GetCollectionID())
+	if err != nil {
+		return merr.Status(err), nil
+	}
 
 	taskCtx, taskCancel := context.WithCancel(node.ctx)
 	if oldInfo := node.taskManager.LoadOrStoreAnalyzeTask(req.GetClusterID(), req.GetTaskID(), &index.AnalyzeTaskInfo{
@@ -347,7 +351,7 @@ func (node *DataNode) createAnalyzeTask(ctx context.Context, req *workerpb.Analy
 		mlog.Warn(context.TODO(), "duplicated analyze task", mlog.Err(err))
 		return merr.Status(err), nil
 	}
-	t := index.NewAnalyzeTask(taskCtx, taskCancel, req, node.taskManager)
+	t := index.NewAnalyzeTask(taskCtx, taskCancel, req, node.taskManager, pluginContext)
 	ret := merr.Success()
 	if err := node.taskScheduler.TaskQueue.Enqueue(t); err != nil {
 		mlog.Warn(context.TODO(), "DataNode failed to schedule", mlog.Err(err))
@@ -377,6 +381,10 @@ func (node *DataNode) createStatsTask(ctx context.Context, req *workerpb.CreateS
 		mlog.Warn(ctx, "receive stats task with invalid slot, set to 64", mlog.Int64("taskSlot", req.GetTaskSlot()))
 		req.TaskSlot = 64
 	}
+	pluginContext, err := hookutil.GetCPluginContext(req.GetPluginContext(), req.GetCollectionID())
+	if err != nil {
+		return merr.Status(err), nil
+	}
 
 	taskCtx, taskCancel := context.WithCancel(node.ctx)
 	if oldInfo := node.taskManager.LoadOrStoreStatsTask(req.GetClusterID(), req.GetTaskID(), &index.StatsTaskInfo{
@@ -398,7 +406,7 @@ func (node *DataNode) createStatsTask(ctx context.Context, req *workerpb.CreateS
 		return merr.Status(err), nil
 	}
 
-	t := index.NewStatsTask(taskCtx, taskCancel, req, node.taskManager, cm)
+	t := index.NewStatsTask(taskCtx, taskCancel, req, node.taskManager, cm, pluginContext)
 	ret := merr.Success()
 	if err := node.taskScheduler.TaskQueue.Enqueue(t); err != nil {
 		mlog.Warn(context.TODO(), "DataNode failed to schedule", mlog.Err(err))

--- a/internal/datanode/index_services_test.go
+++ b/internal/datanode/index_services_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -32,10 +33,16 @@ import (
 	"github.com/milvus-io/milvus/internal/datanode/index"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/analyzecgowrapper"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/cgopb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/clusteringpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -70,6 +77,180 @@ func TestIndexTaskWhenStoppingNode(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		assert.Fail(t, "timeout task chan")
 	}
+}
+
+type fakeServiceIndex struct{}
+
+func (fakeServiceIndex) Build(*indexcgowrapper.Dataset) error                        { return nil }
+func (fakeServiceIndex) Serialize() ([]*indexcgowrapper.Blob, error)                 { return nil, nil }
+func (fakeServiceIndex) GetIndexFileInfo() ([]*indexcgowrapper.IndexFileInfo, error) { return nil, nil }
+func (fakeServiceIndex) Load([]*indexcgowrapper.Blob) error                          { return nil }
+func (fakeServiceIndex) Delete() error                                               { return nil }
+func (fakeServiceIndex) CleanLocalData() error                                       { return nil }
+func (fakeServiceIndex) UpLoad() (*cgopb.IndexStats, error) {
+	return &cgopb.IndexStats{SerializedIndexInfos: []*cgopb.SerializedIndexFileInfo{{FileName: "text-index", FileSize: 10}}}, nil
+}
+
+func TestCreateAnalyzeTaskPropagatesPluginContext(t *testing.T) {
+	paramtable.Init()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	node := NewDataNode(ctx)
+	defer node.cancel()
+
+	requestContext := []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}}
+	expected := &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     1,
+		EncryptionKey:    "unsafe-key",
+	}
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).To(
+		func(got []*commonpb.KeyValuePair, collectionID int64) (*indexcgopb.StoragePluginContext, error) {
+			require.Equal(t, requestContext, got)
+			require.Equal(t, expected.GetCollectionId(), collectionID)
+			return expected, nil
+		}).Build()
+	defer parseMock.UnPatch()
+
+	var captured *indexcgopb.StoragePluginContext
+	analyzeMock := mockey.Mock(analyzecgowrapper.Analyze).To(
+		func(_ context.Context, _ *clusteringpb.AnalyzeInfo, pluginContext *indexcgopb.StoragePluginContext) (analyzecgowrapper.CodecAnalyze, error) {
+			captured = pluginContext
+			return nil, nil
+		}).Build()
+	defer analyzeMock.UnPatch()
+
+	status, err := node.createAnalyzeTask(ctx, &workerpb.AnalyzeRequest{
+		ClusterID:     "cluster",
+		TaskID:        100,
+		CollectionID:  expected.GetCollectionId(),
+		PartitionID:   2,
+		FieldID:       101,
+		FieldName:     "vector",
+		FieldType:     schemapb.DataType_FloatVector,
+		Dim:           8,
+		PluginContext: requestContext,
+		StorageConfig: &indexpb.StorageConfig{RootPath: t.TempDir(), StorageType: "local"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, merr.Error(status))
+
+	task := node.taskScheduler.TaskQueue.PopUnissuedTask()
+	require.NotNil(t, task)
+	require.NoError(t, task.Execute(ctx))
+	require.Equal(t, expected, captured)
+}
+
+func TestCreateAnalyzeTaskPluginContextErrorDoesNotRegisterTask(t *testing.T) {
+	paramtable.Init()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	node := NewDataNode(ctx)
+	defer node.cancel()
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).Return(nil, assert.AnError).Build()
+	defer parseMock.UnPatch()
+
+	const taskID = int64(100)
+	status, err := node.createAnalyzeTask(ctx, &workerpb.AnalyzeRequest{
+		ClusterID:    "cluster",
+		TaskID:       taskID,
+		CollectionID: 1,
+	})
+	require.NoError(t, err)
+	taskErr := merr.Error(status)
+	require.Error(t, taskErr)
+	require.Nil(t, node.taskManager.GetAnalyzeTaskInfo("cluster", taskID))
+}
+
+func TestCreateStatsTaskPropagatesPluginContext(t *testing.T) {
+	paramtable.Init()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	node := NewDataNode(ctx)
+	defer node.cancel()
+
+	requestContext := []*commonpb.KeyValuePair{{Key: "cipher-context", Value: "opaque"}}
+	expected := &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     1,
+		EncryptionKey:    "unsafe-key",
+	}
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).To(
+		func(got []*commonpb.KeyValuePair, collectionID int64) (*indexcgopb.StoragePluginContext, error) {
+			require.Equal(t, requestContext, got)
+			require.Equal(t, expected.GetCollectionId(), collectionID)
+			return expected, nil
+		}).Build()
+	defer parseMock.UnPatch()
+
+	var captured *indexcgopb.BuildIndexInfo
+	buildMock := mockey.Mock(indexcgowrapper.CreateIndex).To(
+		func(_ context.Context, info *indexcgopb.BuildIndexInfo) (indexcgowrapper.CodecIndex, error) {
+			captured = info
+			return fakeServiceIndex{}, nil
+		}).Build()
+	defer buildMock.UnPatch()
+
+	const fieldID = int64(101)
+	status, err := node.createStatsTask(ctx, &workerpb.CreateStatsRequest{
+		ClusterID:       "cluster",
+		TaskID:          100,
+		CollectionID:    expected.GetCollectionId(),
+		PartitionID:     2,
+		SegmentID:       3,
+		TargetSegmentID: 4,
+		SubJobType:      indexpb.StatsSubJob_TextIndexJob,
+		StorageVersion:  storage.StorageV2,
+		PluginContext:   requestContext,
+		StorageConfig:   &indexpb.StorageConfig{RootPath: t.TempDir(), StorageType: "local"},
+		Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  fieldID,
+				Name:     "text",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "enable_match", Value: "true"},
+				},
+			},
+		}},
+		InsertLogs: []*datapb.FieldBinlog{{
+			FieldID: fieldID,
+			Binlogs: []*datapb.Binlog{{LogID: 1}},
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, merr.Error(status))
+
+	task := node.taskScheduler.TaskQueue.PopUnissuedTask()
+	require.NotNil(t, task)
+	require.NoError(t, task.Execute(ctx))
+	require.NotNil(t, captured)
+	require.Equal(t, expected, captured.GetStoragePluginContext())
+}
+
+func TestCreateStatsTaskPluginContextErrorDoesNotRegisterTask(t *testing.T) {
+	paramtable.Init()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	node := NewDataNode(ctx)
+	defer node.cancel()
+	parseMock := mockey.Mock(hookutil.GetCPluginContext).Return(nil, assert.AnError).Build()
+	defer parseMock.UnPatch()
+
+	const taskID = int64(100)
+	status, err := node.createStatsTask(ctx, &workerpb.CreateStatsRequest{
+		ClusterID:    "cluster",
+		TaskID:       taskID,
+		CollectionID: 1,
+	})
+	require.NoError(t, err)
+	taskErr := merr.Error(status)
+	require.Error(t, taskErr)
+	require.Nil(t, node.taskManager.GetStatsTaskInfo("cluster", taskID))
 }
 
 func TestCreateIndexTaskInitializesIndexStorePathVersion(t *testing.T) {

--- a/internal/util/analyzecgowrapper/analyze.go
+++ b/internal/util/analyzecgowrapper/analyze.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/clusteringpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 )
 
 type CodecAnalyze interface {
@@ -41,7 +42,7 @@ type CodecAnalyze interface {
 	GetResult(size int) (string, int64, []string, []int64, error)
 }
 
-func Analyze(ctx context.Context, analyzeInfo *clusteringpb.AnalyzeInfo) (CodecAnalyze, error) {
+func Analyze(ctx context.Context, analyzeInfo *clusteringpb.AnalyzeInfo, pluginContext *indexcgopb.StoragePluginContext) (CodecAnalyze, error) {
 	analyzeInfoBlob, err := proto.Marshal(analyzeInfo)
 	if err != nil {
 		mlog.Warn(ctx, "marshal analyzeInfo failed",
@@ -49,8 +50,23 @@ func Analyze(ctx context.Context, analyzeInfo *clusteringpb.AnalyzeInfo) (CodecA
 			mlog.Err(err))
 		return nil, err
 	}
+
+	var pluginContextPtr *C.CPluginContext
+	if pluginContext != nil {
+		// Analyze is synchronous; C++ copies the key before this function
+		// returns and retains only the encryption-zone and collection IDs.
+		key := C.CString(pluginContext.GetEncryptionKey())
+		defer C.free(unsafe.Pointer(key))
+		cPluginContext := C.CPluginContext{
+			ez_id:         C.int64_t(pluginContext.GetEncryptionZoneId()),
+			collection_id: C.int64_t(pluginContext.GetCollectionId()),
+			key:           key,
+		}
+		pluginContextPtr = &cPluginContext
+	}
+
 	var analyzePtr C.CAnalyze
-	status := C.Analyze(&analyzePtr, (*C.uint8_t)(unsafe.Pointer(&analyzeInfoBlob[0])), (C.uint64_t)(len(analyzeInfoBlob)))
+	status := C.Analyze(&analyzePtr, (*C.uint8_t)(unsafe.Pointer(&analyzeInfoBlob[0])), (C.uint64_t)(len(analyzeInfoBlob)), pluginContextPtr)
 	if err := HandleCStatus(&status, "failed to analyze task"); err != nil {
 		return nil, err
 	}

--- a/internal/util/analyzecgowrapper/analyze_test.go
+++ b/internal/util/analyzecgowrapper/analyze_test.go
@@ -1,0 +1,48 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzecgowrapper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/clusteringpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
+)
+
+func TestAnalyzeAppliesPluginContext(t *testing.T) {
+	info := &clusteringpb.AnalyzeInfo{
+		FieldSchema: &schemapb.FieldSchema{DataType: schemapb.DataType_Int64},
+		StorageConfig: &clusteringpb.StorageConfig{
+			RootPath:    t.TempDir(),
+			StorageType: "local",
+		},
+	}
+
+	_, err := Analyze(context.Background(), info, nil)
+	require.ErrorContains(t, err, "invalid data type")
+
+	_, err = Analyze(context.Background(), info, &indexcgopb.StoragePluginContext{
+		EncryptionZoneId: 17,
+		CollectionId:     23,
+		EncryptionKey:    "unsafe-key",
+	})
+	require.ErrorContains(t, err, "failed to get cipher plugin")
+}


### PR DESCRIPTION
Propagate storage plugin context to stats and compaction text-index
builds, and pass it through the analyze CGO boundary so C++ registers
the cipher key before storage access.

Centralize C++ cipher-context registration in PluginLoader and add
focused Go and C++ coverage for index and analyze entry points.

See also: #51752
pr: #51789 

Signed-off-by: yangxuan <xuan.yang@zilliz.com>

