### PR TITLE
enhance: add a command-reply endpoint and synchronous mode to the telemetry API

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -165,6 +165,8 @@ const (
 	TelemetryClientHistoryPath = "/_telemetry/clients/:clientId/history"
 	// TelemetryCommandsPath is the path to manage client commands.
 	TelemetryCommandsPath = "/_telemetry/commands"
+	// TelemetryCommandReplyPath is the path to fetch a client's reply to a pushed command.
+	TelemetryCommandReplyPath = "/_telemetry/commands/:commandId/reply"
 	// TelemetryUIPath is the path for telemetry management web UI.
 	TelemetryUIPath = "/telemetry"
 )

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -6509,6 +6509,7 @@ func (node *Proxy) RegisterRestRouter(router gin.IRouter) {
 	router.GET(http.TelemetryClientsPath+"/:clientId/config", telemetryAuth, getTelemetryClientConfig(node))
 	router.GET(http.TelemetryClientHistoryPath, telemetryAuth, getTelemetryClientHistory(node))
 	router.POST(http.TelemetryCommandsPath, telemetryAuth, postTelemetryCommand(node))
+	router.GET(http.TelemetryCommandReplyPath, telemetryAuth, getTelemetryCommandReply(node))
 	router.DELETE(http.TelemetryCommandsPath+"/:commandId", telemetryAuth, deleteTelemetryCommand(node))
 }
 

