### PR TITLE
fix: make reopen metadata updates retryable

### DIFF
--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -222,13 +222,23 @@ func (ex *Executor) executeSegmentAction(task *SegmentTask, step int) {
 // not really executes the request
 func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	action := task.Actions()[step].(*SegmentAction)
-	defer action.rpcReturned.Store(true)
+	markRPCReturned := true
+	defer func() {
+		if markRPCReturned {
+			action.rpcReturned.Store(true)
+		}
+	}()
 	ctx := task.Context()
 
 	var err error
 	defer func() {
 		if err != nil {
-			task.Fail(err)
+			if errors.Is(err, merr.ErrCollectionSchemaVersionNotReady) {
+				markRPCReturned = false
+				task.SetReason(err.Error())
+			} else {
+				task.Fail(err)
+			}
 		}
 		ex.removeTask(task, step)
 	}()
@@ -278,7 +288,11 @@ func (ex *Executor) loadSegment(task *SegmentTask, step int) error {
 	status, err := ex.cluster.LoadSegments(task.Context(), view.Node, req)
 	err = merr.CheckRPCCall(status, err)
 	if err != nil {
-		mlog.Warn(context.TODO(), "failed to load segment", mlog.Err(err))
+		if errors.Is(err, merr.ErrCollectionSchemaVersionNotReady) {
+			mlog.Info(ctx, "load segment waits for delegator schema version", mlog.Err(err))
+		} else {
+			mlog.Warn(ctx, "failed to load segment", mlog.Err(err))
+		}
 		return err
 	}
 

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -181,6 +181,7 @@ func (suite *TaskSuite) BeforeTest(suiteName, testName string) {
 		"TestLoadSegmentTask",
 		"TestLoadSegmentTaskNotIndex",
 		"TestSegmentTaskWaitsDistAfterLoadRPC",
+		"TestLoadSegmentTaskWaitsDelegatorSchema",
 		"TestLoadSegmentTaskFailed",
 		"TestTaskCanceled",
 		"TestMoveSegmentTask",
@@ -637,6 +638,86 @@ func (suite *TaskSuite) TestLoadSegmentTaskNotIndex() {
 		suite.Equal(TaskStatusSucceeded, task.Status())
 		suite.NoError(task.Err())
 	}
+}
+
+func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
+	ctx := context.Background()
+	timeout := 10 * time.Second
+	targetNode := int64(3)
+	partition := int64(100)
+	segment := suite.loadSegments[0]
+	channel := &datapb.VchannelInfo{
+		CollectionID: suite.collection,
+		ChannelName:  Params.CommonCfg.RootCoordDml.GetValue() + "-test",
+	}
+
+	suite.broker.EXPECT().DescribeCollection(mock.Anything, suite.collection).RunAndReturn(func(ctx context.Context, i int64) (*milvuspb.DescribeCollectionResponse, error) {
+		return &milvuspb.DescribeCollectionResponse{
+			Schema: &schemapb.CollectionSchema{
+				Name:    "TestLoadSegmentTaskWaitsDelegatorSchema",
+				Version: 1,
+				Fields: []*schemapb.FieldSchema{
+					{FieldID: 100, Name: "vec", DataType: schemapb.DataType_FloatVector},
+				},
+			},
+		}, nil
+	})
+	suite.broker.EXPECT().ListIndexes(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
+		{
+			CollectionID: suite.collection,
+		},
+	}, nil)
+	suite.broker.EXPECT().GetSegmentInfo(mock.Anything, segment).Return([]*datapb.SegmentInfo{
+		{
+			ID:            segment,
+			CollectionID:  suite.collection,
+			PartitionID:   partition,
+			InsertChannel: channel.ChannelName,
+		},
+	}, nil)
+	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil)
+	schemaErr := merr.WrapErrCollectionSchemaVersionNotReadyWithVersion("TestLoadSegmentTaskWaitsDelegatorSchema", 0, 1)
+	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Status(schemaErr), nil).Once()
+
+	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
+		VchannelInfo: channel,
+		Node:         targetNode,
+		Version:      1,
+		View: &meta.LeaderView{
+			ID:           targetNode,
+			CollectionID: suite.collection,
+			Channel:      channel.ChannelName,
+			Status:       &querypb.LeaderViewStatus{Serviceable: true},
+		},
+	})
+	task, err := NewSegmentTask(
+		ctx,
+		timeout,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(targetNode, ActionTypeGrow, channel.GetChannelName(), segment),
+	)
+	suite.NoError(err)
+	suite.NoError(suite.scheduler.Add(task))
+
+	segments := []*datapb.SegmentInfo{{
+		ID:            segment,
+		InsertChannel: channel.ChannelName,
+		PartitionID:   1,
+	}}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, suite.collection).Return([]*datapb.VchannelInfo{channel}, segments, nil)
+	suite.target.UpdateCollectionNextTarget(ctx, suite.collection)
+	suite.AssertTaskNum(0, 1, 0, 1)
+
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(1, 0, 0, 1)
+	suite.Equal(TaskStatusStarted, task.Status())
+	suite.NoError(task.Err())
+	suite.Contains(task.GetReason(), "collection schema version not ready")
+	action := task.Actions()[0].(*SegmentAction)
+	suite.False(action.rpcReturned.Load())
 }
 
 func (suite *TaskSuite) TestLoadSegmentTaskFailed() {

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -661,12 +661,12 @@ func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
 				},
 			},
 		}, nil
-	})
+	}).Twice()
 	suite.broker.EXPECT().ListIndexes(mock.Anything, suite.collection).Return([]*indexpb.IndexInfo{
 		{
 			CollectionID: suite.collection,
 		},
-	}, nil)
+	}, nil).Twice()
 	suite.broker.EXPECT().GetSegmentInfo(mock.Anything, segment).Return([]*datapb.SegmentInfo{
 		{
 			ID:            segment,
@@ -674,10 +674,11 @@ func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
 			PartitionID:   partition,
 			InsertChannel: channel.ChannelName,
 		},
-	}, nil)
-	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil)
+	}, nil).Twice()
+	suite.broker.EXPECT().GetIndexInfo(mock.Anything, suite.collection, segment).Return(nil, nil).Twice()
 	schemaErr := merr.WrapErrCollectionSchemaVersionNotReadyWithVersion("TestLoadSegmentTaskWaitsDelegatorSchema", 0, 1)
 	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Status(schemaErr), nil).Once()
+	suite.cluster.EXPECT().LoadSegments(mock.Anything, targetNode, mock.Anything).Return(merr.Success(), nil).Once()
 
 	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
 		VchannelInfo: channel,
@@ -718,6 +719,37 @@ func (suite *TaskSuite) TestLoadSegmentTaskWaitsDelegatorSchema() {
 	suite.Contains(task.GetReason(), "collection schema version not ready")
 	action := task.Actions()[0].(*SegmentAction)
 	suite.False(action.rpcReturned.Load())
+
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(1, 0, 0, 1)
+	suite.Equal(TaskStatusStarted, task.Status())
+	suite.NoError(task.Err())
+	suite.True(action.rpcReturned.Load())
+
+	view := &meta.LeaderView{
+		ID:           targetNode,
+		CollectionID: suite.collection,
+		Segments: map[int64]*querypb.SegmentDist{
+			segment: {NodeID: targetNode, Version: 0},
+		},
+		Channel: channel.ChannelName,
+	}
+	suite.dist.SegmentDistManager.Update(targetNode, meta.SegmentFromInfo(&datapb.SegmentInfo{
+		ID:            segment,
+		CollectionID:  suite.collection,
+		PartitionID:   partition,
+		InsertChannel: channel.ChannelName,
+	}))
+	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
+		VchannelInfo: channel,
+		Node:         targetNode,
+		Version:      1,
+		View:         view,
+	})
+	suite.dispatchAndWait(targetNode)
+	suite.AssertTaskNum(0, 0, 0, 0)
+	suite.Equal(TaskStatusSucceeded, task.Status())
+	suite.NoError(task.Err())
 }
 
 func (suite *TaskSuite) TestLoadSegmentTaskFailed() {

--- a/internal/querycoordv2/task/utils.go
+++ b/internal/querycoordv2/task/utils.go
@@ -191,8 +191,8 @@ func packLoadMeta(loadType querypb.LoadType, collectionInfo *milvuspb.DescribeCo
 		DbName:        collectionInfo.GetDbName(),
 		ResourceGroup: resourceGroup,
 		LoadFields:    loadFields,
-		// The update timestamp is a load barrier, not the logical schema version.
-		// QueryNode uses it only to reject stale load results after schema changes.
+		// Keep the collection update timestamp in load meta for compatibility.
+		// Delegator load freshness is gated by the request schema version.
 		SchemaBarrierTs: collectionInfo.GetUpdateTimestamp(),
 	}
 }

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -135,6 +135,11 @@ type idfOracleHolder struct {
 	oracle IDFOracle
 }
 
+type delegatorSchemaView struct {
+	schema  *schemapb.CollectionSchema
+	version uint64
+}
+
 // shardDelegator maintains the shard distribution and streaming part of the data.
 type shardDelegator struct {
 	// shard information attributes
@@ -178,9 +183,10 @@ type shardDelegator struct {
 	// current forward policy
 	l0ForwardPolicy string
 
-	// schemaBarrierTs fences load results started before the latest schema update.
+	// schemaView is the delegator's WAL-driven schema snapshot. Load requests
+	// may require a matching version, but must never advance this view.
 	schemaChangeMutex sync.RWMutex
-	schemaBarrierTs   uint64
+	schemaView        delegatorSchemaView
 
 	// limits delegator-side post-load work after worker LoadSegments returns.
 	postLoadSem           *syncutil.Semaphore
@@ -203,6 +209,63 @@ type shardDelegator struct {
 	growingSourceProvider     *delegatorGrowingSourceProvider
 
 	leaderViewUpdatedCallback func(channel string)
+}
+
+func newDelegatorSchemaView(schema *schemapb.CollectionSchema) delegatorSchemaView {
+	if schema == nil {
+		return delegatorSchemaView{}
+	}
+	return delegatorSchemaView{
+		schema:  typeutil.Clone(schema),
+		version: uint64(schema.GetVersion()),
+	}
+}
+
+func (sd *shardDelegator) ensureDelegatorSchemaViewLocked() {
+	if sd.schemaView.schema != nil || sd.collection == nil {
+		return
+	}
+	schema, version := sd.collection.SchemaAndVersion()
+	if schema == nil {
+		return
+	}
+	sd.schemaView = delegatorSchemaView{
+		schema:  typeutil.Clone(schema),
+		version: version,
+	}
+}
+
+func (sd *shardDelegator) delegatorSchemaSnapshot() (*schemapb.CollectionSchema, uint64) {
+	sd.schemaChangeMutex.RLock()
+	schema, version := sd.delegatorSchemaSnapshotLocked()
+	sd.schemaChangeMutex.RUnlock()
+	if schema != nil {
+		return schema, version
+	}
+
+	sd.schemaChangeMutex.Lock()
+	defer sd.schemaChangeMutex.Unlock()
+	sd.ensureDelegatorSchemaViewLocked()
+	return sd.delegatorSchemaSnapshotLocked()
+}
+
+func (sd *shardDelegator) delegatorSchemaSnapshotLocked() (*schemapb.CollectionSchema, uint64) {
+	if sd.schemaView.schema == nil {
+		return nil, 0
+	}
+	return typeutil.Clone(sd.schemaView.schema), sd.schemaView.version
+}
+
+func (sd *shardDelegator) shouldUpdateDelegatorSchemaLocked(schema *schemapb.CollectionSchema) bool {
+	if schema == nil {
+		return false
+	}
+	sd.ensureDelegatorSchemaViewLocked()
+	return uint64(schema.GetVersion()) > sd.schemaView.version
+}
+
+func (sd *shardDelegator) publishDelegatorSchemaLocked(schema *schemapb.CollectionSchema) {
+	sd.schemaView = newDelegatorSchemaView(schema)
 }
 
 // getLogger returns the logger with pre-defined shard attributes.
@@ -1274,25 +1337,19 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 	sd.schemaChangeMutex.Lock()
 	defer sd.schemaChangeMutex.Unlock()
 
-	if !segments.ShouldUpdateCollectionSchema(sd.collection, schema, schemaBarrierTs) {
+	if !sd.shouldUpdateDelegatorSchemaLocked(schema) {
 		mlog.Info(ctx, "delegator skip stale or no-op schema event",
 			mlog.Uint64("schemaVersion", schemaVersion),
 			mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
 		)
 		return nil
 	}
-	oldSet := newBM25FunctionSet(sd.collection.Schema())
+	oldSchema := sd.schemaView.schema
+	oldSet := newBM25FunctionSet(oldSchema)
 	newSet := newBM25FunctionSet(schema)
 	idfOracle := sd.getIDFOracle()
 	if idfOracle != nil && newSet.HasIncompatibleCommonFunction(oldSet) {
 		return merr.WrapErrServiceInternal("unsupported incompatible BM25 function schema change on loaded collection")
-	}
-
-	// Keep the load barrier monotonic. A higher logical schema version can be
-	// replayed with a smaller barrier than an earlier same-version property
-	// refresh, but that must not reopen older load results.
-	if sd.schemaBarrierTs < schemaBarrierTs {
-		sd.schemaBarrierTs = schemaBarrierTs
 	}
 
 	sealed, growing, version := sd.distribution.PinOnlineSegments()
@@ -1309,9 +1366,9 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 		),
 		CollectionID: sd.collectionID,
 		Schema:       schema,
-		// SchemaBarrierTs fences stale load results and lets QueryNode refresh
-		// same-version schema payloads such as collection properties. Logical
-		// schema freshness is still guarded by schema.version in collectionManager.
+		// Keep sending SchemaBarrierTs to workers and the collection manager for
+		// same-version schema payloads such as collection properties. Delegator
+		// load freshness is gated by schema.Version, not this timestamp.
 		SchemaBarrierTs: schemaBarrierTs,
 	},
 		sealed,
@@ -1364,10 +1421,11 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 			return err
 		}
 	}
+	sd.publishDelegatorSchemaLocked(schema)
 	mlog.Info(ctx, "delegator finished update schema event",
 		mlog.Uint64("schemaVersion", schemaVersion),
 		mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
-		mlog.Uint64("loadBarrierTs", sd.schemaBarrierTs),
+		mlog.Uint64("delegatorSchemaVersion", sd.schemaView.version),
 		mlog.Int("sealedNum", len(sealed)),
 		mlog.Int("growingNum", len(growing)),
 		mlog.Int("bm25FunctionNum", len(newSet)),
@@ -1520,6 +1578,7 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		vchannelName:      channel,
 		version:           version,
 		collection:        collection,
+		schemaView:        newDelegatorSchemaView(collection.Schema()),
 		collectionManager: manager.Collection,
 		segmentManager:    manager.Segment,
 		workerManager:     workerManager,

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -964,6 +964,7 @@ type subTask[T any] struct {
 	req      T
 	targetID int64
 	worker   cluster.Worker
+	err      error
 }
 
 func organizeSubTask[T any](ctx context.Context,
@@ -1001,6 +1002,7 @@ func organizeSubTask[T any](ctx context.Context,
 			req:      req,
 			targetID: workerID,
 			worker:   worker,
+			err:      err,
 		})
 		return nil
 	}
