### PR TITLE
enhance: [GoSDK] fix client telemetry correctness gaps and add request ID propagation

### DIFF
--- a/client/milvusclient/interceptors.go
+++ b/client/milvusclient/interceptors.go
@@ -18,6 +18,8 @@ package milvusclient
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"strconv"
 	"time"
 
@@ -40,7 +42,86 @@ const (
 
 	// ClientRequestMsecKey temp const value, TODO use common package def after upgrading milvus/pkg version
 	ClientRequestMsecKey string = "client-request-unixmsec"
+
+	// ClientRequestIDKey carries a caller-supplied ID used to correlate a request with the
+	// server-side logs it produces. The server parses it as an OpenTelemetry TraceID and
+	// adopts it as the trace ID for the request, but only when no W3C `traceparent` was
+	// propagated. See pkg/tracer/client_request_id_propagator.go.
+	//
+	// The value MUST be a 32-character lowercase hex string (a 16-byte OTel TraceID);
+	// anything else is ignored by the server.
+	ClientRequestIDKey string = "client_request_id"
+
+	// traceIDHexLen is the encoded length of a 16-byte OpenTelemetry TraceID.
+	traceIDHexLen = 32
 )
+
+// clientRequestIDKeyType is the context key used to carry a caller-supplied request ID.
+type clientRequestIDKeyType struct{}
+
+// WithClientRequestID returns a context that makes the SDK send `id` as the
+// client_request_id header on every request issued with it. The server adopts `id` as the
+// trace ID for those requests, so it shows up in Milvus server logs and can be used to
+// find everything a specific client call did -- the same mechanism pymilvus exposes via
+// CallContext(client_request_id=...).
+//
+// `id` must be a 32-character lowercase hex OpenTelemetry TraceID (as produced by
+// trace.TraceID.String()); NewClientRequestID generates a conforming one. An invalid value
+// is dropped rather than sent, because the server would silently ignore it anyway.
+//
+// This is opt-in by design. The header is NOT sent by default because of how the server
+// consumes it: pkg/tracer/client_request_id_propagator.go builds a remote span context
+// with no sampled flag, and the server's ParentBased sampler maps an unsampled remote
+// parent to NeverSample. So a request carrying client_request_id is excluded from trace
+// sampling regardless of trace.sampleFraction. Use this for log correlation; it is not a
+// substitute for W3C traceparent propagation.
+func WithClientRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, clientRequestIDKeyType{}, id)
+}
+
+// NewClientRequestID returns a random, well-formed ID suitable for WithClientRequestID.
+// It returns "" if the system entropy source fails.
+func NewClientRequestID() string {
+	return newClientRequestID()
+}
+
+// isValidTraceIDHex reports whether s is a well-formed, non-zero 32-char hex TraceID.
+// It mirrors trace.TraceIDFromHex on the server so an invalid value is never put on the
+// wire, where it would be silently dropped anyway.
+func isValidTraceIDHex(s string) bool {
+	if len(s) != traceIDHexLen {
+		return false
+	}
+	nonZero := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch >= '0' && ch <= '9':
+		case ch >= 'a' && ch <= 'f':
+		default:
+			return false
+		}
+		if ch != '0' {
+			nonZero = true
+		}
+	}
+	return nonZero
+}
+
+// newClientRequestID returns a random 32-char hex TraceID, or "" if the system entropy
+// source fails (in which case the header is simply omitted).
+func newClientRequestID() string {
+	var buf [traceIDHexLen / 2]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return ""
+	}
+	id := hex.EncodeToString(buf[:])
+	if !isValidTraceIDHex(id) {
+		// All-zero read: not a valid TraceID for the server.
+		return ""
+	}
+	return id
+}
 
 func (c *Client) MetadataUnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
@@ -75,7 +156,21 @@ func (c *Client) state(ctx context.Context) context.Context {
 
 func (c *Client) extraInfo(ctx context.Context) context.Context {
 	ctx = metadata.AppendToOutgoingContext(ctx, ClientRequestMsecKey, strconv.FormatInt(time.Now().UnixMilli(), 10))
+	if requestID := clientRequestIDFromContext(ctx); requestID != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, ClientRequestIDKey, requestID)
+	}
 	return ctx
+}
+
+// clientRequestIDFromContext returns the caller-supplied request ID, or "" when none was
+// set or it is malformed. Nothing is generated here: sending an ID the caller did not ask
+// for would opt every request out of server-side trace sampling (see WithClientRequestID).
+func clientRequestIDFromContext(ctx context.Context) string {
+	id, ok := ctx.Value(clientRequestIDKeyType{}).(string)
+	if !ok || !isValidTraceIDHex(id) {
+		return ""
+	}
+	return id
 }
 
 // ref: https://github.com/grpc-ecosystem/go-grpc-middleware

