### PR TITLE
enhance: harden compaction logic against potential risks

### DIFF
--- a/internal/datacoord/compaction_task_bump_schema_version.go
+++ b/internal/datacoord/compaction_task_bump_schema_version.go
@@ -26,15 +26,18 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
+	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 var _ CompactionTask = (*bumpSchemaVersionTask)(nil)
@@ -113,6 +116,26 @@ func (t *bumpSchemaVersionTask) BuildCompactionRequest() (*datapb.CompactionPlan
 		JsonParams:                compactionParams,
 		CurrentScalarIndexVersion: t.ievm.ResolveScalarIndexVersion(),
 	}
+
+	// set analyzer resource for text match index if use ref mode.
+	// Only the full-rewrite path consumes these (inline createTextIndex, mirroring
+	// sort/mix); which path a segment takes is decided on the datanode, so attach
+	// best-effort: on failure keep building the plan without resources instead of
+	// failing tasks (bump-only / partial backfill) that never need them. A
+	// full-rewrite that does need them fails at createTextIndex resource
+	// resolution, next to the actual consumer.
+	if fileresource.IsRefMode(paramtable.Get().CommonCfg.DNFileResourceMode.GetValue()) &&
+		schemaNeedsTextIndex(taskProto.GetSchema()) &&
+		len(taskProto.GetSchema().GetFileResourceIds()) > 0 {
+		resources, err := t.meta.GetFileResources(context.Background(), taskProto.GetSchema().GetFileResourceIds()...)
+		if err != nil {
+			mlog.Warn(context.TODO(), "get file resources for schema bump compaction failed, building plan without them",
+				mlog.Int64("collectionID", taskProto.GetCollectionID()), mlog.Err(err))
+		} else {
+			plan.FileResources = resources
+		}
+	}
+
 	segments := make([]*SegmentInfo, 0, len(taskProto.GetInputSegments()))
 	for _, segID := range taskProto.GetInputSegments() {
 		segInfo := t.meta.GetHealthySegment(context.TODO(), segID)
@@ -145,6 +168,15 @@ func (t *bumpSchemaVersionTask) BuildCompactionRequest() (*datapb.CompactionPlan
 	plan.BeginLogID = logIDRange.Begin
 	WrapPluginContext(taskProto.GetCollectionID(), taskProto.GetSchema().GetProperties(), plan)
 	return plan, nil
+}
+
+func schemaNeedsTextIndex(schema *schemapb.CollectionSchema) bool {
+	for _, field := range schema.GetFields() {
+		if typeutil.CreateFieldSchemaHelper(field).EnableMatch() {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *bumpSchemaVersionTask) GetSlotUsage() int64 {

--- a/internal/datacoord/compaction_task_bump_schema_version_test.go
+++ b/internal/datacoord/compaction_task_bump_schema_version_test.go
@@ -37,8 +37,10 @@ import (
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	taskcommon "github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestBumpSchemaVersionCompactionTaskSuite(t *testing.T) {
@@ -203,6 +205,108 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildCompactionRequest() {
 	s.Require().NotNil(plan.GetSchema())
 	s.Equal(task.GetTaskProto().GetSchema().GetVersion(), plan.GetSchema().GetVersion())
 	s.Equal(int32(3), plan.GetCurrentScalarIndexVersion())
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) addFlushedSegmentForBuild(segmentID int64) {
+	err := s.meta.AddSegment(context.TODO(), &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:            segmentID,
+			CollectionID:  1,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			Level:         datapb.SegmentLevel_L1,
+			State:         commonpb.SegmentState_Flushed,
+			NumOfRows:     1000,
+			Binlogs: []*datapb.FieldBinlog{
+				{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 1000, EntriesNum: 1000}}},
+			},
+		},
+	})
+	s.NoError(err)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) taskWithFileResourceIds(ids []int64) *bumpSchemaVersionTask {
+	proto := s.generateBasicTask().GetTaskProto()
+	proto.Schema.FileResourceIds = ids
+	for _, field := range proto.Schema.GetFields() {
+		if field.GetName() == "text" {
+			field.TypeParams = append(field.TypeParams, &commonpb.KeyValuePair{Key: "enable_match", Value: "true"})
+			break
+		}
+	}
+	return newBumpSchemaVersionTask(proto, s.mockAlloc, s.meta, s.ievm)
+}
+
+// TestBuildCompactionRequest_BumpFileResourcesInRefMode covers the ref-mode FileResources
+// branch of bump BuildCompactionRequest: bump full-rewrite rebuilds the text-match index
+// inline (createTextIndex) and must carry the analyzer resources, mirroring sort/mix. Without
+// them ref mode cannot resolve the referenced analyzer resource and the compaction fails.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildCompactionRequest_BumpFileResourcesInRefMode() {
+	expectedResources := []*internalpb.FileResourceInfo{
+		{Id: 7, Name: "dict", Path: "dict.jieba"},
+	}
+
+	s.Run("ref_mode_carries_resources", func() {
+		pt := paramtable.Get()
+		pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "ref")
+		defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+		s.NoError(s.meta.UpdateFileResources(context.TODO(), expectedResources, 1))
+		s.addFlushedSegmentForBuild(101)
+
+		plan, err := s.taskWithFileResourceIds([]int64{7}).BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Equal(expectedResources, plan.GetFileResources(),
+			"bump full-rewrite must carry FileResources for inline text-index analyzer resources in ref mode")
+		s.NotEmpty(plan.GetSegmentBinlogs(),
+			"BuildCompactionRequest must run to completion (past the segment loop), not early-return")
+	})
+
+	s.Run("sync_mode_skips_resources", func() {
+		pt := paramtable.Get()
+		pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "sync")
+		defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+		s.addFlushedSegmentForBuild(101)
+
+		plan, err := s.taskWithFileResourceIds([]int64{7}).BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Empty(plan.GetFileResources(),
+			"sync mode pre-syncs resources, so the plan does not carry them")
+	})
+
+	s.Run("ref_mode_missing_resource_is_best_effort", func() {
+		pt := paramtable.Get()
+		pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "ref")
+		defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+		s.addFlushedSegmentForBuild(101)
+
+		// resource id 7 is never registered in meta; datacoord's resource view may
+		// legitimately be unpopulated, and only the full-rewrite path consumes the
+		// resources. Plan building must proceed without them so bump-only / partial
+		// backfill tasks are not failed by a resource they never use.
+		plan, err := s.taskWithFileResourceIds([]int64{7}).BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Empty(plan.GetFileResources(),
+			"missing resources must degrade to an empty carry, not fail the plan")
+		s.NotEmpty(plan.GetSegmentBinlogs(),
+			"BuildCompactionRequest must run to completion despite the missing resource")
+	})
+
+	s.Run("ref_mode_without_text_index_skips_resources", func() {
+		pt := paramtable.Get()
+		pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "ref")
+		defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+		taskProto := s.generateBasicTask().GetTaskProto()
+		taskProto.Schema.FileResourceIds = []int64{7}
+		s.addFlushedSegmentForBuild(101)
+
+		plan, err := newBumpSchemaVersionTask(taskProto, s.mockAlloc, s.meta, s.ievm).BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Empty(plan.GetFileResources(), "analyzer resources are unnecessary when no field enables text match")
+	})
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildCompactionRequestCarriesV3ManifestAndPreAllocatedLogs() {

--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -131,19 +131,19 @@ func (t *bumpSchemaVersionCompactionTask) preCompact() error {
 	return nil
 }
 
-func (t *bumpSchemaVersionCompactionTask) missingFunctionInputSchema(missingFunctions []*schemapb.FunctionSchema) (*schemapb.CollectionSchema, []int64, error) {
+func (t *bumpSchemaVersionCompactionTask) buildFunctionBackfillReadSchema(missingFunctions []*schemapb.FunctionSchema, sourceFields map[int64]struct{}) (*schemapb.CollectionSchema, []int64, error) {
 	schema := t.plan.GetSchema()
 	seen := make(map[int64]struct{})
-	var fields []*schemapb.FieldSchema
-	var fieldIDs []int64
-	addInputField := func(field *schemapb.FieldSchema) {
+	var readFields []*schemapb.FieldSchema
+	var readFieldIDs []int64
+	addReadField := func(field *schemapb.FieldSchema) {
 		fieldID := field.GetFieldID()
 		if _, ok := seen[fieldID]; ok {
 			return
 		}
 		seen[fieldID] = struct{}{}
-		fields = append(fields, field)
-		fieldIDs = append(fieldIDs, fieldID)
+		readFields = append(readFields, field)
+		readFieldIDs = append(readFieldIDs, fieldID)
 	}
 	for _, functionSchema := range missingFunctions {
 		if err := validateSupportedMissingFunctionMaterialization(functionSchema); err != nil {
@@ -157,39 +157,59 @@ func (t *bumpSchemaVersionCompactionTask) missingFunctionInputSchema(missingFunc
 			if err := validateMaterializationInputField(functionSchema, inputField); err != nil {
 				return nil, nil, err
 			}
-			addInputField(inputField)
+			addReadField(inputField)
 
-			additionalFields, err := additionalFunctionInputFields(schema, functionSchema, inputField)
+			implicitFields, err := implicitFunctionInputFields(schema, functionSchema, inputField)
 			if err != nil {
 				return nil, nil, err
 			}
-			for _, additionalField := range additionalFields {
-				if err := validateMaterializationInputField(functionSchema, additionalField); err != nil {
+			for _, implicitField := range implicitFields {
+				if err := validateMaterializationInputField(functionSchema, implicitField); err != nil {
 					return nil, nil, err
 				}
-				addInputField(additionalField)
+				addReadField(implicitField)
+			}
+		}
+	}
+	// If no explicit or implicit input exists physically, the filtered read
+	// schema would be empty. Add one system column as a row-count anchor.
+	hasReadableSourceField := false
+	for _, fieldID := range readFieldIDs {
+		if _, ok := sourceFields[fieldID]; ok {
+			hasReadableSourceField = true
+			break
+		}
+	}
+	if !hasReadableSourceField {
+		for _, fieldID := range []int64{common.RowIDField, common.TimeStampField} {
+			if _, ok := sourceFields[fieldID]; !ok {
+				continue
+			}
+			if field := typeutil.GetField(schema, fieldID); field != nil {
+				addReadField(field)
+				break
 			}
 		}
 	}
 	return &schemapb.CollectionSchema{
 		Name:               schema.GetName(),
 		Description:        schema.GetDescription(),
-		Fields:             fields,
+		Fields:             readFields,
 		EnableDynamicField: schema.GetEnableDynamicField(),
 		Properties:         schema.GetProperties(),
-	}, fieldIDs, nil
+	}, readFieldIDs, nil
 }
 
-func additionalFunctionInputFields(schema *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema, inputField *schemapb.FieldSchema) ([]*schemapb.FieldSchema, error) {
+func implicitFunctionInputFields(schema *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema, inputField *schemapb.FieldSchema) ([]*schemapb.FieldSchema, error) {
 	switch functionSchema.GetType() {
 	case schemapb.FunctionType_BM25:
-		return bm25AdditionalInputFields(schema, inputField)
+		return bm25ImplicitInputFields(schema, functionSchema, inputField)
 	default:
 		return nil, nil
 	}
 }
 
-func bm25AdditionalInputFields(schema *schemapb.CollectionSchema, inputField *schemapb.FieldSchema) ([]*schemapb.FieldSchema, error) {
+func bm25ImplicitInputFields(schema *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema, inputField *schemapb.FieldSchema) ([]*schemapb.FieldSchema, error) {
 	params, ok := typeutil.CreateFieldSchemaHelper(inputField).GetMultiAnalyzerParams()
 	if !ok {
 		return nil, nil
@@ -198,14 +218,14 @@ func bm25AdditionalInputFields(schema *schemapb.CollectionSchema, inputField *sc
 		ByField string `json:"by_field"`
 	}
 	if err := json.Unmarshal([]byte(params), &multiAnalyzerParams); err != nil {
-		return nil, err
+		return nil, merr.WrapErrDataIntegrity(err, "failed to parse multi_analyzer_params for function %s", functionSchema.GetName())
 	}
 	if multiAnalyzerParams.ByField == "" {
-		return nil, merr.WrapErrParameterInvalidMsg("multi_analyzer_params missing required 'by_field' key")
+		return nil, merr.WrapErrDataIntegrityMsg("multi_analyzer_params for function %s is missing required 'by_field' key", functionSchema.GetName())
 	}
 	byField := typeutil.GetFieldByName(schema, multiAnalyzerParams.ByField)
 	if byField == nil {
-		return nil, merr.WrapErrParameterInvalidMsg("input field not found in schema")
+		return nil, merr.WrapErrDataIntegrityMsg("multi_analyzer_params for function %s references missing input field %s", functionSchema.GetName(), multiAnalyzerParams.ByField)
 	}
 	return []*schemapb.FieldSchema{byField}, nil
 }
@@ -288,16 +308,6 @@ func validateMaterializationOutputField(functionSchema *schemapb.FunctionSchema,
 	return nil
 }
 
-func partialMaterializerExistingFields(schema *schemapb.CollectionSchema, missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) map[int64]struct{} {
-	fields := collectionSchemaFields(schema)
-	for _, functionSchema := range missingFunctions {
-		for _, outputIndex := range functionOutputIndexesToMaterialize(functionSchema, existingFields) {
-			delete(fields, functionSchema.GetOutputFieldIds()[outputIndex])
-		}
-	}
-	return fields
-}
-
 func (t *bumpSchemaVersionCompactionTask) openRecordReader(segment *datapb.CompactionSegmentBinlogs, schema *schemapb.CollectionSchema) (storage.RecordReader, map[int64]struct{}, error) {
 	reader, existingFields, err := newCompactionSegmentRecordReader(t.ctx, segment, schema, t.compactionParams.StorageConfig,
 		storage.WithCollectionID(segment.GetCollectionID()),
@@ -328,35 +338,35 @@ func (t *bumpSchemaVersionCompactionTask) fullRewriteSegmentID() (int64, error) 
 	return idRange.GetBegin(), nil
 }
 
-func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchema, entityFilter compaction.EntityFilter, ttlFieldID int64, useTTLField bool, ttlValues []int64) (*recordSelection, []int64, error) {
+func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchema, entityFilter compaction.EntityFilter, ttlFieldID int64, useTTLField bool, ttlDefault int64, useTTLDefault bool) (*recordSelection, error) {
 	pkArray := record.Column(pkField.GetFieldID())
 	var pkAt func(int) any
 	switch pkField.GetDataType() {
 	case schemapb.DataType_Int64:
 		int64Array, ok := pkArray.(*array.Int64)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("int64 primary key field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("int64 primary key field not found in full schema rewrite record")
 		}
 		pkAt = func(i int) any { return int64Array.Value(i) }
 	case schemapb.DataType_VarChar:
 		stringArray, ok := pkArray.(*array.String)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("varchar primary key field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("varchar primary key field not found in full schema rewrite record")
 		}
 		pkAt = func(i int) any { return stringArray.Value(i) }
 	default:
-		return nil, nil, merr.WrapErrServiceInternal("invalid primary key data type for full schema rewrite")
+		return nil, merr.WrapErrServiceInternal("invalid primary key data type for full schema rewrite")
 	}
 
 	timestampArray, ok := record.Column(common.TimeStampField).(*array.Int64)
 	if !ok {
-		return nil, nil, merr.WrapErrServiceInternal("timestamp field not found in full schema rewrite record")
+		return nil, merr.WrapErrServiceInternal("timestamp field not found in full schema rewrite record")
 	}
 	var ttlArray *array.Int64
 	if useTTLField {
 		ttlArray, ok = record.Column(ttlFieldID).(*array.Int64)
 		if !ok {
-			return nil, nil, merr.WrapErrServiceInternal("TTL field not found in full schema rewrite record")
+			return nil, merr.WrapErrServiceInternal("TTL field not found in full schema rewrite record")
 		}
 	}
 
@@ -367,6 +377,8 @@ func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchem
 		expireTs := int64(-1)
 		if useTTLField && ttlArray.IsValid(i) {
 			expireTs = ttlArray.Value(i)
+		} else if !useTTLField && useTTLDefault {
+			expireTs = ttlDefault
 		}
 		if entityFilter.Filtered(pkAt(i), typeutil.Timestamp(timestampArray.Value(i)), expireTs) {
 			if sliceStart != -1 {
@@ -378,9 +390,6 @@ func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchem
 			continue
 		}
 
-		if useTTLField && expireTs > 0 {
-			ttlValues = append(ttlValues, expireTs)
-		}
 		if sliceStart == -1 {
 			sliceStart = i
 		}
@@ -390,9 +399,24 @@ func selectFullRewriteRecord(record storage.Record, pkField *schemapb.FieldSchem
 		selection.length += record.Len() - sliceStart
 	}
 	if filteredRows == 0 {
-		return nil, ttlValues, nil
+		return nil, nil
 	}
-	return selection, ttlValues, nil
+	return selection, nil
+}
+
+func fullRewriteTTLDefault(schema *schemapb.CollectionSchema, ttlFieldID int64) (int64, bool, error) {
+	if ttlFieldID < common.StartOfUserFieldID {
+		return 0, false, nil
+	}
+	ttlField := typeutil.GetField(schema, ttlFieldID)
+	if ttlField == nil || ttlField.GetDefaultValue() == nil {
+		return 0, false, nil
+	}
+	value, ok := ttlField.GetDefaultValue().GetData().(*schemapb.ValueField_TimestamptzData)
+	if !ok {
+		return 0, false, merr.WrapErrDataIntegrityMsg("TTL field %d has a non-timestamptz default value", ttlFieldID)
+	}
+	return value.TimestamptzData, true, nil
 }
 
 func (t *bumpSchemaVersionCompactionTask) runSchemaVersionBumpOnly() *datapb.CompactionPlanResult {
@@ -425,6 +449,7 @@ func (t *bumpSchemaVersionCompactionTask) runSchemaVersionBumpOnly() *datapb.Com
 }
 
 func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields map[int64]struct{}) (*datapb.CompactionPlanResult, error) {
+	// 1. Set up source filtering, reading, and materialization.
 	segment := t.plan.GetSegmentBinlogs()[0]
 	collectionID := segment.GetCollectionID()
 	newSegmentID, err := t.fullRewriteSegmentID()
@@ -461,10 +486,8 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 	}
 	defer materializer.Close()
 
-	// Prepare LOB (TEXT) handling: a schema bump keeps existing TEXT LOB data
-	// unchanged, so REUSE_ALL — the writer preserves the encoded LOB reference
-	// bytes (WithTextRefsAsBinary) and the source LOB files are merged into the
-	// output manifest afterwards (applyLOBCompaction). Mirrors sort compaction.
+	// 2. Set up LOB reuse and the output writer.
+	// Existing TEXT LOB references stay unchanged in REUSE_ALL mode.
 	if err := t.initLOBCompactionContext(t.ctx); err != nil {
 		return nil, err
 	}
@@ -504,6 +527,16 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		}
 	}()
 
+	// 3. Filter, materialize, and rewrite source records.
+	// Source TTL presence is decided from existingFields, never by probing the
+	// record: V2/V3 records panic on Column for a field they do not carry.
+	_, sourceHasTTL := existingFields[ttlFieldID]
+	sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && sourceHasTTL
+	ttlDefault, hasTTLDefault, err := fullRewriteTTLDefault(t.plan.GetSchema(), ttlFieldID)
+	if err != nil {
+		return nil, err
+	}
+	preMaterializeFilter := len(delta) > 0 || t.plan.GetCollectionTtl() > 0 || sourceHasTTLField || hasTTLDefault
 	var totalRows int64
 	for {
 		record, err := reader.Next()
@@ -514,11 +547,9 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			return nil, err
 		}
 
-		sourceHasTTLField := ttlFieldID >= common.StartOfUserFieldID && record.Column(ttlFieldID) != nil
-		preMaterializeFilter := len(delta) > 0 || t.plan.GetCollectionTtl() > 0 || sourceHasTTLField
 		var selection *recordSelection
 		if preMaterializeFilter {
-			selection, _, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField, nil)
+			selection, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField, ttlDefault, hasTTLDefault)
 			if err != nil {
 				return nil, err
 			}
@@ -549,6 +580,7 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		cleanupMaterializedRecord(wrapped)
 	}
 
+	// 4. Finalize writer output and assemble the rewritten segment.
 	if err := writer.Close(); err != nil {
 		return nil, err
 	}
@@ -600,20 +632,13 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		ExpirQuantiles:      expirQuantiles,
 		IsSorted:            segment.GetIsSorted(),
 		IsSortedByNamespace: segment.GetIsSortedByNamespace(),
-		// Stats: insert aggregates from the freshly emitted insert logs,
-		// stats footprint from the writer's tracked counter. V3 writers
-		// leave statsLog/bm25StatsLogs nil because stats live in the
-		// manifest — the counter is the only correct source.
+		// Build insert stats from emitted logs. For V3, the writer's tracked size
+		// is authoritative because stats are stored in the manifest.
 		Stats: buildCompactionOutputStats(sortedInsertLogs, nil, writer.GetStatsBlobSize()),
 	}
 
-	// Merge the source segment's TEXT LOB file references into the output manifest
-	// (REUSE_ALL) BEFORE building the text-match index. createTextIndex reads the TEXT
-	// column through this manifest, so the carried LOB files must already be referenced
-	// -- otherwise the match index for an out-of-line (>=64KB) TEXT field is built against
-	// a manifest that does not yet list those LOB files, silently missing that data.
-	// Mirrors sort/mix (applyLOBCompaction before createTextIndex); AddStatsToManifest
-	// below then chains its text stats onto the LOB-merged manifest.
+	// 5. Merge LOB references before building text-match indexes so the reader
+	// can resolve out-of-line TEXT data from the output manifest.
 	if err := t.applyLOBCompaction(t.ctx, resultSegment); err != nil {
 		return nil, err
 	}
@@ -746,6 +771,32 @@ type bumpSchemaVersionBatchWriter interface {
 	GetWrittenUncompressed() uint64
 	AsNewColumnGroups()
 	Close() (packed.WriterOutput, error)
+	Abort()
+}
+
+type bumpSchemaVersionWriterLease struct {
+	writer    bumpSchemaVersionBatchWriter
+	exhausted bool
+}
+
+func (l *bumpSchemaVersionWriterLease) Close() (packed.WriterOutput, error) {
+	output, err := l.writer.Close()
+	// Close consumes the native writer even when it returns an error. Never call
+	// it again from deferred cleanup; only the returned output still needs release.
+	l.exhausted = true
+	return output, err
+}
+
+// Cleanup aborts an unconsumed writer without flushing pending column groups:
+// the output will not be committed, so a farewell flush would only upload
+// orphan files. Files already flushed during Write stay on storage,
+// unreferenced by the manifest.
+func (l *bumpSchemaVersionWriterLease) Cleanup() {
+	if l == nil || l.exhausted {
+		return
+	}
+	l.exhausted = true
+	l.writer.Abort()
 }
 
 type bumpSchemaVersionWriterResult struct {
@@ -755,10 +806,7 @@ type bumpSchemaVersionWriterResult struct {
 	basePath       string
 	baseVersion    int64
 	v3Stats        []packed.StatEntry
-	// statsBlobSize tracks the cumulative bloom-filter + BM25 blob memory
-	// committed via addV3Stats. Reported to DataCoord on
-	// CompactionSegment.Stats.StatsBinlogSize.
-	statsBlobSize int64
+	statsBlobSize  int64
 }
 
 func (t *bumpSchemaVersionCompactionTask) setupWriter(outputFields []*schemapb.FieldSchema, segment *datapb.CompactionSegmentBinlogs, collectionID int64) (*bumpSchemaVersionWriterResult, error) {
@@ -943,19 +991,23 @@ func (t *bumpSchemaVersionCompactionTask) finalizeMergedLogs(segment *datapb.Com
 	return storage.SortFieldBinlogs(mergedInsertLogs), nil
 }
 
-func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx context.Context, missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*datapb.CompactionPlanResult, error) {
+func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx context.Context, missingFunctions []*schemapb.FunctionSchema, sourceFields map[int64]struct{}) (*datapb.CompactionPlanResult, error) {
 	segment := t.plan.GetSegmentBinlogs()[0]
 	collectionID := segment.GetCollectionID()
 	partitionID := segment.GetPartitionID()
 	segmentID := segment.GetSegmentID()
 
-	inputSchema, inputFieldIDs, err := t.missingFunctionInputSchema(missingFunctions)
+	readSchema, readFieldIDs, err := t.buildFunctionBackfillReadSchema(missingFunctions, sourceFields)
 	if err != nil {
 		return nil, err
 	}
-	outputFields, outputFieldIDs, err := t.missingFunctionOutputFields(missingFunctions, existingFields)
+	outputFields, outputFieldIDs, err := t.missingFunctionOutputFields(missingFunctions, sourceFields)
 	if err != nil {
 		return nil, err
+	}
+	baseStatsBlobSize, err := packed.StatsBinlogSizeFromManifest(segment.GetManifest(), t.compactionParams.StorageConfig)
+	if err != nil {
+		return nil, merr.Wrap(err, "failed to read base schema bump stats size")
 	}
 
 	log := mlog.With(
@@ -963,13 +1015,13 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		mlog.FieldCollectionID(collectionID),
 		mlog.FieldPartitionID(partitionID),
 		mlog.FieldSegmentID(segmentID),
-		mlog.Int64s("inputFieldIDs", inputFieldIDs),
+		mlog.Int64s("readFieldIDs", readFieldIDs),
 		mlog.Int64s("outputFieldIDs", outputFieldIDs),
 	)
 
 	var readDuration, computeDuration, writeDuration, updateStatsDuration time.Duration
 
-	reader, _, err := t.openRecordReader(segment, inputSchema)
+	reader, _, err := t.openRecordReader(segment, readSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -979,12 +1031,14 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	if err != nil {
 		return nil, err
 	}
+	writerLease := &bumpSchemaVersionWriterLease{writer: writerResult.writer}
+	defer writerLease.Cleanup()
 
 	log.Info(ctx, "schema bump writer setup",
 		mlog.Int64("effectiveStorageVersion", writerResult.storageVersion),
 		mlog.Int64("clusterStorageVersion", t.compactionParams.StorageVersion),
 		mlog.Bool("segmentHasManifest", segment.GetManifest() != ""),
-		mlog.Int64s("inputFieldIDs", inputFieldIDs),
+		mlog.Int64s("readFieldIDs", readFieldIDs),
 		mlog.Int64s("outputFieldIDs", outputFieldIDs),
 	)
 	_, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BumpSchemaVersionCompact.batchProcess")
@@ -995,8 +1049,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 			statsByField[outputFieldID] = storage.NewBM25Stats()
 		}
 	}
-	existingFields = partialMaterializerExistingFields(t.plan.GetSchema(), missingFunctions, existingFields)
-	materializer, err := NewRecordMaterializer(t.plan.GetSchema(), missingFunctions, existingFields)
+	materializer, err := NewFunctionBackfillMaterializer(t.plan.GetSchema(), missingFunctions, sourceFields)
 	if err != nil {
 		span.End()
 		return nil, err
@@ -1089,12 +1142,12 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		return nil, err
 	}
 
-	writerOutput, err := writerResult.writer.Close()
-	if err != nil {
-		return nil, err
-	}
+	writerOutput, err := writerLease.Close()
 	if writerOutput != nil {
 		defer writerOutput.Destroy()
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	manifestPath, err := packed.CommitManifestUpdates(
@@ -1130,15 +1183,12 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 				StorageVersion:      writerResult.storageVersion,
 				Manifest:            manifestPath,
 				BaseManifest:        segment.GetManifest(),
-				// Partial-writer path merges new inserts with the
-				// input's existing statslogs and deltalogs. statsBlobSize
-				// comes from the freshly committed V3 stats (tracked on
-				// writerResult); insert/delta aggregates come from the
-				// merged arrays.
+				// Missing function outputs add new stats keys, so the final
+				// footprint is the base manifest plus this task's new blobs.
 				Stats: buildCompactionOutputStats(
 					mergedInsertLogs,
 					segment.GetDeltalogs(),
-					writerResult.statsBlobSize,
+					baseStatsBlobSize+writerResult.statsBlobSize,
 				),
 			},
 		},

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/internal/util/initcore"
@@ -50,6 +51,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
@@ -104,6 +106,25 @@ func (w *fakeBinlogRecordWriter) GetStatsBlobSize() int64            { return w.
 func (w *fakeBinlogRecordWriter) FlushChunk() error                  { return nil }
 func (w *fakeBinlogRecordWriter) GetBufferUncompressed() uint64      { return 0 }
 func (w *fakeBinlogRecordWriter) Schema() *schemapb.CollectionSchema { return w.schema }
+
+type fakeBumpSchemaVersionBatchWriter struct {
+	closeCalls int
+	abortCalls int
+	output     packed.WriterOutput
+	closeErr   error
+}
+
+func (w *fakeBumpSchemaVersionBatchWriter) Abort() { w.abortCalls++ }
+
+func (w *fakeBumpSchemaVersionBatchWriter) Write(storage.Record) error { return nil }
+func (w *fakeBumpSchemaVersionBatchWriter) GetWrittenUncompressed() uint64 {
+	return 0
+}
+func (w *fakeBumpSchemaVersionBatchWriter) AsNewColumnGroups() {}
+func (w *fakeBumpSchemaVersionBatchWriter) Close() (packed.WriterOutput, error) {
+	w.closeCalls++
+	return w.output, w.closeErr
+}
 
 type BumpSchemaVersionCompactionTaskSuite struct {
 	suite.Suite
@@ -449,6 +470,9 @@ func (s *BumpSchemaVersionCompactionTaskSuite) initSegBufferForSchemaBumpWithFie
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionSuccess() {
 	s.prepareBumpSchemaVersionCompaction()
+	baseStatsSize, err := packed.StatsBinlogSizeFromManifest(
+		s.task.plan.GetSegmentBinlogs()[0].GetManifest(), s.task.compactionParams.StorageConfig)
+	s.Require().NoError(err)
 
 	result, err := s.task.Compact()
 	s.NoError(err)
@@ -466,6 +490,11 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionSu
 	// BM25 stats are embedded in the V3 manifest atomically with column groups.
 	s.Empty(segment.GetBm25Logs())
 	s.NotEmpty(segment.GetManifest())
+	expectedStatsSize, err := packed.StatsBinlogSizeFromManifest(segment.GetManifest(), s.task.compactionParams.StorageConfig)
+	s.Require().NoError(err)
+	s.Require().NotNil(segment.GetStats())
+	s.Equal(expectedStatsSize, segment.GetStats().GetStatsBinlogSize())
+	s.Greater(expectedStatsSize, baseStatsSize)
 
 	// The materialized output field (ID=102) must carry a non-zero LogID in its insert binlog.
 	const materializedOutputFieldID = int64(102)
@@ -476,6 +505,88 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionSu
 				"V3 schema bump insert binlog (fieldID=%d) must have non-zero LogID", materializedOutputFieldID)
 		}
 	}
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) configureMissingBM25InputSchema() int64 {
+	const inputFieldID = int64(104)
+	const outputFieldID = int64(105)
+	inputField := &schemapb.FieldSchema{
+		FieldID: inputFieldID, Name: "new_text", DataType: schemapb.DataType_VarChar, Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "128"}},
+	}
+	outputField := &schemapb.FieldSchema{
+		FieldID: outputFieldID, Name: "new_sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true,
+	}
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "new_bm25", Type: schemapb.FunctionType_BM25,
+		InputFieldNames: []string{inputField.GetName()}, InputFieldIds: []int64{inputFieldID},
+		OutputFieldNames: []string{outputField.GetName()}, OutputFieldIds: []int64{outputFieldID},
+	}
+	s.task.plan.Schema = &schemapb.CollectionSchema{
+		Name: "missing_function_input", Fields: append(schemaBumpBaseFields(), inputField, outputField),
+		Functions: []*schemapb.FunctionSchema{functionSchema},
+	}
+	s.task.plan.Functions = []*schemapb.FunctionSchema{functionSchema}
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+	return outputFieldID
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialMaterializationUsesMissingNullableFunctionInput() {
+	outputFieldID := s.configureMissingBM25InputSchema()
+	s.prepareBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	s.EqualValues(3, result.GetSegments()[0].GetNumOfRows())
+	var found bool
+	for _, fieldBinlog := range result.GetSegments()[0].GetInsertLogs() {
+		if compactionFieldBinlogReadable(fieldBinlog, map[int64]struct{}{outputFieldID: {}}) {
+			found = true
+			break
+		}
+	}
+	s.True(found, "partial backfill must write the function output computed from the missing nullable input")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteUsesMissingNullableFunctionInput() {
+	outputFieldID := s.configureMissingBM25InputSchema()
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	s.EqualValues(3, result.GetSegments()[0].GetNumOfRows())
+	var found bool
+	for _, fieldBinlog := range result.GetSegments()[0].GetInsertLogs() {
+		if compactionFieldBinlogReadable(fieldBinlog, map[int64]struct{}{outputFieldID: {}}) {
+			found = true
+			break
+		}
+	}
+	s.True(found, "full rewrite must write the function output computed from the missing nullable input")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialMaterializationFailsBeforeCommitWhenBaseStatsCannotBeRead() {
+	s.prepareBumpSchemaVersionCompaction()
+	statsPatch := mockey.Mock(packed.StatsBinlogSizeFromManifest).Return(int64(0), assert.AnError).Build()
+	defer statsPatch.UnPatch()
+	commitCalled := false
+	commitPatch := mockey.Mock(packed.CommitManifestUpdates).To(func(
+		string, int64, *indexpb.StorageConfig, *packed.ManifestUpdates,
+	) (string, error) {
+		commitCalled = true
+		return "", nil
+	}).Build()
+	defer commitPatch.UnPatch()
+
+	result, err := s.task.Compact()
+	s.Nil(result)
+	s.ErrorIs(err, assert.AnError)
+	s.ErrorContains(err, "failed to read base schema bump stats size")
+	s.False(commitCalled, "manifest must not be committed after the base stats read fails")
 }
 
 // buildTextLOBTask builds a minimal schema-bump task whose schema optionally has a
@@ -869,6 +980,104 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteFillsMissingNullab
 	s.True(found, "missing nullable TEXT field must be backfilled into the rewritten segment")
 }
 
+// TestFullRewriteFillsMissingTTLFieldWithoutProbingRecord is the real-cgo regression
+// for the source-TTL presence check: the target schema designates a TTL field that
+// old segments do not carry, and a dropped field routes them through full rewrite.
+// Presence must be decided from existingFields; probing record.Column(ttlFieldID)
+// panics on V3 records ("no such field") before the materializer can fill the null
+// TTL column.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteFillsMissingTTLFieldWithoutProbingRecord() {
+	const newTTLFieldID = int64(105)
+	// Target schema gains a nullable Timestamptz field absent from the source
+	// segment and designates it as the collection TTL field.
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, &schemapb.FieldSchema{
+		FieldID:  newTTLFieldID,
+		Name:     "expire_at",
+		DataType: schemapb.DataType_Timestamptz,
+		Nullable: true,
+	})
+	s.task.plan.Schema.Properties = append(s.task.plan.Schema.Properties, &commonpb.KeyValuePair{
+		Key:   common.CollectionTTLFieldKey,
+		Value: "expire_at",
+	})
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+
+	// Source segment carries a dropped field (103) -> droppedFieldIDs>0 -> full rewrite.
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.Equal(datapb.CompactionTaskState_completed, result.GetState())
+	s.Require().Len(result.GetSegments(), 1)
+
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+
+	found := false
+	for _, fb := range segment.GetInsertLogs() {
+		if fb.GetFieldID() == newTTLFieldID {
+			found = true
+			break
+		}
+		for _, cf := range fb.GetChildFields() {
+			if cf == newTTLFieldID {
+				found = true
+				break
+			}
+		}
+		if found {
+			break
+		}
+	}
+	s.True(found, "missing TTL field must be backfilled into the rewritten segment")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) configureMissingTTLField(defaultValue *int64) {
+	const ttlFieldID = int64(105)
+	ttlField := &schemapb.FieldSchema{
+		FieldID: ttlFieldID, Name: "expire_at", DataType: schemapb.DataType_Timestamptz, Nullable: true,
+	}
+	if defaultValue != nil {
+		ttlField.DefaultValue = &schemapb.ValueField{
+			Data: &schemapb.ValueField_TimestamptzData{TimestamptzData: *defaultValue},
+		}
+	}
+	s.task.plan.Schema.Fields = append(s.task.plan.Schema.Fields, ttlField)
+	s.task.plan.Schema.Properties = append(s.task.plan.Schema.Properties, &commonpb.KeyValuePair{
+		Key: common.CollectionTTLFieldKey, Value: ttlField.GetName(),
+	})
+	params, err := compaction.GenerateJSONParams(s.task.plan.GetSchema())
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = params
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteFiltersMissingTTLFieldByExpiredDefault() {
+	s.task.currentTime = getMilvusBirthday().Add(time.Hour)
+	expired := s.task.currentTime.Add(-time.Minute).UnixMicro()
+	s.configureMissingTTLField(&expired)
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	s.Zero(result.GetSegments()[0].GetNumOfRows())
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteKeepsMissingTTLFieldByFutureDefault() {
+	s.task.currentTime = getMilvusBirthday().Add(time.Hour)
+	future := s.task.currentTime.Add(time.Hour).UnixMicro()
+	s.configureMissingTTLField(&future)
+	s.prepareBumpSchemaVersionCompactionWithDroppedField()
+
+	result, err := s.task.Compact()
+	s.Require().NoError(err)
+	s.Require().Len(result.GetSegments(), 1)
+	s.EqualValues(3, result.GetSegments()[0].GetNumOfRows())
+}
+
 // TestFullRewriteMergesLOBRefsBeforeBuildingTextIndex guards the ordering fixed for
 // liliu-z's review. createTextIndex reads the TEXT column through the output segment's
 // manifest, so applyLOBCompaction -- which merges the carried source LOB file references
@@ -930,12 +1139,11 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestSelectFullRewriteRecordDropsD
 	deleteTs := tsoutil.ComposeTSByTime(currentTime.Add(time.Second))
 	entityFilter := compaction.NewEntityFilter(map[any]typeutil.Timestamp{int64(2): deleteTs}, int64(time.Minute), currentTime, 0)
 
-	selection, ttlValues, err := selectFullRewriteRecord(record, pkField, entityFilter, 102, true, nil)
+	selection, err := selectFullRewriteRecord(record, pkField, entityFilter, 102, true, 0, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(selection)
 	s.Equal(2, selection.Len())
 	s.Equal([]rowRange{{start: 0, end: 1}, {start: 4, end: 5}}, selection.ranges)
-	s.Equal([]int64{keptTTLField, keptTTLField}, ttlValues)
 	s.Equal(1, entityFilter.GetDeletedCount())
 	s.Equal(2, entityFilter.GetExpiredCount())
 }
@@ -971,6 +1179,43 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestSchemaVersionBumpOnlyPreserve
 	s.Equal(expirQuantiles, segment.GetExpirQuantiles())
 }
 
+// CollectionSchema.FileResourceIds is a collection-wide union, not a
+// field-to-resource binding. A match field using the built-in analyzer must not
+// be rejected because an unrelated non-match analyzer field owns a resource.
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteDoesNotRejectUnrelatedRefModeResources() {
+	savedManager := fileresource.GlobalFileManager
+	fileresource.GlobalFileManager = fileresource.NewRefManger()
+	defer func() { fileresource.GlobalFileManager = savedManager }()
+
+	schema := s.task.plan.GetSchema()
+	textField := typeutil.GetField(schema, 101)
+	s.Require().NotNil(textField)
+	textField.TypeParams = append(textField.GetTypeParams(),
+		&commonpb.KeyValuePair{Key: common.EnableAnalyzerKey, Value: "true"},
+		&commonpb.KeyValuePair{Key: "enable_match", Value: "true"})
+	schema.Fields = append(schema.GetFields(), &schemapb.FieldSchema{
+		FieldID:  104,
+		Name:     "resource_text",
+		DataType: schemapb.DataType_VarChar,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "128"},
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":{"type":"jieba","dict":["resource://dict"]}}`},
+		},
+	})
+	schema.FileResourceIds = []int64{7}
+	jsonParams, err := compaction.GenerateJSONParams(schema)
+	s.Require().NoError(err)
+	s.task.plan.JsonParams = jsonParams
+	s.task.plan.FileResources = nil
+
+	composePatch := mockey.Mock(compaction.ComposeDeleteFromDeltalogs).Return(nil, assert.AnError).Build()
+	defer composePatch.UnPatch()
+
+	_, err = s.task.runFullSchemaRewrite(collectionSchemaFields(schema))
+	s.ErrorIs(err, assert.AnError)
+}
+
 func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRequiresPreallocatedSegmentID() {
 	s.task.plan.PreAllocatedSegmentIDs = nil
 	_, err := s.task.fullRewriteSegmentID()
@@ -987,6 +1232,51 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestAppendBM25StatsFromArrowArray
 
 	_, err := appendBM25StatsFromArrowArray(storage.NewBM25Stats(), arr)
 	s.ErrorContains(err, "arrow binary array")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialWriterLeaseCleanupAbortsOnceWithoutFlush() {
+	writer := &fakeBumpSchemaVersionBatchWriter{output: &packed.ColumnGroups{}}
+	lease := &bumpSchemaVersionWriterLease{writer: writer}
+	lease.Cleanup()
+	lease.Cleanup()
+
+	s.Equal(1, writer.abortCalls)
+	s.Zero(writer.closeCalls, "Cleanup must not finalize the writer: Close flushes pending column groups that will never be committed")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialWriterLeaseSuccessfulCloseSkipsAbort() {
+	output := &packed.ColumnGroups{}
+	writer := &fakeBumpSchemaVersionBatchWriter{output: output}
+	lease := &bumpSchemaVersionWriterLease{writer: writer}
+
+	gotOutput, err := lease.Close()
+	s.NoError(err)
+	s.Same(output, gotOutput)
+	lease.Cleanup()
+
+	s.Equal(1, writer.closeCalls)
+	s.Zero(writer.abortCalls)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialWriterLeaseCloseErrorDoesNotDoubleClose() {
+	output := &packed.ColumnGroups{}
+	destroyCalls := 0
+	destroyPatch := mockey.Mock((*packed.ColumnGroups).Destroy).To(func(*packed.ColumnGroups) {
+		destroyCalls++
+	}).Build()
+	defer destroyPatch.UnPatch()
+
+	writer := &fakeBumpSchemaVersionBatchWriter{output: output, closeErr: assert.AnError}
+	lease := &bumpSchemaVersionWriterLease{writer: writer}
+	gotOutput, err := lease.Close()
+	s.ErrorIs(err, assert.AnError)
+	s.Same(output, gotOutput)
+	gotOutput.Destroy()
+	lease.Cleanup()
+
+	s.Equal(1, writer.closeCalls)
+	s.Equal(1, destroyCalls)
+	s.Zero(writer.abortCalls, "explicit Close consumed the writer; Cleanup must not abort it again")
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestPreserveDeltaLogsV3CountMismatch() {
@@ -1056,7 +1346,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestValidateSupportedMissingFunct
 	s.NoError(err)
 }
 
-func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaIncludesAdditionalInputFields() {
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildFunctionBackfillReadSchemaIncludesImplicitInputFields() {
 	s.task.plan.Schema = &schemapb.CollectionSchema{
 		Name: "schema",
 		Fields: []*schemapb.FieldSchema{
@@ -1084,11 +1374,57 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionInputSchemaInc
 		OutputFieldIds:   []int64{102},
 	}}
 
-	inputSchema, inputFieldIDs, err := s.task.missingFunctionInputSchema(missingFunctions)
+	readSchema, readFieldIDs, err := s.task.buildFunctionBackfillReadSchema(missingFunctions, map[int64]struct{}{101: {}, 115: {}})
 	s.NoError(err)
-	s.ElementsMatch([]int64{101, 115}, inputFieldIDs)
-	s.Require().Len(inputSchema.GetFields(), 2)
-	s.ElementsMatch([]string{"text", "lang"}, []string{inputSchema.GetFields()[0].GetName(), inputSchema.GetFields()[1].GetName()})
+	s.ElementsMatch([]int64{101, 115}, readFieldIDs)
+	s.Require().Len(readSchema.GetFields(), 2)
+	s.ElementsMatch([]string{"text", "lang"}, []string{readSchema.GetFields()[0].GetName(), readSchema.GetFields()[1].GetName()})
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildFunctionBackfillReadSchemaMalformedMultiAnalyzerParamsIsDataIntegrityError() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "BM25", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{101}, OutputFieldIds: []int64{102},
+	}
+	s.task.plan.Schema = &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+				{Key: "multi_analyzer_params", Value: "{bad"},
+			}},
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+		},
+		Functions: []*schemapb.FunctionSchema{functionSchema},
+	}
+
+	_, _, err := s.task.buildFunctionBackfillReadSchema([]*schemapb.FunctionSchema{functionSchema}, map[int64]struct{}{101: {}})
+	s.Require().Error(err)
+	s.ErrorIs(err, merr.ErrDataIntegrity)
+	s.ErrorContains(err, "failed to parse multi_analyzer_params for function BM25")
+	s.ErrorContains(err, "invalid character")
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBuildFunctionBackfillReadSchemaAddsRowCountAnchor() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "BM25", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{101}, OutputFieldIds: []int64{102},
+	}
+	s.task.plan.Schema = &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "new_text", DataType: schemapb.DataType_VarChar, Nullable: true},
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+		},
+		Functions: []*schemapb.FunctionSchema{functionSchema},
+	}
+
+	readSchema, readFieldIDs, err := s.task.buildFunctionBackfillReadSchema(
+		[]*schemapb.FunctionSchema{functionSchema},
+		map[int64]struct{}{common.RowIDField: {}},
+	)
+	s.NoError(err)
+	s.Equal([]int64{101, common.RowIDField}, readFieldIDs)
+	s.Require().Len(readSchema.GetFields(), 2)
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionMissingOutputFieldInMultiOutputFunction() {
@@ -1393,7 +1729,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsSe
 	s.setupTest()
 	schema := schemaBumpMultiOutputBM25Schema()
 	s.task.plan.Schema = schema
-	existingFields := map[int64]struct{}{
+	sourceFields := map[int64]struct{}{
 		common.RowIDField:     {},
 		common.TimeStampField: {},
 		100:                   {},
@@ -1401,7 +1737,7 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsSe
 		102:                   {},
 	}
 
-	outputFields, outputFieldIDs, err := s.task.missingFunctionOutputFields(schema.GetFunctions(), existingFields)
+	outputFields, outputFieldIDs, err := s.task.missingFunctionOutputFields(schema.GetFunctions(), sourceFields)
 	s.NoError(err)
 
 	s.Equal([]int64{102, 103}, outputFieldIDs)
@@ -1410,20 +1746,138 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestMissingFunctionOutputFieldsSe
 	s.Equal(int64(103), outputFields[1].GetFieldID())
 }
 
-func (s *BumpSchemaVersionCompactionTaskSuite) TestPartialMaterializerExistingFieldsTreatsAllFunctionOutputsAsMissing() {
-	schema := schemaBumpMultiOutputBM25Schema()
-	existingFields := map[int64]struct{}{
+// schemaBumpBM25SchemaWithUnrelatedGeo is a legal single-output BM25 schema
+// (input 101 -> output 102) plus an earlier add_field column that is
+// physically absent from the segment and unrelated to the backfill.
+func schemaBumpBM25SchemaWithUnrelatedGeo() *schemapb.CollectionSchema {
+	fields := append(schemaBumpBaseFields(),
+		&schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     "sparse",
+			DataType: schemapb.DataType_SparseFloatVector,
+		},
+		&schemapb.FieldSchema{
+			FieldID:  110,
+			Name:     "geo_added",
+			DataType: schemapb.DataType_Geometry,
+			Nullable: true,
+			DefaultValue: &schemapb.ValueField{
+				Data: &schemapb.ValueField_StringData{StringData: "POINT (1 2)"},
+			},
+		},
+	)
+	return &schemapb.CollectionSchema{
+		Name:   "schema",
+		Fields: fields,
+		Functions: []*schemapb.FunctionSchema{{
+			Name:             "BM25",
+			Id:               100,
+			Type:             schemapb.FunctionType_BM25,
+			InputFieldNames:  []string{"text"},
+			InputFieldIds:    []int64{101},
+			OutputFieldNames: []string{"sparse"},
+			OutputFieldIds:   []int64{102},
+		}},
+	}
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFunctionBackfillMaterializerPrefillsOnlyAbsentFunctionInputs() {
+	schema := schemaBumpBM25SchemaWithUnrelatedGeo()
+	sourceFields := map[int64]struct{}{
+		common.RowIDField:     {},
+		common.TimeStampField: {},
+		100:                   {},
+	}
+
+	backfill, err := NewFunctionBackfillMaterializer(schema, schema.GetFunctions(), sourceFields)
+	s.Require().NoError(err)
+	defer backfill.Close()
+
+	// prefill scope = the absent function input only; the unrelated absent
+	// field is ignored even though it is missing from storage too
+	s.Require().Len(backfill.missingFields, 1)
+	s.Equal(int64(101), backfill.missingFields[0].GetFieldID())
+	s.Len(backfill.materializers, 1)
+
+	// differential proof: a full materializer over the same storage truth WOULD
+	// prefill the unrelated field — the backfill scoping is what excludes it
+	full, err := NewRecordMaterializer(schema, schema.GetFunctions(), sourceFields)
+	s.Require().NoError(err)
+	defer full.Close()
+	fullPrefillsGeo := false
+	for _, field := range full.missingFields {
+		if field.GetFieldID() == int64(110) {
+			fullPrefillsGeo = true
+		}
+	}
+	s.True(fullPrefillsGeo)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFunctionBackfillMaterializerNothingToPrefillWhenInputsPresent() {
+	schema := schemaBumpBM25SchemaWithUnrelatedGeo()
+	// input present, output and the unrelated geo absent
+	sourceFields := map[int64]struct{}{
 		common.RowIDField:     {},
 		common.TimeStampField: {},
 		100:                   {},
 		101:                   {},
-		102:                   {},
 	}
 
-	materializerFields := partialMaterializerExistingFields(schema, schema.GetFunctions(), existingFields)
+	backfill, err := NewFunctionBackfillMaterializer(schema, schema.GetFunctions(), sourceFields)
+	s.Require().NoError(err)
+	defer backfill.Close()
 
-	s.NotContains(materializerFields, int64(102))
-	s.NotContains(materializerFields, int64(103))
+	s.Empty(backfill.missingFields, "nothing to prefill when the function inputs are all present")
+	s.Len(backfill.materializers, 1)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestFunctionBackfillMaterializerPrefillsImplicitMultiAnalyzerInput() {
+	schema := &schemapb.CollectionSchema{
+		Name: "schema",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+			{FieldID: common.TimeStampField, Name: "Timestamp", DataType: schemapb.DataType_Int64},
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID:  101,
+				Name:     "text",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: "multi_analyzer_params", Value: `{"by_field":"lang","analyzers":{"default":{"type":"standard"}}}`},
+				},
+			},
+			{FieldID: 115, Name: "lang", DataType: schemapb.DataType_VarChar, Nullable: true, TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "32"}}},
+			{FieldID: 102, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name:             "BM25",
+			Id:               100,
+			Type:             schemapb.FunctionType_BM25,
+			InputFieldNames:  []string{"text"},
+			InputFieldIds:    []int64{101},
+			OutputFieldNames: []string{"sparse"},
+			OutputFieldIds:   []int64{102},
+		}},
+	}
+	// the implicit by_field column (115) was added by an earlier add_field and
+	// is absent from the segment; InputFieldIds only lists the text field
+	sourceFields := map[int64]struct{}{
+		common.RowIDField:     {},
+		common.TimeStampField: {},
+		100:                   {},
+		101:                   {},
+	}
+
+	backfill, err := NewFunctionBackfillMaterializer(schema, schema.GetFunctions(), sourceFields)
+	s.Require().NoError(err)
+	defer backfill.Close()
+
+	// prefill must follow the runner-declared inputs, which include the
+	// implicit multi-analyzer by_field the schema's InputFieldIds never lists
+	s.Require().Len(backfill.missingFields, 1)
+	s.Equal(int64(115), backfill.missingFields[0].GetFieldID())
 }
 
 func (s *BumpSchemaVersionCompactionTaskSuite) TestFinalizeMergedLogsReplacesExistingOutputFieldLogs() {

--- a/internal/datanode/compactor/compactor_common.go
+++ b/internal/datanode/compactor/compactor_common.go
@@ -54,6 +54,18 @@ import (
 
 const compactionBatchSize = 100
 
+// schemaNeedsTextIndex reports whether any field enables text match — the
+// condition under which compaction output builds text indexes (and, in ref
+// mode, needs plan-attached analyzer file resources).
+func schemaNeedsTextIndex(schema *schemapb.CollectionSchema) bool {
+	for _, field := range schema.GetFields() {
+		if typeutil.CreateFieldSchemaHelper(field).EnableMatch() {
+			return true
+		}
+	}
+	return false
+}
+
 func createTextIndex(ctx context.Context,
 	cm storage.ChunkManager,
 	plan *datapb.CompactionPlan,
@@ -70,6 +82,13 @@ func createTextIndex(ctx context.Context,
 		mlog.FieldPartitionID(partitionID),
 		mlog.FieldSegmentID(segmentID),
 	)
+
+	// Text indexes are built only for enable_match fields, and the analyzer file
+	// resources below are downloaded solely to build them. If no field enables
+	// match, skip the resource download and all setup entirely.
+	if !schemaNeedsTextIndex(plan.GetSchema()) {
+		return map[int64]*datapb.TextIndexStats{}, nil
+	}
 
 	fieldBinlogs := lo.GroupBy(segment.GetInsertLogs(), func(binlog *datapb.FieldBinlog) int64 {
 		return binlog.GetFieldID()

--- a/internal/datanode/compactor/record_materializer.go
+++ b/internal/datanode/compactor/record_materializer.go
@@ -54,15 +54,56 @@ func (s *recordSelection) Len() int {
 }
 
 type RecordMaterializer struct {
-	materializers  []FunctionMaterializer
-	missingFields  []*schemapb.FieldSchema
-	schema         *schemapb.CollectionSchema
+	materializers []FunctionMaterializer
+	missingFields []*schemapb.FieldSchema
+	schema        *schemapb.CollectionSchema
+	// existingFields is the set of fields physically present in the source
+	// records. Selection slicing is gated on it: probing a record for a field
+	// it does not carry is not an option, since V2/V3 records panic on Column
+	// for an unknown field instead of returning nil.
 	existingFields map[int64]struct{}
 }
 
+// NewRecordMaterializer builds a full materializer: it computes the absent
+// function outputs and prefills every other schema field existingFields does
+// not carry, so the wrapped record covers the whole schema (full rewrites,
+// sort/mix/clustering, which persist every column).
 func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, error) {
+	materializer, materializedFields, _, err := newRecordMaterializerBase(schema, functions, existingFields)
+	if err != nil {
+		return nil, err
+	}
+	materializer.missingFields = missingNonMaterializedSchemaFields(schema, existingFields, materializedFields)
+	return materializer, nil
+}
+
+// NewFunctionBackfillMaterializer scopes materialization to backfilling the
+// given functions' outputs: it computes those outputs and prefills only their
+// inputs absent from existingFields. Every other absent schema field stays
+// untouched — an added field is nullable by DDL mandate and thus synthesizable
+// at read time, so a version bump never requires materializing it physically
+// (the bump-only path stamps metadata without touching data at all); rewriting
+// compactions materialize such fields only as a byproduct of writing the full
+// schema. existingFields must be the segment's physical storage truth.
+func NewFunctionBackfillMaterializer(schema *schemapb.CollectionSchema, missingFunctions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, error) {
+	materializer, _, activeInputFields, err := newRecordMaterializerBase(schema, missingFunctions, existingFields)
+	if err != nil {
+		return nil, err
+	}
+	materializer.missingFields = absentInputFields(activeInputFields, existingFields)
+	return materializer, nil
+}
+
+// newRecordMaterializerBase sets up the function runners for every function
+// with at least one output to materialize, leaving missingFields (the prefill
+// set) to the exported constructors. The returned input fields are the
+// runner-declared reads of those functions — the runner, not the function
+// schema, is the authority on what gets read: it resolves implicit inputs
+// (e.g. the multi-analyzer by_field column) that InputFieldIds never lists.
+func newRecordMaterializerBase(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, map[int64]struct{}, []*schemapb.FieldSchema, error) {
 	materializer := &RecordMaterializer{schema: schema, existingFields: existingFields}
 	materializedFields := make(map[int64]struct{})
+	var activeInputFields []*schemapb.FieldSchema
 	for _, functionSchema := range functions {
 		outputIndexes := functionOutputIndexesToMaterialize(functionSchema, existingFields)
 		if len(outputIndexes) == 0 {
@@ -75,22 +116,42 @@ func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schem
 		runner, err := function.NewFunctionRunner(schema, functionSchema)
 		if err != nil {
 			materializer.Close()
-			return nil, err
+			return nil, nil, nil, err
 		}
 		if runner == nil {
 			materializer.Close()
-			return nil, merr.WrapErrFunctionFailedMsg("failed to set up function runner for %s", functionSchema.GetName())
+			return nil, nil, nil, merr.WrapErrFunctionFailedMsg("failed to set up function runner for %s", functionSchema.GetName())
 		}
 		functionMaterializer, err := newFunctionMaterializer(schema, runner, outputIndexes, true)
 		if err != nil {
 			runner.Close()
 			materializer.Close()
-			return nil, err
+			return nil, nil, nil, err
 		}
 		materializer.materializers = append(materializer.materializers, functionMaterializer)
+		activeInputFields = append(activeInputFields, runner.GetInputFields()...)
 	}
-	materializer.missingFields = missingNonMaterializedSchemaFields(schema, existingFields, materializedFields)
-	return materializer, nil
+	return materializer, materializedFields, activeInputFields, nil
+}
+
+// absentInputFields returns the input fields existingFields does not carry —
+// the exact set a backfill materializer must prefill before running the
+// functions.
+func absentInputFields(inputFields []*schemapb.FieldSchema, existingFields map[int64]struct{}) []*schemapb.FieldSchema {
+	seen := make(map[int64]struct{})
+	missing := make([]*schemapb.FieldSchema, 0)
+	for _, field := range inputFields {
+		fieldID := field.GetFieldID()
+		if _, ok := existingFields[fieldID]; ok {
+			continue
+		}
+		if _, dup := seen[fieldID]; dup {
+			continue
+		}
+		seen[fieldID] = struct{}{}
+		missing = append(missing, field)
+	}
+	return missing
 }
 
 func (m *RecordMaterializer) Wrap(rec storage.Record) (storage.Record, error) {
@@ -117,8 +178,23 @@ func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *re
 	}
 
 	computed := make(map[int64]arrow.Array)
+	view := &materializedRecord{base: base, computed: computed}
+
+	// Fill ordinary missing fields before running functions. Function inputs may
+	// themselves be fields added by an earlier schema evolution, so runners must
+	// read through this overlay instead of probing the physical source record.
+	for _, field := range m.missingFields {
+		fieldID := field.GetFieldID()
+		arr, err := storage.GenerateEmptyArrayFromSchema(field, base.Len())
+		if err != nil {
+			releaseArrowArrays(computed)
+			cleanupMaterializedRecord(base)
+			return nil, err
+		}
+		computed[fieldID] = arr
+	}
 	for _, materializer := range m.materializers {
-		arrays, err := materializer.Materialize(base)
+		arrays, err := materializer.Materialize(view)
 		if err != nil {
 			releaseArrowArrays(computed)
 			cleanupMaterializedRecord(base)
@@ -128,23 +204,10 @@ func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *re
 			computed[fieldID] = arr
 		}
 	}
-	for _, field := range m.missingFields {
-		fieldID := field.GetFieldID()
-		if _, ok := computed[fieldID]; ok {
-			continue
-		}
-		arr, err := storage.GenerateEmptyArrayFromSchema(field, base.Len())
-		if err != nil {
-			releaseArrowArrays(computed)
-			cleanupMaterializedRecord(base)
-			return nil, err
-		}
-		computed[fieldID] = arr
-	}
 	if len(computed) == 0 {
 		return base, nil
 	}
-	return &materializedRecord{base: base, computed: computed}, nil
+	return view, nil
 }
 
 func (m *RecordMaterializer) Close() {
@@ -340,6 +403,7 @@ type minHashFunctionMaterializer struct {
 	outputFieldIDs       []int64
 	missingOutputIndexes []int
 	outputFields         map[int64]*schemapb.FieldSchema
+	outputDims           map[int64]int64
 	ownRunner            bool
 }
 
@@ -383,6 +447,7 @@ func newMinHashFunctionMaterializer(schema *schemapb.CollectionSchema, runner fu
 	}
 
 	outputFields := make(map[int64]*schemapb.FieldSchema, len(outputFieldIDs))
+	outputDims := make(map[int64]int64, len(outputFieldIDs))
 	for _, outputFieldID := range outputFieldIDs {
 		outputField := typeutil.GetField(schema, outputFieldID)
 		if outputField == nil {
@@ -394,7 +459,15 @@ func newMinHashFunctionMaterializer(schema *schemapb.CollectionSchema, runner fu
 		if outputField.GetNullable() {
 			return nil, merr.WrapErrFunctionFailedMsg("function output field cannot be nullable: function %s, field %s", functionSchema.GetName(), outputField.GetName())
 		}
+		outputDim, err := typeutil.GetDim(outputField)
+		if err != nil {
+			return nil, merr.WrapErrFunctionFailed(err, "failed to read MinHash output field %s dimension", outputField.GetName())
+		}
+		if outputDim <= 0 || outputDim%32 != 0 {
+			return nil, merr.WrapErrFunctionFailedMsg("invalid MinHash output field %s dimension %d", outputField.GetName(), outputDim)
+		}
 		outputFields[outputFieldID] = outputField
+		outputDims[outputFieldID] = outputDim
 	}
 
 	return &minHashFunctionMaterializer{
@@ -403,6 +476,7 @@ func newMinHashFunctionMaterializer(schema *schemapb.CollectionSchema, runner fu
 		outputFieldIDs:       outputFieldIDs,
 		missingOutputIndexes: missingOutputIndexes,
 		outputFields:         outputFields,
+		outputDims:           outputDims,
 		ownRunner:            ownRunner,
 	}, nil
 }
@@ -521,13 +595,35 @@ func (m *minHashFunctionMaterializer) Materialize(rec storage.Record) (map[int64
 			return nil, merr.WrapErrFunctionFailedMsg("unexpected output type from MinHash function runner, expected FieldData, got %T", outputs[outputIndex])
 		}
 		vectorField := outputFieldData.GetVectors()
-		if vectorField == nil || vectorField.GetBinaryVector() == nil {
+		if vectorField == nil {
 			releaseArrowArrays(result)
 			return nil, merr.WrapErrFunctionFailedMsg("unexpected output from MinHash function runner, expected binary vector field data")
 		}
+		binaryVector, ok := vectorField.GetData().(*schemapb.VectorField_BinaryVector)
+		if !ok || binaryVector == nil {
+			releaseArrowArrays(result)
+			return nil, merr.WrapErrFunctionFailedMsg("unexpected output from MinHash function runner, expected binary vector field data")
+		}
+		outputDim := vectorField.GetDim()
+		if outputDim <= 0 || outputDim%32 != 0 {
+			releaseArrowArrays(result)
+			return nil, merr.WrapErrFunctionFailedMsg("invalid MinHash output dim %d for field %d", outputDim, outputFieldID)
+		}
+		expectedDim := m.outputDims[outputFieldID]
+		if outputDim != expectedDim {
+			releaseArrowArrays(result)
+			return nil, merr.WrapErrFunctionFailedMsg("minhash function output dim mismatch for field %d, expected %d, got %d", outputFieldID, expectedDim, outputDim)
+		}
+		expectedBytes := int64(rec.Len()) * outputDim / 8
+		if int64(len(binaryVector.BinaryVector)) != expectedBytes {
+			releaseArrowArrays(result)
+			return nil, merr.WrapErrFunctionFailedMsg(
+				"minhash function output payload length mismatch for field %d, expected %d bytes, got %d",
+				outputFieldID, expectedBytes, len(binaryVector.BinaryVector))
+		}
 		fieldData := &storage.BinaryVectorFieldData{
-			Data: vectorField.GetBinaryVector(),
-			Dim:  int(vectorField.GetDim()),
+			Data: binaryVector.BinaryVector,
+			Dim:  int(outputDim),
 		}
 		if fieldData.RowNum() != rec.Len() {
 			releaseArrowArrays(result)
@@ -620,6 +716,20 @@ func buildSparseFloatVectorArrowArray(field *schemapb.FieldSchema, outputSparseA
 }
 
 func buildArrowArrayFromFieldData(field *schemapb.FieldSchema, fieldData storage.FieldData, rowCount int) (arrow.Array, error) {
+	if rowCount == 0 {
+		outputSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{field}}
+		arrowSchema, err := storage.ConvertToArrowSchema(outputSchema, true)
+		if err != nil {
+			return nil, err
+		}
+		builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+		defer builder.Release()
+		record := builder.NewRecord()
+		defer record.Release()
+		col := record.Column(0)
+		col.Retain()
+		return col, nil
+	}
 	if fieldData.RowNum() != rowCount {
 		return nil, merr.WrapErrFunctionFailedMsg("function output row count mismatch for field %d, expected %d, got %d", field.GetFieldID(), rowCount, fieldData.RowNum())
 	}

--- a/internal/datanode/compactor/record_materializer_test.go
+++ b/internal/datanode/compactor/record_materializer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -174,6 +175,66 @@ func TestRecordMaterializerWrapFillsNullableMissingTextFieldAsBinary(t *testing.
 	require.Equal(t, 3, column.NullN())
 	cleanupMaterializedRecord(wrapped)
 	require.Equal(t, 0, record.releaseCount)
+}
+
+func TestRecordMaterializerMaterializesFunctionFromMissingNullableInput(t *testing.T) {
+	inputField := &schemapb.FieldSchema{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar, Nullable: true}
+	outputField := &schemapb.FieldSchema{FieldID: 101, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector}
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "bm25", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+	}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{inputField, outputField}, Functions: []*schemapb.FunctionSchema{functionSchema}}
+	emptyRow := typeutil.CreateSparseFloatRow(nil, nil)
+	runner := &materializerTestFunctionRunner{
+		schema: functionSchema, inputFields: []*schemapb.FieldSchema{inputField}, outputFields: []*schemapb.FieldSchema{outputField},
+		outputs: []any{&schemapb.SparseFloatArray{Contents: [][]byte{emptyRow, emptyRow}}},
+	}
+	functionMaterializer, err := newBM25FunctionMaterializer(schema, runner, []int{0}, false)
+	require.NoError(t, err)
+	materializer := &RecordMaterializer{
+		schema: schema, materializers: []FunctionMaterializer{functionMaterializer}, missingFields: []*schemapb.FieldSchema{inputField},
+	}
+	defer materializer.Close()
+
+	record := &materializerTestRecord{len: 2}
+	wrapped, err := materializer.Wrap(record)
+	require.NoError(t, err)
+	defer cleanupMaterializedRecord(wrapped)
+	require.Equal(t, []any{[]string{"", ""}}, runner.inputs)
+	require.Equal(t, 2, wrapped.Column(outputField.GetFieldID()).Len())
+	require.Equal(t, 0, record.releaseCount)
+}
+
+func TestRecordMaterializerMaterializesFunctionFromMissingDefaultInput(t *testing.T) {
+	inputField := &schemapb.FieldSchema{
+		FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar, Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_StringData{StringData: "fallback"}},
+	}
+	outputField := &schemapb.FieldSchema{FieldID: 101, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector}
+	functionSchema := &schemapb.FunctionSchema{
+		Name: "bm25", Type: schemapb.FunctionType_BM25,
+		InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+	}
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{inputField, outputField}, Functions: []*schemapb.FunctionSchema{functionSchema}}
+	emptyRow := typeutil.CreateSparseFloatRow(nil, nil)
+	runner := &materializerTestFunctionRunner{
+		schema: functionSchema, inputFields: []*schemapb.FieldSchema{inputField}, outputFields: []*schemapb.FieldSchema{outputField},
+		outputs: []any{&schemapb.SparseFloatArray{Contents: [][]byte{emptyRow, emptyRow}}},
+	}
+	functionMaterializer, err := newBM25FunctionMaterializer(schema, runner, []int{0}, false)
+	require.NoError(t, err)
+	materializer := &RecordMaterializer{
+		schema: schema, materializers: []FunctionMaterializer{functionMaterializer}, missingFields: []*schemapb.FieldSchema{inputField},
+	}
+	defer materializer.Close()
+
+	record := &materializerTestRecord{len: 2}
+	wrapped, err := materializer.Wrap(record)
+	require.NoError(t, err)
+	defer cleanupMaterializedRecord(wrapped)
+	require.Equal(t, []any{[]string{"fallback", "fallback"}}, runner.inputs)
+	require.Equal(t, 2, wrapped.Column(outputField.GetFieldID()).Len())
 }
 
 func TestRecordMaterializerWrapWithSelectionMaterializesKeptRowsOnly(t *testing.T) {
@@ -706,37 +767,122 @@ func TestMinHashFunctionMaterializerRejectsNonBinaryOutputField(t *testing.T) {
 	require.ErrorContains(t, err, "output field data type must be binary vector for minhash function materialization")
 }
 
-func TestMinHashFunctionMaterializerRejectsRowCountMismatch(t *testing.T) {
+func TestMinHashFunctionMaterializerRejectsPayloadLengthMismatch(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload []byte
+	}{
+		{name: "short payload", payload: []byte{0x01, 0x02, 0x03}},
+		{name: "trailing byte", payload: []byte{0x01, 0x02, 0x03, 0x04, 0x05}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, functionSchema, inputField, outputField := materializerMinHashSchema()
+			runner := &materializerTestFunctionRunner{
+				schema:       functionSchema,
+				inputFields:  []*schemapb.FieldSchema{inputField},
+				outputFields: []*schemapb.FieldSchema{outputField},
+				outputs: []any{&schemapb.FieldData{
+					Type:    schemapb.DataType_BinaryVector,
+					FieldId: outputField.GetFieldID(),
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim:  32,
+						Data: &schemapb.VectorField_BinaryVector{BinaryVector: tc.payload},
+					}},
+				}},
+			}
+			materializer, err := newFunctionMaterializer(schema, runner, []int{0}, false)
+			require.NoError(t, err)
+			defer materializer.Close()
+
+			input := newStringArray(t, []string{"hello"})
+			defer input.Release()
+			arrays, err := materializer.Materialize(&materializerTestRecord{
+				len: 1, columns: map[storage.FieldID]arrow.Array{100: input},
+			})
+			require.Nil(t, arrays)
+			require.ErrorIs(t, err, merr.ErrFunctionFailed)
+			require.ErrorContains(t, err, "payload length mismatch")
+		})
+	}
+}
+
+func TestMinHashFunctionMaterializerHandlesZeroRows(t *testing.T) {
 	schema, functionSchema, inputField, outputField := materializerMinHashSchema()
 	runner := &materializerTestFunctionRunner{
-		schema:       functionSchema,
-		inputFields:  []*schemapb.FieldSchema{inputField},
-		outputFields: []*schemapb.FieldSchema{outputField},
+		schema: functionSchema, inputFields: []*schemapb.FieldSchema{inputField}, outputFields: []*schemapb.FieldSchema{outputField},
 		outputs: []any{&schemapb.FieldData{
-			Type:    schemapb.DataType_BinaryVector,
-			FieldId: outputField.GetFieldID(),
-			Field: &schemapb.FieldData_Vectors{
-				Vectors: &schemapb.VectorField{
-					Dim: 32,
-					Data: &schemapb.VectorField_BinaryVector{
-						BinaryVector: []byte{0x01, 0x02, 0x03, 0x04},
-					},
-				},
-			},
+			Type: schemapb.DataType_BinaryVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: 32, Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{}},
+			}},
 		}},
 	}
 	materializer, err := newFunctionMaterializer(schema, runner, []int{0}, false)
 	require.NoError(t, err)
 	defer materializer.Close()
 
-	input := newStringArray(t, []string{"hello", "world"})
+	input := newStringArray(t, nil)
 	defer input.Release()
-	record := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{100: input}}
+	arrays, err := materializer.Materialize(&materializerTestRecord{len: 0, columns: map[storage.FieldID]arrow.Array{100: input}})
+	require.NoError(t, err)
+	defer releaseArrowArrays(arrays)
+	require.Zero(t, arrays[outputField.GetFieldID()].Len())
+}
 
