### PR TITLE
doc: refresh client telemetry MEP to match the implementation

### DIFF
--- a/docs/design-docs/design_docs/20260131-client_side_telemetry.md
+++ b/docs/design-docs/design_docs/20260131-client_side_telemetry.md
@@ -2,10 +2,17 @@
 
 - **Created:** 2026-01-31
 - **Author(s):** @xiaofanluan
-- **Status:** Draft
+- **Status:** Implemented
 - **Component:** SDK | Proxy | Coordinator
-- **Related Issues:** #46934
-- **Released:** [TBD]
+- **Related Issues:** #46934, #47281
+- **Implemented by:** #47523, #47542
+
+> This document was refreshed to match the implementation. Where the original draft
+> described interfaces that were never built (`set_sampling_rate`, `enable_collections`,
+> `update_config`, `/api/v1/telemetry/*`, `NewConfigHash`), those sections have been
+> replaced with what the code actually does. Source of truth is
+> `internal/rootcoord/telemetry/`, `internal/proxy/telemetry_*.go` and
+> `client/milvusclient/telemetry.go`.
 
 ## Summary
 
@@ -32,7 +39,7 @@ This feature addresses these gaps by implementing a comprehensive client telemet
 ```go
 // TelemetryConfig holds configurable settings for client telemetry
 type TelemetryConfig struct {
-    Enabled           bool          // Enable/disable telemetry collection
+    Enabled           bool          // Enable/disable telemetry collection (default: true)
     HeartbeatInterval time.Duration // Heartbeat frequency (default: 30s)
     SamplingRate      float64       // Sampling rate 0.0-1.0 (default: 1.0)
     ErrorMaxCount     int           // Max errors to track (default: 100)
@@ -45,19 +52,35 @@ type ClientConfig struct {
 }
 ```
 
+`DefaultTelemetryConfig()` returns `Enabled: true`. Telemetry is opt-in at the level of
+whether a caller constructs a `TelemetryConfig` at all, not via this flag.
+
 ### HTTP REST APIs (Proxy)
 
+Served on the internal HTTP port (`9091` by default), not on the gRPC port.
+
 ```
-GET  /api/v1/telemetry/clients          - List connected clients with optional filtering
-POST /api/v1/telemetry/commands         - Push commands to clients
-DELETE /api/v1/telemetry/commands/{id}  - Delete a command
+GET    /_telemetry/clients                      - List connected clients
+GET    /_telemetry/clients/{clientId}           - Metrics for one client
+GET    /_telemetry/clients/{clientId}/config    - Ask a client for its config (async)
+GET    /_telemetry/clients/{clientId}/history   - Ask a client for latency history (async)
+POST   /_telemetry/commands                     - Push a command to clients
+DELETE /_telemetry/commands/{commandId}         - Delete a command
+GET    /telemetry                               - WebUI dashboard
 ```
 
-### gRPC APIs (RootCoord)
+Path constants live in `internal/http/router.go`; registration is in
+`internal/proxy/impl.go` (`registerHTTPHandlers`).
+
+### gRPC APIs
+
+The RPCs live in their own service, `ClientTelemetryService`, registered on the Proxy's
+**external** gRPC server. Proxy forwards to MixCoord, which forwards to RootCoord, where
+`TelemetryManager` holds the state.
 
 ```protobuf
-service RootCoord {
-    // Client heartbeat with metrics
+service ClientTelemetryService {
+    // Client heartbeat with metrics; response carries pending commands
     rpc ClientHeartbeat(ClientHeartbeatRequest) returns (ClientHeartbeatResponse);
 
     // Query connected clients
@@ -71,6 +94,11 @@ service RootCoord {
 }
 ```
 
+`ClientHeartbeat` carries no `privilege_ext_obj` annotation, so the privilege interceptor
+short-circuits for it and only normal authentication applies. The REST endpoints are
+guarded by `TelemetryAuthMiddleware`, which is Basic Auth only -- there is no RBAC
+privilege check on this surface.
+
 ## Design Details
 
 ### Architecture Overview
