### PR TITLE
fix: avoid duplicate external loading resource reservation

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -152,10 +152,11 @@ type resourceEstimateFactor struct {
 	TieredEvictableMemoryCacheRatio float64
 	TieredEvictableDiskCacheRatio   float64
 	// externalRawDataFactor is the peak-memory safety factor for external
-	// segments. External tables always download, decompress and deserialize
-	// row groups into Arrow buffers regardless of mmap / TieredEviction
-	// settings, so peak transient memory = rawDataSize * factor. Defaults
-	// to 2.0 via paramtable queryNode.externalCollection.rawDataFactor.
+	// segments when tiered eviction is disabled. With tiered eviction enabled,
+	// the caching layer reserves transient loading overhead from the sampled
+	// external row size, so applying this factor in Go would reserve the same
+	// raw-data memory twice. Defaults to 2.0 via paramtable
+	// queryNode.externalCollection.rawDataFactor.
 	externalRawDataFactor float64
 }
 
@@ -2284,10 +2285,12 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 	// External segments carry pre-computed MemorySize in fake binlogs (from
 	// DataNode Take sampling). Adjust the memory estimate for two external-
 	// specific behaviors:
-	//   1. Non-lazy path: apply externalRawDataFactor to cover the peak
-	//      transient memory during download + decompress + Arrow deserialize
-	//      (normal packed segments do not have this peak because their
-	//      binlogs are already in Arrow IPC format).
+	//   1. Non-lazy path without tiered eviction: apply externalRawDataFactor
+	//      to cover the peak transient memory during download + decompress +
+	//      Arrow deserialize (normal packed segments do not have this peak
+	//      because their binlogs are already in Arrow IPC format). When tiered
+	//      eviction is enabled, the caching layer reserves this loading
+	//      overhead, so Go must not reserve the same raw-data margin again.
 	//   2. Full-lazy path (all external fields warmup=disable): no eager
 	//      load, so subtract the raw data size that PART 2 added.
 	// Also propagate EstimatedBytesPerRow to the C++ ManifestGroupTranslator
@@ -2307,9 +2310,11 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 			} else {
 				segMemoryLoadingSize = 0
 			}
-		} else if factor := multiplyFactor.externalRawDataFactor; factor > 1.0 {
-			// Non-lazy → add peak margin on top of rawSize that PART 2 added.
-			segMemoryLoadingSize += uint64(float64(fakeBinlogMemSize) * (factor - 1.0))
+		} else if !multiplyFactor.TieredEvictionEnabled {
+			if factor := multiplyFactor.externalRawDataFactor; factor > 1.0 {
+				// Non-lazy → add peak margin on top of rawSize that PART 2 added.
+				segMemoryLoadingSize += uint64(float64(fakeBinlogMemSize) * (factor - 1.0))
+			}
 		}
 	}
 

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -2482,6 +2482,28 @@ func (suite *ExternalSegmentEstimateSuite) TestExternalRawDataFactor() {
 	suite.True(usage.MemorySize >= 150000, "should include raw data factor: got %d", usage.MemorySize)
 }
 
+func (suite *ExternalSegmentEstimateSuite) TestExternalRawDataFactorSkippedWithTieredEviction() {
+	loadInfo := suite.externalLoadInfo(1000, 100000)
+	factor := resourceEstimateFactor{
+		externalRawDataFactor: 2.0,
+		TieredEvictionEnabled: true,
+	}
+
+	usage, err := estimateLoadingResourceUsageOfSegment(suite.schema, loadInfo, factor)
+	suite.NoError(err)
+	suite.Equal(int64(100), loadInfo.EstimatedBytesPerRow)
+
+	baselineLoadInfo := suite.externalLoadInfo(1000, 100000)
+	baselineFactor := resourceEstimateFactor{
+		externalRawDataFactor: 1.0,
+		TieredEvictionEnabled: true,
+	}
+	baselineUsage, err := estimateLoadingResourceUsageOfSegment(suite.schema, baselineLoadInfo, baselineFactor)
+	suite.NoError(err)
+	suite.Equal(baselineUsage.MemorySize, usage.MemorySize)
+	suite.Equal(baselineUsage.DiskSize, usage.DiskSize)
+}
+
 func (suite *ExternalSegmentEstimateSuite) TestExternalRawDataFactor_NoExtraWhenFactorLe1() {
 	loadInfo := suite.externalLoadInfo(1000, 100000)
 	factor := resourceEstimateFactor{externalRawDataFactor: 0.8}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5231,7 +5231,7 @@ user-task-polling:
 		Key:          "queryNode.externalCollection.rawDataFactor",
 		Version:      "3.0.0",
 		DefaultValue: "2.0",
-		Doc:          "Peak memory amplification factor for external segment loading. External tables always download, decompress, and deserialize entire row groups into Arrow buffers regardless of mmap/eviction settings, so peak transient memory = rawDataSize * this factor.",
+		Doc:          "Peak memory amplification factor for external segment loading when tiered eviction is disabled. With tiered eviction enabled, the caching layer accounts for transient loading overhead.",
 		Export:       false,
 	}
 	p.ExternalCollectionRawDataFactor.Init(base.mgr)


### PR DESCRIPTION
issue: #45881

## What changed

- Apply `externalCollection.rawDataFactor` only when tiered eviction is
  disabled.
- Preserve `EstimatedBytesPerRow` for the C++ caching layer.
- Add regression coverage showing factors 1.0 and 2.0 produce the same
  tiered estimate.
- Clarify the configuration boundary.

## Why

Tiered external loading already reserves cell storage and transient
loading overhead in the caching layer. Applying the Go-side factor as
well reserves the sampled raw-data margin twice, which can reject mmap
warmup loads even when the real resource requirement fits.

The non-tiered path still uses the default factor of 2.0.

## Validation

- `git diff --check`
- `check-commit`, compilation, and tests were not run per request.
