### PR TITLE
fix: use the defined JSON compare macro for shift ops in the NotEqual branch

### DIFF
--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -397,12 +397,12 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
                         break;
                     }
                     case proto::plan::ArithOpType::Shl: {
-                        BinaryArithRangeJSONCompareNotEqual(
+                        BinaryArithRangeJSONCompare(
                             (int64_t(json_v) << int64_t(right_operand)) != val);
                         break;
                     }
                     case proto::plan::ArithOpType::Shr: {
-                        BinaryArithRangeJSONCompareNotEqual(
+                        BinaryArithRangeJSONCompare(
                             (int64_t(json_v) >> int64_t(right_operand)) != val);
                         break;
                     }

--- a/internal/core/src/exec/expression/ExprArithOpTest.cpp
+++ b/internal/core/src/exec/expression/ExprArithOpTest.cpp
@@ -1090,6 +1090,21 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeJSON) {
                  auto val = json.template at<int64_t>(pointer).value();
                  return (~int64_t(val)) < 0;
              }},
+            // The NotEqual branch dispatches shifts through its own case, so
+            // cover it explicitly: ~ is rewritten to (x ^ -1) and lands on the
+            // BitXor case instead.
+            {R"((json["int"] << 1) != 2)",
+             [](const milvus::Json& json) {
+                 auto pointer = milvus::Json::pointer({"int"});
+                 auto val = json.template at<int64_t>(pointer).value();
+                 return (int64_t(val) << 1) != 2;
+             }},
+            {R"((json["int"] >> 1) != 0)",
+             [](const milvus::Json& json) {
+                 auto pointer = milvus::Json::pointer({"int"});
+                 auto val = json.template at<int64_t>(pointer).value();
+                 return (int64_t(val) >> 1) != 0;
+             }},
             // Test cases for BinaryArithOpEvalRangeExpr GT of various data types
             {R"(json["int"] + 1 > 2)",
              [](const milvus::Json& json) {


### PR DESCRIPTION
issue: #51905

`master` currently does not compile. The Shl/Shr cases that #51051 added to the JSON
**NotEqual** branch call `BinaryArithRangeJSONCompareNotEqual`, which is not defined
anywhere — `BinaryArithOpEvalRangeExpr.cpp` only defines `BinaryArithRangeJSONCompare`
(L201), `BinaryArithRangeJONCompareArrayLength` (L243), `BinaryArithRangeArrayCompare`
(L763) and `BinaryArithRangeArrayLengthCompate` (L785), and nothing produces the name by
token pasting. `json_v` is declared inside the expansion of the real macro, hence:

```
BinaryArithOpEvalRangeExpr.cpp:401:38: error: 'json_v' was not declared in this scope
BinaryArithOpEvalRangeExpr.cpp:400:60: error: 'BinaryArithRangeJSONCompareNotEqual' was not
                                             declared in this scope
```

Every other case in the same switch — Div, Mod, ArrayLength, BitAnd, BitOr, BitXor —
already passes its `!= val` comparison to `BinaryArithRangeJSONCompare`, so the two shift
cases just use the same macro. No semantics change.

Also adds the two test cases the branch was missing. The JSON shift cases added by #51051
cover `<`, `>=` and `~json["int"] < 0`; `~` is rewritten to `(x ^ -1)` and dispatches
through the BitXor case, so nothing exercised the JSON NotEqual branch with an explicit
shift — which is why the broken lines got through.

### Verification

- Before: `make build-cpp` fails in segcore. After: builds clean.
- `*TestBinaryArithOpEvalRange*` — 540/540 passed.
- To confirm the new cases actually reach the changed lines, one reference lambda was
  temporarily inverted; the suite then failed with
  `(json["int"] << 1) != 2@0!!{"int":1622650073,...}` and passed again once restored.
