### PR TITLE
enhance: [TiKV] enable TiKV 1PC by default

### DIFF
--- a/pkg/util/tikv/tikv_util_test.go
+++ b/pkg/util/tikv/tikv_util_test.go
@@ -17,24 +17,23 @@
 package tikv
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/tikv/client-go/v2/config"
-	"github.com/tikv/client-go/v2/txnkv"
 
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
-func GetTiKVClient(cfg *paramtable.TiKVConfig) (*txnkv.Client, error) {
-	config.UpdateGlobal(func(conf *config.Config) {
-		applyTiKVClientConfig(cfg, conf)
-	})
+func TestApplyTiKVClientConfigEnable1PC(t *testing.T) {
+	cfg := &paramtable.TiKVConfig{}
+	cfg.Init(paramtable.NewBaseTable())
 
-	return txnkv.NewClient([]string{cfg.Endpoints.GetValue()})
-}
+	conf := config.DefaultConfig()
+	conf.EnableAsyncCommit = true
 
-func applyTiKVClientConfig(cfg *paramtable.TiKVConfig, conf *config.Config) {
-	if cfg.TiKVUseSSL.GetAsBool() {
-		conf.Security = config.NewSecurity(cfg.TiKVTLSCACert.GetValue(), cfg.TiKVTLSCert.GetValue(), cfg.TiKVTLSKey.GetValue(), []string{})
-	}
-	conf.Enable1PC = true
-	conf.EnableAsyncCommit = false
+	applyTiKVClientConfig(cfg, &conf)
+
+	assert.True(t, conf.Enable1PC)
+	assert.False(t, conf.EnableAsyncCommit)
 }


### PR DESCRIPTION
Related issue: #51914

## What changed

This PR enables TiKV 1PC by default when Milvus creates the TiKV `txnkv.Client` for metastore usage.

The client still uses `txnkv`; this does not switch Milvus to RawKV. 1PC is an optimization attempted by client-go. For transactions that cannot use 1PC, such as keys spanning multiple regions, client-go disables 1PC and continues through the normal 2PC commit flow.

## Benchmark: TiKV 2PC vs TiKV 1PC

100k collection catalog-method benchmark. Values are QPS and latency from the existing local catalog benchmark CSVs. Write operations use c=128. The `txn/op` and `catalog write shape` columns describe the catalog method workload shape in this benchmark, which is why single-transaction ops can reach several thousand or 10k+ QPS while collection create/drop are lower per logical collection DDL.

| op | c | txn/op | catalog write shape | 2PC QPS | 1PC QPS | QPS ratio | 2PC p50 ms | 1PC p50 ms | 2PC p99 ms | 1PC p99 ms |
|---|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|
| `sn_save_consume_checkpoint` | 128 | 1 | single WAL checkpoint key, small value | 4188.6 | 8569.6 | 2.05x | 29.0 | 12.7 | 48.2 | 45.7 |
| `dc_alter_segments_flush_commit` | 128 | 1 | segment metadata and column group binlogs in one `MultiSave` | 2302.9 | 3809.8 | 1.65x | 32.9 | 24.7 | 168.8 | 94.0 |
| `sn_save_segment_assignments_active` | 128 | 1 | single active segment-assignment key | 4044.3 | 8562.6 | 2.12x | 30.5 | 14.2 | 49.9 | 28.8 |
| `sn_save_vchannels_active` | 128 | 1 | vchannel metadata and schema version in one `MultiSave` | 977.9 | 5600.6 | 5.73x | 119.6 | 17.6 | 217.1 | 53.4 |
| `dc_add_segment` | 128 | 1 | segment metadata and column group binlogs in one `MultiSave` | 3173.4 | 3668.1 | 1.16x | 31.5 | 24.4 | 133.6 | 95.7 |
| `rc_create_collection` | 128 | 2 | child metadata is written first, then the collection key is written as the visibility point | 433.5 | 1330.1 | 3.07x | 298.6 | 96.6 | 794.2 | 211.4 |
| `rc_drop_collection` | 128 | 2 | child metadata is removed first, then the collection key is removed | 487.0 | 1831.1 | 3.76x | 256.2 | 51.7 | 452.4 | 114.3 |
| `qc_save_replica` | 128 | 1 | single replica key, small value | 3601.4 | 10288.3 | 2.86x | 33.9 | 10.4 | 62.4 | 30.4 |

Benchmark notes:

- The benchmark calls Milvus catalog methods directly, not RawKV and not the full Proxy/RootCoord DDL path.
- `rc_create_collection` and `rc_drop_collection` are lower per logical op because one collection DDL maps to two TiKV transaction commits and multiple real catalog metadata keys in this fixture.
- Both runs completed with `errors=0` for the aligned rows above.