### PR TITLE
fix: avoid duplicate schema-bump TextStats prefix

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -628,16 +628,6 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			return nil, err
 		}
 		if resultSegment.GetManifest() != "" && len(textStatsLogs) > 0 {
-			basePath, _, err := packed.UnmarshalManifestPath(resultSegment.GetManifest())
-			if err != nil {
-				return nil, err
-			}
-			for _, stats := range textStatsLogs {
-				prefix := fmt.Sprintf("%s/_stats/text_index.%d", basePath, stats.GetFieldID())
-				for i, f := range stats.GetFiles() {
-					stats.Files[i] = prefix + "/" + f
-				}
-			}
 			newManifest, err := packed.AddStatsToManifest(resultSegment.GetManifest(), t.compactionParams.StorageConfig, packed.TextIndexStatEntries(textStatsLogs, t.plan.GetCurrentScalarIndexVersion()))
 			if err != nil {
 				return nil, err

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"math"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -782,6 +783,11 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRebuildsTextStats(
 	segment := result.GetSegments()[0]
 	s.Contains(segment.GetTextStatsLogs(), int64(101))
 	s.EqualValues(42, segment.GetTextStatsLogs()[101].GetLogSize())
+	files := segment.GetTextStatsLogs()[101].GetFiles()
+	s.Require().NotEmpty(files)
+	for _, file := range files {
+		s.Equal(1, strings.Count(file, "_stats/text_index.101"))
+	}
 	s.Contains(segment.GetManifest(), "with-text-stats")
 }
 


### PR DESCRIPTION
issue: #51866

## What changed

- Stop schema-bump full rewrite from prefixing TextStats paths after `createTextIndex` has already built complete object paths.
- Extend the existing full-rewrite TextStats test to verify the field path prefix appears exactly once.

## Why

The duplicate prefix produces an invalid TextStats object path in the committed manifest. Source segment data is unaffected, but the rebuilt text-match stats cannot be read from that path.

## Test

```text
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datanode/compactor -run 'TestBumpSchemaVersionCompactionTaskSuite/TestFullRewriteRebuildsTextStats'
```
