### PR TITLE
enhance: rewrite storage.MergeSort as a proper k-way merge

### DIFF
--- a/internal/datanode/compactor/merge_sort.go
+++ b/internal/datanode/compactor/merge_sort.go
@@ -134,13 +134,14 @@ func mergeSortMultipleSegments(ctx context.Context,
 
 	if _, err = storage.MergeSort(compactionParams.BinLogMaxSize, writerSchema, segmentReaders, writer, predicate, sortByFields); err != nil {
 		// segmentReaders[i] is built from binlogs[i], so the reader index the
-		// error names indexes into this list.
+		// error names, when it names one, indexes into this list.
 		segmentIDs := make([]int64, len(binlogs))
 		for i, s := range binlogs {
 			segmentIDs[i] = s.GetSegmentID()
 		}
 		log.Warn(ctx, "compact wrong, failed to merge sort segments",
-			mlog.Int64s("segmentIDs", segmentIDs),
+			mlog.Int64("collectionID", collectionID),
+			mlog.Int64s("segmentIDsByReaderIndex", segmentIDs),
 			mlog.Int64s("sortByFields", sortByFields),
 			mlog.Err(err))
 		if closeErr := writer.Close(); closeErr != nil {

--- a/internal/datanode/compactor/merge_sort.go
+++ b/internal/datanode/compactor/merge_sort.go
@@ -133,6 +133,16 @@ func mergeSortMultipleSegments(ctx context.Context,
 	}
 
 	if _, err = storage.MergeSort(compactionParams.BinLogMaxSize, writerSchema, segmentReaders, writer, predicate, sortByFields); err != nil {
+		// segmentReaders[i] is built from binlogs[i], so the reader index the
+		// error names indexes into this list.
+		segmentIDs := make([]int64, len(binlogs))
+		for i, s := range binlogs {
+			segmentIDs[i] = s.GetSegmentID()
+		}
+		log.Warn(ctx, "compact wrong, failed to merge sort segments",
+			mlog.Int64s("segmentIDs", segmentIDs),
+			mlog.Int64s("sortByFields", sortByFields),
+			mlog.Err(err))
 		if closeErr := writer.Close(); closeErr != nil {
 			log.Warn(ctx, "failed to close writer after merge sort error", mlog.Err(closeErr))
 		}

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -562,9 +562,11 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 	return planResult, nil
 }
 
-// canMergeSort reports whether this plan's segments can be merged by
-// storage.MergeSort, which requires every input to be physically ordered by the
-// plan's merge key.
+// canMergeSort reports whether this plan is eligible for storage.MergeSort,
+// which merges without sorting and so requires every input to already be
+// ordered by the plan's merge key. This checks that each segment carries a
+// sort flag from sort compaction; it does not yet check that the flag
+// corresponds to this plan's merge key.
 func canMergeSort(plan *datapb.CompactionPlan, params compaction.Params) bool {
 	if !params.UseMergeSort {
 		return false
@@ -574,7 +576,7 @@ func canMergeSort(plan *datapb.CompactionPlan, params compaction.Params) bool {
 			return false
 		}
 	}
-	// Merge sort holds one record per reader, so the reader count is capped. A
+	// Each reader holds a live record, so memory grows with the reader count. A
 	// single segment is allowed: merge sort keeps the output flagged sorted,
 	// whereas mergeSplit emits it unsorted and needs a follow-up sort compaction.
 	return len(plan.GetSegmentBinlogs()) <= params.MaxSegmentMergeSort

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -469,24 +469,11 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 		return nil, err
 	}
 
-	sortMergeAppicable := t.compactionParams.UseMergeSort
-	if sortMergeAppicable {
-		for _, segment := range t.plan.GetSegmentBinlogs() {
-			if !segment.GetIsSorted() && !segment.GetIsSortedByNamespace() {
-				sortMergeAppicable = false
-				break
-			}
-		}
-
-		if len(t.plan.GetSegmentBinlogs()) > t.compactionParams.MaxSegmentMergeSort {
-			// sort merge is not applicable if there is only one segment or too many segments
-			sortMergeAppicable = false
-		}
-	}
+	useMergeSort := canMergeSort(t.plan, t.compactionParams)
 
 	var res []*datapb.CompactionSegment
 	var err error
-	if sortMergeAppicable {
+	if useMergeSort {
 		mlog.Info(context.TODO(), "compact by merge sort")
 		writerOpts := t.buildWriterOptions(ctx)
 		res, err = mergeSortMultipleSegments(ctxTimeout, t.plan, t.collectionID, t.partitionID, t.maxRows, t.binlogIO,
@@ -573,6 +560,24 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 		Type:     t.plan.GetType(),
 	}
 	return planResult, nil
+}
+
+// canMergeSort reports whether this plan's segments can be merged by
+// storage.MergeSort, which requires every input to be physically ordered by the
+// plan's merge key.
+func canMergeSort(plan *datapb.CompactionPlan, params compaction.Params) bool {
+	if !params.UseMergeSort {
+		return false
+	}
+	for _, segment := range plan.GetSegmentBinlogs() {
+		if !segment.GetIsSorted() && !segment.GetIsSortedByNamespace() {
+			return false
+		}
+	}
+	// Merge sort holds one record per reader, so the reader count is capped. A
+	// single segment is allowed: merge sort keeps the output flagged sorted,
+	// whereas mergeSplit emits it unsorted and needs a follow-up sort compaction.
+	return len(plan.GetSegmentBinlogs()) <= params.MaxSegmentMergeSort
 }
 
 func (t *mixCompactionTask) Complete() {

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -480,7 +480,11 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 			t.plan.GetSegmentBinlogs(), t.tr, t.currentTime, t.plan.GetCollectionTtl(), t.compactionParams,
 			writerOpts, t.lobContext, t.sortByFieldIDs)
 		if err != nil {
-			mlog.Warn(ctx, "compact wrong, fail to merge sort segments",
+			// Compactor-boundary catch-all: mergeSortMultipleSegments can fail
+			// before it ever reaches the merge sort step (reader/writer
+			// construction, deltalog composition, ...), and those paths don't
+			// log on their own, so this line is their only record.
+			mlog.Warn(ctx, "compact wrong, merge sort compaction failed (compactor boundary)",
 				mlog.Int64("planID", t.GetPlanID()),
 				mlog.Int64("collectionID", t.collectionID),
 				mlog.Err(err))

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -480,7 +480,10 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 			t.plan.GetSegmentBinlogs(), t.tr, t.currentTime, t.plan.GetCollectionTtl(), t.compactionParams,
 			writerOpts, t.lobContext, t.sortByFieldIDs)
 		if err != nil {
-			mlog.Warn(context.TODO(), "compact wrong, fail to merge sort segments", mlog.Err(err))
+			mlog.Warn(ctx, "compact wrong, fail to merge sort segments",
+				mlog.Int64("planID", t.GetPlanID()),
+				mlog.Int64("collectionID", t.collectionID),
+				mlog.Err(err))
 			return nil, err
 		}
 	} else {

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -570,11 +570,13 @@ func canMergeSort(plan *datapb.CompactionPlan, params compaction.Params) bool {
 	if !params.UseMergeSort {
 		return false
 	}
-	// The two sorted flags record which of the two orders sort compaction wrote a
-	// segment in. This plan merges by [pk] or [partitionKey, pk] under the same
-	// schema setting, so the flag that must be set is the matching one, not
-	// either one. namespaceEnabled is read from the same expression that
-	// internal/datanode/services.go uses to derive sortByFieldIDs.
+	// The two sorted flags record which order the compactors that write sorted
+	// output used. datanode/services.go derives this plan's merge key from the
+	// same EnableNamespace setting -- [pk], or [partitionKey, pk] -- so the flag
+	// that must be set is the matching one, not either one. It also rejects the
+	// plan outright when a namespace-enabled collection has no partition key
+	// (namespace.mode=partition), which is why reading the setting is enough
+	// here rather than inspecting the merge key itself.
 	namespaceEnabled := plan.GetSchema().GetEnableNamespace()
 	for _, segment := range plan.GetSegmentBinlogs() {
 		sortedByMergeKey := segment.GetIsSorted()

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -564,15 +564,24 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 
 // canMergeSort reports whether this plan is eligible for storage.MergeSort,
 // which merges without sorting and so requires every input to already be
-// ordered by the plan's merge key. This checks that each segment carries a
-// sort flag from sort compaction; it does not yet check that the flag
-// corresponds to this plan's merge key.
+// ordered by the plan's merge key. A plan that is not eligible falls back to
+// mergeSplit, which does not assume ordering.
 func canMergeSort(plan *datapb.CompactionPlan, params compaction.Params) bool {
 	if !params.UseMergeSort {
 		return false
 	}
+	// The two sorted flags record which of the two orders sort compaction wrote a
+	// segment in. This plan merges by [pk] or [partitionKey, pk] under the same
+	// schema setting, so the flag that must be set is the matching one, not
+	// either one. namespaceEnabled is read from the same expression that
+	// internal/datanode/services.go uses to derive sortByFieldIDs.
+	namespaceEnabled := plan.GetSchema().GetEnableNamespace()
 	for _, segment := range plan.GetSegmentBinlogs() {
-		if !segment.GetIsSorted() && !segment.GetIsSortedByNamespace() {
+		sortedByMergeKey := segment.GetIsSorted()
+		if namespaceEnabled {
+			sortedByMergeKey = segment.GetIsSortedByNamespace()
+		}
+		if !sortedByMergeKey {
 			return false
 		}
 	}

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -1430,3 +1430,41 @@ func BenchmarkMixCompactor(b *testing.B) {
 
 	s.TearDownTest()
 }
+
+func TestCanMergeSort(t *testing.T) {
+	params := compaction.Params{UseMergeSort: true, MaxSegmentMergeSort: 30}
+	emptySchema := &schemapb.CollectionSchema{}
+
+	t.Run("disabled by param", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema:         emptySchema,
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1, IsSorted: true}},
+		}
+		assert.False(t, canMergeSort(plan, compaction.Params{UseMergeSort: false, MaxSegmentMergeSort: 30}))
+	})
+
+	t.Run("unsorted segment rejected", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema:         emptySchema,
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1}},
+		}
+		assert.False(t, canMergeSort(plan, params))
+	})
+
+	t.Run("single sorted segment allowed", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema:         emptySchema,
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1, IsSorted: true}},
+		}
+		assert.True(t, canMergeSort(plan, params))
+	})
+
+	t.Run("too many segments rejected", func(t *testing.T) {
+		segs := make([]*datapb.CompactionSegmentBinlogs, params.MaxSegmentMergeSort+1)
+		for i := range segs {
+			segs[i] = &datapb.CompactionSegmentBinlogs{SegmentID: int64(i), IsSorted: true}
+		}
+		plan := &datapb.CompactionPlan{Schema: emptySchema, SegmentBinlogs: segs}
+		assert.False(t, canMergeSort(plan, params))
+	})
+}

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -1433,11 +1433,14 @@ func BenchmarkMixCompactor(b *testing.B) {
 
 func TestCanMergeSort(t *testing.T) {
 	params := compaction.Params{UseMergeSort: true, MaxSegmentMergeSort: 30}
-	emptySchema := &schemapb.CollectionSchema{}
+	// EnableNamespace is false here, so the merge key is [pk] and IsSorted is
+	// the flag canMergeSort requires. TestCanMergeSortMatchesMergeKey covers
+	// the namespace-enabled half.
+	namespaceDisabledSchema := &schemapb.CollectionSchema{}
 
 	t.Run("disabled by param", func(t *testing.T) {
 		plan := &datapb.CompactionPlan{
-			Schema:         emptySchema,
+			Schema:         namespaceDisabledSchema,
 			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1, IsSorted: true}},
 		}
 		assert.False(t, canMergeSort(plan, compaction.Params{UseMergeSort: false, MaxSegmentMergeSort: 30}))
@@ -1445,7 +1448,7 @@ func TestCanMergeSort(t *testing.T) {
 
 	t.Run("unsorted segment rejected", func(t *testing.T) {
 		plan := &datapb.CompactionPlan{
-			Schema:         emptySchema,
+			Schema:         namespaceDisabledSchema,
 			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1}},
 		}
 		assert.False(t, canMergeSort(plan, params))
@@ -1453,7 +1456,7 @@ func TestCanMergeSort(t *testing.T) {
 
 	t.Run("single sorted segment allowed", func(t *testing.T) {
 		plan := &datapb.CompactionPlan{
-			Schema:         emptySchema,
+			Schema:         namespaceDisabledSchema,
 			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{SegmentID: 1, IsSorted: true}},
 		}
 		assert.True(t, canMergeSort(plan, params))
@@ -1464,7 +1467,7 @@ func TestCanMergeSort(t *testing.T) {
 		for i := range segs {
 			segs[i] = &datapb.CompactionSegmentBinlogs{SegmentID: int64(i), IsSorted: true}
 		}
-		plan := &datapb.CompactionPlan{Schema: emptySchema, SegmentBinlogs: segs}
+		plan := &datapb.CompactionPlan{Schema: namespaceDisabledSchema, SegmentBinlogs: segs}
 		assert.False(t, canMergeSort(plan, params))
 	})
 
@@ -1473,13 +1476,13 @@ func TestCanMergeSort(t *testing.T) {
 		for i := range segs {
 			segs[i] = &datapb.CompactionSegmentBinlogs{SegmentID: int64(i), IsSorted: true}
 		}
-		plan := &datapb.CompactionPlan{Schema: emptySchema, SegmentBinlogs: segs}
+		plan := &datapb.CompactionPlan{Schema: namespaceDisabledSchema, SegmentBinlogs: segs}
 		assert.True(t, canMergeSort(plan, params))
 	})
 
 	t.Run("later unsorted segment rejected", func(t *testing.T) {
 		plan := &datapb.CompactionPlan{
-			Schema: emptySchema,
+			Schema: namespaceDisabledSchema,
 			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
 				{SegmentID: 1, IsSorted: true},
 				{SegmentID: 2},

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -1467,4 +1467,24 @@ func TestCanMergeSort(t *testing.T) {
 		plan := &datapb.CompactionPlan{Schema: emptySchema, SegmentBinlogs: segs}
 		assert.False(t, canMergeSort(plan, params))
 	})
+
+	t.Run("exactly max segments allowed", func(t *testing.T) {
+		segs := make([]*datapb.CompactionSegmentBinlogs, params.MaxSegmentMergeSort)
+		for i := range segs {
+			segs[i] = &datapb.CompactionSegmentBinlogs{SegmentID: int64(i), IsSorted: true}
+		}
+		plan := &datapb.CompactionPlan{Schema: emptySchema, SegmentBinlogs: segs}
+		assert.True(t, canMergeSort(plan, params))
+	})
+
+	t.Run("later unsorted segment rejected", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema: emptySchema,
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+				{SegmentID: 1, IsSorted: true},
+				{SegmentID: 2},
+			},
+		}
+		assert.False(t, canMergeSort(plan, params))
+	})
 }

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -1488,3 +1488,48 @@ func TestCanMergeSort(t *testing.T) {
 		assert.False(t, canMergeSort(plan, params))
 	})
 }
