### PR TITLE
test: [cp3.0]Update PyMilvus to 3.0.1rc74

### DIFF
--- a/tests/python_client/milvus_client/test_drop_field_feature.py
+++ b/tests/python_client/milvus_client/test_drop_field_feature.py
@@ -224,7 +224,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         TC-L0-03: Drop BM25 function and verify output field/index cascade.
 
         target: verify dropping BM25 function removes function output field and its index
-        method: create BM25 function from text to sparse, reject detach-only drop, then cascade-drop function field
+        method: create BM25 function from text to sparse, reject the deprecated drop API, then cascade-drop function field
         expected: function and sparse output field disappear; text and vec remain usable
         """
         client = self._client()
@@ -292,7 +292,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         assert len(bm25_res[0]) > 0
         assert "text" in bm25_res[0][0]["entity"]
 
-        # Step 4: BM25 cannot be detached from its output field through the legacy SDK API.
+        # Step 4: The deprecated detach API is rejected without mutating the schema.
         self.drop_collection_function(
             client,
             collection_name,
@@ -301,9 +301,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "detaching a function without dropping its output field is not supported; "
-                    "drop_function always removes the function together with its output field: "
-                    "bm25: invalid parameter"
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
                 ),
             },
         )
@@ -1321,9 +1319,9 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         """
         TC-L1-07: Drop Function negative constraints.
 
-        target: verify Drop Function rejects invalid requests and preserves schema on failure
-        method: test empty name, missing function, detach-only BM25 rejection, repeated drop, and last-vector cascade rejection
-        expected: errors are clear; failed drops do not partially mutate schema
+        target: verify deprecated and cascade Drop Function requests preserve schema on failure
+        method: reject deprecated API requests, then test repeated cascade and last-vector rejection
+        expected: unsupported or invalid requests do not partially mutate schema
         """
         client = self._client()
         collection_name = f"{cf.gen_collection_name_by_testcase_name()}_function_negative"
@@ -1350,7 +1348,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             consistency_level="Strong",
         )
 
-        # Step 2: Reject empty and missing function names before any successful drop.
+        # Step 2: Reject deprecated API calls with empty and missing function names.
         self.drop_collection_function(
             client,
             collection_name,
@@ -1358,7 +1356,9 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_task=ct.CheckTasks.err_res,
             check_items={
                 ct.err_code: 1100,
-                ct.err_msg: "Must specify exactly one valid Drop identifier (drop_field_name/drop_field_id/drop_function_name)",
+                ct.err_msg: (
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
+                ),
             },
         )
 
@@ -1367,14 +1367,19 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             collection_name,
             "missing_function",
             check_task=ct.CheckTasks.err_res,
-            check_items={ct.err_code: 1100, ct.err_msg: "function not found: missing_function: invalid parameter"},
+            check_items={
+                ct.err_code: 1100,
+                ct.err_msg: (
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
+                ),
+            },
         )
 
         desc = client.describe_collection(collection_name)
         assert "bm25" in [func["name"] for func in desc.get("functions", [])]
         assert "sparse" in [field["name"] for field in desc["fields"]]
 
-        # Step 3: Reject detach-only BM25 drop and verify schema stays unchanged.
+        # Step 3: Reject the deprecated API for an existing function and preserve its schema.
         self.drop_collection_function(
             client,
             collection_name,
@@ -1383,9 +1388,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "detaching a function without dropping its output field is not supported; "
-                    "drop_function always removes the function together with its output field: "
-                    "bm25: invalid parameter"
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
                 ),
             },
         )
@@ -1461,9 +1464,9 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
         """
         TC-L1-07a: Drop Function detach vs cascade semantics for MinHash.
 
-        target: verify MinHash detach-only drop is rejected and cascade-output-field drop works
-        method: drop_collection_function (detach) is rejected; drop_function_field removes function + output field/index
-        expected: detach rejected (function/field unchanged); cascade removes function, output field, and output index
+        target: verify the deprecated MinHash drop API is rejected and cascade-output-field drop works
+        method: drop_collection_function is rejected; drop_function_field removes function + output field/index
+        expected: deprecated API rejected (function/field unchanged); cascade removes function, output field, and output index
         """
         client = self._client()
         detach_collection_name = f"{cf.gen_collection_name_by_testcase_name()}_detach"
@@ -1527,7 +1530,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             assert len(search_res[0]) > 0
             assert "doc" in search_res[0][0]["entity"]
 
-        # Step 1: Detach-only MinHash drop is rejected; the function keeps its output field.
+        # Step 1: The deprecated MinHash drop API is rejected; the function keeps its output field.
         create_minhash_collection(detach_collection_name)
         self.drop_collection_function(
             client,
@@ -1537,9 +1540,7 @@ class TestMilvusClientDropFieldFeature(TestMilvusClientV2Base):
             check_items={
                 ct.err_code: 1100,
                 ct.err_msg: (
-                    "detaching a function without dropping its output field is not supported; "
-                    "drop_function always removes the function together with its output field: "
-                    "text_to_minhash: invalid parameter"
+                    "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field"
                 ),
             },
         )

--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -2965,7 +2965,7 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
 
         error = {
             ct.err_code: 1100,
-            ct.err_msg: "alter collection schema operation is not supported for external collection",
+            ct.err_msg: "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field",
         }
         self.drop_collection_function(
             client,

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -1,11 +1,11 @@
-import pytest
+import time
 
+import pytest
 from base.client_v2_base import TestMilvusClientV2Base
-from utils.util_log import test_log as log
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
-from utils.util_pymilvus import *
+from pymilvus import DataType
 
 prefix = "client_insert"
 epsilon = ct.epsilon
@@ -16,10 +16,10 @@ default_dim = ct.default_dim
 default_limit = ct.default_limit
 default_search_exp = "id >= 0"
 exp_res = "exp_res"
-default_search_string_exp = "varchar >= \"0\""
-default_search_mix_exp = "int64 >= 0 && varchar >= \"0\""
+default_search_string_exp = 'varchar >= "0"'
+default_search_mix_exp = 'int64 >= 0 && varchar >= "0"'
 default_invaild_string_exp = "varchar >= 0"
-default_json_search_exp = "json_field[\"number\"] >= 0"
+default_json_search_exp = 'json_field["number"] >= 0'
 perfix_expr = 'varchar like "0%"'
 default_search_field = ct.default_float_vec_field_name
 default_search_params = ct.default_search_params
@@ -35,13 +35,14 @@ default_int32_field_name = ct.default_int32_field_name
 default_int32_value = ct.default_int32_value
 default_timestamp_field_name = "timestamp"
 
-class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
 
+class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
     """
     ******************************************************************
     #  The following are valid base cases
     ******************************************************************
     """
+
     @pytest.mark.tags(CaseLabel.L0)
     def test_milvus_client_timestamptz_UTC(self):
         """
@@ -59,23 +60,27 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: generate rows and insert the rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
 
         # step 3: query the rows
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: rows,
-                                         "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
 
         self.drop_collection(client, collection_name)
 
@@ -98,33 +103,37 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
 
         self.create_database(client, db_name)
         self.use_database(client, db_name)
