### PR TITLE
fix: [3.0] avoid duplicate schema-bump TextStats prefix

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -617,16 +617,6 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			return nil, err
 		}
 		if resultSegment.GetManifest() != "" && len(textStatsLogs) > 0 {
-			basePath, _, err := packed.UnmarshalManifestPath(resultSegment.GetManifest())
-			if err != nil {
-				return nil, err
-			}
-			for _, stats := range textStatsLogs {
-				prefix := fmt.Sprintf("%s/_stats/text_index.%d", basePath, stats.GetFieldID())
-				for i, f := range stats.GetFiles() {
-					stats.Files[i] = prefix + "/" + f
-				}
-			}
 			newManifest, err := packed.AddStatsToManifest(resultSegment.GetManifest(), t.compactionParams.StorageConfig, packed.TextIndexStatEntries(textStatsLogs, t.plan.GetCurrentScalarIndexVersion()))
 			if err != nil {
 				return nil, err

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"math"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -745,6 +746,11 @@ func (s *BumpSchemaVersionCompactionTaskSuite) TestFullRewriteRebuildsTextStats(
 	segment := result.GetSegments()[0]
 	s.Contains(segment.GetTextStatsLogs(), int64(101))
 	s.EqualValues(42, segment.GetTextStatsLogs()[101].GetLogSize())
+	files := segment.GetTextStatsLogs()[101].GetFiles()
+	s.Require().NotEmpty(files)
+	for _, file := range files {
+		s.Equal(1, strings.Count(file, "_stats/text_index.101"))
+	}
 	s.Contains(segment.GetManifest(), "with-text-stats")
 }
 


### PR DESCRIPTION
issue: #51866
pr: #51867

## What changed

Backport the schema-bump TextStats path fix from master:

- Preserve the complete paths returned by `createTextIndex` instead of adding the same field prefix again.
- Verify each rebuilt TextStats path contains its field prefix exactly once.

## Test

```text
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datanode/compactor -run 'TestBumpSchemaVersionCompactionTaskSuite/TestFullRewriteRebuildsTextStats'
```
