### PR TITLE
feat: target telemetry config at a workload label

### DIFF
--- a/client/milvusclient/interceptors.go
+++ b/client/milvusclient/interceptors.go
@@ -18,6 +18,8 @@ package milvusclient
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"strconv"
 	"time"
 
@@ -40,7 +42,86 @@ const (
 
 	// ClientRequestMsecKey temp const value, TODO use common package def after upgrading milvus/pkg version
 	ClientRequestMsecKey string = "client-request-unixmsec"
+
+	// ClientRequestIDKey carries a caller-supplied ID used to correlate a request with the
+	// server-side logs it produces. The server parses it as an OpenTelemetry TraceID and
+	// adopts it as the trace ID for the request, but only when no W3C `traceparent` was
+	// propagated. See pkg/tracer/client_request_id_propagator.go.
+	//
+	// The value MUST be a 32-character lowercase hex string (a 16-byte OTel TraceID);
+	// anything else is ignored by the server.
+	ClientRequestIDKey string = "client_request_id"
+
+	// traceIDHexLen is the encoded length of a 16-byte OpenTelemetry TraceID.
+	traceIDHexLen = 32
 )
+
+// clientRequestIDKeyType is the context key used to carry a caller-supplied request ID.
+type clientRequestIDKeyType struct{}
+
+// WithClientRequestID returns a context that makes the SDK send `id` as the
+// client_request_id header on every request issued with it. The server adopts `id` as the
+// trace ID for those requests, so it shows up in Milvus server logs and can be used to
+// find everything a specific client call did -- the same mechanism pymilvus exposes via
+// CallContext(client_request_id=...).
+//
+// `id` must be a 32-character lowercase hex OpenTelemetry TraceID (as produced by
+// trace.TraceID.String()); NewClientRequestID generates a conforming one. An invalid value
+// is dropped rather than sent, because the server would silently ignore it anyway.
+//
+// This is opt-in by design. The header is NOT sent by default because of how the server
+// consumes it: pkg/tracer/client_request_id_propagator.go builds a remote span context
+// with no sampled flag, and the server's ParentBased sampler maps an unsampled remote
+// parent to NeverSample. So a request carrying client_request_id is excluded from trace
+// sampling regardless of trace.sampleFraction. Use this for log correlation; it is not a
+// substitute for W3C traceparent propagation.
+func WithClientRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, clientRequestIDKeyType{}, id)
+}
+
+// NewClientRequestID returns a random, well-formed ID suitable for WithClientRequestID.
+// It returns "" if the system entropy source fails.
+func NewClientRequestID() string {
+	return newClientRequestID()
+}
+
+// isValidTraceIDHex reports whether s is a well-formed, non-zero 32-char hex TraceID.
+// It mirrors trace.TraceIDFromHex on the server so an invalid value is never put on the
+// wire, where it would be silently dropped anyway.
+func isValidTraceIDHex(s string) bool {
+	if len(s) != traceIDHexLen {
+		return false
+	}
+	nonZero := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch >= '0' && ch <= '9':
+		case ch >= 'a' && ch <= 'f':
+		default:
+			return false
+		}
+		if ch != '0' {
+			nonZero = true
+		}
+	}
+	return nonZero
+}
+
+// newClientRequestID returns a random 32-char hex TraceID, or "" if the system entropy
+// source fails (in which case the header is simply omitted).
+func newClientRequestID() string {
+	var buf [traceIDHexLen / 2]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return ""
+	}
+	id := hex.EncodeToString(buf[:])
+	if !isValidTraceIDHex(id) {
+		// All-zero read: not a valid TraceID for the server.
+		return ""
+	}
+	return id
+}
 
 func (c *Client) MetadataUnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
@@ -75,7 +156,21 @@ func (c *Client) state(ctx context.Context) context.Context {
 
 func (c *Client) extraInfo(ctx context.Context) context.Context {
 	ctx = metadata.AppendToOutgoingContext(ctx, ClientRequestMsecKey, strconv.FormatInt(time.Now().UnixMilli(), 10))
+	if requestID := clientRequestIDFromContext(ctx); requestID != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, ClientRequestIDKey, requestID)
+	}
 	return ctx
+}
+
+// clientRequestIDFromContext returns the caller-supplied request ID, or "" when none was
+// set or it is malformed. Nothing is generated here: sending an ID the caller did not ask
+// for would opt every request out of server-side trace sampling (see WithClientRequestID).
+func clientRequestIDFromContext(ctx context.Context) string {
+	id, ok := ctx.Value(clientRequestIDKeyType{}).(string)
+	if !ok || !isValidTraceIDHex(id) {
+		return ""
+	}
+	return id
 }
 
 // ref: https://github.com/grpc-ecosystem/go-grpc-middleware

--- a/client/milvusclient/interceptors.go
+++ b/client/milvusclient/interceptors.go
@@ -69,12 +69,16 @@ type clientRequestIDKeyType struct{}
 // trace.TraceID.String()); NewClientRequestID generates a conforming one. An invalid value
 // is dropped rather than sent, because the server would silently ignore it anyway.
 //
-// This is opt-in by design. The header is NOT sent by default because of how the server
-// consumes it: pkg/tracer/client_request_id_propagator.go builds a remote span context
-// with no sampled flag, and the server's ParentBased sampler maps an unsampled remote
-// parent to NeverSample. So a request carrying client_request_id is excluded from trace
-// sampling regardless of trace.sampleFraction. Use this for log correlation; it is not a
-// substitute for W3C traceparent propagation.
+// This is opt-in by design, because the SDK cannot assume what the server does with the
+// header. Servers that predate the clientRequestIDSampler fix turn it into an unsampled
+// remote parent, which their ParentBased sampler maps to NeverSample -- so on those, a
+// request carrying this header is excluded from tracing entirely, whatever
+// trace.sampleFraction says. Fixed servers sample it as a root span, so the ratio applies
+// normally. Sending it unconditionally would therefore silently disable tracing against
+// any older cluster.
+//
+// Either way this is for log correlation, not a substitute for W3C traceparent
+// propagation: it carries no sampling decision and no parent span.
 func WithClientRequestID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, clientRequestIDKeyType{}, id)
 }

--- a/client/milvusclient/interceptors_test.go
+++ b/client/milvusclient/interceptors_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 )
@@ -65,4 +66,93 @@ func TestRateLimitInterceptor(t *testing.T) {
 	err = inter(ctx1, "", nil, mockInvokerReply, nil, mockInvoker)
 	assert.NoError(t, err)
 	assert.Equal(t, uint(1), uint(mockInvokeTimes))
+}
+
+func TestIsValidTraceIDHex(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"valid", "4bf92f3577b34da6a3ce929d0e0e4736", true},
+		{"all zero", "00000000000000000000000000000000", false},
+		{"too short", "4bf92f3577b34da6a3ce929d0e0e473", false},
+		{"too long", "4bf92f3577b34da6a3ce929d0e0e47366", false},
+		{"empty", "", false},
+		{"uppercase rejected", "4BF92F3577B34DA6A3CE929D0E0E4736", false},
+		{"non hex", "4bf92f3577b34da6a3ce929d0e0e473g", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isValidTraceIDHex(tc.input))
+		})
+	}
+}
+
+func TestNewClientRequestID(t *testing.T) {
+	id := newClientRequestID()
+	assert.Len(t, id, traceIDHexLen)
+	assert.True(t, isValidTraceIDHex(id), "generated id must be parseable by the server")
+
+	// IDs must differ per call, otherwise every request collapses onto one trace.
+	assert.NotEqual(t, id, newClientRequestID())
+}
+
+func TestClientRequestIDFromContext(t *testing.T) {
+	t.Run("caller supplied id wins", func(t *testing.T) {
+		want := "4bf92f3577b34da6a3ce929d0e0e4736"
+		ctx := WithClientRequestID(context.Background(), want)
+		assert.Equal(t, want, clientRequestIDFromContext(ctx))
+	})
+
+	t.Run("malformed id is dropped", func(t *testing.T) {
+		ctx := WithClientRequestID(context.Background(), "not-a-trace-id")
+		assert.Empty(t, clientRequestIDFromContext(ctx))
+	})
+
+	t.Run("no id yields empty", func(t *testing.T) {
+		assert.Empty(t, clientRequestIDFromContext(context.Background()))
+	})
+}
+
+func TestExtraInfoInjectsClientRequestID(t *testing.T) {
+	c := &Client{}
+
+	// The header is opt-in: sending it unrequested would opt the request out of
+	// server-side trace sampling, since the server maps it to an unsampled remote parent.
+	t.Run("absent unless requested", func(t *testing.T) {
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(context.Background()))
+		assert.True(t, ok)
+
+		assert.Empty(t, md.Get(ClientRequestIDKey))
+		// The timestamp header is unconditional and must still be present.
+		assert.Len(t, md.Get(ClientRequestMsecKey), 1)
+	})
+
+	t.Run("propagates caller supplied id", func(t *testing.T) {
+		want := "4bf92f3577b34da6a3ce929d0e0e4736"
+		ctx := WithClientRequestID(context.Background(), want)
+
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(ctx))
+		assert.True(t, ok)
+		assert.Equal(t, []string{want}, md.Get(ClientRequestIDKey))
+	})
+
+	t.Run("malformed id is not sent", func(t *testing.T) {
+		ctx := WithClientRequestID(context.Background(), "bogus")
+
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(ctx))
+		assert.True(t, ok)
+		assert.Empty(t, md.Get(ClientRequestIDKey))
+	})
+
+	t.Run("NewClientRequestID round trips", func(t *testing.T) {
+		id := NewClientRequestID()
+		ctx := WithClientRequestID(context.Background(), id)
+
+		md, ok := metadata.FromOutgoingContext(c.extraInfo(ctx))
+		assert.True(t, ok)
+		assert.Equal(t, []string{id}, md.Get(ClientRequestIDKey))
+	})
 }

--- a/client/milvusclient/telemetry.go
+++ b/client/milvusclient/telemetry.go
@@ -28,6 +28,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -47,6 +50,14 @@ type TelemetryConfig struct {
 	SamplingRate float64
 	// ErrorMaxCount is the maximum number of errors to keep
 	ErrorMaxCount int
+	// ClientID identifies this client to the server across process restarts.
+	//
+	// When empty, a random UUID is generated per Client, which means the server sees a
+	// brand-new client on every restart: telemetry history fragments and `client:<id>`
+	// scoped commands cannot target a long-lived client. Set it to a stable value (e.g.
+	// a pod name, or hostname+role) to get continuity. It must be unique per process --
+	// reusing one value across processes collapses them into a single server-side entry.
+	ClientID string
 }
 
 // DefaultTelemetryConfig returns the default telemetry configuration
@@ -431,7 +442,9 @@ type ClientTelemetryManager struct {
 	configMu sync.RWMutex // Protects config access
 	client   *Client
 
-	// Unique client ID (UUID), generated once at startup, stable across reconnections
+	// Unique client ID, resolved once at construction. Stable for the lifetime of this
+	// Client (and therefore across gRPC reconnects). It only survives a process restart
+	// when the caller pins it via TelemetryConfig.ClientID; otherwise it is a fresh UUID.
 	clientID string
 
 	// Metrics collectors per operation
@@ -476,6 +489,17 @@ type ClientTelemetryManager struct {
 	// Startup state - indicates if telemetry manager has started
 	ready atomic.Bool
 
+	// unsupported is set when the server does not implement ClientTelemetryService
+	// (returns codes.Unimplemented). Once set, the heartbeat loop exits permanently
+	// instead of retrying a call that can never succeed.
+	unsupported atomic.Bool
+
+	// lastHeartbeatErr records the most recent heartbeat failure. The client module has
+	// no logger, so this is the only way to surface an otherwise silent best-effort
+	// failure; read it with LastHeartbeatError().
+	lastHeartbeatErr   error
+	lastHeartbeatErrMu sync.RWMutex
+
 	// Deterministic sampling counter
 	samplingCounter uint64
 }
@@ -496,10 +520,17 @@ func NewClientTelemetryManager(client *Client, config *TelemetryConfig) *ClientT
 		config = DefaultTelemetryConfig()
 	}
 
