### PR TITLE
enhance: export filesystem metrics on scrape instead of on task completion

### DIFF
--- a/cmd/roles/roles.go
+++ b/cmd/roles/roles.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/http/healthz"
+	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/internal/util/initcore"
@@ -70,6 +71,9 @@ func init() {
 	metrics.RegisterMetaMetrics(Registry.GoRegistry)
 	metrics.RegisterMsgStreamMetrics(Registry.GoRegistry)
 	metrics.RegisterStorageMetrics(Registry.GoRegistry)
+	// The storage layer's counters are read at scrape time; pkg/metrics is its
+	// own module and cannot import this cgo package, hence the callback.
+	metrics.SetFilesystemStatsFn(storagev2.CollectFilesystemStats)
 }
 
 // stopRocksmqIfUsed closes the RocksMQ if it is used.

--- a/internal/datanode/compactor/executor.go
+++ b/internal/datanode/compactor/executor.go
@@ -158,11 +158,8 @@ func (e *executor) completeTask(planID int64, result *datapb.CompactionPlanResul
 
 		task.compactor.Complete()
 
-		// Publish filesystem metrics after compaction task completion
-		storageConfig := task.compactor.GetStorageConfig()
-		if _, err := storagev2.PublishFilesystemMetricsWithConfig(storageConfig); err != nil {
-			mlog.Warn(context.TODO(), "failed to publish filesystem metrics", mlog.Err(err))
-		}
+		// Make this backend visible to the filesystem metrics scrape.
+		storagev2.RegisterFilesystemConfig(task.compactor.GetStorageConfig())
 		return
 	}
 

--- a/internal/datanode/index/scheduler.go
+++ b/internal/datanode/index/scheduler.go
@@ -288,11 +288,9 @@ func (sched *TaskScheduler) processTask(t Task) {
 		mlog.Debug(t.Ctx(), "process task completed", mlog.String("task", t.Name()))
 	}
 
-	// Publish filesystem metrics after index task completion
-	if indexTask != nil {
-		if indexTask.req != nil && indexTask.req.GetStorageConfig() != nil {
-			storagev2.PublishFilesystemMetricsWithConfig(indexTask.req.GetStorageConfig())
-		}
+	// Make this backend visible to the filesystem metrics scrape.
+	if indexTask != nil && indexTask.req != nil {
+		storagev2.RegisterFilesystemConfig(indexTask.req.GetStorageConfig())
 	}
 }
 

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -227,8 +227,9 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 	}
 	metrics.DataNodeFlushBufferCount.WithLabelValues(paramtable.GetStringNodeID(), metrics.SuccessLabel, t.level.String()).Inc()
 
-	// Publish filesystem metrics after sync task completion
-	storagev2.PublishFilesystemMetricsWithConfig(t.storageConfig)
+	// Make this backend visible to the filesystem metrics scrape. Registration
+	// is idempotent and does no cgo, so it is fine on the sync path.
+	storagev2.RegisterFilesystemConfig(t.storageConfig)
 
 	return nil
 }

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -38,7 +38,6 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/querynodev2/tasks"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/storagev2"
 	"github.com/milvus-io/milvus/internal/streamingnode/client/handler"
 	"github.com/milvus-io/milvus/internal/streamingnode/client/handler/registry"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
@@ -584,10 +583,6 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 
 	log.Info(ctx, "load segments done...",
 		mlog.Int64s("segments", lo.Map(loaded, func(s segments.Segment, _ int) int64 { return s.ID() })))