@@ -1045,14 +1047,20 @@ func executeSubTasks[T any, R interface {
 		wg.Go(func() error {
 			var result R
 			var err error
-			if task.targetID == -1 || task.worker == nil {
+			if task.err != nil {
+				err = task.err
+			} else if task.targetID == -1 || task.worker == nil {
 				var segments []int64
 				if req, ok := any(task.req).(interface{ GetSegmentIDs() []int64 }); ok {
 					segments = req.GetSegmentIDs()
 				} else {
 					segments = []int64{}
 				}
-				err = merr.WrapErrServiceInternalMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				if taskType == "UpdateSchema" {
+					err = merr.WrapErrServiceUnavailableMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				} else {
+					err = merr.WrapErrServiceInternalMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				}
 			} else {
 				result, err = execute(ctx, task.req, task.worker)
 				if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
@@ -1323,7 +1331,7 @@ func (sd *shardDelegator) CatchingUpStreamingData() bool {
 
 func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
 	log := sd.getLogger(ctx)
-	if err := sd.lifetime.Add(sd.IsWorking); err != nil {
+	if err := sd.lifetime.Add(sd.NotStopped); err != nil {
 		return err
 	}
 	defer sd.lifetime.Done()

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1553,11 +1553,12 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	if collection == nil {
 		return nil, merr.WrapErrCollectionNotFound(collectionID, "not in delegator manager")
 	}
-	if err := function.GetManager().Alloc(collectionID, delegatorFunctionRunnerKey(channel), collection.Schema()); err != nil {
+	collectionSchema, _, _ := collection.SchemaSnapshot()
+	if err := function.GetManager().Alloc(collectionID, delegatorFunctionRunnerKey(channel), collectionSchema); err != nil {
 		return nil, err
 	}
 
-	skipStreamingForExternalTable := typeutil.IsExternalCollection(collection.Schema())
+	skipStreamingForExternalTable := typeutil.IsExternalCollection(collectionSchema)
 	catchingUpStreamingData := !skipStreamingForExternalTable
 	if skipStreamingForExternalTable {
 		log.Info(ctx, "skip streaming data catchup for read-only external collection",
@@ -1586,7 +1587,7 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		vchannelName:      channel,
 		version:           version,
 		collection:        collection,
-		schemaView:        newDelegatorSchemaView(collection.Schema()),
+		schemaView:        newDelegatorSchemaView(collectionSchema),
 		collectionManager: manager.Collection,
 		segmentManager:    manager.Segment,
 		workerManager:     workerManager,
@@ -1611,12 +1612,12 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		opt(sd)
 	}
 
-	hasBM25Field := lo.ContainsBy(collection.Schema().GetFunctions(), func(tf *schemapb.FunctionSchema) bool {
+	hasBM25Field := lo.ContainsBy(collectionSchema.GetFunctions(), func(tf *schemapb.FunctionSchema) bool {
 		return tf.GetType() == schemapb.FunctionType_BM25
 	})
 
 	if hasBM25Field {
-		idfOracle := NewIDFOracle(sd.vchannelName, collection.Schema().GetFunctions())
+		idfOracle := NewIDFOracle(sd.vchannelName, collectionSchema.GetFunctions())
 		idfOracle.Start()
 		sd.distribution.SetIDFOracle(idfOracle)
 		sd.publishIDFOracle(idfOracle)
@@ -1624,7 +1625,9 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 
 	// Register growing-source segments as optional local flush sources. Metadata
 	// commit is still owned by WAL flusher / WriteBuffer.
-	if sd.allowGrowingSourceFlush() {
+	if typeutil.AllowGrowingSourceFlush(collectionSchema,
+		paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool(),
+		paramtable.Get().CommonCfg.EnableGrowingSourceFlush.GetAsBool()) {
 		sd.growingSourceProvider = newDelegatorGrowingSourceProvider(manager.Segment, func(ctx context.Context, fenceTs uint64) error {
 			_, err := sd.waitTSafe(ctx, fenceTs)
 			return err
@@ -1639,16 +1642,6 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	paramtable.Get().Watch(paramtable.Get().QueryNodeCfg.DelegatorPostLoadConcurrencyFactor.Key, postLoadConfigHandler)
 	log.Info(ctx, "finish build new shardDelegator")
 	return sd, nil
-}
-
-// allowGrowingSourceFlush returns true when the collection may expose growing segments as a flush source.
-func (sd *shardDelegator) allowGrowingSourceFlush() bool {
-	if sd == nil || sd.collection == nil {
-		return false
-	}
-	return typeutil.AllowGrowingSourceFlush(sd.collection.Schema(),
-		paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool(),
-		paramtable.Get().CommonCfg.EnableGrowingSourceFlush.GetAsBool())
 }
 
 func (sd *shardDelegator) runWithAnalyzer(ctx context.Context, fieldID int64, run func(function.Analyzer) error) (bool, error) {

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -530,22 +530,41 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 // load bm25 stats for sealed segments.
 // idf oracle owns the full lifecycle: download, disk write, register, cleanup.
 func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.SegmentLoadInfo, req *querypb.LoadSegmentsRequest) error {
+	// Keep the WAL schema transition fenced through path resolution and IDF
+	// installation. A schema drop must either happen before this load (so the
+	// dropped field is filtered) or after it (so SyncFunctions prunes it).
+	sd.schemaChangeMutex.RLock()
+	defer sd.schemaChangeMutex.RUnlock()
+
+	schema, currentVersion := sd.delegatorSchemaSnapshotLocked()
+	if err := sd.checkLoadSchemaVersionReadyWithVersion(ctx, req, currentVersion); err != nil {
+		return err
+	}
+
+	loads, err := resolveBM25StatsLoads(infos, schema)
+	if err != nil {
+		return err
+	}
+	if len(loads) == 0 {
+		return nil
+	}
+
 	idfOracle := sd.getIDFOracle()
 	if idfOracle == nil {
-		return nil
+		return merr.WrapErrServiceNotReadyMsg("load contains BM25 stats for an active function before delegator BM25 oracle is initialized")
 	}
 
 	pool := segments.GetLoadPool()
 
 	cm := sd.loader.GetChunkManager()
-	futures := make([]*conc.Future[any], 0, len(infos))
-	for _, info := range infos {
-		info := info
+	futures := make([]*conc.Future[any], 0, len(loads))
+	for _, load := range loads {
+		load := load
 		futures = append(futures, pool.Submit(func() (any, error) {
-			if err := idfOracle.LoadSealed(ctx, info.GetSegmentID(), info, cm); err != nil {
+			if err := idfOracle.LoadSealedWithPaths(ctx, load.info.GetSegmentID(), load.paths, cm); err != nil {
 				mlog.Warn(ctx, "failed to load bm25 stats for segment",
 					mlog.FieldCollectionID(req.GetCollectionID()),
-					mlog.FieldSegmentID(info.GetSegmentID()),
+					mlog.FieldSegmentID(load.info.GetSegmentID()),
 					mlog.Err(err))
 				return nil, err
 			}
@@ -553,7 +572,7 @@ func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.Se
 		}))
 	}
 
-	err := conc.BlockOnAll(futures...)
+	err = conc.BlockOnAll(futures...)
 	if err != nil {
 		mlog.Warn(ctx, "failed to load bm25 stats", mlog.Err(err))
 		return err
@@ -561,47 +580,88 @@ func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.Se
 	return nil
 }
 
-func (sd *shardDelegator) handleReopenPostLoad(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+type bm25StatsLoad struct {
+	info  *querypb.SegmentLoadInfo
+	paths map[int64][]string
+}
+
+func resolveBM25StatsLoads(infos []*querypb.SegmentLoadInfo, schema *schemapb.CollectionSchema) ([]bm25StatsLoad, error) {
+	activeFields := bm25FunctionFieldIDs(schema.GetFunctions())
+	if len(activeFields) == 0 {
+		// Segments keep historical BM25 logs after a function field is dropped.
+		// They are not work for the current schema and must not wait for an oracle
+		// that will never be created.
+		return nil, nil
+	}
+
+	loads := make([]bm25StatsLoad, 0, len(infos))
+	for _, info := range infos {
+		bm25Paths, err := packed.NewStatsResolverFromLoadInfo(info).BM25StatsPaths()
+		if err != nil {
+			return nil, err
+		}
+		for fieldID := range bm25Paths {
+			if _, ok := activeFields[fieldID]; !ok {
+				delete(bm25Paths, fieldID)
+			}
+		}
+		if len(bm25Paths) > 0 {
+			loads = append(loads, bm25StatsLoad{info: info, paths: bm25Paths})
+		}
+	}
+	return loads, nil
+}
+
+func (sd *shardDelegator) checkBM25StatsReady(infos []*querypb.SegmentLoadInfo, schema *schemapb.CollectionSchema) error {
+	if sd.getIDFOracle() != nil {
+		return nil
+	}
+
+	loads, err := resolveBM25StatsLoads(infos, schema)
+	if err != nil {
+		return err
+	}
+	if len(loads) > 0 {
+		return merr.WrapErrServiceNotReadyMsg("load contains BM25 stats for an active function before delegator BM25 oracle is initialized")
+	}
+	return nil
+}
+
+func (sd *shardDelegator) loadBM25StatsForReopenRequest(ctx context.Context, req *querypb.LoadSegmentsRequest, schema *schemapb.CollectionSchema) error {
 	log := sd.getLogger(ctx).With(
 		mlog.Int64s("segments", lo.Map(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) int64 { return info.GetSegmentID() })),
 		mlog.String("loadScope", req.GetLoadScope().String()),
 	)
 
-	infosWithBM25Stats := make([]*querypb.SegmentLoadInfo, 0, len(req.GetInfos()))
-	for _, info := range req.GetInfos() {
-		bm25Paths, err := packed.NewStatsResolverFromLoadInfo(info).BM25StatsPaths()
-		if err != nil {
-			log.Warn(ctx, "resolve reopened bm25 stats failed", mlog.FieldSegmentID(info.GetSegmentID()), mlog.Err(err))
-			return err
-		}
-		if len(bm25Paths) > 0 {
-			infosWithBM25Stats = append(infosWithBM25Stats, info)
-		}
+	loads, err := resolveBM25StatsLoads(req.GetInfos(), schema)
+	if err != nil {
+		log.Warn(ctx, "resolve reopened bm25 stats failed", mlog.Err(err))
+		return err
 	}
 
-	if len(infosWithBM25Stats) == 0 {
+	if len(loads) == 0 {
 		return nil
 	}
-	return sd.loadBM25StatsForReopen(ctx, infosWithBM25Stats, req)
+	return sd.loadBM25StatsForReopen(ctx, loads, req)
 }
 
-func (sd *shardDelegator) loadBM25StatsForReopen(ctx context.Context, infos []*querypb.SegmentLoadInfo, req *querypb.LoadSegmentsRequest) error {
+func (sd *shardDelegator) loadBM25StatsForReopen(ctx context.Context, loads []bm25StatsLoad, req *querypb.LoadSegmentsRequest) error {
 	idfOracle := sd.getIDFOracle()
 	if idfOracle == nil {
-		return merr.WrapErrServiceInternal("reopen contains BM25 stats before delegator BM25 oracle is initialized")
+		return merr.WrapErrServiceNotReadyMsg("reopen contains BM25 stats for an active function before delegator BM25 oracle is initialized")
 	}
 
 	pool := segments.GetLoadPool()
 	cm := sd.loader.GetChunkManager()
-	futures := make([]*conc.Future[any], 0, len(infos))
-	for _, info := range infos {
-		info := info
+	futures := make([]*conc.Future[any], 0, len(loads))
+	for _, load := range loads {
+		load := load
 		futures = append(futures, pool.Submit(func() (any, error) {
-			activateIfReadable := sd.distribution.IsReadableSealedSegment(info.GetSegmentID())
-			if err := idfOracle.LoadSealedForReopen(ctx, info.GetSegmentID(), info, cm, activateIfReadable); err != nil {
+			activateIfReadable := sd.distribution.IsReadableSealedSegment(load.info.GetSegmentID())
+			if err := idfOracle.LoadSealedForReopenWithPaths(ctx, load.info.GetSegmentID(), load.paths, cm, activateIfReadable); err != nil {
 				mlog.Warn(ctx, "failed to load reopened bm25 stats for segment",
 					mlog.FieldCollectionID(req.GetCollectionID()),
-					mlog.FieldSegmentID(info.GetSegmentID()),
+					mlog.FieldSegmentID(load.info.GetSegmentID()),
 					mlog.Bool("activateIfReadable", activateIfReadable),
 					mlog.Err(err))
 				return nil, err
@@ -617,34 +677,41 @@ func (sd *shardDelegator) loadBM25StatsForReopen(ctx context.Context, infos []*q
 	return nil
 }
 
-// syncCollectionIndexMeta refreshes the delegator node's CCollection IndexMeta after a
-// forwarded worker load. Worker LoadSegments already updates IndexMeta on the target
-// worker, but the delegator (which executes growing search locally) must stay in sync.
+// syncCollectionIndexMeta refreshes the delegator node's CCollection IndexMeta.
+// The target worker updates its own IndexMeta, while the delegator also needs the
+// same metadata for growing search. Reopen calls this before the worker commit so
+// an update failure leaves the worker distribution stale and therefore retryable.
 func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
-	if len(req.GetIndexInfoList()) == 0 {
-		return nil
-	}
-
 	schema, _ := sd.delegatorSchemaSnapshot()
+	return sd.syncCollectionIndexMetaWithSchema(ctx, req, schema)
+}
+
+func (sd *shardDelegator) syncCollectionIndexMetaWithSchema(ctx context.Context, req *querypb.LoadSegmentsRequest, schema *schemapb.CollectionSchema) error {
 	if schema == nil {
 		schema = req.GetSchema()
 	}
 
-	loadMeta := req.GetLoadMeta()
-	if loadMeta == nil {
-		loadMeta = &querypb.LoadMetaInfo{
-			CollectionID: req.GetCollectionID(),
-		}
-	} else {
-		loadMeta = typeutil.Clone(loadMeta)
-	}
-	loadMeta.SchemaBarrierTs = 0
-
 	meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), schema)
-	if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
+	return sd.collectionManager.UpdateIndexMeta(req.GetCollectionID(), meta)
+}
+
+func (sd *shardDelegator) prepareReopen(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	// Keep the WAL schema transition fenced through BM25 installation. Without
+	// this shared epoch, a DDL could prune a dropped BM25 field and a stale
+	// reopen could install it again after the prune with no later cleanup path.
+	sd.schemaChangeMutex.RLock()
+	defer sd.schemaChangeMutex.RUnlock()
+
+	schema, currentVersion := sd.delegatorSchemaSnapshotLocked()
+	if err := sd.checkLoadSchemaVersionReadyWithVersion(ctx, req, currentVersion); err != nil {
 		return err
 	}
-	sd.collectionManager.Unref(req.GetCollectionID(), 1)
+	if err := sd.loadBM25StatsForReopenRequest(ctx, req, schema); err != nil {
+		return err
+	}
+	if err := sd.syncCollectionIndexMetaWithSchema(ctx, req, schema); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -687,6 +754,28 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	if err != nil {
 		log.Warn(ctx, "delegator failed to find worker", mlog.Err(err))
 		return err
+	}
+
+	isReopen := req.GetLoadScope() == querypb.LoadScope_Reopen || req.GetLoadScope() == querypb.LoadScope_Stats
+	if isReopen {
+		if err := sd.prepareReopen(ctx, req); err != nil {
+			log.Warn(ctx, "failed to prepare segment reopen", mlog.Err(err))
+			return err
+		}
+		// A schema update waiting on the preflight read lock may have completed
+		// immediately after prepareReopen returned. Avoid starting the worker RPC
+		// with an already stale request when that transition is observable here.
+		if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+			return err
+		}
+	} else if req.GetLoadScope() == querypb.LoadScope_Full {
+		// Validate this before the worker commits a full load. A missing oracle
+		// discovered only in post-load would make the failed task look converged
+		// from the worker distribution and suppress a useful retry.
+		schema, _ := sd.delegatorSchemaSnapshot()
+		if err := sd.checkBM25StatsReady(req.GetInfos(), schema); err != nil {
+			return err
+		}
 	}
 
 	req.Base.TargetID = targetNodeID
@@ -733,13 +822,13 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return err
 	}
 
+	if isReopen {
+		return nil
+	}
+
 	if err := sd.syncCollectionIndexMeta(ctx, req); err != nil {
 		log.Warn(ctx, "failed to sync collection index meta on delegator", mlog.Err(err))
 		return err
-	}
-
-	if req.GetLoadScope() == querypb.LoadScope_Reopen {
-		return sd.handleReopenPostLoad(ctx, req)
 	}
 
 	return sd.withPostLoadLimit(ctx, func() error {

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -451,13 +451,17 @@ func (sd *shardDelegator) addGrowing(entries ...SegmentEntry) {
 }
 
 func (sd *shardDelegator) checkLoadSchemaVersionReady(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	_, currentVersion := sd.delegatorSchemaSnapshot()
+	return sd.checkLoadSchemaVersionReadyWithVersion(ctx, req, currentVersion)
+}
+
+func (sd *shardDelegator) checkLoadSchemaVersionReadyWithVersion(ctx context.Context, req *querypb.LoadSegmentsRequest, currentVersion uint64) error {
 	requiredSchema := req.GetSchema()
 	if requiredSchema == nil {
 		return nil
 	}
 
 	requiredVersion := uint64(requiredSchema.GetVersion())
-	_, currentVersion := sd.delegatorSchemaSnapshot()
 	if currentVersion == requiredVersion {
 		return nil
 	}
@@ -812,7 +816,11 @@ func (sd *shardDelegator) withPostLoadLimit(ctx context.Context, fn func() error
 }
 
 func (sd *shardDelegator) addDistributionIfLoadSchemaOK(ctx context.Context, req *querypb.LoadSegmentsRequest, entries ...SegmentEntry) error {
-	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+	sd.schemaChangeMutex.RLock()
+	defer sd.schemaChangeMutex.RUnlock()
+
+	_, currentVersion := sd.delegatorSchemaSnapshotLocked()
+	if err := sd.checkLoadSchemaVersionReadyWithVersion(ctx, req, currentVersion); err != nil {
 		return err
 	}
 	// alter distribution

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -449,6 +450,31 @@ func (sd *shardDelegator) addGrowing(entries ...SegmentEntry) {
 	sd.distribution.AddGrowing(entries...)
 }
 
+func (sd *shardDelegator) checkLoadSchemaVersionReady(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	requiredSchema := req.GetSchema()
+	if requiredSchema == nil {
+		return nil
+	}
+
+	requiredVersion := uint64(requiredSchema.GetVersion())
+	_, currentVersion := sd.delegatorSchemaSnapshot()
+	if currentVersion == requiredVersion {
+		return nil
+	}
+
+	err := merr.WrapErrCollectionSchemaVersionNotReadyWithVersion(requiredSchema.GetName(), currentVersion, requiredVersion)
+	sd.getLogger(ctx).RatedInfo(ctx, rate.Limit(10), "delegator rejects load request due to schema version mismatch",
+		mlog.Uint64("currentSchemaVersion", currentVersion),
+		mlog.Uint64("requiredSchemaVersion", requiredVersion),
+		mlog.String("loadScope", req.GetLoadScope().String()),
+		mlog.Int64s("segmentIDs", lo.Map(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) int64 {
+			return info.GetSegmentID()
+		})),
+		mlog.Err(err),
+	)
+	return err
+}
+
 // LoadGrowing load growing segments locally.
 func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.SegmentLoadInfo, version int64) error {
 	log := sd.getLogger(ctx)
@@ -595,9 +621,9 @@ func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *quer
 		return nil
 	}
 
-	schema := req.GetSchema()
+	schema, _ := sd.delegatorSchemaSnapshot()
 	if schema == nil {
-		schema = sd.collection.Schema()
+		schema = req.GetSchema()
 	}
 
 	loadMeta := req.GetLoadMeta()
@@ -605,14 +631,17 @@ func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *quer
 		loadMeta = &querypb.LoadMetaInfo{
 			CollectionID: req.GetCollectionID(),
 		}
+	} else {
+		loadMeta = typeutil.Clone(loadMeta)
 	}
+	loadMeta.SchemaBarrierTs = 0
 
 	meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), schema)
 	if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
 		return err
 	}
 	sd.collectionManager.Unref(req.GetCollectionID(), 1)
-	return function.GetManager().Update(sd.collectionID, delegatorFunctionRunnerKey(sd.vchannelName), schema)
+	return nil
 }
 
 // LoadSegments load segments local or remotely depends on the target node.
@@ -632,6 +661,10 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 
 	if req.GetInfos()[0].GetLevel() == datapb.SegmentLevel_L0 {
 		return merr.WrapErrServiceInternal("load L0 segment is not supported, l0 segment should only be loaded by watchChannel")
+	}
+
+	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+		return err
 	}
 
 	// pin all segments to prevent delete buffer has been cleaned up during worker load segments
@@ -692,6 +725,10 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	}
 	log.Debug(ctx, "work loads segments done")
 
+	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+		return err
+	}
+
 	if err := sd.syncCollectionIndexMeta(ctx, req); err != nil {
 		log.Warn(ctx, "failed to sync collection index meta on delegator", mlog.Err(err))
 		return err
@@ -743,8 +780,7 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 
 		log.Debug(ctx, "load delete...")
 		// loadStreamDelete now handles distribution add atomically in Phase 3
-		err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker,
-			entries, req.GetLoadMeta().GetSchemaBarrierTs())
+		err = sd.loadStreamDelete(ctx, candidates, infos, req, targetNodeID, worker, entries)
 		if err != nil {
 			log.Warn(ctx, "load stream delete failed", mlog.Err(err))
 			// BM25 stats already loaded into idf oracle will be cleaned up
@@ -775,13 +811,10 @@ func (sd *shardDelegator) withPostLoadLimit(ctx context.Context, fn func() error
 	return fn()
 }
 
-func (sd *shardDelegator) addDistributionIfSchemaBarrierOK(schemaBarrierTs uint64, entries ...SegmentEntry) error {
-	sd.schemaChangeMutex.RLock()
-	defer sd.schemaChangeMutex.RUnlock()
-	if schemaBarrierTs < sd.schemaBarrierTs {
-		return merr.WrapErrServiceInternal("schema barrier changed")
+func (sd *shardDelegator) addDistributionIfLoadSchemaOK(ctx context.Context, req *querypb.LoadSegmentsRequest, entries ...SegmentEntry) error {
+	if err := sd.checkLoadSchemaVersionReady(ctx, req); err != nil {
+		return err
 	}
-
 	// alter distribution
 	sd.distribution.AddDistributions(entries...)
 	return nil
@@ -994,7 +1027,6 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 	targetNodeID int64,
 	worker cluster.Worker,
 	entries []SegmentEntry,
-	schemaBarrierTs uint64,
 ) error {
 	log := sd.getLogger(ctx)
 
@@ -1124,7 +1156,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 			// Atomically add to distribution while still holding RLock, so no
 			// ProcessDelete can run between "deletes applied" and "segment
 			// visible".
-			if err := sd.addDistributionIfSchemaBarrierOK(schemaBarrierTs, entries...); err != nil {
+			if err := sd.addDistributionIfLoadSchemaOK(ctx, req, entries...); err != nil {
 				sd.deleteMut.RUnlock()
 				return err
 			}
@@ -1160,7 +1192,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 					mlog.Int64("bfCost", time.Since(start).Milliseconds()),
 				)
 			}
-			if err := sd.addDistributionIfSchemaBarrierOK(schemaBarrierTs, entries...); err != nil {
+			if err := sd.addDistributionIfLoadSchemaOK(ctx, req, entries...); err != nil {
 				sd.deleteMut.RUnlock()
 				return err
 			}

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -1244,7 +1244,50 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 	})
 }
 
-func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaUpdatesFunctionRunners() {
+func (s *DelegatorDataSuite) TestLoadSegmentsSchemaVersionGate() {
+	newSchema := typeutil.Clone(s.delegator.collection.Schema())
+	newSchema.Version = s.delegator.collection.Schema().GetVersion() + 1
+	req := &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		Schema:       newSchema,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			},
+		},
+	}
+
+	err := s.delegator.LoadSegments(context.Background(), req)
+	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
+
+	s.Require().NoError(s.delegator.UpdateSchema(context.Background(), newSchema, 100))
+	_, version := s.delegator.delegatorSchemaSnapshot()
+	s.Equal(uint64(newSchema.GetVersion()), version)
+
+	worker := &cluster.MockWorker{}
+	worker.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+
+	err = s.delegator.LoadSegments(context.Background(), req)
+	s.NoError(err)
+
+	staleSchema := typeutil.Clone(newSchema)
+	staleSchema.Version--
+	staleReq := typeutil.Clone(req)
+	staleReq.Schema = staleSchema
+	err = s.delegator.LoadSegments(context.Background(), staleReq)
+	s.ErrorIs(err, merr.ErrCollectionSchemaVersionNotReady)
+}
+
+func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaDoesNotUpdateFunctionRunners() {
 	ctx := context.Background()
 	s.delegator.Start()
 	schema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
@@ -1256,11 +1299,15 @@ func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaUpdatesFunctionRunners()
 	})
 	s.Require().NoError(err)
 
-	// The load path has already advanced the collection snapshot, so the DDL
-	// event is skipped as a no-op. The function runner key must still point at
-	// the schema installed by the load path.
-	s.Require().NoError(s.delegator.UpdateSchema(ctx, schema, 1))
 	ok, err := function.GetManager().RunWithRunner(ctx, s.collectionID, delegatorFunctionRunnerKey(s.vchannelName), 102, func(function.FunctionRunner) error {
+		return nil
+	})
+	s.Require().NoError(err)
+	s.False(ok)
+
+	// Only the WAL UpdateSchema path advances the delegator schema/function view.
+	s.Require().NoError(s.delegator.UpdateSchema(ctx, schema, 1))
+	ok, err = function.GetManager().RunWithRunner(ctx, s.collectionID, delegatorFunctionRunnerKey(s.vchannelName), 102, func(function.FunctionRunner) error {
 		return nil
 	})
 	s.Require().NoError(err)

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/proto"
 
@@ -109,6 +110,18 @@ func (s *DelegatorDataSuite) getIDFOracleForTest() *idfOracle {
 	oracle, ok := s.delegator.getIDFOracle().(*idfOracle)
 	s.Require().True(ok)
 	return oracle
+}
+
+func (s *DelegatorDataSuite) publishBM25SchemaWithoutOracle(outputFieldID int64) *schemapb.CollectionSchema {
+	schema := proto.Clone(s.delegator.collection.Schema()).(*schemapb.CollectionSchema)
+	schema.Functions = []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		OutputFieldIds: []int64{outputFieldID},
+	}}
+	s.delegator.schemaChangeMutex.Lock()
+	s.delegator.publishDelegatorSchemaLocked(schema)
+	s.delegator.schemaChangeMutex.Unlock()
+	return schema
 }
 
 func (s *DelegatorDataSuite) SetupSuite() {
@@ -833,7 +846,7 @@ func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25Stats() {
 	s.Empty(sealed)
 }
 
-func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsMergesReadableSegment() {
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsRetriesBeforeWorkerWithoutDoubleMerge() {
 	s.genCollectionWithFunction()
 	s.delegator.distribution.AddDistributions(SegmentEntry{
 		NodeID:      1,
@@ -857,20 +870,34 @@ func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsMergesReadableSegmen
 	data, err := stats.Serialize()
 	s.Require().NoError(err)
 
+	readErr := errors.New("mocked bm25 read failure")
 	cm := mocks.NewChunkManager(s.T())
-	cm.EXPECT().Reader(mock.Anything, remotePath).Return(&bytesFileReader{bytes.NewReader(data)}, nil)
-	s.loader.EXPECT().GetChunkManager().Return(cm)
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(nil, readErr).Once()
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(&bytesFileReader{bytes.NewReader(data)}, nil).Once()
+	s.loader.EXPECT().GetChunkManager().Return(cm).Times(3)
 
+	workerErr := errors.New("mocked worker reopen failure")
+	var workerCalls atomic.Int32
 	worker1 := &cluster.MockWorker{}
-	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
-	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).RunAndReturn(
+		func(context.Context, *querypb.LoadSegmentsRequest) error {
+			fieldStats, err := s.getIDFOracleForTest().current.GetStats(101)
+			s.Require().NoError(err)
+			s.Equal(int64(3), fieldStats.NumRow(), "BM25 stats must be installed before worker reopen")
+			if workerCalls.Add(1) == 1 {
+				return workerErr
+			}
+			return nil
+		}).Times(2)
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil).Times(3)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err = s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+	req := &querypb.LoadSegmentsRequest{
 		Base:         commonpbutil.NewMsgBase(),
 		DstNodeID:    1,
 		CollectionID: s.collectionID,
+		Schema:       s.delegator.collection.Schema(),
 		LoadScope:    querypb.LoadScope_Reopen,
 		Infos: []*querypb.SegmentLoadInfo{
 			{
@@ -883,26 +910,42 @@ func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsMergesReadableSegmen
 				Bm25Logs:      bm25LogsForField(101, remotePath),
 			},
 		},
-	})
+	}
 
+	err = s.delegator.LoadSegments(ctx, req)
+	s.ErrorIs(err, readErr)
+	s.Zero(workerCalls.Load(), "worker must not reopen when BM25 preflight fails")
+
+	err = s.delegator.LoadSegments(ctx, req)
+	s.ErrorIs(err, workerErr)
+	s.Equal(int32(1), workerCalls.Load())
+
+	err = s.delegator.LoadSegments(ctx, req)
 	s.NoError(err)
+	s.Equal(int32(2), workerCalls.Load())
 	loadedStats := s.getIDFOracleForTest()
 	fieldStats, err := loadedStats.current.GetStats(101)
 	s.NoError(err)
 	s.Equal(int64(3), fieldStats.NumRow())
+	segStats, ok := loadedStats.sealed.Get(100)
+	s.True(ok)
+	s.True(segStats.HasField(101))
 }
 
 func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsRequiresOracleForRetry() {
+	schema := s.publishBM25SchemaWithoutOracle(101)
 	worker1 := &cluster.MockWorker{}
-	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
-	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil).Times(2)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+	remotePath := "bm25stats/reopen/segment_100/field_101/0"
+	req := &querypb.LoadSegmentsRequest{
 		Base:         commonpbutil.NewMsgBase(),
 		DstNodeID:    1,
 		CollectionID: s.collectionID,
+		Schema:       schema,
 		LoadScope:    querypb.LoadScope_Reopen,
 		Infos: []*querypb.SegmentLoadInfo{
 			{
@@ -912,13 +955,152 @@ func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsRequiresOracleForRet
 				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
 				Level:         datapb.SegmentLevel_L1,
 				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
-				Bm25Logs:      bm25LogsForField(101, "bm25stats/reopen/segment_100/field_101/0"),
+				Bm25Logs:      bm25LogsForField(101, remotePath),
 			},
 		},
+	}
+
+	err := s.delegator.LoadSegments(ctx, req)
+	s.Error(err)
+	s.ErrorIs(err, merr.ErrServiceNotReady)
+	worker1.AssertNotCalled(s.T(), "LoadSegments", mock.Anything, mock.Anything)
+
+	stats := storage.NewBM25Stats()
+	stats.Append(map[uint32]float32{1: 1})
+	data, err := stats.Serialize()
+	s.Require().NoError(err)
+	cm := mocks.NewChunkManager(s.T())
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(&bytesFileReader{bytes.NewReader(data)}, nil).Once()
+	s.loader.EXPECT().GetChunkManager().Return(cm).Once()
+
+	idfOracle := NewIDFOracle(s.vchannelName, []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		OutputFieldIds: []int64{101},
+	}})
+	idfOracle.Start()
+	defer idfOracle.Close()
+	s.delegator.distribution.SetIDFOracle(idfOracle)
+	s.delegator.publishIDFOracle(idfOracle)
+
+	err = s.delegator.LoadSegments(ctx, req)
+	s.NoError(err)
+	worker1.AssertNumberOfCalls(s.T(), "LoadSegments", 1)
+}
+
+func (s *DelegatorDataSuite) TestLoadSegmentsFullBM25StatsRequiresOracleBeforeWorker() {
+	schema := s.publishBM25SchemaWithoutOracle(101)
+	worker1 := &cluster.MockWorker{}
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil).Once()
+
+	err := s.delegator.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		Schema:       schema,
+		LoadScope:    querypb.LoadScope_Full,
+		Infos: []*querypb.SegmentLoadInfo{{
+			SegmentID:     100,
+			PartitionID:   500,
+			Level:         datapb.SegmentLevel_L1,
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			Bm25Logs:      bm25LogsForField(101, "bm25stats/full/segment_100/field_101/0"),
+		}},
 	})
 
+	s.ErrorIs(err, merr.ErrServiceNotReady)
+	worker1.AssertNotCalled(s.T(), "LoadSegments", mock.Anything, mock.Anything)
+}
+
+func (s *DelegatorDataSuite) TestLoadSegmentsIgnoresHistoricalBM25StatsForDroppedFields() {
+	workerErr := errors.New("mocked worker failure")
+	worker := &cluster.MockWorker{}
+	worker.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(workerErr).Times(3)
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Times(3)
+
+	schema, _ := s.delegator.delegatorSchemaSnapshot()
+	s.Require().Empty(schema.GetFunctions())
+	for _, loadScope := range []querypb.LoadScope{
+		querypb.LoadScope_Reopen,
+		querypb.LoadScope_Stats,
+		querypb.LoadScope_Full,
+	} {
+		err := s.delegator.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+			Base:         commonpbutil.NewMsgBase(),
+			DstNodeID:    1,
+			CollectionID: s.collectionID,
+			Schema:       schema,
+			LoadScope:    loadScope,
+			Infos: []*querypb.SegmentLoadInfo{{
+				SegmentID:     100,
+				PartitionID:   500,
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+				Bm25Logs:      bm25LogsForField(101, "bm25stats/dropped/segment_100/field_101/0"),
+			}},
+		})
+
+		s.ErrorIs(err, workerErr)
+		s.NotErrorIs(err, merr.ErrServiceNotReady)
+	}
+}
+
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenDoesNotReinstallDroppedBM25Stats() {
+	oracle := NewIDFOracle(s.vchannelName, []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		OutputFieldIds: []int64{101},
+	}}).(*idfOracle)
+	oracle.Start()
+	defer oracle.Close()
+	s.Require().NoError(oracle.SyncFunctions(nil))
+	s.delegator.distribution.SetIDFOracle(oracle)
+	s.delegator.publishIDFOracle(oracle)
+
+	worker := &cluster.MockWorker{}
+	worker.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+
+	schema, _ := s.delegator.delegatorSchemaSnapshot()
+	s.Require().Empty(schema.GetFunctions())
+	err := s.delegator.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		Schema:       schema,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{{
+			SegmentID:     100,
+			PartitionID:   500,
+			Level:         datapb.SegmentLevel_L1,
+			InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			Bm25Logs:      bm25LogsForField(101, "bm25stats/dropped/segment_100/field_101/0"),
+		}},
+	})
+
+	s.NoError(err)
+	s.loader.AssertNotCalled(s.T(), "GetChunkManager")
+	s.False(oracle.sealed.Contain(100))
+	_, err = oracle.current.GetStats(101)
 	s.Error(err)
-	s.ErrorIs(err, merr.ErrServiceInternal)
+}
+
+func TestResolveBM25StatsLoadsFiltersInactiveFields(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Functions: []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		OutputFieldIds: []int64{101},
+	}}}
+	activePath := "bm25stats/segment_100/field_101/0"
+	droppedPath := "bm25stats/segment_100/field_102/0"
+	loads, err := resolveBM25StatsLoads([]*querypb.SegmentLoadInfo{{
+		SegmentID: 100,
+		Bm25Logs: append(
+			bm25LogsForField(101, activePath),
+			bm25LogsForField(102, droppedPath)...,
+		),
+	}}, schema)
+
+	require.NoError(t, err)
+	require.Len(t, loads, 1)
+	assert.Equal(t, map[int64][]string{101: {activePath}}, loads[0].paths)
 }
 
 func (s *DelegatorDataSuite) TestLoadSegmentsReopenWithoutBM25StatsNoop() {
@@ -948,6 +1130,74 @@ func (s *DelegatorDataSuite) TestLoadSegmentsReopenWithoutBM25StatsNoop() {
 	s.NoError(err)
 	sealed, _ := s.delegator.GetSegmentInfo(false)
 	s.Empty(sealed)
+}
+
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenIndexMetaFailureSkipsWorker() {
+	originalCollectionManager := s.delegator.collectionManager
+	collectionManager := segments.NewMockCollectionManager(s.T())
+	s.delegator.collectionManager = collectionManager
+	defer func() {
+		s.delegator.collectionManager = originalCollectionManager
+	}()
+
+	indexMetaErr := merr.WrapErrServiceUnavailableMsg("mocked index meta update failure")
+	collectionManager.EXPECT().UpdateIndexMeta(
+		s.collectionID,
+		mock.AnythingOfType("*segcorepb.CollectionIndexMeta"),
+	).Return(indexMetaErr).Once()
+
+	worker := &cluster.MockWorker{}
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+
+	schema, _ := s.delegator.delegatorSchemaSnapshot()
+	indexInfos := mock_segcore.GenTestIndexInfoList(s.collectionID, schema)
+	s.Require().NotEmpty(indexInfos)
+	err := s.delegator.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		Base:          commonpbutil.NewMsgBase(),
+		DstNodeID:     1,
+		CollectionID:  s.collectionID,
+		Schema:        schema,
+		LoadScope:     querypb.LoadScope_Reopen,
+		IndexInfoList: indexInfos,
+		Infos: []*querypb.SegmentLoadInfo{{
+			CollectionID: s.collectionID,
+			SegmentID:    100,
+			PartitionID:  500,
+			Level:        datapb.SegmentLevel_L1,
+		}},
+	})
+
+	s.ErrorIs(err, merr.ErrServiceUnavailable)
+	worker.AssertNotCalled(s.T(), "LoadSegments", mock.Anything, mock.Anything)
+}
+
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenClearsDroppedLastIndexMeta() {
+	collection := s.manager.Collection.Get(s.collectionID)
+	s.Require().NotNil(collection)
+	s.Require().NotEmpty(collection.GetCCollection().IndexMeta().GetIndexMetas())
+
+	worker := &cluster.MockWorker{}
+	worker.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+
+	schema, _ := s.delegator.delegatorSchemaSnapshot()
+	err := s.delegator.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		Base:          commonpbutil.NewMsgBase(),
+		DstNodeID:     1,
+		CollectionID:  s.collectionID,
+		Schema:        schema,
+		LoadScope:     querypb.LoadScope_Reopen,
+		IndexInfoList: nil,
+		Infos: []*querypb.SegmentLoadInfo{{
+			CollectionID: s.collectionID,
+			SegmentID:    100,
+			PartitionID:  500,
+			Level:        datapb.SegmentLevel_L1,
+		}},
+	})
+
+	s.NoError(err)
+	s.Empty(collection.GetCCollection().IndexMeta().GetIndexMetas())
 }
 
 func (s *DelegatorDataSuite) TestLoadSegments() {

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -2620,7 +2620,6 @@ func TestUpdateSchemaSkipsStaleSchemaBeforeSideEffects(t *testing.T) {
 		lifetime:                   lifetime.NewLifetime(lifetime.Working),
 		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
 		workerManager:              workerManager,
-		schemaBarrierTs:            100,
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
 		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
@@ -2631,7 +2630,8 @@ func TestUpdateSchemaSkipsStaleSchemaBeforeSideEffects(t *testing.T) {
 	err := sd.UpdateSchema(context.Background(), staleSchema, 200)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint64(100), sd.schemaBarrierTs)
+	_, delegatorSchemaVersion := sd.delegatorSchemaSnapshot()
+	assert.Equal(t, uint64(2), delegatorSchemaVersion)
 	assert.Equal(t, uint64(2), sd.collection.SchemaVersion())
 }
 

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -1545,6 +1545,19 @@ func (s *DelegatorSuite) TestUpdateSchema() {
 	})
 }
 