-        self.alter_database_properties(client, db_name, properties={"timezone": IANA_timezone}) 
+        self.alter_database_properties(client, db_name, properties={"timezone": IANA_timezone})
         prop = self.describe_database(client, db_name)
         assert prop[0]["timezone"] == IANA_timezone
 
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
         prop = self.describe_collection(client, collection_name)[0].get("properties")
         assert prop["timezone"] == IANA_timezone
-        
+
         # step 2: generate rows and insert the rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
 
         # step 3: query the rows
         new_rows = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone)
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: new_rows,
-                                         "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows, "pk_name": default_primary_key_field_name},
+        )
+
         self.drop_collection(client, collection_name)
         self.drop_database(client, db_name)
 
@@ -146,13 +155,14 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: alter collection properties
         self.alter_collection_properties(client, collection_name, properties={"timezone": IANA_timezone})
         prop = self.describe_collection(client, collection_name)[0].get("properties")
@@ -164,11 +174,14 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
 
         # step 4: query the rows
         new_rows = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone)
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: new_rows,
-                                "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows, "pk_name": default_primary_key_field_name},
+        )
+
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -189,36 +202,43 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: insert the rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
 
         # verify the rows are in UTC time
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                check_task=CheckTasks.check_query_results,
-                check_items={exp_res: rows,
-                            "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
 
         # step 3: alter collection properties
         self.alter_collection_properties(client, collection_name, properties={"timezone": IANA_timezone})
         prop = self.describe_collection(client, collection_name)[0].get("properties")
         assert prop["timezone"] == IANA_timezone
-        
+
         # step 4: query the rows
         new_rows = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone)
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: new_rows,
-                                    "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows, "pk_name": default_primary_key_field_name},
+        )
+
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -245,15 +265,29 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
         self.alter_database_properties(client, db_name, properties={"timezone": IANA_timezone_1})
-        self.create_collection(client, collection_name1, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params, database_name=db_name)
-        self.create_collection(client, collection_name2, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params, database_name=db_name)
+        self.create_collection(
+            client,
+            collection_name1,
+            default_dim,
+            schema=schema,
+            consistency_level="Strong",
+            index_params=index_params,
+            database_name=db_name,
+        )
+        self.create_collection(
+            client,
+            collection_name2,
+            default_dim,
+            schema=schema,
+            consistency_level="Strong",
+            index_params=index_params,
+            database_name=db_name,
+        )
 
         # step 2: alter collection properties of the 1 collections
         prop = self.describe_collection(client, collection_name1)[0].get("properties")
@@ -274,19 +308,25 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         # step 4: query the rows from the 2 collections
         new_rows1 = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone_1)
         new_rows2 = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone_2)
-        self.query(client, collection_name1, filter=f"{default_primary_key_field_name} >= 0",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: new_rows1,
-                                    "pk_name": default_primary_key_field_name})
-        self.query(client, collection_name2, filter=f"{default_primary_key_field_name} >= 0",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: new_rows2,
-                                    "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name1,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows1, "pk_name": default_primary_key_field_name},
+        )
+        self.query(
+            client,
+            collection_name2,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows2, "pk_name": default_primary_key_field_name},
+        )
+
         self.drop_collection(client, collection_name1)
         self.drop_collection(client, collection_name2)
         self.drop_database(client, db_name)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_alter_database_property_after_alter_collection_property(self):
         """
@@ -310,39 +350,46 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
 
         # step 2: alter collection properties
         self.alter_collection_properties(client, collection_name, properties={"timezone": IANA_timezone})
         prop = self.describe_collection(client, collection_name)[0].get("properties")
         assert prop["timezone"] == IANA_timezone
-        
+
         # step 3: insert the rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone)
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: rows,
-                                    "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
+
         # step 4: alter database property
         new_timezone = "Asia/Shanghai"
         self.alter_database_properties(client, db_name, properties={"timezone": new_timezone})
         prop = self.describe_database(client, db_name)[0]
         assert prop["timezone"] == new_timezone
 
-        # step 5: query the rows   
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: rows,
-                                    "pk_name": default_primary_key_field_name})
-        
+        # step 5: query the rows
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
+
         self.drop_collection(client, collection_name)
         self.drop_database(client, db_name)
 
@@ -366,13 +413,14 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: Alter collection properties
         self.alter_collection_properties(client, collection_name, properties={"timezone": IANA_timezone_1})
         prop = self.describe_collection(client, collection_name)[0].get("properties")
@@ -382,21 +430,26 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone_1)
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: rows,
-                                    "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
+
         # step 4: query the rows
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, IANA_timezone_2)
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                    check_task=CheckTasks.check_query_results,
-                    timezone=IANA_timezone_2,
-                    check_items={exp_res: rows,
-                                    "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            timezone=IANA_timezone_2,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
+
         self.drop_collection(client, collection_name)
-        
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_default_value(self):
@@ -414,13 +467,16 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True, default_value="2025-01-01T00:00:00")
-        index_params = self.prepare_index_params(client)[0] 
+        schema.add_field(
+            default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True, default_value="2025-01-01T00:00:00"
+        )
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
 
         # step 2: generate rows without timestamptz and insert the rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema, skip_field_names=[default_timestamp_field_name])
@@ -430,13 +486,16 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         for row in rows:
             row[default_timestamp_field_name] = "2025-01-01T00:00:00"
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: rows,
-                                         "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
+
         self.drop_collection(client, collection_name)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_search(self):
         """
@@ -454,32 +513,39 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: generate rows with timestamptz and insert the rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        
+
         # step 3: search with timestamptz expr
         vectors_to_search = cf.gen_vectors(1, default_dim, vector_data_type=DataType.FLOAT_VECTOR)
         insert_ids = [i for i in range(default_nb)]
