### PR TITLE
fix: emit an empty cause label instead of "na" for unclassified requests

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -46,7 +46,11 @@ const (
 	CauseUser   = "user"   // the request itself is at fault: bad arguments, missing auth, no such collection
 	CauseSystem = "system" // Milvus is at fault: component failure, IO error, internal bug
 	CauseCancel = "cancel" // neither party: the client gave up before the request completed
-	CauseNA     = "na"     // no cause applies: the request did not hard-fail
+	// CauseNA is the empty string on purpose: Prometheus treats an empty label
+	// value as equivalent to the label being absent, so success/total/retry/
+	// abandon series carry no meaningful cause and stay byte-identical to what
+	// pre-2.6.19 emitted -- only fail/rejected actually carry user/system/cancel.
+	CauseNA = "" // no cause applies: the request did not hard-fail
 
 	HybridSearchLabel = "hybrid_search"
 


### PR DESCRIPTION
issue: #51493

### What

#51495 introduced the `cause` dimension with `CauseNA = "na"`, so every
`success` / `total` / `retry` / `abandon` series now carries a `cause="na"`
label pair. Prometheus treats an empty label value as equivalent to the label
being absent, so emitting `""` instead keeps those series byte-identical to
what pre-2.6.19 emitted; only `fail` / `rejected` series then carry a real
cause (`user` / `system` / `cancel`).

```
status: success | fail | rejected | retry | total | abandon   (as before v2.6.19)
cause:  user | system | cancel                                (only on fail/rejected)
```

The classification itself is unchanged — this only affects the value written
for series that have no cause.

### Why this is safe

- No call site depends on the literal: all 54 references go through the
  `metrics.CauseNA` symbol.
- Nothing queries `cause="na"` — checked `deployments/`, `configs/` and `docs/`.
- A selector such as `milvus_proxy_req_count{status="success"}` matches either
  way; the difference is that with `""` the series identity is exactly the
  pre-2.6.19 one, so recording rules and joins that key on the full label set
  keep working across the upgrade.

### Verification

- Compiles: `pkg/...` and `./internal/...`.
- Green: `pkg/metrics`, `pkg/util/requestutil`, `pkg/util/merr`,
  `internal/proxy`, `internal/distributed/proxy`,
  `internal/distributed/proxy/httpserver`, `internal/distributed/proxy/client`.
- `make verifiers`: 0 issues.

3.0 carries the same value via #51526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