+func (s *DelegatorSuite) TestUpdateSchemaAllowedWhileInitializing() {
+	s.ResetDelegator()
+	collection := s.manager.Collection.Get(s.collectionID)
+	s.Require().NotNil(collection)
+	schema := collection.Schema()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := s.delegator.UpdateSchema(ctx, schema, 100)
+	s.NoError(err)
+}
+
 func (s *DelegatorSuite) ResetDelegator() {
 	var err error
 	s.delegator.Close()

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -198,6 +198,36 @@ func (s *DelegatorSuite) TearDownTest() {
 }
 
 func (s *DelegatorSuite) TestCreateDelegatorWithFunction() {
+	s.Run("constructor uses one coherent schema snapshot", func() {
+		collectionID := s.collectionID + 9999
+		vchannel := s.vchannelName + "-coherent-snapshot"
+		manager := segments.NewManager()
+		schema := proto.Clone(s.manager.Collection.Get(s.collectionID).Schema()).(*schemapb.CollectionSchema)
+		schema.Name = "coherent-snapshot"
+		schema.Version = 7
+		s.Require().NoError(manager.Collection.PutOrRef(collectionID, schema, nil, &querypb.LoadMetaInfo{
+			SchemaBarrierTs: 100,
+		}))
+		defer manager.Collection.Unref(collectionID, 1)
+
+		var snapshotCalls atomic.Int32
+		patch := mockey.Mock((*segments.Collection).SchemaSnapshot).To(
+			func(*segments.Collection) (*schemapb.CollectionSchema, uint64, uint64) {
+				snapshotCalls.Inc()
+				return schema, uint64(schema.GetVersion()), 100
+			}).Build()
+		defer patch.UnPatch()
+
+		delegator, err := NewShardDelegator(context.Background(), collectionID, s.replicaID, vchannel, s.version, s.workerManager, manager, s.loader, 10000, nil, s.chunkManager, NewChannelQueryView(nil, nil, nil, initialTargetVersion), nil)
+		s.Require().NoError(err)
+		defer delegator.Close()
+
+		s.Equal(int32(1), snapshotCalls.Load())
+		delegatorSchema, version := delegator.(*shardDelegator).delegatorSchemaSnapshot()
+		s.True(proto.Equal(schema, delegatorSchema))
+		s.Equal(uint64(schema.GetVersion()), version)
+	})
+
 	s.Run("function runner init failure does not block delegator", func() {
 		collectionID := s.collectionID + 10000
 		vchannel := s.vchannelName + "-init-failure"
@@ -2421,6 +2451,69 @@ func TestUpdateSchemaSyncsAdditiveIDFOracleFunctions(t *testing.T) {
 
 	_, _, err = sd.getIDFOracle().BuildIDF(105, &schemapb.SparseFloatArray{Contents: [][]byte{typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{7: 1})}, Dim: 1})
 	require.NoError(t, err)
+}
+
+func TestSharedCollectionUpdateDoesNotSuppressShardRuntimeDDL(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+
+	const collectionID = int64(1000)
+	manager := segments.NewManager()
+	initialSchema := newFunctionRuntimeTestSchemaWithVersion(0)
+	require.NoError(t, manager.Collection.PutOrRef(collectionID, initialSchema, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: 1}))
+	defer manager.Collection.Unref(collectionID, 1)
+
+	newWorkerManager := func() *cluster.MockManager {
+		worker := cluster.NewMockWorker(t)
+		worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Success(), nil).Once()
+		workerManager := cluster.NewMockManager(t)
+		workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+		return workerManager
+	}
+
+	newDelegator := func(channel string, workerManager cluster.Manager) *shardDelegator {
+		delegator, err := NewShardDelegator(
+			context.Background(),
+			collectionID,
+			1,
+			channel,
+			1,
+			workerManager,
+			manager,
+			segments.NewMockLoader(t),
+			100,
+			nil,
+			nil,
+			NewChannelQueryView(nil, nil, nil, initialTargetVersion),
+			nil,
+		)
+		require.NoError(t, err)
+		sd := delegator.(*shardDelegator)
+		sd.Start()
+		return sd
+	}
+
+	first := newDelegator("test-channel-1", newWorkerManager())
+	defer first.Close()
+	second := newDelegator("test-channel-2", newWorkerManager())
+	defer second.Close()
+
+	updatedSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
+	require.NoError(t, first.UpdateSchema(context.Background(), updatedSchema, 100))
+	require.Equal(t, uint64(1), manager.Collection.Get(collectionID).SchemaVersion())
+
+	// The shared Collection is already at V1, but the second shard still has a
+	// V0 served/runtime view and must execute its own WAL DDL side effects.
+	require.NoError(t, second.UpdateSchema(context.Background(), updatedSchema, 100))
+	_, secondVersion := second.delegatorSchemaSnapshot()
+	require.Equal(t, uint64(1), secondVersion)
+	require.NotNil(t, second.getIDFOracle())
+
+	ok, err := function.GetManager().RunWithRunner(context.Background(), collectionID, delegatorFunctionRunnerKey(second.vchannelName), 102, func(function.FunctionRunner) error {
+		return nil
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 func TestUpdateSchemaDoesNotSyncIDFOracleWhenWorkerUpdateFails(t *testing.T) {

--- a/internal/querynodev2/delegator/idf_oracle.go
+++ b/internal/querynodev2/delegator/idf_oracle.go
@@ -65,7 +65,12 @@ type IDFOracle interface {
 	// Internally handles: streaming download → local disk → optional parse → register.
 	// Idempotent: skips if segment already loaded.
 	LoadSealed(ctx context.Context, segmentID int64, loadInfo *querypb.SegmentLoadInfo, cm storage.ChunkManager) error
+	// LoadSealedWithPaths accepts paths that were already resolved and filtered
+	// against the caller's fenced schema snapshot.
+	LoadSealedWithPaths(ctx context.Context, segmentID int64, logpaths map[int64][]string, cm storage.ChunkManager) error
 	LoadSealedForReopen(ctx context.Context, segmentID int64, loadInfo *querypb.SegmentLoadInfo, cm storage.ChunkManager, activateIfReadable bool) error
+	// LoadSealedForReopenWithPaths is the reopen counterpart of LoadSealedWithPaths.
+	LoadSealedForReopenWithPaths(ctx context.Context, segmentID int64, logpaths map[int64][]string, cm storage.ChunkManager, activateIfReadable bool) error
 	SyncFunctions(functions []*schemapb.FunctionSchema) error
 
 	BuildIDF(fieldID int64, tfs *schemapb.SparseFloatArray) ([][]byte, float64, error)
@@ -496,18 +501,25 @@ func (o *idfOracle) SyncFunctions(functions []*schemapb.FunctionSchema) error {
 // LoadSealed loads BM25 stats for a sealed segment from remote storage to local disk.
 // Idempotent: skips if segment already loaded.
 func (o *idfOracle) LoadSealed(ctx context.Context, segmentID int64, loadInfo *querypb.SegmentLoadInfo, cm storage.ChunkManager) error {
+	if o.sealed.Contain(segmentID) {
+		return nil
+	}
+
+	logpaths, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BM25StatsPaths()
+	if err != nil {
+		mlog.Warn(ctx, "load remote segment bm25 stats failed",
+			mlog.FieldSegmentID(segmentID),
+			mlog.Err(err),
+		)
+		return err
+	}
+	return o.LoadSealedWithPaths(ctx, segmentID, logpaths, cm)
+}
+
+func (o *idfOracle) LoadSealedWithPaths(ctx context.Context, segmentID int64, logpaths map[int64][]string, cm storage.ChunkManager) error {
 	_, err, _ := o.sf.Do(fmt.Sprintf("load_sealed_%d", segmentID), func() (any, error) {
 		if o.sealed.Contain(segmentID) {
 			return nil, nil
-		}
-
-		logpaths, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BM25StatsPaths()
-		if err != nil {
-			mlog.Warn(ctx, "load remote segment bm25 stats failed",
-				mlog.FieldSegmentID(segmentID),
-				mlog.Err(err),
-			)
-			return nil, err
 		}
 
 		if len(logpaths) == 0 {
@@ -549,15 +561,22 @@ func (o *idfOracle) LoadSealed(ctx context.Context, segmentID int64, loadInfo *q
 }
 
 func (o *idfOracle) LoadSealedForReopen(ctx context.Context, segmentID int64, loadInfo *querypb.SegmentLoadInfo, cm storage.ChunkManager, activateIfReadable bool) error {
+	logpaths, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BM25StatsPaths()
+	if err != nil {
+		mlog.Warn(ctx, "load remote segment bm25 stats for reopen failed",
+			mlog.FieldSegmentID(segmentID),
+			mlog.Err(err),
+		)
+		return err
+	}
+	return o.LoadSealedForReopenWithPaths(ctx, segmentID, logpaths, cm, activateIfReadable)
+}
+
+func (o *idfOracle) LoadSealedForReopenWithPaths(ctx context.Context, segmentID int64, logpaths map[int64][]string, cm storage.ChunkManager, activateIfReadable bool) error {
 	// QueryCoord deduplicates same sealed-segment load/reopen tasks by replica, segment, and scope.
 	// This shared singleflight key only coalesces duplicate calls; it is not relied on to serialize different tasks.
 	_, err, _ := o.sf.Do(fmt.Sprintf("load_sealed_%d", segmentID), func() (any, error) {
 		logger := mlog.With(mlog.FieldSegmentID(segmentID))
-		logpaths, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BM25StatsPaths()
-		if err != nil {
-			logger.Warn(ctx, "load remote segment bm25 stats for reopen failed", mlog.Err(err))
-			return nil, err
-		}
 		if len(logpaths) == 0 {
 			return nil, nil
 		}

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -19,6 +19,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	base "github.com/milvus-io/milvus/internal/util/pipeline"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -41,6 +43,8 @@ type deleteNode struct {
 	manager   *DataManager
 	delegator delegator.ShardDelegator
 	closed    atomic.Bool
+	closeCh   chan struct{}
+	closeOnce sync.Once
 }
 
 var deleteNodeUpdateSchemaRetryInterval = 200 * time.Millisecond
@@ -113,10 +117,28 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 
 func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *deleteNodeMsg) bool {
 	for {
+		if dNode.closed.Load() {
+			return false
+		}
 		err := dNode.delegator.UpdateSchema(ctx, nodeMsg.schema, nodeMsg.schemaBarrierTs)
 		if err == nil {
 			return true
 		}
+
+		if dNode.closed.Load() {
+			return false
+		}
+		if !merr.IsRetryableErr(err) {
+			wrapped := merr.Wrap(err, "non-retryable schema update failure in delete node")
+			mlog.Error(ctx, "non-retryable schema update failure in delete node, stop process to replay WAL after restart",
+				mlog.Int64("collectionID", dNode.collectionID),
+				mlog.String("channel", dNode.channel),
+				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+				mlog.Err(wrapped))
+			panic(wrapped)
+		}
+
 		mlog.RatedWarn(ctx, rate.Limit(1), "failed to update schema in delete node, retrying before advancing tsafe",
 			mlog.Int64("collectionID", dNode.collectionID),
 			mlog.String("channel", dNode.channel),
@@ -128,17 +150,24 @@ func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *
 			return false
 		}
 		timer := time.NewTimer(deleteNodeUpdateSchemaRetryInterval)
-		<-timer.C
-		timer.Stop()
-		if dNode.closed.Load() {
+		select {
+		case <-timer.C:
+		case <-dNode.closeCh:
+			timer.Stop()
 			return false
 		}
+		timer.Stop()
 	}
 }
 
-func (dNode *deleteNode) Close() {
-	dNode.closed.Store(true)
+func (dNode *deleteNode) PreClose() {
+	dNode.closeOnce.Do(func() {
+		dNode.closed.Store(true)
+		close(dNode.closeCh)
+	})
 }
+
+func (dNode *deleteNode) Close() { dNode.PreClose() }
 
 func newDeleteNode(
 	collectionID UniqueID, channel string,
@@ -151,5 +180,6 @@ func newDeleteNode(
 		channel:      channel,
 		manager:      manager,
 		delegator:    delegator,
+		closeCh:      make(chan struct{}),
 	}
 }

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -18,6 +18,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/samber/lo"
 	"golang.org/x/time/rate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -43,11 +46,16 @@ type deleteNode struct {
 	manager   *DataManager
 	delegator delegator.ShardDelegator
 	closed    atomic.Bool
+	ctx       context.Context
+	cancel    context.CancelFunc
 	closeCh   chan struct{}
 	closeOnce sync.Once
 }
 
-var deleteNodeUpdateSchemaRetryInterval = 200 * time.Millisecond
+var (
+	deleteNodeUpdateSchemaRetryInterval    = 200 * time.Millisecond
+	deleteNodeUpdateSchemaMaxRetryDuration = 5 * time.Minute
+)
 
 // addDeleteData find the segment of delete column in DeleteMsg and save in deleteData
 func (dNode *deleteNode) addDeleteData(deleteDatas map[UniqueID]*delegator.DeleteData, msg *DeleteMsg) {
@@ -104,8 +112,7 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 	}
 
 	if nodeMsg.schema != nil {
-		ctx := context.TODO()
-		if !dNode.updateSchemaUntilApplied(ctx, nodeMsg) {
+		if !dNode.updateSchemaUntilApplied(dNode.ctx, nodeMsg) {
 			return nil
 		}
 	}
@@ -116,6 +123,7 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 }
 
 func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *deleteNodeMsg) bool {
+	start := time.Now()
 	for {
 		if dNode.closed.Load() {
 			return false
@@ -128,13 +136,24 @@ func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *
 		if dNode.closed.Load() {
 			return false
 		}
-		if !merr.IsRetryableErr(err) {
+		if !isUpdateSchemaRetryable(err) {
 			wrapped := merr.Wrap(err, "non-retryable schema update failure in delete node")
 			mlog.Error(ctx, "non-retryable schema update failure in delete node, stop process to replay WAL after restart",
 				mlog.Int64("collectionID", dNode.collectionID),
 				mlog.String("channel", dNode.channel),
 				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
 				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+				mlog.Err(wrapped))
+			panic(wrapped)
+		}
+		if time.Since(start) >= deleteNodeUpdateSchemaMaxRetryDuration {
+			wrapped := merr.Wrap(err, "schema update retry limit reached in delete node")
+			mlog.Error(ctx, "schema update retry limit reached in delete node, stop process to replay WAL after restart",
+				mlog.Int64("collectionID", dNode.collectionID),
+				mlog.String("channel", dNode.channel),
+				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+				mlog.Duration("retryDuration", time.Since(start)),
 				mlog.Err(wrapped))
 			panic(wrapped)
 		}
@@ -160,9 +179,30 @@ func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *
 	}
 }
 
+func isUpdateSchemaRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if merr.IsRetryableErr(err) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, merr.ErrChannelNotAvailable) ||
+		errors.Is(err, merr.ErrNodeNotAvailable) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted:
+		return true
+	default:
+		return false
+	}
+}
+
 func (dNode *deleteNode) PreClose() {
 	dNode.closeOnce.Do(func() {
 		dNode.closed.Store(true)
+		dNode.cancel()
 		close(dNode.closeCh)
 	})
 }
@@ -174,12 +214,15 @@ func newDeleteNode(
 	manager *DataManager, delegator delegator.ShardDelegator,
 	maxQueueLength int32,
 ) *deleteNode {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &deleteNode{
 		BaseNode:     base.NewBaseNode(fmt.Sprintf("DeleteNode-%s", channel), maxQueueLength),
 		collectionID: collectionID,
 		channel:      channel,
 		manager:      manager,
 		delegator:    delegator,
+		ctx:          ctx,
+		cancel:       cancel,
 		closeCh:      make(chan struct{}),
 	}
 }

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -19,8 +19,11 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
+	"time"
 
 	"github.com/samber/lo"
+	"golang.org/x/time/rate"
 
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -37,7 +40,10 @@ type deleteNode struct {
 
 	manager   *DataManager
 	delegator delegator.ShardDelegator
+	closed    atomic.Bool
 }
+
+var deleteNodeUpdateSchemaRetryInterval = 200 * time.Millisecond
 
 // addDeleteData find the segment of delete column in DeleteMsg and save in deleteData
 func (dNode *deleteNode) addDeleteData(deleteDatas map[UniqueID]*delegator.DeleteData, msg *DeleteMsg) {
@@ -95,19 +101,43 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 
 	if nodeMsg.schema != nil {
 		ctx := context.TODO()
-		if err := dNode.delegator.UpdateSchema(ctx, nodeMsg.schema, nodeMsg.schemaBarrierTs); err != nil {
-			mlog.Warn(ctx, "failed to update schema in delete node",
-				mlog.Int64("collectionID", dNode.collectionID),
-				mlog.String("channel", dNode.channel),
-				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
-				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
-				mlog.Err(err))
+		if !dNode.updateSchemaUntilApplied(ctx, nodeMsg) {
+			return nil
 		}
 	}
 
 	// update tSafe
 	dNode.delegator.UpdateTSafe(nodeMsg.timeRange.timestampMax)
 	return nil
+}
+
+func (dNode *deleteNode) updateSchemaUntilApplied(ctx context.Context, nodeMsg *deleteNodeMsg) bool {
+	for {
+		err := dNode.delegator.UpdateSchema(ctx, nodeMsg.schema, nodeMsg.schemaBarrierTs)
+		if err == nil {
+			return true
+		}
+		mlog.RatedWarn(ctx, rate.Limit(1), "failed to update schema in delete node, retrying before advancing tsafe",
+			mlog.Int64("collectionID", dNode.collectionID),
+			mlog.String("channel", dNode.channel),
+			mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
+			mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
+			mlog.Err(err))
+
+		if dNode.closed.Load() {
+			return false
+		}
+		timer := time.NewTimer(deleteNodeUpdateSchemaRetryInterval)
+		<-timer.C
+		timer.Stop()
+		if dNode.closed.Load() {
+			return false
+		}
+	}
+}
+
+func (dNode *deleteNode) Close() {
+	dNode.closed.Store(true)
 }
 
 func newDeleteNode(

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -17,7 +17,10 @@
 package pipeline
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
@@ -149,7 +152,51 @@ func (suite *DeleteNodeSuite) TestProcessDeleteBatchesUseDeleteMsgEndTs() {
 	suite.Nil(out)
 }
 
-func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotPanic() {
+func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotAdvanceTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	expectedErr := merr.WrapErrServiceUnavailableMsg("delegator is not ready")
+	var updateSchemaCalled atomic.Bool
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Run(func(context.Context, *schemapb.CollectionSchema, uint64) {
+		updateSchemaCalled.Store(true)
+	}).Return(expectedErr)
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldInterval := deleteNodeUpdateSchemaRetryInterval
+	deleteNodeUpdateSchemaRetryInterval = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaRetryInterval = oldInterval
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.Nil(node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		}))
+	}()
+
+	suite.Eventually(func() bool {
+		return updateSchemaCalled.Load()
+	}, time.Second, time.Millisecond)
+	node.Close()
+	suite.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesBeforeTSafe() {
 	manager := &segments.Manager{
 		Collection: segments.NewMockCollectionManager(suite.T()),
 		Segment:    segments.NewMockSegmentManager(suite.T()),
@@ -158,16 +205,21 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotPanic() {
 	schema := &schemapb.CollectionSchema{Version: 2}
 	expectedErr := merr.WrapErrServiceUnavailableMsg("delegator is not ready")
 	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(nil).Once()
 	delegator.EXPECT().UpdateTSafe(uint64(10)).Return().Once()
 
 	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
-	suite.NotPanics(func() {
-		suite.Nil(node.Operate(&deleteNodeMsg{
-			schema:          schema,
-			schemaBarrierTs: 10,
-			timeRange:       TimeRange{timestampMax: 10},
-		}))
+	oldInterval := deleteNodeUpdateSchemaRetryInterval
+	deleteNodeUpdateSchemaRetryInterval = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaRetryInterval = oldInterval
 	})
+
+	suite.Nil(node.Operate(&deleteNodeMsg{
+		schema:          schema,
+		schemaBarrierTs: 10,
+		timeRange:       TimeRange{timestampMax: 10},
+	}))
 }
 
 func TestDeleteNode(t *testing.T) {

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -184,9 +184,7 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotAdvanceTSafe() {
 		}))
 	}()
 
-	suite.Eventually(func() bool {
-		return updateSchemaCalled.Load()
-	}, time.Second, time.Millisecond)
+	suite.Eventually(updateSchemaCalled.Load, time.Second, time.Millisecond)
 	node.Close()
 	suite.Eventually(func() bool {
 		select {

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -222,6 +222,26 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesBeforeTSafe() {
 	}))
 }
 
+func (suite *DeleteNodeSuite) TestUpdateSchemaNonRetryableErrorPanicsWithoutTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	expectedErr := merr.WrapErrServiceInternal("unsupported incompatible schema change")
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	suite.Panics(func() {
+		node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		})
+	})
+}
+
 func TestDeleteNode(t *testing.T) {
 	suite.Run(t, new(DeleteNodeSuite))
 }

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
@@ -222,6 +224,36 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesBeforeTSafe() {
 	}))
 }
 
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetriesTransientErrorsBeforeTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		Return(merr.WrapErrChannelNotAvailable(suite.channel, "delegator initializing")).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		Return(merr.WrapErrNodeNotAvailable(10, "worker unhealthy")).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		Return(status.Error(codes.Unavailable, "worker unavailable")).Once()
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(nil).Once()
+	delegator.EXPECT().UpdateTSafe(uint64(10)).Return().Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldInterval := deleteNodeUpdateSchemaRetryInterval
+	deleteNodeUpdateSchemaRetryInterval = time.Millisecond
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaRetryInterval = oldInterval
+	})
+
+	suite.Nil(node.Operate(&deleteNodeMsg{
+		schema:          schema,
+		schemaBarrierTs: 10,
+		timeRange:       TimeRange{timestampMax: 10},
+	}))
+}
+
 func (suite *DeleteNodeSuite) TestUpdateSchemaNonRetryableErrorPanicsWithoutTSafe() {
 	manager := &segments.Manager{
 		Collection: segments.NewMockCollectionManager(suite.T()),
@@ -240,6 +272,77 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaNonRetryableErrorPanicsWithoutTSaf
 			timeRange:       TimeRange{timestampMax: 10},
 		})
 	})
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaRetryLimitPanicsWithoutTSafe() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	expectedErr := merr.WrapErrChannelNotAvailable(suite.channel, "delegator initializing")
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	oldMaxRetryDuration := deleteNodeUpdateSchemaMaxRetryDuration
+	deleteNodeUpdateSchemaMaxRetryDuration = 0
+	suite.T().Cleanup(func() {
+		deleteNodeUpdateSchemaMaxRetryDuration = oldMaxRetryDuration
+	})
+
+	suite.Panics(func() {
+		node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		})
+	})
+}
+
+func (suite *DeleteNodeSuite) TestUpdateSchemaPreCloseCancelsInFlightUpdate() {
+	manager := &segments.Manager{
+		Collection: segments.NewMockCollectionManager(suite.T()),
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+	delegator := delegator.NewMockShardDelegator(suite.T())
+	schema := &schemapb.CollectionSchema{Version: 2}
+	updateStarted := make(chan struct{})
+	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).
+		RunAndReturn(func(ctx context.Context, sch *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
+			close(updateStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		}).Once()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.Nil(node.Operate(&deleteNodeMsg{
+			schema:          schema,
+			schemaBarrierTs: 10,
+			timeRange:       TimeRange{timestampMax: 10},
+		}))
+	}()
+
+	suite.Eventually(func() bool {
+		select {
+		case <-updateStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	node.PreClose()
+	suite.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
 }
 
 func TestDeleteNode(t *testing.T) {

--- a/internal/querynodev2/pipeline/filter_node.go
+++ b/internal/querynodev2/pipeline/filter_node.go
@@ -95,7 +95,15 @@ func (fNode *filterNode) Operate(in Msg) Msg {
 				mlog.Err(err),
 			)
 		} else {
-			out.append(msg)
+			if err := out.append(msg); err != nil {
+				wrapped := merr.Wrap(err, "failed to append filtered message")
+				mlog.Error(ctx, "failed to append filtered message, stop process to replay WAL",
+					mlog.String("message type", msg.Type().String()),
+					mlog.String("channel", fNode.channel),
+					mlog.FieldCollectionID(fNode.collectionID),
+					mlog.Err(wrapped))
+				panic(wrapped)
+			}
 		}
 	}
 	fNode.delegator.TryCleanExcludedSegments(streamMsgPack.EndTs)

--- a/internal/querynodev2/pipeline/filter_node_test.go
+++ b/internal/querynodev2/pipeline/filter_node_test.go
@@ -26,10 +26,14 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/pkg/v3/mocks/streaming/util/mock_message"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/adaptor"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -106,6 +110,41 @@ func (suite *FilterNodeSuite) TestWithLoadCollection() {
 		suite.True(lo.Contains(suite.validSegmentIDs, msg.SegmentID))
 	}
 	suite.Equal(suite.deleteSegmentSum, len(nodeMsg.deleteMsgs))
+}
+
+func (suite *FilterNodeSuite) TestSchemaChangeAppendErrorPanics() {
+	collection := segments.NewTestCollection(suite.collectionID, querypb.LoadType_LoadCollection, nil)
+	mockCollectionManager := segments.NewMockCollectionManager(suite.T())
+	mockCollectionManager.EXPECT().Get(suite.collectionID).Return(collection)
+
+	suite.manager = &segments.Manager{
+		Collection: mockCollectionManager,
+		Segment:    segments.NewMockSegmentManager(suite.T()),
+	}
+
+	validMutable := message.NewSchemaChangeMessageBuilderV2().
+		WithHeader(&message.SchemaChangeMessageHeader{
+			CollectionId: suite.collectionID,
+		}).
+		WithBody(&message.SchemaChangeMessageBody{
+			Schema: &schemapb.CollectionSchema{Version: 1},
+		}).
+		MustBuildMutable()
+	raw := validMutable.IntoMessageProto()
+	corruptedMutable := message.NewMutableMessageBeforeAppend([]byte{0xff}, raw.GetProperties()).WithTimeTick(10)
+	msgID := mock_message.NewMockMessageID(suite.T())
+	msgID.EXPECT().String().Return("mock-id").Maybe()
+	tsMsg, err := adaptor.NewSchemaChangeMessageBody(corruptedMutable.IntoImmutableMessage(msgID))
+	suite.Require().NoError(err)
+
+	node := newFilterNode(suite.collectionID, suite.channel, suite.manager, suite.delegator, 8)
+	suite.Panics(func() {
+		node.Operate(&msgstream.MsgPack{
+			BeginTs: 10,
+			EndTs:   10,
+			Msgs:    []msgstream.TsMsg{tsMsg},
+		})
+	})
 }
 
 // test filter node with collection load partition

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -53,6 +53,9 @@ type CollectionManager interface {
 	// version. The manager derives the logical schema version from schema.Version
 	// when a schema payload is present.
 	UpdateSchema(collectionID int64, schema *schemapb.CollectionSchema, schemaBarrierTs uint64) error
+	// UpdateIndexMeta updates only the native collection index metadata without
+	// changing the collection schema snapshot or its externally visible refs.
+	UpdateIndexMeta(collectionID int64, meta *segcorepb.CollectionIndexMeta) error
 }
 
 type collectionManager struct {
@@ -184,6 +187,16 @@ func (m *collectionManager) UpdateSchema(collectionID int64, schema *schemapb.Co
 	//   properties-only schema snapshots such as ttl_field changes.
 	_, _, err := collection.applySchemaUpdate(schema, logicalSchemaVersion, schemaBarrierTs)
 	return err
+}
+
+func (m *collectionManager) UpdateIndexMeta(collectionID int64, meta *segcorepb.CollectionIndexMeta) error {
+	collection, ok := m.acquireCollectionLease(collectionID)
+	if !ok {
+		return merr.WrapErrCollectionNotFound(collectionID, "collection not found in querynode collection manager")
+	}
+	defer m.Unref(collectionID, 1)
+
+	return collection.updateIndexMeta(meta)
 }
 
 // ShouldUpdateCollectionSchema reports whether an UpdateSchema payload would
@@ -332,7 +345,7 @@ type Collection struct {
 	// if resource group is not updated, the reference count of collection manager works failed.
 	metricType atomic.String // deprecated
 	schema     atomic.Pointer[collectionSchemaSnapshot]
-	isGpuIndex bool
+	isGpuIndex atomic.Bool
 	loadFields typeutil.Set[int64]
 
 	refCount *atomic.Uint32
@@ -412,10 +425,16 @@ func (c *Collection) updateIndexMeta(meta *segcorepb.CollectionIndexMeta) error 
 	if c.ccollection == nil {
 		return merr.WrapErrServiceInternal("update index meta on released collection")
 	}
+	isGpuIndex := collectionIndexMetaRequiresGPU(meta)
 	if proto.Equal(c.ccollection.IndexMeta(), meta) {
+		c.isGpuIndex.Store(isGpuIndex)
 		return nil
 	}
-	return c.ccollection.UpdateIndexMeta(meta)
+	if err := c.ccollection.UpdateIndexMeta(meta); err != nil {
+		return err
+	}
+	c.isGpuIndex.Store(isGpuIndex)
+	return nil
 }
 
 func (c *Collection) updateSchema(schema *schemapb.CollectionSchema, version uint64) error {
@@ -534,7 +553,7 @@ func (c *Collection) SchemaVersion() uint64 {
 
 // IsGpuIndex returns a boolean value indicating whether the collection is using a GPU index.
 func (c *Collection) IsGpuIndex() bool {
-	return c.isGpuIndex
+	return c.isGpuIndex.Load()
 }
 
 // getPartitionIDs return partitionIDs of collection
@@ -598,19 +617,13 @@ func NewCollection(collectionID int64, schema *schemapb.CollectionSchema, indexM
 		}
 	}
 
-	isGpuIndex := false
+	isGpuIndex := collectionIndexMetaRequiresGPU(indexMeta)
 	req := &segcore.CreateCCollectionRequest{
 		Schema:        loadSchema,
 		LoadFieldList: loadFieldIDs.Collect(),
 	}
 	if indexMeta != nil && len(indexMeta.GetIndexMetas()) > 0 && indexMeta.GetMaxIndexRowCount() > 0 {
 		req.IndexMeta = indexMeta
-		for _, indexMeta := range indexMeta.GetIndexMetas() {
-			isGpuIndex = gpuIndexRequiresGpu(indexMeta.GetIndexParams())
-			if isGpuIndex {
-				break
-			}
-		}
 	}
 
 	ccollection, err := segcore.CreateCCollection(req)
@@ -627,9 +640,9 @@ func NewCollection(collectionID int64, schema *schemapb.CollectionSchema, indexM
 		dbProperties:  loadMetaInfo.GetDbProperties(),
 		resourceGroup: loadMetaInfo.GetResourceGroup(),
 		refCount:      atomic.NewUint32(0),
-		isGpuIndex:    isGpuIndex,
 		loadFields:    loadFieldIDs,
 	}
+	coll.isGpuIndex.Store(isGpuIndex)
 	for _, partitionID := range loadMetaInfo.GetPartitionIDs() {
 		coll.partitions.Insert(partitionID)
 	}
@@ -638,6 +651,15 @@ func NewCollection(collectionID int64, schema *schemapb.CollectionSchema, indexM
 	coll.setSchema(schema, logicalSchemaVersion, schemaBarrierTs, initialSegcoreSchemaVersion(logicalSchemaVersion, schemaBarrierTs))
 
 	return coll, nil
+}
+
+func collectionIndexMetaRequiresGPU(indexMeta *segcorepb.CollectionIndexMeta) bool {
+	if indexMeta == nil || len(indexMeta.GetIndexMetas()) == 0 || indexMeta.GetMaxIndexRowCount() <= 0 {
+		return false
+	}
+	return lo.ContainsBy(indexMeta.GetIndexMetas(), func(indexMeta *segcorepb.FieldIndexMeta) bool {
+		return gpuIndexRequiresGpu(indexMeta.GetIndexParams())
+	})
 }
 
 // Only for test

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -377,6 +378,73 @@ func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMeta() {
 	s.True(found,
 		"PutOrRef should update IndexMeta for existing collections; field %d is missing",
 		newVecFieldID)
+}
+
+func (s *CollectionManagerSuite) TestUpdateIndexMetaOnlyChangesNativeMeta() {
+	coll := s.cm.Get(1)
+	s.Require().NotNil(coll)
+
+	schemaBefore, logicalVersionBefore, barrierBefore := coll.SchemaSnapshot()
+	_, segcoreVersionBefore := coll.SchemaAndSegcoreVersion()
+	refCountBefore := coll.refCount.Load()
+	indexMetaBefore := proto.Clone(coll.GetCCollection().IndexMeta()).(*segcorepb.CollectionIndexMeta)
+
+	updatedIndexMeta := proto.Clone(indexMetaBefore).(*segcorepb.CollectionIndexMeta)
+	updatedIndexMeta.MaxIndexRowCount++
+	s.Require().NotEqual(indexMetaBefore.GetMaxIndexRowCount(), updatedIndexMeta.GetMaxIndexRowCount())
+
+	err := s.cm.UpdateIndexMeta(1, updatedIndexMeta)
+	s.Require().NoError(err)
+
+	indexMetaAfter := coll.GetCCollection().IndexMeta()
+	s.True(proto.Equal(updatedIndexMeta, indexMetaAfter))
+	s.False(proto.Equal(indexMetaBefore, indexMetaAfter))
+
+	schemaAfter, logicalVersionAfter, barrierAfter := coll.SchemaSnapshot()
+	_, segcoreVersionAfter := coll.SchemaAndSegcoreVersion()
+	s.Same(schemaBefore, schemaAfter)
+	s.Equal(logicalVersionBefore, logicalVersionAfter)
+	s.Equal(barrierBefore, barrierAfter)
+	s.Equal(segcoreVersionBefore, segcoreVersionAfter)
+	s.Equal(refCountBefore, coll.refCount.Load())
+}
+
+func (s *CollectionManagerSuite) TestUpdateIndexMetaRefreshesGpuIndexFlag() {
+	coll := s.cm.Get(1)
+	s.Require().NotNil(coll)
+	s.False(coll.IsGpuIndex())
+
+	cpuIndexMeta := proto.Clone(coll.GetCCollection().IndexMeta()).(*segcorepb.CollectionIndexMeta)
+	s.Require().NotEmpty(cpuIndexMeta.GetIndexMetas())
+
+	gpuIndexMeta := proto.Clone(cpuIndexMeta).(*segcorepb.CollectionIndexMeta)
+	gpuIndexMeta.IndexMetas[0].IndexName = "GPU_IVF_FLAT"
+	gpuIndexMeta.IndexMetas[0].IndexParams = []*commonpb.KeyValuePair{
+		{Key: common.IndexTypeKey, Value: "GPU_IVF_FLAT"},
+		{Key: common.MetricTypeKey, Value: "L2"},
+	}
+
+	s.Require().NoError(s.cm.UpdateIndexMeta(1, gpuIndexMeta))
+	s.True(coll.IsGpuIndex())
+
+	// The equal-meta path also recomputes the derived scheduler flag, so a
+	// retry can repair stale Go-side state without rewriting native metadata.
+	coll.isGpuIndex.Store(false)
+	s.Require().NoError(s.cm.UpdateIndexMeta(1, gpuIndexMeta))
+	s.True(coll.IsGpuIndex())
+
+	emptyIndexMeta := &segcorepb.CollectionIndexMeta{MaxIndexRowCount: gpuIndexMeta.GetMaxIndexRowCount()}
+	s.Require().NoError(s.cm.UpdateIndexMeta(1, emptyIndexMeta))
+	s.Empty(coll.GetCCollection().IndexMeta().GetIndexMetas())
+	s.False(coll.IsGpuIndex())
+
+	s.Require().NoError(s.cm.UpdateIndexMeta(1, cpuIndexMeta))
+	s.False(coll.IsGpuIndex())
+}
+
+func (s *CollectionManagerSuite) TestUpdateIndexMetaMissingCollection() {
+	err := s.cm.UpdateIndexMeta(999, &segcorepb.CollectionIndexMeta{})
+	s.ErrorIs(err, merr.ErrCollectionNotFound)
 }
 
 func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMetaWaitsForCollectionNativeLock() {

--- a/internal/querynodev2/segments/mock_collection_manager.go
+++ b/internal/querynodev2/segments/mock_collection_manager.go
@@ -307,6 +307,53 @@ func (_c *MockCollectionManager_Unref_Call) RunAndReturn(run func(int64, uint32)
 	return _c
 }
 
+// UpdateIndexMeta provides a mock function with given fields: collectionID, meta
+func (_m *MockCollectionManager) UpdateIndexMeta(collectionID int64, meta *segcorepb.CollectionIndexMeta) error {
+	ret := _m.Called(collectionID, meta)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateIndexMeta")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, *segcorepb.CollectionIndexMeta) error); ok {
+		r0 = rf(collectionID, meta)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockCollectionManager_UpdateIndexMeta_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateIndexMeta'
+type MockCollectionManager_UpdateIndexMeta_Call struct {
+	*mock.Call
+}
+
+// UpdateIndexMeta is a helper method to define mock.On call
+//   - collectionID int64
+//   - meta *segcorepb.CollectionIndexMeta
+func (_e *MockCollectionManager_Expecter) UpdateIndexMeta(collectionID interface{}, meta interface{}) *MockCollectionManager_UpdateIndexMeta_Call {
+	return &MockCollectionManager_UpdateIndexMeta_Call{Call: _e.mock.On("UpdateIndexMeta", collectionID, meta)}
+}
+
+func (_c *MockCollectionManager_UpdateIndexMeta_Call) Run(run func(collectionID int64, meta *segcorepb.CollectionIndexMeta)) *MockCollectionManager_UpdateIndexMeta_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(int64), args[1].(*segcorepb.CollectionIndexMeta))
+	})
+	return _c
+}
+
+func (_c *MockCollectionManager_UpdateIndexMeta_Call) Return(_a0 error) *MockCollectionManager_UpdateIndexMeta_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockCollectionManager_UpdateIndexMeta_Call) RunAndReturn(run func(int64, *segcorepb.CollectionIndexMeta) error) *MockCollectionManager_UpdateIndexMeta_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateSchema provides a mock function with given fields: collectionID, schema, schemaBarrierTs
 func (_m *MockCollectionManager) UpdateSchema(collectionID int64, schema *schemapb.CollectionSchema, schemaBarrierTs uint64) error {
 	ret := _m.Called(collectionID, schema, schemaBarrierTs)

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -483,8 +483,11 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 	}
 	defer node.lifetime.Done()
 