-
-	// Publish filesystem metrics after load task completion
-	// Use default filesystem (empty path) for load tasks
-	storagev2.PublishDefaultFilesystemMetrics()
 
 	return merr.Success(), nil
 }

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -296,6 +297,12 @@ func defaultStorageConfig() *indexpb.StorageConfig {
 var (
 	knownFilesystemsMu sync.RWMutex
 	knownFilesystems   = make(map[string]*indexpb.StorageConfig)
+
+	// Set once the default backend has actually been registered. Not a
+	// sync.Once: paramtable may not be populated on the first scrape, and a
+	// Once would burn its single shot on that failure and never register at
+	// all.
+	defaultFilesystemRegistered atomic.Bool
 )
 
 // RegisterFilesystemConfig records a storage config so its filesystem is
@@ -333,7 +340,17 @@ func RegisterFilesystemConfig(storageConfig *indexpb.StorageConfig) {
 func CollectFilesystemStats() []metrics.FilesystemStats {
 	// The default backend is always of interest, but paramtable may not be
 	// populated at init time, so it is registered on first scrape instead.
-	RegisterFilesystemConfig(defaultStorageConfig())
+	// Skipped once registered, because building the config reads ~20
+	// paramtable values (each behind a lock) and this runs on the /metrics
+	// response path -- otherwise every scrape would pay for a config it then
+	// throws away.
+	if !defaultFilesystemRegistered.Load() {
+		storageConfig := defaultStorageConfig()
+		if GetFilesystemKeyFromStorageConfig(storageConfig) != "" {
+			RegisterFilesystemConfig(storageConfig)
+			defaultFilesystemRegistered.Store(true)
+		}
+	}
 
 	knownFilesystemsMu.RLock()
 	configs := make(map[string]*indexpb.StorageConfig, len(knownFilesystems))

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -29,6 +29,7 @@ import "C"
 import (
 	"context"
 	"strconv"
+	"sync"
 	"unsafe"
 
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -257,62 +258,109 @@ func GetFilesystemKeyFromStorageConfig(storageConfig *indexpb.StorageConfig) str
 	return address + "/" + bucketName
 }
 
-// PublishDefaultFilesystemMetrics retrieves and publishes metrics from the default filesystem.
-func PublishDefaultFilesystemMetrics() (*FilesystemMetrics, error) {
+// defaultStorageConfig builds the storage config of the process-wide default
+// filesystem, which is the one every role reads and writes through.
+func defaultStorageConfig() *indexpb.StorageConfig {
 	params := paramtable.Get()
-	var storageConfig *indexpb.StorageConfig
-
 	if params.CommonCfg.StorageType.GetValue() == "local" {
-		storageConfig = &indexpb.StorageConfig{
+		return &indexpb.StorageConfig{
 			RootPath:    params.LocalStorageCfg.Path.GetValue(),
 			StorageType: params.CommonCfg.StorageType.GetValue(),
 		}
-	} else {
-		storageConfig = &indexpb.StorageConfig{
-			Address:           params.MinioCfg.Address.GetValue(),
-			AccessKeyID:       params.MinioCfg.AccessKeyID.GetValue(),
-			SecretAccessKey:   params.MinioCfg.SecretAccessKey.GetValue(),
-			UseSSL:            params.MinioCfg.UseSSL.GetAsBool(),
-			SslCACert:         params.MinioCfg.SslCACert.GetValue(),
-			BucketName:        params.MinioCfg.BucketName.GetValue(),
-			RootPath:          params.MinioCfg.RootPath.GetValue(),
-			UseIAM:            params.MinioCfg.UseIAM.GetAsBool(),
-			IAMEndpoint:       params.MinioCfg.IAMEndpoint.GetValue(),
-			StorageType:       params.CommonCfg.StorageType.GetValue(),
-			Region:            params.MinioCfg.Region.GetValue(),
-			UseVirtualHost:    params.MinioCfg.UseVirtualHost.GetAsBool(),
-			CloudProvider:     params.MinioCfg.CloudProvider.GetValue(),
-			RequestTimeoutMs:  params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
-			GcpCredentialJSON: params.MinioCfg.GcpCredentialJSON.GetValue(),
-			SslTlsMinVersion:  params.MinioCfg.SslTLSMinVersion.GetValue(),
-			UseCrc32CChecksum: params.MinioCfg.UseCRC32C.GetAsBool(),
-		}
 	}
-	return PublishFilesystemMetricsWithConfig(storageConfig)
+	return &indexpb.StorageConfig{
+		Address:           params.MinioCfg.Address.GetValue(),
+		AccessKeyID:       params.MinioCfg.AccessKeyID.GetValue(),
+		SecretAccessKey:   params.MinioCfg.SecretAccessKey.GetValue(),
+		UseSSL:            params.MinioCfg.UseSSL.GetAsBool(),
+		SslCACert:         params.MinioCfg.SslCACert.GetValue(),
+		BucketName:        params.MinioCfg.BucketName.GetValue(),
+		RootPath:          params.MinioCfg.RootPath.GetValue(),
+		UseIAM:            params.MinioCfg.UseIAM.GetAsBool(),
+		IAMEndpoint:       params.MinioCfg.IAMEndpoint.GetValue(),
+		StorageType:       params.CommonCfg.StorageType.GetValue(),
+		Region:            params.MinioCfg.Region.GetValue(),
+		UseVirtualHost:    params.MinioCfg.UseVirtualHost.GetAsBool(),
+		CloudProvider:     params.MinioCfg.CloudProvider.GetValue(),
+		RequestTimeoutMs:  params.MinioCfg.RequestTimeoutMs.GetAsInt64(),
+		GcpCredentialJSON: params.MinioCfg.GcpCredentialJSON.GetValue(),
+		SslTlsMinVersion:  params.MinioCfg.SslTLSMinVersion.GetValue(),
+		UseCrc32CChecksum: params.MinioCfg.UseCRC32C.GetAsBool(),
+	}
 }
 
-// PublishFilesystemMetricsWithConfig retrieves and publishes filesystem metrics using storage config.
-func PublishFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*FilesystemMetrics, error) {
-	metricSnapshot, err := GetFilesystemMetricsWithConfig(storageConfig)
-	if err != nil {
-		mlog.Warn(context.TODO(), "failed to get filesystem metrics with config", mlog.Err(err))
-		return nil, err
-	}
+// Filesystems are created lazily and the storage layer offers no way to
+// enumerate them, so we remember every config we have been told about and read
+// each one at scrape time. Keyed by address+bucket, so the set stays as small
+// as the number of distinct backends.
+var (
+	knownFilesystemsMu sync.RWMutex
+	knownFilesystems   = make(map[string]*indexpb.StorageConfig)
+)
 
-	fsKey := GetFilesystemKeyFromStorageConfig(storageConfig)
-	if fsKey == "" {
-		fsKey = "default"
+// RegisterFilesystemConfig records a storage config so its filesystem is
+// included in the metrics scrape. Callers that write through a non-default
+// backend (sync tasks carry their own config) should call this once the config
+// is known; it is cheap enough for a hot path -- a map lookup, no cgo.
+func RegisterFilesystemConfig(storageConfig *indexpb.StorageConfig) {
+	if storageConfig == nil {
+		return
 	}
-	metrics.PublishFilesystemMetrics(
-		fsKey,
-		metricSnapshot.ReadCount,
-		metricSnapshot.WriteCount,
-		metricSnapshot.ReadBytes,
-		metricSnapshot.WriteBytes,
-		metricSnapshot.GetFileInfoCount,
-		metricSnapshot.FailedCount,
-		metricSnapshot.MultiPartUploadCreated,
-		metricSnapshot.MultiPartUploadFinished,
-	)
-	return metricSnapshot, nil
+	key := GetFilesystemKeyFromStorageConfig(storageConfig)
+	if key == "" {
+		return
+	}
+	knownFilesystemsMu.RLock()
+	_, ok := knownFilesystems[key]
+	knownFilesystemsMu.RUnlock()
+	if ok {
+		return
+	}
+	knownFilesystemsMu.Lock()
+	defer knownFilesystemsMu.Unlock()
+	if _, ok := knownFilesystems[key]; !ok {
+		knownFilesystems[key] = storageConfig
+	}
+}
+
+// CollectFilesystemStats reads the cumulative counters of every filesystem we
+// know about. It is installed as metrics.SetFilesystemStatsFn and therefore
+// runs once per scrape, on the /metrics request path: it must stay cheap (a
+// FilesystemCache lookup plus a few relaxed atomic loads per filesystem) and
+// must never fail loudly. Before the storage layer is initialized the lookup
+// errors out, which is a normal startup state, so it degrades to "no series"
+// at debug level rather than warning on every scrape.
+func CollectFilesystemStats() []metrics.FilesystemStats {
+	// The default backend is always of interest, but paramtable may not be
+	// populated at init time, so it is registered on first scrape instead.
+	RegisterFilesystemConfig(defaultStorageConfig())
+
+	knownFilesystemsMu.RLock()
+	configs := make(map[string]*indexpb.StorageConfig, len(knownFilesystems))
+	for k, v := range knownFilesystems {
+		configs[k] = v
+	}
+	knownFilesystemsMu.RUnlock()
+
+	stats := make([]metrics.FilesystemStats, 0, len(configs))
+	for key, storageConfig := range configs {
+		snapshot, err := GetFilesystemMetricsWithConfig(storageConfig)
+		if err != nil {
+			mlog.Debug(context.TODO(), "filesystem metrics unavailable",
+				mlog.String("filesystem", key), mlog.Err(err))
+			continue
+		}
+		stats = append(stats, metrics.FilesystemStats{
+			Key:                     key,
+			ReadCount:               snapshot.ReadCount,
+			WriteCount:              snapshot.WriteCount,
+			ReadBytes:               snapshot.ReadBytes,
+			WriteBytes:              snapshot.WriteBytes,
+			GetFileInfoCount:        snapshot.GetFileInfoCount,
+			FailedCount:             snapshot.FailedCount,
+			MultiPartUploadCreated:  snapshot.MultiPartUploadCreated,
+			MultiPartUploadFinished: snapshot.MultiPartUploadFinished,
+		})
+	}
+	return stats
 }

--- a/internal/storagev2/filesystem_metrics_test.go
+++ b/internal/storagev2/filesystem_metrics_test.go
@@ -19,6 +19,7 @@ package storagev2
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -202,8 +203,9 @@ func TestGetFilesystemMetricsWithConfig(t *testing.T) {
 	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
 }
 
-// TestPublishFilesystemMetricsWithLocalConfig tests PublishFilesystemMetricsWithConfig
-func TestPublishFilesystemMetricsWithLocalConfig(t *testing.T) {
+// A registered backend must show up in the scrape, with the same key the
+// metrics label uses.
+func TestRegisteredFilesystemIsCollected(t *testing.T) {
 	dir := t.TempDir()
 	pt := paramtable.Get()
 	pt.Save(pt.CommonCfg.StorageType.Key, "local")
@@ -221,65 +223,55 @@ func TestPublishFilesystemMetricsWithLocalConfig(t *testing.T) {
 		StorageType: "local",
 		RootPath:    dir,
 	}
-	metrics, err := PublishFilesystemMetricsWithConfig(localConfig)
-	if err != nil {
-		t.Skipf("Skipping CGO test: %v", err)
+	RegisterFilesystemConfig(localConfig)
+
+	stats := CollectFilesystemStats()
+	if len(stats) == 0 {
+		t.Skip("Skipping CGO test: storage layer not available")
 		return
 	}
-
-	require.NotNil(t, metrics, "Metrics should not be nil")
-	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
-	assert.GreaterOrEqual(t, metrics.WriteBytes, int64(0))
-	assert.GreaterOrEqual(t, metrics.GetFileInfoCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.MultiPartUploadCreated, int64(0))
-	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
+	for _, s := range stats {
+		assert.NotEmpty(t, s.Key)
+		assert.GreaterOrEqual(t, s.ReadCount, int64(0))
+		assert.GreaterOrEqual(t, s.ReadBytes, int64(0))
+		assert.GreaterOrEqual(t, s.WriteCount, int64(0))
+		assert.GreaterOrEqual(t, s.WriteBytes, int64(0))
+	}
 }
 
-// TestPublishFilesystemMetricsWithConfig tests PublishFilesystemMetricsWithConfig function
-func TestPublishFilesystemMetricsWithConfig(t *testing.T) {
-	// Set up local storage for testing
-	dir := t.TempDir()
-	pt := paramtable.Get()
-	pt.Save(pt.CommonCfg.StorageType.Key, "local")
-	pt.Save(pt.LocalStorageCfg.Path.Key, dir)
+// Registration is on hot paths (every sync/compaction task), so it must be
+// idempotent rather than growing the set on every call.
+func TestRegisterFilesystemConfigIsIdempotent(t *testing.T) {
+	cfg := &indexpb.StorageConfig{
+		Address:    "localhost:19530",
+		BucketName: "idempotent-bucket",
+	}
+	key := GetFilesystemKeyFromStorageConfig(cfg)
+	require.NotEmpty(t, key)
 
-	t.Cleanup(func() {
-		pt.Reset(pt.CommonCfg.StorageType.Key)
-		pt.Reset(pt.LocalStorageCfg.Path.Key)
-	})
-
-	// Initialize local arrow filesystem
-	err := initcore.InitLocalArrowFileSystem(dir)
-	require.NoError(t, err, "Failed to initialize local arrow filesystem")
-
-	// Test with local storage config
-	localConfig := &indexpb.StorageConfig{
-		StorageType: "local",
-		RootPath:    dir,
+	for i := 0; i < 10; i++ {
+		RegisterFilesystemConfig(cfg)
 	}
 
-	metrics, err := PublishFilesystemMetricsWithConfig(localConfig)
-	assert.NoError(t, err)
-
-	// Verify metrics struct is not nil
-	require.NotNil(t, metrics, "Metrics should not be nil")
-
-	// Verify all 8 metrics fields are present
-	assert.GreaterOrEqual(t, metrics.ReadCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.WriteCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.ReadBytes, int64(0))
-	assert.GreaterOrEqual(t, metrics.WriteBytes, int64(0))
-	assert.GreaterOrEqual(t, metrics.GetFileInfoCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.FailedCount, int64(0))
-	assert.GreaterOrEqual(t, metrics.MultiPartUploadCreated, int64(0))
-	assert.GreaterOrEqual(t, metrics.MultiPartUploadFinished, int64(0))
+	knownFilesystemsMu.RLock()
+	defer knownFilesystemsMu.RUnlock()
+	assert.Len(t, lo.Filter(lo.Keys(knownFilesystems), func(k string, _ int) bool {
+		return k == key
+	}), 1)
 }
 
-// TestPublishDefaultFilesystemMetrics tests PublishDefaultFilesystemMetrics function
-func TestPublishDefaultFilesystemMetrics(t *testing.T) {
+// A nil or keyless config must be ignored, not recorded under an empty key.
+func TestRegisterFilesystemConfigIgnoresUnusable(t *testing.T) {
+	RegisterFilesystemConfig(nil)
+
+	knownFilesystemsMu.RLock()
+	_, ok := knownFilesystems[""]
+	knownFilesystemsMu.RUnlock()
+	assert.False(t, ok)
+}
+
+// The default backend must be collected without explicit registration.
+func TestDefaultFilesystemIsCollected(t *testing.T) {
 	// Set up local storage for testing
 	dir := t.TempDir()
 	pt := paramtable.Get()
@@ -295,10 +287,10 @@ func TestPublishDefaultFilesystemMetrics(t *testing.T) {
 	err := initcore.InitLocalArrowFileSystem(dir)
 	require.NoError(t, err, "Failed to initialize local arrow filesystem")
 
-	// Test PublishDefaultFilesystemMetrics
-	metrics, err := PublishDefaultFilesystemMetrics()
-	assert.NoError(t, err)
-	assert.NotNil(t, metrics, "Metrics should not be nil")
+	// The default backend is registered lazily on first collection, so it must
+	// appear without anyone having called RegisterFilesystemConfig for it.
+	stats := CollectFilesystemStats()
+	assert.NotNil(t, stats)
 }
 
 // TestNilConfig tests error handling for nil config
@@ -306,8 +298,6 @@ func TestNilConfig(t *testing.T) {
 	_, err := GetFilesystemMetricsWithConfig(nil)
 	assert.Error(t, err)
 
-	_, err = PublishFilesystemMetricsWithConfig(nil)
-	assert.Error(t, err)
 }
 
 // TestGetFilesystemKeyFromStorageConfigEdgeCases tests edge cases for key generation

--- a/internal/storagev2/filesystem_metrics_test.go
+++ b/internal/storagev2/filesystem_metrics_test.go
@@ -225,11 +225,12 @@ func TestRegisteredFilesystemIsCollected(t *testing.T) {
 	}
 	RegisterFilesystemConfig(localConfig)
 
+	// Asserted, not skipped: InitLocalArrowFileSystem above already succeeded,
+	// so an empty result here means registration or collection is broken, not
+	// that the environment is unavailable. Skipping would hide exactly the
+	// regression this test exists to catch.
 	stats := CollectFilesystemStats()
-	if len(stats) == 0 {
-		t.Skip("Skipping CGO test: storage layer not available")
-		return
-	}
+	require.NotEmpty(t, stats, "registered backend did not show up in the scrape")
 	for _, s := range stats {
 		assert.NotEmpty(t, s.Key)
 		assert.GreaterOrEqual(t, s.ReadCount, int64(0))

--- a/pkg/metrics/persistent_store_metrics.go
+++ b/pkg/metrics/persistent_store_metrics.go
@@ -17,6 +17,8 @@
 package metrics
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -56,87 +58,6 @@ var (
 			Name:      "op_count",
 			Help:      "count of persistent data operation",
 		}, []string{persistentDataOpType, statusLabelName})
-
-	// Filesystem metrics (default filesystem only) - common across all nodes
-	FilesystemReadCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: "storage",
-			Name:      "filesystem_read_count",
-			Help:      "number of filesystem read operations",
-		}, []string{
-			filesystemKeyLabelName,
-		})
-
-	FilesystemWriteCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: "storage",
-			Name:      "filesystem_write_count",
-			Help:      "number of filesystem write operations",
-		}, []string{
-			filesystemKeyLabelName,
-		})
-
-	FilesystemReadBytes = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: "storage",
-			Name:      "filesystem_read_bytes",
-			Help:      "total bytes read from filesystem",
-		}, []string{
-			filesystemKeyLabelName,
-		})
-
-	FilesystemWriteBytes = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: "storage",
-			Name:      "filesystem_write_bytes",
-			Help:      "total bytes written to filesystem",
-		}, []string{
-			filesystemKeyLabelName,
-		})
-
-	FilesystemGetFileInfoCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: "storage",
-			Name:      "filesystem_get_file_info_count",
-			Help:      "number of get file info operations",
-		}, []string{
-			filesystemKeyLabelName,
-		})
-
-	FilesystemFailedCount = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: "storage",
-			Name:      "filesystem_failed_count",
-			Help:      "number of failed filesystem operations",
-		}, []string{
-			filesystemKeyLabelName,
-		})
-
-	FilesystemMultiPartUploadCreated = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: "storage",
-			Name:      "filesystem_multi_part_upload_created",
-			Help:      "number of multi-part uploads created",
-		}, []string{
-			filesystemKeyLabelName,
-		})
-
-	FilesystemMultiPartUploadFinished = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: "storage",
-			Name:      "filesystem_multi_part_upload_finished",
-			Help:      "number of multi-part uploads finished",
-		}, []string{
-			filesystemKeyLabelName,
-		})
 )
 
 // RegisterStorageMetrics registers storage metrics
