### PR TITLE
test: extend struct array index build timeout

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_nullable.py
@@ -3749,7 +3749,7 @@ class TestMilvusClientStructArraySchemaEvolution(TestMilvusClientV2Base):
             metric_type=STRUCT_VECTOR_METRIC_TYPE,
             params=INDEX_PARAMS,
         )
-        res, _ = self.create_index(client, collection_name, index_params)
+        res, _ = self.create_index(client, collection_name, index_params, timeout=300)
 
         assert self.wait_for_index_ready(client, collection_name, VECTOR_FIELD, timeout=300)
         assert self.wait_for_index_ready(client, collection_name, STRUCT_VECTOR_FIELD, timeout=300)


### PR DESCRIPTION
## What changed

Set a 300-second timeout on the synchronous create_index call in TestMilvusClientStructArraySchemaEvolution::test_stress_nullable_struct_array_vector_field_query_search_iterators. This matches the two existing 300-second index-readiness allowances without changing rows, index parameters, query/search/iterator coverage, or assertions.

## Root cause

Under legitimate shared index-slot contention, the client-v2 helper default of 120 seconds is forwarded to synchronous index creation and its internal wait. The call can therefore time out while the index remains queued or building, before either explicit 300-second wait_for_index_ready check is reached.

## Reproduction

- Unfixed target invocations: 29 total while calibrating a valid local contention harness.
- Matching failures: 3/29; the exact calibrated pressure batch failed 3/3 with wait_for_creating_index Retry timeout: 120s.
- Milvus remained healthy and the blocker still had pending index work when the failures occurred.

## Verification

- Fixed target: 29/29 passed.
- Exact failure-mode pressure: 3/3 passed in 247.70-249.67 seconds, beyond the old 120-second limit and below the new 300-second limit.
- Remaining fixed invocations: 26/26 passed on the same totalSlots=1 server.
- Default configuration smoke: passed; DataNode slot metrics returned total=16, indexStatsUsed=0, available=16 after restoring the default.
- Ruff 0.15.11 check: passed.
- Ruff 0.15.11 format --check: passed.
- git diff --check: passed.