-	// check index
-	if len(req.GetIndexInfoList()) == 0 {
+	// Full and delta loads still require an index. Reopen/Stats carries the
+	// complete collection index snapshot, so an empty list is authoritative and
+	// must be allowed to clear metadata after the last index is dropped.
+	isMetadataOnlyLoad := req.GetLoadScope() == querypb.LoadScope_Reopen || req.GetLoadScope() == querypb.LoadScope_Stats
+	if len(req.GetIndexInfoList()) == 0 && !isMetadataOnlyLoad {
 		err := merr.WrapErrIndexNotFoundForCollection(req.GetSchema().GetName())
 		return merr.Status(err), nil
 	}
@@ -536,25 +539,38 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 		return merr.Success(), nil
 	}
 
-	err := node.manager.Collection.PutOrRef(req.GetCollectionID(), req.GetSchema(),
-		segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), req.GetSchema()), req.GetLoadMeta())
-	if err != nil {
-		log.Warn(ctx, "failed to ref collection", mlog.Err(err))
-		return merr.Status(err), nil
-	}
-	defer node.manager.Collection.Unref(req.GetCollectionID(), 1)
-
 	switch req.GetLoadScope() {
+	case querypb.LoadScope_Stats, querypb.LoadScope_Reopen:
+		collection := node.manager.Collection.Get(req.GetCollectionID())
+		if collection == nil {
+			err := merr.WrapErrCollectionNotFound(req.GetCollectionID(), "collection not found before segment reopen")
+			return merr.Status(err), nil
+		}
+		meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), collection.Schema())
+		if err := node.manager.Collection.UpdateIndexMeta(req.GetCollectionID(), meta); err != nil {
+			log.Warn(ctx, "failed to update collection index meta before segment reopen", mlog.Err(err))
+			return merr.Status(err), nil
+		}
+		defer node.markDataDistributionSegmentLoadInfos(req.GetInfos())
+		return node.reopenSegments(ctx, req), nil
 	case querypb.LoadScope_Delta:
