### PR TITLE
fix: bound growing reads and make flush retries deterministic

### DIFF
--- a/internal/core/src/common/OffsetMapping.cpp
+++ b/internal/core/src/common/OffsetMapping.cpp
@@ -370,6 +370,12 @@ GrowingOffsetMapping::Append(const bool* valid_data,
                "into one growing segment must stay serial.",
                physical_idx,
                valid_count_);
+    AssertInfo(start_logical == total_count_,
+               "growing offset mapping requires logical offsets to be appended "
+               "in order: got start_logical={}, expected {}. Inserts into one "
+               "growing segment must stay serial.",
+               start_logical,
+               total_count_);
     for (int64_t i = 0; i < count; ++i) {
         if (valid_data[i]) {
             const auto logical_offset = start_logical + i;

--- a/internal/core/src/common/OffsetMapping.cpp
+++ b/internal/core/src/common/OffsetMapping.cpp
@@ -1,6 +1,7 @@
 #include "common/OffsetMapping.h"
 
 #include <algorithm>
+#include <limits>
 #include <mutex>
 #include <shared_mutex>
 #include <utility>
@@ -51,6 +52,12 @@ OffsetMapping::IsValid(int64_t logical_offset) const {
 int64_t
 OffsetMapping::GetValidCount() const {
     return 0;
+}
+
+int64_t
+OffsetMapping::ValidCountBelow(int64_t logical_bound) const {
+    // No mapping: physical space == logical space.
+    return std::max<int64_t>(0, logical_bound);
 }
 
 bool
@@ -203,6 +210,42 @@ SealedOffsetMapping::GetValidCount() const {
     return valid_count_;
 }
 
+int64_t
+SealedOffsetMapping::ValidCountBelow(int64_t logical_bound) const {
+    if (!enabled_) {
+        return std::max<int64_t>(0, logical_bound);
+    }
+    if (logical_bound <= 0) {
+        return 0;
+    }
+    if (logical_bound >= total_count_) {
+        return valid_count_;
+    }
+    // physical -> logical is built in ascending logical order, so it is
+    // strictly increasing and binary-searchable in either representation.
+    if (!use_map_) {
+        auto it = std::lower_bound(p2l_vec_.begin(),
+                                   p2l_vec_.end(),
+                                   static_cast<int32_t>(logical_bound));
+        return static_cast<int64_t>(std::distance(p2l_vec_.begin(), it));
+    }
+    int64_t lo = 0;
+    int64_t hi = valid_count_;
+    while (lo < hi) {
+        const int64_t mid = lo + (hi - lo) / 2;
+        auto it = p2l_map_.find(static_cast<int32_t>(mid));
+        const int64_t logical = (it == p2l_map_.end())
+                                    ? std::numeric_limits<int64_t>::max()
+                                    : static_cast<int64_t>(it->second);
+        if (logical < logical_bound) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo;
+}
+
 bool
 SealedOffsetMapping::IsEnabled() const {
     return enabled_;
@@ -306,6 +349,27 @@ GrowingOffsetMapping::Append(const bool* valid_data,
         start_logical = total_count_;
     }
     auto physical_idx = start_physical >= 0 ? start_physical : valid_count_;
+    // Physical offsets MUST be claimed in ascending logical order, which is
+    // what makes p2l monotonic and ValidCountBelow's binary search valid.
+    //
+    // Nothing in this class enforces that -- it holds because inserts into one
+    // growing segment are serial end to end: the QueryNode flow graph drives
+    // delegator ProcessInsert from a single goroutine over a plain loop, and
+    // watchDmChannel finishes loadGrowingSegments before it ever subscribes to
+    // the WAL, so a load can never interleave with an insert either.
+    //
+    // ConcurrentVector reads GetValidCount() and calls Append() under two
+    // separate locks, so the moment inserts into one segment become concurrent
+    // a later logical batch can win that race and take an earlier physical
+    // offset. p2l stops being monotonic, the binary search walks past the rows
+    // it must exclude, and a search silently returns unacknowledged rows -- no
+    // crash, no log. Fail loudly here instead.
+    AssertInfo(physical_idx == valid_count_,
+               "growing offset mapping requires physical offsets to be claimed "
+               "in logical order: got start_physical={}, expected {}. Inserts "
+               "into one growing segment must stay serial.",
+               physical_idx,
+               valid_count_);
     for (int64_t i = 0; i < count; ++i) {
         if (valid_data[i]) {
             const auto logical_offset = start_logical + i;
@@ -410,6 +474,43 @@ GrowingOffsetMapping::TransformBitset(const BitsetView& bitset,
         }
     }
     return BitsetTransformStatus::Transformed;
+}
+
+int64_t
+GrowingOffsetMapping::ValidCountBelow(int64_t logical_bound) const {
+    std::shared_lock lock(mutex_);
+    if (!enabled_) {
+        // No mapping: logical and physical spaces coincide.
+        return std::max<int64_t>(0, logical_bound);
+    }
+    if (logical_bound <= 0) {
+        return 0;
+    }
+    if (logical_bound >= total_count_) {
+        return valid_count_;
+    }
+    // Append walks rows in ascending logical order and assigns physical
+    // offsets with physical_idx++, so physical -> logical is strictly
+    // increasing. Binary search for the first physical row whose logical
+    // offset has already reached the bound; its index is the count of rows
+    // strictly below the bound.
+    int64_t lo = 0;
+    int64_t hi = valid_count_;
+    while (lo < hi) {
+        const int64_t mid = lo + (hi - lo) / 2;
+        auto it = p2l_map_.find(static_cast<int32_t>(mid));
+        // A hole would break monotonicity; treat it as "at or past the bound"
+        // so the result stays a safe under-approximation.
+        const int64_t logical = (it == p2l_map_.end())
+                                    ? std::numeric_limits<int64_t>::max()
+                                    : static_cast<int64_t>(it->second);
+        if (logical < logical_bound) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo;
 }
 
 void

--- a/internal/core/src/common/OffsetMapping.h
+++ b/internal/core/src/common/OffsetMapping.h
@@ -57,6 +57,28 @@ class OffsetMapping {
     virtual int64_t
     GetValidCount() const;
 
+    // Physical scan bound corresponding to a logical visibility bound: the
+    // number of valid (non-null) rows whose logical offset is < logical_bound.
+    //
+    // Callers that need a scan bound must use this and NOT GetValidCount().
+    // On a growing mapping the two differ under concurrent inserts, and
+    // GetValidCount() would admit rows the query must not see.
+    //
+    // The default (no mapping) is the identity: logical and physical spaces
+    // coincide.
+    // Number of physical rows whose logical offset is below logical_bound --
+    // i.e. the visible prefix once the plan layer's MVCC bound is translated
+    // into the mapping's physical space.
+    //
+    // PRECONDITION: physical offsets are claimed in ascending logical order,
+    // so p2l is monotonic and the visible rows form a physical prefix. That
+    // holds only because inserts into one growing segment are serial (see the
+    // assertion in GrowingOffsetMapping::Append). If that ever changes, a
+    // count is the wrong shape for this answer -- out of order the visible
+    // rows are an arbitrary subset, not a prefix, and this must become a mask.
+    virtual int64_t
+    ValidCountBelow(int64_t logical_bound) const;
+
     // Check if mapping is enabled
     virtual bool
     IsEnabled() const;
@@ -94,6 +116,11 @@ class SealedOffsetMapping final : public OffsetMapping {
 
     int64_t
     GetValidCount() const override;
+
+    // Sealed mappings are immutable once built, so this is a pure coordinate
+    // conversion with no race; it exists so every caller can use one API.
+    int64_t
+    ValidCountBelow(int64_t logical_bound) const override;
 
     bool
     IsEnabled() const override;
@@ -155,6 +182,22 @@ class GrowingOffsetMapping final : public OffsetMapping {
 
     int64_t
     GetValidCount() const override;
+
+    // Number of valid (non-null) rows whose logical offset is below
+    // logical_bound, i.e. the physical scan bound that corresponds to a
+    // logical visibility bound.
+    //
+    // A growing mapping keeps growing under concurrent inserts, so a search
+    // must NEVER use GetValidCount() as its scan bound: that count includes
+    // rows published after the query fixed its visible-row bound, which are
+    // neither acknowledged by ack_responder_ nor visible at the query
+    // timestamp. Convert the plan-layer bound instead of asking the mapping
+    // how big it is right now.
+    //
+    // Append assigns physical offsets in ascending logical order, so p2l is
+    // monotonic and this is a binary search: O(log n) lookups under one lock.
+    int64_t
+    ValidCountBelow(int64_t logical_bound) const override;
 
     bool
     IsEnabled() const override;

--- a/internal/core/src/common/OffsetMappingTest.cpp
+++ b/internal/core/src/common/OffsetMappingTest.cpp
@@ -257,6 +257,18 @@ TEST(OffsetMapping, GrowingValidCountBelowIgnoresRowsAppendedAfterBound) {
     }
 }
 
+TEST(OffsetMapping, GrowingAppendRejectsNonContiguousLogicalBatch) {
+    GrowingOffsetMapping mapping;
+    auto first = ToBoolBytes(MakeValid({1, 1}));
+    mapping.Append(reinterpret_cast<const bool*>(first.data()), 2, 0, 0);
+
+    auto non_contiguous = ToBoolBytes(MakeValid({1}));
+    EXPECT_ANY_THROW(mapping.Append(
+        reinterpret_cast<const bool*>(non_contiguous.data()), 1, 3, 2));
+    EXPECT_ANY_THROW(mapping.Append(
+        reinterpret_cast<const bool*>(non_contiguous.data()), 1, 1, 2));
+}
+
 TEST(OffsetMapping, SealedValidCountBelowConvertsLogicalBound) {
     SealedOffsetMapping mapping;
     auto v = ToBoolBytes(MakeValid({1, 0, 1, 1, 0, 1}));

--- a/internal/core/src/common/OffsetMappingTest.cpp
+++ b/internal/core/src/common/OffsetMappingTest.cpp
@@ -202,4 +202,81 @@ TEST(OffsetMapping, OutOfBoundsReturnsMinusOne) {
     EXPECT_EQ(mapping.GetLogicalOffset(99), -1);
 }
 
+// logical: 0(v) 1(x) 2(v) 3(v) 4(x) 5(v)
+// physical:  0        1    2         3
+TEST(OffsetMapping, GrowingValidCountBelowConvertsLogicalBound) {
+    GrowingOffsetMapping mapping;
+    auto v = ToBoolBytes(MakeValid({1, 0, 1, 1, 0, 1}));
+    mapping.Append(reinterpret_cast<const bool*>(v.data()), 6, 0, 0);
+    ASSERT_EQ(mapping.GetValidCount(), 4);
+    ASSERT_EQ(mapping.GetTotalCount(), 6);
+
+    EXPECT_EQ(mapping.ValidCountBelow(0), 0);
+    EXPECT_EQ(mapping.ValidCountBelow(1), 1);  // {0}
+    EXPECT_EQ(mapping.ValidCountBelow(2), 1);  // logical 1 is null
+    EXPECT_EQ(mapping.ValidCountBelow(3), 2);  // {0,2}
+    EXPECT_EQ(mapping.ValidCountBelow(4), 3);  // {0,2,3}
+    EXPECT_EQ(mapping.ValidCountBelow(5), 3);  // logical 4 is null
+    EXPECT_EQ(mapping.ValidCountBelow(6), 4);  // all
+    // Bounds outside the mapping clamp instead of over-reporting.
+    EXPECT_EQ(mapping.ValidCountBelow(-1), 0);
+    EXPECT_EQ(mapping.ValidCountBelow(100), 4);
+}
+
+// The reason this API exists: a concurrent insert grows the mapping after a
+// query has fixed its visible-row bound. The scan bound must reflect the
+// bound the query was planned with, not the mapping's current size.
+TEST(OffsetMapping, GrowingValidCountBelowIgnoresRowsAppendedAfterBound) {
+    GrowingOffsetMapping mapping;
+    auto first = ToBoolBytes(MakeValid({1, 0, 1, 1}));
+    mapping.Append(reinterpret_cast<const bool*>(first.data()), 4, 0, 0);
+
+    // The query is planned here: 4 logical rows are acknowledged/visible.
+    const int64_t planned_bound = mapping.GetTotalCount();
+    const int64_t planned_physical = mapping.ValidCountBelow(planned_bound);
+    ASSERT_EQ(planned_physical, 3);
+
+    // A concurrent insert publishes more rows into the mapping before the
+    // search kernel picks its scan range.
+    auto second = ToBoolBytes(MakeValid({1, 1, 1, 1}));
+    mapping.Append(reinterpret_cast<const bool*>(second.data()),
+                   4,
+                   mapping.GetTotalCount(),
+                   mapping.GetValidCount());
+    ASSERT_EQ(mapping.GetValidCount(), 7);
+
+    // GetValidCount() would hand the search 7 physical rows, four of which are
+    // not visible to this query; the converted bound stays at 3.
+    EXPECT_EQ(mapping.ValidCountBelow(planned_bound), planned_physical);
+    EXPECT_NE(mapping.GetValidCount(), planned_physical);
+
+    // Every physical offset within the converted bound maps back below the
+    // query's logical bound, which is exactly what Reduce asserts.
+    for (int64_t physical = 0; physical < planned_physical; ++physical) {
+        EXPECT_LT(mapping.GetLogicalOffset(physical), planned_bound);
+    }
+}
+
+TEST(OffsetMapping, SealedValidCountBelowConvertsLogicalBound) {
+    SealedOffsetMapping mapping;
+    auto v = ToBoolBytes(MakeValid({1, 0, 1, 1, 0, 1}));
+    mapping.Build(reinterpret_cast<const bool*>(v.data()), 6);
+    ASSERT_EQ(mapping.GetValidCount(), 4);
+
+    EXPECT_EQ(mapping.ValidCountBelow(0), 0);
+    EXPECT_EQ(mapping.ValidCountBelow(3), 2);
+    EXPECT_EQ(mapping.ValidCountBelow(6), 4);
+    EXPECT_EQ(mapping.ValidCountBelow(100), 4);
+}
+
+// A disabled mapping means logical and physical spaces coincide, so the bound
+// must pass through unchanged rather than collapsing to zero.
+TEST(OffsetMapping, ValidCountBelowIsIdentityWithoutMapping) {
+    OffsetMapping mapping;
+    EXPECT_FALSE(mapping.IsEnabled());
+    EXPECT_EQ(mapping.ValidCountBelow(0), 0);
+    EXPECT_EQ(mapping.ValidCountBelow(42), 42);
+    EXPECT_EQ(mapping.ValidCountBelow(-5), 0);
+}
+
 }  // namespace milvus

--- a/internal/core/src/common/QueryInfo.h
+++ b/internal/core/src/common/QueryInfo.h
@@ -65,6 +65,21 @@ struct SearchInfo {
     bool global_refine_enable_{false};
     float search_topk_ratio_{0.0f};
     float refine_topk_ratio_{0.0f};
+    // Number of rows visible to this search, in the segment's logical row
+    // space. Decided ONCE by the plan layer from get_active_count(timestamp)
+    // and carried down so no kernel re-derives it.
+    //
+    // Re-deriving it is not safe on a growing segment: a concurrent insert
+    // publishes rows into the column storage (and into a nullable field's
+    // offset mapping) before ack_responder_ advances, so a later read sees
+    // rows this search must not touch. Reduce then validates offsets against
+    // the acknowledged count and rejects them ("invalid offset ... rows num
+    // ..."), or, if the ack catches up first, silently returns rows newer
+    // than the query's MVCC timestamp.
+    //
+    // -1 means "not supplied" (direct unit-test callers); kernels fall back to
+    // computing it themselves in that case.
+    int64_t active_count_{-1};
 
     bool
     element_level() const {

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -69,6 +69,11 @@ PhyVectorSearchNode::PhyVectorSearchNode(
     active_count_ = query_context_->get_active_count();
     placeholder_group_ = query_context_->get_placeholder_group();
     search_info_ = query_context_->get_search_info();
+    // Freeze the visible-row bound at plan time and carry it into the search
+    // kernels. They must not re-read it from the segment: on a growing segment
+    // a concurrent insert can publish rows between this point and the kernel's
+    // read, and those rows are neither acknowledged nor visible to this query.
+    search_info_.active_count_ = active_count_;
 }
 
 void

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -208,10 +208,37 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             }
         }
 
+        // The visible-row bound is decided once, in the plan layer, and
+        // travels here through SearchInfo. Re-reading it from the segment (or
+        // asking the offset mapping how big it is now) races with concurrent
+        // inserts: a growing segment publishes rows into column storage and
+        // into the nullable field's offset mapping BEFORE ack_responder_
+        // advances, so a later read admits rows that are neither acknowledged
+        // nor visible at `timestamp`. Those rows then fail Reduce's
+        // `offset < get_row_count()` assertion, or slip into the result when
+        // the ack happens to catch up first.
+        //
+        // Fall back to computing it only for direct callers (unit tests) that
+        // do not go through the plan layer.
+        const int64_t plan_bound = info.active_count_ >= 0
+                                       ? info.active_count_
+                                       : segment.get_active_count(timestamp);
+
+        // An empty BitsetView means "no filter", NOT "zero rows": its size() is
+        // 0 and clamping to it would zero the bound and make the search return
+        // an empty result. Only a populated bitset carries a row count worth
+        // clamping to.
+        const int64_t logical_bound =
+            bitset.empty() ? plan_bound
+                           : std::min(int64_t(bitset.size()), plan_bound);
+
+        // Nullable vector fields store only non-null rows, so the scan runs in
+        // the mapping's physical space. Convert the logical bound instead of
+        // querying the mapping's current size, so both branches enforce the
+        // same MVCC bound.
         auto active_count = has_offset_mapping
-                                ? offset_mapping.GetValidCount()
-                                : std::min(int64_t(bitset.size()),
-                                           segment.get_active_count(timestamp));
+                                ? offset_mapping.ValidCountBelow(logical_bound)
+                                : logical_bound;
 
         // Check for nullable vector field with all null values
         if (active_count == 0) {

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -534,6 +534,79 @@ TEST(SearchOnGrowingBitsetLifetime,
     AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
 }
 
+// An empty BitsetView means "no filter", not "zero rows". Clamping the
+// visible-row bound to bitset.size() therefore zeroes it, and a nullable
+// vector field -- whose branch resolves the bound through the offset mapping
+// -- comes back with an empty result instead of every visible row.
+TEST(SearchOnGrowingBitsetLifetime, NullableGrowingEmptyBitsetMeansNoFilter) {
+    constexpr int64_t total_count = 512;
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::L2, true);
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_field);
+
+    auto dataset = segcore::DataGen(schema,
+                                    total_count,
+                                    /*seed=*/42,
+                                    /*ts_offset=*/0,
+                                    /*repeat_count=*/1,
+                                    /*array_len=*/10,
+                                    /*group_count=*/1,
+                                    /*random_pk=*/false,
+                                    /*random_val=*/true,
+                                    /*random_valid=*/false,
+                                    /*null_percent=*/10);
+    const auto& vector_data = FindFieldData(dataset, vector_field);
+    auto valid_count = CountValidRows(vector_data, total_count);
+    ASSERT_GT(valid_count, 0);
+
+    auto segment = segcore::CreateGrowingSegment(schema, empty_index_meta);
+    auto reserved_offset = segment->PreInsert(total_count);
+    segment->Insert(reserved_offset,
+                    total_count,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+    auto* growing_segment =
+        dynamic_cast<segcore::SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing_segment, nullptr);
+
+    const auto& vectors = vector_data.vectors().float_vector().data();
+    ASSERT_GE(vectors.size(), kDim);
+
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = kTopK;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = knowhere::metric::L2;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "32"},
+    };
+    // The plan layer froze the visible-row bound; the kernel must carry it
+    // through instead of re-deriving one from the (absent) bitset.
+    search_info.active_count_ = total_count;
+
+    SearchResult search_result;
+    SearchOnGrowing(*growing_segment,
+                    search_info,
+                    vectors.data(),
+                    nullptr,
+                    1,
+                    MAX_TIMESTAMP,
+                    BitsetView{},
+                    nullptr,
+                    search_result);
+
+    auto matched = std::count_if(
+        search_result.seg_offsets_.begin(),
+        search_result.seg_offsets_.end(),
+        [](int64_t offset) { return offset != INVALID_SEG_OFFSET; });
+    EXPECT_GT(matched, 0)
+        << "an empty bitset must not be read as zero visible rows";
+}
+
 TEST(SearchOnSealedColumnBitsetLifetime,
      GroupByIteratorMustNotKeepDanglingTransformedBitset) {
     constexpr int64_t total_count = 512;

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1447,6 +1447,9 @@ class InsertRecordSealed {
 
 class InsertRecordGrowing {
  public:
+    using FieldMap = std::unordered_map<FieldId, std::shared_ptr<VectorBase>>;
+    using ValidDataMap = std::unordered_map<FieldId, ThreadSafeValidDataPtr>;
+
     InsertRecordGrowing(
         const Schema& schema,
         const int64_t size_per_chunk,
@@ -1593,9 +1596,10 @@ class InsertRecordGrowing {
         }
         reserved = 0;
         {
-            std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
-            data_.clear();
-            valid_data_.clear();
+            std::lock_guard<std::mutex> lck(field_write_mutex_);
+            std::atomic_store(&data_, std::make_shared<const FieldMap>());
+            std::atomic_store(&valid_data_,
+                              std::make_shared<const ValidDataMap>());
         }
         ack_responder_.clear();
     }
@@ -1765,10 +1769,7 @@ class InsertRecordGrowing {
     // get data without knowing the type
     VectorBase*
     get_data_base(FieldId field_id) const {
-        // Guard the field map against concurrent structural modification
-        // (e.g. append_field_meta during schema evolution rehashing data_).
-        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
-        return get_data_base_unlocked(field_id);
+        return get_data_base_in(*CaptureFields(), field_id);
     }
 
     // get field data in given type, const version
@@ -1793,16 +1794,13 @@ class InsertRecordGrowing {
 
     ThreadSafeValidDataPtr
     get_valid_data(FieldId field_id) const {
-        // Guard the field map against concurrent structural modification
-        // (e.g. append_field_meta during schema evolution rehashing valid_data_).
-        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
-        return get_valid_data_unlocked(field_id);
+        return get_valid_data_in(*CaptureValidData(), field_id);
     }
 
     bool
     is_data_exist(FieldId field_id) const {
-        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
-        return data_.find(field_id) != data_.end();
+        auto fields = CaptureFields();
+        return fields->find(field_id) != fields->end();
     }
 
     // Field ids that have materialized columns. The exact set the flush
@@ -1810,10 +1808,10 @@ class InsertRecordGrowing {
     // absent here.
     std::vector<int64_t>
     get_data_field_ids() const {
-        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
+        auto fields = CaptureFields();
         std::vector<int64_t> ids;
-        ids.reserve(data_.size());
-        for (const auto& [field_id, entry] : data_) {
+        ids.reserve(fields->size());
+        for (const auto& [field_id, entry] : *fields) {
             // An allocated-but-empty column (e.g. a function output the
             // replayed older-era inserts never filled) is not materialized.
             if (!entry || entry->empty()) {
@@ -1826,24 +1824,23 @@ class InsertRecordGrowing {
 
     bool
     is_valid_data_exist(FieldId field_id) const {
-        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
-        return is_valid_data_exist_unlocked(field_id);
+        auto valid = CaptureValidData();
+        return valid->find(field_id) != valid->end();
     }
 
     SpanBase
     get_span_base(FieldId field_id, int64_t chunk_id) const {
-        // Take the shared lock once for the whole span resolution instead of
-        // re-locking inside each of get_data_base / is_valid_data_exist /
-        // get_valid_data. This both removes the redundant lock churn on this
-        // hot path and gives a consistent snapshot of the field map across the
-        // three lookups.
-        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
-        auto data = get_data_base_unlocked(field_id);
-        if (is_valid_data_exist_unlocked(field_id)) {
+        // One snapshot pair for the whole span resolution: the three lookups
+        // below must agree with each other, and a snapshot gives that for free
+        // without any lock on this hot path.
+        auto fields = CaptureFields();
+        auto valid = CaptureValidData();
+        auto data = get_data_base_in(*fields, field_id);
+        if (valid->find(field_id) != valid->end()) {
             auto size = data->get_chunk_size(chunk_id);
             auto element_offset = data->get_element_offset(chunk_id);
             return SpanBase(data->get_chunk_data(chunk_id),
-                            get_valid_data_unlocked(field_id)->get_chunk_data(
+                            get_valid_data_in(*valid, field_id)->get_chunk_data(
                                 element_offset),
                             size,
                             data->get_element_size());
@@ -1855,8 +1852,10 @@ class InsertRecordGrowing {
     void
     append_valid_data(FieldId field_id, int64_t size_per_chunk) {
         auto valid_data = std::make_shared<ThreadSafeValidData>(size_per_chunk);
-        std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
-        valid_data_.emplace(field_id, std::move(valid_data));
+        std::lock_guard<std::mutex> lck(field_write_mutex_);
+        auto next = std::make_shared<ValidDataMap>(*CaptureValidData());
+        next->emplace(field_id, std::move(valid_data));
+        std::atomic_store(&valid_data_, std::shared_ptr<const ValidDataMap>(next));
     }
 
     // append a column of vector type
@@ -1870,14 +1869,16 @@ class InsertRecordGrowing {
         bool use_mapping_storage = is_valid_data_exist(field_id);
         // Resolve valid_data and build the column before taking the write lock
         // so the shared-lock readers above are not nested inside the unique lock.
-        auto column = std::make_unique<ConcurrentVector<VectorType>>(
+        auto column = std::make_shared<ConcurrentVector<VectorType>>(
             dim,
             size_per_chunk,
             mmap_descriptor,
             use_mapping_storage ? get_valid_data(field_id) : nullptr,
             use_mapping_storage);
-        std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
-        data_.emplace(field_id, std::move(column));
+        std::lock_guard<std::mutex> lck(field_write_mutex_);
+        auto next = std::make_shared<FieldMap>(*CaptureFields());
+        next->emplace(field_id, std::move(column));
+        std::atomic_store(&data_, std::shared_ptr<const FieldMap>(next));
     }
 
     // append a column of scalar or sparse float vector type
@@ -1890,28 +1891,35 @@ class InsertRecordGrowing {
         bool use_mapping_storage = is_valid_data_exist(field_id);
         // Resolve valid_data and build the column before taking the write lock
         // so the shared-lock readers above are not nested inside the unique lock.
-        std::unique_ptr<ConcurrentVector<Type>> column;
+        std::shared_ptr<ConcurrentVector<Type>> column;
         if constexpr (IsSparse<Type>) {
-            column = std::make_unique<ConcurrentVector<Type>>(
+            column = std::make_shared<ConcurrentVector<Type>>(
                 size_per_chunk,
                 mmap_descriptor,
                 use_mapping_storage ? get_valid_data(field_id) : nullptr,
                 use_mapping_storage);
         } else {
-            column = std::make_unique<ConcurrentVector<Type>>(
+            column = std::make_shared<ConcurrentVector<Type>>(
                 size_per_chunk,
                 mmap_descriptor,
                 use_mapping_storage ? get_valid_data(field_id) : nullptr);
         }
-        std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
-        data_.emplace(field_id, std::move(column));
+        std::lock_guard<std::mutex> lck(field_write_mutex_);
+        auto next = std::make_shared<FieldMap>(*CaptureFields());
+        next->emplace(field_id, std::move(column));
+        std::atomic_store(&data_, std::shared_ptr<const FieldMap>(next));
     }
 
     void
     drop_field_data(FieldId field_id) {
-        std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
-        data_.erase(field_id);
-        valid_data_.erase(field_id);
+        std::lock_guard<std::mutex> lck(field_write_mutex_);
+        auto fields = std::make_shared<FieldMap>(*CaptureFields());
+        fields->erase(field_id);
+        std::atomic_store(&data_, std::shared_ptr<const FieldMap>(fields));
+        auto valid = std::make_shared<ValidDataMap>(*CaptureValidData());
+        valid->erase(field_id);
+        std::atomic_store(&valid_data_,
+                          std::shared_ptr<const ValidDataMap>(valid));
     }
 
     int64_t
@@ -1935,11 +1943,10 @@ class InsertRecordGrowing {
     AckResponder ack_responder_;
 
  private:
-    // Unlocked field-map lookups. Callers MUST already hold field_map_mutex_
-    // (at least shared). These let multi-lookup hot paths such as
-    // get_span_base resolve under a single lock acquisition.
-    VectorBase*
-    get_data_base_unlocked(FieldId field_id) const {
+    // Snapshot lookups. They take the map by reference so a hot path such as
+    // get_span_base can resolve several fields against ONE snapshot.
+    static VectorBase*
+    get_data_base_in(const FieldMap& data_, FieldId field_id) {
         AssertInfo(data_.find(field_id) != data_.end(),
                    "Cannot find field_data with field_id: " +
                        std::to_string(field_id.get()));
@@ -1948,8 +1955,8 @@ class InsertRecordGrowing {
         return data_.at(field_id).get();
     }
 
-    ThreadSafeValidDataPtr
-    get_valid_data_unlocked(FieldId field_id) const {
+    static ThreadSafeValidDataPtr
+    get_valid_data_in(const ValidDataMap& valid_data_, FieldId field_id) {
         AssertInfo(valid_data_.find(field_id) != valid_data_.end(),
                    "Cannot find valid_data with field_id: " +
                        std::to_string(field_id.get()));
@@ -1958,29 +1965,32 @@ class InsertRecordGrowing {
         return valid_data_.at(field_id);
     }
 
-    bool
-    is_valid_data_exist_unlocked(FieldId field_id) const {
-        return valid_data_.find(field_id) != valid_data_.end();
+    // Copy-on-write field maps. Readers capture an immutable snapshot with a
+    // single atomic load -- no lock, so the hottest accessor in the segment
+    // costs nothing and a writer can never be starved behind it. Writers
+    // serialize on field_write_mutex_ (which readers never touch), build the
+    // next map beside the live one, and publish it atomically.
+    //
+    // This is the same shape ChunkedSegmentSealedImpl uses for its derived
+    // resources (CapturePublishedState). It also fixes element lifetime: the
+    // snapshot keeps every column alive for as long as a reader holds it, so
+    // the raw VectorBase* handed out by get_data_base() can no longer dangle
+    // if a field is ever dropped.
+    std::shared_ptr<const FieldMap>
+    CaptureFields() const {
+        return std::atomic_load(&data_);
     }
 
-    std::unordered_map<FieldId, std::unique_ptr<VectorBase>> data_{};
-    std::unordered_map<FieldId, ThreadSafeValidDataPtr> valid_data_{};
+    std::shared_ptr<const ValidDataMap>
+    CaptureValidData() const {
+        return std::atomic_load(&valid_data_);
+    }
+
+    std::shared_ptr<const FieldMap> data_{std::make_shared<const FieldMap>()};
+    std::shared_ptr<const ValidDataMap> valid_data_{
+        std::make_shared<const ValidDataMap>()};
+    mutable std::mutex field_write_mutex_;
     mutable std::shared_mutex shared_mutex_{};
-    // Protects the structure of data_ / valid_data_ against concurrent
-    // rehash: structural writes (append_*/drop/clear during schema evolution)
-    // take it unique, lookups (get_data_base/get_valid_data/...) take it shared.
-    // Kept separate from shared_mutex_ so frequent reads do not contend with
-    // pk inserts.
-    //
-    // PRECONDITION: this lock only protects the map structure, NOT element
-    // lifetime. The raw VectorBase* returned by get_data_base() escapes the
-    // shared lock, so callers rely on no concurrent erase()/clear() of the
-    // entry they hold (append-only mutation is safe). Today that holds because
-    // drop_field_data() has no callers and clear() is never called
-    // concurrently with reads; whoever adds drop-field support (e.g. schema
-    // evolution dropping fields) must also fence element lifetime, this lock
-    // alone will not save the escaped pointers.
-    mutable std::shared_mutex field_map_mutex_{};
 };
 
 // Keep the original template API via alias

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1840,8 +1840,8 @@ class InsertRecordGrowing {
             auto size = data->get_chunk_size(chunk_id);
             auto element_offset = data->get_element_offset(chunk_id);
             return SpanBase(data->get_chunk_data(chunk_id),
-                            get_valid_data_in(*valid, field_id)->get_chunk_data(
-                                element_offset),
+                            get_valid_data_in(*valid, field_id)
+                                ->get_chunk_data(element_offset),
                             size,
                             data->get_element_size());
         }
@@ -1855,7 +1855,8 @@ class InsertRecordGrowing {
         std::lock_guard<std::mutex> lck(field_write_mutex_);
         auto next = std::make_shared<ValidDataMap>(*CaptureValidData());
         next->emplace(field_id, std::move(valid_data));
-        std::atomic_store(&valid_data_, std::shared_ptr<const ValidDataMap>(next));
+        std::atomic_store(&valid_data_,
+                          std::shared_ptr<const ValidDataMap>(next));
     }
 
     // append a column of vector type

--- a/internal/core/unittest/test_utils/DataGen.h
+++ b/internal/core/unittest/test_utils/DataGen.h
@@ -573,7 +573,16 @@ DataGen(SchemaPtr schema,
         auto dim = field_meta.get_dim();
         vector<float> final(dim * N);
         bool is_ip = starts_with(field_meta.get_name().get(), "normalized");
-#pragma omp parallel for
+        // Deliberately serial. The VECTOR_ARRAY generator calls this once per
+        // row with N == array_len (typically 3), so an OpenMP region here is
+        // entered once per row: a 10k-row fixture opened 10k parallel regions,
+        // each forking a team sized to the host's core count to run three
+        // iterations. On a 128-core machine the fork/join and barrier cost
+        // dwarfs the work by orders of magnitude and the fixture never
+        // finishes -- ElementFilter.GrowingSegmentArrayOffsets hung
+        // indefinitely there while passing on smaller CI hosts. The loop is
+        // cheap RNG arithmetic; generating it serially costs milliseconds even
+        // for the largest fixtures.
         for (int n = 0; n < N; ++n) {
             vector<float> data(dim);
             float sum = 0;

--- a/internal/flushcommon/metacache/actions.go
+++ b/internal/flushcommon/metacache/actions.go
@@ -239,6 +239,16 @@ func AbortSyncing(batchSize int64) SegmentAction {
 	}
 }
 
+// DiscardSyncing removes a task's syncing ownership without pretending that
+// its payload was restored to the write buffer. Use AbortSyncing only when the
+// exact batch is actually put back into a buffer.
+func DiscardSyncing(batchSize int64) SegmentAction {
+	return func(info *SegmentInfo) {
+		info.syncingRows -= batchSize
+		info.syncingTasks--
+	}
+}
+
 func FinishSyncing(batchSize int64) SegmentAction {
 	return func(info *SegmentInfo) {
 		info.flushedRows += batchSize

--- a/internal/flushcommon/metacache/actions_test.go
+++ b/internal/flushcommon/metacache/actions_test.go
@@ -132,6 +132,18 @@ func (s *SegmentActionSuite) TestActions() {
 	s.Equal(1, len(info.Bm25logs()))
 }
 
+func (s *SegmentActionSuite) TestDiscardSyncingDoesNotRestoreMissingPayload() {
+	info := &SegmentInfo{}
+	UpdateBufferedRows(10)(info)
+	StartSyncing(10)(info)
+
+	DiscardSyncing(10)(info)
+
+	s.Zero(info.BufferRows())
+	s.Zero(info.SyncingRows())
+	s.True(WithNoSyncingTask().Filter(info))
+}
+
 func (s *SegmentActionSuite) TestMergeActions() {
 	info := &SegmentInfo{}
 

--- a/internal/flushcommon/pipeline/data_sync_service.go
+++ b/internal/flushcommon/pipeline/data_sync_service.go
@@ -302,7 +302,7 @@ func getServiceWithChannel(initCtx context.Context, params *util.PipelineParams,
 	nodeList = append(nodeList, ddNode)
 
 	// 2.writeNode
-	writeNode, err := newWriteNode(params.Ctx, params.WriteBufferManager, ds.timetickSender, config)
+	writeNode, err := newWriteNode(ds.ctx, params.WriteBufferManager, ds.timetickSender, config)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/flushcommon/pipeline/flow_graph_write_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_write_node.go
@@ -24,6 +24,7 @@ import (
 type writeNode struct {
 	BaseNode
 
+	ctx          context.Context
 	channelName  string
 	collectionID int64
 	wbManager    writebuffer.BufferManager
@@ -154,7 +155,7 @@ func (wNode *writeNode) Operate(in []Msg) []Msg {
 	}
 
 	if fgMsg.dropCollection {
-		wNode.wbManager.DropChannel(wNode.channelName)
+		wNode.wbManager.DropChannel(wNode.ctx, wNode.channelName)
 	}
 
 	if len(fgMsg.dropPartitions) > 0 {
@@ -166,7 +167,7 @@ func (wNode *writeNode) Operate(in []Msg) []Msg {
 }
 
 func newWriteNode(
-	_ context.Context,
+	ctx context.Context,
 	writeBufferManager writebuffer.BufferManager,
 	updater util.StatsUpdater,
 	config *nodeConfig,
@@ -184,6 +185,7 @@ func newWriteNode(
 
 	wNode := &writeNode{
 		BaseNode:     baseNode,
+		ctx:          ctx,
 		channelName:  config.vChannelName,
 		collectionID: config.collectionID,
 		wbManager:    writeBufferManager,

--- a/internal/flushcommon/syncmgr/growing_source.go
+++ b/internal/flushcommon/syncmgr/growing_source.go
@@ -621,9 +621,13 @@ func (t *GrowingSourceSyncTask) Run(ctx context.Context) (err error) {
 		if commitSource && shouldCommit && (t.IsFlush() || t.IsDrop()) {
 			committer.CommitGrowingFlush(t.targetOffset)
 		}
-		if err != nil {
-			t.HandleError(err)
-		}
+		// HandleError is NOT called here. syncManager.submit prepends a
+		// handler that already invokes it for every task it runs, and this
+		// defer used to fire on the same error: two failureCallback calls and
+		// two DataNodeFlushBufferCount increments per failure. That stayed
+		// invisible while the callback panicked on the first call; once
+		// growing-source failures became recoverable it turned into a doubled
+		// warn every retry interval. The manager owns the call.
 	}()
 
 	segment, ok := t.metacache.GetSegmentByID(t.segmentID)
@@ -637,7 +641,9 @@ func (t *GrowingSourceSyncTask) Run(ctx context.Context) (err error) {
 	}
 	expectedRows := t.targetOffset - segment.FlushedRows()
 	if expectedRows < 0 {
-		return merr.WrapErrServiceInternalMsg("growing source target offset is behind flushed rows, flushedRows=%d targetOffset=%d segmentID=%d",
+		// Deterministic: FlushedRows only grows and targetOffset is fixed for
+		// this task, so a retry re-derives the same negative span.
+		return merr.WrapErrDataIntegrityMsg("growing source target offset is behind flushed rows, flushedRows=%d targetOffset=%d segmentID=%d",
 			segment.FlushedRows(), t.targetOffset, t.segmentID)
 	}
 	columnGroups, err := t.getColumnGroups(segment)
@@ -829,7 +835,7 @@ func (t *GrowingSourceSyncTask) trimColumnGroupsToMaterialized(ctx context.Conte
 	// InsertRecord ctor, so an empty set has no legal meaning — refuse it
 	// instead of writing a layout that may disagree with the data.
 	if len(materialized) == 0 {
-		return nil, merr.WrapErrServiceInternalMsg(
+		return nil, merr.WrapErrDataIntegrityMsg(
 			"growing flush source reported empty materialized field ids for segment %d", t.segmentID)
 	}
 	materializedSet := typeutil.NewSet(materialized...)

--- a/internal/flushcommon/syncmgr/key_lock_dispatcher.go
+++ b/internal/flushcommon/syncmgr/key_lock_dispatcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
@@ -39,24 +40,37 @@ type pendingTask struct {
 // Different keys execute concurrently up to the worker pool capacity.
 // A semaphore limits total pending (queued + in-flight) tasks to provide backpressure.
 type keyLockDispatcher[K comparable] struct {
-	mu         sync.Mutex
-	queues     map[K]*list.List // per-key FIFO queue of *pendingTask
-	inFlight   map[K]bool       // true if a task for this key is currently running
-	workerPool *conc.Pool[struct{}]
-	semaphore  *syncutil.Semaphore
+	mu          sync.Mutex
+	queues      map[K]*list.List // per-key FIFO queue of *pendingTask
+	inFlight    map[K]bool       // true if a task for this key is currently running
+	closed      bool
+	closeCtx    context.Context
+	closeCancel context.CancelFunc
+	workerPool  *conc.Pool[struct{}]
+	semaphore   *syncutil.Semaphore
+	accepted    int
+	completed   *syncutil.ContextCond
 }
 
 func newKeyLockDispatcher[K comparable](maxParallel int) *keyLockDispatcher[K] {
+	// closeCancel is retained by the dispatcher and invoked exactly once by
+	// beginClose; it cannot be deferred in this constructor.
+	//nolint:gosec
+	closeCtx, closeFn := context.WithCancel(context.Background())
 	semCap := maxParallel * 2
 	if semCap < 4 {
 		semCap = 4
 	}
-	return &keyLockDispatcher[K]{
-		queues:     make(map[K]*list.List),
-		inFlight:   make(map[K]bool),
-		workerPool: conc.NewPool[struct{}](maxParallel, conc.WithPreAlloc(false)),
-		semaphore:  syncutil.NewSemaphore(semCap),
+	dispatcher := &keyLockDispatcher[K]{
+		queues:      make(map[K]*list.List),
+		inFlight:    make(map[K]bool),
+		closeCtx:    closeCtx,
+		closeCancel: closeFn,
+		workerPool:  conc.NewPool[struct{}](maxParallel, conc.WithPreAlloc(false)),
+		semaphore:   syncutil.NewSemaphore(semCap),
 	}
+	dispatcher.completed = syncutil.NewContextCond(&dispatcher.mu)
+	return dispatcher
 }
 
 // Submit enqueues a task for the given key and returns a Future.
@@ -72,34 +86,46 @@ func newKeyLockDispatcher[K comparable](maxParallel int) *keyLockDispatcher[K] {
 func (d *keyLockDispatcher[K]) Submit(ctx context.Context, key K, t Task, callbacks ...func(error) error) *conc.Future[struct{}] {
 	nodeID := paramtable.GetStringNodeID()
 
+	// The close fence and completion accounting share d.mu. Every Submit that
+	// crosses this gate before beginClose is included in waitClosed, including
+	// calls still blocked on semaphore admission or asynchronous pool handoff.
+	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		pt, future := newPendingTaskFuture(ctx, t, callbacks)
+		panicValue := d.finishDetached(pt, context.Canceled, false, false)
+		repanicAsync(panicValue)
+		return future
+	}
+	d.accepted++
+	d.mu.Unlock()
+
 	// Backpressure: acquire a semaphore slot. Blocks if all slots are taken.
 	// Returns early if ctx is canceled (e.g. during shutdown).
-	if err := d.semaphore.Acquire(ctx); err != nil {
-		return conc.Go(func() (struct{}, error) {
-			return struct{}{}, err
-		})
+	acquireCtx, cancelAcquire := context.WithCancel(ctx)
+	stopCloseCancel := context.AfterFunc(d.closeCtx, cancelAcquire)
+	err := d.semaphore.Acquire(acquireCtx)
+	stopCloseCancel()
+	cancelAcquire()
+	if err != nil {
+		pt, future := newPendingTaskFuture(ctx, t, callbacks)
+		panicValue := d.finishDetached(pt, err, false, true)
+		repanicAsync(panicValue)
+		return future
 	}
 
 	metrics.WALFlusherSyncDispatcherTaskTotal.WithLabelValues(nodeID).Inc()
 	metrics.WALFlusherSyncDispatcherPendingTasks.WithLabelValues(nodeID).Inc()
 
-	pt := &pendingTask{
-		ctx:       ctx,
-		task:      t,
-		callbacks: callbacks,
-		resultCh:  make(chan error, 1),
-		enqueueAt: time.Now(),
-	}
-
-	// Create a Future that resolves when the task completes.
-	// The goroutine spawned by conc.Go is parked on resultCh until the task
-	// finishes. The number of such goroutines is bounded by the semaphore capacity.
-	future := conc.Go(func() (struct{}, error) {
-		err := <-pt.resultCh
-		return struct{}{}, err
-	})
+	pt, future := newPendingTaskFuture(ctx, t, callbacks)
 
 	d.mu.Lock()
+	if d.closed {
+		d.mu.Unlock()
+		panicValue := d.finishDetached(pt, context.Canceled, true, true)
+		repanicAsync(panicValue)
+		return future
+	}
 	q, ok := d.queues[key]
 	if !ok {
 		q = list.New()
@@ -112,9 +138,110 @@ func (d *keyLockDispatcher[K]) Submit(ctx context.Context, key K, t Task, callba
 	return future
 }
 
+func newPendingTaskFuture(ctx context.Context, task Task, callbacks []func(error) error) (*pendingTask, *conc.Future[struct{}]) {
+	pt := &pendingTask{
+		ctx:       ctx,
+		task:      task,
+		callbacks: callbacks,
+		resultCh:  make(chan error, 1),
+		enqueueAt: time.Now(),
+	}
+	future := conc.Go(func() (struct{}, error) {
+		err := <-pt.resultCh
+		return struct{}{}, err
+	})
+	return pt, future
+}
+
+// runCallbacks is deliberately panic-tolerant per callback. HandleError is the
+// first callback installed by SyncManager and may be fatal; write-buffer
+// lifecycle callbacks after it still have to release segment state and payload
+// ownership before that panic is propagated.
+func runCallbacks(initialErr error, callbacks []func(error) error) (any, error) {
+	finalErr := initialErr
+	var firstPanic any
+	var panicResultErr error
+	for _, callback := range callbacks {
+		if firstPanic != nil {
+			// Once a callback panics, every remaining lifecycle callback must see
+			// the preserved failure even if an earlier cleanup callback returned nil.
+			finalErr = panicResultErr
+		}
+		func() {
+			defer func() {
+				if panicValue := recover(); panicValue != nil {
+					if firstPanic == nil {
+						firstPanic = panicValue
+						// Preserve the error being handled when the first panic happened
+						// so downstream lifecycle callbacks and the Future retain its
+						// errors.Is/merr identity. A panic on an otherwise successful
+						// attempt becomes a System error instead of reported success.
+						panicResultErr = finalErr
+						if panicResultErr == nil {
+							panicResultErr = merr.WrapErrServiceInternalMsg("sync task callback panicked: %v", panicValue)
+						}
+					}
+					finalErr = panicResultErr
+				}
+			}()
+			finalErr = callback(finalErr)
+		}()
+	}
+	if firstPanic != nil {
+		finalErr = panicResultErr
+	}
+	return firstPanic, finalErr
+}
+
+func publishPendingTaskResult(pt *pendingTask, err error) {
+	pt.resultCh <- err
+	close(pt.resultCh)
+}
+
+func repanicAsync(panicValue any) {
+	if panicValue == nil {
+		return
+	}
+	go func() {
+		panic(panicValue)
+	}()
+}
+
+func (d *keyLockDispatcher[K]) finishAccepted() {
+	d.completed.LockAndBroadcast()
+	d.accepted--
+	if d.accepted < 0 {
+		d.mu.Unlock()
+		panic("sync dispatcher completed more tasks than it accepted")
+	}
+	d.mu.Unlock()
+}
+
+// finishDetached completes a task that will never enter the worker pool. It
+// releases any admission slot before callbacks (so callbacks may re-enter),
+// runs every callback, and publishes the Future result last. The caller decides
+// when to re-panic so Close can drain all detached tasks first.
+func (d *keyLockDispatcher[K]) finishDetached(pt *pendingTask, err error, releaseSlot, accepted bool) any {
+	if releaseSlot {
+		d.semaphore.Release()
+		metrics.WALFlusherSyncDispatcherPendingTasks.WithLabelValues(paramtable.GetStringNodeID()).Dec()
+	}
+	panicValue, finalErr := runCallbacks(err, pt.callbacks)
+	publishPendingTaskResult(pt, finalErr)
+	if accepted {
+		d.finishAccepted()
+	}
+	return panicValue
+}
+
 // tryDrainLocked dispatches the next queued task for key if no task is in-flight.
 // Must be called with d.mu held.
 func (d *keyLockDispatcher[K]) tryDrainLocked(key K) {
+	if d.closed {
+		delete(d.queues, key)
+		delete(d.inFlight, key)
+		return
+	}
 	if d.inFlight[key] {
 		return
 	}
@@ -147,18 +274,24 @@ func (d *keyLockDispatcher[K]) tryDrainLocked(key K) {
 // rejection (e.g., during shutdown). Both paths call onComplete; only the first wins.
 func (d *keyLockDispatcher[K]) dispatchLocked(key K, pt *pendingTask) {
 	var once sync.Once
-	onComplete := func(err error) {
+	complete := func(err error) {
 		once.Do(func() {
-			pt.resultCh <- err
-			close(pt.resultCh)
-
 			d.semaphore.Release()
 			metrics.WALFlusherSyncDispatcherPendingTasks.WithLabelValues(paramtable.GetStringNodeID()).Dec()
+			panicValue, finalErr := runCallbacks(err, pt.callbacks)
 
 			d.mu.Lock()
 			d.inFlight[key] = false
 			d.tryDrainLocked(key)
 			d.mu.Unlock()
+
+			// Future completion is the public completion fence: once Await returns,
+			// callbacks, semaphore accounting, and per-key ownership are all clean.
+			publishPendingTaskResult(pt, finalErr)
+			d.finishAccepted()
+			if panicValue != nil {
+				panic(panicValue)
+			}
 		})
 	}
 
@@ -176,47 +309,79 @@ func (d *keyLockDispatcher[K]) dispatchLocked(key K, pt *pendingTask) {
 
 			startTime := time.Now()
 			err := pt.task.Run(pt.ctx)
-			for _, cb := range pt.callbacks {
-				err = cb(err)
-			}
 			metrics.WALFlusherSyncDispatcherExecuteDuration.WithLabelValues(nodeID).Observe(time.Since(startTime).Seconds())
-			onComplete(err)
+			complete(err)
 			return struct{}{}, err
 		})
 
-		// Detect pool rejection (e.g., pool closed during shutdown).
-		// When the pool rejects a submission, it closes f's channel synchronously
-		// before Submit returns, so a non-blocking receive succeeds immediately.
-		// When the pool accepts, f's channel is still open (closed only after the
-		// task function completes), so the default branch is taken and this
-		// goroutine exits without blocking.
-		select {
-		case <-f.Inner():
-			onComplete(f.Err())
-		default:
-		}
+		// Watch every pool future. Normal execution calls complete before the
+		// future closes; pool rejection or a panic skips that call, and the watcher
+		// drives the same exact-once callback/cleanup funnel instead.
+		<-f.Inner()
+		complete(f.Err())
 	}()
 }
 
-// Close drains all remaining queued tasks across all keys, notifying each
-// pending Future with context.Canceled. Should be called after the worker pool
-// has been released to clean up tasks that were never dispatched.
-func (d *keyLockDispatcher[K]) Close() {
-	nodeID := paramtable.GetStringNodeID()
-	err := context.Canceled
+// beginClose fences new submissions, cancels semaphore waiters, and completes
+// every task that is still queued in the dispatcher. Tasks already handed to,
+// or asynchronously being handed to, the worker pool remain accepted and are
+// completed by their normal/rejection path.
+//
+// Worker-pool shutdown must happen after beginClose. Once ReleaseTimeout
+// succeeds, waitClosed makes the asynchronous Submit handoff part of the Close
+// completion fence without waiting forever for a worker after pool timeout.
+func (d *keyLockDispatcher[K]) beginClose() any {
 	d.mu.Lock()
-	defer d.mu.Unlock()
+	if d.closed {
+		d.mu.Unlock()
+		return nil
+	}
+	d.closed = true
+	d.closeCancel()
+	pending := make([]*pendingTask, 0)
 	for key, q := range d.queues {
 		for q.Len() > 0 {
 			elem := q.Front()
 			q.Remove(elem)
-			pt := elem.Value.(*pendingTask)
-			pt.resultCh <- err
-			close(pt.resultCh)
-			d.semaphore.Release()
-			metrics.WALFlusherSyncDispatcherPendingTasks.WithLabelValues(nodeID).Dec()
+			pending = append(pending, elem.Value.(*pendingTask))
 		}
 		delete(d.queues, key)
+	}
+	d.mu.Unlock()
+
+	// Callbacks are external code and may re-enter the dispatcher or the write
+	// buffer. Complete detached tasks only after releasing d.mu. Drain every
+	// task even if one callback panics, then preserve the first panic after all
+	// futures and semaphore slots have been cleaned up.
+	var firstPanic any
+	for _, pt := range pending {
+		if panicValue := d.finishDetached(pt, context.Canceled, true, true); panicValue != nil && firstPanic == nil {
+			firstPanic = panicValue
+		}
+	}
+	return firstPanic
+}
+
+// waitClosed waits until every task accepted before beginClose has completed
+// its callbacks, Future publication, and semaphore accounting. The context is
+// the shutdown bound; callers must not wait here after worker-pool timeout.
+func (d *keyLockDispatcher[K]) waitClosed(ctx context.Context) error {
+	d.mu.Lock()
+	for d.accepted > 0 {
+		if err := d.completed.Wait(ctx); err != nil {
+			return err
+		}
+	}
+	d.mu.Unlock()
+	return nil
+}
+
+// Close is the dispatcher-only close fence used by tests and callback
+// re-entry. SyncManager performs the complete bounded shutdown sequence with
+// beginClose, workerPool.ReleaseTimeout, and waitClosed.
+func (d *keyLockDispatcher[K]) Close() {
+	if panicValue := d.beginClose(); panicValue != nil {
+		panic(panicValue)
 	}
 }
 

--- a/internal/flushcommon/syncmgr/key_lock_dispatcher_test.go
+++ b/internal/flushcommon/syncmgr/key_lock_dispatcher_test.go
@@ -2,11 +2,11 @@ package syncmgr
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"

--- a/internal/flushcommon/syncmgr/key_lock_dispatcher_test.go
+++ b/internal/flushcommon/syncmgr/key_lock_dispatcher_test.go
@@ -2,6 +2,7 @@ package syncmgr
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -9,6 +10,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type KeyLockDispatcherSuite struct {
@@ -149,6 +153,237 @@ func (s *KeyLockDispatcherSuite) TestCallbackPropagation() {
 	_, err := f.Await()
 	s.NoError(err)
 	s.True(callbackCalled.Load())
+}
+
+func (s *KeyLockDispatcherSuite) TestCloseRunsQueuedCallbacksOutsideDispatcherLock() {
+	ctx := context.Background()
+	d := newKeyLockDispatcher[int64](1)
+
+	blocker := make(chan struct{})
+	first := NewMockTask(s.T())
+	first.EXPECT().Run(ctx).Run(func(context.Context) {
+		<-blocker
+	}).Return(nil)
+	second := NewMockTask(s.T())
+
+	firstFuture := d.Submit(ctx, 1, first)
+	callbackEntered := make(chan struct{})
+	secondFuture := d.Submit(ctx, 1, second, func(err error) error {
+		close(callbackEntered)
+		// Re-enter Close. This deadlocked when the outer Close invoked callbacks
+		// while still holding d.mu.
+		d.Close()
+		return err
+	})
+
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		d.Close()
+	}()
+
+	select {
+	case <-callbackEntered:
+	case <-time.After(time.Second):
+		s.FailNow("queued callback was not invoked")
+	}
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		s.FailNow("Close deadlocked on a re-entrant callback")
+	}
+	_, err := secondFuture.Await()
+	s.ErrorIs(err, context.Canceled)
+
+	close(blocker)
+	_, err = firstFuture.Await()
+	s.NoError(err)
+}
+
+func (s *KeyLockDispatcherSuite) TestSubmitAfterCloseIsRejectedAndCleaned() {
+	d := newKeyLockDispatcher[int64](1)
+	d.Close()
+
+	task := NewMockTask(s.T())
+	callbackCount := atomic.NewInt32(0)
+	future := d.Submit(context.Background(), 1, task, func(err error) error {
+		callbackCount.Inc()
+		return err
+	})
+
+	_, err := future.Await()
+	s.ErrorIs(err, context.Canceled)
+	s.EqualValues(1, callbackCount.Load())
+	s.Zero(d.Pending())
+	d.mu.Lock()
+	s.Empty(d.queues)
+	s.Empty(d.inFlight)
+	d.mu.Unlock()
+}
+
+func (s *KeyLockDispatcherSuite) TestCloseCancelsSubmitBlockedByBackpressure() {
+	d := newKeyLockDispatcher[int64](1)
+	capacity := d.semaphore.Cap()
+	for range capacity {
+		s.Require().NoError(d.semaphore.Acquire(context.Background()))
+	}
+
+	task := NewMockTask(s.T())
+	callbackCount := atomic.NewInt32(0)
+	futureCh := make(chan *conc.Future[struct{}], 1)
+	go func() {
+		futureCh <- d.Submit(context.Background(), 1, task, func(err error) error {
+			callbackCount.Inc()
+			return err
+		})
+	}()
+
+	s.Eventually(func() bool {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		return d.accepted == 1
+	}, time.Second, time.Millisecond)
+	s.Nil(d.beginClose())
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	s.NoError(d.waitClosed(waitCtx))
+	var future *conc.Future[struct{}]
+	select {
+	case future = <-futureCh:
+	case <-time.After(time.Second):
+		s.FailNow("Close did not cancel a Submit blocked on dispatcher backpressure")
+	}
+	_, err := future.Await()
+	s.ErrorIs(err, context.Canceled)
+	s.EqualValues(1, callbackCount.Load())
+	d.mu.Lock()
+	s.Zero(d.accepted)
+	d.mu.Unlock()
+
+	for range capacity {
+		d.semaphore.Release()
+	}
+}
+
+func (s *KeyLockDispatcherSuite) TestCallbackPanicDoesNotSkipLaterCleanup() {
+	attemptErr := errors.New("attempt failed")
+	cleanupCalled := false
+	panicValue, finalErr := runCallbacks(attemptErr, []func(error) error{
+		func(error) error {
+			panic("fatal callback")
+		},
+		func(err error) error {
+			cleanupCalled = true
+			s.ErrorIs(err, attemptErr)
+			return nil
+		},
+		func(err error) error {
+			s.ErrorIs(err, attemptErr)
+			return err
+		},
+	})
+
+	s.True(cleanupCalled)
+	s.Equal("fatal callback", panicValue)
+	s.ErrorIs(finalErr, attemptErr)
+}
+
+func (s *KeyLockDispatcherSuite) TestCallbackPanicWithoutAttemptErrorBecomesSystemError() {
+	cleanupCalled := false
+	panicValue, finalErr := runCallbacks(nil, []func(error) error{
+		func(error) error {
+			panic("fatal callback")
+		},
+		func(err error) error {
+			cleanupCalled = true
+			s.ErrorIs(err, merr.ErrServiceInternal)
+			return nil
+		},
+	})
+
+	s.True(cleanupCalled)
+	s.Equal("fatal callback", panicValue)
+	s.ErrorIs(finalErr, merr.ErrServiceInternal)
+}
+
+func (s *KeyLockDispatcherSuite) TestFutureCompletesAfterDispatcherCleanup() {
+	d := newKeyLockDispatcher[int64](1)
+	task := NewMockTask(s.T())
+	task.EXPECT().Run(mock.Anything).Return(nil).Once()
+
+	future := d.Submit(context.Background(), 1, task)
+	_, err := future.Await()
+	s.NoError(err)
+	s.Zero(d.Pending())
+	d.mu.Lock()
+	s.Empty(d.queues)
+	s.False(d.inFlight[1])
+	d.mu.Unlock()
+}
+
+func (s *KeyLockDispatcherSuite) TestPoolRejectionCompletesExactlyOnce() {
+	d := newKeyLockDispatcher[int64](1)
+	d.workerPool.Release()
+
+	task := NewMockTask(s.T())
+	callbackCount := atomic.NewInt32(0)
+	future := d.Submit(context.Background(), 1, task, func(err error) error {
+		callbackCount.Inc()
+		return err
+	})
+
+	_, err := future.Await()
+	s.Error(err)
+	s.EqualValues(1, callbackCount.Load())
+	s.Zero(d.Pending())
+}
+
+func (s *KeyLockDispatcherSuite) TestCloseWaitsForAsyncPoolSubmitHandoff() {
+	d := newKeyLockDispatcher[int64](1)
+
+	workerStarted := make(chan struct{})
+	releaseWorker := make(chan struct{})
+	workerFuture := d.workerPool.Submit(func() (struct{}, error) {
+		close(workerStarted)
+		<-releaseWorker
+		return struct{}{}, nil
+	})
+	<-workerStarted
+
+	task := NewMockTask(s.T())
+	callbackCount := atomic.NewInt32(0)
+	future := d.Submit(context.Background(), 1, task, func(err error) error {
+		callbackCount.Inc()
+		return err
+	})
+	s.Eventually(func() bool {
+		return d.workerPool.Waiting() > 0
+	}, time.Second, time.Millisecond, "dispatcher handoff did not block in workerPool.Submit")
+
+	s.Nil(d.beginClose())
+	releaseDone := make(chan error, 1)
+	go func() {
+		releaseDone <- d.workerPool.ReleaseTimeout(time.Second)
+	}()
+	s.Eventually(d.workerPool.IsClosed, time.Second, time.Millisecond)
+	close(releaseWorker)
+	s.NoError(<-releaseDone)
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	s.NoError(d.waitClosed(waitCtx))
+
+	_, err := future.Await()
+	s.Error(err)
+	_, err = workerFuture.Await()
+	s.NoError(err)
+	s.EqualValues(1, callbackCount.Load())
+	s.Zero(d.Pending())
+	d.mu.Lock()
+	s.Zero(d.accepted)
+	s.Empty(d.queues)
+	s.Empty(d.inFlight)
+	d.mu.Unlock()
 }
 
 // TestMixedKeysConcurrency verifies a realistic scenario: multiple segments

--- a/internal/flushcommon/syncmgr/meta_writer.go
+++ b/internal/flushcommon/syncmgr/meta_writer.go
@@ -319,7 +319,7 @@ func insertBinlogTimestampRange(inserts map[int64]*datapb.FieldBinlog) (uint64, 
 
 func (b *brokerMetaWriter) DropChannel(ctx context.Context, channelName string) error {
 	err := retry.Handle(ctx, func() (bool, error) {
-		status, err := b.broker.DropVirtualChannel(context.Background(), &datapb.DropVirtualChannelRequest{
+		status, err := b.broker.DropVirtualChannel(ctx, &datapb.DropVirtualChannelRequest{
 			Base: commonpbutil.NewMsgBase(
 				commonpbutil.WithSourceID(b.serverID),
 			),

--- a/internal/flushcommon/syncmgr/meta_writer_test.go
+++ b/internal/flushcommon/syncmgr/meta_writer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
@@ -105,6 +106,38 @@ func (s *MetaWriterSuite) TestReturnError() {
 	task := NewSyncTask().WithMetaCache(s.metacache).WithSyncPack(new(SyncPack))
 	err := s.writer.UpdateSync(ctx, task)
 	s.Error(err)
+}
+
+func (s *MetaWriterSuite) TestDropChannelPropagatesCallerContext() {
+	type contextKey struct{}
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey{}, "caller"))
+	received := make(chan context.Context, 1)
+	s.broker.EXPECT().DropVirtualChannel(mock.Anything, mock.Anything).RunAndReturn(
+		func(callCtx context.Context, _ *datapb.DropVirtualChannelRequest) (*datapb.DropVirtualChannelResponse, error) {
+			received <- callCtx
+			<-callCtx.Done()
+			return nil, callCtx.Err()
+		}).Once()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.writer.DropChannel(ctx, "channel")
+	}()
+
+	select {
+	case callCtx := <-received:
+		s.Equal("caller", callCtx.Value(contextKey{}))
+	case <-time.After(time.Second):
+		s.FailNow("DropVirtualChannel was not called")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		s.ErrorIs(err, context.Canceled)
+	case <-time.After(time.Second):
+		s.FailNow("DropChannel ignored caller cancellation")
+	}
 }
 
 func (s *MetaWriterSuite) TestGrowingSourceSyncPersistsColumnGroupBinlogs() {

--- a/internal/flushcommon/syncmgr/options.go
+++ b/internal/flushcommon/syncmgr/options.go
@@ -78,3 +78,13 @@ func (t *SyncTask) WithFailureCallback(callback func(error)) *SyncTask {
 	t.failureCallback = callback
 	return t
 }
+
+// WithPayloadAccounting tracks the in-memory row payload until ReleaseData is
+// actually called. The callback runs exactly once, including terminal discard
+// paths that never enter Run.
+func (t *SyncTask) WithPayloadAccounting(insertBytes, deleteBytes int64, onRelease func(int64)) *SyncTask {
+	t.payload = &syncTaskPayloadAccounting{onRelease: onRelease}
+	t.payload.insertBytes.Store(insertBytes)
+	t.payload.deleteBytes.Store(deleteBytes)
+	return t
+}

--- a/internal/flushcommon/syncmgr/sync_manager.go
+++ b/internal/flushcommon/syncmgr/sync_manager.go
@@ -51,7 +51,9 @@ type SyncManager interface {
 	SyncData(ctx context.Context, task Task, callbacks ...func(error) error) (*conc.Future[struct{}], error)
 	SyncDataWithChunkManager(ctx context.Context, task Task, chunkManager storage.ChunkManager, callbacks ...func(error) error) (*conc.Future[struct{}], error)
 
-	// Close waits for the task to finish and then shuts down the sync manager.
+	// Close fences new submissions and shuts down the sync manager. A nil return
+	// means every accepted task has completed callbacks, Future publication, and
+	// dispatcher accounting. On timeout, running tasks may complete asynchronously.
 	Close() error
 	TaskStatsJSON() string
 }
@@ -187,8 +189,22 @@ func (mgr *syncManager) TaskStatsJSON() string {
 func (mgr *syncManager) Close() error {
 	paramtable.Get().Unwatch(paramtable.Get().DataNodeCfg.MaxParallelSyncMgrTasksPerCPUCore.Key, mgr.handler)
 	timeout := paramtable.Get().CommonCfg.SyncTaskPoolReleaseTimeoutSeconds.GetAsDuration(time.Second)
-	err := mgr.workerPool.ReleaseTimeout(timeout)
-	// Drain all remaining queued tasks that were never dispatched.
-	mgr.keyLockDispatcher.Close()
+	deadline := time.Now().Add(timeout)
+	panicValue := mgr.beginClose()
+	remaining := time.Until(deadline)
+	var err error
+	if remaining <= 0 {
+		err = context.DeadlineExceeded
+	} else {
+		err = mgr.workerPool.ReleaseTimeout(remaining)
+	}
+	if err == nil {
+		ctx, cancel := context.WithDeadline(context.Background(), deadline)
+		err = mgr.waitClosed(ctx)
+		cancel()
+	}
+	if panicValue != nil {
+		panic(panicValue)
+	}
 	return err
 }

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -314,6 +314,12 @@ func (t *SyncTask) writeMeta(ctx context.Context) error {
 	return t.metaWriter.UpdateSync(ctx, t)
 }
 
+// BatchRows is the row count this attempt carries. The write buffer needs it
+// to pair StartSyncing with Abort/FinishSyncing across a re-submission.
+func (t *SyncTask) BatchRows() int64 {
+	return t.batchRows
+}
+
 func (t *SyncTask) SegmentID() int64 {
 	return t.segmentID
 }

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -87,6 +87,9 @@ type SyncTask struct {
 	writeRetryOpts []retry.Option
 
 	failureCallback func(err error)
+	dataWritten     bool
+	preparedStats   *metacache.SegmentStats
+	preparedColumns []storagecommon.ColumnGroup
 
 	tr *timerecord.TimeRecorder
 
@@ -123,72 +126,80 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 	t.tr = timerecord.NewTimeRecorder("syncTask")
 
 	logger := t.getLogger()
-	defer func() {
-		if err != nil {
-			t.HandleError(err)
-		}
-	}()
 
 	segmentInfo, has := t.metacache.GetSegmentByID(t.segmentID)
 	if !has {
 		if t.pack.isDrop {
 			logger.Info(ctx, "segment dropped, discard sync task")
+			t.releasePayload()
 			return nil
 		}
 		logger.Warn(ctx, "segment not found in metacache, may be already synced")
+		t.releasePayload()
 		return nil
 	}
 
-	columnGroups := t.getColumnGroups(segmentInfo)
+	columnGroups := t.preparedColumns
 
-	// statsWriter, when set (V2 / V3), exposes this sync's prepared cumulative
-	// stats. SyncTask.Run installs it on the metaCache only after the DataCoord
-	// ack below, so a failed/retried sync never double-counts.
-	var statsWriter interface {
-		PreparedStats() *metacache.SegmentStats
-	}
-
-	switch segmentInfo.GetStorageVersion() {
-	case storage.StorageV2:
-		// New sync task means needs to flush data immediately, so do not need to buffer data in writer again.
-		writer := NewBulkPackWriterV2(t.metacache, t.schema, t.chunkManager, t.allocator, 0,
-			packed.DefaultMultiPartUploadSize, t.storageConfig, columnGroups, t.writeRetryOpts...)
-		t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.manifestPath, t.flushedSize, t.stats, err = writer.Write(ctx, t.pack)
-		statsWriter = writer
-	case storage.StorageV3:
-		writer := NewBulkPackWriterV3(t.metacache, t.schema, t.chunkManager, t.allocator, 0,
-			packed.DefaultMultiPartUploadSize, t.storageConfig, columnGroups, segmentInfo.ManifestPath(), t.writeRetryOpts...)
-		t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.manifestPath, t.flushedSize, t.stats, err = writer.Write(ctx, t.pack)
-		statsWriter = writer
-	default:
-		writer, writerErr := NewBulkPackWriter(t.metacache, t.schema, t.chunkManager, t.allocator, t.writeRetryOpts...)
-		if writerErr != nil {
-			return writerErr
+	if !t.dataWritten {
+		columnGroups = t.getColumnGroups(segmentInfo)
+		// statsWriter, when set (V2 / V3), exposes this sync's prepared cumulative
+		// stats. Freeze it with the logical task so a metadata retry does not write
+		// the payload again or publish different statistics.
+		var statsWriter interface {
+			PreparedStats() *metacache.SegmentStats
 		}
-		t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.flushedSize, err = writer.Write(ctx, t.pack)
-	}
 
-	if err != nil {
-		logger.Warn(ctx, "failed to write sync data with storage v2 format", mlog.Err(err))
-		return err
-	}
-
-	getDataCount := func(binlogs ...*datapb.FieldBinlog) int64 {
-		count := int64(0)
-		for _, binlog := range binlogs {
-			for _, fbinlog := range binlog.GetBinlogs() {
-				count += fbinlog.GetEntriesNum()
+		switch segmentInfo.GetStorageVersion() {
+		case storage.StorageV2:
+			// New sync task means needs to flush data immediately, so do not need to buffer data in writer again.
+			writer := NewBulkPackWriterV2(t.metacache, t.schema, t.chunkManager, t.allocator, 0,
+				packed.DefaultMultiPartUploadSize, t.storageConfig, columnGroups, t.writeRetryOpts...)
+			t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.manifestPath, t.flushedSize, t.stats, err = writer.Write(ctx, t.pack)
+			statsWriter = writer
+		case storage.StorageV3:
+			writer := NewBulkPackWriterV3(t.metacache, t.schema, t.chunkManager, t.allocator, 0,
+				packed.DefaultMultiPartUploadSize, t.storageConfig, columnGroups, segmentInfo.ManifestPath(), t.writeRetryOpts...)
+			t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.manifestPath, t.flushedSize, t.stats, err = writer.Write(ctx, t.pack)
+			statsWriter = writer
+		default:
+			writer, writerErr := NewBulkPackWriter(t.metacache, t.schema, t.chunkManager, t.allocator, t.writeRetryOpts...)
+			if writerErr != nil {
+				return writerErr
 			}
+			t.insertBinlogs, t.deltaBinlog, t.statsBinlogs, t.bm25Binlogs, t.flushedSize, err = writer.Write(ctx, t.pack)
 		}
-		return count
+
+		if err != nil {
+			logger.Warn(ctx, "failed to write sync data", mlog.Err(err))
+			return err
+		}
+		t.dataWritten = true
+		t.preparedColumns = columnGroups
+		if statsWriter != nil {
+			t.preparedStats = statsWriter.PreparedStats()
+		}
+
+		getDataCount := func(binlogs ...*datapb.FieldBinlog) int64 {
+			count := int64(0)
+			for _, binlog := range binlogs {
+				for _, fbinlog := range binlog.GetBinlogs() {
+					count += fbinlog.GetEntriesNum()
+				}
+			}
+			return count
+		}
+		metrics.DataNodeWriteDataCount.WithLabelValues(paramtable.GetStringNodeID(), t.dataSource, metrics.InsertLabel, fmt.Sprint(t.collectionID)).Add(float64(t.batchRows))
+		metrics.DataNodeWriteDataCount.WithLabelValues(paramtable.GetStringNodeID(), t.dataSource, metrics.DeleteLabel, fmt.Sprint(t.collectionID)).Add(float64(getDataCount(t.deltaBinlog)))
+		metrics.DataNodeFlushedSize.WithLabelValues(paramtable.GetStringNodeID(), t.dataSource, t.level.String()).Add(float64(t.flushedSize))
+		metrics.DataNodeFlushedRows.WithLabelValues(paramtable.GetStringNodeID(), t.dataSource).Add(float64(t.batchRows))
+		metrics.DataNodeSave2StorageLatency.WithLabelValues(paramtable.GetStringNodeID(), t.level.String()).Observe(float64(t.tr.RecordSpan().Milliseconds()))
+
+		// Metadata retry only needs the frozen binlogs, statistics and column
+		// groups above. Release the row payload as soon as object storage has
+		// accepted it instead of retaining a large pack across metadata retries.
+		t.releasePayload()
 	}
-	metrics.DataNodeWriteDataCount.WithLabelValues(paramtable.GetStringNodeID(), t.dataSource, metrics.InsertLabel, fmt.Sprint(t.collectionID)).Add(float64(t.batchRows))
-	metrics.DataNodeWriteDataCount.WithLabelValues(paramtable.GetStringNodeID(), t.dataSource, metrics.DeleteLabel, fmt.Sprint(t.collectionID)).Add(float64(getDataCount(t.deltaBinlog)))
-	metrics.DataNodeFlushedSize.WithLabelValues(paramtable.GetStringNodeID(), t.dataSource, t.level.String()).Add(float64(t.flushedSize))
-
-	metrics.DataNodeFlushedRows.WithLabelValues(paramtable.GetStringNodeID(), t.dataSource).Add(float64(t.batchRows))
-
-	metrics.DataNodeSave2StorageLatency.WithLabelValues(paramtable.GetStringNodeID(), t.level.String()).Observe(float64(t.tr.RecordSpan().Milliseconds()))
 
 	if t.metaWriter != nil {
 		err = t.writeMeta(ctx)
@@ -197,8 +208,6 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 			return err
 		}
 	}
-
-	t.pack.ReleaseData()
 
 	actions := []metacache.SegmentAction{metacache.FinishSyncing(t.batchRows), metacache.UpdateManifestPath(t.manifestPath)}
 	if columnGroups != nil {
@@ -209,8 +218,8 @@ func (t *SyncTask) Run(ctx context.Context) (err error) {
 	}
 	// Install the prepared cumulative stats directly in the commit transaction:
 	// no digest work, the exact object whose Publish() DataCoord just persisted.
-	if statsWriter != nil {
-		actions = append(actions, metacache.SetStatistics(statsWriter.PreparedStats()))
+	if t.preparedStats != nil {
+		actions = append(actions, metacache.SetStatistics(t.preparedStats))
 	}
 	t.metacache.UpdateSegments(metacache.MergeSegmentAction(actions...), metacache.WithSegmentIDs(t.segmentID))
 
@@ -318,6 +327,19 @@ func (t *SyncTask) writeMeta(ctx context.Context) error {
 // to pair StartSyncing with Abort/FinishSyncing across a re-submission.
 func (t *SyncTask) BatchRows() int64 {
 	return t.batchRows
+}
+
+func (t *SyncTask) releasePayload() {
+	if t.pack != nil {
+		t.pack.ReleaseData()
+	}
+}
+
+// ReleasePayload discards the in-memory input owned by this logical task. It
+// is idempotent and is used only after the write buffer has decided that the
+// task will never be submitted again (shutdown or terminal failure).
+func (t *SyncTask) ReleasePayload() {
+	t.releasePayload()
 }
 
 func (t *SyncTask) SegmentID() int64 {

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -19,6 +19,8 @@ package syncmgr
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/samber/lo"
@@ -44,6 +46,13 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+type syncTaskPayloadAccounting struct {
+	insertBytes atomic.Int64
+	deleteBytes atomic.Int64
+	releaseOnce sync.Once
+	onRelease   func(int64)
+}
 
 type SyncTask struct {
 	chunkManager storage.ChunkManager
@@ -87,6 +96,7 @@ type SyncTask struct {
 	writeRetryOpts []retry.Option
 
 	failureCallback func(err error)
+	payload         *syncTaskPayloadAccounting
 	dataWritten     bool
 	preparedStats   *metacache.SegmentStats
 	preparedColumns []storagecommon.ColumnGroup
@@ -330,9 +340,21 @@ func (t *SyncTask) BatchRows() int64 {
 }
 
 func (t *SyncTask) releasePayload() {
-	if t.pack != nil {
-		t.pack.ReleaseData()
+	if t.payload == nil {
+		if t.pack != nil {
+			t.pack.ReleaseData()
+		}
+		return
 	}
+	t.payload.releaseOnce.Do(func() {
+		if t.pack != nil {
+			t.pack.ReleaseData()
+		}
+		released := t.payload.insertBytes.Swap(0) + t.payload.deleteBytes.Swap(0)
+		if t.payload.onRelease != nil {
+			t.payload.onRelease(released)
+		}
+	})
 }
 
 // ReleasePayload discards the in-memory input owned by this logical task. It
@@ -340,6 +362,29 @@ func (t *SyncTask) releasePayload() {
 // task will never be submitted again (shutdown or terminal failure).
 func (t *SyncTask) ReleasePayload() {
 	t.releasePayload()
+}
+
+// PayloadBytes is the ordinary row payload still retained by this task.
+// Metadata-only retries report zero after the object data has been written.
+func (t *SyncTask) PayloadBytes() int64 {
+	if t.payload == nil {
+		return 0
+	}
+	return t.payload.insertBytes.Load() + t.payload.deleteBytes.Load()
+}
+
+func (t *SyncTask) InsertPayloadBytes() int64 {
+	if t.payload == nil {
+		return 0
+	}
+	return t.payload.insertBytes.Load()
+}
+
+func (t *SyncTask) DeletePayloadBytes() int64 {
+	if t.payload == nil {
+		return 0
+	}
+	return t.payload.deleteBytes.Load()
 }
 
 func (t *SyncTask) SegmentID() int64 {

--- a/internal/flushcommon/syncmgr/task_test.go
+++ b/internal/flushcommon/syncmgr/task_test.go
@@ -472,18 +472,41 @@ func (s *SyncTaskSuite) TestRunError() {
 	s.metacache.EXPECT().GetSchema(mock.Anything).Return(s.schema).Maybe()
 
 	s.Run("metawrite_fail", func() {
-		s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Return(errors.New("mocked"))
+		metaErr := errors.New("mocked")
+		s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Return(metaErr).Once()
+		s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Return(nil).Once()
+		s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return().Maybe()
 
 		task := s.getSuiteSyncTask(new(SyncPack).
+			WithInsertData([]*storage.InsertData{s.getInsertBuffer()}).
 			WithCheckpoint(&msgpb.MsgPosition{
 				ChannelName: s.channelName,
 				MsgID:       []byte{1, 2, 3, 4},
 				Timestamp:   100,
 			}))
 		task.WithMetaWriter(BrokerMetaWriter(s.broker, 1, retry.Attempts(1)))
+		s.NotEmpty(task.pack.insertData)
+		writeCallCount := func() int {
+			count := 0
+			for _, call := range s.chunkManager.Calls {
+				if call.Method == "Write" {
+					count++
+				}
+			}
+			return count
+		}
 
 		err := task.Run(ctx)
-		s.Error(err)
+		s.ErrorIs(err, metaErr)
+		s.True(task.dataWritten)
+		s.Empty(task.pack.insertData, "metadata retry must not retain the row payload")
+		firstWriteCalls := writeCallCount()
+		s.Positive(firstWriteCalls)
+
+		err = task.Run(ctx)
+		s.NoError(err)
+		s.Empty(task.pack.insertData)
+		s.Equal(firstWriteCalls, writeCallCount(), "metadata retry must not rewrite object-storage payloads")
 	})
 
 	s.Run("chunk_manager_save_fail", func() {
@@ -499,7 +522,7 @@ func (s *SyncTaskSuite) TestRunError() {
 		err := task.Run(ctx)
 
 		s.Error(err)
-		s.True(flag)
+		s.False(flag, "SyncManager owns the single HandleError call")
 	})
 }
 

--- a/internal/flushcommon/syncmgr/task_test.go
+++ b/internal/flushcommon/syncmgr/task_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -477,15 +479,19 @@ func (s *SyncTaskSuite) TestRunError() {
 		s.broker.EXPECT().SaveBinlogPaths(mock.Anything, mock.Anything).Return(nil).Once()
 		s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return().Maybe()
 
+		var payloadReleases atomic.Int32
 		task := s.getSuiteSyncTask(new(SyncPack).
 			WithInsertData([]*storage.InsertData{s.getInsertBuffer()}).
 			WithCheckpoint(&msgpb.MsgPosition{
 				ChannelName: s.channelName,
 				MsgID:       []byte{1, 2, 3, 4},
 				Timestamp:   100,
-			}))
+			})).WithPayloadAccounting(100, 0, func(int64) {
+			payloadReleases.Add(1)
+		})
 		task.WithMetaWriter(BrokerMetaWriter(s.broker, 1, retry.Attempts(1)))
 		s.NotEmpty(task.pack.insertData)
+		s.EqualValues(100, task.PayloadBytes())
 		writeCallCount := func() int {
 			count := 0
 			for _, call := range s.chunkManager.Calls {
@@ -500,6 +506,8 @@ func (s *SyncTaskSuite) TestRunError() {
 		s.ErrorIs(err, metaErr)
 		s.True(task.dataWritten)
 		s.Empty(task.pack.insertData, "metadata retry must not retain the row payload")
+		s.Zero(task.PayloadBytes())
+		s.EqualValues(1, payloadReleases.Load())
 		firstWriteCalls := writeCallCount()
 		s.Positive(firstWriteCalls)
 
@@ -507,23 +515,65 @@ func (s *SyncTaskSuite) TestRunError() {
 		s.NoError(err)
 		s.Empty(task.pack.insertData)
 		s.Equal(firstWriteCalls, writeCallCount(), "metadata retry must not rewrite object-storage payloads")
+		s.EqualValues(1, payloadReleases.Load())
 	})
 
 	s.Run("chunk_manager_save_fail", func() {
 		flag := false
+		var payloadReleases atomic.Int32
 		handler := func(_ error) { flag = true }
 		s.chunkManager.ExpectedCalls = nil
 		s.chunkManager.EXPECT().RootPath().Return("files")
 		s.chunkManager.EXPECT().Write(mock.Anything, mock.Anything, mock.Anything).Return(merr.WrapErrIoPermissionDenied("mocked-key", errors.New("mocked")))
 		task := s.getSuiteSyncTask(new(SyncPack).WithInsertData([]*storage.InsertData{s.getInsertBuffer()})).
 			WithFailureCallback(handler).
+			WithPayloadAccounting(100, 0, func(int64) { payloadReleases.Add(1) }).
 			WithWriteRetryOptions(retry.AttemptAlways(), retry.MaxSleepTime(10*time.Second))
 
 		err := task.Run(ctx)
 
 		s.Error(err)
 		s.False(flag, "SyncManager owns the single HandleError call")
+		s.EqualValues(100, task.PayloadBytes())
+		s.Zero(payloadReleases.Load())
+		task.ReleasePayload()
+		s.Zero(task.PayloadBytes())
+		s.EqualValues(1, payloadReleases.Load())
 	})
+}
+
+func (s *SyncTaskSuite) TestPayloadAccountingReleaseIsExactOnce() {
+	pack := new(SyncPack).
+		WithInsertData([]*storage.InsertData{{}}).
+		WithDeleteData(&storage.DeleteData{})
+	var releaseCount atomic.Int32
+	var releasedBytes atomic.Int64
+	task := NewSyncTask().
+		WithSyncPack(pack).
+		WithPayloadAccounting(60, 40, func(released int64) {
+			releaseCount.Add(1)
+			releasedBytes.Add(released)
+		})
+
+	s.EqualValues(100, task.PayloadBytes())
+	s.EqualValues(60, task.InsertPayloadBytes())
+	s.EqualValues(40, task.DeletePayloadBytes())
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			task.ReleasePayload()
+		}()
+	}
+	wg.Wait()
+
+	s.Zero(task.PayloadBytes())
+	s.Empty(pack.insertData)
+	s.Nil(pack.deltaData)
+	s.EqualValues(1, releaseCount.Load())
+	s.EqualValues(100, releasedBytes.Load())
 }
 
 func (s *SyncTaskSuite) TestSyncTask_MarshalJSON() {

--- a/internal/flushcommon/writebuffer/insert_buffer.go
+++ b/internal/flushcommon/writebuffer/insert_buffer.go
@@ -138,7 +138,9 @@ func (ib *InsertBuffer) Buffer(inData *InsertData, startPos, endPos *msgpb.MsgPo
 		bufferedSize += int64(data.GetMemorySize())
 	}
 	if inData.bm25Stats != nil {
-		ib.statsBuffer.Buffer(inData.bm25Stats)
+		statsSize := ib.statsBuffer.Buffer(inData.bm25Stats)
+		ib.size += statsSize
+		bufferedSize += statsSize
 	}
 
 	return bufferedSize

--- a/internal/flushcommon/writebuffer/insert_buffer_test.go
+++ b/internal/flushcommon/writebuffer/insert_buffer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -126,6 +127,62 @@ func (s *InsertBufferSuite) TestBasic() {
 		s.True(insertBuffer.IsFull())
 		s.False(insertBuffer.IsEmpty())
 	})
+}
+
+func (s *InsertBufferSuite) TestBM25StatsCountTowardBufferSize() {
+	schema := &schemapb.CollectionSchema{
+		Name:      s.collSchema.Name,
+		Fields:    s.collSchema.Fields,
+		Functions: []*schemapb.FunctionSchema{{Name: "bm25"}},
+	}
+	insertBuffer, err := NewInsertBuffer(schema)
+	s.Require().NoError(err)
+
+	stats := storage.NewBM25Stats()
+	stats.Append(map[uint32]float32{1: 1, 2: 1})
+	insertBuffer.sizeLimit = stats.MemSize()
+	insertData := &InsertData{
+		data:      []*storage.InsertData{{}},
+		tsField:   []*storage.Int64FieldData{{Data: []int64{100}}},
+		bm25Stats: map[int64]*storage.BM25Stats{101: stats},
+	}
+	buffered := insertBuffer.Buffer(insertData,
+		&msgpb.MsgPosition{Timestamp: 100},
+		&msgpb.MsgPosition{Timestamp: 200})
+
+	s.Equal(stats.MemSize(), buffered)
+	s.Equal(stats.MemSize(), insertBuffer.size)
+	s.Equal(stats.MemSize(), insertBuffer.statsBuffer.MemorySize())
+	s.True(insertBuffer.IsFull())
+
+	moreStats := storage.NewBM25Stats()
+	moreStats.Append(map[uint32]float32{2: 1, 3: 1})
+	before := insertBuffer.statsBuffer.MemorySize()
+	insertData.bm25Stats = map[int64]*storage.BM25Stats{101: moreStats}
+	buffered = insertBuffer.Buffer(insertData,
+		&msgpb.MsgPosition{Timestamp: 201},
+		&msgpb.MsgPosition{Timestamp: 300})
+
+	s.Equal(insertBuffer.statsBuffer.MemorySize()-before, buffered)
+	s.Equal(insertBuffer.statsBuffer.MemorySize(), insertBuffer.size)
+
+	before = insertBuffer.size
+	insertData.bm25Stats = map[int64]*storage.BM25Stats{101: nil}
+	buffered = insertBuffer.Buffer(insertData,
+		&msgpb.MsgPosition{Timestamp: 301},
+		&msgpb.MsgPosition{Timestamp: 400})
+	s.Zero(buffered)
+	s.Equal(before, insertBuffer.size)
+
+	replacement := storage.NewBM25Stats()
+	replacement.Append(map[uint32]float32{4: 1})
+	insertBuffer.statsBuffer.bm25Stats[102] = nil
+	insertData.bm25Stats = map[int64]*storage.BM25Stats{102: replacement}
+	buffered = insertBuffer.Buffer(insertData,
+		&msgpb.MsgPosition{Timestamp: 401},
+		&msgpb.MsgPosition{Timestamp: 500})
+	s.Equal(replacement.MemSize(), buffered)
+	s.Equal(insertBuffer.statsBuffer.MemorySize(), insertBuffer.size)
 }
 
 func (s *InsertBufferSuite) TestBuffer() {

--- a/internal/flushcommon/writebuffer/l0_write_buffer.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer.go
@@ -105,7 +105,7 @@ func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgs
 		wb.syncSegments(wb.syncCtx, segmentsSync)
 	}
 
-	return nil
+	return wb.waitFlushCapacity()
 }
 
 // bufferInsert function InsertMsg into bufferred InsertData and returns primary key field data for future usage.

--- a/internal/flushcommon/writebuffer/l0_write_buffer.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer.go
@@ -60,6 +60,10 @@ func (wb *l0WriteBuffer) dispatchDeleteMsgsWithoutFilter(deleteMsgs []*msgstream
 
 func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition, schemaVersion int32) error {
 	wb.mut.Lock()
+	if wb.closed || wb.dropping {
+		wb.mut.Unlock()
+		return merr.WrapErrChannelNotFound(wb.channelName)
+	}
 
 	for _, inData := range insertData {
 		if wb.allowGrowingSourceFlush {
@@ -74,8 +78,7 @@ func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgs
 			}
 		}
 
-		err := wb.bufferInsert(inData, startPos, endPos, schemaVersion)
-		if err != nil {
+		if err := wb.bufferInsert(inData, startPos, endPos, schemaVersion); err != nil {
 			wb.mut.Unlock()
 			return err
 		}
@@ -85,7 +88,6 @@ func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgs
 	// So, here we skip generating BF (growing segment's BF will be regenerated during the sync phase)
 	// and also skip filtering delete entries by bf.
 	wb.dispatchDeleteMsgsWithoutFilter(deleteMsgs, startPos, endPos)
-	// update buffer last checkpoint
 	wb.checkpoint = endPos
 	wb.updateProcessedTsLocked(endPos.GetTimestamp())
 
@@ -97,11 +99,10 @@ func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgs
 			delete(wb.l0Segments, partition)
 		}
 	}
-	syncTasks := wb.getSyncTasksLocked(context.Background(), segmentsSync)
 	wb.mut.Unlock()
 
-	if len(syncTasks) > 0 {
-		wb.submitSyncTasks(context.Background(), syncTasks)
+	if len(segmentsSync) > 0 {
+		wb.syncSegments(wb.syncCtx, segmentsSync)
 	}
 
 	return nil

--- a/internal/flushcommon/writebuffer/l0_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer_test.go
@@ -380,6 +380,81 @@ func (s *L0WriteBufferSuite) TestBufferData() {
 	})
 }
 
+func (s *L0WriteBufferSuite) TestOrdinaryPayloadBackpressureStartsAfterSubmit() {
+	paramtable.Get().Save(paramtable.Get().CommonCfg.EnableGrowingSourceFlush.Key, "false")
+	paramtable.Get().Save(paramtable.Get().DataNodeCfg.FlushInsertBufferSize.Key, "1")
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.EnableGrowingSourceFlush.Key)
+	defer paramtable.Get().Reset(paramtable.Get().DataNodeCfg.FlushInsertBufferSize.Key)
+
+	const segmentID = int64(1000)
+	segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             segmentID,
+		PartitionID:    10,
+		CollectionID:   s.collID,
+		State:          commonpb.SegmentState_Growing,
+		StorageVersion: storage.StorageV2,
+	}, pkoracle.NewBloomFilterSet(), nil, metacache.NewEmptySegmentStats())
+	s.metacache.EXPECT().GetSegmentByID(segmentID).Return(nil, false).Once()
+	s.metacache.EXPECT().GetSegmentByID(segmentID).Return(segment, true).Maybe()
+	s.metacache.EXPECT().AddSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Once()
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return().Maybe()
+
+	wb, err := NewL0WriteBuffer(s.channelName, s.metacache, s.syncMgr, &writeBufferOption{
+		idAllocator:  s.allocator,
+		syncPolicies: []SyncPolicy{GetFullBufferPolicy()},
+	})
+	s.Require().NoError(err)
+	l0wb := wb.(*l0WriteBuffer)
+
+	submitted := make(chan *syncmgr.SyncTask, 1)
+	s.syncMgr.EXPECT().SyncData(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, task syncmgr.Task, _ ...func(error) error) (*conc.Future[struct{}], error) {
+			ordinaryTask := task.(*syncmgr.SyncTask)
+			submitted <- ordinaryTask
+			return conc.Go(func() (struct{}, error) { return struct{}{}, nil }), nil
+		}).Once()
+
+	_, msg := s.composeInsertMsg(segmentID, 1, 128, schemapb.DataType_Int64)
+	insertData, err := PrepareInsert(s.collSchema, s.pkSchema, []*msgstream.InsertMsg{msg})
+	s.Require().NoError(err)
+	metrics.DataNodeFlowGraphBufferDataSize.Reset()
+
+	bufferDone := make(chan error, 1)
+	go func() {
+		bufferDone <- wb.BufferData(insertData, nil,
+			&msgpb.MsgPosition{Timestamp: 100},
+			&msgpb.MsgPosition{Timestamp: 200}, 100)
+	}()
+
+	var task *syncmgr.SyncTask
+	select {
+	case task = <-submitted:
+	case <-time.After(time.Second):
+		s.FailNow("full payload was not submitted before backpressure")
+	}
+	select {
+	case err := <-bufferDone:
+		s.FailNow("BufferData returned before the in-flight payload was released", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	s.Equal(task.PayloadBytes(), l0wb.MemorySize())
+	value, err := metrics.DataNodeFlowGraphBufferDataSize.GetMetricWithLabelValues(
+		paramtable.GetStringNodeID(), fmt.Sprint(s.metacache.Collection()))
+	s.Require().NoError(err)
+	s.MetricsEqual(value, float64(task.PayloadBytes()))
+
+	task.ReleasePayload()
+	select {
+	case err := <-bufferDone:
+		s.NoError(err)
+	case <-time.After(time.Second):
+		s.FailNow("payload release did not remove BufferData backpressure")
+	}
+	s.Zero(l0wb.MemorySize())
+	s.MetricsEqual(value, 0)
+}
+
 func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
 	paramtable.Get().Save(paramtable.Get().CommonCfg.EnableGrowingSourceFlush.Key, "true")

--- a/internal/flushcommon/writebuffer/l0_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer_test.go
@@ -788,6 +788,11 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 				return conc.Go(func() (struct{}, error) {
 					defer close(done)
 					err := textTask.Run(ctx)
+					// Mirror syncManager.submit, which prepends a handler
+					// invoking HandleError before the caller's callbacks.
+					if err != nil {
+						textTask.HandleError(err)
+					}
 					for _, callback := range callbacks {
 						if cbErr := callback(err); cbErr != nil {
 							return struct{}{}, cbErr
@@ -862,6 +867,11 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 				textTask.WithChunkManager(storage.NewLocalChunkManager(objectstorage.RootPath(s.T().TempDir())))
 				return conc.Go(func() (struct{}, error) {
 					err := textTask.Run(ctx)
+					// Mirror syncManager.submit, which prepends a handler
+					// invoking HandleError before the caller's callbacks.
+					if err != nil {
+						textTask.HandleError(err)
+					}
 					for _, callback := range callbacks {
 						if cbErr := callback(err); cbErr != nil {
 							return struct{}{}, cbErr
@@ -909,11 +919,15 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 			},
 		}
 		var errorHandlerCalls atomic.Int32
+		var growingHandlerCalls atomic.Int32
 		wb, err := NewL0WriteBuffer(s.channelName, metacache, s.syncMgr, &writeBufferOption{
 			idAllocator:                s.allocator,
 			growingSourceRetryInterval: time.Hour,
 			errorHandler: func(error) {
 				errorHandlerCalls.Add(1)
+			},
+			growingSourceErrorHandler: func(error) {
+				growingHandlerCalls.Add(1)
 			},
 			growingSourceResolver: func(segmentID int64, targetOffset int64, _ *msgpb.MsgPosition) (syncmgr.GrowingFlushSource, syncmgr.GrowingSourceState) {
 				return source, syncmgr.GrowingSourceUsable
@@ -931,6 +945,11 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 						done <- textTask
 					}()
 					err := textTask.Run(ctx)
+					// Mirror syncManager.submit, which prepends a handler
+					// invoking HandleError before the caller's callbacks.
+					if err != nil {
+						textTask.HandleError(err)
+					}
 					for _, callback := range callbacks {
 						if cbErr := callback(err); cbErr != nil {
 							return struct{}{}, cbErr
@@ -951,7 +970,11 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		s.ErrorContains(conc.AwaitAll(futures...), "mock growing source flush error")
 		firstTask := <-done
 
-		s.EqualValues(1, errorHandlerCalls.Load())
+		// A retryable growing-source failure is reported through the
+		// non-fatal handler and never escalated: the rows stay in the growing
+		// segment and the write buffer re-submits the task.
+		s.EqualValues(1, growingHandlerCalls.Load())
+		s.EqualValues(0, errorHandlerCalls.Load())
 		progress, ok := l0wb.growingSourceProgress[int64(1010)]
 		s.True(ok)
 		s.EqualValues(1, progress.failureCount)
@@ -967,7 +990,9 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		s.Require().Len(futures, 1)
 		s.NoError(conc.AwaitAll(futures...))
 		secondTask := <-done
-		s.EqualValues(1, errorHandlerCalls.Load())
+		// The retry succeeded, so neither handler fires again.
+		s.EqualValues(1, growingHandlerCalls.Load())
+		s.EqualValues(0, errorHandlerCalls.Load())
 		s.EqualValues(10, secondTask.BatchRows())
 		segment, ok = metacache.GetSegmentByID(1010)
 		s.True(ok)
@@ -1005,6 +1030,11 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 				return conc.Go(func() (struct{}, error) {
 					defer close(done)
 					err := textTask.Run(ctx)
+					// Mirror syncManager.submit, which prepends a handler
+					// invoking HandleError before the caller's callbacks.
+					if err != nil {
+						textTask.HandleError(err)
+					}
 					for _, callback := range callbacks {
 						if cbErr := callback(err); cbErr != nil {
 							return struct{}{}, cbErr
@@ -1058,12 +1088,16 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		}
 		metaWriter := syncmgr.NewMockMetaWriter(s.T())
 		var errorHandlerCalls atomic.Int32
+		var growingHandlerCalls atomic.Int32
 		wb, err := NewL0WriteBuffer(s.channelName, metacache, s.syncMgr, &writeBufferOption{
 			idAllocator:                s.allocator,
 			metaWriter:                 metaWriter,
 			growingSourceRetryInterval: time.Hour,
 			errorHandler: func(error) {
 				errorHandlerCalls.Add(1)
+			},
+			growingSourceErrorHandler: func(error) {
+				growingHandlerCalls.Add(1)
 			},
 			growingSourceResolver: func(segmentID int64, targetOffset int64, _ *msgpb.MsgPosition) (syncmgr.GrowingFlushSource, syncmgr.GrowingSourceState) {
 				return source, syncmgr.GrowingSourceUsable
@@ -1079,6 +1113,11 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 				return conc.Go(func() (struct{}, error) {
 					defer close(done)
 					err := textTask.Run(ctx)
+					// Mirror syncManager.submit, which prepends a handler
+					// invoking HandleError before the caller's callbacks.
+					if err != nil {
+						textTask.HandleError(err)
+					}
 					for _, callback := range callbacks {
 						if cbErr := callback(err); cbErr != nil {
 							return struct{}{}, cbErr
@@ -1099,6 +1138,11 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		s.ErrorContains(conc.AwaitAll(futures...), "row count mismatch")
 		<-done
 
+		// A row-count mismatch is a data-integrity violation: the task
+		// re-derives it from the same segment state and the same offset range,
+		// so retrying reproduces it forever while pinning the checkpoint. It
+		// escalates to the fatal handler instead.
+		s.EqualValues(1, growingHandlerCalls.Load())
 		s.EqualValues(1, errorHandlerCalls.Load())
 		progress, ok := l0wb.growingSourceProgress[int64(1011)]
 		s.True(ok)
@@ -1140,6 +1184,11 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 				textTask.WithChunkManager(storage.NewLocalChunkManager(objectstorage.RootPath(s.T().TempDir())))
 				return conc.Go(func() (struct{}, error) {
 					err := textTask.Run(ctx)
+					// Mirror syncManager.submit, which prepends a handler
+					// invoking HandleError before the caller's callbacks.
+					if err != nil {
+						textTask.HandleError(err)
+					}
 					for _, callback := range callbacks {
 						if cbErr := callback(err); cbErr != nil {
 							return struct{}{}, cbErr
@@ -1238,6 +1287,11 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 				secondTaskCh <- textTask
 				return conc.Go(func() (struct{}, error) {
 					err := textTask.Run(ctx)
+					// Mirror syncManager.submit, which prepends a handler
+					// invoking HandleError before the caller's callbacks.
+					if err != nil {
+						textTask.HandleError(err)
+					}
 					for _, callback := range callbacks {
 						if cbErr := callback(err); cbErr != nil {
 							return struct{}{}, cbErr
@@ -1420,6 +1474,11 @@ func (s *L0WriteBufferSuite) TestGetGrowingFlushProgress() {
 				return conc.Go(func() (struct{}, error) {
 					defer close(done)
 					err := textTask.Run(ctx)
+					// Mirror syncManager.submit, which prepends a handler
+					// invoking HandleError before the caller's callbacks.
+					if err != nil {
+						textTask.HandleError(err)
+					}
 					for _, callback := range callbacks {
 						if cbErr := callback(err); cbErr != nil {
 							return struct{}{}, cbErr
@@ -1479,6 +1538,11 @@ func (s *L0WriteBufferSuite) TestGetGrowingFlushProgress() {
 				return conc.Go(func() (struct{}, error) {
 					defer close(done)
 					err := textTask.Run(ctx)
+					// Mirror syncManager.submit, which prepends a handler
+					// invoking HandleError before the caller's callbacks.
+					if err != nil {
+						textTask.HandleError(err)
+					}
 					for _, callback := range callbacks {
 						if cbErr := callback(err); cbErr != nil {
 							return struct{}{}, cbErr

--- a/internal/flushcommon/writebuffer/l0_write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer_test.go
@@ -542,16 +542,28 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		time.Sleep(50 * time.Millisecond)
 	})
 
-	s.Run("drop_close_skips_unavailable_growing_source", func() {
+	s.Run("drop_close_waits_for_pending_growing_source", func() {
 		textSchema := s.textSchema()
-		metacache := s.newTextRealMetaCache(textSchema)
+		metaCache := s.newTextRealMetaCache(textSchema)
 		metaWriter := syncmgr.NewMockMetaWriter(s.T())
-		wb, err := NewL0WriteBuffer(s.channelName, metacache, s.syncMgr, &writeBufferOption{
+		syncManager := syncmgr.NewMockSyncManager(s.T())
+		var sourceState atomic.Int32
+		sourceState.Store(int32(syncmgr.GrowingSourcePending))
+		var dropStarted atomic.Bool
+		pendingObserved := make(chan struct{}, 1)
+		wb, err := NewL0WriteBuffer(s.channelName, metaCache, syncManager, &writeBufferOption{
 			idAllocator:                s.allocator,
 			metaWriter:                 metaWriter,
-			growingSourceRetryInterval: time.Hour,
+			growingSourceRetryInterval: 10 * time.Millisecond,
 			growingSourceResolver: func(segmentID int64, targetOffset int64, _ *msgpb.MsgPosition) (syncmgr.GrowingFlushSource, syncmgr.GrowingSourceState) {
-				return fakeGrowingFlushSource{}, syncmgr.GrowingSourcePending
+				state := syncmgr.GrowingSourceState(sourceState.Load())
+				if dropStarted.Load() && state == syncmgr.GrowingSourcePending {
+					select {
+					case pendingObserved <- struct{}{}:
+					default:
+					}
+				}
+				return fakeGrowingFlushSource{}, state
 			},
 		})
 		s.NoError(err)
@@ -563,16 +575,163 @@ func (s *L0WriteBufferSuite) TestBufferDataGrowingSourceMode() {
 		err = wb.BufferData(insertData, nil, &msgpb.MsgPosition{Timestamp: 100}, &msgpb.MsgPosition{Timestamp: 200}, 100)
 		s.NoError(err)
 
-		metaWriter.EXPECT().DropChannel(mock.Anything, s.channelName).Return(nil).Once()
-		s.NotPanics(func() {
-			wb.Close(context.Background(), true)
-		})
+		var syncCompleted atomic.Bool
+		var dropAfterSync atomic.Bool
+		submitted := make(chan *syncmgr.GrowingSourceSyncTask, 1)
+		syncManager.EXPECT().SyncData(mock.Anything, mock.AnythingOfType("*syncmgr.GrowingSourceSyncTask"), mock.Anything).
+			RunAndReturn(func(_ context.Context, task syncmgr.Task, callbacks ...func(error) error) (*conc.Future[struct{}], error) {
+				textTask := task.(*syncmgr.GrowingSourceSyncTask)
+				submitted <- textTask
+				return conc.Go(func() (struct{}, error) {
+					if textTask.BatchRows() > 0 {
+						metaCache.UpdateSegments(
+							metacache.FinishSyncing(textTask.BatchRows()),
+							metacache.WithSegmentIDs(textTask.SegmentID()),
+						)
+					}
+					var callbackErr error
+					for _, callback := range callbacks {
+						callbackErr = callback(callbackErr)
+					}
+					syncCompleted.Store(true)
+					return struct{}{}, callbackErr
+				}), nil
+			}).Once()
+		metaWriter.EXPECT().DropChannel(mock.Anything, s.channelName).
+			Run(func(context.Context, string) {
+				dropAfterSync.Store(syncCompleted.Load())
+			}).
+			Return(nil).
+			Once()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		closeResult := make(chan any, 1)
+		dropStarted.Store(true)
+		go func() {
+			var panicValue any
+			func() {
+				defer func() {
+					panicValue = recover()
+				}()
+				wb.Close(ctx, true)
+			}()
+			closeResult <- panicValue
+		}()
+
+		select {
+		case <-pendingObserved:
+		case <-time.After(time.Second):
+			s.FailNow("drop did not observe the pending growing source")
+		}
+		select {
+		case panicValue := <-closeResult:
+			s.FailNow("drop returned before the growing source became usable", "panic", panicValue)
+		case <-time.After(20 * time.Millisecond):
+		}
+
+		sourceState.Store(int32(syncmgr.GrowingSourceUsable))
+		select {
+		case panicValue := <-closeResult:
+			s.Nil(panicValue)
+		case <-time.After(time.Second):
+			s.FailNow("drop did not finish after the growing source became usable")
+		}
+
+		select {
+		case task := <-submitted:
+			s.True(task.IsDrop())
+			s.EqualValues(10, task.BatchRows())
+		case <-time.After(time.Second):
+			s.FailNow("drop did not submit the final growing-source task")
+		}
 
 		l0wb := wb.(*l0WriteBuffer)
 		s.NotContains(l0wb.growingSourceProgress, int64(1103))
-		// flushSourceMode lives on metacache.SegmentInfo and is reclaimed
-		// when the segment is removed from metacache by the drop path; no
-		// dedicated map to assert against on the writeBuffer side anymore.
+		s.False(l0wb.growingSourceRetryScheduled)
+		s.Nil(l0wb.growingSourceRetryTimer)
+		s.True(dropAfterSync.Load(), "DropChannel must run after the final source sync commits")
+		segment, ok := metaCache.GetSegmentByID(1103)
+		if ok {
+			s.Zero(segment.SyncingRows())
+			s.True(metacache.WithNoSyncingTask().Filter(segment))
+		}
+	})
+
+	s.Run("drop_close_pending_growing_source_honors_caller_timeout", func() {
+		textSchema := s.textSchema()
+		metaCache := s.newTextRealMetaCache(textSchema)
+		metaWriter := syncmgr.NewMockMetaWriter(s.T())
+		syncManager := syncmgr.NewMockSyncManager(s.T())
+		pendingObserved := make(chan struct{}, 1)
+		var dropStarted atomic.Bool
+		wb, err := NewL0WriteBuffer(s.channelName, metaCache, syncManager, &writeBufferOption{
+			idAllocator:                s.allocator,
+			metaWriter:                 metaWriter,
+			growingSourceRetryInterval: 5 * time.Millisecond,
+			growingSourceResolver: func(segmentID int64, targetOffset int64, _ *msgpb.MsgPosition) (syncmgr.GrowingFlushSource, syncmgr.GrowingSourceState) {
+				if dropStarted.Load() {
+					select {
+					case pendingObserved <- struct{}{}:
+					default:
+					}
+				}
+				return fakeGrowingFlushSource{}, syncmgr.GrowingSourcePending
+			},
+		})
+		s.NoError(err)
+
+		_, msg := s.composeTextInsertMsg(1104, 10)
+		insertData, err := PrepareInsert(textSchema, s.pkSchema, []*msgstream.InsertMsg{msg})
+		s.NoError(err)
+		err = wb.BufferData(insertData, nil, &msgpb.MsgPosition{Timestamp: 100}, &msgpb.MsgPosition{Timestamp: 200}, 100)
+		s.NoError(err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		closeResult := make(chan any, 1)
+		dropStarted.Store(true)
+		go func() {
+			var panicValue any
+			func() {
+				defer func() {
+					panicValue = recover()
+				}()
+				wb.Close(ctx, true)
+			}()
+			closeResult <- panicValue
+		}()
+
+		select {
+		case <-pendingObserved:
+		case <-time.After(time.Second):
+			s.FailNow("drop did not observe the pending growing source")
+		}
+
+		var panicValue any
+		select {
+		case panicValue = <-closeResult:
+		case <-time.After(time.Second):
+			s.FailNow("drop did not honor the caller deadline")
+		}
+		s.Require().NotNil(panicValue)
+		panicErr, ok := panicValue.(error)
+		s.Require().True(ok, "drop should propagate the caller context error")
+		s.ErrorIs(panicErr, context.DeadlineExceeded)
+
+		l0wb := wb.(*l0WriteBuffer)
+		s.NotContains(l0wb.growingSourceProgress, int64(1104))
+		s.False(l0wb.growingSourceRetryScheduled)
+		s.Nil(l0wb.growingSourceRetryTimer)
+		s.True(l0wb.closed)
+		s.False(l0wb.dropping)
+		segment, ok := metaCache.GetSegmentByID(1104)
+		if ok {
+			s.Zero(segment.SyncingRows())
+			s.True(metacache.WithNoSyncingTask().Filter(segment))
+		}
+		metaWriter.AssertNotCalled(s.T(), "DropChannel", mock.Anything, s.channelName)
+		syncManager.AssertNotCalled(s.T(), "SyncData", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	s.Run("pending_source_records_progress_instead_of_falling_back_to_writebuffer", func() {

--- a/internal/flushcommon/writebuffer/manager.go
+++ b/internal/flushcommon/writebuffer/manager.go
@@ -38,7 +38,7 @@ type BufferManager interface {
 	// RemoveChannel removes a write buffer from manager.
 	RemoveChannel(channel string)
 	// DropChannel remove write buffer and perform drop.
-	DropChannel(channel string)
+	DropChannel(ctx context.Context, channel string)
 	DropPartitions(channel string, partitionIDs []int64)
 	// BufferData put data into channel write buffer.
 	BufferData(channel string, insertData []*InsertData, deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition, schemaVersion int32) error
@@ -343,14 +343,19 @@ func (m *bufferManager) RemoveChannel(channel string) {
 
 // DropChannel removes channel WriteBuffer and process `DropChannel`
 // this method will save all buffered data
-func (m *bufferManager) DropChannel(channel string) {
+func (m *bufferManager) DropChannel(ctx context.Context, channel string) {
 	buf, loaded := m.buffers.GetAndRemove(channel)
 	if !loaded {
 		mlog.Warn(context.TODO(), "failed to drop channel, channel not maintained in manager", mlog.String("channel", channel))
 		return
 	}
 
-	buf.Close(context.Background(), true)
+	dropCtx, cancel := context.WithTimeout(
+		ctx,
+		paramtable.Get().DataNodeCfg.GracefulStopTimeout.GetAsDuration(time.Second),
+	)
+	defer cancel()
+	buf.Close(dropCtx, true)
 }
 
 func (m *bufferManager) DropPartitions(channel string, partitionIDs []int64) {

--- a/internal/flushcommon/writebuffer/manager.go
+++ b/internal/flushcommon/writebuffer/manager.go
@@ -83,6 +83,10 @@ type bufferManager struct {
 	ch lifetime.SafeChan
 }
 
+type evictableMemoryWriteBuffer interface {
+	EvictableMemorySize() int64
+}
+
 func (m *bufferManager) Start() {
 	m.wg.Add(1)
 	go func() {
@@ -141,8 +145,12 @@ func (m *bufferManager) memoryCheck() {
 		m.buffers.Range(func(chanName string, buf WriteBuffer) bool {
 			size := buf.MemorySize()
 			total += size
-			if size > candiSize {
-				candiSize = size
+			evictable := size
+			if sized, ok := buf.(evictableMemoryWriteBuffer); ok {
+				evictable = sized.EvictableMemorySize()
+			}
+			if evictable > candiSize {
+				candiSize = evictable
 				candidate = buf
 				candiChan = chanName
 			}
@@ -158,10 +166,21 @@ func (m *bufferManager) memoryCheck() {
 			return
 		}
 
-		if candidate != nil {
-			candidate.EvictBuffer(GetOldestBufferPolicy(paramtable.Get().DataNodeCfg.MemoryForceSyncSegmentNum.GetAsInt()))
-			mlog.Info(context.TODO(), "notify writebuffer to sync",
-				mlog.String("channel", candiChan), mlog.Float64("bufferSize(MB)", logutil.ToMB(float64(candiSize))))
+		if candidate == nil {
+			mlog.RatedWarn(context.TODO(), rate.Limit(20), "memory watermark exceeded by in-flight flush payload",
+				mlog.Float64("current_total_memory_usage", logutil.ToMB(float64(total))),
+				mlog.Float64("current_memory_watermark", logutil.ToMB(memoryWatermark)))
+			return
+		}
+
+		candidate.EvictBuffer(GetOldestBufferPolicy(paramtable.Get().DataNodeCfg.MemoryForceSyncSegmentNum.GetAsInt()))
+		mlog.Info(context.TODO(), "notify writebuffer to sync",
+			mlog.String("channel", candiChan), mlog.Float64("bufferSize(MB)", logutil.ToMB(float64(candiSize))))
+		if sized, ok := candidate.(evictableMemoryWriteBuffer); ok && sized.EvictableMemorySize() >= candiSize {
+			mlog.RatedWarn(context.TODO(), rate.Limit(20), "memory force sync made no progress",
+				mlog.String("channel", candiChan),
+				mlog.Float64("evictable_memory", logutil.ToMB(float64(candiSize))))
+			return
 		}
 	}
 }

--- a/internal/flushcommon/writebuffer/manager_test.go
+++ b/internal/flushcommon/writebuffer/manager_test.go
@@ -83,6 +83,27 @@ func (s *ManagerSuite) TestRegister() {
 	s.ErrorIs(err, merr.ErrChannelReduplicate)
 }
 
+func (s *ManagerSuite) TestDropChannelPropagatesBoundedContext() {
+	param := paramtable.Get()
+	param.Save(param.DataNodeCfg.GracefulStopTimeout.Key, "2")
+	defer param.Reset(param.DataNodeCfg.GracefulStopTimeout.Key)
+
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "caller")
+	wb := NewMockWriteBuffer(s.T())
+	wb.EXPECT().Close(mock.MatchedBy(func(dropCtx context.Context) bool {
+		deadline, ok := dropCtx.Deadline()
+		remaining := time.Until(deadline)
+		return ok && dropCtx.Value(contextKey{}) == "caller" && remaining > 0 && remaining <= 2*time.Second
+	}), true).Return().Once()
+	s.manager.buffers.Insert(s.channelName, wb)
+
+	s.manager.DropChannel(ctx, s.channelName)
+
+	_, loaded := s.manager.buffers.Get(s.channelName)
+	s.False(loaded)
+}
+
 func (s *ManagerSuite) TestFlushSegments() {
 	manager := s.manager
 	s.Run("channel_not_found", func() {

--- a/internal/flushcommon/writebuffer/manager_test.go
+++ b/internal/flushcommon/writebuffer/manager_test.go
@@ -344,6 +344,36 @@ func (s *ManagerSuite) TestStopDuringMemoryCheck() {
 	manager.Stop()
 }
 
+func (s *ManagerSuite) TestMemoryCheckDoesNotSpinOnInFlightPayload() {
+	param := paramtable.Get()
+	param.Save(param.DataNodeCfg.MemoryForceSyncEnable.Key, "true")
+	param.Save(param.DataNodeCfg.MemoryForceSyncWatermark.Key, "0")
+	defer param.Reset(param.DataNodeCfg.MemoryForceSyncEnable.Key)
+	defer param.Reset(param.DataNodeCfg.MemoryForceSyncWatermark.Key)
+
+	segmentID := int64(1001)
+	task := syncmgr.NewSyncTask().
+		WithSyncPack(new(syncmgr.SyncPack).WithSegmentID(segmentID)).
+		WithPayloadAccounting(100, 0, nil)
+	wb := &l0WriteBuffer{writeBufferBase: &writeBufferBase{
+		buffers:               make(map[int64]*segmentBuffer),
+		ordinarySyncs:         map[int64]*ordinarySyncState{segmentID: {task: task}},
+		growingSourceProgress: make(map[int64]*growingSourceProgress),
+	}}
+	s.manager.buffers.Insert(s.channelName, wb)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.manager.memoryCheck()
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		s.FailNow("memory check spun on non-evictable in-flight payload")
+	}
+}
+
 func TestManager(t *testing.T) {
 	suite.Run(t, new(ManagerSuite))
 }

--- a/internal/flushcommon/writebuffer/mock_manager.go
+++ b/internal/flushcommon/writebuffer/mock_manager.go
@@ -125,9 +125,9 @@ func (_c *MockBufferManager_CreateNewGrowingSegment_Call) RunAndReturn(run func(
 	return _c
 }
 
-// DropChannel provides a mock function with given fields: channel
-func (_m *MockBufferManager) DropChannel(channel string) {
-	_m.Called(channel)
+// DropChannel provides a mock function with given fields: ctx, channel
+func (_m *MockBufferManager) DropChannel(ctx context.Context, channel string) {
+	_m.Called(ctx, channel)
 }
 
 // MockBufferManager_DropChannel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DropChannel'
@@ -136,14 +136,15 @@ type MockBufferManager_DropChannel_Call struct {
 }
 
 // DropChannel is a helper method to define mock.On call
+//   - ctx context.Context
 //   - channel string
-func (_e *MockBufferManager_Expecter) DropChannel(channel interface{}) *MockBufferManager_DropChannel_Call {
-	return &MockBufferManager_DropChannel_Call{Call: _e.mock.On("DropChannel", channel)}
+func (_e *MockBufferManager_Expecter) DropChannel(ctx interface{}, channel interface{}) *MockBufferManager_DropChannel_Call {
+	return &MockBufferManager_DropChannel_Call{Call: _e.mock.On("DropChannel", ctx, channel)}
 }
 
-func (_c *MockBufferManager_DropChannel_Call) Run(run func(channel string)) *MockBufferManager_DropChannel_Call {
+func (_c *MockBufferManager_DropChannel_Call) Run(run func(ctx context.Context, channel string)) *MockBufferManager_DropChannel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -153,7 +154,7 @@ func (_c *MockBufferManager_DropChannel_Call) Return() *MockBufferManager_DropCh
 	return _c
 }
 
-func (_c *MockBufferManager_DropChannel_Call) RunAndReturn(run func(string)) *MockBufferManager_DropChannel_Call {
+func (_c *MockBufferManager_DropChannel_Call) RunAndReturn(run func(context.Context, string)) *MockBufferManager_DropChannel_Call {
 	_c.Run(run)
 	return _c
 }
@@ -705,7 +706,8 @@ func (_c *MockBufferManager_Stop_Call) RunAndReturn(run func()) *MockBufferManag
 func NewMockBufferManager(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockBufferManager {
+},
+) *MockBufferManager {
 	mock := &MockBufferManager{}
 	mock.Mock.Test(t)
 

--- a/internal/flushcommon/writebuffer/options.go
+++ b/internal/flushcommon/writebuffer/options.go
@@ -26,11 +26,23 @@ type writeBufferOption struct {
 	idAllocator  allocator.Interface
 	syncPolicies []SyncPolicy
 
-	pkStatsFactory       metacache.PkStatsFactory
-	metaWriter           syncmgr.MetaWriter
-	errorHandler         func(error)
-	taskObserverCallback TaskObserverCallback
-	storageVersion       int64
+	pkStatsFactory metacache.PkStatsFactory
+	metaWriter     syncmgr.MetaWriter
+	// errorHandler terminates the process. It is the last resort for a sync
+	// failure the write buffer cannot recover from: the rows have already been
+	// yielded out of the buffer, so if nobody re-runs the task the data is
+	// gone from memory while the checkpoint stays pinned — a silent, signal-less
+	// stall that is strictly worse than a crash. Only wire a non-fatal handler
+	// for a task type that owns a re-submit path.
+	errorHandler func(error)
+	// growingSourceErrorHandler handles growing-source sync failures that the
+	// write buffer WILL retry (see scheduleGrowingSourceRetryLocked). Those
+	// rows live in the segcore growing segment, not in a yielded buffer, so a
+	// failed attempt loses nothing and the next attempt re-reads the same
+	// offset range. Defaults to record-and-continue.
+	growingSourceErrorHandler func(error)
+	taskObserverCallback      TaskObserverCallback
+	storageVersion            int64
 
 	growingSourceResolver      GrowingSourceResolver
 	growingSourceRetryInterval time.Duration
@@ -49,6 +61,17 @@ func defaultWBOption(metacache metacache.MetaCache) *writeBufferOption {
 		errorHandler: func(err error) {
 			panic(err)
 		},
+	}
+	// growingSourceErrorHandler is deliberately left nil: newWriteBufferBase
+	// installs a rate-limited handler once the channel logger exists. Setting a
+	// plain mlog.Warn here would win over that fallback and, at a 100ms retry
+	// interval, emit ~10 unrated warnings per second per stuck segment.
+}
+
+// WithGrowingSourceErrorHandler overrides the growing-source failure handler.
+func WithGrowingSourceErrorHandler(handler func(err error)) WriteBufferOption {
+	return func(opt *writeBufferOption) {
+		opt.growingSourceErrorHandler = handler
 	}
 }
 

--- a/internal/flushcommon/writebuffer/ordinary_sync_state.go
+++ b/internal/flushcommon/writebuffer/ordinary_sync_state.go
@@ -1,0 +1,338 @@
+package writebuffer
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"golang.org/x/time/rate"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+)
+
+type ordinarySyncPhase uint8
+
+const (
+	ordinarySyncAttemptInFlight ordinarySyncPhase = iota
+	ordinarySyncRetryWait
+)
+
+type retryTimer interface {
+	Stop() bool
+}
+
+type retryAfterFunc func(time.Duration, func()) retryTimer
+
+type ordinarySyncState struct {
+	task        *syncmgr.SyncTask
+	phase       ordinarySyncPhase
+	attempt     uint64
+	retryTimer  retryTimer
+	retryCtx    context.Context
+	done        chan struct{}
+	doneOnce    sync.Once
+	terminalErr error
+	pending     bool
+}
+
+type ordinarySyncOutcome struct {
+	attemptErr  error
+	terminalErr error
+	fatalErr    error
+	terminal    bool
+}
+
+func (s *ordinarySyncState) complete(err error) {
+	s.doneOnce.Do(func() {
+		s.terminalErr = err
+		close(s.done)
+	})
+}
+
+func (wb *writeBufferBase) scheduleOrdinaryRetryLocked(state *ordinarySyncState) {
+	if state == nil || state.phase != ordinarySyncRetryWait || state.retryTimer != nil || wb.closed {
+		return
+	}
+	delay := wb.growingSourceRetryInterval
+	if delay < 0 {
+		if !wb.dropping {
+			return
+		}
+		delay = defaultGrowingSourceRetryInterval
+	}
+	segmentID := state.task.SegmentID()
+	expectedAttempt := state.attempt
+	state.retryTimer = wb.ordinaryRetryAfterFunc(delay, func() {
+		wb.retryOrdinarySync(segmentID, state, expectedAttempt)
+	})
+}
+
+// beginOrdinaryDropLocked transfers every current logical task to the Drop
+// context and snapshots its completion before any callback can remove it from
+// ordinarySyncs. The caller must set wb.dropping and hold wb.mut.
+func (wb *writeBufferBase) beginOrdinaryDropLocked(ctx context.Context) ([]syncmgr.Task, []*ordinarySyncState) {
+	tasks := make([]syncmgr.Task, 0)
+	waiters := make([]*ordinarySyncState, 0, len(wb.ordinarySyncs))
+	for _, state := range wb.ordinarySyncs {
+		state.retryCtx = ctx
+		if state.phase == ordinarySyncRetryWait {
+			if state.retryTimer != nil {
+				state.retryTimer.Stop()
+				state.retryTimer = nil
+			}
+			state.phase = ordinarySyncAttemptInFlight
+			state.attempt++
+			tasks = append(tasks, state.task)
+		}
+		waiters = append(waiters, state)
+	}
+	return tasks, waiters
+}
+
+func (wb *writeBufferBase) waitOrdinarySyncs(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	tasks []syncmgr.Task,
+	waiters []*ordinarySyncState,
+) error {
+	if err := ctx.Err(); err != nil {
+		remaining := wb.cancelOutstandingOrdinarySyncs(err, cancel)
+		for _, waiter := range remaining {
+			<-waiter.done
+		}
+		return err
+	}
+
+	if len(tasks) > 0 {
+		wb.submitSyncTasks(ctx, tasks)
+	}
+	return wb.waitOrdinarySyncWaiters(ctx, cancel, waiters)
+}
+
+func (wb *writeBufferBase) waitOrdinarySyncWaiters(ctx context.Context, cancel context.CancelFunc, waiters []*ordinarySyncState) error {
+	if len(waiters) == 0 {
+		return ctx.Err()
+	}
+
+	// A sequential drain can hide a terminal failure behind an earlier task
+	// that is still retrying. Fan every completion into one buffered channel so
+	// the first terminal signal cancels the Drop context immediately, then keep
+	// draining until every logical owner has completed its cleanup.
+	results := make(chan error, len(waiters))
+	for _, state := range waiters {
+		go func(state *ordinarySyncState) {
+			<-state.done
+			results <- state.terminalErr
+		}(state)
+	}
+
+	var firstErr error
+	ctxDone := ctx.Done()
+	for range waiters {
+		select {
+		case err := <-results:
+			if err != nil && firstErr == nil {
+				firstErr = err
+				wb.cancelOutstandingOrdinarySyncs(err, cancel)
+				ctxDone = nil
+			}
+		case <-ctxDone:
+			if firstErr == nil {
+				firstErr = ctx.Err()
+				wb.cancelOutstandingOrdinarySyncs(firstErr, cancel)
+				ctxDone = nil
+			}
+		}
+	}
+	return firstErr
+}
+
+// cancelOutstandingOrdinarySyncs aborts a Drop drain without returning while
+// another logical task still owns its payload. Retry-wait tasks can be
+// discarded immediately; queued/running attempts are canceled and their
+// callbacks remain the sole owner of terminal cleanup.
+func (wb *writeBufferBase) cancelOutstandingOrdinarySyncs(terminalErr error, cancel context.CancelFunc) []*ordinarySyncState {
+	if cancel != nil {
+		cancel()
+	}
+	wb.syncCancel()
+
+	wb.mut.Lock()
+	waiters := make([]*ordinarySyncState, 0, len(wb.ordinarySyncs))
+	completed := make([]*ordinarySyncState, 0)
+	for _, state := range wb.ordinarySyncs {
+		waiters = append(waiters, state)
+		if state.phase == ordinarySyncRetryWait {
+			wb.discardOrdinarySyncLocked(state, false)
+			completed = append(completed, state)
+		}
+	}
+	wb.mut.Unlock()
+
+	for _, state := range completed {
+		state.complete(terminalErr)
+	}
+	return waiters
+}
+
+func (wb *writeBufferBase) retryOrdinarySync(segmentID int64, expectedState *ordinarySyncState, expectedAttempt uint64) {
+	wb.mut.Lock()
+	state, ok := wb.ordinarySyncs[segmentID]
+	if !ok || state != expectedState || state.phase != ordinarySyncRetryWait || state.attempt != expectedAttempt || wb.closed {
+		wb.mut.Unlock()
+		return
+	}
+	state.retryTimer = nil
+	retryCtx := state.retryCtx
+	if retryCtx == nil {
+		retryCtx = wb.syncCtx
+	}
+	if err := retryCtx.Err(); err != nil {
+		wb.discardOrdinarySyncLocked(state, false)
+		wb.mut.Unlock()
+		state.complete(err)
+		return
+	}
+	state.phase = ordinarySyncAttemptInFlight
+	state.attempt++
+	task := state.task
+	wb.mut.Unlock()
+
+	wb.submitSyncTasks(retryCtx, []syncmgr.Task{task})
+}
+
+func (wb *writeBufferBase) discardOrdinarySyncLocked(state *ordinarySyncState, removeCheckpoint bool) {
+	if state == nil {
+		return
+	}
+	segmentID := state.task.SegmentID()
+	if state.retryTimer != nil {
+		state.retryTimer.Stop()
+		state.retryTimer = nil
+	}
+	if state.task != nil {
+		wb.metaCache.UpdateSegments(
+			metacache.DiscardSyncing(state.task.BatchRows()),
+			metacache.WithSegmentIDs(segmentID),
+		)
+		if removeCheckpoint && state.task.StartPosition() != nil {
+			wb.syncCheckpoint.Remove(segmentID, state.task.StartPosition().GetTimestamp())
+		}
+		state.task.ReleasePayload()
+	}
+	if current, ok := wb.ordinarySyncs[segmentID]; ok && current == state {
+		delete(wb.ordinarySyncs, segmentID)
+	}
+}
+
+func (wb *writeBufferBase) handleOrdinarySyncResult(ctx context.Context, task *syncmgr.SyncTask, attempt uint64, attemptErr error) ordinarySyncOutcome {
+	segmentID := task.SegmentID()
+	var followup bool
+
+	wb.mut.Lock()
+	state, ok := wb.ordinarySyncs[segmentID]
+	if !ok || state.task != task || state.attempt != attempt || state.phase != ordinarySyncAttemptInFlight {
+		wb.mut.Unlock()
+		return ordinarySyncOutcome{attemptErr: attemptErr}
+	}
+	if attemptErr != nil {
+		outcome := ordinarySyncOutcome{attemptErr: attemptErr}
+		if wb.closed {
+			wb.discardOrdinarySyncLocked(state, true)
+			outcome.terminal = true
+			outcome.terminalErr = attemptErr
+		} else if wb.dropping && (ctx.Err() != nil || errors.Is(attemptErr, context.Canceled) || errors.Is(attemptErr, context.DeadlineExceeded)) {
+			// Drop is aborting before metadata commit. Keep the checkpoint pinned
+			// for WAL replay, but do not leave a detached retry loop owning the
+			// pack after Close returns.
+			wb.discardOrdinarySyncLocked(state, false)
+			outcome.terminal = true
+			outcome.terminalErr = attemptErr
+		} else if reason := ordinarySyncFatal(attemptErr); reason != "" {
+			fatalErr := errors.Wrapf(attemptErr,
+				"sync unrecoverable (%s), segmentID=%d", reason, segmentID)
+			// Keep the checkpoint candidate pinned for WAL replay, but release
+			// every in-memory ownership before invoking the fatal handler. A
+			// custom handler that returns must not leak the payload.
+			wb.discardOrdinarySyncLocked(state, false)
+			outcome.terminal = true
+			outcome.terminalErr = fatalErr
+			outcome.fatalErr = fatalErr
+		} else {
+			state.phase = ordinarySyncRetryWait
+			wb.growingSourceRatedLogger.RatedWarn(ctx, rate.Limit(1),
+				"sync task failed, retaining logical task for retry",
+				mlog.Int64("segmentID", segmentID),
+				mlog.Uint64("attempt", attempt),
+				mlog.Err(attemptErr))
+			wb.scheduleOrdinaryRetryLocked(state)
+		}
+		wb.mut.Unlock()
+		return outcome
+	}
+
+	if state.retryTimer != nil {
+		state.retryTimer.Stop()
+		state.retryTimer = nil
+	}
+	_, hasBufferedPayload := wb.buffers[segmentID]
+	followup = state.pending && hasBufferedPayload
+	if segment, exists := wb.metaCache.GetSegmentByID(segmentID); exists {
+		switch segment.State() {
+		case commonpb.SegmentState_Sealed, commonpb.SegmentState_Flushing:
+			followup = followup || !task.IsFlush()
+		case commonpb.SegmentState_Dropped:
+			followup = followup || !task.IsDrop()
+		}
+	}
+	if task.StartPosition() != nil {
+		wb.syncCheckpoint.Remove(segmentID, task.StartPosition().GetTimestamp())
+	}
+	if task.IsFlush() {
+		wb.metaCache.RemoveSegments(metacache.WithSegmentIDs(segmentID))
+	}
+	delete(wb.ordinarySyncs, segmentID)
+	followupAllowed := !wb.closed && !wb.dropping
+	wb.mut.Unlock()
+
+	if followup && followupAllowed {
+		go wb.syncSegments(wb.syncCtx, []int64{segmentID})
+	}
+	return ordinarySyncOutcome{terminal: true}
+}
+
+// finishOrdinarySyncOutcome publishes logical-task completion only after all
+// user-visible callbacks have finished. The defer also preserves the completion
+// fence when an observer or fatal handler panics.
+func (wb *writeBufferBase) finishOrdinarySyncOutcome(state *ordinarySyncState, task syncmgr.Task, outcome ordinarySyncOutcome) error {
+	if outcome.terminal {
+		defer state.complete(outcome.terminalErr)
+	}
+	var firstPanic any
+	run := func(callback func()) {
+		defer func() {
+			if panicValue := recover(); panicValue != nil && firstPanic == nil {
+				firstPanic = panicValue
+			}
+		}()
+		callback()
+	}
+	if wb.taskObserverCallback != nil {
+		run(func() {
+			wb.taskObserverCallback(task, outcome.attemptErr)
+		})
+	}
+	if outcome.fatalErr != nil {
+		run(func() {
+			wb.errHandler(outcome.fatalErr)
+		})
+	}
+	if firstPanic != nil {
+		panic(firstPanic)
+	}
+	return outcome.attemptErr
+}

--- a/internal/flushcommon/writebuffer/ordinary_sync_state.go
+++ b/internal/flushcommon/writebuffer/ordinary_sync_state.go
@@ -28,15 +28,16 @@ type retryTimer interface {
 type retryAfterFunc func(time.Duration, func()) retryTimer
 
 type ordinarySyncState struct {
-	task        *syncmgr.SyncTask
-	phase       ordinarySyncPhase
-	attempt     uint64
-	retryTimer  retryTimer
-	retryCtx    context.Context
-	done        chan struct{}
-	doneOnce    sync.Once
-	terminalErr error
-	pending     bool
+	task            *syncmgr.SyncTask
+	phase           ordinarySyncPhase
+	attempt         uint64
+	retryTimer      retryTimer
+	retryCtx        context.Context
+	payloadReleased chan struct{}
+	done            chan struct{}
+	doneOnce        sync.Once
+	terminalErr     error
+	pending         bool
 }
 
 type ordinarySyncOutcome struct {
@@ -232,6 +233,7 @@ func (wb *writeBufferBase) discardOrdinarySyncLocked(state *ordinarySyncState, r
 func (wb *writeBufferBase) handleOrdinarySyncResult(ctx context.Context, task *syncmgr.SyncTask, attempt uint64, attemptErr error) ordinarySyncOutcome {
 	segmentID := task.SegmentID()
 	var followup bool
+	var followupTasks []syncmgr.Task
 
 	wb.mut.Lock()
 	state, ok := wb.ordinarySyncs[segmentID]
@@ -297,10 +299,18 @@ func (wb *writeBufferBase) handleOrdinarySyncResult(ctx context.Context, task *s
 	}
 	delete(wb.ordinarySyncs, segmentID)
 	followupAllowed := !wb.closed && !wb.dropping
+	if followup && followupAllowed {
+		// Build the next logical owner before state.done is published. Otherwise a
+		// BufferData waiter can observe a full tail with no owner during the gap
+		// between this callback and an asynchronous syncSegments call.
+		followupTasks = wb.getSyncTasksLocked(wb.syncCtx, []int64{segmentID})
+	}
 	wb.mut.Unlock()
 
-	if followup && followupAllowed {
-		go wb.syncSegments(wb.syncCtx, []int64{segmentID})
+	if len(followupTasks) > 0 {
+		// Submission can block on dispatcher admission. Keep it asynchronous so
+		// the current callback can finish and release its own semaphore slot.
+		go wb.submitSyncTasks(wb.syncCtx, followupTasks)
 	}
 	return ordinarySyncOutcome{terminal: true}
 }

--- a/internal/flushcommon/writebuffer/stats_buffer.go
+++ b/internal/flushcommon/writebuffer/stats_buffer.go
@@ -18,26 +18,46 @@ package writebuffer
 
 import (
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 // stats buffer used for bm25 stats
 type statsBuffer struct {
 	bm25Stats map[int64]*storage.BM25Stats
+	size      int64
 }
 
-func (b *statsBuffer) Buffer(stats map[int64]*storage.BM25Stats) {
+func (b *statsBuffer) MemorySize() int64 {
+	if b == nil {
+		return 0
+	}
+	return b.size
+}
+
+func (b *statsBuffer) Buffer(stats map[int64]*storage.BM25Stats) int64 {
+	bytesPerEntry := paramtable.Get().QueryNodeCfg.BM25StatsBytesPerEntry.GetAsInt64()
+	var delta int64
 	for fieldID, stat := range stats {
-		if fieldMeta, ok := b.bm25Stats[fieldID]; ok {
+		if stat == nil {
+			continue
+		}
+		if fieldMeta, ok := b.bm25Stats[fieldID]; ok && fieldMeta != nil {
+			before := fieldMeta.MemSizeWithBytesPerEntry(bytesPerEntry)
 			fieldMeta.Merge(stat)
+			delta += fieldMeta.MemSizeWithBytesPerEntry(bytesPerEntry) - before
 		} else {
 			b.bm25Stats[fieldID] = stat
+			delta += stat.MemSizeWithBytesPerEntry(bytesPerEntry)
 		}
 	}
+	b.size += delta
+	return delta
 }
 
 func (b *statsBuffer) yieldBuffer() map[int64]*storage.BM25Stats {
 	result := b.bm25Stats
 	b.bm25Stats = make(map[int64]*storage.BM25Stats)
+	b.size = 0
 	return result
 }
 

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -204,6 +204,50 @@ func isGrowingSourceLayoutMismatch(err error) bool {
 		strings.Contains(msg, "Column group size mismatch")
 }
 
+// growingSourceSyncFatal reports why a growing-source sync failure can never
+// succeed on retry, or "" when the failure is worth retrying.
+//
+// Retry is the default. A growing-source flush re-reads the same offset range
+// from the segcore growing segment, so retrying is cheap and loses nothing;
+// only failures whose cause cannot change between attempts belong here.
+//
+// Storage-layer permanence is deliberately NOT consulted here. Today every
+// loon FFI failure is wrapped as packed.ErrLoonTransient regardless of its
+// real cause, so asking would classify a dead bucket as retryable and a
+// throttle as fatal with equal confidence — worse than not asking. Retrying
+// forever is the safe side of that ignorance: the rows stay pinned in the
+// growing segment and the checkpoint stays put. Once the storage error
+// classification lands, add the permanent branch here.
+func growingSourceSyncFatal(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case isGrowingSourceLayoutMismatch(err):
+		// The flush layout disagrees with what the segment materialized.
+		// Re-reading the same rows reproduces it exactly.
+		return "layout mismatch"
+	case errors.Is(err, merr.ErrDataIntegrity):
+		// The task refused its own inputs: empty manifest, row-count mismatch,
+		// missing insert summary, a non-V3 segment, a target offset behind
+		// already-flushed rows. Every one of these is re-derived from the same
+		// segment state and the same offset range, so a retry reproduces it
+		// exactly -- and retrying forever would pin the channel checkpoint with
+		// nothing but rate-limited warnings to show for it.
+		//
+		// ErrServiceInternal is deliberately NOT here: on this path it means
+		// "the source is not ready yet" (nil source, source behind the target
+		// offset), which the next round genuinely can resolve.
+		return "data integrity violation"
+	case merr.IsNonRetryableErr(err):
+		// Milvus-side terminal error: the request is malformed or the target
+		// is gone. A restart can at least pick up corrected configuration;
+		// retrying in-process cannot.
+		return "non-retryable error"
+	default:
+		return ""
+	}
+}
+
 func cloneBM25StatsMap(stats map[int64]*storage.BM25Stats) map[int64]*storage.BM25Stats {
 	if len(stats) == 0 {
 		return nil
@@ -276,8 +320,16 @@ type writeBufferBase struct {
 	processedTs    uint64
 	flushTimestamp *atomic.Uint64
 
-	errHandler           func(err error)
-	taskObserverCallback func(t syncmgr.Task, err error) // execute when a sync task finished, should be concurrent safe.
+	// errHandler is fatal: it is used for sync tasks whose payload was yielded
+	// out of the buffer and that have no re-submit path, so the only safe
+	// recovery is process restart plus WAL replay from the (unadvanced)
+	// checkpoint.
+	errHandler func(err error)
+	// growingSourceErrHandler is non-fatal: growing-source syncs read from the
+	// segcore growing segment and are re-submitted by
+	// scheduleGrowingSourceRetryLocked, so a failed attempt loses nothing.
+	growingSourceErrHandler func(err error)
+	taskObserverCallback    func(t syncmgr.Task, err error) // execute when a sync task finished, should be concurrent safe.
 
 	// Channel-level admission flag for trying growing-source flush. Actual segment
 	// source selection remains sticky in metacache.
@@ -292,8 +344,22 @@ type writeBufferBase struct {
 	growingSourceRetryInterval  time.Duration
 	growingSourceRetryScheduled bool
 	growingSourceRetryTimer     *time.Timer
-	flushSourceModeNotifier     FlushSourceModeNotifier
-	closed                      bool
+
+	// Ordinary sync tasks that failed recoverably and are waiting to be
+	// re-submitted. The rows are NOT lost when a sync fails: yieldBuffer moved
+	// them into the task's SyncPack, so the task still owns them and re-running
+	// the same object replays exactly the same batch.
+	//
+	// While an entry is present, getSyncTask returns it instead of yielding a
+	// fresh batch for that segment. That is what keeps ordering intact: the
+	// key-locked dispatcher serializes tasks per segment but does not reorder a
+	// re-submission behind a newer batch, so a newer batch must not be built.
+	pendingSyncRetries        map[int64]*syncmgr.SyncTask
+	pendingSyncRetryBytes     int64
+	pendingSyncRetryScheduled bool
+	pendingSyncRetryTimer     *time.Timer
+	flushSourceModeNotifier   FlushSourceModeNotifier
+	closed                    bool
 
 	// pre build logger
 	logger                   *mlog.Logger
@@ -341,11 +407,13 @@ func newWriteBufferBase(channel string, metacache metacache.MetaCache, syncMgr s
 		syncPolicies:               option.syncPolicies,
 		flushTimestamp:             flushTs,
 		errHandler:                 option.errorHandler,
+		growingSourceErrHandler:    option.growingSourceErrorHandler,
 		taskObserverCallback:       option.taskObserverCallback,
 		allowGrowingSourceFlush:    allowGrowingSourceFlush,
 		growingSourceResolver:      growingSourceResolver,
 		growingSourceProgress:      make(map[int64]*growingSourceProgress),
 		growingSourceRetryInterval: growingSourceRetryInterval,
+		pendingSyncRetries:         make(map[int64]*syncmgr.SyncTask),
 		flushSourceModeNotifier:    option.flushSourceModeNotifier,
 	}
 
@@ -353,6 +421,19 @@ func newWriteBufferBase(channel string, metacache metacache.MetaCache, syncMgr s
 		mlog.String("channel", wb.channelName))
 	wb.cpRatedLogger = wb.logger
 	wb.growingSourceRatedLogger = wb.logger
+
+	// A nil handler would silently drop failure reporting for a path that is
+	// expected to fail and retry, so never leave it unset even when the option
+	// struct was built directly (tests, embedded callers). Rate-limited on
+	// purpose: the retry interval is 100ms, so an unrated warn here turns one
+	// stuck segment into a log flood. The per-failure counter and the escalating
+	// summary live in observeGrowingSourceSyncFailureLocked.
+	if wb.growingSourceErrHandler == nil {
+		wb.growingSourceErrHandler = func(err error) {
+			wb.growingSourceRatedLogger.RatedWarn(context.TODO(), rate.Limit(1),
+				"growing-source sync failed, will retry", mlog.Err(err))
+		}
+	}
 
 	return wb, nil
 }
@@ -745,6 +826,74 @@ func (wb *writeBufferBase) growingSourceProgressSyncable(segmentID int64, progre
 	return false, true
 }
 
+// ordinarySyncFatal reports why an ordinary sync failure can never succeed on
+// retry, or "" when it is worth re-submitting. Same split as the
+// growing-source path: data-integrity violations are re-derived from the same
+// batch and would pin the checkpoint forever, everything else gets another go.
+func ordinarySyncFatal(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, merr.ErrDataIntegrity):
+		return "data integrity violation"
+	case merr.IsNonRetryableErr(err):
+		return "non-retryable error"
+	default:
+		return ""
+	}
+}
+
+func (wb *writeBufferBase) parkSyncRetryLocked(task *syncmgr.SyncTask) {
+	segmentID := task.SegmentID()
+	if _, exists := wb.pendingSyncRetries[segmentID]; !exists {
+		wb.pendingSyncRetryBytes += task.BatchRows()
+	}
+	wb.pendingSyncRetries[segmentID] = task
+	wb.growingSourceRatedLogger.RatedWarn(context.TODO(), rate.Limit(1),
+		"sync task parked for retry",
+		mlog.Int64("segmentID", segmentID),
+		mlog.Int("pending", len(wb.pendingSyncRetries)))
+	wb.scheduleSyncRetryLocked()
+}
+
+func (wb *writeBufferBase) clearSyncRetryLocked(segmentID int64) {
+	if task, ok := wb.pendingSyncRetries[segmentID]; ok {
+		wb.pendingSyncRetryBytes -= task.BatchRows()
+		if wb.pendingSyncRetryBytes < 0 {
+			wb.pendingSyncRetryBytes = 0
+		}
+		delete(wb.pendingSyncRetries, segmentID)
+	}
+}
+
+func (wb *writeBufferBase) scheduleSyncRetryLocked() {
+	if wb.closed || wb.pendingSyncRetryScheduled ||
+		wb.growingSourceRetryInterval < 0 || len(wb.pendingSyncRetries) == 0 {
+		return
+	}
+	wb.pendingSyncRetryScheduled = true
+	wb.pendingSyncRetryTimer = time.AfterFunc(wb.growingSourceRetryInterval,
+		wb.retrySyncTasks)
+}
+
+func (wb *writeBufferBase) retrySyncTasks() {
+	wb.mut.Lock()
+	wb.pendingSyncRetryScheduled = false
+	wb.pendingSyncRetryTimer = nil
+	if wb.closed || len(wb.pendingSyncRetries) == 0 {
+		wb.mut.Unlock()
+		return
+	}
+	segmentIDs := lo.Keys(wb.pendingSyncRetries)
+	wb.scheduleSyncRetryLocked()
+	syncTasks := wb.getSyncTasksLocked(context.Background(), segmentIDs)
+	wb.mut.Unlock()
+
+	if len(syncTasks) > 0 {
+		wb.submitSyncTasks(context.Background(), syncTasks)
+	}
+}
+
 func (wb *writeBufferBase) scheduleGrowingSourceRetryLocked() {
 	if wb.closed || wb.growingSourceRetryScheduled || wb.growingSourceRetryInterval < 0 || len(wb.growingSourceProgress) == 0 {
 		return
@@ -984,12 +1133,25 @@ func (wb *writeBufferBase) submitSyncTasks(ctx context.Context, syncTasks []sync
 						progress.failSync(err)
 						wb.rollbackGrowingSourceSyncTaskLocked(growingSourceTask)
 						wb.observeGrowingSourceSyncFailureLocked(growingSourceTask.SegmentID(), progress)
-						if isGrowingSourceLayoutMismatch(err) {
+						if fatal := growingSourceSyncFatal(err); fatal != "" {
+							// markNonRetryableFailure permanently parks this
+							// segment: growingSourceProgressSyncable refuses it
+							// forever, so its batches are never trimmed and the
+							// channel checkpoint stays pinned at
+							// firstUncommittedPosition. Left silent that is an
+							// unbounded, alert-less stall — strictly worse than
+							// a crash, because nothing ever reports it. Fail
+							// loudly instead: the rows are still recoverable
+							// from the WAL, and a human has to look at this.
 							progress.markNonRetryableFailure()
-							mlog.Error(ctx, "growing-source source sync failed with non-retryable layout mismatch",
+							mlog.Error(ctx, "growing-source sync hit a non-retryable failure, escalating",
+								mlog.String("reason", fatal),
 								mlog.Int64("segmentID", growingSourceTask.SegmentID()),
 								mlog.Int64("targetOffset", progress.targetOffset),
 								mlog.String("lastFailure", progress.lastFailure))
+							fatalErr := errors.Wrapf(err, "growing-source sync unrecoverable (%s), segmentID=%d targetOffset=%d",
+								fatal, growingSourceTask.SegmentID(), progress.targetOffset)
+							defer wb.errHandler(fatalErr)
 						} else {
 							wb.scheduleGrowingSourceRetryLocked()
 						}
@@ -1023,6 +1185,30 @@ func (wb *writeBufferBase) submitSyncTasks(ctx context.Context, syncTasks []sync
 			}
 			if resyncGrowingSourceSegmentID != 0 {
 				wb.syncSegments(context.Background(), []int64{resyncGrowingSourceSegmentID})
+			}
+
+			if ordinaryTask, isOrdinary := syncTask.(*syncmgr.SyncTask); isOrdinary {
+				wb.mut.Lock()
+				if err != nil {
+					if reason := ordinarySyncFatal(err); reason == "" {
+						// Recoverable: hand the batch back to the metacache and
+						// park the task. It keeps its rows, so the retry replays
+						// the same range against an unadvanced checkpoint.
+						wb.metaCache.UpdateSegments(
+							metacache.AbortSyncing(ordinaryTask.BatchRows()),
+							metacache.WithSegmentIDs(ordinaryTask.SegmentID()))
+						wb.parkSyncRetryLocked(ordinaryTask)
+					} else {
+						mlog.Error(ctx, "sync task hit a non-retryable failure, escalating",
+							mlog.String("reason", reason),
+							mlog.FieldSegmentID(syncTask.SegmentID()))
+						defer wb.errHandler(errors.Wrapf(err,
+							"sync unrecoverable (%s), segmentID=%d", reason, syncTask.SegmentID()))
+					}
+				} else {
+					wb.clearSyncRetryLocked(ordinaryTask.SegmentID())
+				}
+				wb.mut.Unlock()
 			}
 
 			if err != nil {
@@ -1425,6 +1611,15 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		mlog.Warn(ctx, "segment info not found in meta cache", mlog.FieldSegmentID(segmentID))
 		return nil, merr.WrapErrSegmentNotFound(segmentID)
 	}
+	// A recoverable failure left this segment's batch parked. Re-submit that
+	// exact task -- it still owns the rows -- and re-arm the syncing counter so
+	// each attempt remains one StartSyncing paired with one Abort/Finish.
+	// Building a newer batch here would let it overtake the parked one.
+	if task, ok := wb.pendingSyncRetries[segmentID]; ok {
+		wb.metaCache.UpdateSegments(metacache.StartSyncing(task.BatchRows()),
+			metacache.WithSegmentIDs(segmentID))
+		return task, nil
+	}
 	if progress, ok := wb.growingSourceProgress[segmentID]; ok && !wb.hasWriteBufferInsertPayload(segmentID) {
 		return wb.getGrowingSourceSyncTask(ctx, segmentInfo, progress)
 	}
@@ -1565,7 +1760,13 @@ func (wb *writeBufferBase) getGrowingSourceSyncTask(ctx context.Context, segment
 			WithSchema(wb.metaCache.GetSchema(schemaTimestamp)).
 			WithAllocator(wb.allocator).
 			WithStorageConfig(packed.CreateStorageConfig()).
-			WithFailureCallback(wb.errHandler).
+			// Non-fatal on purpose: this task is re-submitted by
+			// scheduleGrowingSourceRetryLocked, and the rows it flushes stay
+			// pinned in the growing segment until CommitGrowingFlush, so a
+			// failed attempt costs nothing but a round trip. Escalation to the
+			// fatal handler happens only where recovery is impossible — see the
+			// non-retryable branch in submitSyncTasks.
+			WithFailureCallback(wb.growingSourceErrHandler).
 			// Same as above: keep the critical write path retrying despite the
 			// retry.Do InputError short-circuit.
 			WithWriteRetryOptions(retry.AttemptAlways(), retry.MaxSleepTime(10*time.Second),

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -618,7 +618,7 @@ func (wb *writeBufferBase) MemorySize() int64 {
 	wb.mut.RLock()
 	defer wb.mut.RUnlock()
 
-	return wb.totalBufferedMemorySizeLocked()
+	return wb.totalBufferedMemorySizeLocked() + wb.totalOrdinaryPayloadMemorySizeLocked()
 }
 
 func (wb *writeBufferBase) totalBufferedMemorySizeLocked() int64 {
@@ -627,6 +627,85 @@ func (wb *writeBufferBase) totalBufferedMemorySizeLocked() int64 {
 		size += segBuf.MemorySize()
 	}
 	return size
+}
+
+func (wb *writeBufferBase) totalOrdinaryPayloadMemorySizeLocked() int64 {
+	var size int64
+	for _, state := range wb.ordinarySyncs {
+		size += state.task.PayloadBytes()
+	}
+	return size
+}
+
+// EvictableMemorySize is the buffered subset that can be yielded immediately.
+// Retained ordinary payload is resident memory, but selecting it for eviction
+// would only spin while the existing logical owner is still active.
+func (wb *writeBufferBase) EvictableMemorySize() int64 {
+	wb.mut.RLock()
+	defer wb.mut.RUnlock()
+
+	var size int64
+	for segmentID, buffer := range wb.buffers {
+		if _, owned := wb.ordinarySyncs[segmentID]; owned {
+			continue
+		}
+		if progress, ok := wb.growingSourceProgress[segmentID]; ok && progress.syncing {
+			continue
+		}
+		size += buffer.MemorySize()
+	}
+	return size
+}
+
+func (wb *writeBufferBase) flushCapacityWaiterLocked() <-chan struct{} {
+	insertLimit := paramtable.Get().DataNodeCfg.FlushInsertBufferSize.GetAsInt64()
+	deleteLimit := paramtable.Get().DataNodeCfg.FlushDeleteBufferBytes.GetAsInt64()
+	for segmentID, state := range wb.ordinarySyncs {
+		insertBytes := state.task.InsertPayloadBytes()
+		deleteBytes := state.task.DeletePayloadBytes()
+		if buffer := wb.buffers[segmentID]; buffer != nil {
+			if buffer.insertBuffer != nil {
+				insertBytes += buffer.insertBuffer.size
+			}
+			if buffer.deltaBuffer != nil {
+				deleteBytes += buffer.deltaBuffer.size
+			}
+		}
+		insertFull := insertBytes > 0 && insertLimit != noLimit && insertBytes >= insertLimit
+		deleteFull := deleteBytes > 0 && deleteLimit != noLimit && deleteBytes >= deleteLimit
+		if !insertFull && !deleteFull {
+			continue
+		}
+		if state.task.PayloadBytes() > 0 && state.payloadReleased != nil {
+			return state.payloadReleased
+		}
+		return state.done
+	}
+	return nil
+}
+
+// waitFlushCapacity applies per-segment backpressure using the existing flush
+// thresholds. The triggering batch is submitted before this wait, so a batch
+// larger than the threshold can still make progress and release its payload.
+func (wb *writeBufferBase) waitFlushCapacity() error {
+	for {
+		wb.mut.RLock()
+		if wb.closed || wb.dropping {
+			wb.mut.RUnlock()
+			return merr.WrapErrChannelNotFound(wb.channelName)
+		}
+		waiter := wb.flushCapacityWaiterLocked()
+		wb.mut.RUnlock()
+		if waiter == nil {
+			return nil
+		}
+
+		select {
+		case <-waiter:
+		case <-wb.syncCtx.Done():
+			return merr.WrapErrChannelNotFound(wb.channelName)
+		}
+	}
 }
 
 func (wb *writeBufferBase) EvictBuffer(policies ...SyncPolicy) {
@@ -1680,7 +1759,8 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		return wb.getGrowingSourceSyncTask(ctx, segmentInfo, progress)
 	}
 	var batchSize int64
-	var totalMemSize float64
+	var insertMemSize int64
+	var deleteMemSize int64
 	var tsFrom, tsTo uint64
 
 	insert, bm25, delta, schema, timeRange, startPos := wb.yieldBuffer(segmentID)
@@ -1696,10 +1776,10 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 
 	for _, chunk := range insert {
 		batchSize += int64(chunk.GetRowNum())
-		totalMemSize += float64(chunk.GetMemorySize())
+		insertMemSize += int64(chunk.GetMemorySize())
 	}
 	if delta != nil {
-		totalMemSize += float64(delta.Size())
+		deleteMemSize += delta.Size()
 	}
 
 	actions = append(actions, metacache.StartSyncing(batchSize))
@@ -1736,6 +1816,7 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		pack.WithDrop()
 	}
 
+	payloadReleased := make(chan struct{})
 	task := syncmgr.NewSyncTask().
 		WithAllocator(wb.allocator).
 		WithMetaWriter(wb.metaWriter).
@@ -1743,19 +1824,25 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		WithSchema(schema).
 		WithSyncPack(pack).
 		WithStorageConfig(packed.CreateStorageConfig()).
+		WithPayloadAccounting(insertMemSize, deleteMemSize, func(released int64) {
+			if released > 0 {
+				metrics.DataNodeFlowGraphBufferDataSize.WithLabelValues(
+					paramtable.GetStringNodeID(), fmt.Sprint(wb.collectionID)).Sub(float64(released))
+			}
+			close(payloadReleased)
+		}).
 		// Keep the storage write inside this logical attempt retrying until its
 		// context is canceled. Submission and metadata failures are handled by
 		// the per-segment logical retry state.
 		WithWriteRetryOptions(retry.AttemptAlways(), retry.MaxSleepTime(10*time.Second),
 			retry.RetryErr(func(error) bool { return true }))
-	metrics.DataNodeFlowGraphBufferDataSize.WithLabelValues(
-		paramtable.GetStringNodeID(), fmt.Sprint(wb.collectionID)).Sub(totalMemSize)
 	wb.ordinarySyncs[segmentID] = &ordinarySyncState{
-		task:     task,
-		phase:    ordinarySyncAttemptInFlight,
-		attempt:  1,
-		retryCtx: ctx,
-		done:     make(chan struct{}),
+		task:            task,
+		phase:           ordinarySyncAttemptInFlight,
+		attempt:         1,
+		retryCtx:        ctx,
+		payloadReleased: payloadReleased,
+		done:            make(chan struct{}),
 	}
 	return task, nil
 }
@@ -1997,12 +2084,6 @@ func (wb *writeBufferBase) abortDrop(cancel context.CancelFunc, terminalErr erro
 }
 
 func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
-	var dropCtx context.Context
-	var dropCancel context.CancelFunc
-	if drop {
-		dropCtx, dropCancel = context.WithCancel(ctx)
-	}
-
 	wb.mut.Lock()
 	wb.growingSourceRetryScheduled = false
 	if wb.growingSourceRetryTimer != nil {
@@ -2033,10 +2114,11 @@ func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
 		_ = wb.waitGrowingSourceSyncs(context.Background())
 		return
 	}
+	dropCtx, dropCancel := context.WithCancel(ctx)
+	defer dropCancel()
 	wb.dropping = true
 	ordinaryTasks, ordinaryWaiters := wb.beginOrdinaryDropLocked(dropCtx)
 	wb.mut.Unlock()
-	defer dropCancel()
 	defer func() {
 		if panicValue := recover(); panicValue != nil {
 			wb.mut.RLock()

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -319,6 +319,8 @@ type writeBufferBase struct {
 	checkpoint     *msgpb.MsgPosition
 	processedTs    uint64
 	flushTimestamp *atomic.Uint64
+	syncCtx        context.Context
+	syncCancel     context.CancelFunc
 
 	// errHandler is fatal: it is used for sync tasks whose payload was yielded
 	// out of the buffer and that have no re-submit path, so the only safe
@@ -345,21 +347,15 @@ type writeBufferBase struct {
 	growingSourceRetryScheduled bool
 	growingSourceRetryTimer     *time.Timer
 
-	// Ordinary sync tasks that failed recoverably and are waiting to be
-	// re-submitted. The rows are NOT lost when a sync fails: yieldBuffer moved
-	// them into the task's SyncPack, so the task still owns them and re-running
-	// the same object replays exactly the same batch.
-	//
-	// While an entry is present, getSyncTask returns it instead of yielding a
-	// fresh batch for that segment. That is what keeps ordering intact: the
-	// key-locked dispatcher serializes tasks per segment but does not reorder a
-	// re-submission behind a newer batch, so a newer batch must not be built.
-	pendingSyncRetries        map[int64]*syncmgr.SyncTask
-	pendingSyncRetryBytes     int64
-	pendingSyncRetryScheduled bool
-	pendingSyncRetryTimer     *time.Timer
-	flushSourceModeNotifier   FlushSourceModeNotifier
-	closed                    bool
+	// ordinarySyncs owns every ordinary logical sync from the moment its
+	// payload leaves wb.buffers until final success or a true abort. Presence in
+	// this map is the per-segment gate: queued/running/retry-wait all prevent a
+	// second pack from being built for the same segment.
+	ordinarySyncs           map[int64]*ordinarySyncState
+	ordinaryRetryAfterFunc  retryAfterFunc
+	flushSourceModeNotifier FlushSourceModeNotifier
+	dropping                bool
+	closed                  bool
 
 	// pre build logger
 	logger                   *mlog.Logger
@@ -377,6 +373,7 @@ func newWriteBufferBase(channel string, metacache metacache.MetaCache, syncMgr s
 	if err != nil {
 		return nil, err
 	}
+	syncCtx, syncCancel := context.WithCancel(context.Background())
 
 	allowGrowingSourceFlush := typeutil.AllowGrowingSourceFlush(schema,
 		paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool(),
@@ -393,7 +390,6 @@ func newWriteBufferBase(channel string, metacache metacache.MetaCache, syncMgr s
 	if growingSourceRetryInterval == 0 {
 		growingSourceRetryInterval = defaultGrowingSourceRetryInterval
 	}
-
 	wb := &writeBufferBase{
 		channelName:                channel,
 		collectionID:               metacache.Collection(),
@@ -406,6 +402,8 @@ func newWriteBufferBase(channel string, metacache metacache.MetaCache, syncMgr s
 		syncCheckpoint:             newCheckpointCandiates(),
 		syncPolicies:               option.syncPolicies,
 		flushTimestamp:             flushTs,
+		syncCtx:                    syncCtx,
+		syncCancel:                 syncCancel,
 		errHandler:                 option.errorHandler,
 		growingSourceErrHandler:    option.growingSourceErrorHandler,
 		taskObserverCallback:       option.taskObserverCallback,
@@ -413,14 +411,22 @@ func newWriteBufferBase(channel string, metacache metacache.MetaCache, syncMgr s
 		growingSourceResolver:      growingSourceResolver,
 		growingSourceProgress:      make(map[int64]*growingSourceProgress),
 		growingSourceRetryInterval: growingSourceRetryInterval,
-		pendingSyncRetries:         make(map[int64]*syncmgr.SyncTask),
-		flushSourceModeNotifier:    option.flushSourceModeNotifier,
+		ordinarySyncs:              make(map[int64]*ordinarySyncState),
+		ordinaryRetryAfterFunc: func(delay time.Duration, f func()) retryTimer {
+			return time.AfterFunc(delay, f)
+		},
+		flushSourceModeNotifier: option.flushSourceModeNotifier,
 	}
 
 	wb.logger = mlog.With(mlog.Int64("collectionID", wb.collectionID),
 		mlog.String("channel", wb.channelName))
 	wb.cpRatedLogger = wb.logger
 	wb.growingSourceRatedLogger = wb.logger
+	if wb.errHandler == nil {
+		wb.errHandler = func(err error) {
+			panic(err)
+		}
+	}
 
 	// A nil handler would silently drop failure reporting for a path that is
 	// expected to fail and retry, so never leave it unset even when the option
@@ -612,6 +618,10 @@ func (wb *writeBufferBase) MemorySize() int64 {
 	wb.mut.RLock()
 	defer wb.mut.RUnlock()
 
+	return wb.totalBufferedMemorySizeLocked()
+}
+
+func (wb *writeBufferBase) totalBufferedMemorySizeLocked() int64 {
 	var size int64
 	for _, segBuf := range wb.buffers {
 		size += segBuf.MemorySize()
@@ -633,16 +643,14 @@ func (wb *writeBufferBase) EvictBuffer(policies ...SyncPolicy) {
 
 	ts := wb.checkpoint.GetTimestamp()
 	segmentIDs := wb.getSegmentsToSync(ts, policies...)
-	var syncTasks []syncmgr.Task
 	if len(segmentIDs) > 0 {
 		logger.Info(context.TODO(), "evict buffer find segments to sync", mlog.Int64s("segmentIDs", segmentIDs))
-		syncTasks = wb.getSyncTasksLocked(context.Background(), segmentIDs)
 	}
 
 	wb.mut.Unlock()
 
-	if len(syncTasks) > 0 {
-		futures := wb.submitSyncTasks(context.Background(), syncTasks)
+	if len(segmentIDs) > 0 {
+		futures := wb.syncSegments(wb.syncCtx, segmentIDs)
 		if len(futures) > 0 {
 			conc.AwaitAll(futures...)
 		}
@@ -843,59 +851,8 @@ func ordinarySyncFatal(err error) string {
 	}
 }
 
-func (wb *writeBufferBase) parkSyncRetryLocked(task *syncmgr.SyncTask) {
-	segmentID := task.SegmentID()
-	if _, exists := wb.pendingSyncRetries[segmentID]; !exists {
-		wb.pendingSyncRetryBytes += task.BatchRows()
-	}
-	wb.pendingSyncRetries[segmentID] = task
-	wb.growingSourceRatedLogger.RatedWarn(context.TODO(), rate.Limit(1),
-		"sync task parked for retry",
-		mlog.Int64("segmentID", segmentID),
-		mlog.Int("pending", len(wb.pendingSyncRetries)))
-	wb.scheduleSyncRetryLocked()
-}
-
-func (wb *writeBufferBase) clearSyncRetryLocked(segmentID int64) {
-	if task, ok := wb.pendingSyncRetries[segmentID]; ok {
-		wb.pendingSyncRetryBytes -= task.BatchRows()
-		if wb.pendingSyncRetryBytes < 0 {
-			wb.pendingSyncRetryBytes = 0
-		}
-		delete(wb.pendingSyncRetries, segmentID)
-	}
-}
-
-func (wb *writeBufferBase) scheduleSyncRetryLocked() {
-	if wb.closed || wb.pendingSyncRetryScheduled ||
-		wb.growingSourceRetryInterval < 0 || len(wb.pendingSyncRetries) == 0 {
-		return
-	}
-	wb.pendingSyncRetryScheduled = true
-	wb.pendingSyncRetryTimer = time.AfterFunc(wb.growingSourceRetryInterval,
-		wb.retrySyncTasks)
-}
-
-func (wb *writeBufferBase) retrySyncTasks() {
-	wb.mut.Lock()
-	wb.pendingSyncRetryScheduled = false
-	wb.pendingSyncRetryTimer = nil
-	if wb.closed || len(wb.pendingSyncRetries) == 0 {
-		wb.mut.Unlock()
-		return
-	}
-	segmentIDs := lo.Keys(wb.pendingSyncRetries)
-	wb.scheduleSyncRetryLocked()
-	syncTasks := wb.getSyncTasksLocked(context.Background(), segmentIDs)
-	wb.mut.Unlock()
-
-	if len(syncTasks) > 0 {
-		wb.submitSyncTasks(context.Background(), syncTasks)
-	}
-}
-
 func (wb *writeBufferBase) scheduleGrowingSourceRetryLocked() {
-	if wb.closed || wb.growingSourceRetryScheduled || wb.growingSourceRetryInterval < 0 || len(wb.growingSourceProgress) == 0 {
+	if wb.closed || wb.dropping || wb.growingSourceRetryScheduled || wb.growingSourceRetryInterval < 0 || len(wb.growingSourceProgress) == 0 {
 		return
 	}
 	wb.growingSourceRetryScheduled = true
@@ -907,7 +864,7 @@ func (wb *writeBufferBase) retryGrowingSourceProgress() {
 	wb.mut.Lock()
 	wb.growingSourceRetryScheduled = false
 	wb.growingSourceRetryTimer = nil
-	if wb.closed || wb.checkpoint == nil || len(wb.growingSourceProgress) == 0 {
+	if wb.closed || wb.dropping || wb.checkpoint == nil || len(wb.growingSourceProgress) == 0 {
 		wb.mut.Unlock()
 		return
 	}
@@ -920,12 +877,12 @@ func (wb *writeBufferBase) retryGrowingSourceProgress() {
 	var syncTasks []syncmgr.Task
 	if len(segmentIDs) > 0 {
 		wb.logger.Info(context.TODO(), "retry growing-source source sync", mlog.Int64s("segmentIDs", segmentIDs))
-		syncTasks = wb.getSyncTasksLocked(context.Background(), segmentIDs)
+		syncTasks = wb.getSyncTasksLocked(wb.syncCtx, segmentIDs)
 	}
 	wb.mut.Unlock()
 
 	if len(syncTasks) > 0 {
-		futures := wb.submitSyncTasks(context.Background(), syncTasks)
+		futures := wb.submitSyncTasks(wb.syncCtx, syncTasks)
 		if len(futures) > 0 {
 			conc.AwaitAll(futures...)
 		}
@@ -1076,10 +1033,59 @@ func (wb *writeBufferBase) dropPartitions(partitionIDs []int64) {
 }
 
 func (wb *writeBufferBase) syncSegments(ctx context.Context, segmentIDs []int64) []*conc.Future[struct{}] {
+	result := make([]*conc.Future[struct{}], 0, len(segmentIDs))
+	for _, segmentID := range segmentIDs {
+		// Build and submit one task before moving to the next segment so a task
+		// that owns yielded data is never left detached from the sync manager.
+		wb.mut.Lock()
+		if wb.closed || wb.dropping {
+			wb.mut.Unlock()
+			break
+		}
+		tasks := wb.getSyncTasksLocked(ctx, []int64{segmentID})
+		wb.mut.Unlock()
+		if len(tasks) == 0 {
+			continue
+		}
+		result = append(result, wb.submitSyncTasks(ctx, tasks)...)
+	}
+	return result
+}
+
+// submitDropSegment builds the final task for one drained segment. Drop has
+// already blocked normal submissions and waited for any existing owner, so the
+// regular per-segment gate remains the only synchronization needed here.
+func (wb *writeBufferBase) submitDropSegment(ctx context.Context, segmentID int64) ([]*conc.Future[struct{}], *ordinarySyncState, error) {
 	wb.mut.Lock()
-	syncTasks := wb.getSyncTasksLocked(ctx, segmentIDs)
+	if wb.closed {
+		wb.mut.Unlock()
+		return nil, nil, nil
+	}
+	task, err := wb.getSyncTask(ctx, segmentID)
+	if err != nil {
+		if errors.Is(err, errGrowingSourceUnavailable) {
+			wb.rollbackGrowingSourceSyncCandidate(segmentID)
+		}
+		wb.mut.Unlock()
+		return nil, nil, err
+	}
+	if task == nil {
+		wb.mut.Unlock()
+		return nil, nil, merr.WrapErrServiceInternalMsg("segment %d still has an outstanding sync owner", segmentID)
+	}
+	var ordinaryState *ordinarySyncState
+	switch typedTask := task.(type) {
+	case *syncmgr.SyncTask:
+		typedTask.WithDrop()
+		ordinaryState = wb.ordinarySyncs[segmentID]
+	case *syncmgr.GrowingSourceSyncTask:
+		typedTask.WithDrop()
+	default:
+		wb.mut.Unlock()
+		return nil, nil, merr.WrapErrServiceInternalMsg("unsupported drop task %T for segment %d", task, segmentID)
+	}
 	wb.mut.Unlock()
-	return wb.submitSyncTasks(ctx, syncTasks)
+	return wb.submitSyncTasks(ctx, []syncmgr.Task{task}), ordinaryState, nil
 }
 
 // getSyncTasksLocked builds sync tasks and moves payload out of the write buffer.
@@ -1103,7 +1109,9 @@ func (wb *writeBufferBase) getSyncTasksLocked(ctx context.Context, segmentIDs []
 				mlog.Fatal(ctx, "failed to get sync task", mlog.FieldSegmentID(segmentID), mlog.Err(err))
 			}
 		}
-		result = append(result, syncTask)
+		if syncTask != nil {
+			result = append(result, syncTask)
+		}
 	}
 	return result
 }
@@ -1111,13 +1119,35 @@ func (wb *writeBufferBase) getSyncTasksLocked(ctx context.Context, segmentIDs []
 func (wb *writeBufferBase) submitSyncTasks(ctx context.Context, syncTasks []syncmgr.Task) []*conc.Future[struct{}] {
 	result := make([]*conc.Future[struct{}], 0, len(syncTasks))
 	for _, syncTask := range syncTasks {
+		var ordinaryAttempt uint64
+		var ordinaryState *ordinarySyncState
+		if ordinaryTask, ok := syncTask.(*syncmgr.SyncTask); ok {
+			wb.mut.Lock()
+			state, exists := wb.ordinarySyncs[ordinaryTask.SegmentID()]
+			if exists && state.task == ordinaryTask && state.phase == ordinarySyncAttemptInFlight {
+				ordinaryAttempt = state.attempt
+				ordinaryState = state
+			}
+			wb.mut.Unlock()
+			if ordinaryAttempt == 0 {
+				continue
+			}
+		}
+
 		future, err := wb.syncMgr.SyncData(ctx, syncTask, func(err error) error {
-			if wb.taskObserverCallback != nil {
-				wb.taskObserverCallback(syncTask, err)
+			if ordinaryTask, isOrdinary := syncTask.(*syncmgr.SyncTask); isOrdinary {
+				outcome := wb.handleOrdinarySyncResult(ctx, ordinaryTask, ordinaryAttempt, err)
+				return wb.finishOrdinarySyncOutcome(ordinaryState, syncTask, outcome)
 			}
 
 			var resyncGrowingSourceSegmentID int64
 			if growingSourceTask, ok := syncTask.(*syncmgr.GrowingSourceSyncTask); ok {
+				if err != nil {
+					// Run releases its source in a defer. Dispatcher rejection and
+					// queued-task cancellation never enter Run, so make the callback
+					// path idempotently cover both cases.
+					growingSourceTask.ReleaseSource()
+				}
 				wb.mut.Lock()
 				if progress, exists := wb.growingSourceProgress[growingSourceTask.SegmentID()]; exists {
 					if err != nil {
@@ -1173,7 +1203,7 @@ func (wb *writeBufferBase) submitSyncTasks(ctx context.Context, syncTasks []sync
 							}
 						} else if len(progress.batches) == 0 {
 							segment, ok := wb.metaCache.GetSegmentByID(growingSourceTask.SegmentID())
-							if growingSourceTask.IsFlush() || !ok ||
+							if growingSourceTask.IsFlush() || growingSourceTask.IsDrop() || !ok ||
 								segment.State() == commonpb.SegmentState_Flushed ||
 								segment.State() == commonpb.SegmentState_Dropped {
 								delete(wb.growingSourceProgress, growingSourceTask.SegmentID())
@@ -1184,34 +1214,13 @@ func (wb *writeBufferBase) submitSyncTasks(ctx context.Context, syncTasks []sync
 				wb.mut.Unlock()
 			}
 			if resyncGrowingSourceSegmentID != 0 {
-				wb.syncSegments(context.Background(), []int64{resyncGrowingSourceSegmentID})
-			}
-
-			if ordinaryTask, isOrdinary := syncTask.(*syncmgr.SyncTask); isOrdinary {
-				wb.mut.Lock()
-				if err != nil {
-					if reason := ordinarySyncFatal(err); reason == "" {
-						// Recoverable: hand the batch back to the metacache and
-						// park the task. It keeps its rows, so the retry replays
-						// the same range against an unadvanced checkpoint.
-						wb.metaCache.UpdateSegments(
-							metacache.AbortSyncing(ordinaryTask.BatchRows()),
-							metacache.WithSegmentIDs(ordinaryTask.SegmentID()))
-						wb.parkSyncRetryLocked(ordinaryTask)
-					} else {
-						mlog.Error(ctx, "sync task hit a non-retryable failure, escalating",
-							mlog.String("reason", reason),
-							mlog.FieldSegmentID(syncTask.SegmentID()))
-						defer wb.errHandler(errors.Wrapf(err,
-							"sync unrecoverable (%s), segmentID=%d", reason, syncTask.SegmentID()))
-					}
-				} else {
-					wb.clearSyncRetryLocked(ordinaryTask.SegmentID())
-				}
-				wb.mut.Unlock()
+				wb.syncSegments(wb.syncCtx, []int64{resyncGrowingSourceSegmentID})
 			}
 
 			if err != nil {
+				if wb.taskObserverCallback != nil {
+					wb.taskObserverCallback(syncTask, err)
+				}
 				return err
 			}
 
@@ -1223,11 +1232,37 @@ func (wb *writeBufferBase) submitSyncTasks(ctx context.Context, syncTasks []sync
 				wb.metaCache.RemoveSegments(metacache.WithSegmentIDs(syncTask.SegmentID()))
 				mlog.Info(ctx, "flushed segment removed", mlog.FieldSegmentID(syncTask.SegmentID()), mlog.String("channel", syncTask.ChannelName()))
 			}
+			if wb.taskObserverCallback != nil {
+				wb.taskObserverCallback(syncTask, nil)
+			}
 			return nil
 		})
 		if err != nil {
+			if ordinaryTask, ok := syncTask.(*syncmgr.SyncTask); ok {
+				outcome := wb.handleOrdinarySyncResult(ctx, ordinaryTask, ordinaryAttempt, err)
+				err = wb.finishOrdinarySyncOutcome(ordinaryState, syncTask, outcome)
+				result = append(result, conc.Go(func() (struct{}, error) {
+					return struct{}{}, err
+				}))
+				continue
+			}
 			if growingSourceTask, ok := syncTask.(*syncmgr.GrowingSourceSyncTask); ok {
 				growingSourceTask.ReleaseSource()
+				wb.mut.Lock()
+				if progress, exists := wb.growingSourceProgress[growingSourceTask.SegmentID()]; exists {
+					progress.failSync(err)
+					wb.rollbackGrowingSourceSyncTaskLocked(growingSourceTask)
+					wb.observeGrowingSourceSyncFailureLocked(growingSourceTask.SegmentID(), progress)
+					wb.scheduleGrowingSourceRetryLocked()
+				}
+				wb.mut.Unlock()
+				if wb.taskObserverCallback != nil {
+					wb.taskObserverCallback(syncTask, err)
+				}
+				result = append(result, conc.Go(func() (struct{}, error) {
+					return struct{}{}, err
+				}))
+				continue
 			}
 			mlog.Fatal(ctx, "failed to sync data", mlog.Int64("segmentID", syncTask.SegmentID()), mlog.Err(err))
 		}
@@ -1239,7 +1274,9 @@ func (wb *writeBufferBase) submitSyncTasks(ctx context.Context, syncTasks []sync
 // getSegmentsToSync applies all policies to get segments list to sync.
 // **NOTE** shall be invoked within mutex protection
 func (wb *writeBufferBase) getSegmentsToSync(ts typeutil.Timestamp, policies ...SyncPolicy) []int64 {
-	buffers := lo.Values(wb.buffers)
+	buffers := lo.Filter(lo.Values(wb.buffers), func(buffer *segmentBuffer, _ int) bool {
+		return buffer != nil
+	})
 	segments := typeutil.NewSet[int64]()
 	for _, policy := range policies {
 		result := policy.SelectSegments(buffers, ts)
@@ -1255,6 +1292,13 @@ func (wb *writeBufferBase) getSegmentsToSync(ts typeutil.Timestamp, policies ...
 	}
 
 	return lo.Filter(segments.Collect(), func(segmentID int64, _ int) bool {
+		if state, ok := wb.ordinarySyncs[segmentID]; ok {
+			// The older logical task owns ordering for this segment. Record the
+			// policy edge so its terminal success immediately schedules the tail,
+			// but do not build a second task yet.
+			state.pending = true
+			return false
+		}
 		progress, ok := wb.growingSourceProgress[segmentID]
 		if !ok {
 			return true
@@ -1599,32 +1643,44 @@ func (wb *writeBufferBase) newGrowingSegmentManifestPath(partitionID int64, segm
 }
 
 // bufferDelete buffers DeleteMsg into DeleteData.
-func (wb *writeBufferBase) bufferDelete(segmentID int64, pks []storage.PrimaryKey, tss []typeutil.Timestamp, startPos, endPos *msgpb.MsgPosition) {
+func (wb *writeBufferBase) bufferDelete(segmentID int64, pks []storage.PrimaryKey, tss []typeutil.Timestamp, startPos, endPos *msgpb.MsgPosition) int64 {
 	segBuf := wb.getOrCreateBuffer(segmentID, tss[0])
 	bufSize := segBuf.deltaBuffer.Buffer(pks, tss, startPos, endPos)
 	metrics.DataNodeFlowGraphBufferDataSize.WithLabelValues(paramtable.GetStringNodeID(), fmt.Sprint(wb.collectionID)).Add(float64(bufSize))
+	return bufSize
 }
 
 func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (syncmgr.Task, error) {
+	if state, ok := wb.ordinarySyncs[segmentID]; ok {
+		// A queued, running, or retry-wait task owns the older logical batch.
+		// Remember that another policy selected this segment, but leave all new
+		// rows in wb.buffers until the owner reaches a terminal state.
+		state.pending = true
+		return nil, nil
+	}
+	if progress, ok := wb.growingSourceProgress[segmentID]; ok && progress.syncing {
+		// Growing-source and write-buffer tasks share one segment-level gate.
+		// The keyed dispatcher would serialize two tasks, but it cannot prevent
+		// the second task from being built against counters that the first task
+		// has not committed yet.
+		if segment, exists := wb.metaCache.GetSegmentByID(segmentID); exists {
+			switch segment.State() {
+			case commonpb.SegmentState_Sealed, commonpb.SegmentState_Flushing, commonpb.SegmentState_Dropped:
+				progress.pendingFlush = true
+			}
+		}
+		return nil, nil
+	}
 	segmentInfo, ok := wb.metaCache.GetSegmentByID(segmentID) // wb.metaCache.GetSegmentsBy(metacache.WithSegmentIDs(segmentID))
 	if !ok {
 		mlog.Warn(ctx, "segment info not found in meta cache", mlog.FieldSegmentID(segmentID))
 		return nil, merr.WrapErrSegmentNotFound(segmentID)
 	}
-	// A recoverable failure left this segment's batch parked. Re-submit that
-	// exact task -- it still owns the rows -- and re-arm the syncing counter so
-	// each attempt remains one StartSyncing paired with one Abort/Finish.
-	// Building a newer batch here would let it overtake the parked one.
-	if task, ok := wb.pendingSyncRetries[segmentID]; ok {
-		wb.metaCache.UpdateSegments(metacache.StartSyncing(task.BatchRows()),
-			metacache.WithSegmentIDs(segmentID))
-		return task, nil
-	}
 	if progress, ok := wb.growingSourceProgress[segmentID]; ok && !wb.hasWriteBufferInsertPayload(segmentID) {
 		return wb.getGrowingSourceSyncTask(ctx, segmentInfo, progress)
 	}
 	var batchSize int64
-	var totalMemSize float64 = 0
+	var totalMemSize float64
 	var tsFrom, tsTo uint64
 
 	insert, bm25, delta, schema, timeRange, startPos := wb.yieldBuffer(segmentID)
@@ -1642,7 +1698,6 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		batchSize += int64(chunk.GetRowNum())
 		totalMemSize += float64(chunk.GetMemorySize())
 	}
-
 	if delta != nil {
 		totalMemSize += float64(delta.Size())
 	}
@@ -1663,7 +1718,10 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		WithDataSource(metrics.StreamingDataSourceLabel).
 		WithCheckpoint(wb.checkpoint).
 		WithBatchRows(batchSize).
-		WithErrorHandler(wb.errHandler)
+		// HandleError is owned by syncManager and remains non-fatal for ordinary
+		// logical tasks. The write buffer classifies the attempt result and only
+		// invokes errHandler after proving the task cannot be retried.
+		WithErrorHandler(nil)
 
 	if len(bm25) != 0 {
 		pack.WithBM25Stats(bm25)
@@ -1678,8 +1736,6 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		pack.WithDrop()
 	}
 
-	metrics.DataNodeFlowGraphBufferDataSize.WithLabelValues(paramtable.GetStringNodeID(), fmt.Sprint(wb.collectionID)).Sub(totalMemSize)
-
 	task := syncmgr.NewSyncTask().
 		WithAllocator(wb.allocator).
 		WithMetaWriter(wb.metaWriter).
@@ -1687,12 +1743,20 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 		WithSchema(schema).
 		WithSyncPack(pack).
 		WithStorageConfig(packed.CreateStorageConfig()).
-		// The flush write path must keep retrying: aborting surfaces the error
-		// to SyncTask.HandleError, whose default callback panics the datanode.
-		// retry.Do short-circuits InputError-typed errors unless an explicit
-		// RetryErr predicate is supplied, so AttemptAlways alone is not enough.
+		// Keep the storage write inside this logical attempt retrying until its
+		// context is canceled. Submission and metadata failures are handled by
+		// the per-segment logical retry state.
 		WithWriteRetryOptions(retry.AttemptAlways(), retry.MaxSleepTime(10*time.Second),
 			retry.RetryErr(func(error) bool { return true }))
+	metrics.DataNodeFlowGraphBufferDataSize.WithLabelValues(
+		paramtable.GetStringNodeID(), fmt.Sprint(wb.collectionID)).Sub(totalMemSize)
+	wb.ordinarySyncs[segmentID] = &ordinarySyncState{
+		task:     task,
+		phase:    ordinarySyncAttemptInFlight,
+		attempt:  1,
+		retryCtx: ctx,
+		done:     make(chan struct{}),
+	}
 	return task, nil
 }
 
@@ -1809,21 +1873,198 @@ func (wb *writeBufferBase) getEstBatchSize() uint {
 	return uint(sizeLimit / int64(wb.estSizePerRecord))
 }
 
-func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
-	// sink all data and call Drop for meta writer
+func (wb *writeBufferBase) waitGrowingSourceSyncs(ctx context.Context) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	canceled := false
+	for {
+		wb.mut.RLock()
+		inFlight := false
+		for _, progress := range wb.growingSourceProgress {
+			if progress.syncing {
+				inFlight = true
+				break
+			}
+		}
+		wb.mut.RUnlock()
+		if !inFlight {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return nil
+		}
+		if canceled {
+			<-ticker.C
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			// Pre-existing attempts were submitted with wb.syncCtx before Drop
+			// took ownership. Cancel both generations, then keep waiting until the
+			// task callback has rolled back syncing rows and source ownership.
+			wb.syncCancel()
+			canceled = true
+		case <-ticker.C:
+		}
+	}
+}
+
+func (wb *writeBufferBase) waitDropRetry(ctx context.Context) error {
+	interval := wb.growingSourceRetryInterval
+	if interval < 0 {
+		interval = defaultGrowingSourceRetryInterval
+	}
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// syncDropSegment uses the same task construction, write path, retry
+// classification, and per-segment ownership as normal syncing. Drop only adds
+// the final task flag and waits synchronously so DropChannel cannot overtake an
+// unfinished retry.
+func (wb *writeBufferBase) syncDropSegment(ctx context.Context, cancel context.CancelFunc, segmentID int64) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		futures, ordinaryState, err := wb.submitDropSegment(ctx, segmentID)
+		if err != nil {
+			if errors.Is(err, errGrowingSourceUnavailable) {
+				if err := wb.waitDropRetry(ctx); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+
+		if ordinaryState != nil {
+			return wb.waitOrdinarySyncWaiters(ctx, cancel, []*ordinarySyncState{ordinaryState})
+		}
+		if len(futures) == 0 {
+			return nil
+		}
+
+		err = conc.BlockOnAll(futures...)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if growingSourceSyncFatal(err) != "" {
+			return err
+		}
+		if err := wb.waitDropRetry(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+// abortDrop closes every local ownership path before Close propagates a Drop
+// failure. Data was not committed, so ordinary checkpoints stay pinned for WAL
+// replay. The write buffer has already been removed from its manager and cannot
+// safely accept more work after this point.
+func (wb *writeBufferBase) abortDrop(cancel context.CancelFunc, terminalErr error) {
+	waiters := wb.cancelOutstandingOrdinarySyncs(terminalErr, cancel)
+	for _, state := range waiters {
+		<-state.done
+	}
+	_ = wb.waitGrowingSourceSyncs(context.Background())
+
 	wb.mut.Lock()
+	if wb.growingSourceRetryTimer != nil {
+		wb.growingSourceRetryTimer.Stop()
+		wb.growingSourceRetryTimer = nil
+	}
+	wb.growingSourceRetryScheduled = false
+	wb.growingSourceProgress = make(map[int64]*growingSourceProgress)
+	bufferedBytes := wb.totalBufferedMemorySizeLocked()
+	if bufferedBytes > 0 {
+		metrics.DataNodeFlowGraphBufferDataSize.WithLabelValues(
+			paramtable.GetStringNodeID(), fmt.Sprint(wb.collectionID)).Sub(float64(bufferedBytes))
+	}
+	wb.buffers = make(map[int64]*segmentBuffer)
 	wb.closed = true
+	wb.dropping = false
+	wb.mut.Unlock()
+}
+
+func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
+	var dropCtx context.Context
+	var dropCancel context.CancelFunc
+	if drop {
+		dropCtx, dropCancel = context.WithCancel(ctx)
+	}
+
+	wb.mut.Lock()
 	wb.growingSourceRetryScheduled = false
 	if wb.growingSourceRetryTimer != nil {
 		wb.growingSourceRetryTimer.Stop()
 		wb.growingSourceRetryTimer = nil
 	}
 	if !drop {
+		wb.closed = true
+		wb.syncCancel()
+		completed := make([]*ordinarySyncState, 0)
+		waiters := make([]*ordinarySyncState, 0, len(wb.ordinarySyncs))
+		for _, state := range wb.ordinarySyncs {
+			switch state.phase {
+			case ordinarySyncRetryWait:
+				wb.discardOrdinarySyncLocked(state, true)
+				completed = append(completed, state)
+			default:
+				waiters = append(waiters, state)
+			}
+		}
 		wb.mut.Unlock()
+		for _, state := range completed {
+			state.complete(context.Canceled)
+		}
+		for _, state := range waiters {
+			<-state.done
+		}
+		_ = wb.waitGrowingSourceSyncs(context.Background())
 		return
 	}
+	wb.dropping = true
+	ordinaryTasks, ordinaryWaiters := wb.beginOrdinaryDropLocked(dropCtx)
+	wb.mut.Unlock()
+	defer dropCancel()
+	defer func() {
+		if panicValue := recover(); panicValue != nil {
+			wb.mut.RLock()
+			closed := wb.closed
+			wb.mut.RUnlock()
+			if !closed {
+				terminalErr, ok := panicValue.(error)
+				if !ok {
+					terminalErr = merr.WrapErrServiceInternalMsg("drop callback panicked: %v", panicValue)
+				}
+				wb.abortDrop(dropCancel, terminalErr)
+			}
+			panic(panicValue)
+		}
+	}()
 
-	var syncTasks []syncmgr.Task
+	// Existing logical tasks own older batches and must reach terminal success
+	// before any buffered tail can be turned into the final drop task.
+	if err := wb.waitOrdinarySyncs(dropCtx, dropCancel, ordinaryTasks, ordinaryWaiters); err != nil {
+		mlog.Error(ctx, "failed to drain outstanding sync tasks while dropping write buffer", mlog.Err(err))
+		panic(err)
+	}
+	if err := wb.waitGrowingSourceSyncs(dropCtx); err != nil {
+		mlog.Error(ctx, "failed to drain outstanding growing-source tasks while dropping write buffer", mlog.Err(err))
+		panic(err)
+	}
+
+	wb.mut.Lock()
 	segmentIDs := typeutil.NewSet[int64]()
 	for id := range wb.buffers {
 		segmentIDs.Insert(id)
@@ -1831,73 +2072,33 @@ func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
 	for id := range wb.growingSourceProgress {
 		segmentIDs.Insert(id)
 	}
-	for _, id := range segmentIDs.Collect() {
-		syncTask, err := wb.getSyncTask(ctx, id)
-		if err != nil {
-			if wb.hasGrowingSourceProgress(id) {
-				mlog.Warn(ctx, "skip growing source sync while dropping write buffer",
-					mlog.Int64("segmentID", id),
-					mlog.String("channel", wb.channelName),
-					mlog.Err(err))
-				delete(wb.growingSourceProgress, id)
-				// flushSourceMode lives on metacache.SegmentInfo and is
-				// reclaimed when the segment is removed from metacache by
-				// the drop path (no manual cleanup needed here).
-			}
-			continue
-		}
-		switch t := syncTask.(type) {
-		case *syncmgr.SyncTask:
-			t.WithDrop()
-		case *syncmgr.GrowingSourceSyncTask:
-			t.WithDrop()
-		}
-		syncTasks = append(syncTasks, syncTask)
-	}
+	dropSegmentIDs := segmentIDs.Collect()
 	wb.mut.Unlock()
 
-	futures := wb.submitDropSyncTasks(ctx, syncTasks)
-	err := conc.AwaitAll(futures...)
-	if err != nil {
-		mlog.Error(ctx, "failed to sink write buffer data", mlog.Err(err))
-		// TODO change to remove channel in the future
+	for _, id := range dropSegmentIDs {
+		if err := wb.syncDropSegment(dropCtx, dropCancel, id); err != nil {
+			mlog.Error(ctx, "failed to sync final drop segment",
+				mlog.Int64("segmentID", id),
+				mlog.String("channel", wb.channelName),
+				mlog.Err(err))
+			panic(err)
+		}
+	}
+	if err := dropCtx.Err(); err != nil {
+		mlog.Error(ctx, "drop context canceled before channel metadata commit", mlog.Err(err))
 		panic(err)
 	}
-	err = wb.metaWriter.DropChannel(ctx, wb.channelName)
+	err := wb.metaWriter.DropChannel(dropCtx, wb.channelName)
 	if err != nil {
 		mlog.Error(ctx, "failed to drop channel", mlog.Err(err))
 		// TODO change to remove channel in the future
 		panic(err)
 	}
-}
-
-func (wb *writeBufferBase) submitDropSyncTasks(ctx context.Context, syncTasks []syncmgr.Task) []*conc.Future[struct{}] {
-	futures := make([]*conc.Future[struct{}], 0, len(syncTasks))
-	for _, syncTask := range syncTasks {
-		f, err := wb.syncMgr.SyncData(ctx, syncTask, func(err error) error {
-			if wb.taskObserverCallback != nil {
-				wb.taskObserverCallback(syncTask, err)
-			}
-
-			if err != nil {
-				return err
-			}
-			if syncTask.StartPosition() != nil {
-				wb.mut.Lock()
-				wb.syncCheckpoint.Remove(syncTask.SegmentID(), syncTask.StartPosition().GetTimestamp())
-				wb.mut.Unlock()
-			}
-			return nil
-		})
-		if err != nil {
-			if growingSourceTask, ok := syncTask.(*syncmgr.GrowingSourceSyncTask); ok {
-				growingSourceTask.ReleaseSource()
-			}
-			mlog.Fatal(ctx, "failed to sync segment", mlog.Int64("segmentID", syncTask.SegmentID()), mlog.Err(err))
-		}
-		futures = append(futures, f)
-	}
-	return futures
+	wb.mut.Lock()
+	wb.closed = true
+	wb.dropping = false
+	wb.syncCancel()
+	wb.mut.Unlock()
 }
 
 // prepareInsert transfers InsertMsg into organized InsertData grouped by segmentID

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -1763,6 +1763,10 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 	var deleteMemSize int64
 	var tsFrom, tsTo uint64
 
+	if buffer := wb.buffers[segmentID]; buffer != nil {
+		insertMemSize = buffer.insertBuffer.size
+		deleteMemSize = buffer.deltaBuffer.size
+	}
 	insert, bm25, delta, schema, timeRange, startPos := wb.yieldBuffer(segmentID)
 	if timeRange != nil {
 		tsFrom, tsTo = timeRange.timestampMin, timeRange.timestampMax
@@ -1776,10 +1780,6 @@ func (wb *writeBufferBase) getSyncTask(ctx context.Context, segmentID int64) (sy
 
 	for _, chunk := range insert {
 		batchSize += int64(chunk.GetRowNum())
-		insertMemSize += int64(chunk.GetMemorySize())
-	}
-	if delta != nil {
-		deleteMemSize += delta.Size()
 	}
 
 	actions = append(actions, metacache.StartSyncing(batchSize))

--- a/internal/flushcommon/writebuffer/write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/write_buffer_test.go
@@ -80,6 +80,557 @@ func (s *WriteBufferSuite) TestHasSegment() {
 	s.True(s.wb.HasSegment(segmentID))
 }
 
+func (s *WriteBufferSuite) TestOrdinarySyncStateBlocksSecondLogicalTask() {
+	segmentID := int64(1101)
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithBatchRows(10).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	state := &ordinarySyncState{
+		task:    task,
+		phase:   ordinarySyncAttemptInFlight,
+		attempt: 1,
+		done:    make(chan struct{}),
+	}
+
+	s.wb.mut.Lock()
+	s.wb.ordinarySyncs[segmentID] = state
+	s.wb.buffers[segmentID] = &segmentBuffer{
+		segmentID:    segmentID,
+		insertBuffer: &InsertBuffer{},
+		deltaBuffer:  &DeltaBuffer{},
+	}
+	tasks := s.wb.getSyncTasksLocked(context.Background(), []int64{segmentID})
+	_, buffered := s.wb.buffers[segmentID]
+	s.wb.mut.Unlock()
+
+	s.Empty(tasks)
+	s.True(state.pending)
+	s.True(buffered, "new rows must stay buffered behind the outstanding logical task")
+}
+
+func (s *WriteBufferSuite) TestGrowingObserverPanicHappensAfterLifecycleCleanup() {
+	segmentID := int64(1109)
+	segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: segmentID}, nil, nil, nil)
+	s.metacache.EXPECT().GetSegmentByID(segmentID).Return(segment, true).Maybe()
+	s.wb.growingSourceProgress[segmentID] = &growingSourceProgress{
+		segmentID: segmentID,
+		syncing:   true,
+	}
+	s.wb.taskObserverCallback = func(syncmgr.Task, error) {
+		panic("observer failure")
+	}
+	task := syncmgr.NewGrowingSourceSyncTask().
+		WithSegmentID(segmentID).
+		WithChannelName(s.channelName).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200})
+	s.syncMgr.EXPECT().SyncData(mock.Anything, task, mock.Anything).RunAndReturn(
+		func(_ context.Context, _ syncmgr.Task, callbacks ...func(error) error) (*conc.Future[struct{}], error) {
+			func() {
+				defer func() { _ = recover() }()
+				_ = callbacks[0](nil)
+			}()
+			return conc.Go(func() (struct{}, error) { return struct{}{}, nil }), nil
+		}).Once()
+
+	_ = s.wb.submitSyncTasks(context.Background(), []syncmgr.Task{task})
+	s.False(s.wb.growingSourceProgress[segmentID].syncing)
+}
+
+func (s *WriteBufferSuite) TestDropRetriesGrowingSourceFailure() {
+	segmentID := int64(1110)
+	segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             segmentID,
+		PartitionID:    10,
+		State:          commonpb.SegmentState_Growing,
+		StorageVersion: storage.StorageV3,
+	}, nil, nil, metacache.NewEmptySegmentStats())
+	s.metacache.EXPECT().GetSegmentByID(segmentID).Return(segment, true).Maybe()
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return().Maybe()
+
+	s.wb.checkpoint = &msgpb.MsgPosition{Timestamp: 200}
+	s.wb.growingSourceRetryInterval = time.Millisecond
+	s.wb.growingSourceResolver = func(int64, int64, *msgpb.MsgPosition) (syncmgr.GrowingFlushSource, syncmgr.GrowingSourceState) {
+		return fakeGrowingFlushSource{}, syncmgr.GrowingSourceUsable
+	}
+	s.wb.growingSourceProgress[segmentID] = &growingSourceProgress{
+		segmentID:    segmentID,
+		targetOffset: 0,
+	}
+
+	transientErr := errors.New("transient growing-source sync failure")
+	var attempts atomic.Int32
+	s.syncMgr.EXPECT().SyncData(mock.Anything, mock.MatchedBy(func(task syncmgr.Task) bool {
+		return task.SegmentID() == segmentID && task.IsDrop()
+	}), mock.Anything).RunAndReturn(
+		func(_ context.Context, _ syncmgr.Task, callbacks ...func(error) error) (*conc.Future[struct{}], error) {
+			attempt := attempts.Add(1)
+			var callbackErr error
+			if attempt == 1 {
+				callbackErr = transientErr
+			}
+			for _, callback := range callbacks {
+				callbackErr = callback(callbackErr)
+			}
+			return conc.Go(func() (struct{}, error) { return struct{}{}, callbackErr }), nil
+		}).Twice()
+	metaWriter := syncmgr.NewMockMetaWriter(s.T())
+	metaWriter.EXPECT().DropChannel(mock.Anything, s.channelName).Return(nil).Once()
+	s.wb.metaWriter = metaWriter
+
+	s.NotPanics(func() { s.wb.Close(context.Background(), true) })
+	s.EqualValues(2, attempts.Load())
+	s.NotContains(s.wb.growingSourceProgress, segmentID)
+}
+
+func (s *WriteBufferSuite) TestCloseWaitsForOrdinaryAndGrowingCleanup() {
+	segmentID := int64(1107)
+	segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: segmentID}, nil, nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateBufferedRows(10)(segment)
+	metacache.StartSyncing(10)(segment)
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Run(
+		func(action metacache.SegmentAction, _ ...metacache.SegmentFilter) {
+			action(segment)
+		}).Return().Once()
+
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithBatchRows(10).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	state := &ordinarySyncState{
+		task:    task,
+		phase:   ordinarySyncAttemptInFlight,
+		attempt: 1,
+		done:    make(chan struct{}),
+	}
+	s.wb.ordinarySyncs[segmentID] = state
+	s.wb.growingSourceProgress[2207] = &growingSourceProgress{segmentID: 2207, syncing: true}
+
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		s.wb.Close(context.Background(), false)
+	}()
+
+	select {
+	case <-closeDone:
+		s.FailNow("Close returned before the ordinary callback cleaned its state")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	outcome := s.wb.handleOrdinarySyncResult(context.Background(), task, 1, context.Canceled)
+	s.ErrorIs(outcome.attemptErr, context.Canceled)
+	s.ErrorIs(s.wb.finishOrdinarySyncOutcome(state, task, outcome), context.Canceled)
+	select {
+	case <-closeDone:
+		s.FailNow("Close returned before growing-source cleanup")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	s.wb.mut.Lock()
+	s.wb.growingSourceProgress[2207].failSync(context.Canceled)
+	s.wb.mut.Unlock()
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		s.FailNow("Close did not finish after all sync ownership was cleaned")
+	}
+	s.Zero(segment.BufferRows(), "discard must not claim the payload was restored to the buffer")
+	s.Zero(segment.SyncingRows())
+	s.True(metacache.WithNoSyncingTask().Filter(segment))
+	s.Zero(s.wb.MemorySize())
+}
+
+func (s *WriteBufferSuite) TestDropCancellationDiscardsOrdinaryTask() {
+	segmentID := int64(1111)
+	segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: segmentID}, nil, nil, metacache.NewEmptySegmentStats())
+	metacache.UpdateBufferedRows(10)(segment)
+	metacache.StartSyncing(10)(segment)
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Run(
+		func(action metacache.SegmentAction, _ ...metacache.SegmentFilter) {
+			action(segment)
+		}).Return().Once()
+
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithBatchRows(10).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	state := &ordinarySyncState{
+		task:    task,
+		phase:   ordinarySyncAttemptInFlight,
+		attempt: 1,
+		done:    make(chan struct{}),
+	}
+	s.wb.ordinarySyncs[segmentID] = state
+	s.wb.dropping = true
+
+	outcome := s.wb.handleOrdinarySyncResult(context.Background(), task, 1, context.Canceled)
+	s.ErrorIs(outcome.attemptErr, context.Canceled)
+	s.ErrorIs(s.wb.finishOrdinarySyncOutcome(state, task, outcome), context.Canceled)
+	s.NotContains(s.wb.ordinarySyncs, segmentID)
+	s.Zero(s.wb.MemorySize())
+	s.Zero(segment.BufferRows())
+	s.Zero(segment.SyncingRows())
+	s.True(metacache.WithNoSyncingTask().Filter(segment))
+}
+
+func (s *WriteBufferSuite) TestOrdinaryDoneWaitsForObserverCompletion() {
+	segmentID := int64(1114)
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	state := &ordinarySyncState{
+		task:    task,
+		phase:   ordinarySyncAttemptInFlight,
+		attempt: 1,
+		done:    make(chan struct{}),
+	}
+	s.wb.ordinarySyncs[segmentID] = state
+	s.metacache.EXPECT().GetSegmentByID(segmentID).Return(nil, false).Once()
+
+	observerEntered := make(chan struct{})
+	releaseObserver := make(chan struct{})
+	s.wb.taskObserverCallback = func(syncmgr.Task, error) {
+		close(observerEntered)
+		<-releaseObserver
+	}
+	outcome := s.wb.handleOrdinarySyncResult(context.Background(), task, 1, nil)
+	finishDone := make(chan error, 1)
+	go func() {
+		finishDone <- s.wb.finishOrdinarySyncOutcome(state, task, outcome)
+	}()
+
+	select {
+	case <-observerEntered:
+	case <-time.After(time.Second):
+		s.FailNow("ordinary observer was not invoked")
+	}
+	select {
+	case <-state.done:
+		s.FailNow("ordinary done was published before observer completion")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseObserver)
+	select {
+	case err := <-finishDone:
+		s.NoError(err)
+	case <-time.After(time.Second):
+		s.FailNow("ordinary completion did not finish after observer returned")
+	}
+	<-state.done
+	s.NoError(state.terminalErr)
+}
+
+func (s *WriteBufferSuite) TestOrdinaryObserverPanicDoesNotSkipFatalHandler() {
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(1115).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	state := &ordinarySyncState{done: make(chan struct{})}
+	fatalErr := merr.WrapErrServiceInternalMsg("fatal ordinary sync")
+	fatalCalled := false
+	s.wb.taskObserverCallback = func(syncmgr.Task, error) {
+		panic("observer panic")
+	}
+	s.wb.errHandler = func(err error) {
+		fatalCalled = true
+		s.ErrorIs(err, fatalErr)
+	}
+
+	s.PanicsWithValue("observer panic", func() {
+		_ = s.wb.finishOrdinarySyncOutcome(state, task, ordinarySyncOutcome{
+			attemptErr:  fatalErr,
+			terminalErr: fatalErr,
+			fatalErr:    fatalErr,
+			terminal:    true,
+		})
+	})
+	s.True(fatalCalled)
+	<-state.done
+	s.ErrorIs(state.terminalErr, fatalErr)
+}
+
+func (s *WriteBufferSuite) TestOrdinaryWaitersObserveLaterTerminalErrorAndSettleAll() {
+	segmentID := int64(1116)
+	terminalErr := errors.New("terminal sync failure")
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	retrying := &ordinarySyncState{
+		task:    task,
+		phase:   ordinarySyncAttemptInFlight,
+		attempt: 1,
+		done:    make(chan struct{}),
+	}
+	terminal := &ordinarySyncState{done: make(chan struct{})}
+	terminal.complete(terminalErr)
+	s.wb.ordinarySyncs[segmentID] = retrying
+	s.wb.dropping = true
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return().Once()
+
+	dropCtx, dropCancel := context.WithCancel(context.Background())
+	defer dropCancel()
+	cancelObserved := make(chan struct{})
+	settleRelease := make(chan struct{})
+	go func() {
+		<-dropCtx.Done()
+		close(cancelObserved)
+		<-settleRelease
+		outcome := s.wb.handleOrdinarySyncResult(dropCtx, task, 1, context.Canceled)
+		_ = s.wb.finishOrdinarySyncOutcome(retrying, task, outcome)
+	}()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- s.wb.waitOrdinarySyncWaiters(dropCtx, dropCancel, []*ordinarySyncState{retrying, terminal})
+	}()
+
+	select {
+	case <-cancelObserved:
+	case <-time.After(time.Second):
+		s.FailNow("later terminal waiter did not cancel the Drop context")
+	}
+	select {
+	case <-result:
+		s.FailNow("wait returned before the retrying owner settled")
+	default:
+	}
+	close(settleRelease)
+	select {
+	case err := <-result:
+		s.ErrorIs(err, terminalErr)
+	case <-time.After(time.Second):
+		s.FailNow("wait did not return after every owner settled")
+	}
+	s.NotContains(s.wb.ordinarySyncs, segmentID)
+}
+
+func (s *WriteBufferSuite) TestBeginDropSnapshotsOrdinaryTerminalErrorAtomically() {
+	segmentID := int64(1117)
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	state := &ordinarySyncState{
+		task:    task,
+		phase:   ordinarySyncAttemptInFlight,
+		attempt: 1,
+		done:    make(chan struct{}),
+	}
+	s.wb.ordinarySyncs[segmentID] = state
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return().Once()
+
+	dropCtx, dropCancel := context.WithCancel(context.Background())
+	defer dropCancel()
+	s.wb.mut.Lock()
+	s.wb.dropping = true
+	tasks, waiters := s.wb.beginOrdinaryDropLocked(dropCtx)
+	s.Empty(tasks)
+	s.Equal([]*ordinarySyncState{state}, waiters)
+
+	callbackStarted := make(chan struct{})
+	callbackDone := make(chan struct{})
+	go func() {
+		defer close(callbackDone)
+		close(callbackStarted)
+		outcome := s.wb.handleOrdinarySyncResult(dropCtx, task, 1, context.Canceled)
+		_ = s.wb.finishOrdinarySyncOutcome(state, task, outcome)
+	}()
+	<-callbackStarted
+	s.wb.mut.Unlock()
+
+	s.ErrorIs(s.wb.waitOrdinarySyncs(dropCtx, dropCancel, tasks, waiters), context.Canceled)
+	<-callbackDone
+	s.NotContains(s.wb.ordinarySyncs, segmentID)
+}
+
+func (s *WriteBufferSuite) TestGrowingAndOrdinaryShareSegmentAdmissionGate() {
+	segmentID := int64(1108)
+	s.wb.growingSourceProgress[segmentID] = &growingSourceProgress{
+		segmentID: segmentID,
+		syncing:   true,
+	}
+	s.wb.buffers[segmentID] = &segmentBuffer{
+		segmentID:    segmentID,
+		insertBuffer: &InsertBuffer{},
+		deltaBuffer:  &DeltaBuffer{},
+	}
+	s.metacache.EXPECT().GetSegmentByID(segmentID).Return(
+		metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: segmentID}, nil, nil, nil), true).Maybe()
+
+	futures := s.wb.syncSegments(context.Background(), []int64{segmentID})
+	s.Empty(futures)
+	s.Contains(s.wb.buffers, segmentID)
+	s.NotContains(s.wb.ordinarySyncs, segmentID)
+}
+
+type manualOrdinaryRetryTimer struct {
+	stopped atomic.Bool
+}
+
+func (t *manualOrdinaryRetryTimer) Stop() bool {
+	return !t.stopped.Swap(true)
+}
+
+func (s *WriteBufferSuite) TestOrdinaryRetrySchedulesOneAttemptAtATime() {
+	segmentID := int64(1103)
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithBatchRows(10).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	state := &ordinarySyncState{
+		task:    task,
+		phase:   ordinarySyncRetryWait,
+		attempt: 1,
+		done:    make(chan struct{}),
+	}
+	var scheduled []func()
+	s.wb.ordinaryRetryAfterFunc = func(_ time.Duration, f func()) retryTimer {
+		scheduled = append(scheduled, f)
+		return &manualOrdinaryRetryTimer{}
+	}
+	s.wb.ordinarySyncs[segmentID] = state
+
+	s.wb.mut.Lock()
+	s.wb.scheduleOrdinaryRetryLocked(state)
+	s.wb.scheduleOrdinaryRetryLocked(state)
+	s.wb.mut.Unlock()
+	s.Require().Len(scheduled, 1)
+
+	s.syncMgr.EXPECT().SyncData(mock.Anything, task, mock.Anything).Return(
+		conc.Go(func() (struct{}, error) { return struct{}{}, nil }), nil).Once()
+	scheduled[0]()
+	s.Equal(ordinarySyncAttemptInFlight, state.phase)
+	s.EqualValues(2, state.attempt)
+
+	// A stale timer callback cannot enqueue another copy while attempt 2 is
+	// queued/running.
+	scheduled[0]()
+	s.syncMgr.AssertExpectations(s.T())
+
+	// It also cannot enqueue after attempt 2 has failed and installed its own
+	// retry timer. The attempt generation, not just the phase, distinguishes the
+	// stale callback from the current one.
+	attemptErr := errors.New("attempt 2 failed")
+	outcome := s.wb.handleOrdinarySyncResult(context.Background(), task, 2, attemptErr)
+	s.ErrorIs(s.wb.finishOrdinarySyncOutcome(state, task, outcome), attemptErr)
+	s.Require().Len(scheduled, 2)
+	scheduled[0]()
+	s.syncMgr.AssertNumberOfCalls(s.T(), "SyncData", 1)
+}
+
+func (s *WriteBufferSuite) TestOrdinaryRetryUsesLogicalTaskContext() {
+	segmentID := int64(1113)
+	segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: segmentID}, nil, nil, metacache.NewEmptySegmentStats())
+	metacache.StartSyncing(10)(segment)
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Run(
+		func(action metacache.SegmentAction, _ ...metacache.SegmentFilter) {
+			action(segment)
+		}).Return().Once()
+
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithBatchRows(10).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	retryCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	state := &ordinarySyncState{
+		task:     task,
+		phase:    ordinarySyncRetryWait,
+		attempt:  1,
+		retryCtx: retryCtx,
+		done:     make(chan struct{}),
+	}
+	s.wb.ordinarySyncs[segmentID] = state
+
+	s.wb.retryOrdinarySync(segmentID, state, 1)
+
+	s.NotContains(s.wb.ordinarySyncs, segmentID)
+	s.Zero(s.wb.MemorySize())
+	<-state.done
+	s.ErrorIs(state.terminalErr, context.Canceled)
+	s.Zero(segment.SyncingRows())
+	s.True(metacache.WithNoSyncingTask().Filter(segment))
+	s.syncMgr.AssertNotCalled(s.T(), "SyncData", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func (s *WriteBufferSuite) TestOrdinaryFailureRetainsLogicalTaskAndCounters() {
+	segmentID := int64(1104)
+	task := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithBatchRows(10).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	state := &ordinarySyncState{
+		task:    task,
+		phase:   ordinarySyncAttemptInFlight,
+		attempt: 1,
+		done:    make(chan struct{}),
+	}
+	s.wb.ordinaryRetryAfterFunc = func(_ time.Duration, _ func()) retryTimer {
+		return &manualOrdinaryRetryTimer{}
+	}
+	s.wb.ordinarySyncs[segmentID] = state
+
+	attemptErr := errors.New("transient metadata failure")
+	outcome := s.wb.handleOrdinarySyncResult(context.Background(), task, 1, attemptErr)
+	s.ErrorIs(outcome.attemptErr, attemptErr)
+	s.Equal(ordinarySyncRetryWait, state.phase)
+	s.Same(state, s.wb.ordinarySyncs[segmentID])
+	s.NotNil(state.retryTimer)
+	// No AbortSyncing/StartSyncing call is expected for an attempt failure;
+	// the logical task keeps the original syncing-row ownership.
+	s.metacache.AssertExpectations(s.T())
+}
+
+func (s *WriteBufferSuite) TestDropDrainsOutstandingBeforeBufferedTail() {
+	segmentID := int64(1105)
+	segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             segmentID,
+		PartitionID:    10,
+		State:          commonpb.SegmentState_Growing,
+		StorageVersion: storage.StorageV2,
+	}, nil, nil, metacache.NewEmptySegmentStats())
+	s.metacache.EXPECT().GetSegmentByID(segmentID).Return(segment, true).Maybe()
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Run(
+		func(action metacache.SegmentAction, _ ...metacache.SegmentFilter) {
+			action(segment)
+		}).Return().Maybe()
+
+	metaWriter := syncmgr.NewMockMetaWriter(s.T())
+	metaWriter.EXPECT().DropChannel(mock.Anything, s.channelName).Return(nil).Once()
+	s.wb.metaWriter = metaWriter
+	s.wb.checkpoint = &msgpb.MsgPosition{Timestamp: 300}
+
+	firstTask := syncmgr.NewSyncTask().WithSyncPack(new(syncmgr.SyncPack).
+		WithSegmentID(segmentID).
+		WithBatchRows(10).
+		WithCheckpoint(&msgpb.MsgPosition{Timestamp: 200}))
+	firstState := &ordinarySyncState{
+		task:    firstTask,
+		phase:   ordinarySyncRetryWait,
+		attempt: 1,
+		done:    make(chan struct{}),
+	}
+	s.wb.ordinarySyncs[segmentID] = firstState
+	tail, err := newSegmentBuffer(segmentID, s.collSchema)
+	s.Require().NoError(err)
+	s.wb.buffers[segmentID] = tail
+
+	var submitted []syncmgr.Task
+	s.syncMgr.EXPECT().SyncData(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, task syncmgr.Task, callbacks ...func(error) error) (*conc.Future[struct{}], error) {
+			submitted = append(submitted, task)
+			var callbackErr error
+			for _, callback := range callbacks {
+				callbackErr = callback(callbackErr)
+			}
+			return conc.Go(func() (struct{}, error) { return struct{}{}, callbackErr }), nil
+		}).Twice()
+
+	s.wb.Close(context.Background(), true)
+	s.Require().Len(submitted, 2)
+	s.False(submitted[0].IsDrop(), "the older logical task must retain its immutable flags")
+	s.True(submitted[1].IsDrop(), "the buffered tail is the final drop task")
+}
+
 func (s *WriteBufferSuite) TestFlushSourceModeNotifier() {
 	segmentID := int64(1001)
 	var notifiedSegmentID int64
@@ -603,11 +1154,15 @@ func (s *WriteBufferSuite) TestEvictBuffer() {
 		syncMgr.EXPECT().SyncData(mock.Anything, mock.MatchedBy(func(task syncmgr.Task) bool {
 			return task != nil && task.SegmentID() == 5 && task.IsDrop()
 		}), mock.Anything).RunAndReturn(
-			func(context.Context, syncmgr.Task, ...func(error) error) (*conc.Future[struct{}], error) {
+			func(_ context.Context, _ syncmgr.Task, callbacks ...func(error) error) (*conc.Future[struct{}], error) {
 				close(submitEntered)
 				<-releaseSubmit
+				var callbackErr error
+				for _, callback := range callbacks {
+					callbackErr = callback(callbackErr)
+				}
 				return conc.Go[struct{}](func() (struct{}, error) {
-					return struct{}{}, nil
+					return struct{}{}, callbackErr
 				}), nil
 			},
 		).Once()

--- a/internal/flushcommon/writebuffer/write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/write_buffer_test.go
@@ -109,6 +109,61 @@ func (s *WriteBufferSuite) TestOrdinarySyncStateBlocksSecondLogicalTask() {
 	s.True(buffered, "new rows must stay buffered behind the outstanding logical task")
 }
 
+func (s *WriteBufferSuite) TestOrdinaryPayloadCountsTowardFlushCapacity() {
+	paramtable.Get().Save(paramtable.Get().DataNodeCfg.FlushInsertBufferSize.Key, "100")
+	defer paramtable.Get().Reset(paramtable.Get().DataNodeCfg.FlushInsertBufferSize.Key)
+
+	segmentID := int64(1102)
+	payloadReleased := make(chan struct{})
+	releasedBytes := make(chan int64, 1)
+	task := syncmgr.NewSyncTask().
+		WithSyncPack(new(syncmgr.SyncPack).WithSegmentID(segmentID)).
+		WithPayloadAccounting(60, 0, func(released int64) {
+			releasedBytes <- released
+			close(payloadReleased)
+		})
+	state := &ordinarySyncState{
+		task:            task,
+		phase:           ordinarySyncAttemptInFlight,
+		attempt:         1,
+		payloadReleased: payloadReleased,
+		done:            make(chan struct{}),
+	}
+	s.wb.mut.Lock()
+	s.wb.ordinarySyncs[segmentID] = state
+	s.wb.buffers[segmentID] = &segmentBuffer{
+		segmentID: segmentID,
+		insertBuffer: &InsertBuffer{BufferBase: BufferBase{
+			size: 40,
+		}},
+		deltaBuffer: &DeltaBuffer{},
+	}
+	s.wb.mut.Unlock()
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- s.wb.waitFlushCapacity()
+	}()
+	select {
+	case err := <-waitDone:
+		s.FailNow("flush capacity did not apply backpressure", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	s.EqualValues(100, s.wb.MemorySize())
+	s.Zero(s.wb.EvictableMemorySize())
+	task.ReleasePayload()
+	s.EqualValues(60, <-releasedBytes)
+
+	select {
+	case err := <-waitDone:
+		s.NoError(err)
+	case <-time.After(time.Second):
+		s.FailNow("payload release did not unblock flush capacity")
+	}
+	s.EqualValues(40, s.wb.MemorySize())
+}
+
 func (s *WriteBufferSuite) TestGrowingObserverPanicHappensAfterLifecycleCleanup() {
 	segmentID := int64(1109)
 	segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{ID: segmentID}, nil, nil, nil)

--- a/internal/flushcommon/writebuffer/write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/write_buffer_test.go
@@ -2,6 +2,7 @@ package writebuffer
 
 import (
 	"context"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -162,6 +163,48 @@ func (s *WriteBufferSuite) TestOrdinaryPayloadCountsTowardFlushCapacity() {
 		s.FailNow("payload release did not unblock flush capacity")
 	}
 	s.EqualValues(40, s.wb.MemorySize())
+}
+
+func (s *WriteBufferSuite) TestBM25StatsCountTowardOrdinaryPayload() {
+	segmentID := int64(1108)
+	segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             segmentID,
+		PartitionID:    10,
+		State:          commonpb.SegmentState_Growing,
+		StorageVersion: storage.StorageV2,
+	}, nil, nil, metacache.NewEmptySegmentStats())
+	s.metacache.EXPECT().GetSegmentByID(segmentID).Return(segment, true).Once()
+	s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return().Once()
+
+	stats := storage.NewBM25Stats()
+	stats.Append(map[uint32]float32{1: 1, 2: 1, 3: 1})
+	statsBuffer := newStatsBuffer()
+	statsSize := statsBuffer.Buffer(map[int64]*storage.BM25Stats{101: stats})
+	s.wb.buffers[segmentID] = &segmentBuffer{
+		segmentID: segmentID,
+		insertBuffer: &InsertBuffer{
+			BufferBase:  BufferBase{size: statsSize},
+			collSchema:  s.collSchema,
+			statsBuffer: statsBuffer,
+		},
+		deltaBuffer: NewDeltaBuffer(),
+	}
+	s.wb.checkpoint = &msgpb.MsgPosition{Timestamp: 200}
+	bytesPerEntry := &paramtable.Get().QueryNodeCfg.BM25StatsBytesPerEntry
+	paramtable.Get().Save(bytesPerEntry.Key, strconv.FormatInt(bytesPerEntry.GetAsInt64()+1, 10))
+	defer paramtable.Get().Reset(bytesPerEntry.Key)
+	s.NotEqual(statsSize, stats.MemSize())
+	s.Equal(statsSize, s.wb.MemorySize())
+
+	s.wb.mut.Lock()
+	task, err := s.wb.getSyncTask(context.Background(), segmentID)
+	s.wb.mut.Unlock()
+	s.Require().NoError(err)
+	ordinaryTask := task.(*syncmgr.SyncTask)
+
+	s.Equal(statsSize, ordinaryTask.InsertPayloadBytes())
+	s.Equal(statsSize, ordinaryTask.PayloadBytes())
+	s.Equal(statsSize, s.wb.MemorySize())
 }
 
 func (s *WriteBufferSuite) TestGrowingObserverPanicHappensAfterLifecycleCleanup() {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1836,7 +1836,7 @@ func (s *DelegatorDataSuite) TestReleaseGrowingSourceAfterPreparedHandoff() {
 	segment.EXPECT().Type().Return(segments.SegmentTypeGrowing).Maybe()
 	segment.EXPECT().Level().Return(datapb.SegmentLevel_Legacy).Maybe()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(targetOffset).Once()
+	segment.EXPECT().RowNum().Return(targetOffset).Once()
 	segment.EXPECT().MemSize().Return(int64(1024)).Once()
 	segment.EXPECT().Unpin().Maybe()
 

--- a/internal/querynodev2/delegator/growing_flush_source.go
+++ b/internal/querynodev2/delegator/growing_flush_source.go
@@ -118,7 +118,7 @@ func (p *delegatorGrowingSourceProvider) GetGrowingFlushSource(segmentID int64, 
 		return nil, syncmgr.GrowingSourceUnavailable
 	}
 	source := &delegatorGrowingFlushSource{segmentID: segmentID, segment: segment, provider: p, targetOffset: targetOffset, retained: retained}
-	if p.currentOffset(segment) < targetOffset {
+	if growingSourceCurrentOffset(segment) < targetOffset {
 		return source, syncmgr.GrowingSourcePending
 	}
 	return source, syncmgr.GrowingSourceUsable
@@ -230,7 +230,7 @@ func (p *delegatorGrowingSourceProvider) registerRetained(segmentID int64, targe
 	if err := segment.PinIfNotReleased(); err != nil {
 		return err
 	}
-	currentOffset := p.currentOffset(segment)
+	currentOffset := growingSourceCurrentOffset(segment)
 	if currentOffset < targetOffset {
 		segment.Unpin()
 		return merr.WrapErrServiceInternalMsg("growing-source segment %d is behind target offset, current=%d target=%d", segmentID, currentOffset, targetOffset)
@@ -555,11 +555,33 @@ func (p *delegatorGrowingSourceProvider) unregisterIfInactiveLocked() *syncmgr.G
 	return registration
 }
 
-func (p *delegatorGrowingSourceProvider) currentOffset(segment segments.Segment) int64 {
+// growingSourceCurrentOffset reports how far the growing segment can safely be
+// flushed. It is the single owner of that bound — every admission check and
+// every GrowingFlushSource.CurrentOffset goes through here, so the flush range
+// can never be derived two different ways.
+//
+// This MUST agree with the bound segcore validates the flush range against:
+// FlushGrowingSegmentData rejects end_offset > get_row_count(), where
+// get_row_count() is ack_responder_.GetAck() — the contiguous *acknowledged*
+// prefix, i.e. exactly the rows an MVCC read would see.
+//
+// InsertCount() is a Go-side counter bumped after each Insert returns. With
+// concurrent inserts into one segment the acknowledged prefix lags it: a later
+// batch can finish while an earlier one is still in flight, so InsertCount
+// covers rows the ack has not reached. Admitting a flush on that number gave
+// segcore a range it then refused, and the resulting error was treated as a
+// sync failure rather than "not ready yet".
+//
+// Reading the acked count instead makes an un-acked tail report
+// GrowingSourcePending, so the flush simply waits for the next round and picks
+// up the rows once they are visible. RowNum() is a cgo call whenever an insert
+// has invalidated the cached value; that cost is paid per flush decision, not
+// per row.
+func growingSourceCurrentOffset(segment segments.Segment) int64 {
 	if segment == nil {
 		return 0
 	}
-	return segment.InsertCount()
+	return segment.RowNum()
 }
 
 func (p *delegatorGrowingSourceProvider) observeRetainedMetricsLocked() {
@@ -611,13 +633,7 @@ type delegatorGrowingFlushSource struct {
 }
 
 func (s *delegatorGrowingFlushSource) CurrentOffset() int64 {
-	if s.provider != nil {
-		return s.provider.currentOffset(s.segment)
-	}
-	if s.segment == nil {
-		return 0
-	}
-	return s.segment.InsertCount()
+	return growingSourceCurrentOffset(s.segment)
 }
 
 func (s *delegatorGrowingFlushSource) FlushGrowingData(ctx context.Context, startOffset, endOffset int64, config *syncmgr.GrowingFlushConfig) (*syncmgr.GrowingFlushResult, error) {

--- a/internal/querynodev2/delegator/growing_flush_source_test.go
+++ b/internal/querynodev2/delegator/growing_flush_source_test.go
@@ -73,7 +73,7 @@ func TestDelegatorGrowingSourceProviderCloseWaitsForSourceRelease(t *testing.T) 
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().Unpin().Once()
 
 	source, state := provider.GetGrowingFlushSource(1001, 10, nil)
@@ -114,7 +114,7 @@ func TestDelegatorGrowingSourceProviderRetainedSource(t *testing.T) {
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().MemSize().Return(int64(1024)).Once()
 
 	err := provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 0, []syncmgr.GrowingSourceReleaseHandoffSegment{
@@ -124,7 +124,7 @@ func TestDelegatorGrowingSourceProviderRetainedSource(t *testing.T) {
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(nil).Twice()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Twice()
-	segment.EXPECT().InsertCount().Return(int64(10)).Twice()
+	segment.EXPECT().RowNum().Return(int64(10)).Twice()
 	segment.EXPECT().Unpin().Times(3)
 	segmentManager.EXPECT().ReleaseDetached(context.Background(), segment).Once()
 
@@ -147,20 +147,44 @@ func TestDelegatorGrowingSourceProviderRetainedSource(t *testing.T) {
 	require.Nil(t, source)
 }
 
-func TestDelegatorGrowingSourceProviderUsesInsertCountAsOffset(t *testing.T) {
+func TestDelegatorGrowingSourceProviderUsesAckedRowCountAsOffset(t *testing.T) {
 	segmentManager := segments.NewMockSegmentManager(t)
 	segment := segments.NewMockSegment(t)
 	provider := newDelegatorGrowingSourceProvider(segmentManager, nil)
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(12)).Twice()
+	segment.EXPECT().RowNum().Return(int64(12)).Twice()
 	segment.EXPECT().Unpin().Once()
 
 	source, state := provider.GetGrowingFlushSource(1001, 12, nil)
 	require.Equal(t, syncmgr.GrowingSourceUsable, state)
 	require.NotNil(t, source)
 	require.EqualValues(t, 12, source.CurrentOffset())
+	source.Release()
+}
+
+// An un-acked tail must report Pending, not Usable. Admitting the flush on
+// rows segcore has not acknowledged is what produced the invalid-offset
+// rejection: FlushGrowingSegmentData validates end_offset against
+// get_row_count() == ack_responder_.GetAck(), so a range past the acked
+// prefix comes back as an error that the sync path then mistook for a real
+// sync failure instead of "not ready yet".
+func TestDelegatorGrowingSourceProviderPendingWhenAckLagsTarget(t *testing.T) {
+	segmentManager := segments.NewMockSegmentManager(t)
+	segment := segments.NewMockSegment(t)
+	provider := newDelegatorGrowingSourceProvider(segmentManager, nil)
+
+	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
+	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
+	// 12 rows inserted, only 10 acknowledged.
+	segment.EXPECT().RowNum().Return(int64(10)).Twice()
+	segment.EXPECT().Unpin().Once()
+
+	source, state := provider.GetGrowingFlushSource(1001, 12, nil)
+	require.Equal(t, syncmgr.GrowingSourcePending, state)
+	require.NotNil(t, source)
+	require.EqualValues(t, 10, source.CurrentOffset())
 	source.Release()
 }
 
@@ -201,7 +225,7 @@ func TestDelegatorGrowingSourceProviderPrepareWaitsFence(t *testing.T) {
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().MemSize().Return(int64(1024)).Once()
 
 	err := provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 200, []syncmgr.GrowingSourceReleaseHandoffSegment{
@@ -255,7 +279,7 @@ func TestDelegatorGrowingSourceProviderHandoffOnlyRejectsNewSegmentsBeforeFence(
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().MemSize().Return(int64(1024)).Once()
 	close(releaseFence)
 	require.NoError(t, <-prepareDone)
@@ -275,7 +299,7 @@ func TestDelegatorGrowingSourceProviderDeactivatedOnlyServesRetainedSources(t *t
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().MemSize().Return(int64(1024)).Once()
 
 	err := provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 100, []syncmgr.GrowingSourceReleaseHandoffSegment{
@@ -316,7 +340,7 @@ func TestDelegatorGrowingSourceProviderReleasesWhenDetachedBeforeCommit(t *testi
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().MemSize().Return(int64(1024)).Once()
 
 	err := provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 0, []syncmgr.GrowingSourceReleaseHandoffSegment{
@@ -340,11 +364,11 @@ func TestDelegatorGrowingSourceProviderPrepareRollbackOnFailure(t *testing.T) {
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().MemSize().Return(int64(1024)).Once()
 	segmentManager.EXPECT().GetGrowing(int64(1002)).Return(behindSegment).Once()
 	behindSegment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	behindSegment.EXPECT().InsertCount().Return(int64(5)).Once()
+	behindSegment.EXPECT().RowNum().Return(int64(5)).Once()
 	behindSegment.EXPECT().Unpin().Once()
 	segment.EXPECT().Unpin().Once()
 
@@ -386,7 +410,7 @@ func TestDelegatorGrowingSourceProviderPrepareMixedRetainedAndMissing(t *testing
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().MemSize().Return(int64(1024)).Once()
 	segmentManager.EXPECT().GetGrowing(int64(1002)).Return(nil).Once()
 
@@ -413,7 +437,7 @@ func TestDelegatorGrowingSourceProviderRegisterRetainedBehindTarget(t *testing.T
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(5)).Once()
+	segment.EXPECT().RowNum().Return(int64(5)).Once()
 	segment.EXPECT().Unpin().Once()
 
 	err := provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 0, []syncmgr.GrowingSourceReleaseHandoffSegment{
@@ -440,7 +464,7 @@ func TestDelegatorGrowingSourceProviderRetainedMetrics(t *testing.T) {
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().MemSize().Return(int64(4096)).Once()
 
 	err := provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 0, []syncmgr.GrowingSourceReleaseHandoffSegment{
@@ -500,7 +524,7 @@ func TestDelegatorGrowingSourceProviderRetainedMetricsDeletedWhenRetainedDrains(
 
 	segmentManager.EXPECT().GetGrowing(int64(1001)).Return(segment).Once()
 	segment.EXPECT().PinIfNotReleased().Return(nil).Once()
-	segment.EXPECT().InsertCount().Return(int64(10)).Once()
+	segment.EXPECT().RowNum().Return(int64(10)).Once()
 	segment.EXPECT().MemSize().Return(int64(2048)).Once()
 
 	err := provider.PrepareGrowingSourceReleaseHandoff(context.Background(), 0, []syncmgr.GrowingSourceReleaseHandoffSegment{

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -510,8 +510,15 @@ func DeserializeBloomFilterStats(paths []string, blobs []*Blob) ([]*PrimaryKeySt
 // len(map) is O(1) in Go (reads hmap.count directly). Per-entry cost is configurable
 // via queryNode.idfOracle.bm25StatsBytesPerEntry.
 func (m *BM25Stats) MemSize() int64 {
+	return m.MemSizeWithBytesPerEntry(paramtable.Get().QueryNodeCfg.BM25StatsBytesPerEntry.GetAsInt64())
+}
+
+// MemSizeWithBytesPerEntry estimates the in-memory size using a fixed
+// per-entry cost. Callers that account a memory delta can snapshot the cost
+// once so a concurrent configuration refresh cannot make the delta negative.
+func (m *BM25Stats) MemSizeWithBytesPerEntry(bytesPerEntry int64) int64 {
 	// Fixed overhead: numRow(8) + numToken(8) + map header (~100B)
-	return 120 + int64(len(m.rowsWithToken))*paramtable.Get().QueryNodeCfg.BM25StatsBytesPerEntry.GetAsInt64()
+	return 120 + int64(len(m.rowsWithToken))*bytesPerEntry
 }
 
 // DeserializeFromReader reads BM25 stats from an io.Reader and accumulates into self.

--- a/internal/storage/stats_test.go
+++ b/internal/storage/stats_test.go
@@ -277,6 +277,7 @@ func TestBM25Stats_MemSize(t *testing.T) {
 	}
 	bytesPerEntry := paramtable.Get().QueryNodeCfg.BM25StatsBytesPerEntry.GetAsInt64()
 	assert.Equal(t, int64(120)+100*bytesPerEntry, stats.MemSize())
+	assert.Equal(t, int64(820), stats.MemSizeWithBytesPerEntry(7))
 }
 
 func TestBM25Stats_DeserializeFromReader(t *testing.T) {

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -63,7 +63,7 @@ func (impl *flusherComponents) WhenCreateCollection(ctx context.Context, createC
 	ds := pipeline.NewEmptyStreamingNodeDataSyncService(
 		context.Background(), // There's no any rpc in this function, so the context is not used here.
 		&util.PipelineParams{
-			Ctx:                context.Background(),
+			Ctx:                ctx,
 			Broker:             impl.broker,
 			SyncMgr:            resource.Resource().SyncManager(),
 			ChunkManager:       impl.chunkManager,
@@ -252,7 +252,7 @@ func (impl *flusherComponents) buildDataSyncService(ctx context.Context, recover
 	schema := schemaManager.GetSchema(0)
 	ds, err := pipeline.NewStreamingNodeDataSyncService(ctx,
 		&util.PipelineParams{
-			Ctx:                context.Background(),
+			Ctx:                ctx,
 			Broker:             impl.broker,
 			SyncMgr:            resource.Resource().SyncManager(),
 			ChunkManager:       impl.chunkManager,


### PR DESCRIPTION
issue: #51643

## What this fixes

Growing rows can be published into column storage and nullable offset mappings before the acknowledged row count advances. Search and flush must use the same frozen acknowledged prefix. At the same time, transient flush failures must preserve exactly one logical owner for the data: they must not enter the default panic path, duplicate an attempt, lose a parked pack during Drop, hide retained memory from backpressure, or commit channel metadata before segment data is durable.

This PR fixes both sides of that correctness boundary.

## Growing search correctness

- `SearchInfo` carries `active_count_`, frozen once by the plan layer.
- Nullable vector search converts that logical bound with `OffsetMapping::ValidCountBelow`, so it never scans rows beyond the same MVCC snapshot used by the non-nullable path.
- `GrowingOffsetMapping::Append` checks both physical and logical continuity. The binary search requires monotonic physical-to-logical order, so an out-of-order future insert fails loudly instead of silently returning unacknowledged rows.
- The growing flush admission bound uses `RowNum()`, the acknowledged prefix validated by segcore.

## Flush retry, memory, and cleanup correctness

- `SyncManager` is the sole owner of `HandleError`; `SyncTask.Run` no longer invokes the default panic callback before recovery can run.
- Ordinary sync has one per-segment logical state and at most one in-flight attempt. Retry generations reject stale timers, the same immutable task is reused, and a later batch cannot overtake a failed earlier batch.
- Follow-up ownership is installed before the previous logical completion is published, so backpressure never observes a full buffered tail without an owner.
- Ordinary insert, delete, and BM25 stats payload remains in `MemorySize()` and `DataNodeFlowGraphBufferDataSize` after yield. It is removed exactly once only when `ReleaseData()` actually runs.
- BM25 stats enter the existing insert threshold from the buffered stage onward. The already-accounted byte estimate is frozen and transferred to the sync task, so a runtime `bm25StatsBytesPerEntry` refresh cannot make the gauge negative or create an accounting gap.
- Per-segment backpressure reuses the existing `FlushInsertBufferSize` and `FlushDeleteBufferBytes` thresholds. The combined retained payload plus current write-buffer tail blocks `BufferData` after the triggering task has been submitted, so oversized batches can still make progress without allowing storage outages to accumulate invisible packs.
- The memory manager counts all resident ordinary payload but chooses eviction candidates only from immediately evictable buffers, avoiding a busy loop when the watermark is dominated by in-flight flushes.
- After object storage succeeds, the task freezes binlog metadata and releases the row payload. A metadata-only retry does not rewrite object data or continue consuming payload capacity.
- Success, cancellation, fatal errors, callback panics, dispatcher shutdown, and retry submission failure converge on exactly-once accounting and cleanup.
- `Drop` and `SaveAll` atomically take ownership of pending ordinary syncs, drain ordinary and growing data under their context, and call `DropChannel` only after persistence succeeds. The streaming flusher lifecycle context now reaches writeNode, BufferManager, WriteBuffer, and the final broker `DropVirtualChannel` RPC; BufferManager also applies `GracefulStopTimeout` as an upper bound.
- Dispatcher close fences semaphore waiters, async handoff, queued cancellation, callbacks, futures, and task accounting.

## Scope

This PR introduces no separate process-wide packed-memory budget, lease, or weighted byte semaphore. Ordinary backpressure reuses the existing per-segment flush thresholds and DataNode memory watermark. Growing-source data remains owned by segcore and is not counted as a yielded pack.

Storage-layer retryable/permanent classification remains out of scope; retry behavior uses the classifications currently exposed by the sync path.

## Validation

- CI-aligned golangci-lint 2.11.3 for flushcommon, storage, and streaming flusher packages - 0 issues
- explicit govet and test depguard checks - 0 issues
- remote focused Go tests passed for payload exact-once accounting, storage failure retention, metadata-only release, BufferData backpressure, memory-manager no-spin, bounded Drop context propagation, BM25 buffered/in-flight accounting, and BM25 config-refresh transfer
- remote full pipeline and streaming flusher package tests passed
- race tests passed for payload concurrent release, BufferData backpressure, and the complete write-buffer base suite
- local compile-only checks passed for writebuffer, pipeline, storage, and streaming flusher packages
- `git diff --check`, gofmt, gofumpt, and gci checks
- remote C++ fast build - 737 targets completed
- remote `OffsetMapping.*` - 17/17 passed

The local macOS test binaries cannot execute because the environment does not provide `libmilvus-storage.dylib`; the Go tests above were executed on the configured Linux development host with the CI build tags and Mockey gcflags.