+
+func TestCanMergeSortMatchesMergeKey(t *testing.T) {
+	params := compaction.Params{UseMergeSort: true, MaxSegmentMergeSort: 30}
+
+	t.Run("namespace enabled rejects pk-only sorted segment", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema: &schemapb.CollectionSchema{EnableNamespace: true},
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+				{SegmentID: 1, IsSorted: true, IsSortedByNamespace: false},
+			},
+		}
+		assert.False(t, canMergeSort(plan, params))
+	})
+
+	t.Run("namespace enabled accepts namespace-sorted segment", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema: &schemapb.CollectionSchema{EnableNamespace: true},
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+				{SegmentID: 1, IsSorted: false, IsSortedByNamespace: true},
+			},
+		}
+		assert.True(t, canMergeSort(plan, params))
+	})
+
+	t.Run("namespace disabled rejects namespace-sorted segment", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema: &schemapb.CollectionSchema{EnableNamespace: false},
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+				{SegmentID: 1, IsSorted: false, IsSortedByNamespace: true},
+			},
+		}
+		assert.False(t, canMergeSort(plan, params))
+	})
+
+	t.Run("mixed flags rejected when one does not match", func(t *testing.T) {
+		plan := &datapb.CompactionPlan{
+			Schema: &schemapb.CollectionSchema{EnableNamespace: true},
+			SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+				{SegmentID: 1, IsSortedByNamespace: true},
+				{SegmentID: 2, IsSorted: true},
+			},
+		}
+		assert.False(t, canMergeSort(plan, params))
+	})
+}

