### PR TITLE
enhance: [3.0] unify RecordReader ownership on a borrow contract (#51884)

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -514,20 +514,17 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		if preMaterializeFilter {
 			selection, _, err = selectFullRewriteRecord(record, pkField, entityFilter, ttlFieldID, sourceHasTTLField, nil)
 			if err != nil {
-				record.Release()
 				return nil, err
 			}
 			if selection != nil && selection.Len() == 0 {
-				record.Release()
 				continue
 			}
 		}
 
+		// record stays owned by the reader (released on its next Next/Close);
+		// only the derived arrays of the wrapped record are cleaned up here.
 		wrapped, err := materializer.WrapWithSelection(record, selection)
 		if err != nil {
-			if selection == nil {
-				record.Release()
-			}
 			return nil, err
 		}
 		out := overwriteRecordTimestamps(wrapped, segment.GetCommitTimestamp())
@@ -535,7 +532,7 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 			if out != wrapped {
 				out.Release()
 			}
-			releaseWrappedRecord(wrapped, record)
+			cleanupMaterializedRecord(wrapped)
 			return nil, err
 		}
 		if out != wrapped {
@@ -543,7 +540,7 @@ func (t *bumpSchemaVersionCompactionTask) runFullSchemaRewrite(existingFields ma
 		}
 
 		totalRows += int64(wrapped.Len())
-		releaseWrappedRecord(wrapped, record)
+		cleanupMaterializedRecord(wrapped)
 	}
 
 	if err := writer.Close(); err != nil {
@@ -1005,10 +1002,11 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		readDuration += time.Since(readStart)
 
 		computeStart := time.Now()
+		// record stays owned by the reader (released on its next Next/Close);
+		// only the derived arrays of the wrapped record are cleaned up here.
 		wrapped, err := materializer.Wrap(record)
 		computeDuration += time.Since(computeStart)
 		if err != nil {
-			record.Release()
 			span.End()
 			return nil, err
 		}
@@ -1017,7 +1015,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 			outputFieldID := outputField.GetFieldID()
 			outputCol := wrapped.Column(outputFieldID)
 			if outputCol == nil {
-				releaseWrappedRecord(wrapped, record)
+				cleanupMaterializedRecord(wrapped)
 				span.End()
 				return nil, merr.WrapErrServiceInternalMsg("output field %d not found in materialized record", outputFieldID)
 			}
@@ -1025,7 +1023,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 			if stats, ok := statsByField[outputFieldID]; ok {
 				bm25MemSize, err := appendBM25StatsFromArrowArray(stats, outputCol)
 				if err != nil {
-					releaseWrappedRecord(wrapped, record)
+					cleanupMaterializedRecord(wrapped)
 					span.End()
 					return nil, err
 				}
@@ -1036,7 +1034,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 
 		writeStart := time.Now()
 		if err := writerResult.writer.Write(wrapped); err != nil {
-			releaseWrappedRecord(wrapped, record)
+			cleanupMaterializedRecord(wrapped)
 			span.End()
 			return nil, err
 		}
@@ -1048,7 +1046,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		)
 
 		totalRows += int64(wrapped.Len())
-		releaseWrappedRecord(wrapped, record)
+		cleanupMaterializedRecord(wrapped)
 	}
 	span.End()
 

--- a/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
+++ b/internal/datanode/compactor/clustering_compactor_storage_v2_test.go
@@ -60,6 +60,7 @@ func (s *ClusteringCompactionTaskStorageV2Suite) TearDownTest() {
 	os.RemoveAll(paramtable.Get().LocalStorageCfg.Path.GetValue() + "insert_log")
 	os.RemoveAll(paramtable.Get().LocalStorageCfg.Path.GetValue() + "delta_log")
 	os.RemoveAll(paramtable.Get().LocalStorageCfg.Path.GetValue() + "stats_log")
+	s.ClusteringCompactionTaskSuite.TearDownTest()
 }
 
 func (s *ClusteringCompactionTaskStorageV2Suite) TestScalarCompactionNormal() {

--- a/internal/datanode/compactor/clustering_compactor_test.go
+++ b/internal/datanode/compactor/clustering_compactor_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -65,6 +66,8 @@ func (s *ClusteringCompactionTaskSuite) SetupSuite() {
 func (s *ClusteringCompactionTaskSuite) setupTest() {
 	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
 	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "false")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, s.T().TempDir())
+	initcore.InitStorageV2FileSystem(paramtable.Get())
 
 	s.mockBinlogIO = mock_util.NewMockBinlogIO(s.T())
 
@@ -119,6 +122,8 @@ func (s *ClusteringCompactionTaskSuite) SetupSubTest() {
 func (s *ClusteringCompactionTaskSuite) TearDownTest() {
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+	paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+	initcore.CleanArrowFileSystem()
 }
 
 func (s *ClusteringCompactionTaskSuite) TestWrongCompactionType() {

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -323,7 +323,6 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 		baseRecord := r
 		r, err = materializer.Wrap(baseRecord)
 		if err != nil {
-			baseRecord.Release()
 			mlog.Warn(ctx, "compact wrong, failed to materialize record", mlog.Err(err))
 			return
 		}
@@ -392,7 +391,7 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 					return mWriter.Write(out)
 				}()
 				if err != nil {
-					releaseWrappedRecord(r, baseRecord)
+					cleanupMaterializedRecord(r)
 					return 0, 0, err
 				}
 			}
@@ -403,11 +402,11 @@ func (t *mixCompactionTask) writeSegment(ctx context.Context,
 				out.Release()
 			}
 			if err != nil {
-				releaseWrappedRecord(r, baseRecord)
+				cleanupMaterializedRecord(r)
 				return 0, 0, err
 			}
 		}
-		releaseWrappedRecord(r, baseRecord)
+		cleanupMaterializedRecord(r)
 	}
 
 	deltalogDeleteEntriesCount := len(delta)

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
@@ -95,9 +96,13 @@ func newMixCompactionStorageV1SuiteForDirectTest(t *testing.T) *MixCompactionTas
 	s.SetupSuite()
 	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
 	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "false")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, t.TempDir())
+	initcore.InitStorageV2FileSystem(paramtable.Get())
 	t.Cleanup(func() {
 		paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
 		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+		paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+		initcore.CleanArrowFileSystem()
 		s.TearDownTest()
 	})
 	s.SetupTest()