-        self.search(client, collection_name, vectors_to_search, 
-                    timezone="Asia/Shanghai",
-                    time_fields="year, month, day, hour, minute, second, microsecond",
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"enable_milvus_client_api": True,
-                            "nq": len(vectors_to_search),
-                            "ids": insert_ids,
-                            "pk_name": default_primary_key_field_name,
-                            "limit": default_limit})
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            timezone="Asia/Shanghai",
+            time_fields="year, month, day, hour, minute, second, microsecond",
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": len(vectors_to_search),
+                "ids": insert_ids,
+                "pk_name": default_primary_key_field_name,
+                "limit": default_limit,
+            },
+        )
 
         self.drop_collection(client, collection_name)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_search_group_by(self):
         """
@@ -497,31 +563,38 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-    
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: generate rows with timestamptz and insert the rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        
+
         # step 3: search with group by timestamptz
         vectors_to_search = cf.gen_vectors(1, default_dim, vector_data_type=DataType.FLOAT_VECTOR)
         insert_ids = [i for i in range(default_nb)]
-        self.search(client, collection_name, vectors_to_search, 
-                    timezone="Asia/Shanghai",
-                    time_fields="year, month, day, hour, minute, second, microsecond",
-                    group_by_field=default_timestamp_field_name,
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"enable_milvus_client_api": True,
-                            "nq": len(vectors_to_search),
-                            "ids": insert_ids,
-                            "pk_name": default_primary_key_field_name,
-                            "limit": default_limit})
-        
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            timezone="Asia/Shanghai",
+            time_fields="year, month, day, hour, minute, second, microsecond",
+            group_by_field=default_timestamp_field_name,
+            check_task=CheckTasks.check_search_results,
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": len(vectors_to_search),
+                "ids": insert_ids,
+                "pk_name": default_primary_key_field_name,
+                "limit": default_limit,
+            },
+        )
+
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -542,48 +615,66 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: add collection field with timestamptz
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        self.add_collection_field(client, collection_name, field_name=default_timestamp_field_name, data_type=DataType.TIMESTAMPTZ,
-                                  nullable=True)
+        self.add_collection_field(
+            client,
+            collection_name,
+            field_name=default_timestamp_field_name,
+            data_type=DataType.TIMESTAMPTZ,
+            nullable=True,
+        )
         index_params.add_index(default_timestamp_field_name, index_type="STL_SORT")
         self.create_index(client, collection_name, index_params=index_params)
 
         # step 3: query the rows
         for row in rows:
             row[default_timestamp_field_name] = None
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: rows,
-                                         "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
 
         # step 4: insert new rows and query the rows
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
         new_rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema, start=default_nb)
         self.insert(client, collection_name, new_rows)
         new_rows = cf.convert_timestamptz(new_rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= {default_nb}",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: new_rows,
-                                         "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= {default_nb}",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows, "pk_name": default_primary_key_field_name},
+        )
+
         # step 5: partial update the rows and query the rows
-        pu_rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema, 
-                                            desired_field_names=[default_primary_key_field_name, default_timestamp_field_name])
+        pu_rows = cf.gen_row_data_by_schema(
+            nb=default_nb,
+            schema=schema,
+            desired_field_names=[default_primary_key_field_name, default_timestamp_field_name],
+        )
         self.upsert(client, collection_name, pu_rows, partial_update=True)
         pu_rows = cf.convert_timestamptz(pu_rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"0 <= {default_primary_key_field_name} < {default_nb}",
-                            check_task=CheckTasks.check_query_results,
-                            output_fields=[default_timestamp_field_name],
-                            check_items={exp_res: pu_rows,
-                                         "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"0 <= {default_primary_key_field_name} < {default_nb}",
+            check_task=CheckTasks.check_query_results,
+            output_fields=[default_timestamp_field_name],
+            check_items={exp_res: pu_rows, "pk_name": default_primary_key_field_name},
+        )
 
         self.drop_collection(client, collection_name)
 
@@ -605,25 +696,31 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: insert rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        
+
         # step 3: add field with timestamptz
-        self.add_collection_field(client, collection_name, field_name=default_timestamp_field_name, data_type=DataType.TIMESTAMPTZ,
-                                  nullable=True)
+        self.add_collection_field(
+            client,
+            collection_name,
+            field_name=default_timestamp_field_name,
+            data_type=DataType.TIMESTAMPTZ,
+            nullable=True,
+        )
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
         index_params.add_index(default_timestamp_field_name, index_type="STL_SORT")
         self.create_index(client, collection_name, index_params=index_params)
         new_rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema, start=default_nb)
         self.insert(client, collection_name, new_rows)
-        
+
         # step 4: compact
         compact_id = self.compact(client, collection_name, is_clustering=False)[0]
         cost = 180
@@ -635,7 +732,7 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
                 break
             if time.time() - start > cost:
                 raise Exception(1, f"Compact after index cost more than {cost}s")
-        
+
         # step 5: query the rows
         # first release the collection
         self.release_collection(client, collection_name)
@@ -644,16 +741,22 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         # then query the rows
         for row in rows:
             row[default_timestamp_field_name] = None
-        self.query(client, collection_name, filter=f"0 <= {default_primary_key_field_name} < {default_nb}",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: rows,
-                                    "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"0 <= {default_primary_key_field_name} < {default_nb}",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
 
         new_rows = cf.convert_timestamptz(new_rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= {default_nb}",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: new_rows,
-                                    "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= {default_nb}",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows, "pk_name": default_primary_key_field_name},
+        )
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -673,45 +776,61 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: insert rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        
+
         # step 3: add field with timestamptz
-        self.add_collection_field(client, collection_name, field_name=default_timestamp_field_name, data_type=DataType.TIMESTAMPTZ,
-                                  nullable=True)
+        self.add_collection_field(
+            client,
+            collection_name,
+            field_name=default_timestamp_field_name,
+            data_type=DataType.TIMESTAMPTZ,
+            nullable=True,
+        )
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
         self.create_index(client, collection_name, index_params=index_params)
-        
+
         # step 4: search the rows
         vectors_to_search = cf.gen_vectors(1, default_dim, vector_data_type=DataType.FLOAT_VECTOR)
         insert_ids = [i for i in range(default_nb)]
-        check_items = {"enable_milvus_client_api": True,
-                        "nq": len(vectors_to_search),
-                        "ids": insert_ids,
-                        "pk_name": default_primary_key_field_name,
-                        "limit": default_limit}
-        self.search(client, collection_name, vectors_to_search, 
-                    filter=f"{default_timestamp_field_name} is null",
-                    check_task=CheckTasks.check_search_results,
-                    check_items=check_items)
+        check_items = {
+            "enable_milvus_client_api": True,
+            "nq": len(vectors_to_search),
+            "ids": insert_ids,
+            "pk_name": default_primary_key_field_name,
+            "limit": default_limit,
+        }
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            filter=f"{default_timestamp_field_name} is null",
+            check_task=CheckTasks.check_search_results,
+            check_items=check_items,
+        )
 
         new_rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, new_rows)
-        self.search(client, collection_name, vectors_to_search,
-                    filter=f"{default_timestamp_field_name} is not null",
-                    check_task=CheckTasks.check_search_results,
-                    check_items=check_items)
-        
+        self.search(
+            client,
+            collection_name,
+            vectors_to_search,
+            filter=f"{default_timestamp_field_name} is not null",
+            check_task=CheckTasks.check_search_results,
+            check_items=check_items,
+        )
+
         self.drop_collection(client, collection_name)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_add_field_with_default_value(self):
         """
@@ -728,30 +847,40 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: add field with timestamptz and default value
         default_timestamp_value = "2025-01-01T00:00:00Z"
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        self.add_collection_field(client, collection_name, field_name=default_timestamp_field_name, data_type=DataType.TIMESTAMPTZ,
-                                  nullable=True, default_value=default_timestamp_value)
+        self.add_collection_field(
+            client,
+            collection_name,
+            field_name=default_timestamp_field_name,
+            data_type=DataType.TIMESTAMPTZ,
+            nullable=True,
+            default_value=default_timestamp_value,
+        )
         index_params.add_index(default_timestamp_field_name, index_type="STL_SORT")
         self.create_index(client, collection_name, index_params=index_params)
-        
+
         # step 3: query the rows
         for row in rows:
             row[default_timestamp_field_name] = default_timestamp_value
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: rows,
-                                         "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows, "pk_name": default_primary_key_field_name},
+        )
+
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -777,17 +906,23 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="STL_SORT")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: insert rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        
+
         # step 3: add another timestamptz field
-        self.add_collection_field(client, collection_name, field_name=default_timestamp_field_name + "_new", data_type=DataType.TIMESTAMPTZ,
-                                  nullable=True)
-        schema.add_field(default_timestamp_field_name + "_new", DataType.TIMESTAMPTZ, nullable=True) 
+        self.add_collection_field(
+            client,
+            collection_name,
+            field_name=default_timestamp_field_name + "_new",
+            data_type=DataType.TIMESTAMPTZ,
+            nullable=True,
+        )
+        schema.add_field(default_timestamp_field_name + "_new", DataType.TIMESTAMPTZ, nullable=True)
         index_params.add_index(default_timestamp_field_name + "_new", index_type="STL_SORT")
 
         # step 4: insert new rows
