### PR TITLE
fix: [3.0] bound QueryNode queue-full retries

### DIFF
--- a/internal/proxy/shardclient/lb_policy.go
+++ b/internal/proxy/shardclient/lb_policy.go
@@ -264,6 +264,7 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 		mlog.String("channelName", workload.Channel),
 	)
 	var lastErr error
+	var overloadErr error
 	var err error
 	var shardLeaders []NodeInfo
 	requestExcludedNodes := typeutil.NewUniqueSet()
@@ -271,6 +272,9 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 		// Get fresh blacklist on each retry to include newly blacklisted nodes
 		blacklist := lb.blacklist.GetBlacklistedNodes(workload.Channel)
 		if len(shardLeaders) > 0 && requestExcludedNodes.Len() >= len(shardLeaders) {
+			if overloadErr != nil {
+				return false, overloadErr
+			}
 			shardLeaders, err = lb.GetShard(ctx, workload.Db, workload.CollectionName, workload.CollectionID, workload.Channel, false)
 			if err != nil {
 				log.Warn(ctx, "failed to refresh shard leaders", mlog.Err(err))
@@ -302,6 +306,9 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 				mlog.Int64s("excluded", excludeNodes.Collect()),
 				mlog.Err(err),
 			)
+			if overloadErr != nil {
+				return false, overloadErr
+			}
 			if lastErr != nil {
 				return true, lastErr
 			}
@@ -334,6 +341,14 @@ func (lb *LBPolicyImpl) ExecuteWithRetry(ctx context.Context, workload ChannelWo
 			// immediately without retrying or touching the blacklist.
 			if merr.GetErrorType(err) == merr.InputError {
 				return false, err
+			}
+			// Queue saturation is a transient overload signal from a healthy
+			// QueryNode. Try each replica at most once, then return the overload
+			// to the caller instead of cycling through saturated replicas.
+			if errors.Is(err, merr.ErrServiceTooManyRequests) {
+				requestExcludedNodes.Insert(targetNode.NodeID)
+				overloadErr = err
+				return true, err
 			}
 			if merr.IsRetryableErr(err) {
 				requestExcludedNodes.Insert(targetNode.NodeID)

--- a/internal/proxy/shardclient/lb_policy_test.go
+++ b/internal/proxy/shardclient/lb_policy_test.go
@@ -700,6 +700,125 @@ func (s *LBPolicySuite) TestExecuteWithRetryInputErrorSkipsBlacklist() {
 	s.NotContains(s.lbPolicy.blacklist.GetBlacklistedNodes(channel), int64(1))
 }
 
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsStopsAfterReplicaSweep() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{{NodeID: 1, Address: "localhost:9000", Serviceable: true}}
+	s.lbPolicy.retryOnReplica = 5
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil)
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	execCount := 0
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			execCount++
+			return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+		},
+	})
+
+	s.ErrorIs(err, merr.ErrServiceTooManyRequests)
+	s.Equal(1, execCount)
+	s.Empty(s.lbPolicy.blacklist.GetBlacklistedNodes(channel))
+	status := merr.Status(err)
+	s.Equal(int32(4), status.GetCode())
+	s.True(status.GetRetriable())
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsFailsOverToAnotherReplica() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 5
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil)
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			return availableNodes[0], nil
+		})
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	executedNodes := make([]int64, 0, len(nodes))
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			if len(executedNodes) == 1 {
+				return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+			}
+			return nil
+		},
+	})
+
+	s.NoError(err)
+	s.Len(executedNodes, 2)
+	s.NotEqual(executedNodes[0], executedNodes[1])
+	s.Empty(s.lbPolicy.blacklist.GetBlacklistedNodes(channel))
+}
+
+func (s *LBPolicySuite) TestExecuteWithRetryTooManyRequestsTriesEachReplicaOnce() {
+	ctx := context.Background()
+	channel := s.channels[0]
+	nodes := []NodeInfo{
+		{NodeID: 1, Address: "localhost:9000", Serviceable: true},
+		{NodeID: 2, Address: "localhost:9001", Serviceable: true},
+	}
+	s.lbPolicy.retryOnReplica = 5
+
+	s.mgr.ExpectedCalls = nil
+	s.lbBalancer.ExpectedCalls = nil
+	s.mgr.EXPECT().GetShard(mock.Anything, true, s.dbName, s.collectionName, s.collectionID, channel).Return(nodes, nil)
+	s.mgr.EXPECT().GetClient(mock.Anything, mock.Anything).Return(s.qn, nil)
+	s.lbBalancer.EXPECT().RegisterNodeInfo(mock.Anything)
+	s.lbBalancer.EXPECT().SelectNode(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, availableNodes []int64, nq int64) (int64, error) {
+			return availableNodes[0], nil
+		})
+	s.lbBalancer.EXPECT().CancelWorkload(mock.Anything, mock.Anything)
+
+	executedNodes := make([]int64, 0, len(nodes))
+	err := s.lbPolicy.ExecuteWithRetry(ctx, ChannelWorkload{
+		Db:             s.dbName,
+		CollectionName: s.collectionName,
+		CollectionID:   s.collectionID,
+		Channel:        channel,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID UniqueID, qn types.QueryNodeClient, channel string) error {
+			executedNodes = append(executedNodes, nodeID)
+			return errors.Wrapf(merr.WrapErrTooManyRequests(1024), "queue full on QueryNode %d", nodeID)
+		},
+	})
+
+	s.ErrorIs(err, merr.ErrServiceTooManyRequests)
+	s.Len(executedNodes, len(nodes))
+	s.ElementsMatch([]int64{1, 2}, executedNodes)
+	s.Empty(s.lbPolicy.blacklist.GetBlacklistedNodes(channel))
+	status := merr.Status(err)
+	s.Equal(int32(4), status.GetCode())
+	s.True(status.GetRetriable())
+}
+
 func (s *LBPolicySuite) TestExecuteOneChannel() {
 	ctx := context.Background()
 	mockErr := errors.New("mock error")


### PR DESCRIPTION
issue: #51948
pr: #51974

2.6 PR: #51949

## What changed

- Treat `ErrServiceTooManyRequests` as request-scoped QueryNode saturation.
- Exclude the saturated QueryNode for the current request and preserve one failover pass across the remaining cached replicas.
- Once all cached replicas have been attempted, stop before any uncached shard-leader refresh and return the original code 4 status with `Retriable=true`.
- Keep shard-leader refresh and exclusion-set recycling only for non-overload failures.
- Do not add a healthy but saturated QueryNode to the cross-request blacklist.
- Cover single-replica saturation, successful two-replica failover, all-replicas-saturated behavior, and the absence of `GetShard(false)` on overload paths.

## Root cause

The load-balancing policy treated queue-full as a generic retriable execution failure. Once every replica was request-level excluded, it cleared the exclusion set and cycled through the same saturated replicas again according to `retryOnReplica`. Hybrid-search fanout amplified those repeated dispatches.

An intermediate version stopped that QueryNode retry cycle only after `GetShard(false)`. Because uncached shard lookup calls `MixCoord.GetShardLeaders`, the single-replica overload path added one coordinator RPC per failed channel workload. The overload check now runs before that refresh.

## Behavior

- Single replica: execute on the QueryNode once, then return the overload status without an uncached shard refresh.
- Multiple replicas: a queue-full response can fail over to each cached, untried replica within the same request.
- All cached replicas saturated: each replica is attempted at most once; no `GetShard(false)` or exclusion-set clearing occurs.
- The original retriable status reaches the client; automatic backoff still depends on the SDK or application retry policy.

## Validation

```text
go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/shardclient/...
ok github.com/milvus-io/milvus/internal/proxy/shardclient 154.596s
```