--- a/internal/datanode/compactor/namespace_compactor_test.go
+++ b/internal/datanode/compactor/namespace_compactor_test.go
@@ -47,8 +47,8 @@ func (s *NamespaceCompactorTestSuite) SetupSuite() {
 	s.binlogIO = mock_util.NewMockBinlogIO(s.T())
 	s.binlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
 	s.schema = &schemapb.CollectionSchema{
-		// NamespaceCompactor is only constructed when the collection has
-		// namespace enabled (services.go:261), and the merge key below is
+		// NamespaceCompactor is only constructed inside the namespaceEnabled
+		// branch of datanode/services.go, and the merge key below is
 		// [partitionKey, pk] accordingly.
 		EnableNamespace: true,
 		Fields: []*schemapb.FieldSchema{
@@ -69,9 +69,10 @@ func (s *NamespaceCompactorTestSuite) SetupSuite() {
 				IsPrimaryKey: true,
 			},
 			{
-				FieldID:  101,
-				Name:     "namespace",
-				DataType: schemapb.DataType_Int64,
+				FieldID:        101,
+				Name:           "namespace",
+				DataType:       schemapb.DataType_Int64,
+				IsPartitionKey: true,
 			},
 		},
 	}

--- a/internal/datanode/compactor/namespace_compactor_test.go
+++ b/internal/datanode/compactor/namespace_compactor_test.go
@@ -47,6 +47,10 @@ func (s *NamespaceCompactorTestSuite) SetupSuite() {
 	s.binlogIO = mock_util.NewMockBinlogIO(s.T())
 	s.binlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
 	s.schema = &schemapb.CollectionSchema{
+		// NamespaceCompactor is only constructed when the collection has
+		// namespace enabled (services.go:261), and the merge key below is
+		// [partitionKey, pk] accordingly.
+		EnableNamespace: true,
 		Fields: []*schemapb.FieldSchema{
 			{
 				FieldID:  common.RowIDField,

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -358,8 +358,11 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 	recs := make([]Record, len(rr))
 	// keys[ri][fp] is the fp-th merge key column of the record reader ri holds.
 	// Allocated once and overwritten in place on every advance; recs[ri] == nil
-	// is the sole exhausted-reader sentinel, and a reader's keys are only read
-	// while that reader has an entry in the heap.
+	// is the sole exhausted-reader sentinel. keys[ri] stays valid until
+	// seedNext(ri) advances that reader again -- not merely while ri has a heap
+	// entry: the main loop reads keys[ri] in compareWithLast and saveLast after
+	// popping ri's only entry. Moving either of those after seedNext would be a
+	// use-after-advance.
 	keys := make([][]sortKeyCol, len(rr))
 	for i := range keys {
 		keys[i] = make([]sortKeyCol, nk)
@@ -426,10 +429,13 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 			if c := compareKeys(x, y); c != 0 {
 				return c < 0
 			}
-			if x.ri != y.ri {
-				return x.ri < y.ri
-			}
-			return x.i < y.i
+			// Equal keys break by reader index alone: a reader holds at most one
+			// heap entry, since seedNext pushes a single row and is called again
+			// only after that entry is popped. So x.ri != y.ri always holds here,
+			// and there is no second row of the same reader to order against.
+			// Stability is unaffected -- a reader's equal-key rows are re-seeded
+			// in increasing pos, so they still leave the heap in input order.
+			return x.ri < y.ri
 		},
 	}
 

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -369,6 +369,13 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 	}
 	// pos[ri] is the next row of that record to consider.
 	pos := make([]int32, len(rr))
+	// recNo[ri] counts the records that reader has produced. It turns an
+	// out-of-order row into a (record, row) coordinate, since pos -- and so
+	// idx.i -- restarts at zero on every record.
+	recNo := make([]int32, len(rr))
+	for i := range recNo {
+		recNo[i] = -1
+	}
 
 	extractKeys := func(ri int) error {
 		cols := keys[ri]
@@ -392,6 +399,7 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 			return err
 		}
 		pos[ri] = 0
+		recNo[ri]++
 		return extractKeys(ri)
 	}
 
@@ -542,8 +550,8 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 
 		if hasLast && compareWithLast(idx) < 0 {
 			return 0, merr.WrapErrDataIntegrityMsg(
-				"input record is not sorted by the merge key: reader %d row %d out of order, merge key fields %v",
-				idx.ri, idx.i, sortedByFieldIDs)
+				"input record is not sorted by the merge key: reader %d record %d row %d out of order, merge key fields %v",
+				idx.ri, recNo[idx.ri], idx.i, sortedByFieldIDs)
 		}
 		saveLast(idx)
 

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -541,7 +541,9 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 		idx := h.pop()
 
 		if hasLast && compareWithLast(idx) < 0 {
-			return 0, merr.WrapErrStorageMsg("input record is not sorted by the merge key")
+			return 0, merr.WrapErrDataIntegrityMsg(
+				"input record is not sorted by the merge key: reader %d row %d out of order, merge key fields %v",
+				idx.ri, idx.i, sortedByFieldIDs)
 		}
 		saveLast(idx)
 

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"container/heap"
 	"io"
 	"slices"
 	"time"
@@ -27,6 +26,12 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// sort key kinds shared by Sort and MergeSort.
+const (
+	keyInt64 = iota
+	keyString
 )
 
 // SortTimings holds phase-level timing information from the Sort function.
@@ -96,10 +101,6 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 	if len(sortByFieldIDs) > 0 {
 		// Pre-extract the sort key columns into flat per-record slices so the
 		// comparator avoids a Column() map lookup + type assert per comparison.
-		const (
-			keyInt64 = iota
-			keyString
-		)
 		kinds := make([]int, len(sortByFieldIDs))
 		int64Keys := make([][][]int64, len(sortByFieldIDs))
 		stringKeys := make([][][]string, len(sortByFieldIDs))
@@ -230,6 +231,63 @@ type rowIndex struct {
 	i  int32
 }
 
+// rowHeap is a min-heap of rowIndex values. It exists instead of container/heap
+// because heap.Push takes `any`, which boxes the value and costs one allocation
+// per push; MergeSort pushes once per row.
+type rowHeap struct {
+	items []rowIndex
+	less  func(x, y rowIndex) bool
+}
+
+func (h *rowHeap) len() int { return len(h.items) }
+
+func (h *rowHeap) push(v rowIndex) {
+	h.items = append(h.items, v)
+	i := len(h.items) - 1
+	for i > 0 {
+		p := (i - 1) / 2
+		if !h.less(h.items[i], h.items[p]) {
+			break
+		}
+		h.items[i], h.items[p] = h.items[p], h.items[i]
+		i = p
+	}
+}
+
+func (h *rowHeap) pop() rowIndex {
+	top := h.items[0]
+	n := len(h.items) - 1
+	h.items[0] = h.items[n]
+	h.items = h.items[:n]
+	i := 0
+	for {
+		l, r := 2*i+1, 2*i+2
+		m := i
+		if l < n && h.less(h.items[l], h.items[m]) {
+			m = l
+		}
+		if r < n && h.less(h.items[r], h.items[m]) {
+			m = r
+		}
+		if m == i {
+			break
+		}
+		h.items[i], h.items[m] = h.items[m], h.items[i]
+		i = m
+	}
+	return top
+}
+
+// sortKeyCol is a merge key column of the record a reader currently holds.
+// int64 keys reference the arrow buffer directly; varchar keys keep the array
+// pointer so Value(i) stays available without a per-comparison map lookup and
+// type assert. Both are rebuilt when the reader advances to the next record.
+type sortKeyCol struct {
+	kind int
+	i64  []int64
+	str  *array.String
+}
+
 // radixSortByInt64 sorts indices in place so that keys[indices[k].ri][indices[k].i]
 // is non-decreasing, using a stable LSD radix sort over the 8 bytes of the int64
 // key (O(N)). The sign bit is flipped so unsigned byte ordering matches signed
@@ -275,54 +333,19 @@ func radixSortByInt64(indices []rowIndex, keys [][]int64) {
 	}
 }
 
-// A PriorityQueue implements heap.Interface and holds Items.
-type PriorityQueue[T any] struct {
-	items []*T
-	less  func(x, y *T) bool
-}
-
-var _ heap.Interface = (*PriorityQueue[any])(nil)
-
-func (pq PriorityQueue[T]) Len() int { return len(pq.items) }
-
-func (pq PriorityQueue[T]) Less(i, j int) bool {
-	return pq.less(pq.items[i], pq.items[j])
-}
-
-func (pq PriorityQueue[T]) Swap(i, j int) {
-	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
-}
-
-func (pq *PriorityQueue[T]) Push(x any) {
-	pq.items = append(pq.items, x.(*T))
-}
-
-func (pq *PriorityQueue[T]) Pop() any {
-	old := pq.items
-	n := len(old)
-	x := old[n-1]
-	old[n-1] = nil
-	pq.items = old[0 : n-1]
-	return x
-}
-
-func (pq *PriorityQueue[T]) Enqueue(x *T) {
-	heap.Push(pq, x)
-}
-
-func (pq *PriorityQueue[T]) Dequeue() *T {
-	return heap.Pop(pq).(*T)
-}
-
-func NewPriorityQueue[T any](less func(x, y *T) bool) *PriorityQueue[T] {
-	pq := PriorityQueue[T]{
-		items: make([]*T, 0),
-		less:  less,
-	}
-	heap.Init(&pq)
-	return &pq
-}
-
+// MergeSort merges rows from rr, which each yield records already sorted by
+// sortedByFieldIDs, into a single sorted stream written through rw in batches
+// of roughly batchSize bytes. Rows for which predicate returns false are
+// skipped; predicate is evaluated exactly once per row.
+//
+// Performance notes (vs. the earlier all-rows-in-the-queue approach):
+//   - The heap holds one entry per reader rather than every in-flight row, so
+//     comparisons per row drop from O(log totalRows) to O(log len(rr)) and the
+//     heap stays small enough to be cache resident.
+//   - Merge keys are resolved once per record in advanceRecord instead of once
+//     per comparison, avoiding a Column() map lookup plus type assert per side.
+//   - The heap stores rowIndex by value, removing the per-row heap allocation
+//     that came from queueing *index through container/heap.
 func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader,
 	rw RecordWriter, predicate func(r Record, ri, i int) bool, sortedByFieldIDs []int64,
 ) (numRows int, err error) {
@@ -331,112 +354,119 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 		return 0, nil
 	}
 
