### PR TITLE
fix: honor reserved offset for growing nullable validity

### DIFF
--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -61,27 +61,39 @@ class ThreadSafeValidData {
     }
 
     void
-    set_data_raw(const std::vector<FieldDataPtr>& datas) {
+    set_data_raw(size_t offset, const std::vector<FieldDataPtr>& datas) {
         std::unique_lock<std::shared_mutex> lck(mutex_);
+        size_t total = 0;
+        for (auto& field_data : datas) {
+            total += field_data->get_num_rows();
+        }
+        if (total == 0) {
+            return;
+        }
+        reserve_to(offset + total);
+
+        auto write_offset = offset;
         for (auto& field_data : datas) {
             auto num_row = field_data->get_num_rows();
-            reserve_to(length_ + num_row);
-            write_bits(length_, num_row, [&field_data](size_t i) {
+            write_bits(write_offset, num_row, [&field_data](size_t i) {
                 return field_data->is_valid(i);
             });
-            length_ += num_row;
+            write_offset += num_row;
         }
+        length_ = std::max(length_, write_offset);
     }
 
     void
-    set_data_raw(size_t num_rows,
+    set_data_raw(size_t offset,
+                 size_t num_rows,
                  const DataArray* data,
                  const FieldMeta& field_meta) {
         std::unique_lock<std::shared_mutex> lck(mutex_);
-        if (field_meta.is_nullable()) {
-            reserve_to(length_ + num_rows);
-            write_from(length_, num_rows, data->valid_data().data());
-            length_ += num_rows;
+        if (field_meta.is_nullable() && num_rows > 0) {
+            auto end = offset + num_rows;
+            reserve_to(end);
+            write_from(offset, num_rows, data->valid_data().data());
+            length_ = std::max(length_, end);
         }
     }
 
@@ -204,7 +216,8 @@ class ThreadSafeValidData {
     // Fixed-size (size_per_chunk_) buffers; deque keeps existing buffers put.
     std::deque<FixedVector<bool>> chunks_;
     const int64_t size_per_chunk_;
-    // number of actual elements
+    // End of the highest initialized logical range. Earlier reserved ranges
+    // may still be holes; row visibility is published by ack_responder_.
     size_t length_{0};
 };
 using ThreadSafeValidDataPtr = std::shared_ptr<ThreadSafeValidData>;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -711,6 +711,7 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
         auto data_offset = field_id_to_offset[field_id];
         if (field_meta.is_nullable()) {
             insert_record_.get_valid_data(field_id)->set_data_raw(
+                reserved_offset,
                 num_rows,
                 &insert_record_proto->fields_data(data_offset),
                 field_meta);
@@ -979,7 +980,8 @@ SegmentGrowingImpl::load_field_data_common(
     // Growing-source flush reads raw data from insert_record_. Keep it
     // populated even when an interim index can provide raw vector data.
     if (insert_record_.is_valid_data_exist(field_id)) {
-        insert_record_.get_valid_data(field_id)->set_data_raw(field_data);
+        insert_record_.get_valid_data(field_id)->set_data_raw(reserved_offset,
+                                                              field_data);
     }
     insert_record_.get_data_base(field_id)->set_data_raw(reserved_offset,
                                                          field_data);
@@ -3006,7 +3008,7 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
     auto data = bulk_subscript_not_exist_field(field_meta, total_row_num);
     if (insert_record_.is_valid_data_exist(field_id)) {
         insert_record_.get_valid_data(field_id)->set_data_raw(
-            total_row_num, data.get(), field_meta);
+            0, total_row_num, data.get(), field_meta);
     }
     insert_record_.get_data_base(field_id)->set_data_raw(
         0, total_row_num, data.get(), field_meta);

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -728,6 +728,197 @@ TEST(Growing, FillNullableData) {
     }
 }
 
+TEST(Growing, OutOfOrderInsertKeepsNullableScalarValidityAligned) {
+    constexpr int64_t batch_size = 2;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto nullable_value =
+        schema->AddDebugField("nullable_value", DataType::INT64, true);
+    schema->set_primary_field_id(pk);
+
+    auto config = SegcoreConfig::default_config();
+    config.set_chunk_rows(3);
+    config.set_enable_interim_segment_index(false);
+    auto segment_growing =
+        CreateGrowingSegment(schema, empty_index_meta, 1, config);
+    auto segment = dynamic_cast<SegmentGrowingImpl*>(segment_growing.get());
+    ASSERT_NE(segment, nullptr);
+
+    auto make_batch = [&](const std::array<int64_t, batch_size>& pks,
+                          const std::array<int64_t, batch_size>& values,
+                          const std::array<bool, batch_size>& valid_data) {
+        auto insert_data = std::make_unique<InsertRecordProto>();
+        insert_data->set_num_rows(batch_size);
+        insert_data->mutable_fields_data()->AddAllocated(
+            CreateDataArrayFrom(pks.data(), nullptr, batch_size, (*schema)[pk])
+                .release());
+        insert_data->mutable_fields_data()->AddAllocated(
+            CreateDataArrayFrom(values.data(),
+                                valid_data.data(),
+                                batch_size,
+                                (*schema)[nullable_value])
+                .release());
+        return insert_data;
+    };
+
+    const std::array<int64_t, batch_size> pks_a = {10, 11};
+    const std::array<int64_t, batch_size> pks_b = {20, 21};
+    const std::array<int64_t, batch_size> values_a = {100, 101};
+    const std::array<int64_t, batch_size> values_b = {200, 201};
+    const std::array<bool, batch_size> valid_a = {true, false};
+    const std::array<bool, batch_size> valid_b = {false, true};
+    auto batch_a = make_batch(pks_a, values_a, valid_a);
+    auto batch_b = make_batch(pks_b, values_b, valid_b);
+
+    const std::array<int64_t, batch_size> row_ids_a = {0, 1};
+    const std::array<int64_t, batch_size> row_ids_b = {2, 3};
+    const std::array<Timestamp, batch_size> timestamps_a = {100, 101};
+    const std::array<Timestamp, batch_size> timestamps_b = {102, 103};
+
+    auto offset_a = segment->PreInsert(batch_size);
+    auto offset_b = segment->PreInsert(batch_size);
+    ASSERT_EQ(offset_a, 0);
+    ASSERT_EQ(offset_b, batch_size);
+
+    ASSERT_NO_THROW(segment->Insert(offset_b,
+                                    batch_size,
+                                    row_ids_b.data(),
+                                    timestamps_b.data(),
+                                    batch_b.get()));
+    EXPECT_EQ(segment->get_row_count(), 0);
+
+    ASSERT_NO_THROW(segment->Insert(offset_a,
+                                    batch_size,
+                                    row_ids_a.data(),
+                                    timestamps_a.data(),
+                                    batch_a.get()));
+    ASSERT_EQ(segment->get_row_count(), 2 * batch_size);
+
+    const std::array<int64_t, 2 * batch_size> offsets = {0, 1, 2, 3};
+    auto result = segment->bulk_subscript(
+        nullptr, nullable_value, offsets.data(), offsets.size());
+    ASSERT_NE(result, nullptr);
+
+    const auto& actual_values = result->scalars().long_data().data();
+    ASSERT_EQ(actual_values.size(), 2 * batch_size);
+    ASSERT_EQ(result->valid_data_size(), 2 * batch_size);
+    const std::array<bool, 2 * batch_size> expected_validity = {
+        true, false, false, true};
+    for (size_t i = 0; i < expected_validity.size(); ++i) {
+        EXPECT_EQ(result->valid_data(i), expected_validity[i]);
+    }
+    EXPECT_EQ(actual_values[0], 100);
+    EXPECT_EQ(actual_values[3], 201);
+}
+
+TEST(Growing, OutOfOrderInsertKeepsNullableVectorMappingAligned) {
+    constexpr int64_t batch_size = 2;
+    constexpr int64_t dim = 2;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto nullable_vector = schema->AddDebugField("nullable_vector",
+                                                 DataType::VECTOR_FLOAT,
+                                                 dim,
+                                                 knowhere::metric::L2,
+                                                 true);
+    schema->set_primary_field_id(pk);
+
+    auto config = SegcoreConfig::default_config();
+    config.set_chunk_rows(3);
+    config.set_enable_interim_segment_index(false);
+    auto segment_growing =
+        CreateGrowingSegment(schema, empty_index_meta, 1, config);
+    auto segment = dynamic_cast<SegmentGrowingImpl*>(segment_growing.get());
+    ASSERT_NE(segment, nullptr);
+
+    auto make_batch = [&](const std::array<int64_t, batch_size>& pks,
+                          const std::array<float, dim>& compact_vector,
+                          const std::array<bool, batch_size>& valid_data) {
+        auto insert_data = std::make_unique<InsertRecordProto>();
+        insert_data->set_num_rows(batch_size);
+        insert_data->mutable_fields_data()->AddAllocated(
+            CreateDataArrayFrom(pks.data(), nullptr, batch_size, (*schema)[pk])
+                .release());
+        insert_data->mutable_fields_data()->AddAllocated(
+            CreateVectorDataArrayFrom(compact_vector.data(),
+                                      valid_data.data(),
+                                      batch_size,
+                                      1,
+                                      (*schema)[nullable_vector])
+                .release());
+        return insert_data;
+    };
+
+    const std::array<int64_t, batch_size> pks_a = {10, 11};
+    const std::array<int64_t, batch_size> pks_b = {20, 21};
+    const std::array<float, dim> vector_a = {1.0F, 2.0F};
+    const std::array<float, dim> vector_b = {3.0F, 4.0F};
+    const std::array<bool, batch_size> valid_a = {true, false};
+    const std::array<bool, batch_size> valid_b = {false, true};
+    auto batch_a = make_batch(pks_a, vector_a, valid_a);
+    auto batch_b = make_batch(pks_b, vector_b, valid_b);
+
+    const std::array<int64_t, batch_size> row_ids_a = {0, 1};
+    const std::array<int64_t, batch_size> row_ids_b = {2, 3};
+    const std::array<Timestamp, batch_size> timestamps_a = {100, 101};
+    const std::array<Timestamp, batch_size> timestamps_b = {102, 103};
+
+    auto offset_a = segment->PreInsert(batch_size);
+    auto offset_b = segment->PreInsert(batch_size);
+    ASSERT_EQ(offset_a, 0);
+    ASSERT_EQ(offset_b, batch_size);
+
+    ASSERT_NO_THROW(segment->Insert(offset_b,
+                                    batch_size,
+                                    row_ids_b.data(),
+                                    timestamps_b.data(),
+                                    batch_b.get()));
+    EXPECT_EQ(segment->get_row_count(), 0);
+
+    ASSERT_NO_THROW(segment->Insert(offset_a,
+                                    batch_size,
+                                    row_ids_a.data(),
+                                    timestamps_a.data(),
+                                    batch_a.get()));
+    ASSERT_EQ(segment->get_row_count(), 2 * batch_size);
+
+    const std::array<int64_t, 2 * batch_size> offsets = {0, 1, 2, 3};
+    auto result = segment->bulk_subscript(
+        nullptr, nullable_vector, offsets.data(), offsets.size());
+    ASSERT_NE(result, nullptr);
+
+    const std::array<bool, 2 * batch_size> expected_validity = {
+        true, false, false, true};
+    ASSERT_EQ(result->valid_data_size(), expected_validity.size());
+    for (size_t i = 0; i < expected_validity.size(); ++i) {
+        EXPECT_EQ(result->valid_data(i), expected_validity[i]);
+    }
+
+    const std::array<float, 2 * dim> expected_vectors = {
+        1.0F, 2.0F, 3.0F, 4.0F};
+    const auto& actual_vectors = result->vectors().float_vector().data();
+    ASSERT_EQ(actual_vectors.size(), expected_vectors.size());
+    for (size_t i = 0; i < expected_vectors.size(); ++i) {
+        EXPECT_FLOAT_EQ(actual_vectors[i], expected_vectors[i]);
+    }
+
+    auto vector_data =
+        segment->get_insert_record().get_data_base(nullable_vector);
+    ASSERT_TRUE(vector_data->is_mapping_storage());
+    EXPECT_EQ(vector_data->get_physical_offset(1), -1);
+    EXPECT_EQ(vector_data->get_physical_offset(2), -1);
+    auto physical_a = vector_data->get_physical_offset(0);
+    auto physical_b = vector_data->get_physical_offset(3);
+    EXPECT_GE(physical_a, 0);
+    EXPECT_GE(physical_b, 0);
+    EXPECT_NE(physical_a, physical_b);
+    EXPECT_EQ(vector_data->get_logical_offset(physical_a), 0);
+    EXPECT_EQ(vector_data->get_logical_offset(physical_b), 3);
+    EXPECT_EQ(vector_data->get_valid_count(), 2);
+}
+
 class GrowingNullableTest : public ::testing::TestWithParam<
                                 std::tuple</*data_type*/ DataType,
                                            /*metric_type*/ knowhere::MetricType,


### PR DESCRIPTION
## What this fixes

`PreInsert` assigns each growing insert a logical range. Field values, row IDs, and timestamps honor `reserved_offset`, but nullable validity previously appended by insert completion order. If a later reservation completes first, NULL markers can attach to the wrong scalar rows, and nullable vector mapping storage can read beyond the initialized validity range.

## Changes

- Pass `reserved_offset` into growing validity writes.
- Reserve through `reserved_offset + num_rows` and write into that logical range.
- Keep the initialized high-watermark monotonic while `AckResponder` remains responsible for publishing the contiguous visible prefix.
- Preserve the fixed-chunk, pointer-stable validity storage introduced by #51678.
- Add deterministic scalar and nullable-vector regressions for reverse insert completion order.

## Scope

This PR fixes logical validity-range alignment for out-of-order insert completion. It does not claim to solve the separate pre-existing physical-offset allocation race between truly simultaneous nullable-vector mapping writers.

## Testing

- `Growing.OutOfOrderInsertKeepsNullable*`: 2/2 passed
- `Growing.*`: 19/19 passed
- clang-format 15 dry-run and `git diff --check` passed

issue: #51842
related: #51678