### PR TITLE
enhance: attribute column group size per field for task slot estimation

### DIFF
--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -211,7 +211,7 @@ func (i *indexInspector) createIndexForSegment(ctx context.Context, segment *Seg
 	indexType := GetIndexType(indexParams)
 	isVectorIndex := vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType)
 	fieldID := i.meta.indexMeta.GetFieldIDByIndexID(segment.CollectionID, indexID)
-	fieldSize := segment.getFieldBinlogSize(fieldID)
+	fieldSize := i.estimateIndexFieldSize(ctx, segment, fieldID)
 	taskSlot := calculateIndexTaskSlot(fieldSize, segment.NumOfRows, indexParams)
 
 	// rewrite the index type if needed, and this final index type will be persisted in the meta
@@ -264,6 +264,31 @@ func (i *indexInspector) isExternalCollection(collectionID int64) bool {
 	return coll != nil && coll.IsExternal()
 }
 
+// estimateIndexFieldSize returns the amount of data the index build task reads
+// for fieldID, which drives the task slot estimation.
+//
+// The index build only reads the indexed column, while the binlog size covers
+// the whole column group holding it. On any unresolvable schema the binlog size
+// is used, which keeps the previous (over-estimating but safe) behavior.
+func (i *indexInspector) estimateIndexFieldSize(ctx context.Context, segment *SegmentInfo, fieldID int64) int64 {
+	binlogSize := segment.getFieldBinlogSize(fieldID)
+	coll := i.meta.GetCollection(segment.GetCollectionID())
+	if coll == nil {
+		return binlogSize
+	}
+
+	fieldSize, err := estimateFieldsReadSize(coll.Schema, segment, []int64{fieldID})
+	if err != nil {
+		mlog.Warn(ctx, "failed to estimate index field size, fallback to binlog size",
+			mlog.FieldSegmentID(segment.GetID()),
+			mlog.FieldFieldID(fieldID),
+			mlog.Int64("binlogSize", binlogSize),
+			mlog.Err(err))
+		return binlogSize
+	}
+	return fieldSize
+}
+
 func (i *indexInspector) reloadFromMeta() {
 	segments := i.meta.GetAllSegmentsUnsafe()
 	for _, segment := range segments {
@@ -276,7 +301,7 @@ func (i *indexInspector) reloadFromMeta() {
 
 			indexParams := i.meta.indexMeta.GetIndexParams(segment.CollectionID, segIndex.IndexID)
 			fieldID := i.meta.indexMeta.GetFieldIDByIndexID(segment.CollectionID, segIndex.IndexID)
-			fieldSize := segment.getFieldBinlogSize(fieldID)
+			fieldSize := i.estimateIndexFieldSize(i.ctx, segment, fieldID)
 			taskSlot := calculateIndexTaskSlot(fieldSize, segment.NumOfRows, indexParams)
 
 			i.scheduler.Enqueue(newIndexBuildTask(

--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -274,9 +274,23 @@ func (i *indexInspector) isExternalCollection(collectionID int64) bool {
 // the binlog size covers the whole column group holding it. StorageV2 reads the
 // whole group and therefore keeps the binlog size. An unresolved collection
 // also keeps that previous conservative behavior.
+//
+// V3 segments do not persist their FieldBinlog arrays (the catalog skips the
+// per-FieldBinlog KVs, see isV3Segment), so the per-column attribution only
+// applies to segments flushed or refreshed during the current DataCoord
+// process lifetime; a segment recovered after a restart carries no binlogs and
+// keeps the whole-segment size until it is rewritten.
 func (i *indexInspector) estimateIndexFieldSize(ctx context.Context, coll *collectionInfo, segment *SegmentInfo, fieldID int64) int64 {
 	binlogSize := segment.getFieldBinlogSize(fieldID)
 	if !supportsFieldProjection(segment) {
+		return binlogSize
+	}
+	if len(segment.GetBinlogs()) == 0 {
+		// a manifest-backed segment recovered from the catalog: there is
+		// nothing to attribute, keep the whole-segment size
+		mlog.Debug(ctx, "no binlogs recorded for manifest-backed segment, fallback to segment size for index task slot",
+			mlog.FieldSegmentID(segment.GetID()),
+			mlog.Int64("binlogSize", binlogSize))
 		return binlogSize
 	}
 	if coll == nil {

--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -211,7 +211,10 @@ func (i *indexInspector) createIndexForSegment(ctx context.Context, segment *Seg
 	indexType := GetIndexType(indexParams)
 	isVectorIndex := vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType)
 	fieldID := i.meta.indexMeta.GetFieldIDByIndexID(segment.CollectionID, indexID)
-	fieldSize := i.estimateIndexFieldSize(ctx, resolveCollection(ctx, i.handler, segment.GetCollectionID()), segment, fieldID)
+	fieldSize := segment.getFieldBinlogSize(fieldID)
+	if supportsFieldProjection(segment) {
+		fieldSize = i.estimateIndexFieldSize(ctx, resolveCollection(ctx, i.handler, segment.GetCollectionID()), segment, fieldID)
+	}
 	taskSlot := calculateIndexTaskSlot(fieldSize, segment.NumOfRows, indexParams)
 
 	// rewrite the index type if needed, and this final index type will be persisted in the meta
@@ -267,11 +270,15 @@ func (i *indexInspector) isExternalCollection(collectionID int64) bool {
 // estimateIndexFieldSize returns the amount of data the index build task reads
 // for fieldID, which drives the task slot estimation.
 //
-// The index build only reads the indexed column, while the binlog size covers
-// the whole column group holding it. On any unresolvable schema the binlog size
-// is used, which keeps the previous (over-estimating but safe) behavior.
+// A manifest-backed StorageV3 index build projects the indexed column, while
+// the binlog size covers the whole column group holding it. StorageV2 reads the
+// whole group and therefore keeps the binlog size. An unresolvable schema also
+// keeps that previous conservative behavior.
 func (i *indexInspector) estimateIndexFieldSize(ctx context.Context, coll *collectionInfo, segment *SegmentInfo, fieldID int64) int64 {
 	binlogSize := segment.getFieldBinlogSize(fieldID)
+	if !supportsFieldProjection(segment) {
+		return binlogSize
+	}
 	if coll == nil {
 		mlog.Warn(ctx, "cannot resolve collection, fallback to binlog size for index task slot",
 			mlog.FieldCollectionID(segment.GetCollectionID()),

--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -159,10 +159,11 @@ func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *S
 		if _, ok := indexIDToSegIndexes[index.IndexID]; ok {
 			continue
 		}
-		if !i.canCreateIndexForSegment(ctx, segment, index) {
+		collection, ok := i.canCreateIndexForSegment(ctx, segment, index)
+		if !ok {
 			continue
 		}
-		if err := i.createIndexForSegment(ctx, segment, index.IndexID); err != nil {
+		if err := i.createIndexForSegment(ctx, collection, segment, index.IndexID); err != nil {
 			mlog.Warn(ctx, "create index for segment fail", mlog.FieldSegmentID(segment.ID),
 				mlog.FieldIndexID(index.IndexID))
 			return err
@@ -172,15 +173,17 @@ func (i *indexInspector) createIndexesForSegment(ctx context.Context, segment *S
 }
 
 // canCreateIndexForSegment reports whether the segment is ready to build the
-// index. The schema is resolved through the handler (lazy-loading on cache miss,
-// e.g. right after a datacoord restart); the check fails closed, deferring to
-// the next inspection round on an unresolvable or inconsistent view.
-func (i *indexInspector) canCreateIndexForSegment(ctx context.Context, segment *SegmentInfo, index *model.Index) bool {
+// index, returning the resolved collection so the caller does not have to look
+// it up again. The schema is resolved through the handler (lazy-loading on
+// cache miss, e.g. right after a datacoord restart); the check fails closed,
+// deferring to the next inspection round on an unresolvable or inconsistent
+// view.
+func (i *indexInspector) canCreateIndexForSegment(ctx context.Context, segment *SegmentInfo, index *model.Index) (*collectionInfo, bool) {
 	collection, err := i.handler.GetCollection(ctx, segment.CollectionID)
 	if err != nil || collection == nil || collection.Schema == nil {
 		mlog.Warn(ctx, "cannot resolve collection schema, defer index build",
 			mlog.FieldSegmentID(segment.ID), mlog.FieldFieldID(index.FieldID), mlog.FieldIndexID(index.IndexID), mlog.Err(err))
-		return false
+		return nil, false
 	}
 	// Function outputs are materialized by schema-bump reconciliation, which
 	// advances the segment schema version. A segment behind the collection schema
@@ -190,17 +193,17 @@ func (i *indexInspector) canCreateIndexForSegment(ctx context.Context, segment *
 		mlog.Debug(ctx, "segment schema behind collection, function outputs may be unmaterialized, defer index build",
 			mlog.FieldSegmentID(segment.ID), mlog.FieldFieldID(index.FieldID), mlog.FieldIndexID(index.IndexID),
 			mlog.Int32("segmentSchemaVersion", segment.GetSchemaVersion()), mlog.Int32("collectionSchemaVersion", collection.Schema.GetVersion()))
-		return false
+		return nil, false
 	}
 	if typeutil.GetFieldByID(collection.Schema, index.FieldID) == nil {
 		mlog.Warn(ctx, "indexed field not found in cached collection schema, defer index build",
 			mlog.FieldSegmentID(segment.ID), mlog.FieldFieldID(index.FieldID), mlog.FieldIndexID(index.IndexID))
-		return false
+		return nil, false
 	}
-	return true
+	return collection, true
 }
 
-func (i *indexInspector) createIndexForSegment(ctx context.Context, segment *SegmentInfo, indexID UniqueID) error {
+func (i *indexInspector) createIndexForSegment(ctx context.Context, collection *collectionInfo, segment *SegmentInfo, indexID UniqueID) error {
 	mlog.Info(ctx, "create index for segment", mlog.FieldSegmentID(segment.ID), mlog.FieldIndexID(indexID))
 	buildID, err := i.allocator.AllocID(context.Background())
 	if err != nil {
@@ -211,10 +214,7 @@ func (i *indexInspector) createIndexForSegment(ctx context.Context, segment *Seg
 	indexType := GetIndexType(indexParams)
 	isVectorIndex := vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType)
 	fieldID := i.meta.indexMeta.GetFieldIDByIndexID(segment.CollectionID, indexID)
-	fieldSize := segment.getFieldBinlogSize(fieldID)
-	if supportsFieldProjection(segment) {
-		fieldSize = i.estimateIndexFieldSize(ctx, resolveCollection(ctx, i.handler, segment.GetCollectionID()), segment, fieldID)
-	}
+	fieldSize := i.estimateIndexFieldSize(ctx, collection, segment, fieldID)
 	taskSlot := calculateIndexTaskSlot(fieldSize, segment.NumOfRows, indexParams)
 
 	// rewrite the index type if needed, and this final index type will be persisted in the meta
@@ -272,15 +272,18 @@ func (i *indexInspector) isExternalCollection(collectionID int64) bool {
 //
 // A manifest-backed StorageV3 index build projects the indexed column, while
 // the binlog size covers the whole column group holding it. StorageV2 reads the
-// whole group and therefore keeps the binlog size. An unresolvable schema also
-// keeps that previous conservative behavior.
+// whole group and therefore keeps the binlog size. An unresolved collection
+// also keeps that previous conservative behavior.
 func (i *indexInspector) estimateIndexFieldSize(ctx context.Context, coll *collectionInfo, segment *SegmentInfo, fieldID int64) int64 {
 	binlogSize := segment.getFieldBinlogSize(fieldID)
 	if !supportsFieldProjection(segment) {
 		return binlogSize
 	}
 	if coll == nil {
-		mlog.Warn(ctx, "cannot resolve collection, fallback to binlog size for index task slot",
+		// The collection is not cached yet, e.g. task recovery right after a
+		// restart, before the async cache reload catches up. Keep the
+		// conservative binlog size instead of loading through rootcoord here.
+		mlog.Debug(ctx, "collection not cached, fallback to binlog size for index task slot",
 			mlog.FieldCollectionID(segment.GetCollectionID()),
 			mlog.FieldSegmentID(segment.GetID()),
 			mlog.Int64("binlogSize", binlogSize))
@@ -301,9 +304,6 @@ func (i *indexInspector) estimateIndexFieldSize(ctx context.Context, coll *colle
 
 func (i *indexInspector) reloadFromMeta() {
 	segments := i.meta.GetAllSegmentsUnsafe()
-	// the collection cache is usually not filled yet at startup, and resolving
-	// it hits rootcoord, so memoize it across all recovered tasks
-	collections := newCollectionCache(i.handler)
 	for _, segment := range segments {
 		for _, segIndex := range i.meta.indexMeta.GetSegmentIndexes(segment.GetCollectionID(), segment.ID) {
 			if segIndex.IsDeleted || (segIndex.IndexState != commonpb.IndexState_Unissued &&
@@ -314,7 +314,11 @@ func (i *indexInspector) reloadFromMeta() {
 
 			indexParams := i.meta.indexMeta.GetIndexParams(segment.CollectionID, segIndex.IndexID)
 			fieldID := i.meta.indexMeta.GetFieldIDByIndexID(segment.CollectionID, segIndex.IndexID)
-			fieldSize := i.estimateIndexFieldSize(i.ctx, collections.get(i.ctx, segment.GetCollectionID()), segment, fieldID)
+			// Only the local cache is consulted: recovery runs synchronously in
+			// Start(), so it must not load collections through rootcoord. On a
+			// cold cache the estimation falls back to the conservative binlog
+			// size, which is the pre-optimization behavior.
+			fieldSize := i.estimateIndexFieldSize(i.ctx, i.meta.GetCollection(segment.GetCollectionID()), segment, fieldID)
 			taskSlot := calculateIndexTaskSlot(fieldSize, segment.NumOfRows, indexParams)
 
 			i.scheduler.Enqueue(newIndexBuildTask(

--- a/internal/datacoord/index_inspector.go
+++ b/internal/datacoord/index_inspector.go
@@ -211,7 +211,7 @@ func (i *indexInspector) createIndexForSegment(ctx context.Context, segment *Seg
 	indexType := GetIndexType(indexParams)
 	isVectorIndex := vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType)
 	fieldID := i.meta.indexMeta.GetFieldIDByIndexID(segment.CollectionID, indexID)
-	fieldSize := i.estimateIndexFieldSize(ctx, segment, fieldID)
+	fieldSize := i.estimateIndexFieldSize(ctx, resolveCollection(ctx, i.handler, segment.GetCollectionID()), segment, fieldID)
 	taskSlot := calculateIndexTaskSlot(fieldSize, segment.NumOfRows, indexParams)
 
 	// rewrite the index type if needed, and this final index type will be persisted in the meta
@@ -270,10 +270,13 @@ func (i *indexInspector) isExternalCollection(collectionID int64) bool {
 // The index build only reads the indexed column, while the binlog size covers
 // the whole column group holding it. On any unresolvable schema the binlog size
 // is used, which keeps the previous (over-estimating but safe) behavior.
-func (i *indexInspector) estimateIndexFieldSize(ctx context.Context, segment *SegmentInfo, fieldID int64) int64 {
+func (i *indexInspector) estimateIndexFieldSize(ctx context.Context, coll *collectionInfo, segment *SegmentInfo, fieldID int64) int64 {
 	binlogSize := segment.getFieldBinlogSize(fieldID)
-	coll := i.meta.GetCollection(segment.GetCollectionID())
 	if coll == nil {
+		mlog.Warn(ctx, "cannot resolve collection, fallback to binlog size for index task slot",
+			mlog.FieldCollectionID(segment.GetCollectionID()),
+			mlog.FieldSegmentID(segment.GetID()),
+			mlog.Int64("binlogSize", binlogSize))
 		return binlogSize
 	}
 
@@ -291,6 +294,9 @@ func (i *indexInspector) estimateIndexFieldSize(ctx context.Context, segment *Se
 
 func (i *indexInspector) reloadFromMeta() {
 	segments := i.meta.GetAllSegmentsUnsafe()
+	// the collection cache is usually not filled yet at startup, and resolving
+	// it hits rootcoord, so memoize it across all recovered tasks
+	collections := newCollectionCache(i.handler)
 	for _, segment := range segments {
 		for _, segIndex := range i.meta.indexMeta.GetSegmentIndexes(segment.GetCollectionID(), segment.ID) {
 			if segIndex.IsDeleted || (segIndex.IndexState != commonpb.IndexState_Unissued &&
@@ -301,7 +307,7 @@ func (i *indexInspector) reloadFromMeta() {
 
 			indexParams := i.meta.indexMeta.GetIndexParams(segment.CollectionID, segIndex.IndexID)
 			fieldID := i.meta.indexMeta.GetFieldIDByIndexID(segment.CollectionID, segIndex.IndexID)
-			fieldSize := i.estimateIndexFieldSize(i.ctx, segment, fieldID)
+			fieldSize := i.estimateIndexFieldSize(i.ctx, collections.get(i.ctx, segment.GetCollectionID()), segment, fieldID)
 			taskSlot := calculateIndexTaskSlot(fieldSize, segment.NumOfRows, indexParams)
 
 			i.scheduler.Enqueue(newIndexBuildTask(

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -159,10 +159,6 @@ func TestIndexInspector_ReloadFromMeta(t *testing.T) {
 	}
 
 	inspector := newIndexInspector(ctx, notifyChan, meta, scheduler, alloc, handler, storage, versionManager)
-	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
-		func(_ context.Context, collectionID int64) (*collectionInfo, error) {
-			return meta.GetCollection(collectionID), nil
-		}).Maybe()
 
 	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 
@@ -264,14 +260,13 @@ func TestIndexInspector_CreateIndexForSegment_FMIndexUsesMemoryBasedSlots(t *tes
 		assert.Equal(t, int64(4), scheduled.GetTaskSlot())
 	}).Return()
 
-	assert.NoError(t, inspector.createIndexForSegment(ctx, segment, 5))
+	assert.NoError(t, inspector.createIndexForSegment(ctx, meta.GetCollection(segment.CollectionID), segment, 5))
 }
 
-func TestIndexInspector_ReloadFromMetaResolvesCollectionThroughHandler(t *testing.T) {
-	// The datacoord collection cache is filled by an async goroutine, so it is
-	// usually still empty while reloadFromMeta recovers index tasks at startup.
-	// Recovered tasks must still get the per column estimate, and rootcoord must
-	// be hit once per collection, not once per task.
+func TestIndexInspector_ReloadFromMetaUsesCachedCollection(t *testing.T) {
+	// Recovery reads the collection from the local meta cache only: when the
+	// cache already holds the collection, recovered tasks get the per column
+	// estimate without going through the handler (rootcoord).
 	const (
 		collID    = UniqueID(2)
 		vecField  = UniqueID(101)
@@ -283,6 +278,7 @@ func TestIndexInspector_ReloadFromMetaResolvesCollectionThroughHandler(t *testin
 	notifyChan := make(chan int64, 1)
 	scheduler := task.NewMockGlobalScheduler(t)
 	alloc := allocator.NewMockAllocator(t)
+	// no GetCollection expectation: any handler resolution fails the test
 	handler := NewNMockHandler(t)
 	storageCli := mocks.NewChunkManager(t)
 	versionManager := newIndexEngineVersionManager()
@@ -312,8 +308,7 @@ func TestIndexInspector_ReloadFromMetaResolvesCollectionThroughHandler(t *testin
 	}
 	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 
-	// the collection lives in rootcoord only, exactly as after a restart
-	collInfo := &collectionInfo{
+	m.collections.Insert(collID, &collectionInfo{
 		ID: collID,
 		Schema: &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
@@ -329,8 +324,7 @@ func TestIndexInspector_ReloadFromMetaResolvesCollectionThroughHandler(t *testin
 				},
 			},
 		},
-	}
-	handler.EXPECT().GetCollection(mock.Anything, collID).Return(collInfo, nil).Once()
+	})
 
 	for _, segmentID := range []UniqueID{1, 2} {
 		segment := &SegmentInfo{
@@ -378,6 +372,121 @@ func TestIndexInspector_ReloadFromMetaResolvesCollectionThroughHandler(t *testin
 	for _, slot := range slots {
 		assert.Equal(t, expected, slot)
 		assert.Less(t, slot, calculateIndexTaskSlot(groupSize, numRows, indexParams))
+	}
+}
+
+func TestIndexInspector_ReloadFromMetaNeverResolvesThroughHandler(t *testing.T) {
+	// Recovery runs synchronously in Start(), so it must never load a
+	// collection through the handler (rootcoord): a StorageV2 segment keeps the
+	// whole binlog size, and a projection-capable segment whose collection is
+	// not cached yet falls back to the conservative group size.
+	const (
+		collID    = UniqueID(2)
+		vecField  = UniqueID(101)
+		numRows   = int64(3000)
+		fieldSize = int64(600 * 1024 * 1024)
+	)
+
+	ctx := context.Background()
+	notifyChan := make(chan int64, 1)
+	scheduler := task.NewMockGlobalScheduler(t)
+	alloc := allocator.NewMockAllocator(t)
+	// no GetCollection expectation: any resolution attempt fails the test
+	handler := NewNMockHandler(t)
+	storageCli := mocks.NewChunkManager(t)
+	versionManager := newIndexEngineVersionManager()
+	catalog := mocks2.NewDataCoordCatalog(t)
+
+	m := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		indexMeta: &indexMeta{
+			keyLock:          lock.NewKeyLock[UniqueID](),
+			catalog:          catalog,
+			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			indexes:          make(map[UniqueID]map[UniqueID]*model.Index),
+			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+		},
+	}
+	m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
+		3: {
+			CollectionID: collID,
+			FieldID:      vecField,
+			IndexID:      3,
+			IndexName:    indexName,
+			IndexParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "IVF_FLAT"},
+			},
+		},
+	}
+	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
+
+	// segment 1 is StorageV2, segment 2 is projection-capable but its
+	// collection is not cached: both must keep the conservative binlog size
+	// without any handler lookup.
+	segments := []*SegmentInfo{
+		{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:             1,
+				CollectionID:   collID,
+				NumOfRows:      numRows,
+				State:          commonpb.SegmentState_Flushed,
+				StorageVersion: storage.StorageV2,
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID: vecField,
+						Binlogs: []*datapb.Binlog{
+							{EntriesNum: numRows, MemorySize: fieldSize},
+						},
+					},
+				},
+			},
+		},
+		{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:             2,
+				CollectionID:   collID,
+				NumOfRows:      numRows,
+				State:          commonpb.SegmentState_Flushed,
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   "manifest.json",
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID:     0,
+						ChildFields: []int64{100, vecField},
+						Binlogs: []*datapb.Binlog{
+							{EntriesNum: numRows, MemorySize: fieldSize},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, segment := range segments {
+		m.segments.SetSegment(segment.GetID(), segment)
+		err := m.indexMeta.AddSegmentIndex(ctx, &model.SegmentIndex{
+			CollectionID: collID,
+			SegmentID:    segment.GetID(),
+			IndexID:      3,
+			BuildID:      100 + segment.GetID(),
+			NumRows:      numRows,
+			IndexState:   commonpb.IndexState_Unissued,
+		})
+		assert.NoError(t, err)
+	}
+
+	slots := make([]int64, 0, 2)
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(t task.Task) {
+		slots = append(slots, t.GetTaskSlot())
+	}).Return()
+
+	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+	inspector.reloadFromMeta()
+
+	assert.Len(t, slots, 2)
+	indexParams := m.indexMeta.indexes[collID][3].IndexParams
+	for _, slot := range slots {
+		assert.Equal(t, calculateIndexTaskSlot(fieldSize, numRows, indexParams), slot)
 	}
 }
 
@@ -594,16 +703,12 @@ func TestIndexInspector_CreateIndexForSegment_OverrideIndexType(t *testing.T) {
 	}
 
 	inspector := newIndexInspector(ctx, notifyChan, meta, scheduler, alloc, handler, storage, versionManager)
-	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
-		func(_ context.Context, collectionID int64) (*collectionInfo, error) {
-			return meta.GetCollection(collectionID), nil
-		}).Maybe()
 
 	alloc.EXPECT().AllocID(mock.Anything).Return(int64(12345), nil)
 	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 	scheduler.EXPECT().Enqueue(mock.Anything).Return()
 
-	err := inspector.createIndexForSegment(ctx, segment, 5)
+	err := inspector.createIndexForSegment(ctx, meta.GetCollection(segment.CollectionID), segment, 5)
 	assert.NoError(t, err)
 
 	segIndexes := meta.indexMeta.GetSegmentIndexes(segment.CollectionID, segment.ID)
@@ -1103,10 +1208,6 @@ func TestIndexInspector_CreateIndexForSegment_ExternalTaskSlot(t *testing.T) {
 	m.segments.SetSegment(segment.GetID(), segment)
 
 	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
-	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
-		func(_ context.Context, collectionID int64) (*collectionInfo, error) {
-			return m.GetCollection(collectionID), nil
-		}).Maybe()
 
 	var enqueuedSlot int64
 	alloc.EXPECT().AllocID(mock.Anything).Return(int64(12345), nil)
@@ -1115,7 +1216,7 @@ func TestIndexInspector_CreateIndexForSegment_ExternalTaskSlot(t *testing.T) {
 		enqueuedSlot = t.GetTaskSlot()
 	}).Return()
 
-	err := inspector.createIndexForSegment(ctx, segment, indexID)
+	err := inspector.createIndexForSegment(ctx, m.GetCollection(collID), segment, indexID)
 	assert.NoError(t, err)
 
 	// 128 dim float vector over 3000 rows is ~1.5MB, the smallest slot bucket,

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -736,3 +736,225 @@ func TestIndexInspector_FunctionOutputSchemaVersionGate(t *testing.T) {
 		assert.Contains(t, m.indexMeta.GetSegmentIndexes(collID, segment.GetID()), UniqueID(14))
 	})
 }
+
+func TestIndexInspector_estimateIndexFieldSize(t *testing.T) {
+	const (
+		collID   = UniqueID(2)
+		vecField = UniqueID(101)
+		numRows  = int64(3000)
+		// The synthetic column group of an external segment covers every
+		// column at once, so it is much larger than the indexed field alone.
+		groupSize = int64(2 * 1024 * 1024 * 1024)
+	)
+
+	ctx := context.Background()
+	notifyChan := make(chan int64, 1)
+	scheduler := task.NewMockGlobalScheduler(t)
+	alloc := allocator.NewMockAllocator(t)
+	handler := NewNMockHandler(t)
+	storageCli := mocks.NewChunkManager(t)
+	versionManager := newIndexEngineVersionManager()
+
+	m := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		indexMeta: &indexMeta{
+			keyLock:          lock.NewKeyLock[UniqueID](),
+			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			indexes:          make(map[UniqueID]map[UniqueID]*model.Index),
+			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+		},
+	}
+	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+
+	externalSchema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+			{
+				FieldID:       vecField,
+				Name:          "vec",
+				DataType:      schemapb.DataType_FloatVector,
+				ExternalField: "vec_col",
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+		},
+	}
+	// An external segment carries a single fake column group listing every
+	// field in ChildFields, so getFieldBinlogSize reports the whole segment.
+	externalSegment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:           1,
+			CollectionID: collID,
+			NumOfRows:    numRows,
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0,
+					ChildFields: []int64{100, vecField},
+					Binlogs: []*datapb.Binlog{
+						{EntriesNum: numRows, MemorySize: groupSize},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("collection not found falls back to binlog size", func(t *testing.T) {
+		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, externalSegment, vecField))
+	})
+
+	t.Run("shared column group is attributed per field", func(t *testing.T) {
+		// a normal storage v3 segment sharing one column group behaves the
+		// same way: only the indexed column is read out of the group
+		m.collections.Insert(collID, &collectionInfo{
+			ID: collID,
+			Schema: &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{
+					{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64},
+					{
+						FieldID:  vecField,
+						Name:     "vec",
+						DataType: schemapb.DataType_FloatVector,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.DimKey, Value: "128"},
+						},
+					},
+				},
+			},
+		})
+		assert.Equal(t, int64(128*4)*numRows, inspector.estimateIndexFieldSize(ctx, externalSegment, vecField))
+	})
+
+	t.Run("single field column group keeps the measured size", func(t *testing.T) {
+		m.collections.Insert(collID, &collectionInfo{ID: collID, Schema: externalSchema})
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:           2,
+				CollectionID: collID,
+				NumOfRows:    numRows,
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID: vecField,
+						Binlogs: []*datapb.Binlog{
+							{EntriesNum: numRows, MemorySize: groupSize},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, segment, vecField))
+	})
+
+	t.Run("external collection estimates from schema", func(t *testing.T) {
+		m.collections.Insert(collID, &collectionInfo{ID: collID, Schema: externalSchema})
+		assert.Equal(t, int64(128*4)*numRows, inspector.estimateIndexFieldSize(ctx, externalSegment, vecField))
+	})
+
+	t.Run("external collection falls back on unknown field", func(t *testing.T) {
+		m.collections.Insert(collID, &collectionInfo{ID: collID, Schema: externalSchema})
+		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, externalSegment, 999))
+	})
+}
+
+func TestIndexInspector_CreateIndexForSegment_ExternalTaskSlot(t *testing.T) {
+	paramtable.Init()
+
+	const (
+		collID   = UniqueID(2)
+		vecField = UniqueID(101)
+		indexID  = UniqueID(5)
+		numRows  = int64(3000)
+		// 2GB column group: the whole-segment size would ask for
+		// (2GB / 512MB) * indexTaskSlotUsage slots.
+		groupSize = int64(2 * 1024 * 1024 * 1024)
+	)
+
+	ctx := context.Background()
+	notifyChan := make(chan int64, 1)
+	scheduler := task.NewMockGlobalScheduler(t)
+	alloc := allocator.NewMockAllocator(t)
+	handler := NewNMockHandler(t)
+	storageCli := mocks.NewChunkManager(t)
+	versionManager := newIndexEngineVersionManager()
+	catalog := mocks2.NewDataCoordCatalog(t)
+
+	m := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		indexMeta: &indexMeta{
+			keyLock:          lock.NewKeyLock[UniqueID](),
+			catalog:          catalog,
+			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			indexes:          make(map[UniqueID]map[UniqueID]*model.Index),
+			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+		},
+	}
+	m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
+		indexID: {
+			CollectionID: collID,
+			FieldID:      vecField,
+			IndexID:      indexID,
+			IndexName:    indexName,
+			IndexParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "IVF_FLAT"},
+			},
+		},
+	}
+	m.collections.Insert(collID, &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+				{
+					FieldID:       vecField,
+					Name:          "vec",
+					DataType:      schemapb.DataType_FloatVector,
+					ExternalField: "vec_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "128"},
+					},
+				},
+			},
+		},
+	})
+
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:           1,
+			CollectionID: collID,
+			PartitionID:  3,
+			NumOfRows:    numRows,
+			State:        commonpb.SegmentState_Flushed,
+			Level:        datapb.SegmentLevel_L1,
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0,
+					ChildFields: []int64{100, vecField},
+					Binlogs: []*datapb.Binlog{
+						{EntriesNum: numRows, MemorySize: groupSize},
+					},
+				},
+			},
+		},
+	}
+	m.segments.SetSegment(segment.GetID(), segment)
+
+	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+
+	var enqueuedSlot int64
+	alloc.EXPECT().AllocID(mock.Anything).Return(int64(12345), nil)
+	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(t task.Task) {
+		enqueuedSlot = t.GetTaskSlot()
+	}).Return()
+
+	err := inspector.createIndexForSegment(ctx, segment, indexID)
+	assert.NoError(t, err)
+
+	// 128 dim float vector over 3000 rows is ~1.5MB, the smallest slot bucket,
+	// instead of the whole 2GB column group.
+	expected := calculateIndexTaskSlot(int64(128*4)*numRows, true)
+	assert.Equal(t, expected, enqueuedSlot)
+	assert.Less(t, enqueuedSlot, calculateIndexTaskSlot(groupSize, true))
+}

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -889,13 +889,18 @@ func TestIndexInspector_estimateIndexFieldSize(t *testing.T) {
 			return m.GetCollection(collectionID), nil
 		}).Maybe()
 
+	// Nullable is set on every user field: create time forces it for non
+	// milvus-table external collections (Pass 2 of
+	// NormalizeAndValidateExternalCollectionSchema), so this is the only
+	// schema shape production can produce here.
 	externalSchema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, Nullable: true, ExternalField: "pk_col"},
 			{
 				FieldID:       vecField,
 				Name:          "vec",
 				DataType:      schemapb.DataType_FloatVector,
+				Nullable:      true,
 				ExternalField: "vec_col",
 				TypeParams: []*commonpb.KeyValuePair{
 					{Key: common.DimKey, Value: "128"},
@@ -995,8 +1000,10 @@ func TestIndexInspector_estimateIndexFieldSize(t *testing.T) {
 	})
 
 	t.Run("external collection estimates from schema", func(t *testing.T) {
+		// all user fields are nullable, so the vector is charged its width
+		// plus the nullable encoding overhead instead of the whole group
 		m.collections.Insert(collID, &collectionInfo{ID: collID, Schema: externalSchema})
-		assert.Equal(t, int64(128*4)*numRows, inspector.estimateIndexFieldSize(ctx, m.GetCollection(collID), externalSegment, vecField))
+		assert.Equal(t, int64(128*4+nullableFixedWidthPadPerRow)*numRows, inspector.estimateIndexFieldSize(ctx, m.GetCollection(collID), externalSegment, vecField))
 	})
 
 	t.Run("external collection falls back on unknown field", func(t *testing.T) {
@@ -1049,15 +1056,18 @@ func TestIndexInspector_CreateIndexForSegment_ExternalTaskSlot(t *testing.T) {
 			},
 		},
 	}
+	// production shape: non milvus-table external user fields are always
+	// nullable (Pass 2 of NormalizeAndValidateExternalCollectionSchema)
 	m.collections.Insert(collID, &collectionInfo{
 		ID: collID,
 		Schema: &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
-				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, Nullable: true, ExternalField: "pk_col"},
 				{
 					FieldID:       vecField,
 					Name:          "vec",
 					DataType:      schemapb.DataType_FloatVector,
+					Nullable:      true,
 					ExternalField: "vec_col",
 					TypeParams: []*commonpb.KeyValuePair{
 						{Key: common.DimKey, Value: "128"},
@@ -1102,10 +1112,11 @@ func TestIndexInspector_CreateIndexForSegment_ExternalTaskSlot(t *testing.T) {
 	err := inspector.createIndexForSegment(ctx, m.GetCollection(collID), segment, indexID)
 	assert.NoError(t, err)
 
-	// 128 dim float vector over 3000 rows is ~1.5MB, the smallest slot bucket,
+	// A 128 dim nullable float vector over 3000 rows is bounded by its width
+	// plus the nullable encoding overhead — ~1.5MB, the smallest slot bucket,
 	// instead of the whole 2GB column group.
 	indexParams := m.indexMeta.indexes[collID][indexID].IndexParams
-	expected := calculateIndexTaskSlot(int64(128*4)*numRows, numRows, indexParams)
+	expected := calculateIndexTaskSlot(int64(128*4+nullableFixedWidthPadPerRow)*numRows, numRows, indexParams)
 	assert.Equal(t, expected, enqueuedSlot)
 	assert.Less(t, enqueuedSlot, calculateIndexTaskSlot(groupSize, numRows, indexParams))
 }

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -263,123 +263,13 @@ func TestIndexInspector_CreateIndexForSegment_FMIndexUsesMemoryBasedSlots(t *tes
 	assert.NoError(t, inspector.createIndexForSegment(ctx, meta.GetCollection(segment.CollectionID), segment, 5))
 }
 
-func TestIndexInspector_ReloadFromMetaUsesCachedCollection(t *testing.T) {
-	// Recovery reads the collection from the local meta cache only: when the
-	// cache already holds the collection, recovered tasks get the per column
-	// estimate without going through the handler (rootcoord).
-	const (
-		collID    = UniqueID(2)
-		vecField  = UniqueID(101)
-		numRows   = int64(3000)
-		groupSize = int64(2 * 1024 * 1024 * 1024)
-	)
-
-	ctx := context.Background()
-	notifyChan := make(chan int64, 1)
-	scheduler := task.NewMockGlobalScheduler(t)
-	alloc := allocator.NewMockAllocator(t)
-	// no GetCollection expectation: any handler resolution fails the test
-	handler := NewNMockHandler(t)
-	storageCli := mocks.NewChunkManager(t)
-	versionManager := newIndexEngineVersionManager()
-	catalog := mocks2.NewDataCoordCatalog(t)
-
-	m := &meta{
-		segments:    NewSegmentsInfo(),
-		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
-		indexMeta: &indexMeta{
-			keyLock:          lock.NewKeyLock[UniqueID](),
-			catalog:          catalog,
-			segmentBuildInfo: newSegmentIndexBuildInfo(),
-			indexes:          make(map[UniqueID]map[UniqueID]*model.Index),
-			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
-		},
-	}
-	m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
-		3: {
-			CollectionID: collID,
-			FieldID:      vecField,
-			IndexID:      3,
-			IndexName:    indexName,
-			IndexParams: []*commonpb.KeyValuePair{
-				{Key: common.IndexTypeKey, Value: "IVF_FLAT"},
-			},
-		},
-	}
-	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
-
-	m.collections.Insert(collID, &collectionInfo{
-		ID: collID,
-		Schema: &schemapb.CollectionSchema{
-			Fields: []*schemapb.FieldSchema{
-				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
-				{
-					FieldID:       vecField,
-					Name:          "vec",
-					DataType:      schemapb.DataType_FloatVector,
-					ExternalField: "vec_col",
-					TypeParams: []*commonpb.KeyValuePair{
-						{Key: common.DimKey, Value: "128"},
-					},
-				},
-			},
-		},
-	})
-
-	for _, segmentID := range []UniqueID{1, 2} {
-		segment := &SegmentInfo{
-			SegmentInfo: &datapb.SegmentInfo{
-				ID:             segmentID,
-				CollectionID:   collID,
-				NumOfRows:      numRows,
-				State:          commonpb.SegmentState_Flushed,
-				StorageVersion: storage.StorageV3,
-				ManifestPath:   "manifest.json",
-				Binlogs: []*datapb.FieldBinlog{
-					{
-						FieldID:     0,
-						ChildFields: []int64{100, vecField},
-						Binlogs: []*datapb.Binlog{
-							{EntriesNum: numRows, MemorySize: groupSize},
-						},
-					},
-				},
-			},
-		}
-		m.segments.SetSegment(segmentID, segment)
-		err := m.indexMeta.AddSegmentIndex(ctx, &model.SegmentIndex{
-			CollectionID: collID,
-			SegmentID:    segmentID,
-			IndexID:      3,
-			BuildID:      100 + segmentID,
-			NumRows:      numRows,
-			IndexState:   commonpb.IndexState_Unissued,
-		})
-		assert.NoError(t, err)
-	}
-
-	slots := make([]int64, 0, 2)
-	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(t task.Task) {
-		slots = append(slots, t.GetTaskSlot())
-	}).Return()
-
-	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
-	inspector.reloadFromMeta()
-
-	assert.Len(t, slots, 2)
-	indexParams := m.indexMeta.indexes[collID][3].IndexParams
-	expected := calculateIndexTaskSlot(int64(128*4)*numRows, numRows, indexParams)
-	for _, slot := range slots {
-		assert.Equal(t, expected, slot)
-		assert.Less(t, slot, calculateIndexTaskSlot(groupSize, numRows, indexParams))
-	}
-}
-
 func TestIndexInspector_ReloadFromMetaNeverResolvesThroughHandler(t *testing.T) {
 	// Recovery runs synchronously in Start(), so it must never load a
-	// collection through the handler (rootcoord): a StorageV2 segment keeps the
-	// whole binlog size, and a projection-capable segment whose collection is
-	// not cached yet falls back to the conservative group size.
+	// collection through the handler (rootcoord). It also never narrows the
+	// estimate: a StorageV2 segment keeps its per-field binlog size, and a
+	// manifest-backed V3 segment is recovered without FieldBinlog arrays (the
+	// catalog does not persist them), so it keeps the Stats-derived whole
+	// segment size.
 	const (
 		collID    = UniqueID(2)
 		vecField  = UniqueID(101)
@@ -421,9 +311,10 @@ func TestIndexInspector_ReloadFromMetaNeverResolvesThroughHandler(t *testing.T) 
 	}
 	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 
-	// segment 1 is StorageV2, segment 2 is projection-capable but its
-	// collection is not cached: both must keep the conservative binlog size
-	// without any handler lookup.
+	// segment 1 is StorageV2 as recovered from the catalog (per-field binlogs
+	// persisted); segment 2 is a manifest-backed V3 segment as recovered from
+	// the catalog: no FieldBinlog arrays, aggregate size on Stats only. Both
+	// must keep the conservative size without any handler lookup.
 	segments := []*SegmentInfo{
 		{
 			SegmentInfo: &datapb.SegmentInfo{
@@ -450,15 +341,7 @@ func TestIndexInspector_ReloadFromMetaNeverResolvesThroughHandler(t *testing.T) 
 				State:          commonpb.SegmentState_Flushed,
 				StorageVersion: storage.StorageV3,
 				ManifestPath:   "manifest.json",
-				Binlogs: []*datapb.FieldBinlog{
-					{
-						FieldID:     0,
-						ChildFields: []int64{100, vecField},
-						Binlogs: []*datapb.Binlog{
-							{EntriesNum: numRows, MemorySize: fieldSize},
-						},
-					},
-				},
+				Stats:          &datapb.Statistics{InsertBinlogSize: fieldSize},
 			},
 		},
 	}

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -90,6 +90,10 @@ func TestIndexInspector_inspect(t *testing.T) {
 		}
 
 		inspector := newIndexInspector(ctx, notifyChan, meta, scheduler, alloc, handler, storage, versionManager)
+		handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
+			func(_ context.Context, collectionID int64) (*collectionInfo, error) {
+				return meta.GetCollection(collectionID), nil
+			}).Maybe()
 
 		// Register all expectations before Start(): the inspector goroutine
 		// (reloadFromMeta, the ticker, and the notify channel) may invoke the
@@ -159,6 +163,10 @@ func TestIndexInspector_ReloadFromMeta(t *testing.T) {
 	}
 
 	inspector := newIndexInspector(ctx, notifyChan, meta, scheduler, alloc, handler, storage, versionManager)
+	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, collectionID int64) (*collectionInfo, error) {
+			return meta.GetCollection(collectionID), nil
+		}).Maybe()
 
 	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 
@@ -263,6 +271,118 @@ func TestIndexInspector_CreateIndexForSegment_FMIndexUsesMemoryBasedSlots(t *tes
 	assert.NoError(t, inspector.createIndexForSegment(ctx, segment, 5))
 }
 
+func TestIndexInspector_ReloadFromMetaResolvesCollectionThroughHandler(t *testing.T) {
+	// The datacoord collection cache is filled by an async goroutine, so it is
+	// usually still empty while reloadFromMeta recovers index tasks at startup.
+	// Recovered tasks must still get the per column estimate, and rootcoord must
+	// be hit once per collection, not once per task.
+	const (
+		collID    = UniqueID(2)
+		vecField  = UniqueID(101)
+		numRows   = int64(3000)
+		groupSize = int64(2 * 1024 * 1024 * 1024)
+	)
+
+	ctx := context.Background()
+	notifyChan := make(chan int64, 1)
+	scheduler := task.NewMockGlobalScheduler(t)
+	alloc := allocator.NewMockAllocator(t)
+	handler := NewNMockHandler(t)
+	storageCli := mocks.NewChunkManager(t)
+	versionManager := newIndexEngineVersionManager()
+	catalog := mocks2.NewDataCoordCatalog(t)
+
+	m := &meta{
+		segments:    NewSegmentsInfo(),
+		collections: typeutil.NewConcurrentMap[UniqueID, *collectionInfo](),
+		indexMeta: &indexMeta{
+			keyLock:          lock.NewKeyLock[UniqueID](),
+			catalog:          catalog,
+			segmentBuildInfo: newSegmentIndexBuildInfo(),
+			indexes:          make(map[UniqueID]map[UniqueID]*model.Index),
+			segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+		},
+	}
+	m.indexMeta.indexes[collID] = map[UniqueID]*model.Index{
+		3: {
+			CollectionID: collID,
+			FieldID:      vecField,
+			IndexID:      3,
+			IndexName:    indexName,
+			IndexParams: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "IVF_FLAT"},
+			},
+		},
+	}
+	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
+
+	// the collection lives in rootcoord only, exactly as after a restart
+	collInfo := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+				{
+					FieldID:       vecField,
+					Name:          "vec",
+					DataType:      schemapb.DataType_FloatVector,
+					ExternalField: "vec_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "128"},
+					},
+				},
+			},
+		},
+	}
+	handler.EXPECT().GetCollection(mock.Anything, collID).Return(collInfo, nil).Once()
+
+	for _, segmentID := range []UniqueID{1, 2} {
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:           segmentID,
+				CollectionID: collID,
+				NumOfRows:    numRows,
+				State:        commonpb.SegmentState_Flushed,
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID:     0,
+						ChildFields: []int64{100, vecField},
+						Binlogs: []*datapb.Binlog{
+							{EntriesNum: numRows, MemorySize: groupSize},
+						},
+					},
+				},
+			},
+		}
+		m.segments.SetSegment(segmentID, segment)
+		err := m.indexMeta.AddSegmentIndex(ctx, &model.SegmentIndex{
+			CollectionID: collID,
+			SegmentID:    segmentID,
+			IndexID:      3,
+			BuildID:      100 + segmentID,
+			NumRows:      numRows,
+			IndexState:   commonpb.IndexState_Unissued,
+		})
+		assert.NoError(t, err)
+	}
+
+	slots := make([]int64, 0, 2)
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(t task.Task) {
+		slots = append(slots, t.GetTaskSlot())
+	}).Return()
+
+	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+	inspector.reloadFromMeta()
+
+	assert.Len(t, slots, 2)
+	indexParams := m.indexMeta.indexes[collID][3].IndexParams
+	expected := calculateIndexTaskSlot(int64(128*4)*numRows, numRows, indexParams)
+	for _, slot := range slots {
+		assert.Equal(t, expected, slot)
+		assert.Less(t, slot, calculateIndexTaskSlot(groupSize, numRows, indexParams))
+	}
+}
+
 func TestIndexInspector_isExternalCollection(t *testing.T) {
 	ctx := context.Background()
 	notifyChan := make(chan int64, 1)
@@ -284,6 +404,10 @@ func TestIndexInspector_isExternalCollection(t *testing.T) {
 	}
 
 	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, collectionID int64) (*collectionInfo, error) {
+			return m.GetCollection(collectionID), nil
+		}).Maybe()
 
 	t.Run("collection not found", func(t *testing.T) {
 		assert.False(t, inspector.isExternalCollection(999))
@@ -354,6 +478,10 @@ func TestIndexInspector_CreateIndexesForSegment_ExternalUnsorted(t *testing.T) {
 	}
 
 	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, collectionID int64) (*collectionInfo, error) {
+			return m.GetCollection(collectionID), nil
+		}).Maybe()
 
 	t.Run("normal unsorted segment is skipped", func(t *testing.T) {
 		m.collections.Insert(2, &collectionInfo{
@@ -468,6 +596,10 @@ func TestIndexInspector_CreateIndexForSegment_OverrideIndexType(t *testing.T) {
 	}
 
 	inspector := newIndexInspector(ctx, notifyChan, meta, scheduler, alloc, handler, storage, versionManager)
+	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, collectionID int64) (*collectionInfo, error) {
+			return meta.GetCollection(collectionID), nil
+		}).Maybe()
 
 	alloc.EXPECT().AllocID(mock.Anything).Return(int64(12345), nil)
 	catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
@@ -766,6 +898,10 @@ func TestIndexInspector_estimateIndexFieldSize(t *testing.T) {
 		},
 	}
 	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, collectionID int64) (*collectionInfo, error) {
+			return m.GetCollection(collectionID), nil
+		}).Maybe()
 
 	externalSchema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