--- a/internal/proxy/telemetry_command_reply.go
+++ b/internal/proxy/telemetry_command_reply.go
@@ -1,0 +1,164 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+const (
+	// maxTelemetryWait bounds how long a synchronous telemetry request may block. A client
+	// answers on its next heartbeat, so anything beyond a couple of heartbeat intervals is
+	// almost certainly a client that is not going to answer at all.
+	maxTelemetryWait = 90 * time.Second
+
+	// telemetryReplyPollInterval is how often the proxy re-reads client state while waiting
+	// for a reply. Replies only ever land on a heartbeat, so polling faster buys nothing.
+	telemetryReplyPollInterval = 500 * time.Millisecond
+)
+
+// Reply lookup outcomes reported to API callers.
+const (
+	replyStatusDone    = "done"
+	replyStatusPending = "pending"
+)
+
+// parseWaitParam interprets the `wait` query parameter. It accepts a Go duration string
+// ("30s", "1m500ms") or a bare number of seconds ("30"). An empty value means "do not
+// wait". The result is clamped to [0, maxTelemetryWait]; a negative value is treated as 0.
+func parseWaitParam(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, nil
+	}
+
+	wait, err := time.ParseDuration(raw)
+	if err != nil {
+		seconds, convErr := strconv.ParseFloat(raw, 64)
+		if convErr != nil {
+			return 0, merr.WrapErrParameterInvalidMsg(
+				"invalid wait %q: expected a duration such as \"30s\" or a number of seconds", raw)
+		}
+		wait = time.Duration(seconds * float64(time.Second))
+	}
+
+	if wait < 0 {
+		return 0, nil
+	}
+	if wait > maxTelemetryWait {
+		wait = maxTelemetryWait
+	}
+	return wait, nil
+}
+
+// findCommandReply looks up a single command reply. clientID may be empty, in which case
+// every known client is scanned; passing it turns the lookup into a targeted one, which is
+// what callers who just pushed a command should do.
+//
+// It returns the reply and the ID of the client that produced it. A nil reply with a nil
+// error means the command has not been answered yet -- that is a normal state, not a
+// failure, because replies only arrive on the client's next heartbeat.
+func findCommandReply(ctx context.Context, node *Proxy, clientID, commandID string) (*CommandReply, string, error) {
+	// Metrics are not needed to read replies, and skipping them keeps this cheap enough to
+	// poll: command_replies is populated independently of IncludeMetrics.
+	resp, err := node.GetClientTelemetry(ctx, &milvuspb.GetClientTelemetryRequest{
+		ClientId:       clientID,
+		IncludeMetrics: false,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	if err := merr.Error(resp.GetStatus()); err != nil {
+		return nil, "", err
+	}
+
+	for _, client := range ConvertClientTelemetryResponse(resp).Clients {
+		for _, reply := range client.CommandReplies {
+			if reply.CommandID == commandID {
+				return reply, client.ClientID, nil
+			}
+		}
+	}
+
+	return nil, "", nil
+}
+
+// waitForCommandReply polls for a command reply until it appears, the timeout elapses, or
+// the request is canceled. A zero timeout performs exactly one lookup.
+//
+// A nil reply with a nil error means "still pending" and is a normal outcome.
+func waitForCommandReply(ctx context.Context, node *Proxy, clientID, commandID string, timeout time.Duration) (*CommandReply, string, error) {
+	reply, replyClientID, err := findCommandReply(ctx, node, clientID, commandID)
+	if err != nil || reply != nil || timeout <= 0 {
+		return reply, replyClientID, err
+	}
+
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(telemetryReplyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Caller hung up or the server is shutting down; report as still pending
+			// rather than as an error, the command itself is unaffected.
+			return nil, "", nil
+		case <-ticker.C:
+			reply, replyClientID, err = findCommandReply(ctx, node, clientID, commandID)
+			if err != nil || reply != nil {
+				return reply, replyClientID, err
+			}
+			if !time.Now().Before(deadline) {
+				return nil, "", nil
+			}
+		}
+	}
+}
+
+// commandReplyPayload renders a reply lookup as the JSON body shared by every endpoint
+// that can return one, so callers can parse a single shape regardless of which endpoint
+// produced it.
+//
+// `status` is always present: "done" when the client has answered, "pending" otherwise.
+// Callers should branch on it rather than on the presence of `reply`, and a "pending"
+// response is not an error -- retry, or ask again with a longer `wait`.
+func commandReplyPayload(commandID, clientID string, reply *CommandReply, waited time.Duration) map[string]interface{} {
+	body := map[string]interface{}{
+		"command_id": commandID,
+		"status":     replyStatusPending,
+	}
+	if clientID != "" {
+		body["client_id"] = clientID
+	}
+	if waited > 0 {
+		body["waited_ms"] = waited.Milliseconds()
+	}
+
+	if reply == nil {
+		body["message"] = "Command has not been answered yet. The client replies on its " +
+			"next heartbeat; retry, or pass ?wait= to block until it arrives."
+		return body
+	}
+
+	body["status"] = replyStatusDone
+	body["reply"] = reply
+	return body
+}

--- a/internal/proxy/telemetry_command_reply_test.go
+++ b/internal/proxy/telemetry_command_reply_test.go
@@ -1,0 +1,309 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// telemetryRespWithReply builds the shape the server actually returns: replies are JSON
+// encoded into ClientInfo.Reserved["command_replies"], not a dedicated proto field.
+func telemetryRespWithReply(clientID, commandID string, success bool, payload string) *milvuspb.GetClientTelemetryResponse {
+	replies := []map[string]interface{}{
+		{
+			"command_id":   commandID,
+			"command_type": "get_config",
+			"success":      success,
+			"payload":      payload,
+			"received_at":  int64(1700000000000),
+		},
+	}
+	encoded, _ := json.Marshal(replies)
+
+	return &milvuspb.GetClientTelemetryResponse{
+		Status: merr.Success(),
+		Clients: []*milvuspb.ClientTelemetry{
+			{
+				ClientInfo: &commonpb.ClientInfo{
+					SdkType: "Go",
+					Reserved: map[string]string{
+						"client_id":       clientID,
+						"command_replies": string(encoded),
+					},
+				},
+			},
+		},
+	}
+}
+
+func telemetryRespNoReply(clientID string) *milvuspb.GetClientTelemetryResponse {
+	return &milvuspb.GetClientTelemetryResponse{
+		Status: merr.Success(),
+		Clients: []*milvuspb.ClientTelemetry{
+			{
+				ClientInfo: &commonpb.ClientInfo{
+					SdkType:  "Go",
+					Reserved: map[string]string{"client_id": clientID},
+				},
+			},
+		},
+	}
+}
+
+func TestParseWaitParam(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected time.Duration
+		wantErr  bool
+	}{
+		{"empty means no wait", "", 0, false},
+		{"duration string", "30s", 30 * time.Second, false},
+		{"compound duration", "1m30s", 90 * time.Second, false},
+		{"bare seconds", "15", 15 * time.Second, false},
+		{"fractional seconds", "0.5", 500 * time.Millisecond, false},
+		{"negative clamps to zero", "-5s", 0, false},
+		{"over the cap is clamped", "10m", maxTelemetryWait, false},
+		{"garbage is rejected", "soon", 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseWaitParam(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestCommandReplyPayload(t *testing.T) {
+	t.Run("pending when there is no reply", func(t *testing.T) {
+		body := commandReplyPayload("cmd-1", "client-1", nil, 0)
+
+		assert.Equal(t, replyStatusPending, body["status"])
+		assert.Equal(t, "cmd-1", body["command_id"])
+		assert.Equal(t, "client-1", body["client_id"])
+		assert.NotContains(t, body, "reply")
+		assert.Contains(t, body, "message")
+	})
+
+	t.Run("done when a reply exists", func(t *testing.T) {
+		reply := &CommandReply{CommandID: "cmd-1", Success: true}
+		body := commandReplyPayload("cmd-1", "client-1", reply, 250*time.Millisecond)
+
+		assert.Equal(t, replyStatusDone, body["status"])
+		assert.Equal(t, reply, body["reply"])
+		assert.Equal(t, int64(250), body["waited_ms"])
+	})
+
+	t.Run("omits client id when unknown", func(t *testing.T) {
+		assert.NotContains(t, commandReplyPayload("cmd-1", "", nil, 0), "client_id")
+	})
+}
+
+func TestGetTelemetryCommandReplyHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newCtx := func(url string, commandID string) (*httptest.ResponseRecorder, *gin.Context) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest("GET", url, nil)
+		c.Params = gin.Params{{Key: "commandId", Value: commandID}}
+		return w, c
+	}
+
+	t.Run("nil node returns error", func(t *testing.T) {
+		w, c := newCtx("/", "cmd-1")
+		getTelemetryCommandReply(nil)(c)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("missing command id is rejected", func(t *testing.T) {
+		w, c := newCtx("/", "")
+		getTelemetryCommandReply(&Proxy{})(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("invalid wait is rejected", func(t *testing.T) {
+		w, c := newCtx("/?wait=whenever", "cmd-1")
+		getTelemetryCommandReply(&Proxy{})(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns the reply when the client has answered", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespWithReply("client-1", "cmd-1", true, `{"telemetry_enabled":true}`), nil)
+
+		w, c := newCtx("/?client_id=client-1", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusDone, body["status"])
+		assert.Equal(t, "client-1", body["client_id"])
+
+		reply := body["reply"].(map[string]interface{})
+		assert.Equal(t, "cmd-1", reply["command_id"])
+		assert.Equal(t, true, reply["success"])
+		assert.Equal(t, `{"telemetry_enabled":true}`, reply["payload"])
+	})
+
+	t.Run("pending is a 200, not an error", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespNoReply("client-1"), nil)
+
+		w, c := newCtx("/?client_id=client-1", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusPending, body["status"])
+		assert.NotContains(t, body, "reply")
+	})
+
+	t.Run("a reply for a different command is not matched", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespWithReply("client-1", "some-other-command", true, "{}"), nil)
+
+		w, c := newCtx("/", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusPending, body["status"])
+	})
+
+	t.Run("client_id turns the lookup into a targeted one", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		// Metrics must not be requested: replies are populated regardless, and pulling
+		// metrics would make polling far more expensive than it needs to be.
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.MatchedBy(
+			func(req *milvuspb.GetClientTelemetryRequest) bool {
+				return req.ClientId == "client-9" && !req.IncludeMetrics
+			})).Return(telemetryRespWithReply("client-9", "cmd-1", true, "{}"), nil)
+
+		w, c := newCtx("/?client_id=client-9", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("wait polls until the reply lands", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		// First look finds nothing; the client answers before the second.
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespNoReply("client-1"), nil).Once()
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespWithReply("client-1", "cmd-1", true, "{}"), nil).Once()
+
+		w, c := newCtx("/?client_id=client-1&wait=5s", "cmd-1")
+
+		start := time.Now()
+		getTelemetryCommandReply(proxy)(c)
+		elapsed := time.Since(start)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusDone, body["status"], "should have picked up the reply on the second poll")
+		assert.GreaterOrEqual(t, elapsed, telemetryReplyPollInterval, "must have actually waited a poll cycle")
+		assert.Less(t, elapsed, 5*time.Second, "must return as soon as the reply lands, not burn the full budget")
+	})
+
+	t.Run("wait gives up and reports pending", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespNoReply("client-1"), nil)
+
+		w, c := newCtx("/?client_id=client-1&wait=600ms", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusPending, body["status"], "timing out must not be reported as an error")
+	})
+}
+
+func TestWaitForCommandReplyRespectsCancellation(t *testing.T) {
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	proxy := &Proxy{mixCoord: mixCoord}
+	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+		Return(telemetryRespNoReply("client-1"), nil)
+
+	// A caller that hangs up mid-wait must unblock promptly, well before the budget.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	reply, _, err := waitForCommandReply(ctx, proxy, "client-1", "cmd-1", 30*time.Second)
+
+	assert.NoError(t, err, "cancellation is not a lookup failure")
+	assert.Nil(t, reply)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}

