### PR TITLE
test: Increase PyMilvus version to 3.1.0rc78 from master for master branch

### DIFF
--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -287,7 +287,7 @@ func prepareAlterSchemaAddField(coll *model.Collection, plan *schemautil.AlterSc
 			timezone = common.DefaultTimezone
 		}
 		if err := timestamptz.CheckAndRewriteTimestampTzDefaultValueForFieldSchema(fieldSchema, timezone); err != nil {
-			return merr.WrapErrParameterInvalidMsg("invalid default value of field, name: %s, err: %w", fieldSchema.Name, err)
+			return merr.Wrapf(err, "invalid default value of field, name: %s", fieldSchema.Name)
 		}
 	}
 

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -222,10 +222,14 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 		DataType: schemapb.DataType_Timestamptz,
 		Nullable: true,
 		DefaultValue: &schemapb.ValueField{
-			Data: &schemapb.ValueField_StringData{StringData: "not-a-timestamp"},
+			Data: &schemapb.ValueField_StringData{StringData: "1234"},
 		},
 	}, false))
-	require.ErrorIs(t, merr.CheckRPCCall(resp.GetAlterStatus(), err), merr.ErrParameterInvalid)
+	invalidTimestampErr := merr.CheckRPCCall(resp.GetAlterStatus(), err)
+	require.ErrorIs(t, invalidTimestampErr, merr.ErrParameterInvalid)
+	require.ErrorContains(t, invalidTimestampErr, "invalid default value of field, name: invalid_created_at_tz")
+	require.ErrorContains(t, invalidTimestampErr, "invalid timestamp string: '1234'. Does not match any known format")
+	require.NotContains(t, invalidTimestampErr.Error(), "%!w")
 
 	// case 3.4: multiple function schemas remain unsupported.
 	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{

--- a/tests/python_client/milvus_client/test_drop_field_feature.py
+++ b/tests/python_client/milvus_client/test_drop_field_feature.py
@@ -224,7 +224,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         TC-L0-03: Drop BM25 function and verify output field/index cascade.
 
         target: verify dropping BM25 function removes function output field and its index
-        method: create BM25 function from text to sparse, reject detach-only drop, then cascade-drop function field
+        method: create BM25 function from text to sparse, reject the deprecated drop API, then cascade-drop function field
         expected: function and sparse output field disappear; text and vec remain usable
         """
         client = self._client()
@@ -292,7 +292,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         assert len(bm25_res[0]) > 0
         assert "text" in bm25_res[0][0]["entity"]
 
-        # Step 4: BM25 cannot be detached from its output field through the legacy SDK API.
+        # Step 4: The deprecated detach API is rejected without mutating the schema.
         self.drop_collection_function(
             client,
             collection_name,
@@ -301,9 +301,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "detaching a function without dropping its output field is not supported; "
-                    "drop_function always removes the function together with its output field: "
-                    "bm25: invalid parameter"
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
                 ),
             },
         )
@@ -1321,9 +1319,9 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         """
         TC-L1-07: Drop Function negative constraints.
 
-        target: verify Drop Function rejects invalid requests and preserves schema on failure
-        method: test empty name, missing function, detach-only BM25 rejection, repeated drop, and last-vector cascade rejection
-        expected: errors are clear; failed drops do not partially mutate schema
+        target: verify deprecated and cascade Drop Function requests preserve schema on failure
+        method: reject deprecated API requests, then test repeated cascade and last-vector rejection
+        expected: unsupported or invalid requests do not partially mutate schema
         """
         client = self._client()
         collection_name = f"{cf.gen_collection_name_by_testcase_name()}_function_negative"
@@ -1350,7 +1348,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             consistency_level="Strong",
         )
 
-        # Step 2: Reject empty and missing function names before any successful drop.
+        # Step 2: Reject deprecated API calls with empty and missing function names.
         self.drop_collection_function(
             client,
             collection_name,
@@ -1358,7 +1356,9 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_task=ct.CheckTasks.err_res,
             check_items={
                 ct.err_code: 1100,
-                ct.err_msg: "Must specify exactly one valid Drop identifier (drop_field_name/drop_field_id/drop_function_name)",
+                ct.err_msg: (
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
+                ),
             },
         )
 
@@ -1367,14 +1367,19 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             collection_name,
             "missing_function",
             check_task=ct.CheckTasks.err_res,
-            check_items={ct.err_code: 1100, ct.err_msg: "function not found: missing_function: invalid parameter"},
+            check_items={
+                ct.err_code: 1100,
+                ct.err_msg: (
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
+                ),
+            },
         )
 
         desc = client.describe_collection(collection_name)
         assert "bm25" in [func["name"] for func in desc.get("functions", [])]
         assert "sparse" in [field["name"] for field in desc["fields"]]
 
-        # Step 3: Reject detach-only BM25 drop and verify schema stays unchanged.
+        # Step 3: Reject the deprecated API for an existing function and preserve its schema.
         self.drop_collection_function(
             client,
             collection_name,
@@ -1383,9 +1388,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "detaching a function without dropping its output field is not supported; "
-                    "drop_function always removes the function together with its output field: "
-                    "bm25: invalid parameter"
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
                 ),
             },
         )
@@ -1461,9 +1464,9 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         """
         TC-L1-07a: Drop Function detach vs cascade semantics for MinHash.
 
-        target: verify MinHash detach-only drop is rejected and cascade-output-field drop works
-        method: drop_collection_function (detach) is rejected; drop_function_field removes function + output field/index
-        expected: detach rejected (function/field unchanged); cascade removes function, output field, and output index
+        target: verify the deprecated MinHash drop API is rejected and cascade-output-field drop works
+        method: drop_collection_function is rejected; drop_function_field removes function + output field/index
+        expected: deprecated API rejected (function/field unchanged); cascade removes function, output field, and output index
         """
         client = self._client()
         detach_collection_name = f"{cf.gen_collection_name_by_testcase_name()}_detach"
@@ -1527,7 +1530,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             assert len(search_res[0]) > 0
             assert "doc" in search_res[0][0]["entity"]
 
-        # Step 1: Detach-only MinHash drop is rejected; the function keeps its output field.
+        # Step 1: The deprecated MinHash drop API is rejected; the function keeps its output field.
         create_minhash_collection(detach_collection_name)
         self.drop_collection_function(
             client,
@@ -1537,9 +1540,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "detaching a function without dropping its output field is not supported; "
-                    "drop_function always removes the function together with its output field: "
-                    "text_to_minhash: invalid parameter"
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
                 ),
             },
         )

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -23,8 +23,8 @@ pytest-sugar==0.9.5
 pytest-random-order
 
 # pymilvus
-pymilvus==3.1.0rc69
-pymilvus[bulk_writer]==3.1.0rc69
+pymilvus==3.1.0rc78
+pymilvus[bulk_writer]==3.1.0rc78
 # for protobuf
 protobuf>=5.29.5
 

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -885,7 +885,10 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             assert False, "Expected exception: drop_collection_function is no longer supported"
         except Exception as e:
             log.info(f"Expected error: {e}")
-            assert "not supported" in str(e)
+            assert (
+                "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
+                in str(e)
+            )
 
     # ==================== alter_collection_function tests ====================
 


### PR DESCRIPTION
## What changed

- Update `pymilvus` and `pymilvus[bulk_writer]` from 3.1.0rc69 to 3.1.0rc78.
- Align deprecated `drop_collection_function` tests with the unsupported legacy RPC response.
- Keep `drop_function_field` coverage for the supported cascade deletion behavior.
- Preserve the underlying TIMESTAMPTZ validation error returned by `AlterCollectionSchema`.
- Assert the complete deprecated DropCollectionFunction response in the TextEmbedding E2E test.

This supersedes https://github.com/milvus-io/milvus/pull/51849.

Related PyMilvus changes:
- https://github.com/milvus-io/pymilvus/pull/3704
- https://github.com/milvus-io/pymilvus/pull/3727
- https://github.com/milvus-io/pymilvus/pull/3729

## Verification

- `ruff check tests/python_client/testcases/test_text_embedding_function_e2e.py`
- `ruff format --check tests/python_client/testcases/test_text_embedding_function_e2e.py`
- `gofumpt -l internal/rootcoord/ddl_callbacks_alter_collection_schema.go internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go`
- `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/rootcoord -run TestDDLCallbacksBroadcastAlterCollectionSchema`
- PyMilvus 3.1.0rc78 TestPyPI dependency dry-run
- `git diff --check`