### PR TITLE
build(deps): update Knowhere sparse codec fix

### DIFF
--- a/internal/core/thirdparty/knowhere/CMakeLists.txt
+++ b/internal/core/thirdparty/knowhere/CMakeLists.txt
@@ -14,11 +14,9 @@
 # Update KNOWHERE_VERSION for the first occurrence
 milvus_add_pkg_config("knowhere")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-# zilliztech/knowhere#1699 (iterator error-code interface) that this segcore
-# adaptation depends on has landed on knowhere main and is included in the
-# v3.0.6 release tag, so pin to the tagged release instead of a raw commit.
-set( KNOWHERE_VERSION v3.0.6 )
-set( GIT_REPOSITORY  "https://github.com/zilliztech/knowhere.git")
+# zilliztech/knowhere#1738 preserves the v8/v9 sparse flat codec.
+set( KNOWHERE_VERSION 62486cd10c5c87a1d1f5e9f066b30e5f7b91d6b3 )
+set( GIT_REPOSITORY  "https://github.com/sparknack/knowhere.git")
 
 message(STATUS "Knowhere repo: ${GIT_REPOSITORY}")
 message(STATUS "Knowhere version: ${KNOWHERE_VERSION}")


### PR DESCRIPTION
## What changed
- Pin Knowhere to sparknack/knowhere commit 62486cd1 from https://github.com/zilliztech/knowhere/pull/1738.
- Preserve the v8/v9 sparse flat-codec fix until it lands upstream.

## Test
- ninja -C cmake_build -j1 knowhere
- make verifiers (did not complete: local parallel C++ compilation hit host resource/compiler failures outside the Knowhere target)