### PR TITLE
fix: decode field stats centroids explicitly instead of relying on decoder merge

### DIFF
--- a/internal/storage/field_stats.go
+++ b/internal/storage/field_stats.go
@@ -171,10 +171,10 @@ func (stats *FieldStats) UnmarshalJSON(data []byte) error {
 			}
 			stats.BF = bf
 		}
-	} else {
-		stats.initCentroids(data, stats.Type)
-		err = json.Unmarshal(*messageMap["centroids"], &stats.Centroids)
-		if err != nil {
+	} else if value, ok := messageMap["centroids"]; ok && value != nil {
+		// Guarded: an unsupported/vector-less type reaches this branch too, and
+		// dereferencing a missing "centroids" key used to panic.
+		if err := stats.unmarshalCentroids(*value, stats.Type); err != nil {
 			return err
 		}
 	}
@@ -182,28 +182,43 @@ func (stats *FieldStats) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (stats *FieldStats) initCentroids(data []byte, dataType schemapb.DataType) {
-	type FieldStatsAux struct {
-		FieldID   int64                            `json:"fieldID"`
-		Type      schemapb.DataType                `json:"type"`
-		Max       json.RawMessage                  `json:"max"`
-		Min       json.RawMessage                  `json:"min"`
-		BF        bloomfilter.BloomFilterInterface `json:"bf"`
-		Centroids []json.RawMessage                `json:"centroids"`
+// unmarshalCentroids decodes the centroid array into concrete VectorFieldValue
+// implementations chosen by dataType.
+//
+// It decodes each centroid explicitly instead of pre-allocating concrete values into
+// the interface slice and letting the decoder reuse them. That older trick depended on
+// the decoder's merge-into-existing-value behaviour, which is NOT portable: this
+// package decodes with `internal/json` (bytedance/sonic), and sonic rejects `null` into
+// a non-empty interface where encoding/json silently leaves it nil. A vector FieldStats
+// always serializes `"bf":null`, so the helper's auxiliary struct — which declared a
+// `bloomfilter.BloomFilterInterface` field it never even read — failed on every vector
+// field, swallowed the error, pre-allocated nothing, and left the real decode below to
+// fail with a misleading "cannot unmarshal into VectorFieldValue". Partition stats with
+// centroids then never loaded, and loadPartitionStats only logs that.
+func (stats *FieldStats) unmarshalCentroids(data json.RawMessage, dataType schemapb.DataType) error {
+	var rawCentroids []json.RawMessage
+	if err := json.Unmarshal(data, &rawCentroids); err != nil {
+		return err
 	}
-	// Unmarshal JSON into the auxiliary struct
-	var aux FieldStatsAux
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return
-	}
-	for i := 0; i < len(aux.Centroids); i++ {
+
+	centroids := make([]VectorFieldValue, 0, len(rawCentroids))
+	for _, rawCentroid := range rawCentroids {
 		switch dataType {
 		case schemapb.DataType_FloatVector:
-			stats.Centroids = append(stats.Centroids, &FloatVectorFieldValue{})
+			centroid := &FloatVectorFieldValue{}
+			if err := json.Unmarshal(rawCentroid, centroid); err != nil {
+				return err
+			}
+			centroids = append(centroids, centroid)
 		default:
-			// other vector datatype
+			// Fail loudly rather than dropping the centroids: a silently empty
+			// snapshot degrades segment pruning to a full scan with no signal.
+			return merr.WrapErrServiceInternalMsg("unsupported data type %s for field stats centroids", dataType.String())
 		}
 	}
+
+	stats.Centroids = centroids
+	return nil
 }
 
 func (stats *FieldStats) UpdateByMsgs(msgs FieldData) {

--- a/internal/storage/field_stats.go
+++ b/internal/storage/field_stats.go
@@ -204,22 +204,23 @@ func (stats *FieldStats) UnmarshalJSON(data []byte) error {
 func (stats *FieldStats) unmarshalCentroids(data json.RawMessage, dataType schemapb.DataType) error {
 	var rawCentroids []json.RawMessage
 	if err := json.Unmarshal(data, &rawCentroids); err != nil {
-		return err
+		return merr.WrapErrDataIntegrity(err, "field stats of field %d has a malformed centroids array", stats.FieldID)
 	}
 
 	centroids := make([]VectorFieldValue, 0, len(rawCentroids))
-	for _, rawCentroid := range rawCentroids {
+	for i, rawCentroid := range rawCentroids {
 		switch dataType {
 		case schemapb.DataType_FloatVector:
 			centroid := &FloatVectorFieldValue{}
 			if err := json.Unmarshal(rawCentroid, centroid); err != nil {
-				return err
+				return merr.WrapErrDataIntegrity(err, "field stats of field %d has a malformed centroid at index %d", stats.FieldID, i)
 			}
 			centroids = append(centroids, centroid)
 		default:
 			// Fail loudly rather than dropping the centroids: a silently empty
 			// snapshot degrades segment pruning to a full scan with no signal.
-			return merr.WrapErrServiceInternalMsg("unsupported data type %s for field stats centroids", dataType.String())
+			return merr.WrapErrDataIntegrityMsg("field stats of field %d has centroids for unsupported data type %s",
+				stats.FieldID, dataType.String())
 		}
 	}
 

--- a/internal/storage/field_stats.go
+++ b/internal/storage/field_stats.go
@@ -171,30 +171,36 @@ func (stats *FieldStats) UnmarshalJSON(data []byte) error {
 			}
 			stats.BF = bf
 		}
-	} else if value, ok := messageMap["centroids"]; ok && value != nil {
-		// Guarded: an unsupported/vector-less type reaches this branch too, and
-		// dereferencing a missing "centroids" key used to panic.
-		if err := stats.unmarshalCentroids(*value, stats.Type); err != nil {
-			return err
+	} else {
+		// "centroids" carries no omitempty, so a snapshot Milvus wrote always has the
+		// key, null when there is nothing to store. Types without centroid support also
+		// reach this branch, so only a float vector may read a missing key as corruption.
+		value, ok := messageMap["centroids"]
+		switch {
+		case value != nil:
+			if err := stats.unmarshalCentroids(*value, stats.Type); err != nil {
+				return err
+			}
+		case !ok && stats.Type == schemapb.DataType_FloatVector:
+			// Accepting this silently hands segment pruning an empty centroid set,
+			// which degrades to a full scan with no signal.
+			return merr.WrapErrDataIntegrityMsg("field stats of field %d has no centroids key", stats.FieldID)
 		}
 	}
 
 	return nil
 }
 
-// unmarshalCentroids decodes the centroid array into concrete VectorFieldValue
-// implementations chosen by dataType.
+// unmarshalCentroids decodes the centroid array into the concrete VectorFieldValue
+// implementation chosen by dataType.
 //
-// It decodes each centroid explicitly instead of pre-allocating concrete values into
-// the interface slice and letting the decoder reuse them. That older trick depended on
-// the decoder's merge-into-existing-value behaviour, which is NOT portable: this
-// package decodes with `internal/json` (bytedance/sonic), and sonic rejects `null` into
-// a non-empty interface where encoding/json silently leaves it nil. A vector FieldStats
-// always serializes `"bf":null`, so the helper's auxiliary struct — which declared a
-// `bloomfilter.BloomFilterInterface` field it never even read — failed on every vector
-// field, swallowed the error, pre-allocated nothing, and left the real decode below to
-// fail with a misleading "cannot unmarshal into VectorFieldValue". Partition stats with
-// centroids then never loaded, and loadPartitionStats only logs that.
+// Each centroid is decoded explicitly rather than pre-allocating concrete values into
+// the interface slice and letting the decoder fill them in place. That older trick
+// needed a pre-pass over the whole blob, which sonic's arm64 decoder aborts: it rejects
+// null into an interface whose method set carries UnmarshalJSON, and a vector field
+// always serializes "bf" as null. Nothing got pre-allocated, so partition stats with
+// centroids failed to load on arm64 and pruning silently fell back to a full scan
+// (#51869).
 func (stats *FieldStats) unmarshalCentroids(data json.RawMessage, dataType schemapb.DataType) error {
 	var rawCentroids []json.RawMessage
 	if err := json.Unmarshal(data, &rawCentroids); err != nil {

--- a/internal/storage/field_stats_test.go
+++ b/internal/storage/field_stats_test.go
@@ -17,6 +17,7 @@
 package storage
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -691,10 +692,8 @@ func TestVectorFieldStatsMarshal(t *testing.T) {
 
 	stats2, err := NewFieldStats(1, schemapb.DataType_FloatVector, 1)
 	assert.NoError(t, err)
-	// The error MUST be asserted: dropping it here is why the centroid decode stayed
-	// broken for so long — sonic reported a failure while still filling the slice, so
-	// the assertions below passed and only loadPartitionStats (which checks the error)
-	// ever saw it.
+	// Assert the error: sonic reported a failure while still filling the slice, so
+	// discarding it here kept the assertions below green while the decode was broken.
 	assert.NoError(t, stats2.UnmarshalJSON(bytes))
 	assert.Equal(t, 1, len(stats2.Centroids))
 	assert.ElementsMatch(t, []VectorFieldValue{centroid}, stats2.Centroids)
@@ -714,11 +713,10 @@ func TestVectorFieldStatsMarshal(t *testing.T) {
 	assert.ElementsMatch(t, []VectorFieldValue{centroid, centroid2}, stats4.Centroids)
 }
 
-// TestVectorFieldStatsDecodeIntoZeroValue covers the path the production code actually
-// takes: a PartitionStatsSnapshot decodes into ZERO-VALUE FieldStats elements inside a
-// slice, with nothing pre-allocated. TestVectorFieldStatsMarshal above missed the bug
-// because it decoded into a FieldStats the test had constructed itself AND discarded
-// the error.
+// TestVectorFieldStatsDecodeIntoZeroValue covers the path production actually takes: a
+// PartitionStatsSnapshot decodes into zero-value FieldStats elements inside a slice,
+// with nothing pre-allocated. TestVectorFieldStatsMarshal missed the bug because it
+// decoded into a FieldStats the test had constructed itself.
 func TestVectorFieldStatsDecodeIntoZeroValue(t *testing.T) {
 	centroid := NewFloatVectorFieldValue([]float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0})
 	centroid2 := NewFloatVectorFieldValue([]float32{9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0})
@@ -752,13 +750,38 @@ func TestVectorFieldStatsDecodeIntoZeroValue(t *testing.T) {
 			got.SegmentStats[1].FieldStats[0].Centroids)
 	})
 
-	t.Run("missing centroids key does not panic", func(t *testing.T) {
+	t.Run("explicit null centroids decodes as empty", func(t *testing.T) {
 		var decoded FieldStats
-		assert.NotPanics(t, func() {
-			err := decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101}`))
-			assert.NoError(t, err)
-		})
+		assert.NoError(t, decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101,"centroids":null}`)))
 		assert.Empty(t, decoded.Centroids)
+	})
+
+	t.Run("missing centroids key is a data integrity error", func(t *testing.T) {
+		var decoded FieldStats
+		var err error
+		// Used to nil-panic on the unguarded deref; a missing key must now be reported
+		// rather than silently yielding an empty centroid set.
+		assert.NotPanics(t, func() {
+			err = decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101}`))
+		})
+		assert.ErrorIs(t, err, merr.ErrDataIntegrity)
+	})
+
+	t.Run("unsupported vector type is rejected", func(t *testing.T) {
+		blob := fmt.Sprintf(`{"fieldID":3,"type":%d,"centroids":[{"value":[1.0,2.0]}]}`,
+			int32(schemapb.DataType_BinaryVector))
+		var decoded FieldStats
+		assert.Error(t, decoded.UnmarshalJSON([]byte(blob)))
+	})
+
+	t.Run("malformed centroid propagates the decode error", func(t *testing.T) {
+		var decoded FieldStats
+		assert.Error(t, decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101,"centroids":[{"value":"nope"}]}`)))
+	})
+
+	t.Run("malformed centroid array propagates the decode error", func(t *testing.T) {
+		var decoded FieldStats
+		assert.Error(t, decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101,"centroids":{"not":"an array"}}`)))
 	})
 }
 

--- a/internal/storage/field_stats_test.go
+++ b/internal/storage/field_stats_test.go
@@ -691,7 +691,11 @@ func TestVectorFieldStatsMarshal(t *testing.T) {
 
 	stats2, err := NewFieldStats(1, schemapb.DataType_FloatVector, 1)
 	assert.NoError(t, err)
-	stats2.UnmarshalJSON(bytes)
+	// The error MUST be asserted: dropping it here is why the centroid decode stayed
+	// broken for so long — sonic reported a failure while still filling the slice, so
+	// the assertions below passed and only loadPartitionStats (which checks the error)
+	// ever saw it.
+	assert.NoError(t, stats2.UnmarshalJSON(bytes))
 	assert.Equal(t, 1, len(stats2.Centroids))
 	assert.ElementsMatch(t, []VectorFieldValue{centroid}, stats2.Centroids)
 
@@ -705,9 +709,57 @@ func TestVectorFieldStatsMarshal(t *testing.T) {
 
 	stats4, err := NewFieldStats(1, schemapb.DataType_FloatVector, 2)
 	assert.NoError(t, err)
-	stats4.UnmarshalJSON(bytes2)
+	assert.NoError(t, stats4.UnmarshalJSON(bytes2))
 	assert.Equal(t, 2, len(stats4.Centroids))
 	assert.ElementsMatch(t, []VectorFieldValue{centroid, centroid2}, stats4.Centroids)
+}
+
+// TestVectorFieldStatsDecodeIntoZeroValue covers the path the production code actually
+// takes: a PartitionStatsSnapshot decodes into ZERO-VALUE FieldStats elements inside a
+// slice, with nothing pre-allocated. TestVectorFieldStatsMarshal above missed the bug
+// because it decoded into a FieldStats the test had constructed itself AND discarded
+// the error.
+func TestVectorFieldStatsDecodeIntoZeroValue(t *testing.T) {
+	centroid := NewFloatVectorFieldValue([]float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0})
+	centroid2 := NewFloatVectorFieldValue([]float32{9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0})
+
+	stats, err := NewFieldStats(3, schemapb.DataType_FloatVector, 2)
+	assert.NoError(t, err)
+	stats.SetVectorCentroids(centroid, centroid2)
+
+	t.Run("through a slice of zero-value FieldStats", func(t *testing.T) {
+		blob, err := json.Marshal([]FieldStats{*stats})
+		assert.NoError(t, err)
+
+		var decoded []FieldStats
+		assert.NoError(t, json.Unmarshal(blob, &decoded))
+		assert.Len(t, decoded, 1)
+		assert.ElementsMatch(t, []VectorFieldValue{centroid, centroid2}, decoded[0].Centroids)
+	})
+
+	t.Run("through a PartitionStatsSnapshot", func(t *testing.T) {
+		snapshot := &PartitionStatsSnapshot{
+			SegmentStats: map[UniqueID]SegmentStats{
+				1: *NewSegmentStats([]FieldStats{*stats}, 1990),
+			},
+		}
+		blob, err := SerializePartitionStatsSnapshot(snapshot)
+		assert.NoError(t, err)
+
+		got, err := DeserializePartitionsStatsSnapshot(blob)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, []VectorFieldValue{centroid, centroid2},
+			got.SegmentStats[1].FieldStats[0].Centroids)
+	})
+
+	t.Run("missing centroids key does not panic", func(t *testing.T) {
+		var decoded FieldStats
+		assert.NotPanics(t, func() {
+			err := decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101}`))
+			assert.NoError(t, err)
+		})
+		assert.Empty(t, decoded.Centroids)
+	})
 }
 
 func TestFindMaxVersion(t *testing.T) {

--- a/internal/storage/field_stats_test.go
+++ b/internal/storage/field_stats_test.go
@@ -767,21 +767,26 @@ func TestVectorFieldStatsDecodeIntoZeroValue(t *testing.T) {
 		assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 	})
 