--- a/client/milvusclient/interceptors_test.go
+++ b/client/milvusclient/interceptors_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 )
@@ -65,4 +66,93 @@ func TestRateLimitInterceptor(t *testing.T) {
 	err = inter(ctx1, "", nil, mockInvokerReply, nil, mockInvoker)
 	assert.NoError(t, err)
 	assert.Equal(t, uint(1), uint(mockInvokeTimes))
+}
+
+func TestIsValidTraceIDHex(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"valid", "4bf92f3577b34da6a3ce929d0e0e4736", true},
+		{"all zero", "00000000000000000000000000000000", false},
+		{"too short", "4bf92f3577b34da6a3ce929d0e0e473", false},
+		{"too long", "4bf92f3577b34da6a3ce929d0e0e47366", false},
+		{"empty", "", false},
+		{"uppercase rejected", "4BF92F3577B34DA6A3CE929D0E0E4736", false},
+		{"non hex", "4bf92f3577b34da6a3ce929d0e0e473g", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isValidTraceIDHex(tc.input))
+		})
+	}
+}
+
+func TestNewClientRequestID(t *testing.T) {
+	id := newClientRequestID()
+	assert.Len(t, id, traceIDHexLen)
+	assert.True(t, isValidTraceIDHex(id), "generated id must be parseable by the server")
+
+	// IDs must differ per call, otherwise every request collapses onto one trace.
+	assert.NotEqual(t, id, newClientRequestID())
+}
+
+func TestClientRequestIDFromContext(t *testing.T) {
+	t.Run("caller supplied id wins", func(t *testing.T) {
+		want := "4bf92f3577b34da6a3ce929d0e0e4736"
+		ctx := WithClientRequestID(context.Background(), want)
+		assert.Equal(t, want, clientRequestIDFromContext(ctx))
+	})
+
+	t.Run("malformed id is dropped", func(t *testing.T) {
+		ctx := WithClientRequestID(context.Background(), "not-a-trace-id")
+		assert.Empty(t, clientRequestIDFromContext(ctx))
+	})
+
+	t.Run("no id yields empty", func(t *testing.T) {
+		assert.Empty(t, clientRequestIDFromContext(context.Background()))
+	})
+}
+
+func TestExtraInfoInjectsClientRequestID(t *testing.T) {
+	c := &Client{}
+
+	// The header is opt-in: sending it unrequested would opt the request out of
+	// server-side trace sampling, since the server maps it to an unsampled remote parent.
+	t.Run("absent unless requested", func(t *testing.T) {
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(context.Background()))
+		assert.True(t, ok)
+
+		assert.Empty(t, md.Get(ClientRequestIDKey))
+		// The timestamp header is unconditional and must still be present.
+		assert.Len(t, md.Get(ClientRequestMsecKey), 1)
+	})
+
+	t.Run("propagates caller supplied id", func(t *testing.T) {
+		want := "4bf92f3577b34da6a3ce929d0e0e4736"
+		ctx := WithClientRequestID(context.Background(), want)
+
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(ctx))
+		assert.True(t, ok)
+		assert.Equal(t, []string{want}, md.Get(ClientRequestIDKey))
+	})
+
+	t.Run("malformed id is not sent", func(t *testing.T) {
+		ctx := WithClientRequestID(context.Background(), "bogus")
+
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(ctx))
+		assert.True(t, ok)
+		assert.Empty(t, md.Get(ClientRequestIDKey))
+	})
+
+	t.Run("NewClientRequestID round trips", func(t *testing.T) {
+		id := NewClientRequestID()
+		ctx := WithClientRequestID(context.Background(), id)
+
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(ctx))
+		assert.True(t, ok)
+		assert.Equal(t, []string{id}, md.Get(ClientRequestIDKey))
+	})
 }

--- a/client/milvusclient/telemetry.go
+++ b/client/milvusclient/telemetry.go
@@ -28,6 +28,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -47,6 +50,14 @@ type TelemetryConfig struct {
 	SamplingRate float64
 	// ErrorMaxCount is the maximum number of errors to keep
 	ErrorMaxCount int
+	// ClientID identifies this client to the server across process restarts.
+	//
+	// When empty, a random UUID is generated per Client, which means the server sees a
+	// brand-new client on every restart: telemetry history fragments and `client:<id>`
+	// scoped commands cannot target a long-lived client. Set it to a stable value (e.g.
+	// a pod name, or hostname+role) to get continuity. It must be unique per process --
+	// reusing one value across processes collapses them into a single server-side entry.
+	ClientID string
 }
 
 // DefaultTelemetryConfig returns the default telemetry configuration
@@ -431,7 +442,9 @@ type ClientTelemetryManager struct {
 	configMu sync.RWMutex // Protects config access
 	client   *Client
 
-	// Unique client ID (UUID), generated once at startup, stable across reconnections
+	// Unique client ID, resolved once at construction. Stable for the lifetime of this
+	// Client (and therefore across gRPC reconnects). It only survives a process restart
+	// when the caller pins it via TelemetryConfig.ClientID; otherwise it is a fresh UUID.
 	clientID string
 
 	// Metrics collectors per operation
@@ -476,6 +489,17 @@ type ClientTelemetryManager struct {
 	// Startup state - indicates if telemetry manager has started
 	ready atomic.Bool
 
+	// unsupported is set when the server does not implement ClientTelemetryService
+	// (returns codes.Unimplemented). Once set, the heartbeat loop exits permanently
+	// instead of retrying a call that can never succeed.
+	unsupported atomic.Bool
+
+	// lastHeartbeatErr records the most recent heartbeat failure. The client module has
+	// no logger, so this is the only way to surface an otherwise silent best-effort
+	// failure; read it with LastHeartbeatError().
+	lastHeartbeatErr   error
+	lastHeartbeatErrMu sync.RWMutex
+
 	// Deterministic sampling counter
 	samplingCounter uint64
 }
@@ -496,10 +520,17 @@ func NewClientTelemetryManager(client *Client, config *TelemetryConfig) *ClientT
 		config = DefaultTelemetryConfig()
 	}
 
