### PR TITLE
fix: gate segment load on delegator schema version

### DIFF
--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -222,13 +222,23 @@ func (ex *Executor) executeSegmentAction(task *SegmentTask, step int) {
 // not really executes the request
 func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	action := task.Actions()[step].(*SegmentAction)
-	defer action.rpcReturned.Store(true)
+	markRPCReturned := true
+	defer func() {
+		if markRPCReturned {
+			action.rpcReturned.Store(true)
+		}
+	}()
 	ctx := task.Context()
 
 	var err error
 	defer func() {
 		if err != nil {
-			task.Fail(err)
+			if errors.Is(err, merr.ErrCollectionSchemaVersionNotReady) {
+				markRPCReturned = false
+				task.SetReason(err.Error())
+			} else {
+				task.Fail(err)
+			}
 		}
 		ex.removeTask(task, step)
 	}()
@@ -278,7 +288,11 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	status, err := ex.cluster.LoadSegments(task.Context(), view.Node, req)
 	err = merr.CheckRPCCall(status, err)
 	if err != nil {
-		mlog.Warn(context.TODO(), "failed to load segment", mlog.Err(err))
+		if errors.Is(err, merr.ErrCollectionSchemaVersionNotReady) {
+			mlog.Info(ctx, "load segment waits for delegator schema version", mlog.Err(err))
+		} else {
+			mlog.Warn(ctx, "failed to load segment", mlog.Err(err))
+		}
 		return err
 	}
 

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -27,6 +27,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -233,7 +235,7 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	var err error
 	defer func() {
 		if err != nil {
-			if errors.Is(err, merr.ErrCollectionSchemaVersionNotReady) {
+			if isLoadSegmentPendingError(err) {
 				markRPCReturned = false
 				task.SetReason(err.Error())
 			} else {
@@ -288,8 +290,8 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	status, err := ex.cluster.LoadSegments(task.Context(), view.Node, req)
 	err = merr.CheckRPCCall(status, err)
 	if err != nil {
-		if errors.Is(err, merr.ErrCollectionSchemaVersionNotReady) {
-			mlog.Info(ctx, "load segment waits for delegator schema version", mlog.Err(err))
+		if isLoadSegmentPendingError(err) {
+			mlog.Info(ctx, "load segment waits for transient runtime readiness", mlog.Err(err))
 		} else {
 			mlog.Warn(ctx, "failed to load segment", mlog.Err(err))
 		}
@@ -300,6 +302,25 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	mlog.Info(context.TODO(), "load segments done", mlog.Duration("elapsed", elapsed))
 
 	return nil
+}
+
+func isLoadSegmentPendingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if merr.IsRetryableErr(err) {
+		return true
+	}
+	if errors.IsAny(err,
+		context.DeadlineExceeded,
+		grpc.ErrClientConnClosing,
+		merr.ErrChannelNotAvailable,
+		merr.ErrNodeNotAvailable,
+		merr.ErrNodeNotFound,
+	) {
+		return true
+	}
+	return funcutil.IsGrpcErr(err, codes.Unavailable, codes.DeadlineExceeded, codes.Aborted)
 }
 
 // If we enable following checking when loading segments,

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -181,6 +181,7 @@ func (suite *TaskSuite) BeforeTest(suiteName, testName string) {
 		"TestLoadSegmentTask",
 		"TestLoadSegmentTaskNotIndex",
 		"TestSegmentTaskWaitsDistAfterLoadRPC",
+		"TestLoadSegmentTaskWaitsDelegatorSchema",
 		"TestLoadSegmentTaskFailed",
 		"TestTaskCanceled",
 		"TestMoveSegmentTask",
@@ -637,6 +638,86 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 		suite.Equal(TaskStatusSucceeded, task.Status())
 		suite.NoError(task.Err())
 	}
+}
+
+func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
+	ctx := context.Background()
+	timeout := 10 * time.Second
+	targetNode := int64(3)
+	partition := int64(100)
+	segment := suite.loadSegments[0]
+	channel := &datapb.VchannelInfo{
+		CollectionID: suite.collection,
+		ChannelName:  Params.CommonCfg.RootCoordDml.GetValue() + "-test",
+	}
+
+	suite.broker.EXPECT().DescribeCollection(mock.Anything, suite.collection).RunAndReturn(func(ctx context.Context, i int64) (*milvuspb.DescribeCollectionResponse, error) {
+		return &milvuspb.DescribeCollectionResponse{
+			Schema: &schemapb.CollectionSchema{
+				Name:    "TestLoadSegmentTaskWaitsDelegatorSchema",
+				Version: 1,
+				Fields: []*schemapb.FieldSchema{
+					{FieldID: 100, Name: "vec", DataType: schemapb.DataType_FloatVector},
+				},
+			},
+		}, nil
+	})
+	suite.broker.EXPECT().ListIndexes(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
+		{
+			CollectionID: suite.collection,
+		},
+	}, nil)
+	suite.broker.EXPECT().GetSegmentInfo(mock.Anything, segment).Return([]*datapb.SegmentInfo{
+		{
+			ID:            segment,
+			CollectionID:  suite.collection,
+			PartitionID:   partition,
+			InsertChannel: channel.ChannelName,
+		},
+	}, nil)
+	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil)
+	schemaErr := merr.WrapErrCollectionSchemaVersionNotReadyWithVersion("TestLoadSegmentTaskWaitsDelegatorSchema", 0, 1)
+	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Status(schemaErr), nil).Once()
+
+	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
+		VchannelInfo: channel,
+		Node:         targetNode,
+		Version:      1,
+		View: &meta.LeaderView{
+			ID:           targetNode,
+			CollectionID: suite.collection,
+			Channel:      channel.ChannelName,
+			Status:       &querypb.LeaderViewStatus{Serviceable: true},
+		},
+	})
+	task, err := NewSegmentTask(
+		ctx,
+		timeout,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
+	)
+	suite.NoError(err)
+	suite.NoError(suite.scheduler.Add(task))
+
+	segments := []*datapb.SegmentInfo{{
+		ID:            segment,
+		InsertChannel: channel.ChannelName,
+		PartitionID:   1,
+	}}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.target.UpdateCollectionNextTarget(ctx, suite.collection)
+	suite.AssertTaskNum(0, 1, 0, 1)
+
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(1, 0, 0, 1)
+	suite.Equal(TaskStatusStarted, task.Status())
+	suite.NoError(task.Err())
+	suite.Contains(task.GetReason(), "collection schema version not ready")
+	action := task.Actions()[0].(*SegmentAction)
+	suite.False(action.rpcReturned.Load())
 }
 
 func (suite *TaskSuite) TestLoadSegmentTaskFailed() {

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -661,12 +661,12 @@ func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
 				},
 			},
 		}, nil
-	}).Twice()
+	}).Times(3)
 	suite.broker.EXPECT().ListIndexes(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
 		{
 			CollectionID: suite.collection,
 		},
-	}, nil).Twice()
+	}, nil).Times(3)
 	suite.broker.EXPECT().GetSegmentInfo(mock.Anything, segment).Return([]*datapb.SegmentInfo{
 		{
 			ID:            segment,
@@ -674,10 +674,11 @@ func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
 			PartitionID:   partition,
 			InsertChannel: channel.ChannelName,
 		},
-	}, nil).Twice()
-	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil).Twice()
+	}, nil).Times(3)
+	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil).Times(3)
 	schemaErr := merr.WrapErrCollectionSchemaVersionNotReadyWithVersion("TestLoadSegmentTaskWaitsDelegatorSchema", 0, 1)
 	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Status(schemaErr), nil).Once()
+	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Status(merr.WrapErrNodeNotAvailable(targetNode, "worker churn")), nil).Once()
 	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Success(), nil).Once()
 
 	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
@@ -718,6 +719,13 @@ func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
 	suite.NoError(task.Err())
 	suite.Contains(task.GetReason(), "collection schema version not ready")
 	action := task.Actions()[0].(*SegmentAction)
+	suite.False(action.rpcReturned.Load())
+
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(1, 0, 0, 1)
+	suite.Equal(TaskStatusStarted, task.Status())
+	suite.NoError(task.Err())
+	suite.Contains(task.GetReason(), "node not available")
 	suite.False(action.rpcReturned.Load())
 
 	suite.dispatchAndWait(targetNode)

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -661,12 +661,12 @@ func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
 				},
 			},
 		}, nil
-	})
+	}).Twice()
 	suite.broker.EXPECT().ListIndexes(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
 		{
 			CollectionID: suite.collection,
 		},
-	}, nil)
+	}, nil).Twice()
 	suite.broker.EXPECT().GetSegmentInfo(mock.Anything, segment).Return([]*datapb.SegmentInfo{
 		{
 			ID:            segment,
@@ -674,10 +674,11 @@ func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
 			PartitionID:   partition,
 			InsertChannel: channel.ChannelName,
 		},
-	}, nil)
-	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil)
+	}, nil).Twice()
+	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil).Twice()
 	schemaErr := merr.WrapErrCollectionSchemaVersionNotReadyWithVersion("TestLoadSegmentTaskWaitsDelegatorSchema", 0, 1)
 	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Status(schemaErr), nil).Once()
+	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Success(), nil).Once()
 
 	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
 		VchannelInfo: channel,
@@ -718,6 +719,37 @@ func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
 	suite.Contains(task.GetReason(), "collection schema version not ready")
 	action := task.Actions()[0].(*SegmentAction)
 	suite.False(action.rpcReturned.Load())
+
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(1, 0, 0, 1)
+	suite.Equal(TaskStatusStarted, task.Status())
+	suite.NoError(task.Err())
+	suite.True(action.rpcReturned.Load())
+
+	view := &meta.LeaderView{
+		ID:           targetNode,
+		CollectionID: suite.collection,
+		Segments: map[int64]*querypb.SegmentDist{
+			segment: {NodeID: targetNode, Version: 0},
+		},
+		Channel: channel.ChannelName,
+	}
+	suite.dist.SegmentDistManager.Update(targetNode, meta.SegmentFromInfo(&datapb.SegmentInfo{
+		ID:            segment,
+		CollectionID:  suite.collection,
+		PartitionID:   partition,
+		InsertChannel: channel.ChannelName,
+	}))
+	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
+		VchannelInfo: channel,
+		Node:         targetNode,
+		Version:      1,
+		View:         view,
+	})
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(0, 0, 0, 0)
+	suite.Equal(TaskStatusSucceeded, task.Status())
+	suite.NoError(task.Err())
 }
 
 func (suite *TaskSuite) TestLoadSegmentTaskFailed() {

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -191,8 +191,8 @@ func packLoadMeta(loadType querypb.LoadType, collectionInfo *milvuspb.DescribeCo
 		DbName:        collectionInfo.GetDbName(),
 		ResourceGroup: resourceGroup,
 		LoadFields:    loadFields,
-		// The update timestamp is a load barrier, not the logical schema version.
-		// QueryNode uses it only to reject stale load results after schema changes.
+		// Keep the collection update timestamp in load meta for compatibility.
+		// Delegator load freshness is gated by the request schema version.
 		SchemaBarrierTs: collectionInfo.GetUpdateTimestamp(),
 	}
 }

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -135,6 +135,11 @@ type idfOracleHolder struct {
 	oracle IDFOracle
 }
 
+type delegatorSchemaView struct {
+	schema  *schemapb.CollectionSchema
+	version uint64
+}
+
 // shardDelegator maintains the shard distribution and streaming part of the data.
 type shardDelegator struct {
 	// shard information attributes
@@ -178,9 +183,10 @@ type shardDelegator struct {
 	// current forward policy
 	l0ForwardPolicy string
 
-	// schemaBarrierTs fences load results started before the latest schema update.
+	// schemaView is the delegator's WAL-driven schema snapshot. Load requests
+	// may require a matching version, but must never advance this view.
 	schemaChangeMutex sync.RWMutex
-	schemaBarrierTs   uint64
+	schemaView        delegatorSchemaView
 
 	// limits delegator-side post-load work after worker LoadSegments returns.
 	postLoadSem           *syncutil.Semaphore
@@ -203,6 +209,63 @@ type shardDelegator struct {
 	growingSourceProvider     *delegatorGrowingSourceProvider
 
 	leaderViewUpdatedCallback func(channel string)
+}
+
+func newDelegatorSchemaView(schema *schemapb.CollectionSchema) delegatorSchemaView {
+	if schema == nil {
+		return delegatorSchemaView{}
+	}
+	return delegatorSchemaView{
+		schema:  typeutil.Clone(schema),
+		version: uint64(schema.GetVersion()),
+	}
+}
+
+func (sd *shardDelegator) ensureDelegatorSchemaViewLocked() {
+	if sd.schemaView.schema != nil || sd.collection == nil {
+		return
+	}
+	schema, version := sd.collection.SchemaAndVersion()
+	if schema == nil {
+		return
+	}
+	sd.schemaView = delegatorSchemaView{
+		schema:  typeutil.Clone(schema),
+		version: version,
+	}
+}
+
+func (sd *shardDelegator) delegatorSchemaSnapshot() (*schemapb.CollectionSchema, uint64) {
+	sd.schemaChangeMutex.RLock()
+	schema, version := sd.delegatorSchemaSnapshotLocked()
+	sd.schemaChangeMutex.RUnlock()
+	if schema != nil {
+		return schema, version
+	}
+
+	sd.schemaChangeMutex.Lock()
+	defer sd.schemaChangeMutex.Unlock()
+	sd.ensureDelegatorSchemaViewLocked()
+	return sd.delegatorSchemaSnapshotLocked()
+}
+
+func (sd *shardDelegator) delegatorSchemaSnapshotLocked() (*schemapb.CollectionSchema, uint64) {
+	if sd.schemaView.schema == nil {
+		return nil, 0
+	}
+	return typeutil.Clone(sd.schemaView.schema), sd.schemaView.version
+}
+
+func (sd *shardDelegator) shouldUpdateDelegatorSchemaLocked(schema *schemapb.CollectionSchema) bool {
+	if schema == nil {
+		return false
+	}
+	sd.ensureDelegatorSchemaViewLocked()
+	return uint64(schema.GetVersion()) > sd.schemaView.version
+}
+
+func (sd *shardDelegator) publishDelegatorSchemaLocked(schema *schemapb.CollectionSchema) {
+	sd.schemaView = newDelegatorSchemaView(schema)
 }
 
 // getLogger returns the logger with pre-defined shard attributes.
@@ -1274,25 +1337,19 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 	sd.schemaChangeMutex.Lock()
 	defer sd.schemaChangeMutex.Unlock()
 
-	if !segments.ShouldUpdateCollectionSchema(sd.collection, schema, schemaBarrierTs) {
+	if !sd.shouldUpdateDelegatorSchemaLocked(schema) {
 		mlog.Info(ctx, "delegator skip stale or no-op schema event",
 			mlog.Uint64("schemaVersion", schemaVersion),
 			mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
 		)
 		return nil
 	}
-	oldSet := newBM25FunctionSet(sd.collection.Schema())
+	oldSchema := sd.schemaView.schema
+	oldSet := newBM25FunctionSet(oldSchema)
 	newSet := newBM25FunctionSet(schema)
 	idfOracle := sd.getIDFOracle()
 	if idfOracle != nil && newSet.HasIncompatibleCommonFunction(oldSet) {
 		return merr.WrapErrServiceInternal("unsupported incompatible BM25 function schema change on loaded collection")
-	}
-
-	// Keep the load barrier monotonic. A higher logical schema version can be
-	// replayed with a smaller barrier than an earlier same-version property
-	// refresh, but that must not reopen older load results.
-	if sd.schemaBarrierTs < schemaBarrierTs {
-		sd.schemaBarrierTs = schemaBarrierTs
 	}
 
 	sealed, growing, version := sd.distribution.PinOnlineSegments()
@@ -1309,9 +1366,9 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 		),
 		CollectionID: sd.collectionID,
 		Schema:       schema,
-		// SchemaBarrierTs fences stale load results and lets QueryNode refresh
-		// same-version schema payloads such as collection properties. Logical
-		// schema freshness is still guarded by schema.version in collectionManager.
+		// Keep sending SchemaBarrierTs to workers and the collection manager for
+		// same-version schema payloads such as collection properties. Delegator
+		// load freshness is gated by schema.Version, not this timestamp.
 		SchemaBarrierTs: schemaBarrierTs,
 	},
 		sealed,
@@ -1364,10 +1421,11 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 			return err
 		}
 	}