+		err := node.manager.Collection.PutOrRef(req.GetCollectionID(), req.GetSchema(),
+			segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), req.GetSchema()), req.GetLoadMeta())
+		if err != nil {
+			log.Warn(ctx, "failed to ref collection", mlog.Err(err))
+			return merr.Status(err), nil
+		}
+		defer node.manager.Collection.Unref(req.GetCollectionID(), 1)
 		defer node.markDataDistributionSegmentLoadInfos(req.GetInfos())
 		return node.loadDeltaLogs(ctx, req), nil
-	case querypb.LoadScope_Stats:
-		defer node.markDataDistributionSegmentLoadInfos(req.GetInfos())
-		return node.reopenSegments(ctx, req), nil
-	case querypb.LoadScope_Reopen:
-		defer node.markDataDistributionSegmentLoadInfos(req.GetInfos())
-		return node.reopenSegments(ctx, req), nil
 	case querypb.LoadScope_Full:
+		err := node.manager.Collection.PutOrRef(req.GetCollectionID(), req.GetSchema(),
+			segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), req.GetSchema()), req.GetLoadMeta())
+		if err != nil {
+			log.Warn(ctx, "failed to ref collection", mlog.Err(err))
+			return merr.Status(err), nil
+		}
+		defer node.manager.Collection.Unref(req.GetCollectionID(), 1)
 		defer node.markDataDistributionSegmentLoadInfos(req.GetInfos())
 		// Continue with the full segment load below.
 	case legacyLoadScopeIndex:

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
@@ -992,6 +993,299 @@ func (suite *ServiceSuite) TestLoadSegmentsReopenReportsDelta() {
 			suite.Empty(deltaResp.GetRemovedSegmentIds())
 		})
 	}