@@ -83,7 +111,7 @@ service RootCoord {
 │  │  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐       │  │
 │  │  │ Operation       │  │ Error           │  │ Command         │       │  │
 │  │  │ Metrics         │  │ Collector       │  │ Handler         │       │  │
-│  │  │ Collector       │  │ (Ring Buffer)   │  │ Router          │       │  │
+│  │  │ Collector       │  │ (Ring Buffer)   │  │ Registry        │       │  │
 │  │  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘       │  │
 │  │           │                    │                    │                 │  │
 │  │           └────────────────────┼────────────────────┘                 │  │
@@ -104,12 +132,15 @@ service RootCoord {
 │  │     Proxy      │◄────────►│              RootCoord                     │  │
 │  │                │          │  ┌─────────────────────────────────────┐  │  │
 │  │  HTTP API      │          │  │      Telemetry Manager              │  │  │
-│  │  /telemetry/*  │          │  │  ┌───────────┐  ┌───────────────┐   │  │  │
+│  │  /_telemetry/* │          │  │  ┌───────────┐  ┌───────────────┐   │  │  │
 │  │                │          │  │  │ Client    │  │ Command       │   │  │  │
-│  │  WebUI         │          │  │  │ Store     │  │ Store         │   │  │  │
-│  │  telemetry.html│          │  │  └───────────┘  └───────────────┘   │  │  │
-│  └────────────────┘          │  └─────────────────────────────────────┘  │  │
-│                              └───────────────────────────────────────────┘  │
+│  │  WebUI         │          │  │  │ Cache     │  │ Store         │   │  │  │
+│  │  telemetry.html│          │  │  └───────────┘  └──────┬────────┘   │  │  │
+│  └────────────────┘          │  └────────────────────────┼────────────┘  │  │
+│                              └───────────────────────────┼───────────────┘  │
+│                                                          ▼                   │
+│                                            etcd: /client-telemetry/configs/  │
+│                                            (persistent configs only)         │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -121,24 +152,36 @@ The central component managing telemetry collection and heartbeat communication.
 
 ```go
 type ClientTelemetryManager struct {
-    config         *TelemetryConfig
-    client         *Client
-    clientID       string                              // Stable UUID
-    collectors     map[string]*OperationMetricsCollector
-    errorCollector *ErrorCollectorImpl
+    config          *TelemetryConfig
+    client          *Client
+    clientID        string                              // UUID, see below
+    collectors      map[string]*OperationMetricsCollector
+    errorCollector  *ErrorCollectorImpl
     commandHandlers map[string]CommandHandler
 
+    // Deduplication and change detection
+    configHash           string
+    lastCommandTimestamp atomic.Int64
+    executedCommands     map[string]int64
+
     // Heartbeat management
-    stopCh         chan struct{}
-    wg             sync.WaitGroup
+    stopCh chan struct{}
+    wg     sync.WaitGroup
 }
 ```
 
 **Key behaviors:**
-- Generates stable client UUID on creation
+- Generates a client UUID on creation. It is stable for the lifetime of the `Client`, and
+  therefore across gRPC reconnects, but **not across process restarts** -- each `New()`
+  produces a fresh UUID. Servers see a restarted process as a new client.
 - Starts background heartbeat loop on `Start()`
 - Sends first heartbeat immediately, then every `HeartbeatInterval`
+- Uses `time.After` per iteration rather than a `time.Ticker`, so a server-pushed interval
+  change takes effect on the next cycle
 - Collects and resets metrics atomically during snapshot creation
+
+**Instrumented operations (7):** `Search`, `Query`, `HybridSearch`, `RunAnalyzer`,
+`Insert`, `Delete`, `Upsert`. DDL, index and partition operations are not instrumented.
 
 #### 2. OperationMetricsCollector
 
@@ -162,12 +205,15 @@ type OperationMetricsCollector struct {
 }
 ```
 
-**Metrics tracked:**
-- Request count
-- Success/error counts
-- Average latency (ms)
-- P99 latency (ms) - calculated from 1000 sample buffer
-- Max latency (ms)
+**Metrics tracked:** request count, success/error counts, average latency (ms), P99 latency
+(ms, from the 1000-sample buffer), max latency (ms).
+
+P99 is computed inside the locked snapshot, *before* the sample buffer is reset, so a
+concurrent heartbeat cannot read a cleared buffer. `totalSamples` is tracked separately
+from the buffer index so a genuine 0µs latency is distinguishable from an unwritten slot.
+
+Per-collection metrics are **off by default** and enabled by the `collection_metrics`
+command.
 
 #### 3. ErrorCollectorImpl
 
@@ -181,11 +227,11 @@ type ErrorCollectorImpl struct {
 }
 
 type ErrorInfo struct {
-    Timestamp  int64
-    Operation  string
-    ErrorMsg   string
-    Collection string
-    RequestID  string
+    Timestamp  int64  `json:"timestamp"`             // Unix ms
+    Operation  string `json:"operation"`
+    ErrorMsg   string `json:"error_msg"`
+    Collection string `json:"collection,omitempty"`
+    RequestID  string `json:"request_id,omitempty"`
 }
 ```
 
@@ -194,52 +240,121 @@ type ErrorInfo struct {
 Supports server-pushed commands with extensible handler registration.
 
 ```go
-type CommandHandler func(cmd *ClientCommand) string  // Returns error message or ""
-
-// Built-in commands:
-const (
-    CmdSetSamplingRate   = "set_sampling_rate"        // Adjust sampling rate
-    CmdEnableCollections = "enable_collections"       // Enable specific collections
-    CmdUpdateConfig      = "update_config"            // Update telemetry config
-)
+type CommandHandler func(cmd *ClientCommand) *CommandReply
 ```
+
+**Command types.** These five strings are the complete set. `command_type` is a free-form
+string on the wire and the server does not validate it on push, so an unknown type reaches
+the client and is answered with `"unknown command type: <type>"`.
+
+| Type | Purpose | May be persistent |
+|------|---------|-------------------|
+| `push_config` | Change client telemetry settings | **Yes (the only one)** |
+| `collection_metrics` | Enable/disable per-collection metrics | No |
+| `show_errors` | Return the last N client-side errors | No |
+| `show_latency_history` | Return client metric snapshots for a time window | No |
+| `get_config` | Return the client's current effective config | No |
+
+`command_store.go` rejects `persistent=true` for anything other than `push_config`.
+
+**Payload schemas.** `ClientCommand.payload` is raw JSON (not protobuf).
+
+```go
+// push_config
+type PushConfigPayload struct {
+    Enabled             *bool    `json:"enabled,omitempty"`
+    HeartbeatIntervalMs *int64   `json:"heartbeat_interval_ms,omitempty"`
+    SamplingRate        *float64 `json:"sampling_rate,omitempty"`   // 0.0-1.0
+    TTLSeconds          int64    `json:"ttl_seconds,omitempty"`
+}
+
+// collection_metrics -- "*" in Collections is the all-collections wildcard
+type CollectionMetricsPayload struct {
+    Collections  []string `json:"collections"`
+    Enabled      bool     `json:"enabled"`
+    MetricsTypes []string `json:"metrics_types,omitempty"`
+}
+
+// show_errors
+type ErrorMessagesPayload struct {
+    MaxCount int `json:"max_count,omitempty"`   // default 100
+}
+
+// show_latency_history -- RFC3339 timestamps, window must be <= 1 hour
+type LatencyHistoryPayload struct {
+    StartTime string `json:"start_time"`
+    EndTime   string `json:"end_time"`
+    Detail    bool   `json:"detail"`
+}
+
+// get_config -- no payload
+```
+
+Reply payloads are capped at 1 MB client-side; `show_errors` halves the returned count
+until it fits. `get_config` deliberately omits `Password` and `APIKey`.
 
 ### Server-Side Components
 
 #### 1. Telemetry Manager (RootCoord)
 
-Central server-side storage for client telemetry data.
+Central server-side storage for client telemetry data. Client state is held in a
+`sync.Map` keyed by client ID.
 
 ```go
-type TelemetryManager struct {
-    clients      map[string]*ClientTelemetry  // clientID -> telemetry
-    commandStore *CommandStore
-}
-
-type ClientTelemetry struct {
+type ClientMetricsCache struct {
     ClientInfo        *commonpb.ClientInfo
     LastHeartbeatTime int64
-    Status            string  // "active" or "inactive"
-    Databases         []string
-    Metrics           []*commonpb.OperationMetrics
+    Status            string       // "active" or "inactive"
+    AccessedDatabases sync.Map     // accumulative, never pruned
+    LatestMetrics     []*commonpb.OperationMetrics
+    CommandReplies    []*StoredCommandReply   // last 50
+    LastCommandTS     int64
 }
 ```
+
+**Client identity.** The manager reads `ClientInfo.Reserved["client_id"]`. When absent it
+falls back to `legacy:<host>:<hash(sdkType|sdkVersion|host|user)>`, in which case two
+processes on the same host with the same SDK and user **collide into one entry** and
+`client:` scoping becomes unusable. Database association comes from
+`Reserved["db_name"]` (or `Reserved["database"]`).
+
+**Hardcoded limits.** There are no `milvus.yaml` or paramtable keys for this feature;
+`DefaultTelemetryConfig()` in `manager.go` is never overridden in production:
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `ClientStatusThreshold` | 1 min | No heartbeat for this long → `Status: "inactive"` |
+| `InactiveClientThreshold` | 10 min | No heartbeat for this long → evicted from memory |
+| `CleanupInterval` | 1 min | Sweep cadence for expired commands and dead clients |
+| `MaxClientsInMemory` | 100000 | Then LRU eviction by last heartbeat |
+| `MaxMetricsPerClient` | 1 MB | Larger payloads are truncated (see below) |
+| `MaxOperationTypesPerClient` | 100 | Operation list truncated to this many |
+
+**Metrics ingest guards.** On each heartbeat the server drops every `CollectionMetrics`
+entry whose `RequestCount == 0`, truncates the operation list to 100, and if the message
+still exceeds 1 MB, first nulls all `CollectionMetrics`, then truncates further.
 
 #### 2. Command Store
 
-Manages pending commands for clients with support for persistent and one-time commands.
+Manages pending commands, with different storage for the two kinds:
 
-```go
-type CommandStore struct {
-    commands     []*commonpb.ClientCommand  // One-time commands
-    persistent   []*commonpb.ClientCommand  // Persistent commands
-}
-```
+- **Persistent (`push_config` only)** → written to etcd under `/client-telemetry/configs/`.
+  Survives RootCoord restart. Deduplicated by `(ConfigType, TargetScope)`: pushing a second
+  config for the same scope **JSON-merges** the new payload over the old one and deletes the
+  superseded entry, so partial updates accumulate rather than replace.
+- **One-time** → in-memory on the RootCoord that received the push. Lost on restart and
+  **not shared across coordinator replicas**.
 
-**Command targeting:**
-- `TargetScope = "*"` - All clients
-- `TargetScope = "client_id:xxx"` - Specific client
-- `TargetScope = "db:database_name"` - Clients using specific database
+**Command targeting** (`TargetScope`, built server-side from the push request):
+
+- `global` — all clients
+- `client:<clientID>` — one client, exact match
+- `database:<dbName>` — clients that have accessed that database
+
+**TTL.** `ttl_seconds` is a field of `PushClientCommandRequest`, not of `ClientCommand`, so
+clients never see it. `0` means never expire — the command lives until a reply deletes it.
+Both `get_config` and `show_latency_history` are pushed with `ttl_seconds: 0`, so a client
+that never replies leaks them.
 
 #### 3. HTTP Handlers (Proxy)
 
@@ -247,13 +362,22 @@ REST API endpoints for WebUI and external integrations.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/v1/telemetry/clients` | GET | List connected clients |
-| `/api/v1/telemetry/clients?database=X` | GET | Filter by database |
-| `/api/v1/telemetry/clients?include_metrics=true` | GET | Include operation metrics |
-| `/api/v1/telemetry/commands` | POST | Push command to clients |
-| `/api/v1/telemetry/commands/{id}` | DELETE | Remove a command |
+| `/_telemetry/clients` | GET | List clients; `?database=`, `?client_id=`, `?include_metrics=` |
+| `/_telemetry/clients/{clientId}` | GET | Metrics for one client |
+| `/_telemetry/clients/{clientId}/config` | GET | Push `get_config`; returns a command ID |
+| `/_telemetry/clients/{clientId}/history` | GET | Push `show_latency_history`; `?start_time=`, `?end_time=`, `?detail=` |
+| `/_telemetry/commands` | POST | Push an arbitrary command |
+| `/_telemetry/commands/{commandId}` | DELETE | Remove a command |
 
-**Authentication:** Uses existing Milvus Basic Auth when authorization is enabled.
+**Authentication:** Basic Auth via `TelemetryAuthMiddleware`, active only when
+`common.security.authorizationEnabled` is set. No RBAC.
+
+**Asynchrony.** The `/config` and `/history` endpoints are fire-and-forget: they push a
+command and immediately return `{"command_id": ..., "status": "pending"}`. The result
+arrives with the client's next heartbeat (up to one `HeartbeatInterval` later) and is
+stored as a `StoredCommandReply`. Callers read it back from `GET /_telemetry/clients`,
+matching on `command_id` in the `command_replies` array. There is no dedicated
+"fetch reply by command ID" endpoint.
 
 ### Heartbeat Protocol
 
@@ -264,40 +388,84 @@ Client                                      Server
    │     - ClientInfo (ID, SDK version, host)  │
    │     - Metrics (per-operation, per-coll)   │
    │     - CommandReplies                      │
-   │     - ConfigHash (for change detection)   │
+   │     - ConfigHash                          │
+   │     - LastCommandTimestamp                │
    │                                           │
    │◄─── ClientHeartbeatResponse ─────────────│
+   │     - ServerTimestamp                     │
    │     - Commands (pending for this client)  │
-   │     - NewConfigHash (if config changed)   │
    │                                           │
 ```
 
-**Heartbeat interval:** 30 seconds (configurable, server can override)
+**Heartbeat interval:** 30 seconds (client default; the server can change it via
+`push_config`).
 
-**Config hash:** SHA-256 of client configuration, used to detect when server pushes new config.
+**`report_timestamp`** is accepted but ignored — the server uses its own clock for
+`LastHeartbeat` and `server_timestamp`.
+
+#### Config hash
+
+Used to avoid re-sending persistent configs on every heartbeat. Both sides must compute it
+identically or configs are re-pushed forever.
+
+```
+if no configs:            hash = ""
+else:                     sort configs by ID ascending
+                          h = sha256()
+                          for each: h.write(ID); h.write(Type); h.write(Payload)
+                          hash = hex(h.sum())[:16]      // first 16 hex chars
+```
+
+The server computes it over the configs **already filtered to this client's scope**, and
+sends persistent configs only when `request.ConfigHash != serverHash`. The response has no
+"new hash" field — the client recomputes it locally after processing commands.
+
+#### Command delivery and deduplication
+
+One-time commands are returned only when `command.CreateTime > request.LastCommandTimestamp`
+(strict). The client advances `LastCommandTimestamp` to the maximum `CreateTime` it has
+seen, **after** processing the whole batch, so a mid-batch crash re-fetches. Because the
+comparison is strict, clients must additionally deduplicate by command ID to handle two
+commands created in the same millisecond.
+
+Consequence: a one-time command is delivered **once**. It is not redelivered if the client
+fails to execute it, because the client has already advanced its watermark past it.
+
+#### Replies
+
+Any reply with a non-empty `command_id` — **whether or not `success` is true** — deletes the
+corresponding non-persistent command server-side. Replies are the garbage-collection
+mechanism; a client that never replies leaks commands with `ttl_seconds: 0`.
+
+The client queues replies and clears them **only after a successful heartbeat**, so replies
+survive a failed heartbeat and are retried on the next one. Commands already executed still
+receive an idempotent success ACK.
+
+Persistent configs are never deleted by a reply; they are removed only via
+`DeleteClientCommand`, and are suppressed on the wire whenever `config_hash` matches.
 
 ### Data Flow
 
 1. **Metrics Collection:**
-   - Each SDK operation (Search, Insert, Query, etc.) records metrics
-   - Sampling rate determines if operation is tracked (default: 100%)
-   - Metrics stored in per-operation collectors
+   - Each instrumented SDK operation records into a per-operation collector
+   - Sampling rate determines whether an operation is tracked (default 100%)
 
 2. **Heartbeat Cycle:**
-   - Background goroutine wakes every 30 seconds
-   - Creates atomic snapshot of all metrics (resets counters)
-   - Sends snapshot to RootCoord via ClientHeartbeat RPC
+   - Background goroutine sends immediately on start, then every `HeartbeatInterval`
+   - Creates an atomic snapshot of all metrics (resetting counters, computing P99)
+   - Sends the snapshot, pending replies, config hash and watermark
    - Receives and processes any pending commands
 
 3. **Command Processing:**
-   - Server pushes commands via heartbeat response
-   - Client executes command handler
-   - Reply sent in next heartbeat request
-   - Persistent commands re-sent until explicitly deleted
+   - Server returns commands in the heartbeat response
+   - Client dispatches to the registered handler for that type
+   - Reply is queued and sent with the next heartbeat
+   - Persistent configs are re-sent only when the client's `config_hash` disagrees
 
 ### WebUI Dashboard
 
-A new telemetry dashboard (`/webui/telemetry.html`) provides:
+A telemetry dashboard served at `/telemetry` (source: `internal/http/webui/telemetry.html`)
+provides:
 
 - **Client List:** Active/inactive clients with connection details
 - **Metrics View:** Per-client operation metrics with latency charts
@@ -306,20 +474,35 @@ A new telemetry dashboard (`/webui/telemetry.html`) provides:
 
 ## Compatibility, Deprecation, and Migration Plan
 
-- **Backward Compatible:** Telemetry is opt-in and disabled by default can be enabled
-- **No Breaking Changes:** Existing SDK usage remains unchanged
-- **Server Compatibility:** Old clients work with new servers (no heartbeats sent)
-- **Client Compatibility:** New clients work with old servers (heartbeats fail silently)
+- **Backward Compatible:** No wire or API breaking changes.
+- **No Breaking Changes:** Existing SDK usage remains unchanged.
+- **Server Compatibility:** Old clients simply never heartbeat; they appear only through
+  their `Connect` call, not in telemetry.
+- **Client Compatibility:** Against a server without `ClientTelemetryService`, the heartbeat
+  fails with `codes.Unimplemented`. Telemetry is best-effort and the failure is not
+  surfaced through the normal API surface.
+
+## Implementation Status
+
+Client-side telemetry is implemented in the **Go SDK only**. pymilvus, the Java, Node.js and
+Rust SDKs do not implement the client half; the generated protobuf stubs exist for some of
+them but are unused. Any operator-facing claim about client coverage should be read as
+"Go SDK clients only".
+
+Server-side components are complete. Two pieces of the original design are present but not
+wired into the live path: `CommandRouter` validates payload shapes but is never invoked from
+`HandleHeartbeat`, and `PushCommand` does not validate `command_type` against it.
 
 ## Test Plan
 
 ### Unit Tests
-- `telemetry_test.go`: Metrics collection, P99 calculation, ring buffer
-- `telemetry_http_handler_test.go`: HTTP API handlers
-- `command_router_test.go`: Command routing and handling
+- `client/milvusclient/telemetry_test.go`: metrics collection, P99, ring buffer,
+  command dispatch, config hash
+- `internal/proxy/telemetry_http_handler_test.go`: HTTP API handlers
+- `internal/rootcoord/telemetry/*_test.go`: manager, command store, scope matching
 
 ### Integration Tests
-- `telemetry_integration_test.go`: End-to-end heartbeat flow
+- `client/milvusclient/telemetry_integration_test.go`: end-to-end heartbeat flow
 - Multi-client scenarios with different configurations
 - Command push and execution verification
 
@@ -344,6 +527,8 @@ Server polls clients for metrics.
 
 ## References
 
-- Milvus existing telemetry: `internal/proxy/impl.go`
+- Server implementation: `internal/rootcoord/telemetry/`
+- Proxy HTTP layer: `internal/proxy/telemetry_http_handler.go`, `telemetry_models.go`
+- Go SDK client: `client/milvusclient/telemetry.go`
 - gRPC health checking: https://github.com/grpc/grpc/blob/master/doc/health-checking.md
 - OpenTelemetry SDK patterns: https://opentelemetry.io/docs/instrumentation/go/


### PR DESCRIPTION
The client telemetry MEP (`20260131-client_side_telemetry.md`) was written before the feature landed and never updated. Several sections describe interfaces that were never built. Anyone implementing the client half for another SDK from this document would produce something that does not interoperate with the server.

Found while auditing the Go SDK client implementation against `internal/rootcoord/telemetry`.

## Corrected

| Doc said | Reality |
|---|---|
| Commands `set_sampling_rate` / `enable_collections` / `update_config` | None exist. Real set: `push_config`, `collection_metrics`, `show_errors`, `show_latency_history`, `get_config` — and only `push_config` may be persistent |
| `TargetScope` = `"*"` / `"client_id:xxx"` / `"db:name"` | `global` / `client:<id>` / `database:<db>` |
| REST at `/api/v1/telemetry/*` | `/_telemetry/*` on the internal HTTP port; two endpoints were missing from the doc |
| RPCs on `service RootCoord` | Own `service ClientTelemetryService` |
| `ClientHeartbeatResponse.NewConfigHash` | No such field — the client recomputes the hash locally |
| "Persistent commands re-sent until explicitly deleted" | Suppressed whenever `config_hash` matches |
| "Telemetry disabled by default" | `DefaultTelemetryConfig()` has `Enabled: true` |
| `CommandHandler func(*ClientCommand) string` | Returns `*CommandReply` |
| clientID is "a stable UUID" | Stable per `Client`, **not** across process restarts |

Added the JSON payload schema for each of the five real command types, since `payload` is raw JSON and there was nothing to implement against.

## Added

Load-bearing details that were absent and that a port to another SDK cannot be written without:

- The exact `config_hash` algorithm. Client and server must agree **byte-for-byte** (sha256 over persistent configs sorted by ID, writing `ID + Type + Payload`, truncated to 16 hex chars, `""` for the empty set) or configs get re-pushed on every single heartbeat.
- The `last_command_timestamp` watermark, its strict `>` comparison, and the resulting exactly-once delivery — including that a failed command is never redelivered.
- Replies as the garbage-collection mechanism: any reply deletes the command *regardless of success*, and `ttl_seconds: 0` commands (which is what `/config` and `/history` push) leak forever if the client never replies.
- Persistent configs are JSON-**merged** on re-push to the same scope, not replaced.
- The hardcoded server limits, and explicitly that **there are no `milvus.yaml` / paramtable keys** for this feature.
- Metrics ingest truncation rules (drop `RequestCount == 0` collection entries, cap at 100 operations / 1 MB).
- The `legacy:<host>:<hash>` client-ID fallback and the fact that it collides same-host same-SDK processes into one entry, which breaks `client:` scoping.
- That `/config` and `/history` are fire-and-forget: they return a command ID, and the result must be read back from `GET /_telemetry/clients` by matching `command_id` in `command_replies`.

## Implementation status

Recorded two things the doc implied were universal:

- The client half is implemented in the **Go SDK only**. pymilvus, Java, Node.js and Rust do not implement it.
- `CommandRouter` validates payload shapes but is never invoked from `HandleHeartbeat`, and `PushCommand` does not validate `command_type` against it.

Status moved `Draft` → `Implemented`, and the header notes the refresh so the diff is not mistaken for a design change. No code changes.