### PR TITLE
feat: support Apache Paimon external collections

### DIFF
--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -745,8 +746,9 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
     }
 
     // Format-layer: emit per-format properties derived from spec.format.
-    // Currently only Iceberg-table → iceberg.snapshot_id. Future formats
-    // (Lance version, Iceberg branch, etc.) land here.
+    // Currently iceberg-table → iceberg.snapshot_id and paimon-table →
+    // paimon.snapshot_id. Future formats (Lance version, Iceberg branch,
+    // etc.) land here.
     if (external_spec.empty()) {
         return;
     }
@@ -758,7 +760,16 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
         if (doc.find_field("format").get_string().get(format_view) ==
             simdjson::SUCCESS) {
             std::string format{format_view};
+            // Table formats whose snapshot pin travels as a loon property.
+            // For paimon-table the property is optional: when absent, the
+            // planner reads the latest snapshot.
+            const char* snapshot_property = nullptr;
             if (format == "iceberg-table") {
+                snapshot_property = "iceberg.snapshot_id";
+            } else if (format == "paimon-table") {
+                snapshot_property = "paimon.snapshot_id";
+            }
+            if (snapshot_property != nullptr) {
                 auto snapshot_field = doc.find_field("snapshot_id");
                 int64_t snapshot_id = 0;
                 auto int_err = snapshot_field.get_int64().get(snapshot_id);
@@ -772,8 +783,9 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
                             int_err = simdjson::SUCCESS;
                         } catch (const std::exception& e) {
                             LOG_WARN(
-                                "iceberg snapshot_id parse failed "
+                                "{} parse failed "
                                 "(collection_id={}): {}",
+                                snapshot_property,
                                 collection_id,
                                 e.what());
                         }
@@ -782,7 +794,7 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
                 if (int_err == simdjson::SUCCESS) {
                     milvus_storage::api::SetValue(
                         properties,
-                        "iceberg.snapshot_id",
+                        snapshot_property,
                         std::to_string(snapshot_id).c_str());
                 }
             }
@@ -791,6 +803,34 @@ InjectExternalSpecProperties(milvus_storage::api::Properties& properties,
         // Top-level parse failure already caught by the extfs block above;
         // this second pass only runs after the first succeeded.
         LOG_WARN("format-props parse failed (collection_id={}): {}",
+                 collection_id,
+                 e.what());
+    }
+
+    // Paimon's path selection is a format property, not an extfs setting.
+    // Parse it independently from the on-demand snapshot pass above so JSON
+    // field order cannot affect lookup. Go validates the enum at the API
+    // boundary; milvus-storage validates it again when the property is set.
+    try {
+        const auto spec = json::parse(external_spec);
+        if (spec.value("format", std::string{}) == "paimon-table") {
+            auto scan_mode = spec.find("scan_mode");
+            if (scan_mode != spec.end()) {
+                AssertInfo(scan_mode->is_string(),
+                           "Paimon scan_mode must be a string");
+                milvus_storage::api::SetValue(
+                    properties,
+                    PROPERTY_PAIMON_SCAN_MODE,
+                    scan_mode->get_ref<const std::string&>().c_str());
+            }
+        }
+    } catch (const json::exception& e) {
+        // Every pass in this function tolerates a structurally broken spec:
+        // Go's ParseExternalSpec rejects it long before this point, and the
+        // extfs passes above still populate what they derived from the URI.
+        // Throwing here would turn that documented fallthrough into a load
+        // failure (InjectExtfsAllowlist.InvalidJsonIsHandledGracefully).
+        LOG_WARN("Paimon scan_mode parse failed (collection_id={}): {}",
                  collection_id,
                  e.what());
     }
@@ -892,6 +932,41 @@ GetLoonManifest(
     }
 }
 
+namespace {
+
+// TODO: the vector<string> comma join is ambiguous when an element contains
+// a comma, and std::to_string renders doubles with fixed six decimals. No
+// property crossing this C-ABI today carries either shape; revisit the
+// encoding before one does.
+std::string
+PropertyValueToString(const milvus_storage::api::PropertyVariant& value) {
+    return std::visit(
+        [](const auto& v) -> std::string {
+            using T = std::decay_t<decltype(v)>;
+            if constexpr (std::is_same_v<T, bool>) {
+                return v ? "true" : "false";
+            } else if constexpr (std::is_same_v<T, std::nullptr_t>) {
+                return "";
+            } else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
+                std::ostringstream output;
+                for (size_t i = 0; i < v.size(); ++i) {
+                    if (i != 0) {
+                        output << ',';
+                    }
+                    output << v[i];
+                }
+                return output.str();
+            } else if constexpr (std::is_arithmetic_v<T>) {
+                return std::to_string(v);
+            } else {
+                return v;
+            }
+        },
+        value);
+}
+
+}  // namespace
+
 // ==================== C-ABI: external spec injection ====================
 //
 // Bridges Go callers into the C++ InjectExternalSpecProperties pipeline so
@@ -949,8 +1024,8 @@ loon_properties_inject_external_spec(LoonProperties* properties,
         size_t i = 0;
         for (const auto& kv : props) {
             arr[i].key = strdup(kv.first.c_str());
-            const auto* sval = std::get_if<std::string>(&kv.second);
-            arr[i].value = strdup(sval ? sval->c_str() : "");
+            const auto value = PropertyValueToString(kv.second);
+            arr[i].value = strdup(value.c_str());
             ++i;
         }
         properties->properties = arr;

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,8 +14,8 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 63c29c6)
-set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
+set( milvus-storage_VERSION 1292eccc)
+set( GIT_REPOSITORY  "https://github.com/yanbinyang/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")
 

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -41,6 +41,7 @@
 #include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegmentSealed.h"
 #include "storage/Util.h"
+#include "storage/loon_ffi/external_spec_c.h"
 #include "storage/loon_ffi/util.h"
 
 using namespace milvus;
@@ -3298,6 +3299,73 @@ TEST(InjectExtfsAllowlist, IcebergSnapshotIDAcceptsString) {
 
     EXPECT_EQ(std::get<std::string>(props.at("iceberg.snapshot_id")),
               "5320540205222981137");
+}
+
+TEST(InjectExtfsAllowlist, PaimonSnapshotIDAcceptsStringAndNumber) {
+    const int64_t coll_id = 42;
+    {
+        milvus_storage::api::Properties props;
+        std::string spec =
+            R"({"format":"paimon-table","snapshot_id":"5320540205222981137"})";
+        ::InjectExternalSpecProperties(
+            props, coll_id, "s3://s3.amazonaws.com/bucket/key", spec);
+        EXPECT_EQ(std::get<int64_t>(props.at("paimon.snapshot_id")),
+                  int64_t{5320540205222981137});
+    }
+    {
+        milvus_storage::api::Properties props;
+        std::string spec = R"({"format":"paimon-table","snapshot_id":7})";
+        ::InjectExternalSpecProperties(
+            props, coll_id, "s3://s3.amazonaws.com/bucket/key", spec);
+        EXPECT_EQ(std::get<int64_t>(props.at("paimon.snapshot_id")),
+                  int64_t{7});
+    }
+}
+
+TEST(InjectExtfsAllowlist, PaimonSnapshotIDSurvivesCABIConversion) {
+    LoonProperties props{nullptr, 0};
+    auto result = loon_properties_inject_external_spec(
+        &props,
+        42,
+        "s3://s3.amazonaws.com/bucket/key",
+        R"({"format":"paimon-table","snapshot_id":"5320540205222981137"})");
+    ASSERT_NE(loon_ffi_is_success(&result), 0);
+    loon_ffi_free_result(&result);
+
+    const auto* snapshot_id = loon_properties_get(&props, "paimon.snapshot_id");
+    ASSERT_NE(snapshot_id, nullptr);
+    EXPECT_STREQ(snapshot_id, "5320540205222981137");
+
+    const auto* use_ssl = loon_properties_get(&props, "extfs.42.use_ssl");
+    ASSERT_NE(use_ssl, nullptr);
+    EXPECT_STREQ(use_ssl, "true");
+
+    loon_properties_free(&props);
+}
+
+TEST(InjectExtfsAllowlist, PaimonSnapshotIDOptional) {
+    // Without snapshot_id the property must stay absent so the paimon
+    // planner falls back to the latest snapshot.
+    milvus_storage::api::Properties props;
+    const int64_t coll_id = 42;
+    std::string spec = R"({"format":"paimon-table"})";
+
+    ::InjectExternalSpecProperties(
+        props, coll_id, "s3://s3.amazonaws.com/bucket/key", spec);
+
+    EXPECT_EQ(props.count("paimon.snapshot_id"), 0u);
+}
+
+TEST(InjectExtfsAllowlist, PaimonScanModeIsInjected) {
+    milvus_storage::api::Properties props;
+    const int64_t coll_id = 42;
+    std::string spec = R"({"format":"paimon-table","scan_mode":"direct-file"})";
+
+    ::InjectExternalSpecProperties(
+        props, coll_id, "s3://s3.amazonaws.com/bucket/key", spec);
+
+    EXPECT_EQ(std::get<std::string>(props.at(PROPERTY_PAIMON_SCAN_MODE)),
+              "direct-file");
 }
 
 // ============================================================