-	arrays, err := materializer.Materialize(record)
+func TestMinHashFunctionMaterializerRejectsInvalidOutputDim(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		dim  int64
+		want string
+	}{
+		{name: "zero", dim: 0, want: "invalid MinHash output dim"},
+		{name: "schema mismatch", dim: 64, want: "output dim mismatch"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, functionSchema, inputField, outputField := materializerMinHashSchema()
+			runner := &materializerTestFunctionRunner{
+				schema: functionSchema, inputFields: []*schemapb.FieldSchema{inputField}, outputFields: []*schemapb.FieldSchema{outputField},
+				outputs: []any{&schemapb.FieldData{
+					Type: schemapb.DataType_BinaryVector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim: tc.dim, Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+					}},
+				}},
+			}
+			materializer, err := newFunctionMaterializer(schema, runner, []int{0}, false)
+			require.NoError(t, err)
+			defer materializer.Close()
+
+			input := newStringArray(t, []string{"hello"})
+			defer input.Release()
+			arrays, err := materializer.Materialize(&materializerTestRecord{len: 1, columns: map[storage.FieldID]arrow.Array{100: input}})
+			require.Nil(t, arrays)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestMinHashFunctionMaterializerRejectsTypedNilBinaryVector(t *testing.T) {
+	schema, functionSchema, inputField, _ := materializerMinHashSchema()
+	runner := &materializerTestFunctionRunner{
+		schema: functionSchema, inputFields: []*schemapb.FieldSchema{inputField},
+		outputs: []any{&schemapb.FieldData{
+			Type: schemapb.DataType_BinaryVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: 32, Data: (*schemapb.VectorField_BinaryVector)(nil),
+			}},
+		}},
+	}
+	materializer, err := newFunctionMaterializer(schema, runner, []int{0}, false)
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	input := newStringArray(t, []string{"hello"})
+	defer input.Release()
+	arrays, err := materializer.Materialize(&materializerTestRecord{len: 1, columns: map[storage.FieldID]arrow.Array{100: input}})
 	require.Nil(t, arrays)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "minhash function output row count mismatch")
