### PR TITLE
fix: [3.0] preserve growing nullable all-visible snapshot bound

### DIFF
--- a/internal/core/src/common/OffsetMapping.cpp
+++ b/internal/core/src/common/OffsetMapping.cpp
@@ -395,25 +395,32 @@ GrowingOffsetMapping::TransformBitset(const BitsetView& bitset,
         return BitsetTransformStatus::NoFilter;
     }
     const auto valid_count = valid_count_;
-    const auto total_count = total_count_;
 
     result.clear();
+    AssertInfo(!bitset.empty(),
+               "growing nullable vector search requires a bounded bitset");
     if (bitset.all()) {
         return BitsetTransformStatus::AllFiltered;
     }
 
-    if (static_cast<int64_t>(bitset.size()) >= total_count && bitset.none()) {
-        result.resize(valid_count, false);
-        return BitsetTransformStatus::Transformed;
-    }
-
-    result.resize(valid_count, true);
-    for (int64_t physical_idx = 0; physical_idx < valid_count; ++physical_idx) {
-        auto it = p2l_map_.find(static_cast<int32_t>(physical_idx));
-        if (it != p2l_map_.end() &&
-            it->second < static_cast<int64_t>(bitset.size())) {
-            result[physical_idx] = bitset.test(it->second);
+    const auto logical_count = static_cast<int64_t>(bitset.size());
+    const auto max_physical_count = std::min(valid_count, logical_count);
+    result.resize(max_physical_count, true);
+    int64_t physical_bound = 0;
+    for (; physical_bound < max_physical_count; ++physical_bound) {
+        auto it = p2l_map_.find(static_cast<int32_t>(physical_bound));
+        if (it == p2l_map_.end()) {
+            break;
         }
+        if (it->second >= logical_count) {
+            break;
+        }
+        result[physical_bound] = bitset.test(it->second);
+    }
+    result.resize(physical_bound);
+
+    if (result.empty()) {
+        return BitsetTransformStatus::AllFiltered;
     }
     return BitsetTransformStatus::Transformed;
 }

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -307,6 +307,7 @@ struct SearchResult {
 
     BitsetView
     PinBitset(TargetBitmap&& bitset) {
+        pinned_bitsets_.clear();
         auto pinned = std::make_unique<TargetBitmap>(std::move(bitset));
         auto view = BitsetView(*pinned);
         pinned_bitsets_.emplace_back(std::move(pinned));

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -111,9 +111,13 @@ PhyVectorSearchNode::GetOutput() {
         search_info_.array_offsets_ = array_offsets;
     }
 
+    // Single search + metrics path
+    milvus::SearchResult search_result;
+
     // Prepare BitsetView for search.
-    // Fast path: all_rows_visible + non-element-level → empty BitsetView
-    //            (IDSelectorAll in Knowhere, skips per-vector bit test).
+    // Fast path: sealed all_rows_visible + non-element-level leaves an empty
+    // BitsetView (IDSelectorAll in Knowhere). Growing keeps the logical
+    // snapshot bound by materializing an all-visible bitset.
     // Normal path: build BitsetView from the bitmap produced upstream.
     milvus::BitsetView search_view;
     int64_t data_cnt = active_count_;
@@ -126,7 +130,10 @@ PhyVectorSearchNode::GetOutput() {
     }
 
     if (query_context_->get_all_rows_visible() && !ph.element_level_) {
-        // search_view stays default-constructed (empty)
+        if (segment_->type() == SegmentType::Growing) {
+            TargetBitmap all_visible(active_count_, false);
+            search_view = search_result.PinBitset(std::move(all_visible));
+        }
     } else {
         // There are two types of execution: pre-filter and iterative filter
         // For **pre-filter**: FilterBitsNode -> MvccNode -> ElementFilterBitsNode -> VectorSearchNode -> ...
@@ -176,8 +183,6 @@ PhyVectorSearchNode::GetOutput() {
         data_cnt = search_view.size();
     }
 
-    // Single search + metrics path
-    milvus::SearchResult search_result;
     auto op_context = query_context_->get_op_context();
     segment_->vector_search(search_info_,
                             src_data,

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -33,11 +33,15 @@
 #include "common/QueryResult.h"
 #include "common/Schema.h"
 #include "common/Types.h"
+#include "common/Vector.h"
+#include "exec/operator/VectorSearchNode.h"
+#include "exec/Task.h"
 #include "index/IndexFactory.h"
 #include "index/VectorIndex.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/dataset.h"
 #include "mmap/ChunkedColumn.h"
+#include "query/PlanImpl.h"
 #include "query/SearchOnGrowing.h"
 #include "query/SearchOnSealed.h"
 #include "segcore/SegmentGrowing.h"
@@ -532,6 +536,128 @@ TEST(SearchOnGrowingBitsetLifetime,
                     search_result);
 
     AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+TEST(PhyVectorSearchNodeGrowingNullableAllVisible,
+     MaterializesSnapshotBitsetBeforeSearch) {
+    constexpr int64_t snapshot_rows = 4;
+    constexpr int64_t later_rows = 1;
+    constexpr int64_t topk = 1;
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::L2, true);
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_field);
+
+    auto segment = segcore::CreateGrowingSegment(schema, empty_index_meta);
+    auto* growing_segment =
+        dynamic_cast<segcore::SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing_segment, nullptr);
+
+    // Row 0 is null, rows 1..3 are valid. This makes the logical snapshot
+    // length different from the physical vector count after offset mapping.
+    auto snapshot_data = segcore::DataGen(schema,
+                                          snapshot_rows,
+                                          /*seed=*/100,
+                                          /*ts_offset=*/0,
+                                          /*repeat_count=*/1,
+                                          /*array_len=*/10,
+                                          /*group_count=*/1,
+                                          /*random_pk=*/false,
+                                          /*random_val=*/true,
+                                          /*random_valid=*/false,
+                                          /*null_percent=*/1);
+    auto snapshot_offset = segment->PreInsert(snapshot_rows);
+    segment->Insert(snapshot_offset,
+                    snapshot_rows,
+                    snapshot_data.row_ids_.data(),
+                    snapshot_data.timestamps_.data(),
+                    snapshot_data.raw_);
+
+    auto later_data = segcore::DataGen(schema,
+                                       later_rows,
+                                       /*seed=*/200,
+                                       /*ts_offset=*/snapshot_rows,
+                                       /*repeat_count=*/1,
+                                       /*array_len=*/10,
+                                       /*group_count=*/1,
+                                       /*random_pk=*/false,
+                                       /*random_val=*/true,
+                                       /*random_valid=*/false,
+                                       /*null_percent=*/0);
+    const auto& later_vectors =
+        FindFieldData(later_data, vector_field).vectors().float_vector().data();
+    ASSERT_EQ(later_vectors.size(), kDim);
+
+    auto later_offset = segment->PreInsert(later_rows);
+    segment->Insert(later_offset,
+                    later_rows,
+                    later_data.row_ids_.data(),
+                    later_data.timestamps_.data(),
+                    later_data.raw_);
+
+    const auto& offset_mapping = growing_segment->get_insert_record()
+                                     .get_data_base(vector_field)
+                                     ->get_offset_mapping();
+    ASSERT_TRUE(offset_mapping.IsEnabled());
+    ASSERT_EQ(offset_mapping.GetValidCount(), snapshot_rows);
+    ASSERT_EQ(offset_mapping.GetPhysicalOffset(0), -1);
+
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = topk;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = knowhere::metric::L2;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "1"},
+    };
+
+    Plan placeholder_plan(schema);
+    placeholder_plan.plan_node_ = std::make_unique<VectorPlanNode>();
+    placeholder_plan.plan_node_->search_info_ = search_info;
+    placeholder_plan.tag2field_["$0"] = vector_field;
+    auto ph_group_raw =
+        segcore::CreatePlaceholderGroupFromBlob(1, kDim, later_vectors.data());
+    auto ph_group = ParsePlaceholderGroup(&placeholder_plan,
+                                          ph_group_raw.SerializeAsString());
+
+    auto query_context = std::make_shared<exec::QueryContext>(
+        "growing-nullable-all-visible",
+        growing_segment,
+        snapshot_rows,
+        MAX_TIMESTAMP,
+        0,
+        0,
+        PlanOptions{false},
+        std::make_shared<exec::QueryConfig>());
+    query_context->set_search_info(search_info);
+    query_context->set_placeholder_group(ph_group.get());
+    query_context->set_all_rows_visible(true);
+
+    auto vector_plan = std::make_shared<plan::VectorSearchNode>("vector");
+    auto task = exec::Task::Create("growing-nullable-all-visible-task",
+                                   plan::PlanFragment(vector_plan),
+                                   0,
+                                   query_context);
+    exec::DriverContext driver_context(task, 0, 0, 0, 0);
+    exec::PhyVectorSearchNode node(1, &driver_context, vector_plan);
+
+    auto input = std::make_shared<RowVector>(std::vector<VectorPtr>{});
+    node.AddInput(input);
+    node.NoMoreInput();
+    auto output = node.GetOutput();
+    ASSERT_NE(output, nullptr);
+
+    auto search_result = query_context->get_search_result();
+    ASSERT_EQ(search_result.seg_offsets_.size(), topk);
+    ASSERT_EQ(search_result.pinned_bitsets_.size(), 1);
+    ASSERT_EQ(search_result.pinned_bitsets_[0]->size(), snapshot_rows - 1);
+
+    auto offset = search_result.seg_offsets_[0];
+    ASSERT_NE(offset, INVALID_SEG_OFFSET);
+    EXPECT_GE(offset, 1);
+    EXPECT_LT(offset, snapshot_rows);
 }
 
 TEST(SearchOnSealedColumnBitsetLifetime,

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -28,6 +28,7 @@
 namespace milvus::query {
 inline void
 FillEmptySearchResult(SearchResult& result, int64_t num_queries, int64_t topk) {
+    result.pinned_bitsets_.clear();
     auto total_num = num_queries * topk;
     result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
     result.distances_.resize(total_num, 0.0f);

--- a/internal/core/src/segcore/UtilsTest.cpp
+++ b/internal/core/src/segcore/UtilsTest.cpp
@@ -419,7 +419,7 @@ TEST(Util_Segcore, TransformBitsetMasksNullableVectorRowsOutsideLogicalView) {
 
     // Growing search passes a logical bitset sized by the query timestamp's
     // active row count. Rows beyond that logical view are not visible yet and
-    // must be masked in the transformed physical bitset.
+    // must stay outside the transformed physical search range.
     BitsetType logical_bitset(2);
     BitsetView logical_view(logical_bitset);
 
@@ -427,10 +427,9 @@ TEST(Util_Segcore, TransformBitsetMasksNullableVectorRowsOutsideLogicalView) {
     auto status = mapping.TransformBitset(logical_view, physical_bitset);
 
     EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::Transformed);
-    ASSERT_EQ(physical_bitset.size(), 3);
+    ASSERT_EQ(physical_bitset.size(), 2);
     EXPECT_FALSE(physical_bitset[0]);
     EXPECT_FALSE(physical_bitset[1]);
-    EXPECT_TRUE(physical_bitset[2]);
 }
 
 TEST(Util_Segcore, GrowingTransformBitsetMaterializesNoFilterSnapshot) {
@@ -453,7 +452,10 @@ TEST(Util_Segcore, GrowingTransformBitsetMaterializesNoFilterSnapshot) {
     std::array<bool, 2> later_valid_data = {true, true};
     mapping.Append(later_valid_data.data(), later_valid_data.size(), 5, 4);
     EXPECT_EQ(mapping.GetValidCount(), 6);
-    EXPECT_EQ(physical_bitset.size(), 4);
+
+    status = mapping.TransformBitset(logical_view, physical_bitset);
+    EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::Transformed);
+    ASSERT_EQ(physical_bitset.size(), 4);
     EXPECT_TRUE(physical_bitset.none());
 }
 


### PR DESCRIPTION
## Summary
- Cherrypick the growing nullable-vector all-visible snapshot-bound fix to 3.0.
- Materialize the all-visible growing bitset before vector search so offset mapping can trim physical vector search to the visible logical rows.
- Keep pinned bitset replacement behavior and coverage aligned with the master fix.

pr: #51988
issue: #51982

## Test plan
- [x] `git diff upstream/3.0..HEAD --check`
- [x] `clang-format-15 --dry-run --Werror internal/core/src/common/OffsetMapping.cpp internal/core/src/common/QueryResult.h internal/core/src/exec/operator/VectorSearchNode.cpp internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp internal/core/src/query/Utils.h internal/core/src/segcore/UtilsTest.cpp`
- [ ] C++ unit tests not completed locally before PR creation.