### PR TITLE
fix: preserve object storage cancellation errors

### DIFF
--- a/internal/storage/azure_object_storage.go
+++ b/internal/storage/azure_object_storage.go
@@ -157,7 +157,7 @@ func (AzureObjectStorage *AzureObjectStorage) WalkWithObjects(ctx context.Contex
 		for pager.More() {
 			pageResp, err := pager.NextPage(ctx)
 			if err != nil {
-				return err
+				return mapObjectStorageError(prefix, err)
 			}
 			for _, blob := range pageResp.Segment.BlobItems {
 				if !walkFunc(&ChunkObjectInfo{FilePath: *blob.Name, ModifyTime: *blob.Properties.LastModified}) {
@@ -172,7 +172,7 @@ func (AzureObjectStorage *AzureObjectStorage) WalkWithObjects(ctx context.Contex
 		for pager.More() {
 			pageResp, err := pager.NextPage(ctx)
 			if err != nil {
-				return err
+				return mapObjectStorageError(prefix, err)
 			}
 
 			for _, blob := range pageResp.Segment.BlobItems {

--- a/internal/storage/minio_object_storage.go
+++ b/internal/storage/minio_object_storage.go
@@ -107,7 +107,7 @@ func (minioObjectStorage *MinioObjectStorage) WalkWithObjects(ctx context.Contex
 
 	for object := range in {
 		if object.Err != nil {
-			return object.Err
+			return mapObjectStorageError(prefix, object.Err)
 		}
 		if !walkFunc(&ChunkObjectInfo{FilePath: object.Key, ModifyTime: object.LastModified}) {
 			return nil

--- a/internal/storage/minio_object_storage_test.go
+++ b/internal/storage/minio_object_storage_test.go
@@ -21,11 +21,15 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -456,6 +460,56 @@ func listAllObjectsWithPrefixAtBucket(ctx context.Context, objectStorage ObjectS
 		return nil, nil, err
 	}
 	return dirs, mods, nil
+}
+
+func TestMinioObjectStorageWalkWithObjectsMapsErrors(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		statusCode int
+		code       string
+		expected   error
+	}{
+		{name: "access denied", statusCode: http.StatusForbidden, code: minioAccessDenied, expected: merr.ErrIoPermissionDenied},
+		{name: "bucket not found", statusCode: http.StatusNotFound, code: minioNoSuchBucket, expected: merr.ErrIoBucketNotFound},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/xml")
+				w.WriteHeader(test.statusCode)
+				fmt.Fprintf(w, "<Error><Code>%s</Code><Message>test error</Message></Error>", test.code)
+			}))
+			defer server.Close()
+
+			client, err := minio.New(strings.TrimPrefix(server.URL, "http://"), &minio.Options{
+				Creds:  credentials.NewStaticV4("access-key", "secret-key", ""),
+				Secure: false,
+			})
+			require.NoError(t, err)
+
+			storage := &MinioObjectStorage{Client: client}
+			err = storage.WalkWithObjects(context.Background(), "test-bucket", "test-prefix", true, func(*ChunkObjectInfo) bool {
+				return true
+			})
+			assert.ErrorIs(t, err, test.expected)
+		})
+	}
+
+	t.Run("canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		client, err := minio.New("127.0.0.1:1", &minio.Options{
+			Creds:  credentials.NewStaticV4("access-key", "secret-key", ""),
+			Secure: false,
+		})
+		require.NoError(t, err)
+
+		storage := &MinioObjectStorage{Client: client}
+		err = storage.WalkWithObjects(ctx, "test-bucket", "test-prefix", true, func(*ChunkObjectInfo) bool {
+			return true
+		})
+		assert.ErrorIs(t, err, context.Canceled)
+	})
 }
 
 func TestMapObjectStorageError_MinIO_NewErrors(t *testing.T) {

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -513,6 +513,12 @@ func mapObjectStorageError(fileName string, err error) error {
 		return err
 	}
 
+	// Preserve context termination so callers can stop retries and classify
+	// canceled operations correctly.
+	if merr.IsCanceledOrTimeout(err) {
+		return err
+	}
+
 	switch err := err.(type) {
 	case *azcore.ResponseError:
 		switch err.ErrorCode {

--- a/internal/storage/remote_chunk_manager_test.go
+++ b/internal/storage/remote_chunk_manager_test.go
@@ -31,10 +31,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/cockroachdb/errors"
 	"github.com/minio/minio-go/v7"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/googleapi"
 
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
@@ -1250,6 +1252,65 @@ func TestAzureChunkManager(t *testing.T) {
 	})
 }
 
+func TestRemoteChunkManagerCanceledMetrics(t *testing.T) {
+	mcm := &RemoteChunkManager{}
+
+	t.Run("get", func(t *testing.T) {
+		cancelCounter := metrics.PersistentDataOpCounter.WithLabelValues(metrics.DataGetLabel, metrics.CancelLabel)
+		failCounter := metrics.PersistentDataOpCounter.WithLabelValues(metrics.DataGetLabel, metrics.FailLabel)
+		cancelBefore := testutil.ToFloat64(cancelCounter)
+		failBefore := testutil.ToFloat64(failCounter)
+
+		mcm.client = &canceledObjectStorage{getErr: ToMilvusIoError("test/path", context.Canceled)}
+		_, err := mcm.getObject(context.Background(), "test-bucket", "test/path", 0, 0)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, cancelBefore+1, testutil.ToFloat64(cancelCounter))
+		assert.Equal(t, failBefore, testutil.ToFloat64(failCounter))
+	})
+
+	t.Run("put", func(t *testing.T) {
+		cancelCounter := metrics.PersistentDataOpCounter.WithLabelValues(metrics.DataPutLabel, metrics.CancelLabel)
+		failCounter := metrics.PersistentDataOpCounter.WithLabelValues(metrics.DataPutLabel, metrics.FailLabel)
+		cancelBefore := testutil.ToFloat64(cancelCounter)
+		failBefore := testutil.ToFloat64(failCounter)
+
+		mcm.client = &canceledObjectStorage{putErr: ToMilvusIoError("test/path", context.Canceled)}
+		err := mcm.putObject(context.Background(), "test-bucket", "test/path", nil, 0)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, cancelBefore+1, testutil.ToFloat64(cancelCounter))
+		assert.Equal(t, failBefore, testutil.ToFloat64(failCounter))
+	})
+}
+
+type canceledObjectStorage struct {
+	getErr error
+	putErr error
+}
+
+func (s *canceledObjectStorage) GetObject(context.Context, string, string, int64, int64) (FileReader, error) {
+	return nil, s.getErr
+}
+
+func (s *canceledObjectStorage) PutObject(context.Context, string, string, io.Reader, int64) error {
+	return s.putErr
+}
+
+func (*canceledObjectStorage) StatObject(context.Context, string, string) (int64, error) {
+	return 0, nil
+}
+
+func (*canceledObjectStorage) WalkWithObjects(context.Context, string, string, bool, ChunkObjectWalkFunc) error {
+	return nil
+}
+
+func (*canceledObjectStorage) RemoveObject(context.Context, string, string) error {
+	return nil
+}
+
+func (*canceledObjectStorage) CopyObject(context.Context, string, string, string) error {
+	return nil
+}
+
 func TestToMilvusIoError(t *testing.T) {
 	fileName := "test_file"
 
@@ -1272,6 +1333,28 @@ func TestToMilvusIoError(t *testing.T) {
 		err := ToMilvusIoError(fileName, errors.New("some error"))
 		assert.ErrorIs(t, err, merr.ErrIoFailed)
 	})