+}
+
+func (suite *ServiceSuite) TestLoadSegmentsReopenOnlyUpdatesIndexMeta() {
+	ctx := context.Background()
+
+	for _, loadScope := range []querypb.LoadScope{
+		querypb.LoadScope_Reopen,
+		querypb.LoadScope_Stats,
+	} {
+		suite.Run(loadScope.String(), func() {
+			originalCollectionManager := suite.node.manager.Collection
+			collectionManager := segments.NewCollectionManager()
+			suite.node.manager.Collection = collectionManager
+			defer func() {
+				suite.node.manager.Collection = originalCollectionManager
+			}()
+
+			servedSchema := mock_segcore.GenTestCollectionSchema("served-schema", schemapb.DataType_Int64, false)
+			servedSchema.Version = 7
+			const servedBarrier = uint64(100)
+			err := collectionManager.PutOrRef(
+				suite.collectionID,
+				servedSchema,
+				mock_segcore.GenTestIndexMeta(suite.collectionID, servedSchema),
+				&querypb.LoadMetaInfo{
+					LoadType:        querypb.LoadType_LoadCollection,
+					CollectionID:    suite.collectionID,
+					SchemaBarrierTs: servedBarrier,
+				},
+			)
+			suite.Require().NoError(err)
+			defer collectionManager.Unref(suite.collectionID, 1)
+
+			collection := collectionManager.Get(suite.collectionID)
+			suite.Require().NotNil(collection)
+			beforeSchema, beforeLogicalVersion, beforeBarrier := collection.SchemaSnapshot()
+			beforeSchema = proto.Clone(beforeSchema).(*schemapb.CollectionSchema)
+			_, beforeSegcoreVersion := collection.SchemaAndSegcoreVersion()
+
+			requestSchema := proto.Clone(servedSchema).(*schemapb.CollectionSchema)
+			requestSchema.Description = "request payload must not replace the served schema"
+			suite.Require().False(proto.Equal(beforeSchema, requestSchema))
+
+			indexInfos := mock_segcore.GenTestIndexInfoList(suite.collectionID, requestSchema)
+			suite.Require().NotEmpty(indexInfos)
+			indexInfos[0].IndexName = "reopen-index-meta"
+			updatedIndexFieldID := indexInfos[0].GetFieldID()
+
+			originalLoader := suite.node.loader
+			mockLoader := segments.NewMockLoader(suite.T())
+			suite.node.loader = mockLoader
+			defer func() {
+				suite.node.loader = originalLoader
+			}()
+
+			req := &querypb.LoadSegmentsRequest{
+				Base: &commonpb.MsgBase{
+					MsgID:    rand.Int63(),
+					TargetID: suite.node.session.ServerID,
+				},
+				CollectionID: suite.collectionID,
+				DstNodeID:    suite.node.session.ServerID,
+				Infos: []*querypb.SegmentLoadInfo{
+					{
+						CollectionID: suite.collectionID,
+						SegmentID:    suite.validSegmentIDs[0],
+					},
+				},
+				Schema:        requestSchema,
+				LoadMeta:      &querypb.LoadMetaInfo{CollectionID: suite.collectionID, SchemaBarrierTs: servedBarrier + 1},
+				LoadScope:     loadScope,
+				IndexInfoList: indexInfos,
+			}
+			mockLoader.EXPECT().ReopenSegments(mock.Anything, req.GetInfos()).Return(nil).Once()
+
+			status, err := suite.node.LoadSegments(ctx, req)
+			suite.Require().NoError(merr.CheckRPCCall(status, err))
+
+			afterSchema, afterLogicalVersion, afterBarrier := collection.SchemaSnapshot()
+			_, afterSegcoreVersion := collection.SchemaAndSegcoreVersion()
+			suite.True(proto.Equal(beforeSchema, afterSchema))
+			suite.Equal(beforeLogicalVersion, afterLogicalVersion)
+			suite.Equal(beforeBarrier, afterBarrier)
+			suite.Equal(beforeSegcoreVersion, afterSegcoreVersion)
+
+			updatedIndexMeta := collection.GetCCollection().IndexMeta()
+			suite.Require().NotNil(updatedIndexMeta)
+			suite.True(lo.ContainsBy(updatedIndexMeta.GetIndexMetas(), func(meta *segcorepb.FieldIndexMeta) bool {
+				return meta.GetFieldID() == updatedIndexFieldID && meta.GetIndexName() == "reopen-index-meta"
+			}))
+		})
+	}
+}
+
+func (suite *ServiceSuite) TestLoadSegmentsReopenAcceptsEmptyIndexMeta() {
+	ctx := context.Background()
+
+	for _, loadScope := range []querypb.LoadScope{
+		querypb.LoadScope_Reopen,
+		querypb.LoadScope_Stats,
+	} {
+		suite.Run(loadScope.String(), func() {
+			originalCollectionManager := suite.node.manager.Collection
+			collectionManager := segments.NewCollectionManager()
+			suite.node.manager.Collection = collectionManager
+			defer func() {
+				suite.node.manager.Collection = originalCollectionManager
+			}()
+
+			schema := mock_segcore.GenTestCollectionSchema("drop-last-index", schemapb.DataType_Int64, false)
+			err := collectionManager.PutOrRef(
+				suite.collectionID,
+				schema,
+				mock_segcore.GenTestIndexMeta(suite.collectionID, schema),
+				&querypb.LoadMetaInfo{CollectionID: suite.collectionID},
+			)
+			suite.Require().NoError(err)
+			defer collectionManager.Unref(suite.collectionID, 1)
+
+			collection := collectionManager.Get(suite.collectionID)
+			suite.Require().NotNil(collection)
+			suite.Require().NotEmpty(collection.GetCCollection().IndexMeta().GetIndexMetas())
+
+			originalLoader := suite.node.loader
+			mockLoader := segments.NewMockLoader(suite.T())
+			suite.node.loader = mockLoader
+			defer func() {
+				suite.node.loader = originalLoader
+			}()
+
+			req := &querypb.LoadSegmentsRequest{
+				Base: &commonpb.MsgBase{
+					MsgID:    rand.Int63(),
+					TargetID: suite.node.session.ServerID,
+				},
+				CollectionID: suite.collectionID,
+				DstNodeID:    suite.node.session.ServerID,
+				Infos: []*querypb.SegmentLoadInfo{{
+					CollectionID: suite.collectionID,
+					SegmentID:    suite.validSegmentIDs[0],
+					Level:        datapb.SegmentLevel_L1,
+				}},
+				Schema:        schema,
+				LoadScope:     loadScope,
+				IndexInfoList: nil,
+			}
+			mockLoader.EXPECT().ReopenSegments(mock.Anything, req.GetInfos()).Return(nil).Once()
+
+			status, err := suite.node.LoadSegments(ctx, req)
+			suite.Require().NoError(merr.CheckRPCCall(status, err))
+			suite.Empty(collection.GetCCollection().IndexMeta().GetIndexMetas())
+		})
+	}
+}
+
+func (suite *ServiceSuite) TestLoadSegmentsTransferReopenAcceptsEmptyIndexMeta() {
+	ctx := context.Background()
+
+	for _, loadScope := range []querypb.LoadScope{
+		querypb.LoadScope_Reopen,
+		querypb.LoadScope_Stats,
+	} {
+		suite.Run(loadScope.String(), func() {
+			delegator := delegator.NewMockShardDelegator(suite.T())
+			suite.node.delegators.Insert(suite.vchannel, delegator)
+			defer suite.node.delegators.GetAndRemove(suite.vchannel)
+
+			delegator.EXPECT().LoadSegments(mock.Anything, mock.MatchedBy(func(req *querypb.LoadSegmentsRequest) bool {
+				return req.GetLoadScope() == loadScope && !req.GetNeedTransfer() && len(req.GetIndexInfoList()) == 0
+			})).Return(nil).Once()
+
+			schema := mock_segcore.GenTestCollectionSchema(suite.collectionName, schemapb.DataType_Int64, false)
+			req := &querypb.LoadSegmentsRequest{
+				Base: &commonpb.MsgBase{
+					MsgID:    rand.Int63(),
+					TargetID: suite.node.session.ServerID,
+				},
+				CollectionID: suite.collectionID,
+				DstNodeID:    suite.node.session.ServerID,
+				Infos: []*querypb.SegmentLoadInfo{{
+					CollectionID:  suite.collectionID,
+					SegmentID:     suite.validSegmentIDs[0],
+					InsertChannel: suite.vchannel,
+					Level:         datapb.SegmentLevel_L1,
+				}},
+				Schema:        schema,
+				NeedTransfer:  true,
+				LoadScope:     loadScope,
+				IndexInfoList: nil,
+			}
+
+			status, err := suite.node.LoadSegments(ctx, req)
+			suite.Require().NoError(merr.CheckRPCCall(status, err))
+		})
+	}
+}
+
+func (suite *ServiceSuite) TestLoadSegmentsReopenMissingCollectionSkipsLoader() {
+	ctx := context.Background()
+	schema := mock_segcore.GenTestCollectionSchema("missing-collection", schemapb.DataType_Int64, false)
+	indexInfos := mock_segcore.GenTestIndexInfoList(suite.collectionID, schema)
+
+	for _, loadScope := range []querypb.LoadScope{
+		querypb.LoadScope_Reopen,
+		querypb.LoadScope_Stats,
+	} {
+		suite.Run(loadScope.String(), func() {
+			originalCollectionManager := suite.node.manager.Collection
+			suite.node.manager.Collection = segments.NewCollectionManager()
+			defer func() {
+				suite.node.manager.Collection = originalCollectionManager
+			}()
+
+			originalLoader := suite.node.loader
+			mockLoader := segments.NewMockLoader(suite.T())
+			suite.node.loader = mockLoader
+			defer func() {
+				suite.node.loader = originalLoader
+			}()
+
+			req := &querypb.LoadSegmentsRequest{
+				Base: &commonpb.MsgBase{
+					MsgID:    rand.Int63(),
+					TargetID: suite.node.session.ServerID,
+				},
+				CollectionID: suite.collectionID,
+				DstNodeID:    suite.node.session.ServerID,
+				Infos: []*querypb.SegmentLoadInfo{
+					{
+						CollectionID: suite.collectionID,
+						SegmentID:    suite.validSegmentIDs[0],
+					},
+				},
+				Schema:        schema,
+				LoadScope:     loadScope,
+				IndexInfoList: indexInfos,
+			}
+
+			status, err := suite.node.LoadSegments(ctx, req)
+			suite.Require().NoError(err)
+			suite.ErrorIs(merr.Error(status), merr.ErrCollectionNotFound)
+			mockLoader.AssertNotCalled(suite.T(), "ReopenSegments", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func (suite *ServiceSuite) TestLoadSegmentsReopenIndexMetaFailureSkipsLoader() {
+	ctx := context.Background()
+	schema := mock_segcore.GenTestCollectionSchema("index-meta-failure", schemapb.DataType_Int64, false)
+	indexInfos := mock_segcore.GenTestIndexInfoList(suite.collectionID, schema)
+	suite.Require().NotEmpty(indexInfos)
+
+	collection := segments.NewCollectionWithoutSegcoreForTest(suite.collectionID, schema)
+	collectionManager := segments.NewMockCollectionManager(suite.T())
+	collectionManager.EXPECT().Get(suite.collectionID).Return(collection).Once()
+	indexMetaErr := merr.WrapErrServiceUnavailableMsg("mocked index meta update failure")
+	collectionManager.EXPECT().UpdateIndexMeta(
+		suite.collectionID,
+		mock.AnythingOfType("*segcorepb.CollectionIndexMeta"),
+	).Return(indexMetaErr).Once()
+
+	originalCollectionManager := suite.node.manager.Collection
+	suite.node.manager.Collection = collectionManager
+	defer func() {
+		suite.node.manager.Collection = originalCollectionManager
+	}()
+
+	originalLoader := suite.node.loader
+	mockLoader := segments.NewMockLoader(suite.T())
+	suite.node.loader = mockLoader
+	defer func() {
+		suite.node.loader = originalLoader
+	}()
+
+	status, err := suite.node.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+		Base: &commonpb.MsgBase{
+			MsgID:    rand.Int63(),
+			TargetID: suite.node.session.ServerID,
+		},
+		CollectionID: suite.collectionID,
+		DstNodeID:    suite.node.session.ServerID,
+		Infos: []*querypb.SegmentLoadInfo{{
+			CollectionID: suite.collectionID,
+			SegmentID:    suite.validSegmentIDs[0],
+		}},
+		Schema:        schema,
+		LoadScope:     querypb.LoadScope_Reopen,
+		IndexInfoList: indexInfos,
+	})
+
+	suite.Require().NoError(err)
+	suite.ErrorIs(merr.Error(status), merr.ErrServiceUnavailable)
+	mockLoader.AssertNotCalled(suite.T(), "ReopenSegments", mock.Anything, mock.Anything)
 }
 
 func (suite *ServiceSuite) TestLoadSegments_Failed() {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -209,6 +209,10 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 	// fill the put load config if rg or replica number is changed.
 	udpates.AlterLoadConfig = c.getAlterLoadConfigOfAlterCollection(coll.Properties, udpates.Properties)
 
+	if err := validateAlterCollectionSchemaPayloadVersion(coll.SchemaVersion, header, udpates); err != nil {
+		return err
+	}
+
 	channels := make([]string, 0, len(coll.VirtualChannelNames)+1)
 	channels = append(channels, streaming.WAL().ControlChannel())
 	channels = append(channels, coll.VirtualChannelNames...)
@@ -221,6 +225,23 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateAlterCollectionSchemaPayloadVersion(currentVersion int32, header *messagespb.AlterCollectionMessageHeader, updates *messagespb.AlterCollectionMessageUpdates) error {
+	if header == nil || header.GetUpdateMask() == nil || !funcutil.SliceContain(header.GetUpdateMask().GetPaths(), message.FieldMaskCollectionSchema) {
+		return nil
+	}
+	if updates == nil || updates.GetSchema() == nil {
+		return merr.WrapErrServiceInternalMsg("alter collection schema update mask requires schema payload")
+	}
+	if updates.GetSchema().GetVersion() <= currentVersion {
+		return merr.WrapErrServiceInternalMsg(
+			"alter collection schema payload must advance schema version, current=%d, payload=%d",
+			currentVersion,
+			updates.GetSchema().GetVersion(),
+		)
 	}
 	return nil
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -123,20 +123,24 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionConsistencyLevel)
 			}
 		case common.CollectionExternalSource:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSource = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			if prop.GetValue() != coll.ExternalSource {
+				if udpates.Schema == nil {
+					udpates.Schema = &schemapb.CollectionSchema{}
+				}
+				udpates.Schema.ExternalSource = prop.GetValue()
+				if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+					header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+				}
 			}
 		case common.CollectionExternalSpec:
-			if udpates.Schema == nil {
-				udpates.Schema = &schemapb.CollectionSchema{}
-			}
-			udpates.Schema.ExternalSpec = prop.GetValue()
-			if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
-				header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+			if prop.GetValue() != coll.ExternalSpec {
+				if udpates.Schema == nil {
+					udpates.Schema = &schemapb.CollectionSchema{}
+				}
+				udpates.Schema.ExternalSpec = prop.GetValue()
+				if !funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec) {
+					header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+				}
 			}
 		default:
 			newProperties[prop.GetKey()] = prop.GetValue()
@@ -153,12 +157,15 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 		header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionProperties)
 	}
 