--- a/internal/proxy/telemetry_http_handler.go
+++ b/internal/proxy/telemetry_http_handler.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -149,6 +150,103 @@ func getTelemetryClients(node *Proxy) gin.HandlerFunc {
 		// Convert to API response format
 		wrapped := ConvertClientTelemetryResponse(resp)
 		c.JSON(http.StatusOK, wrapped)
+	}
+}
+
+// respondToPushedCommand finishes an endpoint that just pushed a command to one client.
+//
+// With wait <= 0 it returns the command ID straight away and the caller collects the reply
+// later from the command-reply endpoint. With wait > 0 it blocks until the client answers
+// or the budget runs out, so a caller gets the result from a single request.
+//
+// Either way the body has the same shape, so callers do not need to special-case the two
+// modes: check "status", and read "reply" when it is "done".
+func respondToPushedCommand(c *gin.Context, node *Proxy, clientID, commandID string, wait time.Duration) {
+	if wait <= 0 {
+		c.JSON(http.StatusOK, commandReplyPayload(commandID, clientID, nil, 0))
+		return
+	}
+
+	start := time.Now()
+	reply, replyClientID, err := waitForCommandReply(c.Request.Context(), node, clientID, commandID, wait)
+	if err != nil {
+		mlog.Warn(c.Request.Context(), "respondToPushedCommand: failed to wait for reply",
+			mlog.Err(err),
+			mlog.String("command_id", commandID),
+			mlog.String("client_id", clientID))
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	if replyClientID == "" {
+		replyClientID = clientID
+	}
+	c.JSON(http.StatusOK, commandReplyPayload(commandID, replyClientID, reply, time.Since(start)))
+}
+
+// getTelemetryCommandReply returns a client's reply to a previously pushed command.
+//
+// Commands are answered asynchronously, on the client's next heartbeat, so a caller that
+// pushed a command needs a way to collect the result. Without this endpoint the only way
+// was to list every client and scan the command_replies array by hand.
+//
+// URL param: commandId
+// Query params:
+//   - client_id: the client the command was sent to. Optional, but supplying it turns a
+//     scan of all clients into a targeted lookup.
+//   - wait: block up to this long for the reply (e.g. "30s"). Default is to return
+//     immediately with whatever is known.
+//
+// Always 200 on a successful lookup; branch on the "status" field ("done" or "pending").
+// "pending" is a normal state, not an error: the reply may still be in flight, and replies
+// are also evicted once a client accumulates more than 50 of them.
+func getTelemetryCommandReply(node *Proxy) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		if node == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "proxy node not initialized",
+			})
+			return
+		}
+
+		commandID := c.Param("commandId")
+		if commandID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "commandId parameter is required",
+			})
+			return
+		}
+
+		wait, err := parseWaitParam(c.Query("wait"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		clientID := c.Query("client_id")
+
+		start := time.Now()
+		reply, replyClientID, err := waitForCommandReply(ctx, node, clientID, commandID, wait)
+		if err != nil {
+			mlog.Warn(ctx, "getTelemetryCommandReply: failed to look up reply",
+				mlog.Err(err),
+				mlog.String("command_id", commandID))
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		if replyClientID == "" {
+			replyClientID = clientID
+		}
+		c.JSON(http.StatusOK, commandReplyPayload(commandID, replyClientID, reply, time.Since(start)))
 	}
 }
 
@@ -395,6 +493,14 @@ func getTelemetryClientHistory(node *Proxy) gin.HandlerFunc {
 			return
 		}
 
+		wait, err := parseWaitParam(c.Query("wait"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
 		// Build the payload for show_latency_history command
 		payload := map[string]interface{}{
 			"start_time": startTime,
@@ -436,13 +542,7 @@ func getTelemetryClientHistory(node *Proxy) gin.HandlerFunc {
 			return
 		}
 
-		// Return the command ID - client will need to poll for results
-		// via the command reply in the next heartbeat
-		c.JSON(http.StatusOK, gin.H{
-			"command_id": resp.CommandId,
-			"status":     "pending",
-			"message":    "Command sent to client. Results will be available in the client's next heartbeat response.",
-		})
+		respondToPushedCommand(c, node, clientID, resp.CommandId, wait)
 	}
 }
 
@@ -464,6 +564,14 @@ func getTelemetryClientConfig(node *Proxy) gin.HandlerFunc {
 		if clientID == "" {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": "client_id parameter is required",
+			})
+			return
+		}
+
+		wait, err := parseWaitParam(c.Query("wait"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": err.Error(),
 			})
 			return
 		}
