### PR TITLE
fix: restore growing index raw data ownership

### DIFF
--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -361,6 +361,13 @@ VectorFieldIndexing::AppendSegmentIndexSparse(int64_t reserved_offset,
             sync_with_index_.store(true);
         } catch (SegcoreError& error) {
             LOG_ERROR("growing sparse index add error: {}", error.what());
+            // Known design defect: after a raw-data-owning interim index has
+            // synchronized, its source chunks may have been reclaimed and
+            // field_raw_data is no longer a complete recovery source. This
+            // catch is reachable when AddWithDataset fails, but recreating the
+            // index here is not a valid recovery path and must not exist under
+            // single-owner semantics. The failure should instead be propagated
+            // and the segment marked unrecoverable.
             recreate_index(get_data_type(), field_raw_data);
         }
     } else {
@@ -387,6 +394,14 @@ VectorFieldIndexing::AppendSegmentIndexSparse(int64_t reserved_offset,
                 index_->AddWithDataset(dataset, conf);
             } catch (SegcoreError& error) {
                 LOG_ERROR("growing sparse index add error: {}", error.what());
+                // Known design defect: after a raw-data-owning interim index
+                // has synchronized, its source chunks may have been reclaimed
+                // and field_raw_data is no longer a complete recovery source.
+                // This catch is reachable when AddWithDataset fails, but
+                // recreating the index here is not a valid recovery path and
+                // must not exist under single-owner semantics. The failure
+                // should instead be propagated and the segment marked
+                // unrecoverable.
                 recreate_index(get_data_type(), field_raw_data);
             }
         }
@@ -497,6 +512,13 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
             sync_with_index_.store(true);
         } catch (SegcoreError& error) {
             LOG_ERROR("growing index add error: {}", error.what());
+            // Known design defect: after a raw-data-owning interim index has
+            // synchronized, its source chunks may have been reclaimed and
+            // field_raw_data is no longer a complete recovery source. This
+            // catch is reachable when AddWithDataset fails, but recreating the
+            // index here is not a valid recovery path and must not exist under
+            // single-owner semantics. The failure should instead be propagated
+            // and the segment marked unrecoverable.
             recreate_index(get_data_type(), field_raw_data);
         }
     } else {
@@ -525,6 +547,14 @@ VectorFieldIndexing::AppendSegmentIndexDense(int64_t reserved_offset,
                 index_->AddWithDataset(dataset, conf);
             } catch (SegcoreError& error) {
                 LOG_ERROR("growing index add error: {}", error.what());
+                // Known design defect: after a raw-data-owning interim index
+                // has synchronized, its source chunks may have been reclaimed
+                // and field_raw_data is no longer a complete recovery source.
+                // This catch is reachable when AddWithDataset fails, but
+                // recreating the index here is not a valid recovery path and
+                // must not exist under single-owner semantics. The failure
+                // should instead be propagated and the segment marked
+                // unrecoverable.
                 recreate_index(get_data_type(), field_raw_data);
             }
         }

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -715,10 +715,14 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
                 &insert_record_proto->fields_data(data_offset),
                 field_meta);
         }