+	// Prefer a caller-supplied stable ID so the server can correlate this client across
+	// process restarts; fall back to a per-process UUID.
+	clientID := config.ClientID
+	if clientID == "" {
+		clientID = uuid.New().String()
+	}
+
 	tm := &ClientTelemetryManager{
 		config:             config,
 		client:             client,
-		clientID:           uuid.New().String(),
+		clientID:           clientID,
 		collectors:         make(map[string]*OperationMetricsCollector),
 		commandHandlers:    make(map[string]CommandHandler),
 		executedCommands:   make(map[string]int64),
@@ -581,6 +612,12 @@ func (m *ClientTelemetryManager) heartbeatLoop() {
 	// Use time.After instead of ticker to dynamically adapt to interval changes
 	// This allows server-pushed config to take effect immediately
 	for {
+		// A server without ClientTelemetryService will never accept a heartbeat; stop
+		// rather than burn an RPC every interval for the lifetime of the client.
+		if m.unsupported.Load() {
+			return
+		}
+
 		interval := m.getHeartbeatInterval()
 		select {
 		case <-m.stopCh:
@@ -590,6 +627,28 @@ func (m *ClientTelemetryManager) heartbeatLoop() {
 			m.sendHeartbeat()
 		}
 	}
+}
+
+// IsSupported reports whether the connected server implements ClientTelemetryService.
+// It returns false once a heartbeat has been rejected with codes.Unimplemented, at which
+// point telemetry is permanently disabled for this client.
+func (m *ClientTelemetryManager) IsSupported() bool {
+	return !m.unsupported.Load()
+}
+
+// LastHeartbeatError returns the most recent heartbeat failure, or nil if the last
+// heartbeat succeeded. Heartbeats are best-effort and never surfaced through the normal
+// API, so this is the supported way to diagnose a client that is not reporting.
+func (m *ClientTelemetryManager) LastHeartbeatError() error {
+	m.lastHeartbeatErrMu.RLock()
+	defer m.lastHeartbeatErrMu.RUnlock()
+	return m.lastHeartbeatErr
+}
+
+func (m *ClientTelemetryManager) setLastHeartbeatError(err error) {
+	m.lastHeartbeatErrMu.Lock()
+	defer m.lastHeartbeatErrMu.Unlock()
+	m.lastHeartbeatErr = err
 }
 
 // sendHeartbeat sends a heartbeat to the server
@@ -602,45 +661,18 @@ func (m *ClientTelemetryManager) sendHeartbeat() {
 		return
 	}
 
-	if m.client == nil || m.client.service == nil {
+	if m.unsupported.Load() {
+		return
+	}
+
+	if m.client == nil || m.client.telemetryService == nil {
 		return
 	}
 
 	// Get metrics from the latest snapshot (P99 already calculated during snapshot creation)
 	var metrics []*commonpb.OperationMetrics
-	latestSnapshot := m.GetLatestSnapshot()
-	if latestSnapshot != nil {
-		enabledCollections, allEnabled := m.snapshotEnabledCollections()
-
-		// Convert snapshot metrics to proto format
-		for _, opMetrics := range latestSnapshot.Metrics {
-			protoCollMetrics := make(map[string]*commonpb.Metrics)
-			// Only include metrics for enabled collections
-			// Use "*" wildcard to enable all collections
-			for coll, cm := range opMetrics.CollectionMetrics {
-				if allEnabled || enabledCollections[coll] {
-					protoCollMetrics[coll] = &commonpb.Metrics{
-						RequestCount: cm.RequestCount,
-						SuccessCount: cm.SuccessCount,
-						ErrorCount:   cm.ErrorCount,
-						AvgLatencyMs: cm.AvgLatencyMs,
-						P99LatencyMs: cm.P99LatencyMs,
-					}
-				}
-			}
-
-			metrics = append(metrics, &commonpb.OperationMetrics{
-				Operation: opMetrics.Operation,
-				Global: &commonpb.Metrics{
-					RequestCount: opMetrics.Global.RequestCount,
-					SuccessCount: opMetrics.Global.SuccessCount,
-					ErrorCount:   opMetrics.Global.ErrorCount,
-					AvgLatencyMs: opMetrics.Global.AvgLatencyMs,
-					P99LatencyMs: opMetrics.Global.P99LatencyMs, // Use P99 from snapshot
-				},
-				CollectionMetrics: protoCollMetrics,
-			})
-		}
+	if latestSnapshot := m.GetLatestSnapshot(); latestSnapshot != nil {
+		metrics = m.toProtoOperationMetrics(latestSnapshot.Metrics)
 	}
 
 	// Get pending command replies (snapshot only)
@@ -662,19 +694,28 @@ func (m *ClientTelemetryManager) sendHeartbeat() {
 		LastCommandTimestamp: m.lastCommandTimestamp.Load(),
 	}
 
-	// Send heartbeat with 30s fixed interval (no retry - telemetry is best effort)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	resp, err := m.client.telemetryService.ClientHeartbeat(ctx, req)
+	// Telemetry is best-effort: opt out of the client-wide retry interceptor so a failing
+	// heartbeat costs exactly one RPC instead of up to 6 with backoff. The next heartbeat
+	// is the retry.
+	resp, err := m.client.telemetryService.ClientHeartbeat(ctx, req, grpc_retry.Disable())
 	if err != nil {
-		// Log error but continue - telemetry is best-effort
+		m.setLastHeartbeatError(err)
+		// A server that predates ClientTelemetryService will fail this way forever.
+		// Latch it off so the heartbeat loop can exit instead of retrying every interval.
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			m.unsupported.Store(true)
+		}
 		return
 	}
 
-	if !merr.Ok(resp.GetStatus()) {
+	if err := merr.Error(resp.GetStatus()); err != nil {
+		m.setLastHeartbeatError(err)
 		return
 	}
+	m.setLastHeartbeatError(nil)
 
 	// Clear sent replies only after successful heartbeat
 	m.clearPendingProtoReplies(len(replies))
@@ -735,51 +776,48 @@ func (m *ClientTelemetryManager) shouldSample(samplingRate float64) bool {
 	return counter%samplingDenominator < threshold
 }
 
-// collectProtoMetrics collects all operation metrics and converts to proto format
-func (m *ClientTelemetryManager) collectProtoMetrics() []*commonpb.OperationMetrics {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+// toProtoOperationMetrics converts collected metrics into their proto form, dropping
+// collection-level entries for collections that are not currently enabled ("*" enables
+// all). This is the single conversion path used for everything put on the wire.
+func (m *ClientTelemetryManager) toProtoOperationMetrics(opMetricsList []*OperationMetrics) []*commonpb.OperationMetrics {
+	if len(opMetricsList) == 0 {
+		return nil
+	}
 
 	enabledCollections, allEnabled := m.snapshotEnabledCollections()
 
-	var result []*commonpb.OperationMetrics
-	for opName, collector := range m.collectors {
-		globalMetrics := collector.GetMetrics()
-		if globalMetrics == nil {
-			continue
-		}
-
-		collMetrics := collector.GetCollectionMetrics()
-
+	result := make([]*commonpb.OperationMetrics, 0, len(opMetricsList))
+	for _, opMetrics := range opMetricsList {
 		protoCollMetrics := make(map[string]*commonpb.Metrics)
-		// Only include metrics for enabled collections
-		// Use "*" wildcard to enable all collections
-		for coll, cm := range collMetrics {
+		for coll, cm := range opMetrics.CollectionMetrics {
 			if allEnabled || enabledCollections[coll] {
-				protoCollMetrics[coll] = &commonpb.Metrics{
-					RequestCount: cm.RequestCount,
-					SuccessCount: cm.SuccessCount,
-					ErrorCount:   cm.ErrorCount,
-					AvgLatencyMs: cm.AvgLatencyMs,
-					P99LatencyMs: cm.P99LatencyMs,
-				}
+				protoCollMetrics[coll] = toProtoMetrics(cm)
 			}
 		}
 
 		result = append(result, &commonpb.OperationMetrics{
-			Operation: opName,
-			Global: &commonpb.Metrics{
-				RequestCount: globalMetrics.RequestCount,
-				SuccessCount: globalMetrics.SuccessCount,
-				ErrorCount:   globalMetrics.ErrorCount,
-				AvgLatencyMs: globalMetrics.AvgLatencyMs,
-				P99LatencyMs: globalMetrics.P99LatencyMs,
-			},
+			Operation:         opMetrics.Operation,
+			Global:            toProtoMetrics(opMetrics.Global),
 			CollectionMetrics: protoCollMetrics,
 		})
 	}
 
 	return result
+}
+
+// toProtoMetrics converts a single metrics bucket to proto form.
+func toProtoMetrics(metrics *Metrics) *commonpb.Metrics {
+	if metrics == nil {
+		return nil
+	}
+	return &commonpb.Metrics{
+		RequestCount: metrics.RequestCount,
+		SuccessCount: metrics.SuccessCount,
+		ErrorCount:   metrics.ErrorCount,
+		AvgLatencyMs: metrics.AvgLatencyMs,
+		P99LatencyMs: metrics.P99LatencyMs,
+		MaxLatencyMs: metrics.MaxLatencyMs,
+	}
 }
 
 // getPendingProtoRepliesSnapshot returns a snapshot of pending replies without clearing.
@@ -981,100 +1019,6 @@ func (m *ClientTelemetryManager) collectMetrics() []*OperationMetrics {
 	return result
 }
 
-// getPendingReplies gets and clears pending command replies (local types, for testing)
-func (m *ClientTelemetryManager) getPendingReplies() []*CommandReply {
-	m.pendingRepliesMu.Lock()
-	defer m.pendingRepliesMu.Unlock()
-
-	var result []*CommandReply
-	for _, r := range m.pendingReplies {
-		result = append(result, &CommandReply{
-			CommandId:    r.GetCommandId(),
-			Success:      r.GetSuccess(),
-			ErrorMessage: r.GetErrorMessage(),
-			Payload:      r.GetPayload(),
-		})
-	}
-	m.pendingReplies = nil
-	return result
-}
-
-// processCommands processes commands (local types, for testing)
-// Commands are only executed once using timestamp-based deduplication:
-// - Commands with CreateTime < lastCommandTimestamp are filtered by timestamp (already processed)
-// - Commands with CreateTime >= lastCommandTimestamp use ID-based tracking for same-millisecond deduplication
-func (m *ClientTelemetryManager) processCommands(commands []*ClientCommand) {
-	hasPersistent := false
-	lastTS := m.lastCommandTimestamp.Load()
-	maxCommandTS := lastTS
-
-	// First, process all commands
-	for _, cmd := range commands {
-		if cmd.Persistent {
-			hasPersistent = true
-		}
-		if cmd.CreateTime > maxCommandTS {
-			maxCommandTS = cmd.CreateTime
-		}
-
-		// Timestamp-based deduplication: commands older than lastTS are already processed
-		if cmd.CreateTime < lastTS {
-			// Already processed in a previous cycle - skip
-			continue
-		}
-
-		// For commands at or after lastTS, check map for same-millisecond duplicates
-		m.executedCommandsMu.RLock()
-		_, alreadyExecuted := m.executedCommands[cmd.CommandId]
-		m.executedCommandsMu.RUnlock()
-
-		if alreadyExecuted {
-			// Skip execution but still generate a success reply
-			continue
-		}
-
-		// Handle the command
-		reply := m.handleCommand(cmd)
-
-		// Track command with its timestamp for later cleanup
-		m.executedCommandsMu.Lock()
-		m.executedCommands[cmd.CommandId] = cmd.CreateTime
-		m.executedCommandsMu.Unlock()
-
-		if reply != nil {
-			m.pendingRepliesMu.Lock()
-			m.pendingReplies = append(m.pendingReplies, &commonpb.CommandReply{
-				CommandId:    reply.CommandId,
-				Success:      reply.Success,
-				ErrorMessage: reply.ErrorMessage,
-				Payload:      reply.Payload,
-			})
-			m.pendingRepliesMu.Unlock()
-		}
-	}
-
-	// Clean up old entries from executedCommands map
-	// Commands with CreateTime <= lastTS are now filtered by timestamp comparison
-	// Using <= ensures commands with same millisecond timestamp are also cleaned up
-	m.executedCommandsMu.Lock()
-	for cmdID, ts := range m.executedCommands {
-		if ts <= lastTS {
-			delete(m.executedCommands, cmdID)
-		}
-	}
-	m.executedCommandsMu.Unlock()
-
-	// Update config hash AFTER all commands are processed
-	// This ensures partial processing doesn't lead to lost configs on reconnect
-	if hasPersistent {
-		m.configHashMu.Lock()
-		m.configHash = m.calculateConfigHash(commands)
-		m.configHashMu.Unlock()
-	}
-
-	m.updateLastCommandTimestamp(maxCommandTS)
-}
-
 // handleCommand handles a single command
 func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) *CommandReply {
 	m.commandHandlersMu.RLock()
@@ -1090,32 +1034,6 @@ func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) *CommandReply
 	}
 
 	return handler(cmd)
-}
-
-// calculateConfigHash calculates a hash for persistent commands (local types)
-func (m *ClientTelemetryManager) calculateConfigHash(commands []*ClientCommand) string {
-	if len(commands) == 0 {
-		return ""
-	}
-
-	var commandStrs []string
-	for _, cmd := range commands {
-		if cmd.Persistent {
-			commandStrs = append(commandStrs, cmd.CommandId+":"+cmd.CommandType)
-		}
-	}
-
-	if len(commandStrs) == 0 {
-		return ""
-	}
-
-	sort.Strings(commandStrs)
-
-	h := sha256.New()
-	for _, str := range commandStrs {
-		h.Write([]byte(str))
-	}
-	return hex.EncodeToString(h.Sum(nil))[:16]
 }
 
 // RegisterCommandHandler registers a handler for a command type

--- a/client/milvusclient/telemetry_integration_test.go
+++ b/client/milvusclient/telemetry_integration_test.go
@@ -143,13 +143,13 @@ func TestTelemetryIntegration(t *testing.T) {
 			},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Check state
 		fmt.Printf("\nConfig hash: %s\n", manager.GetConfigHash())
 
 		// Get pending replies
-		replies := manager.getPendingReplies()
+		replies := drainPendingReplies(manager)
 		fmt.Printf("Pending replies: %d\n", len(replies))
 		for _, r := range replies {
 			fmt.Printf("  Command %s: success=%v\n", r.CommandId, r.Success)
@@ -177,7 +177,7 @@ func TestTelemetryIntegration(t *testing.T) {
 		metrics := manager.collectMetrics()
 		fmt.Printf("Metrics count: %d\n", len(metrics))
 
-		replies := manager.getPendingReplies()
+		replies := drainPendingReplies(manager)
 		fmt.Printf("Pending replies: %d\n", len(replies))
 	})
 }

--- a/client/milvusclient/telemetry_test.go
+++ b/client/milvusclient/telemetry_test.go
@@ -17,12 +17,18 @@
 package milvusclient
 
 import (
+	"context"
 	"encoding/json"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 )
@@ -260,14 +266,14 @@ func TestClientTelemetryManager(t *testing.T) {
 			}
 		})
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Config hash should be updated for persistent commands
 		assert.NotEmpty(t, manager.GetConfigHash())
 
 		// Process the same commands again - should be idempotent
 		oldHash := manager.GetConfigHash()
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 		assert.Equal(t, oldHash, manager.GetConfigHash())
 	})
 
