### PR TITLE
enhance: tighten sealed segment reopen COW lifecycle

### DIFF
--- a/docs/design-docs/design_docs/20260627-segment-reopen-atomic-read-update-cow.md
+++ b/docs/design-docs/design_docs/20260627-segment-reopen-atomic-read-update-cow.md
@@ -240,6 +240,91 @@ The design rule is:
 
 > The published runtime object graph and readiness bitsets must describe the same visible world.
 
+### 4.4 Row Count and Delete Bitmap Capacity
+
+`RuntimeResourceState::row_count` is snapshot-owned runtime state. A prepared
+runtime may populate or verify it while loading fields, and readers consume the
+value from the published runtime snapshot.
+
+The sealed segment delete bitmap has different lifetime semantics: its capacity
+is initialized exactly once during segment bootstrap and is not resized by an
+online runtime update. Resizing it while delete ingestion or readers are active
+would mutate live, non-snapshot state and invalidate the COW publication model.
+
+Therefore:
+
+- online `Reopen` requires the incoming row count to equal the currently
+  published row count
+- a mismatch is rejected before diff computation, IO, or runtime preparation
+- field-load compatibility paths may initialize the delete bitmap when no
+  bootstrap load-info was provided, but subsequent calls only verify the same
+  value
+- any refresh that changes row count must use full segment replacement, which
+  creates a new segment instance and a new delete bitmap
+
+### 4.5 Commit Timestamp Publication
+
+`PublishedSegmentState::commit_ts` is the only source of truth for both readers
+and load preparation. Direct load paths capture it once from the current
+published snapshot, while Reopen paths use the value already carried by their
+staged snapshot. The captured value remains stable for the complete prepare
+operation.
+
+`SetCommitTimestamp()` and `SetLoadInfo()` publish a new state containing the
+new timestamp. They must not first mutate a separate live timestamp member,
+because a prepare or publication failure would otherwise expose a mixed world
+where load preparation and readers observe different commit timestamps.
+
+### 4.6 Text Index Lifecycle and Reopen Contract
+
+A published text index has one of two source identities:
+
+- **Prebuilt**: loaded from `TextIndexStats`; its load identity is the field,
+  version/build ID, scalar-index version, base path, sizes, and ordered file
+  list.
+- **RawBuilt**: built locally from the field column or scalar-index raw data;
+  `SegmentLoadInfo::created_text_indexes_` records that source identity as
+  snapshot-owned bookkeeping.
+
+The schema identity of either source includes the field data type,
+`enable_match`, `enable_analyzer`, and analyzer parameters. Online `Reopen`
+supports only these transitions:
+
+- no text index to Prebuilt
+- no text index to RawBuilt
+- unchanged Prebuilt to unchanged Prebuilt
+- unchanged RawBuilt to unchanged RawBuilt
+- either source to field removal from the schema
+
+The following transitions are rejected during diff validation, before index
+IO or staged runtime mutation begins:
+
+- replacing a Prebuilt load identity
+- Prebuilt to RawBuilt or RawBuilt to Prebuilt
+- removing a RawBuilt index while retaining the field
+- changing text-index schema identity while retaining the field
+
+These transitions require full segment replacement until staged text-index
+replacement is implemented explicitly. This keeps online reopen from silently
+retaining an old runtime index under new metadata or destroying a published
+index before a replacement is ready.
+
+Text-index update serialization belongs to `reopen_mutex_`: full load,
+`Reopen`, and direct `CreateTextIndex` cannot overlap. Within one staged load,
+prebuilt work is keyed by a unique field map and raw-build work by a unique
+field set; parallel commits into the cloned runtime are serialized by
+`StagedStateCommitter`. Consequently, a separate live
+`pending_text_index_fields_` set and its mutex-protected build guard do not
+provide an independent correctness guarantee and are removed.
+
+Both loaded and raw-built text indexes are inserted only into cloned runtime
+state and become visible with the published snapshot. On field removal, the
+entry is erased from the cloned runtime; old snapshots retain the old index by
+shared ownership until their readers finish. The new load-info snapshot also
+prunes both the runtime-only `created_text_indexes_` marker and the proto-backed
+`textstatslogs` entry for the removed field, so a later `Reopen` cannot observe
+stale text-index identity metadata.
+
 ---
 
 ## 5. Reader Model
@@ -270,6 +355,46 @@ With a snapshot-owned runtime graph:
 - old and new readers do not need to share one mutable live-member view
 
 This is one of the main benefits of the COW publication model.
+
+### 5.4 Snapshot-Only Leaf Readers Do Not Need the Inherited Segment Mutex
+
+Once a reader captures one `PublishedSegmentState`, the snapshot owns the
+schema, readiness facts, and runtime resources used by that operation. Holding
+the snapshot keeps the selected columns and indexes alive even if a later
+publication installs a new generation.
+
+The historical shared locks taken by snapshot-only sealed-segment leaf helpers
+did not participate in this publication protocol: runtime writers are
+serialized by `reopen_mutex_` and publish with an atomic shared-pointer swap,
+rather than by taking the inherited segment mutex. Those leaf-reader locks
+therefore had no writer counterpart that could make snapshot capture more
+atomic or extend resource lifetime.
+
+Snapshot-only readers should instead:
+
+- capture one published snapshot, or one runtime pointer derived from it
+- pass that captured generation through nested helpers
+- pin cache cells or retain shared owners for the duration of the operation
+- avoid recapturing schema/runtime when the caller already selected a
+  generation
+
+This migration step applies only to leaf readers implemented by
+`ChunkedSegmentSealedImpl`. It does not change the common
+`SegmentInternalInterface::Search` or `Retrieve` entry-point locks, because
+those methods are also used by Growing segments whose live mutable state still
+depends on the inherited mutex. Separating Growing and Sealed query
+synchronization ownership is deferred to a follow-up change.
+
+Production multi-stage Sealed requests remain generation-consistent through
+the request-level `SegmentReadLease` acquired at the C API boundary. Direct C++
+Search/Retrieve calls that do not acquire such a lease are not made
+concurrency-safe with online publication by this migration step.
+
+Under this scoped rule, removing the leaf-reader shared locks does not weaken
+the COW publication boundary. The remaining inherited locks include the common
+Search/Retrieve entry-point shared locks and the `ClearData()` exclusive lock
+around legacy live state; none of them is the lifetime mechanism for
+snapshot-owned resources.
 
 ---
 
@@ -320,6 +445,13 @@ Drop / replace should also become snapshot-driven:
 - the old snapshot retains ownership of the old resource until no reader still references it
 
 This avoids the fragile pattern of “delete from live member first, then hope readers do not step on it.”
+
+Cancellation of asynchronous cache warmup is a retirement side effect, not a
+prepare action. A scalar index removed or replaced in a cloned runtime is kept
+in a retirement list while the new state is prepared. `CancelWarmup()` is
+called only after publication succeeds and the publication gate has drained
+old readers. If prepare or publication fails, the currently published index is
+left untouched and its warmup is not cancelled.
 
 ---
 

--- a/docs/design-docs/design_docs/20260627-segment-reopen-atomic-read-update-cow.md
+++ b/docs/design-docs/design_docs/20260627-segment-reopen-atomic-read-update-cow.md
@@ -283,8 +283,10 @@ A published text index has one of two source identities:
   version/build ID, scalar-index version, base path, sizes, and ordered file
   list.
 - **RawBuilt**: built locally from the field column or scalar-index raw data;
-  `SegmentLoadInfo::created_text_indexes_` records that source identity as
-  snapshot-owned bookkeeping.
+  `SegmentLoadInfo::created_text_indexes_` records the actual source kind
+  (`FieldData` or `ScalarIndexRawData`) as snapshot-owned bookkeeping. The
+  field/scalar-index load identities remain the authoritative identities of
+  those source resources.
 
 The schema identity of either source includes the field data type,
 `enable_match`, `enable_analyzer`, and analyzer parameters. Online `Reopen`
@@ -294,6 +296,8 @@ supports only these transitions:
 - no text index to RawBuilt
 - unchanged Prebuilt to unchanged Prebuilt
 - unchanged RawBuilt to unchanged RawBuilt
+- RawBuilt to rebuilt RawBuilt when its field data, scalar-index source, or
+  analyzer/schema identity changes
 - either source to field removal from the schema
 
 The following transitions are rejected during diff validation, before index
@@ -302,12 +306,23 @@ IO or staged runtime mutation begins:
 - replacing a Prebuilt load identity
 - Prebuilt to RawBuilt or RawBuilt to Prebuilt
 - removing a RawBuilt index while retaining the field
-- changing text-index schema identity while retaining the field
 
-These transitions require full segment replacement until staged text-index
-replacement is implemented explicitly. This keeps online reopen from silently
-retaining an old runtime index under new metadata or destroying a published
-index before a replacement is ready.
+These remaining transitions require full segment replacement. RawBuilt
+replacement, however, is prepared online as a derived-resource rebuild:
+
+1. compute field/index/schema dependency changes from complete load identities
+   (including build ID, version, store-path version, parameters, and ordered
+   files rather than only `index_id`);
+2. load or drop the target field/scalar-index sources in cloned runtime;
+3. build a replacement holder from that staged source without mutating live
+   runtime;
+4. install the holder and its actual source-kind marker in the cloned state;
+5. publish data, text index, and metadata atomically.
+
+Build failure or cancellation discards the cloned generation, leaving the old
+field data, marker, and query results published. Each local Tantivy build uses
+a UUID-scoped path so mmap-backed old and new holders can coexist while old
+readers retain their snapshot.
 
 Text-index update serialization belongs to `reopen_mutex_`: full load,
 `Reopen`, and direct `CreateTextIndex` cannot overlap. Within one staged load,
@@ -323,7 +338,11 @@ entry is erased from the cloned runtime; old snapshots retain the old index by
 shared ownership until their readers finish. The new load-info snapshot also
 prunes both the runtime-only `created_text_indexes_` marker and the proto-backed
 `textstatslogs` entry for the removed field, so a later `Reopen` cannot observe
-stale text-index identity metadata.
+stale text-index identity metadata. Before final publication, the segment
+validates the bidirectional invariant: every raw holder has exactly one raw
+marker, every prebuilt cache slot has exactly one `TextIndexStats` entry, no
+field has both identities, and no dropped-schema field retains text-index
+runtime or metadata.
 
 ---
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -13,6 +13,8 @@
 #include "segcore/default_fs.h"
 
 #include <cxxabi.h>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <fmt/core.h>
 #include <folly/ScopeGuard.h>
 #include <folly/Try.h>
@@ -1358,6 +1360,82 @@ ChunkedSegmentSealedImpl::NormalizePublishedState(
     SetSystemFieldReadyInState(state, state.load_info.get());
 }
 
+void
+ChunkedSegmentSealedImpl::ValidateTextIndexState(
+    const PublishedSegmentState& state) const {
+    if (state.schema == nullptr || state.load_info == nullptr ||
+        state.runtime == nullptr) {
+        bool has_runtime_text_index =
+            state.runtime != nullptr && !state.runtime->text_indexes.empty();
+        bool has_text_index_metadata =
+            state.load_info != nullptr &&
+            (!state.load_info->GetCreatedTextIndexes().empty() ||
+             !state.load_info->GetTextStatsLogs().empty());
+        AssertInfo(!has_runtime_text_index && !has_text_index_metadata,
+                   "published text-index state requires schema, load info, "
+                   "and runtime resources");
+        return;
+    }
+
+    const auto& markers = state.load_info->GetCreatedTextIndexes();
+    const auto& stats = state.load_info->GetTextStatsLogs();
+    const auto& indexes = state.runtime->text_indexes;
+
+    for (const auto& [field_id, _] : markers) {
+        AssertInfo(field_exists_in_schema(state.schema, field_id),
+                   "raw-built text index marker references dropped field {}",
+                   field_id.get());
+        AssertInfo(stats.find(field_id.get()) == stats.end(),
+                   "text index field {} is both raw-built and pre-built",
+                   field_id.get());
+        auto runtime_it = indexes.find(field_id);
+        AssertInfo(runtime_it != indexes.end() &&
+                       std::holds_alternative<
+                           std::shared_ptr<index::TextMatchIndexHolder>>(
+                           runtime_it->second) &&
+                       std::get<std::shared_ptr<index::TextMatchIndexHolder>>(
+                           runtime_it->second) != nullptr,
+                   "raw-built text index marker for field {} has no raw "
+                   "runtime holder",
+                   field_id.get());
+    }
+
+    for (const auto& [field_id_value, _] : stats) {
+        auto field_id = FieldId(field_id_value);
+        AssertInfo(field_exists_in_schema(state.schema, field_id),
+                   "pre-built text index metadata references dropped field {}",
+                   field_id_value);
+        AssertInfo(markers.find(field_id) == markers.end(),
+                   "text index field {} is both pre-built and raw-built",
+                   field_id_value);
+        auto runtime_it = indexes.find(field_id);
+        using PrebuiltTextIndexSlot =
+            std::shared_ptr<cachinglayer::CacheSlot<index::TextMatchIndex>>;
+        AssertInfo(
+            runtime_it != indexes.end() &&
+                std::holds_alternative<PrebuiltTextIndexSlot>(
+                    runtime_it->second) &&
+                std::get<PrebuiltTextIndexSlot>(runtime_it->second) != nullptr,
+            "pre-built text index metadata for field {} has no cache "
+            "slot",
+            field_id_value);
+    }
+
+    for (const auto& [field_id, runtime_index] : indexes) {
+        AssertInfo(field_exists_in_schema(state.schema, field_id),
+                   "runtime text index references dropped field {}",
+                   field_id.get());
+        bool raw = std::holds_alternative<
+            std::shared_ptr<index::TextMatchIndexHolder>>(runtime_index);
+        AssertInfo(raw ? markers.find(field_id) != markers.end()
+                       : stats.find(field_id.get()) != stats.end(),
+                   "runtime {} text index for field {} has no matching "
+                   "published metadata",
+                   raw ? "raw-built" : "pre-built",
+                   field_id.get());
+    }
+}
+
 std::shared_ptr<ChunkedSegmentSealedImpl::PublishedSegmentState>
 ChunkedSegmentSealedImpl::BuildNextPublishedState(
     const std::shared_ptr<const PublishedSegmentState>& current,
@@ -1444,9 +1522,11 @@ ChunkedSegmentSealedImpl::CloneLoadInfoWithDefaultFilled(
 
 std::shared_ptr<const SegmentLoadInfo>
 ChunkedSegmentSealedImpl::CloneLoadInfoWithTextIndexCreated(
-    const std::shared_ptr<const SegmentLoadInfo>& current, FieldId field_id) {
+    const std::shared_ptr<const SegmentLoadInfo>& current,
+    FieldId field_id,
+    RawTextIndexSource source) {
     auto load_info_copy = std::make_shared<SegmentLoadInfo>(*current);
-    load_info_copy->SetTextIndexCreated(field_id);
+    load_info_copy->SetTextIndexCreated(field_id, source);
     return std::const_pointer_cast<const SegmentLoadInfo>(load_info_copy);
 }
 
@@ -2291,7 +2371,10 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
         runtime->timestamps = std::move(timestamps);
         runtime->timestamp_index = std::make_shared<const TimestampIndex>();
         runtime->timestamp_index_slot.reset();
-        SetRuntimeRowCount(*runtime, 0);
+        // This is an explicit staged-runtime clear, not a field-data load.
+        // Non-zero load paths still go through SetRuntimeRowCount and must
+        // preserve the existing row-count invariant.
+        runtime->row_count = 0;
         return;
     }
 
@@ -5274,33 +5357,24 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
         field_id, CaptureSchemaSnapshot(), op_ctx, true, nullptr);
 }
 
-void
-ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
+ChunkedSegmentSealedImpl::RawTextIndexBuildResult
+ChunkedSegmentSealedImpl::BuildRawTextIndexWithSchema(
     FieldId field_id,
     const SchemaPtr& schema_snapshot,
     milvus::OpContext* op_ctx,
-    bool publish_marker,
-    RuntimeResourceState* runtime) {
+    const RuntimeResourceState& runtime) {
     CheckCancellation(op_ctx,
                       id_,
                       field_id.get(),
                       "ChunkedSegmentSealedImpl::CreateTextIndex()");
 
-    std::shared_ptr<RuntimeResourceState> owned_runtime;
-    auto* target_runtime = runtime;
-    if (target_runtime == nullptr) {
-        owned_runtime = CloneMutableRuntimeResourceState();
-        target_runtime = owned_runtime.get();
-    }
-    AssertInfo(target_runtime->text_indexes.find(field_id) ==
-                   target_runtime->text_indexes.end(),
-               "text index for field {} already exists, refusing to rebuild",
-               field_id.get());
-
     const auto& field_meta = schema_snapshot->operator[](field_id);
     auto& cfg = storage::MmapManager::GetInstance().GetMmapConfig();
     std::unique_ptr<index::TextMatchIndex> index;
-    std::string unique_id = GetUniqueFieldId(field_meta.get_id().get());
+    auto build_uuid = boost::uuids::random_generator()();
+    auto unique_id = fmt::format("{}_{}",
+                                 GetUniqueFieldId(field_meta.get_id().get()),
+                                 boost::uuids::to_string(build_uuid));
     if (!cfg.GetScalarIndexEnableMmap()) {
         // build text index in ram.
         // Sealed interim index: no background merge — finish() ends with an
@@ -5326,9 +5400,9 @@ ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
 
     {
         // build
-        auto it = target_runtime->fields.find(field_id);
+        auto it = runtime.fields.find(field_id);
         std::shared_ptr<ChunkedColumnInterface> column =
-            it != target_runtime->fields.end() ? it->second : nullptr;
+            it != runtime.fields.end() ? it->second : nullptr;
         if (column) {
             // Check for cancellation before bulk operation
             CheckCancellation(op_ctx,
@@ -5336,7 +5410,7 @@ ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
                               field_id.get(),
                               "ChunkedSegmentSealedImpl::CreateTextIndex()");
             if (field_meta.get_data_type() == DataType::TEXT) {
-                const auto* path_map = &target_runtime->text_lob_paths;
+                const auto* path_map = &runtime.text_lob_paths;
                 auto it = path_map->find(field_id);
                 AssertInfo(it != path_map->end(),
                            "TEXT field {} has no LOB path. TEXT type "
@@ -5411,12 +5485,10 @@ ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
                     });
             }
         } else {  // fetch raw data from index.
-            auto field_index_iter =
-                target_runtime->scalar_indexings.find(field_id);
-            AssertInfo(
-                field_index_iter != target_runtime->scalar_indexings.end(),
-                "failed to create text index, neither raw data nor "
-                "index are found");
+            auto field_index_iter = runtime.scalar_indexings.find(field_id);
+            AssertInfo(field_index_iter != runtime.scalar_indexings.end(),
+                       "failed to create text index, neither raw data nor "
+                       "index are found");
             auto accessor =
                 SemiInlineGet(field_index_iter->second->PinCells(op_ctx, {0}));
             auto ptr = accessor->get_cell_of(0);
@@ -5462,20 +5534,11 @@ ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
                       id_,
                       field_id.get(),
                       "ChunkedSegmentSealedImpl::CreateTextIndex()");
-    target_runtime->text_indexes.emplace(field_id,
-                                         std::move(text_index_holder));
-
-    if (owned_runtime != nullptr) {
-        auto current = CapturePublishedState();
-        auto next = ClonePublishedState(current);
-        next->runtime = ToConstRuntimeState(std::move(owned_runtime));
-        if (publish_marker) {
-            next->load_info =
-                CloneLoadInfoWithTextIndexCreated(next->load_info, field_id);
-        }
-        NormalizePublishedState(*next);
-        PublishStateOnline(std::move(next));
-    }
+    return RawTextIndexBuildResult{
+        std::move(text_index_holder),
+        runtime.fields.count(field_id) > 0
+            ? RawTextIndexSource::FieldData
+            : RawTextIndexSource::ScalarIndexRawData};
 }
 
 void
@@ -5483,9 +5546,58 @@ ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
     FieldId field_id,
     const SchemaPtr& schema_snapshot,
     milvus::OpContext* op_ctx,
+    bool publish_marker,
+    RuntimeResourceState* runtime) {
+    std::shared_ptr<RuntimeResourceState> owned_runtime;
+    auto* target_runtime = runtime;
+    if (target_runtime == nullptr) {
+        owned_runtime = CloneMutableRuntimeResourceState();
+        target_runtime = owned_runtime.get();
+    }
+    AssertInfo(target_runtime->text_indexes.find(field_id) ==
+                   target_runtime->text_indexes.end(),
+               "text index for field {} already exists, refusing to rebuild",
+               field_id.get());
+
+    auto result = BuildRawTextIndexWithSchema(
+        field_id, schema_snapshot, op_ctx, *target_runtime);
+    auto source = result.source;
+    target_runtime->text_indexes.emplace(field_id, std::move(result.index));
+
+    if (owned_runtime != nullptr) {
+        auto current = CapturePublishedState();
+        auto next = ClonePublishedState(current);
+        next->runtime = ToConstRuntimeState(std::move(owned_runtime));
+        if (publish_marker) {
+            next->load_info = CloneLoadInfoWithTextIndexCreated(
+                next->load_info, field_id, source);
+        }
+        NormalizePublishedState(*next);
+        ValidateTextIndexState(*next);
+        PublishStateOnline(std::move(next));
+    }
+}
+
+RawTextIndexSource
+ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
+    FieldId field_id,
+    const SchemaPtr& schema_snapshot,
+    milvus::OpContext* op_ctx,
     StagedStateCommitter& committer) {
-    CreateTextIndexWithSchema(
-        field_id, schema_snapshot, op_ctx, false, committer.runtime());
+    auto* runtime = committer.runtime();
+    AssertInfo(
+        runtime->text_indexes.find(field_id) == runtime->text_indexes.end(),
+        "text index for field {} already exists, refusing to create",
+        field_id.get());
+    auto result = BuildRawTextIndexWithSchema(
+        field_id, schema_snapshot, op_ctx, *runtime);
+    auto source = result.source;
+    committer.Commit([field_id, index = std::move(result.index)](
+                         RuntimeResourceState& staged_runtime,
+                         PublishedSegmentState&) mutable {
+        staged_runtime.text_indexes.emplace(field_id, std::move(index));
+    });
+    return source;
 }
 
 void