+	// Everything below is the same failure in the caller's eyes: the stats buffer on
+	// disk does not match the expected shape. They must all carry ErrDataIntegrity so
+	// loadPartitionStats can classify them without string matching.
 	t.Run("unsupported vector type is rejected", func(t *testing.T) {
 		blob := fmt.Sprintf(`{"fieldID":3,"type":%d,"centroids":[{"value":[1.0,2.0]}]}`,
 			int32(schemapb.DataType_BinaryVector))
 		var decoded FieldStats
-		assert.Error(t, decoded.UnmarshalJSON([]byte(blob)))
+		assert.ErrorIs(t, decoded.UnmarshalJSON([]byte(blob)), merr.ErrDataIntegrity)
 	})
 
-	t.Run("malformed centroid propagates the decode error", func(t *testing.T) {
+	t.Run("malformed centroid is a data integrity error", func(t *testing.T) {
 		var decoded FieldStats
-		assert.Error(t, decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101,"centroids":[{"value":"nope"}]}`)))
+		err := decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101,"centroids":[{"value":"nope"}]}`))
+		assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 	})
 
-	t.Run("malformed centroid array propagates the decode error", func(t *testing.T) {
+	t.Run("malformed centroid array is a data integrity error", func(t *testing.T) {
 		var decoded FieldStats
-		assert.Error(t, decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101,"centroids":{"not":"an array"}}`)))
+		err := decoded.UnmarshalJSON([]byte(`{"fieldID":3,"type":101,"centroids":{"not":"an array"}}`))
+		assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 	})
 }
 


### PR DESCRIPTION
issue: #51869

## What

`FieldStats.Centroids` is `[]VectorFieldValue`, an interface slice JSON cannot allocate into. `UnmarshalJSON` worked around that by having `initCentroids` pre-allocate concrete `*FloatVectorFieldValue` values and letting the decoder merge into them.

That depends on merge-into-existing-value behavior, which is not portable. This package decodes with `internal/json` (**bytedance/sonic**), and sonic rejects `null` into an interface **whose method set carries `UnmarshalJSON`** — which `bloomfilter.BloomFilterInterface` does — where `encoding/json` silently leaves it nil:

```
STDLIB  null -> bloomfilter.BloomFilterInterface   err=<nil>
SONIC   null -> bloomfilter.BloomFilterInterface   err=json: cannot unmarshal  into Go value of type ...
```

A vector `FieldStats` always serializes `"bf":null`, and `initCentroids`' auxiliary struct declared a `bloomfilter.BloomFilterInterface` field it never read. So on every vector field: the auxiliary unmarshal failed on `bf` → `initCentroids` swallowed it with a bare `return` → nothing was pre-allocated → the real centroid decode failed with a misleading `cannot unmarshal into VectorFieldValue`.

Partition stats with centroids therefore never loaded. `loadPartitionStats` only logs that error and continues, so the delegator's `partitionStats` stayed empty and **segment pruning silently degraded to a full scan**.

## Platform: the optdec decoder path

sonic's `sonic.go` build tag admits both amd64 and arm64, but the two dispatch to **different decoder implementations**:

- `internal/decoder/api/decoder_arm64.go` → `optdec` — the only choice on arm64
- `internal/decoder/api/decoder_amd64.go` → `jitdec` by default, but `optdec` when `SONIC_USE_OPTDEC=1` (`internal/envs/decode.go`)

Only `optdec` rejects `null` into an `UnmarshalJSON`-bearing interface. So this hits **arm64 by default, and amd64 as well whenever optdec is enabled**. Milvus does not set `SONIC_USE_OPTDEC`, so amd64 deployments are unaffected in practice today — but the trigger is the decoder, not the architecture.

That matches the evidence: `TestLoadPartitionStats` asserts `len(Centroids) == 2` and has been green on master in ci-v2 (linux/amd64, default `jitdec`) all along, while failing on darwin/arm64.

So on **ARM deployments** partition stats with centroids never loaded and segment pruning silently ran as a full scan — invisible to CI.

## How

Decode each centroid explicitly into its concrete type — no reliance on decoder merge semantics. Alongside that, in the same block:

- stop swallowing the decode failure (it now propagates)
- reject unsupported vector types loudly instead of producing an empty snapshot
- classify every failure on this path as `ErrDataIntegrity` (1009). Malformed array, malformed centroid, unsupported type and missing key all mean "the stats buffer on disk does not match the expected shape", which is what [`error_handling_casebook.md`](docs/dev/error_handling_casebook.md) assigns to `ErrDataIntegrity`; `WrapErrDataIntegrity` is documented for exactly this case ("json unmarshal of stats buffer"). Inner errors go in the error argument, not the format string (Pattern 4), so the sonic cause stays in the chain
- replace the previously unconditional deref of `"centroids"` (which could nil-panic) with a check that distinguishes the two cases. The field carries no `omitempty`, so a snapshot Milvus wrote always has the key — `null` when there is nothing to store. An explicit `null` decodes as empty; a **missing** key on a float vector is reported as a data-integrity error, because accepting it silently hands `FilterSegmentsByVector` an empty centroid set, which it treats as "search this segment" without logging — the same silent full-scan degradation this PR is fixing. Types without centroid support are still free to omit the key.

## Why existing tests missed it

`TestVectorFieldStatsMarshal` covers this path but stayed green for two reasons: it discarded the `UnmarshalJSON` error return (sonic fills the slice while still reporting failure), and it decoded into a `FieldStats` the test constructed itself rather than the zero-value elements production decodes into.

Both are fixed: the error is asserted, and `TestVectorFieldStatsDecodeIntoZeroValue` covers the shapes production actually uses — zero-value `FieldStats` inside a slice and a full `PartitionStatsSnapshot` round trip — plus every error path this change introduces: explicit `null`, missing key, unsupported vector type, malformed centroid, malformed centroid array — the last three asserting `errors.Is(err, merr.ErrDataIntegrity)` rather than just `Error()`.

## Verification

Based on master (785ab5117c), darwin/arm64, go1.26.5.

| | before | after |
|---|---|---|
| `TestDelegatorDataSuite` (incl. `TestLoadPartitionStats`) | FAIL | ok |
| `internal/querynodev2/delegator` (package) | FAIL | ok |
| `internal/storage` centroid tests | passed for the wrong reason | ok |
| `golangci-lint` misspell (`locale: US`) | 1 issue | 0 issues |

Confirmed failing on unmodified master before the change, so this is not a regression from any in-flight PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzrY94C2vx4GmVGCfTp8D6