+	require.ErrorIs(t, err, merr.ErrFunctionFailed)
+	require.ErrorContains(t, err, "expected binary vector field data")
 }
 
 func TestRecordMaterializerMaterializesBM25AndMinHashOutputs(t *testing.T) {
@@ -834,4 +980,41 @@ func newInt64Array(t *testing.T, values []int64) *array.Int64 {
 	t.Cleanup(builder.Release)
 	builder.AppendValues(values, nil)
 	return builder.NewInt64Array()
+}
+
+// Regression for the eager-selection existence probe: V2/V3 records are
+// simpleArrowRecord, whose Column PANICS for a field absent from the source
+// (e.g. the output field just added by add_function_field). Selection building
+// must consult existingFields and never probe the record. With the old
+// Column()==nil probe this test panics with "no such field: 101".
+func TestRecordMaterializerSelectionSkipsAbsentFieldOnPanickyRecord(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+		{FieldID: 101, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
+	}}
+	materializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	pk := newInt64Array(t, []int64{1, 2, 3})
+	defer pk.Release()
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "pk", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	arrowRecord := array.NewRecord(arrowSchema, []arrow.Array{pk}, 3)
+	defer arrowRecord.Release()
+	record := storage.NewSimpleArrowRecord(arrowRecord, map[storage.FieldID]int{100: 0})
+	selection := &recordSelection{ranges: []rowRange{{start: 1, end: 3}}, length: 2}
+
+	wrapped, err := materializer.WrapWithSelection(record, selection)
+	require.NoError(t, err)
+	require.Equal(t, 2, wrapped.Len())
+
+	pkColumn, ok := wrapped.Column(100).(*array.Int64)
+	require.True(t, ok)
+	require.Equal(t, []int64{2, 3}, []int64{pkColumn.Value(0), pkColumn.Value(1)})
+	addedColumn := wrapped.Column(101)
+	require.NotNil(t, addedColumn)
+	require.Equal(t, 2, addedColumn.Len())
+	require.Equal(t, 2, addedColumn.NullN())
+
+	cleanupMaterializedRecord(wrapped)
 }