--- a/internal/datanode/compactor/multi_segment_writer_test.go
+++ b/internal/datanode/compactor/multi_segment_writer_test.go
@@ -145,6 +145,7 @@ func (s *MultiSegmentWriterSuite) SetupSuite() {
 
 func (s *MultiSegmentWriterSuite) SetupTest() {
 	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, s.T().TempDir())
 
 	s.mockBinlogIO = mock_util.NewMockBinlogIO(s.T())
 	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -170,6 +171,7 @@ func (s *MultiSegmentWriterSuite) SetupTest() {
 
 func (s *MultiSegmentWriterSuite) TearDownTest() {
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
+	paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
 }
 
 // genSimpleSchema generates a simple collection schema for testing

--- a/internal/datanode/compactor/namespace_compactor_test.go
+++ b/internal/datanode/compactor/namespace_compactor_test.go
@@ -41,6 +41,7 @@ type NamespaceCompactorTestSuite struct {
 func (s *NamespaceCompactorTestSuite) SetupSuite() {
 	paramtable.Get().Init(paramtable.NewBaseTable())
 	paramtable.Get().Save(paramtable.Get().CommonCfg.StorageType.Key, "local")
+	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, s.T().TempDir())
 	initcore.InitStorageV2FileSystem(paramtable.Get())
 
 	s.binlogIO = mock_util.NewMockBinlogIO(s.T())
@@ -75,6 +76,7 @@ func (s *NamespaceCompactorTestSuite) SetupSuite() {
 
 func (s *NamespaceCompactorTestSuite) TearDownSuite() {
 	paramtable.Get().Reset(paramtable.Get().CommonCfg.StorageType.Key)
+	paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
 	initcore.CleanArrowFileSystem()
 }
 

--- a/internal/datanode/compactor/record_materializer.go
+++ b/internal/datanode/compactor/record_materializer.go
@@ -17,6 +17,8 @@
 package compactor
 
 import (
+	"sync"
+
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
@@ -52,13 +54,14 @@ func (s *recordSelection) Len() int {
 }
 
 type RecordMaterializer struct {
-	materializers []FunctionMaterializer
-	missingFields []*schemapb.FieldSchema
-	schema        *schemapb.CollectionSchema
+	materializers  []FunctionMaterializer
+	missingFields  []*schemapb.FieldSchema
+	schema         *schemapb.CollectionSchema
+	existingFields map[int64]struct{}
 }
 
 func NewRecordMaterializer(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, existingFields map[int64]struct{}) (*RecordMaterializer, error) {
-	materializer := &RecordMaterializer{schema: schema}
+	materializer := &RecordMaterializer{schema: schema, existingFields: existingFields}
 	materializedFields := make(map[int64]struct{})
 	for _, functionSchema := range functions {
 		outputIndexes := functionOutputIndexesToMaterialize(functionSchema, existingFields)
@@ -94,11 +97,19 @@ func (m *RecordMaterializer) Wrap(rec storage.Record) (storage.Record, error) {
 	return m.WrapWithSelection(rec, nil)
 }
 
+// WrapWithSelection wraps rec — optionally filtered to selection — filling absent
+// function outputs and missing schema fields. rec stays borrowed from its reader
+// and is valid until the reader's next Next/Close; the caller must clean up only
+// the derived arrays owned by the returned record (cleanupMaterializedRecord),
+// never the input record itself. Callers that keep the returned record across a
+// reader advance must Retain/Release it explicitly (see storage.Sort).
 func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *recordSelection) (storage.Record, error) {
 	base := rec
-	var selected *selectedRecord
 	if selection != nil {
-		selected = newSelectedRecord(rec, m.schema, selection)
+		selected, err := newSelectedRecord(rec, m.schema, m.existingFields, selection)
+		if err != nil {
+			return nil, err
+		}
 		base = selected
 	}
 	if !m.hasMaterialization() {
@@ -110,18 +121,8 @@ func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *re
 		arrays, err := materializer.Materialize(base)
 		if err != nil {
 			releaseArrowArrays(computed)
-			if base != rec {
-				base.Release()
-			}
-			if selected != nil && selected.err != nil {
-				return nil, selected.err
-			}
+			cleanupMaterializedRecord(base)
 			return nil, err
-		}
-		if selected != nil && selected.err != nil {
-			releaseArrowArrays(computed)
-			base.Release()
-			return nil, selected.err
 		}
 		for fieldID, arr := range arrays {
 			computed[fieldID] = arr
@@ -135,9 +136,7 @@ func (m *RecordMaterializer) WrapWithSelection(rec storage.Record, selection *re
 		arr, err := storage.GenerateEmptyArrayFromSchema(field, base.Len())
 		if err != nil {
 			releaseArrowArrays(computed)
-			if base != rec {
-				base.Release()
-			}
+			cleanupMaterializedRecord(base)
 			return nil, err
 		}
 		computed[fieldID] = arr
@@ -162,8 +161,9 @@ func (m *RecordMaterializer) hasMaterialization() bool {
 }
 
 type materializedRecord struct {
-	base     storage.Record
-	computed map[int64]arrow.Array
+	base        storage.Record
+	computed    map[int64]arrow.Array
+	cleanupOnce sync.Once
 }
 
 var _ storage.Record = (*materializedRecord)(nil)
@@ -186,10 +186,6 @@ func (r *materializedRecord) Retain() {
 	}
 }
 
-func (r *materializedRecord) retainBase() {
-	r.base.Retain()
-}
-
 func (r *materializedRecord) Release() {
 	r.base.Release()
 	for _, col := range r.computed {
@@ -197,55 +193,69 @@ func (r *materializedRecord) Release() {
 	}
 }
 
+func (r *materializedRecord) cleanupDerived() {
+	r.cleanupOnce.Do(func() {
+		releaseArrowArrays(r.computed)
+		cleanupMaterializedRecord(r.base)
+	})
+}
+
 type selectedRecord struct {
-	base      storage.Record
-	fields    map[int64]*schemapb.FieldSchema
-	selection *recordSelection
-	columns   map[int64]arrow.Array
-	err       error
+	base        storage.Record
+	selection   *recordSelection
+	columns     map[int64]arrow.Array
+	cleanupOnce sync.Once
 }
 
 var _ storage.Record = (*selectedRecord)(nil)
 
-func newSelectedRecord(base storage.Record, schema *schemapb.CollectionSchema, selection *recordSelection) *selectedRecord {
-	fields := make(map[int64]*schemapb.FieldSchema)
+// newSelectedRecord eagerly slices every schema field physically present in
+// base down to the selection ranges. The column set must be fixed for the
+// record's lifetime: a column created lazily after a wrapper Retain-snapshot
+// (e.g. timestampOverwriteRecord) would escape the snapshot and be released
+// once more than it was retained. Presence is decided by existingFields, never
+// by probing base.Column: V2/V3 records panic on Column for absent fields.
+func newSelectedRecord(base storage.Record, schema *schemapb.CollectionSchema, existingFields map[int64]struct{}, selection *recordSelection) (*selectedRecord, error) {
+	columns := make(map[int64]arrow.Array)
 	for _, field := range typeutil.GetAllFieldSchemas(schema) {
-		fields[field.GetFieldID()] = field
+		fieldID := field.GetFieldID()
+		if _, ok := existingFields[fieldID]; !ok {
+			continue
+		}
+		col, err := buildSelectedColumn(base, field, selection)
+		if err != nil {
+			releaseArrowArrays(columns)
+			return nil, err
+		}
+		columns[fieldID] = col
 	}
 	return &selectedRecord{
 		base:      base,
-		fields:    fields,
 		selection: selection,
-		columns:   make(map[int64]arrow.Array),
+		columns:   columns,
+	}, nil
+}
+
+func buildSelectedColumn(base storage.Record, field *schemapb.FieldSchema, selection *recordSelection) (arrow.Array, error) {
+	builder := storage.NewRecordBuilder(&schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{field}})
+	defer builder.Release()
+	for _, rowRange := range selection.ranges {
+		if err := builder.Append(base, rowRange.start, rowRange.end); err != nil {
+			return nil, err
+		}
 	}
+	built := builder.Build()
+	defer built.Release()
+	col := built.Column(field.GetFieldID())
+	if col == nil {
+		return nil, merr.WrapErrServiceInternalMsg("selected record field %d not found", field.GetFieldID())
+	}
+	col.Retain()
+	return col, nil
 }
 
 func (r *selectedRecord) Column(fieldID storage.FieldID) arrow.Array {
-	if col, ok := r.columns[fieldID]; ok {
-		return col
-	}
-	field := r.fields[fieldID]
-	if field == nil {
-		return nil
-	}
-	builder := storage.NewRecordBuilder(&schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{field}})
-	defer builder.Release()
-	for _, rowRange := range r.selection.ranges {
-		if err := builder.Append(r.base, rowRange.start, rowRange.end); err != nil {
-			r.err = err
-			return nil
-		}
-	}
-	selected := builder.Build()
-	defer selected.Release()
-	col := selected.Column(fieldID)
-	if col == nil {
-		r.err = merr.WrapErrServiceInternalMsg("selected record field %d not found", fieldID)
-		return nil
-	}
-	col.Retain()
-	r.columns[fieldID] = col
-	return col
+	return r.columns[fieldID]
 }
 
 func (r *selectedRecord) Len() int {
@@ -266,6 +276,12 @@ func (r *selectedRecord) Release() {
 	}
 }
 
+func (r *selectedRecord) cleanupDerived() {
+	r.cleanupOnce.Do(func() {
+		releaseArrowArrays(r.columns)
+	})
+}
+
 type materializedRecordReader struct {
 	base         storage.RecordReader
 	materializer *RecordMaterializer
@@ -283,7 +299,7 @@ func newMaterializedRecordReader(base storage.RecordReader, materializer *Record
 
 func (r *materializedRecordReader) Next() (storage.Record, error) {
 	if r.current != nil {
-		r.current.Release()
+		cleanupMaterializedRecord(r.current)
 		r.current = nil
 	}
 	rec, err := r.base.Next()
@@ -292,13 +308,9 @@ func (r *materializedRecordReader) Next() (storage.Record, error) {
 	}
 	wrapped, err := r.materializer.Wrap(rec)
 	if err != nil {
-		rec.Release()
+		// rec stays owned by the base reader; it is released on its next
+		// Next/Close, never here.
 		return nil, err
-	}
-	if materialized, ok := wrapped.(*materializedRecord); ok {
-		materialized.retainBase()
-	} else {
-		wrapped.Retain()
 	}
 	r.current = wrapped
 	return wrapped, nil
@@ -306,7 +318,7 @@ func (r *materializedRecordReader) Next() (storage.Record, error) {
 
 func (r *materializedRecordReader) Close() error {
 	if r.current != nil {
-		r.current.Release()
+		cleanupMaterializedRecord(r.current)
 		r.current = nil
 	}
 	r.materializer.Close()
@@ -640,10 +652,14 @@ func releaseArrowArrays(arrays map[int64]arrow.Array) {
 	}
 }
 
-func releaseWrappedRecord(wrapped storage.Record, base storage.Record) {
-	if wrapped != base {
-		wrapped.Release()
-		return
+type derivedRecord interface {
+	cleanupDerived()
+}
+
+// cleanupMaterializedRecord releases only the arrays created by materialization
+// or selection. The base record stays borrowed from and owned by its reader.
+func cleanupMaterializedRecord(record storage.Record) {
+	if derived, ok := record.(derivedRecord); ok {
+		derived.cleanupDerived()
 	}
-	base.Release()
 }

--- a/internal/datanode/compactor/record_materializer_test.go
+++ b/internal/datanode/compactor/record_materializer_test.go
@@ -44,18 +44,28 @@ type materializerTestReader struct {
 	records []*materializerTestRecord
 	idx     int
 	closed  bool
+	current *materializerTestRecord
 }
 
 func (r *materializerTestReader) Next() (storage.Record, error) {
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
 	if r.idx >= len(r.records) {
 		return nil, errors.New("no more records")
 	}
 	record := r.records[r.idx]
 	r.idx++
+	r.current = record
 	return record, nil
 }
 
 func (r *materializerTestReader) Close() error {
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
 	r.closed = true
 	return nil
 }
@@ -137,7 +147,8 @@ func TestRecordMaterializerWrapFillsNullableMissingFields(t *testing.T) {
 	require.NotNil(t, column)
 	require.Equal(t, 3, column.Len())
 	require.Equal(t, 3, column.NullN())
-	wrapped.Release()
+	cleanupMaterializedRecord(wrapped)
+	require.Equal(t, 0, record.releaseCount)
 }
 
 func TestRecordMaterializerWrapFillsNullableMissingTextFieldAsBinary(t *testing.T) {
@@ -161,7 +172,8 @@ func TestRecordMaterializerWrapFillsNullableMissingTextFieldAsBinary(t *testing.
 	require.IsType(t, &array.Binary{}, column)
 	require.Equal(t, 3, column.Len())
 	require.Equal(t, 3, column.NullN())
-	wrapped.Release()
+	cleanupMaterializedRecord(wrapped)
+	require.Equal(t, 0, record.releaseCount)
 }
 
 func TestRecordMaterializerWrapWithSelectionMaterializesKeptRowsOnly(t *testing.T) {
@@ -189,17 +201,18 @@ func TestRecordMaterializerWrapWithSelectionMaterializesKeptRowsOnly(t *testing.
 	require.Equal(t, 2, addedColumn.Len())
 	require.Equal(t, 2, addedColumn.NullN())
 
-	wrapped.Release()
-	require.Equal(t, 1, record.releaseCount)
+	cleanupMaterializedRecord(wrapped)
+	require.Equal(t, 0, record.releaseCount)
 }
 
-func TestRecordMaterializerWrapWithSelectionReturnsLazyColumnError(t *testing.T) {
+func TestRecordMaterializerWrapWithSelectionReturnsColumnBuildError(t *testing.T) {
 	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
 		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
 	}}
 	materializer := &RecordMaterializer{
-		schema:        schema,
-		materializers: []FunctionMaterializer{selectedColumnMaterializer{fieldID: 100}},
+		schema:         schema,
+		existingFields: map[int64]struct{}{100: {}},
+		materializers:  []FunctionMaterializer{selectedColumnMaterializer{fieldID: 100}},
 	}
 
 	input := newInt64Array(t, []int64{1, 2})
@@ -210,6 +223,133 @@ func TestRecordMaterializerWrapWithSelectionReturnsLazyColumnError(t *testing.T)
 	wrapped, err := materializer.WrapWithSelection(record, selection)
 	require.Nil(t, wrapped)
 	require.ErrorContains(t, err, "failed to append value")
+	require.Equal(t, 0, record.releaseCount)
+}
+
+func TestRecordMaterializerSelectionColumnsFixedBeforeTimestampOverwrite(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
+	}}
+	materializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	input := newStringArray(t, []string{"drop-0", "keep-1", "drop-2", "keep-3"})
+	defer input.Release()
+	record := &materializerTestRecord{len: 4, columns: map[storage.FieldID]arrow.Array{100: input}}
+	selection := &recordSelection{ranges: []rowRange{{start: 1, end: 2}, {start: 3, end: 4}}, length: 2}
+
+	wrapped, err := materializer.WrapWithSelection(record, selection)
+	require.NoError(t, err)
+
+	// commit-ts wrapper snapshots refcounts via Retain; a writer only pulls
+	// columns afterwards. Every column must exist before the snapshot, or the
+	// late-created ones escape it and get released more than they were retained.
+	selected := wrapped.(*materializedRecord).base.(*selectedRecord)
+	require.Len(t, selected.columns, 1)
+
+	out := overwriteRecordTimestamps(wrapped, 12345)
+	require.NotSame(t, wrapped, out)
+	require.NotNil(t, out.Column(100))
+	require.NotNil(t, out.Column(101))
+	require.Equal(t, 2, out.Column(100).Len())
+
+	out.Release()
+	cleanupMaterializedRecord(wrapped)
+	require.Equal(t, record.retainCount, record.releaseCount)
+}
+
+func TestRecordMaterializerSelectionColumnLifecycleExact(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	original := memory.DefaultAllocator
+	memory.DefaultAllocator = alloc
+	defer func() { memory.DefaultAllocator = original }()
+
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
+	}}
+	materializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	func() {
+		builder := array.NewStringBuilder(alloc)
+		defer builder.Release()
+		builder.AppendValues([]string{"drop-0", "keep-1", "drop-2", "keep-3"}, nil)
+		input := builder.NewStringArray()
+		defer input.Release()
+
+		record := &materializerTestRecord{len: 4, columns: map[storage.FieldID]arrow.Array{100: input}}
+		selection := &recordSelection{ranges: []rowRange{{start: 1, end: 2}, {start: 3, end: 4}}, length: 2}
+
+		wrapped, err := materializer.WrapWithSelection(record, selection)
+		require.NoError(t, err)
+		out := overwriteRecordTimestamps(wrapped, 12345)
+		require.NotNil(t, out.Column(100))
+		require.NotNil(t, out.Column(101))
+		out.Release()
+		cleanupMaterializedRecord(wrapped)
+	}()
+	alloc.AssertSize(t, 0)
+
+	// a mid-build failure (int64 data under a varchar field) must not leak
+	// the partially built selection columns either
+	func() {
+		builder := array.NewInt64Builder(alloc)
+		defer builder.Release()
+		builder.AppendValues([]int64{1, 2}, nil)
+		input := builder.NewInt64Array()
+		defer input.Release()
+
+		record := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{100: input}}
+		selection := &recordSelection{ranges: []rowRange{{start: 0, end: 1}}, length: 1}
+
+		wrapped, err := materializer.WrapWithSelection(record, selection)
+		require.Error(t, err)
+		require.Nil(t, wrapped)
+	}()
+	alloc.AssertSize(t, 0)
+}
+
+func TestRecordMaterializerSelectionPartialBuildFailureReleasesBuiltColumns(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	original := memory.DefaultAllocator
+	memory.DefaultAllocator = alloc
+	defer func() { memory.DefaultAllocator = original }()
+
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "text_ok", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "text_bad", DataType: schemapb.DataType_VarChar},
+	}}
+	materializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}, 101: {}})
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	func() {
+		good := array.NewStringBuilder(alloc)
+		defer good.Release()
+		good.AppendValues([]string{"a", "b"}, nil)
+		goodArr := good.NewStringArray()
+		defer goodArr.Release()
+
+		bad := array.NewInt64Builder(alloc)
+		defer bad.Release()
+		bad.AppendValues([]int64{1, 2}, nil)
+		badArr := bad.NewInt64Array()
+		defer badArr.Release()
+
+		record := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{100: goodArr, 101: badArr}}
+		selection := &recordSelection{ranges: []rowRange{{start: 0, end: 1}}, length: 1}
+
+		// field 100 builds, field 101 fails: the already built column must be
+		// released by the eager constructor's error path
+		wrapped, err := materializer.WrapWithSelection(record, selection)
+		require.Error(t, err)
+		require.Nil(t, wrapped)
+	}()
+	alloc.AssertSize(t, 0)
 }
 
 func TestRecordMaterializerWrapSkipsMissingSystemFields(t *testing.T) {
@@ -237,9 +377,11 @@ func TestRecordMaterializerWrapFailsForMissingNonNullableField(t *testing.T) {
 	require.NoError(t, err)
 	defer materializer.Close()
 
-	_, err = materializer.Wrap(&materializerTestRecord{len: 3})
+	record := &materializerTestRecord{len: 3}
+	_, err = materializer.Wrap(record)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "missing field data required")
+	require.Equal(t, 0, record.releaseCount)
 }
 
 func TestBM25FunctionMaterializerMaterializesSparseOutput(t *testing.T) {
@@ -430,6 +572,39 @@ func TestMaterializedRecordReaderReleasesPreviousRecordOnNextAndClose(t *testing
 	require.NoError(t, reader.Close())
 	require.Equal(t, 1, second.releaseCount)
 	require.True(t, base.closed)
+}
+
+// A consumer that keeps a wrapped record across a reader advance must Retain it;
+// the retained composite stays readable after the reader releases its own base
+// reference and the wrapper cleans its derived arrays, and every reference
+// balances to zero at the end.
+func TestMaterializedRecordReaderRetainedRecordSurvivesAdvance(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "text", DataType: schemapb.DataType_VarChar},
+		{FieldID: 101, Name: "added", DataType: schemapb.DataType_Int64, Nullable: true},
+	}}
+	materializer, err := NewRecordMaterializer(schema, nil, map[int64]struct{}{100: {}})
+	require.NoError(t, err)
+
+	first := &materializerTestRecord{len: 1}
+	second := &materializerTestRecord{len: 1}
+	base := &materializerTestReader{records: []*materializerTestRecord{first, second}}
+	reader := newMaterializedRecordReader(base, materializer)
+
+	retained, err := reader.Next()
+	require.NoError(t, err)
+	retained.Retain()
+
+	_, err = reader.Next()
+	require.NoError(t, err)
+	require.Equal(t, 1, first.releaseCount)
+	require.Equal(t, 1, first.retainCount)
+	require.Equal(t, 1, retained.Column(101).Len())
+
+	retained.Release()
+	require.Equal(t, 2, first.releaseCount)
+	require.NoError(t, reader.Close())
+	require.Equal(t, 1, second.releaseCount)
 }
 
 func materializerBM25Schema() (*schemapb.CollectionSchema, *schemapb.FunctionSchema, *schemapb.FieldSchema, *schemapb.FieldSchema) {
@@ -626,7 +801,7 @@ func TestRecordMaterializerMaterializesBM25AndMinHashOutputs(t *testing.T) {
 
 	wrapped, err := materializer.Wrap(record)
 	require.NoError(t, err)
-	defer wrapped.Release()
+	defer cleanupMaterializedRecord(wrapped)
 
 	require.NotNil(t, wrapped.Column(bm25Output.GetFieldID()))
 	require.NotNil(t, wrapped.Column(minHashOutput.GetFieldID()))

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -268,10 +268,10 @@ func (t *sortCompactionTask) sortSegment(ctx context.Context) (*datapb.Compactio
 		return nil, err
 	}
 	rr = newMaterializedRecordReader(rr, materializer)
-	defer rr.Close()
 	initReaderCost := time.Since(phaseStart)
 
 	rr = wrapReaderWithTimestampOverwrite(rr, t.plan.GetSegmentBinlogs()[0].GetCommitTimestamp())
+	defer rr.Close()
 	rrs := []storage.RecordReader{rr}
 	numValidRows, sortTimings, err := storage.Sort(t.compactionParams.BinLogMaxSize, writerSchema, rrs, srw, predicate, t.sortByFieldIDs)
 	if err != nil {

--- a/internal/datanode/external/function_executor.go
+++ b/internal/datanode/external/function_executor.go
@@ -351,7 +351,6 @@ func streamBatches(
 		}
 
 		batch, err := storage.RecordToInsertData(rec, executionSchema, requiredInputFields)
-		rec.Release()
 		if err != nil {
 			return totalRows, merr.Wrap(err, "record to InsertData")
 		}

--- a/internal/datanode/external/milvus_table_deltalog.go
+++ b/internal/datanode/external/milvus_table_deltalog.go
@@ -490,11 +490,9 @@ func (t *RefreshExternalCollectionTask) loadMilvusTableFragmentSourcePKOffsets(
 			deletedSourcePKKeys,
 			sourcePKOffsets,
 		); err != nil {
-			record.Release()
 			return err
 		}
 		sourceOffset += int64(record.Len())
-		record.Release()
 	}
 	return nil
 }
@@ -572,11 +570,9 @@ func (t *RefreshExternalCollectionTask) loadMilvusTableSourceDeltalogDeletes(
 			deletedSourcePKKeys,
 			&deletes.events,
 		); err != nil {
-			record.Release()
 			_ = reader.Close()
 			return milvusTableSourceDeltalogDeletes{}, nil, err
 		}
-		record.Release()
 	}
 	if err := reader.Close(); err != nil {
 		return milvusTableSourceDeltalogDeletes{}, nil, err

--- a/internal/datanode/external/milvus_table_deltalog_test.go
+++ b/internal/datanode/external/milvus_table_deltalog_test.go
@@ -46,9 +46,14 @@ type fakeMilvusTableDeltalogReader struct {
 	nextErr  error
 	closeErr error
 	next     int
+	current  storage.Record
 }
 
 func (r *fakeMilvusTableDeltalogReader) Next() (storage.Record, error) {
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
 	if r.nextErr != nil {
 		return nil, r.nextErr
 	}
@@ -57,10 +62,15 @@ func (r *fakeMilvusTableDeltalogReader) Next() (storage.Record, error) {
 	}
 	record := r.records[r.next]
 	r.next++
+	r.current = record
 	return record, nil
 }
 
 func (r *fakeMilvusTableDeltalogReader) Close() error {
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
 	return r.closeErr
 }
 
@@ -1322,15 +1332,12 @@ func readInt64Deltalog(t *testing.T, storageConfig *indexpb.StorageConfig, path 
 		if err != nil {
 			t.Fatalf("read deltalog: %v", err)
 		}
-		func() {
-			defer record.Release()
-			pkColumn := record.Column(0).(*array.Int64)
-			tsColumn := record.Column(common.TimeStampField).(*array.Int64)
-			for i := 0; i < record.Len(); i++ {
-				pks = append(pks, pkColumn.Value(i))
-				tss = append(tss, tsColumn.Value(i))
-			}
-		}()
+		pkColumn := record.Column(0).(*array.Int64)
+		tsColumn := record.Column(common.TimeStampField).(*array.Int64)
+		for i := 0; i < record.Len(); i++ {
+			pks = append(pks, pkColumn.Value(i))
+			tss = append(tss, tsColumn.Value(i))
+		}
 	}
 	return pks, tss
 }

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -65,9 +65,14 @@ type fakeRecordReader struct {
 	records []storage.Record
 	errs    []error
 	idx     int
+	current storage.Record
 }
 
 func (r *fakeRecordReader) Next() (storage.Record, error) {
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
 	if r.idx < len(r.errs) && r.errs[r.idx] != nil {
 		err := r.errs[r.idx]
 		r.idx++
@@ -78,10 +83,15 @@ func (r *fakeRecordReader) Next() (storage.Record, error) {
 	}
 	record := r.records[r.idx]
 	r.idx++
+	r.current = record
 	return record, nil
 }
 
 func (r *fakeRecordReader) Close() error {
+	if r.current != nil {
+		r.current.Release()
+		r.current = nil
+	}
 	return nil
 }
 

--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -394,6 +394,11 @@ func (b *RecordBuilder) Build() Record {
 	}
 
 	rec := NewSimpleArrowRecord(array.NewRecord(arrow.NewSchema(fields, nil), arrays, int64(b.nRows)), field2Col)
+	// NewRecord retained every column; drop the builder-side creator refs so the
+	// record is the sole owner and columns can actually reach refcount zero.
+	for _, arr := range arrays {
+		arr.Release()
+	}
 	b.nRows = 0
 	b.size = 0
 	return rec

--- a/internal/storage/arrow_util_test.go
+++ b/internal/storage/arrow_util_test.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -333,4 +335,47 @@ func TestRecordBuilderNullableDenseVectorPreservesDimMetadata(t *testing.T) {
 	dim, ok := field.Metadata.GetValue("dim")
 	assert.True(t, ok)
 	assert.Equal(t, "4", dim)
+}
+
+func TestRecordBuilderBuildReleasesCreatorRefs(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	original := memory.DefaultAllocator
+	memory.DefaultAllocator = alloc
+	defer func() { memory.DefaultAllocator = original }()
+
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+		{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+	}}
+
+	func() {
+		ints := array.NewInt64Builder(alloc)
+		defer ints.Release()
+		ints.AppendValues([]int64{1, 2, 3}, nil)
+		intArr := ints.NewInt64Array()
+		defer intArr.Release()
+		strs := array.NewStringBuilder(alloc)
+		defer strs.Release()
+		strs.AppendValues([]string{"a", "b", "c"}, nil)
+		strArr := strs.NewStringArray()
+		defer strArr.Release()
+
+		src := NewSimpleArrowRecord(array.NewRecord(arrow.NewSchema([]arrow.Field{
+			{Name: "pk", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "text", Type: arrow.BinaryTypes.String},
+		}, nil), []arrow.Array{intArr, strArr}, 3), map[FieldID]int{100: 0, 101: 1})
+		defer src.Release()
+
+		rb := NewRecordBuilder(schema)
+		defer rb.Release()
+		require.NoError(t, rb.Append(src, 0, 3))
+
+		// Build hands back the sole owner of its columns: a single Release
+		// must return every column buffer to the allocator.
+		rec := rb.Build()
+		require.Equal(t, 3, rec.Column(100).Len())
+		require.Equal(t, 3, rec.Column(101).Len())
+		rec.Release()
+	}()
+	alloc.AssertSize(t, 0)
 }

--- a/internal/storage/data_codec.go
+++ b/internal/storage/data_codec.go
@@ -1025,7 +1025,6 @@ func (deleteCodec *DeleteCodec) Deserialize(blobs []*Blob) (partitionID UniqueID
 
 		handleRecord := func() error {
 			rec := rr.Record()
-			defer rec.Release()
 			column := rec.Column(0)
 			for i := 0; i < column.Len(); i++ {
 				strVal := column.ValueStr(i)

--- a/internal/storage/payload_test.go
+++ b/internal/storage/payload_test.go
@@ -3084,7 +3084,6 @@ func TestArrowRecordReader(t *testing.T) {
 		for rr.Next() {
 			rec := rr.Record()
 			arr := rec.Column(0).(*array.String)
-			defer rec.Release()
 
 			assert.Equal(t, "hello0", arr.Value(0))
 			assert.Equal(t, "hello1", arr.Value(1))
@@ -3194,7 +3193,6 @@ func BenchmarkArrowRecordReader(b *testing.B) {
 		for rr.Next() {
 			rec := rr.Record()
 			arr := rec.Column(0).(*array.String)
-			defer rec.Release()
 			for i := 0; i < arr.Len(); i++ {
 				assert.Equal(b, 20, len(arr.Value(i)))
 			}

--- a/internal/storage/record_reader.go
+++ b/internal/storage/record_reader.go
@@ -17,6 +17,8 @@ import (
 )
 
 type RecordReader interface {
+	// Next returns a record borrowed from the reader and valid until the next
+	// Next or Close. Callers retaining it longer must Retain and Release it.
 	Next() (Record, error)
 	Close() error
 }
@@ -402,15 +404,18 @@ func (mr *ManifestReader) Close() error {
 type ChunkedBlobsReader func() ([]*Blob, error)
 
 type CompositeBinlogRecordReader struct {
-	fields map[FieldID]*schemapb.FieldSchema
-	index  map[FieldID]int16
-	brs    []*BinlogReader
-	rrs    []array.RecordReader
+	fields  map[FieldID]*schemapb.FieldSchema
+	index   map[FieldID]int16
+	brs     []*BinlogReader
+	rrs     []array.RecordReader
+	current Record
 }
 
 var _ RecordReader = (*CompositeBinlogRecordReader)(nil)
 
 func (crr *CompositeBinlogRecordReader) Next() (Record, error) {
+	crr.releaseCurrent()
+
 	recs := make([]arrow.Array, len(crr.fields))
 	releaseRecsOnError := true
 	defer func() {
@@ -452,13 +457,16 @@ func (crr *CompositeBinlogRecordReader) Next() (Record, error) {
 		recs[crr.index[f.FieldID]] = arr
 	}
 	releaseRecsOnError = false
-	return &compositeRecord{
+	crr.current = &compositeRecord{
 		index: crr.index,
 		recs:  recs,
-	}, nil
+	}
+	return crr.current, nil
 }
 
 func (crr *CompositeBinlogRecordReader) Close() error {
+	crr.releaseCurrent()
+
 	if crr.brs != nil {
 		for _, er := range crr.brs {
 			if er != nil {
@@ -474,4 +482,11 @@ func (crr *CompositeBinlogRecordReader) Close() error {
 		}
 	}
 	return nil
+}
+
+func (crr *CompositeBinlogRecordReader) releaseCurrent() {
+	if crr.current != nil {
+		crr.current.Release()
+		crr.current = nil
+	}
 }

--- a/internal/storage/record_reader_test.go
+++ b/internal/storage/record_reader_test.go
@@ -20,8 +20,14 @@ import (
 	"io"
 	"testing"
 
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
 // exhaustedChunkReader is a minimal RecordReader that is already at EOF and
@@ -98,5 +104,40 @@ func TestPackedRecordReader_CloseNilReceiverDoesNotPanic(t *testing.T) {
 	var rr RecordReader = pr
 	assert.NotPanics(t, func() {
 		assert.NoError(t, rr.Close())
+	})
+}
+
+func TestCompositeBinlogRecordReaderOwnsCurrentRecord(t *testing.T) {
+	newCurrent := func(allocator *memory.CheckedAllocator) Record {
+		builder := array.NewInt64Builder(allocator)
+		builder.Append(1)
+		column := builder.NewArray()
+		builder.Release()
+		return &compositeRecord{
+			index: map[FieldID]int16{100: 0},
+			recs:  []arrow.Array{column},
+		}
+	}
+
+	t.Run("next releases previous current", func(t *testing.T) {
+		allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+		reader := &CompositeBinlogRecordReader{
+			fields:  map[FieldID]*schemapb.FieldSchema{},
+			index:   map[FieldID]int16{},
+			current: newCurrent(allocator),
+		}
+
+		_, err := reader.Next()
+		require.NoError(t, err)
+		allocator.AssertSize(t, 0)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("close releases current", func(t *testing.T) {
+		allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+		reader := &CompositeBinlogRecordReader{current: newCurrent(allocator)}
+
+		require.NoError(t, reader.Close())
+		allocator.AssertSize(t, 0)
 	})
 }

--- a/internal/storage/serde_delta.go
+++ b/internal/storage/serde_delta.go
@@ -189,13 +189,12 @@ type simpleArrowRecordReader struct {
 	blobPos int
 	rr      array.RecordReader
 	closer  func()
-
-	r simpleArrowRecord
 }
 
 func (crr *simpleArrowRecordReader) iterateNextBatch() error {
 	if crr.closer != nil {
 		crr.closer()
+		crr.closer = nil
 	}
 
 	crr.blobPos++
@@ -232,35 +231,37 @@ func (crr *simpleArrowRecordReader) Next() (Record, error) {
 			return nil, io.EOF
 		}
 		crr.blobPos = -1
-		crr.r = simpleArrowRecord{
-			field2Col: make(map[FieldID]int),
-		}
 		if err := crr.iterateNextBatch(); err != nil {
 			return nil, err
 		}
 	}
 
-	composeRecord := func() bool {
+	// a fresh wrapper per batch: a Retain()ed record must stay valid across Next()
+	composeRecord := func() (Record, bool) {
 		if ok := crr.rr.Next(); !ok {
-			return false
+			return nil, false
 		}
 		record := crr.rr.Record()
+		field2Col := make(map[FieldID]int, len(record.Schema().Fields()))
 		for i := range record.Schema().Fields() {
-			crr.r.field2Col[FieldID(i)] = i
+			field2Col[FieldID(i)] = i
 		}
-		crr.r.r = record
-		return true
+		return NewSimpleArrowRecord(record, field2Col), true
 	}
 
-	if ok := composeRecord(); !ok {
+	for {
+		if rec, ok := composeRecord(); ok {
+			return rec, nil
+		}
+		// Next()==false means either batch exhaustion or a read error;
+		// pqarrow stores io.EOF in Err() on normal exhaustion
+		if err := crr.rr.Err(); err != nil && err != io.EOF {
+			return nil, merr.WrapErrDataIntegrity(err, "read deltalog record batch")
+		}
 		if err := crr.iterateNextBatch(); err != nil {
 			return nil, err
 		}
-		if ok := composeRecord(); !ok {
-			return nil, io.EOF
-		}
 	}
-	return &crr.r, nil
 }
 
 func (crr *simpleArrowRecordReader) SetNeededFields(_ typeutil.Set[int64]) {
@@ -270,6 +271,7 @@ func (crr *simpleArrowRecordReader) SetNeededFields(_ typeutil.Set[int64]) {
 func (crr *simpleArrowRecordReader) Close() error {
 	if crr.closer != nil {
 		crr.closer()
+		crr.closer = nil
 	}
 	return nil
 }

--- a/internal/storage/serde_delta_test.go
+++ b/internal/storage/serde_delta_test.go
@@ -18,12 +18,16 @@ package storage
 
 import (
 	"context"
+	"io"
 	"testing"
 
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -143,6 +147,106 @@ func TestDeltalogReaderWriter(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func makeParquetDeltalogBlob(t *testing.T, startPk int64, numRows int) *Blob {
+	writer, finalizer, err := createDeltalogWriter(1, 2, 3, schemapb.DataType_Int64, 1024)
+	require.NoError(t, err)
+	for i := int64(0); i < int64(numRows); i++ {
+		require.NoError(t, writer.WriteValue(NewDeleteLog(NewInt64PrimaryKey(startPk+i), uint64(100+i))))
+	}
+	require.NoError(t, writer.Close())
+	blob, err := finalizer()
+	require.NoError(t, err)
+	return blob
+}
+
+func TestSimpleArrowRecordReaderRetainAcrossNext(t *testing.T) {
+	originalFormat := paramtable.Get().DataNodeCfg.DeltalogFormat.GetValue()
+	paramtable.Get().Save(paramtable.Get().DataNodeCfg.DeltalogFormat.Key, "parquet")
+	defer paramtable.Get().Save(paramtable.Get().DataNodeCfg.DeltalogFormat.Key, originalFormat)
+
+	blobs := []*Blob{makeParquetDeltalogBlob(t, 0, 10), makeParquetDeltalogBlob(t, 1000, 10)}
+
+	reader, err := newSimpleArrowRecordReader(blobs)
+	require.NoError(t, err)
+
+	rec1, err := reader.Next()
+	require.NoError(t, err)
+	rec1.Retain()
+	require.Equal(t, 10, rec1.Len())
+	require.Equal(t, int64(0), rec1.Column(0).(*array.Int64).Value(0))
+
+	// cross-blob advance must not invalidate or mutate the retained record
+	rec2, err := reader.Next()
+	require.NoError(t, err)
+	require.NotSame(t, rec1, rec2)
+	require.Equal(t, int64(1000), rec2.Column(0).(*array.Int64).Value(0))
+	require.Equal(t, 10, rec1.Len())
+	require.Equal(t, int64(0), rec1.Column(0).(*array.Int64).Value(0))
+	require.Equal(t, int64(9), rec1.Column(0).(*array.Int64).Value(9))
+	rec1.Release()
+
+	_, err = reader.Next()
+	require.ErrorIs(t, err, io.EOF)
+	require.NoError(t, reader.Close())
+	// Close after EOF must not double-release
+	require.NoError(t, reader.Close())
+}
+
+func TestSimpleArrowRecordReaderEmptyMiddleBlob(t *testing.T) {
+	originalFormat := paramtable.Get().DataNodeCfg.DeltalogFormat.GetValue()
+	paramtable.Get().Save(paramtable.Get().DataNodeCfg.DeltalogFormat.Key, "parquet")
+	defer paramtable.Get().Save(paramtable.Get().DataNodeCfg.DeltalogFormat.Key, originalFormat)
+
+	blobs := []*Blob{
+		makeParquetDeltalogBlob(t, 0, 10),
+		makeParquetDeltalogBlob(t, 0, 0),
+		makeParquetDeltalogBlob(t, 1000, 10),
+	}
+
+	reader, err := newSimpleArrowRecordReader(blobs)
+	require.NoError(t, err)
+
+	pks := make([]int64, 0, 20)
+	for {
+		rec, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		col := rec.Column(0).(*array.Int64)
+		for i := 0; i < rec.Len(); i++ {
+			pks = append(pks, col.Value(i))
+		}
+	}
+	require.Len(t, pks, 20)
+	require.Equal(t, int64(0), pks[0])
+	require.Equal(t, int64(9), pks[9])
+	require.Equal(t, int64(1000), pks[10])
+	require.Equal(t, int64(1009), pks[19])
+	require.NoError(t, reader.Close())
+}
+
+type erroringRecordReader struct {
+	err error
+}
+
+func (e *erroringRecordReader) Retain()               {}
+func (e *erroringRecordReader) Release()              {}
+func (e *erroringRecordReader) Schema() *arrow.Schema { return nil }
+func (e *erroringRecordReader) Next() bool            { return false }
+func (e *erroringRecordReader) Record() arrow.Record  { return nil }
+func (e *erroringRecordReader) Err() error            { return e.err }
+
+func TestSimpleArrowRecordReaderSurfacesReadError(t *testing.T) {
+	// a mid-stream read error must surface as a data-integrity failure,
+	// not be swallowed as batch exhaustion
+	reader := &simpleArrowRecordReader{rr: &erroringRecordReader{err: io.ErrUnexpectedEOF}}
+	_, err := reader.Next()
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.ErrorIs(t, err, merr.ErrDataIntegrity)
+	require.NoError(t, reader.Close())
 }
 
 func TestDeltalogStreamWriter_NoRecordWriter(t *testing.T) {

--- a/internal/storage/serde_events_test.go
+++ b/internal/storage/serde_events_test.go
@@ -143,7 +143,6 @@ func TestBinlogStreamWriter(t *testing.T) {
 		ok := rr.Next()
 		assert.True(t, ok)
 		rec := rr.Record()
-		defer rec.Release()
 		assert.Equal(t, int64(size), rec.NumRows())
 		ok = rr.Next()
 		assert.False(t, ok)


### PR DESCRIPTION
Cherry-pick of #51884 to 3.0. Clean pick — identical patch-id with the master commit.

Unifies all `RecordReader` implementations on a single borrow contract: records returned by `Next()` are reader-owned and valid until the next `Next()`/`Close()`; callers that need a record longer must `Retain()` it.

- storage: V1 `CompositeBinlogRecordReader` holds and releases its current record, mirroring the packed/manifest readers; `simpleArrowRecordReader` returns a fresh wrapper per batch (a retained record survives advance), makes the per-blob closer idempotent, surfaces mid-stream read errors via `rr.Err()`, and advances across empty blobs instead of returning premature EOF
- compactor: the record materializer releases only its derived arrays through an idempotent cleanup channel, never the borrowed base record
- consumers: bump/mix/DeleteCodec/external paths stop releasing reader-owned records; cross-batch holders keep explicit `Retain`/`Release`
- tests: refcount and lifecycle unit tests for both readers; suites verified under `-tags dynamic,test,assert` on master

issue: #51649
pr: #51884

🤖 Generated with [Claude Code](https://claude.com/claude-code)