### PR TITLE
fix: correct JSON shift not-equal evaluation

### DIFF
--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -397,12 +397,12 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
                         break;
                     }
                     case proto::plan::ArithOpType::Shl: {
-                        BinaryArithRangeJSONCompareNotEqual(
+                        BinaryArithRangeJSONCompare(
                             (int64_t(json_v) << int64_t(right_operand)) != val);
                         break;
                     }
                     case proto::plan::ArithOpType::Shr: {
-                        BinaryArithRangeJSONCompareNotEqual(
+                        BinaryArithRangeJSONCompare(
                             (int64_t(json_v) >> int64_t(right_operand)) != val);
                         break;
                     }

--- a/internal/core/src/exec/expression/ExprArithOpTest.cpp
+++ b/internal/core/src/exec/expression/ExprArithOpTest.cpp
@@ -1084,6 +1084,18 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeJSON) {
                  auto val = json.template at<int64_t>(pointer).value();
                  return (int64_t(val) >> 2) >= 0;
              }},
+            {R"((json["int"] << 1) != 0)",
+             [](const milvus::Json& json) {
+                 auto pointer = milvus::Json::pointer({"int"});
+                 auto val = json.template at<int64_t>(pointer).value();
+                 return (int64_t(val) << 1) != 0;
+             }},
+            {R"((json["int"] >> 1) != 0)",
+             [](const milvus::Json& json) {
+                 auto pointer = milvus::Json::pointer({"int"});
+                 auto val = json.template at<int64_t>(pointer).value();
+                 return (int64_t(val) >> 1) != 0;
+             }},
             {R"(~json["int"] < 0)",
              [](const milvus::Json& json) {
                  auto pointer = milvus::Json::pointer({"int"});


### PR DESCRIPTION
issue: #50964

## What changed

- Replace the nonexistent BinaryArithRangeJSONCompareNotEqual invocation with the existing BinaryArithRangeJSONCompare macro for JSON shift-left and shift-right not-equal predicates.
- Add regression coverage for JSON shift-left and shift-right expressions using !=.

## Root cause

PR #51051 added the JSON shift branches, but the NotEqual cases referenced a macro that is not defined. This makes the C++ build fail before unit, integration, and E2E tests can run.

## Impact

Restores master compilation and exercises both affected JSON shift branches.

## Validation

- git diff --check
- clang-format validation on the changed lines