--- a/internal/proxy/function_task_test.go
+++ b/internal/proxy/function_task_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/util/function/validator"
+	"github.com/milvus-io/milvus/internal/util/schemautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -86,13 +87,13 @@ func (f *FunctionTaskSuite) TestValidateAddFunctionInputNotText() {
 	}
 
 	// TEXT input rejected for BM25 and MinHash
-	f.ErrorContains(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "text_in")), "TEXT input field")
-	f.ErrorContains(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "text_in")), "TEXT input field")
+	f.ErrorContains(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "text_in")), "TEXT input field")
+	f.ErrorContains(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "text_in")), "TEXT input field")
 	// VarChar input allowed
-	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "varchar_in")))
-	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "varchar_in")))
+	f.NoError(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_BM25, "varchar_in")))
+	f.NoError(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_MinHash, "varchar_in")))
 	// non-materialized function type (e.g. TextEmbedding) is out of scope -> allowed even with TEXT input
-	f.NoError(validateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_TextEmbedding, "text_in")))
+	f.NoError(schemautil.ValidateAddFunctionInputNotText(schema, fn(schemapb.FunctionType_TextEmbedding, "text_in")))
 }
 
 func (f *FunctionTaskSuite) TestFunctionOnType() {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -239,37 +239,6 @@ func validateAddFunctionRequiresStorageV3() error {
 	return nil
 }
 
-// validateAddFunctionInputNotText rejects adding a BM25/MinHash function whose input is a
-// TEXT field. TEXT columns are stored as binary LOB references, so when the async backfill
-// compaction materializes the function output for pre-existing segments it reads the input
-// back as *array.Binary and hard-fails in stringInputsFromRecord ("cannot materialize bm25
-// from text binary values without lob decoding"); the add-function DDL would return success
-// while the backfill silently fails and old rows never get the output. Reject it up front
-// (fail-fast). VarChar inputs stay allowed, and create_collection with such a function is
-// unaffected -- its output is computed at flush from the raw text. Distinct from the
-// storage-version gate (validateAddFunctionRequiresStorageV3): this is a request-content
-// input-type constraint, not an environment/config check. See issue #51167.
-func validateAddFunctionInputNotText(schema *schemapb.CollectionSchema, function *schemapb.FunctionSchema) error {
-	switch function.GetType() {
-	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
-	default:
-		// Only BM25/MinHash are materialized from string input during backfill.
-		return nil
-	}
-	fieldByName := make(map[string]*schemapb.FieldSchema, len(schema.GetFields()))
-	for _, f := range schema.GetFields() {
-		fieldByName[f.GetName()] = f
-	}
-	for _, name := range function.GetInputFieldNames() {
-		if f, ok := fieldByName[name]; ok && f.GetDataType() == schemapb.DataType_Text {
-			return merr.WrapErrParameterInvalidMsg(
-				"adding a %s function with a TEXT input field (%s) is not supported: its output cannot be backfilled into existing segments; use a VARCHAR input field",
-				function.GetType().String(), name)
-		}
-	}
-	return nil
-}
-
 type createCollectionTask struct {
 	baseTask
 	Condition
@@ -1217,7 +1186,7 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 		mergedSchema.Fields = append(mergedSchema.Fields, proto.Clone(plan.Field).(*schemapb.FieldSchema))
 	}
 	mergedSchema.Functions = append(mergedSchema.Functions, plan.Function)
-	if err := validateAddFunctionInputNotText(mergedSchema, plan.Function); err != nil {
+	if err := schemautil.ValidateAddFunctionInputNotText(mergedSchema, plan.Function); err != nil {
 		return err
 	}
 	if err := validator.ValidateFunction(mergedSchema, plan.Function.GetName(), false); err != nil {

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -3330,6 +3330,30 @@ func TestValidateFunctionInputField(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("Valid MinHash function input - varchar", func(t *testing.T) {
+		function := &schemapb.FunctionSchema{
+			Type: schemapb.FunctionType_MinHash,
+		}
+		fields := []*schemapb.FieldSchema{
+			{DataType: schemapb.DataType_VarChar},
+		}
+		err := validator.CheckFunctionInputField(function, fields)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Invalid MinHash function input - TEXT rejected", func(t *testing.T) {
+		// the MinHash runner has never accepted TEXT; admitting it at create
+		// time produced collections whose every insert failed
+		function := &schemapb.FunctionSchema{
+			Type: schemapb.FunctionType_MinHash,
+		}
+		fields := []*schemapb.FieldSchema{
+			{DataType: schemapb.DataType_Text},
+		}
+		err := validator.CheckFunctionInputField(function, fields)
+		assert.Error(t, err)
+	})
+
 	t.Run("Invalid BM25 function input - multiple fields", func(t *testing.T) {
 		function := &schemapb.FunctionSchema{
 			Type: schemapb.FunctionType_BM25,

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -935,6 +935,23 @@ func validateMultiAnalyzerParams(params string, coll *schemapb.CollectionSchema,
 	return nil
 }
 
+// isMinHashInputFieldByName reports whether fieldSchema is a MinHash function
+// input, keyed on the field name. Used in the pre-normalization schema
+// validation path where field IDs are not yet canonical.
+func isMinHashInputFieldByName(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema) bool {
+	for _, fn := range collSchema.GetFunctions() {
+		if fn.GetType() != schemapb.FunctionType_MinHash {
+			continue
+		}
+		for _, name := range fn.GetInputFieldNames() {
+			if name == fieldSchema.GetName() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func collectAnalyzerInfos(collSchema *schemapb.CollectionSchema) ([]*querypb.AnalyzerInfo, error) {
 	analyzerInfos := make([]*querypb.AnalyzerInfo, 0)
 	for _, field := range collSchema.GetFields() {
@@ -945,8 +962,31 @@ func collectAnalyzerInfos(collSchema *schemapb.CollectionSchema) ([]*querypb.Ana
 	return analyzerInfos, nil
 }
 
+// collectFunctionInputAnalyzerInfos gathers analyzer infos for the given function's
+// input fields only — a subset of collectAnalyzerInfos used to decide whether an
+// added function's input analyzer references a file resource.
+func collectFunctionInputAnalyzerInfos(collSchema *schemapb.CollectionSchema, function *schemapb.FunctionSchema) ([]*querypb.AnalyzerInfo, error) {
+	inputIDs := typeutil.NewSet(function.GetInputFieldIds()...)
+	analyzerInfos := make([]*querypb.AnalyzerInfo, 0)
+	for _, field := range collSchema.GetFields() {
+		if !inputIDs.Contain(field.GetFieldID()) {
+			continue
+		}
+		// MinHash consumes only analyzer_params, not multi_analyzer_params.
+		if function.GetType() == schemapb.FunctionType_MinHash {
+			appendAnalyzerParams(field, &analyzerInfos)
+			continue
+		}
+		if err := validateAnalyzer(collSchema, field, &analyzerInfos); err != nil {
+			return nil, err
+		}
+	}
+	return analyzerInfos, nil
+}
+
 // validateAnalyzer validates active match/BM25 fields and fields with
-// enable_analyzer=true. Analyzer params are ignored while analyzer is disabled.
+// enable_analyzer=true. Analyzer params are ignored while analyzer is disabled,
+// except for MinHash inputs, which consume them regardless.
 func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo) error {
 	h := typeutil.CreateFieldSchemaHelper(fieldSchema)
 	active := h.EnableMatch() || typeutil.IsBm25FunctionInputField(collSchema, fieldSchema)
@@ -954,6 +994,16 @@ func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schema
 		return merr.WrapErrParameterInvalidMsg("field %s which has enable_match or is input of BM25 function must also enable_analyzer", fieldSchema.Name)
 	}
 	if !h.EnableAnalyzer() {
+		// A MinHash input legally keeps enable_analyzer=false yet its runner
+		// consumes analyzer_params. Collect them so any referenced file
+		// resources reach schema.FileResourceIds and ref-counting — otherwise
+		// the DDL gate admits a dependency the ledger never records and
+		// RemoveFileResource can delete a still-required resource. Match by name:
+		// this runs before assignFieldAndFunctionID, so field/function IDs are not
+		// yet canonical and an ID-based check would miss a stale-ID input.
+		if isMinHashInputFieldByName(collSchema, fieldSchema) {
+			appendAnalyzerParams(fieldSchema, analyzerInfos)
+		}
 		return nil
 	}
 
@@ -968,14 +1018,18 @@ func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schema
 		return validateMultiAnalyzerParams(params, collSchema, fieldSchema, analyzerInfos)
 	}
 
+	appendAnalyzerParams(fieldSchema, analyzerInfos)
+	// return nil when use default analyzer
+	return nil
+}
+
+func appendAnalyzerParams(fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo) {
 	for _, kv := range fieldSchema.GetTypeParams() {
-		if kv.GetKey() == "analyzer_params" {
+		if kv.GetKey() == common.AnalyzerParamKey {
 			*analyzerInfos = append(*analyzerInfos, &querypb.AnalyzerInfo{
 				Field:  fieldSchema.GetName(),
 				Params: kv.GetValue(),
 			})
 		}
 	}
-	// return nil when use default analyzer
-	return nil
 }

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -2739,6 +2739,35 @@ func Test_validateMultiAnalyzerParams(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	// Dangling alias targets are deliberately ACCEPTED at DDL for compatibility:
+	// at runtime an ordinary dangling alias falls back to the default analyzer,
+	// and a dangling "default" alias fails the request via the terminal guard
+	// (covered by the function package tests). Tightening this is a product
+	// semantics change that must consciously revisit these assertions.
+	t.Run("dangling alias target passes DDL", func(t *testing.T) {
+		coll := createTestCollectionSchema([]*schemapb.FieldSchema{
+			createTestFieldSchema("string_field", schemapb.DataType_VarChar),
+		})
+		fieldSchema := createTestFieldSchema("test_field", schemapb.DataType_VarChar)
+		infos := make([]*querypb.AnalyzerInfo, 0)
+
+		params := `{"by_field": "string_field", "alias": {"fr": "fr"}, "analyzers": {"default": {}}}`
+		err := validateMultiAnalyzerParams(params, coll, fieldSchema, &infos)
+		assert.NoError(t, err)
+	})
+
+	t.Run("dangling default alias passes DDL", func(t *testing.T) {
+		coll := createTestCollectionSchema([]*schemapb.FieldSchema{
+			createTestFieldSchema("string_field", schemapb.DataType_VarChar),
+		})
+		fieldSchema := createTestFieldSchema("test_field", schemapb.DataType_VarChar)
+		infos := make([]*querypb.AnalyzerInfo, 0)
+
+		params := `{"by_field": "string_field", "alias": {"default": "missing"}, "analyzers": {"default": {}}}`
+		err := validateMultiAnalyzerParams(params, coll, fieldSchema, &infos)
+		assert.NoError(t, err)
+	})
+
 	t.Run("valid params", func(t *testing.T) {
 		coll := createTestCollectionSchema([]*schemapb.FieldSchema{
 			createTestFieldSchema("string_field", schemapb.DataType_VarChar),
@@ -3046,4 +3075,67 @@ func Test_appendConsistecyLevel(t *testing.T) {
 	consistencyLevel, properties := mustConsumeConsistencyLevel(task.Req.Properties)
 	assert.Equal(t, commonpb.ConsistencyLevel_Session, consistencyLevel)
 	assert.Len(t, properties, 0)
+}
+
+// A MinHash input legally keeps enable_analyzer=false yet consumes its
+// analyzer_params; the collector must still emit its analyzer info, or any
+// referenced file resources never reach schema.FileResourceIds / ref-counting
+// while the runtime keeps depending on them.
+func TestCollectAnalyzerInfosIncludesDisabledMinHashInput(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "coll",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+			{FieldID: 102, Name: "sig", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "128"}}},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name: "mh", Type: schemapb.FunctionType_MinHash,
+			InputFieldNames: []string{"text"}, InputFieldIds: []int64{101},
+			OutputFieldNames: []string{"sig"}, OutputFieldIds: []int64{102},
+		}},
+	}
+
+	infos, err := collectAnalyzerInfos(schema)
+	assert.NoError(t, err)
+	assert.Len(t, infos, 1)
+	assert.Equal(t, "text", infos[0].GetField())
+}
+
+// collectAnalyzerInfos runs before assignFieldAndFunctionID, so a request may
+// carry non-canonical (stale, mismatched) field IDs. The MinHash input must
+// still be recognized by name — an ID-based check would miss it and silently
+// drop the resource-backed analyzer_params from FileResourceIds/ref-counting.
+func TestCollectAnalyzerInfosMinHashInputMatchedByNameBeforeIDAssignment(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "coll",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID: 999, Name: "text", DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "128"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+			{FieldID: 102, Name: "sig", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "128"}}},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name: "mh", Type: schemapb.FunctionType_MinHash,
+			// names match the field, IDs are stale and disagree with FieldID above
+			InputFieldNames: []string{"text"}, InputFieldIds: []int64{888},
+			OutputFieldNames: []string{"sig"}, OutputFieldIds: []int64{102},
+		}},
+	}
+
+	infos, err := collectAnalyzerInfos(schema)
+	assert.NoError(t, err)
+	assert.Len(t, infos, 1)
+	assert.Equal(t, "text", infos[0].GetField())
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
+	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/internal/util/function/validator"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/schemautil"
@@ -129,6 +130,12 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 		if err := validator.ValidateFunction(schema, plan.Function.GetName(), true); err != nil {
 			return merr.Wrap(err, "invalid function schema")
 		}
+		if err := schemautil.ValidateAddFunctionInputNotText(schema, plan.Function); err != nil {
+			return err
+		}
+		if err := c.rejectAddFunctionInputAnalyzerFileResource(ctx, schema, plan.Function); err != nil {
+			return err
+		}
 	}
 	if err := typeutil.ValidateExternalCollectionResolvedSchema(schema); err != nil {
 		return err
@@ -183,6 +190,27 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		rollbackAlterCollectionAnalyzerFileResourceReservation(ctx, c.meta, coll.CollectionID, addedFileResourceIds, err)
 		return err
+	}
+	return nil
+}
+
+// rejectAddFunctionInputAnalyzerFileResource rejects add_function_field when the
+// added function's input-field analyzer references a file resource that DataNode
+// cannot resolve during backfill. Sync mode registers resources globally; ref and
+// close modes do not provide them to the compaction record-materializer.
+func (c *Core) rejectAddFunctionInputAnalyzerFileResource(ctx context.Context, schema *schemapb.CollectionSchema, function *schemapb.FunctionSchema) error {
+	analyzerInfos, err := collectFunctionInputAnalyzerInfos(schema, function)
+	if err != nil {
+		return err
+	}
+	resourceIds, err := c.validateAnalyzerInfos(ctx, analyzerInfos)
+	if err != nil {
+		return err
+	}
+	mode := Params.CommonCfg.DNFileResourceMode.GetValue()
+	if len(resourceIds) > 0 && !fileresource.IsSyncMode(mode) {
+		return merr.WrapErrParameterInvalidMsg(
+			"add_function_field with analyzer file resources requires dataNode file-resource sync mode")
 	}
 	return nil
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
 	"github.com/milvus-io/milvus/internal/tso"
 	mocktso "github.com/milvus-io/milvus/internal/tso/mocks"
+	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/internal/util/schemautil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
@@ -772,6 +773,189 @@ func TestDDLCallbacksAlterCollectionSchemaAnalyzerFileResourceRefs(t *testing.T)
 	require.Empty(t, coll.FileResourceIds)
 	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
 	assertFieldNotExists(t, ctx, core, dbName, collectionName, fieldName)
+}
+
+func TestRejectAddFunctionInputAnalyzerFileResource(t *testing.T) {
+	makeSchema := func(extraFields ...*schemapb.FieldSchema) *schemapb.CollectionSchema {
+		fields := []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+			}},
+			{FieldID: 101, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		}
+		fields = append(fields, extraFields...)
+		return &schemapb.CollectionSchema{
+			Fields: fields,
+			Functions: []*schemapb.FunctionSchema{{
+				Name: "bm25", Type: schemapb.FunctionType_BM25,
+				InputFieldNames: []string{"text"}, InputFieldIds: []int64{100},
+				OutputFieldNames: []string{"sparse"}, OutputFieldIds: []int64{101},
+			}},
+		}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		mode    string
+		wantErr bool
+	}{
+		{name: "sync mode allows resource-backed analyzer", mode: fileresource.SyncModeStr},
+		{name: "ref mode rejects resource-backed analyzer", mode: fileresource.RefModeStr, wantErr: true},
+		{name: "close mode rejects resource-backed analyzer", mode: fileresource.CloseModeStr, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paramtable.Get().Save(paramtable.Get().CommonCfg.DNFileResourceMode.Key, tc.mode)
+			defer paramtable.Get().Reset(paramtable.Get().CommonCfg.DNFileResourceMode.Key)
+			schema := makeSchema()
+			mixc := imocks.NewMixCoord(t)
+			mixc.EXPECT().ValidateAnalyzer(mock.Anything, mock.Anything).Return(&querypb.ValidateAnalyzerResponse{
+				Status:      merr.Success(),
+				ResourceIds: []int64{42},
+			}, nil).Once()
+			c := &Core{mixCoord: mixc}
+			err := c.rejectAddFunctionInputAnalyzerFileResource(context.Background(), schema, schema.GetFunctions()[0])
+			if tc.wantErr {
+				require.ErrorContains(t, err, "requires dataNode file-resource sync mode")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("allow when the function input analyzer references no file resource", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.DNFileResourceMode.Key, fileresource.RefModeStr)
+		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.DNFileResourceMode.Key)
+		schema := makeSchema()
+		mixc := imocks.NewMixCoord(t)
+		mixc.EXPECT().ValidateAnalyzer(mock.Anything, mock.Anything).Return(&querypb.ValidateAnalyzerResponse{
+			Status:      merr.Success(),
+			ResourceIds: nil,
+		}, nil).Once()
+		c := &Core{mixCoord: mixc}
+		err := c.rejectAddFunctionInputAnalyzerFileResource(context.Background(), schema, schema.GetFunctions()[0])
+		require.NoError(t, err)
+	})
+
+	t.Run("validates only the function input field, ignoring other analyzer fields", func(t *testing.T) {
+		// A second analyzer-bearing field exists but is not the function input, so it must
+		// not be validated and must not contribute to the rejection decision.
+		schema := makeSchema(&schemapb.FieldSchema{
+			FieldID: 102, Name: "other_text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"jieba"}`},
+			},
+		})
+		mixc := imocks.NewMixCoord(t)
+		mixc.EXPECT().ValidateAnalyzer(mock.Anything, mock.MatchedBy(func(req *querypb.ValidateAnalyzerRequest) bool {
+			infos := req.GetAnalyzerInfos()
+			return len(infos) == 1 && infos[0].GetField() == "text"
+		})).Return(&querypb.ValidateAnalyzerResponse{
+			Status:      merr.Success(),
+			ResourceIds: nil,
+		}, nil).Once()
+		c := &Core{mixCoord: mixc}
+		err := c.rejectAddFunctionInputAnalyzerFileResource(context.Background(), schema, schema.GetFunctions()[0])
+		require.NoError(t, err)
+	})
+
+	t.Run("minhash disabled analyzer still checks resource-backed params", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.DNFileResourceMode.Key, fileresource.RefModeStr)
+		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.DNFileResourceMode.Key)
+		schema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":{"type":"jieba","dict":["resource://dict"]}}`},
+				}},
+				{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "64"},
+				}},
+			},
+			Functions: []*schemapb.FunctionSchema{{
+				Name: "minhash", Type: schemapb.FunctionType_MinHash,
+				InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+			}},
+		}
+		mixc := imocks.NewMixCoord(t)
+		mixc.EXPECT().ValidateAnalyzer(mock.Anything, mock.MatchedBy(func(req *querypb.ValidateAnalyzerRequest) bool {
+			infos := req.GetAnalyzerInfos()
+			return len(infos) == 1 && infos[0].GetField() == "text"
+		})).Return(&querypb.ValidateAnalyzerResponse{
+			Status: merr.Success(), ResourceIds: []int64{42},
+		}, nil).Once()
+
+		err := (&Core{mixCoord: mixc}).rejectAddFunctionInputAnalyzerFileResource(context.Background(), schema, schema.GetFunctions()[0])
+		require.ErrorContains(t, err, "requires dataNode file-resource sync mode")
+	})
+
+	t.Run("minhash ignores resource-backed multi analyzer params", func(t *testing.T) {
+		paramtable.Get().Save(paramtable.Get().CommonCfg.DNFileResourceMode.Key, fileresource.RefModeStr)
+		defer paramtable.Get().Reset(paramtable.Get().CommonCfg.DNFileResourceMode.Key)
+		schema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: "multi_analyzer_params", Value: `{"by_field":"lang","analyzers":{"default":{"tokenizer":{"type":"jieba","dict":["resource://dict"]}}}}`},
+				}},
+				{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, IsFunctionOutput: true, TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "64"},
+				}},
+				{FieldID: 102, Name: "lang", DataType: schemapb.DataType_VarChar},
+			},
+			Functions: []*schemapb.FunctionSchema{{
+				Name: "minhash", Type: schemapb.FunctionType_MinHash,
+				InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+			}},
+		}
+
+		err := (&Core{}).rejectAddFunctionInputAnalyzerFileResource(context.Background(), schema, schema.GetFunctions()[0])
+		require.NoError(t, err)
+	})
+}
+
+func TestDDLCallbacksAlterCollectionSchemaRejectsTextFunctionInput(t *testing.T) {
+	coll := &model.Collection{
+		CollectionID: 1,
+		Name:         "coll",
+		Fields: []*model.Field{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{
+				FieldID: 101, Name: "text_input", DataType: schemapb.DataType_Text, Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+		},
+	}
+	core := &Core{}
+
+	bm25Req := buildAlterSchemaReq("db", coll.Name, "text_input", "sparse_from_text", "bm25_from_text")
+	bm25Err := core.broadcastAlterCollectionSchemaAdd(context.Background(), nil, coll, bm25Req)
+	require.ErrorIs(t, bm25Err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, bm25Err, "TEXT input field")
+
+	minHashReq := buildAlterSchemaReq("db", coll.Name, "text_input", "hash_from_text", "minhash_from_text")
+	minHashOutput := minHashReq.GetAction().GetAddRequest().GetFieldInfos()[0]
+	minHashOutput.FieldSchema.DataType = schemapb.DataType_BinaryVector
+	minHashOutput.FieldSchema.TypeParams = []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "4096"}}
+	minHashOutput.ExtraParams = []*commonpb.KeyValuePair{
+		{Key: common.IndexTypeKey, Value: "MINHASH_LSH"},
+		{Key: common.MetricTypeKey, Value: "MHJACCARD"},
+	}
+	minHashFunction := minHashReq.GetAction().GetAddRequest().GetFuncSchema()[0]
+	minHashFunction.Type = schemapb.FunctionType_MinHash
+	minHashFunction.Params = []*commonpb.KeyValuePair{
+		{Key: "num_hashes", Value: "128"},
+		{Key: "shingle_size", Value: "3"},
+		{Key: "hash_function", Value: "xxhash64"},
+		{Key: "seed", Value: "42"},
+	}
+	minHashErr := core.broadcastAlterCollectionSchemaAdd(context.Background(), nil, coll, minHashReq)
+	require.ErrorIs(t, minHashErr, merr.ErrParameterInvalid)
+	// MinHash fails the earlier VarChar-only input type check (its runner never
+	// accepted TEXT); the TEXT backfill gate stays load-bearing for BM25 above.
+	require.ErrorContains(t, minHashErr, "must be a VARCHAR field")
 }
 
 func TestDDLCallbacksAlterCollectionSchemaRejectsFunctionOnlyAdd(t *testing.T) {

--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -326,6 +327,16 @@ func GenerateEmptyArrayFromSchema(schema *schemapb.FieldSchema, numRows int) (ar
 			bd := builder.(*array.BinaryBuilder)
 			bd.AppendValues(
 				lo.RepeatBy(numRows, func(_ int) []byte { return schema.GetDefaultValue().GetBytesData() }),
+				nil)
+		case schemapb.DataType_Geometry:
+			// DDL persists the geometry default as WKT; storage carries WKB.
+			wkb, err := common.ConvertWKTToWKB(schema.GetDefaultValue().GetStringData())
+			if err != nil {
+				return nil, merr.WrapErrServiceInternalErr(err, "convert geometry default value for field %s", schema.GetName())
+			}
+			bd := builder.(*array.BinaryBuilder)
+			bd.AppendValues(
+				lo.RepeatBy(numRows, func(_ int) []byte { return wkb }),
 				nil)
 		default:
 			return nil, merr.WrapErrServiceInternalMsg("Unexpected default value type: %s", schema.GetDataType().String())

--- a/internal/storage/arrow_util_test.go
+++ b/internal/storage/arrow_util_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 )
 
 func TestGenerateEmptyArray(t *testing.T) {
@@ -378,4 +379,26 @@ func TestRecordBuilderBuildReleasesCreatorRefs(t *testing.T) {
 		rec.Release()
 	}()
 	alloc.AssertSize(t, 0)
+}
+
+func TestGenerateEmptyArrayGeometryDefault(t *testing.T) {
+	wkt := "POINT (30 10)"
+	field := &schemapb.FieldSchema{
+		FieldID: 110, Name: "geo", DataType: schemapb.DataType_Geometry, Nullable: true,
+		DefaultValue: &schemapb.ValueField{Data: &schemapb.ValueField_StringData{StringData: wkt}},
+	}
+
+	arr, err := GenerateEmptyArrayFromSchema(field, 3)
+	require.NoError(t, err)
+	defer arr.Release()
+
+	wkb, err := common.ConvertWKTToWKB(wkt)
+	require.NoError(t, err)
+	bin, ok := arr.(*array.Binary)
+	require.True(t, ok)
+	require.Equal(t, 3, bin.Len())
+	for i := 0; i < 3; i++ {
+		require.True(t, bin.IsValid(i))
+		require.Equal(t, wkb, bin.Value(i))
+	}
 }

--- a/internal/storage/record_writer.go
+++ b/internal/storage/record_writer.go
@@ -271,6 +271,17 @@ func (pw *packedRecordBatchWriter) Close() (packed.WriterOutput, error) {
 	return out, nil
 }
 
+// Abort releases the underlying FFI writer without flushing pending column
+// groups — for error paths whose output will not be committed. Files already
+// flushed during Write are not undone; they stay unreferenced by the manifest.
+func (pw *packedRecordBatchWriter) Abort() {
+	if pw.writer == nil {
+		return
+	}
+	pw.writer.Destroy()
+	pw.writer = nil
+}
+
 func (pw *packedRecordBatchWriter) AsNewColumnGroups() {
 	if pw.writer != nil {
 		pw.writer.AsNewColumnGroups()

--- a/internal/util/function/embedding/function_executor.go
+++ b/internal/util/function/embedding/function_executor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
@@ -81,15 +80,10 @@ func validateFunction(schema *schemapb.CollectionSchema, fSchema *schemapb.Funct
 		return err
 	}
 
-	// BM25 or minhash function returns nil from createFunction
+	// BM25 and MinHash return nil from createFunction: neither needs a model
+	// runtime check. MinHash parameter validation is pure schema checking and
+	// runs unconditionally in validator.ValidateFunction instead.
 	if f == nil {
-		if fSchema.GetType() == schemapb.FunctionType_MinHash {
-			err := function.ValidateMinHashFunction(schema, fSchema)
-			if err != nil {
-				return err
-			}
-		}
-		// bm25 or minhash validate pass
 		return nil
 	}
 

--- a/internal/util/function/minhash_function.go
+++ b/internal/util/function/minhash_function.go
@@ -17,11 +17,11 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/internal/util/analyzer/canalyzer"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 // MinHashFunctionRunner
@@ -95,11 +95,15 @@ func NewMinHashFunctionRunner(
 	if inputField == nil {
 		return nil, merr.WrapErrParameterInvalidMsg("no input field")
 	}
-
-	params := getAnalyzerParams(inputField)
-	tokenizer, err := analyzer.NewAnalyzer(params, "")
+	if outputField.GetDataType() != schemapb.DataType_BinaryVector {
+		return nil, merr.WrapErrFunctionFailedMsg("minhash function output field '%s' is not binary vector type", outputField.GetName())
+	}
+	outputDim, err := typeutil.GetDim(outputField)
 	if err != nil {
-		return nil, err
+		return nil, merr.WrapErrFunctionFailed(err, "failed to read minhash output field dimension")
+	}
+	if outputDim <= 0 || outputDim%32 != 0 {
+		return nil, merr.WrapErrFunctionFailedMsg("minhash function output field '%s' dim %d is invalid(dim > 0, dim %% 32 == 0)", outputField.GetName(), outputDim)
 	}
 
 	numHashes := 0
@@ -156,26 +160,24 @@ func NewMinHashFunctionRunner(
 		}
 	}
 	if numHashes <= 0 {
-		// auto generate numHashes from output field dim
-		var outputDim int64 = -1
-
-		for _, param := range outputField.GetTypeParams() {
-			if param.GetKey() == "dim" {
-				val, err := strconv.ParseInt(param.GetValue(), 10, 64)
-				if err == nil {
-					outputDim = val
-					break
-				}
-			}
-		}
-		if outputDim <= 0 || outputDim%32 != 0 {
-			return nil, merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim not found or invalid(dim > 0, dim %% 32 == 0)", outputField.GetName())
-		}
+		// Keep the derived value runner-local. funSchema is shared with the
+		// compaction plan and may be read by concurrent runner constructions.
 		numHashes = int(outputDim / 32)
-		funSchema.Params = append(funSchema.Params, &commonpb.KeyValuePair{
-			Key:   NumHashesKey,
-			Value: strconv.Itoa(numHashes),
-		})
+	}
+	// Compare via division: outputDim is validated positive and %32==0 above,
+	// while numHashes*32 can wrap around int64 and defeat the check.
+	if int64(numHashes) != outputDim/32 {
+		return nil, merr.WrapErrFunctionFailedMsg(
+			"minhash function output field '%s' dim %d does not match expected dim for num_hashes %d (dim must be num_hashes * 32)",
+			outputField.GetName(), outputDim, numHashes)
+	}
+
+	// Create the native tokenizer only after every pure-Go validation succeeds;
+	// no error-returning initialization remains below this point.
+	params := getAnalyzerParams(inputField)
+	tokenizer, err := analyzer.NewAnalyzer(params, "")
+	if err != nil {
+		return nil, err
 	}
 	// Initialize permutations
 	permA, permB = initializePermutations(numHashes, int64(seed))
@@ -289,9 +291,10 @@ func ValidateMinHashFunction(collSchema *schemapb.CollectionSchema, funSchema *s
 	}
 
 	if numHashes > 0 {
-		expectedDim := int64(numHashes * 32) // binary vector, each hash is 4 bytes (32 bits), but stored as 8 bits in binary vector
-		if outputDim != expectedDim {
-			return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim %d does not match expected dim %d (numHashes %d * one minhash signature size of 32bit)", outputFieldName, outputDim, expectedDim, numHashes)
+		// Compare via division: numHashes*32 can wrap around and defeat the
+		// check. Each hash occupies 32 bits of the binary vector.
+		if outputDim%32 != 0 || outputDim/32 != int64(numHashes) {
+			return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim %d does not match expected dim (numHashes %d * one minhash signature size of 32bit)", outputFieldName, outputDim, numHashes)
 		}
 	} else {
 		if outputDim%32 != 0 {
@@ -392,7 +395,7 @@ func (m *MinHashFunctionRunner) BatchRun(inputs ...any) ([]any, error) {
 		}
 	}
 
-	return []any{buildBinaryVectorFieldData(signatures)}, nil
+	return []any{buildBinaryVectorFieldData(signatures, int64(m.numHashes*32))}, nil
 }
 
 func (v *MinHashFunctionRunner) GetSchema() *schemapb.FunctionSchema {
@@ -560,12 +563,10 @@ func batchSignatureToBinaryVector(signatures [][]uint32, dst [][]byte) {
 	}
 }
 
-func buildBinaryVectorFieldData(signatures [][]byte) *schemapb.FieldData {
-	var dim int64
+func buildBinaryVectorFieldData(signatures [][]byte, dim int64) *schemapb.FieldData {
 	var flatData []byte
 
 	if len(signatures) > 0 {
-		dim = int64(len(signatures[0]) * 8)
 		flatData = make([]byte, 0, len(signatures)*len(signatures[0]))
 		for _, sig := range signatures {
 			flatData = append(flatData, sig...)

--- a/internal/util/function/minhash_function_test.go
+++ b/internal/util/function/minhash_function_test.go
@@ -1,0 +1,179 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package function
+
+import (
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/analyzer"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// The FunctionSchema is shared with the compaction plan and runner constructions
+// can run concurrently (clustering builds one materializer per segment), so the
+// constructor must keep the derived num_hashes runner-local and never write it
+// back into the schema.
+func TestMinHashRunnerDoesNotMutateSharedSchema(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "64"},
+		}},
+	}}
+	// num_hashes intentionally omitted: the runner derives it from the output dim.
+	funSchema := &schemapb.FunctionSchema{
+		Name:           "minhash",
+		Type:           schemapb.FunctionType_MinHash,
+		InputFieldIds:  []int64{100},
+		OutputFieldIds: []int64{101},
+	}
+
+	runner, err := NewMinHashFunctionRunner(collSchema, funSchema)
+	require.NoError(t, err)
+	defer runner.Close()
+
+	require.Empty(t, funSchema.GetParams(), "constructor must not write derived params into the shared schema")
+	minHashRunner, ok := runner.(*MinHashFunctionRunner)
+	require.True(t, ok)
+	require.Equal(t, 2, minHashRunner.numHashes)
+}
+
+func TestMinHashRunnerValidatesExplicitNumHashesBeforeCreatingAnalyzer(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "64"},
+		}},
+	}}
+	funSchema := &schemapb.FunctionSchema{
+		Name: "minhash", Type: schemapb.FunctionType_MinHash,
+		InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+		Params: []*commonpb.KeyValuePair{{Key: NumHashesKey, Value: "4"}},
+	}
+
+	analyzerCalls := 0
+	patch := mockey.Mock(analyzer.NewAnalyzer).To(func(string, string) (analyzer.Analyzer, error) {
+		analyzerCalls++
+		return nil, errors.New("unexpected analyzer construction")
+	}).Build()
+	defer patch.UnPatch()
+
+	runner, err := NewMinHashFunctionRunner(collSchema, funSchema)
+	require.Nil(t, runner)
+	require.ErrorIs(t, err, merr.ErrFunctionFailed)
+	require.ErrorContains(t, err, "does not match expected dim")
+	require.Zero(t, analyzerCalls)
+}
+
+func TestMinHashRunnerExplicitNumHashesMatchesOutputDim(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "64"},
+		}},
+	}}
+	funSchema := &schemapb.FunctionSchema{
+		Name: "minhash", Type: schemapb.FunctionType_MinHash,
+		InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+		Params: []*commonpb.KeyValuePair{{Key: NumHashesKey, Value: "2"}},
+	}
+
+	runner, err := NewMinHashFunctionRunner(collSchema, funSchema)
+	require.NoError(t, err)
+	defer runner.Close()
+	require.Equal(t, 2, runner.(*MinHashFunctionRunner).numHashes)
+}
+
+// num_hashes = 2^59+1: (2^59+1)*32 wraps around int64 to 32, so a
+// multiply-based dim check would accept it and pass the raw value to
+// initializePermutations' slice allocation.
+func TestMinHashRunnerRejectsNumHashesOverflowingDimCheck(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "32"},
+		}},
+	}}
+	funSchema := &schemapb.FunctionSchema{
+		Name: "minhash", Type: schemapb.FunctionType_MinHash,
+		InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+		Params: []*commonpb.KeyValuePair{{Key: NumHashesKey, Value: "576460752303423489"}},
+	}
+
+	analyzerCalls := 0
+	patch := mockey.Mock(analyzer.NewAnalyzer).To(func(string, string) (analyzer.Analyzer, error) {
+		analyzerCalls++
+		return nil, errors.New("unexpected analyzer construction")
+	}).Build()
+	defer patch.UnPatch()
+
+	runner, err := NewMinHashFunctionRunner(collSchema, funSchema)
+	require.Nil(t, runner)
+	require.ErrorIs(t, err, merr.ErrFunctionFailed)
+	require.ErrorContains(t, err, "does not match expected dim")
+	require.Zero(t, analyzerCalls)
+}
+
+func TestValidateMinHashFunctionRejectsNumHashesOverflowingDimCheck(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{Name: "text", DataType: schemapb.DataType_VarChar},
+		{Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "32"},
+		}},
+	}}
+	funSchema := &schemapb.FunctionSchema{
+		Name: "minhash", Type: schemapb.FunctionType_MinHash,
+		InputFieldNames: []string{"text"}, OutputFieldNames: []string{"hash"},
+		Params: []*commonpb.KeyValuePair{{Key: NumHashesKey, Value: "576460752303423489"}},
+	}
+
+	err := ValidateMinHashFunction(collSchema, funSchema)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, err, "does not match expected dim")
+}
+
+func TestMinHashRunnerEmptyBatchKeepsSchemaDim(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "64"},
+		}},
+	}}
+	funSchema := &schemapb.FunctionSchema{
+		Name: "minhash", Type: schemapb.FunctionType_MinHash,
+		InputFieldIds: []int64{100}, OutputFieldIds: []int64{101},
+	}
+
+	runner, err := NewMinHashFunctionRunner(collSchema, funSchema)
+	require.NoError(t, err)
+	defer runner.Close()
+
+	outputs, err := runner.BatchRun([]string{})
+	require.NoError(t, err)
+	require.Len(t, outputs, 1)
+	fieldData := outputs[0].(*schemapb.FieldData)
+	require.EqualValues(t, 64, fieldData.GetVectors().GetDim())
+	require.Empty(t, fieldData.GetVectors().GetBinaryVector())
+}