+	// Prefer a caller-supplied stable ID so the server can correlate this client across
+	// process restarts; fall back to a per-process UUID.
+	clientID := config.ClientID
+	if clientID == "" {
+		clientID = uuid.New().String()
+	}
+
 	tm := &ClientTelemetryManager{
 		config:             config,
 		client:             client,
-		clientID:           uuid.New().String(),
+		clientID:           clientID,
 		collectors:         make(map[string]*OperationMetricsCollector),
 		commandHandlers:    make(map[string]CommandHandler),
 		executedCommands:   make(map[string]int64),
@@ -581,6 +612,12 @@ func (m *ClientTelemetryManager) heartbeatLoop() {
 	// Use time.After instead of ticker to dynamically adapt to interval changes
 	// This allows server-pushed config to take effect immediately
 	for {
+		// A server without ClientTelemetryService will never accept a heartbeat; stop
+		// rather than burn an RPC every interval for the lifetime of the client.
+		if m.unsupported.Load() {
+			return
+		}
+
 		interval := m.getHeartbeatInterval()
 		select {
 		case <-m.stopCh:
@@ -590,6 +627,28 @@ func (m *ClientTelemetryManager) heartbeatLoop() {
 			m.sendHeartbeat()
 		}
 	}
+}
+
+// IsSupported reports whether the connected server implements ClientTelemetryService.
+// It returns false once a heartbeat has been rejected with codes.Unimplemented, at which
+// point telemetry is permanently disabled for this client.
+func (m *ClientTelemetryManager) IsSupported() bool {
+	return !m.unsupported.Load()
+}
+
+// LastHeartbeatError returns the most recent heartbeat failure, or nil if the last
+// heartbeat succeeded. Heartbeats are best-effort and never surfaced through the normal
+// API, so this is the supported way to diagnose a client that is not reporting.
+func (m *ClientTelemetryManager) LastHeartbeatError() error {
+	m.lastHeartbeatErrMu.RLock()
+	defer m.lastHeartbeatErrMu.RUnlock()
+	return m.lastHeartbeatErr
+}
+
+func (m *ClientTelemetryManager) setLastHeartbeatError(err error) {
+	m.lastHeartbeatErrMu.Lock()
+	defer m.lastHeartbeatErrMu.Unlock()
+	m.lastHeartbeatErr = err
 }
 
 // sendHeartbeat sends a heartbeat to the server
@@ -602,45 +661,18 @@ func (m *ClientTelemetryManager) sendHeartbeat() {
 		return
 	}
 
-	if m.client == nil || m.client.service == nil {
+	if m.unsupported.Load() {
+		return
+	}
+
+	if m.client == nil || m.client.telemetryService == nil {
 		return
 	}
 
 	// Get metrics from the latest snapshot (P99 already calculated during snapshot creation)
 	var metrics []*commonpb.OperationMetrics
-	latestSnapshot := m.GetLatestSnapshot()
-	if latestSnapshot != nil {
-		enabledCollections, allEnabled := m.snapshotEnabledCollections()
-
-		// Convert snapshot metrics to proto format
-		for _, opMetrics := range latestSnapshot.Metrics {
-			protoCollMetrics := make(map[string]*commonpb.Metrics)
-			// Only include metrics for enabled collections
-			// Use "*" wildcard to enable all collections
-			for coll, cm := range opMetrics.CollectionMetrics {
-				if allEnabled || enabledCollections[coll] {
-					protoCollMetrics[coll] = &commonpb.Metrics{
-						RequestCount: cm.RequestCount,
-						SuccessCount: cm.SuccessCount,
-						ErrorCount:   cm.ErrorCount,
-						AvgLatencyMs: cm.AvgLatencyMs,
-						P99LatencyMs: cm.P99LatencyMs,
-					}
-				}
-			}
-
-			metrics = append(metrics, &commonpb.OperationMetrics{
-				Operation: opMetrics.Operation,
-				Global: &commonpb.Metrics{
-					RequestCount: opMetrics.Global.RequestCount,
-					SuccessCount: opMetrics.Global.SuccessCount,
-					ErrorCount:   opMetrics.Global.ErrorCount,
-					AvgLatencyMs: opMetrics.Global.AvgLatencyMs,
-					P99LatencyMs: opMetrics.Global.P99LatencyMs, // Use P99 from snapshot
-				},
-				CollectionMetrics: protoCollMetrics,
-			})
-		}
+	if latestSnapshot := m.GetLatestSnapshot(); latestSnapshot != nil {
+		metrics = m.toProtoOperationMetrics(latestSnapshot.Metrics)
 	}
 
 	// Get pending command replies (snapshot only)
@@ -662,19 +694,28 @@ func (m *ClientTelemetryManager) sendHeartbeat() {
 		LastCommandTimestamp: m.lastCommandTimestamp.Load(),
 	}
 
-	// Send heartbeat with 30s fixed interval (no retry - telemetry is best effort)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	resp, err := m.client.telemetryService.ClientHeartbeat(ctx, req)
+	// Telemetry is best-effort: opt out of the client-wide retry interceptor so a failing
+	// heartbeat costs exactly one RPC instead of up to 6 with backoff. The next heartbeat
+	// is the retry.
+	resp, err := m.client.telemetryService.ClientHeartbeat(ctx, req, grpc_retry.Disable())
 	if err != nil {
-		// Log error but continue - telemetry is best-effort
+		m.setLastHeartbeatError(err)
+		// A server that predates ClientTelemetryService will fail this way forever.
+		// Latch it off so the heartbeat loop can exit instead of retrying every interval.
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			m.unsupported.Store(true)
+		}
 		return
 	}
 
-	if !merr.Ok(resp.GetStatus()) {
+	if err := merr.Error(resp.GetStatus()); err != nil {
+		m.setLastHeartbeatError(err)
 		return
 	}
+	m.setLastHeartbeatError(nil)
 
 	// Clear sent replies only after successful heartbeat
 	m.clearPendingProtoReplies(len(replies))
@@ -735,51 +776,48 @@ func (m *ClientTelemetryManager) shouldSample(samplingRate float64) bool {
 	return counter%samplingDenominator < threshold
 }
 
-// collectProtoMetrics collects all operation metrics and converts to proto format
-func (m *ClientTelemetryManager) collectProtoMetrics() []*commonpb.OperationMetrics {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+// toProtoOperationMetrics converts collected metrics into their proto form, dropping
+// collection-level entries for collections that are not currently enabled ("*" enables
+// all). This is the single conversion path used for everything put on the wire.
+func (m *ClientTelemetryManager) toProtoOperationMetrics(opMetricsList []*OperationMetrics) []*commonpb.OperationMetrics {
+	if len(opMetricsList) == 0 {
+		return nil
+	}
 
 	enabledCollections, allEnabled := m.snapshotEnabledCollections()
 
-	var result []*commonpb.OperationMetrics
-	for opName, collector := range m.collectors {
-		globalMetrics := collector.GetMetrics()
-		if globalMetrics == nil {
-			continue
-		}
-
-		collMetrics := collector.GetCollectionMetrics()
-
+	result := make([]*commonpb.OperationMetrics, 0, len(opMetricsList))
+	for _, opMetrics := range opMetricsList {
 		protoCollMetrics := make(map[string]*commonpb.Metrics)
-		// Only include metrics for enabled collections
-		// Use "*" wildcard to enable all collections
-		for coll, cm := range collMetrics {
+		for coll, cm := range opMetrics.CollectionMetrics {
 			if allEnabled || enabledCollections[coll] {
-				protoCollMetrics[coll] = &commonpb.Metrics{
-					RequestCount: cm.RequestCount,
-					SuccessCount: cm.SuccessCount,
-					ErrorCount:   cm.ErrorCount,
-					AvgLatencyMs: cm.AvgLatencyMs,
-					P99LatencyMs: cm.P99LatencyMs,
-				}
+				protoCollMetrics[coll] = toProtoMetrics(cm)
 			}
 		}
 
 		result = append(result, &commonpb.OperationMetrics{
-			Operation: opName,
-			Global: &commonpb.Metrics{
-				RequestCount: globalMetrics.RequestCount,
-				SuccessCount: globalMetrics.SuccessCount,
-				ErrorCount:   globalMetrics.ErrorCount,
-				AvgLatencyMs: globalMetrics.AvgLatencyMs,
-				P99LatencyMs: globalMetrics.P99LatencyMs,
-			},
+			Operation:         opMetrics.Operation,
+			Global:            toProtoMetrics(opMetrics.Global),
 			CollectionMetrics: protoCollMetrics,
 		})
 	}
 
 	return result
+}
+
+// toProtoMetrics converts a single metrics bucket to proto form.
+func toProtoMetrics(metrics *Metrics) *commonpb.Metrics {
+	if metrics == nil {
+		return nil
+	}
+	return &commonpb.Metrics{
+		RequestCount: metrics.RequestCount,
+		SuccessCount: metrics.SuccessCount,
+		ErrorCount:   metrics.ErrorCount,
+		AvgLatencyMs: metrics.AvgLatencyMs,
+		P99LatencyMs: metrics.P99LatencyMs,
+		MaxLatencyMs: metrics.MaxLatencyMs,
+	}
 }
 
 // getPendingProtoRepliesSnapshot returns a snapshot of pending replies without clearing.
@@ -981,100 +1019,6 @@ func (m *ClientTelemetryManager) collectMetrics() []*OperationMetrics {
 	return result
 }
 
-// getPendingReplies gets and clears pending command replies (local types, for testing)
-func (m *ClientTelemetryManager) getPendingReplies() []*CommandReply {
-	m.pendingRepliesMu.Lock()
-	defer m.pendingRepliesMu.Unlock()
-
-	var result []*CommandReply
-	for _, r := range m.pendingReplies {
-		result = append(result, &CommandReply{
-			CommandId:    r.GetCommandId(),
-			Success:      r.GetSuccess(),
-			ErrorMessage: r.GetErrorMessage(),
-			Payload:      r.GetPayload(),
-		})
-	}
-	m.pendingReplies = nil
-	return result
-}
-
-// processCommands processes commands (local types, for testing)
-// Commands are only executed once using timestamp-based deduplication:
-// - Commands with CreateTime < lastCommandTimestamp are filtered by timestamp (already processed)
-// - Commands with CreateTime >= lastCommandTimestamp use ID-based tracking for same-millisecond deduplication
-func (m *ClientTelemetryManager) processCommands(commands []*ClientCommand) {
-	hasPersistent := false
-	lastTS := m.lastCommandTimestamp.Load()
-	maxCommandTS := lastTS
-
-	// First, process all commands
-	for _, cmd := range commands {
-		if cmd.Persistent {
-			hasPersistent = true
-		}
-		if cmd.CreateTime > maxCommandTS {
-			maxCommandTS = cmd.CreateTime
-		}
-
-		// Timestamp-based deduplication: commands older than lastTS are already processed
-		if cmd.CreateTime < lastTS {
-			// Already processed in a previous cycle - skip
-			continue
-		}
-
-		// For commands at or after lastTS, check map for same-millisecond duplicates
-		m.executedCommandsMu.RLock()
-		_, alreadyExecuted := m.executedCommands[cmd.CommandId]
-		m.executedCommandsMu.RUnlock()
-
-		if alreadyExecuted {
-			// Skip execution but still generate a success reply
-			continue
-		}
-
-		// Handle the command
-		reply := m.handleCommand(cmd)
-
-		// Track command with its timestamp for later cleanup
-		m.executedCommandsMu.Lock()
-		m.executedCommands[cmd.CommandId] = cmd.CreateTime
-		m.executedCommandsMu.Unlock()
-
-		if reply != nil {
-			m.pendingRepliesMu.Lock()
-			m.pendingReplies = append(m.pendingReplies, &commonpb.CommandReply{
-				CommandId:    reply.CommandId,
-				Success:      reply.Success,
-				ErrorMessage: reply.ErrorMessage,
-				Payload:      reply.Payload,
-			})
-			m.pendingRepliesMu.Unlock()
-		}
-	}
-
-	// Clean up old entries from executedCommands map
-	// Commands with CreateTime <= lastTS are now filtered by timestamp comparison
-	// Using <= ensures commands with same millisecond timestamp are also cleaned up
-	m.executedCommandsMu.Lock()
-	for cmdID, ts := range m.executedCommands {
-		if ts <= lastTS {
-			delete(m.executedCommands, cmdID)
-		}
-	}
-	m.executedCommandsMu.Unlock()
-
-	// Update config hash AFTER all commands are processed
-	// This ensures partial processing doesn't lead to lost configs on reconnect
-	if hasPersistent {
-		m.configHashMu.Lock()
-		m.configHash = m.calculateConfigHash(commands)
-		m.configHashMu.Unlock()
-	}
-
-	m.updateLastCommandTimestamp(maxCommandTS)
-}
-
 // handleCommand handles a single command
 func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) *CommandReply {
 	m.commandHandlersMu.RLock()
@@ -1090,32 +1034,6 @@ func (m *ClientTelemetryManager) handleCommand(cmd *ClientCommand) *CommandReply
 	}
 
 	return handler(cmd)
-}
-
-// calculateConfigHash calculates a hash for persistent commands (local types)
-func (m *ClientTelemetryManager) calculateConfigHash(commands []*ClientCommand) string {
-	if len(commands) == 0 {
-		return ""
-	}
-
-	var commandStrs []string
-	for _, cmd := range commands {
-		if cmd.Persistent {
-			commandStrs = append(commandStrs, cmd.CommandId+":"+cmd.CommandType)
-		}
-	}
-
-	if len(commandStrs) == 0 {
-		return ""
-	}
-
-	sort.Strings(commandStrs)
-
-	h := sha256.New()
-	for _, str := range commandStrs {
-		h.Write([]byte(str))
-	}
-	return hex.EncodeToString(h.Sum(nil))[:16]
 }
 
 // RegisterCommandHandler registers a handler for a command type

--- a/client/milvusclient/telemetry.go
+++ b/client/milvusclient/telemetry.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -50,6 +51,16 @@ type TelemetryConfig struct {
 	SamplingRate float64
 	// ErrorMaxCount is the maximum number of errors to keep
 	ErrorMaxCount int
+	// Labels describe the workload this client belongs to, e.g. {"app": "ingest-worker"}.
+	//
+	// The server can target commands at a label instead of a client ID. That matters for
+	// configuration meant to stick: a client ID names this process and dies with it, so a
+	// config targeted at one stops applying after a restart, whereas a label keeps
+	// matching every process that declares it. Several clients may share a label.
+	//
+	// Keys must be non-empty and free of "=". Sent as ClientInfo.Reserved["label.<key>"].
+	Labels map[string]string
+
 	// ClientID identifies this client to the server across process restarts.
 	//
 	// When empty, a random UUID is generated per Client, which means the server sees a
@@ -59,6 +70,10 @@ type TelemetryConfig struct {
 	// reusing one value across processes collapses them into a single server-side entry.
 	ClientID string
 }
+
+// labelReservedPrefix is how a label is published in ClientInfo.Reserved; the server
+// reads the same prefix when matching a label: scope.
+const labelReservedPrefix = "label."
 
 // DefaultTelemetryConfig returns the default telemetry configuration
 func DefaultTelemetryConfig() *TelemetryConfig {
@@ -579,6 +594,18 @@ func (m *ClientTelemetryManager) buildClientInfo() *commonpb.ClientInfo {
 			"client_id": m.clientID, // Always send stable UUID to prevent ID collisions
 		},
 	}
+	m.configMu.RLock()
+	labels := m.config.Labels
+	m.configMu.RUnlock()
+	for key, value := range labels {
+		// A key containing "=" could not be addressed by a label:key=value scope, and an
+		// empty key addresses nothing; drop rather than emit something unmatchable.
+		if key == "" || strings.Contains(key, "=") {
+			continue
+		}
+		clientInfo.Reserved[labelReservedPrefix+key] = value
+	}
+
 	if m.client != nil {
 		if m.client.config != nil {
 			clientInfo.User = m.client.config.Username

--- a/client/milvusclient/telemetry_integration_test.go
+++ b/client/milvusclient/telemetry_integration_test.go
@@ -143,13 +143,13 @@ func TestTelemetryIntegration(t *testing.T) {
 			},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Check state
 		fmt.Printf("\nConfig hash: %s\n", manager.GetConfigHash())
 
 		// Get pending replies
-		replies := manager.getPendingReplies()
+		replies := drainPendingReplies(manager)
 		fmt.Printf("Pending replies: %d\n", len(replies))
 		for _, r := range replies {
 			fmt.Printf("  Command %s: success=%v\n", r.CommandId, r.Success)
@@ -177,7 +177,7 @@ func TestTelemetryIntegration(t *testing.T) {
 		metrics := manager.collectMetrics()
 		fmt.Printf("Metrics count: %d\n", len(metrics))
 
-		replies := manager.getPendingReplies()
+		replies := drainPendingReplies(manager)
 		fmt.Printf("Pending replies: %d\n", len(replies))
 	})
 }

--- a/client/milvusclient/telemetry_test.go
+++ b/client/milvusclient/telemetry_test.go
@@ -17,12 +17,18 @@
 package milvusclient
 
 import (
+	"context"
 	"encoding/json"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 )
@@ -260,14 +266,14 @@ func TestClientTelemetryManager(t *testing.T) {
 			}
 		})
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Config hash should be updated for persistent commands
 		assert.NotEmpty(t, manager.GetConfigHash())
 
 		// Process the same commands again - should be idempotent
 		oldHash := manager.GetConfigHash()
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 		assert.Equal(t, oldHash, manager.GetConfigHash())
 	})
 
@@ -291,14 +297,14 @@ func TestClientTelemetryManager(t *testing.T) {
 		commands := []*ClientCommand{
 			{CommandId: "cmd-1", CommandType: "test", CreateTime: 1000},
 		}
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
-		replies := manager.getPendingReplies()
+		replies := drainPendingReplies(manager)
 		assert.Len(t, replies, 1)
 		assert.Equal(t, "cmd-1", replies[0].CommandId)
 
 		// Second call should return empty
-		replies = manager.getPendingReplies()
+		replies = drainPendingReplies(manager)
 		assert.Len(t, replies, 0)
 	})
 }
@@ -484,7 +490,7 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 			{CommandId: "cfg2", CommandType: "enable_trace", Payload: []byte(`{"enabled": true}`), Persistent: true},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should be updated after all commands processed
 		hash := manager.GetConfigHash()
@@ -492,7 +498,7 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 
 		// Hash should include both commands
 		// Verify by processing again - hash should remain the same
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 		assert.Equal(t, hash, manager.GetConfigHash())
 	})
 
@@ -504,7 +510,7 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 			{CommandId: "cmd1", CommandType: "show_errors", Persistent: false},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should remain empty
 		assert.Equal(t, "", manager.GetConfigHash())
@@ -520,16 +526,16 @@ func TestConfigHashUpdateTiming(t *testing.T) {
 			{CommandId: "cmd2", CommandType: "clear_metrics", Persistent: false},
 		}
 
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should be calculated based on persistent commands only
 		hash := manager.GetConfigHash()
 		assert.NotEmpty(t, hash)
 
 		// Add another non-persistent command - hash shouldn't change
-		manager.processCommands([]*ClientCommand{
+		manager.processProtoCommands(toProtoCommands([]*ClientCommand{
 			{CommandId: "cmd3", CommandType: "show_metrics", Persistent: false},
-		})
+		}))
 		assert.Equal(t, hash, manager.GetConfigHash())
 	})
 }
@@ -555,10 +561,10 @@ func TestPartialDeliveryScenario(t *testing.T) {
 		assert.Equal(t, "", manager.GetConfigHash())
 
 		// Now process all commands properly
-		manager.processCommands(commands)
+		manager.processProtoCommands(toProtoCommands(commands))
 
 		// Hash should now be updated
-		expectedHash := manager.calculateConfigHash(commands)
+		expectedHash := manager.calculateProtoConfigHash(toProtoCommands(commands))
 		assert.Equal(t, expectedHash, manager.GetConfigHash())
 	})
 }
