### PR TITLE
enhance: make growing source HandleError idempotent

### DIFF
--- a/internal/flushcommon/syncmgr/growing_source.go
+++ b/internal/flushcommon/syncmgr/growing_source.go
@@ -400,6 +400,7 @@ type GrowingSourceSyncTask struct {
 
 	writeRetryOpts  []retry.Option
 	failureCallback func(error)
+	errorHandled    bool
 	tr              *timerecord.TimeRecorder
 }
 
@@ -593,6 +594,12 @@ func (t *GrowingSourceSyncTask) HandleError(err error) {
 	if errors.IsAny(err, merr.ErrSegmentNotFound, merr.ErrChannelNotFound) {
 		return
 	}
+	// Run's defer and syncManager.submit's handler both call HandleError for the
+	// same failure; keep the callback and the failure metric single-shot.
+	if t.errorHandled {
+		return
+	}
+	t.errorHandled = true
 	if t.failureCallback != nil {
 		t.failureCallback(err)
 	}

--- a/internal/flushcommon/syncmgr/growing_source_test.go
+++ b/internal/flushcommon/syncmgr/growing_source_test.go
@@ -145,6 +145,31 @@ func TestGrowingSourceSyncTaskHandleErrorSkipsFailureCallbackForStaleMetaErrors(
 	}
 }
 
+// GrowingSourceSyncTask.Run calls HandleError from its own defer and
+// syncManager.submit's handler calls it again for the same failure, so the
+// failure callback would otherwise run twice.
+func TestGrowingSourceSyncTaskHandleErrorIsIdempotent(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+	metrics.DataNodeFlushBufferCount.Reset()
+
+	callbackCount := 0
+	task := NewGrowingSourceSyncTask().
+		WithFailureCallback(func(error) {
+			callbackCount++
+		})
+
+	err := merr.WrapErrServiceInternalMsg("flush growing source data failed")
+	task.HandleError(err)
+	task.HandleError(err)
+
+	require.Equal(t, 1, callbackCount)
+	require.EqualValues(t, 1, testutil.ToFloat64(metrics.DataNodeFlushBufferCount.WithLabelValues(
+		paramtable.GetStringNodeID(),
+		metrics.FailLabel,
+		task.level.String(),
+	)))
+}
+
 func pkStatsAsOracle(stats *storage.PrimaryKeyStats) *storage.PkStatistics {
 	return &storage.PkStatistics{
 		PkFilter: stats.BF,


### PR DESCRIPTION
## What

`GrowingSourceSyncTask.HandleError` is invoked twice for a single failure:

- `GrowingSourceSyncTask.Run` calls it from its own defer
- `syncManager.submit` prepends a handler that calls it again (`sync_manager.go:164`), ahead of the writebuffer callback

So `failureCallback` runs twice and `DataNodeFlushBufferCount{status="fail"}` is incremented twice per failure. This PR makes both single-shot.

## Scope

**No behavior change today.** The failure callback wired for growing-source tasks is `wb.errHandler` (`write_buffer.go:1568`), whose default implementation panics (`options.go:48-51`), and no production code overrides it. That panic escapes `Run` before `keyLockDispatcher` reaches the callback list (`key_lock_dispatcher.go:178-181`), so the second `HandleError` call is never reached and the guard cannot fire. It takes effect once that callback stops panicking.

Deliberately **not** addressed here: that the panicking callback preempts the writebuffer recovery path (rollback of `SyncingRows`, failure counters, retry scheduling) — see #51854. Changing that is a behavior change and belongs in its own PR.

## Verification

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/syncmgr/` — ok, including the new `TestGrowingSourceSyncTaskHandleErrorIsIdempotent` (fails without the guard: callback count 2)
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/writebuffer/` — ok
- `golangci-lint run --build-tags dynamic,test ./internal/flushcommon/...` — 0 issues


issue: #51854