### PR TITLE
test: Add standalone woodpecker embed Helm values

### DIFF
--- a/tests/_helm/values/e2e-amd/standalone-wp-embed
+++ b/tests/_helm/values/e2e-amd/standalone-wp-embed
@@ -1,0 +1,149 @@
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - preference:
+        matchExpressions:
+        - key: jenkins-e2e-amd
+          operator: In
+          values:
+          - "true"
+      weight: 100
+    - preference:
+        matchExpressions:
+        - key: node-role.kubernetes.io/e2e
+          operator: Exists
+      weight: 1
+cluster:
+  enabled: false
+streaming:
+  enabled: true
+service:
+  type: ClusterIP
+woodpecker:
+  enabled: true
+standalone:
+  messageQueue: woodpecker
+  disk:
+    enabled: true
+  resources:
+    limits:
+      cpu: "8"
+      memory: 16Gi
+    requests:
+      cpu: "3"
+      memory: 8Gi
+log:
+  level: debug
+extraConfigFiles:
+  user.yaml: |+
+    common:
+      storage:
+        # enable storage v3
+        useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
+    dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
+      compaction:
+        bumpSchemaVersion:
+          enabled: true
+      gc:
+        interval: 1800
+        missingTolerance: 1800
+        dropTolerance: 1800
+    queryNode:
+      segcore:
+        exprEvalBatchSize: 512
+    quotaAndLimits:
+      flushRate:
+        collection:
+          max: 4
+metrics:
+  serviceMonitor:
+    enabled: true
+etcd:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: jenkins-e2e-amd
+            operator: In
+            values:
+            - "true"
+        weight: 100
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/e2e
+            operator: Exists
+        weight: 1
+  metrics:
+    enabled: true
+    podMonitor:
+      enabled: true
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: "0.2"
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 4Gi
+  tolerations:
+  - effect: PreferNoSchedule
+    key: jenkins-milvus-ci-only
+    operator: Equal
+    value: "true"
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/e2e
+    operator: Exists
+image:
+  all:
+    pullPolicy: Always
+    repository: harbor.milvus.io/milvus/milvus
+    tag: PR-35402-20240812-402f716b5
+minio:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: jenkins-e2e-amd
+            operator: In
+            values:
+            - "true"
+        weight: 100
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/e2e
+            operator: Exists
+        weight: 1
+  mode: standalone
+  resources:
+    requests:
+      cpu: "0.5"
+      memory: 3Gi
+    limits:
+      cpu: "1"
+      memory: 6Gi
+  tolerations:
+  - effect: PreferNoSchedule
+    key: jenkins-milvus-ci-only
+    operator: Equal
+    value: "true"
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/e2e
+    operator: Exists
+pulsarv3:
+  enabled: false
+tolerations:
+- effect: PreferNoSchedule
+  key: jenkins-milvus-ci-only
+  operator: Equal
+  value: "true"
+- effect: NoSchedule
+  key: node-role.kubernetes.io/e2e
+  operator: Exists

--- a/tests/_helm/values/e2e-arm/standalone-wp-embed
+++ b/tests/_helm/values/e2e-arm/standalone-wp-embed
@@ -1,0 +1,99 @@
+nodeSelector:
+  jenkins-e2e-arm: "true"
+cluster:
+  enabled: false
+streaming:
+  enabled: true
+service:
+  type: ClusterIP
+woodpecker:
+  enabled: true
+standalone:
+  messageQueue: woodpecker
+  disk:
+    enabled: true
+  resources:
+    limits:
+      cpu: "8"
+      memory: 16Gi
+    requests:
+      cpu: "3"
+      memory: 8Gi
+log:
+  level: debug
+extraConfigFiles:
+  user.yaml: |+
+    common:
+      storage:
+        # enable storage v3
+        useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
+    dataCoord:
+      targetVecIndexVersion: 10
+      forceRebuildScalarSegmentIndex: true
+      targetScalarIndexVersion: 3
+      compaction:
+        bumpSchemaVersion:
+          enabled: true
+      gc:
+        interval: 1800
+        missingTolerance: 1800
+        dropTolerance: 1800
+    queryNode:
+      segcore:
+        exprEvalBatchSize: 512
+metrics:
+  serviceMonitor:
+    enabled: true
+etcd:
+  nodeSelector:
+    jenkins-e2e-arm: "true"
+  metrics:
+    enabled: true
+    podMonitor:
+      enabled: true
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: "0.2"
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 4Gi
+  image:
+    registry: "harbor-us-vdc.zilliz.cc"
+    repository: "milvusdb/etcd"
+  tolerations:
+  - effect: NoSchedule
+    key: jenkins-e2e-arm
+    operator: Exists
+image:
+  all:
+    pullPolicy: Always
+    repository: harbor.milvus.io/milvus/milvus
+    tag: PR-35402-20240812-402f716b5
+minio:
+  nodeSelector:
+    jenkins-e2e-arm: "true"
+  mode: standalone
+  image:
+    repository: "harbor-us-vdc.zilliz.cc/milvusdb/minio"
+  resources:
+    requests:
+      cpu: "0.2"
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 4Gi
+  tolerations:
+  - effect: NoSchedule
+    key: jenkins-e2e-arm
+    operator: Exists
+pulsarv3:
+  enabled: false
+tolerations:
+- effect: NoSchedule
+  key: jenkins-e2e-arm
+  operator: Exists


### PR DESCRIPTION
pr: #52192

## Summary

- Add AMD standalone woodpecker embedded Helm values
- Add ARM standalone woodpecker embedded Helm values with ARM scheduling settings
- Keep CI index version overrides aligned with existing Helm values

issue: #51791
Related to #51748

## Test Plan

- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' tests/_helm/values/e2e-amd/standalone-wp-embed tests/_helm/values/e2e-arm/standalone-wp-embed
- ruby -e 'require "yaml"; ARGV.each do |f| outer=YAML.load_file(f); user=outer.dig("extraConfigFiles", "user.yaml"); inner=YAML.safe_load(user); dc=inner["dataCoord"] || {}; raise "bad #{f}" unless dc["targetVecIndexVersion"] == 10 && dc["forceRebuildScalarSegmentIndex"] == true && dc["targetScalarIndexVersion"] == 3; end; puts "index_versions_ok"' tests/_helm/values/e2e-amd/standalone-wp-embed tests/_helm/values/e2e-arm/standalone-wp-embed
- ruby -e 'require "yaml"; f="tests/_helm/values/e2e-arm/standalone-wp-embed"; outer=YAML.load_file(f); raise "top" unless outer.dig("nodeSelector", "jenkins-e2e-arm") == "true"; raise "etcd" unless outer.dig("etcd", "nodeSelector", "jenkins-e2e-arm") == "true"; raise "minio" unless outer.dig("minio", "nodeSelector", "jenkins-e2e-arm") == "true"; raise "top toleration" unless outer["tolerations"].any? { |t| t["key"] == "jenkins-e2e-arm" }; puts "arm_scheduling_ok"'
- diff -q tests/_helm/values/e2e-amd/standalone tests/_helm/values/e2e-amd/standalone-wp-embed
- diff -q tests/_helm/values/e2e-arm/standalone tests/_helm/values/e2e-arm/standalone-wp-embed