-	type index struct {
-		ri int
-		i  int
-	}
-
+	nk := len(sortedByFieldIDs)
 	recs := make([]Record, len(rr))
-	advanceRecord := func(i int) error {
-		rec, err := rr[i].Next()
-		recs[i] = rec // assign nil if err
-		return err
+	// keys[ri][fp] is the fp-th merge key column of the record reader ri holds.
+	// Allocated once and overwritten in place on every advance; recs[ri] == nil
+	// is the sole exhausted-reader sentinel, and a reader's keys are only read
+	// while that reader has an entry in the heap.
+	keys := make([][]sortKeyCol, len(rr))
+	for i := range keys {
+		keys[i] = make([]sortKeyCol, nk)
 	}
+	// pos[ri] is the next row of that record to consider.
+	pos := make([]int32, len(rr))
 
-	for i := range rr {
-		err := advanceRecord(i)
-		if err == io.EOF {
-			continue
-		}
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	comparators := make([]func(x, y *index) int, 0, len(sortedByFieldIDs))
-	for _, fid := range sortedByFieldIDs {
-		switch recs[0].Column(fid).(type) {
-		case *array.Int64:
-			comparators = append(comparators, func(x, y *index) int {
-				xVal := recs[x.ri].Column(fid).(*array.Int64).Value(x.i)
-				yVal := recs[y.ri].Column(fid).(*array.Int64).Value(y.i)
-				if xVal < yVal {
-					return -1
-				}
-				if xVal > yVal {
-					return 1
-				}
-				return 0
-			})
-		case *array.String:
-			comparators = append(comparators, func(x, y *index) int {
-				xVal := recs[x.ri].Column(fid).(*array.String).Value(x.i)
-				yVal := recs[y.ri].Column(fid).(*array.String).Value(y.i)
-				if xVal < yVal {
-					return -1
-				}
-				if xVal > yVal {
-					return 1
-				}
-				return 0
-			})
-		default:
-			return 0, merr.WrapErrStorageMsg("unsupported type for sorting key")
-		}
-	}
-
-	pq := NewPriorityQueue(func(x, y *index) bool {
-		for _, cmp := range comparators {
-			c := cmp(x, y)
-			if c < 0 {
-				return true
-			}
-			if c > 0 {
-				return false
+	extractKeys := func(ri int) error {
+		cols := keys[ri]
+		for fp, fid := range sortedByFieldIDs {
+			switch a := recs[ri].Column(fid).(type) {
+			case *array.Int64:
+				cols[fp] = sortKeyCol{kind: keyInt64, i64: a.Int64Values()}
+			case *array.String:
+				cols[fp] = sortKeyCol{kind: keyString, str: a}
+			default:
+				return merr.WrapErrStorageMsg("unsupported type for sorting key")
 			}
 		}
-		if x.ri != y.ri {
-			return x.ri < y.ri
-		}
-		return x.i < y.i
-	})
-
-	endPositions := make([]int, len(recs))
-	var enqueueAll func(ri int) error
-	enqueueAll = func(ri int) error {
-		r := recs[ri]
-		hasValid := false
-		endPosition := 0
-		for j := 0; j < r.Len(); j++ {
-			if predicate(r, ri, j) {
-				pq.Enqueue(&index{
-					ri: ri,
-					i:  j,
-				})
-				numRows++
-				hasValid = true
-				endPosition = j
-			}
-		}
-		if !hasValid {
-			err := advanceRecord(ri)
-			if err == io.EOF {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-			return enqueueAll(ri)
-		}
-		endPositions[ri] = endPosition
 		return nil
 	}
 
-	for i, v := range recs {
-		if v != nil {
-			if err := enqueueAll(i); err != nil {
-				return 0, err
+	advanceRecord := func(ri int) error {
+		rec, err := rr[ri].Next()
+		recs[ri] = rec // assign nil if err
+		if err != nil {
+			return err
+		}
+		pos[ri] = 0
+		return extractKeys(ri)
+	}
+
+	// compareKeys orders two rows that are both currently live in the heap.
+	// sortKeyCol is 40 bytes, so take it by pointer: this runs on both sides of
+	// every comparison.
+	compareKeys := func(x, y rowIndex) int {
+		for fp := 0; fp < nk; fp++ {
+			cx, cy := &keys[x.ri][fp], &keys[y.ri][fp]
+			switch cx.kind {
+			case keyInt64:
+				xv, yv := cx.i64[x.i], cy.i64[y.i]
+				if xv != yv {
+					if xv < yv {
+						return -1
+					}
+					return 1
+				}
+			case keyString:
+				xv, yv := cx.str.Value(int(x.i)), cy.str.Value(int(y.i))
+				if xv != yv {
+					if xv < yv {
+						return -1
+					}
+					return 1
+				}
 			}
+		}
+		return 0
+	}
+
+	h := &rowHeap{
+		items: make([]rowIndex, 0, len(rr)),
+		less: func(x, y rowIndex) bool {
+			if c := compareKeys(x, y); c != 0 {
+				return c < 0
+			}
+			if x.ri != y.ri {
+				return x.ri < y.ri
+			}
+			return x.i < y.i
+		},
+	}
+
+	// seedNext pushes reader ri's next qualifying row, advancing across records
+	// as needed. Every (record, row) position is evaluated by predicate exactly
+	// once: pos only moves forward within a record, and is reset only when
+	// advanceRecord installs a new one.
+	seedNext := func(ri int) error {
+		for recs[ri] != nil {
+			r := recs[ri]
+			for int(pos[ri]) < r.Len() {
+				i := pos[ri]
+				if predicate(r, ri, int(i)) {
+					h.push(rowIndex{ri: int32(ri), i: i})
+					return nil
+				}
+				pos[ri]++
+			}
+			if err := advanceRecord(ri); err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+		}
+		return nil
+	}
+
+	for i := range rr {
+		if err := advanceRecord(i); err != nil {
+			if err == io.EOF {
+				continue
+			}
+			return 0, err
+		}
+		if err := seedNext(i); err != nil {
+			return 0, err
 		}
 	}
 
@@ -450,11 +480,70 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 		return nil
 	}
 
-	for pq.Len() > 0 {
-		idx := pq.Dequeue()
-		if err := rb.Append(recs[idx.ri], idx.i, idx.i+1); err != nil {
+	// The emitted key must never decrease. It can only do so when an input
+	// record is not sorted by the merge key, which this merge relies on. Detect
+	// that explicitly instead of silently emitting rows out of order. The
+	// previous key is kept by value because seedNext may already have advanced
+	// the record it came from, and records are only borrowed from the reader.
+	lastI64 := make([]int64, nk)
+	// varchar keys are copied into reusable buffers rather than cloned per row:
+	// the arrow buffer is only borrowed until the reader advances, but a fresh
+	// string per row would reintroduce exactly the per-row allocation this
+	// rewrite removes. Comparing via string(buf) does not allocate.
+	lastStrBuf := make([][]byte, nk)
+	hasLast := false
+
+	compareWithLast := func(x rowIndex) int {
+		for fp := 0; fp < nk; fp++ {
+			cx := &keys[x.ri][fp]
+			switch cx.kind {
+			case keyInt64:
+				xv := cx.i64[x.i]
+				if xv != lastI64[fp] {
+					if xv < lastI64[fp] {
+						return -1
+					}
+					return 1
+				}
+			case keyString:
+				xv := cx.str.Value(int(x.i))
+				if xv != string(lastStrBuf[fp]) {
+					if xv < string(lastStrBuf[fp]) {
+						return -1
+					}
+					return 1
+				}
+			}
+		}
+		return 0
+	}
+
+	saveLast := func(x rowIndex) {
+		for fp := 0; fp < nk; fp++ {
+			cx := &keys[x.ri][fp]
+			switch cx.kind {
+			case keyInt64:
+				lastI64[fp] = cx.i64[x.i]
+			case keyString:
+				lastStrBuf[fp] = append(lastStrBuf[fp][:0], cx.str.Value(int(x.i))...)
+			}
+		}
+		hasLast = true
+	}
+
+	for h.len() > 0 {
+		idx := h.pop()
+
+		if hasLast && compareWithLast(idx) < 0 {
+			return 0, merr.WrapErrStorageMsg("input record is not sorted by the merge key")
+		}
+		saveLast(idx)
+
+		if err := rb.Append(recs[idx.ri], int(idx.i), int(idx.i)+1); err != nil {
 			return 0, err
 		}
+		numRows++
+
 		// Due to current arrow impl (v12), the write performance is largely dependent on the batch size,
 		//	small batch size will cause write performance degradation. To work around this issue, we accumulate
 		//	records and write them in batches. This requires additional memory copy.
@@ -464,18 +553,9 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 			}
 		}
 
-		// If the popped idx reaches the last valid data of the segment, invalidate the cache and advance to the next record
-		if idx.i == endPositions[idx.ri] {
-			err := advanceRecord(idx.ri)
-			if err == io.EOF {
-				continue
-			}
-			if err != nil {
-				return 0, err
-			}
-			if err := enqueueAll(idx.ri); err != nil {
-				return 0, err
-			}
+		pos[idx.ri]++
+		if err := seedNext(int(idx.ri)); err != nil {
+			return 0, err
 		}
 	}
 

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -645,3 +645,58 @@ func TestMergeSortPredicateCalledOncePerRow(t *testing.T) {
 		assert.Equalf(t, 1, n, "predicate called %d times for pk %d", n, pk)
 	}
 }
+
+func TestRowHeap(t *testing.T) {
+	h := &rowHeap{less: func(x, y rowIndex) bool {
+		if x.ri != y.ri {
+			return x.ri < y.ri
+		}
+		return x.i < y.i
+	}}
+	assert.Equal(t, 0, h.len())
+
+	in := []rowIndex{{3, 1}, {1, 2}, {2, 0}, {1, 0}, {3, 0}, {2, 1}}
+	for _, v := range in {
+		h.push(v)
+	}
+	assert.Equal(t, len(in), h.len())
+
+	var got []rowIndex
+	for h.len() > 0 {
+		got = append(got, h.pop())
+	}
+	assert.Equal(t, []rowIndex{{1, 0}, {1, 2}, {2, 0}, {2, 1}, {3, 0}, {3, 1}}, got)
+}
+
+func TestRowHeapSingleElement(t *testing.T) {
+	h := &rowHeap{less: func(x, y rowIndex) bool { return x.i < y.i }}
+	h.push(rowIndex{0, 7})
+	assert.Equal(t, 1, h.len())
+	assert.Equal(t, rowIndex{0, 7}, h.pop())
+	assert.Equal(t, 0, h.len())
+}
+
+// A k-way merge relies on each input record being sorted by the merge key.
+// When that does not hold, fail explicitly rather than emitting rows out of
+// order. This is the shape reported in #48322: the last row of a record carries
+// the smallest key, and the next record is shorter.
+func TestMergeSortUnsortedInputReturnsError(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {50, 60, 1}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {70}}, nil),
+	}}
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(1024, schema, []RecordReader{r0}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField})
+	assert.ErrorContains(t, err, "not sorted by the merge key")
+}

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type oneShotRecordReader struct {
@@ -699,4 +700,6 @@ func TestMergeSortUnsortedInputReturnsError(t *testing.T) {
 		return true
 	}, []int64{common.RowIDField})
 	assert.ErrorContains(t, err, "not sorted by the merge key")
+	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
+	assert.ErrorContains(t, err, "reader 0")
 }

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -48,6 +50,62 @@ func (r *oneShotRecordReader) Next() (Record, error) {
 func (r *oneShotRecordReader) Close() error {
 	return nil
 }
+
+// mergeSortTestRec builds a record with one column per given field. int64Cols
+// and strCols are keyed by FieldID; all columns must have the same length.
+func mergeSortTestRec(t *testing.T, int64Cols map[FieldID][]int64, strCols map[FieldID][]string) Record {
+	t.Helper()
+	fids := make([]FieldID, 0, len(int64Cols)+len(strCols))
+	for fid := range int64Cols {
+		fids = append(fids, fid)
+	}
+	for fid := range strCols {
+		fids = append(fids, fid)
+	}
+	slices.Sort(fids)
+
+	fields := make([]arrow.Field, 0, len(fids))
+	arrs := make([]arrow.Array, 0, len(fids))
+	f2c := make(map[FieldID]int, len(fids))
+	n := 0
+	for _, fid := range fids {
+		if vals, ok := int64Cols[fid]; ok {
+			b := array.NewInt64Builder(memory.DefaultAllocator)
+			b.AppendValues(vals, nil)
+			arrs = append(arrs, b.NewArray())
+			b.Release()
+			fields = append(fields, arrow.Field{Name: strconv.FormatInt(fid, 10), Type: arrow.PrimitiveTypes.Int64})
+			n = len(vals)
+		} else {
+			vals := strCols[fid]
+			b := array.NewStringBuilder(memory.DefaultAllocator)
+			b.AppendValues(vals, nil)
+			arrs = append(arrs, b.NewArray())
+			b.Release()
+			fields = append(fields, arrow.Field{Name: strconv.FormatInt(fid, 10), Type: arrow.BinaryTypes.String})
+			n = len(vals)
+		}
+		f2c[fid] = len(arrs) - 1
+	}
+	return NewSimpleArrowRecord(array.NewRecord(arrow.NewSchema(fields, nil), arrs, int64(n)), f2c)
+}
+
+// sliceRecordReader yields the given records in order.
+type sliceRecordReader struct {
+	recs []Record
+	pos  int
+}
+
+func (r *sliceRecordReader) Next() (Record, error) {
+	if r.pos >= len(r.recs) {
+		return nil, io.EOF
+	}
+	rec := r.recs[r.pos]
+	r.pos++
+	return rec, nil
+}
+
+func (r *sliceRecordReader) Close() error { return nil }
 
 func TestRadixSortByInt64(t *testing.T) {
 	t.Run("edge values across records", func(t *testing.T) {
@@ -230,9 +288,15 @@ func TestMergeSort(t *testing.T) {
 	lastPK := int64(-1)
 	rw := &MockRecordWriter{
 		writefn: func(r Record) error {
-			pk := r.Column(common.RowIDField).(*array.Int64).Value(0)
-			assert.Greater(t, pk, lastPK)
-			lastPK = pk
+			// check every row, not just the first of each batch. The two
+			// readers overlap on pk, so the merged order is non-decreasing
+			// rather than strictly increasing.
+			col := r.Column(common.RowIDField).(*array.Int64)
+			for i := 0; i < col.Len(); i++ {
+				pk := col.Value(i)
+				assert.GreaterOrEqual(t, pk, lastPK)
+				lastPK = pk
+			}
 			return nil
 		},
 
@@ -242,7 +306,8 @@ func TestMergeSort(t *testing.T) {
 		},
 	}
 
-	const batchSize = 64 * 1024 * 1024
+	// small enough to force multiple output batches
+	const batchSize = 4096
 
 	t.Run("merge sort", func(t *testing.T) {
 		gotNumRows, err := MergeSort(batchSize, generateTestSchema(), getReaders(), rw, func(r Record, ri, i int) bool {
@@ -344,6 +409,93 @@ func BenchmarkSort(b *testing.B) {
 	})
 }
 
+// Benchmark merge sort
+func BenchmarkMergeSort(b *testing.B) {
+	batch := 100000
+	const batchSize = 64 * 1024 * 1024
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	// Generate the payload once: it dwarfs the merge itself, and ReportAllocs
+	// counts allocations made inside StopTimer too.
+	blobs10, err := generateTestDataWithSeed(batch, batch)
+	assert.NoError(b, err)
+	blobs20, err := generateTestDataWithSeed(batch*2+1, batch)
+	assert.NoError(b, err)
+	schema := generateTestSchema()
+
+	b.Run("merge_sort", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			// readers are single-use, so only they are rebuilt per iteration
+			reader10 := newIterativeCompositeBinlogRecordReader(schema, nil, MakeBlobsReader(blobs10))
+			reader20 := newIterativeCompositeBinlogRecordReader(schema, nil, MakeBlobsReader(blobs20))
+
+			_, err := MergeSort(batchSize, schema, []RecordReader{reader20, reader10}, rw,
+				func(r Record, ri, i int) bool { return true }, []int64{common.RowIDField})
+			assert.NoError(b, err)
+		}
+	})
+}
+
+// Benchmark merge sort on a varchar key, which takes the string comparison path
+// and the reusable key buffer in the ordering check.
+func BenchmarkMergeSortVarcharKey(b *testing.B) {
+	const strField = FieldID(16)
+	const rowsPerRec = 4096
+	const recsPerReader = 8
+	const batchSize = 64 * 1024 * 1024
+
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: strField, Name: "vc", DataType: schemapb.DataType_VarChar, IsPrimaryKey: true},
+	}}
+
+	// two interleaved ascending key spaces, 32-byte keys
+	build := func(t *testing.B, offset int) []Record {
+		recs := make([]Record, recsPerReader)
+		k := offset
+		for j := range recs {
+			vals := make([]string, rowsPerRec)
+			for i := range vals {
+				vals[i] = fmt.Sprintf("%024d%08d", k, k)
+				k += 2
+			}
+			bld := array.NewStringBuilder(memory.DefaultAllocator)
+			bld.AppendValues(vals, nil)
+			arr := bld.NewArray()
+			bld.Release()
+			recs[j] = NewSimpleArrowRecord(
+				array.NewRecord(arrow.NewSchema([]arrow.Field{{Name: "16", Type: arrow.BinaryTypes.String}}, nil),
+					[]arrow.Array{arr}, int64(rowsPerRec)),
+				map[FieldID]int{strField: 0})
+		}
+		return recs
+	}
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	// records are read-only here, so build them once and only rewrap per iteration
+	recs0, recs1 := build(b, 0), build(b, 1)
+
+	b.Run("merge_sort_varchar", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			r0 := &sliceRecordReader{recs: recs0}
+			r1 := &sliceRecordReader{recs: recs1}
+
+			_, err := MergeSort(batchSize, schema, []RecordReader{r0, r1}, rw,
+				func(r Record, ri, i int) bool { return true }, []int64{strField})
+			assert.NoError(b, err)
+		}
+	})
+}
+
 func TestSortByMoreThanOneField(t *testing.T) {
 	const batchSize = 10000
 	sortByFieldIDs := []int64{common.RowIDField, common.TimeStampField}
@@ -378,4 +530,118 @@ func TestSortByMoreThanOneField(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, batchSize*2, gotNumRows)
 	assert.NoError(t, rw.Close())
+}
+
+func TestMergeSortVarcharKey(t *testing.T) {
+	const strField = FieldID(16)
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: strField, Name: "vc", DataType: schemapb.DataType_VarChar, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, nil, map[FieldID][]string{strField: {"a", "c", "e"}}),
+		mergeSortTestRec(t, nil, map[FieldID][]string{strField: {"g", "i"}}),
+	}}
+	r1 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, nil, map[FieldID][]string{strField: {"b", "d", "f", "h"}}),
+	}}
+
+	var got []string
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			col := r.Column(strField).(*array.String)
+			for i := 0; i < col.Len(); i++ {
+				got = append(got, col.Value(i))
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	n, err := MergeSort(16, schema, []RecordReader{r0, r1}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{strField})
+	assert.NoError(t, err)
+	assert.Equal(t, 9, n)
+	assert.NoError(t, rw.Close())
+	assert.Equal(t, []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}, got)
+}
+
+func TestMergeSortByMoreThanOneField(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		{FieldID: common.TimeStampField, Name: "ts", DataType: schemapb.DataType_Int64},
+	}}
+
+	// each record is ascending by (rowid, ts)
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{
+			common.RowIDField:     {1, 1, 3},
+			common.TimeStampField: {10, 20, 10},
+		}, nil),
+	}}
+	r1 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{
+			common.RowIDField:     {1, 2, 3},
+			common.TimeStampField: {15, 5, 5},
+		}, nil),
+	}}
+
+	type pair struct{ pk, ts int64 }
+	var got []pair
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error {
+			pk := r.Column(common.RowIDField).(*array.Int64)
+			ts := r.Column(common.TimeStampField).(*array.Int64)
+			for i := 0; i < pk.Len(); i++ {
+				got = append(got, pair{pk.Value(i), ts.Value(i)})
+			}
+			return nil
+		},
+		closefn: func() error { return nil },
+	}
+
+	n, err := MergeSort(16, schema, []RecordReader{r0, r1}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField, common.TimeStampField})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, n)
+	assert.NoError(t, rw.Close())
+	assert.Equal(t, []pair{{1, 10}, {1, 15}, {1, 20}, {2, 5}, {3, 5}, {3, 10}}, got)
+}
+
+// The predicate carries a side effect in production (segmentTotalRows[ri]++ in
+// merge_sort.go), so every row must be evaluated exactly once.
+func TestMergeSortPredicateCalledOncePerRow(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {1, 3, 5}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {7, 9}}, nil),
+	}}
+	r1 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {2, 4, 6, 8}}, nil),
+	}}
+
+	// pk is unique across all records here, so it identifies a row globally.
+	counts := map[int64]int{}
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(16, schema, []RecordReader{r0, r1}, rw, func(r Record, ri, i int) bool {
+		pk := r.Column(common.RowIDField).(*array.Int64).Value(i)
+		counts[pk]++
+		return pk%3 != 0 // also exercise skipping filtered rows
+	}, []int64{common.RowIDField})
+	assert.NoError(t, err)
+	assert.NoError(t, rw.Close())
+
+	assert.Equal(t, 9, len(counts), "every row must be visited exactly once")
+	for pk, n := range counts {
+		assert.Equalf(t, 1, n, "predicate called %d times for pk %d", n, pk)
+	}
 }

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -701,5 +701,33 @@ func TestMergeSortUnsortedInputReturnsError(t *testing.T) {
 	}, []int64{common.RowIDField})
 	assert.ErrorContains(t, err, "not sorted by the merge key")
 	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
