### PR TITLE
enhance:[3.0] preserve storage error classification across segcore boundaries (#51530)

### DIFF
--- a/internal/core/src/segcore/ArrowFsCTest.cpp
+++ b/internal/core/src/segcore/ArrowFsCTest.cpp
@@ -14,13 +14,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <cstdlib>
 #include <memory>
+#include <string>
 
 #include "common/common_type_c.h"
 #include "gtest/gtest.h"
+#include "milvus-storage/common/extend_status.h"
 #include "segcore/arrow_fs_c.h"
 #include "test_utils/Constants.h"
+
+namespace {
+
+void
+FreeStatusMessage(CStatus& status) {
+    free(const_cast<char*>(status.error_msg));
+    status.error_msg = nullptr;
+}
+
+}  // namespace
+
+TEST(StorageStatus, ConvertsToCStatusWithoutLosingClassification) {
+    auto transient = milvus_storage::MakeExtendError(
+        milvus_storage::ExtendStatusCode::StorageTransientTimeout,
+        "storage timeout",
+        "request timed out");
+    auto transient_error = milvus_storage::ToSegcoreError(transient);
+    auto transient_status = milvus::FailureCStatus(&transient_error);
+    EXPECT_EQ(transient_status.error_code,
+              milvus::ErrorCode::StorageTransientError);
+    EXPECT_NE(std::string(transient_status.error_msg).find("storage timeout"),
+              std::string::npos);
+    FreeStatusMessage(transient_status);
+
+    auto permanent = milvus_storage::MakeExtendError(
+        milvus_storage::ExtendStatusCode::AwsErrorAccessDenied,
+        "access denied",
+        "invalid credentials");
+    auto permanent_error = milvus_storage::ToSegcoreError(permanent);
+    auto permanent_status = milvus::FailureCStatus(&permanent_error);
+    EXPECT_EQ(permanent_status.error_code, milvus::ErrorCode::StorageError);
+    EXPECT_NE(std::string(permanent_status.error_msg).find("access denied"),
+              std::string::npos);
+    FreeStatusMessage(permanent_status);
+}
 
 TEST(ArrowFileSystem, InitAndClean) {
     CStorageConfig config = {};

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -100,6 +100,7 @@
 #include "knowhere/version.h"
 #include "log/Log.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/parquet/file_reader.h"
@@ -8226,12 +8227,16 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
         "reader must exist before loading manifest column group, segment {}",
         get_segment_id());
     auto chunk_reader_result = reader->get_chunk_reader(index, needed_columns);
-    AssertInfo(chunk_reader_result.ok(),
-               "get chunk reader failed, segment {}, column group index {}, "
-               "status msg: {}",
-               get_segment_id(),
-               index,
-               chunk_reader_result.status().ToString());
+    if (!chunk_reader_result.ok()) {
+        auto error =
+            milvus_storage::ToSegcoreError(chunk_reader_result.status());
+        ThrowInfo(error.get_error_code(),
+                  "get chunk reader failed, segment {}, column group index "
+                  "{}, status msg: {}",
+                  get_segment_id(),
+                  index,
+                  error.what());
+    }
 
     auto chunk_reader = std::move(chunk_reader_result).ValueOrDie();
 
@@ -8374,12 +8379,16 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
         "reader must exist before loading manifest column group, segment {}",
         get_segment_id());
     auto chunk_reader_result = reader->get_chunk_reader(index, needed_columns);
-    AssertInfo(chunk_reader_result.ok(),
-               "get chunk reader failed, segment {}, column group index {}, "
-               "status msg: {}",
-               get_segment_id(),
-               index,
-               chunk_reader_result.status().ToString());
+    if (!chunk_reader_result.ok()) {
+        auto error =
+            milvus_storage::ToSegcoreError(chunk_reader_result.status());
+        ThrowInfo(error.get_error_code(),
+                  "get chunk reader failed, segment {}, column group index "
+                  "{}, status msg: {}",
+                  get_segment_id(),
+                  index,
+                  error.what());
+    }
 
     auto chunk_reader = std::move(chunk_reader_result).ValueOrDie();
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -60,6 +60,7 @@
 #include "log/Log.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/parquet/file_reader.h"
@@ -2876,12 +2877,16 @@ SegmentGrowingImpl::LoadColumnGroup(
     LOG_INFO("Loading segment {} column group {}", id_, index);
 
     auto chunk_reader_result = reader_->get_chunk_reader(index);
-    AssertInfo(chunk_reader_result.ok(),
-               "get chunk reader failed, segment {}, column group index {}, "
-               "error: {}",
-               get_segment_id(),
-               index,
-               chunk_reader_result.status().ToString());
+    if (!chunk_reader_result.ok()) {
+        auto error =
+            milvus_storage::ToSegcoreError(chunk_reader_result.status());
+        ThrowInfo(error.get_error_code(),
+                  "get chunk reader failed, segment {}, column group index "
+                  "{}, error: {}",
+                  get_segment_id(),
+                  index,
+                  error.what());
+    }
 
     auto chunk_reader = std::move(chunk_reader_result.ValueOrDie());
 
@@ -2892,12 +2897,15 @@ SegmentGrowingImpl::LoadColumnGroup(
                "load column group row limit should be non-negative, got {}",
                row_limit);
     auto chunk_rows_result = chunk_reader->get_chunk_rows();
-    AssertInfo(chunk_rows_result.ok(),
-               "get chunk rows failed, segment {}, column group index {}, "
-               "error: {}",
-               get_segment_id(),
-               index,
-               chunk_rows_result.status().ToString());
+    if (!chunk_rows_result.ok()) {
+        auto error = milvus_storage::ToSegcoreError(chunk_rows_result.status());
+        ThrowInfo(error.get_error_code(),
+                  "get chunk rows failed, segment {}, column group index {}, "
+                  "error: {}",
+                  get_segment_id(),
+                  index,
+                  error.what());
+    }
 
     auto chunk_rows = std::move(chunk_rows_result).ValueOrDie();
     std::vector<int64_t> row_groups_to_load;
@@ -2933,7 +2941,13 @@ SegmentGrowingImpl::LoadColumnGroup(
                 std::iota(chunk_ids.begin(), chunk_ids.end(), part.offset);
 
                 auto result = chunk_reader->get_chunks(chunk_ids, 1);
-                AssertInfo(result.ok(), "get chunks failed");
+                if (!result.ok()) {
+                    auto error =
+                        milvus_storage::ToSegcoreError(result.status());
+                    ThrowInfo(error.get_error_code(),
+                              "get chunks failed: {}",
+                              error.what());
+                }
                 return result.ValueOrDie();
             }));
     }

