### PR TITLE
fix: return futures for accepted thread pool tasks

### DIFF
--- a/internal/core/src/storage/ThreadPool.h
+++ b/internal/core/src/storage/ThreadPool.h
@@ -139,64 +139,67 @@ class ThreadPool {
         std::function<decltype(f(args...))()> func =
             std::bind(std::forward<F>(f), std::forward<Args>(args)...);
         auto task_ptr =
-            std::make_shared<std::packaged_task<decltype(f(args...))()>>(func);
-
-        auto enqueue_time = std::chrono::steady_clock::now();
-        auto* queue_metric = metric_queue_duration_;
-        auto* execute_metric = metric_execute_duration_;
-        std::function<void()> wrap_func = [task_ptr,
-                                           enqueue_time,
-                                           queue_metric,
-                                           execute_metric]() {
-            auto execute_start = std::chrono::steady_clock::now();
-            if (queue_metric) {
-                queue_metric->Observe(
-                    std::chrono::duration<double>(execute_start - enqueue_time)
-                        .count());
-            }
-            auto observe_execute = [&]() {
-                if (execute_metric) {
-                    execute_metric->Observe(
-                        std::chrono::duration<double>(
-                            std::chrono::steady_clock::now() - execute_start)
-                            .count());
-                }
-            };
-            try {
-                (*task_ptr)();
-            } catch (...) {
-                observe_execute();
-                throw;
-            }
-            observe_execute();
-        };
-
+            std::make_shared<std::packaged_task<decltype(f(args...))()>>(
+                std::move(func));
         auto future = task_ptr->get_future();
 
-        std::unique_lock<std::mutex> lock(mutex_);
-        work_queue_.enqueue(std::move(wrap_func));
+        auto* queue_metric = metric_queue_duration_;
+        auto* execute_metric = metric_execute_duration_;
 
-        if (idle_threads_size_ > 0) {
-            condition_lock_.notify_one();
-        }
-        if (work_queue_.size() > static_cast<size_t>(idle_threads_size_) &&
-            current_threads_size_ < max_threads_size_.load()) {
-            // Dynamic increase thread number
-            try {
+        // Lifetime-safety contract: do not move work_queue_.enqueue() above
+        // this block. Every fallible worker-provisioning step must finish
+        // before task publication. A caller may release task-captured state
+        // when Submit() throws; enqueueing first could leave an accepted but
+        // untracked task using that state after the caller unwinds.
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (work_queue_.size() >= static_cast<size_t>(idle_threads_size_) &&
+                current_threads_size_ < max_threads_size_.load()) {
+                // Dynamic increase thread number
                 if (worker_spawn_hook_for_test_) {
                     worker_spawn_hook_for_test_();
                 }
                 threads_.emplace_back(&ThreadPool::Worker, this);
                 current_threads_size_++;
-            } catch (const std::exception& e) {
-                LOG_WARN(
-                    "Failed to expand thread pool {}: {}", name_, e.what());
-            } catch (...) {
-                LOG_WARN("Failed to expand thread pool {}", name_);
+            }
+
+            // Queue duration starts after lock wait and worker provisioning, so
+            // it measures time from queue publication to task execution.
+            auto enqueue_time = std::chrono::steady_clock::now();
+            std::function<void()> wrap_func =
+                [task_ptr, enqueue_time, queue_metric, execute_metric]() {
+                    auto execute_start = std::chrono::steady_clock::now();
+                    if (queue_metric) {
+                        queue_metric->Observe(std::chrono::duration<double>(
+                                                  execute_start - enqueue_time)
+                                                  .count());
+                    }
+                    auto observe_execute = [&]() {
+                        if (execute_metric) {
+                            execute_metric->Observe(
+                                std::chrono::duration<double>(
+                                    std::chrono::steady_clock::now() -
+                                    execute_start)
+                                    .count());
+                        }
+                    };
+                    try {
+                        (*task_ptr)();
+                    } catch (...) {
+                        observe_execute();
+                        throw;
+                    }
+                    observe_execute();
+                };
+            work_queue_.enqueue(wrap_func);
+            if (idle_threads_size_ > 0) {
+                condition_lock_.notify_one();
             }
         }
-        lock.unlock();
 
+        // Queue publication is the acceptance boundary. Do not let optional
+        // post-enqueue metrics prevent the accepted task's future from being
+        // returned.
         try {
             if (metric_submitted_) {
                 metric_submitted_->Increment();
@@ -204,14 +207,10 @@ class ThreadPool {
             if (metric_queue_depth_) {
                 metric_queue_depth_->Set(work_queue_.size());
             }
-        } catch (const std::exception& e) {
-            LOG_WARN("Failed to update thread pool {} submit metrics: {}",
-                     name_,
-                     e.what());
         } catch (...) {
-            LOG_WARN("Failed to update thread pool {} submit metrics", name_);
+            // Metrics are best-effort. Nothing after queue publication may
+            // throw before the accepted task's future is returned.
         }
-
         return future;
     }
 
@@ -289,7 +288,7 @@ class ThreadPool {
     prometheus::Histogram* metric_execute_duration_{nullptr};
 
  private:
-    friend class ThreadPoolTest_WorkerSpawnFailureDoesNotFailQueuedTask_Test;
+    friend class ThreadPoolTest_WorkerSpawnFailureRejectsUnqueuedTask_Test;
 
     // Deterministic test seam for worker-spawn failure coverage.
     std::function<void()> worker_spawn_hook_for_test_;

--- a/internal/core/src/storage/ThreadPoolTest.cpp
+++ b/internal/core/src/storage/ThreadPoolTest.cpp
@@ -19,6 +19,7 @@
 #include <concepts>
 #include <future>
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <system_error>
 
@@ -189,7 +190,7 @@ TEST_F(ThreadPoolTest, LoadFileOverheadControllerIsLazyAndStable) {
     EXPECT_EQ(file_group, file_owner.GetOrCreate(/*executor_workers=*/8));
 }
 
-TEST_F(ThreadPoolTest, WorkerSpawnFailureDoesNotFailQueuedTask) {
+TEST_F(ThreadPoolTest, WorkerSpawnFailureRejectsUnqueuedTask) {
     ThreadPool pool(1.0, "test_pool");
 
     std::promise<void> blocker_started;
@@ -208,18 +209,24 @@ TEST_F(ThreadPoolTest, WorkerSpawnFailureDoesNotFailQueuedTask) {
     };
 
     std::atomic<int> task_runs{0};
-    std::future<void> task_future;
-    EXPECT_NO_THROW(
-        task_future = pool.Submit([&task_runs]() { task_runs.fetch_add(1); }));
+    EXPECT_THROW(pool.Submit([&task_runs]() { task_runs.fetch_add(1); }),
+                 std::system_error);
 
     unblock_worker.set_value();
     blocker.get();
 
-    ASSERT_TRUE(task_future.valid());
-    ASSERT_EQ(task_future.wait_for(std::chrono::seconds(2)),
-              std::future_status::ready);
-    task_future.get();
-    EXPECT_EQ(task_runs.load(), 1);
+    EXPECT_EQ(task_runs.load(), 0);
+}
+
+TEST_F(ThreadPoolTest, SubmissionPreservesResultAndTaskException) {
+    ThreadPool pool(1.0, "test_pool");
+
+    auto result = pool.Submit([](int value) { return value + 1; }, 41);
+    EXPECT_EQ(result.get(), 42);
+
+    auto failure =
+        pool.Submit([]() { throw std::runtime_error("task failed"); });
+    EXPECT_THROW(failure.get(), std::runtime_error);
 }
 
 }  // namespace milvus


### PR DESCRIPTION
issue: #51919

## What does this PR do?

This PR closes a rare but unsafe acceptance gap in the shared C++ `ThreadPool::Submit()` implementation.

On the original base of this PR, `Submit()` enqueued a task and only returned its future after post-enqueue metrics, locking, and optional dynamic worker creation. If `std::thread` construction failed while expanding the pool, the task remained queued but `Submit()` threw. The caller therefore had no future for an accepted task and could unwind while that task still referenced caller-owned state.

The concrete trigger is uncommon—an expanding pool must hit an OS/process thread-resource limit—but the consequence is not local to one reader. Current `master` has 31 direct production submissions across 11 implementation files. Several callers drain returned futures specifically to protect stack references, buffers, output state, readers, or file descriptors; no caller can drain a future that was never returned.

## Divergence from current master

Current master now contains the alternative implementation merged through [#51403](https://github.com/milvus-io/milvus/pull/51403). It obtains the future, publishes the task first, and treats dynamic worker expansion as best effort: worker-spawn failure is caught, the accepted task remains queued, and the future is returned. This resolves the original thread-construction failure for ordinary submissions without rejecting the task.

This PR keeps a different contract. When projected demand requires another worker, provisioning completes before queue publication. If provisioning fails, `Submit()` throws and the current task has not been accepted. The difference is therefore no longer whether the original failure is noticed; it is whether failed expansion should leave the task queued or reject it before publication.

Two theoretical boundaries remain in the current-master policy:

1. the post-enqueue `LOG_WARN` calls in failure handlers may themselves allocate and throw under extreme memory pressure;
2. if every existing worker is blocked and a task submitted from a worker synchronously waits on another task in the same pool, failed expansion can leave that child future waiting indefinitely.

A static audit of the current production call graph found no same-pool nested synchronous submission. Existing nested load paths deliberately cross pools, such as MIDDLE to HIGH/LOW, and one LOW-pool decode path explicitly documents that it must not be called from a LOW-pool worker. Same-pool submit-and-wait should remain disallowed; callers should use a different pool, continuations, or return the future to a non-worker coordinator instead.

The PR is being held open for now while the desired acceptance policy is considered. No additional implementation change is proposed solely for a nested-submission scenario that has no current production instance.

## How does it work?

The submission contract is now based on queue publication:

- the packaged-task future is obtained before publication;
- while holding the pool mutex, `Submit()` evaluates projected queue demand and creates/registers any required expansion worker before the task is enqueued;
- if `std::thread` construction fails, the submission throws while the task is still unaccepted and absent from `work_queue_`;
- after enqueue succeeds, optional metric failures are contained without suppressing the future of the accepted task;
- normal task results and task-thrown exceptions continue to propagate through the future.

Provisioning before publication also preserves nested-submission behavior. If the only worker submits a child task and expansion fails, the child submission remains a visible exception instead of returning an unserviceable child future.

The implementation remains directly in the existing `Submit()` template. It does not add a test peer, injectable worker factory, new public/private helper, `ThreadPool` data member, or other test-only production seam. The current master already provides a deterministic worker-spawn hook; this PR reuses that existing seam to verify the rejection boundary.

## Affected surface

The shared fix covers all current and future users. The audited direct callers are:

- storage: `IndexEntryReader`, `DiskFileManagerImpl`, `IndexEntryEncryptedLocalWriter`, and `Util`;
- index/json stats: `JsonKeyStats`;
- segcore: `ChunkedSegmentSealedImpl`, `SegmentGrowingImpl`, `Utils`, `memory_planner`, `reduce/Reduce`, and `search_result_export_c`.

This is intentionally a pool-level fix. Adding ownership gates independently to consumers would duplicate the same contract, impose per-consumer overhead, and leave other callers exposed.

## Behavior and performance

The normal submission path adds no allocation, atomic state, worker wait, or `ThreadPool` data member. It reorders existing locking, worker provisioning, queue publication, and future retrieval so failure and acceptance are unambiguous. Paired empty-task microbenchmarks on the same provisioning-before-publication ordering showed no normal-path regression; details are posted separately for review.

The intentional exceptional-path behavior is:

- worker provisioning failure rejects the not-yet-published task;
- after publication, the caller receives the future that tracks the accepted task.

The PR does not change the existing pool-shutdown lifecycle. Production `ThreadPools` are shut down only from teardown/destruction after their users stop submitting work.

## Validation

Validation covers ordinary return values and task-thrown exceptions through the reordered submission path. It also reuses the deterministic worker-spawn hook already present on current master to verify that a provisioning failure propagates to the caller and the rejected task never enters the queue or executes. This PR does not introduce a new production test seam or change the public API or object layout.