-	assert.ErrorContains(t, err, "reader 0")
+	assert.ErrorContains(t, err, "reader 0 record 0 row 2 out of order")
+}
+
+// The disorder in TestMergeSortUnsortedInputReturnsError falls in the reader's
+// first record, so a reported record number of 0 does not prove that number
+// was actually computed rather than hardcoded. This variant keeps the first
+// record in order and puts the offending row in the second record, so the
+// reported record number must be non-zero to be correct.
+func TestMergeSortUnsortedInputReportsLaterRecord(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {10, 20, 30}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {5, 40}}, nil),
+	}}
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(1024, schema, []RecordReader{r0}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField})
+	assert.ErrorContains(t, err, "not sorted by the merge key")
+	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
+	assert.ErrorContains(t, err, "reader 0 record 1 row 0 out of order")
 }

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -731,3 +731,35 @@ func TestMergeSortUnsortedInputReportsLaterRecord(t *testing.T) {
 	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 	assert.ErrorContains(t, err, "reader 0 record 1 row 0 out of order")
 }
+
+// Both preceding tests drive a single reader, so idx.ri is always 0 in the
+// error -- a hardcoded 0 in place of idx.ri would pass them too. This variant
+// uses two readers, keeps reader 0 in order throughout, and puts the disorder
+// in reader 1's second record, so the reported reader index and per-reader
+// record number are both load-bearing.
+func TestMergeSortUnsortedInputReportsOffendingReader(t *testing.T) {
+	schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+		{FieldID: common.RowIDField, Name: "rowid", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+	}}
+
+	r0 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {10, 20, 30}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {40}}, nil),
+	}}
+	r1 := &sliceRecordReader{recs: []Record{
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {15, 25}}, nil),
+		mergeSortTestRec(t, map[FieldID][]int64{common.RowIDField: {35, 5}}, nil),
+	}}
+
+	rw := &MockRecordWriter{
+		writefn: func(r Record) error { return nil },
+		closefn: func() error { return nil },
+	}
+
+	_, err := MergeSort(1024, schema, []RecordReader{r0, r1}, rw, func(r Record, ri, i int) bool {
+		return true
+	}, []int64{common.RowIDField})
+	assert.ErrorContains(t, err, "not sorted by the merge key")
+	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
+	assert.ErrorContains(t, err, "reader 1 record 1 row 1 out of order")
+}


