### PR TITLE
enhance: [2.6] reuse precomputed BM25 function outputs (#49717)

### DIFF
--- a/internal/flushcommon/pipeline/flow_graph_embedding_node.go
+++ b/internal/flushcommon/pipeline/flow_graph_embedding_node.go
@@ -91,6 +91,15 @@ func (eNode *embeddingNode) bm25Embedding(runner function.FunctionRunner, data *
 	if _, ok := meta[outputFieldId]; !ok {
 		meta[outputFieldId] = storage.NewBM25Stats()
 	}
+	// Newer producers may have already materialized the output before WAL append.
+	if output, ok := data.Data[outputFieldId]; ok {
+		sparseData, ok := output.(*storage.SparseFloatVectorFieldData)
+		if !ok {
+			return merr.WrapErrFunctionFailedMsg("BM25 output field %d is not sparse vector data", outputFieldId)
+		}
+		meta[outputFieldId].AppendFieldData(sparseData)
+		return nil
+	}
 
 	datas := []any{}
 

--- a/internal/flushcommon/pipeline/flow_graph_embedding_node_test.go
+++ b/internal/flushcommon/pipeline/flow_graph_embedding_node_test.go
@@ -26,9 +26,11 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/flushcommon/metacache"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/flowgraph"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 func TestEmbeddingNode_BM25_Operator(t *testing.T) {
@@ -111,6 +113,65 @@ func TestEmbeddingNode_BM25_Operator(t *testing.T) {
 		msg, ok := output[0].(*FlowGraphMsg)
 		assert.True(t, ok)
 		assert.NotNil(t, msg.InsertData)
+	})
+
+	t.Run("precomputed BM25 output", func(t *testing.T) {
+		node, err := newEmbeddingNode("test-channel", metaCache)
+		assert.NoError(t, err)
+		defer node.Free()
+
+		rows := [][]byte{
+			typeutil.CreateSparseFloatRow([]uint32{7}, []float32{2}),
+			typeutil.CreateSparseFloatRow([]uint32{9}, []float32{3}),
+			typeutil.CreateSparseFloatRow([]uint32{11}, []float32{4}),
+		}
+		precomputed := &schemapb.SparseFloatArray{Contents: rows, Dim: 12}
+		output := node.Operate([]Msg{
+			&FlowGraphMsg{
+				BaseMsg: flowgraph.NewBaseMsg(false),
+				InsertMessages: []*msgstream.InsertMsg{{
+					BaseMsg: msgstream.BaseMsg{},
+					InsertRequest: &msgpb.InsertRequest{
+						SegmentID:  1,
+						Version:    msgpb.InsertDataVersion_ColumnBased,
+						Timestamps: []uint64{1, 1, 1},
+						FieldsData: []*schemapb.FieldData{
+							{
+								FieldId: 100,
+								Field: &schemapb.FieldData_Scalars{
+									Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
+								},
+							}, {
+								FieldId: 101,
+								Field: &schemapb.FieldData_Scalars{
+									Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: []string{"different1", "different2", "different3"}}}},
+								},
+							}, {
+								FieldId: 102,
+								Field: &schemapb.FieldData_Vectors{
+									Vectors: &schemapb.VectorField{
+										Dim: 12,
+										Data: &schemapb.VectorField_SparseFloatVector{
+											SparseFloatVector: precomputed,
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+			},
+		})
+
+		msg := output[0].(*FlowGraphMsg)
+		actual := msg.InsertData[0].GetDatas()[0].Data[102].(*storage.SparseFloatVectorFieldData)
+		assert.Equal(t, precomputed, &actual.SparseFloatArray)
+
+		data := &storage.InsertData{Data: map[int64]storage.FieldData{102: actual}}
+		stats, err := node.embedding([]*storage.InsertData{data})
+		assert.NoError(t, err)
+		assert.Equal(t, int64(3), stats[102].NumRow())
+		assert.Equal(t, int64(9), stats[102].NumToken())
 	})
 
 	t.Run("with close msg", func(t *testing.T) {

--- a/internal/querynodev2/pipeline/embedding_node.go
+++ b/internal/querynodev2/pipeline/embedding_node.go
@@ -140,10 +140,27 @@ func (eNode *embeddingNode) addInsertData(insertDatas map[UniqueID]*delegator.In
 }
 
 func (eNode *embeddingNode) bm25Embedding(runner function.FunctionRunner, msg *msgstream.InsertMsg, stats map[int64]*storage.BM25Stats) error {
-	inputFields := runner.GetInputFields()
 	outputField := runner.GetOutputFields()[0]
 
 	outputFieldID := outputField.GetFieldID()
+	// Newer producers may have already materialized the output before WAL append.
+	for _, fieldData := range msg.GetFieldsData() {
+		if fieldData.GetFieldId() != outputFieldID {
+			continue
+		}
+
+		sparseArray := fieldData.GetVectors().GetSparseFloatVector()
+		if sparseArray == nil {
+			return merr.WrapErrFunctionFailedMsg("BM25 output field %d is not sparse vector data", outputFieldID)
+		}
+		if _, ok := stats[outputFieldID]; !ok {
+			stats[outputFieldID] = storage.NewBM25Stats()
+		}
+		stats[outputFieldID].AppendBytes(sparseArray.GetContents()...)
+		return nil
+	}
+
+	inputFields := runner.GetInputFields()
 	datas, err := getEmbeddingFieldDatas(msg.FieldsData, lo.Map(inputFields, func(field *schemapb.FieldSchema, _ int) int64 { return field.GetFieldID() })...)
 	if err != nil {
 		return err

--- a/internal/querynodev2/pipeline/embedding_node_test.go
+++ b/internal/querynodev2/pipeline/embedding_node_test.go
@@ -29,10 +29,12 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 // test of embedding node
@@ -251,6 +253,43 @@ func (suite *EmbeddingNodeSuite) TestAddInsertData() {
 }
 
 func (suite *EmbeddingNodeSuite) TestBM25Embedding() {
+	suite.Run("precomputed output", func() {
+		collection := segments.NewCollectionWithoutSegcoreForTest(suite.collectionID, suite.collectionSchema)
+		suite.colManager.EXPECT().Get(suite.collectionID).Return(collection).Once()
+		node, err := newEmbeddingNode(suite.collectionID, suite.channel, suite.manager, 128)
+		suite.NoError(err)
+		defer node.Close()
+
+		rows := [][]byte{
+			typeutil.CreateSparseFloatRow([]uint32{7}, []float32{2}),
+			typeutil.CreateSparseFloatRow([]uint32{9}, []float32{3}),
+			typeutil.CreateSparseFloatRow([]uint32{11}, []float32{4}),
+		}
+		msg := &msgstream.InsertMsg{
+			BaseMsg:       msgstream.BaseMsg{},
+			InsertRequest: proto.Clone(suite.msgs[0].InsertRequest).(*msgpb.InsertRequest),
+		}
+		msg.FieldsData = append(msg.FieldsData, &schemapb.FieldData{
+			FieldId: 102,
+			Type:    schemapb.DataType_SparseFloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: 12,
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{Contents: rows, Dim: 12},
+				},
+			}},
+		})
+
+		runner := function.NewMockFunctionRunner(suite.T())
+		runner.EXPECT().GetOutputFields().Return([]*schemapb.FieldSchema{suite.collectionSchema.Fields[3]})
+		stats := make(map[int64]*storage.BM25Stats)
+		err = node.bm25Embedding(runner, msg, stats)
+		suite.NoError(err)
+		suite.Len(msg.FieldsData, 3)
+		suite.Equal(int64(3), stats[102].NumRow())
+		suite.Equal(int64(9), stats[102].NumToken())
+	})
+
 	suite.Run("function run failed", func() {
 		collection := segments.NewCollectionWithoutSegcoreForTest(suite.collectionID, suite.collectionSchema)
 		suite.colManager.EXPECT().Get(suite.collectionID).Return(collection).Once()

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -884,7 +884,11 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 	handleFieldData := func(field *schemapb.FieldSchema) (FieldData, error) {
 		if typeutil.IsBM25FunctionOutputField(field, collSchema) {
-			return nil, nil
+			// Newer producers may materialize BM25 output before appending to WAL.
+			// Keep the column when present, while still accepting legacy messages that omit it.
+			if _, ok := srcFields[field.GetFieldID()]; !ok {
+				return nil, nil
+			}
 		}
 
 		fieldData, err := getFieldData(field)


### PR DESCRIPTION
issue: #49716
pr: https://github.com/milvus-io/milvus/pull/49717

## Summary
Reuse BM25 function output fields already materialized by newer producers instead of generating duplicate columns in 2.6 DataNode and QueryNode consumers. Preserve BM25 statistics collection from the precomputed sparse vectors.