@@ -798,10 +933,13 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         # step 5: query the new rows
         new_rows = cf.convert_timestamptz(new_rows, default_timestamp_field_name + "_new", "UTC")
         new_rows = cf.convert_timestamptz(new_rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= {default_nb}",
-                    check_task=CheckTasks.check_query_results,
-                    check_items={exp_res: new_rows,
-                                    "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= {default_nb}",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows, "pk_name": default_primary_key_field_name},
+        )
 
         self.drop_collection(client, collection_name)
 
@@ -825,42 +963,49 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: insert rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        
+
         # step 3: delete the rows
-        self.delete(client, collection_name, filter=f"{default_primary_key_field_name} < {default_nb//2}")
-        
+        self.delete(client, collection_name, filter=f"{default_primary_key_field_name} < {default_nb // 2}")
+
         # step 4: flush the rows and query
         self.flush(client, collection_name)
         rows = cf.convert_timestamptz(rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: rows[default_nb//2:],
-                                         "pk_name": default_primary_key_field_name})
-        
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: rows[default_nb // 2 :], "pk_name": default_primary_key_field_name},
+        )
+
         # step 5: upsert the rows and flush
         new_rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.upsert(client, collection_name, new_rows)
         self.flush(client, collection_name)
-        
+
         # step 6: query the rows
         new_rows = cf.convert_timestamptz(new_rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: new_rows,
-                                         "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows, "pk_name": default_primary_key_field_name},
+        )
 
         self.drop_collection(client, collection_name)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_insert_upsert_flush_delete_upsert_flush(self):
         """
@@ -882,39 +1027,46 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: insert rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        
+
         # step 3: upsert the rows
-        partial_rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema, 
-                                                 desired_field_names=[default_primary_key_field_name, default_timestamp_field_name])
+        partial_rows = cf.gen_row_data_by_schema(
+            nb=default_nb,
+            schema=schema,
+            desired_field_names=[default_primary_key_field_name, default_timestamp_field_name],
+        )
         self.upsert(client, collection_name, partial_rows, partial_update=True)
 
         # step 4: flush the rows
         self.flush(client, collection_name)
-        
+
         # step 5: delete the rows
-        self.delete(client, collection_name, filter=f"{default_primary_key_field_name} < {default_nb//2}")
-        
+        self.delete(client, collection_name, filter=f"{default_primary_key_field_name} < {default_nb // 2}")
+
         # step 6: upsert the rows and flush
         new_rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.upsert(client, collection_name, new_rows)
         self.flush(client, collection_name)
-        
+
         # step 7: query the rows
         new_rows = cf.convert_timestamptz(new_rows, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                            check_task=CheckTasks.check_query_results,
-                            check_items={exp_res: new_rows,
-                                         "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: new_rows, "pk_name": default_primary_key_field_name},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_read_from_different_client(self):
@@ -933,44 +1085,51 @@ class TestMilvusClientTimestamptzValid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                                consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: insert rows
         rows = cf.gen_row_data_by_schema(nb=default_nb, schema=schema)
         self.insert(client, collection_name, rows)
-        
+
         # step 3: query the rows from different client in different timezone
         client2 = self._client(alias="client2_alias")
         UTC_time_row = cf.convert_timestamptz(rows, default_timestamp_field_name, "UTC")
         shanghai_rows = cf.convert_timestamptz(UTC_time_row, default_timestamp_field_name, "Asia/Shanghai")
         LA_rows = cf.convert_timestamptz(UTC_time_row, default_timestamp_field_name, "America/Los_Angeles")
-        result_1 = self.query(client, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                        check_task=CheckTasks.check_query_results,
-                        timezone="Asia/Shanghai",
-                        check_items={exp_res: shanghai_rows,
-                                        "pk_name": default_primary_key_field_name})[0]
-        result_2 = self.query(client2, collection_name, filter=f"{default_primary_key_field_name} >= 0",
-                        check_task=CheckTasks.check_query_results,
-                        timezone="America/Los_Angeles",
-                        check_items={exp_res: LA_rows,
-                                        "pk_name": default_primary_key_field_name})[0]
-        
+        result_1 = self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            timezone="Asia/Shanghai",
+            check_items={exp_res: shanghai_rows, "pk_name": default_primary_key_field_name},
+        )[0]
+        result_2 = self.query(
+            client2,
+            collection_name,
+            filter=f"{default_primary_key_field_name} >= 0",
+            check_task=CheckTasks.check_query_results,
+            timezone="America/Los_Angeles",
+            check_items={exp_res: LA_rows, "pk_name": default_primary_key_field_name},
+        )[0]
+
         assert len(result_1) == len(result_2) == default_nb
         self.drop_collection(client, collection_name)
 
 
 class TestMilvusClientTimestamptzInvalid(TestMilvusClientV2Base):
-
     """
     ******************************************************************
     #  The following are invalid base cases
     ******************************************************************
     """
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_input_data_invalid_time_format(self):
         """
@@ -983,38 +1142,58 @@ class TestMilvusClientTimestamptzInvalid(TestMilvusClientV2Base):
         """
         # step 1: create collection
         default_dim = 3
-        client = self._client() 
+        client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
-        
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
+
         # step 2: generate rows with invalid timestamptz and insert the rows
-        rows = [{default_primary_key_field_name: 0, default_vector_field_name: [1,2,3], default_timestamp_field_name: "invalid_time_format"},
-                # April 31 does not exist
-                {default_primary_key_field_name: 1, default_vector_field_name: [4,5,6], default_timestamp_field_name: "2025-04-31 00:00:00"},
-                # 2025 is not a leap year
-                {default_primary_key_field_name: 2, default_vector_field_name: [7,8,9], default_timestamp_field_name: "2025-02-29 00:00:00"},
-                # UTC+24:00 is not a valid timezone
-                {default_primary_key_field_name: 3, default_vector_field_name: [10,11,12], default_timestamp_field_name: "2025-01-01T00:00:00+24:00"}]
-        
+        rows = [
+            {
+                default_primary_key_field_name: 0,
+                default_vector_field_name: [1, 2, 3],
+                default_timestamp_field_name: "invalid_time_format",
+            },
+            # April 31 does not exist
+            {
+                default_primary_key_field_name: 1,
+                default_vector_field_name: [4, 5, 6],
+                default_timestamp_field_name: "2025-04-31 00:00:00",
+            },
+            # 2025 is not a leap year
+            {
+                default_primary_key_field_name: 2,
+                default_vector_field_name: [7, 8, 9],
+                default_timestamp_field_name: "2025-02-29 00:00:00",
+            },
+            # UTC+24:00 is not a valid timezone
+            {
+                default_primary_key_field_name: 3,
+                default_vector_field_name: [10, 11, 12],
+                default_timestamp_field_name: "2025-01-01T00:00:00+24:00",
+            },
+        ]
+
         # step 3: query the rows
         for row in rows:
             print(row[default_timestamp_field_name])
-            error = {ct.err_code: 1100, ct.err_msg: f"got invalid timestamptz string '{row[default_timestamp_field_name]}': invalid timezone name; must be a valid IANA Time Zone ID (e.g., 'Asia/Shanghai' or 'UTC'): invalid parameter"}
-            self.insert(client, collection_name, row, 
-                        check_task=CheckTasks.err_res, 
-                        check_items=error)
-        
+            error = {
+                ct.err_code: 1100,
+                ct.err_msg: f"got invalid timestamptz string '{row[default_timestamp_field_name]}': invalid timezone name; must be a valid IANA Time Zone ID (e.g., 'Asia/Shanghai' or 'UTC'): invalid parameter",
+            }
+            self.insert(client, collection_name, row, check_task=CheckTasks.err_res, check_items=error)
+
         self.drop_collection(client, collection_name)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_wrong_index_type(self):
         """