### PR DESCRIPTION
issue: #51981

## What

`storage.MergeSort` is the default mix-compaction path (`dataNode.compaction.useMergeSort` defaults to `true`), reached via `mix_compactor.go` -> `merge_sort.go:135`. Three changes:

1. **Heap holds k entries, not every in-flight row.** `enqueueAll` pushed every qualifying row of the current record into the queue, so the heap held the in-flight row count rather than the reader count. Each input record is already sorted by the merge key, so the standard form applies: one entry per reader, pop one and push one. At 30 readers x 4096 rows/record the heap goes from ~246k entries to 30.

2. **Merge keys resolved once per record.** The comparator did `recs[x.ri].Column(fid).(*array.Int64).Value(x.i)` per side per comparison -- a map lookup plus a type assert whose result is invariant for a record. They are now extracted in `advanceRecord` (`Int64Values()` for int64, the `*array.String` pointer for varchar; both O(1) and copy-free).

3. **No per-row allocation.** `pq.Enqueue(&index{...})` escaped once per row, and `container/heap`'s `Push(x any)` boxes regardless. Replaced by a small typed value heap over the existing `rowIndex{ri, i int32}` (added in #50817). `storage.PriorityQueue` had no other users repo-wide and is removed, along with the `endPositions` bookkeeping.

