### PR TITLE
enhance: include field names and types in range, IN, and comparison errors

### DIFF
--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -1205,8 +1205,15 @@ func (v *ParserVisitor) VisitTerm(ctx *parser.TermContext) interface{} {
 		for i, e := range array {
 			castedValue, err := castValue(dataType, e)
 			if err != nil {
+				// dataType is printed as-is after the target is narrowed above. If the array
+				// target is not narrowed, dataType remains Array, so the element type is appended
+				// to reflect the expected shape of each value in the list.
+				fieldDataType := dataType.String()
+				if typeutil.IsArrayType(dataType) {
+					fieldDataType = getDataType(childExpr)
+				}
 				return merr.WrapErrParameterInvalidMsg("value %s (%s) in list cannot be casted to field %s (%s)",
-					formatGenericValue(e), getValueDataType(e), ctx.Expr(0).GetText(), dataType.String())
+					literalText(termElementText(ctx.Expr(1), i), e), getValueDataType(e), ctx.Expr(0).GetText(), fieldDataType)
 			}
 			values[i] = castedValue
 		}
@@ -1408,6 +1415,21 @@ func columnIdentifierText(identifier, child, structSubField, structIndexField an
 	}
 }
 
+// termElementText returns the source text of the i-th element in a term list. It
+// returns an empty string when the list is not a literal, such as when it is
+// produced by constant folding, since there is no source token available to quote.
+func termElementText(list parser.IExprContext, i int) string {
+	arrayCtx, ok := list.(*parser.ArrayContext)
+	if !ok {
+		return ""
+	}
+	elements := arrayCtx.AllExpr()
+	if i >= len(elements) {
+		return ""
+	}
+	return elements[i].GetText()
+}
+
 func (v *ParserVisitor) getChildColumnInfo(identifier, child, structSubField, structIndexField antlr.TerminalNode) (*planpb.ColumnInfo, error) {
 	if identifier != nil {
 		childExpr, err := v.translateIdentifier(identifier.GetText())
@@ -1546,12 +1568,12 @@ func (v *ParserVisitor) VisitRange(ctx *parser.RangeContext) interface{} {
 	lowerValue := lowerValueExpr.GetValue()
 	upperValue := upperValueExpr.GetValue()
 	if !isTemplateExpr(lowerValueExpr) {
-		if lowerValue, err = castRangeValue(fieldText, fieldDataType, lowerValue); err != nil {
+		if lowerValue, err = castRangeValue(fieldText, ctx.Expr(0).GetText(), fieldDataType, lowerValue); err != nil {
 			return err
 		}
 	}
 	if !isTemplateExpr(upperValueExpr) {
-		if upperValue, err = castRangeValue(fieldText, fieldDataType, upperValue); err != nil {
+		if upperValue, err = castRangeValue(fieldText, ctx.Expr(1).GetText(), fieldDataType, upperValue); err != nil {
 			return err
 		}
 	}
@@ -1633,12 +1655,12 @@ func (v *ParserVisitor) VisitReverseRange(ctx *parser.ReverseRangeContext) inter
 	lowerValue := lowerValueExpr.GetValue()
 	upperValue := upperValueExpr.GetValue()
 	if !isTemplateExpr(lowerValueExpr) {
-		if lowerValue, err = castRangeValue(fieldText, fieldDataType, lowerValue); err != nil {
+		if lowerValue, err = castRangeValue(fieldText, ctx.Expr(1).GetText(), fieldDataType, lowerValue); err != nil {
 			return err
 		}
 	}
 	if !isTemplateExpr(upperValueExpr) {
-		if upperValue, err = castRangeValue(fieldText, fieldDataType, upperValue); err != nil {
+		if upperValue, err = castRangeValue(fieldText, ctx.Expr(0).GetText(), fieldDataType, upperValue); err != nil {
 			return err
 		}
 	}

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -546,7 +546,7 @@ func (v *ParserVisitor) VisitEquality(ctx *parser.EqualityContext) interface{} {
 		return ret
 	}
 
-	expr, err := HandleCompare(ctx.GetOp().GetTokenType(), leftExpr, rightExpr)
+	expr, err := HandleCompare(ctx.GetOp().GetTokenType(), leftExpr, rightExpr, ctx.Expr(0).GetText(), ctx.Expr(1).GetText())
 	if err != nil {
 		return err
 	}
@@ -601,7 +601,7 @@ func (v *ParserVisitor) VisitRelational(ctx *parser.RelationalContext) interface
 		return err
 	}
 
-	expr, err := HandleCompare(ctx.GetOp().GetTokenType(), leftExpr, rightExpr)
+	expr, err := HandleCompare(ctx.GetOp().GetTokenType(), leftExpr, rightExpr, ctx.Expr(0).GetText(), ctx.Expr(1).GetText())
 	if err != nil {
 		return err
 	}
@@ -1205,7 +1205,8 @@ func (v *ParserVisitor) VisitTerm(ctx *parser.TermContext) interface{} {
 		for i, e := range array {
 			castedValue, err := castValue(dataType, e)
 			if err != nil {
-				return merr.WrapErrParameterInvalidMsg("value '%s' in list cannot be casted to %s", e.String(), dataType.String())
+				return merr.WrapErrParameterInvalidMsg("value %s (%s) in list cannot be casted to field %s (%s)",
+					formatGenericValue(e), getValueDataType(e), ctx.Expr(0).GetText(), dataType.String())
 			}
 			values[i] = castedValue
 		}
@@ -1389,6 +1390,24 @@ func (v *ParserVisitor) getColumnInfoFromStructIndexField(identifier string) (*p
 	}, nil
 }
 
+// columnIdentifierText returns the source text for the identifier matched by the rule.
+// ColumnInfo only contains the field ID, so the original field name must be resolved
+// here for user-facing error messages. The lookup order follows getChildColumnInfo.
+func columnIdentifierText(identifier, child, structSubField, structIndexField antlr.TerminalNode) string {
+	switch {
+	case identifier != nil:
+		return identifier.GetText()
+	case structSubField != nil:
+		return structSubField.GetText()
+	case structIndexField != nil:
+		return structIndexField.GetText()
+	case child != nil:
+		return child.GetText()
+	default:
+		return ""
+	}
+}
+
 func (v *ParserVisitor) getChildColumnInfo(identifier, child, structSubField, structIndexField antlr.TerminalNode) (*planpb.ColumnInfo, error) {
 	if identifier != nil {
 		childExpr, err := v.translateIdentifier(identifier.GetText())
@@ -1480,6 +1499,12 @@ func (v *ParserVisitor) VisitCall(ctx *parser.CallContext) interface{} {
 
 // VisitRange translates expr to range plan.
 func (v *ParserVisitor) VisitRange(ctx *parser.RangeContext) interface{} {
+	fieldText := columnIdentifierText(
+		ctx.Identifier(),
+		ctx.JSONIdentifier(),
+		ctx.StructSubFieldIdentifier(),
+		ctx.StructIndexFieldIdentifier(),
+	)
 	columnInfo, err := v.getChildColumnInfo(
 		ctx.Identifier(),
 		ctx.JSONIdentifier(),
@@ -1521,12 +1546,12 @@ func (v *ParserVisitor) VisitRange(ctx *parser.RangeContext) interface{} {
 	lowerValue := lowerValueExpr.GetValue()
 	upperValue := upperValueExpr.GetValue()
 	if !isTemplateExpr(lowerValueExpr) {
-		if lowerValue, err = castRangeValue(fieldDataType, lowerValue); err != nil {
+		if lowerValue, err = castRangeValue(fieldText, fieldDataType, lowerValue); err != nil {
 			return err
 		}
 	}
 	if !isTemplateExpr(upperValueExpr) {
-		if upperValue, err = castRangeValue(fieldDataType, upperValue); err != nil {
+		if upperValue, err = castRangeValue(fieldText, fieldDataType, upperValue); err != nil {
 			return err
 		}
 	}
@@ -1560,6 +1585,12 @@ func (v *ParserVisitor) VisitRange(ctx *parser.RangeContext) interface{} {
 
 // VisitReverseRange parses the expression like "1 > a > 0".
 func (v *ParserVisitor) VisitReverseRange(ctx *parser.ReverseRangeContext) interface{} {
+	fieldText := columnIdentifierText(
+		ctx.Identifier(),
+		ctx.JSONIdentifier(),
+		ctx.StructSubFieldIdentifier(),
+		ctx.StructIndexFieldIdentifier(),
+	)
 	columnInfo, err := v.getChildColumnInfo(
 		ctx.Identifier(),
 		ctx.JSONIdentifier(),
@@ -1602,12 +1633,12 @@ func (v *ParserVisitor) VisitReverseRange(ctx *parser.ReverseRangeContext) inter
 	lowerValue := lowerValueExpr.GetValue()
 	upperValue := upperValueExpr.GetValue()
 	if !isTemplateExpr(lowerValueExpr) {
-		if lowerValue, err = castRangeValue(fieldDataType, lowerValue); err != nil {
+		if lowerValue, err = castRangeValue(fieldText, fieldDataType, lowerValue); err != nil {
 			return err
 		}
 	}
 	if !isTemplateExpr(upperValueExpr) {
-		if upperValue, err = castRangeValue(fieldDataType, upperValue); err != nil {
+		if upperValue, err = castRangeValue(fieldText, fieldDataType, upperValue); err != nil {
 			return err
 		}
 	}

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -1604,6 +1604,43 @@ func TestExpr_JSONBinaryRangePreciseBoundValidation(t *testing.T) {
 	require.NotNil(t, expr.GetBinaryExpr())
 }
 
+// Type-mismatch errors in range, `in`, and comparison expressions must include
+// the rejected field name and its type. Without this, users must manually isolate
+// the failing operand.
+func TestExpr_TypeMismatchNamesFieldAndType(t *testing.T) {
+	helper := newTestSchemaHelper(t)
+
+	cases := []struct {
+		expr     string
+		contains []string
+	}{
+		{`1.5 < Int64Field < 3.5`, []string{"1.5", "Double", "Int64Field", "Int64"}},
+		{`"a" < Int64Field < "z"`, []string{`"a"`, "VarChar", "Int64Field", "Int64"}},
+		{`3.5 > Int64Field > 1.5`, []string{"1.5", "Double", "Int64Field", "Int64"}},
+		{`1 < VarCharField < 5`, []string{"1", "Int64", "VarCharField", "VarChar"}},
+		{`0 < BoolField < 1`, []string{"boolean expr", "BoolField", "Bool"}},
+		{`1 < ArrayField[0] < "z"`, []string{`"z"`, "VarChar", "ArrayField[0]", "Int64"}},
+		{`Int64Field in [1, "two", 3]`, []string{`"two"`, "VarChar", "Int64Field", "Int64"}},
+		{`VarCharField in [1, 2]`, []string{"1", "Int64", "VarCharField", "VarChar"}},
+		{`VarCharField > 5`, []string{"VarCharField", "VarChar", "5", "Int64"}},
+		{`Int64Field == "abc"`, []string{"Int64Field", "Int64", `"abc"`, "VarChar"}},
+		{`VarCharField > Int64Field`, []string{"VarCharField", "VarChar", "Int64Field", "Int64"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.expr, func(t *testing.T) {
+			_, err := ParseExpr(helper, c.expr, nil)
+			require.Error(t, err)
+			for _, want := range c.contains {
+				assert.Contains(t, err.Error(), want)
+			}
+			// The internal protobuf text format must never appear in a user-facing error message.
+			assert.NotContains(t, err.Error(), "string_val:")
+			assert.NotContains(t, err.Error(), "int64_val:")
+		})
+	}
+}
+
 func TestExpr_castValue(t *testing.T) {
 	schema := newTestSchema(true)
 	helper, err := typeutil.CreateSchemaHelper(schema)

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -1611,20 +1611,55 @@ func TestExpr_TypeMismatchNamesFieldAndType(t *testing.T) {
 	helper := newTestSchemaHelper(t)
 
 	cases := []struct {
-		expr     string
-		contains []string
+		expr        string
+		contains    []string
+		notContains []string
 	}{
-		{`1.5 < Int64Field < 3.5`, []string{"1.5", "Double", "Int64Field", "Int64"}},
-		{`"a" < Int64Field < "z"`, []string{`"a"`, "VarChar", "Int64Field", "Int64"}},
-		{`3.5 > Int64Field > 1.5`, []string{"1.5", "Double", "Int64Field", "Int64"}},
-		{`1 < VarCharField < 5`, []string{"1", "Int64", "VarCharField", "VarChar"}},
-		{`0 < BoolField < 1`, []string{"boolean expr", "BoolField", "Bool"}},
-		{`1 < ArrayField[0] < "z"`, []string{`"z"`, "VarChar", "ArrayField[0]", "Int64"}},
-		{`Int64Field in [1, "two", 3]`, []string{`"two"`, "VarChar", "Int64Field", "Int64"}},
-		{`VarCharField in [1, 2]`, []string{"1", "Int64", "VarCharField", "VarChar"}},
-		{`VarCharField > 5`, []string{"VarCharField", "VarChar", "5", "Int64"}},
-		{`Int64Field == "abc"`, []string{"Int64Field", "Int64", `"abc"`, "VarChar"}},
-		{`VarCharField > Int64Field`, []string{"VarCharField", "VarChar", "Int64Field", "Int64"}},
+		{expr: `1.5 < Int64Field < 3.5`, contains: []string{"1.5", "Double", "Int64Field", "Int64"}},
+		{expr: `"a" < Int64Field < "z"`, contains: []string{`"a"`, "VarChar", "Int64Field", "Int64"}},
+		{expr: `3.5 > Int64Field > 1.5`, contains: []string{"1.5", "Double", "Int64Field", "Int64"}},
+		{expr: `1 < VarCharField < 5`, contains: []string{"1", "Int64", "VarCharField", "VarChar"}},
+		{expr: `0 < BoolField < 1`, contains: []string{"boolean expr", "BoolField", "Bool"}},
+		{expr: `1 < ArrayField[0] < "z"`, contains: []string{`"z"`, "VarChar", "ArrayField[0]", "Int64"}},
+		{expr: `Int64Field in [1, "two", 3]`, contains: []string{`"two"`, "VarChar", "Int64Field", "Int64"}},
+		{expr: `VarCharField in [1, 2]`, contains: []string{"1", "Int64", "VarCharField", "VarChar"}},
+		{expr: `VarCharField > 5`, contains: []string{"VarCharField", "VarChar", "5", "Int64"}},
+		{expr: `Int64Field == "abc"`, contains: []string{"Int64Field", "Int64", `"abc"`, "VarChar"}},
+		{expr: `VarCharField > Int64Field`, contains: []string{"VarCharField", "VarChar", "Int64Field", "Int64"}},
+
+		// Literals whose source text differs from their parsed value must be shown as
+		// written. Reporting `1.0` as `1 (Double)` would be misleading.
+		{
+			expr:        `Int64Field in [1.0]`,
+			contains:    []string{"value 1.0 (Double)", "Int64Field", "Int64"},
+			notContains: []string{"value 1 ("},
+		},
+		{
+			expr:        `Int64Field in [1e3]`,
+			contains:    []string{"value 1e3 (Double)"},
+			notContains: []string{"1000"},
+		},
+		{
+			expr:        `Int64Field in ['two']`,
+			contains:    []string{`value 'two' (VarChar)`},
+			notContains: []string{`"two"`},
+		},
+		{
+			expr:        `0x1p+1 < Int64Field < 3`,
+			contains:    []string{"bound value 0x1p+1 (Double)", "Int64Field", "Int64"},
+			notContains: []string{"bound value 2 "},
+		},
+		{
+			expr:        `3 > Int64Field > 0x1p+1`,
+			contains:    []string{"bound value 0x1p+1 (Double)"},
+			notContains: []string{"bound value 2 "},
+		},
+
+		// An unindexed array target expects a list of arrays, so the error must preserve
+		// the element type. `ArrayField in [[1, 2]]` is valid, while `ArrayField in [1]`
+		// is not; reporting only `Array` would not clearly communicate this distinction.
+		{expr: `ArrayField in [1]`, contains: []string{"ArrayField", "Array[Int64]"}},
+		{expr: `StringArrayField in [1]`, contains: []string{"StringArrayField", "Array[VarChar]"}},
 	}
 
 	for _, c := range cases {
@@ -1633,6 +1668,9 @@ func TestExpr_TypeMismatchNamesFieldAndType(t *testing.T) {
 			require.Error(t, err)
 			for _, want := range c.contains {
 				assert.Contains(t, err.Error(), want)
+			}
+			for _, unwanted := range c.notContains {
+				assert.NotContains(t, err.Error(), unwanted)
 			}
 			// The internal protobuf text format must never appear in a user-facing error message.
 			assert.NotContains(t, err.Error(), "string_val:")

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -555,9 +555,15 @@ func getDataType(expr *ExprWithType) string {
 	return expr.dataType.String()
 }
 
-// formatGenericValue formats a literal the way the user wrote it. GenericValue.String()
-// returns an internal protobuf representation (e.g. `string_val:"two"`), which must
-// never be exposed in a user-facing error message.
+// formatGenericValue renders a parsed literal in a user-readable form.
+// GenericValue.String() returns an internal protobuf representation, such as
+// `string_val:"two"`, and must never be exposed in user-facing error messages.
+//
+// This function returns a canonical representation of the parsed value rather than
+// the original source text. By the time a GenericValue is created, literals such as
+// `1.0`, `1e3`, and `0x1p+1` have already lost their original spelling. Use
+// `literalText` when the caller has access to the original source text, and fall
+// back to this function only when it does not.
 func formatGenericValue(value *planpb.GenericValue) string {
 	switch v := value.GetVal().(type) {
 	case *planpb.GenericValue_BoolVal:
@@ -578,6 +584,18 @@ func formatGenericValue(value *planpb.GenericValue) string {
 	default:
 		return value.String()
 	}
+}
+
+// literalText returns the original source text when the caller can access the
+// literal in the parse tree, allowing error messages to show the operand exactly
+// as the user wrote it. text is empty when the operand does not have a
+// corresponding source token, such as a value provided through a template; in
+// that case, the parsed value is rendered instead.
+func literalText(text string, value *planpb.GenericValue) string {
+	if text != "" {
+		return text
+	}
+	return formatGenericValue(value)
 }
 
 // getValueDataType returns the parsed type of a literal so type-mismatch errors
@@ -788,28 +806,29 @@ func checkValidModArith(tokenType planpb.ArithOpType, leftType, leftElementType,
 }
 
 // errRangeBoundMismatch reports a bound whose type does not match the field it
-// is compared against. fieldName is the source text of the column operand.
-func errRangeBoundMismatch(fieldName string, dataType schemapb.DataType, value *planpb.GenericValue) error {
+// is compared against. fieldName and valueText contain the original source text
+// for the column operand and the bound, respectively.
+func errRangeBoundMismatch(fieldName, valueText string, dataType schemapb.DataType, value *planpb.GenericValue) error {
 	return merr.WrapErrQueryPlanMsg("invalid range operations: bound value %s (%s) does not match field %s (%s)",
-		formatGenericValue(value), getValueDataType(value), fieldName, dataType.String())
+		literalText(valueText, value), getValueDataType(value), fieldName, dataType.String())
 }
 
-func castRangeValue(fieldName string, dataType schemapb.DataType, value *planpb.GenericValue) (*planpb.GenericValue, error) {
+func castRangeValue(fieldName, valueText string, dataType schemapb.DataType, value *planpb.GenericValue) (*planpb.GenericValue, error) {
 	switch dataType {
 	case schemapb.DataType_String, schemapb.DataType_VarChar:
 		if !IsString(value) {
-			return nil, errRangeBoundMismatch(fieldName, dataType, value)
+			return nil, errRangeBoundMismatch(fieldName, valueText, dataType, value)
 		}
 	case schemapb.DataType_Bool:
 		return nil, merr.WrapErrQueryPlanMsg("invalid range operations on boolean expr: field %s (%s)",
 			fieldName, dataType.String())
 	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32, schemapb.DataType_Int64:
 		if !IsInteger(value) {
-			return nil, errRangeBoundMismatch(fieldName, dataType, value)
+			return nil, errRangeBoundMismatch(fieldName, valueText, dataType, value)
 		}
 	case schemapb.DataType_Float, schemapb.DataType_Double:
 		if !IsNumber(value) {
-			return nil, errRangeBoundMismatch(fieldName, dataType, value)
+			return nil, errRangeBoundMismatch(fieldName, valueText, dataType, value)
 		}
 		if IsInteger(value) {
 			return NewFloat(float64(value.GetInt64Val())), nil

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -555,11 +555,47 @@ func getDataType(expr *ExprWithType) string {
 	return expr.dataType.String()
 }
 
-func HandleCompare(op int, left, right *ExprWithType) (*planpb.Expr, error) {
+// formatGenericValue formats a literal the way the user wrote it. GenericValue.String()
+// returns an internal protobuf representation (e.g. `string_val:"two"`), which must
+// never be exposed in a user-facing error message.
+func formatGenericValue(value *planpb.GenericValue) string {
+	switch v := value.GetVal().(type) {
+	case *planpb.GenericValue_BoolVal:
+		return strconv.FormatBool(v.BoolVal)
+	case *planpb.GenericValue_Int64Val:
+		return strconv.FormatInt(v.Int64Val, 10)
+	case *planpb.GenericValue_FloatVal:
+		return strconv.FormatFloat(v.FloatVal, 'g', -1, 64)
+	case *planpb.GenericValue_StringVal:
+		return strconv.Quote(v.StringVal)
+	case *planpb.GenericValue_ArrayVal:
+		elements := v.ArrayVal.GetArray()
+		formatted := make([]string, 0, len(elements))
+		for _, element := range elements {
+			formatted = append(formatted, formatGenericValue(element))
+		}
+		return "[" + strings.Join(formatted, ", ") + "]"
+	default:
+		return value.String()
+	}
+}
+
+// getValueDataType returns the parsed type of a literal so type-mismatch errors
+// can include the types of both operands.
+func getValueDataType(value *planpb.GenericValue) string {
+	if valueExpr := toValueExpr(value); valueExpr != nil {
+		return valueExpr.dataType.String()
+	}
+	return schemapb.DataType_None.String()
+}
+
+// leftText and rightText contain the source text of the operands. They are used
+// only to identify the offending field when the two sides cannot be compared.
+func HandleCompare(op int, left, right *ExprWithType, leftText, rightText string) (*planpb.Expr, error) {
 	if !left.expr.GetIsTemplate() && !right.expr.GetIsTemplate() {
 		if !canBeCompared(left, right) {
-			return nil, merr.WrapErrQueryPlanMsg("comparisons between %s and %s are not supported",
-				getDataType(left), getDataType(right))
+			return nil, merr.WrapErrQueryPlanMsg("comparisons between %s (%s) and %s (%s) are not supported",
+				leftText, getDataType(left), rightText, getDataType(right))
 		}
 	}
 
@@ -751,21 +787,29 @@ func checkValidModArith(tokenType planpb.ArithOpType, leftType, leftElementType,
 	return nil
 }
 
-func castRangeValue(dataType schemapb.DataType, value *planpb.GenericValue) (*planpb.GenericValue, error) {
+// errRangeBoundMismatch reports a bound whose type does not match the field it
+// is compared against. fieldName is the source text of the column operand.
+func errRangeBoundMismatch(fieldName string, dataType schemapb.DataType, value *planpb.GenericValue) error {
+	return merr.WrapErrQueryPlanMsg("invalid range operations: bound value %s (%s) does not match field %s (%s)",
+		formatGenericValue(value), getValueDataType(value), fieldName, dataType.String())
+}
+
+func castRangeValue(fieldName string, dataType schemapb.DataType, value *planpb.GenericValue) (*planpb.GenericValue, error) {
 	switch dataType {
 	case schemapb.DataType_String, schemapb.DataType_VarChar:
 		if !IsString(value) {
-			return nil, merr.WrapErrQueryPlanMsg("invalid range operations")
+			return nil, errRangeBoundMismatch(fieldName, dataType, value)
 		}
 	case schemapb.DataType_Bool:
-		return nil, merr.WrapErrQueryPlanMsg("invalid range operations on boolean expr")
+		return nil, merr.WrapErrQueryPlanMsg("invalid range operations on boolean expr: field %s (%s)",
+			fieldName, dataType.String())
 	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32, schemapb.DataType_Int64:
 		if !IsInteger(value) {
-			return nil, merr.WrapErrQueryPlanMsg("invalid range operations")
+			return nil, errRangeBoundMismatch(fieldName, dataType, value)
 		}
 	case schemapb.DataType_Float, schemapb.DataType_Double:
 		if !IsNumber(value) {
-			return nil, merr.WrapErrQueryPlanMsg("invalid range operations")
+			return nil, errRangeBoundMismatch(fieldName, dataType, value)
 		}
 		if IsInteger(value) {
 			return NewFloat(float64(value.GetInt64Val())), nil

--- a/internal/parser/planparserv2/utils_test.go
+++ b/internal/parser/planparserv2/utils_test.go
@@ -1270,14 +1270,14 @@ func Test_checkValidBitwiseArith(t *testing.T) {
 func Test_castRangeValue(t *testing.T) {
 	t.Run("string value for string type", func(t *testing.T) {
 		value := NewString("test")
-		result, err := castRangeValue("name", schemapb.DataType_VarChar, value)
+		result, err := castRangeValue("name", "\"test\"", schemapb.DataType_VarChar, value)
 		assert.NoError(t, err)
 		assert.Equal(t, "test", result.GetStringVal())
 	})
 
 	t.Run("non-string value for string type fails", func(t *testing.T) {
 		value := NewInt(42)
-		_, err := castRangeValue("name", schemapb.DataType_VarChar, value)
+		_, err := castRangeValue("name", "42", schemapb.DataType_VarChar, value)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid range operations")
 		// The error must include the bound, its type, the field, and the field type.
@@ -1289,7 +1289,7 @@ func Test_castRangeValue(t *testing.T) {
 
 	t.Run("bool type is invalid for range", func(t *testing.T) {
 		value := NewBool(true)
-		_, err := castRangeValue("flag", schemapb.DataType_Bool, value)
+		_, err := castRangeValue("flag", "true", schemapb.DataType_Bool, value)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid range operations on boolean expr")
 		assert.Contains(t, err.Error(), "flag")
@@ -1298,14 +1298,14 @@ func Test_castRangeValue(t *testing.T) {
 
 	t.Run("integer value for integer type", func(t *testing.T) {
 		value := NewInt(42)
-		result, err := castRangeValue("age", schemapb.DataType_Int64, value)
+		result, err := castRangeValue("age", "42", schemapb.DataType_Int64, value)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(42), result.GetInt64Val())
 	})
 
 	t.Run("non-integer value for integer type fails", func(t *testing.T) {
 		value := NewFloat(3.14)
-		_, err := castRangeValue("age", schemapb.DataType_Int64, value)
+		_, err := castRangeValue("age", "3.14", schemapb.DataType_Int64, value)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "3.14")
 		assert.Contains(t, err.Error(), "Double")
@@ -1315,7 +1315,7 @@ func Test_castRangeValue(t *testing.T) {
 
 	t.Run("float value for float type", func(t *testing.T) {
 		value := NewFloat(3.14)
-		result, err := castRangeValue("price", schemapb.DataType_Float, value)
+		result, err := castRangeValue("price", "3.14", schemapb.DataType_Float, value)
 		assert.NoError(t, err)
 		assert.Equal(t, 3.14, result.GetFloatVal())
 	})
@@ -1323,14 +1323,14 @@ func Test_castRangeValue(t *testing.T) {
 	t.Run("integer value promoted to float for float type", func(t *testing.T) {
 		// Integer values should be promoted to float when target type is float
 		value := NewInt(42)
-		result, err := castRangeValue("price", schemapb.DataType_Double, value)
+		result, err := castRangeValue("price", "42", schemapb.DataType_Double, value)
 		assert.NoError(t, err)
 		assert.Equal(t, float64(42), result.GetFloatVal())
 	})
 
 	t.Run("non-number value for float type fails", func(t *testing.T) {
 		value := NewString("test")
-		_, err := castRangeValue("price", schemapb.DataType_Float, value)
+		_, err := castRangeValue("price", "\"test\"", schemapb.DataType_Float, value)
 		assert.Error(t, err)
 		// The rejected literal must preserve its original formatting and must not expose
 		// protobuf text representation.
@@ -1339,10 +1339,34 @@ func Test_castRangeValue(t *testing.T) {
 		assert.Contains(t, err.Error(), "price")
 		assert.Contains(t, err.Error(), "Float")
 	})
+
+	t.Run("bound is reported as written, not as parsed", func(t *testing.T) {
+		// Once parsed, `1e3`, `1.0`, and `0x1p+1` are indistinguishable from integer
+		// literals, so the source text is needed to determine which literal was rejected.
+		for _, text := range []string{"1e3", "1.0", "0x1p+1"} {
+			_, err := castRangeValue("age", text, schemapb.DataType_Int64, NewFloat(1000))
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), text)
+		}
+	})
+
+	t.Run("parsed value is rendered without source text", func(t *testing.T) {
+		_, err := castRangeValue("age", "", schemapb.DataType_Int64, NewFloat(3.14))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "3.14")
+		assert.NotContains(t, err.Error(), "float_val")
+	})
 }
 
-// Test_formatGenericValue verifies that literals are formatted exactly as the user
-// wrote them, not using the protobuf text format returned by GenericValue.String().
+func Test_literalText(t *testing.T) {
+	assert.Equal(t, "1e3", literalText("1e3", NewFloat(1000)))
+	assert.Equal(t, `'two'`, literalText(`'two'`, NewString("two")))
+	assert.Equal(t, "1000", literalText("", NewFloat(1000)))
+	assert.Equal(t, `"two"`, literalText("", NewString("two")))
+}
+
+// Test_formatGenericValue verifies that parsed literals are rendered in a readable
+// form, not in the protobuf text format returned by GenericValue.String().
 func Test_formatGenericValue(t *testing.T) {
 	assert.Equal(t, "true", formatGenericValue(NewBool(true)))
 	assert.Equal(t, "42", formatGenericValue(NewInt(42)))

--- a/internal/parser/planparserv2/utils_test.go
+++ b/internal/parser/planparserv2/utils_test.go
@@ -1270,41 +1270,52 @@ func Test_checkValidBitwiseArith(t *testing.T) {
 func Test_castRangeValue(t *testing.T) {
 	t.Run("string value for string type", func(t *testing.T) {
 		value := NewString("test")
-		result, err := castRangeValue(schemapb.DataType_VarChar, value)
+		result, err := castRangeValue("name", schemapb.DataType_VarChar, value)
 		assert.NoError(t, err)
 		assert.Equal(t, "test", result.GetStringVal())
 	})
 
 	t.Run("non-string value for string type fails", func(t *testing.T) {
 		value := NewInt(42)
-		_, err := castRangeValue(schemapb.DataType_VarChar, value)
+		_, err := castRangeValue("name", schemapb.DataType_VarChar, value)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid range operations")
+		// The error must include the bound, its type, the field, and the field type.
+		assert.Contains(t, err.Error(), "42")
+		assert.Contains(t, err.Error(), "Int64")
+		assert.Contains(t, err.Error(), "name")
+		assert.Contains(t, err.Error(), "VarChar")
 	})
 
 	t.Run("bool type is invalid for range", func(t *testing.T) {
 		value := NewBool(true)
-		_, err := castRangeValue(schemapb.DataType_Bool, value)
+		_, err := castRangeValue("flag", schemapb.DataType_Bool, value)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid range operations on boolean expr")
+		assert.Contains(t, err.Error(), "flag")
+		assert.Contains(t, err.Error(), "Bool")
 	})
 
 	t.Run("integer value for integer type", func(t *testing.T) {
 		value := NewInt(42)
-		result, err := castRangeValue(schemapb.DataType_Int64, value)
+		result, err := castRangeValue("age", schemapb.DataType_Int64, value)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(42), result.GetInt64Val())
 	})
 
 	t.Run("non-integer value for integer type fails", func(t *testing.T) {
 		value := NewFloat(3.14)
-		_, err := castRangeValue(schemapb.DataType_Int64, value)
+		_, err := castRangeValue("age", schemapb.DataType_Int64, value)
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "3.14")
+		assert.Contains(t, err.Error(), "Double")
+		assert.Contains(t, err.Error(), "age")
+		assert.Contains(t, err.Error(), "Int64")
 	})
 
 	t.Run("float value for float type", func(t *testing.T) {
 		value := NewFloat(3.14)
-		result, err := castRangeValue(schemapb.DataType_Float, value)
+		result, err := castRangeValue("price", schemapb.DataType_Float, value)
 		assert.NoError(t, err)
 		assert.Equal(t, 3.14, result.GetFloatVal())
 	})
@@ -1312,16 +1323,44 @@ func Test_castRangeValue(t *testing.T) {
 	t.Run("integer value promoted to float for float type", func(t *testing.T) {
 		// Integer values should be promoted to float when target type is float
 		value := NewInt(42)
-		result, err := castRangeValue(schemapb.DataType_Double, value)
+		result, err := castRangeValue("price", schemapb.DataType_Double, value)
 		assert.NoError(t, err)
 		assert.Equal(t, float64(42), result.GetFloatVal())
 	})
 
 	t.Run("non-number value for float type fails", func(t *testing.T) {
 		value := NewString("test")
-		_, err := castRangeValue(schemapb.DataType_Float, value)
+		_, err := castRangeValue("price", schemapb.DataType_Float, value)
 		assert.Error(t, err)
+		// The rejected literal must preserve its original formatting and must not expose
+		// protobuf text representation.
+		assert.Contains(t, err.Error(), `"test"`)
+		assert.NotContains(t, err.Error(), "string_val")
+		assert.Contains(t, err.Error(), "price")
+		assert.Contains(t, err.Error(), "Float")
 	})
+}
+
+// Test_formatGenericValue verifies that literals are formatted exactly as the user
+// wrote them, not using the protobuf text format returned by GenericValue.String().
+func Test_formatGenericValue(t *testing.T) {
+	assert.Equal(t, "true", formatGenericValue(NewBool(true)))
+	assert.Equal(t, "42", formatGenericValue(NewInt(42)))
+	assert.Equal(t, "3.14", formatGenericValue(NewFloat(3.14)))
+	assert.Equal(t, `"two"`, formatGenericValue(NewString("two")))
+	assert.Equal(t, `[1, "two"]`, formatGenericValue(&planpb.GenericValue{
+		Val: &planpb.GenericValue_ArrayVal{
+			ArrayVal: &planpb.Array{Array: []*planpb.GenericValue{NewInt(1), NewString("two")}},
+		},
+	}))
+}
+
+func Test_getValueDataType(t *testing.T) {
+	assert.Equal(t, "Bool", getValueDataType(NewBool(true)))
+	assert.Equal(t, "Int64", getValueDataType(NewInt(42)))
+	assert.Equal(t, "Double", getValueDataType(NewFloat(3.14)))
+	assert.Equal(t, "VarChar", getValueDataType(NewString("two")))
+	assert.Equal(t, "None", getValueDataType(&planpb.GenericValue{}))
 }
 
 // Test_hexDigit tests the hexDigit helper function

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -546,7 +546,7 @@ class TestMilvusClientQueryInvalidShared(TestMilvusClientV2Base):
         term_expr = f"{default_primary_key_field_name} in {values}"
         error = {
             ct.err_code: 1100,
-            ct.err_msg: "value 1 (Double) in list cannot be casted to field id (Int64)",
+            ct.err_msg: "value 1.0 (Double) in list cannot be casted to field id (Int64)",
         }
         self.query(
             client, INVALID_SHARED_COLLECTION, filter=term_expr, check_task=CheckTasks.err_res, check_items=error
@@ -556,7 +556,7 @@ class TestMilvusClientQueryInvalidShared(TestMilvusClientV2Base):
         term_expr = f"{default_primary_key_field_name} in {values}"
         error = {
             ct.err_code: 1100,
-            ct.err_msg: "value 2 (Double) in list cannot be casted to field id (Int64)",
+            ct.err_msg: "value 2.0 (Double) in list cannot be casted to field id (Int64)",
         }
         self.query(
             client, INVALID_SHARED_COLLECTION, filter=term_expr, check_task=CheckTasks.err_res, check_items=error

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -546,7 +546,7 @@ class TestMilvusClientQueryInvalidShared(TestMilvusClientV2Base):
         term_expr = f"{default_primary_key_field_name} in {values}"
         error = {
             ct.err_code: 1100,
-            ct.err_msg: "value 'float_val:1' in list cannot be casted to Int64",
+            ct.err_msg: "value 1 (Double) in list cannot be casted to field id (Int64)",
         }
         self.query(
             client, INVALID_SHARED_COLLECTION, filter=term_expr, check_task=CheckTasks.err_res, check_items=error
@@ -556,7 +556,7 @@ class TestMilvusClientQueryInvalidShared(TestMilvusClientV2Base):
         term_expr = f"{default_primary_key_field_name} in {values}"
         error = {
             ct.err_code: 1100,
-            ct.err_msg: "value 'float_val:2' in list cannot be casted to Int64",
+            ct.err_msg: "value 2 (Double) in list cannot be casted to field id (Int64)",
         }
         self.query(
             client, INVALID_SHARED_COLLECTION, filter=term_expr, check_task=CheckTasks.err_res, check_items=error
@@ -1614,7 +1614,7 @@ class TestMilvusClientQueryValid(TestMilvusClientV2Base):
         not_support_expr = f"{ct.default_bool_field_name} in [0]"
         error = {
             ct.err_code: 65535,
-            ct.err_msg: "value 'int64_val:0' in list cannot be casted to Bool",
+            ct.err_msg: "value 0 (Int64) in list cannot be casted to field bool (Bool)",
         }
         self.query(
             client,
@@ -5143,7 +5143,7 @@ class TestQueryStringPrimaryShared(TestMilvusClientV2Base):
         expression = "varchar == int64"
         error = {
             ct.err_code: 1100,
-            ct.err_msg: "comparisons between VarChar and Int64 are not supported",
+            ct.err_msg: "comparisons between varchar (VarChar) and int64 (Int64) are not supported",
         }
         self.query(
             client,

--- a/tests/python_client/milvus_client/test_milvus_client_search_by_pk.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_by_pk.py
@@ -2179,7 +2179,7 @@ class TestSearchByPkIndependent(TestMilvusClientV2Base):
             filter=search_exp,
             output_fields=output_fields,
             check_task=CheckTasks.err_res,
-            check_items={"err_code": 1100, "err_msg": "comparisons between VarChar and Int64 are not supported"},
+            check_items={"err_code": 1100, "err_msg": "comparisons between expr_field (VarChar) and 0 (Int64) are not supported"},
         )
 
     @pytest.mark.tags(CaseLabel.L2)

--- a/tests/python_client/milvus_client/test_milvus_client_search_none_default.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_none_default.py
@@ -663,5 +663,5 @@ class TestSearchNoneDefaultIndependent(TestMilvusClientV2Base):
                     check_task=CheckTasks.err_res,
                     check_items={"err_code": 1100,
                                  "err_msg": "failed to create query plan: cannot parse expression: float == 0, "
-                                            "error: comparisons between VarChar and Int64 are not supported: "
+                                            "error: comparisons between float (VarChar) and 0 (Int64) are not supported: "
                                             "invalid parameter"})

--- a/tests/python_client/milvus_client/test_milvus_client_search_v2.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_v2.py
@@ -1875,7 +1875,7 @@ class TestSearchV2Independent(TestMilvusClientV2Base):
                     output_fields=output_fields,
                     check_task=CheckTasks.err_res,
                     check_items={"err_code": 1100,
-                                 "err_msg": "comparisons between VarChar and Int64 are not supported"})
+                                 "err_msg": "comparisons between expr_field (VarChar) and 0 (Int64) are not supported"})
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_using_all_types_of_default_value(self):

--- a/tests/python_client/testcases/test_delete.py
+++ b/tests/python_client/testcases/test_delete.py
@@ -1839,7 +1839,7 @@ class TestDeleteString(TestcaseBase):
         collection_w.load()
         error = {ct.err_code: 1100,
                  ct.err_msg: f"failed to create delete plan: cannot parse expression: {default_invalid_string_exp}: "
-                             f"comparisons between VarChar and Int64 are not supported: query plan failed: invalid parameter"}
+                             f"comparisons between varchar (VarChar) and 0 (Int64) are not supported: query plan failed: invalid parameter"}
         collection_w.delete(expr=default_invalid_string_exp,
                             check_task=CheckTasks.err_res, check_items=error)
 


### PR DESCRIPTION
issue: #51900

## Summary

Type-mismatch errors for range, `in`, and comparison expressions in `planparserv2` did not indicate which field was rejected. Range errors had the least context: they omitted the field name, field type, and offending bound value, and all three mismatch cases returned the same generic message, `invalid range operations`. The `in` error also printed literals in protobuf text format (`string_val:"two"`).

* `castRangeValue()` now takes the source text of the column operand and reports both sides of the mismatch. The boolean case also includes the field name.
* `HandleCompare()` now takes the source text of both operands, so comparison errors can identify the operands instead of only their types. Both call sites, `VisitEquality` and `VisitRelational`, pass `ctx.Expr(0).GetText()` and `ctx.Expr(1).GetText()`.
* `VisitTerm()` now reports the field a list value failed to cast to.
* New helpers:

  * `formatGenericValue()` formats a literal in the same way the user wrote it.
  * `getValueDataType()` returns the parsed type of a literal.
  * `columnIdentifierText()` extracts the field name from the parse tree, since `ColumnInfo` only carries a field ID.

Field names are derived from the operand's parse-tree text, consistent with the approach used for arithmetic operators in PR #51022.

```diff
1.5 < Int64Field < 3.5
- invalid range operations
+ invalid range operations: bound value 1.5 (Double) does not match field Int64Field (Int64)
```

```diff
0 < BoolField < 1
- invalid range operations on boolean expr
+ invalid range operations on boolean expr: field BoolField (Bool)
```

```diff
1 < ArrayField[0] < "z"
- invalid range operations
+ invalid range operations: bound value "z" (VarChar) does not match field ArrayField[0] (Int64)
```

```diff
Int64Field in [1, "two", 3]
- value 'string_val:"two"' in list cannot be casted to Int64
+ value "two" (VarChar) in list cannot be casted to field Int64Field (Int64)
```

```diff
VarCharField > Int64Field
- comparisons between VarChar and Int64 are not supported
+ comparisons between VarCharField (VarChar) and Int64Field (Int64) are not supported
```

Error factories and error codes are unchanged. These remain input errors created via `merr.WrapErrQueryPlanMsg` or `merr.WrapErrParameterInvalidMsg`.

`castRangeValue()` keeps the `invalid range operations` prefix so existing assertions and any tooling that depends on that string continue to work.

## Not covered

Template-filled bounds such as `1 < f < {v}` are validated in `FillBinaryRangeExpressionValue()` through `castValue()`, which still reports:

```text
cannot cast value to Int64, value: string_val:"a"
```

`castValue()` and `checkContainsElement()` (used by the `json_contains*` path) have the same limitation and are tracked as follow-ups in #51900. This PR does not modify them.

There is no conflict with PR #51022. That PR updates `canArithmetic()`, `checkValidModArith()`, and their call sites, none of which are touched here.

## Verification

* Added `TestExpr_TypeMismatchNamesFieldAndType` in `plan_parser_v2_test.go`.

  * Covers 11 expressions across both range directions, array element access, `in`, field-vs-literal comparisons, and field-vs-field comparisons.
  * Verifies that errors include field name, field type, offending value, and value type.
  * Ensures protobuf-style representations like `string_val:` and `int64_val:` never appear in error output.
* Updated `Test_castRangeValue` for the new signature and added message-level assertions.
* Added `Test_formatGenericValue` and `Test_getValueDataType` in `utils_test.go`.

```text
LOCAL_STORAGE_SIZE=10 go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/parser/planparserv2/...
ok  github.com/milvus-io/milvus/internal/parser/planparserv2            5.232s
ok  github.com/milvus-io/milvus/internal/parser/planparserv2/rewriter   5.106s
```

The before/after messages above are the actual parser outputs captured by running each expression through `ParseExpr` on this branch.
