### PR TITLE
enhance: [3.0] enable GIS split/fusion optimization by default

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -538,7 +538,7 @@ queryNode:
       buildParallelRate: 0.5 # the ratio of building interim index parallel matched with cpu num
     multipleChunkedEnable: true # Deprecated. Enable multiple chunked search
     enableGeometryCache: false # Enable geometry cache for geometry data
-    enableGISSplitFusion: false # Enable GIS filter coarse/refine split + same-column fusion optimization
+    enableGISSplitFusion: true # Enable GIS filter coarse/refine split + same-column fusion optimization
     tieredStorage:
       warmup:
         # options: sync, async, disable.

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4273,7 +4273,7 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 	p.EnableGISSplitFusion = ParamItem{
 		Key:          "queryNode.segcore.enableGISSplitFusion",
 		Version:      "2.6.6",
-		DefaultValue: "false",
+		DefaultValue: "true",
 		Doc:          "Enable GIS filter coarse/refine split + same-column fusion optimization",
 		Export:       true,
 	}

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -508,6 +508,15 @@ func TestComponentParam(t *testing.T) {
 		nprobe := Params.InterimIndexNProbe.GetAsInt64()
 		assert.Equal(t, int64(16), nprobe)
 
+		// enableGISSplitFusion defaults to true: the GIS coarse/refine split and
+		// same-column fusion rewrite is on unless explicitly disabled.
+		assert.True(t, Params.EnableGISSplitFusion.GetAsBool())
+		assert.Equal(t, "true", Params.EnableGISSplitFusion.DefaultValue)
+		params.Save(Params.EnableGISSplitFusion.Key, "false")
+		assert.False(t, Params.EnableGISSplitFusion.GetAsBool())
+		params.Reset(Params.EnableGISSplitFusion.Key)
+		assert.True(t, Params.EnableGISSplitFusion.GetAsBool())
+
 		assert.Equal(t, int32(1024), Params.MaxUnsolvedQueueSize.GetAsInt32())
 		assert.Equal(t, "1024", Params.MaxUnsolvedQueueSize.DefaultValue)
 		assert.Equal(t, int64(64), Params.MaxGroupNQ.GetAsInt64())


### PR DESCRIPTION
issue: #50674
pr: #52007

Cherry-pick of the master change to the 3.0 branch.

## What

Flips `queryNode.segcore.enableGISSplitFusion` from `false` to `true`, enabling the GIS coarse/refine split + same-column fusion optimization added in #50675 by default.

No behavioural code changes: only the default value in `component_param.go` and `configs/milvus.yaml`, plus unit-test coverage asserting the new default and that the flag can still be switched off and reset.

## Why

The optimization has shipped dark since #50675. Its pruning counters (`gis_coarse_ratio` / `gis_refine_ratio`) only emit when the flag is on, so leaving it off means never collecting the evidence needed to promote it. This PR breaks that deadlock with a measured A/B.

### Setup

- Milvus standalone, image built from the 2.6 line (`2.6-20260728-d93c392f4-756285d`)
- Two 5,000,000-row collections: all-`POINT`, and mixed (all 7 OGC geometry types, 64-vertex polygons)
- Indexes: `RTREE` on `geo`, `INVERTED` on `bucket`/`tenant`/`geo_type`, `BITMAP` on `active`, `IVF_FLAT` on `vec`
- Benchmark client co-located in the same Kubernetes cluster and AZ (RTT p50 ~2.8 ms), so client/server latency does not mask segcore differences
- 71 filter shapes x {query, search}, warmup 10, 100 iterations, concurrency 1
- **Same binary, same persisted data on both sides; only the flag differs.** `enableGeometryCache: false` on both sides

### Results (POINT collection, `query` p50 in ms, OFF -> ON)

| case | OFF | ON | speedup | hits |
|---|---|---|---|---|
| `C05_dual_pair_direct_plus_or` | 462.80 | 49.73 | **9.31x** | 7,882 |
| `B01_scalar_1pct_and_gis` | 92.43 | 11.03 | **8.38x** | 2,245 |
| `C04_scalar_and_direct_and_fusion` | 455.72 | 55.07 | **8.28x** | 24,522 |
| `B05_varchar_5pct_and_gis` | 91.98 | 14.47 | **6.36x** | 12,535 |
| `C01_scalar_and_or2_fusion` | 96.00 | 17.75 | **5.41x** | 24,305 |
| `D02_large_coarse_80pct` | 1451.47 | 269.54 | **5.38x** | 411,321 |
| `E01_dwithin_excluded_plus_intersects` | 97.18 | 18.38 | **5.29x** | 0 |
| `D04_full_gis_hits` | 1873.18 | 367.85 | **5.09x** | 500,004 |
| `D01_large_coarse_20pct` | 367.40 | 73.56 | **4.99x** | 103,138 |
| `B02_scalar_10pct_and_gis` | 94.82 | 20.91 | **4.54x** | 24,522 |
| `B07_multi_scalar_and_gis` | 97.42 | 26.05 | **3.74x** | 615 |
| `A03_gis_only_and_fusion` | 449.22 | 129.79 | **3.46x** | 250,880 |
| `F05_operator_crosses` | 3963.19 | 2033.36 | **1.95x** | 0 |
| `B06_bool_50pct_and_gis` | 91.74 | 48.45 | **1.89x** | 125,441 |
| `B03_scalar_50pct_and_gis` | 108.53 | 66.05 | **1.64x** | 127,911 |
| `D03_no_gis_hits` | 8.76 | 5.55 | **1.58x** | 0 |
| `F04_operator_overlaps` | 22.80 | 19.63 | **1.16x** | 0 |
| `F03_operator_touches` | 22.26 | 19.55 | **1.14x** | 1 |
| `F01_operator_equals_point` | 22.10 | 19.51 | **1.13x** | 1 |
| `C03_scalar_1pct_and_or4_fusion` | 103.02 | 102.30 | **1.01x** | 2,442 |
| `C02_scalar_and_or4_fusion` | 105.88 | 105.34 | **1.01x** | 24,707 |
| `A01_lone_gis_intersects_5pct` | 90.24 | 90.97 | **0.99x** | 250,880 |
| `A02_root_or_two_gis` | 92.00 | 92.91 | **0.99x** | 250,272 |
| `E03_mixed_or_subtree_no_fusion` | 93.13 | 94.06 | **0.99x** | 149,375 |
| `E04_root_or_scalar_gis_no_fusion` | 92.06 | 93.71 | **0.98x** | 298,636 |
| `E05_not_gis_no_fusion` | 95.22 | 97.53 | **0.98x** | 475,482 |
| `B04_scalar_zero_and_gis` | 1.62 | 1.66 | **0.97x** | 0 |
### Controls behave exactly as designed

`A01`/`A02` (lone GIS predicate, no scalar sibling to prune with) and `E03`/`E04`/`E05` (OR-rooted, mixed OR subtree, and `NOT`-wrapped GIS -- all deliberately excluded from the rewrite) land at **0.98-0.99x**. The speedups above are attributable to the optimized path rather than to environmental drift.

### Pruning counters confirm the mechanism

Across the run, `gis_coarse_ratio` averaged **0.147** and `gis_refine_ratio` averaged **0.019**: exact refine now touches ~2% of the rows it used to. A refine ratio approaching 1 would mean the pruning had silently degraded to a full scan; it does not.

Row counts were identical between OFF and ON on every case compared so far.

## Tests

`pkg/util/paramtable/component_param_test.go` asserts the new default, and that the flag can still be set to `false` and reset back -- so the escape hatch stays covered:

```go
assert.True(t, Params.EnableGISSplitFusion.GetAsBool())
assert.Equal(t, "true", Params.EnableGISSplitFusion.DefaultValue)
params.Save(Params.EnableGISSplitFusion.Key, "false")
assert.False(t, Params.EnableGISSplitFusion.GetAsBool())
params.Reset(Params.EnableGISSplitFusion.Key)
assert.True(t, Params.EnableGISSplitFusion.GetAsBool())
```

Passes on master, 3.0 and 2.6.

## Notes and limitations

1. **Measured on a 2.6-line build.** master additionally has `DetermineExecPath()` / `PrefetchRawData()` and the all-at-once path, which the 2.6 backport explicitly omits, so absolute numbers may differ on master even though the mechanism is the same.
2. **`ST_ISVALID` shapes are not covered.** The 2.6 plan proto `GISOp` enum stops at `DWithin`, so the `st_isvalid` case was excluded from this run. That negative path (ISVALID must stay off the fusion group) is unit-tested but not represented in these numbers.
3. **Same-column OR groups with more than two branches do not currently benefit.** A 2-branch OR (`C01`) gains 5.41x, while 4-branch ORs (`C02`, `C03`) come out at 1.01x -- no regression, but no gain either. `as_groupable_gis()` only accepts a direct `PhyGISFunctionFilterExpr`, so a nested OR subtree fails the Shape-B purity check and the group is skipped. Tracked separately; it does not affect correctness.
4. The mixed-geometry collection run was still in flight when this PR was opened; those numbers will follow as a comment.

The flag remains configurable -- setting `queryNode.segcore.enableGISSplitFusion: false` restores the previous execution path.