@@ -801,7 +937,7 @@ func TestIndexInspector_estimateIndexFieldSize(t *testing.T) {
 	}
 
 	t.Run("collection not found falls back to binlog size", func(t *testing.T) {
-		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, externalSegment, vecField))
+		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, m.GetCollection(collID), externalSegment, vecField))
 	})
 
 	t.Run("shared column group is attributed per field", func(t *testing.T) {
@@ -823,7 +959,7 @@ func TestIndexInspector_estimateIndexFieldSize(t *testing.T) {
 				},
 			},
 		})
-		assert.Equal(t, int64(128*4)*numRows, inspector.estimateIndexFieldSize(ctx, externalSegment, vecField))
+		assert.Equal(t, int64(128*4)*numRows, inspector.estimateIndexFieldSize(ctx, m.GetCollection(collID), externalSegment, vecField))
 	})
 
 	t.Run("single field column group keeps the measured size", func(t *testing.T) {
@@ -843,17 +979,17 @@ func TestIndexInspector_estimateIndexFieldSize(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, segment, vecField))
+		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, m.GetCollection(collID), segment, vecField))
 	})
 
 	t.Run("external collection estimates from schema", func(t *testing.T) {
 		m.collections.Insert(collID, &collectionInfo{ID: collID, Schema: externalSchema})
-		assert.Equal(t, int64(128*4)*numRows, inspector.estimateIndexFieldSize(ctx, externalSegment, vecField))
+		assert.Equal(t, int64(128*4)*numRows, inspector.estimateIndexFieldSize(ctx, m.GetCollection(collID), externalSegment, vecField))
 	})
 
 	t.Run("external collection falls back on unknown field", func(t *testing.T) {
 		m.collections.Insert(collID, &collectionInfo{ID: collID, Schema: externalSchema})
-		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, externalSegment, 999))
+		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, m.GetCollection(collID), externalSegment, 999))
 	})
 }
 