-        // A synchronized interim index that owns raw data consumes later
-        // batches directly. Do not repopulate chunks reclaimed by
-        // try_remove_chunks.
-        if (!indexing_record_.HasRawData(field_id)) {
+        // A synchronized vector interim index that owns raw data consumes
+        // later batches directly. Do not repopulate chunks reclaimed by
+        // try_remove_chunks. Scalar indexes do not take over raw-data
+        // ownership from ConcurrentVector.
+        const bool index_owns_raw_data =
+            IsVectorDataType(field_meta.get_data_type()) &&
+            indexing_record_.HasRawData(field_id);
+        if (!index_owns_raw_data) {
             if (field_meta.get_data_type() == DataType::TEXT) {
                 auto spillover = GetTextLobSpillover(field_id);
                 AssertInfo(spillover != nullptr,
@@ -981,9 +985,13 @@ SegmentGrowingImpl::load_field_data_common(
     if (insert_record_.is_valid_data_exist(field_id)) {
         insert_record_.get_valid_data(field_id)->set_data_raw(field_data);
     }
-    // Keep the load path aligned with Insert: once the interim index owns raw
-    // data, append the loaded batch to the index without rebuilding raw chunks.
-    if (!indexing_record_.HasRawData(field_id)) {
+    // Keep the load path aligned with Insert: once a vector interim index owns
+    // raw data, append the loaded batch to the index without rebuilding raw
+    // chunks. Scalar indexes do not take over raw-data ownership.
+    const bool index_owns_raw_data =
+        IsVectorDataType(field_meta.get_data_type()) &&
+        indexing_record_.HasRawData(field_id);
+    if (!index_owns_raw_data) {
         insert_record_.get_data_base(field_id)->set_data_raw(reserved_offset,
                                                              field_data);
     }

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -715,36 +715,38 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
                 &insert_record_proto->fields_data(data_offset),
                 field_meta);
         }
-        // Growing-source flush reads raw data from insert_record_. Keep it
-        // populated even when the interim index can also serve raw vector data.
-        // Otherwise later inserts after index sync would be visible by row count
-        // but missing from field chunks during FlushGrowingSegmentData.
-        if (field_meta.get_data_type() == DataType::TEXT) {
-            auto spillover = GetTextLobSpillover(field_id);
-            AssertInfo(spillover != nullptr, "TEXT field must have spillover");
-            const auto& field_data =
-                insert_record_proto->fields_data(data_offset);
-            const auto& string_data = field_data.scalars().string_data();
+        // A synchronized interim index that owns raw data consumes later
+        // batches directly. Do not repopulate chunks reclaimed by
+        // try_remove_chunks.
+        if (!indexing_record_.HasRawData(field_id)) {
+            if (field_meta.get_data_type() == DataType::TEXT) {
+                auto spillover = GetTextLobSpillover(field_id);
+                AssertInfo(spillover != nullptr,
+                           "TEXT field must have spillover");
+                const auto& field_data =
+                    insert_record_proto->fields_data(data_offset);
+                const auto& string_data = field_data.scalars().string_data();
 
-            std::vector<std::string> ref_strings(num_rows);
-            for (int64_t i = 0; i < num_rows; i++) {
-                const auto& text = string_data.data(i);
-                ref_strings[i] = spillover->WriteAndEncode(text);
+                std::vector<std::string> ref_strings(num_rows);
+                for (int64_t i = 0; i < num_rows; i++) {
+                    const auto& text = string_data.data(i);
+                    ref_strings[i] = spillover->WriteAndEncode(text);
+                }
+
+                auto* vec_base = insert_record_.get_data_base(field_id);
+                auto* string_vec =
+                    dynamic_cast<ConcurrentVector<std::string>*>(vec_base);
+                AssertInfo(string_vec != nullptr,
+                           "TEXT field must use ConcurrentVector<std::string>");
+                string_vec->set_data_raw(
+                    reserved_offset, ref_strings.data(), num_rows);
+            } else {
+                insert_record_.get_data_base(field_id)->set_data_raw(
+                    reserved_offset,
+                    num_rows,
+                    &insert_record_proto->fields_data(data_offset),
+                    field_meta);
             }
-
-            auto* vec_base = insert_record_.get_data_base(field_id);
-            auto* string_vec =
-                dynamic_cast<ConcurrentVector<std::string>*>(vec_base);
-            AssertInfo(string_vec != nullptr,
-                       "TEXT field must use ConcurrentVector<std::string>");
-            string_vec->set_data_raw(
-                reserved_offset, ref_strings.data(), num_rows);
-        } else {
-            insert_record_.get_data_base(field_id)->set_data_raw(
-                reserved_offset,
-                num_rows,
-                &insert_record_proto->fields_data(data_offset),
-                field_meta);
         }
 
         //insert vector data into index
@@ -976,13 +978,15 @@ SegmentGrowingImpl::load_field_data_common(
 
     auto field_meta = (*schema_)[field_id];
 
-    // Growing-source flush reads raw data from insert_record_. Keep it
-    // populated even when an interim index can provide raw vector data.
     if (insert_record_.is_valid_data_exist(field_id)) {
         insert_record_.get_valid_data(field_id)->set_data_raw(field_data);
     }
-    insert_record_.get_data_base(field_id)->set_data_raw(reserved_offset,
-                                                         field_data);
+    // Keep the load path aligned with Insert: once the interim index owns raw
+    // data, append the loaded batch to the index without rebuilding raw chunks.
+    if (!indexing_record_.HasRawData(field_id)) {
+        insert_record_.get_data_base(field_id)->set_data_raw(reserved_offset,
+                                                             field_data);
+    }
     if (segcore_config_.get_enable_interim_segment_index()) {
         auto offset = reserved_offset;
         for (auto& data : field_data) {

--- a/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
@@ -52,6 +52,7 @@
 #include "segcore/SegmentGrowing.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "storage/FileManager.h"
+#include "storage/Util.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/indexbuilder_test_utils.h"
@@ -369,67 +370,120 @@ TEST_P(GrowingIndexTest, Correctness) {
     }
 }
 
-TEST(GrowingIndex, IndexedVectorOwnershipStopsRawWritesAfterSynchronization) {
-    constexpr int64_t dim = 4;
-    constexpr int64_t row_count = 100;
+class GrowingIndexRawOwnershipTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        schema_ = std::make_shared<Schema>();
+        pk_ = schema_->AddDebugField("pk", DataType::INT64);
+        vec_ = schema_->AddDebugField("embeddings",
+                                      DataType::VECTOR_FLOAT,
+                                      dim,
+                                      knowhere::metric::L2,
+                                      true);
+        schema_->set_primary_field_id(pk_);
 
-    auto schema = std::make_shared<Schema>();
-    auto pk = schema->AddDebugField("pk", DataType::INT64);
-    auto vec = schema->AddDebugField(
-        "embeddings", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2, true);
-    schema->set_primary_field_id(pk);
+        std::map<std::string, std::string> index_params = {
+            {"index_type", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT},
+            {"metric_type", knowhere::metric::L2},
+            {"nlist", "1"}};
+        std::map<std::string, std::string> type_params = {
+            {"dim", std::to_string(dim)}};
+        FieldIndexMeta field_index_meta(
+            vec_, std::move(index_params), std::move(type_params));
+        std::map<FieldId, FieldIndexMeta> field_map = {
+            {vec_, field_index_meta}};
+        meta_ =
+            std::make_shared<CollectionIndexMeta>(100, std::move(field_map));
 
-    std::map<std::string, std::string> index_params = {
-        {"index_type", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT},
-        {"metric_type", knowhere::metric::L2},
-        {"nlist", "1"}};
-    std::map<std::string, std::string> type_params = {
-        {"dim", std::to_string(dim)}};
-    FieldIndexMeta field_index_meta(
-        vec, std::move(index_params), std::move(type_params));
-    std::map<FieldId, FieldIndexMeta> field_map = {{vec, field_index_meta}};
-    IndexMetaPtr meta =
-        std::make_shared<CollectionIndexMeta>(100, std::move(field_map));
+        InterimIndexConfigForTest interim_config;
+        interim_config.chunk_rows = 16;
+        interim_config.nlist = 1;
+        interim_config.nprobe = 1;
+        interim_config.dense_vector_interim_index_type =
+            knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
+        interim_config.sub_dim = dim;
+        interim_config.refine_ratio = 1.0F;
+        interim_config.refine_quant_type = "NONE";
+        interim_config.refine_with_quant_flag = false;
+        ApplyInterimIndexConfigForTest(interim_config, config_);
+        config_.set_storage_v3_enabled(true);
+        config_.set_enable_growing_source_flush(true);
+    }
 
-    auto& config = SegcoreConfig::default_config();
-    ScopedSegcoreConfigRestore config_restore(config);
-    InterimIndexConfigForTest interim_config;
-    interim_config.chunk_rows = 16;
-    interim_config.nlist = 1;
-    interim_config.nprobe = 1;
-    interim_config.dense_vector_interim_index_type =
-        knowhere::IndexEnum::INDEX_FAISS_IVFFLAT_CC;
-    interim_config.sub_dim = dim;
-    interim_config.refine_ratio = 1.0F;
-    interim_config.refine_quant_type = "NONE";
-    interim_config.refine_with_quant_flag = false;
-    ApplyInterimIndexConfigForTest(interim_config, config);
-    config.set_storage_v3_enabled(true);
-    config.set_enable_growing_source_flush(true);
-
-    auto insert = [&](SegmentGrowing* segment) {
-        auto dataset = DataGen(schema, row_count);
+    GeneratedData
+    InsertBatch(SegmentGrowing* segment, uint64_t seed) const {
+        auto dataset = DataGen(schema_, row_count, seed);
         auto offset = segment->PreInsert(row_count);
         segment->Insert(offset,
                         row_count,
                         dataset.row_ids_.data(),
                         dataset.timestamps_.data(),
                         dataset.raw_);
-    };
+        return dataset;
+    }
 
-    auto segment = CreateGrowingSegment(schema, meta, 1, config);
+    FieldDataPtr
+    CreateNullableFloatFieldData(const DataArray& data) const {
+        std::vector<uint8_t> valid_bitmap((row_count + 7) / 8, 0);
+        for (int64_t i = 0; i < row_count; ++i) {
+            if (data.valid_data(i)) {
+                valid_bitmap[i / 8] |= uint8_t{1} << (i % 8);
+            }
+        }
+
+        auto field_data = storage::CreateFieldData(
+            DataType::VECTOR_FLOAT, DataType::NONE, true, dim, row_count);
+        field_data->FillFieldData(data.vectors().float_vector().data().data(),
+                                  valid_bitmap.data(),
+                                  row_count,
+                                  0);
+        return field_data;
+    }
+
+    void
+    AssertNullableFloatDataEqual(const DataArray& actual,
+                                 const DataArray& expected) const {
+        ASSERT_EQ(actual.valid_data_size(), expected.valid_data_size());
+        for (int i = 0; i < actual.valid_data_size(); ++i) {
+            EXPECT_EQ(actual.valid_data(i), expected.valid_data(i));
+        }
+
+        const auto& actual_values = actual.vectors().float_vector().data();
+        const auto& expected_values = expected.vectors().float_vector().data();
+        ASSERT_FALSE(expected_values.empty());
+        ASSERT_EQ(actual_values.size(), expected_values.size());
+        for (int i = 0; i < actual_values.size(); ++i) {
+            EXPECT_FLOAT_EQ(actual_values[i], expected_values[i]);
+        }
+    }
+
+    static constexpr int64_t dim = 4;
+    static constexpr int64_t row_count = 100;
+
+    SegcoreConfig& config_ = SegcoreConfig::default_config();
+    ScopedSegcoreConfigRestore config_restore_{config_};
+    SchemaPtr schema_;
+    FieldId pk_;
+    FieldId vec_;
+    IndexMetaPtr meta_;
+};
+
+TEST_F(GrowingIndexRawOwnershipTest,
+       InsertAfterSynchronizationDoesNotRepopulateRawData) {
+    auto segment = CreateGrowingSegment(schema_, meta_, 1, config_);
     auto* segment_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
     ASSERT_NE(segment_impl, nullptr);
 
-    insert(segment.get());
-    auto* raw_vector = segment_impl->get_insert_record().get_data_base(vec);
+    InsertBatch(segment.get(), 42);
+    auto* raw_vector = segment_impl->get_insert_record().get_data_base(vec_);
     ASSERT_EQ(raw_vector->num_chunk(), 0);
-    ASSERT_TRUE(segment_impl->CanReadRawVectorFromIndex(vec));
+    ASSERT_TRUE(segment_impl->CanReadRawVectorFromIndex(vec_));
     const auto raw_logical_count =
         raw_vector->get_offset_mapping().GetTotalCount();
     ASSERT_EQ(raw_logical_count, row_count);
 
-    insert(segment.get());
+    auto second_batch = InsertBatch(segment.get(), 43);
 
     EXPECT_EQ(segment->get_row_count(), 2 * row_count);
     EXPECT_EQ(raw_vector->num_chunk(), 0);
@@ -440,13 +494,44 @@ TEST(GrowingIndex, IndexedVectorOwnershipStopsRawWritesAfterSynchronization) {
     for (int64_t i = 0; i < row_count; ++i) {
         offsets[i] = row_count + i;
     }
-    auto field_data =
-        segment_impl->bulk_subscript(nullptr, vec, offsets.data(), row_count);
-    ASSERT_EQ(field_data->valid_data_size(), row_count);
-    const auto valid_count = std::count(
-        field_data->valid_data().begin(), field_data->valid_data().end(), true);
-    EXPECT_EQ(field_data->vectors().float_vector().data_size(),
-              valid_count * dim);
+    auto actual =
+        segment_impl->bulk_subscript(nullptr, vec_, offsets.data(), row_count);
+    auto expected = second_batch.get_col(vec_);
+    AssertNullableFloatDataEqual(*actual, *expected);
+}
+
+TEST_F(GrowingIndexRawOwnershipTest,
+       LoadAfterSynchronizationPreservesValidityWithoutRawData) {
+    auto segment = CreateGrowingSegment(schema_, meta_, 1, config_);
+    auto* segment_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(segment_impl, nullptr);
+
+    InsertBatch(segment.get(), 42);
+    auto* raw_vector = segment_impl->get_insert_record().get_data_base(vec_);
+    ASSERT_EQ(raw_vector->num_chunk(), 0);
+    ASSERT_TRUE(segment_impl->CanReadRawVectorFromIndex(vec_));
+    const auto raw_logical_count =
+        raw_vector->get_offset_mapping().GetTotalCount();
+    ASSERT_EQ(raw_logical_count, row_count);
+
+    auto second_batch = DataGen(schema_, row_count, 44);
+    auto expected = second_batch.get_col(vec_);
+    auto field_data = CreateNullableFloatFieldData(*expected);
+    auto offset = segment->PreInsert(row_count);
+    segment_impl->load_field_data_common(
+        vec_, offset, {field_data}, pk_, row_count);
+
+    EXPECT_EQ(raw_vector->num_chunk(), 0);
+    EXPECT_EQ(raw_vector->get_offset_mapping().GetTotalCount(),
+              raw_logical_count);
+
+    std::vector<int64_t> offsets(row_count);
+    for (int64_t i = 0; i < row_count; ++i) {
+        offsets[i] = row_count + i;
+    }
+    auto actual =
+        segment_impl->bulk_subscript(nullptr, vec_, offsets.data(), row_count);
+    AssertNullableFloatDataEqual(*actual, *expected);
 }
 
 TEST_P(GrowingIndexTest, AddWithoutBuildPool) {

--- a/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
@@ -369,14 +369,14 @@ TEST_P(GrowingIndexTest, Correctness) {
     }
 }
 
-TEST(GrowingIndex, GrowingSourceFlushDoesNotRetainIndexedVectorChunks) {
+TEST(GrowingIndex, IndexedVectorOwnershipStopsRawWritesAfterSynchronization) {
     constexpr int64_t dim = 4;
     constexpr int64_t row_count = 100;
 
     auto schema = std::make_shared<Schema>();
     auto pk = schema->AddDebugField("pk", DataType::INT64);
     auto vec = schema->AddDebugField(
-        "embeddings", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2);
+        "embeddings", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2, true);
     schema->set_primary_field_id(pk);
 
     std::map<std::string, std::string> index_params = {
@@ -422,9 +422,31 @@ TEST(GrowingIndex, GrowingSourceFlushDoesNotRetainIndexedVectorChunks) {
     ASSERT_NE(segment_impl, nullptr);
 
     insert(segment.get());
-    EXPECT_EQ(segment_impl->get_insert_record().get_data_base(vec)->num_chunk(),
-              0);
-    EXPECT_TRUE(segment_impl->CanReadRawVectorFromIndex(vec));
+    auto* raw_vector = segment_impl->get_insert_record().get_data_base(vec);
+    ASSERT_EQ(raw_vector->num_chunk(), 0);
+    ASSERT_TRUE(segment_impl->CanReadRawVectorFromIndex(vec));
+    const auto raw_logical_count =
+        raw_vector->get_offset_mapping().GetTotalCount();
+    ASSERT_EQ(raw_logical_count, row_count);
+
+    insert(segment.get());
+
+    EXPECT_EQ(segment->get_row_count(), 2 * row_count);
+    EXPECT_EQ(raw_vector->num_chunk(), 0);
+    EXPECT_EQ(raw_vector->get_offset_mapping().GetTotalCount(),
+              raw_logical_count);
+
+    std::vector<int64_t> offsets(row_count);
+    for (int64_t i = 0; i < row_count; ++i) {
+        offsets[i] = row_count + i;
+    }
+    auto field_data =
+        segment_impl->bulk_subscript(nullptr, vec, offsets.data(), row_count);
+    ASSERT_EQ(field_data->valid_data_size(), row_count);
+    const auto valid_count = std::count(
+        field_data->valid_data().begin(), field_data->valid_data().end(), true);
+    EXPECT_EQ(field_data->vectors().float_vector().data_size(),
+              valid_count * dim);
 }
 
 TEST_P(GrowingIndexTest, AddWithoutBuildPool) {


### PR DESCRIPTION
issue: #51916

- growing segment writes: restore vector interim-index raw-data ownership and stop repopulating reclaimed chunks after synchronization
- field loading: apply the same vector-only ownership rule while preserving nullable validity metadata
- index append failures: document the invalid recreate path after the only complete raw-data source has been reclaimed