### PR TITLE
fix: keep file resource sync retryable on analyzer failure

### DIFF
--- a/internal/util/fileresource/manager.go
+++ b/internal/util/fileresource/manager.go
@@ -232,6 +232,9 @@ func (m *SyncManager) Sync(version uint64, resourceList []*internalpb.FileResour
 		}
 	}
 
+	if err := analyzer.UpdateGlobalResourceInfo(newResourceMap); err != nil {
+		return err
+	}
 	for _, resourceID := range removes {
 		err := os.RemoveAll(path.Join(m.localPath, fmt.Sprint(resourceID)))
 		if err != nil {
@@ -240,9 +243,6 @@ func (m *SyncManager) Sync(version uint64, resourceList []*internalpb.FileResour
 	}
 	m.resourceMap = newResourceMap
 	m.version.Store(version)
-	if err := analyzer.UpdateGlobalResourceInfo(newResourceMap); err != nil {
-		return err
-	}
 	notifyListeners(SyncEvent{Version: version, Resources: resolvedResources})
 	return nil
 }

--- a/internal/util/fileresource/manager_test.go
+++ b/internal/util/fileresource/manager_test.go
@@ -28,10 +28,13 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -225,6 +228,22 @@ func (suite *SyncManagerSuite) TestSync_UpdateAndRemoveNotifyListener() {
 	suite.Require().Len(listener.events, 3)
 	suite.Empty(listener.events[2].Resources)
 	suite.NoDirExists(path.Join(suite.tempDir, "2"))
+}
+
+func (suite *SyncManagerSuite) TestSync_AnalyzerUpdateFailureDoesNotAdvanceVersion() {
+	mockey.PatchConvey("failed analyzer update keeps version retryable", suite.T(), func() {
+		expectedErr := errors.New("mock analyzer update failed")
+		mockey.Mock(analyzer.UpdateGlobalResourceInfo).Return(expectedErr).Build()
+
+		resources := []*internalpb.FileResourceInfo{
+			{Id: 1, Name: "test.file", Path: "/storage/test.file"},
+		}
+		suite.mockStorage.EXPECT().Reader(context.Background(), "/storage/test.file").Return(newMockReader("test content"), nil).Once()
+
+		err := suite.manager.Sync(1, resources)
+		suite.ErrorIs(err, expectedErr)
+		suite.Equal(uint64(0), suite.manager.GetVersion())
+	})
 }
 
 func (suite *SyncManagerSuite) TestMode() {

--- a/internal/util/fileresource/manager_test.go
+++ b/internal/util/fileresource/manager_test.go
@@ -233,7 +233,7 @@ func (suite *SyncManagerSuite) TestSync_UpdateAndRemoveNotifyListener() {
 func (suite *SyncManagerSuite) TestSync_AnalyzerUpdateFailureDoesNotAdvanceVersion() {
 	mockey.PatchConvey("failed analyzer update keeps version retryable", suite.T(), func() {
 		expectedErr := errors.New("mock analyzer update failed")
-		mockey.Mock(analyzer.UpdateGlobalResourceInfo).Return(expectedErr).Build()
+		mocker := mockey.Mock(analyzer.UpdateGlobalResourceInfo).Return(expectedErr).Build()
 
 		resources := []*internalpb.FileResourceInfo{
 			{Id: 1, Name: "test.file", Path: "/storage/test.file"},
@@ -243,6 +243,16 @@ func (suite *SyncManagerSuite) TestSync_AnalyzerUpdateFailureDoesNotAdvanceVersi
 		err := suite.manager.Sync(1, resources)
 		suite.ErrorIs(err, expectedErr)
 		suite.Equal(uint64(0), suite.manager.GetVersion())
+
+		// the same version is retried and reaches the analyzer again, re-downloading the resource
+		suite.mockStorage.EXPECT().Reader(context.Background(), "/storage/test.file").Return(newMockReader("test content"), nil).Once()
+		mocker.Return(nil)
+
+		suite.Require().NoError(suite.manager.Sync(1, resources))
+		suite.Equal(uint64(1), suite.manager.GetVersion())
+		content, err := os.ReadFile(path.Join(suite.tempDir, "1", "test.file"))
+		suite.NoError(err)
+		suite.Equal("test content", string(content))
 	})
 }
 


### PR DESCRIPTION
issue: #51837

## What changed

Move `SyncManager.Sync`'s `analyzer.UpdateGlobalResourceInfo` call before advancing the local file resource `version` and `resourceMap`.

If analyzer runtime option update fails, the node now keeps the old synced version so the coordinator's next `SyncFileResource` retry will execute the sync path again instead of being skipped as already complete.

## Verification

- `GOWORK=/home/sheep/workspace/milvus/.worktrees/fix-fileresource-sync-version/go.work PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/internal/core/output/lib64 go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/fileresource -v`
- `GOWORK=/home/sheep/workspace/milvus/.worktrees/fix-fileresource-sync-version/go.work make static-check`

## Notes

The local worktree needed untracked helper symlinks for existing C++ output and generated migration legacy proto files so Milvus tooling could run from the required `.worktrees/` location. Those files are not included in the commit.