@@ -1030,15 +1209,21 @@ class TestMilvusClientTimestamptzInvalid(TestMilvusClientV2Base):
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="INVERTED")
         error = {ct.err_code: 1100, ct.err_msg: "INVERTED are not supported on Timestamptz field"}
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params,
-                               check_task=CheckTasks.err_res,
-                               check_items=error)
+        self.create_collection(
+            client,
+            collection_name,
+            default_dim,
+            schema=schema,
+            consistency_level="Strong",
+            index_params=index_params,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_wrong_default_value(self):
@@ -1057,24 +1242,42 @@ class TestMilvusClientTimestamptzInvalid(TestMilvusClientV2Base):
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True, default_value="timestamp")
 
-        error = {ct.err_code: 65536, ct.err_msg: "invalid timestamp string: 'timestamp'. Does not match any known format"}
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong",
-                               check_task=CheckTasks.err_res, check_items=error)
-        
-        # step 2: create collection 
+        error = {
+            ct.err_code: 65536,
+            ct.err_msg: "invalid timestamp string: 'timestamp'. Does not match any known format",
+        }
+        self.create_collection(
+            client,
+            collection_name,
+            default_dim,
+            schema=schema,
+            consistency_level="Strong",
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
+        # step 2: create collection
         new_schema = self.create_schema(client, enable_dynamic_field=False)[0]
         new_schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         new_schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
         new_schema.add_field(default_timestamp_field_name, DataType.TIMESTAMPTZ, nullable=True, default_value=10)
 
-        error = {ct.err_code: 65536, ct.err_msg: "type (Timestamptz) of field (timestamp) is not equal to the type(DataType_Int64) of default_value: invalid parameter"}
-        self.create_collection(client, collection_name, default_dim, schema=new_schema, 
-                               consistency_level="Strong",
-                               check_task=CheckTasks.err_res, check_items=error)
-        
+        error = {
+            ct.err_code: 65536,
+            ct.err_msg: "type (Timestamptz) of field (timestamp) is not equal to the type(DataType_Int64) of default_value: invalid parameter",
+        }
+        self.create_collection(
+            client,
+            collection_name,
+            default_dim,
+            schema=new_schema,
+            consistency_level="Strong",
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
         self.drop_collection(client, collection_name)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_add_field_not_nullable(self):
         """
@@ -1084,20 +1287,29 @@ class TestMilvusClientTimestamptzInvalid(TestMilvusClientV2Base):
             2. Add non-nullable timestamptz field
         expected: Step 2 should result fail
         """
-        # step 1: create collection 
+        # step 1: create collection
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong")
-        
+        self.create_collection(client, collection_name, default_dim, schema=schema, consistency_level="Strong")
+
         # step 2: add non-nullable timestamptz field
-        error = {ct.err_code: 1100, ct.err_msg: f"added field must be nullable, please check it, field name = {default_timestamp_field_name}: invalid parameter"}
-        self.add_collection_field(client, collection_name, field_name=default_timestamp_field_name, data_type=DataType.TIMESTAMPTZ,
-                                  nullable=False, check_task=CheckTasks.err_res, check_items=error)
-        
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: f"added field must be nullable, please check it, field name = {default_timestamp_field_name}: invalid parameter",
+        }
+        self.add_collection_field(
+            client,
+            collection_name,
+            field_name=default_timestamp_field_name,
+            data_type=DataType.TIMESTAMPTZ,
+            nullable=False,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
         self.drop_collection(client, collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -1115,20 +1327,27 @@ class TestMilvusClientTimestamptzInvalid(TestMilvusClientV2Base):
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
         schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
-        index_params = self.prepare_index_params(client)[0] 
+        index_params = self.prepare_index_params(client)[0]
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
-        self.create_collection(client, collection_name, default_dim, schema=schema, 
-                               consistency_level="Strong", index_params=index_params)
+        self.create_collection(
+            client, collection_name, default_dim, schema=schema, consistency_level="Strong", index_params=index_params
+        )
 
         # step 2: add field with default value for timestamptz field
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "invalid timestamp string: '1234'. Does not match any known format"}
-        self.add_collection_field(client, collection_name, field_name=default_timestamp_field_name, data_type=DataType.TIMESTAMPTZ,
-                                  nullable=True, default_value="1234", check_task=CheckTasks.err_res, check_items=error)
-        
-        self.drop_collection(client, collection_name)
+        error = {ct.err_code: 1100, ct.err_msg: "invalid default value of field, name: timestamp"}
+        self.add_collection_field(
+            client,
+            collection_name,
+            field_name=default_timestamp_field_name,
+            data_type=DataType.TIMESTAMPTZ,
+            nullable=True,
+            default_value="1234",
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
+        self.drop_collection(client, collection_name)
 
 
 COLLECTION_NAME = "test_timestamptz" + cf.gen_unique_str("_")
@@ -1140,53 +1359,187 @@ COLLECTION_NAME = "test_timestamptz" + cf.gen_unique_str("_")
 
 # test_edge_case: pk 0-9 (uses 0-3)
 EDGE_CASE_ROWS = [
-    {default_primary_key_field_name: 0, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "0000-01-01 00:00:00"},
-    {default_primary_key_field_name: 1, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "9999-12-31T23:59:59"},
-    {default_primary_key_field_name: 2, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "1970-01-01T00:00:00+01:00"},
-    {default_primary_key_field_name: 3, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2000-01-01T00:00:00+01:00"}]
+    {
+        default_primary_key_field_name: 0,
+        default_vector_field_name: [1, 2, 3],
+        default_timestamp_field_name: "0000-01-01 00:00:00",
+    },
+    {
+        default_primary_key_field_name: 1,
+        default_vector_field_name: [4, 5, 6],
+        default_timestamp_field_name: "9999-12-31T23:59:59",
+    },
+    {
+        default_primary_key_field_name: 2,
+        default_vector_field_name: [7, 8, 9],
+        default_timestamp_field_name: "1970-01-01T00:00:00+01:00",
+    },
+    {
+        default_primary_key_field_name: 3,
+        default_vector_field_name: [10, 11, 12],
+        default_timestamp_field_name: "2000-01-01T00:00:00+01:00",
+    },
+]
 
 # test_Feb_29: pk 10-19 (uses 10)
 FEB29_ROWS = [
-    {default_primary_key_field_name: 10, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2024-02-29T00:00:00+03:00"}]
+    {
+        default_primary_key_field_name: 10,
+        default_vector_field_name: [13, 14, 15],
+        default_timestamp_field_name: "2024-02-29T00:00:00+03:00",
+    }
+]
 
 # test_partial_update: pk 20-29 (base rows 20-24 inserted by fixture; test mutates this range only)
 PARTIAL_UPDATE_BASE_ROWS = [
-    {default_primary_key_field_name: 20, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "0000-01-01 00:00:00"},
-    {default_primary_key_field_name: 21, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "9999-12-31T23:59:59"},
-    {default_primary_key_field_name: 22, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "1970-01-01T00:00:00+01:00"},
-    {default_primary_key_field_name: 23, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2000-01-01T00:00:00+01:00"},
-    {default_primary_key_field_name: 24, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2024-02-29T00:00:00+03:00"}]
+    {
+        default_primary_key_field_name: 20,
+        default_vector_field_name: [1, 2, 3],
+        default_timestamp_field_name: "0000-01-01 00:00:00",
+    },
+    {
+        default_primary_key_field_name: 21,
+        default_vector_field_name: [4, 5, 6],
+        default_timestamp_field_name: "9999-12-31T23:59:59",
+    },
+    {
+        default_primary_key_field_name: 22,
+        default_vector_field_name: [7, 8, 9],
+        default_timestamp_field_name: "1970-01-01T00:00:00+01:00",
+    },
+    {
+        default_primary_key_field_name: 23,
+        default_vector_field_name: [10, 11, 12],
+        default_timestamp_field_name: "2000-01-01T00:00:00+01:00",
+    },
+    {
+        default_primary_key_field_name: 24,
+        default_vector_field_name: [13, 14, 15],
+        default_timestamp_field_name: "2024-02-29T00:00:00+03:00",
+    },
+]
 
 # test_query: pk 30-39 (uses 30-35)
 QUERY_ROWS = [
-    {default_primary_key_field_name: 30, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "1970-01-01 00:00:00"},
-    {default_primary_key_field_name: 31, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "2021-02-28T00:00:00Z"},
-    {default_primary_key_field_name: 32, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "2025-05-25T23:46:05"},
-    {default_primary_key_field_name: 33, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2025-05-30T23:46:05+05:30"},
-    {default_primary_key_field_name: 34, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2025-10-05 12:56:34"},
-    {default_primary_key_field_name: 35, default_vector_field_name: [16, 17, 18], default_timestamp_field_name: "9999-12-31T23:46:05"}]
+    {
+        default_primary_key_field_name: 30,
+        default_vector_field_name: [1, 2, 3],
+        default_timestamp_field_name: "1970-01-01 00:00:00",
+    },
+    {
+        default_primary_key_field_name: 31,
+        default_vector_field_name: [4, 5, 6],
+        default_timestamp_field_name: "2021-02-28T00:00:00Z",
+    },
+    {
+        default_primary_key_field_name: 32,
+        default_vector_field_name: [7, 8, 9],
+        default_timestamp_field_name: "2025-05-25T23:46:05",
+    },
+    {
+        default_primary_key_field_name: 33,
+        default_vector_field_name: [10, 11, 12],
+        default_timestamp_field_name: "2025-05-30T23:46:05+05:30",
+    },
+    {
+        default_primary_key_field_name: 34,
+        default_vector_field_name: [13, 14, 15],
+        default_timestamp_field_name: "2025-10-05 12:56:34",
+    },
+    {
+        default_primary_key_field_name: 35,
+        default_vector_field_name: [16, 17, 18],
+        default_timestamp_field_name: "9999-12-31T23:46:05",
+    },
+]
 
 # test_different_time_expressions: pk 40-49 (uses 40-47, inserted with Asia/Shanghai tz)
 TIME_EXPR_ROWS = [
-    {default_primary_key_field_name: 40, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "2024-12-31 22:00:00Z"},
-    {default_primary_key_field_name: 41, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "2024-12-31 22:00:00"},
-    {default_primary_key_field_name: 42, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "2024-12-31T22:00:00"},
-    {default_primary_key_field_name: 43, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2024-12-31T22:00:00+08:00"},
-    {default_primary_key_field_name: 44, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2024-12-31T22:00:00-08:00"},
-    {default_primary_key_field_name: 45, default_vector_field_name: [16, 17, 18], default_timestamp_field_name: "2024-12-31T22:00:00Z"},
-    {default_primary_key_field_name: 46, default_vector_field_name: [19, 20, 21], default_timestamp_field_name: "2024-12-31 22:00:00+08:00"},
-    {default_primary_key_field_name: 47, default_vector_field_name: [22, 23, 24], default_timestamp_field_name: "2024-12-31 22:00:00-08:00"}]
+    {
+        default_primary_key_field_name: 40,
+        default_vector_field_name: [1, 2, 3],
+        default_timestamp_field_name: "2024-12-31 22:00:00Z",
+    },
+    {
+        default_primary_key_field_name: 41,
+        default_vector_field_name: [4, 5, 6],
+        default_timestamp_field_name: "2024-12-31 22:00:00",
+    },
+    {
+        default_primary_key_field_name: 42,
+        default_vector_field_name: [7, 8, 9],
+        default_timestamp_field_name: "2024-12-31T22:00:00",
+    },
+    {
+        default_primary_key_field_name: 43,
+        default_vector_field_name: [10, 11, 12],
+        default_timestamp_field_name: "2024-12-31T22:00:00+08:00",
+    },
+    {
+        default_primary_key_field_name: 44,
+        default_vector_field_name: [13, 14, 15],
+        default_timestamp_field_name: "2024-12-31T22:00:00-08:00",
+    },
+    {
+        default_primary_key_field_name: 45,
+        default_vector_field_name: [16, 17, 18],
+        default_timestamp_field_name: "2024-12-31T22:00:00Z",
+    },
+    {
+        default_primary_key_field_name: 46,
+        default_vector_field_name: [19, 20, 21],
+        default_timestamp_field_name: "2024-12-31 22:00:00+08:00",
+    },
+    {
+        default_primary_key_field_name: 47,
+        default_vector_field_name: [22, 23, 24],
+        default_timestamp_field_name: "2024-12-31 22:00:00-08:00",
+    },
+]
 
 # test_different_timezone_query: pk 50-59 (uses 50-57, inserted with Asia/Shanghai tz)
 TZ_QUERY_ROWS = [
-    {default_primary_key_field_name: 50, default_vector_field_name: [1, 2, 3], default_timestamp_field_name: "2024-12-31 22:00:00Z"},
-    {default_primary_key_field_name: 51, default_vector_field_name: [4, 5, 6], default_timestamp_field_name: "2024-12-31 22:00:00"},
-    {default_primary_key_field_name: 52, default_vector_field_name: [7, 8, 9], default_timestamp_field_name: "2024-12-31T22:00:00"},
-    {default_primary_key_field_name: 53, default_vector_field_name: [10, 11, 12], default_timestamp_field_name: "2024-12-31T22:00:00+08:00"},
-    {default_primary_key_field_name: 54, default_vector_field_name: [13, 14, 15], default_timestamp_field_name: "2024-12-31T22:00:00-08:00"},
-    {default_primary_key_field_name: 55, default_vector_field_name: [16, 17, 18], default_timestamp_field_name: "2024-12-31T22:00:00Z"},
-    {default_primary_key_field_name: 56, default_vector_field_name: [19, 20, 21], default_timestamp_field_name: "2024-12-31 22:00:00+08:00"},
-    {default_primary_key_field_name: 57, default_vector_field_name: [22, 23, 24], default_timestamp_field_name: "2024-12-31 22:00:00-08:00"}]
+    {
+        default_primary_key_field_name: 50,
+        default_vector_field_name: [1, 2, 3],
+        default_timestamp_field_name: "2024-12-31 22:00:00Z",
+    },
+    {
+        default_primary_key_field_name: 51,
+        default_vector_field_name: [4, 5, 6],
+        default_timestamp_field_name: "2024-12-31 22:00:00",
+    },
+    {
+        default_primary_key_field_name: 52,
+        default_vector_field_name: [7, 8, 9],
+        default_timestamp_field_name: "2024-12-31T22:00:00",
+    },
+    {
+        default_primary_key_field_name: 53,
+        default_vector_field_name: [10, 11, 12],
+        default_timestamp_field_name: "2024-12-31T22:00:00+08:00",
+    },
+    {
+        default_primary_key_field_name: 54,
+        default_vector_field_name: [13, 14, 15],
+        default_timestamp_field_name: "2024-12-31T22:00:00-08:00",
+    },
+    {
+        default_primary_key_field_name: 55,
+        default_vector_field_name: [16, 17, 18],
+        default_timestamp_field_name: "2024-12-31T22:00:00Z",
+    },
+    {
+        default_primary_key_field_name: 56,
+        default_vector_field_name: [19, 20, 21],
+        default_timestamp_field_name: "2024-12-31 22:00:00+08:00",
+    },
+    {
+        default_primary_key_field_name: 57,
+        default_vector_field_name: [22, 23, 24],
+        default_timestamp_field_name: "2024-12-31 22:00:00-08:00",
+    },
+]
 
 
 @pytest.mark.xdist_group("TestMilvusClientTimestamptz")
@@ -1199,6 +1552,7 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
     All data is inserted once in the module-scoped fixture.
     #########################################################
     """
+
     @pytest.fixture(scope="class", autouse=True)
     def prepare_timestamptz_collection(self, request):
         """
@@ -1221,18 +1575,15 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="AUTOINDEX")
-        client.create_collection(collection_name, schema=schema,
-                                 consistency_level="Strong", index_params=index_params)
+        client.create_collection(collection_name, schema=schema, consistency_level="Strong", index_params=index_params)
 
         # --- UTC batch (naive timestamps → UTC) ---
-        self.alter_collection_properties(client, collection_name,
-                                         properties={"timezone": "UTC"})
+        self.alter_collection_properties(client, collection_name, properties={"timezone": "UTC"})
         utc_rows = EDGE_CASE_ROWS + FEB29_ROWS + PARTIAL_UPDATE_BASE_ROWS + QUERY_ROWS
         self.insert(client, collection_name, utc_rows)
 
         # --- Asia/Shanghai batch (naive timestamps → +08:00) ---
-        self.alter_collection_properties(client, collection_name,
-                                         properties={"timezone": "Asia/Shanghai"})
+        self.alter_collection_properties(client, collection_name, properties={"timezone": "Asia/Shanghai"})
         shanghai_rows = TIME_EXPR_ROWS + TZ_QUERY_ROWS
         self.insert(client, collection_name, shanghai_rows)
 
@@ -1242,6 +1593,7 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
                     self.drop_collection(self._client(), COLLECTION_NAME)
             except Exception:
                 pass
+
         request.addfinalizer(teardown)
 
     # ------------------------------------------------------------------
@@ -1258,12 +1610,14 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         client.load_collection(collection_name)
 
         expected = cf.convert_timestamptz(EDGE_CASE_ROWS, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name,
-                   filter=f"0 <= {default_primary_key_field_name} <= 3",
-                   timezone="UTC",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: expected,
-                                "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"0 <= {default_primary_key_field_name} <= 3",
+            timezone="UTC",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: expected, "pk_name": default_primary_key_field_name},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_Feb_29(self):
@@ -1275,12 +1629,14 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         client.load_collection(collection_name)
 
         expected = cf.convert_timestamptz(FEB29_ROWS, default_timestamp_field_name, "UTC")
-        self.query(client, collection_name,
-                   filter=f"{default_primary_key_field_name} == 10",
-                   timezone="UTC",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: expected,
-                                "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"{default_primary_key_field_name} == 10",
+            timezone="UTC",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: expected, "pk_name": default_primary_key_field_name},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_partial_update(self):
@@ -1297,17 +1653,20 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
             {default_primary_key_field_name: 21, default_timestamp_field_name: "2021-02-28T00:00:00Z"},
             {default_primary_key_field_name: 22, default_timestamp_field_name: "2025-05-25T23:46:05"},
             {default_primary_key_field_name: 23, default_timestamp_field_name: "2025-05-30T23:46:05+05:30"},
-            {default_primary_key_field_name: 24, default_timestamp_field_name: "2025-10-05 12:56:34"}]
+            {default_primary_key_field_name: 24, default_timestamp_field_name: "2025-10-05 12:56:34"},
+        ]
         self.upsert(client, collection_name, update_rows, partial_update=True)
 
         expected_update = cf.convert_timestamptz(update_rows, default_timestamp_field_name, "Asia/Shanghai")
-        self.query(client, collection_name,
-                   filter=f"20 <= {default_primary_key_field_name} <= 24",
-                   timezone="Asia/Shanghai",
-                   output_fields=[default_timestamp_field_name],
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: expected_update,
-                                "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"20 <= {default_primary_key_field_name} <= 24",
+            timezone="Asia/Shanghai",
+            output_fields=[default_timestamp_field_name],
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: expected_update, "pk_name": default_primary_key_field_name},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_query(self):
@@ -1326,47 +1685,64 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         shanghai_time_row = cf.convert_timestamptz(UTC_time_row, ts, "Asia/Shanghai")
 
         # all rows
-        self.query(client, collection_name,
-                   filter=pk_range,
-                   timezone="Asia/Shanghai",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: shanghai_time_row,
-                                "pk_name": pk})
+        self.query(
+            client,
+            collection_name,
+            filter=pk_range,
+            timezone="Asia/Shanghai",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: shanghai_time_row, "pk_name": pk},
+        )
         # >=
         expr = f"{pk_range} and {ts} >= ISO '2025-05-30T23:46:05+05:30'"
-        self.query(client, collection_name, filter=expr,
-                   timezone="Asia/Shanghai",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: shanghai_time_row[3:],
-                                "pk_name": pk})
+        self.query(
+            client,
+            collection_name,
+            filter=expr,
+            timezone="Asia/Shanghai",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: shanghai_time_row[3:], "pk_name": pk},
+        )
         # ==
         expr = f"{pk_range} and {ts} == ISO '9999-12-31T23:46:05Z'"
-        self.query(client, collection_name, filter=expr,
-                   timezone="Asia/Shanghai",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: [shanghai_time_row[-1]],
-                                "pk_name": pk})
+        self.query(
+            client,
+            collection_name,
+            filter=expr,
+            timezone="Asia/Shanghai",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: [shanghai_time_row[-1]], "pk_name": pk},
+        )
         # <=
         expr = f"{pk_range} and {ts} <= ISO '2025-01-01T00:00:00+08:00'"