The sibling `Sort` in the same file already received (2) and (3) in #50817.

## Numbers

`BenchmarkMergeSort` (added here), 200k rows over `generateTestSchema()` -- 20 fields including 5 vector types. Median of 3, `-benchtime 10x -cpu 1`:

| | before | after |
|---|---|---|
| time | 523.50 ms | **325.96 ms (1.61x)** |
| allocs | 302,617 | **102,599 (-66%)** |

The gain depends on how much `rb.Append` dominates. `BenchmarkMergeSortVarcharKey`, 65k rows over a single varchar field:

| | before | after |
|---|---|---|
| time | 60.83 ms | **9.18 ms (6.63x)** |
| allocs | 65,642 | **91** |
| B/op | 6.11 MB | 4.84 MB (-21%) |

The varchar allocation count is the cleanest evidence: 65,642 is approximately the 65,536 rows, i.e. one allocation per row; after is 91 in total, identical across all three runs.

## One deliberate behavior change

A k-way merge relies on each input record being sorted by the merge key. That reliance is not new, but the old path did not fail uniformly on disorder, so this is a narrowing and worth stating precisely.

`endPositions` already depended on sortedness for the general case: an unsorted record could dequeue its smallest key first and trigger `advanceRecord` while stale entries from the now-invalid record remained queued (`RecordReader.Next` is borrow-scoped, `record_reader.go:20-21`), which panics with `index out of range` -- the `[3,1,2]` shape.