--- a/internal/util/function/multi_analyzer_bm25_function.go
+++ b/internal/util/function/multi_analyzer_bm25_function.go
@@ -19,12 +19,17 @@
 package function
 
 import (
+	"context"
 	"encoding/json"
+	"sort"
 	"sync"
+
+	"golang.org/x/time/rate"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -62,6 +67,15 @@ func NewMultiAnalyzerBM25FunctionRunner(coll *schemapb.CollectionSchema, schema 
 		outputField: outputField,
 		analyzers:   make(map[string]analyzer.Analyzer),
 	}
+	constructed := false
+	defer func() {
+		if constructed {
+			return
+		}
+		for _, created := range runner.analyzers {
+			created.Destroy()
+		}
+	}()
 
 	var m map[string]json.RawMessage
 	var mFileName string
@@ -119,10 +133,37 @@ func NewMultiAnalyzerBM25FunctionRunner(coll *schemapb.CollectionSchema, schema 
 		runner.analyzers[name] = analyzer
 	}
 
+	// A dangling alias is accepted for compatibility. At runtime an ordinary
+	// dangling alias falls back to the default analyzer, while a dangling
+	// "default" alias makes the default unresolvable and fails the request.
+	// Aggregate aliases and rate-limit the constructor warning: compaction may
+	// construct the same runner once per segment and repeat it on task retries.
+	danglingAliases := make([]string, 0)
+	for aliasName, target := range runner.alias {
+		if _, ok := runner.analyzers[target]; !ok {
+			danglingAliases = append(danglingAliases, aliasName+"->"+target)
+		}
+	}
+	if len(danglingAliases) > 0 {
+		sort.Strings(danglingAliases)
+		mlog.RatedWarn(context.TODO(), rate.Limit(1.0/60.0),
+			"multi analyzer aliases target undefined analyzers; affected values fall back to the default analyzer, or fail at runtime if the default alias itself dangles",
+			mlog.FieldDbName(coll.GetDbName()),
+			mlog.FieldCollectionName(coll.GetName()),
+			mlog.Int32("schemaVersion", coll.GetVersion()),
+			mlog.FieldFieldID(inputField.GetFieldID()),
+			mlog.String("fieldName", inputField.GetName()),
+			mlog.Int64("functionID", schema.GetId()),
+			mlog.String("functionName", schema.GetName()),
+			mlog.Strings("danglingAliases", danglingAliases))
+	}
+
+	constructed = true
 	return runner, nil
 }
 
 func (v *MultiAnalyzerBM25FunctionRunner) getAnalyzer(name string, analyzers map[string]analyzer.Analyzer) (analyzer.Analyzer, error) {
+	origName := name
 	if alias, ok := v.alias[name]; ok {
 		name = alias
 	}
@@ -140,6 +181,14 @@ func (v *MultiAnalyzerBM25FunctionRunner) getAnalyzer(name string, analyzers map
 		return analyzers[name], nil
 	}
 
+	// "default" is the terminal fallback. If even it cannot resolve (missing, or
+	// aliased to an undefined analyzer), fail instead of recursing forever. Guard
+	// on the pre-alias name so a dangling default alias cannot loop. This is a
+	// system-side failure: ordinary unknown names fall back by design, so only a
+	// broken persisted configuration reaches this point — never request content.
+	if origName == "default" {
+		return nil, merr.WrapErrFunctionFailedMsg("multi analyzer cannot resolve analyzer %q: the default analyzer is missing or aliased to an undefined analyzer", name)
+	}
 	return v.getAnalyzer("default", analyzers)
 }
 

