### PR TITLE
enhance: secure configuration projections by default

### DIFF
--- a/internal/coordinator/restful_mgr_routes.go
+++ b/internal/coordinator/restful_mgr_routes.go
@@ -1404,10 +1404,11 @@ func (s *mixCoordImpl) HandleGetConfig(writer http.ResponseWriter, request *http
 		if key == "" {
 			continue
 		}
-		// Redact sensitive config keys (passwords, secrets, tokens).
-		normalizedKey := strings.ToLower(key)
-		if strings.Contains(normalizedKey, "password") || strings.Contains(normalizedKey, "secret") ||
-			strings.Contains(normalizedKey, "token") || strings.Contains(normalizedKey, "credential") {
+		if !paramMgr.IsConfigRegistered(key) {
+			results = append(results, configResult{Key: key, Error: "access to unregistered config key is denied"})
+			continue
+		}
+		if paramMgr.IsSensitive(key) {
 			results = append(results, configResult{Key: key, Error: "access to sensitive config key is denied"})
 			continue
 		}

--- a/internal/coordinator/restful_mgr_routes_test.go
+++ b/internal/coordinator/restful_mgr_routes_test.go
@@ -309,6 +309,11 @@ func TestHandleGetConfig(t *testing.T) {
 	mgr.SetConfig("test.getconfig.key1", "val1")
 	mgr.SetConfig("test.getconfig.key2", "val2")
 	mgr.SetConfig("test.getconfig.key3", "val3")
+	mgr.SetConfig("test.getconfig.opaque", "opaque-secret")
+	for _, key := range []string{"test.getconfig.key1", "test.getconfig.key2", "test.getconfig.key3", "test.getconfig.opaque"} {
+		mgr.RegisterConfigKey(key)
+	}
+	mgr.RegisterSensitiveKey("test.getconfig.opaque")
 
 	type configResult struct {
 		Key    string `json:"key"`
@@ -409,16 +414,31 @@ func TestHandleGetConfig(t *testing.T) {
 	})
 
 	t.Run("sensitive keys are redacted", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/management/config/get?keys=minio.secretAccessKey,test.getconfig.key1,etcd.auth.password", nil)
+		req := httptest.NewRequest(http.MethodGet, "/management/config/get?keys=minio.secretAccessKey,test.getconfig.key1,etcd.auth.password,test.getconfig.opaque", nil)
 		w := httptest.NewRecorder()
 		coord.HandleGetConfig(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		configs := parseResponse(t, w)
-		require.Len(t, configs, 3)
+		require.Len(t, configs, 4)
 		assert.Contains(t, configs[0].Error, "sensitive")
 		assert.Equal(t, "val1", configs[1].Value)
 		assert.Contains(t, configs[2].Error, "sensitive")
+		assert.Contains(t, configs[3].Error, "sensitive")
+		assert.NotContains(t, w.Body.String(), "opaque-secret")
+	})
+
+	t.Run("unregistered keys are denied", func(t *testing.T) {
+		mgr.SetConfig("test.getconfig.unknown", "unknown-secret")
+		req := httptest.NewRequest(http.MethodGet, "/management/config/get?keys=test.getconfig.unknown", nil)
+		w := httptest.NewRecorder()
+		coord.HandleGetConfig(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		configs := parseResponse(t, w)
+		require.Len(t, configs, 1)
+		assert.Contains(t, configs[0].Error, "unregistered")
+		assert.NotContains(t, w.Body.String(), "unknown-secret")
 	})
 
 	t.Run("all empty keys should fail", func(t *testing.T) {

--- a/internal/proxy/http_req_impl.go
+++ b/internal/proxy/http_req_impl.go
@@ -31,7 +31,9 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy/connection"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/dependency"
+	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -41,35 +43,51 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
+// authenticatedUsernameKey matches the trusted identity populated by the
+// distributed proxy authentication middleware. Keeping the key here avoids an
+// import cycle from internal/proxy back into internal/distributed/proxy.
+const authenticatedUsernameKey = "username"
+
 var (
 	contentType        = "application/json"
 	defaultDB          = "default"
 	httpDBName         = "db_name"
 	HTTPCollectionName = "collection_name"
 	UnknownData        = "unknown"
-	sensitiveMark      = "*****"
-	sensitiveKeys      = []string{
-		"secretaccesskey",
-		"secret_access_key",
-		"password",
-		"apikey",
-		"credentialjson",
-		"credential_json",
-	}
+	sensitiveMark      = config.RedactedValue
 )
 
 func hideSensitive(configs map[string]string) {
-	checkFunc := func(key string) bool {
-		for _, sensitive := range sensitiveKeys {
-			if strings.Contains(strings.ToLower(key), sensitive) {
-				return true
-			}
-		}
-		return false
-	}
+	paramtable.Init()
+	manager := paramtable.GetBaseTable().Manager()
 	for key := range configs {
-		if checkFunc(key) {
+		if manager.IsSensitive(key) {
 			configs[key] = sensitiveMark
+		}
+	}
+}
+
+func authorizeConfigView() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !paramtable.Get().CommonCfg.AuthorizationEnabled.GetAsBool() {
+			return
+		}
+
+		usernameValue, ok := c.Get(authenticatedUsernameKey)
+		username, isString := usernameValue.(string)
+		if !ok || !isString || username == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				mhttp.HTTPReturnCode:    merr.Code(merr.ErrNeedAuthenticate),
+				mhttp.HTTPReturnMessage: merr.ErrNeedAuthenticate.Error(),
+			})
+			return
+		}
+		if username != util.UserRoot {
+			err := merr.WrapErrPrivilegeNotPermitted("only root user can read configuration views")
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				mhttp.HTTPReturnCode:    merr.Code(err),
+				mhttp.HTTPReturnMessage: err.Error(),
+			})
 		}
 	}
 }

