### PR TITLE
test: [3.0] pin CI scalar index version to 4 so JSON path index tests can run

### DIFF
--- a/tests/_helm/values/e2e-amd/distributed-pulsar
+++ b/tests/_helm/values/e2e-amd/distributed-pulsar
@@ -87,7 +87,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-amd/distributed-woodpecker-service-boundary
@@ -93,7 +93,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       enableCompaction: true
       compaction:
         enableAutoCompaction: false

--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -46,7 +46,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-amd/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-amd/standalone-kafka-mmap
@@ -42,7 +42,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-pulsar
+++ b/tests/_helm/values/e2e-arm/distributed-pulsar
@@ -74,7 +74,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
+++ b/tests/_helm/values/e2e-arm/distributed-woodpecker-service-boundary
@@ -80,7 +80,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       enableCompaction: true
       compaction:
         enableAutoCompaction: false

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -33,7 +33,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e-arm/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-arm/standalone-kafka-mmap
@@ -29,7 +29,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/distributed-pulsar
+++ b/tests/_helm/values/e2e/distributed-pulsar
@@ -87,7 +87,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -46,7 +46,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/e2e/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e/standalone-kafka-mmap
@@ -42,7 +42,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-kafka
+++ b/tests/_helm/values/nightly/distributed-kafka
@@ -88,7 +88,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-pulsar-mmap
+++ b/tests/_helm/values/nightly/distributed-pulsar-mmap
@@ -89,7 +89,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker
+++ b/tests/_helm/values/nightly/distributed-woodpecker
@@ -94,7 +94,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/distributed-woodpecker-service
+++ b/tests/_helm/values/nightly/distributed-woodpecker-service
@@ -100,7 +100,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         storageVersion:
           enabled: true

--- a/tests/_helm/values/nightly/standalone-authentication-mmap
+++ b/tests/_helm/values/nightly/standalone-authentication-mmap
@@ -39,7 +39,7 @@ extraConfigFiles:
     dataCoord:
       targetVecIndexVersion: 10
       forceRebuildScalarSegmentIndex: true
-      targetScalarIndexVersion: 3
+      targetScalarIndexVersion: 4
       compaction:
         bumpSchemaVersion:
           enabled: true


### PR DESCRIPTION
issue: #51858

## Problem

On 3.0, e2e `create_index` for `STL_SORT`/`BITMAP` JSON path indexes fails deterministically:

```
code=1100, JSON path index with STL_SORT requires scalar index engine version >= 4, current resolved version: 3
```

#51792 pinned the CI Helm values to `forceRebuildScalarSegmentIndex: true` + `targetScalarIndexVersion: 3`. With force-rebuild set, `ResolveScalarIndexVersion()` returns the target verbatim (3). But `STL_SORT`/`BITMAP` JSON path multi-type indexes require version **>= 4** (`common.MinScalarIndexVersionForJsonPathMultiType`, on 3.0 via #48953). So `create_index` (`internal/datacoord/index_service.go`) rejects those requests, failing `test_milvus_client_index.py` / `test_milvus_client_query.py` / `test_milvus_client_json_path_index.py` (and cascading files) on every 3.0 PR whose e2e test distribution runs them — e.g. #51839 (the current 3.0 tip), #51780, #51748, #51488.

## Fix

Bump `targetScalarIndexVersion: 3` → `4` in the 16 `tests/_helm/values/**` files #51792 touched. The node supports up to `MaximumScalarIndexEngineVersion = 4`, so 4 is a valid target; force-rebuild is preserved (now rebuilding to the max supported version) and the JSON-path-index requirement is met. master does not pin this value at all — this is a 3.0-only CI config fix, no product code changed.

## Verification

- `ResolveScalarIndexVersion()` with target=4 + forceRebuild=true returns 4 ≥ `MinScalarIndexVersionForJsonPathMultiType` (4) → `create_index` accepts STL_SORT/BITMAP JSON path indexes.
- All 16 values files parse as valid YAML after the change.