--- a/internal/core/src/segcore/TextColumnCache.cpp
+++ b/internal/core/src/segcore/TextColumnCache.cpp
@@ -18,6 +18,7 @@
 
 #include "common/EasyAssert.h"
 #include "log/Log.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/lob_column/lob_reference.h"
 
 namespace milvus::segcore {
@@ -71,10 +72,11 @@ TextColumnCache::GetOrCreateReader(
 
     auto reader_result = reader_factory_(std::move(fs), config);
     if (!reader_result.ok()) {
-        ThrowInfo(ErrorCode::UnexpectedError,
+        auto error = milvus_storage::ToSegcoreError(reader_result.status());
+        ThrowInfo(error.get_error_code(),
                   "Failed to create LobColumnReader for {}: {}",
                   lob_base_path,
-                  reader_result.status().message());
+                  error.what());
     }
 
     auto reader = std::shared_ptr<LobColumnReader>(
@@ -120,10 +122,11 @@ TextColumnCache::ReadText(const std::string& lob_base_path,
     std::lock_guard<std::mutex> reader_lock(cached_reader->mutex);
     auto result = cached_reader->reader->ReadText(encoded_ref, ref_size);
     if (!result.ok()) {
-        ThrowInfo(ErrorCode::UnexpectedError,
+        auto error = milvus_storage::ToSegcoreError(result.status());
+        ThrowInfo(error.get_error_code(),
                   "Failed to read text from {}: {}",
                   lob_base_path,
-                  result.status().message());
+                  error.what());
     }
 
     return std::move(result).ValueOrDie();
@@ -168,10 +171,12 @@ TextColumnCache::ReadBatch(const std::string& lob_base_path,
             std::lock_guard<std::mutex> reader_lock(cached_reader->mutex);
             auto batch_result = cached_reader->reader->ReadBatch(pending_refs);
             if (!batch_result.ok()) {
-                ThrowInfo(ErrorCode::UnexpectedError,
+                auto error =
+                    milvus_storage::ToSegcoreError(batch_result.status());
+                ThrowInfo(error.get_error_code(),
                           "Failed to read text batch from {}: {}",
                           lob_base_path,
-                          batch_result.status().message());
+                          error.what());
             }
             texts = std::move(batch_result).ValueOrDie();
         }
@@ -225,10 +230,12 @@ TextColumnCache::ReadBatchInto(
             std::lock_guard<std::mutex> reader_lock(cached_reader->mutex);
             auto batch_result = cached_reader->reader->ReadBatch(pending_refs);
             if (!batch_result.ok()) {
-                ThrowInfo(ErrorCode::UnexpectedError,
+                auto error =
+                    milvus_storage::ToSegcoreError(batch_result.status());
+                ThrowInfo(error.get_error_code(),
                           "Failed to read text batch from {}: {}",
                           lob_base_path,
-                          batch_result.status().message());
+                          error.what());
             }
             texts = std::move(batch_result).ValueOrDie();
         }

--- a/internal/core/src/segcore/TextColumnCacheTest.cpp
+++ b/internal/core/src/segcore/TextColumnCacheTest.cpp
@@ -32,6 +32,8 @@
 #include <utility>
 #include <vector>
 
+#include "common/EasyAssert.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/lob_column/lob_reference.h"
 
 namespace milvus::segcore {
@@ -136,6 +138,50 @@ class InstrumentedLobColumnReader : public LobColumnReader {
  private:
     std::shared_ptr<BlockingCallTracker> tracker_;
     bool closed_{false};
+};
+
+class FailingLobColumnReader : public LobColumnReader {
+ public:
+    explicit FailingLobColumnReader(arrow::Status status)
+        : status_(std::move(status)) {
+    }
+
+    arrow::Result<std::vector<uint8_t>>
+    ReadData(const uint8_t*, size_t) override {
+        return status_;
+    }
+
+    arrow::Result<std::vector<std::vector<uint8_t>>>
+    ReadBatchData(const std::vector<EncodedRef>&) override {
+        return status_;
+    }
+
+    arrow::Result<std::shared_ptr<arrow::BinaryArray>>
+    ReadArrowArray(const std::shared_ptr<arrow::BinaryArray>&) override {
+        return status_;
+    }
+
+    arrow::Result<std::vector<std::vector<uint8_t>>>
+    TakeData(const std::string&, const std::vector<int32_t>&) override {
+        return status_;
+    }
+
+    arrow::Status
+    Close() override {
+        return arrow::Status::OK();
+    }
+
+    bool
+    IsClosed() const override {
+        return false;
+    }
+
+    void
+    ClearCache() override {
+    }
+
+ private:
+    arrow::Status status_;
 };
 
 TextLobReaderFactory
@@ -304,6 +350,59 @@ TEST(TextColumnCache, ReadBatchIntoSerializesCallsOnCachedReader) {
     EXPECT_EQ(dst->Get(1), "mock-text");
     EXPECT_EQ(factory_calls->load(std::memory_order_relaxed), 1);
     EXPECT_EQ(tracker->CallCount(), 1);
+}
+
+TEST(TextColumnCache, PreservesStorageErrorWhenCreatingReader) {
+    auto status = milvus_storage::MakeExtendError(
+        milvus_storage::ExtendStatusCode::StorageTransientTimeout,
+        "storage timeout");
+    TextColumnCache cache(
+        TextColumnCacheConfig{},
+        [status](std::shared_ptr<arrow::fs::FileSystem>, const LobColumnConfig&)
+            -> arrow::Result<std::unique_ptr<LobColumnReader>> {
+            return status;
+        });
+    milvus_storage::api::Properties properties;
+
+    try {
+        static_cast<void>(cache.GetOrCreateReader(
+            "/tmp/text-column-cache", nullptr, properties));
+        FAIL() << "expected storage error";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(),
+                  milvus::ErrorCode::StorageTransientError);
+        EXPECT_NE(std::string(error.what()).find("storage timeout"),
+                  std::string::npos);
+    }
+}
+
+TEST(TextColumnCache, PreservesStorageErrorWhenReadingText) {
+    auto status = milvus_storage::MakeExtendError(
+        milvus_storage::ExtendStatusCode::AwsErrorAccessDenied,
+        "access denied");
+    TextColumnCache cache(
+        TextColumnCacheConfig{},
+        [status](std::shared_ptr<arrow::fs::FileSystem>, const LobColumnConfig&)
+            -> arrow::Result<std::unique_ptr<LobColumnReader>> {
+            std::unique_ptr<LobColumnReader> reader =
+                std::make_unique<FailingLobColumnReader>(status);
+            return reader;
+        });
+    milvus_storage::api::Properties properties;
+    auto ref = MakeLobReference();
+
+    try {
+        static_cast<void>(cache.ReadText("/tmp/text-column-cache",
+                                         nullptr,
+                                         properties,
+                                         ref.data(),
+                                         ref.size()));
+        FAIL() << "expected storage error";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::ErrorCode::StorageError);
+        EXPECT_NE(std::string(error.what()).find("access denied"),
+                  std::string::npos);
+    }
 }
 
 }  // namespace

--- a/internal/core/src/segcore/arrow_fs_c.cpp
+++ b/internal/core/src/segcore/arrow_fs_c.cpp
@@ -5,6 +5,7 @@
 
 #include "common/EasyAssert.h"
 #include "common/type_c.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "storage/loon_ffi/property_singleton.h"
 
@@ -20,9 +21,8 @@ InitArrowFileSystem(CStorageConfig c_storage_config) {
             auto result =
                 milvus_storage::FilesystemCache::getInstance().get(*props, "");
             if (!result.ok()) {
-                throw std::runtime_error(
-                    "Failed to populate FilesystemCache: " +
-                    result.status().ToString());
+                auto error = milvus_storage::ToSegcoreError(result.status());
+                return milvus::FailureCStatus(&error);
             }
         }
 

--- a/internal/core/src/segcore/default_fs.cpp
+++ b/internal/core/src/segcore/default_fs.cpp
@@ -2,6 +2,8 @@
 
 #include <stdexcept>
 
+#include "common/EasyAssert.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "storage/loon_ffi/property_singleton.h"
 
@@ -19,9 +21,11 @@ GetDefaultArrowFileSystem() {
     auto result =
         milvus_storage::FilesystemCache::getInstance().get(*props, "");
     if (!result.ok()) {
-        throw std::runtime_error(
-            "GetDefaultArrowFileSystem: FilesystemCache lookup failed: " +
-            result.status().ToString());
+        auto error = milvus_storage::ToSegcoreError(result.status());
+        ThrowInfo(error.get_error_code(),
+                  "GetDefaultArrowFileSystem: FilesystemCache lookup failed: "
+                  "{}",
+                  error.what());
     }
     return result.ValueOrDie();
 }

--- a/internal/core/src/segcore/external_utils_c.cpp
+++ b/internal/core/src/segcore/external_utils_c.cpp
@@ -37,6 +37,7 @@
 #include "fmt/format.h"
 #include "log/Log.h"
 #include "milvus-storage/column_groups.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/ffi_internal/bridge.h"
 #include "milvus-storage/properties.h"
 #include "milvus-storage/reader.h"
@@ -53,10 +54,18 @@ ThrowIfFFIError(LoonFFIResult result, const std::string& context) {
         return;
     }
 
+    auto extend_status_code =
+        milvus_storage::ExtendStatusCodeFromInt(result.err_code);
+    auto error_code =
+        extend_status_code.has_value()
+            ? milvus_storage::ToSegcoreErrorCode(extend_status_code.value())
+            : (loon_ffi_is_retryable_errcode(result.err_code) != 0
+                   ? milvus::StorageTransientError
+                   : milvus::StorageError);
     const char* msg = loon_ffi_get_errmsg(&result);
     std::string detail = msg != nullptr ? msg : "unknown error";
     loon_ffi_free_result(&result);
-    throw std::runtime_error(context + ": " + detail);
+    ThrowInfo(error_code, "{}: {}", context, detail);
 }
 
 struct TransactionGuard {
@@ -117,8 +126,10 @@ ReadManifestColumnGroupsWithFFI(const char* manifest_path,
     auto status = milvus_storage::column_groups_import(
         &manifest.manifest->column_groups, cgs.get());
     if (!status.ok()) {
-        throw std::runtime_error("import external segment column groups: " +
-                                 status.ToString());
+        auto error = milvus_storage::ToSegcoreError(status);
+        ThrowInfo(error.get_error_code(),
+                  "import external segment column groups: {}",
+                  error.what());
     }
     return cgs;
 }
@@ -186,7 +197,8 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
 
         auto result = reader->take(indices, 1);
         if (!result.ok()) {
-            return MakeCStatusError(result.status().ToString().c_str());
+            auto error = milvus_storage::ToSegcoreError(result.status());
+            return milvus::FailureCStatus(&error);
         }
         auto table = result.ValueOrDie();
         auto num_rows = table->num_rows();
@@ -330,7 +342,7 @@ SampleExternalSegmentFieldSizes(const char* manifest_path,
         ok.error_msg = nullptr;
         return ok;
     } catch (const std::exception& e) {
-        return MakeCStatusError(e.what());
+        return milvus::FailureCStatus(&e);
     }
 }
 

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -35,6 +35,7 @@
 #include "folly/ScopeGuard.h"
 #include "glog/logging.h"
 #include "log/Log.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/parquet/file_reader.h"
@@ -582,9 +583,13 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                                                    batch.rg_count,
                                                    reader_memory_limit,
                                                    read_parallelism);