--- a/internal/util/function/multi_analyzer_bm25_function_test.go
+++ b/internal/util/function/multi_analyzer_bm25_function_test.go
@@ -19,17 +19,26 @@
 package function
 
 import (
+	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 
+	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/time/rate"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/internal/util/analyzer/interfaces"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type MultiAnalyzerBM25FunctionSuite struct {
@@ -134,6 +143,82 @@ func (s *MultiAnalyzerBM25FunctionSuite) TestNewMultiAnalyzerBM25FunctionRunner(
 	})
 }
 
+func (s *MultiAnalyzerBM25FunctionSuite) TestConstructorRollsBackCreatedAnalyzersOnError() {
+	created := interfaces.NewMockAnalyzer(s.T())
+	created.EXPECT().Destroy().Return().Once()
+	calls := 0
+	patch := mockey.Mock(analyzer.NewAnalyzer).To(func(string, string) (analyzer.Analyzer, error) {
+		calls++
+		if calls == 1 {
+			return created, nil
+		}
+		return nil, errors.New("create analyzer failed")
+	}).Build()
+	defer patch.UnPatch()
+
+	runner, err := NewMultiAnalyzerBM25FunctionRunner(
+		s.collection,
+		s.function,
+		s.collection.Fields[0],
+		s.collection.Fields[2],
+		`{"by_field":"analyzer","analyzers":{"default":{"type":"standard"},"english":{"type":"english"}}}`,
+	)
+	s.Nil(runner)
+	s.ErrorContains(err, "create analyzer")
+	s.Equal(2, calls)
+}
+
+func (s *MultiAnalyzerBM25FunctionSuite) TestConstructorAggregatesDanglingAliasWarning() {
+	collection := proto.Clone(s.collection).(*schemapb.CollectionSchema)
+	collection.DbName = "test_db"
+	collection.Name = "test_collection"
+	collection.Version = 7
+	functionSchema := proto.Clone(s.function).(*schemapb.FunctionSchema)
+	functionSchema.Id = 1000
+
+	var (
+		calls      int
+		gotLimit   rate.Limit
+		gotMessage string
+		gotFields  []mlog.Field
+	)
+	warnPatch := mockey.Mock(mlog.RatedWarn).To(func(_ context.Context, limit rate.Limit, message string, fields ...mlog.Field) {
+		calls++
+		gotLimit = limit
+		gotMessage = message
+		gotFields = append([]mlog.Field(nil), fields...)
+	}).Build()
+	defer warnPatch.UnPatch()
+
+	runner, err := NewMultiAnalyzerBM25FunctionRunner(
+		collection,
+		functionSchema,
+		collection.Fields[0],
+		collection.Fields[2],
+		`{"by_field":"analyzer","analyzers":{"default":{"type":"standard"},"english":{"type":"english"}},"alias":{"z":"missing_z","a":"missing_a","valid":"english"}}`,
+	)
+	s.Require().NoError(err)
+	s.Require().NotNil(runner)
+	defer runner.Close()
+
+	s.Equal(1, calls)
+	s.Equal(rate.Limit(1.0/60.0), gotLimit)
+	s.Contains(gotMessage, "aliases target undefined analyzers")
+
+	fieldsByKey := make(map[string]mlog.Field, len(gotFields))
+	for _, field := range gotFields {
+		fieldsByKey[field.Key] = field
+	}
+	s.Equal("test_db", fieldsByKey["dbName"].String)
+	s.Equal("test_collection", fieldsByKey["collectionName"].String)
+	s.Equal(int64(7), fieldsByKey["schemaVersion"].Integer)
+	s.Equal(int64(101), fieldsByKey["fieldID"].Integer)
+	s.Equal("text", fieldsByKey["fieldName"].String)
+	s.Equal(int64(1000), fieldsByKey["functionID"].Integer)
+	s.Equal("bm25", fieldsByKey["functionName"].String)
+	s.Equal("[a->missing_a z->missing_z]", fmt.Sprint(fieldsByKey["danglingAliases"].Interface))
+}
+
 func (s *MultiAnalyzerBM25FunctionSuite) TestBatchRun() {
 	s.Run("normal", func() {
 		runner, err := NewBM25FunctionRunner(s.collection, s.function)
@@ -234,4 +319,42 @@ func (s *MultiAnalyzerBM25FunctionSuite) TestAnalyzeReleasesTokenStreamsPerInput
 
 func TestMultiAnalyzerBm25Function(t *testing.T) {
 	suite.Run(t, new(MultiAnalyzerBM25FunctionSuite))
+}
+
+// getAnalyzer must terminate with an error — not recurse forever — when even the
+// "default" analyzer cannot resolve (missing, or aliased to an undefined name).
+func TestMultiAnalyzerGetAnalyzerTerminalGuard(t *testing.T) {
+	t.Run("dangling default alias returns error instead of recursing", func(t *testing.T) {
+		runner := &MultiAnalyzerBM25FunctionRunner{
+			alias:     map[string]string{"default": "missing"},
+			analyzers: map[string]analyzer.Analyzer{},
+		}
+		_, err := runner.getAnalyzer("en", map[string]analyzer.Analyzer{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "default analyzer is missing or aliased to an undefined analyzer")
+		// broken persisted configuration, not request content: must classify as
+		// a system-side function failure, not an input error
+		require.ErrorIs(t, err, merr.ErrFunctionFailed)
+	})
+
+	t.Run("unknown name falls back to existing default", func(t *testing.T) {
+		def := interfaces.NewMockAnalyzer(t)
+		def.EXPECT().Clone().Return(def, nil).Once()
+		runner := &MultiAnalyzerBM25FunctionRunner{
+			alias:     map[string]string{"en": "english_typo"},
+			analyzers: map[string]analyzer.Analyzer{"default": def},
+		}
+		got, err := runner.getAnalyzer("en", map[string]analyzer.Analyzer{})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+	})
+
+	t.Run("missing default without alias returns error", func(t *testing.T) {
+		runner := &MultiAnalyzerBM25FunctionRunner{
+			analyzers: map[string]analyzer.Analyzer{},
+		}
+		_, err := runner.getAnalyzer("default", map[string]analyzer.Analyzer{})
+		require.Error(t, err)
+		require.ErrorIs(t, err, merr.ErrFunctionFailed)
+	})
 }

--- a/internal/util/function/validator/validator.go
+++ b/internal/util/function/validator/validator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/function/embedding"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -96,6 +97,20 @@ func ValidateFunction(coll *schemapb.CollectionSchema, needValidateFunctionName 
 			if usedOutputField.Contain(name) {
 				return merr.WrapErrParameterInvalidMsg("function %s input field %s is the output of another function; function cascade is not supported", function.GetName(), name)
 			}
+		}
+	}
+	// MinHash parameter validation (num_hashes vs output dim relation) is pure
+	// schema checking with no external calls; it must run even when the model
+	// runtime checks below are disabled.
+	for _, fn := range coll.GetFunctions() {
+		if fn.GetType() != schemapb.FunctionType_MinHash {
+			continue
+		}
+		if needValidateFunctionName != "" && fn.GetName() != needValidateFunctionName {
+			continue
+		}
+		if err := function.ValidateMinHashFunction(coll, fn); err != nil {
+			return err
 		}
 	}
 	if !disableRuntimeCheck {
@@ -189,8 +204,11 @@ func CheckFunctionInputField(function *schemapb.FunctionSchema, fields []*schema
 			return err
 		}
 	case schemapb.FunctionType_MinHash:
-		if len(fields) != 1 || (fields[0].DataType != schemapb.DataType_VarChar && fields[0].DataType != schemapb.DataType_Text) {
-			return merr.WrapErrParameterInvalidMsg("MinHash function input field must be a VARCHAR/TEXT field, got %d field with type %s",
+		// VarChar only: the MinHash runner has never accepted TEXT
+		// (ValidateMinHashFunction), so admitting it here produced
+		// collections whose every insert failed at the function executor.
+		if len(fields) != 1 || fields[0].DataType != schemapb.DataType_VarChar {
+			return merr.WrapErrParameterInvalidMsg("MinHash function input field must be a VARCHAR field, got %d field with type %s",
 				len(fields), fields[0].DataType.String())
 		}
 	default:

--- a/internal/util/function/validator/validator_test.go
+++ b/internal/util/function/validator/validator_test.go
@@ -1,0 +1,59 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func minHashCollectionSchema(numHashes string) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+			{FieldID: 101, Name: "hash", DataType: schemapb.DataType_BinaryVector, TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "64"},
+			}},
+		},
+		Functions: []*schemapb.FunctionSchema{{
+			Name:             "minhash",
+			Type:             schemapb.FunctionType_MinHash,
+			InputFieldNames:  []string{"text"},
+			OutputFieldNames: []string{"hash"},
+			Params:           []*commonpb.KeyValuePair{{Key: function.NumHashesKey, Value: numHashes}},
+		}},
+	}
+}
+
+// The direct RootCoord DDL path calls ValidateFunction with
+// disableRuntimeCheck=true; MinHash parameter validation is pure schema
+// checking and must still run there.
+func TestValidateFunctionChecksMinHashParamsWithRuntimeCheckDisabled(t *testing.T) {
+	err := ValidateFunction(minHashCollectionSchema("3"), "minhash", true)
+	require.ErrorIs(t, err, merr.ErrParameterInvalid)
+	require.ErrorContains(t, err, "does not match expected dim")
+}
+
+func TestValidateFunctionAcceptsValidMinHashWithRuntimeCheckDisabled(t *testing.T) {
+	require.NoError(t, ValidateFunction(minHashCollectionSchema("2"), "minhash", true))
+}

