### PR TITLE
test: isolate external storage cleanup

### DIFF
--- a/internal/querynodev2/segments/search_test.go
+++ b/internal/querynodev2/segments/search_test.go
@@ -37,6 +37,7 @@ import (
 
 type SearchSuite struct {
 	suite.Suite
+	rootPath     string
 	chunkManager storage.ChunkManager
 
 	manager      *Manager
@@ -58,8 +59,11 @@ func (suite *SearchSuite) SetupTest() {
 	ctx := context.Background()
 	msgLength := 100
 
-	chunkManagerFactory := storage.NewChunkManagerFactoryWithParam(paramtable.Get())
-	suite.chunkManager, _ = chunkManagerFactory.NewPersistentStorageChunkManager(ctx)
+	suite.rootPath = suite.T().Name()
+	chunkManagerFactory := storage.NewTestChunkManagerFactory(paramtable.Get(), suite.rootPath)
+	chunkManager, err := chunkManagerFactory.NewPersistentStorageChunkManager(ctx)
+	suite.Require().NoError(err)
+	suite.chunkManager = chunkManager
 	initcore.InitRemoteChunkManager(paramtable.Get())
 	initcore.InitLocalChunkManager(suite.T().Name())
 	initcore.InitMmapManager(paramtable.Get(), 1)
@@ -139,10 +143,19 @@ func (suite *SearchSuite) SetupTest() {
 }
 
 func (suite *SearchSuite) TearDownTest() {
-	suite.sealed.Release(context.Background())
-	DeleteCollection(suite.collection)
 	ctx := context.Background()
-	suite.chunkManager.RemoveWithPrefix(ctx, paramtable.Get().MinioCfg.RootPath.GetValue())
+	if suite.sealed != nil {
+		suite.sealed.Release(ctx)
+		suite.sealed = nil
+	}
+	if suite.collection != nil {
+		DeleteCollection(suite.collection)
+		suite.collection = nil
+	}
+	if suite.chunkManager != nil {
+		suite.chunkManager.RemoveWithPrefix(ctx, suite.rootPath)
+		suite.chunkManager = nil
+	}
 }
 
 func (suite *SearchSuite) TestSearchSealed() {

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -122,7 +122,7 @@ func TestUpdateSessions(t *testing.T) {
 
 	metaRoot := fmt.Sprintf("%d/%s", rand.Int(), DefaultServiceRoot)
 	etcdCli, _ := kvfactory.GetEtcdAndPath()
-	etcdKV := etcdkv.NewEtcdKV(etcdCli, "")
+	etcdKV := etcdkv.NewEtcdKV(etcdCli, metaRoot)
 
 	defer etcdKV.RemoveWithPrefix(ctx, "")
 
@@ -161,7 +161,7 @@ func TestUpdateSessions(t *testing.T) {
 	notExistSessions, _, _ := s.GetSessions(ctx, "testt")
 	assert.Equal(t, len(notExistSessions), 0)
 
-	etcdKV.RemoveWithPrefix(ctx, metaRoot)
+	etcdKV.RemoveWithPrefix(ctx, "")
 	assert.Eventually(t, func() bool {
 		sessions, _, _ := s.GetSessions(ctx, "test")
 		return len(sessions) == 0


### PR DESCRIPTION
issue: #51971

Fixes #51971

## Background

Several Go unit tests initialize `paramtable` from `configs/milvus.yaml`, so they may connect to the etcd and object storage configured for a real or shared environment.

Two teardown paths were not scoped to test-owned data:

- `TestUpdateSessions` created an etcd KV with an empty root and deferred `RemoveWithPrefix("")`. With an unrestricted client, this removes every key visible to the test credentials.
- `SearchSuite` removed `minio.rootPath` directly. With the default value `files`, this removes every object under `files/`, including data unrelated to the test.

This stayed mostly hidden when tests used disposable local etcd and MinIO instances, but it is destructive when a developer's configuration points to shared services.

## Changes

- Bind the `TestUpdateSessions` etcd KV to the test's existing random `metaRoot`, so empty-prefix cleanup is limited to that namespace.
- Give each `SearchSuite` test its own chunk-manager root and remove only that root during teardown.
- Check chunk-manager initialization errors instead of ignoring them.
- Keep the change limited to test setup and teardown; no production storage interfaces are changed.

## Verification

- [x] `TestUpdateSessions` with `-tags dynamic,test -gcflags="all=-N -l" -count=1`
- [x] Full `TestSearch` suite with `-tags dynamic,test -gcflags="all=-N -l" -count=1`
- [x] An etcd sentinel outside the test root remained after `TestUpdateSessions`
- [x] A MinIO sentinel under the configured global `files/` root remained after `TestSearch`
- [x] `make static-check` — 0 issues
