### PR TITLE
fix: [3.0] recognize struct array vectors in REST inserts

### DIFF
--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -1810,7 +1810,7 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 			IsDynamic: field.IsDynamic,
 		}
 	}
-	if len(nameDims) == 0 && len(sch.Functions) == 0 && !partialUpdate {
+	if len(typeutil.GetVectorFieldSchemas(sch)) == 0 && len(sch.Functions) == 0 && !partialUpdate {
 		return nil, merr.WrapErrParameterInvalidMsg("collection: %s has no vector field or functions", sch.Name)
 	}
 

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -4041,6 +4041,50 @@ func TestAnyToColumnsStructArray(t *testing.T) {
 	assert.Len(t, vecData[1].GetFloatVector().GetData(), 4)
 }
 
+func TestAnyToColumnsStructArrayAsOnlyVectorField(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	schema.Fields = schema.Fields[:1]
+	body := []byte(`{
+		"data": [
+			{
+				"id": 1,
+				"my_struct": [
+					{"sub_int": 10, "sub_vec": [1.1, 1.2, 1.3, 1.4]}
+				]
+			}
+		]
+	}`)
+
+	rows, _, err := checkAndSetData(body, schema, false)
+	require.NoError(t, err)
+
+	fds, err := anyToColumns(rows, nil, schema, true, false)
+	require.NoError(t, err)
+	require.Len(t, fds, 2)
+	assert.Equal(t, schemapb.DataType_Int64, fds[0].GetType())
+	assert.Equal(t, schemapb.DataType_ArrayOfStruct, fds[1].GetType())
+}
+
+func TestAnyToColumnsRejectsSchemaWithoutVectorOrFunction(t *testing.T) {
+	schema := buildStructArrayTestSchema()
+	schema.Fields = schema.Fields[:1]
+	schema.StructArrayFields[0].Fields = schema.StructArrayFields[0].Fields[:1]
+	body := []byte(`{
+		"data": [
+			{
+				"id": 1,
+				"my_struct": [{"sub_int": 10}]
+			}
+		]
+	}`)
+
+	rows, _, err := checkAndSetData(body, schema, false)
+	require.NoError(t, err)
+
+	_, err = anyToColumns(rows, nil, schema, true, false)
+	require.ErrorContains(t, err, "has no vector field or functions")
+}
+
 func TestBuildQueryRespStructArrayRoundTrip(t *testing.T) {
 	schema := buildStructArrayTestSchema()
 	body := []byte(`{


### PR DESCRIPTION
pr: #51889
issue: #51888

## What changed

- Backport the REST Struct Array vector detection fix from #51889 to the `3.0` branch.
- Use `typeutil.GetVectorFieldSchemas` so nested `ArrayOfVector` fields count as vectors.
- Add regression coverage for a Struct Array as the only vector-bearing field.
- Preserve rejection for schemas with no vector fields or functions.

## Root cause

`nameDims` is populated only from top-level fields. The validation ran before Struct Array conversion, so it incorrectly rejected schemas whose vectors exist only in Struct Array sub-fields.

## Verification

- `TestAnyToColumnsStructArrayAsOnlyVectorField`
- `TestAnyToColumnsRejectsSchemaWithoutVectorOrFunction`
- The same change passed the full `internal/distributed/proxy/httpserver` Go test package on master.
- REST v2 E2E on the master fix with Float, Float16, Int8, and Binary vector sub-fields: `code=0`, `insertCount=1`
- 3.0 CI pending.
