### PR TITLE
fix: keep sync dispatcher cleanup after task panic

### DIFF
--- a/internal/flushcommon/syncmgr/key_lock_dispatcher.go
+++ b/internal/flushcommon/syncmgr/key_lock_dispatcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
@@ -170,18 +171,21 @@ func (d *keyLockDispatcher[K]) dispatchLocked(key K, pt *pendingTask) {
 	// By spawning a goroutine, the current worker function can return and
 	// release its slot, allowing the goroutine's Submit to proceed.
 	go func() {
-		f := d.workerPool.Submit(func() (struct{}, error) {
+		f := d.workerPool.Submit(func() (ret struct{}, err error) {
 			nodeID := paramtable.GetStringNodeID()
 			metrics.WALFlusherSyncDispatcherQueueDuration.WithLabelValues(nodeID).Observe(time.Since(pt.enqueueAt).Seconds())
 
 			startTime := time.Now()
-			err := pt.task.Run(pt.ctx)
+			defer func() {
+				metrics.WALFlusherSyncDispatcherExecuteDuration.WithLabelValues(nodeID).Observe(time.Since(startTime).Seconds())
+				onComplete(err)
+			}()
+
+			err = runTaskSafely(pt.ctx, pt.task)
 			for _, cb := range pt.callbacks {
-				err = cb(err)
+				err = runTaskCallbackSafely(cb, err)
 			}
-			metrics.WALFlusherSyncDispatcherExecuteDuration.WithLabelValues(nodeID).Observe(time.Since(startTime).Seconds())
-			onComplete(err)
-			return struct{}{}, err
+			return ret, err
 		})
 
 		// Detect pool rejection (e.g., pool closed during shutdown).
@@ -196,6 +200,28 @@ func (d *keyLockDispatcher[K]) dispatchLocked(key K, pt *pendingTask) {
 		default:
 		}
 	}()
+}
+
+func runTaskSafely(ctx context.Context, task Task) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = merr.WrapErrServiceInternalMsg("sync task panicked: %v", r)
+		}
+	}()
+	return task.Run(ctx)
+}
+
+func runTaskCallbackSafely(callback func(error) error, err error) (result error) {
+	result = err
+	if callback == nil {
+		return result
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			result = merr.WrapErrServiceInternalMsg("sync task callback panicked: %v", r)
+		}
+	}()
+	return callback(err)
 }
 
 // Close drains all remaining queued tasks across all keys, notifying each

--- a/internal/flushcommon/syncmgr/key_lock_dispatcher_test.go
+++ b/internal/flushcommon/syncmgr/key_lock_dispatcher_test.go
@@ -151,6 +151,56 @@ func (s *KeyLockDispatcherSuite) TestCallbackPropagation() {
 	s.True(callbackCalled.Load())
 }
 
+// TestPanicStillCompletesAndDrains verifies that a task/callback panic cannot
+// bypass dispatcher cleanup. The writebuffer failure handler may panic, but the
+// dispatcher must still complete the future, release capacity, and drain the
+// next task for the same key.
+func (s *KeyLockDispatcherSuite) TestPanicStillCompletesAndDrains() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := newKeyLockDispatcher[int64](1)
+
+	callbackCalled := atomic.NewBool(false)
+	recoveryCallbackCalled := atomic.NewBool(false)
+	panicTask := NewMockTask(s.T())
+	panicTask.EXPECT().Run(ctx).Run(func(_ context.Context) {
+		panic("mock task panic")
+	}).Return(nil)
+
+	nextRan := atomic.NewBool(false)
+	nextTask := NewMockTask(s.T())
+	nextTask.EXPECT().Run(ctx).Run(func(_ context.Context) {
+		nextRan.Store(true)
+	}).Return(nil)
+
+	f1 := d.Submit(ctx, 1, panicTask, func(err error) error {
+		callbackCalled.Store(err != nil)
+		panic("mock callback panic")
+	}, func(err error) error {
+		recoveryCallbackCalled.Store(err != nil)
+		return err
+	})
+	f2 := d.Submit(ctx, 1, nextTask)
+
+	select {
+	case <-f1.Inner():
+	case <-time.After(time.Second):
+		s.FailNow("panicking task future must complete")
+	}
+	s.Error(f1.Err())
+	s.True(callbackCalled.Load(), "callbacks must observe the panic error")
+	s.True(recoveryCallbackCalled.Load(), "later callbacks must run after a callback panic")
+
+	select {
+	case <-f2.Inner():
+	case <-time.After(time.Second):
+		s.FailNow("queued task for the same key must drain after panic cleanup")
+	}
+	s.NoError(f2.Err())
+	s.True(nextRan.Load())
+	s.Eventually(func() bool { return d.Pending() == 0 }, time.Second, 10*time.Millisecond)
+}
+
 // TestMixedKeysConcurrency verifies a realistic scenario: multiple segments
 // syncing concurrently while same-segment syncs remain serial.
 func (s *KeyLockDispatcherSuite) TestMixedKeysConcurrency() {


### PR DESCRIPTION
issue: #51854

## What

Recover task and callback panics inside the key-locked sync dispatcher, convert them to typed system errors, and still run dispatcher completion bookkeeping.

This keeps the dispatcher future complete, releases pending capacity, clears the in-flight segment key, and lets later callbacks run even when an earlier task/callback panics. The growing-source writebuffer recovery callback can then roll back sync state and schedule retry instead of being skipped by the default panicking error handler.

## Verification

Local worktree note: this branch lives under `.worktrees/`, so the Go commands used `GOWORK=off`; the worktree also used ignored symlinks to the main checkout's `internal/core/output` and generated migration `legacypb` artifact.

- Repro first: `PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:$LD_LIBRARY_PATH GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/syncmgr -run 'TestKeyLockDispatcher/TestPanicStillCompletesAndDrains'` failed before the fix with `panic: mock task panic [recovered, repanicked]`.
- `PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:$LD_LIBRARY_PATH GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/syncmgr -run 'TestKeyLockDispatcher/TestPanicStillCompletesAndDrains'`
- `PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:$LD_LIBRARY_PATH GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/syncmgr`
- `PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:$LD_LIBRARY_PATH GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/writebuffer`
- `PKG_CONFIG_PATH=/home/sheep/workspace/milvus/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=/home/sheep/workspace/milvus/internal/core/output/lib:$LD_LIBRARY_PATH GOWORK=off go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/flushcommon/...`
- `GOWORK=off make static-check` -> 0 issues across core, pkg, client, and go_client e2e phases.
