### PR TITLE
fix: client_request_id no longer disables trace sampling

### DIFF
--- a/pkg/tracer/client_request_id_propagator.go
+++ b/pkg/tracer/client_request_id_propagator.go
@@ -29,12 +29,48 @@ const (
 	clientRequestIDKey       = "client_request_id"
 )
 
+// syntheticParentKey marks a context whose remote span context was synthesized from a
+// client_request_id header rather than extracted from a real upstream traceparent. The
+// value is the synthesized SpanID, so the sampler can tell that span context apart from
+// any other parent it might later be asked about.
+//
+// This is an in-process marker only: it is a context value, never a span-context field, so
+// it is not propagated to downstream components. Those receive a normal traceparent whose
+// sampled flag already reflects the decision made here.
+type syntheticParentKey struct{}
+
+// withSyntheticParent records that spanID was synthesized locally rather than propagated.
+func withSyntheticParent(ctx context.Context, spanID trace.SpanID) context.Context {
+	return context.WithValue(ctx, syntheticParentKey{}, spanID)
+}
+
+// hasSyntheticParent reports whether the parent span context in ctx is one this package
+// synthesized from a client_request_id.
+//
+// It re-checks the span context rather than trusting the marker alone: the marker stays in
+// the context for the whole request, so a child span started later in the same process
+// would otherwise be misidentified as having a synthetic parent and be re-sampled
+// independently of its real parent.
+func hasSyntheticParent(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	spanID, ok := ctx.Value(syntheticParentKey{}).(trace.SpanID)
+	if !ok {
+		return false
+	}
+	psc := trace.SpanContextFromContext(ctx)
+	return psc.IsRemote() && psc.SpanID() == spanID
+}
+
 type clientRequestIDPropagator struct{}
 
 func (clientRequestIDPropagator) Inject(_ context.Context, _ propagation.TextMapCarrier) {
 }
 
 func (clientRequestIDPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	// A real traceparent always wins. This propagator is composed after the W3C one, so a
+	// valid span context here means TraceContext already extracted an upstream decision.
 	if trace.SpanContextFromContext(ctx).IsValid() {
 		return ctx
 	}
@@ -48,6 +84,13 @@ func (clientRequestIDPropagator) Extract(ctx context.Context, carrier propagatio
 	if !spanID.IsValid() {
 		return ctx
 	}
+
+	// The synthesized context carries no sampled flag on purpose: a client must not be
+	// able to force sampling on. Instead it is marked as synthetic, and clientRequestIDSampler
+	// samples it as a root span so trace.sampleFraction governs the decision. Without that
+	// marker the ParentBased sampler would read "remote parent, not sampled" and drop the
+	// trace outright.
+	ctx = withSyntheticParent(ctx, spanID)
 
 	return trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID: traceID,

--- a/pkg/tracer/sampler.go
+++ b/pkg/tracer/sampler.go
@@ -1,0 +1,64 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	sdk "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// clientRequestIDSampler makes a client-supplied request ID seed the trace ID without also
+// acting as an upstream sampling decision.
+//
+// A client_request_id is turned into a remote span context by clientRequestIDPropagator so
+// that the resulting trace carries the caller's ID. That span context has no sampled flag,
+// because a client must not be able to switch sampling on. But ParentBased maps
+// "remote parent, not sampled" to NeverSample, so on its own that arrangement drops every
+// request carrying a client_request_id -- regardless of trace.sampleFraction, and for the
+// whole downstream call tree.
+//
+// This sampler restores the intended behavior: a synthetic parent is sampled as if the
+// span were a root, so trace.sampleFraction decides. Everything else, including a genuine
+// upstream traceparent that says sampled=0, is delegated to ParentBased and keeps standard
+// W3C semantics.
+type clientRequestIDSampler struct {
+	// root decides for spans whose parent was synthesized locally.
+	root sdk.Sampler
+	// delegate decides for every other span.
+	delegate sdk.Sampler
+}
+
+// newClientRequestIDSampler builds the sampler used by SetTracerProvider. root is applied
+// to synthetic parents and is also the root sampler of the ParentBased delegate, so both
+// paths use the same sampling ratio.
+func newClientRequestIDSampler(root sdk.Sampler) sdk.Sampler {
+	return clientRequestIDSampler{
+		root:     root,
+		delegate: sdk.ParentBased(root),
+	}
+}
+
+func (s clientRequestIDSampler) ShouldSample(p sdk.SamplingParameters) sdk.SamplingResult {
+	if hasSyntheticParent(p.ParentContext) {
+		// Not a real upstream decision -- decide as a root span would.
+		return s.root.ShouldSample(p)
+	}
+	return s.delegate.ShouldSample(p)
+}
+
+func (s clientRequestIDSampler) Description() string {
+	return "ClientRequestIDSampler{" + s.delegate.Description() + "}"
+}

--- a/pkg/tracer/sampler_test.go
+++ b/pkg/tracer/sampler_test.go
@@ -1,0 +1,200 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	sdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	testClientTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	testUpstreamSpan  = "00f067aa0ba902b7"
+)
+
+// serverPropagator mirrors the composition used by getServerHandlerOpts.
+func serverPropagator() propagation.TextMapPropagator {
+	return propagation.NewCompositeTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}),
+		clientRequestIDPropagator{},
+	)
+}
+
+// startServerSpan extracts headers the way the gRPC server stats handler does, then starts
+// the span that handler would start, and reports the resulting span context.
+func startServerSpan(t *testing.T, headers map[string]string, ratio float64) trace.SpanContext {
+	t.Helper()
+
+	tp := sdk.NewTracerProvider(sdk.WithSampler(newClientRequestIDSampler(sdk.TraceIDRatioBased(ratio))))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	ctx := serverPropagator().Extract(context.Background(), propagation.MapCarrier(headers))
+	_, span := tp.Tracer("test").Start(ctx, "server-rpc")
+	defer span.End()
+
+	return span.SpanContext()
+}
+
+// TestClientRequestIDIsSampledByRatio is the regression test for client_request_id
+// suppressing tracing: the synthesized parent carries no sampled flag, so a plain
+// ParentBased sampler mapped it to NeverSample and dropped the trace no matter what
+// trace.sampleFraction said.
+func TestClientRequestIDIsSampledByRatio(t *testing.T) {
+	t.Run("sampled when fraction is 1.0", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{clientRequestIDKey: testClientTraceID}, 1.0)
+
+		assert.True(t, sc.IsSampled(), "client_request_id must not opt the request out of sampling")
+		assert.Equal(t, testClientTraceID, sc.TraceID().String(), "trace must adopt the client supplied id")
+	})
+
+	t.Run("not sampled when fraction is 0.0", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{clientRequestIDKey: testClientTraceID}, 0.0)
+
+		assert.False(t, sc.IsSampled(), "the configured ratio must still govern")
+		assert.Equal(t, testClientTraceID, sc.TraceID().String())
+	})
+
+	t.Run("legacy header behaves the same", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{clientRequestIDKeyLegacy: testClientTraceID}, 1.0)
+
+		assert.True(t, sc.IsSampled())
+		assert.Equal(t, testClientTraceID, sc.TraceID().String())
+	})
+}
+
+// TestTraceparentKeepsW3CSemantics guards the other half: a real upstream decision must be
+// honored exactly, never overridden by the ratio.
+func TestTraceparentKeepsW3CSemantics(t *testing.T) {
+	t.Run("upstream sampled wins over ratio 0.0", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{
+			"traceparent": "00-" + testClientTraceID + "-" + testUpstreamSpan + "-01",
+		}, 0.0)
+
+		assert.True(t, sc.IsSampled(), "an upstream sampled=1 must be honored")
+		assert.Equal(t, testClientTraceID, sc.TraceID().String())
+	})
+
+	t.Run("upstream not sampled wins over ratio 1.0", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{
+			"traceparent": "00-" + testClientTraceID + "-" + testUpstreamSpan + "-00",
+		}, 1.0)
+
+		assert.False(t, sc.IsSampled(), "an upstream sampled=0 must not be re-sampled")
+	})
+}
+
+// TestTraceparentWinsOverClientRequestID pins the propagator ordering. Both headers present
+// must resolve to the upstream decision, not the synthesized one.
+func TestTraceparentWinsOverClientRequestID(t *testing.T) {
+	otherTraceID := "0af7651916cd43dd8448eb211c80319c"
+
+	sc := startServerSpan(t, map[string]string{
+		"traceparent":      "00-" + otherTraceID + "-" + testUpstreamSpan + "-00",
+		clientRequestIDKey: testClientTraceID,
+	}, 1.0)
+
+	assert.Equal(t, otherTraceID, sc.TraceID().String(), "traceparent must win")
+	assert.False(t, sc.IsSampled(), "and its sampling decision must be preserved")
+}
+
+func TestNoHeadersFallsBackToRatio(t *testing.T) {
+	assert.True(t, startServerSpan(t, nil, 1.0).IsSampled())
+	assert.False(t, startServerSpan(t, nil, 0.0).IsSampled())
+}
+
+// TestHasSyntheticParent covers the guard that keeps the marker from leaking onto child
+// spans. The marker lives in the context for the whole request, so without the span-ID
+// check an in-process child would be re-sampled as a root and could disagree with its
+// parent, splitting the trace.
+func TestHasSyntheticParent(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex(testClientTraceID)
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex(testUpstreamSpan)
+	require.NoError(t, err)
+
+	t.Run("nil context", func(t *testing.T) {
+		//nolint:staticcheck // SA1012: exercising the nil guard is the point of this case
+		assert.False(t, hasSyntheticParent(nil))
+	})
+
+	t.Run("no marker", func(t *testing.T) {
+		assert.False(t, hasSyntheticParent(context.Background()))
+	})
+
+	t.Run("marker matching the remote parent", func(t *testing.T) {
+		ctx := withSyntheticParent(context.Background(), spanID)
+		ctx = trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  spanID,
+			Remote:  true,
+		}))
+
+		assert.True(t, hasSyntheticParent(ctx))
+	})
+
+	t.Run("marker present but parent is a local child span", func(t *testing.T) {
+		localSpanID, err := trace.SpanIDFromHex("1112131415161718")
+		require.NoError(t, err)
+
+		ctx := withSyntheticParent(context.Background(), spanID)
+		// A child span started in-process: same trace, different span, not remote.
+		ctx = trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  localSpanID,
+		}))
+
+		assert.False(t, hasSyntheticParent(ctx),
+			"a child span must fall through to ParentBased, not be re-sampled as a root")
+	})
+}
+
+// TestChildSpanFollowsParentDecision is the end-to-end consequence of the guard above:
+// once the root decision is made, in-process children must inherit it.
+func TestChildSpanFollowsParentDecision(t *testing.T) {
+	tp := sdk.NewTracerProvider(sdk.WithSampler(newClientRequestIDSampler(sdk.TraceIDRatioBased(1.0))))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tracer := tp.Tracer("test")
+
+	ctx := serverPropagator().Extract(context.Background(),
+		propagation.MapCarrier{clientRequestIDKey: testClientTraceID})
+
+	ctx, root := tracer.Start(ctx, "server-rpc")
+	defer root.End()
+	require.True(t, root.SpanContext().IsSampled())
+
+	_, child := tracer.Start(ctx, "child")
+	defer child.End()
+
+	assert.True(t, child.SpanContext().IsSampled())
+	assert.Equal(t, root.SpanContext().TraceID(), child.SpanContext().TraceID())
+
+	ro, ok := child.(sdk.ReadOnlySpan)
+	require.True(t, ok, "a sampled span is recording and exposes ReadOnlySpan")
+	assert.Equal(t, root.SpanContext().SpanID(), ro.Parent().SpanID(),
+		"child must hang off the real root span, not the synthesized parent")
+}
+
+func TestClientRequestIDSamplerDescription(t *testing.T) {
+	s := newClientRequestIDSampler(sdk.TraceIDRatioBased(0.5))
+	assert.Contains(t, s.Description(), "ClientRequestIDSampler")
+}

