### PR TITLE
fix: bound QueryNode queue-full retries

### DIFF
--- a/internal/proxy/shardclient/lb_policy.go
+++ b/internal/proxy/shardclient/lb_policy.go
@@ -151,110 +151,127 @@ func preferredNodeID(workload CollectionWorkLoad, channel string) int64 {
 	return nodeID
 }
 
+func allShardLeadersExcluded(shardLeaders []NodeInfo, excludeNodes typeutil.UniqueSet) bool {
+	if len(shardLeaders) == 0 {
+		return false
+	}
+	for _, node := range shardLeaders {
+		if !excludeNodes.Contain(node.NodeID) {
+			return false
+		}
+	}
+	return true
+}
+
 // try to select the best node from the available nodes
 func (lb *LBPolicyImpl) selectNode(ctx context.Context, balancer LBBalancer, workload ChannelWorkload, excludeNodes *typeutil.UniqueSet) (NodeInfo, bool, error) {
+	targetNode, selectedByBalancer, _, err := lb.selectNodeWithUncachedRetry(ctx, balancer, workload, excludeNodes)
+	return targetNode, selectedByBalancer, err
+}
+
+func (lb *LBPolicyImpl) selectNodeFromShardLeaders(ctx context.Context, balancer LBBalancer, workload ChannelWorkload, shardLeaders []NodeInfo, excludeNodes *typeutil.UniqueSet) (targetNode NodeInfo, selectedByBalancer bool, err error) {
 	log := mlog.With(
 		mlog.Int64("collectionID", workload.CollectionID),
 		mlog.String("channelName", workload.Channel),
 	)
-	// Select node using specified nodes
-	trySelectNode := func(withCache bool) (NodeInfo, bool, error) {
+
+	candidateNodes := make(map[int64]NodeInfo)
+	serviceableNodes := make(map[int64]NodeInfo)
+	defer func() {
+		if err != nil {
+			candidatesInStr := lo.Map(shardLeaders, func(node NodeInfo, _ int) string {
+				return node.String()
+			})
+			serviceableNodesInStr := lo.Map(lo.Values(serviceableNodes), func(node NodeInfo, _ int) string {
+				return node.String()
+			})
+			log.Warn(ctx, "failed to select shard",
+				mlog.Int64s("excluded", excludeNodes.Collect()),
+				mlog.String("candidates", strings.Join(candidatesInStr, ", ")),
+				mlog.String("serviceableNodes", strings.Join(serviceableNodesInStr, ", ")),
+				mlog.Err(err))
+		}
+	}()
+
+	// Filter nodes based on excludeNodes
+	for _, node := range shardLeaders {
+		if !excludeNodes.Contain(node.NodeID) {
+			if node.Serviceable {
+				serviceableNodes[node.NodeID] = node
+			}
+			candidateNodes[node.NodeID] = node
+		}
+	}
+	if len(candidateNodes) == 0 {
+		err = merr.WrapErrChannelNotAvailable(workload.Channel, "no available shard leaders")
+		return NodeInfo{}, false, err
+	}
+
+	if preferredNode, ok := serviceableNodes[workload.PreferredNodeID]; ok {
+		recordPreferredNodeSelection(metrics.PreferredNodeHitLabel)
+		return preferredNode, false, nil
+	} else if workload.PreferredNodeID != 0 {
+		recordPreferredNodeSelection(metrics.PreferredNodeUnavailableLabel)
+	}
+
+	balancer.RegisterNodeInfo(lo.Values(candidateNodes))
+
+	// prefer serviceable nodes
+	var targetNodeID int64
+	if len(serviceableNodes) > 0 {
+		targetNodeID, err = balancer.SelectNode(ctx, lo.Keys(serviceableNodes), workload.Nq)
+	} else {
+		targetNodeID, err = balancer.SelectNode(ctx, lo.Keys(candidateNodes), workload.Nq)
+	}
+	if err != nil {
+		return NodeInfo{}, false, err
+	}
+
+	if _, ok := candidateNodes[targetNodeID]; !ok {
+		err = merr.WrapErrNodeNotAvailable(targetNodeID)
+		return NodeInfo{}, false, err
+	}
+
+	return candidateNodes[targetNodeID], true, nil
+}
+
+func (lb *LBPolicyImpl) selectNodeWithUncachedRetry(ctx context.Context, balancer LBBalancer, workload ChannelWorkload, excludeNodes *typeutil.UniqueSet) (NodeInfo, bool, []NodeInfo, error) {
+	log := mlog.With(
+		mlog.Int64("collectionID", workload.CollectionID),
+		mlog.String("channelName", workload.Channel),
+	)
+	trySelectNode := func(withCache bool) (NodeInfo, bool, []NodeInfo, error) {
 		shardLeaders, err := lb.GetShard(ctx, workload.Db, workload.CollectionName, workload.CollectionID, workload.Channel, withCache)
 		if err != nil {
 			log.Warn(ctx, "failed to get shard delegator",
 				mlog.Err(err))
-			return NodeInfo{}, false, err
+			return NodeInfo{}, false, nil, err
 		}
 
 		// if all available delegator has been excluded even after refresh shard leader cache
 		// we should clear excludeNodes and try to select node again instead of failing the request at selectNode
-		if !withCache && len(shardLeaders) > 0 && len(shardLeaders) <= excludeNodes.Len() {
-			allReplicaExcluded := true
-			for _, node := range shardLeaders {
-				if !excludeNodes.Contain(node.NodeID) {
-					allReplicaExcluded = false
-					break
-				}
-			}
-			if allReplicaExcluded {
-				log.Warn(ctx, "all replicas are excluded after refresh shard leader cache, clear it and try to select node")
-				excludeNodes.Clear()
-			}
+		if !withCache && allShardLeadersExcluded(shardLeaders, *excludeNodes) {
+			log.Warn(ctx, "all replicas are excluded after refresh shard leader cache, clear it and try to select node")
+			excludeNodes.Clear()
 		}
 
-		candidateNodes := make(map[int64]NodeInfo)
-		serviceableNodes := make(map[int64]NodeInfo)
-		defer func() {
-			if err != nil {
-				candidatesInStr := lo.Map(shardLeaders, func(node NodeInfo, _ int) string {
-					return node.String()
-				})
-				serviceableNodesInStr := lo.Map(lo.Values(serviceableNodes), func(node NodeInfo, _ int) string {
-					return node.String()
-				})
-				log.Warn(ctx, "failed to select shard",
-					mlog.Int64s("excluded", excludeNodes.Collect()),
-					mlog.String("candidates", strings.Join(candidatesInStr, ", ")),
-					mlog.String("serviceableNodes", strings.Join(serviceableNodesInStr, ", ")),
-					mlog.Err(err))
-			}
-		}()
-
-		// Filter nodes based on excludeNodes
-		for _, node := range shardLeaders {
-			if !excludeNodes.Contain(node.NodeID) {
-				if node.Serviceable {
-					serviceableNodes[node.NodeID] = node
-				}
-				candidateNodes[node.NodeID] = node
-			}
-		}
-		if len(candidateNodes) == 0 {
-			err = merr.WrapErrChannelNotAvailable(workload.Channel, "no available shard leaders")
-			return NodeInfo{}, false, err
-		}
-
-		if preferredNode, ok := serviceableNodes[workload.PreferredNodeID]; ok {
-			recordPreferredNodeSelection(metrics.PreferredNodeHitLabel)
-			return preferredNode, false, nil
-		} else if workload.PreferredNodeID != 0 {
-			recordPreferredNodeSelection(metrics.PreferredNodeUnavailableLabel)
-		}
-
-		balancer.RegisterNodeInfo(lo.Values(candidateNodes))
-
-		// prefer serviceable nodes
-		var targetNodeID int64
-		if len(serviceableNodes) > 0 {
-			targetNodeID, err = balancer.SelectNode(ctx, lo.Keys(serviceableNodes), workload.Nq)
-		} else {
-			targetNodeID, err = balancer.SelectNode(ctx, lo.Keys(candidateNodes), workload.Nq)
-		}
-		if err != nil {
-			return NodeInfo{}, false, err
-		}
-
-		if _, ok := candidateNodes[targetNodeID]; !ok {
-			err = merr.WrapErrNodeNotAvailable(targetNodeID)
-			return NodeInfo{}, false, err
-		}
-
-		return candidateNodes[targetNodeID], true, nil
+		targetNode, selectedByBalancer, err := lb.selectNodeFromShardLeaders(ctx, balancer, workload, shardLeaders, excludeNodes)
+		return targetNode, selectedByBalancer, shardLeaders, err
 	}
 
 	// First attempt with current shard leaders cache
 	withShardLeaderCache := true
-	targetNode, selectedByBalancer, err := trySelectNode(withShardLeaderCache)
+	targetNode, selectedByBalancer, shardLeaders, err := trySelectNode(withShardLeaderCache)
 	if err != nil {
 		// Second attempt with fresh shard leaders
 		withShardLeaderCache = false
-		targetNode, selectedByBalancer, err = trySelectNode(withShardLeaderCache)
+		targetNode, selectedByBalancer, shardLeaders, err = trySelectNode(withShardLeaderCache)
 		if err != nil {
-			return NodeInfo{}, false, err
+			return NodeInfo{}, false, shardLeaders, err
 		}
 	}
 
-	return targetNode, selectedByBalancer, nil
+	return targetNode, selectedByBalancer, shardLeaders, err
 }
 
 // ExecuteWithRetry will choose a qn to execute the workload, and retry if failed, until reach the max retryTimes.
@@ -264,44 +281,59 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 		mlog.String("channelName", workload.Channel),
 	)
 	var lastErr error
+	var overloadErr error
 	var err error
 	var shardLeaders []NodeInfo
+	// Keep overload selection and exhaustion accounting on the exact leader
+	// snapshot that selected the first saturated replica.
+	var overloadShardLeaders []NodeInfo
 	requestExcludedNodes := typeutil.NewUniqueSet()
 	tryExecute := func() (bool, error) {
 		// Get fresh blacklist on each retry to include newly blacklisted nodes
 		blacklist := lb.blacklist.GetBlacklistedNodes(workload.Channel)
-		if len(shardLeaders) > 0 && requestExcludedNodes.Len() >= len(shardLeaders) {
-			shardLeaders, err = lb.GetShard(ctx, workload.Db, workload.CollectionName, workload.CollectionID, workload.Channel, false)
-			if err != nil {
-				log.Warn(ctx, "failed to refresh shard leaders", mlog.Err(err))
-				if lastErr != nil {
-					return true, lastErr
-				}
-				return true, err
-			}
-
-			allReplicaExcluded := len(shardLeaders) > 0
-			for _, node := range shardLeaders {
-				if !requestExcludedNodes.Contain(node.NodeID) {
-					allReplicaExcluded = false
-					break
-				}
-			}
-			if allReplicaExcluded {
-				log.Warn(ctx, "all replicas are request-level excluded after refresh, clear it and retry")
-				requestExcludedNodes.Clear()
-			}
-		}
 		excludeNodes := typeutil.NewUniqueSet(blacklist...)
 		excludeNodes.Insert(requestExcludedNodes.Collect()...)
 		balancer := lb.getBalancer()
-		targetNode, selectedByBalancer, err := lb.selectNode(ctx, balancer, workload, &excludeNodes)
+		var targetNode NodeInfo
+		var selectedByBalancer bool
+		var selectedShardLeaders []NodeInfo
+		if overloadErr != nil {
+			// Do not re-read or refresh shard leaders while sweeping overloaded
+			// replicas; a changing cache would make selection and exhaustion use
+			// different node sets.
+			if allShardLeadersExcluded(overloadShardLeaders, excludeNodes) {
+				return false, overloadErr
+			}
+			targetNode, selectedByBalancer, err = lb.selectNodeFromShardLeaders(ctx, balancer, workload, overloadShardLeaders, &excludeNodes)
+		} else {
+			if allShardLeadersExcluded(shardLeaders, requestExcludedNodes) {
+				shardLeaders, err = lb.GetShard(ctx, workload.Db, workload.CollectionName, workload.CollectionID, workload.Channel, false)
+				if err != nil {
+					log.Warn(ctx, "failed to refresh shard leaders", mlog.Err(err))
+					if lastErr != nil {
+						return true, lastErr
+					}
+					return true, err
+				}
+
+				if allShardLeadersExcluded(shardLeaders, requestExcludedNodes) {
+					log.Warn(ctx, "all replicas are request-level excluded after refresh, clear it and retry")
+					requestExcludedNodes.Clear()
+				}
+				excludeNodes = typeutil.NewUniqueSet(blacklist...)
+				excludeNodes.Insert(requestExcludedNodes.Collect()...)
+			}
+			targetNode, selectedByBalancer, selectedShardLeaders, err = lb.selectNodeWithUncachedRetry(ctx, balancer, workload, &excludeNodes)
+		}
 		if err != nil {
 			log.Warn(ctx, "failed to select node for shard",
 				mlog.Int64("nodeID", targetNode.NodeID),
 				mlog.Int64s("excluded", excludeNodes.Collect()),
 				mlog.Err(err),
 			)
+			if overloadErr != nil {
+				return false, overloadErr
+			}
 			if lastErr != nil {
 				return true, lastErr
 			}
@@ -334,6 +366,21 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 			// immediately without retrying or touching the blacklist.
 			if merr.GetErrorType(err) == merr.InputError {
 				return false, err
+			}
+			// Queue saturation is a transient overload signal from a healthy
+			// QueryNode. Try each replica at most once, then return the overload
+			// to the caller instead of cycling through saturated replicas.
+			if errors.Is(err, merr.ErrServiceTooManyRequests) {
+				if overloadErr == nil {
+					overloadShardLeaders = append([]NodeInfo(nil), selectedShardLeaders...)
+				}
+				requestExcludedNodes.Insert(targetNode.NodeID)
+				excludeNodes.Insert(targetNode.NodeID)
+				overloadErr = err
+				if allShardLeadersExcluded(overloadShardLeaders, excludeNodes) {
+					return false, overloadErr
+				}
+				return true, err
 			}
 			if merr.IsRetryableErr(err) {
 				requestExcludedNodes.Insert(targetNode.NodeID)

--- a/internal/proxy/shardclient/lb_policy_test.go
+++ b/internal/proxy/shardclient/lb_policy_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -702,6 +703,325 @@ func (s *LBPolicySuite) TestExecuteWithRetryInputErrorSkipsBlacklist() {
 	s.Equal(1, execCount)
 	// serving node not blacklisted for the request's own fault
 	s.NotContains(s.lbPolicy.blacklist.GetBlacklistedNodes(channel), int64(1))
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsStopsAfterReplicaSweep() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{{NodeID: 1, Address: "localhost:9000", Serviceable: true}}
+	s.lbPolicy.retryOnReplica = 5
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil).Twice()
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	execCount := 0
+	start := time.Now()
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			execCount++
+			return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+		},
+	})
+
+	s.ErrorIs(err, merr.ErrServiceTooManyRequests)
+	s.Equal(1, execCount)
+	s.Less(time.Since(start), 200*time.Millisecond, "the final saturated replica should not incur another retry backoff")
+	s.Empty(s.lbPolicy.blacklist.GetBlacklistedNodes(channel))
+	status := merr.Status(err)
+	s.Equal(int32(4), status.GetCode())
+	s.True(status.GetRetriable())
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsHonorsBlacklistWhenCheckingExhaustion() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 5
+	s.lbPolicy.blacklist.Add(channel, 1)
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil).Twice()
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil).Once()
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything).Once()
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).Return(int64(2), nil).Once()
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything).Once()
+
+	execCount := 0
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			execCount++
+			s.Equal(int64(2), nodeID)
+			return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+		},
+	})
+
+	s.ErrorIs(err, merr.ErrServiceTooManyRequests)
+	s.Equal(1, execCount)
+	s.Contains(s.lbPolicy.blacklist.GetBlacklistedNodes(channel), int64(1))
+	s.mgr.AssertNotCalled(s.T(), "GetShard", mock.Anything, false, s.dbName, s.collectionName, s.collectionID, channel)
+	status := merr.Status(err)
+	s.Equal(int32(4), status.GetCode())
+	s.True(status.GetRetriable())
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsDoesNotUseUncachedRetry() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	initialNodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	nodesAfterQueueFull := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 5
+	cachedNodes := initialNodes
+	getShardCalls := 0
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).RunAndReturn(
+		func(context.Context, bool, string, string, int64, string) ([]NodeInfo, error) {
+			getShardCalls++
+			return cachedNodes, nil
+		})
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil).Twice()
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything).Twice()
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			if lo.Contains(availableNodes, int64(1)) {
+				return 1, nil
+			}
+			return 2, nil
+		}).Twice()
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything).Twice()
+
+	executedNodes := make([]int64, 0, len(initialNodes))
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			if nodeID == 1 {
+				cachedNodes = nodesAfterQueueFull
+				return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+			}
+			return nil
+		},
+	})
+
+	s.NoError(err)
+	s.Equal([]int64{1, 2}, executedNodes)
+	s.Equal(2, getShardCalls)
+	s.mgr.AssertNotCalled(s.T(), "GetShard", mock.Anything, false, s.dbName, s.collectionName, s.collectionID, channel)
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsUsesSelectionSnapshotAfterCacheExpansion() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	initialNodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+	}
+	expandedNodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 1
+	getShardCalls := 0
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).RunAndReturn(
+		func(context.Context, bool, string, string, int64, string) ([]NodeInfo, error) {
+			getShardCalls++
+			if getShardCalls == 1 {
+				return initialNodes, nil
+			}
+			return expandedNodes, nil
+		})
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil).Twice()
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything).Twice()
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			if lo.Contains(availableNodes, int64(1)) {
+				return 1, nil
+			}
+			return 2, nil
+		}).Twice()
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything).Twice()
+
+	executedNodes := make([]int64, 0, len(expandedNodes))
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			if nodeID == 1 {
+				return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+			}
+			return nil
+		},
+	})
+
+	s.NoError(err)
+	s.Equal([]int64{1, 2}, executedNodes)
+	s.Equal(2, getShardCalls)
+	s.mgr.AssertNotCalled(s.T(), "GetShard", mock.Anything, false, s.dbName, s.collectionName, s.collectionID, channel)
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsFailsOverToAnotherReplica() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 5
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil).Twice()
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			return availableNodes[0], nil
+		})
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	executedNodes := make([]int64, 0, len(nodes))
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			if len(executedNodes) == 1 {
+				return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+			}
+			return nil
+		},
+	})
+
+	s.NoError(err)
+	s.Len(executedNodes, 2)
+	s.NotEqual(executedNodes[0], executedNodes[1])
+	s.Empty(s.lbPolicy.blacklist.GetBlacklistedNodes(channel))
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsIgnoresStaleBlacklistForExhaustion() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 5
+	s.lbPolicy.blacklist.Add(channel, 99)
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil).Twice()
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil).Twice()
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything).Twice()
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			if lo.Contains(availableNodes, int64(1)) {
+				return 1, nil
+			}
+			return 2, nil
+		}).Twice()
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything).Twice()
+
+	executedNodes := make([]int64, 0, len(nodes))
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			if nodeID == 1 {
+				return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+			}
+			return nil
+		},
+	})
+
+	s.NoError(err)
+	s.Equal([]int64{1, 2}, executedNodes)
+	s.Contains(s.lbPolicy.blacklist.GetBlacklistedNodes(channel), int64(99))
+	s.mgr.AssertNotCalled(s.T(), "GetShard", mock.Anything, false, s.dbName, s.collectionName, s.collectionID, channel)
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsTriesEachReplicaOnce() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 5
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil).Twice()
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			return availableNodes[0], nil
+		})
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	executedNodes := make([]int64, 0, len(nodes))
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+		},
+	})
+
+	s.ErrorIs(err, merr.ErrServiceTooManyRequests)
+	s.Len(executedNodes, len(nodes))
+	s.ElementsMatch([]int64{1, 2}, executedNodes)
+	s.Empty(s.lbPolicy.blacklist.GetBlacklistedNodes(channel))
+	status := merr.Status(err)
+	s.Equal(int32(4), status.GetCode())
+	s.True(status.GetRetriable())
 }
 
 func (s *LBPolicySuite) TestExecuteOneChannel() {


### PR DESCRIPTION
issue: #51948

3.0 PR: #51975
2.6 PR: #51949

## What changed

- Treat `ErrServiceTooManyRequests` as request-scoped QueryNode saturation.
- Exclude the saturated QueryNode for the current request and preserve one failover pass across the remaining replicas in the exact cached leader snapshot used for selection.
- Once all selectable replicas in that snapshot have been attempted, stop immediately before another retry backoff or any shard-leader refresh, and return the original code 4 status with `Retriable=true`.
- Keep shard-leader refresh and exclusion-set recycling only for non-overload failures.
- Do not add a healthy but saturated QueryNode to the cross-request blacklist.
- Cover single-replica saturation, successful multi-replica failover, all-replicas-saturated behavior, cache snapshot shrink/expansion, and the absence of cached or uncached shard lookup during the overload sweep.

## Root cause

The load-balancing policy treated queue-full as a generic retriable execution failure. Once every replica was request-level excluded, it cleared the exclusion set and cycled through the same saturated replicas again according to `retryOnReplica`. Hybrid-search fanout amplified those repeated dispatches.

An intermediate version stopped that QueryNode retry cycle only after `GetShard(false)`. Because uncached shard lookup calls `MixCoord.GetShardLeaders`, the single-replica overload path added one coordinator RPC per failed channel workload. The overload check now runs before that refresh.

## Behavior

- Single replica: execute on the QueryNode once, then return the overload status without another retry backoff or shard-leader refresh.
- Multiple replicas: a queue-full response can fail over to each cached, untried replica in the captured selection snapshot within the same request.
- All selectable replicas saturated or excluded: each saturated replica is attempted at most once; no cached/uncached shard lookup or exclusion-set clearing occurs after overload begins.
- The original retriable status reaches the client; automatic backoff still depends on the SDK or application retry policy.

## Scope

This PR bounds request-level replica retries when `ErrServiceTooManyRequests` reaches Proxy as code 4. It does not change Delegator partial-result mixed-error aggregation. In the opt-in partial-result path, aggregation can mask code 4 when queue-full is combined with other worker errors; that pre-existing case remains a separate follow-up and is not covered by this PR's retry-bounding claim.

## Validation

```text
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/shardclient -run 'TestLBPolicySuite/TestExecuteWithRetryTooManyRequests'
ok github.com/milvus-io/milvus/internal/proxy/shardclient 6.260s

go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/shardclient
ok github.com/milvus-io/milvus/internal/proxy/shardclient 153.604s
```