@@ -145,29 +66,124 @@ func RegisterStorageMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(PersistentDataRequestLatency)
 	registry.MustRegister(PersistentDataOpCounter)
 
-	// filesystem metrics
-	registry.MustRegister(FilesystemReadCount)
-	registry.MustRegister(FilesystemWriteCount)
-	registry.MustRegister(FilesystemReadBytes)
-	registry.MustRegister(FilesystemWriteBytes)
-	registry.MustRegister(FilesystemGetFileInfoCount)
-	registry.MustRegister(FilesystemFailedCount)
-	registry.MustRegister(FilesystemMultiPartUploadCreated)
-	registry.MustRegister(FilesystemMultiPartUploadFinished)
+	registry.MustRegister(filesystemCollector)
 }
 
-// PublishFilesystemMetrics publishes filesystem metrics (common across all nodes)
-func PublishFilesystemMetrics(fs string, readCount, writeCount, readBytes, writeBytes, getFileInfoCount, failedCount, multiPartUploadCreated, multiPartUploadFinished int64) {
-	labels := prometheus.Labels{
-		filesystemKeyLabelName: fs,
-	}
+// FilesystemStats is one filesystem's cumulative counters as reported by the
+// storage layer. Every field is monotonic for the lifetime of the process, so
+// they are exported as counters. Counts are of real object-storage requests
+// (S3 GetObject/PutObject and their local-filesystem equivalents), not of
+// higher-level chunk or column reads -- one logical read may coalesce into
+// fewer requests, which is exactly what this is meant to make visible.
+type FilesystemStats struct {
+	Key                     string
+	ReadCount               int64
+	WriteCount              int64
+	ReadBytes               int64
+	WriteBytes              int64
+	GetFileInfoCount        int64
+	FailedCount             int64
+	MultiPartUploadCreated  int64
+	MultiPartUploadFinished int64
+}
 
-	FilesystemReadCount.With(labels).Set(float64(readCount))
-	FilesystemWriteCount.With(labels).Set(float64(writeCount))
-	FilesystemReadBytes.With(labels).Set(float64(readBytes))
-	FilesystemWriteBytes.With(labels).Set(float64(writeBytes))
-	FilesystemGetFileInfoCount.With(labels).Set(float64(getFileInfoCount))
-	FilesystemFailedCount.With(labels).Set(float64(failedCount))
-	FilesystemMultiPartUploadCreated.With(labels).Set(float64(multiPartUploadCreated))
-	FilesystemMultiPartUploadFinished.With(labels).Set(float64(multiPartUploadFinished))
+var (
+	filesystemLabels = []string{filesystemKeyLabelName}
+
+	filesystemReadCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, "storage", "filesystem_read_count"),
+		"number of object-storage read requests issued by the storage layer",
+		filesystemLabels, nil)
+	filesystemWriteCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, "storage", "filesystem_write_count"),
+		"number of object-storage write requests issued by the storage layer",
+		filesystemLabels, nil)
+	filesystemReadBytesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, "storage", "filesystem_read_bytes"),
+		"total bytes read from the storage layer",
+		filesystemLabels, nil)
+	filesystemWriteBytesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, "storage", "filesystem_write_bytes"),
+		"total bytes written to the storage layer",
+		filesystemLabels, nil)
+	filesystemGetFileInfoCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, "storage", "filesystem_get_file_info_count"),
+		"number of get file info operations",
+		filesystemLabels, nil)
+	filesystemFailedCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, "storage", "filesystem_failed_count"),
+		"number of failed storage layer operations",
+		filesystemLabels, nil)
+	filesystemMultiPartUploadCreatedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, "storage", "filesystem_multi_part_upload_created"),
+		"number of multi-part uploads created",
+		filesystemLabels, nil)
+	filesystemMultiPartUploadFinishedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, "storage", "filesystem_multi_part_upload_finished"),
+		"number of multi-part uploads finished",
+		filesystemLabels, nil)
+
+	filesystemCollector = &filesystemMetricsCollector{}
+
+	filesystemStatsMu sync.RWMutex
+	filesystemStatsFn func() []FilesystemStats
+)
+
+// SetFilesystemStatsFn installs the callback the collector uses to read the
+// storage layer's counters. It lives behind a callback because pkg/ is its own
+// module and cannot import the cgo storage package. Safe to call more than
+// once; passing nil disables collection.
+func SetFilesystemStatsFn(fn func() []FilesystemStats) {
+	filesystemStatsMu.Lock()
+	defer filesystemStatsMu.Unlock()
+	filesystemStatsFn = fn
+}
+
+// filesystemMetricsCollector exports the storage layer's counters using the
+// pull model: the values are read at scrape time rather than pushed on some
+// unrelated event. The push version only ran after a LoadSegments RPC, which
+// froze every series at whatever the totals were when the last load finished
+// and left roles that never load segments with no series at all.
+type filesystemMetricsCollector struct{}
+
+func (c *filesystemMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- filesystemReadCountDesc
+	ch <- filesystemWriteCountDesc
+	ch <- filesystemReadBytesDesc
+	ch <- filesystemWriteBytesDesc
+	ch <- filesystemGetFileInfoCountDesc
+	ch <- filesystemFailedCountDesc
+	ch <- filesystemMultiPartUploadCreatedDesc
+	ch <- filesystemMultiPartUploadFinishedDesc
+}
+
+func (c *filesystemMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, s := range collectFilesystemStats() {
+		ch <- prometheus.MustNewConstMetric(filesystemReadCountDesc, prometheus.CounterValue, float64(s.ReadCount), s.Key)
+		ch <- prometheus.MustNewConstMetric(filesystemWriteCountDesc, prometheus.CounterValue, float64(s.WriteCount), s.Key)
+		ch <- prometheus.MustNewConstMetric(filesystemReadBytesDesc, prometheus.CounterValue, float64(s.ReadBytes), s.Key)
+		ch <- prometheus.MustNewConstMetric(filesystemWriteBytesDesc, prometheus.CounterValue, float64(s.WriteBytes), s.Key)
+		ch <- prometheus.MustNewConstMetric(filesystemGetFileInfoCountDesc, prometheus.CounterValue, float64(s.GetFileInfoCount), s.Key)
+		ch <- prometheus.MustNewConstMetric(filesystemFailedCountDesc, prometheus.CounterValue, float64(s.FailedCount), s.Key)
+		ch <- prometheus.MustNewConstMetric(filesystemMultiPartUploadCreatedDesc, prometheus.CounterValue, float64(s.MultiPartUploadCreated), s.Key)
+		ch <- prometheus.MustNewConstMetric(filesystemMultiPartUploadFinishedDesc, prometheus.CounterValue, float64(s.MultiPartUploadFinished), s.Key)
+	}
+}
+
+// collectFilesystemStats calls the installed callback, which crosses cgo into
+// the storage layer. A failure or panic there must degrade to "no series this
+// scrape" rather than take down the whole /metrics endpoint.
+func collectFilesystemStats() (stats []FilesystemStats) {
+	filesystemStatsMu.RLock()
+	fn := filesystemStatsFn
+	filesystemStatsMu.RUnlock()
+	if fn == nil {
+		return nil
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			stats = nil
+		}
+	}()
+	return fn()
 }

