### PR TITLE
fix: [3.0] treat unset IdField in zero-hit search results as empty in chain converter

### DIFF
--- a/internal/util/function/chain/converter.go
+++ b/internal/util/function/chain/converter.go
@@ -278,7 +278,11 @@ func FromSearchResultData(resultData *schemapb.SearchResultData, alloc memory.Al
 	}
 
 	// Import ID column ($id)
-	if ids := resultData.GetIds(); ids != nil {
+	// Zero-hit results may carry Ids as a non-nil shell whose IdField oneof is
+	// unset (e.g. querynode emptySearchResultData forwarded verbatim by the
+	// single-channel reduce fast path); it holds no IDs, so treat it exactly
+	// like Ids == nil.
+	if ids := resultData.GetIds(); ids.GetIdField() != nil {
 		if err := importIDs(builder, ids, offsets, alloc); err != nil {
 			return nil, err
 		}
@@ -287,6 +291,9 @@ func FromSearchResultData(resultData *schemapb.SearchResultData, alloc memory.Al
 		if err := importEmptyIDs(builder, offsets, alloc); err != nil {
 			return nil, err
 		}
+	} else if ids != nil {
+		// IdField unset but rows present: malformed input.
+		return nil, importIDs(builder, ids, offsets, alloc)
 	}
 
 	// Import Score column ($score)

--- a/internal/util/function/chain/converter_test.go
+++ b/internal/util/function/chain/converter_test.go
@@ -2461,6 +2461,76 @@ func (s *ConverterSuite) TestFromSearchResultData_UnsupportedIDType() {
 	s.Contains(err.Error(), "unsupported ID type")
 }
 
+// Zero-hit results reach the proxy as Ids=&schemapb.IDs{} with the IdField
+// oneof unset (e.g. querynode emptySearchResultData, single-channel reduce
+// passthrough). Such a shell carries no IDs and must take the same empty
+// path as Ids == nil instead of failing with "unsupported ID type" (#50969).
+func (s *ConverterSuite) TestFromSearchResultData_EmptyIDsZeroRows() {
+	for name, ids := range map[string]*schemapb.IDs{
+		"nil ids":             nil,
+		"shell without oneof": {}, // IDs with no IdField set
+	} {
+		for _, topks := range [][]int64{{0}, {0, 0}} {
+			resultData := &schemapb.SearchResultData{
+				NumQueries: int64(len(topks)),
+				TopK:       10,
+				Topks:      topks,
+				Scores:     []float32{},
+				Ids:        ids,
+				FieldsData: []*schemapb.FieldData{},
+			}
+
+			df, err := FromSearchResultData(resultData, s.pool, nil)
+			s.Require().NoError(err, name)
+			s.Equal(int64(0), df.NumRows(), name)
+			s.True(df.HasColumn(types.IDFieldName), name)
+			idType, ok := df.FieldType(types.IDFieldName)
+			s.True(ok, name)
+			// Int64 is the converter's schema-less empty-ID fallback, not necessarily the collection PK type.
+			s.Equal(schemapb.DataType_Int64, idType, name)
+			s.True(df.HasColumn(types.ScoreFieldName), name)
+			df.Release()
+		}
+	}
+}
+
+func (s *ConverterSuite) TestFromSearchResultData_EmptyIDsNoTopks() {
+	resultData := &schemapb.SearchResultData{
+		NumQueries: 0,
+		TopK:       10,
+		Topks:      []int64{},
+		Scores:     []float32{},
+		Ids:        &schemapb.IDs{},
+		FieldsData: []*schemapb.FieldData{},
+	}
+
+	df, err := FromSearchResultData(resultData, s.pool, nil)
+	s.Require().NoError(err)
+	defer df.Release()
+	s.Equal(int64(0), df.NumRows())
+	s.False(df.HasColumn(types.IDFieldName))
+	s.False(df.HasColumn(types.ScoreFieldName))
+}
+
+// Ids == nil with rows present is tolerated: the DataFrame is built without
+// an $id column (aggregation-style results carry no IDs). Pins the
+// pre-existing passthrough so it is not accidentally turned into an error.
+func (s *ConverterSuite) TestFromSearchResultData_NilIDsWithRows() {
+	resultData := &schemapb.SearchResultData{
+		NumQueries: 1,
+		TopK:       2,
+		Topks:      []int64{2},
+		Scores:     []float32{0.9, 0.8},
+	}
+
+	df, err := FromSearchResultData(resultData, s.pool, nil)
+	s.Require().NoError(err)
+	defer df.Release()
+	s.Equal(int64(2), df.NumRows())
+	s.False(df.HasColumn(types.IDFieldName))
+	s.True(df.HasColumn(types.ScoreFieldName))
+}
+
 // =============================================================================
 // exportFieldData unsupported type
 // =============================================================================


### PR DESCRIPTION
Cherry-pick from master

issue: #50969
pr: https://github.com/milvus-io/milvus/pull/51156

## Summary

Backport #51156 to the 3.0 branch.

Zero-hit search results may reach the proxy as a non-nil `Ids: &schemapb.IDs{}` shell whose `IdField` oneof is unset. The single-channel reduce fast path forwards that shell to `chain.FromSearchResultData`, where it was previously treated as an unsupported ID type.

Treat an unset `IdField` like `Ids == nil` for zero-row results, while preserving the existing behavior for malformed shells with rows and nil IDs with rows.

## Testing

- `gofmt -l internal/util/function/chain/converter.go internal/util/function/chain/converter_test.go` is clean.
- `git diff --check upstream/3.0...HEAD` is clean.
- Focused chain tests compile and link locally. Execution in the temporary worktree is blocked by the local native runtime configuration (`libmilvus_core.dylib` has no runtime rpath); the 3.0 CI run is required for full execution verification.
