### PR TITLE
fix: [2.6] re-watch etcd on recoverable auth-token errors

### DIFF
--- a/internal/util/proxyutil/proxy_watcher.go
+++ b/internal/util/proxyutil/proxy_watcher.go
@@ -152,12 +152,33 @@ func (p *ProxyWatcher) startWatchEtcd(ctx context.Context, eventCh clientv3.Watc
 					// On success WatchProxy spawns a new startWatchEtcd goroutine, so
 					// this goroutine returns and hands the watch over to it (not a
 					// recursive call that would accumulate goroutines).
-					err2 := retry.Do(ctx, func() error {
+					//
+					// The retry must observe the watcher lifetime, not just the
+					// component ctx: Stop() closes closeCh and then blocks in
+					// wg.Wait(), so a retry bound only to ctx would stall Stop()
+					// and could re-establish a watch after the watcher stopped.
+					// Bridge closeCh into a child ctx that gates the retry (and
+					// its backoff sleeps); WatchProxy itself still runs on the
+					// component ctx so a successfully re-established watch is not
+					// torn down when the bridge is released.
+					reCtx, reCancel := context.WithCancel(ctx)
+					go func() {
+						defer reCancel()
+						select {
+						case <-p.closeCh.CloseCh():
+						case <-reCtx.Done():
+						}
+					}()
+					err2 := retry.Do(reCtx, func() error {
+						if p.closeCh.IsClosed() {
+							return merr.WrapErrServiceInternal("proxy watcher is stopped")
+						}
 						return p.WatchProxy(ctx)
 					}, retry.RetryErr(etcd.IsRetriableWatchErr))
+					reCancel()
 					if err2 != nil {
-						if ctx.Err() != nil {
-							logger.Warn("stop re-watching proxy due to context done", zap.Error(err2))
+						if ctx.Err() != nil || p.closeCh.IsClosed() {
+							logger.Warn("stop re-watching proxy due to shutdown", zap.Error(err2))
 							return
 						}
 						logger.Error("re watch proxy failed after retries, exit",

--- a/internal/util/proxyutil/proxy_watcher.go
+++ b/internal/util/proxyutil/proxy_watcher.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
-	v3rpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -31,9 +30,11 @@ import (
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v2/util/lifetime"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/retry"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
@@ -116,33 +117,57 @@ func (p *ProxyWatcher) WatchProxy(ctx context.Context) error {
 }
 
 func (p *ProxyWatcher) startWatchEtcd(ctx context.Context, eventCh clientv3.WatchChan) {
-	log.Info("start to watch etcd")
+	logger := log.Ctx(ctx)
+	logger.Info("start to watch etcd")
 	for {
 		select {
 		case <-ctx.Done():
-			log.Warn("stop watching etcd loop")
+			logger.Warn("stop watching etcd loop")
 			return
 
 		case <-p.closeCh.CloseCh():
-			log.Warn("stop watching etcd loop")
+			logger.Warn("stop watching etcd loop")
 			return
 
 		case event, ok := <-eventCh:
 			if !ok {
-				log.Warn("stop watching etcd loop due to closed etcd event channel")
+				logger.Warn("stop watching etcd loop due to closed etcd event channel")
 				panic("stop watching etcd loop due to closed etcd event channel")
 			}
 			if err := event.Err(); err != nil {
-				if err == v3rpc.ErrCompacted {
-					err2 := p.WatchProxy(ctx)
+				// Recoverable watch errors (compaction, or auth-token
+				// invalidation when etcd auth is enabled) are handled by
+				// re-establishing the watch instead of crashing. Re-watching
+				// issues a unary request that refreshes the etcd auth token, so
+				// the new watch stream recovers. See etcd.IsRetriableWatchErr.
+				if etcd.IsRetriableWatchErr(err) {
+					logger.Warn("proxy watch hit a recoverable error, re-establishing watch", zap.Error(err))
+					// Re-watch with a bounded retry/backoff. WatchProxy first issues
+					// a unary Get (getSessionsOnEtcd), which goes through clientv3's
+					// unary retry interceptor and refreshes the etcd auth token before
+					// a fresh watch stream is opened. retry.Do is bounded by its
+					// default attempt count and backoff; only transient errors are
+					// retried, a non-transient failure aborts immediately.
+					//
+					// On success WatchProxy spawns a new startWatchEtcd goroutine, so
+					// this goroutine returns and hands the watch over to it (not a
+					// recursive call that would accumulate goroutines).
+					err2 := retry.Do(ctx, func() error {
+						return p.WatchProxy(ctx)
+					}, retry.RetryErr(etcd.IsRetriableWatchErr))
 					if err2 != nil {
-						log.Error("re watch proxy fails when etcd has a compaction error",
-							zap.Error(err), zap.Error(err2))
+						if ctx.Err() != nil {
+							logger.Warn("stop re-watching proxy due to context done", zap.Error(err2))
+							return
+						}
+						logger.Error("re watch proxy failed after retries, exit",
+							zap.NamedError("watchErr", err),
+							zap.NamedError("reWatchErr", err2))
 						panic("failed to handle etcd request, exit..")
 					}
 					return
 				}
-				log.Error("Watch proxy service failed", zap.Error(err))
+				logger.Error("Watch proxy service failed", zap.Error(err))
 				panic(err)
 			}
 			for _, e := range event.Events {
@@ -154,7 +179,7 @@ func (p *ProxyWatcher) startWatchEtcd(ctx context.Context, eventCh clientv3.Watc
 					err = p.handleDeleteEvent(e)
 				}
 				if err != nil {
-					log.Warn("failed to handle proxy event", zap.Any("event", e), zap.Error(err))
+					logger.Warn("failed to handle proxy event", zap.Any("event", e), zap.Error(err))
 				}
 			}
 		}

--- a/internal/util/proxyutil/proxy_watcher_test.go
+++ b/internal/util/proxyutil/proxy_watcher_test.go
@@ -131,15 +131,6 @@ func TestProxyManager_ErrCompacted(t *testing.T) {
 	}
 	pm := NewProxyWatcher(etcdCli, f1)
 
-	eventCh := pm.etcdCli.Watch(
-		ctx,
-		path.Join(paramtable.Get().EtcdCfg.MetaRootPath.GetValue(), sessionutil.DefaultServiceRoot, typeutil.ProxyRole),
-		clientv3.WithPrefix(),
-		clientv3.WithCreatedNotify(),
-		clientv3.WithPrevKV(),
-		clientv3.WithRev(1),
-	)
-
 	for i := 1; i < 10; i++ {
 		k := path.Join(sessKey, typeutil.ProxyRole+strconv.FormatInt(int64(i), 10))
 		v := "invalid session: " + strconv.FormatInt(int64(i), 10)
@@ -150,6 +141,20 @@ func TestProxyManager_ErrCompacted(t *testing.T) {
 	// The reason there the error is no handle is that if you run compact twice, an error will be reported;
 	// error msg is "etcdserver: mvcc: required revision has been compacted"
 	etcdCli.Compact(ctx, 10)
+
+	// Open the watch only AFTER the compaction, from a revision that is already
+	// compacted. This guarantees the watch deterministically returns
+	// ErrCompacted on its first response, instead of racing the live event
+	// stream (a fast etcd can deliver revs 2..10 before the compaction takes
+	// effect, leaving the watch with no error and the test blocking forever).
+	eventCh := pm.etcdCli.Watch(
+		ctx,
+		path.Join(paramtable.Get().EtcdCfg.MetaRootPath.GetValue(), sessionutil.DefaultServiceRoot, typeutil.ProxyRole),
+		clientv3.WithPrefix(),
+		clientv3.WithCreatedNotify(),
+		clientv3.WithPrevKV(),
+		clientv3.WithRev(1),
+	)
 
 	assert.Panics(t, func() {
 		pm.startWatchEtcd(ctx, eventCh)

--- a/internal/util/proxyutil/proxy_watcher_test.go
+++ b/internal/util/proxyutil/proxy_watcher_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/milvus-io/milvus/internal/json"
@@ -165,4 +167,34 @@ func TestProxyManager_ErrCompacted(t *testing.T) {
 		_, err = etcdCli.Delete(ctx, k)
 		assert.NoError(t, err)
 	}
+}
+
+func TestProxyManager_StopInterruptsReWatchRetry(t *testing.T) {
+	paramtable.Init()
+
+	// Every re-watch attempt fails with a retriable auth-token error, so the
+	// bounded retry would otherwise sleep through its full backoff budget on
+	// the component ctx. Stop() closes closeCh, which must abort the retry
+	// promptly and let startWatchEtcd return quietly instead of stalling
+	// Stop() (or panicking after the retries are exhausted).
+	mockWatch := mockey.Mock((*ProxyWatcher).WatchProxy).Return(rpctypes.ErrInvalidAuthToken).Build()
+	defer mockWatch.UnPatch()
+
+	pm := NewProxyWatcher(nil)
+
+	// A compacted response is retriable and sends the loop into the re-watch
+	// retry path without needing a real etcd.
+	watchCh := make(chan clientv3.WatchResponse, 1)
+	watchCh <- clientv3.WatchResponse{CompactRevision: 1}
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		pm.Stop()
+	}()
+
+	start := time.Now()
+	assert.NotPanics(t, func() {
+		pm.startWatchEtcd(context.Background(), watchCh)
+	})
+	assert.Less(t, time.Since(start), 5*time.Second)
 }

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -791,7 +791,12 @@ type SessionEvent struct {
 }
 
 type sessionWatcher struct {
-	s         *Session
+	s *Session
+	// ctx is the watcher-owned context (child of the session context), canceled
+	// by Stop(). Every watcher-side etcd call — the watch itself, the re-watch
+	// retry and its GetSessions — must use it, so Stop() interrupts in-flight
+	// recovery instead of waiting on the session context.
+	ctx       context.Context
 	cancel    context.CancelFunc
 	rch       clientv3.WatchChan
 	eventCh   chan *SessionEvent
@@ -859,9 +864,10 @@ func (s *Session) WatchServices(prefix string, revision int64, rewatch Rewatch) 
 	ctx, cancel := context.WithCancel(s.ctx)
 	w := &sessionWatcher{
 		s:        s,
+		ctx:      ctx,
 		cancel:   cancel,
 		eventCh:  make(chan *SessionEvent, 100),
-		rch:      s.etcdCli.Watch(s.ctx, path.Join(s.metaRoot, DefaultServiceRoot, prefix), clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision)),
+		rch:      s.etcdCli.Watch(ctx, path.Join(s.metaRoot, DefaultServiceRoot, prefix), clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision)),
 		prefix:   prefix,
 		rewatch:  rewatch,
 		validate: func(s *Session) bool { return true },
@@ -880,9 +886,10 @@ func (s *Session) WatchServicesWithVersionRange(prefix string, r semver.Range, r
 	ctx, cancel := context.WithCancel(s.ctx)
 	w := &sessionWatcher{
 		s:        s,
+		ctx:      ctx,
 		cancel:   cancel,
 		eventCh:  make(chan *SessionEvent, 100),
-		rch:      s.etcdCli.Watch(s.ctx, path.Join(s.metaRoot, DefaultServiceRoot, prefix), clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision)),
+		rch:      s.etcdCli.Watch(ctx, path.Join(s.metaRoot, DefaultServiceRoot, prefix), clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision)),
 		prefix:   prefix,
 		rewatch:  rewatch,
 		validate: func(s *Session) bool { return r(s.Version) },
@@ -892,15 +899,17 @@ func (s *Session) WatchServicesWithVersionRange(prefix string, r semver.Range, r
 }
 
 func (w *sessionWatcher) handleWatchResponse(wresp clientv3.WatchResponse) {
-	log := log.Ctx(w.s.ctx)
+	log := log.Ctx(w.ctx)
 	if wresp.Err() != nil {
 		err := w.handleWatchErr(wresp.Err())
 		if err != nil {
-			// On graceful shutdown s.ctx is canceled, the etcd watch delivers a
-			// final response carrying context.Canceled, and re-watching fails for
-			// the same reason. That is normal teardown, not a fault: exit quietly
-			// instead of crashing the process.
-			if w.s.ctx.Err() != nil {
+			// On teardown the watcher ctx is canceled — either directly by
+			// Stop() or via the parent session ctx on graceful shutdown — the
+			// etcd watch delivers a final response carrying context.Canceled,
+			// and re-watching fails for the same reason. That is normal
+			// teardown, not a fault: exit quietly instead of crashing the
+			// process.
+			if w.ctx.Err() != nil {
 				log.Warn("stop watching session service due to context done", zap.Error(err))
 				return
 			}
@@ -957,7 +966,7 @@ func (w *sessionWatcher) handleWatchErr(err error) error {
 	// stream. Any other error closes the channel. See etcd.IsRetriableWatchErr.
 	if !etcd.IsRetriableWatchErr(err) {
 		// close event channel
-		log.Ctx(w.s.ctx).Warn("Watch service found error", zap.Error(err))
+		log.Ctx(w.ctx).Warn("Watch service found error", zap.Error(err))
 		w.closeEventCh()
 		return err
 	}
@@ -965,9 +974,10 @@ func (w *sessionWatcher) handleWatchErr(err error) error {
 	// Re-establish the watch with a bounded retry. handleReWatch issues a unary
 	// request first, which refreshes the etcd auth token via clientv3's unary
 	// retry interceptor. Only keep retrying transient errors (e.g. a still-stale
-	// auth token); a non-transient failure aborts immediately.
-	if reErr := retry.Do(w.s.ctx, w.handleReWatch, retry.RetryErr(etcd.IsRetriableWatchErr)); reErr != nil {
-		log.Ctx(w.s.ctx).Warn("re-watch session service failed", zap.String("prefix", w.prefix), zap.Error(reErr))
+	// auth token); a non-transient failure aborts immediately. The retry runs on
+	// the watcher ctx so Stop() interrupts it.
+	if reErr := retry.Do(w.ctx, w.handleReWatch, retry.RetryErr(etcd.IsRetriableWatchErr)); reErr != nil {
+		log.Ctx(w.ctx).Warn("re-watch session service failed", zap.String("prefix", w.prefix), zap.Error(reErr))
 		w.closeEventCh()
 		return reErr
 	}
@@ -979,16 +989,16 @@ func (w *sessionWatcher) handleWatchErr(err error) error {
 // them through the rewatch hook, then opens a fresh watch stream from the new
 // revision.
 func (w *sessionWatcher) handleReWatch() error {
-	sessions, revision, err := w.s.GetSessions(w.s.ctx, w.prefix)
+	sessions, revision, err := w.s.GetSessions(w.ctx, w.prefix)
 	if err != nil {
 		return err
 	}
 	if w.rewatch == nil {
-		log.Ctx(w.s.ctx).Warn("re-watch session service but no rewatch logic provided", zap.String("prefix", w.prefix))
+		log.Ctx(w.ctx).Warn("re-watch session service but no rewatch logic provided", zap.String("prefix", w.prefix))
 	} else if err = w.rewatch(sessions); err != nil {
 		return err
 	}
-	w.rch = w.s.etcdCli.Watch(w.s.ctx, path.Join(w.s.metaRoot, DefaultServiceRoot, w.prefix), clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision))
+	w.rch = w.s.etcdCli.Watch(w.ctx, path.Join(w.s.metaRoot, DefaultServiceRoot, w.prefix), clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision))
 	return nil
 }
 

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -41,6 +41,7 @@ import (
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/retry"
@@ -891,10 +892,18 @@ func (s *Session) WatchServicesWithVersionRange(prefix string, r semver.Range, r
 }
 
 func (w *sessionWatcher) handleWatchResponse(wresp clientv3.WatchResponse) {
-	log := log.Ctx(context.TODO())
+	log := log.Ctx(w.s.ctx)
 	if wresp.Err() != nil {
 		err := w.handleWatchErr(wresp.Err())
 		if err != nil {
+			// On graceful shutdown s.ctx is canceled, the etcd watch delivers a
+			// final response carrying context.Canceled, and re-watching fails for
+			// the same reason. That is normal teardown, not a fault: exit quietly
+			// instead of crashing the process.
+			if w.s.ctx.Err() != nil {
+				log.Warn("stop watching session service due to context done", zap.Error(err))
+				return
+			}
 			log.Error("failed to handle watch session response", zap.Error(err))
 			panic(err)
 		}
@@ -942,32 +951,43 @@ func (w *sessionWatcher) handleWatchResponse(wresp clientv3.WatchResponse) {
 }
 
 func (w *sessionWatcher) handleWatchErr(err error) error {
-	// if not ErrCompacted, just close the channel
-	if err != v3rpc.ErrCompacted {
+	// Only recoverable errors are re-watched. ErrCompacted needs a fresh
+	// revision; auth-token errors (etcd auth enabled) need the watch
+	// re-established because clientv3 won't refresh the token on a live watch
+	// stream. Any other error closes the channel. See etcd.IsRetriableWatchErr.
+	if !etcd.IsRetriableWatchErr(err) {
 		// close event channel
-		log.Warn("Watch service found error", zap.Error(err))
+		log.Ctx(w.s.ctx).Warn("Watch service found error", zap.Error(err))
 		w.closeEventCh()
 		return err
 	}
 
+	// Re-establish the watch with a bounded retry. handleReWatch issues a unary
+	// request first, which refreshes the etcd auth token via clientv3's unary
+	// retry interceptor. Only keep retrying transient errors (e.g. a still-stale
+	// auth token); a non-transient failure aborts immediately.
+	if reErr := retry.Do(w.s.ctx, w.handleReWatch, retry.RetryErr(etcd.IsRetriableWatchErr)); reErr != nil {
+		log.Ctx(w.s.ctx).Warn("re-watch session service failed", zap.String("prefix", w.prefix), zap.Error(reErr))
+		w.closeEventCh()
+		return reErr
+	}
+	return nil
+}
+
+// handleReWatch re-establishes the session watch: it re-reads the current
+// sessions (a unary request that also refreshes the etcd auth token), replays
+// them through the rewatch hook, then opens a fresh watch stream from the new
+// revision.
+func (w *sessionWatcher) handleReWatch() error {
 	sessions, revision, err := w.s.GetSessions(w.s.ctx, w.prefix)
 	if err != nil {
-		log.Warn("GetSession before rewatch failed", zap.String("prefix", w.prefix), zap.Error(err))
-		w.closeEventCh()
 		return err
 	}
-	// rewatch is nil, no logic to handle
 	if w.rewatch == nil {
-		log.Warn("Watch service with ErrCompacted but no rewatch logic provided")
-	} else {
-		err = w.rewatch(sessions)
-	}
-	if err != nil {
-		log.Warn("WatchServices rewatch failed", zap.String("prefix", w.prefix), zap.Error(err))
-		w.closeEventCh()
+		log.Ctx(w.s.ctx).Warn("re-watch session service but no rewatch logic provided", zap.String("prefix", w.prefix))
+	} else if err = w.rewatch(sessions); err != nil {
 		return err
 	}
-
 	w.rch = w.s.etcdCli.Watch(w.s.ctx, path.Join(w.s.metaRoot, DefaultServiceRoot, w.prefix), clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision))
 	return nil
 }

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	v3rpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 
@@ -299,6 +300,22 @@ func TestWatcherHandleWatchResp(t *testing.T) {
 		})
 	})
 
+	t.Run("error during shutdown does not panic", func(t *testing.T) {
+		// When the session ctx is canceled (graceful shutdown), the etcd watch
+		// delivers a final error response; handling it must exit quietly instead
+		// of crashing the process.
+		cctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		downSession := NewSessionWithEtcd(cctx, metaRoot, etcdCli)
+		w := getWatcher(downSession, nil)
+		wresp := clientv3.WatchResponse{
+			Canceled: true,
+		}
+		assert.NotPanics(t, func() {
+			w.handleWatchResponse(wresp)
+		})
+	})
+
 	t.Run("err handled but rewatch failed", func(t *testing.T) {
 		w := getWatcher(s, func(sessions map[string]*Session) error {
 			return errors.New("mocked")
@@ -309,6 +326,27 @@ func TestWatcherHandleWatchResp(t *testing.T) {
 		assert.Panics(t, func() {
 			w.handleWatchResponse(wresp)
 		})
+	})
+
+	t.Run("invalid auth token triggers rewatch instead of close", func(t *testing.T) {
+		rewatched := false
+		w := getWatcher(s, func(sessions map[string]*Session) error {
+			rewatched = true
+			return nil
+		})
+		// An Unauthenticated watch error is recoverable: the watcher must
+		// re-establish the watch (which refreshes the etcd auth token via the
+		// unary path) rather than close the channel and panic.
+		err := w.handleWatchErr(v3rpc.ErrInvalidAuthToken)
+		assert.NoError(t, err)
+		assert.True(t, rewatched)
+		assert.NotNil(t, w.rch)
+	})
+
+	t.Run("non-retriable error closes channel", func(t *testing.T) {
+		w := getWatcher(s, nil)
+		err := w.handleWatchErr(errors.New("some fatal error"))
+		assert.Error(t, err)
 	})
 }
 
@@ -1036,7 +1074,13 @@ func testForceKill(t *testing.T, serverName string) {
 	// trigger a force kill
 	_, err := etcdCli.Revoke(context.Background(), *session.LeaseID)
 	require.NoError(t, err)
-	time.Sleep(5 * time.Second)
+
+	// The force kill is asynchronous: the keepalive loop must observe the lost
+	// lease and call os.Exit(ExitCodeEtcd). Block long enough for that to fire,
+	// otherwise this function returns and the subprocess exits 0, racing (and
+	// usually beating) the force kill. The sleep is only paid in full on a
+	// regression; on success os.Exit terminates the process well before it ends.
+	time.Sleep(30 * time.Second)
 }
 
 func TestGetResourceGroupName(t *testing.T) {

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -209,8 +209,11 @@ func TestWatcherHandleWatchResp(t *testing.T) {
 	defer s.Stop()
 
 	getWatcher := func(s *Session, rewatch Rewatch) *sessionWatcher {
+		wctx, wcancel := context.WithCancel(s.ctx)
 		return &sessionWatcher{
 			s:        s,
+			ctx:      wctx,
+			cancel:   wcancel,
 			prefix:   "test",
 			rewatch:  rewatch,
 			eventCh:  make(chan *SessionEvent, 10),
@@ -347,6 +350,44 @@ func TestWatcherHandleWatchResp(t *testing.T) {
 		w := getWatcher(s, nil)
 		err := w.handleWatchErr(errors.New("some fatal error"))
 		assert.Error(t, err)
+	})
+
+	t.Run("cancel-reason shaped auth error triggers rewatch", func(t *testing.T) {
+		// The etcd server delivers auth-token watch cancellations as
+		// CancelReason text; clientv3 rebuilds it as a plain error that no
+		// longer matches the sentinel via errors.Is. The watcher must still
+		// classify it as retriable and re-establish the watch.
+		rewatched := false
+		w := getWatcher(s, func(sessions map[string]*Session) error {
+			rewatched = true
+			return nil
+		})
+		err := w.handleWatchErr(v3rpc.Error(errors.New(v3rpc.ErrGRPCInvalidAuthToken.Error())))
+		assert.NoError(t, err)
+		assert.True(t, rewatched)
+		assert.NotNil(t, w.rch)
+	})
+
+	t.Run("Stop interrupts rewatch retry", func(t *testing.T) {
+		// Keep every rewatch attempt failing with a retriable error so the
+		// bounded retry would otherwise run its full backoff budget on the
+		// session ctx. Stop() cancels the watcher ctx, which must abort the
+		// retry promptly and make the teardown quiet instead of panicking.
+		w := getWatcher(s, func(sessions map[string]*Session) error {
+			return v3rpc.ErrInvalidAuthToken
+		})
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			w.Stop()
+		}()
+		start := time.Now()
+		wresp := clientv3.WatchResponse{
+			CompactRevision: 1,
+		}
+		assert.NotPanics(t, func() {
+			w.handleWatchResponse(wresp)
+		})
+		assert.Less(t, time.Since(start), 5*time.Second)
 	})
 }
 

--- a/pkg/util/etcd/etcd_util.go
+++ b/pkg/util/etcd/etcd_util.go
@@ -39,6 +39,43 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
+// IsRetriableWatchErr reports whether an etcd watch error can be recovered by
+// re-establishing the watch.
+//
+// It returns true for:
+//   - ErrCompacted: the watched revision has been compacted; re-watch from a
+//     fresh revision (pre-existing behavior).
+//   - auth-token errors (ErrInvalidAuthToken, ErrUserEmpty, ErrAuthOldRevision):
+//     with etcd auth enabled, the auth token held by a client can be
+//     invalidated server-side (the default "simple" token is GC'd after idle
+//     TTL, is member-local, and is lost on member restart). A long-idle standby
+//     coordinator hits this on promotion. clientv3 treats the resulting
+//     Unauthenticated error on an already-established watch stream as a halt
+//     error (see isHaltErr) and tears the stream down WITHOUT refreshing the
+//     token, so the watch owner must re-watch. Re-watching issues a unary
+//     request first, which goes through clientv3's unary retry interceptor and
+//     refreshes the auth token, so the new watch stream recovers.
+//
+// Genuine authorization failures (permission denied, bad credentials) carry
+// different codes (PermissionDenied, InvalidArgument, FailedPrecondition) and
+// are deliberately NOT retriable. We match the etcd sentinels via errors.Is
+// rather than the raw gRPC Unauthenticated code: clientv3 maps watch errors
+// back to these sentinels (v3rpc.Error), and ErrInvalidAuthToken is the only
+// source of Unauthenticated, so matching the sentinel is both sufficient and
+// narrower than trusting the code.
+//
+// Callers should wrap the re-watch in a bounded retry (retry.Attempts) so a
+// genuinely persistent failure does not loop forever.
+func IsRetriableWatchErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, rpctypes.ErrCompacted) ||
+		errors.Is(err, rpctypes.ErrInvalidAuthToken) ||
+		errors.Is(err, rpctypes.ErrUserEmpty) ||
+		errors.Is(err, rpctypes.ErrAuthOldRevision)
+}
+
 type ClientOption func(*clientv3.Config)
 
 // WithDialKeepAlive configures gRPC keepalive and autosync behaviors for the etcd client.

--- a/pkg/util/etcd/etcd_util.go
+++ b/pkg/util/etcd/etcd_util.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -70,10 +71,33 @@ func IsRetriableWatchErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	return errors.Is(err, rpctypes.ErrCompacted) ||
+	if errors.Is(err, rpctypes.ErrCompacted) ||
 		errors.Is(err, rpctypes.ErrInvalidAuthToken) ||
 		errors.Is(err, rpctypes.ErrUserEmpty) ||
-		errors.Is(err, rpctypes.ErrAuthOldRevision)
+		errors.Is(err, rpctypes.ErrAuthOldRevision) {
+		return true
+	}
+	// A server-side watch cancellation loses the sentinel identity: etcd's
+	// serverWatchStream puts ErrGRPC*.Error() — the full "rpc error: code =
+	// Unauthenticated desc = ..." string — into WatchResponse.CancelReason, and
+	// clientv3 rebuilds it via errors.New / status.Error before v3rpc.Error,
+	// whose lookup table is keyed by the bare description only. The rebuilt
+	// error therefore never maps back to a sentinel and errors.Is above is
+	// false. Match the sentinel descriptions inside the message to cover this
+	// transport shape (including the substream path that nests it inside a
+	// FailedPrecondition status).
+	msg := err.Error()
+	for _, sentinel := range []error{
+		rpctypes.ErrGRPCCompacted,
+		rpctypes.ErrGRPCInvalidAuthToken,
+		rpctypes.ErrGRPCUserEmpty,
+		rpctypes.ErrGRPCAuthOldRevision,
+	} {
+		if strings.Contains(msg, rpctypes.ErrorDesc(sentinel)) {
+			return true
+		}
+	}
+	return false
 }
 
 type ClientOption func(*clientv3.Config)

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -27,7 +27,36 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+func TestIsRetriableWatchErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"compacted", rpctypes.ErrCompacted, true},
+		{"invalid auth token", rpctypes.ErrInvalidAuthToken, true},
+		{"user empty", rpctypes.ErrUserEmpty, true},
+		{"auth old revision", rpctypes.ErrAuthOldRevision, true},
+		// A raw gRPC Unauthenticated that was not mapped back to an etcd
+		// sentinel is deliberately NOT retriable: we match sentinels only.
+		{"unmapped raw grpc unauthenticated", status.Error(codes.Unauthenticated, "some unmapped error"), false},
+		{"wrapped invalid auth token", errors.Wrap(rpctypes.ErrInvalidAuthToken, "watch failed"), true},
+		{"permission denied", rpctypes.ErrPermissionDenied, false},
+		{"lease not found", rpctypes.ErrLeaseNotFound, false},
+		{"generic error", errors.New("some other error"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, IsRetriableWatchErr(c.err))
+		})
+	}
+}
 
 // freePort grabs a random unused TCP port. There's a small TOCTOU window
 // between Close and the subsequent bind, but for unit tests it's acceptable.

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -46,6 +46,40 @@ func TestIsRetriableWatchErr(t *testing.T) {
 		// A raw gRPC Unauthenticated that was not mapped back to an etcd
 		// sentinel is deliberately NOT retriable: we match sentinels only.
 		{"unmapped raw grpc unauthenticated", status.Error(codes.Unauthenticated, "some unmapped error"), false},
+		// CancelReason transport shape: the etcd server cancels the watch with
+		// CancelReason = ErrGRPC*.Error() (the full "rpc error: ..." string) and
+		// clientv3 rebuilds it as a plain error (watch.go: v3rpc.Error(
+		// errors.New(resp.CancelReason))), so errors.Is no longer matches the
+		// sentinel. These must still be classified as retriable.
+		{
+			"cancel-reason shaped invalid auth token",
+			rpctypes.Error(errors.New(rpctypes.ErrGRPCInvalidAuthToken.Error())),
+			true,
+		},
+		{
+			"cancel-reason shaped user empty",
+			rpctypes.Error(errors.New(rpctypes.ErrGRPCUserEmpty.Error())),
+			true,
+		},
+		{
+			"cancel-reason shaped auth old revision",
+			rpctypes.Error(errors.New(rpctypes.ErrGRPCAuthOldRevision.Error())),
+			true,
+		},
+		// Substream cancellation nests the cancel reason inside a
+		// FailedPrecondition status (clientv3 WatchResponse.Err()).
+		{
+			"substream-nested invalid auth token",
+			rpctypes.Error(status.Error(codes.FailedPrecondition, rpctypes.ErrGRPCInvalidAuthToken.Error())),
+			true,
+		},
+		// A permission-denied cancel reason keeps the same transport shape but
+		// must remain non-retriable.
+		{
+			"cancel-reason shaped permission denied",
+			rpctypes.Error(errors.New(rpctypes.ErrGRPCPermissionDenied.Error())),
+			false,
+		},
 		{"wrapped invalid auth token", errors.Wrap(rpctypes.ErrInvalidAuthToken, "watch failed"), true},
 		{"permission denied", rpctypes.ErrPermissionDenied, false},
 		{"lease not found", rpctypes.ErrLeaseNotFound, false},


### PR DESCRIPTION
## What this PR does

Backports #50614 to the `2.6` branch.

With etcd auth enabled and MixCoord active-standby enabled, a long-running standby can hold an auth token that etcd has invalidated. When the standby is promoted, an established watch stream returns `Unauthenticated: invalid auth token`. The 2.6 watcher code only recovers from `ErrCompacted` and panics on other watch errors, causing the promoted MixCoord to exit.

This PR:

- Adds `etcd.IsRetriableWatchErr` for compacted revisions and recoverable etcd auth-token errors.
- Makes `ProxyWatcher` re-list sessions and establish a new watch with bounded retry instead of panicking on those errors.
- Applies the same recovery behavior to `sessionutil` watchers.
- Keeps permission errors, invalid credentials, and other non-recoverable errors fail-fast.
- Avoids panicking when re-watch fails because the owning context is already canceled.
- Includes the classification, re-watch, and compaction regression tests from #50614.

Re-listing uses the unary etcd client path, which refreshes an invalid auth token before the replacement watch stream is opened.

## Verification

Passed:

- `(cd pkg && go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./util/etcd)`
- `git diff --check`
- `gofmt` check on all changed Go files

The following targeted watcher test was started locally but its first-time C++/Go dependency compilation was stopped due to local build time; CI will run it:

- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 -p 1 ./internal/util/sessionutil ./internal/util/proxyutil -run 'TestWatcherHandleWatchResp|TestProxyManager_ErrCompacted'`

issue: #50102
pr: #50614