-        self.query(client, collection_name, filter=expr,
-                   timezone="Asia/Shanghai",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: shanghai_time_row[:2],
-                                "pk_name": pk})
+        self.query(
+            client,
+            collection_name,
+            filter=expr,
+            timezone="Asia/Shanghai",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: shanghai_time_row[:2], "pk_name": pk},
+        )
         # !=
         expr = f"{pk_range} and {ts} != ISO '9999-12-31T23:46:05Z'"
-        self.query(client, collection_name, filter=expr,
-                   timezone="Asia/Shanghai",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: shanghai_time_row[:-1],
-                                "pk_name": pk})
+        self.query(
+            client,
+            collection_name,
+            filter=expr,
+            timezone="Asia/Shanghai",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: shanghai_time_row[:-1], "pk_name": pk},
+        )
         # INTERVAL
         expr = f"{pk_range} and {ts} - INTERVAL 'P3D' >= ISO '1970-01-01T00:00:00Z'"
-        self.query(client, collection_name, filter=expr,
-                   timezone="Asia/Shanghai",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: shanghai_time_row[1:],
-                                "pk_name": pk})
+        self.query(
+            client,
+            collection_name,
+            filter=expr,
+            timezone="Asia/Shanghai",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: shanghai_time_row[1:], "pk_name": pk},
+        )
 
         # lower < tz < upper
         # BUG: https://github.com/milvus-io/milvus/issues/44600