@@ -291,14 +297,14 @@ func TestClientTelemetryManager(t *testing.T) {
 		commands := []*ClientCommand{
 			{CommandId: "cmd-1", CommandType: "test", CreateTime: 1000},
 		}
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
-		replies := manager.getPendingReplies()
+		replies := drainPendingReplies(manager)
 		assert.Len(t, replies, 1)
 		assert.Equal(t, "cmd-1", replies[0].CommandId)
 
 		// Second call should return empty
-		replies = manager.getPendingReplies()
+		replies = drainPendingReplies(manager)
 		assert.Len(t, replies, 0)
 	})
 }
@@ -484,7 +490,7 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 			{CommandId: "cfg2", CommandType: "enable_trace", Payload: []byte(`{"enabled": true}`), Persistent: true},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should be updated after all commands processed
 		hash := manager.GetConfigHash()
@@ -492,7 +498,7 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 
 		// Hash should include both commands
 		// Verify by processing again - hash should remain the same
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 		assert.Equal(t, hash, manager.GetConfigHash())
 	})
 
@@ -504,7 +510,7 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 			{CommandId: "cmd1", CommandType: "show_errors", Persistent: false},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should remain empty
 		assert.Equal(t, "", manager.GetConfigHash())
@@ -520,16 +526,16 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 			{CommandId: "cmd2", CommandType: "clear_metrics", Persistent: false},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should be calculated based on persistent commands only
 		hash := manager.GetConfigHash()
 		assert.NotEmpty(t, hash)
 
 		// Add another non-persistent command - hash shouldn't change
