### PR TITLE
fix: stop handing Go dangling pointers from GetAnalyzeResultMeta

### DIFF
--- a/internal/core/src/clustering/KmeansClustering.h
+++ b/internal/core/src/clustering/KmeansClustering.h
@@ -56,7 +56,14 @@ class KmeansClustering {
     Run(const milvus::proto::clustering::AnalyzeInfo& config);
 
     // should never be called before run
-    ClusteringResultMeta
+    //
+    // Returns a reference, not a copy, and that is load-bearing: the cgo
+    // boundary (GetAnalyzeResultMeta) hands the caller raw char* pointers into
+    // this struct's std::string members. A by-value return would make those
+    // pointers reference a local copy that is destroyed on return, so Go would
+    // read freed memory. The pointers stay valid for as long as this
+    // KmeansClustering object lives, which the Go side owns until DeleteAnalyze.
+    const ClusteringResultMeta&
     GetClusteringResultMeta() {
         if (!is_runned_) {
             throw SegcoreError(

--- a/internal/core/src/clustering/analyze_c.cpp
+++ b/internal/core/src/clustering/analyze_c.cpp
@@ -163,7 +163,7 @@ DeleteAnalyze(CAnalyze analyze) {
 
 CStatus
 GetAnalyzeResultMeta(CAnalyze analyze,
-                     char** centroid_path,
+                     const char** centroid_path,
                      int64_t* centroid_file_size,
                      void* id_mapping_paths,
                      int64_t* id_mapping_sizes) {
@@ -176,11 +176,14 @@ GetAnalyzeResultMeta(CAnalyze analyze,
                    "was null");
         auto real_analyze =
             reinterpret_cast<milvus::clustering::KmeansClustering*>(analyze);
-        auto res = real_analyze->GetClusteringResultMeta();
+        // Bind by reference: the pointers handed out below point into this
+        // struct's std::string members, so they must reference the object owned
+        // by real_analyze rather than a local copy that dies on return.
+        const auto& res = real_analyze->GetClusteringResultMeta();
         *centroid_path = res.centroid_path.data();
         *centroid_file_size = res.centroid_file_size;
 
-        auto& map_ = res.id_mappings;
+        const auto& map_ = res.id_mappings;
         const char** id_mapping_paths_ = (const char**)id_mapping_paths;
         size_t i = 0;
         for (auto it = map_.begin(); it != map_.end(); ++it, i++) {

--- a/internal/core/src/clustering/analyze_c.h
+++ b/internal/core/src/clustering/analyze_c.h
@@ -30,7 +30,7 @@ DeleteAnalyze(CAnalyze analyze);
 
 CStatus
 GetAnalyzeResultMeta(CAnalyze analyze,
-                     char** centroid_path,
+                     const char** centroid_path,
                      int64_t* centroid_file_size,
                      void* id_mapping_paths,
                      int64_t* id_mapping_sizes);

--- a/internal/util/analyzecgowrapper/analyze.go
+++ b/internal/util/analyzecgowrapper/analyze.go
@@ -89,9 +89,17 @@ func (ca *CgoAnalyze) Delete() error {
 func (ca *CgoAnalyze) GetResult(size int) (string, int64, []string, []int64, error) {
 	cOffsetMappingFilesPath := make([]unsafe.Pointer, size)
 	cOffsetMappingFilesSize := make([]C.int64_t, size)
-	cCentroidsFilePath := C.CString("")
+	// Out-parameters only: GetAnalyzeResultMeta overwrites this with a pointer
+	// into C++-owned memory (the KmeansClustering object's result meta, valid
+	// until DeleteAnalyze), which Go must not free. Starting from nil rather
+	// than C.CString("") avoids allocating a value that is never read, and
+	// removes the trap in the previous `defer C.free(cCentroidsFilePath)`:
+	// deferred arguments are evaluated at the defer statement, so it freed the
+	// initial empty-string allocation rather than whatever C++ wrote back —
+	// correct only by accident, and it would become a free of C++ memory the
+	// moment someone "fixed" it to evaluate late.
+	var cCentroidsFilePath *C.char
 	cCentroidsFileSize := C.int64_t(0)
-	defer C.free(unsafe.Pointer(cCentroidsFilePath))
 
 	status := C.GetAnalyzeResultMeta(ca.analyzePtr,
 		&cCentroidsFilePath,


### PR DESCRIPTION
issue: #51871

Fixes #51871.

## The bug

`GetAnalyzeResultMeta` handed Go pointers into a C++ object that was already destroyed:

```cpp
auto res = real_analyze->GetClusteringResultMeta();   // (1) local COPY, by value
*centroid_path = res.centroid_path.data();            // (2) pointer INTO the copy
*centroid_file_size = res.centroid_file_size;

const auto& map_ = res.id_mappings;
for (auto it = map_.begin(); it != map_.end(); ++it, i++) {
    id_mapping_paths_[i] = it->first.data();          // (3) and into the copy's map keys
    id_mapping_sizes[i] = it->second;
}
```

`GetClusteringResultMeta()` returned `ClusteringResultMeta` **by value**, and that struct owns a `std::string` plus an `unordered_map<std::string, int64_t>`. `res` is therefore a local copy whose buffers are freed when the function returns — every pointer written through `centroid_path` / `id_mapping_paths` dangles before the Go side reads it with `C.GoString`.

## The fix

`KmeansClustering` outlives the call — the Go side owns it until `DeleteAnalyze` — so `cluster_result_` is a safe thing to point into. The accessor now returns a const reference to the member instead of a copy, and the out parameter becomes `const char**` to match. cgo strips `const` from pointer types, so the Go call site needs no change.

Also drops the Go-side `C.CString("")` seed. The value is overwritten by the callee before it is ever read, and its

```go
defer C.free(unsafe.Pointer(cCentroidsFilePath))
```

was correct only by accident: deferred call arguments are evaluated at the `defer` statement, so it freed the initial empty-string allocation rather than the pointer C++ wrote back. Had it evaluated late — the intuitive reading — it would have freed C++-owned memory. Starting from a nil `*C.char` removes both the stray allocation and the trap.

## Why CI did not catch it

This is undefined behaviour, not a deterministic failure. On glibc/x86 the freed block usually still holds the original bytes at the moment of the read. A different allocator recycles it immediately, which is where it surfaced.

Note the window is not empty on Linux either: the id-mapping loop and the `status` writes both run after the pointer at (2) has been handed out.

## Verification

`TestIndexServiceSuite/Test_CreateAnalyzeTask` fails before this change and passes after it, on macOS arm64 with a locally rebuilt core.

Before — the analyze job completes, but the centroids path is 11 bytes of binary garbage, and the test fails on `s.Contains(centroidsFile, "/"+common.Centroids)`:

```
[INFO] [index/task_analyze.go:190] ["analyze result"] [centroidsFile="<garbage>"]
Error: "\x8b\x7f\x98\xcfb\xf7\x96K\x10i\xc7" does not contain "/centroids"
```

After:

```
[INFO] [index/task_analyze.go:190] ["analyze result"] [centroidsFile="index-service-ut/analyze_stats/200/1/1/2/111/centroids"]
ok  github.com/milvus-io/milvus/internal/datanode
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMUfpxrLwZHnS5xZc2zEyW