--- a/internal/util/schemautil/alter_schema_add.go
+++ b/internal/util/schemautil/alter_schema_add.go
@@ -146,6 +146,29 @@ func ValidateAlterSchemaAddFunctionPlan(plan *AlterSchemaAddPlan) error {
 	}
 }
 
+// ValidateAddFunctionInputNotText rejects BM25/MinHash backfill from TEXT
+// fields because existing TEXT values are stored as binary LOB references.
+func ValidateAddFunctionInputNotText(schema *schemapb.CollectionSchema, function *schemapb.FunctionSchema) error {
+	switch function.GetType() {
+	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
+	default:
+		return nil
+	}
+
+	fieldByName := make(map[string]*schemapb.FieldSchema, len(schema.GetFields()))
+	for _, field := range schema.GetFields() {
+		fieldByName[field.GetName()] = field
+	}
+	for _, inputFieldName := range function.GetInputFieldNames() {
+		if field, ok := fieldByName[inputFieldName]; ok && field.GetDataType() == schemapb.DataType_Text {
+			return merr.WrapErrParameterInvalidMsg(
+				"adding a %s function with a TEXT input field (%s) is not supported: its output cannot be backfilled into existing segments; use a VARCHAR input field",
+				function.GetType().String(), inputFieldName)
+		}
+	}
+	return nil
+}
+
 func validateAddFunctionFieldAllowed(function *schemapb.FunctionSchema) error {
 	switch function.GetType() {
 	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:

--- a/internal/util/schemautil/alter_schema_add_test.go
+++ b/internal/util/schemautil/alter_schema_add_test.go
@@ -55,3 +55,24 @@ func TestCheckNoFunctionCascade(t *testing.T) {
 		assert.NoError(t, CheckNoFunctionCascade(existing, nil))
 	})
 }
