### PR TITLE
fix: [3.0] synchronize delegator function runtime with collection schema (#51818)

### DIFF
--- a/internal/querycoordv2/observers/target_observer.go
+++ b/internal/querycoordv2/observers/target_observer.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/params"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
@@ -524,9 +525,30 @@ func (ob *TargetObserver) shouldUpdateCurrentTarget(ctx context.Context, collect
 // 1. if next target is changed before delegator becomes serviceable, we need to sync the new next target to delegator to support partial search
 // 2. if next target is ready to read, we need to sync the next target to delegator to support full search
 func (ob *TargetObserver) syncNextTargetToDelegator(ctx context.Context, collectionID int64, collReadyDelegatorList []*meta.DmChannel, newVersion int64) bool {
-	var partitions []int64
-	var indexInfo []*indexpb.IndexInfo
-	var err error
+	if len(collReadyDelegatorList) == 0 {
+		return true
+	}
+
+	collectionInfo, err := ob.broker.DescribeCollection(ctx, collectionID)
+	if err != nil {
+		mlog.Warn(ctx, "failed to describe collection", mlog.Err(err))
+		return false
+	}
+	schema := collectionInfo.GetSchema()
+	schemaBarrierTs := collectionInfo.GetUpdateTimestamp()
+
+	partitions, err := utils.GetPartitions(ctx, ob.targetMgr, collectionID)
+	if err != nil {
+		mlog.Warn(ctx, "failed to get partitions", mlog.Err(err))
+		return false
+	}
+
+	indexInfo, err := ob.broker.ListIndexes(ctx, collectionID)
+	if err != nil {
+		mlog.Warn(ctx, "fail to get index info of collection", mlog.Err(err))
+		return false
+	}
+
 	for _, d := range collReadyDelegatorList {
 		updateVersionAction := ob.genSyncAction(ctx, d.View, newVersion)
 		replica := ob.meta.GetByCollectionAndNode(ctx, collectionID, d.Node)
@@ -535,23 +557,8 @@ func (ob *TargetObserver) syncNextTargetToDelegator(ctx context.Context, collect
 			// should not happen, don't update current target if replica not found
 			return false
 		}
-		// init all the meta information
-		if partitions == nil {
-			partitions, err = utils.GetPartitions(ctx, ob.targetMgr, collectionID)
-			if err != nil {
-				mlog.Warn(ctx, "failed to get partitions", mlog.Err(err))
-				return false
-			}
 
-			// Get collection index info
-			indexInfo, err = ob.broker.ListIndexes(ctx, collectionID)
-			if err != nil {
-				mlog.Warn(ctx, "fail to get index info of collection", mlog.Err(err))
-				return false
-			}
-		}
-
-		if !ob.syncToDelegator(ctx, replica, d.View, updateVersionAction, partitions, indexInfo) {
+		if !ob.syncToDelegator(ctx, replica, d.View, updateVersionAction, schema, schemaBarrierTs, partitions, indexInfo) {
 			return false
 		}
 	}
@@ -559,7 +566,7 @@ func (ob *TargetObserver) syncNextTargetToDelegator(ctx context.Context, collect
 }
 
 func (ob *TargetObserver) syncToDelegator(ctx context.Context, replica *meta.Replica, LeaderView *meta.LeaderView, action *querypb.SyncAction,
-	partitions []int64, indexInfo []*indexpb.IndexInfo,
+	schema *schemapb.CollectionSchema, schemaBarrierTs uint64, partitions []int64, indexInfo []*indexpb.IndexInfo,
 ) bool {
 	replicaID := replica.GetID()
 
@@ -577,11 +584,13 @@ func (ob *TargetObserver) syncToDelegator(ctx context.Context, replica *meta.Rep
 		ReplicaID:    replicaID,
 		Channel:      LeaderView.Channel,
 		Actions:      []*querypb.SyncAction{action},
+		Schema:       schema,
 		LoadMeta: &querypb.LoadMetaInfo{
-			LoadType:      ob.meta.GetLoadType(ctx, LeaderView.CollectionID),
-			CollectionID:  LeaderView.CollectionID,
-			PartitionIDs:  partitions,
-			ResourceGroup: replica.GetResourceGroup(),
+			LoadType:        ob.meta.GetLoadType(ctx, LeaderView.CollectionID),
+			CollectionID:    LeaderView.CollectionID,
+			PartitionIDs:    partitions,
+			ResourceGroup:   replica.GetResourceGroup(),
+			SchemaBarrierTs: schemaBarrierTs,
 		},
 		Version:       time.Now().UnixNano(),
 		IndexInfoList: indexInfo,

--- a/internal/querycoordv2/observers/target_observer_test.go
+++ b/internal/querycoordv2/observers/target_observer_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/metastore/kv/querycoord"
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
@@ -539,6 +541,7 @@ func TestShouldUpdateCurrentTarget_ReplicaReadiness(t *testing.T) {
 	targetMgr.EXPECT().GetDmChannelsByCollection(mock.Anything, collectionID, meta.NextTarget).Return(channelNames).Maybe()
 	targetMgr.EXPECT().GetCollectionTargetVersion(mock.Anything, collectionID, meta.NextTarget).Return(newVersion).Maybe()
 	targetMgr.EXPECT().GetSealedSegmentsByCollection(mock.Anything, collectionID, meta.NextTarget).Return(map[int64]*datapb.SegmentInfo{}).Maybe()
+	broker.EXPECT().DescribeCollection(mock.Anything, collectionID).Return(&milvuspb.DescribeCollectionResponse{}, nil).Maybe()
 	broker.EXPECT().ListIndexes(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	cluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
 
@@ -611,6 +614,8 @@ func TestShouldUpdateCurrentTarget_OnlyReadyDelegatorsSynced(t *testing.T) {
 	ctx := context.Background()
 	collectionID := int64(1000)
 	newVersion := int64(100)
+	schemaBarrierTs := uint64(200)
+	schema := &schemapb.CollectionSchema{Version: 1}
 
 	nodeMgr := session.NewNodeManager()
 	nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{NodeID: 1}))
@@ -670,12 +675,18 @@ func TestShouldUpdateCurrentTarget_OnlyReadyDelegatorsSynced(t *testing.T) {
 	targetMgr.EXPECT().GetSealedSegmentsByCollection(mock.Anything, collectionID, meta.NextTarget).Return(targetSegments).Maybe()
 
 	broker.EXPECT().ListIndexes(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+	broker.EXPECT().DescribeCollection(mock.Anything, collectionID).Return(&milvuspb.DescribeCollectionResponse{
+		Schema:          schema,
+		UpdateTimestamp: schemaBarrierTs,
+	}, nil).Once()
 
 	// Track which nodes receive SyncDistribution calls
 	syncedNodes := make([]int64, 0)
 	cluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, nodeID int64, req *querypb.SyncDistributionRequest) (*commonpb.Status, error) {
 			syncedNodes = append(syncedNodes, nodeID)
+			assert.Same(t, schema, req.GetSchema())
+			assert.Equal(t, schemaBarrierTs, req.GetLoadMeta().GetSchemaBarrierTs())
 			return merr.Success(), nil
 		}).Maybe()
 
@@ -818,6 +829,7 @@ func TestShouldUpdateCurrentTarget_AllChannelsSynced(t *testing.T) {
 	// Return segments for CheckSegmentDataReady
 	targetMgr.EXPECT().GetSealedSegmentsByCollection(mock.Anything, collectionID, meta.NextTarget).Return(allSegments).Maybe()
 
+	broker.EXPECT().DescribeCollection(mock.Anything, collectionID).Return(&milvuspb.DescribeCollectionResponse{}, nil).Maybe()
 	broker.EXPECT().ListIndexes(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	cluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
 
@@ -957,6 +969,7 @@ func TestShouldUpdateCurrentTarget_PartialChannelsSynced(t *testing.T) {
 	// Return segments for CheckSegmentDataReady - this will fail since segment distribution is incomplete
 	targetMgr.EXPECT().GetSealedSegmentsByCollection(mock.Anything, collectionID, meta.NextTarget).Return(allSegments).Maybe()
 
+	broker.EXPECT().DescribeCollection(mock.Anything, collectionID).Return(&milvuspb.DescribeCollectionResponse{}, nil).Maybe()
 	broker.EXPECT().ListIndexes(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	cluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
 
@@ -1065,6 +1078,7 @@ func TestShouldUpdateCurrentTarget_NoReadyDelegators(t *testing.T) {
 	// Return segments for CheckSegmentDataReady - this will fail since no segment in distribution
 	targetMgr.EXPECT().GetSealedSegmentsByCollection(mock.Anything, collectionID, meta.NextTarget).Return(targetSegments).Maybe()
 
+	broker.EXPECT().DescribeCollection(mock.Anything, collectionID).Return(&milvuspb.DescribeCollectionResponse{}, nil).Maybe()
 	broker.EXPECT().ListIndexes(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
 	cluster.EXPECT().SyncDistribution(mock.Anything, mock.Anything, mock.Anything).Return(merr.Success(), nil).Maybe()
 

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -70,6 +70,12 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
+const (
+	updateSchemaWorkerRetryCount          = 5
+	updateSchemaWorkerRetryInitialBackoff = 500 * time.Millisecond
+	updateSchemaWorkerRetryMaxBackoff     = time.Minute
+)
+
 // ShardDelegator is the interface definition.
 type ShardDelegator interface {
 	Collection() int64
@@ -168,6 +174,11 @@ type shardDelegator struct {
 	// schemaBarrierTs fences load results started before the latest schema update.
 	schemaChangeMutex sync.RWMutex
 	schemaBarrierTs   uint64
+	// collectionVersion is the collection schema version applied to this delegator's
+	// channel-local FunctionRunner and IDF runtime.
+	collectionVersion atomic.Uint64
+	// bm25Functions is the BM25 function set applied to the channel-local IDF runtime.
+	bm25Functions bm25FunctionSet
 
 	// limits delegator-side post-load work after worker LoadSegments returns.
 	postLoadSem           *syncutil.Semaphore
@@ -209,6 +220,79 @@ func (sd *shardDelegator) getIDFOracle() IDFOracle {
 
 func (sd *shardDelegator) publishIDFOracle(idfOracle IDFOracle) {
 	sd.idfOracle.Store(&idfOracleHolder{oracle: idfOracle})
+}
+
+// UpdateDelegatorSchema synchronizes this delegator's channel-local FunctionRunner,
+// IDF runtime, schema version, and load barrier with the shared Collection snapshot.
+func (sd *shardDelegator) UpdateDelegatorSchema(ctx context.Context) error {
+	if err := sd.lifetime.Add(sd.NotStopped); err != nil {
+		return err
+	}
+	defer sd.lifetime.Done()
+
+	_, collectionVersion, schemaBarrierTs := sd.collection.SchemaSnapshot()
+	sd.schemaChangeMutex.RLock()
+	upToDate := sd.collectionVersion.Load() >= collectionVersion && sd.schemaBarrierTs >= schemaBarrierTs
+	sd.schemaChangeMutex.RUnlock()
+	if upToDate {
+		return nil
+	}
+
+	sd.schemaChangeMutex.Lock()
+	defer sd.schemaChangeMutex.Unlock()
+
+	return sd.updateDelegatorSchemaLocked(ctx)
+}
+
+// updateDelegatorSchemaLocked requires schemaChangeMutex to be held for writing.
+func (sd *shardDelegator) updateDelegatorSchemaLocked(ctx context.Context) error {
+	schema, collectionVersion, schemaBarrierTs := sd.collection.SchemaSnapshot()
+	currentVersion := sd.collectionVersion.Load()
+	if currentVersion > collectionVersion {
+		return nil
+	}
+	if currentVersion == collectionVersion {
+		if sd.schemaBarrierTs < schemaBarrierTs {
+			sd.schemaBarrierTs = schemaBarrierTs
+		}
+		return nil
+	}
+
+	newSet := newBM25FunctionSet(schema)
+	if newSet.HasIncompatibleCommonFunction(sd.bm25Functions) {
+		return merr.WrapErrServiceInternal("unsupported incompatible BM25 function schema change on loaded collection")
+	}
+	if err := function.GetManager().Update(sd.collectionID, delegatorFunctionRunnerKey(sd.vchannelName), schema); err != nil {
+		return err
+	}
+
+	idfOracle := sd.getIDFOracle()
+	if idfOracle == nil {
+		if len(newSet) > 0 {
+			idfOracle = NewIDFOracle(sd.vchannelName, schema.GetFunctions())
+			idfOracle.Start()
+			sd.distribution.SetIDFOracle(idfOracle)
+			if current := sd.distribution.current.Load(); current != nil {
+				idfOracle.SetNext(current)
+			}
+			sd.publishIDFOracle(idfOracle)
+		}
+	} else if !newSet.Equal(sd.bm25Functions) {
+		if err := idfOracle.SyncFunctions(schema.GetFunctions()); err != nil {
+			return err
+		}
+	}
+
+	sd.bm25Functions = newSet
+	sd.collectionVersion.Store(collectionVersion)
+	if sd.schemaBarrierTs < schemaBarrierTs {
+		sd.schemaBarrierTs = schemaBarrierTs
+	}
+	sd.getLogger(ctx).Info(ctx, "delegator runtime schema updated",
+		mlog.Uint64("schemaVersion", collectionVersion),
+		mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
+	)
+	return nil
 }
 
 func (sd *shardDelegator) NotStopped(state lifetime.State) error {
@@ -1257,20 +1341,7 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 			mlog.Uint64("schemaVersion", schemaVersion),
 			mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
 		)
-		return nil
-	}
-	oldSet := newBM25FunctionSet(sd.collection.Schema())
-	newSet := newBM25FunctionSet(schema)
-	idfOracle := sd.getIDFOracle()
-	if idfOracle != nil && newSet.HasIncompatibleCommonFunction(oldSet) {
-		return merr.WrapErrServiceInternal("unsupported incompatible BM25 function schema change on loaded collection")
-	}
-
-	// Keep the load barrier monotonic. A higher logical schema version can be
-	// replayed with a smaller barrier than an earlier same-version property
-	// refresh, but that must not reopen older load results.
-	if sd.schemaBarrierTs < schemaBarrierTs {
-		sd.schemaBarrierTs = schemaBarrierTs
+		return sd.updateDelegatorSchemaLocked(ctx)
 	}
 
 	sealed, growing, version := sd.distribution.PinOnlineSegments()
@@ -1306,8 +1377,17 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 	}
 
 	_, err = executeSubTasks(ctx, tasks, nil, func(ctx context.Context, req *querypb.UpdateSchemaRequest, worker cluster.Worker) (*StatusWrapper, error) {
-		ctx = retry.WithMaxAttemptsContext(ctx, 1)
-		status, err := worker.UpdateSchema(ctx, req)
+		var status *commonpb.Status
+		err := retry.Do(ctx, func() error {
+			rpcCtx := retry.WithMaxAttemptsContext(ctx, 1)
+			var err error
+			status, err = worker.UpdateSchema(rpcCtx, req)
+			return merr.CheckRPCCall(status, err)
+		},
+			retry.Attempts(updateSchemaWorkerRetryCount+1),
+			retry.Sleep(updateSchemaWorkerRetryInitialBackoff),
+			retry.MaxSleepTime(updateSchemaWorkerRetryMaxBackoff),
+		)
 		return (*StatusWrapper)(status), err
 	}, "UpdateSchema", log)
 	if err != nil {
@@ -1319,36 +1399,16 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 	if err := sd.collectionManager.UpdateSchema(sd.collectionID, schema, schemaBarrierTs); err != nil {
 		return err
 	}
+	if err := sd.updateDelegatorSchemaLocked(ctx); err != nil {
+		return err
+	}
 
-	// Publish the manager schema after the delegator schema update. Queries use
-	// the previous function schema until this point.
-	if err := function.GetManager().Update(sd.collectionID, delegatorFunctionRunnerKey(sd.vchannelName), schema); err != nil {
-		// Runner construction failures are retried asynchronously by the manager.
-		// A synchronous error here means the internal function metadata is invalid.
-		panic(err)
-	}
-	if idfOracle == nil && len(newSet) > 0 {
-		// StreamingNode schema changes flush and fence old growings before UpdateSchema and new-schema inserts.
-		// Old growings cannot receive stats for newly added BM25 fields; ProcessInsert registers only new growings.
-		idfOracle = NewIDFOracle(sd.vchannelName, schema.GetFunctions())
-		idfOracle.Start()
-		sd.distribution.SetIDFOracle(idfOracle)
-		if current := sd.distribution.current.Load(); current != nil {
-			idfOracle.SetNext(current)
-		}
-		sd.publishIDFOracle(idfOracle)
-	} else if idfOracle != nil && !newSet.Equal(oldSet) {
-		if err := idfOracle.SyncFunctions(schema.GetFunctions()); err != nil {
-			return err
-		}
-	}
 	mlog.Info(ctx, "delegator finished update schema event",
 		mlog.Uint64("schemaVersion", schemaVersion),
 		mlog.Uint64("schemaBarrierTs", schemaBarrierTs),
-		mlog.Uint64("loadBarrierTs", sd.schemaBarrierTs),
 		mlog.Int("sealedNum", len(sealed)),
 		mlog.Int("growingNum", len(growing)),
-		mlog.Int("bm25FunctionNum", len(newSet)),
+		mlog.Int("bm25FunctionNum", len(newBM25FunctionSet(schema))),
 	)
 	return nil
 }
@@ -1464,11 +1524,12 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	if collection == nil {
 		return nil, merr.WrapErrCollectionNotFound(collectionID, "not in delegator manager")
 	}
-	if err := function.GetManager().Alloc(collectionID, delegatorFunctionRunnerKey(channel), collection.Schema()); err != nil {
+	schema, schemaVersion, schemaBarrierTs := collection.SchemaSnapshot()
+	if err := function.GetManager().Alloc(collectionID, delegatorFunctionRunnerKey(channel), schema); err != nil {
 		return nil, err
 	}
 
-	skipStreamingForExternalTable := typeutil.IsExternalCollection(collection.Schema())
+	skipStreamingForExternalTable := typeutil.IsExternalCollection(schema)
 	catchingUpStreamingData := !skipStreamingForExternalTable
 	if skipStreamingForExternalTable {
 		log.Info(ctx, "skip streaming data catchup for read-only external collection",
@@ -1516,18 +1577,17 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		catchingUpStreamingData:       atomic.NewBool(catchingUpStreamingData),
 		skipStreamingForExternalTable: skipStreamingForExternalTable,
 		latestRequiredMVCCTimeTick:    atomic.NewUint64(0),
+		schemaBarrierTs:               schemaBarrierTs,
 	}
+	sd.bm25Functions = newBM25FunctionSet(schema)
 
-	hasBM25Field := lo.ContainsBy(collection.Schema().GetFunctions(), func(tf *schemapb.FunctionSchema) bool {
-		return tf.GetType() == schemapb.FunctionType_BM25
-	})
-
-	if hasBM25Field {
-		idfOracle := NewIDFOracle(sd.vchannelName, collection.Schema().GetFunctions())
+	if len(sd.bm25Functions) > 0 {
+		idfOracle := NewIDFOracle(sd.vchannelName, schema.GetFunctions())
 		idfOracle.Start()
 		sd.distribution.SetIDFOracle(idfOracle)
 		sd.publishIDFOracle(idfOracle)
 	}
+	sd.collectionVersion.Store(schemaVersion)
 
 	// Register growing-source segments as optional local flush sources. Metadata
 	// commit is still owned by WAL flusher / WriteBuffer.

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -59,7 +59,13 @@ import (
 
 // delegator data related part
 
-const defaultAnalyzerName = "default"
+const (
+	defaultAnalyzerName = "default"
+
+	reopenBM25LoadRetryCount          = 5
+	reopenBM25LoadRetryInitialBackoff = 200 * time.Millisecond
+	reopenBM25LoadRetryMaxBackoff     = time.Minute
+)
 
 func normalizeAnalyzerNames(analyzerNames []string, textNum int) ([]string, error) {
 	if textNum == 0 {
@@ -562,8 +568,17 @@ func (sd *shardDelegator) loadBM25StatsForReopen(ctx context.Context, infos []*q
 	for _, info := range infos {
 		info := info
 		futures = append(futures, pool.Submit(func() (any, error) {
-			activateIfReadable := sd.distribution.IsReadableSealedSegment(info.GetSegmentID())
-			if err := idfOracle.LoadSealedForReopen(ctx, info.GetSegmentID(), info, cm, activateIfReadable); err != nil {
+			var activateIfReadable bool
+			err := retry.Do(ctx, func() error {
+				activateIfReadable = sd.distribution.IsReadableSealedSegment(info.GetSegmentID())
+				return idfOracle.LoadSealedForReopen(ctx, info.GetSegmentID(), info, cm, activateIfReadable)
+			},
+				retry.Attempts(reopenBM25LoadRetryCount+1),
+				retry.Sleep(reopenBM25LoadRetryInitialBackoff),
+				retry.MaxSleepTime(reopenBM25LoadRetryMaxBackoff),
+				retry.RetryErr(merr.IsRetryableErr),
+			)
+			if err != nil {
 				mlog.Warn(ctx, "failed to load reopened bm25 stats for segment",
 					mlog.FieldCollectionID(req.GetCollectionID()),
 					mlog.FieldSegmentID(info.GetSegmentID()),
@@ -582,32 +597,33 @@ func (sd *shardDelegator) loadBM25StatsForReopen(ctx context.Context, infos []*q
 	return nil
 }
 
-// syncCollectionIndexMeta refreshes the delegator node's CCollection IndexMeta after a
-// forwarded worker load. Worker LoadSegments already updates IndexMeta on the target
-// worker, but the delegator (which executes growing search locally) must stay in sync.
-func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
-	if len(req.GetIndexInfoList()) == 0 {
-		return nil
-	}
-
-	schema := req.GetSchema()
-	if schema == nil {
-		schema = sd.collection.Schema()
-	}
-
-	loadMeta := req.GetLoadMeta()
-	if loadMeta == nil {
-		loadMeta = &querypb.LoadMetaInfo{
-			CollectionID: req.GetCollectionID(),
+// syncCollectionMeta refreshes the delegator node's CCollection IndexMeta and
+// channel-local function runtime after a forwarded worker load. Worker LoadSegments
+// already updates IndexMeta on the target worker, but the delegator must stay in sync.
+func (sd *shardDelegator) syncCollectionMeta(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	if len(req.GetIndexInfoList()) > 0 {
+		schema := req.GetSchema()
+		if schema == nil {
+			schema = sd.collection.Schema()
 		}
+
+		loadMeta := req.GetLoadMeta()
+		if loadMeta == nil {
+			loadMeta = &querypb.LoadMetaInfo{
+				CollectionID: req.GetCollectionID(),
+			}
+		}
+
+		meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), schema)
+		if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
+			return err
+		}
+		sd.collectionManager.Unref(req.GetCollectionID(), 1)
 	}
 
-	meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), schema)
-	if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
-		return err
-	}
-	sd.collectionManager.Unref(req.GetCollectionID(), 1)
-	return function.GetManager().Update(sd.collectionID, delegatorFunctionRunnerKey(sd.vchannelName), schema)
+	// Reopen and concurrent loads also provide a deterministic catch-up point when
+	// another channel has already advanced the shared Collection schema.
+	return sd.UpdateDelegatorSchema(ctx)
 }
 
 // LoadSegments load segments local or remotely depends on the target node.
@@ -687,8 +703,8 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	}
 	log.Debug(ctx, "work loads segments done")
 
-	if err := sd.syncCollectionIndexMeta(ctx, req); err != nil {
-		log.Warn(ctx, "failed to sync collection index meta on delegator", mlog.Err(err))
+	if err := sd.syncCollectionMeta(ctx, req); err != nil {
+		log.Warn(ctx, "failed to sync collection metadata on delegator", mlog.Err(err))
 		return err
 	}
 

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -63,7 +63,6 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/metric"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
-	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -186,7 +185,7 @@ func (s *DelegatorDataSuite) genNormalCollection() {
 	}, &querypb.LoadMetaInfo{
 		LoadType:        querypb.LoadType_LoadCollection,
 		PartitionIDs:    []int64{1001, 1002},
-		SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now()),
+		SchemaBarrierTs: 0,
 	})
 }
 
@@ -220,7 +219,7 @@ func (s *DelegatorDataSuite) genTextCollection() {
 	}, nil, &querypb.LoadMetaInfo{
 		LoadType:        querypb.LoadType_LoadCollection,
 		PartitionIDs:    []int64{1001},
-		SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now()),
+		SchemaBarrierTs: 0,
 	})
 }
 
@@ -257,7 +256,7 @@ func (s *DelegatorDataSuite) genCollectionWithFunction() {
 			InputFieldIds:  []int64{102},
 			OutputFieldIds: []int64{101},
 		}},
-	}, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: tsoutil.ComposeTSByTime(time.Now())})
+	}, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: 0})
 
 	delegator, err := NewShardDelegator(context.Background(), s.collectionID, s.replicaID, s.vchannelName, s.version, s.workerManager, s.manager, s.loader, 10000, nil, s.chunkManager, NewChannelQueryView(nil, nil, nil, initialTargetVersion), nil)
 	s.NoError(err)
@@ -808,6 +807,104 @@ func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25Stats() {
 	s.Empty(sealed)
 }
 
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsRetriesTransientFailure() {
+	s.genCollectionWithFunction()
+
+	remotePath := "bm25stats/reopen-retry/segment_100/field_101/0"
+	stats := storage.NewBM25Stats()
+	for i := uint32(1); i < 4; i++ {
+		stats.Append(map[uint32]float32{i: 1})
+	}
+	data, err := stats.Serialize()
+	s.Require().NoError(err)
+
+	cm := mocks.NewChunkManager(s.T())
+	cm.EXPECT().Reader(mock.Anything, remotePath).
+		Run(func(context.Context, string) {
+			s.delegator.distribution.AddDistributions(SegmentEntry{
+				NodeID:      1,
+				SegmentID:   100,
+				PartitionID: 500,
+				Version:     1,
+				Level:       datapb.SegmentLevel_L1,
+			})
+			s.delegator.distribution.SyncTargetVersion(&querypb.SyncAction{
+				TargetVersion:         1,
+				SealedInTarget:        []int64{100},
+				SealedSegmentRowCount: map[int64]int64{100: 3},
+			}, []int64{500})
+		}).
+		Return(nil, merr.WrapErrIoTooManyRequests(remotePath, errors.New("storage throttled"))).Once()
+	cm.EXPECT().Reader(mock.Anything, remotePath).
+		Return(&bytesFileReader{bytes.NewReader(data)}, nil).Once()
+	s.loader.EXPECT().GetChunkManager().Return(cm)
+
+	worker1 := &cluster.MockWorker{}
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+
+	err = s.delegator.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+				Bm25Logs:      bm25LogsForField(101, remotePath),
+			},
+		},
+	})
+
+	s.NoError(err)
+	loadedStats := s.getIDFOracleForTest()
+	segStats, ok := loadedStats.sealed.Get(100)
+	s.True(ok)
+	s.True(segStats.HasField(101))
+	fieldStats, err := loadedStats.current.GetStats(101)
+	s.NoError(err)
+	s.Equal(int64(3), fieldStats.NumRow())
+}
+
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsDoesNotRetryPermanentFailure() {
+	s.genCollectionWithFunction()
+
+	remotePath := "bm25stats/reopen-missing/segment_100/field_101/0"
+	cm := mocks.NewChunkManager(s.T())
+	cm.EXPECT().Reader(mock.Anything, remotePath).
+		Return(nil, merr.WrapErrIoKeyNotFound(remotePath)).Once()
+	s.loader.EXPECT().GetChunkManager().Return(cm)
+
+	worker1 := &cluster.MockWorker{}
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil).Once()
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+
+	err := s.delegator.LoadSegments(context.Background(), &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+				Bm25Logs:      bm25LogsForField(101, remotePath),
+			},
+		},
+	})
+
+	s.ErrorIs(err, merr.ErrIoKeyNotFound)
+}
+
 func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsMergesReadableSegment() {
 	s.genCollectionWithFunction()
 	s.delegator.distribution.AddDistributions(SegmentEntry{
@@ -1219,17 +1316,21 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 	})
 }
 
-func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaUpdatesFunctionRunners() {
+func (s *DelegatorDataSuite) TestSyncCollectionMetaUpdatesFunctionRunners() {
 	ctx := context.Background()
 	s.delegator.Start()
 	schema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
-	err := s.delegator.syncCollectionIndexMeta(ctx, &querypb.LoadSegmentsRequest{
+	s.Require().Nil(s.delegator.getIDFOracle())
+	err := s.delegator.syncCollectionMeta(ctx, &querypb.LoadSegmentsRequest{
 		CollectionID:  s.collectionID,
 		Schema:        schema,
 		LoadMeta:      &querypb.LoadMetaInfo{SchemaBarrierTs: 1},
 		IndexInfoList: mock_segcore.GenTestIndexInfoList(s.collectionID, schema),
 	})
 	s.Require().NoError(err)
+	s.Equal(uint64(1), s.delegator.collectionVersion.Load())
+	s.Equal(uint64(1), s.delegator.schemaBarrierTs)
+	s.Require().NotNil(s.delegator.getIDFOracle())
 
 	// The load path has already advanced the collection snapshot, so the DDL
 	// event is skipped as a no-op. The function runner key must still point at
@@ -1240,6 +1341,19 @@ func (s *DelegatorDataSuite) TestSyncCollectionIndexMetaUpdatesFunctionRunners()
 	})
 	s.Require().NoError(err)
 	s.True(ok)
+}
+
+func (s *DelegatorDataSuite) TestSyncCollectionMetaWithoutIndexInfoUpdatesDelegatorSchema() {
+	ctx := context.Background()
+	s.delegator.Start()
+	schema := proto.Clone(s.delegator.collection.Schema()).(*schemapb.CollectionSchema)
+	schema.Version = 1
+	s.Require().NoError(s.manager.Collection.PutOrRef(s.collectionID, schema, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: 100}))
+	s.manager.Collection.Unref(s.collectionID, 1)
+
+	s.Require().NoError(s.delegator.syncCollectionMeta(ctx, &querypb.LoadSegmentsRequest{CollectionID: s.collectionID}))
+	s.Equal(uint64(1), s.delegator.collectionVersion.Load())
+	s.Equal(uint64(100), s.delegator.schemaBarrierTs)
 }
 
 func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -1478,7 +1478,35 @@ func (s *DelegatorSuite) TestUpdateSchema() {
 		s.NoError(err)
 	})
 
-	s.Run("worker_return_error", func() {
+	s.Run("worker_retry", func() {
+		workers := make(map[int64]*cluster.MockWorker)
+		worker1 := cluster.NewMockWorker(s.T())
+		worker2 := cluster.NewMockWorker(s.T())
+		worker1Calls := atomic.NewInt32(0)
+
+		workers[1] = worker1
+		workers[2] = worker2
+
+		worker1.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).RunAndReturn(func(ctx context.Context, usr *querypb.UpdateSchemaRequest) (*commonpb.Status, error) {
+			if worker1Calls.Inc() == 1 {
+				err := merr.WrapErrServiceUnavailableMsg("mocked")
+				return merr.Status(err), err
+			}
+			return merr.Success(), nil
+		}).Times(3)
+
+		worker2.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Success(), nil).Once()
+
+		s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Call.Return(func(_ context.Context, nodeID int64) cluster.Worker {
+			return workers[nodeID]
+		}, nil).Times(3)
+
+		err := s.delegator.UpdateSchema(context.Background(), newFunctionRuntimeTestSchemaWithVersion(s.nextSchemaVersion()), 100)
+		s.NoError(err)
+		s.Equal(int32(3), worker1Calls.Load())
+	})
+
+	s.Run("worker_return_non_retryable_error", func() {
 		workers := make(map[int64]*cluster.MockWorker)
 		worker1 := cluster.NewMockWorker(s.T())
 		worker2 := cluster.NewMockWorker(s.T())
@@ -1487,7 +1515,8 @@ func (s *DelegatorSuite) TestUpdateSchema() {
 		workers[2] = worker2
 
 		worker1.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).RunAndReturn(func(ctx context.Context, usr *querypb.UpdateSchemaRequest) (*commonpb.Status, error) {
-			return merr.Status(merr.WrapErrServiceInternal("mocked")), merr.WrapErrServiceInternal("mocked")
+			err := merr.WrapErrParameterInvalidMsg("mocked")
+			return merr.Status(err), err
 		}).Maybe()
 
 		worker2.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).RunAndReturn(func(ctx context.Context, usr *querypb.UpdateSchemaRequest) (*commonpb.Status, error) {
@@ -2342,10 +2371,9 @@ func TestBM25FunctionSetNormalizesFunctionParamOrder(t *testing.T) {
 	assert.True(t, changed.IsSupersetOf(base))
 }
 
-func TestUpdateSchemaRejectsIncompatibleBM25FunctionChange(t *testing.T) {
+func TestUpdateDelegatorSchemaRejectsIncompatibleBM25FunctionChange(t *testing.T) {
 	paramtable.Init()
 	paramtable.SetNodeID(1)
-	workerManager := cluster.NewMockManager(t)
 	oldSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema())
 	oldOracle := NewIDFOracle("test-channel", oldSchema.GetFunctions())
 	sd := &shardDelegator{
@@ -2354,20 +2382,22 @@ func TestUpdateSchemaRejectsIncompatibleBM25FunctionChange(t *testing.T) {
 		collection:                 segments.NewCollectionWithoutSegcoreForTest(1000, oldSchema),
 		lifetime:                   lifetime.NewLifetime(lifetime.Working),
 		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
-		workerManager:              workerManager,
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
 		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+		bm25Functions:              newBM25FunctionSet(oldSchema),
 	}
 	sd.publishIDFOracle(oldOracle)
 	defer sd.Close()
 
 	changed := proto.Clone(newBM25FunctionSchema()).(*schemapb.FunctionSchema)
 	changed.InputFieldIds = []int64{103}
-	err := sd.UpdateSchema(context.Background(), newFunctionRuntimeTestSchemaWithVersion(1, changed), 100)
+	sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, newFunctionRuntimeTestSchemaWithVersion(1, changed))
+	err := sd.UpdateDelegatorSchema(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported incompatible BM25 function schema change")
 	assert.Same(t, oldOracle, sd.getIDFOracle())
+	assert.Equal(t, uint64(0), sd.collectionVersion.Load())
 }
 
 func TestUpdateSchemaSyncsAdditiveIDFOracleFunctions(t *testing.T) {
@@ -2395,7 +2425,9 @@ func TestUpdateSchemaSyncsAdditiveIDFOracleFunctions(t *testing.T) {
 
 	newSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema(), newAdditionalBM25FunctionSchema())
 	collectionManager := segments.NewMockCollectionManager(t)
-	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Return(nil).Once()
+	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Run(func(int64, *schemapb.CollectionSchema, uint64) {
+		sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, newSchema)
+	}).Return(nil).Once()
 	sd.collectionManager = collectionManager
 
 	err := sd.UpdateSchema(context.Background(), newSchema, 100)
@@ -2409,7 +2441,8 @@ func TestUpdateSchemaDoesNotSyncIDFOracleWhenWorkerUpdateFails(t *testing.T) {
 	paramtable.Init()
 	paramtable.SetNodeID(1)
 	worker := cluster.NewMockWorker(t)
-	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Status(merr.WrapErrServiceInternal("mocked")), merr.WrapErrServiceInternal("mocked")).Once()
+	workerErr := merr.WrapErrParameterInvalidMsg("mocked")
+	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Status(workerErr), workerErr).Once()
 	workerManager := cluster.NewMockManager(t)
 	workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
 	oldSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema())
@@ -2459,7 +2492,9 @@ func TestUpdateSchemaInitializesIDFOracleWhenBM25Added(t *testing.T) {
 
 	newSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
 	collectionManager := segments.NewMockCollectionManager(t)
-	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Return(nil).Once()
+	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Run(func(int64, *schemapb.CollectionSchema, uint64) {
+		sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, newSchema)
+	}).Return(nil).Once()
 	sd.collectionManager = collectionManager
 
 	err := sd.UpdateSchema(context.Background(), newSchema, 100)
@@ -2470,44 +2505,39 @@ func TestUpdateSchemaInitializesIDFOracleWhenBM25Added(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestUpdateSchemaRefreshesCollectionBaselineForSequentialBM25Validation(t *testing.T) {
+func TestUpdateDelegatorSchemaUsesAppliedBM25FunctionsForValidation(t *testing.T) {
 	paramtable.Init()
 	paramtable.SetNodeID(1)
-	manager := segments.NewManager()
 	oldSchema := newFunctionRuntimeTestSchema()
-	require.NoError(t, manager.Collection.PutOrRef(1000, oldSchema, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: 1}))
-	defer manager.Collection.Unref(1000, 1)
-
-	worker := cluster.NewMockWorker(t)
-	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Success(), nil).Once()
-	workerManager := cluster.NewMockManager(t)
-	workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+	key := delegatorFunctionRunnerKey("test-channel")
+	require.NoError(t, function.GetManager().Alloc(1000, key, oldSchema))
 
 	sd := &shardDelegator{
 		collectionID:               1000,
 		vchannelName:               "test-channel",
-		collection:                 manager.Collection.Get(1000),
-		collectionManager:          manager.Collection,
+		collection:                 segments.NewCollectionWithoutSegcoreForTest(1000, oldSchema),
 		lifetime:                   lifetime.NewLifetime(lifetime.Working),
 		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
-		workerManager:              workerManager,
 		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
 		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+		bm25Functions:              newBM25FunctionSet(oldSchema),
 	}
 	defer sd.Close()
 
 	firstSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
-	err := sd.UpdateSchema(context.Background(), firstSchema, 100)
+	sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, firstSchema)
+	err := sd.UpdateDelegatorSchema(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), sd.collection.SchemaVersion())
+	require.Equal(t, uint64(1), sd.collectionVersion.Load())
 
 	changed := proto.Clone(newBM25FunctionSchema()).(*schemapb.FunctionSchema)
 	changed.InputFieldIds = []int64{103}
-	err = sd.UpdateSchema(context.Background(), newFunctionRuntimeTestSchemaWithVersion(2, changed), 200)
+	sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, newFunctionRuntimeTestSchemaWithVersion(2, changed))
+	err = sd.UpdateDelegatorSchema(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported incompatible BM25 function schema change")
-	require.Equal(t, uint64(1), sd.collection.SchemaVersion())
+	require.Equal(t, uint64(1), sd.collectionVersion.Load())
 }
 
 func TestUpdateSchemaSyncsFunctionRunnerMetadata(t *testing.T) {
@@ -2537,7 +2567,9 @@ func TestUpdateSchemaSyncsFunctionRunnerMetadata(t *testing.T) {
 
 	newSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema(), newMinHashFunctionSchema())
 	collectionManager := segments.NewMockCollectionManager(t)
-	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Return(nil).Once()
+	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Run(func(int64, *schemapb.CollectionSchema, uint64) {
+		sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, newSchema)
+	}).Return(nil).Once()
 	sd.collectionManager = collectionManager
 
 	err := sd.UpdateSchema(context.Background(), newSchema, 100)
@@ -2562,7 +2594,7 @@ func TestUpdateSchemaSyncsFunctionRunnerMetadata(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestUpdateSchemaPanicsOnInvalidFunctionMetadata(t *testing.T) {
+func TestUpdateSchemaReturnsInvalidFunctionMetadata(t *testing.T) {
 	paramtable.Init()
 	paramtable.SetNodeID(1)
 	key := delegatorFunctionRunnerKey("test-channel")
@@ -2591,14 +2623,146 @@ func TestUpdateSchemaPanicsOnInvalidFunctionMetadata(t *testing.T) {
 	invalidFunction.OutputFieldIds = []int64{999}
 	invalidSchema := newFunctionRuntimeTestSchemaWithVersion(1, invalidFunction)
 	collectionManager := segments.NewMockCollectionManager(t)
-	collectionManager.EXPECT().UpdateSchema(int64(1000), invalidSchema, uint64(100)).Return(nil).Once()
+	collectionManager.EXPECT().UpdateSchema(int64(1000), invalidSchema, uint64(100)).Run(func(int64, *schemapb.CollectionSchema, uint64) {
+		sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, invalidSchema)
+	}).Return(nil).Once()
 	sd.collectionManager = collectionManager
 
 	_, expectedErr := function.EmbeddingOutputFieldIDs(invalidSchema)
 	require.Error(t, expectedErr)
-	require.PanicsWithError(t, expectedErr.Error(), func() {
-		_ = sd.UpdateSchema(context.Background(), invalidSchema, 100)
+	err := sd.UpdateSchema(context.Background(), invalidSchema, 100)
+	require.EqualError(t, err, expectedErr.Error())
+	require.Equal(t, uint64(0), sd.collectionVersion.Load())
+
+	validSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
+	sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, validSchema)
+	require.NoError(t, sd.UpdateDelegatorSchema(context.Background()))
+	require.Equal(t, uint64(1), sd.collectionVersion.Load())
+	require.NotNil(t, sd.getIDFOracle())
+}
+
+func TestUpdateSchemaUpdatesDelegatorRuntimeAfterCollectionAdvanced(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+	manager := segments.NewManager()
+	oldSchema := newFunctionRuntimeTestSchema()
+	require.NoError(t, manager.Collection.PutOrRef(1000, oldSchema, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: 1}))
+	defer manager.Collection.Unref(1000, 1)
+
+	key := delegatorFunctionRunnerKey("test-channel")
+	require.NoError(t, function.GetManager().Alloc(1000, key, oldSchema))
+
+	sd := &shardDelegator{
+		collectionID:               1000,
+		vchannelName:               "test-channel",
+		collection:                 manager.Collection.Get(1000),
+		collectionManager:          manager.Collection,
+		lifetime:                   lifetime.NewLifetime(lifetime.Working),
+		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		workerManager:              cluster.NewMockManager(t),
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+	}
+	defer sd.Close()
+
+	newSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
+	require.NoError(t, manager.Collection.PutOrRef(1000, newSchema, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: 100}))
+	manager.Collection.Unref(1000, 1)
+	require.Equal(t, uint64(0), sd.collectionVersion.Load())
+	require.Nil(t, sd.getIDFOracle())
+
+	require.NoError(t, sd.UpdateSchema(context.Background(), newSchema, 100))
+	require.Equal(t, uint64(1), sd.collectionVersion.Load())
+	require.Equal(t, uint64(100), sd.schemaBarrierTs)
+	require.Error(t, sd.addDistributionIfSchemaBarrierOK(99))
+	require.NotNil(t, sd.getIDFOracle())
+	ok, err := function.GetManager().RunWithRunner(context.Background(), 1000, key, 102, func(function.FunctionRunner) error {
+		return nil
 	})
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestUpdateDelegatorSchemaSerializesConcurrentUpdates(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+	oldSchema := newFunctionRuntimeTestSchema()
+	key := delegatorFunctionRunnerKey("test-channel")
+	require.NoError(t, function.GetManager().Alloc(1000, key, oldSchema))
+
+	sd := &shardDelegator{
+		collectionID:               1000,
+		vchannelName:               "test-channel",
+		collection:                 segments.NewCollectionWithoutSegcoreForTest(1000, oldSchema),
+		lifetime:                   lifetime.NewLifetime(lifetime.Working),
+		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+	}
+	defer sd.Close()
+
+	var publishCount atomic.Int32
+	patch := mockey.Mock((*shardDelegator).publishIDFOracle).To(func(sd *shardDelegator, oracle IDFOracle) {
+		publishCount.Inc()
+		sd.idfOracle.Store(&idfOracleHolder{oracle: oracle})
+	}).Build()
+	defer patch.UnPatch()
+
+	newSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
+	sd.collection = segments.NewCollectionWithoutSegcoreForTest(1000, newSchema)
+	const concurrency = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, concurrency)
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- sd.UpdateDelegatorSchema(context.Background())
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, int32(1), publishCount.Load())
+	require.Equal(t, uint64(1), sd.collectionVersion.Load())
+	require.NotNil(t, sd.getIDFOracle())
+}
+
+func TestUpdateDelegatorSchemaAdvancesBarrierForSameVersion(t *testing.T) {
+	paramtable.Init()
+	manager := segments.NewManager()
+	oldSchema := newFunctionRuntimeTestSchemaWithVersion(1, newBM25FunctionSchema())
+	changedFunction := proto.Clone(newBM25FunctionSchema()).(*schemapb.FunctionSchema)
+	changedFunction.InputFieldIds = []int64{103}
+	changedSchema := newFunctionRuntimeTestSchemaWithVersion(1, changedFunction)
+	require.NoError(t, manager.Collection.PutOrRef(1000, changedSchema, nil, &querypb.LoadMetaInfo{SchemaBarrierTs: 100}))
+	defer manager.Collection.Unref(1000, 1)
+
+	sd := &shardDelegator{
+		collectionID:               1000,
+		vchannelName:               "test-channel",
+		collection:                 manager.Collection.Get(1000),
+		lifetime:                   lifetime.NewLifetime(lifetime.Working),
+		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+		schemaBarrierTs:            10,
+		bm25Functions:              newBM25FunctionSet(oldSchema),
+	}
+	sd.collectionVersion.Store(1)
+	defer sd.Close()
+
+	require.NoError(t, sd.UpdateDelegatorSchema(context.Background()))
+	require.Equal(t, uint64(1), sd.collectionVersion.Load())
+	require.Equal(t, uint64(100), sd.schemaBarrierTs)
+	require.Nil(t, sd.getIDFOracle())
+	require.True(t, sd.bm25Functions.Equal(newBM25FunctionSet(oldSchema)))
 }
 
 func TestUpdateSchemaSkipsStaleSchemaBeforeSideEffects(t *testing.T) {

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -95,12 +95,7 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 	if nodeMsg.schema != nil {
 		ctx := context.TODO()
 		if err := dNode.delegator.UpdateSchema(ctx, nodeMsg.schema, nodeMsg.schemaBarrierTs); err != nil {
-			mlog.Warn(ctx, "failed to update schema in delete node",
-				mlog.Int64("collectionID", dNode.collectionID),
-				mlog.String("channel", dNode.channel),
-				mlog.Int32("schemaVersion", nodeMsg.schema.GetVersion()),
-				mlog.Uint64("schemaBarrierTs", nodeMsg.schemaBarrierTs),
-				mlog.Err(err))
+			panic(err)
 		}
 	}
 

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -149,7 +149,7 @@ func (suite *DeleteNodeSuite) TestProcessDeleteBatchesUseDeleteMsgEndTs() {
 	suite.Nil(out)
 }
 
-func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotPanic() {
+func (suite *DeleteNodeSuite) TestUpdateSchemaErrorPanics() {
 	manager := &segments.Manager{
 		Collection: segments.NewMockCollectionManager(suite.T()),
 		Segment:    segments.NewMockSegmentManager(suite.T()),
@@ -158,15 +158,14 @@ func (suite *DeleteNodeSuite) TestUpdateSchemaErrorDoesNotPanic() {
 	schema := &schemapb.CollectionSchema{Version: 2}
 	expectedErr := merr.WrapErrServiceUnavailableMsg("delegator is not ready")
 	delegator.EXPECT().UpdateSchema(mock.Anything, schema, uint64(10)).Return(expectedErr).Once()
-	delegator.EXPECT().UpdateTSafe(uint64(10)).Return().Once()
 
 	node := newDeleteNode(suite.collectionID, suite.channel, manager, delegator, 8)
-	suite.NotPanics(func() {
-		suite.Nil(node.Operate(&deleteNodeMsg{
+	suite.PanicsWithError(expectedErr.Error(), func() {
+		node.Operate(&deleteNodeMsg{
 			schema:          schema,
 			schemaBarrierTs: 10,
 			timeRange:       TimeRange{timestampMax: 10},
-		}))
+		})
 	})
 }
 


### PR DESCRIPTION
issue: #49716
pr: https://github.com/milvus-io/milvus/pull/51818

## Summary
Track the collection schema version applied to each shard delegator's FunctionRunner and IDF runtime. Catch up channel-local runtime when the shared Collection was advanced by another channel or load path, while serializing concurrent updates and preserving retry after failed updates.