### PR TITLE
fix: unblock delegator distribution removal after close

### DIFF
--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -213,6 +213,17 @@ func (d *distribution) PinReadableSegments(requiredLoadRatio float64, partitions
 	d.mut.RLock()
 	defer d.mut.RUnlock()
 
+	// Close() expires the current snapshot, so with no reader pinned its cleared
+	// channel is already closed. Pinning it afterwards would hand out a snapshot
+	// whose reader barrier is spent, and the next RemoveDistributions would let
+	// ReleaseSegments unload those segments while this reader is still fanning out
+	// to them. This check is atomic against Close(): the pin holds d.mut.RLock and
+	// Close holds d.mut.Lock, so either the pin wins and its inUse keeps the
+	// barrier up, or it observes closed here and gives up.
+	if d.closed.Load() {
+		return nil, nil, nil, -1, merr.WrapErrChannelNotAvailable(d.channelName, "channel distribution is closed")
+	}
+
 	requireFullResult := requiredLoadRatio >= 1.0
 	loadRatioSatisfy := d.queryView.GetLoadedRatio() >= requiredLoadRatio
 	var isServiceable bool

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -600,11 +600,17 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 	}
 
 	var signal chan struct{}
-	if d.closed.Load() {
-		signal = getClosedCh()
-	} else if current := d.current.Load(); current != nil {
+	if current := d.current.Load(); current != nil {
 		// Capture current snapshot's cleared channel. The next genSnapshot will
 		// create a new snapshot and expire this one, closing the channel.
+		//
+		// This holds after Close() too: Close() expires the current snapshot, so
+		// its cleared channel closes as soon as the last in-flight reader unpins
+		// it -- keeping the reader barrier this function documents, instead of
+		// short-circuiting to an already-closed channel and letting the caller
+		// release segments out from under a running QueryStream. genSnapshot()
+		// refuses to install a new snapshot once closed, so this channel is
+		// guaranteed to be reached by an Expire.
 		signal = current.cleared
 	} else {
 		signal = make(chan struct{})
@@ -629,6 +635,21 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 // in which, user could use found nodeID=>segmentID list.
 // mutex RLock is required before calling this method.
 func (d *distribution) genSnapshot() chan struct{} {
+	// Once closed, d.current must stay the expired snapshot installed by Close():
+	// RemoveDistributions hands that snapshot's cleared channel to callers as the
+	// reader barrier, and a fresh unexpired snapshot here would leave that channel
+	// forever open (the loop is stopping, so nothing would expire it) and
+	// reintroduce the post-close hang. Reachable from the snapshot loop -- an
+	// iteration that already took a notifier token can be parked on d.mut while
+	// Close() holds it -- and from AddGrowing/SyncTargetVersion/Flush, none of
+	// which are ordered against Close().
+	if d.closed.Load() {
+		if current := d.current.Load(); current != nil {
+			return current.cleared
+		}
+		return getClosedCh()
+	}
+
 	// stores last snapshot
 	// ok to be nil
 	last := d.current.Load()

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -599,10 +599,12 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 		delete(d.growingSegments, growing.SegmentID)
 	}
 
-	// Capture current snapshot's cleared channel. The next genSnapshot will
-	// create a new snapshot and expire this one, closing the channel.
 	var signal chan struct{}
-	if current := d.current.Load(); current != nil {
+	if d.closed.Load() {
+		signal = getClosedCh()
+	} else if current := d.current.Load(); current != nil {
+		// Capture current snapshot's cleared channel. The next genSnapshot will
+		// create a new snapshot and expire this one, closing the channel.
 		signal = current.cleared
 	} else {
 		signal = make(chan struct{})
@@ -816,7 +818,12 @@ func (d *distribution) Flush() {
 // Close stops the background snapshot loop and waits for it to exit.
 func (d *distribution) Close() {
 	d.closeOnce.Do(func() {
+		d.mut.Lock()
 		d.closed.Store(true)
+		if current := d.current.Load(); current != nil {
+			current.Expire(d.getCleanup(current.version))
+		}
+		d.mut.Unlock()
 		close(d.snapshotClose)
 	})
 	<-d.snapshotDone

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -521,7 +521,7 @@ func (s *DistributionSuite) TestRemoveDistributionsAfterCloseReturnsClosedSignal
 
 	ch := s.dist.RemoveDistributions([]SegmentEntry{{NodeID: 1, SegmentID: 1}}, nil)
 
-	timeout := time.NewTimer(100 * time.Millisecond)
+	timeout := time.NewTimer(time.Second)
 	defer timeout.Stop()
 	select {
 	case <-ch:
@@ -540,7 +540,7 @@ func (s *DistributionSuite) TestCloseClearsPendingRemoveDistributionSignal() {
 	ch := s.dist.RemoveDistributions([]SegmentEntry{{NodeID: 1, SegmentID: 1}}, nil)
 	s.dist.Close()
 
-	timeout := time.NewTimer(100 * time.Millisecond)
+	timeout := time.NewTimer(time.Second)
 	defer timeout.Stop()
 	select {
 	case <-ch:

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -591,6 +591,33 @@ func (s *DistributionSuite) TestRemoveDistributionsAfterCloseKeepsReaderBarrier(
 	}
 }
 
+// TestPinReadableSegmentsAfterCloseFails covers the opposite ordering of the test
+// above: Close() first, pin afterwards. Close() expires the current snapshot, so
+// with no reader pinned its cleared channel is already closed -- a late pin would
+// get a snapshot whose reader barrier is spent, and the next RemoveDistributions
+// would return that already-closed channel. QueryStream takes no delegator
+// lifetime, so it can still reach PinReadableSegments after Close().
+func (s *DistributionSuite) TestPinReadableSegmentsAfterCloseFails() {
+	s.dist.AddDistributions(SegmentEntry{
+		NodeID:      1,
+		SegmentID:   1,
+		PartitionID: 1,
+	})
+	// update target version, make distribution serviceable
+	s.dist.SyncTargetVersion(&querypb.SyncAction{
+		TargetVersion:         1000,
+		SealedSegmentRowCount: map[int64]int64{1: 100},
+	}, []int64{1})
+
+	// Serviceable on its own is not enough once the distribution is closed.
+	s.Require().True(s.dist.Serviceable())
+	s.dist.Close()
+
+	_, _, _, version, err := s.dist.PinReadableSegments(1.0, 1)
+	s.Error(err)
+	s.Equal(int64(-1), version)
+}
+
 func (s *DistributionSuite) TestPeek() {
 	type testCase struct {
 		tag      string
@@ -1568,6 +1595,17 @@ func (s *DistributionSuite) TestSyncTargetVersion_RedundantGrowingLogic() {
 	}
 }
 
+// stopSnapshotLoop stops the background snapshot goroutine without marking the
+// distribution closed. Tests that patch channelQueryView methods need the loop
+// quiescent, but PinReadableSegments refuses a closed distribution, so Close()
+// cannot serve that purpose. It shares closeOnce so a later Close() is a no-op.
+func stopSnapshotLoop(d *distribution) {
+	d.closeOnce.Do(func() {
+		close(d.snapshotClose)
+	})
+	<-d.snapshotDone
+}
+
 func TestPinReadableSegments(t *testing.T) {
 	// Helper function to create test distribution
 	setupDistribution := func() *distribution {
@@ -1585,7 +1623,7 @@ func TestPinReadableSegments(t *testing.T) {
 		// Flush pending snapshot and stop background goroutine to avoid
 		// data race with mockey patches in sub-tests.
 		dist.Flush()
-		dist.Close()
+		stopSnapshotLoop(dist)
 		return dist
 	}
 
@@ -1671,7 +1709,7 @@ func TestPinReadableSegments_ServiceableLogic(t *testing.T) {
 
 	// Stop background goroutine to avoid data race with mockey patches.
 	dist.Flush()
-	dist.Close()
+	stopSnapshotLoop(dist)
 
 	// Test case: requireFullResult=true, Serviceable=false, GetLoadedRatio=1.0
 	// This tests the case where load ratio is satisfied but serviceable is false
@@ -1707,7 +1745,7 @@ func TestPinReadableSegments_LoadRatioLogic(t *testing.T) {
 
 	// Stop background goroutine to avoid data race with mockey patches.
 	dist.Flush()
-	dist.Close()
+	stopSnapshotLoop(dist)
 
 	// Test case: requireFullResult=false, loadRatioSatisfy=false
 	// This tests the case where partial result is requested but load ratio is insufficient
@@ -1741,7 +1779,7 @@ func TestPinReadableSegments_EdgeCases(t *testing.T) {
 
 	// Stop background goroutine to avoid data race with mockey patches.
 	dist.Flush()
-	dist.Close()
+	stopSnapshotLoop(dist)
 
 	// Test case 1: requiredLoadRatio = 0.0 (edge case)
 	mockGetLoadedRatio := mockey.Mock((*channelQueryView).GetLoadedRatio).Return(0.0).Build()
@@ -1805,7 +1843,7 @@ func TestPinReadableSegments_PartialResultNotEmpty(t *testing.T) {
 
 	// Stop background goroutine to avoid data race with mockey patches.
 	dist.Flush()
-	dist.Close()
+	stopSnapshotLoop(dist)
 
 	// Call PinReadableSegments with partial result enabled (requiredLoadRatio < 1.0)
 	sealed, growing, _, _, err := dist.PinReadableSegments(0.8, 1)

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -511,6 +511,44 @@ func (s *DistributionSuite) TestRemoveDistribution() {
 	}
 }
 
+func (s *DistributionSuite) TestRemoveDistributionsAfterCloseReturnsClosedSignal() {
+	s.dist.AddDistributions(SegmentEntry{
+		NodeID:    1,
+		SegmentID: 1,
+	})
+	s.dist.Flush()
+	s.dist.Close()
+
+	ch := s.dist.RemoveDistributions([]SegmentEntry{{NodeID: 1, SegmentID: 1}}, nil)
+
+	timeout := time.NewTimer(100 * time.Millisecond)
+	defer timeout.Stop()
+	select {
+	case <-ch:
+	case <-timeout.C:
+		s.Fail("remove distribution signal not closed after distribution close")
+	}
+}
+
+func (s *DistributionSuite) TestCloseClearsPendingRemoveDistributionSignal() {
+	s.dist.AddDistributions(SegmentEntry{
+		NodeID:    1,
+		SegmentID: 1,
+	})
+	s.dist.Flush()
+
+	ch := s.dist.RemoveDistributions([]SegmentEntry{{NodeID: 1, SegmentID: 1}}, nil)
+	s.dist.Close()
+
+	timeout := time.NewTimer(100 * time.Millisecond)
+	defer timeout.Stop()
+	select {
+	case <-ch:
+	case <-timeout.C:
+		s.Fail("pending remove distribution signal not closed by distribution close")
+	}
+}
+
 func (s *DistributionSuite) TestPeek() {
 	type testCase struct {
 		tag      string

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -549,6 +549,48 @@ func (s *DistributionSuite) TestCloseClearsPendingRemoveDistributionSignal() {
 	}
 }
 
+// TestRemoveDistributionsAfterCloseKeepsReaderBarrier pins the barrier that
+// RemoveDistributions documents: the returned signal must not close while an
+// in-flight reader still holds the snapshot containing the removed segment, even
+// after Close(). Short-circuiting to an already-closed channel here would let
+// ReleaseSegments drop a segment out from under a running QueryStream, which
+// does not take the delegator lifetime and so is not drained by Close().
+func (s *DistributionSuite) TestRemoveDistributionsAfterCloseKeepsReaderBarrier() {
+	s.dist.AddDistributions(SegmentEntry{
+		NodeID:      1,
+		SegmentID:   1,
+		PartitionID: 1,
+	})
+	// update target version, make distribution serviceable
+	s.dist.SyncTargetVersion(&querypb.SyncAction{
+		TargetVersion:         1000,
+		SealedSegmentRowCount: map[int64]int64{1: 100},
+	}, []int64{1})
+
+	// An in-flight reader pins the snapshot that still contains segment 1.
+	_, _, _, version, err := s.dist.PinReadableSegments(1.0, 1)
+	s.Require().NoError(err)
+
+	s.dist.Close()
+
+	ch := s.dist.RemoveDistributions([]SegmentEntry{{NodeID: 1, SegmentID: 1}}, nil)
+
+	// The reader is still running, so the barrier must hold.
+	select {
+	case <-ch:
+		s.Fail("remove distribution signal closed while a reader still pinned the snapshot")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Once the reader finishes, the barrier lifts.
+	s.dist.Unpin(version)
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		s.Fail("remove distribution signal not closed after the last reader unpinned")
+	}
+}
+
 func (s *DistributionSuite) TestPeek() {
 	type testCase struct {
 		tag      string


### PR DESCRIPTION
issue: #51863

## What this PR changes

- Expires the current delegator distribution snapshot during Close so any RemoveDistributions caller that already captured the old cleared signal is unblocked.
- Returns an already-closed signal when RemoveDistributions observes a closed distribution, since the snapshot loop can no longer generate a new snapshot.
- Adds regressions for both orderings: removal after close, and close after removal captured the signal.

## Verification

- GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator -run 'TestDistributionSuite/TestRemoveDistributionsAfterCloseReturnsClosedSignal'
- GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator -run 'TestDistributionSuite/Test(RemoveDistributionsAfterCloseReturnsClosedSignal|CloseClearsPendingRemoveDistributionSignal)'
- GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator
- GOWORK=off PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig:/home/sheep/workspace/milvus/cmake_build/src:/home/sheep/workspace/milvus/cmake_build/thirdparty/milvus-storage LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:/home/sheep/workspace/milvus/cmake_build/lib make static-check