@@ -1656,7 +1662,7 @@ func TestCollectProtoMetrics(t *testing.T) {
 		manager.RecordOperation("Search", "test_col", startTime, nil)
 		manager.RecordOperation("Insert", "test_col", startTime, errors.New("insert error"))
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.NotEmpty(t, metrics)
 
 		// Find Search metrics
@@ -1685,7 +1691,7 @@ func TestCollectProtoMetrics(t *testing.T) {
 		manager.RecordOperation("Query", "col_a", startTime, nil)
 		manager.RecordOperation("Query", "col_b", startTime, nil) // Not enabled
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		for _, m := range metrics {
 			if m.Operation == "Query" {
 				// Only col_a should have collection metrics
@@ -1766,7 +1772,7 @@ func TestCalculateProtoConfigHash(t *testing.T) {
 func TestCalculateConfigHash(t *testing.T) {
 	t.Run("empty commands", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
-		hash := manager.calculateConfigHash(nil)
+		hash := manager.calculateProtoConfigHash(nil)
 		assert.Empty(t, hash)
 	})
 
@@ -1775,7 +1781,7 @@ func TestCalculateConfigHash(t *testing.T) {
 		commands := []*ClientCommand{
 			{CommandId: "cmd-1", CommandType: "show_errors", Persistent: false},
 		}
-		hash := manager.calculateConfigHash(commands)
+		hash := manager.calculateProtoConfigHash(toProtoCommands(commands))
 		assert.Empty(t, hash)
 	})
 }
@@ -1980,7 +1986,7 @@ func TestCollectProtoMetricsEdgeCases(t *testing.T) {
 	t.Run("no collectors", func(t *testing.T) {
 		manager := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.Empty(t, metrics)
 	})
 
@@ -1992,7 +1998,7 @@ func TestCollectProtoMetricsEdgeCases(t *testing.T) {
 		manager.collectors["EmptyOp"] = NewOperationMetricsCollector()
 		manager.mu.Unlock()
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.Empty(t, metrics) // Should skip collectors with no data
 	})
 
@@ -2007,7 +2013,7 @@ func TestCollectProtoMetricsEdgeCases(t *testing.T) {
 		// Record operations
 		manager.RecordOperation("Search", "any_collection", time.Now().Add(-10*time.Millisecond), nil)
 
-		metrics := manager.collectProtoMetrics()
+		metrics := manager.toProtoOperationMetrics(manager.collectMetrics())
 		assert.NotEmpty(t, metrics)
 
 		// Find Search metrics and verify collection is included
@@ -3296,4 +3302,157 @@ func TestAggregateSnapshotsZeroRequestCount(t *testing.T) {
 	assert.NotNil(t, result.Aggregated.Metrics["Search"])
 	assert.Equal(t, float64(0), result.Aggregated.Metrics["Search"].AvgLatencyMs)
 	assert.Equal(t, float64(0), result.Aggregated.Metrics["Search"].P99LatencyMs)
+}
+
+// toProtoCommands converts local test fixtures into the proto form the production command
+// path consumes. Tests drive processProtoCommands/calculateProtoConfigHash through this so
+// they exercise the same code that runs against a real server, rather than a parallel
+// local-type implementation that can silently drift from it.
+func toProtoCommands(commands []*ClientCommand) []*commonpb.ClientCommand {
+	if commands == nil {
+		return nil
+	}
+	result := make([]*commonpb.ClientCommand, 0, len(commands))
+	for _, cmd := range commands {
+		result = append(result, &commonpb.ClientCommand{
+			CommandId:   cmd.CommandId,
+			CommandType: cmd.CommandType,
+			Payload:     cmd.Payload,
+			CreateTime:  cmd.CreateTime,
+			Persistent:  cmd.Persistent,
+			TargetScope: cmd.TargetScope,
+		})
+	}
+	return result
+}
+
+// drainPendingReplies returns the queued command replies and clears them, mirroring what a
+// successful heartbeat does, so assertions can be written against local types.
+func drainPendingReplies(m *ClientTelemetryManager) []*CommandReply {
+	protoReplies := m.getPendingProtoRepliesSnapshot()
+	m.clearPendingProtoReplies(len(protoReplies))
+
+	var result []*CommandReply
+	for _, r := range protoReplies {
+		result = append(result, &CommandReply{
+			CommandId:    r.GetCommandId(),
+			Success:      r.GetSuccess(),
+			ErrorMessage: r.GetErrorMessage(),
+			Payload:      r.GetPayload(),
+		})
+	}
+	return result
+}
+
+func TestTelemetryClientID(t *testing.T) {
+	t.Run("defaults to generated uuid", func(t *testing.T) {
+		m1 := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+		m2 := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+
+		assert.NotEmpty(t, m1.clientID)
+		assert.NotEqual(t, m1.clientID, m2.clientID)
+	})
+
+	t.Run("honors configured stable id", func(t *testing.T) {
+		cfg := DefaultTelemetryConfig()
+		cfg.ClientID = "milvus-worker-0"
+
+		m := NewClientTelemetryManager(nil, cfg)
+		assert.Equal(t, "milvus-worker-0", m.clientID)
+
+		// The heartbeat must carry it, that is what the server keys scoping on.
+		assert.Equal(t, "milvus-worker-0", m.buildClientInfo().GetReserved()["client_id"])
+	})
+}
+
+func TestMaxLatencyIsReported(t *testing.T) {
+	m := NewClientTelemetryManager(nil, DefaultTelemetryConfig())
+	m.handleCollectionMetrics(&ClientCommand{
+		CommandId:   "enable-all",
+		CommandType: "collection_metrics",
+		Payload:     []byte(`{"enabled": true, "collections": ["*"]}`),
+	})
+
+	start := time.Now().Add(-50 * time.Millisecond)
+	m.RecordOperation("Search", "coll-1", start, nil)
+
+	protoMetrics := m.toProtoOperationMetrics(m.collectMetrics())
+	assert.Len(t, protoMetrics, 1)
+
+	global := protoMetrics[0].GetGlobal()
+	assert.Greater(t, global.GetMaxLatencyMs(), float64(0), "max_latency_ms must reach the wire")
+	assert.GreaterOrEqual(t, global.GetMaxLatencyMs(), global.GetAvgLatencyMs())
+
+	collMetrics := protoMetrics[0].GetCollectionMetrics()["coll-1"]
+	assert.NotNil(t, collMetrics)
+	assert.Greater(t, collMetrics.GetMaxLatencyMs(), float64(0))
+}
+
+// TestHeartbeatAgainstUnimplementedServer covers a client talking to a Milvus that predates
+// ClientTelemetryService: the heartbeat can never succeed, so it must latch off instead of
+// firing forever on every interval.
+func TestHeartbeatAgainstUnimplementedServer(t *testing.T) {
+	lis := bufconn.Listen(bufSize)
+	// Deliberately register no services: every RPC answers codes.Unimplemented.
+	svr := grpc.NewServer()
+	go func() { _ = svr.Serve(lis) }()
+	defer func() {
+		svr.Stop()
+		lis.Close()
+	}()
+
+	c, err := New(context.Background(), &ClientConfig{
+		Address:         "bufnet",
+		DisableConn:     true,
+		TelemetryConfig: &TelemetryConfig{Enabled: false},
+		DialOptions: []grpc.DialOption{
+			grpc.WithBlock(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
+		},
+	})
+	require.NoError(t, err)
+	defer c.Close(context.Background())
+
+	m := NewClientTelemetryManager(c, &TelemetryConfig{
+		Enabled:           true,
+		HeartbeatInterval: time.Hour,
+		SamplingRate:      1.0,
+		ErrorMaxCount:     10,
+	})
+	require.True(t, m.IsSupported())
+	require.NoError(t, m.LastHeartbeatError())
+
+	m.sendHeartbeat()
+
+	assert.False(t, m.IsSupported(), "Unimplemented must permanently disable telemetry")
+	assert.Error(t, m.LastHeartbeatError(), "the failure must be observable, not silently swallowed")
+
+	// Once latched, further heartbeats are a no-op rather than another doomed RPC.
+	m.sendHeartbeat()
+	assert.False(t, m.IsSupported())
+}
+
+func TestHeartbeatLoopExitsWhenUnsupported(t *testing.T) {
+	// A one-hour interval means a loop that does not honor the latch would hang here.
+	m := NewClientTelemetryManager(nil, &TelemetryConfig{
+		Enabled:           true,
+		HeartbeatInterval: time.Hour,
+		SamplingRate:      1.0,
+		ErrorMaxCount:     10,
+	})
+	m.unsupported.Store(true)
+	m.Start()
+
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("heartbeat loop did not exit after telemetry was marked unsupported")
+	}
 }

--- a/client/milvusclient/telemetry_test.go
+++ b/client/milvusclient/telemetry_test.go
@@ -3456,3 +3456,38 @@ func TestHeartbeatLoopExitsWhenUnsupported(t *testing.T) {
 		t.Fatal("heartbeat loop did not exit after telemetry was marked unsupported")
 	}
 }
+
+func TestClientInfoLabels(t *testing.T) {
+	t.Run("labels are published under the label prefix", func(t *testing.T) {
+		cfg := DefaultTelemetryConfig()
+		cfg.Labels = map[string]string{"app": "ingest-worker", "env": "prod"}
+
+		reserved := NewClientTelemetryManager(nil, cfg).buildClientInfo().GetReserved()
+
+		assert.Equal(t, "ingest-worker", reserved["label.app"])
+		assert.Equal(t, "prod", reserved["label.env"])
+		// The existing reserved entries must survive alongside them.
+		assert.NotEmpty(t, reserved["client_id"])
+	})
+
+	t.Run("no labels means no label entries", func(t *testing.T) {
+		reserved := NewClientTelemetryManager(nil, DefaultTelemetryConfig()).buildClientInfo().GetReserved()
+
+		for key := range reserved {
+			assert.NotContains(t, key, "label.")
+		}
+	})
+
+	t.Run("unaddressable keys are dropped", func(t *testing.T) {
+		cfg := DefaultTelemetryConfig()
+		// A key containing "=" could never be selected by a label:key=value scope, and an
+		// empty key addresses nothing.
+		cfg.Labels = map[string]string{"": "x", "a=b": "y", "ok": "z"}
+
+		reserved := NewClientTelemetryManager(nil, cfg).buildClientInfo().GetReserved()
+
+		assert.Equal(t, "z", reserved["label.ok"])
+		assert.NotContains(t, reserved, "label.")
+		assert.NotContains(t, reserved, "label.a=b")
+	})
+}

--- a/docs/design-docs/design_docs/20260131-client_side_telemetry.md
+++ b/docs/design-docs/design_docs/20260131-client_side_telemetry.md
@@ -65,6 +65,7 @@ GET    /_telemetry/clients/{clientId}           - Metrics for one client
 GET    /_telemetry/clients/{clientId}/config    - Ask a client for its config (async)
 GET    /_telemetry/clients/{clientId}/history   - Ask a client for latency history (async)
 POST   /_telemetry/commands                     - Push a command to clients
+GET    /_telemetry/commands/{commandId}/reply   - Fetch a client's reply to a command
 DELETE /_telemetry/commands/{commandId}         - Delete a command
 GET    /telemetry                               - WebUI dashboard
 ```
@@ -367,17 +368,36 @@ REST API endpoints for WebUI and external integrations.
 | `/_telemetry/clients/{clientId}/config` | GET | Push `get_config`; returns a command ID |
 | `/_telemetry/clients/{clientId}/history` | GET | Push `show_latency_history`; `?start_time=`, `?end_time=`, `?detail=` |
 | `/_telemetry/commands` | POST | Push an arbitrary command |
+| `/_telemetry/commands/{commandId}/reply` | GET | Fetch a client's reply; `?client_id=`, `?wait=` |
 | `/_telemetry/commands/{commandId}` | DELETE | Remove a command |
 
 **Authentication:** Basic Auth via `TelemetryAuthMiddleware`, active only when
 `common.security.authorizationEnabled` is set. No RBAC.
 
-**Asynchrony.** The `/config` and `/history` endpoints are fire-and-forget: they push a
-command and immediately return `{"command_id": ..., "status": "pending"}`. The result
-arrives with the client's next heartbeat (up to one `HeartbeatInterval` later) and is
-stored as a `StoredCommandReply`. Callers read it back from `GET /_telemetry/clients`,
-matching on `command_id` in the `command_replies` array. There is no dedicated
-"fetch reply by command ID" endpoint.
+**Asynchrony.** Commands are answered on the client's next heartbeat, so any endpoint that
+pulls data from a client is inherently asynchronous. `/config`, `/history` and the
+command-reply endpoint share one response shape:
+
+```json
+{"command_id": "...", "client_id": "...", "status": "pending" | "done", "reply": { ... }}
+```
+
+Callers branch on `status` and read `reply` when it is `done`. `pending` is returned with
+HTTP 200, not an error: a reply that has not arrived is indistinguishable from one that
+never will, since replies are also evicted once a client accumulates more than 50.
+
+Two ways to collect a result:
+
+- **Synchronous** — pass `?wait=30s` to `/config`, `/history`, or the reply endpoint. The
+  proxy polls until the reply lands or the budget expires. Waits are clamped to 90s and
+  bounded by the request context; expiry is reported as `pending`.
+- **Deferred** — push without `wait`, keep the returned `command_id`, and fetch it later
+  from `/_telemetry/commands/{commandId}/reply`. Passing `?client_id=` makes that a
+  targeted lookup instead of a scan of all clients.
+
+Replies are also visible in the `command_replies` array of `GET /_telemetry/clients`,
+which is how the WebUI polls; on the wire they are JSON-encoded into
+`ClientInfo.Reserved["command_replies"]` rather than carried in a dedicated proto field.
 
 ### Heartbeat Protocol
 
@@ -479,8 +499,10 @@ provides:
 - **Server Compatibility:** Old clients simply never heartbeat; they appear only through
   their `Connect` call, not in telemetry.
 - **Client Compatibility:** Against a server without `ClientTelemetryService`, the heartbeat
-  fails with `codes.Unimplemented`. Telemetry is best-effort and the failure is not
-  surfaced through the normal API surface.
+  fails with `codes.Unimplemented`. The client latches telemetry off and stops the heartbeat
+  loop rather than retrying a call that can never succeed. Because telemetry is best-effort
+  and the `client/` module carries no logger, the failure is not raised through the normal
+  API; inspect it with `ClientTelemetryManager.IsSupported()` and `LastHeartbeatError()`.
 
 ## Implementation Status
 

--- a/docs/design-docs/design_docs/20260131-client_side_telemetry.md
+++ b/docs/design-docs/design_docs/20260131-client_side_telemetry.md
@@ -353,9 +353,21 @@ Manages pending commands, with different storage for the two kinds:
 - `database:<dbName>` — clients that have accessed that database
 
 **TTL.** `ttl_seconds` is a field of `PushClientCommandRequest`, not of `ClientCommand`, so
-clients never see it. `0` means never expire — the command lives until a reply deletes it.
-Both `get_config` and `show_latency_history` are pushed with `ttl_seconds: 0`, so a client
-that never replies leaks them.
+clients never see it. It is resolved once at push time:
+
+| Requested | Stored | Meaning |
+|-----------|--------|---------|
+| unset (`0`) | `300` | Default: ten heartbeat cycles at the nominal 30s interval |
+| `> 0` | as given | Honoured verbatim |
+| `< 0` | as given | Never expires (every expiry check treats `<= 0` as immortal) |
+
+A one-time command that has not been collected within ten heartbeat cycles is not going to
+be, so it is dropped. Without a default, a client that restarted, crashed, or simply never
+answered would leave the command in RootCoord memory indefinitely — and clients are
+expected to be ephemeral, since the SDK generates a fresh client ID per process.
+
+Replying still deletes a command immediately; the TTL is the backstop for when no reply
+ever arrives. Persistent configs ignore TTL entirely.
 
 #### 3. HTTP Handlers (Proxy)
 
@@ -454,8 +466,8 @@ fails to execute it, because the client has already advanced its watermark past 
 #### Replies
 
 Any reply with a non-empty `command_id` — **whether or not `success` is true** — deletes the
-corresponding non-persistent command server-side. Replies are the garbage-collection
-mechanism; a client that never replies leaks commands with `ttl_seconds: 0`.
+corresponding non-persistent command server-side. Replies are the fast path for reclaiming
+a command; the TTL above is the backstop for clients that never answer.
 
 The client queues replies and clears them **only after a successful heartbeat**, so replies
 survive a failed heartbeat and are retried on the next one. Commands already executed still

--- a/docs/design-docs/design_docs/20260131-client_side_telemetry.md
+++ b/docs/design-docs/design_docs/20260131-client_side_telemetry.md
@@ -2,10 +2,17 @@
 
 - **Created:** 2026-01-31
 - **Author(s):** @xiaofanluan
-- **Status:** Draft
+- **Status:** Implemented
 - **Component:** SDK | Proxy | Coordinator
-- **Related Issues:** #46934
-- **Released:** [TBD]
+- **Related Issues:** #46934, #47281
+- **Implemented by:** #47523, #47542
+
+> This document was refreshed to match the implementation. Where the original draft
+> described interfaces that were never built (`set_sampling_rate`, `enable_collections`,
+> `update_config`, `/api/v1/telemetry/*`, `NewConfigHash`), those sections have been
+> replaced with what the code actually does. Source of truth is
+> `internal/rootcoord/telemetry/`, `internal/proxy/telemetry_*.go` and
+> `client/milvusclient/telemetry.go`.
 
 ## Summary
 
@@ -32,7 +39,7 @@ This feature addresses these gaps by implementing a comprehensive client telemet
 ```go
 // TelemetryConfig holds configurable settings for client telemetry
 type TelemetryConfig struct {
-    Enabled           bool          // Enable/disable telemetry collection
+    Enabled           bool          // Enable/disable telemetry collection (default: true)
     HeartbeatInterval time.Duration // Heartbeat frequency (default: 30s)
     SamplingRate      float64       // Sampling rate 0.0-1.0 (default: 1.0)
     ErrorMaxCount     int           // Max errors to track (default: 100)
@@ -45,19 +52,35 @@ type ClientConfig struct {
 }
 ```
 
+`DefaultTelemetryConfig()` returns `Enabled: true`. Telemetry is opt-in at the level of
+whether a caller constructs a `TelemetryConfig` at all, not via this flag.
+
 ### HTTP REST APIs (Proxy)
 
+Served on the internal HTTP port (`9091` by default), not on the gRPC port.
+
 ```
-GET  /api/v1/telemetry/clients          - List connected clients with optional filtering
-POST /api/v1/telemetry/commands         - Push commands to clients
-DELETE /api/v1/telemetry/commands/{id}  - Delete a command
+GET    /_telemetry/clients                      - List connected clients
+GET    /_telemetry/clients/{clientId}           - Metrics for one client
+GET    /_telemetry/clients/{clientId}/config    - Ask a client for its config (async)
+GET    /_telemetry/clients/{clientId}/history   - Ask a client for latency history (async)
+POST   /_telemetry/commands                     - Push a command to clients
+DELETE /_telemetry/commands/{commandId}         - Delete a command
+GET    /telemetry                               - WebUI dashboard
 ```
 
-### gRPC APIs (RootCoord)
+Path constants live in `internal/http/router.go`; registration is in
+`internal/proxy/impl.go` (`registerHTTPHandlers`).
+
+### gRPC APIs
+
+The RPCs live in their own service, `ClientTelemetryService`, registered on the Proxy's
+**external** gRPC server. Proxy forwards to MixCoord, which forwards to RootCoord, where
+`TelemetryManager` holds the state.
 
 ```protobuf
-service RootCoord {
-    // Client heartbeat with metrics
+service ClientTelemetryService {
+    // Client heartbeat with metrics; response carries pending commands
     rpc ClientHeartbeat(ClientHeartbeatRequest) returns (ClientHeartbeatResponse);
 
     // Query connected clients
@@ -71,6 +94,11 @@ service RootCoord {
 }
 ```
 
+`ClientHeartbeat` carries no `privilege_ext_obj` annotation, so the privilege interceptor
+short-circuits for it and only normal authentication applies. The REST endpoints are
+guarded by `TelemetryAuthMiddleware`, which is Basic Auth only -- there is no RBAC
+privilege check on this surface.
+
 ## Design Details
 
 ### Architecture Overview
@@ -83,7 +111,7 @@ service RootCoord {
 │  │  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐       │  │
 │  │  │ Operation       │  │ Error           │  │ Command         │       │  │
 │  │  │ Metrics         │  │ Collector       │  │ Handler         │       │  │
-│  │  │ Collector       │  │ (Ring Buffer)   │  │ Router          │       │  │
+│  │  │ Collector       │  │ (Ring Buffer)   │  │ Registry        │       │  │
 │  │  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘       │  │
 │  │           │                    │                    │                 │  │
 │  │           └────────────────────┼────────────────────┘                 │  │
@@ -104,12 +132,15 @@ service RootCoord {
 │  │     Proxy      │◄────────►│              RootCoord                     │  │
 │  │                │          │  ┌─────────────────────────────────────┐  │  │
 │  │  HTTP API      │          │  │      Telemetry Manager              │  │  │
-│  │  /telemetry/*  │          │  │  ┌───────────┐  ┌───────────────┐   │  │  │
+│  │  /_telemetry/* │          │  │  ┌───────────┐  ┌───────────────┐   │  │  │
 │  │                │          │  │  │ Client    │  │ Command       │   │  │  │
-│  │  WebUI         │          │  │  │ Store     │  │ Store         │   │  │  │
-│  │  telemetry.html│          │  │  └───────────┘  └───────────────┘   │  │  │
-│  └────────────────┘          │  └─────────────────────────────────────┘  │  │
-│                              └───────────────────────────────────────────┘  │
+│  │  WebUI         │          │  │  │ Cache     │  │ Store         │   │  │  │
+│  │  telemetry.html│          │  │  └───────────┘  └──────┬────────┘   │  │  │
+│  └────────────────┘          │  └────────────────────────┼────────────┘  │  │
+│                              └───────────────────────────┼───────────────┘  │
+│                                                          ▼                   │
+│                                            etcd: /client-telemetry/configs/  │
+│                                            (persistent configs only)         │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -121,24 +152,36 @@ The central component managing telemetry collection and heartbeat communication.
 
 ```go
 type ClientTelemetryManager struct {
-    config         *TelemetryConfig
-    client         *Client
-    clientID       string                              // Stable UUID
-    collectors     map[string]*OperationMetricsCollector
-    errorCollector *ErrorCollectorImpl
+    config          *TelemetryConfig
+    client          *Client
+    clientID        string                              // UUID, see below
+    collectors      map[string]*OperationMetricsCollector
+    errorCollector  *ErrorCollectorImpl
     commandHandlers map[string]CommandHandler
 
+    // Deduplication and change detection
+    configHash           string
+    lastCommandTimestamp atomic.Int64
+    executedCommands     map[string]int64
+
     // Heartbeat management
-    stopCh         chan struct{}
-    wg             sync.WaitGroup
+    stopCh chan struct{}
+    wg     sync.WaitGroup
 }
 ```
 
 **Key behaviors:**
-- Generates stable client UUID on creation
+- Generates a client UUID on creation. It is stable for the lifetime of the `Client`, and
+  therefore across gRPC reconnects, but **not across process restarts** -- each `New()`
+  produces a fresh UUID. Servers see a restarted process as a new client.
 - Starts background heartbeat loop on `Start()`
 - Sends first heartbeat immediately, then every `HeartbeatInterval`
+- Uses `time.After` per iteration rather than a `time.Ticker`, so a server-pushed interval
+  change takes effect on the next cycle
 - Collects and resets metrics atomically during snapshot creation
+
+**Instrumented operations (7):** `Search`, `Query`, `HybridSearch`, `RunAnalyzer`,
+`Insert`, `Delete`, `Upsert`. DDL, index and partition operations are not instrumented.
 
 #### 2. OperationMetricsCollector
 
@@ -162,12 +205,15 @@ type OperationMetricsCollector struct {
 }
 ```
 
-**Metrics tracked:**
-- Request count
-- Success/error counts
-- Average latency (ms)
-- P99 latency (ms) - calculated from 1000 sample buffer
-- Max latency (ms)
+**Metrics tracked:** request count, success/error counts, average latency (ms), P99 latency
+(ms, from the 1000-sample buffer), max latency (ms).
+
+P99 is computed inside the locked snapshot, *before* the sample buffer is reset, so a
+concurrent heartbeat cannot read a cleared buffer. `totalSamples` is tracked separately
+from the buffer index so a genuine 0µs latency is distinguishable from an unwritten slot.
+
+Per-collection metrics are **off by default** and enabled by the `collection_metrics`
+command.
 
 #### 3. ErrorCollectorImpl
 
@@ -181,11 +227,11 @@ type ErrorCollectorImpl struct {
 }
 
 type ErrorInfo struct {
-    Timestamp  int64
-    Operation  string
-    ErrorMsg   string
-    Collection string
-    RequestID  string
+    Timestamp  int64  `json:"timestamp"`             // Unix ms
+    Operation  string `json:"operation"`
+    ErrorMsg   string `json:"error_msg"`
+    Collection string `json:"collection,omitempty"`
+    RequestID  string `json:"request_id,omitempty"`
 }
 ```
 
@@ -194,52 +240,121 @@ type ErrorInfo struct {
 Supports server-pushed commands with extensible handler registration.
 
 ```go
-type CommandHandler func(cmd *ClientCommand) string  // Returns error message or ""
-
-// Built-in commands:
-const (
-    CmdSetSamplingRate   = "set_sampling_rate"        // Adjust sampling rate
-    CmdEnableCollections = "enable_collections"       // Enable specific collections
-    CmdUpdateConfig      = "update_config"            // Update telemetry config
-)
+type CommandHandler func(cmd *ClientCommand) *CommandReply
 ```
+
+**Command types.** These five strings are the complete set. `command_type` is a free-form
+string on the wire and the server does not validate it on push, so an unknown type reaches
+the client and is answered with `"unknown command type: <type>"`.
+
+| Type | Purpose | May be persistent |
+|------|---------|-------------------|
+| `push_config` | Change client telemetry settings | **Yes (the only one)** |
+| `collection_metrics` | Enable/disable per-collection metrics | No |
+| `show_errors` | Return the last N client-side errors | No |
+| `show_latency_history` | Return client metric snapshots for a time window | No |
+| `get_config` | Return the client's current effective config | No |
+
+`command_store.go` rejects `persistent=true` for anything other than `push_config`.
+
+**Payload schemas.** `ClientCommand.payload` is raw JSON (not protobuf).
+
+```go
+// push_config
+type PushConfigPayload struct {
+    Enabled             *bool    `json:"enabled,omitempty"`
+    HeartbeatIntervalMs *int64   `json:"heartbeat_interval_ms,omitempty"`
+    SamplingRate        *float64 `json:"sampling_rate,omitempty"`   // 0.0-1.0
+    TTLSeconds          int64    `json:"ttl_seconds,omitempty"`
+}
+
+// collection_metrics -- "*" in Collections is the all-collections wildcard
+type CollectionMetricsPayload struct {
+    Collections  []string `json:"collections"`
+    Enabled      bool     `json:"enabled"`
+    MetricsTypes []string `json:"metrics_types,omitempty"`
+}
+
+// show_errors
+type ErrorMessagesPayload struct {
+    MaxCount int `json:"max_count,omitempty"`   // default 100
+}
+
+// show_latency_history -- RFC3339 timestamps, window must be <= 1 hour
+type LatencyHistoryPayload struct {
+    StartTime string `json:"start_time"`
+    EndTime   string `json:"end_time"`
+    Detail    bool   `json:"detail"`
+}
+
+// get_config -- no payload
+```
+
+Reply payloads are capped at 1 MB client-side; `show_errors` halves the returned count
+until it fits. `get_config` deliberately omits `Password` and `APIKey`.
 
 ### Server-Side Components
 
 #### 1. Telemetry Manager (RootCoord)
 
-Central server-side storage for client telemetry data.
+Central server-side storage for client telemetry data. Client state is held in a
+`sync.Map` keyed by client ID.
 
 ```go
-type TelemetryManager struct {
-    clients      map[string]*ClientTelemetry  // clientID -> telemetry
-    commandStore *CommandStore
-}
-
-type ClientTelemetry struct {
+type ClientMetricsCache struct {
     ClientInfo        *commonpb.ClientInfo
     LastHeartbeatTime int64
-    Status            string  // "active" or "inactive"
-    Databases         []string
-    Metrics           []*commonpb.OperationMetrics
+    Status            string       // "active" or "inactive"
+    AccessedDatabases sync.Map     // accumulative, never pruned
+    LatestMetrics     []*commonpb.OperationMetrics
+    CommandReplies    []*StoredCommandReply   // last 50
+    LastCommandTS     int64
 }
 ```
+
+**Client identity.** The manager reads `ClientInfo.Reserved["client_id"]`. When absent it
+falls back to `legacy:<host>:<hash(sdkType|sdkVersion|host|user)>`, in which case two
+processes on the same host with the same SDK and user **collide into one entry** and
+`client:` scoping becomes unusable. Database association comes from
+`Reserved["db_name"]` (or `Reserved["database"]`).
+
+**Hardcoded limits.** There are no `milvus.yaml` or paramtable keys for this feature;
+`DefaultTelemetryConfig()` in `manager.go` is never overridden in production:
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `ClientStatusThreshold` | 1 min | No heartbeat for this long → `Status: "inactive"` |
+| `InactiveClientThreshold` | 10 min | No heartbeat for this long → evicted from memory |
+| `CleanupInterval` | 1 min | Sweep cadence for expired commands and dead clients |
+| `MaxClientsInMemory` | 100000 | Then LRU eviction by last heartbeat |
+| `MaxMetricsPerClient` | 1 MB | Larger payloads are truncated (see below) |
+| `MaxOperationTypesPerClient` | 100 | Operation list truncated to this many |
+
+**Metrics ingest guards.** On each heartbeat the server drops every `CollectionMetrics`
+entry whose `RequestCount == 0`, truncates the operation list to 100, and if the message
+still exceeds 1 MB, first nulls all `CollectionMetrics`, then truncates further.
 
 #### 2. Command Store
 
-Manages pending commands for clients with support for persistent and one-time commands.
+Manages pending commands, with different storage for the two kinds:
 
-```go
-type CommandStore struct {
-    commands     []*commonpb.ClientCommand  // One-time commands
-    persistent   []*commonpb.ClientCommand  // Persistent commands
-}
-```
+- **Persistent (`push_config` only)** → written to etcd under `/client-telemetry/configs/`.
+  Survives RootCoord restart. Deduplicated by `(ConfigType, TargetScope)`: pushing a second
+  config for the same scope **JSON-merges** the new payload over the old one and deletes the
+  superseded entry, so partial updates accumulate rather than replace.
+- **One-time** → in-memory on the RootCoord that received the push. Lost on restart and
+  **not shared across coordinator replicas**.
 
-**Command targeting:**
-- `TargetScope = "*"` - All clients
-- `TargetScope = "client_id:xxx"` - Specific client
-- `TargetScope = "db:database_name"` - Clients using specific database
+**Command targeting** (`TargetScope`, built server-side from the push request):
+
+- `global` — all clients
+- `client:<clientID>` — one client, exact match
+- `database:<dbName>` — clients that have accessed that database
+
+**TTL.** `ttl_seconds` is a field of `PushClientCommandRequest`, not of `ClientCommand`, so
+clients never see it. `0` means never expire — the command lives until a reply deletes it.
+Both `get_config` and `show_latency_history` are pushed with `ttl_seconds: 0`, so a client
+that never replies leaks them.
 
 #### 3. HTTP Handlers (Proxy)
 
@@ -247,13 +362,22 @@ REST API endpoints for WebUI and external integrations.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/v1/telemetry/clients` | GET | List connected clients |
-| `/api/v1/telemetry/clients?database=X` | GET | Filter by database |
-| `/api/v1/telemetry/clients?include_metrics=true` | GET | Include operation metrics |
-| `/api/v1/telemetry/commands` | POST | Push command to clients |
-| `/api/v1/telemetry/commands/{id}` | DELETE | Remove a command |
+| `/_telemetry/clients` | GET | List clients; `?database=`, `?client_id=`, `?include_metrics=` |
+| `/_telemetry/clients/{clientId}` | GET | Metrics for one client |
+| `/_telemetry/clients/{clientId}/config` | GET | Push `get_config`; returns a command ID |
+| `/_telemetry/clients/{clientId}/history` | GET | Push `show_latency_history`; `?start_time=`, `?end_time=`, `?detail=` |
+| `/_telemetry/commands` | POST | Push an arbitrary command |
+| `/_telemetry/commands/{commandId}` | DELETE | Remove a command |
 
-**Authentication:** Uses existing Milvus Basic Auth when authorization is enabled.
+**Authentication:** Basic Auth via `TelemetryAuthMiddleware`, active only when
+`common.security.authorizationEnabled` is set. No RBAC.
+
+**Asynchrony.** The `/config` and `/history` endpoints are fire-and-forget: they push a
+command and immediately return `{"command_id": ..., "status": "pending"}`. The result
+arrives with the client's next heartbeat (up to one `HeartbeatInterval` later) and is
+stored as a `StoredCommandReply`. Callers read it back from `GET /_telemetry/clients`,
+matching on `command_id` in the `command_replies` array. There is no dedicated
+"fetch reply by command ID" endpoint.
 
 ### Heartbeat Protocol
 
@@ -264,40 +388,84 @@ Client                                      Server
    │     - ClientInfo (ID, SDK version, host)  │
    │     - Metrics (per-operation, per-coll)   │
    │     - CommandReplies                      │
-   │     - ConfigHash (for change detection)   │
+   │     - ConfigHash                          │
+   │     - LastCommandTimestamp                │
    │                                           │
    │◄─── ClientHeartbeatResponse ─────────────│
+   │     - ServerTimestamp                     │
    │     - Commands (pending for this client)  │
-   │     - NewConfigHash (if config changed)   │
    │                                           │
 ```
 
-**Heartbeat interval:** 30 seconds (configurable, server can override)
+**Heartbeat interval:** 30 seconds (client default; the server can change it via
+`push_config`).
 
-**Config hash:** SHA-256 of client configuration, used to detect when server pushes new config.
+**`report_timestamp`** is accepted but ignored — the server uses its own clock for
+`LastHeartbeat` and `server_timestamp`.
+
+#### Config hash
+
+Used to avoid re-sending persistent configs on every heartbeat. Both sides must compute it
+identically or configs are re-pushed forever.
+
+```
+if no configs:            hash = ""
+else:                     sort configs by ID ascending
+                          h = sha256()
+                          for each: h.write(ID); h.write(Type); h.write(Payload)
+                          hash = hex(h.sum())[:16]      // first 16 hex chars
+```
+
+The server computes it over the configs **already filtered to this client's scope**, and
+sends persistent configs only when `request.ConfigHash != serverHash`. The response has no
+"new hash" field — the client recomputes it locally after processing commands.
+
+#### Command delivery and deduplication
+
+One-time commands are returned only when `command.CreateTime > request.LastCommandTimestamp`
+(strict). The client advances `LastCommandTimestamp` to the maximum `CreateTime` it has
+seen, **after** processing the whole batch, so a mid-batch crash re-fetches. Because the
+comparison is strict, clients must additionally deduplicate by command ID to handle two
+commands created in the same millisecond.
+
+Consequence: a one-time command is delivered **once**. It is not redelivered if the client
+fails to execute it, because the client has already advanced its watermark past it.
+
+#### Replies
+
+Any reply with a non-empty `command_id` — **whether or not `success` is true** — deletes the
+corresponding non-persistent command server-side. Replies are the garbage-collection
+mechanism; a client that never replies leaks commands with `ttl_seconds: 0`.
+
+The client queues replies and clears them **only after a successful heartbeat**, so replies
+survive a failed heartbeat and are retried on the next one. Commands already executed still
+receive an idempotent success ACK.
+
+Persistent configs are never deleted by a reply; they are removed only via
+`DeleteClientCommand`, and are suppressed on the wire whenever `config_hash` matches.
 
 ### Data Flow
 
 1. **Metrics Collection:**
-   - Each SDK operation (Search, Insert, Query, etc.) records metrics
-   - Sampling rate determines if operation is tracked (default: 100%)
-   - Metrics stored in per-operation collectors
+   - Each instrumented SDK operation records into a per-operation collector
+   - Sampling rate determines whether an operation is tracked (default 100%)
 
 2. **Heartbeat Cycle:**
-   - Background goroutine wakes every 30 seconds
-   - Creates atomic snapshot of all metrics (resets counters)
-   - Sends snapshot to RootCoord via ClientHeartbeat RPC
+   - Background goroutine sends immediately on start, then every `HeartbeatInterval`
+   - Creates an atomic snapshot of all metrics (resetting counters, computing P99)
+   - Sends the snapshot, pending replies, config hash and watermark
    - Receives and processes any pending commands
 
 3. **Command Processing:**
-   - Server pushes commands via heartbeat response
-   - Client executes command handler
-   - Reply sent in next heartbeat request
-   - Persistent commands re-sent until explicitly deleted
+   - Server returns commands in the heartbeat response
+   - Client dispatches to the registered handler for that type
+   - Reply is queued and sent with the next heartbeat
+   - Persistent configs are re-sent only when the client's `config_hash` disagrees
 
 ### WebUI Dashboard
 
-A new telemetry dashboard (`/webui/telemetry.html`) provides:
+A telemetry dashboard served at `/telemetry` (source: `internal/http/webui/telemetry.html`)
+provides:
 
 - **Client List:** Active/inactive clients with connection details
 - **Metrics View:** Per-client operation metrics with latency charts
@@ -306,20 +474,35 @@ A new telemetry dashboard (`/webui/telemetry.html`) provides:
 
 ## Compatibility, Deprecation, and Migration Plan
 
-- **Backward Compatible:** Telemetry is opt-in and disabled by default can be enabled
-- **No Breaking Changes:** Existing SDK usage remains unchanged
-- **Server Compatibility:** Old clients work with new servers (no heartbeats sent)
-- **Client Compatibility:** New clients work with old servers (heartbeats fail silently)
+- **Backward Compatible:** No wire or API breaking changes.
+- **No Breaking Changes:** Existing SDK usage remains unchanged.
+- **Server Compatibility:** Old clients simply never heartbeat; they appear only through
+  their `Connect` call, not in telemetry.
+- **Client Compatibility:** Against a server without `ClientTelemetryService`, the heartbeat
+  fails with `codes.Unimplemented`. Telemetry is best-effort and the failure is not
+  surfaced through the normal API surface.
+
+## Implementation Status
+
+Client-side telemetry is implemented in the **Go SDK only**. pymilvus, the Java, Node.js and
+Rust SDKs do not implement the client half; the generated protobuf stubs exist for some of
+them but are unused. Any operator-facing claim about client coverage should be read as
+"Go SDK clients only".
+
+Server-side components are complete. Two pieces of the original design are present but not
+wired into the live path: `CommandRouter` validates payload shapes but is never invoked from
+`HandleHeartbeat`, and `PushCommand` does not validate `command_type` against it.
 
 ## Test Plan
 
 ### Unit Tests
-- `telemetry_test.go`: Metrics collection, P99 calculation, ring buffer
-- `telemetry_http_handler_test.go`: HTTP API handlers
-- `command_router_test.go`: Command routing and handling
+- `client/milvusclient/telemetry_test.go`: metrics collection, P99, ring buffer,
+  command dispatch, config hash
+- `internal/proxy/telemetry_http_handler_test.go`: HTTP API handlers
+- `internal/rootcoord/telemetry/*_test.go`: manager, command store, scope matching
 
 ### Integration Tests
-- `telemetry_integration_test.go`: End-to-end heartbeat flow
+- `client/milvusclient/telemetry_integration_test.go`: end-to-end heartbeat flow
 - Multi-client scenarios with different configurations
 - Command push and execution verification
 
@@ -344,6 +527,8 @@ Server polls clients for metrics.
 
 ## References
 
-- Milvus existing telemetry: `internal/proxy/impl.go`
+- Server implementation: `internal/rootcoord/telemetry/`
+- Proxy HTTP layer: `internal/proxy/telemetry_http_handler.go`, `telemetry_models.go`
+- Go SDK client: `client/milvusclient/telemetry.go`
 - gRPC health checking: https://github.com/grpc/grpc/blob/master/doc/health-checking.md
 - OpenTelemetry SDK patterns: https://opentelemetry.io/docs/instrumentation/go/

--- a/docs/design-docs/design_docs/20260131-client_side_telemetry.md
+++ b/docs/design-docs/design_docs/20260131-client_side_telemetry.md
@@ -348,9 +348,35 @@ Manages pending commands, with different storage for the two kinds:
 
 **Command targeting** (`TargetScope`, built server-side from the push request):
 
-- `global` — all clients
-- `client:<clientID>` — one client, exact match
-- `database:<dbName>` — clients that have accessed that database
+| Scope | Selects | Lifetime | Persistent config allowed |
+|-------|---------|----------|---------------------------|
+| `global` | every client | durable | yes |
+| `database:<db>` | clients that have accessed the database | durable | yes |
+| `label:<k>=<v>` | clients declaring that label | durable | yes |
+| `client:<id>` | one client process, exact match | **ephemeral** | **no** |
+
+Scope lifetime is what decides whether a config may be persistent. A `client:` scope names
+a *process* — client IDs are generated per process — so a config targeted at one stops
+applying as soon as that client restarts, and could never match again. A `label:` scope
+names a *workload*, so it keeps matching across restarts. `PushCommand` rejects
+`persistent=true` with a client target for that reason.
+
+Clients declare labels through the existing `ClientInfo.Reserved` map, as `label.<key>`
+entries; the Go SDK populates them from `TelemetryConfig.Labels`:
+
+```go
+client.New(ctx, &milvusclient.ClientConfig{
+    TelemetryConfig: &milvusclient.TelemetryConfig{
+        Labels: map[string]string{"app": "ingest-worker"},
+    },
+})
+```
+
+An operator then pushes with `target_label: "app=ingest-worker"`. A selector matches a
+single `key=value` pair; a client matches if it declared exactly that value.
+
+If more than one target field is set, the most specific wins: client, then label, then
+database.
 
 **TTL.** `ttl_seconds` is a field of `PushClientCommandRequest`, not of `ClientCommand`, so
 clients never see it. It is resolved once at push time:

--- a/go.mod
+++ b/go.mod
@@ -321,3 +321,5 @@ replace (
 	github.com/milvus-io/milvus/pkg/v3 => ./pkg
 	github.com/tecbot/gorocksdb => github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b // indirect
 )
+
+replace github.com/milvus-io/milvus-proto/go-api/v3 => github.com/xiaofan-luan/milvus-proto/go-api/v3 v3.0.0-20260729004244-442f2bb06151

--- a/go.sum
+++ b/go.sum
@@ -1130,6 +1130,10 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xiaofan-luan/milvus-proto/go-api/v3 v3.0.0-20260729003650-3a57941870b1 h1:01mjKreegcFQeqHOAJYj1VJo/dZkjgWZlF8dKJDlrbo=
+github.com/xiaofan-luan/milvus-proto/go-api/v3 v3.0.0-20260729003650-3a57941870b1/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/xiaofan-luan/milvus-proto/go-api/v3 v3.0.0-20260729004244-442f2bb06151 h1:EBYVw5uLitdlKsi9Lc3oDSmZNmK9fVki4zzGxGtjQ7g=
+github.com/xiaofan-luan/milvus-proto/go-api/v3 v3.0.0-20260729004244-442f2bb06151/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -165,6 +165,8 @@ const (
 	TelemetryClientHistoryPath = "/_telemetry/clients/:clientId/history"
 	// TelemetryCommandsPath is the path to manage client commands.
 	TelemetryCommandsPath = "/_telemetry/commands"
+	// TelemetryCommandReplyPath is the path to fetch a client's reply to a pushed command.
+	TelemetryCommandReplyPath = "/_telemetry/commands/:commandId/reply"
 	// TelemetryUIPath is the path for telemetry management web UI.
 	TelemetryUIPath = "/telemetry"
 )

--- a/internal/http/webui/telemetry.html
+++ b/internal/http/webui/telemetry.html
@@ -1300,11 +1300,14 @@
                         </div>
 
                         <div class="form-row" style="margin-top: 16px;">
-                            <div class="form-group" style="display: flex; align-items: center;">
+                            <div class="form-group" style="display: flex; align-items: center; flex-direction: column; align-items: flex-start;">
                                 <label class="checkbox-label">
                                     <input type="checkbox" id="configPersistent" checked>
-                                    Persistent (survives client restart)
+                                    Persistent (re-applied to matching clients)
                                 </label>
+                                <small id="configPersistentHint" style="color: var(--gray-400); margin-top: 4px; display: none;">
+                                    Not available for a client target: client IDs change on restart, so the config could never apply again. It will be sent once to the running client.
+                                </small>
                             </div>
                         </div>
 
@@ -2555,6 +2558,19 @@
             const scope = document.getElementById('configTargetScope').value;
             document.getElementById('configClientIdGroup').style.display = scope === 'client' ? 'block' : 'none';
             document.getElementById('configDatabaseIdGroup').style.display = scope === 'database' ? 'block' : 'none';
+
+            // A client-scoped config cannot be persistent: client IDs are per-process, so a
+            // persisted config would never match again after the client restarts. The server
+            // rejects the combination; disable it here rather than let the request fail.
+            const persistentBox = document.getElementById('configPersistent');
+            const hint = document.getElementById('configPersistentHint');
+            const clientScoped = scope === 'client';
+
+            persistentBox.disabled = clientScoped;
+            if (clientScoped) {
+                persistentBox.checked = false;
+            }
+            hint.style.display = clientScoped ? 'block' : 'none';
         }
 
         function setConfigEnabled(value) {
@@ -2636,7 +2652,8 @@
                         target_database: targetScope === 'database' ? targetDatabase : '',
                         payload: Object.keys(payload).length > 0 ? JSON.stringify(payload) : '',
                         ttl_seconds: 3600,
-                        persistent: persistent
+                        // Client-scoped configs are one-time by construction; see updateConfigTargetClient.
+                        persistent: targetScope === 'client' ? false : persistent
                     })
                 });
 

--- a/internal/http/webui/telemetry.html
+++ b/internal/http/webui/telemetry.html
@@ -1248,6 +1248,7 @@
                                 <label>Target</label>
                                 <select id="configTargetScope" onchange="updateConfigTargetClient()">
                                     <option value="global">All Clients</option>
+                                    <option value="label">Workload (label)</option>
                                     <option value="client">Specific Client</option>
                                     <option value="database">Specific Database</option>
                                 </select>
@@ -1259,6 +1260,10 @@
                             <div class="form-group" id="configDatabaseIdGroup" style="display: none;">
                                 <label>Database Name</label>
                                 <input type="text" id="configTargetDatabase" class="form-input" placeholder="Enter database name">
+                            </div>
+                            <div class="form-group" id="configLabelGroup" style="display: none;">
+                                <label>Label</label>
+                                <input type="text" id="configTargetLabel" class="form-input" placeholder="key=value, e.g. app=ingest-worker">
                             </div>
                         </div>
 
@@ -2558,6 +2563,7 @@
             const scope = document.getElementById('configTargetScope').value;
             document.getElementById('configClientIdGroup').style.display = scope === 'client' ? 'block' : 'none';
             document.getElementById('configDatabaseIdGroup').style.display = scope === 'database' ? 'block' : 'none';
+            document.getElementById('configLabelGroup').style.display = scope === 'label' ? 'block' : 'none';
 
             // A client-scoped config cannot be persistent: client IDs are per-process, so a
             // persisted config would never match again after the client restarts. The server
@@ -2595,6 +2601,7 @@
             const targetScope = document.getElementById('configTargetScope').value;
             const targetClient = document.getElementById('configTargetClient').value;
             const targetDatabase = document.getElementById('configTargetDatabase').value;
+            const targetLabel = document.getElementById('configTargetLabel').value;
 
             if (targetScope === 'client' && !targetClient) {
                 showToast('Please enter a client ID', 'error');
@@ -2603,6 +2610,13 @@
             if (targetScope === 'database' && !targetDatabase) {
                 showToast('Please enter a database name', 'error');
                 return;
+            }
+            if (targetScope === 'label') {
+                const eq = targetLabel.indexOf('=');
+                if (eq <= 0) {
+                    showToast('Please enter a label as key=value', 'error');
+                    return;
+                }
             }
 
             // Build config payload
@@ -2650,6 +2664,7 @@
                         command_type: 'push_config',
                         target_client_id: targetScope === 'client' ? targetClient : '',
                         target_database: targetScope === 'database' ? targetDatabase : '',
+                        target_label: targetScope === 'label' ? targetLabel : '',
                         payload: Object.keys(payload).length > 0 ? JSON.stringify(payload) : '',
                         ttl_seconds: 3600,
                         // Client-scoped configs are one-time by construction; see updateConfigTargetClient.

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -6509,6 +6509,7 @@ func (node *Proxy) RegisterRestRouter(router gin.IRouter) {
 	router.GET(http.TelemetryClientsPath+"/:clientId/config", telemetryAuth, getTelemetryClientConfig(node))
 	router.GET(http.TelemetryClientHistoryPath, telemetryAuth, getTelemetryClientHistory(node))
 	router.POST(http.TelemetryCommandsPath, telemetryAuth, postTelemetryCommand(node))
+	router.GET(http.TelemetryCommandReplyPath, telemetryAuth, getTelemetryCommandReply(node))
 	router.DELETE(http.TelemetryCommandsPath+"/:commandId", telemetryAuth, deleteTelemetryCommand(node))
 }
 

--- a/internal/proxy/telemetry_command_reply.go
+++ b/internal/proxy/telemetry_command_reply.go
@@ -1,0 +1,164 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+const (
+	// maxTelemetryWait bounds how long a synchronous telemetry request may block. A client
+	// answers on its next heartbeat, so anything beyond a couple of heartbeat intervals is
+	// almost certainly a client that is not going to answer at all.
+	maxTelemetryWait = 90 * time.Second
+
+	// telemetryReplyPollInterval is how often the proxy re-reads client state while waiting
+	// for a reply. Replies only ever land on a heartbeat, so polling faster buys nothing.
+	telemetryReplyPollInterval = 500 * time.Millisecond
+)
+
+// Reply lookup outcomes reported to API callers.
+const (
+	replyStatusDone    = "done"
+	replyStatusPending = "pending"
+)
+
+// parseWaitParam interprets the `wait` query parameter. It accepts a Go duration string
+// ("30s", "1m500ms") or a bare number of seconds ("30"). An empty value means "do not
+// wait". The result is clamped to [0, maxTelemetryWait]; a negative value is treated as 0.
+func parseWaitParam(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, nil
+	}
+
+	wait, err := time.ParseDuration(raw)
+	if err != nil {
+		seconds, convErr := strconv.ParseFloat(raw, 64)
+		if convErr != nil {
+			return 0, merr.WrapErrParameterInvalidMsg(
+				"invalid wait %q: expected a duration such as \"30s\" or a number of seconds", raw)
+		}
+		wait = time.Duration(seconds * float64(time.Second))
+	}
+
+	if wait < 0 {
+		return 0, nil
+	}
+	if wait > maxTelemetryWait {
+		wait = maxTelemetryWait
+	}
+	return wait, nil
+}
+
+// findCommandReply looks up a single command reply. clientID may be empty, in which case
+// every known client is scanned; passing it turns the lookup into a targeted one, which is
+// what callers who just pushed a command should do.
+//
+// It returns the reply and the ID of the client that produced it. A nil reply with a nil
+// error means the command has not been answered yet -- that is a normal state, not a
+// failure, because replies only arrive on the client's next heartbeat.
+func findCommandReply(ctx context.Context, node *Proxy, clientID, commandID string) (*CommandReply, string, error) {
+	// Metrics are not needed to read replies, and skipping them keeps this cheap enough to
+	// poll: command_replies is populated independently of IncludeMetrics.
+	resp, err := node.GetClientTelemetry(ctx, &milvuspb.GetClientTelemetryRequest{
+		ClientId:       clientID,
+		IncludeMetrics: false,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	if err := merr.Error(resp.GetStatus()); err != nil {
+		return nil, "", err
+	}
+
+	for _, client := range ConvertClientTelemetryResponse(resp).Clients {
+		for _, reply := range client.CommandReplies {
+			if reply.CommandID == commandID {
+				return reply, client.ClientID, nil
+			}
+		}
+	}
+
+	return nil, "", nil
+}
+
+// waitForCommandReply polls for a command reply until it appears, the timeout elapses, or
+// the request is canceled. A zero timeout performs exactly one lookup.
+//
+// A nil reply with a nil error means "still pending" and is a normal outcome.
+func waitForCommandReply(ctx context.Context, node *Proxy, clientID, commandID string, timeout time.Duration) (*CommandReply, string, error) {
+	reply, replyClientID, err := findCommandReply(ctx, node, clientID, commandID)
+	if err != nil || reply != nil || timeout <= 0 {
+		return reply, replyClientID, err
+	}
+
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(telemetryReplyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Caller hung up or the server is shutting down; report as still pending
+			// rather than as an error, the command itself is unaffected.
+			return nil, "", nil
+		case <-ticker.C:
+			reply, replyClientID, err = findCommandReply(ctx, node, clientID, commandID)
+			if err != nil || reply != nil {
+				return reply, replyClientID, err
+			}
+			if !time.Now().Before(deadline) {
+				return nil, "", nil
+			}
+		}
+	}
+}
+
+// commandReplyPayload renders a reply lookup as the JSON body shared by every endpoint
+// that can return one, so callers can parse a single shape regardless of which endpoint
+// produced it.
+//
+// `status` is always present: "done" when the client has answered, "pending" otherwise.
+// Callers should branch on it rather than on the presence of `reply`, and a "pending"
+// response is not an error -- retry, or ask again with a longer `wait`.
+func commandReplyPayload(commandID, clientID string, reply *CommandReply, waited time.Duration) map[string]interface{} {
+	body := map[string]interface{}{
+		"command_id": commandID,
+		"status":     replyStatusPending,
+	}
+	if clientID != "" {
+		body["client_id"] = clientID
+	}
+	if waited > 0 {
+		body["waited_ms"] = waited.Milliseconds()
+	}
+
+	if reply == nil {
+		body["message"] = "Command has not been answered yet. The client replies on its " +
+			"next heartbeat; retry, or pass ?wait= to block until it arrives."
+		return body
+	}
+
+	body["status"] = replyStatusDone
+	body["reply"] = reply
+	return body
+}

--- a/internal/proxy/telemetry_command_reply_test.go
+++ b/internal/proxy/telemetry_command_reply_test.go
@@ -1,0 +1,309 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// telemetryRespWithReply builds the shape the server actually returns: replies are JSON
+// encoded into ClientInfo.Reserved["command_replies"], not a dedicated proto field.
+func telemetryRespWithReply(clientID, commandID string, success bool, payload string) *milvuspb.GetClientTelemetryResponse {
+	replies := []map[string]interface{}{
+		{
+			"command_id":   commandID,
+			"command_type": "get_config",
+			"success":      success,
+			"payload":      payload,
+			"received_at":  int64(1700000000000),
+		},
+	}
+	encoded, _ := json.Marshal(replies)
+
+	return &milvuspb.GetClientTelemetryResponse{
+		Status: merr.Success(),
+		Clients: []*milvuspb.ClientTelemetry{
+			{
+				ClientInfo: &commonpb.ClientInfo{
+					SdkType: "Go",
+					Reserved: map[string]string{
+						"client_id":       clientID,
+						"command_replies": string(encoded),
+					},
+				},
+			},
+		},
+	}
+}
+
+func telemetryRespNoReply(clientID string) *milvuspb.GetClientTelemetryResponse {
+	return &milvuspb.GetClientTelemetryResponse{
+		Status: merr.Success(),
+		Clients: []*milvuspb.ClientTelemetry{
+			{
+				ClientInfo: &commonpb.ClientInfo{
+					SdkType:  "Go",
+					Reserved: map[string]string{"client_id": clientID},
+				},
+			},
+		},
+	}
+}
+
+func TestParseWaitParam(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected time.Duration
+		wantErr  bool
+	}{
+		{"empty means no wait", "", 0, false},
+		{"duration string", "30s", 30 * time.Second, false},
+		{"compound duration", "1m30s", 90 * time.Second, false},
+		{"bare seconds", "15", 15 * time.Second, false},
+		{"fractional seconds", "0.5", 500 * time.Millisecond, false},
+		{"negative clamps to zero", "-5s", 0, false},
+		{"over the cap is clamped", "10m", maxTelemetryWait, false},
+		{"garbage is rejected", "soon", 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseWaitParam(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestCommandReplyPayload(t *testing.T) {
+	t.Run("pending when there is no reply", func(t *testing.T) {
+		body := commandReplyPayload("cmd-1", "client-1", nil, 0)
+
+		assert.Equal(t, replyStatusPending, body["status"])
+		assert.Equal(t, "cmd-1", body["command_id"])
+		assert.Equal(t, "client-1", body["client_id"])
+		assert.NotContains(t, body, "reply")
+		assert.Contains(t, body, "message")
+	})
+
+	t.Run("done when a reply exists", func(t *testing.T) {
+		reply := &CommandReply{CommandID: "cmd-1", Success: true}
+		body := commandReplyPayload("cmd-1", "client-1", reply, 250*time.Millisecond)
+
+		assert.Equal(t, replyStatusDone, body["status"])
+		assert.Equal(t, reply, body["reply"])
+		assert.Equal(t, int64(250), body["waited_ms"])
+	})
+
+	t.Run("omits client id when unknown", func(t *testing.T) {
+		assert.NotContains(t, commandReplyPayload("cmd-1", "", nil, 0), "client_id")
+	})
+}
+
+func TestGetTelemetryCommandReplyHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newCtx := func(url string, commandID string) (*httptest.ResponseRecorder, *gin.Context) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest("GET", url, nil)
+		c.Params = gin.Params{{Key: "commandId", Value: commandID}}
+		return w, c
+	}
+
+	t.Run("nil node returns error", func(t *testing.T) {
+		w, c := newCtx("/", "cmd-1")
+		getTelemetryCommandReply(nil)(c)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("missing command id is rejected", func(t *testing.T) {
+		w, c := newCtx("/", "")
+		getTelemetryCommandReply(&Proxy{})(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("invalid wait is rejected", func(t *testing.T) {
+		w, c := newCtx("/?wait=whenever", "cmd-1")
+		getTelemetryCommandReply(&Proxy{})(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns the reply when the client has answered", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespWithReply("client-1", "cmd-1", true, `{"telemetry_enabled":true}`), nil)
+
+		w, c := newCtx("/?client_id=client-1", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusDone, body["status"])
+		assert.Equal(t, "client-1", body["client_id"])
+
+		reply := body["reply"].(map[string]interface{})
+		assert.Equal(t, "cmd-1", reply["command_id"])
+		assert.Equal(t, true, reply["success"])
+		assert.Equal(t, `{"telemetry_enabled":true}`, reply["payload"])
+	})
+
+	t.Run("pending is a 200, not an error", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespNoReply("client-1"), nil)
+
+		w, c := newCtx("/?client_id=client-1", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusPending, body["status"])
+		assert.NotContains(t, body, "reply")
+	})
+
+	t.Run("a reply for a different command is not matched", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespWithReply("client-1", "some-other-command", true, "{}"), nil)
+
+		w, c := newCtx("/", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusPending, body["status"])
+	})
+
+	t.Run("client_id turns the lookup into a targeted one", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		// Metrics must not be requested: replies are populated regardless, and pulling
+		// metrics would make polling far more expensive than it needs to be.
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.MatchedBy(
+			func(req *milvuspb.GetClientTelemetryRequest) bool {
+				return req.ClientId == "client-9" && !req.IncludeMetrics
+			})).Return(telemetryRespWithReply("client-9", "cmd-1", true, "{}"), nil)
+
+		w, c := newCtx("/?client_id=client-9", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("wait polls until the reply lands", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		// First look finds nothing; the client answers before the second.
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespNoReply("client-1"), nil).Once()
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespWithReply("client-1", "cmd-1", true, "{}"), nil).Once()
+
+		w, c := newCtx("/?client_id=client-1&wait=5s", "cmd-1")
+
+		start := time.Now()
+		getTelemetryCommandReply(proxy)(c)
+		elapsed := time.Since(start)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusDone, body["status"], "should have picked up the reply on the second poll")
+		assert.GreaterOrEqual(t, elapsed, telemetryReplyPollInterval, "must have actually waited a poll cycle")
+		assert.Less(t, elapsed, 5*time.Second, "must return as soon as the reply lands, not burn the full budget")
+	})
+
+	t.Run("wait gives up and reports pending", func(t *testing.T) {
+		mixCoord := mocks.NewMockMixCoordClient(t)
+		proxy := &Proxy{mixCoord: mixCoord}
+		proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+			Return(telemetryRespNoReply("client-1"), nil)
+
+		w, c := newCtx("/?client_id=client-1&wait=600ms", "cmd-1")
+		getTelemetryCommandReply(proxy)(c)
+
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, replyStatusPending, body["status"], "timing out must not be reported as an error")
+	})
+}
+
+func TestWaitForCommandReplyRespectsCancellation(t *testing.T) {
+	mixCoord := mocks.NewMockMixCoordClient(t)
+	proxy := &Proxy{mixCoord: mixCoord}
+	proxy.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	mixCoord.EXPECT().GetClientTelemetry(mock.Anything, mock.Anything).
+		Return(telemetryRespNoReply("client-1"), nil)
+
+	// A caller that hangs up mid-wait must unblock promptly, well before the budget.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	reply, _, err := waitForCommandReply(ctx, proxy, "client-1", "cmd-1", 30*time.Second)
+
+	assert.NoError(t, err, "cancellation is not a lookup failure")
+	assert.Nil(t, reply)
+	assert.Less(t, time.Since(start), 5*time.Second)
+}

--- a/internal/proxy/telemetry_http_handler.go
+++ b/internal/proxy/telemetry_http_handler.go
@@ -307,7 +307,7 @@ func getTelemetryClientMetrics(node *Proxy) gin.HandlerFunc {
 //	  "target_client_id": "client-123" or "" for global,
 //	  "target_database": "db_name" or "" for global (mutually exclusive with target_client_id),
 //	  "payload": {...},
-//	  "ttl_seconds": 3600,
+//	  "ttl_seconds": 3600,   // optional; omit for the default (10 heartbeat cycles), negative to never expire
 //	  "persistent": false
 //	}
 func postTelemetryCommand(node *Proxy) gin.HandlerFunc {
@@ -520,7 +520,7 @@ func getTelemetryClientHistory(node *Proxy) gin.HandlerFunc {
 			CommandType:    "show_latency_history",
 			TargetClientId: clientID,
 			Payload:        payloadBytes,
-			TtlSeconds:     0, // Keep until client replies; server deletes on reply
+			TtlSeconds:     0, // Unset: the store applies the default TTL. Deleted earlier if the client replies.
 			Persistent:     false,
 		}
 
@@ -580,7 +580,7 @@ func getTelemetryClientConfig(node *Proxy) gin.HandlerFunc {
 		pushReq := &milvuspb.PushClientCommandRequest{
 			CommandType:    "get_config",
 			TargetClientId: clientID,
-			TtlSeconds:     0, // Keep until client replies; server deletes on reply
+			TtlSeconds:     0, // Unset: the store applies the default TTL. Deleted earlier if the client replies.
 			Persistent:     false,
 		}
 

--- a/internal/proxy/telemetry_http_handler.go
+++ b/internal/proxy/telemetry_http_handler.go
@@ -305,7 +305,9 @@ func getTelemetryClientMetrics(node *Proxy) gin.HandlerFunc {
 //	{
 //	  "command_type": "show_errors|collection_metrics|debug_log|push_config",
 //	  "target_client_id": "client-123" or "" for global,
-//	  "target_database": "db_name" or "" for global (mutually exclusive with target_client_id),
+//	  "target_database": "db_name" or "" for global,
+//	  "target_label": "key=value" to target a workload; durable across client restarts,
+//	  // the three target fields are mutually exclusive
 //	  "payload": {...},
 //	  "ttl_seconds": 3600,   // optional; omit for the default (10 heartbeat cycles), negative to never expire
 //	  "persistent": false
@@ -334,6 +336,7 @@ func postTelemetryCommand(node *Proxy) gin.HandlerFunc {
 			CommandType    string          `json:"command_type"`
 			TargetClientID string          `json:"target_client_id"`
 			TargetDatabase string          `json:"target_database"`
+			TargetLabel    string          `json:"target_label"`
 			Payload        json.RawMessage `json:"payload"`
 			TTLSeconds     int64           `json:"ttl_seconds"`
 			Persistent     bool            `json:"persistent"`
@@ -376,6 +379,7 @@ func postTelemetryCommand(node *Proxy) gin.HandlerFunc {
 			CommandType:    cmdReq.CommandType,
 			TargetClientId: cmdReq.TargetClientID,
 			TargetDatabase: cmdReq.TargetDatabase,
+			TargetLabel:    cmdReq.TargetLabel,
 			Payload:        payloadBytes,
 			TtlSeconds:     cmdReq.TTLSeconds,
 			Persistent:     cmdReq.Persistent,

--- a/internal/proxy/telemetry_http_handler.go
+++ b/internal/proxy/telemetry_http_handler.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -149,6 +150,103 @@ func getTelemetryClients(node *Proxy) gin.HandlerFunc {
 		// Convert to API response format
 		wrapped := ConvertClientTelemetryResponse(resp)
 		c.JSON(http.StatusOK, wrapped)
+	}
+}
+
+// respondToPushedCommand finishes an endpoint that just pushed a command to one client.
+//
+// With wait <= 0 it returns the command ID straight away and the caller collects the reply
+// later from the command-reply endpoint. With wait > 0 it blocks until the client answers
+// or the budget runs out, so a caller gets the result from a single request.
+//
+// Either way the body has the same shape, so callers do not need to special-case the two
+// modes: check "status", and read "reply" when it is "done".
+func respondToPushedCommand(c *gin.Context, node *Proxy, clientID, commandID string, wait time.Duration) {
+	if wait <= 0 {
+		c.JSON(http.StatusOK, commandReplyPayload(commandID, clientID, nil, 0))
+		return
+	}
+
+	start := time.Now()
+	reply, replyClientID, err := waitForCommandReply(c.Request.Context(), node, clientID, commandID, wait)
+	if err != nil {
+		mlog.Warn(c.Request.Context(), "respondToPushedCommand: failed to wait for reply",
+			mlog.Err(err),
+			mlog.String("command_id", commandID),
+			mlog.String("client_id", clientID))
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	if replyClientID == "" {
+		replyClientID = clientID
+	}
+	c.JSON(http.StatusOK, commandReplyPayload(commandID, replyClientID, reply, time.Since(start)))
+}
+
+// getTelemetryCommandReply returns a client's reply to a previously pushed command.
+//
+// Commands are answered asynchronously, on the client's next heartbeat, so a caller that
+// pushed a command needs a way to collect the result. Without this endpoint the only way
+// was to list every client and scan the command_replies array by hand.
+//
+// URL param: commandId
+// Query params:
+//   - client_id: the client the command was sent to. Optional, but supplying it turns a
+//     scan of all clients into a targeted lookup.
+//   - wait: block up to this long for the reply (e.g. "30s"). Default is to return
+//     immediately with whatever is known.
+//
+// Always 200 on a successful lookup; branch on the "status" field ("done" or "pending").
+// "pending" is a normal state, not an error: the reply may still be in flight, and replies
+// are also evicted once a client accumulates more than 50 of them.
+func getTelemetryCommandReply(node *Proxy) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		if node == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "proxy node not initialized",
+			})
+			return
+		}
+
+		commandID := c.Param("commandId")
+		if commandID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "commandId parameter is required",
+			})
+			return
+		}
+
+		wait, err := parseWaitParam(c.Query("wait"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		clientID := c.Query("client_id")
+
+		start := time.Now()
+		reply, replyClientID, err := waitForCommandReply(ctx, node, clientID, commandID, wait)
+		if err != nil {
+			mlog.Warn(ctx, "getTelemetryCommandReply: failed to look up reply",
+				mlog.Err(err),
+				mlog.String("command_id", commandID))
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		if replyClientID == "" {
+			replyClientID = clientID
+		}
+		c.JSON(http.StatusOK, commandReplyPayload(commandID, replyClientID, reply, time.Since(start)))
 	}
 }
 
@@ -395,6 +493,14 @@ func getTelemetryClientHistory(node *Proxy) gin.HandlerFunc {
 			return
 		}
 
+		wait, err := parseWaitParam(c.Query("wait"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
 		// Build the payload for show_latency_history command
 		payload := map[string]interface{}{
 			"start_time": startTime,
@@ -436,13 +542,7 @@ func getTelemetryClientHistory(node *Proxy) gin.HandlerFunc {
 			return
 		}
 
-		// Return the command ID - client will need to poll for results
-		// via the command reply in the next heartbeat
-		c.JSON(http.StatusOK, gin.H{
-			"command_id": resp.CommandId,
-			"status":     "pending",
-			"message":    "Command sent to client. Results will be available in the client's next heartbeat response.",
-		})
+		respondToPushedCommand(c, node, clientID, resp.CommandId, wait)
 	}
 }
 
@@ -464,6 +564,14 @@ func getTelemetryClientConfig(node *Proxy) gin.HandlerFunc {
 		if clientID == "" {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": "client_id parameter is required",
+			})
+			return
+		}
+
+		wait, err := parseWaitParam(c.Query("wait"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": err.Error(),
 			})
 			return
 		}
@@ -494,11 +602,6 @@ func getTelemetryClientConfig(node *Proxy) gin.HandlerFunc {
 			return
 		}
 
-		// Return the command ID - client will respond with config in next heartbeat
-		c.JSON(http.StatusOK, gin.H{
-			"command_id": resp.CommandId,
-			"status":     "pending",
-			"message":    "Command sent to client. Config will be available in the client's command reply.",
-		})
+		respondToPushedCommand(c, node, clientID, resp.CommandId, wait)
 	}
 }

--- a/internal/rootcoord/telemetry/command_store.go
+++ b/internal/rootcoord/telemetry/command_store.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -210,6 +211,8 @@ func (s *CommandStore) loadCache() {
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()
 
+	stale := 0
+
 	// Load configs
 	if resp, err := s.kv.Get(ctx, s.configPath, clientv3.WithPrefix()); err != nil {
 		mlog.Warn(ctx, "loadCache: failed to load configs", mlog.Err(err))
@@ -222,6 +225,21 @@ func (s *CommandStore) loadCache() {
 					mlog.String("key", string(kv.Key)))
 				continue
 			}
+			// Client-scoped configs are no longer accepted, and any that survive from
+			// before that rule are dead weight: their target client ID belongs to a
+			// process that is long gone and will never reappear under the same ID.
+			// Dropping them here doubles as the migration and as the cleanup for
+			// whatever already accumulated.
+			if strings.HasPrefix(cfg.TargetScope, "client:") {
+				if err := s.kv.Delete(ctx, string(kv.Key)); err != nil {
+					mlog.Warn(ctx, "loadCache: failed to drop stale client-scoped config",
+						mlog.Err(err),
+						mlog.String("key", string(kv.Key)))
+					// Leave it out of the cache regardless; it can never match a client.
+				}
+				stale++
+				continue
+			}
 			s.cache.configs[cfg.ConfigID] = &cfg
 		}
 	}
@@ -229,6 +247,10 @@ func (s *CommandStore) loadCache() {
 	// Calculate config hash
 	s.cache.configHash = s.computeConfigHash()
 
+	if stale > 0 {
+		mlog.Info(ctx, "loadCache: dropped stale client-scoped configs",
+			mlog.Int("dropped", stale))
+	}
 	mlog.Info(ctx, "loadCache: completed",
 		mlog.Int("commands", len(s.cache.commands)),
 		mlog.Int("configs", len(s.cache.configs)))
@@ -241,6 +263,19 @@ func (s *CommandStore) PushCommand(ctx context.Context, req *milvuspb.PushClient
 	if req.Persistent && req.CommandType != "push_config" {
 		return "", merr.WrapErrParameterInvalid("push_config", req.CommandType,
 			"only push_config can be persistent")
+	}
+
+	// A client-scoped config must not be persistent. `client:<id>` names a running
+	// process, and client IDs are per-process: the SDK generates a fresh one on every
+	// start. A config that outlives the process it names can never match anything again,
+	// so it would sit in etcd forever while the operator believes the setting is in
+	// effect. Persistence is for scopes that outlive processes.
+	if req.Persistent && req.TargetClientId != "" {
+		return "", merr.WrapErrParameterInvalidMsg(
+			"a client-scoped config cannot be persistent: client IDs do not survive a client " +
+				"restart, so the config would never apply again. Push it as a one-time command " +
+				"(persistent=false) to configure the running client, or target a database or " +
+				"global scope for a setting that should outlive it")
 	}
 
 	cmdID := uuid.New().String()

--- a/internal/rootcoord/telemetry/command_store.go
+++ b/internal/rootcoord/telemetry/command_store.go
@@ -106,6 +106,35 @@ func (w *etcdKVWrapper) Delete(ctx context.Context, key string, opts ...clientv3
 	return err
 }
 
+const (
+	// defaultHeartbeatIntervalSeconds mirrors the SDK's default heartbeat interval
+	// (client/milvusclient/telemetry.go). The server cannot know a given client's actual
+	// interval -- it is client-side config that the server may or may not have overridden
+	// -- so command lifetimes are expressed against this nominal value.
+	defaultHeartbeatIntervalSeconds = 30
+
+	// defaultCommandTTLSeconds is how long an unspecified-TTL one-time command survives:
+	// ten heartbeat cycles. A command that has not been collected within ten chances is
+	// not going to be, and keeping it forever leaks memory for every client that was
+	// restarted, crashed, or otherwise never came back to answer.
+	//
+	// Applied when a caller leaves ttl_seconds unset. A negative ttl_seconds still means
+	// "never expire" for the rare caller that genuinely wants that.
+	defaultCommandTTLSeconds = 10 * defaultHeartbeatIntervalSeconds
+)
+
+// resolveCommandTTL maps a requested TTL onto the value stored with the command.
+//
+//	0  -> unspecified, use the default
+//	<0 -> never expire (explicit opt-in; every expiry check treats <=0 as immortal)
+//	>0 -> honor the caller
+func resolveCommandTTL(requested int64) int64 {
+	if requested == 0 {
+		return defaultCommandTTLSeconds
+	}
+	return requested
+}
+
 // cache holds in-memory cache of all commands and configs
 // Loaded at initialization and kept in sync with etcd on writes
 type cache struct {
@@ -278,7 +307,9 @@ func (s *CommandStore) PushCommand(ctx context.Context, req *milvuspb.PushClient
 			Payload:     req.Payload,
 			CreateTime:  createTime,
 			TargetScope: scope,
-			TTLSeconds:  req.TtlSeconds,
+			// Resolved once, at push time, so every downstream expiry check and the
+			// remaining-time shown in the WebUI operate on the effective value.
+			TTLSeconds: resolveCommandTTL(req.TtlSeconds),
 		}
 		// Update cache
 		s.cacheMu.Lock()

--- a/internal/rootcoord/telemetry/command_store.go
+++ b/internal/rootcoord/telemetry/command_store.go
@@ -108,6 +108,16 @@ func (w *etcdKVWrapper) Delete(ctx context.Context, key string, opts ...clientv3
 }
 
 const (
+	// labelScopePrefix marks a target scope that selects clients by a declared label,
+	// written as "label:<key>=<value>".
+	labelScopePrefix = "label:"
+
+	// labelReservedPrefix is how a client publishes a label in ClientInfo.Reserved:
+	// Reserved["label.app"] = "ingest-worker" declares app=ingest-worker.
+	labelReservedPrefix = "label."
+)
+
+const (
 	// defaultHeartbeatIntervalSeconds mirrors the SDK's default heartbeat interval
 	// (client/milvusclient/telemetry.go). The server cannot know a given client's actual
 	// interval -- it is client-side config that the server may or may not have overridden
@@ -123,6 +133,37 @@ const (
 	// "never expire" for the rare caller that genuinely wants that.
 	defaultCommandTTLSeconds = 10 * defaultHeartbeatIntervalSeconds
 )
+
+// resolveTargetScope turns the targeting fields of a push request into the scope string
+// stored with the command.
+//
+// Scopes differ in lifetime, which is what decides whether a config may be persistent:
+//
+//	global            durable   -- every client
+//	database:<db>     durable   -- clients that have accessed the database
+//	label:<k>=<v>     durable   -- clients declaring the label; names a workload
+//	client:<id>       ephemeral -- one process; the ID dies with it
+//
+// Setting more than one target field is resolved by precedence rather than rejected, which
+// is the behavior callers have always had: most specific wins, so client beats label beats
+// database. No target set means global.
+func resolveTargetScope(req *milvuspb.PushClientCommandRequest) (string, error) {
+	switch {
+	case req.GetTargetClientId() != "":
+		return "client:" + req.GetTargetClientId(), nil
+	case req.GetTargetLabel() != "":
+		key, value, ok := strings.Cut(req.GetTargetLabel(), "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			return "", merr.WrapErrParameterInvalid("key=value", req.GetTargetLabel(),
+				"target_label must be of the form key=value")
+		}
+		return labelScopePrefix + strings.TrimSpace(key) + "=" + strings.TrimSpace(value), nil
+	case req.GetTargetDatabase() != "":
+		return "database:" + req.GetTargetDatabase(), nil
+	default:
+		return "global", nil
+	}
+}
 
 // resolveCommandTTL maps a requested TTL onto the value stored with the command.
 //
@@ -278,13 +319,12 @@ func (s *CommandStore) PushCommand(ctx context.Context, req *milvuspb.PushClient
 				"global scope for a setting that should outlive it")
 	}
 
-	cmdID := uuid.New().String()
-	scope := "global"
-	if req.TargetClientId != "" {
-		scope = "client:" + req.TargetClientId
-	} else if req.TargetDatabase != "" {
-		scope = "database:" + req.TargetDatabase
+	scope, err := resolveTargetScope(req)
+	if err != nil {
+		return "", err
 	}
+
+	cmdID := uuid.New().String()
 	createTime := time.Now().UnixMilli()
 
 	if req.Persistent {

--- a/internal/rootcoord/telemetry/command_store_test.go
+++ b/internal/rootcoord/telemetry/command_store_test.go
@@ -1061,3 +1061,87 @@ func TestListCommandsWithInfoEdgeCases(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveCommandTTL(t *testing.T) {
+	cases := []struct {
+		name      string
+		requested int64
+		expected  int64
+	}{
+		{"unset gets the default", 0, defaultCommandTTLSeconds},
+		{"explicit value is honored", 3600, 3600},
+		{"negative means never expire", -1, -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, resolveCommandTTL(tc.requested))
+		})
+	}
+
+	// Ten heartbeat cycles at the nominal interval; a command nobody collected in that
+	// many chances is not going to be collected.
+	assert.Equal(t, int64(300), int64(defaultCommandTTLSeconds))
+}
+
+func TestPushCommandAppliesDefaultTTL(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("one-time command with unset ttl expires", func(t *testing.T) {
+		store := NewCommandStoreWithKV(newMockKV(), "/test/")
+
+		id, err := store.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+			CommandType:    "show_errors",
+			TargetClientId: "client-1",
+			TtlSeconds:     0,
+		})
+		require.NoError(t, err)
+
+		store.cacheMu.RLock()
+		cmd := store.cache.commands[id]
+		store.cacheMu.RUnlock()
+
+		require.NotNil(t, cmd)
+		assert.Equal(t, int64(defaultCommandTTLSeconds), cmd.TTLSeconds,
+			"an uncollected command must not live forever")
+	})
+
+	t.Run("negative ttl still means never expire", func(t *testing.T) {
+		store := NewCommandStoreWithKV(newMockKV(), "/test/")
+
+		id, err := store.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+			CommandType: "show_errors",
+			TtlSeconds:  -1,
+		})
+		require.NoError(t, err)
+
+		store.cacheMu.RLock()
+		cmd := store.cache.commands[id]
+		store.cacheMu.RUnlock()
+
+		require.NotNil(t, cmd)
+		assert.Equal(t, int64(-1), cmd.TTLSeconds)
+	})
+
+	t.Run("expired default-ttl command is swept", func(t *testing.T) {
+		store := NewCommandStoreWithKV(newMockKV(), "/test/")
+
+		id, err := store.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+			CommandType: "show_errors",
+			TtlSeconds:  0,
+		})
+		require.NoError(t, err)
+
+		// Backdate past the default TTL, as if the client never answered.
+		store.cacheMu.Lock()
+		store.cache.commands[id].CreateTime = time.Now().UnixMilli() - (defaultCommandTTLSeconds+1)*1000
+		store.cacheMu.Unlock()
+
+		store.CleanupExpiredCommands(ctx)
+
+		store.cacheMu.RLock()
+		_, stillThere := store.cache.commands[id]
+		store.cacheMu.RUnlock()
+		assert.False(t, stillThere, "default TTL must actually reclaim the command")
+	})
+}

--- a/internal/rootcoord/telemetry/command_store_test.go
+++ b/internal/rootcoord/telemetry/command_store_test.go
@@ -1241,3 +1241,84 @@ func TestLoadCacheDropsStaleClientScopedConfigs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), resp.Count, "the stale config must be deleted from etcd, not just skipped")
 }
+
+func TestResolveTargetScope(t *testing.T) {
+	cases := []struct {
+		name    string
+		req     *milvuspb.PushClientCommandRequest
+		want    string
+		wantErr string
+	}{
+		{"no target is global", &milvuspb.PushClientCommandRequest{}, "global", ""},
+		{"client", &milvuspb.PushClientCommandRequest{TargetClientId: "c1"}, "client:c1", ""},
+		{"database", &milvuspb.PushClientCommandRequest{TargetDatabase: "db1"}, "database:db1", ""},
+		{"label", &milvuspb.PushClientCommandRequest{TargetLabel: "app=ingest"}, "label:app=ingest", ""},
+		{"label is trimmed", &milvuspb.PushClientCommandRequest{TargetLabel: " app = ingest "}, "label:app=ingest", ""},
+		{"label with empty value", &milvuspb.PushClientCommandRequest{TargetLabel: "app="}, "label:app=", ""},
+		{"label without =", &milvuspb.PushClientCommandRequest{TargetLabel: "app"}, "", "key=value"},
+		{"label with empty key", &milvuspb.PushClientCommandRequest{TargetLabel: "=ingest"}, "", "key=value"},
+		{"label wins over database", &milvuspb.PushClientCommandRequest{TargetLabel: "app=ingest", TargetDatabase: "db1"}, "label:app=ingest", ""},
+		{
+			"client wins over label",
+			&milvuspb.PushClientCommandRequest{TargetClientId: "c1", TargetLabel: "app=ingest"},
+			"client:c1", "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveTargetScope(tc.req)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestLabelScopedConfigMayBePersistent is the point of the label scope: it is durable, so
+// unlike a client scope it is a legitimate target for config that must survive restarts.
+func TestLabelScopedConfigMayBePersistent(t *testing.T) {
+	ctx := context.Background()
+	store := NewCommandStoreWithKV(newMockKV(), "/test/")
+
+	_, err := store.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+		CommandType: "push_config",
+		TargetLabel: "app=ingest",
+		Payload:     []byte(`{"sampling_rate":0.1}`),
+		Persistent:  true,
+	})
+	require.NoError(t, err)
+
+	configs, _, err := store.ListConfigs(ctx)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
+	assert.Equal(t, "label:app=ingest", configs[0].TargetScope)
+}
+
+// TestLabelScopedConfigSurvivesReload is the restart behavior that a client-scoped config
+// could never provide: the config is still there, and still addressable, afterwards.
+func TestLabelScopedConfigSurvivesReload(t *testing.T) {
+	ctx := context.Background()
+	sharedKV := newMockKV()
+
+	store1 := NewCommandStoreWithKV(sharedKV, "/test/")
+	_, err := store1.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+		CommandType: "push_config",
+		TargetLabel: "app=ingest",
+		Payload:     []byte(`{"sampling_rate":0.1}`),
+		Persistent:  true,
+	})
+	require.NoError(t, err)
+
+	// Simulate a RootCoord restart.
+	store2 := NewCommandStoreWithKV(sharedKV, "/test/")
+
+	configs, _, err := store2.ListConfigs(ctx)
+	require.NoError(t, err)
+	require.Len(t, configs, 1, "a label-scoped config must survive reload")
+	assert.Equal(t, "label:app=ingest", configs[0].TargetScope)
+}

--- a/internal/rootcoord/telemetry/command_store_test.go
+++ b/internal/rootcoord/telemetry/command_store_test.go
@@ -377,12 +377,12 @@ func TestConfigHashConsistency(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, hash1)
 
-	// Add a config for client1 (scope: client:client1)
+	// Add a config for db1 (scope: database:db1)
 	cfgID1, _ := store.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
 		CommandType:    "push_config",
 		Payload:        []byte(`{"a": 1}`),
 		Persistent:     true,
-		TargetClientId: "client1",
+		TargetDatabase: "db1",
 	})
 
 	_, hash2, err := store.ListConfigs(ctx)
@@ -399,7 +399,7 @@ func TestConfigHashConsistency(t *testing.T) {
 		CommandType:    "push_config",
 		Payload:        []byte(`{"b": 2}`),
 		Persistent:     true,
-		TargetClientId: "client2",
+		TargetDatabase: "db2",
 	})
 
 	_, hash4, _ := store.ListConfigs(ctx)
@@ -486,13 +486,13 @@ func TestRestartBehavior_MultipleConfigs(t *testing.T) {
 		CommandType:    "push_config",
 		Payload:        []byte(`{"setting": "value1"}`),
 		Persistent:     true,
-		TargetClientId: "client1",
+		TargetDatabase: "db1",
 	})
 	cfgID2, _ := store1.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
 		CommandType:    "push_config",
 		Payload:        []byte(`{"setting": "value2"}`),
 		Persistent:     true,
-		TargetClientId: "client2",
+		TargetDatabase: "db2",
 	})
 
 	_, hash1, _ := store1.ListConfigs(ctx)
@@ -666,7 +666,7 @@ func TestPayloadPreservation(t *testing.T) {
 			CommandType:    "push_config",
 			Payload:        payload,
 			Persistent:     true,
-			TargetClientId: fmt.Sprintf("client%d", i),
+			TargetDatabase: fmt.Sprintf("db%d", i),
 		})
 		require.NoError(t, err, "failed for payload %d", i)
 	}
@@ -1144,4 +1144,100 @@ func TestPushCommandAppliesDefaultTTL(t *testing.T) {
 		store.cacheMu.RUnlock()
 		assert.False(t, stillThere, "default TTL must actually reclaim the command")
 	})
+}
+
+func TestClientScopedConfigCannotBePersistent(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("rejected", func(t *testing.T) {
+		store := NewCommandStoreWithKV(newMockKV(), "/test/")
+
+		_, err := store.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+			CommandType:    "push_config",
+			TargetClientId: "client-1",
+			Payload:        []byte(`{"sampling_rate":0.1}`),
+			Persistent:     true,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client-scoped config cannot be persistent")
+	})
+
+	t.Run("same config is fine as a one-time command", func(t *testing.T) {
+		store := NewCommandStoreWithKV(newMockKV(), "/test/")
+
+		id, err := store.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+			CommandType:    "push_config",
+			TargetClientId: "client-1",
+			Payload:        []byte(`{"sampling_rate":0.1}`),
+			Persistent:     false,
+		})
+
+		require.NoError(t, err)
+		store.cacheMu.RLock()
+		cmd := store.cache.commands[id]
+		store.cacheMu.RUnlock()
+		require.NotNil(t, cmd)
+		assert.Equal(t, "client:client-1", cmd.TargetScope)
+	})
+
+	t.Run("durable scopes still accept persistent configs", func(t *testing.T) {
+		store := NewCommandStoreWithKV(newMockKV(), "/test/")
+
+		_, err := store.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+			CommandType: "push_config",
+			Payload:     []byte(`{"sampling_rate":0.1}`),
+			Persistent:  true,
+		})
+		require.NoError(t, err, "global scope")
+
+		_, err = store.PushCommand(ctx, &milvuspb.PushClientCommandRequest{
+			CommandType:    "push_config",
+			TargetDatabase: "db1",
+			Payload:        []byte(`{"sampling_rate":0.2}`),
+			Persistent:     true,
+		})
+		require.NoError(t, err, "database scope")
+	})
+}
+
+// TestLoadCacheDropsStaleClientScopedConfigs covers the migration: configs written before
+// the rule above are unreachable -- their client ID names a process that is gone -- so they
+// must not be loaded, and must be removed from etcd rather than left to accumulate.
+func TestLoadCacheDropsStaleClientScopedConfigs(t *testing.T) {
+	kv := newMockKV()
+
+	staleKey := "/test/configs/stale-id"
+	stale, _ := json.Marshal(storedConfig{
+		ConfigID:    "stale-id",
+		ConfigType:  "push_config",
+		Payload:     []byte(`{"sampling_rate":0.1}`),
+		CreateTime:  time.Now().UnixMilli(),
+		TargetScope: "client:long-gone-uuid",
+	})
+	require.NoError(t, kv.Put(context.Background(), staleKey, string(stale)))
+
+	liveKey := "/test/configs/live-id"
+	live, _ := json.Marshal(storedConfig{
+		ConfigID:    "live-id",
+		ConfigType:  "push_config",
+		Payload:     []byte(`{"sampling_rate":0.5}`),
+		CreateTime:  time.Now().UnixMilli(),
+		TargetScope: "database:db1",
+	})
+	require.NoError(t, kv.Put(context.Background(), liveKey, string(live)))
+
+	store := NewCommandStoreWithKV(kv, "/test/")
+
+	store.cacheMu.RLock()
+	_, staleLoaded := store.cache.configs["stale-id"]
+	_, liveLoaded := store.cache.configs["live-id"]
+	store.cacheMu.RUnlock()
+
+	assert.False(t, staleLoaded, "an unreachable client-scoped config must not be loaded")
+	assert.True(t, liveLoaded, "durable-scope configs must survive the migration")
+
+	resp, err := kv.Get(context.Background(), staleKey)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.Count, "the stale config must be deleted from etcd, not just skipped")
 }

--- a/internal/rootcoord/telemetry/manager.go
+++ b/internal/rootcoord/telemetry/manager.go
@@ -607,7 +607,34 @@ func (m *TelemetryManager) matchesScope(scope, clientID string, info *commonpb.C
 		}
 		return false
 	}
+	if strings.HasPrefix(scope, labelScopePrefix) {
+		return matchesLabel(strings.TrimPrefix(scope, labelScopePrefix), info)
+	}
 	return false
+}
+
+// matchesLabel reports whether the client declared the "key=value" label in selector.
+//
+// Labels are read from ClientInfo.Reserved, where a client publishes them as
+// "label.<key>" entries. Unlike a client ID, a label names a workload rather than a
+// process, so it keeps matching after the client restarts -- which is what makes it a
+// valid target for persistent config.
+func matchesLabel(selector string, info *commonpb.ClientInfo) bool {
+	key, value, ok := strings.Cut(selector, "=")
+	if !ok {
+		return false
+	}
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if key == "" {
+		return false
+	}
+
+	declared, present := info.GetReserved()[labelReservedPrefix+key]
+	if !present {
+		return false
+	}
+	return declared == value
 }
 
 // computeClientConfigHash computes hash over configs that a specific client will receive

--- a/internal/rootcoord/telemetry/manager_test.go
+++ b/internal/rootcoord/telemetry/manager_test.go
@@ -3763,3 +3763,41 @@ func TestProcessCommandRepliesPayloadFormat(t *testing.T) {
 	assert.Contains(t, jsonStr, `"payload":"{\"user_config\"`)
 	assert.NotContains(t, jsonStr, "eyJ1c2VyX2NvbmZpZyI") // base64 prefix
 }
+
+func TestMatchesLabel(t *testing.T) {
+	info := &commonpb.ClientInfo{
+		Reserved: map[string]string{
+			"client_id":  "some-uuid",
+			"label.app":  "ingest-worker",
+			"label.env":  "prod",
+			"label.tier": "",
+		},
+	}
+
+	cases := []struct {
+		name     string
+		selector string
+		expected bool
+	}{
+		{"matching label", "app=ingest-worker", true},
+		{"second label", "env=prod", true},
+		{"wrong value", "app=query-worker", false},
+		{"unknown key", "region=us-east", false},
+		{"empty value matches empty label", "tier=", true},
+		{"empty value does not match a set label", "app=", false},
+		{"malformed selector", "app", false},
+		{"empty key", "=ingest-worker", false},
+		{"whitespace is trimmed", " app = ingest-worker ", true},
+		{"client_id is not a label", "client_id=some-uuid", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, matchesLabel(tc.selector, info))
+		})
+	}
+
+	t.Run("client with no labels matches nothing", func(t *testing.T) {
+		assert.False(t, matchesLabel("app=ingest-worker", &commonpb.ClientInfo{}))
+	})
+}

--- a/pkg/tracer/client_request_id_propagator.go
+++ b/pkg/tracer/client_request_id_propagator.go
@@ -29,12 +29,48 @@ const (
 	clientRequestIDKey       = "client_request_id"
 )
 
+// syntheticParentKey marks a context whose remote span context was synthesized from a
+// client_request_id header rather than extracted from a real upstream traceparent. The
+// value is the synthesized SpanID, so the sampler can tell that span context apart from
+// any other parent it might later be asked about.
+//
+// This is an in-process marker only: it is a context value, never a span-context field, so
+// it is not propagated to downstream components. Those receive a normal traceparent whose
+// sampled flag already reflects the decision made here.
+type syntheticParentKey struct{}
+
+// withSyntheticParent records that spanID was synthesized locally rather than propagated.
+func withSyntheticParent(ctx context.Context, spanID trace.SpanID) context.Context {
+	return context.WithValue(ctx, syntheticParentKey{}, spanID)
+}
+
+// hasSyntheticParent reports whether the parent span context in ctx is one this package
+// synthesized from a client_request_id.
+//
+// It re-checks the span context rather than trusting the marker alone: the marker stays in
+// the context for the whole request, so a child span started later in the same process
+// would otherwise be misidentified as having a synthetic parent and be re-sampled
+// independently of its real parent.
+func hasSyntheticParent(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	spanID, ok := ctx.Value(syntheticParentKey{}).(trace.SpanID)
+	if !ok {
+		return false
+	}
+	psc := trace.SpanContextFromContext(ctx)
+	return psc.IsRemote() && psc.SpanID() == spanID
+}
+
 type clientRequestIDPropagator struct{}
 
 func (clientRequestIDPropagator) Inject(_ context.Context, _ propagation.TextMapCarrier) {
 }
 
 func (clientRequestIDPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	// A real traceparent always wins. This propagator is composed after the W3C one, so a
+	// valid span context here means TraceContext already extracted an upstream decision.
 	if trace.SpanContextFromContext(ctx).IsValid() {
 		return ctx
 	}
@@ -48,6 +84,13 @@ func (clientRequestIDPropagator) Extract(ctx context.Context, carrier propagatio
 	if !spanID.IsValid() {
 		return ctx
 	}
+
+	// The synthesized context carries no sampled flag on purpose: a client must not be
+	// able to force sampling on. Instead it is marked as synthetic, and clientRequestIDSampler
+	// samples it as a root span so trace.sampleFraction governs the decision. Without that
+	// marker the ParentBased sampler would read "remote parent, not sampled" and drop the
+	// trace outright.
+	ctx = withSyntheticParent(ctx, spanID)
 
 	return trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID: traceID,

--- a/pkg/tracer/sampler.go
+++ b/pkg/tracer/sampler.go
@@ -1,0 +1,64 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	sdk "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// clientRequestIDSampler makes a client-supplied request ID seed the trace ID without also
+// acting as an upstream sampling decision.
+//
+// A client_request_id is turned into a remote span context by clientRequestIDPropagator so
+// that the resulting trace carries the caller's ID. That span context has no sampled flag,
+// because a client must not be able to switch sampling on. But ParentBased maps
+// "remote parent, not sampled" to NeverSample, so on its own that arrangement drops every
+// request carrying a client_request_id -- regardless of trace.sampleFraction, and for the
+// whole downstream call tree.
+//
+// This sampler restores the intended behavior: a synthetic parent is sampled as if the
+// span were a root, so trace.sampleFraction decides. Everything else, including a genuine
+// upstream traceparent that says sampled=0, is delegated to ParentBased and keeps standard
+// W3C semantics.
+type clientRequestIDSampler struct {
+	// root decides for spans whose parent was synthesized locally.
+	root sdk.Sampler
+	// delegate decides for every other span.
+	delegate sdk.Sampler
+}
+
+// newClientRequestIDSampler builds the sampler used by SetTracerProvider. root is applied
+// to synthetic parents and is also the root sampler of the ParentBased delegate, so both
+// paths use the same sampling ratio.
+func newClientRequestIDSampler(root sdk.Sampler) sdk.Sampler {
+	return clientRequestIDSampler{
+		root:     root,
+		delegate: sdk.ParentBased(root),
+	}
+}
+
+func (s clientRequestIDSampler) ShouldSample(p sdk.SamplingParameters) sdk.SamplingResult {
+	if hasSyntheticParent(p.ParentContext) {
+		// Not a real upstream decision -- decide as a root span would.
+		return s.root.ShouldSample(p)
+	}
+	return s.delegate.ShouldSample(p)
+}
+
+func (s clientRequestIDSampler) Description() string {
+	return "ClientRequestIDSampler{" + s.delegate.Description() + "}"
+}

--- a/pkg/tracer/sampler_test.go
+++ b/pkg/tracer/sampler_test.go
@@ -1,0 +1,200 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	sdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	testClientTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	testUpstreamSpan  = "00f067aa0ba902b7"
+)
+
+// serverPropagator mirrors the composition used by getServerHandlerOpts.
+func serverPropagator() propagation.TextMapPropagator {
+	return propagation.NewCompositeTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}),
+		clientRequestIDPropagator{},
+	)
+}
+
+// startServerSpan extracts headers the way the gRPC server stats handler does, then starts
+// the span that handler would start, and reports the resulting span context.
+func startServerSpan(t *testing.T, headers map[string]string, ratio float64) trace.SpanContext {
+	t.Helper()
+
+	tp := sdk.NewTracerProvider(sdk.WithSampler(newClientRequestIDSampler(sdk.TraceIDRatioBased(ratio))))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	ctx := serverPropagator().Extract(context.Background(), propagation.MapCarrier(headers))
+	_, span := tp.Tracer("test").Start(ctx, "server-rpc")
+	defer span.End()
+
+	return span.SpanContext()
+}
+
+// TestClientRequestIDIsSampledByRatio is the regression test for client_request_id
+// suppressing tracing: the synthesized parent carries no sampled flag, so a plain
+// ParentBased sampler mapped it to NeverSample and dropped the trace no matter what
+// trace.sampleFraction said.
+func TestClientRequestIDIsSampledByRatio(t *testing.T) {
+	t.Run("sampled when fraction is 1.0", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{clientRequestIDKey: testClientTraceID}, 1.0)
+
+		assert.True(t, sc.IsSampled(), "client_request_id must not opt the request out of sampling")
+		assert.Equal(t, testClientTraceID, sc.TraceID().String(), "trace must adopt the client supplied id")
+	})
+
+	t.Run("not sampled when fraction is 0.0", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{clientRequestIDKey: testClientTraceID}, 0.0)
+
+		assert.False(t, sc.IsSampled(), "the configured ratio must still govern")
+		assert.Equal(t, testClientTraceID, sc.TraceID().String())
+	})
+
+	t.Run("legacy header behaves the same", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{clientRequestIDKeyLegacy: testClientTraceID}, 1.0)
+
+		assert.True(t, sc.IsSampled())
+		assert.Equal(t, testClientTraceID, sc.TraceID().String())
+	})
+}
+
+// TestTraceparentKeepsW3CSemantics guards the other half: a real upstream decision must be
+// honored exactly, never overridden by the ratio.
+func TestTraceparentKeepsW3CSemantics(t *testing.T) {
+	t.Run("upstream sampled wins over ratio 0.0", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{
+			"traceparent": "00-" + testClientTraceID + "-" + testUpstreamSpan + "-01",
+		}, 0.0)
+
+		assert.True(t, sc.IsSampled(), "an upstream sampled=1 must be honored")
+		assert.Equal(t, testClientTraceID, sc.TraceID().String())
+	})
+
+	t.Run("upstream not sampled wins over ratio 1.0", func(t *testing.T) {
+		sc := startServerSpan(t, map[string]string{
+			"traceparent": "00-" + testClientTraceID + "-" + testUpstreamSpan + "-00",
+		}, 1.0)
+
+		assert.False(t, sc.IsSampled(), "an upstream sampled=0 must not be re-sampled")
+	})
+}
+
+// TestTraceparentWinsOverClientRequestID pins the propagator ordering. Both headers present
+// must resolve to the upstream decision, not the synthesized one.
+func TestTraceparentWinsOverClientRequestID(t *testing.T) {
+	otherTraceID := "0af7651916cd43dd8448eb211c80319c"
+
+	sc := startServerSpan(t, map[string]string{
+		"traceparent":      "00-" + otherTraceID + "-" + testUpstreamSpan + "-00",
+		clientRequestIDKey: testClientTraceID,
+	}, 1.0)
+
+	assert.Equal(t, otherTraceID, sc.TraceID().String(), "traceparent must win")
+	assert.False(t, sc.IsSampled(), "and its sampling decision must be preserved")
+}
+
+func TestNoHeadersFallsBackToRatio(t *testing.T) {
+	assert.True(t, startServerSpan(t, nil, 1.0).IsSampled())
+	assert.False(t, startServerSpan(t, nil, 0.0).IsSampled())
+}
+
+// TestHasSyntheticParent covers the guard that keeps the marker from leaking onto child
+// spans. The marker lives in the context for the whole request, so without the span-ID
+// check an in-process child would be re-sampled as a root and could disagree with its
+// parent, splitting the trace.
+func TestHasSyntheticParent(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex(testClientTraceID)
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex(testUpstreamSpan)
+	require.NoError(t, err)
+
+	t.Run("nil context", func(t *testing.T) {
+		//nolint:staticcheck // SA1012: exercising the nil guard is the point of this case
+		assert.False(t, hasSyntheticParent(nil))
+	})
+
+	t.Run("no marker", func(t *testing.T) {
+		assert.False(t, hasSyntheticParent(context.Background()))
+	})
+
+	t.Run("marker matching the remote parent", func(t *testing.T) {
+		ctx := withSyntheticParent(context.Background(), spanID)
+		ctx = trace.ContextWithRemoteSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  spanID,
+			Remote:  true,
+		}))
+
+		assert.True(t, hasSyntheticParent(ctx))
+	})
+
+	t.Run("marker present but parent is a local child span", func(t *testing.T) {
+		localSpanID, err := trace.SpanIDFromHex("1112131415161718")
+		require.NoError(t, err)
+
+		ctx := withSyntheticParent(context.Background(), spanID)
+		// A child span started in-process: same trace, different span, not remote.
+		ctx = trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  localSpanID,
+		}))
+
+		assert.False(t, hasSyntheticParent(ctx),
+			"a child span must fall through to ParentBased, not be re-sampled as a root")
+	})
+}
+
+// TestChildSpanFollowsParentDecision is the end-to-end consequence of the guard above:
+// once the root decision is made, in-process children must inherit it.
+func TestChildSpanFollowsParentDecision(t *testing.T) {
+	tp := sdk.NewTracerProvider(sdk.WithSampler(newClientRequestIDSampler(sdk.TraceIDRatioBased(1.0))))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tracer := tp.Tracer("test")
+
+	ctx := serverPropagator().Extract(context.Background(),
+		propagation.MapCarrier{clientRequestIDKey: testClientTraceID})
+
+	ctx, root := tracer.Start(ctx, "server-rpc")
+	defer root.End()
+	require.True(t, root.SpanContext().IsSampled())
+
+	_, child := tracer.Start(ctx, "child")
+	defer child.End()
+
+	assert.True(t, child.SpanContext().IsSampled())
+	assert.Equal(t, root.SpanContext().TraceID(), child.SpanContext().TraceID())
+
+	ro, ok := child.(sdk.ReadOnlySpan)
+	require.True(t, ok, "a sampled span is recording and exposes ReadOnlySpan")
+	assert.Equal(t, root.SpanContext().SpanID(), ro.Parent().SpanID(),
+		"child must hang off the real root span, not the synthesized parent")
+}
+
+func TestClientRequestIDSamplerDescription(t *testing.T) {
+	s := newClientRequestIDSampler(sdk.TraceIDRatioBased(0.5))
+	assert.Contains(t, s.Description(), "ClientRequestIDSampler")
+}

--- a/pkg/tracer/stats_handler.go
+++ b/pkg/tracer/stats_handler.go
@@ -93,9 +93,14 @@ func getServerHandlerOpts() []otelgrpc.Option {
 	return []otelgrpc.Option{
 		otelgrpc.WithInterceptorFilter(filterFunc),
 		otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+		// Order matters: the W3C propagator runs first so a real traceparent always wins,
+		// and clientRequestIDPropagator's "already have a span context" guard becomes
+		// meaningful. With the previous order that guard could never fire, and the two
+		// propagators only happened to compose correctly because the later one overwrote
+		// the earlier one's span context.
 		otelgrpc.WithPropagators(propagation.NewCompositeTextMapPropagator(
-			clientRequestIDPropagator{},
 			otel.GetTextMapPropagator(),
+			clientRequestIDPropagator{},
 		)),
 	}
 }

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -74,7 +74,7 @@ func SetTracerProvider(exp sdk.SpanExporter, traceIDRatio float64) {
 			semconv.ServiceNameKey.String(paramtable.GetRole()),
 			attribute.Int64("NodeID", paramtable.GetNodeID()),
 		)),
-		sdk.WithSampler(sdk.ParentBased(
+		sdk.WithSampler(newClientRequestIDSampler(
 			sdk.TraceIDRatioBased(traceIDRatio),
 		)),
 	)


### PR DESCRIPTION
issue: #51963
design doc: `docs/design-docs/design_docs/20260131-client_side_telemetry.md` (updated in this PR)

> **Draft — blocked on milvus-io/milvus-proto#646.**
> `go.mod` carries a temporary `replace` onto that PR's commit so this compiles and is fully reviewable. It must be dropped and re-pinned to a merged milvus-proto version before merge.
>
> Stacked on #51967, which is where client-scoped configs became one-time.

## Why

#51967 rejects `persistent=true` with a `client:` target, because a client ID names a *process*: the SDK mints a fresh one per start, so a config targeted at one silently stops applying the moment that client restarts.

That closed a leak but left a gap. The remaining durable scopes are `global` and `database:<db>` — there is no way to express *"turn the sampling rate down on the ingest workers, and keep it that way"* short of configuring an entire database or the whole cluster.

## What

A label names a **workload** rather than a process, so it keeps matching across restarts — which is exactly what makes it a legitimate target for persistent config.

**Clients declare labels** through the existing `ClientInfo.Reserved` map, so the client half needs no schema change:

```go
milvusclient.New(ctx, &milvusclient.ClientConfig{
    TelemetryConfig: &milvusclient.TelemetryConfig{
        Labels: map[string]string{"app": "ingest-worker"},
    },
})
```

→ `Reserved["label.app"] = "ingest-worker"`

**Operators target them:**

```bash
curl -u root:pw -XPOST "$M/_telemetry/commands" -d '{
  "command_type": "push_config",
  "target_label": "app=ingest-worker",
  "payload": {"sampling_rate": 0.1},
  "persistent": true
}'
```

Also available in the WebUI as a new **Workload (label)** target.

Keys that are empty or contain `=` are dropped client-side rather than sent — neither could ever be selected by a `label:key=value` scope, so emitting them would just produce labels that silently never match.

## Scope model after this PR

| Scope | Selects | Lifetime | Persistent allowed |
|---|---|---|---|
| `global` | every client | durable | yes |
| `database:<db>` | clients that accessed the db | durable | yes |
| `label:<k>=<v>` | clients declaring the label | durable | **yes** ← new |
| `client:<id>` | one process | ephemeral | no |

Lifetime is what decides persistence eligibility, and that is now a coherent rule rather than a special case.

## One deliberate non-change

An earlier draft made the three target fields mutually exclusive, which felt like the better API — and it broke `TestCommandWithTargetClientTakesPrecedenceOverDatabase`, an existing test pinning the behaviour that client wins when both are set.

Reverted to precedence (client → label → database). Adding a scope should not change how the existing ones resolve; tightening that is a separate decision, not a side effect of this feature. The proto comment documents the precedence.

## Tests

- `TestResolveTargetScope` — all four scopes, label trimming, malformed selectors (`app`, `=ingest`), and both precedence pairs
- `TestMatchesLabel` — hit/miss, empty-value semantics (`tier=` matches a declared empty label but `app=` does not match a set one), whitespace, and that `client_id` is not addressable as a label
- `TestLabelScopedConfigMayBePersistent` / `TestLabelScopedConfigSurvivesReload` — the actual point: a label-scoped config is accepted as persistent and is still there, still addressable, after a simulated RootCoord restart
- `TestClientInfoLabels` — SDK publishes under the prefix, coexists with `client_id`, drops unaddressable keys

## Verification

`go test` green for the `client/` module and `internal/rootcoord/telemetry`; `golangci-lint` 0 issues on both; `gofmt` clean.

Unit-level only — **not run against a live cluster**. In particular the end-to-end path (client declares a label → server matches it → config survives a real RootCoord restart) is covered by a simulated reload, not an actual restart.