### PR TITLE
enhance: Add optimistic CAS for partial updates

### DIFF
--- a/internal/distributed/streaming/internal/producer/producer.go
+++ b/internal/distributed/streaming/internal/producer/producer.go
@@ -144,6 +144,11 @@ func (p *ResumableProducer) produceInternal(ctx context.Context, msg message.Mut
 			return nil, errors.Mark(err, errs.ErrCanceledOrDeadlineExceed)
 		}
 		if sErr := status.AsStreamingError(err); sErr != nil {
+			if sErr.IsPartialUpdateRetryableCAS() {
+				// Proxy must re-query and rebuild the row instead of retrying the
+				// transaction with stale merged fields.
+				return nil, err
+			}
 			// if the error is txn unavailable or unrecoverable error,
 			// it cannot be retried forever.
 			// we should mark it and return.

--- a/internal/distributed/streaming/internal/producer/producer_task.go
+++ b/internal/distributed/streaming/internal/producer/producer_task.go
@@ -130,9 +130,13 @@ func (g *ProduceGuard) commit(ctx context.Context) (*types.AppendResult, error) 
 		}
 		return g.producer.produceInternal(ctx, g.msgs[0])
 	}
-	// auto commit if there's only one message.
 	if len(g.msgs) == 1 {
-		return g.produceAutocommit(ctx, g.msgs[0])
+		msg := g.msgs[0]
+		// Only a local CAS message without transaction context needs wrapping.
+		// Replication already carries the source transaction and must preserve it.
+		if !message.HasPartialUpdateCAS(msg) || msg.TxnContext() != nil || msg.ReplicateHeader() != nil {
+			return g.produceAutocommit(ctx, msg)
+		}
 	}
 	// produce with transaction.
 	return g.produceTxn(ctx, g.msgs...)
@@ -170,7 +174,12 @@ func (g *ProduceGuard) produceTxn(ctx context.Context, msgs ...message.MutableMe
 			return nil, ctx.Err()
 		}
 		result, err := g.produceWithTxnOnce(ctx, msgs...)
-		if err := status.AsStreamingError(err); err != nil && err.IsTxnExpired() {
+		if streamingErr := status.AsStreamingError(err); streamingErr != nil && streamingErr.IsTxnExpired() {
+			for _, msg := range msgs {
+				if message.HasPartialUpdateCAS(msg) {
+					return nil, status.NewPartialUpdateRetryable("partial update transaction expired before commit")
+				}
+			}
 			// if the transaction is expired,
 			// there may be wal is transferred to another streaming node,
 			// retry it with new transaction.
@@ -186,6 +195,14 @@ func (g *ProduceGuard) produceTxn(ctx context.Context, msgs ...message.MutableMe
 
 // produceWithTxnOnce produces the messages with a transaction once.
 func (g *ProduceGuard) produceWithTxnOnce(ctx context.Context, msgs ...message.MutableMessage) (_ *types.AppendResult, err error) {
+	partialUpdateCAS := false
+	for _, msg := range msgs {
+		if message.HasPartialUpdateCAS(msg) && msg.ReplicateHeader() == nil {
+			partialUpdateCAS = true
+			break
+		}
+	}
+
 	// a txn batch should always belong to one vchannel.
 	txn, err := g.beginTxn(ctx, msgs[0].VChannel())
 	if err != nil {
@@ -194,7 +211,7 @@ func (g *ProduceGuard) produceWithTxnOnce(ctx context.Context, msgs ...message.M
 	if err := g.appendTxnBody(ctx, txn, msgs...); err != nil {
 		return nil, err
 	}
-	return g.commitTxn(ctx, msgs[0].VChannel(), txn)
+	return g.commitTxn(ctx, msgs[0].VChannel(), txn, partialUpdateCAS)
 }
 
 // beginTxn begins a new transaction.
@@ -242,13 +259,23 @@ func (g *ProduceGuard) appendTxnBody(ctx context.Context, txn *message.TxnContex
 }
 
 // commitTxn commits the transaction.
-func (g *ProduceGuard) commitTxn(ctx context.Context, vchannel string, txn *message.TxnContext) (*types.AppendResult, error) {
+func (g *ProduceGuard) commitTxn(
+	ctx context.Context,
+	vchannel string,
+	txn *message.TxnContext,
+	partialUpdateCAS bool,
+) (*types.AppendResult, error) {
 	commitTxn := message.NewCommitTxnMessageBuilderV2().
 		WithVChannel(vchannel).
 		WithHeader(&message.CommitTxnMessageHeader{}).
 		WithBody(&message.CommitTxnMessageBody{}).
 		MustBuildMutable()
 	message.InjectTraceContext(ctx, commitTxn)
+	if partialUpdateCAS {
+		if err := message.MarkPartialUpdateCASCommit(commitTxn); err != nil {
+			return nil, err
+		}
+	}
 
 	return g.producer.produceInternal(ctx, commitTxn.WithTxnContext(*txn))
 }

--- a/internal/distributed/streaming/internal/producer/producer_task_test.go
+++ b/internal/distributed/streaming/internal/producer/producer_task_test.go
@@ -504,8 +504,6 @@ func validProducerPartialUpdateCAS() *messagespb.PartialUpdateCAS {
 	return &messagespb.PartialUpdateCAS{
 		ReadTs:               100,
 		ObservedPchannelTerm: 2,
-		CollectionId:         10,
-		PrimaryKeyFieldId:    100,
 	}
 }
 

--- a/internal/distributed/streaming/internal/producer/producer_task_test.go
+++ b/internal/distributed/streaming/internal/producer/producer_task_test.go
@@ -18,19 +18,25 @@ package producer
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/client/handler/mock_producer"
 	"github.com/milvus-io/milvus/internal/streamingnode/client/handler"
 	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/producer"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
 )
 
 func TestBatchCommitProduce(t *testing.T) {
@@ -172,6 +178,222 @@ func TestProduceGuard_Commit_NoMessages(t *testing.T) {
 	})
 }
 
+func TestProduceGuardCommitPartialUpdateSingleMessageUsesTxn(t *testing.T) {
+	rp := &ResumableProducer{opts: &ProducerOptions{PChannel: "p1"}}
+
+	msg := createRealPartialUpdateInsertMessage(t, "test-v")
+
+	var (
+		mu           sync.Mutex
+		seen         []message.MessageType
+		bodyTxn      *message.TxnContext
+		commitMsg    message.MutableMessage
+		beginTxnCtx  = &message.TxnContext{TxnID: 1, Keepalive: time.Second}
+		producePatch = mockey.Mock((*ResumableProducer).produceInternal).To(
+			func(_ *ResumableProducer, _ context.Context, m message.MutableMessage) (*types.AppendResult, error) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				seen = append(seen, m.MessageType())
+				switch m.MessageType() {
+				case message.MessageTypeBeginTxn:
+					return &types.AppendResult{TxnCtx: beginTxnCtx}, nil
+				case message.MessageTypeInsert:
+					bodyTxn = m.TxnContext()
+					return &types.AppendResult{TxnCtx: m.TxnContext()}, nil
+				case message.MessageTypeCommitTxn:
+					commitMsg = m
+					return &types.AppendResult{TxnCtx: m.TxnContext()}, nil
+				default:
+					return &types.AppendResult{}, nil
+				}
+			}).Build()
+	)
+	defer producePatch.UnPatch()
+
+	guard := &ProduceGuard{producer: rp, msgs: []message.MutableMessage{msg}}
+	result, err := guard.commit(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []message.MessageType{
+		message.MessageTypeBeginTxn,
+		message.MessageTypeInsert,
+		message.MessageTypeCommitTxn,
+	}, seen)
+	require.NotNil(t, bodyTxn)
+	assert.Equal(t, beginTxnCtx.TxnID, bodyTxn.TxnID)
+	require.NotNil(t, commitMsg)
+	require.True(t, message.HasPartialUpdateCAS(commitMsg))
+	marker, ok := commitMsg.Properties().Get("_puc")
+	require.True(t, ok)
+	require.Empty(t, marker)
+}
+
+func TestProduceGuardPartialUpdateTxnExpiredReturnsCASRetry(t *testing.T) {
+	msg := createRealPartialUpdateInsertMessage(t, "test-v")
+	guard := &ProduceGuard{
+		producer: &ResumableProducer{opts: &ProducerOptions{PChannel: "p1"}},
+		msgs:     []message.MutableMessage{msg},
+	}
+
+	attempts := 0
+	m := mockey.Mock((*ProduceGuard).produceWithTxnOnce).To(
+		func(*ProduceGuard, context.Context, ...message.MutableMessage) (*types.AppendResult, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, status.NewTransactionExpired("expired")
+			}
+			return &types.AppendResult{}, nil
+		},
+	).Build()
+	defer m.UnPatch()
+
+	_, err := guard.produceTxn(context.Background(), msg)
+
+	require.Error(t, err)
+	require.True(t, status.AsStreamingError(err).IsPartialUpdateRetryableCAS())
+	require.Equal(t, 1, attempts)
+}
+
+func TestProduceGuardOrdinaryTxnExpiredReplaysWholeTransaction(t *testing.T) {
+	msgs := []message.MutableMessage{
+		createRealInsertMessage(t, "test-v"),
+		createRealInsertMessage(t, "test-v"),
+	}
+	guard := &ProduceGuard{
+		producer: &ResumableProducer{opts: &ProducerOptions{PChannel: "p1"}},
+		msgs:     msgs,
+	}
+
+	var (
+		mu        sync.Mutex
+		beginIDs  []message.TxnID
+		bodyCount = make(map[message.TxnID]int)
+		commitIDs []message.TxnID
+	)
+	nextTxnID := message.TxnID(1)
+	producePatch := mockey.Mock((*ResumableProducer).produceInternal).To(
+		func(_ *ResumableProducer, _ context.Context, msg message.MutableMessage) (*types.AppendResult, error) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			switch msg.MessageType() {
+			case message.MessageTypeBeginTxn:
+				txnCtx := &message.TxnContext{TxnID: nextTxnID, Keepalive: time.Second}
+				nextTxnID++
+				beginIDs = append(beginIDs, txnCtx.TxnID)
+				return &types.AppendResult{TxnCtx: txnCtx}, nil
+			case message.MessageTypeCommitTxn:
+				txnID := msg.TxnContext().TxnID
+				commitIDs = append(commitIDs, txnID)
+				if txnID == 1 {
+					return nil, status.NewTransactionExpired("expired")
+				}
+				return &types.AppendResult{TxnCtx: msg.TxnContext()}, nil
+			default:
+				txnID := msg.TxnContext().TxnID
+				bodyCount[txnID]++
+				return &types.AppendResult{TxnCtx: msg.TxnContext()}, nil
+			}
+		},
+	).Build()
+	defer producePatch.UnPatch()
+
+	result, err := guard.produceTxn(context.Background(), msgs...)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, []message.TxnID{1, 2}, beginIDs)
+	require.Equal(t, []message.TxnID{1, 2}, commitIDs)
+	require.Equal(t, len(msgs), bodyCount[1])
+	require.Equal(t, len(msgs), bodyCount[2])
+}
+
+func TestProduceGuardCommitExistingPartialUpdateTxnIsNotRewrapped(t *testing.T) {
+	rp := &ResumableProducer{opts: &ProducerOptions{PChannel: "p1"}}
+	txnCtx := message.TxnContext{TxnID: 7, Keepalive: time.Second}
+	replicateHeader := &message.ReplicateHeader{
+		ClusterID:              "primary",
+		MessageID:              walimplstest.NewTestMessageID(10),
+		LastConfirmedMessageID: walimplstest.NewTestMessageID(9),
+		TimeTick:               100,
+		VChannel:               "test-v",
+	}
+
+	for _, tc := range []struct {
+		name      string
+		replicate bool
+	}{
+		{name: "local transactional message"},
+		{name: "replicated transactional message", replicate: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := createRealPartialUpdateInsertMessage(t, "test-v").WithTxnContext(txnCtx)
+			if tc.replicate {
+				msg = msg.WithReplicateHeader(replicateHeader)
+			}
+
+			var seen []message.MutableMessage
+			producePatch := mockey.Mock((*ResumableProducer).produceInternal).To(
+				func(_ *ResumableProducer, _ context.Context, m message.MutableMessage) (*types.AppendResult, error) {
+					seen = append(seen, m)
+					if m.MessageType() == message.MessageTypeBeginTxn {
+						return &types.AppendResult{TxnCtx: &message.TxnContext{TxnID: 99, Keepalive: time.Second}}, nil
+					}
+					return &types.AppendResult{TxnCtx: m.TxnContext()}, nil
+				}).Build()
+			defer producePatch.UnPatch()
+
+			guard := &ProduceGuard{producer: rp, msgs: []message.MutableMessage{msg}}
+			_, err := guard.commit(context.Background())
+			require.NoError(t, err)
+			require.Len(t, seen, 1)
+			require.Equal(t, message.MessageTypeInsert, seen[0].MessageType())
+			require.Equal(t, txnCtx.TxnID, seen[0].TxnContext().TxnID)
+			if tc.replicate {
+				require.Equal(t, replicateHeader.ClusterID, seen[0].ReplicateHeader().ClusterID)
+			} else {
+				require.Nil(t, seen[0].ReplicateHeader())
+			}
+		})
+	}
+}
+
+func TestProduceGuardCommitOrdinarySingleMessageAutoCommit(t *testing.T) {
+	rp := &ResumableProducer{opts: &ProducerOptions{PChannel: "p1"}}
+	msg := createRealInsertMessage(t, "test-v")
+
+	var seen []message.MessageType
+	producePatch := mockey.Mock((*ResumableProducer).produceInternal).To(
+		func(_ *ResumableProducer, _ context.Context, m message.MutableMessage) (*types.AppendResult, error) {
+			seen = append(seen, m.MessageType())
+			return &types.AppendResult{}, nil
+		}).Build()
+	defer producePatch.UnPatch()
+
+	guard := &ProduceGuard{producer: rp, msgs: []message.MutableMessage{msg}}
+	result, err := guard.commit(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []message.MessageType{message.MessageTypeInsert}, seen)
+}
+
+func TestCommitTxnReturnsMarkerError(t *testing.T) {
+	expected := status.NewUnrecoverableError("mark commit failed")
+	patch := mockey.Mock(message.MarkPartialUpdateCASCommit).Return(expected).Build()
+	defer patch.UnPatch()
+
+	guard := &ProduceGuard{}
+	result, err := guard.commitTxn(
+		context.Background(),
+		"test-v",
+		&message.TxnContext{TxnID: 1},
+		true,
+	)
+	require.Nil(t, result)
+	require.ErrorIs(t, err, expected)
+}
+
 func TestBatchCommitProduce_ReservationError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -276,4 +498,23 @@ func TestProduceGuard_Commit_Error(t *testing.T) {
 	resAppend, err := task.commit(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, resAppend)
+}
+
+func validProducerPartialUpdateCAS() *messagespb.PartialUpdateCAS {
+	return &messagespb.PartialUpdateCAS{
+		ReadTs:               100,
+		ObservedPchannelTerm: 2,
+		CollectionId:         10,
+		PrimaryKeyFieldId:    100,
+	}
+}
+
+func createRealPartialUpdateInsertMessage(t *testing.T, vchannel string) message.MutableMessage {
+	t.Helper()
+	builder := message.NewInsertMessageBuilderV1().
+		WithHeader(&message.InsertMessageHeader{CollectionId: 1}).
+		WithBody(&msgpb.InsertRequest{CollectionID: 1}).
+		WithVChannel(vchannel)
+	require.NoError(t, builder.AddPartialUpdateCAS(validProducerPartialUpdateCAS()))
+	return builder.MustBuildMutable()
 }

--- a/internal/distributed/streaming/internal/producer/producer_test.go
+++ b/internal/distributed/streaming/internal/producer/producer_test.go
@@ -21,9 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming/internal/errs"
@@ -435,6 +437,45 @@ func TestResumableProducer_ConcurrentProduce(t *testing.T) {
 		err := <-errCh
 		assert.NoError(t, err)
 	}
+}
+
+func TestResumableProducerReturnsPartialUpdateCASError(t *testing.T) {
+	rejectProducer := &partialUpdateCASRejectProducer{}
+	appendCalls := 0
+	m := mockey.Mock((*partialUpdateCASRejectProducer).Append).To(
+		func(*partialUpdateCASRejectProducer, context.Context, message.MutableMessage) (*types.AppendResult, error) {
+			appendCalls++
+			if appendCalls > 1 {
+				return nil, context.Canceled
+			}
+			return nil, status.NewPartialUpdateRetryable("conflict")
+		},
+	).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*partialUpdateCASRejectProducer).IsAvailable).Return(true).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*partialUpdateCASRejectProducer).Available).Return(make(chan struct{})).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*partialUpdateCASRejectProducer).Close).Return().Build()
+	defer m.UnPatch()
+
+	rp := NewResumableProducer(func(context.Context, *handler.ProducerOptions) (producer.Producer, error) {
+		return rejectProducer, nil
+	}, &ProducerOptions{PChannel: "partial-update-cas"})
+	defer rp.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result, err := rp.produceInternal(ctx, createRealInsertMessage(t, "test-v"))
+
+	require.Error(t, err)
+	require.True(t, status.AsStreamingError(err).IsPartialUpdateRetryableCAS())
+	require.Nil(t, result)
+	require.Equal(t, 1, appendCalls)
+}
+
+type partialUpdateCASRejectProducer struct {
+	producer.Producer
 }
 
 func TestResumableProducer_ProduceAfterClose(t *testing.T) {

--- a/internal/distributed/streaming/streaming.go
+++ b/internal/distributed/streaming/streaming.go
@@ -11,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/util"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/options"
@@ -63,6 +64,20 @@ func Release() error {
 // WAL is the entrance to interact with the milvus write ahead log.
 func WAL() WALAccesser {
 	return singleton
+}
+
+type pchannelInfoResolver interface {
+	ResolvePChannelInfo(ctx context.Context, vchannel string) (types.PChannelInfo, error)
+}
+
+// ResolvePChannelInfo returns the current pchannel assignment without
+// expanding WALAccesser for callers that do not need assignment discovery.
+func ResolvePChannelInfo(ctx context.Context, vchannel string) (types.PChannelInfo, error) {
+	resolver, ok := singleton.(pchannelInfoResolver)
+	if !ok {
+		return types.PChannelInfo{}, status.NewUnrecoverableError("wal accesser does not support pchannel assignment discovery")
+	}
+	return resolver.ResolvePChannelInfo(ctx, vchannel)
 }
 
 // AppendOption is the option for append operation.

--- a/internal/distributed/streaming/streaming_test.go
+++ b/internal/distributed/streaming/streaming_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/adaptor"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/options"
 	pulsar2 "github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/pulsar"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -33,6 +34,30 @@ func TestMain(m *testing.M) {
 	streamingutil.SetStreamingServiceEnabled()
 	paramtable.Init()
 	m.Run()
+}
+
+func TestResolvePChannelInfo(t *testing.T) {
+	previous := streaming.WAL()
+	t.Cleanup(func() { streaming.SetWALForTest(previous) })
+
+	t.Run("supported", func(t *testing.T) {
+		streaming.SetupNoopWALForTest()
+		info, err := streaming.ResolvePChannelInfo(context.Background(), vChannels[0])
+		if err != nil {
+			t.Fatalf("resolve pchannel info: %v", err)
+		}
+		if info.Name != funcutil.ToPhysicalChannel(vChannels[0]) || info.Term != 1 {
+			t.Fatalf("unexpected pchannel info: %+v", info)
+		}
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		streaming.SetWALForTest(&struct{ streaming.WALAccesser }{})
+		_, err := streaming.ResolvePChannelInfo(context.Background(), vChannels[0])
+		if err == nil {
+			t.Fatal("expected unsupported resolver error")
+		}
+	})
 }
 
 func TestReplicate(t *testing.T) {

--- a/internal/distributed/streaming/test_streaming.go
+++ b/internal/distributed/streaming/test_streaming.go
@@ -214,6 +214,14 @@ func (n *noopWALAccesser) Read(ctx context.Context, opts ReadOption) Scanner {
 	return &noopScanner{}
 }
 
+func (n *noopWALAccesser) ResolvePChannelInfo(ctx context.Context, vchannel string) (types.PChannelInfo, error) {
+	return types.PChannelInfo{
+		Name:       funcutil.ToPhysicalChannel(vchannel),
+		Term:       1,
+		AccessMode: types.AccessModeRW,
+	}, nil
+}
+
 func (n *noopWALAccesser) AppendMessages(ctx context.Context, msgs ...message.MutableMessage) AppendResponses {
 	if err := getExpectErr(); err != nil {
 		return AppendResponses{

--- a/internal/distributed/streaming/wal.go
+++ b/internal/distributed/streaming/wal.go
@@ -132,6 +132,26 @@ func (w *walAccesserImpl) Read(ctx context.Context, opts ReadOption) Scanner {
 	return rc
 }
 
+// ResolvePChannelInfo returns the current pchannel assignment for the vchannel.
+func (w *walAccesserImpl) ResolvePChannelInfo(ctx context.Context, vchannel string) (types.PChannelInfo, error) {
+	if !w.lifetime.Add(typeutil.LifetimeStateWorking) {
+		return types.PChannelInfo{}, ErrWALAccesserClosed
+	}
+	defer w.lifetime.Done()
+
+	pchannel := funcutil.ToPhysicalChannel(vchannel)
+	assignments, err := w.streamingCoordClient.Assignment().GetLatestAssignments(ctx)
+	if err != nil {
+		return types.PChannelInfo{}, err
+	}
+	for _, assignment := range assignments.Assignments {
+		if pchannelInfo, ok := assignment.Channels[pchannel]; ok {
+			return pchannelInfo, nil
+		}
+	}
+	return types.PChannelInfo{}, status.NewChannelNotExist(pchannel)
+}
+
 // Broadcast returns a broadcast for broadcasting records to the wal.
 func (w *walAccesserImpl) Broadcast() Broadcast {
 	return broadcast{w}

--- a/internal/distributed/streaming/wal_test.go
+++ b/internal/distributed/streaming/wal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/atomic"
@@ -16,6 +17,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/client/handler/mock_consumer"
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/client/handler/mock_producer"
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/client/mock_handler"
+	streamingcoordclient "github.com/milvus-io/milvus/internal/streamingcoord/client"
 	streamingnodehandler "github.com/milvus-io/milvus/internal/streamingnode/client/handler"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
@@ -204,6 +206,92 @@ func TestWALAccesserPrepareReleaseManualFlushIfLocal(t *testing.T) {
 	prepared, err := w.Local().PrepareReleaseManualFlushIfLocal(ctx, 100, vChannel1, []int64{1001})
 	assert.NoError(t, err)
 	assert.True(t, prepared)
+}
+
+type resolvePChannelInfoTestClient struct {
+	streamingcoordclient.Client
+}
+
+type resolvePChannelInfoAssignment struct {
+	streamingcoordclient.AssignmentService
+}
+
+func newResolvePChannelInfoTestClient(
+	t *testing.T,
+	assignments *types.VersionedStreamingNodeAssignments,
+	err error,
+) streamingcoordclient.Client {
+	t.Helper()
+
+	assignment := &resolvePChannelInfoAssignment{}
+	client := &resolvePChannelInfoTestClient{}
+	getAssignmentsMock := mockey.Mock((*resolvePChannelInfoAssignment).GetLatestAssignments).Return(assignments, err).Build()
+	t.Cleanup(func() { getAssignmentsMock.UnPatch() })
+	assignmentMock := mockey.Mock((*resolvePChannelInfoTestClient).Assignment).Return(assignment).Build()
+	t.Cleanup(func() { assignmentMock.UnPatch() })
+	closeMock := mockey.Mock((*resolvePChannelInfoTestClient).Close).Return().Build()
+	t.Cleanup(func() { closeMock.UnPatch() })
+	return client
+}
+
+func TestResolvePChannelInfoByVChannel(t *testing.T) {
+	const (
+		pchannel = "by-dev-rootcoord-dml_0"
+		vchannel = "by-dev-rootcoord-dml_0_100v0"
+	)
+
+	t.Run("matched assignment", func(t *testing.T) {
+		w := &walAccesserImpl{
+			lifetime: typeutil.NewLifetime(),
+			streamingCoordClient: newResolvePChannelInfoTestClient(t, &types.VersionedStreamingNodeAssignments{
+				Assignments: map[int64]types.StreamingNodeAssignment{
+					100: {
+						Channels: map[string]types.PChannelInfo{
+							pchannel: {
+								Name:       pchannel,
+								Term:       88,
+								AccessMode: types.AccessModeRW,
+							},
+						},
+					},
+				},
+			}, nil),
+		}
+		defer w.Close()
+
+		pchannelInfo, err := w.ResolvePChannelInfo(context.Background(), vchannel)
+		assert.NoError(t, err)
+		assert.Equal(t, pchannel, pchannelInfo.Name)
+		assert.Equal(t, int64(88), pchannelInfo.Term)
+	})
+
+	t.Run("missing assignment", func(t *testing.T) {
+		w := &walAccesserImpl{
+			lifetime: typeutil.NewLifetime(),
+			streamingCoordClient: newResolvePChannelInfoTestClient(t, &types.VersionedStreamingNodeAssignments{
+				Assignments: map[int64]types.StreamingNodeAssignment{
+					100: {
+						Channels: map[string]types.PChannelInfo{},
+					},
+				},
+			}, nil),
+		}
+		defer w.Close()
+
+		pchannelInfo, err := w.ResolvePChannelInfo(context.Background(), vchannel)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), pchannel)
+		assert.Zero(t, pchannelInfo)
+	})
+
+	t.Run("closed accesser", func(t *testing.T) {
+		w, _, _, _ := createMockWAL(t)
+		w.Close()
+
+		pchannelInfo, err := w.ResolvePChannelInfo(context.Background(), vchannel)
+		assert.ErrorIs(t, err, ErrWALAccesserClosed)
+		assert.Zero(t, pchannelInfo)
+	})
 }
 
 func newInsertMessage(vChannel string) message.MutableMessage {

--- a/internal/proxy/task_insert_streaming.go
+++ b/internal/proxy/task_insert_streaming.go
@@ -13,6 +13,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
@@ -63,9 +64,9 @@ func (it *insertTask) Execute(ctx context.Context) error {
 	// start to repack insert data
 	var msgs []message.MutableMessage
 	if it.partitionKeys == nil {
-		msgs, err = repackInsertDataForStreamingService(it.TraceCtx(), channelNames, it.insertMsg, it.result, ez, it.schemaVersion)
+		msgs, err = repackInsertDataForStreamingService(it.TraceCtx(), channelNames, it.insertMsg, it.result, ez, it.schemaVersion, nil)
 	} else {
-		msgs, err = repackInsertDataWithPartitionKeyForStreamingService(it.TraceCtx(), channelNames, it.insertMsg, it.result, it.partitionKeys, ez, it.schema, it.schemaVersion)
+		msgs, err = repackInsertDataWithPartitionKeyForStreamingService(it.TraceCtx(), channelNames, it.insertMsg, it.result, it.partitionKeys, ez, it.schema, it.schemaVersion, nil)
 	}
 	if err != nil {
 		mlog.Warn(ctx, "assign segmentID and repack insert data failed", mlog.Err(err))
@@ -93,6 +94,7 @@ func repackInsertDataForStreamingService(
 	result *milvuspb.MutationResult,
 	ez *message.CipherConfig,
 	schemaVersion int32,
+	partialUpdateCASGroups map[string]*messagespb.PartialUpdateCAS,
 ) ([]message.MutableMessage, error) {
 	messages := make([]message.MutableMessage, 0)
 
@@ -114,7 +116,7 @@ func repackInsertDataForStreamingService(
 		}
 		for _, msg := range msgs {
 			insertRequest := msg.(*msgstream.InsertMsg).InsertRequest
-			newMsg, err := message.NewInsertMessageBuilderV1().
+			builder := message.NewInsertMessageBuilderV1().
 				WithVChannel(channel).
 				WithHeader(&message.InsertMessageHeader{
 					CollectionId: insertMsg.CollectionID,
@@ -127,7 +129,17 @@ func repackInsertDataForStreamingService(
 					},
 					SchemaVersion: &schemaVersion,
 				}).
-				WithBody(insertRequest).
+				WithBody(insertRequest)
+			if partialUpdateCASGroups != nil {
+				meta, ok := partialUpdateCASGroups[channel]
+				if !ok {
+					return nil, merr.WrapErrServiceInternalMsg("partial update insert has no CAS metadata for vchannel %s", channel)
+				}
+				if err := builder.AddPartialUpdateCAS(meta); err != nil {
+					return nil, err
+				}
+			}
+			newMsg, err := builder.
 				WithCipher(ez).
 				BuildMutable()
 			if err != nil {
@@ -148,6 +160,7 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 	ez *message.CipherConfig,
 	schema *schemapb.CollectionSchema,
 	schemaVersion int32,
+	partialUpdateCASGroups map[string]*messagespb.PartialUpdateCAS,
 ) ([]message.MutableMessage, error) {
 	messages := make([]message.MutableMessage, 0)
 
@@ -207,7 +220,7 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 			}
 			for _, msg := range msgs {
 				insertRequest := msg.(*msgstream.InsertMsg).InsertRequest
-				newMsg, err := message.NewInsertMessageBuilderV1().
+				builder := message.NewInsertMessageBuilderV1().
 					WithVChannel(channel).
 					WithHeader(&message.InsertMessageHeader{
 						CollectionId: insertMsg.CollectionID,
@@ -220,7 +233,17 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 						},
 						SchemaVersion: &schemaVersion,
 					}).
-					WithBody(insertRequest).
+					WithBody(insertRequest)
+				if partialUpdateCASGroups != nil {
+					meta, ok := partialUpdateCASGroups[channel]
+					if !ok {
+						return nil, merr.WrapErrServiceInternalMsg("partial update insert has no CAS metadata for vchannel %s", channel)
+					}
+					if err := builder.AddPartialUpdateCAS(meta); err != nil {
+						return nil, err
+					}
+				}
+				newMsg, err := builder.
 					WithCipher(ez).
 					BuildMutable()
 				if err != nil {

--- a/internal/proxy/task_insert_streaming.go
+++ b/internal/proxy/task_insert_streaming.go
@@ -109,44 +109,27 @@ func repackInsertDataForStreamingService(
 	}
 
 	for channel, rowOffsets := range channel2RowOffsets {
-		// segment id is assigned at streaming node.
-		msgs, err := genInsertMsgsByPartition(ctx, 0, partitionID, partitionName, rowOffsets, channel, insertMsg)
+		partialUpdateCAS, err := getPartialUpdateCASForStreamingService(partialUpdateCASGroups, channel)
 		if err != nil {
 			return nil, err
 		}
-		for _, msg := range msgs {
-			insertRequest := msg.(*msgstream.InsertMsg).InsertRequest
-			builder := message.NewInsertMessageBuilderV1().
-				WithVChannel(channel).
-				WithHeader(&message.InsertMessageHeader{
-					CollectionId: insertMsg.CollectionID,
-					Partitions: []*message.PartitionSegmentAssignment{
-						{
-							PartitionId: partitionID,
-							Rows:        insertRequest.GetNumRows(),
-							BinarySize:  0, // TODO: current not used, message estimate size is used.
-						},
-					},
-					SchemaVersion: &schemaVersion,
-				}).
-				WithBody(insertRequest)
-			if partialUpdateCASGroups != nil {
-				meta, ok := partialUpdateCASGroups[channel]
-				if !ok {
-					return nil, merr.WrapErrServiceInternalMsg("partial update insert has no CAS metadata for vchannel %s", channel)
-				}
-				if err := builder.AddPartialUpdateCAS(meta); err != nil {
-					return nil, err
-				}
-			}
-			newMsg, err := builder.
-				WithCipher(ez).
-				BuildMutable()
-			if err != nil {
-				return nil, err
-			}
-			messages = append(messages, newMsg)
+
+		// segment id is assigned at streaming node.
+		msgs, err := repackInsertDataByPartitionForStreamingService(
+			ctx,
+			partitionID,
+			partitionName,
+			rowOffsets,
+			channel,
+			insertMsg,
+			ez,
+			schemaVersion,
+			partialUpdateCAS,
+		)
+		if err != nil {
+			return nil, err
 		}
+		messages = append(messages, msgs...)
 	}
 	return messages, nil
 }
@@ -204,6 +187,11 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 		return nil, err
 	}
 	for channel, rowOffsets := range channel2RowOffsets {
+		partialUpdateCAS, err := getPartialUpdateCASForStreamingService(partialUpdateCASGroups, channel)
+		if err != nil {
+			return nil, err
+		}
+
 		partition2RowOffsets := make(map[string][]int)
 		for _, idx := range rowOffsets {
 			partitionName := partitionNames[hashValues[idx]]
@@ -214,44 +202,157 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 		}
 
 		for partitionName, rowOffsets := range partition2RowOffsets {
-			msgs, err := genInsertMsgsByPartition(ctx, 0, partitionIDs[partitionName], partitionName, rowOffsets, channel, insertMsg)
+			msgs, err := repackInsertDataByPartitionForStreamingService(
+				ctx,
+				partitionIDs[partitionName],
+				partitionName,
+				rowOffsets,
+				channel,
+				insertMsg,
+				ez,
+				schemaVersion,
+				partialUpdateCAS,
+			)
 			if err != nil {
 				return nil, err
 			}
-			for _, msg := range msgs {
-				insertRequest := msg.(*msgstream.InsertMsg).InsertRequest
-				builder := message.NewInsertMessageBuilderV1().
-					WithVChannel(channel).
-					WithHeader(&message.InsertMessageHeader{
-						CollectionId: insertMsg.CollectionID,
-						Partitions: []*message.PartitionSegmentAssignment{
-							{
-								PartitionId: partitionIDs[partitionName],
-								Rows:        insertRequest.GetNumRows(),
-								BinarySize:  0, // TODO: current not used, message estimate size is used.
-							},
-						},
-						SchemaVersion: &schemaVersion,
-					}).
-					WithBody(insertRequest)
-				if partialUpdateCASGroups != nil {
-					meta, ok := partialUpdateCASGroups[channel]
-					if !ok {
-						return nil, merr.WrapErrServiceInternalMsg("partial update insert has no CAS metadata for vchannel %s", channel)
-					}
-					if err := builder.AddPartialUpdateCAS(meta); err != nil {
-						return nil, err
-					}
-				}
-				newMsg, err := builder.
-					WithCipher(ez).
-					BuildMutable()
-				if err != nil {
-					return nil, err
-				}
-				messages = append(messages, newMsg)
-			}
+			messages = append(messages, msgs...)
 		}
 	}
 	return messages, nil
+}
+
+func getPartialUpdateCASForStreamingService(
+	groups map[string]*messagespb.PartialUpdateCAS,
+	channel string,
+) (*messagespb.PartialUpdateCAS, error) {
+	if groups == nil {
+		return nil, nil
+	}
+	meta, ok := groups[channel]
+	if !ok {
+		return nil, merr.WrapErrServiceInternalMsg("partial update insert has no CAS metadata for vchannel %s", channel)
+	}
+	if meta == nil {
+		return nil, merr.WrapErrServiceInternalMsg("partial update insert has nil CAS metadata for vchannel %s", channel)
+	}
+	return meta, nil
+}
+
+func repackInsertDataByPartitionForStreamingService(
+	ctx context.Context,
+	partitionID int64,
+	partitionName string,
+	rowOffsets []int,
+	channel string,
+	insertMsg *msgstream.InsertMsg,
+	ez *message.CipherConfig,
+	schemaVersion int32,
+	partialUpdateCAS *messagespb.PartialUpdateCAS,
+) ([]message.MutableMessage, error) {
+	type pendingInsertPack struct {
+		rowOffsets []int
+		insertMsg  *msgstream.InsertMsg
+	}
+
+	maxMessageSize := Params.PulsarCfg.MaxMessageSize.GetAsInt()
+	messages := make([]message.MutableMessage, 0)
+	pending := []pendingInsertPack{{rowOffsets: rowOffsets}}
+	for len(pending) > 0 {
+		pack := pending[0]
+		pending = pending[1:]
+		if pack.insertMsg == nil {
+			packedMsgs, err := genInsertMsgsByPartition(
+				ctx,
+				0,
+				partitionID,
+				partitionName,
+				pack.rowOffsets,
+				channel,
+				insertMsg,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			generated := make([]pendingInsertPack, 0, len(packedMsgs))
+			rowOffsetCursor := 0
+			for _, packedMsg := range packedMsgs {
+				packedInsertMsg := packedMsg.(*msgstream.InsertMsg)
+				nextRowOffsetCursor := rowOffsetCursor + int(packedInsertMsg.GetNumRows())
+				generated = append(generated, pendingInsertPack{
+					rowOffsets: pack.rowOffsets[rowOffsetCursor:nextRowOffsetCursor],
+					insertMsg:  packedInsertMsg,
+				})
+				rowOffsetCursor = nextRowOffsetCursor
+			}
+			pending = append(generated, pending...)
+			continue
+		}
+
+		msg, err := buildInsertMessageForStreamingService(
+			pack.insertMsg.InsertRequest,
+			insertMsg.CollectionID,
+			partitionID,
+			channel,
+			schemaVersion,
+			ez,
+			partialUpdateCAS,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// Entity-size packing does not include the streaming header or CAS
+		// metadata. Validate the fully built message and split the original row
+		// offsets again when that final envelope crosses the transport limit.
+		if partialUpdateCAS == nil || msg.EstimateSize() <= maxMessageSize {
+			messages = append(messages, msg)
+			continue
+		}
+		if len(pack.rowOffsets) == 1 {
+			return nil, merr.WrapErrParameterTooLarge("single partial update row exceeds max message size")
+		}
+
+		middle := len(pack.rowOffsets) / 2
+		split := []pendingInsertPack{
+			{rowOffsets: pack.rowOffsets[:middle]},
+			{rowOffsets: pack.rowOffsets[middle:]},
+		}
+		pending = append(split, pending...)
+	}
+	return messages, nil
+}
+
+func buildInsertMessageForStreamingService(
+	insertRequest *message.InsertRequest,
+	collectionID int64,
+	partitionID int64,
+	channel string,
+	schemaVersion int32,
+	ez *message.CipherConfig,
+	partialUpdateCAS *messagespb.PartialUpdateCAS,
+) (message.MutableMessage, error) {
+	builder := message.NewInsertMessageBuilderV1().
+		WithVChannel(channel).
+		WithHeader(&message.InsertMessageHeader{
+			CollectionId: collectionID,
+			Partitions: []*message.PartitionSegmentAssignment{
+				{
+					PartitionId: partitionID,
+					Rows:        insertRequest.GetNumRows(),
+					BinarySize:  0, // TODO: current not used, message estimate size is used.
+				},
+			},
+			SchemaVersion: &schemaVersion,
+		}).
+		WithBody(insertRequest)
+	if partialUpdateCAS != nil {
+		if err := builder.AddPartialUpdateCAS(partialUpdateCAS); err != nil {
+			return nil, err
+		}
+	}
+	return builder.
+		WithCipher(ez).
+		BuildMutable()
 }

--- a/internal/proxy/task_insert_test.go
+++ b/internal/proxy/task_insert_test.go
@@ -67,7 +67,7 @@ func TestRepackInsertDataForStreamingServicePreservesExplicitZeroSchemaVersion(t
 		},
 	}
 
-	msgs, err := repackInsertDataForStreamingService(context.Background(), []string{"ch"}, insertMsg, result, nil, 0)
+	msgs, err := repackInsertDataForStreamingService(context.Background(), []string{"ch"}, insertMsg, result, nil, 0, nil)
 	assert.NoError(t, err)
 	assert.Len(t, msgs, 1)
 

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -76,8 +76,11 @@ type queryTask struct {
 	shardclientMgr   shardclient.ShardClientMgr
 	lb               shardclient.LBPolicy
 	channelsMvcc     map[string]Timestamp
-	preferredNodes   map[string]int64
-	fastSkip         bool
+	// fixedSnapshotTimestamp pins internal queries whose read timestamp is
+	// also used as a later write-side correctness proof.
+	fixedSnapshotTimestamp uint64
+	preferredNodes         map[string]int64
+	fastSkip               bool
 
 	reQuery              bool
 	allQueryCnt          int64
@@ -94,6 +97,16 @@ func (t *queryTask) getQueryLabel() string {
 		return label
 	}
 	return metrics.QueryLabel
+}
+
+// applyFixedSnapshotTimestamp restores the exact read fence after generic
+// query preprocessing adjusts consistency and collection metadata fences.
+func (t *queryTask) applyFixedSnapshotTimestamp(guaranteeTimestamp uint64) uint64 {
+	if t.fixedSnapshotTimestamp == 0 {
+		return guaranteeTimestamp
+	}
+	t.MvccTimestamp = t.fixedSnapshotTimestamp
+	return t.fixedSnapshotTimestamp
 }
 
 type queryParams struct {
@@ -883,6 +896,7 @@ func (t *queryTask) PreExecute(ctx context.Context) error {
 	if collectionInfo.updateTimestamp > guaranteeTs {
 		guaranteeTs = collectionInfo.updateTimestamp
 	}
+	guaranteeTs = t.applyFixedSnapshotTimestamp(guaranteeTs)
 
 	t.GuaranteeTimestamp = guaranteeTs
 	// Extract physical time for entity-level TTL (issue #47413)

--- a/internal/proxy/task_query_test.go
+++ b/internal/proxy/task_query_test.go
@@ -44,6 +44,18 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
+func TestQueryTaskAppliesFixedSnapshotTimestamp(t *testing.T) {
+	const snapshotTS = uint64(100)
+	task := &queryTask{
+		RetrieveRequest:        &internalpb.RetrieveRequest{MvccTimestamp: 200},
+		fixedSnapshotTimestamp: snapshotTS,
+	}
+
+	guaranteeTS := task.applyFixedSnapshotTimestamp(300)
+	require.Equal(t, snapshotTS, guaranteeTS)
+	require.Equal(t, snapshotTS, task.GetMvccTimestamp())
+}
+
 func TestQueryTask_all(t *testing.T) {
 	var (
 		err error

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -76,6 +77,13 @@ type upsertTask struct {
 
 	deletePKs       *schemapb.IDs
 	insertFieldData []*schemapb.FieldData
+	// partialUpdateCASGroups binds one partial-update attempt to the metadata
+	// prepared before its MVCC query starts.
+	partialUpdateCASGroups map[string]*messagespb.PartialUpdateCAS // vchannel -> metadata
+	// partialUpdateOriginalFields is captured before function generation and
+	// query merge mutate the request payload.
+	partialUpdateOriginalFields []*schemapb.FieldData
+	partialUpdateReadTs         uint64
 
 	storageCost segcore.StorageCost
 }
@@ -112,6 +120,14 @@ func (it *upsertTask) SetTs(ts Timestamp) {
 
 func (it *upsertTask) EndTs() Timestamp {
 	return it.baseMsg.EndTimestamp
+}
+
+// refreshMutationResultCounts synchronizes the response with the rebuilt
+// insert/delete payload for the current CAS attempt.
+func (it *upsertTask) refreshMutationResultCounts() {
+	it.result.DeleteCnt = it.upsertMsg.DeleteMsg.NumRows
+	it.result.InsertCnt = int64(it.upsertMsg.InsertMsg.NumRows)
+	it.result.UpsertCnt = it.result.InsertCnt
 }
 
 func (it *upsertTask) getPChanStats() (map[pChan]pChanStatistics, error) {
@@ -160,18 +176,25 @@ func (it *upsertTask) OnEnqueue() error {
 func retrieveByPKs(ctx context.Context, t *upsertTask, ids *schemapb.IDs, outputFields []string) (*milvuspb.QueryResults, segcore.StorageCost, error) {
 	log := mlog.With(mlog.String("collectionName", t.req.GetCollectionName()))
 	var err error
+	readTS := t.partialUpdateReadTs
+	if readTS == 0 {
+		if t.req.GetPartialUpdate() {
+			return nil, segcore.StorageCost{}, merr.WrapErrServiceInternalMsg("partial update read timestamp is unavailable")
+		}
+		readTS = t.BeginTs()
+	}
 	queryReq := &milvuspb.QueryRequest{
 		Base: &commonpb.MsgBase{
 			MsgType:   commonpb.MsgType_Retrieve,
-			Timestamp: t.BeginTs(),
+			Timestamp: readTS,
 		},
 		DbName:                t.req.GetDbName(),
 		CollectionName:        t.req.GetCollectionName(),
-		ConsistencyLevel:      commonpb.ConsistencyLevel_Strong,
+		ConsistencyLevel:      commonpb.ConsistencyLevel_Customized,
 		NotReturnAllMeta:      false,
 		OutputFields:          []string{"*"},
 		UseDefaultConsistency: false,
-		GuaranteeTimestamp:    t.BeginTs(),
+		GuaranteeTimestamp:    readTS,
 		Namespace:             t.req.Namespace,
 	}
 	pkField, err := typeutil.GetPrimaryFieldSchema(t.schema.CollectionSchema)
@@ -214,16 +237,19 @@ func retrieveByPKs(ctx context.Context, t *upsertTask, ids *schemapb.IDs, output
 			),
 			ReqID:            paramtable.GetNodeID(),
 			PartitionIDs:     partitionIDs,
-			ConsistencyLevel: commonpb.ConsistencyLevel_Strong,
+			ConsistencyLevel: commonpb.ConsistencyLevel_Customized,
 			QueryLabel:       metrics.UpsertQueryLabel,
 		},
-		request:        queryReq,
-		plan:           plan,
-		mixCoord:       t.node.(*Proxy).mixCoord,
-		lb:             t.node.(*Proxy).lbPolicy,
-		shardclientMgr: t.node.(*Proxy).shardMgr,
-		chMgr:          t.node.(*Proxy).chMgr,
+		request:                queryReq,
+		plan:                   plan,
+		mixCoord:               t.node.(*Proxy).mixCoord,
+		lb:                     t.node.(*Proxy).lbPolicy,
+		shardclientMgr:         t.node.(*Proxy).shardMgr,
+		chMgr:                  t.node.(*Proxy).chMgr,
+		fixedSnapshotTimestamp: readTS,
 	}
+	// Pin the query snapshot to the read timestamp carried by the CAS write.
+	qt.MvccTimestamp = readTS
 
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-Upsert-retrieveByPKs")
 	defer func() {
@@ -272,7 +298,8 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		log.Info(ctx, "retrieve by primary key failed", mlog.Err(err))
 		return err
 	}
-	it.storageCost = storageCost
+	it.storageCost.ScannedRemoteBytes += storageCost.ScannedRemoteBytes
+	it.storageCost.ScannedTotalBytes += storageCost.ScannedTotalBytes
 	if len(resp.GetFieldsData()) == 0 {
 		return merr.WrapErrParameterInvalidMsg("retrieve by primary key failed, no data found")
 	}
@@ -398,6 +425,9 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		} else {
 			insertIdxInUpsert = append(insertIdxInUpsert, upsertIdx)
 		}
+	}
+	if it.req.GetPartialUpdate() && primaryFieldSchema.GetAutoID() && len(insertIdxInUpsert) > 0 {
+		return merr.WrapErrParameterInvalidMsg("partial update on an AutoID collection requires every primary key to exist")
 	}
 
 	// 2. merge field data on update semantic
@@ -1408,9 +1438,15 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 
 	allFields := typeutil.GetAllFieldSchemas(it.schema.CollectionSchema)
 
-	// use the passed pk as new pk when autoID == false
-	// automatic generate pk as new pk wehen autoID == true
-	it.result.IDs, it.oldIDs, err = checkUpsertPrimaryFieldData(ctx, allFields, it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
+	// Partial update identifies an existing AutoID row by its current PK. Keep
+	// that PK so delete, insert, and CAS remain on the same vchannel.
+	it.result.IDs, it.oldIDs, err = checkUpsertPrimaryFieldData(
+		ctx,
+		allFields,
+		it.schema.CollectionSchema,
+		it.upsertMsg.InsertMsg,
+		it.req.GetPartialUpdate(),
+	)
 	if err != nil {
 		log.Warn(ctx, "check primary field data and hash primary key failed when upsert",
 			mlog.Err(err))
@@ -1665,11 +1701,19 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 		return merr.WrapErrParameterInvalid("invalid num_rows", fmt.Sprint(it.req.NumRows), "num_rows should be greater than 0")
 	}
 
+	if it.req.GetPartialUpdate() {
+		it.partialUpdateOriginalFields = cloneFieldDataList(it.req.GetFieldsData())
+	}
+
 	if err := genFunctionFields(ctx, it.upsertMsg.InsertMsg, it.schema, it.req.GetPartialUpdate()); err != nil {
 		return err
 	}
 
 	if it.req.GetPartialUpdate() {
+		if err = it.preparePartialUpdateCASGroups(ctx); err != nil {
+			log.Warn(ctx, "Fail to prepare partial update CAS metadata", mlog.Err(err))
+			return err
+		}
 		err = it.queryPreExecute(ctx)
 		if err != nil {
 			log.Warn(ctx, "Fail to queryPreExecute", mlog.Err(err))
@@ -1693,14 +1737,12 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 
-	it.result.DeleteCnt = it.upsertMsg.DeleteMsg.NumRows
-	it.result.InsertCnt = int64(it.upsertMsg.InsertMsg.NumRows)
+	it.refreshMutationResultCounts()
 	if it.result.DeleteCnt != it.result.InsertCnt {
 		log.Info(ctx, "DeleteCnt and InsertCnt are not the same when upsert",
 			mlog.Int64("DeleteCnt", it.result.DeleteCnt),
 			mlog.Int64("InsertCnt", it.result.InsertCnt))
 	}
-	it.result.UpsertCnt = it.result.InsertCnt
 	log.Debug(ctx, "Proxy Upsert PreExecute done")
 	return nil
 }

--- a/internal/proxy/task_upsert_streaming.go
+++ b/internal/proxy/task_upsert_streaming.go
@@ -3,52 +3,197 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/otel"
+	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+const (
+	partialUpdateCASMaxRetryAttempts = 5
+	partialUpdateCASRetryBackoff     = 10 * time.Millisecond
 )
 
 func (ut *upsertTask) Execute(ctx context.Context) error {
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-Upsert-Execute")
 	defer sp.End()
-	log := mlog.With(mlog.FieldCollectionName(ut.req.CollectionName))
 
 	var ez *message.CipherConfig
 	if hookutil.IsClusterEncryptionEnabled() {
 		ez = hookutil.GetEzByCollProperties(ut.schema.GetProperties(), ut.collectionID).AsMessageConfig()
 	}
 
+	if ut.req.GetPartialUpdate() {
+		return ut.executePartialUpdateWithCASRetry(ctx, ez)
+	}
+	return ut.appendUpsertAttempt(ctx, ez)
+}
+
+func (ut *upsertTask) executePartialUpdateWithCASRetry(ctx context.Context, ez *message.CipherConfig) error {
+	// A request-level retry can reapply relative operations on vchannels that
+	// already committed before another vchannel rejected the CAS.
+	if !ut.canRetryPartialUpdateCASConflict() {
+		return projectPartialUpdateCASError(ut.appendUpsertAttempt(ctx, ez), false)
+	}
+
+	if ut.partialUpdateOriginalFields == nil {
+		return merr.WrapErrServiceInternalMsg("partial update original fields snapshot is unavailable")
+	}
+	attempt := 0
+	err := retry.Do(ctx, func() error {
+		if attempt > 0 {
+			if err := ut.preparePartialUpdateRetryAttempt(ctx); err != nil {
+				return err
+			}
+		}
+		attempt++
+		return ut.appendUpsertAttempt(ctx, ez)
+	},
+		retry.Attempts(partialUpdateCASMaxRetryAttempts),
+		retry.Sleep(partialUpdateCASRetryBackoff),
+		retry.MaxSleepTime(4*partialUpdateCASRetryBackoff),
+		retry.RetryErr(func(err error) bool {
+			return status.AsStreamingError(err).IsPartialUpdateRetryableCAS()
+		}),
+	)
+	return projectPartialUpdateCASError(err, true)
+}
+
+func projectPartialUpdateCASError(err error, allowConflictRetry bool) error {
+	if err == nil || !status.AsStreamingError(err).IsPartialUpdateRetryableCAS() {
+		return err
+	}
+	if !allowConflictRetry {
+		return merr.WrapErrCollectionPartialUpdateConflictErr(
+			err,
+			"relative partial update conflicted with a concurrent write; automatic retry is unsafe",
+		)
+	}
+	return merr.WrapErrServiceUnavailableErr(err, "partial update conflicted with a concurrent write")
+}
+
+// preparePartialUpdateRetryAttempt restores the original payload and rebuilds
+// term, read timestamp, query, and DML state for one retry.
+func (ut *upsertTask) preparePartialUpdateRetryAttempt(ctx context.Context) error {
+	fields := cloneFieldDataList(ut.partialUpdateOriginalFields)
+	ut.req.FieldsData = fields
+	ut.upsertMsg.InsertMsg.FieldsData = fields
+	if err := genFunctionFields(ctx, ut.upsertMsg.InsertMsg, ut.schema, true); err != nil {
+		return err
+	}
+	if err := ut.preparePartialUpdateCASGroups(ctx); err != nil {
+		return err
+	}
+	if err := ut.queryPreExecute(ctx); err != nil {
+		return err
+	}
+	ut.upsertMsg.InsertMsg.FieldsData = ut.insertFieldData
+	ut.upsertMsg.DeleteMsg.PrimaryKeys = ut.deletePKs
+	ut.upsertMsg.DeleteMsg.NumRows = int64(typeutil.GetSizeOfIDs(ut.deletePKs))
+	if err := ut.insertPreExecute(ctx); err != nil {
+		return err
+	}
+	if err := ut.deletePreExecute(ctx); err != nil {
+		return err
+	}
+	ut.refreshMutationResultCounts()
+	return nil
+}
+
+func cloneFieldDataList(fields []*schemapb.FieldData) []*schemapb.FieldData {
+	if fields == nil {
+		return nil
+	}
+	cloned := make([]*schemapb.FieldData, len(fields))
+	for i, field := range fields {
+		if field == nil {
+			continue
+		}
+		cloned[i] = proto.Clone(field).(*schemapb.FieldData)
+	}
+	return cloned
+}
+
+func (ut *upsertTask) refreshPartialUpdateReadTs(ctx context.Context) error {
+	proxy, ok := ut.node.(*Proxy)
+	if !ok || proxy == nil || proxy.tsoAllocator == nil {
+		return merr.WrapErrServiceInternal("partial update read timestamp allocator is unavailable")
+	}
+	ts, err := proxy.tsoAllocator.AllocOne(ctx)
+	if err != nil {
+		return err
+	}
+	ut.partialUpdateReadTs = ts
+	return nil
+}
+
+func (ut *upsertTask) appendUpsertAttempt(ctx context.Context, ez *message.CipherConfig) error {
+	logger := mlog.With(mlog.FieldCollectionName(ut.req.CollectionName))
+
 	insertMsgs, err := ut.packInsertMessage(ctx, ez)
 	if err != nil {
-		log.Warn(ctx, "pack insert message failed", mlog.Err(err))
+		logger.Warn(ctx, "pack insert message failed", mlog.Err(err))
 		return err
 	}
 	deleteMsgs, err := ut.packDeleteMessage(ctx, ez)
 	if err != nil {
-		log.Warn(ctx, "pack delete message failed", mlog.Err(err))
+		logger.Warn(ctx, "pack delete message failed", mlog.Err(err))
 		return err
 	}
 
 	messages := append(insertMsgs, deleteMsgs...)
+	if ut.req.GetPartialUpdate() {
+		if err := ut.attachPartialUpdateCAS(messages); err != nil {
+			logger.Warn(ctx, "attach partial update CAS metadata failed", mlog.Err(err))
+			return err
+		}
+	}
 	resp := streaming.WAL().AppendMessages(ctx, messages...)
-	if err := resp.UnwrapFirstError(); err != nil {
-		log.Warn(ctx, "append messages to wal failed", mlog.Err(err))
-		if status.AsStreamingError(err).IsSchemaVersionMismatch() {
+	appendErr := resp.UnwrapFirstError()
+	if ut.req.GetPartialUpdate() {
+		appendErr = unwrapPartialUpdateAppendError(resp)
+	}
+	if appendErr != nil {
+		logger.Warn(ctx, "append messages to wal failed", mlog.Err(appendErr))
+		if status.AsStreamingError(appendErr).IsSchemaVersionMismatch() {
 			return merr.ErrCollectionSchemaMismatch
 		}
-		return err
+		return appendErr
 	}
 	// Update result.Timestamp for session consistency.
 	ut.result.Timestamp = resp.MaxTimeTick()
 	return nil
+}
+
+// unwrapPartialUpdateAppendError returns a CAS retry signal only when no
+// vchannel reported a failure with an unknown or non-CAS outcome.
+func unwrapPartialUpdateAppendError(resp streaming.AppendResponses) error {
+	var casErr error
+	for _, response := range resp.Responses {
+		if response.Error == nil {
+			continue
+		}
+		if !status.AsStreamingError(response.Error).IsPartialUpdateRetryableCAS() {
+			return response.Error
+		}
+		if casErr == nil {
+			casErr = response.Error
+		}
+	}
+	return casErr
 }
 
 func (ut *upsertTask) packInsertMessage(ctx context.Context, ez *message.CipherConfig) ([]message.MutableMessage, error) {
@@ -86,9 +231,9 @@ func (ut *upsertTask) packInsertMessage(ctx context.Context, ez *message.CipherC
 	// start to repack insert data
 	var msgs []message.MutableMessage
 	if ut.partitionKeys == nil {
-		msgs, err = repackInsertDataForStreamingService(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ez, ut.schemaVersion)
+		msgs, err = repackInsertDataForStreamingService(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ez, ut.schemaVersion, ut.partialUpdateCASGroups)
 	} else {
-		msgs, err = repackInsertDataWithPartitionKeyForStreamingService(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ut.partitionKeys, ez, ut.schema.CollectionSchema, ut.schemaVersion)
+		msgs, err = repackInsertDataWithPartitionKeyForStreamingService(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ut.partitionKeys, ez, ut.schema.CollectionSchema, ut.schemaVersion, ut.partialUpdateCASGroups)
 	}
 	if err != nil {
 		log.Warn(ctx, "assign segmentID and repack insert data failed", mlog.Err(err))
@@ -156,4 +301,146 @@ func (ut *upsertTask) packDeleteMessage(ctx context.Context, ez *message.CipherC
 		mlog.Duration("prepare duration", tr.ElapseSpan()))
 
 	return msgs, nil
+}
+
+func (ut *upsertTask) attachPartialUpdateCAS(messages []message.MutableMessage) error {
+	groups := ut.partialUpdateCASGroups
+	if len(groups) == 0 {
+		return merr.WrapErrServiceInternalMsg("partial update CAS metadata snapshot is empty")
+	}
+
+	attached := make(map[string]struct{}, len(groups))
+	for _, msg := range messages {
+		if msg.MessageType() != message.MessageTypeInsert {
+			continue
+		}
+		vchannel := msg.VChannel()
+		_, ok := groups[vchannel]
+		if !ok {
+			return merr.WrapErrServiceInternalMsg("partial update insert has no CAS metadata for vchannel %s", vchannel)
+		}
+		if !message.HasPartialUpdateCAS(msg) {
+			return merr.WrapErrServiceInternalMsg("partial update insert is missing CAS metadata for vchannel %s", vchannel)
+		}
+		if msg.EstimateSize() > Params.PulsarCfg.MaxMessageSize.GetAsInt() {
+			return merr.WrapErrParameterTooLarge("partial update message exceeds max message size")
+		}
+		attached[vchannel] = struct{}{}
+	}
+	for vchannel := range groups {
+		if _, ok := attached[vchannel]; !ok {
+			return merr.WrapErrServiceInternalMsg("partial update CAS has no insert message for vchannel %s", vchannel)
+		}
+	}
+	return nil
+}
+
+// preparePartialUpdateCASGroups resolves all touched PChannel terms before it
+// allocates the attempt read timestamp used by both query and CAS metadata.
+func (ut *upsertTask) preparePartialUpdateCASGroups(ctx context.Context) error {
+	ut.partialUpdateCASGroups = nil
+	ut.partialUpdateReadTs = 0
+	groups, err := ut.buildPartialUpdateCASGroups()
+	if err != nil {
+		return err
+	}
+
+	terms := make(map[string]int64, len(groups))
+	for vchannel, meta := range groups {
+		pchannel := funcutil.ToPhysicalChannel(vchannel)
+		term, ok := terms[pchannel]
+		if !ok {
+			info, err := streaming.ResolvePChannelInfo(ctx, vchannel)
+			if err != nil {
+				return err
+			}
+			if info.Term <= 0 {
+				return merr.WrapErrServiceInternalMsg("partial update CAS resolved invalid term %d for vchannel %s", info.Term, vchannel)
+			}
+			term = info.Term
+			terms[pchannel] = term
+		}
+		meta.ObservedPchannelTerm = term
+	}
+	if err := ut.refreshPartialUpdateReadTs(ctx); err != nil {
+		return err
+	}
+	for _, meta := range groups {
+		meta.ReadTs = ut.partialUpdateReadTs
+	}
+	ut.partialUpdateCASGroups = groups
+	return nil
+}
+
+func (ut *upsertTask) buildPartialUpdateCASGroups() (map[string]*messagespb.PartialUpdateCAS, error) {
+	primaryFieldSchema, err := typeutil.GetPrimaryFieldSchema(ut.schema.CollectionSchema)
+	if err != nil {
+		return nil, err
+	}
+	primaryFieldData, err := typeutil.GetPrimaryFieldData(ut.req.GetFieldsData(), primaryFieldSchema)
+	if err != nil {
+		return nil, merr.WrapErrParameterInvalidMsg(err.Error())
+	}
+	originalIDs, err := parsePrimaryFieldData2IDs(primaryFieldData)
+	if err != nil {
+		return nil, err
+	}
+
+	size := typeutil.GetSizeOfIDs(originalIDs)
+	if size == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("partial update primary keys are empty")
+	}
+	if ut.chMgr == nil {
+		return nil, merr.WrapErrServiceInternalMsg("partial update channel manager is unavailable")
+	}
+	vchannels, err := ut.chMgr.getVChannels(ut.collectionID)
+	if err != nil {
+		return nil, err
+	}
+	channelIndexes, err := ut.partialUpdateCASChannelIndexes(originalIDs, vchannels)
+	if err != nil {
+		return nil, err
+	}
+	groups := make(map[string]*messagespb.PartialUpdateCAS, len(vchannels))
+	for _, channelIndex := range channelIndexes {
+		vchannel := vchannels[channelIndex]
+		group := groups[vchannel]
+		if group == nil {
+			group = &messagespb.PartialUpdateCAS{
+				PrimaryKeyFieldId: primaryFieldSchema.GetFieldID(),
+				CollectionId:      ut.collectionID,
+			}
+			groups[vchannel] = group
+		}
+	}
+	return groups, nil
+}
+
+// partialUpdateCASChannelIndexes mirrors normal upsert routing so CAS metadata
+// and the corresponding DML transaction target the same vchannel.
+func (ut *upsertTask) partialUpdateCASChannelIndexes(ids *schemapb.IDs, vchannels []string) ([]uint32, error) {
+	channelID, ok, err := namespaceShardingChannelID(ut.schema.CollectionSchema, ut.req.Namespace, vchannels)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return typeutil.HashPK2Channels(ids, vchannels)
+	}
+	size := typeutil.GetSizeOfIDs(ids)
+	channelIndexes := make([]uint32, size)
+	for offset := range channelIndexes {
+		channelIndexes[offset] = channelID
+	}
+	return channelIndexes, nil
+}
+
+// canRetryPartialUpdateCASConflict reports whether rebuilding the whole request
+// after a deterministic CAS conflict preserves the requested operation semantics.
+func (ut *upsertTask) canRetryPartialUpdateCASConflict() bool {
+	for _, op := range ut.req.GetFieldOps() {
+		if op.GetOp() != schemapb.FieldPartialUpdateOp_REPLACE {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/proxy/task_upsert_streaming.go
+++ b/internal/proxy/task_upsert_streaming.go
@@ -322,8 +322,15 @@ func (ut *upsertTask) attachPartialUpdateCAS(messages []message.MutableMessage) 
 		if !message.HasPartialUpdateCAS(msg) {
 			return merr.WrapErrServiceInternalMsg("partial update insert is missing CAS metadata for vchannel %s", vchannel)
 		}
-		if msg.EstimateSize() > Params.PulsarCfg.MaxMessageSize.GetAsInt() {
-			return merr.WrapErrParameterTooLarge("partial update message exceeds max message size")
+		maxMessageSize := Params.PulsarCfg.MaxMessageSize.GetAsInt()
+		messageSize := msg.EstimateSize()
+		if messageSize > maxMessageSize {
+			return merr.WrapErrServiceInternalMsg(
+				"partial update insert packer emitted oversized message for vchannel %s: size=%d, max=%d",
+				vchannel,
+				messageSize,
+				maxMessageSize,
+			)
 		}
 		attached[vchannel] = struct{}{}
 	}

--- a/internal/proxy/task_upsert_streaming.go
+++ b/internal/proxy/task_upsert_streaming.go
@@ -343,7 +343,7 @@ func (ut *upsertTask) attachPartialUpdateCAS(messages []message.MutableMessage) 
 }
 
 // preparePartialUpdateCASGroups resolves all touched PChannel terms before it
-// allocates the attempt read timestamp used by both query and CAS metadata.
+// allocates the attempt read timestamp used by both query and CAS proof.
 func (ut *upsertTask) preparePartialUpdateCASGroups(ctx context.Context) error {
 	ut.partialUpdateCASGroups = nil
 	ut.partialUpdateReadTs = 0
@@ -413,17 +413,14 @@ func (ut *upsertTask) buildPartialUpdateCASGroups() (map[string]*messagespb.Part
 		vchannel := vchannels[channelIndex]
 		group := groups[vchannel]
 		if group == nil {
-			group = &messagespb.PartialUpdateCAS{
-				PrimaryKeyFieldId: primaryFieldSchema.GetFieldID(),
-				CollectionId:      ut.collectionID,
-			}
+			group = &messagespb.PartialUpdateCAS{}
 			groups[vchannel] = group
 		}
 	}
 	return groups, nil
 }
 
-// partialUpdateCASChannelIndexes mirrors normal upsert routing so CAS metadata
+// partialUpdateCASChannelIndexes mirrors normal upsert routing so CAS proof
 // and the corresponding DML transaction target the same vchannel.
 func (ut *upsertTask) partialUpdateCASChannelIndexes(ids *schemapb.IDs, vchannels []string) ([]uint32, error) {
 	channelID, ok, err := namespaceShardingChannelID(ut.schema.CollectionSchema, ut.req.Namespace, vchannels)

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -702,7 +702,6 @@ func requireAppendedPartialUpdateCASGroups(
 	expected map[string]partialUpdateCASExpected,
 	readTS uint64,
 	term int64,
-	collectionID int64,
 ) {
 	t.Helper()
 
@@ -718,8 +717,6 @@ func requireAppendedPartialUpdateCASGroups(
 		require.Equal(t, streamingmessage.MessageTypeInsert, msg.MessageType())
 		require.Equal(t, readTS, meta.GetReadTs())
 		require.EqualValues(t, term, meta.GetObservedPchannelTerm())
-		require.Equal(t, collectionID, meta.GetCollectionId())
-		require.EqualValues(t, 100, meta.GetPrimaryKeyFieldId())
 		seen[msg.VChannel()] = struct{}{}
 	}
 	require.Len(t, seen, len(expected))
@@ -1078,8 +1075,6 @@ func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
 			vchannel: {
 				ReadTs:               100,
 				ObservedPchannelTerm: 1,
-				CollectionId:         task.collectionID,
-				PrimaryKeyFieldId:    100,
 			},
 		}
 	}
@@ -1150,8 +1145,6 @@ func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing
 		vchannel: {
 			ReadTs:               100,
 			ObservedPchannelTerm: 1,
-			CollectionId:         task.collectionID,
-			PrimaryKeyFieldId:    100,
 		},
 	}
 
@@ -1208,8 +1201,6 @@ func TestRepackInsertDataForStreamingServiceRejectsOversizedSingleRow(t *testing
 		vchannel: {
 			ReadTs:               100,
 			ObservedPchannelTerm: 1,
-			CollectionId:         task.collectionID,
-			PrimaryKeyFieldId:    100,
 		},
 	}
 
@@ -1291,8 +1282,6 @@ func TestRepackInsertDataByPartitionForStreamingServicePreservesEntityPackingOrd
 	meta := &messagespb.PartialUpdateCAS{
 		ReadTs:               100,
 		ObservedPchannelTerm: 1,
-		CollectionId:         task.collectionID,
-		PrimaryKeyFieldId:    100,
 	}
 
 	baseline, err := repackInsertDataByPartitionForStreamingService(
@@ -1366,8 +1355,6 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testi
 			vchannel: {
 				ReadTs:               100,
 				ObservedPchannelTerm: 1,
-				CollectionId:         task.collectionID,
-				PrimaryKeyFieldId:    100,
 			},
 		}
 	}
@@ -1451,8 +1438,6 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceSplitsOversizedCASMe
 		vchannel: {
 			ReadTs:               100,
 			ObservedPchannelTerm: 1,
-			CollectionId:         task.collectionID,
-			PrimaryKeyFieldId:    100,
 		},
 	}
 
@@ -1591,8 +1576,6 @@ func TestAttachPartialUpdateCASRejectsMissingMarker(t *testing.T) {
 		insertMsgs[0].VChannel(): {
 			ReadTs:               100,
 			ObservedPchannelTerm: 1,
-			CollectionId:         task.collectionID,
-			PrimaryKeyFieldId:    100,
 		},
 	}
 	err := task.attachPartialUpdateCAS(insertMsgs[:1])
@@ -1657,7 +1640,7 @@ func TestPartialUpdateAppendAcceptsBuilderCASMetadata(t *testing.T) {
 	require.Equal(t, len(expected), fakeWAL.resolveCalls)
 	require.Equal(t, 1, fakeWAL.appendCalls)
 	require.Len(t, fakeWAL.appended, len(insertMsgs)+len(deleteMsgs))
-	requireAppendedPartialUpdateCASGroups(t, fakeWAL.appended, expected, task.partialUpdateReadTs, 9, task.collectionID)
+	requireAppendedPartialUpdateCASGroups(t, fakeWAL.appended, expected, task.partialUpdateReadTs, 9)
 }
 
 func TestPartialUpdateAppendPacksMessagesAndAttachesCASMetadata(t *testing.T) {
@@ -1684,7 +1667,7 @@ func TestPartialUpdateAppendPacksMessagesAndAttachesCASMetadata(t *testing.T) {
 	require.Equal(t, 1, fakeWAL.resolveCalls)
 	require.Equal(t, 1, fakeWAL.appendCalls)
 	require.Len(t, fakeWAL.appended, 2)
-	requireAppendedPartialUpdateCASGroups(t, fakeWAL.appended, expected, task.partialUpdateReadTs, 9, task.collectionID)
+	requireAppendedPartialUpdateCASGroups(t, fakeWAL.appended, expected, task.partialUpdateReadTs, 9)
 }
 
 func TestPartialUpdateRetriesAfterCASConflict(t *testing.T) {
@@ -2099,7 +2082,7 @@ func TestPartialUpdateAppendAcceptsBuilderCASMetadataForVarCharPK(t *testing.T) 
 	require.Equal(t, len(expected), fakeWAL.resolveCalls)
 	require.Equal(t, 1, fakeWAL.appendCalls)
 	require.Len(t, fakeWAL.appended, len(insertMsgs)+len(deleteMsgs))
-	requireAppendedPartialUpdateCASGroups(t, fakeWAL.appended, expected, task.partialUpdateReadTs, 9, task.collectionID)
+	requireAppendedPartialUpdateCASGroups(t, fakeWAL.appended, expected, task.partialUpdateReadTs, 9)
 }
 
 func TestPartialUpdateAutoIDBuildsCASGroupsFromOriginalPKs(t *testing.T) {
@@ -2220,12 +2203,10 @@ func TestAttachPartialUpdateCASValidatesPreparedGroups(t *testing.T) {
 }
 
 func TestAttachPartialUpdateCASRejectsVChannelMismatch(t *testing.T) {
-	newMeta := func(collectionID int64) *messagespb.PartialUpdateCAS {
+	newMeta := func() *messagespb.PartialUpdateCAS {
 		return &messagespb.PartialUpdateCAS{
 			ReadTs:               100,
 			ObservedPchannelTerm: 1,
-			CollectionId:         collectionID,
-			PrimaryKeyFieldId:    100,
 		}
 	}
 
@@ -2234,10 +2215,10 @@ func TestAttachPartialUpdateCASRejectsVChannelMismatch(t *testing.T) {
 		knownChannel := partialUpdateCASTestVChannels[0]
 		unknownChannel := partialUpdateCASTestVChannels[1]
 		task.partialUpdateCASGroups = map[string]*messagespb.PartialUpdateCAS{
-			knownChannel: newMeta(task.collectionID),
+			knownChannel: newMeta(),
 		}
 		messageGroups := map[string]*messagespb.PartialUpdateCAS{
-			unknownChannel: newMeta(task.collectionID),
+			unknownChannel: newMeta(),
 		}
 		insertMsgs, _ := buildPartialUpdateCASTestMessages(
 			t,
@@ -2258,8 +2239,8 @@ func TestAttachPartialUpdateCASRejectsVChannelMismatch(t *testing.T) {
 		presentChannel := partialUpdateCASTestVChannels[0]
 		missingChannel := partialUpdateCASTestVChannels[1]
 		task.partialUpdateCASGroups = map[string]*messagespb.PartialUpdateCAS{
-			presentChannel: newMeta(task.collectionID),
-			missingChannel: newMeta(task.collectionID),
+			presentChannel: newMeta(),
+			missingChannel: newMeta(),
 		}
 		insertMsgs, _ := buildPartialUpdateCASTestMessages(
 			t,

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -18,12 +18,15 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -31,16 +34,22 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	grpcmixcoordclient "github.com/milvus-io/milvus/internal/distributed/mixcoord/client"
+	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
 	"github.com/milvus-io/milvus/internal/util/segcore"
+	streamingstatus "github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
+	streamingmessage "github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	streamingtypes "github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/testutils"
@@ -525,6 +534,9 @@ func createTestUpdateTask() *upsertTask {
 		baseTask:  baseTask{},
 		Condition: NewTaskCondition(context.Background()),
 		req: &milvuspb.UpsertRequest{
+			Base: commonpbutil.NewMsgBase(
+				commonpbutil.WithMsgType(commonpb.MsgType_Upsert),
+			),
 			DbName:         "test_db",
 			CollectionName: "test_collection",
 			PartitionName:  "_default",
@@ -610,6 +622,1354 @@ func createTestSchema() *schemaInfo {
 	return mustNewSchemaInfo(schema)
 }
 
+type partialUpdateCASTestWAL struct {
+	streaming.WALAccesser
+	term            int64
+	resolveErr      error
+	resolveHook     func(string)
+	resolveCalls    int
+	appendCalls     int
+	appendHook      func(context.Context, ...streamingmessage.MutableMessage) streaming.AppendResponses
+	appended        []streamingmessage.MutableMessage
+	appendedBatches [][]streamingmessage.MutableMessage
+}
+
+func newPartialUpdateCASTestWAL(t *testing.T, term int64) *partialUpdateCASTestWAL {
+	t.Helper()
+
+	w := &partialUpdateCASTestWAL{term: term}
+	appendMock := mockey.Mock((*partialUpdateCASTestWAL).AppendMessages).To(
+		func(w *partialUpdateCASTestWAL, ctx context.Context, msgs ...streamingmessage.MutableMessage) streaming.AppendResponses {
+			w.appendCalls++
+			w.appended = append([]streamingmessage.MutableMessage(nil), msgs...)
+			w.appendedBatches = append(w.appendedBatches, append([]streamingmessage.MutableMessage(nil), msgs...))
+			if w.appendHook != nil {
+				return w.appendHook(ctx, msgs...)
+			}
+			responses := make([]streaming.AppendResponse, len(msgs))
+			for idx := range responses {
+				responses[idx].AppendResult = &streamingtypes.AppendResult{TimeTick: uint64(idx + 1)}
+			}
+			return streaming.AppendResponses{Responses: responses}
+		},
+	).Build()
+	t.Cleanup(func() { appendMock.UnPatch() })
+	return w
+}
+
+func (w *partialUpdateCASTestWAL) ResolvePChannelInfo(_ context.Context, vchannel string) (streamingtypes.PChannelInfo, error) {
+	w.resolveCalls++
+	if w.resolveHook != nil {
+		w.resolveHook(vchannel)
+	}
+	if w.resolveErr != nil {
+		return streamingtypes.PChannelInfo{}, w.resolveErr
+	}
+	term := w.term
+	if term == 0 {
+		term = 9
+	}
+	return streamingtypes.PChannelInfo{
+		Name:       funcutil.ToPhysicalChannel(vchannel),
+		Term:       term,
+		AccessMode: streamingtypes.AccessModeRW,
+	}, nil
+}
+
+type partialUpdateCASExpected struct{}
+
+func expectedPartialUpdateCASGroups(t *testing.T, ids *schemapb.IDs, vchannels []string) map[string]partialUpdateCASExpected {
+	t.Helper()
+
+	channelIndexes, err := typeutil.HashPK2Channels(ids, vchannels)
+	require.NoError(t, err)
+	require.Equal(t, typeutil.GetSizeOfIDs(ids), len(channelIndexes))
+
+	groups := make(map[string]partialUpdateCASExpected, len(vchannels))
+	for _, channelIndex := range channelIndexes {
+		require.Less(t, int(channelIndex), len(vchannels))
+		vchannel := vchannels[channelIndex]
+		groups[vchannel] = partialUpdateCASExpected{}
+	}
+	return groups
+}
+
+func requireAppendedPartialUpdateCASGroups(
+	t *testing.T,
+	msgs []streamingmessage.MutableMessage,
+	expected map[string]partialUpdateCASExpected,
+	readTS uint64,
+	term int64,
+	collectionID int64,
+) {
+	t.Helper()
+
+	seen := make(map[string]struct{}, len(expected))
+	for _, msg := range msgs {
+		meta, err := streamingmessage.ExtractPartialUpdateCAS(msg)
+		require.NoError(t, err)
+		if meta == nil {
+			continue
+		}
+		_, ok := expected[msg.VChannel()]
+		require.True(t, ok, "unexpected partial update CAS for vchannel %s", msg.VChannel())
+		require.Equal(t, streamingmessage.MessageTypeInsert, msg.MessageType())
+		require.Equal(t, readTS, meta.GetReadTs())
+		require.EqualValues(t, term, meta.GetObservedPchannelTerm())
+		require.Equal(t, collectionID, meta.GetCollectionId())
+		require.EqualValues(t, 100, meta.GetPrimaryKeyFieldId())
+		seen[msg.VChannel()] = struct{}{}
+	}
+	require.Len(t, seen, len(expected))
+}
+
+func requireFirstPartialUpdateCAS(t *testing.T, msgs []streamingmessage.MutableMessage) *messagespb.PartialUpdateCAS {
+	t.Helper()
+
+	for _, msg := range msgs {
+		meta, err := streamingmessage.ExtractPartialUpdateCAS(msg)
+		require.NoError(t, err)
+		if meta != nil {
+			return meta
+		}
+	}
+	require.Fail(t, "partial update CAS metadata not found")
+	return nil
+}
+
+func partialUpdateCASIDs(data []int64) *schemapb.IDs {
+	return &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: data},
+		},
+	}
+}
+
+func partialUpdateCASPKFieldData(data []int64) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		FieldName: "id",
+		FieldId:   100,
+		Type:      schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: data},
+				},
+			},
+		},
+	}
+}
+
+func partialUpdateCASStringIDs(data []string) *schemapb.IDs {
+	return &schemapb.IDs{
+		IdField: &schemapb.IDs_StrId{
+			StrId: &schemapb.StringArray{Data: data},
+		},
+	}
+}
+
+func partialUpdateCASStringPKFieldData(data []string) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		FieldName: "id",
+		FieldId:   100,
+		Type:      schemapb.DataType_VarChar,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: data},
+				},
+			},
+		},
+	}
+}
+
+var partialUpdateCASTestVChannels = []string{
+	"by-dev-rootcoord-dml_0_1001v0",
+	"by-dev-rootcoord-dml_1_1001v1",
+}
+
+func setPartialUpdateCASTestChannels(task *upsertTask, vchannels []string) {
+	task.chMgr = newChannelsMgrImpl(func(collectionID UniqueID) (channelInfos, error) {
+		vchans := make([]vChan, 0, len(vchannels))
+		pchans := make([]pChan, 0, len(vchannels))
+		for _, vchannel := range vchannels {
+			vchans = append(vchans, vchannel)
+			pchans = append(pchans, funcutil.ToPhysicalChannel(vchannel))
+		}
+		return newChannels(vchans, pchans)
+	}, nil)
+	proxy := task.node.(*Proxy)
+	if proxy.tsoAllocator == nil {
+		proxy.tsoAllocator = &timestampAllocator{
+			tso:    newMockTimestampAllocatorInterface(),
+			peerID: paramtable.GetNodeID(),
+		}
+	}
+}
+
+func preparePartialUpdateCASTestGroups(t *testing.T, task *upsertTask) {
+	t.Helper()
+	require.NoError(t, task.preparePartialUpdateCASGroups(context.Background()))
+}
+
+func buildPartialUpdateCASTestMessages(
+	t *testing.T,
+	collectionID int64,
+	vchannels []string,
+	insertPKs []int64,
+	deletePKs []int64,
+	casGroups map[string]*messagespb.PartialUpdateCAS,
+) ([]streamingmessage.MutableMessage, []streamingmessage.MutableMessage) {
+	insertGroups := groupPartialUpdateCASIntPKs(t, insertPKs, vchannels)
+	insertMsgs := make([]streamingmessage.MutableMessage, 0, len(insertGroups))
+	for vchannel, pks := range insertGroups {
+		builder := streamingmessage.NewInsertMessageBuilderV1().
+			WithVChannel(vchannel).
+			WithHeader(&streamingmessage.InsertMessageHeader{
+				CollectionId: collectionID,
+				Partitions: []*streamingmessage.PartitionSegmentAssignment{{
+					PartitionId: 100,
+					Rows:        uint64(len(pks)),
+				}},
+			}).
+			WithBody(&msgpb.InsertRequest{
+				CollectionID: collectionID,
+				NumRows:      uint64(len(pks)),
+				FieldsData:   []*schemapb.FieldData{partialUpdateCASPKFieldData(pks)},
+			})
+		if casGroups != nil {
+			meta, ok := casGroups[vchannel]
+			require.True(t, ok)
+			require.NoError(t, builder.AddPartialUpdateCAS(meta))
+		}
+		insertMsg, err := builder.BuildMutable()
+		require.NoError(t, err)
+		insertMsgs = append(insertMsgs, insertMsg)
+	}
+
+	deleteGroups := groupPartialUpdateCASIntPKs(t, deletePKs, vchannels)
+	deleteMsgs := make([]streamingmessage.MutableMessage, 0, len(deleteGroups))
+	for vchannel, pks := range deleteGroups {
+		deleteMsg, err := streamingmessage.NewDeleteMessageBuilderV1().
+			WithVChannel(vchannel).
+			WithHeader(&streamingmessage.DeleteMessageHeader{
+				CollectionId: collectionID,
+				Rows:         uint64(len(pks)),
+			}).
+			WithBody(&msgpb.DeleteRequest{
+				CollectionID: collectionID,
+				NumRows:      int64(len(pks)),
+				PrimaryKeys:  partialUpdateCASIDs(pks),
+			}).
+			BuildMutable()
+		require.NoError(t, err)
+		deleteMsgs = append(deleteMsgs, deleteMsg)
+	}
+	return insertMsgs, deleteMsgs
+}
+
+func buildPartialUpdateCASStringTestMessages(
+	t *testing.T,
+	collectionID int64,
+	vchannels []string,
+	insertPKs []string,
+	deletePKs []string,
+	casGroups map[string]*messagespb.PartialUpdateCAS,
+) ([]streamingmessage.MutableMessage, []streamingmessage.MutableMessage) {
+	insertGroups := groupPartialUpdateCASStringPKs(t, insertPKs, vchannels)
+	insertMsgs := make([]streamingmessage.MutableMessage, 0, len(insertGroups))
+	for vchannel, pks := range insertGroups {
+		builder := streamingmessage.NewInsertMessageBuilderV1().
+			WithVChannel(vchannel).
+			WithHeader(&streamingmessage.InsertMessageHeader{
+				CollectionId: collectionID,
+				Partitions: []*streamingmessage.PartitionSegmentAssignment{{
+					PartitionId: 100,
+					Rows:        uint64(len(pks)),
+				}},
+			}).
+			WithBody(&msgpb.InsertRequest{
+				CollectionID: collectionID,
+				NumRows:      uint64(len(pks)),
+				FieldsData:   []*schemapb.FieldData{partialUpdateCASStringPKFieldData(pks)},
+			})
+		if casGroups != nil {
+			meta, ok := casGroups[vchannel]
+			require.True(t, ok)
+			require.NoError(t, builder.AddPartialUpdateCAS(meta))
+		}
+		insertMsg, err := builder.BuildMutable()
+		require.NoError(t, err)
+		insertMsgs = append(insertMsgs, insertMsg)
+	}
+
+	deleteGroups := groupPartialUpdateCASStringPKs(t, deletePKs, vchannels)
+	deleteMsgs := make([]streamingmessage.MutableMessage, 0, len(deleteGroups))
+	for vchannel, pks := range deleteGroups {
+		deleteMsg, err := streamingmessage.NewDeleteMessageBuilderV1().
+			WithVChannel(vchannel).
+			WithHeader(&streamingmessage.DeleteMessageHeader{
+				CollectionId: collectionID,
+				Rows:         uint64(len(pks)),
+			}).
+			WithBody(&msgpb.DeleteRequest{
+				CollectionID: collectionID,
+				NumRows:      int64(len(pks)),
+				PrimaryKeys:  partialUpdateCASStringIDs(pks),
+			}).
+			BuildMutable()
+		require.NoError(t, err)
+		deleteMsgs = append(deleteMsgs, deleteMsg)
+	}
+	return insertMsgs, deleteMsgs
+}
+
+func groupPartialUpdateCASIntPKs(t *testing.T, pks []int64, vchannels []string) map[string][]int64 {
+	t.Helper()
+	groups := make(map[string][]int64)
+	if len(pks) == 0 {
+		return groups
+	}
+	indexes, err := typeutil.HashPK2Channels(partialUpdateCASIDs(pks), vchannels)
+	require.NoError(t, err)
+	for idx, channelIndex := range indexes {
+		vchannel := vchannels[channelIndex]
+		groups[vchannel] = append(groups[vchannel], pks[idx])
+	}
+	return groups
+}
+
+func groupPartialUpdateCASStringPKs(t *testing.T, pks []string, vchannels []string) map[string][]string {
+	t.Helper()
+	groups := make(map[string][]string)
+	if len(pks) == 0 {
+		return groups
+	}
+	indexes, err := typeutil.HashPK2Channels(partialUpdateCASStringIDs(pks), vchannels)
+	require.NoError(t, err)
+	for idx, channelIndex := range indexes {
+		vchannel := vchannels[channelIndex]
+		groups[vchannel] = append(groups[vchannel], pks[idx])
+	}
+	return groups
+}
+
+func partialUpdateCASTestTask(
+	t *testing.T,
+	partial bool,
+	originalPKs []int64,
+	finalInsertPKs []int64,
+	deletePKs []int64,
+) (*upsertTask, []streamingmessage.MutableMessage, []streamingmessage.MutableMessage) {
+	task := createTestUpdateTask()
+	task.SetTs(12345)
+	task.req.PartialUpdate = partial
+	task.req.FieldOps = []*schemapb.FieldPartialUpdateOp{{
+		FieldName: "name",
+		Op:        schemapb.FieldPartialUpdateOp_ARRAY_APPEND,
+	}}
+	task.req.NumRows = uint32(len(originalPKs))
+	task.req.FieldsData[0] = partialUpdateCASPKFieldData(originalPKs)
+	task.partialUpdateOriginalFields = cloneFieldDataList(task.req.GetFieldsData())
+	task.result = &milvuspb.MutationResult{
+		IDs: partialUpdateCASIDs(finalInsertPKs),
+	}
+	task.deletePKs = partialUpdateCASIDs(deletePKs)
+	task.upsertMsg = &msgstream.UpsertMsg{
+		InsertMsg: &msgstream.InsertMsg{InsertRequest: &msgpb.InsertRequest{}},
+		DeleteMsg: &msgstream.DeleteMsg{DeleteRequest: &msgpb.DeleteRequest{}},
+	}
+	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels)
+	insertMsgs, deleteMsgs := buildPartialUpdateCASTestMessages(t, task.collectionID, partialUpdateCASTestVChannels, finalInsertPKs, deletePKs, nil)
+	return task, insertMsgs, deleteMsgs
+}
+
+func partialUpdateCASRealPackTestTask(
+	t *testing.T,
+	originalPKs []int64,
+	finalInsertPKs []int64,
+	deletePKs []int64,
+) *upsertTask {
+	require.Len(t, finalInsertPKs, len(originalPKs))
+	rowIDs := make([]int64, len(finalInsertPKs))
+	timestamps := make([]uint64, len(finalInsertPKs))
+	for i := range finalInsertPKs {
+		rowIDs[i] = int64(101 + i)
+	}
+
+	task := createTestUpdateTask()
+	task.SetTs(12345)
+	for i := range timestamps {
+		timestamps[i] = task.BeginTs()
+	}
+	task.req.PartialUpdate = true
+	task.req.Base = commonpbutil.NewMsgBase(
+		commonpbutil.WithMsgType(commonpb.MsgType_Upsert),
+		commonpbutil.WithMsgID(10000),
+		commonpbutil.WithTimeStamp(task.BeginTs()),
+	)
+	task.req.FieldOps = []*schemapb.FieldPartialUpdateOp{{
+		FieldName: "name",
+		Op:        schemapb.FieldPartialUpdateOp_ARRAY_APPEND,
+	}}
+	task.req.NumRows = uint32(len(originalPKs))
+	task.req.FieldsData[0] = partialUpdateCASPKFieldData(originalPKs)
+	task.partialUpdateOriginalFields = cloneFieldDataList(task.req.GetFieldsData())
+	task.result = &milvuspb.MutationResult{
+		IDs: partialUpdateCASIDs(finalInsertPKs),
+	}
+	task.deletePKs = partialUpdateCASIDs(deletePKs)
+	task.idAllocator = &allocator.IDAllocator{}
+	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels[:1])
+	task.upsertMsg = &msgstream.UpsertMsg{
+		InsertMsg: &msgstream.InsertMsg{
+			BaseMsg: msgstream.BaseMsg{
+				Ctx:            context.Background(),
+				BeginTimestamp: task.BeginTs(),
+				EndTimestamp:   task.BeginTs(),
+			},
+			InsertRequest: &msgpb.InsertRequest{
+				Base: commonpbutil.NewMsgBase(
+					commonpbutil.WithMsgType(commonpb.MsgType_Insert),
+					commonpbutil.WithTimeStamp(task.BeginTs()),
+				),
+				CollectionName: task.req.GetCollectionName(),
+				CollectionID:   task.collectionID,
+				PartitionName:  task.req.GetPartitionName(),
+				FieldsData:     []*schemapb.FieldData{partialUpdateCASPKFieldData(finalInsertPKs)},
+				NumRows:        uint64(len(finalInsertPKs)),
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+				DbName:         task.req.GetDbName(),
+				RowIDs:         rowIDs,
+				Timestamps:     timestamps,
+			},
+		},
+		DeleteMsg: &msgstream.DeleteMsg{
+			DeleteRequest: &msgpb.DeleteRequest{
+				Base: commonpbutil.NewMsgBase(
+					commonpbutil.WithMsgType(commonpb.MsgType_Delete),
+					commonpbutil.WithTimeStamp(task.BeginTs()),
+				),
+				DbName:         task.req.GetDbName(),
+				CollectionName: task.req.GetCollectionName(),
+				CollectionID:   task.collectionID,
+				PrimaryKeys:    partialUpdateCASIDs(deletePKs),
+				NumRows:        int64(len(deletePKs)),
+				PartitionName:  task.req.GetPartitionName(),
+			},
+		},
+	}
+	return task
+}
+
+func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
+	oldMetaCache := globalMetaCache
+	globalMetaCache = &MetaCache{}
+	t.Cleanup(func() { globalMetaCache = oldMetaCache })
+	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
+	defer partitionPatch.UnPatch()
+
+	newInput := func() (*upsertTask, string, map[string]*messagespb.PartialUpdateCAS) {
+		task := partialUpdateCASRealPackTestTask(t, []int64{10}, []int64{10}, nil)
+		vchannel := partialUpdateCASTestVChannels[0]
+		return task, vchannel, map[string]*messagespb.PartialUpdateCAS{
+			vchannel: {
+				ReadTs:               100,
+				ObservedPchannelTerm: 1,
+				CollectionId:         task.collectionID,
+				PrimaryKeyFieldId:    100,
+			},
+		}
+	}
+
+	task, vchannel, groups := newInput()
+	msgs, err := repackInsertDataForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		nil,
+		1,
+		groups,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.True(t, streamingmessage.HasPartialUpdateCAS(msgs[0]))
+
+	task, vchannel, _ = newInput()
+	_, err = repackInsertDataForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		nil,
+		1,
+		map[string]*messagespb.PartialUpdateCAS{},
+	)
+	require.Error(t, err)
+
+	task, vchannel, _ = newInput()
+	_, err = repackInsertDataForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		nil,
+		1,
+		map[string]*messagespb.PartialUpdateCAS{vchannel: nil},
+	)
+	require.Error(t, err)
+}
+
+func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testing.T) {
+	oldMetaCache := globalMetaCache
+	globalMetaCache = &MetaCache{}
+	t.Cleanup(func() { globalMetaCache = oldMetaCache })
+	partitionsPatch := mockey.Mock((*MetaCache).GetPartitions).
+		Return(map[string]int64{"_default_0": 200}, nil).
+		Build()
+	defer partitionsPatch.UnPatch()
+	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
+	defer partitionPatch.UnPatch()
+
+	newInput := func() (*upsertTask, string, map[string]*messagespb.PartialUpdateCAS) {
+		task := partialUpdateCASRealPackTestTask(t, []int64{10}, []int64{10}, nil)
+		task.partitionKeys = partialUpdateCASPKFieldData([]int64{10})
+		vchannel := partialUpdateCASTestVChannels[0]
+		return task, vchannel, map[string]*messagespb.PartialUpdateCAS{
+			vchannel: {
+				ReadTs:               100,
+				ObservedPchannelTerm: 1,
+				CollectionId:         task.collectionID,
+				PrimaryKeyFieldId:    100,
+			},
+		}
+	}
+
+	task, vchannel, groups := newInput()
+	msgs, err := repackInsertDataWithPartitionKeyForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		task.partitionKeys,
+		nil,
+		task.schema.CollectionSchema,
+		1,
+		groups,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.True(t, streamingmessage.HasPartialUpdateCAS(msgs[0]))
+
+	task, vchannel, _ = newInput()
+	_, err = repackInsertDataWithPartitionKeyForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		task.partitionKeys,
+		nil,
+		task.schema.CollectionSchema,
+		1,
+		map[string]*messagespb.PartialUpdateCAS{},
+	)
+	require.Error(t, err)
+
+	task, vchannel, _ = newInput()
+	_, err = repackInsertDataWithPartitionKeyForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		task.partitionKeys,
+		nil,
+		task.schema.CollectionSchema,
+		1,
+		map[string]*messagespb.PartialUpdateCAS{vchannel: nil},
+	)
+	require.Error(t, err)
+}
+
+func TestInsertTaskExecuteSelectsPartitionRouting(t *testing.T) {
+	for _, partitionKey := range []bool{false, true} {
+		t.Run(map[bool]string{false: "primary key", true: "partition key"}[partitionKey], func(t *testing.T) {
+			oldMetaCache := globalMetaCache
+			globalMetaCache = &MetaCache{}
+			t.Cleanup(func() { globalMetaCache = oldMetaCache })
+			collectionPatch := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
+			defer collectionPatch.UnPatch()
+
+			primaryPatch := mockey.Mock(repackInsertDataForStreamingService).
+				Return([]streamingmessage.MutableMessage{}, nil).
+				Build()
+			defer primaryPatch.UnPatch()
+			partitionPatch := mockey.Mock(repackInsertDataWithPartitionKeyForStreamingService).
+				Return([]streamingmessage.MutableMessage{}, nil).
+				Build()
+			defer partitionPatch.UnPatch()
+
+			fakeWAL := newPartialUpdateCASTestWAL(t, 1)
+			oldWAL := streaming.WAL()
+			streaming.SetWALForTest(fakeWAL)
+			t.Cleanup(func() { streaming.SetWALForTest(oldWAL) })
+
+			task := &insertTask{
+				ctx: context.Background(),
+				insertMsg: &msgstream.InsertMsg{InsertRequest: &msgpb.InsertRequest{
+					Base:           &commonpb.MsgBase{},
+					DbName:         "test_db",
+					CollectionName: "test_collection",
+				}},
+				result: &milvuspb.MutationResult{},
+				chMgr: newChannelsMgrImpl(func(UniqueID) (channelInfos, error) {
+					return newChannels([]vChan{partialUpdateCASTestVChannels[0]}, []pChan{funcutil.ToPhysicalChannel(partialUpdateCASTestVChannels[0])})
+				}, nil),
+				schema: &schemapb.CollectionSchema{},
+			}
+			if partitionKey {
+				task.partitionKeys = partialUpdateCASPKFieldData([]int64{10})
+			}
+
+			require.NoError(t, task.Execute(context.Background()))
+			require.Equal(t, 1, fakeWAL.appendCalls)
+		})
+	}
+}
+
+func TestPackInsertMessageUsesPartitionKeyRouting(t *testing.T) {
+	task := partialUpdateCASRealPackTestTask(t, []int64{10}, []int64{10}, nil)
+	task.partitionKeys = partialUpdateCASPKFieldData([]int64{10})
+	oldMetaCache := globalMetaCache
+	globalMetaCache = &MetaCache{}
+	t.Cleanup(func() { globalMetaCache = oldMetaCache })
+	collectionPatch := mockey.Mock((*MetaCache).GetCollectionID).Return(task.collectionID, nil).Build()
+	defer collectionPatch.UnPatch()
+	partitionPatch := mockey.Mock(repackInsertDataWithPartitionKeyForStreamingService).
+		Return([]streamingmessage.MutableMessage{}, nil).
+		Build()
+	defer partitionPatch.UnPatch()
+
+	msgs, err := task.packInsertMessage(context.Background(), nil)
+	require.NoError(t, err)
+	require.Empty(t, msgs)
+}
+
+func TestAppendUpsertAttemptMapsSchemaVersionMismatch(t *testing.T) {
+	task, insertMsgs, _ := partialUpdateCASTestTask(t, false, []int64{10}, []int64{10}, nil)
+	fakeWAL := newPartialUpdateCASTestWAL(t, 1)
+	fakeWAL.appendHook = func(context.Context, ...streamingmessage.MutableMessage) streaming.AppendResponses {
+		return streaming.AppendResponses{Responses: []streaming.AppendResponse{{
+			Error: streamingstatus.NewSchemaVersionMismatch("schema changed"),
+		}}}
+	}
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	t.Cleanup(func() { streaming.SetWALForTest(oldWAL) })
+	insertPatch := mockey.Mock((*upsertTask).packInsertMessage).Return(insertMsgs, nil).Build()
+	defer insertPatch.UnPatch()
+	deletePatch := mockey.Mock((*upsertTask).packDeleteMessage).Return(nil, nil).Build()
+	defer deletePatch.UnPatch()
+
+	err := task.appendUpsertAttempt(context.Background(), nil)
+	require.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+}
+
+func TestAttachPartialUpdateCASRejectsMissingMarker(t *testing.T) {
+	task, insertMsgs, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, nil)
+	require.NotEmpty(t, insertMsgs)
+	task.partialUpdateCASGroups = map[string]*messagespb.PartialUpdateCAS{
+		insertMsgs[0].VChannel(): {
+			ReadTs:               100,
+			ObservedPchannelTerm: 1,
+			CollectionId:         task.collectionID,
+			PrimaryKeyFieldId:    100,
+		},
+	}
+	err := task.attachPartialUpdateCAS(insertMsgs[:1])
+	require.ErrorIs(t, err, merr.ErrServiceInternal)
+	require.Contains(t, err.Error(), "missing CAS metadata")
+}
+
+func partialUpdateCASStringTestTask(
+	t *testing.T,
+	originalPKs []string,
+	finalInsertPKs []string,
+	deletePKs []string,
+) (*upsertTask, []streamingmessage.MutableMessage, []streamingmessage.MutableMessage) {
+	task := createTestUpdateTask()
+	task.SetTs(12345)
+	task.schema.CollectionSchema.Fields[0].DataType = schemapb.DataType_VarChar
+	task.req.PartialUpdate = true
+	task.req.FieldOps = []*schemapb.FieldPartialUpdateOp{{
+		FieldName: "name",
+		Op:        schemapb.FieldPartialUpdateOp_ARRAY_APPEND,
+	}}
+	task.req.NumRows = uint32(len(originalPKs))
+	task.req.FieldsData[0] = partialUpdateCASStringPKFieldData(originalPKs)
+	task.partialUpdateOriginalFields = cloneFieldDataList(task.req.GetFieldsData())
+	task.result = &milvuspb.MutationResult{
+		IDs: partialUpdateCASStringIDs(finalInsertPKs),
+	}
+	task.deletePKs = partialUpdateCASStringIDs(deletePKs)
+	task.upsertMsg = &msgstream.UpsertMsg{
+		InsertMsg: &msgstream.InsertMsg{InsertRequest: &msgpb.InsertRequest{}},
+		DeleteMsg: &msgstream.DeleteMsg{DeleteRequest: &msgpb.DeleteRequest{}},
+	}
+	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels)
+	insertMsgs, deleteMsgs := buildPartialUpdateCASStringTestMessages(t, task.collectionID, partialUpdateCASTestVChannels, finalInsertPKs, deletePKs, nil)
+	return task, insertMsgs, deleteMsgs
+}
+
+func TestPartialUpdateAppendAcceptsBuilderCASMetadata(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+	preparePartialUpdateCASTestGroups(t, task)
+	insertMsgs, deleteMsgs := buildPartialUpdateCASTestMessages(
+		t,
+		task.collectionID,
+		partialUpdateCASTestVChannels,
+		[]int64{20, 10, 30},
+		[]int64{20},
+		task.partialUpdateCASGroups,
+	)
+
+	m := mockey.Mock((*upsertTask).packInsertMessage).Return(insertMsgs, nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).packDeleteMessage).Return(deleteMsgs, nil).Build()
+	defer m.UnPatch()
+
+	err := task.Execute(context.Background())
+	require.NoError(t, err)
+	expected := expectedPartialUpdateCASGroups(t, partialUpdateCASIDs([]int64{10, 20, 30}), partialUpdateCASTestVChannels)
+	require.Equal(t, len(expected), fakeWAL.resolveCalls)
+	require.Equal(t, 1, fakeWAL.appendCalls)
+	require.Len(t, fakeWAL.appended, len(insertMsgs)+len(deleteMsgs))
+	requireAppendedPartialUpdateCASGroups(t, fakeWAL.appended, expected, task.partialUpdateReadTs, 9, task.collectionID)
+}
+
+func TestPartialUpdateAppendPacksMessagesAndAttachesCASMetadata(t *testing.T) {
+	task := partialUpdateCASRealPackTestTask(t, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	oldMetaCache := globalMetaCache
+	streaming.SetWALForTest(fakeWAL)
+	globalMetaCache = &MetaCache{}
+	defer streaming.SetWALForTest(oldWAL)
+	defer func() { globalMetaCache = oldMetaCache }()
+	preparePartialUpdateCASTestGroups(t, task)
+
+	m := mockey.Mock((*MetaCache).GetCollectionID).Return(task.collectionID, nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*MetaCache).GetPartitionID).Return(UniqueID(100), nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*allocator.IDAllocator).Alloc).Return(UniqueID(1000), UniqueID(1001), nil).Build()
+	defer m.UnPatch()
+
+	err := task.Execute(context.Background())
+	require.NoError(t, err)
+	expected := expectedPartialUpdateCASGroups(t, partialUpdateCASIDs([]int64{10, 20, 30}), partialUpdateCASTestVChannels[:1])
+	require.Equal(t, 1, fakeWAL.resolveCalls)
+	require.Equal(t, 1, fakeWAL.appendCalls)
+	require.Len(t, fakeWAL.appended, 2)
+	requireAppendedPartialUpdateCASGroups(t, fakeWAL.appended, expected, task.partialUpdateReadTs, 9, task.collectionID)
+}
+
+func TestPartialUpdateRetriesAfterCASConflict(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+	task.req.FieldOps[0].Op = schemapb.FieldPartialUpdateOp_REPLACE
+	task.node.(*Proxy).tsoAllocator = &timestampAllocator{
+		tso:    newMockTimestampAllocatorInterface(),
+		peerID: paramtable.GetNodeID(),
+	}
+	initialTs := task.BeginTs()
+	initialID := task.ID()
+
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	fakeWAL.appendHook = func(ctx context.Context, msgs ...streamingmessage.MutableMessage) streaming.AppendResponses {
+		resp := streamingtypes.NewAppendResponseN(len(msgs))
+		if fakeWAL.appendCalls == 1 {
+			fakeWAL.term = 10
+			resp.FillAllError(streamingstatus.NewPartialUpdateRetryable("conflict"))
+			return resp
+		}
+		resp.FillAllResponse(streaming.AppendResponse{
+			AppendResult: &streamingtypes.AppendResult{TimeTick: 200},
+		})
+		return resp
+	}
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+	preparePartialUpdateCASTestGroups(t, task)
+	firstAttemptReadTS := task.partialUpdateReadTs
+
+	m := mockey.Mock((*upsertTask).packInsertMessage).To(
+		func(task *upsertTask, ctx context.Context, ez *streamingmessage.CipherConfig) ([]streamingmessage.MutableMessage, error) {
+			insertMsgs, _ := buildPartialUpdateCASTestMessages(
+				t,
+				task.collectionID,
+				partialUpdateCASTestVChannels,
+				[]int64{20, 10, 30},
+				[]int64{20},
+				task.partialUpdateCASGroups,
+			)
+			return insertMsgs, nil
+		},
+	).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).packDeleteMessage).To(
+		func(task *upsertTask, ctx context.Context, ez *streamingmessage.CipherConfig) ([]streamingmessage.MutableMessage, error) {
+			_, deleteMsgs := buildPartialUpdateCASTestMessages(
+				t,
+				task.collectionID,
+				partialUpdateCASTestVChannels,
+				[]int64{20, 10, 30},
+				[]int64{20},
+				nil,
+			)
+			return deleteMsgs, nil
+		},
+	).Build()
+	defer m.UnPatch()
+
+	requeryCalls := 0
+	m = mockey.Mock((*upsertTask).queryPreExecute).To(func(task *upsertTask, ctx context.Context) error {
+		requeryCalls++
+		require.Equal(t, initialTs, task.BeginTs())
+		require.Equal(t, initialID, task.ID())
+		for _, meta := range task.partialUpdateCASGroups {
+			require.Greater(t, meta.GetReadTs(), initialTs)
+		}
+		return nil
+	}).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).insertPreExecute).Return(nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).deletePreExecute).Return(nil).Build()
+	defer m.UnPatch()
+
+	err := task.Execute(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, fakeWAL.appendCalls)
+	require.Equal(t, 1, requeryCalls)
+	require.Len(t, fakeWAL.appendedBatches, 2)
+
+	firstCAS := requireFirstPartialUpdateCAS(t, fakeWAL.appendedBatches[0])
+	secondCAS := requireFirstPartialUpdateCAS(t, fakeWAL.appendedBatches[1])
+	require.Equal(t, firstAttemptReadTS, firstCAS.GetReadTs())
+	require.Greater(t, secondCAS.GetReadTs(), firstCAS.GetReadTs())
+	require.EqualValues(t, 9, firstCAS.GetObservedPchannelTerm())
+	require.EqualValues(t, 10, secondCAS.GetObservedPchannelTerm())
+	require.Equal(t, initialTs, task.BeginTs())
+	require.Equal(t, initialID, task.ID())
+	require.Equal(t, uint64(200), task.result.GetTimestamp())
+}
+
+func TestPartialUpdateCASConflictProjection(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		canRetryConflict bool
+		expectedError    error
+		expectedRetry    bool
+	}{
+		{
+			name:          "relative update",
+			expectedError: merr.ErrCollectionPartialUpdateConflict,
+		},
+		{
+			name:             "replace retry exhausted",
+			canRetryConflict: true,
+			expectedError:    merr.ErrServiceUnavailable,
+			expectedRetry:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			task, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, []int64{10})
+			if tc.canRetryConflict {
+				task.req.FieldOps[0].Op = schemapb.FieldPartialUpdateOp_REPLACE
+			}
+
+			casErr := streamingstatus.NewPartialUpdateRetryable("conflict")
+			appendPatch := mockey.Mock((*upsertTask).appendUpsertAttempt).
+				Return(casErr).Build()
+			defer appendPatch.UnPatch()
+			preparePatch := mockey.Mock((*upsertTask).preparePartialUpdateRetryAttempt).Return(nil).Build()
+			defer preparePatch.UnPatch()
+
+			err := task.executePartialUpdateWithCASRetry(context.Background(), nil)
+			require.Error(t, err)
+			require.ErrorIs(t, err, tc.expectedError)
+			require.ErrorIs(t, err, casErr)
+			resultStatus := merr.Status(err)
+			require.Equal(t, merr.Code(tc.expectedError), resultStatus.GetCode())
+			require.Equal(t, tc.expectedRetry, resultStatus.GetRetriable())
+		})
+	}
+}
+
+func TestPartialUpdateCASRetryRequiresOriginalFields(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, []int64{10})
+	task.req.FieldOps[0].Op = schemapb.FieldPartialUpdateOp_REPLACE
+	task.partialUpdateOriginalFields = nil
+
+	err := task.executePartialUpdateWithCASRetry(context.Background(), nil)
+	require.ErrorIs(t, err, merr.ErrServiceInternal)
+}
+
+func TestPartialUpdateCASRetryStopsWhenAttemptPreparationFails(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, []int64{10})
+	task.req.FieldOps[0].Op = schemapb.FieldPartialUpdateOp_REPLACE
+	casErr := streamingstatus.NewPartialUpdateRetryable("conflict")
+	prepareErr := merr.WrapErrServiceInternalMsg("prepare retry attempt failed")
+
+	appendCalls := 0
+	appendPatch := mockey.Mock((*upsertTask).appendUpsertAttempt).To(
+		func(task *upsertTask, ctx context.Context, ez *streamingmessage.CipherConfig) error {
+			appendCalls++
+			return casErr
+		},
+	).Build()
+	defer appendPatch.UnPatch()
+	preparePatch := mockey.Mock((*upsertTask).preparePartialUpdateRetryAttempt).Return(prepareErr).Build()
+	defer preparePatch.UnPatch()
+
+	err := task.executePartialUpdateWithCASRetry(context.Background(), nil)
+	require.ErrorIs(t, err, prepareErr)
+	require.Equal(t, 1, appendCalls)
+}
+
+func TestUnwrapPartialUpdateAppendErrorRejectsMixedOutcome(t *testing.T) {
+	casErr := streamingstatus.NewPartialUpdateRetryable("conflict")
+	unknownErr := context.DeadlineExceeded
+
+	err := unwrapPartialUpdateAppendError(streaming.AppendResponses{
+		Responses: []streaming.AppendResponse{
+			{Error: casErr},
+			{Error: unknownErr},
+		},
+	})
+	require.ErrorIs(t, err, unknownErr)
+
+	err = unwrapPartialUpdateAppendError(streaming.AppendResponses{
+		Responses: []streaming.AppendResponse{
+			{Error: casErr},
+			{AppendResult: &streamingtypes.AppendResult{TimeTick: 100}},
+		},
+	})
+	require.ErrorIs(t, err, casErr)
+}
+
+func TestPartialUpdateQueryAccumulatesStorageCost(t *testing.T) {
+	schema := createTestSchema()
+	upsertData := []*schemapb.FieldData{
+		partialUpdateCASPKFieldData([]int64{1}),
+		{
+			FieldName: "name",
+			FieldId:   102,
+			Type:      schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"new"}}},
+			}},
+		},
+	}
+	queryResult := &milvuspb.QueryResults{
+		Status: merr.Success(),
+		FieldsData: []*schemapb.FieldData{
+			partialUpdateCASPKFieldData([]int64{1}),
+			{
+				FieldName: "name",
+				FieldId:   102,
+				Type:      schemapb.DataType_VarChar,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"old"}}},
+				}},
+			},
+		},
+	}
+	task := &upsertTask{
+		ctx:    context.Background(),
+		schema: schema,
+		req: &milvuspb.UpsertRequest{
+			FieldsData: upsertData,
+			NumRows:    1,
+		},
+		upsertMsg: &msgstream.UpsertMsg{InsertMsg: &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{FieldsData: upsertData, NumRows: 1},
+		}},
+		node:        &Proxy{},
+		storageCost: segcore.StorageCost{ScannedRemoteBytes: 5, ScannedTotalBytes: 10},
+	}
+	retrievePatch := mockey.Mock(retrieveByPKs).Return(queryResult, segcore.StorageCost{
+		ScannedRemoteBytes: 7,
+		ScannedTotalBytes:  20,
+	}, nil).Build()
+	defer retrievePatch.UnPatch()
+
+	require.NoError(t, task.queryPreExecute(context.Background()))
+	require.EqualValues(t, 12, task.storageCost.ScannedRemoteBytes)
+	require.EqualValues(t, 30, task.storageCost.ScannedTotalBytes)
+}
+
+func TestPartialUpdateRetryRestoresOriginalFieldsBeforeQuery(t *testing.T) {
+	task := createTestUpdateTask()
+	task.req.PartialUpdate = true
+	task.result = &milvuspb.MutationResult{}
+	task.upsertMsg = &msgstream.UpsertMsg{
+		InsertMsg: &msgstream.InsertMsg{InsertRequest: &msgpb.InsertRequest{}},
+		DeleteMsg: &msgstream.DeleteMsg{DeleteRequest: &msgpb.DeleteRequest{}},
+	}
+	task.upsertMsg.InsertMsg.FieldsData = []*schemapb.FieldData{
+		partialUpdateCASPKFieldData([]int64{10}),
+		partialUpdateCASPKFieldData([]int64{20}),
+		partialUpdateCASPKFieldData([]int64{30}),
+		partialUpdateCASPKFieldData([]int64{40}),
+	}
+	task.node.(*Proxy).tsoAllocator = &timestampAllocator{
+		tso:    newMockTimestampAllocatorInterface(),
+		peerID: paramtable.GetNodeID(),
+	}
+	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels)
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+
+	m := mockey.Mock((*upsertTask).queryPreExecute).To(func(task *upsertTask, ctx context.Context) error {
+		require.Len(t, task.upsertMsg.InsertMsg.GetFieldsData(), len(task.req.GetFieldsData()))
+		for i, field := range task.req.GetFieldsData() {
+			require.Same(t, field, task.upsertMsg.InsertMsg.GetFieldsData()[i])
+		}
+		return nil
+	}).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).insertPreExecute).Return(nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).deletePreExecute).Return(nil).Build()
+	defer m.UnPatch()
+
+	task.partialUpdateOriginalFields = cloneFieldDataList(task.req.GetFieldsData())
+	require.NoError(t, task.preparePartialUpdateRetryAttempt(context.Background()))
+}
+
+func TestPartialUpdateRetryRefreshesMutationResultCounts(t *testing.T) {
+	task := createTestUpdateTask()
+	task.req.PartialUpdate = true
+	task.result = &milvuspb.MutationResult{
+		DeleteCnt: 1,
+		InsertCnt: 1,
+		UpsertCnt: 1,
+	}
+	task.upsertMsg = &msgstream.UpsertMsg{
+		InsertMsg: &msgstream.InsertMsg{InsertRequest: &msgpb.InsertRequest{
+			FieldsData: task.req.GetFieldsData(),
+			NumRows:    uint64(task.req.GetNumRows()),
+		}},
+		DeleteMsg: &msgstream.DeleteMsg{DeleteRequest: &msgpb.DeleteRequest{}},
+	}
+	task.node.(*Proxy).tsoAllocator = &timestampAllocator{
+		tso:    newMockTimestampAllocatorInterface(),
+		peerID: paramtable.GetNodeID(),
+	}
+	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels)
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+
+	m := mockey.Mock((*upsertTask).queryPreExecute).To(func(task *upsertTask, ctx context.Context) error {
+		task.insertFieldData = cloneFieldDataList(task.req.GetFieldsData())
+		task.deletePKs = partialUpdateCASIDs([]int64{1, 2})
+		return nil
+	}).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).insertPreExecute).Return(nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).deletePreExecute).Return(nil).Build()
+	defer m.UnPatch()
+
+	task.partialUpdateOriginalFields = cloneFieldDataList(task.req.GetFieldsData())
+	err := task.preparePartialUpdateRetryAttempt(context.Background())
+	require.NoError(t, err)
+	require.EqualValues(t, 2, task.result.GetDeleteCnt())
+	require.EqualValues(t, 3, task.result.GetInsertCnt())
+	require.EqualValues(t, 3, task.result.GetUpsertCnt())
+}
+
+func TestPartialUpdateRetryResolvesTermBeforeQuery(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+	task.result = &milvuspb.MutationResult{}
+	task.node.(*Proxy).tsoAllocator = &timestampAllocator{
+		tso:    newMockTimestampAllocatorInterface(),
+		peerID: paramtable.GetNodeID(),
+	}
+
+	events := make([]string, 0, len(partialUpdateCASTestVChannels)+1)
+	fakeWAL := newPartialUpdateCASTestWAL(t, 11)
+	fakeWAL.resolveHook = func(string) {
+		events = append(events, "resolve")
+	}
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+
+	m := mockey.Mock((*timestampAllocator).AllocOne).To(
+		func(_ *timestampAllocator, _ context.Context) (Timestamp, error) {
+			events = append(events, "readTS")
+			return 1000, nil
+		},
+	).Build()
+	defer m.UnPatch()
+
+	generatedField := &schemapb.FieldData{FieldName: "generated", FieldId: 999}
+	m = mockey.Mock(genFunctionFields).To(
+		func(ctx context.Context, insertMsg *msgstream.InsertMsg, schema *schemaInfo, partialUpdate bool) error {
+			events = append(events, "function")
+			require.Len(t, insertMsg.GetFieldsData(), len(task.req.GetFieldsData()))
+			insertMsg.FieldsData = append(insertMsg.FieldsData, generatedField)
+			return nil
+		},
+	).Build()
+	defer m.UnPatch()
+
+	m = mockey.Mock((*upsertTask).queryPreExecute).To(func(task *upsertTask, ctx context.Context) error {
+		events = append(events, "query")
+		require.Contains(t, task.upsertMsg.InsertMsg.GetFieldsData(), generatedField)
+		return nil
+	}).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).insertPreExecute).Return(nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).deletePreExecute).Return(nil).Build()
+	defer m.UnPatch()
+
+	task.partialUpdateOriginalFields = cloneFieldDataList(task.req.GetFieldsData())
+	err := task.preparePartialUpdateRetryAttempt(context.Background())
+	require.NoError(t, err)
+	require.Len(t, events, len(partialUpdateCASTestVChannels)+3)
+	require.Equal(t, "function", events[0])
+	for _, event := range events[1 : len(events)-2] {
+		require.Equal(t, "resolve", event)
+	}
+	require.Equal(t, "readTS", events[len(events)-2])
+	require.Equal(t, "query", events[len(events)-1])
+}
+
+func TestPartialUpdateAppendAcceptsBuilderCASMetadataForVarCharPK(t *testing.T) {
+	task, _, _ := partialUpdateCASStringTestTask(
+		t,
+		[]string{"pk10", "pk20", "pk30"},
+		[]string{"pk20", "pk10", "pk30"},
+		[]string{"pk20"},
+	)
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+	preparePartialUpdateCASTestGroups(t, task)
+	insertMsgs, deleteMsgs := buildPartialUpdateCASStringTestMessages(
+		t,
+		task.collectionID,
+		partialUpdateCASTestVChannels,
+		[]string{"pk20", "pk10", "pk30"},
+		[]string{"pk20"},
+		task.partialUpdateCASGroups,
+	)
+
+	m := mockey.Mock((*upsertTask).packInsertMessage).Return(insertMsgs, nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).packDeleteMessage).Return(deleteMsgs, nil).Build()
+	defer m.UnPatch()
+
+	err := task.Execute(context.Background())
+	require.NoError(t, err)
+	expected := expectedPartialUpdateCASGroups(t, partialUpdateCASStringIDs([]string{"pk10", "pk20", "pk30"}), partialUpdateCASTestVChannels)
+	require.Equal(t, len(expected), fakeWAL.resolveCalls)
+	require.Equal(t, 1, fakeWAL.appendCalls)
+	require.Len(t, fakeWAL.appended, len(insertMsgs)+len(deleteMsgs))
+	requireAppendedPartialUpdateCASGroups(t, fakeWAL.appended, expected, task.partialUpdateReadTs, 9, task.collectionID)
+}
+
+func TestPartialUpdateAutoIDBuildsCASGroupsFromOriginalPKs(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10, 20, 30}, []int64{10, 20, 30}, []int64{20})
+	task.schema.CollectionSchema.Fields[0].AutoID = true
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+
+	preparePartialUpdateCASTestGroups(t, task)
+	expected := expectedPartialUpdateCASGroups(t, partialUpdateCASIDs([]int64{10, 20, 30}), partialUpdateCASTestVChannels)
+	require.Len(t, task.partialUpdateCASGroups, len(expected))
+	for vchannel := range expected {
+		require.Contains(t, task.partialUpdateCASGroups, vchannel)
+	}
+	require.Equal(t, len(expected), fakeWAL.resolveCalls)
+	require.Zero(t, fakeWAL.appendCalls)
+}
+
+func TestNonPartialUpsertDoesNotAttachCASMetadata(t *testing.T) {
+	task, insertMsgs, deleteMsgs := partialUpdateCASTestTask(t, false, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+
+	m := mockey.Mock((*upsertTask).packInsertMessage).Return(insertMsgs, nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).packDeleteMessage).Return(deleteMsgs, nil).Build()
+	defer m.UnPatch()
+
+	err := task.Execute(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, fakeWAL.resolveCalls)
+	require.Equal(t, 1, fakeWAL.appendCalls)
+	require.Len(t, fakeWAL.appended, len(insertMsgs)+len(deleteMsgs))
+	for _, msg := range fakeWAL.appended {
+		meta, err := streamingmessage.ExtractPartialUpdateCAS(msg)
+		require.NoError(t, err)
+		require.Nil(t, meta)
+	}
+}
+
+func TestPreparePartialUpdateCASGroupsResolveErrorStopsBeforeQuery(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+	task.partialUpdateReadTs = 123
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	fakeWAL.resolveErr = errors.New("resolve pchannel failed")
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+
+	err := task.preparePartialUpdateCASGroups(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 1, fakeWAL.resolveCalls)
+	require.Equal(t, 0, fakeWAL.appendCalls)
+	require.Empty(t, fakeWAL.appended)
+	require.Zero(t, task.partialUpdateReadTs)
+}
+
+func TestPreparePartialUpdateCASGroupsRejectsInvalidTerm(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+	fakeWAL := newPartialUpdateCASTestWAL(t, -1)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+
+	err := task.preparePartialUpdateCASGroups(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid term")
+	require.Empty(t, task.partialUpdateCASGroups)
+}
+
+func TestAttachPartialUpdateCASRequiresMetadataSnapshot(t *testing.T) {
+	task, insertMsgs, deleteMsgs := partialUpdateCASTestTask(t, true, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+
+	err := task.attachPartialUpdateCAS(append(insertMsgs, deleteMsgs...))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "metadata snapshot is empty")
+}
+
+func TestPreparePartialUpdateCASGroupsSetsEveryVChannelTerm(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+	preparePartialUpdateCASTestGroups(t, task)
+
+	require.NotEmpty(t, task.partialUpdateCASGroups)
+	for _, meta := range task.partialUpdateCASGroups {
+		require.Equal(t, int64(9), meta.GetObservedPchannelTerm())
+	}
+}
+
+func TestAttachPartialUpdateCASValidatesPreparedGroups(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10, 20, 30}, []int64{20, 10, 30}, []int64{20})
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+	preparePartialUpdateCASTestGroups(t, task)
+	insertMsgs, deleteMsgs := buildPartialUpdateCASTestMessages(
+		t,
+		task.collectionID,
+		partialUpdateCASTestVChannels,
+		[]int64{20, 10, 30},
+		[]int64{20},
+		task.partialUpdateCASGroups,
+	)
+
+	// Validation uses the attempt-scoped channel snapshot and does not rebuild
+	// metadata from the request payload after message encryption.
+	task.req.FieldsData = nil
+	err := task.attachPartialUpdateCAS(append(insertMsgs, deleteMsgs...))
+	require.NoError(t, err)
+}
+
+func TestPartialUpdateCASMetadataSizeIsBounded(t *testing.T) {
+	smallTask, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, nil)
+	setPartialUpdateCASTestChannels(smallTask, partialUpdateCASTestVChannels[:1])
+	smallGroups, err := smallTask.buildPartialUpdateCASGroups()
+	require.NoError(t, err)
+
+	largePKs := make([]int64, 1000)
+	for idx := range largePKs {
+		largePKs[idx] = int64(idx + 1)
+	}
+	largeTask, _, _ := partialUpdateCASTestTask(t, true, largePKs, largePKs, nil)
+	setPartialUpdateCASTestChannels(largeTask, partialUpdateCASTestVChannels[:1])
+	largeGroups, err := largeTask.buildPartialUpdateCASGroups()
+	require.NoError(t, err)
+
+	smallEncoded, err := streamingmessage.EncodeProto(smallGroups[partialUpdateCASTestVChannels[0]])
+	require.NoError(t, err)
+	largeEncoded, err := streamingmessage.EncodeProto(largeGroups[partialUpdateCASTestVChannels[0]])
+	require.NoError(t, err)
+	require.Equal(t, len(smallEncoded), len(largeEncoded))
+}
+
+func TestAttachPartialUpdateCASAcceptsEveryBuilderMarkedInsertChunk(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10, 20}, []int64{10, 20}, nil)
+	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels[:1])
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+	preparePartialUpdateCASTestGroups(t, task)
+
+	first, _ := buildPartialUpdateCASTestMessages(t, task.collectionID, partialUpdateCASTestVChannels[:1], []int64{10}, nil, task.partialUpdateCASGroups)
+	second, _ := buildPartialUpdateCASTestMessages(t, task.collectionID, partialUpdateCASTestVChannels[:1], []int64{20}, nil, task.partialUpdateCASGroups)
+	msgs := []streamingmessage.MutableMessage{first[0], second[0]}
+	require.NoError(t, task.attachPartialUpdateCAS(msgs))
+
+	for _, msg := range msgs {
+		meta, err := streamingmessage.ExtractPartialUpdateCAS(msg)
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+	}
+}
+
+func TestAttachPartialUpdateCASRejectsOversizedMessage(t *testing.T) {
+	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, nil)
+	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels[:1])
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+	preparePartialUpdateCASTestGroups(t, task)
+	insertMsgs, _ := buildPartialUpdateCASTestMessages(t, task.collectionID, partialUpdateCASTestVChannels[:1], []int64{10}, nil, task.partialUpdateCASGroups)
+
+	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(insertMsgs[0].EstimateSize()-1)))
+	defer Params.Reset(Params.PulsarCfg.MaxMessageSize.Key)
+
+	err := task.attachPartialUpdateCAS(insertMsgs)
+	require.ErrorIs(t, err, merr.ErrParameterTooLarge)
+}
+
 func TestRetrieveByPKs_Success(t *testing.T) {
 	mockey.PatchConvey("TestRetrieveByPKs_Success", t, func() {
 		// Setup mocks
@@ -677,6 +2037,99 @@ func TestRetrieveByPKs_Success(t *testing.T) {
 		assert.Equal(t, commonpb.ErrorCode_Success, result.Status.ErrorCode)
 		assert.Len(t, result.FieldsData, 1)
 	})
+}
+
+func TestRetrieveByPKsUsesPartialUpdateReadTsAsSnapshotFence(t *testing.T) {
+	const (
+		beginTS = uint64(100)
+		readTS  = uint64(200)
+	)
+	var captured *queryTask
+
+	m := mockey.Mock(typeutil.GetPrimaryFieldSchema).Return(&schemapb.FieldSchema{
+		FieldID:      100,
+		Name:         "id",
+		IsPrimaryKey: true,
+		DataType:     schemapb.DataType_Int64,
+	}, nil).Build()
+	defer m.UnPatch()
+
+	m = mockey.Mock(validatePartitionTag).Return(nil).Build()
+	defer m.UnPatch()
+
+	m = mockey.Mock((*MetaCache).GetPartitionID).Return(int64(1002), nil).Build()
+	defer m.UnPatch()
+
+	m = mockey.Mock(planparserv2.CreateRequeryPlan).Return(&planpb.PlanNode{}).Build()
+	defer m.UnPatch()
+
+	m = mockey.Mock((*Proxy).query).To(
+		func(_ *Proxy, ctx context.Context, qt *queryTask, sp trace.Span) (*milvuspb.QueryResults, segcore.StorageCost, error) {
+			captured = qt
+			return &milvuspb.QueryResults{Status: merr.Success()}, segcore.StorageCost{}, nil
+		},
+	).Build()
+	defer m.UnPatch()
+
+	oldMetaCache := globalMetaCache
+	globalMetaCache = &MetaCache{}
+	defer func() {
+		globalMetaCache = oldMetaCache
+	}()
+
+	task := createTestUpdateTask()
+	task.SetTs(beginTS)
+	task.partialUpdateReadTs = readTS
+	task.partitionKeyMode = false
+	task.upsertMsg = &msgstream.UpsertMsg{
+		DeleteMsg: &msgstream.DeleteMsg{
+			DeleteRequest: &msgpb.DeleteRequest{PartitionName: "_default"},
+		},
+		InsertMsg: &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{PartitionName: "_default"},
+		},
+	}
+
+	ids := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		},
+	}
+	_, _, err := retrieveByPKs(context.Background(), task, ids, []string{"*"})
+
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.NotNil(t, captured.RetrieveRequest)
+	require.Equal(t, commonpb.ConsistencyLevel_Customized, captured.request.GetConsistencyLevel())
+	require.Equal(t, commonpb.ConsistencyLevel_Customized, captured.GetConsistencyLevel())
+	require.Equal(t, readTS, captured.request.GetGuaranteeTimestamp())
+	require.Equal(t, readTS, captured.GetMvccTimestamp())
+	require.Equal(t, readTS, captured.fixedSnapshotTimestamp)
+	require.Equal(t, beginTS, task.BeginTs())
+}
+
+func TestRetrieveByPKsRejectsMissingPartialUpdateReadTs(t *testing.T) {
+	m := mockey.Mock((*Proxy).query).Return(
+		&milvuspb.QueryResults{Status: merr.Success()},
+		segcore.StorageCost{},
+		nil,
+	).Build()
+	defer m.UnPatch()
+
+	task := createTestUpdateTask()
+	task.req.PartialUpdate = true
+	task.SetTs(100)
+	task.partitionKeyMode = true
+
+	ids := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		},
+	}
+	_, _, err := retrieveByPKs(context.Background(), task, ids, []string{"*"})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "partial update read timestamp is unavailable")
 }
 
 func TestRetrieveByPKs_GetPrimaryFieldSchemaError(t *testing.T) {
@@ -954,7 +2407,19 @@ func TestUpdateTask_PreExecute_Success(t *testing.T) {
 			name: "_default",
 		}, nil).Build()
 
-		mockey.Mock((*upsertTask).queryPreExecute).Return(nil).Build()
+		events := make([]string, 0, 2)
+		fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+		fakeWAL.resolveHook = func(string) {
+			events = append(events, "resolve")
+		}
+		oldWAL := streaming.WAL()
+		streaming.SetWALForTest(fakeWAL)
+		defer streaming.SetWALForTest(oldWAL)
+
+		mockey.Mock((*upsertTask).queryPreExecute).To(func(task *upsertTask, ctx context.Context) error {
+			events = append(events, "query")
+			return nil
+		}).Build()
 
 		mockey.Mock((*upsertTask).insertPreExecute).Return(nil).Build()
 
@@ -963,6 +2428,7 @@ func TestUpdateTask_PreExecute_Success(t *testing.T) {
 		// Execute test
 		task := createTestUpdateTask()
 		task.req.PartialUpdate = true
+		setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels)
 
 		err := task.PreExecute(context.Background())
 
@@ -972,7 +2438,60 @@ func TestUpdateTask_PreExecute_Success(t *testing.T) {
 		assert.Equal(t, int64(1001), task.collectionID)
 		assert.NotNil(t, task.schema)
 		assert.NotNil(t, task.upsertMsg)
+		require.GreaterOrEqual(t, len(events), 2)
+		for _, event := range events[:len(events)-1] {
+			require.Equal(t, "resolve", event)
+		}
+		require.Equal(t, "query", events[len(events)-1])
 	})
+}
+
+func TestUpdateTaskPreExecuteSnapshotsOriginalPartialFieldsBeforeMerge(t *testing.T) {
+	oldMetaCache := globalMetaCache
+	globalMetaCache = &MetaCache{}
+	defer func() {
+		globalMetaCache = oldMetaCache
+	}()
+
+	m := mockey.Mock((*MetaCache).GetCollectionID).Return(int64(1001), nil).Build()
+	defer m.UnPatch()
+	schema := createTestSchema()
+	m = mockey.Mock((*MetaCache).GetCollectionInfo).Return(&collectionInfo{
+		updateTimestamp: 12345,
+		schema:          schema,
+	}, nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*MetaCache).GetCollectionSchema).Return(schema, nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock(isPartitionKeyMode).Return(false, nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*MetaCache).GetPartitionInfo).Return(&partitionInfo{name: "_default"}, nil).Build()
+	defer m.UnPatch()
+
+	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+	oldWAL := streaming.WAL()
+	streaming.SetWALForTest(fakeWAL)
+	defer streaming.SetWALForTest(oldWAL)
+
+	m = mockey.Mock((*upsertTask).queryPreExecute).To(func(task *upsertTask, ctx context.Context) error {
+		task.req.FieldsData[1].ValidData = []bool{true, false, true}
+		return nil
+	}).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).insertPreExecute).Return(nil).Build()
+	defer m.UnPatch()
+	m = mockey.Mock((*upsertTask).deletePreExecute).Return(nil).Build()
+	defer m.UnPatch()
+
+	task := createTestUpdateTask()
+	task.req.PartialUpdate = true
+	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels)
+	originalFields := cloneFieldDataList(task.req.GetFieldsData())
+
+	err := task.PreExecute(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, originalFields, task.partialUpdateOriginalFields)
+	require.NotSame(t, task.req.GetFieldsData()[0], task.partialUpdateOriginalFields[0])
 }
 
 func TestUpdateTask_PreExecute_GetCollectionIDError(t *testing.T) {
@@ -1059,9 +2578,14 @@ func TestUpdateTask_PreExecute_QueryPreExecuteError(t *testing.T) {
 
 		expectedErr := merr.WrapErrParameterInvalidMsg("query pre-execute failed")
 		mockey.Mock((*upsertTask).queryPreExecute).Return(expectedErr).Build()
+		fakeWAL := newPartialUpdateCASTestWAL(t, 9)
+		oldWAL := streaming.WAL()
+		streaming.SetWALForTest(fakeWAL)
+		defer streaming.SetWALForTest(oldWAL)
 
 		task := createTestUpdateTask()
 		task.req.PartialUpdate = true
+		setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels)
 
 		err := task.PreExecute(context.Background())
 
@@ -1161,6 +2685,64 @@ func TestUpsertTask_queryPreExecute_MixLogic(t *testing.T) {
 	}
 	assert.NotNil(t, valueField)
 	assert.Equal(t, []int32{100, 200, 300}, valueField.GetScalars().GetIntData().GetData())
+}
+
+func TestUpsertTaskQueryPreExecuteRejectsMissingAutoIDPrimaryKey(t *testing.T) {
+	schema := mustNewSchemaInfo(&schemapb.CollectionSchema{
+		Name:   "test_autoid_partial_update",
+		AutoID: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, AutoID: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+		},
+	})
+	upsertData := []*schemapb.FieldData{
+		{
+			FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2}}}}},
+		},
+		{
+			FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{100, 200}}}}},
+		},
+	}
+	queryResult := &milvuspb.QueryResults{
+		Status: merr.Success(),
+		FieldsData: []*schemapb.FieldData{
+			{
+				FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1}}}}},
+			},
+			{
+				FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{10}}}}},
+			},
+		},
+	}
+	task := &upsertTask{
+		ctx:    context.Background(),
+		schema: schema,
+		req: &milvuspb.UpsertRequest{
+			FieldsData:     upsertData,
+			NumRows:        2,
+			PartialUpdate:  true,
+			CollectionName: "test_autoid_partial_update",
+		},
+		upsertMsg: &msgstream.UpsertMsg{InsertMsg: &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: upsertData,
+				NumRows:    2,
+				Version:    msgpb.InsertDataVersion_ColumnBased,
+			},
+		}},
+		node: &Proxy{},
+	}
+	mockRetrieve := mockey.Mock(retrieveByPKs).Return(queryResult, segcore.StorageCost{}, nil).Build()
+	defer mockRetrieve.UnPatch()
+
+	err := task.queryPreExecute(context.Background())
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.Contains(t, err.Error(), "requires every primary key to exist")
 }
 
 func TestUpsertTask_queryPreExecute_PureInsert(t *testing.T) {
@@ -2649,6 +4231,58 @@ func TestInsertPreExecute_FilterBM25AndMinHashOutputFields(t *testing.T) {
 		assert.Contains(t, remainingFields, "vec")
 		assert.Len(t, remainingFields, 2)
 	})
+}
+
+func TestInsertPreExecutePreservesAutoIDPrimaryKeyForPartialUpdate(t *testing.T) {
+	m := mockey.Mock(common.AllocAutoID).Return(int64(1000), int64(1001), nil).Build()
+	defer m.UnPatch()
+
+	schema := mustNewSchemaInfo(&schemapb.CollectionSchema{
+		Name:   "test_autoid_partial_update",
+		AutoID: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+			{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int32},
+		},
+	})
+	fieldsData := []*schemapb.FieldData{
+		{
+			FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{10}}}}},
+		},
+		{
+			FieldName: "value", FieldId: 101, Type: schemapb.DataType_Int32,
+			Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_IntData{IntData: &schemapb.IntArray{Data: []int32{20}}}}},
+		},
+	}
+	task := &upsertTask{
+		ctx:         context.Background(),
+		schema:      schema,
+		idAllocator: &allocator.IDAllocator{},
+		req: &milvuspb.UpsertRequest{
+			CollectionName: "test_autoid_partial_update",
+			PartialUpdate:  true,
+		},
+		upsertMsg: &msgstream.UpsertMsg{InsertMsg: &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				CollectionName: "test_autoid_partial_update",
+				PartitionName:  Params.CommonCfg.DefaultPartitionName.GetValue(),
+				FieldsData:     fieldsData,
+				NumRows:        1,
+				Version:        msgpb.InsertDataVersion_ColumnBased,
+			},
+		}},
+		result: &milvuspb.MutationResult{},
+	}
+
+	err := task.insertPreExecute(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int64{10}, task.result.GetIDs().GetIntId().GetData())
+	require.Equal(t, []int64{10}, task.oldIDs.GetIntId().GetData())
+	primaryField, err := typeutil.GetPrimaryFieldData(task.upsertMsg.InsertMsg.GetFieldsData(), schema.Fields[0])
+	require.NoError(t, err)
+	require.Equal(t, []int64{10}, primaryField.GetScalars().GetLongData().GetData())
+	require.Equal(t, []int64{1000}, task.upsertMsg.InsertMsg.GetRowIDs())
 }
 
 func TestUpsertTask_queryPreExecute_NullableFields(t *testing.T) {

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/bytedance/mockey"
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -1119,6 +1121,230 @@ func TestRepackInsertDataForStreamingServiceCASMetadata(t *testing.T) {
 		map[string]*messagespb.PartialUpdateCAS{vchannel: nil},
 	)
 	require.Error(t, err)
+
+	task, vchannel, groups = newInput()
+	groups[vchannel].ReadTs = 0
+	_, err = repackInsertDataForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		nil,
+		1,
+		groups,
+	)
+	require.ErrorIs(t, err, merr.ErrServiceInternal)
+}
+
+func TestRepackInsertDataForStreamingServiceSplitsOversizedCASMessage(t *testing.T) {
+	oldMetaCache := globalMetaCache
+	globalMetaCache = &MetaCache{}
+	t.Cleanup(func() { globalMetaCache = oldMetaCache })
+	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
+	defer partitionPatch.UnPatch()
+
+	pks := []int64{10, 20}
+	task := partialUpdateCASRealPackTestTask(t, pks, pks, nil)
+	vchannel := partialUpdateCASTestVChannels[0]
+	groups := map[string]*messagespb.PartialUpdateCAS{
+		vchannel: {
+			ReadTs:               100,
+			ObservedPchannelTerm: 1,
+			CollectionId:         task.collectionID,
+			PrimaryKeyFieldId:    100,
+		},
+	}
+
+	unsplit, err := repackInsertDataForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		nil,
+		1,
+		groups,
+	)
+	require.NoError(t, err)
+	require.Len(t, unsplit, 1)
+	maxMessageSize := unsplit[0].EstimateSize() - 1
+	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(maxMessageSize)))
+	t.Cleanup(func() { Params.Reset(Params.PulsarCfg.MaxMessageSize.Key) })
+
+	msgs, err := repackInsertDataForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		nil,
+		1,
+		groups,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	rowIDs := make([]int64, 0, len(pks))
+	for _, msg := range msgs {
+		require.LessOrEqual(t, msg.EstimateSize(), maxMessageSize)
+		require.True(t, streamingmessage.HasPartialUpdateCAS(msg))
+		meta, err := streamingmessage.ExtractPartialUpdateCAS(msg)
+		require.NoError(t, err)
+		require.True(t, proto.Equal(groups[vchannel], meta))
+		body := streamingmessage.MustAsMutableInsertMessageV1(msg).MustBody()
+		rowIDs = append(rowIDs, body.GetRowIDs()...)
+	}
+	require.Equal(t, []int64{101, 102}, rowIDs)
+}
+
+func TestRepackInsertDataForStreamingServiceRejectsOversizedSingleRow(t *testing.T) {
+	oldMetaCache := globalMetaCache
+	globalMetaCache = &MetaCache{}
+	t.Cleanup(func() { globalMetaCache = oldMetaCache })
+	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
+	defer partitionPatch.UnPatch()
+
+	task := partialUpdateCASRealPackTestTask(t, []int64{10}, []int64{10}, nil)
+	vchannel := partialUpdateCASTestVChannels[0]
+	groups := map[string]*messagespb.PartialUpdateCAS{
+		vchannel: {
+			ReadTs:               100,
+			ObservedPchannelTerm: 1,
+			CollectionId:         task.collectionID,
+			PrimaryKeyFieldId:    100,
+		},
+	}
+
+	baseline, err := repackInsertDataForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		nil,
+		1,
+		groups,
+	)
+	require.NoError(t, err)
+	require.Len(t, baseline, 1)
+	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(baseline[0].EstimateSize()-1)))
+	t.Cleanup(func() { Params.Reset(Params.PulsarCfg.MaxMessageSize.Key) })
+
+	_, err = repackInsertDataForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		nil,
+		1,
+		groups,
+	)
+	require.ErrorIs(t, err, merr.ErrParameterTooLarge)
+}
+
+func TestRepackInsertDataByPartitionForStreamingServicePropagatesPackingError(t *testing.T) {
+	task := partialUpdateCASRealPackTestTask(t, []int64{10}, []int64{10}, nil)
+	task.upsertMsg.InsertMsg.FieldsData = []*schemapb.FieldData{
+		{
+			Type: schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := repackInsertDataByPartitionForStreamingService(
+		context.Background(),
+		200,
+		"_default",
+		[]int{0},
+		partialUpdateCASTestVChannels[0],
+		task.upsertMsg.InsertMsg,
+		nil,
+		1,
+		nil,
+	)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+}
+
+func TestRepackInsertDataByPartitionForStreamingServicePreservesEntityPackingOrder(t *testing.T) {
+	pks := []int64{10, 20}
+	task := partialUpdateCASRealPackTestTask(t, pks, pks, nil)
+	task.upsertMsg.InsertMsg.HashValues = []uint32{0, 0}
+	task.upsertMsg.InsertMsg.FieldsData = []*schemapb.FieldData{
+		{
+			FieldId: 100,
+			Type:    schemapb.DataType_VarChar,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{Data: []string{
+							strings.Repeat("a", 4096),
+							strings.Repeat("b", 4096),
+						}},
+					},
+				},
+			},
+		},
+	}
+	meta := &messagespb.PartialUpdateCAS{
+		ReadTs:               100,
+		ObservedPchannelTerm: 1,
+		CollectionId:         task.collectionID,
+		PrimaryKeyFieldId:    100,
+	}
+
+	baseline, err := repackInsertDataByPartitionForStreamingService(
+		context.Background(),
+		200,
+		"_default",
+		[]int{0},
+		partialUpdateCASTestVChannels[0],
+		task.upsertMsg.InsertMsg,
+		nil,
+		1,
+		meta,
+	)
+	require.NoError(t, err)
+	require.Len(t, baseline, 1)
+	maxMessageSize := baseline[0].EstimateSize()
+	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(maxMessageSize)))
+	t.Cleanup(func() { Params.Reset(Params.PulsarCfg.MaxMessageSize.Key) })
+
+	entityPacked, err := genInsertMsgsByPartition(
+		context.Background(),
+		0,
+		200,
+		"_default",
+		[]int{0, 1},
+		partialUpdateCASTestVChannels[0],
+		task.upsertMsg.InsertMsg,
+	)
+	require.NoError(t, err)
+	require.Len(t, entityPacked, 2)
+
+	msgs, err := repackInsertDataByPartitionForStreamingService(
+		context.Background(),
+		200,
+		"_default",
+		[]int{0, 1},
+		partialUpdateCASTestVChannels[0],
+		task.upsertMsg.InsertMsg,
+		nil,
+		1,
+		meta,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	rowIDs := make([]int64, 0, len(pks))
+	for _, msg := range msgs {
+		require.LessOrEqual(t, msg.EstimateSize(), maxMessageSize)
+		body := streamingmessage.MustAsMutableInsertMessageV1(msg).MustBody()
+		rowIDs = append(rowIDs, body.GetRowIDs()...)
+	}
+	require.Equal(t, []int64{101, 102}, rowIDs)
 }
 
 func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testing.T) {
@@ -1189,6 +1415,89 @@ func TestRepackInsertDataWithPartitionKeyForStreamingServiceCASMetadata(t *testi
 		map[string]*messagespb.PartialUpdateCAS{vchannel: nil},
 	)
 	require.Error(t, err)
+
+	task, vchannel, groups = newInput()
+	groups[vchannel].ReadTs = 0
+	_, err = repackInsertDataWithPartitionKeyForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		task.partitionKeys,
+		nil,
+		task.schema.CollectionSchema,
+		1,
+		groups,
+	)
+	require.ErrorIs(t, err, merr.ErrServiceInternal)
+}
+
+func TestRepackInsertDataWithPartitionKeyForStreamingServiceSplitsOversizedCASMessage(t *testing.T) {
+	oldMetaCache := globalMetaCache
+	globalMetaCache = &MetaCache{}
+	t.Cleanup(func() { globalMetaCache = oldMetaCache })
+	partitionsPatch := mockey.Mock((*MetaCache).GetPartitions).
+		Return(map[string]int64{"_default_0": 200}, nil).
+		Build()
+	defer partitionsPatch.UnPatch()
+	partitionPatch := mockey.Mock((*MetaCache).GetPartitionID).Return(int64(200), nil).Build()
+	defer partitionPatch.UnPatch()
+
+	pks := []int64{10, 20}
+	task := partialUpdateCASRealPackTestTask(t, pks, pks, nil)
+	task.partitionKeys = partialUpdateCASPKFieldData(pks)
+	vchannel := partialUpdateCASTestVChannels[0]
+	groups := map[string]*messagespb.PartialUpdateCAS{
+		vchannel: {
+			ReadTs:               100,
+			ObservedPchannelTerm: 1,
+			CollectionId:         task.collectionID,
+			PrimaryKeyFieldId:    100,
+		},
+	}
+
+	unsplit, err := repackInsertDataWithPartitionKeyForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		task.partitionKeys,
+		nil,
+		task.schema.CollectionSchema,
+		1,
+		groups,
+	)
+	require.NoError(t, err)
+	require.Len(t, unsplit, 1)
+	maxMessageSize := unsplit[0].EstimateSize() - 1
+	require.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, strconv.Itoa(maxMessageSize)))
+	t.Cleanup(func() { Params.Reset(Params.PulsarCfg.MaxMessageSize.Key) })
+
+	msgs, err := repackInsertDataWithPartitionKeyForStreamingService(
+		context.Background(),
+		[]string{vchannel},
+		task.upsertMsg.InsertMsg,
+		task.result,
+		task.partitionKeys,
+		nil,
+		task.schema.CollectionSchema,
+		1,
+		groups,
+	)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	rowIDs := make([]int64, 0, len(pks))
+	for _, msg := range msgs {
+		require.LessOrEqual(t, msg.EstimateSize(), maxMessageSize)
+		require.True(t, streamingmessage.HasPartialUpdateCAS(msg))
+		meta, err := streamingmessage.ExtractPartialUpdateCAS(msg)
+		require.NoError(t, err)
+		require.True(t, proto.Equal(groups[vchannel], meta))
+		body := streamingmessage.MustAsMutableInsertMessageV1(msg).MustBody()
+		rowIDs = append(rowIDs, body.GetRowIDs()...)
+	}
+	require.Equal(t, []int64{101, 102}, rowIDs)
 }
 
 func TestInsertTaskExecuteSelectsPartitionRouting(t *testing.T) {
@@ -1910,6 +2219,63 @@ func TestAttachPartialUpdateCASValidatesPreparedGroups(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAttachPartialUpdateCASRejectsVChannelMismatch(t *testing.T) {
+	newMeta := func(collectionID int64) *messagespb.PartialUpdateCAS {
+		return &messagespb.PartialUpdateCAS{
+			ReadTs:               100,
+			ObservedPchannelTerm: 1,
+			CollectionId:         collectionID,
+			PrimaryKeyFieldId:    100,
+		}
+	}
+
+	t.Run("message vchannel is not in snapshot", func(t *testing.T) {
+		task, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, nil)
+		knownChannel := partialUpdateCASTestVChannels[0]
+		unknownChannel := partialUpdateCASTestVChannels[1]
+		task.partialUpdateCASGroups = map[string]*messagespb.PartialUpdateCAS{
+			knownChannel: newMeta(task.collectionID),
+		}
+		messageGroups := map[string]*messagespb.PartialUpdateCAS{
+			unknownChannel: newMeta(task.collectionID),
+		}
+		insertMsgs, _ := buildPartialUpdateCASTestMessages(
+			t,
+			task.collectionID,
+			[]string{unknownChannel},
+			[]int64{10},
+			nil,
+			messageGroups,
+		)
+
+		err := task.attachPartialUpdateCAS(insertMsgs)
+		require.ErrorIs(t, err, merr.ErrServiceInternal)
+		require.Contains(t, err.Error(), "no CAS metadata")
+	})
+
+	t.Run("snapshot vchannel has no insert message", func(t *testing.T) {
+		task, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, nil)
+		presentChannel := partialUpdateCASTestVChannels[0]
+		missingChannel := partialUpdateCASTestVChannels[1]
+		task.partialUpdateCASGroups = map[string]*messagespb.PartialUpdateCAS{
+			presentChannel: newMeta(task.collectionID),
+			missingChannel: newMeta(task.collectionID),
+		}
+		insertMsgs, _ := buildPartialUpdateCASTestMessages(
+			t,
+			task.collectionID,
+			[]string{presentChannel},
+			[]int64{10},
+			nil,
+			task.partialUpdateCASGroups,
+		)
+
+		err := task.attachPartialUpdateCAS(insertMsgs)
+		require.ErrorIs(t, err, merr.ErrServiceInternal)
+		require.Contains(t, err.Error(), "no insert message")
+	})
+}
+
 func TestPartialUpdateCASMetadataSizeIsBounded(t *testing.T) {
 	smallTask, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, nil)
 	setPartialUpdateCASTestChannels(smallTask, partialUpdateCASTestVChannels[:1])
@@ -1953,7 +2319,7 @@ func TestAttachPartialUpdateCASAcceptsEveryBuilderMarkedInsertChunk(t *testing.T
 	}
 }
 
-func TestAttachPartialUpdateCASRejectsOversizedMessage(t *testing.T) {
+func TestAttachPartialUpdateCASRejectsOversizedInvariant(t *testing.T) {
 	task, _, _ := partialUpdateCASTestTask(t, true, []int64{10}, []int64{10}, nil)
 	setPartialUpdateCASTestChannels(task, partialUpdateCASTestVChannels[:1])
 	fakeWAL := newPartialUpdateCASTestWAL(t, 9)
@@ -1967,7 +2333,7 @@ func TestAttachPartialUpdateCASRejectsOversizedMessage(t *testing.T) {
 	defer Params.Reset(Params.PulsarCfg.MaxMessageSize.Key)
 
 	err := task.attachPartialUpdateCAS(insertMsgs)
-	require.ErrorIs(t, err, merr.ErrParameterTooLarge)
+	require.ErrorIs(t, err, merr.ErrServiceInternal)
 }
 
 func TestRetrieveByPKs_Success(t *testing.T) {

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2383,7 +2383,13 @@ func checkInputUtf8Compatiable(allFields []*schemapb.FieldSchema, insertMsg *msg
 	return nil
 }
 
-func checkUpsertPrimaryFieldData(ctx context.Context, allFields []*schemapb.FieldSchema, schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) (*schemapb.IDs, *schemapb.IDs, error) {
+func checkUpsertPrimaryFieldData(
+	ctx context.Context,
+	allFields []*schemapb.FieldSchema,
+	schema *schemapb.CollectionSchema,
+	insertMsg *msgstream.InsertMsg,
+	preserveAutoIDPrimaryKey bool,
+) (*schemapb.IDs, *schemapb.IDs, error) {
 	log := mlog.With(mlog.String("collectionName", insertMsg.CollectionName))
 	rowNums := uint32(insertMsg.NRows())
 	// TODO(dragondriver): in fact, NumRows is not trustable, we should check all input fields
@@ -2412,9 +2418,8 @@ func checkUpsertPrimaryFieldData(ctx context.Context, allFields []*schemapb.Fiel
 	for i, field := range insertMsg.GetFieldsData() {
 		if field.FieldId == primaryFieldID || field.FieldName == primaryFieldName {
 			primaryFieldData = field
-			if primaryFieldSchema.AutoID {
-				// use the passed pk as new pk when autoID == false
-				// automatic generate pk as new pk wehen autoID == true
+			if primaryFieldSchema.AutoID && !preserveAutoIDPrimaryKey {
+				// Normal AutoID upsert deletes the supplied PK and inserts a new PK.
 				newPrimaryFieldData, err = autoGenPrimaryFieldData(primaryFieldSchema, insertMsg.GetRowIDs())
 				if err != nil {
 					log.Info(ctx, "generate new primary field data failed when upsert", mlog.Err(err))
@@ -2437,7 +2442,7 @@ func checkUpsertPrimaryFieldData(ctx context.Context, allFields []*schemapb.Fiel
 		log.Warn(ctx, "parse primary field data to IDs failed", mlog.Err(err))
 		return nil, nil, err
 	}
-	if !primaryFieldSchema.GetAutoID() {
+	if !primaryFieldSchema.GetAutoID() || preserveAutoIDPrimaryKey {
 		return ids, ids, nil
 	}
 	newIDs, err := parsePrimaryFieldData2IDs(newPrimaryFieldData)

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2037,7 +2037,7 @@ func Test_UpsertTaskCheckPrimaryFieldData(t *testing.T) {
 				Status: merr.Success(),
 			},
 		}
-		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg)
+		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg, false)
 		assert.NotEqual(t, nil, err)
 	})
 
@@ -2081,7 +2081,7 @@ func Test_UpsertTaskCheckPrimaryFieldData(t *testing.T) {
 				Status: merr.Success(),
 			},
 		}
-		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg)
+		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg, false)
 		assert.NotEqual(t, nil, err)
 	})
 
@@ -2122,7 +2122,7 @@ func Test_UpsertTaskCheckPrimaryFieldData(t *testing.T) {
 				Status: merr.Success(),
 			},
 		}
-		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg)
+		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg, false)
 		assert.NotEqual(t, nil, err)
 	})
 
@@ -2167,7 +2167,7 @@ func Test_UpsertTaskCheckPrimaryFieldData(t *testing.T) {
 				Status: merr.Success(),
 			},
 		}
-		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg)
+		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg, false)
 		assert.NotEqual(t, nil, err)
 	})
 
@@ -2218,7 +2218,7 @@ func Test_UpsertTaskCheckPrimaryFieldData(t *testing.T) {
 				Status: merr.Success(),
 			},
 		}
-		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg)
+		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg, false)
 		assert.NotEqual(t, nil, err)
 	})
 
@@ -2259,7 +2259,7 @@ func Test_UpsertTaskCheckPrimaryFieldData(t *testing.T) {
 				Status: merr.Success(),
 			},
 		}
-		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg)
+		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg, false)
 		assert.NoError(t, nil, err)
 
 		// autoid==false
@@ -2298,11 +2298,11 @@ func Test_UpsertTaskCheckPrimaryFieldData(t *testing.T) {
 				Status: merr.Success(),
 			},
 		}
-		_, _, err = checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg)
+		_, _, err = checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg, false)
 		assert.NoError(t, nil, err)
 	})
 
-	t.Run("will generate new pk when autoid == true", func(t *testing.T) {
+	t.Run("handle autoid primary key modes", func(t *testing.T) {
 		// autoid==true
 		task := insertTask{
 			schema: &schemapb.CollectionSchema{
@@ -2349,10 +2349,16 @@ func Test_UpsertTaskCheckPrimaryFieldData(t *testing.T) {
 				Status: merr.Success(),
 			},
 		}
-		_, _, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg)
+		ids, oldIDs, err := checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg, true)
+		assert.NoError(t, err)
+		assert.Equal(t, []int64{2}, task.insertMsg.FieldsData[0].GetScalars().GetLongData().GetData())
+		assert.Equal(t, []int64{2}, ids.GetIntId().GetData())
+		assert.Equal(t, []int64{2}, oldIDs.GetIntId().GetData())
+
+		_, _, err = checkUpsertPrimaryFieldData(context.TODO(), task.schema.Fields, task.schema, task.insertMsg, false)
 		newPK := task.insertMsg.FieldsData[0].GetScalars().GetLongData().GetData()
 		assert.Equal(t, newPK, task.insertMsg.RowIDs)
-		assert.NoError(t, nil, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/internal/streamingnode/server/wal/interceptors/chain_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/chain_interceptor_test.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/wal/mock_interceptors"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
-	"github.com/milvus-io/milvus/pkg/v3/mocks/streaming/util/mock_message"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -87,60 +87,72 @@ func TestChainReady(t *testing.T) {
 	}
 }
 
-func testChainInterceptor(t *testing.T, count int, named bool) {
-	type record struct {
-		before bool
-		after  bool
-		closed bool
-	}
+type chainInterceptorRecord struct {
+	before bool
+	after  bool
+	closed bool
+}
 
-	appendInterceptorRecords := make([]record, 0, count)
+type chainInterceptorStub struct {
+	record *chainInterceptorRecord
+	delay  time.Duration
+}
+
+func (s *chainInterceptorStub) DoAppend(
+	ctx context.Context,
+	msg message.MutableMessage,
+	appendOp interceptors.Append,
+) (message.MessageID, error) {
+	s.record.before = true
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	msgID, err := appendOp(ctx, msg)
+	s.record.after = true
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	return msgID, err
+}
+
+func (s *chainInterceptorStub) Close() {
+	s.record.closed = true
+}
+
+type namedChainInterceptorStub struct {
+	*chainInterceptorStub
+	name string
+}
+
+func (s *namedChainInterceptorStub) Name() string {
+	return s.name
+}
+
+func testChainInterceptor(t *testing.T, count int, named bool) {
+	appendInterceptorRecords := make([]chainInterceptorRecord, count)
 	ips := make([]interceptors.Interceptor, 0, count)
 	for i := 0; i < count; i++ {
-		j := i
-		appendInterceptorRecords = append(appendInterceptorRecords, record{})
-
-		if !named {
-			interceptor := mock_interceptors.NewMockInterceptor(t)
-
-			interceptor.EXPECT().DoAppend(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-				func(ctx context.Context, mm message.MutableMessage, f func(context.Context, message.MutableMessage) (message.MessageID, error)) (message.MessageID, error) {
-					appendInterceptorRecords[j].before = true
-					msgID, err := f(ctx, mm)
-					appendInterceptorRecords[j].after = true
-					return msgID, err
-				})
-			interceptor.EXPECT().Close().Run(func() {
-				appendInterceptorRecords[j].closed = true
+		interceptor := &chainInterceptorStub{record: &appendInterceptorRecords[i]}
+		if named {
+			interceptor.delay = time.Microsecond
+			ips = append(ips, &namedChainInterceptorStub{
+				chainInterceptorStub: interceptor,
+				name:                 fmt.Sprintf("interceptor-%d", i),
 			})
-			ips = append(ips, interceptor)
-		} else {
-			interceptor := mock_interceptors.NewMockInterceptorWithMetrics(t)
-			interceptor.EXPECT().DoAppend(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-				func(ctx context.Context, mm message.MutableMessage, f func(context.Context, message.MutableMessage) (message.MessageID, error)) (message.MessageID, error) {
-					appendInterceptorRecords[j].before = true
-					// time.Sleep(time.Duration(j) * 10 * time.Millisecond)
-					msgID, err := f(ctx, mm)
-					appendInterceptorRecords[j].after = true
-					// time.Sleep(time.Duration(j) * 20 * time.Millisecond)
-					return msgID, err
-				})
-			interceptor.EXPECT().Name().Return(fmt.Sprintf("interceptor-%d", j))
-			interceptor.EXPECT().Close().Run(func() {
-				appendInterceptorRecords[j].closed = true
-			})
-			ips = append(ips, interceptor)
+			continue
 		}
+		ips = append(ips, interceptor)
 	}
 	interceptor := interceptors.NewChainedInterceptor(ips...)
 
 	// fast return
 	<-interceptor.Ready()
 
-	msg := mock_message.NewMockMutableMessage(t)
-	msg.EXPECT().MessageType().Return(message.MessageTypeDelete).Maybe()
-	msg.EXPECT().EstimateSize().Return(1).Maybe()
-	msg.EXPECT().TxnContext().Return(nil).Maybe()
+	msg := message.NewDeleteMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&messagespb.DeleteMessageHeader{CollectionId: 1, Rows: 1}).
+		WithBody(&msgpb.DeleteRequest{}).
+		MustBuildMutable()
 	mw := metricsutil.NewWriteMetrics(types.PChannelInfo{}, message.WALNameRocksmq)
 	m := mw.StartAppend(msg)
 	ctx := utility.WithAppendMetricsContext(context.Background(), m)

--- a/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor.go
@@ -28,7 +28,6 @@ func (r *lockAppendInterceptor) DoAppend(ctx context.Context, msg message.Mutabl
 
 // acquireLockGuard acquires the lock for the vchannel and return a function as a guard.
 func (r *lockAppendInterceptor) acquireLockGuard(_ context.Context, msg message.MutableMessage) func() {
-	// Acquire the write lock for the vchannel.
 	vchannel := msg.VChannel()
 	if msg.MessageType().IsExclusiveRequired() {
 		if vchannel == "" || vchannel == r.channel.Name || msg.IsPChannelLevel() {
@@ -39,6 +38,7 @@ func (r *lockAppendInterceptor) acquireLockGuard(_ context.Context, msg message.
 				r.glock.Unlock()
 			}
 		} else if !funcutil.IsControlChannel(vchannel) {
+			r.glock.RLock()
 			r.vchannelLocker.Lock(vchannel)
 			return func() {
 				// For exclusive messages, we need to fail all transactions at the vchannel.
@@ -51,6 +51,7 @@ func (r *lockAppendInterceptor) acquireLockGuard(_ context.Context, msg message.
 				// the append operation of exclusive message should be low rate, so it's acceptable to fail all transactions at the vchannel.
 				r.txnManager.FailTxnAtVChannel(vchannel)
 				r.vchannelLocker.Unlock(vchannel)
+				r.glock.RUnlock()
 			}
 		}
 		// Collection-scoped DDL is exclusive on its data VChannels. Its
@@ -58,6 +59,15 @@ func (r *lockAppendInterceptor) acquireLockGuard(_ context.Context, msg message.
 		// non-conflicting resource keys can append concurrently. Conflicting
 		// DDL is serialized by the broadcaster resource-key lock. PChannel-level
 		// messages already acquire the global write lock above.
+	}
+	if msg.MessageType() == message.MessageTypeCommitTxn &&
+		message.HasPartialUpdateCAS(msg) && msg.ReplicateHeader() == nil {
+		r.glock.RLock()
+		r.vchannelLocker.Lock(vchannel)
+		return func() {
+			r.vchannelLocker.Unlock(vchannel)
+			r.glock.RUnlock()
+		}
 	}
 	r.glock.RLock()
 	r.vchannelLocker.RLock(vchannel)

--- a/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/lock/lock_interceptor_test.go
@@ -3,9 +3,11 @@ package lock
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
@@ -73,7 +75,8 @@ func TestAcquireLockGuard(t *testing.T) {
 		interceptor.glock.RUnlock()
 	})
 
-	// Test: Exclusive message on regular vchannel should acquire per-vchannel lock only (not global).
+	// Test: Exclusive message on regular vchannel should acquire the global
+	// read lock before the per-vchannel write lock.
 	t.Run("ExclusiveOnRegularVChannel", func(t *testing.T) {
 		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
 		defer mocker.UnPatch()
@@ -86,8 +89,8 @@ func TestAcquireLockGuard(t *testing.T) {
 			MustBuildMutable()
 
 		guard := interceptor.acquireLockGuard(context.Background(), msg)
-		// glock should NOT be write-locked.
-		assert.True(t, interceptor.glock.TryRLock(), "glock should not be write-locked for exclusive message on regular vchannel")
+		assert.False(t, interceptor.glock.TryLock(), "glock write lock should fail while the shared hierarchy lock is held")
+		assert.True(t, interceptor.glock.TryRLock(), "glock read lock should remain shareable")
 		interceptor.glock.RUnlock()
 		// Per-vchannel write lock should be held.
 		assert.False(t, interceptor.vchannelLocker.TryLock(testVChannel), "vchannel lock should be held")
@@ -121,6 +124,34 @@ func TestAcquireLockGuard(t *testing.T) {
 		guard()
 	})
 
+	t.Run("PartialUpdateCASCommit", func(t *testing.T) {
+		failCalls := 0
+		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).To(
+			func(*txn.TxnManager, string) {
+				failCalls++
+			},
+		).Build()
+		defer mocker.UnPatch()
+
+		interceptor := newTestInterceptor()
+		msg := message.NewCommitTxnMessageBuilderV2().
+			WithVChannel(testVChannel).
+			WithHeader(&message.CommitTxnMessageHeader{}).
+			WithBody(&message.CommitTxnMessageBody{}).
+			MustBuildMutable()
+		assert.NoError(t, message.MarkPartialUpdateCASCommit(msg))
+
+		guard := interceptor.acquireLockGuard(context.Background(), msg)
+		assert.False(t, interceptor.glock.TryLock())
+		assert.True(t, interceptor.glock.TryRLock())
+		interceptor.glock.RUnlock()
+		assert.False(t, interceptor.vchannelLocker.TryLock(testVChannel))
+		assert.True(t, interceptor.vchannelLocker.TryLock("other-vchannel"))
+		interceptor.vchannelLocker.Unlock("other-vchannel")
+		guard()
+		assert.Equal(t, 0, failCalls)
+	})
+
 	// Test: Non-exclusive message on regular vchannel should acquire read locks on both glock and vchannel.
 	t.Run("NonExclusiveOnRegularVChannel", func(t *testing.T) {
 		mocker := mockey.Mock((*txn.TxnManager).FailTxnAtVChannel).Return().Build()
@@ -149,4 +180,158 @@ func TestAcquireLockGuard(t *testing.T) {
 		interceptor.vchannelLocker.RUnlock(testVChannel)
 		guard()
 	})
+}
+
+func TestPartialUpdateCASCommitWaitsForSameVChannelWriter(t *testing.T) {
+	interceptor := newTestInterceptor()
+	writer := newLockTestInsertMessage(testVChannel)
+	commit := newLockTestCASCommit(t, testVChannel)
+	writerStarted := make(chan struct{})
+	releaseWriter := make(chan struct{})
+	writerDone := make(chan error, 1)
+	go func() {
+		_, err := interceptor.DoAppend(context.Background(), writer, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			close(writerStarted)
+			<-releaseWriter
+			return nil, nil
+		})
+		writerDone <- err
+	}()
+	<-writerStarted
+
+	commitEntered := make(chan struct{})
+	commitDone := make(chan error, 1)
+	go func() {
+		_, err := interceptor.DoAppend(context.Background(), commit, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			close(commitEntered)
+			return nil, nil
+		})
+		commitDone <- err
+	}()
+
+	select {
+	case <-commitEntered:
+		close(releaseWriter)
+		require.NoError(t, <-writerDone)
+		t.Fatal("CAS commit entered while a same-vchannel writer still held the read lock")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseWriter)
+	require.NoError(t, <-writerDone)
+	select {
+	case <-commitEntered:
+	case <-time.After(time.Second):
+		t.Fatal("CAS commit did not resume after the writer released the lock")
+	}
+	require.NoError(t, <-commitDone)
+}
+
+func TestPartialUpdateCASCommitsOnDifferentVChannelsProceedConcurrently(t *testing.T) {
+	interceptor := newTestInterceptor()
+	first := newLockTestCASCommit(t, testVChannel)
+	second := newLockTestCASCommit(t, "test-pchannel_other-v0")
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := interceptor.DoAppend(context.Background(), first, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			close(firstStarted)
+			<-releaseFirst
+			return nil, nil
+		})
+		firstDone <- err
+	}()
+	<-firstStarted
+
+	secondEntered := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := interceptor.DoAppend(context.Background(), second, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			close(secondEntered)
+			return nil, nil
+		})
+		secondDone <- err
+	}()
+
+	select {
+	case <-secondEntered:
+	case <-time.After(time.Second):
+		close(releaseFirst)
+		require.NoError(t, <-firstDone)
+		t.Fatal("different vchannels shared one CAS commit lock")
+	}
+	require.NoError(t, <-secondDone)
+	close(releaseFirst)
+	require.NoError(t, <-firstDone)
+}
+
+func TestPChannelExclusiveWaitsForSharedWriter(t *testing.T) {
+	interceptor := newTestInterceptor()
+	writerStarted := make(chan struct{})
+	releaseWriter := make(chan struct{})
+	writerDone := make(chan error, 1)
+	go func() {
+		_, err := interceptor.DoAppend(context.Background(), newLockTestInsertMessage(testVChannel), func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			close(writerStarted)
+			<-releaseWriter
+			return nil, nil
+		})
+		writerDone <- err
+	}()
+	<-writerStarted
+
+	exclusive := message.NewManualFlushMessageBuilderV2().
+		WithVChannel(testPChannelName).
+		WithHeader(&message.ManualFlushMessageHeader{CollectionId: 1}).
+		WithBody(&message.ManualFlushMessageBody{}).
+		MustBuildMutable()
+	exclusiveEntered := make(chan struct{})
+	exclusiveDone := make(chan error, 1)
+	go func() {
+		_, err := interceptor.DoAppend(context.Background(), exclusive, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			close(exclusiveEntered)
+			return nil, nil
+		})
+		exclusiveDone <- err
+	}()
+
+	select {
+	case <-exclusiveEntered:
+		close(releaseWriter)
+		require.NoError(t, <-writerDone)
+		t.Fatal("PChannel-exclusive message bypassed an active shared writer")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseWriter)
+	require.NoError(t, <-writerDone)
+	select {
+	case <-exclusiveEntered:
+	case <-time.After(time.Second):
+		t.Fatal("PChannel-exclusive message did not resume")
+	}
+	require.NoError(t, <-exclusiveDone)
+}
+
+func newLockTestInsertMessage(vchannel string) message.MutableMessage {
+	return message.NewInsertMessageBuilderV1().
+		WithVChannel(vchannel).
+		WithHeader(&messagespb.InsertMessageHeader{
+			CollectionId: 1,
+			Partitions: []*messagespb.PartitionSegmentAssignment{
+				{PartitionId: 1, Rows: 1, BinarySize: 100},
+			},
+		}).
+		WithBody(&msgpb.InsertRequest{}).
+		MustBuildMutable()
+}
+
+func newLockTestCASCommit(t *testing.T, vchannel string) message.MutableMessage {
+	t.Helper()
+	msg := message.NewCommitTxnMessageBuilderV2().
+		WithVChannel(vchannel).
+		WithHeader(&message.CommitTxnMessageHeader{}).
+		WithBody(&message.CommitTxnMessageBody{}).
+		MustBuildMutable()
+	require.NoError(t, message.MarkPartialUpdateCASCommit(msg))
+	return msg
 }

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/admission.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/admission.go
@@ -1,0 +1,225 @@
+package partialupdate
+
+import (
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+)
+
+// partialUpdateState owns write tracking and CAS admission for one WAL term.
+type partialUpdateState struct {
+	channel             types.PChannelInfo
+	pkVersions          *pkVersionIndex
+	fences              *collectionFenceIndex
+	incompleteTxnFences *vchannelFenceIndex
+	txnMu               sync.RWMutex
+	txns                map[message.TxnID]*pendingTxn
+}
+
+func newPartialUpdateState(versionIndexTTL time.Duration, maxVersionIndexBytes int64) *partialUpdateState {
+	return &partialUpdateState{
+		pkVersions:          newPKVersionIndex(versionIndexTTL, maxVersionIndexBytes),
+		fences:              newCollectionFenceIndex(),
+		incompleteTxnFences: newVChannelFenceIndex(),
+		txns:                make(map[message.TxnID]*pendingTxn),
+	}
+}
+
+// removeDroppedVChannel releases all proof state after DropCollection is
+// durably appended under the vchannel exclusive lock.
+func (s *partialUpdateState) removeDroppedVChannel(vchannel string, collectionID int64) {
+	s.pkVersions.Remove(vchannel)
+	s.incompleteTxnFences.Remove(vchannel)
+	s.fences.Remove(vchannel, collectionID)
+}
+
+func (s *partialUpdateState) registerTxnCleanup(session *txn.TxnSession, timetick uint64) {
+	if session == nil {
+		return
+	}
+	txnID := session.TxnContext().TxnID
+	if !s.markTxnCleanup(txnID) {
+		return
+	}
+	session.RegisterCleanup(func() {
+		s.deleteTxn(txnID)
+	}, timetick)
+}
+
+// validateCommit snapshots a completed transaction and validates local CAS
+// proof before CommitTxn reaches the WAL.
+func (s *partialUpdateState) validateCommit(msg message.MutableMessage, txnID message.TxnID) (*pendingTxn, error) {
+	if msg == nil || msg.VChannel() == "" {
+		return nil, status.NewUnrecoverableError("partial update commit vchannel is empty")
+	}
+	txnState := s.getTxn(txnID)
+	marker := message.HasPartialUpdateCAS(msg)
+	if txnState != nil && txnState.meta != nil && !marker {
+		return nil, status.NewUnrecoverableError("partial update transaction %d commit marker is missing", txnID)
+	}
+	if txnState == nil || !txnState.observedBegin {
+		if marker && msg.ReplicateHeader() == nil {
+			return nil, status.NewPartialUpdateRetryable(
+				"partial update transaction %d has no complete runtime proof in the current WAL lifecycle",
+				txnID,
+			)
+		}
+		return txnState, nil
+	}
+
+	if txnState.meta == nil {
+		if marker {
+			return nil, status.NewUnrecoverableError("partial update transaction %d has no CAS metadata", txnID)
+		}
+		return txnState, nil
+	}
+	if len(txnState.pks) == 0 {
+		return nil, status.NewUnrecoverableError("partial update transaction %d has no primary key writes", txnID)
+	}
+	if txnState.fenceCollection != 0 && txnState.meta.GetCollectionId() != txnState.fenceCollection {
+		return nil, status.NewUnrecoverableError(
+			"partial update transaction %d mixes collection ids %d and %d",
+			txnID,
+			txnState.meta.GetCollectionId(),
+			txnState.fenceCollection,
+		)
+	}
+	if msg.ReplicateHeader() != nil {
+		return txnState, nil
+	}
+	if txnState.meta.GetObservedPchannelTerm() != s.channel.Term {
+		return nil, status.NewPartialUpdateRetryable(
+			"partial update observed term %d, current term %d",
+			txnState.meta.GetObservedPchannelTerm(),
+			s.channel.Term,
+		)
+	}
+	if err := s.incompleteTxnFences.Verify(msg.VChannel(), txnState.meta.GetReadTs()); err != nil {
+		return nil, err
+	}
+	if err := s.pkVersions.Verify(msg.VChannel(), txnState.pks, txnState.meta.GetReadTs(), msg.TimeTick()); err != nil {
+		return nil, err
+	}
+	if err := s.fences.Verify(msg.VChannel(), txnState.meta.GetCollectionId(), txnState.meta.GetReadTs()); err != nil {
+		return nil, err
+	}
+	return txnState, nil
+}
+
+func (s *partialUpdateState) publishCommit(msg message.MutableMessage, txnState *pendingTxn) {
+	if txnState == nil || !txnState.observedBegin {
+		s.pkVersions.Advance(msg.TimeTick())
+		s.incompleteTxnFences.Update(msg.VChannel(), msg.TimeTick())
+		return
+	}
+	if len(txnState.pks) > 0 {
+		s.pkVersions.UpdateAll(msg.VChannel(), txnState.pks, msg.TimeTick())
+	} else {
+		s.pkVersions.Advance(msg.TimeTick())
+	}
+	if txnState.fenceCollection != 0 {
+		s.fences.Update(msg.VChannel(), txnState.fenceCollection, msg.TimeTick())
+	}
+}
+
+// pendingTxn joins optional CAS metadata with writes observed in one runtime
+// transaction. observedBegin distinguishes a complete runtime write set from
+// a recovered transaction for which only a body suffix or CommitTxn was seen.
+type pendingTxn struct {
+	pks               []any
+	meta              *messagespb.PartialUpdateCAS
+	fenceCollection   int64
+	observedBegin     bool
+	cleanupRegistered bool
+}
+
+func (s *partialUpdateState) txnLocked(txnID message.TxnID) *pendingTxn {
+	txnState := s.txns[txnID]
+	if txnState == nil {
+		txnState = &pendingTxn{}
+		s.txns[txnID] = txnState
+	}
+	return txnState
+}
+
+func (s *partialUpdateState) recordTxnWrites(txnID message.TxnID, pks []any) {
+	if len(pks) == 0 {
+		return
+	}
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	txnState := s.txnLocked(txnID)
+	txnState.pks = append(txnState.pks, pks...)
+}
+
+func (s *partialUpdateState) recordTxnBegin(txnID message.TxnID) {
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	s.txnLocked(txnID).observedBegin = true
+}
+
+func (s *partialUpdateState) recordTxnMeta(txnID message.TxnID, meta *messagespb.PartialUpdateCAS) error {
+	if meta == nil {
+		return nil
+	}
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	txnState := s.txnLocked(txnID)
+	if txnState.meta == nil {
+		txnState.meta = meta
+		return nil
+	}
+	if !proto.Equal(txnState.meta, meta) {
+		return status.NewUnrecoverableError("partial update txn %d carries different CAS metadata", txnID)
+	}
+	return nil
+}
+
+func (s *partialUpdateState) recordTxnFence(txnID message.TxnID, collectionID int64) {
+	if collectionID == 0 {
+		return
+	}
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	s.txnLocked(txnID).fenceCollection = collectionID
+}
+
+func (s *partialUpdateState) markTxnCleanup(txnID message.TxnID) bool {
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	txnState := s.txnLocked(txnID)
+	if txnState.cleanupRegistered {
+		return false
+	}
+	txnState.cleanupRegistered = true
+	return true
+}
+
+func (s *partialUpdateState) getTxn(txnID message.TxnID) *pendingTxn {
+	s.txnMu.RLock()
+	defer s.txnMu.RUnlock()
+	txnState := s.txns[txnID]
+	if txnState == nil {
+		return nil
+	}
+	return &pendingTxn{
+		pks:               append([]any(nil), txnState.pks...),
+		meta:              txnState.meta,
+		fenceCollection:   txnState.fenceCollection,
+		observedBegin:     txnState.observedBegin,
+		cleanupRegistered: txnState.cleanupRegistered,
+	}
+}
+
+func (s *partialUpdateState) deleteTxn(txnID message.TxnID) {
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	delete(s.txns, txnID)
+}

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/admission.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/admission.go
@@ -76,18 +76,24 @@ func (s *partialUpdateState) validateCommit(msg message.MutableMessage, txnID me
 
 	if txnState.meta == nil {
 		if marker {
-			return nil, status.NewUnrecoverableError("partial update transaction %d has no CAS metadata", txnID)
+			return nil, status.NewUnrecoverableError("partial update transaction %d has no CAS proof", txnID)
 		}
 		return txnState, nil
+	}
+	if !txnState.casScopeSet {
+		return nil, status.NewUnrecoverableError(
+			"partial update transaction %d has no derived CAS scope",
+			txnID,
+		)
 	}
 	if len(txnState.pks) == 0 {
 		return nil, status.NewUnrecoverableError("partial update transaction %d has no primary key writes", txnID)
 	}
-	if txnState.fenceCollection != 0 && txnState.meta.GetCollectionId() != txnState.fenceCollection {
+	if txnState.fenceCollection != 0 && txnState.collectionID != txnState.fenceCollection {
 		return nil, status.NewUnrecoverableError(
 			"partial update transaction %d mixes collection ids %d and %d",
 			txnID,
-			txnState.meta.GetCollectionId(),
+			txnState.collectionID,
 			txnState.fenceCollection,
 		)
 	}
@@ -107,7 +113,7 @@ func (s *partialUpdateState) validateCommit(msg message.MutableMessage, txnID me
 	if err := s.pkVersions.Verify(msg.VChannel(), txnState.pks, txnState.meta.GetReadTs(), msg.TimeTick()); err != nil {
 		return nil, err
 	}
-	if err := s.fences.Verify(msg.VChannel(), txnState.meta.GetCollectionId(), txnState.meta.GetReadTs()); err != nil {
+	if err := s.fences.Verify(msg.VChannel(), txnState.collectionID, txnState.meta.GetReadTs()); err != nil {
 		return nil, err
 	}
 	return txnState, nil
@@ -129,12 +135,15 @@ func (s *partialUpdateState) publishCommit(msg message.MutableMessage, txnState 
 	}
 }
 
-// pendingTxn joins optional CAS metadata with writes observed in one runtime
+// pendingTxn joins optional CAS proof and derived scope with writes observed in one runtime
 // transaction. observedBegin distinguishes a complete runtime write set from
 // a recovered transaction for which only a body suffix or CommitTxn was seen.
 type pendingTxn struct {
 	pks               []any
 	meta              *messagespb.PartialUpdateCAS
+	collectionID      int64
+	schemaVersion     int32
+	casScopeSet       bool
 	fenceCollection   int64
 	observedBegin     bool
 	cleanupRegistered bool
@@ -165,19 +174,44 @@ func (s *partialUpdateState) recordTxnBegin(txnID message.TxnID) {
 	s.txnLocked(txnID).observedBegin = true
 }
 
-func (s *partialUpdateState) recordTxnMeta(txnID message.TxnID, meta *messagespb.PartialUpdateCAS) error {
+func (s *partialUpdateState) recordTxnCAS(
+	txnID message.TxnID,
+	meta *messagespb.PartialUpdateCAS,
+	scope casInsertScope,
+) error {
 	if meta == nil {
 		return nil
+	}
+	if scope.collectionID == 0 {
+		return status.NewUnrecoverableError(
+			"partial update txn %d carries an empty collection id",
+			txnID,
+		)
 	}
 	s.txnMu.Lock()
 	defer s.txnMu.Unlock()
 	txnState := s.txnLocked(txnID)
 	if txnState.meta == nil {
-		txnState.meta = meta
+		txnState.meta = proto.Clone(meta).(*messagespb.PartialUpdateCAS)
+		txnState.collectionID = scope.collectionID
+		txnState.schemaVersion = scope.schemaVersion
+		txnState.casScopeSet = true
 		return nil
 	}
 	if !proto.Equal(txnState.meta, meta) {
-		return status.NewUnrecoverableError("partial update txn %d carries different CAS metadata", txnID)
+		return status.NewUnrecoverableError("partial update txn %d carries different CAS proof", txnID)
+	}
+	if !txnState.casScopeSet ||
+		txnState.collectionID != scope.collectionID ||
+		txnState.schemaVersion != scope.schemaVersion {
+		return status.NewUnrecoverableError(
+			"partial update txn %d mixes CAS scope collection/schema %d/%d and %d/%d",
+			txnID,
+			txnState.collectionID,
+			txnState.schemaVersion,
+			scope.collectionID,
+			scope.schemaVersion,
+		)
 	}
 	return nil
 }
@@ -211,11 +245,21 @@ func (s *partialUpdateState) getTxn(txnID message.TxnID) *pendingTxn {
 	}
 	return &pendingTxn{
 		pks:               append([]any(nil), txnState.pks...),
-		meta:              txnState.meta,
+		meta:              cloneCASMeta(txnState.meta),
+		collectionID:      txnState.collectionID,
+		schemaVersion:     txnState.schemaVersion,
+		casScopeSet:       txnState.casScopeSet,
 		fenceCollection:   txnState.fenceCollection,
 		observedBegin:     txnState.observedBegin,
 		cleanupRegistered: txnState.cleanupRegistered,
 	}
+}
+
+func cloneCASMeta(meta *messagespb.PartialUpdateCAS) *messagespb.PartialUpdateCAS {
+	if meta == nil {
+		return nil
+	}
+	return proto.Clone(meta).(*messagespb.PartialUpdateCAS)
 }
 
 func (s *partialUpdateState) deleteTxn(txnID message.TxnID) {

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/admission_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/admission_test.go
@@ -36,7 +36,7 @@ func TestValidateCommitRejectsPKConflict(t *testing.T) {
 	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
 	state.pkVersions.UpdateAll("v1", []any{int64(10)}, 200)
 	state.recordTxnBegin(1)
-	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 	state.recordTxnWrites(1, []any{int64(10)})
 
 	_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 300), 1)
@@ -46,7 +46,7 @@ func TestValidateCommitRejectsPKConflict(t *testing.T) {
 func TestValidateCommitPublishesAfterSuccessfulAppend(t *testing.T) {
 	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
 	state.recordTxnBegin(1)
-	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 	state.recordTxnWrites(1, []any{int64(10)})
 
 	commit := newCASCommitTxnMessage(t, "v1", 1, 300)
@@ -72,7 +72,7 @@ func TestValidateCommitMarkerConsistency(t *testing.T) {
 	t.Run("runtime CAS without marker", func(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 		state.recordTxnWrites(1, []any{int64(10)})
 
 		_, err := state.validateCommit(newCommitTxnMessage("v1", 1, 300), 1)
@@ -98,7 +98,7 @@ func TestValidateCommitMarkerConsistency(t *testing.T) {
 	t.Run("empty vchannel", func(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 		state.recordTxnWrites(1, []any{int64(10)})
 
 		_, err := state.validateCommit(newCASCommitTxnMessage(t, "", 1, 300), 1)
@@ -116,10 +116,22 @@ func TestPublishCommitAdvancesRetentionAndFence(t *testing.T) {
 }
 
 func TestValidateCommitRejectsInvalidProof(t *testing.T) {
+	t.Run("missing derived CAS scope", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+		state.txns[1] = &pendingTxn{
+			meta:          validCASMeta(100, 1),
+			pks:           []any{int64(10)},
+			observedBegin: true,
+		}
+
+		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 300), 1)
+		requireUnrecoverable(t, err)
+	})
+
 	t.Run("missing primary keys", func(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 
 		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 300), 1)
 		requireUnrecoverable(t, err)
@@ -128,7 +140,7 @@ func TestValidateCommitRejectsInvalidProof(t *testing.T) {
 	t.Run("mixed collection ids", func(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 		state.recordTxnWrites(1, []any{int64(10)})
 		state.recordTxnFence(1, 2)
 
@@ -141,7 +153,7 @@ func TestValidateCommitRejectsTermAndReadConflicts(t *testing.T) {
 	t.Run("term mismatch", func(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 		state.recordTxnWrites(1, []any{int64(10)})
 
 		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 120), 1)
@@ -152,7 +164,7 @@ func TestValidateCommitRejectsTermAndReadConflicts(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
 		state.pkVersions.channel("v1").retainedSinceTS = 200
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 		state.recordTxnWrites(1, []any{int64(10)})
 
 		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 220), 1)
@@ -161,9 +173,10 @@ func TestValidateCommitRejectsTermAndReadConflicts(t *testing.T) {
 
 	t.Run("collection fence", func(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
-		state.fences.Update("v1", 1, 150)
+		scope := casInsertScope{collectionID: 2, schemaVersion: 1}
+		state.fences.Update("v1", scope.collectionID, 150)
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), scope))
 		state.recordTxnWrites(1, []any{int64(10)})
 
 		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 160), 1)
@@ -175,7 +188,7 @@ func TestValidateCommitRejectsIncompleteTransactionFence(t *testing.T) {
 	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
 	state.incompleteTxnFences.Update("v1", 150)
 	state.recordTxnBegin(1)
-	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 	state.recordTxnWrites(1, []any{int64(10)})
 
 	_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 160), 1)
@@ -185,7 +198,7 @@ func TestValidateCommitRejectsIncompleteTransactionFence(t *testing.T) {
 func TestValidateCommitReplicatedCASBypassesSourceProof(t *testing.T) {
 	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
 	state.recordTxnBegin(1)
-	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 	state.recordTxnWrites(1, []any{int64(10)})
 
 	commit := newCASCommitTxnMessage(t, "v1", 1, 160)
@@ -239,7 +252,7 @@ func TestValidateCommitReplicatedCASRequiresCompleteWriteSet(t *testing.T) {
 	t.Run("missing primary keys", func(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 
 		_, err := state.validateCommit(newReplicatedCommit(t), 1)
 		requireUnrecoverable(t, err)
@@ -248,7 +261,7 @@ func TestValidateCommitReplicatedCASRequiresCompleteWriteSet(t *testing.T) {
 	t.Run("mixed collection ids", func(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 		state.recordTxnWrites(1, []any{int64(10)})
 		state.recordTxnFence(1, 2)
 
@@ -259,7 +272,7 @@ func TestValidateCommitReplicatedCASRequiresCompleteWriteSet(t *testing.T) {
 	t.Run("missing commit marker", func(t *testing.T) {
 		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
 		state.recordTxnBegin(1)
-		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
 		state.recordTxnWrites(1, []any{int64(10)})
 		msgID := walimplstest.NewTestMessageID(1)
 		commit := newCommitTxnMessage("v1", 1, 160).WithReplicateHeader(&message.ReplicateHeader{
@@ -275,13 +288,36 @@ func TestValidateCommitReplicatedCASRequiresCompleteWriteSet(t *testing.T) {
 	})
 }
 
-func TestPartialUpdateStateStoresTxnMetadata(t *testing.T) {
+func TestPartialUpdateStateStoresTxnCASProofAndScope(t *testing.T) {
 	state := newPartialUpdateState(time.Second, versionIndexBudgetForEntries(100))
-	require.NoError(t, state.recordTxnMeta(1, nil))
-	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
-	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
-	require.Error(t, state.recordTxnMeta(1, validCASMeta(101, 1)))
-	require.EqualValues(t, 100, state.getTxn(1).meta.GetPrimaryKeyFieldId())
+	require.NoError(t, state.recordTxnCAS(1, nil, casInsertScope{}))
+	require.Error(t, state.recordTxnCAS(2, validCASMeta(100, 1), casInsertScope{}))
+
+	meta := validCASMeta(100, 1)
+	require.NoError(t, state.recordTxnCAS(1, meta, validCASScope()))
+	meta.ReadTs = 999
+	require.NoError(t, state.recordTxnCAS(1, validCASMeta(100, 1), validCASScope()))
+	require.Error(t, state.recordTxnCAS(1, validCASMeta(101, 1), validCASScope()))
+	require.Error(t, state.recordTxnCAS(1, validCASMeta(100, 1), casInsertScope{
+		collectionID:  2,
+		schemaVersion: 1,
+	}))
+	require.Error(t, state.recordTxnCAS(1, validCASMeta(100, 1), casInsertScope{
+		collectionID:  1,
+		schemaVersion: 2,
+	}))
+	require.NoError(t, state.recordTxnCAS(3, validCASMeta(100, 1), casInsertScope{
+		collectionID:  1,
+		schemaVersion: 0,
+	}))
+
+	txnState := state.getTxn(1)
+	require.EqualValues(t, 100, txnState.meta.GetReadTs())
+	require.EqualValues(t, 1, txnState.collectionID)
+	require.EqualValues(t, 1, txnState.schemaVersion)
+	require.True(t, txnState.casScopeSet)
+	txnState.meta.ReadTs = 999
+	require.EqualValues(t, 100, state.getTxn(1).meta.GetReadTs())
 }
 
 func newTestAdmissionState(channel types.PChannelInfo) *partialUpdateState {
@@ -311,7 +347,9 @@ func validCASMeta(readTS uint64, term int64) *messagespb.PartialUpdateCAS {
 	return &messagespb.PartialUpdateCAS{
 		ReadTs:               readTS,
 		ObservedPchannelTerm: term,
-		CollectionId:         1,
-		PrimaryKeyFieldId:    100,
 	}
+}
+
+func validCASScope() casInsertScope {
+	return casInsertScope{collectionID: 1, schemaVersion: 1}
 }

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/admission_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/admission_test.go
@@ -1,0 +1,317 @@
+package partialupdate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
+)
+
+func requirePartialUpdateCode(t *testing.T, err error, code streamingpb.StreamingCode) {
+	t.Helper()
+	require.Error(t, err)
+	streamingErr := status.AsStreamingError(err)
+	require.NotNil(t, streamingErr)
+	require.Equal(t, code, streamingErr.Code)
+}
+
+func requirePartialUpdateRetryable(t *testing.T, err error) {
+	t.Helper()
+	requirePartialUpdateCode(t, err, streamingpb.StreamingCode_STREAMING_CODE_PARTIAL_UPDATE_RETRYABLE)
+}
+
+func requireUnrecoverable(t *testing.T, err error) {
+	t.Helper()
+	requirePartialUpdateCode(t, err, streamingpb.StreamingCode_STREAMING_CODE_UNRECOVERABLE)
+}
+
+func TestValidateCommitRejectsPKConflict(t *testing.T) {
+	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+	state.pkVersions.UpdateAll("v1", []any{int64(10)}, 200)
+	state.recordTxnBegin(1)
+	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	state.recordTxnWrites(1, []any{int64(10)})
+
+	_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 300), 1)
+	requirePartialUpdateRetryable(t, err)
+}
+
+func TestValidateCommitPublishesAfterSuccessfulAppend(t *testing.T) {
+	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+	state.recordTxnBegin(1)
+	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	state.recordTxnWrites(1, []any{int64(10)})
+
+	commit := newCASCommitTxnMessage(t, "v1", 1, 300)
+	txnState, err := state.validateCommit(commit, 1)
+	require.NoError(t, err)
+	state.publishCommit(commit, txnState)
+
+	requirePartialUpdateRetryable(t, state.pkVersions.Verify("v1", []any{int64(10)}, 299, 301))
+}
+
+func TestValidateCommitMarkerConsistency(t *testing.T) {
+	t.Run("ordinary commit without runtime state", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+
+		txnState, err := state.validateCommit(newCommitTxnMessage("v1", 1, 300), 1)
+		require.NoError(t, err)
+		require.Nil(t, txnState)
+		state.publishCommit(newCommitTxnMessage("v1", 1, 300), txnState)
+		requirePartialUpdateRetryable(t, state.incompleteTxnFences.Verify("v1", 299))
+		require.NoError(t, state.incompleteTxnFences.Verify("v1", 300))
+	})
+
+	t.Run("runtime CAS without marker", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		state.recordTxnWrites(1, []any{int64(10)})
+
+		_, err := state.validateCommit(newCommitTxnMessage("v1", 1, 300), 1)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("marker without runtime state", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+
+		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 300), 1)
+		requirePartialUpdateRetryable(t, err)
+	})
+
+	t.Run("marker without CAS metadata", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+		state.recordTxnBegin(1)
+		state.recordTxnWrites(1, []any{int64(10)})
+
+		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 300), 1)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("empty vchannel", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		state.recordTxnWrites(1, []any{int64(10)})
+
+		_, err := state.validateCommit(newCASCommitTxnMessage(t, "", 1, 300), 1)
+		requireUnrecoverable(t, err)
+	})
+}
+
+func TestPublishCommitAdvancesRetentionAndFence(t *testing.T) {
+	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+	commit := newCommitTxnMessage("v1", 1, 300)
+
+	state.publishCommit(commit, &pendingTxn{fenceCollection: 10, observedBegin: true})
+
+	requirePartialUpdateRetryable(t, state.fences.Verify("v1", 10, 299))
+}
+
+func TestValidateCommitRejectsInvalidProof(t *testing.T) {
+	t.Run("missing primary keys", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+
+		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 300), 1)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("mixed collection ids", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		state.recordTxnWrites(1, []any{int64(10)})
+		state.recordTxnFence(1, 2)
+
+		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 300), 1)
+		requireUnrecoverable(t, err)
+	})
+}
+
+func TestValidateCommitRejectsTermAndReadConflicts(t *testing.T) {
+	t.Run("term mismatch", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		state.recordTxnWrites(1, []any{int64(10)})
+
+		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 120), 1)
+		requirePartialUpdateRetryable(t, err)
+	})
+
+	t.Run("stale read", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+		state.pkVersions.channel("v1").retainedSinceTS = 200
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		state.recordTxnWrites(1, []any{int64(10)})
+
+		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 220), 1)
+		requirePartialUpdateRetryable(t, err)
+	})
+
+	t.Run("collection fence", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+		state.fences.Update("v1", 1, 150)
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		state.recordTxnWrites(1, []any{int64(10)})
+
+		_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 160), 1)
+		requirePartialUpdateRetryable(t, err)
+	})
+}
+
+func TestValidateCommitRejectsIncompleteTransactionFence(t *testing.T) {
+	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 1})
+	state.incompleteTxnFences.Update("v1", 150)
+	state.recordTxnBegin(1)
+	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	state.recordTxnWrites(1, []any{int64(10)})
+
+	_, err := state.validateCommit(newCASCommitTxnMessage(t, "v1", 1, 160), 1)
+	requirePartialUpdateRetryable(t, err)
+}
+
+func TestValidateCommitReplicatedCASBypassesSourceProof(t *testing.T) {
+	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
+	state.recordTxnBegin(1)
+	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	state.recordTxnWrites(1, []any{int64(10)})
+
+	commit := newCASCommitTxnMessage(t, "v1", 1, 160)
+	msgID := walimplstest.NewTestMessageID(1)
+	commit = commit.WithReplicateHeader(&message.ReplicateHeader{
+		ClusterID:              "cluster-a",
+		MessageID:              msgID,
+		LastConfirmedMessageID: msgID,
+		TimeTick:               160,
+		VChannel:               "v1",
+	})
+
+	txnState, err := state.validateCommit(commit, 1)
+	require.NoError(t, err)
+	state.publishCommit(commit, txnState)
+	requirePartialUpdateRetryable(t, state.pkVersions.Verify("v1", []any{int64(10)}, 159, 161))
+}
+
+func TestValidateCommitReplicatedCASWithoutRuntimeStateUsesFence(t *testing.T) {
+	state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
+	commit := newCASCommitTxnMessage(t, "v1", 1, 160)
+	msgID := walimplstest.NewTestMessageID(1)
+	commit = commit.WithReplicateHeader(&message.ReplicateHeader{
+		ClusterID:              "cluster-a",
+		MessageID:              msgID,
+		LastConfirmedMessageID: msgID,
+		TimeTick:               160,
+		VChannel:               "v1",
+	})
+
+	txnState, err := state.validateCommit(commit, 1)
+	require.NoError(t, err)
+	require.Nil(t, txnState)
+	state.publishCommit(commit, txnState)
+	requirePartialUpdateRetryable(t, state.incompleteTxnFences.Verify("v1", 159))
+}
+
+func TestValidateCommitReplicatedCASRequiresCompleteWriteSet(t *testing.T) {
+	newReplicatedCommit := func(t *testing.T) message.MutableMessage {
+		t.Helper()
+		msgID := walimplstest.NewTestMessageID(1)
+		return newCASCommitTxnMessage(t, "v1", 1, 160).WithReplicateHeader(&message.ReplicateHeader{
+			ClusterID:              "cluster-a",
+			MessageID:              msgID,
+			LastConfirmedMessageID: msgID,
+			TimeTick:               160,
+			VChannel:               "v1",
+		})
+	}
+
+	t.Run("missing primary keys", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+
+		_, err := state.validateCommit(newReplicatedCommit(t), 1)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("mixed collection ids", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		state.recordTxnWrites(1, []any{int64(10)})
+		state.recordTxnFence(1, 2)
+
+		_, err := state.validateCommit(newReplicatedCommit(t), 1)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("missing commit marker", func(t *testing.T) {
+		state := newTestAdmissionState(types.PChannelInfo{Name: "p1", Term: 2})
+		state.recordTxnBegin(1)
+		require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+		state.recordTxnWrites(1, []any{int64(10)})
+		msgID := walimplstest.NewTestMessageID(1)
+		commit := newCommitTxnMessage("v1", 1, 160).WithReplicateHeader(&message.ReplicateHeader{
+			ClusterID:              "cluster-a",
+			MessageID:              msgID,
+			LastConfirmedMessageID: msgID,
+			TimeTick:               160,
+			VChannel:               "v1",
+		})
+
+		_, err := state.validateCommit(commit, 1)
+		requireUnrecoverable(t, err)
+	})
+}
+
+func TestPartialUpdateStateStoresTxnMetadata(t *testing.T) {
+	state := newPartialUpdateState(time.Second, versionIndexBudgetForEntries(100))
+	require.NoError(t, state.recordTxnMeta(1, nil))
+	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	require.NoError(t, state.recordTxnMeta(1, validCASMeta(100, 1)))
+	require.Error(t, state.recordTxnMeta(1, validCASMeta(101, 1)))
+	require.EqualValues(t, 100, state.getTxn(1).meta.GetPrimaryKeyFieldId())
+}
+
+func newTestAdmissionState(channel types.PChannelInfo) *partialUpdateState {
+	state := newPartialUpdateState(30*time.Second, versionIndexBudgetForEntries(100))
+	state.channel = channel
+	return state
+}
+
+func newCommitTxnMessage(vchannel string, txnID message.TxnID, timetick uint64) message.MutableMessage {
+	return message.NewCommitTxnMessageBuilderV2().
+		WithVChannel(vchannel).
+		WithHeader(&message.CommitTxnMessageHeader{}).
+		WithBody(&message.CommitTxnMessageBody{}).
+		MustBuildMutable().
+		WithTxnContext(message.TxnContext{TxnID: txnID, Keepalive: time.Second}).
+		WithTimeTick(timetick)
+}
+
+func newCASCommitTxnMessage(t *testing.T, vchannel string, txnID message.TxnID, timetick uint64) message.MutableMessage {
+	t.Helper()
+	msg := newCommitTxnMessage(vchannel, txnID, timetick)
+	require.NoError(t, message.MarkPartialUpdateCASCommit(msg))
+	return msg
+}
+
+func validCASMeta(readTS uint64, term int64) *messagespb.PartialUpdateCAS {
+	return &messagespb.PartialUpdateCAS{
+		ReadTs:               readTS,
+		ObservedPchannelTerm: term,
+		CollectionId:         1,
+		PrimaryKeyFieldId:    100,
+	}
+}

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/index.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/index.go
@@ -1,0 +1,424 @@
+package partialupdate
+
+import (
+	"container/heap"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+)
+
+const (
+	defaultVersionIndexTTL = 30 * time.Second
+
+	// The estimate covers the map key/value, heap pointer, entry object, and
+	// allocator overhead. String backing bytes are accounted separately.
+	estimatedVersionEntryFixedBytes int64 = 128
+	defaultVersionIndexBudgetBytes        = 5_000_000 * estimatedVersionEntryFixedBytes
+)
+
+// pkVersionIndex owns one byte budget for a PChannel term and isolates mutable
+// PK history by vchannel.
+type pkVersionIndex struct {
+	ttl      time.Duration
+	budget   *versionByteBudget
+	channels sync.Map // map[string]*vchannelPKVersionIndex
+}
+
+// versionByteBudget bounds the estimated memory retained by all vchannels in
+// one PChannel term.
+type versionByteBudget struct {
+	limit int64
+	used  atomic.Int64
+}
+
+func newVersionByteBudget(limit int64) *versionByteBudget {
+	if limit < 0 {
+		limit = 0
+	}
+	return &versionByteBudget{limit: limit}
+}
+
+func (b *versionByteBudget) tryReserve(bytes int64) bool {
+	if bytes <= 0 {
+		return true
+	}
+	for {
+		used := b.used.Load()
+		if bytes > b.limit-used {
+			return false
+		}
+		if b.used.CompareAndSwap(used, used+bytes) {
+			return true
+		}
+	}
+}
+
+func (b *versionByteBudget) release(bytes int64) {
+	if bytes <= 0 {
+		return
+	}
+	if remaining := b.used.Add(-bytes); remaining < 0 {
+		panic("partial update version index byte budget underflow")
+	}
+}
+
+// vchannelPKVersionIndex tracks recent PK writes on one vchannel.
+type vchannelPKVersionIndex struct {
+	mu                sync.Mutex
+	ttl               time.Duration
+	budget            *versionByteBudget
+	retainedSinceTS   uint64
+	lastMissedWriteTS uint64
+	versions          map[any]*versionEntry
+	expirations       versionMinHeap
+}
+
+type versionEntry struct {
+	pk             any
+	commitTS       uint64
+	estimatedBytes int64
+	index          int
+}
+
+type versionMinHeap []*versionEntry
+
+func (h versionMinHeap) Len() int {
+	return len(h)
+}
+
+func (h versionMinHeap) Less(i, j int) bool {
+	return h[i].commitTS < h[j].commitTS
+}
+
+func (h versionMinHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+
+func (h *versionMinHeap) Push(value any) {
+	entry := value.(*versionEntry)
+	entry.index = len(*h)
+	*h = append(*h, entry)
+}
+
+func (h *versionMinHeap) Pop() any {
+	old := *h
+	last := len(old) - 1
+	entry := old[last]
+	old[last] = nil
+	entry.index = -1
+	*h = old[:last]
+	return entry
+}
+
+// newPKVersionIndex creates a byte-bounded index for one PChannel term.
+func newPKVersionIndex(ttl time.Duration, maxBytes int64) *pkVersionIndex {
+	return &pkVersionIndex{
+		ttl:    ttl,
+		budget: newVersionByteBudget(maxBytes),
+	}
+}
+
+func (idx *pkVersionIndex) channel(vchannel string) *vchannelPKVersionIndex {
+	if existing, ok := idx.channels.Load(vchannel); ok {
+		return existing.(*vchannelPKVersionIndex)
+	}
+	created := &vchannelPKVersionIndex{
+		ttl:      idx.ttl,
+		budget:   idx.budget,
+		versions: make(map[any]*versionEntry),
+	}
+	actual, _ := idx.channels.LoadOrStore(vchannel, created)
+	return actual.(*vchannelPKVersionIndex)
+}
+
+// Remove releases all retained PK-version state for a terminal vchannel.
+// DropCollection serializes this call with writes through the vchannel lock.
+func (idx *pkVersionIndex) Remove(vchannel string) {
+	value, ok := idx.channels.LoadAndDelete(vchannel)
+	if !ok {
+		return
+	}
+	value.(*vchannelPKVersionIndex).clear()
+}
+
+func (idx *vchannelPKVersionIndex) clear() {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	var releasedBytes int64
+	for _, entry := range idx.versions {
+		releasedBytes += entry.estimatedBytes
+	}
+	idx.versions = make(map[any]*versionEntry)
+	idx.expirations = nil
+	idx.retainedSinceTS = 0
+	idx.lastMissedWriteTS = 0
+	idx.budget.release(releasedBytes)
+}
+
+// UpdateAll records one committed write batch atomically within its vchannel.
+func (idx *pkVersionIndex) UpdateAll(vchannel string, pks []any, commitTS uint64) {
+	candidates := make([]versionCandidate, 0, len(pks))
+	for _, pk := range pks {
+		candidate, err := newVersionCandidate(pk)
+		if err != nil {
+			// All live and recovered writes validate PK types before publication.
+			panic(err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	idx.channel(vchannel).updateAll(candidates, commitTS)
+}
+
+func (idx *vchannelPKVersionIndex) updateAll(candidates []versionCandidate, commitTS uint64) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	idx.advanceRetentionLocked(commitTS)
+	for _, candidate := range candidates {
+		entry, ok := idx.versions[candidate.pk]
+		if ok && entry.commitTS >= commitTS {
+			continue
+		}
+		if ok {
+			entry.commitTS = commitTS
+			heap.Fix(&idx.expirations, entry.index)
+			continue
+		}
+		if commitTS < idx.retainedSinceTS {
+			continue
+		}
+		if !idx.budget.tryReserve(candidate.estimatedBytes) {
+			// Once a committed write is omitted, exact conflict detection is
+			// incomplete until that write leaves every valid read window.
+			if commitTS > idx.lastMissedWriteTS {
+				idx.lastMissedWriteTS = commitTS
+			}
+			continue
+		}
+		entry = &versionEntry{
+			pk:             candidate.pk,
+			commitTS:       commitTS,
+			estimatedBytes: candidate.estimatedBytes,
+		}
+		idx.versions[candidate.pk] = entry
+		heap.Push(&idx.expirations, entry)
+	}
+}
+
+// Advance moves retention forward without publishing a PK write. TimeTick
+// messages use it to reclaim memory and restore complete read windows while idle.
+func (idx *pkVersionIndex) Advance(currentTS uint64) {
+	idx.channels.Range(func(_, value any) bool {
+		value.(*vchannelPKVersionIndex).advance(currentTS)
+		return true
+	})
+}
+
+func (idx *vchannelPKVersionIndex) advance(currentTS uint64) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.advanceRetentionLocked(currentTS)
+}
+
+// Verify rejects reads whose retained PK version changed after readTS.
+func (idx *pkVersionIndex) Verify(vchannel string, pks []any, readTS, commitTS uint64) error {
+	return idx.channel(vchannel).verify(vchannel, pks, readTS, commitTS)
+}
+
+func (idx *vchannelPKVersionIndex) verify(vchannel string, pks []any, readTS, commitTS uint64) error {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	idx.advanceRetentionLocked(commitTS)
+	if err := idx.verifyReadWindowLocked(readTS, commitTS); err != nil {
+		return err
+	}
+
+	for _, pk := range pks {
+		candidate, err := newVersionCandidate(pk)
+		if err != nil {
+			return err
+		}
+		if entry := idx.versions[candidate.pk]; entry != nil && entry.commitTS > readTS {
+			return status.NewPartialUpdateRetryable("partial update pk conflict, vchannel: %s, read ts: %d, last commit ts: %d", vchannel, readTS, entry.commitTS)
+		}
+	}
+	return nil
+}
+
+func (idx *vchannelPKVersionIndex) verifyReadWindowLocked(readTS, commitTS uint64) error {
+	if readTS < idx.retainedSinceTS {
+		return status.NewPartialUpdateRetryable("partial update read ts %d is older than retained since ts %d", readTS, idx.retainedSinceTS)
+	}
+	if commitTS < readTS {
+		return status.NewUnrecoverableError("partial update commit ts %d is older than read ts %d", commitTS, readTS)
+	}
+	if time.Duration(tsoutil.CalculateDuration(commitTS, readTS))*time.Millisecond > idx.ttl {
+		return status.NewPartialUpdateRetryable("partial update read window exceeds max age, read ts: %d, commit ts: %d, max age: %s", readTS, commitTS, idx.ttl)
+	}
+	if idx.lastMissedWriteTS != 0 {
+		return status.NewPartialUpdateRetryable("partial update version index is incomplete after missing write ts %d", idx.lastMissedWriteTS)
+	}
+	return nil
+}
+
+// advanceRetentionLocked evicts only versions older than the maximum valid
+// read window. Moving retainedSinceTS with the same cutoff preserves fail-closed
+// verification for reads whose conflict history has been discarded.
+func (idx *vchannelPKVersionIndex) advanceRetentionLocked(commitTS uint64) {
+	evictUntilTS := retentionCutoffTS(commitTS, idx.ttl)
+	if evictUntilTS == 0 {
+		return
+	}
+	if evictUntilTS <= idx.retainedSinceTS {
+		return
+	}
+	idx.retainedSinceTS = evictUntilTS
+	idx.sweepLocked(evictUntilTS)
+	if idx.lastMissedWriteTS != 0 && idx.lastMissedWriteTS <= evictUntilTS {
+		idx.lastMissedWriteTS = 0
+	}
+}
+
+func retentionCutoffTS(ts uint64, ttl time.Duration) uint64 {
+	physical, logical := tsoutil.ParseHybridTs(ts)
+	cutoffPhysical := physical - ttl.Milliseconds()
+	if cutoffPhysical <= 0 {
+		return 0
+	}
+	return tsoutil.ComposeTS(cutoffPhysical, logical)
+}
+
+func (idx *vchannelPKVersionIndex) sweepLocked(evictUntilTS uint64) {
+	for idx.expirations.Len() > 0 && idx.expirations[0].commitTS <= evictUntilTS {
+		entry := heap.Pop(&idx.expirations).(*versionEntry)
+		delete(idx.versions, entry.pk)
+		idx.budget.release(entry.estimatedBytes)
+	}
+}
+
+type versionCandidate struct {
+	pk             any
+	estimatedBytes int64
+}
+
+func newVersionCandidate(pk any) (versionCandidate, error) {
+	switch value := pk.(type) {
+	case int64:
+		return versionCandidate{pk: value, estimatedBytes: estimatedVersionEntryFixedBytes}, nil
+	case string:
+		return versionCandidate{
+			pk:             value,
+			estimatedBytes: estimatedVersionEntryFixedBytes + int64(len(value)),
+		}, nil
+	default:
+		return versionCandidate{}, status.NewUnrecoverableError("partial update pk must be int64 or string")
+	}
+}
+
+// collectionFenceIndex records collection-wide writes that cannot be
+// represented as exact PK updates. Fences live for the collection lifetime
+// within one PChannel term and are removed explicitly on DropCollection.
+type collectionFenceIndex struct {
+	mu     sync.RWMutex
+	fences map[collectionFenceKey]uint64
+}
+
+type collectionFenceKey struct {
+	vchannel     string
+	collectionID int64
+}
+
+// newCollectionFenceIndex creates an empty collection fence index.
+func newCollectionFenceIndex() *collectionFenceIndex {
+	return &collectionFenceIndex{
+		fences: make(map[collectionFenceKey]uint64),
+	}
+}
+
+// Update advances the collection fence monotonically.
+func (idx *collectionFenceIndex) Update(vchannel string, collectionID int64, ts uint64) {
+	if collectionID == 0 {
+		return
+	}
+	key := collectionFenceKey{vchannel: vchannel, collectionID: collectionID}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	if ts > idx.fences[key] {
+		idx.fences[key] = ts
+	}
+}
+
+// Remove deletes the fence for a collection after DropCollection is durable.
+func (idx *collectionFenceIndex) Remove(vchannel string, collectionID int64) {
+	if collectionID == 0 {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	delete(idx.fences, collectionFenceKey{vchannel: vchannel, collectionID: collectionID})
+}
+
+// Verify rejects reads older than a collection-wide invalidation.
+func (idx *collectionFenceIndex) Verify(vchannel string, collectionID int64, readTS uint64) error {
+	if collectionID == 0 {
+		return status.NewUnrecoverableError("partial update collection fence id is empty")
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	key := collectionFenceKey{vchannel: vchannel, collectionID: collectionID}
+	fenceTS := idx.fences[key]
+	if fenceTS > readTS {
+		return status.NewPartialUpdateRetryable("partial update read ts %d is older than collection fence ts %d", readTS, fenceTS)
+	}
+	return nil
+}
+
+// vchannelFenceIndex records commits whose complete transaction write set was
+// not observed in the current WAL lifecycle. It conservatively invalidates all
+// earlier CAS reads on that vchannel without changing transaction recovery.
+type vchannelFenceIndex struct {
+	mu     sync.RWMutex
+	fences map[string]uint64
+}
+
+func newVChannelFenceIndex() *vchannelFenceIndex {
+	return &vchannelFenceIndex{fences: make(map[string]uint64)}
+}
+
+func (idx *vchannelFenceIndex) Update(vchannel string, ts uint64) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	if ts > idx.fences[vchannel] {
+		idx.fences[vchannel] = ts
+	}
+}
+
+// Remove deletes the conservative fence for a terminal vchannel.
+func (idx *vchannelFenceIndex) Remove(vchannel string) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	delete(idx.fences, vchannel)
+}
+
+func (idx *vchannelFenceIndex) Verify(vchannel string, readTS uint64) error {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	fenceTS := idx.fences[vchannel]
+	if fenceTS > readTS {
+		return status.NewPartialUpdateRetryable(
+			"partial update read ts %d is older than incomplete transaction fence ts %d",
+			readTS,
+			fenceTS,
+		)
+	}
+	return nil
+}

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/index_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/index_test.go
@@ -1,0 +1,471 @@
+package partialupdate
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+)
+
+func snapshotPKVersionIndex(idx *pkVersionIndex) (size int, withinCapacity bool) {
+	idx.channels.Range(func(_, value any) bool {
+		channel := value.(*vchannelPKVersionIndex)
+		channel.mu.Lock()
+		size += len(channel.versions)
+		channel.mu.Unlock()
+		return true
+	})
+	return size, idx.budget.used.Load() <= idx.budget.limit
+}
+
+func versionIndexBudgetForEntries(entries int64) int64 {
+	return entries * estimatedVersionEntryFixedBytes
+}
+
+func TestVersionByteBudget(t *testing.T) {
+	budget := newVersionByteBudget(10)
+	require.True(t, budget.tryReserve(0))
+	budget.release(0)
+	require.True(t, budget.tryReserve(10))
+	require.False(t, budget.tryReserve(1))
+	budget.release(10)
+	require.Zero(t, budget.used.Load())
+	require.Panics(t, func() {
+		budget.release(1)
+	})
+}
+
+func TestVersionByteBudgetConcurrentReservations(t *testing.T) {
+	const entries = 10
+	budget := newVersionByteBudget(versionIndexBudgetForEntries(entries))
+	var admitted atomic.Int64
+	var waitGroup sync.WaitGroup
+	for range 100 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			if budget.tryReserve(estimatedVersionEntryFixedBytes) {
+				admitted.Add(1)
+			}
+		}()
+	}
+	waitGroup.Wait()
+
+	require.Equal(t, int64(entries), admitted.Load())
+	require.Equal(t, budget.limit, budget.used.Load())
+}
+
+func TestPKVersionIndexVerifyConflict(t *testing.T) {
+	idx := newPKVersionIndex(10*time.Second, versionIndexBudgetForEntries(100))
+	idx.UpdateAll("v1", []any{int64(10)}, 100)
+
+	err := idx.Verify("v1", []any{int64(11), int64(10)}, 99, 101)
+	requirePartialUpdateRetryable(t, err)
+	require.True(t, status.AsStreamingError(err).IsPartialUpdateRetryableCAS())
+	require.NoError(t, idx.Verify("v1", []any{int64(10)}, 100, 101))
+}
+
+func TestPKVersionIndexNormalizesNegativeBudget(t *testing.T) {
+	idx := newPKVersionIndex(time.Second, -1)
+	require.Zero(t, idx.budget.limit)
+}
+
+func TestPKVersionIndexRejectsEvictedReadWindow(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(100))
+	idx.channel("").retainedSinceTS = 50
+	requirePartialUpdateRetryable(t, idx.Verify("", nil, 49, 80))
+}
+
+func TestPKVersionIndexRejectsCommitBeforeRead(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(100))
+	requireUnrecoverable(t, idx.Verify("", nil, 100, 99))
+}
+
+func TestPKVersionIndexRejectsReadWindowBeyondTTL(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(100))
+	readTS := tsoutil.ComposeTSByTime(time.Now())
+	commitTS := tsoutil.AddPhysicalDurationOnTs(readTS, 31*time.Second)
+	requirePartialUpdateRetryable(t, idx.Verify("", nil, readTS, commitTS))
+}
+
+func TestPKVersionIndexDirectlyRejectsReadWindowBeyondTTL(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(100))
+	readTS := tsoutil.ComposeTSByTime(time.Now())
+	commitTS := tsoutil.AddPhysicalDurationOnTs(readTS, 31*time.Second)
+
+	requirePartialUpdateRetryable(t, idx.channel("").verifyReadWindowLocked(readTS, commitTS))
+}
+
+func TestPKVersionIndexBudgetFailsClosed(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	idx.UpdateAll("v1", []any{int64(1)}, 10)
+	idx.UpdateAll("v1", []any{int64(2)}, 11)
+
+	size, withinCapacity := snapshotPKVersionIndex(idx)
+	require.True(t, withinCapacity)
+	require.Equal(t, 1, size)
+	channel := idx.channel("v1")
+	channel.mu.Lock()
+	require.Len(t, channel.expirations, 1)
+	channel.mu.Unlock()
+	requirePartialUpdateRetryable(t, idx.Verify("v1", nil, 11, 12))
+}
+
+func TestPKVersionIndexUpdatesExistingPKAtCapacity(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	now := time.Now()
+	firstCommit := tsoutil.ComposeTSByTime(now)
+	updatedCommit := tsoutil.ComposeTSByTime(now.Add(time.Second))
+	verifyCommit := tsoutil.ComposeTSByTime(now.Add(2 * time.Second))
+
+	idx.UpdateAll("v1", []any{int64(1)}, firstCommit)
+	idx.UpdateAll("v1", []any{int64(1)}, updatedCommit)
+
+	require.Equal(t, estimatedVersionEntryFixedBytes, idx.budget.used.Load())
+	require.NoError(t, idx.Verify("v1", nil, updatedCommit, verifyCommit))
+	requirePartialUpdateRetryable(t, idx.Verify("v1", []any{int64(1)}, firstCommit, verifyCommit))
+}
+
+func TestPKVersionIndexIgnoresOlderWriteForExistingPK(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	idx.UpdateAll("v1", []any{int64(1)}, 100)
+	idx.UpdateAll("v1", []any{int64(1)}, 90)
+
+	requirePartialUpdateRetryable(t, idx.Verify("v1", []any{int64(1)}, 99, 101))
+}
+
+func TestPKVersionIndexIgnoresWriteOlderThanRetention(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	idx.channel("v1").retainedSinceTS = 100
+	idx.UpdateAll("v1", []any{int64(1)}, 90)
+
+	size, _ := snapshotPKVersionIndex(idx)
+	require.Zero(t, size)
+}
+
+func TestPKVersionIndexPanicsOnInvalidPublishedPK(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	require.Panics(t, func() {
+		idx.UpdateAll("v1", []any{struct{}{}}, 100)
+	})
+}
+
+func TestPKVersionIndexLatestMissExtendsIncompleteWindow(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	now := time.Now()
+	firstCommit := tsoutil.ComposeTSByTime(now)
+	firstMiss := tsoutil.ComposeTSByTime(now.Add(time.Second))
+	latestMiss := tsoutil.ComposeTSByTime(now.Add(20 * time.Second))
+	readAfterFirstMiss := tsoutil.ComposeTSByTime(now.Add(2 * time.Second))
+	commitAfterFirstMissExpires := tsoutil.ComposeTSByTime(now.Add(32 * time.Second))
+	readAfterLatestMiss := tsoutil.ComposeTSByTime(now.Add(21 * time.Second))
+	commitAfterLatestMissExpires := tsoutil.ComposeTSByTime(now.Add(51 * time.Second))
+
+	idx.UpdateAll("v1", []any{int64(1)}, firstCommit)
+	idx.UpdateAll("v1", []any{int64(2)}, firstMiss)
+	idx.UpdateAll("v1", []any{int64(3)}, latestMiss)
+
+	requirePartialUpdateRetryable(t, idx.Verify("v1", nil, readAfterFirstMiss, commitAfterFirstMissExpires))
+	require.NoError(t, idx.Verify("v1", nil, readAfterLatestMiss, commitAfterLatestMissExpires))
+	size, withinCapacity := snapshotPKVersionIndex(idx)
+	require.True(t, withinCapacity)
+	require.Zero(t, size)
+}
+
+func TestPKVersionIndexSweepsExpiredVersionsBeforeCapacityCheck(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	now := time.Now()
+	firstCommit := tsoutil.ComposeTSByTime(now)
+	secondCommit := tsoutil.ComposeTSByTime(now.Add(31 * time.Second))
+	readAfterFirstExpired := tsoutil.ComposeTSByTime(now.Add(30 * time.Second))
+	commitAfterSecond := tsoutil.ComposeTSByTime(now.Add(32 * time.Second))
+
+	idx.UpdateAll("v1", []any{int64(1)}, firstCommit)
+	idx.UpdateAll("v1", []any{int64(2)}, secondCommit)
+
+	size, withinCapacity := snapshotPKVersionIndex(idx)
+	require.True(t, withinCapacity)
+	require.Equal(t, 1, size)
+	require.NoError(t, idx.Verify("v1", []any{int64(1)}, readAfterFirstExpired, commitAfterSecond))
+	requirePartialUpdateRetryable(t, idx.Verify("v1", []any{int64(2)}, readAfterFirstExpired, commitAfterSecond))
+}
+
+func TestPKVersionIndexKeepsUpdatedVersionPastOriginalExpiry(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(100))
+	now := time.Now()
+	firstCommit := tsoutil.ComposeTSByTime(now)
+	updatedCommit := tsoutil.ComposeTSByTime(now.Add(20 * time.Second))
+	commitAfterOriginalExpiry := tsoutil.ComposeTSByTime(now.Add(31 * time.Second))
+
+	idx.UpdateAll("v1", []any{int64(1)}, firstCommit)
+	idx.UpdateAll("v1", []any{int64(1)}, updatedCommit)
+	requirePartialUpdateRetryable(t, idx.Verify("v1", []any{int64(1)}, firstCommit, commitAfterOriginalExpiry))
+}
+
+func TestPKVersionIndexMaintainsOneExpirationPerPK(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(100))
+	base := time.Now()
+	for offset := range 10 {
+		idx.UpdateAll("v1", []any{int64(1)}, tsoutil.ComposeTSByTime(base.Add(time.Duration(offset)*time.Second)))
+	}
+
+	channel := idx.channel("v1")
+	channel.mu.Lock()
+	defer channel.mu.Unlock()
+	require.Len(t, channel.versions, 1)
+	require.Len(t, channel.expirations, 1)
+}
+
+func TestPKVersionIndexRecoversAfterBudgetEntriesExpire(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	now := time.Now()
+	firstCommit := tsoutil.ComposeTSByTime(now)
+	secondCommit := tsoutil.ComposeTSByTime(now.Add(time.Second))
+	thirdCommit := tsoutil.ComposeTSByTime(now.Add(32 * time.Second))
+
+	idx.UpdateAll("v1", []any{int64(1)}, firstCommit)
+	idx.UpdateAll("v1", []any{int64(2)}, secondCommit)
+	size, withinCapacity := snapshotPKVersionIndex(idx)
+	require.True(t, withinCapacity)
+	require.Equal(t, 1, size)
+
+	idx.UpdateAll("v1", []any{int64(3)}, thirdCommit)
+	size, withinCapacity = snapshotPKVersionIndex(idx)
+	require.True(t, withinCapacity)
+	require.Equal(t, 1, size)
+}
+
+func TestPKVersionIndexVerifyRecoversAfterBudgetEntriesExpire(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	now := time.Now()
+	firstCommit := tsoutil.ComposeTSByTime(now)
+	secondCommit := tsoutil.ComposeTSByTime(now.Add(time.Second))
+	readAfterExpiry := tsoutil.ComposeTSByTime(now.Add(31 * time.Second))
+	commitAfterExpiry := tsoutil.ComposeTSByTime(now.Add(32 * time.Second))
+
+	idx.UpdateAll("v1", []any{int64(1)}, firstCommit)
+	idx.UpdateAll("v1", []any{int64(2)}, secondCommit)
+	size, withinCapacity := snapshotPKVersionIndex(idx)
+	require.True(t, withinCapacity)
+	require.Equal(t, 1, size)
+
+	require.NoError(t, idx.Verify("v1", nil, readAfterExpiry, commitAfterExpiry))
+	size, withinCapacity = snapshotPKVersionIndex(idx)
+	require.True(t, withinCapacity)
+	require.Zero(t, size)
+	require.Zero(t, idx.budget.used.Load())
+}
+
+func TestPKVersionIndexStringPKConflict(t *testing.T) {
+	idx := newPKVersionIndex(10*time.Second, versionIndexBudgetForEntries(100))
+	idx.UpdateAll("v1", []any{"pk-1"}, 100)
+
+	requirePartialUpdateRetryable(t, idx.Verify("v1", []any{"pk-1"}, 99, 101))
+	require.NoError(t, idx.Verify("v1", []any{"pk-1"}, 100, 101))
+}
+
+func TestPKVersionIndexRejectsMalformedPK(t *testing.T) {
+	idx := newPKVersionIndex(10*time.Second, versionIndexBudgetForEntries(100))
+
+	err := idx.Verify("v1", []any{nil}, 1, 2)
+	requireUnrecoverable(t, err)
+	require.Contains(t, err.Error(), "int64 or string")
+	require.False(t, status.AsStreamingError(err).IsPartialUpdateRetryableCAS())
+
+	err = idx.Verify("v1", []any{struct{}{}}, 1, 2)
+	requireUnrecoverable(t, err)
+}
+
+func TestPKVersionIndexAccountsStringBytes(t *testing.T) {
+	budget := estimatedVersionEntryFixedBytes + 3
+	idx := newPKVersionIndex(30*time.Second, budget)
+	idx.UpdateAll("v1", []any{"abc"}, 100)
+	idx.UpdateAll("v1", []any{strings.Repeat("x", 4)}, 101)
+
+	require.Equal(t, budget, idx.budget.used.Load())
+	requirePartialUpdateRetryable(t, idx.Verify("v1", nil, 101, 102))
+}
+
+func TestPKVersionIndexBudgetMissIsVChannelScoped(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	idx.UpdateAll("v1", []any{int64(1)}, 100)
+	idx.UpdateAll("v2", []any{int64(2)}, 101)
+
+	require.NoError(t, idx.Verify("v1", nil, 100, 102))
+	requirePartialUpdateRetryable(t, idx.Verify("v2", nil, 101, 102))
+}
+
+func TestPKVersionIndexKeepsVChannelsSeparate(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(2))
+	idx.UpdateAll("v1", []any{int64(1)}, 100)
+
+	requirePartialUpdateRetryable(t, idx.Verify("v1", []any{int64(1)}, 99, 101))
+	require.NoError(t, idx.Verify("v2", []any{int64(1)}, 99, 101))
+}
+
+func TestPKVersionIndexVChannelsUseIndependentLocks(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(2))
+	v1 := idx.channel("v1")
+	v1.mu.Lock()
+
+	done := make(chan struct{})
+	go func() {
+		idx.UpdateAll("v2", []any{int64(2)}, 100)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		v1.mu.Unlock()
+	case <-time.After(time.Second):
+		v1.mu.Unlock()
+		t.Fatal("v2 update blocked on v1 index lock")
+	}
+}
+
+func TestPKVersionIndexRemoveVChannelReleasesBudget(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(3))
+	idx.UpdateAll("v1", []any{int64(1), int64(2)}, 100)
+	idx.UpdateAll("v2", []any{int64(3)}, 100)
+	require.Equal(t, versionIndexBudgetForEntries(3), idx.budget.used.Load())
+
+	idx.Remove("v1")
+
+	_, loaded := idx.channels.Load("v1")
+	require.False(t, loaded)
+	_, loaded = idx.channels.Load("v2")
+	require.True(t, loaded)
+	require.Equal(t, versionIndexBudgetForEntries(1), idx.budget.used.Load())
+	requirePartialUpdateRetryable(t, idx.Verify("v2", []any{int64(3)}, 99, 101))
+
+	idx.Remove("v1")
+	require.Equal(t, versionIndexBudgetForEntries(1), idx.budget.used.Load())
+}
+
+func TestPKVersionIndexRemoveVChannelConcurrentWithAdvance(t *testing.T) {
+	idx := newPKVersionIndex(30*time.Second, versionIndexBudgetForEntries(1))
+	now := time.Now()
+
+	for offset := range 100 {
+		commitTS := tsoutil.ComposeTSByTime(now.Add(time.Duration(offset) * time.Minute))
+		idx.UpdateAll("v1", []any{int64(offset)}, commitTS)
+
+		var waitGroup sync.WaitGroup
+		waitGroup.Add(2)
+		go func() {
+			defer waitGroup.Done()
+			idx.Advance(tsoutil.AddPhysicalDurationOnTs(commitTS, 31*time.Second))
+		}()
+		go func() {
+			defer waitGroup.Done()
+			idx.Remove("v1")
+		}()
+		waitGroup.Wait()
+
+		require.Zero(t, idx.budget.used.Load())
+	}
+
+	_, loaded := idx.channels.Load("v1")
+	require.False(t, loaded)
+}
+
+func TestCollectionFenceIndexRejectsFenceAfterRead(t *testing.T) {
+	fences := newCollectionFenceIndex()
+	fences.Update("v1", 1, 100)
+	requirePartialUpdateRetryable(t, fences.Verify("v1", 1, 99))
+	require.NoError(t, fences.Verify("v1", 1, 100))
+}
+
+func TestCollectionFenceIndexKeepsCollectionsSeparate(t *testing.T) {
+	fences := newCollectionFenceIndex()
+	fences.Update("v1", 1, 100)
+	fences.Update("v1", 2, 200)
+
+	requirePartialUpdateRetryable(t, fences.Verify("v1", 1, 99))
+	require.NoError(t, fences.Verify("v1", 1, 100))
+	requirePartialUpdateRetryable(t, fences.Verify("v1", 2, 199))
+	require.NoError(t, fences.Verify("v1", 2, 200))
+}
+
+func TestCollectionFenceIndexKeepsEntriesUntilExplicitRemoval(t *testing.T) {
+	fences := newCollectionFenceIndex()
+	now := time.Now()
+	oldFence := tsoutil.ComposeTSByTime(now)
+	newFence := tsoutil.ComposeTSByTime(now.Add(31 * time.Second))
+	fences.Update("v1", 1, oldFence)
+	fences.Update("v2", 2, newFence)
+
+	requirePartialUpdateRetryable(t, fences.Verify("v1", 1, oldFence-1))
+	requirePartialUpdateRetryable(t, fences.Verify("v2", 2, newFence-1))
+}
+
+func TestCollectionFenceIndexRemovesOnlyTargetCollection(t *testing.T) {
+	fences := newCollectionFenceIndex()
+	fences.Update("v1", 1, 100)
+	fences.Update("v1", 2, 100)
+	fences.Update("v2", 1, 100)
+
+	fences.Remove("v1", 1)
+
+	require.NoError(t, fences.Verify("v1", 1, 99))
+	requirePartialUpdateRetryable(t, fences.Verify("v1", 2, 99))
+	requirePartialUpdateRetryable(t, fences.Verify("v2", 1, 99))
+}
+
+func TestCollectionFenceIndexRemoveIgnoresEmptyCollection(t *testing.T) {
+	fences := newCollectionFenceIndex()
+	fences.Update("v1", 1, 100)
+
+	fences.Remove("v1", 0)
+
+	requirePartialUpdateRetryable(t, fences.Verify("v1", 1, 99))
+}
+
+func TestCollectionFenceIndexRejectsMalformedCollectionID(t *testing.T) {
+	fences := newCollectionFenceIndex()
+
+	err := fences.Verify("v1", 0, 100)
+	requireUnrecoverable(t, err)
+	require.Contains(t, err.Error(), "collection fence id is empty")
+	require.False(t, status.AsStreamingError(err).IsPartialUpdateRetryableCAS())
+
+	fences.Update("v1", 0, 100)
+	require.NoError(t, fences.Verify("v1", 1, 100))
+}
+
+func TestVChannelFenceIndexRejectsEarlierRead(t *testing.T) {
+	fences := newVChannelFenceIndex()
+	fences.Update("v1", 100)
+
+	requirePartialUpdateRetryable(t, fences.Verify("v1", 99))
+	require.NoError(t, fences.Verify("v1", 100))
+	require.NoError(t, fences.Verify("v2", 99))
+}
+
+func TestVChannelFenceIndexAdvancesMonotonically(t *testing.T) {
+	fences := newVChannelFenceIndex()
+	fences.Update("v1", 100)
+	fences.Update("v1", 90)
+	fences.Update("v1", 110)
+
+	requirePartialUpdateRetryable(t, fences.Verify("v1", 109))
+	require.NoError(t, fences.Verify("v1", 110))
+}
+
+func TestVChannelFenceIndexRemove(t *testing.T) {
+	fences := newVChannelFenceIndex()
+	fences.Update("v1", 100)
+	fences.Update("v2", 200)
+
+	fences.Remove("v1")
+
+	require.NoError(t, fences.Verify("v1", 99))
+	requirePartialUpdateRetryable(t, fences.Verify("v2", 199))
+	fences.Remove("v1")
+}

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor.go
@@ -100,21 +100,22 @@ func (i *appendInterceptor) appendWrite(
 ) (message.MessageID, error) {
 	meta, err := message.ExtractPartialUpdateCAS(msg)
 	if err != nil {
-		return nil, status.NewUnrecoverableError("partial update CAS metadata is malformed: %v", err)
+		return nil, status.NewUnrecoverableError("partial update CAS proof is malformed: %v", err)
 	}
 	if meta != nil && msg.TxnContext() == nil {
 		return nil, status.NewUnrecoverableError("partial update CAS message must be transactional")
 	}
 
 	var pks []any
+	var casScope casInsertScope
 	var fenceCollectionID int64
 	var droppedCollectionID int64
 	if meta != nil {
-		pks, err = extractPKsFromInsert(msg, meta.GetPrimaryKeyFieldId())
+		pks, casScope, err = extractPKsFromCASInsert(msg, i.pkDescriptorGetter)
 		if err != nil {
 			return nil, err
 		}
-		if err := i.state.recordTxnMeta(msg.TxnContext().TxnID, meta); err != nil {
+		if err := i.state.recordTxnCAS(msg.TxnContext().TxnID, meta, casScope); err != nil {
 			return nil, err
 		}
 	} else {

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor.go
@@ -1,0 +1,178 @@
+package partialupdate
+
+import (
+	"context"
+
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/shards"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+)
+
+const interceptorName = "partialupdate"
+
+var _ interceptors.InterceptorBuilder = (*interceptorBuilder)(nil)
+
+type interceptorBuilder struct{}
+
+type primaryKeyDescriptorGetter interface {
+	GetPrimaryKeyDescriptor(collectionID int64, schemaVersion int32) (shards.PrimaryKeyDescriptor, error)
+}
+
+// NewInterceptorBuilder creates one per-WAL partial-update write tracker.
+func NewInterceptorBuilder() interceptors.InterceptorBuilder {
+	return &interceptorBuilder{}
+}
+
+func (b *interceptorBuilder) Build(param *interceptors.InterceptorBuildParam) interceptors.Interceptor {
+	state := newPartialUpdateState(defaultVersionIndexTTL, defaultVersionIndexBudgetBytes)
+	state.channel = param.ChannelInfo
+	pkDescriptorGetter, _ := param.ShardManager.(primaryKeyDescriptorGetter)
+	return &appendInterceptor{
+		state:              state,
+		pkDescriptorGetter: pkDescriptorGetter,
+	}
+}
+
+type appendInterceptor struct {
+	state              *partialUpdateState
+	pkDescriptorGetter primaryKeyDescriptorGetter
+}
+
+func (i *appendInterceptor) Name() string {
+	return interceptorName
+}
+
+func (i *appendInterceptor) DoAppend(
+	ctx context.Context,
+	msg message.MutableMessage,
+	appendOp interceptors.Append,
+) (message.MessageID, error) {
+	switch msg.MessageType() {
+	case message.MessageTypeCommitTxn:
+		return i.appendCommit(ctx, msg, appendOp)
+	case message.MessageTypeRollbackTxn:
+		return i.appendRollback(ctx, msg, appendOp)
+	default:
+		return i.appendWrite(ctx, msg, appendOp)
+	}
+}
+
+func (i *appendInterceptor) appendCommit(
+	ctx context.Context,
+	msg message.MutableMessage,
+	appendOp interceptors.Append,
+) (message.MessageID, error) {
+	txnContext := msg.TxnContext()
+	if txnContext == nil {
+		return nil, status.NewUnrecoverableError("partial update commit transaction context is missing")
+	}
+	defer i.state.deleteTxn(txnContext.TxnID)
+
+	txnState, err := i.state.validateCommit(msg, txnContext.TxnID)
+	if err != nil {
+		return nil, txn.MarkCommitAdmissionRejected(err)
+	}
+	msgID, err := appendOp(ctx, msg)
+	if err != nil {
+		return msgID, err
+	}
+	i.state.publishCommit(msg, txnState)
+	return msgID, nil
+}
+
+func (i *appendInterceptor) appendRollback(
+	ctx context.Context,
+	msg message.MutableMessage,
+	appendOp interceptors.Append,
+) (message.MessageID, error) {
+	if txnContext := msg.TxnContext(); txnContext != nil {
+		defer i.state.deleteTxn(txnContext.TxnID)
+	}
+	return appendOp(ctx, msg)
+}
+
+func (i *appendInterceptor) appendWrite(
+	ctx context.Context,
+	msg message.MutableMessage,
+	appendOp interceptors.Append,
+) (message.MessageID, error) {
+	meta, err := message.ExtractPartialUpdateCAS(msg)
+	if err != nil {
+		return nil, status.NewUnrecoverableError("partial update CAS metadata is malformed: %v", err)
+	}
+	if meta != nil && msg.TxnContext() == nil {
+		return nil, status.NewUnrecoverableError("partial update CAS message must be transactional")
+	}
+
+	var pks []any
+	var fenceCollectionID int64
+	var droppedCollectionID int64
+	if meta != nil {
+		pks, err = extractPKsFromInsert(msg, meta.GetPrimaryKeyFieldId())
+		if err != nil {
+			return nil, err
+		}
+		if err := i.state.recordTxnMeta(msg.TxnContext().TxnID, meta); err != nil {
+			return nil, err
+		}
+	} else {
+		extractedPKs, ok, err := extractPKs(msg)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			pks = extractedPKs
+		} else if collectionID, ok := extractCollectionFenceID(msg); ok {
+			if collectionID == 0 {
+				return nil, status.NewUnrecoverableError("partial update collection fence has empty collection id")
+			}
+			fenceCollectionID = collectionID
+		} else if collectionID, ok := extractDropCollectionID(msg); ok {
+			if collectionID == 0 {
+				return nil, status.NewUnrecoverableError("partial update dropped collection has empty collection id")
+			}
+			droppedCollectionID = collectionID
+		} else if msg.MessageType() == message.MessageTypeInsert {
+			pks, fenceCollectionID, err = extractPKsFromOrdinaryInsert(msg, i.pkDescriptorGetter)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if msg.TxnContext() != nil {
+		i.state.registerTxnCleanup(txn.GetTxnSessionFromContext(ctx), msg.TimeTick())
+	}
+
+	msgID, err := appendOp(ctx, msg)
+	if err != nil {
+		return msgID, err
+	}
+
+	if msg.TxnContext() != nil {
+		txnID := msg.TxnContext().TxnID
+		if msg.MessageType() == message.MessageTypeBeginTxn {
+			i.state.recordTxnBegin(txnID)
+		}
+		i.state.recordTxnWrites(txnID, pks)
+		i.state.recordTxnFence(txnID, fenceCollectionID)
+		return msgID, nil
+	}
+
+	if len(pks) > 0 {
+		i.state.pkVersions.UpdateAll(msg.VChannel(), pks, msg.TimeTick())
+	} else {
+		i.state.pkVersions.Advance(msg.TimeTick())
+	}
+	if fenceCollectionID != 0 {
+		i.state.fences.Update(msg.VChannel(), fenceCollectionID, msg.TimeTick())
+	}
+	if droppedCollectionID != 0 {
+		i.state.removeDroppedVChannel(msg.VChannel(), droppedCollectionID)
+	}
+	return msgID, nil
+}
+
+func (i *appendInterceptor) Close() {}

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor_test.go
@@ -1,0 +1,935 @@
+package partialupdate
+
+import (
+	"context"
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	lockinterceptor "github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/lock"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/shards"
+	streamingtimetick "github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/timetick"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/timetick/mvcc"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
+)
+
+func TestPartialUpdateInterceptorBuildsIndependentPerWALState(t *testing.T) {
+	builder := NewInterceptorBuilder()
+	first := builder.Build(&interceptors.InterceptorBuildParam{
+		ChannelInfo: types.PChannelInfo{Name: "p1", Term: 1},
+	}).(*appendInterceptor)
+	second := builder.Build(&interceptors.InterceptorBuildParam{
+		ChannelInfo: types.PChannelInfo{Name: "p1", Term: 2},
+	}).(*appendInterceptor)
+
+	require.NotSame(t, first.state, second.state)
+	require.EqualValues(t, 1, first.state.channel.Term)
+	require.EqualValues(t, 2, second.state.channel.Term)
+	first.Close()
+	second.Close()
+}
+
+func TestPartialUpdateChainSerializesConcurrentCASCommits(t *testing.T) {
+	env := newPartialUpdateChainTestEnv(t)
+	readTS := env.allocateReadTS(t)
+	firstTxn := env.prepareCASTxn(t, readTS, 10)
+	secondTxn := env.prepareCASTxn(t, readTS, 10)
+	firstCommit := newChainTestCASCommit(t, firstTxn)
+	secondCommit := newChainTestCASCommit(t, secondTxn)
+
+	firstCommitAtWAL := make(chan struct{})
+	releaseFirstCommit := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := env.append(
+			firstCommit,
+			func(context.Context, message.MutableMessage) (message.MessageID, error) {
+				close(firstCommitAtWAL)
+				<-releaseFirstCommit
+				return env.nextMessageID(), nil
+			},
+		)
+		firstDone <- err
+	}()
+	<-firstCommitAtWAL
+
+	var commitAppendCount atomic.Int32
+	commitAppendCount.Store(1)
+	secondStarted := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		close(secondStarted)
+		_, err := env.append(
+			secondCommit,
+			func(context.Context, message.MutableMessage) (message.MessageID, error) {
+				commitAppendCount.Add(1)
+				return env.nextMessageID(), nil
+			},
+		)
+		secondDone <- err
+	}()
+	<-secondStarted
+
+	select {
+	case err := <-secondDone:
+		close(releaseFirstCommit)
+		require.NoError(t, <-firstDone)
+		t.Fatalf("second CAS completed before the first commit published its write: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseFirstCommit)
+	require.NoError(t, <-firstDone)
+	requirePartialUpdateRetryable(t, <-secondDone)
+	require.EqualValues(t, 1, commitAppendCount.Load())
+}
+
+func TestPartialUpdateChainCASWaitsForOrdinaryWritePublication(t *testing.T) {
+	env := newPartialUpdateChainTestEnv(t)
+	readTS := env.allocateReadTS(t)
+	casTxn := env.prepareCASTxn(t, readTS, 10)
+	commit := newChainTestCASCommit(t, casTxn)
+
+	writerAtWAL := make(chan struct{})
+	releaseWriter := make(chan struct{})
+	writerDone := make(chan error, 1)
+	go func() {
+		_, err := env.append(
+			newDeleteMessage(&schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10}}},
+			}),
+			func(context.Context, message.MutableMessage) (message.MessageID, error) {
+				close(writerAtWAL)
+				<-releaseWriter
+				return env.nextMessageID(), nil
+			},
+		)
+		writerDone <- err
+	}()
+	<-writerAtWAL
+
+	commitReachedWAL := make(chan struct{}, 1)
+	commitDone := make(chan error, 1)
+	go func() {
+		_, err := env.append(
+			commit,
+			func(context.Context, message.MutableMessage) (message.MessageID, error) {
+				commitReachedWAL <- struct{}{}
+				return env.nextMessageID(), nil
+			},
+		)
+		commitDone <- err
+	}()
+
+	select {
+	case err := <-commitDone:
+		close(releaseWriter)
+		require.NoError(t, <-writerDone)
+		t.Fatalf("CAS completed before the ordinary writer published its PK: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseWriter)
+	require.NoError(t, <-writerDone)
+	requirePartialUpdateRetryable(t, <-commitDone)
+	select {
+	case <-commitReachedWAL:
+		t.Fatal("conflicting CAS CommitTxn reached the WAL")
+	default:
+	}
+}
+
+func TestPartialUpdateChainPublishesCASBeforeNextOrdinaryWriter(t *testing.T) {
+	env := newPartialUpdateChainTestEnv(t)
+	readTS := env.allocateReadTS(t)
+	casTxn := env.prepareCASTxn(t, readTS, 10)
+	commit := newChainTestCASCommit(t, casTxn)
+
+	commitAtWAL := make(chan struct{})
+	releaseCommit := make(chan struct{})
+	commitDone := make(chan error, 1)
+	go func() {
+		_, err := env.append(
+			commit,
+			func(context.Context, message.MutableMessage) (message.MessageID, error) {
+				close(commitAtWAL)
+				<-releaseCommit
+				return env.nextMessageID(), nil
+			},
+		)
+		commitDone <- err
+	}()
+	<-commitAtWAL
+
+	writerAtWAL := make(chan bool, 1)
+	writerDone := make(chan error, 1)
+	go func() {
+		_, err := env.append(
+			newDeleteMessage(&schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10}}},
+			}),
+			func(context.Context, message.MutableMessage) (message.MessageID, error) {
+				writerAtWAL <- env.hasPKVersionAfter("v1", int64(10), readTS)
+				return env.nextMessageID(), nil
+			},
+		)
+		writerDone <- err
+	}()
+
+	select {
+	case <-writerAtWAL:
+		close(releaseCommit)
+		require.NoError(t, <-commitDone)
+		t.Fatal("ordinary writer reached the WAL while the CAS commit held the vchannel lock")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseCommit)
+	require.NoError(t, <-commitDone)
+	require.True(t, <-writerAtWAL, "CAS PK version was not published before the next writer acquired the vchannel lock")
+	require.NoError(t, <-writerDone)
+}
+
+func TestPartialUpdateChainExpirationCleansPendingTxn(t *testing.T) {
+	env := newPartialUpdateChainTestEnv(t)
+	readTS := env.allocateReadTS(t)
+	txnContext := env.prepareCASTxn(t, readTS, 10)
+	require.NotNil(t, env.partial.state.getTxn(txnContext.TxnID))
+
+	env.txnManager.CleanupTxnUntil(math.MaxUint64)
+	require.Nil(t, env.partial.state.getTxn(txnContext.TxnID))
+}
+
+func TestPartialUpdateChainRecoveredOrdinaryTxnKeepsCommitSemantics(t *testing.T) {
+	env := newPartialUpdateChainTestEnvWithRecoveredTxn(t, false)
+	readTS := env.allocateReadTS(t)
+
+	_, err := env.append(newCommitTxnMessage("v1", 1, 0), nil)
+	require.NoError(t, err)
+	requirePartialUpdateRetryable(t, env.partial.state.incompleteTxnFences.Verify("v1", readTS))
+
+	session, err := env.txnManager.GetSessionOfTxn(1)
+	require.NoError(t, err)
+	require.Equal(t, message.TxnStateCommitted, session.State())
+}
+
+func TestPartialUpdateChainRecoveredLocalCASReturnsRetry(t *testing.T) {
+	env := newPartialUpdateChainTestEnvWithRecoveredTxn(t, true)
+	commit := newCASCommitTxnMessage(t, "v1", 1, 0)
+
+	_, err := env.append(commit, nil)
+	requirePartialUpdateRetryable(t, err)
+	require.True(t, txn.IsCommitAdmissionRejected(err))
+
+	session, err := env.txnManager.GetSessionOfTxn(1)
+	require.NoError(t, err)
+	require.Equal(t, message.TxnStateRollbacked, session.State())
+}
+
+func TestPartialUpdateInterceptorRecordsTxnWriteAndMetaAfterAppend(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	meta := validCASMeta(100, 1)
+	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(10)}, meta).
+		WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
+		WithTimeTick(120)
+
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	require.NoError(t, err)
+	txnState := interceptor.state.getTxn(1)
+	require.Equal(t, []any{int64(10)}, txnState.pks)
+	require.True(t, proto.Equal(meta, txnState.meta))
+}
+
+func TestPartialUpdateInterceptorCollectsPKsAcrossInsertChunks(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	meta := validCASMeta(100, 1)
+
+	for idx, pks := range [][]int64{{10}, {20, 30}} {
+		msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(pks...)}, meta).
+			WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
+			WithTimeTick(uint64(120 + idx))
+		_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+		require.NoError(t, err)
+	}
+
+	txnState := interceptor.state.getTxn(1)
+	require.Equal(t, []any{int64(10), int64(20), int64(30)}, txnState.pks)
+	require.True(t, proto.Equal(meta, txnState.meta))
+}
+
+func TestPartialUpdateInterceptorPublishesConcurrentTxnBodies(t *testing.T) {
+	for _, replicated := range []bool{false, true} {
+		t.Run(map[bool]string{false: "ordinary", true: "replicated"}[replicated], func(t *testing.T) {
+			interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+			txnContext := message.TxnContext{TxnID: 1, Keepalive: time.Second}
+			interceptor.state.recordTxnBegin(txnContext.TxnID)
+			bodies := make([]message.MutableMessage, 0, 3)
+			for idx, pk := range []int64{10, 20, 30} {
+				body := newDeleteMessage(&schemapb.IDs{
+					IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{pk}}},
+				}).WithTxnContext(txnContext).WithTimeTick(uint64(120 + idx))
+				if replicated {
+					body = body.WithReplicateHeader(newChainTestReplicateHeader(int64(idx+1), body.TimeTick()))
+				}
+				bodies = append(bodies, body)
+			}
+
+			var wg sync.WaitGroup
+			errs := make(chan error, len(bodies))
+			for _, body := range bodies {
+				wg.Add(1)
+				go func(body message.MutableMessage) {
+					defer wg.Done()
+					_, err := interceptor.DoAppend(context.Background(), body, appendOK)
+					errs <- err
+				}(body)
+			}
+			wg.Wait()
+			close(errs)
+			for err := range errs {
+				require.NoError(t, err)
+			}
+
+			commit := newCommitTxnMessage("v1", txnContext.TxnID, 130)
+			if replicated {
+				commit = commit.WithReplicateHeader(newChainTestReplicateHeader(4, commit.TimeTick()))
+			}
+			_, err := interceptor.DoAppend(context.Background(), commit, appendOK)
+			require.NoError(t, err)
+			for _, pk := range []int64{10, 20, 30} {
+				requirePartialUpdateRetryable(t, interceptor.state.pkVersions.Verify("v1", []any{pk}, 129, 131))
+			}
+		})
+	}
+}
+
+func TestPartialUpdateInterceptorCommitsCAS(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	appendCASTxnBody(t, interceptor, 1, validCASMeta(100, 1), 120, 10)
+	commit := newCASCommitTxnMessage(t, "v1", 1, 130)
+
+	_, err := interceptor.DoAppend(context.Background(), commit, appendOK)
+	require.NoError(t, err)
+	require.Nil(t, interceptor.state.getTxn(1))
+	requirePartialUpdateRetryable(t, interceptor.state.pkVersions.Verify("v1", []any{int64(10)}, 129, 131))
+}
+
+func TestPartialUpdateInterceptorRejectsCommitWithoutTxnContext(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	commit := message.NewCommitTxnMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&message.CommitTxnMessageHeader{}).
+		WithBody(&message.CommitTxnMessageBody{}).
+		MustBuildMutable()
+
+	_, err := interceptor.DoAppend(context.Background(), commit, appendOK)
+	requireUnrecoverable(t, err)
+}
+
+func TestPartialUpdateInterceptorRejectsCASConflictBeforeAppend(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	appendCASTxnBody(t, interceptor, 1, validCASMeta(100, 1), 120, 10)
+	interceptor.state.pkVersions.UpdateAll("v1", []any{int64(10)}, 125)
+	called := false
+
+	_, err := interceptor.DoAppend(context.Background(), newCASCommitTxnMessage(t, "v1", 1, 130), func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		called = true
+		return walimplstest.NewTestMessageID(1), nil
+	})
+
+	requirePartialUpdateRetryable(t, err)
+	require.False(t, called)
+	require.Nil(t, interceptor.state.getTxn(1))
+}
+
+func TestPartialUpdateInterceptorCommitAppendErrorDoesNotPublish(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	appendCASTxnBody(t, interceptor, 1, validCASMeta(100, 1), 120, 10)
+	expectedErr := errors.New("append failed")
+
+	_, err := interceptor.DoAppend(context.Background(), newCASCommitTxnMessage(t, "v1", 1, 130), func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		return nil, expectedErr
+	})
+
+	require.ErrorIs(t, err, expectedErr)
+	require.Nil(t, interceptor.state.getTxn(1))
+	require.NoError(t, interceptor.state.pkVersions.Verify("v1", []any{int64(10)}, 129, 131))
+}
+
+func TestPartialUpdateInterceptorRejectsMissingCommitMarker(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	appendCASTxnBody(t, interceptor, 1, validCASMeta(100, 1), 120, 10)
+	called := false
+
+	_, err := interceptor.DoAppend(context.Background(), newCommitTxnMessage("v1", 1, 130), func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		called = true
+		return walimplstest.NewTestMessageID(1), nil
+	})
+
+	requireUnrecoverable(t, err)
+	require.False(t, called)
+}
+
+func TestPartialUpdateInterceptorPublishesOrdinaryTxn(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	interceptor.state.recordTxnBegin(1)
+	body := newDeleteMessage(&schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10}}},
+	}).WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).WithTimeTick(120)
+	_, err := interceptor.DoAppend(context.Background(), body, appendOK)
+	require.NoError(t, err)
+
+	_, err = interceptor.DoAppend(context.Background(), newCommitTxnMessage("v1", 1, 130), appendOK)
+	require.NoError(t, err)
+	requirePartialUpdateRetryable(t, interceptor.state.pkVersions.Verify("v1", []any{int64(10)}, 129, 131))
+}
+
+func TestPartialUpdateInterceptorRecoveredOrdinaryTxnUsesVChannelFence(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	body := newDeleteMessage(&schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10}}},
+	}).WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).WithTimeTick(120)
+	_, err := interceptor.DoAppend(context.Background(), body, appendOK)
+	require.NoError(t, err)
+	require.False(t, interceptor.state.getTxn(1).observedBegin)
+
+	_, err = interceptor.DoAppend(context.Background(), newCommitTxnMessage("v1", 1, 130), appendOK)
+	require.NoError(t, err)
+	requirePartialUpdateRetryable(t, interceptor.state.incompleteTxnFences.Verify("v1", 129))
+	require.NoError(t, interceptor.state.incompleteTxnFences.Verify("v1", 130))
+}
+
+func TestPartialUpdateInterceptorRecoveredLocalCASRetries(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(10)}, validCASMeta(100, 1)).
+		WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
+		WithTimeTick(120)
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	require.NoError(t, err)
+
+	called := false
+	_, err = interceptor.DoAppend(
+		context.Background(),
+		newCASCommitTxnMessage(t, "v1", 1, 130),
+		func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			called = true
+			return walimplstest.NewTestMessageID(1), nil
+		},
+	)
+	requirePartialUpdateRetryable(t, err)
+	require.True(t, txn.IsCommitAdmissionRejected(err))
+	require.False(t, called)
+}
+
+func TestPartialUpdateInterceptorRecoveredReplicatedCASUsesVChannelFence(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 2})
+	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(10)}, validCASMeta(100, 1)).
+		WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
+		WithTimeTick(120)
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	require.NoError(t, err)
+
+	commit := newCASCommitTxnMessage(t, "v1", 1, 130).
+		WithReplicateHeader(newChainTestReplicateHeader(2, 130))
+	_, err = interceptor.DoAppend(context.Background(), commit, appendOK)
+	require.NoError(t, err)
+	requirePartialUpdateRetryable(t, interceptor.state.incompleteTxnFences.Verify("v1", 129))
+}
+
+func TestPartialUpdateInterceptorReplicatedCASBypassesSourceTerm(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 2})
+	appendCASTxnBody(t, interceptor, 1, validCASMeta(100, 1), 120, 10)
+	commit := newCASCommitTxnMessage(t, "v1", 1, 130).WithReplicateHeader(&message.ReplicateHeader{
+		ClusterID:              "primary",
+		MessageID:              walimplstest.NewTestMessageID(10),
+		LastConfirmedMessageID: walimplstest.NewTestMessageID(9),
+		TimeTick:               130,
+		VChannel:               "v1",
+	})
+
+	_, err := interceptor.DoAppend(context.Background(), commit, appendOK)
+	require.NoError(t, err)
+	requirePartialUpdateRetryable(t, interceptor.state.pkVersions.Verify("v1", []any{int64(10)}, 129, 131))
+}
+
+func TestPartialUpdateInterceptorRollbackCleansTxnState(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	appendCASTxnBody(t, interceptor, 1, validCASMeta(100, 1), 120, 10)
+	rollback := message.NewRollbackTxnMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&message.RollbackTxnMessageHeader{}).
+		WithBody(&message.RollbackTxnMessageBody{}).
+		MustBuildMutable().
+		WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
+		WithTimeTick(130)
+
+	_, err := interceptor.DoAppend(context.Background(), rollback, appendOK)
+	require.NoError(t, err)
+	require.Nil(t, interceptor.state.getTxn(1))
+}
+
+func TestPartialUpdateInterceptorRejectsMalformedCASBeforeAppend(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	msg := withRawPartialUpdateCAS(
+		newInsertMessage([]*schemapb.FieldData{int64PKFieldData(10)}).
+			WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
+			WithTimeTick(120),
+		"bad-cas",
+	)
+	called := false
+
+	_, err := interceptor.DoAppend(context.Background(), msg, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		called = true
+		return walimplstest.NewTestMessageID(1), nil
+	})
+
+	requireUnrecoverable(t, err)
+	require.False(t, called)
+}
+
+func TestPartialUpdateInterceptorRejectsNonTransactionalCAS(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(10)}, validCASMeta(100, 1)).WithTimeTick(120)
+
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	requireUnrecoverable(t, err)
+}
+
+func TestPartialUpdateInterceptorRejectsCASWithMissingPKField(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	meta := validCASMeta(100, 1)
+	meta.PrimaryKeyFieldId = 999
+	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(10)}, meta).
+		WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
+		WithTimeTick(120)
+
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	requireUnrecoverable(t, err)
+}
+
+func TestPartialUpdateInterceptorRejectsMalformedDeleteBody(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	msg := corruptMessageBody(newDeleteMessage(&schemapb.IDs{})).WithTimeTick(120)
+
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	requireUnrecoverable(t, err)
+}
+
+func TestPartialUpdateInterceptorUpdatesNonTxnDeletePKAfterAppend(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	msg := newDeleteMessage(&schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10}}},
+	}).WithTimeTick(120)
+
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	require.NoError(t, err)
+	requirePartialUpdateRetryable(t, interceptor.state.pkVersions.Verify("v1", []any{int64(10)}, 119, 121))
+}
+
+func TestPartialUpdateInterceptorTimeTickAdvancesPKVersionRetention(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	now := time.Now()
+	commitTS := tsoutil.ComposeTSByTime(now)
+	advanceTS := tsoutil.ComposeTSByTime(now.Add(31 * time.Second))
+	interceptor.state.pkVersions.UpdateAll("v1", []any{int64(10)}, commitTS)
+
+	msg := streamingtimetick.NewTimeTickMsg(advanceTS, nil, 1, false)
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	require.NoError(t, err)
+
+	size, withinCapacity := snapshotPKVersionIndex(interceptor.state.pkVersions)
+	require.True(t, withinCapacity)
+	require.Zero(t, size)
+}
+
+func TestPartialUpdateInterceptorCollectionFences(t *testing.T) {
+	t.Run("truncate", func(t *testing.T) {
+		interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+		_, err := interceptor.DoAppend(context.Background(), newTruncateCollectionMessage(10).WithTimeTick(120), appendOK)
+		require.NoError(t, err)
+		requirePartialUpdateRetryable(t, interceptor.state.fences.Verify("v1", 10, 119))
+	})
+	t.Run("drop collection", func(t *testing.T) {
+		interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+		interceptor.state.pkVersions.UpdateAll("v1", []any{int64(10)}, 110)
+		interceptor.state.pkVersions.UpdateAll("v2", []any{int64(20)}, 110)
+		interceptor.state.incompleteTxnFences.Update("v1", 110)
+		interceptor.state.incompleteTxnFences.Update("v2", 110)
+		interceptor.state.fences.Update("v1", 10, 110)
+		interceptor.state.fences.Update("v2", 20, 110)
+		_, err := interceptor.DoAppend(context.Background(), newDropCollectionMessage(10).WithTimeTick(120), appendOK)
+		require.NoError(t, err)
+
+		_, loaded := interceptor.state.pkVersions.channels.Load("v1")
+		require.False(t, loaded)
+		_, loaded = interceptor.state.pkVersions.channels.Load("v2")
+		require.True(t, loaded)
+		require.Equal(t, versionIndexBudgetForEntries(1), interceptor.state.pkVersions.budget.used.Load())
+		requirePartialUpdateRetryable(t, interceptor.state.pkVersions.Verify("v2", []any{int64(20)}, 109, 121))
+		require.NoError(t, interceptor.state.incompleteTxnFences.Verify("v1", 109))
+		requirePartialUpdateRetryable(t, interceptor.state.incompleteTxnFences.Verify("v2", 109))
+		require.NoError(t, interceptor.state.fences.Verify("v1", 10, 109))
+		requirePartialUpdateRetryable(t, interceptor.state.fences.Verify("v2", 20, 109))
+	})
+}
+
+func TestPartialUpdateInterceptorKeepsStateWhenDropCollectionAppendFails(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	interceptor.state.pkVersions.UpdateAll("v1", []any{int64(10)}, 110)
+	interceptor.state.incompleteTxnFences.Update("v1", 110)
+	interceptor.state.fences.Update("v1", 10, 110)
+	expectedErr := errors.New("append failed")
+
+	_, err := interceptor.DoAppend(context.Background(), newDropCollectionMessage(10).WithTimeTick(120), func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		return nil, expectedErr
+	})
+
+	require.ErrorIs(t, err, expectedErr)
+	_, loaded := interceptor.state.pkVersions.channels.Load("v1")
+	require.True(t, loaded)
+	require.Equal(t, versionIndexBudgetForEntries(1), interceptor.state.pkVersions.budget.used.Load())
+	requirePartialUpdateRetryable(t, interceptor.state.pkVersions.Verify("v1", []any{int64(10)}, 109, 121))
+	requirePartialUpdateRetryable(t, interceptor.state.incompleteTxnFences.Verify("v1", 109))
+	requirePartialUpdateRetryable(t, interceptor.state.fences.Verify("v1", 10, 109))
+}
+
+func TestPartialUpdateInterceptorRejectsEmptyDropCollectionBeforeAppend(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	called := false
+
+	_, err := interceptor.DoAppend(context.Background(), newDropCollectionMessage(0).WithTimeTick(120), func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		called = true
+		return walimplstest.NewTestMessageID(1), nil
+	})
+
+	requireUnrecoverable(t, err)
+	require.False(t, called)
+}
+
+func TestPartialUpdateInterceptorExtractsOrdinaryInsertPKUsingDescriptor(t *testing.T) {
+	schemaManager := &partialUpdateSchemaManagerTarget{}
+	descriptor := shards.PrimaryKeyDescriptor{FieldID: 100, DataType: schemapb.DataType_Int64}
+	m := mockey.Mock((*partialUpdateSchemaManagerTarget).GetPrimaryKeyDescriptor).Return(descriptor, nil).Build()
+	defer m.UnPatch()
+	interceptor := NewInterceptorBuilder().Build(&interceptors.InterceptorBuildParam{
+		ChannelInfo:  types.PChannelInfo{Name: "p1", Term: 1},
+		ShardManager: schemaManager,
+	}).(*appendInterceptor)
+
+	_, err := interceptor.DoAppend(
+		context.Background(),
+		newInsertMessage([]*schemapb.FieldData{int64PKFieldData(10)}).WithTimeTick(120),
+		appendOK,
+	)
+	require.NoError(t, err)
+	requirePartialUpdateRetryable(t, interceptor.state.pkVersions.Verify("v1", []any{int64(10)}, 119, 121))
+}
+
+func TestPartialUpdateInterceptorFallsBackToFenceWithoutSchema(t *testing.T) {
+	schemaManager := &partialUpdateSchemaManagerTarget{}
+	m := mockey.Mock((*partialUpdateSchemaManagerTarget).GetPrimaryKeyDescriptor).
+		Return(shards.PrimaryKeyDescriptor{}, shards.ErrCollectionSchemaNotFound).
+		Build()
+	defer m.UnPatch()
+	interceptor := NewInterceptorBuilder().Build(&interceptors.InterceptorBuildParam{
+		ChannelInfo:  types.PChannelInfo{Name: "p1", Term: 1},
+		ShardManager: schemaManager,
+	}).(*appendInterceptor)
+	msg := newInsertMessage([]*schemapb.FieldData{int64PKFieldData(10)})
+	insertMsg := message.MustAsMutableInsertMessageV1(msg)
+	header := insertMsg.Header()
+	header.SchemaVersion = nil
+	insertMsg.OverwriteHeader(header)
+
+	_, err := interceptor.DoAppend(context.Background(), msg.WithTimeTick(120), appendOK)
+	require.NoError(t, err)
+	requirePartialUpdateRetryable(t, interceptor.state.fences.Verify("v1", 10, 119))
+}
+
+func TestPartialUpdateInterceptorPreservesSchemaVersionMismatch(t *testing.T) {
+	schemaManager := &partialUpdateSchemaManagerTarget{}
+	m := mockey.Mock((*partialUpdateSchemaManagerTarget).GetPrimaryKeyDescriptor).
+		Return(shards.PrimaryKeyDescriptor{}, shards.ErrCollectionSchemaVersionNotMatch).
+		Build()
+	defer m.UnPatch()
+	interceptor := NewInterceptorBuilder().Build(&interceptors.InterceptorBuildParam{
+		ChannelInfo:  types.PChannelInfo{Name: "p1", Term: 1},
+		ShardManager: schemaManager,
+	}).(*appendInterceptor)
+
+	_, err := interceptor.DoAppend(
+		context.Background(),
+		newInsertMessage([]*schemapb.FieldData{int64PKFieldData(10)}).WithTimeTick(120),
+		appendOK,
+	)
+	require.Error(t, err)
+	require.True(t, status.AsStreamingError(err).IsSchemaVersionMismatch())
+}
+
+func TestPartialUpdateInterceptorRejectsTxnCASAttemptMismatchBeforeAppend(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	require.NoError(t, interceptor.state.recordTxnMeta(1, validCASMeta(100, 1)))
+	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(20)}, validCASMeta(101, 1)).
+		WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
+		WithTimeTick(120)
+	called := false
+
+	_, err := interceptor.DoAppend(context.Background(), msg, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		called = true
+		return walimplstest.NewTestMessageID(1), nil
+	})
+
+	requireUnrecoverable(t, err)
+	require.False(t, called)
+}
+
+type partialUpdateChainTestEnv struct {
+	chain        interceptors.InterceptorWithReady
+	partial      *appendInterceptor
+	txnManager   *txn.TxnManager
+	writeMetrics *metricsutil.WriteMetrics
+	nextID       atomic.Int64
+}
+
+func newPartialUpdateChainTestEnv(t *testing.T) *partialUpdateChainTestEnv {
+	return newPartialUpdateChainTestEnvWithBuilders(t, nil)
+}
+
+func newPartialUpdateChainTestEnvWithRecoveredTxn(t *testing.T, cas bool) *partialUpdateChainTestEnv {
+	t.Helper()
+	txnContext := message.TxnContext{TxnID: 1, Keepalive: message.TxnKeepaliveInfinite}
+	begin := message.NewBeginTxnMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&message.BeginTxnMessageHeader{}).
+		WithBody(&message.BeginTxnMessageBody{}).
+		MustBuildMutable().
+		WithTxnContext(txnContext).
+		WithTimeTick(10)
+	beginID := walimplstest.NewTestMessageID(10)
+	builder := message.NewImmutableTxnMessageBuilder(
+		message.MustAsImmutableBeginTxnMessageV2(begin.IntoImmutableMessage(beginID)),
+	)
+
+	var body message.MutableMessage
+	if cas {
+		body = newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(10)}, validCASMeta(5, 1))
+	} else {
+		body = newDeleteMessage(&schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10}}},
+		})
+	}
+	body = body.WithTxnContext(txnContext).WithTimeTick(11)
+	builder.Add(body.IntoImmutableMessage(walimplstest.NewTestMessageID(11)))
+	return newPartialUpdateChainTestEnvWithBuilders(t, map[message.TxnID]*message.ImmutableTxnMessageBuilder{
+		txnContext.TxnID: builder,
+	})
+}
+
+func newPartialUpdateChainTestEnvWithBuilders(
+	t *testing.T,
+	builders map[message.TxnID]*message.ImmutableTxnMessageBuilder,
+) *partialUpdateChainTestEnv {
+	t.Helper()
+	paramtable.Init()
+	resource.InitForTest(t)
+
+	channel := types.PChannelInfo{Name: "p1", Term: 1}
+	lastConfirmed := walimplstest.NewTestMessageID(0)
+	lastTimeTick := streamingtimetick.NewTimeTickMsg(1, lastConfirmed, 0, true).
+		IntoImmutableMessage(lastConfirmed)
+	txnManager := txn.NewTxnManager(channel, builders)
+	if len(builders) == 0 {
+		<-txnManager.RecoverDone()
+	}
+	param := &interceptors.InterceptorBuildParam{
+		ChannelInfo:            channel,
+		LastTimeTickMessage:    lastTimeTick,
+		LastConfirmedMessageID: lastConfirmed,
+		MVCCManager:            mvcc.NewMVCCManager(lastTimeTick.TimeTick()),
+		TxnManager:             txnManager,
+	}
+	partial := NewInterceptorBuilder().Build(param).(*appendInterceptor)
+	chain := interceptors.NewChainedInterceptor(
+		lockinterceptor.NewInterceptorBuilder().Build(param),
+		streamingtimetick.NewInterceptorBuilder().Build(param),
+		partial,
+	)
+	writeMetrics := metricsutil.NewWriteMetrics(channel, message.WALNameRocksmq)
+	t.Cleanup(writeMetrics.Close)
+	t.Cleanup(chain.Close)
+	return &partialUpdateChainTestEnv{
+		chain:        chain,
+		partial:      partial,
+		txnManager:   txnManager,
+		writeMetrics: writeMetrics,
+	}
+}
+
+func (e *partialUpdateChainTestEnv) append(
+	msg message.MutableMessage,
+	appendOp interceptors.Append,
+) (*utility.ExtraAppendResult, error) {
+	if appendOp == nil {
+		appendOp = func(context.Context, message.MutableMessage) (message.MessageID, error) {
+			return e.nextMessageID(), nil
+		}
+	}
+	extra := &utility.ExtraAppendResult{}
+	ctx := utility.WithExtraAppendResult(context.Background(), extra)
+	ctx = utility.WithAppendMetricsContext(ctx, e.writeMetrics.StartAppend(msg))
+	_, err := e.chain.DoAppend(ctx, msg, appendOp)
+	return extra, err
+}
+
+func (e *partialUpdateChainTestEnv) allocateReadTS(t *testing.T) uint64 {
+	t.Helper()
+	readTS, err := resource.Resource().TSOAllocator().Allocate(context.Background())
+	require.NoError(t, err)
+	return readTS
+}
+
+func (e *partialUpdateChainTestEnv) prepareCASTxn(t *testing.T, readTS uint64, pk int64) message.TxnContext {
+	t.Helper()
+	begin := message.NewBeginTxnMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&message.BeginTxnMessageHeader{KeepaliveMilliseconds: time.Second.Milliseconds()}).
+		WithBody(&message.BeginTxnMessageBody{}).
+		MustBuildMutable()
+	result, err := e.append(begin, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result.TxnCtx)
+
+	meta := validCASMeta(readTS, 1)
+	meta.CollectionId = 10
+	body := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(pk)}, meta).
+		WithTxnContext(*result.TxnCtx)
+	_, err = e.append(body, nil)
+	require.NoError(t, err)
+	return *result.TxnCtx
+}
+
+func (e *partialUpdateChainTestEnv) nextMessageID() message.MessageID {
+	return walimplstest.NewTestMessageID(e.nextID.Add(1))
+}
+
+func (e *partialUpdateChainTestEnv) hasPKVersionAfter(vchannel string, pk any, readTS uint64) bool {
+	channel := e.partial.state.pkVersions.channel(vchannel)
+	channel.mu.Lock()
+	defer channel.mu.Unlock()
+	entry := channel.versions[pk]
+	return entry != nil && entry.commitTS > readTS
+}
+
+func newChainTestCASCommit(t *testing.T, txnContext message.TxnContext) message.MutableMessage {
+	t.Helper()
+	commit := message.NewCommitTxnMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&message.CommitTxnMessageHeader{}).
+		WithBody(&message.CommitTxnMessageBody{}).
+		MustBuildMutable().
+		WithTxnContext(txnContext)
+	require.NoError(t, message.MarkPartialUpdateCASCommit(commit))
+	return commit
+}
+
+func newChainTestReplicateHeader(id int64, timetick uint64) *message.ReplicateHeader {
+	msgID := walimplstest.NewTestMessageID(id)
+	return &message.ReplicateHeader{
+		ClusterID:              "primary",
+		MessageID:              msgID,
+		LastConfirmedMessageID: msgID,
+		TimeTick:               timetick,
+		VChannel:               "v1",
+	}
+}
+
+func appendCASTxnBody(
+	t *testing.T,
+	interceptor *appendInterceptor,
+	txnID message.TxnID,
+	meta *messagespb.PartialUpdateCAS,
+	timetick uint64,
+	pks ...int64,
+) {
+	t.Helper()
+	interceptor.state.recordTxnBegin(txnID)
+	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(pks...)}, meta).
+		WithTxnContext(message.TxnContext{TxnID: txnID, Keepalive: time.Second}).
+		WithTimeTick(timetick)
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	require.NoError(t, err)
+}
+
+func newTestAppendInterceptor(channel types.PChannelInfo) *appendInterceptor {
+	state := newPartialUpdateState(30*time.Second, versionIndexBudgetForEntries(100))
+	state.channel = channel
+	return &appendInterceptor{state: state}
+}
+
+func appendOK(context.Context, message.MutableMessage) (message.MessageID, error) {
+	return walimplstest.NewTestMessageID(1), nil
+}
+
+func newCASInsertMessage(
+	t *testing.T,
+	fields []*schemapb.FieldData,
+	meta *messagespb.PartialUpdateCAS,
+) message.MutableMessage {
+	t.Helper()
+	schemaVersion := int32(1)
+	builder := message.NewInsertMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&message.InsertMessageHeader{
+			CollectionId:  10,
+			SchemaVersion: &schemaVersion,
+		}).
+		WithBody(&msgpb.InsertRequest{FieldsData: fields})
+	require.NoError(t, builder.AddPartialUpdateCAS(meta))
+	return builder.MustBuildMutable()
+}
+
+type partialUpdateSchemaManagerTarget struct {
+	shards.ShardManager
+	primaryKeyDescriptorGetter
+}
+
+func withRawPartialUpdateCAS(msg message.MutableMessage, raw string) message.MutableMessage {
+	insertMsg := message.MustAsMutableInsertMessageV1(msg)
+	body := insertMsg.MustBody()
+	if body.Base == nil {
+		body.Base = &commonpb.MsgBase{}
+	}
+	if body.Base.Properties == nil {
+		body.Base.Properties = make(map[string]string)
+	}
+	body.Base.Properties["_puc"] = raw
+	insertMsg.OverwriteBody(body)
+
+	props := make(map[string]string, len(msg.Properties().ToRawMap())+1)
+	for key, value := range msg.Properties().ToRawMap() {
+		props[key] = value
+	}
+	props["_puc"] = ""
+	return message.NewMutableMessageBeforeAppend(msg.Payload(), props)
+}

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor_test.go
@@ -786,6 +786,14 @@ func newPartialUpdateChainTestEnvWithBuilders(
 		LastConfirmedMessageID: lastConfirmed,
 		MVCCManager:            mvcc.NewMVCCManager(lastTimeTick.TimeTick()),
 		TxnManager:             txnManager,
+		ShardManager: &partialUpdateSchemaManagerTarget{
+			primaryKeyDescriptorGetter: &staticPrimaryKeyDescriptorGetter{
+				descriptor: shards.PrimaryKeyDescriptor{
+					FieldID:  100,
+					DataType: schemapb.DataType_Int64,
+				},
+			},
+		},
 	}
 	partial := NewInterceptorBuilder().Build(param).(*appendInterceptor)
 	chain := interceptors.NewChainedInterceptor(

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/interceptor_test.go
@@ -259,6 +259,9 @@ func TestPartialUpdateInterceptorRecordsTxnWriteAndMetaAfterAppend(t *testing.T)
 	txnState := interceptor.state.getTxn(1)
 	require.Equal(t, []any{int64(10)}, txnState.pks)
 	require.True(t, proto.Equal(meta, txnState.meta))
+	require.EqualValues(t, 10, txnState.collectionID)
+	require.EqualValues(t, 1, txnState.schemaVersion)
+	require.True(t, txnState.casScopeSet)
 }
 
 func TestPartialUpdateInterceptorCollectsPKsAcrossInsertChunks(t *testing.T) {
@@ -518,11 +521,23 @@ func TestPartialUpdateInterceptorRejectsNonTransactionalCAS(t *testing.T) {
 
 func TestPartialUpdateInterceptorRejectsCASWithMissingPKField(t *testing.T) {
 	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
-	meta := validCASMeta(100, 1)
-	meta.PrimaryKeyFieldId = 999
-	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(10)}, meta).
+	msg := newCASInsertMessage(t, nil, validCASMeta(100, 1)).
 		WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
 		WithTimeTick(120)
+
+	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
+	requireUnrecoverable(t, err)
+}
+
+func TestPartialUpdateInterceptorRejectsCASWithoutExplicitSchemaVersion(t *testing.T) {
+	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
+	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(10)}, validCASMeta(100, 1)).
+		WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
+		WithTimeTick(120)
+	insertMsg := message.MustAsMutableInsertMessageV1(msg)
+	header := insertMsg.Header()
+	header.SchemaVersion = nil
+	insertMsg.OverwriteHeader(header)
 
 	_, err := interceptor.DoAppend(context.Background(), msg, appendOK)
 	requireUnrecoverable(t, err)
@@ -689,7 +704,10 @@ func TestPartialUpdateInterceptorPreservesSchemaVersionMismatch(t *testing.T) {
 
 func TestPartialUpdateInterceptorRejectsTxnCASAttemptMismatchBeforeAppend(t *testing.T) {
 	interceptor := newTestAppendInterceptor(types.PChannelInfo{Name: "p1", Term: 1})
-	require.NoError(t, interceptor.state.recordTxnMeta(1, validCASMeta(100, 1)))
+	require.NoError(t, interceptor.state.recordTxnCAS(1, validCASMeta(100, 1), casInsertScope{
+		collectionID:  10,
+		schemaVersion: 1,
+	}))
 	msg := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(20)}, validCASMeta(101, 1)).
 		WithTxnContext(message.TxnContext{TxnID: 1, Keepalive: time.Second}).
 		WithTimeTick(120)
@@ -820,9 +838,7 @@ func (e *partialUpdateChainTestEnv) prepareCASTxn(t *testing.T, readTS uint64, p
 	require.NoError(t, err)
 	require.NotNil(t, result.TxnCtx)
 
-	meta := validCASMeta(readTS, 1)
-	meta.CollectionId = 10
-	body := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(pk)}, meta).
+	body := newCASInsertMessage(t, []*schemapb.FieldData{int64PKFieldData(pk)}, validCASMeta(readTS, 1)).
 		WithTxnContext(*result.TxnCtx)
 	_, err = e.append(body, nil)
 	require.NoError(t, err)
@@ -884,7 +900,15 @@ func appendCASTxnBody(
 func newTestAppendInterceptor(channel types.PChannelInfo) *appendInterceptor {
 	state := newPartialUpdateState(30*time.Second, versionIndexBudgetForEntries(100))
 	state.channel = channel
-	return &appendInterceptor{state: state}
+	return &appendInterceptor{
+		state: state,
+		pkDescriptorGetter: &staticPrimaryKeyDescriptorGetter{
+			descriptor: shards.PrimaryKeyDescriptor{
+				FieldID:  100,
+				DataType: schemapb.DataType_Int64,
+			},
+		},
+	}
 }
 
 func appendOK(context.Context, message.MutableMessage) (message.MessageID, error) {

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/pk_extract.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/pk_extract.go
@@ -14,6 +14,11 @@ import (
 // when an insert header does not carry an explicit version.
 const latestCollectionSchemaVersion int32 = -1
 
+type casInsertScope struct {
+	collectionID  int64
+	schemaVersion int32
+}
+
 // extractPKs extracts row-content primary keys from WAL delete messages.
 // ok=false means callers must handle inserts and collection-wide writes separately.
 func extractPKs(msg message.MutableMessage) ([]any, bool, error) {
@@ -53,6 +58,78 @@ func extractPKsFromInsert(msg message.MutableMessage, fieldID int64) ([]any, err
 		return nil, status.NewUnrecoverableError("decode partial update insert body failed: %v", err)
 	}
 	return extractPKsFromFieldData(body.GetFieldsData(), fieldID)
+}
+
+// extractPKsFromCASInsert derives collection and PK identity from the Insert
+// header and ShardManager instead of trusting attempt-scoped CAS proof.
+func extractPKsFromCASInsert(
+	msg message.MutableMessage,
+	descriptorGetter primaryKeyDescriptorGetter,
+) ([]any, casInsertScope, error) {
+	if descriptorGetter == nil {
+		return nil, casInsertScope{}, status.NewUnrecoverableError(
+			"partial update primary key descriptor getter is unavailable",
+		)
+	}
+	insertMsg, err := message.AsMutableInsertMessageV1(msg)
+	if err != nil {
+		return nil, casInsertScope{}, status.NewUnrecoverableError(
+			"decode partial update insert message failed: %v",
+			err,
+		)
+	}
+	header := insertMsg.Header()
+	if header.GetCollectionId() == 0 {
+		return nil, casInsertScope{}, status.NewUnrecoverableError(
+			"partial update CAS insert collection id is empty",
+		)
+	}
+	if header.SchemaVersion == nil {
+		return nil, casInsertScope{}, status.NewUnrecoverableError(
+			"partial update CAS insert schema version is missing",
+		)
+	}
+
+	scope := casInsertScope{
+		collectionID:  header.GetCollectionId(),
+		schemaVersion: header.GetSchemaVersion(),
+	}
+	descriptor, err := descriptorGetter.GetPrimaryKeyDescriptor(
+		scope.collectionID,
+		scope.schemaVersion,
+	)
+	if err != nil {
+		if errors.Is(err, shards.ErrCollectionSchemaVersionNotMatch) {
+			return nil, casInsertScope{}, status.NewSchemaVersionMismatch(
+				"schema version mismatch while validating partial update CAS, collection: %d, schema version: %d",
+				scope.collectionID,
+				scope.schemaVersion,
+			)
+		}
+		return nil, casInsertScope{}, status.NewUnrecoverableError(
+			"get primary key descriptor for partial update CAS failed: %v",
+			err,
+		)
+	}
+	if descriptor.FieldID <= 0 || !typeutil.IsPrimaryFieldType(descriptor.DataType) {
+		return nil, casInsertScope{}, status.NewUnrecoverableError(
+			"partial update primary key descriptor is invalid, field: %d, type: %s",
+			descriptor.FieldID,
+			descriptor.DataType.String(),
+		)
+	}
+	body, err := insertMsg.Body()
+	if err != nil {
+		return nil, casInsertScope{}, status.NewUnrecoverableError(
+			"decode partial update insert body failed: %v",
+			err,
+		)
+	}
+	pks, err := extractPKsFromDescriptor(body.GetFieldsData(), descriptor)
+	if err != nil {
+		return nil, casInsertScope{}, err
+	}
+	return pks, scope, nil
 }
 
 // extractPKsFromOrdinaryInsert returns exact PKs when schema is available, or
@@ -118,6 +195,62 @@ func extractPKsFromFieldData(fields []*schemapb.FieldData, fieldID int64) ([]any
 		}
 	}
 	return nil, status.NewUnrecoverableError("partial update insert primary key field %d is missing", fieldID)
+}
+
+func extractPKsFromDescriptor(
+	fields []*schemapb.FieldData,
+	descriptor shards.PrimaryKeyDescriptor,
+) ([]any, error) {
+	for _, field := range fields {
+		if field.GetFieldId() != descriptor.FieldID {
+			continue
+		}
+		if field.GetType() != descriptor.DataType {
+			return nil, status.NewUnrecoverableError(
+				"partial update insert primary key field %d has type %s, expected %s",
+				descriptor.FieldID,
+				field.GetType().String(),
+				descriptor.DataType.String(),
+			)
+		}
+		scalars := field.GetScalars()
+		switch descriptor.DataType {
+		case schemapb.DataType_Int64:
+			values, ok := scalars.GetData().(*schemapb.ScalarField_LongData)
+			if !ok {
+				return nil, status.NewUnrecoverableError(
+					"partial update insert primary key field %d does not match schema type %s",
+					descriptor.FieldID,
+					descriptor.DataType.String(),
+				)
+			}
+			return pksFromIDs(&schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{IntId: values.LongData},
+			})
+		case schemapb.DataType_VarChar:
+			values, ok := scalars.GetData().(*schemapb.ScalarField_StringData)
+			if !ok {
+				return nil, status.NewUnrecoverableError(
+					"partial update insert primary key field %d does not match schema type %s",
+					descriptor.FieldID,
+					descriptor.DataType.String(),
+				)
+			}
+			return pksFromIDs(&schemapb.IDs{
+				IdField: &schemapb.IDs_StrId{StrId: values.StringData},
+			})
+		default:
+			return nil, status.NewUnrecoverableError(
+				"partial update primary key field %d has unsupported data type %s",
+				descriptor.FieldID,
+				descriptor.DataType.String(),
+			)
+		}
+	}
+	return nil, status.NewUnrecoverableError(
+		"partial update insert primary key field %d is missing",
+		descriptor.FieldID,
+	)
 }
 
 // extractCollectionFenceID extracts collections affected by wide data mutations.

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/pk_extract.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/pk_extract.go
@@ -1,0 +1,188 @@
+package partialupdate
+
+import (
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/shards"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// latestCollectionSchemaVersion asks ShardManager for its current PK descriptor
+// when an insert header does not carry an explicit version.
+const latestCollectionSchemaVersion int32 = -1
+
+// extractPKs extracts row-content primary keys from WAL delete messages.
+// ok=false means callers must handle inserts and collection-wide writes separately.
+func extractPKs(msg message.MutableMessage) ([]any, bool, error) {
+	if msg == nil {
+		return nil, false, nil
+	}
+
+	switch msg.MessageType() {
+	case message.MessageTypeDelete:
+		deleteMsg, err := message.AsMutableDeleteMessageV1(msg)
+		if err != nil {
+			return nil, true, status.NewUnrecoverableError("decode partial update delete message failed: %v", err)
+		}
+		body, err := deleteMsg.Body()
+		if err != nil {
+			return nil, true, status.NewUnrecoverableError("decode partial update delete body failed: %v", err)
+		}
+		pks, err := pksFromIDs(body.GetPrimaryKeys())
+		return pks, true, err
+	default:
+		return nil, false, nil
+	}
+}
+
+// extractPKsFromInsert extracts the PK column identified by fieldID from one
+// partial-update insert chunk.
+func extractPKsFromInsert(msg message.MutableMessage, fieldID int64) ([]any, error) {
+	if msg == nil || fieldID <= 0 {
+		return nil, status.NewUnrecoverableError("partial update insert primary key field id is invalid")
+	}
+	insertMsg, err := message.AsMutableInsertMessageV1(msg)
+	if err != nil {
+		return nil, status.NewUnrecoverableError("decode partial update insert message failed: %v", err)
+	}
+	body, err := insertMsg.Body()
+	if err != nil {
+		return nil, status.NewUnrecoverableError("decode partial update insert body failed: %v", err)
+	}
+	return extractPKsFromFieldData(body.GetFieldsData(), fieldID)
+}
+
+// extractPKsFromOrdinaryInsert returns exact PKs when schema is available, or
+// a collection fence ID for a schema-less legacy insert accepted by shard.
+func extractPKsFromOrdinaryInsert(msg message.MutableMessage, descriptorGetter primaryKeyDescriptorGetter) (pks []any, fenceCollectionID int64, err error) {
+	if descriptorGetter == nil {
+		return nil, 0, status.NewUnrecoverableError("partial update primary key descriptor getter is unavailable")
+	}
+	insertMsg, err := message.AsMutableInsertMessageV1(msg)
+	if err != nil {
+		return nil, 0, status.NewUnrecoverableError("decode insert message for partial update tracking failed: %v", err)
+	}
+	header := insertMsg.Header()
+	schemaVersion := latestCollectionSchemaVersion
+	if header.SchemaVersion != nil {
+		schemaVersion = header.GetSchemaVersion()
+	}
+	descriptor, err := descriptorGetter.GetPrimaryKeyDescriptor(header.GetCollectionId(), schemaVersion)
+	if err != nil {
+		if errors.Is(err, shards.ErrCollectionSchemaVersionNotMatch) {
+			return nil, 0, status.NewSchemaVersionMismatch(
+				"schema version mismatch while tracking partial update writes, collection: %d, schema version: %d",
+				header.GetCollectionId(), header.GetSchemaVersion())
+		}
+		// Shard accepts schema-less legacy inserts during rolling upgrades.
+		// Fence the collection when their exact PK field cannot be recovered.
+		if header.SchemaVersion == nil && errors.Is(err, shards.ErrCollectionSchemaNotFound) {
+			if header.GetCollectionId() == 0 {
+				return nil, 0, status.NewUnrecoverableError("partial update ordinary insert collection id is empty")
+			}
+			return nil, header.GetCollectionId(), nil
+		}
+		return nil, 0, status.NewUnrecoverableError("get primary key descriptor for partial update tracking failed: %v", err)
+	}
+	if !typeutil.IsPrimaryFieldType(descriptor.DataType) {
+		return nil, 0, status.NewUnrecoverableError(
+			"partial update primary key field %d has unsupported data type %s",
+			descriptor.FieldID,
+			descriptor.DataType.String(),
+		)
+	}
+	pks, err = extractPKsFromInsert(msg, descriptor.FieldID)
+	return pks, 0, err
+}
+
+func extractPKsFromFieldData(fields []*schemapb.FieldData, fieldID int64) ([]any, error) {
+	for _, field := range fields {
+		if field.GetFieldId() != fieldID {
+			continue
+		}
+		scalars := field.GetScalars()
+		switch scalars.GetData().(type) {
+		case *schemapb.ScalarField_LongData:
+			return pksFromIDs(&schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{IntId: scalars.GetLongData()},
+			})
+		case *schemapb.ScalarField_StringData:
+			return pksFromIDs(&schemapb.IDs{
+				IdField: &schemapb.IDs_StrId{StrId: scalars.GetStringData()},
+			})
+		default:
+			return nil, status.NewUnrecoverableError("partial update insert primary key field %d must be int64 or varchar", fieldID)
+		}
+	}
+	return nil, status.NewUnrecoverableError("partial update insert primary key field %d is missing", fieldID)
+}
+
+// extractCollectionFenceID extracts collections affected by wide data mutations.
+func extractCollectionFenceID(msg message.MutableMessage) (int64, bool) {
+	if msg == nil {
+		return 0, false
+	}
+
+	switch msg.MessageType() {
+	case message.MessageTypeTruncateCollection:
+		truncateMsg, err := message.AsMutableTruncateCollectionMessageV2(msg)
+		if err != nil {
+			return 0, true
+		}
+		collectionID := truncateMsg.Header().GetCollectionId()
+		if collectionID == 0 {
+			return 0, true
+		}
+		return collectionID, true
+	default:
+		return 0, false
+	}
+}
+
+// extractDropCollectionID identifies the collection whose fence can be
+// discarded after DropCollection is durably appended.
+func extractDropCollectionID(msg message.MutableMessage) (int64, bool) {
+	if msg == nil || msg.MessageType() != message.MessageTypeDropCollection {
+		return 0, false
+	}
+	dropMsg, err := message.AsMutableDropCollectionMessageV1(msg)
+	if err != nil {
+		return 0, true
+	}
+	return dropMsg.Header().GetCollectionId(), true
+}
+
+func pksFromIDs(ids *schemapb.IDs) ([]any, error) {
+	if ids == nil {
+		return nil, status.NewUnrecoverableError("partial update primary keys are nil")
+	}
+	switch values := ids.GetIdField().(type) {
+	case *schemapb.IDs_IntId:
+		if values == nil || values.IntId == nil {
+			return nil, status.NewUnrecoverableError("partial update int64 primary keys are nil")
+		}
+	case *schemapb.IDs_StrId:
+		if values == nil || values.StrId == nil {
+			return nil, status.NewUnrecoverableError("partial update varchar primary keys are nil")
+		}
+	default:
+		return nil, status.NewUnrecoverableError("unsupported partial update primary key ids type %T", values)
+	}
+
+	size := typeutil.GetSizeOfIDs(ids)
+	if size == 0 {
+		return nil, status.NewUnrecoverableError("partial update primary keys are empty")
+	}
+	pks := make([]any, size)
+	for idx := range pks {
+		pk := typeutil.GetPK(ids, int64(idx))
+		if pk == nil {
+			return nil, status.NewUnrecoverableError("partial update primary key at offset %d is empty", idx)
+		}
+		pks[idx] = pk
+	}
+	return pks, nil
+}

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/pk_extract_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/pk_extract_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/shards"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -188,6 +189,183 @@ func TestExtractPKsFromInsert(t *testing.T) {
 	})
 }
 
+func TestExtractPKsFromCASInsert(t *testing.T) {
+	t.Run("int64", func(t *testing.T) {
+		getter := &staticPrimaryKeyDescriptorGetter{
+			descriptor: shards.PrimaryKeyDescriptor{
+				FieldID:  100,
+				DataType: schemapb.DataType_Int64,
+			},
+		}
+
+		pks, scope, err := extractPKsFromCASInsert(newInsertMessage([]*schemapb.FieldData{
+			int64PKFieldData(10, 20),
+		}), getter)
+
+		require.NoError(t, err)
+		require.Equal(t, []any{int64(10), int64(20)}, pks)
+		require.Equal(t, casInsertScope{collectionID: 10, schemaVersion: 1}, scope)
+		require.EqualValues(t, 10, getter.collectionID)
+		require.EqualValues(t, 1, getter.schemaVersion)
+	})
+
+	t.Run("varchar", func(t *testing.T) {
+		getter := &staticPrimaryKeyDescriptorGetter{
+			descriptor: shards.PrimaryKeyDescriptor{
+				FieldID:  100,
+				DataType: schemapb.DataType_VarChar,
+			},
+		}
+
+		pks, scope, err := extractPKsFromCASInsert(newInsertMessage([]*schemapb.FieldData{
+			varcharPKFieldData("pk-1", "pk-2"),
+		}), getter)
+
+		require.NoError(t, err)
+		require.Equal(t, []any{"pk-1", "pk-2"}, pks)
+		require.Equal(t, casInsertScope{collectionID: 10, schemaVersion: 1}, scope)
+	})
+
+	t.Run("explicit zero schema version", func(t *testing.T) {
+		getter := &staticPrimaryKeyDescriptorGetter{
+			descriptor: shards.PrimaryKeyDescriptor{
+				FieldID:  100,
+				DataType: schemapb.DataType_Int64,
+			},
+		}
+		msg := newInsertMessage([]*schemapb.FieldData{int64PKFieldData(10)})
+		insertMsg := message.MustAsMutableInsertMessageV1(msg)
+		header := insertMsg.Header()
+		zero := int32(0)
+		header.SchemaVersion = &zero
+		insertMsg.OverwriteHeader(header)
+
+		pks, scope, err := extractPKsFromCASInsert(msg, getter)
+
+		require.NoError(t, err)
+		require.Equal(t, []any{int64(10)}, pks)
+		require.Equal(t, casInsertScope{collectionID: 10, schemaVersion: 0}, scope)
+		require.EqualValues(t, 0, getter.schemaVersion)
+	})
+}
+
+func TestExtractPKsFromCASInsertErrors(t *testing.T) {
+	validGetter := func() *staticPrimaryKeyDescriptorGetter {
+		return &staticPrimaryKeyDescriptorGetter{
+			descriptor: shards.PrimaryKeyDescriptor{
+				FieldID:  100,
+				DataType: schemapb.DataType_Int64,
+			},
+		}
+	}
+
+	t.Run("missing descriptor getter", func(t *testing.T) {
+		_, _, err := extractPKsFromCASInsert(newInsertMessage(nil), nil)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("decode insert", func(t *testing.T) {
+		_, _, err := extractPKsFromCASInsert(newDeleteMessage(&schemapb.IDs{}), validGetter())
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("empty collection", func(t *testing.T) {
+		msg := newInsertMessage(nil)
+		insertMsg := message.MustAsMutableInsertMessageV1(msg)
+		header := insertMsg.Header()
+		header.CollectionId = 0
+		insertMsg.OverwriteHeader(header)
+
+		_, _, err := extractPKsFromCASInsert(msg, validGetter())
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("missing schema version", func(t *testing.T) {
+		msg := newInsertMessage(nil)
+		insertMsg := message.MustAsMutableInsertMessageV1(msg)
+		header := insertMsg.Header()
+		header.SchemaVersion = nil
+		insertMsg.OverwriteHeader(header)
+
+		_, _, err := extractPKsFromCASInsert(msg, validGetter())
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("schema version mismatch", func(t *testing.T) {
+		_, _, err := extractPKsFromCASInsert(newInsertMessage(nil), &staticPrimaryKeyDescriptorGetter{
+			err: shards.ErrCollectionSchemaVersionNotMatch,
+		})
+		require.Error(t, err)
+		require.True(t, status.AsStreamingError(err).IsSchemaVersionMismatch())
+	})
+
+	t.Run("descriptor lookup", func(t *testing.T) {
+		_, _, err := extractPKsFromCASInsert(newInsertMessage(nil), &staticPrimaryKeyDescriptorGetter{
+			err: errors.New("schema lookup failed"),
+		})
+		requireUnrecoverable(t, err)
+	})
+
+	for _, test := range []struct {
+		name       string
+		descriptor shards.PrimaryKeyDescriptor
+	}{
+		{
+			name: "missing descriptor field",
+			descriptor: shards.PrimaryKeyDescriptor{
+				DataType: schemapb.DataType_Int64,
+			},
+		},
+		{
+			name: "unsupported descriptor type",
+			descriptor: shards.PrimaryKeyDescriptor{
+				FieldID:  100,
+				DataType: schemapb.DataType_Float,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := extractPKsFromCASInsert(newInsertMessage(nil), &staticPrimaryKeyDescriptorGetter{
+				descriptor: test.descriptor,
+			})
+			requireUnrecoverable(t, err)
+		})
+	}
+
+	t.Run("decode insert body", func(t *testing.T) {
+		_, _, err := extractPKsFromCASInsert(
+			corruptMessageBody(newInsertMessage(nil)),
+			validGetter(),
+		)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("missing primary key field", func(t *testing.T) {
+		_, _, err := extractPKsFromCASInsert(newInsertMessage(nil), validGetter())
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("primary key field type mismatch", func(t *testing.T) {
+		_, _, err := extractPKsFromCASInsert(newInsertMessage([]*schemapb.FieldData{
+			varcharPKFieldData("pk-1"),
+		}), validGetter())
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("primary key scalar payload mismatch", func(t *testing.T) {
+		field := int64PKFieldData(10)
+		field.Field = &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: []string{"pk-1"}},
+				},
+			},
+		}
+		_, _, err := extractPKsFromCASInsert(newInsertMessage([]*schemapb.FieldData{field}), validGetter())
+		requireUnrecoverable(t, err)
+	})
+}
+
 func TestExtractPKsFromOrdinaryInsertErrors(t *testing.T) {
 	t.Run("missing schema getter", func(t *testing.T) {
 		_, _, err := extractPKsFromOrdinaryInsert(newInsertMessage(nil), nil)
@@ -355,8 +533,10 @@ func TestPKsFromIDsRejectsNilArraysAndPK(t *testing.T) {
 }
 
 type staticPrimaryKeyDescriptorGetter struct {
-	descriptor shards.PrimaryKeyDescriptor
-	err        error
+	descriptor    shards.PrimaryKeyDescriptor
+	err           error
+	collectionID  int64
+	schemaVersion int32
 }
 
 func corruptMessageBody(msg message.MutableMessage) message.MutableMessage {
@@ -367,7 +547,9 @@ func corruptMessageBody(msg message.MutableMessage) message.MutableMessage {
 	return message.NewMutableMessageBeforeAppend([]byte{0xff}, properties)
 }
 
-func (g *staticPrimaryKeyDescriptorGetter) GetPrimaryKeyDescriptor(int64, int32) (shards.PrimaryKeyDescriptor, error) {
+func (g *staticPrimaryKeyDescriptorGetter) GetPrimaryKeyDescriptor(collectionID int64, schemaVersion int32) (shards.PrimaryKeyDescriptor, error) {
+	g.collectionID = collectionID
+	g.schemaVersion = schemaVersion
 	return g.descriptor, g.err
 }
 

--- a/internal/streamingnode/server/wal/interceptors/partialupdate/pk_extract_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partialupdate/pk_extract_test.go
@@ -1,0 +1,470 @@
+package partialupdate
+
+import (
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard/shards"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func TestExtractPKsFromDelete(t *testing.T) {
+	t.Run("int64", func(t *testing.T) {
+		msg := newDeleteMessage(&schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{
+				IntId: &schemapb.LongArray{Data: []int64{10, 20}},
+			},
+		})
+
+		pks, ok, err := extractPKs(msg)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, []any{int64(10), int64(20)}, pks)
+	})
+
+	t.Run("varchar", func(t *testing.T) {
+		msg := newDeleteMessage(&schemapb.IDs{
+			IdField: &schemapb.IDs_StrId{
+				StrId: &schemapb.StringArray{Data: []string{"pk-1", "pk-2"}},
+			},
+		})
+
+		pks, ok, err := extractPKs(msg)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, []any{"pk-1", "pk-2"}, pks)
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		tests := []struct {
+			name string
+			ids  *schemapb.IDs
+		}{
+			{name: "nil_ids"},
+			{name: "nil_id_field", ids: &schemapb.IDs{}},
+			{
+				name: "nil_typed_int_id",
+				ids: &schemapb.IDs{
+					IdField: (*schemapb.IDs_IntId)(nil),
+				},
+			},
+			{
+				name: "nil_int_array",
+				ids: &schemapb.IDs{
+					IdField: &schemapb.IDs_IntId{},
+				},
+			},
+			{
+				name: "empty_int_array",
+				ids: &schemapb.IDs{
+					IdField: &schemapb.IDs_IntId{
+						IntId: &schemapb.LongArray{},
+					},
+				},
+			},
+			{
+				name: "nil_string_array",
+				ids: &schemapb.IDs{
+					IdField: &schemapb.IDs_StrId{},
+				},
+			},
+			{
+				name: "nil_typed_string_id",
+				ids: &schemapb.IDs{
+					IdField: (*schemapb.IDs_StrId)(nil),
+				},
+			},
+			{
+				name: "empty_string_array",
+				ids: &schemapb.IDs{
+					IdField: &schemapb.IDs_StrId{
+						StrId: &schemapb.StringArray{},
+					},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				_, ok, err := extractPKs(newDeleteMessage(test.ids))
+				require.True(t, ok)
+				requireUnrecoverable(t, err)
+			})
+		}
+	})
+}
+
+func TestExtractPKsFromNonRowMessage(t *testing.T) {
+	pks, ok, err := extractPKs(newDropCollectionMessage(10))
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, pks)
+}
+
+func TestExtractPKsRejectsInvalidMessages(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		pks, ok, err := extractPKs(nil)
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.Nil(t, pks)
+	})
+
+	t.Run("decode delete", func(t *testing.T) {
+		patch := mockey.Mock(message.AsMutableDeleteMessageV1).
+			Return(nil, errors.New("decode failed")).
+			Build()
+		defer patch.UnPatch()
+
+		_, ok, err := extractPKs(newDeleteMessage(&schemapb.IDs{}))
+		require.True(t, ok)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("decode delete body", func(t *testing.T) {
+		msg := corruptMessageBody(newDeleteMessage(&schemapb.IDs{}))
+		_, ok, err := extractPKs(msg)
+		require.True(t, ok)
+		requireUnrecoverable(t, err)
+	})
+}
+
+func TestExtractPKsFromInsert(t *testing.T) {
+	t.Run("int64", func(t *testing.T) {
+		pks, err := extractPKsFromInsert(newInsertMessage([]*schemapb.FieldData{
+			int64PKFieldData(10, 20),
+		}), 100)
+		require.NoError(t, err)
+		require.Equal(t, []any{int64(10), int64(20)}, pks)
+	})
+
+	t.Run("varchar", func(t *testing.T) {
+		pks, err := extractPKsFromInsert(newInsertMessage([]*schemapb.FieldData{
+			varcharPKFieldData("pk-1", "pk-2"),
+		}), 100)
+		require.NoError(t, err)
+		require.Equal(t, []any{"pk-1", "pk-2"}, pks)
+	})
+
+	t.Run("missing_field", func(t *testing.T) {
+		_, err := extractPKsFromInsert(newInsertMessage(nil), 100)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("unsupported_type", func(t *testing.T) {
+		field := int64PKFieldData(10)
+		field.Field = &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{}}
+		_, err := extractPKsFromInsert(newInsertMessage([]*schemapb.FieldData{field}), 100)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("invalid arguments", func(t *testing.T) {
+		_, err := extractPKsFromInsert(nil, 100)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("decode insert", func(t *testing.T) {
+		_, err := extractPKsFromInsert(newDeleteMessage(&schemapb.IDs{}), 100)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("decode insert body", func(t *testing.T) {
+		_, err := extractPKsFromInsert(corruptMessageBody(newInsertMessage(nil)), 100)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("skip unrelated field", func(t *testing.T) {
+		pks, err := extractPKsFromFieldData([]*schemapb.FieldData{
+			{FieldId: 101},
+			int64PKFieldData(10),
+		}, 100)
+		require.NoError(t, err)
+		require.Equal(t, []any{int64(10)}, pks)
+	})
+}
+
+func TestExtractPKsFromOrdinaryInsertErrors(t *testing.T) {
+	t.Run("missing schema getter", func(t *testing.T) {
+		_, _, err := extractPKsFromOrdinaryInsert(newInsertMessage(nil), nil)
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("decode insert", func(t *testing.T) {
+		expected := errors.New("decode failed")
+		patch := mockey.Mock(message.AsMutableInsertMessageV1).Return(nil, expected).Build()
+		defer patch.UnPatch()
+
+		_, _, err := extractPKsFromOrdinaryInsert(newInsertMessage(nil), &staticPrimaryKeyDescriptorGetter{})
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("legacy insert without collection id", func(t *testing.T) {
+		msg := newInsertMessage(nil)
+		insert := message.MustAsMutableInsertMessageV1(msg)
+		header := insert.Header()
+		header.CollectionId = 0
+		header.SchemaVersion = nil
+		insert.OverwriteHeader(header)
+
+		_, _, err := extractPKsFromOrdinaryInsert(msg, &staticPrimaryKeyDescriptorGetter{
+			err: shards.ErrCollectionSchemaNotFound,
+		})
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("schema lookup", func(t *testing.T) {
+		_, _, err := extractPKsFromOrdinaryInsert(newInsertMessage(nil), &staticPrimaryKeyDescriptorGetter{
+			err: errors.New("schema lookup failed"),
+		})
+		requireUnrecoverable(t, err)
+	})
+
+	t.Run("unsupported primary key type", func(t *testing.T) {
+		_, _, err := extractPKsFromOrdinaryInsert(newInsertMessage(nil), &staticPrimaryKeyDescriptorGetter{
+			descriptor: shards.PrimaryKeyDescriptor{
+				FieldID:  100,
+				DataType: schemapb.DataType_Float,
+			},
+		})
+		requireUnrecoverable(t, err)
+	})
+}
+
+func TestExtractCollectionFenceID(t *testing.T) {
+	tests := []struct {
+		name         string
+		msg          message.MutableMessage
+		collectionID int64
+	}{
+		{
+			name:         "truncate_collection",
+			msg:          newTruncateCollectionMessage(11),
+			collectionID: 11,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			collectionID, ok := extractCollectionFenceID(test.msg)
+			require.True(t, ok)
+			require.Equal(t, test.collectionID, collectionID)
+		})
+	}
+}
+
+func TestExtractCollectionFenceIDIgnoresPKAndLifecycleMessages(t *testing.T) {
+	for _, msg := range []message.MutableMessage{
+		newDropCollectionMessage(10),
+		newDropPartitionMessage(10, 20),
+		newAlterCollectionMessage(10),
+		newInsertMessage([]*schemapb.FieldData{int64PKFieldData(10)}),
+		newDeleteMessage(&schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10}}},
+		}),
+	} {
+		collectionID, ok := extractCollectionFenceID(msg)
+		require.False(t, ok)
+		require.Zero(t, collectionID)
+	}
+}
+
+func TestExtractCollectionFenceIDReturnsEmptyForMalformedMessages(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  message.MutableMessage
+	}{
+		{
+			name: "truncate_collection_zero_collection_id",
+			msg:  newTruncateCollectionMessage(0),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			collectionID, ok := extractCollectionFenceID(test.msg)
+			require.True(t, ok)
+			require.Zero(t, collectionID)
+		})
+	}
+}
+
+func TestExtractCollectionFenceIDHandlesDecodeErrors(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		collectionID, ok := extractCollectionFenceID(nil)
+		require.False(t, ok)
+		require.Zero(t, collectionID)
+	})
+
+	t.Run("truncate", func(t *testing.T) {
+		patch := mockey.Mock(message.AsMutableTruncateCollectionMessageV2).
+			Return(nil, errors.New("decode failed")).
+			Build()
+		defer patch.UnPatch()
+
+		collectionID, ok := extractCollectionFenceID(newTruncateCollectionMessage(10))
+		require.True(t, ok)
+		require.Zero(t, collectionID)
+	})
+}
+
+func TestExtractCollectionFenceIDFromNonFenceMessage(t *testing.T) {
+	collectionID, ok := extractCollectionFenceID(newDeleteMessage(&schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		},
+	}))
+	require.False(t, ok)
+	require.Zero(t, collectionID)
+}
+
+func TestExtractDropCollectionIDReturnsEmptyForMalformedMessage(t *testing.T) {
+	patch := mockey.Mock(message.AsMutableDropCollectionMessageV1).
+		Return(nil, errors.New("decode failed")).
+		Build()
+	defer patch.UnPatch()
+
+	collectionID, ok := extractDropCollectionID(newDropCollectionMessage(10))
+	require.True(t, ok)
+	require.Zero(t, collectionID)
+}
+
+func TestPKsFromIDsRejectsNilArraysAndPK(t *testing.T) {
+	_, err := pksFromIDs(&schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{},
+	})
+	requireUnrecoverable(t, err)
+
+	_, err = pksFromIDs(&schemapb.IDs{
+		IdField: &schemapb.IDs_StrId{},
+	})
+	requireUnrecoverable(t, err)
+
+	patch := mockey.Mock(typeutil.GetPK).Return(nil).Build()
+	defer patch.UnPatch()
+	_, err = pksFromIDs(&schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{10}},
+		},
+	})
+	requireUnrecoverable(t, err)
+}
+
+type staticPrimaryKeyDescriptorGetter struct {
+	descriptor shards.PrimaryKeyDescriptor
+	err        error
+}
+
+func corruptMessageBody(msg message.MutableMessage) message.MutableMessage {
+	properties := make(map[string]string, len(msg.Properties().ToRawMap()))
+	for key, value := range msg.Properties().ToRawMap() {
+		properties[key] = value
+	}
+	return message.NewMutableMessageBeforeAppend([]byte{0xff}, properties)
+}
+
+func (g *staticPrimaryKeyDescriptorGetter) GetPrimaryKeyDescriptor(int64, int32) (shards.PrimaryKeyDescriptor, error) {
+	return g.descriptor, g.err
+}
+
+func newDeleteMessage(ids *schemapb.IDs) message.MutableMessage {
+	return message.NewDeleteMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&message.DeleteMessageHeader{
+			CollectionId: 10,
+			Rows:         1,
+		}).
+		WithBody(&msgpb.DeleteRequest{
+			PrimaryKeys: ids,
+		}).
+		MustBuildMutable()
+}
+
+func newInsertMessage(fields []*schemapb.FieldData) message.MutableMessage {
+	schemaVersion := int32(1)
+	return message.NewInsertMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&message.InsertMessageHeader{
+			CollectionId:  10,
+			SchemaVersion: &schemaVersion,
+		}).
+		WithBody(&msgpb.InsertRequest{
+			FieldsData: fields,
+		}).
+		MustBuildMutable()
+}
+
+func newDropCollectionMessage(collectionID int64) message.MutableMessage {
+	return message.NewDropCollectionMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&message.DropCollectionMessageHeader{
+			CollectionId: collectionID,
+		}).
+		WithBody(&msgpb.DropCollectionRequest{}).
+		MustBuildMutable()
+}
+
+func newDropPartitionMessage(collectionID int64, partitionID int64) message.MutableMessage {
+	return message.NewDropPartitionMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&message.DropPartitionMessageHeader{
+			CollectionId: collectionID,
+			PartitionId:  partitionID,
+		}).
+		WithBody(&msgpb.DropPartitionRequest{}).
+		MustBuildMutable()
+}
+
+func newTruncateCollectionMessage(collectionID int64) message.MutableMessage {
+	return message.NewTruncateCollectionMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&message.TruncateCollectionMessageHeader{
+			CollectionId: collectionID,
+		}).
+		WithBody(&message.TruncateCollectionMessageBody{}).
+		MustBuildMutable()
+}
+
+func newAlterCollectionMessage(collectionID int64) message.MutableMessage {
+	return message.NewAlterCollectionMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&message.AlterCollectionMessageHeader{
+			CollectionId: collectionID,
+		}).
+		WithBody(&message.AlterCollectionMessageBody{}).
+		MustBuildMutable()
+}
+
+func int64PKFieldData(values ...int64) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "pk",
+		FieldId:   100,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: values},
+				},
+			},
+		},
+	}
+}
+
+func varcharPKFieldData(values ...string) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		Type:      schemapb.DataType_VarChar,
+		FieldName: "pk",
+		FieldId:   100,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{Data: values},
+				},
+			},
+		},
+	}
+}

--- a/internal/streamingnode/server/wal/interceptors/replicate/replicates/manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/replicate/replicates/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
@@ -378,6 +379,73 @@ func TestSecondaryReplicateManagerWithTxn(t *testing.T) {
 			assert.Nil(t, g)
 		}
 	}
+}
+
+func TestSecondaryReplicateManagerRecoveredTxnCommitFailureAllowsFullReplay(t *testing.T) {
+	txnBuffer := utility.NewTxnBuffer(mlog.With(), metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics())
+	recovered := newReplicateTxnMessage("test1", "test2", 2)
+	for _, msg := range []message.MutableMessage{recovered[0], recovered[2]} {
+		immutableMsg := msg.WithTimeTick(3).IntoImmutableMessage(walimplstest.NewTestMessageID(1))
+		txnBuffer.HandleImmutableMessages([]message.ImmutableMessage{immutableMsg}, msg.TimeTick())
+	}
+
+	rm, err := RecoverReplicateManager(&ReplicateManagerRecoverParam{
+		ChannelInfo: types.PChannelInfo{
+			Name: "test1-rootcoord-dml_0",
+			Term: 1,
+		},
+		CurrentClusterID: "test1",
+		InitialRecoverSnapshot: &recovery.RecoverySnapshot{
+			Checkpoint: &utility.WALCheckpoint{
+				MessageID: walimplstest.NewTestMessageID(1),
+				TimeTick:  1,
+				ReplicateCheckpoint: &utility.ReplicateCheckpoint{
+					ClusterID: "test2",
+					PChannel:  "test2-rootcoord-dml_0",
+					MessageID: walimplstest.NewTestMessageID(1),
+					TimeTick:  1,
+				},
+				ReplicateConfig: newReplicateConfiguration("test2", "test1"),
+			},
+			TxnBuffer: txnBuffer,
+		},
+	})
+	require.NoError(t, err)
+
+	firstReplay := newReplicateTxnMessage("test1", "test2", 2)
+	for _, msg := range firstReplay {
+		acker, appendErr := rm.BeginReplicateMessage(context.Background(), msg)
+		if msg.MessageType() == message.MessageTypeCommitTxn && acker != nil {
+			require.NoError(t, appendErr)
+			acker.Ack(status.NewTransactionExpired("recovered transaction"))
+			continue
+		}
+		require.Nil(t, acker)
+		require.True(t, status.AsStreamingError(appendErr).IsIgnoredOperation())
+	}
+	checkpoint, err := rm.GetReplicateCheckpoint()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, checkpoint.TimeTick)
+
+	accepted := make([]message.MessageType, 0, 3)
+	for _, msg := range newReplicateTxnMessage("test1", "test2", 2) {
+		acker, appendErr := rm.BeginReplicateMessage(context.Background(), msg)
+		if acker == nil {
+			require.True(t, status.AsStreamingError(appendErr).IsIgnoredOperation())
+			continue
+		}
+		require.NoError(t, appendErr)
+		accepted = append(accepted, msg.MessageType())
+		acker.Ack(nil)
+	}
+	require.Equal(t, []message.MessageType{
+		message.MessageTypeBeginTxn,
+		message.MessageTypeCreateDatabase,
+		message.MessageTypeCommitTxn,
+	}, accepted)
+	checkpoint, err = rm.GetReplicateCheckpoint()
+	require.NoError(t, err)
+	require.EqualValues(t, 2, checkpoint.TimeTick)
 }
 
 func TestSecondaryReplicateManagerIgnoreStaleTxnBody(t *testing.T) {

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager.go
@@ -26,8 +26,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
-// latestCollectionSchemaVersion asks GetCollectionSchema to use the latest
-// schema snapshot. Zero is a valid schema version and must stay explicit.
+// latestCollectionSchemaVersion asks schema accessors to use the latest
+// snapshot. Zero is a valid schema version and must stay explicit.
 const latestCollectionSchemaVersion int32 = -1
 
 var (
@@ -98,7 +98,7 @@ func RecoverShardManager(param *ShardManagerRecoverParam) ShardManager {
 		}
 	}
 	m := &shardManagerImpl{
-		mu:                sync.Mutex{},
+		mu:                sync.RWMutex{},
 		ctx:               ctx,
 		cancel:            cancel,
 		wal:               param.WAL,
@@ -188,11 +188,12 @@ func newCollectionInfos(recoverInfos *recovery.RecoverySnapshot) map[int64]*Coll
 		if len(vchannelInfo.CollectionInfo.Schemas) > 0 {
 			latestSchema = vchannelInfo.CollectionInfo.Schemas[len(vchannelInfo.CollectionInfo.Schemas)-1]
 		}
-		collectionInfoMap[vchannelInfo.CollectionInfo.CollectionId] = &CollectionInfo{
+		collectionInfo := &CollectionInfo{
 			VChannel:     vchannelInfo.Vchannel,
 			PartitionIDs: currentPartition,
-			Schema:       latestSchema,
 		}
+		collectionInfo.setSchema(latestSchema)
+		collectionInfoMap[vchannelInfo.CollectionInfo.CollectionId] = collectionInfo
 	}
 	return collectionInfoMap
 }
@@ -203,7 +204,7 @@ func newCollectionInfos(recoverInfos *recovery.RecoverySnapshot) map[int64]*Coll
 type shardManagerImpl struct {
 	mlog.Binder
 
-	mu                sync.Mutex
+	mu                sync.RWMutex
 	ctx               context.Context
 	cancel            context.CancelFunc
 	wal               *syncutil.Future[wal.WAL]
@@ -218,6 +219,37 @@ type CollectionInfo struct {
 	VChannel     string
 	PartitionIDs map[int64]struct{}
 	Schema       *streamingpb.CollectionSchemaOfVChannel
+	primaryKey   *PrimaryKeyDescriptor
+}
+
+// PrimaryKeyDescriptor is the immutable PK information needed by WAL write
+// tracking without exposing or cloning a collection schema.
+type PrimaryKeyDescriptor struct {
+	FieldID  int64
+	DataType schemapb.DataType
+}
+
+func (c *CollectionInfo) setSchema(schema *streamingpb.CollectionSchemaOfVChannel) {
+	c.Schema = schema
+	c.primaryKey = nil
+	if schema == nil || schema.GetSchema() == nil {
+		return
+	}
+	descriptor, err := primaryKeyDescriptorFromSchema(schema.GetSchema())
+	if err == nil {
+		c.primaryKey = &descriptor
+	}
+}
+
+func primaryKeyDescriptorFromSchema(schema *schemapb.CollectionSchema) (PrimaryKeyDescriptor, error) {
+	primaryField, err := typeutil.GetPrimaryFieldSchema(schema)
+	if err != nil {
+		return PrimaryKeyDescriptor{}, err
+	}
+	return PrimaryKeyDescriptor{
+		FieldID:  primaryField.GetFieldID(),
+		DataType: primaryField.GetDataType(),
+	}, nil
 }
 
 // SchemaVersion returns the current collection schema version for the write path.

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_collection.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_collection.go
@@ -77,11 +77,11 @@ func (m *shardManagerImpl) CreateCollection(msg message.ImmutableCreateCollectio
 	collectionInfo := newCollectionInfo(vchannel, partitionIDs)
 	// Set schema when creating collection.
 	if schema != nil {
-		collectionInfo.Schema = &streamingpb.CollectionSchemaOfVChannel{
+		collectionInfo.setSchema(&streamingpb.CollectionSchemaOfVChannel{
 			Schema:             schema,
 			CheckpointTimeTick: timetick,
 			State:              streamingpb.VChannelSchemaState_VCHANNEL_SCHEMA_STATE_NORMAL,
-		}
+		})
 	}
 	m.collections[collectionID] = collectionInfo
 
@@ -184,11 +184,11 @@ func (m *shardManagerImpl) AlterCollection(msg message.MutableAlterCollectionMes
 			return nil, status.NewInvalidArgument("schema change message has nil schema body")
 		}
 		collectionInfo := m.collections[collectionID]
-		collectionInfo.Schema = &streamingpb.CollectionSchemaOfVChannel{
+		collectionInfo.setSchema(&streamingpb.CollectionSchemaOfVChannel{
 			Schema:             schema,
 			CheckpointTimeTick: timetick,
 			State:              streamingpb.VChannelSchemaState_VCHANNEL_SCHEMA_STATE_NORMAL,
-		}
+		})
 		logger.Info(context.TODO(), "updated collection schema in shard manager",
 			mlog.Int64("collectionID", collectionID),
 			mlog.Int32("schemaVersion", schema.GetVersion()),
@@ -199,8 +199,8 @@ func (m *shardManagerImpl) AlterCollection(msg message.MutableAlterCollectionMes
 }
 
 func (m *shardManagerImpl) CheckIfCollectionSchemaVersionMatch(header *message.InsertMessageHeader) (int32, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	return m.checkIfCollectionSchemaVersionMatch(header)
 }
@@ -237,8 +237,8 @@ func (m *shardManagerImpl) checkIfCollectionSchemaVersionMatch(header *message.I
 }
 
 func (m *shardManagerImpl) GetCollectionSchema(collectionID int64, schemaVersion int32) (*schemapb.CollectionSchema, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	collectionInfo, ok := m.collections[collectionID]
 	if !ok {
@@ -255,9 +255,32 @@ func (m *shardManagerImpl) GetCollectionSchema(collectionID int64, schemaVersion
 	return proto.Clone(collectionInfo.Schema.GetSchema()).(*schemapb.CollectionSchema), nil
 }
 
+// GetPrimaryKeyDescriptor returns immutable PK schema data without cloning the
+// complete collection schema.
+func (m *shardManagerImpl) GetPrimaryKeyDescriptor(collectionID int64, schemaVersion int32) (PrimaryKeyDescriptor, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	collectionInfo, ok := m.collections[collectionID]
+	if !ok {
+		return PrimaryKeyDescriptor{}, ErrCollectionNotFound
+	}
+	if collectionInfo.Schema == nil || collectionInfo.Schema.GetSchema() == nil {
+		return PrimaryKeyDescriptor{}, ErrCollectionSchemaNotFound
+	}
+	collectionSchemaVersion := collectionInfo.SchemaVersion()
+	if schemaVersion != latestCollectionSchemaVersion && collectionSchemaVersion != schemaVersion {
+		return PrimaryKeyDescriptor{}, ErrCollectionSchemaVersionNotMatch
+	}
+	if collectionInfo.primaryKey != nil {
+		return *collectionInfo.primaryKey, nil
+	}
+	return primaryKeyDescriptorFromSchema(collectionInfo.Schema.GetSchema())
+}
+
 func (m *shardManagerImpl) GetAllCollectionSchemaInfos() map[int64]CollectionSchemaInfo {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	infos := make(map[int64]CollectionSchemaInfo)
 	for collectionID, collectionInfo := range m.collections {

--- a/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/shard/shards/shard_manager_test.go
@@ -663,6 +663,84 @@ func TestShardManagerSchemaVersionCheck(t *testing.T) {
 	m.Close()
 }
 
+func TestShardManagerGetPrimaryKeyDescriptor(t *testing.T) {
+	newSchema := func(version int32, fieldID int64, dataType schemapb.DataType) *streamingpb.CollectionSchemaOfVChannel {
+		return &streamingpb.CollectionSchemaOfVChannel{
+			Schema: &schemapb.CollectionSchema{
+				Version: version,
+				Fields: []*schemapb.FieldSchema{{
+					FieldID:      fieldID,
+					DataType:     dataType,
+					IsPrimaryKey: true,
+				}},
+			},
+		}
+	}
+
+	t.Run("returns cached descriptor", func(t *testing.T) {
+		info := &CollectionInfo{}
+		info.setSchema(newSchema(2, 100, schemapb.DataType_Int64))
+		m := &shardManagerImpl{collections: map[int64]*CollectionInfo{10: info}}
+
+		descriptor, err := m.GetPrimaryKeyDescriptor(10, 2)
+		assert.NoError(t, err)
+		assert.Equal(t, PrimaryKeyDescriptor{FieldID: 100, DataType: schemapb.DataType_Int64}, descriptor)
+		assert.NotNil(t, info.primaryKey)
+	})
+
+	t.Run("refreshes descriptor with schema", func(t *testing.T) {
+		info := &CollectionInfo{}
+		info.setSchema(newSchema(1, 100, schemapb.DataType_Int64))
+		info.setSchema(newSchema(2, 101, schemapb.DataType_VarChar))
+		m := &shardManagerImpl{collections: map[int64]*CollectionInfo{10: info}}
+
+		descriptor, err := m.GetPrimaryKeyDescriptor(10, latestCollectionSchemaVersion)
+		assert.NoError(t, err)
+		assert.Equal(t, PrimaryKeyDescriptor{FieldID: 101, DataType: schemapb.DataType_VarChar}, descriptor)
+	})
+
+	t.Run("reads existing uncached collection info", func(t *testing.T) {
+		info := &CollectionInfo{Schema: newSchema(1, 100, schemapb.DataType_Int64)}
+		m := &shardManagerImpl{collections: map[int64]*CollectionInfo{10: info}}
+
+		descriptor, err := m.GetPrimaryKeyDescriptor(10, 1)
+		assert.NoError(t, err)
+		assert.Equal(t, PrimaryKeyDescriptor{FieldID: 100, DataType: schemapb.DataType_Int64}, descriptor)
+		assert.Nil(t, info.primaryKey)
+	})
+
+	t.Run("collection not found", func(t *testing.T) {
+		m := &shardManagerImpl{collections: map[int64]*CollectionInfo{}}
+		_, err := m.GetPrimaryKeyDescriptor(10, 1)
+		assert.ErrorIs(t, err, ErrCollectionNotFound)
+	})
+
+	t.Run("schema not found", func(t *testing.T) {
+		m := &shardManagerImpl{collections: map[int64]*CollectionInfo{10: {}}}
+		_, err := m.GetPrimaryKeyDescriptor(10, 1)
+		assert.ErrorIs(t, err, ErrCollectionSchemaNotFound)
+	})
+
+	t.Run("schema version mismatch", func(t *testing.T) {
+		info := &CollectionInfo{}
+		info.setSchema(newSchema(2, 100, schemapb.DataType_Int64))
+		m := &shardManagerImpl{collections: map[int64]*CollectionInfo{10: info}}
+
+		_, err := m.GetPrimaryKeyDescriptor(10, 1)
+		assert.ErrorIs(t, err, ErrCollectionSchemaVersionNotMatch)
+	})
+
+	t.Run("schema has no primary key", func(t *testing.T) {
+		info := &CollectionInfo{Schema: &streamingpb.CollectionSchemaOfVChannel{
+			Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{FieldID: 101}}},
+		}}
+		m := &shardManagerImpl{collections: map[int64]*CollectionInfo{10: info}}
+
+		_, err := m.GetPrimaryKeyDescriptor(10, latestCollectionSchemaVersion)
+		assert.Error(t, err)
+	})
+}
+
 // newShardManagerWithGrowingSegment builds a minimal shard manager that has
 // collection collID / partition partID / growing segment segID pre-loaded.
 func newShardManagerWithGrowingSegment(t *testing.T, collID, partID, segID int64) *shardManagerImpl {

--- a/internal/streamingnode/server/wal/interceptors/timetick/timetick_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/timetick_interceptor.go
@@ -84,7 +84,15 @@ func (impl *timeTickAppendInterceptor) DoAppend(ctx context.Context, msg message
 		if txnSession, err = impl.handleCommit(ctx, msg); err != nil {
 			return nil, err
 		}
-		defer txnSession.CommitDone()
+		defer func() {
+			if txn.IsCommitAdmissionRejected(err) {
+				txnSession.RejectCommit()
+				return
+			}
+			// Preserve the existing transaction outcome for non-admission errors.
+			// WAL append failures do not prove that CommitTxn was not persisted.
+			txnSession.CommitDone()
+		}()
 	case message.MessageTypeRollbackTxn:
 		if txnSession, err = impl.handleRollback(ctx, msg); err != nil {
 			return nil, err

--- a/internal/streamingnode/server/wal/interceptors/timetick/timetick_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/timetick/timetick_interceptor_test.go
@@ -1,0 +1,149 @@
+package timetick
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/timetick/mvcc"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/txn"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/impls/walimplstest"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func TestTimeTickCommitAppendSuccessCommits(t *testing.T) {
+	impl := newTestTimeTickAppendInterceptor(t)
+	commit, session := newCommitTxnMessageForExistingSession(t, impl, "v1")
+	expectedMsgID := walimplstest.NewTestMessageID(2)
+
+	ctx := utility.WithExtraAppendResult(context.Background(), &utility.ExtraAppendResult{})
+	msgID, err := impl.DoAppend(ctx, commit, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		return expectedMsgID, nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, expectedMsgID.EQ(msgID))
+	require.Equal(t, message.TxnStateCommitted, session.State())
+	requireCommitAckerSuccess(t, impl, session)
+}
+
+func TestTimeTickCommitAdmissionRejects(t *testing.T) {
+	impl := newTestTimeTickAppendInterceptor(t)
+	commit, session := newCommitTxnMessageForExistingSession(t, impl, "v1")
+	expectedErr := errors.New("validation rejected")
+
+	ctx := utility.WithExtraAppendResult(context.Background(), &utility.ExtraAppendResult{})
+	_, err := impl.DoAppend(ctx, commit, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		return nil, txn.MarkCommitAdmissionRejected(expectedErr)
+	})
+
+	require.ErrorIs(t, err, expectedErr)
+	require.True(t, txn.IsCommitAdmissionRejected(err))
+	require.Equal(t, message.TxnStateRollbacked, session.State())
+	requireCommitAckerError(t, impl, expectedErr)
+}
+
+func TestTimeTickCommitInnerErrorPreservesExistingStateTransition(t *testing.T) {
+	impl := newTestTimeTickAppendInterceptor(t)
+	commit, session := newCommitTxnMessageForExistingSession(t, impl, "v1")
+	expectedErr := errors.New("wal append failed")
+
+	ctx := utility.WithExtraAppendResult(context.Background(), &utility.ExtraAppendResult{})
+	_, err := impl.DoAppend(ctx, commit, func(context.Context, message.MutableMessage) (message.MessageID, error) {
+		return nil, expectedErr
+	})
+
+	require.ErrorIs(t, err, expectedErr)
+	require.False(t, txn.IsCommitAdmissionRejected(err))
+	require.Equal(t, message.TxnStateCommitted, session.State())
+	requireCommitAckerError(t, impl, expectedErr)
+}
+
+func requireCommitAckerSuccess(t *testing.T, impl *timeTickAppendInterceptor, session *txn.TxnSession) {
+	t.Helper()
+	details, err := impl.operator.AckManager().SyncAndGetAcknowledged(context.Background())
+	require.NoError(t, err)
+	for _, detail := range details {
+		if detail.Message != nil && detail.Message.MessageType() == message.MessageTypeCommitTxn {
+			require.NoError(t, detail.Err)
+			require.Same(t, session, detail.TxnSession)
+			return
+		}
+	}
+	t.Fatal("commit acker was not completed with the committed transaction")
+}
+
+func requireCommitAckerError(t *testing.T, impl *timeTickAppendInterceptor, expectedErr error) {
+	t.Helper()
+	details, err := impl.operator.AckManager().SyncAndGetAcknowledged(context.Background())
+	require.NoError(t, err)
+	for _, detail := range details {
+		if errors.Is(detail.Err, expectedErr) {
+			return
+		}
+	}
+	t.Fatal("commit acker did not retain the inner append error")
+}
+
+func newTestTimeTickAppendInterceptor(t *testing.T) *timeTickAppendInterceptor {
+	t.Helper()
+	paramtable.Init()
+	resource.InitForTest(t)
+
+	lastConfirmed := walimplstest.NewTestMessageID(0)
+	lastTimeTick := NewTimeTickMsg(1, lastConfirmed, 0, true).IntoImmutableMessage(lastConfirmed)
+	txnManager := txn.NewTxnManager(types.PChannelInfo{Name: "test"}, nil)
+	<-txnManager.RecoverDone()
+
+	param := &interceptors.InterceptorBuildParam{
+		ChannelInfo:            types.PChannelInfo{Name: "test"},
+		LastTimeTickMessage:    lastTimeTick,
+		LastConfirmedMessageID: lastConfirmed,
+		MVCCManager:            mvcc.NewMVCCManager(lastTimeTick.TimeTick()),
+		TxnManager:             txnManager,
+	}
+	impl, ok := NewInterceptorBuilder().Build(param).(*timeTickAppendInterceptor)
+	require.True(t, ok)
+	t.Cleanup(impl.Close)
+	return impl
+}
+
+func newCommitTxnMessageForExistingSession(
+	t *testing.T,
+	impl *timeTickAppendInterceptor,
+	vchannel string,
+) (message.MutableMessage, *txn.TxnSession) {
+	t.Helper()
+
+	var txnContext *message.TxnContext
+	begin := message.NewBeginTxnMessageBuilderV2().
+		WithVChannel(vchannel).
+		WithHeader(&message.BeginTxnMessageHeader{KeepaliveMilliseconds: time.Second.Milliseconds()}).
+		WithBody(&message.BeginTxnMessageBody{}).
+		MustBuildMutable()
+	ctx := utility.WithExtraAppendResult(context.Background(), &utility.ExtraAppendResult{})
+	_, err := impl.DoAppend(ctx, begin, func(_ context.Context, msg message.MutableMessage) (message.MessageID, error) {
+		txnContext = msg.TxnContext()
+		return walimplstest.NewTestMessageID(1), nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, txnContext)
+
+	session, err := impl.txnManager.GetSessionOfTxn(txnContext.TxnID)
+	require.NoError(t, err)
+
+	return message.NewCommitTxnMessageBuilderV2().
+		WithVChannel(vchannel).
+		WithHeader(&message.CommitTxnMessageHeader{}).
+		WithBody(&message.CommitTxnMessageBody{}).
+		MustBuildMutable().
+		WithTxnContext(*txnContext), session
+}

--- a/internal/streamingnode/server/wal/interceptors/txn/commit.go
+++ b/internal/streamingnode/server/wal/interceptors/txn/commit.go
@@ -1,0 +1,16 @@
+package txn
+
+import "github.com/cockroachdb/errors"
+
+var errCommitAdmissionRejected = errors.New("commit admission rejected")
+
+// MarkCommitAdmissionRejected marks an error as a deterministic rejection
+// before CommitTxn reaches the WAL.
+func MarkCommitAdmissionRejected(err error) error {
+	return errors.Mark(err, errCommitAdmissionRejected)
+}
+
+// IsCommitAdmissionRejected reports whether CommitTxn was rejected before WAL append.
+func IsCommitAdmissionRejected(err error) bool {
+	return errors.Is(err, errCommitAdmissionRejected)
+}

--- a/internal/streamingnode/server/wal/interceptors/txn/session.go
+++ b/internal/streamingnode/server/wal/interceptors/txn/session.go
@@ -164,6 +164,19 @@ func (s *TxnSession) CommitDone() {
 	s.cleanup()
 }
 
+// RejectCommit marks the transaction as rollbacked after commit admission rejects it.
+func (s *TxnSession) RejectCommit() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.state != message.TxnStateOnCommit {
+		// unreachable code here.
+		panic("invalid state for commit rejection")
+	}
+	s.state = message.TxnStateRollbacked
+	s.cleanup()
+}
+
 // RequestRollback rolls back the transaction.
 func (s *TxnSession) RequestRollback(ctx context.Context, timetick uint64) error {
 	waitCh, err := s.getDoneChan(timetick, message.TxnStateOnRollback)

--- a/internal/streamingnode/server/wal/interceptors/txn/session_test.go
+++ b/internal/streamingnode/server/wal/interceptors/txn/session_test.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
@@ -211,6 +213,29 @@ func TestWithContext(t *testing.T) {
 
 	session = GetTxnSessionFromContext(ctx)
 	assert.NotNil(t, session)
+}
+
+func TestTxnSessionRejectCommitAdmission(t *testing.T) {
+	metrics := metricsutil.NewTxnMetrics("p1")
+	defer metrics.Close()
+	session := newTxnSession("v1", message.TxnContext{TxnID: 1, Keepalive: time.Second}, 10, metrics.BeginTxn())
+	cleanupCalled := atomic.NewInt32(0)
+	session.RegisterCleanup(func() {
+		cleanupCalled.Inc()
+	}, 0)
+
+	err := session.RequestCommitAndWait(context.Background(), 11)
+	require.NoError(t, err)
+
+	session.RejectCommit()
+	require.Equal(t, message.TxnStateRollbacked, session.State())
+	require.Equal(t, int32(1), cleanupCalled.Load())
+	require.NotPanics(t, func() {
+		session.Cleanup()
+		session.Cleanup()
+		session.Cleanup()
+	})
+	require.Equal(t, int32(1), cleanupCalled.Load())
 }
 
 func TestRollbackAllInFlightTransactions(t *testing.T) {

--- a/internal/streamingnode/server/walmanager/manager_impl.go
+++ b/internal/streamingnode/server/walmanager/manager_impl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/adaptor"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/lock"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/partialupdate"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/redo"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/replicate"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard"
@@ -25,16 +26,21 @@ var errWALManagerClosed = status.NewOnShutdownError("wal manager is closed")
 func OpenManager() (Manager, error) {
 	resource.Resource().Logger().Info(context.TODO(), "open wal manager with dynamic opener")
 	// Create dynamic opener directly with interceptors
-	opener := adaptor.NewOpenerAdaptor(
-		[]interceptors.InterceptorBuilder{
-			redo.NewInterceptorBuilder(),
-			lock.NewInterceptorBuilder(),
-			replicate.NewInterceptorBuilder(),
-			timetick.NewInterceptorBuilder(),
-			shard.NewInterceptorBuilder(),
-		},
-	)
+	opener := adaptor.NewOpenerAdaptor(newInterceptorBuilders())
 	return newManager(opener), nil
+}
+
+// newInterceptorBuilders keeps shard validation ahead of partial-update write
+// tracking while both remain inside the TimeTick publication boundary.
+func newInterceptorBuilders() []interceptors.InterceptorBuilder {
+	return []interceptors.InterceptorBuilder{
+		redo.NewInterceptorBuilder(),
+		lock.NewInterceptorBuilder(),
+		replicate.NewInterceptorBuilder(),
+		timetick.NewInterceptorBuilder(),
+		shard.NewInterceptorBuilder(),
+		partialupdate.NewInterceptorBuilder(),
+	}
 }
 
 // newManager create a wal manager.

--- a/internal/streamingnode/server/walmanager/manager_impl_test.go
+++ b/internal/streamingnode/server/walmanager/manager_impl_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/mock_wal"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/partialupdate"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard"
 	internaltypes "github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
@@ -22,6 +24,22 @@ import (
 func TestMain(m *testing.M) {
 	paramtable.Init()
 	m.Run()
+}
+
+func TestOpenManager(t *testing.T) {
+	resource.InitForTest(t)
+
+	m, err := OpenManager()
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+	m.Close()
+}
+
+func TestPartialUpdateInterceptorRunsAfterShard(t *testing.T) {
+	builders := newInterceptorBuilders()
+	assert.Len(t, builders, 6)
+	assert.IsType(t, shard.NewInterceptorBuilder(), builders[4])
+	assert.IsType(t, partialupdate.NewInterceptorBuilder(), builders[5])
 }
 
 func TestManager(t *testing.T) {

--- a/internal/util/streamingutil/status/rpc_error.go
+++ b/internal/util/streamingutil/status/rpc_error.go
@@ -24,13 +24,14 @@ var streamingErrorToGRPCStatus = map[streamingpb.StreamingCode]codes.Code{
 	streamingpb.StreamingCode_STREAMING_CODE_INVAILD_ARGUMENT:          codes.InvalidArgument,
 	streamingpb.StreamingCode_STREAMING_CODE_TRANSACTION_EXPIRED:       codes.FailedPrecondition,
 	streamingpb.StreamingCode_STREAMING_CODE_INVALID_TRANSACTION_STATE: codes.FailedPrecondition,
+	streamingpb.StreamingCode_STREAMING_CODE_UNKNOWN:                   codes.Unknown,
+	streamingpb.StreamingCode_STREAMING_CODE_PARTIAL_UPDATE_RETRYABLE:  codes.Aborted,
 	streamingpb.StreamingCode_STREAMING_CODE_UNRECOVERABLE:             codes.FailedPrecondition,
 	streamingpb.StreamingCode_STREAMING_CODE_RESOURCE_ACQUIRED:         codes.FailedPrecondition,
 	streamingpb.StreamingCode_STREAMING_CODE_REPLICATE_VIOLATION:       codes.FailedPrecondition,
 	streamingpb.StreamingCode_STREAMING_CODE_WALNAME_MISMATCH:          codes.FailedPrecondition,
 	streamingpb.StreamingCode_STREAMING_CODE_SCHEMA_VERSION_MISMATCH:   codes.FailedPrecondition,
 	streamingpb.StreamingCode_STREAMING_CODE_RATE_LIMIT_REJECTED:       codes.ResourceExhausted,
-	streamingpb.StreamingCode_STREAMING_CODE_UNKNOWN:                   codes.Unknown,
 }
 
 // NewGRPCStatusFromStreamingError converts StreamingError to grpc status.

--- a/internal/util/streamingutil/status/rpc_error_test.go
+++ b/internal/util/streamingutil/status/rpc_error_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
@@ -60,4 +61,24 @@ func TestNewGRPCStatusFromStreamingError(t *testing.T) {
 		New(10086, "test"),
 	)
 	assert.Equal(t, codes.Unknown, st.Code())
+}
+
+func TestPartialUpdateCASErrorsGRPCMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *StreamingError
+		code codes.Code
+	}{
+		{"retryable", NewPartialUpdateRetryable("retry"), codes.Aborted},
+		{"malformed", NewUnrecoverableError("bad"), codes.FailedPrecondition},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := NewGRPCStatusFromStreamingError(tc.err)
+			require.Equal(t, tc.code, st.Code())
+			roundTrip := ConvertStreamingError("test", st.Err())
+			se := AsStreamingError(roundTrip)
+			require.Equal(t, tc.err.Code, se.Code)
+		})
+	}
 }

--- a/internal/util/streamingutil/status/streaming_error.go
+++ b/internal/util/streamingutil/status/streaming_error.go
@@ -107,6 +107,11 @@ func (e *StreamingError) IsRateLimitRejected() bool {
 	return e.Code == streamingpb.StreamingCode_STREAMING_CODE_RATE_LIMIT_REJECTED
 }
 
+// IsPartialUpdateRetryableCAS returns true if the partial update CAS error is retryable.
+func (e *StreamingError) IsPartialUpdateRetryableCAS() bool {
+	return e.Code == streamingpb.StreamingCode_STREAMING_CODE_PARTIAL_UPDATE_RETRYABLE
+}
+
 // NewOnShutdownError creates a new StreamingError with code STREAMING_CODE_ON_SHUTDOWN.
 func NewOnShutdownError(format string, args ...interface{}) *StreamingError {
 	return New(streamingpb.StreamingCode_STREAMING_CODE_ON_SHUTDOWN, format, args...)
@@ -191,6 +196,11 @@ func NewResourceAcquired(format string, args ...interface{}) *StreamingError {
 // NewRateLimitRejected creates a new StreamingError with code STREAMING_CODE_RATE_LIMIT_REJECTED.
 func NewRateLimitRejected(format string, args ...interface{}) *StreamingError {
 	return New(streamingpb.StreamingCode_STREAMING_CODE_RATE_LIMIT_REJECTED, format, args...)
+}
+
+// NewPartialUpdateRetryable creates a retryable partial update CAS error.
+func NewPartialUpdateRetryable(format string, args ...interface{}) *StreamingError {
+	return New(streamingpb.StreamingCode_STREAMING_CODE_PARTIAL_UPDATE_RETRYABLE, format, args...)
 }
 
 // New creates a new StreamingError with the given code and cause.

--- a/internal/util/streamingutil/status/streaming_error_test.go
+++ b/internal/util/streamingutil/status/streaming_error_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 )
@@ -76,4 +77,15 @@ func TestStreamingError(t *testing.T) {
 	assert.True(t, streamingErr.IsUnrecoverable())
 	pbErr = streamingErr.AsPBError()
 	assert.Equal(t, streamingpb.StreamingCode_STREAMING_CODE_INVAILD_ARGUMENT, pbErr.Code)
+}
+
+func TestPartialUpdateCASErrors(t *testing.T) {
+	retryable := NewPartialUpdateRetryable("retry")
+	require.Equal(t, streamingpb.StreamingCode_STREAMING_CODE_PARTIAL_UPDATE_RETRYABLE, retryable.Code)
+	require.True(t, retryable.IsPartialUpdateRetryableCAS())
+
+	unrecoverable := NewUnrecoverableError("bad metadata")
+	require.Equal(t, streamingpb.StreamingCode_STREAMING_CODE_UNRECOVERABLE, unrecoverable.Code)
+	require.False(t, unrecoverable.IsPartialUpdateRetryableCAS())
+	require.True(t, unrecoverable.IsUnrecoverable())
 }

--- a/pkg/streaming/util/message/partial_update_cas.go
+++ b/pkg/streaming/util/message/partial_update_cas.go
@@ -117,10 +117,6 @@ func validatePartialUpdateCAS(meta *messagespb.PartialUpdateCAS) error {
 		return merr.WrapErrServiceInternalMsg("partial update CAS read_ts is empty")
 	case meta.GetObservedPchannelTerm() <= 0:
 		return merr.WrapErrServiceInternalMsg("partial update CAS observed_pchannel_term is empty")
-	case meta.GetCollectionId() == 0:
-		return merr.WrapErrServiceInternalMsg("partial update CAS collection_id is empty")
-	case meta.GetPrimaryKeyFieldId() <= 0:
-		return merr.WrapErrServiceInternalMsg("partial update CAS primary_key_field_id is empty")
 	default:
 	}
 	return nil

--- a/pkg/streaming/util/message/partial_update_cas.go
+++ b/pkg/streaming/util/message/partial_update_cas.go
@@ -1,0 +1,127 @@
+package message
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// setProperty lets package helpers update ordinary and specialized mutable
+// messages without expanding the public MutableMessage interface.
+func (m *messageImpl) setProperty(key, value string) {
+	m.properties.Set(key, value)
+}
+
+// AddPartialUpdateCAS stores CAS metadata in an insert builder before its body
+// is encrypted and marks the resulting message for transactional production.
+func (b *mutableMesasgeBuilder[H, B]) AddPartialUpdateCAS(meta *messagespb.PartialUpdateCAS) error {
+	encoded, err := encodePartialUpdateCAS(meta)
+	if err != nil {
+		return err
+	}
+	body, ok := any(b.body).(*InsertRequest)
+	if !ok || body == nil {
+		return merr.WrapErrServiceInternalMsg("partial update CAS metadata requires an insert message builder")
+	}
+	setPartialUpdateCASInsertBody(body, encoded)
+	b.properties.Set(messagePartialUpdateCAS, "")
+	return nil
+}
+
+// MarkPartialUpdateCASCommit marks a locally-created CommitTxn so the WAL can
+// serialize its CAS admission without exposing the proof metadata in headers.
+func MarkPartialUpdateCASCommit(msg MutableMessage) error {
+	if msg == nil || msg.MessageType() != MessageTypeCommitTxn {
+		return merr.WrapErrServiceInternalMsg("partial update CAS commit marker requires a commit transaction message")
+	}
+	setter, ok := msg.(interface {
+		setProperty(key, value string)
+	})
+	if !ok {
+		return merr.WrapErrServiceInternalMsg("mutable message does not support properties")
+	}
+	setter.setProperty(messagePartialUpdateCAS, "")
+	return nil
+}
+
+func encodePartialUpdateCAS(meta *messagespb.PartialUpdateCAS) (string, error) {
+	if err := validatePartialUpdateCAS(meta); err != nil {
+		return "", err
+	}
+	encoded, err := EncodeProto(meta)
+	if err != nil {
+		return "", merr.WrapErrServiceInternalErr(err, "encode partial update CAS metadata")
+	}
+	return encoded, nil
+}
+
+func setPartialUpdateCASInsertBody(body *InsertRequest, encoded string) {
+	if body.Base == nil {
+		body.Base = &commonpb.MsgBase{}
+	}
+	if body.Base.Properties == nil {
+		body.Base.Properties = make(map[string]string)
+	}
+	body.Base.Properties[messagePartialUpdateCAS] = encoded
+}
+
+// HasPartialUpdateCAS returns true when the message is marked for partial update CAS.
+func HasPartialUpdateCAS(msg BasicMessage) bool {
+	return msg.Properties().Exist(messagePartialUpdateCAS)
+}
+
+// ExtractPartialUpdateCAS decodes partial update CAS metadata from the DML body.
+func ExtractPartialUpdateCAS(msg BasicMessage) (*messagespb.PartialUpdateCAS, error) {
+	if !HasPartialUpdateCAS(msg) {
+		return nil, nil
+	}
+	encoded, err := extractPartialUpdateCASBody(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	meta := &messagespb.PartialUpdateCAS{}
+	if err := DecodeProto(encoded, meta); err != nil {
+		return nil, merr.WrapErrServiceInternalErr(err, "decode partial update CAS metadata")
+	}
+	if err := validatePartialUpdateCAS(meta); err != nil {
+		return nil, err
+	}
+	return meta, nil
+}
+
+func extractPartialUpdateCASBody(msg BasicMessage) (string, error) {
+	if msg.MessageType() != MessageTypeInsert {
+		return "", merr.WrapErrServiceInternalMsg("partial update CAS marker requires an insert message")
+	}
+	body := &msgpb.InsertRequest{}
+	if err := proto.Unmarshal(msg.Payload(), body); err != nil {
+		return "", merr.WrapErrServiceInternalErr(err, "decode partial update insert body")
+	}
+	properties := body.GetBase().GetProperties()
+	encoded, ok := properties[messagePartialUpdateCAS]
+	if !ok || encoded == "" {
+		return "", merr.WrapErrServiceInternalMsg("partial update CAS body metadata is missing")
+	}
+	return encoded, nil
+}
+
+func validatePartialUpdateCAS(meta *messagespb.PartialUpdateCAS) error {
+	switch {
+	case meta == nil:
+		return merr.WrapErrServiceInternalMsg("partial update CAS metadata is nil")
+	case meta.GetReadTs() == 0:
+		return merr.WrapErrServiceInternalMsg("partial update CAS read_ts is empty")
+	case meta.GetObservedPchannelTerm() <= 0:
+		return merr.WrapErrServiceInternalMsg("partial update CAS observed_pchannel_term is empty")
+	case meta.GetCollectionId() == 0:
+		return merr.WrapErrServiceInternalMsg("partial update CAS collection_id is empty")
+	case meta.GetPrimaryKeyFieldId() <= 0:
+		return merr.WrapErrServiceInternalMsg("partial update CAS primary_key_field_id is empty")
+	default:
+	}
+	return nil
+}

--- a/pkg/streaming/util/message/partial_update_cas_test.go
+++ b/pkg/streaming/util/message/partial_update_cas_test.go
@@ -173,22 +173,26 @@ func TestPartialUpdateCASPropertyValidation(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "zero_primary_key_field_id",
+			name: "zero_read_ts",
 			meta: func() *messagespb.PartialUpdateCAS {
 				meta := validPartialUpdateCAS()
-				meta.PrimaryKeyFieldId = 0
+				meta.ReadTs = 0
 				return meta
 			},
 			wantErr: true,
 		},
 		{
-			name: "negative_primary_key_field_id",
+			name: "zero_observed_term",
 			meta: func() *messagespb.PartialUpdateCAS {
 				meta := validPartialUpdateCAS()
-				meta.PrimaryKeyFieldId = -1
+				meta.ObservedPchannelTerm = 0
 				return meta
 			},
 			wantErr: true,
+		},
+		{
+			name: "valid_attempt_proof",
+			meta: validPartialUpdateCAS,
 		},
 	}
 
@@ -264,8 +268,6 @@ func validPartialUpdateCAS() *messagespb.PartialUpdateCAS {
 	return &messagespb.PartialUpdateCAS{
 		ReadTs:               100,
 		ObservedPchannelTerm: 2,
-		CollectionId:         10,
-		PrimaryKeyFieldId:    100,
 	}
 }
 

--- a/pkg/streaming/util/message/partial_update_cas_test.go
+++ b/pkg/streaming/util/message/partial_update_cas_test.go
@@ -1,0 +1,306 @@
+package message
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/hook"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func TestPartialUpdateCASPropertyRoundTrip(t *testing.T) {
+	meta := validPartialUpdateCAS()
+	msg := newPartialUpdateCASTestMessageWithMeta(t, meta)
+
+	got, err := ExtractPartialUpdateCAS(msg)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(meta, got))
+	require.True(t, HasPartialUpdateCAS(msg))
+}
+
+func TestPartialUpdateCASMetadataStoredInBody(t *testing.T) {
+	meta := validPartialUpdateCAS()
+	builder := NewInsertMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&InsertMessageHeader{CollectionId: 10}).
+		WithBody(&msgpb.InsertRequest{Base: &commonpb.MsgBase{}})
+	require.NoError(t, builder.AddPartialUpdateCAS(meta))
+	msg := builder.MustBuildMutable()
+
+	marker, ok := msg.Properties().Get(messagePartialUpdateCAS)
+	require.True(t, ok)
+	require.Empty(t, marker)
+
+	insertMsg, err := AsMutableInsertMessageV1(msg)
+	require.NoError(t, err)
+	body, err := insertMsg.Body()
+	require.NoError(t, err)
+	encoded := body.GetBase().GetProperties()[messagePartialUpdateCAS]
+	require.NotEmpty(t, encoded)
+	decoded := &messagespb.PartialUpdateCAS{}
+	require.NoError(t, DecodeProto(encoded, decoded))
+	require.True(t, proto.Equal(meta, decoded))
+}
+
+func TestPartialUpdateCASBuilderEncryptsMetadataWithBody(t *testing.T) {
+	oldCipher := cipher
+	cipher = partialUpdateCASTestCipher{}
+	t.Cleanup(func() { cipher = oldCipher })
+
+	meta := validPartialUpdateCAS()
+	body := &msgpb.InsertRequest{Base: &commonpb.MsgBase{}}
+	builder := NewInsertMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&InsertMessageHeader{CollectionId: 10}).
+		WithBody(body)
+	require.NoError(t, builder.AddPartialUpdateCAS(meta))
+	plainBody, err := proto.Marshal(body)
+	require.NoError(t, err)
+	encodedMeta, err := EncodeProto(meta)
+	require.NoError(t, err)
+
+	msg, err := builder.
+		WithCipher(&CipherConfig{EzID: 1, CollectionID: 10}).
+		BuildMutable()
+	require.NoError(t, err)
+	rawPayload := msg.IntoMessageProto().GetPayload()
+	require.NotEqual(t, plainBody, rawPayload)
+	require.False(t, bytes.Contains(rawPayload, []byte(encodedMeta)))
+
+	got, err := ExtractPartialUpdateCAS(msg)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(meta, got))
+}
+
+func TestMarkPartialUpdateCASCommit(t *testing.T) {
+	commit := NewCommitTxnMessageBuilderV2().
+		WithVChannel("v1").
+		WithHeader(&CommitTxnMessageHeader{}).
+		WithBody(&CommitTxnMessageBody{}).
+		MustBuildMutable()
+
+	require.NoError(t, MarkPartialUpdateCASCommit(commit))
+	require.True(t, HasPartialUpdateCAS(commit))
+	marker, ok := commit.Properties().Get(messagePartialUpdateCAS)
+	require.True(t, ok)
+	require.Empty(t, marker)
+
+	require.Error(t, MarkPartialUpdateCASCommit(newPartialUpdateCASTestMessage()))
+	require.Error(t, MarkPartialUpdateCASCommit(nil))
+}
+
+func TestPartialUpdateCASDefensiveErrors(t *testing.T) {
+	t.Run("invalid builder metadata", func(t *testing.T) {
+		builder := NewInsertMessageBuilderV1().
+			WithVChannel("v1").
+			WithHeader(&InsertMessageHeader{CollectionId: 10}).
+			WithBody(&msgpb.InsertRequest{Base: &commonpb.MsgBase{}})
+		require.Error(t, builder.AddPartialUpdateCAS(&messagespb.PartialUpdateCAS{ReadTs: 100}))
+	})
+
+	t.Run("non insert builder", func(t *testing.T) {
+		builder := NewCommitTxnMessageBuilderV2().
+			WithVChannel("v1").
+			WithHeader(&CommitTxnMessageHeader{}).
+			WithBody(&CommitTxnMessageBody{})
+		require.Error(t, builder.AddPartialUpdateCAS(validPartialUpdateCAS()))
+	})
+
+	t.Run("commit without property setter", func(t *testing.T) {
+		commit := NewCommitTxnMessageBuilderV2().
+			WithVChannel("v1").
+			WithHeader(&CommitTxnMessageHeader{}).
+			WithBody(&CommitTxnMessageBody{}).
+			MustBuildMutable()
+		wrappedCommit := struct{ MutableMessage }{commit}
+		require.Error(t, MarkPartialUpdateCASCommit(wrappedCommit))
+	})
+}
+
+func TestPartialUpdateCASPropertyMissing(t *testing.T) {
+	msg := newPartialUpdateCASTestMessage()
+
+	got, err := ExtractPartialUpdateCAS(msg)
+	require.NoError(t, err)
+	require.Nil(t, got)
+	require.False(t, HasPartialUpdateCAS(msg))
+}
+
+func TestPartialUpdateCASPropertyMalformed(t *testing.T) {
+	msg := newPartialUpdateCASTestMessage("not-base64")
+
+	got, err := ExtractPartialUpdateCAS(msg)
+	require.Error(t, err)
+	require.ErrorIs(t, err, merr.ErrServiceInternal)
+	require.Nil(t, got)
+}
+
+func TestPartialUpdateCASPropertyIncomplete(t *testing.T) {
+	builder := NewInsertMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&InsertMessageHeader{CollectionId: 10}).
+		WithBody(&msgpb.InsertRequest{Base: &commonpb.MsgBase{}})
+	err := builder.AddPartialUpdateCAS(&messagespb.PartialUpdateCAS{ReadTs: 100})
+	require.Error(t, err)
+
+	invalid := validPartialUpdateCAS()
+	invalid.ObservedPchannelTerm = -1
+	err = builder.AddPartialUpdateCAS(invalid)
+	require.Error(t, err)
+}
+
+func TestPartialUpdateCASPropertyNilMeta(t *testing.T) {
+	builder := NewInsertMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&InsertMessageHeader{CollectionId: 10}).
+		WithBody(&msgpb.InsertRequest{Base: &commonpb.MsgBase{}})
+	err := builder.AddPartialUpdateCAS(nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, merr.ErrServiceInternal)
+}
+
+func TestPartialUpdateCASPropertyValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		meta    func() *messagespb.PartialUpdateCAS
+		wantErr bool
+	}{
+		{
+			name: "zero_primary_key_field_id",
+			meta: func() *messagespb.PartialUpdateCAS {
+				meta := validPartialUpdateCAS()
+				meta.PrimaryKeyFieldId = 0
+				return meta
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative_primary_key_field_id",
+			meta: func() *messagespb.PartialUpdateCAS {
+				meta := validPartialUpdateCAS()
+				meta.PrimaryKeyFieldId = -1
+				return meta
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder := NewInsertMessageBuilderV1().
+				WithVChannel("v1").
+				WithHeader(&InsertMessageHeader{CollectionId: 10}).
+				WithBody(&msgpb.InsertRequest{Base: &commonpb.MsgBase{}})
+			err := builder.AddPartialUpdateCAS(test.meta())
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPartialUpdateCASPropertyImmutableExtraction(t *testing.T) {
+	meta := validPartialUpdateCAS()
+	msg := newPartialUpdateCASTestMessageWithMeta(t, meta)
+	immutable := msg.IntoImmutableMessage(nil)
+
+	got, err := ExtractPartialUpdateCAS(immutable)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(meta, got))
+	require.True(t, HasPartialUpdateCAS(immutable))
+}
+
+func TestPartialUpdateCASPropertyInvalidProtoWire(t *testing.T) {
+	msg := newPartialUpdateCASTestMessage(base64.StdEncoding.EncodeToString([]byte{0xff, 0xff, 0xff}))
+
+	got, err := ExtractPartialUpdateCAS(msg)
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func TestPartialUpdateCASPropertyExtractSemanticallyInvalid(t *testing.T) {
+	encoded, err := EncodeProto(&messagespb.PartialUpdateCAS{ReadTs: 100})
+	require.NoError(t, err)
+	msg := newPartialUpdateCASTestMessage(encoded)
+
+	got, err := ExtractPartialUpdateCAS(msg)
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func newPartialUpdateCASTestMessage(propertyValue ...string) MutableMessage {
+	body := &msgpb.InsertRequest{Base: &commonpb.MsgBase{}}
+	builder := NewInsertMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&InsertMessageHeader{CollectionId: 10}).
+		WithBody(body)
+	if len(propertyValue) > 0 {
+		body.Base.Properties = map[string]string{messagePartialUpdateCAS: propertyValue[0]}
+		builder.WithBody(body).WithProperty(messagePartialUpdateCAS, "")
+	}
+	return builder.MustBuildMutable()
+}
+
+func newPartialUpdateCASTestMessageWithMeta(t *testing.T, meta *messagespb.PartialUpdateCAS) MutableMessage {
+	t.Helper()
+	builder := NewInsertMessageBuilderV1().
+		WithVChannel("v1").
+		WithHeader(&InsertMessageHeader{CollectionId: 10}).
+		WithBody(&msgpb.InsertRequest{Base: &commonpb.MsgBase{}})
+	require.NoError(t, builder.AddPartialUpdateCAS(meta))
+	return builder.MustBuildMutable()
+}
+
+func validPartialUpdateCAS() *messagespb.PartialUpdateCAS {
+	return &messagespb.PartialUpdateCAS{
+		ReadTs:               100,
+		ObservedPchannelTerm: 2,
+		CollectionId:         10,
+		PrimaryKeyFieldId:    100,
+	}
+}
+
+type partialUpdateCASTestCipher struct{}
+
+func (partialUpdateCASTestCipher) Init(map[string]string) error {
+	return nil
+}
+
+func (partialUpdateCASTestCipher) GetEncryptor(int64, int64) (hook.Encryptor, []byte, error) {
+	return partialUpdateCASTestCryptor{}, []byte("safe-key"), nil
+}
+
+func (partialUpdateCASTestCipher) GetDecryptor(int64, int64, []byte) (hook.Decryptor, error) {
+	return partialUpdateCASTestCryptor{}, nil
+}
+
+func (partialUpdateCASTestCipher) GetUnsafeKey(int64, int64) []byte {
+	return nil
+}
+
+type partialUpdateCASTestCryptor struct{}
+
+func (partialUpdateCASTestCryptor) Encrypt(plainText []byte) ([]byte, error) {
+	return partialUpdateCASTestXOR(plainText), nil
+}
+
+func (partialUpdateCASTestCryptor) Decrypt(cipherText []byte) ([]byte, error) {
+	return partialUpdateCASTestXOR(cipherText), nil
+}
+
+func partialUpdateCASTestXOR(input []byte) []byte {
+	output := make([]byte, len(input))
+	for i, value := range input {
+		output[i] = value ^ 0xff
+	}
+	return output
+}

--- a/pkg/streaming/util/message/properties.go
+++ b/pkg/streaming/util/message/properties.go
@@ -19,6 +19,7 @@ const (
 	messageReplicateMesssageHeader          = "_rh"  // replicate message header.
 	messageUnreplicable                     = "_ur"  // mark the message as unsafe to replicate.
 	messageTraceContext                     = "_tc"  // Trace context subset header.
+	messagePartialUpdateCAS                 = "_puc" // partial update CAS transaction marker.
 )
 
 var (

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -82,6 +82,9 @@ var (
 	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false, WithErrorType(InputError))
 	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false, WithErrorType(InputError))
 	ErrCollectionSchemaVersionNotReady = newMilvusError("collection schema version not ready", 110, true)
+	// ErrCollectionPartialUpdateConflict prevents clients from automatically
+	// replaying non-idempotent relative updates after a CAS rejection.
+	ErrCollectionPartialUpdateConflict = newMilvusError("partial update conflict", 111, false)
 
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false) // SystemError by default; the proxy GetPartitionInfo name chokepoint stamps InputError for user-supplied partition names, while id-based lookups stay system.

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -320,6 +320,15 @@ func TestWrapErrPreservesInnerChain(t *testing.T) {
 			code:     ErrServiceInternal.errCode,
 		},
 		{
+			name: "CollectionPartialUpdateConflict",
+			wrap: func() error {
+				return WrapErrCollectionPartialUpdateConflictErr(inner, "ctx %s", "test")
+			},
+			sentinel: ErrCollectionPartialUpdateConflict,
+			other:    ErrServiceUnavailable,
+			code:     ErrCollectionPartialUpdateConflict.errCode,
+		},
+		{
 			name:     "ParameterInvalid",
 			wrap:     func() error { return WrapErrParameterInvalidErr(inner, "ctx %d", 42) },
 			sentinel: ErrParameterInvalid,
@@ -381,4 +390,8 @@ func TestWrapErrPreservesInnerChain(t *testing.T) {
 
 	// nil err falls back to the Msg variant; just make sure that still works.
 	assert.True(t, errors.Is(WrapErrServiceInternalErr(nil, "no underlying err"), ErrServiceInternal))
+	assert.True(t, errors.Is(
+		WrapErrCollectionPartialUpdateConflictErr(nil, "no underlying err"),
+		ErrCollectionPartialUpdateConflict,
+	))
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -457,6 +457,15 @@ func WrapErrServiceUnavailableMsg(fmt string, args ...any) error {
 	return wrapMsg(ErrServiceUnavailable, fmt, args...)
 }
 
+// WrapErrServiceUnavailableErr classifies an untyped dependency or transport
+// failure as retriable service unavailability while preserving its cause.
+func WrapErrServiceUnavailableErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrServiceUnavailableMsg(format, args...)
+	}
+	return wrapInner(ErrServiceUnavailable, formatMsg(format, args...), err)
+}
+
 func WrapErrServiceMemoryLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceMemoryLimitExceeded,
 		value("predict(MB)", toMB(float64(predict))),
@@ -680,6 +689,15 @@ func WrapErrCollectionSchemaVersionNotReady(collection any, consistentSegments, 
 		fmt.Sprintf("%d/%d segments are consistent, required 100%%", consistentSegments, totalSegments),
 		value("collection", collection),
 	)
+}
+
+// WrapErrCollectionPartialUpdateConflictErr relabels a CAS rejection as a
+// non-retriable client result while preserving the original error chain.
+func WrapErrCollectionPartialUpdateConflictErr(err error, format string, args ...any) error {
+	if err == nil {
+		return wrapMsg(ErrCollectionPartialUpdateConflict, format, args...)
+	}
+	return wrapInner(ErrCollectionPartialUpdateConflict, formatMsg(format, args...), err)
 }
 
 func WrapErrAliasNotFound(db any, alias any, msg ...string) error {

--- a/pkg/util/merr/utils_test.go
+++ b/pkg/util/merr/utils_test.go
@@ -85,6 +85,16 @@ func TestIsRetryableErrWrapped(t *testing.T) {
 	assert.False(t, IsRetryableErr(nonRetryableErr))
 }
 
+func TestWrapErrServiceUnavailableErrPreservesCause(t *testing.T) {
+	cause := errors.New("transport failed")
+	err := WrapErrServiceUnavailableErr(cause, "dependency unavailable")
+
+	assert.ErrorIs(t, err, ErrServiceUnavailable)
+	assert.ErrorIs(t, err, cause)
+	assert.Equal(t, Code(ErrServiceUnavailable), Code(err))
+	assert.True(t, IsRetryableErr(err))
+}
+
 func TestChannelTSafeStalledStatus(t *testing.T) {
 	err := WrapErrChannelTSafeStalled("channel-1", "lag 3s")
 	assert.ErrorIs(t, err, ErrChannelTSafeStalled)

--- a/tests/go_client/testcases/nullable_default_value_test.go
+++ b/tests/go_client/testcases/nullable_default_value_test.go
@@ -2396,18 +2396,10 @@ func TestNullableVectorUpsert(t *testing.T) {
 			common.CheckErr(t, err, true)
 			require.EqualValues(t, upsert3Nb, upsertRes3.UpsertCount)
 
-			// For AutoID=true, upsert returns new IDs for the upserted rows
+			// AutoID partial update keeps the existing primary keys.
 			if autoID {
 				upsertedIDs := upsertRes3.IDs.(*column.ColumnInt64)
-				newPkData := upsertedIDs.Data()
-				// Update actualPkData for rows 0 to nullPercent-1
-				for i := range upsert3Nb {
-					// Remove old expected state
-					delete(expectedVectorMap, actualPkData[i])
-					delete(expectedScalarMap, actualPkData[i])
-					// Update to new PK
-					actualPkData[i] = newPkData[i]
-				}
+				require.Equal(t, upsert3PkData, upsertedIDs.Data())
 			}
 
 			// Update expected state: rows 0 to nullPercent-1 scalar updated, vector preserved (null)

--- a/tests/restful_client_v2/testcases/test_partial_update.py
+++ b/tests/restful_client_v2/testcases/test_partial_update.py
@@ -474,7 +474,7 @@ class TestPartialUpdate(TestBase):
 
     def test_partial_update_with_auto_id(self):
         """
-        Test partial update with autoID primary key - should fail as autoID is not supported for upsert
+        Test partial update with autoID primary key preserves the existing IDs.
         """
         # Create collection with autoID primary key
         name = gen_collection_name()
@@ -524,14 +524,13 @@ class TestPartialUpdate(TestBase):
         assert rsp["code"] == 0
         assert len(rsp["data"]) == nb
 
-        original_ids = [data["book_id"] for data in rsp["data"]]
+        original_ids_by_user = {data["user_id"]: data["book_id"] for data in rsp["data"]}
 
         # Partial update existing records using their auto-generated IDs
-        # When autoID=true, partial update should generate NEW IDs for existing records
         partial_update_data = []
-        for i, book_id in enumerate(original_ids):
+        for i in range(nb):
             tmp = {
-                "book_id": book_id,
+                "book_id": original_ids_by_user[i],
                 "book_describe": f"updated_book_{i}",  # Only update description
             }
             partial_update_data.append(tmp)
@@ -543,13 +542,13 @@ class TestPartialUpdate(TestBase):
         c.flush()
         time.sleep(3)
 
-        # Critical verification: old IDs should no longer exist
-        for old_id in original_ids:
-            rsp = self.vector_client.vector_query({"collectionName": name, "filter": f"book_id == {old_id}"})
+        # Existing IDs remain addressable after the update.
+        for original_id in original_ids_by_user.values():
+            rsp = self.vector_client.vector_query({"collectionName": name, "filter": f"book_id == {original_id}"})
             assert rsp["code"] == 0
-            assert len(rsp["data"]) == 0, f"Old ID {old_id} should not exist after partial update with autoID=true"
+            assert len(rsp["data"]) == 1
 
-        # Verify updated records have NEW auto-generated IDs
+        # Verify updated records retain their original auto-generated IDs.
         for i in range(nb):
             rsp = self.vector_client.vector_query({"collectionName": name, "filter": f"user_id == {i}"})
             assert rsp["code"] == 0
@@ -560,20 +559,26 @@ class TestPartialUpdate(TestBase):
             assert data["book_describe"] == f"updated_book_{i}"
             # Should have same user_id (identifies the record)
             assert data["user_id"] == i
-            # Should have NEW book_id (different from original)
-            assert data["book_id"] not in original_ids, (
-                f"New ID {data['book_id']} should be different from original IDs {original_ids}"
-            )
+            assert data["book_id"] == original_ids_by_user[i]
 
         # Verify total count is still correct (3 updated)
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id >= 0"})
         assert rsp["code"] == 0
         assert len(rsp["data"]) == 3
 
-        logger.info("Partial update with autoID test passed - verified new IDs generated for updated records")
+        missing_id = max(original_ids_by_user.values()) + 1
+        payload = {
+            "collectionName": name,
+            "data": [{"book_id": missing_id, "book_describe": "missing"}],
+            "partialUpdate": True,
+        }
+        rsp = self.vector_client.vector_upsert(payload)
+        assert rsp["code"] != 0
+
+        logger.info("Partial update with autoID test passed - verified IDs are preserved")
 
         """
-        Test detailed behavior of partial update with autoID: old record deletion and new record insertion
+        Test detailed behavior of partial update with autoID using the original ID.
         """
         # Create collection with autoID primary key
         name = gen_collection_name()
@@ -639,12 +644,10 @@ class TestPartialUpdate(TestBase):
         c.flush()
         time.sleep(3)
 
-        # Verify the original ID no longer exists
+        # Verify the original ID still identifies the updated record.
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": f"id == {original_id}"})
         assert rsp["code"] == 0
-        assert len(rsp["data"]) == 0, (
-            f"Original ID {original_id} should be deleted after partial update with autoID=true"
-        )
+        assert len(rsp["data"]) == 1
 
         # Verify there's still exactly one record with updated data
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "age > 0"})
@@ -652,12 +655,12 @@ class TestPartialUpdate(TestBase):
         assert len(rsp["data"]) == 1
 
         updated_record = rsp["data"][0]
-        new_id = updated_record["id"]
+        updated_id = updated_record["id"]
 
-        logger.info(f"Updated record: ID={new_id}, name={updated_record['name']}, age={updated_record['age']}")
+        logger.info(f"Updated record: ID={updated_id}, name={updated_record['name']}, age={updated_record['age']}")
 
-        # Verify the record has a new ID and updated fields
-        assert new_id != original_id, f"New ID {new_id} should be different from original ID {original_id}"
+        # Verify the record keeps its ID and updates only the requested field.
+        assert updated_id == original_id
         assert updated_record["name"] == "Alice Updated", "Name should be updated"
         assert updated_record["age"] == 25, "Age should remain unchanged (inherited from original record)"
 
@@ -731,8 +734,8 @@ class TestPartialUpdate(TestBase):
 
         updated_record = rsp["data"][0]
 
-        # Verify new ID generated
-        assert updated_record["id"] != original_id, "Should have new autoID"
+        # Verify the original ID is preserved.
+        assert updated_record["id"] == original_id
         # Verify field1 was updated
         assert updated_record["field1"] == "updated_value1", "field1 should be updated"
         # Verify other fields remained unchanged


### PR DESCRIPTION
issue: #49980

## Design review

- Primary approver: @chyezh
- Independent approver: @liliu-z
- Review date: 2026-08-07

## What changed

- Keep partial-update query and merge execution in Proxy.
- Resolve PChannel terms before allocating an attempt-scoped read timestamp.
- Carry only `read_ts` and `observed_pchannel_term` in the encrypted CAS
  attempt proof.
- Require every CAS Insert to carry an explicit schema version.
- Derive collection identity from the Insert header and resolve the
  authoritative PK descriptor through ShardManager.
- Reject transactions whose CAS chunks disagree on proof, collection, or
  schema.
- Serialize CAS validation, WAL append, index publication, and transaction
  transition with the existing vchannel lock.
- Rebuild safe REPLACE attempts after deterministic CAS rejection.
- Preserve existing transaction recovery and replication behavior.
- Release partial-update proof state after a durable DropCollection.

## Why

Concurrent partial updates can read the same row snapshot and subsequently
overwrite fields committed by another writer. The commit-side admission check
rejects a mutation when the PK changed after the Proxy snapshot.

Collection and PK identity are derived on StreamingNode instead of duplicated
in Proxy-generated proof. This prevents metadata from selecting a collection
or field that differs from the actual Insert message and schema.

## Behavior boundaries

- AutoID partial updates use update-only semantics: every supplied PK must
  exist in the query snapshot, and the merged insert preserves that PK.
- ARRAY_APPEND and ARRAY_REMOVE conflicts are non-retriable.
- Cross-vchannel atomicity and transaction-level exactly-once are unchanged.
- Concurrent Import, RestoreSnapshot, and backfill are outside this change.

## Design

- [Partial update optimistic lock design](docs/design-docs/design_docs/20260601-partial-update-optimistic-lock-design.md)
- [Protocol and design PR](https://github.com/milvus-io/milvus/pull/52235)

## Validation

- Full partialupdate package test with race detection, dynamic/test tags,
  disabled optimizations, and at least 99% coverage
- Targeted message, producer, and Proxy tests with dynamic/test tags and
  disabled optimizations
- `make milvus`
- `git diff --check`
