### PR TITLE
fix: surface disk write failures and stop dropping queued writes on pool reconfig

### DIFF
--- a/internal/core/src/storage/FileWriter.cpp
+++ b/internal/core/src/storage/FileWriter.cpp
@@ -267,6 +267,10 @@ FileWriter::WriteInternal(const void* data, size_t nbyte) {
 
 void
 FileWriter::Write(const void* data, size_t nbyte) {
+    // a failed write closes the file and frees the aligned buffer, so refuse to
+    // keep going instead of memcpy'ing into the freed buffer below
+    AssertInfo(fd_ != -1, "File is not open: {}", filename_);
+
     // if the data can fit in the aligned buffer, we can just copy it to the aligned buffer
     if (nbyte <= capacity_ - offset_) {
         const char* src = static_cast<const char*>(data);
@@ -283,7 +287,10 @@ FileWriter::Write(const void* data, size_t nbyte) {
 
     auto promise = std::make_shared<folly::Promise<folly::Unit>>();
     auto future = promise->getFuture();
-    auto task = [this, data, nbyte, promise]() {
+    // the queued task has to be the only owner of the promise: if it is
+    // discarded before it runs, destroying it is what publishes BrokenPromise
+    // and wakes the wait below, so no owner may be left on this side
+    auto task = [this, data, nbyte, promise = std::move(promise)]() {
         try {
             WriteInternal(data, nbyte);
             promise->setValue(folly::Unit{});
@@ -295,15 +302,24 @@ FileWriter::Write(const void* data, size_t nbyte) {
 
     // try to add the task to the writer pool
     // fallback to write the data directly if the task cannot be added to the pool
-    if (FileWriteWorkerPool::GetInstance().AddTask(task)) {
-        try {
-            future.wait();
-        } catch (const std::exception& e) {
-            Cleanup();
-            ThrowInfo(ErrorCode::FileWriteFailed,
-                      "Failed to write to file: {}, error: {}",
-                      filename_,
-                      e.what());
+    if (FileWriteWorkerPool::GetInstance().AddTask(std::move(task))) {
+        // folly's Future::wait() only blocks until the future is ready, it does
+        // not rethrow the stored exception, so the result has to be taken out
+        // explicitly. Otherwise a failed write is reported as a success.
+        auto result = std::move(future).getTry();
+        if (result.hasException()) {
+            if (result.exception().is_compatible_with<folly::BrokenPromise>()) {
+                // the task was destroyed before it ran, so nothing was written
+                // and the writer is untouched: do the write on this thread
+                WriteInternal(data, nbyte);
+            } else {
+                auto reason = result.exception().what().toStdString();
+                Cleanup();
+                ThrowInfo(ErrorCode::FileWriteFailed,
+                          "Failed to write to file: {}, error: {}",
+                          filename_,
+                          reason);
+            }
         }
     } else {
         WriteInternal(data, nbyte);
@@ -342,11 +358,16 @@ FileWriter::FlushWithBufferedIO() {
 
 size_t
 FileWriter::Finish() {
+    // an earlier failure closed the file and freed the aligned buffer while
+    // leaving offset_ alone, so finalizing here would either memset the freed
+    // buffer or report a stale file_size_ as a successful finalization
+    AssertInfo(fd_ != -1, "File is not open: {}", filename_);
+
     // if the aligned buffer is not empty, we should flush it to the file
     if (offset_ != 0) {
         auto promise = std::make_shared<folly::Promise<folly::Unit>>();
         auto future = promise->getFuture();
-        auto task = [this, promise]() {
+        auto task = [this, promise = std::move(promise)]() {
             try {
                 if (use_direct_io_) {
                     FlushWithDirectIO();
@@ -360,15 +381,26 @@ FileWriter::Finish() {
             }
         };
 
-        if (FileWriteWorkerPool::GetInstance().AddTask(task)) {
-            try {
-                future.wait();
-            } catch (const std::exception& e) {
-                Cleanup();
-                ThrowInfo(ErrorCode::FileWriteFailed,
-                          "Failed to flush file: {}, error: {}",
-                          filename_,
-                          e.what());
+        if (FileWriteWorkerPool::GetInstance().AddTask(std::move(task))) {
+            // see the notes in Write(): wait() never rethrows, and a broken
+            // promise means the task never ran
+            auto result = std::move(future).getTry();
+            if (result.hasException()) {
+                if (result.exception()
+                        .is_compatible_with<folly::BrokenPromise>()) {
+                    if (use_direct_io_) {
+                        FlushWithDirectIO();
+                    } else {
+                        FlushWithBufferedIO();
+                    }
+                } else {
+                    auto reason = result.exception().what().toStdString();
+                    Cleanup();
+                    ThrowInfo(ErrorCode::FileWriteFailed,
+                              "Failed to flush file: {}, error: {}",
+                              filename_,
+                              reason);
+                }
             }
         } else {
             if (use_direct_io_) {

--- a/internal/core/src/storage/FileWriter.h
+++ b/internal/core/src/storage/FileWriter.h
@@ -366,22 +366,40 @@ class FileWriteWorkerPool {
                 std::thread::hardware_concurrency());
             nr_worker = std::thread::hardware_concurrency();
         }
-        std::shared_ptr<folly::CPUThreadPoolExecutor> old_executor = nullptr;
+        std::shared_ptr<folly::CPUThreadPoolExecutor> retired_executor = nullptr;
         {
+            // held across the resize so no task is submitted to a pool that is
+            // being taken down, and so two reconfigurations cannot interleave
             std::lock_guard<std::mutex> lock(executor_mutex_);
-            old_executor = executor_;
-            if (nr_worker > 0) {
+            auto current = executor_ == nullptr
+                               ? 0
+                               : static_cast<int>(executor_->numThreads());
+            if (nr_worker == current) {
+                // every common.diskWrite* key funnels into this call, so most
+                // reconfigurations do not touch the worker count at all
+                return;
+            }
+            if (nr_worker == 0) {
+                retired_executor = std::move(executor_);
+                executor_ = nullptr;
+            } else if (executor_ == nullptr) {
                 executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
                     nr_worker,
                     std::make_shared<folly::NamedThreadFactory>(
                         "MILVUS_FL_WR_"));
             } else {
-                executor_ = nullptr;
+                // resize in place: replacing the executor would either discard
+                // the tasks still queued on it or, while the old one drains,
+                // run up to 2 * nr_worker writes at once and break the very
+                // concurrency cap this setting exists to enforce
+                executor_->setNumThreads(nr_worker);
             }
         }
-        if (old_executor != nullptr) {
-            old_executor->stop();
-            old_executor->join();
+        if (retired_executor != nullptr) {
+            // join(), not stop(): stop() makes every worker return as soon as
+            // its current task ends and leaves the queued tasks unexecuted,
+            // which breaks the promises they carry.
+            retired_executor->join();
         }
         LOG_INFO("Set the number of write worker to {}", nr_worker);
     }
@@ -398,8 +416,7 @@ class FileWriteWorkerPool {
 
     bool
     HasPool() const {
-        // no lock here, so it's not thread-safe
-        // but it's ok because we still can write without the pool
+        std::lock_guard<std::mutex> lock(executor_mutex_);
         return executor_ != nullptr;
     }
 
@@ -414,7 +431,7 @@ class FileWriteWorkerPool {
 
  private:
     std::shared_ptr<folly::CPUThreadPoolExecutor> executor_{nullptr};
-    std::mutex executor_mutex_{};
+    mutable std::mutex executor_mutex_{};
 };
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/FileWriterTest.cpp
+++ b/internal/core/src/storage/FileWriterTest.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
@@ -1149,4 +1150,145 @@ TEST_F(FileWriterTest, ConfigChangeDuringFileWriterOperations) {
     std::string content2((std::istreambuf_iterator<char>(file2)),
                          std::istreambuf_iterator<char>());
     EXPECT_EQ(content2, test_data2);
+}
+
+// A write that fails inside the worker pool must reach the caller. folly's
+// Future::wait() does not rethrow the stored exception, so taking the result
+// out explicitly is what makes this observable instead of a phantom success.
+TEST_F(FileWriterTest, PooledWriteFailureIsReportedToCaller) {
+    // /dev/full is seekable and fails every write with ENOSPC
+    if (!std::filesystem::exists("/dev/full")) {
+        GTEST_SKIP() << "/dev/full is not available on this platform";
+    }
+
+    FileWriteWorkerPool::GetInstance().Configure(1);
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    FileWriter writer("/dev/full");
+    // larger than the internal buffer, so the write is handed to the pool
+    std::vector<char> data(kBufferSize * 4, 'x');
+    EXPECT_THROW(writer.Write(data.data(), data.size()), std::runtime_error);
+
+    FileWriteWorkerPool::GetInstance().Configure(0);
+}
+
+// Swapping the pool must not discard the tasks that are still queued on the
+// outgoing executor: their promises would be broken and, since the caller is
+// blocked on the future, the write would be silently skipped.
+TEST_F(FileWriterTest, ExecutorReconfigDoesNotDropQueuedTasks) {
+    auto& pool = FileWriteWorkerPool::GetInstance();
+    pool.SetWorker(1);
+
+    std::atomic<bool> started{false};
+    std::atomic<int> executed{0};
+
+    // occupy the only worker long enough for the tasks below to queue up
+    ASSERT_TRUE(pool.AddTask([&]() {
+        started.store(true, std::memory_order_release);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        executed.fetch_add(1, std::memory_order_acq_rel);
+    }));
+
+    constexpr int kQueuedTasks = 8;
+    for (int i = 0; i < kQueuedTasks; ++i) {
+        ASSERT_TRUE(pool.AddTask([&]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            executed.fetch_add(1, std::memory_order_acq_rel);
+        }));
+    }
+
+    // make sure the worker is busy, i.e. the tasks above are really queued
+    while (!started.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    // resizing keeps the same executor, so this returns without waiting; what
+    // matters is that no queued task is discarded on the way
+    pool.SetWorker(2);
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (executed.load(std::memory_order_acquire) < kQueuedTasks + 1 &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_EQ(executed.load(std::memory_order_acquire), kQueuedTasks + 1);
+
+    pool.SetWorker(0);
+}
+
+// A write that failed has already closed the file and freed the aligned
+// buffer, so a caller that swallows the error and keeps writing used to
+// memcpy into a null pointer. It must get an error instead.
+TEST_F(FileWriterTest, WriteAfterFailedWriteIsRejected) {
+    if (!std::filesystem::exists("/dev/full")) {
+        GTEST_SKIP() << "/dev/full is not available on this platform";
+    }
+
+    FileWriteWorkerPool::GetInstance().Configure(1);
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    FileWriter writer("/dev/full");
+    std::vector<char> data(kBufferSize * 4, 'x');
+    EXPECT_THROW(writer.Write(data.data(), data.size()), std::runtime_error);
+
+    // small enough to take the fast path, which is where the freed buffer was
+    // dereferenced before the guard was added
+    std::vector<char> small(16, 'y');
+    EXPECT_THROW(writer.Write(small.data(), small.size()), std::runtime_error);
+
+    FileWriteWorkerPool::GetInstance().Configure(0);
+}
+
+// The same invalidation applies to Finish(): with direct I/O it would memset
+// the freed aligned buffer, and with an empty buffer it would report the stale
+// file_size_ as a successful finalization.
+TEST_F(FileWriterTest, FinishAfterFailedWriteIsRejected) {
+    if (!std::filesystem::exists("/dev/full")) {
+        GTEST_SKIP() << "/dev/full is not available on this platform";
+    }
+
+    FileWriteWorkerPool::GetInstance().Configure(1);
+    FileWriter::SetMode(FileWriter::WriteMode::BUFFERED);
+    FileWriter::SetBufferSize(kBufferSize);
+
+    FileWriter writer("/dev/full");
+    std::vector<char> data(kBufferSize * 4, 'x');
+    EXPECT_THROW(writer.Write(data.data(), data.size()), std::runtime_error);
+    EXPECT_THROW(writer.Finish(), std::runtime_error);
+
+    FileWriteWorkerPool::GetInstance().Configure(0);
+}
+
+// Turning the pool off is the one path that still tears an executor down, so
+// it must drain the queue rather than discard it.
+TEST_F(FileWriterTest, ExecutorShutdownDrainsQueuedTasks) {
+    auto& pool = FileWriteWorkerPool::GetInstance();
+    pool.SetWorker(1);
+
+    std::atomic<bool> started{false};
+    std::atomic<int> executed{0};
+
+    ASSERT_TRUE(pool.AddTask([&]() {
+        started.store(true, std::memory_order_release);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        executed.fetch_add(1, std::memory_order_acq_rel);
+    }));
+
+    constexpr int kQueuedTasks = 8;
+    for (int i = 0; i < kQueuedTasks; ++i) {
+        ASSERT_TRUE(pool.AddTask([&]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            executed.fetch_add(1, std::memory_order_acq_rel);
+        }));
+    }
+
+    while (!started.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+
+    pool.SetWorker(0);
+
+    EXPECT_EQ(executed.load(std::memory_order_acquire), kQueuedTasks + 1);
 }


### PR DESCRIPTION
issue: #51902

Defects in the optional disk-write worker pool, plus the guards that turn the resulting
corruption into an error. All of this is behind `common.diskWriteNumThreads > 0`; the
default `0` bypasses the pool entirely and is unaffected.

### 1. `Future::wait()` never rethrows, so failed writes were reported as success

`FileWriter::Write()` / `Finish()` handed the write to the pool and then called
`future.wait()` inside a `try`/`catch`. folly's `Future<T>& wait() &` only blocks — its
only postcondition is `isReady() == true` — so the `catch` was dead code and a failed write
returned to the caller as a success. The result is now taken out with `getTry()` and
`ErrorCode::FileWriteFailed` is raised on the calling thread.

A broken promise is handled separately: it means the task was destroyed before it ran, so
nothing was written and the writer is untouched, and the write is redone inline. For that
to be reachable the queued task must be the promise's only owner, so the closure captures
the promise by move and is itself moved into `AddTask()` — otherwise the caller-side owners
keep the Promise alive, `BrokenPromise` is never published, and the wait hangs.

### 2. Reconfiguring the pool discarded queued writes

`SetWorker()` replaced the executor on every call. `stop()` makes each worker `return` as
soon as its current task ends (`threadsToStop_ > 0 && !isJoin_` in
`CPUThreadPoolExecutor::threadRun()`), so everything still queued was destroyed with the
executor, breaking those tasks' promises — which, via defect 1, the caller saw as success.

Merely draining instead of discarding is not enough: while the outgoing executor works
through its backlog the replacement is already accepting writes, so a same-size refresh
runs up to `2 * nr_worker` writes at once, breaking the cap this setting exists to enforce.
`SetWorker()` therefore no longer replaces the executor at all:

- unchanged count → return early
- `n → m`, both > 0 → `setNumThreads(m)`, resized in place
- `0 → n` → create; `n → 0` → `join()` (drains) then release

The resize happens under `executor_mutex_`, which also gates `AddTask()` for its duration,
so two live pools never coexist. Shrinking via `setNumThreads()` does not repeat the
original bug: it retires only the surplus threads while the executor and its queue survive.

### 3. A failed writer was left booby-trapped

`Cleanup()` closes `fd_` and frees `aligned_buf_` but leaves `capacity_`/`offset_` intact,
and `PositionedWriteWithCheck()` calls it *before* rethrowing. A caller that swallowed the
error and kept going therefore hit a null dereference in `Write()`'s fast path or in the
`memset()` inside `FlushWithDirectIO()`, and with an empty buffer `Finish()` skipped the
flush and returned the stale `file_size_` as a successful finalization. Both entry points
now check the file is still open, like `PositionedFileWriter::WriteAt()` already does.

Also takes `executor_mutex_` in `HasPool()`, which previously read the `shared_ptr`
concurrently with `SetWorker()`'s write.

## Verification

Five regression tests; each was confirmed to fail against the code without the
corresponding fix:

| test | without the fix | with it |
|---|---|---|
| `PooledWriteFailureIsReportedToCaller` | `Actual: it throws nothing` | throws `FileWriteFailed` |
| `ExecutorReconfigDoesNotDropQueuedTasks` | timeout at 1 of 9 tasks | 9/9 run |
| `ExecutorShutdownDrainsQueuedTasks` | 1 of 9 tasks | 9/9 run |
| `WriteAfterFailedWriteIsRejected` | killed by `SIGSEGV` (shown with `EXPECT_EXIT(..., KilledBySignal(SIGSEGV))`) | throws |
| `FinishAfterFailedWriteIsRejected` | `Actual: it throws nothing` | throws |

Failures are fault-injected against `/dev/full`, which is seekable and fails every write
with `ENOSPC`, so the error travels the real path: `PWriteAll` → promise → `getTry()` →
rethrow on the calling thread.

Full C++ suite: 8030 tests, **all passing except 7 `AzureChunkManagerTest` cases that fail
because the local azurite container had exited mid-run** (`Request was cancelled by
context`); after restarting it that suite passes 9/9. `internal/core/src/storage/azure/`
does not reference `FileWriter`.

Also exercised on a running standalone with `common.diskWriteNumThreads: 1`:

- QueryNode does create the pool — `[CGO] [FileWriter.h] Set the number of write worker to 1`.
- Before this PR, changing **one unrelated** key (`common.diskWriteRateLimiter.avgKBps`)
  fired `SetWorker()` **twice**, since QueryNode registers nine `common.diskWrite*` keys
  against the same handler. With the early return those reconfigurations are now no-ops.
- 20k×128 HNSW, five release/load cycles while flipping `avgKBps` every 50 ms: searches
  returned correct results, no write errors, no panics.

## Not verified

- The promise-ownership change is reasoned, not covered by a test: after the `SetWorker()`
  rework no path discards a queued task except the pool destructor.
- I did not instrument whether individual index-file writes exceed the 64 KB buffer, so I
  cannot claim the standalone run above actually raced a reconfiguration against a queued
  write. That mechanism is pinned by the unit tests instead.
- I did not reproduce end-to-end data loss on a pre-fix binary.
- `~FileWriteWorkerPool()` still uses `stop(); join();`, left alone deliberately — at static
  destruction a fast shutdown is reasonable and no caller can consume the result.