But it did tolerate a narrower class. Because the old loop enqueued every eligible row of a record, disorder whose maximum key still lands on the last row (a single reader with key order `[2,1,3]`, so `endPositions[ri]` is the final index) never triggered the early `advanceRecord`: it was emitted correctly as 1,2,3 and `MergeSort` returned success. Those inputs now return an error instead. The narrowing is intended -- a bare k-way merge would emit them silently out of order, and trading a loud failure for silent corruption is the one outcome worth avoiding -- and `mix_compactor.go:473-484` gates merge-sort to already-sorted segments, so the affected class is vanishingly rare on real data.

To avoid trading a loud failure for silent corruption, the merge now checks that the emitted key never decreases and returns a merr error otherwise. The previous key is held in reusable buffers rather than cloned per row -- cloning would reintroduce exactly the per-row allocation this PR removes.

**On #48322 / #48449.** An earlier revision of this description named the gate as their root cause and called for a reachability analysis. Both parts have since been resolved, and neither the way that paragraph assumed.

#48322 was an arrow-go use-after-free on STRUCT array deallocation, fixed by milvus-io/arrow#3 and #48775 and verified on `master-20260429`. #48449 carries the same title; its closure trail is inconclusive and does not point at the gate either. Neither issue supports the attribution.

The reachability analysis has been done, and the scenario it described -- an `IsSorted=true` segment passing the gate "after `namespaceEnabled` is turned on" -- is **not reachable**. `EnableNamespace` is written only at collection creation (`ddl_callbacks_create_collection.go:217`); every schema-altering path rebuilds the snapshot through `coll.ToCollectionSchemaPB()`, which copies the stored value (`collection.go:163`), so the assignment at `collection.go:216` is an identity. And `sort_compaction.go:373-374` derives both sorted flags from that same immutable setting (`isSorted := !isNamespaceSorted`), so a segment's flag and the plan's merge key cannot disagree today.

The gate is nonetheless loose in *structure* -- it tests whether a segment was sorted, not by which key -- so it is safe by coincidence rather than by construction. This PR now tightens it.

## Gate tightened

`canMergeSort` (extracted from `Compact()` so it is unit-testable) now requires the sorted flag that corresponds to *this plan's* merge key, rather than either flag. A mismatch falls through to the existing `mergeSplit` path before any segment rows are read; no new fallback code.

Two reviewers asked for this. It is defense-in-depth, not a fix for an observed production case -- as established above, the metadata-level mismatch is not reachable today.

The failure that *is* left loud -- a segment whose flag matches but whose bytes do not -- is now diagnosable. `MergeSort` reports `ErrDataIntegrity` (`ErrStorage`'s own doc directs callers here; both are non-retriable `SystemError`, so retry semantics and classification are unchanged) with a `reader N record M row K` coordinate, and `mergeSortMultipleSegments` logs the reader-index to segment-ID mapping alongside it, so the reader index resolves to a segment.

**Not done:** degrading to `mergeSplit` when that error fires. Rationale in the review thread -- briefly, the prior behavior for general disorder was a panic, so a deterministic error is not a regression against it; and a metadata/data inconsistency is a should-not-happen class where silent degradation would hide the problem.

## Test coverage

`MergeSort` had no varchar-key test and no multi-field-key test, and `TestMergeSort`'s ordering assertion only checked `Value(0)` of each output record while the 64MB `batchSize` yielded a single batch. The first commit adds those baselines and shows them green on the pre-rewrite implementation; the second keeps them green.

- `TestMergeSort` -- every row checked, small batchSize to force multiple batches
- `TestMergeSortVarcharKey`, `TestMergeSortByMoreThanOneField` -- previously uncovered paths
- `TestMergeSortPredicateCalledOncePerRow` -- pins predicate arity, whose production implementation carries a side effect (`segmentTotalRows`)
- `TestMergeSortUnsortedInputReturnsError` -- the ordering check
- `TestMergeSortUnsortedInputReportsLaterRecord`, `TestMergeSortUnsortedInputReportsOffendingReader` -- pin the reported coordinate: the first that the record number is computed rather than always 0, the second that the reader index is too
- `TestCanMergeSort`, `TestCanMergeSortMatchesMergeKey` -- the gate, both halves of the merge-key truth table plus the segment-count boundary
- `TestRowHeap`, `TestRowHeapSingleElement`

## Verification

- `./internal/storage/ -run 'TestMergeSort|TestRowHeap|TestSort|TestRadixSort'` -- pass
- `./internal/datanode/compactor/...` -- pass
- `pkg/util/merr` guard tests -- pass (an error code changed)
- `go build -tags dynamic` on both packages -- pass
- `make static-check` -- **not verified locally**; the local golangci-lint binary is incompatible with the current Go toolchain (`unsupported version: 2`). `go vet` on both packages reports only pre-existing findings in files this PR does not touch. Relying on CI for this one.

Two pre-existing failures in the full `./internal/storage/` package (`TestAzureObjectStorage` timeout, `TestReadFile` nil deref) reproduce on unmodified master and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)