--- a/pkg/tracer/stats_handler.go
+++ b/pkg/tracer/stats_handler.go
@@ -93,9 +93,14 @@ func getServerHandlerOpts() []otelgrpc.Option {
 	return []otelgrpc.Option{
 		otelgrpc.WithInterceptorFilter(filterFunc),
 		otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+		// Order matters: the W3C propagator runs first so a real traceparent always wins,
+		// and clientRequestIDPropagator's "already have a span context" guard becomes
+		// meaningful. With the previous order that guard could never fire, and the two
+		// propagators only happened to compose correctly because the later one overwrote
+		// the earlier one's span context.
 		otelgrpc.WithPropagators(propagation.NewCompositeTextMapPropagator(
-			clientRequestIDPropagator{},
 			otel.GetTextMapPropagator(),
+			clientRequestIDPropagator{},
 		)),
 	}
 }

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -74,7 +74,7 @@ func SetTracerProvider(exp sdk.SpanExporter, traceIDRatio float64) {
 			semconv.ServiceNameKey.String(paramtable.GetRole()),
 			attribute.Int64("NodeID", paramtable.GetNodeID()),
 		)),
-		sdk.WithSampler(sdk.ParentBased(
+		sdk.WithSampler(newClientRequestIDSampler(
 			sdk.TraceIDRatioBased(traceIDRatio),
 		)),
 	)


### PR DESCRIPTION
issue: #51963

## Problem

A request carrying `client_request_id` was **never sampled**, regardless of `trace.sampleFraction`, and the suppression propagated to every downstream component — the whole call tree vanished from Jaeger/OTLP.

It was silent because the header still did its main job: the trace ID reached the logs. You kept log correlation and lost tracing without any signal.

`clientRequestIDPropagator` carries the client ID in a synthesized **remote parent span context** with no sampled flag (`client_request_id_propagator.go:52-56`). `ParentBased` maps *remote parent, not sampled* → `NeverSample` (`sdk@v1.43.0 trace/sampling.go:200`), and its `root` sampler — the only one that consults `sampleFraction` — is reached **only when there is no parent at all**. Synthesizing a parent therefore took the decision away from the operator and hardcoded it to drop.

Root design error: a client-supplied *correlation ID* was placed in the *parent span context*, a slot that in OTel also encodes an upstream sampling decision.

## Fix

Separate the two meanings.

1. The propagator marks the span context it synthesized, via an **in-process context value** — never a span-context field, so nothing leaks onto the wire or downstream.
2. `clientRequestIDSampler` samples a synthetic parent **as if it were a root span**, so `trace.sampleFraction` governs it. Everything else delegates to `ParentBased` unchanged, so a genuine upstream `traceparent` — including `sampled=0` — keeps standard W3C semantics.

The marker is validated against the current parent span ID rather than trusted alone. It stays in the context for the whole request, so without that check an in-process **child** span would be re-sampled independently of its parent and split the trace. `TestHasSyntheticParent` and `TestChildSpanFollowsParentDecision` cover this.

## Also: propagator ordering

```go
propagation.NewCompositeTextMapPropagator(
    clientRequestIDPropagator{},   // ran first
    otel.GetTextMapPropagator(),   // TraceContext + Baggage, ran second
)
```

`clientRequestIDPropagator.Extract` opens with `if trace.SpanContextFromContext(ctx).IsValid() { return ctx }` — a guard meant to yield to a real traceparent. Running **first**, nothing has been extracted yet, so it could never fire. The two only composed correctly because `TraceContext` ran later and overwrote the synthesized context.

Swapped the order so the guard does what it says, and precedence is explicit instead of incidental — otherwise a future reordering silently flips behavior.

## Behaviour matrix

| Incoming | Before | After |
|---|---|---|
| `client_request_id`, `sampleFraction=1.0` | **dropped** | sampled, trace ID = client's ID |
| `client_request_id`, `sampleFraction=0.0` | dropped | dropped (ratio governs) |
| `traceparent` sampled=1, fraction=0.0 | sampled | sampled (unchanged) |
| `traceparent` sampled=0, fraction=1.0 | dropped | dropped (unchanged, W3C respected) |
| both headers | traceparent wins | traceparent wins (now by design, not by accident) |
| neither | ratio | ratio (unchanged) |

## Tests

`pkg/tracer/sampler_test.go` drives the real composite propagator and a real `TracerProvider`, covering every row above plus the child-span and marker-scoping cases.

Reverting the sampler branch makes `TestClientRequestIDIsSampledByRatio/sampled_when_fraction_is_1.0` fail with `sampled=false` at `sampleFraction=1.0` — i.e. the tests reproduce the bug rather than merely describing it.

## Verification

`go test ./tracer/...` green (including the pre-existing propagator tests), `golangci-lint` 0 issues, `gofmt` clean, `go build ./...` green for the `pkg` module. No exported API changed — every new symbol is unexported and `SetTracerProvider`'s signature is untouched.

Verification is unit-level. **Not yet exercised against a live Jaeger/OTLP backend**; the end-to-end claim in the matrix is derived from the sampler and propagator semantics plus these tests.

## Note

One pre-existing cosmetic consequence is now visible: a trace started from `client_request_id` has a root span whose `parentSpanID` refers to the synthesized span, which is never reported. Jaeger and Zipkin both render this as a normal partial trace (the span becomes the root). Removing the fake parent entirely would mean seeding the trace ID through a custom `IDGenerator` instead — a larger change on the hot path for every span, which seemed disproportionate for this fix. Happy to follow up if reviewers prefer it.