--- a/pkg/metrics/persistent_store_metrics_test.go
+++ b/pkg/metrics/persistent_store_metrics_test.go
@@ -17,101 +17,77 @@
 package metrics
 
 import (
+	"strings"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPublishFilesystemMetrics(t *testing.T) {
-	// Test values
-	fsName := "test-filesystem"
-	readCount := int64(100)
-	writeCount := int64(50)
-	readBytes := int64(1024000)
-	writeBytes := int64(512000)
-	getFileInfoCount := int64(200)
-	failedCount := int64(5)
-	multiPartUploadCreated := int64(10)
-	multiPartUploadFinished := int64(8)
+func TestFilesystemCollectorExportsCounters(t *testing.T) {
+	t.Cleanup(func() { SetFilesystemStatsFn(nil) })
 
-	// Call the function
-	PublishFilesystemMetrics(fsName, readCount, writeCount, readBytes, writeBytes,
-		getFileInfoCount, failedCount, multiPartUploadCreated, multiPartUploadFinished)
+	SetFilesystemStatsFn(func() []FilesystemStats {
+		return []FilesystemStats{{
+			Key:                     "localhost:9000/bucket-a",
+			ReadCount:               100,
+			WriteCount:              50,
+			ReadBytes:               1000,
+			WriteBytes:              500,
+			GetFileInfoCount:        10,
+			FailedCount:             1,
+			MultiPartUploadCreated:  5,
+			MultiPartUploadFinished: 3,
+		}}
+	})
 
-	// Verify each metric
-	labels := prometheus.Labels{filesystemKeyLabelName: fsName}
+	expected := `
+# HELP milvus_storage_filesystem_read_bytes total bytes read from the storage layer
+# TYPE milvus_storage_filesystem_read_bytes counter
+milvus_storage_filesystem_read_bytes{fs="localhost:9000/bucket-a"} 1000
+`
+	err := testutil.CollectAndCompare(filesystemCollector, strings.NewReader(expected),
+		"milvus_storage_filesystem_read_bytes")
+	assert.NoError(t, err)
 
-	// Check FilesystemReadCount
-	readCountMetric := FilesystemReadCount.With(labels)
-	assert.NotNil(t, readCountMetric)
-
-	// Check FilesystemWriteCount
-	writeCountMetric := FilesystemWriteCount.With(labels)
-	assert.NotNil(t, writeCountMetric)
-
-	// Check FilesystemReadBytes
-	readBytesMetric := FilesystemReadBytes.With(labels)
-	assert.NotNil(t, readBytesMetric)
-
-	// Check FilesystemWriteBytes
-	writeBytesMetric := FilesystemWriteBytes.With(labels)
-	assert.NotNil(t, writeBytesMetric)
-
-	// Check FilesystemGetFileInfoCount
-	getFileInfoMetric := FilesystemGetFileInfoCount.With(labels)
-	assert.NotNil(t, getFileInfoMetric)
-
-	// Check FilesystemFailedCount
-	failedMetric := FilesystemFailedCount.With(labels)
-	assert.NotNil(t, failedMetric)
-
-	// Check FilesystemMultiPartUploadCreated
-	multiPartCreatedMetric := FilesystemMultiPartUploadCreated.With(labels)
-	assert.NotNil(t, multiPartCreatedMetric)
-
-	// Check FilesystemMultiPartUploadFinished
-	multiPartFinishedMetric := FilesystemMultiPartUploadFinished.With(labels)
-	assert.NotNil(t, multiPartFinishedMetric)
+	// The values are cumulative process counters, so they must be exported as
+	// counters -- exporting them as gauges is what made rate() unusable before.
+	assert.Equal(t, 8, testutil.CollectAndCount(filesystemCollector))
 }
 
-func TestPublishFilesystemMetricsMultipleFilesystems(t *testing.T) {
-	// Test with multiple filesystem names to ensure labels work correctly
-	fs1 := "minio"
-	fs2 := "s3"
+func TestFilesystemCollectorMultipleFilesystems(t *testing.T) {
+	t.Cleanup(func() { SetFilesystemStatsFn(nil) })
 
-	// Publish metrics for first filesystem
-	PublishFilesystemMetrics(fs1, 100, 50, 1000, 500, 10, 1, 5, 3)
+	SetFilesystemStatsFn(func() []FilesystemStats {
+		return []FilesystemStats{
+			{Key: "fs-1", ReadBytes: 1000},
+			{Key: "fs-2", ReadBytes: 2000},
+		}
+	})
 
-	// Publish metrics for second filesystem
-	PublishFilesystemMetrics(fs2, 200, 100, 2000, 1000, 20, 2, 10, 6)
-
-	// Verify both filesystems have their own metric values
-	labels1 := prometheus.Labels{filesystemKeyLabelName: fs1}
-	labels2 := prometheus.Labels{filesystemKeyLabelName: fs2}
-
-	// Both should be non-nil and independently tracked
-	assert.NotNil(t, FilesystemReadCount.With(labels1))
-	assert.NotNil(t, FilesystemReadCount.With(labels2))
-	assert.NotNil(t, FilesystemWriteCount.With(labels1))
-	assert.NotNil(t, FilesystemWriteCount.With(labels2))
+	assert.Equal(t, 2, testutil.CollectAndCount(filesystemCollector,
+		"milvus_storage_filesystem_read_bytes"))
 }
 
-func TestPublishFilesystemMetricsZeroValues(t *testing.T) {
-	// Test with zero values to ensure no issues with edge cases
-	fsName := "empty-filesystem"
+// Without a provider installed there is nothing to report; the collector must
+// stay silent rather than emit zeros, which would read as "no traffic" instead
+// of "not measured".
+func TestFilesystemCollectorWithoutProvider(t *testing.T) {
+	SetFilesystemStatsFn(nil)
+	assert.Equal(t, 0, testutil.CollectAndCount(filesystemCollector))
+}
 
-	PublishFilesystemMetrics(fsName, 0, 0, 0, 0, 0, 0, 0, 0)
+// The provider crosses cgo into the storage layer. If it blows up, the scrape
+// must degrade to "no series" instead of taking down /metrics for everything
+// else on the endpoint.
+func TestFilesystemCollectorSurvivesProviderPanic(t *testing.T) {
+	t.Cleanup(func() { SetFilesystemStatsFn(nil) })
 
-	labels := prometheus.Labels{filesystemKeyLabelName: fsName}
+	SetFilesystemStatsFn(func() []FilesystemStats {
+		panic("storage layer exploded")
+	})
 
-	// All metrics should still be created with zero values
-	assert.NotNil(t, FilesystemReadCount.With(labels))
-	assert.NotNil(t, FilesystemWriteCount.With(labels))
-	assert.NotNil(t, FilesystemReadBytes.With(labels))
-	assert.NotNil(t, FilesystemWriteBytes.With(labels))
-	assert.NotNil(t, FilesystemGetFileInfoCount.With(labels))
-	assert.NotNil(t, FilesystemFailedCount.With(labels))
-	assert.NotNil(t, FilesystemMultiPartUploadCreated.With(labels))
-	assert.NotNil(t, FilesystemMultiPartUploadFinished.With(labels))
+	assert.NotPanics(t, func() {
+		assert.Equal(t, 0, testutil.CollectAndCount(filesystemCollector))
+	})
 }


### PR DESCRIPTION
## What & why

The `milvus_storage_filesystem_*` gauges are collected correctly — milvus-storage increments them at the real `S3Client::GetObject`/`PutObject` calls — but they are **pushed only when a load / sync / compaction / index-build task finishes**. Object storage read outside those events is never reflected.

That is not a corner case on the default configuration. `queryNode.segcore.tieredStorage.warmup.vectorField` defaults to `disable`, and `CacheWarmupPolicy_Disable` is implemented as a plain `return;` — nothing is preloaded. So **vector raw data is fetched from object storage the first time a query touches it**, via `if (need_load) RunLoad(...)` on the pin path, long after `LoadSegments` returned. Enabling eviction puts every cold reload on the same invisible path.

To be precise about the scope: the other three warmup policies default to `sync`, so scalar fields and indexes really are resident after load and genuinely do not read object storage at query time — for those, a frozen value is accurate. Vector raw data is the part that goes unaccounted, and it is usually the largest part of a collection.

The value is also mislabelled. `filesystem_read_bytes` reads as "bytes read so far", but actually means *"the process total as of the last task completion"*. On a query-serving node it is frozen and no dashboard reveals that — a number that looks current but is stale is worse than a missing one.

## Change

Export on the **pull model**: read the counters when Prometheus scrapes.

- The 8 `GaugeVec`s become `Desc`s plus a collector emitting `CounterValue` at scrape time. The values are monotonic process counters, so counter is the honest type, and `MustNewConstMetric` removes any need to track deltas.
- `pkg/` is its own module and cannot import the cgo storage package, so the provider is installed through a callback — the same pattern as the existing `SetPoolCollectFn`.
- The provider crosses cgo, so a failure or panic in it degrades to "no series this scrape" rather than taking down `/metrics` for everything else on the endpoint.

**Keeping multi-backend coverage.** Pulling only the default filesystem would have been a regression: sync, compaction and index tasks each carry their own `StorageConfig`, and the storage layer cannot enumerate live filesystems (`loon_filesystem_get_metrics` takes one handle; `FilesystemCache` exposes only `get`/`size`/`remove`). Those four call sites now **register** their config instead of publishing it — idempotent, no cgo, and cheaper than the per-task cgo call plus eight `Set`s they did before — and the collector reads every registered backend.

## Compatibility

Metric names and the `fs` label are unchanged. Only the type (`gauge` → `counter`) and the freshness of the value change, so existing queries keep working and `rate()` becomes meaningful.

The names deliberately keep **no `_total` suffix** despite becoming counters, so existing dashboards are not broken. This deviates from the Prometheus naming convention; several Milvus counters (e.g. `milvus_proxy_scanned_remote_mb`) are already in that position.

## Tests

`pkg/metrics` — counter type and values, multiple backends, silence when no provider is installed (emitting zeros would read as "no traffic" rather than "not measured"), and `/metrics` surviving a provider panic.

`internal/storagev2` — registration is idempotent (it is on the sync path), nil/keyless configs are ignored, the default backend is registered lazily on first scrape (paramtable is not populated at `init` time), and a registered backend round-trips through collection.

## Out of scope

- Splitting traffic by purpose (load vs query vs compaction) — the storage layer's counters are process-global; separating them needs per-context accounting inside milvus-storage.
- Per-collection / per-segment attribution — no such label exists.
- Read amplification (bytes fetched vs bytes actually needed) — additionally requires a "useful bytes" measure that does not exist yet.

issue: #51875