--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -304,7 +304,7 @@ func (t *RefreshExternalCollectionTask) GetKeptSegmentIDs() []int64 {
 // fragmentKey identifies the L1 data fragment. Delete overlays are handled as
 // manifest-only updates so L0 changes do not force a new target segment ID.
 func fragmentKey(f packed.Fragment) string {
-	return fmt.Sprintf("%s:%d:%d", f.FilePath, f.StartRow, f.EndRow)
+	return packed.FragmentIdentity(f)
 }
 
 // buildCurrentSegmentFragments builds segment to fragments mapping from current segments
@@ -723,62 +723,117 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 			}
 		}
 	} else {
+		// DataCoord derives this target from the configured segment sizing policy
+		// and passes it with the refresh request.
 		targetRowsPerSegment := t.req.GetTargetRowsPerSegment()
+		if targetRowsPerSegment <= 0 {
+			return nil, merr.WrapErrParameterInvalidMsg("external collection target rows per segment must be positive")
+		}
 		if totalRows < targetRowsPerSegment {
 			targetRowsPerSegment = totalRows
 		}
 
-		numSegments := (totalRows + targetRowsPerSegment - 1) / targetRowsPerSegment
-		if numSegments == 0 {
-			numSegments = 1
-		}
-
-		avgRowsPerSegment := totalRows / numSegments
-
-		mlog.Info(context.TODO(), "Balancing fragments to segments",
-			mlog.Int("numFragments", len(fragments)),
-			mlog.Int64("totalRows", totalRows),
-			mlog.Int64("numSegments", numSegments),
-			mlog.Int64("avgRowsPerSegment", avgRowsPerSegment))
-
-		// Sort fragments by row count descending for better bin-packing
-		sortedFragments := make([]packed.Fragment, len(fragments))
-		copy(sortedFragments, fragments)
-		sort.Slice(sortedFragments, func(i, j int) bool {
-			return sortedFragments[i].RowCount > sortedFragments[j].RowCount
-		})
-
-		// Initialize segment bins
-		type segmentBin struct {
-			fragments []packed.Fragment
-			rowCount  int64
-		}
-		bins := make([]segmentBin, numSegments)
-
-		// Greedy bin-packing: assign each fragment to the bin with lowest current row count
-		for _, f := range sortedFragments {
-			if err := ensureContext(ctx); err != nil {
-				return nil, err
+		isPaimonTask := t.parsedSpec != nil && t.parsedSpec.Format == externalspec.FormatPaimonTable
+		maxDataSplitsPerSegment := int64(len(fragments))
+		if isPaimonTask {
+			maxDataSplitsPerSegment = paramtable.Get().DataNodeCfg.ExternalCollectionPaimonMaxDataSplitsPerSegment.GetAsInt64()
+			if maxDataSplitsPerSegment <= 0 {
+				return nil, merr.WrapErrParameterInvalidMsg("Paimon max DataSplits per segment must be positive")
 			}
-			// Find bin with minimum row count
-			minIdx := 0
-			for i := 1; i < len(bins); i++ {
-				if bins[i].rowCount < bins[minIdx].rowCount {
-					minIdx = i
+		}
+
+		// Native Paimon DataSplits are independent merge domains. Preserve their
+		// bucket boundary while allowing several immutable DataSplits from one
+		// bucket to share a Milvus segment. Direct files keep the same global
+		// packing behavior as Iceberg and other file-based formats.
+		packingGroups := make(map[string][]packed.Fragment)
+		for _, fragment := range fragments {
+			group := ""
+			if isPaimonTask {
+				readPath, bucket, err := packed.PaimonRoutingMeta(fragment.Properties)
+				if err != nil {
+					return nil, err
+				}
+				if readPath == packed.PaimonDataSplitReadPath {
+					group = "paimon-bucket:" + strconv.FormatInt(int64(bucket), 10)
 				}
 			}
-			bins[minIdx].fragments = append(bins[minIdx].fragments, f)
-			bins[minIdx].rowCount += f.RowCount
+			packingGroups[group] = append(packingGroups[group], fragment)
+		}
+		groupNames := make([]string, 0, len(packingGroups))
+		for group := range packingGroups {
+			groupNames = append(groupNames, group)
+		}
+		sort.Strings(groupNames)
+
+		type segmentBin struct {
+			fragments  []packed.Fragment
+			rowCount   int64
+			dataSplits int64
+		}
+		for _, group := range groupNames {
+			groupFragments := packingGroups[group]
+			var groupRows int64
+			for _, fragment := range groupFragments {
+				groupRows += fragment.RowCount
+			}
+
+			numSegments := (groupRows + targetRowsPerSegment - 1) / targetRowsPerSegment
+			isDataSplitGroup := isPaimonTask && group != ""
+			if isDataSplitGroup {
+				dataSplits := int64(len(groupFragments))
+				bySplitLimit := (dataSplits + maxDataSplitsPerSegment - 1) / maxDataSplitsPerSegment
+				if bySplitLimit > numSegments {
+					numSegments = bySplitLimit
+				}
+			}
+			if numSegments == 0 {
+				numSegments = 1
+			}
+
+			sortedFragments := append([]packed.Fragment(nil), groupFragments...)
+			sort.SliceStable(sortedFragments, func(i, j int) bool {
+				return sortedFragments[i].RowCount > sortedFragments[j].RowCount
+			})
+			bins := make([]segmentBin, numSegments)
+			for _, fragment := range sortedFragments {
+				if err := ensureContext(ctx); err != nil {
+					return nil, err
+				}
+				minIdx := -1
+				for index := range bins {
+					if isDataSplitGroup && bins[index].dataSplits >= maxDataSplitsPerSegment {
+						continue
+					}
+					if minIdx < 0 || bins[index].rowCount < bins[minIdx].rowCount {
+						minIdx = index
+					}
+				}
+				if minIdx < 0 {
+					return nil, merr.WrapErrParameterInvalidMsg("cannot place Paimon DataSplit within per-segment limit %d", maxDataSplitsPerSegment)
+				}
+				bins[minIdx].fragments = append(bins[minIdx].fragments, fragment)
+				bins[minIdx].rowCount += fragment.RowCount
+				if isDataSplitGroup {
+					bins[minIdx].dataSplits++
+				}
+			}
+
+			for _, bin := range bins {
+				if len(bin.fragments) == 0 {
+					continue
+				}
+				if err := appendWork(bin.rowCount, bin.fragments); err != nil {
+					return nil, err
+				}
+			}
 		}
 
-		for _, bin := range bins {
-			if len(bin.fragments) == 0 {
-				continue
-			}
-			if err := appendWork(bin.rowCount, bin.fragments); err != nil {
-				return nil, err
-			}
-		}
+		mlog.Info(context.TODO(), "Balanced fragments to segments",
+			mlog.Int("numFragments", len(fragments)),
+			mlog.Int64("totalRows", totalRows),
+			mlog.Int("packingGroups", len(packingGroups)),
+			mlog.Int("numSegments", len(works)))
 	}
 
 	mlog.Info(context.TODO(), "Allocated segment IDs, starting manifest creation",

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -468,6 +469,79 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_Mult
 		// The difference between max and min should be reasonable
 		avgFragmentSize := int64(2000000 / 5)
 		s.Less(maxRows-minRows, avgFragmentSize*2)
+	}
+}
+
+func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_PaimonDataSplitLimitsAndBuckets() {
+	paramtable.Init()
+	maxSplitsKey := paramtable.Get().DataNodeCfg.ExternalCollectionPaimonMaxDataSplitsPerSegment.Key
+	paramtable.Get().Save(maxSplitsKey, "2")
+	defer paramtable.Get().Reset(maxSplitsKey)
+
+	req := &datapb.RefreshExternalCollectionTaskRequest{
+		CollectionID:           s.collectionID,
+		TaskID:                 s.taskID,
+		PreAllocatedSegmentIds: &datapb.IDRange{Begin: 100, End: 300},
+		TargetRowsPerSegment:   100,
+		StorageConfig:          &indexpb.StorageConfig{StorageType: "local"},
+		ExternalSource:         "s3://bucket/table",
+		ExternalSpec:           `{"format":"paimon-table"}`,
+		Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", ExternalField: "pk"},
+		}},
+	}
+	task := NewRefreshExternalCollectionTask(context.Background(), req)
+	task.preallocatedIDRange = req.GetPreAllocatedSegmentIds()
+	task.nextAllocID = task.preallocatedIDRange.Begin
+	task.parsedSpec = &externalspec.ExternalSpec{Format: externalspec.FormatPaimonTable}
+
+	var mu sync.Mutex
+	var packedBins [][]packed.Fragment
+	m1 := mockey.Mock(packed.CreateSegmentManifestWithBasePathAndExtfs).
+		To(func(ctx context.Context, basePath, format string, columns []string, fragments []packed.Fragment, storageConfig *indexpb.StorageConfig, extfs packed.ExternalSpecContext) (string, error) {
+			mu.Lock()
+			packedBins = append(packedBins, append([]packed.Fragment(nil), fragments...))
+			mu.Unlock()
+			return fmt.Sprintf("%s/manifest.json", basePath), nil
+		}).Build()
+	defer m1.UnPatch()
+	m2 := mockey.Mock(packed.SampleExternalFieldSizes).Return(map[string]int64{"pk": 8}, nil).Build()
+	defer m2.UnPatch()
+
+	fragments := make([]packed.Fragment, 0, 6)
+	for bucket := 0; bucket < 2; bucket++ {
+		for split := 0; split < 3; split++ {
+			fragments = append(fragments, packed.Fragment{
+				FragmentID: int64(bucket*3 + split),
+				FilePath:   fmt.Sprintf("split-%d-%d", bucket, split),
+				RowCount:   10,
+				Properties: map[string]string{
+					// Production fragments carry only the descriptor; routing
+					// is derived from it.
+					"metadata": fmt.Sprintf(
+						`{"version":1,"read_path":"data-split","bucket":%d,"snapshot_id":9,"record_count":10}`,
+						bucket),
+				},
+			})
+		}
+	}
+
+	result, err := task.balanceFragmentsToSegments(context.Background(), fragments)
+	s.NoError(err)
+	s.Len(result, 4)
+	s.Len(packedBins, 4)
+	for _, bin := range packedBins {
+		s.LessOrEqual(len(bin), 2)
+		if !s.NotEmpty(bin) {
+			continue
+		}
+		_, bucket, err := packed.PaimonRoutingMeta(bin[0].Properties)
+		s.NoError(err)
+		for _, fragment := range bin {
+			_, fragmentBucket, err := packed.PaimonRoutingMeta(fragment.Properties)
+			s.NoError(err)
+			s.Equal(bucket, fragmentBucket)
+		}
 	}
 }
 
@@ -2741,6 +2815,23 @@ func (s *RefreshExternalCollectionTaskSuite) TestFragmentKey() {
 	// Identical fragments should produce the same key
 	f4 := packed.Fragment{FilePath: "/data/file1.parquet", StartRow: 0, EndRow: 1000}
 	s.Equal(fragmentKey(f1), fragmentKey(f4))
+
+	// Snapshot-specific file properties are part of the data view identity.
+	// Their map insertion order is not.
+	withSnapshot1 := packed.Fragment{
+		FilePath: "/data/file1.parquet", StartRow: 0, EndRow: 1000,
+		Properties: map[string]string{"metadata": "snapshot-1", "file_size": "10"},
+	}
+	withSnapshot1Reordered := packed.Fragment{
+		FilePath: "/data/file1.parquet", StartRow: 0, EndRow: 1000,
+		Properties: map[string]string{"file_size": "10", "metadata": "snapshot-1"},
+	}
+	withSnapshot2 := packed.Fragment{
+		FilePath: "/data/file1.parquet", StartRow: 0, EndRow: 1000,
+		Properties: map[string]string{"metadata": "snapshot-2", "file_size": "10"},
+	}
+	s.Equal(fragmentKey(withSnapshot1), fragmentKey(withSnapshot1Reordered))
+	s.NotEqual(fragmentKey(withSnapshot1), fragmentKey(withSnapshot2))
 
 	// L0 deltalogs are not part of the L1 data identity. They are handled by a
 	// manifest-only refresh so the target segment ID can be reused.

--- a/internal/storagev2/packed/explore_ffi.go
+++ b/internal/storagev2/packed/explore_ffi.go
@@ -91,6 +91,7 @@ func NormalizeFileInfos(fileInfos []FileInfo, format string) ([]FileInfo, int) {
 type FileInfo struct {
 	FilePath        string
 	NumRows         int64
+	Properties      map[string]string
 	SourceSegmentID int64
 	Deltalogs       []*datapb.FieldBinlog
 }
@@ -438,12 +439,40 @@ func ReadFileInfosFromManifestPath(
 			if fileArray[j].path == nil {
 				return nil, merr.WrapErrServiceInternalMsg("file path is nil in column group %d, file %d", i, j)
 			}
+			properties, err := columnGroupFileProperties(&fileArray[j])
+			if err != nil {
+				return nil, merr.Wrapf(err, "read properties from column group %d, file %d", i, j)
+			}
 			fileInfos = append(fileInfos, FileInfo{
-				FilePath: C.GoString(fileArray[j].path),
-				NumRows:  int64(fileArray[j].end_index),
+				FilePath:   C.GoString(fileArray[j].path),
+				NumRows:    int64(fileArray[j].end_index),
+				Properties: properties,
 			})
 		}
 	}
 
 	return fileInfos, nil
+}
+
+// columnGroupFileProperties copies format-specific file properties as
+// opaque values. Iceberg delete-file metadata and Paimon snapshot split
+// descriptors are interpreted only by their format readers.
+func columnGroupFileProperties(file *C.LoonColumnGroupFile) (map[string]string, error) {
+	if file == nil || file.num_properties == 0 {
+		return nil, nil
+	}
+	if file.property_keys == nil || file.property_values == nil {
+		return nil, merr.WrapErrDataIntegrityMsg("column group file has %d properties but nil key/value arrays", file.num_properties)
+	}
+
+	keys := unsafe.Slice(file.property_keys, int(file.num_properties))
+	values := unsafe.Slice(file.property_values, int(file.num_properties))
+	properties := make(map[string]string, len(keys))
+	for i := range keys {
+		if keys[i] == nil || values[i] == nil {
+			return nil, merr.WrapErrDataIntegrityMsg("column group file property %d has nil key or value", i)
+		}
+		properties[C.GoString(keys[i])] = C.GoString(values[i])
+	}
+	return properties, nil
 }

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -19,6 +19,7 @@ package packed
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -180,6 +181,141 @@ func TestManifestColumnGroupsToFragments_DeduplicatesByPathRange(t *testing.T) {
 	assert.Equal(t, "a.parquet", fragments[0].FilePath)
 	assert.Equal(t, int64(0), fragments[0].StartRow)
 	assert.Equal(t, int64(10), fragments[0].EndRow)
+}
+
+func TestManifestColumnGroupsToFragments_KeepsDifferentOpaqueProperties(t *testing.T) {
+	groups := []manifestColumnGroup{
+		{
+			Columns: []string{"id"},
+			Fragments: []Fragment{{
+				FilePath: "same.parquet", StartRow: 0, EndRow: 7, RowCount: 7,
+				Properties: map[string]string{"metadata": "snapshot-1"},
+			}},
+		},
+		{
+			Columns: []string{"vector"},
+			Fragments: []Fragment{{
+				FilePath: "same.parquet", StartRow: 0, EndRow: 7, RowCount: 7,
+				Properties: map[string]string{"metadata": "snapshot-2"},
+			}},
+		},
+	}
+
+	fragments := manifestColumnGroupsToFragments(groups)
+	require.Len(t, fragments, 2)
+	assert.NotEqual(t, FragmentIdentity(fragments[0]), FragmentIdentity(fragments[1]))
+}
+
+func TestPaimonDirectFileIdentityIsStableAcrossSnapshots(t *testing.T) {
+	base := Fragment{
+		FilePath: "s3://bucket/table/bucket-0/data-1.parquet",
+		StartRow: 0,
+		EndRow:   10,
+		RowCount: 10,
+	}
+
+	// The same physical file re-planned under a newer snapshot keeps its
+	// identity: this is what lets refresh keep segments for unchanged
+	// append-only files.
+	snapshotOne := base
+	snapshotOne.Properties = map[string]string{
+		"metadata": `{"version":1,"read_path":"direct-file","bucket":1,"snapshot_id":1,"record_count":10}`,
+	}
+	snapshotTwo := base
+	snapshotTwo.Properties = map[string]string{
+		"metadata": `{"version":1,"read_path":"direct-file","bucket":1,"snapshot_id":2,"record_count":10}`,
+	}
+	assert.Equal(t, FragmentIdentity(snapshotOne), FragmentIdentity(snapshotTwo))
+
+	// Future fields are conservatively part of the read identity. Only the
+	// snapshot id is intentionally ignored for direct files.
+	futureSemantics := base
+	futureSemantics.Properties = map[string]string{
+		"metadata": `{"version":1,"read_path":"direct-file","bucket":1,"snapshot_id":2,"record_count":10,` +
+			`"reader_semantics":"v2"}`,
+	}
+	assert.NotEqual(t, FragmentIdentity(snapshotTwo), FragmentIdentity(futureSemantics))
+
+	// Community ColumnGroupFile properties outside the Paimon descriptor also
+	// remain part of the identity.
+	withFileSize := snapshotTwo
+	withFileSize.Properties = maps.Clone(snapshotTwo.Properties)
+	withFileSize.Properties["file_size"] = "123"
+	assert.NotEqual(t, FragmentIdentity(snapshotTwo), FragmentIdentity(withFileSize))
+
+	// Any deletion-vector change is a physical state change and must break
+	// the identity: a new deletion vector...
+	withDeletion := base
+	withDeletion.Properties = map[string]string{
+		"metadata": `{"version":1,"read_path":"direct-file","bucket":1,"snapshot_id":2,"record_count":8,` +
+			`"deletion_file":{"path":"s3://bucket/table/index/dv-1","offset":1,"length":24,"cardinality":2}}`,
+	}
+	assert.NotEqual(t, FragmentIdentity(snapshotOne), FragmentIdentity(withDeletion))
+
+	// ...or a rewritten deletion vector (same cardinality, different region).
+	movedDeletion := base
+	movedDeletion.Properties = map[string]string{
+		"metadata": `{"version":1,"read_path":"direct-file","bucket":1,"snapshot_id":3,"record_count":8,` +
+			`"deletion_file":{"path":"s3://bucket/table/index/dv-2","offset":40,"length":24,"cardinality":2}}`,
+	}
+	assert.NotEqual(t, FragmentIdentity(withDeletion), FragmentIdentity(movedDeletion))
+
+	// A different row range or file path is a different fragment.
+	otherRange := snapshotOne
+	otherRange.StartRow, otherRange.EndRow = 10, 20
+	assert.NotEqual(t, FragmentIdentity(snapshotOne), FragmentIdentity(otherRange))
+
+	// Data-split descriptors bind their pinned snapshot by design, so their
+	// identity must keep changing with the snapshot.
+	dataSplitOne := base
+	dataSplitOne.Properties = map[string]string{
+		"metadata": `{"version":1,"read_path":"data-split","snapshot_id":1,"record_count":10,"payload":"AAA"}`,
+	}
+	dataSplitTwo := base
+	dataSplitTwo.Properties = map[string]string{
+		"metadata": `{"version":1,"read_path":"data-split","snapshot_id":2,"record_count":10,"payload":"BBB"}`,
+	}
+	assert.NotEqual(t, FragmentIdentity(dataSplitOne), FragmentIdentity(dataSplitTwo))
+
+	// Non-Paimon metadata (no read_path field) stays on the property hash.
+	iceberg := base
+	iceberg.Properties = map[string]string{"metadata": `{"manifest":"v2"}`}
+	assert.NotEqual(t, FragmentIdentity(iceberg), FragmentIdentity(snapshotOne))
+
+	// Direct-file fragments with identical physical state dedup to one.
+	duplicated := manifestColumnGroupsToFragments([]manifestColumnGroup{
+		{Columns: []string{"id"}, Fragments: []Fragment{snapshotOne}},
+		{Columns: []string{"vector"}, Fragments: []Fragment{snapshotTwo}},
+	})
+	assert.Len(t, duplicated, 1)
+}
+
+func TestPaimonRoutingMetaValidatesDescriptorVersionAndBucket(t *testing.T) {
+	readPath, bucket, err := PaimonRoutingMeta(map[string]string{
+		"metadata": `{"version":1,"read_path":"data-split","bucket":7}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, PaimonDataSplitReadPath, readPath)
+	assert.Equal(t, int32(7), bucket)
+
+	readPath, bucket, err = PaimonRoutingMeta(map[string]string{
+		"metadata": `{"version":1,"read_path":"direct-file"}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "direct-file", readPath)
+	assert.Zero(t, bucket)
+
+	_, _, err = PaimonRoutingMeta(map[string]string{
+		"metadata": `{"version":2,"read_path":"data-split","bucket":7}`,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported Paimon metadata version")
+
+	_, _, err = PaimonRoutingMeta(map[string]string{
+		"metadata": `{"version":1,"read_path":"data-split"}`,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has no bucket")
 }
 
 func TestColumnsToAppend_SkipsExistingSameFragments(t *testing.T) {
@@ -706,6 +842,48 @@ func TestReadFragmentsFromManifest_FiltersColumns(t *testing.T) {
 	_, err = ReadFragmentsFromManifest("bad manifest", config, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse manifest path")
+}
+
+func TestExternalManifestPreservesOpaqueFileProperties(t *testing.T) {
+	tmpDir := t.TempDir()
+	config := &indexpb.StorageConfig{StorageType: "local", BucketName: tmpDir, RootPath: tmpDir}
+	properties := map[string]string{
+		"metadata":    `{"snapshot_id":2,"split_descriptor":"opaque"}`,
+		"file_size":   "0",
+		"footer_size": "17",
+	}
+	fragments := []Fragment{{
+		FragmentID: 0,
+		FilePath:   filepath.Join(tmpDir, "logical-split"),
+		StartRow:   0,
+		EndRow:     7,
+		RowCount:   7,
+		Properties: properties,
+	}}
+
+	manifestPath, err := CreateManifestForSegment(
+		filepath.Join(tmpDir, "segment-properties"),
+		[]string{"pk", "vector"},
+		"paimon-table",
+		fragments,
+		config,
+	)
+	require.NoError(t, err)
+
+	got, err := ReadFragmentsFromManifest(manifestPath, config, []string{"pk"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, properties, got[0].Properties)
+
+	basePath, version, err := UnmarshalManifestPath(manifestPath)
+	require.NoError(t, err)
+	fileInfos, err := ReadFileInfosFromManifestPath(
+		fmt.Sprintf("%s/_metadata/manifest-%d.avro", basePath, version),
+		config,
+	)
+	require.NoError(t, err)
+	require.Len(t, fileInfos, 1)
+	assert.Equal(t, properties, fileInfos[0].Properties)
 }
 
 func TestMarshalUnmarshalManifestPath(t *testing.T) {
@@ -1600,6 +1778,82 @@ func TestFetchFragmentsFromExternalSourceWithRange_HappyPath(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, fragments)
+}
+
+func TestFetchFragmentsFromExternalSourceWithRange_PreservesOpaqueProperties(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	config := &indexpb.StorageConfig{StorageType: "local", BucketName: tmpDir, RootPath: tmpDir}
+	properties := map[string]string{
+		"metadata":  `{"version":1,"read_path":"direct-file","bucket":7,"snapshot_id":3,"record_count":10}`,
+		"file_size": "0",
+	}
+	mockRead := mockey.Mock(ReadFileInfosFromManifestPath).Return([]FileInfo{{
+		FilePath: "logical-split", NumRows: 10, Properties: properties,
+	}}, nil).Build()
+	defer mockRead.UnPatch()
+
+	fragments, err := FetchFragmentsFromExternalSourceWithRange(
+		ctx, "paimon-table", []string{"pk"}, "s3://endpoint/bucket/table", config,
+		0, 1, "/manifest.json", ExternalFetchOptions{CollectionID: 1, RowLimit: 4},
+	)
+	require.NoError(t, err)
+	require.Len(t, fragments, 3)
+	for _, fragment := range fragments {
+		assert.Equal(t, properties, fragment.Properties)
+	}
+
+	// Each split owns its map; changing one cannot rewrite another fragment's
+	// reader descriptor.
+	fragments[0].Properties["metadata"] = "changed"
+	assert.Equal(t, properties["metadata"], fragments[1].Properties["metadata"])
+}
+
+func TestFetchFragmentsFromExternalSourceWithRange_RejectsMalformedPaimonMetadata(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	config := &indexpb.StorageConfig{StorageType: "local", BucketName: tmpDir, RootPath: tmpDir}
+	mockRead := mockey.Mock(ReadFileInfosFromManifestPath).Return([]FileInfo{{
+		FilePath: "logical-split",
+		NumRows:  10,
+		Properties: map[string]string{
+			"metadata": "not-json",
+		},
+	}}, nil).Build()
+	defer mockRead.UnPatch()
+
+	_, err := FetchFragmentsFromExternalSourceWithRange(
+		ctx, "paimon-table", []string{"pk"}, "s3://endpoint/bucket/table", config,
+		0, 1, "/manifest.json", ExternalFetchOptions{CollectionID: 1, RowLimit: 4},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid Paimon metadata descriptor")
+}
+
+func TestFetchFragmentsFromExternalSourceWithRange_PreservesAtomicPaimonDataSplit(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	config := &indexpb.StorageConfig{StorageType: "local", BucketName: tmpDir, RootPath: tmpDir}
+	// Exactly what the explore pass attaches: the opaque descriptor and
+	// nothing else. Atomicity must be derived from it, not from discrete
+	// paimon.* properties nothing populates in production.
+	properties := map[string]string{
+		"metadata": `{"version":1,"read_path":"data-split","bucket":7,"snapshot_id":3,"record_count":10}`,
+	}
+	mockRead := mockey.Mock(ReadFileInfosFromManifestPath).Return([]FileInfo{{
+		FilePath: "data-split", NumRows: 10, Properties: properties,
+	}}, nil).Build()
+	defer mockRead.UnPatch()
+
+	fragments, err := FetchFragmentsFromExternalSourceWithRange(
+		ctx, "paimon-table", []string{"pk"}, "s3://endpoint/bucket/table", config,
+		0, 1, "/manifest.json", ExternalFetchOptions{CollectionID: 1, RowLimit: 4},
+	)
+	require.NoError(t, err)
+	require.Len(t, fragments, 1)
+	assert.Equal(t, int64(0), fragments[0].StartRow)
+	assert.Equal(t, int64(10), fragments[0].EndRow)
+	assert.Equal(t, properties, fragments[0].Properties)
 }
 
 func TestFetchFragmentsFromExternalSourceWithRange_EmptyManifest(t *testing.T) {

--- a/internal/storagev2/packed/manifest_ffi.go
+++ b/internal/storagev2/packed/manifest_ffi.go
@@ -39,7 +39,10 @@ import "C"
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -64,6 +67,7 @@ type Fragment struct {
 	StartRow   int64                 // Start row index within the file (inclusive)
 	EndRow     int64                 // End row index within the file (exclusive)
 	RowCount   int64                 // Number of rows (EndRow - StartRow)
+	Properties map[string]string     // Opaque format-reader metadata (snapshot/delete descriptors, sizes, etc.)
 	Deltalogs  []*datapb.FieldBinlog // Source delete logs for milvus-table fragments
 }
 
@@ -73,8 +77,120 @@ type manifestColumnGroup struct {
 	Format    string
 }
 
-func fragmentIdentity(f Fragment) string {
-	return fmt.Sprintf("%s:%d:%d", f.FilePath, f.StartRow, f.EndRow)
+// paimonFileMetadataProperty carries the opaque per-file descriptor attached
+// by the milvus-storage explore pass; its JSON shape is owned by
+// milvus-storage and only the routing fields below are interpreted here.
+const (
+	paimonFileMetadataProperty = "metadata"
+	paimonMetadataVersion      = 1
+)
+
+type paimonRoutingMetadata struct {
+	Version  int    `json:"version"`
+	ReadPath string `json:"read_path"`
+	Bucket   *int32 `json:"bucket"`
+}
+
+func parsePaimonRoutingMetadata(properties map[string]string) (string, paimonRoutingMetadata, error) {
+	raw, found := properties[paimonFileMetadataProperty]
+	if !found {
+		return "", paimonRoutingMetadata{}, merr.WrapErrServiceInternalMsg("Paimon fragment has no metadata descriptor")
+	}
+	var metadata paimonRoutingMetadata
+	if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+		return "", paimonRoutingMetadata{}, merr.WrapErrServiceInternalMsg("invalid Paimon metadata descriptor: %v", err)
+	}
+	if metadata.Version != paimonMetadataVersion {
+		return "", paimonRoutingMetadata{}, merr.WrapErrServiceInternalMsg(
+			"unsupported Paimon metadata version %d, expected %d", metadata.Version, paimonMetadataVersion)
+	}
+	if metadata.ReadPath != "direct-file" && metadata.ReadPath != PaimonDataSplitReadPath {
+		return "", paimonRoutingMetadata{}, merr.WrapErrServiceInternalMsg("invalid Paimon read_path %q", metadata.ReadPath)
+	}
+	return raw, metadata, nil
+}
+
+// PaimonRoutingMeta extracts the fields used for fragment splitting and
+// segment packing. Paimon fragments must carry valid storage-owned metadata;
+// silently treating a malformed DataSplit as a regular file would make it
+// splittable and violate its snapshot boundary.
+func PaimonRoutingMeta(properties map[string]string) (readPath string, bucket int32, err error) {
+	_, metadata, err := parsePaimonRoutingMetadata(properties)
+	if err != nil {
+		return "", 0, err
+	}
+	if metadata.ReadPath == PaimonDataSplitReadPath && metadata.Bucket == nil {
+		return "", 0, merr.WrapErrServiceInternalMsg("Paimon metadata descriptor has no bucket")
+	}
+	if metadata.Bucket == nil {
+		return metadata.ReadPath, 0, nil
+	}
+	return metadata.ReadPath, *metadata.Bucket, nil
+}
+
+// paimonDirectFileIdentity excludes snapshot_id so an unchanged append-only
+// file can retain its segment across refreshes. Every other current or future
+// descriptor field remains part of the canonical property hash. DataSplits use
+// the unmodified property hash because their descriptors pin a snapshot.
+func paimonDirectFileIdentity(f Fragment, base string) (string, bool) {
+	raw, metadata, err := parsePaimonRoutingMetadata(f.Properties)
+	if err != nil || metadata.ReadPath != "direct-file" {
+		return "", false
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	var descriptor map[string]any
+	if err := decoder.Decode(&descriptor); err != nil {
+		return "", false
+	}
+	delete(descriptor, "snapshot_id")
+	canonicalMetadata, err := json.Marshal(descriptor)
+	if err != nil {
+		return "", false
+	}
+
+	properties := maps.Clone(f.Properties)
+	properties[paimonFileMetadataProperty] = string(canonicalMetadata)
+	return "paimon-direct|" + fragmentIdentityWithProperties(base, properties), true
+}
+
+func fragmentIdentityWithProperties(base string, properties map[string]string) string {
+	if len(properties) == 0 {
+		return base
+	}
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var canonical strings.Builder
+	for _, key := range keys {
+		value := properties[key]
+		canonical.WriteString(strconv.Itoa(len(key)))
+		canonical.WriteString(":")
+		canonical.WriteString(key)
+		canonical.WriteString(strconv.Itoa(len(value)))
+		canonical.WriteString(":")
+		canonical.WriteString(value)
+	}
+	digest := sha256.Sum256([]byte(canonical.String()))
+	return fmt.Sprintf("%s:%x", base, digest)
+}
+
+// FragmentIdentity identifies the immutable data view represented by a
+// fragment. Format-specific properties are hashed rather than exposed in the
+// key because they may contain large snapshot descriptors. Deltalogs remain
+// outside this identity: milvus-table refreshes them in-place.
+//
+// Paimon direct files use snapshot-independent physical read state so
+// unchanged files keep their segments across refreshes.
+func FragmentIdentity(f Fragment) string {
+	base := fmt.Sprintf("%s:%d:%d", f.FilePath, f.StartRow, f.EndRow)
+	if identity, ok := paimonDirectFileIdentity(f, base); ok {
+		return identity
+	}
+	return fragmentIdentityWithProperties(base, f.Properties)
 }
 
 func sameFragmentSet(a, b []Fragment) bool {
@@ -84,10 +200,10 @@ func sameFragmentSet(a, b []Fragment) bool {
 
 	seen := make(map[string]int, len(a))
 	for _, fragment := range a {
-		seen[fragmentIdentity(fragment)]++
+		seen[FragmentIdentity(fragment)]++
 	}
 	for _, fragment := range b {
-		identity := fragmentIdentity(fragment)
+		identity := FragmentIdentity(fragment)
 		if seen[identity] == 0 {
 			return false
 		}
@@ -102,7 +218,7 @@ func manifestColumnGroupsToFragments(groups []manifestColumnGroup) []Fragment {
 
 	for _, group := range groups {
 		for _, fragment := range group.Fragments {
-			identity := fragmentIdentity(fragment)
+			identity := FragmentIdentity(fragment)
 			if _, ok := seen[identity]; ok {
 				continue
 			}
@@ -163,7 +279,7 @@ func CreateManifestForSegment(
 	if err != nil {
 		return "", merr.Wrap(err, "failed to create column groups")
 	}
-	defer C.loon_column_groups_destroy(columnGroups)
+	defer destroyCreatedColumnGroups(columnGroups)
 
 	// Create properties from storage config
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
@@ -376,8 +492,80 @@ func createColumnGroups(
 	if err := HandleLoonFFIResult(result); err != nil {
 		return nil, merr.WrapErrStorage(err, "loon_column_groups_create failed")
 	}
+	for i, fragment := range fragments {
+		if err := setColumnGroupFileProperties(outColumnGroups, i, fragment.Properties); err != nil {
+			destroyCreatedColumnGroups(outColumnGroups)
+			return nil, err
+		}
+	}
 
 	return outColumnGroups, nil
+}
+
+func setColumnGroupFileProperties(columnGroups *C.LoonColumnGroups, fileIndex int, properties map[string]string) error {
+	if len(properties) == 0 {
+		return nil
+	}
+	if columnGroups == nil || columnGroups.num_of_column_groups != 1 || columnGroups.column_group_array == nil {
+		return merr.WrapErrServiceInternalMsg(
+			"invalid column groups while setting file properties")
+	}
+	group := columnGroups.column_group_array
+	if fileIndex < 0 || fileIndex >= int(group.num_of_files) || group.files == nil {
+		return merr.WrapErrServiceInternalMsg(
+			"column group file index %d is out of range", fileIndex)
+	}
+
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	file := &unsafe.Slice(group.files, int(group.num_of_files))[fileIndex]
+	pointerBytes := C.size_t(len(keys)) * C.size_t(unsafe.Sizeof((*C.char)(nil)))
+	file.property_keys = (**C.char)(C.malloc(pointerBytes))
+	file.property_values = (**C.char)(C.malloc(pointerBytes))
+	cKeys := unsafe.Slice(file.property_keys, len(keys))
+	cValues := unsafe.Slice(file.property_values, len(keys))
+	for i, key := range keys {
+		cKeys[i] = C.CString(key)
+		cValues[i] = C.CString(properties[key])
+	}
+	file.num_properties = C.uint32_t(len(keys))
+	return nil
+}
+
+func freeColumnGroupFileProperties(columnGroups *C.LoonColumnGroups) {
+	if columnGroups == nil || columnGroups.column_group_array == nil {
+		return
+	}
+	group := columnGroups.column_group_array
+	if group.files == nil {
+		return
+	}
+	files := unsafe.Slice(group.files, int(group.num_of_files))
+	for i := range files {
+		file := &files[i]
+		keys := unsafe.Slice(file.property_keys, int(file.num_properties))
+		values := unsafe.Slice(file.property_values, int(file.num_properties))
+		for j := range keys {
+			C.free(unsafe.Pointer(keys[j]))
+			C.free(unsafe.Pointer(values[j]))
+		}
+		C.free(unsafe.Pointer(file.property_keys))
+		C.free(unsafe.Pointer(file.property_values))
+		file.property_keys = nil
+		file.property_values = nil
+		file.num_properties = 0
+	}
+}
+
+// File properties are C-allocated by Go and must be detached before the
+// C++ column-groups destructor frees the remaining fields.
+func destroyCreatedColumnGroups(columnGroups *C.LoonColumnGroups) {
+	freeColumnGroupFileProperties(columnGroups)
+	C.loon_column_groups_destroy(columnGroups)
 }
 
 // GetManifestFieldIDs reads numeric field IDs stored as column names in a
@@ -633,10 +821,14 @@ func readColumnGroupsFromManifest(
 				filePath := C.GoString(file.path)
 				startRow := int64(file.start_index)
 				endRow := int64(file.end_index)
+				properties, err := columnGroupFileProperties(file)
+				if err != nil {
+					return nil, merr.Wrapf(err, "read properties from column group %d, file %d", i, j)
+				}
 
-				sourceManifestPath := columnGroupFileProperty(file, milvusTableSourceManifestPathProperty)
+				sourceManifestPath := properties[milvusTableSourceManifestPathProperty]
 				if sourceManifestPath != "" {
-					rowCountText := columnGroupFileProperty(file, milvusTableSourceRowCountProperty)
+					rowCountText := properties[milvusTableSourceRowCountProperty]
 					rowCount, err := strconv.ParseInt(rowCountText, 10, 64)
 					if err != nil || rowCount <= 0 {
 						return nil, merr.WrapErrServiceInternalMsg("invalid milvus-table source row count %q for %s", rowCountText, sourceManifestPath)
@@ -658,6 +850,7 @@ func readColumnGroupsFromManifest(
 					StartRow:   startRow,
 					EndRow:     endRow,
 					RowCount:   endRow - startRow,
+					Properties: properties,
 				})
 			}
 		}
@@ -697,19 +890,8 @@ func deltaLogsFromManifest(manifest *C.LoonManifest) ([]*datapb.FieldBinlog, err
 	return []*datapb.FieldBinlog{{Binlogs: binlogs}}, nil
 }
 
-func columnGroupFileProperty(file *C.LoonColumnGroupFile, key string) string {
-	if file == nil || file.num_properties == 0 || file.property_keys == nil || file.property_values == nil {
-		return ""
-	}
-	keys := unsafe.Slice(file.property_keys, int(file.num_properties))
-	values := unsafe.Slice(file.property_values, int(file.num_properties))
-	for i, cKey := range keys {
-		if cKey == nil || C.GoString(cKey) != key || values[i] == nil {
-			continue
-		}
-		return C.GoString(values[i])
-	}
-	return ""
+func cloneStringProperties(properties map[string]string) map[string]string {
+	return maps.Clone(properties)
 }
 
 func AppendSegmentManifestColumns(
@@ -760,7 +942,7 @@ func AppendSegmentManifestColumns(
 		cColumnGroups:      columnGroups,
 		addNewColumnGroups: true,
 	}
-	defer newFiles.Destroy()
+	defer destroyCreatedColumnGroups(columnGroups)
 
 	if columnGroups.column_group_array == nil && columnGroups.num_of_column_groups > 0 {
 		return "", merr.WrapErrServiceInternalMsg("column_group_array is nil but num_of_column_groups is %d", columnGroups.num_of_column_groups)

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -136,7 +136,7 @@ func NewFFIPackedReaderWithFragments(
 	if err != nil {
 		return nil, err
 	}
-	defer C.loon_column_groups_destroy(cColumnGroups)
+	defer destroyCreatedColumnGroups(cColumnGroups)
 
 	return openFFIPackedReader(schema, neededColumns, bufferSize, storageConfig, storagePluginContext, extfs,
 		func(cSchema *C.struct_ArrowSchema,

--- a/internal/storagev2/packed/transaction_test.go
+++ b/internal/storagev2/packed/transaction_test.go
@@ -559,11 +559,17 @@ func TestCreateMilvusTableManifestFromSegmentManifests_PreservesSourceFragmentId
 	sourceBasePath := filepath.Join(dir, "insert_log/1/2/source")
 	sourceManifest := createBaseManifest(t, sourceBasePath, storageConfig)
 	sourceRowCount := int64(7)
+	sourceFragment := Fragment{
+		FilePath: sourceManifest,
+		StartRow: 0,
+		EndRow:   sourceRowCount,
+		RowCount: sourceRowCount,
+	}
 	targetBasePath := filepath.Join(dir, "insert_log/1/2/target")
 	targetManifest, err := CreateMilvusTableManifestFromSegmentManifests(
 		targetBasePath,
 		[]string{"pk", "ts"},
-		[]Fragment{{FilePath: sourceManifest, StartRow: 0, EndRow: sourceRowCount, RowCount: sourceRowCount}},
+		[]Fragment{sourceFragment},
 		storageConfig,
 		ExternalSpecContext{MilvusTablePKMode: MilvusTablePrimaryKeyModeVirtual},
 	)
@@ -576,6 +582,8 @@ func TestCreateMilvusTableManifestFromSegmentManifests_PreservesSourceFragmentId
 	assert.Equal(t, int64(0), fragments[0].StartRow)
 	assert.Equal(t, sourceRowCount, fragments[0].EndRow)
 	assert.Equal(t, sourceRowCount, fragments[0].RowCount)
+	assert.Empty(t, fragments[0].Properties)
+	assert.Equal(t, FragmentIdentity(sourceFragment), FragmentIdentity(fragments[0]))
 }
 
 func TestCreateMilvusTableManifestFromSegmentManifests_RejectsMissingSourceRowCount(t *testing.T) {

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -31,6 +31,10 @@ import (
 const (
 	// DefaultFragmentRowLimit is the default row limit for splitting large files into fragments
 	DefaultFragmentRowLimit = 1000000 // 1 million rows
+
+	// PaimonDataSplitReadPath is the descriptor read_path marking a fragment
+	// that must be consumed as one atomic Paimon DataSplit.
+	PaimonDataSplitReadPath = "data-split"
 )
 
 // SegmentFragments maps segment ID to its fragments
@@ -266,7 +270,33 @@ func FetchFragmentsFromExternalSourceWithRange(
 			})
 			continue
 		}
-		fragments = append(fragments, SplitFileToFragments(fi.FilePath, rowCounts[i], rowLimit, fragmentIDGenerator)...)
+		// A Paimon data-split FileInfo is one immutable DataSplit descriptor. Its
+		// logical range cannot be reopened independently, so preserve it as one
+		// atomic fragment even when it exceeds the generic row limit. Bounded
+		// batches inside PaimonFormatReader provide read parallelism without
+		// changing the snapshot split boundary.
+		if format == "paimon-table" {
+			readPath, _, err := PaimonRoutingMeta(fi.Properties)
+			if err != nil {
+				return nil, err
+			}
+			if readPath == PaimonDataSplitReadPath {
+				fragments = append(fragments, Fragment{
+					FragmentID: fragmentIDGenerator(),
+					FilePath:   fi.FilePath,
+					StartRow:   0,
+					EndRow:     rowCounts[i],
+					RowCount:   rowCounts[i],
+					Properties: cloneStringProperties(fi.Properties),
+				})
+				continue
+			}
+		}
+		fileFragments := SplitFileToFragments(fi.FilePath, rowCounts[i], rowLimit, fragmentIDGenerator)
+		for j := range fileFragments {
+			fileFragments[j].Properties = cloneStringProperties(fi.Properties)
+		}
+		fragments = append(fragments, fileFragments...)
 	}
 	if len(fragments) == 0 {
 		return nil, merr.WrapErrServiceInternalMsg("no data files in range [%d, %d)", fileIndexBegin, fileIndexEnd)

--- a/pkg/util/externalspec/external_spec.go
+++ b/pkg/util/externalspec/external_spec.go
@@ -34,6 +34,7 @@ const (
 	FormatLanceTable   = specutil.FormatLanceTable
 	FormatVortex       = specutil.FormatVortex
 	FormatIcebergTable = specutil.FormatIcebergTable
+	FormatPaimonTable  = specutil.FormatPaimonTable
 	FormatMilvusTable  = specutil.FormatMilvusTable
 )
 

--- a/pkg/util/externalspec/external_spec_test.go
+++ b/pkg/util/externalspec/external_spec_test.go
@@ -18,6 +18,7 @@ package externalspec
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,7 @@ func TestParseExternalSpec_DefaultFormat(t *testing.T) {
 }
 
 func TestParseExternalSpec_SupportedFormats(t *testing.T) {
-	for _, fmt := range []string{"parquet", "lance-table", "vortex", "iceberg-table", "milvus-table"} {
+	for _, fmt := range []string{"parquet", "lance-table", "vortex", "iceberg-table", "paimon-table", "milvus-table"} {
 		spec, err := ParseExternalSpec(`{"format":"` + fmt + `"}`)
 		require.NoError(t, err, "format %s should be supported", fmt)
 		assert.Equal(t, fmt, spec.Format)
@@ -393,22 +394,24 @@ func TestRedactExternalSpec(t *testing.T) {
 }
 
 func TestExternalSpecMarshalJSON(t *testing.T) {
-	t.Run("snapshot_id_marshaled_as_string", func(t *testing.T) {
-		snapshotID := int64(5320540205222981137)
-		out, err := json.Marshal(ExternalSpec{
-			Format:     FormatIcebergTable,
-			Columns:    []string{"id", "vec"},
-			Extfs:      map[string]string{"cloud_provider": "aws"},
-			SnapshotID: &snapshotID,
-		})
-		require.NoError(t, err)
-		assert.Contains(t, string(out), `"snapshot_id":"5320540205222981137"`)
+	for _, format := range []string{FormatIcebergTable, FormatPaimonTable} {
+		t.Run(format+"_snapshot_id_marshaled_as_string", func(t *testing.T) {
+			snapshotID := int64(5320540205222981137)
+			out, err := json.Marshal(ExternalSpec{
+				Format:     format,
+				Columns:    []string{"id", "vec"},
+				Extfs:      map[string]string{"cloud_provider": "aws"},
+				SnapshotID: &snapshotID,
+			})
+			require.NoError(t, err)
+			assert.Contains(t, string(out), `"snapshot_id":"5320540205222981137"`)
 
-		var got map[string]any
-		require.NoError(t, json.Unmarshal(out, &got))
-		assert.Equal(t, FormatIcebergTable, got["format"])
-		assert.Equal(t, "5320540205222981137", got["snapshot_id"])
-	})
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(out, &got))
+			assert.Equal(t, format, got["format"])
+			assert.Equal(t, "5320540205222981137", got["snapshot_id"])
+		})
+	}
 
 	t.Run("nil_snapshot_id_omitted", func(t *testing.T) {
 		out, err := json.Marshal(ExternalSpec{Format: FormatParquet})
@@ -695,35 +698,41 @@ func TestValidateExtfsComplete_Azure(t *testing.T) {
 }
 
 func TestParseExternalSpec_SnapshotID(t *testing.T) {
-	t.Run("string_form_accepted", func(t *testing.T) {
-		spec, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":"5320540205222981137"}`)
-		require.NoError(t, err)
-		require.NotNil(t, spec.SnapshotID)
-		assert.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
-	})
+	for _, format := range []string{FormatIcebergTable, FormatPaimonTable} {
+		t.Run(format, func(t *testing.T) {
+			t.Run("string_form_accepted", func(t *testing.T) {
+				spec, err := ParseExternalSpec(fmt.Sprintf(`{"format":%q,"snapshot_id":"5320540205222981137"}`, format))
+				require.NoError(t, err)
+				require.NotNil(t, spec.SnapshotID)
+				assert.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
+			})
 
-	t.Run("bare_number_accepted", func(t *testing.T) {
-		spec, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":5320540205222981137}`)
-		require.NoError(t, err)
-		require.NotNil(t, spec.SnapshotID)
-		assert.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
-	})
+			t.Run("bare_number_accepted", func(t *testing.T) {
+				spec, err := ParseExternalSpec(fmt.Sprintf(`{"format":%q,"snapshot_id":5320540205222981137}`, format))
+				require.NoError(t, err)
+				require.NotNil(t, spec.SnapshotID)
+				assert.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
+			})
 
-	t.Run("non_numeric_string_rejected", func(t *testing.T) {
-		_, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":"abc"}`)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid external spec JSON")
-	})
+			t.Run("non_numeric_string_rejected", func(t *testing.T) {
+				_, err := ParseExternalSpec(fmt.Sprintf(`{"format":%q,"snapshot_id":"abc"}`, format))
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid external spec JSON")
+			})
 
-	t.Run("omitted_yields_nil", func(t *testing.T) {
-		spec, err := ParseExternalSpec(`{"format":"iceberg-table"}`)
-		require.NoError(t, err)
-		assert.Nil(t, spec.SnapshotID)
-	})
+			t.Run("omitted_yields_nil", func(t *testing.T) {
+				spec, err := ParseExternalSpec(fmt.Sprintf(`{"format":%q}`, format))
+				require.NoError(t, err)
+				assert.Nil(t, spec.SnapshotID)
+			})
+		})
+	}
 }
 
 func TestRedactExternalSpec_SnapshotIDNumber(t *testing.T) {
-	redacted := RedactExternalSpec(`{"format":"iceberg-table","snapshot_id":5320540205222981137}`)
-	assert.Contains(t, redacted, `"snapshot_id":"5320540205222981137"`)
-	assert.NotEqual(t, "<invalid spec>", redacted)
+	for _, format := range []string{FormatIcebergTable, FormatPaimonTable} {
+		redacted := RedactExternalSpec(fmt.Sprintf(`{"format":%q,"snapshot_id":5320540205222981137}`, format))
+		assert.Contains(t, redacted, `"snapshot_id":"5320540205222981137"`)
+		assert.NotEqual(t, "<invalid spec>", redacted)
+	}
 }

--- a/pkg/util/externalspec/specutil/spec.go
+++ b/pkg/util/externalspec/specutil/spec.go
@@ -35,6 +35,7 @@ const (
 	FormatLanceTable   = "lance-table"
 	FormatVortex       = "vortex"
 	FormatIcebergTable = "iceberg-table"
+	FormatPaimonTable  = "paimon-table"
 	FormatMilvusTable  = "milvus-table"
 )
 
@@ -71,6 +72,7 @@ type ExternalSpec struct {
 	Columns    []string          `json:"columns"`         // optional: specific columns to load
 	Extfs      map[string]string `json:"extfs,omitempty"` // optional: extfs config overrides
 	SnapshotID *int64            `json:"snapshot_id,omitempty"`
+	ScanMode   string            `json:"scan_mode,omitempty"` // Paimon: auto, direct-file, or data-split
 }
 
 // UnmarshalJSON accepts snapshot_id as either a JSON number or a decimal
@@ -136,6 +138,7 @@ var supportedFormats = map[string]bool{
 	FormatLanceTable:   true,
 	FormatVortex:       true,
 	FormatIcebergTable: true,
+	FormatPaimonTable:  true,
 	FormatMilvusTable:  true,
 }
 
@@ -189,6 +192,20 @@ func ParseExternalSpec(specStr string) (*ExternalSpec, error) {
 	if !supportedFormats[spec.Format] {
 		return nil, merr.WrapErrParameterInvalidMsg("unsupported format %q, supported formats: %s",
 			spec.Format, strings.Join(sortedKeys(supportedFormats), ", "))
+	}
+
+	if spec.Format == FormatPaimonTable {
+		if spec.ScanMode == "" {
+			spec.ScanMode = "auto"
+		}
+		switch spec.ScanMode {
+		case "auto", "direct-file", "data-split":
+		default:
+			return nil, merr.WrapErrParameterInvalidMsg(
+				"unsupported Paimon scan_mode %q; allowed values: auto, direct-file, data-split", spec.ScanMode)
+		}
+	} else if spec.ScanMode != "" {
+		return nil, merr.WrapErrParameterInvalidMsg("scan_mode is only supported for format %q", FormatPaimonTable)
 	}
 
 	for key, val := range spec.Extfs {

--- a/pkg/util/externalspec/specutil/spec_test.go
+++ b/pkg/util/externalspec/specutil/spec_test.go
@@ -18,6 +18,7 @@ package specutil
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,34 +84,65 @@ func TestParseExternalSpec(t *testing.T) {
 			spec.Extfs[ExtfsKeyAzureCredentialEndpoint])
 	})
 
-	t.Run("snapshot id accepts string and number", func(t *testing.T) {
-		spec, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":"5320540205222981137"}`)
-		require.NoError(t, err)
-		require.NotNil(t, spec.SnapshotID)
-		require.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
+	t.Run("table snapshot id accepts string and number", func(t *testing.T) {
+		for _, format := range []string{FormatIcebergTable, FormatPaimonTable} {
+			spec, err := ParseExternalSpec(fmt.Sprintf(`{"format":%q,"snapshot_id":"5320540205222981137"}`, format))
+			require.NoError(t, err)
+			require.NotNil(t, spec.SnapshotID)
+			require.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
 
-		spec, err = ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":5320540205222981137}`)
+			spec, err = ParseExternalSpec(fmt.Sprintf(`{"format":%q,"snapshot_id":5320540205222981137}`, format))
+			require.NoError(t, err)
+			require.NotNil(t, spec.SnapshotID)
+			require.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
+		}
+	})
+
+	t.Run("paimon table with optional snapshot id", func(t *testing.T) {
+		spec, err := ParseExternalSpec(`{"format":"paimon-table"}`)
+		require.NoError(t, err)
+		require.Equal(t, FormatPaimonTable, spec.Format)
+		require.Nil(t, spec.SnapshotID)
+		require.Equal(t, "auto", spec.ScanMode)
+
+		spec, err = ParseExternalSpec(`{"format":"paimon-table","snapshot_id":7}`)
 		require.NoError(t, err)
 		require.NotNil(t, spec.SnapshotID)
-		require.Equal(t, int64(5320540205222981137), *spec.SnapshotID)
+		require.Equal(t, int64(7), *spec.SnapshotID)
+	})
+
+	t.Run("paimon scan mode", func(t *testing.T) {
+		for _, mode := range []string{"auto", "direct-file", "data-split"} {
+			spec, err := ParseExternalSpec(fmt.Sprintf(`{"format":"paimon-table","scan_mode":%q}`, mode))
+			require.NoError(t, err)
+			require.Equal(t, mode, spec.ScanMode)
+		}
+		_, err := ParseExternalSpec(`{"format":"paimon-table","scan_mode":"native"}`)
+		require.ErrorContains(t, err, "unsupported Paimon scan_mode")
+		_, err = ParseExternalSpec(`{"format":"iceberg-table","scan_mode":"auto"}`)
+		require.ErrorContains(t, err, "only supported")
 	})
 
 	t.Run("invalid snapshot id rejected", func(t *testing.T) {
-		_, err := ParseExternalSpec(`{"format":"iceberg-table","snapshot_id":"abc"}`)
-		require.ErrorContains(t, err, "invalid external spec JSON")
+		for _, format := range []string{FormatIcebergTable, FormatPaimonTable} {
+			_, err := ParseExternalSpec(fmt.Sprintf(`{"format":%q,"snapshot_id":"abc"}`, format))
+			require.ErrorContains(t, err, "invalid external spec JSON")
+		}
 	})
 }
 
 func TestExternalSpecMarshalJSON(t *testing.T) {
-	snapshotID := int64(5320540205222981137)
-	out, err := json.Marshal(ExternalSpec{
-		Format:     FormatIcebergTable,
-		SnapshotID: &snapshotID,
-	})
-	require.NoError(t, err)
-	require.Contains(t, string(out), `"snapshot_id":"5320540205222981137"`)
+	for _, format := range []string{FormatIcebergTable, FormatPaimonTable} {
+		snapshotID := int64(5320540205222981137)
+		out, err := json.Marshal(ExternalSpec{
+			Format:     format,
+			SnapshotID: &snapshotID,
+		})
+		require.NoError(t, err)
+		require.Contains(t, string(out), `"snapshot_id":"5320540205222981137"`)
+	}
 
-	out, err = json.Marshal(ExternalSpec{Format: FormatParquet})
+	out, err := json.Marshal(ExternalSpec{Format: FormatParquet})
 	require.NoError(t, err)
 	require.NotContains(t, string(out), "snapshot_id")
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -7190,7 +7190,8 @@ type dataNodeConfig struct {
 	StandaloneSlotRatio ParamItem `refreshable:"false"`
 
 	// external collection
-	ExternalCollectionTargetRowsPerSegment ParamItem `refreshable:"true"`
+	ExternalCollectionTargetRowsPerSegment          ParamItem `refreshable:"true"`
+	ExternalCollectionPaimonMaxDataSplitsPerSegment ParamItem `refreshable:"true"`
 }
 
 func (p *dataNodeConfig) init(base *BaseTable) {
@@ -7715,6 +7716,15 @@ if this parameter <= 0, will set it as 10`,
 		Export:       false,
 	}
 	p.ExternalCollectionTargetRowsPerSegment.Init(base.mgr)
+
+	p.ExternalCollectionPaimonMaxDataSplitsPerSegment = ParamItem{
+		Key:          "dataNode.externalCollection.paimon.maxDataSplitsPerSegment",
+		Version:      "3.0.0",
+		DefaultValue: "64",
+		Doc:          "Maximum number of Paimon DataSplits packed into one external collection segment",
+		Export:       false,
+	}
+	p.ExternalCollectionPaimonMaxDataSplitsPerSegment.Init(base.mgr)
 }
 
 type streamingConfig struct {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -1008,6 +1008,7 @@ func TestCachedParam(t *testing.T) {
 	assert.Equal(t, int32(16), params.DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
 	assert.Equal(t, int32(16), params.DataNodeCfg.FlowGraphMaxQueueLength.GetAsInt32())
 	assert.Equal(t, int64(1000000), params.DataNodeCfg.ExternalCollectionTargetRowsPerSegment.GetAsInt64())
+	assert.Equal(t, int64(64), params.DataNodeCfg.ExternalCollectionPaimonMaxDataSplitsPerSegment.GetAsInt64())
 
 	assert.Equal(t, uint(100000), params.CommonCfg.BloomFilterSize.GetAsUint())
 	assert.Equal(t, uint(100000), params.CommonCfg.BloomFilterSize.GetAsUint())

--- a/tests/go_client/testcases/external_table_paimon_e2e_test.go
+++ b/tests/go_client/testcases/external_table_paimon_e2e_test.go
@@ -1,0 +1,320 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testcases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v3/column"
+	"github.com/milvus-io/milvus/client/v3/entity"
+	"github.com/milvus-io/milvus/client/v3/index"
+	client "github.com/milvus-io/milvus/client/v3/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/base"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+type paimonTableInfo struct {
+	TableLocation string
+	SnapshotIDs   []int64
+}
+
+type paimonExpectedRow struct {
+	PK    int64
+	Label string
+}
+
+func findPaimonLoon(t *testing.T) string {
+	t.Helper()
+	if configured := os.Getenv("PAIMON_LOON_BIN"); configured != "" {
+		info, err := os.Stat(configured)
+		require.NoError(t, err, "PAIMON_LOON_BIN does not exist")
+		require.False(t, info.IsDir(), "PAIMON_LOON_BIN points to a directory")
+		return configured
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "failed to locate the Paimon E2E source file")
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", ".."))
+	candidates := []string{
+		filepath.Join(repoRoot, "cmake_build", "thirdparty", "milvus-storage", "milvus-storage-build", "tools", "loon"),
+		filepath.Join(repoRoot, "cmake_build", "thirdparty", "milvus-storage", "milvus-storage-src", "cpp", "build", "Release", "tools", "loon"),
+	}
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	require.FailNow(t, "Paimon loon fixture binary not found",
+		"build the C++ unit-test target or set PAIMON_LOON_BIN; checked %s", strings.Join(candidates, ", "))
+	return ""
+}
+
+func createPaimonTable(t *testing.T, loon, scenario, minioAddress, accessKey, secretKey, bucket,
+	warehousePath string, rows, dimension int, deletedRows []int64,
+) paimonTableInfo {
+	t.Helper()
+	warehouse := fmt.Sprintf("s3://%s/%s/%s", minioAddress, bucket, strings.TrimPrefix(warehousePath, "/"))
+	args := []string{
+		"demo-table",
+		"--type", "paimon",
+		"--scenario", scenario,
+		"--path", warehouse,
+		"--dim", strconv.Itoa(dimension),
+		"--prop", "extfs.paimon.address=http://" + minioAddress,
+		"--prop", "extfs.paimon.bucket_name=" + bucket,
+		"--prop", "extfs.paimon.access_key_id=" + accessKey,
+		"--prop", "extfs.paimon.access_key_value=" + secretKey,
+		"--prop", "extfs.paimon.storage_type=remote",
+		"--prop", "extfs.paimon.cloud_provider=aws",
+		"--prop", "extfs.paimon.region=us-east-1",
+		"--prop", "extfs.paimon.use_ssl=false",
+		"--prop", "extfs.paimon.use_iam=false",
+		"--prop", "extfs.paimon.use_virtual_host=false",
+	}
+	args = append(args, "--rows", strconv.Itoa(rows))
+	if len(deletedRows) > 0 {
+		values := make([]string, 0, len(deletedRows))
+		for _, row := range deletedRows {
+			values = append(values, strconv.FormatInt(row, 10))
+		}
+		args = append(args, "--deletes", strings.Join(values, ","))
+	}
+
+	cmd := exec.Command(loon, args...) // #nosec G204 -- test-controlled binary and arguments
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "failed to create %s fixture with loon:\n%s", scenario, output)
+	t.Logf("created %s Paimon fixture:\n%s", scenario, output)
+
+	locationMatch := regexp.MustCompile(`(?m)^\s*(?:table_location|path):\s*(\S+)\s*$`).FindSubmatch(output)
+	require.Len(t, locationMatch, 2, "loon output has no table location")
+	snapshotMatch := regexp.MustCompile(`(?m)^\s*snapshots:\s*\[([0-9,]+)\]\s*$`).FindSubmatch(output)
+	require.Len(t, snapshotMatch, 2, "loon output has no snapshots")
+
+	snapshotValues := strings.Split(string(snapshotMatch[1]), ",")
+	snapshotIDs := make([]int64, 0, len(snapshotValues))
+	for _, value := range snapshotValues {
+		snapshotID, err := strconv.ParseInt(value, 10, 64)
+		require.NoError(t, err, "invalid snapshot id in loon output")
+		snapshotIDs = append(snapshotIDs, snapshotID)
+	}
+	return paimonTableInfo{TableLocation: string(locationMatch[1]), SnapshotIDs: snapshotIDs}
+}
+
+func waitPaimonRefresh(t *testing.T, ctx context.Context, mc *base.MilvusClient, jobID int64) {
+	t.Helper()
+	deadline := time.After(10 * time.Minute)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("Paimon refresh job %d timed out", jobID)
+		case <-ticker.C:
+			progress, err := mc.GetRefreshExternalCollectionProgress(ctx,
+				client.NewGetRefreshExternalCollectionProgressOption(jobID))
+			require.NoError(t, err)
+			switch progress.State {
+			case entity.RefreshStateCompleted:
+				return
+			case entity.RefreshStateFailed:
+				t.Fatalf("Paimon refresh job %d failed: %s", jobID, progress.Reason)
+			}
+		}
+	}
+}
+
+func runPaimonSnapshotRead(t *testing.T, externalSource string, snapshotID int64, scanMode string, dimension int,
+	expected []paimonExpectedRow, extfs map[string]string,
+) {
+	t.Helper()
+	type externalSpecJSON struct {
+		Format     string            `json:"format"`
+		SnapshotID int64             `json:"snapshot_id,string"`
+		ScanMode   string            `json:"scan_mode,omitempty"`
+		Extfs      map[string]string `json:"extfs"`
+	}
+	specBytes, err := json.Marshal(externalSpecJSON{
+		Format:     "paimon-table",
+		SnapshotID: snapshotID,
+		ScanMode:   scanMode,
+		Extfs:      extfs,
+	})
+	require.NoError(t, err)
+	externalSpec := string(specBytes)
+
+	ctx := hp.CreateContext(t, 30*time.Minute)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	collName := common.GenRandomString("paimon_e2e", 6)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(externalSource).
+		WithExternalSpec(externalSpec).
+		WithField(entity.NewField().WithName("pk").WithDataType(entity.FieldTypeInt64).WithExternalField("pk")).
+		WithField(entity.NewField().WithName("label").WithDataType(entity.FieldTypeVarChar).WithMaxLength(256).WithExternalField("label")).
+		WithField(entity.NewField().WithName("vector").WithDataType(entity.FieldTypeFloatVector).WithDim(int64(dimension)).WithExternalField("vector"))
+	require.NoError(t, mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema)))
+
+	refreshResult, err := mc.RefreshExternalCollection(ctx,
+		client.NewRefreshExternalCollectionOption(collName).
+			WithExternalSource(externalSource).
+			WithExternalSpec(externalSpec))
+	require.NoError(t, err)
+	waitPaimonRefresh(t, ctx, mc, refreshResult.JobID)
+
+	indexTask, err := mc.CreateIndex(ctx,
+		client.NewCreateIndexOption(collName, "vector", index.NewFlatIndex(entity.COSINE)))
+	require.NoError(t, err)
+	require.NoError(t, indexTask.Await(ctx))
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	require.NoError(t, err)
+	require.NoError(t, loadTask.Await(ctx))
+
+	queryResult, err := mc.Query(ctx,
+		client.NewQueryOption(collName).
+			WithFilter("pk >= 0").
+			WithOutputFields("pk", "label").
+			WithLimit(100))
+	require.NoError(t, err)
+	pkColumn, ok := queryResult.GetColumn("pk").(*column.ColumnInt64)
+	require.True(t, ok)
+	labelColumn, ok := queryResult.GetColumn("label").(*column.ColumnVarChar)
+	require.True(t, ok)
+	require.Equal(t, len(pkColumn.Data()), len(labelColumn.Data()))
+
+	actual := make([]paimonExpectedRow, len(pkColumn.Data()))
+	for i, pk := range pkColumn.Data() {
+		actual[i] = paimonExpectedRow{PK: pk, Label: labelColumn.Data()[i]}
+	}
+	sort.Slice(actual, func(i, j int) bool { return actual[i].PK < actual[j].PK })
+	require.Equal(t, expected, actual)
+
+	queryVector := make([]float32, dimension)
+	searchResult, err := mc.Search(ctx,
+		client.NewSearchOption(collName, 3, []entity.Vector{entity.FloatVector(queryVector)}).
+			WithOutputFields("pk", "label"))
+	require.NoError(t, err)
+	require.NotEmpty(t, searchResult)
+	require.Greater(t, searchResult[0].ResultCount, 0)
+}
+
+// TestExternalTablePaimonE2E mirrors the Iceberg external-table E2E while
+// adding the two Paimon-specific correctness paths: row-tracking deletion
+// vectors and primary-key merge-on-read. Each fixture reads both its initial
+// and latest snapshot so snapshot pinning cannot be masked by latest-state
+// planning.
+//
+// Run:
+//
+//	PAIMON_LOON_BIN=/path/to/loon go test -v -run TestExternalTablePaimonE2E \
+//	  -timeout 45m -tags dynamic,test
+func TestExternalTablePaimonE2E(t *testing.T) {
+	minioAddress := envOrDefault("MINIO_ADDRESS", "localhost:9000")
+	accessKey := envOrDefault("PAIMON_MINIO_ACCESS_KEY", "minioadmin")
+	secretKey := envOrDefault("PAIMON_MINIO_SECRET_KEY", "minioadmin")
+	bucket := envOrDefault("MINIO_BUCKET", "a-bucket")
+	dimension := 4
+	loon := findPaimonLoon(t)
+	extfs := map[string]string{
+		"access_key_id":    accessKey,
+		"access_key_value": secretKey,
+		"cloud_provider":   "minio",
+		"region":           "us-east-1",
+		"use_ssl":          "false",
+	}
+
+	appendTable := createPaimonTable(t, loon, "append-only", minioAddress, accessKey, secretKey, bucket,
+		fmt.Sprintf("paimon-test/append-%d", time.Now().UnixNano()), 10, dimension, nil)
+	require.Len(t, appendTable.SnapshotIDs, 1)
+	appendSource := toMilvusS3URIForMinIO(appendTable.TableLocation, minioAddress)
+	appendExpected := make([]paimonExpectedRow, 0, 10)
+	for pk := int64(0); pk < 10; pk++ {
+		appendExpected = append(appendExpected, paimonExpectedRow{PK: pk, Label: fmt.Sprintf("label_%d", pk%10)})
+	}
+	for _, testCase := range []struct {
+		name     string
+		scanMode string
+	}{
+		{name: "append_default_auto"},
+		{name: "append_explicit_direct_file", scanMode: "direct-file"},
+		{name: "append_explicit_data_split", scanMode: "data-split"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			runPaimonSnapshotRead(t, appendSource, appendTable.SnapshotIDs[0], testCase.scanMode, dimension,
+				appendExpected, extfs)
+		})
+	}
+
+	dvTable := createPaimonTable(t, loon, "deletion-vector", minioAddress, accessKey, secretKey, bucket,
+		fmt.Sprintf("paimon-test/dv-%d", time.Now().UnixNano()), 10, dimension, []int64{0, 5, 9})
+	require.Len(t, dvTable.SnapshotIDs, 2)
+	dvSource := toMilvusS3URIForMinIO(dvTable.TableLocation, minioAddress)
+	dvInitial := make([]paimonExpectedRow, 0, 10)
+	for pk := int64(0); pk < 10; pk++ {
+		dvInitial = append(dvInitial, paimonExpectedRow{PK: pk, Label: fmt.Sprintf("label_%d", pk%10)})
+	}
+	dvLatest := []paimonExpectedRow{
+		{PK: 1, Label: "label_1"}, {PK: 2, Label: "label_2"},
+		{PK: 3, Label: "label_3"}, {PK: 4, Label: "label_4"},
+		{PK: 6, Label: "label_6"}, {PK: 7, Label: "label_7"},
+		{PK: 8, Label: "label_8"},
+	}
+	t.Run("deletion_vector_initial_snapshot", func(t *testing.T) {
+		runPaimonSnapshotRead(t, dvSource, dvTable.SnapshotIDs[0], "", dimension, dvInitial, extfs)
+	})
+	t.Run("deletion_vector_latest_snapshot", func(t *testing.T) {
+		runPaimonSnapshotRead(t, dvSource, dvTable.SnapshotIDs[1], "", dimension, dvLatest, extfs)
+	})
+
+	morTable := createPaimonTable(t, loon, "merge-on-read", minioAddress, accessKey, secretKey, bucket,
+		fmt.Sprintf("paimon-test/mor-%d", time.Now().UnixNano()), 6, dimension, nil)
+	require.Len(t, morTable.SnapshotIDs, 2)
+	morSource := toMilvusS3URIForMinIO(morTable.TableLocation, minioAddress)
+	morInitial := make([]paimonExpectedRow, 0, 6)
+	for pk := int64(0); pk < 6; pk++ {
+		morInitial = append(morInitial, paimonExpectedRow{PK: pk, Label: fmt.Sprintf("label_%d", pk)})
+	}
+	morLatest := []paimonExpectedRow{
+		{PK: 0, Label: "label_0"}, {PK: 1, Label: "label_1_updated"},
+		{PK: 3, Label: "label_3"}, {PK: 4, Label: "label_4"},
+		{PK: 5, Label: "label_5"}, {PK: 6, Label: "label_6"},
+	}
+	t.Run("merge_on_read_initial_snapshot", func(t *testing.T) {
+		runPaimonSnapshotRead(t, morSource, morTable.SnapshotIDs[0], "", dimension, morInitial, extfs)
+	})
+	t.Run("merge_on_read_latest_snapshot", func(t *testing.T) {
+		runPaimonSnapshotRead(t, morSource, morTable.SnapshotIDs[1], "", dimension, morLatest, extfs)
+	})
+}


### PR DESCRIPTION
Closes #50632

Design + tracking: #45881

Storage direct-file support: milvus-io/milvus-storage#602

Depends on: milvus-io/milvus-storage#616

## What changed

Add Apache Paimon as a read-only source for the existing external collection framework.

- Accept `paimon-table` external specs and validate `auto`, `direct-file`, and `data-split` scan modes.
- Forward the selected snapshot, scan mode, and object-storage options to milvus-storage.
- Preserve storage-owned Paimon descriptors in StorageV3 column-group file properties.
- Keep native DataSplits atomic, group them by bucket, and greedily pack them into Milvus segments using the existing target-row policy and a configurable per-segment DataSplit limit.
- Keep direct files on the same fragment and segment path used by Iceberg and other file-based formats.
- Use decoded-memory estimates for load planning and retain stable direct-file fragment identities across snapshot refreshes.
- Add C++, Go, and client/v3 coverage for routing, descriptors, segment packing, deletion vectors, merge-on-read, Parquet, Vortex, and snapshot pinning.

## Read-path routing

- `auto` uses direct-file reads when a split is safely raw-convertible, and falls back to native DataSplit execution when Paimon semantics require it.
- `direct-file` fails explicitly if a split cannot be read safely without native Paimon execution.
- `data-split` forces native DataSplit execution.

Direct-file support is provided by the merged milvus-storage#602. Until milvus-storage#616 is merged, this draft pins its exact fork commit. The repository URL and revision will be changed back to the merged upstream `main` commit before this PR is marked ready.

## Compatibility and scope

- Existing Parquet, Vortex, Lance, Iceberg, and `milvus-table` external collections keep their current behavior.
- Paimon DataSplits are not divided into smaller external fragments.
- This change does not make external collections writable.

## Test plan

- External-spec parsing and scan-mode validation tests.
- StorageV3 manifest property round-trip and descriptor validation tests.
- DataNode fragment identity, bucket-aware packing, and DataSplit-count limit tests.
- Segcore direct-file and DataSplit read tests.
- Go external collection refresh tests.
- Linux standalone client/v3 E2E for automatic routing, explicit scan modes, deletion vectors, merge-on-read, and pinned snapshots.
