### PR TITLE
fix: avoid OpenMP overhead in vector test data generation

### DIFF
--- a/internal/core/unittest/test_utils/DataGen.h
+++ b/internal/core/unittest/test_utils/DataGen.h
@@ -573,7 +573,16 @@ DataGen(SchemaPtr schema,
         auto dim = field_meta.get_dim();
         vector<float> final(dim * N);
         bool is_ip = starts_with(field_meta.get_name().get(), "normalized");
-#pragma omp parallel for
+        // Deliberately serial. The VECTOR_ARRAY generator calls this once per
+        // row with N == array_len (typically 3), so an OpenMP region here is
+        // entered once per row: a 10k-row fixture opened 10k parallel regions,
+        // each forking a team sized to the host's core count to run three
+        // iterations. On a 128-core machine the fork/join and barrier cost
+        // dwarfs the work by orders of magnitude and the fixture never
+        // finishes -- ElementFilter.GrowingSegmentArrayOffsets hung
+        // indefinitely there while passing on smaller CI hosts. The loop is
+        // cheap RNG arithmetic; generating it serially costs milliseconds even
+        // for the largest fixtures.
         for (int n = 0; n < N; ++n) {
             vector<float> data(dim);
             float sum = 0;


### PR DESCRIPTION
Split from #51878.

## What this fixes

The vector-array test-data generator called `generate_float_vector` once per row with a very small `N`, but entered an OpenMP parallel region for every call. A 10k-row fixture therefore created 10k thread teams to execute only a few loop iterations each.

On high-core-count test hosts, fork/join and barrier overhead dominated the actual RNG work and could make vector-array tests appear hung. The loop is now deliberately serial.

This is test infrastructure only; it does not change production vector generation or query behavior.

## Validation

- Single-file patch: `internal/core/unittest/test_utils/DataGen.h`.
- Patch-id exactly matches the DataGen change reviewed in #51878.
- clang-format 15.0.7 `--dry-run --Werror` passed.
- `git diff --check` passed.
- The source #51878 head passed the complete C++ CI suite: 8447/8447 tests.