@@ -941,6 +1077,10 @@ func TestIndexInspector_CreateIndexForSegment_ExternalTaskSlot(t *testing.T) {
 	m.segments.SetSegment(segment.GetID(), segment)
 
 	inspector := newIndexInspector(ctx, notifyChan, m, scheduler, alloc, handler, storageCli, versionManager)
+	handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, collectionID int64) (*collectionInfo, error) {
+			return m.GetCollection(collectionID), nil
+		}).Maybe()
 
 	var enqueuedSlot int64
 	alloc.EXPECT().AllocID(mock.Anything).Return(int64(12345), nil)

--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -90,10 +90,6 @@ func TestIndexInspector_inspect(t *testing.T) {
 		}
 
 		inspector := newIndexInspector(ctx, notifyChan, meta, scheduler, alloc, handler, storage, versionManager)
-		handler.EXPECT().GetCollection(mock.Anything, mock.Anything).RunAndReturn(
-			func(_ context.Context, collectionID int64) (*collectionInfo, error) {
-				return meta.GetCollection(collectionID), nil
-			}).Maybe()
 
 		// Register all expectations before Start(): the inspector goroutine
 		// (reloadFromMeta, the ticker, and the notify channel) may invoke the
@@ -339,10 +335,12 @@ func TestIndexInspector_ReloadFromMetaResolvesCollectionThroughHandler(t *testin
 	for _, segmentID := range []UniqueID{1, 2} {
 		segment := &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           segmentID,
-				CollectionID: collID,
-				NumOfRows:    numRows,
-				State:        commonpb.SegmentState_Flushed,
+				ID:             segmentID,
+				CollectionID:   collID,
+				NumOfRows:      numRows,
+				State:          commonpb.SegmentState_Flushed,
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   "manifest.json",
 				Binlogs: []*datapb.FieldBinlog{
 					{
 						FieldID:     0,
@@ -921,9 +919,11 @@ func TestIndexInspector_estimateIndexFieldSize(t *testing.T) {
 	// field in ChildFields, so getFieldBinlogSize reports the whole segment.
 	externalSegment := &SegmentInfo{
 		SegmentInfo: &datapb.SegmentInfo{
-			ID:           1,
-			CollectionID: collID,
-			NumOfRows:    numRows,
+			ID:             1,
+			CollectionID:   collID,
+			NumOfRows:      numRows,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   "manifest.json",
 			Binlogs: []*datapb.FieldBinlog{
 				{
 					FieldID:     0,
@@ -966,12 +966,36 @@ func TestIndexInspector_estimateIndexFieldSize(t *testing.T) {
 		m.collections.Insert(collID, &collectionInfo{ID: collID, Schema: externalSchema})
 		segment := &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           2,
-				CollectionID: collID,
-				NumOfRows:    numRows,
+				ID:             2,
+				CollectionID:   collID,
+				NumOfRows:      numRows,
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   "manifest.json",
 				Binlogs: []*datapb.FieldBinlog{
 					{
 						FieldID: vecField,
+						Binlogs: []*datapb.Binlog{
+							{EntriesNum: numRows, MemorySize: groupSize},
+						},
+					},
+				},
+			},
+		}
+		assert.Equal(t, groupSize, inspector.estimateIndexFieldSize(ctx, m.GetCollection(collID), segment, vecField))
+	})
+
+	t.Run("storage v2 shared group falls back to the group size", func(t *testing.T) {
+		m.collections.Insert(collID, &collectionInfo{ID: collID, Schema: externalSchema})
+		segment := &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:             3,
+				CollectionID:   collID,
+				NumOfRows:      numRows,
+				StorageVersion: storage.StorageV2,
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID:     0,
+						ChildFields: []int64{100, vecField},
 						Binlogs: []*datapb.Binlog{
 							{EntriesNum: numRows, MemorySize: groupSize},
 						},
@@ -1057,12 +1081,14 @@ func TestIndexInspector_CreateIndexForSegment_ExternalTaskSlot(t *testing.T) {
 
 	segment := &SegmentInfo{
 		SegmentInfo: &datapb.SegmentInfo{
-			ID:           1,
-			CollectionID: collID,
-			PartitionID:  3,
-			NumOfRows:    numRows,
-			State:        commonpb.SegmentState_Flushed,
-			Level:        datapb.SegmentLevel_L1,
+			ID:             1,
+			CollectionID:   collID,
+			PartitionID:    3,
+			NumOfRows:      numRows,
+			State:          commonpb.SegmentState_Flushed,
+			Level:          datapb.SegmentLevel_L1,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   "manifest.json",
 			Binlogs: []*datapb.FieldBinlog{
 				{
 					FieldID:     0,
@@ -1094,7 +1120,8 @@ func TestIndexInspector_CreateIndexForSegment_ExternalTaskSlot(t *testing.T) {
 
 	// 128 dim float vector over 3000 rows is ~1.5MB, the smallest slot bucket,
 	// instead of the whole 2GB column group.
-	expected := calculateIndexTaskSlot(int64(128*4)*numRows, true)
+	indexParams := m.indexMeta.indexes[collID][indexID].IndexParams
+	expected := calculateIndexTaskSlot(int64(128*4)*numRows, numRows, indexParams)
 	assert.Equal(t, expected, enqueuedSlot)
-	assert.Less(t, enqueuedSlot, calculateIndexTaskSlot(groupSize, true))
+	assert.Less(t, enqueuedSlot, calculateIndexTaskSlot(groupSize, numRows, indexParams))
 }

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -2407,11 +2407,12 @@ func (suite *MetaBasicSuite) TestCompleteBumpSchemaVersionCompactionMutation() {
 			},
 		}, nil).Once()
 		inspector := &indexInspector{handler: handler}
-		suite.True(inspector.canCreateIndexForSegment(context.Background(), updated, &model.Index{
+		_, ok := inspector.canCreateIndexForSegment(context.Background(), updated, &model.Index{
 			CollectionID: updated.GetCollectionID(),
 			FieldID:      102,
 			IndexID:      1,
-		}), "materialized function-output field must be index-eligible")
+		})
+		suite.True(ok, "materialized function-output field must be index-eligible")
 	})
 
 	suite.Run("in-place result with stale base manifest is rejected", func() {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -589,16 +589,20 @@ func statsTaskFieldIDs(schema *schemapb.CollectionSchema, subJobType indexpb.Sta
 // columns they index, while the segment size covers every column. This is worst
 // for external segments, which report one synthetic column group holding all
 // of them. StorageV2 and any other stats task read conservatively as the whole
-// segment. The segment size is also kept whenever estimation is not possible.
+// segment. The segment size is also kept whenever estimation is not possible,
+// including for V3 segments recovered after a restart, whose FieldBinlog
+// arrays are not persisted (see isV3Segment in the datacoord catalog).
 func (si *statsInspector) estimateStatsTaskSize(coll *collectionInfo, segment *SegmentInfo, subJobType indexpb.StatsSubJob) int64 {
 	segmentSize := segment.getSegmentSize()
 
 	readSize := segmentSize
-	if coll != nil && supportsFieldProjection(segment) {
+	if coll != nil && supportsFieldProjection(segment) && len(segment.GetBinlogs()) > 0 {
 		if fieldIDs := statsTaskFieldIDs(coll.Schema, subJobType); len(fieldIDs) > 0 {
 			fieldsSize, err := estimateFieldsReadSize(coll.Schema, segment, fieldIDs)
 			if err != nil {
-				mlog.Warn(si.ctx, "failed to estimate stats task field size, fallback to segment size",
+				// rated: the trigger loop re-estimates pending segments every
+				// tick, before the duplicate-task check can suppress them
+				mlog.RatedWarn(si.ctx, rate.Limit(1), "failed to estimate stats task field size, fallback to segment size",
 					mlog.FieldSegmentID(segment.GetID()),
 					mlog.String("subJobType", subJobType.String()),
 					mlog.Int64("segmentSize", segmentSize),
@@ -610,8 +614,11 @@ func (si *statsInspector) estimateStatsTaskSize(coll *collectionInfo, segment *S
 	}
 
 	if subJobType == indexpb.StatsSubJob_JsonKeyIndexJob {
-		// the json key index task also writes an index of comparable size, so
-		// it handles roughly twice the data it reads.
+		// The json key index task also writes shredded column data of a size
+		// comparable to what it reads, so it handles roughly twice the data.
+		// The text index task is deliberately not doubled: its inverted index
+		// is bounded by the tokenized column, and the pre-existing whole
+		// segment estimation never doubled it either.
 		return readSize * 2
 	}
 	return readSize

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -133,9 +133,6 @@ func (si *statsInspector) Stop() {
 
 func (si *statsInspector) reloadFromMeta() {
 	tasks := si.mt.statsTaskMeta.GetAllTasks()
-	// the collection cache is usually not filled yet at startup, and resolving
-	// it hits rootcoord, so memoize it across all recovered tasks
-	collections := newCollectionCache(si.handler)
 	for _, st := range tasks {
 		if st.GetState() != indexpb.JobState_JobStateInit &&
 			st.GetState() != indexpb.JobState_JobStateRetry &&
@@ -145,7 +142,11 @@ func (si *statsInspector) reloadFromMeta() {
 		taskSlot := int64(0)
 		segment := si.mt.GetHealthySegment(si.ctx, st.GetSegmentID())
 		if segment != nil {
-			coll := collections.get(si.ctx, segment.GetCollectionID())
+			// Only the local cache is consulted: recovery runs synchronously in
+			// Start(), so it must not load collections through rootcoord. On a
+			// cold cache the estimation falls back to the conservative segment
+			// size, which is the pre-optimization behavior.
+			coll := si.getCollection(segment.GetCollectionID())
 			taskSlot = calculateStatsTaskSlot(si.estimateStatsTaskSize(coll, segment, st.GetSubJobType()))
 		}
 		si.scheduler.Enqueue(newStatsTask(
@@ -494,7 +495,7 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 	if err != nil {
 		return err
 	}
-	coll := resolveCollection(si.ctx, si.handler, originSegment.GetCollectionID())
+	coll := si.getCollection(originSegment.GetCollectionID())
 	originSegmentSize := si.estimateStatsTaskSize(coll, originSegment, subJobType)
 
 	taskSlot := calculateStatsTaskSlot(originSegmentSize)

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -28,7 +28,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/task"
-	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -197,7 +196,7 @@ func needDoJSONKeyIndex(segment *SegmentInfo, fieldIDs []UniqueID, allowUnsorted
 }
 
 func canBuildExternalJSONKeyIndex(segment *SegmentInfo) bool {
-	return segment.GetStorageVersion() == storage.StorageV3 && segment.GetManifestPath() != ""
+	return supportsFieldProjection(segment)
 }
 
 func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
@@ -460,17 +459,16 @@ func statsTaskFieldIDs(schema *schemapb.CollectionSchema, subJobType indexpb.Sta
 // estimateStatsTaskSize returns the data size the stats task handles, which
 // drives the task slot estimation.
 //
-// The json key index and text index tasks only read the columns they index,
-// while the segment size covers every column. This is worst for external
-// segments, which report one synthetic column group holding all of them. Any
-// other stats task reads the whole segment. The segment size is kept whenever
-// the estimation is not possible, which is the previous (over-estimating but
-// safe) behavior.
+// Manifest-backed StorageV3 json key index and text index tasks project the
+// columns they index, while the segment size covers every column. This is worst
+// for external segments, which report one synthetic column group holding all
+// of them. StorageV2 and any other stats task read conservatively as the whole
+// segment. The segment size is also kept whenever estimation is not possible.
 func (si *statsInspector) estimateStatsTaskSize(coll *collectionInfo, segment *SegmentInfo, subJobType indexpb.StatsSubJob) int64 {
 	segmentSize := segment.getSegmentSize()
 
 	readSize := segmentSize
-	if coll != nil {
+	if coll != nil && supportsFieldProjection(segment) {
 		if fieldIDs := statsTaskFieldIDs(coll.Schema, subJobType); len(fieldIDs) > 0 {
 			fieldsSize, err := estimateFieldsReadSize(coll.Schema, segment, fieldIDs)
 			if err != nil {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -28,7 +28,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/task"
-	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -244,7 +243,7 @@ func needDoJSONKeyIndex(segment *SegmentInfo, fieldIDs []UniqueID, allowUnsorted
 }
 
 func canBuildExternalJSONKeyIndex(segment *SegmentInfo) bool {
-	return segment.GetStorageVersion() == storage.StorageV3 && segment.GetManifestPath() != ""
+	return supportsFieldProjection(segment)
 }
 
 func needDoBM25(segment *SegmentInfo, fieldIDs []UniqueID) bool {
@@ -585,17 +584,16 @@ func statsTaskFieldIDs(schema *schemapb.CollectionSchema, subJobType indexpb.Sta
 // estimateStatsTaskSize returns the data size the stats task handles, which
 // drives the task slot estimation.
 //
-// The json key index and text index tasks only read the columns they index,
-// while the segment size covers every column. This is worst for external
-// segments, which report one synthetic column group holding all of them. Any
-// other stats task reads the whole segment. The segment size is kept whenever
-// the estimation is not possible, which is the previous (over-estimating but
-// safe) behavior.
+// Manifest-backed StorageV3 json key index and text index tasks project the
+// columns they index, while the segment size covers every column. This is worst
+// for external segments, which report one synthetic column group holding all
+// of them. StorageV2 and any other stats task read conservatively as the whole
+// segment. The segment size is also kept whenever estimation is not possible.
 func (si *statsInspector) estimateStatsTaskSize(coll *collectionInfo, segment *SegmentInfo, subJobType indexpb.StatsSubJob) int64 {
 	segmentSize := segment.getSegmentSize()
 
 	readSize := segmentSize
-	if coll != nil {
+	if coll != nil && supportsFieldProjection(segment) {
 		if fieldIDs := statsTaskFieldIDs(coll.Schema, subJobType); len(fieldIDs) > 0 {
 			fieldsSize, err := estimateFieldsReadSize(coll.Schema, segment, fieldIDs)
 			if err != nil {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -101,6 +101,9 @@ func (si *statsInspector) Stop() {
 
 func (si *statsInspector) reloadFromMeta() {
 	tasks := si.mt.statsTaskMeta.GetAllTasks()
+	// the collection cache is usually not filled yet at startup, and resolving
+	// it hits rootcoord, so memoize it across all recovered tasks
+	collections := newCollectionCache(si.handler)
 	for _, st := range tasks {
 		if st.GetState() != indexpb.JobState_JobStateInit &&
 			st.GetState() != indexpb.JobState_JobStateRetry &&
@@ -110,7 +113,8 @@ func (si *statsInspector) reloadFromMeta() {
 		taskSlot := int64(0)
 		segment := si.mt.GetHealthySegment(si.ctx, st.GetSegmentID())
 		if segment != nil {
-			taskSlot = calculateStatsTaskSlot(segment.getSegmentSize())
+			coll := collections.get(si.ctx, segment.GetCollectionID())
+			taskSlot = calculateStatsTaskSlot(si.estimateStatsTaskSize(coll, segment, st.GetSubJobType()))
 		}
 		si.scheduler.Enqueue(newStatsTask(
 			proto.Clone(st).(*indexpb.StatsTask),
@@ -366,7 +370,8 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 	if err != nil {
 		return err
 	}
-	originSegmentSize := si.estimateStatsTaskSize(originSegment, subJobType)
+	coll := resolveCollection(si.ctx, si.handler, originSegment.GetCollectionID())
+	originSegmentSize := si.estimateStatsTaskSize(coll, originSegment, subJobType)
 
 	taskSlot := calculateStatsTaskSlot(originSegmentSize)
 	t := &indexpb.StatsTask{
@@ -461,11 +466,11 @@ func statsTaskFieldIDs(schema *schemapb.CollectionSchema, subJobType indexpb.Sta
 // other stats task reads the whole segment. The segment size is kept whenever
 // the estimation is not possible, which is the previous (over-estimating but
 // safe) behavior.
-func (si *statsInspector) estimateStatsTaskSize(segment *SegmentInfo, subJobType indexpb.StatsSubJob) int64 {
+func (si *statsInspector) estimateStatsTaskSize(coll *collectionInfo, segment *SegmentInfo, subJobType indexpb.StatsSubJob) int64 {
 	segmentSize := segment.getSegmentSize()
 
 	readSize := segmentSize
-	if coll := si.getCollection(segment.GetCollectionID()); coll != nil {
+	if coll != nil {
 		if fieldIDs := statsTaskFieldIDs(coll.Schema, subJobType); len(fieldIDs) > 0 {
 			fieldsSize, err := estimateFieldsReadSize(coll.Schema, segment, fieldIDs)
 			if err != nil {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/task"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -365,10 +366,7 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 	if err != nil {
 		return err
 	}
-	originSegmentSize := originSegment.getSegmentSize()
-	if subJobType == indexpb.StatsSubJob_JsonKeyIndexJob {
-		originSegmentSize = originSegment.getSegmentSize() * 2
-	}
+	originSegmentSize := si.estimateStatsTaskSize(originSegment, subJobType)
 
 	taskSlot := calculateStatsTaskSlot(originSegmentSize)
 	t := &indexpb.StatsTask{
@@ -428,10 +426,76 @@ func (si *statsInspector) DropStatsTask(originSegmentID int64, subJobType indexp
 	return nil
 }
 
-func (si *statsInspector) isExternalCollection(collectionID int64) bool {
-	if si.mt == nil {
-		return false
+// statsTaskFieldIDs returns the fields the stats task reads, or nil when it is
+// not restricted to a subset of the columns.
+func statsTaskFieldIDs(schema *schemapb.CollectionSchema, subJobType indexpb.StatsSubJob) []int64 {
+	var predicate func(field *schemapb.FieldSchema) bool
+	switch subJobType {
+	case indexpb.StatsSubJob_JsonKeyIndexJob:
+		predicate = func(field *schemapb.FieldSchema) bool {
+			return typeutil.CreateFieldSchemaHelper(field).EnableJSONKeyStatsIndex()
+		}
+	case indexpb.StatsSubJob_TextIndexJob:
+		predicate = func(field *schemapb.FieldSchema) bool {
+			return typeutil.CreateFieldSchemaHelper(field).EnableMatch()
+		}
+	default:
+		return nil
 	}
-	coll := si.mt.GetCollection(collectionID)
+
+	fieldIDs := make([]int64, 0)
+	for _, field := range schema.GetFields() {
+		if predicate(field) {
+			fieldIDs = append(fieldIDs, field.GetFieldID())
+		}
+	}
+	return fieldIDs
+}
+
+// estimateStatsTaskSize returns the data size the stats task handles, which
+// drives the task slot estimation.
+//
+// The json key index and text index tasks only read the columns they index,
+// while the segment size covers every column. This is worst for external
+// segments, which report one synthetic column group holding all of them. Any
+// other stats task reads the whole segment. The segment size is kept whenever
+// the estimation is not possible, which is the previous (over-estimating but
+// safe) behavior.
+func (si *statsInspector) estimateStatsTaskSize(segment *SegmentInfo, subJobType indexpb.StatsSubJob) int64 {
+	segmentSize := segment.getSegmentSize()
+
+	readSize := segmentSize
+	if coll := si.getCollection(segment.GetCollectionID()); coll != nil {
+		if fieldIDs := statsTaskFieldIDs(coll.Schema, subJobType); len(fieldIDs) > 0 {
+			fieldsSize, err := estimateFieldsReadSize(coll.Schema, segment, fieldIDs)
+			if err != nil {
+				mlog.Warn(si.ctx, "failed to estimate stats task field size, fallback to segment size",
+					mlog.FieldSegmentID(segment.GetID()),
+					mlog.String("subJobType", subJobType.String()),
+					mlog.Int64("segmentSize", segmentSize),
+					mlog.Err(err))
+			} else {
+				readSize = fieldsSize
+			}
+		}
+	}
+
+	if subJobType == indexpb.StatsSubJob_JsonKeyIndexJob {
+		// the json key index task also writes an index of comparable size, so
+		// it handles roughly twice the data it reads.
+		return readSize * 2
+	}
+	return readSize
+}
+
+func (si *statsInspector) getCollection(collectionID int64) *collectionInfo {
+	if si.mt == nil {
+		return nil
+	}
+	return si.mt.GetCollection(collectionID)
+}
+
+func (si *statsInspector) isExternalCollection(collectionID int64) bool {
+	coll := si.getCollection(collectionID)
 	return coll != nil && coll.IsExternal()
 }

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -134,6 +134,9 @@ func (si *statsInspector) Stop() {
 
 func (si *statsInspector) reloadFromMeta() {
 	tasks := si.mt.statsTaskMeta.GetAllTasks()
+	// the collection cache is usually not filled yet at startup, and resolving
+	// it hits rootcoord, so memoize it across all recovered tasks
+	collections := newCollectionCache(si.handler)
 	for _, st := range tasks {
 		if st.GetState() != indexpb.JobState_JobStateInit &&
 			st.GetState() != indexpb.JobState_JobStateRetry &&
@@ -143,7 +146,8 @@ func (si *statsInspector) reloadFromMeta() {
 		taskSlot := int64(0)
 		segment := si.mt.GetHealthySegment(si.ctx, st.GetSegmentID())
 		if segment != nil {
-			taskSlot = calculateStatsTaskSlot(segment.getSegmentSize())
+			coll := collections.get(si.ctx, segment.GetCollectionID())
+			taskSlot = calculateStatsTaskSlot(si.estimateStatsTaskSize(coll, segment, st.GetSubJobType()))
 		}
 		si.scheduler.Enqueue(newStatsTask(
 			proto.Clone(st).(*indexpb.StatsTask),
@@ -491,7 +495,8 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 	if err != nil {
 		return err
 	}
-	originSegmentSize := si.estimateStatsTaskSize(originSegment, subJobType)
+	coll := resolveCollection(si.ctx, si.handler, originSegment.GetCollectionID())
+	originSegmentSize := si.estimateStatsTaskSize(coll, originSegment, subJobType)
 
 	taskSlot := calculateStatsTaskSlot(originSegmentSize)
 	t := &indexpb.StatsTask{
@@ -586,11 +591,11 @@ func statsTaskFieldIDs(schema *schemapb.CollectionSchema, subJobType indexpb.Sta
 // other stats task reads the whole segment. The segment size is kept whenever
 // the estimation is not possible, which is the previous (over-estimating but
 // safe) behavior.
-func (si *statsInspector) estimateStatsTaskSize(segment *SegmentInfo, subJobType indexpb.StatsSubJob) int64 {
+func (si *statsInspector) estimateStatsTaskSize(coll *collectionInfo, segment *SegmentInfo, subJobType indexpb.StatsSubJob) int64 {
 	segmentSize := segment.getSegmentSize()
 
 	readSize := segmentSize
-	if coll := si.getCollection(segment.GetCollectionID()); coll != nil {
+	if coll != nil {
 		if fieldIDs := statsTaskFieldIDs(coll.Schema, subJobType); len(fieldIDs) > 0 {
 			fieldsSize, err := estimateFieldsReadSize(coll.Schema, segment, fieldIDs)
 			if err != nil {

--- a/internal/datacoord/stats_inspector.go
+++ b/internal/datacoord/stats_inspector.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/task"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -490,10 +491,7 @@ func (si *statsInspector) SubmitStatsTask(originSegmentID, targetSegmentID int64
 	if err != nil {
 		return err
 	}
-	originSegmentSize := originSegment.getSegmentSize()
-	if subJobType == indexpb.StatsSubJob_JsonKeyIndexJob {
-		originSegmentSize = originSegment.getSegmentSize() * 2
-	}
+	originSegmentSize := si.estimateStatsTaskSize(originSegment, subJobType)
 
 	taskSlot := calculateStatsTaskSlot(originSegmentSize)
 	t := &indexpb.StatsTask{
@@ -553,10 +551,76 @@ func (si *statsInspector) DropStatsTask(originSegmentID int64, subJobType indexp
 	return nil
 }
 
-func (si *statsInspector) isExternalCollection(collectionID int64) bool {
-	if si.mt == nil {
-		return false
+// statsTaskFieldIDs returns the fields the stats task reads, or nil when it is
+// not restricted to a subset of the columns.
+func statsTaskFieldIDs(schema *schemapb.CollectionSchema, subJobType indexpb.StatsSubJob) []int64 {
+	var predicate func(field *schemapb.FieldSchema) bool
+	switch subJobType {
+	case indexpb.StatsSubJob_JsonKeyIndexJob:
+		predicate = func(field *schemapb.FieldSchema) bool {
+			return typeutil.CreateFieldSchemaHelper(field).EnableJSONKeyStatsIndex()
+		}
+	case indexpb.StatsSubJob_TextIndexJob:
+		predicate = func(field *schemapb.FieldSchema) bool {
+			return typeutil.CreateFieldSchemaHelper(field).EnableMatch()
+		}
+	default:
+		return nil
 	}
-	coll := si.mt.GetCollection(collectionID)
+
+	fieldIDs := make([]int64, 0)
+	for _, field := range schema.GetFields() {
+		if predicate(field) {
+			fieldIDs = append(fieldIDs, field.GetFieldID())
+		}
+	}
+	return fieldIDs
+}
+
+// estimateStatsTaskSize returns the data size the stats task handles, which
+// drives the task slot estimation.
+//
+// The json key index and text index tasks only read the columns they index,
+// while the segment size covers every column. This is worst for external
+// segments, which report one synthetic column group holding all of them. Any
+// other stats task reads the whole segment. The segment size is kept whenever
+// the estimation is not possible, which is the previous (over-estimating but
+// safe) behavior.
+func (si *statsInspector) estimateStatsTaskSize(segment *SegmentInfo, subJobType indexpb.StatsSubJob) int64 {
+	segmentSize := segment.getSegmentSize()
+
+	readSize := segmentSize
+	if coll := si.getCollection(segment.GetCollectionID()); coll != nil {
+		if fieldIDs := statsTaskFieldIDs(coll.Schema, subJobType); len(fieldIDs) > 0 {
+			fieldsSize, err := estimateFieldsReadSize(coll.Schema, segment, fieldIDs)
+			if err != nil {
+				mlog.Warn(si.ctx, "failed to estimate stats task field size, fallback to segment size",
+					mlog.FieldSegmentID(segment.GetID()),
+					mlog.String("subJobType", subJobType.String()),
+					mlog.Int64("segmentSize", segmentSize),
+					mlog.Err(err))
+			} else {
+				readSize = fieldsSize
+			}
+		}
+	}
+
+	if subJobType == indexpb.StatsSubJob_JsonKeyIndexJob {
+		// the json key index task also writes an index of comparable size, so
+		// it handles roughly twice the data it reads.
+		return readSize * 2
+	}
+	return readSize
+}
+
+func (si *statsInspector) getCollection(collectionID int64) *collectionInfo {
+	if si.mt == nil {
+		return nil
+	}
+	return si.mt.GetCollection(collectionID)
+}
+
+func (si *statsInspector) isExternalCollection(collectionID int64) bool {
+	coll := si.getCollection(collectionID)
 	return coll != nil && coll.IsExternal()
 }

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -732,16 +732,18 @@ func (s *statsInspectorSuite) TestReloadFromMeta() {
 }
 
 func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
-	// Recovered stats tasks read the collection from the local meta cache and
-	// are sized by the columns their sub job actually reads; recovery must not
-	// resolve collections through the handler (rootcoord).
+	// A recovered manifest-backed V3 segment carries no FieldBinlog arrays
+	// (the catalog does not persist them), so recovered stats tasks keep the
+	// Stats-derived whole segment size — doubled for the json key index job —
+	// and recovery must not resolve collections through the handler
+	// (rootcoord).
 	const (
 		collectionID = UniqueID(5)
 		segmentID    = UniqueID(50)
 		pkFieldID    = int64(500)
 		jsonFieldID  = int64(501)
 		numRows      = int64(1000)
-		groupSize    = int64(2 * 1024 * 1024 * 1024)
+		segmentSize  = int64(2 * 1024 * 1024 * 1024)
 	)
 
 	s.mt.collections.Insert(collectionID, &collectionInfo{
@@ -766,15 +768,7 @@ func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
 			NumOfRows:      numRows,
 			StorageVersion: storage.StorageV3,
 			ManifestPath:   packed.MarshalManifestPath("files/insert_log/5/3/50", 1),
-			Binlogs: []*datapb.FieldBinlog{
-				{
-					FieldID:     0,
-					ChildFields: []int64{pkFieldID, jsonFieldID},
-					Binlogs: []*datapb.Binlog{
-						{EntriesNum: numRows, LogSize: groupSize, MemorySize: groupSize},
-					},
-				},
-			},
+			Stats:          &datapb.Statistics{InsertBinlogSize: segmentSize},
 		},
 	}
 	s.mt.segments.SetSegment(segmentID, segment)
@@ -802,12 +796,10 @@ func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
 
 	s.inspector.reloadFromMeta()
 
-	// the json key index task drops the pk column out of its estimation, while
-	// the sort task still reads the whole segment
-	residualBytes := groupSize - 8*numRows
-	s.Equal(calculateStatsTaskSlot(residualBytes*2), slots[indexpb.StatsSubJob_JsonKeyIndexJob])
-	s.Equal(calculateStatsTaskSlot(segment.getSegmentSize()), slots[indexpb.StatsSubJob_Sort])
-	s.Less(slots[indexpb.StatsSubJob_JsonKeyIndexJob], calculateStatsTaskSlot(segment.getSegmentSize()*2))
+	// without binlogs to attribute, the json key index task keeps the whole
+	// segment size doubled, and the sort task the whole segment size
+	s.Equal(calculateStatsTaskSlot(segmentSize*2), slots[indexpb.StatsSubJob_JsonKeyIndexJob])
+	s.Equal(calculateStatsTaskSlot(segmentSize), slots[indexpb.StatsSubJob_Sort])
 }
 
 func (s *statsInspectorSuite) TestReloadFromMetaSkipsCollectionResolutionWithoutProjection() {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -541,6 +541,87 @@ func (s *statsInspectorSuite) TestReloadFromMeta() {
 	s.Equal(1, enqueueCount)
 }
 
+func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
+	// The collection cache is filled asynchronously, so recovered stats tasks
+	// must resolve the collection through the handler and be sized by the
+	// columns their sub job actually reads.
+	const (
+		collectionID = UniqueID(5)
+		segmentID    = UniqueID(50)
+		pkFieldID    = int64(500)
+		jsonFieldID  = int64(501)
+		numRows      = int64(1000)
+		groupSize    = int64(2 * 1024 * 1024 * 1024)
+	)
+
+	collInfo := &collectionInfo{
+		ID: collectionID,
+		Schema: &schemapb.CollectionSchema{
+			ExternalSource: "s3://external",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: pkFieldID, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+				{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON, ExternalField: "json_col"},
+			},
+		},
+	}
+	handler := NewNMockHandler(s.T())
+	// resolved once for the two recovered tasks
+	handler.EXPECT().GetCollection(mock.Anything, collectionID).Return(collInfo, nil).Once()
+	s.inspector.handler = handler
+
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             segmentID,
+			CollectionID:   collectionID,
+			PartitionID:    3,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      numRows,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath("files/insert_log/5/3/50", 1),
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0,
+					ChildFields: []int64{pkFieldID, jsonFieldID},
+					Binlogs: []*datapb.Binlog{
+						{EntriesNum: numRows, LogSize: groupSize, MemorySize: groupSize},
+					},
+				},
+			},
+		},
+	}
+	s.mt.segments.SetSegment(segmentID, segment)
+
+	for taskID, subJobType := range map[UniqueID]indexpb.StatsSubJob{
+		2001: indexpb.StatsSubJob_JsonKeyIndexJob,
+		2002: indexpb.StatsSubJob_Sort,
+	} {
+		s.mt.statsTaskMeta.tasks.Insert(taskID, &indexpb.StatsTask{
+			CollectionID: collectionID,
+			TaskID:       taskID,
+			SegmentID:    segmentID,
+			SubJobType:   subJobType,
+			State:        indexpb.JobState_JobStateInProgress,
+		})
+	}
+
+	slots := make(map[indexpb.StatsSubJob]int64)
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(t task.Task) {
+		st := t.(*statsTask)
+		slots[st.GetSubJobType()] = t.GetTaskSlot()
+	}).Return()
+	s.inspector.scheduler = scheduler
+
+	s.inspector.reloadFromMeta()
+
+	// the json key index task drops the pk column out of its estimation, while
+	// the sort task still reads the whole segment
+	residual := groupSize/numRows - 8
+	s.Equal(calculateStatsTaskSlot(residual*numRows*2), slots[indexpb.StatsSubJob_JsonKeyIndexJob])
+	s.Equal(calculateStatsTaskSlot(segment.getSegmentSize()), slots[indexpb.StatsSubJob_Sort])
+	s.Less(slots[indexpb.StatsSubJob_JsonKeyIndexJob], calculateStatsTaskSlot(segment.getSegmentSize()*2))
+}
+
 func (s *statsInspectorSuite) TestReloadFromMetaExternalStatsTask() {
 	testCases := []struct {
 		name           string
@@ -729,10 +810,12 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 		return int64(size)
 	}
 	pkSize := perRecord(schema.Fields[0])
-	textSize := perRecord(schema.Fields[1])
-	jsonSize := perRecord(schema.Fields[2])
+	// both variable width columns of the group, only used to assert the
+	// estimation is not the raw schema guess
+	schemaGuess := perRecord(schema.Fields[1]) + perRecord(schema.Fields[2])
 	// bytes the two variable width columns really take per row
 	residual := wholeRowSize/numRows - pkSize
+	s.Greater(residual, schemaGuess)
 
 	newSegment := func(collID UniqueID) *SegmentInfo {
 		return &SegmentInfo{
@@ -757,35 +840,38 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 
 	s.Run("sort job reads the whole segment", func() {
 		segment := newSegment(collectionID)
-		s.Equal(segment.getSegmentSize(), s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_Sort))
+		s.Equal(segment.getSegmentSize(), s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_Sort))
 	})
 
-	s.Run("json job only counts json columns", func() {
+	s.Run("json job drops the fixed width columns of the group", func() {
+		// the json column is charged the whole measured residual of the group,
+		// i.e. everything but the pk, doubled for the index it writes
 		segment := newSegment(collectionID)
-		expected := residual * jsonSize / (jsonSize + textSize) * numRows * 2
-		s.Equal(expected, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		expected := residual * numRows * 2
+		s.Equal(expected, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 		s.Less(expected, segment.getSegmentSize()*2)
 	})
 
-	s.Run("text job only counts match enabled columns and is not doubled", func() {
+	s.Run("text job is not doubled", func() {
 		segment := newSegment(collectionID)
-		expected := residual * textSize / (jsonSize + textSize) * numRows
-		s.Equal(expected, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_TextIndexJob))
+		expected := residual * numRows
+		s.Equal(expected, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_TextIndexJob))
+		s.Less(expected, segment.getSegmentSize())
 	})
 
 	s.Run("collection without the indexed column falls back to segment size", func() {
 		segment := newSegment(1)
-		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 	})
 
 	s.Run("unresolvable collection falls back to segment size", func() {
 		segment := newSegment(999)
-		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 	})
 
 	s.Run("segment without the field binlog falls back to segment size", func() {
 		segment := newSegment(collectionID)
 		segment.Binlogs[0].ChildFields = []int64{pkFieldID}
-		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 	})
 }

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -1010,9 +1010,11 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 	newSegment := func(collID UniqueID) *SegmentInfo {
 		return &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           30,
-				CollectionID: collID,
-				NumOfRows:    numRows,
+				ID:             30,
+				CollectionID:   collID,
+				NumOfRows:      numRows,
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   "manifest.json",
 				// external segments report one synthetic column group holding
 				// every column at once
 				Binlogs: []*datapb.FieldBinlog{
@@ -1047,6 +1049,14 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 		expected := residual * numRows
 		s.Equal(expected, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_TextIndexJob))
 		s.Less(expected, segment.getSegmentSize())
+	})
+
+	s.Run("storage v2 falls back to the whole segment", func() {
+		segment := newSegment(collectionID)
+		segment.StorageVersion = storage.StorageV2
+		segment.ManifestPath = ""
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(
+			s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 	})
 
 	s.Run("collection without the indexed column falls back to segment size", func() {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
@@ -858,4 +859,123 @@ func (s *statsInspectorSuite) TestEnableBM25() {
 	// Test if BM25 is enabled
 	result := s.inspector.enableBM25()
 	s.False(result, "BM25 should be disabled by default")
+}
+
+func (s *statsInspectorSuite) TestStatsTaskFieldIDs() {
+	// collection 2 declares one json field (202) and one match enabled varchar
+	// (201) among a pk.
+	coll := s.mt.GetCollection(2)
+	s.Equal([]int64{202}, statsTaskFieldIDs(coll.Schema, indexpb.StatsSubJob_JsonKeyIndexJob))
+	s.Equal([]int64{201}, statsTaskFieldIDs(coll.Schema, indexpb.StatsSubJob_TextIndexJob))
+	// a sort task reads every column
+	s.Nil(statsTaskFieldIDs(coll.Schema, indexpb.StatsSubJob_Sort))
+
+	// collection 1 has no json field at all.
+	coll = s.mt.GetCollection(1)
+	s.Empty(statsTaskFieldIDs(coll.Schema, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+func (s *statsInspectorSuite) TestGetCollectionWithoutMeta() {
+	inspector := &statsInspector{}
+	s.Nil(inspector.getCollection(1))
+	s.False(inspector.isExternalCollection(1))
+}
+
+func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
+	const (
+		collectionID = UniqueID(4)
+		numRows      = int64(1000)
+		pkFieldID    = int64(300)
+		textFieldID  = int64(301)
+		jsonFieldID  = int64(302)
+		wholeRowSize = int64(100 * 1024 * 1024)
+	)
+
+	schema := &schemapb.CollectionSchema{
+		ExternalSource: "s3://external",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: pkFieldID, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+			{
+				FieldID:       textFieldID,
+				Name:          "var",
+				DataType:      schemapb.DataType_VarChar,
+				ExternalField: "var_col",
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "1024"},
+					{Key: "enable_match", Value: "true"},
+					{Key: "enable_analyzer", Value: "true"},
+				},
+			},
+			{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON, ExternalField: "json_col"},
+		},
+	}
+	s.mt.collections.Insert(collectionID, &collectionInfo{ID: collectionID, Schema: schema})
+
+	perRecord := func(field *schemapb.FieldSchema) int64 {
+		size, err := typeutil.EstimateSizePerRecord(&schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{field},
+		})
+		s.NoError(err)
+		return int64(size)
+	}
+	pkSize := perRecord(schema.Fields[0])
+	textSize := perRecord(schema.Fields[1])
+	jsonSize := perRecord(schema.Fields[2])
+	// bytes the two variable width columns really take per row
+	residual := wholeRowSize/numRows - pkSize
+
+	newSegment := func(collID UniqueID) *SegmentInfo {
+		return &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:           30,
+				CollectionID: collID,
+				NumOfRows:    numRows,
+				// external segments report one synthetic column group holding
+				// every column at once
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID:     0,
+						ChildFields: []int64{pkFieldID, textFieldID, jsonFieldID},
+						Binlogs: []*datapb.Binlog{
+							{EntriesNum: numRows, LogSize: wholeRowSize, MemorySize: wholeRowSize},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	s.Run("sort job reads the whole segment", func() {
+		segment := newSegment(collectionID)
+		s.Equal(segment.getSegmentSize(), s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_Sort))
+	})
+
+	s.Run("json job only counts json columns", func() {
+		segment := newSegment(collectionID)
+		expected := residual * jsonSize / (jsonSize + textSize) * numRows * 2
+		s.Equal(expected, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		s.Less(expected, segment.getSegmentSize()*2)
+	})
+
+	s.Run("text job only counts match enabled columns and is not doubled", func() {
+		segment := newSegment(collectionID)
+		expected := residual * textSize / (jsonSize + textSize) * numRows
+		s.Equal(expected, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_TextIndexJob))
+	})
+
+	s.Run("collection without the indexed column falls back to segment size", func() {
+		segment := newSegment(1)
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+	})
+
+	s.Run("unresolvable collection falls back to segment size", func() {
+		segment := newSegment(999)
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+	})
+
+	s.Run("segment without the field binlog falls back to segment size", func() {
+		segment := newSegment(collectionID)
+		segment.Binlogs[0].ChildFields = []int64{pkFieldID}
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+	})
 }

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
@@ -668,4 +669,123 @@ func (s *statsInspectorSuite) TestEnableBM25() {
 	// Test if BM25 is enabled
 	result := s.inspector.enableBM25()
 	s.False(result, "BM25 should be disabled by default")
+}
+
+func (s *statsInspectorSuite) TestStatsTaskFieldIDs() {
+	// collection 2 declares one json field (202) and one match enabled varchar
+	// (201) among a pk.
+	coll := s.mt.GetCollection(2)
+	s.Equal([]int64{202}, statsTaskFieldIDs(coll.Schema, indexpb.StatsSubJob_JsonKeyIndexJob))
+	s.Equal([]int64{201}, statsTaskFieldIDs(coll.Schema, indexpb.StatsSubJob_TextIndexJob))
+	// a sort task reads every column
+	s.Nil(statsTaskFieldIDs(coll.Schema, indexpb.StatsSubJob_Sort))
+
+	// collection 1 has no json field at all.
+	coll = s.mt.GetCollection(1)
+	s.Empty(statsTaskFieldIDs(coll.Schema, indexpb.StatsSubJob_JsonKeyIndexJob))
+}
+
+func (s *statsInspectorSuite) TestGetCollectionWithoutMeta() {
+	inspector := &statsInspector{}
+	s.Nil(inspector.getCollection(1))
+	s.False(inspector.isExternalCollection(1))
+}
+
+func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
+	const (
+		collectionID = UniqueID(4)
+		numRows      = int64(1000)
+		pkFieldID    = int64(300)
+		textFieldID  = int64(301)
+		jsonFieldID  = int64(302)
+		wholeRowSize = int64(100 * 1024 * 1024)
+	)
+
+	schema := &schemapb.CollectionSchema{
+		ExternalSource: "s3://external",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: pkFieldID, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+			{
+				FieldID:       textFieldID,
+				Name:          "var",
+				DataType:      schemapb.DataType_VarChar,
+				ExternalField: "var_col",
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "1024"},
+					{Key: "enable_match", Value: "true"},
+					{Key: "enable_analyzer", Value: "true"},
+				},
+			},
+			{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON, ExternalField: "json_col"},
+		},
+	}
+	s.mt.collections.Insert(collectionID, &collectionInfo{ID: collectionID, Schema: schema})
+
+	perRecord := func(field *schemapb.FieldSchema) int64 {
+		size, err := typeutil.EstimateSizePerRecord(&schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{field},
+		})
+		s.NoError(err)
+		return int64(size)
+	}
+	pkSize := perRecord(schema.Fields[0])
+	textSize := perRecord(schema.Fields[1])
+	jsonSize := perRecord(schema.Fields[2])
+	// bytes the two variable width columns really take per row
+	residual := wholeRowSize/numRows - pkSize
+
+	newSegment := func(collID UniqueID) *SegmentInfo {
+		return &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:           30,
+				CollectionID: collID,
+				NumOfRows:    numRows,
+				// external segments report one synthetic column group holding
+				// every column at once
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID:     0,
+						ChildFields: []int64{pkFieldID, textFieldID, jsonFieldID},
+						Binlogs: []*datapb.Binlog{
+							{EntriesNum: numRows, LogSize: wholeRowSize, MemorySize: wholeRowSize},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	s.Run("sort job reads the whole segment", func() {
+		segment := newSegment(collectionID)
+		s.Equal(segment.getSegmentSize(), s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_Sort))
+	})
+
+	s.Run("json job only counts json columns", func() {
+		segment := newSegment(collectionID)
+		expected := residual * jsonSize / (jsonSize + textSize) * numRows * 2
+		s.Equal(expected, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		s.Less(expected, segment.getSegmentSize()*2)
+	})
+
+	s.Run("text job only counts match enabled columns and is not doubled", func() {
+		segment := newSegment(collectionID)
+		expected := residual * textSize / (jsonSize + textSize) * numRows
+		s.Equal(expected, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_TextIndexJob))
+	})
+
+	s.Run("collection without the indexed column falls back to segment size", func() {
+		segment := newSegment(1)
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+	})
+
+	s.Run("unresolvable collection falls back to segment size", func() {
+		segment := newSegment(999)
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+	})
+
+	s.Run("segment without the field binlog falls back to segment size", func() {
+		segment := newSegment(collectionID)
+		segment.Binlogs[0].ChildFields = []int64{pkFieldID}
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+	})
 }

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -116,17 +116,20 @@ func (s *statsInspectorSuite) SetupTest() {
 		ID: 2,
 		Schema: &schemapb.CollectionSchema{
 			ExternalSource: "s3://external",
+			ExternalSpec:   `{"format":"parquet"}`,
 			Fields: []*schemapb.FieldSchema{
 				{
 					FieldID:       200,
 					Name:          "pk",
 					DataType:      schemapb.DataType_Int64,
+					Nullable:      true,
 					ExternalField: "pk_col",
 				},
 				{
 					FieldID:       201,
 					Name:          "var",
 					DataType:      schemapb.DataType_VarChar,
+					Nullable:      true,
 					ExternalField: "var_col",
 					TypeParams: []*commonpb.KeyValuePair{
 						{
@@ -141,6 +144,7 @@ func (s *statsInspectorSuite) SetupTest() {
 					FieldID:       202,
 					Name:          "json",
 					DataType:      schemapb.DataType_JSON,
+					Nullable:      true,
 					ExternalField: "json_col",
 				},
 			},
@@ -750,9 +754,10 @@ func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
 		ID: collectionID,
 		Schema: &schemapb.CollectionSchema{
 			ExternalSource: "s3://external",
+			ExternalSpec:   `{"format":"parquet"}`,
 			Fields: []*schemapb.FieldSchema{
-				{FieldID: pkFieldID, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
-				{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON, ExternalField: "json_col"},
+				{FieldID: pkFieldID, Name: "pk", DataType: schemapb.DataType_Int64, Nullable: true, ExternalField: "pk_col"},
+				{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON, Nullable: true, ExternalField: "json_col"},
 			},
 		},
 	})
@@ -992,22 +997,22 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 		wholeRowSize = int64(100 * 1024 * 1024)
 	)
 
+	// an internal storage v3 collection whose short columns share one column
+	// group: the non-nullable pk is exact and deductible from the group budget
 	schema := &schemapb.CollectionSchema{
-		ExternalSource: "s3://external",
 		Fields: []*schemapb.FieldSchema{
-			{FieldID: pkFieldID, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+			{FieldID: pkFieldID, Name: "pk", DataType: schemapb.DataType_Int64},
 			{
-				FieldID:       textFieldID,
-				Name:          "var",
-				DataType:      schemapb.DataType_VarChar,
-				ExternalField: "var_col",
+				FieldID:  textFieldID,
+				Name:     "var",
+				DataType: schemapb.DataType_VarChar,
 				TypeParams: []*commonpb.KeyValuePair{
 					{Key: common.MaxLengthKey, Value: "1024"},
 					{Key: "enable_match", Value: "true"},
 					{Key: "enable_analyzer", Value: "true"},
 				},
 			},
-			{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON, ExternalField: "json_col"},
+			{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON},
 		},
 	}
 	s.mt.collections.Insert(collectionID, &collectionInfo{ID: collectionID, Schema: schema})
@@ -1093,5 +1098,41 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 		segment := newSegment(collectionID)
 		segment.Binlogs[0].ChildFields = []int64{pkFieldID}
 		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+	})
+
+	s.Run("non milvus-table external collection keeps the whole segment", func() {
+		// The only schema shape production can produce for a non milvus-table
+		// external collection: source and spec both set, every user field
+		// nullable (Pass 2 of NormalizeAndValidateExternalCollectionSchema).
+		// With nothing exact to deduct, a variable length target column is
+		// charged the whole synthetic group, i.e. the pre-attribution size.
+		const externalCollID = UniqueID(7)
+		externalSchema := &schemapb.CollectionSchema{
+			ExternalSource: "s3://external",
+			ExternalSpec:   `{"format":"parquet"}`,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: pkFieldID, Name: "pk", DataType: schemapb.DataType_Int64, Nullable: true, ExternalField: "pk_col"},
+				{
+					FieldID:       textFieldID,
+					Name:          "var",
+					DataType:      schemapb.DataType_VarChar,
+					Nullable:      true,
+					ExternalField: "var_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "1024"},
+						{Key: "enable_match", Value: "true"},
+						{Key: "enable_analyzer", Value: "true"},
+					},
+				},
+				{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON, Nullable: true, ExternalField: "json_col"},
+			},
+		}
+		s.mt.collections.Insert(externalCollID, &collectionInfo{ID: externalCollID, Schema: externalSchema})
+
+		segment := newSegment(externalCollID)
+		s.Equal(wholeRowSize, s.inspector.estimateStatsTaskSize(
+			s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_TextIndexJob))
+		s.Equal(wholeRowSize*2, s.inspector.estimateStatsTaskSize(
+			s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 	})
 }

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -731,6 +731,87 @@ func (s *statsInspectorSuite) TestReloadFromMeta() {
 	s.Equal(1, enqueueCount)
 }
 
+func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
+	// The collection cache is filled asynchronously, so recovered stats tasks
+	// must resolve the collection through the handler and be sized by the
+	// columns their sub job actually reads.
+	const (
+		collectionID = UniqueID(5)
+		segmentID    = UniqueID(50)
+		pkFieldID    = int64(500)
+		jsonFieldID  = int64(501)
+		numRows      = int64(1000)
+		groupSize    = int64(2 * 1024 * 1024 * 1024)
+	)
+
+	collInfo := &collectionInfo{
+		ID: collectionID,
+		Schema: &schemapb.CollectionSchema{
+			ExternalSource: "s3://external",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: pkFieldID, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+				{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON, ExternalField: "json_col"},
+			},
+		},
+	}
+	handler := NewNMockHandler(s.T())
+	// resolved once for the two recovered tasks
+	handler.EXPECT().GetCollection(mock.Anything, collectionID).Return(collInfo, nil).Once()
+	s.inspector.handler = handler
+
+	segment := &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             segmentID,
+			CollectionID:   collectionID,
+			PartitionID:    3,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      numRows,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   packed.MarshalManifestPath("files/insert_log/5/3/50", 1),
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0,
+					ChildFields: []int64{pkFieldID, jsonFieldID},
+					Binlogs: []*datapb.Binlog{
+						{EntriesNum: numRows, LogSize: groupSize, MemorySize: groupSize},
+					},
+				},
+			},
+		},
+	}
+	s.mt.segments.SetSegment(segmentID, segment)
+
+	for taskID, subJobType := range map[UniqueID]indexpb.StatsSubJob{
+		2001: indexpb.StatsSubJob_JsonKeyIndexJob,
+		2002: indexpb.StatsSubJob_Sort,
+	} {
+		s.mt.statsTaskMeta.tasks.Insert(taskID, &indexpb.StatsTask{
+			CollectionID: collectionID,
+			TaskID:       taskID,
+			SegmentID:    segmentID,
+			SubJobType:   subJobType,
+			State:        indexpb.JobState_JobStateInProgress,
+		})
+	}
+
+	slots := make(map[indexpb.StatsSubJob]int64)
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(t task.Task) {
+		st := t.(*statsTask)
+		slots[st.GetSubJobType()] = t.GetTaskSlot()
+	}).Return()
+	s.inspector.scheduler = scheduler
+
+	s.inspector.reloadFromMeta()
+
+	// the json key index task drops the pk column out of its estimation, while
+	// the sort task still reads the whole segment
+	residual := groupSize/numRows - 8
+	s.Equal(calculateStatsTaskSlot(residual*numRows*2), slots[indexpb.StatsSubJob_JsonKeyIndexJob])
+	s.Equal(calculateStatsTaskSlot(segment.getSegmentSize()), slots[indexpb.StatsSubJob_Sort])
+	s.Less(slots[indexpb.StatsSubJob_JsonKeyIndexJob], calculateStatsTaskSlot(segment.getSegmentSize()*2))
+}
+
 func (s *statsInspectorSuite) TestReloadFromMetaExternalStatsTask() {
 	testCases := []struct {
 		name           string
@@ -919,10 +1000,12 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 		return int64(size)
 	}
 	pkSize := perRecord(schema.Fields[0])
-	textSize := perRecord(schema.Fields[1])
-	jsonSize := perRecord(schema.Fields[2])
+	// both variable width columns of the group, only used to assert the
+	// estimation is not the raw schema guess
+	schemaGuess := perRecord(schema.Fields[1]) + perRecord(schema.Fields[2])
 	// bytes the two variable width columns really take per row
 	residual := wholeRowSize/numRows - pkSize
+	s.Greater(residual, schemaGuess)
 
 	newSegment := func(collID UniqueID) *SegmentInfo {
 		return &SegmentInfo{
@@ -947,35 +1030,38 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 
 	s.Run("sort job reads the whole segment", func() {
 		segment := newSegment(collectionID)
-		s.Equal(segment.getSegmentSize(), s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_Sort))
+		s.Equal(segment.getSegmentSize(), s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_Sort))
 	})
 
-	s.Run("json job only counts json columns", func() {
+	s.Run("json job drops the fixed width columns of the group", func() {
+		// the json column is charged the whole measured residual of the group,
+		// i.e. everything but the pk, doubled for the index it writes
 		segment := newSegment(collectionID)
-		expected := residual * jsonSize / (jsonSize + textSize) * numRows * 2
-		s.Equal(expected, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		expected := residual * numRows * 2
+		s.Equal(expected, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 		s.Less(expected, segment.getSegmentSize()*2)
 	})
 
-	s.Run("text job only counts match enabled columns and is not doubled", func() {
+	s.Run("text job is not doubled", func() {
 		segment := newSegment(collectionID)
-		expected := residual * textSize / (jsonSize + textSize) * numRows
-		s.Equal(expected, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_TextIndexJob))
+		expected := residual * numRows
+		s.Equal(expected, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_TextIndexJob))
+		s.Less(expected, segment.getSegmentSize())
 	})
 
 	s.Run("collection without the indexed column falls back to segment size", func() {
 		segment := newSegment(1)
-		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 	})
 
 	s.Run("unresolvable collection falls back to segment size", func() {
 		segment := newSegment(999)
-		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 	})
 
 	s.Run("segment without the field binlog falls back to segment size", func() {
 		segment := newSegment(collectionID)
 		segment.Binlogs[0].ChildFields = []int64{pkFieldID}
-		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(segment, indexpb.StatsSubJob_JsonKeyIndexJob))
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 	})
 }

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -732,9 +732,9 @@ func (s *statsInspectorSuite) TestReloadFromMeta() {
 }
 
 func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
-	// The collection cache is filled asynchronously, so recovered stats tasks
-	// must resolve the collection through the handler and be sized by the
-	// columns their sub job actually reads.
+	// Recovered stats tasks read the collection from the local meta cache and
+	// are sized by the columns their sub job actually reads; recovery must not
+	// resolve collections through the handler (rootcoord).
 	const (
 		collectionID = UniqueID(5)
 		segmentID    = UniqueID(50)
@@ -744,7 +744,7 @@ func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
 		groupSize    = int64(2 * 1024 * 1024 * 1024)
 	)
 
-	collInfo := &collectionInfo{
+	s.mt.collections.Insert(collectionID, &collectionInfo{
 		ID: collectionID,
 		Schema: &schemapb.CollectionSchema{
 			ExternalSource: "s3://external",
@@ -753,11 +753,9 @@ func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
 				{FieldID: jsonFieldID, Name: "json", DataType: schemapb.DataType_JSON, ExternalField: "json_col"},
 			},
 		},
-	}
-	handler := NewNMockHandler(s.T())
-	// resolved once for the two recovered tasks
-	handler.EXPECT().GetCollection(mock.Anything, collectionID).Return(collInfo, nil).Once()
-	s.inspector.handler = handler
+	})
+	// no GetCollection expectation: any handler resolution fails the test
+	s.inspector.handler = NewNMockHandler(s.T())
 
 	segment := &SegmentInfo{
 		SegmentInfo: &datapb.SegmentInfo{
@@ -810,6 +808,36 @@ func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
 	s.Equal(calculateStatsTaskSlot(residual*numRows*2), slots[indexpb.StatsSubJob_JsonKeyIndexJob])
 	s.Equal(calculateStatsTaskSlot(segment.getSegmentSize()), slots[indexpb.StatsSubJob_Sort])
 	s.Less(slots[indexpb.StatsSubJob_JsonKeyIndexJob], calculateStatsTaskSlot(segment.getSegmentSize()*2))
+}
+
+func (s *statsInspectorSuite) TestReloadFromMetaSkipsCollectionResolutionWithoutProjection() {
+	// Recovery reads collections from the local meta cache only; it must never
+	// resolve one through the handler (rootcoord), whose cache-miss retries
+	// would block Start().
+	// no GetCollection expectation: any resolution attempt fails the test
+	handler := NewNMockHandler(s.T())
+	s.inspector.handler = handler
+
+	s.mt.statsTaskMeta.tasks.Insert(1005, &indexpb.StatsTask{
+		CollectionID: 1,
+		TaskID:       1005,
+		SegmentID:    10,
+		SubJobType:   indexpb.StatsSubJob_Sort,
+		State:        indexpb.JobState_JobStateInProgress,
+	})
+
+	slots := make([]int64, 0, 1)
+	scheduler := task.NewMockGlobalScheduler(s.T())
+	scheduler.EXPECT().Enqueue(mock.Anything).Run(func(t task.Task) {
+		slots = append(slots, t.GetTaskSlot())
+	}).Return()
+	s.inspector.scheduler = scheduler
+
+	s.inspector.reloadFromMeta()
+
+	s.Require().Len(slots, 1)
+	segment := s.mt.GetHealthySegment(s.ctx, 10)
+	s.Equal(calculateStatsTaskSlot(s.inspector.estimateStatsTaskSize(nil, segment, indexpb.StatsSubJob_Sort)), slots[0])
 }
 
 func (s *statsInspectorSuite) TestReloadFromMetaExternalStatsTask() {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -820,9 +820,11 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 	newSegment := func(collID UniqueID) *SegmentInfo {
 		return &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:           30,
-				CollectionID: collID,
-				NumOfRows:    numRows,
+				ID:             30,
+				CollectionID:   collID,
+				NumOfRows:      numRows,
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   "manifest.json",
 				// external segments report one synthetic column group holding
 				// every column at once
 				Binlogs: []*datapb.FieldBinlog{
@@ -857,6 +859,14 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 		expected := residual * numRows
 		s.Equal(expected, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_TextIndexJob))
 		s.Less(expected, segment.getSegmentSize())
+	})
+
+	s.Run("storage v2 falls back to the whole segment", func() {
+		segment := newSegment(collectionID)
+		segment.StorageVersion = storage.StorageV2
+		segment.ManifestPath = ""
+		s.Equal(segment.getSegmentSize()*2, s.inspector.estimateStatsTaskSize(
+			s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 	})
 
 	s.Run("collection without the indexed column falls back to segment size", func() {

--- a/internal/datacoord/stats_inspector_test.go
+++ b/internal/datacoord/stats_inspector_test.go
@@ -804,8 +804,8 @@ func (s *statsInspectorSuite) TestReloadFromMetaEstimatesPerSubJobType() {
 
 	// the json key index task drops the pk column out of its estimation, while
 	// the sort task still reads the whole segment
-	residual := groupSize/numRows - 8
-	s.Equal(calculateStatsTaskSlot(residual*numRows*2), slots[indexpb.StatsSubJob_JsonKeyIndexJob])
+	residualBytes := groupSize - 8*numRows
+	s.Equal(calculateStatsTaskSlot(residualBytes*2), slots[indexpb.StatsSubJob_JsonKeyIndexJob])
 	s.Equal(calculateStatsTaskSlot(segment.getSegmentSize()), slots[indexpb.StatsSubJob_Sort])
 	s.Less(slots[indexpb.StatsSubJob_JsonKeyIndexJob], calculateStatsTaskSlot(segment.getSegmentSize()*2))
 }
@@ -1031,9 +1031,9 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 	// both variable width columns of the group, only used to assert the
 	// estimation is not the raw schema guess
 	schemaGuess := perRecord(schema.Fields[1]) + perRecord(schema.Fields[2])
-	// bytes the two variable width columns really take per row
-	residual := wholeRowSize/numRows - pkSize
-	s.Greater(residual, schemaGuess)
+	// bytes the two variable width columns really take in total
+	residualBytes := wholeRowSize - pkSize*numRows
+	s.Greater(residualBytes, schemaGuess*numRows)
 
 	newSegment := func(collID UniqueID) *SegmentInfo {
 		return &SegmentInfo{
@@ -1067,14 +1067,14 @@ func (s *statsInspectorSuite) TestEstimateStatsTaskSize() {
 		// the json column is charged the whole measured residual of the group,
 		// i.e. everything but the pk, doubled for the index it writes
 		segment := newSegment(collectionID)
-		expected := residual * numRows * 2
+		expected := residualBytes * 2
 		s.Equal(expected, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_JsonKeyIndexJob))
 		s.Less(expected, segment.getSegmentSize()*2)
 	})
 
 	s.Run("text job is not doubled", func() {
 		segment := newSegment(collectionID)
-		expected := residual * numRows
+		expected := residualBytes
 		s.Equal(expected, s.inspector.estimateStatsTaskSize(s.mt.GetCollection(segment.GetCollectionID()), segment, indexpb.StatsSubJob_TextIndexJob))
 		s.Less(expected, segment.getSegmentSize())
 	})

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -581,9 +581,15 @@ func calculateIndexTaskSlot(fieldSize, numRows int64, indexParams []*commonpb.Ke
 // a field, i.e. the estimation cannot be off. Variable length types only get a
 // configured guess out of the schema (see typeutil.EstimateSizePerRecord), so
 // they are attributed from the measured data instead whenever possible.
+//
+// Bool is deliberately absent: the schema charges it 1 byte per row while the
+// measured group size accounts it bit-packed (~1/8 byte per row, see
+// ActualSizeInBytes handling of arrow.BOOL), and external sampling can round
+// it down to 0. Treating it as exact would over-deduct from the residual and
+// understate the variable length columns sharing its group.
 func isFixedWidthType(dataType schemapb.DataType) bool {
 	switch dataType {
-	case schemapb.DataType_Bool, schemapb.DataType_Int8, schemapb.DataType_Int16,
+	case schemapb.DataType_Int8, schemapb.DataType_Int16,
 		schemapb.DataType_Int32, schemapb.DataType_Int64, schemapb.DataType_Float,
 		schemapb.DataType_Double, schemapb.DataType_Timestamptz,
 		schemapb.DataType_BinaryVector, schemapb.DataType_FloatVector,
@@ -655,6 +661,13 @@ func segmentColumnGroups(segment *SegmentInfo) map[int64]*columnGroup {
 
 // estimateFieldsReadSize estimates how much data a task reads for fieldIDs of a
 // segment.
+//
+// It works off segment.GetBinlogs(), which for manifest-backed StorageV3
+// segments only exists in memory: the catalog does not persist their
+// FieldBinlog arrays (see isV3Segment), so after a DataCoord restart such
+// segments carry no binlogs and every field errors out here, letting the
+// callers keep their conservative whole-segment fallback until the segment is
+// rewritten.
 //
 // Both the index build and the json/text stats tasks request a single column at
 // a time. Per-field attribution is safe only for a StorageV3 segment with a

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -644,14 +645,15 @@ func segmentColumnGroups(segment *SegmentInfo) map[int64]*columnGroup {
 // estimateFieldsReadSize estimates how much data a task reads for fieldIDs of a
 // segment.
 //
-// Both the index build and the json/text stats tasks read a single column at a
-// time: for storage v3 the reader is built with a schema holding only the target
-// column, so parquet only touches that column inside the column group file (see
-// GetFieldDatasFromStorageV2 in internal/core/src/storage/Util.cpp). The binlog
-// size however is recorded per column group, so a field sharing a group with
-// others gets charged for all of them. This is worst for external collections,
-// whose segments carry one synthetic group holding every column at once (see
-// buildFakeBinlogs in internal/datanode/external).
+// Both the index build and the json/text stats tasks request a single column at
+// a time. Per-field attribution is safe only for a StorageV3 segment with a
+// manifest: GetFieldDatasFromManifest asks the reader for the target column,
+// while GetFieldDatasFromStorageV2 materializes every column of the selected
+// column group. The binlog size however is recorded per column group, so a
+// projected field sharing a group with others otherwise gets charged for all of
+// them. This is worst for external collections, whose segments carry one
+// synthetic group holding every column at once (see buildFakeBinlogs in
+// internal/datanode/external).
 //
 // The group size is the measured truth for the group as a whole, so it is used
 // as the budget: fields whose schema gives an exact size take exactly that, and
@@ -670,6 +672,12 @@ func estimateFieldsReadSize(schema *schemapb.CollectionSchema, segment *SegmentI
 	numRows := segment.GetNumOfRows()
 	if numRows <= 0 {
 		return 0, nil
+	}
+	if !supportsFieldProjection(segment) {
+		// Callers gate this optimization on supportsFieldProjection. Reaching
+		// this branch means an internal contract was violated, not bad input.
+		return 0, merr.WrapErrServiceInternalMsg(
+			"segment %d does not have a StorageV3 manifest for projected field reads", segment.GetID())
 	}
 
 	groups := segmentColumnGroups(segment)
@@ -692,6 +700,14 @@ func estimateFieldsReadSize(schema *schemapb.CollectionSchema, segment *SegmentI
 		total += size
 	}
 	return total, nil
+}
+
+// supportsFieldProjection matches the actual reader selection in the index and
+// stats workers. A non-empty manifest selects GetFieldDatasFromManifest, which
+// projects the requested column. StorageV2 files without a manifest are read by
+// GetFieldDatasFromStorageV2, which materializes the whole column group.
+func supportsFieldProjection(segment *SegmentInfo) bool {
+	return segment.GetStorageVersion() == storage.StorageV3 && segment.GetManifestPath() != ""
 }
 
 // estimateGroupFieldsSize attributes the measured size of one column group to
@@ -719,6 +735,10 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 	estimates := make(map[int64]fieldEstimate, len(group.fields))
 	var fixedPerRecord int64
 	var hasVariableField bool
+	var externalColumnResolver *typeutil.StorageColumnResolver
+	if typeutil.IsExternalCollection(schema) {
+		externalColumnResolver = typeutil.NewStorageColumnResolver(schema)
+	}
 	for _, fieldID := range group.fields {
 		size, exact, err := fieldSizePerRecord(schema, fieldID)
 		if err != nil {
@@ -733,7 +753,17 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 		}
 		estimates[fieldID] = fieldEstimate{sizePerRecord: size, exact: exact}
 		if exact {
-			fixedPerRecord += size
+			measured := true
+			if externalColumnResolver != nil {
+				field := typeutil.GetFieldByID(schema, fieldID)
+				_, measured = externalColumnResolver.SourceDataColumnName(field)
+				// Refresh adds generated function outputs to MemorySize after
+				// sampling the source columns, so they are measured too.
+				measured = measured || typeutil.IsFunctionOutputField(schema, field)
+			}
+			if measured {
+				fixedPerRecord += size
+			}
 			continue
 		}
 		hasVariableField = true

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -803,44 +803,6 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 	return total, nil
 }
 
-// collectionCache memoizes collection lookups over a loop that resolves the
-// same collections repeatedly. It goes through the handler, which loads from
-// rootcoord on a cache miss: the datacoord collection cache is filled by an
-// async goroutine (see Server.initMeta), so it is usually still empty while the
-// inspectors recover their tasks at startup. That load costs up to 5 retries
-// with a 10s timeout, hence the memoization - including of misses.
-type collectionCache struct {
-	handler Handler
-	cached  map[int64]*collectionInfo
-}
-
-func newCollectionCache(handler Handler) *collectionCache {
-	return &collectionCache{handler: handler, cached: make(map[int64]*collectionInfo)}
-}
-
-func (c *collectionCache) get(ctx context.Context, collectionID int64) *collectionInfo {
-	if coll, ok := c.cached[collectionID]; ok {
-		return coll
-	}
-	coll := resolveCollection(ctx, c.handler, collectionID)
-	c.cached[collectionID] = coll
-	return coll
-}
-
-// resolveCollection returns the collection info, loading it from rootcoord when
-// the datacoord cache does not hold it yet.
-func resolveCollection(ctx context.Context, handler Handler, collectionID int64) *collectionInfo {
-	if handler == nil {
-		return nil
-	}
-	coll, err := handler.GetCollection(ctx, collectionID)
-	if err != nil {
-		mlog.Warn(ctx, "failed to resolve collection", mlog.FieldCollectionID(collectionID), mlog.Err(err))
-		return nil
-	}
-	return coll
-}
-
 func calculateStatsTaskSlot(segmentSize int64) int64 {
 	defaultSlots := Params.DataCoordCfg.StatsTaskSlotUsage.GetAsInt64()
 	if segmentSize > 512*1024*1024 {

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -655,10 +655,14 @@ func segmentColumnGroups(segment *SegmentInfo) map[int64]*columnGroup {
 //
 // The group size is the measured truth for the group as a whole, so it is used
 // as the budget: fields whose schema gives an exact size take exactly that, and
-// the remaining bytes are shared between the variable length fields
-// proportionally to their schema estimate. That keeps a 128 dim vector at its
-// real size while a large json column still gets the bytes it actually
-// occupies, instead of the configured per row guess.
+// whatever remains is charged to the variable length fields. That keeps a 128
+// dim vector at its real size, while a json column is charged what the data
+// really contains instead of the configured per row guess
+// (common.dynamicFieldLengthAvg), which can be an order of magnitude off. The
+// residual is not split proportionally between several variable length fields:
+// the schema weights are guesses, and splitting by them could understate a fat
+// column, i.e. over-admit tasks. Charging it once keeps the result an upper
+// bound, which is what a slot must be.
 func estimateFieldsReadSize(schema *schemapb.CollectionSchema, segment *SegmentInfo, fieldIDs []int64) (int64, error) {
 	if len(fieldIDs) == 0 {
 		return 0, merr.WrapErrParameterInvalidMsg("no field to estimate size for")
@@ -703,28 +707,41 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 		return group.size, nil
 	}
 
+	requestedFields := make(map[int64]struct{}, len(fieldIDs))
+	for _, fieldID := range fieldIDs {
+		requestedFields[fieldID] = struct{}{}
+	}
+
 	type fieldEstimate struct {
 		sizePerRecord int64
 		exact         bool
 	}
 	estimates := make(map[int64]fieldEstimate, len(group.fields))
-	var fixedPerRecord, variableWeight int64
+	var fixedPerRecord int64
+	var hasVariableField bool
 	for _, fieldID := range group.fields {
 		size, exact, err := fieldSizePerRecord(schema, fieldID)
 		if err != nil {
-			return 0, err
+			if _, requested := requestedFields[fieldID]; requested {
+				return 0, err
+			}
+			// A group member the schema cannot resolve, e.g. a field dropped
+			// after this segment was flushed and before compaction rewrote it.
+			// Skipping it leaves its bytes in the residual instead of giving up
+			// on the whole group.
+			continue
 		}
 		estimates[fieldID] = fieldEstimate{sizePerRecord: size, exact: exact}
 		if exact {
 			fixedPerRecord += size
 			continue
 		}
-		variableWeight += size
+		hasVariableField = true
 	}
 
 	// bytes the variable length fields of this group take per row, measured
 	residualPerRecord := group.size/numRows - fixedPerRecord
-	if residualPerRecord < 0 || variableWeight == 0 {
+	if residualPerRecord < 0 || !hasVariableField {
 		// the schema does not add up to the measured data, e.g. because some
 		// field of the group is not materialized in it. Fall back to the schema
 		// estimation alone, still bounded by the group size.
@@ -732,18 +749,62 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 	}
 
 	var total int64
+	var residualCharged bool
 	for _, fieldID := range fieldIDs {
 		estimate := estimates[fieldID]
-		sizePerRecord := estimate.sizePerRecord
 		if !estimate.exact && residualPerRecord > 0 {
-			sizePerRecord = residualPerRecord * sizePerRecord / variableWeight
+			// every variable length field of the group shares the same residual,
+			// so it is charged once no matter how many of them are requested
+			if !residualCharged {
+				total += residualPerRecord * numRows
+				residualCharged = true
+			}
+			continue
 		}
-		total += sizePerRecord * numRows
+		total += estimate.sizePerRecord * numRows
 	}
 	if total > group.size {
 		return group.size, nil
 	}
 	return total, nil
+}
+
+// collectionCache memoizes collection lookups over a loop that resolves the
+// same collections repeatedly. It goes through the handler, which loads from
+// rootcoord on a cache miss: the datacoord collection cache is filled by an
+// async goroutine (see Server.initMeta), so it is usually still empty while the
+// inspectors recover their tasks at startup. That load costs up to 5 retries
+// with a 10s timeout, hence the memoization - including of misses.
+type collectionCache struct {
+	handler Handler
+	cached  map[int64]*collectionInfo
+}
+
+func newCollectionCache(handler Handler) *collectionCache {
+	return &collectionCache{handler: handler, cached: make(map[int64]*collectionInfo)}
+}
+
+func (c *collectionCache) get(ctx context.Context, collectionID int64) *collectionInfo {
+	if coll, ok := c.cached[collectionID]; ok {
+		return coll
+	}
+	coll := resolveCollection(ctx, c.handler, collectionID)
+	c.cached[collectionID] = coll
+	return coll
+}
+
+// resolveCollection returns the collection info, loading it from rootcoord when
+// the datacoord cache does not hold it yet.
+func resolveCollection(ctx context.Context, handler Handler, collectionID int64) *collectionInfo {
+	if handler == nil {
+		return nil
+	}
+	coll, err := handler.GetCollection(ctx, collectionID)
+	if err != nil {
+		mlog.Warn(ctx, "failed to resolve collection", mlog.FieldCollectionID(collectionID), mlog.Err(err))
+		return nil
+	}
+	return coll
 }
 
 func calculateStatsTaskSlot(segmentSize int64) int64 {

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -659,10 +659,14 @@ func segmentColumnGroups(segment *SegmentInfo) map[int64]*columnGroup {
 //
 // The group size is the measured truth for the group as a whole, so it is used
 // as the budget: fields whose schema gives an exact size take exactly that, and
-// the remaining bytes are shared between the variable length fields
-// proportionally to their schema estimate. That keeps a 128 dim vector at its
-// real size while a large json column still gets the bytes it actually
-// occupies, instead of the configured per row guess.
+// whatever remains is charged to the variable length fields. That keeps a 128
+// dim vector at its real size, while a json column is charged what the data
+// really contains instead of the configured per row guess
+// (common.dynamicFieldLengthAvg), which can be an order of magnitude off. The
+// residual is not split proportionally between several variable length fields:
+// the schema weights are guesses, and splitting by them could understate a fat
+// column, i.e. over-admit tasks. Charging it once keeps the result an upper
+// bound, which is what a slot must be.
 func estimateFieldsReadSize(schema *schemapb.CollectionSchema, segment *SegmentInfo, fieldIDs []int64) (int64, error) {
 	if len(fieldIDs) == 0 {
 		return 0, merr.WrapErrParameterInvalidMsg("no field to estimate size for")
@@ -707,28 +711,41 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 		return group.size, nil
 	}
 
+	requestedFields := make(map[int64]struct{}, len(fieldIDs))
+	for _, fieldID := range fieldIDs {
+		requestedFields[fieldID] = struct{}{}
+	}
+
 	type fieldEstimate struct {
 		sizePerRecord int64
 		exact         bool
 	}
 	estimates := make(map[int64]fieldEstimate, len(group.fields))
-	var fixedPerRecord, variableWeight int64
+	var fixedPerRecord int64
+	var hasVariableField bool
 	for _, fieldID := range group.fields {
 		size, exact, err := fieldSizePerRecord(schema, fieldID)
 		if err != nil {
-			return 0, err
+			if _, requested := requestedFields[fieldID]; requested {
+				return 0, err
+			}
+			// A group member the schema cannot resolve, e.g. a field dropped
+			// after this segment was flushed and before compaction rewrote it.
+			// Skipping it leaves its bytes in the residual instead of giving up
+			// on the whole group.
+			continue
 		}
 		estimates[fieldID] = fieldEstimate{sizePerRecord: size, exact: exact}
 		if exact {
 			fixedPerRecord += size
 			continue
 		}
-		variableWeight += size
+		hasVariableField = true
 	}
 
 	// bytes the variable length fields of this group take per row, measured
 	residualPerRecord := group.size/numRows - fixedPerRecord
-	if residualPerRecord < 0 || variableWeight == 0 {
+	if residualPerRecord < 0 || !hasVariableField {
 		// the schema does not add up to the measured data, e.g. because some
 		// field of the group is not materialized in it. Fall back to the schema
 		// estimation alone, still bounded by the group size.
@@ -736,18 +753,62 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 	}
 
 	var total int64
+	var residualCharged bool
 	for _, fieldID := range fieldIDs {
 		estimate := estimates[fieldID]
-		sizePerRecord := estimate.sizePerRecord
 		if !estimate.exact && residualPerRecord > 0 {
-			sizePerRecord = residualPerRecord * sizePerRecord / variableWeight
+			// every variable length field of the group shares the same residual,
+			// so it is charged once no matter how many of them are requested
+			if !residualCharged {
+				total += residualPerRecord * numRows
+				residualCharged = true
+			}
+			continue
 		}
-		total += sizePerRecord * numRows
+		total += estimate.sizePerRecord * numRows
 	}
 	if total > group.size {
 		return group.size, nil
 	}
 	return total, nil
+}
+
+// collectionCache memoizes collection lookups over a loop that resolves the
+// same collections repeatedly. It goes through the handler, which loads from
+// rootcoord on a cache miss: the datacoord collection cache is filled by an
+// async goroutine (see Server.initMeta), so it is usually still empty while the
+// inspectors recover their tasks at startup. That load costs up to 5 retries
+// with a 10s timeout, hence the memoization - including of misses.
+type collectionCache struct {
+	handler Handler
+	cached  map[int64]*collectionInfo
+}
+
+func newCollectionCache(handler Handler) *collectionCache {
+	return &collectionCache{handler: handler, cached: make(map[int64]*collectionInfo)}
+}
+
+func (c *collectionCache) get(ctx context.Context, collectionID int64) *collectionInfo {
+	if coll, ok := c.cached[collectionID]; ok {
+		return coll
+	}
+	coll := resolveCollection(ctx, c.handler, collectionID)
+	c.cached[collectionID] = coll
+	return coll
+}
+
+// resolveCollection returns the collection info, loading it from rootcoord when
+// the datacoord cache does not hold it yet.
+func resolveCollection(ctx context.Context, handler Handler, collectionID int64) *collectionInfo {
+	if handler == nil {
+		return nil
+	}
+	coll, err := handler.GetCollection(ctx, collectionID)
+	if err != nil {
+		mlog.Warn(ctx, "failed to resolve collection", mlog.FieldCollectionID(collectionID), mlog.Err(err))
+		return nil
+	}
+	return coll
 }
 
 func calculateStatsTaskSlot(segmentSize int64) int64 {

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -597,6 +597,12 @@ func isFixedWidthType(dataType schemapb.DataType) bool {
 
 // fieldSizePerRecord returns the per row size of a field derived from the
 // schema, together with whether that size is exact.
+//
+// A nullable field is never exact, whatever its data type: rows holding null
+// store less than the full width (nullable vectors are even stored with a
+// variable length encoding, see CreateArrowSchema in
+// internal/core/src/storage/Util.cpp), so its real size is data dependent and
+// must come from the measured residual instead.
 func fieldSizePerRecord(schema *schemapb.CollectionSchema, fieldID int64) (int64, bool, error) {
 	field := typeutil.GetFieldByID(schema, fieldID)
 	if field == nil {
@@ -614,7 +620,8 @@ func fieldSizePerRecord(schema *schemapb.CollectionSchema, fieldID int64) (int64
 		return 0, false, merr.WrapErrParameterInvalidMsg("cannot estimate size of field %d with data type %s",
 			fieldID, field.GetDataType().String())
 	}
-	return int64(sizePerRecord), isFixedWidthType(field.GetDataType()), nil
+	exact := isFixedWidthType(field.GetDataType()) && !field.GetNullable()
+	return int64(sizePerRecord), exact, nil
 }
 
 // columnGroup is a set of fields stored together, which is what a binlog entry
@@ -773,24 +780,27 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 		hasVariableField = true
 	}
 
-	// bytes the variable length fields of this group take per row, measured
-	residualPerRecord := group.size/numRows - fixedPerRecord
-	if residualPerRecord < 0 || !hasVariableField {
+	// bytes the variable length fields of this group take in total, measured.
+	// Kept in whole bytes rather than per record: a per record truncation
+	// could lose up to numRows bytes and drop the estimate into a lower slot
+	// bucket.
+	residualBytes := group.size - fixedPerRecord*numRows
+	if residualBytes < 0 || !hasVariableField {
 		// the schema does not add up to the measured data, e.g. because some
 		// field of the group is not materialized in it. Fall back to the schema
 		// estimation alone, still bounded by the group size.
-		residualPerRecord = 0
+		residualBytes = 0
 	}
 
 	var total int64
 	var residualCharged bool
 	for _, fieldID := range fieldIDs {
 		estimate := estimates[fieldID]
-		if !estimate.exact && residualPerRecord > 0 {
+		if !estimate.exact && residualBytes > 0 {
 			// every variable length field of the group shares the same residual,
 			// so it is charged once no matter how many of them are requested
 			if !residualCharged {
-				total += residualPerRecord * numRows
+				total += residualBytes
 				residualCharged = true
 			}
 			continue

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -573,6 +574,180 @@ func calculateIndexTaskSlot(fieldSize, numRows int64, indexParams []*commonpb.Ke
 		return max(defaultSlots/16, 1)
 	}
 	return max(defaultSlots/64, 1)
+}
+
+// isFixedWidthType tells whether the schema alone fully determines the size of
+// a field, i.e. the estimation cannot be off. Variable length types only get a
+// configured guess out of the schema (see typeutil.EstimateSizePerRecord), so
+// they are attributed from the measured data instead whenever possible.
+func isFixedWidthType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_Bool, schemapb.DataType_Int8, schemapb.DataType_Int16,
+		schemapb.DataType_Int32, schemapb.DataType_Int64, schemapb.DataType_Float,
+		schemapb.DataType_Double, schemapb.DataType_Timestamptz,
+		schemapb.DataType_BinaryVector, schemapb.DataType_FloatVector,
+		schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector:
+		return true
+	default:
+		return false
+	}
+}
+
+// fieldSizePerRecord returns the per row size of a field derived from the
+// schema, together with whether that size is exact.
+func fieldSizePerRecord(schema *schemapb.CollectionSchema, fieldID int64) (int64, bool, error) {
+	field := typeutil.GetFieldByID(schema, fieldID)
+	if field == nil {
+		return 0, false, merr.WrapErrFieldNotFound(fieldID)
+	}
+	sizePerRecord, err := typeutil.EstimateSizePerRecord(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{field},
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	if sizePerRecord <= 0 {
+		// An unrecognized data type estimates to zero, which would understate
+		// the slot usage. Let the caller keep the conservative binlog size.
+		return 0, false, merr.WrapErrParameterInvalidMsg("cannot estimate size of field %d with data type %s",
+			fieldID, field.GetDataType().String())
+	}
+	return int64(sizePerRecord), isFixedWidthType(field.GetDataType()), nil
+}
+
+// columnGroup is a set of fields stored together, which is what a binlog entry
+// describes for storage v3 segments. Storage v1 binlogs hold a single field and
+// therefore form a group of one.
+type columnGroup struct {
+	fields []int64
+	size   int64
+}
+
+// segmentColumnGroups returns the column groups of a segment, keyed by every
+// field they hold.
+func segmentColumnGroups(segment *SegmentInfo) map[int64]*columnGroup {
+	groups := make(map[int64]*columnGroup)
+	for _, fieldBinlog := range segment.GetBinlogs() {
+		fields := fieldBinlog.GetChildFields()
+		if len(fields) == 0 {
+			fields = []int64{fieldBinlog.GetFieldID()}
+		}
+		var size int64
+		for _, binlog := range fieldBinlog.GetBinlogs() {
+			size += binlog.GetMemorySize()
+		}
+		group := &columnGroup{fields: fields, size: size}
+		for _, fieldID := range fields {
+			groups[fieldID] = group
+		}
+	}
+	return groups
+}
+
+// estimateFieldsReadSize estimates how much data a task reads for fieldIDs of a
+// segment.
+//
+// Both the index build and the json/text stats tasks read a single column at a
+// time: for storage v3 the reader is built with a schema holding only the target
+// column, so parquet only touches that column inside the column group file (see
+// GetFieldDatasFromStorageV2 in internal/core/src/storage/Util.cpp). The binlog
+// size however is recorded per column group, so a field sharing a group with
+// others gets charged for all of them. This is worst for external collections,
+// whose segments carry one synthetic group holding every column at once (see
+// buildFakeBinlogs in internal/datanode/external).
+//
+// The group size is the measured truth for the group as a whole, so it is used
+// as the budget: fields whose schema gives an exact size take exactly that, and
+// the remaining bytes are shared between the variable length fields
+// proportionally to their schema estimate. That keeps a 128 dim vector at its
+// real size while a large json column still gets the bytes it actually
+// occupies, instead of the configured per row guess.
+func estimateFieldsReadSize(schema *schemapb.CollectionSchema, segment *SegmentInfo, fieldIDs []int64) (int64, error) {
+	if len(fieldIDs) == 0 {
+		return 0, merr.WrapErrParameterInvalidMsg("no field to estimate size for")
+	}
+	numRows := segment.GetNumOfRows()
+	if numRows <= 0 {
+		return 0, nil
+	}
+
+	groups := segmentColumnGroups(segment)
+	// requested fields grouped by the column group holding them
+	requested := make(map[*columnGroup][]int64)
+	for _, fieldID := range fieldIDs {
+		group, ok := groups[fieldID]
+		if !ok {
+			return 0, merr.WrapErrFieldNotFound(fieldID, "field has no binlog in segment")
+		}
+		requested[group] = append(requested[group], fieldID)
+	}
+
+	var total int64
+	for group, groupFieldIDs := range requested {
+		size, err := estimateGroupFieldsSize(schema, group, groupFieldIDs, numRows)
+		if err != nil {
+			return 0, err
+		}
+		total += size
+	}
+	return total, nil
+}
+
+// estimateGroupFieldsSize attributes the measured size of one column group to
+// the requested fields of that group.
+func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGroup, fieldIDs []int64, numRows int64) (int64, error) {
+	if group.size <= 0 {
+		// nothing measured to attribute, e.g. binlogs written before the size
+		// was recorded. Let the caller keep its own conservative fallback.
+		return 0, merr.WrapErrParameterInvalidMsg("column group of fields %v has no recorded size", group.fields)
+	}
+	if len(group.fields) <= 1 {
+		// the group holds nothing but the requested field, its size is exact
+		return group.size, nil
+	}
+
+	type fieldEstimate struct {
+		sizePerRecord int64
+		exact         bool
+	}
+	estimates := make(map[int64]fieldEstimate, len(group.fields))
+	var fixedPerRecord, variableWeight int64
+	for _, fieldID := range group.fields {
+		size, exact, err := fieldSizePerRecord(schema, fieldID)
+		if err != nil {
+			return 0, err
+		}
+		estimates[fieldID] = fieldEstimate{sizePerRecord: size, exact: exact}
+		if exact {
+			fixedPerRecord += size
+			continue
+		}
+		variableWeight += size
+	}
+
+	// bytes the variable length fields of this group take per row, measured
+	residualPerRecord := group.size/numRows - fixedPerRecord
+	if residualPerRecord < 0 || variableWeight == 0 {
+		// the schema does not add up to the measured data, e.g. because some
+		// field of the group is not materialized in it. Fall back to the schema
+		// estimation alone, still bounded by the group size.
+		residualPerRecord = 0
+	}
+
+	var total int64
+	for _, fieldID := range fieldIDs {
+		estimate := estimates[fieldID]
+		sizePerRecord := estimate.sizePerRecord
+		if !estimate.exact && residualPerRecord > 0 {
+			sizePerRecord = residualPerRecord * sizePerRecord / variableWeight
+		}
+		total += sizePerRecord * numRows
+	}
+	if total > group.size {
+		return group.size, nil
+	}
+	return total, nil
 }
 
 func calculateStatsTaskSlot(segmentSize int64) int64 {

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -648,14 +649,15 @@ func segmentColumnGroups(segment *SegmentInfo) map[int64]*columnGroup {
 // estimateFieldsReadSize estimates how much data a task reads for fieldIDs of a
 // segment.
 //
-// Both the index build and the json/text stats tasks read a single column at a
-// time: for storage v3 the reader is built with a schema holding only the target
-// column, so parquet only touches that column inside the column group file (see
-// GetFieldDatasFromStorageV2 in internal/core/src/storage/Util.cpp). The binlog
-// size however is recorded per column group, so a field sharing a group with
-// others gets charged for all of them. This is worst for external collections,
-// whose segments carry one synthetic group holding every column at once (see
-// buildFakeBinlogs in internal/datanode/external).
+// Both the index build and the json/text stats tasks request a single column at
+// a time. Per-field attribution is safe only for a StorageV3 segment with a
+// manifest: GetFieldDatasFromManifest asks the reader for the target column,
+// while GetFieldDatasFromStorageV2 materializes every column of the selected
+// column group. The binlog size however is recorded per column group, so a
+// projected field sharing a group with others otherwise gets charged for all of
+// them. This is worst for external collections, whose segments carry one
+// synthetic group holding every column at once (see buildFakeBinlogs in
+// internal/datanode/external).
 //
 // The group size is the measured truth for the group as a whole, so it is used
 // as the budget: fields whose schema gives an exact size take exactly that, and
@@ -674,6 +676,12 @@ func estimateFieldsReadSize(schema *schemapb.CollectionSchema, segment *SegmentI
 	numRows := segment.GetNumOfRows()
 	if numRows <= 0 {
 		return 0, nil
+	}
+	if !supportsFieldProjection(segment) {
+		// Callers gate this optimization on supportsFieldProjection. Reaching
+		// this branch means an internal contract was violated, not bad input.
+		return 0, merr.WrapErrServiceInternalMsg(
+			"segment %d does not have a StorageV3 manifest for projected field reads", segment.GetID())
 	}
 
 	groups := segmentColumnGroups(segment)
@@ -696,6 +704,14 @@ func estimateFieldsReadSize(schema *schemapb.CollectionSchema, segment *SegmentI
 		total += size
 	}
 	return total, nil
+}
+
+// supportsFieldProjection matches the actual reader selection in the index and
+// stats workers. A non-empty manifest selects GetFieldDatasFromManifest, which
+// projects the requested column. StorageV2 files without a manifest are read by
+// GetFieldDatasFromStorageV2, which materializes the whole column group.
+func supportsFieldProjection(segment *SegmentInfo) bool {
+	return segment.GetStorageVersion() == storage.StorageV3 && segment.GetManifestPath() != ""
 }
 
 // estimateGroupFieldsSize attributes the measured size of one column group to
@@ -723,6 +739,10 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 	estimates := make(map[int64]fieldEstimate, len(group.fields))
 	var fixedPerRecord int64
 	var hasVariableField bool
+	var externalColumnResolver *typeutil.StorageColumnResolver
+	if typeutil.IsExternalCollection(schema) {
+		externalColumnResolver = typeutil.NewStorageColumnResolver(schema)
+	}
 	for _, fieldID := range group.fields {
 		size, exact, err := fieldSizePerRecord(schema, fieldID)
 		if err != nil {
@@ -737,7 +757,17 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 		}
 		estimates[fieldID] = fieldEstimate{sizePerRecord: size, exact: exact}
 		if exact {
-			fixedPerRecord += size
+			measured := true
+			if externalColumnResolver != nil {
+				field := typeutil.GetFieldByID(schema, fieldID)
+				_, measured = externalColumnResolver.SourceDataColumnName(field)
+				// Refresh adds generated function outputs to MemorySize after
+				// sampling the source columns, so they are measured too.
+				measured = measured || typeutil.IsFunctionOutputField(schema, field)
+			}
+			if measured {
+				fixedPerRecord += size
+			}
 			continue
 		}
 		hasVariableField = true

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -601,33 +601,54 @@ func isFixedWidthType(dataType schemapb.DataType) bool {
 	}
 }
 
+// fieldSizeEstimate is the schema-derived size of one field, qualified by how
+// far it can be trusted. The two flags serve the two distinct uses of a size:
+//
+//   - exact: the stored size is fully determined by the schema (fixed width,
+//     not nullable). Safe to deduct from the measured group budget — a
+//     deduction must never exceed the field's real bytes, or the remaining
+//     variable length fields get understated.
+//   - fixedWidth: the schema width bounds the stored data from above even when
+//     the field is nullable (null rows only shrink it). Safe to charge the
+//     requested field with, never to deduct.
+type fieldSizeEstimate struct {
+	sizePerRecord int64
+	exact         bool
+	fixedWidth    bool
+}
+
 // fieldSizePerRecord returns the per row size of a field derived from the
-// schema, together with whether that size is exact.
+// schema.
 //
 // A nullable field is never exact, whatever its data type: rows holding null
 // store less than the full width (nullable vectors are even stored with a
-// variable length encoding, see CreateArrowSchema in
-// internal/core/src/storage/Util.cpp), so its real size is data dependent and
-// must come from the measured residual instead.
-func fieldSizePerRecord(schema *schemapb.CollectionSchema, fieldID int64) (int64, bool, error) {
+// variable length encoding, see add_vector_payload in
+// internal/core/src/storage/Util.cpp), so its real size is data dependent.
+// For a fixed width type the schema width still bounds it from above, which
+// fixedWidth records.
+func fieldSizePerRecord(schema *schemapb.CollectionSchema, fieldID int64) (fieldSizeEstimate, error) {
 	field := typeutil.GetFieldByID(schema, fieldID)
 	if field == nil {
-		return 0, false, merr.WrapErrFieldNotFound(fieldID)
+		return fieldSizeEstimate{}, merr.WrapErrFieldNotFound(fieldID)
 	}
 	sizePerRecord, err := typeutil.EstimateSizePerRecord(&schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{field},
 	})
 	if err != nil {
-		return 0, false, err
+		return fieldSizeEstimate{}, err
 	}
 	if sizePerRecord <= 0 {
 		// An unrecognized data type estimates to zero, which would understate
 		// the slot usage. Let the caller keep the conservative binlog size.
-		return 0, false, merr.WrapErrParameterInvalidMsg("cannot estimate size of field %d with data type %s",
+		return fieldSizeEstimate{}, merr.WrapErrParameterInvalidMsg("cannot estimate size of field %d with data type %s",
 			fieldID, field.GetDataType().String())
 	}
-	exact := isFixedWidthType(field.GetDataType()) && !field.GetNullable()
-	return int64(sizePerRecord), exact, nil
+	fixedWidth := isFixedWidthType(field.GetDataType())
+	return fieldSizeEstimate{
+		sizePerRecord: int64(sizePerRecord),
+		exact:         fixedWidth && !field.GetNullable(),
+		fixedWidth:    fixedWidth,
+	}, nil
 }
 
 // columnGroup is a set of fields stored together, which is what a binlog entry
@@ -680,15 +701,21 @@ func segmentColumnGroups(segment *SegmentInfo) map[int64]*columnGroup {
 // internal/datanode/external).
 //
 // The group size is the measured truth for the group as a whole, so it is used
-// as the budget: fields whose schema gives an exact size take exactly that, and
+// as the budget: fields whose schema gives an exact size take exactly that,
+// nullable fixed width fields take their schema width plus the nullable
+// encoding overhead (an upper bound — nulls only shrink the stored data), and
 // whatever remains is charged to the variable length fields. That keeps a 128
-// dim vector at its real size, while a json column is charged what the data
-// really contains instead of the configured per row guess
-// (common.dynamicFieldLengthAvg), which can be an order of magnitude off. The
-// residual is not split proportionally between several variable length fields:
-// the schema weights are guesses, and splitting by them could understate a fat
-// column, i.e. over-admit tasks. Charging it once keeps the result an upper
-// bound, which is what a slot must be.
+// dim vector at (close to) its real size — including on non milvus-table
+// external collections, where every user field is forced nullable at create
+// time — while a json column is charged what the data really contains instead
+// of the configured per row guess (common.dynamicFieldLengthAvg), which can be
+// an order of magnitude off. The residual is not split proportionally between
+// several variable length fields: the schema weights are guesses, and
+// splitting by them could understate a fat column, i.e. over-admit tasks.
+// Charging it once keeps the result an upper bound, which is what a slot must
+// be. The flip side is that a variable length column of a group with nothing
+// exact to deduct (e.g. any non milvus-table external group, all nullable) is
+// charged the whole group.
 func estimateFieldsReadSize(schema *schemapb.CollectionSchema, segment *SegmentInfo, fieldIDs []int64) (int64, error) {
 	if len(fieldIDs) == 0 {
 		return 0, merr.WrapErrParameterInvalidMsg("no field to estimate size for")
@@ -734,8 +761,23 @@ func supportsFieldProjection(segment *SegmentInfo) bool {
 	return segment.GetStorageVersion() == storage.StorageV3 && segment.GetManifestPath() != ""
 }
 
+// nullableFixedWidthPadPerRow bounds the per row encoding overhead a nullable
+// fixed width column adds on top of its schema width: nullable vectors are
+// binary encoded (4 byte offsets, see add_vector_payload in
+// internal/core/src/storage/Util.cpp), and every nullable column carries a
+// validity bitmap (1/8 byte per row).
+const nullableFixedWidthPadPerRow = 8
+
 // estimateGroupFieldsSize attributes the measured size of one column group to
 // the requested fields of that group.
+//
+// Each requested field is charged by the strongest bound available: an exact
+// field its schema size, a nullable fixed width field its schema width plus
+// the nullable encoding overhead (nulls only shrink the stored data), and a
+// variable length field the measured residual of the group — the group size
+// minus the exact fields, which only exact fields may reduce (deducting a
+// nullable field's full width could overstate its real bytes and understate
+// everyone else's).
 func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGroup, fieldIDs []int64, numRows int64) (int64, error) {
 	if group.size <= 0 {
 		// nothing measured to attribute, e.g. binlogs written before the size
@@ -752,11 +794,7 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 		requestedFields[fieldID] = struct{}{}
 	}
 
-	type fieldEstimate struct {
-		sizePerRecord int64
-		exact         bool
-	}
-	estimates := make(map[int64]fieldEstimate, len(group.fields))
+	estimates := make(map[int64]fieldSizeEstimate, len(group.fields))
 	var fixedPerRecord int64
 	var hasVariableField bool
 	var externalColumnResolver *typeutil.StorageColumnResolver
@@ -764,7 +802,7 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 		externalColumnResolver = typeutil.NewStorageColumnResolver(schema)
 	}
 	for _, fieldID := range group.fields {
-		size, exact, err := fieldSizePerRecord(schema, fieldID)
+		estimate, err := fieldSizePerRecord(schema, fieldID)
 		if err != nil {
 			if _, requested := requestedFields[fieldID]; requested {
 				return 0, err
@@ -775,8 +813,8 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 			// on the whole group.
 			continue
 		}
-		estimates[fieldID] = fieldEstimate{sizePerRecord: size, exact: exact}
-		if exact {
+		estimates[fieldID] = estimate
+		if estimate.exact {
 			measured := true
 			if externalColumnResolver != nil {
 				field := typeutil.GetFieldByID(schema, fieldID)
@@ -786,7 +824,7 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 				measured = measured || typeutil.IsFunctionOutputField(schema, field)
 			}
 			if measured {
-				fixedPerRecord += size
+				fixedPerRecord += estimate.sizePerRecord
 			}
 			continue
 		}
@@ -809,16 +847,34 @@ func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGro
 	var residualCharged bool
 	for _, fieldID := range fieldIDs {
 		estimate := estimates[fieldID]
-		if !estimate.exact && residualBytes > 0 {
-			// every variable length field of the group shares the same residual,
-			// so it is charged once no matter how many of them are requested
+		switch {
+		case estimate.exact:
+			total += estimate.sizePerRecord * numRows
+		case estimate.fixedWidth:
+			// Nullable fixed width: null rows only shrink the stored data, so
+			// the schema width plus the nullable encoding overhead bounds it
+			// from above; the measured residual it lives in caps it further.
+			// This branch is what keeps the attribution alive on non
+			// milvus-table external collections, where create time forces
+			// every user field nullable (see Pass 2 of
+			// NormalizeAndValidateExternalCollectionSchema) and nothing is
+			// left to deduct from the group budget.
+			charge := (estimate.sizePerRecord + nullableFixedWidthPadPerRow) * numRows
+			if residualBytes > 0 && charge > residualBytes {
+				charge = residualBytes
+			}
+			total += charge
+		case residualBytes > 0:
+			// every variable length field of the group shares the same
+			// residual, so it is charged once no matter how many of them are
+			// requested
 			if !residualCharged {
 				total += residualBytes
 				residualCharged = true
 			}
-			continue
+		default:
+			total += estimate.sizePerRecord * numRows
 		}
-		total += estimate.sizePerRecord * numRows
 	}
 	if total > group.size {
 		return group.size, nil

--- a/internal/datacoord/util.go
+++ b/internal/datacoord/util.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -569,6 +570,180 @@ func calculateIndexTaskSlot(fieldSize, numRows int64, indexParams []*commonpb.Ke
 		return max(defaultSlots/16, 1)
 	}
 	return max(defaultSlots/64, 1)
+}
+
+// isFixedWidthType tells whether the schema alone fully determines the size of
+// a field, i.e. the estimation cannot be off. Variable length types only get a
+// configured guess out of the schema (see typeutil.EstimateSizePerRecord), so
+// they are attributed from the measured data instead whenever possible.
+func isFixedWidthType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_Bool, schemapb.DataType_Int8, schemapb.DataType_Int16,
+		schemapb.DataType_Int32, schemapb.DataType_Int64, schemapb.DataType_Float,
+		schemapb.DataType_Double, schemapb.DataType_Timestamptz,
+		schemapb.DataType_BinaryVector, schemapb.DataType_FloatVector,
+		schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector:
+		return true
+	default:
+		return false
+	}
+}
+
+// fieldSizePerRecord returns the per row size of a field derived from the
+// schema, together with whether that size is exact.
+func fieldSizePerRecord(schema *schemapb.CollectionSchema, fieldID int64) (int64, bool, error) {
+	field := typeutil.GetFieldByID(schema, fieldID)
+	if field == nil {
+		return 0, false, merr.WrapErrFieldNotFound(fieldID)
+	}
+	sizePerRecord, err := typeutil.EstimateSizePerRecord(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{field},
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	if sizePerRecord <= 0 {
+		// An unrecognized data type estimates to zero, which would understate
+		// the slot usage. Let the caller keep the conservative binlog size.
+		return 0, false, merr.WrapErrParameterInvalidMsg("cannot estimate size of field %d with data type %s",
+			fieldID, field.GetDataType().String())
+	}
+	return int64(sizePerRecord), isFixedWidthType(field.GetDataType()), nil
+}
+
+// columnGroup is a set of fields stored together, which is what a binlog entry
+// describes for storage v3 segments. Storage v1 binlogs hold a single field and
+// therefore form a group of one.
+type columnGroup struct {
+	fields []int64
+	size   int64
+}
+
+// segmentColumnGroups returns the column groups of a segment, keyed by every
+// field they hold.
+func segmentColumnGroups(segment *SegmentInfo) map[int64]*columnGroup {
+	groups := make(map[int64]*columnGroup)
+	for _, fieldBinlog := range segment.GetBinlogs() {
+		fields := fieldBinlog.GetChildFields()
+		if len(fields) == 0 {
+			fields = []int64{fieldBinlog.GetFieldID()}
+		}
+		var size int64
+		for _, binlog := range fieldBinlog.GetBinlogs() {
+			size += binlog.GetMemorySize()
+		}
+		group := &columnGroup{fields: fields, size: size}
+		for _, fieldID := range fields {
+			groups[fieldID] = group
+		}
+	}
+	return groups
+}
+
+// estimateFieldsReadSize estimates how much data a task reads for fieldIDs of a
+// segment.
+//
+// Both the index build and the json/text stats tasks read a single column at a
+// time: for storage v3 the reader is built with a schema holding only the target
+// column, so parquet only touches that column inside the column group file (see
+// GetFieldDatasFromStorageV2 in internal/core/src/storage/Util.cpp). The binlog
+// size however is recorded per column group, so a field sharing a group with
+// others gets charged for all of them. This is worst for external collections,
+// whose segments carry one synthetic group holding every column at once (see
+// buildFakeBinlogs in internal/datanode/external).
+//
+// The group size is the measured truth for the group as a whole, so it is used
+// as the budget: fields whose schema gives an exact size take exactly that, and
+// the remaining bytes are shared between the variable length fields
+// proportionally to their schema estimate. That keeps a 128 dim vector at its
+// real size while a large json column still gets the bytes it actually
+// occupies, instead of the configured per row guess.
+func estimateFieldsReadSize(schema *schemapb.CollectionSchema, segment *SegmentInfo, fieldIDs []int64) (int64, error) {
+	if len(fieldIDs) == 0 {
+		return 0, merr.WrapErrParameterInvalidMsg("no field to estimate size for")
+	}
+	numRows := segment.GetNumOfRows()
+	if numRows <= 0 {
+		return 0, nil
+	}
+
+	groups := segmentColumnGroups(segment)
+	// requested fields grouped by the column group holding them
+	requested := make(map[*columnGroup][]int64)
+	for _, fieldID := range fieldIDs {
+		group, ok := groups[fieldID]
+		if !ok {
+			return 0, merr.WrapErrFieldNotFound(fieldID, "field has no binlog in segment")
+		}
+		requested[group] = append(requested[group], fieldID)
+	}
+
+	var total int64
+	for group, groupFieldIDs := range requested {
+		size, err := estimateGroupFieldsSize(schema, group, groupFieldIDs, numRows)
+		if err != nil {
+			return 0, err
+		}
+		total += size
+	}
+	return total, nil
+}
+
+// estimateGroupFieldsSize attributes the measured size of one column group to
+// the requested fields of that group.
+func estimateGroupFieldsSize(schema *schemapb.CollectionSchema, group *columnGroup, fieldIDs []int64, numRows int64) (int64, error) {
+	if group.size <= 0 {
+		// nothing measured to attribute, e.g. binlogs written before the size
+		// was recorded. Let the caller keep its own conservative fallback.
+		return 0, merr.WrapErrParameterInvalidMsg("column group of fields %v has no recorded size", group.fields)
+	}
+	if len(group.fields) <= 1 {
+		// the group holds nothing but the requested field, its size is exact
+		return group.size, nil
+	}
+
+	type fieldEstimate struct {
+		sizePerRecord int64
+		exact         bool
+	}
+	estimates := make(map[int64]fieldEstimate, len(group.fields))
+	var fixedPerRecord, variableWeight int64
+	for _, fieldID := range group.fields {
+		size, exact, err := fieldSizePerRecord(schema, fieldID)
+		if err != nil {
+			return 0, err
+		}
+		estimates[fieldID] = fieldEstimate{sizePerRecord: size, exact: exact}
+		if exact {
+			fixedPerRecord += size
+			continue
+		}
+		variableWeight += size
+	}
+
+	// bytes the variable length fields of this group take per row, measured
+	residualPerRecord := group.size/numRows - fixedPerRecord
+	if residualPerRecord < 0 || variableWeight == 0 {
+		// the schema does not add up to the measured data, e.g. because some
+		// field of the group is not materialized in it. Fall back to the schema
+		// estimation alone, still bounded by the group size.
+		residualPerRecord = 0
+	}
+
+	var total int64
+	for _, fieldID := range fieldIDs {
+		estimate := estimates[fieldID]
+		sizePerRecord := estimate.sizePerRecord
+		if !estimate.exact && residualPerRecord > 0 {
+			sizePerRecord = residualPerRecord * sizePerRecord / variableWeight
+		}
+		total += sizePerRecord * numRows
+	}
+	if total > group.size {
+		return group.size, nil
+	}
+	return total, nil
 }
 
 func calculateStatsTaskSlot(segmentSize int64) int64 {

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -280,6 +280,24 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		suite.Equal(jsonBytes, size)
 	})
 
+	suite.Run("bool group member does not reduce the measured residual", func() {
+		// bool is measured bit-packed (~1/8 B per row) but the schema charges
+		// 1 B per row: treating it as exact would over-deduct from the
+		// variable width columns of its group
+		boolSchema := &schemapb.CollectionSchema{
+			Fields: append([]*schemapb.FieldSchema{
+				{FieldID: 106, Name: "flag", DataType: schemapb.DataType_Bool},
+			}, schema.Fields...),
+		}
+		boolBytes := numRows / 8
+		jsonBytes := jsonSize * numRows
+		segment := newSegment(group(pkSize*numRows+boolBytes+jsonBytes, 106, pkField, jsonField))
+
+		size, err := estimateFieldsReadSize(boolSchema, segment, []int64{jsonField})
+		suite.NoError(err)
+		suite.Equal(boolBytes+jsonBytes, size)
+	})
+
 	suite.Run("nullable fixed width field is charged from the residual", func() {
 		// a nullable vector is stored with a variable length encoding and rows
 		// holding null store less than the full width, so the schema size is
@@ -466,12 +484,15 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 
 func (suite *UtilSuite) TestIsFixedWidthType() {
 	for _, dataType := range []schemapb.DataType{
-		schemapb.DataType_Bool, schemapb.DataType_Int64, schemapb.DataType_Double,
+		schemapb.DataType_Int64, schemapb.DataType_Double,
 		schemapb.DataType_FloatVector, schemapb.DataType_Int8Vector,
 	} {
 		suite.True(isFixedWidthType(dataType), dataType.String())
 	}
 	for _, dataType := range []schemapb.DataType{
+		// Bool is stored bit-packed, so the 1 byte per row schema estimate is
+		// not exact and it must be attributed from the measured residual
+		schemapb.DataType_Bool,
 		schemapb.DataType_VarChar, schemapb.DataType_Text, schemapb.DataType_JSON,
 		schemapb.DataType_Array, schemapb.DataType_Geometry,
 		schemapb.DataType_SparseFloatVector, schemapb.DataType_ArrayOfVector,

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -123,6 +124,211 @@ func (suite *UtilSuite) TestVerifyResponse() {
 
 func TestUtil(t *testing.T) {
 	suite.Run(t, new(UtilSuite))
+}
+
+func (suite *UtilSuite) TestEstimateFieldsReadSize() {
+	const (
+		numRows      = int64(1000)
+		pkField      = int64(100)
+		vecField     = int64(101)
+		jsonField    = int64(102)
+		varcharField = int64(103)
+		badField     = int64(104)
+	)
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: pkField, Name: "pk", DataType: schemapb.DataType_Int64},
+			{
+				FieldID:  vecField,
+				Name:     "vec",
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+			{FieldID: jsonField, Name: "json", DataType: schemapb.DataType_JSON},
+			{
+				FieldID:  varcharField,
+				Name:     "var",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "256"},
+				},
+			},
+			// VarChar without max_length cannot be estimated
+			{FieldID: badField, Name: "bad", DataType: schemapb.DataType_VarChar},
+		},
+	}
+
+	// per row schema estimates
+	vecSize := int64(128 * 4)
+	pkSize := int64(8)
+	jsonEstimate, err := typeutil.EstimateSizePerRecord(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{schema.Fields[2]},
+	})
+	suite.NoError(err)
+	jsonSize := int64(jsonEstimate)
+	varcharEstimate, err := typeutil.EstimateSizePerRecord(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{schema.Fields[3]},
+	})
+	suite.NoError(err)
+	varcharSize := int64(varcharEstimate)
+
+	newSegment := func(groups ...*datapb.FieldBinlog) *SegmentInfo {
+		return &SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:        1,
+				NumOfRows: numRows,
+				Binlogs:   groups,
+			},
+		}
+	}
+	group := func(size int64, fields ...int64) *datapb.FieldBinlog {
+		fieldBinlog := &datapb.FieldBinlog{
+			FieldID: fields[0],
+			Binlogs: []*datapb.Binlog{{EntriesNum: numRows, MemorySize: size}},
+		}
+		if len(fields) > 1 {
+			fieldBinlog.FieldID = 0
+			fieldBinlog.ChildFields = fields
+		}
+		return fieldBinlog
+	}
+
+	suite.Run("single field group is measured", func() {
+		// a field owning its column group, e.g. a vector in storage v3
+		segment := newSegment(group(vecSize*numRows, vecField))
+		size, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		suite.NoError(err)
+		suite.Equal(vecSize*numRows, size)
+	})
+
+	suite.Run("fixed width field of a shared group takes its exact size", func() {
+		groupSize := (pkSize + vecSize + jsonSize) * numRows
+		segment := newSegment(group(groupSize, pkField, vecField, jsonField))
+
+		size, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		suite.NoError(err)
+		suite.Equal(vecSize*numRows, size)
+		suite.Less(size, groupSize)
+	})
+
+	suite.Run("variable width field takes the residual of the group", func() {
+		// json rows are 10x bigger than the schema guesses, the residual of the
+		// measured group size must land on the json column, not on the vector
+		measuredJSONSize := jsonSize * 10
+		groupSize := (pkSize + vecSize + measuredJSONSize) * numRows
+		segment := newSegment(group(groupSize, pkField, vecField, jsonField))
+
+		size, err := estimateFieldsReadSize(schema, segment, []int64{jsonField})
+		suite.NoError(err)
+		suite.Equal(measuredJSONSize*numRows, size)
+
+		size, err = estimateFieldsReadSize(schema, segment, []int64{vecField})
+		suite.NoError(err)
+		suite.Equal(vecSize*numRows, size)
+	})
+
+	suite.Run("residual is shared between variable width fields", func() {
+		residualPerRow := (jsonSize + varcharSize) * 4
+		groupSize := (pkSize + residualPerRow) * numRows
+		segment := newSegment(group(groupSize, pkField, jsonField, varcharField))
+
+		jsonRead, err := estimateFieldsReadSize(schema, segment, []int64{jsonField})
+		suite.NoError(err)
+		varcharRead, err := estimateFieldsReadSize(schema, segment, []int64{varcharField})
+		suite.NoError(err)
+
+		// proportional to the schema estimates, summing up to the residual
+		suite.Equal(residualPerRow*jsonSize/(jsonSize+varcharSize)*numRows, jsonRead)
+		suite.Equal(residualPerRow*varcharSize/(jsonSize+varcharSize)*numRows, varcharRead)
+		suite.Less(jsonRead+varcharRead, groupSize)
+	})
+
+	suite.Run("schema estimate is used when the group has no residual", func() {
+		// measured data smaller than the fixed width fields alone
+		segment := newSegment(group(pkSize*numRows/2, pkField, jsonField))
+		size, err := estimateFieldsReadSize(schema, segment, []int64{jsonField})
+		suite.NoError(err)
+		// bounded by the group size
+		suite.Equal(pkSize*numRows/2, size)
+	})
+
+	suite.Run("fields of several groups are summed", func() {
+		segment := newSegment(
+			group(vecSize*numRows, vecField),
+			group((pkSize+jsonSize)*numRows, pkField, jsonField),
+		)
+		size, err := estimateFieldsReadSize(schema, segment, []int64{vecField, pkField})
+		suite.NoError(err)
+		suite.Equal((vecSize+pkSize)*numRows, size)
+	})
+
+	suite.Run("empty segment", func() {
+		segment := newSegment(group(vecSize*numRows, vecField))
+		segment.NumOfRows = 0
+		size, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		suite.NoError(err)
+		suite.Equal(int64(0), size)
+	})
+
+	suite.Run("column group without recorded size", func() {
+		segment := newSegment(group(0, vecField))
+		_, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		suite.Error(err)
+	})
+
+	suite.Run("no field requested", func() {
+		segment := newSegment(group(vecSize*numRows, vecField))
+		_, err := estimateFieldsReadSize(schema, segment, nil)
+		suite.Error(err)
+	})
+
+	suite.Run("field without binlog", func() {
+		segment := newSegment(group(vecSize*numRows, vecField))
+		_, err := estimateFieldsReadSize(schema, segment, []int64{pkField})
+		suite.Error(err)
+	})
+
+	suite.Run("field missing from schema", func() {
+		segment := newSegment(group(vecSize*numRows, vecField, 999))
+		_, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		suite.Error(err)
+	})
+
+	suite.Run("field size not estimable", func() {
+		segment := newSegment(group(vecSize*numRows, vecField, badField))
+		_, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		suite.Error(err)
+	})
+
+	suite.Run("unrecognized data type", func() {
+		unknownSchema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: pkField, Name: "pk", DataType: schemapb.DataType_Int64},
+				{FieldID: vecField, Name: "unknown", DataType: schemapb.DataType_None},
+			},
+		}
+		segment := newSegment(group(pkSize*numRows, pkField, vecField))
+		_, err := estimateFieldsReadSize(unknownSchema, segment, []int64{pkField})
+		suite.Error(err)
+	})
+}
+
+func (suite *UtilSuite) TestIsFixedWidthType() {
+	for _, dataType := range []schemapb.DataType{
+		schemapb.DataType_Bool, schemapb.DataType_Int64, schemapb.DataType_Double,
+		schemapb.DataType_FloatVector, schemapb.DataType_Int8Vector,
+	} {
+		suite.True(isFixedWidthType(dataType), dataType.String())
+	}
+	for _, dataType := range []schemapb.DataType{
+		schemapb.DataType_VarChar, schemapb.DataType_Text, schemapb.DataType_JSON,
+		schemapb.DataType_Array, schemapb.DataType_Geometry,
+		schemapb.DataType_SparseFloatVector, schemapb.DataType_ArrayOfVector,
+	} {
+		suite.False(isFixedWidthType(dataType), dataType.String())
+	}
 }
 
 type fixedTSOAllocator struct {

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -298,10 +298,14 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		suite.Equal(boolBytes+jsonBytes, size)
 	})
 
-	suite.Run("nullable fixed width field is charged from the residual", func() {
+	suite.Run("nullable fixed width field is charged its bounded width", func() {
 		// a nullable vector is stored with a variable length encoding and rows
 		// holding null store less than the full width, so the schema size is
-		// not exact: the field takes the measured residual of its group
+		// not exact. It is still bounded above by the width plus the nullable
+		// encoding overhead, and by the measured residual of its group —
+		// whichever is smaller.
+
+		// half the rows are null: the measured residual is the tighter bound
 		nullableVecBytes := vecSize * numRows / 2
 		segment := newSegment(group(pkSize*numRows+nullableVecBytes, pkField, nullableVecField))
 
@@ -313,6 +317,50 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		size, err = estimateFieldsReadSize(schema, segment, []int64{pkField})
 		suite.NoError(err)
 		suite.Equal(pkSize*numRows, size)
+
+		// no nulls and a fat neighbor: the width bound is the tighter one, the
+		// nullable vector must not absorb the whole residual
+		fatGroupSize := (pkSize+vecSize)*numRows + 10*vecSize*numRows
+		segment = newSegment(group(fatGroupSize, pkField, nullableVecField, jsonField))
+		size, err = estimateFieldsReadSize(schema, segment, []int64{nullableVecField})
+		suite.NoError(err)
+		suite.Equal((vecSize+nullableFixedWidthPadPerRow)*numRows, size)
+	})
+
+	suite.Run("all nullable external group still attributes fixed width columns", func() {
+		// A non milvus-table external collection forces every user field
+		// nullable at create time (Pass 2 of
+		// NormalizeAndValidateExternalCollectionSchema), so nothing in its one
+		// synthetic column group is exact. The indexed vector must still be
+		// charged its bounded width, not the whole 100x bigger group.
+		externalSchema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: pkField, Name: "pk", DataType: schemapb.DataType_Int64, Nullable: true, ExternalField: "pk_col"},
+				{
+					FieldID:       vecField,
+					Name:          "vec",
+					DataType:      schemapb.DataType_FloatVector,
+					Nullable:      true,
+					ExternalField: "vec_col",
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "128"},
+					},
+				},
+				{FieldID: jsonField, Name: "json", DataType: schemapb.DataType_JSON, Nullable: true, ExternalField: "json_col"},
+			},
+		}
+		groupSize := 100 * vecSize * numRows
+		segment := newSegment(group(groupSize, pkField, vecField, jsonField))
+
+		size, err := estimateFieldsReadSize(externalSchema, segment, []int64{vecField})
+		suite.NoError(err)
+		suite.Equal((vecSize+nullableFixedWidthPadPerRow)*numRows, size)
+
+		// a variable length column has no schema bound and nothing exact is
+		// deductible, so it conservatively keeps the whole group
+		size, err = estimateFieldsReadSize(externalSchema, segment, []int64{jsonField})
+		suite.NoError(err)
+		suite.Equal(groupSize, size)
 	})
 
 	suite.Run("schema estimate is used when the group has no residual", func() {
@@ -438,14 +486,17 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 			virtualPKField      = int64(105)
 			functionOutputField = int64(106)
 		)
+		// production shape: user fields mapped from the source are nullable
+		// (Pass 2 of NormalizeAndValidateExternalCollectionSchema), while
+		// system, virtual, and function output fields keep Nullable=false
 		externalSchema := &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
 				{FieldID: 0, Name: common.RowIDFieldName, DataType: schemapb.DataType_Int64},
 				{FieldID: 1, Name: common.TimeStampFieldName, DataType: schemapb.DataType_Int64},
 				{FieldID: virtualPKField, Name: common.VirtualPKFieldName, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
-				{FieldID: pkField, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+				{FieldID: pkField, Name: "pk", DataType: schemapb.DataType_Int64, Nullable: true, ExternalField: "pk_col"},
 				{FieldID: functionOutputField, Name: "generated", DataType: schemapb.DataType_Int64, IsFunctionOutput: true},
-				{FieldID: jsonField, Name: "json", DataType: schemapb.DataType_JSON, ExternalField: "json_col"},
+				{FieldID: jsonField, Name: "json", DataType: schemapb.DataType_JSON, Nullable: true, ExternalField: "json_col"},
 			},
 			Functions: []*schemapb.FunctionSchema{
 				{OutputFieldIds: []int64{functionOutputField}},
@@ -458,9 +509,16 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		groupSize := (pkSize + 8 + residualPerRow) * numRows
 		segment := newSegment(group(groupSize, 0, 1, virtualPKField, pkField, functionOutputField, jsonField))
 
+		// only the function output is deductible; the nullable pk stays in
+		// the residual the json column is charged with
 		size, err := estimateFieldsReadSize(externalSchema, segment, []int64{jsonField})
 		suite.NoError(err)
-		suite.Equal(residualPerRow*numRows, size)
+		suite.Equal((pkSize+residualPerRow)*numRows, size)
+
+		// the nullable pk itself is charged its bounded width
+		size, err = estimateFieldsReadSize(externalSchema, segment, []int64{pkField})
+		suite.NoError(err)
+		suite.Equal((pkSize+nullableFixedWidthPadPerRow)*numRows, size)
 
 		// Unmeasured generated fields retain their schema-derived estimate when
 		// requested, but do not consume the sampled source-column budget.

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -129,12 +129,13 @@ func TestUtil(t *testing.T) {
 
 func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 	const (
-		numRows      = int64(1000)
-		pkField      = int64(100)
-		vecField     = int64(101)
-		jsonField    = int64(102)
-		varcharField = int64(103)
-		badField     = int64(104)
+		numRows          = int64(1000)
+		pkField          = int64(100)
+		vecField         = int64(101)
+		jsonField        = int64(102)
+		varcharField     = int64(103)
+		badField         = int64(104)
+		nullableVecField = int64(105)
 	)
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
@@ -158,6 +159,15 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 			},
 			// VarChar without max_length cannot be estimated
 			{FieldID: badField, Name: "bad", DataType: schemapb.DataType_VarChar},
+			{
+				FieldID:  nullableVecField,
+				Name:     "nullable_vec",
+				DataType: schemapb.DataType_FloatVector,
+				Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
 		},
 	}
 
@@ -257,6 +267,34 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		pkRead, err := estimateFieldsReadSize(schema, segment, []int64{pkField})
 		suite.NoError(err)
 		suite.Equal(pkSize*numRows, pkRead)
+	})
+
+	suite.Run("residual keeps sub-row remainder bytes", func() {
+		// a group size that is not a multiple of the row count must not lose
+		// its remainder to a per-record truncation: near a slot bucket
+		// boundary that loss could drop the task into a lower bucket
+		jsonBytes := jsonSize*numRows + 777
+		segment := newSegment(group(vecSize*numRows+jsonBytes, vecField, jsonField))
+		size, err := estimateFieldsReadSize(schema, segment, []int64{jsonField})
+		suite.NoError(err)
+		suite.Equal(jsonBytes, size)
+	})
+
+	suite.Run("nullable fixed width field is charged from the residual", func() {
+		// a nullable vector is stored with a variable length encoding and rows
+		// holding null store less than the full width, so the schema size is
+		// not exact: the field takes the measured residual of its group
+		nullableVecBytes := vecSize * numRows / 2
+		segment := newSegment(group(pkSize*numRows+nullableVecBytes, pkField, nullableVecField))
+
+		size, err := estimateFieldsReadSize(schema, segment, []int64{nullableVecField})
+		suite.NoError(err)
+		suite.Equal(nullableVecBytes, size)
+
+		// and it does not consume the fixed width budget of the group
+		size, err = estimateFieldsReadSize(schema, segment, []int64{pkField})
+		suite.NoError(err)
+		suite.Equal(pkSize*numRows, size)
 	})
 
 	suite.Run("schema estimate is used when the group has no residual", func() {

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -229,20 +230,31 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		suite.Equal(vecSize*numRows, size)
 	})
 
-	suite.Run("residual is shared between variable width fields", func() {
+	suite.Run("every variable width field is charged the whole residual", func() {
+		// the schema weights are guesses, so a single variable width column is
+		// charged all the measured variable bytes of its group instead of a
+		// share of them: under-charging a fat column would over-admit tasks
 		residualPerRow := (jsonSize + varcharSize) * 4
 		groupSize := (pkSize + residualPerRow) * numRows
 		segment := newSegment(group(groupSize, pkField, jsonField, varcharField))
 
 		jsonRead, err := estimateFieldsReadSize(schema, segment, []int64{jsonField})
 		suite.NoError(err)
+		suite.Equal(residualPerRow*numRows, jsonRead)
+
 		varcharRead, err := estimateFieldsReadSize(schema, segment, []int64{varcharField})
 		suite.NoError(err)
+		suite.Equal(residualPerRow*numRows, varcharRead)
 
-		// proportional to the schema estimates, summing up to the residual
-		suite.Equal(residualPerRow*jsonSize/(jsonSize+varcharSize)*numRows, jsonRead)
-		suite.Equal(residualPerRow*varcharSize/(jsonSize+varcharSize)*numRows, varcharRead)
-		suite.Less(jsonRead+varcharRead, groupSize)
+		// requesting both does not charge the residual twice
+		bothRead, err := estimateFieldsReadSize(schema, segment, []int64{jsonField, varcharField})
+		suite.NoError(err)
+		suite.Equal(residualPerRow*numRows, bothRead)
+
+		// and the fixed width column of the same group is unaffected
+		pkRead, err := estimateFieldsReadSize(schema, segment, []int64{pkField})
+		suite.NoError(err)
+		suite.Equal(pkSize*numRows, pkRead)
 	})
 
 	suite.Run("schema estimate is used when the group has no residual", func() {
@@ -290,16 +302,58 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		suite.Error(err)
 	})
 
-	suite.Run("field missing from schema", func() {
+	suite.Run("requested field missing from schema", func() {
 		segment := newSegment(group(vecSize*numRows, vecField, 999))
-		_, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		_, err := estimateFieldsReadSize(schema, segment, []int64{999})
 		suite.Error(err)
 	})
 
-	suite.Run("field size not estimable", func() {
+	suite.Run("requested field size not estimable", func() {
 		segment := newSegment(group(vecSize*numRows, vecField, badField))
-		_, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		_, err := estimateFieldsReadSize(schema, segment, []int64{badField})
 		suite.Error(err)
+	})
+
+	suite.Run("group member missing from schema is skipped", func() {
+		// a field dropped after the segment was flushed still shows up in
+		// ChildFields until compaction rewrites the segment: its bytes stay in
+		// the residual instead of aborting the whole group
+		groupSize := (pkSize + vecSize + jsonSize) * numRows
+		segment := newSegment(group(groupSize, pkField, vecField, jsonField, 999))
+		size, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		suite.NoError(err)
+		suite.Equal(vecSize*numRows, size)
+	})
+
+	suite.Run("group member of unestimable size is skipped", func() {
+		groupSize := (pkSize + vecSize + jsonSize) * numRows
+		segment := newSegment(group(groupSize, pkField, vecField, jsonField, badField))
+		size, err := estimateFieldsReadSize(schema, segment, []int64{vecField})
+		suite.NoError(err)
+		suite.Equal(vecSize*numRows, size)
+	})
+
+	suite.Run("system fields of a group are charged as fixed width", func() {
+		// real external segments list RowID(0) and Timestamp(1) in ChildFields,
+		// both Int64 in the persisted schema
+		sysSchema := &schemapb.CollectionSchema{
+			Fields: append([]*schemapb.FieldSchema{
+				{FieldID: 0, Name: "row_id", DataType: schemapb.DataType_Int64},
+				{FieldID: 1, Name: "timestamp", DataType: schemapb.DataType_Int64},
+			}, schema.Fields...),
+		}
+		residualPerRow := jsonSize * 4
+		groupSize := (8 + 8 + pkSize + residualPerRow) * numRows
+		segment := newSegment(group(groupSize, 0, 1, pkField, jsonField))
+
+		size, err := estimateFieldsReadSize(sysSchema, segment, []int64{0})
+		suite.NoError(err)
+		suite.Equal(int64(8)*numRows, size)
+
+		// the two system columns eat 16B/row out of the json residual
+		size, err = estimateFieldsReadSize(sysSchema, segment, []int64{jsonField})
+		suite.NoError(err)
+		suite.Equal(residualPerRow*numRows, size)
 	})
 
 	suite.Run("unrecognized data type", func() {
@@ -310,8 +364,36 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 			},
 		}
 		segment := newSegment(group(pkSize*numRows, pkField, vecField))
-		_, err := estimateFieldsReadSize(unknownSchema, segment, []int64{pkField})
+		_, err := estimateFieldsReadSize(unknownSchema, segment, []int64{vecField})
 		suite.Error(err)
+	})
+}
+
+func (suite *UtilSuite) TestCollectionCache() {
+	const collectionID = int64(7)
+	coll := &collectionInfo{ID: collectionID}
+
+	suite.Run("resolves once and memoizes", func() {
+		handler := NewNMockHandler(suite.T())
+		handler.EXPECT().GetCollection(mock.Anything, collectionID).Return(coll, nil).Once()
+
+		cache := newCollectionCache(handler)
+		suite.Equal(coll, cache.get(context.Background(), collectionID))
+		suite.Equal(coll, cache.get(context.Background(), collectionID))
+	})
+
+	suite.Run("memoizes misses too", func() {
+		handler := NewNMockHandler(suite.T())
+		handler.EXPECT().GetCollection(mock.Anything, collectionID).
+			Return(nil, errors.New("mock rootcoord unreachable")).Once()
+
+		cache := newCollectionCache(handler)
+		suite.Nil(cache.get(context.Background(), collectionID))
+		suite.Nil(cache.get(context.Background(), collectionID))
+	})
+
+	suite.Run("no handler", func() {
+		suite.Nil(resolveCollection(context.Background(), nil, collectionID))
 	})
 }
 

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -178,9 +179,11 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 	newSegment := func(groups ...*datapb.FieldBinlog) *SegmentInfo {
 		return &SegmentInfo{
 			SegmentInfo: &datapb.SegmentInfo{
-				ID:        1,
-				NumOfRows: numRows,
-				Binlogs:   groups,
+				ID:             1,
+				NumOfRows:      numRows,
+				StorageVersion: storage.StorageV3,
+				ManifestPath:   "manifest.json",
+				Binlogs:        groups,
 			},
 		}
 	}
@@ -276,6 +279,26 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		suite.Equal((vecSize+pkSize)*numRows, size)
 	})
 
+	suite.Run("segment without a projecting reader is rejected", func() {
+		for name, configure := range map[string]func(*SegmentInfo){
+			"storage v2": func(segment *SegmentInfo) {
+				segment.StorageVersion = storage.StorageV2
+				segment.ManifestPath = ""
+			},
+			"storage v3 without manifest": func(segment *SegmentInfo) {
+				segment.StorageVersion = storage.StorageV3
+				segment.ManifestPath = ""
+			},
+		} {
+			suite.Run(name, func() {
+				segment := newSegment(group((pkSize+jsonSize)*numRows, pkField, jsonField))
+				configure(segment)
+				_, err := estimateFieldsReadSize(schema, segment, []int64{jsonField})
+				suite.Error(err)
+			})
+		}
+	})
+
 	suite.Run("empty segment", func() {
 		segment := newSegment(group(vecSize*numRows, vecField))
 		segment.NumOfRows = 0
@@ -333,13 +356,11 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		suite.Equal(vecSize*numRows, size)
 	})
 
-	suite.Run("system fields of a group are charged as fixed width", func() {
-		// real external segments list RowID(0) and Timestamp(1) in ChildFields,
-		// both Int64 in the persisted schema
+	suite.Run("regular system fields of a group are charged as fixed width", func() {
 		sysSchema := &schemapb.CollectionSchema{
 			Fields: append([]*schemapb.FieldSchema{
-				{FieldID: 0, Name: "row_id", DataType: schemapb.DataType_Int64},
-				{FieldID: 1, Name: "timestamp", DataType: schemapb.DataType_Int64},
+				{FieldID: 0, Name: common.RowIDFieldName, DataType: schemapb.DataType_Int64},
+				{FieldID: 1, Name: common.TimeStampFieldName, DataType: schemapb.DataType_Int64},
 			}, schema.Fields...),
 		}
 		residualPerRow := jsonSize * 4
@@ -350,10 +371,47 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		suite.NoError(err)
 		suite.Equal(int64(8)*numRows, size)
 
-		// the two system columns eat 16B/row out of the json residual
+		// Regular StorageV3 manifests measure these materialized columns, so
+		// they consume 16B/row of the group budget.
 		size, err = estimateFieldsReadSize(sysSchema, segment, []int64{jsonField})
 		suite.NoError(err)
 		suite.Equal(residualPerRow*numRows, size)
+	})
+
+	suite.Run("external system and virtual fields do not reduce measured residual", func() {
+		const (
+			virtualPKField      = int64(105)
+			functionOutputField = int64(106)
+		)
+		externalSchema := &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 0, Name: common.RowIDFieldName, DataType: schemapb.DataType_Int64},
+				{FieldID: 1, Name: common.TimeStampFieldName, DataType: schemapb.DataType_Int64},
+				{FieldID: virtualPKField, Name: common.VirtualPKFieldName, DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{FieldID: pkField, Name: "pk", DataType: schemapb.DataType_Int64, ExternalField: "pk_col"},
+				{FieldID: functionOutputField, Name: "generated", DataType: schemapb.DataType_Int64, IsFunctionOutput: true},
+				{FieldID: jsonField, Name: "json", DataType: schemapb.DataType_JSON, ExternalField: "json_col"},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{OutputFieldIds: []int64{functionOutputField}},
+			},
+		}
+		residualPerRow := jsonSize * 4
+		// External refresh samples pk_col and json_col, then explicitly adds
+		// generated function outputs. RowID, Timestamp, and VirtualPK still
+		// appear in ChildFields but are absent from the measured group size.
+		groupSize := (pkSize + 8 + residualPerRow) * numRows
+		segment := newSegment(group(groupSize, 0, 1, virtualPKField, pkField, functionOutputField, jsonField))
+
+		size, err := estimateFieldsReadSize(externalSchema, segment, []int64{jsonField})
+		suite.NoError(err)
+		suite.Equal(residualPerRow*numRows, size)
+
+		// Unmeasured generated fields retain their schema-derived estimate when
+		// requested, but do not consume the sampled source-column budget.
+		size, err = estimateFieldsReadSize(externalSchema, segment, []int64{virtualPKField})
+		suite.NoError(err)
+		suite.Equal(int64(8)*numRows, size)
 	})
 
 	suite.Run("unrecognized data type", func() {

--- a/internal/datacoord/util_test.go
+++ b/internal/datacoord/util_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -424,34 +423,6 @@ func (suite *UtilSuite) TestEstimateFieldsReadSize() {
 		segment := newSegment(group(pkSize*numRows, pkField, vecField))
 		_, err := estimateFieldsReadSize(unknownSchema, segment, []int64{vecField})
 		suite.Error(err)
-	})
-}
-
-func (suite *UtilSuite) TestCollectionCache() {
-	const collectionID = int64(7)
-	coll := &collectionInfo{ID: collectionID}
-
-	suite.Run("resolves once and memoizes", func() {
-		handler := NewNMockHandler(suite.T())
-		handler.EXPECT().GetCollection(mock.Anything, collectionID).Return(coll, nil).Once()
-
-		cache := newCollectionCache(handler)
-		suite.Equal(coll, cache.get(context.Background(), collectionID))
-		suite.Equal(coll, cache.get(context.Background(), collectionID))
-	})
-
-	suite.Run("memoizes misses too", func() {
-		handler := NewNMockHandler(suite.T())
-		handler.EXPECT().GetCollection(mock.Anything, collectionID).
-			Return(nil, errors.New("mock rootcoord unreachable")).Once()
-
-		cache := newCollectionCache(handler)
-		suite.Nil(cache.get(context.Background(), collectionID))
-		suite.Nil(cache.get(context.Background(), collectionID))
-	})
-
-	suite.Run("no handler", func() {
-		suite.Nil(resolveCollection(context.Background(), nil, collectionID))
 	})
 }
 


### PR DESCRIPTION
issue: #52002

### What this PR does

DataCoord sized the index build and the json/text index stats tasks by the whole column group (or the whole segment) holding the indexed column, while those tasks read a single column: a manifest-backed StorageV3 read goes through `GetFieldDatasFromManifest`, which asks the reader for just the target column (`internal/core/src/storage/Util.cpp`). (`GetFieldDatasFromStorageV2`, in contrast, materializes the whole column group — which is why per-field attribution is applied only to manifest-backed segments.)

External collections were the worst case, since their segments carry one synthetic column group listing every field (`buildFakeBinlogs` in `internal/datanode/external/task_update.go`): a 128 dim float vector over 3000 rows really needs ~1.5MB (1 slot) but a 2GB synthetic group asked for `(2GB / 512MB) * indexTaskSlotUsage` = 256 slots.

This PR attributes the measured column group size to the fields it holds:

- fields whose schema gives an exact size (fixed width scalars except Bool, non-nullable dense vectors) take exactly that size, and **only these** are deducted from the group budget;
- **nullable fixed width fields** are charged their schema width plus a small nullable-encoding overhead (binary offsets + validity bitmap, 8 B/row) — an upper bound, since null rows only shrink the stored data. This is what keeps the attribution effective on non-milvus-table external collections, where create time forces every user field nullable (Pass 2 of `NormalizeAndValidateExternalCollectionSchema`), so nothing there is exact;
- everything else — variable length fields (VarChar / Text / JSON / Array / Geometry / sparse and array vectors) and Bool (bit-packed on disk, so the 1 B/row schema guess is not exact) — is charged the **whole measured residual** of its group (group size minus the exact fields), computed in whole bytes;
- the result is bounded by the column group size.

The residual is deliberately **not** split proportionally between several variable length fields: the schema weights are configured guesses (`common.dynamicFieldLengthAvg`), and splitting by them could understate a fat column and over-admit tasks. Charging the full residual once per group keeps the estimate an upper bound — it can over-estimate an individual column, never under-estimate it. A schema-only estimation would not be enough on its own for the same reason: the configured guess can understate a large json column by an order of magnitude.

### Where it applies

| task | before | after |
| --- | --- | --- |
| index build | whole column group | the indexed column's share |
| json key index stats | whole segment, doubled | the json columns' share, doubled ¹ |
| text index stats | whole segment | the match enabled columns' share ¹ |
| sort and other stats jobs | whole segment | unchanged |

¹ The share of a variable length column is the group size minus the exact (fixed width, non-nullable) fields. On a non-milvus-table external collection every user field is nullable, so nothing is deductible and these tasks keep the whole (synthetic) group — the attribution helps them on internal StorageV3, milvus-table external, and groups holding function-output fields.

### Scope and fallbacks

Manifest-backed V3 segments do not persist their `FieldBinlog` arrays (the datacoord catalog skips the per-FieldBinlog KVs, see `isV3Segment`), so the per-column attribution is effective for segments flushed or refreshed **during the current DataCoord process lifetime**. A segment recovered after a restart carries no binlogs and keeps the previous whole-segment estimation until it is rewritten; the recovery paths read only the local collection cache and never load through rootcoord.

Any segment without a recorded group size, a field with no binlog, or a schema that cannot be resolved also keeps the previous whole segment estimation, so every fallback is exactly as conservative as today.

### Tests

`internal/datacoord` passes in full. New unit tests cover the estimation (`estimateFieldsReadSize`, `estimateGroupFieldsSize`, `fieldSizePerRecord`, `segmentColumnGroups`, `isFixedWidthType`), both call sites (`estimateIndexFieldSize`, `estimateStatsTaskSize`, `statsTaskFieldIDs`), the recovery paths with catalog-realistic segments (manifest set, binlog arrays empty), and the Bool / nullable / sub-row-remainder attribution cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
