### PR TITLE
fix: classify NGRAM as a scalar index

### DIFF
--- a/internal/datacoord/index_meta_test.go
+++ b/internal/datacoord/index_meta_test.go
@@ -250,6 +250,38 @@ func TestMeta_ScalarAutoIndex(t *testing.T) {
 		assert.Equal(t, newIndexParams[0].Key, common.IndexTypeKey)
 		assert.Equal(t, newIndexParams[0].Value, "INVERTED")
 	})
+
+	t.Run("ngram index param rewrite", func(t *testing.T) {
+		m.indexes[collID] = map[UniqueID]*model.Index{
+			indexID: {
+				CollectionID: collID,
+				FieldID:      fieldID,
+				IndexID:      indexID,
+				IndexName:    indexName,
+				CreateTime:   10,
+				IndexParams: []*commonpb.KeyValuePair{
+					{Key: common.IndexTypeKey, Value: "NGRAM"},
+				},
+				UserIndexParams: userIndexParams,
+			},
+		}
+		ngramReq := &indexpb.CreateIndexRequest{
+			CollectionID: collID,
+			FieldID:      fieldID,
+			IndexName:    indexName,
+			IndexParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "HYBRID"},
+			},
+			IsAutoIndex:     true,
+			UserIndexParams: userIndexParams,
+		}
+
+		indexID, err := m.CanCreateIndex(ngramReq, false)
+		assert.ErrorIs(t, err, errIndexOperationIgnored)
+		assert.Zero(t, indexID)
+		require.Len(t, ngramReq.GetIndexParams(), 1)
+		assert.Equal(t, "NGRAM", ngramReq.GetIndexParams()[0].GetValue())
+	})
 }
 
 func TestMeta_CanCreateIndex(t *testing.T) {
@@ -761,6 +793,44 @@ func TestMeta_GetSegmentIndexState(t *testing.T) {
 		state := m.GetSegmentIndexState(collID, segID, indexID)
 		assert.Equal(t, commonpb.IndexState_Finished, state.GetState())
 	})
+}
+
+func TestMeta_GetSegmentsIndexStatesUsesScalarVersionForNGRAM(t *testing.T) {
+	const (
+		collID  = UniqueID(1)
+		indexID = UniqueID(10)
+		segID   = UniqueID(1000)
+	)
+
+	segmentIndexes := typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]]()
+	indexesForSegment := typeutil.NewConcurrentMap[UniqueID, *model.SegmentIndex]()
+	indexesForSegment.Insert(indexID, &model.SegmentIndex{
+		SegmentID:                 segID,
+		IndexID:                   indexID,
+		IndexType:                 "NGRAM",
+		CurrentIndexVersion:       11,
+		CurrentScalarIndexVersion: 7,
+		IndexState:                commonpb.IndexState_Finished,
+	})
+	segmentIndexes.Insert(segID, indexesForSegment)
+
+	m := &indexMeta{
+		indexes: map[UniqueID]map[UniqueID]*model.Index{
+			collID: {
+				indexID: {
+					CollectionID: collID,
+					IndexID:      indexID,
+					IndexName:    "ngram_idx",
+				},
+			},
+		},
+		segmentIndexes: segmentIndexes,
+	}
+
+	states := m.getSegmentsIndexStates(collID, []UniqueID{segID})
+	require.Contains(t, states, segID)
+	require.Contains(t, states[segID], indexID)
+	assert.Equal(t, int32(7), states[segID][indexID].GetIndexVersion())
 }
 
 func TestMeta_GetIndexedSegment(t *testing.T) {

--- a/internal/util/indexparamcheck/index_type.go
+++ b/internal/util/indexparamcheck/index_type.go
@@ -41,7 +41,8 @@ const (
 
 func IsScalarIndexType(indexType IndexType) bool {
 	return indexType == IndexSTLSORT || indexType == IndexTRIE || indexType == IndexTrie ||
-		indexType == IndexBitmap || indexType == IndexHybrid || indexType == IndexINVERTED
+		indexType == IndexBitmap || indexType == IndexHybrid || indexType == IndexINVERTED ||
+		indexType == IndexNGRAM
 }
 
 func IsGpuIndex(indexType IndexType) bool {

--- a/internal/util/indexparamcheck/index_type_test.go
+++ b/internal/util/indexparamcheck/index_type_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 )
 
+func TestIsScalarIndexType_NGRAM(t *testing.T) {
+	assert.True(t, IsScalarIndexType(IndexNGRAM))
+}
+
 func TestIsScalarMmapIndex(t *testing.T) {
 	t.Run("inverted index", func(t *testing.T) {
 		assert.True(t, IsScalarMmapIndex(IndexINVERTED))


### PR DESCRIPTION
## What changed

- Classify `NGRAM` as a scalar index in `IsScalarIndexType`.
- Preserve the stored NGRAM AutoIndex parameters when the resolved scalar AutoIndex configuration changes.
- Report `CurrentScalarIndexVersion`, rather than the vector `CurrentIndexVersion`, for NGRAM segment-index state.

## Why

NGRAM is implemented by the scalar-index engine, but its index type was omitted from `IsScalarIndexType` when NGRAM support was introduced. The helper's two DataCoord call sites therefore treated NGRAM as a vector index for version reporting and skipped scalar AutoIndex compatibility handling.

This was discovered while reviewing #51375 and is split out so the behavior change can be reviewed and tested independently from FMINDEX.

## Tests

- Added direct coverage for `IsScalarIndexType(IndexNGRAM)`.
- Added DataCoord coverage for NGRAM AutoIndex parameter preservation.
- Added DataCoord coverage verifying NGRAM reports `CurrentScalarIndexVersion`.
- `go test -c -tags dynamic,test` succeeds for `./internal/util/indexparamcheck` and `./internal/datacoord`.

Targeted binaries could not be executed locally because this checkout does not have the required `libmilvus_core.dylib` / `libmilvus-storage.dylib`; CI will run the tests in the complete build environment.