-	// If TTL field is changed through properties, also broadcast an updated schema snapshot and mark it as schema change,
-	// so QueryNode can refresh runtime schema properties without requiring release/load.
+	// If a property alter changes schema payload, broadcast a full schema
+	// snapshot and mark it as schema change so WAL consumers advance by
+	// schema.Version instead of relying on the broadcast timestamp.
 	ttlOld, okOld := oldProperties[common.CollectionTTLFieldKey]
 	ttlNew, okNew := newProperties[common.CollectionTTLFieldKey]
 	needTTLFieldSchemaRefresh := (okOld != okNew) || (okOld && okNew && ttlOld != ttlNew)
-	if needTTLFieldSchemaRefresh {
+	needExternalSpecSchemaRefresh := funcutil.SliceContain(header.UpdateMask.Paths, message.FieldMaskCollectionExternalSpec)
+	if needTTLFieldSchemaRefresh || needExternalSpecSchemaRefresh {
+		schemaUpdate := udpates.Schema
 		// validate ttl field name exists in schema fields when setting it
 		if okNew {
 			found := false
@@ -178,16 +185,18 @@ func (c *Core) broadcastAlterCollectionForAlterCollection(ctx context.Context, r
 			header.UpdateMask.Paths = append(header.UpdateMask.Paths, message.FieldMaskCollectionSchema)
 		}
 
-		// Build schema snapshot with updated properties (schema version should NOT be changed for properties-only alter).
+		// Build schema snapshot with updated properties. Any schema payload
+		// change must advance schema.Version so WAL consumers can gate on it.
 		schema := coll.ToCollectionSchemaPB()
+		schema.Version = coll.SchemaVersion + 1
 		schema.Properties = newPropsKeyValuePairs
 		// Preserve ExternalSource/ExternalSpec from current collection state
 		// unless this alter is itself updating them (refresh-completion sync).
-		if udpates.Schema != nil && udpates.Schema.ExternalSource != "" {
-			schema.ExternalSource = udpates.Schema.ExternalSource
+		if schemaUpdate != nil && schemaUpdate.ExternalSource != "" {
+			schema.ExternalSource = schemaUpdate.ExternalSource
 		}
-		if udpates.Schema != nil && udpates.Schema.ExternalSpec != "" {
-			schema.ExternalSpec = udpates.Schema.ExternalSpec
+		if schemaUpdate != nil && schemaUpdate.ExternalSpec != "" {
+			schema.ExternalSpec = schemaUpdate.ExternalSpec
 		}
 		udpates.Schema = schema
 	}

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -685,14 +685,14 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldShouldBroadcastSchema(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
 
-	// Alter properties to set ttl field should succeed and should NOT change schema version in meta.
+	// Alter properties to set ttl field should bump schema version because it broadcasts a schema payload.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
 		DbName:         dbName,
 		CollectionName: collectionName,
 		Properties:     []*commonpb.KeyValuePair{{Key: common.CollectionTTLFieldKey, Value: "ttl"}},
 	})
 	require.NoError(t, merr.CheckRPCCall(resp, err))
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *testing.T) {
@@ -738,6 +738,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 0)
 
 	// Alter TTL field only — must preserve previously persisted external source/spec.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
@@ -750,6 +751,7 @@ func TestDDLCallbacksAlterCollectionProperties_TTLFieldPreservesExternalSpec(t *
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/ttl-path")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 
 	// TTL with invalid field name still rejected.
 	resp, err = core.AlterCollection(ctx, &milvuspb.AlterCollectionRequest{
@@ -818,6 +820,7 @@ func TestDDLCallbacksAlterCollectionProperties_AcceptExternalSourceSpec(t *testi
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 // Regression for #49335: refresh override path may carry source-only updates
@@ -861,6 +864,7 @@ func TestDDLCallbacksAlterCollectionProperties_PartialExternalUpdatePreservesOth
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertExternalSpec(t, ctx, core, dbName, collectionName, `{"format":"parquet","extfs":{"anonymous":"true","region":"us-east-1","cloud_provider":"aws"}}`)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 // Regression for #49335: alter that mixes external_source with a regular
@@ -905,6 +909,7 @@ func TestDDLCallbacksAlterCollectionProperties_MixedExternalAndRegular(t *testin
 	require.NoError(t, merr.CheckRPCCall(resp, err))
 	assertExternalSource(t, ctx, core, dbName, collectionName, "s3://bucket/new/")
 	assertReplicaNumber(t, ctx, core, dbName, collectionName, 2)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 1)
 }
 
 func createCollectionForTest(t *testing.T, ctx context.Context, core *Core, dbName string, collectionName string) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -345,6 +346,23 @@ func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigRPCError(t *te
 		Results: map[string]*message.AppendResult{},
 	})
 	require.Error(t, err)
+}
+
+func TestValidateAlterCollectionSchemaPayloadVersion(t *testing.T) {
+	header := &messagespb.AlterCollectionMessageHeader{
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{message.FieldMaskCollectionSchema},
+		},
+	}
+
+	require.NoError(t, validateAlterCollectionSchemaPayloadVersion(10, &messagespb.AlterCollectionMessageHeader{}, nil))
+	require.Error(t, validateAlterCollectionSchemaPayloadVersion(10, header, nil))
+	require.Error(t, validateAlterCollectionSchemaPayloadVersion(10, header, &messagespb.AlterCollectionMessageUpdates{
+		Schema: &schemapb.CollectionSchema{Version: 10},
+	}))
+	require.NoError(t, validateAlterCollectionSchemaPayloadVersion(10, header, &messagespb.AlterCollectionMessageUpdates{
+		Schema: &schemapb.CollectionSchema{Version: 11},
+	}))
 }
 
 func TestDDLCallbacksAlterCollectionV2AckCallback_UpdateLoadConfigNonRGNotFoundError(t *testing.T) {

--- a/internal/util/pipeline/node.go
+++ b/internal/util/pipeline/node.go
@@ -28,6 +28,10 @@ type Node interface {
 	Close()
 }
 
+type preCloser interface {
+	PreClose()
+}
+
 type nodeCtx struct {
 	node         Node
 	InputChannel chan Msg

--- a/internal/util/pipeline/pipeline.go
+++ b/internal/util/pipeline/pipeline.go
@@ -77,6 +77,14 @@ func (p *pipeline) Close() {
 	}
 }
 
+func (p *pipeline) PreClose() {
+	for _, node := range p.nodes {
+		if preCloser, ok := node.node.(preCloser); ok {
+			preCloser.PreClose()
+		}
+	}
+}
+
 func (p *pipeline) process() {
 	if len(p.nodes) == 0 {
 		return

--- a/internal/util/pipeline/stream_pipeline.go
+++ b/internal/util/pipeline/stream_pipeline.go
@@ -161,6 +161,7 @@ func (p *streamPipeline) Close() {
 		p.dispatcher.Deregister(p.vChannel)
 		// close stream input
 		close(p.closeCh)
+		p.pipeline.PreClose()
 		p.closeWg.Wait()
 		if p.scanner != nil {
 			p.scanner.Close()

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -20,6 +20,7 @@ import (
 	context2 "context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -134,6 +135,44 @@ func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherMergesBufferedDMLPacks() 
 	suite.Empty(received)
 }
 
+func (suite *StreamPipelineSuite) TestClosePreClosesNodesBeforeWaitingWorkDone() {
+	node := &preCloseBlockingNode{
+		BaseNode:  NewBaseNode("pre-close-blocking", 8),
+		operating: make(chan struct{}),
+		preClosed: make(chan struct{}),
+	}
+	suite.pipeline.Add(node)
+
+	err := suite.pipeline.ConsumeMsgStream(context2.Background(), &msgpb.MsgPosition{})
+	suite.NoError(err)
+	suite.NoError(suite.pipeline.Start())
+	suite.inChannel <- &msgstream.MsgPack{BeginTs: 1001}
+
+	suite.Eventually(func() bool {
+		select {
+		case <-node.operating:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.pipeline.Close()
+	}()
+
+	suite.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
 func TestDMLMsgPackBatcherLimitsByTotalMessageNum(t *testing.T) {
 	maxMsgNum := 3
 	batcher := NewDMLMsgPackBatcher(func() int { return maxMsgNum })
@@ -190,6 +229,22 @@ type captureMsgPackNode struct {
 func (node *captureMsgPackNode) Operate(in Msg) Msg {
 	node.outChannel <- in.(*msgstream.MsgPack)
 	return nil
+}
+
+type preCloseBlockingNode struct {
+	*BaseNode
+	operating chan struct{}
+	preClosed chan struct{}
+}
+
+func (node *preCloseBlockingNode) Operate(in Msg) Msg {
+	close(node.operating)
+	<-node.preClosed
+	return in
+}
+
+func (node *preCloseBlockingNode) PreClose() {
+	close(node.preClosed)
 }
 
 func newDMLMsgPack(beginTs, endTs uint64, msgs ...msgstream.TsMsg) *msgstream.MsgPack {

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -103,6 +103,9 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3), ErrCollectionSchemaVersionNotReady)
 	s.True(Status(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3)).GetRetriable())
 	s.Equal(commonpb.ErrorCode_NotReadyServe, Status(WrapErrCollectionSchemaVersionNotReady("test_collection", 1, 3)).GetErrorCode())
+	s.ErrorIs(WrapErrCollectionSchemaVersionNotReadyWithVersion("test_collection", 1, 3), ErrCollectionSchemaVersionNotReady)
+	s.True(Status(WrapErrCollectionSchemaVersionNotReadyWithVersion("test_collection", 1, 3)).GetRetriable())
+	s.Equal(commonpb.ErrorCode_NotReadyServe, Status(WrapErrCollectionSchemaVersionNotReadyWithVersion("test_collection", 1, 3)).GetErrorCode())
 	// Partition related
 	s.ErrorIs(WrapErrPartitionNotFound("test_partition", "failed to get partition"), ErrPartitionNotFound)
 	s.ErrorIs(WrapErrPartitionNotLoaded("test_partition", "failed to query"), ErrPartitionNotLoaded)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -682,6 +682,14 @@ func WrapErrCollectionSchemaVersionNotReady(collection any, consistentSegments, 
 	)
 }
 
+func WrapErrCollectionSchemaVersionNotReadyWithVersion(collection any, currentVersion, requiredVersion uint64) error {
+	return wrapFieldsWithDesc(
+		ErrCollectionSchemaVersionNotReady,
+		fmt.Sprintf("current schema version %d, required schema version %d", currentVersion, requiredVersion),
+		value("collection", collection),
+	)
+}
+
 func WrapErrAliasNotFound(db any, alias any, msg ...string) error {
 	err := wrapFields(ErrAliasNotFound,
 		value("database", db),


### PR DESCRIPTION
issue: #51062

Depends on #51886 and should merge after it. Also covers the per-shard runtime race described in #50989.

## Summary

#51886 makes the shard WAL schema version the load/reopen fence and keeps schema-not-ready tasks retryable. This follow-up makes the remaining Reopen side effects schema-neutral and convergent:

- Initialize each shard delegator from one coherent collection schema snapshot.
- Gate DDL runtime work on the shard delegator served schema, so another shard or a shared Collection update cannot suppress this shard function-runner and IDF update.
- Make worker and delegator Reopen/Stats update only collection index metadata, without changing schema, schema versions, barriers, or externally visible collection refs.
- Treat an empty Reopen/Stats index snapshot as authoritative, so dropping the final index clears native metadata and the GPU scheduler flag. Full and Delta loads still require an index.
- Finish BM25 and index-meta preparation before the worker reopens a segment. A preparation failure therefore leaves worker distribution stale and retryable.
- Return retryable ServiceNotReady while an active BM25 function has no oracle.
- Filter historical BM25 logs against the fenced current schema, so logs for dropped fields neither block forever nor get installed again.
- Keep the scheduler GPU-index flag synchronized with index-only metadata updates.

This replaces the relevant minimal-convergence pieces from #51818 and #51785 without collapsing the existing schema version domains.

## Retry and ordering

- Per-shard WAL UpdateSchema retry, including partial worker fanout failure, and schema-version fencing are provided by #51886.
- Delegator preflight failure happens before the worker RPC, so QueryCoord still observes stale worker distribution and schedules Reopen again.
- Worker-side index-meta failure happens before segment Reopen and is safe to retry.
- BM25 installation and identical index-meta updates are idempotent across retries.
- A DDL that lands during the worker RPC is caught by the existing post-RPC schema check; QueryCoord retries with refreshed metadata.

## Scope

This intentionally does not solve concurrent last-writer-wins updates between different whole CollectionIndexMeta snapshots. That ordering problem is independent of Reopen schema/runtime ownership.

## Tests

Added focused coverage for:

- BM25 preflight failure before the worker call, successful retry, and no double merge.
- Active BM25 with a nil oracle before Reopen and Full worker commits.
- Historical or mixed active/dropped BM25 logs.
- Delegator index-meta failure skipping the worker call.
- Worker index-meta failure skipping segment Reopen.
- Worker/delegator schema, barrier, segcore-version, and ref isolation.
- Per-shard DDL runtime updates over a shared Collection.
- CPU/GPU/empty scheduler flag convergence after index-meta updates.
- Empty Reopen/Stats index snapshots on direct-worker and NeedTransfer paths.
- Clearing native collection metadata after dropping the final index.
- Coherent delegator construction from one schema snapshot.

The required local Go test command is blocked on this macOS host by missing rocksdb, milvus_core, and milvus-storage pkg-config artifacts. PR CI is the verification path for the native-backed packages.