@@ -5513,8 +5625,10 @@ ChunkedSegmentSealedImpl::RecordDefaultFieldsFilled(
 
 void
 ChunkedSegmentSealedImpl::RecordTextIndexCreated(
-    SegmentLoadInfo& segment_load_info, FieldId field_id) {
-    segment_load_info.SetTextIndexCreated(field_id);
+    SegmentLoadInfo& segment_load_info,
+    FieldId field_id,
+    RawTextIndexSource source) {
+    segment_load_info.SetTextIndexCreated(field_id, source);
 }
 ChunkedSegmentSealedImpl::TextIndexVariant
 ChunkedSegmentSealedImpl::BuildTextIndexFromFiles(
@@ -7321,11 +7435,66 @@ ChunkedSegmentSealedImpl::PrepareLoadDiffForReopen(
     }
 
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
+    if (!diff.text_indexes_to_rebuild.empty()) {
+        for (const auto& [field_id, _] : diff.text_indexes_to_rebuild) {
+            CheckCancellation(op_ctx,
+                              id_,
+                              field_id.get(),
+                              "ChunkedSegmentSealedImpl::RebuildTextIndex()");
+
+            // Make the cloned runtime describe the target source set before
+            // choosing whether to rebuild from a field column or scalar-index
+            // raw data. Pure drops normally happen in FinalizeLoadDiff, which
+            // is too late for source selection here.
+            if (diff.field_data_to_drop.erase(field_id) > 0) {
+                committer.Commit([&](RuntimeResourceState& runtime,
+                                     PublishedSegmentState& staged_state) {
+                    bool drop_binlog_index = get_bit_if_present(
+                        staged_state.binlog_index_bitset, field_id);
+                    DropFieldData(field_id, schema_snapshot, &runtime);
+                    if (drop_binlog_index) {
+                        committer.StageVectorIndexDropLocked(field_id);
+                    }
+                    DropFieldFromState(staged_state, field_id);
+                });
+            }
+            if (diff.indexes_to_drop.count(field_id) > 0 &&
+                diff.indexes_to_replace.count(field_id) == 0 &&
+                diff.indexes_to_load.count(field_id) == 0) {
+                committer.Commit([&](RuntimeResourceState& runtime,
+                                     PublishedSegmentState& staged_state) {
+                    committer.RetireCacheIndexingLocked(
+                        DropIndex(field_id, schema_snapshot, &runtime));
+                    committer.StageVectorIndexDropLocked(field_id);
+                    DropIndexFromState(staged_state, field_id);
+                });
+                diff.indexes_to_drop.erase(field_id);
+            }
+
+            auto result = BuildRawTextIndexWithSchema(
+                field_id, schema_snapshot, op_ctx, *committer.runtime());
+            auto source = result.source;
+            committer.Commit([field_id, index = std::move(result.index)](
+                                 RuntimeResourceState& runtime,
+                                 PublishedSegmentState&) mutable {
+                runtime.text_indexes.insert_or_assign(field_id,
+                                                      std::move(index));
+            });
+            RecordTextIndexCreated(segment_load_info, field_id, source);
+            committer.Commit([&](RuntimeResourceState&,
+                                 PublishedSegmentState& staged_state) {
+                staged_state.load_info =
+                    std::make_shared<const SegmentLoadInfo>(segment_load_info);
+            });
+        }
+    }
+
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
     if (!diff.text_indexes_to_create.empty()) {
         for (const auto& field_id : diff.text_indexes_to_create) {
-            CreateTextIndexWithSchema(
+            auto source = CreateTextIndexWithSchema(
                 field_id, schema_snapshot, op_ctx, committer);
-            RecordTextIndexCreated(segment_load_info, field_id);
+            RecordTextIndexCreated(segment_load_info, field_id, source);
             committer.Commit([&](RuntimeResourceState&,
                                  PublishedSegmentState& staged_state) {
                 staged_state.load_info =
@@ -7533,17 +7702,15 @@ ChunkedSegmentSealedImpl::Reopen(
 
     SegmentLoadInfo current_mutable(*current->load_info);
     SegmentLoadInfo new_local(new_load_info, target_schema);
-    AssertInfo(
-        current->load_info->GetNumOfRows() == new_local.GetNumOfRows(),
-        "online reopen cannot change row count for segment {}: current {}, "
-        "incoming {}; use full segment replacement instead",
-        id_,
-        current->load_info->GetNumOfRows(),
-        new_local.GetNumOfRows());
+    // Construction filters derived caches, while reopen normalization also
+    // removes proto-backed state for fields dropped from the target schema.
+    new_local.ReplaceSchemaForReopen(target_schema);
+    new_local.ValidateReopenRowCount(current->load_info->GetNumOfRows());
     new_local.InheritCachedColumnGroupsFrom(*current->load_info);
-    for (auto fid : current->load_info->GetCreatedTextIndexes()) {
+    for (const auto& [fid, meta] :
+         current->load_info->GetCreatedTextIndexes()) {
         if (field_exists_in_schema(target_schema, fid)) {
-            new_local.SetTextIndexCreated(fid);
+            new_local.SetTextIndexCreated(fid, meta.source);
         }
     }
 
@@ -8831,8 +8998,9 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
                                  snapshot->schema);
     mutable_copy.SetFieldsFilledWithDefault(
         snapshot->load_info->GetFieldsFilledWithDefault());
-    for (auto fid : snapshot->load_info->GetCreatedTextIndexes()) {
-        mutable_copy.SetTextIndexCreated(fid);
+    for (const auto& [fid, meta] :
+         snapshot->load_info->GetCreatedTextIndexes()) {
+        mutable_copy.SetTextIndexCreated(fid, meta.source);
     }
     auto diff = mutable_copy.GetLoadDiff();
     LOG_WARN("Load segment {} with diff {}", id_, diff.ToString());

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1064,6 +1064,7 @@ ChunkedSegmentSealedImpl::BuildPublishedState(
     state->load_info = load_info;
     state->runtime = BuildRuntimeResourceState();
     state->commit_ts = commit_ts;
+    state->phase = PublishedStatePhase::Bootstrap;
     NormalizePublishedState(*state);
     return state;
 }
@@ -1238,6 +1239,7 @@ ChunkedSegmentSealedImpl::ClonePublishedState(
     state->index_ready_bitset = current->index_ready_bitset.clone();
     state->binlog_index_bitset = current->binlog_index_bitset.clone();
     state->index_has_raw_data = current->index_has_raw_data;
+    state->phase = current->phase;
     return state;
 }
 
@@ -1267,6 +1269,9 @@ ChunkedSegmentSealedImpl::ApplyDeltaToState(PublishedSegmentState& state,
     if (delta.published_index_has_raw_data.has_value()) {
         state.published_index_has_raw_data =
             *delta.published_index_has_raw_data;
+    }
+    if (delta.phase.has_value()) {
+        state.phase = *delta.phase;
     }
 }
 
@@ -1436,13 +1441,164 @@ ChunkedSegmentSealedImpl::ValidateTextIndexState(
     }
 }
 
+void
+ChunkedSegmentSealedImpl::ValidatePublishedState(
+    const PublishedSegmentState& state) const {
+    AssertInfo(state.schema != nullptr,
+               "published segment {} state has no schema",
+               id_);
+    AssertInfo(state.load_info != nullptr,
+               "published segment {} state has no load info",
+               id_);
+    AssertInfo(state.load_info->GetSchema() != nullptr,
+               "published segment {} load info has no projected schema",
+               id_);
+    AssertInfo(state.load_info->GetSchema() == state.schema,
+               "published segment {} schema/load-info do not share the same "
+               "schema snapshot",
+               id_);
+    AssertInfo(state.load_info->GetSchema()->get_schema_version() ==
+                   state.schema->get_schema_version(),
+               "published segment {} schema/load-info version mismatch: {} "
+               "vs {}",
+               id_,
+               state.schema->get_schema_version(),
+               state.load_info->GetSchema()->get_schema_version());
+    state.load_info->ValidateSchemaProjection();
+
+    if (state.phase == PublishedStatePhase::Bootstrap) {
+        return;
+    }
+
+    AssertInfo(state.runtime != nullptr,
+               "serving segment {} state has no runtime resources",
+               id_);
+    AssertInfo(state.runtime->row_count == state.load_info->GetNumOfRows(),
+               "published segment {} row count mismatch: runtime {}, load "
+               "info {}",
+               id_,
+               state.runtime->row_count,
+               state.load_info->GetNumOfRows());
+
+    auto validate_runtime_field = [&](FieldId field_id, std::string_view kind) {
+        AssertInfo(field_exists_in_schema(state.schema, field_id),
+                   "published {} references dropped field {} for segment {}",
+                   kind,
+                   field_id.get(),
+                   id_);
+    };
+    for (const auto& [field_id, _] : state.runtime->fields) {
+        validate_runtime_field(field_id, "field data");
+    }
+    for (const auto& [field_id, _] : state.runtime->array_offsets_map) {
+        validate_runtime_field(field_id, "array-offset metadata");
+    }
+    for (const auto& [field_id, _] : state.runtime->scalar_indexings) {
+        validate_runtime_field(field_id, "scalar index");
+    }
+    for (const auto& [field_id, _] : state.runtime->vector_indexings) {
+        validate_runtime_field(field_id, "vector index");
+    }
+    for (const auto& [field_id, _] : state.runtime->vec_binlog_config) {
+        validate_runtime_field(field_id, "vector binlog config");
+    }
+    for (const auto& field_id : state.runtime->ngram_fields) {
+        validate_runtime_field(field_id, "ngram index");
+    }
+    for (const auto& [field_id, _] : state.runtime->ngram_indexings) {
+        validate_runtime_field(field_id, "JSON ngram index");
+    }
+    for (const auto& [field_id, _] : state.runtime->text_lob_paths) {
+        validate_runtime_field(field_id, "TEXT LOB path");
+    }
+    for (const auto& [field_id, _] : state.runtime->json_stats) {
+        validate_runtime_field(field_id, "JSON key stats runtime");
+        AssertInfo(state.load_info->HasJsonKeyStatsLog(field_id.get()),
+                   "published JSON key stats runtime for field {} has no "
+                   "matching metadata in segment {}",
+                   field_id.get(),
+                   id_);
+    }
+    for (const auto& index : state.runtime->json_indices) {
+        validate_runtime_field(index.field_id, "JSON index");
+    }
+    for (const auto& field_id : state.runtime->mmap_field_ids) {
+        validate_runtime_field(field_id, "mmap field marker");
+    }
+    for (const auto& [field_id, _] : state.runtime->variable_fields_avg_size) {
+        validate_runtime_field(field_id, "variable-field size metadata");
+    }
+    std::unordered_set<std::string> schema_structs;
+    for (const auto& [_, field_meta] : state.schema->get_fields()) {
+        if (auto struct_name = GetStructNameForArrayField(field_meta);
+            struct_name.has_value()) {
+            schema_structs.insert(*struct_name);
+        }
+    }
+    for (const auto& [struct_name, _] :
+         state.runtime->struct_to_array_offsets) {
+        AssertInfo(schema_structs.count(struct_name) > 0,
+                   "published array-offset metadata references dropped "
+                   "struct {} for segment {}",
+                   struct_name,
+                   id_);
+    }
+
+    auto runtime_index_ready = [&](FieldId field_id) {
+        return state.runtime->scalar_indexings.count(field_id) > 0 ||
+               state.runtime->vector_indexings.count(field_id) > 0 ||
+               state.runtime->ngram_fields.count(field_id) > 0 ||
+               RuntimeJsonNgramIndexReady(*state.runtime, field_id);
+    };
+    for (size_t i = 0; i < state.index_ready_bitset.size(); ++i) {
+        if (!state.index_ready_bitset[i]) {
+            continue;
+        }
+        auto field_id = FieldId(START_USER_FIELDID + static_cast<int64_t>(i));
+        AssertInfo(runtime_index_ready(field_id),
+                   "published index-ready bit for field {} has no runtime "
+                   "index in segment {}",
+                   field_id.get(),
+                   id_);
+    }
+    for (size_t i = 0; i < state.binlog_index_bitset.size(); ++i) {
+        if (!state.binlog_index_bitset[i]) {
+            continue;
+        }
+        auto field_id = FieldId(START_USER_FIELDID + static_cast<int64_t>(i));
+        AssertInfo(state.runtime->vector_indexings.count(field_id) > 0,
+                   "published binlog-index-ready bit for field {} has no "
+                   "runtime vector index in segment {}",
+                   field_id.get(),
+                   id_);
+    }
+    for (size_t i = 0; i < state.field_data_ready_bitset.size(); ++i) {
+        if (!state.field_data_ready_bitset[i]) {
+            continue;
+        }
+        auto field_id = FieldId(START_USER_FIELDID + static_cast<int64_t>(i));
+        auto it = state.runtime->fields.find(field_id);
+        AssertInfo(it != state.runtime->fields.end() && it->second != nullptr,
+                   "published field-data-ready bit for field {} has no runtime "
+                   "column in segment {}",
+                   field_id.get(),
+                   id_);
+    }
+
+    ValidateTextIndexState(state);
+}
+
 std::shared_ptr<ChunkedSegmentSealedImpl::PublishedSegmentState>
-ChunkedSegmentSealedImpl::BuildNextPublishedState(
+ChunkedSegmentSealedImpl::PrepareTargetState(
     const std::shared_ptr<const PublishedSegmentState>& current,
     const StateDelta& delta) const {
     auto next = ClonePublishedState(current);
     ApplyDeltaToState(*next, delta);
     NormalizePublishedState(*next);
+    // Validate before returning so callers cannot perform retirement or other
+    // publication side effects for an invalid target state. PublishState()
+    // validates again immediately before the atomic store as the final gate.
+    ValidatePublishedState(*next);
     return next;
 }
 
@@ -1649,6 +1805,7 @@ ChunkedSegmentSealedImpl::DropIndexFromState(PublishedSegmentState& state,
 
 void
 ChunkedSegmentSealedImpl::ClearState(PublishedSegmentState& state) {
+    state.phase = PublishedStatePhase::Bootstrap;
     state.system_field_ready = false;
     state.runtime = nullptr;
     state.published_index_ready_bitset.reset();
@@ -1664,7 +1821,7 @@ void
 ChunkedSegmentSealedImpl::PublishReopenState(
     const std::shared_ptr<const PublishedSegmentState>& current,
     const StateDelta& delta) {
-    PublishStateOnline(BuildNextPublishedState(current, delta));
+    PublishStateOnline(PrepareTargetState(current, delta));
 }
 
 void
@@ -1942,7 +2099,7 @@ ChunkedSegmentSealedImpl::PublishRuntimeStateLocked(
         return;
     }
     auto current = CapturePublishedState();
-    PublishStateOnline(BuildNextPublishedState(
+    PublishStateOnline(PrepareTargetState(
         current,
         MakeStateDelta(
             current->schema, current->load_info, runtime, current->commit_ts)));
@@ -2009,7 +2166,7 @@ ChunkedSegmentSealedImpl::RefreshPublishedLoadInfoLocked(
     const std::shared_ptr<const SegmentLoadInfo>& load_info,
     Timestamp commit_ts) {
     auto current = CapturePublishedState();
-    PublishStateOnline(BuildNextPublishedState(
+    PublishStateOnline(PrepareTargetState(
         current, MakeStateDelta(current->schema, load_info, commit_ts)));
 }
 
@@ -2017,10 +2174,12 @@ void
 ChunkedSegmentSealedImpl::RefreshPublishedSchemaLocked(
     const SchemaPtr& schema_snapshot) {
     auto current = CapturePublishedState();
-    PublishStateOnline(BuildNextPublishedState(
+    SegmentLoadInfo projected(*current->load_info);
+    projected.ProjectToSchema(schema_snapshot);
+    auto load_info = std::make_shared<const SegmentLoadInfo>(projected);
+    PublishStateOnline(PrepareTargetState(
         current,
-        MakeStateDelta(
-            schema_snapshot, current->load_info, current->commit_ts)));
+        MakeStateDelta(schema_snapshot, load_info, current->commit_ts)));
 }
 
 void
@@ -2029,7 +2188,7 @@ ChunkedSegmentSealedImpl::RefreshPublishedStateLocked(
     const std::shared_ptr<const SegmentLoadInfo>& load_info,
     Timestamp commit_ts) {
     auto current = CapturePublishedState();
-    PublishStateOnline(BuildNextPublishedState(
+    PublishStateOnline(PrepareTargetState(
         current, MakeStateDelta(schema_snapshot, load_info, commit_ts)));
 }
 
@@ -2039,9 +2198,11 @@ ChunkedSegmentSealedImpl::PrepareMutableStateForPublish(
     Timestamp commit_ts,
     std::shared_ptr<PublishedSegmentState>& next) const {
     auto current = CapturePublishedState();
-    next = BuildNextPublishedState(
-        current,
-        MakeStateDelta(schema_snapshot, current->load_info, commit_ts));
+    SegmentLoadInfo projected(*current->load_info);
+    projected.ProjectToSchema(schema_snapshot);
+    auto load_info = std::make_shared<const SegmentLoadInfo>(projected);
+    next = PrepareTargetState(
+        current, MakeStateDelta(schema_snapshot, load_info, commit_ts));
 }
 
 void
@@ -2052,6 +2213,7 @@ ChunkedSegmentSealedImpl::PublishState(
         return;
     }
     AssertInfo(publish_lease.valid(), "online publication requires a lease");
+    ValidatePublishedState(*state);
     std::atomic_store(&published_state_, state);
     publish_lease.MarkPublished();
 }
@@ -4894,8 +5056,9 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
           segment_id) {
     auto load_info = std::make_shared<const SegmentLoadInfo>(
         milvus::proto::segcore::SegmentLoadInfo(), schema);
-    std::atomic_store(&published_state_,
-                      BuildPublishedState(schema, load_info, 0));
+    auto initial_state = BuildPublishedState(schema, load_info, 0);
+    ValidatePublishedState(*initial_state);
+    std::atomic_store(&published_state_, std::move(initial_state));
 }
 
 ChunkedSegmentSealedImpl::~ChunkedSegmentSealedImpl() {
@@ -7597,6 +7760,29 @@ ChunkedSegmentSealedImpl::FinalizeLoadDiffForReopen(
                     ++it;
                 }
             }
+            for (auto it = runtime.text_lob_paths.begin();
+                 it != runtime.text_lob_paths.end();) {
+                if (!field_exists_in_schema(schema_snapshot, it->first)) {
+                    it = runtime.text_lob_paths.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            std::unordered_set<std::string> schema_structs;
+            for (const auto& [_, field_meta] : schema_snapshot->get_fields()) {
+                if (auto struct_name = GetStructNameForArrayField(field_meta);
+                    struct_name.has_value()) {
+                    schema_structs.insert(*struct_name);
+                }
+            }
+            for (auto it = runtime.struct_to_array_offsets.begin();
+                 it != runtime.struct_to_array_offsets.end();) {
+                if (schema_structs.count(it->first) == 0) {
+                    it = runtime.struct_to_array_offsets.erase(it);
+                } else {
+                    ++it;
+                }
+            }
         });
 }
 
@@ -7632,7 +7818,7 @@ ChunkedSegmentSealedImpl::ReopenSchemaLocked(milvus::OpContext* op_ctx,
 
     SegmentLoadInfo current_mutable(*current->load_info);
     SegmentLoadInfo new_local(*current->load_info);
-    new_local.ReplaceSchemaForReopen(sch);
+    new_local.ProjectToSchema(sch);
 
     auto diff = current_mutable.ComputeDiff(new_local);
     new_local.SetFieldsFilledWithDefault(
@@ -7702,9 +7888,7 @@ ChunkedSegmentSealedImpl::Reopen(
 
     SegmentLoadInfo current_mutable(*current->load_info);
     SegmentLoadInfo new_local(new_load_info, target_schema);
-    // Construction filters derived caches, while reopen normalization also
-    // removes proto-backed state for fields dropped from the target schema.
-    new_local.ReplaceSchemaForReopen(target_schema);
+    new_local.ProjectToSchema(target_schema);
     new_local.ValidateReopenRowCount(current->load_info->GetNumOfRows());
     new_local.InheritCachedColumnGroupsFrom(*current->load_info);
     for (const auto& [fid, meta] :
@@ -7743,6 +7927,7 @@ ChunkedSegmentSealedImpl::Reopen(
                                 published,
                                 ToConstRuntimeState(std::move(next_runtime)),
                                 current->commit_ts);
+    delta.phase = PublishedStatePhase::Serving;
     delta.published_index_ready_bitset =
         staged->published_index_ready_bitset.clone();
     delta.published_binlog_index_ready_bitset =
@@ -7778,6 +7963,7 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
                                 published,
                                 ToConstRuntimeState(std::move(next_runtime)),
                                 current->commit_ts);
+    delta.phase = PublishedStatePhase::Serving;
     delta.published_index_ready_bitset =
         staged->published_index_ready_bitset.clone();
     delta.published_binlog_index_ready_bitset =
@@ -8141,12 +8327,15 @@ ChunkedSegmentSealedImpl::SetLoadInfo(
         static_cast<milvus::Timestamp>(load_info.commit_timestamp());
     // Do not parse manifest here: Load() must be able to observe a
     // pre-cancelled OpContext before any storage/manifest IO happens.
-    auto published = std::make_shared<const SegmentLoadInfo>(
-        std::move(load_info), schema_snapshot);
-    PublishStateOnline(BuildNextPublishedState(
-        current,
-        MakeStateDelta(
-            schema_snapshot, published, static_cast<Timestamp>(commit_ts))));
+    auto projected = std::make_shared<SegmentLoadInfo>(std::move(load_info),
+                                                       schema_snapshot);
+    projected->ProjectToSchema(schema_snapshot);
+    auto published =
+        std::const_pointer_cast<const SegmentLoadInfo>(std::move(projected));
+    auto delta = MakeStateDelta(
+        schema_snapshot, published, static_cast<Timestamp>(commit_ts));
+    delta.phase = PublishedStatePhase::Bootstrap;
+    PublishStateOnline(PrepareTargetState(current, delta));
     LOG_INFO(
         "SetLoadInfo for segment {}, num_rows: {}, index count: {}, "
         "storage_version: {}, use_take_for_output: {}, commit_ts: {}",
@@ -8996,6 +9185,7 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
 
     SegmentLoadInfo mutable_copy(snapshot->load_info->GetProto(),
                                  snapshot->schema);
+    mutable_copy.ProjectToSchema(snapshot->schema);
     mutable_copy.SetFieldsFilledWithDefault(
         snapshot->load_info->GetFieldsFilledWithDefault());
     for (const auto& [fid, meta] :

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -234,15 +234,17 @@ cancel_warmup(const index::CacheIndexBasePtr& index) {
     }
 }
 
-static inline void
-cancel_and_erase_scalar_index(
+static inline index::CacheIndexBasePtr
+erase_scalar_index(
     std::unordered_map<FieldId, index::CacheIndexBasePtr>& scalar_indexings,
     FieldId field_id) {
     if (auto it = scalar_indexings.find(field_id);
         it != scalar_indexings.end()) {
-        cancel_warmup(it->second);
+        auto retired = std::move(it->second);
         scalar_indexings.erase(it);
+        return retired;
     }
+    return nullptr;
 }
 
 PinWrapper<const storagev2translator::TimestampIndexCell*>
@@ -714,7 +716,10 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
                                           RuntimeResourceState* runtime,
                                           PublishedSegmentState* staged_state,
                                           StagedStateCommitter* committer) {
-    // NOTE: lock only when data is ready to avoid starvation
+    // Direct updates are serialized by reopen_mutex_; staged updates are
+    // serialized by StagedStateCommitter. Snapshot-owned leaf accessors use
+    // immutable runtime snapshots for lifetime safety. The common
+    // Search/Retrieve entrypoint locks remain unchanged for now.
     auto field_id = FieldId(info.field_id);
     auto snapshot = CapturePublishedState();
     auto& field_meta = schema_snapshot->operator[](field_id);
@@ -732,7 +737,9 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
         }
         if (committer != nullptr) {
             committer->RetireCacheIndexingLocked(std::move(indexing));
-        } else if (owned_runtime != nullptr) {
+        } else {
+            AssertInfo(owned_runtime != nullptr,
+                       "scalar index retirement requires a publication owner");
             retired_indexings.push_back(std::move(indexing));
         }
     };
@@ -762,14 +769,13 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
     bool has_index =
         get_bit_if_present(visible_state.index_ready_bitset, field_id);
 
-    std::unique_lock lck(mutex_);
     if (is_replace) {
         if (target_runtime == nullptr) {
             owned_runtime = CloneRuntimeResourceState(snapshot->runtime);
             target_runtime = owned_runtime.get();
         }
-        cancel_and_erase_scalar_index(target_runtime->scalar_indexings,
-                                      field_id);
+        retire_indexing(
+            erase_scalar_index(target_runtime->scalar_indexings, field_id));
         target_runtime->ngram_fields.erase(field_id);
         LOG_INFO("Replacing scalar index for field {} in segment {}",
                  field_id.get(),
@@ -808,7 +814,6 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
                     owned_runtime != nullptr
                         ? ToConstRuntimeState(std::move(owned_runtime))
                         : FreezeRuntimeResourceState(*target_runtime);
-                lck.unlock();
                 PublishIndexReadyLocked(field_id, false, published_runtime);
                 cancel_retired_indexings();
             }
@@ -828,7 +833,6 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
             } else if (owned_runtime != nullptr) {
                 auto published_runtime =
                     ToConstRuntimeState(std::move(owned_runtime));
-                lck.unlock();
                 MutatePublishedStateLocked([&](PublishedSegmentState& state) {
                     state.runtime = published_runtime;
                     SyncJsonNgramIndexState(
@@ -879,7 +883,6 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
         info.field_id,
         id_,
         request.has_raw_data);
-    lck.unlock();
     if (staged_state != nullptr) {
         clear_bit_if_present(staged_state->published_binlog_index_ready_bitset,
                              field_id);
@@ -891,6 +894,7 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
         auto published_runtime = ToConstRuntimeState(std::move(owned_runtime));
         PublishIndexReadyLocked(
             field_id, request.has_raw_data, published_runtime);
+        cancel_retired_indexings();
     }
 }
 
@@ -1589,14 +1593,10 @@ ChunkedSegmentSealedImpl::PublishReopenState(
     const SchemaPtr& sch,
     const std::shared_ptr<const SegmentLoadInfo>& published) {
     auto schema_snapshot = sch ? sch : current->schema;
-    Timestamp commit_ts = 0;
-    {
-        std::shared_lock lck(mutex_);
-        commit_ts = commit_ts_;
-    }
     auto load_info = published ? published : current->load_info;
-    PublishReopenState(current,
-                       MakeStateDelta(schema_snapshot, load_info, commit_ts));
+    PublishReopenState(
+        current,
+        MakeStateDelta(schema_snapshot, load_info, current->commit_ts));
 }
 
 void
@@ -1617,14 +1617,10 @@ ChunkedSegmentSealedImpl::PublishReopenState(
         schema_snapshot = current_schema;
     }
 
-    Timestamp commit_ts = 0;
-    {
-        std::shared_lock lck(mutex_);
-        commit_ts = commit_ts_;
-    }
     auto load_info = published ? published : current->load_info;
-    PublishReopenState(current,
-                       MakeStateDelta(schema_snapshot, load_info, commit_ts));
+    PublishReopenState(
+        current,
+        MakeStateDelta(schema_snapshot, load_info, current->commit_ts));
 }
 
 bool
@@ -2077,6 +2073,8 @@ ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
                                         milvus::OpContext* op_ctx,
                                         bool is_replace) {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+    InitializeDeletedRecordRowCount(
+        static_cast<int64_t>(storage::GetNumRowsForLoadInfo(load_info)));
     auto snapshot = CapturePublishedState();
     LoadFieldData(load_info,
                   *snapshot->load_info,
@@ -2293,10 +2291,7 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
         runtime->timestamps = std::move(timestamps);
         runtime->timestamp_index = std::make_shared<const TimestampIndex>();
         runtime->timestamp_index_slot.reset();
-        {
-            std::unique_lock lck(mutex_);
-            update_row_count(*runtime, 0);
-        }
+        SetRuntimeRowCount(*runtime, 0);
         return;
     }
 
@@ -2341,11 +2336,9 @@ ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
         runtime->timestamp_index_slot.reset();
     }
 
-    // Row count
-    {
-        std::unique_lock lck(mutex_);
-        update_row_count(*runtime, num_rows);
-    }
+    // Row count belongs to the staged runtime snapshot. DeletedRecord capacity
+    // is initialized once at segment bootstrap and is not resized here.
+    SetRuntimeRowCount(*runtime, num_rows);
 }
 
 void
@@ -2512,6 +2505,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
     milvus::OpContext* op_ctx,
     bool is_replace,
     RuntimeResourceState* runtime) {
+    const auto commit_ts = CapturePublishedState()->commit_ts;
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
     ArrowSchemaPtr arrow_schema = schema_snapshot->ConvertToArrowSchema();
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
@@ -2645,8 +2639,8 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                                    op_ctx,
                                    is_replace);
             if (field_id == TimestampFieldID) {
-                if (commit_ts_ != 0) {
-                    std::vector<Timestamp> ts(num_rows, commit_ts_);
+                if (commit_ts != 0) {
+                    std::vector<Timestamp> ts(num_rows, commit_ts);
                     init_storage_v1_timestamp_index(
                         std::move(ts), num_rows, runtime);
                 } else {
@@ -2673,6 +2667,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
     milvus::OpContext* op_ctx,
     bool is_replace,
     StagedStateCommitter& committer) {
+    const auto commit_ts = committer.staged_state()->commit_ts;
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
     ArrowSchemaPtr arrow_schema = schema_snapshot->ConvertToArrowSchema();
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
@@ -2798,8 +2793,8 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                                    is_replace,
                                    &committer);
             if (field_id == TimestampFieldID) {
-                if (commit_ts_ != 0) {
-                    std::vector<Timestamp> ts(num_rows, commit_ts_);
+                if (commit_ts != 0) {
+                    std::vector<Timestamp> ts(num_rows, commit_ts);
                     auto timestamp_index =
                         std::make_shared<const TimestampIndex>(
                             build_timestamp_index(ts.data(), num_rows));
@@ -2985,6 +2980,7 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
     StagedStateCommitter& committer) {
     SCOPE_CGO_CALL_METRIC();
 
+    const auto commit_ts = committer.staged_state()->commit_ts;
     auto& mmap_config = storage::MmapManager::GetInstance().GetMmapConfig();
 
     size_t num_rows = storage::GetNumRowsForLoadInfo(load_info);
@@ -3047,8 +3043,8 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                     offset += chunk_ptr->Span().row_count();
                 }
 
-                if (commit_ts_ != 0) {
-                    std::fill(timestamps.begin(), timestamps.end(), commit_ts_);
+                if (commit_ts != 0) {
+                    std::fill(timestamps.begin(), timestamps.end(), commit_ts);
                 }
                 auto timestamp_index = std::make_shared<const TimestampIndex>(
                     build_timestamp_index(timestamps.data(), num_rows));
@@ -3062,8 +3058,7 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                     runtime.timestamps = std::move(timestamp_data);
                     runtime.timestamp_index = std::move(timestamp_index);
                     runtime.timestamp_index_slot.reset();
-                    std::unique_lock lck(mutex_);
-                    update_row_count(runtime, num_rows);
+                    SetRuntimeRowCount(runtime, num_rows);
                     stats_.mem_size += sizeof(Timestamp) * num_rows;
                 });
             } else {
@@ -3074,8 +3069,7 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                 }
                 committer.Commit([this, num_rows](RuntimeResourceState& runtime,
                                                   PublishedSegmentState&) {
-                    std::unique_lock lck(mutex_);
-                    update_row_count(runtime, num_rows);
+                    SetRuntimeRowCount(runtime, num_rows);
                 });
             }
             LOG_INFO("segment {} loads system field {} mmap false done",
@@ -3139,6 +3133,7 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
     bool publish_ready) {
     SCOPE_CGO_CALL_METRIC();
 
+    const auto commit_ts = CapturePublishedState()->commit_ts;
     auto num_rows = data.row_count;
     std::shared_ptr<RuntimeResourceState> owned_runtime;
     auto* target_runtime = runtime;
@@ -3167,8 +3162,8 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
             offset += chunk_ptr->Span().row_count();
         }
 
-        if (commit_ts_ != 0) {
-            std::fill(timestamps.begin(), timestamps.end(), commit_ts_);
+        if (commit_ts != 0) {
+            std::fill(timestamps.begin(), timestamps.end(), commit_ts);
         }
         init_storage_v1_timestamp_index(
             std::move(timestamps), num_rows, target_runtime);
@@ -3181,10 +3176,7 @@ ChunkedSegmentSealedImpl::load_system_field_internal(
         while (data.arrow_reader_channel->pop(r)) {
         }
     }
-    {
-        std::unique_lock lck(mutex_);
-        update_row_count(*target_runtime, num_rows);
-    }
+    SetRuntimeRowCount(*target_runtime, num_rows);
     if (owned_runtime != nullptr && publish_ready) {
         PublishRuntimeStateLocked(
             ToConstRuntimeState(std::move(owned_runtime)));
@@ -3299,10 +3291,11 @@ ChunkedSegmentSealedImpl::prefetch_chunks(
 }
 
 void
-ChunkedSegmentSealedImpl::prefetch_chunks_locked(milvus::OpContext* op_ctx,
-                                                 FieldId field_id) const {
-    auto snapshot = CapturePublishedState();
-    if (auto column = get_column(snapshot->runtime, field_id)) {
+ChunkedSegmentSealedImpl::PrefetchChunksFromRuntime(
+    milvus::OpContext* op_ctx,
+    FieldId field_id,
+    const std::shared_ptr<const RuntimeResourceState>& runtime) const {
+    if (auto column = get_column(runtime, field_id)) {
         auto num_chunks = column->num_chunks();
         std::vector<int64_t> ids(num_chunks);
         std::iota(ids.begin(), ids.end(), 0);
@@ -3313,8 +3306,7 @@ ChunkedSegmentSealedImpl::prefetch_chunks_locked(milvus::OpContext* op_ctx,
 void
 ChunkedSegmentSealedImpl::prefetch_chunks(milvus::OpContext* op_ctx,
                                           FieldId field_id) const {
-    std::shared_lock lck(mutex_);
-    prefetch_chunks_locked(op_ctx, field_id);
+    PrefetchChunksFromRuntime(op_ctx, field_id, CaptureRuntimeResourceState());
 }
 
 void
@@ -3584,7 +3576,6 @@ ChunkedSegmentSealedImpl::GetSkipIndexSnapshot() const {
 
 int64_t
 ChunkedSegmentSealedImpl::get_deleted_count() const {
-    std::shared_lock lck(mutex_);
     return deleted_record_.size();
 }
 
@@ -3609,7 +3600,6 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
                                         const BitsetView& bitset,
                                         milvus::OpContext* op_context,
                                         SearchResult& output) const {
-    std::shared_lock vector_state_lck(mutex_);
     auto snapshot = CapturePublishedState();
     AssertInfo(snapshot->system_field_ready, "System field is not ready");
     auto field_id = search_info.field_id_;
@@ -3642,7 +3632,7 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
             "finish_searching_vector_temperate_binlog_index");
     } else if (get_bit(snapshot->index_ready_bitset, field_id)) {
         if (search_info.global_refine_enable_ &&
-            IsIndexRefineEnabledLocked(op_context, field_id, runtime)) {
+            IsIndexRefineEnabledFromRuntime(op_context, field_id, runtime)) {
             search_info.topk_ = GetEffectiveSearchTopk(search_info);
         }
         auto vector_entry = GetVectorIndexing(runtime, field_id);
@@ -3748,14 +3738,23 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
                                      FieldId field_id,
                                      const int64_t* ids,
                                      int64_t count) const {
-    std::shared_lock vector_state_lck(mutex_);
     auto snapshot = CapturePublishedState();
+    return get_vector_from_snapshot(op_ctx, field_id, ids, count, snapshot);
+}
+
+std::unique_ptr<DataArray>
+ChunkedSegmentSealedImpl::get_vector_from_snapshot(
+    milvus::OpContext* op_ctx,
+    FieldId field_id,
+    const int64_t* ids,
+    int64_t count,
+    const std::shared_ptr<const PublishedSegmentState>& snapshot) const {
     auto& field_meta = snapshot->schema->operator[](field_id);
     AssertInfo(field_meta.is_vector(), "vector field is not vector type");
 
     if (!get_bit(snapshot->index_ready_bitset, field_id) &&
         !get_bit(snapshot->binlog_index_bitset, field_id)) {
-        return fill_with_empty(field_id, count);
+        return fill_with_empty(field_meta, count);
     }
 
     auto vector_entry = GetVectorIndexing(snapshot->runtime, field_id);
@@ -3778,8 +3777,12 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
                 if (column != nullptr) {
                     CheckVectorOutputCellsLoaded(
                         id_, field_id, field_meta, column.get(), ids, count);
-                    return get_raw_data(
-                        op_ctx, field_id, field_meta, ids, count);
+                    return get_raw_data(op_ctx,
+                                        field_id,
+                                        field_meta,
+                                        ids,
+                                        count,
+                                        snapshot->runtime);
                 }
                 ThrowInfo(ErrorCode::UnexpectedError,
                           "nullable vector index has raw data but no valid "
@@ -3811,19 +3814,19 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
 }
 
 std::unique_ptr<DataArray>
-ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
-                                       FieldId field_id,
-                                       const FieldMeta& field_meta,
-                                       const int64_t* seg_offsets,
-                                       int64_t count) const {
-    std::shared_lock vector_state_lck(mutex_);
-    auto snapshot = CapturePublishedState();
+ChunkedSegmentSealedImpl::get_emb_list(
+    milvus::OpContext* op_ctx,
+    FieldId field_id,
+    const FieldMeta& field_meta,
+    const int64_t* seg_offsets,
+    int64_t count,
+    const std::shared_ptr<const PublishedSegmentState>& snapshot) const {
     AssertInfo(field_meta.get_data_type() == DataType::VECTOR_ARRAY,
                "get_emb_list only supports VECTOR_ARRAY");
 
     if (!get_bit(snapshot->index_ready_bitset, field_id) &&
         !get_bit(snapshot->binlog_index_bitset, field_id)) {
-        return fill_with_empty(field_id, count);
+        return fill_with_empty(field_meta, count);
     }
 
     auto vector_entry = GetVectorIndexing(snapshot->runtime, field_id);
@@ -3851,8 +3854,12 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
                                              column.get(),
                                              seg_offsets,
                                              count);
-                return get_raw_data(
-                    op_ctx, field_id, field_meta, seg_offsets, count);
+                return get_raw_data(op_ctx,
+                                    field_id,
+                                    field_meta,
+                                    seg_offsets,
+                                    count,
+                                    snapshot->runtime);
             }
             ThrowInfo(ErrorCode::UnexpectedError,
                       "nullable vector index has raw data but no valid "
@@ -4053,7 +4060,7 @@ ChunkedSegmentSealedImpl::DropFieldData(
     }
 }
 
-void
+index::CacheIndexBasePtr
 ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id,
                                     const SchemaPtr& schema_snapshot,
                                     RuntimeResourceState* runtime,
@@ -4067,16 +4074,19 @@ ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id,
     }
 
     if (runtime != nullptr) {
-        cancel_and_erase_scalar_index(runtime->scalar_indexings, field_id);
+        auto retired = erase_scalar_index(runtime->scalar_indexings, field_id);
         runtime->ngram_fields.erase(field_id);
+        return retired;
     } else {
         auto next_runtime = CloneMutableRuntimeResourceState();
-        cancel_and_erase_scalar_index(next_runtime->scalar_indexings, field_id);
+        auto retired =
+            erase_scalar_index(next_runtime->scalar_indexings, field_id);
         next_runtime->ngram_fields.erase(field_id);
         DropVectorIndexing(*next_runtime, field_id);
         next_runtime->vec_binlog_config.erase(field_id);
         PublishIndexDroppedLocked(
             field_id, ToConstRuntimeState(std::move(next_runtime)), op_ctx);
+        return retired;
     }
 }
 
@@ -4190,8 +4200,9 @@ ChunkedSegmentSealedImpl::search_batch_pks(
     const std::function<void(const SegOffset offset, const Timestamp ts)>&
         callback) const {
     // Helper to read a single timestamp by segment offset.
-    // For import/CDC segments with commit_ts_ set: every row carries commit_ts_,
-    // so short-circuit without touching the raw timestamp column.
+    // For import/CDC segments with a published commit timestamp: every row
+    // carries that timestamp, so short-circuit without touching the raw
+    // timestamp column.
     // For StorageV2: pins the timestamp column and indexes into chunks.
     // PK lookup and timestamp data come from the same published runtime.
     auto snapshot = CapturePublishedState();
@@ -4801,7 +4812,7 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
     auto load_info = std::make_shared<const SegmentLoadInfo>(
         milvus::proto::segcore::SegmentLoadInfo(), schema);
     std::atomic_store(&published_state_,
-                      BuildPublishedState(schema, load_info, commit_ts_));
+                      BuildPublishedState(schema, load_info, 0));
 }
 
 ChunkedSegmentSealedImpl::~ChunkedSegmentSealedImpl() {
@@ -4833,10 +4844,10 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
     switch (system_type) {
         case SystemFieldType::Timestamp: {
             auto* dst = static_cast<Timestamp*>(output);
-            // Import/CDC segments: every row carries commit_ts_, including
-            // v2/v3 column-group segments where the raw timestamp column is
-            // published in runtime but never overwritten. Short-circuit
-            // before consulting the column.
+            // Import/CDC segments: every row carries the published commit
+            // timestamp, including v2/v3 column-group segments where the raw
+            // timestamp column is published in runtime but never overwritten.
+            // Short-circuit before consulting the column.
             auto runtime = snapshot->runtime;
             auto effective_commit_ts =
                 snapshot->commit_ts != 0
@@ -5164,10 +5175,8 @@ ChunkedSegmentSealedImpl::bulk_subscript_text_impl(
     const ChunkedColumnInterface* column,
     const int64_t* seg_offsets,
     int64_t count,
-    google::protobuf::RepeatedPtrField<std::string>* dst) const {
-    auto snapshot = CapturePublishedState();
-    auto runtime = snapshot->runtime != nullptr ? snapshot->runtime
-                                                : BuildRuntimeResourceState();
+    google::protobuf::RepeatedPtrField<std::string>* dst,
+    const std::shared_ptr<const RuntimeResourceState>& runtime) const {
     auto it = runtime->text_lob_paths.find(field_id);
     AssertInfo(it != runtime->text_lob_paths.end(),
                "TEXT field {} has no LOB path. TEXT type requires StorageV3 "
@@ -5242,6 +5251,14 @@ ChunkedSegmentSealedImpl::fill_with_empty(FieldId field_id,
                                           const void* valid_data) const {
     auto schema_snapshot = CaptureSchemaSnapshot();
     auto& field_meta = schema_snapshot->operator[](field_id);
+    return fill_with_empty(field_meta, count, valid_count, valid_data);
+}
+
+std::unique_ptr<DataArray>
+ChunkedSegmentSealedImpl::fill_with_empty(const FieldMeta& field_meta,
+                                          int64_t count,
+                                          int64_t valid_count,
+                                          const void* valid_data) const {
     if (IsVectorDataType(field_meta.get_data_type())) {
         return CreateEmptyVectorDataArray(
             count, valid_count, valid_data, field_meta);
@@ -5255,39 +5272,6 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
     CreateTextIndexWithSchema(
         field_id, CaptureSchemaSnapshot(), op_ctx, true, nullptr);
-}
-
-void
-ChunkedSegmentSealedImpl::ScopedTextIndexBuildGuard::Register() {
-    std::unique_lock lck(segment_.mutex_);
-
-    AssertInfo(segment_.pending_text_index_fields_.count(field_id_) == 0,
-               "text index for field {} is already being built",
-               field_id_.get());
-
-    segment_.pending_text_index_fields_.insert(field_id_);
-    registered_ = true;
-}
-
-void
-ChunkedSegmentSealedImpl::ScopedTextIndexBuildGuard::Commit() {
-    std::unique_lock lck(segment_.mutex_);
-
-    AssertInfo(segment_.pending_text_index_fields_.count(field_id_) == 1,
-               "text index for field {} lost pending build state",
-               field_id_.get());
-
-    segment_.pending_text_index_fields_.erase(field_id_);
-    committed_ = true;
-}
-
-ChunkedSegmentSealedImpl::ScopedTextIndexBuildGuard::
-    ~ScopedTextIndexBuildGuard() {
-    if (!registered_ || committed_) {
-        return;
-    }
-    std::unique_lock lck(segment_.mutex_);
-    segment_.pending_text_index_fields_.erase(field_id_);
 }
 
 void
@@ -5312,9 +5296,6 @@ ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
                    target_runtime->text_indexes.end(),
                "text index for field {} already exists, refusing to rebuild",
                field_id.get());
-
-    ScopedTextIndexBuildGuard build_guard(*this, field_id);
-    build_guard.Register();
 
     const auto& field_meta = schema_snapshot->operator[](field_id);
     auto& cfg = storage::MmapManager::GetInstance().GetMmapConfig();
@@ -5483,7 +5464,6 @@ ChunkedSegmentSealedImpl::CreateTextIndexWithSchema(
                       "ChunkedSegmentSealedImpl::CreateTextIndex()");
     target_runtime->text_indexes.emplace(field_id,
                                          std::move(text_index_holder));
-    build_guard.Commit();
 
     if (owned_runtime != nullptr) {
         auto current = CapturePublishedState();
@@ -5742,7 +5722,6 @@ ChunkedSegmentSealedImpl::FillPrimaryKeys(const query::Plan* plan,
                                           SearchResult& results,
                                           milvus::OpContext* op_ctx) const {
     {
-        std::shared_lock lck(mutex_);
         AssertInfo(plan, "empty plan");
         auto size = results.distances_.size();
         AssertInfo(results.seg_offsets_.size() == size,
@@ -5803,15 +5782,16 @@ ChunkedSegmentSealedImpl::FillPrimaryKeys(const query::Plan* plan,
 }
 
 std::unique_ptr<DataArray>
-ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
-                                       FieldId field_id,
-                                       const FieldMeta& field_meta,
-                                       const int64_t* seg_offsets,
-                                       int64_t count) const {
+ChunkedSegmentSealedImpl::get_raw_data(
+    milvus::OpContext* op_ctx,
+    FieldId field_id,
+    const FieldMeta& field_meta,
+    const int64_t* seg_offsets,
+    int64_t count,
+    const std::shared_ptr<const RuntimeResourceState>& runtime) const {
     // Keep a shared column owner from the captured runtime so the column stays
     // alive even if a newer runtime is published.
-    auto snapshot = CapturePublishedState();
-    auto column = get_column(snapshot->runtime, field_id);
+    auto column = get_column(runtime, field_id);
     AssertInfo(column != nullptr,
                "field {} must exist when getting raw data",
                field_id.get());
@@ -5829,7 +5809,7 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
         valid_data = filter_result.valid_data.get();
         valid_offsets = filter_result.valid_offsets.data();
     }
-    auto ret = fill_with_empty(field_id, count, valid_count, valid_data);
+    auto ret = fill_with_empty(field_meta, count, valid_count, valid_data);
     if (field_meta.is_vector() && valid_count == 0) {
         return ret;
     }
@@ -5857,22 +5837,14 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
 
         case DataType::TEXT: {
             // TEXT type is only supported in StorageV3 with LOB files.
-            auto runtime = snapshot->runtime != nullptr
-                               ? snapshot->runtime
-                               : BuildRuntimeResourceState();
-            auto it = runtime->text_lob_paths.find(field_id);
-            AssertInfo(it != runtime->text_lob_paths.end(),
-                       "TEXT field {} has no LOB path. TEXT type requires "
-                       "StorageV3 with manifest. segment_id={}",
-                       field_id.get(),
-                       id_);
             bulk_subscript_text_impl(
                 op_ctx,
                 field_id,
                 column.get(),
                 seg_offsets,
                 count,
-                ret->mutable_scalars()->mutable_string_data()->mutable_data());
+                ret->mutable_scalars()->mutable_string_data()->mutable_data(),
+                runtime);
             break;
         }
 
@@ -6127,7 +6099,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
     auto& field_meta = snapshot->schema->operator[](field_id);
     // if count == 0, return empty data array
     if (count == 0) {
-        return fill_with_empty(field_id, count);
+        return fill_with_empty(field_meta, count);
     }
 
     // Fast path for int64 PK field: use compressed offset2pk index
@@ -6136,7 +6108,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
     if (pk_field_id.has_value() && pk_field_id.value() == field_id &&
         field_meta.get_data_type() == DataType::INT64 &&
         pk_index.get() != nullptr && pk_index.get()->has_int64_pk_index()) {
-        auto ret = fill_with_empty(field_id, count);
+        auto ret = fill_with_empty(field_meta, count);
         auto* output = ret->mutable_scalars()
                            ->mutable_long_data()
                            ->mutable_data()
@@ -6148,8 +6120,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
 
     // Decide once whether to serve this retrieve from column data instead of
     // the index-backed raw data. The flag is off by default, so short-circuit
-    // before touching HasFieldData — that call takes a shared_lock and would
-    // otherwise be paid on every retrieve regardless of the flag.
+    // before checking field-data availability on every retrieve.
     bool use_field_data =
         SegcoreConfig::default_config()
             .get_prefer_field_data_when_index_has_raw_data() &&
@@ -6171,7 +6142,12 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                 }
             }
         }
-        return get_raw_data(op_ctx, field_id, field_meta, seg_offsets, count);
+        return get_raw_data(op_ctx,
+                            field_id,
+                            field_meta,
+                            seg_offsets,
+                            count,
+                            snapshot->runtime);
     }
 
     // === Vector field ===
@@ -6182,24 +6158,30 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
     // Try index first: if vector index exists and has raw data, read from index
     if (!use_field_data && IndexHasRawData(field_id)) {
         if (IsVectorArrayDataType(field_meta.get_data_type())) {
-            vector =
-                get_emb_list(op_ctx, field_id, field_meta, seg_offsets, count);
+            vector = get_emb_list(
+                op_ctx, field_id, field_meta, seg_offsets, count, snapshot);
         } else {
-            vector = get_vector(op_ctx, field_id, seg_offsets, count);
+            vector = get_vector_from_snapshot(
+                op_ctx, field_id, seg_offsets, count, snapshot);
         }
     } else {
         // retrieve data from column data instead of index
         // we could reject remote vector output if the vector is not loaded in local cache
         // for performance needs
         if (SegcoreConfig::default_config().get_reject_remote_vector_output()) {
-            auto column = get_column(field_id);
+            auto column = get_column(snapshot->runtime, field_id);
             AssertInfo(column != nullptr,
                        "field {} must exist when getting raw data",
                        field_id.get());
             CheckVectorOutputCellsLoaded(
                 id_, field_id, field_meta, column.get(), seg_offsets, count);
         }
-        vector = get_raw_data(op_ctx, field_id, field_meta, seg_offsets, count);
+        vector = get_raw_data(op_ctx,
+                              field_id,
+                              field_meta,
+                              seg_offsets,
+                              count,
+                              snapshot->runtime);
     }
 
     std::chrono::high_resolution_clock::time_point get_vector_end =
@@ -6221,16 +6203,17 @@ ChunkedSegmentSealedImpl::bulk_subscript(
     int64_t count,
     const std::vector<std::string>& dynamic_field_names) const {
     auto snapshot = CapturePublishedState();
+    auto& field_meta = snapshot->schema->operator[](field_id);
     Assert(!dynamic_field_names.empty());
     if (count == 0) {
-        return fill_with_empty(field_id, 0);
+        return fill_with_empty(field_meta, 0);
     }
 
-    auto column = get_column(field_id);
+    auto column = get_column(snapshot->runtime, field_id);
     AssertInfo(column != nullptr,
                "json field {} must exist when bulk_subscript",
                field_id.get());
-    auto ret = fill_with_empty(field_id, count);
+    auto ret = fill_with_empty(field_meta, count);
     if (column->IsNullable()) {
         auto dst = ret->mutable_valid_data()->mutable_data();
         column->BulkIsValid(
@@ -6325,7 +6308,6 @@ ChunkedSegmentSealedImpl::GetFieldDataIfExist(FieldId field_id) const {
 
 bool
 ChunkedSegmentSealedImpl::HasRawData(int64_t field_id) const {
-    std::shared_lock lck(mutex_);
     auto snapshot = CapturePublishedState();
     auto fieldID = FieldId(field_id);
     const auto& field_meta = snapshot->schema->operator[](fieldID);
@@ -6357,7 +6339,6 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
     size_t count,
     bool is_cosine,
     float* distances) const {
-    std::shared_lock vector_state_lck(mutex_);
     auto runtime = CaptureRuntimeResourceState();
     auto vector_entry = GetVectorIndexing(runtime, field_id);
     if (vector_entry == nullptr) {
@@ -6397,7 +6378,7 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
 }
 
 bool
-ChunkedSegmentSealedImpl::IsIndexRefineEnabledLocked(
+ChunkedSegmentSealedImpl::IsIndexRefineEnabledFromRuntime(
     milvus::OpContext* op_ctx,
     FieldId field_id,
     const std::shared_ptr<const RuntimeResourceState>& runtime) const {
@@ -6415,8 +6396,7 @@ ChunkedSegmentSealedImpl::IsIndexRefineEnabledLocked(
 bool
 ChunkedSegmentSealedImpl::IsIndexRefineEnabled(milvus::OpContext* op_ctx,
                                                FieldId field_id) const {
-    std::shared_lock vector_state_lck(mutex_);
-    return IsIndexRefineEnabledLocked(
+    return IsIndexRefineEnabledFromRuntime(
         op_ctx, field_id, CaptureRuntimeResourceState());
 }
 
@@ -7096,7 +7076,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
                                "field {} data already loaded",
                                field_id.get());
                 }
-                update_row_count(target_runtime, num_rows);
+                SetRuntimeRowCount(target_runtime, num_rows);
             }
         };
 
@@ -7112,7 +7092,6 @@ ChunkedSegmentSealedImpl::load_field_data_common(
                 old_column = get_column(capture_snapshot()->runtime, field_id);
             }
 
-            std::unique_lock lck(mutex_);
             apply_loaded_column(target_runtime, old_column, staged_state);
         });
         return;
@@ -7128,12 +7107,10 @@ ChunkedSegmentSealedImpl::load_field_data_common(
             old_column = get_column(capture_snapshot()->runtime, field_id);
         }
 
-        std::unique_lock lck(mutex_);
         apply_loaded_column(*runtime, old_column, *capture_snapshot());
         return;
     }
 
-    std::unique_lock lck(mutex_);
     auto current = capture_snapshot();
     auto next_runtime = CloneRuntimeResourceState(current->runtime);
     auto old_column = get_column(current->runtime, field_id);
@@ -7141,7 +7118,6 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     apply_loaded_column(*next_runtime, old_column, *current);
 
     auto published_runtime = ToConstRuntimeState(std::move(next_runtime));
-    lck.unlock();
     if (SystemProperty::Instance().IsSystem(field_id)) {
         PublishRuntimeStateLocked(published_runtime);
     } else {
@@ -7375,7 +7351,8 @@ ChunkedSegmentSealedImpl::FinalizeLoadDiffForReopen(
             }
             committer.Commit([&](RuntimeResourceState& runtime,
                                  PublishedSegmentState& staged_state) {
-                DropIndex(field_id, schema_snapshot, &runtime);
+                committer.RetireCacheIndexingLocked(
+                    DropIndex(field_id, schema_snapshot, &runtime));
                 committer.StageVectorIndexDropLocked(field_id);
                 DropIndexFromState(staged_state, field_id);
             });
@@ -7556,6 +7533,13 @@ ChunkedSegmentSealedImpl::Reopen(
 
     SegmentLoadInfo current_mutable(*current->load_info);
     SegmentLoadInfo new_local(new_load_info, target_schema);
+    AssertInfo(
+        current->load_info->GetNumOfRows() == new_local.GetNumOfRows(),
+        "online reopen cannot change row count for segment {}: current {}, "
+        "incoming {}; use full segment replacement instead",
+        id_,
+        current->load_info->GetNumOfRows(),
+        new_local.GetNumOfRows());
     new_local.InheritCachedColumnGroupsFrom(*current->load_info);
     for (auto fid : current->load_info->GetCreatedTextIndexes()) {
         if (field_exists_in_schema(target_schema, fid)) {
@@ -7943,10 +7927,6 @@ ChunkedSegmentSealedImpl::LoadGeometryCache(
 void
 ChunkedSegmentSealedImpl::SetCommitTimestamp(uint64_t ts) {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
-    {
-        std::unique_lock lck(mutex_);
-        commit_ts_ = ts;
-    }
     MutatePublishedStateLocked([&](PublishedSegmentState& state) {
         state.commit_ts = static_cast<Timestamp>(ts);
     });
@@ -7955,6 +7935,26 @@ ChunkedSegmentSealedImpl::SetCommitTimestamp(uint64_t ts) {
 uint64_t
 ChunkedSegmentSealedImpl::GetCommitTimestamp() const {
     return CapturePublishedState()->commit_ts;
+}
+
+void
+ChunkedSegmentSealedImpl::InitializeDeletedRecordRowCount(int64_t row_count) {
+    AssertInfo(row_count >= 0,
+               "sealed segment {} row count must be non-negative, got {}",
+               id_,
+               row_count);
+    if (deleted_record_row_count_ >= 0) {
+        AssertInfo(deleted_record_row_count_ == row_count,
+                   "sealed segment {} row count cannot change after delete "
+                   "record initialization: current {}, incoming {}",
+                   id_,
+                   deleted_record_row_count_,
+                   row_count);
+        return;
+    }
+
+    deleted_record_.set_sealed_row_count(row_count);
+    deleted_record_row_count_ = row_count;
 }
 
 std::optional<Timestamp>
@@ -7967,14 +7967,11 @@ void
 ChunkedSegmentSealedImpl::SetLoadInfo(
     proto::segcore::SegmentLoadInfo load_info) {
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+    InitializeDeletedRecordRowCount(load_info.num_of_rows());
     auto current = CapturePublishedState();
     auto schema_snapshot = current->schema;
     auto commit_ts =
         static_cast<milvus::Timestamp>(load_info.commit_timestamp());
-    {
-        std::unique_lock lck(mutex_);
-        commit_ts_ = commit_ts;
-    }
     // Do not parse manifest here: Load() must be able to observe a
     // pre-cancelled OpContext before any storage/manifest IO happens.
     auto published = std::make_shared<const SegmentLoadInfo>(
@@ -8169,6 +8166,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     milvus::OpContext* op_ctx,
     bool is_replace,
     RuntimeResourceState* runtime) {
+    const auto commit_ts = CapturePublishedState()->commit_ts;
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
     AssertInfo(!milvus_field_ids.empty(),
@@ -8305,8 +8303,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             is_replace);
         if (field_id == TimestampFieldID) {
             int64_t num_rows = segment_load_info.GetNumOfRows();
-            if (commit_ts_ != 0) {
-                std::vector<Timestamp> ts(num_rows, commit_ts_);
+            if (commit_ts != 0) {
+                std::vector<Timestamp> ts(num_rows, commit_ts);
                 init_storage_v1_timestamp_index(
                     std::move(ts), num_rows, runtime);
             } else {
@@ -8331,6 +8329,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     milvus::OpContext* op_ctx,
     bool is_replace,
     StagedStateCommitter& committer) {
+    const auto commit_ts = committer.staged_state()->commit_ts;
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
     AssertInfo(!milvus_field_ids.empty(),
@@ -8449,8 +8448,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
                                &committer);
         if (field_id == TimestampFieldID) {
             int64_t num_rows = segment_load_info.GetNumOfRows();
-            if (commit_ts_ != 0) {
-                std::vector<Timestamp> ts(num_rows, commit_ts_);
+            if (commit_ts != 0) {
+                std::vector<Timestamp> ts(num_rows, commit_ts);
                 auto timestamp_index = std::make_shared<const TimestampIndex>(
                     build_timestamp_index(ts.data(), num_rows));
                 auto timestamp_data = std::make_shared<TimestampData>();
@@ -8544,8 +8543,6 @@ ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
                                    info = std::move(load_text_index_info),
                                    &segment_load_info,
                                    &committer]() mutable -> void {
-            ScopedTextIndexBuildGuard build_guard(*this, field_id);
-            build_guard.Register();
             auto text_index =
                 BuildTextIndexFromFiles(op_ctx, info, segment_load_info);
             committer.Commit([field_id, text_index = std::move(text_index)](
@@ -8558,7 +8555,6 @@ ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
                            field_id.get());
                 runtime.text_indexes.emplace(field_id, std::move(text_index));
             });
-            build_guard.Commit();
         });
         load_index_futures.emplace_back(std::move(future));
     }
@@ -8828,6 +8824,7 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
 
     auto snapshot = CapturePublishedState();
     auto num_rows = snapshot->load_info->GetNumOfRows();
+    InitializeDeletedRecordRowCount(num_rows);
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 
     SegmentLoadInfo mutable_copy(snapshot->load_info->GetProto(),
@@ -9868,13 +9865,12 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
 void
 ChunkedSegmentSealedImpl::prefetch_vector(milvus::OpContext* op_ctx,
                                           FieldId field_id) const {
-    std::shared_lock vector_state_lck(mutex_);
     auto runtime = CaptureRuntimeResourceState();
     auto vector_entry = GetVectorIndexing(runtime, field_id);
     if (vector_entry != nullptr) {
         SemiInlineGet(vector_entry->indexing_->PinCells(op_ctx, {0}));
     } else {
-        this->prefetch_chunks_locked(op_ctx, field_id);
+        PrefetchChunksFromRuntime(op_ctx, field_id, runtime);
     }
 }
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -477,11 +477,21 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                int64_t count) const override;
 
     std::unique_ptr<DataArray>
-    get_emb_list(milvus::OpContext* op_ctx,
-                 FieldId field_id,
-                 const FieldMeta& field_meta,
-                 const int64_t* seg_offsets,
-                 int64_t count) const;
+    get_vector_from_snapshot(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        const int64_t* ids,
+        int64_t count,
+        const std::shared_ptr<const PublishedSegmentState>& snapshot) const;
+
+    std::unique_ptr<DataArray>
+    get_emb_list(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        const FieldMeta& field_meta,
+        const int64_t* seg_offsets,
+        int64_t count,
+        const std::shared_ptr<const PublishedSegmentState>& snapshot) const;
 
     bool
     is_nullable(FieldId field_id) const override {
@@ -1260,7 +1270,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const ChunkedColumnInterface* column,
         const int64_t* seg_offsets,
         int64_t count,
-        google::protobuf::RepeatedPtrField<std::string>* dst) const;
+        google::protobuf::RepeatedPtrField<std::string>* dst,
+        const std::shared_ptr<const RuntimeResourceState>& runtime) const;
 
     std::unique_ptr<DataArray>
     fill_with_empty(FieldId field_id,
@@ -1269,11 +1280,19 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                     const void* valid_data = nullptr) const;
 
     std::unique_ptr<DataArray>
-    get_raw_data(milvus::OpContext* op_ctx,
-                 FieldId field_id,
-                 const FieldMeta& field_meta,
-                 const int64_t* seg_offsets,
-                 int64_t count) const;
+    fill_with_empty(const FieldMeta& field_meta,
+                    int64_t count,
+                    int64_t valid_count = 0,
+                    const void* valid_data = nullptr) const;
+
+    std::unique_ptr<DataArray>
+    get_raw_data(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        const FieldMeta& field_meta,
+        const int64_t* seg_offsets,
+        int64_t count,
+        const std::shared_ptr<const RuntimeResourceState>& runtime) const;
 
     struct ValidResult {
         int64_t valid_count = 0;
@@ -1293,11 +1312,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                        const int64_t* seg_offsets,
                                        int64_t count) const;
 
-    void
-    update_row_count(RuntimeResourceState& runtime, int64_t row_count) {
+    static void
+    SetRuntimeRowCount(RuntimeResourceState& runtime, int64_t row_count) {
         runtime.row_count = row_count;
-        deleted_record_.set_sealed_row_count(row_count);
     }
+
+    void
+    InitializeDeletedRecordRowCount(int64_t row_count);
 
     void
     mask_with_timestamps(BitsetTypeView& bitset_chunk,
@@ -1369,13 +1390,16 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         StagedStateCommitter* committer = nullptr);
 
     bool
-    IsIndexRefineEnabledLocked(
+    IsIndexRefineEnabledFromRuntime(
         milvus::OpContext* op_ctx,
         FieldId field_id,
         const std::shared_ptr<const RuntimeResourceState>& runtime) const;
 
     void
-    prefetch_chunks_locked(milvus::OpContext* op_ctx, FieldId field_id) const;
+    PrefetchChunksFromRuntime(
+        milvus::OpContext* op_ctx,
+        FieldId field_id,
+        const std::shared_ptr<const RuntimeResourceState>& runtime) const;
 
     void
     fill_empty_field(const FieldMeta& field_meta,
@@ -1869,7 +1893,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     FillDefaultValueFields(const std::vector<FieldId>& field_ids);
 
-    void
+    index::CacheIndexBasePtr
     DropIndex(const FieldId field_id,
               const SchemaPtr& schema_snapshot,
               RuntimeResourceState* runtime = nullptr,
@@ -2063,28 +2087,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                               milvus::OpContext* op_ctx,
                               StagedStateCommitter& committer);
 
-    class ScopedTextIndexBuildGuard {
-     public:
-        ScopedTextIndexBuildGuard(ChunkedSegmentSealedImpl& segment,
-                                  FieldId field_id)
-            : segment_(segment), field_id_(field_id) {
-        }
-
-        void
-        Register();
-
-        void
-        Commit();
-
-        ~ScopedTextIndexBuildGuard();
-
-     private:
-        ChunkedSegmentSealedImpl& segment_;
-        FieldId field_id_;
-        bool registered_{false};
-        bool committed_{false};
-    };
-
     TextIndexVariant
     BuildTextIndexFromFiles(
         milvus::OpContext* op_ctx,
@@ -2218,6 +2220,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     // deleted pks
     mutable DeletedRecord<true> deleted_record_;
+    // Initialized once during segment bootstrap while reopen_mutex_ is held.
+    // Online reopen/load paths may verify the value but must never resize the
+    // live delete bitmap.
+    int64_t deleted_record_row_count_{-1};
 
     LoadFieldDataInfo field_data_info_;
 
@@ -2230,8 +2236,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // Serializes all published_state_ writers so reopen/load/runtime-marker
     // copy-on-write publications never interleave. Does NOT block readers —
     // reader paths access published_state_ via atomic_load.
-    // Lock order: reopen_mutex_ → mutex_ (outer → inner) only. Never inverse,
-    // and reader paths that take mutex_ must not take reopen_mutex_.
+    // Lock order: reopen_mutex_ → mutex_ (outer → inner) only. The common
+    // SegmentInternalInterface Search/Retrieve entrypoints still take the
+    // inherited mutex_; separating Growing and Sealed synchronization belongs
+    // to a follow-up change. Until then, never acquire reopen_mutex_ while
+    // holding mutex_.
     std::mutex reopen_mutex_;
 
     // Cross-thread request leases block online publication while a sealed
@@ -2240,12 +2249,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     storage::MmapChunkDescriptorPtr mmap_descriptor_ = nullptr;
     int64_t id_;
-    // commit_ts_ remains the writer-side source of truth for load-time data
-    // preparation; published readers consume the value through
-    // PublishedSegmentState.
-    uint64_t commit_ts_{0};
-
-    std::unordered_set<FieldId> pending_text_index_fields_;
 
     // only useful in binlog
     IndexMetaPtr col_index_meta_;
@@ -2622,17 +2625,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
             ClearFieldBitsForAbsentLoadInfo(state);
             SetSystemFieldReadyInState(state, state.load_info.get());
         });
-    }
-
-    bool
-    TestHasPendingTextIndex(FieldId field_id) const {
-        return pending_text_index_fields_.count(field_id) > 0;
-    }
-
-    void
-    TestRegisterPendingTextIndex(FieldId field_id) {
-        ScopedTextIndexBuildGuard guard(*this, field_id);
-        guard.Register();
     }
 
     void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -368,6 +368,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         int64_t row_count{0};
     };
 
+    enum class PublishedStatePhase {
+        Bootstrap,
+        Serving,
+    };
+
     struct PublishedSegmentState {
         SchemaPtr schema;
         std::shared_ptr<const SegmentLoadInfo> load_info;
@@ -382,6 +387,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         BitsetType index_ready_bitset;
         BitsetType binlog_index_bitset;
         std::unordered_map<FieldId, bool> index_has_raw_data;
+        PublishedStatePhase phase{PublishedStatePhase::Bootstrap};
     };
 
     struct StateDelta {
@@ -393,6 +399,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         std::optional<BitsetType> published_binlog_index_ready_bitset;
         std::optional<std::unordered_map<FieldId, bool>>
             published_index_has_raw_data;
+        std::optional<PublishedStatePhase> phase;
     };
 
     static std::shared_ptr<const RuntimeResourceState>
@@ -1499,7 +1506,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                             FieldId field_id);
 
     std::shared_ptr<PublishedSegmentState>
-    BuildNextPublishedState(
+    PrepareTargetState(
         const std::shared_ptr<const PublishedSegmentState>& current,
         const StateDelta& delta) const;
 
@@ -1512,6 +1519,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     ValidateTextIndexState(const PublishedSegmentState& state) const;
+
+    void
+    ValidatePublishedState(const PublishedSegmentState& state) const;
 
     enum class PublishMode {
         Drain,
@@ -1593,8 +1603,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
             std::shared_ptr<PublishedSegmentState> next;
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-                next = segment_.BuildNextPublishedState(current, delta);
-                segment_.ValidateTextIndexState(*next);
+                next = segment_.PrepareTargetState(current, delta);
                 retired_indexings.swap(retired_vector_indexings_);
                 retired_cache_indexings.swap(retired_cache_indexings_);
             }
@@ -2412,7 +2421,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     TestBuildNextPublishedState(
         const std::shared_ptr<const PublishedSegmentState>& current,
         const StateDelta& delta) const {
-        return BuildNextPublishedState(current, delta);
+        return PrepareTargetState(current, delta);
     }
 
     std::shared_ptr<RuntimeResourceState>

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1314,6 +1314,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     static void
     SetRuntimeRowCount(RuntimeResourceState& runtime, int64_t row_count) {
+        AssertInfo(runtime.row_count == 0 || runtime.row_count == row_count,
+                   "runtime row count mismatch: current {}, incoming {}",
+                   runtime.row_count,
+                   row_count);
         runtime.row_count = row_count;
     }
 
@@ -1506,6 +1510,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     NormalizePublishedState(PublishedSegmentState& state) const;
 
+    void
+    ValidateTextIndexState(const PublishedSegmentState& state) const;
+
     enum class PublishMode {
         Drain,
         FailFast,
@@ -1587,6 +1594,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
             {
                 std::lock_guard<std::mutex> lock(mutex_);
                 next = segment_.BuildNextPublishedState(current, delta);
+                segment_.ValidateTextIndexState(*next);
                 retired_indexings.swap(retired_vector_indexings_);
                 retired_cache_indexings.swap(retired_cache_indexings_);
             }
@@ -1725,7 +1733,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     static std::shared_ptr<const SegmentLoadInfo>
     CloneLoadInfoWithTextIndexCreated(
         const std::shared_ptr<const SegmentLoadInfo>& current,
-        FieldId field_id);
+        FieldId field_id,
+        RawTextIndexSource source = RawTextIndexSource::Unknown);
 
     static std::shared_ptr<const SegmentLoadInfo>
     CloneLoadInfoForReopen(const SegmentLoadInfo& load_info,
@@ -2074,6 +2083,17 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const SegmentLoadInfo& segment_load_info,
         StagedStateCommitter& committer);
 
+    struct RawTextIndexBuildResult {
+        std::shared_ptr<index::TextMatchIndexHolder> index;
+        RawTextIndexSource source{RawTextIndexSource::Unknown};
+    };
+
+    RawTextIndexBuildResult
+    BuildRawTextIndexWithSchema(FieldId field_id,
+                                const SchemaPtr& schema_snapshot,
+                                milvus::OpContext* op_ctx,
+                                const RuntimeResourceState& runtime);
+
     void
     CreateTextIndexWithSchema(FieldId field_id,
                               const SchemaPtr& schema_snapshot,
@@ -2081,7 +2101,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                               bool publish_marker = true,
                               RuntimeResourceState* runtime = nullptr);
 
-    void
+    RawTextIndexSource
     CreateTextIndexWithSchema(FieldId field_id,
                               const SchemaPtr& schema_snapshot,
                               milvus::OpContext* op_ctx,
@@ -2095,7 +2115,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     RecordTextIndexCreated(SegmentLoadInfo& segment_load_info,
-                           FieldId field_id);
+                           FieldId field_id,
+                           RawTextIndexSource source);
 
     void
     PrepareSchemaForReopen(const SchemaPtr& sch);

--- a/internal/core/src/segcore/DeletedRecord.h
+++ b/internal/core/src/segcore/DeletedRecord.h
@@ -429,7 +429,7 @@ class DeletedRecord {
     std::shared_ptr<SortedDeleteList> deleted_lists_;
     // max timestamp of deleted records which replayed in load process
     Timestamp max_load_timestamp_{0};
-    int32_t sealed_row_count_;
+    int32_t sealed_row_count_{0};
     // used to remove duplicated deleted records for fast access
     BitsetType deleted_mask_;
 

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -816,6 +816,44 @@ CurrentJsonStatsDataFormatVersion() {
 }
 
 bool
+TextStatsFilesEqual(const proto::segcore::TextIndexStats& lhs,
+                    const proto::segcore::TextIndexStats& rhs) {
+    if (lhs.files_size() != rhs.files_size()) {
+        return false;
+    }
+    for (int i = 0; i < lhs.files_size(); ++i) {
+        if (lhs.files(i) != rhs.files(i)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool
+TextStatsLoadIdentityEqual(const proto::segcore::TextIndexStats& lhs,
+                           const proto::segcore::TextIndexStats& rhs) {
+    return lhs.fieldid() == rhs.fieldid() && lhs.version() == rhs.version() &&
+           lhs.buildid() == rhs.buildid() &&
+           lhs.current_scalar_index_version() ==
+               rhs.current_scalar_index_version() &&
+           lhs.base_path() == rhs.base_path() &&
+           lhs.log_size() == rhs.log_size() &&
+           lhs.memory_size() == rhs.memory_size() &&
+           TextStatsFilesEqual(lhs, rhs);
+}
+
+bool
+TextIndexSchemaIdentityEqual(const FieldMeta& lhs, const FieldMeta& rhs) {
+    if (lhs.get_data_type() != rhs.get_data_type() ||
+        lhs.enable_match() != rhs.enable_match() ||
+        lhs.enable_analyzer() != rhs.enable_analyzer()) {
+        return false;
+    }
+    return !lhs.enable_analyzer() ||
+           lhs.get_analyzer_params() == rhs.get_analyzer_params();
+}
+
+bool
 JsonStatsFilesEqual(const proto::segcore::JsonKeyStats& lhs,
                     const proto::segcore::JsonKeyStats& rhs) {
     if (lhs.files_size() != rhs.files_size()) {
@@ -846,6 +884,89 @@ JsonStatsLoadIdentityEqual(const proto::segcore::JsonKeyStats& lhs,
 void
 SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
                                         SegmentLoadInfo& new_info) {
+    // Online reopen currently supports adding a text index, preserving an
+    // unchanged text index, or dropping it together with its schema field.
+    // Replacing a pre-built index or changing between pre-built and raw-built
+    // sources requires full segment replacement. Reject these transitions
+    // before any load IO or staged runtime mutation starts.
+    for (const auto& [field_id, current_stats] : GetTextStatsLogs()) {
+        auto fid = FieldId(field_id);
+        AssertInfo(HasFieldInSchema(fid),
+                   "published pre-built text index field {} is absent from "
+                   "the current schema for segment {}",
+                   field_id,
+                   GetSegmentID());
+        AssertInfo(created_text_indexes_.count(fid) == 0,
+                   "published text index field {} is marked as both "
+                   "pre-built and raw-built for segment {}",
+                   field_id,
+                   GetSegmentID());
+        if (!new_info.HasFieldInSchema(fid)) {
+            continue;
+        }
+
+        const auto* incoming_stats = new_info.GetTextStatsLog(field_id);
+        const auto& incoming_meta = new_info.schema_->operator[](fid);
+        AssertInfo(
+            incoming_stats != nullptr,
+            "online reopen cannot change text index source for segment {}, "
+            "field {} from pre-built to {}; use full segment replacement "
+            "instead",
+            new_info.GetSegmentID(),
+            field_id,
+            incoming_meta.enable_match() ? "raw-built" : "none");
+        AssertInfo(
+            TextStatsLoadIdentityEqual(current_stats, *incoming_stats),
+            "online reopen cannot replace pre-built text index identity for "
+            "segment {}, field {}; use full segment replacement instead",
+            new_info.GetSegmentID(),
+            field_id);
+        AssertInfo(TextIndexSchemaIdentityEqual(schema_->operator[](fid),
+                                                incoming_meta),
+                   "online reopen cannot change text index schema identity for "
+                   "segment {}, field {}; use full segment replacement instead",
+                   new_info.GetSegmentID(),
+                   field_id);
+    }
+
+    for (const auto& fid : created_text_indexes_) {
+        AssertInfo(HasFieldInSchema(fid),
+                   "published raw-built text index field {} is absent from "
+                   "the current schema for segment {}",
+                   fid.get(),
+                   GetSegmentID());
+        AssertInfo(GetTextStatsLog(fid.get()) == nullptr,
+                   "published text index field {} is marked as both "
+                   "pre-built and raw-built for segment {}",
+                   fid.get(),
+                   GetSegmentID());
+        if (!new_info.HasFieldInSchema(fid)) {
+            continue;
+        }
+
+        AssertInfo(
+            new_info.GetTextStatsLog(fid.get()) == nullptr,
+            "online reopen cannot change text index source for segment {}, "
+            "field {} from raw-built to pre-built; use full segment "
+            "replacement instead",
+            new_info.GetSegmentID(),
+            fid.get());
+        const auto& incoming_meta = new_info.schema_->operator[](fid);
+        AssertInfo(
+            incoming_meta.enable_match(),
+            "online reopen cannot remove raw-built text index for segment "
+            "{}, field {} while keeping the field; use full segment "
+            "replacement instead",
+            new_info.GetSegmentID(),
+            fid.get());
+        AssertInfo(TextIndexSchemaIdentityEqual(schema_->operator[](fid),
+                                                incoming_meta),
+                   "online reopen cannot change text index schema identity for "
+                   "segment {}, field {}; use full segment replacement instead",
+                   new_info.GetSegmentID(),
+                   fid.get());
+    }
+
     // Build current text indexed fields (fields with loaded text index stats)
     std::set<FieldId> current_text_indexed;
     for (const auto& [field_id, stats] : GetTextStatsLogs()) {

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -75,6 +75,50 @@ SegmentLoadInfo::HasManifestColumn(const std::string& column_name) const {
     return false;
 }
 
+void
+SegmentLoadInfo::ValidateReopenRowCount(int64_t expected) const {
+    AssertInfo(
+        GetNumOfRows() == expected,
+        "online reopen cannot change row count for segment {}: current {}, "
+        "incoming {}; use full segment replacement instead",
+        GetSegmentID(),
+        expected,
+        GetNumOfRows());
+
+    if (HasManifestPath()) {
+        return;
+    }
+
+    for (const auto& field_binlog : GetBinlogPaths()) {
+        bool retained = false;
+        if (field_binlog.child_fields().empty()) {
+            retained = HasFieldInSchema(FieldId(field_binlog.fieldid()));
+        } else {
+            for (auto child_id : field_binlog.child_fields()) {
+                if (HasFieldInSchema(FieldId(child_id))) {
+                    retained = true;
+                    break;
+                }
+            }
+        }
+        if (!retained) {
+            continue;
+        }
+
+        int64_t actual = 0;
+        for (const auto& binlog : field_binlog.binlogs()) {
+            actual += binlog.entries_num();
+        }
+        AssertInfo(actual == expected,
+                   "online reopen row count mismatch for segment {}, field "
+                   "binlog group {}: expected {}, actual {}",
+                   GetSegmentID(),
+                   field_binlog.fieldid(),
+                   expected,
+                   actual);
+    }
+}
+
 LoadIndexInfo
 SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo(
     const proto::segcore::FieldIndexInfo* field_index_info,
@@ -271,25 +315,13 @@ SegmentLoadInfo::ConvertJsonKeyStatsToLoadJsonKeyIndexInfo(
 
 void
 SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
-    // Get current index IDs from the lightweight identity cache.
-    std::set<int64_t> current_index_ids;
     // Build a set of field IDs that currently have indexes loaded
     std::set<FieldId> current_indexed_fields;
-    for (const auto& [field_id, index_ids] : field_index_id_cache_) {
-        current_indexed_fields.insert(field_id);
-        for (auto index_id : index_ids) {
-            current_index_ids.insert(index_id);
-        }
-    }
-
-    std::set<int64_t> new_index_ids;
-    for (const auto& [field_id, index_ids] : new_info.field_index_id_cache_) {
-        if (!new_info.HasFieldInSchema(field_id)) {
+    for (const auto& [field_id, identities] : field_index_identity_cache_) {
+        if (identities.empty()) {
             continue;
         }
-        for (auto index_id : index_ids) {
-            new_index_ids.insert(index_id);
-        }
+        current_indexed_fields.insert(field_id);
     }
     std::unordered_map<FieldId, std::unordered_set<std::string>>
         new_json_index_paths;
@@ -313,9 +345,18 @@ SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
             continue;
         }
         for (const auto& load_index_info : load_index_infos) {
-            if (current_index_ids.find(load_index_info.index_id) ==
-                current_index_ids.end()) {
-                // New index_id: check if field already has an index loaded
+            auto incoming_identity = FieldIndexIdentity::From(load_index_info);
+            auto current_field = field_index_identity_cache_.find(field_id);
+            bool identity_unchanged = false;
+            if (current_field != field_index_identity_cache_.end()) {
+                identity_unchanged =
+                    std::find(current_field->second.begin(),
+                              current_field->second.end(),
+                              incoming_identity) != current_field->second.end();
+            }
+            if (!identity_unchanged) {
+                // A stable index_id is insufficient identity: compaction can
+                // publish a new build/version/file set under the same id.
                 if (current_indexed_fields.find(field_id) !=
                     current_indexed_fields.end()) {
                     diff.indexes_to_replace[field_id].push_back(
@@ -328,22 +369,36 @@ SegmentLoadInfo::ComputeDiffIndexes(LoadDiff& diff, SegmentLoadInfo& new_info) {
     }
 
     // Find indexes to drop: fields that have indexes in current but not in new_info
-    for (const auto& [field_id, index_ids] : field_index_id_cache_) {
-        for (auto index_id : index_ids) {
-            if (!new_info.HasFieldInSchema(field_id) ||
-                new_index_ids.find(index_id) == new_index_ids.end()) {
-                auto field_paths = json_index_path_cache_.find(field_id);
-                if (field_paths != json_index_path_cache_.end()) {
-                    auto path = field_paths->second.find(index_id);
-                    if (path != field_paths->second.end()) {
-                        if (new_json_index_paths[field_id].find(path->second) ==
+    for (const auto& [field_id, identities] : field_index_identity_cache_) {
+        for (const auto& identity : identities) {
+            auto incoming_field =
+                new_info.field_index_identity_cache_.find(field_id);
+            bool index_id_still_present =
+                incoming_field != new_info.field_index_identity_cache_.end() &&
+                std::any_of(incoming_field->second.begin(),
+                            incoming_field->second.end(),
+                            [&](const FieldIndexIdentity& incoming) {
+                                return incoming.index_id == identity.index_id;
+                            });
+            auto field_paths = json_index_path_cache_.find(field_id);
+            if (field_paths != json_index_path_cache_.end()) {
+                auto path = field_paths->second.find(identity.index_id);
+                if (path != field_paths->second.end()) {
+                    // JSON indexes are runtime-owned by nested path. A new
+                    // identity may reuse the same index_id while moving to a
+                    // different path; load/replace handles the incoming path,
+                    // while finalize must explicitly retire the old one.
+                    if (!new_info.HasFieldInSchema(field_id) ||
+                        new_json_index_paths[field_id].find(path->second) ==
                             new_json_index_paths[field_id].end()) {
-                            diff.json_indexes_to_drop[field_id].insert(
-                                path->second);
-                        }
-                        continue;
+                        diff.json_indexes_to_drop[field_id].insert(
+                            path->second);
                     }
+                    continue;
                 }
+            }
+            if (!new_info.HasFieldInSchema(field_id) ||
+                !index_id_still_present) {
                 diff.indexes_to_drop.insert(field_id);
             }
         }
@@ -884,11 +939,11 @@ JsonStatsLoadIdentityEqual(const proto::segcore::JsonKeyStats& lhs,
 void
 SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
                                         SegmentLoadInfo& new_info) {
-    // Online reopen currently supports adding a text index, preserving an
-    // unchanged text index, or dropping it together with its schema field.
-    // Replacing a pre-built index or changing between pre-built and raw-built
-    // sources requires full segment replacement. Reject these transitions
-    // before any load IO or staged runtime mutation starts.
+    // Online reopen supports adding a text index, preserving an unchanged
+    // index, rebuilding a raw-built index from staged target sources, or
+    // dropping it together with its schema field. Replacing a pre-built index
+    // or changing between pre-built and raw-built sources still requires full
+    // segment replacement; reject those transitions before any load IO.
     for (const auto& [field_id, current_stats] : GetTextStatsLogs()) {
         auto fid = FieldId(field_id);
         AssertInfo(HasFieldInSchema(fid),
@@ -929,7 +984,7 @@ SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
                    field_id);
     }
 
-    for (const auto& fid : created_text_indexes_) {
+    for (const auto& [fid, _] : created_text_indexes_) {
         AssertInfo(HasFieldInSchema(fid),
                    "published raw-built text index field {} is absent from "
                    "the current schema for segment {}",
@@ -959,12 +1014,9 @@ SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
             "replacement instead",
             new_info.GetSegmentID(),
             fid.get());
-        AssertInfo(TextIndexSchemaIdentityEqual(schema_->operator[](fid),
-                                                incoming_meta),
-                   "online reopen cannot change text index schema identity for "
-                   "segment {}, field {}; use full segment replacement instead",
-                   new_info.GetSegmentID(),
-                   fid.get());
+        // Raw-built indexes can be rebuilt from the staged target data when
+        // analyzer/schema identity changes. The rebuild is planned after all
+        // field/index source diffs have been computed.
     }
 
     // Build current text indexed fields (fields with loaded text index stats)
@@ -973,7 +1025,7 @@ SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
         current_text_indexed.insert(FieldId(field_id));
     }
     // Also include text indexes created from raw data
-    for (const auto& field_id : created_text_indexes_) {
+    for (const auto& [field_id, _] : created_text_indexes_) {
         current_text_indexed.insert(field_id);
     }
 
@@ -1018,6 +1070,82 @@ SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
             continue;
         }
         diff.text_indexes_to_create.insert(field_id);
+    }
+}
+
+void
+SegmentLoadInfo::PlanRawBuiltTextIndexRebuilds(
+    LoadDiff& diff, const SegmentLoadInfo& new_info) const {
+    auto pair_list_contains = [](const auto& values, FieldId field_id) {
+        for (const auto& [_, field_ids] : values) {
+            if (std::find(field_ids.begin(), field_ids.end(), field_id) !=
+                field_ids.end()) {
+                return true;
+            }
+        }
+        return false;
+    };
+    auto binlog_list_contains = [](const auto& values, FieldId field_id) {
+        for (const auto& [field_ids, _] : values) {
+            if (std::find(field_ids.begin(), field_ids.end(), field_id) !=
+                field_ids.end()) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    for (const auto& [field_id, meta] : created_text_indexes_) {
+        if (!new_info.HasFieldInSchema(field_id)) {
+            continue;
+        }
+
+        bool field_data_changed =
+            // A Storage V2 manifest replacement can change a TEXT field's
+            // LOB base path even when its column-group files are identical.
+            // Treat the manifest identity itself as a raw-field dependency.
+            diff.manifest_updated || diff.load_external_manifest ||
+            binlog_list_contains(diff.binlogs_to_load, field_id) ||
+            binlog_list_contains(diff.binlogs_to_replace, field_id) ||
+            pair_list_contains(diff.column_groups_to_load, field_id) ||
+            pair_list_contains(diff.column_groups_to_replace, field_id) ||
+            pair_list_contains(diff.column_groups_to_lazyload, field_id) ||
+            pair_list_contains(diff.column_groups_to_lazyreplace, field_id) ||
+            std::find(diff.fields_to_reload.begin(),
+                      diff.fields_to_reload.end(),
+                      field_id) != diff.fields_to_reload.end() ||
+            diff.field_data_to_drop.count(field_id) > 0 ||
+            std::find(diff.fields_to_fill_default.begin(),
+                      diff.fields_to_fill_default.end(),
+                      field_id) != diff.fields_to_fill_default.end();
+
+        bool scalar_index_changed =
+            diff.indexes_to_load.count(field_id) > 0 ||
+            diff.indexes_to_replace.count(field_id) > 0 ||
+            diff.indexes_to_drop.count(field_id) > 0;
+
+        bool schema_identity_changed = !TextIndexSchemaIdentityEqual(
+            schema_->operator[](field_id),
+            new_info.schema_->operator[](field_id));
+
+        bool rebuild = schema_identity_changed;
+        switch (meta.source) {
+            case RawTextIndexSource::FieldData:
+                rebuild = rebuild || field_data_changed;
+                break;
+            case RawTextIndexSource::ScalarIndexRawData:
+                // A field-data mutation may also change source priority from
+                // scalar-index raw data to a newly resident field column.
+                rebuild = rebuild || scalar_index_changed || field_data_changed;
+                break;
+            case RawTextIndexSource::Unknown:
+                rebuild = rebuild || field_data_changed || scalar_index_changed;
+                break;
+        }
+
+        if (rebuild) {
+            diff.text_indexes_to_rebuild[field_id] = meta.source;
+        }
     }
 }
 
@@ -1158,6 +1286,8 @@ SegmentLoadInfo::ComputeDiff(SegmentLoadInfo& new_info) {
     if (!schema_->is_external_collection()) {
         ComputeDiffDefaultFields(diff, new_info);
     }
+
+    PlanRawBuiltTextIndexRebuilds(diff, new_info);
 
     return diff;
 }

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -36,6 +36,165 @@
 
 namespace milvus::segcore {
 
+namespace {
+
+template <typename StatsMap>
+void
+ValidateStatsMapFieldIds(const StatsMap& stats,
+                         std::string_view kind,
+                         int64_t segment_id) {
+    for (const auto& [field_id, value] : stats) {
+        if (value.fieldid() != field_id) {
+            ThrowInfo(ErrorCode::DataFormatBroken,
+                      "{} metadata key {} disagrees with embedded field id {} "
+                      "for segment {}",
+                      kind,
+                      field_id,
+                      value.fieldid(),
+                      segment_id);
+        }
+    }
+}
+
+template <typename Repeated, typename Predicate>
+void
+PruneRepeatedByField(Repeated* values, Predicate&& keep) {
+    Repeated projected;
+    for (const auto& value : *values) {
+        if (keep(FieldId(value.fieldid()))) {
+            *projected.Add() = value;
+        }
+    }
+    values->Swap(&projected);
+}
+
+}  // namespace
+
+void
+SegmentLoadInfo::ValidateStructuralMetadata() const {
+    ValidateStatsMapFieldIds(
+        info_.textstatslogs(), "text index stats", GetSegmentID());
+    ValidateStatsMapFieldIds(
+        info_.jsonkeystatslogs(), "JSON key stats", GetSegmentID());
+}
+
+void
+SegmentLoadInfo::ProjectFieldBinlogs(
+    google::protobuf::RepeatedPtrField<proto::segcore::FieldBinlog>* logs) {
+    google::protobuf::RepeatedPtrField<proto::segcore::FieldBinlog> projected;
+    for (const auto& field_binlog : *logs) {
+        if (field_binlog.child_fields().empty()) {
+            if (HasFieldInSchema(FieldId(field_binlog.fieldid()))) {
+                *projected.Add() = field_binlog;
+            }
+            continue;
+        }
+
+        auto* retained = projected.Add();
+        *retained = field_binlog;
+        retained->clear_child_fields();
+        for (auto child_id : field_binlog.child_fields()) {
+            if (HasFieldInSchema(FieldId(child_id))) {
+                retained->add_child_fields(child_id);
+            }
+        }
+        if (retained->child_fields().empty()) {
+            projected.RemoveLast();
+        }
+    }
+    logs->Swap(&projected);
+}
+
+void
+SegmentLoadInfo::ProjectToSchema(SchemaPtr schema) {
+    AssertInfo(schema != nullptr,
+               "cannot project segment {} load info to a null schema",
+               GetSegmentID());
+    schema_ = std::move(schema);
+    ValidateStructuralMetadata();
+
+    auto keep = [this](FieldId field_id) { return HasFieldInSchema(field_id); };
+    PruneRepeatedByField(info_.mutable_index_infos(), keep);
+    ProjectFieldBinlogs(info_.mutable_binlog_paths());
+    ProjectFieldBinlogs(info_.mutable_statslogs());
+    ProjectFieldBinlogs(info_.mutable_bm25logs());
+
+    auto prune_stats = [this](auto* stats) {
+        for (auto it = stats->begin(); it != stats->end();) {
+            if (!HasFieldInSchema(FieldId(it->first))) {
+                it = stats->erase(it);
+            } else {
+                ++it;
+            }
+        }
+    };
+    prune_stats(info_.mutable_textstatslogs());
+    prune_stats(info_.mutable_jsonkeystatslogs());
+
+    PruneRuntimeStateNotInSchema();
+    BuildFieldBinlogCache();
+    ValidateSchemaProjection();
+}
+
+void
+SegmentLoadInfo::ValidateSchemaProjection() const {
+    AssertInfo(schema_ != nullptr,
+               "segment {} load info has no schema projection",
+               GetSegmentID());
+    ValidateStructuralMetadata();
+
+    auto validate_field = [this](int64_t field_id, std::string_view kind) {
+        AssertInfo(HasFieldInSchema(FieldId(field_id)),
+                   "projected {} references dropped field {} for segment {}",
+                   kind,
+                   field_id,
+                   GetSegmentID());
+    };
+    for (const auto& index_info : info_.index_infos()) {
+        validate_field(index_info.fieldid(), "index metadata");
+    }
+    for (const auto& [field_id, _] : info_.textstatslogs()) {
+        validate_field(field_id, "text index stats");
+    }
+    for (const auto& [field_id, _] : info_.jsonkeystatslogs()) {
+        validate_field(field_id, "JSON key stats");
+    }
+
+    auto validate_binlogs = [&](const auto& logs, std::string_view kind) {
+        for (const auto& field_binlog : logs) {
+            if (field_binlog.child_fields().empty()) {
+                validate_field(field_binlog.fieldid(), kind);
+                continue;
+            }
+            for (auto child_id : field_binlog.child_fields()) {
+                validate_field(child_id, kind);
+            }
+        }
+    };
+    validate_binlogs(info_.binlog_paths(), "field binlog");
+    validate_binlogs(info_.statslogs(), "stats binlog");
+    validate_binlogs(info_.bm25logs(), "BM25 binlog");
+
+    for (const auto& [field_id, _] : converted_field_index_cache_) {
+        validate_field(field_id.get(), "converted index cache");
+    }
+    for (const auto& [field_id, _] : field_index_identity_cache_) {
+        validate_field(field_id.get(), "index identity cache");
+    }
+    for (const auto& [field_id, _] : json_index_path_cache_) {
+        validate_field(field_id.get(), "JSON index path cache");
+    }
+    for (const auto& field_id : field_index_has_raw_data_) {
+        validate_field(field_id.get(), "index raw-data marker");
+    }
+    for (const auto& field_id : fields_filled_with_default_) {
+        validate_field(field_id.get(), "default-filled marker");
+    }
+    for (const auto& [field_id, _] : created_text_indexes_) {
+        validate_field(field_id.get(), "raw-built text index marker");
+    }
+}
+
 std::shared_ptr<milvus_storage::api::ColumnGroups>
 SegmentLoadInfo::GetColumnGroups() const {
     auto manifest_path = GetManifestPath();
@@ -77,13 +236,15 @@ SegmentLoadInfo::HasManifestColumn(const std::string& column_name) const {
 
 void
 SegmentLoadInfo::ValidateReopenRowCount(int64_t expected) const {
-    AssertInfo(
-        GetNumOfRows() == expected,
-        "online reopen cannot change row count for segment {}: current {}, "
-        "incoming {}; use full segment replacement instead",
-        GetSegmentID(),
-        expected,
-        GetNumOfRows());
+    if (GetNumOfRows() != expected) {
+        ThrowInfo(kNeedFullSegmentReplacement,
+                  "online reopen cannot change row count for segment {}: "
+                  "current {}, incoming {}; use full segment replacement "
+                  "instead",
+                  GetSegmentID(),
+                  expected,
+                  GetNumOfRows());
+    }
 
     if (HasManifestPath()) {
         return;
@@ -109,13 +270,16 @@ SegmentLoadInfo::ValidateReopenRowCount(int64_t expected) const {
         for (const auto& binlog : field_binlog.binlogs()) {
             actual += binlog.entries_num();
         }
-        AssertInfo(actual == expected,
-                   "online reopen row count mismatch for segment {}, field "
-                   "binlog group {}: expected {}, actual {}",
-                   GetSegmentID(),
-                   field_binlog.fieldid(),
-                   expected,
-                   actual);
+        if (actual != expected) {
+            ThrowInfo(kNeedFullSegmentReplacement,
+                      "online reopen row count mismatch for segment {}, "
+                      "field binlog group {}: expected {}, actual {}; use "
+                      "full segment replacement instead",
+                      GetSegmentID(),
+                      field_binlog.fieldid(),
+                      expected,
+                      actual);
+        }
     }
 }
 
@@ -962,26 +1126,34 @@ SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
 
         const auto* incoming_stats = new_info.GetTextStatsLog(field_id);
         const auto& incoming_meta = new_info.schema_->operator[](fid);
-        AssertInfo(
-            incoming_stats != nullptr,
-            "online reopen cannot change text index source for segment {}, "
-            "field {} from pre-built to {}; use full segment replacement "
-            "instead",
-            new_info.GetSegmentID(),
-            field_id,
-            incoming_meta.enable_match() ? "raw-built" : "none");
-        AssertInfo(
-            TextStatsLoadIdentityEqual(current_stats, *incoming_stats),
-            "online reopen cannot replace pre-built text index identity for "
-            "segment {}, field {}; use full segment replacement instead",
-            new_info.GetSegmentID(),
-            field_id);
-        AssertInfo(TextIndexSchemaIdentityEqual(schema_->operator[](fid),
-                                                incoming_meta),
-                   "online reopen cannot change text index schema identity for "
-                   "segment {}, field {}; use full segment replacement instead",
-                   new_info.GetSegmentID(),
-                   field_id);
+        if (incoming_stats == nullptr) {
+            ThrowInfo(
+                kNeedFullSegmentReplacement,
+                "online reopen cannot change text index source for segment "
+                "{}, field {} from pre-built to {}; use full segment "
+                "replacement instead",
+                new_info.GetSegmentID(),
+                field_id,
+                incoming_meta.enable_match() ? "raw-built" : "none");
+        }
+        if (!TextStatsLoadIdentityEqual(current_stats, *incoming_stats)) {
+            ThrowInfo(
+                kNeedFullSegmentReplacement,
+                "online reopen cannot replace pre-built text index identity "
+                "for segment {}, field {}; use full segment replacement "
+                "instead",
+                new_info.GetSegmentID(),
+                field_id);
+        }
+        if (!TextIndexSchemaIdentityEqual(schema_->operator[](fid),
+                                          incoming_meta)) {
+            ThrowInfo(
+                kNeedFullSegmentReplacement,
+                "online reopen cannot change text index schema identity for "
+                "segment {}, field {}; use full segment replacement instead",
+                new_info.GetSegmentID(),
+                field_id);
+        }
     }
 
     for (const auto& [fid, _] : created_text_indexes_) {
@@ -999,21 +1171,25 @@ SegmentLoadInfo::ComputeDiffTextIndexes(LoadDiff& diff,
             continue;
         }
 
-        AssertInfo(
-            new_info.GetTextStatsLog(fid.get()) == nullptr,
-            "online reopen cannot change text index source for segment {}, "
-            "field {} from raw-built to pre-built; use full segment "
-            "replacement instead",
-            new_info.GetSegmentID(),
-            fid.get());
+        if (new_info.GetTextStatsLog(fid.get()) != nullptr) {
+            ThrowInfo(
+                kNeedFullSegmentReplacement,
+                "online reopen cannot change text index source for segment "
+                "{}, field {} from raw-built to pre-built; use full segment "
+                "replacement instead",
+                new_info.GetSegmentID(),
+                fid.get());
+        }
         const auto& incoming_meta = new_info.schema_->operator[](fid);
-        AssertInfo(
-            incoming_meta.enable_match(),
-            "online reopen cannot remove raw-built text index for segment "
-            "{}, field {} while keeping the field; use full segment "
-            "replacement instead",
-            new_info.GetSegmentID(),
-            fid.get());
+        if (!incoming_meta.enable_match()) {
+            ThrowInfo(
+                kNeedFullSegmentReplacement,
+                "online reopen cannot remove raw-built text index for segment "
+                "{}, field {} while keeping the field; use full segment "
+                "replacement instead",
+                new_info.GetSegmentID(),
+                fid.get());
+        }
         // Raw-built indexes can be rebuilt from the staged target data when
         // analyzer/schema identity changes. The rebuild is planned after all
         // field/index source diffs have been computed.
@@ -1262,8 +1438,12 @@ SegmentLoadInfo::ComputeDiff(SegmentLoadInfo& new_info) {
     // - manifest -> manifest
     // Cross-category changes are not supported.
     if (HasManifestPath()) {
-        AssertInfo(new_info.HasManifestPath(),
-                   "manifest could only be updated with other manifest");
+        if (!new_info.HasManifestPath()) {
+            ThrowInfo(kNeedFullSegmentReplacement,
+                      "online reopen cannot change segment {} from manifest "
+                      "to binlog storage; use full segment replacement instead",
+                      GetSegmentID());
+        }
         if (GetManifestPath() != new_info.GetManifestPath()) {
             diff.manifest_updated = true;
             diff.new_manifest_path = new_info.GetManifestPath();
@@ -1276,9 +1456,12 @@ SegmentLoadInfo::ComputeDiff(SegmentLoadInfo& new_info) {
             ComputeDiffColumnGroups(diff, new_info);
         }
     } else {
-        AssertInfo(
-            !new_info.HasManifestPath(),
-            "field binlogs could only be updated with non-manfest load info");
+        if (new_info.HasManifestPath()) {
+            ThrowInfo(kNeedFullSegmentReplacement,
+                      "online reopen cannot change segment {} from binlog to "
+                      "manifest storage; use full segment replacement instead",
+                      GetSegmentID());
+        }
         ComputeDiffBinlogs(diff, new_info);
     }
 

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -1195,6 +1195,17 @@ class SegmentLoadInfo {
         prune_set(field_index_has_raw_data_);
         prune_set(fields_filled_with_default_);
         prune_set(created_text_indexes_);
+
+        std::vector<int64_t> dropped_text_stats_fields;
+        for (const auto& [field_id, _] : info_.textstatslogs()) {
+            if (!HasFieldInSchema(FieldId(field_id))) {
+                dropped_text_stats_fields.push_back(field_id);
+            }
+        }
+        auto* text_stats_logs = info_.mutable_textstatslogs();
+        for (auto field_id : dropped_text_stats_fields) {
+            text_stats_logs->erase(field_id);
+        }
     }
 
     void

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -40,6 +40,12 @@
 
 namespace milvus::segcore {
 
+// Online reopen cannot complete these transitions in place.  Keep this code
+// local to Milvus until it is promoted into the milvus-common ErrorCode enum;
+// it is projected to a named merr sentinel at the CGO boundary.
+inline constexpr auto kNeedFullSegmentReplacement =
+    static_cast<ErrorCode>(2047);
+
 enum class RawTextIndexSource {
     Unknown,
     FieldData,
@@ -1117,13 +1123,27 @@ class SegmentLoadInfo {
         BuildCache();
     }
 
+    /**
+     * @brief Build the schema-effective view of persisted segment metadata.
+     *
+     * Storage manifests are historical inputs and can legitimately retain
+     * metadata for fields dropped by a newer collection schema.  Every load
+     * path must project that raw input before diff computation or publication.
+     * Structural inconsistencies inside the persisted metadata are rejected;
+     * historical entries for dropped fields are removed silently.
+     */
     void
-    ReplaceSchemaForReopen(SchemaPtr schema) {
-        if (!schema) {
-            return;
-        }
-        schema_ = std::move(schema);
-        PruneRuntimeStateNotInSchema();
+    ProjectToSchema(SchemaPtr schema);
+
+    /**
+     * @brief Validate that this instance is a canonical schema projection.
+     */
+    void
+    ValidateSchemaProjection() const;
+
+    [[nodiscard]] const SchemaPtr&
+    GetSchema() const {
+        return schema_;
     }
 
     void
@@ -1223,6 +1243,13 @@ class SegmentLoadInfo {
 
  private:
     void
+    ValidateStructuralMetadata() const;
+
+    void
+    ProjectFieldBinlogs(
+        google::protobuf::RepeatedPtrField<proto::segcore::FieldBinlog>* logs);
+
+    void
     PruneRuntimeStateNotInSchema() {
         auto prune_map = [this](auto& values) {
             for (auto it = values.begin(); it != values.end();) {
@@ -1249,17 +1276,6 @@ class SegmentLoadInfo {
         prune_set(field_index_has_raw_data_);
         prune_set(fields_filled_with_default_);
         prune_map(created_text_indexes_);
-
-        std::vector<int64_t> dropped_text_stats_fields;
-        for (const auto& [field_id, _] : info_.textstatslogs()) {
-            if (!HasFieldInSchema(FieldId(field_id))) {
-                dropped_text_stats_fields.push_back(field_id);
-            }
-        }
-        auto* text_stats_logs = info_.mutable_textstatslogs();
-        for (auto field_id : dropped_text_stats_fields) {
-            text_stats_logs->erase(field_id);
-        }
     }
 
     void

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -40,6 +40,16 @@
 
 namespace milvus::segcore {
 
+enum class RawTextIndexSource {
+    Unknown,
+    FieldData,
+    ScalarIndexRawData,
+};
+
+struct RawBuiltTextIndexMeta {
+    RawTextIndexSource source{RawTextIndexSource::Unknown};
+};
+
 /**
  * @brief Structure representing the difference between two SegmentLoadInfos,
  *       used for reopening segments.
@@ -122,6 +132,11 @@ struct LoadDiff {
     // Text fields that need text indexes created from raw data
     std::unordered_set<FieldId> text_indexes_to_create;
 
+    // Existing raw-built text indexes whose underlying field/index source is
+    // being replaced in this reopen. Values record the source used by the
+    // currently published index; the rebuild records the actual new source.
+    std::unordered_map<FieldId, RawTextIndexSource> text_indexes_to_rebuild;
+
     // External collections with manifest should bypass ComputeDiffColumnGroups
     // (their column names are parquet field names, not numeric field IDs)
     // and use LoadColumnGroups(manifest_path) directly in ApplyLoadDiff
@@ -146,7 +161,8 @@ struct LoadDiff {
                !fields_to_fill_default.empty() ||
                !text_indexes_to_load.empty() || !json_stats_to_load.empty() ||
                !json_stats_to_replace.empty() || !json_stats_to_drop.empty() ||
-               !text_indexes_to_create.empty() || manifest_updated ||
+               !text_indexes_to_create.empty() ||
+               !text_indexes_to_rebuild.empty() || manifest_updated ||
                load_external_manifest;
     }
 
@@ -386,6 +402,17 @@ struct LoadDiff {
         }
         oss << "], ";
 
+        // text_indexes_to_rebuild
+        oss << "text_indexes_to_rebuild=[";
+        first = true;
+        for (const auto& [field_id, source] : text_indexes_to_rebuild) {
+            if (!first)
+                oss << ", ";
+            first = false;
+            oss << field_id.get() << ":" << static_cast<int>(source);
+        }
+        oss << "], ";
+
         // manifest_updated and new_manifest_path
         oss << "manifest_updated=" << (manifest_updated ? "true" : "false");
         if (manifest_updated) {
@@ -443,7 +470,7 @@ class SegmentLoadInfo {
         : info_(other.info_),
           schema_(other.schema_),
           converted_field_index_cache_(other.converted_field_index_cache_),
-          field_index_id_cache_(other.field_index_id_cache_),
+          field_index_identity_cache_(other.field_index_identity_cache_),
           json_index_path_cache_(other.json_index_path_cache_),
           field_index_has_raw_data_(other.field_index_has_raw_data_),
           fields_filled_with_default_(other.fields_filled_with_default_),
@@ -460,7 +487,8 @@ class SegmentLoadInfo {
           schema_(std::move(other.schema_)),
           converted_field_index_cache_(
               std::move(other.converted_field_index_cache_)),
-          field_index_id_cache_(std::move(other.field_index_id_cache_)),
+          field_index_identity_cache_(
+              std::move(other.field_index_identity_cache_)),
           json_index_path_cache_(std::move(other.json_index_path_cache_)),
           field_index_has_raw_data_(std::move(other.field_index_has_raw_data_)),
           fields_filled_with_default_(
@@ -481,7 +509,7 @@ class SegmentLoadInfo {
             info_ = other.info_;
             schema_ = other.schema_;
             converted_field_index_cache_ = other.converted_field_index_cache_;
-            field_index_id_cache_ = other.field_index_id_cache_;
+            field_index_identity_cache_ = other.field_index_identity_cache_;
             json_index_path_cache_ = other.json_index_path_cache_;
             field_index_has_raw_data_ = other.field_index_has_raw_data_;
             column_groups_ = other.column_groups_;
@@ -502,7 +530,8 @@ class SegmentLoadInfo {
             schema_ = std::move(other.schema_);
             converted_field_index_cache_ =
                 std::move(other.converted_field_index_cache_);
-            field_index_id_cache_ = std::move(other.field_index_id_cache_);
+            field_index_identity_cache_ =
+                std::move(other.field_index_identity_cache_);
             json_index_path_cache_ = std::move(other.json_index_path_cache_);
             field_index_has_raw_data_ =
                 std::move(other.field_index_has_raw_data_);
@@ -618,6 +647,16 @@ class SegmentLoadInfo {
     GetEstimatedBytesPerRow() const {
         return info_.estimated_bytes_per_row();
     }
+
+    /**
+     * @brief Validate that an online reopen preserves the segment row count
+     *
+     * In binlog mode, the top-level row count is only metadata. Validate each
+     * schema-visible field/column-group against the published row count too,
+     * before reopen diff computation can schedule storage IO.
+     */
+    void
+    ValidateReopenRowCount(int64_t expected) const;
 
     // ==================== Compaction Info ====================
 
@@ -974,8 +1013,11 @@ class SegmentLoadInfo {
     // ==================== Created Text Indexes Tracking ====================
 
     void
-    SetTextIndexCreated(FieldId field_id) {
-        created_text_indexes_.insert(field_id);
+    SetTextIndexCreated(
+        FieldId field_id,
+        RawTextIndexSource source = RawTextIndexSource::Unknown) {
+        created_text_indexes_.insert_or_assign(field_id,
+                                               RawBuiltTextIndexMeta{source});
     }
 
     [[nodiscard]] bool
@@ -984,7 +1026,19 @@ class SegmentLoadInfo {
                created_text_indexes_.end();
     }
 
-    [[nodiscard]] const std::unordered_set<FieldId>&
+    [[nodiscard]] RawTextIndexSource
+    GetTextIndexCreatedSource(FieldId field_id) const {
+        auto it = created_text_indexes_.find(field_id);
+        return it == created_text_indexes_.end() ? RawTextIndexSource::Unknown
+                                                 : it->second.source;
+    }
+
+    void
+    ClearTextIndexCreated(FieldId field_id) {
+        created_text_indexes_.erase(field_id);
+    }
+
+    [[nodiscard]] const std::unordered_map<FieldId, RawBuiltTextIndexMeta>&
     GetCreatedTextIndexes() const {
         return created_text_indexes_;
     }
@@ -1190,11 +1244,11 @@ class SegmentLoadInfo {
         };
 
         prune_map(converted_field_index_cache_);
-        prune_map(field_index_id_cache_);
+        prune_map(field_index_identity_cache_);
         prune_map(json_index_path_cache_);
         prune_set(field_index_has_raw_data_);
         prune_set(fields_filled_with_default_);
-        prune_set(created_text_indexes_);
+        prune_map(created_text_indexes_);
 
         std::vector<int64_t> dropped_text_stats_fields;
         for (const auto& [field_id, _] : info_.textstatslogs()) {
@@ -1225,7 +1279,7 @@ class SegmentLoadInfo {
 
         // Convert index infos to LoadIndexInfo and build per-field cache
         converted_field_index_cache_.clear();
-        field_index_id_cache_.clear();
+        field_index_identity_cache_.clear();
         json_index_path_cache_.clear();
         field_index_has_raw_data_.clear();
         for (int i = 0; i < info_.index_infos_size(); i++) {
@@ -1237,7 +1291,6 @@ class SegmentLoadInfo {
             if (!HasFieldInSchema(field_id)) {
                 continue;
             }
-            field_index_id_cache_[field_id].push_back(index_info.indexid());
             auto load_index_info = ConvertFieldIndexInfoToLoadIndexInfo(
                 &index_info, info_.segmentid());
             auto index_type_it =
@@ -1262,6 +1315,8 @@ class SegmentLoadInfo {
             if (CheckIndexHasRawData(load_index_info)) {
                 field_index_has_raw_data_.insert(field_id);
             }
+            field_index_identity_cache_[field_id].push_back(
+                FieldIndexIdentity::From(load_index_info));
             if (load_index_info.field_type == DataType::JSON) {
                 auto path_it = load_index_info.index_params.find(JSON_PATH);
                 if (path_it != load_index_info.index_params.end()) {
@@ -1295,6 +1350,10 @@ class SegmentLoadInfo {
     void
     ComputeDiffJsonKeyStats(LoadDiff& diff, SegmentLoadInfo& new_info);
 
+    void
+    PlanRawBuiltTextIndexRebuilds(LoadDiff& diff,
+                                  const SegmentLoadInfo& new_info) const;
+
     [[nodiscard]] std::set<FieldId>
     CollectDataFields() const;
 
@@ -1306,10 +1365,48 @@ class SegmentLoadInfo {
     std::unordered_map<FieldId, std::vector<LoadIndexInfo>>
         converted_field_index_cache_;
 
-    // Lightweight runtime identity for current loaded indexes. Manifest mode
-    // can drop converted_field_index_cache_ after load, but reopen diff still
-    // needs to know which index ids are already present per field.
-    std::unordered_map<FieldId, std::vector<int64_t>> field_index_id_cache_;
+    struct FieldIndexIdentity {
+        int64_t index_id{0};
+        int64_t build_id{0};
+        int64_t index_version{0};
+        proto::index::IndexStorePathVersion store_path_version{
+            proto::index::IndexStorePathVersion::
+                INDEX_STORE_PATH_VERSION_BUILD_ROOTED};
+        IndexVersion index_engine_version{};
+        bool enable_mmap{false};
+        std::map<std::string, std::string> index_params;
+        std::vector<std::string> index_files;
+
+        static FieldIndexIdentity
+        From(const LoadIndexInfo& info) {
+            return FieldIndexIdentity{info.index_id,
+                                      info.index_build_id,
+                                      info.index_version,
+                                      info.index_store_path_version,
+                                      info.index_engine_version,
+                                      info.enable_mmap,
+                                      info.index_params,
+                                      info.index_files};
+        }
+
+        bool
+        operator==(const FieldIndexIdentity& other) const {
+            return index_id == other.index_id && build_id == other.build_id &&
+                   index_version == other.index_version &&
+                   store_path_version == other.store_path_version &&
+                   index_engine_version == other.index_engine_version &&
+                   enable_mmap == other.enable_mmap &&
+                   index_params == other.index_params &&
+                   index_files == other.index_files;
+        }
+    };
+
+    // Full runtime identity for current loaded indexes. Manifest mode drops
+    // converted_field_index_cache_ after load, but reopen still has to detect
+    // a rebuilt index whose index_id stayed constant while build/version/files
+    // changed.
+    std::unordered_map<FieldId, std::vector<FieldIndexIdentity>>
+        field_index_identity_cache_;
 
     // Lightweight JSON index identity retained after manifest load-info
     // compaction so reopen can drop one nested path without affecting sibling
@@ -1333,7 +1430,7 @@ class SegmentLoadInfo {
 
     // Field IDs where text indexes were created from raw data (not loaded from files)
     // These should NOT be re-loaded in diff computation
-    std::unordered_set<FieldId> created_text_indexes_;
+    std::unordered_map<FieldId, RawBuiltTextIndexMeta> created_text_indexes_;
 };
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -456,8 +456,6 @@ TEST_F(SegmentLoadInfoTest,
         std::make_shared<milvus_storage::api::ColumnGroups>());
     current_info.SetFieldFilledWithDefault(FieldId(101));
     current_info.SetFieldFilledWithDefault(FieldId(102));
-    current_info.SetTextIndexCreated(FieldId(101));
-    current_info.SetTextIndexCreated(FieldId(102));
     current_info.CompactRuntimeInfoForManifest();
 
     auto new_schema = std::make_shared<Schema>();
@@ -478,8 +476,7 @@ TEST_F(SegmentLoadInfoTest,
     EXPECT_FALSE(new_info.HasIndexInfo(FieldId(102)));
     EXPECT_FALSE(new_info.IsFieldFilledWithDefault(FieldId(101)));
     EXPECT_TRUE(new_info.IsFieldFilledWithDefault(FieldId(102)));
-    EXPECT_FALSE(new_info.HasTextIndexCreated(FieldId(101)));
-    EXPECT_TRUE(new_info.HasTextIndexCreated(FieldId(102)));
+    EXPECT_FALSE(new_info.HasTextStatsLog(101));
 
     auto diff = current_info.ComputeDiff(new_info);
     EXPECT_TRUE(diff.indexes_to_load.empty());
@@ -1756,6 +1753,84 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffTextIndexAlreadyLoaded) {
     EXPECT_TRUE(diff.text_indexes_to_create.empty());
 }
 
+TEST_F(SegmentLoadInfoTest, RejectsPrebuiltTextIndexIdentityChange) {
+    auto text_schema = CreateSchemaWithTextMatchField();
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto& current_stats = (*current_proto.mutable_textstatslogs())[102];
+    current_stats.set_fieldid(102);
+    current_stats.set_version(1);
+    current_stats.set_buildid(5001);
+    current_stats.set_memory_size(1024);
+    current_stats.set_current_scalar_index_version(3);
+    current_stats.set_base_path("/text/index/v1");
+    current_stats.add_files("index.bin");
+
+    auto new_proto = current_proto;
+    (*new_proto.mutable_textstatslogs())[102].set_version(2);
+
+    SegmentLoadInfo current_info(current_proto, text_schema);
+    SegmentLoadInfo new_info(new_proto, text_schema);
+    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+}
+
+TEST_F(SegmentLoadInfoTest, RejectsPrebuiltTextIndexSchemaIdentityChange) {
+    auto old_schema = CreateSchemaWithTextMatchField();
+
+    auto new_schema = std::make_shared<Schema>();
+    new_schema->AddDebugField("pk", DataType::INT64);
+    new_schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    std::map<std::string, std::string> analyzer_params = {
+        {"analyzer_params", R"({"tokenizer":"standard"})"}};
+    new_schema->AddDebugVarcharField(FieldName("text_field"),
+                                     DataType::VARCHAR,
+                                     /*max_length=*/65535,
+                                     /*nullable=*/false,
+                                     /*enable_match=*/true,
+                                     /*enable_analyzer=*/true,
+                                     analyzer_params,
+                                     std::nullopt);
+    new_schema->AddDebugField("plain_varchar", DataType::VARCHAR);
+    new_schema->set_primary_field_id(FieldId(100));
+
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+    auto& text_stats = (*proto.mutable_textstatslogs())[102];
+    text_stats.set_fieldid(102);
+    text_stats.set_version(1);
+    text_stats.set_buildid(5001);
+    text_stats.add_files("/path/to/text_index");
+
+    SegmentLoadInfo current_info(proto, old_schema);
+    SegmentLoadInfo new_info(proto, new_schema);
+    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+}
+
+TEST_F(SegmentLoadInfoTest, RejectsPrebuiltToRawBuiltTextIndexChange) {
+    auto text_schema = CreateSchemaWithTextMatchField();
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto& current_stats = (*current_proto.mutable_textstatslogs())[102];
+    current_stats.set_fieldid(102);
+    current_stats.set_version(1);
+    current_stats.set_buildid(5001);
+    current_stats.add_files("/path/to/text_index");
+
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+
+    SegmentLoadInfo current_info(current_proto, text_schema);
+    SegmentLoadInfo new_info(new_proto, text_schema);
+    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+}
+
 TEST_F(SegmentLoadInfoTest, ComputeDiffTextIndexCreatedFromRawData) {
     // ComputeDiff: current already created text index from raw data ->
     // should not be re-created or re-loaded
@@ -1776,6 +1851,79 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffTextIndexCreatedFromRawData) {
     EXPECT_TRUE(diff.text_indexes_to_create.count(FieldId(102)) == 0);
     // Field 102 should NOT be in text_indexes_to_load (no stats in new)
     EXPECT_TRUE(diff.text_indexes_to_load.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, RejectsRawBuiltToPrebuiltTextIndexChange) {
+    auto text_schema = CreateSchemaWithTextMatchField();
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    auto& incoming_stats = (*new_proto.mutable_textstatslogs())[102];
+    incoming_stats.set_fieldid(102);
+    incoming_stats.set_version(1);
+    incoming_stats.set_buildid(5001);
+    incoming_stats.add_files("/path/to/text_index");
+
+    SegmentLoadInfo current_info(current_proto, text_schema);
+    current_info.SetTextIndexCreated(FieldId(102));
+    SegmentLoadInfo new_info(new_proto, text_schema);
+    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+}
+
+TEST_F(SegmentLoadInfoTest, RejectsRawBuiltTextIndexSchemaIdentityChange) {
+    auto old_schema = CreateSchemaWithTextMatchField();
+
+    auto new_schema = std::make_shared<Schema>();
+    new_schema->AddDebugField("pk", DataType::INT64);
+    new_schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    std::map<std::string, std::string> analyzer_params = {
+        {"analyzer_params", R"({"tokenizer":"standard"})"}};
+    new_schema->AddDebugVarcharField(FieldName("text_field"),
+                                     DataType::VARCHAR,
+                                     /*max_length=*/65535,
+                                     /*nullable=*/false,
+                                     /*enable_match=*/true,
+                                     /*enable_analyzer=*/true,
+                                     analyzer_params,
+                                     std::nullopt);
+    new_schema->AddDebugField("plain_varchar", DataType::VARCHAR);
+    new_schema->set_primary_field_id(FieldId(100));
+
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+
+    SegmentLoadInfo current_info(proto, old_schema);
+    current_info.SetTextIndexCreated(FieldId(102));
+    SegmentLoadInfo new_info(proto, new_schema);
+    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+}
+
+TEST_F(SegmentLoadInfoTest, RejectsRawBuiltTextIndexRemovalWithFieldRetained) {
+    auto old_schema = CreateSchemaWithTextMatchField();
+
+    auto new_schema = std::make_shared<Schema>();
+    new_schema->AddDebugField("pk", DataType::INT64);
+    new_schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    new_schema->AddDebugField("text_field", DataType::VARCHAR);
+    new_schema->AddDebugField("plain_varchar", DataType::VARCHAR);
+    new_schema->set_primary_field_id(FieldId(100));
+
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+
+    SegmentLoadInfo current_info(proto, old_schema);
+    current_info.SetTextIndexCreated(FieldId(102));
+    SegmentLoadInfo new_info(proto, new_schema);
+    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
 }
 
 TEST_F(SegmentLoadInfoTest, ComputeDiffTextIndexCreateForUnindexed) {
@@ -3730,7 +3878,12 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffTextIndexesDroppedField) {
     new_schema->AddDebugField(
         "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
     // Skip field 102 (dropped)
-    new_schema->AddDebugField("plain_varchar", DataType::VARCHAR);
+    new_schema->AddField(FieldName("plain_varchar"),
+                         FieldId(103),
+                         DataType::VARCHAR,
+                         /*max_length=*/65535,
+                         /*nullable=*/false,
+                         std::nullopt);
     new_schema->set_primary_field_id(FieldId(100));
 
     proto::segcore::SegmentLoadInfo current_proto;
@@ -3742,12 +3895,50 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffTextIndexesDroppedField) {
     new_proto.set_num_of_rows(1000);
 
     SegmentLoadInfo current_info(current_proto, old_schema);
+    current_info.SetTextIndexCreated(FieldId(102));
     SegmentLoadInfo new_info(new_proto, new_schema);
     auto diff = current_info.ComputeDiff(new_info);
 
     // Field 102 is dropped — it should NOT be in text_indexes_to_create
     EXPECT_TRUE(diff.text_indexes_to_create.count(FieldId(102)) == 0)
         << "Dropped field 102 should not be in text_indexes_to_create";
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ReplaceSchemaForReopenPrunesDroppedRawBuiltTextIndex) {
+    auto old_schema = CreateSchemaWithTextMatchField();
+
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+    SegmentLoadInfo current_info(proto, old_schema);
+    current_info.SetTextIndexCreated(FieldId(102));
+
+    auto new_schema = std::make_shared<Schema>();
+    new_schema->AddField(
+        FieldName("pk"), FieldId(100), DataType::INT64, false, std::nullopt);
+    new_schema->AddField(FieldName("vec"),
+                         FieldId(101),
+                         DataType::VECTOR_FLOAT,
+                         128,
+                         knowhere::metric::L2,
+                         false);
+    new_schema->AddField(FieldName("plain_varchar"),
+                         FieldId(103),
+                         DataType::VARCHAR,
+                         /*max_length=*/65535,
+                         /*nullable=*/false,
+                         std::nullopt);
+    new_schema->set_primary_field_id(FieldId(100));
+    new_schema->set_schema_version(old_schema->get_schema_version() + 1);
+
+    SegmentLoadInfo new_info(current_info);
+    new_info.ReplaceSchemaForReopen(new_schema);
+    EXPECT_FALSE(new_info.HasTextIndexCreated(FieldId(102)));
+
+    auto diff = current_info.ComputeDiff(new_info);
+    EXPECT_TRUE(diff.text_indexes_to_load.empty());
+    EXPECT_TRUE(diff.text_indexes_to_create.empty());
 }
 
 // NOTE: ComputeDiffIndexes also has a schema filter for dropped fields, but

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -44,6 +44,21 @@
 using namespace milvus;
 using namespace milvus::segcore;
 
+namespace {
+
+template <typename Fn>
+void
+ExpectNeedFullSegmentReplacement(Fn&& fn) {
+    try {
+        fn();
+        FAIL() << "transition should require full segment replacement";
+    } catch (const SegcoreError& err) {
+        EXPECT_EQ(err.get_error_code(), kNeedFullSegmentReplacement);
+    }
+}
+
+}  // namespace
+
 class SegmentLoadInfoTest : public ::testing::Test {
  protected:
     void
@@ -439,7 +454,7 @@ TEST_F(SegmentLoadInfoTest,
     new_schema->set_schema_version(schema_->get_schema_version() + 1);
 
     SegmentLoadInfo new_info(current_info);
-    new_info.ReplaceSchemaForReopen(new_schema);
+    new_info.ProjectToSchema(new_schema);
     auto diff = current_info.ComputeDiff(new_info);
 
     EXPECT_TRUE(diff.indexes_to_load.empty());
@@ -451,8 +466,7 @@ TEST_F(SegmentLoadInfoTest,
               diff.fields_to_fill_default.end());
 }
 
-TEST_F(SegmentLoadInfoTest,
-       ReplaceSchemaForReopenPrunesDroppedFieldRuntimeState) {
+TEST_F(SegmentLoadInfoTest, ProjectToSchemaPrunesDroppedFieldRuntimeState) {
     SegmentLoadInfo current_info(proto_, schema_);
     current_info.SetColumnGroupsForTesting(
         std::make_shared<milvus_storage::api::ColumnGroups>());
@@ -472,7 +486,7 @@ TEST_F(SegmentLoadInfoTest,
     new_schema->set_schema_version(schema_->get_schema_version() + 1);
 
     SegmentLoadInfo new_info(current_info);
-    new_info.ReplaceSchemaForReopen(new_schema);
+    new_info.ProjectToSchema(new_schema);
 
     EXPECT_FALSE(new_info.HasIndexInfo(FieldId(101)));
     EXPECT_FALSE(new_info.HasIndexInfo(FieldId(102)));
@@ -486,11 +500,88 @@ TEST_F(SegmentLoadInfoTest,
     EXPECT_EQ(diff.indexes_to_drop, std::set<FieldId>({FieldId(101)}));
 
     SegmentLoadInfo next_info(new_info);
-    next_info.ReplaceSchemaForReopen(new_schema);
+    next_info.ProjectToSchema(new_schema);
     auto second_diff = new_info.ComputeDiff(next_info);
     EXPECT_TRUE(second_diff.indexes_to_load.empty());
     EXPECT_TRUE(second_diff.indexes_to_replace.empty());
     EXPECT_TRUE(second_diff.indexes_to_drop.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, ProjectToSchemaNormalizesAllSchemaScopedMetadata) {
+    auto raw = proto_;
+    auto* dropped_index = raw.add_index_infos();
+    dropped_index->set_fieldid(110);
+    dropped_index->set_indexid(9999);
+    dropped_index->add_index_file_paths("/path/to/dropped-index");
+
+    auto& dropped_text = (*raw.mutable_textstatslogs())[110];
+    dropped_text.set_fieldid(110);
+    dropped_text.set_version(1);
+    auto& dropped_json = (*raw.mutable_jsonkeystatslogs())[110];
+    dropped_json.set_fieldid(110);
+    dropped_json.set_version(1);
+
+    auto* mixed_stats = raw.add_statslogs();
+    mixed_stats->set_fieldid(200);
+    mixed_stats->add_child_fields(105);
+    mixed_stats->add_child_fields(110);
+    mixed_stats->add_binlogs()->set_log_path("/path/to/mixed-stats");
+
+    auto projected_schema = std::make_shared<Schema>();
+    projected_schema->AddField(
+        FieldName("pk"), FieldId(100), DataType::INT64, false, std::nullopt);
+    projected_schema->AddField(FieldName("json_field"),
+                               FieldId(102),
+                               DataType::JSON,
+                               false,
+                               std::nullopt);
+    projected_schema->AddField(FieldName("child_field1"),
+                               FieldId(105),
+                               DataType::FLOAT,
+                               false,
+                               std::nullopt);
+    projected_schema->set_primary_field_id(FieldId(100));
+    projected_schema->set_schema_version(schema_->get_schema_version() + 1);
+
+    // Construct against the target schema so historical metadata for dropped
+    // fields is not interpreted before canonical projection removes it.
+    SegmentLoadInfo info(raw, projected_schema);
+    info.SetFieldFilledWithDefault(FieldId(110));
+    info.SetTextIndexCreated(FieldId(110));
+    info.ProjectToSchema(projected_schema);
+
+    EXPECT_FALSE(info.HasIndexInfo(FieldId(110)));
+    EXPECT_FALSE(info.HasTextStatsLog(110));
+    EXPECT_FALSE(info.HasJsonKeyStatsLog(110));
+    EXPECT_FALSE(info.IsFieldFilledWithDefault(FieldId(110)));
+    EXPECT_FALSE(info.HasTextIndexCreated(FieldId(110)));
+    EXPECT_EQ(info.GetDeltalogCount(), proto_.deltalogs_size());
+
+    ASSERT_EQ(info.GetBinlogPathCount(), 1);
+    ASSERT_EQ(info.GetBinlogPath(0).child_fields_size(), 1);
+    EXPECT_EQ(info.GetBinlogPath(0).child_fields(0), 105);
+
+    ASSERT_EQ(info.GetStatslogCount(), 1);
+    ASSERT_EQ(info.GetStatslog(0).child_fields_size(), 1);
+    EXPECT_EQ(info.GetStatslog(0).child_fields(0), 105);
+    EXPECT_EQ(info.GetBm25logCount(), 0);
+    EXPECT_NO_THROW(info.ValidateSchemaProjection());
+}
+
+TEST_F(SegmentLoadInfoTest, ProjectToSchemaRejectsStatsMapFieldIdMismatch) {
+    auto raw = proto_;
+    (*raw.mutable_textstatslogs())[101].set_fieldid(102);
+    SegmentLoadInfo info(raw, schema_);
+
+    try {
+        info.ProjectToSchema(schema_);
+        FAIL() << "structurally corrupt text stats should be rejected";
+    } catch (const SegcoreError& err) {
+        EXPECT_EQ(err.get_error_code(), ErrorCode::DataFormatBroken);
+        EXPECT_NE(
+            std::string(err.what()).find("disagrees with embedded field id"),
+            std::string::npos);
+    }
 }
 
 TEST_F(SegmentLoadInfoTest, BinlogInfo) {
@@ -541,7 +632,7 @@ TEST_F(SegmentLoadInfoTest, ValidateReopenRowCountRejectsRetainedGroup) {
         info.ValidateReopenRowCount(1000);
         FAIL() << "mismatched retained column group should be rejected";
     } catch (const SegcoreError& err) {
-        EXPECT_EQ(err.get_error_code(), ErrorCode::UnexpectedError);
+        EXPECT_EQ(err.get_error_code(), kNeedFullSegmentReplacement);
         EXPECT_NE(std::string(err.what()).find("field binlog group 104"),
                   std::string::npos);
         EXPECT_NE(std::string(err.what()).find("expected 1000, actual 999"),
@@ -564,6 +655,35 @@ TEST_F(SegmentLoadInfoTest, ValidateReopenRowCountIgnoresDroppedGroup) {
 
     SegmentLoadInfo info(proto, reduced_schema);
     EXPECT_NO_THROW(info.ValidateReopenRowCount(1000));
+}
+
+TEST_F(SegmentLoadInfoTest, ManifestToBinlogRequiresFullReplacement) {
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    current_proto.set_manifest_path("/manifest/current");
+
+    auto new_proto = current_proto;
+    new_proto.clear_manifest_path();
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    ExpectNeedFullSegmentReplacement(
+        [&] { current_info.ComputeDiff(new_info); });
+}
+
+TEST_F(SegmentLoadInfoTest, BinlogToManifestRequiresFullReplacement) {
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+
+    auto new_proto = current_proto;
+    new_proto.set_manifest_path("/manifest/new");
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    ExpectNeedFullSegmentReplacement(
+        [&] { current_info.ComputeDiff(new_info); });
 }
 
 TEST_F(SegmentLoadInfoTest, ColumnGroup) {
@@ -1825,7 +1945,8 @@ TEST_F(SegmentLoadInfoTest, RejectsPrebuiltTextIndexIdentityChange) {
 
     SegmentLoadInfo current_info(current_proto, text_schema);
     SegmentLoadInfo new_info(new_proto, text_schema);
-    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+    ExpectNeedFullSegmentReplacement(
+        [&] { current_info.ComputeDiff(new_info); });
 }
 
 TEST_F(SegmentLoadInfoTest, RejectsPrebuiltTextIndexSchemaIdentityChange) {
@@ -1859,7 +1980,8 @@ TEST_F(SegmentLoadInfoTest, RejectsPrebuiltTextIndexSchemaIdentityChange) {
 
     SegmentLoadInfo current_info(proto, old_schema);
     SegmentLoadInfo new_info(proto, new_schema);
-    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+    ExpectNeedFullSegmentReplacement(
+        [&] { current_info.ComputeDiff(new_info); });
 }
 
 TEST_F(SegmentLoadInfoTest, RejectsPrebuiltToRawBuiltTextIndexChange) {
@@ -1880,7 +2002,8 @@ TEST_F(SegmentLoadInfoTest, RejectsPrebuiltToRawBuiltTextIndexChange) {
 
     SegmentLoadInfo current_info(current_proto, text_schema);
     SegmentLoadInfo new_info(new_proto, text_schema);
-    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+    ExpectNeedFullSegmentReplacement(
+        [&] { current_info.ComputeDiff(new_info); });
 }
 
 TEST_F(SegmentLoadInfoTest, ComputeDiffTextIndexCreatedFromRawData) {
@@ -1924,7 +2047,8 @@ TEST_F(SegmentLoadInfoTest, RejectsRawBuiltToPrebuiltTextIndexChange) {
     SegmentLoadInfo current_info(current_proto, text_schema);
     current_info.SetTextIndexCreated(FieldId(102));
     SegmentLoadInfo new_info(new_proto, text_schema);
-    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+    ExpectNeedFullSegmentReplacement(
+        [&] { current_info.ComputeDiff(new_info); });
 }
 
 TEST_F(SegmentLoadInfoTest, RebuildsRawBuiltTextIndexOnSchemaIdentityChange) {
@@ -2089,7 +2213,8 @@ TEST_F(SegmentLoadInfoTest, RejectsRawBuiltTextIndexRemovalWithFieldRetained) {
     SegmentLoadInfo current_info(proto, old_schema);
     current_info.SetTextIndexCreated(FieldId(102));
     SegmentLoadInfo new_info(proto, new_schema);
-    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+    ExpectNeedFullSegmentReplacement(
+        [&] { current_info.ComputeDiff(new_info); });
 }
 
 TEST_F(SegmentLoadInfoTest, ComputeDiffTextIndexCreateForUnindexed) {
@@ -4118,8 +4243,7 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffTextIndexesDroppedField) {
         << "Dropped field 102 should not be in text_indexes_to_create";
 }
 
-TEST_F(SegmentLoadInfoTest,
-       ReplaceSchemaForReopenPrunesDroppedRawBuiltTextIndex) {
+TEST_F(SegmentLoadInfoTest, ProjectToSchemaPrunesDroppedRawBuiltTextIndex) {
     auto old_schema = CreateSchemaWithTextMatchField();
 
     proto::segcore::SegmentLoadInfo proto;
@@ -4147,7 +4271,7 @@ TEST_F(SegmentLoadInfoTest,
     new_schema->set_schema_version(old_schema->get_schema_version() + 1);
 
     SegmentLoadInfo new_info(current_info);
-    new_info.ReplaceSchemaForReopen(new_schema);
+    new_info.ProjectToSchema(new_schema);
     EXPECT_FALSE(new_info.HasTextIndexCreated(FieldId(102)));
 
     auto diff = current_info.ComputeDiff(new_info);

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -371,6 +371,7 @@ TEST_F(SegmentLoadInfoTest,
     auto* cur_index = current_proto.add_index_infos();
     cur_index->set_fieldid(101);
     cur_index->set_indexid(1001);
+    cur_index->set_buildid(5001);
     cur_index->add_index_file_paths("/path/to/old_index");
     auto* cur_param = cur_index->add_index_params();
     cur_param->set_key("index_type");
@@ -382,7 +383,8 @@ TEST_F(SegmentLoadInfoTest,
     new_proto.set_manifest_path("/path/to/current_manifest");
     auto* new_index = new_proto.add_index_infos();
     new_index->set_fieldid(101);
-    new_index->set_indexid(2001);
+    new_index->set_indexid(1001);
+    new_index->set_buildid(5002);
     new_index->add_index_file_paths("/path/to/new_index");
     auto* new_param = new_index->add_index_params();
     new_param->set_key("index_type");
@@ -404,9 +406,9 @@ TEST_F(SegmentLoadInfoTest,
     EXPECT_EQ(diff.indexes_to_replace.size(), 1);
     ASSERT_TRUE(diff.indexes_to_replace.count(FieldId(101)) > 0);
     ASSERT_EQ(diff.indexes_to_replace[FieldId(101)].size(), 1);
-    EXPECT_EQ(diff.indexes_to_replace[FieldId(101)][0].index_id, 2001);
-    EXPECT_EQ(diff.indexes_to_drop.size(), 1);
-    EXPECT_TRUE(diff.indexes_to_drop.count(FieldId(101)) > 0);
+    EXPECT_EQ(diff.indexes_to_replace[FieldId(101)][0].index_id, 1001);
+    EXPECT_EQ(diff.indexes_to_replace[FieldId(101)][0].index_build_id, 5002);
+    EXPECT_TRUE(diff.indexes_to_drop.empty());
 }
 
 TEST_F(SegmentLoadInfoTest,
@@ -517,6 +519,51 @@ TEST_F(SegmentLoadInfoTest, BinlogInfo) {
 
     auto zero_count = info.GetFieldBinlogRowCount(FieldId(999));
     EXPECT_EQ(zero_count, 0);
+}
+
+TEST_F(SegmentLoadInfoTest, ValidateReopenRowCountAcceptsMatchingBinlogs) {
+    auto proto = proto_;
+    proto.clear_manifest_path();
+    proto.set_num_of_rows(1000);
+
+    SegmentLoadInfo info(proto, schema_);
+    EXPECT_NO_THROW(info.ValidateReopenRowCount(1000));
+}
+
+TEST_F(SegmentLoadInfoTest, ValidateReopenRowCountRejectsRetainedGroup) {
+    auto proto = proto_;
+    proto.clear_manifest_path();
+    proto.set_num_of_rows(1000);
+    proto.mutable_binlog_paths(1)->mutable_binlogs(0)->set_entries_num(999);
+
+    SegmentLoadInfo info(proto, schema_);
+    try {
+        info.ValidateReopenRowCount(1000);
+        FAIL() << "mismatched retained column group should be rejected";
+    } catch (const SegcoreError& err) {
+        EXPECT_EQ(err.get_error_code(), ErrorCode::UnexpectedError);
+        EXPECT_NE(std::string(err.what()).find("field binlog group 104"),
+                  std::string::npos);
+        EXPECT_NE(std::string(err.what()).find("expected 1000, actual 999"),
+                  std::string::npos);
+    }
+}
+
+TEST_F(SegmentLoadInfoTest, ValidateReopenRowCountIgnoresDroppedGroup) {
+    auto proto = proto_;
+    proto.clear_manifest_path();
+    proto.clear_index_infos();
+    proto.set_num_of_rows(1000);
+    proto.mutable_binlog_paths(1)->mutable_binlogs(0)->set_entries_num(999);
+
+    auto reduced_schema = std::make_shared<Schema>();
+    auto pk = reduced_schema->AddDebugField("pk", DataType::INT64);
+    reduced_schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    reduced_schema->set_primary_field_id(pk);
+
+    SegmentLoadInfo info(proto, reduced_schema);
+    EXPECT_NO_THROW(info.ValidateReopenRowCount(1000));
 }
 
 TEST_F(SegmentLoadInfoTest, ColumnGroup) {
@@ -1519,14 +1566,19 @@ TEST_F(SegmentLoadInfoTest, CreatedTextIndexesCopyConstructor) {
     proto.set_num_of_rows(1000);
 
     SegmentLoadInfo info1(proto, schema_);
-    info1.SetTextIndexCreated(FieldId(101));
-    info1.SetTextIndexCreated(FieldId(102));
+    info1.SetTextIndexCreated(FieldId(101), RawTextIndexSource::FieldData);
+    info1.SetTextIndexCreated(FieldId(102),
+                              RawTextIndexSource::ScalarIndexRawData);
 
     // Copy constructor
     SegmentLoadInfo info2(info1);
     EXPECT_TRUE(info2.HasTextIndexCreated(FieldId(101)));
     EXPECT_TRUE(info2.HasTextIndexCreated(FieldId(102)));
     EXPECT_FALSE(info2.HasTextIndexCreated(FieldId(103)));
+    EXPECT_EQ(info2.GetTextIndexCreatedSource(FieldId(101)),
+              RawTextIndexSource::FieldData);
+    EXPECT_EQ(info2.GetTextIndexCreatedSource(FieldId(102)),
+              RawTextIndexSource::ScalarIndexRawData);
 }
 
 TEST_F(SegmentLoadInfoTest, CreatedTextIndexesMoveConstructor) {
@@ -1875,7 +1927,7 @@ TEST_F(SegmentLoadInfoTest, RejectsRawBuiltToPrebuiltTextIndexChange) {
     EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
 }
 
-TEST_F(SegmentLoadInfoTest, RejectsRawBuiltTextIndexSchemaIdentityChange) {
+TEST_F(SegmentLoadInfoTest, RebuildsRawBuiltTextIndexOnSchemaIdentityChange) {
     auto old_schema = CreateSchemaWithTextMatchField();
 
     auto new_schema = std::make_shared<Schema>();
@@ -1900,9 +1952,123 @@ TEST_F(SegmentLoadInfoTest, RejectsRawBuiltTextIndexSchemaIdentityChange) {
     proto.set_num_of_rows(1000);
 
     SegmentLoadInfo current_info(proto, old_schema);
-    current_info.SetTextIndexCreated(FieldId(102));
+    current_info.SetTextIndexCreated(FieldId(102),
+                                     RawTextIndexSource::FieldData);
     SegmentLoadInfo new_info(proto, new_schema);
-    EXPECT_THROW(current_info.ComputeDiff(new_info), SegcoreError);
+    auto diff = current_info.ComputeDiff(new_info);
+    ASSERT_EQ(diff.text_indexes_to_rebuild.size(), 1);
+    EXPECT_EQ(diff.text_indexes_to_rebuild.at(FieldId(102)),
+              RawTextIndexSource::FieldData);
+}
+
+TEST_F(SegmentLoadInfoTest, RebuildsRawTextIndexOnlyForChangedFieldSource) {
+    auto text_schema = CreateSchemaWithTextMatchField();
+    auto add_binlog = [](proto::segcore::SegmentLoadInfo& proto,
+                         int64_t field_id,
+                         const std::string& path) {
+        auto* field_binlog = proto.add_binlog_paths();
+        field_binlog->set_fieldid(field_id);
+        auto* binlog = field_binlog->add_binlogs();
+        binlog->set_log_path(path);
+        binlog->set_entries_num(1000);
+    };
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    add_binlog(current_proto, 102, "/text/old");
+    add_binlog(current_proto, 103, "/plain/old");
+
+    SegmentLoadInfo current_info(current_proto, text_schema);
+    current_info.SetTextIndexCreated(FieldId(102),
+                                     RawTextIndexSource::FieldData);
+
+    auto unchanged_proto = current_proto;
+    SegmentLoadInfo unchanged_info(unchanged_proto, text_schema);
+    EXPECT_TRUE(current_info.ComputeDiff(unchanged_info)
+                    .text_indexes_to_rebuild.empty());
+
+    auto unrelated_proto = current_proto;
+    unrelated_proto.mutable_binlog_paths(1)->mutable_binlogs(0)->set_log_path(
+        "/plain/new");
+    SegmentLoadInfo unrelated_info(unrelated_proto, text_schema);
+    EXPECT_TRUE(current_info.ComputeDiff(unrelated_info)
+                    .text_indexes_to_rebuild.empty());
+
+    auto changed_proto = current_proto;
+    changed_proto.mutable_binlog_paths(0)->mutable_binlogs(0)->set_log_path(
+        "/text/new");
+    SegmentLoadInfo changed_info(changed_proto, text_schema);
+    auto changed_diff = current_info.ComputeDiff(changed_info);
+    ASSERT_EQ(changed_diff.text_indexes_to_rebuild.size(), 1);
+    EXPECT_EQ(changed_diff.text_indexes_to_rebuild.at(FieldId(102)),
+              RawTextIndexSource::FieldData);
+}
+
+TEST_F(SegmentLoadInfoTest,
+       RebuildsRawTextIndexWhenScalarSourceIdentityChanges) {
+    auto text_schema = CreateSchemaWithTextMatchField();
+    auto add_index = [](proto::segcore::SegmentLoadInfo& proto,
+                        int64_t build_id,
+                        const std::string& path) {
+        auto* index = proto.add_index_infos();
+        index->set_fieldid(102);
+        index->set_indexid(7001);
+        index->set_buildid(build_id);
+        index->set_index_version(3);
+        index->add_index_file_paths(path);
+        auto* param = index->add_index_params();
+        param->set_key("index_type");
+        param->set_value(milvus::index::ASCENDING_SORT);
+    };
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    add_index(current_proto, 8001, "/scalar/old");
+
+    auto new_proto = current_proto;
+    new_proto.clear_index_infos();
+    add_index(new_proto, 8002, "/scalar/new");
+
+    SegmentLoadInfo current_info(current_proto, text_schema);
+    current_info.SetTextIndexCreated(FieldId(102),
+                                     RawTextIndexSource::ScalarIndexRawData);
+    SegmentLoadInfo new_info(new_proto, text_schema);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    ASSERT_EQ(diff.indexes_to_replace.at(FieldId(102)).size(), 1);
+    ASSERT_EQ(diff.text_indexes_to_rebuild.size(), 1);
+    EXPECT_EQ(diff.text_indexes_to_rebuild.at(FieldId(102)),
+              RawTextIndexSource::ScalarIndexRawData);
+}
+
+TEST_F(SegmentLoadInfoTest, RebuildsRawTextIndexWhenManifestIdentityChanges) {
+    auto text_schema = CreateSchemaWithTextMatchField();
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    current_proto.set_manifest_path("/manifest/old");
+
+    auto new_proto = current_proto;
+    new_proto.set_manifest_path("/manifest/new");
+
+    SegmentLoadInfo current_info(current_proto, text_schema);
+    current_info.SetTextIndexCreated(FieldId(102),
+                                     RawTextIndexSource::FieldData);
+    SegmentLoadInfo new_info(new_proto, text_schema);
+    current_info.SetColumnGroupsForTesting(
+        std::make_shared<milvus_storage::api::ColumnGroups>());
+    new_info.SetColumnGroupsForTesting(
+        std::make_shared<milvus_storage::api::ColumnGroups>());
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    EXPECT_TRUE(diff.manifest_updated);
+    ASSERT_EQ(diff.text_indexes_to_rebuild.size(), 1);
+    EXPECT_EQ(diff.text_indexes_to_rebuild.at(FieldId(102)),
+              RawTextIndexSource::FieldData);
 }
 
 TEST_F(SegmentLoadInfoTest, RejectsRawBuiltTextIndexRemovalWithFieldRetained) {
@@ -2516,6 +2682,54 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffDropsJsonIndexByNestedPath) {
     auto diff = current_info.ComputeDiff(new_info);
 
     ASSERT_EQ(diff.json_indexes_to_drop.count(FieldId(102)), 1);
+    EXPECT_EQ(diff.json_indexes_to_drop.at(FieldId(102)).count("a"), 1);
+    EXPECT_EQ(diff.json_indexes_to_drop.at(FieldId(102)).count("b"), 0);
+    EXPECT_EQ(diff.indexes_to_drop.count(FieldId(102)), 0);
+}
+
+TEST_F(SegmentLoadInfoTest, ComputeDiffDropsOldJsonPathWhenSameIndexIdMoves) {
+    auto add_json_index = [](proto::segcore::SegmentLoadInfo& proto,
+                             const std::string& nested_path,
+                             const std::string& file_path) {
+        auto* index = proto.add_index_infos();
+        index->set_fieldid(102);
+        index->set_indexid(5001);
+        index->set_buildid(6001);
+        index->add_index_file_paths(file_path);
+        auto* type = index->add_index_params();
+        type->set_key(milvus::index::INDEX_TYPE);
+        type->set_value(milvus::index::INVERTED_INDEX_TYPE);
+        auto* path = index->add_index_params();
+        path->set_key(JSON_PATH);
+        path->set_value(nested_path);
+        auto* cast = index->add_index_params();
+        cast->set_key(JSON_CAST_TYPE);
+        cast->set_value("DOUBLE");
+    };
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    current_proto.set_manifest_path("/path/to/manifest");
+    add_json_index(current_proto, "a", "/path/to/json_index_a");
+
+    proto::segcore::SegmentLoadInfo new_proto;
+    new_proto.set_segmentid(100);
+    new_proto.set_num_of_rows(1000);
+    new_proto.set_manifest_path("/path/to/manifest");
+    add_json_index(new_proto, "b", "/path/to/json_index_b");
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    SegmentLoadInfo new_info(new_proto, schema_);
+    current_info.SetColumnGroupsForTesting(
+        std::make_shared<milvus_storage::api::ColumnGroups>());
+    new_info.SetColumnGroupsForTesting(
+        std::make_shared<milvus_storage::api::ColumnGroups>());
+
+    auto diff = current_info.ComputeDiff(new_info);
+
+    ASSERT_EQ(diff.indexes_to_replace.at(FieldId(102)).size(), 1);
+    ASSERT_EQ(diff.json_indexes_to_drop.at(FieldId(102)).size(), 1);
     EXPECT_EQ(diff.json_indexes_to_drop.at(FieldId(102)).count("a"), 1);
     EXPECT_EQ(diff.json_indexes_to_drop.at(FieldId(102)).count("b"), 0);
     EXPECT_EQ(diff.indexes_to_drop.count(FieldId(102)), 0);

--- a/internal/core/unittest/test_commit_timestamp.cpp
+++ b/internal/core/unittest/test_commit_timestamp.cpp
@@ -18,7 +18,8 @@
 //
 // Tests for commit_timestamp behavior in ChunkedSegmentSealedImpl (Approach A).
 // Approach A: during LoadFieldData, in-memory timestamps are overwritten to
-// commit_ts_ when commit_ts_ != 0. This file tests the four invariants:
+// the published commit timestamp when it is non-zero. This file tests the four
+// invariants:
 //
 //   I1. MVCC gate  — rows invisible for query_ts < commit_ts after overwrite
 //   I2. TTL gate   — rows NOT expired when commit_ts > ttl_threshold
@@ -498,7 +499,7 @@ TEST(CommitTimestamp, NormalSegment_BehaviorUnchanged) {
     constexpr Timestamp ROW_TS_MAX = 1009;
 
     auto dataset = DataGen(schema, N, /*seed=*/42, /*ts_offset=*/ROW_TS_MIN);
-    // No SetCommitTimestamp call -> commit_ts_=0 -> no overwrite.
+    // No SetCommitTimestamp call -> published commit_ts=0 -> no overwrite.
     auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
 
     // MVCC: query_ts=500 < ROW_TS_MIN=1000 -> all rows masked

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -4163,6 +4163,62 @@ TEST(SealedSegmentReopen, SchemaAwareReopenDiscardsOlderSchema) {
     EXPECT_TRUE(sealed->HasFieldData(new_field));
 }
 
+TEST(SealedSegmentReopen, RejectsRowCountChangeBeforePublication) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+
+    constexpr int64_t row_count = 4;
+    auto dataset = DataGen(schema, row_count);
+    auto segment = CreateSealedSegment(schema);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(kSegmentID);
+    current_proto.set_partitionid(kPartitionID);
+    current_proto.set_collectionid(kCollectionID);
+    current_proto.set_num_of_rows(row_count);
+    sealed->SetLoadInfo(current_proto);
+    LoadGeneratedDataIntoSegment(dataset, sealed);
+
+    auto before = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(before, nullptr);
+    ASSERT_NE(before->runtime, nullptr);
+    EXPECT_EQ(before->load_info->GetNumOfRows(), row_count);
+    EXPECT_EQ(before->runtime->row_count, row_count);
+
+    auto reopen_proto = current_proto;
+    reopen_proto.set_num_of_rows(row_count + 1);
+    milvus::OpContext op_ctx;
+    try {
+        sealed->Reopen(&op_ctx, reopen_proto);
+        FAIL() << "row-count-changing reopen should fail";
+    } catch (const SegcoreError& err) {
+        EXPECT_EQ(err.get_error_code(), ErrorCode::UnexpectedError);
+        EXPECT_NE(std::string(err.what())
+                      .find("online reopen cannot change row count"),
+                  std::string::npos);
+    }
+
+    auto after = sealed->TestGetPublishedStateSnapshot();
+    EXPECT_EQ(after, before);
+    EXPECT_EQ(after->load_info->GetNumOfRows(), row_count);
+    EXPECT_EQ(after->runtime->row_count, row_count);
+
+    auto pks = dataset.get_col<int64_t>(pk_id);
+    auto delete_ids = std::make_unique<IdArray>();
+    delete_ids->mutable_int_id()->add_data(pks.back());
+    Timestamp delete_ts = 1000000;
+    auto status = sealed->Delete(1, delete_ids.get(), &delete_ts);
+    ASSERT_TRUE(status.ok());
+
+    BitsetType bitset(row_count, false);
+    auto bitset_view = BitsetTypeView(bitset);
+    segment->mask_with_delete(bitset_view, row_count, delete_ts + 1);
+    EXPECT_EQ(bitset.count(), 1);
+}
+
 TEST(SealedSegmentReopen, DropFieldReopenPublishesSchemaAndLoadInfoTogether) {
     auto old_schema = std::make_shared<Schema>();
     auto pk_id = old_schema->AddDebugField("pk", DataType::INT64);
@@ -4196,7 +4252,7 @@ TEST(SealedSegmentReopen, DropFieldReopenPublishesSchemaAndLoadInfoTogether) {
     EXPECT_FALSE(sealed->FieldAccessible(dropped_id));
 }
 
-TEST(SealedSegmentReopen, TextIndexCancellationGuardDoesNotLeakPendingState) {
+TEST(SealedSegmentReopen, CancelledTextIndexBuildDoesNotPublishAndCanRetry) {
     std::map<std::string, std::string> analyzer_params;
     auto schema = std::make_shared<Schema>();
     auto pk_id = schema->AddDebugField("pk", DataType::INT64);
@@ -4210,19 +4266,79 @@ TEST(SealedSegmentReopen, TextIndexCancellationGuardDoesNotLeakPendingState) {
                                                  std::nullopt);
     schema->set_primary_field_id(pk_id);
 
-    auto segment = CreateSealedSegment(schema);
+    auto dataset = DataGen(schema, 4);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
     auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
     ASSERT_NE(sealed, nullptr);
 
-    EXPECT_FALSE(sealed->TestHasPendingTextIndex(text_fid));
-    EXPECT_FALSE(
-        sealed->TestGetLoadInfoSnapshot()->HasTextIndexCreated(text_fid));
+    auto before = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_EQ(before->runtime->text_indexes.count(text_fid), 0);
+    ASSERT_FALSE(before->load_info->HasTextIndexCreated(text_fid));
 
-    sealed->TestRegisterPendingTextIndex(text_fid);
+    folly::CancellationSource source;
+    source.requestCancellation();
+    milvus::OpContext cancelled(source.getToken());
+    EXPECT_THROW(sealed->CreateTextIndex(text_fid, &cancelled), SegcoreError);
 
-    EXPECT_FALSE(sealed->TestHasPendingTextIndex(text_fid));
-    EXPECT_FALSE(
-        sealed->TestGetLoadInfoSnapshot()->HasTextIndexCreated(text_fid));
+    auto after_cancel = sealed->TestGetPublishedStateSnapshot();
+    EXPECT_EQ(after_cancel, before);
+    EXPECT_EQ(after_cancel->runtime->text_indexes.count(text_fid), 0);
+    EXPECT_FALSE(after_cancel->load_info->HasTextIndexCreated(text_fid));
+
+    EXPECT_NO_THROW(sealed->CreateTextIndex(text_fid));
+    auto after_retry = sealed->TestGetPublishedStateSnapshot();
+    EXPECT_NE(after_retry, before);
+    EXPECT_EQ(after_retry->runtime->text_indexes.count(text_fid), 1);
+    EXPECT_TRUE(after_retry->load_info->HasTextIndexCreated(text_fid));
+}
+
+TEST(SealedSegmentReopen, RejectsRawBuiltToPrebuiltTextIndexBeforePublication) {
+    std::map<std::string, std::string> analyzer_params;
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    auto text_fid = schema->AddDebugVarcharField(FieldName("text_field"),
+                                                 DataType::VARCHAR,
+                                                 /*max_length=*/65535,
+                                                 /*nullable=*/false,
+                                                 /*enable_match=*/true,
+                                                 /*enable_analyzer=*/true,
+                                                 analyzer_params,
+                                                 std::nullopt);
+    schema->set_primary_field_id(pk_id);
+
+    auto dataset = DataGen(schema, 4);
+    auto segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    sealed->CreateTextIndex(text_fid);
+
+    auto before = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_EQ(before->runtime->text_indexes.count(text_fid), 1);
+    ASSERT_TRUE(before->load_info->HasTextIndexCreated(text_fid));
+
+    auto reopen_proto = before->load_info->GetProto();
+    auto& text_stats = (*reopen_proto.mutable_textstatslogs())[text_fid.get()];
+    text_stats.set_fieldid(text_fid.get());
+    text_stats.set_version(1);
+    text_stats.set_buildid(5001);
+    text_stats.add_files("/must/not/be/read/text-index");
+
+    milvus::OpContext op_ctx;
+    try {
+        sealed->Reopen(&op_ctx, reopen_proto);
+        FAIL() << "raw-built to pre-built text index reopen should fail";
+    } catch (const SegcoreError& err) {
+        EXPECT_EQ(err.get_error_code(), ErrorCode::UnexpectedError);
+        EXPECT_NE(std::string(err.what()).find("raw-built to pre-built"),
+                  std::string::npos);
+        EXPECT_NE(std::string(err.what()).find("full segment replacement"),
+                  std::string::npos);
+    }
+
+    auto after = sealed->TestGetPublishedStateSnapshot();
+    EXPECT_EQ(after, before);
+    EXPECT_EQ(after->runtime->text_indexes.count(text_fid), 1);
+    EXPECT_TRUE(after->load_info->HasTextIndexCreated(text_fid));
 }
 
 TEST(SealedSegmentReopen, RuntimeTextIndexMarkerPublishesToLoadInfoSnapshot) {
@@ -5070,7 +5186,8 @@ TEST(SealedSegmentCowState,
               published_cache_index);
 }
 
-TEST(SealedSegmentCowState, ReplaceScalarIndexStagesRuntimeUntilFinalPublish) {
+TEST(SealedSegmentCowState,
+     StagedScalarIndexRetiresPublishedWarmupOnlyAfterPublish) {
     auto schema = std::make_shared<Schema>();
     auto pk = schema->AddDebugField("pk", DataType::INT64);
     auto payload = schema->AddDebugField("payload", DataType::INT64);
@@ -5081,73 +5198,114 @@ TEST(SealedSegmentCowState, ReplaceScalarIndexStagesRuntimeUntilFinalPublish) {
     auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
     ASSERT_NE(sealed, nullptr);
 
-    LoadIndexInfo first_index;
-    first_index.field_id = payload.get();
-    first_index.field_type = DataType::INT64;
-    first_index.index_params["index_type"] = "STL_SORT";
     auto payload_data = dataset.get_col<int64_t>(payload);
-    auto first_impl = GenScalarIndexing<int64_t>(dataset.raw_->num_rows(),
-                                                 payload_data.data());
-    first_index.index_params = GenIndexParams(first_impl.get());
-    first_index.cache_index =
-        CreateTestCacheIndex("first", std::move(first_impl));
-    auto first_cache_index = first_index.cache_index;
-    sealed->LoadIndex(first_index);
+    auto create_index = [&] {
+        return GenScalarIndexing<int64_t>(dataset.raw_->num_rows(),
+                                          payload_data.data());
+    };
 
-    auto before = sealed->TestGetPublishedStateSnapshot();
-    ASSERT_NE(before, nullptr);
-    ASSERT_NE(before->runtime, nullptr);
-    ASSERT_TRUE(before->runtime->scalar_indexings.count(payload) > 0);
-    auto published_before_replace =
-        before->runtime->scalar_indexings.at(payload);
-    ASSERT_EQ(published_before_replace, first_cache_index);
+    auto warmup_limit = cachinglayer::ResourceUsage{1024 * 1024, 0};
+    auto warmup_dlist = std::make_shared<cachinglayer::internal::DList>(
+        false,
+        warmup_limit,
+        warmup_limit,
+        warmup_limit,
+        cachinglayer::EvictionConfig{});
+    folly::CancellationToken published_warmup_token;
+    std::promise<void> warmup_started;
+    auto warmup_started_future = warmup_started.get_future();
+    auto published_impl = create_index();
+    auto published_index_params = GenIndexParams(published_impl.get());
+    auto published_cache_index =
+        CreateCancellationObservingCacheIndex("published-scalar",
+                                              std::move(published_impl),
+                                              &published_warmup_token,
+                                              &warmup_started,
+                                              warmup_dlist.get());
+    auto warmup_pool = std::make_shared<folly::CPUThreadPoolExecutor>(1);
+    published_cache_index->Warmup(nullptr, warmup_pool);
+    ASSERT_EQ(warmup_started_future.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    ASSERT_FALSE(published_warmup_token.isCancellationRequested());
 
-    auto runtime = sealed->TestCloneMutableRuntimeResourceState();
-    ASSERT_TRUE(runtime->scalar_indexings.count(payload) > 0);
-    auto stale_runtime_index = runtime->scalar_indexings.at(payload);
-    ASSERT_EQ(stale_runtime_index, first_cache_index);
+    LoadIndexInfo published_index;
+    published_index.field_id = payload.get();
+    published_index.field_type = DataType::INT64;
+    published_index.index_params = std::move(published_index_params);
+    published_index.cache_index = published_cache_index;
+    published_index.load_resource_request =
+        LoadResourceRequest{0, 0, 0, 0, true};
+    sealed->LoadIndex(published_index);
 
-    LoadIndexInfo replacement_index;
-    replacement_index.field_id = payload.get();
-    replacement_index.field_type = DataType::INT64;
-    replacement_index.index_params["index_type"] = "STL_SORT";
-    auto replacement_impl = GenScalarIndexing<int64_t>(dataset.raw_->num_rows(),
-                                                       payload_data.data());
-    replacement_index.index_params = GenIndexParams(replacement_impl.get());
-    replacement_index.cache_index =
-        CreateTestCacheIndex("replacement", std::move(replacement_impl));
-    auto replacement_cache_index = replacement_index.cache_index;
+    auto stage_replacement = [&](bool fail_before_publish) {
+        auto current = sealed->TestGetPublishedStateSnapshot();
+        auto runtime = sealed->TestCloneMutableRuntimeResourceState();
+        auto staged = sealed->TestBuildNextPublishedState(
+            current,
+            {current->schema,
+             current->load_info,
+             sealed->TestFreezeRuntimeResourceState(runtime),
+             current->commit_ts});
 
-    sealed->TestLoadIndex(replacement_index, true, runtime.get());
+        auto replacement_impl = create_index();
+        LoadIndexInfo replacement;
+        replacement.field_id = payload.get();
+        replacement.field_type = DataType::INT64;
+        replacement.index_params = GenIndexParams(replacement_impl.get());
+        replacement.cache_index = CreateTestCacheIndex(
+            fail_before_publish ? "rolled-back-scalar" : "replacement-scalar",
+            std::move(replacement_impl));
+        auto replacement_cache_index = replacement.cache_index;
+        replacement.load_resource_request =
+            LoadResourceRequest{0, 0, 0, 0, true};
 
-    ASSERT_TRUE(runtime->scalar_indexings.count(payload) > 0);
-    EXPECT_EQ(runtime->scalar_indexings.size(), 1);
-    auto updated_runtime_index = runtime->scalar_indexings.at(payload);
-    EXPECT_EQ(updated_runtime_index, replacement_cache_index);
-    EXPECT_NE(updated_runtime_index, stale_runtime_index);
+        ChunkedSegmentSealedImpl::StateDelta final_delta;
+        final_delta.schema = current->schema;
+        final_delta.load_info = current->load_info;
+        final_delta.commit_ts = current->commit_ts;
 
-    auto staged_only = sealed->TestGetPublishedStateSnapshot();
-    ASSERT_NE(staged_only, nullptr);
-    ASSERT_NE(staged_only->runtime, nullptr);
-    ASSERT_TRUE(staged_only->runtime->scalar_indexings.count(payload) > 0);
-    EXPECT_EQ(staged_only->runtime->scalar_indexings.at(payload),
-              first_cache_index);
+        auto stage_and_publish = [&] {
+            sealed->TestStageLoadIndexThenPublish(
+                replacement,
+                true,
+                current->schema,
+                runtime,
+                staged.get(),
+                current,
+                final_delta,
+                [&] {
+                    auto published = sealed->TestGetPublishedStateSnapshot();
+                    ASSERT_EQ(published->runtime->scalar_indexings.at(payload),
+                              published_cache_index);
+                    ASSERT_EQ(runtime->scalar_indexings.at(payload),
+                              replacement_cache_index);
+                    EXPECT_FALSE(
+                        published_warmup_token.isCancellationRequested());
+                    if (fail_before_publish) {
+                        throw std::runtime_error("abort staged publish");
+                    }
+                });
+        };
 
-    ChunkedSegmentSealedImpl::StateDelta delta;
-    delta.schema = staged_only->schema;
-    delta.load_info = staged_only->load_info;
-    delta.runtime = sealed->TestFreezeRuntimeResourceState(std::move(runtime));
-    delta.commit_ts = staged_only->commit_ts;
+        if (fail_before_publish) {
+            EXPECT_THROW(stage_and_publish(), std::runtime_error);
+        } else {
+            EXPECT_NO_THROW(stage_and_publish());
+        }
+        return replacement_cache_index;
+    };
 
-    auto next = sealed->TestBuildNextPublishedState(staged_only, delta);
-    ASSERT_NE(next, nullptr);
-    ASSERT_NE(next->runtime, nullptr);
-    EXPECT_EQ(next->runtime->scalar_indexings.size(), 1);
-    ASSERT_TRUE(next->runtime->scalar_indexings.count(payload) > 0);
-    auto published_runtime_index = next->runtime->scalar_indexings.at(payload);
-    EXPECT_EQ(published_runtime_index, replacement_cache_index);
-    EXPECT_NE(published_runtime_index, stale_runtime_index);
-    EXPECT_EQ(next->runtime->ngram_fields.count(payload), 0);
+    stage_replacement(true);
+    EXPECT_FALSE(published_warmup_token.isCancellationRequested());
+    auto after_rollback = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_EQ(after_rollback->runtime->scalar_indexings.at(payload),
+              published_cache_index);
+
+    auto replacement_cache_index = stage_replacement(false);
+    EXPECT_TRUE(published_warmup_token.isCancellationRequested());
+    auto after_publish = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_EQ(after_publish->runtime->scalar_indexings.at(payload),
+              replacement_cache_index);
 }
 
 TEST(SealedSegmentCowState, ReplacePkStateIsInvisibleUntilFinalPublish) {

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -4118,7 +4118,20 @@ TEST(SealedSegmentLoad, LoadPublishesDefaultFilledStateAfterCompact) {
         }
     }
 
+    // Storage V3 manifests are historical and may still expose text stats for
+    // a field dropped from the collection schema.  Fresh Load (not Reopen)
+    // must consume the schema-effective projection and never try this path.
+    constexpr int64_t dropped_text_field = 107;
+    auto& stale_text_stats =
+        (*proto.mutable_textstatslogs())[dropped_text_field];
+    stale_text_stats.set_fieldid(dropped_text_field);
+    stale_text_stats.set_version(1);
+    stale_text_stats.set_buildid(5001);
+    stale_text_stats.add_files("/must/not/be/read/dropped-text-index");
+
     sealed->SetLoadInfo(proto);
+    EXPECT_FALSE(
+        sealed->TestGetSegmentLoadInfo()->HasTextStatsLog(dropped_text_field));
 
     milvus::tracer::TraceContext trace_ctx;
     milvus::OpContext op_ctx;
@@ -4126,6 +4139,8 @@ TEST(SealedSegmentLoad, LoadPublishesDefaultFilledStateAfterCompact) {
     EXPECT_TRUE(sealed->HasFieldData(new_field));
     EXPECT_TRUE(
         sealed->TestGetSegmentLoadInfo()->IsFieldFilledWithDefault(new_field));
+    EXPECT_FALSE(
+        sealed->TestGetSegmentLoadInfo()->HasTextStatsLog(dropped_text_field));
 }
 
 TEST(SealedSegmentReopen, SchemaAwareReopenDiscardsOlderSchema) {
@@ -4200,7 +4215,7 @@ TEST(SealedSegmentReopen, RejectsRowCountChangeBeforePublication) {
         sealed->Reopen(&op_ctx, reopen_proto);
         FAIL() << "row-count-changing reopen should fail";
     } catch (const SegcoreError& err) {
-        EXPECT_EQ(err.get_error_code(), ErrorCode::UnexpectedError);
+        EXPECT_EQ(err.get_error_code(), kNeedFullSegmentReplacement);
         EXPECT_NE(std::string(err.what())
                       .find("online reopen cannot change row count"),
                   std::string::npos);
@@ -4262,7 +4277,7 @@ TEST(SealedSegmentReopen, RejectsStorageV2BinlogRowCountMismatchBeforeIO) {
         sealed->Reopen(&op_ctx, reopen_proto);
         FAIL() << "actual binlog row-count mismatch should fail";
     } catch (const SegcoreError& err) {
-        EXPECT_EQ(err.get_error_code(), ErrorCode::UnexpectedError);
+        EXPECT_EQ(err.get_error_code(), kNeedFullSegmentReplacement);
         EXPECT_NE(std::string(err.what()).find("field binlog group"),
                   std::string::npos);
         EXPECT_NE(std::string(err.what()).find("expected 4, actual 5"),
@@ -4361,6 +4376,7 @@ TEST(SealedSegmentReopen, FullReopenPrunesDroppedPrebuiltTextIndexMetadata) {
     text_stats.set_buildid(5001);
     text_stats.add_files("/must/not/be/read/dropped-text-index");
     sealed->SetLoadInfo(load_info);
+    sealed->SetTextLobPathForTesting(text_fid, "/stale/dropped-text-lob");
 
     milvus::OpContext op_ctx;
     EXPECT_NO_THROW(sealed->Reopen(&op_ctx, load_info, new_schema));
@@ -4370,6 +4386,7 @@ TEST(SealedSegmentReopen, FullReopenPrunesDroppedPrebuiltTextIndexMetadata) {
     EXPECT_EQ(first->schema->get_schema_version(), 200);
     EXPECT_FALSE(first->load_info->HasFieldInSchema(text_fid));
     EXPECT_FALSE(first->load_info->HasTextStatsLog(text_fid.get()));
+    EXPECT_EQ(first->runtime->text_lob_paths.count(text_fid), 0);
 
     // A stale dropped-field textstats entry in the first published load info
     // would make ComputeDiffTextIndexes reject every subsequent reopen.
@@ -4591,7 +4608,7 @@ TEST(SealedSegmentReopen, RejectsRawBuiltToPrebuiltTextIndexBeforePublication) {
         sealed->Reopen(&op_ctx, reopen_proto);
         FAIL() << "raw-built to pre-built text index reopen should fail";
     } catch (const SegcoreError& err) {
-        EXPECT_EQ(err.get_error_code(), ErrorCode::UnexpectedError);
+        EXPECT_EQ(err.get_error_code(), kNeedFullSegmentReplacement);
         EXPECT_NE(std::string(err.what()).find("raw-built to pre-built"),
                   std::string::npos);
         EXPECT_NE(std::string(err.what()).find("full segment replacement"),

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -380,6 +380,11 @@ TEST(Sealed, CreateTextIndexFromNullableScalarIndexRawData) {
     segment->LoadIndex(load_info);
 
     ASSERT_NO_THROW(segment->CreateTextIndex(text_fid));
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+    EXPECT_EQ(
+        sealed->TestGetLoadInfoSnapshot()->GetTextIndexCreatedSource(text_fid),
+        RawTextIndexSource::ScalarIndexRawData);
     auto text_index = segment->GetTextIndex(nullptr, text_fid);
 
     auto nulls = text_index.get()->IsNull();
@@ -4219,6 +4224,70 @@ TEST(SealedSegmentReopen, RejectsRowCountChangeBeforePublication) {
     EXPECT_EQ(bitset.count(), 1);
 }
 
+TEST(SealedSegmentReopen, RejectsStorageV2BinlogRowCountMismatchBeforeIO) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_id);
+
+    constexpr int64_t row_count = 4;
+    auto dataset = DataGen(schema, row_count);
+    auto segment = CreateSealedSegment(schema);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(kSegmentID);
+    current_proto.set_partitionid(kPartitionID);
+    current_proto.set_collectionid(kCollectionID);
+    current_proto.set_num_of_rows(row_count);
+    sealed->SetLoadInfo(current_proto);
+    LoadGeneratedDataIntoSegment(dataset, sealed);
+
+    auto before = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(before, nullptr);
+    ASSERT_NE(before->runtime, nullptr);
+    EXPECT_EQ(before->load_info->GetNumOfRows(), row_count);
+    EXPECT_EQ(before->runtime->row_count, row_count);
+
+    auto reopen_proto = current_proto;
+    reopen_proto.set_storageversion(2);
+    auto* field_binlog = reopen_proto.add_binlog_paths();
+    field_binlog->set_fieldid(pk_id.get());
+    auto* binlog = field_binlog->add_binlogs();
+    binlog->set_log_path("/must/not/be/read/row-count-mismatch");
+    binlog->set_entries_num(row_count + 1);
+
+    milvus::OpContext op_ctx;
+    try {
+        sealed->Reopen(&op_ctx, reopen_proto);
+        FAIL() << "actual binlog row-count mismatch should fail";
+    } catch (const SegcoreError& err) {
+        EXPECT_EQ(err.get_error_code(), ErrorCode::UnexpectedError);
+        EXPECT_NE(std::string(err.what()).find("field binlog group"),
+                  std::string::npos);
+        EXPECT_NE(std::string(err.what()).find("expected 4, actual 5"),
+                  std::string::npos);
+    }
+
+    auto after = sealed->TestGetPublishedStateSnapshot();
+    EXPECT_EQ(after, before);
+    EXPECT_EQ(after->load_info->GetNumOfRows(), row_count);
+    EXPECT_EQ(after->load_info->GetBinlogPathCount(), 0);
+    EXPECT_EQ(after->runtime->row_count, row_count);
+
+    auto pks = dataset.get_col<int64_t>(pk_id);
+    auto delete_ids = std::make_unique<IdArray>();
+    delete_ids->mutable_int_id()->add_data(pks.back());
+    Timestamp delete_ts = 1000000;
+    auto status = sealed->Delete(1, delete_ids.get(), &delete_ts);
+    ASSERT_TRUE(status.ok());
+
+    BitsetType bitset(row_count, false);
+    auto bitset_view = BitsetTypeView(bitset);
+    segment->mask_with_delete(bitset_view, row_count, delete_ts + 1);
+    EXPECT_EQ(bitset.count(), 1);
+}
+
 TEST(SealedSegmentReopen, DropFieldReopenPublishesSchemaAndLoadInfoTogether) {
     auto old_schema = std::make_shared<Schema>();
     auto pk_id = old_schema->AddDebugField("pk", DataType::INT64);
@@ -4250,6 +4319,67 @@ TEST(SealedSegmentReopen, DropFieldReopenPublishesSchemaAndLoadInfoTogether) {
     EXPECT_FALSE(sealed->HasFieldData(dropped_id));
     EXPECT_FALSE(sealed->HasIndex(dropped_id));
     EXPECT_FALSE(sealed->FieldAccessible(dropped_id));
+}
+
+TEST(SealedSegmentReopen, FullReopenPrunesDroppedPrebuiltTextIndexMetadata) {
+    std::map<std::string, std::string> analyzer_params;
+    auto old_schema = std::make_shared<Schema>();
+    auto pk_id = old_schema->AddDebugField("pk", DataType::INT64);
+    auto text_fid = old_schema->AddDebugVarcharField(FieldName("text_field"),
+                                                     DataType::VARCHAR,
+                                                     /*max_length=*/65535,
+                                                     /*nullable=*/false,
+                                                     /*enable_match=*/true,
+                                                     /*enable_analyzer=*/true,
+                                                     analyzer_params,
+                                                     std::nullopt);
+    old_schema->set_primary_field_id(pk_id);
+    old_schema->set_schema_version(100);
+
+    auto new_schema = std::make_shared<Schema>();
+    auto new_pk_id = new_schema->AddDebugField("pk", DataType::INT64);
+    new_schema->set_primary_field_id(new_pk_id);
+    new_schema->set_schema_version(200);
+
+    auto segment = CreateSealedSegment(old_schema);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_segmentid(kSegmentID);
+    load_info.set_partitionid(kPartitionID);
+    load_info.set_collectionid(kCollectionID);
+    load_info.set_num_of_rows(0);
+    auto* field_binlog = load_info.add_binlog_paths();
+    field_binlog->set_fieldid(pk_id.get());
+    auto* binlog = field_binlog->add_binlogs();
+    binlog->set_log_path("/must/not/be/read/unchanged-pk-binlog");
+    binlog->set_entries_num(0);
+    auto& text_stats = (*load_info.mutable_textstatslogs())[text_fid.get()];
+    text_stats.set_fieldid(text_fid.get());
+    text_stats.set_version(1);
+    text_stats.set_buildid(5001);
+    text_stats.add_files("/must/not/be/read/dropped-text-index");
+    sealed->SetLoadInfo(load_info);
+
+    milvus::OpContext op_ctx;
+    EXPECT_NO_THROW(sealed->Reopen(&op_ctx, load_info, new_schema));
+
+    auto first = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(first->schema->get_schema_version(), 200);
+    EXPECT_FALSE(first->load_info->HasFieldInSchema(text_fid));
+    EXPECT_FALSE(first->load_info->HasTextStatsLog(text_fid.get()));
+
+    // A stale dropped-field textstats entry in the first published load info
+    // would make ComputeDiffTextIndexes reject every subsequent reopen.
+    EXPECT_NO_THROW(sealed->Reopen(&op_ctx, load_info, new_schema));
+
+    auto second = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(second->schema->get_schema_version(), 200);
+    EXPECT_FALSE(second->load_info->HasFieldInSchema(text_fid));
+    EXPECT_FALSE(second->load_info->HasTextStatsLog(text_fid.get()));
 }
 
 TEST(SealedSegmentReopen, CancelledTextIndexBuildDoesNotPublishAndCanRetry) {
@@ -4290,6 +4420,139 @@ TEST(SealedSegmentReopen, CancelledTextIndexBuildDoesNotPublishAndCanRetry) {
     EXPECT_NE(after_retry, before);
     EXPECT_EQ(after_retry->runtime->text_indexes.count(text_fid), 1);
     EXPECT_TRUE(after_retry->load_info->HasTextIndexCreated(text_fid));
+}
+
+TEST(SealedSegmentReopen, RebuildsRawTextIndexFromReplacedFieldDataAtomically) {
+    std::map<std::string, std::string> analyzer_params;
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    auto text_fid = schema->AddDebugVarcharField(FieldName("text_field"),
+                                                 DataType::VARCHAR,
+                                                 /*max_length=*/65535,
+                                                 /*nullable=*/false,
+                                                 /*enable_match=*/true,
+                                                 /*enable_analyzer=*/true,
+                                                 analyzer_params,
+                                                 std::nullopt);
+    schema->set_primary_field_id(pk_id);
+
+    constexpr int64_t row_count = 4;
+    auto set_text_values = [text_fid](GeneratedData& dataset,
+                                      const std::string& value) {
+        for (auto& field : *dataset.raw_->mutable_fields_data()) {
+            if (field.field_id() != text_fid.get()) {
+                continue;
+            }
+            auto* values = field.mutable_scalars()->mutable_string_data();
+            values->clear_data();
+            for (int64_t i = 0; i < dataset.raw_->num_rows(); ++i) {
+                values->add_data(value);
+            }
+            return;
+        }
+        FAIL() << "text field not found in generated data";
+    };
+
+    auto old_dataset = DataGen(schema, row_count);
+    set_text_values(old_dataset, "apple");
+    auto segment = CreateSealedWithFieldDataLoaded(schema, old_dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(kSegmentID);
+    current_proto.set_partitionid(kPartitionID);
+    current_proto.set_collectionid(kCollectionID);
+    current_proto.set_num_of_rows(row_count);
+    auto add_binlog = [&](FieldId field_id, const std::string& path) {
+        auto* field_binlog = current_proto.add_binlog_paths();
+        field_binlog->set_fieldid(field_id.get());
+        auto* binlog = field_binlog->add_binlogs();
+        binlog->set_log_path(path);
+        binlog->set_entries_num(row_count);
+    };
+    add_binlog(pk_id, TestRemotePath + std::to_string(pk_id.get()));
+    add_binlog(text_fid, TestRemotePath + std::to_string(text_fid.get()));
+    sealed->SetLoadInfo(current_proto);
+    sealed->CreateTextIndex(text_fid);
+
+    auto before = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_TRUE(before->load_info->HasTextIndexCreated(text_fid));
+    EXPECT_EQ(before->load_info->GetTextIndexCreatedSource(text_fid),
+              RawTextIndexSource::FieldData);
+    auto old_pin = sealed->GetTextIndex(nullptr, text_fid);
+    ASSERT_EQ(old_pin.get()->MatchQuery("apple", 1).count(), row_count);
+    ASSERT_EQ(old_pin.get()->MatchQuery("banana", 1).count(), 0);
+
+    auto new_dataset = DataGen(schema, row_count);
+    set_text_values(new_dataset, "banana");
+
+    // Cancellation after a replacement source has been staged in a cloned
+    // runtime must not leak either that source or a partial text index.
+    auto replacement_segment =
+        CreateSealedWithFieldDataLoaded(schema, new_dataset);
+    auto* replacement_sealed =
+        dynamic_cast<ChunkedSegmentSealedImpl*>(replacement_segment.get());
+    ASSERT_NE(replacement_sealed, nullptr);
+    auto replacement_snapshot =
+        replacement_sealed->TestGetPublishedStateSnapshot();
+    auto abandoned_runtime = sealed->TestCloneMutableRuntimeResourceState();
+    abandoned_runtime->fields.insert_or_assign(
+        text_fid, replacement_snapshot->runtime->fields.at(text_fid));
+    abandoned_runtime->text_indexes.erase(text_fid);
+    folly::CancellationSource cancelled_source;
+    cancelled_source.requestCancellation();
+    milvus::OpContext cancelled(cancelled_source.getToken());
+    EXPECT_THROW(sealed->TestCreateTextIndexWithSchema(text_fid,
+                                                       schema,
+                                                       &cancelled,
+                                                       /*publish_marker=*/false,
+                                                       abandoned_runtime.get()),
+                 SegcoreError);
+    EXPECT_EQ(sealed->TestGetPublishedStateSnapshot(), before);
+    EXPECT_EQ(old_pin.get()->MatchQuery("apple", 1).count(), row_count);
+
+    const DataArray* new_text_array = nullptr;
+    for (const auto& field : new_dataset.raw_->fields_data()) {
+        if (field.field_id() == text_fid.get()) {
+            new_text_array = &field;
+            break;
+        }
+    }
+    ASSERT_NE(new_text_array, nullptr);
+    auto new_text_data = CreateFieldDataFromDataArray(
+        row_count, new_text_array, schema->operator[](text_fid));
+    auto chunk_manager = storage::RemoteChunkManagerSingleton::GetInstance()
+                             .GetRemoteChunkManager();
+    auto replacement = PrepareSingleFieldInsertBinlog(kCollectionID,
+                                                      kPartitionID,
+                                                      kSegmentID + 1000,
+                                                      text_fid.get(),
+                                                      {new_text_data},
+                                                      chunk_manager);
+    const auto& replacement_info = replacement.field_infos.at(text_fid.get());
+    ASSERT_EQ(replacement_info.insert_files.size(), 1);
+
+    auto reopen_proto = current_proto;
+    reopen_proto.mutable_binlog_paths(1)->mutable_binlogs(0)->set_log_path(
+        replacement_info.insert_files.front());
+
+    milvus::OpContext op_ctx;
+    ASSERT_NO_THROW(sealed->Reopen(&op_ctx, reopen_proto));
+
+    auto after = sealed->TestGetPublishedStateSnapshot();
+    ASSERT_NE(after, before);
+    EXPECT_TRUE(after->load_info->HasTextIndexCreated(text_fid));
+    EXPECT_EQ(after->load_info->GetTextIndexCreatedSource(text_fid),
+              RawTextIndexSource::FieldData);
+    auto new_pin = sealed->GetTextIndex(nullptr, text_fid);
+    EXPECT_EQ(new_pin.get()->MatchQuery("banana", 1).count(), row_count);
+    EXPECT_EQ(new_pin.get()->MatchQuery("apple", 1).count(), 0);
+
+    // The old generation remains queryable while pinned; rebuild never
+    // mutates or destroys the published holder in place.
+    EXPECT_EQ(old_pin.get()->MatchQuery("apple", 1).count(), row_count);
+    EXPECT_EQ(old_pin.get()->MatchQuery("banana", 1).count(), 0);
 }
 
 TEST(SealedSegmentReopen, RejectsRawBuiltToPrebuiltTextIndexBeforePublication) {
@@ -4409,7 +4672,7 @@ TEST(SealedSegmentReopen, SchemaOnlyReopenPreservesCreatedTextIndexState) {
     auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
     ASSERT_NE(sealed, nullptr);
 
-    sealed->TestRecordTextIndexCreated(text_fid);
+    sealed->CreateTextIndex(text_fid);
     ASSERT_TRUE(
         sealed->TestGetLoadInfoSnapshot()->HasTextIndexCreated(text_fid));
 

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -182,6 +182,74 @@ func cloneMsgPosition(position *msgpb.MsgPosition) *msgpb.MsgPosition {
 	return proto.Clone(position).(*msgpb.MsgPosition)
 }
 
+// projectSegmentLoadInfoToSchema removes metadata for fields that are no
+// longer present in the collection schema. QueryNode consumes SegmentLoadInfo
+// before segcore gets a chance to apply its own projection, so keeping the Go
+// copy canonical prevents resource accounting and runtime metadata caches from
+// observing stale manifest entries for dropped fields.
+func projectSegmentLoadInfoToSchema(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.CollectionSchema) (*querypb.SegmentLoadInfo, error) {
+	if loadInfo == nil {
+		return nil, merr.WrapErrServiceInternalMsg("cannot project nil segment load info")
+	}
+
+	schemaHelper, err := typeutil.CreateSchemaHelper(schema)
+	if err != nil {
+		return nil, merr.Wrap(err, "failed to create schema helper for segment load info projection")
+	}
+	hasField := func(fieldID int64) bool {
+		_, err := schemaHelper.GetFieldFromID(fieldID)
+		return err == nil
+	}
+
+	projected := proto.Clone(loadInfo).(*querypb.SegmentLoadInfo)
+	projectFieldBinlogs := func(logs []*datapb.FieldBinlog) []*datapb.FieldBinlog {
+		retained := make([]*datapb.FieldBinlog, 0, len(logs))
+		for _, fieldBinlog := range logs {
+			if len(fieldBinlog.GetChildFields()) == 0 {
+				if hasField(fieldBinlog.GetFieldID()) {
+					retained = append(retained, fieldBinlog)
+				}
+				continue
+			}
+
+			children := fieldBinlog.GetChildFields()[:0]
+			for _, childFieldID := range fieldBinlog.GetChildFields() {
+				if hasField(childFieldID) {
+					children = append(children, childFieldID)
+				}
+			}
+			fieldBinlog.ChildFields = children
+			if len(children) > 0 {
+				retained = append(retained, fieldBinlog)
+			}
+		}
+		return retained
+	}
+
+	indexInfos := make([]*querypb.FieldIndexInfo, 0, len(projected.GetIndexInfos()))
+	for _, indexInfo := range projected.GetIndexInfos() {
+		if hasField(indexInfo.GetFieldID()) {
+			indexInfos = append(indexInfos, indexInfo)
+		}
+	}
+	projected.IndexInfos = indexInfos
+	projected.BinlogPaths = projectFieldBinlogs(projected.GetBinlogPaths())
+	projected.Statslogs = projectFieldBinlogs(projected.GetStatslogs())
+	projected.Bm25Logs = projectFieldBinlogs(projected.GetBm25Logs())
+	for fieldID := range projected.GetTextStatsLogs() {
+		if !hasField(fieldID) {
+			delete(projected.TextStatsLogs, fieldID)
+		}
+	}
+	for fieldID := range projected.GetJsonKeyStatsLogs() {
+		if !hasField(fieldID) {
+			delete(projected.JsonKeyStatsLogs, fieldID)
+		}
+	}
+
+	return projected, nil
+}
+
 // compactSegmentLoadInfoForRuntime retains runtime identity/version metadata,
 // positions, deltalogs, and manifest/resource estimate fields; callers must
 // consume binlog, index, and stats metadata before compaction.
@@ -1288,28 +1356,38 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 	}
 	defer s.ptrLock.Unpin()
 
+	schema, schemaVersion := s.collection.SchemaAndSegcoreVersion()
+	projectedLoadInfo, err := projectSegmentLoadInfoToSchema(newLoadInfo, schema)
+	if err != nil {
+		return merr.Wrapf(err, "failed to project reopen metadata for segment %d", s.ID())
+	}
+
 	// Reopen forwards the SegmentLoadInfo straight to segcore, so it must inject
 	// the QueryNode-local index load params (e.g. DISKANN num_load_thread) that
 	// the full-load path injects; otherwise segcore asserts on load. See #51249.
-	if err := prepareIndexLoadParams(newLoadInfo.GetIndexInfos()); err != nil {
+	if err := prepareIndexLoadParams(projectedLoadInfo.GetIndexInfos()); err != nil {
 		return err
 	}
 
-	schema, schemaVersion := s.collection.SchemaAndSegcoreVersion()
-	err := s.csegment.Reopen(ctx, &segcore.ReopenRequest{
-		LoadInfo:      newLoadInfo,
+	err = s.csegment.Reopen(ctx, &segcore.ReopenRequest{
+		LoadInfo:      projectedLoadInfo,
 		Schema:        schema,
 		SchemaVersion: schemaVersion,
 	})
 	if err != nil {
+		if errors.Is(err, merr.ErrNeedFullSegmentReplacement) {
+			return merr.Wrapf(err,
+				"segment %d cannot be reopened in place",
+				s.ID())
+		}
 		return err
 	}
-	s.syncFieldIndexes(newLoadInfo.GetIndexInfos())
+	s.syncFieldIndexes(projectedLoadInfo.GetIndexInfos())
 	if s.relatedDataSize != nil {
-		s.relatedDataSize.Store(calculateSegmentLogSize(newLoadInfo))
+		s.relatedDataSize.Store(calculateSegmentLogSize(projectedLoadInfo))
 	}
-	s.loadInfo.Store(newLoadInfo)
-	s.syncFieldJSONStatsFromLoadInfo(ctx, newLoadInfo)
+	s.loadInfo.Store(projectedLoadInfo)
+	s.syncFieldJSONStatsFromLoadInfo(ctx, projectedLoadInfo)
 	s.compactLoadInfoForRuntime()
 	return nil
 }

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -239,9 +239,17 @@ func (loader *segmentLoader) Load(ctx context.Context,
 		mlog.Warn(context.TODO(), "failed to get collection", mlog.Err(err))
 		return nil, err
 	}
+	schema := collection.Schema()
+	projectedSegments := make([]*querypb.SegmentLoadInfo, 0, len(segments))
 	for _, segment := range segments {
-		configureUseTakeForOutput(segment, collection.Schema())
+		projected, err := projectSegmentLoadInfoToSchema(segment, schema)
+		if err != nil {
+			return nil, merr.Wrapf(err, "failed to project load metadata for segment %d", segment.GetSegmentID())
+		}
+		configureUseTakeForOutput(projected, schema)
+		projectedSegments = append(projectedSegments, projected)
 	}
+	segments = projectedSegments
 	// Filter out loaded & loading segments
 	infos := loader.prepare(ctx, segmentType, segments...)
 	defer loader.unregister(infos...)

--- a/internal/querynodev2/segments/segment_test.go
+++ b/internal/querynodev2/segments/segment_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
@@ -236,6 +237,68 @@ func TestCompactSegmentLoadInfoForRuntime(t *testing.T) {
 
 	loadInfo.StartPosition.ChannelName = "mutated"
 	assert.Equal(t, "ch", compact.GetStartPosition().GetChannelName())
+}
+
+func TestProjectSegmentLoadInfoToSchema(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "projected",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "kept_int", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "kept_text", DataType: schemapb.DataType_Text},
+		},
+	}
+	fieldBinlog := func(fieldID int64, children ...int64) *datapb.FieldBinlog {
+		return &datapb.FieldBinlog{
+			FieldID:     fieldID,
+			ChildFields: children,
+			Binlogs:     []*datapb.Binlog{{LogPath: fmt.Sprintf("field-%d", fieldID)}},
+		}
+	}
+	loadInfo := &querypb.SegmentLoadInfo{
+		SegmentID: 1,
+		BinlogPaths: []*datapb.FieldBinlog{
+			fieldBinlog(101),
+			fieldBinlog(103),
+			fieldBinlog(1000, 101, 103),
+			fieldBinlog(1001, 103),
+		},
+		Statslogs:  []*datapb.FieldBinlog{fieldBinlog(101), fieldBinlog(103)},
+		Bm25Logs:   []*datapb.FieldBinlog{fieldBinlog(102), fieldBinlog(103)},
+		Deltalogs:  []*datapb.FieldBinlog{fieldBinlog(103)},
+		IndexInfos: []*querypb.FieldIndexInfo{{FieldID: 101}, {FieldID: 103}},
+		TextStatsLogs: map[int64]*datapb.TextIndexStats{
+			102: {FieldID: 102},
+			103: {FieldID: 103},
+		},
+		JsonKeyStatsLogs: map[int64]*datapb.JsonKeyStats{
+			101: {FieldID: 101},
+			103: {FieldID: 103},
+		},
+	}
+
+	projected, err := projectSegmentLoadInfoToSchema(loadInfo, schema)
+	require.NoError(t, err)
+
+	require.Len(t, projected.GetBinlogPaths(), 2)
+	assert.EqualValues(t, 101, projected.GetBinlogPaths()[0].GetFieldID())
+	assert.Equal(t, []int64{101}, projected.GetBinlogPaths()[1].GetChildFields())
+	require.Len(t, projected.GetStatslogs(), 1)
+	assert.EqualValues(t, 101, projected.GetStatslogs()[0].GetFieldID())
+	require.Len(t, projected.GetBm25Logs(), 1)
+	assert.EqualValues(t, 102, projected.GetBm25Logs()[0].GetFieldID())
+	require.Len(t, projected.GetIndexInfos(), 1)
+	assert.EqualValues(t, 101, projected.GetIndexInfos()[0].GetFieldID())
+	assert.Contains(t, projected.GetTextStatsLogs(), int64(102))
+	assert.NotContains(t, projected.GetTextStatsLogs(), int64(103))
+	assert.Contains(t, projected.GetJsonKeyStatsLogs(), int64(101))
+	assert.NotContains(t, projected.GetJsonKeyStatsLogs(), int64(103))
+	assert.Equal(t, loadInfo.GetDeltalogs(), projected.GetDeltalogs())
+
+	// Projection is copy-on-write at the Go boundary; request metadata remains
+	// available to the caller for diagnostics and retry.
+	require.Len(t, loadInfo.GetBinlogPaths(), 4)
+	assert.Equal(t, []int64{101, 103}, loadInfo.GetBinlogPaths()[2].GetChildFields())
+	assert.Contains(t, loadInfo.GetTextStatsLogs(), int64(103))
 }
 
 func TestCompactLoadInfoForRuntimeCachesResourceUsage(t *testing.T) {
@@ -893,6 +956,112 @@ func TestLocalSegmentReopenErrorDoesNotAdvanceLoadInfo(t *testing.T) {
 	err := segment.Reopen(context.Background(), newLoadInfo)
 	assert.ErrorIs(t, err, merr.ErrCollectionSchemaVersionNotReady)
 	assert.Equal(t, int32(1), segment.LoadInfo().GetDataVersion())
+}
+
+func TestLocalSegmentReopenProjectsLoadInfoToSchema(t *testing.T) {
+	paramtable.Init()
+
+	schema := &schemapb.CollectionSchema{
+		Name: "collection_v2",
+		Fields: []*schemapb.FieldSchema{{
+			FieldID:  101,
+			Name:     "kept_field",
+			DataType: schemapb.DataType_Int64,
+		}},
+		Version: 2,
+	}
+	collection := &Collection{}
+	collection.setSchema(schema, 2, 100, 102)
+
+	newLoadInfo := &querypb.SegmentLoadInfo{
+		CollectionID: 10,
+		SegmentID:    20,
+		PartitionID:  30,
+		Level:        datapb.SegmentLevel_L1,
+		BinlogPaths: []*datapb.FieldBinlog{
+			{FieldID: 101},
+			{FieldID: 103},
+		},
+		TextStatsLogs: map[int64]*datapb.TextIndexStats{
+			103: {FieldID: 103},
+		},
+	}
+
+	var captured *querypb.SegmentLoadInfo
+	csegment := mock_segcore.NewMockCSegment(t)
+	csegment.EXPECT().
+		Reopen(mock.Anything, mock.MatchedBy(func(request *segcore.ReopenRequest) bool {
+			captured = request.LoadInfo
+			return request.Schema == schema && request.SchemaVersion == 102
+		})).
+		Return(nil)
+
+	segment := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:         collection,
+			segmentType:        SegmentTypeSealed,
+			loadInfo:           atomic.NewPointer(&querypb.SegmentLoadInfo{Level: datapb.SegmentLevel_L1}),
+			version:            atomic.NewInt64(0),
+			resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+			needUpdatedVersion: atomic.NewInt64(0),
+		},
+		ptrLock:        state.NewLoadStateLock(state.LoadStateDataLoaded),
+		csegment:       csegment,
+		fieldIndexes:   typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
+		fieldJSONStats: make(map[int64]*querypb.JsonStatsInfo),
+	}
+
+	require.NoError(t, segment.Reopen(context.Background(), newLoadInfo))
+	require.NotNil(t, captured)
+	require.Len(t, captured.GetBinlogPaths(), 1)
+	assert.EqualValues(t, 101, captured.GetBinlogPaths()[0].GetFieldID())
+	assert.Empty(t, captured.GetTextStatsLogs())
+
+	// The caller's request remains unchanged for diagnostics or retry.
+	require.Len(t, newLoadInfo.GetBinlogPaths(), 2)
+	assert.Contains(t, newLoadInfo.GetTextStatsLogs(), int64(103))
+}
+
+func TestLocalSegmentReopenPropagatesFullReplacementSignal(t *testing.T) {
+	paramtable.Init()
+
+	schema := mock_segcore.GenTestCollectionSchema("collection_v1", schemapb.DataType_Int64, false)
+	schema.Version = 1
+	collection := &Collection{}
+	collection.setSchema(schema, 1, 100, 101)
+
+	csegment := mock_segcore.NewMockCSegment(t)
+	csegment.EXPECT().
+		Reopen(mock.Anything, mock.AnythingOfType("*segcore.ReopenRequest")).
+		Return(merr.ErrNeedFullSegmentReplacement)
+
+	oldLoadInfo := &querypb.SegmentLoadInfo{
+		CollectionID:  10,
+		SegmentID:     20,
+		PartitionID:   30,
+		InsertChannel: "by-dev-rootcoord-dml_0_10v0",
+		DataVersion:   1,
+	}
+	newLoadInfo := proto.Clone(oldLoadInfo).(*querypb.SegmentLoadInfo)
+	newLoadInfo.DataVersion = 2
+	segment := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:         collection,
+			loadInfo:           atomic.NewPointer(oldLoadInfo),
+			version:            atomic.NewInt64(0),
+			resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+			needUpdatedVersion: atomic.NewInt64(0),
+		},
+		ptrLock:        state.NewLoadStateLock(state.LoadStateDataLoaded),
+		csegment:       csegment,
+		fieldIndexes:   typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
+		fieldJSONStats: make(map[int64]*querypb.JsonStatsInfo),
+	}
+
+	err := segment.Reopen(context.Background(), newLoadInfo)
+	require.ErrorIs(t, err, merr.ErrNeedFullSegmentReplacement)
+	require.Contains(t, err.Error(), "cannot be reopened in place")
+	require.Equal(t, int32(1), segment.LoadInfo().GetDataVersion())
 }
 
 // TestLocalSegmentReopenInjectsDiskIndexLoadParams reproduces issue #51249:

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -132,6 +132,10 @@ var (
 	// the query coordinator will mark the node as resource exhausted and apply a
 	// penalty period during which the node won't receive new loading tasks.
 	ErrSegmentRequestResourceFailed = newMilvusError("segment request resource failed", 605, false)
+	// ErrNeedFullSegmentReplacement is an internal control contract: the
+	// requested segment state is valid, but cannot be reached by an in-place
+	// reopen. Callers must build and atomically replace the whole segment.
+	ErrNeedFullSegmentReplacement = newMilvusError("full segment replacement required", 606, false)
 
 	// Index related
 	ErrIndexNotFound     = newMilvusError("index not found", 700, false)

--- a/pkg/util/merr/segcore.go
+++ b/pkg/util/merr/segcore.go
@@ -88,6 +88,7 @@ var segcoreCodeTable = map[int32]segcoreClass{
 	2039: {sentinel: ErrSegcoreOutOfRange},                                // OutOfRange (internal bounds bug, not a signal)
 	2040: {sentinel: ErrSegcoreGCPNativeError, retriable: true},           // GcpNativeError (object storage; transient)
 	2046: {sentinel: ErrCollectionSchemaVersionNotReady, retriable: true}, // CollectionSchemaVersionNotReady (stale QueryNode schema snapshot; retry with fresh schema)
+	2047: {sentinel: ErrNeedFullSegmentReplacement},                       // NeedFullSegmentReplacement (valid target state, unsupported in-place transition)
 	2099: {sentinel: KnowhereError},                                       // KnowhereError
 
 	// Wrapper-path special cases (preserve existing errors.Is behavior that

--- a/pkg/util/merr/segcore_test.go
+++ b/pkg/util/merr/segcore_test.go
@@ -71,6 +71,12 @@ func TestSegcoreErrorClassification(t *testing.T) {
 		assert.ErrorIs(t, SegcoreError(2038, "x"), ErrSegcoreFollyCancel)
 		assert.ErrorIs(t, SegcoreError(2039, "x"), ErrSegcoreOutOfRange)
 		assert.ErrorIs(t, SegcoreError(2046, "x"), ErrCollectionSchemaVersionNotReady)
+		replacementErr := SegcoreError(2047, "x")
+		assert.ErrorIs(t, replacementErr, ErrNeedFullSegmentReplacement)
+		assert.Equal(t, int32(606), Code(replacementErr))
+		assert.Equal(t, SystemError, GetErrorType(replacementErr))
+		assert.False(t, Status(replacementErr).GetRetriable())
+		assert.False(t, IsSegcoreSignal(2047))
 		assert.ErrorIs(t, SegcoreError(2099, "x"), KnowhereError)
 	})
 
@@ -176,7 +182,7 @@ func TestSegcoreCodeTableCoverage(t *testing.T) {
 		2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022,
 		2023, 2024, 2025, 2026, 2027, 2028, 2030, 2031, 2032, 2033, 2034,
 		2035, 2036, 2037, 2038, 2039, 2040, 2041, 2042, 2043, 2044, 2045,
-		2046, 2099,
+		2046, 2047, 2099,
 	}
 
 	// Regression guard: the codes we classified on purpose must stay registered


### PR DESCRIPTION
Related to #51068

- reject online reopen when segment row count changes
- publish commit timestamps with segment snapshot state
- retire replaced index warmups only after successful publication
- enforce text index source and schema identity across reopen
- remove redundant mutex locks from snapshot-owned sealed leaf readers
- propagate captured snapshot and runtime state through nested helpers
- defer the Search/Retrieve synchronization split to a follow-up