@@ -494,11 +602,6 @@ func getTelemetryClientConfig(node *Proxy) gin.HandlerFunc {
 			return
 		}
 
-		// Return the command ID - client will respond with config in next heartbeat
-		c.JSON(http.StatusOK, gin.H{
-			"command_id": resp.CommandId,
-			"status":     "pending",
-			"message":    "Command sent to client. Config will be available in the client's command reply.",
-		})
+		respondToPushedCommand(c, node, clientID, resp.CommandId, wait)
 	}
 }


### PR DESCRIPTION
issue: #47281

## Problem

Telemetry commands are answered **asynchronously**, on the client's next heartbeat. `GET /_telemetry/clients/{id}/config` and `.../history` push a command and return:

```json
{"command_id": "...", "status": "pending", "message": "Command sent to client..."}
```

The reply then lands in a `StoredCommandReply` that **no endpoint exposes**. The only way to read it was to list every client and scan the `command_replies` array by hand, matching on command ID — and that array is smuggled through `ClientInfo.Reserved["command_replies"]` as a JSON string. `TelemetryManager.GetClientCommandReplies()` exists but has no production caller.

Net effect: the pull-from-client half of the API is impractical to consume from anything except the WebUI, which carries its own bespoke polling. Every other consumer — a script, a CLI, an agent — has to reimplement push → poll-all-clients → match → time out.

