### PR TITLE
test: extend HNSW SQ index build timeout

### DIFF
--- a/tests/python_client/testcases/indexes/test_hnsw_sq.py
+++ b/tests/python_client/testcases/indexes/test_hnsw_sq.py
@@ -54,7 +54,7 @@ class TestHnswSQBuildParams(TestMilvusClientV2Base):
                               check_task=CheckTasks.err_res,
                               check_items=params.get("expected"))
         else:
-            self.create_index(client, collection_name, index_params)
+            self.create_index(client, collection_name, index_params, timeout=600)
             self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
 
             # load collection

--- a/tests/python_client/testcases/indexes/test_hnsw_sq.py
+++ b/tests/python_client/testcases/indexes/test_hnsw_sq.py
@@ -1,3 +1,4 @@
+# fmt: off
 import pytest
 from base.client_v2_base import TestMilvusClientV2Base
 from common import common_func as cf

--- a/tests/python_client/testcases/indexes/test_hnsw_sq.py
+++ b/tests/python_client/testcases/indexes/test_hnsw_sq.py
@@ -1,11 +1,10 @@
-import logging
-from utils.util_pymilvus import *
-from common.common_type import CaseLabel, CheckTasks
-from common import common_type as ct
-from common import common_func as cf
-from base.client_v2_base import TestMilvusClientV2Base
 import pytest
+from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
 from idx_hnsw_sq import HNSW_SQ
+from pymilvus import DataType
 
 index_type = "HNSW_SQ"
 success = "success"
@@ -13,6 +12,7 @@ pk_field_name = 'id'
 vector_field_name = 'vector'
 dim = ct.default_dim
 default_nb = ct.default_nb
+index_build_timeout = 600
 default_build_params = {"M": 16, "efConstruction": 200, "sq_type": "SQ8"}
 default_search_params = {"ef": 64, "refine_k": 1}
 
@@ -54,7 +54,7 @@ class TestHnswSQBuildParams(TestMilvusClientV2Base):
                               check_task=CheckTasks.err_res,
                               check_items=params.get("expected"))
         else:
-            self.create_index(client, collection_name, index_params, timeout=600)
+            self.create_index(client, collection_name, index_params, timeout=index_build_timeout)
             self.wait_for_index_ready(client, collection_name, index_name=vector_field_name)
 
             # load collection
@@ -126,7 +126,7 @@ class TestHnswSQBuildParams(TestMilvusClientV2Base):
             self.create_index(client, collection_name, index_params,
                               check_task=CheckTasks.err_res,
                               check_items={"err_code": 999,
-                                           "err_msg": f"can't build with this index HNSW_SQ: invalid parameter"})
+                                           "err_msg": "can't build with this index HNSW_SQ: invalid parameter"})
 
         else:
             self.create_index(client, collection_name, index_params)


### PR DESCRIPTION
### What changed

Set a named 600-second timeout on the successful create_index path in TestHnswSQBuildParams::test_hnsw_sq_build_params. Invalid-parameter cases keep the existing timeout and assertions. The touched legacy file was also brought through the repository changed-file Ruff gate by replacing its wildcard import with an explicit DataType import and applying Ruff-safe cleanup.

### Why

The client-v2 test helper supplies a 120-second default timeout to synchronous create_index. Under shared E2E index-slot pressure, valid HNSW-SQ builds can remain queued longer than 120 seconds, so create_index fails before the following readiness check can run. Jenkins dispatcher build 5047 showed the DataNode with no available index slot for about 467 seconds.

The scope is deliberately limited to the build-parameter case that produced the matching CI failures; sibling index suites are unchanged because no equivalent failure was observed for them. A genuine IndexState.Failed result still surfaces immediately, independent of the timeout. The tradeoff is that this functional test no longer treats a successful build taking less than 600 seconds as a performance failure.

### Reproduction

With the unmodified test and a local standalone constrained to one DataNode worker slot, 24 concurrent batches of the five CI-failed parameter cases produced 36 matching create_index / wait_for_creating_index 120-second timeouts. The complete reproduction count was 74 batches.

### Verification

- Same total_runs after the timeout change: 74/74 batches passed, covering 370/370 focused parameter executions under the same one-slot pressure.
- Normal configuration after restoring 16 slots: all 54 HNSW-SQ build-parameter cases passed in 54.13 seconds with reruns disabled.
- After the Ruff cleanup: all 54 cases passed again in 55.85 seconds.
- Ruff 0.15.11 and git diff --check passed.

This change does not reduce test data, parameter coverage, or concurrency.