@@ -1386,11 +1762,13 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         client.load_collection(collection_name)
 
         expected_rows = cf.convert_timestamptz(TIME_EXPR_ROWS, default_timestamp_field_name, "Asia/Shanghai")
-        self.query(client, collection_name,
-                   filter=f"40 <= {default_primary_key_field_name} <= 47",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: expected_rows,
-                                "pk_name": default_primary_key_field_name})
+        self.query(
+            client,
+            collection_name,
+            filter=f"40 <= {default_primary_key_field_name} <= 47",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: expected_rows, "pk_name": default_primary_key_field_name},
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_timestamptz_different_timezone_query(self):
@@ -1420,43 +1798,54 @@ class TestMilvusClientTimestamptz(TestMilvusClientV2Base):
         # pk 50 and 55 both have "...22:00:00Z" → 2024-12-31 22:00:00 UTC
         expected_rows = [
             {pk: 50, default_vector_field_name: [1, 2, 3], ts: "2025-01-01T06:00:00+08:00"},
-            {pk: 55, default_vector_field_name: [16, 17, 18], ts: "2025-01-01T06:00:00+08:00"}]
-        self.query(client, collection_name,
-                   filter=f"{pk_range} and {ts} == ISO '2024-12-31T22:00:00Z'",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: expected_rows,
-                                "pk_name": pk})
+            {pk: 55, default_vector_field_name: [16, 17, 18], ts: "2025-01-01T06:00:00+08:00"},
+        ]
+        self.query(
+            client,
+            collection_name,
+            filter=f"{pk_range} and {ts} == ISO '2024-12-31T22:00:00Z'",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: expected_rows, "pk_name": pk},
+        )
 
         # filter: naive "17:00:00", timezone: Asia/Shanghai → interpreted as 17:00:00+08:00 = 09:00 UTC
         # No row has 09:00 UTC → empty result
         expected_rows = []
