### PR TITLE
fix: stabilize growing nullable bitset snapshot

### DIFF
--- a/internal/core/src/common/OffsetMapping.cpp
+++ b/internal/core/src/common/OffsetMapping.cpp
@@ -396,9 +396,15 @@ GrowingOffsetMapping::TransformBitset(const BitsetView& bitset,
     }
     const auto valid_count = valid_count_;
     const auto total_count = total_count_;
-    BitsetTransformStatus status;
-    if (ShouldSkipBitsetTransform(bitset, total_count, result, status)) {
-        return status;
+
+    result.clear();
+    if (bitset.all()) {
+        return BitsetTransformStatus::AllFiltered;
+    }
+
+    if (static_cast<int64_t>(bitset.size()) >= total_count && bitset.none()) {
+        result.resize(valid_count, false);
+        return BitsetTransformStatus::Transformed;
     }
 
     result.resize(valid_count, true);

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -196,22 +196,19 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
 
         TargetBitmap transformed_bitset;
         BitsetView search_bitset = bitset;
-        if (has_offset_mapping && !bitset.empty()) {
+        int64_t active_count = 0;
+        if (has_offset_mapping) {
             auto status =
                 offset_mapping.TransformBitset(bitset, transformed_bitset);
             if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
                 FillEmptySearchResult(search_result, num_queries, info.topk_);
                 return;
             }
-            if (status == OffsetMapping::BitsetTransformStatus::NoFilter) {
-                search_bitset = BitsetView{};
-            }
+            active_count = static_cast<int64_t>(transformed_bitset.size());
+        } else {
+            active_count = std::min(int64_t(bitset.size()),
+                                    segment.get_active_count(timestamp));
         }
-
-        auto active_count = has_offset_mapping
-                                ? offset_mapping.GetValidCount()
-                                : std::min(int64_t(bitset.size()),
-                                           segment.get_active_count(timestamp));
 
         // Check for nullable vector field with all null values
         if (active_count == 0) {
@@ -219,8 +216,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             FillEmptySearchResult(search_result, num_queries, info.topk_);
             return;
         }
-        if (has_offset_mapping && !bitset.empty() &&
-            !transformed_bitset.empty()) {
+        if (has_offset_mapping && !transformed_bitset.empty()) {
             search_bitset =
                 search_result.PinBitset(std::move(transformed_bitset));
         }

--- a/internal/core/src/segcore/UtilsTest.cpp
+++ b/internal/core/src/segcore/UtilsTest.cpp
@@ -433,6 +433,30 @@ TEST(Util_Segcore, TransformBitsetMasksNullableVectorRowsOutsideLogicalView) {
     EXPECT_TRUE(physical_bitset[2]);
 }
 
+TEST(Util_Segcore, GrowingTransformBitsetMaterializesNoFilterSnapshot) {
+    using namespace milvus;
+
+    std::array<bool, 5> valid_data = {true, true, false, true, true};
+    GrowingOffsetMapping mapping;
+    mapping.Append(valid_data.data(), valid_data.size(), 0, 0);
+
+    BitsetType logical_bitset(valid_data.size());
+    BitsetView logical_view(logical_bitset);
+
+    TargetBitmap physical_bitset;
+    auto status = mapping.TransformBitset(logical_view, physical_bitset);
+
+    EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::Transformed);
+    ASSERT_EQ(physical_bitset.size(), 4);
+    EXPECT_TRUE(physical_bitset.none());
+
+    std::array<bool, 2> later_valid_data = {true, true};
+    mapping.Append(later_valid_data.data(), later_valid_data.size(), 5, 4);
+    EXPECT_EQ(mapping.GetValidCount(), 6);
+    EXPECT_EQ(physical_bitset.size(), 4);
+    EXPECT_TRUE(physical_bitset.none());
+}
+
 TEST(Util_Segcore, TransformBitsetKeepsEmptyViewAsAllVisibleFastPath) {
     using namespace milvus;
 


### PR DESCRIPTION
## Summary
- Materialize growing nullable-vector MVCC no-filter bitsets in physical offset space.
- Use the transformed physical bitset size as the growing search boundary.
- Avoid scanning nullable vector rows appended after the query snapshot.

issue: #51941

## Test plan
- [x] `make build-cpp-with-unittest`
- [x] `make run-test-cpp filter='Util_Segcore.*' jobs="$(nproc)"`
- [x] `clang-format-15 --dry-run -Werror internal/core/src/common/OffsetMapping.cpp internal/core/src/query/SearchOnGrowing.cpp internal/core/src/segcore/UtilsTest.cpp`
- [x] `git diff --check`
