### PR TITLE
fix: [2.6] bound QueryNode queue-full retries

### DIFF
--- a/internal/proxy/shardclient/lb_policy.go
+++ b/internal/proxy/shardclient/lb_policy.go
@@ -262,8 +262,15 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 		zap.String("channelName", workload.Channel),
 	)
 	var lastErr error
+	var overloadErr error
+	var err error
+	var shardLeaders []NodeInfo
 	excludeNodes := typeutil.NewUniqueSet()
 	tryExecute := func() (bool, error) {
+		if overloadErr != nil && len(shardLeaders) > 0 && excludeNodes.Len() >= len(shardLeaders) {
+			return false, overloadErr
+		}
+
 		balancer := lb.getBalancer()
 		targetNode, selectedByBalancer, err := lb.selectNode(ctx, balancer, workload, &excludeNodes)
 		if err != nil {
@@ -272,6 +279,9 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 				zap.Int64s("excluded", excludeNodes.Collect()),
 				zap.Error(err),
 			)
+			if overloadErr != nil {
+				return false, overloadErr
+			}
 			if lastErr != nil {
 				return true, lastErr
 			}
@@ -304,6 +314,14 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 			if merr.GetErrorType(err) == merr.InputError {
 				return false, err
 			}
+			// Queue saturation is a transient overload signal from a healthy
+			// QueryNode. Try each replica at most once, then return the overload
+			// to the caller instead of cycling through saturated replicas.
+			if errors.Is(err, merr.ErrServiceTooManyRequests) {
+				excludeNodes.Insert(targetNode.NodeID)
+				overloadErr = err
+				return true, err
+			}
 			excludeNodes.Insert(targetNode.NodeID)
 			lastErr = errors.Wrapf(err, "failed to search/query delegator %d for channel %s", targetNode.NodeID, workload.Channel)
 			return true, lastErr
@@ -312,7 +330,7 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 		return true, nil
 	}
 
-	shardLeaders, err := lb.GetShard(ctx, workload.Db, workload.CollectionName, workload.CollectionID, workload.Channel, true)
+	shardLeaders, err = lb.GetShard(ctx, workload.Db, workload.CollectionName, workload.CollectionID, workload.Channel, true)
 	if err != nil {
 		log.Warn("failed to get shard leaders", zap.Error(err))
 		return err

--- a/internal/proxy/shardclient/lb_policy_test.go
+++ b/internal/proxy/shardclient/lb_policy_test.go
@@ -696,6 +696,122 @@ func (s *LBPolicySuite) TestExecuteWithRetryInputErrorNotRetried() {
 	s.Equal(1, execCount)
 }
 
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsStopsAfterReplicaSweep() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{{NodeID: 1, Address: "localhost:9000", Serviceable: true}}
+	s.lbPolicy.retryOnReplica = 5
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil)
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	execCount := 0
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			execCount++
+			return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+		},
+	})
+
+	s.ErrorIs(err, merr.ErrServiceTooManyRequests)
+	s.Equal(1, execCount)
+	status := merr.Status(err)
+	s.Equal(int32(4), status.GetCode())
+	s.True(status.GetRetriable())
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsFailsOverToAnotherReplica() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 5
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil)
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			return availableNodes[0], nil
+		})
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	executedNodes := make([]int64, 0, len(nodes))
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			if len(executedNodes) == 1 {
+				return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+			}
+			return nil
+		},
+	})
+
+	s.NoError(err)
+	s.Len(executedNodes, 2)
+	s.NotEqual(executedNodes[0], executedNodes[1])
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsTriesEachReplicaOnce() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 5
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil)
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			return availableNodes[0], nil
+		})
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	executedNodes := make([]int64, 0, len(nodes))
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+		},
+	})
+
+	s.ErrorIs(err, merr.ErrServiceTooManyRequests)
+	s.Len(executedNodes, len(nodes))
+	s.ElementsMatch([]int64{1, 2}, executedNodes)
+	status := merr.Status(err)
+	s.Equal(int32(4), status.GetCode())
+	s.True(status.GetRetriable())
+}
+
 func (s *LBPolicySuite) TestExecuteOneChannel() {
 	ctx := context.Background()
 	mockErr := errors.New("mock error")


### PR DESCRIPTION
issue: #51948
pr: #51974

3.0 PR: #51975

## What changed

- Treat `ErrServiceTooManyRequests` as request-scoped QueryNode saturation.
- Exclude the saturated QueryNode for the current request and preserve one failover pass across the remaining cached replicas.
- Once all cached replicas have been attempted, stop before any uncached shard-leader refresh and return the original code 4 status with `Retriable=true`.
- Keep shard-leader refresh and exclusion-set recycling only for non-overload failures.
- Cover single-replica saturation, successful two-replica failover, all-replicas-saturated behavior, and the absence of `GetShard(false)` on overload paths.

## Root cause

The load-balancing policy treated queue-full as a generic execution failure. Once every replica was excluded, shard selection cleared the exclusion set and cycled through the same saturated replicas again according to `retryOnReplica`. In the reported single-replica deployment, that meant one initial QueryNode execution plus five repeated executions of the same workload per channel.

An intermediate version stopped that QueryNode retry cycle only after `GetShard(false)`. Because uncached shard lookup refreshes the collection shard-leader cache through `MixCoord.GetShardLeaders`, it added one coordinator RPC per failed channel workload. The overload check now runs before that refresh.

## Behavior

- Single replica: execute on the QueryNode once, then return the overload status without an uncached shard refresh.
- Multiple replicas: a queue-full response can fail over to each cached, untried replica within the same request.
- All cached replicas saturated: each replica is attempted at most once; no `GetShard(false)` or exclusion-set clearing occurs.
- The original retriable status reaches the client; automatic backoff still depends on the SDK or application retry policy.

## Validation

- `git diff --check`
- Added regression tests for the behaviors above; an unexpected `GetShard(false)` call fails those tests because no uncached lookup mock is registered.
- The focused 2.6 test was attempted with the required `dynamic,test` tags and debug gcflags. Compilation is blocked before the shard-client package runs because the available local core build exposes the newer FFI ABI while this branch expects `FFIResult`, `FreeFFIResult`, `GetErrorMessage`, and related older symbols in `internal/storagev2/packed`.
- The equivalent full shard-client suite passes on master and 3.0.