--- a/internal/proxy/http_req_impl_test.go
+++ b/internal/proxy/http_req_impl_test.go
@@ -4,31 +4,35 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	mhttp "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proxy/connection"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestHideSensitive(t *testing.T) {
 	visibleConfigs := map[string]string{
-		"dummy":      "secretAccessKey",
-		"Foo":        "password",
-		"api":        "apikey",
-		"access":     "XXX",
-		"key":        "XXX",
-		"credential": "XXX",
+		"dummy":                                "secretAccessKey",
+		"soPath":                               "/tmp/plugin.so",
+		"common.security.authorizationEnabled": "secret-looking-value",
+		"proxy.minPasswordLength":              "8",
+		"proxy.maxPasswordLength":              "72",
+		"dataCoord.compaction.storageVersion.rateLimitTokens": "10",
 	}
 	invisibleConfigs := map[string]string{
 		"MyPassword":                          "123456",
@@ -42,6 +46,10 @@ func TestHideSensitive(t *testing.T) {
 		"credential.apikey1.apikey":           "apikey",
 		"credentialgcp1credentialjson":        "credential",
 		"credential.gcp1.credentialjson":      "credential",
+		"AWS_SESSION_TOKEN":                   "token",
+		"AZURE_CLIENT_SECRET":                 "secret",
+		"tls.private-key":                     "private key",
+		"OPENAI_API_KEY":                      "api key",
 	}
 
 	copiedConfigs := make(map[string]string)
@@ -69,13 +77,111 @@ func TestGetConfigs(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 
-	configs := map[string]string{"key": "value"}
+	configs := map[string]string{
+		"common.security.authorizationEnabled": "true",
+		"service_token":                        "sentinel-secret",
+	}
 	handler := getConfigs(configs)
 	handler(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), "key")
-	assert.Contains(t, w.Body.String(), "value")
+	assert.Contains(t, w.Body.String(), "common.security.authorizationEnabled")
+	assert.Contains(t, w.Body.String(), "true")
+	assert.NotContains(t, w.Body.String(), "sentinel-secret")
+	assert.Contains(t, w.Body.String(), sensitiveMark)
+}
+
+func TestAuthorizeConfigView(t *testing.T) {
+	params := paramtable.Get()
+	authKey := params.CommonCfg.AuthorizationEnabled.Key
+	defer params.Reset(authKey)
+
+	request := func(username any) int {
+		router := gin.New()
+		if username != nil {
+			router.Use(func(c *gin.Context) {
+				c.Set(authenticatedUsernameKey, username)
+			})
+		}
+		router.GET("/configs", authorizeConfigView(), func(c *gin.Context) {
+			c.Status(http.StatusNoContent)
+		})
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/configs", nil)
+		router.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	require.NoError(t, params.Save(authKey, "false"))
+	assert.Equal(t, http.StatusNoContent, request(nil))
+
+	require.NoError(t, params.Save(authKey, "true"))
+	assert.Equal(t, http.StatusUnauthorized, request(nil))
+	assert.Equal(t, http.StatusUnauthorized, request(123))
+	assert.Equal(t, http.StatusForbidden, request("alice"))
+	assert.Equal(t, http.StatusNoContent, request(util.UserRoot))
+}
+
+func TestConfigRoutesRequireRootWhenAuthorizationEnabled(t *testing.T) {
+	params := paramtable.Get()
+	authKey := params.CommonCfg.AuthorizationEnabled.Key
+	defer params.Reset(authKey)
+	require.NoError(t, params.Save(authKey, "true"))
+
+	for _, tc := range []struct {
+		name       string
+		username   string
+		statusCode int
+	}{
+		{name: "missing user", statusCode: http.StatusUnauthorized},
+		{name: "non-root user", username: "alice", statusCode: http.StatusForbidden},
+		{name: "root user", username: util.UserRoot, statusCode: http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			router := gin.New()
+			if tc.username != "" {
+				router.Use(func(c *gin.Context) {
+					c.Set(authenticatedUsernameKey, tc.username)
+				})
+			}
+			(&Proxy{}).RegisterRestRouter(router)
+
+			for _, path := range []string{mhttp.ClusterConfigsPath, mhttp.HookConfigsPath} {
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				router.ServeHTTP(w, req)
+				assert.Equal(t, tc.statusCode, w.Code, path)
+			}
+		})
+	}
+}
+
+func TestGetConfigsRedactsUnknownEnvironment(t *testing.T) {
+	const secret = "proxy-config-view-sentinel"
+	t.Setenv("MILVUS_CONF_SERVICE_TOKEN", secret)
+	t.Setenv("DATABASE_URL", secret)
+
+	base := paramtable.NewBaseTable(paramtable.SkipRemote(true))
+	params := &paramtable.ComponentParam{}
+	params.Init(base)
+
+	foundRaw := false
+	for _, value := range params.GetConfigsViewRaw() {
+		if strings.Contains(value, secret) {
+			foundRaw = true
+			break
+		}
+	}
+	assert.True(t, foundRaw)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	getConfigs(params.GetConfigsView())(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, w.Body.String(), secret)
+	assert.Contains(t, w.Body.String(), sensitiveMark)
 }
 
 func TestGetClusterInfo(t *testing.T) {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -6457,14 +6457,16 @@ func DeregisterSubLabel(subLabel string) {
 
 // RegisterRestRouter registers the router for the proxy
 func (node *Proxy) RegisterRestRouter(router gin.IRouter) {
+	configViewAuth := authorizeConfigView()
+
 	// Cluster request that executed by proxy
 	router.GET(http.ClusterInfoPath, getClusterInfo(node))
-	router.GET(http.ClusterConfigsPath, getConfigs(paramtable.Get().GetConfigsView()))
+	router.GET(http.ClusterConfigsPath, configViewAuth, getConfigs(paramtable.Get().GetConfigsView()))
 	router.GET(http.ClusterClientsPath, getConnectedClients)
 	router.GET(http.ClusterDependenciesPath, getDependencies)
 
 	// Hook request that executed by proxy
-	router.GET(http.HookConfigsPath, getConfigs(paramtable.GetHookParams().GetAll()))
+	router.GET(http.HookConfigsPath, configViewAuth, getConfigs(paramtable.GetHookParams().GetAll()))
 
 	// Slow query request that executed by proxy
 	router.GET(http.SlowQueryPath, getSlowQuery(node))

--- a/internal/util/hookutil/cipher.go
+++ b/internal/util/hookutil/cipher.go
@@ -471,7 +471,7 @@ func registerCallback() {
 	mlog.Info(context.TODO(), "cipher config callbacks registered")
 }
 
-func reloadCipherConfig(ctx context.Context, key, oldValue, newValue string) error {
+func reloadCipherConfig(ctx context.Context, key, _, _ string) error {
 	cipher := GetCipher()
 	if cipher == nil {
 		mlog.Warn(ctx, "cipher plugin not loaded, skip config reload", mlog.String("key", key))
@@ -481,10 +481,7 @@ func reloadCipherConfig(ctx context.Context, key, oldValue, newValue string) err
 	cipherReloadMutex.Lock()
 	defer cipherReloadMutex.Unlock()
 
-	mlog.Info(ctx, "reloading cipher plugin config",
-		mlog.String("key", key),
-		mlog.String("oldValue", oldValue),
-		mlog.String("newValue", newValue))
+	mlog.Info(ctx, "reloading cipher plugin config", mlog.String("key", key))
 
 	initConfigs := buildCipherInitConfig()
 	if err := cipher.Init(initConfigs); err != nil {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -32,7 +32,21 @@ import (
 const (
 	TombValue     = "TOMB_VAULE"
 	RuntimeSource = "RuntimeSource"
+	// RedactedValue replaces values that are unsafe to expose in a configuration projection.
+	RedactedValue = "*****"
 )
+
+// sensitiveKeyPatterns provides defense in depth for secret-like dynamic and
+// source keys. Reviewed false positives use explicit NonSensitive metadata.
+var sensitiveKeyPatterns = []string{
+	"password",
+	"secret",
+	"token",
+	"credential",
+	"privatekey",
+	"accesskey",
+	"apikey",
+}
 
 type Filter func(key string) (string, bool)
 
@@ -83,12 +97,17 @@ func filterate(key string, filters ...Filter) (string, bool) {
 }
 
 type Manager struct {
-	Dispatcher    *EventDispatcher
-	sources       *typeutil.ConcurrentMap[string, Source]
-	keySourceMap  *typeutil.ConcurrentMap[string, string] // store the key to config source, example: key is A.B.C and source is file which means the A.B.C's value is from file
-	overlays      *typeutil.ConcurrentMap[string, string] // store the highest priority configs which modified at runtime
-	forbiddenKeys *typeutil.ConcurrentSet[string]
-	immutableKeys *typeutil.ConcurrentSet[string]
+	Dispatcher            *EventDispatcher
+	sources               *typeutil.ConcurrentMap[string, Source]
+	keySourceMap          *typeutil.ConcurrentMap[string, string] // store the key to config source, example: key is A.B.C and source is file which means the A.B.C's value is from file
+	overlays              *typeutil.ConcurrentMap[string, string] // store the highest priority configs which modified at runtime
+	forbiddenKeys         *typeutil.ConcurrentSet[string]
+	immutableKeys         *typeutil.ConcurrentSet[string]
+	sensitiveKeys         *typeutil.ConcurrentSet[string]
+	sensitiveKeyPrefixes  *typeutil.ConcurrentSet[string]
+	nonSensitiveKeys      *typeutil.ConcurrentSet[string]
+	registeredKeys        *typeutil.ConcurrentSet[string]
+	registeredKeyPrefixes *typeutil.ConcurrentSet[string]
 
 	cacheMutex  sync.RWMutex
 	configCache map[string]any
@@ -97,13 +116,18 @@ type Manager struct {
 
 func NewManager() *Manager {
 	manager := &Manager{
-		Dispatcher:    NewEventDispatcher(),
-		sources:       typeutil.NewConcurrentMap[string, Source](),
-		keySourceMap:  typeutil.NewConcurrentMap[string, string](),
-		overlays:      typeutil.NewConcurrentMap[string, string](),
-		forbiddenKeys: typeutil.NewConcurrentSet[string](),
-		immutableKeys: typeutil.NewConcurrentSet[string](),
-		configCache:   make(map[string]any),
+		Dispatcher:            NewEventDispatcher(),
+		sources:               typeutil.NewConcurrentMap[string, Source](),
+		keySourceMap:          typeutil.NewConcurrentMap[string, string](),
+		overlays:              typeutil.NewConcurrentMap[string, string](),
+		forbiddenKeys:         typeutil.NewConcurrentSet[string](),
+		immutableKeys:         typeutil.NewConcurrentSet[string](),
+		sensitiveKeys:         typeutil.NewConcurrentSet[string](),
+		sensitiveKeyPrefixes:  typeutil.NewConcurrentSet[string](),
+		nonSensitiveKeys:      typeutil.NewConcurrentSet[string](),
+		registeredKeys:        typeutil.NewConcurrentSet[string](),
+		registeredKeyPrefixes: typeutil.NewConcurrentSet[string](),
+		configCache:           make(map[string]any),
 	}
 	resetConfigCacheFunc := NewHandler("reset.config.cache", func(event *Event) {
 		keyToRemove := strings.NewReplacer("/", ".").Replace(event.Key)
@@ -172,8 +196,19 @@ func (m *Manager) GetConfig(key string) (string, string, error) {
 	return sourceName, v, err
 }
 
-// GetConfigs returns all the key values
+// GetConfigs returns a safe projection of all key values. Sensitive and
+// unregistered values are redacted. Internal code that requires the original
+// values must call GetConfigsRaw explicitly.
 func (m *Manager) GetConfigs() map[string]string {
+	return m.getConfigs(true)
+}
+
+// GetConfigsRaw returns all original key values without redaction.
+func (m *Manager) GetConfigsRaw() map[string]string {
+	return m.getConfigs(false)
+}
+
+func (m *Manager) getConfigs(redact bool) map[string]string {
 	config := make(map[string]string)
 
 	m.keySourceMap.Range(func(key, value string) bool {
@@ -182,12 +217,12 @@ func (m *Manager) GetConfigs() map[string]string {
 			return true
 		}
 
-		config[key] = sValue
+		config[key] = m.projectValue(key, sValue, redact)
 		return true
 	})
 
 	m.overlays.Range(func(key, value string) bool {
-		config[key] = value
+		config[key] = m.projectValue(key, value, redact)
 		return true
 	})
 
@@ -195,6 +230,17 @@ func (m *Manager) GetConfigs() map[string]string {
 }
 
 func (m *Manager) GetConfigsView() map[string]string {
+	return m.getConfigsView(true)
+}
+
+// GetConfigsViewRaw returns the original values and their sources without
+// redaction. Prefer GetConfigsView for any diagnostic or externally visible
+// projection.
+func (m *Manager) GetConfigsViewRaw() map[string]string {
+	return m.getConfigsView(false)
+}
+
+func (m *Manager) getConfigsView(redact bool) map[string]string {
 	config := make(map[string]string)
 
 	valueFmt := func(source, value string) string {
@@ -207,12 +253,20 @@ func (m *Manager) GetConfigsView() map[string]string {
 			return true
 		}
 
-		config[key] = valueFmt(source, sValue)
+		if redact && m.ShouldRedact(key) {
+			config[key] = RedactedValue
+		} else {
+			config[key] = valueFmt(source, sValue)
+		}
 		return true
 	})
 
 	m.overlays.Range(func(key, value string) bool {
-		config[key] = valueFmt(RuntimeSource, value)
+		if redact && m.ShouldRedact(key) {
+			config[key] = RedactedValue
+		} else {
+			config[key] = valueFmt(RuntimeSource, value)
+		}
 		return true
 	})
 
@@ -220,6 +274,15 @@ func (m *Manager) GetConfigsView() map[string]string {
 }
 
 func (m *Manager) GetBy(filters ...Filter) map[string]string {
+	return m.getBy(true, filters...)
+}
+
+// GetByRaw returns matching original values without redaction.
+func (m *Manager) GetByRaw(filters ...Filter) map[string]string {
+	return m.getBy(false, filters...)
+}
+
+func (m *Manager) getBy(redact bool, filters ...Filter) map[string]string {
 	matchedConfig := make(map[string]string)
 
 	m.keySourceMap.Range(func(key string, value string) bool {
@@ -232,7 +295,7 @@ func (m *Manager) GetBy(filters ...Filter) map[string]string {
 			return true
 		}
 
-		matchedConfig[newkey] = sValue
+		matchedConfig[newkey] = m.projectValue(key, sValue, redact)
 		return true
 	})
 
@@ -241,7 +304,7 @@ func (m *Manager) GetBy(filters ...Filter) map[string]string {
 		if !ok {
 			return true
 		}
-		matchedConfig[newkey] = value
+		matchedConfig[newkey] = m.projectValue(key, value, redact)
 		return true
 	})
 
@@ -249,6 +312,15 @@ func (m *Manager) GetBy(filters ...Filter) map[string]string {
 }
 
 func (m *Manager) FileConfigs() map[string]string {
+	return m.fileConfigs(true)
+}
+
+// FileConfigsRaw returns the original file-source values without redaction.
+func (m *Manager) FileConfigsRaw() map[string]string {
+	return m.fileConfigs(false)
+}
+
+func (m *Manager) fileConfigs(redact bool) map[string]string {
 	config := make(map[string]string)
 	m.sources.Range(func(key string, value Source) bool {
 		if s, ok := value.(*FileSource); ok {
@@ -257,6 +329,11 @@ func (m *Manager) FileConfigs() map[string]string {
 		}
 		return true
 	})
+	if redact {
+		for key, value := range config {
+			config[key] = m.RedactValue(key, value)
+		}
+	}
 	return config
 }
 
@@ -320,6 +397,130 @@ func (m *Manager) ImmutableUpdate(key string) {
 // IsImmutable checks if a configuration key is marked as immutable
 func (m *Manager) IsImmutable(key string) bool {
 	return m.immutableKeys.Contain(formatKey(key))
+}
+
+// RegisterConfigKey records a declared configuration key. Config sources may
+// contain arbitrary values, including every process environment variable, so
+// safe projections must distinguish declared Milvus configuration from source
+// implementation details.
+func (m *Manager) RegisterConfigKey(key string) {
+	formattedKey := formatKey(key)
+	if formattedKey != "" {
+		m.registeredKeys.Insert(formattedKey)
+	}
+}
+
+// RegisterConfigPrefix records a declared dynamic configuration prefix.
+func (m *Manager) RegisterConfigPrefix(prefix string) {
+	canonicalPrefix := strings.ToLower(prefix)
+	if canonicalPrefix != "" {
+		m.registeredKeyPrefixes.Insert(canonicalPrefix)
+	}
+}
+
+// RegisterSensitiveKey marks a declared configuration key as sensitive.
+func (m *Manager) RegisterSensitiveKey(key string) {
+	formattedKey := formatKey(key)
+	if formattedKey != "" {
+		m.sensitiveKeys.Insert(formattedKey)
+	}
+}
+
+// RegisterNonSensitiveKey exempts a reviewed, declared key from the
+// secret-name fallback. Use it only for names such as password length or token
+// count whose values are not credentials.
+func (m *Manager) RegisterNonSensitiveKey(key string) {
+	formattedKey := formatKey(key)
+	if formattedKey != "" {
+		m.nonSensitiveKeys.Insert(formattedKey)
+	}
+}
+
+// RegisterSensitivePrefix marks every configuration below a dynamic prefix as
+// sensitive.
+func (m *Manager) RegisterSensitivePrefix(prefix string) {
+	canonicalPrefix := strings.ToLower(prefix)
+	if canonicalPrefix != "" {
+		m.sensitiveKeyPrefixes.Insert(canonicalPrefix)
+	}
+}
+
+// IsConfigRegistered reports whether key belongs to a declared ParamItem or
+// ParamGroup.
+func (m *Manager) IsConfigRegistered(key string) bool {
+	formattedKey := formatKey(key)
+	if m.registeredKeys.Contain(formattedKey) {
+		return true
+	}
+
+	// Prefix registration intentionally uses the canonical, separator-preserving
+	// key. EnvSource also stores separator-free aliases for every process
+	// environment variable, so accepting such aliases here would let an
+	// unrelated key such as PROXY_ACCESSLOG_FORMATTERS_DATABASE_URL masquerade
+	// as a member of proxy.accessLog.formatters.
+	canonicalKey := strings.ToLower(key)
+	registered := false
+	m.registeredKeyPrefixes.Range(func(prefix string) bool {
+		if strings.HasPrefix(canonicalKey, prefix) {
+			registered = true
+			return false
+		}
+		return true
+	})
+	return registered
+}
+
+// IsSensitive reports whether key is explicitly marked sensitive or has a
+// secret-like name. Explicit NonSensitive metadata exempts reviewed false
+// positives without weakening dynamic ParamGroup keys.
+func (m *Manager) IsSensitive(key string) bool {
+	formattedKey := formatKey(key)
+	if m.sensitiveKeys.Contain(formattedKey) {
+		return true
+	}
+
+	canonicalKey := strings.ToLower(key)
+	sensitivePrefix := false
+	m.sensitiveKeyPrefixes.Range(func(prefix string) bool {
+		if strings.HasPrefix(canonicalKey, prefix) {
+			sensitivePrefix = true
+			return false
+		}
+		return true
+	})
+	if sensitivePrefix {
+		return true
+	}
+	if m.nonSensitiveKeys.Contain(formattedKey) {
+		return false
+	}
+
+	patternKey := strings.NewReplacer("-", "", "_", "", ".", "", "/", "").Replace(strings.ToLower(key))
+	for _, pattern := range sensitiveKeyPatterns {
+		if strings.Contains(patternKey, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// ShouldRedact reports whether a key is unsafe for a configuration projection.
+// Unknown keys fail closed because EnvSource imports the whole process
+// environment and plugin sources may define arbitrary keys.
+func (m *Manager) ShouldRedact(key string) bool {
+	return !m.IsConfigRegistered(key) || m.IsSensitive(key)
+}
+
+// RedactValue returns a projection-safe value for key.
+func (m *Manager) RedactValue(key, value string) string {
+	return m.projectValue(key, value, true)
+}
+
+func (m *Manager) projectValue(key, value string, redact bool) string {
+	if redact && m.ShouldRedact(key) {
+		return RedactedValue
+	}
+	return value
 }
 
 func (m *Manager) UpdateSourceOptions(opts ...Option) {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,8 +38,14 @@ func TestAllConfigFromManager(t *testing.T) {
 	assert.Equal(t, 0, len(all))
 
 	mgr, _ = Init(WithEnvSource(formatKey))
+	raw := mgr.GetConfigsRaw()
+	assert.Less(t, 0, len(raw))
+
 	all = mgr.GetConfigs()
-	assert.Less(t, 0, len(all))
+	assert.Equal(t, len(raw), len(all))
+	for _, value := range all {
+		assert.Equal(t, RedactedValue, value)
+	}
 }
 
 func TestConfigChangeEvent(t *testing.T) {
@@ -199,7 +206,7 @@ func TestGetConfigAndSource(t *testing.T) {
 	assert.Equal(t, value, "ac-value")
 
 	// test get all configs
-	configs := mgr.GetConfigsView()
+	configs := mgr.GetConfigsViewRaw()
 	v, ok := configs["ab-key"]
 	assert.True(t, ok)
 	assert.Contains(t, v, "EnvironmentSource")
@@ -207,6 +214,118 @@ func TestGetConfigAndSource(t *testing.T) {
 	v, ok = configs["ac-key"]
 	assert.True(t, ok)
 	assert.Contains(t, v, RuntimeSource)
+}
+
+func TestConfigProjectionsRedactByDefault(t *testing.T) {
+	mgr, _ := Init()
+
+	mgr.RegisterConfigKey("public.key")
+	mgr.RegisterConfigKey("opaque.key")
+	mgr.RegisterSensitiveKey("opaque.key")
+	mgr.RegisterConfigPrefix("dynamic.")
+	mgr.RegisterConfigPrefix("sensitive.group.")
+	mgr.RegisterSensitivePrefix("sensitive.group.")
+
+	mgr.SetConfig("public.key", "visible")
+	mgr.SetConfig("opaque.key", "opaque-secret")
+	mgr.SetConfig("unknown.key", "unknown-secret")
+	mgr.SetMapConfig("dynamic.visible", "dynamic-value")
+	mgr.SetMapConfig("dynamic.password", "dynamic-secret")
+	mgr.SetMapConfig("sensitive.group.value", "group-secret")
+
+	publicKey := formatKey("public.key")
+	opaqueKey := formatKey("opaque.key")
+	unknownKey := formatKey("unknown.key")
+	dynamicKey := "dynamic.visible"
+	dynamicSecretKey := "dynamic.password"
+	groupKey := "sensitive.group.value"
+
+	safe := mgr.GetConfigs()
+	assert.Equal(t, "visible", safe[publicKey])
+	assert.Equal(t, RedactedValue, safe[opaqueKey])
+	assert.Equal(t, RedactedValue, safe[unknownKey])
+	assert.Equal(t, "dynamic-value", safe[dynamicKey])
+	assert.Equal(t, RedactedValue, safe[dynamicSecretKey])
+	assert.Equal(t, RedactedValue, safe[groupKey])
+
+	raw := mgr.GetConfigsRaw()
+	assert.Equal(t, "opaque-secret", raw[opaqueKey])
+	assert.Equal(t, "unknown-secret", raw[unknownKey])
+	assert.Equal(t, "group-secret", raw[groupKey])
+	assert.Equal(t, "dynamic-secret", raw[dynamicSecretKey])
+
+	safeView := mgr.GetConfigsView()
+	assert.Contains(t, safeView[publicKey], RuntimeSource)
+	assert.Equal(t, RedactedValue, safeView[opaqueKey])
+	assert.Equal(t, RedactedValue, safeView[unknownKey])
+
+	rawView := mgr.GetConfigsViewRaw()
+	assert.Contains(t, rawView[opaqueKey], "opaque-secret")
+	assert.Contains(t, rawView[unknownKey], "unknown-secret")
+
+	assert.Equal(t, "dynamic-value", mgr.GetBy(WithPrefix("dynamic"))[dynamicKey])
+	assert.Equal(t, RedactedValue, mgr.GetBy(WithPrefix("dynamic"))[dynamicSecretKey])
+	assert.Equal(t, "group-secret", mgr.GetByRaw(WithPrefix("sensitive"))[groupKey])
+}
+
+func TestEnvironmentSecretsAreRedacted(t *testing.T) {
+	const secret = "config-view-sentinel-secret"
+	t.Setenv("MILVUS_CONF_SERVICE_TOKEN", secret)
+	t.Setenv("AWS_SESSION_TOKEN", secret)
+	t.Setenv("OPENAI_API_KEY", secret)
+	t.Setenv("DATABASE_URL", secret)
+	t.Setenv("PROXY_ACCESSLOG_FORMATTERS_DATABASE_URL", secret)
+
+	mgr, _ := Init(WithEnvSource(formatKey))
+	mgr.RegisterConfigPrefix("proxy.accessLog.formatters.")
+	assert.False(t, mgr.IsConfigRegistered("PROXY_ACCESSLOG_FORMATTERS_DATABASE_URL"))
+	assert.False(t, mgr.IsConfigRegistered(formatKey("PROXY_ACCESSLOG_FORMATTERS_DATABASE_URL")))
+	for key, value := range mgr.GetConfigsView() {
+		assert.NotContains(t, value, secret, key)
+	}
+
+	foundRaw := false
+	for _, value := range mgr.GetConfigsViewRaw() {
+		if strings.Contains(value, secret) {
+			foundRaw = true
+			break
+		}
+	}
+	assert.True(t, foundRaw)
+}
+
+func TestRegisteredMetadataOverridesSecretNameFallback(t *testing.T) {
+	mgr := NewManager()
+	for _, key := range []string{
+		"proxy.minPasswordLength",
+		"proxy.maxPasswordLength",
+		"dataCoord.compaction.storageVersion.rateLimitTokens",
+	} {
+		mgr.RegisterConfigKey(key)
+		mgr.RegisterNonSensitiveKey(key)
+		mgr.SetConfig(key, "visible")
+		assert.False(t, mgr.IsSensitive(key), key)
+		assert.Equal(t, "visible", mgr.GetConfigs()[formatKey(key)], key)
+	}
+}
+
+func TestFileConfigProjectionRedactsByDefault(t *testing.T) {
+	yamlFile := path.Join(t.TempDir(), "milvus.yaml")
+	require.NoError(t, os.WriteFile(yamlFile, []byte("public.key: visible\nopaque.key: opaque-secret\nunknown.key: unknown-secret\n"), 0o600))
+
+	mgr, _ := Init(WithFilesSource(&FileInfo{Files: []string{yamlFile}}))
+	mgr.RegisterConfigKey("public.key")
+	mgr.RegisterConfigKey("opaque.key")
+	mgr.RegisterSensitiveKey("opaque.key")
+
+	safe := mgr.FileConfigs()
+	assert.Equal(t, "visible", safe["public.key"])
+	assert.Equal(t, RedactedValue, safe["opaque.key"])
+	assert.Equal(t, RedactedValue, safe["unknown.key"])
+
+	raw := mgr.FileConfigsRaw()
+	assert.Equal(t, "opaque-secret", raw["opaque.key"])
+	assert.Equal(t, "unknown-secret", raw["unknown.key"])
 }
 
 func TestDeadlock(t *testing.T) {

--- a/pkg/util/paramtable/base_table.go
+++ b/pkg/util/paramtable/base_table.go
@@ -254,6 +254,11 @@ func (bt *BaseTable) FileConfigs() map[string]string {
 	return bt.mgr.FileConfigs()
 }
 
+// FileConfigsRaw returns file-source values without projection redaction.
+func (bt *BaseTable) FileConfigsRaw() map[string]string {
+	return bt.mgr.FileConfigsRaw()
+}
+
 func (bt *BaseTable) UpdateSourceOptions(opts ...config.Option) {
 	bt.mgr.UpdateSourceOptions(opts...)
 }

--- a/pkg/util/paramtable/base_table_test.go
+++ b/pkg/util/paramtable/base_table_test.go
@@ -39,7 +39,7 @@ func TestBaseTable_DuplicateValues(t *testing.T) {
 	baseParams.Save("rootcoorddmlchannelnum", "11")
 
 	prefix := "rootcoord."
-	configs := baseParams.mgr.GetConfigs()
+	configs := baseParams.mgr.GetConfigsRaw()
 
 	configsWithPrefix := make(map[string]string)
 	for k, v := range configs {
@@ -48,7 +48,7 @@ func TestBaseTable_DuplicateValues(t *testing.T) {
 		}
 	}
 
-	rootconfigs := baseParams.mgr.GetBy(config.WithPrefix(prefix))
+	rootconfigs := baseParams.mgr.GetByRaw(config.WithPrefix(prefix))
 
 	assert.Equal(t, len(rootconfigs), len(configsWithPrefix))
 	assert.Equal(t, "11", rootconfigs["rootcoord.dmlchannelnum"])

--- a/pkg/util/paramtable/cipher_config.go
+++ b/pkg/util/paramtable/cipher_config.go
@@ -41,18 +41,21 @@ func (c *cipherConfig) init(base *BaseTable) {
 		Key:          "cipherPlugin.kms.defaultKey",
 		Version:      "2.6.1",
 		FallbackKeys: []string{"cipherPlugin.defaultKmsKeyArn"},
+		Sensitive:    true,
 	}
 	c.DefaultRootKey.Init(base.mgr)
 
 	c.KmsAwsRoleARN = ParamItem{
-		Key:     "cipherPlugin.kms.credentials.aws.roleARN",
-		Version: "2.6.1",
+		Key:       "cipherPlugin.kms.credentials.aws.roleARN",
+		Version:   "2.6.1",
+		Sensitive: true,
 	}
 	c.KmsAwsRoleARN.Init(base.mgr)
 
 	c.KmsAwsExternalID = ParamItem{
-		Key:     "cipherPlugin.kms.credentials.aws.externalID",
-		Version: "2.6.1",
+		Key:       "cipherPlugin.kms.credentials.aws.externalID",
+		Version:   "2.6.1",
+		Sensitive: true,
 	}
 	c.KmsAwsExternalID.Init(base.mgr)
 
@@ -83,5 +86,5 @@ func (c *cipherConfig) Save(key string, value string) error {
 }
 
 func (c *cipherConfig) GetAll() map[string]string {
-	return c.cipherBase.mgr.GetConfigs()
+	return c.cipherBase.mgr.GetConfigsRaw()
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -192,8 +192,18 @@ func (p *ComponentParam) GetAll() map[string]string {
 	return p.baseTable.mgr.GetConfigs()
 }
 
+// GetAllRaw returns all configuration values without projection redaction.
+func (p *ComponentParam) GetAllRaw() map[string]string {
+	return p.baseTable.mgr.GetConfigsRaw()
+}
+
 func (p *ComponentParam) GetConfigsView() map[string]string {
 	return p.baseTable.mgr.GetConfigsView()
+}
+
+// GetConfigsViewRaw returns configuration values and sources without projection redaction.
+func (p *ComponentParam) GetConfigsViewRaw() map[string]string {
+	return p.baseTable.mgr.GetConfigsViewRaw()
 }
 
 func (p *ComponentParam) Watch(key string, watcher config.EventHandler) {
@@ -900,6 +910,7 @@ For example, if the rate limit is 100KB/s, and the high priority ratio is 2, the
 like the old password verification when updating the credential`,
 		DefaultValue: "",
 		Export:       true,
+		Sensitive:    true,
 	}
 	p.SuperUsers.Init(base.mgr)
 
@@ -910,6 +921,7 @@ like the old password verification when updating the credential`,
 Large numeric passwords require double quotes to avoid yaml parsing precision issues.`,
 		DefaultValue: "Milvus",
 		Export:       true,
+		Sensitive:    true,
 	}
 	p.DefaultRootPassword.Init(base.mgr)
 
@@ -1598,18 +1610,20 @@ Fractions >= 1 will always sample. Fractions < 0 are treated as zero.`,
 	t.SampleFraction.Init(base.mgr)
 
 	t.JaegerURL = ParamItem{
-		Key:     "trace.jaeger.url",
-		Version: "2.3.0",
-		Doc:     "when exporter is jaeger should set the jaeger's URL",
-		Export:  true,
+		Key:       "trace.jaeger.url",
+		Version:   "2.3.0",
+		Doc:       "when exporter is jaeger should set the jaeger's URL",
+		Export:    true,
+		Sensitive: true,
 	}
 	t.JaegerURL.Init(base.mgr)
 
 	t.OtlpEndpoint = ParamItem{
-		Key:     "trace.otlp.endpoint",
-		Version: "2.3.0",
-		Doc:     `example: "127.0.0.1:4317" for grpc, "127.0.0.1:4318" for http`,
-		Export:  true,
+		Key:       "trace.otlp.endpoint",
+		Version:   "2.3.0",
+		Doc:       `example: "127.0.0.1:4317" for grpc, "127.0.0.1:4318" for http`,
+		Export:    true,
+		Sensitive: true,
 	}
 	t.OtlpEndpoint.Init(base.mgr)
 
@@ -1636,6 +1650,7 @@ Fractions >= 1 will always sample. Fractions < 0 are treated as zero.`,
 		DefaultValue: "",
 		Doc:          "otlp header that encoded in base64",
 		Export:       true,
+		Sensitive:    true,
 	}
 	t.OtlpHeaders.Init(base.mgr)
 
@@ -2195,6 +2210,7 @@ func (p *proxyConfig) init(base *BaseTable) {
 		DefaultValue: "6",
 		Version:      "2.0.0",
 		PanicIfEmpty: true,
+		NonSensitive: true,
 	}
 	p.MinPasswordLength.Init(base.mgr)
 
@@ -2218,6 +2234,7 @@ func (p *proxyConfig) init(base *BaseTable) {
 		Key:          "proxy.maxPasswordLength",
 		DefaultValue: "72", // bcrypt max length
 		Version:      "2.0.0",
+		NonSensitive: true,
 		Formatter: func(v string) string {
 			n := getAsInt(v)
 			if n <= 0 || n > 72 {
@@ -5893,6 +5910,7 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		DefaultValue: "3",
 		Doc:          "The storage version compaction tokens per period, applying rate limit",
 		Export:       false,
+		NonSensitive: true,
 	}
 	p.StorageVersionCompactionRateLimitTokens.Init(base.mgr)
 

--- a/pkg/util/paramtable/credential_param.go
+++ b/pkg/util/paramtable/credential_param.go
@@ -25,6 +25,7 @@ func (p *credentialConfig) init(base *BaseTable) {
 		KeyPrefix: "credential.",
 		Version:   "2.6.0",
 		Export:    true,
+		Sensitive: true,
 		DocFunc: func(key string) string {
 			switch key {
 			case "apikey1.apikey":

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -53,6 +53,7 @@ func (p *functionConfig) init(base *BaseTable) {
 		KeyPrefix: "function.textEmbedding.providers.",
 		Version:   "2.6.0",
 		Export:    true,
+		Sensitive: true,
 		DocFunc: func(key string) string {
 			switch key {
 			case "tei.enable":
@@ -136,6 +137,7 @@ func (p *functionConfig) init(base *BaseTable) {
 		KeyPrefix: "function.rerank.model.providers.",
 		Version:   "2.6.0",
 		Export:    true,
+		Sensitive: true,
 		DocFunc: func(key string) string {
 			switch key {
 			case "tei.credential":
@@ -188,12 +190,14 @@ func (p *functionConfig) init(base *BaseTable) {
 	p.LinderaDownloadUrls = ParamGroup{
 		KeyPrefix: "function.analyzer.lindera.download_urls.",
 		Version:   "2.5.16",
+		Sensitive: true,
 	}
 	p.LinderaDownloadUrls.Init(base.mgr)
 
 	p.ZillizProviders = ParamGroup{
 		KeyPrefix: "function.models.zilliz.",
 		Version:   "2.6.5",
+		Sensitive: true,
 	}
 	p.ZillizProviders.Init(base.mgr)
 

--- a/pkg/util/paramtable/param_item.go
+++ b/pkg/util/paramtable/param_item.go
@@ -45,6 +45,12 @@ type ParamItem struct {
 	Formatter func(originValue string) string
 	Forbidden bool
 	Immutable bool
+	// Sensitive marks values that must be redacted from configuration
+	// projections. Scalar GetValue calls remain raw for internal consumers.
+	Sensitive bool
+	// NonSensitive exempts a reviewed secret-like key name from fallback
+	// matching. It must not be combined with Sensitive.
+	NonSensitive bool
 
 	manager *config.Manager
 
@@ -57,11 +63,27 @@ type ParamItem struct {
 
 func (pi *ParamItem) Init(manager *config.Manager) {
 	pi.manager = manager
+	pi.manager.RegisterConfigKey(pi.Key)
+	for _, key := range pi.FallbackKeys {
+		pi.manager.RegisterConfigKey(key)
+	}
 	if pi.Forbidden {
 		pi.manager.ForbidUpdate(pi.Key)
 	}
 	if pi.Immutable {
 		pi.manager.ImmutableUpdate(pi.Key)
+	}
+	if pi.Sensitive {
+		pi.manager.RegisterSensitiveKey(pi.Key)
+		for _, key := range pi.FallbackKeys {
+			pi.manager.RegisterSensitiveKey(key)
+		}
+	}
+	if pi.NonSensitive {
+		pi.manager.RegisterNonSensitiveKey(pi.Key)
+		for _, key := range pi.FallbackKeys {
+			pi.manager.RegisterNonSensitiveKey(key)
+		}
 	}
 
 	currentValue := pi.GetValue()
@@ -101,20 +123,30 @@ func (pi *ParamItem) handleConfigChange(event *config.Event) {
 		return
 	}
 
-	if err := pi.callback(context.Background(), pi.Key, oldValue, newValue); err != nil {
+	logOldValue := pi.configValueForLog(oldValue)
+	logNewValue := pi.configValueForLog(newValue)
+
+	if err := pi.callback(context.TODO(), pi.Key, oldValue, newValue); err != nil {
 		mlog.Error(context.TODO(), "param change callback failed",
 			mlog.String("key", pi.Key),
-			mlog.String("oldValue", oldValue),
-			mlog.String("newValue", newValue),
+			mlog.String("oldValue", logOldValue),
+			mlog.String("newValue", logNewValue),
 			mlog.Err(err))
 	} else {
 		mlog.Info(context.TODO(), "param value changed",
 			mlog.String("key", pi.Key),
-			mlog.String("oldValue", oldValue),
-			mlog.String("newValue", newValue))
+			mlog.String("oldValue", logOldValue),
+			mlog.String("newValue", logNewValue))
 	}
 
 	pi.lastValue.Store(&newValue)
+}
+
+func (pi *ParamItem) configValueForLog(value string) string {
+	if pi.Sensitive || (pi.manager != nil && pi.manager.IsSensitive(pi.Key)) {
+		return config.RedactedValue
+	}
+	return value
 }
 
 // Get original value with error
@@ -389,6 +421,8 @@ type ParamGroup struct {
 	Version   string
 	Doc       string
 	Export    bool
+	// Sensitive marks every value below KeyPrefix as sensitive.
+	Sensitive bool
 
 	GetFunc func() map[string]string
 	DocFunc func(string) string
@@ -398,13 +432,17 @@ type ParamGroup struct {
 
 func (pg *ParamGroup) Init(manager *config.Manager) {
 	pg.manager = manager
+	pg.manager.RegisterConfigPrefix(pg.KeyPrefix)
+	if pg.Sensitive {
+		pg.manager.RegisterSensitivePrefix(pg.KeyPrefix)
+	}
 }
 
 func (pg *ParamGroup) GetValue() map[string]string {
 	if pg.GetFunc != nil {
 		return pg.GetFunc()
 	}
-	values := pg.manager.GetBy(config.WithPrefix(pg.KeyPrefix), config.RemovePrefix(pg.KeyPrefix))
+	values := pg.manager.GetByRaw(config.WithPrefix(pg.KeyPrefix), config.RemovePrefix(pg.KeyPrefix))
 	return values
 }
 

--- a/pkg/util/paramtable/param_item_callback_test.go
+++ b/pkg/util/paramtable/param_item_callback_test.go
@@ -22,8 +22,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
 )
 
 func TestParamItem_RegisterCallback(t *testing.T) {
@@ -109,6 +114,64 @@ func TestParamItem_CallbackErrorHandling(t *testing.T) {
 	param.handleConfigChange(event)
 
 	assert.True(t, callbackCalled)
+}
+
+func TestParamItem_SensitiveCallbackLogsAreRedacted(t *testing.T) {
+	originalLogger := mlog.L()
+	originalLevel := mlog.GetLevel()
+	core, observedLogs := observer.New(zapcore.DebugLevel)
+	mlog.ReplaceGlobals(zap.New(core), &mlog.ZapProperties{
+		Core:  core,
+		Level: zap.NewAtomicLevelAt(zapcore.DebugLevel),
+	})
+	t.Cleanup(func() {
+		mlog.ReplaceGlobals(originalLogger, nil)
+		mlog.SetLevel(originalLevel)
+	})
+
+	const (
+		oldSecret = "old-cipher-root-key"
+		newSecret = "new-cipher-root-key"
+	)
+
+	for _, test := range []struct {
+		name        string
+		callbackErr error
+		message     string
+	}{
+		{name: "success", message: "param value changed"},
+		{name: "error", callbackErr: fmt.Errorf("callback error"), message: "param change callback failed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			observedLogs.TakeAll()
+			manager := config.NewManager()
+			param := &ParamItem{
+				Key:          "cipherPlugin.kms.defaultKey",
+				DefaultValue: oldSecret,
+				Sensitive:    true,
+			}
+			param.Init(manager)
+
+			param.RegisterCallback(func(_ context.Context, _ string, oldValue, newValue string) error {
+				assert.Equal(t, oldSecret, oldValue)
+				assert.Equal(t, newSecret, newValue)
+				return test.callbackErr
+			})
+			param.handleConfigChange(&config.Event{
+				EventType: config.UpdateType,
+				Key:       param.Key,
+				Value:     newSecret,
+			})
+
+			entries := observedLogs.FilterMessage(test.message).All()
+			require.Len(t, entries, 1)
+			fields := entries[0].ContextMap()
+			assert.Equal(t, config.RedactedValue, fields["oldValue"])
+			assert.Equal(t, config.RedactedValue, fields["newValue"])
+			assert.NotContains(t, fmt.Sprint(fields), oldSecret)
+			assert.NotContains(t, fmt.Sprint(fields), newSecret)
+		})
+	}
 }
 
 func TestParamItem_NoValueChange(t *testing.T) {

--- a/pkg/util/paramtable/sensitive_config_test.go
+++ b/pkg/util/paramtable/sensitive_config_test.go
@@ -1,0 +1,181 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paramtable
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v3/config"
+)
+
+var sensitiveConfigNamePatterns = []string{
+	"password",
+	"secret",
+	"credential",
+	"accesskey",
+	"apikey",
+	"privatekey",
+	"token",
+	"authparams",
+	"saslusername",
+	"superusers",
+}
+
+func TestSensitiveConfigMetadata(t *testing.T) {
+	base := NewBaseTable(SkipRemote(true), SkipEnv(true))
+	require.NoError(t, base.Save("localStorage.path", t.TempDir()))
+	params := ComponentParam{}
+	params.Init(base)
+	cipher := cipherConfig{}
+	cipher.init(base)
+
+	mgr := base.Manager()
+	sensitiveKeys := []string{
+		params.CommonCfg.SuperUsers.Key,
+		params.CommonCfg.DefaultRootPassword.Key,
+		params.EtcdCfg.EtcdAuthUserName.Key,
+		params.EtcdCfg.EtcdAuthPassword.Key,
+		params.PulsarCfg.Address.Key,
+		params.PulsarCfg.AuthParams.Key,
+		params.KafkaCfg.SaslUsername.Key,
+		params.KafkaCfg.SaslPassword.Key,
+		params.KafkaCfg.KafkaTLSKeyPassword.Key,
+		params.MinioCfg.Address.Key,
+		params.MinioCfg.AccessKeyID.Key,
+		params.MinioCfg.SecretAccessKey.Key,
+		params.MinioCfg.GcpCredentialJSON.Key,
+		params.MinioCfg.IAMEndpoint.Key,
+		params.TraceCfg.JaegerURL.Key,
+		params.TraceCfg.OtlpEndpoint.Key,
+		params.TraceCfg.OtlpHeaders.Key,
+		cipher.DefaultRootKey.Key,
+		cipher.KmsAwsRoleARN.Key,
+		cipher.KmsAwsExternalID.Key,
+	}
+	for _, key := range sensitiveKeys {
+		assert.True(t, mgr.IsConfigRegistered(key), key)
+		assert.True(t, mgr.IsSensitive(key), key)
+		assert.Equal(t, config.RedactedValue, mgr.RedactValue(key, "sentinel"), key)
+	}
+
+	sensitiveGroupKeys := []string{
+		"credential.apikey1.apikey",
+		"kafka.consumer.sasl.password",
+		"kafka.producer.ssl.key.password",
+		"function.textEmbedding.providers.openai.credential",
+		"function.rerank.model.providers.cohere.credential",
+		"function.analyzer.lindera.download_urls.ipadic",
+		"function.models.zilliz.api_key",
+	}
+	for _, key := range sensitiveGroupKeys {
+		assert.True(t, mgr.IsConfigRegistered(key), key)
+		assert.True(t, mgr.IsSensitive(key), key)
+	}
+
+	assert.True(t, mgr.IsConfigRegistered(params.CommonCfg.AuthorizationEnabled.Key))
+	assert.False(t, mgr.IsSensitive(params.CommonCfg.AuthorizationEnabled.Key))
+	assert.Equal(t, "visible", mgr.RedactValue(params.CommonCfg.AuthorizationEnabled.Key, "visible"))
+
+	assert.True(t, mgr.IsConfigRegistered("MINIO_SECRET_ACCESS_KEY"))
+	assert.True(t, mgr.IsSensitive("OPENAI_API_KEY"))
+
+	require.NoError(t, params.Save(params.MinioCfg.SecretAccessKey.Key, "configured-secret"))
+	projected := params.GetComponentConfigurations("proxy", "secretaccesskey")
+	assert.Equal(t, config.RedactedValue, projected["miniosecretaccesskey"])
+	raw := mgr.GetByRaw(config.WithSubstr("secretaccesskey"))
+	assert.Equal(t, "configured-secret", raw["miniosecretaccesskey"])
+
+	require.NoError(t, params.Save(params.PulsarCfg.Address.Key, "pulsar://user:pulsar-secret@localhost:6650"))
+	require.NoError(t, params.Save(params.MinioCfg.Address.Key, "user:minio-secret@localhost:9000"))
+	assert.Equal(t, config.RedactedValue, params.GetAll()["pulsaraddress"])
+	assert.Equal(t, config.RedactedValue, params.GetAll()["minioaddress"])
+	assert.Contains(t, params.GetAllRaw()["pulsaraddress"], "pulsar-secret")
+	assert.Contains(t, params.GetAllRaw()["minioaddress"], "minio-secret")
+}
+
+func TestSensitiveParamGroupUsesRawValuesInternally(t *testing.T) {
+	mgr := config.NewManager()
+	group := ParamGroup{
+		KeyPrefix: "credential.",
+		Sensitive: true,
+	}
+	group.Init(mgr)
+	mgr.SetMapConfig("credential.provider.api_key", "group-secret")
+
+	values := group.GetValue()
+	require.Contains(t, values, "provider.api_key")
+	assert.Equal(t, "group-secret", values["provider.api_key"])
+
+	safe := mgr.GetBy(config.WithPrefix("credential."), config.RemovePrefix("credential."))
+	assert.Equal(t, config.RedactedValue, safe["provider.api_key"])
+}
+
+func TestSecretLikeParamItemsDeclareSensitiveMetadata(t *testing.T) {
+	base := NewBaseTable(SkipRemote(true), SkipEnv(true))
+	require.NoError(t, base.Save("localStorage.path", t.TempDir()))
+	params := ComponentParam{}
+	params.Init(base)
+
+	var missing []string
+	walkParamItemsForSensitiveAudit(reflect.ValueOf(&params).Elem(), func(item *ParamItem) {
+		normalizedKey := strings.NewReplacer("-", "", "_", "", ".", "", "/", "").Replace(strings.ToLower(item.Key))
+		if normalizedKey == "" {
+			return
+		}
+		if item.Sensitive && item.NonSensitive {
+			missing = append(missing, item.Key+" (both Sensitive and NonSensitive)")
+			return
+		}
+		for _, pattern := range sensitiveConfigNamePatterns {
+			if strings.Contains(normalizedKey, pattern) && !item.Sensitive && !item.NonSensitive {
+				missing = append(missing, item.Key)
+				return
+			}
+		}
+	})
+	assert.Empty(t, missing, "secret-like ParamItems must declare Sensitive metadata")
+}
+
+func walkParamItemsForSensitiveAudit(value reflect.Value, visit func(*ParamItem)) {
+	if value.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Field(i)
+		if !field.CanInterface() && field.CanAddr() {
+			field = reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
+		}
+
+		switch field.Type().String() {
+		case "paramtable.ParamItem":
+			if field.CanAddr() {
+				visit(field.Addr().Interface().(*ParamItem))
+			}
+		case "paramtable.ParamGroup":
+		default:
+			if field.Kind() == reflect.Struct {
+				walkParamItemsForSensitiveAudit(field, visit)
+			}
+		}
+	}
+}

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -337,6 +337,7 @@ We recommend using version 1.2 and above.`,
 		DefaultValue: "etcdadmin",
 		Doc:          "username for etcd authentication",
 		Export:       true,
+		Sensitive:    true,
 	}
 	p.EtcdAuthUserName.Init(base.mgr)
 
@@ -346,6 +347,7 @@ We recommend using version 1.2 and above.`,
 		DefaultValue: "etcdadmin",
 		Doc:          "password for etcd authentication",
 		Export:       true,
+		Sensitive:    true,
 	}
 	p.EtcdAuthPassword.Init(base.mgr)
 
@@ -1160,7 +1162,8 @@ Environment variable: PULSAR_ADDRESS
 pulsar.address and pulsar.port together generate the valid access to Pulsar.
 Pulsar preferentially acquires the valid IP address from the environment variable PULSAR_ADDRESS when Milvus is started.
 Default value applies when Pulsar is running on the same network with Milvus.`,
-		Export: true,
+		Export:    true,
+		Sensitive: true,
 	}
 	p.Address.Init(base.mgr)
 
@@ -1225,8 +1228,9 @@ To share a Pulsar instance among multiple Milvus instances, you can change this 
 	p.AuthPlugin.Init(base.mgr)
 
 	p.AuthParams = ParamItem{
-		Key:     "pulsar.authParams",
-		Version: "2.2.0",
+		Key:       "pulsar.authParams",
+		Version:   "2.2.0",
+		Sensitive: true,
 		Formatter: func(authParams string) string {
 			jsonMap := make(map[string]string)
 			params := strings.Split(authParams, ",")
@@ -1311,6 +1315,7 @@ func (k *KafkaConfig) Init(base *BaseTable) {
 		DefaultValue: "",
 		Version:      "2.1.0",
 		Export:       true,
+		Sensitive:    true,
 	}
 	k.SaslUsername.Init(base.mgr)
 
@@ -1319,6 +1324,7 @@ func (k *KafkaConfig) Init(base *BaseTable) {
 		DefaultValue: "",
 		Version:      "2.1.0",
 		Export:       true,
+		Sensitive:    true,
 	}
 	k.SaslPassword.Init(base.mgr)
 
@@ -1372,22 +1378,25 @@ func (k *KafkaConfig) Init(base *BaseTable) {
 	k.KafkaTLSCACert.Init(base.mgr)
 
 	k.KafkaTLSKeyPassword = ParamItem{
-		Key:     "kafka.ssl.tlsKeyPassword",
-		Version: "2.3.11",
-		Doc:     "private key passphrase for use with ssl.key.location and set_ssl_cert(), if any",
-		Export:  true,
+		Key:       "kafka.ssl.tlsKeyPassword",
+		Version:   "2.3.11",
+		Doc:       "private key passphrase for use with ssl.key.location and set_ssl_cert(), if any",
+		Export:    true,
+		Sensitive: true,
 	}
 	k.KafkaTLSKeyPassword.Init(base.mgr)
 
 	k.ConsumerExtraConfig = ParamGroup{
 		KeyPrefix: "kafka.consumer.",
 		Version:   "2.2.0",
+		Sensitive: true,
 	}
 	k.ConsumerExtraConfig.Init(base.mgr)
 
 	k.ProducerExtraConfig = ParamGroup{
 		KeyPrefix: "kafka.producer.",
 		Version:   "2.2.0",
+		Sensitive: true,
 	}
 	k.ProducerExtraConfig.Init(base.mgr)
 
@@ -1560,7 +1569,8 @@ Environment variable: MINIO_ADDRESS
 minio.address and minio.port together generate the valid access to MinIO or S3 service.
 MinIO preferentially acquires the valid IP address from the environment variable MINIO_ADDRESS when Milvus is started.
 Default value applies when MinIO or S3 is running on the same network with Milvus.`,
-		Export: true,
+		Export:    true,
+		Sensitive: true,
 	}
 	p.Address.Init(base.mgr)
 
@@ -1574,7 +1584,8 @@ Environment variable: MINIO_ACCESS_KEY_ID or minio.accessKeyID
 minio.accessKeyID and minio.secretAccessKey together are used for identity authentication to access the MinIO or S3 service.
 This configuration must be set identical to the environment variable MINIO_ACCESS_KEY_ID, which is necessary for starting MinIO or S3.
 The default value applies to MinIO or S3 service that started with the default docker-compose.yml file.`,
-		Export: true,
+		Export:    true,
+		Sensitive: true,
 	}
 	p.AccessKeyID.Init(base.mgr)
 
@@ -1588,7 +1599,8 @@ Environment variable: MINIO_SECRET_ACCESS_KEY or minio.secretAccessKey
 minio.accessKeyID and minio.secretAccessKey together are used for identity authentication to access the MinIO or S3 service.
 This configuration must be set identical to the environment variable MINIO_SECRET_ACCESS_KEY, which is necessary for starting MinIO or S3.
 The default value applies to MinIO or S3 service that started with the default docker-compose.yml file.`,
-		Export: true,
+		Export:    true,
+		Sensitive: true,
 	}
 	p.SecretAccessKey.Init(base.mgr)
 
@@ -1704,7 +1716,8 @@ When useIAM enabled, only "aws", "gcp", "aliyun" is supported for now`,
 		DefaultValue: "",
 		Doc: `The JSON content contains the gcs service account credentials.
 Used only for the "gcpnative" cloud provider.`,
-		Export: true,
+		Export:    true,
+		Sensitive: true,
 	}
 	p.GcpCredentialJSON.Init(base.mgr)
 
@@ -1714,7 +1727,8 @@ Used only for the "gcpnative" cloud provider.`,
 		Version:      "2.0.0",
 		Doc: `Custom endpoint for fetch IAM role credentials. when useIAM is true & cloudProvider is "aws".
 Leave it empty if you want to use AWS default endpoint`,
-		Export: true,
+		Export:    true,
+		Sensitive: true,
 	}
 	p.IAMEndpoint.Init(base.mgr)
 	p.LogLevel = ParamItem{


### PR DESCRIPTION
issue: #49846
related: #49847

## Assessment

The original report's claim that the current route returns every plaintext secret was not reproduced. The existing proxy handler already masked several known key-name patterns.

There is still a real defense-in-depth gap:

- EnvSource imports the entire process environment.
- Configuration projection APIs returned raw values by default.
- The boundary denylist did not cover opaque names such as DATABASE_URL or all token/private-key variants.
- A formatted environment alias could masquerade as a dynamic ParamGroup member.
- When data-plane authorization is enabled, any authenticated user could read the proxy cluster and hook configuration views.

This change includes regression coverage showing that unknown environment values are present in the explicit raw view but never appear in the default projection.

## What changed

- Makes Manager.GetConfigs, GetConfigsView, GetBy, and FileConfigs return safe projections by default.
- Adds explicit GetConfigsRaw, GetConfigsViewRaw, GetByRaw, and FileConfigsRaw APIs for internal consumers that require original values.
- Registers declared ParamItem keys and ParamGroup prefixes, with Sensitive and NonSensitive metadata.
- Fails closed for unregistered source keys, including arbitrary process environment variables.
- Preserves separators when matching dynamic prefixes so a key such as PROXY_ACCESSLOG_FORMATTERS_DATABASE_URL cannot impersonate proxy.accessLog.formatters.
- Marks credential-bearing scalar and dynamic configuration groups as sensitive.
- Keeps ParamGroup and cipher runtime consumers on explicit raw APIs.
- Denies sensitive and unregistered keys in /management/config/get.
- Requires the root identity for proxy cluster/hook configuration views when common.security.authorizationEnabled is true. Behavior is unchanged when it is false.
- Redacts sensitive ParamItem old/new values in configuration-change logs while still passing raw values to internal callbacks.
- Removes raw old/new values from cipher reload logs.

## Authorization scope and relationship to #49847

This PR does not introduce a new ReadClusterConfig privilege. The proxy route uses a root-only gate backed by the existing authorizationEnabled setting.

PR #49847 is broader and partially overlapping: it adds an independent adminAuthEnabled gate for the full management plane, profiling endpoints, and additional log sinks. This PR's distinct focus is making the configuration-manager projection APIs safe by default, requiring explicit raw access, adding runtime NonSensitive exceptions, and closing the formatted dynamic-prefix spoofing gap.

The port-9091 /management/config/get and /management/config/alter endpoints are not made authenticated by this PR; they still rely on the management network boundary. The get endpoint now rejects sensitive/unknown keys, but declared non-sensitive keys remain enumerable. The broader management-plane authorization should be handled by #49847. If #49847 lands first, the overlapping metadata and proxy authorization pieces should be reconciled during rebase.

Hook configuration has an empty dynamic prefix, which cannot be safely registered without declaring every source key valid. Its external projection therefore fails closed, while internal hook consumers continue to use raw values.

## Verification

Passed locally with the required dynamic,test tags and disabled inlining:

- Focused pkg/config projection and environment-secret tests.
- Focused pkg/util/paramtable metadata, raw-consumer, callback-log redaction, and duplicate-value tests.
- internal/util/hookutil TestCipherSuite/TestRegisterCallback with embedded-etcd startup disabled.
- git diff --check.

The focused internal/proxy and internal/coordinator targets could not compile in this checkout because rocksdb.pc, milvus_core.pc, and milvus-storage.pc are unavailable locally. CI must type-check and run those tests.

The proxy authorization tests exercise route middleware with an injected trusted username. They do not claim end-to-end Basic/API-key authentication coverage.