## Changes

**New:** `GET /_telemetry/commands/{commandId}/reply`

| Query param | Effect |
|---|---|
| `client_id` | Turns a scan of all clients into a targeted lookup |
| `wait` | Block until the reply arrives (e.g. `30s`, or a bare number of seconds) |

**Also:** the same `?wait=` on `/config` and `/history`, so a caller can push and collect in one request.

```bash
# one-shot
curl -u root:pw "$M/_telemetry/clients/$CID/config?wait=35s"
{"command_id":"...","client_id":"...","status":"done","waited_ms":2140,"reply":{...}}

# or push now, collect later
curl -u root:pw "$M/_telemetry/clients/$CID/config"
{"command_id":"abc","status":"pending",...}
curl -u root:pw "$M/_telemetry/commands/abc/reply?client_id=$CID&wait=30s"
```

## Design notes

**One response shape everywhere.** Sync and async return the same body, so callers do not special-case the two modes: check `status` (`"done"` / `"pending"`), read `reply` when done.

**Pending is 200, not 404 or an error.** A missing reply means "not answered *yet*" — and a client that will never answer is indistinguishable from one that is merely slow (replies are also evicted past 50 per client). Making that an error would force every caller to treat a normal state as an exception. Timing out likewise reports `"pending"`, with `waited_ms`.

**Bounded.** `wait` is clamped to 90s (a couple of heartbeat intervals; beyond that the client is not answering) and is additionally bounded by the request context, so a caller hanging up releases the handler promptly.

**Cheap to poll.** Reply lookups pass `IncludeMetrics=false`. Replies are populated independently of that flag, so polling does not drag every client's metrics along with it. Poll interval is 500ms — replies only ever land on a heartbeat, so faster buys nothing.

## Compatibility

Behaviour without `?wait=` is unchanged: `command_id` and `status: "pending"` are still returned, which is exactly what the WebUI branches on (`telemetry.html`: `if (data.status === 'pending')` → `pollForConfigReply(data.command_id, ...)`). The `message` string is reworded and `client_id` is added; nothing consumes either. The WebUI's own polling could later be replaced by the new endpoint, but this PR leaves it alone to keep the diff focused.

No proto changes — the endpoint is built on the existing `GetClientTelemetry` RPC.

## Tests

`internal/proxy/telemetry_command_reply_test.go`:

- `parseWaitParam`: duration strings, bare/fractional seconds, empty, negative, over-cap clamping, garbage rejection
- Reply found / not found / reply for a *different* command not matched
- `client_id` produces a targeted request **with `IncludeMetrics=false`** (asserted via `MatchedBy`)
- `wait` polls until the reply lands — mock returns pending then done; asserts it waited at least one poll interval and returned well before the budget
- `wait` expiring reports `pending`, not an error
- Context cancellation unblocks promptly and is not reported as a lookup failure

## Verification

`go test -tags dynamic,test` green for the new tests and the existing `Telemetry` suite in `internal/proxy`; `golangci-lint` 0 issues; `gofmt` clean.

Verification is unit-level — **not exercised against a live cluster**. The end-to-end timing (reply actually arriving within one heartbeat) is reasoned from the heartbeat protocol, not observed.