+
+	for _, test := range []struct {
+		name string
+		err  error
+		code int32
+	}{
+		{name: "context canceled", err: context.Canceled, code: merr.CanceledCode},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded, code: merr.TimeoutCode},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := ToMilvusIoError(fileName, test.err)
+			assert.ErrorIs(t, err, test.err)
+			assert.Equal(t, test.code, merr.Code(err))
+		})
+
+		t.Run("wrapped "+test.name, func(t *testing.T) {
+			cause := merr.Wrap(test.err, "object storage request failed")
+			err := ToMilvusIoError(fileName, cause)
+			assert.ErrorIs(t, err, test.err)
+			assert.Equal(t, test.code, merr.Code(err))
+		})
+	}
 
 	t.Run("minio NoSuchKey", func(t *testing.T) {
 		minioErr := minio.ErrorResponse{Code: "NoSuchKey"}


### PR DESCRIPTION
issue: #51852

## What this PR does

- preserves `context.Canceled` and `context.DeadlineExceeded` at the object-storage mapping boundary so `errors.Is` and the existing canceled/timeout status codes remain available to callers
- maps MinIO list-channel errors and both Azure list-pager error paths through `mapObjectStorageError`, matching the existing GCP listing behavior
- adds focused coverage for direct and wrapped context termination, cancellation metric classification, and representative MinIO LIST provider errors

## Why

`mapObjectStorageError` previously converted context termination to `ErrIoFailed` by copying only the message. That removed the cause chain, changed the status code to generic I/O failure, and caused canceled GET/PUT operations to be counted as failures. LIST/WALK was also inconsistent because MinIO and Azure returned raw SDK errors while other operations used Milvus I/O errors.

## Verification

Passed locally:

- `gofmt`
- `git diff --check`
- `go test -count=1 ./util/merr -run 'Test.*Code|Test.*Canceled|Test.*Timeout'` from `pkg/`

The focused `internal/storage` package tests require the Milvus native toolchain. I attempted the official builder path locally, but the repository-pinned builder tag was not yet published; the available amd64 fallback builder under Apple Silicon/Rosetta failed while linking oneTBB with `GNU make jobserver: Bad file descriptor`, including with a fully serial build. The focused storage tests are therefore left for the upstream native CI runner.