-            AssertInfo(tables_result.ok(),
-                       "[StorageV2] Failed to read batch: " +
-                           tables_result.status().ToString());
+            if (!tables_result.ok()) {
+                auto error =
+                    milvus_storage::ToSegcoreError(tables_result.status());
+                ThrowInfo(error.get_error_code(),
+                          "[StorageV2] Failed to read batch: {}",
+                          error.what());
+            }
             auto all_tables = std::move(tables_result).ValueOrDie();
             AssertInfo(all_tables.size() == static_cast<size_t>(batch.rg_count),
                        "reader returns less tables than expected, batch rg "

--- a/internal/core/src/segcore/packed_reader_c.cpp
+++ b/internal/core/src/segcore/packed_reader_c.cpp
@@ -28,6 +28,7 @@
 #include "arrow/result.h"
 #include "common/EasyAssert.h"
 #include "common/type_c.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/ffi_c.h"
 #include "milvus-storage/packed/reader.h"
@@ -149,8 +150,8 @@ NewPackedReaderWithProperties(char** paths,
         auto fs_result = milvus_storage::FilesystemCache::getInstance().get(
             properties, filesystem_path != nullptr ? filesystem_path : "");
         if (!fs_result.ok()) {
-            return milvus::FailureCStatus(milvus::ErrorCode::FileReadFailed,
-                                          fs_result.status().ToString());
+            auto error = milvus_storage::ToSegcoreError(fs_result.status());
+            return milvus::FailureCStatus(&error);
         }
         auto trueFs = fs_result.ValueOrDie();
         auto trueSchema = arrow::ImportSchema(schema).ValueOrDie();
@@ -218,8 +219,8 @@ ReadNext(CPackedReader c_packed_reader,
         std::shared_ptr<arrow::RecordBatch> record_batch;
         auto status = packed_reader->ReadNext(&record_batch);
         if (!status.ok()) {
-            return milvus::FailureCStatus(milvus::ErrorCode::FileReadFailed,
-                                          status.ToString());
+            auto error = milvus_storage::ToSegcoreError(status);
+            return milvus::FailureCStatus(&error);
         }
         if (record_batch == nullptr) {
             // end of file

--- a/internal/core/src/segcore/packed_writer_c.cpp
+++ b/internal/core/src/segcore/packed_writer_c.cpp
@@ -32,6 +32,7 @@
 #include "fmt/core.h"
 #include "common/type_c.h"
 #include "milvus-storage/common/config.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/packed/writer.h"
 #include "monitor/scope_metric.h"
@@ -129,9 +130,10 @@ NewPackedWriterWithStorageConfig(struct ArrowSchema* schema,
                                                           columnGroups,
                                                           buffer_size,
                                                           writer_properties);
-        AssertInfo(result.ok(),
-                   "[StorageV2] Failed to create packed writer: " +
-                       result.status().ToString());
+        if (!result.ok()) {
+            auto error = milvus_storage::ToSegcoreError(result.status());
+            return milvus::FailureCStatus(&error);
+        }
         auto writer = result.ValueOrDie();
         *c_packed_writer =
             new std::shared_ptr<milvus_storage::PackedRecordBatchWriter>(
@@ -202,9 +204,10 @@ NewPackedWriter(struct ArrowSchema* schema,
                                                           columnGroups,
                                                           buffer_size,
                                                           writer_properties);
-        AssertInfo(result.ok(),
-                   "[StorageV2] Failed to create packed writer: " +
-                       result.status().ToString());
+        if (!result.ok()) {
+            auto error = milvus_storage::ToSegcoreError(result.status());
+            return milvus::FailureCStatus(&error);
+        }
         auto writer = result.ValueOrDie();
         *c_packed_writer =
             new std::shared_ptr<milvus_storage::PackedRecordBatchWriter>(
@@ -257,8 +260,8 @@ WriteRecordBatch(CPackedWriter c_packed_writer,
 
         auto status = packed_writer->Write(record_batch);
         if (!status.ok()) {
-            return milvus::FailureCStatus(milvus::ErrorCode::FileWriteFailed,
-                                          status.ToString());
+            auto error = milvus_storage::ToSegcoreError(status);
+            return milvus::FailureCStatus(&error);
         }
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
@@ -277,8 +280,8 @@ CloseWriter(CPackedWriter c_packed_writer) {
         auto status = (*packed_writer)->Close();
         delete packed_writer;
         if (!status.ok()) {
-            return milvus::FailureCStatus(milvus::ErrorCode::FileWriteFailed,
-                                          status.ToString());
+            auto error = milvus_storage::ToSegcoreError(status);
+            return milvus::FailureCStatus(&error);
         }
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
@@ -298,15 +301,15 @@ CloseAndTell(CPackedWriter c_packed_writer, int64_t* sizes, size_t num_groups) {
         auto status = (*packed_writer)->Close();
         if (!status.ok()) {
             delete packed_writer;
-            return milvus::FailureCStatus(milvus::ErrorCode::FileWriteFailed,
-                                          status.ToString());
+            auto error = milvus_storage::ToSegcoreError(status);
+            return milvus::FailureCStatus(&error);
         }
 
         auto res = (*packed_writer)->Tell();
         if (!res.ok()) {
             delete packed_writer;
-            return milvus::FailureCStatus(milvus::ErrorCode::FileReadFailed,
-                                          res.status().ToString());
+            auto error = milvus_storage::ToSegcoreError(res.status());
+            return milvus::FailureCStatus(&error);
         }
 
         const auto& size_vec = res.ValueOrDie();

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -2261,8 +2261,8 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         auto writer_result = milvus_storage::segment::SegmentWriter::Create(
             fs, arrow_schema, writer_config);
         if (!writer_result.ok()) {
-            return milvus::FailureCStatus(milvus::UnexpectedError,
-                                          writer_result.status().ToString());
+            auto error = milvus_storage::ToSegcoreError(writer_result.status());
+            return milvus::FailureCStatus(&error);
         }
         auto writer = std::move(writer_result).ValueOrDie();
 
@@ -2349,8 +2349,8 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                 arrow::RecordBatch::Make(arrow_schema, batch_rows, arrays);
             auto write_status = writer->Write(batch);
             if (!write_status.ok()) {
-                return milvus::FailureCStatus(milvus::UnexpectedError,
-                                              write_status.ToString());
+                auto error = milvus_storage::ToSegcoreError(write_status);
+                return milvus::FailureCStatus(&error);
             }
 
             current_offset += batch_rows;
@@ -2360,8 +2360,8 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         // close writer — returns ColumnGroups + LobFiles, does NOT commit
         auto close_result = writer->Close();
         if (!close_result.ok()) {
-            return milvus::FailureCStatus(milvus::UnexpectedError,
-                                          close_result.status().ToString());
+            auto error = milvus_storage::ToSegcoreError(close_result.status());
+            return milvus::FailureCStatus(&error);
         }
         auto output = std::move(close_result).ValueOrDie();
         if (rows_written > 0 && !has_timestamp) {
@@ -2445,16 +2445,17 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                 milvus_storage::api::transaction::OverwriteResolver,
                 retry_limit);
         if (!transaction_result.ok()) {
-            return milvus::FailureCStatus(
-                milvus::UnexpectedError,
-                transaction_result.status().ToString());
+            auto error =
+                milvus_storage::ToSegcoreError(transaction_result.status());
+            return milvus::FailureCStatus(&error);
         }
         auto transaction = std::move(transaction_result).ValueOrDie();
 
         auto manifest_result = transaction->GetManifest();
         if (!manifest_result.ok()) {
-            return milvus::FailureCStatus(milvus::UnexpectedError,
-                                          manifest_result.status().ToString());
+            auto error =
+                milvus_storage::ToSegcoreError(manifest_result.status());
+            return milvus::FailureCStatus(&error);
         }
         auto manifest = manifest_result.ValueOrDie();
 
@@ -2541,8 +2542,8 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                 fmt::format("{}/{}", writer_config.segment_path, rel_path);
             auto write_status = WriteRawFile(fs, full_path, serialized);
             if (!write_status.ok()) {
-                return milvus::FailureCStatus(milvus::UnexpectedError,
-                                              write_status.ToString());
+                auto error = milvus_storage::ToSegcoreError(write_status);
+                return milvus::FailureCStatus(&error);
             }
             stat_entry.paths.push_back(full_path);
 
@@ -2571,9 +2572,9 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                 for (const auto& existing_path : paths_to_merge) {
                     auto existing_result = ReadBM25StatsFile(fs, existing_path);
                     if (!existing_result.ok()) {
-                        return milvus::FailureCStatus(
-                            milvus::UnexpectedError,
-                            existing_result.status().ToString());
+                        auto error = milvus_storage::ToSegcoreError(
+                            existing_result.status());
+                        return milvus::FailureCStatus(&error);
                     }
                     merged_stats.Merge(existing_result.ValueOrDie());
                 }
@@ -2587,8 +2588,8 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                 write_status =
                     WriteRawFile(fs, merged_full_path, merged_serialized);
                 if (!write_status.ok()) {
-                    return milvus::FailureCStatus(milvus::UnexpectedError,
-                                                  write_status.ToString());
+                    auto error = milvus_storage::ToSegcoreError(write_status);
+                    return milvus::FailureCStatus(&error);
                 }
                 stat_entry.paths.push_back(merged_full_path);
                 memory_size += merged_serialized.size();
@@ -2601,8 +2602,8 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         // commit
         auto commit_result = transaction->Commit();
         if (!commit_result.ok()) {
-            return milvus::FailureCStatus(milvus::UnexpectedError,
-                                          commit_result.status().ToString());
+            auto error = milvus_storage::ToSegcoreError(commit_result.status());
+            return milvus::FailureCStatus(&error);
         }
         auto committed_version = commit_result.ValueOrDie();
 
@@ -2635,7 +2636,7 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         }
         return milvus::SuccessCStatus();
     } catch (std::exception& e) {
-        return milvus::FailureCStatus(milvus::UnexpectedError, e.what());
+        return milvus::FailureCStatus(&e);
     }
 }
 

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -47,6 +47,7 @@
 #include "glog/logging.h"
 #include "log/Log.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/reader.h"
 #include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
@@ -134,8 +135,10 @@ ManifestGroupTranslator::ManifestGroupTranslator(
       load_priority_(load_priority) {
     auto rows_result = chunk_reader_->get_chunk_rows();
     if (!rows_result.ok()) {
-        throw std::runtime_error(fmt::format("get row group rows failed: {}",
-                                             rows_result.status().ToString()));
+        auto error = milvus_storage::ToSegcoreError(rows_result.status());
+        ThrowInfo(error.get_error_code(),
+                  "get row group rows failed: {}",
+                  error.what());
     }
     const auto& row_group_rows = rows_result.ValueOrDie();
 

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -65,6 +65,7 @@
 #include "storage/loon_ffi/ffi_reader_c.h"
 #include "storage/loon_ffi/util.h"
 #include "milvus-storage/common/constants.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/ffi_c.h"
 #include "milvus-storage/format/parquet/file_reader.h"
 #include "milvus-storage/filesystem/fs.h"
@@ -1628,9 +1629,12 @@ GetFieldDatasFromManifest(
     AssertInfo(reader != nullptr, "Failed to create reader");
 
     auto reader_result = reader->get_record_batch_reader("");
-    AssertInfo(reader_result.ok(),
-               "Failed to get record batch reader: " +
-                   reader_result.status().ToString());
+    if (!reader_result.ok()) {
+        auto error = milvus_storage::ToSegcoreError(reader_result.status());
+        ThrowInfo(error.get_error_code(),
+                  "Failed to get record batch reader: {}",
+                  error.what());
+    }
 
     auto record_batch_reader = reader_result.ValueOrDie();
 
@@ -1638,8 +1642,12 @@ GetFieldDatasFromManifest(
     while (true) {
         std::shared_ptr<arrow::RecordBatch> batch;
         auto status = record_batch_reader->ReadNext(&batch);
-        AssertInfo(status.ok(),
-                   "Failed to read record batch: " + status.ToString());
+        if (!status.ok()) {
+            auto error = milvus_storage::ToSegcoreError(status);
+            ThrowInfo(error.get_error_code(),
+                      "Failed to read record batch: {}",
+                      error.what());
+        }
         if (batch == nullptr) {
             break;
         }
@@ -1751,10 +1759,13 @@ OpenTextFieldSegmentReader(
 
     auto fs_result = milvus_storage::FilesystemCache::getInstance().get(
         *loon_ffi_properties, segment_base_path);
-    AssertInfo(fs_result.ok(),
-               "Failed to get filesystem for TEXT field {}: {}",
-               field_meta.field_id,
-               fs_result.status().ToString());
+    if (!fs_result.ok()) {
+        auto error = milvus_storage::ToSegcoreError(fs_result.status());
+        ThrowInfo(error.get_error_code(),
+                  "Failed to get filesystem for TEXT field {}: {}",
+                  field_meta.field_id,
+                  error.what());
+    }
     auto fs = std::move(fs_result.ValueOrDie());
 
     auto schema = BuildTextFieldReaderSchema(field_meta, column_name);
@@ -1763,10 +1774,13 @@ OpenTextFieldSegmentReader(
 
     auto reader_result = milvus_storage::segment::SegmentReader::Open(
         fs, loon_manifest, schema, {column_name}, config);
-    AssertInfo(reader_result.ok(),
-               "Failed to open SegmentReader for TEXT field {}: {}",
-               field_meta.field_id,
-               reader_result.status().ToString());
+    if (!reader_result.ok()) {
+        auto error = milvus_storage::ToSegcoreError(reader_result.status());
+        ThrowInfo(error.get_error_code(),
+                  "Failed to open SegmentReader for TEXT field {}: {}",
+                  field_meta.field_id,
+                  error.what());
+    }
     return std::move(reader_result.ValueOrDie());
 }
 
@@ -1798,10 +1812,13 @@ GetTextFieldDatasFromManifest(
     while (true) {
         std::shared_ptr<arrow::RecordBatch> batch;
         auto status = reader->ReadNext(&batch);
-        AssertInfo(status.ok(),
-                   "Failed to read TEXT field {} from manifest: {}",
-                   field_meta.field_id,
-                   status.ToString());
+        if (!status.ok()) {
+            auto error = milvus_storage::ToSegcoreError(status);
+            ThrowInfo(error.get_error_code(),
+                      "Failed to read TEXT field {} from manifest: {}",
+                      field_meta.field_id,
+                      error.what());
+        }
         if (batch == nullptr) {
             break;
         }
@@ -1827,10 +1844,13 @@ GetTextFieldDatasFromManifest(
     }
 
     auto status = reader->Close();
-    AssertInfo(status.ok(),
-               "Failed to close SegmentReader for TEXT field {}: {}",
-               field_meta.field_id,
-               status.ToString());
+    if (!status.ok()) {
+        auto error = milvus_storage::ToSegcoreError(status);
+        ThrowInfo(error.get_error_code(),
+                  "Failed to close SegmentReader for TEXT field {}: {}",
+                  field_meta.field_id,
+                  error.what());
+    }
 
     return field_datas;
 }

--- a/internal/core/src/storage/loon_ffi/ffi_reader_c.cpp
+++ b/internal/core/src/storage/loon_ffi/ffi_reader_c.cpp
@@ -24,6 +24,7 @@
 #include "common/EasyAssert.h"
 #include "common/common_type_c.h"
 #include "milvus-storage/column_groups.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/ffi_c.h"
 #include "milvus-storage/ffi_internal/bridge.h"
 #include "milvus-storage/manifest.h"
@@ -154,9 +155,10 @@ NewPackedFFIReaderWithManifest(const LoonManifest* loon_manifest,
             std::make_shared<milvus_storage::api::ColumnGroups>();
         auto status = milvus_storage::column_groups_import(
             &loon_manifest->column_groups, column_groups.get());
-        AssertInfo(status.ok(),
-                   "Failed to import column groups: {}",
-                   status.ToString());
+        if (!status.ok()) {
+            auto error = milvus_storage::ToSegcoreError(status);
+            return milvus::FailureCStatus(&error);
+        }
 
         auto reader = GetLoonReader(column_groups,
                                     schema,
@@ -200,9 +202,10 @@ NewPackedFFIReaderWithColumnGroups(const LoonColumnGroups* column_groups,
             std::make_shared<milvus_storage::api::ColumnGroups>();
         auto status = milvus_storage::column_groups_import(
             column_groups, imported_column_groups.get());
-        AssertInfo(status.ok(),
-                   "Failed to import column groups: {}",
-                   status.ToString());
+        if (!status.ok()) {
+            auto error = milvus_storage::ToSegcoreError(status);
+            return milvus::FailureCStatus(&error);
+        }
 
         auto reader = GetLoonReader(imported_column_groups,
                                     schema,
@@ -229,9 +232,10 @@ GetFFIReaderStream(CFFIPackedReader c_packed_reader,
             static_cast<milvus_storage::api::Reader*>(c_packed_reader);
 
         auto result = reader->get_record_batch_reader();
-        AssertInfo(result.ok(),
-                   "failed to get record batch reader, {}",
-                   result.status().ToString());
+        if (!result.ok()) {
+            auto error = milvus_storage::ToSegcoreError(result.status());
+            return milvus::FailureCStatus(&error);
+        }
 
         auto array_stream = result.ValueOrDie();
 

--- a/internal/core/src/storage/loon_ffi/milvus_table_c.cpp
+++ b/internal/core/src/storage/loon_ffi/milvus_table_c.cpp
@@ -159,6 +159,8 @@ ThrowIfFFIError(LoonFFIResult result, const std::string& context) {
     const char* msg = loon_ffi_get_errmsg(&result);
     std::string detail = msg != nullptr ? msg : "unknown error";
     loon_ffi_free_result(&result);
+    // FIXME: Preserve result.err_code across this nested FFI boundary instead
+    // of letting the outer RETURN_EXCEPTION collapse every failure to code 5.
     throw std::runtime_error(context + ": " + detail);
 }
 

--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -31,6 +31,7 @@
 #include "common/EasyAssert.h"
 #include "log/Log.h"
 #include "common/type_c.h"
+#include "milvus-storage/common/extend_status.h"
 #include "milvus-storage/ffi_c.h"
 #include "milvus-storage/ffi_internal/ffi_error_code.h"
 #include "milvus-storage/ffi_internal/result.h"
@@ -747,9 +748,12 @@ GetLoonManifest(
 
         auto fs_result =
             milvus_storage::FilesystemCache::getInstance().get(*properties);
-        AssertInfo(fs_result.ok(),
-                   "Failed to get filesystem: {}",
-                   fs_result.status().ToString());
+        if (!fs_result.ok()) {
+            auto error = milvus_storage::ToSegcoreError(fs_result.status());
+            ThrowInfo(error.get_error_code(),
+                      "Failed to get filesystem: {}",
+                      error.what());
+        }
         auto fs = std::move(fs_result.ValueOrDie());
 
         auto transaction_result =
@@ -759,14 +763,22 @@ GetLoonManifest(
                 version,
                 milvus_storage::api::transaction::FailResolver,
                 1);
-        AssertInfo(transaction_result.ok(),
-                   "Failed to open transaction: {}",
-                   transaction_result.status().ToString());
+        if (!transaction_result.ok()) {
+            auto error =
+                milvus_storage::ToSegcoreError(transaction_result.status());
+            ThrowInfo(error.get_error_code(),
+                      "Failed to open transaction: {}",
+                      error.what());
+        }
         auto transaction = std::move(transaction_result.ValueOrDie());
         auto manifest_result = transaction->GetManifest();
-        AssertInfo(manifest_result.ok(),
-                   "Failed to get manifest: {}",
-                   manifest_result.status().ToString());
+        if (!manifest_result.ok()) {
+            auto error =
+                milvus_storage::ToSegcoreError(manifest_result.status());
+            ThrowInfo(error.get_error_code(),
+                      "Failed to get manifest: {}",
+                      error.what());
+        }
         auto current_manifest = manifest_result.ValueOrDie();
         return current_manifest;
     } catch (const json::parse_error& e) {

--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -199,11 +199,11 @@ func (bw *BulkPackWriterV3) Write(ctx context.Context, pack *SyncPack) (
 // classifyLoonErr maps loon FFI failures to retryable errors and everything
 // else to retry.Unrecoverable so the outer retry loop terminates immediately.
 //
-// NOTE: today milvus-storage does not expose structured error codes, so
-// packed.ErrLoonTransient covers ALL loon errors, including non-recoverable
-// IO failures. The bounded retry budget keeps the worst case finite. Once
-// milvus-storage adds explicit error codes, narrow the retryable set here so
-// only the concurrent-transaction case retries.
+// NOTE: today milvus-storage does not reliably preserve structured error codes
+// through every FFI path, so packed.ErrLoonTransient covers ALL loon errors,
+// including non-recoverable IO failures. The bounded retry budget keeps the
+// worst case finite. Once error codes survive end-to-end, narrow the retryable
+// set here.
 func classifyLoonErr(err error) error {
 	if err == nil {
 		return nil

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -228,12 +228,13 @@ func GetFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*File
 func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
 	defer C.loon_ffi_free_result(&ffiResult)
 	if C.loon_ffi_is_success(&ffiResult) == 0 {
+		errCode := int(ffiResult.err_code)
 		errMsg := C.loon_ffi_get_errmsg(&ffiResult)
 		errStr := "Unknown error"
 		if errMsg != nil {
 			errStr = C.GoString(errMsg)
 		}
-		return merr.WrapErrStorageMsg("loon FFI error: %s", errStr)
+		return merr.WrapErrStorageMsg("loon FFI error (code %d): %s", errCode, errStr)
 	}
 	return nil
 }

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -71,6 +71,7 @@ func TestExploreFiles_InvalidDirectory(t *testing.T) {
 	)
 
 	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrLoonTransient)
 	assert.Nil(t, files)
 }
 

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -24,16 +24,16 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
-// ErrLoonTransient marks any failure surfaced by the loon FFI layer. Today
-// milvus-storage does not expose structured error codes, so callers cannot
-// distinguish a recoverable concurrent-transaction conflict from a hard IO
-// error. We treat all loon failures as retryable for now and rely on a
-// bounded retry budget plus outer error handling to keep the worst case
-// finite.
+// ErrLoonTransient marks any failure surfaced by the loon FFI layer. Some
+// milvus-storage paths can still lose their structured error detail and fall
+// back to a generic error code, so callers cannot reliably distinguish a
+// transient failure from a permanent one. Treat all loon failures as retryable
+// for now and rely on a bounded retry budget plus outer error handling to keep
+// the worst case finite.
 //
-// TODO(storage v3): once milvus-storage exposes explicit error codes, narrow
-// this sentinel to only the concurrent-transaction case (FailResolver) and
-// let other errors propagate immediately as retry.Unrecoverable.
+// TODO(storage v3): once every milvus-storage FFI path preserves explicit error
+// codes end-to-end, narrow this sentinel to the retryable cases and let other
+// errors propagate immediately as retry.Unrecoverable.
 var ErrLoonTransient = errors.New("loon FFI transient error")
 
 // Property keys exported by milvus-storage/ffi_c.h.

--- a/pkg/util/merr/segcore.go
+++ b/pkg/util/merr/segcore.go
@@ -117,6 +117,7 @@ var segcoreCodeTable = map[int32]segcoreClass{
 	2034: {sentinel: ErrSegcore, retriable: true}, // MemAllocateFailed: OOM
 	2036: {sentinel: ErrSegcore, retriable: true}, // MmapError
 	2043: {sentinel: ErrSegcore, retriable: true}, // InsufficientResource
+	2045: {sentinel: ErrSegcore, retriable: true}, // StorageTransientError: retryable storage/network failure
 
 	// Permanent system errors registered explicitly so a future reader does not
 	// mistake them for "unclassified" and flip them to retriable. They map to the
@@ -125,6 +126,7 @@ var segcoreCodeTable = map[int32]segcoreClass{
 	2004: {sentinel: ErrSegcore}, // IndexBuildError: build failed (bad data / permanent)
 	2016: {sentinel: ErrSegcore}, // BucketInvalid: misconfigured bucket (same on every replica)
 	2017: {sentinel: ErrSegcore}, // ObjectNotExist: object missing in shared storage (reroute won't help)
+	2044: {sentinel: ErrSegcore}, // StorageError: permanent storage failure
 
 	// Previously-unclassified C++ codes registered explicitly (review §2): an
 	// unknown code still falls back to non-retriable ErrSegcore, but registering
@@ -144,8 +146,6 @@ var segcoreCodeTable = map[int32]segcoreClass{
 	2030: {sentinel: ErrSegcore},                   // UnistdError: syscall failure
 	2035: {sentinel: ErrSegcore},                   // MemAllocateSizeNotMatch: size logic bug (not OOM)
 	2041: {sentinel: ErrSegcore},                   // TextIndexNotFound
-	2044: {sentinel: ErrSegcore},                   // StorageError: permanent storage fallback
-	2045: {sentinel: ErrSegcore, retriable: true},  // StorageTransientError: transient storage fallback
 }
 
 // classifySegcoreError converts a C++ segcore error code + message into a

--- a/pkg/util/merr/segcore_test.go
+++ b/pkg/util/merr/segcore_test.go
@@ -91,7 +91,7 @@ func TestSegcoreErrorClassification(t *testing.T) {
 		// Transient system codes (object storage / local IO / OOM / mmap /
 		// folly / field-not-loaded / insufficient-resource) -> retriable
 		// system errors, never InputError.
-		for _, code := range []int32{2012, 2014, 2015, 2018, 2027, 2034, 2036, 2037, 2040, 2043} {
+		for _, code := range []int32{2012, 2014, 2015, 2018, 2027, 2034, 2036, 2037, 2040, 2043, 2045} {
 			err := SegcoreError(code, "transient failure")
 			assert.Equal(t, SystemError, GetErrorType(err), "code %d", code)
 			assert.True(t, Status(err).GetRetriable(), "code %d should be retriable", code)
@@ -100,8 +100,8 @@ func TestSegcoreErrorClassification(t *testing.T) {
 
 	t.Run("permanent_system_classification", func(t *testing.T) {
 		// Registered permanent system codes stay non-retriable system errors:
-		// IndexBuildError, BucketInvalid, ObjectNotExist.
-		for _, code := range []int32{2004, 2016, 2017} {
+		// IndexBuildError, BucketInvalid, ObjectNotExist, StorageError.
+		for _, code := range []int32{2004, 2016, 2017, 2044} {
 			err := SegcoreError(code, "permanent failure")
 			assert.Equal(t, SystemError, GetErrorType(err), "code %d", code)
 			assert.False(t, Status(err).GetRetriable(), "code %d should not be retriable", code)


### PR DESCRIPTION
issue: #50915
pr: #51530

Storage failures were being flattened into generic unexpected, read, or write errors as they crossed milvus-storage, Arrow, segcore, and cgo boundaries. This hid the difference between retryable network or service failures and permanent storage, permission, configuration, or data errors, leaving upper layers without reliable information for retry and failure handling.

This change routes storage-backed Arrow statuses through ToSegcoreError across filesystem initialization, packed readers and writers, segment loading and flushing, manifest translation, memory planning, and text or LOB reads. The resulting SegcoreError is preserved through ThrowInfo or FailureCStatus, while the StorageError and StorageTransientError codes are registered in merr so Go keeps the intended retriable classification.

The packed Loon FFI handler now reads the structured error code instead of treating every failure as transient. Errors explicitly marked retryable by milvus-storage continue to carry ErrLoonTransient, while permanent failures become typed storage errors. Returned messages also include the original Loon code, and the affected sync and external refresh paths now handle the narrowed transient signal and permanent storage failures consistently. Packed reader shutdown keeps its previous behavior by releasing the reader without changing how close-status failures are surfaced. The remaining nested milvus-table FFI code-loss path is documented with a FIXME because it should be addressed through a consistent boundary design instead of introducing a one-off exception type.

---------