+	sd.publishDelegatorSchemaLocked(schema)
 	mlog.Info(ctx, "delegator finished update schema event",
 		mlog.Uint64("schemaVersion", schemaVersion),
 		mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
-		mlog.Uint64("loadBarrierTs", sd.schemaBarrierTs),
+		mlog.Uint64("delegatorSchemaVersion", sd.schemaView.version),
 		mlog.Int("sealedNum", len(sealed)),
 		mlog.Int("growingNum", len(growing)),
 		mlog.Int("bm25FunctionNum", len(newSet)),
@@ -1520,6 +1578,7 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		vchannelName:      channel,
 		version:           version,
 		collection:        collection,
+		schemaView:        newDelegatorSchemaView(collection.Schema()),
 		collectionManager: manager.Collection,
 		segmentManager:    manager.Segment,
 		workerManager:     workerManager,

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -118,16 +118,29 @@ type ShardDelegator interface {
 
 var _ ShardDelegator = (*shardDelegator)(nil)
 
+type shardDelegatorBuildOptions struct {
+	initialSchema             *schemapb.CollectionSchema
+	leaderViewUpdatedCallback func(channel string)
+}
+
 // ShardDelegatorOption customizes shard delegator creation.
-type ShardDelegatorOption func(*shardDelegator)
+type ShardDelegatorOption func(*shardDelegatorBuildOptions)
+
+// WithInitialSchema sets the per-vchannel initial schema snapshot. WatchDmChannels
+// must use the schema carried by the watch request, not the shared collection
+// snapshot that another vchannel may have already advanced.
+func WithInitialSchema(schema *schemapb.CollectionSchema) ShardDelegatorOption {
+	return func(opts *shardDelegatorBuildOptions) {
+		if schema != nil {
+			opts.initialSchema = typeutil.Clone(schema)
+		}
+	}
+}
 
 // WithLeaderViewUpdatedCallback registers a callback for leader view changes.
 func WithLeaderViewUpdatedCallback(callback func(channel string)) ShardDelegatorOption {
-	return func(sd *shardDelegator) {
-		sd.leaderViewUpdatedCallback = callback
-		if sd.distribution != nil {
-			sd.distribution.leaderViewUpdatedCallback = callback
-		}
+	return func(opts *shardDelegatorBuildOptions) {
+		opts.leaderViewUpdatedCallback = callback
 	}
 }
 
@@ -982,7 +995,7 @@ func organizeSubTask[T any](ctx context.Context,
 		segmentIDs := lo.Map(segments, func(item SegmentEntry, _ int) int64 {
 			return item.SegmentID
 		})
-		if skipEmpty && len(segmentIDs) == 0 {
+		if len(segmentIDs) == 0 && (skipEmpty || workerID != paramtable.GetNodeID()) {
 			return nil
 		}
 		// update request
@@ -1542,6 +1555,11 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	binlogSaver segments.BinlogSaver,
 	opts ...ShardDelegatorOption,
 ) (ShardDelegator, error) {
+	buildOptions := &shardDelegatorBuildOptions{}
+	for _, opt := range opts {
+		opt(buildOptions)
+	}
+
 	log := mlog.With(mlog.Int64("collectionID", collectionID),
 		mlog.Int64("replicaID", replicaID),
 		mlog.String("channel", channel),
@@ -1553,7 +1571,10 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	if collection == nil {
 		return nil, merr.WrapErrCollectionNotFound(collectionID, "not in delegator manager")
 	}
-	initialSchema := collection.Schema()
+	initialSchema := buildOptions.initialSchema
+	if initialSchema == nil {
+		initialSchema = collection.Schema()
+	}
 	if err := function.GetManager().Alloc(collectionID, delegatorFunctionRunnerKey(channel), initialSchema); err != nil {
 		return nil, err
 	}
@@ -1607,9 +1628,10 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		catchingUpStreamingData:       atomic.NewBool(catchingUpStreamingData),
 		skipStreamingForExternalTable: skipStreamingForExternalTable,
 		latestRequiredMVCCTimeTick:    atomic.NewUint64(0),
+		leaderViewUpdatedCallback:     buildOptions.leaderViewUpdatedCallback,
 	}
-	for _, opt := range opts {
-		opt(sd)
+	if sd.distribution != nil {
+		sd.distribution.leaderViewUpdatedCallback = buildOptions.leaderViewUpdatedCallback
 	}
 
 	hasBM25Field := lo.ContainsBy(initialSchema.GetFunctions(), func(tf *schemapb.FunctionSchema) bool {

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -964,6 +964,7 @@ type subTask[T any] struct {
 	req      T
 	targetID int64
 	worker   cluster.Worker
+	err      error
 }
 
 func organizeSubTask[T any](ctx context.Context,
@@ -1001,6 +1002,7 @@ func organizeSubTask[T any](ctx context.Context,
 			req:      req,
 			targetID: workerID,
 			worker:   worker,
+			err:      err,
 		})
 		return nil
 	}
@@ -1045,14 +1047,20 @@ func executeSubTasks[T any, R interface {
 		wg.Go(func() error {
 			var result R
 			var err error
-			if task.targetID == -1 || task.worker == nil {
+			if task.err != nil {
+				err = task.err
+			} else if task.targetID == -1 || task.worker == nil {
 				var segments []int64
 				if req, ok := any(task.req).(interface{ GetSegmentIDs() []int64 }); ok {
 					segments = req.GetSegmentIDs()
 				} else {
 					segments = []int64{}
 				}
-				err = merr.WrapErrServiceInternalMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				if taskType == "UpdateSchema" {
+					err = merr.WrapErrServiceUnavailableMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				} else {
+					err = merr.WrapErrServiceInternalMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				}
 			} else {
 				result, err = execute(ctx, task.req, task.worker)
 				if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
@@ -1323,7 +1331,7 @@ func (sd *shardDelegator) CatchingUpStreamingData() bool {
 
 func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
 	log := sd.getLogger(ctx)
-	if err := sd.lifetime.Add(sd.IsWorking); err != nil {
+	if err := sd.lifetime.Add(sd.NotStopped); err != nil {
 		return err
 	}
 	defer sd.lifetime.Done()

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1553,11 +1553,12 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	if collection == nil {
 		return nil, merr.WrapErrCollectionNotFound(collectionID, "not in delegator manager")
 	}
-	if err := function.GetManager().Alloc(collectionID, delegatorFunctionRunnerKey(channel), collection.Schema()); err != nil {
+	initialSchema := collection.Schema()
+	if err := function.GetManager().Alloc(collectionID, delegatorFunctionRunnerKey(channel), initialSchema); err != nil {
 		return nil, err
 	}
 
-	skipStreamingForExternalTable := typeutil.IsExternalCollection(collection.Schema())
+	skipStreamingForExternalTable := typeutil.IsExternalCollection(initialSchema)
 	catchingUpStreamingData := !skipStreamingForExternalTable
 	if skipStreamingForExternalTable {
 		log.Info(ctx, "skip streaming data catchup for read-only external collection",
@@ -1586,7 +1587,7 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		vchannelName:      channel,
 		version:           version,
 		collection:        collection,
-		schemaView:        newDelegatorSchemaView(collection.Schema()),
+		schemaView:        newDelegatorSchemaView(initialSchema),
 		collectionManager: manager.Collection,
 		segmentManager:    manager.Segment,
 		workerManager:     workerManager,
@@ -1611,12 +1612,12 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		opt(sd)
 	}
 
-	hasBM25Field := lo.ContainsBy(collection.Schema().GetFunctions(), func(tf *schemapb.FunctionSchema) bool {
+	hasBM25Field := lo.ContainsBy(initialSchema.GetFunctions(), func(tf *schemapb.FunctionSchema) bool {
 		return tf.GetType() == schemapb.FunctionType_BM25
 	})
 
 	if hasBM25Field {
-		idfOracle := NewIDFOracle(sd.vchannelName, collection.Schema().GetFunctions())
+		idfOracle := NewIDFOracle(sd.vchannelName, initialSchema.GetFunctions())
 		idfOracle.Start()
 		sd.distribution.SetIDFOracle(idfOracle)
 		sd.publishIDFOracle(idfOracle)

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -671,6 +671,10 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return err
 	}
 
+	orphanLoadInfos := lo.Filter(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) bool {
+		return !sd.distribution.SealedSegmentExistsOnNode(info.GetSegmentID(), targetNodeID)
+	})
+
 	// pin all segments to prevent delete buffer has been cleaned up during worker load segments
 	// Note: if delete records is pinned, it will skip cleanup during SyncTargetVersion
 	// which means after segment is loaded, then delete buffer will be cleaned up by next SyncTargetVersion call
@@ -730,6 +734,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	log.Debug(ctx, "work loads segments done")
 
 	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+		sd.releaseOrphanLoadedSegments(ctx, worker, targetNodeID, req, orphanLoadInfos)
 		return err
 	}
 
@@ -795,6 +800,39 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 
 		return nil
 	})
+}
+
+func (sd *shardDelegator) releaseOrphanLoadedSegments(
+	ctx context.Context,
+	worker cluster.Worker,
+	targetNodeID int64,
+	loadReq *querypb.LoadSegmentsRequest,
+	infos []*querypb.SegmentLoadInfo,
+) {
+	if len(infos) == 0 || loadReq.GetLoadScope() != querypb.LoadScope_Full {
+		return
+	}
+
+	segmentIDs := lo.Map(infos, func(info *querypb.SegmentLoadInfo, _ int) int64 {
+		return info.GetSegmentID()
+	})
+	req := &querypb.ReleaseSegmentsRequest{
+		Base: commonpbutil.NewMsgBase(
+			commonpbutil.WithSourceID(paramtable.GetNodeID()),
+			commonpbutil.WithTargetID(targetNodeID),
+		),
+		NodeID:       targetNodeID,
+		CollectionID: loadReq.GetCollectionID(),
+		SegmentIDs:   segmentIDs,
+		Scope:        querypb.DataScope_Historical,
+		Shard:        sd.vchannelName,
+	}
+	if err := worker.ReleaseSegments(ctx, req); err != nil {
+		sd.getLogger(ctx).Warn(ctx, "failed to release orphan worker segments after schema gate rejection",
+			mlog.Int64("workerID", targetNodeID),
+			mlog.Int64s("segmentIDs", segmentIDs),
+			mlog.Err(err))
+	}
 }
 
 func (sd *shardDelegator) withPostLoadLimit(ctx context.Context, fn func() error) error {

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -542,7 +542,7 @@ func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.Se
 	for _, info := range infos {
 		info := info
 		futures = append(futures, pool.Submit(func() (any, error) {
-			if err := idfOracle.LoadSealed(ctx, info.GetSegmentID(), info, cm); err != nil {
+			if err := idfOracle.LoadSealedForReopen(ctx, info.GetSegmentID(), info, cm, false); err != nil {
 				mlog.Warn(ctx, "failed to load bm25 stats for segment",
 					mlog.FieldCollectionID(req.GetCollectionID()),
 					mlog.FieldSegmentID(info.GetSegmentID()),
@@ -624,6 +624,15 @@ func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *quer
 	if len(req.GetIndexInfoList()) == 0 {
 		return nil
 	}
+	if req.GetSchema() != nil {
+		if current := sd.collectionManager.Get(req.GetCollectionID()); current != nil &&
+			current.SchemaVersion() > uint64(req.GetSchema().GetVersion()) {
+			sd.getLogger(ctx).Info(ctx, "skip stale collection index meta sync",
+				mlog.Uint64("currentSchemaVersion", current.SchemaVersion()),
+				mlog.Int32("requestSchemaVersion", req.GetSchema().GetVersion()))
+			return nil
+		}
+	}
 
 	schema, _ := sd.delegatorSchemaSnapshot()
 	if schema == nil {
@@ -670,10 +679,6 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
 		return err
 	}
-
-	orphanLoadInfos := lo.Filter(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) bool {
-		return !sd.distribution.SealedSegmentExistsOnNode(info.GetSegmentID(), targetNodeID)
-	})
 
 	// pin all segments to prevent delete buffer has been cleaned up during worker load segments
 	// Note: if delete records is pinned, it will skip cleanup during SyncTargetVersion
@@ -734,7 +739,6 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	log.Debug(ctx, "work loads segments done")
 
 	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
-		sd.releaseOrphanLoadedSegments(ctx, worker, targetNodeID, req, orphanLoadInfos)
 		return err
 	}
 
@@ -800,39 +804,6 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 
 		return nil
 	})
-}
-
-func (sd *shardDelegator) releaseOrphanLoadedSegments(
-	ctx context.Context,
-	worker cluster.Worker,
-	targetNodeID int64,
-	loadReq *querypb.LoadSegmentsRequest,
-	infos []*querypb.SegmentLoadInfo,
-) {
-	if len(infos) == 0 || loadReq.GetLoadScope() != querypb.LoadScope_Full {
-		return
-	}
-
-	segmentIDs := lo.Map(infos, func(info *querypb.SegmentLoadInfo, _ int) int64 {
-		return info.GetSegmentID()
-	})
-	req := &querypb.ReleaseSegmentsRequest{
-		Base: commonpbutil.NewMsgBase(
-			commonpbutil.WithSourceID(paramtable.GetNodeID()),
-			commonpbutil.WithTargetID(targetNodeID),
-		),
-		NodeID:       targetNodeID,
-		CollectionID: loadReq.GetCollectionID(),
-		SegmentIDs:   segmentIDs,
-		Scope:        querypb.DataScope_Historical,
-		Shard:        sd.vchannelName,
-	}
-	if err := worker.ReleaseSegments(ctx, req); err != nil {
-		sd.getLogger(ctx).Warn(ctx, "failed to release orphan worker segments after schema gate rejection",
-			mlog.Int64("workerID", targetNodeID),
-			mlog.Int64s("segmentIDs", segmentIDs),
-			mlog.Err(err))
-	}
 }
 
 func (sd *shardDelegator) withPostLoadLimit(ctx context.Context, fn func() error) error {

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -451,13 +451,17 @@ func (sd *shardDelegator) addGrowing(entries ...SegmentEntry) {
 }
 
 func (sd *shardDelegator) checkLoadSchemaVersionReady(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	_, currentVersion := sd.delegatorSchemaSnapshot()
+	return sd.checkLoadSchemaVersionReadyWithVersion(ctx, req, currentVersion)
+}
+
+func (sd *shardDelegator) checkLoadSchemaVersionReadyWithVersion(ctx context.Context, req *querypb.LoadSegmentsRequest, currentVersion uint64) error {
 	requiredSchema := req.GetSchema()
 	if requiredSchema == nil {
 		return nil
 	}
 
 	requiredVersion := uint64(requiredSchema.GetVersion())
-	_, currentVersion := sd.delegatorSchemaSnapshot()
 	if currentVersion == requiredVersion {
 		return nil
 	}
@@ -812,7 +816,11 @@ func (sd *shardDelegator) withPostLoadLimit(ctx context.Context, fn func() error
 }
 
 func (sd *shardDelegator) addDistributionIfLoadSchemaOK(ctx context.Context, req *querypb.LoadSegmentsRequest, entries ...SegmentEntry) error {
-	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+	sd.schemaChangeMutex.RLock()
+	defer sd.schemaChangeMutex.RUnlock()
+
+	_, currentVersion := sd.delegatorSchemaSnapshotLocked()
+	if err := sd.checkLoadSchemaVersionReadyWithVersion(ctx, req, currentVersion); err != nil {
 		return err
 	}
 	// alter distribution

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -449,6 +450,31 @@ func (sd *shardDelegator) addGrowing(entries ...SegmentEntry) {
 	sd.distribution.AddGrowing(entries...)
 }
 
+func (sd *shardDelegator) checkLoadSchemaVersionReady(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	requiredSchema := req.GetSchema()
+	if requiredSchema == nil {
+		return nil
+	}
+
+	requiredVersion := uint64(requiredSchema.GetVersion())
+	_, currentVersion := sd.delegatorSchemaSnapshot()
+	if currentVersion == requiredVersion {
+		return nil
+	}
+
+	err := merr.WrapErrCollectionSchemaVersionNotReadyWithVersion(requiredSchema.GetName(), currentVersion, requiredVersion)
+	sd.getLogger(ctx).RatedInfo(ctx, rate.Limit(10), "delegator rejects load request due to schema version mismatch",
+		mlog.Uint64("currentSchemaVersion", currentVersion),
+		mlog.Uint64("requiredSchemaVersion", requiredVersion),
+		mlog.String("loadScope", req.GetLoadScope().String()),
+		mlog.Int64s("segmentIDs", lo.Map(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) int64 {
+			return info.GetSegmentID()
+		})),
+		mlog.Err(err),
+	)
+	return err
+}
+
 // LoadGrowing load growing segments locally.
 func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.SegmentLoadInfo, version int64) error {
 	log := sd.getLogger(ctx)
@@ -595,9 +621,9 @@ func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *quer
 		return nil
 	}
 
-	schema := req.GetSchema()
+	schema, _ := sd.delegatorSchemaSnapshot()
 	if schema == nil {
-		schema = sd.collection.Schema()
+		schema = req.GetSchema()
 	}
 
 	loadMeta := req.GetLoadMeta()
@@ -605,14 +631,17 @@ func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *quer
 		loadMeta = &querypb.LoadMetaInfo{
 			CollectionID: req.GetCollectionID(),
 		}
+	} else {
+		loadMeta = typeutil.Clone(loadMeta)
 	}
+	loadMeta.SchemaBarrierTs = 0
 
 	meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), schema)
 	if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
 		return err
 	}
 	sd.collectionManager.Unref(req.GetCollectionID(), 1)
-	return function.GetManager().Update(sd.collectionID, delegatorFunctionRunnerKey(sd.vchannelName), schema)
+	return nil
 }
 
 // LoadSegments load segments local or remotely depends on the target node.
@@ -632,6 +661,10 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 
 	if req.GetInfos()[0].GetLevel() == datapb.SegmentLevel_L0 {
 		return merr.WrapErrServiceInternal("load L0 segment is not supported, l0 segment should only be loaded by watchChannel")
+	}
+
+	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+		return err
 	}
 
 	// pin all segments to prevent delete buffer has been cleaned up during worker load segments
@@ -692,6 +725,10 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	}
 	log.Debug(ctx, "work loads segments done")
 
+	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+		return err
+	}
+
 	if err := sd.syncCollectionIndexMeta(ctx, req); err != nil {
 		log.Warn(ctx, "failed to sync collection index meta on delegator", mlog.Err(err))
 		return err
@@ -743,8 +780,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 
 		log.Debug(ctx, "load delete...")
 		// loadStreamDelete now handles distribution add atomically in Phase 3
-		err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker,
-			entries, req.GetLoadMeta().GetSchemaBarrierTs())
+		err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker, entries)
 		if err != nil {
 			log.Warn(ctx, "load stream delete failed", mlog.Err(err))
 			// BM25 stats already loaded into idf oracle will be cleaned up
@@ -775,13 +811,10 @@ func (sd *shardDelegator) withPostLoadLimit(ctx context.Context, fn func() error
 	return fn()
 }
 
-func (sd *shardDelegator) addDistributionIfSchemaBarrierOK(schemaBarrierTs uint64, entries ...SegmentEntry) error {
-	sd.schemaChangeMutex.RLock()
-	defer sd.schemaChangeMutex.RUnlock()
-	if schemaBarrierTs < sd.schemaBarrierTs {
-		return merr.WrapErrServiceInternal("schema barrier changed")
+func (sd *shardDelegator) addDistributionIfLoadSchemaOK(ctx context.Context, req *querypb.LoadSegmentsRequest, entries ...SegmentEntry) error {
+	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+		return err
 	}
-
 	// alter distribution
 	sd.distribution.AddDistributions(entries...)
 	return nil
@@ -994,7 +1027,6 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 	targetNodeID int64,
 	worker cluster.Worker,
 	entries []SegmentEntry,
-	schemaBarrierTs uint64,
 ) error {
 	log := sd.getLogger(ctx)
 
@@ -1124,7 +1156,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 			// Atomically add to distribution while still holding RLock, so no
 			// ProcessDelete can run between "deletes applied" and "segment
 			// visible".
-			if err := sd.addDistributionIfSchemaBarrierOK(schemaBarrierTs, entries...); err != nil {
+			if err := sd.addDistributionIfLoadSchemaOK(ctx, req, entries...); err != nil {
 				sd.deleteMut.RUnlock()
 				return err
 			}
@@ -1160,7 +1192,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 					mlog.Int64("bfCost", time.Since(start).Milliseconds()),
 				)
 			}
-			if err := sd.addDistributionIfSchemaBarrierOK(schemaBarrierTs, entries...); err != nil {
+			if err := sd.addDistributionIfLoadSchemaOK(ctx, req, entries...); err != nil {
 				sd.deleteMut.RUnlock()
 				return err
 			}

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1287,6 +1287,52 @@ func (s *DelegatorDataSuite) TestLoadSegmentsSchemaVersionGate() {
 	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
 }
 
+func (s *DelegatorDataSuite) TestLoadSegmentsReleasesOrphanWorkerLoadOnFinalSchemaGateFailure() {
+	oldSchema := typeutil.Clone(s.delegator.collection.Schema())
+	newSchema := typeutil.Clone(oldSchema)
+	newSchema.Version = oldSchema.GetVersion() + 1
+	req := &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		Schema:       oldSchema,
+		LoadScope:    querypb.LoadScope_Full,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			},
+		},
+	}
+
+	worker := &cluster.MockWorker{}
+	worker.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
+		Run(func(context.Context, *querypb.LoadSegmentsRequest) {
+			s.delegator.schemaChangeMutex.Lock()
+			defer s.delegator.schemaChangeMutex.Unlock()
+			s.delegator.publishDelegatorSchemaLocked(newSchema)
+		}).
+		Return(nil).
+		Once()
+	worker.EXPECT().ReleaseSegments(mock.Anything, mock.MatchedBy(func(req *querypb.ReleaseSegmentsRequest) bool {
+		return req.GetNodeID() == int64(1) &&
+			req.GetCollectionID() == s.collectionID &&
+			req.GetScope() == querypb.DataScope_Historical &&
+			req.GetShard() == s.vchannelName &&
+			len(req.GetSegmentIDs()) == 1 &&
+			req.GetSegmentIDs()[0] == int64(100)
+	})).Return(nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+
+	err := s.delegator.LoadSegments(context.Background(), req)
+	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
+	s.False(s.delegator.distribution.SealedSegmentExistsOnNode(100, 1))
+}
+
 func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaDoesNotUpdateFunctionRunners() {
 	ctx := context.Background()
 	s.delegator.Start()

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1244,7 +1244,50 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 	})
 }
 
-func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaUpdatesFunctionRunners() {
+func (s *DelegatorDataSuite) TestLoadSegmentsSchemaVersionGate() {
+	newSchema := typeutil.Clone(s.delegator.collection.Schema())
+	newSchema.Version = s.delegator.collection.Schema().GetVersion() + 1
+	req := &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		Schema:       newSchema,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			},
+		},
+	}
+
+	err := s.delegator.LoadSegments(context.Background(), req)
+	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
+
+	s.Require().NoError(s.delegator.UpdateSchema(context.Background(), newSchema, 100))
+	_, version := s.delegator.delegatorSchemaSnapshot()
+	s.Equal(uint64(newSchema.GetVersion()), version)
+
+	worker := &cluster.MockWorker{}
+	worker.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+
+	err = s.delegator.LoadSegments(context.Background(), req)
+	s.NoError(err)
+
+	staleSchema := typeutil.Clone(newSchema)
+	staleSchema.Version--
+	staleReq := typeutil.Clone(req)
+	staleReq.Schema = staleSchema
+	err = s.delegator.LoadSegments(context.Background(), staleReq)
+	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
+}
+
+func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaDoesNotUpdateFunctionRunners() {
 	ctx := context.Background()
 	s.delegator.Start()
 	schema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
@@ -1256,11 +1299,15 @@ func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaUpdatesFunctionRunners()
 	})
 	s.Require().NoError(err)
 
-	// The load path has already advanced the collection snapshot, so the DDL
-	// event is skipped as a no-op. The function runner key must still point at
-	// the schema installed by the load path.
-	s.Require().NoError(s.delegator.UpdateSchema(ctx, schema, 1))
 	ok, err := function.GetManager().RunWithRunner(ctx, s.collectionID, delegatorFunctionRunnerKey(s.vchannelName), 102, func(function.FunctionRunner) error {
+		return nil
+	})
+	s.Require().NoError(err)
+	s.False(ok)
+
+	// Only the WAL UpdateSchema path advances the delegator schema/function view.
+	s.Require().NoError(s.delegator.UpdateSchema(ctx, schema, 1))
+	ok, err = function.GetManager().RunWithRunner(ctx, s.collectionID, delegatorFunctionRunnerKey(s.vchannelName), 102, func(function.FunctionRunner) error {
 		return nil
 	})
 	s.Require().NoError(err)

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1287,52 +1287,6 @@ func (s *DelegatorDataSuite) TestLoadSegmentsSchemaVersionGate() {
 	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
 }
 
-func (s *DelegatorDataSuite) TestLoadSegmentsReleasesOrphanWorkerLoadOnFinalSchemaGateFailure() {
-	oldSchema := typeutil.Clone(s.delegator.collection.Schema())
-	newSchema := typeutil.Clone(oldSchema)
-	newSchema.Version = oldSchema.GetVersion() + 1
-	req := &querypb.LoadSegmentsRequest{
-		Base:         commonpbutil.NewMsgBase(),
-		DstNodeID:    1,
-		CollectionID: s.collectionID,
-		Schema:       oldSchema,
-		LoadScope:    querypb.LoadScope_Full,
-		Infos: []*querypb.SegmentLoadInfo{
-			{
-				SegmentID:     100,
-				PartitionID:   500,
-				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
-				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
-				Level:         datapb.SegmentLevel_L1,
-				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
-			},
-		},
-	}
-
-	worker := &cluster.MockWorker{}
-	worker.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
-		Run(func(context.Context, *querypb.LoadSegmentsRequest) {
-			s.delegator.schemaChangeMutex.Lock()
-			defer s.delegator.schemaChangeMutex.Unlock()
-			s.delegator.publishDelegatorSchemaLocked(newSchema)
-		}).
-		Return(nil).
-		Once()
-	worker.EXPECT().ReleaseSegments(mock.Anything, mock.MatchedBy(func(req *querypb.ReleaseSegmentsRequest) bool {
-		return req.GetNodeID() == int64(1) &&
-			req.GetCollectionID() == s.collectionID &&
-			req.GetScope() == querypb.DataScope_Historical &&
-			req.GetShard() == s.vchannelName &&
-			len(req.GetSegmentIDs()) == 1 &&
-			req.GetSegmentIDs()[0] == int64(100)
-	})).Return(nil).Once()
-	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
-
-	err := s.delegator.LoadSegments(context.Background(), req)
-	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
-	s.False(s.delegator.distribution.SealedSegmentExistsOnNode(100, 1))
-}
-
 func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaDoesNotUpdateFunctionRunners() {
 	ctx := context.Background()
 	s.delegator.Start()

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -2620,7 +2620,6 @@ func TestUpdateSchemaSkipsStaleSchemaBeforeSideEffects(t *testing.T) {
 		lifetime:                   lifetime.NewLifetime(lifetime.Working),
 		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
 		workerManager:              workerManager,
-		schemaBarrierTs:            100,
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
 		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
@@ -2631,7 +2630,8 @@ func TestUpdateSchemaSkipsStaleSchemaBeforeSideEffects(t *testing.T) {
 	err := sd.UpdateSchema(context.Background(), staleSchema, 200)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint64(100), sd.schemaBarrierTs)
+	_, delegatorSchemaVersion := sd.delegatorSchemaSnapshot()
+	assert.Equal(t, uint64(2), delegatorSchemaVersion)
 	assert.Equal(t, uint64(2), sd.collection.SchemaVersion())
 }
 

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -1545,6 +1545,19 @@ func (s *DelegatorSuite) TestUpdateSchema() {
 	})
 }
 
+func (s *DelegatorSuite) TestUpdateSchemaAllowedWhileInitializing() {
+	s.ResetDelegator()
+	collection := s.manager.Collection.Get(s.collectionID)
+	s.Require().NotNil(collection)
+	schema := collection.Schema()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := s.delegator.UpdateSchema(ctx, schema, 100)
+	s.NoError(err)
+}
+
 func (s *DelegatorSuite) ResetDelegator() {
 	var err error
 	s.delegator.Close()

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/querynodev2/tasks"
@@ -148,7 +149,14 @@ func (node *QueryNode) reopenSegments(ctx context.Context, req *querypb.LoadSegm
 	)
 
 	log.Info(ctx, "start to reopen segments")
-	err := node.loader.ReopenSegments(ctx, req.GetInfos())
+	var err error
+	if loader, ok := node.loader.(interface {
+		ReopenSegmentsWithSchema(context.Context, *schemapb.CollectionSchema, []*querypb.SegmentLoadInfo) error
+	}); ok {
+		err = loader.ReopenSegmentsWithSchema(ctx, req.GetSchema(), req.GetInfos())
+	} else {
+		err = node.loader.ReopenSegments(ctx, req.GetInfos())
+	}
 	if err != nil {
 		log.Warn(ctx, "failed to reopen segments", mlog.Err(err))
 		return merr.Status(err)

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -19,6 +19,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	base "github.com/milvus-io/milvus/internal/util/pipeline"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -41,6 +43,8 @@ type deleteNode struct {
 	manager   *DataManager
 	delegator delegator.ShardDelegator
 	closed    atomic.Bool
+	closeCh   chan struct{}
+	closeOnce sync.Once
 }
 
 var deleteNodeUpdateSchemaRetryInterval = 200 * time.Millisecond
@@ -113,10 +117,28 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 
 func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *deleteNodeMsg) bool {
 	for {
+		if dNode.closed.Load() {
+			return false
+		}
 		err := dNode.delegator.UpdateSchema(ctx, nodeMsg.schema, nodeMsg.schemaBarrierTs)
 		if err == nil {
 			return true
 		}
+
+		if dNode.closed.Load() {
+			return false
+		}
+		if !merr.IsRetryableErr(err) {
+			wrapped := merr.Wrap(err, "non-retryable schema update failure in delete node")
+			mlog.Error(ctx, "non-retryable schema update failure in delete node, stop process to replay WAL after restart",
+				mlog.Int64("collectionID", dNode.collectionID),
+				mlog.String("channel", dNode.channel),
+				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+				mlog.Err(wrapped))
+			panic(wrapped)
+		}
+
 		mlog.RatedWarn(ctx, rate.Limit(1), "failed to update schema in delete node, retrying before advancing tsafe",
 			mlog.Int64("collectionID", dNode.collectionID),
 			mlog.String("channel", dNode.channel),
@@ -128,17 +150,24 @@ func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *
 			return false
 		}
 		timer := time.NewTimer(deleteNodeUpdateSchemaRetryInterval)
-		<-timer.C
-		timer.Stop()
-		if dNode.closed.Load() {
+		select {
+		case <-timer.C:
+		case <-dNode.closeCh:
+			timer.Stop()
 			return false
 		}
+		timer.Stop()
 	}
 }
 
-func (dNode *deleteNode) Close() {
-	dNode.closed.Store(true)
+func (dNode *deleteNode) PreClose() {
+	dNode.closeOnce.Do(func() {
+		dNode.closed.Store(true)
+		close(dNode.closeCh)
+	})
 }
+
+func (dNode *deleteNode) Close() { dNode.PreClose() }
 
 func newDeleteNode(
 	collectionID UniqueID, channel string,
@@ -151,5 +180,6 @@ func newDeleteNode(
 		channel:      channel,
 		manager:      manager,
 		delegator:    delegator,
+		closeCh:      make(chan struct{}),
 	}
 }

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -235,6 +235,7 @@ func newDeleteNode(
 	manager *DataManager, delegator delegator.ShardDelegator,
 	maxQueueLength int32,
 ) *deleteNode {
+	// #nosec G118 -- cancel is stored on deleteNode and called by PreClose/Close.
 	ctx, cancel := context.WithCancel(context.Background())
 	return &deleteNode{
 		BaseNode:     base.NewBaseNode(fmt.Sprintf("DeleteNode-%s", channel), maxQueueLength),

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -18,6 +18,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/samber/lo"
 	"golang.org/x/time/rate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -43,11 +46,16 @@ type deleteNode struct {
 	manager   *DataManager
 	delegator delegator.ShardDelegator
 	closed    atomic.Bool
+	ctx       context.Context
+	cancel    context.CancelFunc
 	closeCh   chan struct{}
 	closeOnce sync.Once
 }
 
-var deleteNodeUpdateSchemaRetryInterval = 200 * time.Millisecond
+var (
+	deleteNodeUpdateSchemaRetryInterval    = 200 * time.Millisecond
+	deleteNodeUpdateSchemaMaxRetryDuration = 5 * time.Minute
+)
 
 // addDeleteData find the segment of delete column in DeleteMsg and save in deleteData
 func (dNode *deleteNode) addDeleteData(deleteDatas map[UniqueID]*delegator.DeleteData, msg *DeleteMsg) {
@@ -104,8 +112,7 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 	}
 
 	if nodeMsg.schema != nil {
-		ctx := context.TODO()
-		if !dNode.updateSchemaUntilApplied(ctx, nodeMsg) {
+		if !dNode.updateSchemaUntilApplied(dNode.ctx, nodeMsg) {
 			return nil
 		}
 	}
@@ -116,6 +123,7 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 }
 
 func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *deleteNodeMsg) bool {
+	start := time.Now()
 	for {
 		if dNode.closed.Load() {
 			return false
@@ -128,13 +136,24 @@ func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *
 		if dNode.closed.Load() {
 			return false
 		}
-		if !merr.IsRetryableErr(err) {
+		if !isUpdateSchemaRetryable(err) {
 			wrapped := merr.Wrap(err, "non-retryable schema update failure in delete node")
 			mlog.Error(ctx, "non-retryable schema update failure in delete node, stop process to replay WAL after restart",
 				mlog.Int64("collectionID", dNode.collectionID),
 				mlog.String("channel", dNode.channel),
 				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
 				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+				mlog.Err(wrapped))
+			panic(wrapped)
+		}
+		if time.Since(start) >= deleteNodeUpdateSchemaMaxRetryDuration {
+			wrapped := merr.Wrap(err, "schema update retry limit reached in delete node")
+			mlog.Error(ctx, "schema update retry limit reached in delete node, stop process to replay WAL after restart",
+				mlog.Int64("collectionID", dNode.collectionID),
+				mlog.String("channel", dNode.channel),
+				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+				mlog.Duration("retryDuration", time.Since(start)),
 				mlog.Err(wrapped))
 			panic(wrapped)
 		}
@@ -160,9 +179,30 @@ func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *
 	}
 }
 
+func isUpdateSchemaRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if merr.IsRetryableErr(err) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, merr.ErrChannelNotAvailable) ||
+		errors.Is(err, merr.ErrNodeNotAvailable) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted:
+		return true
+	default:
+		return false
+	}
+}
+
 func (dNode *deleteNode) PreClose() {
 	dNode.closeOnce.Do(func() {
 		dNode.closed.Store(true)
+		dNode.cancel()
 		close(dNode.closeCh)
 	})
 }
@@ -174,12 +214,15 @@ func newDeleteNode(
 	manager *DataManager, delegator delegator.ShardDelegator,
 	maxQueueLength int32,
 ) *deleteNode {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &deleteNode{
 		BaseNode:     base.NewBaseNode(fmt.Sprintf("DeleteNode-%s", channel), maxQueueLength),
 		collectionID: collectionID,
 		channel:      channel,
 		manager:      manager,
 		delegator:    delegator,
+		ctx:          ctx,
+		cancel:       cancel,
 		closeCh:      make(chan struct{}),
 	}
 }

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -18,12 +18,12 @@ package pipeline
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc/codes"

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -124,17 +124,38 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 
 func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *deleteNodeMsg) bool {
 	start := time.Now()
+	applyCtx, cancel := context.WithTimeout(ctx, deleteNodeUpdateSchemaMaxRetryDuration)
+	defer cancel()
+
+	panicRetryLimit := func(err error) {
+		wrapped := merr.Wrap(err, "schema update retry limit reached in delete node")
+		mlog.Error(ctx, "schema update retry limit reached in delete node, stop process to replay WAL after restart",
+			mlog.Int64("collectionID", dNode.collectionID),
+			mlog.String("channel", dNode.channel),
+			mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+			mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+			mlog.Duration("retryDuration", time.Since(start)),
+			mlog.Err(wrapped))
+		panic(wrapped)
+	}
+
 	for {
 		if dNode.closed.Load() {
 			return false
 		}
-		err := dNode.delegator.UpdateSchema(ctx, nodeMsg.schema, nodeMsg.schemaBarrierTs)
+		err := dNode.delegator.UpdateSchema(applyCtx, nodeMsg.schema, nodeMsg.schemaBarrierTs)
 		if err == nil {
 			return true
 		}
 
 		if dNode.closed.Load() {
 			return false
+		}
+		if errors.Is(applyCtx.Err(), context.Canceled) {
+			return false
+		}
+		if errors.Is(applyCtx.Err(), context.DeadlineExceeded) {
+			panicRetryLimit(err)
 		}
 		if !isUpdateSchemaRetryable(err) {
 			wrapped := merr.Wrap(err, "non-retryable schema update failure in delete node")
@@ -147,15 +168,7 @@ func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *
 			panic(wrapped)
 		}
 		if time.Since(start) >= deleteNodeUpdateSchemaMaxRetryDuration {
-			wrapped := merr.Wrap(err, "schema update retry limit reached in delete node")
-			mlog.Error(ctx, "schema update retry limit reached in delete node, stop process to replay WAL after restart",
-				mlog.Int64("collectionID", dNode.collectionID),
-				mlog.String("channel", dNode.channel),
-				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
-				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
-				mlog.Duration("retryDuration", time.Since(start)),
-				mlog.Err(wrapped))
-			panic(wrapped)
+			panicRetryLimit(err)
 		}
 
 		mlog.RatedWarn(ctx, rate.Limit(1), "failed to update schema in delete node, retrying before advancing tsafe",
@@ -174,6 +187,12 @@ func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *
 		case <-dNode.closeCh:
 			timer.Stop()
 			return false
+		case <-applyCtx.Done():
+			timer.Stop()
+			if dNode.closed.Load() || errors.Is(applyCtx.Err(), context.Canceled) {
+				return false
+			}
+			panicRetryLimit(applyCtx.Err())
 		}
 		timer.Stop()
 	}

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -19,8 +19,11 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
+	"time"
 
 	"github.com/samber/lo"
+	"golang.org/x/time/rate"
 
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -37,7 +40,10 @@ type deleteNode struct {
 
 	manager   *DataManager
 	delegator delegator.ShardDelegator
+	closed    atomic.Bool
 }
+
+var deleteNodeUpdateSchemaRetryInterval = 200 * time.Millisecond
 
 // addDeleteData find the segment of delete column in DeleteMsg and save in deleteData
 func (dNode *deleteNode) addDeleteData(deleteDatas map[UniqueID]*delegator.DeleteData, msg *DeleteMsg) {
@@ -95,19 +101,43 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 
 	if nodeMsg.schema != nil {
 		ctx := context.TODO()
-		if err := dNode.delegator.UpdateSchema(ctx, nodeMsg.schema, nodeMsg.schemaBarrierTs); err != nil {
-			mlog.Warn(ctx, "failed to update schema in delete node",
-				mlog.Int64("collectionID", dNode.collectionID),
-				mlog.String("channel", dNode.channel),
-				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
-				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
-				mlog.Err(err))
+		if !dNode.updateSchemaUntilApplied(ctx, nodeMsg) {
+			return nil
 		}
 	}
 
 	// update tSafe
 	dNode.delegator.UpdateTSafe(nodeMsg.timeRange.timestampMax)
 	return nil
+}
+
+func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *deleteNodeMsg) bool {
+	for {
+		err := dNode.delegator.UpdateSchema(ctx, nodeMsg.schema, nodeMsg.schemaBarrierTs)
+		if err == nil {
+			return true
+		}
+		mlog.RatedWarn(ctx, rate.Limit(1), "failed to update schema in delete node, retrying before advancing tsafe",
+			mlog.Int64("collectionID", dNode.collectionID),
+			mlog.String("channel", dNode.channel),
+			mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+			mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+			mlog.Err(err))
+
+		if dNode.closed.Load() {
+			return false
+		}
+		timer := time.NewTimer(deleteNodeUpdateSchemaRetryInterval)
+		<-timer.C
+		timer.Stop()
+		if dNode.closed.Load() {
+			return false
+		}
+	}
+}
+
+func (dNode *deleteNode) Close() {
+	dNode.closed.Store(true)
 }
 
 func newDeleteNode(

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -206,6 +207,7 @@ func isUpdateSchemaRetryable(err error) bool {
 		return true
 	}
 	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, grpc.ErrClientConnClosing) ||
 		errors.Is(err, merr.ErrChannelNotAvailable) ||
 		errors.Is(err, merr.ErrNodeNotAvailable) {
 		return true

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -17,7 +17,10 @@
 package pipeline
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
@@ -149,7 +152,51 @@ func (suite *DeleteNodeSuite) TestProcessDeleteBatchesUseDeleteMsgEndTs() {
 	suite.Nil(out)
 }
 
-func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotPanic() {
+func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotAdvanceTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	expectedErr := merr.WrapErrServiceUnavailableMsg("delegator is not ready")
+	var updateSchemaCalled atomic.Bool
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Run(func(context.Context, *schemapb.CollectionSchema, uint64) {
+		updateSchemaCalled.Store(true)
+	}).Return(expectedErr)
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldInterval := deleteNodeUpdateSchemaRetryInterval
+	deleteNodeUpdateSchemaRetryInterval = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaRetryInterval = oldInterval
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.Nil(node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		}))
+	}()
+
+	suite.Eventually(func() bool {
+		return updateSchemaCalled.Load()
+	}, time.Second, time.Millisecond)
+	node.Close()
+	suite.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesBeforeTSafe() {
 	manager := &segments.Manager{
 		Collection: segments.NewMockCollectionManager(suite.T()),
 		Segment:    segments.NewMockSegmentManager(suite.T()),
@@ -158,16 +205,21 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotPanic() {
 	schema := &schemapb.CollectionSchema{Version: 2}
 	expectedErr := merr.WrapErrServiceUnavailableMsg("delegator is not ready")
 	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(nil).Once()
 	delegator.EXPECT().UpdateTSafe(uint64(10)).Return().Once()
 
 	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
-	suite.NotPanics(func() {
-		suite.Nil(node.Operate(&deleteNodeMsg{
-			schema:          schema,
-			schemaBarrierTs: 10,
-			timeRange:       TimeRange{timestampMax: 10},
-		}))
+	oldInterval := deleteNodeUpdateSchemaRetryInterval
+	deleteNodeUpdateSchemaRetryInterval = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaRetryInterval = oldInterval
 	})
+
+	suite.Nil(node.Operate(&deleteNodeMsg{
+		schema:          schema,
+		schemaBarrierTs: 10,
+		timeRange:       TimeRange{timestampMax: 10},
+	}))
 }
 
 func TestDeleteNode(t *testing.T) {

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -300,6 +300,35 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaRetryLimitPanicsWithoutTSafe() {
 	})
 }
 
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetryLimitCancelsInFlightUpdate() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		RunAndReturn(func(ctx context.Context, sch *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldMaxRetryDuration := deleteNodeUpdateSchemaMaxRetryDuration
+	deleteNodeUpdateSchemaMaxRetryDuration = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaMaxRetryDuration = oldMaxRetryDuration
+	})
+
+	suite.Panics(func() {
+		node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		})
+	})
+}
+
 func (suite *DeleteNodeSuite) TestUpdateSchemaPreCloseCancelsInFlightUpdate() {
 	manager := &segments.Manager{
 		Collection: segments.NewMockCollectionManager(suite.T()),

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -184,9 +184,7 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotAdvanceTSafe() {
 		}))
 	}()
 
-	suite.Eventually(func() bool {
-		return updateSchemaCalled.Load()
-	}, time.Second, time.Millisecond)
+	suite.Eventually(updateSchemaCalled.Load, time.Second, time.Millisecond)
 	node.Close()
 	suite.Eventually(func() bool {
 		select {

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -222,6 +222,26 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesBeforeTSafe() {
 	}))
 }
 
+func (suite *DeleteNodeSuite) TestUpdateSchemaNonRetryableErrorPanicsWithoutTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	expectedErr := merr.WrapErrServiceInternal("unsupported incompatible schema change")
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	suite.Panics(func() {
+		node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		})
+	})
+}
+
 func TestDeleteNode(t *testing.T) {
 	suite.Run(t, new(DeleteNodeSuite))
 }

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
@@ -222,6 +224,36 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesBeforeTSafe() {
 	}))
 }
 
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesTransientErrorsBeforeTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		Return(merr.WrapErrChannelNotAvailable(suite.channel, "delegator initializing")).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		Return(merr.WrapErrNodeNotAvailable(10, "worker unhealthy")).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		Return(status.Error(codes.Unavailable, "worker unavailable")).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(nil).Once()
+	delegator.EXPECT().UpdateTSafe(uint64(10)).Return().Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldInterval := deleteNodeUpdateSchemaRetryInterval
+	deleteNodeUpdateSchemaRetryInterval = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaRetryInterval = oldInterval
+	})
+
+	suite.Nil(node.Operate(&deleteNodeMsg{
+		schema:          schema,
+		schemaBarrierTs: 10,
+		timeRange:       TimeRange{timestampMax: 10},
+	}))
+}
+
 func (suite *DeleteNodeSuite) TestUpdateSchemaNonRetryableErrorPanicsWithoutTSafe() {
 	manager := &segments.Manager{
 		Collection: segments.NewMockCollectionManager(suite.T()),
@@ -240,6 +272,77 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaNonRetryableErrorPanicsWithoutTSaf
 			timeRange:       TimeRange{timestampMax: 10},
 		})
 	})
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetryLimitPanicsWithoutTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	expectedErr := merr.WrapErrChannelNotAvailable(suite.channel, "delegator initializing")
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldMaxRetryDuration := deleteNodeUpdateSchemaMaxRetryDuration
+	deleteNodeUpdateSchemaMaxRetryDuration = 0
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaMaxRetryDuration = oldMaxRetryDuration
+	})
+
+	suite.Panics(func() {
+		node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		})
+	})
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaPreCloseCancelsInFlightUpdate() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	updateStarted := make(chan struct{})
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		RunAndReturn(func(ctx context.Context, sch *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
+			close(updateStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		}).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.Nil(node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		}))
+	}()
+
+	suite.Eventually(func() bool {
+		select {
+		case <-updateStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	node.PreClose()
+	suite.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
 }
 
 func TestDeleteNode(t *testing.T) {

--- a/internal/querynodev2/pipeline/filter_node.go
+++ b/internal/querynodev2/pipeline/filter_node.go
@@ -95,7 +95,15 @@ func (fNode *filterNode) Operate(in Msg) Msg {
 				mlog.Err(err),
 			)
 		} else {
-			out.append(msg)
+			if err := out.append(msg); err != nil {
+				wrapped := merr.Wrap(err, "failed to append filtered message")
+				mlog.Error(ctx, "failed to append filtered message, stop process to replay WAL",
+					mlog.String("message type", msg.Type().String()),
+					mlog.String("channel", fNode.channel),
+					mlog.FieldCollectionID(fNode.collectionID),
+					mlog.Err(wrapped))
+				panic(wrapped)
+			}
 		}
 	}
 	fNode.delegator.TryCleanExcludedSegments(streamMsgPack.EndTs)

--- a/internal/querynodev2/pipeline/filter_node_test.go
+++ b/internal/querynodev2/pipeline/filter_node_test.go
@@ -26,10 +26,14 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/pkg/v3/mocks/streaming/util/mock_message"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/adaptor"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -106,6 +110,41 @@ func (suite *FilterNodeSuite) TestWithLoadCollection() {
 		suite.True(lo.Contains(suite.validSegmentIDs, msg.SegmentID))
 	}
 	suite.Equal(suite.deleteSegmentSum, len(nodeMsg.deleteMsgs))
+}
+
+func (suite *FilterNodeSuite) TestSchemaChangeAppendErrorPanics() {
+	collection := segments.NewTestCollection(suite.collectionID, querypb.LoadType_LoadCollection, nil)
+	mockCollectionManager := segments.NewMockCollectionManager(suite.T())
+	mockCollectionManager.EXPECT().Get(suite.collectionID).Return(collection)
+
+	suite.manager = &segments.Manager{
+		Collection: mockCollectionManager,
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+
+	validMutable := message.NewSchemaChangeMessageBuilderV2().
+		WithHeader(&message.SchemaChangeMessageHeader{
+			CollectionId: suite.collectionID,
+		}).
+		WithBody(&message.SchemaChangeMessageBody{
+			Schema: &schemapb.CollectionSchema{Version: 1},
+		}).
+		MustBuildMutable()
+	raw := validMutable.IntoMessageProto()
+	corruptedMutable := message.NewMutableMessageBeforeAppend([]byte{0xff}, raw.GetProperties()).WithTimeTick(10)
+	msgID := mock_message.NewMockMessageID(suite.T())
+	msgID.EXPECT().String().Return("mock-id").Maybe()
+	tsMsg, err := adaptor.NewSchemaChangeMessageBody(corruptedMutable.IntoImmutableMessage(msgID))
+	suite.Require().NoError(err)
+
+	node := newFilterNode(suite.collectionID, suite.channel, suite.manager, suite.delegator, 8)
+	suite.Panics(func() {
+		node.Operate(&msgstream.MsgPack{
+			BeginTs: 10,
+			EndTs:   10,
+			Msgs:    []msgstream.TsMsg{tsMsg},
+		})
+	})
 }
 
 // test filter node with collection load partition

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -64,8 +64,8 @@ type collectionSchemaUpdatePlan struct {
 	// logicalSchemaVersion is schema.Version from the accepted schema payload.
 	// It is the Go-side structural schema freshness key.
 	logicalSchemaVersion uint64
-	// schemaBarrierTs fences stale load results and orders same-version schema
-	// payload refreshes such as collection property snapshots.
+	// schemaBarrierTs is retained for snapshot metadata and compatibility. It
+	// does not make a same-version schema payload fresh.
 	schemaBarrierTs uint64
 	// segcoreSchemaVersion is only passed to C++ segcore UpdateSchema. Segcore
 	// still has a single increasing version gate, so QueryNode keeps this
@@ -149,10 +149,9 @@ func (m *collectionManager) PutOrRef(collectionID int64, schema *schemapb.Collec
 }
 
 func (m *collectionManager) putOrRefExisting(collectionID int64, collection *Collection, schema *schemapb.CollectionSchema, meta *segcorepb.CollectionIndexMeta, logicalSchemaVersion uint64, schemaBarrierTs uint64) error {
-	// Existing collections may be reached by a later load result or by a
-	// same-version properties refresh. Keep the Go-side logical schema version
-	// separate from the barrier timestamp so stale schema payloads cannot roll
-	// back fields, while newer properties-only payloads can still refresh.
+	// Existing collections may be reached by an older load result. Only a newer
+	// schema.Version can refresh the schema payload; schemaBarrierTs is metadata,
+	// not a schema freshness key.
 	plan, shouldUpdate, err := collection.applyLoadUpdate(schema, meta, logicalSchemaVersion, schemaBarrierTs)
 	if err != nil {
 		return err
@@ -177,11 +176,9 @@ func (m *collectionManager) UpdateSchema(collectionID int64, schema *schemapb.Co
 	defer m.Unref(collectionID, 1)
 
 	logicalSchemaVersion := getUpdateSchemaVersion(schema, schemaBarrierTs)
-	// A schema update carries two ordering domains:
-	// - schema.Version is the logical collection schema version and prevents
-	//   older schema payloads from overwriting newer fields/functions.
-	// - schemaBarrierTs is the DDL barrier timestamp and advances for
-	//   properties-only schema snapshots such as ttl_field changes.
+	// schema.Version is the only schema payload freshness key. schemaBarrierTs is
+	// still carried for compatibility and diagnostics, but it cannot advance a
+	// same-version payload.
 	_, _, err := collection.applySchemaUpdate(schema, logicalSchemaVersion, schemaBarrierTs)
 	return err
 }
@@ -201,16 +198,10 @@ func ShouldUpdateCollectionSchema(collection *Collection, schema *schemapb.Colle
 
 func prepareCollectionSchemaUpdate(collection *Collection, logicalSchemaVersion uint64, schemaBarrierTs uint64) (collectionSchemaUpdatePlan, bool) {
 	_, currentVersion, currentBarrierTs, currentSegcoreSchemaVersion := collection.schemaSnapshotWithSegcoreSchemaVersion()
-	// Never allow logical schema version rollback, even if the incoming message
-	// has a larger timestamp. This preserves the fix for out-of-order schema
-	// messages across replay/channel delivery.
-	if logicalSchemaVersion < currentVersion {
-		return collectionSchemaUpdatePlan{}, false
-	}
-	// For the same logical schema version, only a newer barrier can update the
-	// payload. This is required for collection properties embedded in schema
-	// snapshots because those updates do not necessarily bump schema.Version.
-	if logicalSchemaVersion == currentVersion && schemaBarrierTs <= currentBarrierTs {
+	// Never allow logical schema version rollback or same-version payload refresh,
+	// even if the incoming message has a larger timestamp. Every schema payload
+	// change must bump schema.Version and be replayed from WAL.
+	if logicalSchemaVersion <= currentVersion {
 		return collectionSchemaUpdatePlan{}, false
 	}
 
@@ -310,7 +301,7 @@ type collectionSchemaSnapshot struct {
 	schemaBarrierTs      uint64
 	// segcoreSchemaVersion is an internal monotonic version passed to C++
 	// segcore. It is not the logical collection schema version; Go-side schema
-	// freshness is tracked by logicalSchemaVersion and schemaBarrierTs.
+	// freshness is tracked by logicalSchemaVersion.
 	segcoreSchemaVersion uint64
 }
 

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -167,7 +167,7 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 		s.Same(schemaV8, updatedSchema)
 	})
 
-	s.Run("same_schema_version_with_newer_barrier_updates_properties", func() {
+	s.Run("same_schema_version_with_newer_barrier_does_not_update_payload", func() {
 		cm := NewCollectionManager()
 		baseSchema := mock_segcore.GenTestCollectionSchema("collection_v0", schemapb.DataType_Int64, false)
 		err := cm.PutOrRef(10, baseSchema, mock_segcore.GenTestIndexMeta(10, baseSchema), &querypb.LoadMetaInfo{
@@ -188,8 +188,8 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 
 		schema, version := cm.Get(10).SchemaAndVersion()
 		s.Equal(uint64(0), version)
-		s.Same(updatedSchema, schema)
-		s.Equal("int64Field", common.CloneKeyValuePairs(schema.GetProperties()).ToMap()[common.CollectionTTLFieldKey])
+		s.Same(baseSchema, schema)
+		s.NotContains(common.CloneKeyValuePairs(schema.GetProperties()).ToMap(), common.CollectionTTLFieldKey)
 	})
 
 	s.Run("higher_schema_version_after_high_barrier_refresh_uses_monotonic_segcore_schema_version", func() {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -475,18 +475,37 @@ func NewSegment(ctx context.Context,
 	version int64,
 	loadInfo *querypb.SegmentLoadInfo,
 ) (Segment, error) {
+	return newSegmentWithLoadSchemaVersion(ctx, collection, manager, segmentType, version, collection.SchemaVersion(), loadInfo)
+}
+
+func newSegmentWithLoadSchemaVersion(ctx context.Context,
+	collection *Collection,
+	manager SegmentManager,
+	segmentType SegmentType,
+	version int64,
+	loadSchemaVersion uint64,
+	loadInfo *querypb.SegmentLoadInfo,
+) (Segment, error) {
 	/*
 		CStatus
 		NewSegment(CCollection collection, uint64_t segment_id, SegmentType seg_type, CSegmentInterface* newSegment);
 	*/
 	if loadInfo.GetLevel() == datapb.SegmentLevel_L0 {
-		return NewL0Segment(collection, segmentType, version, loadInfo)
+		segment, err := NewL0Segment(collection, segmentType, version, loadInfo)
+		if err != nil {
+			return nil, err
+		}
+		if versioned, ok := segment.(interface{ SetLoadSchemaVersion(uint64) }); ok {
+			versioned.SetLoadSchemaVersion(loadSchemaVersion)
+		}
+		return segment, nil
 	}
 
 	base, err := newBaseSegment(collection, segmentType, version, loadInfo)
 	if err != nil {
 		return nil, err
 	}
+	base.SetLoadSchemaVersion(loadSchemaVersion)
 
 	var locker *state.LoadStateLock
 	switch segmentType {
@@ -1300,6 +1319,11 @@ func (s *LocalSegment) Load(ctx context.Context) error {
 }
 
 func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentLoadInfo) error {
+	schema, schemaVersion := s.collection.SchemaAndSegcoreVersion()
+	return s.reopenWithSchema(ctx, newLoadInfo, schema, schemaVersion, s.collection.SchemaVersion())
+}
+
+func (s *LocalSegment) reopenWithSchema(ctx context.Context, newLoadInfo *querypb.SegmentLoadInfo, schema *schemapb.CollectionSchema, segcoreSchemaVersion uint64, loadSchemaVersion uint64) error {
 	if !s.ptrLock.PinIfNotReleased() {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released during reopen")
 	}
@@ -1312,17 +1336,16 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 		return err
 	}
 
-	schema, schemaVersion := s.collection.SchemaAndSegcoreVersion()
 	err := s.csegment.Reopen(ctx, &segcore.ReopenRequest{
 		LoadInfo:      newLoadInfo,
 		Schema:        schema,
-		SchemaVersion: schemaVersion,
+		SchemaVersion: segcoreSchemaVersion,
 	})
 	if err != nil {
 		return err
 	}
 	s.syncFieldIndexes(newLoadInfo.GetIndexInfos())
-	s.SetLoadSchemaVersion(s.collection.SchemaVersion())
+	s.SetLoadSchemaVersion(loadSchemaVersion)
 	if s.relatedDataSize != nil {
 		s.relatedDataSize.Store(calculateSegmentLogSize(newLoadInfo))
 	}

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -96,6 +96,7 @@ type baseSegment struct {
 	resourceUsageCache *atomic.Pointer[ResourceUsage]
 
 	needUpdatedVersion *atomic.Int64 // only for lazy load mode update index
+	loadSchemaVersion  *atomic.Uint64
 }
 
 func newBaseSegment(collection *Collection, segmentType SegmentType, version int64, loadInfo *querypb.SegmentLoadInfo) (baseSegment, error) {
@@ -114,6 +115,7 @@ func newBaseSegment(collection *Collection, segmentType SegmentType, version int
 
 		resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
 		needUpdatedVersion: atomic.NewInt64(0),
+		loadSchemaVersion:  atomic.NewUint64(collection.SchemaVersion()),
 	}
 	return bs, nil
 }
@@ -416,6 +418,21 @@ func (s *baseSegment) NeedUpdatedVersion() int64 {
 
 func (s *baseSegment) SetNeedUpdatedVersion(version int64) {
 	s.needUpdatedVersion.Store(version)
+}
+
+func (s *baseSegment) LoadSchemaVersion() uint64 {
+	if s.loadSchemaVersion == nil {
+		return 0
+	}
+	return s.loadSchemaVersion.Load()
+}
+
+func (s *baseSegment) SetLoadSchemaVersion(version uint64) {
+	if s.loadSchemaVersion == nil {
+		s.loadSchemaVersion = atomic.NewUint64(version)
+		return
+	}
+	s.loadSchemaVersion.Store(version)
 }
 
 type FieldInfo struct {
@@ -1305,6 +1322,7 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 		return err
 	}
 	s.syncFieldIndexes(newLoadInfo.GetIndexInfos())
+	s.SetLoadSchemaVersion(s.collection.SchemaVersion())
 	if s.relatedDataSize != nil {
 		s.relatedDataSize.Store(calculateSegmentLogSize(newLoadInfo))
 	}

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -241,6 +241,9 @@ func (loader *segmentLoader) Load(ctx context.Context,
 	for _, segment := range segments {
 		configureUseTakeForOutput(segment, collection.Schema())
 	}
+	if err := loader.reopenLoadedSegmentsIfStale(ctx, collection, segmentType, segments...); err != nil {
+		return nil, err
+	}
 	// Filter out loaded & loading segments
 	infos := loader.prepare(ctx, segmentType, segments...)
 	defer loader.unregister(infos...)
@@ -453,6 +456,56 @@ func (loader *segmentLoader) prepare(ctx context.Context, segmentType SegmentTyp
 	}
 
 	return infos
+}
+
+type loadSchemaVersionedSegment interface {
+	LoadSchemaVersion() uint64
+}
+
+func (loader *segmentLoader) reopenLoadedSegmentsIfStale(ctx context.Context, collection *Collection, segmentType SegmentType, infos ...*querypb.SegmentLoadInfo) error {
+	if segmentType != SegmentTypeSealed {
+		return nil
+	}
+
+	requiredSchemaVersion := collection.SchemaVersion()
+	staleInfos := make([]*querypb.SegmentLoadInfo, 0)
+	for _, info := range infos {
+		segment := loader.manager.Segment.GetWithType(info.GetSegmentID(), segmentType)
+		if segment == nil {
+			continue
+		}
+		if loadedSegmentNeedsReopen(segment, info, requiredSchemaVersion) {
+			staleInfos = append(staleInfos, info)
+		}
+	}
+	if len(staleInfos) == 0 {
+		return nil
+	}
+
+	mlog.Info(ctx, "reopen stale loaded segments before full load",
+		mlog.Int64("collectionID", collection.ID()),
+		mlog.Uint64("requiredSchemaVersion", requiredSchemaVersion),
+		mlog.Int64s("segmentIDs", lo.Map(staleInfos, func(info *querypb.SegmentLoadInfo, _ int) int64 {
+			return info.GetSegmentID()
+		})))
+	return loader.ReopenSegments(ctx, staleInfos)
+}
+
+func loadedSegmentNeedsReopen(segment Segment, incoming *querypb.SegmentLoadInfo, requiredSchemaVersion uint64) bool {
+	current := segment.LoadInfo()
+	if incoming.GetDataVersion() > current.GetDataVersion() {
+		return true
+	}
+	if incoming.GetStorageVersion() > current.GetStorageVersion() {
+		return true
+	}
+	if incoming.GetManifestPath() != "" && incoming.GetManifestPath() != current.GetManifestPath() {
+		return true
+	}
+	if versioned, ok := segment.(loadSchemaVersionedSegment); ok {
+		return versioned.LoadSchemaVersion() < requiredSchemaVersion
+	}
+	return false
 }
 
 func configureUseTakeForOutput(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.CollectionSchema) {

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -227,6 +227,16 @@ func (loader *segmentLoader) Load(ctx context.Context,
 	version int64,
 	segments ...*querypb.SegmentLoadInfo,
 ) ([]Segment, error) {
+	return loader.LoadWithSchema(ctx, collectionID, segmentType, version, nil, segments...)
+}
+
+func (loader *segmentLoader) LoadWithSchema(ctx context.Context,
+	collectionID int64,
+	segmentType SegmentType,
+	version int64,
+	requestSchema *schemapb.CollectionSchema,
+	segments ...*querypb.SegmentLoadInfo,
+) ([]Segment, error) {
 	if len(segments) == 0 {
 		mlog.Info(context.TODO(), "no segment to load")
 		return nil, nil
@@ -238,10 +248,14 @@ func (loader *segmentLoader) Load(ctx context.Context,
 		mlog.Warn(context.TODO(), "failed to get collection", mlog.Err(err))
 		return nil, err
 	}
-	for _, segment := range segments {
-		configureUseTakeForOutput(segment, collection.Schema())
+	if requestSchema == nil {
+		requestSchema = collection.Schema()
 	}
-	if err := loader.reopenLoadedSegmentsIfStale(ctx, collection, segmentType, segments...); err != nil {
+	requestSchemaVersion := uint64(requestSchema.GetVersion())
+	for _, segment := range segments {
+		configureUseTakeForOutput(segment, requestSchema)
+	}
+	if err := loader.reopenLoadedSegmentsIfStale(ctx, collection, requestSchema, segmentType, segments...); err != nil {
 		return nil, err
 	}
 	// Filter out loaded & loading segments
@@ -283,12 +297,13 @@ func (loader *segmentLoader) Load(ctx context.Context,
 			return nil, err
 		}
 
-		segment, err := NewSegment(
+		segment, err := newSegmentWithLoadSchemaVersion(
 			ctx,
 			collection,
 			loader.manager.Segment,
 			segmentType,
 			version,
+			requestSchemaVersion,
 			loadInfo,
 		)
 		if err != nil {
@@ -334,16 +349,15 @@ func (loader *segmentLoader) Load(ctx context.Context,
 			return merr.Wrap(err, "At LoadDeltaLogs")
 		}
 
-		schema := collection.Schema()
-		isExternalCollection := typeutil.IsExternalCollection(schema)
-		isMilvusTableRealPK := typeutil.NewStorageColumnResolver(schema).IsMilvusTable() &&
-			HasExternalPrimaryKey(schema)
+		isExternalCollection := typeutil.IsExternalCollection(requestSchema)
+		isMilvusTableRealPK := typeutil.NewStorageColumnResolver(requestSchema).IsMilvusTable() &&
+			HasExternalPrimaryKey(requestSchema)
 		if !segment.PkCandidateExist() {
 			mlog.Debug(context.TODO(), "loading PK candidate for segment", mlog.Int64("segmentID", segment.ID()))
 			if isExternalCollection {
 				var candidate pkoracle.Candidate
 				if isMilvusTableRealPK {
-					bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
+					bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type(), requestSchema)
 					if err != nil {
 						return merr.Wrap(err, "At LoadBloomFilter")
 					}
@@ -381,7 +395,7 @@ func (loader *segmentLoader) Load(ctx context.Context,
 					}
 				}
 			} else if paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool() {
-				bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
+				bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type(), requestSchema)
 				if err != nil {
 					return merr.Wrap(err, "At LoadBloomFilter")
 				}
@@ -419,8 +433,7 @@ func (loader *segmentLoader) Load(ctx context.Context,
 	}
 
 	// Wait for all segments loaded
-	segmentIDs := lo.Map(segments, func(info *querypb.SegmentLoadInfo, _ int) int64 { return info.GetSegmentID() })
-	if err := loader.waitSegmentLoadDone(ctx, segmentType, segmentIDs, version); err != nil {
+	if err := loader.waitSegmentLoadDone(ctx, segmentType, segments, version, requestSchema); err != nil {
 		mlog.Warn(context.TODO(), "failed to wait the filtered out segments load done", mlog.Err(err))
 		return nil, err
 	}
@@ -462,12 +475,12 @@ type loadSchemaVersionedSegment interface {
 	LoadSchemaVersion() uint64
 }
 
-func (loader *segmentLoader) reopenLoadedSegmentsIfStale(ctx context.Context, collection *Collection, segmentType SegmentType, infos ...*querypb.SegmentLoadInfo) error {
+func (loader *segmentLoader) reopenLoadedSegmentsIfStale(ctx context.Context, collection *Collection, requestSchema *schemapb.CollectionSchema, segmentType SegmentType, infos ...*querypb.SegmentLoadInfo) error {
 	if segmentType != SegmentTypeSealed {
 		return nil
 	}
 
-	requiredSchemaVersion := collection.SchemaVersion()
+	requiredSchemaVersion := uint64(requestSchema.GetVersion())
 	staleInfos := make([]*querypb.SegmentLoadInfo, 0)
 	for _, info := range infos {
 		segment := loader.manager.Segment.GetWithType(info.GetSegmentID(), segmentType)
@@ -488,7 +501,7 @@ func (loader *segmentLoader) reopenLoadedSegmentsIfStale(ctx context.Context, co
 		mlog.Int64s("segmentIDs", lo.Map(staleInfos, func(info *querypb.SegmentLoadInfo, _ int) int64 {
 			return info.GetSegmentID()
 		})))
-	return loader.ReopenSegments(ctx, staleInfos)
+	return loader.ReopenSegmentsWithSchema(ctx, requestSchema, staleInfos)
 }
 
 func loadedSegmentNeedsReopen(segment Segment, incoming *querypb.SegmentLoadInfo, requiredSchemaVersion uint64) bool {
@@ -500,7 +513,10 @@ func loadedSegmentNeedsReopen(segment Segment, incoming *querypb.SegmentLoadInfo
 		return true
 	}
 	if incoming.GetManifestPath() != "" && incoming.GetManifestPath() != current.GetManifestPath() {
-		return true
+		cmp, err := packed.CompareManifestPath(incoming.GetManifestPath(), current.GetManifestPath())
+		if err == nil && cmp > 0 {
+			return true
+		}
 	}
 	if versioned, ok := segment.(loadSchemaVersionedSegment); ok {
 		return versioned.LoadSchemaVersion() < requiredSchemaVersion
@@ -632,9 +648,16 @@ func (loader *segmentLoader) freeRequestResource(requestResourceResult requestRe
 	loader.committedResourceNotifier.NotifyAll()
 }
 
-func (loader *segmentLoader) waitSegmentLoadDone(ctx context.Context, segmentType SegmentType, segmentIDs []int64, version int64) error {
-	for _, segmentID := range segmentIDs {
-		if loader.manager.Segment.GetWithType(segmentID, segmentType) != nil {
+func (loader *segmentLoader) waitSegmentLoadDone(ctx context.Context, segmentType SegmentType, loadInfos []*querypb.SegmentLoadInfo, version int64, requestSchema *schemapb.CollectionSchema) error {
+	requestSchemaVersion := uint64(requestSchema.GetVersion())
+	for _, loadInfo := range loadInfos {
+		segmentID := loadInfo.GetSegmentID()
+		if segment := loader.manager.Segment.GetWithType(segmentID, segmentType); segment != nil {
+			if loadedSegmentNeedsReopen(segment, loadInfo, requestSchemaVersion) {
+				if err := loader.reopenSegmentsWithSchema(ctx, requestSchema, []*querypb.SegmentLoadInfo{loadInfo}); err != nil {
+					return err
+				}
+			}
 			continue
 		}
 
@@ -673,6 +696,12 @@ func (loader *segmentLoader) waitSegmentLoadDone(ctx context.Context, segmentTyp
 
 		// try to update segment version after wait segment loaded
 		loader.manager.Segment.UpdateBy(IncreaseVersion(version), WithType(segmentType), WithID(segmentID))
+		if segment := loader.manager.Segment.GetWithType(segmentID, segmentType); segment != nil &&
+			loadedSegmentNeedsReopen(segment, loadInfo, requestSchemaVersion) {
+			if err := loader.reopenSegmentsWithSchema(ctx, requestSchema, []*querypb.SegmentLoadInfo{loadInfo}); err != nil {
+				return err
+			}
+		}
 
 		mlog.Info(context.TODO(), "segment loaded...", mlog.Int64("segmentID", segmentID))
 	}
@@ -684,7 +713,7 @@ func (loader *segmentLoader) GetChunkManager() storage.ChunkManager {
 }
 
 // load single bloom filter
-func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, collectionID int64, loadInfo *querypb.SegmentLoadInfo, segtype SegmentType) (*pkoracle.BloomFilterSet, error) {
+func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, collectionID int64, loadInfo *querypb.SegmentLoadInfo, segtype SegmentType, requestSchemas ...*schemapb.CollectionSchema) (*pkoracle.BloomFilterSet, error) {
 	partitionID := loadInfo.PartitionID
 	segmentID := loadInfo.SegmentID
 	bfs := pkoracle.NewBloomFilterSet(segmentID, partitionID, segtype)
@@ -699,6 +728,9 @@ func (loader *segmentLoader) loadSingleBloomFilterSet(ctx context.Context, colle
 	mlog.Info(context.TODO(), "start loading remote...", mlog.Int("segmentNum", 1))
 
 	schema := collection.Schema()
+	if len(requestSchemas) > 0 && requestSchemas[0] != nil {
+		schema = requestSchemas[0]
+	}
 	isExternalCollection := typeutil.IsExternalCollection(schema)
 	isMilvusTableRealPK := typeutil.NewStorageColumnResolver(schema).IsMilvusTable() &&
 		HasExternalPrimaryKey(schema)
@@ -2497,11 +2529,25 @@ func prepareIndexLoadParams(indexInfos []*querypb.FieldIndexInfo) error {
 func (loader *segmentLoader) ReopenSegments(ctx context.Context,
 	loadInfos []*querypb.SegmentLoadInfo,
 ) error {
+	return loader.ReopenSegmentsWithSchema(ctx, nil, loadInfos)
+}
+
+func (loader *segmentLoader) ReopenSegmentsWithSchema(ctx context.Context,
+	requestSchema *schemapb.CollectionSchema,
+	loadInfos []*querypb.SegmentLoadInfo,
+) error {
 	// Filter out LOADING segments only
 	// use None to avoid loaded check
 	infos := loader.prepare(ctx, commonpb.SegmentState_SegmentStateNone, loadInfos...)
 	defer loader.unregister(infos...)
 
+	return loader.reopenSegmentsWithSchema(ctx, requestSchema, infos)
+}
+
+func (loader *segmentLoader) reopenSegmentsWithSchema(ctx context.Context,
+	requestSchema *schemapb.CollectionSchema,
+	infos []*querypb.SegmentLoadInfo,
+) error {
 	// use full resource in case of whole segment reopen
 	// TODO use calculated resource from segcore after supported
 	requestResourceResult, err := loader.requestResource(ctx, infos...)
@@ -2518,11 +2564,23 @@ func (loader *segmentLoader) ReopenSegments(ctx context.Context,
 			continue
 		}
 		collection := loader.manager.Collection.Get(info.GetCollectionID())
+		reopenSchema := requestSchema
+		segcoreSchemaVersion := uint64(0)
 		if collection != nil {
-			configureUseTakeForOutput(info, collection.Schema())
+			_, segcoreSchemaVersion = collection.SchemaAndSegcoreVersion()
+			if reopenSchema == nil {
+				reopenSchema = collection.Schema()
+			}
+			configureUseTakeForOutput(info, reopenSchema)
 		}
 
-		err := segment.Reopen(ctx, info)
+		var err error
+		if localSegment, ok := segment.(*LocalSegment); ok && reopenSchema != nil && segcoreSchemaVersion > 0 {
+			requestSchemaVersion := uint64(reopenSchema.GetVersion())
+			err = localSegment.reopenWithSchema(ctx, info, reopenSchema, segcoreSchemaVersion, requestSchemaVersion)
+		} else {
+			err = segment.Reopen(ctx, info)
+		}
 		if err != nil {
 			mlog.Warn(context.TODO(), "failed to reopen segment", mlog.Int64("segmentID", info.GetSegmentID()), mlog.Err(err))
 			return err

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -27,15 +27,18 @@ import (
 	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/state"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -260,6 +263,58 @@ func (suite *SegmentLoaderSuite) TearDownTest() {
 		suite.manager.Segment.Remove(context.Background(), suite.segmentID+int64(i), querypb.DataScope_All)
 	}
 	suite.chunkManager.RemoveWithPrefix(ctx, suite.rootPath)
+}
+
+func (suite *SegmentLoaderSuite) TestReopenLoadedSegmentWithStaleSchemaVersionBeforeFullLoad() {
+	ctx := context.Background()
+	loader := suite.loader.(*segmentLoader)
+
+	oldSchema := suite.manager.Collection.Get(suite.collectionID).Schema()
+	oldSchema.Version = 1
+	newSchema := typeutil.Clone(oldSchema)
+	newSchema.Version = 2
+	collection := suite.manager.Collection.Get(suite.collectionID)
+	collection.setSchema(oldSchema, 1, 1, 1)
+
+	oldLoadInfo := &querypb.SegmentLoadInfo{
+		CollectionID:  suite.collectionID,
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		DataVersion:   1,
+	}
+	newLoadInfo := typeutil.Clone(oldLoadInfo)
+	csegment := mock_segcore.NewMockCSegment(suite.T())
+	csegment.EXPECT().
+		Reopen(mock.Anything, mock.MatchedBy(func(req *segcore.ReopenRequest) bool {
+			return req.LoadInfo == newLoadInfo &&
+				req.Schema.GetVersion() == 2 &&
+				req.SchemaVersion == 2
+		})).
+		Return(nil).
+		Once()
+
+	segment := &LocalSegment{
+		baseSegment: baseSegment{
+			collection:         collection,
+			loadInfo:           atomic.NewPointer(oldLoadInfo),
+			version:            atomic.NewInt64(1),
+			segmentType:        SegmentTypeSealed,
+			resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+			needUpdatedVersion: atomic.NewInt64(0),
+			loadSchemaVersion:  atomic.NewUint64(1),
+		},
+		ptrLock:        state.NewLoadStateLock(state.LoadStateDataLoaded),
+		csegment:       csegment,
+		fieldIndexes:   typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
+		fieldJSONStats: make(map[int64]*querypb.JsonStatsInfo),
+	}
+	suite.manager.Segment.Put(ctx, SegmentTypeSealed, segment)
+	collection.setSchema(newSchema, 2, 2, 2)
+
+	suite.Require().NoError(loader.reopenLoadedSegmentsIfStale(ctx, collection, SegmentTypeSealed, newLoadInfo))
+	suite.Equal(uint64(2), segment.LoadSchemaVersion())
+	suite.Equal(int32(1), segment.LoadInfo().GetDataVersion())
 }
 
 func (suite *SegmentLoaderSuite) TestLoad() {

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -289,7 +289,7 @@ func (suite *SegmentLoaderSuite) TestReopenLoadedSegmentWithStaleSchemaVersionBe
 		Reopen(mock.Anything, mock.MatchedBy(func(req *segcore.ReopenRequest) bool {
 			return req.LoadInfo == newLoadInfo &&
 				req.Schema.GetVersion() == 2 &&
-				req.SchemaVersion == 2
+				req.SchemaVersion == 42
 		})).
 		Return(nil).
 		Once()
@@ -310,11 +310,71 @@ func (suite *SegmentLoaderSuite) TestReopenLoadedSegmentWithStaleSchemaVersionBe
 		fieldJSONStats: make(map[int64]*querypb.JsonStatsInfo),
 	}
 	suite.manager.Segment.Put(ctx, SegmentTypeSealed, segment)
-	collection.setSchema(newSchema, 2, 2, 2)
+	collection.setSchema(newSchema, 2, 2, 42)
 
-	suite.Require().NoError(loader.reopenLoadedSegmentsIfStale(ctx, collection, SegmentTypeSealed, newLoadInfo))
+	suite.Require().NoError(loader.reopenLoadedSegmentsIfStale(ctx, collection, newSchema, SegmentTypeSealed, newLoadInfo))
 	suite.Equal(uint64(2), segment.LoadSchemaVersion())
 	suite.Equal(int32(1), segment.LoadInfo().GetDataVersion())
+}
+
+func (suite *SegmentLoaderSuite) TestWaitSegmentLoadDoneReopensStaleInFlightLoadResult() {
+	ctx := context.Background()
+	loader := suite.loader.(*segmentLoader)
+
+	oldSchema := suite.manager.Collection.Get(suite.collectionID).Schema()
+	oldSchema.Version = 1
+	newSchema := typeutil.Clone(oldSchema)
+	newSchema.Version = 2
+	collection := suite.manager.Collection.Get(suite.collectionID)
+	collection.setSchema(newSchema, 2, 2, 42)
+
+	oldLoadInfo := &querypb.SegmentLoadInfo{
+		CollectionID:  suite.collectionID,
+		SegmentID:     suite.segmentID,
+		PartitionID:   suite.partitionID,
+		InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", suite.collectionID),
+		DataVersion:   1,
+	}
+	newLoadInfo := typeutil.Clone(oldLoadInfo)
+
+	csegment := mock_segcore.NewMockCSegment(suite.T())
+	csegment.EXPECT().
+		Reopen(mock.Anything, mock.MatchedBy(func(req *segcore.ReopenRequest) bool {
+			return req.LoadInfo == newLoadInfo &&
+				req.Schema.GetVersion() == 2 &&
+				req.SchemaVersion == 42
+		})).
+		Return(nil).
+		Once()
+
+	result := newLoadResult()
+	loader.loadingSegments.Insert(suite.segmentID, result)
+	defer loader.loadingSegments.GetAndRemove(suite.segmentID)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		segment := &LocalSegment{
+			baseSegment: baseSegment{
+				collection:         collection,
+				loadInfo:           atomic.NewPointer(oldLoadInfo),
+				version:            atomic.NewInt64(1),
+				segmentType:        SegmentTypeSealed,
+				resourceUsageCache: atomic.NewPointer[ResourceUsage](nil),
+				needUpdatedVersion: atomic.NewInt64(0),
+				loadSchemaVersion:  atomic.NewUint64(1),
+			},
+			ptrLock:        state.NewLoadStateLock(state.LoadStateDataLoaded),
+			csegment:       csegment,
+			fieldIndexes:   typeutil.NewConcurrentMap[int64, *IndexedFieldInfo](),
+			fieldJSONStats: make(map[int64]*querypb.JsonStatsInfo),
+		}
+		suite.manager.Segment.Put(ctx, SegmentTypeSealed, segment)
+		result.SetResult(success)
+	}()
+
+	suite.Require().NoError(loader.waitSegmentLoadDone(ctx, SegmentTypeSealed, []*querypb.SegmentLoadInfo{newLoadInfo}, 2, newSchema))
+	segment := suite.manager.Segment.GetSealed(suite.segmentID).(loadSchemaVersionedSegment)
+	suite.Equal(uint64(2), segment.LoadSchemaVersion())
 }
 
 func (suite *SegmentLoaderSuite) TestLoad() {
@@ -1637,7 +1697,7 @@ func (suite *SegmentLoaderDetailSuite) TestWaitSegmentLoadDone() {
 			suite.loader.notifyLoadFinish(infos...)
 		}()
 
-		err := suite.loader.waitSegmentLoadDone(context.Background(), SegmentTypeSealed, []int64{suite.segmentID}, 0)
+		err := suite.loader.waitSegmentLoadDone(context.Background(), SegmentTypeSealed, infos, 0, suite.manager.Collection.Get(suite.collectionID).Schema())
 		suite.NoError(err)
 	})
 
@@ -1656,14 +1716,14 @@ func (suite *SegmentLoaderDetailSuite) TestWaitSegmentLoadDone() {
 			suite.loader.unregister(infos...)
 		}()
 
-		err := suite.loader.waitSegmentLoadDone(context.Background(), SegmentTypeSealed, []int64{suite.segmentID}, 0)
+		err := suite.loader.waitSegmentLoadDone(context.Background(), SegmentTypeSealed, infos, 0, suite.manager.Collection.Get(suite.collectionID).Schema())
 		suite.Error(err)
 	})
 
 	suite.Run("wait_timeout", func() {
 		suite.SetupTest()
 
-		suite.loader.prepare(context.Background(), SegmentTypeSealed, &querypb.SegmentLoadInfo{
+		infos := suite.loader.prepare(context.Background(), SegmentTypeSealed, &querypb.SegmentLoadInfo{
 			SegmentID:     suite.segmentID,
 			PartitionID:   suite.partitionID,
 			CollectionID:  suite.collectionID,
@@ -1674,7 +1734,7 @@ func (suite *SegmentLoaderDetailSuite) TestWaitSegmentLoadDone() {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		err := suite.loader.waitSegmentLoadDone(ctx, SegmentTypeSealed, []int64{suite.segmentID}, 0)
+		err := suite.loader.waitSegmentLoadDone(ctx, SegmentTypeSealed, infos, 0, suite.manager.Collection.Get(suite.collectionID).Schema())
 		suite.Error(err)
 		suite.True(merr.IsCanceledOrTimeout(err))
 	})

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -385,7 +385,7 @@ func (node *QueryNode) Init() error {
 				return NewLocalWorker(node), nil
 			}
 
-			sessions, _, err := node.session.GetSessions(node.ctx, typeutil.QueryNodeRole)
+			sessions, _, err := node.session.GetSessions(ctx, typeutil.QueryNodeRole)
 			if err != nil {
 				return nil, err
 			}
@@ -397,9 +397,12 @@ func (node *QueryNode) Init() error {
 					break
 				}
 			}
+			if addr == "" {
+				return nil, merr.WrapErrNodeNotAvailable(nodeID, "querynode session address not found")
+			}
 
 			return cluster.NewPoolingRemoteWorker(func() (types.QueryNodeClient, error) {
-				return grpcquerynodeclient.NewClient(node.ctx, addr, nodeID)
+				return grpcquerynodeclient.NewClient(ctx, addr, nodeID)
 			})
 		})
 		node.delegators = typeutil.NewConcurrentMap[string, delegator.ShardDelegator]()

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
@@ -261,6 +262,7 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, req *querypb.WatchDm
 		node.chunkManager,
 		queryView,
 		node.binlogSaver,
+		delegator.WithInitialSchema(req.GetSchema()),
 		delegator.WithLeaderViewUpdatedCallback(node.markLeaderViewUpdated),
 	)
 	if err != nil {
@@ -570,12 +572,25 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 
 	// Actual load segment
 	log.Info(ctx, "start to load segments...")
-	loaded, err := node.loader.Load(ctx,
-		req.GetCollectionID(),
-		segments.SegmentTypeSealed,
-		req.GetVersion(),
-		req.GetInfos()...,
-	)
+	var loaded []segments.Segment
+	if loader, ok := node.loader.(interface {
+		LoadWithSchema(context.Context, int64, segments.SegmentType, int64, *schemapb.CollectionSchema, ...*querypb.SegmentLoadInfo) ([]segments.Segment, error)
+	}); ok {
+		loaded, err = loader.LoadWithSchema(ctx,
+			req.GetCollectionID(),
+			segments.SegmentTypeSealed,
+			req.GetVersion(),
+			req.GetSchema(),
+			req.GetInfos()...,
+		)
+	} else {
+		loaded, err = node.loader.Load(ctx,
+			req.GetCollectionID(),
+			segments.SegmentTypeSealed,
+			req.GetVersion(),
+			req.GetInfos()...,
+		)
+	}
 	if err != nil {
 		return merr.Status(err), nil
 	}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -209,6 +209,10 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 	// fill the put load config if rg or replica number is changed.
 	udpates.AlterLoadConfig = c.getAlterLoadConfigOfAlterCollection(coll.Properties, udpates.Properties)
 
+	if err := validateAlterCollectionSchemaPayloadVersion(coll.SchemaVersion, header, udpates); err != nil {
+		return err
+	}
+
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
 	channels = append(channels, coll.VirtualChannelNames...)
@@ -221,6 +225,23 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateAlterCollectionSchemaPayloadVersion(currentVersion int32, header *messagespb.AlterCollectionMessageHeader, updates *messagespb.AlterCollectionMessageUpdates) error {
+	if header == nil || header.GetUpdateMask() == nil || !funcutil.SliceContain(header.GetUpdateMask().GetPaths(), message.FieldMaskCollectionSchema) {
+		return nil
+	}
+	if updates == nil || updates.GetSchema() == nil {
+		return merr.WrapErrServiceInternalMsg("alter collection schema update mask requires schema payload")
+	}
+	if updates.GetSchema().GetVersion() <= currentVersion {
+		return merr.WrapErrServiceInternalMsg(
+			"alter collection schema payload must advance schema version, current=%d, payload=%d",
+			currentVersion,
+			updates.GetSchema().GetVersion(),
+		)
 	}
 	return nil
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -123,20 +123,24 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionConsistencyLevel)
 			}
 		case common.CollectionExternalSource:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSource = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			if prop.GetValue() != coll.ExternalSource {
+				if udpates.Schema == nil {
+					udpates.Schema = &schemapb.CollectionSchema{}
+				}
+				udpates.Schema.ExternalSource = prop.GetValue()
+				if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+					header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+				}
 			}
 		case common.CollectionExternalSpec:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSpec = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			if prop.GetValue() != coll.ExternalSpec {
+				if udpates.Schema == nil {
+					udpates.Schema = &schemapb.CollectionSchema{}
+				}
+				udpates.Schema.ExternalSpec = prop.GetValue()
+				if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+					header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+				}
 			}
 		default:
 			newProperties[prop.GetKey()] = prop.GetValue()
@@ -153,12 +157,15 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionProperties)
 	}
 
-	// If TTL field is changed through properties, also broadcast an updated schema snapshot and mark it as schema change,
-	// so QueryNode can refresh runtime schema properties without requiring release/load.
+	// If a property alter changes schema payload, broadcast a full schema
+	// snapshot and mark it as schema change so WAL consumers advance by
+	// schema.Version instead of relying on the broadcast timestamp.
 	ttlOld, okOld := oldProperties[common.CollectionTTLFieldKey]
 	ttlNew, okNew := newProperties[common.CollectionTTLFieldKey]
 	needTTLFieldSchemaRefresh := (okOld != okNew) || (okOld && okNew && ttlOld != ttlNew)
-	if needTTLFieldSchemaRefresh {
+	needExternalSpecSchemaRefresh := funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+	if needTTLFieldSchemaRefresh || needExternalSpecSchemaRefresh {
+		schemaUpdate := udpates.Schema
 		// validate ttl field name exists in schema fields when setting it
 		if okNew {
 			found := false
@@ -178,16 +185,18 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 			header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionSchema)
 		}
 
-		// Build schema snapshot with updated properties (schema version should NOT be changed for properties-only alter).
+		// Build schema snapshot with updated properties. Any schema payload
+		// change must advance schema.Version so WAL consumers can gate on it.
 		schema := coll.ToCollectionSchemaPB()
+		schema.Version = coll.SchemaVersion + 1
 		schema.Properties = newPropsKeyValuePairs
 		// Preserve ExternalSource/ExternalSpec from current collection state
 		// unless this alter is itself updating them (refresh-completion sync).
-		if udpates.Schema != nil && udpates.Schema.ExternalSource != "" {
-			schema.ExternalSource = udpates.Schema.ExternalSource
+		if schemaUpdate != nil && schemaUpdate.ExternalSource != "" {
+			schema.ExternalSource = schemaUpdate.ExternalSource
 		}
-		if udpates.Schema != nil && udpates.Schema.ExternalSpec != "" {
-			schema.ExternalSpec = udpates.Schema.ExternalSpec
+		if schemaUpdate != nil && schemaUpdate.ExternalSpec != "" {
+			schema.ExternalSpec = schemaUpdate.ExternalSpec
 		}
 		udpates.Schema = schema
 	}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -685,14 +685,14 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldShouldBroadcastSchema(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
 
-	// Alter properties to set ttl field should succeed and should NOT change schema version in meta.
+	// Alter properties to set ttl field should bump schema version because it broadcasts a schema payload.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
 		DbName:         dbName,
 		CollectionName: collectionName,
 		Properties:     []*commonpb.KeyValuePair{{Key: common.CollectionTTLFieldKey, Value: "ttl"}},
 	})
 	require.NoError(t, merr.CheckRPCCall(resp, err))
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *testing.T) {
@@ -738,6 +738,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
 
 	// Alter TTL field only — must preserve previously persisted external source/spec.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
@@ -750,6 +751,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 
 	// TTL with invalid field name still rejected.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
@@ -818,6 +820,7 @@ func TestDDLCallbacksAlterCollectionProperties_AcceptExternalSourceSpec(t *testi
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 // Regression for #49335: refresh override path may carry source-only updates
@@ -861,6 +864,7 @@ func TestDDLCallbacksAlterCollectionProperties_PartialExternalUpdatePreservesOth
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 // Regression for #49335: alter that mixes external_source with a regular
@@ -905,6 +909,7 @@ func TestDDLCallbacksAlterCollectionProperties_MixedExternalAndRegular(t *testin
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertReplicaNumber(t, ctx, core, dbName, collectionName, 2)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 func createCollectionForTest(t *testing.T, ctx context.Context, core *Core, dbName string, collectionName string) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -345,6 +346,23 @@ func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigRPCError(t *te
 		Results: map[string]*message.AppendResult{},
 	})
 	require.Error(t, err)
+}
+
+func TestValidateAlterCollectionSchemaPayloadVersion(t *testing.T) {
+	header := &messagespb.AlterCollectionMessageHeader{
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{message.FieldMaskCollectionSchema},
+		},
+	}
+
+	require.NoError(t, validateAlterCollectionSchemaPayloadVersion(10, &messagespb.AlterCollectionMessageHeader{}, nil))
+	require.Error(t, validateAlterCollectionSchemaPayloadVersion(10, header, nil))
+	require.Error(t, validateAlterCollectionSchemaPayloadVersion(10, header, &messagespb.AlterCollectionMessageUpdates{
+		Schema: &schemapb.CollectionSchema{Version: 10},
+	}))
+	require.NoError(t, validateAlterCollectionSchemaPayloadVersion(10, header, &messagespb.AlterCollectionMessageUpdates{
+		Schema: &schemapb.CollectionSchema{Version: 11},
+	}))
 }
 
 func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigNonRGNotFoundError(t *testing.T) {

--- a/internal/util/pipeline/node.go
+++ b/internal/util/pipeline/node.go
@@ -28,6 +28,10 @@ type Node interface {
 	Close()
 }
 
+type preCloser interface {
+	PreClose()
+}
+
 type nodeCtx struct {
 	node         Node
 	InputChannel chan Msg

--- a/internal/util/pipeline/pipeline.go
+++ b/internal/util/pipeline/pipeline.go
@@ -77,6 +77,14 @@ func (p *pipeline) Close() {
 	}
 }
 
+func (p *pipeline) PreClose() {
+	for _, node := range p.nodes {
+		if preCloser, ok := node.node.(preCloser); ok {
+			preCloser.PreClose()
+		}
+	}
+}
+
 func (p *pipeline) process() {
 	if len(p.nodes) == 0 {
 		return

--- a/internal/util/pipeline/stream_pipeline.go
+++ b/internal/util/pipeline/stream_pipeline.go
@@ -161,6 +161,7 @@ func (p *streamPipeline) Close() {
 		p.dispatcher.Deregister(p.vChannel)
 		// close stream input
 		close(p.closeCh)
+		p.pipeline.PreClose()
 		p.closeWg.Wait()
 		if p.scanner != nil {
 			p.scanner.Close()

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -20,6 +20,7 @@ import (
 	context2 "context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -134,6 +135,44 @@ func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherMergesBufferedDMLPacks() 
 	suite.Empty(received)
 }
 
+func (suite *StreamPipelineSuite) TestClosePreClosesNodesBeforeWaitingWorkDone() {
+	node := &preCloseBlockingNode{
+		BaseNode:  NewBaseNode("pre-close-blocking", 8),
+		operating: make(chan struct{}),
+		preClosed: make(chan struct{}),
+	}
+	suite.pipeline.Add(node)
+
+	err := suite.pipeline.ConsumeMsgStream(context2.Background(), &msgpb.MsgPosition{})
+	suite.NoError(err)
+	suite.NoError(suite.pipeline.Start())
+	suite.inChannel <- &msgstream.MsgPack{BeginTs: 1001}
+
+	suite.Eventually(func() bool {
+		select {
+		case <-node.operating:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.pipeline.Close()
+	}()
+
+	suite.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
 func TestDMLMsgPackBatcherLimitsByTotalMessageNum(t *testing.T) {
 	maxMsgNum := 3
 	batcher := NewDMLMsgPackBatcher(func() int { return maxMsgNum })
@@ -190,6 +229,22 @@ type captureMsgPackNode struct {
 func (node *captureMsgPackNode) Operate(in Msg) Msg {
 	node.outChannel <- in.(*msgstream.MsgPack)
 	return nil
+}
+
+type preCloseBlockingNode struct {
+	*BaseNode
+	operating chan struct{}
+	preClosed chan struct{}
+}
+
+func (node *preCloseBlockingNode) Operate(in Msg) Msg {
+	close(node.operating)
+	<-node.preClosed
+	return in
+}
+
+func (node *preCloseBlockingNode) PreClose() {
+	close(node.preClosed)
 }
 
 func newDMLMsgPack(beginTs, endTs uint64, msgs ...msgstream.TsMsg) *msgstream.MsgPack {

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -103,6 +103,9 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3), ErrCollectionSchemaVersionNotReady)
 	s.True(Status(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3)).GetRetriable())
 	s.Equal(commonpb.ErrorCode_NotReadyServe, Status(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3)).GetErrorCode())
+	s.ErrorIs(WrapErrCollectionSchemaVersionNotReadyWithVersion("test_collection", 1, 3), ErrCollectionSchemaVersionNotReady)
+	s.True(Status(WrapErrCollectionSchemaVersionNotReadyWithVersion("test_collection", 1, 3)).GetRetriable())
+	s.Equal(commonpb.ErrorCode_NotReadyServe, Status(WrapErrCollectionSchemaVersionNotReadyWithVersion("test_collection", 1, 3)).GetErrorCode())
 	// Partition related
 	s.ErrorIs(WrapErrPartitionNotFound("test_partition", "failed to get partition"), ErrPartitionNotFound)
 	s.ErrorIs(WrapErrPartitionNotLoaded("test_partition", "failed to query"), ErrPartitionNotLoaded)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -682,6 +682,14 @@ func WrapErrCollectionSchemaVersionNotReady(collection any, consistentSegments, 
 	)
 }
 
+func WrapErrCollectionSchemaVersionNotReadyWithVersion(collection any, currentVersion, requiredVersion uint64) error {
+	return wrapFieldsWithDesc(
+		ErrCollectionSchemaVersionNotReady,
+		fmt.Sprintf("current schema version %d, required schema version %d", currentVersion, requiredVersion),
+		value("collection", collection),
+	)
+}
+
 func WrapErrAliasNotFound(db any, alias any, msg ...string) error {
 	err := wrapFields(ErrAliasNotFound,
 		value("database", db),


### PR DESCRIPTION
Related to #51796

Reject load segment and reopen requests when the delegator has not consumed the matching schema version from WAL yet. The gate is implemented in the delegator, because all load requests must pass through it.

Maintain an independent delegator schema view that is advanced only by WAL UpdateSchema events. Load requests may observe that view, but must not advance it, must not update delegator function runners, and must not share schema ownership with other QueryNode components.

Stop using SchemaBarrierTs as the delegator load gate. Keep it only as a compatibility/update timestamp field for workers and collection manager same-version schema payloads.

Treat ErrCollectionSchemaVersionNotReady as a temporary QueryCoord load result: keep the segment task started, leave rpcReturned false, and let scheduler retry after the delegator catches up.

Add focused coverage for the delegator schema gate, load-path schema isolation, QueryCoord retry behavior, and the versioned merr wrapper.