+
+func TestValidateAddFunctionInputNotText(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "varchar_in", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "text_in", DataType: schemapb.DataType_Text},
+	}}
+	function := func(functionType schemapb.FunctionType, input string) *schemapb.FunctionSchema {
+		return &schemapb.FunctionSchema{
+			Name:            "fn",
+			Type:            functionType,
+			InputFieldNames: []string{input},
+		}
+	}
+
+	for _, functionType := range []schemapb.FunctionType{schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash} {
+		err := ValidateAddFunctionInputNotText(schema, function(functionType, "text_in"))
+		assert.ErrorContains(t, err, "TEXT input field")
+		assert.NoError(t, ValidateAddFunctionInputNotText(schema, function(functionType, "varchar_in")))
+	}
+	assert.NoError(t, ValidateAddFunctionInputNotText(schema, function(schemapb.FunctionType_TextEmbedding, "text_in")))
+}


### PR DESCRIPTION
### What

Hardens the `bump_schema_version` / `add_function_field` compaction path against a set of potential risks identified during a deep review, and rounds out ref file-resource (RefMode) handling. All items strengthen existing logic; wire protocols and default behaviors are unchanged.

> **Note:** the RecordReader ownership / borrow-contract portion originally in this PR has been split out into #51884 (master) / #51891 (3.0) and is no longer part of this diff.

### Enhanced items

**RefMode handling**
- **datacoord** — carry the schema's analyzer `FileResources` into the bump compaction plan so the inline text-match index build can resolve them under ref mode, mirroring sort/mix compaction.
- **rootcoord** — reject `add_function_field` when the added function's input-field analyzer references a file resource: the output backfill runs that analyzer inside the compaction record-materializer, which cannot resolve a referenced resource under ref mode, so the combination is intentionally left unsupported for now. The check is scoped to the function's input field, so collections that merely have other resource-referencing analyzer fields are unaffected.

**Materializer robustness**
- decide selection-column and source-TTL presence from `existingFields` instead of probing records — V2/V3 records are strict about `Column` on absent fields.
- build selection columns eagerly so a build failure surfaces with its root cause instead of deep inside the writer.
- fill missing schema fields before running functions so newly added inputs are readable by function runners.
- skip the analyzer file-resource download when no field enables match (that download exists solely to build text-match indexes).
- drop an unused parameter in the full-rewrite path.

**Function runner robustness**
- **MinHash** — keep the derived `num_hashes` runner-local instead of writing it back into the shared plan schema, which clustering reads from parallel runner constructions.
- **multi-analyzer BM25** — DDL validates alias syntax while preserving legacy dangling aliases for compatibility; at runtime unresolved analyzer names fall back to the default analyzer, an unresolvable default returns an error instead of recursing forever, and a constructor warning surfaces undefined alias targets.

### Tests

- Full `internal/datanode/compactor` suite green under `-tags dynamic,test`; targeted `internal/storage` and `internal/datanode/external` suites green.
- New regression tests proven to catch the previous behavior: selection over a record lacking a schema field, and a full rewrite whose source segment lacks the designated TTL field.
- storage / function / rootcoord unit tests green.

issue: #51649

🤖 Generated with [Claude Code](https://claude.com/claude-code)