-		manager.processCommands([]*ClientCommand{
+		manager.processProtoCommands(toProtoCommands([]*ClientCommand{
 			{CommandId: "cmd3", CommandType: "show_metrics", Persistent: false},
-		})
+		}))
 		assert.Equal(t, hash, manager.GetConfigHash())
 	})
 }
@@ -555,10 +561,10 @@ func TestPartialDeliveryScenario(t *testing.T) {
 		assert.Equal(t, "", manager.GetConfigHash())
 
 		// Now process all commands properly
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should now be updated
-		expectedHash := manager.calculateConfigHash(commands)
+		expectedHash := manager.calculateProtoConfigHash(toProtoCommands(commands))
 		assert.Equal(t, expectedHash, manager.GetConfigHash())
 	})
 }
@@ -1656,7 +1662,7 @@ func TestCollectProtoMetrics(t *testing.T) {
 		manager.RecordOperation("Search", "test_col", startTime, nil)
 		manager.RecordOperation("Insert", "test_col", startTime, errors.New("insert error"))
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.NotEmpty(t, metrics)
 
 		// Find Search metrics
@@ -1685,7 +1691,7 @@ func TestCollectProtoMetrics(t *testing.T) {
 		manager.RecordOperation("Query", "col_a", startTime, nil)
 		manager.RecordOperation("Query", "col_b", startTime, nil) // Not enabled
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		for _, m := range metrics {
 			if m.Operation == "Query" {
 				// Only col_a should have collection metrics
@@ -1766,7 +1772,7 @@ func TestCalculateProtoConfigHash(t *testing.T) {
 func TestCalculateConfigHash(t *testing.T) {
 	t.Run("empty commands", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
-		hash := manager.calculateConfigHash(nil)
+		hash := manager.calculateProtoConfigHash(nil)
 		assert.Empty(t, hash)
 	})
 
@@ -1775,7 +1781,7 @@ func TestCalculateConfigHash(t *testing.T) {
 		commands := []*ClientCommand{
 			{CommandId: "cmd-1", CommandType: "show_errors", Persistent: false},
 		}
-		hash := manager.calculateConfigHash(commands)
+		hash := manager.calculateProtoConfigHash(toProtoCommands(commands))
 		assert.Empty(t, hash)
 	})
 }
@@ -1980,7 +1986,7 @@ func TestCollectProtoMetricsEdgeCases(t *testing.T) {
 	t.Run("no collectors", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.Empty(t, metrics)
 	})
 
@@ -1992,7 +1998,7 @@ func TestCollectProtoMetricsEdgeCases(t *testing.T) {
 		manager.collectors["EmptyOp"] = NewOperationMetricsCollector()
 		manager.mu.Unlock()
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.Empty(t, metrics) // Should skip collectors with no data
 	})
 
@@ -2007,7 +2013,7 @@ func TestCollectProtoMetricsEdgeCases(t *testing.T) {
 		// Record operations
 		manager.RecordOperation("Search", "any_collection", time.Now().Add(-10*time.Millisecond), nil)
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.NotEmpty(t, metrics)
 
 		// Find Search metrics and verify collection is included
@@ -3296,4 +3302,157 @@ func TestAggregateSnapshotsZeroRequestCount(t *testing.T) {
 	assert.NotNil(t, result.Aggregated.Metrics["Search"])
 	assert.Equal(t, float64(0), result.Aggregated.Metrics["Search"].AvgLatencyMs)
 	assert.Equal(t, float64(0), result.Aggregated.Metrics["Search"].P99LatencyMs)
+}
+
+// toProtoCommands converts local test fixtures into the proto form the production command
+// path consumes. Tests drive processProtoCommands/calculateProtoConfigHash through this so
+// they exercise the same code that runs against a real server, rather than a parallel
+// local-type implementation that can silently drift from it.
+func toProtoCommands(commands []*ClientCommand) []*commonpb.ClientCommand {
+	if commands == nil {
+		return nil
+	}
+	result := make([]*commonpb.ClientCommand, 0, len(commands))
+	for _, cmd := range commands {
+		result = append(result, &commonpb.ClientCommand{
+			CommandId:   cmd.CommandId,
+			CommandType: cmd.CommandType,
+			Payload:     cmd.Payload,
+			CreateTime:  cmd.CreateTime,
+			Persistent:  cmd.Persistent,
+			TargetScope: cmd.TargetScope,
+		})
+	}
+	return result
+}
+
+// drainPendingReplies returns the queued command replies and clears them, mirroring what a
+// successful heartbeat does, so assertions can be written against local types.
+func drainPendingReplies(m *ClientTelemetryManager) []*CommandReply {
+	protoReplies := m.getPendingProtoRepliesSnapshot()
+	m.clearPendingProtoReplies(len(protoReplies))
+
+	var result []*CommandReply
+	for _, r := range protoReplies {
+		result = append(result, &CommandReply{
+			CommandId:    r.GetCommandId(),
+			Success:      r.GetSuccess(),
+			ErrorMessage: r.GetErrorMessage(),
+			Payload:      r.GetPayload(),
+		})
+	}
+	return result
+}
+
+func TestTelemetryClientID(t *testing.T) {
+	t.Run("defaults to generated uuid", func(t *testing.T) {
+		m1 := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		m2 := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		assert.NotEmpty(t, m1.clientID)
+		assert.NotEqual(t, m1.clientID, m2.clientID)
+	})
+
+	t.Run("honors configured stable id", func(t *testing.T) {
+		cfg := DefaultTelemetryConfig()
+		cfg.ClientID = "milvus-worker-0"
+
+		m := NewClientTelemetryManager(nil, cfg)
+		assert.Equal(t, "milvus-worker-0", m.clientID)
+
+		// The heartbeat must carry it, that is what the server keys scoping on.
+		assert.Equal(t, "milvus-worker-0", m.buildClientInfo().GetReserved()["client_id"])
+	})
+}
+
+func TestMaxLatencyIsReported(t *testing.T) {
+	m := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+	m.handleCollectionMetrics(&ClientCommand{
+		CommandId:   "enable-all",
+		CommandType: "collection_metrics",
+		Payload:     []byte(`{"enabled": true, "collections": ["*"]}`),
+	})
+
+	start := time.Now().Add(-50 * time.Millisecond)
+	m.RecordOperation("Search", "coll-1", start, nil)
+
+	protoMetrics := m.toProtoOperationMetrics(m.collectMetrics())
+	assert.Len(t, protoMetrics, 1)
+
+	global := protoMetrics[0].GetGlobal()
+	assert.Greater(t, global.GetMaxLatencyMs(), float64(0), "max_latency_ms must reach the wire")
+	assert.GreaterOrEqual(t, global.GetMaxLatencyMs(), global.GetAvgLatencyMs())
+
+	collMetrics := protoMetrics[0].GetCollectionMetrics()["coll-1"]
+	assert.NotNil(t, collMetrics)
+	assert.Greater(t, collMetrics.GetMaxLatencyMs(), float64(0))
+}
+
+// TestHeartbeatAgainstUnimplementedServer covers a client talking to a Milvus that predates
+// ClientTelemetryService: the heartbeat can never succeed, so it must latch off instead of
+// firing forever on every interval.
+func TestHeartbeatAgainstUnimplementedServer(t *testing.T) {
+	lis := bufconn.Listen(bufSize)
+	// Deliberately register no services: every RPC answers codes.Unimplemented.
+	svr := grpc.NewServer()
+	go func() { _ = svr.Serve(lis) }()
+	defer func() {
+		svr.Stop()
+		lis.Close()
+	}()
+
+	c, err := New(context.Background(), &ClientConfig{
+		Address:         "bufnet",
+		DisableConn:     true,
+		TelemetryConfig: &TelemetryConfig{Enabled: false},
+		DialOptions: []grpc.DialOption{
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		},
+	})
+	require.NoError(t, err)
+	defer c.Close(context.Background())
+
+	m := NewClientTelemetryManager(c, &TelemetryConfig{
+		Enabled:           true,
+		HeartbeatInterval: time.Hour,
+		SamplingRate:      1.0,
+		ErrorMaxCount:     10,
+	})
+	require.True(t, m.IsSupported())
+	require.NoError(t, m.LastHeartbeatError())
+
+	m.sendHeartbeat()
+
+	assert.False(t, m.IsSupported(), "Unimplemented must permanently disable telemetry")
+	assert.Error(t, m.LastHeartbeatError(), "the failure must be observable, not silently swallowed")
+
+	// Once latched, further heartbeats are a no-op rather than another doomed RPC.
+	m.sendHeartbeat()
+	assert.False(t, m.IsSupported())
+}
+
+func TestHeartbeatLoopExitsWhenUnsupported(t *testing.T) {
+	// A one-hour interval means a loop that does not honor the latch would hang here.
+	m := NewClientTelemetryManager(nil, &TelemetryConfig{
+		Enabled:           true,
+		HeartbeatInterval: time.Hour,
+		SamplingRate:      1.0,
+		ErrorMaxCount:     10,
+	})
+	m.unsupported.Store(true)
+	m.Start()
+
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("heartbeat loop did not exit after telemetry was marked unsupported")
+	}
 }


### PR DESCRIPTION
issue: #47281

## What

The Go SDK is currently the only SDK that implements the client side of `ClientTelemetryService`. Auditing it against the server implementation in `internal/rootcoord/telemetry` turned up five issues. The protocol-critical parts (config_hash algorithm, `last_command_timestamp` watermark, reply retry-on-failed-heartbeat, reservoir P99) were all correct — these are the gaps around them.

## Changes

**1. No way to correlate a client call with server-side logs.**

Adds opt-in `WithClientRequestID(ctx, id)` and `NewClientRequestID()`, sending the `client_request_id` header that `pkg/tracer/client_request_id_propagator.go` already consumes. pymilvus exposes the same thing via `CallContext(client_request_id=...)`; the Go SDK had no equivalent.

This is **deliberately opt-in rather than automatic**. The server propagator builds a remote span context with no sampled flag, and `SetTracerProvider` uses `ParentBased(TraceIDRatioBased(fraction))`, whose default `remoteParentNotSampled` is `NeverSample()`. Injecting the header unconditionally would therefore *exclude* every Go SDK request from trace sampling whenever `trace.sampleFraction > 0` — the opposite of the intent. Use it for log correlation; it is not a substitute for W3C `traceparent` propagation.

**2. Doomed heartbeat retried forever against an older server.**

```go
resp, err := m.client.telemetryService.ClientHeartbeat(ctx, req)
if err != nil {
    // Log error but continue - telemetry is best-effort
    return   // <- nothing was actually logged
}
```

Against a server predating `ClientTelemetryService` this fires every 30s for the lifetime of the client, with no backoff, no self-disable, and no diagnostics. Now latches off on `codes.Unimplemented`, exits the heartbeat loop, and exposes `IsSupported()` / `LastHeartbeatError()` — the `client/` module has no logger, so an accessor is the only way to surface a best-effort failure. `connectInternal` already handled `Unimplemented` this way; the heartbeat path just missed it.

Also passes `grpc_retry.Disable()` on the heartbeat, so a heartbeat against an `Unavailable` server costs one RPC instead of six with exponential backoff (the client-wide interceptor retries `Unavailable`/`ResourceExhausted`).

**3. `max_latency_ms` collected but never sent.**

`common.Metrics` has the field and the collector computed it, but every proto conversion site omitted it, so the server could never display it.

**4. `client_id` not stable across restarts.**

It was a fresh `uuid.New()` per process, so server-side telemetry history fragmented on every restart and `client:<id>` scoped commands could not target a long-lived client. Adds `TelemetryConfig.ClientID` to pin it. Unchanged behaviour when unset.

**5. Test-only fork that had already diverged.**

`processCommands` / `calculateConfigHash` / `collectProtoMetrics` / `getPendingReplies` were a parallel implementation reachable only from tests. They had already drifted: the test-only `calculateConfigHash` hashed `ID:Type`, while production hashes `ID + Type + payload`. Since `config_hash` must match the server byte-for-byte or configs get re-pushed on every heartbeat, the tests were validating an algorithm that never runs.

Deletes the fork, collapses the duplicated snapshot→proto conversion into a single `toProtoOperationMetrics()`, and repoints the tests at the production functions.

## Tests

- `TestIsValidTraceIDHex`, `TestNewClientRequestID`, `TestClientRequestIDFromContext`, `TestExtraInfoInjectsClientRequestID` — header is absent unless requested, malformed IDs are dropped, valid ones round-trip.
- `TestHeartbeatAgainstUnimplementedServer` — bufconn server with no services registered; asserts the latch and that the error is observable.
- `TestHeartbeatLoopExitsWhenUnsupported` — one-hour interval, so a loop ignoring the latch hangs the test.
- `TestMaxLatencyIsReported`, `TestTelemetryClientID`.

## Verification

`go test ./...` green across the `client/` module, `golangci-lint run` 0 issues, `gofmt` clean.

Verification is unit-level. **This has not been run against a live Milvus server** — in particular the end-to-end behaviour of `client_request_id` reaching server logs is reasoned from the propagator and sampler source, not observed.