-        self.query(client, collection_name,
-                   filter=f"{pk_range} and {ts} == ISO '2024-12-31 17:00:00'",
-                   timezone="Asia/Shanghai",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: expected_rows,
-                                "pk_name": pk})
+        self.query(
+            client,
+            collection_name,
+            filter=f"{pk_range} and {ts} == ISO '2024-12-31 17:00:00'",
+            timezone="Asia/Shanghai",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: expected_rows, "pk_name": pk},
+        )
 
         # filter: naive "17:00:00", timezone: America/New_York → interpreted as 17:00:00-05:00 = 22:00 UTC
         # Matches pk 50 and 55
         expected_rows = [
             {pk: 50, default_vector_field_name: [1, 2, 3], ts: "2024-12-31T17:00:00-05:00"},
-            {pk: 55, default_vector_field_name: [16, 17, 18], ts: "2024-12-31T17:00:00-05:00"}]
-        self.query(client, collection_name,
-                   filter=f"{pk_range} and {ts} == ISO '2024-12-31 17:00:00'",
-                   timezone="America/New_York",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: expected_rows,
-                                "pk_name": pk})
+            {pk: 55, default_vector_field_name: [16, 17, 18], ts: "2024-12-31T17:00:00-05:00"},
+        ]
+        self.query(
+            client,
+            collection_name,
+            filter=f"{pk_range} and {ts} == ISO '2024-12-31 17:00:00'",
+            timezone="America/New_York",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: expected_rows, "pk_name": pk},
+        )
 
         # filter: naive "06:00:00", timezone: Asia/Shanghai → interpreted as 06:00:00+08:00 = 22:00 UTC
         # Matches pk 50 and 55
         expected_rows = [
             {pk: 50, default_vector_field_name: [1, 2, 3], ts: "2025-01-01T06:00:00+08:00"},
-            {pk: 55, default_vector_field_name: [16, 17, 18], ts: "2025-01-01T06:00:00+08:00"}]
-        self.query(client, collection_name,
-                   filter=f"{pk_range} and {ts} == ISO '2025-01-01 06:00:00'",
-                   timezone="Asia/Shanghai",
-                   check_task=CheckTasks.check_query_results,
-                   check_items={exp_res: expected_rows,
-                                "pk_name": pk})
+            {pk: 55, default_vector_field_name: [16, 17, 18], ts: "2025-01-01T06:00:00+08:00"},
+        ]
+        self.query(
+            client,
+            collection_name,
+            filter=f"{pk_range} and {ts} == ISO '2025-01-01 06:00:00'",
+            timezone="Asia/Shanghai",
+            check_task=CheckTasks.check_query_results,
+            check_items={exp_res: expected_rows, "pk_name": pk},
+        )

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -23,8 +23,8 @@ pytest-sugar==0.9.5
 pytest-random-order
 
 # pymilvus
-pymilvus==3.0.1rc66
-pymilvus[bulk_writer]==3.0.1rc66
+pymilvus==3.0.1rc74
+pymilvus[bulk_writer]==3.0.1rc74
 # for protobuf
 protobuf>=5.29.5
 

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -885,7 +885,7 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
             assert False, "Expected exception: drop_collection_function is no longer supported"
         except Exception as e:
             log.info(f"Expected error: {e}")
-            assert "not supported" in str(e)
+            assert "DropCollectionFunction RPC is no longer supported; drop a function via drop_function_field" in str(e)
 
     # ==================== alter_collection_function tests ====================
 


### PR DESCRIPTION
Cherry-pick from master
pr: #51939

## Summary

- Align deprecated DropCollectionFunction expectations with the legacy RPC rejection.
- Update the 3.0 Python client test dependency to pymilvus-3.0.1rc74.
- Format test_milvus_client_timestamptz.py and replace its wildcard import with explicit imports so it passes Ruff. The file has accumulated historical formatting debt, so this mechanical formatting accounts for the large diff (832 added / 443 removed lines); it does not alter the test cases beyond the already-described expectation update.

## Test Plan

- ruff check and formatting check for test_milvus_client_timestamptz.py
- Python bytecode compilation for test_milvus_client_timestamptz.py
- Collected the three updated Drop Function cases with pytest
- Verified the RC74 client route with the L0 Search Iterator test
- git diff --check